### PR TITLE
fix: plumb ToolContext.sessionID into phase_complete to fix cross-session tracking

### DIFF
--- a/.swarm/context.md
+++ b/.swarm/context.md
@@ -3,11 +3,13 @@ Swarm: mega
 
 ## Current State
 - **v6.20.0 RELEASED** — 2026-03-07. All implementation merged to `origin/main` via PR #69 (feat) + PR #70 (release). Tag `v6.20.0` published to npm.
-- Active plan: `v6.20 Implementation` — all 8 phases COMPLETE. See plan.md.
-- Last commit on main: `4032e56 Merge pull request #70` (includes CHANGELOG correction `ab2f893`).
-- Retrospective: `.swarm/evidence/retro-10/evidence.json` written.
+- Active plan: `Issue #78 Hotfixes: Summarization Verification, Gate-State Wiring, and Plan-State Guard Hardening` — ALL PHASES COMPLETE.
+- PR #82 open: `fix/gate-enforcement-hardening` → `main`. Awaiting CI green + merge.
+- Commits on branch: `a42f4f1` (feature), `0673429` (lint fix), `b0d59d8` (release-please github changelog mode).
+- Retrospective: `.swarm/evidence/retro-11/evidence.json` written. Phase 11 complete.
 - Knowledge store: 12 entries in `%LOCALAPPDATA%\opencode-swarm\Data\knowledge.jsonl`.
-- No uncommitted changes. No open work items. Branch: `release-please--branches--main--components--opencode-swarm` (release branch — historical after merge).
+- Next version bump after PR #82 merges: patch (fix: commits) → v6.20.4.
+- changelog-notes-type: github now active — future CHANGELOG entries will include full PR body.
 
 ### Phase 1 — DONE (all gates passed)
 - 1.1 `src/agents/index.ts` — primary agents strip `model` ✅
@@ -69,6 +71,16 @@ src/agents/architect.ts, src/agents/index.ts, src/config/constants.ts, src/evide
 - `write_retro` addendum work is folded into the hotfix because the retrospective gate is part of the same architect workflow failure surface.
 - Architect runtime exposure tasks must include plugin registration in `src/index.ts`, not only tool-name and permission lists.
 - Malformed retrospective compatibility repair is planned before regression tests so phase_complete can validate repaired artifacts through the real load path.
+- Issue #78 docs: add new documentation sections for summarization defaults and pagination (no prior README defaults).
+
+## SME Cache
+### ui_ux
+- Raise summarization threshold to reduce premature summaries; explicit read outputs should remain unsummarized by default with clear user control and continuation cues for pagination.
+- Pagination UX should show total lines, loaded range, and explicit next-call hints; chunk ordering must be stable with clear recovery states.
+
+### security
+- Enforce pagination bounds and guard against offset/limit abuse; avoid leaking existence details through error messages.
+- Log retrieval attempts, avoid differentiated errors for missing vs unauthorized, and keep error responses generic for invalid ranges.
 
 ## Known Risks
 - phase_complete agent-dispatch tracking is cross-session — the tool may report missing agents when work was done in prior sessions. This is a known limitation documented in Phase 5 retrospective.
@@ -173,29 +185,27 @@ src/agents/architect.ts, src/agents/index.ts, src/config/constants.ts, src/evide
 
 | Tool | Calls | Success | Failed | Avg Duration |
 |------|-------|---------|--------|--------------|
