### PR TITLE
fix(curator): resolve model via explorer agent, not own DEFAULT_MODELS entry

### DIFF
--- a/docs/releases/v6.43.1.md
+++ b/docs/releases/v6.43.1.md
@@ -1,0 +1,47 @@
+# v6.43.1
+
+## What changed
+
+### Multi-swarm curator resolution — three correctness fixes
+
+Three bugs confirmed by external code review of the v6.43.0 curator agent work:
+
+**Fix 1: Default-swarm sessions could get the wrong curator under mixed deployments**
+
+`resolveCuratorAgentName` used `if (prefix && ...)` in `matchForAgent`, silently skipping the empty-string prefix entry for the default swarm. When a default-swarm session called the curator factory with a `sessionId`, the direct lookup returned no match and fell through to heuristic scan — which could pick a named-swarm curator instead. Now explicitly checks `prefixMap.get('')` before falling through, so default-swarm sessions always resolve to `curator_init` / `curator_phase`.
+
+**Fix 2: phase-monitor passed a pre-built delegate with no session context**
+
+`createPhaseMonitorHook`'s 4th parameter was `llmDelegate?: CuratorLLMDelegate` — built at plugin init time with no `sessionId`. Under multi-swarm deployments the wrong swarm's curator could be used. Changed to `delegateFactory?: CuratorDelegateFactory`, called lazily inside the handler with the `sessionID` extracted from the hook input. `src/index.ts` call sites updated to pass `(sessionId) => createCuratorLLMDelegate(ctx.directory, 'init', sessionId)`.
+
+Exported type: `CuratorDelegateFactory = (sessionId?: string) => CuratorLLMDelegate | undefined`
+
+**Fix 3: `system:` override in session.prompt bypassed registered custom prompts**
+
+`curator-llm-factory.ts` passed `system: systemPrompt` to `session.prompt`, overriding the registered agent's baked-in prompt (including any user-configured custom prompt overrides from `getPrompts('curator_init')`). Removed the `system:` field — the registered agent's prompt is used as-is. The `_systemPrompt` parameter is now accepted but intentionally ignored by the factory.
+
+### Curator model resolution — uses explorer agent
+
+`curator_init` and `curator_phase` were registered with `DEFAULT_MODELS['curator_init'] = 'opencode/trinity-large-preview-free'`, causing `ProviderModelNotFoundError` in the TUI when the ephemeral session was created on setups without that provider entry.
+
+Curator agents are conceptually explorer agents with different prompts — the same relationship that `critic_sounding_board` and `critic_drift_verifier` have to `critic`. The model fallback now chains to `getModel('explorer')` (which uses the user's configured explorer model) rather than a dedicated curator DEFAULT_MODELS entry. Explorer is a required part of initial swarm setup, so this is always resolvable.
+
+Users who want a custom model for curator can still set `agents.curator_init.model` in their swarm config.
+
+## Why
+
+- **TUI crash follow-up**: `ProviderModelNotFoundError` was introduced when curator agents were registered in v6.43.0 — they inherited a model constant that doesn't exist in all setups
+- **Multi-swarm correctness**: Users with 5 custom named swarms (no default swarm) were at risk of curator LLM calls landing on the wrong swarm's agent
+- **Custom prompt support**: Users who set custom prompts for `curator_init`/`curator_phase` via `getPrompts()` were silently getting the hardcoded constant instead
+
+## Migration
+
+No changes required. If you previously saw `ProviderModelNotFoundError` from curator, update the plugin — the error will not recur as long as your swarm config includes an `explorer` agent (required by initial setup).
+
+## Breaking changes
+
+None.
+
+## Known caveats
+
+- `DEFAULT_MODELS['curator_init']` and `DEFAULT_MODELS['curator_phase']` still exist in constants but are dead code — they are never reached by the normal registration path. Kept for test compliance and for users who explicitly call `getModelForAgent('curator_init')` directly (which no built-in code does).

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -329,7 +329,7 @@ If you call @coder instead of @${swarmId}_coder, the call will FAIL or go to the
 	if (!isAgentDisabled('curator_init', swarmAgents, swarmPrefix)) {
 		const curatorInitPrompts = getPrompts('curator_init');
 		const curatorInit = createCuratorAgent(
-			swarmAgents?.curator_init?.model ?? getModel('curator_init'),
+			swarmAgents?.curator_init?.model ?? getModel('explorer'),
 			curatorInitPrompts.prompt,
 			curatorInitPrompts.appendPrompt,
 			'curator_init' as CuratorRole,
@@ -342,7 +342,7 @@ If you call @coder instead of @${swarmId}_coder, the call will FAIL or go to the
 	if (!isAgentDisabled('curator_phase', swarmAgents, swarmPrefix)) {
 		const curatorPhasePrompts = getPrompts('curator_phase');
 		const curatorPhase = createCuratorAgent(
-			swarmAgents?.curator_phase?.model ?? getModel('curator_phase'),
+			swarmAgents?.curator_phase?.model ?? getModel('explorer'),
 			curatorPhasePrompts.prompt,
 			curatorPhasePrompts.appendPrompt,
 			'curator_phase' as CuratorRole,


### PR DESCRIPTION
## Summary

- Fixes `ProviderModelNotFoundError` in TUI — `curator_init` and `curator_phase` were registered with `DEFAULT_MODELS['curator_init'] = 'opencode/trinity-large-preview-free'`, which isn't available in all setups
- Curator agents now resolve their model via `getModel('explorer')`, mirroring the `critic_sounding_board`/`critic_drift_verifier` → `getModel('critic')` pattern; explorer is a required part of initial swarm config so it's always resolvable
- Users can still set `agents.curator_init.model` in their swarm config for an explicit override

## Test plan

- [x] `bun run typecheck` clean
- [x] `src/agents/index.ts` change is 2 lines — `getModel('curator_init')` → `getModel('explorer')` and `getModel('curator_phase')` → `getModel('explorer')`
- [x] All curator tests pass individually (20/20 factory, 17/17 phase-monitor-curator, 72/72 curator.test)
- [x] `bun run build` clean
- [x] QA sweep Phase 2 adversarial (100% confidence, 8/8 checks PASS) + Phase 3 completeness (7/7 DONE)

https://claude.ai/code/session_01PH2g2AcjsFqf8Fo1zAoZh9