### PR TITLE
fix(lang): resolve WASM asset path resolution for bundled npm installs

### DIFF
--- a/docs/releases/v6.40.6.md
+++ b/docs/releases/v6.40.6.md
@@ -1,0 +1,29 @@
+# v6.40.6
+
+## Bug Fixes
+
+- **Fix tree-sitter WASM asset loading when installed as npm dependency**: When `opencode-swarm` is bundled via `bun build` and installed into a consumer's `node_modules`, `import.meta.url` points to `dist/index.js` rather than the original source files. Three independent path resolution mechanisms relied on fragile relative-path heuristics that broke after bundling, causing `ENOENT: no such file or directory` errors for `tree-sitter.wasm` and potentially for language grammar files.
+
+### What Changed
+
+- **`src/lang/runtime.ts`**: Replaced `getGrammarsPath()` (relative-path heuristic) with `getGrammarsDirAbsolute()` which computes the absolute grammars directory from `path.dirname(fileURLToPath(import.meta.url))`. Added `locateFile` callback to `Parser.init()` so `web-tree-sitter` finds `tree-sitter.wasm` in the grammars directory instead of next to the bundle entry point. Updated `loadGrammar()` and `isGrammarAvailable()` to use `path.join()` with absolute paths instead of `new URL(relative, import.meta.url)`.
+
+- **`src/services/diagnose-service.ts`**: Replaced `import.meta.dir`-based grammar directory detection (a Bun extension) with the same `fileURLToPath(import.meta.url)` pattern, fixing incorrect resolution in bundled mode where `path.join(import.meta.dir, '../lang/grammars/')` resolved one directory level too high.
+
+### Why
+
+The `bun build` step collapses all TypeScript source into a single `dist/index.js`. After bundling, `import.meta.url` resolves to `file:///path/to/dist/index.js`, making all relative-path calculations relative to `dist/` rather than the original source file locations. The core `tree-sitter.wasm` file lives at `dist/lang/grammars/tree-sitter.wasm`, but `web-tree-sitter` was looking for `dist/tree-sitter.wasm`.
+
+### Design Decisions
+
+- **Absolute paths everywhere**: All WASM path construction now uses `path.join()` with an absolute base directory, eliminating fragile relative-path resolution via `new URL()`.
+- **Precise detection heuristic**: Dev-vs-bundle detection uses `thisDir.replace(/\\/g, '/').endsWith('/src/lang')` (or `/src/services` in diagnose-service). Uses `endsWith` rather than `includes` to avoid false positives when the package is installed under a parent directory containing `/src/` (e.g., `/home/user/src/projects/node_modules/...`).
+- **`locateFile` callback**: The standard `web-tree-sitter` mechanism for overriding WASM file location, avoiding monkey-patching or wrapper hacks.
+
+### Migration
+
+None required. This is a transparent fix — no API changes, no new configuration.
+
+### Breaking Changes
+
+None.

--- a/src/lang/runtime.ts
+++ b/src/lang/runtime.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Parser as ParserType } from 'web-tree-sitter';
 // Note: Language must be imported as both type and value for runtime loading
@@ -32,7 +33,23 @@ async function initTreeSitter(): Promise<void> {
 		return;
 	}
 
-	await TreeSitterParser.init();
+	const thisDir = path.dirname(fileURLToPath(import.meta.url));
+	const isSource = thisDir.replace(/\\/g, '/').endsWith('/src/lang');
+
+	if (isSource) {
+		// In dev, web-tree-sitter's own import.meta.url resolves tree-sitter.wasm
+		// correctly from node_modules/web-tree-sitter/
+		await TreeSitterParser.init();
+	} else {
+		// In bundle, import.meta.url points to dist/index.js so web-tree-sitter
+		// looks for dist/tree-sitter.wasm — redirect to dist/lang/grammars/
+		const grammarsDir = getGrammarsDirAbsolute();
+		await TreeSitterParser.init({
+			locateFile(scriptName: string) {
+				return path.join(grammarsDir, scriptName);
+			},
+		});
+	}
 	treeSitterInitialized = true;
 }
 
@@ -83,22 +100,18 @@ function getWasmFileName(languageId: string): string {
 }
 
 /**
- * Get the path to the grammars directory
- * Works in both development and production (bundled) environments
+ * Get the absolute path to the grammars directory.
+ * Works in dev (src/lang/runtime.ts) and bundled (dist/index.js) environments,
+ * across Windows, macOS, and Linux.
  */
