### PR TITLE
fix: use debug log for model limits to avoid TUI breakage

### DIFF
--- a/src/hooks/model-limits.ts
+++ b/src/hooks/model-limits.ts
@@ -8,7 +8,7 @@
  * - Copilot caps ALL models at 128k prompt, regardless of native limit
  */
 
-import { warn } from '../utils';
+import { log } from '../utils';
 
 /**
  * Native model context limits (in tokens) when used on their native platform.
@@ -257,7 +257,7 @@ function logFirstCall(
 	const key = `${modelID || 'unknown'}::${providerID || 'unknown'}`;
 	if (!loggedFirstCalls.has(key)) {
 		loggedFirstCalls.add(key);
-		warn(
+		log(
 			`[model-limits] Resolved limit for ${modelID || '(no model)'}@${providerID || '(no provider)'}: ${limit} (source: ${source})`,
 		);
 	}


### PR DESCRIPTION
## Problem

The `warn()` call in `model-limits.ts` was printing WARN messages to the TUI when the architect agent starts working, breaking the look-n-feel of the OpenCode TUI.

## Solution

Changed from `warn()` to `log()` for the model limit resolution message. The `log()` function only outputs when `OPENCODE_SWARM_DEBUG=1` is set, so users won't see these messages unless they explicitly enable debug mode.

## Changes

- `src/hooks/model-limits.ts`: Import `log` instead of `warn`, use `log()` for the first-call message

Fixes #40