### PR TITLE
fix: resolve phase_complete fallback regressions affecting task status flow

### DIFF
--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -63,6 +63,14 @@ interface CrossSessionAgentsResult {
 	contributorSessionIds: string[];
 }
 
+function safeWarn(message: string, error: unknown): void {
+	try {
+		console.warn(message, error);
+	} catch {
+		// Ignore logger failures to keep phase_complete non-blocking
+	}
+}
+
 /**
  * Collect dispatched agents across contributor sessions.
  * Contributor sessions are defined as those with activity since a phase reference timestamp,
@@ -87,13 +95,6 @@ function collectCrossSessionDispatchedAgents(
 		// Collect agents from caller's phaseAgentsDispatched
 		if (callerSession.phaseAgentsDispatched) {
 			for (const agent of callerSession.phaseAgentsDispatched) {
-				agents.add(agent);
-			}
-		}
-
-		// Also include agents from the most recently completed phase (persisted across reset)
-		if (callerSession.lastCompletedPhaseAgentsDispatched) {
-			for (const agent of callerSession.lastCompletedPhaseAgentsDispatched) {
 				agents.add(agent);
 			}
 		}
@@ -147,13 +148,6 @@ function collectCrossSessionDispatchedAgents(
 			// Collect agents from this session's phaseAgentsDispatched
 			if (session.phaseAgentsDispatched) {
 				for (const agent of session.phaseAgentsDispatched) {
-					agents.add(agent);
-				}
-			}
-
-			// Also include agents from this session's most recently completed phase
-			if (session.lastCompletedPhaseAgentsDispatched) {
-				for (const agent of session.lastCompletedPhaseAgentsDispatched) {
 					agents.add(agent);
 				}
 			}
@@ -491,13 +485,13 @@ export async function executePhaseComplete(
 				dir,
 				knowledgeConfig,
 			);
-		} catch (error) {
-			// Log warning but don't block phase completion
-			console.warn(
-				'[phase_complete] Failed to curate lessons from retrospective:',
-				error,
-			);
-		}
+	} catch (error) {
+		// Log warning but don't block phase completion
+		safeWarn(
+			'[phase_complete] Failed to curate lessons from retrospective:',
+			error,
+		);
+	}
 	}
 
 	// Curator pipeline: collect phase data and run drift check. Never blocks phase_complete.
@@ -519,7 +513,7 @@ export async function executePhaseComplete(
 			await runCriticDriftCheck(dir, phase, curatorResult, curatorConfig);
 		}
 	} catch (curatorError) {
-		console.warn(
+		safeWarn(
 			'[phase_complete] Curator pipeline error (non-blocking):',
 			curatorError,
 		);
@@ -577,6 +571,7 @@ export async function executePhaseComplete(
 		| { task_complexity?: string }
 		| undefined;
 	if (
+		loadedRetroTaskId !== primaryRetroTaskId &&
 		loadedRetroTaskId?.startsWith('retro-') &&
 		loadedRetroBundle?.schema_version === '1.0.0' &&
 		firstEntry?.task_complexity &&


### PR DESCRIPTION
### Motivation

- Prevent cross-phase leakage where `lastCompletedPhaseAgentsDispatched` caused new phases to appear as if required agents were already present, breaking `update_task_status`/`phase_complete` gating.
- Ensure non-blocking warning paths never throw or interfere with phase completion when logging itself fails.
- Avoid spurious retrospective migration warnings when the canonical `retro-{phase}` bundle was used (only warn for fallback-loaded retro bundles).

### Description

- Stop aggregating `lastCompletedPhaseAgentsDispatched` into cross-session agent counts so only current-phase evidence (`phaseAgentsDispatched` and delegation chains) is considered during `phase_complete` aggregation. (`src/tools/phase-complete.ts`)
- Add a `safeWarn()` helper that wraps `console.warn` calls in a `try/catch` and replace fragile `console.warn` usages in non-blocking paths with `safeWarn()` to protect tool flows from logger failures. (`src/tools/phase-complete.ts`)
- Narrow the retrospective auto-migration warning to only be emitted when a retrospective was loaded via a fallback task ID (i.e., not the primary `retro-{phase}` task), preventing the migration message from masking policy warning messages. (`src/tools/phase-complete.ts`)

### Testing

- Ran `bun test tests/integration/phase-complete-events.test.ts tests/integration/retrospective-gate.test.ts tests/unit/tools/update-task-status.adversarial.test.ts` and observed all tests in those suites pass.
- Ran `bun test tests/unit/tools/phase-complete-curator.test.ts` to validate curator-error handling and observed the suite pass after the change.
- Verified targeted integration/unit combinations that previously exhibited regressions now pass and phase-agent accounting behaves as expected (no failing tests remaining in the exercised suites).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1ef7be19c832496407d84f0facecc)