### PR TITLE
fix(test): add no_op_warning_threshold and execution_mode to config test expectations

### DIFF
--- a/tests/unit/config/guardrails-profile.test.ts
+++ b/tests/unit/config/guardrails-profile.test.ts
@@ -114,6 +114,7 @@ describe('GuardrailsConfigSchema with profiles', () => {
 			max_consecutive_errors: 5,
 			warning_threshold: 0.75,
 			idle_timeout_minutes: 60,
+			no_op_warning_threshold: 15,
 			profiles: {
 				coder: { max_tool_calls: 400 },
 				explorer: { max_duration_minutes: 60 },
@@ -133,6 +134,7 @@ describe('GuardrailsConfigSchema with profiles', () => {
 			max_consecutive_errors: 5,
 			warning_threshold: 0.75,
 			idle_timeout_minutes: 60,
+			no_op_warning_threshold: 15,
 		};
 
 		const result = GuardrailsConfigSchema.parse(config);
@@ -148,6 +150,7 @@ describe('GuardrailsConfigSchema with profiles', () => {
 			max_consecutive_errors: 5,
 			warning_threshold: 0.75,
 			idle_timeout_minutes: 60,
+			no_op_warning_threshold: 15,
 			profiles: {},
 		};
 

--- a/tests/unit/config/loader.test.ts
+++ b/tests/unit/config/loader.test.ts
@@ -188,6 +188,7 @@ describe('config/loader', () => {
 				max_iterations: 5,
 				qa_retry_limit: 3,
 				inject_phase_reminders: true,
+				execution_mode: 'balanced',
 				adversarial_testing: { enabled: true, scope: 'all' },
 			});
 		});

--- a/tests/unit/config/schema.test.ts
+++ b/tests/unit/config/schema.test.ts
@@ -129,6 +129,7 @@ describe('PluginConfigSchema', () => {
         max_iterations: 5,
         qa_retry_limit: 3,
         inject_phase_reminders: true,
+        execution_mode: 'balanced',
         adversarial_testing: { enabled: true, scope: 'all' },
       });
     }


### PR DESCRIPTION
## Summary

- Add `no_op_warning_threshold: 15` to three `GuardrailsConfigSchema` test expectation objects in `guardrails-profile.test.ts` (L124, L139, L155) to match the new schema default
- Add `execution_mode: 'balanced'` to the `PluginConfigSchema` default expectation in `schema.test.ts` (L128) to match the new schema default
- Add `execution_mode: 'balanced'` to the loader defaults expectation in `loader.test.ts` (L187) to match the new schema default

Fixes 5 CI unit test failures caused by new schema fields being added with defaults that were not reflected in test expectations.

## Test plan

- [ ] `bun test tests/unit/config/guardrails-profile.test.ts` passes
- [ ] `bun test tests/unit/config/schema.test.ts` passes
- [ ] `bun test tests/unit/config/loader.test.ts` passes
- [ ] Full `bun test tests/unit --timeout 120000` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)