-function getGrammarsPath(): string {
-	// In production (bundled), files are in dist/lang/grammars/
-	// The runtime.ts is in dist/lang/, so we use ./grammars/
-	// In development, import.meta.url points to the source file
-	const isProduction =
-		process.env.NODE_ENV === 'production' || !import.meta.url.includes('src/');
-
-	if (isProduction) {
-		return './lang/grammars/';
-	}
-
-	// Development: relative to src/lang/runtime.ts
-	return '../../dist/lang/grammars/';
+function getGrammarsDirAbsolute(): string {
+	const thisDir = path.dirname(fileURLToPath(import.meta.url));
+	// In dev: thisDir = .../src/lang/ → grammars at src/lang/grammars/
+	// In bundle: thisDir = .../dist/ → grammars at dist/lang/grammars/
+	const isSource = thisDir.replace(/\\/g, '/').endsWith('/src/lang');
+	return isSource
+		? path.join(thisDir, 'grammars')
+		: path.join(thisDir, 'lang', 'grammars');
 }
 
 /**
@@ -133,10 +146,7 @@ export async function loadGrammar(languageId: string): Promise<ParserType> {
 
 	// Get WASM file name and construct path
 	const wasmFileName = getWasmFileName(normalizedId);
-	const grammarsPath = getGrammarsPath();
-	const wasmPath = fileURLToPath(
-		new URL(`${grammarsPath}${wasmFileName}`, import.meta.url),
-	);
+	const wasmPath = path.join(getGrammarsDirAbsolute(), wasmFileName);
 
 	// Check if file exists before attempting to load
 	const { existsSync } = await import('node:fs');
@@ -193,10 +203,7 @@ export async function isGrammarAvailable(languageId: string): Promise<boolean> {
 	// Try to check if WASM file exists
 	try {
 		const wasmFileName = getWasmFileName(normalizedId);
-		const grammarsPath = getGrammarsPath();
-		const wasmPath = fileURLToPath(
-			new URL(`${grammarsPath}${wasmFileName}`, import.meta.url),
-		);
+		const wasmPath = path.join(getGrammarsDirAbsolute(), wasmFileName);
 
 		const { statSync } = await import('node:fs');
 		statSync(wasmPath);

--- a/src/services/diagnose-service.ts
+++ b/src/services/diagnose-service.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { loadPluginConfig } from '../config/loader';
 import type { Plan } from '../config/plan-schema';
 import { listEvidenceTaskIds } from '../evidence/manager';
@@ -466,14 +467,12 @@ async function checkGrammarWasmFiles(): Promise<HealthCheck> {
 		'tree-sitter-dart.wasm',
 	];
 
-	// Determine dev vs production path
-	// Check for src/services in the path (more specific than just 'src')
-	const isDev =
-		import.meta.dir.includes('src/services') ||
-		import.meta.dir.includes('src\\services');
-	const grammarDir = isDev
-		? path.join(import.meta.dir, '../../dist/lang/grammars/')
-		: path.join(import.meta.dir, '../lang/grammars/');
+	// Determine dev vs production path using import.meta.url (cross-platform)
+	const thisDir = path.dirname(fileURLToPath(import.meta.url));
+	const isSource = thisDir.replace(/\\/g, '/').endsWith('/src/services');
+	const grammarDir = isSource
+		? path.join(thisDir, '..', 'lang', 'grammars')
+		: path.join(thisDir, 'lang', 'grammars');
 
 	const missing: string[] = [];
 	for (const file of grammarFiles) {


### PR DESCRIPTION
## Summary

- **Fix tree-sitter WASM `ENOENT` errors** when `opencode-swarm` is installed as an npm dependency: `bun build` bundles all source into `dist/index.js`, causing `import.meta.url`-based relative path resolution to look for `tree-sitter.wasm` in the wrong location
- **Replace fragile heuristics** in `src/lang/runtime.ts` (`getGrammarsPath()` → `getGrammarsDirAbsolute()`) and `src/services/diagnose-service.ts` (`import.meta.dir` → `fileURLToPath(import.meta.url)`) with absolute path resolution using `path.dirname(fileURLToPath(import.meta.url))`
- **Add `locateFile` callback** to `Parser.init()` in bundled mode so `web-tree-sitter` finds `tree-sitter.wasm` at `dist/lang/grammars/` instead of `dist/`

## Test plan

- [x] `bun run build` succeeds
- [x] `bun test tests/unit/tools/syntax-check.test.ts` — 14 pass, 0 fail (grammar loading)
- [x] `bun test tests/unit/services/diagnose-service.test.ts` — 29 pass, 0 fail
- [x] `bun test tests/unit/scripts/copy-grammars.test.ts` — 11 pass, 0 fail
- [x] `bun test tests/integration/lang/` — 69 pass, 0 fail
- [x] `bun test tests/unit/build/` — 56 pass, 0 fail
- [x] `bun test tests/smoke/` — 10 pass, 0 fail
- [x] `bun test tests/unit/config/` — 753 pass, 0 fail
- [x] Bundle verification: `locateFile` and `getGrammarsDirAbsolute` present in `dist/index.js`
- [x] `endsWith('/src/lang')` heuristic in bundle (not `includes('/src/')`) — immune to parent-dir false positives
- [x] Independent code review: 0 critical findings, W1 (false-positive heuristic) fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)