### PR TITLE
fix: phase completion reliability and workspace validation hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,39 @@ Every completed task writes structured evidence to `.swarm/evidence/`:
 </details>
 
 <details>
+<summary><strong>Save Plan Tool: Target Workspace Requirement</strong></summary>
+
+The `save_plan` tool requires an explicit target workspace path. It does **not** fall back to `process.cwd()`.
+
+### Explicit Workspace Requirement
+
+- The `working_directory` parameter must be provided
+- Providing no value or relying on implicit directory resolution will result in deterministic failure
+
+### Failure Conditions
+
+| Condition | Behavior |
+|-----------|----------|
+| Missing (`undefined` / `null`) | Fails with: "Target workspace is required" |
+| Empty or whitespace-only | Fails with: "Target workspace cannot be empty or whitespace" |
+| Path traversal (`..`) | Fails with: "Target workspace cannot contain path traversal" |
+
+### Usage Contract
+
+When using `save_plan`, always pass a valid `working_directory`:
+
+```typescript
+save_plan({
+  title: "My Project",
+  swarm_id: "mega",
+  phases: [{ id: 1, name: "Setup", tasks: [{ id: "1.1", description: "Initialize project" }] }],
+  working_directory: "/path/to/project"  // Required - no fallback
+})
+```
+
+</details>
+
+<details>
 <summary><strong>Guardrails and Circuit Breakers</strong></summary>
 
 Every agent runs inside a circuit breaker that kills runaway behavior before it burns your credits.

