### PR TITLE
fix: resolve path before isSourceCodePath check, fix test gate setup

### DIFF
--- a/src/hooks/guardrails.ts
+++ b/src/hooks/guardrails.ts
@@ -350,8 +350,11 @@ export function createGuardrailsHooks(
 
 				if (
 					typeof targetPath === 'string' &&
+					targetPath.length > 0 &&
 					isOutsideSwarmDir(targetPath, directory) &&
-					(isSourceCodePath(targetPath) || hasTraversalSegments(targetPath))
+					isSourceCodePath(
+						path.relative(directory, path.resolve(directory, targetPath)),
+					)
 				) {
 					const session = swarmState.agentSessions.get(input.sessionID);
 					if (session) {

--- a/tests/unit/hooks/guardrails.test.ts
+++ b/tests/unit/hooks/guardrails.test.ts
@@ -1971,6 +1971,8 @@ describe('guardrails circuit breaker', () => {
 				session.reviewerCallCount.set(2, 1);
 				session.reviewerCallCount.set(3, 1);
 				session.reviewerCallCount.set(4, 1);
+				// Populate gateLog so PARTIAL GATE VIOLATION check does not fire
+				session.gateLog.set('no-write-session:unknown', new Set(['diff', 'syntax_check', 'placeholder_scan', 'lint', 'pre_check_batch']));
 			}
 
 			// Transform messages
@@ -2039,6 +2041,8 @@ describe('guardrails circuit breaker', () => {
 				session.reviewerCallCount.set(2, 1);
 				session.reviewerCallCount.set(3, 1);
 				session.reviewerCallCount.set(4, 1);
+				// Populate gateLog so PARTIAL GATE VIOLATION check does not fire
+				session.gateLog.set('old-failure-session:unknown', new Set(['diff', 'syntax_check', 'placeholder_scan', 'lint', 'pre_check_batch']));
 			}
 
 			// Transform messages


### PR DESCRIPTION
## Summary

- **Path traversal false-positive fix** — `src/../README.md` was incorrectly counted as a source write in the self-coding gate because `hasTraversalSegments()` returned `true` for any path containing `/../`. Fixed by resolving the path to its actual destination before calling `isSourceCodePath()`, so traversal paths that resolve to non-source files (e.g. `README.md`) are no longer flagged.
- **Test gate setup fix** — Two tests in `guardrails.test.ts` were failing because `PARTIAL_GATE_VIOLATION` was being injected by `messagesTransform` during test execution (the test session had no `gateLog` entries, triggering the unrelated violation check). Fixed by populating `session.gateLog` with the 5 required gate entries in both test setups to properly isolate self-fix warning behavior.

## Files Changed

| File | Change |
|------|--------|
| `src/hooks/guardrails.ts` | Resolve `targetPath` before `isSourceCodePath()` check in self-coding gate |
| `tests/unit/hooks/guardrails.test.ts` | Add `gateLog` setup to two isolation tests |

## Testing

- `tests/unit/hooks/guardrails.test.ts`: was 102/104, now 104/104 ✅
- `tests/unit/hooks/guardrails-self-coding-gate.test.ts`: was 13/14, now 14/14 ✅

These failures were pre-existing on `main` before the v6.20.2 changes — this PR brings the test suite to fully green.