-| read | 1646 | 1646 | 0 | 7ms |
-| bash | 1228 | 1228 | 0 | 1003ms |
-| edit | 512 | 512 | 0 | 2448ms |
-| task | 344 | 344 | 0 | 110040ms |
-| grep | 335 | 335 | 0 | 112ms |
-| glob | 226 | 226 | 0 | 25ms |
-| retrieve_summary | 127 | 127 | 0 | 3ms |
-| write | 104 | 104 | 0 | 3681ms |
-| todowrite | 68 | 68 | 0 | 4ms |
-| pre_check_batch | 68 | 68 | 0 | 2902ms |
-| lint | 60 | 60 | 0 | 2852ms |
-| test_runner | 45 | 45 | 0 | 17782ms |
-| update_task_status | 44 | 44 | 0 | 6ms |
-| diff | 21 | 21 | 0 | 12ms |
-| phase_complete | 19 | 19 | 0 | 5ms |
-| save_plan | 12 | 12 | 0 | 6ms |
-| imports | 11 | 11 | 0 | 4ms |
-| evidence_check | 4 | 4 | 0 | 2ms |
-| invalid | 4 | 4 | 0 | 1ms |
-| write_retro | 4 | 4 | 0 | 5ms |
-| webfetch | 3 | 3 | 0 | 363ms |
-| todo_extract | 2 | 2 | 0 | 2ms |
+| read | 872 | 872 | 0 | 7ms |
+| bash | 709 | 709 | 0 | 710ms |
+| edit | 240 | 240 | 0 | 1877ms |
+| task | 202 | 202 | 0 | 115495ms |
+| glob | 163 | 163 | 0 | 25ms |
+| grep | 137 | 137 | 0 | 83ms |
+| retrieve_summary | 45 | 45 | 0 | 3ms |
+| write | 44 | 44 | 0 | 1465ms |
+| lint | 31 | 31 | 0 | 2706ms |
+| pre_check_batch | 28 | 28 | 0 | 2254ms |
+| test_runner | 27 | 27 | 0 | 6281ms |
+| todowrite | 22 | 22 | 0 | 3ms |
+| update_task_status | 22 | 22 | 0 | 6ms |
+| save_plan | 14 | 14 | 0 | 12ms |
+| phase_complete | 14 | 14 | 0 | 6ms |
+| diff | 11 | 11 | 0 | 28ms |
+| imports | 10 | 10 | 0 | 5ms |
+| todo_extract | 5 | 5 | 0 | 2ms |
+| invalid | 5 | 5 | 0 | 1ms |
+| declare_scope | 4 | 4 | 0 | 3ms |
+| write_retro | 3 | 3 | 0 | 7ms |
+| evidence_check | 2 | 2 | 0 | 2ms |
 | apply_patch | 2 | 2 | 0 | 113ms |
 | secretscan | 2 | 2 | 0 | 135ms |
-| mystatus | 1 | 1 | 0 | 2165ms |
-| checkpoint | 1 | 1 | 0 | 7ms |

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -29766,7 +29766,7 @@ function createSwarmTool(opts) {
     args: opts.args,
     execute: async (args, ctx) => {
       const directory = ctx?.directory ?? process.cwd();
-      return opts.execute(args, directory);
+      return opts.execute(args, directory, ctx);
     }
   });
 }