--- a/src/plan/manager.ts
+++ b/src/plan/manager.ts
@@ -256,6 +256,16 @@ export async function loadPlan(directory: string): Promise<Plan | null> {
  * then derive and write .swarm/plan.md
  */
 export async function savePlan(directory: string, plan: Plan): Promise<void> {
+	// Fail-fast: reject blank or whitespace-only directory inputs before any I/O
+	if (
+		directory === null ||
+		directory === undefined ||
+		typeof directory !== 'string' ||
+		directory.trim().length === 0
+	) {
+		throw new Error(`Invalid directory: directory must be a non-empty string`);
+	}
+
 	// Validate against schema
 	const validated = PlanSchema.parse(plan);
 

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -47,6 +47,101 @@ interface PhaseCompleteResult {
 }
 
 /**
+ * Result from cross-session agent aggregation helper
+ */
+interface CrossSessionAgentsResult {
+	/** Aggregated normalized agent names from all contributor sessions */
+	agents: Set<string>;
+	/** Session IDs that contributed to this aggregation (including caller session) */
+	contributorSessionIds: string[];
+}
+
+/**
+ * Collect dispatched agents across contributor sessions.
+ * Contributor sessions are defined as those with activity since a phase reference timestamp,
+ * plus the caller session.
+ *
+ * @param phaseReferenceTimestamp - Filter sessions with activity after this timestamp (in ms)
+ * @param callerSessionId - The caller's session ID (always included)
+ * @returns Object containing aggregated agents and contributor session IDs
+ */
+function collectCrossSessionDispatchedAgents(
+	phaseReferenceTimestamp: number,
+	callerSessionId: string,
+): CrossSessionAgentsResult {
+	const agents = new Set<string>();
+	const contributorSessionIds: string[] = [];
+
+	// Always include the caller session
+	const callerSession = swarmState.agentSessions.get(callerSessionId);
+	if (callerSession) {
+		contributorSessionIds.push(callerSessionId);
+
+		// Collect agents from caller's phaseAgentsDispatched
+		if (callerSession.phaseAgentsDispatched) {
+			for (const agent of callerSession.phaseAgentsDispatched) {
+				agents.add(agent);
+			}
+		}
+
+		// Collect agents from caller's delegation chains
+		const callerDelegations = swarmState.delegationChains.get(callerSessionId);
+		if (callerDelegations) {
+			for (const delegation of callerDelegations) {
+				agents.add(stripKnownSwarmPrefix(delegation.from));
+				agents.add(stripKnownSwarmPrefix(delegation.to));
+			}
+		}
+	}
+
+	// Find all other sessions with activity since the reference timestamp
+	for (const [sessionId, session] of swarmState.agentSessions) {
+		// Skip the caller session (already processed)
+		if (sessionId === callerSessionId) {
+			continue;
+		}
+
+		// Check if session has phase-relevant execution evidence since the reference timestamp.
+		// This requires EITHER:
+		// 1. Recent tool call activity (primary evidence of work)
+		// 2. Recent delegation activity (shows coordination/agent dispatch)
+		// Note: lastAgentEventTime alone is insufficient as it can be fresh without actual execution
+
+		const hasRecentToolCalls =
+			session.lastToolCallTime >= phaseReferenceTimestamp;
+
+		// Check for recent delegation activity
+		const delegations = swarmState.delegationChains.get(sessionId);
+		const hasRecentDelegations =
+			delegations?.some((d) => d.timestamp >= phaseReferenceTimestamp) ?? false;
+
+		const hasActivity = hasRecentToolCalls || hasRecentDelegations;
+
+		if (hasActivity) {
+			contributorSessionIds.push(sessionId);
+
+			// Collect agents from this session's phaseAgentsDispatched
+			if (session.phaseAgentsDispatched) {
+				for (const agent of session.phaseAgentsDispatched) {
+					agents.add(agent);
+				}
+			}
+
+			// Collect agents from this session's delegation chains
+			const delegations = swarmState.delegationChains.get(sessionId);
+			if (delegations) {
+				for (const delegation of delegations) {
+					agents.add(stripKnownSwarmPrefix(delegation.from));
+					agents.add(stripKnownSwarmPrefix(delegation.to));
+				}
+			}
+		}
+	}
+
+	return { agents, contributorSessionIds };
+}
+
+/**
  * Event written to .swarm/events.jsonl on phase completion
  */
 interface PhaseCompleteEvent {
@@ -168,24 +263,15 @@ export async function executePhaseComplete(
 	// Ensure session exists and get current state
 	const session = ensureAgentSession(sessionID);
 
-	// Get last completion timestamp from session state
-	const lastCompletionTimestamp = session.lastPhaseCompleteTimestamp ?? 0;
+	// Get phase reference timestamp from session state (derived from last phase complete)
+	const phaseReferenceTimestamp = session.lastPhaseCompleteTimestamp ?? 0;
 
-	// Get delegations since last completion
-	const recentDelegations = getDelegationsSince(
+	// Use aggregated cross-session agents for required-agent evaluation
+	const crossSessionResult = collectCrossSessionDispatchedAgents(
+		phaseReferenceTimestamp,
 		sessionID,
-		lastCompletionTimestamp,
 	);
-
-	// Normalize agent names from delegation chains
-	const delegationAgents = normalizeAgentsFromDelegations(recentDelegations);
-
-	// Get agents from session state tracking (phaseAgentsDispatched)
-	const trackedAgents = session.phaseAgentsDispatched ?? new Set<string>();
-
-	// Merge agents from both sources
-	const allAgents = new Set<string>([...delegationAgents, ...trackedAgents]);
-	const agentsDispatched = Array.from(allAgents).sort();
+	const agentsDispatched = Array.from(crossSessionResult.agents).sort();
 
 	// Load plugin config for policy enforcement
 	const dir = workingDirectory ?? process.cwd();
@@ -279,7 +365,7 @@ export async function executePhaseComplete(
 				status: 'blocked' as const,
 				reason: 'RETROSPECTIVE_MISSING',
 				message: `Phase ${phase} cannot be completed: no valid retrospective evidence found.${schemaErrorDetail} Write a retrospective bundle at .swarm/evidence/retro-${phase}/evidence.json before calling phase_complete.`,
-				agentsDispatched: [],
+				agentsDispatched,
 				agentsMissing: [],
 				warnings: [
 					`Retrospective missing for phase ${phase}.${schemaErrorDetail} Use this template:`,
@@ -372,8 +458,10 @@ export async function executePhaseComplete(
 		effectiveRequired.push('docs');
 	}
 
-	// Compute missing agents
-	const agentsMissing = effectiveRequired.filter((req) => !allAgents.has(req));
+	// Compute missing agents using cross-session aggregated agents
+	const agentsMissing = effectiveRequired.filter(
+		(req) => !crossSessionResult.agents.has(req),
+	);
 
 	// Build warnings and determine success based on policy
 	const warnings: string[] = [];
@@ -399,7 +487,7 @@ export async function executePhaseComplete(
 
 	// Record timing
 	const now = Date.now();
-	const durationMs = now - lastCompletionTimestamp;
+	const durationMs = now - phaseReferenceTimestamp;
 
 	// Write event to .swarm/events.jsonl
 	const event: PhaseCompleteEvent = {
@@ -423,9 +511,16 @@ export async function executePhaseComplete(
 
 	// Reset phase state on success
 	if (success) {
-		session.phaseAgentsDispatched = new Set();
-		session.lastPhaseCompleteTimestamp = now;
-		session.lastPhaseCompletePhase = phase;
+		// Reset phase-tracking state for all contributor sessions
+		for (const contributorSessionId of crossSessionResult.contributorSessionIds) {
+			const contributorSession =
+				swarmState.agentSessions.get(contributorSessionId);
+			if (contributorSession) {
+				contributorSession.phaseAgentsDispatched = new Set();
+				contributorSession.lastPhaseCompleteTimestamp = now;
+				contributorSession.lastPhaseCompletePhase = phase;
+			}
+		}
 	}
 
 	// Build final result

--- a/src/tools/save-plan.ts
+++ b/src/tools/save-plan.ts
@@ -85,6 +85,37 @@ export function detectPlaceholderContent(args: SavePlanArgs): string[] {
 }
 
 /**
+ * Validate target workspace path.
+ * Rejects missing, empty, whitespace-only, and traversal-style paths.
+ * @param target - The target workspace path to validate
+ * @param source - Description of the source (for error messages)
+ * @returns Error message if invalid, undefined if valid
+ */
+export function validateTargetWorkspace(
+	target: string | undefined,
+	source: string,
+): string | undefined {
+	// Reject missing
+	if (target === undefined || target === null) {
+		return `Target workspace is required: ${source} not provided`;
+	}
+
+	// Reject empty or whitespace-only
+	const trimmed = target.trim();
+	if (trimmed.length === 0) {
+		return `Target workspace cannot be empty or whitespace: ${source}`;
+	}
+
+	// Reject path traversal patterns
+	const normalized = trimmed.replace(/\\/g, '/');
+	if (normalized.includes('..')) {
+		return `Target workspace cannot contain path traversal: ${source} contains ".."`;
+	}
+
+	return undefined;
+}
+
+/**
  * Execute the save_plan tool.
  * Validates for placeholder content, builds a Plan object, and saves to disk.
  * @param args - The save plan arguments
@@ -104,7 +135,21 @@ export async function executeSavePlan(
 		};
 	}
 
-	// Step 2: Build the Plan object from args
+	// Step 2: Validate target workspace - do NOT fall back to process.cwd()
+	const targetWorkspace = args.working_directory ?? fallbackDir;
+	const workspaceError = validateTargetWorkspace(
+		targetWorkspace,
+		args.working_directory ? 'working_directory' : 'fallbackDir',
+	);
+	if (workspaceError) {
+		return {
+			success: false,
+			message: 'Target workspace validation failed',
+			errors: [workspaceError],
+		};
+	}
+
+	// Step 3: Build the Plan object from args
 	const plan: Plan = {
 		schema_version: '1.0.0',
 		title: args.title,
@@ -138,10 +183,9 @@ export async function executeSavePlan(
 		0,
 	);
 
-	// Step 3: Determine working directory
-	const dir = args.working_directory ?? fallbackDir ?? process.cwd();
-
-	// Step 4: Save the plan
+	// Step 4: Save the plan using validated target workspace
+	// Note: targetWorkspace is guaranteed to be defined here due to Step 2 validation
+	const dir = targetWorkspace as string;
 	try {
 		await savePlan(dir, plan);
 		return {
@@ -233,7 +277,7 @@ export const save_plan: ToolDefinition = createSwarmTool({
 		working_directory: tool.schema
 			.string()
 			.optional()
-			.describe('Working directory (defaults to process.cwd())'),
+			.describe('Working directory (explicit path, required - no fallback)'),
 	},
 	execute: async (args: unknown, _directory: string) => {
 		return JSON.stringify(

--- a/test/adversarial-plan-write.test.ts
+++ b/test/adversarial-plan-write.test.ts
@@ -277,11 +277,13 @@ describe('Null/Undefined/Empty Directory Inputs', () => {
 				working_directory: undefined,
 			});
 
-			const result = await executeSavePlan(args, undefined);
-			// Should default to process.cwd() or fail gracefully
+			const result = await executeSavePlan(args, TEST_BASE_DIR);
+			// Should default to provided fallbackDir or fail gracefully
 			// Should not create files in unexpected locations
 			if (result.success) {
 				expect(result.plan_path).toBeDefined();
+				// Verify it wrote to the test directory, not cwd
+				expect(result.plan_path).toContain(TEST_BASE_DIR);
 			} else {
 				expect(result.success).toBe(false);
 			}
@@ -293,10 +295,13 @@ describe('Null/Undefined/Empty Directory Inputs', () => {
 				working_directory: null,
 			});
 
-			const result = await executeSavePlan(args);
+			// Explicitly pass TEST_BASE_DIR to avoid cwd fallback
+			const result = await executeSavePlan(args, TEST_BASE_DIR);
 			// Should reject or default safely
 			if (result.success) {
 				expect(result.plan_path).toBeDefined();
+				// Verify it wrote to the test directory
+				expect(result.plan_path).toContain(TEST_BASE_DIR);
 			} else {
 				expect(result.success).toBe(false);
 			}

--- a/tests/unit/tools/phase-complete.test.ts
+++ b/tests/unit/tools/phase-complete.test.ts
@@ -727,4 +727,165 @@ describe('phase_complete tool', () => {
 			expect(parsed.duration_ms).toBeDefined();
 		});
 	});
+
+	describe('multi-session required-agent aggregation', () => {
+		test('succeeds when required agents are split across multiple sessions in same phase window', async () => {
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({phase_complete: {
+							enabled: true,
+							required_agents: ['coder', 'reviewer'],
+							require_docs: false,
+							policy: 'enforce'
+						}})
+			);
+			
+			// Session 1: has coder
+			ensureAgentSession('sess1', 'coder');
+			recordPhaseAgentDispatch('sess1', 'coder');
+			// Update lastToolCallTime to be recent (within phase window)
+			swarmState.agentSessions.get('sess1')!.lastToolCallTime = Date.now();
+			
+			// Session 2: has reviewer
+			ensureAgentSession('sess2', 'reviewer');
+			recordPhaseAgentDispatch('sess2', 'reviewer');
+			// Update lastToolCallTime to be recent (within phase window)
+			swarmState.agentSessions.get('sess2')!.lastToolCallTime = Date.now();
+			
+			// Call phase_complete from sess1 - should aggregate coder from sess1 and reviewer from sess2
+			const result = await phase_complete.execute({ phase: 1, sessionID: 'sess1' });
+			const parsed = JSON.parse(result);
+			
+			expect(parsed.success).toBe(true);
+			expect(parsed.status).toBe('success');
+			expect(parsed.agentsDispatched).toContain('coder');
+			expect(parsed.agentsDispatched).toContain('reviewer');
+			expect(parsed.agentsMissing).toEqual([]);
+		});
+
+		test('fails when one required agent is truly missing across all sessions', async () => {
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({phase_complete: {
+							enabled: true,
+							required_agents: ['coder', 'reviewer', 'test_engineer'],
+							require_docs: false,
+							policy: 'enforce'
+						}})
+			);
+			
+			// Session 1: has coder
+			ensureAgentSession('sess1', 'coder');
+			recordPhaseAgentDispatch('sess1', 'coder');
+			swarmState.agentSessions.get('sess1')!.lastToolCallTime = Date.now();
+			
+			// Session 2: has reviewer
+			ensureAgentSession('sess2', 'reviewer');
+			recordPhaseAgentDispatch('sess2', 'reviewer');
+			swarmState.agentSessions.get('sess2')!.lastToolCallTime = Date.now();
+			
+			// test_engineer is missing from ALL sessions
+			
+			// Call phase_complete from sess1 - should detect test_engineer is missing
+			const result = await phase_complete.execute({ phase: 1, sessionID: 'sess1' });
+			const parsed = JSON.parse(result);
+			
+			expect(parsed.success).toBe(false);
+			expect(parsed.status).toBe('incomplete');
+			expect(parsed.agentsDispatched).toContain('coder');
+			expect(parsed.agentsDispatched).toContain('reviewer');
+			expect(parsed.agentsMissing).toContain('test_engineer');
+		});
+
+		test('resets contributor session phase-tracking state across sessions on success', async () => {
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({phase_complete: {
+							enabled: true,
+							required_agents: ['coder', 'reviewer'],
+							require_docs: false,
+							policy: 'enforce'
+						}})
+			);
+			
+			// Session 1: has coder
+			ensureAgentSession('sess1', 'coder');
+			recordPhaseAgentDispatch('sess1', 'coder');
+			swarmState.agentSessions.get('sess1')!.lastToolCallTime = Date.now();
+			
+			// Session 2: has reviewer
+			ensureAgentSession('sess2', 'reviewer');
+			recordPhaseAgentDispatch('sess2', 'reviewer');
+			swarmState.agentSessions.get('sess2')!.lastToolCallTime = Date.now();
+			
+			// Verify state before
+			const sess1Before = swarmState.agentSessions.get('sess1');
+			const sess2Before = swarmState.agentSessions.get('sess2');
+			expect(sess1Before?.phaseAgentsDispatched.size).toBe(1);
+			expect(sess2Before?.phaseAgentsDispatched.size).toBe(1);
+			expect(sess1Before?.lastPhaseCompleteTimestamp).toBe(0);
+			expect(sess2Before?.lastPhaseCompleteTimestamp).toBe(0);
+			
+			// Call phase_complete from sess1
+			const result = await phase_complete.execute({ phase: 1, sessionID: 'sess1' });
+			const parsed = JSON.parse(result);
+			
+			expect(parsed.success).toBe(true);
+			
+			// Verify state reset for BOTH contributor sessions
+			const sess1After = swarmState.agentSessions.get('sess1');
+			const sess2After = swarmState.agentSessions.get('sess2');
+			expect(sess1After?.phaseAgentsDispatched.size).toBe(0);
+			expect(sess2After?.phaseAgentsDispatched.size).toBe(0);
+			expect(sess1After?.lastPhaseCompleteTimestamp).toBeGreaterThan(0);
+			expect(sess2After?.lastPhaseCompleteTimestamp).toBeGreaterThan(0);
+			expect(sess1After?.lastPhaseCompletePhase).toBe(1);
+			expect(sess2After?.lastPhaseCompletePhase).toBe(1);
+		});
+
+		test('does not reset state for sessions without recent activity', async () => {
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({phase_complete: {
+							enabled: true,
+							required_agents: ['coder'],
+							require_docs: false,
+							policy: 'enforce'
+						}})
+			);
+			
+			// Session 1: recent activity (caller) with established phase reference timestamp
+			ensureAgentSession('sess1', 'coder');
+			recordPhaseAgentDispatch('sess1', 'coder');
+			swarmState.agentSessions.get('sess1')!.lastToolCallTime = Date.now();
+			// Establish non-zero phase reference timestamp so stale session exclusion works
+			swarmState.agentSessions.get('sess1')!.lastPhaseCompleteTimestamp = Date.now() - 60000;
+			swarmState.agentSessions.get('sess1')!.lastPhaseCompletePhase = 0;
+			
+			// Session 2: stale activity (old session, should NOT be contributor)
+			ensureAgentSession('sess2', 'reviewer');
+			recordPhaseAgentDispatch('sess2', 'reviewer');
+			// Set lastToolCallTime to old timestamp (outside phase window)
+			swarmState.agentSessions.get('sess2')!.lastToolCallTime = Date.now() - (24 * 60 * 60 * 1000);
+			
+			// Call phase_complete from sess1
+			const result = await phase_complete.execute({ phase: 1, sessionID: 'sess1' });
+			const parsed = JSON.parse(result);
+			
+			expect(parsed.success).toBe(true);
+			
+			// sess1 should be reset
+			const sess1After = swarmState.agentSessions.get('sess1');
+			expect(sess1After?.phaseAgentsDispatched.size).toBe(0);
+			
+			// sess2 should NOT be reset (was not a contributor)
+			const sess2After = swarmState.agentSessions.get('sess2');
+			expect(sess2After?.phaseAgentsDispatched.size).toBe(1);
+			expect(sess2After?.lastPhaseCompleteTimestamp).toBe(0);
+		});
+	});
 });

--- a/tests/unit/tools/pre-check-batch.adversarial.test.ts
+++ b/tests/unit/tools/pre-check-batch.adversarial.test.ts
@@ -1,0 +1,374 @@
+/**
+ * ADVERSARIAL TESTS: Pre-check batch fail-closed no-files behavior
+ *
+ * These tests validate that security gates CANNOT be bypassed by providing:
+ * - undefined files
+ * - empty files array
+ * - null files
+ * - invalid file paths (traversal, etc.)
+ * - mixed invalid paths
+ *
+ * SECURITY INVARIANT: gates_passed MUST be false when no valid files exist.
+ */
+
+import { beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { runPreCheckBatch } from '../../../src/tools/pre-check-batch';
+
+describe('ADVERSARIAL: fail-closed no-files behavior', () => {
+	const MOCK_DIR = 'C:\\opencode\\opencode-swarm\\src';
+	let consoleWarnSpy: any;
+
+	beforeEach(() => {
+		// Mock console.warn to reduce noise
+		consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	/**
+	 * ATTACK VECTOR 1: Undefined files property
+	 * Attempt to bypass by not providing files at all
+	 */
+	it('REJECTS: undefined files (missing property) - cannot bypass security gates', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			// files property omitted - tests undefined behavior
+		} as any);
+
+		// SECURITY: gates_passed MUST be false
+		expect(result.gates_passed).toBe(false);
+		expect(result.lint.ran).toBe(false);
+		expect(result.lint.error).toContain('No files provided');
+		expect(result.secretscan.ran).toBe(false);
+		expect(result.sast_scan.ran).toBe(false);
+		expect(result.quality_budget.ran).toBe(false);
+	});
+
+	/**
+	 * ATTACK VECTOR 2: Explicit null files
+	 * Attempt to bypass by setting files to null
+	 */
+	it('REJECTS: null files value - cannot bypass security gates', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: null,
+		} as any);
+
+		// SECURITY: gates_passed MUST be false
+		expect(result.gates_passed).toBe(false);
+		expect(result.lint.ran).toBe(false);
+		expect(result.lint.error).toContain('No files provided');
+	});
+
+	/**
+	 * ATTACK VECTOR 3: Empty files array
+	 * Attempt to bypass by providing empty array
+	 */
+	it('REJECTS: empty files array [] - cannot bypass security gates', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: [],
+		});
+
+		// SECURITY: gates_passed MUST be false
+		expect(result.gates_passed).toBe(false);
+		expect(result.lint.ran).toBe(false);
+		expect(result.lint.error).toContain('No files provided');
+	});
+
+	/**
+	 * ATTACK VECTOR 4: Non-array files type
+	 * Attempt to bypass by passing string instead of array
+	 */
+	it('REJECTS: non-array files (string) - fails safely', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: 'src/index.ts',
+		} as any);
+
+		// SECURITY: should fail, not bypass
+		// Implementation may vary based on runtime behavior
+		// But it MUST NOT result in gates_passed=true
+		expect(result.gates_passed).toBe(false);
+	});
+
+	/**
+	 * ATTACK VECTOR 5: Path traversal attempt - parent directory
+	 * Attempt to bypass by using ../ to escape directory
+	 */
+	it('REJECTS: path traversal ../ - cannot bypass validation', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: ['../../../etc/passwd'],
+		});
+
+		// SECURITY: gates_passed MUST be false (no valid files)
+		expect(result.gates_passed).toBe(false);
+		expect(result.lint.ran).toBe(false);
+	});
+
+	/**
+	 * ATTACK VECTOR 6: Path traversal with mixed parent paths
+	 * All paths are invalid -> fail-closed
+	 */
+	it('REJECTS: all traversal paths - cannot bypass validation', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: ['../outside/file1.ts', '../../outside/file2.ts'],
+		});
+
+		// SECURITY: gates_passed MUST be false (no valid files)
+		expect(result.gates_passed).toBe(false);
+	});
+
+	/**
+	 * ATTACK VECTOR 7: Absolute path bypass attempt
+	 * Try to use absolute paths to escape directory boundary
+	 */
+	it('REJECTS: absolute path bypass - cannot escape directory boundary', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: ['C:\\Windows\\System32\\config\\SAM'],
+		});
+
+		// SECURITY: gates_passed MUST be false (absolute path rejected)
+		expect(result.gates_passed).toBe(false);
+	});
+
+	/**
+	 * ATTACK VECTOR 8: Mixed valid and invalid paths
+	 * Even if some valid, adversarial input should not bypass
+	 */
+	it('REJECTS: mixed valid/invalid paths - still must validate all', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: ['index.ts', '../../../etc/passwd', 'utils.ts'],
+		});
+
+		// SECURITY: Should either:
+		// 1. Filter invalid and run on valid, OR
+		// 2. Fail entirely
+		// But MUST NOT bypass security gates by silently accepting bad paths
+		if (result.gates_passed) {
+			// If passes, tools must have run (at least some valid files)
+			// This is acceptable behavior
+			expect(result.lint.ran || result.secretscan.ran).toBe(true);
+		}
+	});
+
+	/**
+	 * ATTACK VECTOR 9: All invalid paths after validation
+	 * Array provided but all paths fail validation
+	 */
+	it('REJECTS: all paths invalid - fail-closed after validation', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: ['../bad1', '../bad2', '../bad3'],
+		});
+
+		// SECURITY: gates_passed MUST be false (no valid files remain)
+		expect(result.gates_passed).toBe(false);
+		expect(result.lint.ran).toBe(false);
+		expect(result.lint.error).toContain('No files provided');
+	});
+
+	/**
+	 * ATTACK VECTOR 10: Empty string in files array
+	 * Attempt to slip past with empty string
+	 */
+	it('REJECTS: empty string path - cannot bypass validation', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: ['', 'index.ts'],
+		});
+
+		// SECURITY: Empty path should be filtered out
+		// If all paths invalid, must fail-closed
+		// If some valid, can proceed (but empty string must not cause bypass)
+		if (result.gates_passed) {
+			// Tools should have run on valid paths only
+			expect(result.lint.ran || result.secretscan.ran).toBe(true);
+		}
+	});
+
+	/**
+	 * ATTACK VECTOR 11: Very long path string (length limit test)
+	 * Attempt to cause buffer overflow or bypass with excessive length
+	 */
+	it('REJECTS: extremely long path - should handle safely', async () => {
+		const longPath = 'a'.repeat(10000); // 10KB path
+
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: [longPath],
+		});
+
+		// SECURITY: Must handle gracefully, not bypass
+		// Either reject long path or fail-closed
+		expect(result.gates_passed).toBe(false);
+	});
+
+	/**
+	 * ATTACK VECTOR 12: Special characters in path
+	 * Attempt to bypass with special characters
+	 */
+	it('REJECTS: special characters in path - cannot bypass validation', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: ['\x00null-byte.ts', '../escape\\n.ts'],
+		});
+
+		// SECURITY: Must not bypass with special chars
+		// Path validation should handle or reject
+		expect(['false', 'true']).toContain(String(result.gates_passed));
+		// If passes, tools must have run (no bypass occurred)
+		if (result.gates_passed) {
+			expect(result.lint.ran || result.secretscan.ran).toBe(true);
+		}
+	});
+
+	/**
+	 * ATTACK VECTOR 13: Unicode path traversal
+	 * Attempt to use unicode homographs or normalization attacks
+	 */
+	it('REJECTS: unicode path traversal - cannot bypass validation', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: ['../\u202e../etc/passwd'], // Right-to-left override
+		});
+
+		// SECURITY: Unicode tricks must not bypass
+		expect(result.gates_passed).toBe(false);
+	});
+
+	/**
+	 * ATTACK VECTOR 14: Only whitespace paths (WEAK VALIDATION)
+	 * Attempt to slip past with whitespace-only paths
+	 *
+	 * VALIDATION WEAKNESS: Whitespace-only paths ('   ', '\t', '\n  ') pass the
+	 * initial validation because validatePath only checks `if (!inputPath || inputPath.length === 0)`
+	 * which doesn't catch whitespace (length > 0).
+	 *
+	 * BEHAVIOR: Paths pass validation but tools fail on non-existent files,
+	 * resulting in fail-closed (gates_passed=false).
+	 *
+	 * SECURITY IMPACT: Not a bypass (gates still fail), but:
+	 * - Wastes resources running tools on invalid paths
+	 * - Could be used for DoS (exhaust resources)
+	 * - Should reject whitespace paths earlier to prevent wasted effort
+	 *
+	 * RESOLUTION: Add trim() check: `if (!inputPath || inputPath.trim().length === 0)`
+	 */
+	it('ACCEPTS (with fail-closed): whitespace-only paths - weak validation but gates still fail', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: ['   ', '\t', '\n  '],
+		});
+
+		// GOOD: Gates fail (fail-closed behavior working)
+		// Paths accepted by validation but tools fail on non-existent files
+		expect(result.gates_passed).toBe(false);
+
+		// Weakness: Tools ran on invalid paths (wasted resources)
+		// This should fail validation earlier, not at tool runtime
+		expect(result.lint.ran).toBe(true);
+	});
+
+	/**
+	 * ATTACK VECTOR 15: Symlink path traversal (if applicable)
+	 * Attempt to use symlinks to escape directory
+	 * Note: This may be platform-dependent
+	 */
+	it('REJECTS: symlink traversal - path validation prevents escape', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: ['symlink-to-parent'],
+		});
+
+		// SECURITY: Symlinks outside directory should not bypass
+		// At minimum, should not allow gates to pass without validation
+		if (result.gates_passed) {
+			// If passes, tools ran (symlink resolved to valid location)
+			expect(result.lint.ran || result.secretscan.ran).toBe(true);
+		}
+	});
+
+	/**
+	 * ATTACK VECTOR 16: Case-insensitive path traversal (Windows)
+	 * Attempt to bypass case sensitivity
+	 */
+	it('REJECTS: mixed case path traversal - validation is path-based', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: ['../OUTSIDE/file.ts', '../outSIDE/file2.ts'],
+		});
+
+		// SECURITY: Case variations of traversal must be caught
+		expect(result.gates_passed).toBe(false);
+	});
+
+	/**
+	 * ATTACK VECTOR 17: Double-encoded traversal
+	 * Attempt to double-encode traversal sequences
+	 */
+	it('REJECTS: double-encoded traversal - must catch encoded attacks', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: ['..././../escape.ts', '..\\..\\escape.ts'], // Windows separator
+		});
+
+		// SECURITY: Encoded variations must be caught
+		expect(result.gates_passed).toBe(false);
+	});
+
+	/**
+	 * ATTACK VECTOR 18: Array with single undefined element
+	 * Attempt to bypass by putting undefined in array
+	 */
+	it('REJECTS: array with undefined element - handles gracefully', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: [undefined],
+		} as any);
+
+		// SECURITY: Undefined element must not bypass
+		expect(result.gates_passed).toBe(false);
+	});
+
+	/**
+	 * ATTACK VECTOR 19: Array with null element
+	 * Attempt to bypass by putting null in array
+	 */
+	it('REJECTS: array with null element - handles gracefully', async () => {
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: [null],
+		} as any);
+
+		// SECURITY: Null element must not bypass
+		expect(result.gates_passed).toBe(false);
+	});
+
+	/**
+	 * ATTACK VECTOR 20: Very large number of invalid paths (DoS)
+	 * Attempt to cause resource exhaustion with many invalid paths
+	 */
+	it('REJECTS: many invalid paths - fails fast without DoS', async () => {
+		const invalidPaths = Array.from(
+			{ length: 1000 },
+			(_, i) => `../bad${i}.ts`,
+		);
+
+		const startTime = Date.now();
+		const result = await runPreCheckBatch({
+			directory: MOCK_DIR,
+			files: invalidPaths,
+		});
+		const duration = Date.now() - startTime;
+
+		// SECURITY: Must fail-closed
+		expect(result.gates_passed).toBe(false);
+
+		// Should not take excessive time (fail fast)
+		// 1000 paths validation should complete quickly
+		expect(duration).toBeLessThan(5000); // < 5 seconds
+	});
+});

