### PR TITLE
feat(sast): phase-scoped baseline diffing so only new findings fail

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -15344,7 +15344,7 @@ var init_manager = __esm(() => {
 });
 
 // src/config/evidence-schema.ts
-var EVIDENCE_MAX_JSON_BYTES, EVIDENCE_MAX_PATCH_BYTES, EVIDENCE_MAX_TASK_BYTES, EvidenceTypeSchema, EvidenceVerdictSchema, BaseEvidenceSchema, ReviewEvidenceSchema, TestEvidenceSchema, DiffEvidenceSchema, ApprovalEvidenceSchema, NoteEvidenceSchema, RetrospectiveEvidenceSchema, SyntaxEvidenceSchema, PlaceholderEvidenceSchema, SastEvidenceSchema, SbomEvidenceSchema, BuildEvidenceSchema, QualityBudgetEvidenceSchema, SecretscanEvidenceSchema, EvidenceSchema, EvidenceBundleSchema;
+var EVIDENCE_MAX_JSON_BYTES, EVIDENCE_MAX_PATCH_BYTES, EVIDENCE_MAX_TASK_BYTES, EvidenceTypeSchema, EvidenceVerdictSchema, BaseEvidenceSchema, ReviewEvidenceSchema, TestEvidenceSchema, DiffEvidenceSchema, ApprovalEvidenceSchema, NoteEvidenceSchema, RetrospectiveEvidenceSchema, SyntaxEvidenceSchema, PlaceholderEvidenceSchema, SastFindingSchema, SastEvidenceSchema, SbomEvidenceSchema, BuildEvidenceSchema, QualityBudgetEvidenceSchema, SecretscanEvidenceSchema, EvidenceSchema, EvidenceBundleSchema;
 var init_evidence_schema = __esm(() => {
   init_zod();
   EVIDENCE_MAX_JSON_BYTES = 500 * 1024;
@@ -15483,19 +15483,20 @@ var init_evidence_schema = __esm(() => {
     files_with_findings: exports_external.number().int(),
     findings_count: exports_external.number().int()
   });
+  SastFindingSchema = exports_external.object({
+    rule_id: exports_external.string(),
+    severity: exports_external.enum(["critical", "high", "medium", "low"]),
+    message: exports_external.string(),
+    location: exports_external.object({
+      file: exports_external.string(),
+      line: exports_external.number().int(),
+      column: exports_external.number().int().optional()
+    }),
+    remediation: exports_external.string().optional()
+  });
   SastEvidenceSchema = BaseEvidenceSchema.extend({
     type: exports_external.literal("sast"),
-    findings: exports_external.array(exports_external.object({
-      rule_id: exports_external.string(),
-      severity: exports_external.enum(["critical", "high", "medium", "low"]),
-      message: exports_external.string(),
-      location: exports_external.object({
-        file: exports_external.string(),
-        line: exports_external.number().int(),
-        column: exports_external.number().int().optional()
-      }),
-      remediation: exports_external.string().optional()
-    })).default([]),
+    findings: exports_external.array(SastFindingSchema).default([]),
     engine: exports_external.enum(["tier_a", "tier_a+tier_b"]),
     files_scanned: exports_external.number().int(),
     findings_count: exports_external.number().int(),
@@ -15504,7 +15505,10 @@ var init_evidence_schema = __esm(() => {
       high: exports_external.number().int(),
       medium: exports_external.number().int(),
       low: exports_external.number().int()
-    })
+    }),
+    new_findings: exports_external.array(SastFindingSchema).optional(),
+    pre_existing_findings: exports_external.array(SastFindingSchema).optional(),
+    baseline_used: exports_external.boolean().optional()
   });
   SbomEvidenceSchema = BaseEvidenceSchema.extend({
     type: exports_external.literal("sbom"),

--- a/dist/config/evidence-schema.d.ts
+++ b/dist/config/evidence-schema.d.ts
@@ -289,6 +289,22 @@ export declare const PlaceholderEvidenceSchema: z.ZodObject<{
     findings_count: z.ZodNumber;
 }, z.core.$strip>;
 export type PlaceholderEvidence = z.infer<typeof PlaceholderEvidenceSchema>;
+export declare const SastFindingSchema: z.ZodObject<{
+    rule_id: z.ZodString;
+    severity: z.ZodEnum<{
+        medium: "medium";
+        low: "low";
+        high: "high";
+        critical: "critical";
+    }>;
+    message: z.ZodString;
+    location: z.ZodObject<{
+        file: z.ZodString;
+        line: z.ZodNumber;
+        column: z.ZodOptional<z.ZodNumber>;
+    }, z.core.$strip>;
+    remediation: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 export declare const SastEvidenceSchema: z.ZodObject<{
     task_id: z.ZodString;
     timestamp: z.ZodString;
@@ -331,6 +347,39 @@ export declare const SastEvidenceSchema: z.ZodObject<{
         medium: z.ZodNumber;
         low: z.ZodNumber;
     }, z.core.$strip>;
+    new_findings: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        rule_id: z.ZodString;
+        severity: z.ZodEnum<{
+            medium: "medium";
+            low: "low";
+            high: "high";
+            critical: "critical";
+        }>;
+        message: z.ZodString;
+        location: z.ZodObject<{
+            file: z.ZodString;
+            line: z.ZodNumber;
+            column: z.ZodOptional<z.ZodNumber>;
+        }, z.core.$strip>;
+        remediation: z.ZodOptional<z.ZodString>;
+    }, z.core.$strip>>>;
+    pre_existing_findings: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        rule_id: z.ZodString;
+        severity: z.ZodEnum<{
+            medium: "medium";
+            low: "low";
+            high: "high";
+            critical: "critical";
+        }>;
+        message: z.ZodString;
+        location: z.ZodObject<{
+            file: z.ZodString;
+            line: z.ZodNumber;
+            column: z.ZodOptional<z.ZodNumber>;
+        }, z.core.$strip>;
+        remediation: z.ZodOptional<z.ZodString>;
+    }, z.core.$strip>>>;
+    baseline_used: z.ZodOptional<z.ZodBoolean>;
 }, z.core.$strip>;
 export type SastEvidence = z.infer<typeof SastEvidenceSchema>;
 export declare const SbomEvidenceSchema: z.ZodObject<{
@@ -722,6 +771,39 @@ export declare const EvidenceSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
         medium: z.ZodNumber;
         low: z.ZodNumber;
     }, z.core.$strip>;
+    new_findings: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        rule_id: z.ZodString;
+        severity: z.ZodEnum<{
+            medium: "medium";
+            low: "low";
+            high: "high";
+            critical: "critical";
+        }>;
+        message: z.ZodString;
+        location: z.ZodObject<{
+            file: z.ZodString;
+            line: z.ZodNumber;
+            column: z.ZodOptional<z.ZodNumber>;
+        }, z.core.$strip>;
+        remediation: z.ZodOptional<z.ZodString>;
+    }, z.core.$strip>>>;
+    pre_existing_findings: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        rule_id: z.ZodString;
+        severity: z.ZodEnum<{
+            medium: "medium";
+            low: "low";
+            high: "high";
+            critical: "critical";
+        }>;
+        message: z.ZodString;
+        location: z.ZodObject<{
+            file: z.ZodString;
+            line: z.ZodNumber;
+            column: z.ZodOptional<z.ZodNumber>;
+        }, z.core.$strip>;
+        remediation: z.ZodOptional<z.ZodString>;
+    }, z.core.$strip>>>;
+    baseline_used: z.ZodOptional<z.ZodBoolean>;
 }, z.core.$strip>, z.ZodObject<{
     task_id: z.ZodString;
     timestamp: z.ZodString;
@@ -1108,6 +1190,39 @@ export declare const EvidenceBundleSchema: z.ZodObject<{
             medium: z.ZodNumber;
             low: z.ZodNumber;
         }, z.core.$strip>;
+        new_findings: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            rule_id: z.ZodString;
+            severity: z.ZodEnum<{
+                medium: "medium";
+                low: "low";
+                high: "high";
+                critical: "critical";
+            }>;
+            message: z.ZodString;
+            location: z.ZodObject<{
+                file: z.ZodString;
+                line: z.ZodNumber;
+                column: z.ZodOptional<z.ZodNumber>;
+            }, z.core.$strip>;
+            remediation: z.ZodOptional<z.ZodString>;
+        }, z.core.$strip>>>;
+        pre_existing_findings: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            rule_id: z.ZodString;
+            severity: z.ZodEnum<{
+                medium: "medium";
+                low: "low";
+                high: "high";
+                critical: "critical";
+            }>;
+            message: z.ZodString;
+            location: z.ZodObject<{
+                file: z.ZodString;
+                line: z.ZodNumber;
+                column: z.ZodOptional<z.ZodNumber>;
+            }, z.core.$strip>;
+            remediation: z.ZodOptional<z.ZodString>;
+        }, z.core.$strip>>>;
+        baseline_used: z.ZodOptional<z.ZodBoolean>;
     }, z.core.$strip>, z.ZodObject<{
         task_id: z.ZodString;
         timestamp: z.ZodString;

--- a/dist/index.js
+++ b/dist/index.js
@@ -14383,7 +14383,7 @@ var init_zod = __esm(() => {
 });
 
 // src/config/evidence-schema.ts
-var EVIDENCE_MAX_JSON_BYTES, EVIDENCE_MAX_PATCH_BYTES, EVIDENCE_MAX_TASK_BYTES, EvidenceTypeSchema, EvidenceVerdictSchema, BaseEvidenceSchema, ReviewEvidenceSchema, TestEvidenceSchema, DiffEvidenceSchema, ApprovalEvidenceSchema, NoteEvidenceSchema, RetrospectiveEvidenceSchema, SyntaxEvidenceSchema, PlaceholderEvidenceSchema, SastEvidenceSchema, SbomEvidenceSchema, BuildEvidenceSchema, QualityBudgetEvidenceSchema, SecretscanEvidenceSchema, EvidenceSchema, EvidenceBundleSchema;
+var EVIDENCE_MAX_JSON_BYTES, EVIDENCE_MAX_PATCH_BYTES, EVIDENCE_MAX_TASK_BYTES, EvidenceTypeSchema, EvidenceVerdictSchema, BaseEvidenceSchema, ReviewEvidenceSchema, TestEvidenceSchema, DiffEvidenceSchema, ApprovalEvidenceSchema, NoteEvidenceSchema, RetrospectiveEvidenceSchema, SyntaxEvidenceSchema, PlaceholderEvidenceSchema, SastFindingSchema, SastEvidenceSchema, SbomEvidenceSchema, BuildEvidenceSchema, QualityBudgetEvidenceSchema, SecretscanEvidenceSchema, EvidenceSchema, EvidenceBundleSchema;
 var init_evidence_schema = __esm(() => {
   init_zod();
   EVIDENCE_MAX_JSON_BYTES = 500 * 1024;
@@ -14522,19 +14522,20 @@ var init_evidence_schema = __esm(() => {
     files_with_findings: exports_external.number().int(),
     findings_count: exports_external.number().int()
   });
+  SastFindingSchema = exports_external.object({
+    rule_id: exports_external.string(),
+    severity: exports_external.enum(["critical", "high", "medium", "low"]),
+    message: exports_external.string(),
+    location: exports_external.object({
+      file: exports_external.string(),
+      line: exports_external.number().int(),
+      column: exports_external.number().int().optional()
+    }),
+    remediation: exports_external.string().optional()
+  });
   SastEvidenceSchema = BaseEvidenceSchema.extend({
     type: exports_external.literal("sast"),
-    findings: exports_external.array(exports_external.object({
-      rule_id: exports_external.string(),
-      severity: exports_external.enum(["critical", "high", "medium", "low"]),
-      message: exports_external.string(),
-      location: exports_external.object({
-        file: exports_external.string(),
-        line: exports_external.number().int(),
-        column: exports_external.number().int().optional()
-      }),
-      remediation: exports_external.string().optional()
-    })).default([]),
+    findings: exports_external.array(SastFindingSchema).default([]),
     engine: exports_external.enum(["tier_a", "tier_a+tier_b"]),
     files_scanned: exports_external.number().int(),
     findings_count: exports_external.number().int(),
@@ -14543,7 +14544,10 @@ var init_evidence_schema = __esm(() => {
       high: exports_external.number().int(),
       medium: exports_external.number().int(),
       low: exports_external.number().int()
-    })
+    }),
+    new_findings: exports_external.array(SastFindingSchema).optional(),
+    pre_existing_findings: exports_external.array(SastFindingSchema).optional(),
+    baseline_used: exports_external.boolean().optional()
   });
   SbomEvidenceSchema = BaseEvidenceSchema.extend({
     type: exports_external.literal("sbom"),
@@ -54547,6 +54551,9 @@ All other gates: failure \u2192 return to coder. No self-fixes. No workarounds.
 5a-bis. **DARK MATTER CO-CHANGE DETECTION**: After declaring scope but BEFORE finalizing the task file list, call knowledge_recall with query hidden-coupling primaryFile where primaryFile is the first file in the task's FILE list. Extract primaryFile from the task's FILE list (first file = primary). If results found, add those files to the task's AFFECTS scope with a BLAST RADIUS note. If no results or knowledge_recall unavailable, proceed gracefully without adding files. This is advisory \u2014 the architect may exclude files from scope if they are unrelated to the current task. Delegate to {{AGENT_PREFIX}}coder only after scope is declared.
 
 5b-PRE (required): Call \`declare_scope({ taskId, files })\` with the EXACT file list for this task \u2014 including any co-change files surfaced by 5a-bis. Skipping this call will cause every coder write to be BLOCKED by scope-guard. No \`declare_scope\` \u2192 no 5b delegation. See Rule 1a.
+    5b-BASE (required, once per task): Call \`sast_scan\` with \`{ capture_baseline: true, phase: <N>, changed_files: <files from 5b-PRE> }\` where \`<N>\` is the current phase number (extract from current task ID: task "3.2" \u2192 phase 3, task "1.5" \u2192 phase 1). The tool maintains \`.swarm/evidence/{phase}/sast-baseline.json\` as a phase-scoped, incrementally merged baseline of pre-existing SAST findings. Calling twice for the same files is safe (idempotent merge). Do NOT re-capture mid-task.
+    \u2192 REQUIRED: Print "sast-baseline: [WRITTEN \u2014 N fingerprints | MERGED \u2014 N fingerprints | SKIPPED \u2014 gate disabled | ERROR \u2014 details]"
+    \u2192 Subsequent \`pre_check_batch\` calls with \`phase: <N>\` will automatically diff against this baseline \u2014 only NEW findings (not in baseline) drive the fail verdict.
 5b. {{AGENT_PREFIX}}coder - Implement (if designer scaffold produced, include it as INPUT).
 5c. Run \`diff\` tool. If \`hasContractChanges\` \u2192 {{AGENT_PREFIX}}explorer integration analysis. If COMPATIBILITY SIGNALS=INCOMPATIBLE or MIGRATION_SURFACE=yes \u2192 coder retry. If COMPATIBILITY SIGNALS=COMPATIBLE and MIGRATION_SURFACE=no \u2192 proceed.
     \u2192 REQUIRED: Print "diff: [PASS | CONTRACT CHANGE \u2014 details]"
@@ -54560,18 +54567,19 @@ All other gates: failure \u2192 return to coder. No self-fixes. No workarounds.
     \u2192 REQUIRED: Print "lint: [PASS | FAIL \u2014 details]"
     5h. Run \`build_check\` tool. BUILD FAILS \u2192 return to coder. SUCCESS \u2192 proceed to pre_check_batch.
     \u2192 REQUIRED: Print "buildcheck: [PASS | FAIL | SKIPPED \u2014 no toolchain]"
-    5i. Run \`pre_check_batch\` tool \u2192 runs four verification tools in parallel (max 4 concurrent):
+    5i. Run \`pre_check_batch\` tool with \`phase: <N>\` (same phase number used in 5b-BASE) \u2192 runs four verification tools in parallel (max 4 concurrent):
     - lint:check (code quality verification)
     - secretscan (secret detection)
-    - sast_scan (static security analysis)
+    - sast_scan (static security analysis \u2014 diffs against phase baseline when phase provided)
     - quality_budget (maintainability metrics)
     \u2192 Returns { gates_passed, lint, secretscan, sast_scan, quality_budget, total_duration_ms }
+    \u2192 sast_scan result may include { new_findings, pre_existing_findings, baseline_used } when baseline diff is active.
     \u2192 If ALL FOUR tools have ran === false (lint.ran === false && secretscan.ran === false && sast_scan.ran === false && quality_budget.ran === false):
         \u2192 This is a SKIP - no tools actually ran. Print "pre_check_batch: SKIP \u2014 all tools ran===false (no files to check or tools not available)" and proceed to {{AGENT_PREFIX}}reviewer.
     \u2192 Else if gates_passed === false: read individual tool results, identify which tool(s) failed, return structured rejection to {{AGENT_PREFIX}}coder with specific tool failures. Do NOT call {{AGENT_PREFIX}}reviewer.
-    \u2192 If gates_passed === true AND sast_preexisting_findings is present: proceed to {{AGENT_PREFIX}}reviewer. Include the pre-existing SAST findings in the reviewer delegation context with instruction: "SAST TRIAGE REQUIRED: The following HIGH/CRITICAL SAST findings exist on unchanged lines in this changeset. Verify these are acceptable pre-existing conditions and do not interact with the new changes." Do NOT return to coder for pre-existing findings on unchanged code.
+    \u2192 If gates_passed === true AND sast_preexisting_findings is present: proceed to {{AGENT_PREFIX}}reviewer. Include the pre-existing SAST findings in the reviewer delegation context with instruction: "SAST TRIAGE REQUIRED: The following SAST findings existed before this task began (from phase baseline or unchanged lines). Verify these are acceptable pre-existing conditions and do not interact with the new changes." Do NOT return to coder for pre-existing findings.
     \u2192 If gates_passed === true (no sast_preexisting_findings): proceed to {{AGENT_PREFIX}}reviewer.
-    \u2192 REQUIRED: Print "pre_check_batch: [PASS \u2014 all gates passed | PASS \u2014 pre-existing SAST findings on unchanged lines (N findings, reviewer triage) | FAIL \u2014 [gate]: [details]]"
+    \u2192 REQUIRED: Print "pre_check_batch: [PASS \u2014 all gates passed | PASS \u2014 pre-existing SAST findings (N findings, reviewer triage) | FAIL \u2014 [gate]: [details]]"
 
 \u26A0\uFE0F pre_check_batch SCOPE BOUNDARY:
 pre_check_batch runs FOUR automated tools: lint:check, secretscan, sast_scan, quality_budget.
@@ -61601,7 +61609,7 @@ var init_runtime = __esm(() => {
 
 // src/index.ts
 init_agents();
-import * as path95 from "path";
+import * as path96 from "path";
 
 // src/background/index.ts
 init_event_bus();
@@ -76620,8 +76628,8 @@ var placeholder_scan = createSwarmTool({
 });
 // src/tools/pre-check-batch.ts
 init_dist();
-import * as fs64 from "fs";
-import * as path78 from "path";
+import * as fs65 from "fs";
+import * as path79 from "path";
 init_manager2();
 init_utils();
 init_create_tool();
@@ -76756,8 +76764,8 @@ var quality_budget = createSwarmTool({
 init_dist();
 init_manager2();
 init_detector();
-import * as fs63 from "fs";
-import * as path77 from "path";
+import * as fs64 from "fs";
+import * as path78 from "path";
 import { extname as extname18 } from "path";
 
 // src/sast/rules/c.ts
@@ -77646,6 +77654,303 @@ async function runSemgrep(options) {
 // src/tools/sast-scan.ts
 init_utils();
 init_create_tool();
+
+// src/tools/sast-baseline.ts
+init_utils2();
+import * as crypto8 from "crypto";
+import * as fs63 from "fs";
+import * as path77 from "path";
+var BASELINE_SCHEMA_VERSION = "1.0.0";
+var MAX_BASELINE_FINDINGS = 2000;
+var MAX_BASELINE_BYTES = 2 * 1048576;
+var LOCK_RETRY_DELAYS_MS = [50, 100, 200, 400, 800];
+function normalizeFindingPath(directory, file3) {
+  const resolved = path77.isAbsolute(file3) ? file3 : path77.resolve(directory, file3);
+  const rel = path77.relative(path77.resolve(directory), resolved);
+  return rel.replace(/\\/g, "/");
+}
+function baselineRelPath(phase) {
+  return path77.join("evidence", String(phase), "sast-baseline.json");
+}
+function tempRelPath(phase) {
+  return path77.join("evidence", String(phase), `sast-baseline.json.tmp.${Date.now()}.${process.pid}`);
+}
+function lockRelPath(phase) {
+  return path77.join("evidence", String(phase), "sast-baseline.json.lock");
+}
+function getLine(lines, idx) {
+  if (idx < 0 || idx >= lines.length)
+    return "";
+  return (lines[idx] ?? "").trim();
+}
+function fingerprintFinding(finding, directory, occurrenceIndex) {
+  const relFile = normalizeFindingPath(directory, finding.location.file);
+  if (relFile.startsWith("..")) {
+    return {
+      fingerprint: `${relFile}|${finding.rule_id}|L${finding.location.line}|UNSTABLE|#${occurrenceIndex}`,
+      stable: false
+    };
+  }
+  const lineNum = finding.location.line;
+  try {
+    const content = fs63.readFileSync(finding.location.file, "utf-8");
+    const lines = content.split(`
+`);
+    const idx = lineNum - 1;
+    const window2 = [
+      getLine(lines, idx - 1),
+      getLine(lines, idx),
+      getLine(lines, idx + 1)
+    ].join(`
+`);
+    const hash3 = crypto8.createHash("sha256").update(window2).digest("hex").slice(0, 16);
+    return {
+      fingerprint: `${relFile}|${finding.rule_id}|${hash3}|#${occurrenceIndex}`,
+      stable: true
+    };
+  } catch {
+    return {
+      fingerprint: `${relFile}|${finding.rule_id}|L${lineNum}|UNSTABLE|#${occurrenceIndex}`,
+      stable: false
+    };
+  }
+}
+function assignOccurrenceIndices(findings, directory) {
+  const countMap = new Map;
+  return findings.map((finding) => {
+    const relFile = normalizeFindingPath(directory, finding.location.file);
+    const lineNum = finding.location.line;
+    let baseKey;
+    try {
+      if (relFile.startsWith(".."))
+        throw new Error("escapes workspace");
+      const content = fs63.readFileSync(finding.location.file, "utf-8");
+      const lines = content.split(`
+`);
+      const idx = lineNum - 1;
+      const window2 = [
+        getLine(lines, idx - 1),
+        getLine(lines, idx),
+        getLine(lines, idx + 1)
+      ].join(`
+`);
+      const hash3 = crypto8.createHash("sha256").update(window2).digest("hex").slice(0, 16);
+      baseKey = `${relFile}|${finding.rule_id}|${hash3}`;
+    } catch {
+      baseKey = `${relFile}|${finding.rule_id}|L${lineNum}|UNSTABLE`;
+    }
+    const occIdx = countMap.get(baseKey) ?? 0;
+    countMap.set(baseKey, occIdx + 1);
+    const fp = fingerprintFinding(finding, directory, occIdx);
+    return {
+      finding,
+      index: occIdx,
+      stable: fp.stable,
+      fingerprint: fp.fingerprint
+    };
+  });
+}
+async function acquireLock(lockPath) {
+  for (let attempt = 0;attempt <= LOCK_RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      const fd = fs63.openSync(lockPath, "wx");
+      fs63.closeSync(fd);
+      return () => {
+        try {
+          fs63.unlinkSync(lockPath);
+        } catch {}
+      };
+    } catch {
+      if (attempt < LOCK_RETRY_DELAYS_MS.length) {
+        await new Promise((resolve31) => setTimeout(resolve31, LOCK_RETRY_DELAYS_MS[attempt]));
+      }
+    }
+  }
+  return () => {};
+}
+function validatePhase(phase) {
+  if (!Number.isInteger(phase) || phase < 1) {
+    return "Invalid phase: must be a positive integer";
+  }
+  return null;
+}
+async function captureOrMergeBaseline(directory, phase, findings, engine, scannedFiles, opts) {
+  const phaseError = validatePhase(phase);
+  if (phaseError)
+    return { status: "error", message: phaseError };
+  if (!scannedFiles || scannedFiles.length === 0) {
+    return {
+      status: "error",
+      message: "capture_baseline requires non-empty changed_files"
+    };
+  }
+  let baselinePath;
+  let tempPath;
+  let lockPath;
+  try {
+    baselinePath = validateSwarmPath(directory, baselineRelPath(phase));
+    tempPath = validateSwarmPath(directory, tempRelPath(phase));
+    lockPath = validateSwarmPath(directory, lockRelPath(phase));
+  } catch (e) {
+    return {
+      status: "error",
+      message: e instanceof Error ? e.message : "Path validation failed"
+    };
+  }
+  fs63.mkdirSync(path77.dirname(baselinePath), { recursive: true });
+  const releaseLock = await acquireLock(lockPath);
+  try {
+    let existing = null;
+    try {
+      const raw = fs63.readFileSync(baselinePath, "utf-8");
+      const parsed = JSON.parse(raw);
+      if (parsed.schema_version === BASELINE_SCHEMA_VERSION) {
+        existing = parsed;
+      }
+    } catch {}
+    const scannedRelFiles = new Set(scannedFiles.map((f) => normalizeFindingPath(directory, f)));
+    const indexed = assignOccurrenceIndices(findings, directory);
+    if (existing && !opts?.force) {
+      const prunedFingerprints = existing.fingerprints.filter((fp) => {
+        const relFile = fp.slice(0, fp.indexOf("|"));
+        return !scannedRelFiles.has(relFile);
+      });
+      const prunedSnapshot = existing.findings_snapshot.filter((f) => {
+        return !scannedRelFiles.has(normalizeFindingPath(directory, f.location.file));
+      });
+      const prunedFilesIndexed = existing.files_indexed.filter((f) => !scannedRelFiles.has(f));
+      const mergedFingerprints = [
+        ...prunedFingerprints,
+        ...indexed.map((i2) => i2.fingerprint)
+      ];
+      const mergedSnapshot = [
+        ...prunedSnapshot,
+        ...indexed.map((i2) => i2.finding)
+      ];
+      const mergedFilesIndexed = [
+        ...prunedFilesIndexed,
+        ...Array.from(scannedRelFiles)
+      ];
+      const truncated2 = mergedSnapshot.length > MAX_BASELINE_FINDINGS;
+      const cappedSnapshot2 = truncated2 ? mergedSnapshot.slice(-MAX_BASELINE_FINDINGS) : mergedSnapshot;
+      const cappedFingerprints2 = truncated2 ? mergedFingerprints.slice(-MAX_BASELINE_FINDINGS) : mergedFingerprints;
+      let cappedFilesIndexed = mergedFilesIndexed;
+      if (truncated2) {
+        const survivingFiles = new Set;
+        for (const finding of cappedSnapshot2) {
+          const relFile = normalizeFindingPath(directory, finding.location.file);
+          survivingFiles.add(relFile);
+        }
+        cappedFilesIndexed = Array.from(survivingFiles);
+      }
+      const now2 = new Date().toISOString();
+      const bundle2 = {
+        schema_version: BASELINE_SCHEMA_VERSION,
+        phase,
+        created_at: existing.created_at,
+        updated_at: now2,
+        engine,
+        files_indexed: cappedFilesIndexed,
+        fingerprints: cappedFingerprints2,
+        findings_snapshot: cappedSnapshot2,
+        truncated: truncated2
+      };
+      const json4 = JSON.stringify(bundle2, null, 2);
+      if (json4.length > MAX_BASELINE_BYTES) {
+        return {
+          status: "error",
+          message: `Baseline would exceed size cap (${json4.length} bytes > ${MAX_BASELINE_BYTES})`
+        };
+      }
+      fs63.writeFileSync(tempPath, json4, "utf-8");
+      fs63.renameSync(tempPath, baselinePath);
+      return {
+        status: "merged",
+        path: baselinePath,
+        fingerprint_count: cappedFingerprints2.length
+      };
+    }
+    const newFingerprints = indexed.map((i2) => i2.fingerprint);
+    const newSnapshot = indexed.map((i2) => i2.finding);
+    const truncated = newSnapshot.length > MAX_BASELINE_FINDINGS;
+    const cappedSnapshot = truncated ? newSnapshot.slice(0, MAX_BASELINE_FINDINGS) : newSnapshot;
+    const cappedFingerprints = truncated ? newFingerprints.slice(0, MAX_BASELINE_FINDINGS) : newFingerprints;
+    const now = new Date().toISOString();
+    const bundle = {
+      schema_version: BASELINE_SCHEMA_VERSION,
+      phase,
+      created_at: now,
+      updated_at: now,
+      engine,
+      files_indexed: Array.from(scannedRelFiles),
+      fingerprints: cappedFingerprints,
+      findings_snapshot: cappedSnapshot,
+      truncated
+    };
+    const json3 = JSON.stringify(bundle, null, 2);
+    if (json3.length > MAX_BASELINE_BYTES) {
+      return {
+        status: "error",
+        message: `Baseline would exceed size cap (${json3.length} bytes > ${MAX_BASELINE_BYTES})`
+      };
+    }
+    fs63.writeFileSync(tempPath, json3, "utf-8");
+    fs63.renameSync(tempPath, baselinePath);
+    return {
+      status: "written",
+      path: baselinePath,
+      fingerprint_count: cappedFingerprints.length
+    };
+  } finally {
+    releaseLock();
+  }
+}
+function loadBaseline(directory, phase) {
+  const phaseError = validatePhase(phase);
+  if (phaseError) {
+    return { status: "invalid_schema", errors: [phaseError] };
+  }
+  let baselinePath;
+  try {
+    baselinePath = validateSwarmPath(directory, baselineRelPath(phase));
+  } catch (e) {
+    return {
+      status: "invalid_schema",
+      errors: [e instanceof Error ? e.message : "Path validation failed"]
+    };
+  }
+  try {
+    const raw = fs63.readFileSync(baselinePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (parsed.schema_version !== BASELINE_SCHEMA_VERSION) {
+      return {
+        status: "invalid_schema",
+        errors: [`Unknown schema version: ${String(parsed.schema_version)}`]
+      };
+    }
+    if (!Array.isArray(parsed.fingerprints)) {
+      return {
+        status: "invalid_schema",
+        errors: ["Missing or invalid fingerprints array"]
+      };
+    }
+    return {
+      status: "found",
+      fingerprints: new Set(parsed.fingerprints),
+      bundle: parsed
+    };
+  } catch (e) {
+    if (e.code === "ENOENT") {
+      return { status: "not_found" };
+    }
+    return {
+      status: "invalid_schema",
+      errors: [e instanceof Error ? e.message : "Failed to read baseline"]
+    };
+  }
+}
+
+// src/tools/sast-scan.ts
 var MAX_FILE_SIZE_BYTES8 = 512 * 1024;
 var MAX_FILES_SCANNED2 = 1000;
 var MAX_FINDINGS2 = 100;
@@ -77657,17 +77962,17 @@ var SEVERITY_ORDER = {
 };
 function shouldSkipFile(filePath) {
   try {
-    const stats = fs63.statSync(filePath);
+    const stats = fs64.statSync(filePath);
     if (stats.size > MAX_FILE_SIZE_BYTES8) {
       return { skip: true, reason: "file too large" };
     }
     if (stats.size === 0) {
       return { skip: true, reason: "empty file" };
     }
-    const fd = fs63.openSync(filePath, "r");
+    const fd = fs64.openSync(filePath, "r");
     const buffer = Buffer.alloc(8192);
-    const bytesRead = fs63.readSync(fd, buffer, 0, 8192, 0);
-    fs63.closeSync(fd);
+    const bytesRead = fs64.readSync(fd, buffer, 0, 8192, 0);
+    fs64.closeSync(fd);
     if (bytesRead > 0) {
       let nullCount = 0;
       for (let i2 = 0;i2 < bytesRead; i2++) {
@@ -77706,7 +78011,7 @@ function countBySeverity(findings) {
 }
 function scanFileWithTierA(filePath, language) {
   try {
-    const content = fs63.readFileSync(filePath, "utf-8");
+    const content = fs64.readFileSync(filePath, "utf-8");
     const findings = executeRulesSync(filePath, content, language);
     return findings.map((f) => ({
       rule_id: f.rule_id,
@@ -77724,7 +78029,12 @@ function scanFileWithTierA(filePath, language) {
   }
 }
 async function sastScan(input, directory, config3) {
-  const { changed_files, severity_threshold = "medium" } = input;
+  const {
+    changed_files,
+    severity_threshold = "medium",
+    capture_baseline = false,
+    phase
+  } = input;
   if (config3?.gates?.sast_scan?.enabled === false) {
     return {
       verdict: "pass",
@@ -77745,6 +78055,7 @@ async function sastScan(input, directory, config3) {
   const allFindings = [];
   let filesScanned = 0;
   let _filesSkipped = 0;
+  const scannedFilePaths = [];
   const semgrepAvailable = isSemgrepAvailable();
   const engine = semgrepAvailable ? "tier_a+tier_b" : "tier_a";
   const filesByLanguage = new Map;
@@ -77753,13 +78064,13 @@ async function sastScan(input, directory, config3) {
       _filesSkipped++;
       continue;
     }
-    const resolvedPath = path77.isAbsolute(filePath) ? filePath : path77.resolve(directory, filePath);
-    const resolvedDirectory = path77.resolve(directory);
-    if (!resolvedPath.startsWith(resolvedDirectory + path77.sep) && resolvedPath !== resolvedDirectory) {
+    const resolvedPath = path78.isAbsolute(filePath) ? filePath : path78.resolve(directory, filePath);
+    const resolvedDirectory = path78.resolve(directory);
+    if (!resolvedPath.startsWith(resolvedDirectory + path78.sep) && resolvedPath !== resolvedDirectory) {
       _filesSkipped++;
       continue;
     }
-    if (!fs63.existsSync(resolvedPath)) {
+    if (!fs64.existsSync(resolvedPath)) {
       _filesSkipped++;
       continue;
     }
@@ -77794,6 +78105,7 @@ async function sastScan(input, directory, config3) {
       }
     }
     filesScanned++;
+    scannedFilePaths.push(resolvedPath);
     if (filesScanned >= MAX_FILES_SCANNED2) {
       warn(`SAST Scan: Reached maximum files limit (${MAX_FILES_SCANNED2}), stopping`);
       break;
@@ -77843,14 +78155,97 @@ async function sastScan(input, directory, config3) {
       warn(`SAST Scan: Semgrep failed, falling back to Tier A: ${error93}`);
     }
   }
-  let finalFindings = allFindings;
-  if (allFindings.length > MAX_FINDINGS2) {
-    finalFindings = allFindings.slice(0, MAX_FINDINGS2);
-    warn(`SAST Scan: Found ${allFindings.length} findings, limiting to ${MAX_FINDINGS2}`);
+  if (capture_baseline) {
+    if (phase === undefined || !Number.isInteger(phase) || phase < 1) {
+      const errorResult = {
+        verdict: "fail",
+        findings: allFindings.slice(0, MAX_FINDINGS2),
+        summary: {
+          engine,
+          files_scanned: filesScanned,
+          findings_count: Math.min(allFindings.length, MAX_FINDINGS2),
+          findings_by_severity: countBySeverity(allFindings.slice(0, MAX_FINDINGS2))
+        }
+      };
+      return errorResult;
+    }
+    const captureFindings = allFindings.slice(0, MAX_BASELINE_FINDINGS);
+    const captureResult = await captureOrMergeBaseline(directory, phase, captureFindings, engine, scannedFilePaths);
+    const captureStatus = captureResult.status === "written" ? "baseline_captured" : captureResult.status === "merged" ? "baseline_merged" : undefined;
+    if (captureResult.status === "error") {
+      warn(`SAST Baseline: capture failed \u2014 ${captureResult.message}`);
+    }
+    const finalFindings2 = allFindings.slice(0, MAX_FINDINGS2);
+    const summary2 = {
+      engine,
+      files_scanned: filesScanned,
+      findings_count: finalFindings2.length,
+      findings_by_severity: countBySeverity(finalFindings2)
+    };
+    await saveEvidence(directory, "sast_scan", {
+      task_id: "sast_scan",
+      type: "sast",
+      timestamp: new Date().toISOString(),
+      agent: "sast_scan",
+      verdict: "pass",
+      summary: `Baseline capture: scanned ${filesScanned} files, recorded ${captureFindings.length} finding(s)`,
+      ...summary2,
+      findings: finalFindings2,
+      baseline_used: false
+    });
+    return {
+      verdict: "pass",
+      findings: finalFindings2,
+      summary: summary2,
+      status: captureStatus,
+      finding_count: captureResult.status !== "error" ? captureResult.fingerprint_count : undefined,
+      baseline_used: false
+    };
+  }
+  let newFindings;
+  let preExistingFindings;
+  let baselineUsed = false;
+  let truncatedPreExisting = false;
+  if (phase !== undefined && Number.isInteger(phase) && phase >= 1) {
+    const baselineResult = loadBaseline(directory, phase);
+    if (baselineResult.status === "found") {
+      baselineUsed = true;
+      const baselineSet = baselineResult.fingerprints;
+      const indexed = assignOccurrenceIndices(allFindings, directory);
+      const rawNew = [];
+      const rawPreExisting = [];
+      for (const { finding, stable, fingerprint } of indexed) {
+        if (!stable || !baselineSet.has(fingerprint)) {
+          rawNew.push(finding);
+        } else {
+          rawPreExisting.push(finding);
+        }
+      }
+      newFindings = rawNew.slice(0, MAX_FINDINGS2);
+      const preExistingBudget = Math.max(0, MAX_FINDINGS2 - newFindings.length);
+      preExistingFindings = rawPreExisting.slice(0, preExistingBudget);
+      truncatedPreExisting = rawPreExisting.length > preExistingBudget;
+    } else if (baselineResult.status === "invalid_schema") {
+      warn(`SAST Baseline: could not load baseline for phase ${phase} \u2014 ${baselineResult.errors.join(", ")}. Falling back to legacy behavior.`);
+    }
+  }
+  let finalFindings;
+  if (!baselineUsed) {
+    finalFindings = allFindings;
+    if (allFindings.length > MAX_FINDINGS2) {
+      finalFindings = allFindings.slice(0, MAX_FINDINGS2);
+      warn(`SAST Scan: Found ${allFindings.length} findings, limiting to ${MAX_FINDINGS2}`);
+    }
+  } else {
+    finalFindings = [
+      ...newFindings ?? [],
+      ...preExistingFindings ?? []
+    ].slice(0, MAX_FINDINGS2);
   }
   const findingsBySeverity = countBySeverity(finalFindings);
+  const verdictSource = baselineUsed ? newFindings ?? [] : finalFindings;
   let verdict = "pass";
-  for (const finding of finalFindings) {
+  for (const finding of verdictSource) {
     if (meetsThreshold(finding.severity, severity_threshold)) {
       verdict = "fail";
       break;
@@ -77873,42 +78268,65 @@ async function sastScan(input, directory, config3) {
     verdict,
     summary: `Scanned ${filesScanned} files, found ${finalFindings.length} finding(s) using ${engine}`,
     ...summary,
-    findings: finalFindings
+    findings: finalFindings,
+    ...baselineUsed && {
+      new_findings: newFindings,
+      pre_existing_findings: preExistingFindings,
+      baseline_used: true
+    }
   });
-  return {
+  const result = {
     verdict,
     findings: finalFindings,
     summary
   };
+  if (baselineUsed) {
+    result.new_findings = newFindings;
+    result.pre_existing_findings = preExistingFindings;
+    result.baseline_used = true;
+    if (truncatedPreExisting)
+      result.truncated_pre_existing = true;
+  }
+  return result;
 }
 var sast_scan = createSwarmTool({
-  description: "Static Application Security Testing (SAST) scan. Scans files for security vulnerabilities using built-in rules (Tier A) and optional Semgrep (Tier B). Returns structured findings with severity levels.",
+  description: "Static Application Security Testing (SAST) scan. Scans files for security vulnerabilities using built-in rules (Tier A) and optional Semgrep (Tier B). Supports phase-scoped baseline diffing: set capture_baseline:true before first coder delegation to snapshot pre-existing findings; subsequent scans with the same phase only fail on NEW findings.",
   args: {
     directory: tool.schema.string().describe("Directory to scan for security vulnerabilities"),
     changed_files: tool.schema.array(tool.schema.string()).optional().describe("List of files to scan (leave empty to scan none)"),
-    severity_threshold: tool.schema.enum(["low", "medium", "high", "critical"]).optional().default("medium").describe("Minimum severity that causes failure")
+    severity_threshold: tool.schema.enum(["low", "medium", "high", "critical"]).optional().default("medium").describe("Minimum severity that causes failure"),
+    capture_baseline: tool.schema.boolean().optional().describe("When true, capture/merge a phase-scoped baseline of pre-existing findings. Requires phase. Subsequent scans with phase only fail on NEW findings."),
+    phase: tool.schema.number().int().min(1).optional().describe("Current phase number (positive integer >= 1). Required with capture_baseline. Enables baseline diff when provided on non-capture scans.")
   },
   execute: async (args2, directory) => {
     let safeArgs;
     try {
       if (args2 && typeof args2 === "object") {
+        const rawPhase = args2.phase;
+        const rawCapture = args2.capture_baseline;
         safeArgs = {
           directory: args2.directory,
           changed_files: args2.changed_files,
-          severity_threshold: args2.severity_threshold
+          severity_threshold: args2.severity_threshold,
+          phase: typeof rawPhase === "number" && Number.isInteger(rawPhase) && rawPhase >= 1 ? rawPhase : undefined,
+          capture_baseline: typeof rawCapture === "boolean" ? rawCapture : undefined
         };
       } else {
         safeArgs = {
           directory: undefined,
           changed_files: undefined,
-          severity_threshold: undefined
+          severity_threshold: undefined,
+          capture_baseline: undefined,
+          phase: undefined
         };
       }
     } catch {
       safeArgs = {
         directory: undefined,
         changed_files: undefined,
-        severity_threshold: undefined
+        severity_threshold: undefined,
+        capture_baseline: undefined,
+        phase: undefined
       };
     }
     if (safeArgs.directory === undefined) {
@@ -77931,7 +78349,9 @@ var sast_scan = createSwarmTool({
     }
     const input = {
       changed_files: safeArgs.changed_files ?? [],
-      severity_threshold: safeArgs.severity_threshold ?? "medium"
+      severity_threshold: safeArgs.severity_threshold ?? "medium",
+      capture_baseline: safeArgs.capture_baseline,
+      phase: safeArgs.phase
     };
     const result = await sastScan(input, directory);
     return JSON.stringify(result, null, 2);
@@ -77957,20 +78377,20 @@ function validatePath(inputPath, baseDir, workspaceDir) {
   let resolved;
   const isWinAbs = isWindowsAbsolutePath(inputPath);
   if (isWinAbs) {
-    resolved = path78.win32.resolve(inputPath);
-  } else if (path78.isAbsolute(inputPath)) {
-    resolved = path78.resolve(inputPath);
+    resolved = path79.win32.resolve(inputPath);
+  } else if (path79.isAbsolute(inputPath)) {
+    resolved = path79.resolve(inputPath);
   } else {
-    resolved = path78.resolve(baseDir, inputPath);
+    resolved = path79.resolve(baseDir, inputPath);
   }
-  const workspaceResolved = path78.resolve(workspaceDir);
-  let relative18;
+  const workspaceResolved = path79.resolve(workspaceDir);
+  let relative19;
   if (isWinAbs) {
-    relative18 = path78.win32.relative(workspaceResolved, resolved);
+    relative19 = path79.win32.relative(workspaceResolved, resolved);
   } else {
-    relative18 = path78.relative(workspaceResolved, resolved);
+    relative19 = path79.relative(workspaceResolved, resolved);
   }
-  if (relative18.startsWith("..")) {
+  if (relative19.startsWith("..")) {
     return "path traversal detected";
   }
   return null;
@@ -78033,7 +78453,7 @@ async function runLintOnFiles(linter, files, workspaceDir) {
     if (typeof file3 !== "string") {
       continue;
     }
-    const resolvedPath = path78.resolve(file3);
+    const resolvedPath = path79.resolve(file3);
     const validationError = validatePath(resolvedPath, workspaceDir, workspaceDir);
     if (validationError) {
       continue;
@@ -78190,7 +78610,7 @@ async function runSecretscanWithFiles(files, directory) {
         skippedFiles++;
         continue;
       }
-      const resolvedPath = path78.resolve(file3);
+      const resolvedPath = path79.resolve(file3);
       const validationError = validatePath(resolvedPath, directory, directory);
       if (validationError) {
         skippedFiles++;
@@ -78208,14 +78628,14 @@ async function runSecretscanWithFiles(files, directory) {
       };
     }
     for (const file3 of validatedFiles) {
-      const ext = path78.extname(file3).toLowerCase();
+      const ext = path79.extname(file3).toLowerCase();
       if (DEFAULT_EXCLUDE_EXTENSIONS2.has(ext)) {
         skippedFiles++;
         continue;
       }
       let stat3;
       try {
-        stat3 = fs64.statSync(file3);
+        stat3 = fs65.statSync(file3);
       } catch {
         skippedFiles++;
         continue;
@@ -78226,7 +78646,7 @@ async function runSecretscanWithFiles(files, directory) {
       }
       let content;
       try {
-        const buffer = fs64.readFileSync(file3);
+        const buffer = fs65.readFileSync(file3);
         if (buffer.includes(0)) {
           skippedFiles++;
           continue;
@@ -78292,10 +78712,14 @@ async function runSecretscanWithFiles(files, directory) {
     return errorResult;
   }
 }
-async function runSastScanWrapped(changedFiles, directory, severityThreshold, config3) {
+async function runSastScanWrapped(changedFiles, directory, severityThreshold, config3, phase) {
   const start2 = process.hrtime.bigint();
   try {
-    const result = await runWithTimeout2(sastScan({ changed_files: changedFiles, severity_threshold: severityThreshold }, directory, config3), TOOL_TIMEOUT_MS);
+    const result = await runWithTimeout2(sastScan({
+      changed_files: changedFiles,
+      severity_threshold: severityThreshold,
+      phase
+    }, directory, config3), TOOL_TIMEOUT_MS);
     return {
       ran: true,
       result,
@@ -78327,6 +78751,15 @@ async function runQualityBudgetWrapped(changedFiles, directory, _config) {
   }
 }
 var GATE_SEVERITIES = new Set(["high", "critical"]);
+var SEVERITY_ORDER_PCB = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3
+};
+function meetsThresholdForTriage(severity, threshold) {
+  return (SEVERITY_ORDER_PCB[severity] ?? 0) >= (SEVERITY_ORDER_PCB[threshold] ?? 1);
+}
 async function runGitDiff(args2, directory) {
   try {
     const proc = Bun.spawn(["git", "diff", ...args2], {
@@ -78414,7 +78847,7 @@ function classifySastFindings(findings, changedLineRanges, directory) {
   const preexistingFindings = [];
   for (const finding of findings) {
     const filePath = finding.location.file;
-    const normalised = path78.relative(directory, filePath).replace(/\\/g, "/");
+    const normalised = path79.relative(directory, filePath).replace(/\\/g, "/");
     const changedLines = changedLineRanges.get(normalised);
     if (changedLines?.has(finding.location.line)) {
       newFindings.push(finding);
@@ -78426,7 +78859,7 @@ function classifySastFindings(findings, changedLineRanges, directory) {
 }
 async function runPreCheckBatch(input, workspaceDir, contextDir) {
   const effectiveWorkspaceDir = workspaceDir || input.directory || contextDir;
-  const { files, directory, sast_threshold = "medium", config: config3 } = input;
+  const { files, directory, sast_threshold = "medium", config: config3, phase } = input;
   const dirError = validateDirectory2(directory, effectiveWorkspaceDir);
   if (dirError) {
     warn(`pre_check_batch: Invalid directory: ${dirError}`);
@@ -78465,7 +78898,7 @@ async function runPreCheckBatch(input, workspaceDir, contextDir) {
       warn(`pre_check_batch: Invalid file path: ${file3}`);
       continue;
     }
-    changedFiles.push(path78.resolve(directory, file3));
+    changedFiles.push(path79.resolve(directory, file3));
   }
   if (changedFiles.length === 0) {
     warn("pre_check_batch: No valid files after validation, skipping all tools (fail-closed)");
@@ -78489,7 +78922,7 @@ async function runPreCheckBatch(input, workspaceDir, contextDir) {
   const [lintResult, secretscanResult, sastScanResult, qualityBudgetResult] = await Promise.all([
     limit(() => runLintWrapped(changedFiles, directory, config3)),
     limit(() => runSecretscanWrapped(changedFiles, directory, config3)),
-    limit(() => runSastScanWrapped(changedFiles, directory, sast_threshold, config3)),
+    limit(() => runSastScanWrapped(changedFiles, directory, sast_threshold, config3, phase)),
     limit(() => runQualityBudgetWrapped(changedFiles, directory, config3))
   ]);
   const totalDuration = lintResult.duration_ms + secretscanResult.duration_ms + sastScanResult.duration_ms + qualityBudgetResult.duration_ms;
@@ -78534,8 +78967,20 @@ async function runPreCheckBatch(input, workspaceDir, contextDir) {
   }
   let sastPreexistingFindings;
   if (sastScanResult.ran && sastScanResult.result) {
-    if (sastScanResult.result.verdict === "fail") {
-      const gateFindings = sastScanResult.result.findings.filter((f) => GATE_SEVERITIES.has(f.severity));
+    const sastResult = sastScanResult.result;
+    if (sastResult.baseline_used) {
+      if (sastResult.pre_existing_findings && sastResult.pre_existing_findings.length > 0) {
+        sastPreexistingFindings = sastResult.pre_existing_findings.filter((f) => meetsThresholdForTriage(f.severity, sast_threshold));
+        if (sastPreexistingFindings.length > 0) {
+          warn(`pre_check_batch: SAST baseline diff found ${sastPreexistingFindings.length} pre-existing finding(s) - passing to reviewer for triage`);
+        }
+      }
+      if (sastResult.verdict === "fail") {
+        gatesPassed = false;
+        warn(`pre_check_batch: SAST scan found new findings above threshold - GATE FAILED`);
+      }
+    } else if (sastResult.verdict === "fail") {
+      const gateFindings = sastResult.findings.filter((f) => GATE_SEVERITIES.has(f.severity));
       if (gateFindings.length > 0) {
         const changedLineRanges = await getChangedLineRanges(directory);
         const { newFindings, preexistingFindings } = classifySastFindings(gateFindings, changedLineRanges, directory);
@@ -78584,7 +79029,8 @@ var pre_check_batch = createSwarmTool({
   args: {
     files: tool.schema.array(tool.schema.string()).optional().describe("Specific files to check (optional, scans directory if not provided)"),
     directory: tool.schema.string().describe('Directory to run checks in (e.g., "." or "./src")'),
-    sast_threshold: tool.schema.enum(["low", "medium", "high", "critical"]).optional().describe("Minimum severity for SAST findings to cause failure (default: medium)")
+    sast_threshold: tool.schema.enum(["low", "medium", "high", "critical"]).optional().describe("Minimum severity for SAST findings to cause failure (default: medium)"),
+    phase: tool.schema.number().int().min(1).optional().describe("Current phase number (positive integer >= 1). When provided, enables SAST baseline diffing: only findings absent from the phase-scoped baseline fail the gate.")
   },
   async execute(args2, directory) {
     if (!args2 || typeof args2 !== "object") {
@@ -78653,7 +79099,7 @@ var pre_check_batch = createSwarmTool({
       };
       return JSON.stringify(errorResult, null, 2);
     }
-    const resolvedDirectory = path78.resolve(typedArgs.directory);
+    const resolvedDirectory = path79.resolve(typedArgs.directory);
     const workspaceAnchor = resolvedDirectory;
     const dirError = validateDirectory2(resolvedDirectory, workspaceAnchor);
     if (dirError) {
@@ -78668,11 +79114,14 @@ var pre_check_batch = createSwarmTool({
       return JSON.stringify(errorResult, null, 2);
     }
     try {
+      const rawPhase = typedArgs.phase;
+      const safePhase = typeof rawPhase === "number" && Number.isInteger(rawPhase) && rawPhase >= 1 ? rawPhase : undefined;
       const result = await runPreCheckBatch({
         files: typedArgs.files,
         directory: resolvedDirectory,
         sast_threshold: typedArgs.sast_threshold,
-        config: typedArgs.config
+        config: typedArgs.config,
+        phase: safePhase
       }, workspaceAnchor, directory);
       return JSON.stringify(result, null, 2);
     } catch (error93) {
@@ -78691,7 +79140,7 @@ var pre_check_batch = createSwarmTool({
 });
 // src/tools/repo-map.ts
 init_dist();
-import * as path79 from "path";
+import * as path80 from "path";
 init_path_security();
 init_create_tool();
 var VALID_ACTIONS = [
@@ -78716,7 +79165,7 @@ function validateFile(p) {
     return "file contains control characters";
   if (containsPathTraversal(p))
     return "file contains path traversal";
-  if (path79.isAbsolute(p) || /^[a-zA-Z]:[\\/]/.test(p)) {
+  if (path80.isAbsolute(p) || /^[a-zA-Z]:[\\/]/.test(p)) {
     return "file must be a workspace-relative path, not absolute";
   }
   return null;
@@ -78739,8 +79188,8 @@ function ok(action, payload) {
 }
 function toRelativeGraphPath(input, workspaceRoot) {
   const normalized = input.replace(/\\/g, "/");
-  if (path79.isAbsolute(normalized)) {
-    const rel = path79.relative(workspaceRoot, normalized).replace(/\\/g, "/");
+  if (path80.isAbsolute(normalized)) {
+    const rel = path80.relative(workspaceRoot, normalized).replace(/\\/g, "/");
     return normalizeGraphPath2(rel);
   }
   return normalizeGraphPath2(normalized);
@@ -78884,8 +79333,8 @@ var repo_map = createSwarmTool({
 // src/tools/req-coverage.ts
 init_dist();
 init_create_tool();
-import * as fs65 from "fs";
-import * as path80 from "path";
+import * as fs66 from "fs";
+import * as path81 from "path";
 var SPEC_FILE = ".swarm/spec.md";
 var EVIDENCE_DIR4 = ".swarm/evidence";
 var OBLIGATION_KEYWORDS = ["MUST", "SHOULD", "SHALL"];
@@ -78944,19 +79393,19 @@ function extractObligationAndText(id, lineText) {
 var PHASE_TASK_ID_REGEX = /^\d+\.\d+(\.\d+)*$/;
 function readTouchedFiles(evidenceDir, phase, cwd) {
   const touchedFiles = new Set;
-  if (!fs65.existsSync(evidenceDir) || !fs65.statSync(evidenceDir).isDirectory()) {
+  if (!fs66.existsSync(evidenceDir) || !fs66.statSync(evidenceDir).isDirectory()) {
     return [];
   }
   let entries;
   try {
-    entries = fs65.readdirSync(evidenceDir);
+    entries = fs66.readdirSync(evidenceDir);
   } catch {
     return [];
   }
   for (const entry of entries) {
-    const entryPath = path80.join(evidenceDir, entry);
+    const entryPath = path81.join(evidenceDir, entry);
     try {
-      const stat3 = fs65.statSync(entryPath);
+      const stat3 = fs66.statSync(entryPath);
       if (!stat3.isDirectory()) {
         continue;
       }
@@ -78970,14 +79419,14 @@ function readTouchedFiles(evidenceDir, phase, cwd) {
     if (entryPhase !== String(phase)) {
       continue;
     }
-    const evidenceFilePath = path80.join(entryPath, "evidence.json");
+    const evidenceFilePath = path81.join(entryPath, "evidence.json");
     try {
-      const resolvedPath = path80.resolve(evidenceFilePath);
-      const evidenceDirResolved = path80.resolve(evidenceDir);
-      if (!resolvedPath.startsWith(evidenceDirResolved + path80.sep)) {
+      const resolvedPath = path81.resolve(evidenceFilePath);
+      const evidenceDirResolved = path81.resolve(evidenceDir);
+      if (!resolvedPath.startsWith(evidenceDirResolved + path81.sep)) {
         continue;
       }
-      const stat3 = fs65.lstatSync(evidenceFilePath);
+      const stat3 = fs66.lstatSync(evidenceFilePath);
       if (!stat3.isFile()) {
         continue;
       }
@@ -78989,7 +79438,7 @@ function readTouchedFiles(evidenceDir, phase, cwd) {
     }
     let content;
     try {
-      content = fs65.readFileSync(evidenceFilePath, "utf-8");
+      content = fs66.readFileSync(evidenceFilePath, "utf-8");
     } catch {
       continue;
     }
@@ -79008,7 +79457,7 @@ function readTouchedFiles(evidenceDir, phase, cwd) {
             if (Array.isArray(diffEntry.files_changed)) {
               for (const file3 of diffEntry.files_changed) {
                 if (typeof file3 === "string") {
-                  touchedFiles.add(path80.resolve(cwd, file3));
+                  touchedFiles.add(path81.resolve(cwd, file3));
                 }
               }
             }
@@ -79021,12 +79470,12 @@ function readTouchedFiles(evidenceDir, phase, cwd) {
 }
 function searchFileForKeywords(filePath, keywords, cwd) {
   try {
-    const resolvedPath = path80.resolve(filePath);
-    const cwdResolved = path80.resolve(cwd);
+    const resolvedPath = path81.resolve(filePath);
+    const cwdResolved = path81.resolve(cwd);
     if (!resolvedPath.startsWith(cwdResolved)) {
       return false;
     }
-    const content = fs65.readFileSync(resolvedPath, "utf-8");
+    const content = fs66.readFileSync(resolvedPath, "utf-8");
     for (const keyword of keywords) {
       const regex = new RegExp(`\\b${keyword}\\b`, "i");
       if (regex.test(content)) {
@@ -79156,10 +79605,10 @@ var req_coverage = createSwarmTool({
       }, null, 2);
     }
     const cwd = inputDirectory || directory;
-    const specPath = path80.join(cwd, SPEC_FILE);
+    const specPath = path81.join(cwd, SPEC_FILE);
     let specContent;
     try {
-      specContent = fs65.readFileSync(specPath, "utf-8");
+      specContent = fs66.readFileSync(specPath, "utf-8");
     } catch (readError) {
       return JSON.stringify({
         success: false,
@@ -79183,7 +79632,7 @@ var req_coverage = createSwarmTool({
         message: "No FR requirements found in spec.md"
       }, null, 2);
     }
-    const evidenceDir = path80.join(cwd, EVIDENCE_DIR4);
+    const evidenceDir = path81.join(cwd, EVIDENCE_DIR4);
     const touchedFiles = readTouchedFiles(evidenceDir, phase, cwd);
     const analyzedRequirements = [];
     let coveredCount = 0;
@@ -79209,12 +79658,12 @@ var req_coverage = createSwarmTool({
       requirements: analyzedRequirements
     };
     const reportFilename = `req-coverage-phase-${phase}.json`;
-    const reportPath = path80.join(evidenceDir, reportFilename);
+    const reportPath = path81.join(evidenceDir, reportFilename);
     try {
-      if (!fs65.existsSync(evidenceDir)) {
-        fs65.mkdirSync(evidenceDir, { recursive: true });
+      if (!fs66.existsSync(evidenceDir)) {
+        fs66.mkdirSync(evidenceDir, { recursive: true });
       }
-      fs65.writeFileSync(reportPath, JSON.stringify(result, null, 2), "utf-8");
+      fs66.writeFileSync(reportPath, JSON.stringify(result, null, 2), "utf-8");
     } catch (writeError) {
       console.warn(`Failed to write coverage report: ${writeError instanceof Error ? writeError.message : String(writeError)}`);
     }
@@ -79292,9 +79741,9 @@ ${paginatedContent}`;
 });
 // src/tools/save-plan.ts
 init_tool();
-import * as crypto8 from "crypto";
-import * as fs66 from "fs";
-import * as path81 from "path";
+import * as crypto9 from "crypto";
+import * as fs67 from "fs";
+import * as path82 from "path";
 init_checkpoint3();
 init_ledger();
 init_manager();
@@ -79375,12 +79824,12 @@ async function executeSavePlan(args2, fallbackDir) {
   let specMtime;
   let specHash;
   if (process.env.SWARM_SKIP_SPEC_GATE !== "1") {
-    const specPath = path81.join(targetWorkspace, ".swarm", "spec.md");
+    const specPath = path82.join(targetWorkspace, ".swarm", "spec.md");
     try {
-      const stat3 = await fs66.promises.stat(specPath);
+      const stat3 = await fs67.promises.stat(specPath);
       specMtime = stat3.mtime.toISOString();
-      const content = await fs66.promises.readFile(specPath, "utf8");
-      specHash = crypto8.createHash("sha256").update(content).digest("hex");
+      const content = await fs67.promises.readFile(specPath, "utf8");
+      specHash = crypto9.createHash("sha256").update(content).digest("hex");
     } catch {
       return {
         success: false,
@@ -79457,14 +79906,14 @@ async function executeSavePlan(args2, fallbackDir) {
       }
       await writeCheckpoint(dir).catch(() => {});
       try {
-        const markerPath = path81.join(dir, ".swarm", ".plan-write-marker");
+        const markerPath = path82.join(dir, ".swarm", ".plan-write-marker");
         const marker = JSON.stringify({
           source: "save_plan",
           timestamp: new Date().toISOString(),
           phases_count: plan.phases.length,
           tasks_count: tasksCount
         });
-        await fs66.promises.writeFile(markerPath, marker, "utf8");
+        await fs67.promises.writeFile(markerPath, marker, "utf8");
       } catch {}
       const warnings = [];
       let criticReviewFound = false;
@@ -79480,7 +79929,7 @@ async function executeSavePlan(args2, fallbackDir) {
       return {
         success: true,
         message: "Plan saved successfully",
-        plan_path: path81.join(dir, ".swarm", "plan.json"),
+        plan_path: path82.join(dir, ".swarm", "plan.json"),
         phases_count: plan.phases.length,
         tasks_count: tasksCount,
         ...warnings.length > 0 ? { warnings } : {}
@@ -79525,8 +79974,8 @@ var save_plan = createSwarmTool({
 // src/tools/sbom-generate.ts
 init_dist();
 init_manager2();
-import * as fs67 from "fs";
-import * as path82 from "path";
+import * as fs68 from "fs";
+import * as path83 from "path";
 
 // src/sbom/detectors/index.ts
 init_utils();
@@ -80374,9 +80823,9 @@ function findManifestFiles(rootDir) {
   const patterns = [...new Set(allDetectors.flatMap((d) => d.patterns))];
   function searchDir(dir) {
     try {
-      const entries = fs67.readdirSync(dir, { withFileTypes: true });
+      const entries = fs68.readdirSync(dir, { withFileTypes: true });
       for (const entry of entries) {
-        const fullPath = path82.join(dir, entry.name);
+        const fullPath = path83.join(dir, entry.name);
         if (entry.name.startsWith(".") || entry.name === "node_modules" || entry.name === "dist" || entry.name === "build" || entry.name === "target") {
           continue;
         }
@@ -80385,7 +80834,7 @@ function findManifestFiles(rootDir) {
         } else if (entry.isFile()) {
           for (const pattern of patterns) {
             if (simpleGlobToRegex(pattern).test(entry.name)) {
-              manifestFiles.push(path82.relative(rootDir, fullPath));
+              manifestFiles.push(path83.relative(rootDir, fullPath));
               break;
             }
           }
@@ -80401,13 +80850,13 @@ function findManifestFilesInDirs(directories, workingDir) {
   const patterns = [...new Set(allDetectors.flatMap((d) => d.patterns))];
   for (const dir of directories) {
     try {
-      const entries = fs67.readdirSync(dir, { withFileTypes: true });
+      const entries = fs68.readdirSync(dir, { withFileTypes: true });
       for (const entry of entries) {
-        const fullPath = path82.join(dir, entry.name);
+        const fullPath = path83.join(dir, entry.name);
         if (entry.isFile()) {
           for (const pattern of patterns) {
             if (simpleGlobToRegex(pattern).test(entry.name)) {
-              found.push(path82.relative(workingDir, fullPath));
+              found.push(path83.relative(workingDir, fullPath));
               break;
             }
           }
@@ -80420,11 +80869,11 @@ function findManifestFilesInDirs(directories, workingDir) {
 function getDirectoriesFromChangedFiles(changedFiles, workingDir) {
   const dirs = new Set;
   for (const file3 of changedFiles) {
-    let currentDir = path82.dirname(file3);
+    let currentDir = path83.dirname(file3);
     while (true) {
-      if (currentDir && currentDir !== "." && currentDir !== path82.sep) {
-        dirs.add(path82.join(workingDir, currentDir));
-        const parent = path82.dirname(currentDir);
+      if (currentDir && currentDir !== "." && currentDir !== path83.sep) {
+        dirs.add(path83.join(workingDir, currentDir));
+        const parent = path83.dirname(currentDir);
         if (parent === currentDir)
           break;
         currentDir = parent;
@@ -80438,7 +80887,7 @@ function getDirectoriesFromChangedFiles(changedFiles, workingDir) {
 }
 function ensureOutputDir(outputDir) {
   try {
-    fs67.mkdirSync(outputDir, { recursive: true });
+    fs68.mkdirSync(outputDir, { recursive: true });
   } catch (error93) {
     if (!error93 || error93.code !== "EEXIST") {
       throw error93;
@@ -80508,7 +80957,7 @@ var sbom_generate = createSwarmTool({
     const changedFiles = obj.changed_files;
     const relativeOutputDir = obj.output_dir || DEFAULT_OUTPUT_DIR;
     const workingDir = directory;
-    const outputDir = path82.isAbsolute(relativeOutputDir) ? relativeOutputDir : path82.join(workingDir, relativeOutputDir);
+    const outputDir = path83.isAbsolute(relativeOutputDir) ? relativeOutputDir : path83.join(workingDir, relativeOutputDir);
     let manifestFiles = [];
     if (scope === "all") {
       manifestFiles = findManifestFiles(workingDir);
@@ -80531,11 +80980,11 @@ var sbom_generate = createSwarmTool({
     const processedFiles = [];
     for (const manifestFile of manifestFiles) {
       try {
-        const fullPath = path82.isAbsolute(manifestFile) ? manifestFile : path82.join(workingDir, manifestFile);
-        if (!fs67.existsSync(fullPath)) {
+        const fullPath = path83.isAbsolute(manifestFile) ? manifestFile : path83.join(workingDir, manifestFile);
+        if (!fs68.existsSync(fullPath)) {
           continue;
         }
-        const content = fs67.readFileSync(fullPath, "utf-8");
+        const content = fs68.readFileSync(fullPath, "utf-8");
         const components = detectComponents(manifestFile, content);
         processedFiles.push(manifestFile);
         if (components.length > 0) {
@@ -80548,8 +80997,8 @@ var sbom_generate = createSwarmTool({
     const bom = generateCycloneDX(allComponents);
     const bomJson = serializeCycloneDX(bom);
     const filename = generateSbomFilename();
-    const outputPath = path82.join(outputDir, filename);
-    fs67.writeFileSync(outputPath, bomJson, "utf-8");
+    const outputPath = path83.join(outputDir, filename);
+    fs68.writeFileSync(outputPath, bomJson, "utf-8");
     const verdict = processedFiles.length > 0 ? "pass" : "pass";
     try {
       const timestamp = new Date().toISOString();
@@ -80591,8 +81040,8 @@ var sbom_generate = createSwarmTool({
 // src/tools/schema-drift.ts
 init_dist();
 init_create_tool();
-import * as fs68 from "fs";
-import * as path83 from "path";
+import * as fs69 from "fs";
+import * as path84 from "path";
 var SPEC_CANDIDATES = [
   "openapi.json",
   "openapi.yaml",
@@ -80624,28 +81073,28 @@ function normalizePath3(p) {
 }
 function discoverSpecFile(cwd, specFileArg) {
   if (specFileArg) {
-    const resolvedPath = path83.resolve(cwd, specFileArg);
-    const normalizedCwd = cwd.endsWith(path83.sep) ? cwd : cwd + path83.sep;
+    const resolvedPath = path84.resolve(cwd, specFileArg);
+    const normalizedCwd = cwd.endsWith(path84.sep) ? cwd : cwd + path84.sep;
     if (!resolvedPath.startsWith(normalizedCwd) && resolvedPath !== cwd) {
       throw new Error("Invalid spec_file: path traversal detected");
     }
-    const ext = path83.extname(resolvedPath).toLowerCase();
+    const ext = path84.extname(resolvedPath).toLowerCase();
     if (!ALLOWED_EXTENSIONS.includes(ext)) {
       throw new Error(`Invalid spec_file: must end in .json, .yaml, or .yml, got ${ext}`);
     }
-    const stats = fs68.statSync(resolvedPath);
+    const stats = fs69.statSync(resolvedPath);
     if (stats.size > MAX_SPEC_SIZE) {
       throw new Error(`Invalid spec_file: file exceeds ${MAX_SPEC_SIZE / 1024 / 1024}MB limit`);
     }
-    if (!fs68.existsSync(resolvedPath)) {
+    if (!fs69.existsSync(resolvedPath)) {
       throw new Error(`Spec file not found: ${resolvedPath}`);
     }
     return resolvedPath;
   }
   for (const candidate of SPEC_CANDIDATES) {
-    const candidatePath = path83.resolve(cwd, candidate);
-    if (fs68.existsSync(candidatePath)) {
-      const stats = fs68.statSync(candidatePath);
+    const candidatePath = path84.resolve(cwd, candidate);
+    if (fs69.existsSync(candidatePath)) {
+      const stats = fs69.statSync(candidatePath);
       if (stats.size <= MAX_SPEC_SIZE) {
         return candidatePath;
       }
@@ -80654,8 +81103,8 @@ function discoverSpecFile(cwd, specFileArg) {
   return null;
 }
 function parseSpec(specFile) {
-  const content = fs68.readFileSync(specFile, "utf-8");
-  const ext = path83.extname(specFile).toLowerCase();
+  const content = fs69.readFileSync(specFile, "utf-8");
+  const ext = path84.extname(specFile).toLowerCase();
   if (ext === ".json") {
     return parseJsonSpec(content);
   }
@@ -80726,12 +81175,12 @@ function extractRoutes(cwd) {
   function walkDir(dir) {
     let entries;
     try {
-      entries = fs68.readdirSync(dir, { withFileTypes: true });
+      entries = fs69.readdirSync(dir, { withFileTypes: true });
     } catch {
       return;
     }
     for (const entry of entries) {
-      const fullPath = path83.join(dir, entry.name);
+      const fullPath = path84.join(dir, entry.name);
       if (entry.isSymbolicLink()) {
         continue;
       }
@@ -80741,7 +81190,7 @@ function extractRoutes(cwd) {
         }
         walkDir(fullPath);
       } else if (entry.isFile()) {
-        const ext = path83.extname(entry.name).toLowerCase();
+        const ext = path84.extname(entry.name).toLowerCase();
         const baseName = entry.name.toLowerCase();
         if (![".ts", ".js", ".mjs"].includes(ext)) {
           continue;
@@ -80759,7 +81208,7 @@ function extractRoutes(cwd) {
 }
 function extractRoutesFromFile(filePath) {
   const routes = [];
-  const content = fs68.readFileSync(filePath, "utf-8");
+  const content = fs69.readFileSync(filePath, "utf-8");
   const lines = content.split(/\r?\n/);
   const expressRegex = /(?:app|router|server|express)\.(get|post|put|patch|delete|options|head)\s*\(\s*['"`]([^'"`]+)['"`]/g;
   const flaskRegex = /@(?:app|blueprint|bp)\.route\s*\(\s*['"]([^'"]+)['"]/g;
@@ -80907,8 +81356,8 @@ var schema_drift = createSwarmTool({
 init_tool();
 init_path_security();
 init_create_tool();
-import * as fs69 from "fs";
-import * as path84 from "path";
+import * as fs70 from "fs";
+import * as path85 from "path";
 var DEFAULT_MAX_RESULTS = 100;
 var DEFAULT_MAX_LINES = 200;
 var REGEX_TIMEOUT_MS = 5000;
@@ -80944,11 +81393,11 @@ function containsWindowsAttacks3(str) {
 }
 function isPathInWorkspace3(filePath, workspace) {
   try {
-    const resolvedPath = path84.resolve(workspace, filePath);
-    const realWorkspace = fs69.realpathSync(workspace);
-    const realResolvedPath = fs69.realpathSync(resolvedPath);
-    const relativePath = path84.relative(realWorkspace, realResolvedPath);
-    if (relativePath.startsWith("..") || path84.isAbsolute(relativePath)) {
+    const resolvedPath = path85.resolve(workspace, filePath);
+    const realWorkspace = fs70.realpathSync(workspace);
+    const realResolvedPath = fs70.realpathSync(resolvedPath);
+    const relativePath = path85.relative(realWorkspace, realResolvedPath);
+    if (relativePath.startsWith("..") || path85.isAbsolute(relativePath)) {
       return false;
     }
     return true;
@@ -80961,12 +81410,12 @@ function validatePathForRead2(filePath, workspace) {
 }
 function findRgInEnvPath() {
   const searchPath = process.env.PATH ?? "";
-  for (const dir of searchPath.split(path84.delimiter)) {
+  for (const dir of searchPath.split(path85.delimiter)) {
     if (!dir)
       continue;
     const isWindows = process.platform === "win32";
-    const candidate = path84.join(dir, isWindows ? "rg.exe" : "rg");
-    if (fs69.existsSync(candidate))
+    const candidate = path85.join(dir, isWindows ? "rg.exe" : "rg");
+    if (fs70.existsSync(candidate))
       return candidate;
   }
   return null;
@@ -81020,7 +81469,7 @@ async function ripgrepSearch(opts) {
       stderr: "pipe",
       cwd: opts.workspace
     });
-    const timeout = new Promise((resolve35) => setTimeout(() => resolve35("timeout"), REGEX_TIMEOUT_MS));
+    const timeout = new Promise((resolve36) => setTimeout(() => resolve36("timeout"), REGEX_TIMEOUT_MS));
     const exitPromise = proc.exited;
     const result = await Promise.race([exitPromise, timeout]);
     if (result === "timeout") {
@@ -81093,10 +81542,10 @@ function collectFiles(dir, workspace, includeGlobs, excludeGlobs) {
     return files;
   }
   try {
-    const entries = fs69.readdirSync(dir, { withFileTypes: true });
+    const entries = fs70.readdirSync(dir, { withFileTypes: true });
     for (const entry of entries) {
-      const fullPath = path84.join(dir, entry.name);
-      const relativePath = path84.relative(workspace, fullPath);
+      const fullPath = path85.join(dir, entry.name);
+      const relativePath = path85.relative(workspace, fullPath);
       if (!validatePathForRead2(fullPath, workspace)) {
         continue;
       }
@@ -81137,13 +81586,13 @@ async function fallbackSearch(opts) {
   const matches = [];
   let total = 0;
   for (const file3 of files) {
-    const fullPath = path84.join(opts.workspace, file3);
+    const fullPath = path85.join(opts.workspace, file3);
     if (!validatePathForRead2(fullPath, opts.workspace)) {
       continue;
     }
     let stats;
     try {
-      stats = fs69.statSync(fullPath);
+      stats = fs70.statSync(fullPath);
       if (stats.size > MAX_FILE_SIZE_BYTES10) {
         continue;
       }
@@ -81152,7 +81601,7 @@ async function fallbackSearch(opts) {
     }
     let content;
     try {
-      content = fs69.readFileSync(fullPath, "utf-8");
+      content = fs70.readFileSync(fullPath, "utf-8");
     } catch {
       continue;
     }
@@ -81264,7 +81713,7 @@ var search = createSwarmTool({
         message: "Exclude pattern contains invalid Windows-specific sequence"
       }, null, 2);
     }
-    if (!fs69.existsSync(directory)) {
+    if (!fs70.existsSync(directory)) {
       return JSON.stringify({
         error: true,
         type: "unknown",
@@ -81387,8 +81836,8 @@ var set_qa_gates = createSwarmTool({
 init_tool();
 init_path_security();
 init_create_tool();
-import * as fs70 from "fs";
-import * as path85 from "path";
+import * as fs71 from "fs";
+import * as path86 from "path";
 var WINDOWS_RESERVED_NAMES4 = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|:|$)/i;
 function containsWindowsAttacks4(str) {
   if (/:[^\\/]/.test(str))
@@ -81402,14 +81851,14 @@ function containsWindowsAttacks4(str) {
 }
 function isPathInWorkspace4(filePath, workspace) {
   try {
-    const resolvedPath = path85.resolve(workspace, filePath);
-    if (!fs70.existsSync(resolvedPath)) {
+    const resolvedPath = path86.resolve(workspace, filePath);
+    if (!fs71.existsSync(resolvedPath)) {
       return true;
     }
-    const realWorkspace = fs70.realpathSync(workspace);
-    const realResolvedPath = fs70.realpathSync(resolvedPath);
-    const relativePath = path85.relative(realWorkspace, realResolvedPath);
-    if (relativePath.startsWith("..") || path85.isAbsolute(relativePath)) {
+    const realWorkspace = fs71.realpathSync(workspace);
+    const realResolvedPath = fs71.realpathSync(resolvedPath);
+    const relativePath = path86.relative(realWorkspace, realResolvedPath);
+    if (relativePath.startsWith("..") || path86.isAbsolute(relativePath)) {
       return false;
     }
     return true;
@@ -81581,7 +82030,7 @@ var suggestPatch = createSwarmTool({
         message: "changes cannot be empty"
       }, null, 2);
     }
-    if (!fs70.existsSync(directory)) {
+    if (!fs71.existsSync(directory)) {
       return JSON.stringify({
         success: false,
         error: true,
@@ -81617,8 +82066,8 @@ var suggestPatch = createSwarmTool({
         });
         continue;
       }
-      const fullPath = path85.resolve(directory, change.file);
-      if (!fs70.existsSync(fullPath)) {
+      const fullPath = path86.resolve(directory, change.file);
+      if (!fs71.existsSync(fullPath)) {
         errors5.push({
           success: false,
           error: true,
@@ -81632,7 +82081,7 @@ var suggestPatch = createSwarmTool({
       }
       let content;
       try {
-        content = fs70.readFileSync(fullPath, "utf-8");
+        content = fs71.readFileSync(fullPath, "utf-8");
       } catch (err3) {
         errors5.push({
           success: false,
@@ -81711,8 +82160,8 @@ var suggestPatch = createSwarmTool({
 // src/tools/lint-spec.ts
 init_spec_schema();
 init_create_tool();
-import * as fs71 from "fs";
-import * as path86 from "path";
+import * as fs72 from "fs";
+import * as path87 from "path";
 var SPEC_FILE_NAME = "spec.md";
 var SWARM_DIR2 = ".swarm";
 var OBLIGATION_KEYWORDS2 = ["MUST", "SHALL", "SHOULD", "MAY"];
@@ -81765,8 +82214,8 @@ var lint_spec = createSwarmTool({
   async execute(_args, directory) {
     const errors5 = [];
     const warnings = [];
-    const specPath = path86.join(directory, SWARM_DIR2, SPEC_FILE_NAME);
-    if (!fs71.existsSync(specPath)) {
+    const specPath = path87.join(directory, SWARM_DIR2, SPEC_FILE_NAME);
+    if (!fs72.existsSync(specPath)) {
       const result2 = {
         valid: false,
         specMtime: null,
@@ -81785,12 +82234,12 @@ var lint_spec = createSwarmTool({
     }
     let specMtime = null;
     try {
-      const stats = fs71.statSync(specPath);
+      const stats = fs72.statSync(specPath);
       specMtime = stats.mtime.toISOString();
     } catch {}
     let content;
     try {
-      content = fs71.readFileSync(specPath, "utf-8");
+      content = fs72.readFileSync(specPath, "utf-8");
     } catch (e) {
       const result2 = {
         valid: false,
@@ -81835,13 +82284,13 @@ var lint_spec = createSwarmTool({
 });
 // src/tools/mutation-test.ts
 init_dist();
-import * as fs72 from "fs";
-import * as path88 from "path";
+import * as fs73 from "fs";
+import * as path89 from "path";
 
 // src/mutation/engine.ts
 import { spawnSync as spawnSync3 } from "child_process";
-import { unlinkSync as unlinkSync11, writeFileSync as writeFileSync17 } from "fs";
-import * as path87 from "path";
+import { unlinkSync as unlinkSync12, writeFileSync as writeFileSync18 } from "fs";
+import * as path88 from "path";
 
 // src/mutation/equivalence.ts
 function isStaticallyEquivalent(originalCode, mutatedCode) {
@@ -81976,9 +82425,9 @@ async function executeMutation(patch, testCommand, _testFiles, workingDir) {
   let patchFile;
   try {
     const safeId2 = patch.id.replace(/[^a-zA-Z0-9_-]/g, "_");
-    patchFile = path87.join(workingDir, `.mutation_patch_${safeId2}.diff`);
+    patchFile = path88.join(workingDir, `.mutation_patch_${safeId2}.diff`);
     try {
-      writeFileSync17(patchFile, patch.patch);
+      writeFileSync18(patchFile, patch.patch);
     } catch (writeErr) {
       error93 = `Failed to write patch file: ${writeErr}`;
       outcome = "error";
@@ -82074,7 +82523,7 @@ async function executeMutation(patch, testCommand, _testFiles, workingDir) {
         revertError = new Error(`Failed to revert mutation ${patch.id}: ${revertErr}. Working tree may be dirty.`);
       }
       try {
-        unlinkSync11(patchFile);
+        unlinkSync12(patchFile);
       } catch (_unlinkErr) {}
     }
   }
@@ -82370,8 +82819,8 @@ var mutation_test = createSwarmTool({
       ];
       for (const filePath of uniquePaths) {
         try {
-          const resolvedPath = path88.resolve(cwd, filePath);
-          sourceFiles.set(filePath, fs72.readFileSync(resolvedPath, "utf-8"));
+          const resolvedPath = path89.resolve(cwd, filePath);
+          sourceFiles.set(filePath, fs73.readFileSync(resolvedPath, "utf-8"));
         } catch {}
       }
       const report = await executeMutationSuite(typedArgs.patches, typedArgs.test_command, typedArgs.files, cwd, undefined, undefined, sourceFiles.size > 0 ? sourceFiles : undefined);
@@ -82389,8 +82838,8 @@ var mutation_test = createSwarmTool({
 init_dist();
 init_manager2();
 init_detector();
-import * as fs73 from "fs";
-import * as path89 from "path";
+import * as fs74 from "fs";
+import * as path90 from "path";
 init_create_tool();
 var MAX_FILE_SIZE2 = 2 * 1024 * 1024;
 var BINARY_CHECK_BYTES = 8192;
@@ -82456,7 +82905,7 @@ async function syntaxCheck(input, directory, config3) {
   if (languages?.length) {
     const lowerLangs = languages.map((l) => l.toLowerCase());
     filesToCheck = filesToCheck.filter((file3) => {
-      const ext = path89.extname(file3.path).toLowerCase();
+      const ext = path90.extname(file3.path).toLowerCase();
       const langDef = getLanguageForExtension(ext);
       const fileProfile = getProfileForFile(file3.path);
       const langId = fileProfile?.id || langDef?.id;
@@ -82469,7 +82918,7 @@ async function syntaxCheck(input, directory, config3) {
   let skippedCount = 0;
   for (const fileInfo of filesToCheck) {
     const { path: filePath } = fileInfo;
-    const fullPath = path89.isAbsolute(filePath) ? filePath : path89.join(directory, filePath);
+    const fullPath = path90.isAbsolute(filePath) ? filePath : path90.join(directory, filePath);
     const result = {
       path: filePath,
       language: "",
@@ -82499,7 +82948,7 @@ async function syntaxCheck(input, directory, config3) {
       }
       let content;
       try {
-        content = fs73.readFileSync(fullPath, "utf8");
+        content = fs74.readFileSync(fullPath, "utf8");
       } catch {
         result.skipped_reason = "file_read_error";
         skippedCount++;
@@ -82518,7 +82967,7 @@ async function syntaxCheck(input, directory, config3) {
         results.push(result);
         continue;
       }
-      const ext = path89.extname(filePath).toLowerCase();
+      const ext = path90.extname(filePath).toLowerCase();
       const langDef = getLanguageForExtension(ext);
       result.language = profile?.id || langDef?.id || "unknown";
       const errors5 = extractSyntaxErrors(parser, content);
@@ -82610,8 +83059,8 @@ init_dist();
 init_utils();
 init_create_tool();
 init_path_security();
-import * as fs74 from "fs";
-import * as path90 from "path";
+import * as fs75 from "fs";
+import * as path91 from "path";
 var MAX_TEXT_LENGTH = 200;
 var MAX_FILE_SIZE_BYTES11 = 1024 * 1024;
 var SUPPORTED_EXTENSIONS4 = new Set([
@@ -82677,9 +83126,9 @@ function validatePathsInput(paths, cwd) {
     return { error: "paths contains path traversal", resolvedPath: null };
   }
   try {
-    const resolvedPath = path90.resolve(paths);
-    const normalizedCwd = path90.resolve(cwd);
-    const normalizedResolved = path90.resolve(resolvedPath);
+    const resolvedPath = path91.resolve(paths);
+    const normalizedCwd = path91.resolve(cwd);
+    const normalizedResolved = path91.resolve(resolvedPath);
     if (!normalizedResolved.startsWith(normalizedCwd)) {
       return {
         error: "paths must be within the current working directory",
@@ -82695,13 +83144,13 @@ function validatePathsInput(paths, cwd) {
   }
 }
 function isSupportedExtension(filePath) {
-  const ext = path90.extname(filePath).toLowerCase();
+  const ext = path91.extname(filePath).toLowerCase();
   return SUPPORTED_EXTENSIONS4.has(ext);
 }
 function findSourceFiles4(dir, files = []) {
   let entries;
   try {
-    entries = fs74.readdirSync(dir);
+    entries = fs75.readdirSync(dir);
   } catch {
     return files;
   }
@@ -82710,10 +83159,10 @@ function findSourceFiles4(dir, files = []) {
     if (SKIP_DIRECTORIES5.has(entry)) {
       continue;
     }
-    const fullPath = path90.join(dir, entry);
+    const fullPath = path91.join(dir, entry);
     let stat3;
     try {
-      stat3 = fs74.statSync(fullPath);
+      stat3 = fs75.statSync(fullPath);
     } catch {
       continue;
     }
@@ -82806,7 +83255,7 @@ var todo_extract = createSwarmTool({
       return JSON.stringify(errorResult, null, 2);
     }
     const scanPath = resolvedPath;
-    if (!fs74.existsSync(scanPath)) {
+    if (!fs75.existsSync(scanPath)) {
       const errorResult = {
         error: `path not found: ${pathsInput}`,
         total: 0,
@@ -82816,13 +83265,13 @@ var todo_extract = createSwarmTool({
       return JSON.stringify(errorResult, null, 2);
     }
     const filesToScan = [];
-    const stat3 = fs74.statSync(scanPath);
+    const stat3 = fs75.statSync(scanPath);
     if (stat3.isFile()) {
       if (isSupportedExtension(scanPath)) {
         filesToScan.push(scanPath);
       } else {
         const errorResult = {
-          error: `unsupported file extension: ${path90.extname(scanPath)}`,
+          error: `unsupported file extension: ${path91.extname(scanPath)}`,
           total: 0,
           byPriority: { high: 0, medium: 0, low: 0 },
           entries: []
@@ -82835,11 +83284,11 @@ var todo_extract = createSwarmTool({
     const allEntries = [];
     for (const filePath of filesToScan) {
       try {
-        const fileStat = fs74.statSync(filePath);
+        const fileStat = fs75.statSync(filePath);
         if (fileStat.size > MAX_FILE_SIZE_BYTES11) {
           continue;
         }
-        const content = fs74.readFileSync(filePath, "utf-8");
+        const content = fs75.readFileSync(filePath, "utf-8");
         const entries = parseTodoComments(content, filePath, tagsSet);
         allEntries.push(...entries);
       } catch {}
@@ -82869,18 +83318,18 @@ init_tool();
 init_loader();
 init_schema();
 init_gate_evidence();
-import * as fs76 from "fs";
-import * as path92 from "path";
+import * as fs77 from "fs";
+import * as path93 from "path";
 
 // src/hooks/diff-scope.ts
-import * as fs75 from "fs";
-import * as path91 from "path";
+import * as fs76 from "fs";
+import * as path92 from "path";
 function getDeclaredScope(taskId, directory) {
   try {
-    const planPath = path91.join(directory, ".swarm", "plan.json");
-    if (!fs75.existsSync(planPath))
+    const planPath = path92.join(directory, ".swarm", "plan.json");
+    if (!fs76.existsSync(planPath))
       return null;
-    const raw = fs75.readFileSync(planPath, "utf-8");
+    const raw = fs76.readFileSync(planPath, "utf-8");
     const plan = JSON.parse(raw);
     for (const phase of plan.phases ?? []) {
       for (const task of phase.tasks ?? []) {
@@ -82995,7 +83444,7 @@ var TIER_3_PATTERNS = [
 ];
 function matchesTier3Pattern(files) {
   for (const file3 of files) {
-    const fileName = path92.basename(file3);
+    const fileName = path93.basename(file3);
     for (const pattern of TIER_3_PATTERNS) {
       if (pattern.test(fileName)) {
         return true;
@@ -83009,8 +83458,8 @@ function checkReviewerGate(taskId, workingDirectory) {
     if (hasActiveTurboMode()) {
       const resolvedDir2 = workingDirectory;
       try {
-        const planPath = path92.join(resolvedDir2, ".swarm", "plan.json");
-        const planRaw = fs76.readFileSync(planPath, "utf-8");
+        const planPath = path93.join(resolvedDir2, ".swarm", "plan.json");
+        const planRaw = fs77.readFileSync(planPath, "utf-8");
         const plan = JSON.parse(planRaw);
         for (const planPhase of plan.phases ?? []) {
           for (const task of planPhase.tasks ?? []) {
@@ -83076,8 +83525,8 @@ function checkReviewerGate(taskId, workingDirectory) {
     }
     try {
       const resolvedDir2 = workingDirectory;
-      const planPath = path92.join(resolvedDir2, ".swarm", "plan.json");
-      const planRaw = fs76.readFileSync(planPath, "utf-8");
+      const planPath = path93.join(resolvedDir2, ".swarm", "plan.json");
+      const planRaw = fs77.readFileSync(planPath, "utf-8");
       const plan = JSON.parse(planRaw);
       for (const planPhase of plan.phases ?? []) {
         for (const task of planPhase.tasks ?? []) {
@@ -83294,8 +83743,8 @@ async function executeUpdateTaskStatus(args2, fallbackDir) {
         };
       }
     }
-    normalizedDir = path92.normalize(args2.working_directory);
-    const pathParts = normalizedDir.split(path92.sep);
+    normalizedDir = path93.normalize(args2.working_directory);
+    const pathParts = normalizedDir.split(path93.sep);
     if (pathParts.includes("..")) {
       return {
         success: false,
@@ -83305,11 +83754,11 @@ async function executeUpdateTaskStatus(args2, fallbackDir) {
         ]
       };
     }
-    const resolvedDir = path92.resolve(normalizedDir);
+    const resolvedDir = path93.resolve(normalizedDir);
     try {
-      const realPath = fs76.realpathSync(resolvedDir);
-      const planPath = path92.join(realPath, ".swarm", "plan.json");
-      if (!fs76.existsSync(planPath)) {
+      const realPath = fs77.realpathSync(resolvedDir);
+      const planPath = path93.join(realPath, ".swarm", "plan.json");
+      if (!fs77.existsSync(planPath)) {
         return {
           success: false,
           message: `Invalid working_directory: plan not found in "${realPath}"`,
@@ -83340,12 +83789,12 @@ async function executeUpdateTaskStatus(args2, fallbackDir) {
   }
   if (args2.status === "in_progress") {
     try {
-      const evidencePath = path92.join(directory, ".swarm", "evidence", `${args2.task_id}.json`);
-      fs76.mkdirSync(path92.dirname(evidencePath), { recursive: true });
-      const fd = fs76.openSync(evidencePath, "wx");
+      const evidencePath = path93.join(directory, ".swarm", "evidence", `${args2.task_id}.json`);
+      fs77.mkdirSync(path93.dirname(evidencePath), { recursive: true });
+      const fd = fs77.openSync(evidencePath, "wx");
       let writeOk = false;
       try {
-        fs76.writeSync(fd, JSON.stringify({
+        fs77.writeSync(fd, JSON.stringify({
           task_id: args2.task_id,
           required_gates: ["reviewer", "test_engineer"],
           gates: {},
@@ -83353,10 +83802,10 @@ async function executeUpdateTaskStatus(args2, fallbackDir) {
         }, null, 2));
         writeOk = true;
       } finally {
-        fs76.closeSync(fd);
+        fs77.closeSync(fd);
         if (!writeOk) {
           try {
-            fs76.unlinkSync(evidencePath);
+            fs77.unlinkSync(evidencePath);
           } catch {}
         }
       }
@@ -83366,8 +83815,8 @@ async function executeUpdateTaskStatus(args2, fallbackDir) {
     recoverTaskStateFromDelegations(args2.task_id);
     let phaseRequiresReviewer = true;
     try {
-      const planPath = path92.join(directory, ".swarm", "plan.json");
-      const planRaw = fs76.readFileSync(planPath, "utf-8");
+      const planPath = path93.join(directory, ".swarm", "plan.json");
+      const planRaw = fs77.readFileSync(planPath, "utf-8");
       const plan = JSON.parse(planRaw);
       const taskPhase = plan.phases.find((p) => p.tasks.some((t) => t.id === args2.task_id));
       if (taskPhase?.required_agents && !taskPhase.required_agents.includes("reviewer")) {
@@ -83476,8 +83925,8 @@ init_utils2();
 init_ledger();
 init_manager();
 init_create_tool();
-import fs77 from "fs";
-import path93 from "path";
+import fs78 from "fs";
+import path94 from "path";
 function derivePlanId5(plan) {
   return `${plan.swarm}-${plan.title}`.replace(/[^a-zA-Z0-9-_]/g, "_");
 }
@@ -83528,7 +83977,7 @@ async function executeWriteDriftEvidence(args2, directory) {
     entries: [evidenceEntry]
   };
   const filename = "drift-verifier.json";
-  const relativePath = path93.join("evidence", String(phase), filename);
+  const relativePath = path94.join("evidence", String(phase), filename);
   let validatedPath;
   try {
     validatedPath = validateSwarmPath(directory, relativePath);
@@ -83539,12 +83988,12 @@ async function executeWriteDriftEvidence(args2, directory) {
       message: error93 instanceof Error ? error93.message : "Failed to validate path"
     }, null, 2);
   }
-  const evidenceDir = path93.dirname(validatedPath);
+  const evidenceDir = path94.dirname(validatedPath);
   try {
-    await fs77.promises.mkdir(evidenceDir, { recursive: true });
-    const tempPath = path93.join(evidenceDir, `.${filename}.tmp`);
-    await fs77.promises.writeFile(tempPath, JSON.stringify(evidenceContent, null, 2), "utf-8");
-    await fs77.promises.rename(tempPath, validatedPath);
+    await fs78.promises.mkdir(evidenceDir, { recursive: true });
+    const tempPath = path94.join(evidenceDir, `.${filename}.tmp`);
+    await fs78.promises.writeFile(tempPath, JSON.stringify(evidenceContent, null, 2), "utf-8");
+    await fs78.promises.rename(tempPath, validatedPath);
     let snapshotInfo;
     let snapshotError;
     let qaProfileLocked;
@@ -83638,8 +84087,8 @@ var write_drift_evidence = createSwarmTool({
 init_tool();
 init_utils2();
 init_create_tool();
-import fs78 from "fs";
-import path94 from "path";
+import fs79 from "fs";
+import path95 from "path";
 function normalizeVerdict2(verdict) {
   switch (verdict) {
     case "APPROVED":
@@ -83687,7 +84136,7 @@ async function executeWriteHallucinationEvidence(args2, directory) {
     entries: [evidenceEntry]
   };
   const filename = "hallucination-guard.json";
-  const relativePath = path94.join("evidence", String(phase), filename);
+  const relativePath = path95.join("evidence", String(phase), filename);
   let validatedPath;
   try {
     validatedPath = validateSwarmPath(directory, relativePath);
@@ -83698,12 +84147,12 @@ async function executeWriteHallucinationEvidence(args2, directory) {
       message: error93 instanceof Error ? error93.message : "Failed to validate path"
     }, null, 2);
   }
-  const evidenceDir = path94.dirname(validatedPath);
+  const evidenceDir = path95.dirname(validatedPath);
   try {
-    await fs78.promises.mkdir(evidenceDir, { recursive: true });
-    const tempPath = path94.join(evidenceDir, `.${filename}.tmp`);
-    await fs78.promises.writeFile(tempPath, JSON.stringify(evidenceContent, null, 2), "utf-8");
-    await fs78.promises.rename(tempPath, validatedPath);
+    await fs79.promises.mkdir(evidenceDir, { recursive: true });
+    const tempPath = path95.join(evidenceDir, `.${filename}.tmp`);
+    await fs79.promises.writeFile(tempPath, JSON.stringify(evidenceContent, null, 2), "utf-8");
+    await fs79.promises.rename(tempPath, validatedPath);
     return JSON.stringify({
       success: true,
       phase,
@@ -83912,7 +84361,7 @@ var OpenCodeSwarm = async (ctx) => {
     const { PreflightTriggerManager: PTM } = await Promise.resolve().then(() => (init_trigger(), exports_trigger));
     preflightTriggerManager = new PTM(automationConfig);
     const { AutomationStatusArtifact: ASA } = await Promise.resolve().then(() => (init_status_artifact(), exports_status_artifact));
-    const swarmDir = path95.resolve(ctx.directory, ".swarm");
+    const swarmDir = path96.resolve(ctx.directory, ".swarm");
     statusArtifact = new ASA(swarmDir);
     statusArtifact.updateConfig(automationConfig.mode, automationConfig.capabilities);
     if (automationConfig.capabilities?.evidence_auto_summaries === true) {

--- a/dist/tools/sast-baseline.d.ts
+++ b/dist/tools/sast-baseline.d.ts
@@ -1,0 +1,126 @@
+/**
+ * SAST Baseline — phase-scoped snapshot of pre-existing security findings.
+ *
+ * Enables baseline diffing so only NEW findings (introduced since baseline capture)
+ * drive the fail verdict in subsequent sast_scan calls.
+ *
+ * Storage: .swarm/evidence/{phase}/sast-baseline.json
+ *   Mirrors the phase-scoped convention used by write-drift-evidence.ts and
+ *   write-hallucination-evidence.ts (path.join('evidence', String(phase), filename)
+ *   passed to validateSwarmPath).
+ *
+ * Fingerprint format (stable):
+ *   `${relFile}|${rule_id}|${sha256(3lineWindow).slice(0,16)}|#${occurrenceIndex}`
+ *
+ * Fingerprint format (unstable — file unreadable or path escapes workspace):
+ *   `${relFile}|${rule_id}|L${line}|UNSTABLE|#${occurrenceIndex}`
+ *   Unstable fingerprints are ALWAYS treated as NEW findings (fail-closed).
+ *
+ * Merge semantics:
+ *   On every capture for a set of files, ALL prior fingerprints for those files
+ *   are removed (full prune, engine-agnostic) before inserting current findings.
+ *   This prevents stale cross-engine fingerprints from causing false-pass verdicts.
+ */
+import type { SastScanFinding } from './sast-scan';
+export declare const BASELINE_SCHEMA_VERSION: "1.0.0";
+/** Maximum findings to store in baseline (heuristic — open for tuning). */
+export declare const MAX_BASELINE_FINDINGS = 2000;
+export interface SastBaselineFile {
+    schema_version: '1.0.0';
+    phase: number;
+    created_at: string;
+    updated_at: string;
+    engine: 'tier_a' | 'tier_a+tier_b';
+    /** Canonical relative paths of files indexed into this baseline. */
+    files_indexed: string[];
+    /** Fingerprint strings for all indexed findings. */
+    fingerprints: string[];
+    /** Full findings snapshot (for auditing / debugging). */
+    findings_snapshot: SastScanFinding[];
+    /** True if the snapshot was truncated at MAX_BASELINE_FINDINGS. */
+    truncated: boolean;
+}
+export type LoadBaselineResult = {
+    status: 'found';
+    fingerprints: Set<string>;
+    bundle: SastBaselineFile;
+} | {
+    status: 'not_found';
+} | {
+    status: 'invalid_schema';
+    errors: string[];
+};
+export interface FingerprintResult {
+    fingerprint: string;
+    /** False when the file was unreadable or the path escapes the workspace. */
+    stable: boolean;
+}
+export interface IndexedFinding {
+    finding: SastScanFinding;
+    index: number;
+    stable: boolean;
+    fingerprint: string;
+}
+export type CaptureResult = {
+    status: 'written';
+    path: string;
+    fingerprint_count: number;
+} | {
+    status: 'merged';
+    path: string;
+    fingerprint_count: number;
+} | {
+    status: 'error';
+    message: string;
+};
+/**
+ * Return the canonical relative path for a finding file.
+ * Mirrors the normalization in pre-check-batch.ts classifySastFindings.
+ */
+export declare function normalizeFindingPath(directory: string, file: string): string;
+/**
+ * Compute a stable or unstable fingerprint for a single finding.
+ *
+ * Stable uses a 3-line content window (N-1, N, N+1) so the fingerprint
+ * survives line-number shifts caused by insertions above the finding.
+ *
+ * Unstable is produced when the file cannot be read or the path escapes
+ * the workspace — such findings are always classified NEW (fail-closed).
+ */
+export declare function fingerprintFinding(finding: SastScanFinding, directory: string, occurrenceIndex: number): FingerprintResult;
+/**
+ * Assign occurrence indices to a batch of findings.
+ *
+ * Two findings that produce the same (relFile, rule_id, contentHash) tuple
+ * — e.g., copy-pasted vulnerable lines — receive different indices so they
+ * get distinct fingerprints and can be individually classified.
+ */
+export declare function assignOccurrenceIndices(findings: SastScanFinding[], directory: string): IndexedFinding[];
+/**
+ * Capture or merge SAST findings into the phase-scoped baseline.
+ *
+ * Merge semantics:
+ *   For every file in `scannedFiles`, ALL prior fingerprints for that file are
+ *   removed from the baseline before inserting the current scan's fingerprints.
+ *   This full-prune (engine-agnostic) prevents stale cross-engine entries from
+ *   causing false-pass verdicts on later full-engine diff scans.
+ *
+ * Severity threshold:
+ *   Callers MUST pass ALL findings regardless of severity threshold so the
+ *   baseline captures the full pre-existing surface. Threshold filtering is
+ *   the diff caller's responsibility.
+ *
+ * Idempotency:
+ *   Calling twice with identical inputs produces an identical baseline file.
+ *   Calling with a new file set adds/replaces only those files' fingerprints.
+ */
+export declare function captureOrMergeBaseline(directory: string, phase: number, findings: SastScanFinding[], engine: 'tier_a' | 'tier_a+tier_b', scannedFiles: string[], opts?: {
+    force?: boolean;
+}): Promise<CaptureResult>;
+/**
+ * Load the SAST baseline for a given phase.
+ *
+ * Returns 'not_found' when no baseline file exists (first run for phase).
+ * Returns 'invalid_schema' when the file is present but unparseable.
+ */
+export declare function loadBaseline(directory: string, phase: number): LoadBaselineResult;

--- a/dist/tools/sast-scan.d.ts
+++ b/dist/tools/sast-scan.d.ts
@@ -10,6 +10,21 @@ export interface SastScanInput {
     changed_files: string[];
     /** Minimum severity that causes failure (default: 'medium') */
     severity_threshold?: 'low' | 'medium' | 'high' | 'critical';
+    /**
+     * When true, capture/merge a phase-scoped baseline snapshot and return
+     * status:'baseline_captured'. Subsequent scans with the same phase will
+     * diff against this baseline so only NEW findings drive the fail verdict.
+     *
+     * Capture mode ignores severity_threshold — all severities are recorded.
+     * Requires `phase` to be provided.
+     */
+    capture_baseline?: boolean;
+    /**
+     * Current phase number (positive integer, >= 1). Required when
+     * capture_baseline is true. When provided without capture_baseline, enables
+     * baseline diff mode: only findings absent from the phase baseline fail.
+     */
+    phase?: number;
 }
 export interface SastScanResult {
     /** Overall verdict: pass if no findings above threshold, fail otherwise */
@@ -32,6 +47,18 @@ export interface SastScanResult {
             low: number;
         };
     };
+    /** 'baseline_captured' when capture_baseline:true succeeded */
+    status?: 'baseline_captured' | 'baseline_merged';
+    /** Number of findings recorded in the baseline (capture mode only) */
+    finding_count?: number;
+    /** Findings NOT present in the baseline (diff mode only) */
+    new_findings?: SastScanFinding[];
+    /** Findings that match the baseline (diff mode only) */
+    pre_existing_findings?: SastScanFinding[];
+    /** True when a baseline was loaded and diff mode was active */
+    baseline_used?: boolean;
+    /** True when pre_existing_findings were truncated to fit result limits */
+    truncated_pre_existing?: boolean;
 }
 export interface SastScanFinding {
     rule_id: string;

--- a/docs/releases/v6.74.0.md
+++ b/docs/releases/v6.74.0.md
@@ -1,0 +1,63 @@
+# Release v6.74.0
+
+## Summary
+
+Implements phase-scoped SAST baseline diffing so only NEW security findings (introduced during the current task) drive the `sast_scan` fail verdict — pre-existing findings become triage-only context. Resolves GitHub issue #489. Previously, a single pre-existing finding in touched code could block a task indefinitely even when the agent's diff introduced no new risk. Baselines are captured once per phase and merged incrementally on every subsequent scan.
+
+## What changed
+
+### New module
+- **`src/tools/sast-baseline.ts`** (new) — Phase-scoped baseline capture, load, and merge logic. Storage path `.swarm/evidence/{phase}/sast-baseline.json` (mirrors the `write-drift-evidence.ts`/`write-hallucination-evidence.ts` convention). Fingerprint format uses a SHA-256 hash of a 3-line content window (`N-1, N, N+1`, trimmed) so findings survive line-number shifts from insertions above. Duplicate `(file, rule, content)` tuples get distinct occurrence indices (`#0`, `#1`, …) to correctly disambiguate copy-pasted vulnerable lines. Atomic writes (temp-file + rename) with an advisory `.lock` sidecar guard concurrent architect invocations. Exports `captureOrMergeBaseline`, `loadBaseline`, `fingerprintFinding`, `assignOccurrenceIndices`, `normalizeFindingPath`, `BASELINE_SCHEMA_VERSION='1.0.0'`, `MAX_BASELINE_FINDINGS=2000`.
+
+### SAST scan tool
+- **`src/tools/sast-scan.ts`** — Added `capture_baseline?: boolean` and `phase?: number` input args. In **capture mode**, severity-threshold filtering and zero-coverage-fail are both bypassed so the baseline captures the full pre-existing surface; verdict always returns `pass`. In **diff mode** (implicit when `phase` is set and a baseline exists), findings are partitioned into `new_findings` vs `pre_existing_findings` via occurrence-indexed fingerprints; the verdict is driven **only** by `new_findings`; unstable fingerprints (unreadable files or path-escape) are treated as NEW (fail-closed); zero-coverage-fail is preserved. Result surface extended with optional `status`, `finding_count`, `new_findings`, `pre_existing_findings`, `baseline_used`, `truncated_pre_existing` fields.
+
+### Pre-check batch
+- **`src/tools/pre-check-batch.ts`** — Threaded `phase` through to `sast_scan`. When `baseline_used` is true and `pre_existing_findings` are present, `sast_preexisting_findings` is now populated **regardless** of the SAST verdict (preserving reviewer triage) and uses the caller's `sast_threshold` via a new `meetsThresholdForTriage()` helper (rather than the legacy `GATE_SEVERITIES` set). Legacy behavior (no baseline, no phase) is unchanged.
+
+### Evidence schema
+- **`src/config/evidence-schema.ts`** — Extracted reusable `SastFindingSchema`. Extended `SastEvidenceSchema` with optional `new_findings`, `pre_existing_findings`, `baseline_used` fields for audit visibility.
+
+### Architect prompt
+- **`src/agents/architect.ts`** — Inserted new **step 5b-BASE** (mandatory, once per task) between `5b-PRE` and `5b` instructing the architect to call `sast_scan` with `capture_baseline:true, phase:<N>, changed_files:<files>` before code is written, and to print one of `sast-baseline: [WRITTEN | MERGED | SKIPPED | ERROR]`. **Step 5i** now passes `phase:<N>` to `pre_check_batch` and references the new `{new_findings, pre_existing_findings, baseline_used}` result fields.
+
+### Tests
+- **`tests/unit/tools/sast-baseline.test.ts`** (new) — 31 tests covering path normalization, stable/unstable fingerprinting (line 1, last line, unreadable file, path escape), occurrence-index disambiguation for copy-pasted findings, capture/merge validation (phase 0 and -1 rejected, empty file set rejected), full-prune-on-rescan, size-cap enforcement, and `loadBaseline` not-found/found/invalid-schema paths.
+- **`tests/unit/tools/sast-scan.test.ts`** — 7 new tests for capture mode, diff-mode all-preexisting, diff-mode new finding, zero-coverage-fail in diff mode, gate-disabled + capture, and legacy (no-phase) behavior.
+- **`tests/unit/tools/pre-check-batch.test.ts`** — New SAST-baseline-diff-mode tests verifying triage preservation and threshold handling.
+
+## Why
+
+Issue #489 documented a recurring pattern where a single `sast_scan` finding in code the agent touched but did not author would fail `pre_check_batch` indefinitely. Because the verdict treated every finding as equally blocking, there was no way to distinguish "agent introduced this" from "this has been here for months." The baseline-diffing approach captures the pre-existing security surface once per phase, then on subsequent scans classifies findings as NEW (fail-closed on any ambiguity) vs PRE-EXISTING (triage-only). The fail verdict is driven only by NEW findings, unblocking tasks that touch legacy code without reducing real security signal for authored code.
+
+## Migration steps
+
+No migration required for existing users — the feature is fully opt-in.
+
+- Agents on the new architect prompt automatically capture a baseline at step 5b-BASE.
+- Existing agents (older architect prompt) continue to work unchanged; `sast_scan` without `phase` uses the legacy single-verdict path.
+- Pre-existing baselines are phase-scoped — each new phase captures its own baseline.
+
+To adopt manually without upgrading the architect prompt:
+
+```
+# Capture baseline before code changes
+sast_scan(capture_baseline=true, phase=<N>, changed_files=[...])
+
+# Subsequent scans (diff mode)
+sast_scan(phase=<N>, changed_files=[...])
+pre_check_batch(phase=<N>, ...)
+```
+
+## Breaking changes
+
+None. All new input args and result fields are optional; legacy behavior is preserved when `phase` is omitted.
+
+## Known caveats
+
+- **Phase-scoped only**: Baselines are keyed by phase integer. Restarting a phase re-captures from the current working state. This is intentional — a fresh phase plan should re-evaluate the security surface.
+- **Full-prune on re-scan**: When a baseline is merged for a previously-scanned file, all prior fingerprints for that file are dropped regardless of engine (tier_a vs tier_a+tier_b). This prevents stale cross-engine fingerprints from causing false-pass verdicts when the engine mix changes between scans.
+- **Unstable fingerprints fail closed**: If the source file backing a finding cannot be read (e.g. binary, deleted, or path escapes workspace), the fingerprint is tagged UNSTABLE and the finding is always classified NEW in diff mode. This trades false-positives for security signal preservation.
+- **Size cap**: `MAX_BASELINE_FINDINGS=2000`. Baselines that would exceed this cap are truncated and `truncated:true` is set on the artifact. Baseline JSON above 2 MB returns an error rather than writing a malformed artifact.
+- **Concurrent capture**: Advisory file lock with retry backoff mitigates concurrent captures within a single phase. If lock acquisition fails after retries, capture proceeds without the lock (rare race window; atomic rename still prevents torn writes).
+- **Capture mode captures ALL severities**: The baseline intentionally records findings below the caller's `severity_threshold` so a later threshold relaxation does not retroactively classify pre-existing findings as NEW. Threshold filtering is the diff caller's responsibility, not the baseline's.

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -952,6 +952,9 @@ All other gates: failure → return to coder. No self-fixes. No workarounds.
 5a-bis. **DARK MATTER CO-CHANGE DETECTION**: After declaring scope but BEFORE finalizing the task file list, call knowledge_recall with query hidden-coupling primaryFile where primaryFile is the first file in the task's FILE list. Extract primaryFile from the task's FILE list (first file = primary). If results found, add those files to the task's AFFECTS scope with a BLAST RADIUS note. If no results or knowledge_recall unavailable, proceed gracefully without adding files. This is advisory — the architect may exclude files from scope if they are unrelated to the current task. Delegate to {{AGENT_PREFIX}}coder only after scope is declared.
 
 5b-PRE (required): Call \`declare_scope({ taskId, files })\` with the EXACT file list for this task — including any co-change files surfaced by 5a-bis. Skipping this call will cause every coder write to be BLOCKED by scope-guard. No \`declare_scope\` → no 5b delegation. See Rule 1a.
+    5b-BASE (required, once per task): Call \`sast_scan\` with \`{ capture_baseline: true, phase: <N>, changed_files: <files from 5b-PRE> }\` where \`<N>\` is the current phase number (extract from current task ID: task "3.2" → phase 3, task "1.5" → phase 1). The tool maintains \`.swarm/evidence/{phase}/sast-baseline.json\` as a phase-scoped, incrementally merged baseline of pre-existing SAST findings. Calling twice for the same files is safe (idempotent merge). Do NOT re-capture mid-task.
+    → REQUIRED: Print "sast-baseline: [WRITTEN — N fingerprints | MERGED — N fingerprints | SKIPPED — gate disabled | ERROR — details]"
+    → Subsequent \`pre_check_batch\` calls with \`phase: <N>\` will automatically diff against this baseline — only NEW findings (not in baseline) drive the fail verdict.
 5b. {{AGENT_PREFIX}}coder - Implement (if designer scaffold produced, include it as INPUT).
 5c. Run \`diff\` tool. If \`hasContractChanges\` → {{AGENT_PREFIX}}explorer integration analysis. If COMPATIBILITY SIGNALS=INCOMPATIBLE or MIGRATION_SURFACE=yes → coder retry. If COMPATIBILITY SIGNALS=COMPATIBLE and MIGRATION_SURFACE=no → proceed.
     → REQUIRED: Print "diff: [PASS | CONTRACT CHANGE — details]"
@@ -965,18 +968,19 @@ All other gates: failure → return to coder. No self-fixes. No workarounds.
     → REQUIRED: Print "lint: [PASS | FAIL — details]"
     5h. Run \`build_check\` tool. BUILD FAILS → return to coder. SUCCESS → proceed to pre_check_batch.
     → REQUIRED: Print "buildcheck: [PASS | FAIL | SKIPPED — no toolchain]"
-    5i. Run \`pre_check_batch\` tool → runs four verification tools in parallel (max 4 concurrent):
+    5i. Run \`pre_check_batch\` tool with \`phase: <N>\` (same phase number used in 5b-BASE) → runs four verification tools in parallel (max 4 concurrent):
     - lint:check (code quality verification)
     - secretscan (secret detection)
-    - sast_scan (static security analysis)
+    - sast_scan (static security analysis — diffs against phase baseline when phase provided)
     - quality_budget (maintainability metrics)
     → Returns { gates_passed, lint, secretscan, sast_scan, quality_budget, total_duration_ms }
+    → sast_scan result may include { new_findings, pre_existing_findings, baseline_used } when baseline diff is active.
     → If ALL FOUR tools have ran === false (lint.ran === false && secretscan.ran === false && sast_scan.ran === false && quality_budget.ran === false):
         → This is a SKIP - no tools actually ran. Print "pre_check_batch: SKIP — all tools ran===false (no files to check or tools not available)" and proceed to {{AGENT_PREFIX}}reviewer.
     → Else if gates_passed === false: read individual tool results, identify which tool(s) failed, return structured rejection to {{AGENT_PREFIX}}coder with specific tool failures. Do NOT call {{AGENT_PREFIX}}reviewer.
-    → If gates_passed === true AND sast_preexisting_findings is present: proceed to {{AGENT_PREFIX}}reviewer. Include the pre-existing SAST findings in the reviewer delegation context with instruction: "SAST TRIAGE REQUIRED: The following HIGH/CRITICAL SAST findings exist on unchanged lines in this changeset. Verify these are acceptable pre-existing conditions and do not interact with the new changes." Do NOT return to coder for pre-existing findings on unchanged code.
+    → If gates_passed === true AND sast_preexisting_findings is present: proceed to {{AGENT_PREFIX}}reviewer. Include the pre-existing SAST findings in the reviewer delegation context with instruction: "SAST TRIAGE REQUIRED: The following SAST findings existed before this task began (from phase baseline or unchanged lines). Verify these are acceptable pre-existing conditions and do not interact with the new changes." Do NOT return to coder for pre-existing findings.
     → If gates_passed === true (no sast_preexisting_findings): proceed to {{AGENT_PREFIX}}reviewer.
-    → REQUIRED: Print "pre_check_batch: [PASS — all gates passed | PASS — pre-existing SAST findings on unchanged lines (N findings, reviewer triage) | FAIL — [gate]: [details]]"
+    → REQUIRED: Print "pre_check_batch: [PASS — all gates passed | PASS — pre-existing SAST findings (N findings, reviewer triage) | FAIL — [gate]: [details]]"
 
 ⚠️ pre_check_batch SCOPE BOUNDARY:
 pre_check_batch runs FOUR automated tools: lint:check, secretscan, sast_scan, quality_budget.

--- a/src/config/evidence-schema.ts
+++ b/src/config/evidence-schema.ts
@@ -206,23 +206,21 @@ export const PlaceholderEvidenceSchema = BaseEvidenceSchema.extend({
 });
 export type PlaceholderEvidence = z.infer<typeof PlaceholderEvidenceSchema>;
 
+export const SastFindingSchema = z.object({
+	rule_id: z.string(),
+	severity: z.enum(['critical', 'high', 'medium', 'low']),
+	message: z.string(),
+	location: z.object({
+		file: z.string(),
+		line: z.number().int(),
+		column: z.number().int().optional(),
+	}),
+	remediation: z.string().optional(),
+});
+
 export const SastEvidenceSchema = BaseEvidenceSchema.extend({
 	type: z.literal('sast'),
-	findings: z
-		.array(
-			z.object({
-				rule_id: z.string(),
-				severity: z.enum(['critical', 'high', 'medium', 'low']),
-				message: z.string(),
-				location: z.object({
-					file: z.string(),
-					line: z.number().int(),
-					column: z.number().int().optional(),
-				}),
-				remediation: z.string().optional(),
-			}),
-		)
-		.default([]),
+	findings: z.array(SastFindingSchema).default([]),
 	engine: z.enum(['tier_a', 'tier_a+tier_b']),
 	files_scanned: z.number().int(),
 	findings_count: z.number().int(),
@@ -232,6 +230,10 @@ export const SastEvidenceSchema = BaseEvidenceSchema.extend({
 		medium: z.number().int(),
 		low: z.number().int(),
 	}),
+	// Baseline-diffing fields (optional — present when baseline diff was active)
+	new_findings: z.array(SastFindingSchema).optional(),
+	pre_existing_findings: z.array(SastFindingSchema).optional(),
+	baseline_used: z.boolean().optional(),
 });
 export type SastEvidence = z.infer<typeof SastEvidenceSchema>;
 

--- a/src/tools/pre-check-batch.ts
+++ b/src/tools/pre-check-batch.ts
@@ -42,6 +42,14 @@ export interface PreCheckBatchInput {
 	sast_threshold?: 'low' | 'medium' | 'high' | 'critical';
 	/** Optional plugin config */
 	config?: PluginConfig;
+	/**
+	 * Current phase number (positive integer >= 1).
+	 * When provided, enables SAST baseline diffing: only findings absent from the
+	 * phase-scoped baseline (.swarm/evidence/{phase}/sast-baseline.json) drive the
+	 * fail verdict. Capture the baseline before first coder delegation via sast_scan
+	 * with capture_baseline:true.
+	 */
+	phase?: number;
 }
 
 export interface ToolResult<T> {
@@ -617,13 +625,18 @@ async function runSastScanWrapped(
 	directory: string,
 	severityThreshold: 'low' | 'medium' | 'high' | 'critical',
 	config?: PluginConfig,
+	phase?: number,
 ): Promise<ToolResult<SastScanResult>> {
 	const start = process.hrtime.bigint();
 
 	try {
 		const result = await runWithTimeout(
 			sastScan(
-				{ changed_files: changedFiles, severity_threshold: severityThreshold },
+				{
+					changed_files: changedFiles,
+					severity_threshold: severityThreshold,
+					phase,
+				},
 				directory,
 				config,
 			),
@@ -676,8 +689,25 @@ async function runQualityBudgetWrapped(
 
 // ============ Changed-Line Detection ============
 
-/** Severity levels that trigger the gate */
+/** Severity levels that trigger the gate (legacy changed-line triage) */
 const GATE_SEVERITIES = new Set(['high', 'critical']);
+
+const SEVERITY_ORDER_PCB: Record<string, number> = {
+	low: 0,
+	medium: 1,
+	high: 2,
+	critical: 3,
+};
+
+/** Whether a finding severity meets or exceeds the given threshold. */
+function meetsThresholdForTriage(
+	severity: string,
+	threshold: 'low' | 'medium' | 'high' | 'critical',
+): boolean {
+	return (
+		(SEVERITY_ORDER_PCB[severity] ?? 0) >= (SEVERITY_ORDER_PCB[threshold] ?? 1)
+	);
+}
 
 /**
  * Run a git diff command and return stdout, or null on failure.
@@ -850,7 +880,7 @@ export async function runPreCheckBatch(
 	const effectiveWorkspaceDir = (workspaceDir ||
 		input.directory ||
 		contextDir) as string;
-	const { files, directory, sast_threshold = 'medium', config } = input;
+	const { files, directory, sast_threshold = 'medium', config, phase } = input;
 
 	// Validate directory
 	const dirError = validateDirectory(directory, effectiveWorkspaceDir);
@@ -939,7 +969,13 @@ export async function runPreCheckBatch(
 			limit(() => runLintWrapped(changedFiles, directory, config)),
 			limit(() => runSecretscanWrapped(changedFiles, directory, config)),
 			limit(() =>
-				runSastScanWrapped(changedFiles, directory, sast_threshold, config),
+				runSastScanWrapped(
+					changedFiles,
+					directory,
+					sast_threshold,
+					config,
+					phase,
+				),
 			),
 			limit(() => runQualityBudgetWrapped(changedFiles, directory, config)),
 		]);
@@ -1010,9 +1046,31 @@ export async function runPreCheckBatch(
 	// Check SAST scan (hard gate with pre-existing finding classification)
 	let sastPreexistingFindings: SastScanFinding[] | undefined;
 	if (sastScanResult.ran && sastScanResult.result) {
-		if (sastScanResult.result.verdict === 'fail') {
-			// Classify HIGH/CRITICAL findings as new vs pre-existing
-			const gateFindings = sastScanResult.result.findings.filter((f) =>
+		const sastResult = sastScanResult.result;
+
+		if (sastResult.baseline_used && sastResult.pre_existing_findings?.length) {
+			// Baseline diff mode: pre_existing_findings come from the phase baseline.
+			// Populate reviewer triage regardless of verdict (verdict is already driven
+			// by new_findings only inside sastScan). Use sast_threshold as triage filter
+			// so mediums are not silently dropped when threshold is 'medium' or lower.
+			sastPreexistingFindings = sastResult.pre_existing_findings.filter((f) =>
+				meetsThresholdForTriage(f.severity, sast_threshold),
+			);
+			if (sastPreexistingFindings.length > 0) {
+				warn(
+					`pre_check_batch: SAST baseline diff found ${sastPreexistingFindings.length} pre-existing finding(s) - passing to reviewer for triage`,
+				);
+			}
+			// Verdict is already correctly set by sastScan — do not override.
+			if (sastResult.verdict === 'fail') {
+				gatesPassed = false;
+				warn(
+					`pre_check_batch: SAST scan found new findings above threshold - GATE FAILED`,
+				);
+			}
+		} else if (sastResult.verdict === 'fail') {
+			// Legacy mode (no baseline): classify HIGH/CRITICAL findings by changed lines
+			const gateFindings = sastResult.findings.filter((f) =>
 				GATE_SEVERITIES.has(f.severity),
 			);
 
@@ -1111,6 +1169,14 @@ export const pre_check_batch: ReturnType<typeof tool> = createSwarmTool({
 			.optional()
 			.describe(
 				'Minimum severity for SAST findings to cause failure (default: medium)',
+			),
+		phase: tool.schema
+			.number()
+			.int()
+			.min(1)
+			.optional()
+			.describe(
+				'Current phase number (positive integer >= 1). When provided, enables SAST baseline diffing: only findings absent from the phase-scoped baseline fail the gate.',
 			),
 	},
 	async execute(args: unknown, directory: string): Promise<string> {
@@ -1213,12 +1279,21 @@ export const pre_check_batch: ReturnType<typeof tool> = createSwarmTool({
 
 		// Run pre-check batch
 		try {
+			const rawPhase = (typedArgs as unknown as Record<string, unknown>).phase;
+			const safePhase =
+				typeof rawPhase === 'number' &&
+				Number.isInteger(rawPhase) &&
+				rawPhase >= 1
+					? rawPhase
+					: undefined;
+
 			const result = await runPreCheckBatch(
 				{
 					files: typedArgs.files,
 					directory: resolvedDirectory,
 					sast_threshold: typedArgs.sast_threshold,
 					config: typedArgs.config,
+					phase: safePhase,
 				},
 				workspaceAnchor,
 				directory,

--- a/src/tools/pre-check-batch.ts
+++ b/src/tools/pre-check-batch.ts
@@ -1048,18 +1048,20 @@ export async function runPreCheckBatch(
 	if (sastScanResult.ran && sastScanResult.result) {
 		const sastResult = sastScanResult.result;
 
-		if (sastResult.baseline_used && sastResult.pre_existing_findings?.length) {
-			// Baseline diff mode: pre_existing_findings come from the phase baseline.
-			// Populate reviewer triage regardless of verdict (verdict is already driven
-			// by new_findings only inside sastScan). Use sast_threshold as triage filter
-			// so mediums are not silently dropped when threshold is 'medium' or lower.
-			sastPreexistingFindings = sastResult.pre_existing_findings.filter((f) =>
-				meetsThresholdForTriage(f.severity, sast_threshold),
-			);
-			if (sastPreexistingFindings.length > 0) {
-				warn(
-					`pre_check_batch: SAST baseline diff found ${sastPreexistingFindings.length} pre-existing finding(s) - passing to reviewer for triage`,
+		if (sastResult.baseline_used) {
+			// Baseline diff mode: verdict is driven ONLY by new_findings in sastScan.
+			// Populate reviewer triage with pre_existing_findings (if any), regardless of verdict.
+			// Use sast_threshold as triage filter so mediums are not silently dropped when
+			// threshold is 'medium' or lower.
+			if (sastResult.pre_existing_findings && sastResult.pre_existing_findings.length > 0) {
+				sastPreexistingFindings = sastResult.pre_existing_findings.filter((f) =>
+					meetsThresholdForTriage(f.severity, sast_threshold),
 				);
+				if (sastPreexistingFindings.length > 0) {
+					warn(
+						`pre_check_batch: SAST baseline diff found ${sastPreexistingFindings.length} pre-existing finding(s) - passing to reviewer for triage`,
+					);
+				}
 			}
 			// Verdict is already correctly set by sastScan — do not override.
 			if (sastResult.verdict === 'fail') {

--- a/src/tools/pre-check-batch.ts
+++ b/src/tools/pre-check-batch.ts
@@ -1053,7 +1053,10 @@ export async function runPreCheckBatch(
 			// Populate reviewer triage with pre_existing_findings (if any), regardless of verdict.
 			// Use sast_threshold as triage filter so mediums are not silently dropped when
 			// threshold is 'medium' or lower.
-			if (sastResult.pre_existing_findings && sastResult.pre_existing_findings.length > 0) {
+			if (
+				sastResult.pre_existing_findings &&
+				sastResult.pre_existing_findings.length > 0
+			) {
 				sastPreexistingFindings = sastResult.pre_existing_findings.filter((f) =>
 					meetsThresholdForTriage(f.severity, sast_threshold),
 				);

--- a/src/tools/sast-baseline.ts
+++ b/src/tools/sast-baseline.ts
@@ -372,7 +372,10 @@ export async function captureOrMergeBaseline(
 			if (truncated) {
 				const survivingFiles = new Set<string>();
 				for (const finding of cappedSnapshot) {
-					const relFile = normalizeFindingPath(directory, finding.location.file);
+					const relFile = normalizeFindingPath(
+						directory,
+						finding.location.file,
+					);
 					survivingFiles.add(relFile);
 				}
 				cappedFilesIndexed = Array.from(survivingFiles);

--- a/src/tools/sast-baseline.ts
+++ b/src/tools/sast-baseline.ts
@@ -361,11 +361,22 @@ export async function captureOrMergeBaseline(
 
 			const truncated = mergedSnapshot.length > MAX_BASELINE_FINDINGS;
 			const cappedSnapshot = truncated
-				? mergedSnapshot.slice(0, MAX_BASELINE_FINDINGS)
+				? mergedSnapshot.slice(-MAX_BASELINE_FINDINGS)
 				: mergedSnapshot;
 			const cappedFingerprints = truncated
-				? mergedFingerprints.slice(0, MAX_BASELINE_FINDINGS)
+				? mergedFingerprints.slice(-MAX_BASELINE_FINDINGS)
 				: mergedFingerprints;
+
+			// When truncating, rebuild files_indexed to only include files with surviving fingerprints
+			let cappedFilesIndexed = mergedFilesIndexed;
+			if (truncated) {
+				const survivingFiles = new Set<string>();
+				for (const finding of cappedSnapshot) {
+					const relFile = normalizeFindingPath(directory, finding.location.file);
+					survivingFiles.add(relFile);
+				}
+				cappedFilesIndexed = Array.from(survivingFiles);
+			}
 
 			const now = new Date().toISOString();
 			const bundle: SastBaselineFile = {
@@ -374,7 +385,7 @@ export async function captureOrMergeBaseline(
 				created_at: existing.created_at,
 				updated_at: now,
 				engine,
-				files_indexed: mergedFilesIndexed,
+				files_indexed: cappedFilesIndexed,
 				fingerprints: cappedFingerprints,
 				findings_snapshot: cappedSnapshot,
 				truncated,

--- a/src/tools/sast-baseline.ts
+++ b/src/tools/sast-baseline.ts
@@ -1,0 +1,500 @@
+/**
+ * SAST Baseline — phase-scoped snapshot of pre-existing security findings.
+ *
+ * Enables baseline diffing so only NEW findings (introduced since baseline capture)
+ * drive the fail verdict in subsequent sast_scan calls.
+ *
+ * Storage: .swarm/evidence/{phase}/sast-baseline.json
+ *   Mirrors the phase-scoped convention used by write-drift-evidence.ts and
+ *   write-hallucination-evidence.ts (path.join('evidence', String(phase), filename)
+ *   passed to validateSwarmPath).
+ *
+ * Fingerprint format (stable):
+ *   `${relFile}|${rule_id}|${sha256(3lineWindow).slice(0,16)}|#${occurrenceIndex}`
+ *
+ * Fingerprint format (unstable — file unreadable or path escapes workspace):
+ *   `${relFile}|${rule_id}|L${line}|UNSTABLE|#${occurrenceIndex}`
+ *   Unstable fingerprints are ALWAYS treated as NEW findings (fail-closed).
+ *
+ * Merge semantics:
+ *   On every capture for a set of files, ALL prior fingerprints for those files
+ *   are removed (full prune, engine-agnostic) before inserting current findings.
+ *   This prevents stale cross-engine fingerprints from causing false-pass verdicts.
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { validateSwarmPath } from '../hooks/utils';
+import type { SastScanFinding } from './sast-scan';
+
+// ============ Constants ============
+
+export const BASELINE_SCHEMA_VERSION = '1.0.0' as const;
+
+/** Maximum findings to store in baseline (heuristic — open for tuning). */
+export const MAX_BASELINE_FINDINGS = 2000;
+
+/** Maximum bytes for the baseline JSON file (heuristic). */
+const MAX_BASELINE_BYTES = 2 * 1_048_576; // 2 MB
+
+/** Retry delays for advisory file-lock acquisition (ms). */
+const LOCK_RETRY_DELAYS_MS = [50, 100, 200, 400, 800];
+
+// ============ Types ============
+
+export interface SastBaselineFile {
+	schema_version: '1.0.0';
+	phase: number;
+	created_at: string;
+	updated_at: string;
+	engine: 'tier_a' | 'tier_a+tier_b';
+	/** Canonical relative paths of files indexed into this baseline. */
+	files_indexed: string[];
+	/** Fingerprint strings for all indexed findings. */
+	fingerprints: string[];
+	/** Full findings snapshot (for auditing / debugging). */
+	findings_snapshot: SastScanFinding[];
+	/** True if the snapshot was truncated at MAX_BASELINE_FINDINGS. */
+	truncated: boolean;
+}
+
+export type LoadBaselineResult =
+	| { status: 'found'; fingerprints: Set<string>; bundle: SastBaselineFile }
+	| { status: 'not_found' }
+	| { status: 'invalid_schema'; errors: string[] };
+
+export interface FingerprintResult {
+	fingerprint: string;
+	/** False when the file was unreadable or the path escapes the workspace. */
+	stable: boolean;
+}
+
+export interface IndexedFinding {
+	finding: SastScanFinding;
+	index: number;
+	stable: boolean;
+	fingerprint: string;
+}
+
+export type CaptureResult =
+	| { status: 'written'; path: string; fingerprint_count: number }
+	| { status: 'merged'; path: string; fingerprint_count: number }
+	| { status: 'error'; message: string };
+
+// ============ Path Utilities ============
+
+/**
+ * Return the canonical relative path for a finding file.
+ * Mirrors the normalization in pre-check-batch.ts classifySastFindings.
+ */
+export function normalizeFindingPath(directory: string, file: string): string {
+	const resolved = path.isAbsolute(file) ? file : path.resolve(directory, file);
+	const rel = path.relative(path.resolve(directory), resolved);
+	return rel.replace(/\\/g, '/');
+}
+
+function baselineRelPath(phase: number): string {
+	return path.join('evidence', String(phase), 'sast-baseline.json');
+}
+
+function tempRelPath(phase: number): string {
+	return path.join(
+		'evidence',
+		String(phase),
+		`sast-baseline.json.tmp.${Date.now()}.${process.pid}`,
+	);
+}
+
+function lockRelPath(phase: number): string {
+	return path.join('evidence', String(phase), 'sast-baseline.json.lock');
+}
+
+// ============ Fingerprinting ============
+
+function getLine(lines: string[], idx: number): string {
+	if (idx < 0 || idx >= lines.length) return '';
+	return (lines[idx] ?? '').trim();
+}
+
+/**
+ * Compute a stable or unstable fingerprint for a single finding.
+ *
+ * Stable uses a 3-line content window (N-1, N, N+1) so the fingerprint
+ * survives line-number shifts caused by insertions above the finding.
+ *
+ * Unstable is produced when the file cannot be read or the path escapes
+ * the workspace — such findings are always classified NEW (fail-closed).
+ */
+export function fingerprintFinding(
+	finding: SastScanFinding,
+	directory: string,
+	occurrenceIndex: number,
+): FingerprintResult {
+	const relFile = normalizeFindingPath(directory, finding.location.file);
+
+	if (relFile.startsWith('..')) {
+		return {
+			fingerprint: `${relFile}|${finding.rule_id}|L${finding.location.line}|UNSTABLE|#${occurrenceIndex}`,
+			stable: false,
+		};
+	}
+
+	const lineNum = finding.location.line; // 1-indexed
+
+	try {
+		const content = fs.readFileSync(finding.location.file, 'utf-8');
+		const lines = content.split('\n');
+		const idx = lineNum - 1; // 0-indexed
+		const window = [
+			getLine(lines, idx - 1),
+			getLine(lines, idx),
+			getLine(lines, idx + 1),
+		].join('\n');
+		const hash = crypto
+			.createHash('sha256')
+			.update(window)
+			.digest('hex')
+			.slice(0, 16);
+		return {
+			fingerprint: `${relFile}|${finding.rule_id}|${hash}|#${occurrenceIndex}`,
+			stable: true,
+		};
+	} catch {
+		return {
+			fingerprint: `${relFile}|${finding.rule_id}|L${lineNum}|UNSTABLE|#${occurrenceIndex}`,
+			stable: false,
+		};
+	}
+}
+
+/**
+ * Assign occurrence indices to a batch of findings.
+ *
+ * Two findings that produce the same (relFile, rule_id, contentHash) tuple
+ * — e.g., copy-pasted vulnerable lines — receive different indices so they
+ * get distinct fingerprints and can be individually classified.
+ */
+export function assignOccurrenceIndices(
+	findings: SastScanFinding[],
+	directory: string,
+): IndexedFinding[] {
+	const countMap = new Map<string, number>();
+
+	return findings.map((finding) => {
+		const relFile = normalizeFindingPath(directory, finding.location.file);
+		const lineNum = finding.location.line;
+
+		let baseKey: string;
+		try {
+			if (relFile.startsWith('..')) throw new Error('escapes workspace');
+			const content = fs.readFileSync(finding.location.file, 'utf-8');
+			const lines = content.split('\n');
+			const idx = lineNum - 1;
+			const window = [
+				getLine(lines, idx - 1),
+				getLine(lines, idx),
+				getLine(lines, idx + 1),
+			].join('\n');
+			const hash = crypto
+				.createHash('sha256')
+				.update(window)
+				.digest('hex')
+				.slice(0, 16);
+			baseKey = `${relFile}|${finding.rule_id}|${hash}`;
+		} catch {
+			baseKey = `${relFile}|${finding.rule_id}|L${lineNum}|UNSTABLE`;
+		}
+
+		const occIdx = countMap.get(baseKey) ?? 0;
+		countMap.set(baseKey, occIdx + 1);
+
+		const fp = fingerprintFinding(finding, directory, occIdx);
+		return {
+			finding,
+			index: occIdx,
+			stable: fp.stable,
+			fingerprint: fp.fingerprint,
+		};
+	});
+}
+
+// ============ File Lock ============
+
+async function acquireLock(lockPath: string): Promise<() => void> {
+	for (let attempt = 0; attempt <= LOCK_RETRY_DELAYS_MS.length; attempt++) {
+		try {
+			const fd = fs.openSync(lockPath, 'wx');
+			fs.closeSync(fd);
+			return () => {
+				try {
+					fs.unlinkSync(lockPath);
+				} catch {
+					/* best-effort cleanup */
+				}
+			};
+		} catch {
+			if (attempt < LOCK_RETRY_DELAYS_MS.length) {
+				await new Promise((resolve) =>
+					setTimeout(resolve, LOCK_RETRY_DELAYS_MS[attempt]),
+				);
+			}
+		}
+	}
+	// Could not acquire lock — proceed without it (concurrent merges are rare in practice)
+	return () => {};
+}
+
+// ============ Phase Validation ============
+
+function validatePhase(phase: number): string | null {
+	if (!Number.isInteger(phase) || phase < 1) {
+		return 'Invalid phase: must be a positive integer';
+	}
+	return null;
+}
+
+// ============ Capture / Merge ============
+
+/**
+ * Capture or merge SAST findings into the phase-scoped baseline.
+ *
+ * Merge semantics:
+ *   For every file in `scannedFiles`, ALL prior fingerprints for that file are
+ *   removed from the baseline before inserting the current scan's fingerprints.
+ *   This full-prune (engine-agnostic) prevents stale cross-engine entries from
+ *   causing false-pass verdicts on later full-engine diff scans.
+ *
+ * Severity threshold:
+ *   Callers MUST pass ALL findings regardless of severity threshold so the
+ *   baseline captures the full pre-existing surface. Threshold filtering is
+ *   the diff caller's responsibility.
+ *
+ * Idempotency:
+ *   Calling twice with identical inputs produces an identical baseline file.
+ *   Calling with a new file set adds/replaces only those files' fingerprints.
+ */
+export async function captureOrMergeBaseline(
+	directory: string,
+	phase: number,
+	findings: SastScanFinding[],
+	engine: 'tier_a' | 'tier_a+tier_b',
+	scannedFiles: string[],
+	opts?: { force?: boolean },
+): Promise<CaptureResult> {
+	const phaseError = validatePhase(phase);
+	if (phaseError) return { status: 'error', message: phaseError };
+
+	if (!scannedFiles || scannedFiles.length === 0) {
+		return {
+			status: 'error',
+			message: 'capture_baseline requires non-empty changed_files',
+		};
+	}
+
+	let baselinePath: string;
+	let tempPath: string;
+	let lockPath: string;
+	try {
+		baselinePath = validateSwarmPath(directory, baselineRelPath(phase));
+		tempPath = validateSwarmPath(directory, tempRelPath(phase));
+		lockPath = validateSwarmPath(directory, lockRelPath(phase));
+	} catch (e) {
+		return {
+			status: 'error',
+			message: e instanceof Error ? e.message : 'Path validation failed',
+		};
+	}
+
+	fs.mkdirSync(path.dirname(baselinePath), { recursive: true });
+
+	const releaseLock = await acquireLock(lockPath);
+	try {
+		// Load existing baseline
+		let existing: SastBaselineFile | null = null;
+		try {
+			const raw = fs.readFileSync(baselinePath, 'utf-8');
+			const parsed = JSON.parse(raw) as SastBaselineFile;
+			if (parsed.schema_version === BASELINE_SCHEMA_VERSION) {
+				existing = parsed;
+			}
+		} catch {
+			/* no baseline yet */
+		}
+
+		// Canonical scanned-file set for prune matching
+		const scannedRelFiles = new Set(
+			scannedFiles.map((f) => normalizeFindingPath(directory, f)),
+		);
+
+		// Compute fingerprints for current scan's findings
+		const indexed = assignOccurrenceIndices(findings, directory);
+
+		if (existing && !opts?.force) {
+			// Full prune: drop ALL prior fingerprints for rescanned files (engine-agnostic).
+			// Fingerprint format: `${relFile}|...` — relFile is the first `|`-delimited segment.
+			const prunedFingerprints = existing.fingerprints.filter((fp) => {
+				const relFile = fp.slice(0, fp.indexOf('|'));
+				return !scannedRelFiles.has(relFile);
+			});
+			const prunedSnapshot = existing.findings_snapshot.filter((f) => {
+				return !scannedRelFiles.has(
+					normalizeFindingPath(directory, f.location.file),
+				);
+			});
+			const prunedFilesIndexed = existing.files_indexed.filter(
+				(f) => !scannedRelFiles.has(f),
+			);
+
+			const mergedFingerprints = [
+				...prunedFingerprints,
+				...indexed.map((i) => i.fingerprint),
+			];
+			const mergedSnapshot = [
+				...prunedSnapshot,
+				...indexed.map((i) => i.finding),
+			];
+			const mergedFilesIndexed = [
+				...prunedFilesIndexed,
+				...Array.from(scannedRelFiles),
+			];
+
+			const truncated = mergedSnapshot.length > MAX_BASELINE_FINDINGS;
+			const cappedSnapshot = truncated
+				? mergedSnapshot.slice(0, MAX_BASELINE_FINDINGS)
+				: mergedSnapshot;
+			const cappedFingerprints = truncated
+				? mergedFingerprints.slice(0, MAX_BASELINE_FINDINGS)
+				: mergedFingerprints;
+
+			const now = new Date().toISOString();
+			const bundle: SastBaselineFile = {
+				schema_version: BASELINE_SCHEMA_VERSION,
+				phase,
+				created_at: existing.created_at,
+				updated_at: now,
+				engine,
+				files_indexed: mergedFilesIndexed,
+				fingerprints: cappedFingerprints,
+				findings_snapshot: cappedSnapshot,
+				truncated,
+			};
+
+			const json = JSON.stringify(bundle, null, 2);
+			if (json.length > MAX_BASELINE_BYTES) {
+				return {
+					status: 'error',
+					message: `Baseline would exceed size cap (${json.length} bytes > ${MAX_BASELINE_BYTES})`,
+				};
+			}
+			fs.writeFileSync(tempPath, json, 'utf-8');
+			fs.renameSync(tempPath, baselinePath);
+
+			return {
+				status: 'merged',
+				path: baselinePath,
+				fingerprint_count: cappedFingerprints.length,
+			};
+		}
+
+		// First write (or force)
+		const newFingerprints = indexed.map((i) => i.fingerprint);
+		const newSnapshot = indexed.map((i) => i.finding);
+		const truncated = newSnapshot.length > MAX_BASELINE_FINDINGS;
+		const cappedSnapshot = truncated
+			? newSnapshot.slice(0, MAX_BASELINE_FINDINGS)
+			: newSnapshot;
+		const cappedFingerprints = truncated
+			? newFingerprints.slice(0, MAX_BASELINE_FINDINGS)
+			: newFingerprints;
+
+		const now = new Date().toISOString();
+		const bundle: SastBaselineFile = {
+			schema_version: BASELINE_SCHEMA_VERSION,
+			phase,
+			created_at: now,
+			updated_at: now,
+			engine,
+			files_indexed: Array.from(scannedRelFiles),
+			fingerprints: cappedFingerprints,
+			findings_snapshot: cappedSnapshot,
+			truncated,
+		};
+
+		const json = JSON.stringify(bundle, null, 2);
+		if (json.length > MAX_BASELINE_BYTES) {
+			return {
+				status: 'error',
+				message: `Baseline would exceed size cap (${json.length} bytes > ${MAX_BASELINE_BYTES})`,
+			};
+		}
+		fs.writeFileSync(tempPath, json, 'utf-8');
+		fs.renameSync(tempPath, baselinePath);
+
+		return {
+			status: 'written',
+			path: baselinePath,
+			fingerprint_count: cappedFingerprints.length,
+		};
+	} finally {
+		releaseLock();
+	}
+}
+
+// ============ Load ============
+
+/**
+ * Load the SAST baseline for a given phase.
+ *
+ * Returns 'not_found' when no baseline file exists (first run for phase).
+ * Returns 'invalid_schema' when the file is present but unparseable.
+ */
+export function loadBaseline(
+	directory: string,
+	phase: number,
+): LoadBaselineResult {
+	const phaseError = validatePhase(phase);
+	if (phaseError) {
+		return { status: 'invalid_schema', errors: [phaseError] };
+	}
+
+	let baselinePath: string;
+	try {
+		baselinePath = validateSwarmPath(directory, baselineRelPath(phase));
+	} catch (e) {
+		return {
+			status: 'invalid_schema',
+			errors: [e instanceof Error ? e.message : 'Path validation failed'],
+		};
+	}
+
+	try {
+		const raw = fs.readFileSync(baselinePath, 'utf-8');
+		const parsed = JSON.parse(raw) as SastBaselineFile;
+		if (parsed.schema_version !== BASELINE_SCHEMA_VERSION) {
+			return {
+				status: 'invalid_schema',
+				errors: [`Unknown schema version: ${String(parsed.schema_version)}`],
+			};
+		}
+		if (!Array.isArray(parsed.fingerprints)) {
+			return {
+				status: 'invalid_schema',
+				errors: ['Missing or invalid fingerprints array'],
+			};
+		}
+		return {
+			status: 'found',
+			fingerprints: new Set(parsed.fingerprints),
+			bundle: parsed,
+		};
+	} catch (e) {
+		if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+			return { status: 'not_found' };
+		}
+		return {
+			status: 'invalid_schema',
+			errors: [e instanceof Error ? e.message : 'Failed to read baseline'],
+		};
+	}
+}

--- a/src/tools/sast-scan.ts
+++ b/src/tools/sast-scan.ts
@@ -17,6 +17,13 @@ import { executeRulesSync } from '../sast/rules/index';
 import { isSemgrepAvailable, runSemgrep } from '../sast/semgrep';
 import { warn } from '../utils';
 import { createSwarmTool } from './create-tool';
+import {
+	assignOccurrenceIndices,
+	type CaptureResult,
+	captureOrMergeBaseline,
+	loadBaseline,
+	MAX_BASELINE_FINDINGS,
+} from './sast-baseline';
 
 // ============ Types ============
 
@@ -25,6 +32,21 @@ export interface SastScanInput {
 	changed_files: string[];
 	/** Minimum severity that causes failure (default: 'medium') */
 	severity_threshold?: 'low' | 'medium' | 'high' | 'critical';
+	/**
+	 * When true, capture/merge a phase-scoped baseline snapshot and return
+	 * status:'baseline_captured'. Subsequent scans with the same phase will
+	 * diff against this baseline so only NEW findings drive the fail verdict.
+	 *
+	 * Capture mode ignores severity_threshold — all severities are recorded.
+	 * Requires `phase` to be provided.
+	 */
+	capture_baseline?: boolean;
+	/**
+	 * Current phase number (positive integer, >= 1). Required when
+	 * capture_baseline is true. When provided without capture_baseline, enables
+	 * baseline diff mode: only findings absent from the phase baseline fail.
+	 */
+	phase?: number;
 }
 
 export interface SastScanResult {
@@ -48,6 +70,19 @@ export interface SastScanResult {
 			low: number;
 		};
 	};
+	// Baseline-diffing fields — present when capture_baseline is true or a baseline was loaded
+	/** 'baseline_captured' when capture_baseline:true succeeded */
+	status?: 'baseline_captured' | 'baseline_merged';
+	/** Number of findings recorded in the baseline (capture mode only) */
+	finding_count?: number;
+	/** Findings NOT present in the baseline (diff mode only) */
+	new_findings?: SastScanFinding[];
+	/** Findings that match the baseline (diff mode only) */
+	pre_existing_findings?: SastScanFinding[];
+	/** True when a baseline was loaded and diff mode was active */
+	baseline_used?: boolean;
+	/** True when pre_existing_findings were truncated to fit result limits */
+	truncated_pre_existing?: boolean;
 }
 
 export interface SastScanFinding {
@@ -199,7 +234,12 @@ export async function sastScan(
 	directory: string,
 	config?: PluginConfig,
 ): Promise<SastScanResult> {
-	const { changed_files, severity_threshold = 'medium' } = input;
+	const {
+		changed_files,
+		severity_threshold = 'medium',
+		capture_baseline = false,
+		phase,
+	} = input;
 
 	// Check feature flag
 	if (config?.gates?.sast_scan?.enabled === false) {
@@ -224,6 +264,8 @@ export async function sastScan(
 	const allFindings: SastScanFinding[] = [];
 	let filesScanned = 0;
 	let _filesSkipped = 0;
+	/** Paths of files that were successfully scanned (for baseline capture). */
+	const scannedFilePaths: string[] = [];
 
 	// Check Semgrep availability once
 	const semgrepAvailable = isSemgrepAvailable();
@@ -324,6 +366,7 @@ export async function sastScan(
 		}
 
 		filesScanned++;
+		scannedFilePaths.push(resolvedPath);
 
 		// Limit files scanned
 		if (filesScanned >= MAX_FILES_SCANNED) {
@@ -394,29 +437,163 @@ export async function sastScan(
 		}
 	}
 
-	// Limit findings
-	let finalFindings = allFindings;
-	if (allFindings.length > MAX_FINDINGS) {
-		finalFindings = allFindings.slice(0, MAX_FINDINGS);
-		warn(
-			`SAST Scan: Found ${allFindings.length} findings, limiting to ${MAX_FINDINGS}`,
+	// ── Capture mode ─────────────────────────────────────────────────────────
+	// Records a baseline snapshot WITHOUT applying severity_threshold and WITHOUT
+	// the zero-coverage-fail invariant (capturing nothing is legitimate).
+	if (capture_baseline) {
+		if (phase === undefined || !Number.isInteger(phase) || phase < 1) {
+			// Capture without a valid phase is a hard error
+			const errorResult: SastScanResult = {
+				verdict: 'fail',
+				findings: allFindings.slice(0, MAX_FINDINGS),
+				summary: {
+					engine,
+					files_scanned: filesScanned,
+					findings_count: Math.min(allFindings.length, MAX_FINDINGS),
+					findings_by_severity: countBySeverity(
+						allFindings.slice(0, MAX_FINDINGS),
+					),
+				},
+			};
+			return errorResult;
+		}
+
+		// Use raised cap for baseline capture so mediums/lows aren't silently lost.
+		const captureFindings = allFindings.slice(0, MAX_BASELINE_FINDINGS);
+
+		const captureResult: CaptureResult = await captureOrMergeBaseline(
+			directory,
+			phase,
+			captureFindings,
+			engine,
+			scannedFilePaths,
 		);
+
+		// Even on capture error, return a pass so the architect flow continues —
+		// baseline failure is surfaced in status field and should be logged.
+		const captureStatus =
+			captureResult.status === 'written'
+				? 'baseline_captured'
+				: captureResult.status === 'merged'
+					? 'baseline_merged'
+					: undefined;
+
+		if (captureResult.status === 'error') {
+			warn(`SAST Baseline: capture failed — ${captureResult.message}`);
+		}
+
+		const finalFindings = allFindings.slice(0, MAX_FINDINGS);
+		const summary = {
+			engine,
+			files_scanned: filesScanned,
+			findings_count: finalFindings.length,
+			findings_by_severity: countBySeverity(finalFindings),
+		};
+
+		await saveEvidence(directory, 'sast_scan', {
+			task_id: 'sast_scan',
+			type: 'sast',
+			timestamp: new Date().toISOString(),
+			agent: 'sast_scan',
+			verdict: 'pass',
+			summary: `Baseline capture: scanned ${filesScanned} files, recorded ${captureFindings.length} finding(s)`,
+			...summary,
+			findings: finalFindings,
+			baseline_used: false,
+		});
+
+		return {
+			verdict: 'pass',
+			findings: finalFindings,
+			summary,
+			status: captureStatus,
+			finding_count:
+				captureResult.status !== 'error'
+					? captureResult.fingerprint_count
+					: undefined,
+			baseline_used: false,
+		};
+	}
+
+	// ── Diff mode (baseline-aware) ────────────────────────────────────────────
+	// When a phase is provided and a baseline exists, partition findings into
+	// new (not in baseline) vs pre_existing (in baseline). Only new findings
+	// drive the fail verdict. Severity threshold applied post-partition.
+	let newFindings: SastScanFinding[] | undefined;
+	let preExistingFindings: SastScanFinding[] | undefined;
+	let baselineUsed = false;
+	let truncatedPreExisting = false;
+
+	if (phase !== undefined && Number.isInteger(phase) && phase >= 1) {
+		const baselineResult = loadBaseline(directory, phase);
+
+		if (baselineResult.status === 'found') {
+			baselineUsed = true;
+			const baselineSet = baselineResult.fingerprints;
+
+			// Partition ALL raw findings (pre-truncation) — avoids false passes
+			// from new findings that would have been truncated before partitioning.
+			const indexed = assignOccurrenceIndices(allFindings, directory);
+
+			const rawNew: SastScanFinding[] = [];
+			const rawPreExisting: SastScanFinding[] = [];
+
+			for (const { finding, stable, fingerprint } of indexed) {
+				if (!stable || !baselineSet.has(fingerprint)) {
+					// Unstable fingerprint or not in baseline → treat as NEW (fail-closed)
+					rawNew.push(finding);
+				} else {
+					rawPreExisting.push(finding);
+				}
+			}
+
+			// Truncate per-bucket (new_findings take priority)
+			newFindings = rawNew.slice(0, MAX_FINDINGS);
+			const preExistingBudget = Math.max(0, MAX_FINDINGS - newFindings.length);
+			preExistingFindings = rawPreExisting.slice(0, preExistingBudget);
+			truncatedPreExisting = rawPreExisting.length > preExistingBudget;
+		} else if (baselineResult.status === 'invalid_schema') {
+			warn(
+				`SAST Baseline: could not load baseline for phase ${phase} — ${baselineResult.errors.join(', ')}. Falling back to legacy behavior.`,
+			);
+		}
+		// 'not_found' → silent legacy fallback (no baseline yet for this phase)
+	}
+
+	// ── Legacy verdict (no baseline) ─────────────────────────────────────────
+	let finalFindings: SastScanFinding[];
+	if (!baselineUsed) {
+		finalFindings = allFindings;
+		if (allFindings.length > MAX_FINDINGS) {
+			finalFindings = allFindings.slice(0, MAX_FINDINGS);
+			warn(
+				`SAST Scan: Found ${allFindings.length} findings, limiting to ${MAX_FINDINGS}`,
+			);
+		}
+	} else {
+		// findings[] = all findings (new + pre_existing) for backward compat with callers
+		finalFindings = [
+			...(newFindings ?? []),
+			...(preExistingFindings ?? []),
+		].slice(0, MAX_FINDINGS);
 	}
 
 	// Count by severity
 	const findingsBySeverity = countBySeverity(finalFindings);
 
-	// Determine verdict based on severity threshold
+	// Determine verdict:
+	// - Baseline mode: only new_findings (above threshold) drive fail
+	// - Legacy mode: all finalFindings (above threshold) drive fail
+	const verdictSource = baselineUsed ? (newFindings ?? []) : finalFindings;
 	let verdict: EvidenceVerdict = 'pass';
-	for (const finding of finalFindings) {
+	for (const finding of verdictSource) {
 		if (meetsThreshold(finding.severity, severity_threshold)) {
 			verdict = 'fail';
 			break;
 		}
 	}
 
-	// Zero-coverage fail: if enabled mode and no files were scanned, fail the verdict
-	// This ensures zero-scanned coverage cannot be treated as a successful security check
+	// Zero-coverage fail: preserved in both modes (only skip for capture mode, handled above)
 	if (filesScanned === 0) {
 		verdict = 'fail';
 	}
@@ -439,13 +616,27 @@ export async function sastScan(
 		summary: `Scanned ${filesScanned} files, found ${finalFindings.length} finding(s) using ${engine}`,
 		...summary,
 		findings: finalFindings,
+		...(baselineUsed && {
+			new_findings: newFindings,
+			pre_existing_findings: preExistingFindings,
+			baseline_used: true,
+		}),
 	});
 
-	return {
+	const result: SastScanResult = {
 		verdict,
 		findings: finalFindings,
 		summary,
 	};
+
+	if (baselineUsed) {
+		result.new_findings = newFindings;
+		result.pre_existing_findings = preExistingFindings;
+		result.baseline_used = true;
+		if (truncatedPreExisting) result.truncated_pre_existing = true;
+	}
+
+	return result;
 }
 
 // ============ Tool Definition ============
@@ -458,7 +649,7 @@ export async function sastScan(
  */
 export const sast_scan: ToolDefinition = createSwarmTool({
 	description:
-		'Static Application Security Testing (SAST) scan. Scans files for security vulnerabilities using built-in rules (Tier A) and optional Semgrep (Tier B). Returns structured findings with severity levels.',
+		'Static Application Security Testing (SAST) scan. Scans files for security vulnerabilities using built-in rules (Tier A) and optional Semgrep (Tier B). Supports phase-scoped baseline diffing: set capture_baseline:true before first coder delegation to snapshot pre-existing findings; subsequent scans with the same phase only fail on NEW findings.',
 	args: {
 		directory: tool.schema
 			.string()
@@ -472,6 +663,20 @@ export const sast_scan: ToolDefinition = createSwarmTool({
 			.optional()
 			.default('medium')
 			.describe('Minimum severity that causes failure'),
+		capture_baseline: tool.schema
+			.boolean()
+			.optional()
+			.describe(
+				'When true, capture/merge a phase-scoped baseline of pre-existing findings. Requires phase. Subsequent scans with phase only fail on NEW findings.',
+			),
+		phase: tool.schema
+			.number()
+			.int()
+			.min(1)
+			.optional()
+			.describe(
+				'Current phase number (positive integer >= 1). Required with capture_baseline. Enables baseline diff when provided on non-capture scans.',
+			),
 	},
 	execute: async (args, directory) => {
 		// Safe args extraction - guard against malformed args and malicious getters
@@ -479,10 +684,14 @@ export const sast_scan: ToolDefinition = createSwarmTool({
 			directory: string | undefined;
 			changed_files: string[] | undefined;
 			severity_threshold: 'low' | 'medium' | 'high' | 'critical' | undefined;
+			capture_baseline: boolean | undefined;
+			phase: number | undefined;
 		};
 
 		try {
 			if (args && typeof args === 'object') {
+				const rawPhase = (args as Record<string, unknown>).phase;
+				const rawCapture = (args as Record<string, unknown>).capture_baseline;
 				safeArgs = {
 					directory: args.directory as unknown as string | undefined,
 					changed_files: args.changed_files as unknown as string[] | undefined,
@@ -492,12 +701,23 @@ export const sast_scan: ToolDefinition = createSwarmTool({
 						| 'high'
 						| 'critical'
 						| undefined,
+					// Strict type guards: reject coerced/string values
+					phase:
+						typeof rawPhase === 'number' &&
+						Number.isInteger(rawPhase) &&
+						rawPhase >= 1
+							? rawPhase
+							: undefined,
+					capture_baseline:
+						typeof rawCapture === 'boolean' ? rawCapture : undefined,
 				};
 			} else {
 				safeArgs = {
 					directory: undefined,
 					changed_files: undefined,
 					severity_threshold: undefined,
+					capture_baseline: undefined,
+					phase: undefined,
 				};
 			}
 		} catch {
@@ -506,6 +726,8 @@ export const sast_scan: ToolDefinition = createSwarmTool({
 				directory: undefined,
 				changed_files: undefined,
 				severity_threshold: undefined,
+				capture_baseline: undefined,
+				phase: undefined,
 			};
 		}
 
@@ -532,6 +754,8 @@ export const sast_scan: ToolDefinition = createSwarmTool({
 		const input: SastScanInput = {
 			changed_files: safeArgs.changed_files ?? [],
 			severity_threshold: safeArgs.severity_threshold ?? 'medium',
+			capture_baseline: safeArgs.capture_baseline,
+			phase: safeArgs.phase,
 		};
 
 		const result = await sastScan(input, directory);

--- a/tests/unit/agents/architect-v6-prompt.test.ts
+++ b/tests/unit/agents/architect-v6-prompt.test.ts
@@ -551,8 +551,8 @@ describe('Architect Prompt v6.0 QA & Security Gates (Task 3.2)', () => {
 				prompt.indexOf('### MODE: EXECUTE'),
 				prompt.indexOf('### MODE: PHASE-WRAP'),
 			);
-			const buildPos = phase5Section.indexOf('build_check');
-			const precheckPos = phase5Section.indexOf('pre_check_batch');
+			const buildPos = phase5Section.indexOf('5h. Run `build_check`');
+			const precheckPos = phase5Section.indexOf('5i. Run `pre_check_batch`');
 			expect(buildPos).toBeLessThan(precheckPos);
 		});
 	});

--- a/tests/unit/tools/pre-check-batch.test.ts
+++ b/tests/unit/tools/pre-check-batch.test.ts
@@ -1373,3 +1373,214 @@ describe('Task 2.1: Fail-Closed for Invalid Scoped Files', () => {
 		expect(result.lint.ran).toBe(true);
 	});
 });
+
+// ============ SAST BASELINE DIFF MODE TESTS ============
+
+describe('SAST baseline diff mode', () => {
+	let tempDir: string;
+	let originalCwd: string;
+
+	beforeEach(() => {
+		originalCwd = process.cwd();
+		tempDir = createTempDir();
+		process.chdir(tempDir);
+
+		try {
+			fs.symlinkSync(
+				path.join(originalCwd, 'node_modules'),
+				path.join(tempDir, 'node_modules'),
+				'junction',
+			);
+		} catch {
+			// Symlink may already exist or fail on some platforms
+		}
+
+		mockDetectAvailableLinter.mockClear();
+		mockRunLint.mockClear();
+		mockRunSecretscan.mockClear();
+		mockSastScan.mockClear();
+		mockQualityBudget.mockClear();
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test('phase in tool schema: runPreCheckBatch accepts phase:1 without schema error', async () => {
+		fs.writeFileSync(path.join(tempDir, 'test.ts'), 'export const x = 1;\n');
+
+		const input: PreCheckBatchInput = {
+			files: ['test.ts'],
+			directory: tempDir,
+			phase: 1,
+		};
+
+		// Should not throw; a schema validation error would surface as a rejection or error in result
+		const result = await runPreCheckBatch(input);
+		expect(result).toBeDefined();
+		expect(result.sast_scan.ran).toBe(true);
+	});
+
+	test('phase is threaded to sastScan: mock receives phase:2', async () => {
+		fs.writeFileSync(path.join(tempDir, 'test.ts'), 'export const x = 1;\n');
+
+		const input: PreCheckBatchInput = {
+			files: ['test.ts'],
+			directory: tempDir,
+			phase: 2,
+		};
+
+		await runPreCheckBatch(input);
+
+		expect(mockSastScan).toHaveBeenCalled();
+		// The first argument to sastScan is the SastScanInput object
+		const callArgs = mockSastScan.mock.calls[0];
+		expect(callArgs).toBeDefined();
+		// callArgs[0] is the SastScanInput
+		const sastInput = callArgs[0] as { phase?: number };
+		expect(sastInput.phase).toBe(2);
+	});
+
+	test('sast_preexisting_findings populated when baseline_used:true and verdict:pass', async () => {
+		fs.writeFileSync(path.join(tempDir, 'test.ts'), 'export const x = 1;\n');
+
+		const highFinding = {
+			rule_id: 'sast/js-eval',
+			severity: 'high' as const,
+			message: 'Use of eval() is dangerous',
+			location: { file: path.join(tempDir, 'test.ts'), line: 1 },
+		};
+
+		mockSastScan.mockResolvedValueOnce({
+			verdict: 'pass' as const,
+			findings: [highFinding],
+			baseline_used: true,
+			pre_existing_findings: [highFinding],
+			new_findings: [],
+			summary: {
+				engine: 'tier_a' as const,
+				files_scanned: 1,
+				findings_count: 1,
+				findings_by_severity: { critical: 0, high: 1, medium: 0, low: 0 },
+			},
+		});
+
+		const input: PreCheckBatchInput = {
+			files: ['test.ts'],
+			directory: tempDir,
+			phase: 1,
+			sast_threshold: 'medium',
+		};
+
+		const result = await runPreCheckBatch(input);
+
+		// Gate passes because verdict is pass (only new findings drive fail in baseline mode)
+		expect(result.gates_passed).toBe(true);
+		// Pre-existing high finding should be surfaced for reviewer triage
+		expect(result.sast_preexisting_findings).toBeDefined();
+		expect(result.sast_preexisting_findings?.length).toBeGreaterThan(0);
+		expect(result.sast_preexisting_findings?.[0].rule_id).toBe('sast/js-eval');
+	});
+
+	test('baseline_used:true and verdict:fail (new finding): gates_passed false, sast_preexisting_findings has only pre-existing', async () => {
+		fs.writeFileSync(path.join(tempDir, 'test.ts'), 'export const x = 1;\n');
+
+		const preExistingFinding = {
+			rule_id: 'sast/js-eval',
+			severity: 'high' as const,
+			message: 'Pre-existing eval usage',
+			location: { file: path.join(tempDir, 'test.ts'), line: 1 },
+		};
+
+		const newFinding = {
+			rule_id: 'sast/js-command-injection',
+			severity: 'high' as const,
+			message: 'New command injection',
+			location: { file: path.join(tempDir, 'test.ts'), line: 5 },
+		};
+
+		mockSastScan.mockResolvedValueOnce({
+			verdict: 'fail' as const,
+			findings: [preExistingFinding, newFinding],
+			baseline_used: true,
+			pre_existing_findings: [preExistingFinding],
+			new_findings: [newFinding],
+			summary: {
+				engine: 'tier_a' as const,
+				files_scanned: 1,
+				findings_count: 2,
+				findings_by_severity: { critical: 0, high: 2, medium: 0, low: 0 },
+			},
+		});
+
+		const input: PreCheckBatchInput = {
+			files: ['test.ts'],
+			directory: tempDir,
+			phase: 1,
+			sast_threshold: 'medium',
+		};
+
+		const result = await runPreCheckBatch(input);
+
+		// New finding above threshold should fail the gate
+		expect(result.gates_passed).toBe(false);
+		// sast_preexisting_findings should contain only the pre-existing finding, not the new one
+		expect(result.sast_preexisting_findings).toBeDefined();
+		const preexistingIds = result.sast_preexisting_findings?.map(
+			(f) => f.rule_id,
+		);
+		expect(preexistingIds).toContain('sast/js-eval');
+		expect(preexistingIds).not.toContain('sast/js-command-injection');
+	});
+
+	test('legacy behavior unchanged: no baseline_used → changed-line classifier path used', async () => {
+		fs.writeFileSync(path.join(tempDir, 'test.ts'), 'export const x = 1;\n');
+
+		const highFinding = {
+			rule_id: 'sast/js-eval',
+			severity: 'high' as const,
+			message: 'eval usage',
+			location: { file: path.join(tempDir, 'test.ts'), line: 1 },
+		};
+
+		// Return without baseline_used — legacy mode
+		mockSastScan.mockResolvedValueOnce({
+			verdict: 'fail' as const,
+			findings: [highFinding],
+			// baseline_used intentionally absent (legacy)
+			summary: {
+				engine: 'tier_a' as const,
+				files_scanned: 1,
+				findings_count: 1,
+				findings_by_severity: { critical: 0, high: 1, medium: 0, low: 0 },
+			},
+		});
+
+		const input: PreCheckBatchInput = {
+			files: ['test.ts'],
+			directory: tempDir,
+			// no phase — pure legacy mode
+		};
+
+		const result = await runPreCheckBatch(input);
+
+		// SAST ran and returned fail verdict
+		expect(result.sast_scan.ran).toBe(true);
+		expect(result.sast_scan.result?.verdict).toBe('fail');
+		// The legacy changed-line classifier is invoked. In a temp dir without git history
+		// the classifier falls back to treating all findings as new (fail-closed),
+		// so gates should fail.
+		expect(result.gates_passed).toBe(false);
+	});
+
+	test('hint text unchanged: pre_check_batch hint mentions pre_check_batch(files, directory)', async () => {
+		// Verify the parallel pre-check hint still references the correct signature
+		const expectedHint =
+			'[SWARM HINT] Parallel pre-check enabled: call pre_check_batch(files, directory) after lint --fix and build_check to run lint:check + secretscan + sast_scan + quality_budget concurrently (max 4 parallel). Check gates_passed before calling @reviewer.';
+
+		expect(expectedHint).toContain('pre_check_batch(files, directory)');
+		expect(expectedHint).toContain('concurrently');
+		expect(expectedHint).toContain('Parallel pre-check enabled');
+	});
+});

--- a/tests/unit/tools/sast-baseline.test.ts
+++ b/tests/unit/tools/sast-baseline.test.ts
@@ -112,9 +112,13 @@ describe('sast-baseline', () => {
 			expect(r1.fingerprint).not.toBe(r2.fingerprint);
 		});
 
-		it('returns stable:false when file is unreadable (non-root only)', () => {
+		it('returns stable:false when file is unreadable (non-root, non-Windows only)', () => {
 			if (process.getuid && process.getuid() === 0) {
 				// root ignores chmod — skip
+				return;
+			}
+			if (process.platform === 'win32') {
+				// Windows permissions don't work the same way — skip
 				return;
 			}
 			const file = path.join(tempDir, 'unreadable.js');

--- a/tests/unit/tools/sast-baseline.test.ts
+++ b/tests/unit/tools/sast-baseline.test.ts
@@ -1,0 +1,575 @@
+/**
+ * SAST Baseline Tool Tests
+ * Comprehensive tests covering:
+ * - normalizeFindingPath
+ * - fingerprintFinding (stable/unstable, line-edge, path-escape)
+ * - assignOccurrenceIndices (single, copy-paste duplicates)
+ * - captureOrMergeBaseline (validation, first write, merge, size cap, prune)
+ * - loadBaseline (not_found, found, invalid_schema)
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+	assignOccurrenceIndices,
+	BASELINE_SCHEMA_VERSION,
+	captureOrMergeBaseline,
+	fingerprintFinding,
+	loadBaseline,
+	MAX_BASELINE_FINDINGS,
+	normalizeFindingPath,
+} from '../../../src/tools/sast-baseline';
+import type { SastScanFinding } from '../../../src/tools/sast-scan';
+
+// ============ Helpers ============
+
+function makeFinding(
+	file: string,
+	line: number,
+	ruleId = 'sast/js-eval',
+	severity: SastScanFinding['severity'] = 'high',
+): SastScanFinding {
+	return {
+		rule_id: ruleId,
+		severity,
+		message: 'Test finding',
+		location: { file, line },
+	};
+}
+
+describe('sast-baseline', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(tmpdir(), 'sast-baseline-test-'));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	// ============ normalizeFindingPath ============
+
+	describe('normalizeFindingPath', () => {
+		it('converts an absolute path inside directory to a relative path', () => {
+			const file = path.join(tempDir, 'src', 'foo.js');
+			const rel = normalizeFindingPath(tempDir, file);
+			expect(rel).toBe('src/foo.js');
+		});
+
+		it('converts a relative path by resolving against directory', () => {
+			const rel = normalizeFindingPath(tempDir, 'src/bar.ts');
+			expect(rel).toBe('src/bar.ts');
+		});
+
+		it('replaces backslashes with forward slashes', () => {
+			// Construct a path with backslashes manually to test the replacement
+			const winStyle = path.join(tempDir, 'src', 'foo.js').replace(/\//g, '\\');
+			const rel = normalizeFindingPath(tempDir, winStyle);
+			expect(rel).not.toContain('\\');
+		});
+
+		it('path outside directory starts with ..', () => {
+			const outsideFile = path.join(path.dirname(tempDir), 'other', 'evil.js');
+			const rel = normalizeFindingPath(tempDir, outsideFile);
+			expect(rel.startsWith('..')).toBe(true);
+		});
+
+		it('root-level file in directory returns just the filename', () => {
+			const file = path.join(tempDir, 'index.js');
+			const rel = normalizeFindingPath(tempDir, file);
+			expect(rel).toBe('index.js');
+		});
+	});
+
+	// ============ fingerprintFinding ============
+
+	describe('fingerprintFinding', () => {
+		it('returns stable:true and consistent fingerprint when file is readable', () => {
+			const file = path.join(tempDir, 'test.js');
+			fs.writeFileSync(file, 'line1\neval(x);\nline3\n');
+			const finding = makeFinding(file, 2);
+
+			const r1 = fingerprintFinding(finding, tempDir, 0);
+			const r2 = fingerprintFinding(finding, tempDir, 0);
+
+			expect(r1.stable).toBe(true);
+			expect(r1.fingerprint).toBe(r2.fingerprint);
+			expect(r1.fingerprint).not.toContain('UNSTABLE');
+		});
+
+		it('produces different fingerprints for different file content at same line', () => {
+			const file = path.join(tempDir, 'test.js');
+			fs.writeFileSync(file, 'line1\neval(x);\nline3\n');
+			const finding = makeFinding(file, 2);
+			const r1 = fingerprintFinding(finding, tempDir, 0);
+
+			fs.writeFileSync(file, 'line1\neval(y);\nline3\n');
+			const r2 = fingerprintFinding(finding, tempDir, 0);
+
+			expect(r1.fingerprint).not.toBe(r2.fingerprint);
+		});
+
+		it('returns stable:false when file is unreadable (non-root only)', () => {
+			if (process.getuid && process.getuid() === 0) {
+				// root ignores chmod — skip
+				return;
+			}
+			const file = path.join(tempDir, 'unreadable.js');
+			fs.writeFileSync(file, 'eval(x);');
+			fs.chmodSync(file, 0o000);
+
+			const finding = makeFinding(file, 1);
+			const result = fingerprintFinding(finding, tempDir, 0);
+
+			// restore for cleanup
+			fs.chmodSync(file, 0o644);
+
+			expect(result.stable).toBe(false);
+			expect(result.fingerprint).toContain('UNSTABLE');
+		});
+
+		it('returns stable:false when path escapes workspace (starts with ..)', () => {
+			const outsideFile = path.join(path.dirname(tempDir), 'evil.js');
+			// We do NOT create the file — the path-escape check happens before file I/O
+			const finding = makeFinding(outsideFile, 1);
+			const result = fingerprintFinding(finding, tempDir, 0);
+
+			expect(result.stable).toBe(false);
+			expect(result.fingerprint).toContain('UNSTABLE');
+		});
+
+		it('includes occurrence index in fingerprint', () => {
+			const file = path.join(tempDir, 'test.js');
+			fs.writeFileSync(file, 'eval(x);');
+			const finding = makeFinding(file, 1);
+
+			const r0 = fingerprintFinding(finding, tempDir, 0);
+			const r1 = fingerprintFinding(finding, tempDir, 1);
+
+			expect(r0.fingerprint).toContain('#0');
+			expect(r1.fingerprint).toContain('#1');
+			expect(r0.fingerprint).not.toBe(r1.fingerprint);
+		});
+
+		// Line-edge tests
+		it('does not throw and returns stable:true for a finding on line 1', () => {
+			const file = path.join(tempDir, 'edge.js');
+			fs.writeFileSync(file, 'eval(x);\nline2\nline3\n');
+			const finding = makeFinding(file, 1);
+
+			let result: ReturnType<typeof fingerprintFinding> | undefined;
+			expect(() => {
+				result = fingerprintFinding(finding, tempDir, 0);
+			}).not.toThrow();
+			expect(result!.stable).toBe(true);
+		});
+
+		it('does not throw and returns stable:true for a finding on the last line', () => {
+			const content = 'line1\nline2\neval(x);';
+			const file = path.join(tempDir, 'edge-last.js');
+			fs.writeFileSync(file, content);
+			const lines = content.split('\n');
+			const lastLine = lines.length;
+			const finding = makeFinding(file, lastLine);
+
+			let result: ReturnType<typeof fingerprintFinding> | undefined;
+			expect(() => {
+				result = fingerprintFinding(finding, tempDir, 0);
+			}).not.toThrow();
+			expect(result!.stable).toBe(true);
+		});
+
+		// Path-escape via finding.location.file
+		it('returns stable:false when finding.location.file is outside directory', () => {
+			const outsideFile = path.resolve(tempDir, '..', 'outside.js');
+			const finding = makeFinding(outsideFile, 1);
+			const result = fingerprintFinding(finding, tempDir, 0);
+
+			expect(result.stable).toBe(false);
+		});
+	});
+
+	// ============ assignOccurrenceIndices ============
+
+	describe('assignOccurrenceIndices', () => {
+		it('assigns index 0 to a single finding', () => {
+			const file = path.join(tempDir, 'single.js');
+			fs.writeFileSync(file, 'eval(x);');
+			const findings = [makeFinding(file, 1)];
+
+			const indexed = assignOccurrenceIndices(findings, tempDir);
+
+			expect(indexed).toHaveLength(1);
+			expect(indexed[0].index).toBe(0);
+			expect(indexed[0].fingerprint).toContain('#0');
+		});
+
+		it('assigns different indices to two identical findings on the same line (copy-paste)', () => {
+			const file = path.join(tempDir, 'copypaste.js');
+			// Both findings point to the same line with the same rule — same content window
+			fs.writeFileSync(file, 'eval(x);\n');
+			const f1 = makeFinding(file, 1);
+			const f2 = makeFinding(file, 1);
+			const findings = [f1, f2];
+
+			const indexed = assignOccurrenceIndices(findings, tempDir);
+
+			expect(indexed).toHaveLength(2);
+			expect(indexed[0].index).toBe(0);
+			expect(indexed[1].index).toBe(1);
+			// Fingerprints must differ
+			expect(indexed[0].fingerprint).not.toBe(indexed[1].fingerprint);
+			expect(indexed[0].fingerprint).toContain('#0');
+			expect(indexed[1].fingerprint).toContain('#1');
+		});
+
+		it('assigns independent indices to findings on different lines', () => {
+			const file = path.join(tempDir, 'multiline.js');
+			fs.writeFileSync(file, 'eval(a);\neval(b);\neval(c);\n');
+			const findings = [
+				makeFinding(file, 1),
+				makeFinding(file, 2),
+				makeFinding(file, 3),
+			];
+
+			const indexed = assignOccurrenceIndices(findings, tempDir);
+
+			// Each different line gives a different base key → each gets index 0
+			expect(indexed[0].index).toBe(0);
+			expect(indexed[1].index).toBe(0);
+			expect(indexed[2].index).toBe(0);
+			// All fingerprints are distinct
+			const fps = indexed.map((i) => i.fingerprint);
+			expect(new Set(fps).size).toBe(3);
+		});
+	});
+
+	// ============ captureOrMergeBaseline ============
+
+	describe('captureOrMergeBaseline', () => {
+		it('rejects phase 0 with status:error', async () => {
+			const file = path.join(tempDir, 'test.js');
+			fs.writeFileSync(file, 'eval(x);');
+			const result = await captureOrMergeBaseline(
+				tempDir,
+				0,
+				[makeFinding(file, 1)],
+				'tier_a',
+				[file],
+			);
+			expect(result.status).toBe('error');
+		});
+
+		it('rejects phase -1 with status:error', async () => {
+			const file = path.join(tempDir, 'test.js');
+			fs.writeFileSync(file, 'eval(x);');
+			const result = await captureOrMergeBaseline(
+				tempDir,
+				-1,
+				[makeFinding(file, 1)],
+				'tier_a',
+				[file],
+			);
+			expect(result.status).toBe('error');
+		});
+
+		it('rejects empty scannedFiles with status:error', async () => {
+			const result = await captureOrMergeBaseline(tempDir, 1, [], 'tier_a', []);
+			expect(result.status).toBe('error');
+		});
+
+		it('first write produces status:written', async () => {
+			const file = path.join(tempDir, 'app.js');
+			fs.writeFileSync(file, 'eval(x);');
+			const finding = makeFinding(file, 1);
+
+			const result = await captureOrMergeBaseline(
+				tempDir,
+				1,
+				[finding],
+				'tier_a',
+				[file],
+			);
+
+			expect(result.status).toBe('written');
+			if (result.status === 'written') {
+				expect(result.fingerprint_count).toBe(1);
+				expect(typeof result.path).toBe('string');
+			}
+		});
+
+		it('second call with same files produces status:merged', async () => {
+			const file = path.join(tempDir, 'app.js');
+			fs.writeFileSync(file, 'eval(x);');
+			const finding = makeFinding(file, 1);
+
+			await captureOrMergeBaseline(tempDir, 1, [finding], 'tier_a', [file]);
+
+			const result2 = await captureOrMergeBaseline(
+				tempDir,
+				1,
+				[finding],
+				'tier_a',
+				[file],
+			);
+
+			expect(result2.status).toBe('merged');
+		});
+
+		it('second call updates fingerprints when content changes (stale replaced)', async () => {
+			const file = path.join(tempDir, 'changing.js');
+			fs.writeFileSync(file, 'eval(old);');
+			const findingV1 = makeFinding(file, 1);
+
+			const r1 = await captureOrMergeBaseline(
+				tempDir,
+				1,
+				[findingV1],
+				'tier_a',
+				[file],
+			);
+			expect(r1.status).toBe('written');
+
+			// Load baseline v1 — record original fingerprints
+			const loadedV1 = loadBaseline(tempDir, 1);
+			expect(loadedV1.status).toBe('found');
+			const fpsV1 =
+				loadedV1.status === 'found' ? Array.from(loadedV1.fingerprints) : [];
+
+			// Change content and re-capture
+			fs.writeFileSync(file, 'eval(new_value);');
+			const findingV2 = makeFinding(file, 1);
+
+			const r2 = await captureOrMergeBaseline(
+				tempDir,
+				1,
+				[findingV2],
+				'tier_a',
+				[file],
+			);
+			expect(r2.status).toBe('merged');
+
+			const loadedV2 = loadBaseline(tempDir, 1);
+			expect(loadedV2.status).toBe('found');
+			const fpsV2 =
+				loadedV2.status === 'found' ? Array.from(loadedV2.fingerprints) : [];
+
+			// Old fingerprint must not appear in new baseline
+			for (const oldFp of fpsV1) {
+				expect(fpsV2).not.toContain(oldFp);
+			}
+		});
+
+		it('incremental merge of disjoint file sets — both files indexed after two captures', async () => {
+			const fileA = path.join(tempDir, 'a.js');
+			const fileB = path.join(tempDir, 'b.js');
+			fs.writeFileSync(fileA, 'eval(a);');
+			fs.writeFileSync(fileB, 'eval(b);');
+
+			// First capture: file A only
+			await captureOrMergeBaseline(
+				tempDir,
+				1,
+				[makeFinding(fileA, 1)],
+				'tier_a',
+				[fileA],
+			);
+
+			// Second capture: file B only
+			const r2 = await captureOrMergeBaseline(
+				tempDir,
+				1,
+				[makeFinding(fileB, 1)],
+				'tier_a',
+				[fileB],
+			);
+			expect(r2.status).toBe('merged');
+
+			// Both should be indexed
+			const loaded = loadBaseline(tempDir, 1);
+			expect(loaded.status).toBe('found');
+			if (loaded.status === 'found') {
+				const relA = path.relative(tempDir, fileA).replace(/\\/g, '/');
+				const relB = path.relative(tempDir, fileB).replace(/\\/g, '/');
+				expect(loaded.bundle.files_indexed).toContain(relA);
+				expect(loaded.bundle.files_indexed).toContain(relB);
+				expect(loaded.fingerprints.size).toBe(2);
+			}
+		});
+
+		it('returns status:error when JSON would exceed MAX_BASELINE_BYTES', async () => {
+			// Create a finding with an enormous message to inflate JSON size
+			const file = path.join(tempDir, 'big.js');
+			fs.writeFileSync(file, 'eval(x);');
+
+			// Build findings list with massive payloads that exceed 2MB
+			const bigMessage = 'x'.repeat(100_000);
+			const findings: SastScanFinding[] = Array.from(
+				{ length: 30 },
+				(_, i) => ({
+					rule_id: 'sast/js-eval',
+					severity: 'high' as const,
+					message: bigMessage,
+					location: { file, line: i + 1 },
+					remediation: bigMessage,
+				}),
+			);
+
+			const result = await captureOrMergeBaseline(
+				tempDir,
+				1,
+				findings,
+				'tier_a',
+				[file],
+			);
+
+			expect(result.status).toBe('error');
+			if (result.status === 'error') {
+				expect(result.message).toContain('size cap');
+			}
+		});
+	});
+
+	// ============ Full prune on re-scan ============
+
+	describe('Full prune on re-scan', () => {
+		it('old fingerprints for file A are gone after re-capturing file A with new findings', async () => {
+			const fileA = path.join(tempDir, 'prune.js');
+			fs.writeFileSync(fileA, 'eval(original);');
+
+			// First capture
+			const r1 = await captureOrMergeBaseline(
+				tempDir,
+				1,
+				[makeFinding(fileA, 1)],
+				'tier_a',
+				[fileA],
+			);
+			expect(r1.status).toBe('written');
+
+			const loadedV1 = loadBaseline(tempDir, 1);
+			expect(loadedV1.status).toBe('found');
+			const originalFps =
+				loadedV1.status === 'found' ? Array.from(loadedV1.fingerprints) : [];
+			expect(originalFps.length).toBeGreaterThan(0);
+
+			// Change file content and re-capture with a different finding
+			fs.writeFileSync(fileA, 'eval(updated_content);');
+			const r2 = await captureOrMergeBaseline(
+				tempDir,
+				1,
+				[makeFinding(fileA, 1, 'sast/js-dangerous-function')],
+				'tier_a',
+				[fileA],
+			);
+			expect(r2.status).toBe('merged');
+
+			const loadedV2 = loadBaseline(tempDir, 1);
+			expect(loadedV2.status).toBe('found');
+			if (loadedV2.status === 'found') {
+				for (const oldFp of originalFps) {
+					expect(loadedV2.fingerprints.has(oldFp)).toBe(false);
+				}
+			}
+		});
+	});
+
+	// ============ loadBaseline ============
+
+	describe('loadBaseline', () => {
+		it('returns not_found for a missing baseline file', () => {
+			const result = loadBaseline(tempDir, 1);
+			expect(result.status).toBe('not_found');
+		});
+
+		it('returns found with correct Set of fingerprints after a write', async () => {
+			const file = path.join(tempDir, 'load-test.js');
+			fs.writeFileSync(file, 'eval(x);');
+
+			const captureResult = await captureOrMergeBaseline(
+				tempDir,
+				1,
+				[makeFinding(file, 1)],
+				'tier_a',
+				[file],
+			);
+			expect(captureResult.status).toBe('written');
+
+			const loaded = loadBaseline(tempDir, 1);
+			expect(loaded.status).toBe('found');
+			if (loaded.status === 'found') {
+				expect(loaded.fingerprints instanceof Set).toBe(true);
+				expect(loaded.fingerprints.size).toBe(1);
+				expect(loaded.bundle.schema_version).toBe(BASELINE_SCHEMA_VERSION);
+				expect(loaded.bundle.phase).toBe(1);
+			}
+		});
+
+		it('returns invalid_schema for phase 0', () => {
+			const result = loadBaseline(tempDir, 0);
+			expect(result.status).toBe('invalid_schema');
+		});
+
+		it('returns invalid_schema for corrupted JSON', () => {
+			// Manually write a corrupted baseline file
+			const evidenceDir = path.join(tempDir, '.swarm', 'evidence', '1');
+			fs.mkdirSync(evidenceDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(evidenceDir, 'sast-baseline.json'),
+				'{ this is not valid JSON !!!',
+			);
+
+			const result = loadBaseline(tempDir, 1);
+			expect(result.status).toBe('invalid_schema');
+		});
+
+		it('returns invalid_schema for a baseline with wrong schema_version', () => {
+			const evidenceDir = path.join(tempDir, '.swarm', 'evidence', '2');
+			fs.mkdirSync(evidenceDir, { recursive: true });
+			const badBundle = {
+				schema_version: '0.0.1',
+				phase: 2,
+				created_at: new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+				engine: 'tier_a',
+				files_indexed: [],
+				fingerprints: [],
+				findings_snapshot: [],
+				truncated: false,
+			};
+			fs.writeFileSync(
+				path.join(evidenceDir, 'sast-baseline.json'),
+				JSON.stringify(badBundle, null, 2),
+			);
+
+			const result = loadBaseline(tempDir, 2);
+			expect(result.status).toBe('invalid_schema');
+		});
+
+		it('returns invalid_schema for a baseline with missing fingerprints array', () => {
+			const evidenceDir = path.join(tempDir, '.swarm', 'evidence', '3');
+			fs.mkdirSync(evidenceDir, { recursive: true });
+			const badBundle = {
+				schema_version: BASELINE_SCHEMA_VERSION,
+				phase: 3,
+				created_at: new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+				engine: 'tier_a',
+				files_indexed: [],
+				// fingerprints deliberately omitted
+				findings_snapshot: [],
+				truncated: false,
+			};
+			fs.writeFileSync(
+				path.join(evidenceDir, 'sast-baseline.json'),
+				JSON.stringify(badBundle, null, 2),
+			);
+
+			const result = loadBaseline(tempDir, 3);
+			expect(result.status).toBe('invalid_schema');
+		});
+	});
+});

--- a/tests/unit/tools/sast-scan.test.ts
+++ b/tests/unit/tools/sast-scan.test.ts
@@ -8,12 +8,13 @@
  * - Edge cases
  */
 
-import { beforeEach, describe, expect, it, vi } from 'bun:test';
+import { beforeEach, describe, expect, it, mock, vi } from 'bun:test';
 import * as fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import type { PluginConfig } from '../../../src/config';
 import { resetSemgrepCache } from '../../../src/sast/semgrep';
+import type { LoadBaselineResult } from '../../../src/tools/sast-baseline';
 import { type SastScanInput, sastScan } from '../../../src/tools/sast-scan';
 
 // Mock the saveEvidence function
@@ -33,6 +34,33 @@ vi.mock('../../../src/sast/semgrep', () => ({
 	}),
 	resetSemgrepCache: vi.fn(),
 }));
+
+// Mock sast-baseline I/O functions so tests don't write real files.
+// Use bun-native mock() + mock.module() so we can hold direct references
+// to the mock functions (vi.mocked() is not available in bun:test).
+// The real helpers (assignOccurrenceIndices, fingerprintFinding, etc.) are
+// re-exported from the actual module so sast-scan.ts logic stays intact.
+const mockCaptureOrMergeBaseline = mock(async () => ({
+	status: 'written' as const,
+	path: '/fake/sast-baseline.json',
+	fingerprint_count: 1,
+}));
+const mockLoadBaseline = mock(
+	(): LoadBaselineResult => ({ status: 'not_found' }),
+);
+
+mock.module('../../../src/tools/sast-baseline', () => {
+	// Spread the real module so non-I/O exports (assignOccurrenceIndices,
+	// MAX_BASELINE_FINDINGS, etc.) remain functional.
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const actual =
+		require('../../../src/tools/sast-baseline') as typeof import('../../../src/tools/sast-baseline');
+	return {
+		...actual,
+		captureOrMergeBaseline: mockCaptureOrMergeBaseline,
+		loadBaseline: mockLoadBaseline,
+	};
+});
 
 describe('sastScan', () => {
 	let tempDir: string;
@@ -702,5 +730,221 @@ const key = "sk-1234567890";`,
 			expect(result.findings).toEqual([]);
 			expect(result.summary.files_scanned).toBe(0);
 		});
+	});
+});
+
+describe('Baseline diffing', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(tmpdir(), 'sast-baseline-test-'));
+		mockSemgrepAvailable = false;
+		vi.clearAllMocks();
+		// Reset defaults after clearAllMocks — use direct mock references
+		// (vi.mocked() is not available in bun:test).
+		mockCaptureOrMergeBaseline.mockResolvedValue({
+			status: 'written',
+			path: '/fake/sast-baseline.json',
+			fingerprint_count: 1,
+		});
+		mockLoadBaseline.mockReturnValue({ status: 'not_found' });
+	});
+
+	it('capture mode returns status:baseline_captured and finding_count', async () => {
+		const testFile = path.join(tempDir, 'vuln.js');
+		fs.writeFileSync(testFile, 'eval("x");');
+
+		const input: SastScanInput = {
+			changed_files: [testFile],
+			capture_baseline: true,
+			phase: 1,
+		};
+
+		const result = await sastScan(input, tempDir);
+
+		expect(result.status).toBe('baseline_captured');
+		expect(typeof result.finding_count).toBe('number');
+		expect(result.finding_count).toBeGreaterThanOrEqual(0);
+		expect(result.verdict).toBe('pass');
+		expect(Array.isArray(result.findings)).toBe(true);
+		expect(result.findings.length).toBeGreaterThanOrEqual(0);
+	});
+
+	it('capture mode without phase returns verdict:fail (hard error, no crash)', async () => {
+		const testFile = path.join(tempDir, 'vuln.js');
+		fs.writeFileSync(testFile, 'eval("x");');
+
+		const input: SastScanInput = {
+			changed_files: [testFile],
+			capture_baseline: true,
+			// phase intentionally omitted
+		};
+
+		const result = await sastScan(input, tempDir);
+
+		// phase is required for capture — must fail but not crash
+		expect(result.verdict).toBe('fail');
+	});
+
+	it('diff mode: all findings pre-existing → verdict pass', async () => {
+		const testFile = path.join(tempDir, 'vuln.js');
+		fs.writeFileSync(testFile, 'eval("x");');
+
+		// Simulate a baseline that already contains the finding's fingerprint
+		// by making loadBaseline return 'found' with a Set containing a wildcard key
+		// that assignOccurrenceIndices will produce for this file.
+		// The easiest approach: pre-build the fingerprint the same way sastScan would.
+		// Instead, use a real capture + diff against real files to avoid coupling to internals.
+		// We mock loadBaseline to return a Set that contains any fingerprint
+		// by using a Proxy-backed Set that always returns true for .has().
+		const alwaysFoundSet = new Proxy(new Set<string>(), {
+			get(target, prop) {
+				if (prop === 'has') return () => true;
+				return Reflect.get(target, prop);
+			},
+		});
+
+		mockLoadBaseline.mockReturnValueOnce({
+			status: 'found',
+			fingerprints: alwaysFoundSet,
+			bundle: {
+				schema_version: '1.0.0',
+				phase: 1,
+				created_at: new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+				engine: 'tier_a',
+				files_indexed: [testFile],
+				fingerprints: [],
+				findings_snapshot: [],
+				truncated: false,
+			},
+		});
+
+		const input: SastScanInput = {
+			changed_files: [testFile],
+			phase: 1,
+		};
+
+		const result = await sastScan(input, tempDir);
+
+		expect(result.baseline_used).toBe(true);
+		expect(result.verdict).toBe('pass');
+		expect(result.new_findings?.length).toBe(0);
+		expect(result.pre_existing_findings?.length ?? 0).toBeGreaterThan(0);
+	});
+
+	it('diff mode: new finding → verdict fail', async () => {
+		// Baseline is empty (no known fingerprints) but file has eval() → new finding
+		mockLoadBaseline.mockReturnValueOnce({
+			status: 'found',
+			fingerprints: new Set<string>(), // empty — nothing pre-existing
+			bundle: {
+				schema_version: '1.0.0',
+				phase: 1,
+				created_at: new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+				engine: 'tier_a',
+				files_indexed: [],
+				fingerprints: [],
+				findings_snapshot: [],
+				truncated: false,
+			},
+		});
+
+		const testFile = path.join(tempDir, 'new_vuln.js');
+		fs.writeFileSync(testFile, 'eval("x");');
+
+		const input: SastScanInput = {
+			changed_files: [testFile],
+			phase: 1,
+		};
+
+		const result = await sastScan(input, tempDir);
+
+		expect(result.verdict).toBe('fail');
+		expect(result.baseline_used).toBe(true);
+		expect(result.new_findings?.length ?? 0).toBeGreaterThan(0);
+	});
+
+	it('zero-coverage-fail is preserved under baseline mode', async () => {
+		// Even with a phase, scanning zero files should still fail
+		mockLoadBaseline.mockReturnValueOnce({
+			status: 'found',
+			fingerprints: new Set<string>(),
+			bundle: {
+				schema_version: '1.0.0',
+				phase: 1,
+				created_at: new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+				engine: 'tier_a',
+				files_indexed: [],
+				fingerprints: [],
+				findings_snapshot: [],
+				truncated: false,
+			},
+		});
+
+		const input: SastScanInput = {
+			changed_files: [],
+			phase: 1,
+		};
+
+		const result = await sastScan(input, tempDir);
+
+		expect(result.verdict).toBe('fail');
+	});
+
+	it('gate disabled + capture_baseline: returns pass and does NOT write baseline file', async () => {
+		const testFile = path.join(tempDir, 'vuln.js');
+		fs.writeFileSync(testFile, 'eval("x");');
+
+		const config = {
+			gates: {
+				sast_scan: {
+					enabled: false,
+				},
+			},
+		} as unknown as PluginConfig;
+
+		const input: SastScanInput = {
+			changed_files: [testFile],
+			capture_baseline: true,
+			phase: 1,
+		};
+
+		const result = await sastScan(input, tempDir, config);
+
+		expect(result.verdict).toBe('pass');
+		// captureOrMergeBaseline must NOT have been called (gate is disabled, early return)
+		expect(mockCaptureOrMergeBaseline).not.toHaveBeenCalled();
+		// No physical baseline file should have been written
+		const baselinePath = path.join(
+			tempDir,
+			'.swarm',
+			'evidence',
+			'1',
+			'sast-baseline.json',
+		);
+		expect(fs.existsSync(baselinePath)).toBe(false);
+	});
+
+	it('legacy behavior (no phase): baseline_used is falsy, verdict driven by findings', async () => {
+		const testFile = path.join(tempDir, 'vuln.js');
+		fs.writeFileSync(testFile, 'eval("x");');
+
+		const input: SastScanInput = {
+			changed_files: [testFile],
+			// no phase — legacy mode
+		};
+
+		const result = await sastScan(input, tempDir);
+
+		// No baseline participation
+		expect(result.baseline_used).toBeFalsy();
+		// loadBaseline should NOT have been called
+		expect(mockLoadBaseline).not.toHaveBeenCalled();
+		// Verdict should be driven by findings the normal way
+		expect(result.findings.length).toBeGreaterThan(0);
+		expect(result.verdict).toBe('fail');
 	});
 });


### PR DESCRIPTION
## Summary
- Resolves #489 by introducing phase-scoped SAST baseline diffing: baseline captured once per task, then only NEW findings drive the `sast_scan` fail verdict while pre-existing findings become triage context.
- New `src/tools/sast-baseline.ts` with atomic capture/merge, 3-line SHA-256 fingerprints (resistant to line shifts), occurrence-indexed disambiguation (copy-paste safe), full-prune-on-rescan (engine-agnostic), and fail-closed unstable fingerprints for unreadable files or path escapes.
- Architect prompt gets step 5b-BASE (capture baseline before code changes) and step 5i threads `phase` through to `pre_check_batch`; all new input args and result fields are optional so legacy behavior is preserved.

## Test plan
- [x] `bun --smol test tests/unit/tools/sast-baseline.test.ts` — 31 pass (path normalization, fingerprint edge cases, occurrence-index disambiguation, capture/merge validation, full-prune, size cap, loadBaseline states)
- [x] `bun --smol test tests/unit/tools/sast-scan.test.ts` — 42 pass (capture mode, diff mode all-preexisting, diff mode new finding, zero-coverage-fail preserved, legacy)
- [x] `bun --smol test tests/unit/tools/pre-check-batch.test.ts` — 72 pass (baseline triage preservation, threshold handling, legacy path)
- [x] `bun --smol test tests/unit/tools/*.test.ts` loop — all 60 tool test files pass
- [x] `bun --smol test tests/unit/agents/*.test.ts` loop — no failures
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bunx biome ci` on all changed files — clean
- [x] Independent adversarial review + completeness audit performed; no blocking bugs found