@@ -35648,7 +35648,7 @@ var HELP_TEXT = [
 
 // src/cli/index.ts
 var CONFIG_DIR = path14.join(process.env.XDG_CONFIG_HOME || path14.join(os2.homedir(), ".config"), "opencode");
-var OPENCODE_CONFIG_PATH = path14.join(CONFIG_DIR, "config.json");
+var OPENCODE_CONFIG_PATH = path14.join(CONFIG_DIR, "opencode.json");
 var PLUGIN_CONFIG_PATH = path14.join(CONFIG_DIR, "opencode-swarm.json");
 var PROMPTS_DIR = path14.join(CONFIG_DIR, "opencode-swarm");
 function ensureDir(dir) {
@@ -35674,9 +35674,16 @@ async function install() {
 `);
   ensureDir(CONFIG_DIR);
   ensureDir(PROMPTS_DIR);
+  const LEGACY_CONFIG_PATH = path14.join(CONFIG_DIR, "config.json");
   let opencodeConfig = loadJson(OPENCODE_CONFIG_PATH);
   if (!opencodeConfig) {
-    opencodeConfig = {};
+    const legacyConfig = loadJson(LEGACY_CONFIG_PATH);
+    if (legacyConfig) {
+      console.log("\u26A0 Migrating existing config from config.json to opencode.json...");
+      opencodeConfig = legacyConfig;
+    } else {
+      opencodeConfig = {};
+    }
   }
   if (!opencodeConfig.plugin) {
     opencodeConfig.plugin = [];

--- a/dist/index.js
+++ b/dist/index.js
@@ -30328,7 +30328,7 @@ function createSwarmTool(opts) {
     args: opts.args,
     execute: async (args2, ctx) => {
       const directory = ctx?.directory ?? process.cwd();
-      return opts.execute(args2, directory);
+      return opts.execute(args2, directory, ctx);
     }
   });
 }
@@ -38299,7 +38299,8 @@ var KNOWN_SWARM_PREFIXES = [
   "custom",
   "team",
   "project",
-  "swarm"
+  "swarm",
+  "synthetic"
 ];
 var SEPARATORS = ["_", "-", " "];
 function stripKnownSwarmPrefix(agentName) {
@@ -47250,15 +47251,23 @@ function createDelegationGateHook(config3) {
           session.qaSkipCount = 0;
           session.qaSkipTaskIds = [];
         }
-        if (hasReviewer && session.currentTaskId) {
-          try {
-            advanceTaskState(session, session.currentTaskId, "reviewer_run");
-          } catch {}
+        if (hasReviewer && session.taskWorkflowStates) {
+          for (const [taskId, state] of session.taskWorkflowStates) {
+            if (state === "coder_delegated" || state === "pre_check_passed") {
+              try {
+                advanceTaskState(session, taskId, "reviewer_run");
+              } catch {}
+            }
+          }
         }
-        if (hasReviewer && hasTestEngineer && session.currentTaskId) {
-          try {
-            advanceTaskState(session, session.currentTaskId, "tests_run");
-          } catch {}
+        if (hasReviewer && hasTestEngineer && session.taskWorkflowStates) {
+          for (const [taskId, state] of session.taskWorkflowStates) {
+            if (state === "reviewer_run") {
+              try {
+                advanceTaskState(session, taskId, "tests_run");
+              } catch {}
+            }
+          }
         }
       }
     }
@@ -47568,7 +47577,9 @@ function createDelegationTrackerHook(config3, guardrailsEnabled = true) {
     if (!isArchitect && guardrailsEnabled) {
       beginInvocation(input.sessionID, agentName);
     }
-    if (config3.hooks?.delegation_tracker === true && previousAgent && previousAgent !== agentName) {
+    const delegationTrackerEnabled = config3.hooks?.delegation_tracker === true;
+    const delegationGateEnabled = config3.hooks?.delegation_gate !== false;
+    if ((delegationTrackerEnabled || delegationGateEnabled) && previousAgent && previousAgent !== agentName) {
       const entry = {
         from: previousAgent,
         to: agentName,
@@ -47579,7 +47590,9 @@ function createDelegationTrackerHook(config3, guardrailsEnabled = true) {
       }
       const chain = swarmState.delegationChains.get(input.sessionID);
       chain?.push(entry);
-      swarmState.pendingEvents++;
+      if (delegationTrackerEnabled) {
+        swarmState.pendingEvents++;
+      }
     }
   };
 }
@@ -53420,13 +53433,13 @@ var phase_complete = createSwarmTool({
     summary: tool.schema.string().optional().describe("Optional summary of what was accomplished in this phase"),
     sessionID: tool.schema.string().optional().describe("Session ID for tracking state (auto-provided by plugin context)")
   },
-  execute: async (args2, directory) => {
+  execute: async (args2, directory, ctx) => {
     let phaseCompleteArgs;
     try {
       phaseCompleteArgs = {
         phase: Number(args2.phase),
         summary: args2.summary !== undefined ? String(args2.summary) : undefined,
-        sessionID: args2.sessionID !== undefined ? String(args2.sessionID) : undefined
+        sessionID: ctx?.sessionID ?? (args2.sessionID !== undefined ? String(args2.sessionID) : undefined)
       };
     } catch {
       return JSON.stringify({
@@ -59445,9 +59458,15 @@ function checkReviewerGate(taskId) {
         return { blocked: false, reason: "" };
       }
     }
+    const stateEntries = [];
+    for (const [sessionId, session] of swarmState.agentSessions) {
+      const state = getTaskState(session, taskId);
+      stateEntries.push(`${sessionId}: ${state}`);
+    }
+    const currentStateStr = stateEntries.length > 0 ? stateEntries.join(", ") : "no active sessions";
     return {
       blocked: true,
-      reason: `Task ${taskId} has not passed QA gates (state machine requires tests_run or complete, current state indicates gates not yet passed). Call mega_reviewer and mega_test_engineer before marking task as completed.`
+      reason: `Task ${taskId} has not passed QA gates. Current state: [${currentStateStr}]. Required state: tests_run or complete. Do not write directly to plan files \u2014 use update_task_status after running mega_reviewer and mega_test_engineer.`
     };
   } catch {
     return { blocked: false, reason: "" };
@@ -59469,6 +59488,16 @@ async function executeUpdateTaskStatus(args2, fallbackDir) {
       message: "Validation failed",
       errors: [taskIdError]
     };
+  }
+  if (args2.status === "in_progress") {
+    for (const [_sessionId, session] of swarmState.agentSessions) {
+      const currentState = getTaskState(session, args2.task_id);
+      if (currentState === "idle") {
+        try {
+          advanceTaskState(session, args2.task_id, "coder_delegated");
+        } catch {}
+      }
+    }
   }
   if (args2.status === "completed") {
     const reviewerCheck = checkReviewerGate(args2.task_id);

--- a/dist/tools/create-tool.d.ts
+++ b/dist/tools/create-tool.d.ts
@@ -1,4 +1,4 @@
-import { tool } from '@opencode-ai/plugin';
+import { type ToolContext, tool } from '@opencode-ai/plugin';
 /**
  * Options for creating a swarm tool.
  * The args type is inferred from what you pass to the tool() call.
@@ -6,10 +6,10 @@ import { tool } from '@opencode-ai/plugin';
 export interface SwarmToolOptions<Args extends Record<string, unknown>> {
     description: string;
     args: Args;
-    execute: (args: Args, directory: string) => Promise<string>;
+    execute: (args: Args, directory: string, ctx?: ToolContext) => Promise<string>;
 }
 /**
  * Creates a swarm tool with automatic working directory injection.
- * Wraps the @opencode-ai/plugin/tool factory to always inject `directory` into tool execute callbacks.
+ * Wraps the @opencode-ai/plugin/tool factory to always inject `directory` and `ctx` into tool execute callbacks.
  */
 export declare function createSwarmTool<Args extends Record<string, unknown>>(opts: SwarmToolOptions<Args>): ReturnType<typeof tool>;

--- a/src/tools/create-tool.ts
+++ b/src/tools/create-tool.ts
@@ -7,12 +7,16 @@ import { type ToolContext, tool } from '@opencode-ai/plugin';
 export interface SwarmToolOptions<Args extends Record<string, unknown>> {
 	description: string;
 	args: Args;
-	execute: (args: Args, directory: string) => Promise<string>;
+	execute: (
+		args: Args,
+		directory: string,
+		ctx?: ToolContext,
+	) => Promise<string>;
 }
 
 /**
  * Creates a swarm tool with automatic working directory injection.
- * Wraps the @opencode-ai/plugin/tool factory to always inject `directory` into tool execute callbacks.
+ * Wraps the @opencode-ai/plugin/tool factory to always inject `directory` and `ctx` into tool execute callbacks.
  */
 export function createSwarmTool<Args extends Record<string, unknown>>(
 	opts: SwarmToolOptions<Args>,
@@ -26,7 +30,7 @@ export function createSwarmTool<Args extends Record<string, unknown>>(
 		execute: async (args: ToolExecuteArgs, ctx?: ToolContext) => {
 			// process.cwd() fallback is intentional: used when tool is invoked directly (CLI) without plugin runtime context
 			const directory = ctx?.directory ?? process.cwd();
-			return opts.execute(args as Args, directory);
+			return opts.execute(args as Args, directory, ctx);
 		},
 	});
 }

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -595,7 +595,7 @@ export const phase_complete: ToolDefinition = createSwarmTool({
 				'Session ID for tracking state (auto-provided by plugin context)',
 			),
 	},
-	execute: async (args, directory) => {
+	execute: async (args, directory, ctx) => {
 		// Parse and validate arguments
 		let phaseCompleteArgs: PhaseCompleteArgs;
 
@@ -604,7 +604,8 @@ export const phase_complete: ToolDefinition = createSwarmTool({
 				phase: Number(args.phase),
 				summary: args.summary !== undefined ? String(args.summary) : undefined,
 				sessionID:
-					args.sessionID !== undefined ? String(args.sessionID) : undefined,
+					ctx?.sessionID ??
+					(args.sessionID !== undefined ? String(args.sessionID) : undefined),
 			};
 		} catch {
 			return JSON.stringify(

--- a/tests/unit/tools/create-tool.test.ts
+++ b/tests/unit/tools/create-tool.test.ts
@@ -289,4 +289,41 @@ describe('createSwarmTool', () => {
 			expect(result).toBe('async result');
 		});
 	});
+
+	describe('Group 6: ToolContext forwarding', () => {
+		it('createSwarmTool passes the ToolContext as the third argument to execute callback', async () => {
+			const receivedCtx: Array<ToolContext | undefined> = [];
+
+			createSwarmTool({
+				description: 'Test tool',
+				args: { foo: z.string() },
+				execute: async (args, directory, ctx) => {
+					receivedCtx.push(ctx);
+					return 'result';
+				},
+			});
+
+			const toolCalls = mockTool.mock.calls;
+			expect(toolCalls.length).toBeGreaterThan(0);
+
+			const toolConfig = toolCalls[0][0] as { execute: (args: unknown, ctx?: ToolContext) => Promise<string> };
+
+			const mockContext: ToolContext = {
+				sessionID: 'test-session-123',
+				messageID: 'test-message-id',
+				agent: 'test-agent',
+				directory: '/test',
+				worktree: '/test',
+				abort: new AbortController().signal,
+				metadata: () => {},
+				ask: async () => {},
+			};
+
+			await toolConfig.execute({ foo: 'bar' }, mockContext);
+
+			expect(receivedCtx).toHaveLength(1);
+			expect(receivedCtx[0]).toBe(mockContext); // same reference
+			expect(receivedCtx[0]?.sessionID).toBe('test-session-123');
+		});
+	});
 });

--- a/tests/unit/tools/phase-complete.test.ts
+++ b/tests/unit/tools/phase-complete.test.ts
@@ -5,6 +5,8 @@ import * as os from 'node:os';
 
 import { resetSwarmState, ensureAgentSession, recordPhaseAgentDispatch, swarmState } from '../../../src/state';
 
+import type { ToolContext } from '@opencode-ai/plugin';
+
 // Import the tool after setting up environment
 const { phase_complete } = await import('../../../src/tools/phase-complete');
 
@@ -52,6 +54,22 @@ function writeRetroBundle(
 		path.join(retroDir, 'evidence.json'),
 		JSON.stringify(retroBundle, null, 2),
 	);
+}
+
+/**
+ * Helper to create a minimal ToolContext mock for testing
+ */
+function mockCtx(sessionID: string, directory: string): ToolContext {
+	return {
+		sessionID,
+		messageID: 'test-message-id',
+		agent: 'test-agent',
+		directory,
+		worktree: directory,
+		abort: new AbortController().signal,
+		metadata: () => {},
+		ask: async () => {},
+	};
 }
 
 describe('phase_complete tool', () => {
@@ -886,6 +904,43 @@ describe('phase_complete tool', () => {
 			const sess2After = swarmState.agentSessions.get('sess2');
 			expect(sess2After?.phaseAgentsDispatched.size).toBe(1);
 			expect(sess2After?.lastPhaseCompleteTimestamp).toBe(0);
+		});
+	});
+
+	describe('sessionID resolution from ToolContext', () => {
+		test('resolves sessionID from ctx.sessionID when args.sessionID is absent', async () => {
+			ensureAgentSession('ctx-session');
+			recordPhaseAgentDispatch('ctx-session', 'coder');
+			recordPhaseAgentDispatch('ctx-session', 'reviewer');
+			recordPhaseAgentDispatch('ctx-session', 'test_engineer');
+			recordPhaseAgentDispatch('ctx-session', 'docs');
+			writeRetroBundle(tempDir, 1, 'pass');
+
+			const ctx = mockCtx('ctx-session', tempDir);
+			const result = await phase_complete.execute({ phase: 1 }, ctx);
+			const parsed = JSON.parse(result);
+
+			// Should succeed: sessionID resolved from ctx, not from args
+			expect(parsed.success).toBe(true);
+			expect(parsed.phase).toBe(1);
+		});
+
+		test('ctx.sessionID takes priority over args.sessionID when both are provided', async () => {
+			ensureAgentSession('ctx-wins');
+			recordPhaseAgentDispatch('ctx-wins', 'coder');
+			recordPhaseAgentDispatch('ctx-wins', 'reviewer');
+			recordPhaseAgentDispatch('ctx-wins', 'test_engineer');
+			recordPhaseAgentDispatch('ctx-wins', 'docs');
+			writeRetroBundle(tempDir, 1, 'pass');
+
+			const ctx = mockCtx('ctx-wins', tempDir);
+			const result = await phase_complete.execute({ phase: 1, sessionID: 'args-ignored' }, ctx);
+			const parsed = JSON.parse(result);
+
+			// Should succeed using ctx-wins session (not args-ignored)
+			// args-ignored was never registered as a session, but ctx-wins was
+			expect(parsed.success).toBe(true);
+			expect(parsed.phase).toBe(1);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #89 — `phase_complete` failed with "Session ID is required" in new OpenCode sessions because the architect has no way to pass its own session ID as an explicit argument.

## Root Cause

`createSwarmTool` wrapped the plugin's `tool()` factory but only forwarded `ctx.directory` to inner execute callbacks — `ctx.sessionID` was silently dropped. `phase_complete` then required `sessionID` as an explicit user-provided arg with no fallback.

## Changes

- **`src/tools/create-tool.ts`** — `SwarmToolOptions.execute` signature extended to `(args, directory, ctx?)`. The `ctx` object is now forwarded as the third argument in the wrapper.
- **`src/tools/phase-complete.ts`** — `sessionID` now reads from `ctx?.sessionID` first (auto-injected from `ToolContext`), falling back to `args.sessionID` for backward-compatibility. The hard error guard remains as a last-resort safety net.

## Tests

- `tests/unit/tools/phase-complete.test.ts` — 2 new tests: ctx.sessionID as primary source, ctx wins over args
- `tests/unit/tools/create-tool.test.ts` — 1 new test: ToolContext forwarded as 3rd arg to execute callback

## Gate Results

All gates passed: typecheck ✓ lint ✓ build ✓ pre_check_batch ✓ reviewer (APPROVED, LOW risk) ✓ test-verification 33/33 ✓ adversarial 8/8 ✓