--- a/tests/unit/tools/sast-scan.adversarial.test.ts
+++ b/tests/unit/tools/sast-scan.adversarial.test.ts
@@ -1,0 +1,128 @@
+/**
+ * ADVERSARIAL TESTS: SAST Scan - Zero Coverage Fail-Closed
+ *
+ * These tests validate that SAST scan cannot be bypassed by providing:
+ * - empty files list
+ * - invalid non-existent paths
+ * - unsupported file types
+ * - Verify enabled-mode zero coverage returns FAIL (not PASS)
+ */
+
+import { beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import * as fs from 'node:fs';
+import { sastScan } from '../../../src/tools/sast-scan';
+
+describe('SAST Scan - Adversarial Tests (R2)', () => {
+	const MOCK_DIR = 'C:\\opencode\\opencode-swarm\\src';
+
+	beforeEach(() => {
+		// Mock fs.existsSync to return false for non-existent paths
+		spyOn(fs, 'existsSync').mockImplementation((path: any) => {
+			const pathStr = String(path);
+			return pathStr.includes('valid') || pathStr.includes('exists');
+		});
+
+		// Mock fs.statSync
+		spyOn(fs, 'statSync').mockReturnValue({ size: 100 } as any);
+
+		// Mock fs.readFileSync
+		spyOn(fs, 'readFileSync').mockReturnValue('code content');
+
+		// Mock fs.openSync, readSync, closeSync for binary detection
+		spyOn(fs, 'openSync').mockReturnValue(0);
+		spyOn(fs, 'readSync').mockReturnValue(12);
+		spyOn(fs, 'closeSync').mockReturnValue(undefined);
+	});
+
+	/**
+	 * ATTACK VECTOR 1: Empty files list
+	 * Attempt to bypass by providing empty array
+	 */
+	it('empty files list → FAIL (zero coverage)', async () => {
+		const result = await sastScan({ changed_files: [] }, MOCK_DIR);
+		expect(result.verdict).toBe('fail');
+		expect(result.summary.files_scanned).toBe(0);
+	});
+
+	/**
+	 * ATTACK VECTOR 2: Invalid non-existent paths
+	 * Attempt to bypass by providing paths that don't exist
+	 */
+	it('invalid non-existent paths → FAIL (zero coverage)', async () => {
+		const existsSyncMock = spyOn(fs, 'existsSync').mockReturnValue(false);
+
+		const result = await sastScan(
+			{ changed_files: ['/nonexistent/file.ts', '../outside/file.js'] },
+			MOCK_DIR,
+		);
+
+		expect(result.verdict).toBe('fail');
+		expect(result.summary.files_scanned).toBe(0);
+
+		existsSyncMock.mockRestore();
+	});
+
+	/**
+	 * ATTACK VECTOR 3: Unsupported file types
+	 * Attempt to bypass by using file types with no language support
+	 */
+	it('unsupported file types → FAIL (zero coverage)', async () => {
+		const existsSyncMock = spyOn(fs, 'existsSync').mockReturnValue(true);
+
+		const result = await sastScan(
+			{ changed_files: ['test.xyz', 'data.unknown', 'file.badext'] },
+			MOCK_DIR,
+		);
+
+		expect(result.verdict).toBe('fail');
+		expect(result.summary.files_scanned).toBe(0);
+
+		existsSyncMock.mockRestore();
+	});
+
+	/**
+	 * ATTACK VECTOR 4: Enabled mode with zero coverage must FAIL (not PASS)
+	 * This is the critical security invariant - zero coverage cannot be treated as success
+	 */
+	it('enabled mode with zero coverage → FAIL (not pass)', async () => {
+		const result = await sastScan({ changed_files: [] }, MOCK_DIR, {
+			gates: {
+				syntax_check: { enabled: true },
+				placeholder_scan: {
+					enabled: true,
+					deny_patterns: [],
+					allow_globs: [],
+					max_allowed_findings: 0,
+				},
+				sast_scan: { enabled: true },
+				sbom_generate: { enabled: true },
+				build_check: { enabled: true },
+				quality_budget: { enabled: true },
+			},
+		} as any);
+		expect(result.verdict).toBe('fail');
+	});
+
+	/**
+	 * ATTACK VECTOR 5: Disabled mode bypasses zero coverage (control test)
+	 * When feature is disabled, zero coverage should return PASS
+	 */
+	it('disabled mode bypasses zero coverage → PASS (control test)', async () => {
+		const result = await sastScan({ changed_files: [] }, MOCK_DIR, {
+			gates: {
+				syntax_check: { enabled: true },
+				placeholder_scan: {
+					enabled: true,
+					deny_patterns: [],
+					allow_globs: [],
+					max_allowed_findings: 0,
+				},
+				sast_scan: { enabled: false },
+				sbom_generate: { enabled: true },
+				build_check: { enabled: true },
+				quality_budget: { enabled: true },
+			},
+		} as any);
+		expect(result.verdict).toBe('pass');
+	});
+});

--- a/tests/unit/tools/save-plan-adversarial.test.ts
+++ b/tests/unit/tools/save-plan-adversarial.test.ts
@@ -585,4 +585,298 @@ describe('save-plan adversarial tests', () => {
 			expect(result.success).toBe(true);
 		});
 	});
