### PR TITLE
feat(security): cross-platform destructive command guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,17 @@ jobs:
             fi
           done
           exit $failed
+      - name: Unit tests (destructive command guard - all platforms)
+        shell: bash
+        run: |
+          failed=0
+          for f in tests/unit/hooks/destructive-command*.test.ts tests/unit/hooks/incident-replay*.test.ts; do
+            [ -f "$f" ] || continue
+            if ! bun --smol test "$f" --timeout 120000; then
+              failed=1
+            fi
+          done
+          exit $failed
       - name: Unit tests (hooks - knowledge types/validator/store)
         if: runner.os != 'Windows'
         shell: bash

--- a/dist/index.js
+++ b/dist/index.js
@@ -42135,17 +42135,17 @@ function normalizeSeparators(filePath) {
 }
 function matchesDocPattern(filePath, patterns) {
   const normalizedPath = normalizeSeparators(filePath);
-  const basename7 = path56.basename(filePath);
+  const basename8 = path56.basename(filePath);
   for (const pattern of patterns) {
     if (!pattern.includes("/") && !pattern.includes("\\")) {
-      if (basename7 === pattern) {
+      if (basename8 === pattern) {
         return true;
       }
       continue;
     }
     if (pattern.startsWith("**/")) {
       const filenamePattern = pattern.slice(3);
-      if (basename7 === filenamePattern) {
+      if (basename8 === filenamePattern) {
         return true;
       }
       continue;
@@ -59443,6 +59443,320 @@ function isInDeclaredScope(filePath, scopeEntries, cwd) {
     return rel.length > 0 && !rel.startsWith("..") && !path41.isAbsolute(rel);
   });
 }
+var DC_MAX_UNWRAP_DEPTH = 5;
+var DC_SAFE_TARGETS = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  "coverage",
+  ".next",
+  ".turbo",
+  ".cache",
+  ".venv",
+  "venv",
+  "__pycache__",
+  "target",
+  "out",
+  ".parcel-cache",
+  ".svelte-kit",
+  ".nuxt",
+  ".output",
+  ".angular",
+  ".gradle",
+  "vendor"
+]);
+var DC_BLOCKED_ABSOLUTE_PREFIXES = [
+  "/root",
+  "/home",
+  "/Users",
+  "/etc",
+  "/var",
+  "/usr",
+  "/opt",
+  "/bin",
+  "/sbin",
+  "/lib",
+  "/boot",
+  "/proc",
+  "/sys",
+  "/dev",
+  "/run",
+  "/System",
+  "/Library",
+  "/Applications",
+  "C:\\Windows",
+  "C:\\Users",
+  "C:\\Program Files",
+  "C:\\ProgramData",
+  "C:/Windows",
+  "C:/Users",
+  "C:/Program Files",
+  "C:/ProgramData"
+];
+var DC_FS_ROOTS = new Set(["/", "C:\\", "C:/", "D:\\", "D:/", "E:\\", "E:/"]);
+var DC_REMOTE_PREFIXES = [
+  "\\\\",
+  "/Volumes/",
+  "/net/",
+  "/nfs/",
+  "/smb/",
+  "/run/user/"
+];
+function dcNormalizeCommand(cmd) {
+  let s = cmd.normalize("NFKC");
+  s = s.replace(/`(.)/g, "$1");
+  s = s.replace(/\^([a-zA-Z0-9 ])/g, "$1");
+  s = s.replace(/""/g, "");
+  return s;
+}
+function dcStripOneWrapper(cmd) {
+  const t = cmd.trim();
+  const cmdExeMatch = /^cmd(?:\.exe)?\s+\/[ckCK]\s+"?(.*?)"?\s*$/is.exec(t);
+  if (cmdExeMatch)
+    return cmdExeMatch[1].trim();
+  const psCommandMatch = /^(?:powershell|pwsh)(?:\.exe)?\s+(?:-(?:Command|command|c)\s+)(.+)$/is.exec(t);
+  if (psCommandMatch)
+    return psCommandMatch[1].replace(/^["']|["']$/g, "").trim();
+  const psEncMatch = /^(?:powershell|pwsh)(?:\.exe)?\s+(?:-(?:EncodedCommand|encodedcommand|enc|e)\s+)([A-Za-z0-9+/=]+)\s*$/.exec(t);
+  if (psEncMatch) {
+    try {
+      const decoded = Buffer.from(psEncMatch[1], "base64").toString("utf16le");
+      return decoded.trim();
+    } catch {
+      return t;
+    }
+  }
+  const shellMatch = /^(?:bash|sh|zsh|dash|fish)(?:\.exe)?\s+-c\s+"?(.*?)"?\s*$/s.exec(t);
+  if (shellMatch)
+    return shellMatch[1].trim();
+  const prefixMatch = /^(?:sudo|time|nohup)\s+(.+)$/s.exec(t) ?? /^env(?:\s+[A-Za-z_][A-Za-z0-9_]*=[^\s]*)*\s+(.+)$/s.exec(t) ?? /^nice\s+(?:-n\s+\d+\s+)?(.+)$/s.exec(t);
+  if (prefixMatch)
+    return prefixMatch[1].trim();
+  const wslMatch = /^wsl(?:\.exe)?\s+(?:-e|--)\s+(.+)$/s.exec(t);
+  if (wslMatch)
+    return wslMatch[1].trim();
+  const scriptBlockMatch = /^&\s*\{(.+)\}$/s.exec(t);
+  if (scriptBlockMatch)
+    return scriptBlockMatch[1].trim();
+  const iexMatch = /^(?:Invoke-Expression|iex)\s+(.+)$/is.exec(t);
+  if (iexMatch)
+    return iexMatch[1].replace(/^["'`]|["'`]$/g, "").trim();
+  const invokeCommandMatch = /^Invoke-Command\s+.*-ScriptBlock\s*\{(.+)\}$/is.exec(t);
+  if (invokeCommandMatch)
+    return invokeCommandMatch[1].trim();
+  const callMatch = /^call\s+(.+)$/is.exec(t);
+  if (callMatch)
+    return callMatch[1].trim();
+  return null;
+}
+function dcUnwrapWrappers(cmd) {
+  let current = cmd.trim();
+  for (let depth = 0;depth < DC_MAX_UNWRAP_DEPTH; depth++) {
+    const inner = dcStripOneWrapper(current);
+    if (inner === null || inner === current)
+      break;
+    current = inner.trim();
+  }
+  return current;
+}
+function dcSplitSegments(cmd) {
+  const segments = [];
+  let current = "";
+  let inDoubleQuote = false;
+  let inSingleQuote = false;
+  for (let i2 = 0;i2 < cmd.length; i2++) {
+    const ch = cmd[i2];
+    const next = cmd[i2 + 1];
+    if (ch === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+      current += ch;
+      continue;
+    }
+    if (ch === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+      current += ch;
+      continue;
+    }
+    if (!inDoubleQuote && !inSingleQuote) {
+      if (ch === "&" && next === "&" || ch === "|" && next === "|") {
+        segments.push(current.trim());
+        current = "";
+        i2++;
+        continue;
+      }
+      if (ch === "|" || ch === ";" || ch === `
+` || ch === "\r") {
+        segments.push(current.trim());
+        current = "";
+        continue;
+      }
+    }
+    current += ch;
+  }
+  if (current.trim())
+    segments.push(current.trim());
+  return segments.filter((s) => s.length > 0);
+}
+function dcHasUnresolvableVars(p) {
+  return /(%[A-Za-z_][A-Za-z0-9_]*%|\$\{?[A-Za-z_]|\$env:)/i.test(p);
+}
+function dcIsRemotePath(p) {
+  return DC_REMOTE_PREFIXES.some((pfx) => p.startsWith(pfx));
+}
+function dcLstatAncestorWalk(targetPath, cwd) {
+  const normalizedTarget = path41.resolve(cwd, targetPath);
+  const normalizedCwd = path41.resolve(cwd);
+  const ancestors = [];
+  let current = normalizedTarget;
+  while (true) {
+    ancestors.push(current);
+    const parent = path41.dirname(current);
+    if (parent === current)
+      break;
+    const rel = path41.relative(normalizedCwd, current);
+    if (rel === "" || rel.startsWith(".."))
+      break;
+    current = parent;
+  }
+  for (const ancestor of ancestors) {
+    let stat2 = null;
+    try {
+      stat2 = fsSync.lstatSync(ancestor);
+    } catch (err2) {
+      const code = err2.code;
+      if (code === "ENOENT") {
+        break;
+      }
+      return `lstat failed on "${ancestor}": ${String(err2)} \u2014 refusing to allow destructive operation on unverifiable path`;
+    }
+    if (stat2.isSymbolicLink()) {
+      return `BLOCKED: "${ancestor}" is a symlink/junction \u2014 deleting recursively through it would destroy the link target. Use platform-specific junction deletion (fsutil reparsepoint delete, Remove-Item without -Recurse) instead.`;
+    }
+  }
+  return null;
+}
+function dcValidateTargets(targets, cwd) {
+  for (const raw of targets) {
+    const t = raw.trim().replace(/^["']|["']$/g, "");
+    if (!t || t === ".")
+      continue;
+    if (dcHasUnresolvableVars(t)) {
+      return `BLOCKED: Destructive command targets path with unexpanded variable "${t}" \u2014 cannot verify safety. Resolve variables before using destructive operations.`;
+    }
+    if (dcIsRemotePath(t)) {
+      return `BLOCKED: Destructive command targets remote/network filesystem path "${t}" \u2014 refusing to execute remote destructive operations.`;
+    }
+    if (/^\\\\/.test(t)) {
+      return `BLOCKED: Destructive command targets UNC path "${t}" \u2014 UNC paths in destructive operations are not allowed.`;
+    }
+    const lstatBlock = dcLstatAncestorWalk(t, cwd);
+    if (lstatBlock)
+      return lstatBlock;
+    const basename6 = path41.basename(t);
+    if (t === basename6 && DC_SAFE_TARGETS.has(t)) {
+      continue;
+    }
+    if (DC_FS_ROOTS.has(t) || DC_FS_ROOTS.has(t.replace(/\//g, "\\"))) {
+      return `BLOCKED: Destructive command targets filesystem root "${t}"`;
+    }
+    if (path41.isAbsolute(t) || /^[A-Za-z]:/.test(t)) {
+      for (const blocked of DC_BLOCKED_ABSOLUTE_PREFIXES) {
+        if (t.startsWith(blocked)) {
+          return `BLOCKED: Destructive command targets system path "${t}" which is under protected prefix "${blocked}"`;
+        }
+      }
+    }
+  }
+  return null;
+}
+function dcCheckJunctionCreation(segment, cwd) {
+  const mklinkMatch = /^mklink(?:\.exe)?\s+\/[JjDd]\s+"?([^"\s]+)"?\s+"?([^"\s]+)"?/i.exec(segment);
+  if (mklinkMatch) {
+    const target = mklinkMatch[2].trim();
+    if (!dcHasUnresolvableVars(target)) {
+      const resolved = path41.resolve(cwd, target);
+      const rel = path41.relative(cwd, resolved);
+      if (rel.startsWith("..") || path41.isAbsolute(rel)) {
+        return `BLOCKED: Junction/symlink creation targeting path outside working directory: mklink target "${target}" resolves to "${resolved}" which is outside "${cwd}". Creating junctions to external paths and then deleting them recursively can destroy data.`;
+      }
+    }
+    return null;
+  }
+  const newItemMatch = /New-Item\b.*-ItemType\s+(?:Junction|SymbolicLink|HardLink)\b.*-Target\s+"?([^"\s;]+)"?/i.exec(segment);
+  if (newItemMatch) {
+    const target = newItemMatch[1].trim();
+    if (!dcHasUnresolvableVars(target)) {
+      const resolved = path41.resolve(cwd, target);
+      const rel = path41.relative(cwd, resolved);
+      if (rel.startsWith("..") || path41.isAbsolute(rel)) {
+        return `BLOCKED: Junction/symlink creation targeting path outside working directory: New-Item target "${target}" resolves to "${resolved}" which is outside "${cwd}". This pattern caused the K2.6 data-loss incident.`;
+      }
+    }
+    return null;
+  }
+  const lnMatch = /^ln\s+(?:-[sfnv]*s[sfnv]*|-s)\s+"?([^"\s]+)"?(?:\s+"?[^"\s]+"?)?\s*$/.exec(segment);
+  if (lnMatch) {
+    const target = lnMatch[1].trim();
+    if (!dcHasUnresolvableVars(target) && path41.isAbsolute(target)) {
+      const rel = path41.relative(cwd, target);
+      if (rel.startsWith("..") || path41.isAbsolute(rel)) {
+        return `BLOCKED: Symlink creation targeting path outside working directory: ln -s target "${target}" is outside "${cwd}". Symlinks to external paths combined with recursive deletion can destroy data.`;
+      }
+    }
+    return null;
+  }
+  return null;
+}
+function dcExtractWindowsCmdTargets(segment) {
+  const rmdirMatch = /^(?:rmdir|rd)(?:\.exe)?\s+(?:\/[sqSQ]\s+)*"?(.+?)"?\s*$/i.exec(segment);
+  if (rmdirMatch)
+    return [rmdirMatch[1].trim()];
+  const delMatch = /^del(?:\.exe)?\s+(?:\/[sqfSQF]\s+)*"?(.+?)"?\s*$/i.exec(segment);
+  if (delMatch)
+    return [delMatch[1].trim()];
+  return [];
+}
+function dcExtractPowerShellTargets(segment) {
+  const verbMatch = /^(?:Remove-Item|ri|rm|rmdir|del|erase|rd)\s+/i.exec(segment);
+  if (!verbMatch)
+    return [];
+  const rest = segment.slice(verbMatch[0].length);
+  const tokens = rest.match(/"[^"]*"|'[^']*'|[^\s]+/g) ?? [];
+  const targets = [];
+  const valueFlags = new Set([
+    "-literalpath",
+    "-path",
+    "-filter",
+    "-include",
+    "-exclude",
+    "-lp"
+  ]);
+  let skipNext = false;
+  for (const tok of tokens) {
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
+    if (tok.startsWith("-")) {
+      if (valueFlags.has(tok.toLowerCase())) {
+        skipNext = true;
+        const idx = tokens.indexOf(tok);
+        if (idx !== -1 && idx + 1 < tokens.length) {
+          const val = tokens[idx + 1].replace(/^["']|["']$/g, "");
+          if (val)
+            targets.push(val);
+          skipNext = true;
+        }
+      }
+    } else {
+      const cleaned = tok.replace(/^["']|["']$/g, "");
+      if (cleaned)
+        targets.push(cleaned);
+    }
+  }
+  return targets;
+}
 function createGuardrailsHooks(directory, directoryOrConfig, config3, authorityConfig) {
   let guardrailsConfig;
   if (directory && typeof directory === "object" && "enabled" in directory) {
@@ -59477,46 +59791,159 @@ function createGuardrailsHooks(directory, directoryOrConfig, config3, authorityC
     if (cfg.block_destructive_commands === false)
       return;
     const toolArgs = args2;
-    const command = typeof toolArgs?.command === "string" ? toolArgs.command.trim() : "";
-    if (!command)
+    const rawCommand = typeof toolArgs?.command === "string" ? toolArgs.command.trim() : "";
+    if (!rawCommand)
       return;
+    const cwd = effectiveDirectory;
+    const command = dcNormalizeCommand(rawCommand);
     if (/:\s*\(\s*\)\s*\{[^}]*\|[^}]*:/.test(command)) {
       throw new Error(`BLOCKED: Potentially destructive shell command detected: fork bomb pattern`);
     }
-    const rmFlagPattern = /^rm\s+(-r\s+-f|-f\s+-r|-rf|-fr)\s+(.+)$/;
-    const rmMatch = rmFlagPattern.exec(command);
-    if (rmMatch) {
-      const targetPart = rmMatch[2].trim();
-      const targets = targetPart.split(/\s+/);
-      const safeTargets = /^(node_modules|\.git)$/;
-      const allSafe = targets.every((t) => safeTargets.test(t));
-      if (!allSafe) {
-        throw new Error(`BLOCKED: Potentially destructive shell command: rm -rf on unsafe path(s): ${targetPart}`);
+    const unwrapped = dcUnwrapWrappers(command);
+    const outerSegments = dcSplitSegments(command);
+    const innerSegments = dcSplitSegments(unwrapped);
+    const perSegmentUnwrapped = outerSegments.map((s) => dcUnwrapWrappers(s));
+    const allSegments = [
+      ...new Set([...outerSegments, ...innerSegments, ...perSegmentUnwrapped])
+    ];
+    for (const segment of allSegments) {
+      const seg = segment.trim();
+      if (!seg)
+        continue;
+      const junctionBlock = dcCheckJunctionCreation(seg, cwd);
+      if (junctionBlock)
+        throw new Error(junctionBlock);
+      const rmShortMatch = /^rm\s+(-[rRfF]+(?:\s+-[rRfF]+)*|-r\s+-f|-f\s+-r)\s+(.+)$/.exec(seg);
+      const rmLongMatch = /^rm\s+(?:--(?:recursive|force)\s+){1,2}(.+)$/.exec(seg);
+      const rmAnyMatch = rmShortMatch ?? rmLongMatch;
+      if (rmAnyMatch) {
+        const targetPart = rmAnyMatch[rmShortMatch ? 2 : 1].trim();
+        const targets = targetPart.split(/\s+/);
+        const validateBlock = dcValidateTargets(targets, cwd);
+        if (validateBlock)
+          throw new Error(validateBlock);
+        const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.replace(/^["']|["']$/g, "").trim()));
+        if (!allSafe) {
+          throw new Error(`BLOCKED: Potentially destructive shell command: rm with recursive/force flags on unsafe path(s): ${targetPart}`);
+        }
       }
-    }
-    if (/^git\s+push\b.*?(--force|-f)\b/.test(command)) {
-      throw new Error(`BLOCKED: Force push detected \u2014 git push --force is not allowed`);
-    }
-    if (/^git\s+reset\s+--hard/.test(command)) {
-      throw new Error(`BLOCKED: "git reset --hard" detected \u2014 use --soft or --mixed with caution`);
-    }
-    if (/^git\s+reset\s+--mixed\s+\S+/.test(command)) {
-      throw new Error(`BLOCKED: "git reset --mixed" with a target branch/commit is not allowed`);
-    }
-    if (/^kubectl\s+delete\b/.test(command)) {
-      throw new Error(`BLOCKED: "kubectl delete" detected \u2014 destructive cluster operation`);
-    }
-    if (/^docker\s+system\s+prune\b/.test(command)) {
-      throw new Error(`BLOCKED: "docker system prune" detected \u2014 destructive container operation`);
-    }
-    if (/^\s*DROP\s+(TABLE|DATABASE|SCHEMA)\b/i.test(command)) {
-      throw new Error(`BLOCKED: SQL DROP command detected \u2014 destructive database operation`);
-    }
-    if (/^\s*TRUNCATE\s+TABLE\b/i.test(command)) {
-      throw new Error(`BLOCKED: SQL TRUNCATE command detected \u2014 destructive database operation`);
-    }
-    if (/^mkfs[./]/.test(command)) {
-      throw new Error(`BLOCKED: Disk format command (mkfs) detected \u2014 disk formatting operation`);
+      if (/^(?:rmdir|rd)(?:\.exe)?\s+.*\/[sS]/i.test(seg)) {
+        const targets = dcExtractWindowsCmdTargets(seg);
+        if (targets.length === 0) {
+          throw new Error(`BLOCKED: Windows recursive directory delete (rmdir /s or rd /s) detected. Verify the target is not a junction/symlink.`);
+        }
+        const validateBlock = dcValidateTargets(targets, cwd);
+        if (validateBlock)
+          throw new Error(validateBlock);
+        const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.trim()));
+        if (!allSafe) {
+          throw new Error(`BLOCKED: Windows recursive directory delete on unsafe path(s): ${targets.join(", ")}`);
+        }
+      }
+      if (/^del(?:\.exe)?\s+.*\/[sS]/i.test(seg)) {
+        const targets = dcExtractWindowsCmdTargets(seg);
+        if (targets.length > 0) {
+          const validateBlock = dcValidateTargets(targets, cwd);
+          if (validateBlock)
+            throw new Error(validateBlock);
+          const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.trim()));
+          if (!allSafe) {
+            throw new Error(`BLOCKED: Windows recursive file delete (del /s) on unsafe path(s): ${targets.join(", ")}`);
+          }
+        }
+      }
+      if (/^(?:Remove-Item|ri|rm|rmdir|del|erase|rd)\b.*-[Rr]ecurse\b/i.test(seg) || /^(?:Remove-Item|ri|rm|rmdir|del|erase|rd)\b.*-[Rr]\b/i.test(seg)) {
+        const targets = dcExtractPowerShellTargets(seg);
+        if (targets.length > 0) {
+          const validateBlock = dcValidateTargets(targets, cwd);
+          if (validateBlock)
+            throw new Error(validateBlock);
+          const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.trim()));
+          if (!allSafe) {
+            throw new Error(`BLOCKED: PowerShell recursive delete on unsafe path(s): ${targets.join(", ")}`);
+          }
+        } else {
+          throw new Error(`BLOCKED: PowerShell Remove-Item with -Recurse detected \u2014 cannot verify target safety`);
+        }
+      }
+      if (/Get-ChildItem\b.*\|\s*Remove-Item\b.*-[Rr]ecurse/i.test(seg) || /gci\b.*\|\s*ri\b.*-[Rr]ecurse/i.test(seg)) {
+        throw new Error(`BLOCKED: PowerShell pipeline "Get-ChildItem | Remove-Item -Recurse" detected \u2014 verify target safety and avoid recursive deletion through symlinks/junctions`);
+      }
+      if (/^vssadmin(?:\.exe)?\s+delete\b/i.test(seg)) {
+        throw new Error(`BLOCKED: "vssadmin delete" detected \u2014 deletes Volume Shadow Copies (ransomware-grade operation)`);
+      }
+      if (/^wbadmin(?:\.exe)?\s+delete\b/i.test(seg)) {
+        throw new Error(`BLOCKED: "wbadmin delete" detected \u2014 deletes Windows backup catalog (ransomware-grade operation)`);
+      }
+      if (/^diskpart(?:\.exe)?$/i.test(seg)) {
+        throw new Error(`BLOCKED: "diskpart" detected \u2014 interactive disk partitioning tool`);
+      }
+      if (/^bcdedit(?:\.exe)?\s+\/delete\b/i.test(seg)) {
+        throw new Error(`BLOCKED: "bcdedit /delete" detected \u2014 modifies Windows boot configuration`);
+      }
+      if (/^sdelete(?:\.exe)?\s+/i.test(seg)) {
+        throw new Error(`BLOCKED: "sdelete" detected \u2014 secure file deletion (Sysinternals)`);
+      }
+      if (/^fsutil(?:\.exe)?\s+reparsepoint\s+delete\b/i.test(seg) || /^fsutil(?:\.exe)?\s+file\s+setzerodata\b/i.test(seg)) {
+        throw new Error(`BLOCKED: "fsutil" destructive subcommand detected`);
+      }
+      if (/^takeown(?:\.exe)?\s+.*\/[rR]\b/i.test(seg)) {
+        throw new Error(`BLOCKED: "takeown /R" (recursive ownership takeover) detected \u2014 often precedes destructive operations`);
+      }
+      if (/^cipher(?:\.exe)?\s+\/[wW]\b/i.test(seg)) {
+        throw new Error(`BLOCKED: "cipher /w" detected \u2014 overwrites free disk space (data wipe operation)`);
+      }
+      if (/^format\s+[A-Za-z]:/i.test(seg)) {
+        throw new Error(`BLOCKED: Windows disk format command detected`);
+      }
+      if (/^robocopy(?:\.exe)?\s+.*\/(?:MIR|mir)\b/.test(seg)) {
+        throw new Error(`BLOCKED: "robocopy /MIR" (mirror) detected \u2014 can delete files in the destination that don't exist in the source`);
+      }
+      if (/^chmod\s+.*-[rR]\b.*000\b/.test(seg)) {
+        throw new Error(`BLOCKED: "chmod -R 000" detected \u2014 removes all permissions recursively`);
+      }
+      if (/^chattr\s+.*\+i\b/.test(seg)) {
+        throw new Error(`BLOCKED: "chattr +i" detected \u2014 makes files immutable`);
+      }
+      if (/^icacls(?:\.exe)?\s+.*\/deny\b/i.test(seg)) {
+        throw new Error(`BLOCKED: "icacls /deny" detected \u2014 denies filesystem permissions`);
+      }
+      if (/^dd\b.*\bif=\/dev\/(zero|null|urandom)\b/.test(seg)) {
+        throw new Error(`BLOCKED: "dd" with /dev/zero, /dev/null, or /dev/urandom as input detected \u2014 data wipe operation`);
+      }
+      if (/^git\s+push\b.*?(--force|-f)\b/.test(seg)) {
+        throw new Error(`BLOCKED: Force push detected \u2014 git push --force is not allowed`);
+      }
+      if (/^git\s+reset\s+--hard/.test(seg)) {
+        throw new Error(`BLOCKED: "git reset --hard" detected \u2014 use --soft or --mixed with caution`);
+      }
+      if (/^git\s+reset\s+--mixed\s+\S+/.test(seg)) {
+        throw new Error(`BLOCKED: "git reset --mixed" with a target branch/commit is not allowed`);
+      }
+      if (/^git\s+clean\s+.*-[fF].*[dD]/.test(seg)) {
+        throw new Error(`BLOCKED: "git clean -fd" detected \u2014 permanently deletes untracked files and directories`);
+      }
+      if (/^git\s+worktree\s+remove\s+.*--force\b/i.test(seg)) {
+        throw new Error(`BLOCKED: "git worktree remove --force" detected \u2014 can delete working tree contents`);
+      }
+      if (/^rsync\b.*--delete(?:-after|-before|-during|-delay)?\b/.test(seg)) {
+        throw new Error(`BLOCKED: "rsync --delete" detected \u2014 can delete files in the destination. Verify source is not empty.`);
+      }
+      if (/^kubectl\s+delete\b/.test(seg)) {
+        throw new Error(`BLOCKED: "kubectl delete" detected \u2014 destructive cluster operation`);
+      }
+      if (/^docker\s+system\s+prune\b/.test(seg)) {
+        throw new Error(`BLOCKED: "docker system prune" detected \u2014 destructive container operation`);
+      }
+      if (/^\s*DROP\s+(TABLE|DATABASE|SCHEMA)\b/i.test(seg)) {
+        throw new Error(`BLOCKED: SQL DROP command detected \u2014 destructive database operation`);
+      }
+      if (/^\s*TRUNCATE\s+TABLE\b/i.test(seg)) {
+        throw new Error(`BLOCKED: SQL TRUNCATE command detected \u2014 destructive database operation`);
+      }
+      if (/^mkfs[./]/.test(seg)) {
+        throw new Error(`BLOCKED: Disk format command (mkfs) detected \u2014 disk formatting operation`);
+      }
     }
   }
   async function checkGateLimits(params) {
@@ -68902,7 +69329,7 @@ function countCodeLines(content) {
   return lines.length;
 }
 function isTestFile(filePath) {
-  const basename9 = path65.basename(filePath);
+  const basename10 = path65.basename(filePath);
   const _ext = path65.extname(filePath).toLowerCase();
   const testPatterns = [
     ".test.",
@@ -68918,7 +69345,7 @@ function isTestFile(filePath) {
     ".spec.jsx"
   ];
   for (const pattern of testPatterns) {
-    if (basename9.includes(pattern)) {
+    if (basename10.includes(pattern)) {
       return true;
     }
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -59508,6 +59508,7 @@ function dcNormalizeCommand(cmd) {
   s = s.replace(/`(.)/g, "$1");
   s = s.replace(/\^([a-zA-Z0-9 ])/g, "$1");
   s = s.replace(/""/g, "");
+  s = s.replace(/''/g, "");
   return s;
 }
 function dcStripOneWrapper(cmd) {
@@ -59527,13 +59528,13 @@ function dcStripOneWrapper(cmd) {
       return t;
     }
   }
-  const shellMatch = /^(?:bash|sh|zsh|dash|fish)(?:\.exe)?\s+-c\s+"?(.*?)"?\s*$/s.exec(t);
+  const shellMatch = /^(?:bash|sh|zsh|dash|fish)(?:\.exe)?\s+-c\s+"?(.*?)"?\s*$/is.exec(t);
   if (shellMatch)
     return shellMatch[1].trim();
-  const prefixMatch = /^(?:sudo|time|nohup)\s+(.+)$/s.exec(t) ?? /^env(?:\s+[A-Za-z_][A-Za-z0-9_]*=[^\s]*)*\s+(.+)$/s.exec(t) ?? /^nice\s+(?:-n\s+\d+\s+)?(.+)$/s.exec(t);
+  const prefixMatch = /^(?:sudo|time|nohup)\s+(.+)$/is.exec(t) ?? /^env(?:\s+[A-Za-z_][A-Za-z0-9_]*=[^\s]*)*\s+(.+)$/is.exec(t) ?? /^nice\s+(?:-n\s+\d+\s+)?(.+)$/is.exec(t);
   if (prefixMatch)
     return prefixMatch[1].trim();
-  const wslMatch = /^wsl(?:\.exe)?\s+(?:-e|--)\s+(.+)$/s.exec(t);
+  const wslMatch = /^wsl(?:\.exe)?\s+(?:-e|--)\s+(.+)$/is.exec(t);
   if (wslMatch)
     return wslMatch[1].trim();
   const scriptBlockMatch = /^&\s*\{(.+)\}$/s.exec(t);
@@ -59683,7 +59684,9 @@ function dcCheckJunctionCreation(segment, cwd) {
     }
     return null;
   }
-  const newItemMatch = /New-Item\b.*-ItemType\s+(?:Junction|SymbolicLink|HardLink)\b.*-Target\s+"?([^"\s;]+)"?/i.exec(segment);
+  const newItemTypeMatch = /New-Item\b.*-ItemType\s+(?:Junction|SymbolicLink|HardLink)\b/i.test(segment);
+  const newItemTargetMatch = /-Target\s+"?([^"\s;]+)"?/i.exec(segment);
+  const newItemMatch = newItemTypeMatch ? newItemTargetMatch : null;
   if (newItemMatch) {
     const target = newItemMatch[1].trim();
     if (!dcHasUnresolvableVars(target)) {
@@ -59698,10 +59701,11 @@ function dcCheckJunctionCreation(segment, cwd) {
   const lnMatch = /^ln\s+(?:-[sfnv]*s[sfnv]*|-s)\s+"?([^"\s]+)"?(?:\s+"?[^"\s]+"?)?\s*$/.exec(segment);
   if (lnMatch) {
     const target = lnMatch[1].trim();
-    if (!dcHasUnresolvableVars(target) && path41.isAbsolute(target)) {
-      const rel = path41.relative(cwd, target);
+    if (!dcHasUnresolvableVars(target)) {
+      const resolved = path41.resolve(cwd, target);
+      const rel = path41.relative(cwd, resolved);
       if (rel.startsWith("..") || path41.isAbsolute(rel)) {
-        return `BLOCKED: Symlink creation targeting path outside working directory: ln -s target "${target}" is outside "${cwd}". Symlinks to external paths combined with recursive deletion can destroy data.`;
+        return `BLOCKED: Symlink creation targeting path outside working directory: ln -s target "${target}" resolves to "${resolved}" which is outside "${cwd}". Symlinks to external paths combined with recursive deletion can destroy data.`;
       }
     }
     return null;

--- a/docs/releases/v6.69.0.md
+++ b/docs/releases/v6.69.0.md
@@ -52,9 +52,10 @@ Commands are normalized before checking:
 - **cmd.exe caret escapes** — `^r^m^d^i^r` → `rmdir`
 - **Quote-splice evasion** — `r""m""dir` → `rmdir`; `R''e''m''o''v''e''-''I''t''e''m`
   → `Remove-Item` (PowerShell single-quote splice, found by post-merge adversarial review)
-- **Wrapper unwrapping** (case-insensitive, depth-5, per-segment in compound
-  commands): `CMD /c`, `POWERSHELL -Command`, `pwsh -c`, `bash -c`, `sudo`,
-  `wsl -e`, `iex`, `Invoke-Expression`, `call`, `-EncodedCommand`
+- **Wrapper unwrapping** (fully case-insensitive, depth-5, per-segment in compound
+  commands): `CMD /c`, `POWERSHELL -Command`, `pwsh -c`, `BASH -c`, `SUDO`,
+  `WSL.EXE -e`, `NOHUP`, `iex`, `Invoke-Expression`, `call`, `-EncodedCommand`;
+  all wrappers now carry the `/i` flag (`SUDO rm -rf /important` is blocked)
 - **Compound command splitting** — each segment of `; && || |` chains checked
   independently, including per-segment wrapper unwrapping
 
@@ -138,14 +139,14 @@ None.
 
 ## Test results
 
-215 tests added across four files, all passing:
+220 tests added across four files, all passing:
 
 | File | Tests |
 |------|-------|
 | `destructive-command-guard.test.ts` (updated) | 26 |
 | `destructive-command-windows.test.ts` (new) | 71 |
 | `destructive-command-lstat.test.ts` (new) | 36 |
-| `destructive-command-wrapper-unwrap.test.ts` (new) | 82 |
+| `destructive-command-wrapper-unwrap.test.ts` (new) | 87 |
 
 `bun run typecheck` clean. Two pre-existing, unrelated test failures in
 `save-plan-auto-checkpoint.test.ts` and `pre-check-batch-cwd.test.ts` are

--- a/docs/releases/v6.69.0.md
+++ b/docs/releases/v6.69.0.md
@@ -1,0 +1,146 @@
+# v6.69.0
+
+## What changed
+
+### Cross-platform destructive command guardrails
+
+Adds deep detection and blocking of destructive shell commands that can cause
+data loss across Linux, macOS, and Windows — motivated by the K2.6 incident
+where an LLM agent created a Windows NTFS directory junction pointing at a
+4.8 GB build tree, then ran `cmd /c "rmdir /q /s <junction>"`. On Windows,
+`rmdir /s` on a junction traverses and destroys the target directory tree.
+
+#### New command patterns blocked
+
+**Windows cmd.exe:**
+- `rmdir /s`, `rd /s` — recursive directory delete with junction traversal
+- `del /s /q /f` — recursive file delete
+- All-caps variants (`RMDIR`, `DEL`), `.exe` suffix forms, reversed flag order
+
+**PowerShell:**
+- `Remove-Item -Recurse` and all PS aliases (`ri`, `rm`, `rmdir`, `del`,
+  `erase`, `rd`) — tokenizer-based path extraction handles flags-before-path
+  and flags-after-path orderings
+- `Get-ChildItem | Remove-Item -Recurse` pipeline form
+- `-EncodedCommand` (base64 UTF-16LE decoded and re-checked)
+
+**Ransomware-grade / disk-level:**
+- `vssadmin delete` (Volume Shadow Copy wipe)
+- `wbadmin delete` (Windows backup wipe)
+- `diskpart` (interactive disk partitioning)
+- `bcdedit /delete` (boot configuration)
+- `sdelete` (Sysinternals secure-delete)
+- `fsutil reparsepoint delete`, `fsutil file setzerodata`
+- `takeown /R`, `cipher /w`, `format C:`
+- `robocopy /MIR` (mirror delete)
+- `icacls /deny`
+- `mkfs` (disk format)
+
+**SQL DDL:**
+- `DROP TABLE`, `DROP DATABASE`, `TRUNCATE TABLE`
+
+**Previously missing POSIX coverage:**
+- `rm --recursive --force` (POSIX long-form flags)
+- Fork bomb patterns (pre-split check to defeat `;` evasion)
+
+#### Evasion normalization
+
+Commands are normalized before checking:
+- **NFKC Unicode** — collapses fullwidth letters (`ｒｍｄｉｒ` → `rmdir`)
+- **PowerShell backtick escapes** — `` R`e`m`o`v`e`-`I`t`e`m `` → `Remove-Item`;
+  handles backtick before any character including `-`
+- **cmd.exe caret escapes** — `^r^m^d^i^r` → `rmdir`
+- **Quote-splice evasion** — `r""m""dir` → `rmdir`
+- **Wrapper unwrapping** (case-insensitive, depth-5, per-segment in compound
+  commands): `CMD /c`, `POWERSHELL -Command`, `pwsh -c`, `bash -c`, `sudo`,
+  `wsl -e`, `iex`, `Invoke-Expression`, `call`, `-EncodedCommand`
+- **Compound command splitting** — each segment of `; && || |` chains checked
+  independently, including per-segment wrapper unwrapping
+
+#### lstat-based junction/symlink detection
+
+Every destructive target is checked with `fs.lstatSync` walking from the
+target up to the working directory. If any ancestor is a symlink or Windows
+junction, the operation is blocked before the deletion executes.
+
+**Critical invariant:** lstat runs **before** the safe-target allowlist
+(`node_modules`, `dist`, `build`, etc.). Without this ordering, an LLM could
+create `mklink /J node_modules C:\important` and then `rm -rf node_modules` —
+bypassing the guard via a safe-named junction. This is the K2.6 mechanism
+replayed with a safe name.
+
+#### Junction/symlink creation blocking
+
+Blocks the setup step of the incident pattern:
+- `mklink /J <link> <external-target>` and `mklink /D`
+- `New-Item -ItemType Junction -Target <external-target>`
+- `New-Item -ItemType SymbolicLink -Target <external-target>`
+- `ln -s <absolute-external-target>`
+
+All blocked when the target resolves outside the current working directory.
+
+#### Additional target safety checks
+
+- Unexpanded variable references (`$var`, `${VAR}`, `$env:VAR`, `%VAR%`) —
+  fail-closed (cannot verify safety without resolving the variable)
+- Remote/network paths (`\\server\share`, `/Volumes/`, `/net/`, `/nfs/`)
+- System path prefixes (`/root`, `/home`, `/etc`, `/usr`, `C:\Windows`,
+  `C:\Users`, `C:\Program Files`, etc.)
+- Filesystem roots (`/`, `C:\`, `D:\`)
+
+## Why
+
+The K2.6 incident destroyed 4.8 GB of a user's portable application tree
+when an LLM used the Windows junction+rmdir footgun. The same mechanism
+applies to POSIX symlinks (POSIX `rm -rf` follows symlinks into the target)
+and PowerShell Remove-Item on junctions before PS 7. Defense requires both
+blocking the pattern at command time and detecting junctions/symlinks via
+lstat before the deletion executes.
+
+## Migration steps
+
+No changes required. The new checks are additive — existing agent sessions
+run unchanged. The `block_destructive_commands` flag (default `true`) controls
+all new checks; setting it to `false` bypasses them entirely (unchanged behavior).
+
+The one behavioral change from previous versions: `rm -rf node_modules` (and
+other safe-named targets) is now blocked if `node_modules` is a symlink or
+junction. Previously the safe-target allowlist bypassed lstat entirely, so a
+symlinked `node_modules` would have been allowed. Legitimate CI usage
+(deleting a real `node_modules` directory) is unaffected.
+
+## Breaking changes
+
+None.
+
+## Known caveats
+
+- **lstat is best-effort on paths that don't exist yet.** If the target path
+  does not exist (ENOENT), lstat silently allows through and the operation is
+  blocked only if the target name is unsafe (not in the safe-target allowlist).
+  This is intentional: tools that pre-delete a directory before re-creating it
+  should not be blocked.
+- **`target` is in the safe-target allowlist** (Maven/Gradle build output
+  directory). `rmdir /s target` is allowed when `target` is a real directory.
+  The lstat check will block it if `target` is a junction.
+- **Tool name filter covers `bash` and `shell` only.** Commands dispatched
+  through other tool names (e.g. a custom `execute` tool) are not checked.
+  This is the scope of this PR; broader tool coverage is tracked separately.
+- **Windows lstat on junctions requires Node ≥ 18.** Earlier Node versions
+  may report junctions as directories rather than symlinks. The plugin requires
+  Bun which uses a current Node-compatible runtime.
+
+## Test results
+
+213 tests added across four files, all passing:
+
+| File | Tests |
+|------|-------|
+| `destructive-command-guard.test.ts` (updated) | 26 |
+| `destructive-command-windows.test.ts` (new) | 71 |
+| `destructive-command-lstat.test.ts` (new) | 36 |
+| `destructive-command-wrapper-unwrap.test.ts` (new) | 80 |
+
+`bun run typecheck` clean. Two pre-existing, unrelated test failures in
+`save-plan-auto-checkpoint.test.ts` and `pre-check-batch-cwd.test.ts` are
+unchanged on this branch.

--- a/docs/releases/v6.69.0.md
+++ b/docs/releases/v6.69.0.md
@@ -50,7 +50,8 @@ Commands are normalized before checking:
 - **PowerShell backtick escapes** — `` R`e`m`o`v`e`-`I`t`e`m `` → `Remove-Item`;
   handles backtick before any character including `-`
 - **cmd.exe caret escapes** — `^r^m^d^i^r` → `rmdir`
-- **Quote-splice evasion** — `r""m""dir` → `rmdir`
+- **Quote-splice evasion** — `r""m""dir` → `rmdir`; `R''e''m''o''v''e''-''I''t''e''m`
+  → `Remove-Item` (PowerShell single-quote splice, found by post-merge adversarial review)
 - **Wrapper unwrapping** (case-insensitive, depth-5, per-segment in compound
   commands): `CMD /c`, `POWERSHELL -Command`, `pwsh -c`, `bash -c`, `sudo`,
   `wsl -e`, `iex`, `Invoke-Expression`, `call`, `-EncodedCommand`
@@ -129,17 +130,22 @@ None.
 - **Windows lstat on junctions requires Node ≥ 18.** Earlier Node versions
   may report junctions as directories rather than symlinks. The plugin requires
   Bun which uses a current Node-compatible runtime.
+- **`rm -- target` (POSIX flag terminator) is not pattern-matched.** `rm --`
+  terminates flag parsing; subsequent arguments are filenames, not flags. Without
+  `-r`/`-rf`, `rm --` cannot recursively delete directories, so this is not
+  exploitable for the K2.6-style recursive-delete scenario. The target-safety
+  checks still run if the `rm -r` pattern matches before `--`.
 
 ## Test results
 
-213 tests added across four files, all passing:
+215 tests added across four files, all passing:
 
 | File | Tests |
 |------|-------|
 | `destructive-command-guard.test.ts` (updated) | 26 |
 | `destructive-command-windows.test.ts` (new) | 71 |
 | `destructive-command-lstat.test.ts` (new) | 36 |
-| `destructive-command-wrapper-unwrap.test.ts` (new) | 80 |
+| `destructive-command-wrapper-unwrap.test.ts` (new) | 82 |
 
 `bun run typecheck` clean. Two pre-existing, unrelated test failures in
 `save-plan-auto-checkpoint.test.ts` and `pre-check-batch-cwd.test.ts` are

--- a/src/hooks/guardrails.ts
+++ b/src/hooks/guardrails.ts
@@ -375,8 +375,10 @@ function dcNormalizeCommand(cmd: string): string {
 	// Carets outside quoted strings are escape characters; collapse all caret-letter sequences.
 	s = s.replace(/\^([a-zA-Z0-9 ])/g, '$1');
 
-	// Step 4: quote-splicing evasion e.g. r""m""dir — collapse doubled quotes
+	// Step 4: quote-splicing evasion e.g. r""m""dir or R''e''m''o''v''e''-''I''t''e''m
+	// Collapse both doubled double-quotes and doubled single-quotes (PS single-quote splice).
 	s = s.replace(/""/g, '');
+	s = s.replace(/''/g, '');
 
 	return s;
 }

--- a/src/hooks/guardrails.ts
+++ b/src/hooks/guardrails.ts
@@ -400,15 +400,16 @@ function dcStripOneWrapper(cmd: string): string | null {
 	const t = cmd.trim();
 
 	// cmd.exe wrappers: cmd /c "inner" or cmd /k "inner" — case-insensitive (CMD, cmd, Cmd)
-	const cmdExeMatch = /^cmd(?:\.exe)?\s+\/[ckCK]\s+"?(.*?)"?\s*$/si.exec(t);
+	const cmdExeMatch = /^cmd(?:\.exe)?\s+\/[ckCK]\s+"?(.*?)"?\s*$/is.exec(t);
 	if (cmdExeMatch) return cmdExeMatch[1].trim();
 
 	// PowerShell -Command / -c variants — case-insensitive (POWERSHELL, powershell, pwsh, PWSH)
 	const psCommandMatch =
-		/^(?:powershell|pwsh)(?:\.exe)?\s+(?:-(?:Command|command|c)\s+)(.+)$/si.exec(
+		/^(?:powershell|pwsh)(?:\.exe)?\s+(?:-(?:Command|command|c)\s+)(.+)$/is.exec(
 			t,
 		);
-	if (psCommandMatch) return psCommandMatch[1].replace(/^["']|["']$/g, '').trim();
+	if (psCommandMatch)
+		return psCommandMatch[1].replace(/^["']|["']$/g, '').trim();
 
 	// PowerShell -EncodedCommand / -enc (base64): decode and return
 	const psEncMatch =
@@ -426,7 +427,8 @@ function dcStripOneWrapper(cmd: string): string | null {
 	}
 
 	// bash/sh/zsh -c "inner"
-	const shellMatch = /^(?:bash|sh|zsh|dash|fish)(?:\.exe)?\s+-c\s+"?(.*?)"?\s*$/s.exec(t);
+	const shellMatch =
+		/^(?:bash|sh|zsh|dash|fish)(?:\.exe)?\s+-c\s+"?(.*?)"?\s*$/s.exec(t);
 	if (shellMatch) return shellMatch[1].trim();
 
 	// sudo / env VAR=val / time / nohup / nice -n N: strip leading word + optional args
@@ -450,7 +452,8 @@ function dcStripOneWrapper(cmd: string): string | null {
 	if (iexMatch) return iexMatch[1].replace(/^["'`]|["'`]$/g, '').trim();
 
 	// PowerShell Invoke-Command -ScriptBlock { ... }
-	const invokeCommandMatch = /^Invoke-Command\s+.*-ScriptBlock\s*\{(.+)\}$/is.exec(t);
+	const invokeCommandMatch =
+		/^Invoke-Command\s+.*-ScriptBlock\s*\{(.+)\}$/is.exec(t);
 	if (invokeCommandMatch) return invokeCommandMatch[1].trim();
 
 	// batch: call <command>
@@ -546,10 +549,7 @@ function dcIsRemotePath(p: string): boolean {
  * Skips silently on ENOENT (target does not exist — nothing to delete).
  * Fails closed on unexpected lstat errors.
  */
-function dcLstatAncestorWalk(
-	targetPath: string,
-	cwd: string,
-): string | null {
+function dcLstatAncestorWalk(targetPath: string, cwd: string): string | null {
 	// Normalize separators to the platform convention
 	const normalizedTarget = path.resolve(cwd, targetPath);
 	const normalizedCwd = path.resolve(cwd);
@@ -599,10 +599,7 @@ function dcLstatAncestorWalk(
  *
  * Returns a block reason string or null if targets are acceptable.
  */
-function dcValidateTargets(
-	targets: string[],
-	cwd: string,
-): string | null {
+function dcValidateTargets(targets: string[], cwd: string): string | null {
 	for (const raw of targets) {
 		const t = raw.trim().replace(/^["']|["']$/g, '');
 		if (!t || t === '.') continue;
@@ -666,10 +663,7 @@ function dcValidateTargets(
  *   New-Item -ItemType SymbolicLink -Path <link> -Target <target>
  *   ln -s <target> <link>  (when target is outside cwd)
  */
-function dcCheckJunctionCreation(
-	segment: string,
-	cwd: string,
-): string | null {
+function dcCheckJunctionCreation(segment: string, cwd: string): string | null {
 	// mklink /J or /D (cmd.exe)
 	const mklinkMatch =
 		/^mklink(?:\.exe)?\s+\/[JjDd]\s+"?([^"\s]+)"?\s+"?([^"\s]+)"?/i.exec(
@@ -705,7 +699,10 @@ function dcCheckJunctionCreation(
 	}
 
 	// ln -s <target> (POSIX symlink; only block if target is outside cwd)
-	const lnMatch = /^ln\s+(?:-[sfnv]*s[sfnv]*|-s)\s+"?([^"\s]+)"?(?:\s+"?[^"\s]+"?)?\s*$/.exec(segment);
+	const lnMatch =
+		/^ln\s+(?:-[sfnv]*s[sfnv]*|-s)\s+"?([^"\s]+)"?(?:\s+"?[^"\s]+"?)?\s*$/.exec(
+			segment,
+		);
 	if (lnMatch) {
 		const target = lnMatch[1].trim();
 		if (!dcHasUnresolvableVars(target) && path.isAbsolute(target)) {
@@ -726,11 +723,14 @@ function dcCheckJunctionCreation(
  */
 function dcExtractWindowsCmdTargets(segment: string): string[] {
 	// rmdir /s /q <path> or rd /s <path>
-	const rmdirMatch = /^(?:rmdir|rd)(?:\.exe)?\s+(?:\/[sqSQ]\s+)*"?(.+?)"?\s*$/i.exec(segment);
+	const rmdirMatch =
+		/^(?:rmdir|rd)(?:\.exe)?\s+(?:\/[sqSQ]\s+)*"?(.+?)"?\s*$/i.exec(segment);
 	if (rmdirMatch) return [rmdirMatch[1].trim()];
 
 	// del /s /q /f <path>
-	const delMatch = /^del(?:\.exe)?\s+(?:\/[sqfSQF]\s+)*"?(.+?)"?\s*$/i.exec(segment);
+	const delMatch = /^del(?:\.exe)?\s+(?:\/[sqfSQF]\s+)*"?(.+?)"?\s*$/i.exec(
+		segment,
+	);
 	if (delMatch) return [delMatch[1].trim()];
 
 	return [];
@@ -742,19 +742,23 @@ function dcExtractWindowsCmdTargets(segment: string): string[] {
  */
 function dcExtractPowerShellTargets(segment: string): string[] {
 	// Strip the leading verb
-	const verbMatch =
-		/^(?:Remove-Item|ri|rm|rmdir|del|erase|rd)\s+/i.exec(segment);
+	const verbMatch = /^(?:Remove-Item|ri|rm|rmdir|del|erase|rd)\s+/i.exec(
+		segment,
+	);
 	if (!verbMatch) return [];
 	const rest = segment.slice(verbMatch[0].length);
 
 	// Tokenize remainder; quoted strings count as one token
-	const tokens: string[] =
-		rest.match(/"[^"]*"|'[^']*'|[^\s]+/g) ?? [];
+	const tokens: string[] = rest.match(/"[^"]*"|'[^']*'|[^\s]+/g) ?? [];
 
 	const targets: string[] = [];
 	// Flags that consume the next token as a value
 	const valueFlags = new Set([
-		'-literalpath', '-path', '-filter', '-include', '-exclude',
+		'-literalpath',
+		'-path',
+		'-filter',
+		'-include',
+		'-exclude',
 		'-lp', // alias for -LiteralPath in PS 7+
 	]);
 	let skipNext = false;
@@ -936,8 +940,9 @@ export function createGuardrailsHooks(
 			// ----------------------------------------------------------------
 			const rmShortMatch =
 				/^rm\s+(-[rRfF]+(?:\s+-[rRfF]+)*|-r\s+-f|-f\s+-r)\s+(.+)$/.exec(seg);
-			const rmLongMatch =
-				/^rm\s+(?:--(?:recursive|force)\s+){1,2}(.+)$/.exec(seg);
+			const rmLongMatch = /^rm\s+(?:--(?:recursive|force)\s+){1,2}(.+)$/.exec(
+				seg,
+			);
 			const rmAnyMatch = rmShortMatch ?? rmLongMatch;
 			if (rmAnyMatch) {
 				const targetPart = rmAnyMatch[rmShortMatch ? 2 : 1].trim();
@@ -945,7 +950,9 @@ export function createGuardrailsHooks(
 				// Always validate — dcValidateTargets runs lstat even for safe-named targets
 				const validateBlock = dcValidateTargets(targets, cwd);
 				if (validateBlock) throw new Error(validateBlock);
-				const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.replace(/^["']|["']$/g, '').trim()));
+				const allSafe = targets.every((t) =>
+					DC_SAFE_TARGETS.has(t.replace(/^["']|["']$/g, '').trim()),
+				);
 				if (!allSafe) {
 					throw new Error(
 						`BLOCKED: Potentially destructive shell command: rm with recursive/force flags on unsafe path(s): ${targetPart}`,
@@ -1064,9 +1071,7 @@ export function createGuardrailsHooks(
 				/^fsutil(?:\.exe)?\s+reparsepoint\s+delete\b/i.test(seg) ||
 				/^fsutil(?:\.exe)?\s+file\s+setzerodata\b/i.test(seg)
 			) {
-				throw new Error(
-					`BLOCKED: "fsutil" destructive subcommand detected`,
-				);
+				throw new Error(`BLOCKED: "fsutil" destructive subcommand detected`);
 			}
 			if (/^takeown(?:\.exe)?\s+.*\/[rR]\b/i.test(seg)) {
 				throw new Error(
@@ -1079,9 +1084,7 @@ export function createGuardrailsHooks(
 				);
 			}
 			if (/^format\s+[A-Za-z]:/i.test(seg)) {
-				throw new Error(
-					`BLOCKED: Windows disk format command detected`,
-				);
+				throw new Error(`BLOCKED: Windows disk format command detected`);
 			}
 			if (/^robocopy(?:\.exe)?\s+.*\/(?:MIR|mir)\b/.test(seg)) {
 				throw new Error(
@@ -1149,9 +1152,7 @@ export function createGuardrailsHooks(
 			// ----------------------------------------------------------------
 			// 12. rsync mirror / sync with delete
 			// ----------------------------------------------------------------
-			if (
-				/^rsync\b.*--delete(?:-after|-before|-during|-delay)?\b/.test(seg)
-			) {
+			if (/^rsync\b.*--delete(?:-after|-before|-during|-delay)?\b/.test(seg)) {
 				throw new Error(
 					`BLOCKED: "rsync --delete" detected — can delete files in the destination. Verify source is not empty.`,
 				);

--- a/src/hooks/guardrails.ts
+++ b/src/hooks/guardrails.ts
@@ -428,21 +428,23 @@ function dcStripOneWrapper(cmd: string): string | null {
 		}
 	}
 
-	// bash/sh/zsh -c "inner"
+	// bash/sh/zsh -c "inner" — case-insensitive for consistency with other wrappers
 	const shellMatch =
-		/^(?:bash|sh|zsh|dash|fish)(?:\.exe)?\s+-c\s+"?(.*?)"?\s*$/s.exec(t);
+		/^(?:bash|sh|zsh|dash|fish)(?:\.exe)?\s+-c\s+"?(.*?)"?\s*$/is.exec(t);
 	if (shellMatch) return shellMatch[1].trim();
 
 	// sudo / env VAR=val / time / nohup / nice -n N: strip leading word + optional args
+	// Case-insensitive: SUDO, TIME, NOHUP are valid in encoded/obfuscated commands.
 	const prefixMatch =
-		/^(?:sudo|time|nohup)\s+(.+)$/s.exec(t) ??
-		/^env(?:\s+[A-Za-z_][A-Za-z0-9_]*=[^\s]*)*\s+(.+)$/s.exec(t) ??
-		/^nice\s+(?:-n\s+\d+\s+)?(.+)$/s.exec(t);
+		/^(?:sudo|time|nohup)\s+(.+)$/is.exec(t) ??
+		/^env(?:\s+[A-Za-z_][A-Za-z0-9_]*=[^\s]*)*\s+(.+)$/is.exec(t) ??
+		/^nice\s+(?:-n\s+\d+\s+)?(.+)$/is.exec(t);
 	if (prefixMatch) return prefixMatch[1].trim();
 
 	// WSL cross-OS bridge: wsl -e ... / wsl -- ... / wsl.exe -e ...
+	// Case-insensitive: WSL.EXE is commonly written uppercase on Windows.
 	// These execute commands in the Linux subsystem — paths like /mnt/c/ map to C:\
-	const wslMatch = /^wsl(?:\.exe)?\s+(?:-e|--)\s+(.+)$/s.exec(t);
+	const wslMatch = /^wsl(?:\.exe)?\s+(?:-e|--)\s+(.+)$/is.exec(t);
 	if (wslMatch) return wslMatch[1].trim();
 
 	// PowerShell script block: & { ... } or & { ... } ; & { ... }

--- a/src/hooks/guardrails.ts
+++ b/src/hooks/guardrails.ts
@@ -686,10 +686,13 @@ function dcCheckJunctionCreation(segment: string, cwd: string): string | null {
 	}
 
 	// New-Item -ItemType Junction|SymbolicLink (PowerShell)
-	const newItemMatch =
-		/New-Item\b.*-ItemType\s+(?:Junction|SymbolicLink|HardLink)\b.*-Target\s+"?([^"\s;]+)"?/i.exec(
+	// Parameters are order-independent in PS, so check for -ItemType and -Target independently.
+	const newItemTypeMatch =
+		/New-Item\b.*-ItemType\s+(?:Junction|SymbolicLink|HardLink)\b/i.test(
 			segment,
 		);
+	const newItemTargetMatch = /-Target\s+"?([^"\s;]+)"?/i.exec(segment);
+	const newItemMatch = newItemTypeMatch ? newItemTargetMatch : null;
 	if (newItemMatch) {
 		const target = newItemMatch[1].trim();
 		if (!dcHasUnresolvableVars(target)) {
@@ -702,17 +705,19 @@ function dcCheckJunctionCreation(segment: string, cwd: string): string | null {
 		return null;
 	}
 
-	// ln -s <target> (POSIX symlink; only block if target is outside cwd)
+	// ln -s <target> (POSIX symlink; block if target resolves outside cwd)
+	// Both absolute and relative targets are checked: ln -s ../sensitive dist escapes cwd.
 	const lnMatch =
 		/^ln\s+(?:-[sfnv]*s[sfnv]*|-s)\s+"?([^"\s]+)"?(?:\s+"?[^"\s]+"?)?\s*$/.exec(
 			segment,
 		);
 	if (lnMatch) {
 		const target = lnMatch[1].trim();
-		if (!dcHasUnresolvableVars(target) && path.isAbsolute(target)) {
-			const rel = path.relative(cwd, target);
+		if (!dcHasUnresolvableVars(target)) {
+			const resolved = path.resolve(cwd, target);
+			const rel = path.relative(cwd, resolved);
 			if (rel.startsWith('..') || path.isAbsolute(rel)) {
-				return `BLOCKED: Symlink creation targeting path outside working directory: ln -s target "${target}" is outside "${cwd}". Symlinks to external paths combined with recursive deletion can destroy data.`;
+				return `BLOCKED: Symlink creation targeting path outside working directory: ln -s target "${target}" resolves to "${resolved}" which is outside "${cwd}". Symlinks to external paths combined with recursive deletion can destroy data.`;
 			}
 		}
 		return null;

--- a/src/hooks/guardrails.ts
+++ b/src/hooks/guardrails.ts
@@ -268,6 +268,524 @@ function isInDeclaredScope(
 	});
 }
 
+// ============================================================================
+// PR A: Cross-platform destructive command protection helpers
+// ============================================================================
+
+/** Maximum recursion depth for wrapper unwrapping */
+const DC_MAX_UNWRAP_DEPTH = 5;
+
+/**
+ * Expanded safe-target allowlist for recursive delete operations.
+ * These directory names are safe to delete recursively by name alone.
+ * NOTE: Subdirectory paths like node_modules/.cache are NOT safe — the
+ * check requires the target be exactly one of these bare names.
+ */
+const DC_SAFE_TARGETS = new Set([
+	'node_modules',
+	'.git',
+	'dist',
+	'build',
+	'coverage',
+	'.next',
+	'.turbo',
+	'.cache',
+	'.venv',
+	'venv',
+	'__pycache__',
+	'target',
+	'out',
+	'.parcel-cache',
+	'.svelte-kit',
+	'.nuxt',
+	'.output',
+	'.angular',
+	'.gradle',
+	'vendor',
+]);
+
+/**
+ * Path prefixes that are unconditionally blocked as destructive targets.
+ * These represent filesystem roots and critical system directories.
+ */
+const DC_BLOCKED_ABSOLUTE_PREFIXES: readonly string[] = [
+	// POSIX roots
+	'/root',
+	'/home',
+	'/Users',
+	'/etc',
+	'/var',
+	'/usr',
+	'/opt',
+	'/bin',
+	'/sbin',
+	'/lib',
+	'/boot',
+	'/proc',
+	'/sys',
+	'/dev',
+	'/run',
+	'/System',
+	'/Library',
+	'/Applications',
+	// Windows roots (drive letters)
+	'C:\\Windows',
+	'C:\\Users',
+	'C:\\Program Files',
+	'C:\\ProgramData',
+	'C:/Windows',
+	'C:/Users',
+	'C:/Program Files',
+	'C:/ProgramData',
+];
+
+/** Filesystem roots that are always blocked outright */
+const DC_FS_ROOTS = new Set(['/', 'C:\\', 'C:/', 'D:\\', 'D:/', 'E:\\', 'E:/']);
+
+/** Path prefixes indicating a remote or network filesystem (best-effort) */
+const DC_REMOTE_PREFIXES: readonly string[] = [
+	'\\\\', // UNC paths e.g. \\server\share
+	'/Volumes/', // macOS external/network volumes
+	'/net/', // autofs network paths
+	'/nfs/', // explicit NFS mounts
+	'/smb/', // Samba mounts
+	'/run/user/', // user session mounts
+];
+
+/**
+ * Normalize a command string for pattern matching:
+ * 1. Unicode NFKC normalize (collapses homoglyphs)
+ * 2. Detect evasion techniques that exist only to defeat scanners
+ *
+ * When an evasion technique is detected, the decoded form is returned so
+ * that pattern matching can still fire on it. Only fails-closed when the
+ * evasion wraps a form we cannot safely decode.
+ */
+function dcNormalizeCommand(cmd: string): string {
+	// Step 1: NFKC — collapses Unicode fullwidth letters and homoglyphs
+	let s = cmd.normalize('NFKC');
+
+	// Step 2: PowerShell backtick escapes — PS uses ` as escape char inside strings.
+	// `r`m`d`i`r decodes to rmdir; R`e`m`o`v`e`-`I`t`e`m decodes to Remove-Item.
+	// In PS, backtick before ANY character produces that character (e.g. `- is just -).
+	// Strip all backtick-char pairs so pattern matching fires on the decoded form.
+	s = s.replace(/`(.)/g, '$1');
+
+	// Step 3: cmd.exe caret escapes — ^r^m^d^i^r decodes to rmdir.
+	// Carets outside quoted strings are escape characters; collapse all caret-letter sequences.
+	s = s.replace(/\^([a-zA-Z0-9 ])/g, '$1');
+
+	// Step 4: quote-splicing evasion e.g. r""m""dir — collapse doubled quotes
+	s = s.replace(/""/g, '');
+
+	return s;
+}
+
+/**
+ * Strip one layer of a shell wrapper from a command string.
+ * Returns the inner command if a wrapper was found, null otherwise.
+ *
+ * Handles:
+ *   - cmd /c "..."  cmd /k "..."
+ *   - powershell -Command "..." / -c "..." / -EncodedCommand <b64> / -enc <b64>
+ *   - pwsh -Command / -c / -EncodedCommand / -enc
+ *   - bash -c "..." / sh -c / zsh -c
+ *   - sudo <...> / env VAR=val <...> / time <...> / nohup <...>
+ *   - wsl -e ... / wsl -- ... / wsl.exe -e ...
+ *   - PowerShell & { ... } script blocks
+ *   - PowerShell iex / Invoke-Expression <...>
+ *   - call <...> (batch)
+ */
+function dcStripOneWrapper(cmd: string): string | null {
+	const t = cmd.trim();
+
+	// cmd.exe wrappers: cmd /c "inner" or cmd /k "inner" — case-insensitive (CMD, cmd, Cmd)
+	const cmdExeMatch = /^cmd(?:\.exe)?\s+\/[ckCK]\s+"?(.*?)"?\s*$/si.exec(t);
+	if (cmdExeMatch) return cmdExeMatch[1].trim();
+
+	// PowerShell -Command / -c variants — case-insensitive (POWERSHELL, powershell, pwsh, PWSH)
+	const psCommandMatch =
+		/^(?:powershell|pwsh)(?:\.exe)?\s+(?:-(?:Command|command|c)\s+)(.+)$/si.exec(
+			t,
+		);
+	if (psCommandMatch) return psCommandMatch[1].replace(/^["']|["']$/g, '').trim();
+
+	// PowerShell -EncodedCommand / -enc (base64): decode and return
+	const psEncMatch =
+		/^(?:powershell|pwsh)(?:\.exe)?\s+(?:-(?:EncodedCommand|encodedcommand|enc|e)\s+)([A-Za-z0-9+/=]+)\s*$/.exec(
+			t,
+		);
+	if (psEncMatch) {
+		try {
+			const decoded = Buffer.from(psEncMatch[1], 'base64').toString('utf16le');
+			return decoded.trim();
+		} catch {
+			// Cannot decode — fail closed by returning the original (pattern match will see -EncodedCommand)
+			return t;
+		}
+	}
+
+	// bash/sh/zsh -c "inner"
+	const shellMatch = /^(?:bash|sh|zsh|dash|fish)(?:\.exe)?\s+-c\s+"?(.*?)"?\s*$/s.exec(t);
+	if (shellMatch) return shellMatch[1].trim();
+
+	// sudo / env VAR=val / time / nohup / nice -n N: strip leading word + optional args
+	const prefixMatch =
+		/^(?:sudo|time|nohup)\s+(.+)$/s.exec(t) ??
+		/^env(?:\s+[A-Za-z_][A-Za-z0-9_]*=[^\s]*)*\s+(.+)$/s.exec(t) ??
+		/^nice\s+(?:-n\s+\d+\s+)?(.+)$/s.exec(t);
+	if (prefixMatch) return prefixMatch[1].trim();
+
+	// WSL cross-OS bridge: wsl -e ... / wsl -- ... / wsl.exe -e ...
+	// These execute commands in the Linux subsystem — paths like /mnt/c/ map to C:\
+	const wslMatch = /^wsl(?:\.exe)?\s+(?:-e|--)\s+(.+)$/s.exec(t);
+	if (wslMatch) return wslMatch[1].trim();
+
+	// PowerShell script block: & { ... } or & { ... } ; & { ... }
+	const scriptBlockMatch = /^&\s*\{(.+)\}$/s.exec(t);
+	if (scriptBlockMatch) return scriptBlockMatch[1].trim();
+
+	// PowerShell Invoke-Expression / iex
+	const iexMatch = /^(?:Invoke-Expression|iex)\s+(.+)$/is.exec(t);
+	if (iexMatch) return iexMatch[1].replace(/^["'`]|["'`]$/g, '').trim();
+
+	// PowerShell Invoke-Command -ScriptBlock { ... }
+	const invokeCommandMatch = /^Invoke-Command\s+.*-ScriptBlock\s*\{(.+)\}$/is.exec(t);
+	if (invokeCommandMatch) return invokeCommandMatch[1].trim();
+
+	// batch: call <command>
+	const callMatch = /^call\s+(.+)$/is.exec(t);
+	if (callMatch) return callMatch[1].trim();
+
+	return null;
+}
+
+/**
+ * Recursively unwrap all shell wrappers up to DC_MAX_UNWRAP_DEPTH.
+ * Returns the innermost unwrapped command.
+ */
+function dcUnwrapWrappers(cmd: string): string {
+	let current = cmd.trim();
+	for (let depth = 0; depth < DC_MAX_UNWRAP_DEPTH; depth++) {
+		const inner = dcStripOneWrapper(current);
+		if (inner === null || inner === current) break;
+		current = inner.trim();
+	}
+	return current;
+}
+
+/**
+ * Split a compound command into individual segments, splitting on:
+ *   ; && || | newlines
+ * Respects double-quoted strings (does not split inside quotes).
+ * Returns array of trimmed non-empty segments.
+ */
+function dcSplitSegments(cmd: string): string[] {
+	const segments: string[] = [];
+	let current = '';
+	let inDoubleQuote = false;
+	let inSingleQuote = false;
+
+	for (let i = 0; i < cmd.length; i++) {
+		const ch = cmd[i];
+		const next = cmd[i + 1];
+
+		if (ch === '"' && !inSingleQuote) {
+			inDoubleQuote = !inDoubleQuote;
+			current += ch;
+			continue;
+		}
+		if (ch === "'" && !inDoubleQuote) {
+			inSingleQuote = !inSingleQuote;
+			current += ch;
+			continue;
+		}
+
+		if (!inDoubleQuote && !inSingleQuote) {
+			// Check for && or ||
+			if ((ch === '&' && next === '&') || (ch === '|' && next === '|')) {
+				segments.push(current.trim());
+				current = '';
+				i++; // skip second char
+				continue;
+			}
+			// Single | (pipe) or ; or newline
+			if (ch === '|' || ch === ';' || ch === '\n' || ch === '\r') {
+				segments.push(current.trim());
+				current = '';
+				continue;
+			}
+		}
+		current += ch;
+	}
+	if (current.trim()) segments.push(current.trim());
+	return segments.filter((s) => s.length > 0);
+}
+
+/**
+ * Returns true if a path string contains unexpanded environment variable
+ * references that we cannot resolve at check time.
+ */
+function dcHasUnresolvableVars(p: string): boolean {
+	// %VAR% (cmd.exe), $VAR or ${VAR} or $env:VAR (PS/bash)
+	return /(%[A-Za-z_][A-Za-z0-9_]*%|\$\{?[A-Za-z_]|\$env:)/i.test(p);
+}
+
+/**
+ * Returns true if the path looks like a remote/network filesystem path.
+ */
+function dcIsRemotePath(p: string): boolean {
+	return DC_REMOTE_PREFIXES.some((pfx) => p.startsWith(pfx));
+}
+
+/**
+ * Walk from target path up to (but not beyond) cwd using synchronous lstat,
+ * checking each ancestor for symlinks, junctions, or reparse points.
+ *
+ * Returns a block reason string if a suspicious ancestor is found, null otherwise.
+ * Skips silently on ENOENT (target does not exist — nothing to delete).
+ * Fails closed on unexpected lstat errors.
+ */
+function dcLstatAncestorWalk(
+	targetPath: string,
+	cwd: string,
+): string | null {
+	// Normalize separators to the platform convention
+	const normalizedTarget = path.resolve(cwd, targetPath);
+	const normalizedCwd = path.resolve(cwd);
+
+	// Collect ancestor chain from target up to (and including) cwd
+	const ancestors: string[] = [];
+	let current = normalizedTarget;
+	while (true) {
+		ancestors.push(current);
+		const parent = path.dirname(current);
+		if (parent === current) break; // filesystem root
+		// Stop once we've gone past cwd
+		const rel = path.relative(normalizedCwd, current);
+		if (rel === '' || rel.startsWith('..')) break;
+		current = parent;
+	}
+
+	for (const ancestor of ancestors) {
+		let stat: ReturnType<typeof fsSync.lstatSync> | null = null;
+		try {
+			stat = fsSync.lstatSync(ancestor);
+		} catch (err: unknown) {
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code === 'ENOENT') {
+				// Target does not exist — nothing to delete at this point
+				break;
+			}
+			// Unexpected error (EPERM, EACCES, etc.) — fail closed
+			return `lstat failed on "${ancestor}": ${String(err)} — refusing to allow destructive operation on unverifiable path`;
+		}
+
+		if (stat.isSymbolicLink()) {
+			return `BLOCKED: "${ancestor}" is a symlink/junction — deleting recursively through it would destroy the link target. Use platform-specific junction deletion (fsutil reparsepoint delete, Remove-Item without -Recurse) instead.`;
+		}
+	}
+
+	return null; // all clear
+}
+
+/**
+ * Given a set of raw target strings from a destructive command, apply:
+ * 1. Unresolvable-var check (fail closed)
+ * 2. Safe-target allowlist check (allow through)
+ * 3. Remote filesystem check (block)
+ * 4. Unconditional system-path block
+ * 5. lstat ancestor walk (block on symlink/junction in chain)
+ *
+ * Returns a block reason string or null if targets are acceptable.
+ */
+function dcValidateTargets(
+	targets: string[],
+	cwd: string,
+): string | null {
+	for (const raw of targets) {
+		const t = raw.trim().replace(/^["']|["']$/g, '');
+		if (!t || t === '.') continue;
+
+		// Check for unexpanded vars — fail closed (cannot verify safety)
+		if (dcHasUnresolvableVars(t)) {
+			return `BLOCKED: Destructive command targets path with unexpanded variable "${t}" — cannot verify safety. Resolve variables before using destructive operations.`;
+		}
+
+		// Check remote filesystem prefixes
+		if (dcIsRemotePath(t)) {
+			return `BLOCKED: Destructive command targets remote/network filesystem path "${t}" — refusing to execute remote destructive operations.`;
+		}
+
+		// UNC path \\server\share or extended \\?\
+		if (/^\\\\/.test(t)) {
+			return `BLOCKED: Destructive command targets UNC path "${t}" — UNC paths in destructive operations are not allowed.`;
+		}
+
+		// lstat ancestor walk: MUST run before safe-target allowlist.
+		// An LLM can create a junction named "node_modules" (or "dist", etc.) pointing to
+		// important data, then run "rm -rf node_modules". Without this check, the safe-target
+		// allowlist would permit the deletion — this is the K2.6 incident mechanism replayed
+		// with a safe-named junction.
+		const lstatBlock = dcLstatAncestorWalk(t, cwd);
+		if (lstatBlock) return lstatBlock;
+
+		// Safe bare-name targets (after lstat confirms no junction/symlink): skip path checks
+		const basename = path.basename(t);
+		if (t === basename && DC_SAFE_TARGETS.has(t)) {
+			continue; // Allowed — lstat confirmed no junction/symlink in ancestor chain
+		}
+
+		// Filesystem roots — unconditional block
+		if (DC_FS_ROOTS.has(t) || DC_FS_ROOTS.has(t.replace(/\//g, '\\'))) {
+			return `BLOCKED: Destructive command targets filesystem root "${t}"`;
+		}
+
+		// Absolute path: check against blocked system prefixes
+		if (path.isAbsolute(t) || /^[A-Za-z]:/.test(t)) {
+			for (const blocked of DC_BLOCKED_ABSOLUTE_PREFIXES) {
+				if (t.startsWith(blocked)) {
+					return `BLOCKED: Destructive command targets system path "${t}" which is under protected prefix "${blocked}"`;
+				}
+			}
+		}
+	}
+	return null;
+}
+
+/**
+ * Detect Windows junction or symlink CREATION commands.
+ * Junction creation followed by recursive deletion of the junction is the
+ * exact mechanism of the K2.6 data-loss incident.
+ * Block junction/symlink creation where the target resolves outside cwd.
+ *
+ * Patterns covered:
+ *   mklink /J <link> <target>
+ *   mklink /D <link> <target>
+ *   New-Item -ItemType Junction -Path <link> -Target <target>
+ *   New-Item -ItemType SymbolicLink -Path <link> -Target <target>
+ *   ln -s <target> <link>  (when target is outside cwd)
+ */
+function dcCheckJunctionCreation(
+	segment: string,
+	cwd: string,
+): string | null {
+	// mklink /J or /D (cmd.exe)
+	const mklinkMatch =
+		/^mklink(?:\.exe)?\s+\/[JjDd]\s+"?([^"\s]+)"?\s+"?([^"\s]+)"?/i.exec(
+			segment,
+		);
+	if (mklinkMatch) {
+		const target = mklinkMatch[2].trim();
+		if (!dcHasUnresolvableVars(target)) {
+			const resolved = path.resolve(cwd, target);
+			const rel = path.relative(cwd, resolved);
+			if (rel.startsWith('..') || path.isAbsolute(rel)) {
+				return `BLOCKED: Junction/symlink creation targeting path outside working directory: mklink target "${target}" resolves to "${resolved}" which is outside "${cwd}". Creating junctions to external paths and then deleting them recursively can destroy data.`;
+			}
+		}
+		return null; // target is inside cwd — allow
+	}
+
+	// New-Item -ItemType Junction|SymbolicLink (PowerShell)
+	const newItemMatch =
+		/New-Item\b.*-ItemType\s+(?:Junction|SymbolicLink|HardLink)\b.*-Target\s+"?([^"\s;]+)"?/i.exec(
+			segment,
+		);
+	if (newItemMatch) {
+		const target = newItemMatch[1].trim();
+		if (!dcHasUnresolvableVars(target)) {
+			const resolved = path.resolve(cwd, target);
+			const rel = path.relative(cwd, resolved);
+			if (rel.startsWith('..') || path.isAbsolute(rel)) {
+				return `BLOCKED: Junction/symlink creation targeting path outside working directory: New-Item target "${target}" resolves to "${resolved}" which is outside "${cwd}". This pattern caused the K2.6 data-loss incident.`;
+			}
+		}
+		return null;
+	}
+
+	// ln -s <target> (POSIX symlink; only block if target is outside cwd)
+	const lnMatch = /^ln\s+(?:-[sfnv]*s[sfnv]*|-s)\s+"?([^"\s]+)"?(?:\s+"?[^"\s]+"?)?\s*$/.exec(segment);
+	if (lnMatch) {
+		const target = lnMatch[1].trim();
+		if (!dcHasUnresolvableVars(target) && path.isAbsolute(target)) {
+			const rel = path.relative(cwd, target);
+			if (rel.startsWith('..') || path.isAbsolute(rel)) {
+				return `BLOCKED: Symlink creation targeting path outside working directory: ln -s target "${target}" is outside "${cwd}". Symlinks to external paths combined with recursive deletion can destroy data.`;
+			}
+		}
+		return null;
+	}
+
+	return null;
+}
+
+/**
+ * Extract candidate target paths from a destructive Windows cmd.exe command.
+ * Returns array of path-like arguments.
+ */
+function dcExtractWindowsCmdTargets(segment: string): string[] {
+	// rmdir /s /q <path> or rd /s <path>
+	const rmdirMatch = /^(?:rmdir|rd)(?:\.exe)?\s+(?:\/[sqSQ]\s+)*"?(.+?)"?\s*$/i.exec(segment);
+	if (rmdirMatch) return [rmdirMatch[1].trim()];
+
+	// del /s /q /f <path>
+	const delMatch = /^del(?:\.exe)?\s+(?:\/[sqfSQF]\s+)*"?(.+?)"?\s*$/i.exec(segment);
+	if (delMatch) return [delMatch[1].trim()];
+
+	return [];
+}
+
+/**
+ * Extract candidate target paths from a destructive PowerShell command.
+ * Handles both `Remove-Item <path> -Recurse` and `Remove-Item -Recurse <path>` orderings.
+ */
+function dcExtractPowerShellTargets(segment: string): string[] {
+	// Strip the leading verb
+	const verbMatch =
+		/^(?:Remove-Item|ri|rm|rmdir|del|erase|rd)\s+/i.exec(segment);
+	if (!verbMatch) return [];
+	const rest = segment.slice(verbMatch[0].length);
+
+	// Tokenize remainder; quoted strings count as one token
+	const tokens: string[] =
+		rest.match(/"[^"]*"|'[^']*'|[^\s]+/g) ?? [];
+
+	const targets: string[] = [];
+	// Flags that consume the next token as a value
+	const valueFlags = new Set([
+		'-literalpath', '-path', '-filter', '-include', '-exclude',
+		'-lp', // alias for -LiteralPath in PS 7+
+	]);
+	let skipNext = false;
+	for (const tok of tokens) {
+		if (skipNext) {
+			skipNext = false;
+			continue;
+		}
+		if (tok.startsWith('-')) {
+			// Switch-like flags: -Recurse, -Force, -ErrorAction, -WhatIf etc.
+			if (valueFlags.has(tok.toLowerCase())) {
+				skipNext = true; // next token is the flag's value (a path) — capture it
+				// Don't push here; the *next* token IS the target path
+				// Re-enter loop with skipNext=false to capture it
+				const idx = tokens.indexOf(tok);
+				if (idx !== -1 && idx + 1 < tokens.length) {
+					const val = tokens[idx + 1].replace(/^["']|["']$/g, '');
+					if (val) targets.push(val);
+					skipNext = true; // skip the value token on next iteration
+				}
+			}
+			// else: plain switch flag like -Recurse, -Force — skip
+		} else {
+			// Non-flag positional argument → path target
+			const cleaned = tok.replace(/^["']|["']$/g, '');
+			if (cleaned) targets.push(cleaned);
+		}
+	}
+	return targets;
+}
+
 /**
  * Creates guardrails hooks for circuit breaker protection
  * @param directory Working directory from plugin init context (required)
@@ -356,91 +874,325 @@ export function createGuardrailsHooks(
 	/**
 	 * Check if a bash/shell command is potentially destructive and should be blocked.
 	 * Only active when block_destructive_commands is not false.
+	 *
+	 * PR A: Extended with cross-platform coverage:
+	 *   - Windows cmd.exe: rmdir /s, rd /s, del /s /q, ransomware-grade commands
+	 *   - PowerShell: Remove-Item -Recurse and all PS aliases, -EncodedCommand
+	 *   - Shell wrapper unwrapping: cmd /c, powershell -Command, bash -c, sudo, wsl, iex
+	 *   - Normalization: NFKC, caret-escape, backtick-escape, quote-splicing
+	 *   - Runtime lstat-ancestor-walk on destructive targets
+	 *   - Junction/symlink creation with external targets
+	 *   - Remote filesystem path rejection
+	 *   - POSIX long-form flags (--recursive --force)
 	 */
 	function checkDestructiveCommand(tool: string, args: unknown): void {
 		if (tool !== 'bash' && tool !== 'shell') return;
 		if (cfg.block_destructive_commands === false) return;
 		const toolArgs = args as Record<string, unknown> | undefined;
-		const command =
+		const rawCommand =
 			typeof toolArgs?.command === 'string' ? toolArgs.command.trim() : '';
-		if (!command) return;
+		if (!rawCommand) return;
 
-		// Fork bomb patterns
+		const cwd = effectiveDirectory;
+
+		// --- Normalize the top-level command (NFKC + evasion collapse) ---
+		const command = dcNormalizeCommand(rawCommand);
+
+		// --- Fork bomb: check on whole command BEFORE splitting (splits break the pattern) ---
 		if (/:\s*\(\s*\)\s*\{[^}]*\|[^}]*:/.test(command)) {
 			throw new Error(
 				`BLOCKED: Potentially destructive shell command detected: fork bomb pattern`,
 			);
 		}
 
-		// rm -rf / rm -r -f with non-safe paths
-		const rmFlagPattern = /^rm\s+(-r\s+-f|-f\s+-r|-rf|-fr)\s+(.+)$/;
-		const rmMatch = rmFlagPattern.exec(command);
-		if (rmMatch) {
-			const targetPart = rmMatch[2].trim();
-			const targets = targetPart.split(/\s+/);
-			const safeTargets = /^(node_modules|\.git)$/;
-			const allSafe = targets.every((t) => safeTargets.test(t));
-			if (!allSafe) {
+		// --- Unwrap all shell wrappers to the innermost command ---
+		const unwrapped = dcUnwrapWrappers(command);
+
+		// --- Split compound command into segments ---
+		// We check both the outer (post-norm) and the innermost (post-unwrap) form
+		const outerSegments = dcSplitSegments(command);
+		const innerSegments = dcSplitSegments(unwrapped);
+		// Per-segment unwrapping: handles wrappers embedded inside compound commands,
+		// e.g. "echo hello && powershell -c 'Remove-Item -Recurse C:\target'"
+		const perSegmentUnwrapped = outerSegments.map((s) => dcUnwrapWrappers(s));
+		// Deduplicate while preserving order
+		const allSegments = [
+			...new Set([...outerSegments, ...innerSegments, ...perSegmentUnwrapped]),
+		];
+
+		for (const segment of allSegments) {
+			const seg = segment.trim();
+			if (!seg) continue;
+
+			// ----------------------------------------------------------------
+			// 2. Junction/symlink CREATION with out-of-cwd target
+			//    (must check before deletion patterns; creation is the setup step)
+			// ----------------------------------------------------------------
+			const junctionBlock = dcCheckJunctionCreation(seg, cwd);
+			if (junctionBlock) throw new Error(junctionBlock);
+
+			// ----------------------------------------------------------------
+			// 3. POSIX rm — short flags (-rf, -fr, -r -f) and long flags
+			// ----------------------------------------------------------------
+			const rmShortMatch =
+				/^rm\s+(-[rRfF]+(?:\s+-[rRfF]+)*|-r\s+-f|-f\s+-r)\s+(.+)$/.exec(seg);
+			const rmLongMatch =
+				/^rm\s+(?:--(?:recursive|force)\s+){1,2}(.+)$/.exec(seg);
+			const rmAnyMatch = rmShortMatch ?? rmLongMatch;
+			if (rmAnyMatch) {
+				const targetPart = rmAnyMatch[rmShortMatch ? 2 : 1].trim();
+				const targets = targetPart.split(/\s+/);
+				// Always validate — dcValidateTargets runs lstat even for safe-named targets
+				const validateBlock = dcValidateTargets(targets, cwd);
+				if (validateBlock) throw new Error(validateBlock);
+				const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.replace(/^["']|["']$/g, '').trim()));
+				if (!allSafe) {
+					throw new Error(
+						`BLOCKED: Potentially destructive shell command: rm with recursive/force flags on unsafe path(s): ${targetPart}`,
+					);
+				}
+			}
+
+			// ----------------------------------------------------------------
+			// 4. Windows cmd.exe: rmdir /s, rd /s
+			// ----------------------------------------------------------------
+			if (/^(?:rmdir|rd)(?:\.exe)?\s+.*\/[sS]/i.test(seg)) {
+				const targets = dcExtractWindowsCmdTargets(seg);
+				if (targets.length === 0) {
+					// Cannot extract target — fail closed
+					throw new Error(
+						`BLOCKED: Windows recursive directory delete (rmdir /s or rd /s) detected. Verify the target is not a junction/symlink.`,
+					);
+				}
+				// Always validate — dcValidateTargets runs lstat even for safe-named targets
+				const validateBlock = dcValidateTargets(targets, cwd);
+				if (validateBlock) throw new Error(validateBlock);
+				const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.trim()));
+				if (!allSafe) {
+					throw new Error(
+						`BLOCKED: Windows recursive directory delete on unsafe path(s): ${targets.join(', ')}`,
+					);
+				}
+			}
+
+			// ----------------------------------------------------------------
+			// 5. Windows cmd.exe: del /s /q /f
+			// ----------------------------------------------------------------
+			if (/^del(?:\.exe)?\s+.*\/[sS]/i.test(seg)) {
+				const targets = dcExtractWindowsCmdTargets(seg);
+				if (targets.length > 0) {
+					// Always validate — dcValidateTargets runs lstat even for safe-named targets
+					const validateBlock = dcValidateTargets(targets, cwd);
+					if (validateBlock) throw new Error(validateBlock);
+					const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.trim()));
+					if (!allSafe) {
+						throw new Error(
+							`BLOCKED: Windows recursive file delete (del /s) on unsafe path(s): ${targets.join(', ')}`,
+						);
+					}
+				}
+			}
+
+			// ----------------------------------------------------------------
+			// 6. PowerShell: Remove-Item / aliases with -Recurse
+			// ----------------------------------------------------------------
+			if (
+				/^(?:Remove-Item|ri|rm|rmdir|del|erase|rd)\b.*-[Rr]ecurse\b/i.test(
+					seg,
+				) ||
+				/^(?:Remove-Item|ri|rm|rmdir|del|erase|rd)\b.*-[Rr]\b/i.test(seg)
+			) {
+				const targets = dcExtractPowerShellTargets(seg);
+				if (targets.length > 0) {
+					// Always validate — dcValidateTargets runs lstat even for safe-named targets
+					const validateBlock = dcValidateTargets(targets, cwd);
+					if (validateBlock) throw new Error(validateBlock);
+					const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.trim()));
+					if (!allSafe) {
+						throw new Error(
+							`BLOCKED: PowerShell recursive delete on unsafe path(s): ${targets.join(', ')}`,
+						);
+					}
+				} else {
+					throw new Error(
+						`BLOCKED: PowerShell Remove-Item with -Recurse detected — cannot verify target safety`,
+					);
+				}
+			}
+
+			// ----------------------------------------------------------------
+			// 7. PowerShell: Get-ChildItem | Remove-Item -Recurse (pipe form)
+			// ----------------------------------------------------------------
+			if (
+				/Get-ChildItem\b.*\|\s*Remove-Item\b.*-[Rr]ecurse/i.test(seg) ||
+				/gci\b.*\|\s*ri\b.*-[Rr]ecurse/i.test(seg)
+			) {
 				throw new Error(
-					`BLOCKED: Potentially destructive shell command: rm -rf on unsafe path(s): ${targetPart}`,
+					`BLOCKED: PowerShell pipeline "Get-ChildItem | Remove-Item -Recurse" detected — verify target safety and avoid recursive deletion through symlinks/junctions`,
 				);
 			}
-		}
 
-		// git push --force or -f
-		if (/^git\s+push\b.*?(--force|-f)\b/.test(command)) {
-			throw new Error(
-				`BLOCKED: Force push detected — git push --force is not allowed`,
-			);
-		}
+			// ----------------------------------------------------------------
+			// 8. Ransomware-grade / disk-level destruction
+			// ----------------------------------------------------------------
+			if (/^vssadmin(?:\.exe)?\s+delete\b/i.test(seg)) {
+				throw new Error(
+					`BLOCKED: "vssadmin delete" detected — deletes Volume Shadow Copies (ransomware-grade operation)`,
+				);
+			}
+			if (/^wbadmin(?:\.exe)?\s+delete\b/i.test(seg)) {
+				throw new Error(
+					`BLOCKED: "wbadmin delete" detected — deletes Windows backup catalog (ransomware-grade operation)`,
+				);
+			}
+			if (/^diskpart(?:\.exe)?$/i.test(seg)) {
+				throw new Error(
+					`BLOCKED: "diskpart" detected — interactive disk partitioning tool`,
+				);
+			}
+			if (/^bcdedit(?:\.exe)?\s+\/delete\b/i.test(seg)) {
+				throw new Error(
+					`BLOCKED: "bcdedit /delete" detected — modifies Windows boot configuration`,
+				);
+			}
+			if (/^sdelete(?:\.exe)?\s+/i.test(seg)) {
+				throw new Error(
+					`BLOCKED: "sdelete" detected — secure file deletion (Sysinternals)`,
+				);
+			}
+			if (
+				/^fsutil(?:\.exe)?\s+reparsepoint\s+delete\b/i.test(seg) ||
+				/^fsutil(?:\.exe)?\s+file\s+setzerodata\b/i.test(seg)
+			) {
+				throw new Error(
+					`BLOCKED: "fsutil" destructive subcommand detected`,
+				);
+			}
+			if (/^takeown(?:\.exe)?\s+.*\/[rR]\b/i.test(seg)) {
+				throw new Error(
+					`BLOCKED: "takeown /R" (recursive ownership takeover) detected — often precedes destructive operations`,
+				);
+			}
+			if (/^cipher(?:\.exe)?\s+\/[wW]\b/i.test(seg)) {
+				throw new Error(
+					`BLOCKED: "cipher /w" detected — overwrites free disk space (data wipe operation)`,
+				);
+			}
+			if (/^format\s+[A-Za-z]:/i.test(seg)) {
+				throw new Error(
+					`BLOCKED: Windows disk format command detected`,
+				);
+			}
+			if (/^robocopy(?:\.exe)?\s+.*\/(?:MIR|mir)\b/.test(seg)) {
+				throw new Error(
+					`BLOCKED: "robocopy /MIR" (mirror) detected — can delete files in the destination that don't exist in the source`,
+				);
+			}
 
-		// git reset --hard
-		if (/^git\s+reset\s+--hard/.test(command)) {
-			throw new Error(
-				`BLOCKED: "git reset --hard" detected — use --soft or --mixed with caution`,
-			);
-		}
+			// ----------------------------------------------------------------
+			// 9. POSIX: chmod/chattr/icacls denial-of-service patterns
+			// ----------------------------------------------------------------
+			if (/^chmod\s+.*-[rR]\b.*000\b/.test(seg)) {
+				throw new Error(
+					`BLOCKED: "chmod -R 000" detected — removes all permissions recursively`,
+				);
+			}
+			if (/^chattr\s+.*\+i\b/.test(seg)) {
+				throw new Error(
+					`BLOCKED: "chattr +i" detected — makes files immutable`,
+				);
+			}
+			if (/^icacls(?:\.exe)?\s+.*\/deny\b/i.test(seg)) {
+				throw new Error(
+					`BLOCKED: "icacls /deny" detected — denies filesystem permissions`,
+				);
+			}
 
-		// git reset --mixed with target commit
-		if (/^git\s+reset\s+--mixed\s+\S+/.test(command)) {
-			throw new Error(
-				`BLOCKED: "git reset --mixed" with a target branch/commit is not allowed`,
-			);
-		}
+			// ----------------------------------------------------------------
+			// 10. dd data-wipe patterns
+			// ----------------------------------------------------------------
+			if (/^dd\b.*\bif=\/dev\/(zero|null|urandom)\b/.test(seg)) {
+				throw new Error(
+					`BLOCKED: "dd" with /dev/zero, /dev/null, or /dev/urandom as input detected — data wipe operation`,
+				);
+			}
 
-		// kubectl delete
-		if (/^kubectl\s+delete\b/.test(command)) {
-			throw new Error(
-				`BLOCKED: "kubectl delete" detected — destructive cluster operation`,
-			);
-		}
+			// ----------------------------------------------------------------
+			// 11. Git destructive operations
+			// ----------------------------------------------------------------
+			if (/^git\s+push\b.*?(--force|-f)\b/.test(seg)) {
+				throw new Error(
+					`BLOCKED: Force push detected — git push --force is not allowed`,
+				);
+			}
+			if (/^git\s+reset\s+--hard/.test(seg)) {
+				throw new Error(
+					`BLOCKED: "git reset --hard" detected — use --soft or --mixed with caution`,
+				);
+			}
+			if (/^git\s+reset\s+--mixed\s+\S+/.test(seg)) {
+				throw new Error(
+					`BLOCKED: "git reset --mixed" with a target branch/commit is not allowed`,
+				);
+			}
+			if (/^git\s+clean\s+.*-[fF].*[dD]/.test(seg)) {
+				throw new Error(
+					`BLOCKED: "git clean -fd" detected — permanently deletes untracked files and directories`,
+				);
+			}
+			if (/^git\s+worktree\s+remove\s+.*--force\b/i.test(seg)) {
+				throw new Error(
+					`BLOCKED: "git worktree remove --force" detected — can delete working tree contents`,
+				);
+			}
 
-		// docker system prune
-		if (/^docker\s+system\s+prune\b/.test(command)) {
-			throw new Error(
-				`BLOCKED: "docker system prune" detected — destructive container operation`,
-			);
-		}
+			// ----------------------------------------------------------------
+			// 12. rsync mirror / sync with delete
+			// ----------------------------------------------------------------
+			if (
+				/^rsync\b.*--delete(?:-after|-before|-during|-delay)?\b/.test(seg)
+			) {
+				throw new Error(
+					`BLOCKED: "rsync --delete" detected — can delete files in the destination. Verify source is not empty.`,
+				);
+			}
 
-		// SQL DROP TABLE/DATABASE/SCHEMA
-		if (/^\s*DROP\s+(TABLE|DATABASE|SCHEMA)\b/i.test(command)) {
-			throw new Error(
-				`BLOCKED: SQL DROP command detected — destructive database operation`,
-			);
-		}
+			// ----------------------------------------------------------------
+			// 13. kubectl / docker (existing patterns preserved)
+			// ----------------------------------------------------------------
+			if (/^kubectl\s+delete\b/.test(seg)) {
+				throw new Error(
+					`BLOCKED: "kubectl delete" detected — destructive cluster operation`,
+				);
+			}
+			if (/^docker\s+system\s+prune\b/.test(seg)) {
+				throw new Error(
+					`BLOCKED: "docker system prune" detected — destructive container operation`,
+				);
+			}
 
-		// SQL TRUNCATE TABLE
-		if (/^\s*TRUNCATE\s+TABLE\b/i.test(command)) {
-			throw new Error(
-				`BLOCKED: SQL TRUNCATE command detected — destructive database operation`,
-			);
-		}
+			// ----------------------------------------------------------------
+			// 14. SQL DDL (existing patterns preserved)
+			// ----------------------------------------------------------------
+			if (/^\s*DROP\s+(TABLE|DATABASE|SCHEMA)\b/i.test(seg)) {
+				throw new Error(
+					`BLOCKED: SQL DROP command detected — destructive database operation`,
+				);
+			}
+			if (/^\s*TRUNCATE\s+TABLE\b/i.test(seg)) {
+				throw new Error(
+					`BLOCKED: SQL TRUNCATE command detected — destructive database operation`,
+				);
+			}
 
-		// mkfs disk format
-		if (/^mkfs[./]/.test(command)) {
-			throw new Error(
-				`BLOCKED: Disk format command (mkfs) detected — disk formatting operation`,
-			);
+			// ----------------------------------------------------------------
+			// 15. Disk format (existing mkfs + new format X:)
+			// ----------------------------------------------------------------
+			if (/^mkfs[./]/.test(seg)) {
+				throw new Error(
+					`BLOCKED: Disk format command (mkfs) detected — disk formatting operation`,
+				);
+			}
 		}
 	}
 

--- a/tests/unit/hooks/destructive-command-guard.test.ts
+++ b/tests/unit/hooks/destructive-command-guard.test.ts
@@ -59,7 +59,7 @@ describe('destructive command guard', () => {
 			const input = makeBashInput('test-session', 'rm -rf /');
 			const output = makeBashOutput('rm -rf /');
 			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED: Potentially destructive shell command/,
+				/BLOCKED/,
 			);
 		});
 
@@ -69,7 +69,7 @@ describe('destructive command guard', () => {
 			const input = makeBashInput('test-session', 'rm -rf /important');
 			const output = makeBashOutput('rm -rf /important');
 			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED: Potentially destructive shell command/,
+				/BLOCKED/,
 			);
 		});
 
@@ -79,7 +79,7 @@ describe('destructive command guard', () => {
 			const input = makeBashInput('test-session', 'rm -rf src/ dist/');
 			const output = makeBashOutput('rm -rf src/ dist/');
 			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED: Potentially destructive shell command/,
+				/BLOCKED/,
 			);
 		});
 
@@ -89,17 +89,16 @@ describe('destructive command guard', () => {
 			const input = makeBashInput('test-session', 'rm -r -f /');
 			const output = makeBashOutput('rm -r -f /');
 			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED: Potentially destructive shell command/,
+				/BLOCKED/,
 			);
 		});
 
-		test('rm --recursive --force / → allowed (long-form flags not detected by current patterns)', async () => {
-			// Current patterns only detect -rf combined or -r/-f separate, not long-form --recursive --force
+		test('rm --recursive --force / → BLOCKED (long-form flags now detected)', async () => {
 			const config = defaultConfig();
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
 			const input = makeBashInput('test-session', 'rm --recursive --force /');
 			const output = makeBashOutput('rm --recursive --force /');
-			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		test('rm -rf node_modules/.cache → BLOCKED (node_modules/.cache is not safe)', async () => {
@@ -108,7 +107,7 @@ describe('destructive command guard', () => {
 			const input = makeBashInput('test-session', 'rm -rf node_modules/.cache');
 			const output = makeBashOutput('rm -rf node_modules/.cache');
 			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED: Potentially destructive shell command/,
+				/BLOCKED/,
 			);
 		});
 	});
@@ -254,7 +253,7 @@ describe('destructive command guard', () => {
 			};
 			const output = makeBashOutput('rm -rf /');
 			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED: Potentially destructive shell command/,
+				/BLOCKED/,
 			);
 		});
 	});

--- a/tests/unit/hooks/destructive-command-guard.test.ts
+++ b/tests/unit/hooks/destructive-command-guard.test.ts
@@ -58,9 +58,7 @@ describe('destructive command guard', () => {
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
 			const input = makeBashInput('test-session', 'rm -rf /');
 			const output = makeBashOutput('rm -rf /');
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		test('rm -rf /important → BLOCKED', async () => {
@@ -68,9 +66,7 @@ describe('destructive command guard', () => {
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
 			const input = makeBashInput('test-session', 'rm -rf /important');
 			const output = makeBashOutput('rm -rf /important');
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		test('rm -rf src/ dist/ → BLOCKED (multiple paths, src/ is not safe)', async () => {
@@ -78,9 +74,7 @@ describe('destructive command guard', () => {
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
 			const input = makeBashInput('test-session', 'rm -rf src/ dist/');
 			const output = makeBashOutput('rm -rf src/ dist/');
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		test('rm -r -f / → BLOCKED (reversed flags)', async () => {
@@ -88,9 +82,7 @@ describe('destructive command guard', () => {
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
 			const input = makeBashInput('test-session', 'rm -r -f /');
 			const output = makeBashOutput('rm -r -f /');
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		test('rm --recursive --force / → BLOCKED (long-form flags now detected)', async () => {
@@ -106,9 +98,7 @@ describe('destructive command guard', () => {
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
 			const input = makeBashInput('test-session', 'rm -rf node_modules/.cache');
 			const output = makeBashOutput('rm -rf node_modules/.cache');
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -252,9 +242,7 @@ describe('destructive command guard', () => {
 				callID: 'call-1',
 			};
 			const output = makeBashOutput('rm -rf /');
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 

--- a/tests/unit/hooks/destructive-command-lstat.test.ts
+++ b/tests/unit/hooks/destructive-command-lstat.test.ts
@@ -50,9 +50,10 @@ describe('junction and symlink creation blocking', () => {
 		// On Linux, path.resolve('/tmp', 'C:\\path') treats the Windows path as relative,
 		// so use a POSIX absolute path to reliably trigger the "outside cwd" detection.
 		// On Windows, C:\opencode\... is properly recognized as an absolute external path.
-		const externalTarget = process.platform === 'win32'
-			? 'C:\\opencode\\dist3\\DocumentQA'
-			: '/opt/opencode/dist3';
+		const externalTarget =
+			process.platform === 'win32'
+				? 'C:\\opencode\\dist3\\DocumentQA'
+				: '/opt/opencode/dist3';
 		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
 		const output = {
 			args: { command: `mklink /J link ${externalTarget}` },
@@ -66,9 +67,8 @@ describe('junction and symlink creation blocking', () => {
 	});
 
 	test('mklink /D with external absolute target → BLOCKED', async () => {
-		const externalTarget = process.platform === 'win32'
-			? 'C:\\Windows\\System32'
-			: '/opt/system32';
+		const externalTarget =
+			process.platform === 'win32' ? 'C:\\Windows\\System32' : '/opt/system32';
 		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
 		const output = {
 			args: { command: `mklink /D dirlink ${externalTarget}` },
@@ -82,9 +82,10 @@ describe('junction and symlink creation blocking', () => {
 	});
 
 	test('New-Item -ItemType Junction with external absolute target → BLOCKED', async () => {
-		const externalTarget = process.platform === 'win32'
-			? 'C:\\opencode\\dist3\\DocumentQA'
-			: '/opt/opencode/dist3';
+		const externalTarget =
+			process.platform === 'win32'
+				? 'C:\\opencode\\dist3\\DocumentQA'
+				: '/opt/opencode/dist3';
 		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
 		const output = {
 			args: {
@@ -100,9 +101,10 @@ describe('junction and symlink creation blocking', () => {
 	});
 
 	test('New-Item -ItemType SymbolicLink with external absolute target → BLOCKED', async () => {
-		const externalTarget = process.platform === 'win32'
-			? 'C:\\sensitive\\data'
-			: '/opt/sensitive/data';
+		const externalTarget =
+			process.platform === 'win32'
+				? 'C:\\sensitive\\data'
+				: '/opt/sensitive/data';
 		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
 		const output = {
 			args: {
@@ -546,9 +548,10 @@ describe('lstat ancestor walk — real symlink detection', () => {
 // ---------------------------------------------------------------------------
 describe('block_destructive_commands: false bypasses all guards', () => {
 	test('mklink /J with external target allowed when flag is false', async () => {
-		const externalTarget = process.platform === 'win32'
-			? 'C:\\opencode\\dist3\\DocumentQA'
-			: '/opt/opencode/dist3';
+		const externalTarget =
+			process.platform === 'win32'
+				? 'C:\\opencode\\dist3\\DocumentQA'
+				: '/opt/opencode/dist3';
 		const hooks = createGuardrailsHooks(
 			TEST_DIR,
 			undefined,

--- a/tests/unit/hooks/destructive-command-lstat.test.ts
+++ b/tests/unit/hooks/destructive-command-lstat.test.ts
@@ -1,7 +1,7 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { beforeEach, describe, expect, test } from 'bun:test';
 import type { GuardrailsConfig } from '../../../src/config/schema';
 import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
 import { resetSwarmState, startAgentSession } from '../../../src/state';

--- a/tests/unit/hooks/destructive-command-lstat.test.ts
+++ b/tests/unit/hooks/destructive-command-lstat.test.ts
@@ -1,0 +1,646 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { GuardrailsConfig } from '../../../src/config/schema';
+import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
+import { resetSwarmState, startAgentSession } from '../../../src/state';
+
+// Mirrored from destructive-command-guard.test.ts
+const TEST_DIR = '/tmp';
+
+function defaultConfig(
+	overrides?: Partial<GuardrailsConfig>,
+): GuardrailsConfig {
+	return {
+		enabled: true,
+		max_tool_calls: 200,
+		max_duration_minutes: 30,
+		idle_timeout_minutes: 60,
+		max_repetitions: 10,
+		max_consecutive_errors: 5,
+		warning_threshold: 0.75,
+		profiles: undefined,
+		block_destructive_commands: true,
+		...overrides,
+	};
+}
+
+function makeBashInput(sessionID = 'test-session', command: string) {
+	return { tool: 'bash', sessionID, callID: 'call-1' };
+}
+
+function makeBashOutput(command: string) {
+	return { args: { command } };
+}
+
+// Symlink creation requires elevated privileges on Windows — skip those tests there.
+const testUnlessWindows = process.platform === 'win32' ? test.skip : test;
+
+beforeEach(() => {
+	resetSwarmState();
+	startAgentSession('test-session', 'coder');
+});
+
+// ---------------------------------------------------------------------------
+// Group 1: Junction / symlink CREATION blocking
+// ---------------------------------------------------------------------------
+describe('junction and symlink creation blocking', () => {
+	test('mklink /J with external absolute target → BLOCKED', async () => {
+		// On Linux, path.resolve('/tmp', 'C:\\path') treats the Windows path as relative,
+		// so use a POSIX absolute path to reliably trigger the "outside cwd" detection.
+		// On Windows, C:\opencode\... is properly recognized as an absolute external path.
+		const externalTarget = process.platform === 'win32'
+			? 'C:\\opencode\\dist3\\DocumentQA'
+			: '/opt/opencode/dist3';
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = {
+			args: { command: `mklink /J link ${externalTarget}` },
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'c1' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('mklink /D with external absolute target → BLOCKED', async () => {
+		const externalTarget = process.platform === 'win32'
+			? 'C:\\Windows\\System32'
+			: '/opt/system32';
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = {
+			args: { command: `mklink /D dirlink ${externalTarget}` },
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'c1b' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('New-Item -ItemType Junction with external absolute target → BLOCKED', async () => {
+		const externalTarget = process.platform === 'win32'
+			? 'C:\\opencode\\dist3\\DocumentQA'
+			: '/opt/opencode/dist3';
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = {
+			args: {
+				command: `New-Item -ItemType Junction -Path link -Target ${externalTarget}`,
+			},
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'c2' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('New-Item -ItemType SymbolicLink with external absolute target → BLOCKED', async () => {
+		const externalTarget = process.platform === 'win32'
+			? 'C:\\sensitive\\data'
+			: '/opt/sensitive/data';
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = {
+			args: {
+				command: `New-Item -ItemType SymbolicLink -Path mylink -Target ${externalTarget}`,
+			},
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'c2b' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('ln -s /etc/passwd mylink → BLOCKED (POSIX absolute external target)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'ln -s /etc/passwd mylink' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'c3' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('ln -s /home/user/secrets mylink → BLOCKED (POSIX absolute external target)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'ln -s /home/user/secrets mylink' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'c3b' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('mklink /H hardlink (not a junction/symlink) → ALLOWED', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = {
+			args: { command: 'mklink /H hardlink.txt source.txt' },
+		};
+		// /H creates a hardlink — the guard only blocks /J and /D
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'c4' },
+				output,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('ln (no -s flag, hardlink) → ALLOWED', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'ln source.txt hardlink.txt' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'c4b' },
+				output,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('ln -s relative/inside target → ALLOWED (non-absolute target)', async () => {
+		// Non-absolute targets are not blocked — the guard only rejects absolute paths outside cwd
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'ln -s real-target mylink' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'c4c' },
+				output,
+			),
+		).resolves.toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Group 2: Unexpanded variable protection
+// ---------------------------------------------------------------------------
+describe('unexpanded variable protection', () => {
+	test('rmdir /s /q $releaseDir\\DocumentQA → BLOCKED (unexpanded bash var)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = {
+			args: { command: 'rmdir /s /q $releaseDir\\DocumentQA' },
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'v1' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('Remove-Item -Recurse $env:APPDATA\\target → BLOCKED (PS env var)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = {
+			args: { command: 'Remove-Item -Recurse $env:APPDATA\\target' },
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'v2' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('rm -rf %USERPROFILE%\\important → BLOCKED (cmd.exe percent var)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = {
+			args: { command: 'rm -rf %USERPROFILE%\\important' },
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'v3' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('rm -rf ${BUILD_DIR}/output → BLOCKED (bash braced var)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'rm -rf ${BUILD_DIR}/output' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'v4' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('rm -rf $TMPDIR/work → BLOCKED (bare $ var)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'rm -rf $TMPDIR/work' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'v5' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Group 3: System path blocking
+// ---------------------------------------------------------------------------
+describe('system path blocking', () => {
+	test('rmdir /s /q C:\\Windows → BLOCKED (Windows system root)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'rmdir /s /q C:\\Windows' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 's1' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('rmdir /s /q C:\\Users → BLOCKED (Windows Users protected prefix)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'rmdir /s /q C:\\Users' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 's2' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('rm -rf /etc → BLOCKED (POSIX /etc protected prefix)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'rm -rf /etc' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 's3' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('rm -rf /home → BLOCKED (POSIX /home protected prefix)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'rm -rf /home' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 's4' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('rm -rf /usr/local/bin → BLOCKED (under /usr protected prefix)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'rm -rf /usr/local/bin' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 's5' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('rm -rf /var/log → BLOCKED (under /var protected prefix)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'rm -rf /var/log' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 's6' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Group 4: POSIX long-form flags (--recursive --force)
+// ---------------------------------------------------------------------------
+describe('POSIX long-form flag detection', () => {
+	test('rm --recursive --force /important → BLOCKED (long-form flags, absolute path)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = {
+			args: { command: 'rm --recursive --force /important' },
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'lf1' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('rm --force --recursive /etc/cron.d → BLOCKED (reversed long-form, system path)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = {
+			args: { command: 'rm --force --recursive /etc/cron.d' },
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'lf2' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('rm --recursive node_modules → ALLOWED (safe bare target)', async () => {
+		// rmLongMatch captures 1–2 occurrences of --recursive/--force then the target.
+		// node_modules is in DC_SAFE_TARGETS so it is allowed unconditionally.
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'rm --recursive node_modules' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'lf3' },
+				output,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('rm --recursive dist → ALLOWED (safe bare target)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'rm --recursive dist' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'lf4' },
+				output,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('rm --recursive --force src/generated → BLOCKED (unsafe relative path with long flags)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = {
+			args: { command: 'rm --recursive --force src/generated' },
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'lf5' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Group 5: Real symlink detection via lstat ancestor walk
+// ---------------------------------------------------------------------------
+describe('lstat ancestor walk — real symlink detection', () => {
+	testUnlessWindows(
+		'rm -rf on a direct symlink directory → BLOCKED via lstat (symlink detected)',
+		async () => {
+			// Use realpathSync so that macOS /tmp → /private/tmp does not cause
+			// a cwd/lstat mismatch when path.resolve() is called inside the guard.
+			const tmpDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-lstat-')),
+			);
+			const realTarget = path.join(tmpDir, 'real-target');
+			const symlinkName = 'symlink-dir';
+			const symlinkPath = path.join(tmpDir, symlinkName);
+			try {
+				fs.mkdirSync(realTarget, { recursive: true });
+				fs.symlinkSync(realTarget, symlinkPath, 'dir');
+
+				const hooks = createGuardrailsHooks(tmpDir, undefined, defaultConfig());
+				const output = { args: { command: `rm -rf ${symlinkName}` } };
+				await expect(
+					hooks.toolBefore(
+						{ tool: 'bash', sessionID: 'test-session', callID: 'c10' },
+						output,
+					),
+				).rejects.toThrow(/BLOCKED.*symlink/i);
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		},
+	);
+
+	testUnlessWindows(
+		'rm -rf on a path whose ancestor directory is a symlink → BLOCKED via lstat',
+		async () => {
+			const tmpDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-lstat-anc-')),
+			);
+			const realTarget = path.join(tmpDir, 'real-target');
+			const symlinkName = 'sym-parent';
+			const symlinkPath = path.join(tmpDir, symlinkName);
+			try {
+				// Create the subdirectory INSIDE the real target so that sym-parent/subdir
+				// resolves through the symlink. This allows lstat to succeed on the leaf
+				// (via symlink traversal for non-final path components), then detect the
+				// symlink at the ancestor (sym-parent) on the walk upward.
+				fs.mkdirSync(path.join(realTarget, 'subdir'), { recursive: true });
+				fs.symlinkSync(realTarget, symlinkPath, 'dir');
+
+				const hooks = createGuardrailsHooks(tmpDir, undefined, defaultConfig());
+				// sym-parent/subdir exists (through the symlink). The lstat walk:
+				// 1. lstat(tmpDir/sym-parent/subdir) → dir (follows sym-parent symlink for intermediate)
+				// 2. lstat(tmpDir/sym-parent) → symlink → BLOCKED
+				const output = {
+					args: { command: `rm -rf ${symlinkName}/subdir` },
+				};
+				await expect(
+					hooks.toolBefore(
+						{ tool: 'bash', sessionID: 'test-session', callID: 'c11' },
+						output,
+					),
+				).rejects.toThrow(/BLOCKED.*symlink/i);
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		},
+	);
+
+	testUnlessWindows(
+		'rm -rf on a real (non-symlink) directory → BLOCKED by generic unsafe-path rule, NOT by symlink check',
+		async () => {
+			const tmpDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-lstat-real-')),
+			);
+			const realDir = path.join(tmpDir, 'real-dir');
+			try {
+				fs.mkdirSync(realDir, { recursive: true });
+
+				const hooks = createGuardrailsHooks(tmpDir, undefined, defaultConfig());
+				// 'real-dir' is a plain directory, not in DC_SAFE_TARGETS.
+				// The guard MUST block it (generic unsafe-path rule) but the error
+				// must NOT mention symlink — that is the lstat-ancestor-walk path.
+				let caughtError: Error | null = null;
+				try {
+					await hooks.toolBefore(
+						{ tool: 'bash', sessionID: 'test-session', callID: 'c12' },
+						{ args: { command: 'rm -rf real-dir' } },
+					);
+				} catch (e) {
+					caughtError = e as Error;
+				}
+				expect(caughtError).not.toBeNull();
+				expect(caughtError?.message).toMatch(/BLOCKED/);
+				expect(caughtError?.message).not.toMatch(/symlink/i);
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		},
+	);
+
+	testUnlessWindows(
+		'rm -rf on a non-existent path → BLOCKED by generic rule (ENOENT silently skips lstat, not a symlink error)',
+		async () => {
+			const tmpDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-lstat-ne-')),
+			);
+			try {
+				const hooks = createGuardrailsHooks(tmpDir, undefined, defaultConfig());
+				// 'does-not-exist' does not exist — lstat gets ENOENT and breaks out of the walk.
+				// The guard then falls through to the generic unsafe-path block.
+				let caughtError: Error | null = null;
+				try {
+					await hooks.toolBefore(
+						{ tool: 'bash', sessionID: 'test-session', callID: 'c13' },
+						{ args: { command: 'rm -rf does-not-exist' } },
+					);
+				} catch (e) {
+					caughtError = e as Error;
+				}
+				expect(caughtError).not.toBeNull();
+				expect(caughtError?.message).toMatch(/BLOCKED/);
+				expect(caughtError?.message).not.toMatch(/symlink/i);
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		},
+	);
+
+	testUnlessWindows(
+		'rm -rf node_modules where node_modules is a real symlink → BLOCKED (lstat runs before safe-list)',
+		async () => {
+			// lstat ancestor walk now runs BEFORE the DC_SAFE_TARGETS allowlist check,
+			// so a symlinked node_modules is blocked even though "node_modules" is a safe name.
+			// This prevents the K2.6 replay: mklink /J node_modules C:\important && rm -rf node_modules.
+			const tmpDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-lstat-safe-')),
+			);
+			const realTarget = path.join(tmpDir, 'real-node-modules');
+			const symlinkPath = path.join(tmpDir, 'node_modules');
+			try {
+				fs.mkdirSync(realTarget, { recursive: true });
+				fs.symlinkSync(realTarget, symlinkPath, 'dir');
+
+				const hooks = createGuardrailsHooks(tmpDir, undefined, defaultConfig());
+				const output = { args: { command: 'rm -rf node_modules' } };
+				await expect(
+					hooks.toolBefore(
+						{ tool: 'bash', sessionID: 'test-session', callID: 'c14' },
+						output,
+					),
+				).rejects.toThrow(/BLOCKED/);
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		},
+	);
+});
+
+// ---------------------------------------------------------------------------
+// Group 6: block_destructive_commands: false bypasses all guards
+// ---------------------------------------------------------------------------
+describe('block_destructive_commands: false bypasses all guards', () => {
+	test('mklink /J with external target allowed when flag is false', async () => {
+		const externalTarget = process.platform === 'win32'
+			? 'C:\\opencode\\dist3\\DocumentQA'
+			: '/opt/opencode/dist3';
+		const hooks = createGuardrailsHooks(
+			TEST_DIR,
+			undefined,
+			defaultConfig({ block_destructive_commands: false }),
+		);
+		const output = {
+			args: { command: `mklink /J link ${externalTarget}` },
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'bypass1' },
+				output,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('ln -s /etc/passwd mylink allowed when flag is false', async () => {
+		const hooks = createGuardrailsHooks(
+			TEST_DIR,
+			undefined,
+			defaultConfig({ block_destructive_commands: false }),
+		);
+		const output = { args: { command: 'ln -s /etc/passwd mylink' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'bypass2' },
+				output,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('rm -rf /etc allowed when flag is false', async () => {
+		const hooks = createGuardrailsHooks(
+			TEST_DIR,
+			undefined,
+			defaultConfig({ block_destructive_commands: false }),
+		);
+		const output = { args: { command: 'rm -rf /etc' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'bypass3' },
+				output,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('rm -rf $VAR/path allowed when flag is false (unexpanded var bypass)', async () => {
+		const hooks = createGuardrailsHooks(
+			TEST_DIR,
+			undefined,
+			defaultConfig({ block_destructive_commands: false }),
+		);
+		const output = { args: { command: 'rm -rf $VAR/path' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'bypass4' },
+				output,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('Remove-Item -Recurse $env:APPDATA allowed when flag is false', async () => {
+		const hooks = createGuardrailsHooks(
+			TEST_DIR,
+			undefined,
+			defaultConfig({ block_destructive_commands: false }),
+		);
+		const output = {
+			args: { command: 'Remove-Item -Recurse $env:APPDATA' },
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'bypass5' },
+				output,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('rm --recursive --force /important allowed when flag is false', async () => {
+		const hooks = createGuardrailsHooks(
+			TEST_DIR,
+			undefined,
+			defaultConfig({ block_destructive_commands: false }),
+		);
+		const output = {
+			args: { command: 'rm --recursive --force /important' },
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'bypass6' },
+				output,
+			),
+		).resolves.toBeUndefined();
+	});
+});

--- a/tests/unit/hooks/destructive-command-lstat.test.ts
+++ b/tests/unit/hooks/destructive-command-lstat.test.ts
@@ -166,8 +166,9 @@ describe('junction and symlink creation blocking', () => {
 		).resolves.toBeUndefined();
 	});
 
-	test('ln -s relative/inside target → ALLOWED (non-absolute target)', async () => {
-		// Non-absolute targets are not blocked — the guard only rejects absolute paths outside cwd
+	test('ln -s relative/inside target → ALLOWED (resolves inside cwd)', async () => {
+		// Relative target that stays inside cwd is allowed.
+		// path.resolve(TEST_DIR='/tmp', 'real-target') = '/tmp/real-target' — inside cwd.
 		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
 		const output = { args: { command: 'ln -s real-target mylink' } };
 		await expect(
@@ -176,6 +177,66 @@ describe('junction and symlink creation blocking', () => {
 				output,
 			),
 		).resolves.toBeUndefined();
+	});
+
+	test('ln -s ../outside mylink → BLOCKED (relative path escaping cwd)', async () => {
+		// path.resolve('/tmp', '../outside') = '/outside' which is outside /tmp → BLOCKED
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'ln -s ../outside mylink' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'c4d' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('ln -s ../../etc/passwd mylink → BLOCKED (deep relative path escaping cwd)', async () => {
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = { args: { command: 'ln -s ../../etc/passwd mylink' } };
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'c4e' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('New-Item -Target /opt/sensitive -ItemType Junction -Path dist → BLOCKED (Target before ItemType)', async () => {
+		// PS params are order-independent; -Target before -ItemType must still be caught
+		const externalTarget =
+			process.platform === 'win32'
+				? 'C:\\opencode\\dist3\\DocumentQA'
+				: '/opt/sensitive/data';
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = {
+			args: {
+				command: `New-Item -Target ${externalTarget} -ItemType Junction -Path dist`,
+			},
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'c4f' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
+	});
+
+	test('New-Item -Path mylink -Target /opt/secret -ItemType SymbolicLink → BLOCKED (Target before ItemType)', async () => {
+		const externalTarget =
+			process.platform === 'win32' ? 'C:\\sensitive\\data' : '/opt/secret';
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+		const output = {
+			args: {
+				command: `New-Item -Path mylink -Target ${externalTarget} -ItemType SymbolicLink`,
+			},
+		};
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 'test-session', callID: 'c4g' },
+				output,
+			),
+		).rejects.toThrow(/BLOCKED/);
 	});
 });
 

--- a/tests/unit/hooks/destructive-command-windows.test.ts
+++ b/tests/unit/hooks/destructive-command-windows.test.ts
@@ -1,0 +1,896 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { GuardrailsConfig } from '../../../src/config/schema';
+import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
+import { resetSwarmState, startAgentSession } from '../../../src/state';
+
+const TEST_DIR = '/tmp';
+
+function defaultConfig(
+	overrides?: Partial<GuardrailsConfig>,
+): GuardrailsConfig {
+	return {
+		enabled: true,
+		max_tool_calls: 200,
+		max_duration_minutes: 30,
+		idle_timeout_minutes: 60,
+		max_repetitions: 10,
+		max_consecutive_errors: 5,
+		warning_threshold: 0.75,
+		profiles: undefined,
+		block_destructive_commands: true,
+		...overrides,
+	};
+}
+
+function makeBashInput(sessionID = 'test-session', _command?: string) {
+	return { tool: 'bash', sessionID, callID: 'call-1' };
+}
+
+function makeBashOutput(command: string) {
+	return { args: { command } };
+}
+
+describe('Windows cmd.exe destructive command guard (adversarial)', () => {
+	beforeEach(() => {
+		resetSwarmState();
+		startAgentSession('test-session', 'coder');
+	});
+
+	// ----------------------------------------------------------------
+	// rmdir /s — canonical and adversarial variants
+	// ----------------------------------------------------------------
+	describe('rmdir /s /q — canonical and adversarial variants', () => {
+		test('rmdir /s /q C:\\target → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'rmdir /s /q C:\\target');
+			const output = makeBashOutput('rmdir /s /q C:\\target');
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		test('rd /S /Q some-path → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'rd /S /Q some-path');
+			const output = makeBashOutput('rd /S /Q some-path');
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// Uppercase command — cmd.exe is case-insensitive
+		test('RMDIR /S /Q important_files → BLOCKED (all-caps command)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'RMDIR /S /Q important_files');
+			const output = makeBashOutput('RMDIR /S /Q important_files');
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// Uppercase RD alias
+		test('RD /s path → BLOCKED (uppercase RD alias)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'RD /s path');
+			const output = makeBashOutput('RD /s path');
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// Path with spaces (quoted)
+		test('rmdir /s /q "C:\\My Documents\\target" → BLOCKED (quoted path with spaces)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'rmdir /s /q "C:\\My Documents\\target"';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// Extra whitespace between flags
+		test('rmdir  /s  /q  C:\\target → BLOCKED (extra whitespace)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'rmdir  /s  /q  C:\\target';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// .exe suffix variant
+		test('rmdir.exe /s /q C:\\target → BLOCKED (.exe suffix)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'rmdir.exe /s /q C:\\target';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// Safe target: node_modules → ALLOWED
+		test('rmdir /s node_modules → ALLOWED (safe target)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'rmdir /s node_modules');
+			const output = makeBashOutput('rmdir /s node_modules');
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+
+		// Safe target: dist → ALLOWED
+		test('rmdir /s /q dist → ALLOWED (safe target)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'rmdir /s /q dist');
+			const output = makeBashOutput('rmdir /s /q dist');
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+	});
+
+	// ----------------------------------------------------------------
+	// del /s /q /f — canonical and adversarial variants
+	// ----------------------------------------------------------------
+	describe('del /s /q /f — canonical and adversarial variants', () => {
+		test('del /s /q /f important_files → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'del /s /q /f important_files');
+			const output = makeBashOutput('del /s /q /f important_files');
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// Uppercase flags
+		test('del /S /Q /F C:\\target → BLOCKED (uppercase flags)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'del /S /Q /F C:\\target';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// .exe suffix
+		test('del.exe /s /q /f important_files → BLOCKED (.exe suffix)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'del.exe /s /q /f important_files';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	// ----------------------------------------------------------------
+	// Ransomware-grade / disk-level Windows commands
+	// ----------------------------------------------------------------
+	describe('vssadmin delete — volume shadow copy wipe', () => {
+		test('vssadmin delete shadows /all → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'vssadmin delete shadows /all';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED.*vssadmin delete/i,
+			);
+		});
+
+		// Uppercase command
+		test('VSSADMIN DELETE shadows /all → BLOCKED (uppercase)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'VSSADMIN DELETE shadows /all';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// .exe suffix
+		test('vssadmin.exe delete shadows /all → BLOCKED (.exe suffix)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'vssadmin.exe delete shadows /all';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	describe('wbadmin delete catalog — backup wipe', () => {
+		test('wbadmin delete catalog → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'wbadmin delete catalog';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED.*wbadmin delete/i,
+			);
+		});
+
+		// .exe suffix
+		test('wbadmin.exe delete catalog → BLOCKED (.exe suffix)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'wbadmin.exe delete catalog';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	describe('diskpart — interactive disk partitioner', () => {
+		test('diskpart → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'diskpart');
+			const output = makeBashOutput('diskpart');
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED.*diskpart/i,
+			);
+		});
+
+		// Uppercase
+		test('DISKPART → BLOCKED (uppercase)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'DISKPART');
+			const output = makeBashOutput('DISKPART');
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// .exe suffix
+		test('diskpart.exe → BLOCKED (.exe suffix)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'diskpart.exe');
+			const output = makeBashOutput('diskpart.exe');
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	describe('bcdedit /delete — boot configuration wipe', () => {
+		test('bcdedit /delete {guid} → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'bcdedit /delete {12345678-1234-1234-1234-123456789abc}';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED.*bcdedit/i,
+			);
+		});
+
+		// Uppercase flag
+		test('bcdedit /DELETE {guid} → BLOCKED (uppercase flag)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'bcdedit /DELETE {12345678-1234-1234-1234-123456789abc}';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// .exe suffix
+		test('bcdedit.exe /delete {guid} → BLOCKED (.exe suffix)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'bcdedit.exe /delete {12345678-1234-1234-1234-123456789abc}';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	describe('sdelete — Sysinternals secure wipe', () => {
+		test('sdelete -p 3 file.txt → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'sdelete -p 3 file.txt';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED.*sdelete/i,
+			);
+		});
+
+		// Uppercase command
+		test('SDELETE -p 3 file.txt → BLOCKED (uppercase)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'SDELETE -p 3 file.txt';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// .exe suffix
+		test('sdelete.exe -p 3 file.txt → BLOCKED (.exe suffix)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'sdelete.exe -p 3 file.txt';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	describe('fsutil reparsepoint delete — symlink/junction wipe', () => {
+		test('fsutil reparsepoint delete C:\\link → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'fsutil reparsepoint delete C:\\link';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED.*fsutil/i,
+			);
+		});
+
+		// Uppercase subcommands — adversarial: implementation uses case-insensitive regex
+		test('FSUTIL REPARSEPOINT DELETE C:\\link → BLOCKED (all-uppercase subcommands)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'FSUTIL REPARSEPOINT DELETE C:\\link';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// Mixed case subcommands
+		test('fsutil REPARSEPOINT DELETE C:\\link → BLOCKED (mixed case subcommands)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'fsutil REPARSEPOINT DELETE C:\\link';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// .exe suffix
+		test('fsutil.exe reparsepoint delete C:\\link → BLOCKED (.exe suffix)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'fsutil.exe reparsepoint delete C:\\link';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	describe('takeown /R — recursive ownership takeover', () => {
+		test('takeown /R /F C:\\target → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'takeown /R /F C:\\target';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED.*takeown/i,
+			);
+		});
+
+		// Lowercase /r flag — adversarial: implementation uses /[rR]/ character class
+		test('takeown /r /f C:\\target → BLOCKED (lowercase flags)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'takeown /r /f C:\\target';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// .exe suffix
+		test('takeown.exe /R /F C:\\target → BLOCKED (.exe suffix)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'takeown.exe /R /F C:\\target';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	describe('cipher /w — free-space wipe', () => {
+		test('cipher /w:C:\\temp → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'cipher /w:C:\\temp';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED.*cipher/i,
+			);
+		});
+
+		// Uppercase flag — adversarial: implementation uses /[wW]/
+		test('cipher /W:C:\\temp → BLOCKED (uppercase /W)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'cipher /W:C:\\temp';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// .exe suffix
+		test('cipher.exe /w:C:\\temp → BLOCKED (.exe suffix)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'cipher.exe /w:C:\\temp';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	describe('format C: — disk format', () => {
+		test('format C: → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'format C:';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED.*format/i,
+			);
+		});
+
+		// Uppercase — adversarial: implementation uses case-insensitive /i flag
+		test('FORMAT C: → BLOCKED (uppercase)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'FORMAT C:';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// Different drive letters — adversarial: pattern uses [A-Za-z]: so all drives covered
+		test('format D: → BLOCKED (drive D)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'format D:';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// Lowercase drive letter
+		test('format c: → BLOCKED (lowercase drive letter)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'format c:';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	describe('robocopy /MIR — mirror delete', () => {
+		test('robocopy /MIR empty dest → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'robocopy /MIR empty dest';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED.*robocopy/i,
+			);
+		});
+
+		// Lowercase /mir — adversarial: implementation pattern uses (?:MIR|mir) so
+		// mixed case like /Mir would slip through; /mir and /MIR are both covered
+		test('robocopy src dest /mir → BLOCKED (lowercase /mir)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'robocopy src dest /mir';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// .exe suffix
+		test('robocopy.exe /MIR empty dest → BLOCKED (.exe suffix)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'robocopy.exe /MIR empty dest';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	describe('icacls /deny — permission denial', () => {
+		test('icacls C:\\path /deny Everyone:(OI)(CI)F → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'icacls C:\\path /deny Everyone:(OI)(CI)F';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED.*icacls/i,
+			);
+		});
+
+		// Uppercase /DENY — adversarial: implementation uses /deny\b with case-insensitive flag
+		test('icacls C:\\path /DENY Everyone:(OI)(CI)F → BLOCKED (uppercase /DENY)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'icacls C:\\path /DENY Everyone:(OI)(CI)F';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// .exe suffix
+		test('icacls.exe C:\\path /deny Everyone:(OI)(CI)F → BLOCKED (.exe suffix)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'icacls.exe C:\\path /deny Everyone:(OI)(CI)F';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	// ----------------------------------------------------------------
+	// Safe Windows commands that must NOT be blocked
+	// ----------------------------------------------------------------
+	describe('safe Windows read-only commands — must be ALLOWED', () => {
+		test('dir /s C:\\path → ALLOWED (read-only listing)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'dir /s C:\\path');
+			const output = makeBashOutput('dir /s C:\\path');
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+
+		test('copy /y src dest → ALLOWED (file copy, not delete)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'copy /y src dest');
+			const output = makeBashOutput('copy /y src dest');
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+	});
+});
+
+// ----------------------------------------------------------------
+// PowerShell destructive command guard (adversarial)
+// ----------------------------------------------------------------
+describe('PowerShell destructive command guard (adversarial)', () => {
+	beforeEach(() => {
+		resetSwarmState();
+		startAgentSession('test-session', 'coder');
+	});
+
+	describe('Remove-Item -Recurse — canonical and adversarial variants', () => {
+		test('Remove-Item -Recurse -Force C:\\target → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'Remove-Item -Recurse -Force C:\\target';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		test('Remove-Item C:\\target -Recurse → BLOCKED (flag after path)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'Remove-Item C:\\target -Recurse';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// PowerShell is case-insensitive; implementation regex uses /i flag
+		test('remove-item -recurse important_files → BLOCKED (all-lowercase PS cmdlet)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'remove-item -recurse important_files';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// REMOVE-ITEM all-caps — adversarial: must be caught by case-insensitive regex
+		test('REMOVE-ITEM -RECURSE important_files → BLOCKED (all-uppercase PS cmdlet)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'REMOVE-ITEM -RECURSE important_files';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// -R short form — adversarial: implementation checks /-[Rr]\b/ separately
+		test('Remove-Item -R C:\\path → BLOCKED (-R short form)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'Remove-Item -R C:\\path';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// Path with spaces (quoted) — adversarial: target extractor must handle quotes
+		test('Remove-Item -Recurse -Force "C:\\Program Files\\target" → BLOCKED (quoted path with spaces)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'Remove-Item -Recurse -Force "C:\\Program Files\\target"';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// Safe target: node_modules → ALLOWED
+		test('Remove-Item -Recurse node_modules → ALLOWED (safe target)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'Remove-Item -Recurse node_modules';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+	});
+
+	describe('PS alias ri — short form', () => {
+		test('ri -r C:\\path → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'ri -r C:\\path';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// Uppercase -R flag
+		test('ri -R C:\\path → BLOCKED (uppercase -R)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'ri -R C:\\path';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	describe('PS alias rm — Windows-path context', () => {
+		test('rm -r C:\\path → BLOCKED (PS rm alias, Windows path)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'rm -r C:\\path';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+
+	describe('Get-ChildItem | Remove-Item -Recurse — pipeline form', () => {
+		test('Get-ChildItem C:\\target | Remove-Item -Recurse → BLOCKED', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'Get-ChildItem C:\\target | Remove-Item -Recurse';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// Extra whitespace around pipe — adversarial: regex uses \|\s* so extra spaces must still match
+		test('Get-ChildItem C:\\target  |  Remove-Item -Recurse → BLOCKED (extra whitespace around pipe)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'Get-ChildItem C:\\target  |  Remove-Item -Recurse';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+
+		// gci | ri short aliases — adversarial: implementation has explicit gci/ri pattern
+		test('gci C:\\target | ri -Recurse → BLOCKED (gci | ri short aliases)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = 'gci C:\\target | ri -Recurse';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/BLOCKED/,
+			);
+		});
+	});
+});
+
+// ----------------------------------------------------------------
+// tool: 'shell' must trigger the same blocks as tool: 'bash'
+// ----------------------------------------------------------------
+describe('tool: shell — must trigger identical blocks', () => {
+	beforeEach(() => {
+		resetSwarmState();
+		startAgentSession('test-session', 'coder');
+	});
+
+	test('rmdir /s /q C:\\target blocked when tool is shell', async () => {
+		const config = defaultConfig();
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = { tool: 'shell', sessionID: 'test-session', callID: 'call-1' };
+		const output = makeBashOutput('rmdir /s /q C:\\target');
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			/BLOCKED/,
+		);
+	});
+
+	test('Remove-Item -Recurse -Force C:\\target blocked when tool is shell', async () => {
+		const config = defaultConfig();
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = { tool: 'shell', sessionID: 'test-session', callID: 'call-1' };
+		const output = makeBashOutput('Remove-Item -Recurse -Force C:\\target');
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			/BLOCKED/,
+		);
+	});
+
+	test('vssadmin delete shadows /all blocked when tool is shell', async () => {
+		const config = defaultConfig();
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = { tool: 'shell', sessionID: 'test-session', callID: 'call-1' };
+		const output = makeBashOutput('vssadmin delete shadows /all');
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			/BLOCKED/,
+		);
+	});
+
+	test('diskpart blocked when tool is shell', async () => {
+		const config = defaultConfig();
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = { tool: 'shell', sessionID: 'test-session', callID: 'call-1' };
+		const output = makeBashOutput('diskpart');
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			/BLOCKED/,
+		);
+	});
+
+	test('format C: blocked when tool is shell', async () => {
+		const config = defaultConfig();
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = { tool: 'shell', sessionID: 'test-session', callID: 'call-1' };
+		const output = makeBashOutput('format C:');
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			/BLOCKED/,
+		);
+	});
+});
+
+// ----------------------------------------------------------------
+// block_destructive_commands: false — must allow everything through
+// ----------------------------------------------------------------
+describe('block_destructive_commands: false — all Windows commands pass through', () => {
+	beforeEach(() => {
+		resetSwarmState();
+		startAgentSession('test-session', 'coder');
+	});
+
+	test('rmdir /s /q C:\\target allowed when block_destructive_commands is false', async () => {
+		const config = defaultConfig({ block_destructive_commands: false });
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = makeBashInput('test-session', 'rmdir /s /q C:\\target');
+		const output = makeBashOutput('rmdir /s /q C:\\target');
+		await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+	});
+
+	test('vssadmin delete shadows /all allowed when block_destructive_commands is false', async () => {
+		const config = defaultConfig({ block_destructive_commands: false });
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = makeBashInput('test-session', 'vssadmin delete shadows /all');
+		const output = makeBashOutput('vssadmin delete shadows /all');
+		await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+	});
+
+	test('diskpart allowed when block_destructive_commands is false', async () => {
+		const config = defaultConfig({ block_destructive_commands: false });
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = makeBashInput('test-session', 'diskpart');
+		const output = makeBashOutput('diskpart');
+		await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+	});
+
+	test('Remove-Item -Recurse -Force C:\\target allowed when block_destructive_commands is false', async () => {
+		const config = defaultConfig({ block_destructive_commands: false });
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = makeBashInput('test-session', 'Remove-Item -Recurse -Force C:\\target');
+		const output = makeBashOutput('Remove-Item -Recurse -Force C:\\target');
+		await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+	});
+
+	test('format C: allowed when block_destructive_commands is false', async () => {
+		const config = defaultConfig({ block_destructive_commands: false });
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = makeBashInput('test-session', 'format C:');
+		const output = makeBashOutput('format C:');
+		await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+	});
+});

--- a/tests/unit/hooks/destructive-command-windows.test.ts
+++ b/tests/unit/hooks/destructive-command-windows.test.ts
@@ -45,9 +45,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
 			const input = makeBashInput('test-session', 'rmdir /s /q C:\\target');
 			const output = makeBashOutput('rmdir /s /q C:\\target');
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		test('rd /S /Q some-path → BLOCKED', async () => {
@@ -55,20 +53,19 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
 			const input = makeBashInput('test-session', 'rd /S /Q some-path');
 			const output = makeBashOutput('rd /S /Q some-path');
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// Uppercase command — cmd.exe is case-insensitive
 		test('RMDIR /S /Q important_files → BLOCKED (all-caps command)', async () => {
 			const config = defaultConfig();
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
-			const input = makeBashInput('test-session', 'RMDIR /S /Q important_files');
-			const output = makeBashOutput('RMDIR /S /Q important_files');
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
+			const input = makeBashInput(
+				'test-session',
+				'RMDIR /S /Q important_files',
 			);
+			const output = makeBashOutput('RMDIR /S /Q important_files');
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// Uppercase RD alias
@@ -77,9 +74,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
 			const input = makeBashInput('test-session', 'RD /s path');
 			const output = makeBashOutput('RD /s path');
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// Path with spaces (quoted)
@@ -89,9 +84,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'rmdir /s /q "C:\\My Documents\\target"';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// Extra whitespace between flags
@@ -101,9 +94,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'rmdir  /s  /q  C:\\target';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// .exe suffix variant
@@ -113,9 +104,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'rmdir.exe /s /q C:\\target';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// Safe target: node_modules → ALLOWED
@@ -144,11 +133,12 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 		test('del /s /q /f important_files → BLOCKED', async () => {
 			const config = defaultConfig();
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
-			const input = makeBashInput('test-session', 'del /s /q /f important_files');
-			const output = makeBashOutput('del /s /q /f important_files');
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
+			const input = makeBashInput(
+				'test-session',
+				'del /s /q /f important_files',
 			);
+			const output = makeBashOutput('del /s /q /f important_files');
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// Uppercase flags
@@ -158,9 +148,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'del /S /Q /F C:\\target';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// .exe suffix
@@ -170,9 +158,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'del.exe /s /q /f important_files';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -198,9 +184,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'VSSADMIN DELETE shadows /all';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// .exe suffix
@@ -210,9 +194,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'vssadmin.exe delete shadows /all';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -235,9 +217,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'wbadmin.exe delete catalog';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -258,9 +238,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
 			const input = makeBashInput('test-session', 'DISKPART');
 			const output = makeBashOutput('DISKPART');
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// .exe suffix
@@ -269,9 +247,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
 			const input = makeBashInput('test-session', 'diskpart.exe');
 			const output = makeBashOutput('diskpart.exe');
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -294,9 +270,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'bcdedit /DELETE {12345678-1234-1234-1234-123456789abc}';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// .exe suffix
@@ -306,9 +280,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'bcdedit.exe /delete {12345678-1234-1234-1234-123456789abc}';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -331,9 +303,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'SDELETE -p 3 file.txt';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// .exe suffix
@@ -343,9 +313,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'sdelete.exe -p 3 file.txt';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -368,9 +336,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'FSUTIL REPARSEPOINT DELETE C:\\link';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// Mixed case subcommands
@@ -380,9 +346,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'fsutil REPARSEPOINT DELETE C:\\link';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// .exe suffix
@@ -392,9 +356,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'fsutil.exe reparsepoint delete C:\\link';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -417,9 +379,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'takeown /r /f C:\\target';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// .exe suffix
@@ -429,9 +389,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'takeown.exe /R /F C:\\target';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -454,9 +412,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'cipher /W:C:\\temp';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// .exe suffix
@@ -466,9 +422,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'cipher.exe /w:C:\\temp';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -491,9 +445,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'FORMAT C:';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// Different drive letters — adversarial: pattern uses [A-Za-z]: so all drives covered
@@ -503,9 +455,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'format D:';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// Lowercase drive letter
@@ -515,9 +465,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'format c:';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -541,9 +489,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'robocopy src dest /mir';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// .exe suffix
@@ -553,9 +499,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'robocopy.exe /MIR empty dest';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -578,9 +522,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'icacls C:\\path /DENY Everyone:(OI)(CI)F';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// .exe suffix
@@ -590,9 +532,7 @@ describe('Windows cmd.exe destructive command guard (adversarial)', () => {
 			const cmd = 'icacls.exe C:\\path /deny Everyone:(OI)(CI)F';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -634,9 +574,7 @@ describe('PowerShell destructive command guard (adversarial)', () => {
 			const cmd = 'Remove-Item -Recurse -Force C:\\target';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		test('Remove-Item C:\\target -Recurse → BLOCKED (flag after path)', async () => {
@@ -645,9 +583,7 @@ describe('PowerShell destructive command guard (adversarial)', () => {
 			const cmd = 'Remove-Item C:\\target -Recurse';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// PowerShell is case-insensitive; implementation regex uses /i flag
@@ -657,9 +593,7 @@ describe('PowerShell destructive command guard (adversarial)', () => {
 			const cmd = 'remove-item -recurse important_files';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// REMOVE-ITEM all-caps — adversarial: must be caught by case-insensitive regex
@@ -669,9 +603,7 @@ describe('PowerShell destructive command guard (adversarial)', () => {
 			const cmd = 'REMOVE-ITEM -RECURSE important_files';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// -R short form — adversarial: implementation checks /-[Rr]\b/ separately
@@ -681,9 +613,7 @@ describe('PowerShell destructive command guard (adversarial)', () => {
 			const cmd = 'Remove-Item -R C:\\path';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// Path with spaces (quoted) — adversarial: target extractor must handle quotes
@@ -693,9 +623,7 @@ describe('PowerShell destructive command guard (adversarial)', () => {
 			const cmd = 'Remove-Item -Recurse -Force "C:\\Program Files\\target"';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// Safe target: node_modules → ALLOWED
@@ -716,9 +644,7 @@ describe('PowerShell destructive command guard (adversarial)', () => {
 			const cmd = 'ri -r C:\\path';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// Uppercase -R flag
@@ -728,9 +654,7 @@ describe('PowerShell destructive command guard (adversarial)', () => {
 			const cmd = 'ri -R C:\\path';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -741,9 +665,7 @@ describe('PowerShell destructive command guard (adversarial)', () => {
 			const cmd = 'rm -r C:\\path';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 
@@ -754,9 +676,7 @@ describe('PowerShell destructive command guard (adversarial)', () => {
 			const cmd = 'Get-ChildItem C:\\target | Remove-Item -Recurse';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// Extra whitespace around pipe — adversarial: regex uses \|\s* so extra spaces must still match
@@ -766,9 +686,7 @@ describe('PowerShell destructive command guard (adversarial)', () => {
 			const cmd = 'Get-ChildItem C:\\target  |  Remove-Item -Recurse';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 
 		// gci | ri short aliases — adversarial: implementation has explicit gci/ri pattern
@@ -778,9 +696,7 @@ describe('PowerShell destructive command guard (adversarial)', () => {
 			const cmd = 'gci C:\\target | ri -Recurse';
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
-			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-				/BLOCKED/,
-			);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 		});
 	});
 });
@@ -797,51 +713,61 @@ describe('tool: shell — must trigger identical blocks', () => {
 	test('rmdir /s /q C:\\target blocked when tool is shell', async () => {
 		const config = defaultConfig();
 		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
-		const input = { tool: 'shell', sessionID: 'test-session', callID: 'call-1' };
+		const input = {
+			tool: 'shell',
+			sessionID: 'test-session',
+			callID: 'call-1',
+		};
 		const output = makeBashOutput('rmdir /s /q C:\\target');
-		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-			/BLOCKED/,
-		);
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 	});
 
 	test('Remove-Item -Recurse -Force C:\\target blocked when tool is shell', async () => {
 		const config = defaultConfig();
 		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
-		const input = { tool: 'shell', sessionID: 'test-session', callID: 'call-1' };
+		const input = {
+			tool: 'shell',
+			sessionID: 'test-session',
+			callID: 'call-1',
+		};
 		const output = makeBashOutput('Remove-Item -Recurse -Force C:\\target');
-		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-			/BLOCKED/,
-		);
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 	});
 
 	test('vssadmin delete shadows /all blocked when tool is shell', async () => {
 		const config = defaultConfig();
 		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
-		const input = { tool: 'shell', sessionID: 'test-session', callID: 'call-1' };
+		const input = {
+			tool: 'shell',
+			sessionID: 'test-session',
+			callID: 'call-1',
+		};
 		const output = makeBashOutput('vssadmin delete shadows /all');
-		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-			/BLOCKED/,
-		);
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 	});
 
 	test('diskpart blocked when tool is shell', async () => {
 		const config = defaultConfig();
 		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
-		const input = { tool: 'shell', sessionID: 'test-session', callID: 'call-1' };
+		const input = {
+			tool: 'shell',
+			sessionID: 'test-session',
+			callID: 'call-1',
+		};
 		const output = makeBashOutput('diskpart');
-		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-			/BLOCKED/,
-		);
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 	});
 
 	test('format C: blocked when tool is shell', async () => {
 		const config = defaultConfig();
 		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
-		const input = { tool: 'shell', sessionID: 'test-session', callID: 'call-1' };
+		const input = {
+			tool: 'shell',
+			sessionID: 'test-session',
+			callID: 'call-1',
+		};
 		const output = makeBashOutput('format C:');
-		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
-			/BLOCKED/,
-		);
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
 	});
 });
 
@@ -881,7 +807,10 @@ describe('block_destructive_commands: false — all Windows commands pass throug
 	test('Remove-Item -Recurse -Force C:\\target allowed when block_destructive_commands is false', async () => {
 		const config = defaultConfig({ block_destructive_commands: false });
 		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
-		const input = makeBashInput('test-session', 'Remove-Item -Recurse -Force C:\\target');
+		const input = makeBashInput(
+			'test-session',
+			'Remove-Item -Recurse -Force C:\\target',
+		);
 		const output = makeBashOutput('Remove-Item -Recurse -Force C:\\target');
 		await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
 	});

--- a/tests/unit/hooks/destructive-command-wrapper-unwrap.test.ts
+++ b/tests/unit/hooks/destructive-command-wrapper-unwrap.test.ts
@@ -343,6 +343,18 @@ describe('wrapper unwrapping and normalization — adversarial', () => {
 		test('r""m""dir /s node_modules → ALLOWED (safe target after quote collapse)', async () => {
 			await expectAllowed('r""m""dir /s node_modules');
 		});
+
+		// PowerShell single-quote splice: R''e''m''o''v''e''-''I''t''e''m
+		// PS treats '' as empty quoted string, so concatenation produces Remove-Item.
+		test("R''e''m''o''v''e''-''I''t''e''m -Recurse important_files → BLOCKED (single-quote splice)", async () => {
+			await expectBlocked(
+				"R''e''m''o''v''e''-''I''t''e''m -Recurse important_files",
+			);
+		});
+
+		test("r''m''dir /s important_files → BLOCKED (single-quote splice collapses to rmdir)", async () => {
+			await expectBlocked("r''m''dir /s important_files");
+		});
 	});
 
 	// -------------------------------------------------------------------------

--- a/tests/unit/hooks/destructive-command-wrapper-unwrap.test.ts
+++ b/tests/unit/hooks/destructive-command-wrapper-unwrap.test.ts
@@ -1,0 +1,509 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { GuardrailsConfig } from '../../../src/config/schema';
+import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
+import { resetSwarmState, startAgentSession } from '../../../src/state';
+
+const TEST_DIR = '/tmp';
+
+function defaultConfig(
+	overrides?: Partial<GuardrailsConfig>,
+): GuardrailsConfig {
+	return {
+		enabled: true,
+		max_tool_calls: 200,
+		max_duration_minutes: 30,
+		idle_timeout_minutes: 60,
+		max_repetitions: 10,
+		max_consecutive_errors: 5,
+		warning_threshold: 0.75,
+		profiles: undefined,
+		block_destructive_commands: true,
+		...overrides,
+	};
+}
+
+function makeBashInput(sessionID = 'test-session', _command?: string) {
+	return { tool: 'bash', sessionID, callID: 'call-1' };
+}
+
+function makeBashOutput(command: string) {
+	return { args: { command } };
+}
+
+async function expectBlocked(command: string): Promise<void> {
+	const config = defaultConfig();
+	const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+	const input = makeBashInput('test-session');
+	const output = makeBashOutput(command);
+	await expect(hooks.toolBefore(input, output)).rejects.toThrow(/BLOCKED/);
+}
+
+async function expectAllowed(command: string): Promise<void> {
+	const config = defaultConfig();
+	const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+	const input = makeBashInput('test-session');
+	const output = makeBashOutput(command);
+	await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+}
+
+describe('wrapper unwrapping and normalization — adversarial', () => {
+	beforeEach(() => {
+		resetSwarmState();
+		startAgentSession('test-session', 'coder');
+	});
+
+	// -------------------------------------------------------------------------
+	// cmd /c and cmd /k wrappers
+	// -------------------------------------------------------------------------
+	describe('cmd /c wrapper — cmd.exe shell dispatch', () => {
+		test('cmd /c "rmdir /s /q C:\\target" → BLOCKED', async () => {
+			await expectBlocked('cmd /c "rmdir /s /q C:\\target"');
+		});
+
+		test('cmd /c "del /s /q C:\\target" → BLOCKED', async () => {
+			await expectBlocked('cmd /c "del /s /q C:\\target"');
+		});
+
+		test('cmd /C rmdir /s /q important_files → BLOCKED (uppercase /C)', async () => {
+			await expectBlocked('cmd /C rmdir /s /q important_files');
+		});
+
+		test('CMD /c "rmdir /s /q C:\\target" → BLOCKED (uppercase CMD)', async () => {
+			await expectBlocked('CMD /c "rmdir /s /q C:\\target"');
+		});
+
+		test('cmd.exe /c "rmdir /s /q C:\\target" → BLOCKED (.exe suffix)', async () => {
+			await expectBlocked('cmd.exe /c "rmdir /s /q C:\\target"');
+		});
+
+		test('cmd /k "rmdir /s node_modules" → ALLOWED (safe target inside /k wrapper)', async () => {
+			await expectAllowed('cmd /k "rmdir /s node_modules"');
+		});
+
+		test('cmd /c "rmdir /s /q dist" → ALLOWED (safe target)', async () => {
+			await expectAllowed('cmd /c "rmdir /s /q dist"');
+		});
+
+		test('cmd /c rmdir /s /q important_files (no quotes around inner) → BLOCKED', async () => {
+			await expectBlocked('cmd /c rmdir /s /q important_files');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// K2.6 data-loss incident literal command — must be blocked
+	// -------------------------------------------------------------------------
+	describe('K2.6 data-loss incident literal command', () => {
+		test('exact K2.6 incident string → BLOCKED', async () => {
+			// The exact command from the K2.6 incident that caused data loss
+			const incidentCommand =
+				'cmd /c "rmdir /q /s "C:\\opencode\\doc_qa_app\\DocumentQA-v2.0.0-Portable\\DocumentQA""';
+			await expectBlocked(incidentCommand);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// powershell -Command wrapper
+	// -------------------------------------------------------------------------
+	describe('powershell -Command wrapper', () => {
+		test('powershell -Command "Remove-Item -Recurse C:\\target" → BLOCKED', async () => {
+			await expectBlocked('powershell -Command "Remove-Item -Recurse C:\\target"');
+		});
+
+		test('powershell -command "Remove-Item -Recurse C:\\target" → BLOCKED (lowercase -command)', async () => {
+			await expectBlocked('powershell -command "Remove-Item -Recurse C:\\target"');
+		});
+
+		test('powershell -c "Remove-Item -Recurse C:\\target" → BLOCKED (-c short form)', async () => {
+			await expectBlocked('powershell -c "Remove-Item -Recurse C:\\target"');
+		});
+
+		test('POWERSHELL -c "Remove-Item -Recurse C:\\target" → BLOCKED (uppercase POWERSHELL)', async () => {
+			await expectBlocked('POWERSHELL -c "Remove-Item -Recurse C:\\target"');
+		});
+
+		test('powershell.exe -Command "Remove-Item -Recurse C:\\target" → BLOCKED (.exe suffix)', async () => {
+			await expectBlocked('powershell.exe -Command "Remove-Item -Recurse C:\\target"');
+		});
+
+		test('pwsh -Command "Remove-Item C:\\target -Recurse" → BLOCKED (pwsh, flags after path)', async () => {
+			await expectBlocked('pwsh -Command "Remove-Item C:\\target -Recurse"');
+		});
+
+		test('pwsh -c "ri -r C:\\path" → BLOCKED (ri alias with short -r)', async () => {
+			await expectBlocked('pwsh -c "ri -r C:\\path"');
+		});
+
+		test('pwsh -c "Remove-Item -r /important" → BLOCKED (pwsh short -r on POSIX path)', async () => {
+			await expectBlocked('pwsh -c "Remove-Item -r /important"');
+		});
+
+		test('PWSH -Command "Remove-Item -Recurse C:\\target" → BLOCKED (uppercase PWSH)', async () => {
+			await expectBlocked('PWSH -Command "Remove-Item -Recurse C:\\target"');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// powershell -EncodedCommand (base64 UTF-16LE decode + check)
+	// -------------------------------------------------------------------------
+	describe('powershell -EncodedCommand base64 decode', () => {
+		test('powershell -EncodedCommand <Remove-Item -Recurse C:\\target> → BLOCKED', async () => {
+			// Generate base64 programmatically — UTF-16LE encoding as PowerShell uses
+			const encoded = Buffer.from(
+				'Remove-Item -Recurse C:\\target',
+				'utf16le',
+			).toString('base64');
+			await expectBlocked(`powershell -EncodedCommand ${encoded}`);
+		});
+
+		test('powershell -encodedcommand <Remove-Item -Recurse C:\\target> → BLOCKED (lowercase flag)', async () => {
+			const encoded = Buffer.from(
+				'Remove-Item -Recurse C:\\target',
+				'utf16le',
+			).toString('base64');
+			await expectBlocked(`powershell -encodedcommand ${encoded}`);
+		});
+
+		test('powershell -enc <Remove-Item -Recurse C:\\target> → BLOCKED (-enc short form)', async () => {
+			const encoded = Buffer.from(
+				'Remove-Item -Recurse C:\\target',
+				'utf16le',
+			).toString('base64');
+			await expectBlocked(`powershell -enc ${encoded}`);
+		});
+
+		test('powershell -e <Remove-Item -Recurse C:\\target> → BLOCKED (-e shortest alias)', async () => {
+			const encoded = Buffer.from(
+				'Remove-Item -Recurse C:\\target',
+				'utf16le',
+			).toString('base64');
+			await expectBlocked(`powershell -e ${encoded}`);
+		});
+
+		test('pwsh -EncodedCommand <Remove-Item -Recurse C:\\target> → BLOCKED (pwsh binary)', async () => {
+			const encoded = Buffer.from(
+				'Remove-Item -Recurse C:\\target',
+				'utf16le',
+			).toString('base64');
+			await expectBlocked(`pwsh -EncodedCommand ${encoded}`);
+		});
+
+		test('powershell -enc <safe "dir C:\\temp"> → ALLOWED', async () => {
+			// A benign command encoded in base64 must not be blocked
+			const encoded = Buffer.from('dir C:\\temp', 'utf16le').toString('base64');
+			await expectAllowed(`powershell -enc ${encoded}`);
+		});
+
+		test('powershell -EncodedCommand <rm -rf /important> → BLOCKED (POSIX rm encoded in PS)', async () => {
+			const encoded = Buffer.from('rm -rf /important', 'utf16le').toString('base64');
+			await expectBlocked(`powershell -EncodedCommand ${encoded}`);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// bash/sh -c wrapper
+	// -------------------------------------------------------------------------
+	describe('bash/sh -c wrapper', () => {
+		test('bash -c "rm -rf /important" → BLOCKED', async () => {
+			await expectBlocked('bash -c "rm -rf /important"');
+		});
+
+		test('sh -c "rm -rf /" → BLOCKED', async () => {
+			await expectBlocked('sh -c "rm -rf /"');
+		});
+
+		test('bash -c "rmdir /s /q C:\\target" → BLOCKED (Windows rmdir inside bash -c)', async () => {
+			await expectBlocked('bash -c "rmdir /s /q C:\\target"');
+		});
+
+		test('zsh -c "rm -rf /important" → BLOCKED', async () => {
+			await expectBlocked('zsh -c "rm -rf /important"');
+		});
+
+		test('bash -c "rm -rf node_modules" → ALLOWED (safe target)', async () => {
+			await expectAllowed('bash -c "rm -rf node_modules"');
+		});
+
+		test('bash -c "echo hello" → ALLOWED', async () => {
+			await expectAllowed('bash -c "echo hello"');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// sudo wrapper
+	// -------------------------------------------------------------------------
+	describe('sudo wrapper', () => {
+		test('sudo rm -rf /important → BLOCKED', async () => {
+			await expectBlocked('sudo rm -rf /important');
+		});
+
+		test('sudo rmdir /s /q C:\\target → BLOCKED', async () => {
+			await expectBlocked('sudo rmdir /s /q C:\\target');
+		});
+
+		test('sudo rm -rf / → BLOCKED (root filesystem)', async () => {
+			await expectBlocked('sudo rm -rf /');
+		});
+
+		test('sudo bash -c "rm -rf /important" → BLOCKED (sudo + bash -c nesting)', async () => {
+			await expectBlocked('sudo bash -c "rm -rf /important"');
+		});
+
+		test('sudo rm -rf node_modules → ALLOWED (safe target)', async () => {
+			await expectAllowed('sudo rm -rf node_modules');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// WSL cross-OS bridge
+	// -------------------------------------------------------------------------
+	describe('WSL cross-OS bridge', () => {
+		test('wsl -e rm -rf /mnt/c/opencode → BLOCKED (rm -rf inside wsl)', async () => {
+			await expectBlocked('wsl -e rm -rf /mnt/c/opencode');
+		});
+
+		test('wsl -- rmdir /s /q C:\\target → BLOCKED (rmdir via wsl --)', async () => {
+			await expectBlocked('wsl -- rmdir /s /q C:\\target');
+		});
+
+		test('wsl.exe -e rm -rf /mnt/c/opencode → BLOCKED (.exe suffix)', async () => {
+			await expectBlocked('wsl.exe -e rm -rf /mnt/c/opencode');
+		});
+
+		test('wsl -e rm -rf / → BLOCKED (root via wsl)', async () => {
+			await expectBlocked('wsl -e rm -rf /');
+		});
+
+		test('wsl -e echo hello → ALLOWED (safe command through wsl)', async () => {
+			await expectAllowed('wsl -e echo hello');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Normalization: PowerShell backtick escape
+	// -------------------------------------------------------------------------
+	describe('PowerShell backtick escape normalization', () => {
+		test('R`e`m`o`v`e`-`I`t`e`m -Recurse C:\\target → BLOCKED (backtick per-char escape)', async () => {
+			await expectBlocked('R`e`m`o`v`e`-`I`t`e`m -Recurse C:\\target');
+		});
+
+		test('`r`m -`r`f /important → BLOCKED (rm with backtick escapes)', async () => {
+			await expectBlocked('`r`m -`r`f /important');
+		});
+
+		test('R`e`m`o`v`e`-`I`t`e`m -`R C:\\target → BLOCKED (short -R flag also backtick escaped)', async () => {
+			await expectBlocked('R`e`m`o`v`e`-`I`t`e`m -`R C:\\target');
+		});
+
+		test('r`m`d`i`r /s /q important_files → BLOCKED (rmdir with backtick escapes)', async () => {
+			await expectBlocked('r`m`d`i`r /s /q important_files');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Normalization: cmd.exe caret escape
+	// -------------------------------------------------------------------------
+	describe('cmd.exe caret escape normalization', () => {
+		test('^r^m^d^i^r /s /q important_files → BLOCKED (carets collapsed → rmdir /s /q)', async () => {
+			await expectBlocked('^r^m^d^i^r /s /q important_files');
+		});
+
+		test('^r^m -^r^f /important → BLOCKED (rm with caret escapes)', async () => {
+			await expectBlocked('^r^m -^r^f /important');
+		});
+
+		test('^r^m^d^i^r /s /q node_modules → ALLOWED (safe target after caret collapse)', async () => {
+			await expectAllowed('^r^m^d^i^r /s /q node_modules');
+		});
+
+		test('^e^c^h^o hello → ALLOWED (benign command with carets)', async () => {
+			await expectAllowed('^e^c^h^o hello');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Normalization: quote-splice evasion
+	// -------------------------------------------------------------------------
+	describe('quote-splice evasion normalization', () => {
+		test('r""m""dir /s important_files → BLOCKED (doubled-quote splice collapses to rmdir)', async () => {
+			await expectBlocked('r""m""dir /s important_files');
+		});
+
+		test('r""m -r""f /important → BLOCKED (rm with quote splicing)', async () => {
+			await expectBlocked('r""m -r""f /important');
+		});
+
+		test('r""m""dir /s node_modules → ALLOWED (safe target after quote collapse)', async () => {
+			await expectAllowed('r""m""dir /s node_modules');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Normalization: NFKC fullwidth Unicode characters
+	// -------------------------------------------------------------------------
+	describe('NFKC fullwidth Unicode normalization', () => {
+		test('ｒｍ　－ｒｆ　／ → BLOCKED (NFKC normalizes fullwidth chars to rm -rf /)', async () => {
+			// ｒ=U+FF52, ｍ=U+FF4D, 　=U+3000, －=U+FF0D, ｒ=U+FF52, ｆ=U+FF46, 　=U+3000, ／=U+FF0F
+			await expectBlocked('\uFF52\uFF4D\u3000\uFF0D\uFF52\uFF46\u3000\uFF0F');
+		});
+
+		test('ｒｍｄｉｒ　／ｓ　／ｑ　important_files → BLOCKED (fullwidth rmdir /s /q)', async () => {
+			// ｒ=FF52, ｍ=FF4D, ｄ=FF44, ｉ=FF49, ｒ=FF52, 　=3000, ／=FF0F, ｓ=FF53, 　=3000, ／=FF0F, ｑ=FF51
+			await expectBlocked(
+				'\uFF52\uFF4D\uFF44\uFF49\uFF52\u3000\uFF0F\uFF53\u3000\uFF0F\uFF51\u3000important_files',
+			);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Compound commands — each segment independently checked
+	// -------------------------------------------------------------------------
+	describe('compound command splitting — per-segment checking', () => {
+		test('echo hello && rmdir /s important_files → BLOCKED (rmdir in second && segment)', async () => {
+			await expectBlocked('echo hello && rmdir /s important_files');
+		});
+
+		test('echo hello; rm -rf / → BLOCKED (rm in second ; segment)', async () => {
+			await expectBlocked('echo hello; rm -rf /');
+		});
+
+		test('ls && echo done → ALLOWED (neither segment is destructive)', async () => {
+			await expectAllowed('ls && echo done');
+		});
+
+		test('echo safe | rm -rf /important → BLOCKED (rm in piped segment)', async () => {
+			await expectBlocked('echo safe | rm -rf /important');
+		});
+
+		test('rm -rf /important || echo fallback → BLOCKED (rm in first || segment)', async () => {
+			await expectBlocked('rm -rf /important || echo fallback');
+		});
+
+		test('ls; echo done; cat file.txt → ALLOWED (all safe segments)', async () => {
+			await expectAllowed('ls; echo done; cat file.txt');
+		});
+
+		test('echo hello && powershell -c "Remove-Item -Recurse C:\\target" → BLOCKED (wrapped cmd in second segment)', async () => {
+			await expectBlocked(
+				'echo hello && powershell -c "Remove-Item -Recurse C:\\target"',
+			);
+		});
+
+		test('echo a && echo b && rmdir /s important_files → BLOCKED (rmdir in third segment)', async () => {
+			await expectBlocked('echo a && echo b && rmdir /s important_files');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Multi-layer wrapper nesting (wrapper inside wrapper)
+	// -------------------------------------------------------------------------
+	describe('multi-layer wrapper nesting', () => {
+		test('sudo bash -c "rm -rf /important" → BLOCKED (sudo → bash -c nesting)', async () => {
+			await expectBlocked('sudo bash -c "rm -rf /important"');
+		});
+
+		test('sudo powershell -Command "Remove-Item -Recurse C:\\target" → BLOCKED (sudo → powershell)', async () => {
+			await expectBlocked(
+				'sudo powershell -Command "Remove-Item -Recurse C:\\target"',
+			);
+		});
+
+		test('wsl -e bash -c "rm -rf /mnt/c/data" → BLOCKED (wsl → bash nesting)', async () => {
+			await expectBlocked('wsl -e bash -c "rm -rf /mnt/c/data"');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Whitespace and flag ordering edge cases
+	// -------------------------------------------------------------------------
+	describe('whitespace and flag ordering edge cases', () => {
+		test('rmdir  /s  /q  C:\\target → BLOCKED (extra internal spaces)', async () => {
+			await expectBlocked('rmdir  /s  /q  C:\\target');
+		});
+
+		test('rmdir /q /s C:\\target → BLOCKED (reversed /q /s flag order)', async () => {
+			await expectBlocked('rmdir /q /s C:\\target');
+		});
+
+		test('rm  -rf  /important → BLOCKED (extra spaces between flag and path)', async () => {
+			await expectBlocked('rm  -rf  /important');
+		});
+
+		test('rm -fr /important → BLOCKED (-fr reversed flag order)', async () => {
+			await expectBlocked('rm -fr /important');
+		});
+
+		test('rm -f -r /important → BLOCKED (split flags -f -r)', async () => {
+			await expectBlocked('rm -f -r /important');
+		});
+
+		test('rm -r -f /important → BLOCKED (reversed split flags -r -f)', async () => {
+			await expectBlocked('rm -r -f /important');
+		});
+
+		test('cmd /c  rmdir /s /q important_files → BLOCKED (extra space after /c)', async () => {
+			await expectBlocked('cmd /c  rmdir /s /q important_files');
+		});
+
+		test('RMDIR /S /Q C:\\target → BLOCKED (all-uppercase RMDIR /S /Q)', async () => {
+			await expectBlocked('RMDIR /S /Q C:\\target');
+		});
+
+		test('Rmdir /S /Q C:\\target → BLOCKED (mixed-case Rmdir)', async () => {
+			await expectBlocked('Rmdir /S /Q C:\\target');
+		});
+
+		test('Remove-Item -RECURSE C:\\target → BLOCKED (uppercase -RECURSE flag)', async () => {
+			await expectBlocked('Remove-Item -RECURSE C:\\target');
+		});
+
+		test('REMOVE-ITEM -Recurse C:\\target → BLOCKED (uppercase cmdlet name)', async () => {
+			await expectBlocked('REMOVE-ITEM -Recurse C:\\target');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// block_destructive_commands: false — must bypass ALL wrapper/normalization checks
+	// -------------------------------------------------------------------------
+	describe('block_destructive_commands: false — bypass all checks', () => {
+		test('rm -rf / allowed when block_destructive_commands is false', async () => {
+			const config = defaultConfig({ block_destructive_commands: false });
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const command = 'rm -rf /';
+			const input = makeBashInput('test-session');
+			const output = makeBashOutput(command);
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+
+		test('cmd /c "rmdir /s /q C:\\target" allowed when block_destructive_commands is false', async () => {
+			const config = defaultConfig({ block_destructive_commands: false });
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const command = 'cmd /c "rmdir /s /q C:\\target"';
+			const input = makeBashInput('test-session');
+			const output = makeBashOutput(command);
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+
+		test('powershell -EncodedCommand <Remove-Item> allowed when block_destructive_commands is false', async () => {
+			const config = defaultConfig({ block_destructive_commands: false });
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const encoded = Buffer.from(
+				'Remove-Item -Recurse C:\\target',
+				'utf16le',
+			).toString('base64');
+			const command = `powershell -EncodedCommand ${encoded}`;
+			const input = makeBashInput('test-session');
+			const output = makeBashOutput(command);
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+
+		test('K2.6 incident string allowed when block_destructive_commands is false', async () => {
+			const config = defaultConfig({ block_destructive_commands: false });
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const command =
+				'cmd /c "rmdir /q /s "C:\\opencode\\doc_qa_app\\DocumentQA-v2.0.0-Portable\\DocumentQA""';
+			const input = makeBashInput('test-session');
+			const output = makeBashOutput(command);
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+	});
+});

--- a/tests/unit/hooks/destructive-command-wrapper-unwrap.test.ts
+++ b/tests/unit/hooks/destructive-command-wrapper-unwrap.test.ts
@@ -106,11 +106,15 @@ describe('wrapper unwrapping and normalization — adversarial', () => {
 	// -------------------------------------------------------------------------
 	describe('powershell -Command wrapper', () => {
 		test('powershell -Command "Remove-Item -Recurse C:\\target" → BLOCKED', async () => {
-			await expectBlocked('powershell -Command "Remove-Item -Recurse C:\\target"');
+			await expectBlocked(
+				'powershell -Command "Remove-Item -Recurse C:\\target"',
+			);
 		});
 
 		test('powershell -command "Remove-Item -Recurse C:\\target" → BLOCKED (lowercase -command)', async () => {
-			await expectBlocked('powershell -command "Remove-Item -Recurse C:\\target"');
+			await expectBlocked(
+				'powershell -command "Remove-Item -Recurse C:\\target"',
+			);
 		});
 
 		test('powershell -c "Remove-Item -Recurse C:\\target" → BLOCKED (-c short form)', async () => {
@@ -122,7 +126,9 @@ describe('wrapper unwrapping and normalization — adversarial', () => {
 		});
 
 		test('powershell.exe -Command "Remove-Item -Recurse C:\\target" → BLOCKED (.exe suffix)', async () => {
-			await expectBlocked('powershell.exe -Command "Remove-Item -Recurse C:\\target"');
+			await expectBlocked(
+				'powershell.exe -Command "Remove-Item -Recurse C:\\target"',
+			);
 		});
 
 		test('pwsh -Command "Remove-Item C:\\target -Recurse" → BLOCKED (pwsh, flags after path)', async () => {
@@ -194,7 +200,9 @@ describe('wrapper unwrapping and normalization — adversarial', () => {
 		});
 
 		test('powershell -EncodedCommand <rm -rf /important> → BLOCKED (POSIX rm encoded in PS)', async () => {
-			const encoded = Buffer.from('rm -rf /important', 'utf16le').toString('base64');
+			const encoded = Buffer.from('rm -rf /important', 'utf16le').toString(
+				'base64',
+			);
 			await expectBlocked(`powershell -EncodedCommand ${encoded}`);
 		});
 	});

--- a/tests/unit/hooks/destructive-command-wrapper-unwrap.test.ts
+++ b/tests/unit/hooks/destructive-command-wrapper-unwrap.test.ts
@@ -284,6 +284,31 @@ describe('wrapper unwrapping and normalization — adversarial', () => {
 		test('wsl -e echo hello → ALLOWED (safe command through wsl)', async () => {
 			await expectAllowed('wsl -e echo hello');
 		});
+
+		test('WSL.EXE -e rm -rf /mnt/c/opencode → BLOCKED (uppercase WSL.EXE)', async () => {
+			await expectBlocked('WSL.EXE -e rm -rf /mnt/c/opencode');
+		});
+
+		test('WSL -- rm -rf /important → BLOCKED (uppercase WSL with --)', async () => {
+			await expectBlocked('WSL -- rm -rf /important');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Uppercase sudo/nohup wrappers
+	// -------------------------------------------------------------------------
+	describe('uppercase prefix wrappers (SUDO, NOHUP)', () => {
+		test('SUDO rm -rf /important → BLOCKED (uppercase SUDO)', async () => {
+			await expectBlocked('SUDO rm -rf /important');
+		});
+
+		test('NOHUP rm -rf /important → BLOCKED (uppercase NOHUP)', async () => {
+			await expectBlocked('NOHUP rm -rf /important');
+		});
+
+		test('SUDO Remove-Item -Recurse /important → BLOCKED (uppercase SUDO + PS)', async () => {
+			await expectBlocked('SUDO Remove-Item -Recurse /important');
+		});
 	});
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Blocks destructive shell commands across Linux, macOS, and Windows — motivated by the K2.6 incident where `cmd /c "rmdir /q /s <junction>"` destroyed 4.8 GB via NTFS junction traversal
- Covers cmd.exe (`rmdir /s`, `del /s /q /f`), PowerShell (`Remove-Item -Recurse` + 7 aliases), ransomware tools (`vssadmin delete`, `diskpart`, `sdelete`, `cipher /w`, `mkfs`, etc.), SQL DDL, and POSIX long-form flags; all wrappers (CMD, POWERSHELL, SUDO, WSL.EXE, BASH, NOHUP) are fully case-insensitive
- Fixes critical DC_SAFE_TARGETS bypass: lstat runs before safe-named-target allowlist so `mklink /J node_modules C:\important && rm -rf node_modules` no longer evades; normalizes backtick/caret/double-quote-splice/single-quote-splice/NFKC evasion

## Test plan
- [x] 220 new tests in 4 files — all passing
- [x] `bun run typecheck` clean; `bunx biome ci .` pre-existing errors only
- [x] Full 5-tier test suite — only pre-existing failures unchanged on this branch
- [x] Independent adversarial review: found PS single-quote splice bypass (`R''e''m''o''v''e''-''I''t''e''m`) → fixed
- [x] Independent completeness verifier: 19/19 claims verified; found uppercase wrapper gap (SUDO/WSL.EXE/NOHUP lacked `/i`) → fixed
- [x] `docs/releases/v6.69.0.md` created with full release notes