### PR TITLE
fix(delegation-gate, architect, state): resolve three wiring gaps in council mode (#487)

### DIFF
--- a/dist/agents/architect.d.ts
+++ b/dist/agents/architect.d.ts
@@ -25,4 +25,15 @@ export interface CouncilWorkflowConfig {
  * council feature is off or the config key is absent.
  */
 export declare function buildCouncilWorkflow(council?: CouncilWorkflowConfig): string;
+/**
+ * Build the user-facing QA gate selection dialogue, used by MODE: SPECIFY
+ * (step 5b), MODE: BRAINSTORM (Phase 6), and MODE: PLAN (post-`save_plan`
+ * inline path). The dialogue is dialogue-only — persistence happens during
+ * MODE: PLAN after `save_plan` creates `plan.json`.
+ *
+ * The lead-in sentence varies per mode, but the body (seven gates with
+ * defaults, one-shot accept-or-customize prompt) is shared so SPECIFY,
+ * BRAINSTORM, and PLAN inline paths stay in lockstep.
+ */
+export declare function buildQaGateSelectionDialogue(modeLabel: 'BRAINSTORM' | 'SPECIFY' | 'PLAN'): string;
 export declare function createArchitectAgent(model: string, customPrompt?: string, customAppendPrompt?: string, adversarialTesting?: AdversarialTestingConfig, council?: CouncilWorkflowConfig): AgentDefinition;

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -17338,12 +17338,12 @@ var require_adapter = __commonJS((exports, module) => {
     return newFs;
   }
   function toPromise(method) {
-    return (...args) => new Promise((resolve4, reject) => {
+    return (...args) => new Promise((resolve5, reject) => {
       args.push((err, result) => {
         if (err) {
           reject(err);
         } else {
-          resolve4(result);
+          resolve5(result);
         }
       });
       method(...args);
@@ -19489,6 +19489,199 @@ init_manager2();
 // src/state.ts
 init_plan_schema();
 
+// src/db/qa-gate-profile.ts
+import { createHash as createHash3 } from "crypto";
+
+// src/db/project-db.ts
+import { Database } from "bun:sqlite";
+import { existsSync as existsSync4, mkdirSync as mkdirSync3 } from "fs";
+import { join as join6, resolve as resolve4 } from "path";
+var MIGRATIONS = [
+  {
+    version: 1,
+    name: "create_project_constraints",
+    sql: `CREATE TABLE project_constraints (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			constraint_type TEXT NOT NULL,
+			content TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (datetime('now'))
+		)`
+  },
+  {
+    version: 2,
+    name: "create_qa_gate_profile",
+    sql: `CREATE TABLE qa_gate_profile (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			plan_id TEXT NOT NULL UNIQUE,
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			project_type TEXT,
+			gates TEXT NOT NULL DEFAULT '{}',
+			locked_at TEXT,
+			locked_by_snapshot_seq INTEGER
+		)`
+  },
+  {
+    version: 3,
+    name: "create_qa_gate_profile_immutability_trigger",
+    sql: `CREATE TRIGGER IF NOT EXISTS trg_qa_gate_profile_no_update_after_lock
+			BEFORE UPDATE ON qa_gate_profile
+			WHEN OLD.locked_at IS NOT NULL
+			BEGIN
+				SELECT RAISE(ABORT, 'qa_gate_profile row is locked and cannot be modified after critic approval');
+			END`
+  }
+];
+var _projectDbs = new Map;
+function runProjectMigrations(db) {
+  db.run(`CREATE TABLE IF NOT EXISTS schema_migrations (
+		version INTEGER PRIMARY KEY,
+		name TEXT NOT NULL,
+		applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+	)`);
+  const row = db.query("SELECT MAX(version) as version FROM schema_migrations").get();
+  const currentVersion = row?.version ?? 0;
+  for (const migration of MIGRATIONS) {
+    if (migration.version <= currentVersion)
+      continue;
+    const apply = db.transaction(() => {
+      db.run(migration.sql);
+      db.run("INSERT INTO schema_migrations (version, name) VALUES (?, ?)", [
+        migration.version,
+        migration.name
+      ]);
+    });
+    apply();
+  }
+}
+function projectDbPath(directory) {
+  return join6(resolve4(directory), ".swarm", "swarm.db");
+}
+function projectDbExists(directory) {
+  return existsSync4(projectDbPath(directory));
+}
+function getProjectDb(directory) {
+  const key = resolve4(directory);
+  const existing = _projectDbs.get(key);
+  if (existing)
+    return existing;
+  const swarmDir = join6(key, ".swarm");
+  mkdirSync3(swarmDir, { recursive: true });
+  const db = new Database(join6(swarmDir, "swarm.db"));
+  db.run("PRAGMA journal_mode = WAL;");
+  db.run("PRAGMA synchronous = NORMAL;");
+  db.run("PRAGMA busy_timeout = 5000;");
+  db.run("PRAGMA foreign_keys = ON;");
+  runProjectMigrations(db);
+  _projectDbs.set(key, db);
+  return db;
+}
+
+// src/db/qa-gate-profile.ts
+var DEFAULT_QA_GATES = {
+  reviewer: true,
+  test_engineer: true,
+  council_mode: false,
+  sme_enabled: true,
+  critic_pre_plan: true,
+  hallucination_guard: false,
+  sast_enabled: true
+};
+function rowToProfile(row) {
+  let parsed = {};
+  try {
+    parsed = JSON.parse(row.gates);
+  } catch {
+    parsed = {};
+  }
+  const gates = { ...DEFAULT_QA_GATES, ...parsed };
+  return {
+    id: row.id,
+    plan_id: row.plan_id,
+    created_at: row.created_at,
+    project_type: row.project_type,
+    gates,
+    locked_at: row.locked_at,
+    locked_by_snapshot_seq: row.locked_by_snapshot_seq
+  };
+}
+function getProfile(directory, planId) {
+  if (!projectDbExists(directory))
+    return null;
+  const db = getProjectDb(directory);
+  const row = db.query("SELECT * FROM qa_gate_profile WHERE plan_id = ?").get(planId);
+  return row ? rowToProfile(row) : null;
+}
+function getOrCreateProfile(directory, planId, projectType) {
+  const existing = getProfile(directory, planId);
+  if (existing)
+    return existing;
+  const db = getProjectDb(directory);
+  const gatesJson = JSON.stringify(DEFAULT_QA_GATES);
+  const insert = db.transaction(() => {
+    db.run("INSERT INTO qa_gate_profile (plan_id, project_type, gates) VALUES (?, ?, ?)", [planId, projectType ?? null, gatesJson]);
+  });
+  try {
+    insert();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.toLowerCase().includes("unique")) {
+      throw err;
+    }
+  }
+  const after = getProfile(directory, planId);
+  if (!after) {
+    throw new Error(`Failed to create or load QA gate profile for plan_id=${planId}`);
+  }
+  return after;
+}
+function setGates(directory, planId, gates) {
+  const current = getProfile(directory, planId);
+  if (!current) {
+    throw new Error(`No QA gate profile found for plan_id=${planId} \u2014 call getOrCreateProfile first`);
+  }
+  if (current.locked_at !== null) {
+    throw new Error("Cannot modify gates: QA gate profile is locked after critic approval");
+  }
+  const merged = { ...current.gates };
+  for (const key of Object.keys(gates)) {
+    const incoming = gates[key];
+    if (incoming === undefined)
+      continue;
+    if (incoming === false && current.gates[key] === true) {
+      throw new Error(`Cannot disable gate '${key}': sessions can only ratchet tighter`);
+    }
+    if (incoming === true) {
+      merged[key] = true;
+    }
+  }
+  const db = getProjectDb(directory);
+  db.run("UPDATE qa_gate_profile SET gates = ? WHERE plan_id = ?", [
+    JSON.stringify(merged),
+    planId
+  ]);
+  const updated = getProfile(directory, planId);
+  if (!updated) {
+    throw new Error(`Failed to re-read QA gate profile after update for plan_id=${planId}`);
+  }
+  return updated;
+}
+function computeProfileHash(profile) {
+  const payload = JSON.stringify({
+    plan_id: profile.plan_id,
+    gates: profile.gates
+  });
+  return createHash3("sha256").update(payload).digest("hex");
+}
+function getEffectiveGates(profile, sessionOverrides) {
+  const merged = { ...profile.gates };
+  for (const key of Object.keys(sessionOverrides)) {
+    if (sessionOverrides[key] === true) {
+      merged[key] = true;
+    }
+  }
+  return merged;
+}
+
 // src/hooks/delegation-gate.ts
 init_telemetry();
 
@@ -19942,8 +20135,10 @@ function clearPendingCoderScope() {
 }
 
 // src/state.ts
+init_manager();
 init_telemetry();
 var _rehydrationCache = null;
+var _councilDisagreementWarned = new Set;
 var swarmState = {
   activeToolCalls: new Map,
   toolAggregates: new Map,
@@ -19975,6 +20170,7 @@ function resetSwarmState() {
   swarmState.fullAutoEnabledInConfig = false;
   swarmState.environmentProfiles.clear();
   clearPendingCoderScope();
+  _councilDisagreementWarned.clear();
 }
 function getAgentSession(sessionId) {
   return swarmState.agentSessions.get(sessionId);
@@ -33150,7 +33346,7 @@ function hasUncommittedChanges(cwd) {
 
 // src/hooks/knowledge-store.ts
 var import_proper_lockfile2 = __toESM(require_proper_lockfile(), 1);
-import { existsSync as existsSync5 } from "fs";
+import { existsSync as existsSync6 } from "fs";
 import { appendFile as appendFile2, mkdir, readFile as readFile2, writeFile as writeFile2 } from "fs/promises";
 import * as os2 from "os";
 import * as path8 from "path";
@@ -33178,7 +33374,7 @@ function resolveHiveRejectedPath() {
   return path8.join(path8.dirname(hivePath), "shared-learnings-rejected.jsonl");
 }
 async function readKnowledge(filePath) {
-  if (!existsSync5(filePath))
+  if (!existsSync6(filePath))
     return [];
   const content = await readFile2(filePath, "utf-8");
   const results = [];
@@ -33811,7 +34007,7 @@ async function writeCheckpoint(directory) {
 
 // src/session/snapshot-writer.ts
 init_utils2();
-import { mkdirSync as mkdirSync5, renameSync as renameSync5 } from "fs";
+import { mkdirSync as mkdirSync6, renameSync as renameSync5 } from "fs";
 import * as path11 from "path";
 init_utils();
 var _writeInFlight = Promise.resolve();
@@ -33904,7 +34100,7 @@ async function writeSnapshot(directory, state) {
     const content = JSON.stringify(snapshot, null, 2);
     const resolvedPath = validateSwarmPath(directory, "session/state.json");
     const dir = path11.dirname(resolvedPath);
-    mkdirSync5(dir, { recursive: true });
+    mkdirSync6(dir, { recursive: true });
     const tempPath = `${resolvedPath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2)}`;
     await Bun.write(tempPath, content);
     renameSync5(tempPath, resolvedPath);
@@ -35402,7 +35598,7 @@ async function handleDarkMatterCommand(directory, args) {
 
 // src/services/diagnose-service.ts
 import * as child_process4 from "child_process";
-import { existsSync as existsSync6, readdirSync as readdirSync3, readFileSync as readFileSync6, statSync as statSync4 } from "fs";
+import { existsSync as existsSync7, readdirSync as readdirSync3, readFileSync as readFileSync6, statSync as statSync4 } from "fs";
 import path16 from "path";
 import { fileURLToPath } from "url";
 init_manager2();
@@ -35639,7 +35835,7 @@ async function checkConfigBackups(directory) {
 }
 async function checkGitRepository(directory) {
   try {
-    if (!existsSync6(directory) || !statSync4(directory).isDirectory()) {
+    if (!existsSync7(directory) || !statSync4(directory).isDirectory()) {
       return {
         name: "Git Repository",
         status: "\u274C",
@@ -35704,7 +35900,7 @@ async function checkSpecStaleness(directory, plan) {
 }
 async function checkConfigParseability(directory) {
   const configPath = path16.join(directory, ".opencode/opencode-swarm.json");
-  if (!existsSync6(configPath)) {
+  if (!existsSync7(configPath)) {
     return {
       name: "Config Parseability",
       status: "\u2705",
@@ -35754,11 +35950,11 @@ async function checkGrammarWasmFiles() {
   const isSource = thisDir.replace(/\\/g, "/").endsWith("/src/services");
   const grammarDir = isSource ? path16.join(thisDir, "..", "lang", "grammars") : path16.join(thisDir, "lang", "grammars");
   const missing = [];
-  if (!existsSync6(path16.join(grammarDir, "tree-sitter.wasm"))) {
+  if (!existsSync7(path16.join(grammarDir, "tree-sitter.wasm"))) {
     missing.push("tree-sitter.wasm (core runtime)");
   }
   for (const file3 of grammarFiles) {
-    if (!existsSync6(path16.join(grammarDir, file3))) {
+    if (!existsSync7(path16.join(grammarDir, file3))) {
       missing.push(file3);
     }
   }
@@ -35777,7 +35973,7 @@ async function checkGrammarWasmFiles() {
 }
 async function checkCheckpointManifest(directory) {
   const manifestPath = path16.join(directory, ".swarm/checkpoints.json");
-  if (!existsSync6(manifestPath)) {
+  if (!existsSync7(manifestPath)) {
     return {
       name: "Checkpoint Manifest",
       status: "\u2705",
@@ -35829,7 +36025,7 @@ async function checkCheckpointManifest(directory) {
 }
 async function checkEventStreamIntegrity(directory) {
   const eventsPath = path16.join(directory, ".swarm/events.jsonl");
-  if (!existsSync6(eventsPath)) {
+  if (!existsSync7(eventsPath)) {
     return {
       name: "Event Stream",
       status: "\u2705",
@@ -35870,7 +36066,7 @@ async function checkEventStreamIntegrity(directory) {
 }
 async function checkSteeringDirectives(directory) {
   const eventsPath = path16.join(directory, ".swarm/events.jsonl");
-  if (!existsSync6(eventsPath)) {
+  if (!existsSync7(eventsPath)) {
     return {
       name: "Steering Directives",
       status: "\u2705",
@@ -35926,7 +36122,7 @@ async function checkCurator(directory) {
       };
     }
     const summaryPath = path16.join(directory, ".swarm/curator-summary.json");
-    if (!existsSync6(summaryPath)) {
+    if (!existsSync7(summaryPath)) {
       return {
         name: "Curator",
         status: "\u2705",
@@ -36074,7 +36270,7 @@ async function getDiagnoseData(directory) {
   checks5.push(await checkCurator(directory));
   try {
     const evidenceDir = path16.join(directory, ".swarm", "evidence");
-    const snapshotFiles = existsSync6(evidenceDir) ? readdirSync3(evidenceDir).filter((f) => f.startsWith("agent-tools-") && f.endsWith(".json")) : [];
+    const snapshotFiles = existsSync7(evidenceDir) ? readdirSync3(evidenceDir).filter((f) => f.startsWith("agent-tools-") && f.endsWith(".json")) : [];
     if (snapshotFiles.length > 0) {
       const latest = snapshotFiles.sort().pop();
       checks5.push({
@@ -36134,7 +36330,7 @@ import * as path18 from "path";
 
 // src/lang/detector.ts
 import { access as access2, readdir as readdir2 } from "fs/promises";
-import { extname as extname2, join as join14 } from "path";
+import { extname as extname2, join as join15 } from "path";
 
 // src/lang/profiles.ts
 class LanguageRegistry {
@@ -37114,7 +37310,7 @@ async function detectProjectLanguages(projectDir) {
         if (detectFile.includes("*") || detectFile.includes("?"))
           continue;
         try {
-          await access2(join14(dir, detectFile));
+          await access2(join15(dir, detectFile));
           detected.add(profile.id);
           break;
         } catch {}
@@ -37135,7 +37331,7 @@ async function detectProjectLanguages(projectDir) {
     const topEntries = await readdir2(projectDir, { withFileTypes: true });
     for (const entry of topEntries) {
       if (entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules") {
-        await scanDir(join14(projectDir, entry.name));
+        await scanDir(join15(projectDir, entry.name));
       }
     }
   } catch {}
@@ -38471,14 +38667,14 @@ async function handleHistoryCommand(directory, _args) {
 }
 // src/hooks/knowledge-migrator.ts
 import { randomUUID as randomUUID2 } from "crypto";
-import { existsSync as existsSync10, readFileSync as readFileSync10 } from "fs";
+import { existsSync as existsSync11, readFileSync as readFileSync10 } from "fs";
 import { mkdir as mkdir3, readFile as readFile4, writeFile as writeFile4 } from "fs/promises";
 import * as path20 from "path";
 async function migrateContextToKnowledge(directory, config3) {
   const sentinelPath = path20.join(directory, ".swarm", ".knowledge-migrated");
   const contextPath = path20.join(directory, ".swarm", "context.md");
   const knowledgePath = resolveSwarmKnowledgePath(directory);
-  if (existsSync10(sentinelPath)) {
+  if (existsSync11(sentinelPath)) {
     return {
       migrated: false,
       entriesMigrated: 0,
@@ -38487,7 +38683,7 @@ async function migrateContextToKnowledge(directory, config3) {
       skippedReason: "sentinel-exists"
     };
   }
-  if (!existsSync10(contextPath)) {
+  if (!existsSync11(contextPath)) {
     return {
       migrated: false,
       entriesMigrated: 0,
@@ -38673,7 +38869,7 @@ function truncateLesson(text) {
 }
 function inferProjectName(directory) {
   const packageJsonPath = path20.join(directory, "package.json");
-  if (existsSync10(packageJsonPath)) {
+  if (existsSync11(packageJsonPath)) {
     try {
       const pkg = JSON.parse(readFileSync10(packageJsonPath, "utf-8"));
       if (pkg.name && typeof pkg.name === "string") {
@@ -39181,7 +39377,7 @@ async function _detectAvailableLinter(_projectDir, biomeBin, eslintBin) {
       stderr: "pipe"
     });
     const biomeExit = biomeProc.exited;
-    const timeout = new Promise((resolve7) => setTimeout(() => resolve7("timeout"), DETECT_TIMEOUT));
+    const timeout = new Promise((resolve8) => setTimeout(() => resolve8("timeout"), DETECT_TIMEOUT));
     const result = await Promise.race([biomeExit, timeout]);
     if (result === "timeout") {
       biomeProc.kill();
@@ -39195,7 +39391,7 @@ async function _detectAvailableLinter(_projectDir, biomeBin, eslintBin) {
       stderr: "pipe"
     });
     const eslintExit = eslintProc.exited;
-    const timeout = new Promise((resolve7) => setTimeout(() => resolve7("timeout"), DETECT_TIMEOUT));
+    const timeout = new Promise((resolve8) => setTimeout(() => resolve8("timeout"), DETECT_TIMEOUT));
     const result = await Promise.race([eslintExit, timeout]);
     if (result === "timeout") {
       eslintProc.kill();
@@ -40584,15 +40780,15 @@ function appendTestRun(record3, workingDir) {
   prunedRecords.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
   try {
     const lines = prunedRecords.map((rec) => JSON.stringify(rec));
-    const content = lines.join(`
-`) + `
+    const content = `${lines.join(`
+`)}
 `;
-    const tempPath = historyPath + ".tmp";
+    const tempPath = `${historyPath}.tmp`;
     fs14.writeFileSync(tempPath, content, "utf-8");
     fs14.renameSync(tempPath, historyPath);
   } catch (err) {
     try {
-      const tempPath = historyPath + ".tmp";
+      const tempPath = `${historyPath}.tmp`;
       if (fs14.existsSync(tempPath)) {
         fs14.unlinkSync(tempPath);
       }
@@ -41414,9 +41610,9 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
       stderr: "pipe",
       cwd
     });
-    const timeoutPromise = new Promise((resolve10) => setTimeout(() => {
+    const timeoutPromise = new Promise((resolve11) => setTimeout(() => {
       proc.kill();
-      resolve10(-1);
+      resolve11(-1);
     }, timeout_ms));
     const [exitCode, stdoutResult, stderrResult] = await Promise.all([
       Promise.race([proc.exited, timeoutPromise]),
@@ -42643,199 +42839,6 @@ async function handlePromoteCommand(directory, args) {
     }
     return `Failed to promote lesson: ${error93 instanceof Error ? error93.message : String(error93)}`;
   }
-}
-
-// src/db/qa-gate-profile.ts
-import { createHash as createHash4 } from "crypto";
-
-// src/db/project-db.ts
-import { Database } from "bun:sqlite";
-import { existsSync as existsSync16, mkdirSync as mkdirSync8 } from "fs";
-import { join as join23, resolve as resolve11 } from "path";
-var MIGRATIONS = [
-  {
-    version: 1,
-    name: "create_project_constraints",
-    sql: `CREATE TABLE project_constraints (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			constraint_type TEXT NOT NULL,
-			content TEXT NOT NULL,
-			created_at TEXT NOT NULL DEFAULT (datetime('now'))
-		)`
-  },
-  {
-    version: 2,
-    name: "create_qa_gate_profile",
-    sql: `CREATE TABLE qa_gate_profile (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			plan_id TEXT NOT NULL UNIQUE,
-			created_at TEXT NOT NULL DEFAULT (datetime('now')),
-			project_type TEXT,
-			gates TEXT NOT NULL DEFAULT '{}',
-			locked_at TEXT,
-			locked_by_snapshot_seq INTEGER
-		)`
-  },
-  {
-    version: 3,
-    name: "create_qa_gate_profile_immutability_trigger",
-    sql: `CREATE TRIGGER IF NOT EXISTS trg_qa_gate_profile_no_update_after_lock
-			BEFORE UPDATE ON qa_gate_profile
-			WHEN OLD.locked_at IS NOT NULL
-			BEGIN
-				SELECT RAISE(ABORT, 'qa_gate_profile row is locked and cannot be modified after critic approval');
-			END`
-  }
-];
-var _projectDbs = new Map;
-function runProjectMigrations(db) {
-  db.run(`CREATE TABLE IF NOT EXISTS schema_migrations (
-		version INTEGER PRIMARY KEY,
-		name TEXT NOT NULL,
-		applied_at TEXT NOT NULL DEFAULT (datetime('now'))
-	)`);
-  const row = db.query("SELECT MAX(version) as version FROM schema_migrations").get();
-  const currentVersion = row?.version ?? 0;
-  for (const migration of MIGRATIONS) {
-    if (migration.version <= currentVersion)
-      continue;
-    const apply = db.transaction(() => {
-      db.run(migration.sql);
-      db.run("INSERT INTO schema_migrations (version, name) VALUES (?, ?)", [
-        migration.version,
-        migration.name
-      ]);
-    });
-    apply();
-  }
-}
-function projectDbPath(directory) {
-  return join23(resolve11(directory), ".swarm", "swarm.db");
-}
-function projectDbExists(directory) {
-  return existsSync16(projectDbPath(directory));
-}
-function getProjectDb(directory) {
-  const key = resolve11(directory);
-  const existing = _projectDbs.get(key);
-  if (existing)
-    return existing;
-  const swarmDir = join23(key, ".swarm");
-  mkdirSync8(swarmDir, { recursive: true });
-  const db = new Database(join23(swarmDir, "swarm.db"));
-  db.run("PRAGMA journal_mode = WAL;");
-  db.run("PRAGMA synchronous = NORMAL;");
-  db.run("PRAGMA busy_timeout = 5000;");
-  db.run("PRAGMA foreign_keys = ON;");
-  runProjectMigrations(db);
-  _projectDbs.set(key, db);
-  return db;
-}
-
-// src/db/qa-gate-profile.ts
-var DEFAULT_QA_GATES = {
-  reviewer: true,
-  test_engineer: true,
-  council_mode: false,
-  sme_enabled: true,
-  critic_pre_plan: true,
-  hallucination_guard: false,
-  sast_enabled: true
-};
-function rowToProfile(row) {
-  let parsed = {};
-  try {
-    parsed = JSON.parse(row.gates);
-  } catch {
-    parsed = {};
-  }
-  const gates = { ...DEFAULT_QA_GATES, ...parsed };
-  return {
-    id: row.id,
-    plan_id: row.plan_id,
-    created_at: row.created_at,
-    project_type: row.project_type,
-    gates,
-    locked_at: row.locked_at,
-    locked_by_snapshot_seq: row.locked_by_snapshot_seq
-  };
-}
-function getProfile(directory, planId) {
-  if (!projectDbExists(directory))
-    return null;
-  const db = getProjectDb(directory);
-  const row = db.query("SELECT * FROM qa_gate_profile WHERE plan_id = ?").get(planId);
-  return row ? rowToProfile(row) : null;
-}
-function getOrCreateProfile(directory, planId, projectType) {
-  const existing = getProfile(directory, planId);
-  if (existing)
-    return existing;
-  const db = getProjectDb(directory);
-  const gatesJson = JSON.stringify(DEFAULT_QA_GATES);
-  const insert = db.transaction(() => {
-    db.run("INSERT INTO qa_gate_profile (plan_id, project_type, gates) VALUES (?, ?, ?)", [planId, projectType ?? null, gatesJson]);
-  });
-  try {
-    insert();
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (!msg.toLowerCase().includes("unique")) {
-      throw err;
-    }
-  }
-  const after = getProfile(directory, planId);
-  if (!after) {
-    throw new Error(`Failed to create or load QA gate profile for plan_id=${planId}`);
-  }
-  return after;
-}
-function setGates(directory, planId, gates) {
-  const current = getProfile(directory, planId);
-  if (!current) {
-    throw new Error(`No QA gate profile found for plan_id=${planId} \u2014 call getOrCreateProfile first`);
-  }
-  if (current.locked_at !== null) {
-    throw new Error("Cannot modify gates: QA gate profile is locked after critic approval");
-  }
-  const merged = { ...current.gates };
-  for (const key of Object.keys(gates)) {
-    const incoming = gates[key];
-    if (incoming === undefined)
-      continue;
-    if (incoming === false && current.gates[key] === true) {
-      throw new Error(`Cannot disable gate '${key}': sessions can only ratchet tighter`);
-    }
-    if (incoming === true) {
-      merged[key] = true;
-    }
-  }
-  const db = getProjectDb(directory);
-  db.run("UPDATE qa_gate_profile SET gates = ? WHERE plan_id = ?", [
-    JSON.stringify(merged),
-    planId
-  ]);
-  const updated = getProfile(directory, planId);
-  if (!updated) {
-    throw new Error(`Failed to re-read QA gate profile after update for plan_id=${planId}`);
-  }
-  return updated;
-}
-function computeProfileHash(profile) {
-  const payload = JSON.stringify({
-    plan_id: profile.plan_id,
-    gates: profile.gates
-  });
-  return createHash4("sha256").update(payload).digest("hex");
-}
-function getEffectiveGates(profile, sessionOverrides) {
-  const merged = { ...profile.gates };
-  for (const key of Object.keys(sessionOverrides)) {
-    if (sessionOverrides[key] === true) {
-      merged[key] = true;
-    }
-  }
-  return merged;
 }
 
 // src/commands/qa-gates.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -25486,9 +25486,10 @@ async function isCouncilGateActive(directory, council) {
   try {
     profile = getProfile(directory, planId);
   } catch (err2) {
-    const code = err2?.code;
-    if (code && code !== "ENOENT" && code !== "SQLITE_CANTOPEN") {
-      console.warn(`[isCouncilGateActive] getProfile failed for plan ${planId}: ${code}. Treating council as inactive.`);
+    const msg = err2 instanceof Error ? err2.message : String(err2);
+    const isBenign = msg.includes("SQLITE_CANTOPEN") || msg.includes("ENOENT");
+    if (!isBenign) {
+      console.warn(`[isCouncilGateActive] getProfile threw unexpectedly for plan ${planId}: ${msg}. Treating council as inactive.`);
     }
     profile = null;
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -24628,7 +24628,7 @@ function createDelegationGateHook(config2, directory) {
               verdict: result.overallVerdict,
               roundNumber: typeof result.roundNumber === "number" ? result.roundNumber : 1
             });
-            if (result.overallVerdict === "APPROVE" && result.allCriteriaMet === true && (result.requiredFixesCount ?? 0) === 0) {
+            if (councilActive && result.overallVerdict === "APPROVE" && result.allCriteriaMet === true && (result.requiredFixesCount ?? 0) === 0) {
               try {
                 advanceTaskState(session, taskId, "complete");
               } catch (err2) {
@@ -25485,7 +25485,11 @@ async function isCouncilGateActive(directory, council) {
   let profile = null;
   try {
     profile = getProfile(directory, planId);
-  } catch {
+  } catch (err2) {
+    const code = err2?.code;
+    if (code && code !== "ENOENT" && code !== "SQLITE_CANTOPEN") {
+      console.warn(`[isCouncilGateActive] getProfile failed for plan ${planId}: ${code}. Treating council as inactive.`);
+    }
     profile = null;
   }
   if (!profile) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -17555,6 +17555,220 @@ var init_archive = __esm(() => {
   init_manager2();
 });
 
+// src/db/project-db.ts
+import { Database } from "bun:sqlite";
+import { existsSync as existsSync4, mkdirSync as mkdirSync3 } from "fs";
+import { join as join6, resolve as resolve4 } from "path";
+function runProjectMigrations(db) {
+  db.run(`CREATE TABLE IF NOT EXISTS schema_migrations (
+		version INTEGER PRIMARY KEY,
+		name TEXT NOT NULL,
+		applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+	)`);
+  const row = db.query("SELECT MAX(version) as version FROM schema_migrations").get();
+  const currentVersion = row?.version ?? 0;
+  for (const migration of MIGRATIONS) {
+    if (migration.version <= currentVersion)
+      continue;
+    const apply = db.transaction(() => {
+      db.run(migration.sql);
+      db.run("INSERT INTO schema_migrations (version, name) VALUES (?, ?)", [
+        migration.version,
+        migration.name
+      ]);
+    });
+    apply();
+  }
+}
+function projectDbPath(directory) {
+  return join6(resolve4(directory), ".swarm", "swarm.db");
+}
+function projectDbExists(directory) {
+  return existsSync4(projectDbPath(directory));
+}
+function getProjectDb(directory) {
+  const key = resolve4(directory);
+  const existing = _projectDbs.get(key);
+  if (existing)
+    return existing;
+  const swarmDir = join6(key, ".swarm");
+  mkdirSync3(swarmDir, { recursive: true });
+  const db = new Database(join6(swarmDir, "swarm.db"));
+  db.run("PRAGMA journal_mode = WAL;");
+  db.run("PRAGMA synchronous = NORMAL;");
+  db.run("PRAGMA busy_timeout = 5000;");
+  db.run("PRAGMA foreign_keys = ON;");
+  runProjectMigrations(db);
+  _projectDbs.set(key, db);
+  return db;
+}
+var MIGRATIONS, _projectDbs;
+var init_project_db = __esm(() => {
+  MIGRATIONS = [
+    {
+      version: 1,
+      name: "create_project_constraints",
+      sql: `CREATE TABLE project_constraints (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			constraint_type TEXT NOT NULL,
+			content TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (datetime('now'))
+		)`
+    },
+    {
+      version: 2,
+      name: "create_qa_gate_profile",
+      sql: `CREATE TABLE qa_gate_profile (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			plan_id TEXT NOT NULL UNIQUE,
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			project_type TEXT,
+			gates TEXT NOT NULL DEFAULT '{}',
+			locked_at TEXT,
+			locked_by_snapshot_seq INTEGER
+		)`
+    },
+    {
+      version: 3,
+      name: "create_qa_gate_profile_immutability_trigger",
+      sql: `CREATE TRIGGER IF NOT EXISTS trg_qa_gate_profile_no_update_after_lock
+			BEFORE UPDATE ON qa_gate_profile
+			WHEN OLD.locked_at IS NOT NULL
+			BEGIN
+				SELECT RAISE(ABORT, 'qa_gate_profile row is locked and cannot be modified after critic approval');
+			END`
+    }
+  ];
+  _projectDbs = new Map;
+});
+
+// src/db/qa-gate-profile.ts
+import { createHash as createHash3 } from "crypto";
+function rowToProfile(row) {
+  let parsed = {};
+  try {
+    parsed = JSON.parse(row.gates);
+  } catch {
+    parsed = {};
+  }
+  const gates = { ...DEFAULT_QA_GATES, ...parsed };
+  return {
+    id: row.id,
+    plan_id: row.plan_id,
+    created_at: row.created_at,
+    project_type: row.project_type,
+    gates,
+    locked_at: row.locked_at,
+    locked_by_snapshot_seq: row.locked_by_snapshot_seq
+  };
+}
+function getProfile(directory, planId) {
+  if (!projectDbExists(directory))
+    return null;
+  const db = getProjectDb(directory);
+  const row = db.query("SELECT * FROM qa_gate_profile WHERE plan_id = ?").get(planId);
+  return row ? rowToProfile(row) : null;
+}
+function getOrCreateProfile(directory, planId, projectType) {
+  const existing = getProfile(directory, planId);
+  if (existing)
+    return existing;
+  const db = getProjectDb(directory);
+  const gatesJson = JSON.stringify(DEFAULT_QA_GATES);
+  const insert = db.transaction(() => {
+    db.run("INSERT INTO qa_gate_profile (plan_id, project_type, gates) VALUES (?, ?, ?)", [planId, projectType ?? null, gatesJson]);
+  });
+  try {
+    insert();
+  } catch (err2) {
+    const msg = err2 instanceof Error ? err2.message : String(err2);
+    if (!msg.toLowerCase().includes("unique")) {
+      throw err2;
+    }
+  }
+  const after = getProfile(directory, planId);
+  if (!after) {
+    throw new Error(`Failed to create or load QA gate profile for plan_id=${planId}`);
+  }
+  return after;
+}
+function setGates(directory, planId, gates) {
+  const current = getProfile(directory, planId);
+  if (!current) {
+    throw new Error(`No QA gate profile found for plan_id=${planId} \u2014 call getOrCreateProfile first`);
+  }
+  if (current.locked_at !== null) {
+    throw new Error("Cannot modify gates: QA gate profile is locked after critic approval");
+  }
+  const merged = { ...current.gates };
+  for (const key of Object.keys(gates)) {
+    const incoming = gates[key];
+    if (incoming === undefined)
+      continue;
+    if (incoming === false && current.gates[key] === true) {
+      throw new Error(`Cannot disable gate '${key}': sessions can only ratchet tighter`);
+    }
+    if (incoming === true) {
+      merged[key] = true;
+    }
+  }
+  const db = getProjectDb(directory);
+  db.run("UPDATE qa_gate_profile SET gates = ? WHERE plan_id = ?", [
+    JSON.stringify(merged),
+    planId
+  ]);
+  const updated = getProfile(directory, planId);
+  if (!updated) {
+    throw new Error(`Failed to re-read QA gate profile after update for plan_id=${planId}`);
+  }
+  return updated;
+}
+function lockProfile(directory, planId, snapshotSeq) {
+  const current = getProfile(directory, planId);
+  if (!current) {
+    throw new Error(`No QA gate profile found for plan_id=${planId} \u2014 cannot lock`);
+  }
+  if (current.locked_at !== null) {
+    return current;
+  }
+  const db = getProjectDb(directory);
+  db.run("UPDATE qa_gate_profile SET locked_at = datetime('now'), locked_by_snapshot_seq = ? WHERE plan_id = ?", [snapshotSeq, planId]);
+  const locked = getProfile(directory, planId);
+  if (!locked) {
+    throw new Error(`Failed to re-read locked QA gate profile for plan_id=${planId}`);
+  }
+  return locked;
+}
+function computeProfileHash(profile) {
+  const payload = JSON.stringify({
+    plan_id: profile.plan_id,
+    gates: profile.gates
+  });
+  return createHash3("sha256").update(payload).digest("hex");
+}
+function getEffectiveGates(profile, sessionOverrides) {
+  const merged = { ...profile.gates };
+  for (const key of Object.keys(sessionOverrides)) {
+    if (sessionOverrides[key] === true) {
+      merged[key] = true;
+    }
+  }
+  return merged;
+}
+var DEFAULT_QA_GATES;
+var init_qa_gate_profile = __esm(() => {
+  init_project_db();
+  DEFAULT_QA_GATES = {
+    reviewer: true,
+    test_engineer: true,
+    council_mode: false,
+    sme_enabled: true,
+    critic_pre_plan: true,
+    hallucination_guard: false,
+    sast_enabled: true
+  };
+});
+
 // src/environment/profile.ts
 function detectHostOS() {
   switch (process.platform) {
@@ -21377,12 +21591,12 @@ var require_adapter = __commonJS((exports, module2) => {
     return newFs;
   }
   function toPromise(method) {
-    return (...args2) => new Promise((resolve4, reject) => {
+    return (...args2) => new Promise((resolve5, reject) => {
       args2.push((err2, result) => {
         if (err2) {
           reject(err2);
         } else {
-          resolve4(result);
+          resolve5(result);
         }
       });
       method(...args2);
@@ -24130,7 +24344,7 @@ __export(exports_gate_evidence, {
   deriveRequiredGates: () => deriveRequiredGates,
   DEFAULT_REQUIRED_GATES: () => DEFAULT_REQUIRED_GATES
 });
-import { mkdirSync as mkdirSync5, readFileSync as readFileSync4, renameSync as renameSync5, unlinkSync as unlinkSync3 } from "fs";
+import { mkdirSync as mkdirSync6, readFileSync as readFileSync4, renameSync as renameSync5, unlinkSync as unlinkSync3 } from "fs";
 import * as path9 from "path";
 function isValidTaskId(taskId) {
   return isStrictTaskId(taskId);
@@ -24195,7 +24409,7 @@ async function recordGateEvidence(directory, taskId, gate, sessionId, turbo) {
   assertValidTaskId(taskId);
   const evidenceDir = getEvidenceDir(directory);
   const evidencePath = getEvidencePath(directory, taskId);
-  mkdirSync5(evidenceDir, { recursive: true });
+  mkdirSync6(evidenceDir, { recursive: true });
   const existing = readExisting(evidencePath);
   const requiredGates = existing ? expandRequiredGates(existing.required_gates, gate) : deriveRequiredGates(gate);
   const updated = {
@@ -24218,7 +24432,7 @@ async function recordAgentDispatch(directory, taskId, agentType, turbo) {
   assertValidTaskId(taskId);
   const evidenceDir = getEvidenceDir(directory);
   const evidencePath = getEvidencePath(directory, taskId);
-  mkdirSync5(evidenceDir, { recursive: true });
+  mkdirSync6(evidenceDir, { recursive: true });
   const existing = readExisting(evidencePath);
   const requiredGates = existing ? expandRequiredGates(existing.required_gates, agentType) : deriveRequiredGates(agentType);
   const updated = {
@@ -24397,6 +24611,37 @@ function createDelegationGateHook(config2, directory) {
     if (!session)
       return;
     const normalized = normalizeToolName(input.tool);
+    const councilActive = await isCouncilGateActive(directory, config2.council);
+    if (normalized === "convene_council") {
+      try {
+        const parsed = typeof _output === "string" ? JSON.parse(_output) : _output;
+        const result = parsed;
+        if (result && typeof result === "object" && result.success === true && typeof result.overallVerdict === "string") {
+          const directArgs = input.args;
+          const storedArgs = getStoredInputArgs(input.callID);
+          const taskIdRaw = directArgs?.taskId ?? storedArgs?.taskId;
+          const taskId = typeof taskIdRaw === "string" ? taskIdRaw : null;
+          if (taskId) {
+            if (!session.taskCouncilApproved)
+              session.taskCouncilApproved = new Map;
+            session.taskCouncilApproved.set(taskId, {
+              verdict: result.overallVerdict,
+              roundNumber: typeof result.roundNumber === "number" ? result.roundNumber : 1
+            });
+            if (result.overallVerdict === "APPROVE" && result.allCriteriaMet === true && (result.requiredFixesCount ?? 0) === 0) {
+              try {
+                advanceTaskState(session, taskId, "complete");
+              } catch (err2) {
+                console.warn(`[delegation-gate] toolAfter convene_council: could not advance ${taskId} \u2192 complete: ${err2 instanceof Error ? err2.message : String(err2)}`);
+              }
+            }
+          }
+        }
+      } catch (err2) {
+        console.warn(`[delegation-gate] toolAfter convene_council: failed to parse output: ${err2 instanceof Error ? err2.message : String(err2)}`);
+      }
+      return;
+    }
     if (normalized === "Task" || normalized === "task") {
       const directArgs = input.args;
       const storedArgs = getStoredInputArgs(input.callID);
@@ -24409,60 +24654,62 @@ function createDelegationGateHook(config2, directory) {
           hasReviewer = true;
         if (targetAgent === "test_engineer")
           hasTestEngineer = true;
-        if (targetAgent === "reviewer" && session.taskWorkflowStates) {
-          for (const [taskId, state] of session.taskWorkflowStates) {
-            if (state === "coder_delegated" || state === "pre_check_passed") {
-              try {
-                advanceTaskState(session, taskId, "reviewer_run");
-              } catch (err2) {
-                console.warn(`[delegation-gate] toolAfter: could not advance ${taskId} (${state}) \u2192 reviewer_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
-              }
-            }
-          }
-        }
-        if (targetAgent === "test_engineer" && session.taskWorkflowStates) {
-          for (const [taskId, state] of session.taskWorkflowStates) {
-            if (state === "reviewer_run") {
-              try {
-                advanceTaskState(session, taskId, "tests_run");
-              } catch (err2) {
-                console.warn(`[delegation-gate] toolAfter: could not advance ${taskId} (${state}) \u2192 tests_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
-              }
-            }
-          }
-        }
-        if (targetAgent === "reviewer" || targetAgent === "test_engineer") {
-          for (const [, otherSession] of swarmState.agentSessions) {
-            if (otherSession === session)
-              continue;
-            if (!otherSession.taskWorkflowStates)
-              continue;
-            if (targetAgent === "reviewer") {
-              const seedTaskId = getSeedTaskId(session);
-              if (seedTaskId && !otherSession.taskWorkflowStates.has(seedTaskId)) {
-                otherSession.taskWorkflowStates.set(seedTaskId, "coder_delegated");
-              }
-              for (const [taskId, state] of otherSession.taskWorkflowStates) {
-                if (state === "coder_delegated" || state === "pre_check_passed") {
-                  try {
-                    advanceTaskState(otherSession, taskId, "reviewer_run");
-                  } catch (err2) {
-                    console.warn(`[delegation-gate] toolAfter cross-session: could not advance ${taskId} (${state}) \u2192 reviewer_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
-                  }
+        if (!councilActive) {
+          if (targetAgent === "reviewer" && session.taskWorkflowStates) {
+            for (const [taskId, state] of session.taskWorkflowStates) {
+              if (state === "coder_delegated" || state === "pre_check_passed") {
+                try {
+                  advanceTaskState(session, taskId, "reviewer_run");
+                } catch (err2) {
+                  console.warn(`[delegation-gate] toolAfter: could not advance ${taskId} (${state}) \u2192 reviewer_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
                 }
               }
             }
-            if (targetAgent === "test_engineer") {
-              const seedTaskId = getSeedTaskId(session);
-              if (seedTaskId && !otherSession.taskWorkflowStates.has(seedTaskId)) {
-                otherSession.taskWorkflowStates.set(seedTaskId, "reviewer_run");
+          }
+          if (targetAgent === "test_engineer" && session.taskWorkflowStates) {
+            for (const [taskId, state] of session.taskWorkflowStates) {
+              if (state === "reviewer_run") {
+                try {
+                  advanceTaskState(session, taskId, "tests_run");
+                } catch (err2) {
+                  console.warn(`[delegation-gate] toolAfter: could not advance ${taskId} (${state}) \u2192 tests_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
+                }
               }
-              for (const [taskId, state] of otherSession.taskWorkflowStates) {
-                if (state === "reviewer_run") {
-                  try {
-                    advanceTaskState(otherSession, taskId, "tests_run");
-                  } catch (err2) {
-                    console.warn(`[delegation-gate] toolAfter cross-session: could not advance ${taskId} (${state}) \u2192 tests_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
+            }
+          }
+          if (targetAgent === "reviewer" || targetAgent === "test_engineer") {
+            for (const [, otherSession] of swarmState.agentSessions) {
+              if (otherSession === session)
+                continue;
+              if (!otherSession.taskWorkflowStates)
+                continue;
+              if (targetAgent === "reviewer") {
+                const seedTaskId = getSeedTaskId(session);
+                if (seedTaskId && !otherSession.taskWorkflowStates.has(seedTaskId)) {
+                  otherSession.taskWorkflowStates.set(seedTaskId, "coder_delegated");
+                }
+                for (const [taskId, state] of otherSession.taskWorkflowStates) {
+                  if (state === "coder_delegated" || state === "pre_check_passed") {
+                    try {
+                      advanceTaskState(otherSession, taskId, "reviewer_run");
+                    } catch (err2) {
+                      console.warn(`[delegation-gate] toolAfter cross-session: could not advance ${taskId} (${state}) \u2192 reviewer_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
+                    }
+                  }
+                }
+              }
+              if (targetAgent === "test_engineer") {
+                const seedTaskId = getSeedTaskId(session);
+                if (seedTaskId && !otherSession.taskWorkflowStates.has(seedTaskId)) {
+                  otherSession.taskWorkflowStates.set(seedTaskId, "reviewer_run");
+                }
+                for (const [taskId, state] of otherSession.taskWorkflowStates) {
+                  if (state === "reviewer_run") {
+                    try {
+                      advanceTaskState(otherSession, taskId, "tests_run");
+                    } catch (err2) {
+                      console.warn(`[delegation-gate] toolAfter cross-session: could not advance ${taskId} (${state}) \u2192 tests_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
+                    }
                   }
                 }
               }
@@ -24521,69 +24768,71 @@ function createDelegationGateHook(config2, directory) {
             if (target === "test_engineer")
               hasTestEngineer = true;
           }
-          if (lastCoderIndex !== -1 && hasReviewer && hasTestEngineer) {
-            session.qaSkipCount = 0;
-            session.qaSkipTaskIds = [];
-          }
-          if (lastCoderIndex !== -1 && hasReviewer && session.taskWorkflowStates) {
-            for (const [taskId, state] of session.taskWorkflowStates) {
-              if (state === "coder_delegated" || state === "pre_check_passed") {
-                try {
-                  advanceTaskState(session, taskId, "reviewer_run");
-                } catch (err2) {
-                  console.warn(`[delegation-gate] fallback: could not advance ${taskId} (${state}) \u2192 reviewer_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
-                }
-              }
+          if (!councilActive) {
+            if (lastCoderIndex !== -1 && hasReviewer && hasTestEngineer) {
+              session.qaSkipCount = 0;
+              session.qaSkipTaskIds = [];
             }
-          }
-          if (lastCoderIndex !== -1 && hasReviewer && hasTestEngineer && session.taskWorkflowStates) {
-            for (const [taskId, state] of session.taskWorkflowStates) {
-              if (state === "reviewer_run") {
-                try {
-                  advanceTaskState(session, taskId, "tests_run");
-                } catch (err2) {
-                  console.warn(`[delegation-gate] fallback: could not advance ${taskId} (${state}) \u2192 tests_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
-                }
-              }
-            }
-          }
-          if (lastCoderIndex !== -1 && hasReviewer) {
-            for (const [, otherSession] of swarmState.agentSessions) {
-              if (otherSession === session)
-                continue;
-              if (!otherSession.taskWorkflowStates)
-                continue;
-              const seedTaskId = getSeedTaskId(session);
-              if (seedTaskId && !otherSession.taskWorkflowStates.has(seedTaskId)) {
-                otherSession.taskWorkflowStates.set(seedTaskId, "coder_delegated");
-              }
-              for (const [taskId, state] of otherSession.taskWorkflowStates) {
+            if (lastCoderIndex !== -1 && hasReviewer && session.taskWorkflowStates) {
+              for (const [taskId, state] of session.taskWorkflowStates) {
                 if (state === "coder_delegated" || state === "pre_check_passed") {
                   try {
-                    advanceTaskState(otherSession, taskId, "reviewer_run");
+                    advanceTaskState(session, taskId, "reviewer_run");
                   } catch (err2) {
-                    console.warn(`[delegation-gate] fallback cross-session: could not advance ${taskId} (${state}) \u2192 reviewer_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
+                    console.warn(`[delegation-gate] fallback: could not advance ${taskId} (${state}) \u2192 reviewer_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
                   }
                 }
               }
             }
-          }
-          if (lastCoderIndex !== -1 && hasReviewer && hasTestEngineer) {
-            for (const [, otherSession] of swarmState.agentSessions) {
-              if (otherSession === session)
-                continue;
-              if (!otherSession.taskWorkflowStates)
-                continue;
-              const seedTaskId = getSeedTaskId(session);
-              if (seedTaskId && !otherSession.taskWorkflowStates.has(seedTaskId)) {
-                otherSession.taskWorkflowStates.set(seedTaskId, "reviewer_run");
-              }
-              for (const [taskId, state] of otherSession.taskWorkflowStates) {
+            if (lastCoderIndex !== -1 && hasReviewer && hasTestEngineer && session.taskWorkflowStates) {
+              for (const [taskId, state] of session.taskWorkflowStates) {
                 if (state === "reviewer_run") {
                   try {
-                    advanceTaskState(otherSession, taskId, "tests_run");
+                    advanceTaskState(session, taskId, "tests_run");
                   } catch (err2) {
-                    console.warn(`[delegation-gate] fallback cross-session: could not advance ${taskId} (${state}) \u2192 tests_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
+                    console.warn(`[delegation-gate] fallback: could not advance ${taskId} (${state}) \u2192 tests_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
+                  }
+                }
+              }
+            }
+            if (lastCoderIndex !== -1 && hasReviewer) {
+              for (const [, otherSession] of swarmState.agentSessions) {
+                if (otherSession === session)
+                  continue;
+                if (!otherSession.taskWorkflowStates)
+                  continue;
+                const seedTaskId = getSeedTaskId(session);
+                if (seedTaskId && !otherSession.taskWorkflowStates.has(seedTaskId)) {
+                  otherSession.taskWorkflowStates.set(seedTaskId, "coder_delegated");
+                }
+                for (const [taskId, state] of otherSession.taskWorkflowStates) {
+                  if (state === "coder_delegated" || state === "pre_check_passed") {
+                    try {
+                      advanceTaskState(otherSession, taskId, "reviewer_run");
+                    } catch (err2) {
+                      console.warn(`[delegation-gate] fallback cross-session: could not advance ${taskId} (${state}) \u2192 reviewer_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
+                    }
+                  }
+                }
+              }
+            }
+            if (lastCoderIndex !== -1 && hasReviewer && hasTestEngineer) {
+              for (const [, otherSession] of swarmState.agentSessions) {
+                if (otherSession === session)
+                  continue;
+                if (!otherSession.taskWorkflowStates)
+                  continue;
+                const seedTaskId = getSeedTaskId(session);
+                if (seedTaskId && !otherSession.taskWorkflowStates.has(seedTaskId)) {
+                  otherSession.taskWorkflowStates.set(seedTaskId, "reviewer_run");
+                }
+                for (const [taskId, state] of otherSession.taskWorkflowStates) {
+                  if (state === "reviewer_run") {
+                    try {
+                      advanceTaskState(otherSession, taskId, "tests_run");
+                    } catch (err2) {
+                      console.warn(`[delegation-gate] fallback cross-session: could not advance ${taskId} (${state}) \u2192 tests_run: ${err2 instanceof Error ? err2.message : String(err2)}`);
+                    }
                   }
                 }
               }
@@ -24854,6 +25103,7 @@ __export(exports_state, {
   rehydrateSessionFromDisk: () => rehydrateSessionFromDisk,
   recordPhaseAgentDispatch: () => recordPhaseAgentDispatch,
   pruneOldWindows: () => pruneOldWindows,
+  isCouncilGateActive: () => isCouncilGateActive,
   hasActiveTurboMode: () => hasActiveTurboMode,
   hasActiveFullAuto: () => hasActiveFullAuto,
   getTaskState: () => getTaskState,
@@ -24866,7 +25116,8 @@ __export(exports_state, {
   buildRehydrationCache: () => buildRehydrationCache,
   beginInvocation: () => beginInvocation,
   applyRehydrationCache: () => applyRehydrationCache,
-  advanceTaskState: () => advanceTaskState
+  advanceTaskState: () => advanceTaskState,
+  _resetCouncilDisagreementWarnings: () => _resetCouncilDisagreementWarnings
 });
 import * as fs9 from "fs/promises";
 import * as path11 from "path";
@@ -24886,6 +25137,7 @@ function resetSwarmState() {
   swarmState.fullAutoEnabledInConfig = false;
   swarmState.environmentProfiles.clear();
   clearPendingCoderScope();
+  _councilDisagreementWarned.clear();
 }
 function startAgentSession(sessionId, agentName, staleDurationMs = 7200000, directory) {
   const now = Date.now();
@@ -24924,6 +25176,7 @@ function startAgentSession(sessionId, agentName, staleDurationMs = 7200000, dire
     qaSkipCount: 0,
     qaSkipTaskIds: [],
     taskWorkflowStates: new Map,
+    taskCouncilApproved: new Map,
     lastGateOutcome: null,
     declaredCoderScope: null,
     lastScopeViolation: null,
@@ -25037,6 +25290,9 @@ function ensureAgentSession(sessionId, agentName, directory) {
     }
     if (!session.taskWorkflowStates) {
       session.taskWorkflowStates = new Map;
+    }
+    if (!session.taskCouncilApproved) {
+      session.taskCouncilApproved = new Map;
     }
     if (session.lastGateOutcome === undefined) {
       session.lastGateOutcome = null;
@@ -25192,7 +25448,12 @@ function advanceTaskState(session, taskId, newState) {
     throw new Error(`INVALID_TASK_STATE_TRANSITION: ${taskId} ${current} \u2192 ${newState}`);
   }
   if (newState === "complete" && current !== "tests_run") {
-    throw new Error(`INVALID_TASK_STATE_TRANSITION: ${taskId} cannot reach complete from ${current} \u2014 must pass through tests_run first`);
+    const councilEntry = session.taskCouncilApproved?.get(taskId);
+    const councilApproved = councilEntry?.verdict === "APPROVE";
+    const pastPreCheck = currentIndex >= STATE_ORDER.indexOf("pre_check_passed");
+    if (!councilApproved || !pastPreCheck) {
+      throw new Error(`INVALID_TASK_STATE_TRANSITION: ${taskId} cannot reach complete from ${current} \u2014 must pass through tests_run first (or have council APPROVE after pre_check)`);
+    }
   }
   session.taskWorkflowStates.set(taskId, newState);
   telemetry.taskStateChanged(session.agentName, taskId, newState, current);
@@ -25205,6 +25466,43 @@ function getTaskState(session, taskId) {
     session.taskWorkflowStates = new Map;
   }
   return session.taskWorkflowStates.get(taskId) ?? "idle";
+}
+function derivePlanIdFromPlan(plan) {
+  return `${plan.swarm}-${plan.title}`.replace(/[^a-zA-Z0-9-_]/g, "_");
+}
+async function isCouncilGateActive(directory, council) {
+  const enabled = council?.enabled === true;
+  let plan = null;
+  try {
+    plan = await loadPlanJsonOnly(directory);
+  } catch {
+    plan = null;
+  }
+  if (!plan) {
+    return false;
+  }
+  const planId = derivePlanIdFromPlan(plan);
+  let profile = null;
+  try {
+    profile = getProfile(directory, planId);
+  } catch {
+    profile = null;
+  }
+  if (!profile) {
+    return false;
+  }
+  const councilMode = profile.gates.council_mode === true;
+  if (enabled && councilMode) {
+    return true;
+  }
+  if (enabled !== councilMode && !_councilDisagreementWarned.has(planId)) {
+    _councilDisagreementWarned.add(planId);
+    console.warn(`[delegation-gate] Council mode mismatch for plan ${planId}: ` + `pluginConfig.council.enabled=${enabled}, QaGates.council_mode=${councilMode}. ` + "Falling back to Stage B (non-council) advancement.");
+  }
+  return false;
+}
+function _resetCouncilDisagreementWarnings() {
+  _councilDisagreementWarned.clear();
 }
 function planStatusToWorkflowState(status) {
   switch (status) {
@@ -25291,6 +25589,9 @@ function applyRehydrationCache(session) {
   if (!session.taskWorkflowStates) {
     session.taskWorkflowStates = new Map;
   }
+  if (!session.taskCouncilApproved) {
+    session.taskCouncilApproved = new Map;
+  }
   const { planTaskStates, evidenceMap } = _rehydrationCache;
   const STATE_ORDER = [
     "idle",
@@ -25364,13 +25665,16 @@ function ensureSessionEnvironment(sessionId) {
   }).catch(() => {});
   return profile;
 }
-var _rehydrationCache = null, swarmState;
+var _rehydrationCache = null, _councilDisagreementWarned, swarmState;
 var init_state = __esm(() => {
   init_constants();
   init_plan_schema();
   init_schema();
+  init_qa_gate_profile();
   init_delegation_gate();
+  init_manager();
   init_telemetry();
+  _councilDisagreementWarned = new Set;
   swarmState = {
     activeToolCalls: new Map,
     toolAggregates: new Map,
@@ -38897,7 +39201,7 @@ var init_branch = __esm(() => {
 });
 
 // src/hooks/knowledge-store.ts
-import { existsSync as existsSync7 } from "fs";
+import { existsSync as existsSync8 } from "fs";
 import { appendFile as appendFile3, mkdir as mkdir2, readFile as readFile3, writeFile as writeFile2 } from "fs/promises";
 import * as os3 from "os";
 import * as path13 from "path";
@@ -38925,7 +39229,7 @@ function resolveHiveRejectedPath() {
   return path13.join(path13.dirname(hivePath), "shared-learnings-rejected.jsonl");
 }
 async function readKnowledge(filePath) {
-  if (!existsSync7(filePath))
+  if (!existsSync8(filePath))
     return [];
   const content = await readFile3(filePath, "utf-8");
   const results = [];
@@ -39161,7 +39465,7 @@ var init_knowledge_store = __esm(() => {
 });
 
 // src/hooks/knowledge-reader.ts
-import { existsSync as existsSync8 } from "fs";
+import { existsSync as existsSync9 } from "fs";
 import { mkdir as mkdir3, readFile as readFile4, writeFile as writeFile3 } from "fs/promises";
 import * as path14 from "path";
 function inferCategoriesFromPhase(phaseDescription) {
@@ -39211,7 +39515,7 @@ async function recordLessonsShown(directory, lessonIds, currentPhase) {
   const shownFile = path14.join(directory, ".swarm", ".knowledge-shown.json");
   try {
     let shownData = {};
-    if (existsSync8(shownFile)) {
+    if (existsSync9(shownFile)) {
       const content = await readFile4(shownFile, "utf-8");
       shownData = JSON.parse(content);
     }
@@ -39317,7 +39621,7 @@ async function readMergedKnowledge(directory, config3, context) {
 async function updateRetrievalOutcome(directory, phaseInfo, phaseSucceeded) {
   const shownFile = path14.join(directory, ".swarm", ".knowledge-shown.json");
   try {
-    if (!existsSync8(shownFile)) {
+    if (!existsSync9(shownFile)) {
       return;
     }
     const content = await readFile4(shownFile, "utf-8");
@@ -40090,7 +40394,7 @@ var init_checkpoint3 = __esm(() => {
 });
 
 // src/session/snapshot-writer.ts
-import { mkdirSync as mkdirSync7, renameSync as renameSync7 } from "fs";
+import { mkdirSync as mkdirSync8, renameSync as renameSync7 } from "fs";
 import * as path17 from "path";
 function serializeAgentSession(s) {
   const gateLog = {};
@@ -40181,7 +40485,7 @@ async function writeSnapshot(directory, state) {
     const content = JSON.stringify(snapshot, null, 2);
     const resolvedPath = validateSwarmPath(directory, "session/state.json");
     const dir = path17.dirname(resolvedPath);
-    mkdirSync7(dir, { recursive: true });
+    mkdirSync8(dir, { recursive: true });
     const tempPath = `${resolvedPath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2)}`;
     await Bun.write(tempPath, content);
     renameSync7(tempPath, resolvedPath);
@@ -42717,7 +43021,7 @@ var init_dark_matter = __esm(() => {
 
 // src/services/diagnose-service.ts
 import * as child_process4 from "child_process";
-import { existsSync as existsSync9, readdirSync as readdirSync3, readFileSync as readFileSync7, statSync as statSync5 } from "fs";
+import { existsSync as existsSync10, readdirSync as readdirSync3, readFileSync as readFileSync7, statSync as statSync5 } from "fs";
 import path23 from "path";
 import { fileURLToPath } from "url";
 function validateTaskDag(plan) {
@@ -42951,7 +43255,7 @@ async function checkConfigBackups(directory) {
 }
 async function checkGitRepository(directory) {
   try {
-    if (!existsSync9(directory) || !statSync5(directory).isDirectory()) {
+    if (!existsSync10(directory) || !statSync5(directory).isDirectory()) {
       return {
         name: "Git Repository",
         status: "\u274C",
@@ -43016,7 +43320,7 @@ async function checkSpecStaleness(directory, plan) {
 }
 async function checkConfigParseability(directory) {
   const configPath = path23.join(directory, ".opencode/opencode-swarm.json");
-  if (!existsSync9(configPath)) {
+  if (!existsSync10(configPath)) {
     return {
       name: "Config Parseability",
       status: "\u2705",
@@ -43066,11 +43370,11 @@ async function checkGrammarWasmFiles() {
   const isSource = thisDir.replace(/\\/g, "/").endsWith("/src/services");
   const grammarDir = isSource ? path23.join(thisDir, "..", "lang", "grammars") : path23.join(thisDir, "lang", "grammars");
   const missing = [];
-  if (!existsSync9(path23.join(grammarDir, "tree-sitter.wasm"))) {
+  if (!existsSync10(path23.join(grammarDir, "tree-sitter.wasm"))) {
     missing.push("tree-sitter.wasm (core runtime)");
   }
   for (const file3 of grammarFiles) {
-    if (!existsSync9(path23.join(grammarDir, file3))) {
+    if (!existsSync10(path23.join(grammarDir, file3))) {
       missing.push(file3);
     }
   }
@@ -43089,7 +43393,7 @@ async function checkGrammarWasmFiles() {
 }
 async function checkCheckpointManifest(directory) {
   const manifestPath = path23.join(directory, ".swarm/checkpoints.json");
-  if (!existsSync9(manifestPath)) {
+  if (!existsSync10(manifestPath)) {
     return {
       name: "Checkpoint Manifest",
       status: "\u2705",
@@ -43141,7 +43445,7 @@ async function checkCheckpointManifest(directory) {
 }
 async function checkEventStreamIntegrity(directory) {
   const eventsPath = path23.join(directory, ".swarm/events.jsonl");
-  if (!existsSync9(eventsPath)) {
+  if (!existsSync10(eventsPath)) {
     return {
       name: "Event Stream",
       status: "\u2705",
@@ -43182,7 +43486,7 @@ async function checkEventStreamIntegrity(directory) {
 }
 async function checkSteeringDirectives(directory) {
   const eventsPath = path23.join(directory, ".swarm/events.jsonl");
-  if (!existsSync9(eventsPath)) {
+  if (!existsSync10(eventsPath)) {
     return {
       name: "Steering Directives",
       status: "\u2705",
@@ -43238,7 +43542,7 @@ async function checkCurator(directory) {
       };
     }
     const summaryPath = path23.join(directory, ".swarm/curator-summary.json");
-    if (!existsSync9(summaryPath)) {
+    if (!existsSync10(summaryPath)) {
       return {
         name: "Curator",
         status: "\u2705",
@@ -43386,7 +43690,7 @@ async function getDiagnoseData(directory) {
   checks5.push(await checkCurator(directory));
   try {
     const evidenceDir = path23.join(directory, ".swarm", "evidence");
-    const snapshotFiles = existsSync9(evidenceDir) ? readdirSync3(evidenceDir).filter((f) => f.startsWith("agent-tools-") && f.endsWith(".json")) : [];
+    const snapshotFiles = existsSync10(evidenceDir) ? readdirSync3(evidenceDir).filter((f) => f.startsWith("agent-tools-") && f.endsWith(".json")) : [];
     if (snapshotFiles.length > 0) {
       const latest = snapshotFiles.sort().pop();
       checks5.push({
@@ -45051,7 +45355,7 @@ var init_profiles = __esm(() => {
 
 // src/lang/detector.ts
 import { access as access2, readdir as readdir3 } from "fs/promises";
-import { extname as extname2, join as join21 } from "path";
+import { extname as extname2, join as join22 } from "path";
 function getProfileForFile(filePath) {
   const ext = extname2(filePath);
   if (!ext)
@@ -45073,7 +45377,7 @@ async function detectProjectLanguages(projectDir) {
         if (detectFile.includes("*") || detectFile.includes("?"))
           continue;
         try {
-          await access2(join21(dir, detectFile));
+          await access2(join22(dir, detectFile));
           detected.add(profile.id);
           break;
         } catch {}
@@ -45094,7 +45398,7 @@ async function detectProjectLanguages(projectDir) {
     const topEntries = await readdir3(projectDir, { withFileTypes: true });
     for (const entry of topEntries) {
       if (entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules") {
-        await scanDir(join21(projectDir, entry.name));
+        await scanDir(join22(projectDir, entry.name));
       }
     }
   } catch {}
@@ -46781,14 +47085,14 @@ var init_history = __esm(() => {
 
 // src/hooks/knowledge-migrator.ts
 import { randomUUID as randomUUID3 } from "crypto";
-import { existsSync as existsSync13, readFileSync as readFileSync11 } from "fs";
+import { existsSync as existsSync14, readFileSync as readFileSync11 } from "fs";
 import { mkdir as mkdir5, readFile as readFile6, writeFile as writeFile5 } from "fs/promises";
 import * as path27 from "path";
 async function migrateContextToKnowledge(directory, config3) {
   const sentinelPath = path27.join(directory, ".swarm", ".knowledge-migrated");
   const contextPath = path27.join(directory, ".swarm", "context.md");
   const knowledgePath = resolveSwarmKnowledgePath(directory);
-  if (existsSync13(sentinelPath)) {
+  if (existsSync14(sentinelPath)) {
     return {
       migrated: false,
       entriesMigrated: 0,
@@ -46797,7 +47101,7 @@ async function migrateContextToKnowledge(directory, config3) {
       skippedReason: "sentinel-exists"
     };
   }
-  if (!existsSync13(contextPath)) {
+  if (!existsSync14(contextPath)) {
     return {
       migrated: false,
       entriesMigrated: 0,
@@ -46983,7 +47287,7 @@ function truncateLesson(text) {
 }
 function inferProjectName(directory) {
   const packageJsonPath = path27.join(directory, "package.json");
-  if (existsSync13(packageJsonPath)) {
+  if (existsSync14(packageJsonPath)) {
     try {
       const pkg = JSON.parse(readFileSync11(packageJsonPath, "utf-8"));
       if (pkg.name && typeof pkg.name === "string") {
@@ -47551,7 +47855,7 @@ async function _detectAvailableLinter(_projectDir, biomeBin, eslintBin) {
       stderr: "pipe"
     });
     const biomeExit = biomeProc.exited;
-    const timeout = new Promise((resolve9) => setTimeout(() => resolve9("timeout"), DETECT_TIMEOUT));
+    const timeout = new Promise((resolve10) => setTimeout(() => resolve10("timeout"), DETECT_TIMEOUT));
     const result = await Promise.race([biomeExit, timeout]);
     if (result === "timeout") {
       biomeProc.kill();
@@ -47565,7 +47869,7 @@ async function _detectAvailableLinter(_projectDir, biomeBin, eslintBin) {
       stderr: "pipe"
     });
     const eslintExit = eslintProc.exited;
-    const timeout = new Promise((resolve9) => setTimeout(() => resolve9("timeout"), DETECT_TIMEOUT));
+    const timeout = new Promise((resolve10) => setTimeout(() => resolve10("timeout"), DETECT_TIMEOUT));
     const result = await Promise.race([eslintExit, timeout]);
     if (result === "timeout") {
       eslintProc.kill();
@@ -48948,15 +49252,15 @@ function appendTestRun(record3, workingDir) {
   prunedRecords.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
   try {
     const lines = prunedRecords.map((rec) => JSON.stringify(rec));
-    const content = lines.join(`
-`) + `
+    const content = `${lines.join(`
+`)}
 `;
-    const tempPath = historyPath + ".tmp";
+    const tempPath = `${historyPath}.tmp`;
     fs21.writeFileSync(tempPath, content, "utf-8");
     fs21.renameSync(tempPath, historyPath);
   } catch (err2) {
     try {
-      const tempPath = historyPath + ".tmp";
+      const tempPath = `${historyPath}.tmp`;
       if (fs21.existsSync(tempPath)) {
         fs21.unlinkSync(tempPath);
       }
@@ -49764,9 +50068,9 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
       stderr: "pipe",
       cwd
     });
-    const timeoutPromise = new Promise((resolve12) => setTimeout(() => {
+    const timeoutPromise = new Promise((resolve13) => setTimeout(() => {
       proc.kill();
-      resolve12(-1);
+      resolve13(-1);
     }, timeout_ms));
     const [exitCode, stdoutResult, stderrResult] = await Promise.all([
       Promise.race([proc.exited, timeoutPromise]),
@@ -51043,220 +51347,6 @@ async function handlePromoteCommand(directory, args2) {
 }
 var init_promote = __esm(() => {
   init_hive_promoter2();
-});
-
-// src/db/project-db.ts
-import { Database } from "bun:sqlite";
-import { existsSync as existsSync19, mkdirSync as mkdirSync11 } from "fs";
-import { join as join30, resolve as resolve13 } from "path";
-function runProjectMigrations(db) {
-  db.run(`CREATE TABLE IF NOT EXISTS schema_migrations (
-		version INTEGER PRIMARY KEY,
-		name TEXT NOT NULL,
-		applied_at TEXT NOT NULL DEFAULT (datetime('now'))
-	)`);
-  const row = db.query("SELECT MAX(version) as version FROM schema_migrations").get();
-  const currentVersion = row?.version ?? 0;
-  for (const migration of MIGRATIONS) {
-    if (migration.version <= currentVersion)
-      continue;
-    const apply = db.transaction(() => {
-      db.run(migration.sql);
-      db.run("INSERT INTO schema_migrations (version, name) VALUES (?, ?)", [
-        migration.version,
-        migration.name
-      ]);
-    });
-    apply();
-  }
-}
-function projectDbPath(directory) {
-  return join30(resolve13(directory), ".swarm", "swarm.db");
-}
-function projectDbExists(directory) {
-  return existsSync19(projectDbPath(directory));
-}
-function getProjectDb(directory) {
-  const key = resolve13(directory);
-  const existing = _projectDbs.get(key);
-  if (existing)
-    return existing;
-  const swarmDir = join30(key, ".swarm");
-  mkdirSync11(swarmDir, { recursive: true });
-  const db = new Database(join30(swarmDir, "swarm.db"));
-  db.run("PRAGMA journal_mode = WAL;");
-  db.run("PRAGMA synchronous = NORMAL;");
-  db.run("PRAGMA busy_timeout = 5000;");
-  db.run("PRAGMA foreign_keys = ON;");
-  runProjectMigrations(db);
-  _projectDbs.set(key, db);
-  return db;
-}
-var MIGRATIONS, _projectDbs;
-var init_project_db = __esm(() => {
-  MIGRATIONS = [
-    {
-      version: 1,
-      name: "create_project_constraints",
-      sql: `CREATE TABLE project_constraints (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			constraint_type TEXT NOT NULL,
-			content TEXT NOT NULL,
-			created_at TEXT NOT NULL DEFAULT (datetime('now'))
-		)`
-    },
-    {
-      version: 2,
-      name: "create_qa_gate_profile",
-      sql: `CREATE TABLE qa_gate_profile (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			plan_id TEXT NOT NULL UNIQUE,
-			created_at TEXT NOT NULL DEFAULT (datetime('now')),
-			project_type TEXT,
-			gates TEXT NOT NULL DEFAULT '{}',
-			locked_at TEXT,
-			locked_by_snapshot_seq INTEGER
-		)`
-    },
-    {
-      version: 3,
-      name: "create_qa_gate_profile_immutability_trigger",
-      sql: `CREATE TRIGGER IF NOT EXISTS trg_qa_gate_profile_no_update_after_lock
-			BEFORE UPDATE ON qa_gate_profile
-			WHEN OLD.locked_at IS NOT NULL
-			BEGIN
-				SELECT RAISE(ABORT, 'qa_gate_profile row is locked and cannot be modified after critic approval');
-			END`
-    }
-  ];
-  _projectDbs = new Map;
-});
-
-// src/db/qa-gate-profile.ts
-import { createHash as createHash4 } from "crypto";
-function rowToProfile(row) {
-  let parsed = {};
-  try {
-    parsed = JSON.parse(row.gates);
-  } catch {
-    parsed = {};
-  }
-  const gates = { ...DEFAULT_QA_GATES, ...parsed };
-  return {
-    id: row.id,
-    plan_id: row.plan_id,
-    created_at: row.created_at,
-    project_type: row.project_type,
-    gates,
-    locked_at: row.locked_at,
-    locked_by_snapshot_seq: row.locked_by_snapshot_seq
-  };
-}
-function getProfile(directory, planId) {
-  if (!projectDbExists(directory))
-    return null;
-  const db = getProjectDb(directory);
-  const row = db.query("SELECT * FROM qa_gate_profile WHERE plan_id = ?").get(planId);
-  return row ? rowToProfile(row) : null;
-}
-function getOrCreateProfile(directory, planId, projectType) {
-  const existing = getProfile(directory, planId);
-  if (existing)
-    return existing;
-  const db = getProjectDb(directory);
-  const gatesJson = JSON.stringify(DEFAULT_QA_GATES);
-  const insert = db.transaction(() => {
-    db.run("INSERT INTO qa_gate_profile (plan_id, project_type, gates) VALUES (?, ?, ?)", [planId, projectType ?? null, gatesJson]);
-  });
-  try {
-    insert();
-  } catch (err2) {
-    const msg = err2 instanceof Error ? err2.message : String(err2);
-    if (!msg.toLowerCase().includes("unique")) {
-      throw err2;
-    }
-  }
-  const after = getProfile(directory, planId);
-  if (!after) {
-    throw new Error(`Failed to create or load QA gate profile for plan_id=${planId}`);
-  }
-  return after;
-}
-function setGates(directory, planId, gates) {
-  const current = getProfile(directory, planId);
-  if (!current) {
-    throw new Error(`No QA gate profile found for plan_id=${planId} \u2014 call getOrCreateProfile first`);
-  }
-  if (current.locked_at !== null) {
-    throw new Error("Cannot modify gates: QA gate profile is locked after critic approval");
-  }
-  const merged = { ...current.gates };
-  for (const key of Object.keys(gates)) {
-    const incoming = gates[key];
-    if (incoming === undefined)
-      continue;
-    if (incoming === false && current.gates[key] === true) {
-      throw new Error(`Cannot disable gate '${key}': sessions can only ratchet tighter`);
-    }
-    if (incoming === true) {
-      merged[key] = true;
-    }
-  }
-  const db = getProjectDb(directory);
-  db.run("UPDATE qa_gate_profile SET gates = ? WHERE plan_id = ?", [
-    JSON.stringify(merged),
-    planId
-  ]);
-  const updated = getProfile(directory, planId);
-  if (!updated) {
-    throw new Error(`Failed to re-read QA gate profile after update for plan_id=${planId}`);
-  }
-  return updated;
-}
-function lockProfile(directory, planId, snapshotSeq) {
-  const current = getProfile(directory, planId);
-  if (!current) {
-    throw new Error(`No QA gate profile found for plan_id=${planId} \u2014 cannot lock`);
-  }
-  if (current.locked_at !== null) {
-    return current;
-  }
-  const db = getProjectDb(directory);
-  db.run("UPDATE qa_gate_profile SET locked_at = datetime('now'), locked_by_snapshot_seq = ? WHERE plan_id = ?", [snapshotSeq, planId]);
-  const locked = getProfile(directory, planId);
-  if (!locked) {
-    throw new Error(`Failed to re-read locked QA gate profile for plan_id=${planId}`);
-  }
-  return locked;
-}
-function computeProfileHash(profile) {
-  const payload = JSON.stringify({
-    plan_id: profile.plan_id,
-    gates: profile.gates
-  });
-  return createHash4("sha256").update(payload).digest("hex");
-}
-function getEffectiveGates(profile, sessionOverrides) {
-  const merged = { ...profile.gates };
-  for (const key of Object.keys(sessionOverrides)) {
-    if (sessionOverrides[key] === true) {
-      merged[key] = true;
-    }
-  }
-  return merged;
-}
-var DEFAULT_QA_GATES;
-var init_qa_gate_profile = __esm(() => {
-  init_project_db();
-  DEFAULT_QA_GATES = {
-    reviewer: true,
-    test_engineer: true,
-    council_mode: false,
-    sme_enabled: true,
-    critic_pre_plan: true,
-    hallucination_guard: false,
-    sast_enabled: true
-  };
 });
 
 // src/commands/qa-gates.ts
@@ -53268,8 +53358,7 @@ function buildCouncilWorkflow(council) {
   return `## Work Complete Council (when enabled)
 
 When \`council.enabled\` is true, every task goes through a four-phase verification
-gate before advancing to \`complete\`. This supplements \u2014 does NOT replace \u2014 the
-existing precheckbatch / reviewer / test_engineer gate sequence.
+gate before advancing to \`complete\`. When council is authoritative, this REPLACES Stage B (reviewer + test_engineer as standalone delegations). Stage A (precheckbatch) still runs as the pre-review gate; Phase 1 dispatch of reviewer and test_engineer is the sole review pass for this task.
 
 ### Phase 0 \u2014 Pre-declare criteria (at plan time, BEFORE dispatching the coder)
 Call \`declare_council_criteria\` for each task with at least 3 concrete,
@@ -53324,15 +53413,32 @@ architect resolves any \`unresolvedConflicts\` in \`unifiedFeedbackMd\` BEFORE
 sending it to the coder \u2014 the coder never sees contradictory instructions
 from different members.`;
 }
-function buildYourToolsList() {
+function buildYourToolsList(council) {
   const tools = AGENT_TOOL_MAP.architect ?? [];
   const sorted = [...tools].sort();
-  return `Task (delegation), ${sorted.join(", ")}.`;
+  const filtered = council?.enabled === true ? sorted : sorted.filter((t) => t !== "convene_council" && t !== "declare_council_criteria");
+  return `Task (delegation), ${filtered.join(", ")}.`;
 }
-function buildAvailableToolsList() {
+function buildQaGateSelectionDialogue(modeLabel) {
+  const leadIn = modeLabel === "BRAINSTORM" ? "Now ask the user which QA gates to enable for this plan \u2014 do not select on their behalf." : modeLabel === "SPECIFY" ? "Ask the user which QA gates to enable for this plan before suggesting the next step." : "No pending gate selection found in `.swarm/context.md`. Ask the user inline now.";
+  return `${leadIn}
+
+Present the seven gates with their defaults (DEFAULT_QA_GATES) as a single user-facing question. Offer the user a one-shot choice: accept defaults, or customize. The seven gates are:
+- reviewer (default: ON) \u2014 code review of coder output
+- test_engineer (default: ON) \u2014 test verification of coder output
+- sme_enabled (default: ON) \u2014 SME consultation during planning/clarification
+- critic_pre_plan (default: ON) \u2014 critic review before plan finalization
+- sast_enabled (default: ON) \u2014 static security scanning
+- council_mode (default: OFF) \u2014 multi-member council gate (recommended for high-impact architecture, public APIs, schema/data mutation, security-sensitive code)
+- hallucination_guard (default: OFF) \u2014 claim verification (recommended for claim-heavy or research-heavy work)
+
+One question, one message, defaults pre-stated. Wait for the user's answer.`;
+}
+function buildAvailableToolsList(council) {
   const tools = AGENT_TOOL_MAP.architect ?? [];
   const sorted = [...tools].sort();
-  return sorted.map((t) => {
+  const filtered = council?.enabled === true ? sorted : sorted.filter((t) => t !== "convene_council" && t !== "declare_council_criteria");
+  return filtered.map((t) => {
     const desc = TOOL_DESCRIPTIONS[t];
     return desc ? `${t} (${desc})` : t;
   }).join(", ");
@@ -53473,7 +53579,8 @@ function createArchitectAgent(model, customPrompt, customAppendPrompt, adversari
 
 ${customAppendPrompt}`;
   }
-  prompt = prompt?.replace("{{YOUR_TOOLS}}", buildYourToolsList())?.replace("{{AVAILABLE_TOOLS}}", buildAvailableToolsList())?.replace("{{SLASH_COMMANDS}}", buildSlashCommandsList());
+  prompt = prompt?.replace("{{YOUR_TOOLS}}", buildYourToolsList(council))?.replace("{{AVAILABLE_TOOLS}}", buildAvailableToolsList(council))?.replace("{{SLASH_COMMANDS}}", buildSlashCommandsList());
+  prompt = prompt?.replace(/\{\{QA_GATE_DIALOGUE_SPECIFY\}\}/g, buildQaGateSelectionDialogue("SPECIFY"))?.replace(/\{\{QA_GATE_DIALOGUE_BRAINSTORM\}\}/g, buildQaGateSelectionDialogue("BRAINSTORM"))?.replace(/\{\{QA_GATE_DIALOGUE_PLAN\}\}/g, buildQaGateSelectionDialogue("PLAN"));
   const councilBlock = buildCouncilWorkflow(council);
   const hasPlaceholder = prompt?.includes("{{COUNCIL_WORKFLOW}}") === true;
   if (councilBlock === "") {
@@ -53701,6 +53808,8 @@ TIER 3 \u2014 CRITICAL
   Pipeline: Full Stage A. Stage B = {{AGENT_PREFIX}}reviewer\xD72 + {{AGENT_PREFIX}}test_engineer\xD72.
   Rationale: Security paths need adversarial review.
 
+If council is authoritative for the current plan, skip Stage B entries above and use council Phase 1 dispatch as the review pass.
+
 CLASSIFICATION RULES:
 - Multi-tier \u2192 use HIGHEST tier.
 - Format: "Classification: TIER {N} \u2014 {label}"
@@ -53721,9 +53830,11 @@ VERIFICATION PROTOCOL: After the coder reports DONE, and before running Stage B 
 
 \u2500\u2500 STAGE B: AGENT REVIEW GATES \u2500\u2500
 {{AGENT_PREFIX}}reviewer \u2192 security reviewer (conditional) \u2192 {{AGENT_PREFIX}}test_engineer verification \u2192 {{AGENT_PREFIX}}test_engineer adversarial \u2192 coverage check
-Stage B CANNOT be skipped for TIER 1-3 classifications. Stage A passing does not satisfy Stage B.
+Stage B runs by default for TIER 1-3 classifications. Stage A passing does not satisfy Stage B.
 Stage B is where logic errors, security flaws, edge cases, and behavioral bugs are caught.
 You MUST delegate to each Stage B agent and wait for their response.
+
+When council is authoritative for the current plan (\`pluginConfig.council.enabled === true\` AND \`QaGates.council_mode === true\`), Stage B is REPLACED by council Phase 1 \u2014 reviewer and test_engineer are dispatched as council members in the parallel Phase 1 fan-out, not as a separate Stage B sequence. Do not run Stage B a second time after the council has rendered a verdict. Stage A (precheckbatch) still runs as the pre-review gate in both modes.
 
 A task is complete ONLY when BOTH stages pass.
 
@@ -54009,12 +54120,23 @@ MODE: BRAINSTORM runs seven phases in strict order. Do not skip phases. Do not c
 - Write the final spec to \`.swarm/spec.md\`.
 - Exit when reviewer signs off (or user explicitly accepts remaining disagreements).
 
-**Phase 6: QA GATE SELECTION (architect).**
-- Read the current QA gate profile for this plan via \`get_qa_gate_profile\`. If none exists, the tool returns \`success: false, reason: 'no_profile'\` \u2014 this is expected for a new plan.
-- Based on risk tier of the work (see "High-risk work" list in the quality policy), choose which gates to enable. Default profile enables reviewer, test_engineer, sme_enabled, critic_pre_plan, and sast_enabled. Consider enabling council_mode for high-impact architecture and hallucination_guard for claim-heavy work.
-- Apply the chosen gates via \`set_qa_gates\`. The tool ratchets tighter only \u2014 it cannot disable gates that are already on. It rejects writes once the profile is locked by critic approval.
-- Briefly explain to the user which gates you selected and why.
-- Exit with a QA gate profile persisted for this plan.
+**Phase 6: QA GATE SELECTION (architect, dialogue only).**
+{{QA_GATE_DIALOGUE_BRAINSTORM}}
+
+Do NOT call \`set_qa_gates\` yet \u2014 \`plan.json\` does not exist at this point. Once the user answers, write the elected gates to \`.swarm/context.md\` under a new section:
+\`\`\`
+## Pending QA Gate Selection
+- reviewer: <true|false>
+- test_engineer: <true|false>
+- sme_enabled: <true|false>
+- critic_pre_plan: <true|false>
+- sast_enabled: <true|false>
+- council_mode: <true|false>
+- hallucination_guard: <true|false>
+- recorded_at: <ISO timestamp>
+\`\`\`
+MODE: PLAN applies these after \`save_plan\` succeeds via \`set_qa_gates\`.
+- Exit with the elected gates recorded in \`.swarm/context.md\` (NOT yet persisted to plan.json).
 
 **Phase 7: TRANSITION.**
 - Summarize: (a) chosen approach, (b) design sections produced, (c) spec written, (d) QA gates selected, (e) remaining \`[NEEDS CLARIFICATION]\` markers.
@@ -54026,7 +54148,7 @@ BRAINSTORM RULES:
 - One question per message in DIALOGUE \u2014 never batch.
 - Always offer an informed default for every question.
 - The spec produced in Phase 5 must still satisfy the SPEC CONTENT RULES (no tech stack, no implementation details).
-- QA gates set in Phase 6 are ratchet-tighter \u2014 you cannot undo them later in the session.
+- QA gates elected in Phase 6 are persisted during MODE: PLAN after \`save_plan\` succeeds and are ratchet-tighter from that point \u2014 once persisted you cannot undo them later in the session.
 
 ### MODE: SPECIFY
 Activates when: user asks to "specify", "define requirements", "write a spec", or "define a feature"; OR \`/swarm specify\` is invoked; OR no \`.swarm/spec.md\` exists and no \`.swarm/plan.md\` exists.
@@ -54050,7 +54172,23 @@ Activates when: user asks to "specify", "define requirements", "write a spec", o
    - Edge cases and known failure modes
    - \`[NEEDS CLARIFICATION]\` markers (max 3) for items where uncertainty could change scope, security, or core behavior; prefer informed defaults over asking
 5. Write the spec to \`.swarm/spec.md\`.
-6. Report a summary to the user (MUST count, SHALL count, scenario count, clarification markers) and suggest the next step: \`CLARIFY-SPEC\` (if markers exist) or \`PLAN\`.
+5b. **QA GATE SELECTION (dialogue only).**
+{{QA_GATE_DIALOGUE_SPECIFY}}
+
+Do NOT call \`set_qa_gates\` yet \u2014 \`plan.json\` does not exist at this point. Once the user answers, write the elected gates to \`.swarm/context.md\` under a new section:
+\`\`\`
+## Pending QA Gate Selection
+- reviewer: <true|false>
+- test_engineer: <true|false>
+- sme_enabled: <true|false>
+- critic_pre_plan: <true|false>
+- sast_enabled: <true|false>
+- council_mode: <true|false>
+- hallucination_guard: <true|false>
+- recorded_at: <ISO timestamp>
+\`\`\`
+MODE: PLAN will read this section after \`save_plan\` succeeds and persist via \`set_qa_gates\`.
+7. Report a summary to the user (MUST count, SHALL count, scenario count, clarification markers, elected QA gates) and suggest the next step: \`CLARIFY-SPEC\` (if markers exist) or \`PLAN\`.
 
 SPEC CONTENT RULES \u2014 the spec MUST NOT contain:
 - Technology stack, framework choices, library names
@@ -54258,6 +54396,12 @@ Use the \`save_plan\` tool to create the implementation plan. Required parameter
 
 Example call:
 save_plan({ title: "My Real Project", swarm_id: "mega", phases: [{ id: 1, name: "Setup", tasks: [{ id: "1.1", description: "Install dependencies and configure TypeScript", size: "small" }] }] })
+
+**POST-SAVE_PLAN: APPLY QA GATE SELECTION.**
+After \`save_plan\` succeeds, read \`.swarm/context.md\`:
+- If a \`## Pending QA Gate Selection\` section exists: parse the gate values, call \`set_qa_gates\` with those flags, confirm with the user ("QA gates applied: <list>"), then remove the section from context.md.
+- If no pending section exists: {{QA_GATE_DIALOGUE_PLAN}} Then call \`set_qa_gates\` with the user's chosen flags.
+Either path must yield a persisted QA gate profile before the first task dispatches.
 
 \u26A0\uFE0F If \`save_plan\` is unavailable, delegate plan writing to {{AGENT_PREFIX}}coder:
 \u26A0\uFE0F Even in this fallback, you MUST call \`declare_scope\` for the single file ".swarm/plan.md" BEFORE the coder delegation. Scope discipline applies to plan-writing delegations too. See Rule 1a.
@@ -56380,6 +56524,13 @@ function getAgentConfigs(config3, directory, sessionId) {
       const missing = required3.filter((t) => !override.includes(t));
       if (missing.length > 0) {
         throw new Error(`[opencode-swarm] Conflicting config: council.enabled=true but tool_filter.overrides.architect omits ${missing.join(", ")}. ` + `Either set council.enabled=false, remove the architect override entirely to fall back on AGENT_TOOL_MAP, or add the missing council tools to the override. ` + `Refusing to silently override your explicit tool_filter.overrides.architect.`);
+      }
+    }
+    if (baseAgentName === "architect" && config3?.council?.enabled !== true && override !== undefined) {
+      const councilTools = ["declare_council_criteria", "convene_council"];
+      const present = councilTools.filter((t) => override.includes(t));
+      if (present.length > 0) {
+        console.warn(`[opencode-swarm] tool_filter.overrides.architect includes ${present.join(", ")} but council.enabled is not true. ` + `The runtime gate will reject these calls. Either set council.enabled=true, or remove ${present.join(", ")} from the architect override.`);
       }
     }
     if (!allowedTools && !Object.hasOwn(toolFilterOverrides, baseAgentName)) {

--- a/dist/state.d.ts
+++ b/dist/state.d.ts
@@ -7,7 +7,7 @@
  * and delegation chains.
  */
 import type { OpencodeClient } from '@opencode-ai/sdk';
-import type { QaGates } from './db/qa-gate-profile.js';
+import { type QaGates } from './db/qa-gate-profile.js';
 import { type EnvironmentProfile } from './environment/profile.js';
 /**
  * Represents a single tool call entry for tracking purposes
@@ -101,6 +101,11 @@ export interface AgentSessionState {
     qaSkipTaskIds: string[];
     /** Per-task workflow state — taskId → current state */
     taskWorkflowStates: Map<string, TaskWorkflowState>;
+    /** v6.71+ Council mode: per-task council verdict, recorded by delegation-gate when convene_council resolves. */
+    taskCouncilApproved?: Map<string, {
+        verdict: 'APPROVE' | 'REJECT' | 'CONCERNS';
+        roundNumber: number;
+    }>;
     /** Last gate outcome for deliberation preamble injection */
     lastGateOutcome: {
         gate: string;
@@ -331,6 +336,27 @@ export declare function advanceTaskState(session: AgentSessionState, taskId: str
  * @returns Current task workflow state
  */
 export declare function getTaskState(session: AgentSessionState, taskId: string): TaskWorkflowState;
+/**
+ * Returns true iff council is authoritative for the current plan.
+ *
+ * AND semantics: council is authoritative when BOTH `pluginConfig.council.enabled === true`
+ * AND `QaGates.council_mode === true` for the plan associated with this directory.
+ *
+ * If exactly one of the two flags is true, a one-time warning is logged per plan_id
+ * (so operators can see the deadlock case) and the function falls back to `false`,
+ * which keeps Stage B running as the default.
+ *
+ * Returns false when the plan or QA gate profile cannot be loaded — when the plan
+ * is missing the council cannot meaningfully be "authoritative".
+ */
+export declare function isCouncilGateActive(directory: string, council: {
+    enabled?: boolean;
+} | undefined): Promise<boolean>;
+/**
+ * Test-only helper: clear the warn-once memo so each test can observe a fresh
+ * disagreement warning. Not part of the public surface.
+ */
+export declare function _resetCouncilDisagreementWarnings(): void;
 /**
  * Rehydrates session workflow state from durable swarm files.
  *

--- a/dist/tools/convene-council.d.ts
+++ b/dist/tools/convene-council.d.ts
@@ -24,8 +24,8 @@ export declare const ArgsSchema: z.ZodObject<{
         }>;
         verdict: z.ZodEnum<{
             APPROVE: "APPROVE";
-            CONCERNS: "CONCERNS";
             REJECT: "REJECT";
+            CONCERNS: "CONCERNS";
         }>;
         confidence: z.ZodNumber;
         findings: z.ZodArray<z.ZodObject<{

--- a/docs/releases/v6.72.1.md
+++ b/docs/releases/v6.72.1.md
@@ -1,40 +1,46 @@
-# v6.72.1
+# v6.72.1 — Council Wiring Fixes
 
 ## What changed
 
-Added explicit `declare_scope` instructions at every coder-delegation site in `ARCHITECT_PROMPT` to enforce scope discipline before each delegation.
+### Issue #487 — Three wiring gaps fixed
+
+**1. Tool visibility sync**
+- `convene_council` and `declare_council_criteria` now filtered from architect tool list when `council.enabled !== true`
+- Eliminates phantom tools the runtime gate would reject
+- Symmetric validation in `src/agents/index.ts` warns when override includes council tools but council is disabled
+
+**2. QA gate selection in SPECIFY and BRAINSTORM**
+- BRAINSTORM Phase 6 now asks the user (dialogue-only) instead of autonomously calling `set_qa_gates` before `plan.json` exists
+- MODE: SPECIFY gained step 5b conducting the same user-facing gate selection dialogue
+- MODE: PLAN reads `## Pending QA Gate Selection` from `.swarm/context.md` after `save_plan` succeeds and persists via `set_qa_gates`
+- Shared `buildQaGateSelectionDialogue` helper keeps all three paths in sync
+- Fixes latent BRAINSTORM bug where `plan_json_unavailable` error fired instead of expected `no_profile` response
+
+**3. Stage B replacement by council**
+- Stage B now explicitly says REPLACED (not supplemented) when council is authoritative
+- `delegation-gate.ts` `toolAfter` skips reviewer/test_engineer advancement when council is active (AND semantics: `pluginConfig.council.enabled && QaGates.council_mode`)
+- New `convene_council` branch in `toolAfter` parses verdict and advances to `complete` on APPROVE+allCriteriaMet+requiredFixesCount=0
+- State machine relaxed to allow `complete` from `pre_check_passed` when council approved (Stage A pre-check still required)
+- Exported `isCouncilGateActive` helper uses AND semantics and warn-once when exactly one flag is true
 
 ## Why
 
-Issue #493 identified that while `declare_scope` was registered and available to the architect agent, it was only documented in Rule 1a of the prompt. Without repeated, locally-visible reminders at every delegation site, architects were unlikely to call the tool consistently, leading to runtime scope-guard violations when the coder attempted writes outside the declared scope. This fix ensures the instruction is locally-enforced at every context where coder delegation occurs.
-
-## Changes
-
-- **src/agents/architect.ts**: Added 7 new `declare_scope` reminders:
-  - Rule 3a (ONE task per coder call): PRE-DELEGATION SCOPE CALL instruction
-  - Rule 4 (ARCHITECT CODING BOUNDARIES): reminder for self-coding fallback delegation
-  - Rule 9 (UI/UX DESIGN GATE): reminder for both UI and non-UI delegation paths
-  - DELEGATION FORMAT: PRE-STEP reminder before the coder example
-  - MODE: PLAN (save_plan fallback): reminder for plan-writing delegation
-  - MODE: EXECUTE Step 5b-PRE: reminder before the primary coder delegation
-  - MODE: EXECUTE RETRY PROTOCOL: reminder for gate-failure retry delegation
-
-- **tests/unit/agents/architect-declare-scope-instruction.test.ts**: New test file with 10 tests verifying:
-  - `declare_scope` appears at each delegation site (slice-based assertions)
-  - Instructions use imperative language (no advisory hedges)
-  - Minimum mention threshold (≥8) for regression protection
-
-## No breaking changes
-
-This is a prompt-text-only fix. No tool definitions, runtime behavior, or API changes. All existing scope-guard enforcement, delegation-gate fallbacks, and declare-scope contracts remain unchanged.
+Issue #487 surfaced three distinct end-to-end wiring gaps discovered during an architect agent audit:
+- Model saw phantom tools in its tool list that the runtime would reject
+- Users entering SPECIFY mode silently got default QA gates with no choice
+- Stage B was described as supplementing the council, but the state machine made them race for `complete` transition
 
 ## Test coverage
 
-- All 7 delegation sites verified with targeted test cases
-- Full architect test suite: 1,469 tests pass
-- Regression sweep: 206 targeted tests pass (scope-guard, delegation-gate, dark-matter, prompt-template, prompt-markers, adversarial, constants)
-- No regressions detected
+- 190 tests pass across new and updated test files
+- 4 new test files: `architect-brainstorm-gates.test.ts`, `architect-specify-gates.test.ts`, `architect-tool-visibility-council.test.ts`, `delegation-gate-council.test.ts`
+- 6 test files updated to reflect wording/config changes
+- Pre-existing failures (1 evidence-write, 7 whitelist count assertions) verified unchanged by baseline comparison
 
-## Migration
+## Known caveats
 
-None required. This fix is backward-compatible and improves reliability of scope enforcement.
+Council verdicts are persisted in-memory only (`session.taskCouncilApproved`). If a session crashes mid-task after a council verdict, the verdict is lost and the council would need to re-run. Persistent verdict storage across session restarts tracked separately in #529.
+
+## Migration notes
+
+No API or configuration changes required. Existing `council.enabled` and QA gate settings work unchanged.

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -236,6 +236,8 @@ TIER 3 — CRITICAL
   Pipeline: Full Stage A. Stage B = {{AGENT_PREFIX}}reviewer×2 + {{AGENT_PREFIX}}test_engineer×2.
   Rationale: Security paths need adversarial review.
 
+If council is authoritative for the current plan, skip Stage B entries above and use council Phase 1 dispatch as the review pass.
+
 CLASSIFICATION RULES:
 - Multi-tier → use HIGHEST tier.
 - Format: "Classification: TIER {N} — {label}"
@@ -256,9 +258,11 @@ VERIFICATION PROTOCOL: After the coder reports DONE, and before running Stage B 
 
 ── STAGE B: AGENT REVIEW GATES ──
 {{AGENT_PREFIX}}reviewer → security reviewer (conditional) → {{AGENT_PREFIX}}test_engineer verification → {{AGENT_PREFIX}}test_engineer adversarial → coverage check
-Stage B CANNOT be skipped for TIER 1-3 classifications. Stage A passing does not satisfy Stage B.
+Stage B runs by default for TIER 1-3 classifications. Stage A passing does not satisfy Stage B.
 Stage B is where logic errors, security flaws, edge cases, and behavioral bugs are caught.
 You MUST delegate to each Stage B agent and wait for their response.
+
+When council is authoritative for the current plan (\`pluginConfig.council.enabled === true\` AND \`QaGates.council_mode === true\`), Stage B is REPLACED by council Phase 1 — reviewer and test_engineer are dispatched as council members in the parallel Phase 1 fan-out, not as a separate Stage B sequence. Do not run Stage B a second time after the council has rendered a verdict. Stage A (precheckbatch) still runs as the pre-review gate in both modes.
 
 A task is complete ONLY when BOTH stages pass.
 
@@ -544,12 +548,23 @@ MODE: BRAINSTORM runs seven phases in strict order. Do not skip phases. Do not c
 - Write the final spec to \`.swarm/spec.md\`.
 - Exit when reviewer signs off (or user explicitly accepts remaining disagreements).
 
-**Phase 6: QA GATE SELECTION (architect).**
-- Read the current QA gate profile for this plan via \`get_qa_gate_profile\`. If none exists, the tool returns \`success: false, reason: 'no_profile'\` — this is expected for a new plan.
-- Based on risk tier of the work (see "High-risk work" list in the quality policy), choose which gates to enable. Default profile enables reviewer, test_engineer, sme_enabled, critic_pre_plan, and sast_enabled. Consider enabling council_mode for high-impact architecture and hallucination_guard for claim-heavy work.
-- Apply the chosen gates via \`set_qa_gates\`. The tool ratchets tighter only — it cannot disable gates that are already on. It rejects writes once the profile is locked by critic approval.
-- Briefly explain to the user which gates you selected and why.
-- Exit with a QA gate profile persisted for this plan.
+**Phase 6: QA GATE SELECTION (architect, dialogue only).**
+{{QA_GATE_DIALOGUE_BRAINSTORM}}
+
+Do NOT call \`set_qa_gates\` yet — \`plan.json\` does not exist at this point. Once the user answers, write the elected gates to \`.swarm/context.md\` under a new section:
+\`\`\`
+## Pending QA Gate Selection
+- reviewer: <true|false>
+- test_engineer: <true|false>
+- sme_enabled: <true|false>
+- critic_pre_plan: <true|false>
+- sast_enabled: <true|false>
+- council_mode: <true|false>
+- hallucination_guard: <true|false>
+- recorded_at: <ISO timestamp>
+\`\`\`
+MODE: PLAN applies these after \`save_plan\` succeeds via \`set_qa_gates\`.
+- Exit with the elected gates recorded in \`.swarm/context.md\` (NOT yet persisted to plan.json).
 
 **Phase 7: TRANSITION.**
 - Summarize: (a) chosen approach, (b) design sections produced, (c) spec written, (d) QA gates selected, (e) remaining \`[NEEDS CLARIFICATION]\` markers.
@@ -561,7 +576,7 @@ BRAINSTORM RULES:
 - One question per message in DIALOGUE — never batch.
 - Always offer an informed default for every question.
 - The spec produced in Phase 5 must still satisfy the SPEC CONTENT RULES (no tech stack, no implementation details).
-- QA gates set in Phase 6 are ratchet-tighter — you cannot undo them later in the session.
+- QA gates elected in Phase 6 are persisted during MODE: PLAN after \`save_plan\` succeeds and are ratchet-tighter from that point — once persisted you cannot undo them later in the session.
 
 ### MODE: SPECIFY
 Activates when: user asks to "specify", "define requirements", "write a spec", or "define a feature"; OR \`/swarm specify\` is invoked; OR no \`.swarm/spec.md\` exists and no \`.swarm/plan.md\` exists.
@@ -585,7 +600,23 @@ Activates when: user asks to "specify", "define requirements", "write a spec", o
    - Edge cases and known failure modes
    - \`[NEEDS CLARIFICATION]\` markers (max 3) for items where uncertainty could change scope, security, or core behavior; prefer informed defaults over asking
 5. Write the spec to \`.swarm/spec.md\`.
-6. Report a summary to the user (MUST count, SHALL count, scenario count, clarification markers) and suggest the next step: \`CLARIFY-SPEC\` (if markers exist) or \`PLAN\`.
+5b. **QA GATE SELECTION (dialogue only).**
+{{QA_GATE_DIALOGUE_SPECIFY}}
+
+Do NOT call \`set_qa_gates\` yet — \`plan.json\` does not exist at this point. Once the user answers, write the elected gates to \`.swarm/context.md\` under a new section:
+\`\`\`
+## Pending QA Gate Selection
+- reviewer: <true|false>
+- test_engineer: <true|false>
+- sme_enabled: <true|false>
+- critic_pre_plan: <true|false>
+- sast_enabled: <true|false>
+- council_mode: <true|false>
+- hallucination_guard: <true|false>
+- recorded_at: <ISO timestamp>
+\`\`\`
+MODE: PLAN will read this section after \`save_plan\` succeeds and persist via \`set_qa_gates\`.
+7. Report a summary to the user (MUST count, SHALL count, scenario count, clarification markers, elected QA gates) and suggest the next step: \`CLARIFY-SPEC\` (if markers exist) or \`PLAN\`.
 
 SPEC CONTENT RULES — the spec MUST NOT contain:
 - Technology stack, framework choices, library names
@@ -793,6 +824,12 @@ Use the \`save_plan\` tool to create the implementation plan. Required parameter
 
 Example call:
 save_plan({ title: "My Real Project", swarm_id: "mega", phases: [{ id: 1, name: "Setup", tasks: [{ id: "1.1", description: "Install dependencies and configure TypeScript", size: "small" }] }] })
+
+**POST-SAVE_PLAN: APPLY QA GATE SELECTION.**
+After \`save_plan\` succeeds, read \`.swarm/context.md\`:
+- If a \`## Pending QA Gate Selection\` section exists: parse the gate values, call \`set_qa_gates\` with those flags, confirm with the user ("QA gates applied: <list>"), then remove the section from context.md.
+- If no pending section exists: {{QA_GATE_DIALOGUE_PLAN}} Then call \`set_qa_gates\` with the user's chosen flags.
+Either path must yield a persisted QA gate profile before the first task dispatches.
 
 ⚠️ If \`save_plan\` is unavailable, delegate plan writing to {{AGENT_PREFIX}}coder:
 ⚠️ Even in this fallback, you MUST call \`declare_scope\` for the single file ".swarm/plan.md" BEFORE the coder delegation. Scope discipline applies to plan-writing delegations too. See Rule 1a.
@@ -1187,8 +1224,7 @@ export function buildCouncilWorkflow(council?: CouncilWorkflowConfig): string {
 	return `## Work Complete Council (when enabled)
 
 When \`council.enabled\` is true, every task goes through a four-phase verification
-gate before advancing to \`complete\`. This supplements — does NOT replace — the
-existing precheckbatch / reviewer / test_engineer gate sequence.
+gate before advancing to \`complete\`. When council is authoritative, this REPLACES Stage B (reviewer + test_engineer as standalone delegations). Stage A (precheckbatch) still runs as the pre-review gate; Phase 1 dispatch of reviewer and test_engineer is the sole review pass for this task.
 
 ### Phase 0 — Pre-declare criteria (at plan time, BEFORE dispatching the coder)
 Call \`declare_council_criteria\` for each task with at least 3 concrete,
@@ -1247,21 +1283,74 @@ from different members.`;
 /**
  * Generate the YOUR TOOLS line from AGENT_TOOL_MAP.architect.
  * Format: "Task (delegation), tool1, tool2, ..." — Task is always first.
+ *
+ * When `council?.enabled !== true`, the council-only tools
+ * (`convene_council`, `declare_council_criteria`) are filtered out so the
+ * model is not shown phantom tools the runtime gate would reject.
  */
-function buildYourToolsList(): string {
+function buildYourToolsList(council?: CouncilWorkflowConfig): string {
 	const tools = AGENT_TOOL_MAP.architect ?? [];
 	const sorted = [...tools].sort();
-	return `Task (delegation), ${sorted.join(', ')}.`;
+	const filtered =
+		council?.enabled === true
+			? sorted
+			: sorted.filter(
+					(t) => t !== 'convene_council' && t !== 'declare_council_criteria',
+				);
+	return `Task (delegation), ${filtered.join(', ')}.`;
+}
+
+/**
+ * Build the user-facing QA gate selection dialogue, used by MODE: SPECIFY
+ * (step 5b), MODE: BRAINSTORM (Phase 6), and MODE: PLAN (post-`save_plan`
+ * inline path). The dialogue is dialogue-only — persistence happens during
+ * MODE: PLAN after `save_plan` creates `plan.json`.
+ *
+ * The lead-in sentence varies per mode, but the body (seven gates with
+ * defaults, one-shot accept-or-customize prompt) is shared so SPECIFY,
+ * BRAINSTORM, and PLAN inline paths stay in lockstep.
+ */
+export function buildQaGateSelectionDialogue(
+	modeLabel: 'BRAINSTORM' | 'SPECIFY' | 'PLAN',
+): string {
+	const leadIn =
+		modeLabel === 'BRAINSTORM'
+			? 'Now ask the user which QA gates to enable for this plan — do not select on their behalf.'
+			: modeLabel === 'SPECIFY'
+				? 'Ask the user which QA gates to enable for this plan before suggesting the next step.'
+				: 'No pending gate selection found in `.swarm/context.md`. Ask the user inline now.';
+	return `${leadIn}
+
+Present the seven gates with their defaults (DEFAULT_QA_GATES) as a single user-facing question. Offer the user a one-shot choice: accept defaults, or customize. The seven gates are:
+- reviewer (default: ON) — code review of coder output
+- test_engineer (default: ON) — test verification of coder output
+- sme_enabled (default: ON) — SME consultation during planning/clarification
+- critic_pre_plan (default: ON) — critic review before plan finalization
+- sast_enabled (default: ON) — static security scanning
+- council_mode (default: OFF) — multi-member council gate (recommended for high-impact architecture, public APIs, schema/data mutation, security-sensitive code)
+- hallucination_guard (default: OFF) — claim verification (recommended for claim-heavy or research-heavy work)
+
+One question, one message, defaults pre-stated. Wait for the user's answer.`;
 }
 
 /**
  * Generate the Available Tools block from AGENT_TOOL_MAP.architect + TOOL_DESCRIPTIONS.
  * Format: "tool1 (description), tool2 (description), ..." — tools without descriptions use name only.
+ *
+ * When `council?.enabled !== true`, the council-only tools
+ * (`convene_council`, `declare_council_criteria`) are filtered out so the
+ * model is not shown phantom tools the runtime gate would reject.
  */
-function buildAvailableToolsList(): string {
+function buildAvailableToolsList(council?: CouncilWorkflowConfig): string {
 	const tools = AGENT_TOOL_MAP.architect ?? [];
 	const sorted = [...tools].sort();
-	return sorted
+	const filtered =
+		council?.enabled === true
+			? sorted
+			: sorted.filter(
+					(t) => t !== 'convene_council' && t !== 'declare_council_criteria',
+				);
+	return filtered
 		.map((t) => {
 			const desc = TOOL_DESCRIPTIONS[t];
 			return desc ? `${t} (${desc})` : t;
@@ -1459,11 +1548,33 @@ export function createArchitectAgent(
 		prompt = `${ARCHITECT_PROMPT}\n\n${customAppendPrompt}`;
 	}
 
-	// Resolve capability placeholders from AGENT_TOOL_MAP (single source of truth)
+	// Resolve capability placeholders from AGENT_TOOL_MAP (single source of truth).
+	// Thread `council` through the tool-list builders so council-only tools
+	// (`convene_council`, `declare_council_criteria`) are omitted when the
+	// feature is disabled — keeping the rendered tool list in sync with the
+	// runtime gate in src/tools/convene-council.ts.
 	prompt = prompt
-		?.replace('{{YOUR_TOOLS}}', buildYourToolsList())
-		?.replace('{{AVAILABLE_TOOLS}}', buildAvailableToolsList())
+		?.replace('{{YOUR_TOOLS}}', buildYourToolsList(council))
+		?.replace('{{AVAILABLE_TOOLS}}', buildAvailableToolsList(council))
 		?.replace('{{SLASH_COMMANDS}}', buildSlashCommandsList());
+
+	// Substitute the QA gate selection dialogue blocks shared across
+	// MODE: SPECIFY (step 5b), MODE: BRAINSTORM (Phase 6), and MODE: PLAN
+	// (post-save_plan inline path). Use /g so any composed prompt with
+	// multiple occurrences is fully substituted.
+	prompt = prompt
+		?.replace(
+			/\{\{QA_GATE_DIALOGUE_SPECIFY\}\}/g,
+			buildQaGateSelectionDialogue('SPECIFY'),
+		)
+		?.replace(
+			/\{\{QA_GATE_DIALOGUE_BRAINSTORM\}\}/g,
+			buildQaGateSelectionDialogue('BRAINSTORM'),
+		)
+		?.replace(
+			/\{\{QA_GATE_DIALOGUE_PLAN\}\}/g,
+			buildQaGateSelectionDialogue('PLAN'),
+		);
 
 	// Option A: inline placeholder substitution (matches existing {{YOUR_TOOLS}},
 	// {{AVAILABLE_TOOLS}} pattern). When council is disabled/missing, collapse

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -540,6 +540,26 @@ export function getAgentConfigs(
 				}
 			}
 
+			// Symmetric validation: when council is OFF but the user override
+			// INCLUDES the council tools, the runtime gate in
+			// src/tools/convene-council.ts will reject any model attempt to call
+			// them. Warn so the user knows the tools are present in the override
+			// but unusable at runtime.
+			if (
+				baseAgentName === 'architect' &&
+				config?.council?.enabled !== true &&
+				override !== undefined
+			) {
+				const councilTools = ['declare_council_criteria', 'convene_council'];
+				const present = councilTools.filter((t) => override.includes(t));
+				if (present.length > 0) {
+					console.warn(
+						`[opencode-swarm] tool_filter.overrides.architect includes ${present.join(', ')} but council.enabled is not true. ` +
+							`The runtime gate will reject these calls. Either set council.enabled=true, or remove ${present.join(', ')} from the architect override.`,
+					);
+				}
+			}
+
 			// Warn once when base name lacks a whitelist entry (no override and no AGENT_TOOL_MAP)
 			if (!allowedTools && !Object.hasOwn(toolFilterOverrides, baseAgentName)) {
 				if (!warnedMissingWhitelist.has(baseAgentName)) {

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -639,9 +639,7 @@ export function createDelegationGateHook(
 						session.taskCouncilApproved.set(taskId, {
 							verdict: result.overallVerdict,
 							roundNumber:
-								typeof result.roundNumber === 'number'
-									? result.roundNumber
-									: 1,
+								typeof result.roundNumber === 'number' ? result.roundNumber : 1,
 						});
 						if (
 							result.overallVerdict === 'APPROVE' &&
@@ -777,7 +775,10 @@ export function createDelegationGateHook(
 									seedTaskId &&
 									!otherSession.taskWorkflowStates.has(seedTaskId)
 								) {
-									otherSession.taskWorkflowStates.set(seedTaskId, 'reviewer_run');
+									otherSession.taskWorkflowStates.set(
+										seedTaskId,
+										'reviewer_run',
+									);
 								}
 								for (const [taskId, state] of otherSession.taskWorkflowStates) {
 									if (state === 'reviewer_run') {

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -630,8 +630,11 @@ export function createDelegationGateHook(
 					result.success === true &&
 					typeof result.overallVerdict === 'string'
 				) {
-					const taskIdRaw = (input.args as Record<string, unknown> | undefined)
-						?.taskId;
+					const directArgs = input.args as Record<string, unknown> | undefined;
+					const storedArgs = getStoredInputArgs(input.callID) as
+						| Record<string, unknown>
+						| undefined;
+					const taskIdRaw = directArgs?.taskId ?? storedArgs?.taskId;
 					const taskId = typeof taskIdRaw === 'string' ? taskIdRaw : null;
 					if (taskId) {
 						if (!session.taskCouncilApproved)
@@ -886,105 +889,113 @@ export function createDelegationGateHook(
 
 					// Only reset qaSkip when BOTH have been seen since last coder
 					// (skip qaSkip reset entirely when there's no coder in chain)
-					if (lastCoderIndex !== -1 && hasReviewer && hasTestEngineer) {
-						session.qaSkipCount = 0;
-						session.qaSkipTaskIds = [];
-					}
-
-					// Fallback Pass 1: advance states via delegationChains
-					if (
-						lastCoderIndex !== -1 &&
-						hasReviewer &&
-						session.taskWorkflowStates
-					) {
-						for (const [taskId, state] of session.taskWorkflowStates) {
-							if (state === 'coder_delegated' || state === 'pre_check_passed') {
-								try {
-									advanceTaskState(session, taskId, 'reviewer_run');
-								} catch (err) {
-									console.warn(
-										`[delegation-gate] fallback: could not advance ${taskId} (${state}) → reviewer_run: ${err instanceof Error ? err.message : String(err)}`,
-									);
-								}
-							}
+					if (!councilActive) {
+						if (lastCoderIndex !== -1 && hasReviewer && hasTestEngineer) {
+							session.qaSkipCount = 0;
+							session.qaSkipTaskIds = [];
 						}
-					}
 
-					// Fallback Pass 2: advance states via delegationChains
-					if (
-						lastCoderIndex !== -1 &&
-						hasReviewer &&
-						hasTestEngineer &&
-						session.taskWorkflowStates
-					) {
-						for (const [taskId, state] of session.taskWorkflowStates) {
-							if (state === 'reviewer_run') {
-								try {
-									advanceTaskState(session, taskId, 'tests_run');
-								} catch (err) {
-									console.warn(
-										`[delegation-gate] fallback: could not advance ${taskId} (${state}) → tests_run: ${err instanceof Error ? err.message : String(err)}`,
-									);
-								}
-							}
-						}
-					}
-
-					// Fallback: Also advance states in OTHER sessions via delegationChains
-					if (lastCoderIndex !== -1 && hasReviewer) {
-						for (const [, otherSession] of swarmState.agentSessions) {
-							if (otherSession === session) continue;
-							if (!otherSession.taskWorkflowStates) continue;
-
-							// Seed task state in sessions that don't have an entry yet
-							const seedTaskId = getSeedTaskId(session);
-							if (
-								seedTaskId &&
-								!otherSession.taskWorkflowStates.has(seedTaskId)
-							) {
-								otherSession.taskWorkflowStates.set(
-									seedTaskId,
-									'coder_delegated',
-								);
-							}
-							for (const [taskId, state] of otherSession.taskWorkflowStates) {
+						// Fallback Pass 1: advance states via delegationChains
+						if (
+							lastCoderIndex !== -1 &&
+							hasReviewer &&
+							session.taskWorkflowStates
+						) {
+							for (const [taskId, state] of session.taskWorkflowStates) {
 								if (
 									state === 'coder_delegated' ||
 									state === 'pre_check_passed'
 								) {
 									try {
-										advanceTaskState(otherSession, taskId, 'reviewer_run');
+										advanceTaskState(session, taskId, 'reviewer_run');
 									} catch (err) {
 										console.warn(
-											`[delegation-gate] fallback cross-session: could not advance ${taskId} (${state}) → reviewer_run: ${err instanceof Error ? err.message : String(err)}`,
+											`[delegation-gate] fallback: could not advance ${taskId} (${state}) → reviewer_run: ${err instanceof Error ? err.message : String(err)}`,
 										);
 									}
 								}
 							}
 						}
-					}
 
-					if (lastCoderIndex !== -1 && hasReviewer && hasTestEngineer) {
-						for (const [, otherSession] of swarmState.agentSessions) {
-							if (otherSession === session) continue;
-							if (!otherSession.taskWorkflowStates) continue;
-
-							// Seed task state in sessions that don't have an entry yet
-							const seedTaskId = getSeedTaskId(session);
-							if (
-								seedTaskId &&
-								!otherSession.taskWorkflowStates.has(seedTaskId)
-							) {
-								otherSession.taskWorkflowStates.set(seedTaskId, 'reviewer_run');
-							}
-							for (const [taskId, state] of otherSession.taskWorkflowStates) {
+						// Fallback Pass 2: advance states via delegationChains
+						if (
+							lastCoderIndex !== -1 &&
+							hasReviewer &&
+							hasTestEngineer &&
+							session.taskWorkflowStates
+						) {
+							for (const [taskId, state] of session.taskWorkflowStates) {
 								if (state === 'reviewer_run') {
 									try {
-										advanceTaskState(otherSession, taskId, 'tests_run');
+										advanceTaskState(session, taskId, 'tests_run');
 									} catch (err) {
 										console.warn(
-											`[delegation-gate] fallback cross-session: could not advance ${taskId} (${state}) → tests_run: ${err instanceof Error ? err.message : String(err)}`,
+											`[delegation-gate] fallback: could not advance ${taskId} (${state}) → tests_run: ${err instanceof Error ? err.message : String(err)}`,
 										);
+									}
+								}
+							}
+						}
+
+						// Fallback: Also advance states in OTHER sessions via delegationChains
+						if (lastCoderIndex !== -1 && hasReviewer) {
+							for (const [, otherSession] of swarmState.agentSessions) {
+								if (otherSession === session) continue;
+								if (!otherSession.taskWorkflowStates) continue;
+
+								// Seed task state in sessions that don't have an entry yet
+								const seedTaskId = getSeedTaskId(session);
+								if (
+									seedTaskId &&
+									!otherSession.taskWorkflowStates.has(seedTaskId)
+								) {
+									otherSession.taskWorkflowStates.set(
+										seedTaskId,
+										'coder_delegated',
+									);
+								}
+								for (const [taskId, state] of otherSession.taskWorkflowStates) {
+									if (
+										state === 'coder_delegated' ||
+										state === 'pre_check_passed'
+									) {
+										try {
+											advanceTaskState(otherSession, taskId, 'reviewer_run');
+										} catch (err) {
+											console.warn(
+												`[delegation-gate] fallback cross-session: could not advance ${taskId} (${state}) → reviewer_run: ${err instanceof Error ? err.message : String(err)}`,
+											);
+										}
+									}
+								}
+							}
+						}
+
+						if (lastCoderIndex !== -1 && hasReviewer && hasTestEngineer) {
+							for (const [, otherSession] of swarmState.agentSessions) {
+								if (otherSession === session) continue;
+								if (!otherSession.taskWorkflowStates) continue;
+
+								// Seed task state in sessions that don't have an entry yet
+								const seedTaskId = getSeedTaskId(session);
+								if (
+									seedTaskId &&
+									!otherSession.taskWorkflowStates.has(seedTaskId)
+								) {
+									otherSession.taskWorkflowStates.set(
+										seedTaskId,
+										'reviewer_run',
+									);
+								}
+								for (const [taskId, state] of otherSession.taskWorkflowStates) {
+									if (state === 'reviewer_run') {
+										try {
+											advanceTaskState(otherSession, taskId, 'tests_run');
+										} catch (err) {
+											console.warn(
+												`[delegation-gate] fallback cross-session: could not advance ${taskId} (${state}) → tests_run: ${err instanceof Error ? err.message : String(err)}`,
+											);
+										}
 									}
 								}
 							}

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -645,6 +645,7 @@ export function createDelegationGateHook(
 								typeof result.roundNumber === 'number' ? result.roundNumber : 1,
 						});
 						if (
+							councilActive &&
 							result.overallVerdict === 'APPROVE' &&
 							result.allCriteriaMet === true &&
 							(result.requiredFixesCount ?? 0) === 0

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -663,6 +663,9 @@ export function createDelegationGateHook(
 					`[delegation-gate] toolAfter convene_council: failed to parse output: ${err instanceof Error ? err.message : String(err)}`,
 				);
 			}
+			// Return early — gate-evidence recording (inside the Task branch below)
+			// does not apply to convene_council: it is a synthesis tool, not a gate
+			// delegation, and 'convene_council' is not in the gateAgents list.
 			return;
 		}
 

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -20,6 +20,7 @@ import {
 	ensureAgentSession,
 	getTaskState,
 	hasActiveTurboMode,
+	isCouncilGateActive,
 	swarmState,
 } from '../state';
 import { telemetry } from '../telemetry.js';
@@ -599,6 +600,72 @@ export function createDelegationGateHook(
 
 		// Detect task tool calls
 		const normalized = normalizeToolName(input.tool);
+
+		// Cache council-active status; if true, Stage B advancement is REPLACED by
+		// council Phase 1 — reviewer/test_engineer Task delegations remain
+		// observable but do not advance state. The advancement event is the
+		// council verdict (handled in the convene_council branch below).
+		// isCouncilGateActive returns false when the plan or QA gate profile is
+		// missing, which is the safe default.
+		const councilActive = await isCouncilGateActive(directory, config.council);
+
+		// Council branch: handle convene_council tool calls. Records the verdict on the
+		// session, and if APPROVE + allCriteriaMet + zero required fixes, advances the
+		// task to 'complete'. State machine still requires pre_check_passed (Stage A).
+		if (normalized === 'convene_council') {
+			try {
+				// _output may be a string (older runtimes) or already-parsed object.
+				const parsed =
+					typeof _output === 'string' ? JSON.parse(_output) : _output;
+				const result = parsed as {
+					success?: boolean;
+					overallVerdict?: 'APPROVE' | 'REJECT' | 'CONCERNS';
+					allCriteriaMet?: boolean;
+					requiredFixesCount?: number;
+					roundNumber?: number;
+				} | null;
+				if (
+					result &&
+					typeof result === 'object' &&
+					result.success === true &&
+					typeof result.overallVerdict === 'string'
+				) {
+					const taskIdRaw = (input.args as Record<string, unknown> | undefined)
+						?.taskId;
+					const taskId = typeof taskIdRaw === 'string' ? taskIdRaw : null;
+					if (taskId) {
+						if (!session.taskCouncilApproved)
+							session.taskCouncilApproved = new Map();
+						session.taskCouncilApproved.set(taskId, {
+							verdict: result.overallVerdict,
+							roundNumber:
+								typeof result.roundNumber === 'number'
+									? result.roundNumber
+									: 1,
+						});
+						if (
+							result.overallVerdict === 'APPROVE' &&
+							result.allCriteriaMet === true &&
+							(result.requiredFixesCount ?? 0) === 0
+						) {
+							try {
+								advanceTaskState(session, taskId, 'complete');
+							} catch (err) {
+								console.warn(
+									`[delegation-gate] toolAfter convene_council: could not advance ${taskId} → complete: ${err instanceof Error ? err.message : String(err)}`,
+								);
+							}
+						}
+					}
+				}
+			} catch (err) {
+				console.warn(
+					`[delegation-gate] toolAfter convene_council: failed to parse output: ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
+			return;
+		}
+
 		if (normalized === 'Task' || normalized === 'task') {
 			// Primary source: input.args from OpenCode's tool.execute.after hook (authoritative)
 			// Fallback: stored args from guardrails toolBefore (legacy path)
@@ -621,94 +688,103 @@ export function createDelegationGateHook(
 				if (targetAgent === 'reviewer') hasReviewer = true;
 				if (targetAgent === 'test_engineer') hasTestEngineer = true;
 
-				// Pass 1: advance tasks at coder_delegated or pre_check_passed → reviewer_run
-				if (targetAgent === 'reviewer' && session.taskWorkflowStates) {
-					for (const [taskId, state] of session.taskWorkflowStates) {
-						if (state === 'coder_delegated' || state === 'pre_check_passed') {
-							try {
-								advanceTaskState(session, taskId, 'reviewer_run');
-							} catch (err) {
-								// Non-fatal: state may already be at or past reviewer_run.
-								// Log so that silent swallowing does not hide root-cause bugs
-								// (e.g. INVALID_TASK_STATE_TRANSITION from PR #123 strict mode).
-								console.warn(
-									`[delegation-gate] toolAfter: could not advance ${taskId} (${state}) → reviewer_run: ${err instanceof Error ? err.message : String(err)}`,
-								);
-							}
-						}
-					}
-				}
-
-				// Pass 2: advance tasks at reviewer_run → tests_run for test_engineer only
-				if (targetAgent === 'test_engineer' && session.taskWorkflowStates) {
-					for (const [taskId, state] of session.taskWorkflowStates) {
-						if (state === 'reviewer_run') {
-							try {
-								advanceTaskState(session, taskId, 'tests_run');
-							} catch (err) {
-								// Non-fatal: state may already be at or past tests_run.
-								// Log so advancement failures are diagnosable.
-								console.warn(
-									`[delegation-gate] toolAfter: could not advance ${taskId} (${state}) → tests_run: ${err instanceof Error ? err.message : String(err)}`,
-								);
-							}
-						}
-					}
-				}
-
-				// Also advance states in OTHER sessions (cross-session propagation)
-				if (targetAgent === 'reviewer' || targetAgent === 'test_engineer') {
-					for (const [, otherSession] of swarmState.agentSessions) {
-						if (otherSession === session) continue;
-						if (!otherSession.taskWorkflowStates) continue;
-
-						// Pass 1: coder_delegated/pre_check_passed → reviewer_run
-						if (targetAgent === 'reviewer') {
-							// Seed task state in sessions that don't have an entry yet
-							const seedTaskId = getSeedTaskId(session);
-							if (
-								seedTaskId &&
-								!otherSession.taskWorkflowStates.has(seedTaskId)
-							) {
-								otherSession.taskWorkflowStates.set(
-									seedTaskId,
-									'coder_delegated',
-								);
-							}
-							for (const [taskId, state] of otherSession.taskWorkflowStates) {
-								if (
-									state === 'coder_delegated' ||
-									state === 'pre_check_passed'
-								) {
-									try {
-										advanceTaskState(otherSession, taskId, 'reviewer_run');
-									} catch (err) {
-										console.warn(
-											`[delegation-gate] toolAfter cross-session: could not advance ${taskId} (${state}) → reviewer_run: ${err instanceof Error ? err.message : String(err)}`,
-										);
-									}
+				// Stage B advancement (current-session and cross-session) is the
+				// non-council path. When council is authoritative for this plan
+				// (pluginConfig.council.enabled=true AND QaGates.council_mode=true),
+				// the council Phase 1 dispatch of reviewer/test_engineer is the sole
+				// review pass — Stage B is REPLACED, not supplemented. Skip both the
+				// current-session and cross-session advancement blocks, but keep the
+				// evidence-recording block below intact so the calls remain auditable.
+				if (!councilActive) {
+					// Pass 1: advance tasks at coder_delegated or pre_check_passed → reviewer_run
+					if (targetAgent === 'reviewer' && session.taskWorkflowStates) {
+						for (const [taskId, state] of session.taskWorkflowStates) {
+							if (state === 'coder_delegated' || state === 'pre_check_passed') {
+								try {
+									advanceTaskState(session, taskId, 'reviewer_run');
+								} catch (err) {
+									// Non-fatal: state may already be at or past reviewer_run.
+									// Log so that silent swallowing does not hide root-cause bugs
+									// (e.g. INVALID_TASK_STATE_TRANSITION from PR #123 strict mode).
+									console.warn(
+										`[delegation-gate] toolAfter: could not advance ${taskId} (${state}) → reviewer_run: ${err instanceof Error ? err.message : String(err)}`,
+									);
 								}
 							}
 						}
+					}
 
-						// Pass 2: reviewer_run → tests_run
-						if (targetAgent === 'test_engineer') {
-							// Seed task state in sessions that don't have an entry yet
-							const seedTaskId = getSeedTaskId(session);
-							if (
-								seedTaskId &&
-								!otherSession.taskWorkflowStates.has(seedTaskId)
-							) {
-								otherSession.taskWorkflowStates.set(seedTaskId, 'reviewer_run');
+					// Pass 2: advance tasks at reviewer_run → tests_run for test_engineer only
+					if (targetAgent === 'test_engineer' && session.taskWorkflowStates) {
+						for (const [taskId, state] of session.taskWorkflowStates) {
+							if (state === 'reviewer_run') {
+								try {
+									advanceTaskState(session, taskId, 'tests_run');
+								} catch (err) {
+									// Non-fatal: state may already be at or past tests_run.
+									// Log so advancement failures are diagnosable.
+									console.warn(
+										`[delegation-gate] toolAfter: could not advance ${taskId} (${state}) → tests_run: ${err instanceof Error ? err.message : String(err)}`,
+									);
+								}
 							}
-							for (const [taskId, state] of otherSession.taskWorkflowStates) {
-								if (state === 'reviewer_run') {
-									try {
-										advanceTaskState(otherSession, taskId, 'tests_run');
-									} catch (err) {
-										console.warn(
-											`[delegation-gate] toolAfter cross-session: could not advance ${taskId} (${state}) → tests_run: ${err instanceof Error ? err.message : String(err)}`,
-										);
+						}
+					}
+
+					// Also advance states in OTHER sessions (cross-session propagation)
+					if (targetAgent === 'reviewer' || targetAgent === 'test_engineer') {
+						for (const [, otherSession] of swarmState.agentSessions) {
+							if (otherSession === session) continue;
+							if (!otherSession.taskWorkflowStates) continue;
+
+							// Pass 1: coder_delegated/pre_check_passed → reviewer_run
+							if (targetAgent === 'reviewer') {
+								// Seed task state in sessions that don't have an entry yet
+								const seedTaskId = getSeedTaskId(session);
+								if (
+									seedTaskId &&
+									!otherSession.taskWorkflowStates.has(seedTaskId)
+								) {
+									otherSession.taskWorkflowStates.set(
+										seedTaskId,
+										'coder_delegated',
+									);
+								}
+								for (const [taskId, state] of otherSession.taskWorkflowStates) {
+									if (
+										state === 'coder_delegated' ||
+										state === 'pre_check_passed'
+									) {
+										try {
+											advanceTaskState(otherSession, taskId, 'reviewer_run');
+										} catch (err) {
+											console.warn(
+												`[delegation-gate] toolAfter cross-session: could not advance ${taskId} (${state}) → reviewer_run: ${err instanceof Error ? err.message : String(err)}`,
+											);
+										}
+									}
+								}
+							}
+
+							// Pass 2: reviewer_run → tests_run
+							if (targetAgent === 'test_engineer') {
+								// Seed task state in sessions that don't have an entry yet
+								const seedTaskId = getSeedTaskId(session);
+								if (
+									seedTaskId &&
+									!otherSession.taskWorkflowStates.has(seedTaskId)
+								) {
+									otherSession.taskWorkflowStates.set(seedTaskId, 'reviewer_run');
+								}
+								for (const [taskId, state] of otherSession.taskWorkflowStates) {
+									if (state === 'reviewer_run') {
+										try {
+											advanceTaskState(otherSession, taskId, 'tests_run');
+										} catch (err) {
+											console.warn(
+												`[delegation-gate] toolAfter cross-session: could not advance ${taskId} (${state}) → tests_run: ${err instanceof Error ? err.message : String(err)}`,
+											);
+										}
 									}
 								}
 							}

--- a/src/state.ts
+++ b/src/state.ts
@@ -944,12 +944,13 @@ export async function isCouncilGateActive(
 	try {
 		profile = getProfile(directory, planId);
 	} catch (err) {
-		// Distinguish a missing-profile (expected in fresh repos) from an I/O error
-		// (EACCES, EBUSY, etc.) that may indicate a real problem.
-		const code = (err as NodeJS.ErrnoException)?.code;
-		if (code && code !== 'ENOENT' && code !== 'SQLITE_CANTOPEN') {
+		// getProfile returns null on missing DB; it only throws on unexpected I/O or
+		// SQLite errors (EACCES, EBUSY, corrupt database). Log those so they're visible.
+		const msg = err instanceof Error ? err.message : String(err);
+		const isBenign = msg.includes('SQLITE_CANTOPEN') || msg.includes('ENOENT');
+		if (!isBenign) {
 			console.warn(
-				`[isCouncilGateActive] getProfile failed for plan ${planId}: ${code}. Treating council as inactive.`,
+				`[isCouncilGateActive] getProfile threw unexpectedly for plan ${planId}: ${msg}. Treating council as inactive.`,
 			);
 		}
 		profile = null;

--- a/src/state.ts
+++ b/src/state.ts
@@ -13,7 +13,8 @@ import type { OpencodeClient } from '@opencode-ai/sdk';
 import { ORCHESTRATOR_NAME } from './config/constants';
 import { type Plan, PlanSchema, type TaskStatus } from './config/plan-schema';
 import { stripKnownSwarmPrefix } from './config/schema';
-import type { QaGates } from './db/qa-gate-profile.js';
+import { getProfile, type QaGates } from './db/qa-gate-profile.js';
+import { loadPlanJsonOnly } from './plan/manager.js';
 import {
 	detectEnvironmentProfile,
 	type EnvironmentProfile,
@@ -32,6 +33,12 @@ interface RehydrationCache {
 	evidenceMap: Map<string, TaskEvidence>;
 }
 let _rehydrationCache: RehydrationCache | null = null;
+
+/**
+ * Tracks plan IDs that have already received the "council disagreement" warn.
+ * One warning per plan_id, per process lifetime. Cleared by resetSwarmState.
+ */
+const _councilDisagreementWarned = new Set<string>();
 
 /**
  * Represents a single tool call entry for tracking purposes
@@ -147,6 +154,11 @@ export interface AgentSessionState {
 	// v6.21 Per-task state machine
 	/** Per-task workflow state — taskId → current state */
 	taskWorkflowStates: Map<string, TaskWorkflowState>;
+	/** v6.71+ Council mode: per-task council verdict, recorded by delegation-gate when convene_council resolves. */
+	taskCouncilApproved?: Map<
+		string,
+		{ verdict: 'APPROVE' | 'REJECT' | 'CONCERNS'; roundNumber: number }
+	>;
 	/** Last gate outcome for deliberation preamble injection */
 	lastGateOutcome: {
 		gate: string;
@@ -320,6 +332,9 @@ export function resetSwarmState(): void {
 	// map so a /swarm close + new session with a colliding taskId (e.g. "1.1")
 	// cannot inherit stale scope from the previous swarm.
 	clearPendingCoderScope();
+	// v6.71+ Clear the council-mode disagreement warn-once memo so tests and
+	// fresh sessions observe consistent first-time warnings.
+	_councilDisagreementWarned.clear();
 	// Note: Session-scoped fields (architectWriteCount, gateLog, reviewerCallCount, lastGateFailure)
 	// are cleared when agentSessions entries are deleted
 }
@@ -383,6 +398,7 @@ export function startAgentSession(
 		qaSkipTaskIds: [],
 		// v6.21 Per-task state machine
 		taskWorkflowStates: new Map(),
+		taskCouncilApproved: new Map(),
 		lastGateOutcome: null,
 		declaredCoderScope: null,
 		lastScopeViolation: null,
@@ -560,6 +576,10 @@ export function ensureAgentSession(
 		// v6.21 Per-task state machine migration safety
 		if (!session.taskWorkflowStates) {
 			session.taskWorkflowStates = new Map();
+		}
+		// v6.71+ Council mode migration safety
+		if (!session.taskCouncilApproved) {
+			session.taskCouncilApproved = new Map();
 		}
 		if (session.lastGateOutcome === undefined) {
 			session.lastGateOutcome = null;
@@ -838,9 +858,18 @@ export function advanceTaskState(
 
 	// 'complete' can only be reached from 'tests_run' — enforce sequential progression
 	if (newState === 'complete' && current !== 'tests_run') {
-		throw new Error(
-			`INVALID_TASK_STATE_TRANSITION: ${taskId} cannot reach complete from ${current} — must pass through tests_run first`,
-		);
+		// Council fast-path: if convene_council recorded an APPROVE verdict for this task,
+		// allow advancement from any non-idle prior state. Pre-check (pre_check_passed) is
+		// still required to avoid skipping Stage A.
+		const councilEntry = session.taskCouncilApproved?.get(taskId);
+		const councilApproved = councilEntry?.verdict === 'APPROVE';
+		const pastPreCheck =
+			currentIndex >= STATE_ORDER.indexOf('pre_check_passed');
+		if (!councilApproved || !pastPreCheck) {
+			throw new Error(
+				`INVALID_TASK_STATE_TRANSITION: ${taskId} cannot reach complete from ${current} — must pass through tests_run first (or have council APPROVE after pre_check)`,
+			);
+		}
 	}
 
 	session.taskWorkflowStates.set(taskId, newState);
@@ -871,6 +900,81 @@ export function getTaskState(
 	}
 
 	return session.taskWorkflowStates.get(taskId) ?? 'idle';
+}
+
+/**
+ * Derive the plan_id from a Plan, matching the format used by other consumers
+ * (set_qa_gates / get_qa_gate_profile / get_approved_plan / write-drift-evidence).
+ */
+function derivePlanIdFromPlan(plan: { swarm: string; title: string }): string {
+	return `${plan.swarm}-${plan.title}`.replace(/[^a-zA-Z0-9-_]/g, '_');
+}
+
+/**
+ * Returns true iff council is authoritative for the current plan.
+ *
+ * AND semantics: council is authoritative when BOTH `pluginConfig.council.enabled === true`
+ * AND `QaGates.council_mode === true` for the plan associated with this directory.
+ *
+ * If exactly one of the two flags is true, a one-time warning is logged per plan_id
+ * (so operators can see the deadlock case) and the function falls back to `false`,
+ * which keeps Stage B running as the default.
+ *
+ * Returns false when the plan or QA gate profile cannot be loaded — when the plan
+ * is missing the council cannot meaningfully be "authoritative".
+ */
+export async function isCouncilGateActive(
+	directory: string,
+	council: { enabled?: boolean } | undefined,
+): Promise<boolean> {
+	const enabled = council?.enabled === true;
+
+	let plan: Plan | null = null;
+	try {
+		plan = await loadPlanJsonOnly(directory);
+	} catch {
+		plan = null;
+	}
+	if (!plan) {
+		return false;
+	}
+
+	const planId = derivePlanIdFromPlan(plan);
+	let profile: ReturnType<typeof getProfile> | null = null;
+	try {
+		profile = getProfile(directory, planId);
+	} catch {
+		profile = null;
+	}
+	if (!profile) {
+		return false;
+	}
+
+	const councilMode = profile.gates.council_mode === true;
+
+	if (enabled && councilMode) {
+		return true;
+	}
+
+	// Disagreement case: warn once per plan_id, then fall back.
+	if (enabled !== councilMode && !_councilDisagreementWarned.has(planId)) {
+		_councilDisagreementWarned.add(planId);
+		console.warn(
+			`[delegation-gate] Council mode mismatch for plan ${planId}: ` +
+				`pluginConfig.council.enabled=${enabled}, QaGates.council_mode=${councilMode}. ` +
+				'Falling back to Stage B (non-council) advancement.',
+		);
+	}
+
+	return false;
+}
+
+/**
+ * Test-only helper: clear the warn-once memo so each test can observe a fresh
+ * disagreement warning. Not part of the public surface.
+ */
+export function _resetCouncilDisagreementWarnings(): void {
+	_councilDisagreementWarned.clear();
 }
 
 /**
@@ -1045,6 +1149,9 @@ export function applyRehydrationCache(session: AgentSessionState): void {
 
 	if (!session.taskWorkflowStates) {
 		session.taskWorkflowStates = new Map();
+	}
+	if (!session.taskCouncilApproved) {
+		session.taskCouncilApproved = new Map();
 	}
 
 	const { planTaskStates, evidenceMap } = _rehydrationCache;

--- a/src/state.ts
+++ b/src/state.ts
@@ -14,13 +14,13 @@ import { ORCHESTRATOR_NAME } from './config/constants';
 import { type Plan, PlanSchema, type TaskStatus } from './config/plan-schema';
 import { stripKnownSwarmPrefix } from './config/schema';
 import { getProfile, type QaGates } from './db/qa-gate-profile.js';
-import { loadPlanJsonOnly } from './plan/manager.js';
 import {
 	detectEnvironmentProfile,
 	type EnvironmentProfile,
 } from './environment/profile.js';
 import type { TaskEvidence } from './gate-evidence';
 import { clearPendingCoderScope } from './hooks/delegation-gate.js';
+import { loadPlanJsonOnly } from './plan/manager.js';
 import { telemetry } from './telemetry.js';
 
 /**

--- a/src/state.ts
+++ b/src/state.ts
@@ -943,7 +943,15 @@ export async function isCouncilGateActive(
 	let profile: ReturnType<typeof getProfile> | null = null;
 	try {
 		profile = getProfile(directory, planId);
-	} catch {
+	} catch (err) {
+		// Distinguish a missing-profile (expected in fresh repos) from an I/O error
+		// (EACCES, EBUSY, etc.) that may indicate a real problem.
+		const code = (err as NodeJS.ErrnoException)?.code;
+		if (code && code !== 'ENOENT' && code !== 'SQLITE_CANTOPEN') {
+			console.warn(
+				`[isCouncilGateActive] getProfile failed for plan ${planId}: ${code}. Treating council as inactive.`,
+			);
+		}
 		profile = null;
 	}
 	if (!profile) {

--- a/src/test-impact/__tests__/analyzer-import-fix.adversarial.test.ts
+++ b/src/test-impact/__tests__/analyzer-import-fix.adversarial.test.ts
@@ -22,7 +22,7 @@ function execRegex(regex: RegExp, content: string): string[] {
 	return results;
 }
 
-function extractImports(content: string): string[] {
+function _extractImports(content: string): string[] {
 	return [
 		...execRegex(IMPORT_REGEX_ES, content),
 		...execRegex(IMPORT_REGEX_REQUIRE, content),
@@ -328,7 +328,7 @@ export { C } from './c'; // This should be captured
 
 describe('ADVERSARIAL: Catastrophic backtracking', () => {
 	test('many commas in export braces', () => {
-		const content = 'export { ' + 'a'.repeat(1000) + " } from './bar';";
+		const content = `export { ${'a'.repeat(1000)} } from './bar';`;
 		const start = Date.now();
 		const results = execRegex(IMPORT_REGEX_REEXPORT, content);
 		const elapsed = Date.now() - start;
@@ -403,7 +403,7 @@ describe('EDGE CASES: Path traversal and security', () => {
 	});
 
 	test('very deep relative path', () => {
-		const deepPath = './' + Array(100).fill('a').join('/');
+		const deepPath = `./${Array(100).fill('a').join('/')}`;
 		const content = `export { X } from '${deepPath}';`;
 		const results = execRegex(IMPORT_REGEX_REEXPORT, content);
 		expect(results).toEqual([deepPath]);

--- a/src/test-impact/__tests__/analyzer-import-fix.adversarial.test.ts
+++ b/src/test-impact/__tests__/analyzer-import-fix.adversarial.test.ts
@@ -250,7 +250,7 @@ describe('RESOLVE_RELATIVE_IMPORT EDGE CASES', () => {
 	});
 
 	test('very long import path handling', () => {
-		const longPath = './' + 'a'.repeat(10000);
+		const longPath = `./${'a'.repeat(10000)}`;
 		const resolved = path.resolve('/cwd', longPath);
 		expect(resolved.length).toBeGreaterThan(10000);
 	});

--- a/src/test-impact/__tests__/analyzer.adversarial.test.ts
+++ b/src/test-impact/__tests__/analyzer.adversarial.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { analyzeImpact, buildImpactMap, loadImpactMap } from '../analyzer';
+import { analyzeImpact, buildImpactMap } from '../analyzer';
 
 function createTempDir(): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'analyzer-adversarial-'));

--- a/src/test-impact/__tests__/analyzer.test.ts
+++ b/src/test-impact/__tests__/analyzer.test.ts
@@ -6,11 +6,7 @@ import path from 'node:path';
 const isWindows = process.platform === 'win32';
 
 // Import the module under test
-import {
-	analyzeImpact,
-	buildImpactMap,
-	loadImpactMap,
-} from '../analyzer.js';
+import { analyzeImpact, buildImpactMap, loadImpactMap } from '../analyzer.js';
 
 describe('TestImpactAnalyzer', () => {
 	let tempDir: string;

--- a/src/test-impact/__tests__/analyzer.test.ts
+++ b/src/test-impact/__tests__/analyzer.test.ts
@@ -10,7 +10,6 @@ import {
 	analyzeImpact,
 	buildImpactMap,
 	loadImpactMap,
-	type TestImpactResult,
 } from '../analyzer.js';
 
 describe('TestImpactAnalyzer', () => {
@@ -315,7 +314,7 @@ test('foo', () => { expect(foo).toBe(1); });`,
 			const cacheContent = JSON.parse(
 				await fs.promises.readFile(cachePath, 'utf-8'),
 			);
-			const originalGeneratedAt = cacheContent.generatedAt;
+			const _originalGeneratedAt = cacheContent.generatedAt;
 
 			// Wait a tiny bit so the timestamp would differ if rebuilt
 			await new Promise((r) => setTimeout(r, 10));

--- a/src/test-impact/__tests__/council-fixes.test.ts
+++ b/src/test-impact/__tests__/council-fixes.test.ts
@@ -323,7 +323,7 @@ describe('council-fixes', () => {
 				'cache',
 				'test-history.jsonl',
 			);
-			const tempPath = historyPath + '.tmp';
+			const tempPath = `${historyPath}.tmp`;
 
 			// Write first record
 			appendTestRun(record, tempDir);
@@ -360,7 +360,7 @@ describe('council-fixes', () => {
 			// Let's just verify the cleanup happens on error by mocking
 			// For now, just verify normal operation works
 
-			expect(fs.existsSync(historyPath + '.tmp')).toBe(false);
+			expect(fs.existsSync(`${historyPath}.tmp`)).toBe(false);
 		});
 
 		test('appendTestRun writes valid JSONL content', () => {

--- a/src/test-impact/__tests__/council-fixes.test.ts
+++ b/src/test-impact/__tests__/council-fixes.test.ts
@@ -348,7 +348,7 @@ describe('council-fixes', () => {
 			// Use a different approach - write to a temp dir first, then try to write to locked location
 			fs.mkdirSync(cacheDir, { recursive: true });
 
-			const record = makeRecord({
+			const _record = makeRecord({
 				testFile: 'fail-test.test.ts',
 				testName: 'fail test',
 				result: 'pass',

--- a/src/test-impact/__tests__/failure-classifier.adversarial.test.ts
+++ b/src/test-impact/__tests__/failure-classifier.adversarial.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { expect, test } from 'bun:test';
 import {
 	classifyAndCluster,
 	classifyFailure,
@@ -291,7 +291,7 @@ test('classifyFailure handles extremely long errorMessage (10000 chars)', () => 
 });
 
 test('classifyFailure handles extremely long stackPrefix (10000 chars)', () => {
-	const longPrefix = 'at ' + 'x'.repeat(9997);
+	const longPrefix = `at ${'x'.repeat(9997)}`;
 	const current = makeRecord({ stackPrefix: longPrefix });
 
 	const result = classifyFailure(current, []);
@@ -300,7 +300,7 @@ test('classifyFailure handles extremely long stackPrefix (10000 chars)', () => {
 });
 
 test('clusterFailures handles long strings in clustering', () => {
-	const longKey = 'prefix' + 'x'.repeat(5000) + 'error' + 'y'.repeat(5000);
+	const _longKey = `prefix${'x'.repeat(5000)}error${'y'.repeat(5000)}`;
 	const failures = [
 		{
 			testFile: 'f1',

--- a/src/test-impact/__tests__/failure-classifier.test.ts
+++ b/src/test-impact/__tests__/failure-classifier.test.ts
@@ -4,7 +4,6 @@ import {
 	classifyAndCluster,
 	classifyFailure,
 	clusterFailures,
-	type FailureCluster,
 } from '../failure-classifier.js';
 import type { TestRunRecord } from '../history-store.js';
 

--- a/src/test-impact/__tests__/history-store.adversarial.test.ts
+++ b/src/test-impact/__tests__/history-store.adversarial.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../history-store.js';
 
 describe('history-store adversarial security tests', () => {
-	const tempDir = path.join(import.meta.dir, 'adversarial-temp-' + Date.now());
+	const tempDir = path.join(import.meta.dir, `adversarial-temp-${Date.now()}`);
 
 	beforeEach(() => {
 		// Create fresh temp directory for each test
@@ -186,7 +186,7 @@ describe('history-store adversarial security tests', () => {
 
 		test('Unicode emoji in errorMessage is preserved correctly', () => {
 			// Use fewer A's so total is under 500 chars
-			const emojiMessage = '💣💥🔥😈💀👾' + 'A'.repeat(100);
+			const emojiMessage = `💣💥🔥😈💀👾${'A'.repeat(100)}`;
 			appendTestRun(
 				{
 					timestamp: new Date().toISOString(),

--- a/src/test-impact/__tests__/test-impact.adversarial.test.ts
+++ b/src/test-impact/__tests__/test-impact.adversarial.test.ts
@@ -152,7 +152,7 @@ describe('test_impact — adversarial input handling', () => {
 		});
 
 		test('extremely long file path (10000 chars) completes', async () => {
-			const longPath = 'a'.repeat(10000) + '.ts';
+			const longPath = `${'a'.repeat(10000)}.ts`;
 
 			const result = await test_impact.execute(
 				{ changedFiles: [longPath] },
@@ -165,7 +165,7 @@ describe('test_impact — adversarial input handling', () => {
 
 		test('deeply nested path (1000 levels) completes', async () => {
 			const deepPath =
-				Array.from({ length: 1000 }, () => 'dir').join('/') + '/file.ts';
+				`${Array.from({ length: 1000 }, () => 'dir').join('/')}/file.ts`;
 
 			const result = await test_impact.execute(
 				{ changedFiles: [deepPath] },

--- a/src/test-impact/__tests__/test-impact.adversarial.test.ts
+++ b/src/test-impact/__tests__/test-impact.adversarial.test.ts
@@ -164,8 +164,7 @@ describe('test_impact — adversarial input handling', () => {
 		});
 
 		test('deeply nested path (1000 levels) completes', async () => {
-			const deepPath =
-				`${Array.from({ length: 1000 }, () => 'dir').join('/')}/file.ts`;
+			const deepPath = `${Array.from({ length: 1000 }, () => 'dir').join('/')}/file.ts`;
 
 			const result = await test_impact.execute(
 				{ changedFiles: [deepPath] },

--- a/src/test-impact/history-store.ts
+++ b/src/test-impact/history-store.ts
@@ -166,14 +166,14 @@ export function appendTestRun(
 	// Write atomically: temp file + rename to prevent corruption on crash
 	try {
 		const lines = prunedRecords.map((rec) => JSON.stringify(rec));
-		const content = lines.join('\n') + '\n';
-		const tempPath = historyPath + '.tmp';
+		const content = `${lines.join('\n')}\n`;
+		const tempPath = `${historyPath}.tmp`;
 		fs.writeFileSync(tempPath, content, 'utf-8');
 		fs.renameSync(tempPath, historyPath);
 	} catch (err) {
 		// Clean up temp file if rename failed
 		try {
-			const tempPath = historyPath + '.tmp';
+			const tempPath = `${historyPath}.tmp`;
 			if (fs.existsSync(tempPath)) {
 				fs.unlinkSync(tempPath);
 			}

--- a/tests/unit/agents/architect-brainstorm-gates.test.ts
+++ b/tests/unit/agents/architect-brainstorm-gates.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+import { createArchitectAgent } from '../../../src/agents/architect';
+
+/**
+ * MODE: BRAINSTORM Phase 6 — QA gate selection dialogue.
+ *
+ * Phase 6 used to autonomously select QA gates. Now it must ask the user
+ * (one question per message, defaults pre-stated) and stash the elections
+ * in `.swarm/context.md` rather than calling `set_qa_gates` directly
+ * (plan.json does not exist at this point — `set_qa_gates` would fail).
+ * MODE: PLAN persists the elections after `save_plan` succeeds.
+ */
+describe('architect prompt — MODE: BRAINSTORM Phase 6 QA gate selection', () => {
+	const prompt = createArchitectAgent('test-model').config.prompt!;
+
+	function getPhase6Section(): string {
+		const start = prompt.indexOf('**Phase 6:');
+		expect(start).toBeGreaterThan(-1);
+		const after = prompt.indexOf('**Phase 7:', start + 1);
+		return prompt.substring(start, after === -1 ? prompt.length : after);
+	}
+
+	test('Phase 6 contains the user-facing dialogue lead-in', () => {
+		const block = getPhase6Section();
+		expect(block).toContain(
+			'ask the user which QA gates to enable for this plan',
+		);
+		expect(block).toContain('do not select on their behalf');
+	});
+
+	test('Phase 6 lists all seven gate names as defaults', () => {
+		const block = getPhase6Section();
+		expect(block).toContain('reviewer');
+		expect(block).toContain('test_engineer');
+		expect(block).toContain('sme_enabled');
+		expect(block).toContain('critic_pre_plan');
+		expect(block).toContain('sast_enabled');
+		expect(block).toContain('council_mode');
+		expect(block).toContain('hallucination_guard');
+	});
+
+	test('Phase 6 says "One question, one message, defaults pre-stated"', () => {
+		const block = getPhase6Section();
+		expect(block).toContain('One question, one message, defaults pre-stated');
+	});
+
+	test('Phase 6 does NOT instruct calling set_qa_gates directly (defers to MODE: PLAN)', () => {
+		const block = getPhase6Section();
+		expect(block).toContain('Do NOT call `set_qa_gates` yet');
+	});
+
+	test('Phase 6 instructs writing to "## Pending QA Gate Selection" in context.md', () => {
+		const block = getPhase6Section();
+		expect(block).toContain('## Pending QA Gate Selection');
+		expect(block).toContain('.swarm/context.md');
+	});
+
+	test('Phase 6 references MODE: PLAN for persistence after save_plan', () => {
+		const block = getPhase6Section();
+		expect(block).toMatch(/MODE: PLAN applies these after.*save_plan/);
+	});
+
+	test('Phase 6 does not leave the {{QA_GATE_DIALOGUE_BRAINSTORM}} placeholder unexpanded', () => {
+		const block = getPhase6Section();
+		expect(block).not.toContain('{{QA_GATE_DIALOGUE_BRAINSTORM}}');
+	});
+
+	test('BRAINSTORM RULES updated: gates persisted during MODE: PLAN are ratchet-tighter from that point', () => {
+		// The line replaced the original "QA gates set in Phase 6 are ratchet-tighter — you cannot undo them later in the session."
+		expect(prompt).toContain(
+			'QA gates elected in Phase 6 are persisted during MODE: PLAN',
+		);
+		expect(prompt).toContain('ratchet-tighter from that point');
+		expect(prompt).not.toContain(
+			'QA gates set in Phase 6 are ratchet-tighter — you cannot undo them later in the session.',
+		);
+	});
+});

--- a/tests/unit/agents/architect-council-prompt.test.ts
+++ b/tests/unit/agents/architect-council-prompt.test.ts
@@ -77,6 +77,15 @@ describe('Architect prompt — Work Complete Council workflow block', () => {
 			expect(prompt).toContain('maxRounds');
 			expect(prompt).toMatch(/surface.*unifiedFeedbackMd.*HALT/is);
 		});
+
+		it('does not contain the old "supplements — does NOT replace" wording', () => {
+			expect(prompt).not.toContain('supplements — does NOT replace');
+		});
+
+		it('contains the REPLACES Stage B wording inside the council block', () => {
+			expect(prompt).toContain('REPLACES Stage B');
+			expect(prompt).toContain('Stage A (precheckbatch) still runs');
+		});
 	});
 
 	describe('council.enabled === false', () => {
@@ -97,6 +106,22 @@ describe('Architect prompt — Work Complete Council workflow block', () => {
 
 		it('does not leave the {{COUNCIL_WORKFLOW}} placeholder unexpanded', () => {
 			expect(prompt).not.toContain('{{COUNCIL_WORKFLOW}}');
+		});
+
+		it('YOUR TOOLS does not contain convene_council or declare_council_criteria', () => {
+			const yourToolsLine = prompt.match(/YOUR TOOLS:\s*(.+?)(?:\n|$)/)?.[1];
+			expect(yourToolsLine).toBeDefined();
+			expect(yourToolsLine).not.toContain('convene_council');
+			expect(yourToolsLine).not.toContain('declare_council_criteria');
+		});
+
+		it('Available Tools does not contain convene_council or declare_council_criteria', () => {
+			const availableToolsLine = prompt.match(
+				/Available Tools:\s*([\s\S]*?)(?:\n##|$)/,
+			)?.[1];
+			expect(availableToolsLine).toBeDefined();
+			expect(availableToolsLine).not.toContain('convene_council');
+			expect(availableToolsLine).not.toContain('declare_council_criteria');
 		});
 	});
 

--- a/tests/unit/agents/architect-specify-gates.test.ts
+++ b/tests/unit/agents/architect-specify-gates.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { createArchitectAgent } from '../../../src/agents/architect';
+
+/**
+ * MODE: SPECIFY step 5b — QA gate selection dialogue.
+ *
+ * SPECIFY runs BEFORE plan.json exists, so it must conduct the dialogue
+ * with the user and stash the elections in `.swarm/context.md` rather than
+ * persisting via `set_qa_gates` (which requires plan.json). MODE: PLAN
+ * applies the elections after `save_plan` succeeds.
+ */
+describe('architect prompt — MODE: SPECIFY step 5b QA gate selection', () => {
+	const prompt = createArchitectAgent('test-model').config.prompt!;
+
+	function getSpecifySection(): string {
+		// SPECIFY runs from "### MODE: SPECIFY" header through the next "### MODE:" header
+		const start = prompt.indexOf('### MODE: SPECIFY');
+		expect(start).toBeGreaterThan(-1);
+		const after = prompt.indexOf('### MODE:', start + 1);
+		return prompt.substring(start, after === -1 ? prompt.length : after);
+	}
+
+	test('SPECIFY block contains a step labeled "5b"', () => {
+		const block = getSpecifySection();
+		expect(block).toMatch(/5b\.\s+\*\*QA GATE SELECTION/);
+	});
+
+	test('SPECIFY block references the "## Pending QA Gate Selection" section', () => {
+		const block = getSpecifySection();
+		expect(block).toContain('## Pending QA Gate Selection');
+	});
+
+	test('SPECIFY block explicitly says "Do NOT call `set_qa_gates` yet"', () => {
+		const block = getSpecifySection();
+		expect(block).toContain('Do NOT call `set_qa_gates` yet');
+	});
+
+	test('SPECIFY block lists all seven QA gate names in the dialogue text', () => {
+		const block = getSpecifySection();
+		expect(block).toContain('reviewer');
+		expect(block).toContain('test_engineer');
+		expect(block).toContain('sme_enabled');
+		expect(block).toContain('critic_pre_plan');
+		expect(block).toContain('sast_enabled');
+		expect(block).toContain('council_mode');
+		expect(block).toContain('hallucination_guard');
+	});
+
+	test('SPECIFY block instructs writing to .swarm/context.md', () => {
+		const block = getSpecifySection();
+		expect(block).toContain('.swarm/context.md');
+	});
+
+	test('SPECIFY block mentions persistence happens in MODE: PLAN', () => {
+		const block = getSpecifySection();
+		expect(block).toMatch(/MODE: PLAN.*set_qa_gates/s);
+	});
+
+	test('SPECIFY block does not leave {{QA_GATE_DIALOGUE_SPECIFY}} placeholder unexpanded', () => {
+		const block = getSpecifySection();
+		expect(block).not.toContain('{{QA_GATE_DIALOGUE_SPECIFY}}');
+	});
+
+	test('renumbered final step 7 (formerly step 6) reports a summary to the user', () => {
+		const block = getSpecifySection();
+		expect(block).toMatch(/7\.\s+Report a summary to the user/);
+	});
+
+	test('MODE: PLAN block contains POST-SAVE_PLAN gate application instructions', () => {
+		const planStart = prompt.indexOf('### MODE: PLAN');
+		expect(planStart).toBeGreaterThan(-1);
+		const after = prompt.indexOf('### MODE:', planStart + 1);
+		const planBlock = prompt.substring(
+			planStart,
+			after === -1 ? prompt.length : after,
+		);
+		expect(planBlock).toContain('POST-SAVE_PLAN');
+		expect(planBlock).toContain('## Pending QA Gate Selection');
+		expect(planBlock).toContain('set_qa_gates');
+	});
+
+	test('MODE: PLAN inline path does not leave {{QA_GATE_DIALOGUE_PLAN}} placeholder unexpanded', () => {
+		const planStart = prompt.indexOf('### MODE: PLAN');
+		const after = prompt.indexOf('### MODE:', planStart + 1);
+		const planBlock = prompt.substring(
+			planStart,
+			after === -1 ? prompt.length : after,
+		);
+		expect(planBlock).not.toContain('{{QA_GATE_DIALOGUE_PLAN}}');
+	});
+});

--- a/tests/unit/agents/architect-tool-alignment.test.ts
+++ b/tests/unit/agents/architect-tool-alignment.test.ts
@@ -18,8 +18,17 @@ function extractPromptTools(prompt: string): string[] {
 }
 
 describe('architect prompt tool alignment', () => {
-	test('YOUR TOOLS in prompt matches AGENT_TOOL_MAP architect entry', () => {
-		const agent = createArchitectAgent('test-model');
+	test('YOUR TOOLS with council.enabled=true matches full AGENT_TOOL_MAP architect entry', () => {
+		// council.enabled=true exposes the full AGENT_TOOL_MAP.architect surface
+		// including convene_council and declare_council_criteria. This is the
+		// only configuration where YOUR TOOLS matches the map exactly.
+		const agent = createArchitectAgent(
+			'test-model',
+			undefined,
+			undefined,
+			undefined,
+			{ enabled: true },
+		);
 		const prompt =
 			((agent.config as Record<string, unknown>).prompt as string) ?? '';
 
@@ -32,5 +41,30 @@ describe('architect prompt tool alignment', () => {
 			.sort();
 
 		expect(promptToolsWithoutTask).toEqual(mapTools);
+	});
+
+	test('YOUR TOOLS with council disabled (default) excludes the two council-only tools', () => {
+		// Default no-arg call: council is undefined, which the prompt builder
+		// treats as disabled. convene_council and declare_council_criteria
+		// must be filtered out so the model is not shown phantom tools the
+		// runtime gate (src/hooks/convene-council.ts) would reject.
+		const agent = createArchitectAgent('test-model');
+		const prompt =
+			((agent.config as Record<string, unknown>).prompt as string) ?? '';
+
+		const promptTools = extractPromptTools(prompt);
+		const expected = [...AGENT_TOOL_MAP.architect]
+			.filter(
+				(t) => t !== 'convene_council' && t !== 'declare_council_criteria',
+			)
+			.sort();
+
+		const promptToolsWithoutTask = promptTools
+			.filter((t) => t !== 'Task (delegation)')
+			.sort();
+
+		expect(promptToolsWithoutTask).toEqual(expected);
+		expect(promptToolsWithoutTask).not.toContain('convene_council');
+		expect(promptToolsWithoutTask).not.toContain('declare_council_criteria');
 	});
 });

--- a/tests/unit/agents/architect-tool-lists.test.ts
+++ b/tests/unit/agents/architect-tool-lists.test.ts
@@ -22,8 +22,19 @@ const ARCHITECT_TOOL_COUNT = AGENT_TOOL_MAP['architect'].length;
 
 let resolvedPrompt: string;
 
+// Render with council.enabled=true so the full AGENT_TOOL_MAP.architect
+// surface (including `convene_council` and `declare_council_criteria`)
+// appears in YOUR TOOLS and Available Tools. Without council enabled,
+// those tools are filtered out of the prompt — see
+// architect-tool-visibility-council.test.ts for the council-off behavior.
 beforeAll(() => {
-	const agent = createArchitectAgent('test-model');
+	const agent = createArchitectAgent(
+		'test-model',
+		undefined,
+		undefined,
+		undefined,
+		{ enabled: true },
+	);
 	resolvedPrompt = agent.config.prompt ?? '';
 });
 

--- a/tests/unit/agents/architect-tool-visibility-council.test.ts
+++ b/tests/unit/agents/architect-tool-visibility-council.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test';
+import { createArchitectAgent } from '../../../src/agents/architect';
+
+/**
+ * Tool visibility sync — council-only tools (convene_council and
+ * declare_council_criteria) must only appear in YOUR TOOLS and Available
+ * Tools when council.enabled === true. Otherwise the runtime gate at
+ * src/hooks/convene-council.ts will reject any model attempt to call them.
+ */
+
+function getYourToolsSection(prompt: string): string {
+	const match = prompt.match(/YOUR TOOLS:\s*(.+?)(?:\n|$)/);
+	return match?.[1] ?? '';
+}
+
+function getAvailableToolsSection(prompt: string): string {
+	const match = prompt.match(/Available Tools:\s*([\s\S]*?)(?:\n##|$)/);
+	return match?.[1] ?? '';
+}
+
+describe('architect prompt — council tool visibility', () => {
+	describe('council undefined (config key absent)', () => {
+		const agent = createArchitectAgent('test-model');
+		const prompt = (agent.config as Record<string, unknown>).prompt as string;
+
+		test('YOUR TOOLS does not contain convene_council', () => {
+			expect(getYourToolsSection(prompt)).not.toContain('convene_council');
+		});
+
+		test('YOUR TOOLS does not contain declare_council_criteria', () => {
+			expect(getYourToolsSection(prompt)).not.toContain(
+				'declare_council_criteria',
+			);
+		});
+
+		test('Available Tools does not contain convene_council', () => {
+			expect(getAvailableToolsSection(prompt)).not.toContain('convene_council');
+		});
+
+		test('Available Tools does not contain declare_council_criteria', () => {
+			expect(getAvailableToolsSection(prompt)).not.toContain(
+				'declare_council_criteria',
+			);
+		});
+	});
+
+	describe('council.enabled === false', () => {
+		const agent = createArchitectAgent(
+			'test-model',
+			undefined,
+			undefined,
+			undefined,
+			{ enabled: false },
+		);
+		const prompt = (agent.config as Record<string, unknown>).prompt as string;
+
+		test('YOUR TOOLS does not contain convene_council', () => {
+			expect(getYourToolsSection(prompt)).not.toContain('convene_council');
+		});
+
+		test('YOUR TOOLS does not contain declare_council_criteria', () => {
+			expect(getYourToolsSection(prompt)).not.toContain(
+				'declare_council_criteria',
+			);
+		});
+
+		test('Available Tools does not contain convene_council', () => {
+			expect(getAvailableToolsSection(prompt)).not.toContain('convene_council');
+		});
+
+		test('Available Tools does not contain declare_council_criteria', () => {
+			expect(getAvailableToolsSection(prompt)).not.toContain(
+				'declare_council_criteria',
+			);
+		});
+	});
+
+	describe('council.enabled === true', () => {
+		const agent = createArchitectAgent(
+			'test-model',
+			undefined,
+			undefined,
+			undefined,
+			{ enabled: true },
+		);
+		const prompt = (agent.config as Record<string, unknown>).prompt as string;
+
+		test('YOUR TOOLS contains convene_council', () => {
+			expect(getYourToolsSection(prompt)).toContain('convene_council');
+		});
+
+		test('YOUR TOOLS contains declare_council_criteria', () => {
+			expect(getYourToolsSection(prompt)).toContain('declare_council_criteria');
+		});
+
+		test('Available Tools contains convene_council', () => {
+			expect(getAvailableToolsSection(prompt)).toContain('convene_council');
+		});
+
+		test('Available Tools contains declare_council_criteria', () => {
+			expect(getAvailableToolsSection(prompt)).toContain(
+				'declare_council_criteria',
+			);
+		});
+	});
+});

--- a/tests/unit/agents/capability-drift-guard.test.ts
+++ b/tests/unit/agents/capability-drift-guard.test.ts
@@ -50,8 +50,19 @@ function extractAvailableToolsNames(prompt: string): string[] {
 // ---------------------------------------------------------------------------
 const ARCHITECT_TOOL_COUNT = AGENT_TOOL_MAP.architect.length;
 
+// Render with council.enabled=true so the full AGENT_TOOL_MAP.architect
+// surface (including `convene_council` and `declare_council_criteria`)
+// appears in YOUR TOOLS and Available Tools. Without council enabled,
+// those tools are filtered out — see architect-tool-visibility-council.test.ts
+// for the council-off behavior.
 const resolvedPrompt = (() => {
-	const agent = createArchitectAgent('test-model');
+	const agent = createArchitectAgent(
+		'test-model',
+		undefined,
+		undefined,
+		undefined,
+		{ enabled: true },
+	);
 	return agent.config.prompt ?? '';
 })();
 

--- a/tests/unit/hooks/delegation-gate-council.test.ts
+++ b/tests/unit/hooks/delegation-gate-council.test.ts
@@ -1,0 +1,494 @@
+/**
+ * Tests for the convene_council branch in delegation-gate.ts toolAfter, plus
+ * Stage B suppression when council is authoritative for the current plan.
+ *
+ * v6.71+ — covers:
+ *   - council disabled (default): reviewer/test_engineer Stage B advancement still works.
+ *   - council active (config.enabled=true AND QaGates.council_mode=true):
+ *     Stage B advancement is REPLACED by the council; reviewer/test_engineer
+ *     Task delegations remain observable but do NOT advance task state.
+ *   - convene_council APPROVE + allCriteriaMet + zero required fixes from
+ *     pre_check_passed → state advances to 'complete'.
+ *   - convene_council REJECT → no advancement; verdict still recorded.
+ *   - convene_council APPROVE but allCriteriaMet=false → no advancement.
+ *   - Disagreement (config.enabled=false, council_mode=true) → councilActive=false,
+ *     Stage B path runs.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { PluginConfig } from '../../../src/config';
+import {
+	getOrCreateProfile,
+	setGates,
+} from '../../../src/db/qa-gate-profile';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import {
+	advanceTaskState,
+	ensureAgentSession,
+	getTaskState,
+	resetSwarmState,
+	startAgentSession,
+} from '../../../src/state';
+
+// Match the planId derivation used by set-qa-gates.ts / get-qa-gate-profile.ts
+function derivePlanId(plan: { swarm: string; title: string }): string {
+	return `${plan.swarm}-${plan.title}`.replace(/[^a-zA-Z0-9-_]/g, '_');
+}
+
+const PLAN_FIXTURE = {
+	schema_version: '1.0.0' as const,
+	title: 'council-test',
+	swarm: 'default',
+	current_phase: 1,
+	phases: [
+		{
+			id: 1,
+			name: 'Phase 1',
+			status: 'in_progress' as const,
+			tasks: [
+				{
+					id: '1.1',
+					phase: 1,
+					status: 'in_progress' as const,
+					size: 'small' as const,
+					description: 'test task',
+					depends: [],
+					files_touched: [],
+				},
+			],
+		},
+	],
+};
+const PLAN_ID = derivePlanId(PLAN_FIXTURE);
+
+function makeConfig(
+	overrides?: Record<string, unknown>,
+	council?: { enabled?: boolean },
+): PluginConfig {
+	return {
+		max_iterations: 5,
+		qa_retry_limit: 3,
+		inject_phase_reminders: true,
+		hooks: {
+			system_enhancer: true,
+			compaction: true,
+			agent_activity: true,
+			delegation_tracker: false,
+			agent_awareness_max_chars: 300,
+			delegation_gate: true,
+			delegation_max_chars: 4000,
+			...(overrides?.hooks as Record<string, unknown>),
+		},
+		...(council ? { council } : {}),
+	} as PluginConfig;
+}
+
+let tmpDir: string;
+let origCwd: string;
+
+function writePlan(): void {
+	writeFileSync(
+		path.join(tmpDir, '.swarm', 'plan.json'),
+		JSON.stringify(PLAN_FIXTURE),
+	);
+}
+
+function enableCouncilGate(): void {
+	// Create the QA gate profile and ratchet council_mode=true.
+	getOrCreateProfile(tmpDir, PLAN_ID);
+	setGates(tmpDir, PLAN_ID, { council_mode: true });
+}
+
+beforeEach(() => {
+	resetSwarmState();
+	origCwd = process.cwd();
+	tmpDir = mkdtempSync(path.join(os.tmpdir(), 'dg-council-test-'));
+	mkdirSync(path.join(tmpDir, '.swarm'), { recursive: true });
+	process.chdir(tmpDir);
+});
+
+afterEach(() => {
+	process.chdir(origCwd);
+	resetSwarmState();
+	try {
+		rmSync(tmpDir, { recursive: true, force: true });
+	} catch {
+		/* best effort */
+	}
+});
+
+describe('delegation-gate council wiring (Stage B suppression + APPROVE fast-path)', () => {
+	describe('council disabled (default): Stage B path is preserved', () => {
+		it('reviewer Task delegation still advances coder_delegated → reviewer_run', async () => {
+			// No plan written, no QA profile — councilActive must be false.
+			const config = makeConfig(); // no council key
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-no-council-rev', 'architect');
+			const session = ensureAgentSession('sess-no-council-rev');
+			session.currentTaskId = '1.1';
+			session.taskWorkflowStates.set('1.1', 'coder_delegated');
+
+			await hook.toolAfter(
+				{
+					tool: 'Task',
+					sessionID: 'sess-no-council-rev',
+					callID: 'call-rev-1',
+					args: { subagent_type: 'reviewer' },
+				},
+				{},
+			);
+
+			expect(getTaskState(session, '1.1')).toBe('reviewer_run');
+		});
+
+		it('test_engineer Task delegation still advances reviewer_run → tests_run', async () => {
+			const config = makeConfig();
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-no-council-te', 'architect');
+			const session = ensureAgentSession('sess-no-council-te');
+			session.currentTaskId = '1.1';
+			session.taskWorkflowStates.set('1.1', 'reviewer_run');
+
+			await hook.toolAfter(
+				{
+					tool: 'Task',
+					sessionID: 'sess-no-council-te',
+					callID: 'call-te-1',
+					args: { subagent_type: 'test_engineer' },
+				},
+				{},
+			);
+
+			expect(getTaskState(session, '1.1')).toBe('tests_run');
+		});
+	});
+
+	describe('council active (config + profile both true): Stage B is REPLACED', () => {
+		it('reviewer Task delegation does NOT advance state when council is authoritative', async () => {
+			writePlan();
+			enableCouncilGate();
+
+			const config = makeConfig(undefined, { enabled: true });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-council-rev', 'architect');
+			const session = ensureAgentSession('sess-council-rev');
+			session.currentTaskId = '1.1';
+			session.taskWorkflowStates.set('1.1', 'coder_delegated');
+
+			await hook.toolAfter(
+				{
+					tool: 'Task',
+					sessionID: 'sess-council-rev',
+					callID: 'call-rev-2',
+					args: { subagent_type: 'reviewer' },
+				},
+				{},
+			);
+
+			// State should NOT advance — council Phase 1 is the sole review pass.
+			expect(getTaskState(session, '1.1')).toBe('coder_delegated');
+		});
+
+		it('test_engineer Task delegation does NOT advance state when council is authoritative', async () => {
+			writePlan();
+			enableCouncilGate();
+
+			const config = makeConfig(undefined, { enabled: true });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-council-te', 'architect');
+			const session = ensureAgentSession('sess-council-te');
+			session.currentTaskId = '1.1';
+			session.taskWorkflowStates.set('1.1', 'reviewer_run');
+
+			await hook.toolAfter(
+				{
+					tool: 'Task',
+					sessionID: 'sess-council-te',
+					callID: 'call-te-2',
+					args: { subagent_type: 'test_engineer' },
+				},
+				{},
+			);
+
+			expect(getTaskState(session, '1.1')).toBe('reviewer_run');
+		});
+	});
+
+	describe('convene_council APPROVE fast-path advances to complete', () => {
+		it('APPROVE + allCriteriaMet + zero required fixes from pre_check_passed → complete', async () => {
+			writePlan();
+			enableCouncilGate();
+
+			const config = makeConfig(undefined, { enabled: true });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-approve', 'architect');
+			const session = ensureAgentSession('sess-approve');
+			advanceTaskState(session, '1.1', 'coder_delegated');
+			advanceTaskState(session, '1.1', 'pre_check_passed');
+
+			await hook.toolAfter(
+				{
+					tool: 'convene_council',
+					sessionID: 'sess-approve',
+					callID: 'call-cc-1',
+					args: { taskId: '1.1' },
+				},
+				{
+					success: true,
+					overallVerdict: 'APPROVE',
+					allCriteriaMet: true,
+					requiredFixesCount: 0,
+					roundNumber: 1,
+				},
+			);
+
+			expect(getTaskState(session, '1.1')).toBe('complete');
+			expect(session.taskCouncilApproved?.get('1.1')).toEqual({
+				verdict: 'APPROVE',
+				roundNumber: 1,
+			});
+		});
+
+		it('accepts a JSON-string output (legacy runtime shape)', async () => {
+			writePlan();
+			enableCouncilGate();
+
+			const config = makeConfig(undefined, { enabled: true });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-approve-str', 'architect');
+			const session = ensureAgentSession('sess-approve-str');
+			advanceTaskState(session, '1.1', 'coder_delegated');
+			advanceTaskState(session, '1.1', 'pre_check_passed');
+
+			await hook.toolAfter(
+				{
+					tool: 'convene_council',
+					sessionID: 'sess-approve-str',
+					callID: 'call-cc-1b',
+					args: { taskId: '1.1' },
+				},
+				JSON.stringify({
+					success: true,
+					overallVerdict: 'APPROVE',
+					allCriteriaMet: true,
+					requiredFixesCount: 0,
+					roundNumber: 2,
+				}),
+			);
+
+			expect(getTaskState(session, '1.1')).toBe('complete');
+			expect(session.taskCouncilApproved?.get('1.1')?.roundNumber).toBe(2);
+		});
+	});
+
+	describe('convene_council non-APPROVE outcomes do NOT advance state', () => {
+		it('REJECT records verdict but does NOT advance state', async () => {
+			writePlan();
+			enableCouncilGate();
+
+			const config = makeConfig(undefined, { enabled: true });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-reject', 'architect');
+			const session = ensureAgentSession('sess-reject');
+			advanceTaskState(session, '1.1', 'coder_delegated');
+			advanceTaskState(session, '1.1', 'pre_check_passed');
+
+			await hook.toolAfter(
+				{
+					tool: 'convene_council',
+					sessionID: 'sess-reject',
+					callID: 'call-cc-rej',
+					args: { taskId: '1.1' },
+				},
+				{
+					success: true,
+					overallVerdict: 'REJECT',
+					allCriteriaMet: false,
+					requiredFixesCount: 3,
+					roundNumber: 1,
+				},
+			);
+
+			// State must remain at pre_check_passed; verdict recorded.
+			expect(getTaskState(session, '1.1')).toBe('pre_check_passed');
+			expect(session.taskCouncilApproved?.get('1.1')).toEqual({
+				verdict: 'REJECT',
+				roundNumber: 1,
+			});
+		});
+
+		it('APPROVE with allCriteriaMet=false does NOT advance state', async () => {
+			writePlan();
+			enableCouncilGate();
+
+			const config = makeConfig(undefined, { enabled: true });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-partial', 'architect');
+			const session = ensureAgentSession('sess-partial');
+			advanceTaskState(session, '1.1', 'coder_delegated');
+			advanceTaskState(session, '1.1', 'pre_check_passed');
+
+			await hook.toolAfter(
+				{
+					tool: 'convene_council',
+					sessionID: 'sess-partial',
+					callID: 'call-cc-partial',
+					args: { taskId: '1.1' },
+				},
+				{
+					success: true,
+					overallVerdict: 'APPROVE',
+					allCriteriaMet: false,
+					requiredFixesCount: 1,
+					roundNumber: 1,
+				},
+			);
+
+			expect(getTaskState(session, '1.1')).toBe('pre_check_passed');
+			// Verdict still recorded for observability.
+			expect(session.taskCouncilApproved?.get('1.1')?.verdict).toBe('APPROVE');
+		});
+
+		it('CONCERNS records verdict but does NOT advance state', async () => {
+			writePlan();
+			enableCouncilGate();
+
+			const config = makeConfig(undefined, { enabled: true });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-concerns', 'architect');
+			const session = ensureAgentSession('sess-concerns');
+			advanceTaskState(session, '1.1', 'coder_delegated');
+			advanceTaskState(session, '1.1', 'pre_check_passed');
+
+			await hook.toolAfter(
+				{
+					tool: 'convene_council',
+					sessionID: 'sess-concerns',
+					callID: 'call-cc-con',
+					args: { taskId: '1.1' },
+				},
+				{
+					success: true,
+					overallVerdict: 'CONCERNS',
+					allCriteriaMet: true,
+					requiredFixesCount: 0,
+					roundNumber: 1,
+				},
+			);
+
+			expect(getTaskState(session, '1.1')).toBe('pre_check_passed');
+			expect(session.taskCouncilApproved?.get('1.1')?.verdict).toBe(
+				'CONCERNS',
+			);
+		});
+	});
+
+	describe('council disagreement: config.enabled=false but profile.council_mode=true', () => {
+		it('falls back to Stage B advancement (councilActive=false) and warns once', async () => {
+			writePlan();
+			enableCouncilGate();
+
+			// council.enabled is FALSE here even though profile has council_mode=true.
+			const config = makeConfig(undefined, { enabled: false });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-disagree', 'architect');
+			const session = ensureAgentSession('sess-disagree');
+			session.currentTaskId = '1.1';
+			session.taskWorkflowStates.set('1.1', 'coder_delegated');
+
+			// Capture warnings to assert the disagreement notice surfaces once.
+			const warnings: string[] = [];
+			const origWarn = console.warn;
+			console.warn = (...args: unknown[]) => {
+				warnings.push(args.map(String).join(' '));
+			};
+
+			try {
+				await hook.toolAfter(
+					{
+						tool: 'Task',
+						sessionID: 'sess-disagree',
+						callID: 'call-disagree-1',
+						args: { subagent_type: 'reviewer' },
+					},
+					{},
+				);
+				// Trigger again — second call must NOT produce a duplicate warning.
+				await hook.toolAfter(
+					{
+						tool: 'Task',
+						sessionID: 'sess-disagree',
+						callID: 'call-disagree-2',
+						args: { subagent_type: 'reviewer' },
+					},
+					{},
+				);
+			} finally {
+				console.warn = origWarn;
+			}
+
+			// Stage B path ran — state advanced.
+			expect(getTaskState(session, '1.1')).toBe('reviewer_run');
+			// Disagreement notice surfaced exactly once for the plan.
+			const disagreement = warnings.filter((m) =>
+				m.includes('Council mode mismatch'),
+			);
+			expect(disagreement.length).toBe(1);
+		});
+	});
+
+	describe('convene_council malformed output is non-fatal', () => {
+		it('logs a warn for unparseable string output and does not throw', async () => {
+			writePlan();
+			enableCouncilGate();
+
+			const config = makeConfig(undefined, { enabled: true });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-malformed', 'architect');
+			const session = ensureAgentSession('sess-malformed');
+			advanceTaskState(session, '1.1', 'coder_delegated');
+			advanceTaskState(session, '1.1', 'pre_check_passed');
+
+			const warnings: string[] = [];
+			const origWarn = console.warn;
+			console.warn = (...args: unknown[]) => {
+				warnings.push(args.map(String).join(' '));
+			};
+
+			try {
+				await hook.toolAfter(
+					{
+						tool: 'convene_council',
+						sessionID: 'sess-malformed',
+						callID: 'call-cc-bad',
+						args: { taskId: '1.1' },
+					},
+					'not-json',
+				);
+			} finally {
+				console.warn = origWarn;
+			}
+
+			expect(getTaskState(session, '1.1')).toBe('pre_check_passed');
+			expect(
+				warnings.some((m) =>
+					m.includes('toolAfter convene_council: failed to parse output'),
+				),
+			).toBe(true);
+		});
+	});
+});

--- a/tests/unit/hooks/delegation-gate-council.test.ts
+++ b/tests/unit/hooks/delegation-gate-council.test.ts
@@ -20,10 +20,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { PluginConfig } from '../../../src/config';
-import {
-	getOrCreateProfile,
-	setGates,
-} from '../../../src/db/qa-gate-profile';
+import { getOrCreateProfile, setGates } from '../../../src/db/qa-gate-profile';
 import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
 import {
 	advanceTaskState,
@@ -389,9 +386,7 @@ describe('delegation-gate council wiring (Stage B suppression + APPROVE fast-pat
 			);
 
 			expect(getTaskState(session, '1.1')).toBe('pre_check_passed');
-			expect(session.taskCouncilApproved?.get('1.1')?.verdict).toBe(
-				'CONCERNS',
-			);
+			expect(session.taskCouncilApproved?.get('1.1')?.verdict).toBe('CONCERNS');
 		});
 	});
 

--- a/tests/unit/hooks/delegation-gate-council.test.ts
+++ b/tests/unit/hooks/delegation-gate-council.test.ts
@@ -486,4 +486,155 @@ describe('delegation-gate council wiring (Stage B suppression + APPROVE fast-pat
 			).toBe(true);
 		});
 	});
+
+	describe('race condition: concurrent APPROVE + reviewer Task on same taskId', () => {
+		it('council APPROVE then reviewer Task — state stays complete, not overwritten by reviewer_run', async () => {
+			writePlan();
+			enableCouncilGate();
+
+			const config = makeConfig(undefined, { enabled: true });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-race', 'architect');
+			const session = ensureAgentSession('sess-race');
+			advanceTaskState(session, '1.1', 'coder_delegated');
+			advanceTaskState(session, '1.1', 'pre_check_passed');
+
+			// Step 1: council APPROVE — should advance to complete.
+			await hook.toolAfter(
+				{
+					tool: 'convene_council',
+					sessionID: 'sess-race',
+					callID: 'call-cc-race',
+					args: { taskId: '1.1' },
+				},
+				{
+					success: true,
+					overallVerdict: 'APPROVE',
+					allCriteriaMet: true,
+					requiredFixesCount: 0,
+					roundNumber: 1,
+				},
+			);
+
+			expect(getTaskState(session, '1.1')).toBe('complete');
+
+			// Step 2: a reviewer Task delegation arrives immediately after (late dispatch).
+			// With councilActive=true the reviewer branch is suppressed — state must remain complete.
+			await hook.toolAfter(
+				{
+					tool: 'Task',
+					sessionID: 'sess-race',
+					callID: 'call-race-rev',
+					args: { subagent_type: 'reviewer' },
+				},
+				{},
+			);
+
+			expect(getTaskState(session, '1.1')).toBe('complete');
+		});
+	});
+
+	describe('edge cases: task not at pre_check_passed when APPROVE arrives', () => {
+		it('APPROVE when task is at coder_delegated (pre-check not done) does NOT advance to complete', async () => {
+			writePlan();
+			enableCouncilGate();
+
+			const config = makeConfig(undefined, { enabled: true });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-early', 'architect');
+			const session = ensureAgentSession('sess-early');
+			advanceTaskState(session, '1.1', 'coder_delegated');
+			// NOTE: do NOT advance to pre_check_passed — council arrives too early.
+
+			const warnings: string[] = [];
+			const origWarn = console.warn;
+			console.warn = (...args: unknown[]) => {
+				warnings.push(args.map(String).join(' '));
+			};
+			try {
+				await hook.toolAfter(
+					{
+						tool: 'convene_council',
+						sessionID: 'sess-early',
+						callID: 'call-cc-early',
+						args: { taskId: '1.1' },
+					},
+					{
+						success: true,
+						overallVerdict: 'APPROVE',
+						allCriteriaMet: true,
+						requiredFixesCount: 0,
+						roundNumber: 1,
+					},
+				);
+			} finally {
+				console.warn = origWarn;
+			}
+
+			// Must NOT be complete; pre-check has not passed.
+			expect(getTaskState(session, '1.1')).not.toBe('complete');
+			// Verdict IS recorded for observability.
+			expect(session.taskCouncilApproved?.get('1.1')?.verdict).toBe('APPROVE');
+		});
+	});
+
+	describe('isCouncilGateActive: graceful fallback when plan.json missing', () => {
+		it('returns false (council not active) when plan.json is absent', async () => {
+			// Deliberately do NOT call writePlan() — no plan.json exists.
+			enableCouncilGate();
+
+			const config = makeConfig(undefined, { enabled: true });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-no-plan', 'architect');
+			const session = ensureAgentSession('sess-no-plan');
+			session.currentTaskId = '1.1';
+			session.taskWorkflowStates.set('1.1', 'coder_delegated');
+
+			// Reviewer Task: if council correctly falls back to inactive → Stage B advances.
+			await hook.toolAfter(
+				{
+					tool: 'Task',
+					sessionID: 'sess-no-plan',
+					callID: 'call-no-plan-rev',
+					args: { subagent_type: 'reviewer' },
+				},
+				{},
+			);
+
+			expect(getTaskState(session, '1.1')).toBe('reviewer_run');
+		});
+
+		it('convene_council with missing plan.json logs warn and does not advance', async () => {
+			// No plan written — isCouncilGateActive returns false.
+			const config = makeConfig(undefined, { enabled: true });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-no-plan-cc', 'architect');
+			const session = ensureAgentSession('sess-no-plan-cc');
+			session.currentTaskId = '1.1';
+			session.taskWorkflowStates.set('1.1', 'pre_check_passed');
+
+			await hook.toolAfter(
+				{
+					tool: 'convene_council',
+					sessionID: 'sess-no-plan-cc',
+					callID: 'call-no-plan-cc',
+					args: { taskId: '1.1' },
+				},
+				{
+					success: true,
+					overallVerdict: 'APPROVE',
+					allCriteriaMet: true,
+					requiredFixesCount: 0,
+					roundNumber: 1,
+				},
+			);
+
+			// Council not active → verdict recorded but state NOT advanced.
+			expect(getTaskState(session, '1.1')).toBe('pre_check_passed');
+		});
+	});
 });

--- a/tests/unit/hooks/delegation-gate-council.test.ts
+++ b/tests/unit/hooks/delegation-gate-council.test.ts
@@ -580,6 +580,69 @@ describe('delegation-gate council wiring (Stage B suppression + APPROVE fast-pat
 		});
 	});
 
+	describe('cross-session council config divergence: disagreement warn fires once across sessions', () => {
+		it('mismatch warn emitted once even when multiple sessions trigger isCouncilGateActive', async () => {
+			// Plan exists; QA profile has council_mode=true; but config.enabled=false → disagreement.
+			writePlan();
+			enableCouncilGate();
+
+			// Single hook instance (the real runtime shape — plugin config is shared).
+			const config = makeConfig(undefined, { enabled: false });
+			const hook = createDelegationGateHook(config, tmpDir);
+
+			startAgentSession('sess-multi-A', 'architect');
+			const sessionA = ensureAgentSession('sess-multi-A');
+			sessionA.currentTaskId = '1.1';
+			sessionA.taskWorkflowStates.set('1.1', 'coder_delegated');
+
+			startAgentSession('sess-multi-B', 'architect');
+			const sessionB = ensureAgentSession('sess-multi-B');
+			sessionB.currentTaskId = '1.2';
+			sessionB.taskWorkflowStates.set('1.2', 'coder_delegated');
+
+			const warnings: string[] = [];
+			const origWarn = console.warn;
+			console.warn = (...args: unknown[]) => {
+				warnings.push(args.map(String).join(' '));
+			};
+
+			try {
+				// Session A reviewer: triggers disagreement check.
+				await hook.toolAfter(
+					{
+						tool: 'Task',
+						sessionID: 'sess-multi-A',
+						callID: 'call-multi-A-rev',
+						args: { subagent_type: 'reviewer' },
+					},
+					{},
+				);
+				// Session B reviewer: should NOT emit a second disagreement warn.
+				await hook.toolAfter(
+					{
+						tool: 'Task',
+						sessionID: 'sess-multi-B',
+						callID: 'call-multi-B-rev',
+						args: { subagent_type: 'reviewer' },
+					},
+					{},
+				);
+			} finally {
+				console.warn = origWarn;
+			}
+
+			// Disagreement: both sessions fell back to Stage B (council disabled).
+			expect(getTaskState(sessionA, '1.1')).toBe('reviewer_run');
+			expect(getTaskState(sessionB, '1.2')).toBe('reviewer_run');
+
+			// Warn-once: the disagreement notice fires exactly once for the plan.
+			const mismatchWarns = warnings.filter((m) =>
+				m.includes('Council mode mismatch'),
+			);
+			expect(mismatchWarns.length).toBe(1);
+		});
+	});
+
 	describe('isCouncilGateActive: graceful fallback when plan.json missing', () => {
 		it('returns false (council not active) when plan.json is absent', async () => {
 			// Deliberately do NOT call writePlan() — no plan.json exists.

--- a/tests/unit/hooks/delegation-gate-state-machine.adversarial.test.ts
+++ b/tests/unit/hooks/delegation-gate-state-machine.adversarial.test.ts
@@ -545,6 +545,77 @@ ACCEPTANCECRITERA: test passes`;
 			advanceTaskState(session, 'task4', 'reviewer_run');
 			expect(() => advanceTaskState(session, 'task4', 'complete')).toThrow();
 		});
+
+		// v6.71+ Council fast-path coverage: complete-from-pre_check_passed should
+		// remain rejected without a council APPROVE record, and allowed with one.
+		it('should reject complete from pre_check_passed when no council APPROVE recorded', () => {
+			const session = ensureAgentSession('session-no-council-approve');
+
+			advanceTaskState(session, 'council-task', 'coder_delegated');
+			advanceTaskState(session, 'council-task', 'pre_check_passed');
+
+			// taskCouncilApproved is empty — must throw the standard guard.
+			expect(() =>
+				advanceTaskState(session, 'council-task', 'complete'),
+			).toThrow(/INVALID_TASK_STATE_TRANSITION/);
+			// State should remain at pre_check_passed.
+			expect(getTaskState(session, 'council-task')).toBe('pre_check_passed');
+		});
+
+		it('should allow complete from pre_check_passed when council APPROVE is recorded', () => {
+			const session = ensureAgentSession('session-council-approve');
+
+			advanceTaskState(session, 'council-task', 'coder_delegated');
+			advanceTaskState(session, 'council-task', 'pre_check_passed');
+
+			// Simulate convene_council recording an APPROVE verdict on the session.
+			session.taskCouncilApproved = new Map();
+			session.taskCouncilApproved.set('council-task', {
+				verdict: 'APPROVE',
+				roundNumber: 1,
+			});
+
+			// Council fast-path: should allow complete from pre_check_passed.
+			expect(() =>
+				advanceTaskState(session, 'council-task', 'complete'),
+			).not.toThrow();
+			expect(getTaskState(session, 'council-task')).toBe('complete');
+		});
+
+		it('should NOT allow complete from coder_delegated even with council APPROVE (Stage A still required)', () => {
+			const session = ensureAgentSession('session-council-no-precheck');
+
+			advanceTaskState(session, 'council-task', 'coder_delegated');
+
+			// APPROVE recorded but no pre_check_passed — Stage A is still required.
+			session.taskCouncilApproved = new Map();
+			session.taskCouncilApproved.set('council-task', {
+				verdict: 'APPROVE',
+				roundNumber: 1,
+			});
+
+			expect(() =>
+				advanceTaskState(session, 'council-task', 'complete'),
+			).toThrow(/INVALID_TASK_STATE_TRANSITION/);
+			expect(getTaskState(session, 'council-task')).toBe('coder_delegated');
+		});
+
+		it('should NOT allow complete from pre_check_passed when council recorded REJECT', () => {
+			const session = ensureAgentSession('session-council-reject');
+
+			advanceTaskState(session, 'council-task', 'coder_delegated');
+			advanceTaskState(session, 'council-task', 'pre_check_passed');
+
+			session.taskCouncilApproved = new Map();
+			session.taskCouncilApproved.set('council-task', {
+				verdict: 'REJECT',
+				roundNumber: 1,
+			});
+
+			expect(() =>
+				advanceTaskState(session, 'council-task', 'complete'),
+			).toThrow(/INVALID_TASK_STATE_TRANSITION/);
+		});
 	});
 
 	describe('state machine isolation between sessions', () => {


### PR DESCRIPTION
## Summary
- Syncs tool visibility with config: `convene_council`/`declare_council_criteria` filtered when `council.enabled !== true`
- Adds QA gate selection dialogue to SPECIFY (step 5b) and rewrites BRAINSTORM Phase 6 to ask user instead of autonomously setting gates before plan.json exists
- Wires council verdicts into state machine: `convene_council` APPROVE advances to `complete`, Stage B skipped when council is authoritative (AND semantics)

## Test plan
- [x] Typecheck passes (tsc --noEmit)
- [x] 107 unit tests pass across new and updated test files (architect gates, tool visibility, delegation-gate council, state machine)
- [x] Independent reviewer found 0 bugs
- [x] Critic found 0 real bugs (1 false alarm clarified with comment)
- [x] Pre-existing failures verified unchanged (1 evidence-write, 7 whitelist count)