### PR TITLE
fix(tests): always write explicit curator config to prevent user config leak

### DIFF
--- a/tests/unit/tools/phase-complete-curator.test.ts
+++ b/tests/unit/tools/phase-complete-curator.test.ts
@@ -106,20 +106,19 @@ function createConfig(curatorConfig?: {
 			require_docs: false,
 			policy: 'enforce',
 		},
-	};
-
-	if (curatorConfig !== undefined) {
-		config.curator = {
-			enabled: curatorConfig.enabled ?? false,
-			phase_enabled: curatorConfig.phase_enabled ?? true,
+		// Always write explicit curator config to override any user-level config that may
+		// have curator.enabled=true (user config deep-merges with project config).
+		curator: {
+			enabled: curatorConfig?.enabled ?? false,
+			phase_enabled: curatorConfig?.phase_enabled ?? true,
 			init_enabled: true,
 			max_summary_tokens: 2000,
 			min_knowledge_confidence: 0.7,
 			compliance_report: true,
 			suppress_warnings: true,
 			drift_inject_max_chars: 500,
-		};
-	}
+		},
+	};
 
 	return JSON.stringify(config);
 }


### PR DESCRIPTION
## Summary

- Fixes an environment-isolation bug in `tests/unit/tools/phase-complete-curator.test.ts`
- The `createConfig()` helper now always writes an explicit `curator` section with `enabled: false` as default, ensuring the project config overrides any user-level `~/.config/opencode/opencode-swarm.json` that may have `curator.enabled: true`
- Previously: tests expecting curator to be disabled would fail on machines where the user config had `curator.enabled: true`, because the config loader deep-merges user + project config and the project config had no `curator` field to override it

## Root Cause

`loadPluginConfig()` deep-merges user config → project config. When `createConfig()` wrote no `curator` field, the user's `curator.enabled: true` was preserved in the merge, causing `runCuratorPhase` to be called in tests that expected it to be skipped.

## Tests

```
252 pass, 0 fail (was 251 pass, 1 fail)
```

Previously failing test now passes: `runCuratorPhase is NOT called when curator is not enabled`