### PR TITLE
fix: restore release-please trigger after non-conventional merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,8 @@ If `.swarm/plan.md` already exists, the architect may enter `RESUME` and then go
 
 Use `/swarm status` if you are unsure what Swarm is doing.
 
+Release automation uses release-please and requires conventional commit prefixes such as `fix:` or `feat:` on changes merged to `main`.
+
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
- add explicit release-please guidance in README requiring conventional commit prefixes on changes merged to main
- provide a parseable  commit on the branch so release-please can classify post-v6.22.7 changes
- unblock automatic creation of the next release PR after merge