+
+	describe('Repository-root mutation prevention (cross-platform)', () => {
+		it('should reject undefined working_directory with no fallback (Windows-style)', async () => {
+			// This tests that without explicit target, the function fails instead of
+			// falling back to process.cwd() which could mutate repository-root .swarm
+			const args: SavePlanArgs = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+				// No working_directory provided
+			};
+			const result = await executeSavePlan(args, undefined);
+			expect(result.success).toBe(false);
+			expect(result.errors?.[0]).toContain('Target workspace is required');
+		});
+
+		it('should reject undefined working_directory with no fallback (POSIX-style)', async () => {
+			const args: SavePlanArgs = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+			};
+			const result = await executeSavePlan(args);
+			expect(result.success).toBe(false);
+			expect(result.errors?.[0]).toContain('Target workspace is required');
+		});
+
+		it('should reject empty string working_directory (Windows-style path forms)', async () => {
+			const args: SavePlanArgs = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+				working_directory: '',
+			};
+			const result = await executeSavePlan(args);
+			expect(result.success).toBe(false);
+			expect(result.errors?.[0]).toContain('cannot be empty or whitespace');
+		});
+
+		it('should reject whitespace-only working_directory (POSIX-style path forms)', async () => {
+			const args: SavePlanArgs = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+				working_directory: '   ',
+			};
+			const result = await executeSavePlan(args);
+			expect(result.success).toBe(false);
+			expect(result.errors?.[0]).toContain('cannot be empty or whitespace');
+		});
+
+		it('should reject path traversal with backslash (Windows-style "..\\")', async () => {
+			const args: SavePlanArgs = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+				working_directory: 'C:\\projects\\..\\..\\.swarm',
+			};
+			const result = await executeSavePlan(args);
+			expect(result.success).toBe(false);
+			expect(result.errors?.[0]).toContain('cannot contain path traversal');
+		});
+
+		it('should reject path traversal with forward slash (POSIX-style "../")', async () => {
+			const args: SavePlanArgs = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+				working_directory: '/home/user/../../etc',
+			};
+			const result = await executeSavePlan(args);
+			expect(result.success).toBe(false);
+			expect(result.errors?.[0]).toContain('cannot contain path traversal');
+		});
+
+		it('should reject relative path traversal with mixed separators (cross-platform)', async () => {
+			const args: SavePlanArgs = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+				working_directory: './..\\..',
+			};
+			const result = await executeSavePlan(args);
+			expect(result.success).toBe(false);
+			expect(result.errors?.[0]).toContain('cannot contain path traversal');
+		});
+
+		it('should accept Windows root drive path (contract-aligned: no root-path rejection)', async () => {
+			// validateTargetWorkspace does NOT reject root paths - it only checks for:
+			// 1. undefined/null 2. empty/whitespace 3. path traversal (..)
+			// This test validates the CONTRACT: root paths pass validation.
+			// Actual write may fail due to OS permissions - that's environment-dependent.
+			// The key mutation-prevention is: no implicit process.cwd() fallback.
+			const args: SavePlanArgs = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+				working_directory: 'C:\\',
+			};
+			const result = await executeSavePlan(args);
+			// Contract: root paths pass validation (no path traversal, not empty)
+			// Success depends on OS write permissions - not deterministic across environments
+			expect(result.success).toBeDefined();
+			// Key assertion: no validation error for root path (path traversal or empty check)
+			const errors = result.errors ?? [];
+			const hasValidationError = errors.some(e => 
+				e.includes('cannot contain path traversal') || 
+				e.includes('cannot be empty')
+			);
+			expect(hasValidationError).toBe(false);
+		});
+
+		it('should accept POSIX root path (contract-aligned: no root-path rejection)', async () => {
+			// validateTargetWorkspace does NOT reject root paths - it only checks for:
+			// 1. undefined/null 2. empty/whitespace 3. path traversal (..)
+			// This test validates the CONTRACT: root paths pass validation.
+			// Actual write may fail due to OS permissions - that's environment-dependent.
+			// The key mutation-prevention is: no implicit process.cwd() fallback.
+			const args: SavePlanArgs = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+				working_directory: '/',
+			};
+			const result = await executeSavePlan(args);
+			// Contract: root paths pass validation (no path traversal, not empty)
+			// Success depends on OS write permissions - not deterministic across environments
+			expect(result.success).toBeDefined();
+			// Key assertion: no validation error for root path (path traversal or empty check)
+			const errors = result.errors ?? [];
+			const hasValidationError = errors.some(e => 
+				e.includes('cannot contain path traversal') || 
+				e.includes('cannot be empty')
+			);
+			expect(hasValidationError).toBe(false);
+		});
+
+		it('should accept Windows UNC path (contract-aligned: no UNC-path rejection)', async () => {
+			// validateTargetWorkspace does NOT reject UNC paths - it only checks for:
+			// 1. undefined/null 2. empty/whitespace 3. path traversal (..)
+			// This test validates the CONTRACT: UNC paths pass validation.
+			// Actual write may fail due to OS permissions - that's environment-dependent.
+			// The key mutation-prevention is: no implicit process.cwd() fallback.
+			const args: SavePlanArgs = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+				working_directory: '\\\\server\\share',
+			};
+			const result = await executeSavePlan(args);
+			// Contract: UNC paths pass validation (no path traversal, not empty)
+			// Success depends on OS write permissions - not deterministic across environments
+			expect(result.success).toBeDefined();
+			// Key assertion: no validation error for UNC path (path traversal or empty check)
+			const errors = result.errors ?? [];
+			const hasValidationError = errors.some(e => 
+				e.includes('cannot contain path traversal') || 
+				e.includes('cannot be empty')
+			);
+			expect(hasValidationError).toBe(false);
+		});
+
+		it('should accept valid Windows-style workspace path with .swarm subdirectory', async () => {
+			const args: SavePlanArgs = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+				working_directory: 'C:\\projects\\myworkspace',
+			};
+			const result = await executeSavePlan(args);
+			// Valid workspace path should succeed
+			expect(result.success).toBe(true);
+		});
+
+		it('should accept valid POSIX-style workspace path', async () => {
+			const args: SavePlanArgs = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+				working_directory: '/home/user/projects/myworkspace',
+			};
+			const result = await executeSavePlan(args);
+			// Valid workspace path should succeed
+			expect(result.success).toBe(true);
+		});
+
+		it('should reject when fallbackDir is also undefined (double-fallback prevention)', async () => {
+			const args: SavePlanArgs = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+				// No working_directory
+			};
+			// Explicitly pass undefined as fallbackDir
+			const result = await executeSavePlan(args, undefined);
+			expect(result.success).toBe(false);
+			expect(result.errors?.[0]).toContain('required');
+		});
+
+		it('should reject null as working_directory', async () => {
+			const args = {
+				title: 'Test Plan',
+				swarm_id: 'test',
+				phases: [
+					{
+						id: 1,
+						name: 'Setup',
+						tasks: [{ id: '1.1', description: 'Valid description' }],
+					},
+				],
+				working_directory: null,
+			} as unknown as SavePlanArgs;
+			const result = await executeSavePlan(args);
+			expect(result.success).toBe(false);
+		});
+	});
 });

