### PR TITLE
fix(repo-graph): drop import specifiers with control chars to prevent graph build failure

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -64063,7 +64063,8 @@ function validateGraphNode(node) {
       throw new Error("Invalid node: exports must be an array of strings");
     }
     if (containsControlChars(exp)) {
-      throw new Error("Invalid node: exports contains control characters");
+      const preview = exp.slice(0, 120);
+      throw new Error(`Invalid node: exports contains control characters (file=${node.filePath}, value="${preview}")`);
     }
   }
   if (!Array.isArray(node.imports)) {
@@ -64074,7 +64075,8 @@ function validateGraphNode(node) {
       throw new Error("Invalid node: imports must be an array of strings");
     }
     if (containsControlChars(imp)) {
-      throw new Error("Invalid node: imports contains control characters");
+      const preview = imp.slice(0, 120);
+      throw new Error(`Invalid node: imports contains control characters (file=${node.filePath}, value="${preview}")`);
     }
   }
 }
@@ -64431,10 +64433,12 @@ var EXTENSION_TO_LANGUAGE = {
 };
 function parseFileImports(content) {
   const imports = [];
-  const importRegex = /import\s+(?:\{[\s\S]*?\}|(?:\*\s+as\s+\w+)|\w+)\s+from\s+['"`]([^'"`]+)['"`]|import\s+['"`]([^'"`]+)['"`]|require\s*\(\s*['"`]([^'"`]+)['"`]\s*\)|export\s*\{[^}]*\}\s*from\s+['"`]([^'"`]+)['"`]|export\s+\*(?:\s+as\s+\w+)?\s+from\s+['"`]([^'"`]+)['"`]|import\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/g;
+  const importRegex = /import\s+(?:\{[\s\S]*?\}|(?:\*\s+as\s+\w+)|\w+)\s+from\s+['"`]([^'"`\0\t\r\n]+)['"`]|import\s+['"`]([^'"`\0\t\r\n]+)['"`]|require\s*\(\s*['"`]([^'"`\0\t\r\n]+)['"`]\s*\)|export\s*\{[^}]*\}\s*from\s+['"`]([^'"`\0\t\r\n]+)['"`]|export\s+\*(?:\s+as\s+\w+)?\s+from\s+['"`]([^'"`\0\t\r\n]+)['"`]|import\s*\(\s*['"`]([^'"`\0\t\r\n]+)['"`]\s*\)/g;
   for (const match of content.matchAll(importRegex)) {
     const modulePath = match[1] || match[2] || match[3] || match[4] || match[5] || match[6];
     if (!modulePath)
+      continue;
+    if (containsControlChars(modulePath))
       continue;
     const matchedString = match[0];
     let importType = "named";

--- a/docs/releases/v6.74.1.md
+++ b/docs/releases/v6.74.1.md
@@ -1,0 +1,40 @@
+# v6.74.1
+
+## What Changed
+
+**Bug fix: repo-graph import specifier validation**
+
+- `parseFileImports()` now rejects import specifiers containing control characters (`\0`, `\t`, `\r`, `\n`) at the parsing stage instead of failing at validation
+- All six regex capture groups tightened from `[^'"\`]+` to `[^'"\`\0\t\r\n]+` to prevent matching across line boundaries or capturing control bytes
+- Belt-and-suspenders check added immediately after extraction to drop any remaining dirty specifiers
+
+## Why
+
+When a TypeScript/JavaScript file contained a CR byte inside an import specifier (e.g., from CRLF line endings in template literals, generated code, or files edited on Windows), the `buildWorkspaceGraph` would fail with:
+
+```
+[repo-graph] Failed to build graph: Invalid node: imports contains control characters
+```
+
+This prevented users from scanning workspaces that contained such files, even if they were harmless artifacts of tooling or editor configuration.
+
+## Migration
+
+No breaking changes. The graph now silently drops malformed imports containing control characters instead of aborting the entire workspace scan. Clean imports in the same file are processed normally.
+
+## Error Message Enhancement
+
+When a node's imports or exports do contain control characters (e.g., when directly constructing nodes in tests), the error message now includes the node's file path and the offending value:
+
+```
+Invalid node: imports contains control characters (file=/abs/foo.ts, value="./bar\r.js")
+```
+
+This aids debugging when control chars are genuinely present in graph node construction.
+
+## Test Coverage
+
+- Regression test: `buildWorkspaceGraph` succeeds on a file with a CR byte in an import specifier
+- Regression test: `updateGraphForFiles` incremental update succeeds on dirty files
+- Validation test: error messages include file path and value
+- All existing tests continue to pass (207 passing, 1 pre-existing skip)

--- a/src/tools/repo-graph.ts
+++ b/src/tools/repo-graph.ts
@@ -980,7 +980,6 @@ function parseFileImports(content: string): ParsedImport[] {
 	// - require('...')
 	// - export { x } from '...' (named re-export)
 	// - export * from '...' (namespace re-export)
-	// biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally excludes control characters from import specifier captures
 	const importRegex =
 		/import\s+(?:\{[\s\S]*?\}|(?:\*\s+as\s+\w+)|\w+)\s+from\s+['"`]([^'"`\0\t\r\n]+)['"`]|import\s+['"`]([^'"`\0\t\r\n]+)['"`]|require\s*\(\s*['"`]([^'"`\0\t\r\n]+)['"`]\s*\)|export\s*\{[^}]*\}\s*from\s+['"`]([^'"`\0\t\r\n]+)['"`]|export\s+\*(?:\s+as\s+\w+)?\s+from\s+['"`]([^'"`\0\t\r\n]+)['"`]|import\s*\(\s*['"`]([^'"`\0\t\r\n]+)['"`]\s*\)/g;
 

--- a/src/tools/repo-graph.ts
+++ b/src/tools/repo-graph.ts
@@ -186,7 +186,10 @@ export function validateGraphNode(node: GraphNode): void {
 			throw new Error('Invalid node: exports must be an array of strings');
 		}
 		if (containsControlChars(exp)) {
-			throw new Error('Invalid node: exports contains control characters');
+			const preview = exp.slice(0, 120);
+			throw new Error(
+				`Invalid node: exports contains control characters (file=${node.filePath}, value="${preview}")`,
+			);
 		}
 	}
 	if (!Array.isArray(node.imports)) {
@@ -197,7 +200,10 @@ export function validateGraphNode(node: GraphNode): void {
 			throw new Error('Invalid node: imports must be an array of strings');
 		}
 		if (containsControlChars(imp)) {
-			throw new Error('Invalid node: imports contains control characters');
+			const preview = imp.slice(0, 120);
+			throw new Error(
+				`Invalid node: imports contains control characters (file=${node.filePath}, value="${preview}")`,
+			);
 		}
 	}
 }
@@ -974,14 +980,17 @@ function parseFileImports(content: string): ParsedImport[] {
 	// - require('...')
 	// - export { x } from '...' (named re-export)
 	// - export * from '...' (namespace re-export)
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally excludes control characters from import specifier captures
 	const importRegex =
-		/import\s+(?:\{[\s\S]*?\}|(?:\*\s+as\s+\w+)|\w+)\s+from\s+['"`]([^'"`]+)['"`]|import\s+['"`]([^'"`]+)['"`]|require\s*\(\s*['"`]([^'"`]+)['"`]\s*\)|export\s*\{[^}]*\}\s*from\s+['"`]([^'"`]+)['"`]|export\s+\*(?:\s+as\s+\w+)?\s+from\s+['"`]([^'"`]+)['"`]|import\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/g;
+		/import\s+(?:\{[\s\S]*?\}|(?:\*\s+as\s+\w+)|\w+)\s+from\s+['"`]([^'"`\0\t\r\n]+)['"`]|import\s+['"`]([^'"`\0\t\r\n]+)['"`]|require\s*\(\s*['"`]([^'"`\0\t\r\n]+)['"`]\s*\)|export\s*\{[^}]*\}\s*from\s+['"`]([^'"`\0\t\r\n]+)['"`]|export\s+\*(?:\s+as\s+\w+)?\s+from\s+['"`]([^'"`\0\t\r\n]+)['"`]|import\s*\(\s*['"`]([^'"`\0\t\r\n]+)['"`]\s*\)/g;
 
 	for (const match of content.matchAll(importRegex)) {
 		// Extract the module path from whichever capture group matched
 		const modulePath =
 			match[1] || match[2] || match[3] || match[4] || match[5] || match[6];
 		if (!modulePath) continue;
+		// Belt-and-suspenders: drop any specifier that still contains control chars
+		if (containsControlChars(modulePath)) continue;
 
 		// Get the matched string for type detection
 		const matchedString = match[0];

--- a/tests/unit/tools/repo-graph-incremental.test.ts
+++ b/tests/unit/tools/repo-graph-incremental.test.ts
@@ -333,4 +333,45 @@ export const indexExport = 'hello';`,
 		// Note: CSS files are scanned but don't produce nodes in the graph
 		// since scanFile only creates nodes for .ts, .tsx, .js, .jsx, .mjs, .cjs, .py
 	});
+
+	test('updateGraphForFiles does not produce control-char specifiers when file has CR in import', async () => {
+		// Seed workspace with a clean file so there is a baseline graph to update
+		const seedContent = "export const seed = 1;\n";
+		await fsSync.promises.writeFile(path.join(tempDir, 'seed.ts'), seedContent);
+
+		const initialGraph = buildWorkspaceGraph(workspacePath);
+		await saveGraph(workspacePath, initialGraph);
+
+		// Now add a file whose import specifier contains a literal carriage-return byte.
+		// Use String.fromCharCode(13) — unambiguously 0x0D, not the two-char \r sequence.
+		const cr = String.fromCharCode(13);
+		const dirtyContent = `import x from './bar${cr}.js';\nimport y from './ok';\n`;
+		const dirtyPath = path.join(tempDir, 'dirty.ts');
+		await fsSync.promises.writeFile(dirtyPath, dirtyContent, 'binary');
+
+		// Must not throw
+		const updatedGraph = await updateGraphForFiles(workspacePath, [dirtyPath]);
+
+		// Node for the dirty file must exist
+		const dirtyModuleName = 'dirty.ts';
+		const dirtyNode = Object.values(updatedGraph.nodes).find(
+			(n) => n.moduleName === dirtyModuleName,
+		);
+		expect(dirtyNode).toBeDefined();
+
+		// No control chars in any node's imports
+		for (const node of Object.values(updatedGraph.nodes)) {
+			for (const imp of node.imports) {
+				expect(/[\0\t\r\n]/.test(imp)).toBe(false);
+			}
+		}
+
+		// No control chars in any edge's importSpecifier originating from the dirty file
+		const dirtyAbsPath = path.resolve(tempDir, 'dirty.ts');
+		for (const edge of updatedGraph.edges) {
+			if (edge.source === dirtyAbsPath) {
+				expect(/[\0\t\r\n]/.test(edge.importSpecifier)).toBe(false);
+			}
+		}
+	});
 });

--- a/tests/unit/tools/repo-graph-incremental.test.ts
+++ b/tests/unit/tools/repo-graph-incremental.test.ts
@@ -336,7 +336,7 @@ export const indexExport = 'hello';`,
 
 	test('updateGraphForFiles does not produce control-char specifiers when file has CR in import', async () => {
 		// Seed workspace with a clean file so there is a baseline graph to update
-		const seedContent = "export const seed = 1;\n";
+		const seedContent = 'export const seed = 1;\n';
 		await fsSync.promises.writeFile(path.join(tempDir, 'seed.ts'), seedContent);
 
 		const initialGraph = buildWorkspaceGraph(workspacePath);

--- a/tests/unit/tools/repo-graph.test.ts
+++ b/tests/unit/tools/repo-graph.test.ts
@@ -12,6 +12,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import {
 	addEdge,
+	buildWorkspaceGraph,
 	clearCache,
 	createEmptyGraph,
 	type GraphEdge,
@@ -1127,5 +1128,90 @@ describe('adversarial input shapes', () => {
 		const graph = createEmptyGraph('test');
 		upsertNode(graph, node);
 		expect(graph.nodes[longPath]).toEqual(node);
+	});
+});
+
+describe('control character safety in buildWorkspaceGraph', () => {
+	let tempDir: string;
+	let workspacePath: string;
+
+	beforeEach(async () => {
+		tempDir = await fs.promises.mkdtemp(
+			path.join(process.cwd(), 'repo-graph-ctrl-char-'),
+		);
+		workspacePath = path.relative(process.cwd(), tempDir);
+	});
+
+	afterEach(async () => {
+		clearCache(workspacePath);
+		try {
+			await fs.promises.rm(tempDir, { recursive: true, force: true });
+		} catch {
+			// Ignore cleanup errors
+		}
+	});
+
+	test('buildWorkspaceGraph does not throw when an import specifier contains a CR byte', async () => {
+		// dirty.ts: one clean import + one import whose specifier contains a literal
+		// carriage-return byte (0x0D).  Use String.fromCharCode(13) so the CR is
+		// unambiguously a single control character, not the two-char sequence \r.
+		const cr = String.fromCharCode(13);
+		const dirtyContent = `import x from './bar${cr}.js';\nimport y from './ok';\n`;
+
+		// clean.ts: a file with well-formed imports of all three kinds
+		const cleanContent = [
+			"import { foo } from './foo';",
+			"const r = require('./req');",
+			"const d = import('./dyn');",
+		].join('\n');
+
+		await fs.promises.writeFile(path.join(tempDir, 'dirty.ts'), dirtyContent, 'binary');
+		await fs.promises.writeFile(path.join(tempDir, 'clean.ts'), cleanContent);
+		// Stub target files so edges can resolve (optional — edges are only created
+		// when targets exist, but graph build must not throw regardless)
+		await fs.promises.writeFile(path.join(tempDir, 'ok.ts'), 'export {};');
+		await fs.promises.writeFile(path.join(tempDir, 'foo.ts'), 'export const foo = 1;');
+
+		// Must not throw
+		const graph = buildWorkspaceGraph(workspacePath);
+
+		// Both source files appear as nodes
+		const moduleNames = Object.values(graph.nodes).map((n) => n.moduleName);
+		expect(moduleNames).toContain('dirty.ts');
+		expect(moduleNames).toContain('clean.ts');
+
+		// The dirty specifier must not appear in any node's imports
+		for (const node of Object.values(graph.nodes)) {
+			for (const imp of node.imports) {
+				expect(/[\0\t\r\n]/.test(imp)).toBe(false);
+			}
+		}
+
+		// The dirty specifier must not appear in any edge's importSpecifier
+		for (const edge of graph.edges) {
+			expect(/[\0\t\r\n]/.test(edge.importSpecifier)).toBe(false);
+		}
+
+		// clean.ts's well-formed specifier is retained
+		const cleanNode = Object.values(graph.nodes).find(
+			(n) => n.moduleName === 'clean.ts',
+		);
+		expect(cleanNode).toBeDefined();
+		expect(cleanNode?.imports).toContain('./foo');
+	});
+
+	test('validateGraphNode error message includes filePath and value when imports contains control characters', () => {
+		const node: GraphNode = {
+			filePath: '/abs/foo.ts',
+			moduleName: 'foo',
+			exports: [],
+			imports: [`./bar${String.fromCharCode(13)}.js`],
+			language: 'ts',
+			mtime: '123',
+		};
+		// Original substring must still be present (toThrow uses substring matching)
+		expect(() => validateGraphNode(node)).toThrow('Invalid node: imports contains control characters');
+		// New context info must also appear
+		expect(() => validateGraphNode(node)).toThrow('/abs/foo.ts');
 	});
 });

--- a/tests/unit/tools/repo-graph.test.ts
+++ b/tests/unit/tools/repo-graph.test.ts
@@ -1165,12 +1165,19 @@ describe('control character safety in buildWorkspaceGraph', () => {
 			"const d = import('./dyn');",
 		].join('\n');
 
-		await fs.promises.writeFile(path.join(tempDir, 'dirty.ts'), dirtyContent, 'binary');
+		await fs.promises.writeFile(
+			path.join(tempDir, 'dirty.ts'),
+			dirtyContent,
+			'binary',
+		);
 		await fs.promises.writeFile(path.join(tempDir, 'clean.ts'), cleanContent);
 		// Stub target files so edges can resolve (optional — edges are only created
 		// when targets exist, but graph build must not throw regardless)
 		await fs.promises.writeFile(path.join(tempDir, 'ok.ts'), 'export {};');
-		await fs.promises.writeFile(path.join(tempDir, 'foo.ts'), 'export const foo = 1;');
+		await fs.promises.writeFile(
+			path.join(tempDir, 'foo.ts'),
+			'export const foo = 1;',
+		);
 
 		// Must not throw
 		const graph = buildWorkspaceGraph(workspacePath);
@@ -1210,7 +1217,9 @@ describe('control character safety in buildWorkspaceGraph', () => {
 			mtime: '123',
 		};
 		// Original substring must still be present (toThrow uses substring matching)
-		expect(() => validateGraphNode(node)).toThrow('Invalid node: imports contains control characters');
+		expect(() => validateGraphNode(node)).toThrow(
+			'Invalid node: imports contains control characters',
+		);
 		// New context info must also appear
 		expect(() => validateGraphNode(node)).toThrow('/abs/foo.ts');
 	});


### PR DESCRIPTION
## Summary

- Fixed graph build failure when files contain CR bytes in import specifiers (e.g., CRLF-edited template literals, generated code)
- Tightened regex capture groups to exclude control characters at parse time, with belt-and-suspenders validation drop check
- Enhanced error messages to include file path and offending value for debugging

Closes #536

## Test plan
- [x] All repo-graph unit tests pass (208 tests, 0 fail)
- [x] New regression tests for buildWorkspaceGraph and updateGraphForFiles with control-char imports
- [x] Error message validation test confirms file path is included in throw
- [x] Dynamic import patterns continue to parse correctly after regex tightening