### PR TITLE
fix(swarm): address 16 QA findings in v6.41.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1059,7 +1059,7 @@ The following tools can be assigned to agents via overrides:
 
 > For the complete version history, see [CHANGELOG.md](CHANGELOG.md) or [docs/releases/](docs/releases/).
 
-### v6.33.5 — Drift Evidence Tool
+### v6.41.0 — Drift Evidence Tool
 
 - **`write_drift_evidence` tool**: New architect tool for persisting drift verification evidence after critic_drift_verifier delegation
   - Accepts phase number, verdict (APPROVED/NEEDS_REVISION), and summary

--- a/docs/releases/v6.41.0.md
+++ b/docs/releases/v6.41.0.md
@@ -4,7 +4,7 @@
 
 - **Dark Matter Detection Pipeline**: Automatic co-change analysis during DISCOVER mode to detect hidden file couplings
 - **New `/swarm close` Command**: Idempotent close command that writes retrospectives, curates lessons, archives evidence, and clears state
-- **writeDriftEvidence Tool**: New tool for persisting drift verification results with gate-contract format
+- **write_drift_evidence Tool**: New tool for persisting drift verification results with gate-contract format
 - **Session Improvements**: Reset-session now cleans session directory, endAgentSession wired at phase boundaries
 
 ## Features
@@ -26,7 +26,7 @@
 - **Writes summary**: Generates `.swarm/close-summary.md` with project summary
 - **State cleanup**: Calls `flushPendingSnapshot`, clears `agentSessions` and `delegationChains`
 
-### writeDriftEvidence Tool (Phase 5 HOTFIX)
+### write_drift_evidence Tool (Phase 5 HOTFIX)
 
 - **Normalizes verdicts**: `APPROVED` → `approved`, `NEEDS_REVISION` → `rejected`
 - **Gate-contract format**: Writes evidence to `.swarm/evidence/{phase}/drift-verifier.json`
@@ -56,7 +56,7 @@
 - **`src/commands/close.ts`**: `/swarm close` command handler (171 lines)
 - **`src/tools/write-drift-evidence.ts`**: Drift evidence persistence tool (212 lines)
 - **`tests/unit/commands/close.test.ts`**: 17 tests for close command
-- **`tests/unit/tools/write-drift-evidence.test.ts`**: 12 tests for writeDriftEvidence tool
+- **`tests/unit/tools/write-drift-evidence.test.ts`**: 12 tests for write_drift_evidence tool
 - **`tests/integration/dark-matter-wiring.test.ts`**: 14 integration tests for dark matter pipeline
 
 ### Modified Files
@@ -67,7 +67,7 @@
 - **`src/commands/reset-session.ts`**: Added session directory cleanup
 - **`src/tools/phase-complete.ts`**: Wired `endAgentSession` at phase boundaries
 - **`src/index.ts`**: Registered close command, added 8 missing commands to help text
-- **`src/agents/architect.ts`**: Added dark matter co-change guidance, updated PHASE-WRAP to use `writeDriftEvidence` tool
+- **`src/agents/architect.ts`**: Added dark matter co-change guidance, updated PHASE-WRAP to use `write_drift_evidence` tool
 - **`src/services/history-service.ts`**: Added `closed` status support
 
 ### Test Updates

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -1,5 +1,4 @@
 import { promises as fs } from 'node:fs';
-import path from 'node:path';
 import { KnowledgeConfigSchema } from '../config/schema';
 import { archiveEvidence } from '../evidence/manager';
 import { curateAndStoreSwarm } from '../hooks/knowledge-curator';