--- a/tests/unit/tools/save-plan-task4-1.test.ts
+++ b/tests/unit/tools/save-plan-task4-1.test.ts
@@ -2,7 +2,7 @@
  * Additional verification tests for Task 4.1 atomic plan write changes
  * Tests for:
  * 1. executeSavePlan() fallbackDir parameter behavior
- * 2. executeSavePlan() process.cwd() fallback behavior
+ * 2. executeSavePlan() explicit workspace behavior (no process.cwd() fallback)
  * 3. Temp file cleanup after successful writes
  */
 
@@ -122,13 +122,13 @@ describe('Task 4.1: fallbackDir parameter behavior', () => {
 	});
 });
 
-describe('Task 4.1: process.cwd() fallback behavior', () => {
+describe('Task 4.1: explicit workspace behavior', () => {
 	let originalCwd: string;
 	let tmpDir: string;
 
 	beforeEach(async () => {
 		originalCwd = process.cwd();
-		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'save-plan-cwd-'));
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'save-plan-explicit-'));
 		// Ensure .swarm/ directory exists in tmpDir
 		await fs.mkdir(path.join(tmpDir, '.swarm'), { recursive: true });
 	});
@@ -142,12 +142,9 @@ describe('Task 4.1: process.cwd() fallback behavior', () => {
 		}
 	});
 
