### PR TITLE
fix: code review group A — JSON safety, regex escaping, directory threading

### DIFF
--- a/src/commands/rollback.ts
+++ b/src/commands/rollback.ts
@@ -23,7 +23,12 @@ export async function handleRollbackCommand(
 			return 'No checkpoints found. Use `/swarm checkpoint` to create checkpoints.';
 		}
 
-		const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+		let manifest: { checkpoints?: Array<{ phase: number; label?: string; timestamp: string }> };
+		try {
+			manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+		} catch {
+			return 'Error: Checkpoint manifest is corrupted. Delete .swarm/checkpoints/manifest.json and re-checkpoint.';
+		}
 		const checkpoints = manifest.checkpoints || [];
 
 		if (checkpoints.length === 0) {
@@ -34,8 +39,7 @@ export async function handleRollbackCommand(
 			'## Available Checkpoints',
 			'',
 			...checkpoints.map(
-				// biome-ignore lint/suspicious/noExplicitAny: checkpoint shape from JSON.parse is untyped
-				(c: any) =>
+				(c) =>
 					`- Phase ${c.phase}: ${c.label || 'no label'} (${new Date(c.timestamp).toLocaleString()})`,
 			),
 			'',
@@ -57,16 +61,19 @@ export async function handleRollbackCommand(
 		return `Error: No checkpoints found. Cannot rollback to phase ${targetPhase}.`;
 	}
 
-	const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+	let manifest: { checkpoints?: Array<{ phase: number; label?: string; timestamp: string }> };
+	try {
+		manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+	} catch {
+		return `Error: Checkpoint manifest is corrupted. Delete .swarm/checkpoints/manifest.json and re-checkpoint.`;
+	}
 	const checkpoint = manifest.checkpoints?.find(
-		// biome-ignore lint/suspicious/noExplicitAny: checkpoint shape from JSON.parse is untyped
-		(c: any) => c.phase === targetPhase,
+		(c) => c.phase === targetPhase,
 	);
 
 	if (!checkpoint) {
 		const available =
-			// biome-ignore lint/suspicious/noExplicitAny: checkpoint shape from JSON.parse is untyped
-			manifest.checkpoints?.map((c: any) => c.phase).join(', ') || 'none';
+			manifest.checkpoints?.map((c) => c.phase).join(', ') || 'none';
 		return `Error: Checkpoint for phase ${targetPhase} not found. Available phases: ${available}`;
 	}
 

--- a/src/hooks/pipeline-tracker.ts
+++ b/src/hooks/pipeline-tracker.ts
@@ -86,7 +86,10 @@ interface MessageWithParts {
  * Creates the experimental.chat.messages.transform hook for pipeline tracking.
  * Only injects for the architect agent.
  */
-export function createPipelineTrackerHook(config: PluginConfig) {
+export function createPipelineTrackerHook(
+	config: PluginConfig,
+	directory?: string,
+) {
 	const enabled = config.inject_phase_reminders !== false;
 
 	if (!enabled) {
@@ -130,7 +133,7 @@ export function createPipelineTrackerHook(config: PluginConfig) {
 				// Load plan and extract current phase for compliance escalation
 				let phaseNumber: number | null = null;
 				try {
-					const plan = await loadPlan(process.cwd());
+					const plan = await loadPlan(directory ?? process.cwd());
 					if (plan) {
 						const phaseString = extractCurrentPhaseFromPlan(plan);
 						phaseNumber = parsePhaseNumber(phaseString);

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ const OpenCodeSwarm: Plugin = async (ctx) => {
 	await loadSnapshot(ctx.directory);
 	const agents = getAgentConfigs(config);
 	const agentDefinitions = createAgents(config);
-	const pipelineHook = createPipelineTrackerHook(config);
+	const pipelineHook = createPipelineTrackerHook(config, ctx.directory);
 	const systemEnhancerHook = createSystemEnhancerHook(config, ctx.directory);
 	const compactionHook = createCompactionCustomizerHook(config, ctx.directory);
 	const contextBudgetHandler = createContextBudgetHandler(config);

--- a/src/state.ts
+++ b/src/state.ts
@@ -274,6 +274,9 @@ export function startAgentSession(
 
 /**
  * End an agent session by removing it from the state.
+ * NOTE: Currently unused in production — no session lifecycle teardown is wired up.
+ * Sessions accumulate for the process lifetime. Callers should integrate this into
+ * a session TTL or idle-timeout mechanism to prevent unbounded Map growth.
  * @param sessionId - The session identifier to remove
  */
 export function endAgentSession(sessionId: string): void {

--- a/src/tools/gitingest.ts
+++ b/src/tools/gitingest.ts
@@ -76,7 +76,14 @@ export async function fetchGitingest(args: GitingestArgs): Promise<string> {
 				throw new Error('gitingest response too large');
 			}
 
-			const data = JSON.parse(text) as GitingestResponse;
+			let data: GitingestResponse;
+			try {
+				data = JSON.parse(text) as GitingestResponse;
+			} catch {
+				throw new Error(
+					`gitingest API returned non-JSON response (${text.length} chars, starts: ${text.slice(0, 80)})`,
+				);
+			}
 			return `${data.summary}\n\n${data.tree}\n\n${data.content}`;
 		} catch (error) {
 			// Timeout errors — convert to domain-specific error

--- a/src/tools/placeholder-scan.ts
+++ b/src/tools/placeholder-scan.ts
@@ -520,8 +520,11 @@ export async function placeholderScan(
 
 	if (deny_patterns && deny_patterns.length > 0) {
 		// Parse custom patterns - they can be simple strings like "TODO" or regex-like
+		// Escape regex metacharacters to prevent ReDoS from user config
+		const escapeRegex = (s: string) =>
+			s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 		commentPatterns = deny_patterns.map((p) => ({
-			pattern: new RegExp(`\\b${p}\\b`, 'i'),
+			pattern: new RegExp(`\\b${escapeRegex(p)}\\b`, 'i'),
 			rule_id: `placeholder/custom-${p.toLowerCase()}`,
 		}));
 		// With custom patterns, disable string and code patterns

--- a/src/tools/schema-drift.ts
+++ b/src/tools/schema-drift.ts
@@ -137,7 +137,12 @@ function parseSpec(specFile: string): SpecPath[] {
 }
 
 function parseJsonSpec(content: string): SpecPath[] {
-	const spec = JSON.parse(content);
+	let spec: { paths?: Record<string, unknown> };
+	try {
+		spec = JSON.parse(content);
+	} catch {
+		return [];
+	}
 	const paths: SpecPath[] = [];
 
 	if (!spec.paths) {


### PR DESCRIPTION
## Code Review Fixes (Group A)

Mechanical, zero-risk fixes from code review of v6.22.16. All changes pass `tsc --noEmit`.

### Changes

**A1. Unprotected JSON.parse in rollback.ts** (2 sites)
- Wrap both `JSON.parse` calls in try-catch, return user-friendly error on corrupt manifest
- Type the manifest shape, removing 3 `biome-ignore lint/suspicious/noExplicitAny` suppressions

**A2. Unprotected JSON.parse in gitingest.ts**
- Catch malformed API responses (e.g. HTML error pages) with a diagnostic message
- Error starts with `gitingest ` so the existing domain-specific handler throws immediately without retry

**A3. Unprotected JSON.parse in schema-drift.ts**
- Return empty paths array instead of crashing on malformed spec JSON

**A4. Regex injection in placeholder-scan.ts**
- `deny_patterns` from user config were interpolated directly into `new RegExp()` without escaping
- Add `escapeRegex()` to neutralize metacharacters before interpolation (prevents ReDoS)

**A5. pipeline-tracker.ts uses bare process.cwd()**
- Thread `directory` parameter through from plugin context
- Update call site in `index.ts` to pass `ctx.directory`
- Falls back to `process.cwd()` if not provided (backward compatible)

**A7. Dead export: endAgentSession**
- Document that it's currently unused in production
- Flag unbounded session accumulation as a future lifecycle concern

### Not included

**A6 (duplicate imports)**: Investigation revealed these are `import type` + `import value` splits required by `isolatedModules: true` in tsconfig.json. Not duplicates — correct as-is.