### PR TITLE
fix(state): prevent evidence rehydration from downgrading workflow state

### DIFF
--- a/docs/releases/v6.40.4.md
+++ b/docs/releases/v6.40.4.md
@@ -1,0 +1,27 @@
+# v6.40.4
+
+## Bug Fixes
+
+### fix(state): prevent evidence rehydration from downgrading workflow state
+
+`applyRehydrationCache` previously applied evidence-derived state unconditionally,
+meaning a stale evidence file on disk could overwrite a higher in-memory state
+(e.g. downgrade `reviewer_run` back to `coder_delegated`). This deadlocked the
+swarm whenever a prior session's evidence lagged behind the live workflow state.
+
+The evidence branch now uses the same "only upgrade, never downgrade" guard that
+the plan-only branch already applied: the derived state is written only when it
+advances past the existing state.
+
+## Why
+
+Evidence files are written asynchronously and only capture completed gates. They
+are not a real-time mirror of in-memory state. Treating them as authoritative and
+unconditional allowed a race where on-disk evidence reflected an older completed
+gate while the session had already advanced further, causing the next rehydration
+cycle to roll the state backwards and block delegation.
+
+## Migration
+
+No configuration or API changes. Upgrade to clear any stale session state
+automatically, or manually delete `.swarm/session/state.json` before restarting.

--- a/src/state.ts
+++ b/src/state.ts
@@ -945,7 +945,7 @@ export async function buildRehydrationCache(directory: string): Promise<void> {
 /**
  * Synchronously applies the cached plan+evidence data to a session.
  * Merge rules:
- *   - evidence-derived state: always applied (replaces snapshot state, even if lower)
+ *   - evidence-derived state: only applied if it advances past existing state
  *   - plan-only derived state: only applied if it advances past existing state
  * No-op when the cache has not been built yet.
  */
@@ -974,11 +974,18 @@ export function applyRehydrationCache(session: AgentSessionState): void {
 		const evidence = evidenceMap.get(taskId);
 
 		if (evidence) {
-			// Evidence provides the strongest signal and always wins.
-			// Apply unconditionally — evidence reflects actual gate completion on disk
-			// and must override any stale value recorded in the snapshot.
+			// Evidence provides the strongest signal for completed gates.
+			// But evidence files lag behind in-memory state (evidence recording
+			// is async and only captures completed gates). Only upgrade state,
+			// never downgrade — same guard as the plan-only branch below.
 			const derivedState = evidenceToWorkflowState(evidence);
-			session.taskWorkflowStates.set(taskId, derivedState);
+			const existingIndex = existingState
+				? STATE_ORDER.indexOf(existingState)
+				: -1;
+			const derivedIndex = STATE_ORDER.indexOf(derivedState);
+			if (derivedIndex > existingIndex) {
+				session.taskWorkflowStates.set(taskId, derivedState);
+			}
 		} else {
 			// Plan-only: only advance past existing state, never downgrade.
 			// A snapshot state that is ahead of the plan is valid (e.g. gates passed


### PR DESCRIPTION
## Summary

- `applyRehydrationCache` previously applied evidence-derived state unconditionally, allowing stale on-disk evidence to downgrade in-memory workflow state (e.g. rolling `reviewer_run` back to `coder_delegated`)
- Added the same upgrade-only guard already used by the plan-only branch: evidence state is only applied when it advances past the existing state
- Fixed stale JSDoc on `applyRehydrationCache` that still described the old unconditional behaviour

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx biome ci .` — clean
- [x] State rehydration tests (`src/state.rehydrate.test.ts`, `src/state.rehydration-*.test.ts`, `tests/unit/state/rehydration.test.ts`) — 99 pass / 2 fail, identical to baseline (zero regressions)
- [x] Gate/state integration + adversarial tests — 139 pass / 12 fail, identical to baseline (zero regressions)
- [x] Independent agent review — confirmed guard is correct, `evidenceToWorkflowState` always returns a value in `STATE_ORDER`, fix fully resolves the described deadlock