-	it('executeSavePlan() uses process.cwd() as final fallback when neither args.working_directory nor fallbackDir is provided', async () => {
-		// Change to tmpDir
-		process.chdir(tmpDir);
-
+	it('executeSavePlan() fails deterministically when both working_directory and fallbackDir are missing', async () => {
 		const args: SavePlanArgs = {
-			title: 'CWD Fallback Test Plan',
+			title: 'No Directory Test Plan',
 			swarm_id: 'test-swarm',
 			phases: [
 				{
@@ -156,19 +153,56 @@ describe('Task 4.1: process.cwd() fallback behavior', () => {
 					tasks: [{ id: '1.1', description: 'Test task' }],
 				},
 			],
-			// No working_directory and no fallbackDir
+			// No working_directory specified
 		};
 
-		// Call without fallbackDir
+		// Call without fallbackDir - should fail explicitly
+		const result: SavePlanResult = await executeSavePlan(args);
+
+		// Should fail because no directory was provided
+		expect(result.success).toBe(false);
+		expect(result.errors).toBeDefined();
+		expect(result.errors?.[0]).toContain('fallbackDir');
+	});
+
+	it('executeSavePlan() uses explicit working_directory from args', async () => {
+		// Change to a different directory to prove working_directory is respected
+		process.chdir(tmpDir);
+
+		const otherDir = await fs.mkdtemp(path.join(os.tmpdir(), 'save-plan-other-'));
+		await fs.mkdir(path.join(otherDir, '.swarm'), { recursive: true });
+
+		const args: SavePlanArgs = {
+			title: 'Explicit Workspace Test',
+			swarm_id: 'test-swarm',
+			phases: [
+				{
+					id: 1,
+					name: 'Setup',
+					tasks: [{ id: '1.1', description: 'Test task' }],
+				},
+			],
+			working_directory: otherDir,
+		};
+
+		// Call without fallbackDir - should use explicit working_directory
 		const result: SavePlanResult = await executeSavePlan(args);
 
 		expect(result.success).toBe(true);
-		expect(result.plan_path).toBe(path.join(tmpDir, '.swarm', 'plan.json'));
+		expect(result.plan_path).toBe(path.join(otherDir, '.swarm', 'plan.json'));
 
-		// Verify plan was written to current working directory
-		const planPath = path.join(tmpDir, '.swarm', 'plan.json');
+		// Verify plan was written to the explicit working_directory, not cwd
+		const planPath = path.join(otherDir, '.swarm', 'plan.json');
 		const exists = await fs.access(planPath).then(() => true).catch(() => false);
 		expect(exists).toBe(true);
+
+		// Verify NOT written to cwd
+		const cwdPlanPath = path.join(tmpDir, '.swarm', 'plan.json');
+		const cwdExists = await fs.access(cwdPlanPath).then(() => true).catch(() => false);
+		expect(cwdExists).toBe(false);
+
+		// Cleanup otherDir
+		await fs.rm(otherDir, { recursive: true, force: true });
 	});
 });
 


### PR DESCRIPTION
## Summary

Bug-fix patch (no new features). Intended to trigger a **patch version bump** via release-please.

## Changes

### Phase Completion Reliability (`src/tools/phase-complete.ts`)
- Added `collectCrossSessionDispatchedAgents()` helper that aggregates dispatched agents across all contributor sessions active since the phase reference timestamp
- `executePhaseComplete` now evaluates required agents against the cross-session aggregated set rather than caller-session-only state
- On successful completion, all contributor sessions have their phase-tracking state reset (not just the caller session)

### Workspace Validation Hardening (`src/tools/save-plan.ts`, `src/plan/manager.ts`)
- `executeSavePlan` now rejects missing, blank, whitespace-only, and path-traversal target workspace inputs deterministically before any write attempt
- `savePlan` fails fast on null/undefined/non-string/blank directory input before temp-file creation — no implicit fallback to `process.cwd()`

### Test Coverage
- Multi-session regression tests for `phase_complete` required-agent aggregation
- Cross-platform adversarial tests for workspace mutation prevention
- Migrated `pre-check-batch.adversarial.test.ts` and `sast-scan.adversarial.test.ts` to canonical `tests/unit/tools/` directory

### Documentation
- README: documented explicit target-workspace requirement for plan-save operations

## Release-please notes

Single `fix:` conventional commit. Expected bump: `6.19.4 → 6.19.5`.