@@ -30,7 +29,7 @@ interface PlanData {
  */
 export async function handleCloseCommand(
 	directory: string,
-	args: string[],
+	_args: string[],
 ): Promise<string> {
 	const planPath = validateSwarmPath(directory, 'plan.json');
 
@@ -47,14 +46,17 @@ export async function handleCloseCommand(
 	const allDone = phases.every(
 		(p) =>
 			p.status === 'complete' ||
+			p.status === 'completed' ||
 			p.status === 'blocked' ||
 			p.status === 'closed',
 	);
 
-	if (inProgressPhases.length === 0 || allDone) {
+	if (allDone) {
 		const closedCount = phases.filter((p) => p.status === 'closed').length;
 		const blockedCount = phases.filter((p) => p.status === 'blocked').length;
-		const completeCount = phases.filter((p) => p.status === 'complete').length;
+		const completeCount = phases.filter(
+			(p) => p.status === 'complete' || p.status === 'completed',
+		).length;
 		return `ℹ️ Swarm already closed. ${completeCount} phases complete, ${closedCount} phases closed, ${blockedCount} phases blocked. No action taken.`;
 	}
 
@@ -94,27 +96,37 @@ export async function handleCloseCommand(
 		}
 
 		for (const task of phase.tasks ?? []) {
-			if (task.status !== 'complete') {
+			if (task.status !== 'completed' && task.status !== 'complete') {
 				closedTasks.push(task.id);
 			}
 		}
 	}
 
-	await curateAndStoreSwarm(
-		[],
-		projectName,
-		{ phase_number: 0 },
-		directory,
-		config,
-	);
+	try {
+		await curateAndStoreSwarm(
+			[],
+			projectName,
+			{ phase_number: 0 },
+			directory,
+			config,
+		);
+	} catch (error) {
+		console.warn('[close-command] curateAndStoreSwarm error:', error);
+	}
 
 	for (const phase of phases) {
-		if (phase.status !== 'complete') {
+		if (phase.status !== 'complete' && phase.status !== 'completed') {
 			phase.status = 'closed';
+			if (!closedPhases.includes(phase.id)) {
+				closedPhases.push(phase.id);
+			}
 		}
 		for (const task of phase.tasks ?? []) {
-			if (task.status !== 'complete') {
+			if (task.status !== 'completed' && task.status !== 'complete') {
 				task.status = 'closed';
+				if (!closedTasks.includes(task.id)) {
+					closedTasks.push(task.id);
+				}
 			}
 		}
 	}
@@ -131,7 +143,7 @@ export async function handleCloseCommand(
 		console.warn('[close-command] archiveEvidence error:', error);
 	}
 
-	const closeSummaryPath = path.join(directory, '.swarm', 'close-summary.md');
+	const closeSummaryPath = validateSwarmPath(directory, 'close-summary.md');
 	const summaryContent = [
 		'# Swarm Close Summary',
 		'',

--- a/src/commands/reset-session.ts
+++ b/src/commands/reset-session.ts
@@ -36,15 +36,15 @@ export async function handleResetSessionCommand(
 		if (fs.existsSync(sessionDir)) {
 			const files = fs.readdirSync(sessionDir);
 			const otherFiles = files.filter((f) => f !== 'state.json');
+			let deletedCount = 0;
 			for (const file of otherFiles) {
 				const filePath = path.join(sessionDir, file);
-				if (fs.statSync(filePath).isFile()) {
+				if (fs.lstatSync(filePath).isFile()) {
 					fs.unlinkSync(filePath);
+					deletedCount++;
 				}
 			}
-			results.push(
-				`✅ Cleaned ${otherFiles.length} additional session file(s)`,
-			);
+			results.push(`✅ Cleaned ${deletedCount} additional session file(s)`);
 		}
 	} catch {
 		// Non-blocking - session directory cleanup is best effort

--- a/src/hooks/system-enhancer.ts
+++ b/src/hooks/system-enhancer.ts
@@ -440,63 +440,70 @@ export function createSystemEnhancerHook(
 
 					// Dark matter scan: detect co-change patterns in git history
 					// Non-blocking — skip silently on repos without git history, shallow clones, or errors
+					// Cached: skip if dark-matter.md already exists (matches doc_scan caching pattern)
 					try {
-						const {
-							detectDarkMatter,
-							formatDarkMatterOutput,
-							darkMatterToKnowledgeEntries,
-						} = await import('../tools/co-change-analyzer.js');
-						const darkMatter = await detectDarkMatter(directory, {
-							minCommits: 20,
-							minCoChanges: 3,
-							npmiThreshold: 0.3,
-						});
-						if (darkMatter && darkMatter.length > 0) {
-							const darkMatterReport = formatDarkMatterOutput(darkMatter);
-							const darkMatterPath = validateSwarmPath(
-								directory,
-								'dark-matter.md',
-							);
-							await Bun.write(darkMatterPath, darkMatterReport);
-							warn(
-								`[system-enhancer] Dark matter scan complete: ${darkMatter.length} co-change patterns found`,
-							);
-							// Generate knowledge entries from dark matter results
-							try {
-								const projectName = path.basename(path.resolve(directory));
-								const knowledgeEntries = darkMatterToKnowledgeEntries(
-									darkMatter,
-									projectName,
+						const darkMatterPath = validateSwarmPath(
+							directory,
+							'dark-matter.md',
+						);
+						if (!fs.existsSync(darkMatterPath)) {
+							const {
+								detectDarkMatter,
+								formatDarkMatterOutput,
+								darkMatterToKnowledgeEntries,
+							} = await import('../tools/co-change-analyzer.js');
+							const darkMatter = await detectDarkMatter(directory, {
+								minCommits: 20,
+								minCoChanges: 3,
+								npmiThreshold: 0.3,
+							});
+							if (darkMatter && darkMatter.length > 0) {
+								const darkMatterReport = formatDarkMatterOutput(darkMatter);
+								await fs.promises.writeFile(
+									darkMatterPath,
+									darkMatterReport,
+									'utf-8',
 								);
-								const knowledgePath = resolveSwarmKnowledgePath(directory);
-								// Deduplicate: skip entries already in knowledge
-								const existingEntries =
-									await readKnowledge<SwarmKnowledgeEntry>(knowledgePath);
-								const existingLessons = new Set(
-									existingEntries.map((e) => e.lesson),
+								warn(
+									`[system-enhancer] Dark matter scan complete: ${darkMatter.length} co-change patterns found`,
 								);
-								const newEntries = knowledgeEntries.filter(
-									(e) => !existingLessons.has(e.lesson),
-								);
-								if (newEntries.length === 0) {
-									console.warn(
-										`[system-enhancer] No new knowledge entries (all duplicates)`,
+								// Generate knowledge entries from dark matter results
+								try {
+									const projectName = path.basename(path.resolve(directory));
+									const knowledgeEntries = darkMatterToKnowledgeEntries(
+										darkMatter,
+										projectName,
 									);
-								} else {
-									for (const entry of newEntries) {
-										await appendKnowledge(knowledgePath, entry);
+									const knowledgePath = resolveSwarmKnowledgePath(directory);
+									// Deduplicate: skip entries already in knowledge
+									const existingEntries =
+										await readKnowledge<SwarmKnowledgeEntry>(knowledgePath);
+									const existingLessons = new Set(
+										existingEntries.map((e) => e.lesson),
+									);
+									const newEntries = knowledgeEntries.filter(
+										(e) => !existingLessons.has(e.lesson),
+									);
+									if (newEntries.length === 0) {
+										console.warn(
+											`[system-enhancer] No new knowledge entries (all duplicates)`,
+										);
+									} else {
+										for (const entry of newEntries) {
+											await appendKnowledge(knowledgePath, entry);
+										}
+										console.warn(
+											`[system-enhancer] Created ${newEntries.length} new knowledge entries (${knowledgeEntries.length - newEntries.length} duplicates skipped)`,
+										);
 									}
+								} catch (e) {
+									// Non-blocking: knowledge is supplementary
 									console.warn(
-										`[system-enhancer] Created ${newEntries.length} new knowledge entries (${knowledgeEntries.length - newEntries.length} duplicates skipped)`,
+										`[system-enhancer] Failed to create knowledge entries: ${e}`,
 									);
 								}
-							} catch (e) {
-								// Non-blocking: knowledge is supplementary
-								console.warn(
-									`[system-enhancer] Failed to create knowledge entries: ${e}`,
-								);
 							}
-						}
+						} // end if (!fs.existsSync(darkMatterPath))
 					} catch {
 						// Non-blocking — skip silently on repos without git history, shallow clones, or errors
 					}

--- a/src/index.ts
+++ b/src/index.ts
@@ -669,6 +669,11 @@ const OpenCodeSwarm: Plugin = async (ctx) => {
 					description:
 						'Use /swarm evidence summary to generate evidence summaries',
 				},
+				'swarm-close': {
+					template: '/swarm close',
+					description:
+						'Use /swarm close to close the swarm project and archive state',
+				},
 			};
 
 			log('Config applied', {

--- a/src/tools/write-drift-evidence.ts
+++ b/src/tools/write-drift-evidence.ts
@@ -110,9 +110,11 @@ export async function executeWriteDriftEvidence(
 	};
 
 	// Validate and construct the file path using validateSwarmPath
-	const filename = `drift-verifier.json`;
+	const filename = 'drift-verifier.json';
+	const relativePath = path.join('evidence', String(phase), filename);
+	let validatedPath: string;
 	try {
-		validateSwarmPath(directory, filename);
+		validatedPath = validateSwarmPath(directory, relativePath);
 	} catch (error) {
 		return JSON.stringify(
 			{
@@ -126,8 +128,7 @@ export async function executeWriteDriftEvidence(
 		);
 	}
 
-	// Construct the full directory path for evidence/{phase}/
-	const evidenceDir = path.join(directory, '.swarm', 'evidence', String(phase));
+	const evidenceDir = path.dirname(validatedPath);
 
 	// Write the evidence file
 	try {
@@ -141,7 +142,7 @@ export async function executeWriteDriftEvidence(
 			JSON.stringify(evidenceContent, null, 2),
 			'utf-8',
 		);
-		await fs.promises.rename(tempPath, path.join(evidenceDir, filename));
+		await fs.promises.rename(tempPath, validatedPath);
 
 		return JSON.stringify(
 			{
@@ -195,13 +196,17 @@ export const write_drift_evidence: ToolDefinition = createSwarmTool({
 		try {
 			const writeDriftEvidenceArgs: WriteDriftEvidenceArgs = {
 				phase: Number(args.phase),
-				verdict: args.verdict as unknown as 'APPROVED' | 'NEEDS_REVISION',
+				verdict: String(args.verdict) as 'APPROVED' | 'NEEDS_REVISION',
 				summary: String(args.summary ?? ''),
 			};
 			return await executeWriteDriftEvidence(writeDriftEvidenceArgs, directory);
-		} catch {
+		} catch (error) {
 			return JSON.stringify(
-				{ success: false, phase: rawPhase, message: 'Invalid arguments' },
+				{
+					success: false,
+					phase: rawPhase,
+					message: error instanceof Error ? error.message : 'Unknown error',
+				},
 				null,
 				2,
 			);

--- a/tests/integration/dark-matter-wiring.test.ts
+++ b/tests/integration/dark-matter-wiring.test.ts
@@ -259,35 +259,15 @@ describe('repos without git skip silently', () => {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	test('detectDarkMatter returns empty array for non-git directory', async () => {
-		// Directory with no git history should return empty without throwing
-		// Use mockDetectDarkMatter directly to verify the mock tracks calls
-		// Set mockImplementation to ensure it returns [] when called directly
-		mockDetectDarkMatter.mockImplementation(async () => []);
-		const result = await mockDetectDarkMatter(tempDir, { minCommits: 20 });
-
-		expect(Array.isArray(result)).toBe(true);
-		expect(result).toEqual([]);
-	});
-
-	test('detectDarkMatter returns empty array for shallow git history', async () => {
-		// Even if git exists, not enough commits should return empty
-		// This is handled by the minCommits check in detectDarkMatter
-		// Set mockImplementation to ensure it returns [] when called directly
-		mockDetectDarkMatter.mockImplementation(async () => []);
-		const result = await mockDetectDarkMatter(tempDir, { minCommits: 20 });
-
-		expect(result).toEqual([]);
-	});
-
-	test('system-enhancer does not write dark-matter.md when detectDarkMatter returns empty', async () => {
+	test('system-enhancer skips dark-matter.md when detectDarkMatter returns empty', async () => {
 		// When detectDarkMatter returns empty, system-enhancer skips writing dark-matter.md
 		const darkMatterPath = path.join(tempDir, '.swarm', 'dark-matter.md');
 
 		// Create .swarm directory
 		mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
 
-		// Default mock returns empty array, so dark-matter.md should not be written
+		// Explicitly set mock to return empty array (mockClear only clears calls, not implementation)
+		mockDetectDarkMatter.mockImplementation(async () => []);
 		const hook = createSystemEnhancerHook({} as PluginConfig, tempDir);
 		const transform = hook['experimental.chat.system.transform'] as (
 			input: { sessionID?: string; model?: unknown },

--- a/tests/unit/commands/close.test.ts
+++ b/tests/unit/commands/close.test.ts
@@ -36,9 +36,17 @@ mock.module('../../../src/session/snapshot-writer.js', () => ({
 
 mock.module('../../../src/state.js', () => ({
 	swarmState: {
-		agentSessions: new Map(),
+		activeToolCalls: new Map(),
+		toolAggregates: new Map(),
+		activeAgent: new Map(),
 		delegationChains: new Map(),
+		pendingEvents: 0,
+		lastBudgetPct: 0,
+		agentSessions: new Map(),
+		pendingRehydrations: new Set(),
 	},
+	endAgentSession: () => {},
+	resetSwarmState: () => {},
 }));
 
 // Import after mock setup
@@ -199,6 +207,78 @@ describe('handleCloseCommand', () => {
 			expect(updatedPlan.phases[0].status).toBe('closed');
 			expect(updatedPlan.phases[0].tasks[0].status).toBe('complete');
 			expect(updatedPlan.phases[0].tasks[1].status).toBe('closed');
+		});
+
+		it('should close pending phases that were never started', async () => {
+			const planData = {
+				title: 'Test Project',
+				phases: [
+					{
+						id: 1,
+						name: 'Phase 1',
+						status: 'complete',
+						tasks: [{ id: '1.1', status: 'completed' }],
+					},
+					{
+						id: 2,
+						name: 'Phase 2',
+						status: 'pending',
+						tasks: [{ id: '2.1', status: 'pending' }],
+					},
+				],
+			};
+			writeFileSync(
+				path.join(testDir, '.swarm', 'plan.json'),
+				JSON.stringify(planData)
+			);
+
+			const result = await handleCloseCommand(testDir, []);
+
+			expect(result).toContain('closed successfully');
+			const updatedPlan = JSON.parse(
+				readFileSync(path.join(testDir, '.swarm', 'plan.json'), 'utf-8')
+			);
+			expect(updatedPlan.phases[0].status).toBe('complete');
+			expect(updatedPlan.phases[1].status).toBe('closed');
+			expect(updatedPlan.phases[1].tasks[0].status).toBe('closed');
+			// No retros for pending phases (never started)
+			expect(mockExecuteWriteRetro).not.toHaveBeenCalled();
+			// Pending phase and task should be counted in close summary
+			expect(result).toContain('1 phase(s) closed');
+			expect(result).toContain('1 incomplete task(s) marked closed');
+		});
+
+		it('should preserve completed (alias) phase status', async () => {
+			const planData = {
+				title: 'Test Project',
+				phases: [
+					{
+						id: 1,
+						name: 'Phase 1',
+						status: 'completed',
+						tasks: [{ id: '1.1', status: 'completed' }],
+					},
+					{
+						id: 2,
+						name: 'Phase 2',
+						status: 'in_progress',
+						tasks: [{ id: '2.1', status: 'in_progress' }],
+					},
+				],
+			};
+			writeFileSync(
+				path.join(testDir, '.swarm', 'plan.json'),
+				JSON.stringify(planData)
+			);
+
+			await handleCloseCommand(testDir, []);
+
+			const updatedPlan = JSON.parse(
+				readFileSync(path.join(testDir, '.swarm', 'plan.json'), 'utf-8')
+			);
+			expect(updatedPlan.phases[0].status).toBe('completed');
+			expect(updatedPlan.phases[0].tasks[0].status).toBe('completed');
+			expect(updatedPlan.phases[1].status).toBe('closed');
 		});
 
 		it('should set complete phases to closed status', async () => {

--- a/tests/unit/index-commands.test.ts
+++ b/tests/unit/index-commands.test.ts
@@ -21,7 +21,7 @@ describe('Swarm subcommand registration', () => {
 		expect(typeof plugin.config).toBe('function');
 	});
 
-	it('should register 30 individual subcommands plus catch-all', async () => {
+	it('should register 31 individual subcommands plus catch-all', async () => {
 		const plugin = await OpenCodeSwarm(mockPluginInput);
 		const mockConfig: Record<string, unknown> = {};
 
@@ -31,8 +31,8 @@ describe('Swarm subcommand registration', () => {
 		expect(commands).toBeDefined();
 		const commandKeys = Object.keys(commands);
 
-		// Should have catch-all + 30 subcommands = 31 total
-		expect(commandKeys.length).toBe(31);
+		// Should have catch-all + 31 subcommands = 32 total
+		expect(commandKeys.length).toBe(32);
 
 		// Verify catch-all exists
 		expect(commands.swarm).toBeDefined();
@@ -50,7 +50,7 @@ describe('Swarm subcommand registration', () => {
 		expect(commands.swarm.description).toBe('Swarm management commands: /swarm [status|plan|agents|history|config|evidence|handoff|archive|diagnose|preflight|sync-plan|benchmark|export|reset|rollback|retrieve|clarify|analyze|specify|dark-matter|knowledge|curate|close]');
 	});
 
-	it('should register all 30 individual subcommands with correct keys', async () => {
+	it('should register all 31 individual subcommands with correct keys', async () => {
 		const plugin = await OpenCodeSwarm(mockPluginInput);
 		const mockConfig: Record<string, unknown> = {};
 
@@ -88,6 +88,7 @@ describe('Swarm subcommand registration', () => {
 			'swarm-checkpoint',
 			'swarm-config-doctor',
 			'swarm-evidence-summary',
+			'swarm-close',
 		];
 
 		// Verify all expected subcommands exist


### PR DESCRIPTION
## Summary

- **Critical**: Fix idempotency bug in close command (`||` → `allDone` only), handle `'completed'` alias in all 5 code paths, fix `closedPhases`/`closedTasks` undercount for pending phases
- **Security**: `validateSwarmPath` for close-summary.md and write-drift-evidence nested paths, remove unsafe double cast, use `lstatSync` for symlink safety in reset-session
- **Quality**: try/catch around `curateAndStoreSwarm`, replace `Bun.write` with `fs.promises.writeFile`, add dark-matter.md cache check, fix cleanup count accuracy, improve error messages

## Details

### Critical Fixes (3)
| # | File | Issue |
|---|------|-------|
| 1 | `close.ts` | `inProgressPhases.length === 0 \|\| allDone` returned early when pending phases existed — changed to `if (allDone)` only |
| 2 | `close.ts` | `'completed'` alias from `PhaseStatusSchema` not handled — added to `allDone`, `completeCount`, status-setting, and task-counting |
| 3 | `close.ts` | `closedPhases`/`closedTasks` only tracked `in_progress` phases — now also counts pending phases set to closed in status loop |

### Security Fixes (4)
| # | File | Issue |
|---|------|-------|
| 4 | `close.ts` | `close-summary.md` path built with raw `path.join` — now uses `validateSwarmPath` |
| 5 | `write-drift-evidence.ts` | `validateSwarmPath` validated filename only, not nested `evidence/{phase}/` path |
| 6 | `write-drift-evidence.ts` | Unsafe `as unknown as` double cast on verdict — replaced with `String()` coercion |
| 7 | `reset-session.ts` | `statSync` follows symlinks — changed to `lstatSync` |

### Quality Fixes (6)
| # | File | Issue |
|---|------|-------|
| 8 | `close.ts` | Bare `curateAndStoreSwarm` call — wrapped in try/catch |
| 9 | `system-enhancer.ts` | `Bun.write` not portable — replaced with `fs.promises.writeFile` |
| 10 | `system-enhancer.ts` | Dark matter scan runs unconditionally — added `fs.existsSync` cache check |
| 11 | `reset-session.ts` | Cleanup count used `otherFiles.length` — now counts actual deletions |
| 12 | `write-drift-evidence.ts` | Generic error message — now includes actual error details |
| 13 | `close.ts` | Unused `args` param and `path` import — prefixed `_args`, removed import |

### Test & Doc Fixes (3)
| # | File | Issue |
|---|------|-------|
| 14 | `close.test.ts` | Mock poisoning — expanded mock from 2 to all 8 `swarmState` properties + function exports |
| 15 | `dark-matter-wiring.test.ts` | Removed 2 mock-tests-mock, fixed mock reset |
| 16 | `README.md`, `docs/releases/v6.41.0.md` | Version heading v6.33.5→v6.41.0, `writeDriftEvidence`→`write_drift_evidence` |

## Test plan

- [x] TypeScript typecheck passes (`npx tsc --noEmit`)
- [x] Biome lint/format passes
- [x] All 69 tests pass across 5 affected test files (0 failures)
- [x] Two rounds of 5-agent QA review completed — all agents approve

https://claude.ai/code/session_01C6irxiBfyqBPUVe81bW2cr