### PR TITLE
fix(guardrails): exempt opencode native agents from swarm guardrails (issue #559)

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -18756,6 +18756,15 @@ var ALL_AGENT_NAMES = [
   ORCHESTRATOR_NAME,
   ...ALL_SUBAGENT_NAMES
 ];
+var OPENCODE_NATIVE_AGENTS = new Set([
+  "build",
+  "plan",
+  "general",
+  "explore",
+  "compaction",
+  "title",
+  "summary"
+]);
 var AGENT_TOOL_MAP = {
   architect: [
     "checkpoint",

--- a/dist/config/constants.d.ts
+++ b/dist/config/constants.d.ts
@@ -4,6 +4,7 @@ export declare const PIPELINE_AGENTS: readonly ["explorer", "coder", "test_engin
 export declare const ORCHESTRATOR_NAME: "architect";
 export declare const ALL_SUBAGENT_NAMES: readonly ["sme", "docs", "designer", "critic_sounding_board", "critic_drift_verifier", "critic_hallucination_verifier", "curator_init", "curator_phase", "reviewer", "critic", "critic_oversight", "explorer", "coder", "test_engineer"];
 export declare const ALL_AGENT_NAMES: readonly ["architect", "sme", "docs", "designer", "critic_sounding_board", "critic_drift_verifier", "critic_hallucination_verifier", "curator_init", "curator_phase", "reviewer", "critic", "critic_oversight", "explorer", "coder", "test_engineer"];
+export declare const OPENCODE_NATIVE_AGENTS: Set<"compaction" | "title" | "build" | "plan" | "general" | "explore" | "summary">;
 export type QAAgentName = (typeof QA_AGENTS)[number];
 export type PipelineAgentName = (typeof PIPELINE_AGENTS)[number];
 export type AgentName = (typeof ALL_AGENT_NAMES)[number];

--- a/dist/index.js
+++ b/dist/index.js
@@ -147,7 +147,7 @@ function isLowCapabilityModel(modelId) {
   const lower = modelId.toLowerCase();
   return LOW_CAPABILITY_MODELS.some((substr) => lower.includes(substr));
 }
-var QA_AGENTS, PIPELINE_AGENTS, ORCHESTRATOR_NAME = "architect", ALL_SUBAGENT_NAMES, ALL_AGENT_NAMES, AGENT_TOOL_MAP, WRITE_TOOL_NAMES, TOOL_DESCRIPTIONS, DEFAULT_MODELS, DEFAULT_SCORING_CONFIG, LOW_CAPABILITY_MODELS, TURBO_MODE_BANNER = `## \uD83D\uDE80 TURBO MODE ACTIVE
+var QA_AGENTS, PIPELINE_AGENTS, ORCHESTRATOR_NAME = "architect", ALL_SUBAGENT_NAMES, ALL_AGENT_NAMES, OPENCODE_NATIVE_AGENTS, AGENT_TOOL_MAP, WRITE_TOOL_NAMES, TOOL_DESCRIPTIONS, DEFAULT_MODELS, DEFAULT_SCORING_CONFIG, LOW_CAPABILITY_MODELS, TURBO_MODE_BANNER = `## \uD83D\uDE80 TURBO MODE ACTIVE
 
 **Speed optimization enabled for this session.**
 
@@ -195,6 +195,15 @@ var init_constants = __esm(() => {
     ORCHESTRATOR_NAME,
     ...ALL_SUBAGENT_NAMES
   ];
+  OPENCODE_NATIVE_AGENTS = new Set([
+    "build",
+    "plan",
+    "general",
+    "explore",
+    "compaction",
+    "title",
+    "summary"
+  ]);
   AGENT_TOOL_MAP = {
     architect: [
       "checkpoint",
@@ -22658,6 +22667,9 @@ function isWriteTool(toolName) {
   const normalized = normalizeToolName(toolName);
   return WRITE_TOOL_NAMES.includes(normalized);
 }
+function isNativeOpencodeAgent(agentName) {
+  return OPENCODE_NATIVE_AGENTS.has(agentName.toLowerCase());
+}
 function isArchitect(sessionId) {
   const activeAgent = swarmState.activeAgent.get(sessionId);
   if (activeAgent) {
@@ -23556,16 +23568,22 @@ function createGuardrailsHooks(directory, directoryOrConfig, config2, authorityC
     const strippedAgent = rawActiveAgent ? stripKnownSwarmPrefix(rawActiveAgent) : undefined;
     if (strippedAgent === ORCHESTRATOR_NAME)
       return null;
+    if (strippedAgent && isNativeOpencodeAgent(strippedAgent))
+      return null;
     const existingSession = swarmState.agentSessions.get(sessionID);
     if (existingSession) {
       const sessionAgent = stripKnownSwarmPrefix(existingSession.agentName);
       if (sessionAgent === ORCHESTRATOR_NAME)
+        return null;
+      if (isNativeOpencodeAgent(sessionAgent))
         return null;
     }
     const agentName = swarmState.activeAgent.get(sessionID) ?? ORCHESTRATOR_NAME;
     const session = ensureAgentSession(sessionID, agentName);
     const resolvedName = stripKnownSwarmPrefix(session.agentName);
     if (resolvedName === ORCHESTRATOR_NAME)
+      return null;
+    if (isNativeOpencodeAgent(resolvedName))
       return null;
     const agentConfig = resolveGuardrailsConfig(cfg, session.agentName);
     if (agentConfig.max_duration_minutes === 0 && agentConfig.max_tool_calls === 0) {
@@ -24493,6 +24511,10 @@ var init_guardrails = __esm(() => {
     maxSize: 200
   });
   DEFAULT_AGENT_AUTHORITY_RULES = {
+    build: {},
+    plan: {},
+    general: {},
+    explore: {},
     architect: {
       blockedExact: [".swarm/plan.md", ".swarm/plan.json"],
       blockedZones: ["generated"]
@@ -67752,7 +67774,7 @@ var GUARD_KEYWORDS = [
 function isGuardKeyword(name2) {
   return GUARD_KEYWORDS.some((keyword) => {
     const ciKeyword = keyword.split("").map((c) => `[${c.toLowerCase()}${c.toUpperCase()}]`).join("");
-    const re = new RegExp("(?<![a-z])" + ciKeyword + "(?![a-z])");
+    const re = new RegExp(`(?<![a-z])${ciKeyword}(?![a-z])`);
     return re.test(name2);
   });
 }

--- a/docs/releases/v6.80.1.md
+++ b/docs/releases/v6.80.1.md
@@ -1,0 +1,42 @@
+# v6.80.1
+
+## Summary
+
+Fixes issue #559: opencode's native built-in agents (`build`, `plan`, `general`, `explore`) were being blocked by the swarm guardrails plugin with "WRITE BLOCKED: Agent 'build' is not authorised to write... Reason: Unknown agent: build". 
+
+Native agents are now fully transparent to the swarm guardrail system:
+- **Write-authority pass-through**: `DEFAULT_AGENT_AUTHORITY_RULES` now includes entries for all native agents with permissive rules (`{}`), allowing them to write anywhere within the working directory
+- **Circuit-breaker exemption**: Native agents are exempted from swarm tool-call limits, loop detection, and QA gates via `resolveSessionAndWindow` — they operate under opencode's own permission and limit system only
+
+## What changed
+
+**`src/config/constants.ts`**: Introduced `OPENCODE_NATIVE_AGENTS` constant set containing the seven known opencode built-in agents: `build`, `plan`, `general`, `explore`, `compaction`, `title`, `summary`.
+
+**`src/hooks/guardrails.ts`**:
+1. Imported `OPENCODE_NATIVE_AGENTS`
+2. Added `isNativeOpencodeAgent()` helper to check agent membership
+3. Updated `DEFAULT_AGENT_AUTHORITY_RULES` to include pass-through entries (`build: {}`, `plan: {}`, `general: {}`, `explore: {}`)
+4. Added three exemption checks inside `resolveSessionAndWindow()` (mirroring existing `ORCHESTRATOR_NAME` pattern) to return `null` for native agents
+
+**Test coverage**:
+- `tests/unit/hooks/guardrails-authority.test.ts`: Added 6 assertions verifying authority pass-through, including the exact `eslint.config.mts` repro from issue #559
+- `tests/unit/hooks/guardrails-native-agents.test.ts`: New test file with circuit-breaker baseline and full pass-through verification
+
+## Why
+
+Users installing the opencode-swarm plugin to use with the swarm workflow were unable to use opencode normally (with default `build`/`plan` agents) due to the guardrails plugin's overly strict agent authorization checks. The plugin was designed for swarm agents only but ran on every session. Native agents must be fully transparent to swarm guardrails and governed only by opencode's own permission system.
+
+## Migration steps
+
+None. This is a bug fix. Users can now use opencode's native `build` and `plan` agents normally with the swarm plugin installed.
+
+## Testing
+
+All relevant guardrails unit tests pass with zero regressions. New tests confirm:
+- Native agents pass write authority checks (do not throw "Unknown agent")
+- Native agents are not subject to swarm circuit-breaker limits
+- Swarm agents (e.g., `coder`) remain under guardrails enforcement
+
+## Known caveats
+
+None. The fix is scoped to native agent exemptions only; swarm agent rules and enforcement are unchanged.

--- a/src/__tests__/evidence-lock.test.ts
+++ b/src/__tests__/evidence-lock.test.ts
@@ -99,7 +99,7 @@ describe('withEvidenceLock — contention path', () => {
 	test('second caller waits while first holds the lock', async () => {
 		const order: string[] = [];
 		let resolveInner!: () => void;
-		const innerDone = new Promise<void>((r) => {
+		const _innerDone = new Promise<void>((r) => {
 			resolveInner = r;
 		});
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -24,6 +24,19 @@ export const ALL_AGENT_NAMES = [
 	...ALL_SUBAGENT_NAMES,
 ] as const;
 
+// Opencode built-in native agents — not part of the swarm workflow.
+// These agents are managed entirely by opencode's own permission system and
+// must be exempted from swarm guardrails (authority checks, circuit breaker, etc.).
+export const OPENCODE_NATIVE_AGENTS = new Set([
+	'build',
+	'plan',
+	'general',
+	'explore',
+	'compaction',
+	'title',
+	'summary',
+] as const);
+
 // Type definitions
 export type QAAgentName = (typeof QA_AGENTS)[number];
 export type PipelineAgentName = (typeof PIPELINE_AGENTS)[number];

--- a/src/diff/semantic-classifier.ts
+++ b/src/diff/semantic-classifier.ts
@@ -84,7 +84,7 @@ function isGuardKeyword(name: string): boolean {
 			.split('')
 			.map((c) => `[${c.toLowerCase()}${c.toUpperCase()}]`)
 			.join('');
-		const re = new RegExp('(?<![a-z])' + ciKeyword + '(?![a-z])');
+		const re = new RegExp(`(?<![a-z])${ciKeyword}(?![a-z])`);
 		return re.test(name);
 	});
 }

--- a/src/hooks/__tests__/semantic-diff-injection.test.ts
+++ b/src/hooks/__tests__/semantic-diff-injection.test.ts
@@ -101,7 +101,7 @@ describe('buildSemanticDiffBlock', () => {
 
 		// Mock file exists in HEAD
 		mockExecFileSync.mockImplementation(
-			(command: string, args: string[], _options: unknown) => {
+			(_command: string, args: string[], _options: unknown) => {
 				if (args[0] === 'cat-file') return ''; // file exists
 				if (args[0] === 'show') return 'old content';
 				throw new Error('unexpected git command');
@@ -389,7 +389,7 @@ describe('buildSemanticDiffBlock', () => {
 		);
 
 		mockExecFileSync.mockImplementation(
-			(command: string, args: string[], _options: unknown) => {
+			(_command: string, args: string[], _options: unknown) => {
 				if (args[0] === 'cat-file') return '';
 				if (args[0] === 'show') return 'old';
 				throw new Error('unexpected');
@@ -481,7 +481,7 @@ describe('buildSemanticDiffBlock', () => {
 		);
 
 		mockExecFileSync.mockImplementation(
-			(command: string, args: string[], _options: unknown) => {
+			(_command: string, args: string[], _options: unknown) => {
 				if (args[0] === 'cat-file') return '';
 				if (args[0] === 'show') return 'old';
 				throw new Error('unexpected');
@@ -561,9 +561,9 @@ describe('buildSemanticDiffBlock', () => {
 			'../semantic-diff-injection.js'
 		);
 
-		let callCount = 0;
-		mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
-			callCount++;
+		let _callCount = 0;
+		mockExecFileSync.mockImplementation((_cmd: string, _args: string[]) => {
+			_callCount++;
 			// All calls throw ENOENT (git binary missing)
 			const error = new Error('spawnSync git ENOENT');
 			(error as NodeJS.ErrnoException).code = 'ENOENT';
@@ -635,7 +635,7 @@ describe('buildSemanticDiffBlock', () => {
 		mockGenerateSummary.mockReturnValue(mockSummary);
 		mockGenerateSummaryMarkdown.mockReturnValue('');
 
-		const result = await buildSemanticDiffBlock('/fake/dir', ['broken.ts']);
+		const _result = await buildSemanticDiffBlock('/fake/dir', ['broken.ts']);
 
 		// classifyChanges should have been called with astDiffs that include the error-only result
 		expect(mockClassifyChanges).toHaveBeenCalled();
@@ -671,7 +671,7 @@ describe('buildSemanticDiffBlock', () => {
 		mockGenerateSummaryMarkdown.mockReturnValue('');
 
 		// Pass traversal paths mixed with a valid path
-		const result = await buildSemanticDiffBlock('/safe/dir', [
+		const _result = await buildSemanticDiffBlock('/safe/dir', [
 			'../../../etc/passwd',
 			'/absolute/path/secret',
 			'valid.ts',
@@ -695,7 +695,7 @@ describe('buildSemanticDiffBlock', () => {
 
 			// Mock git cat-file to return '' (file exists), git show to return 'old content'
 			mockExecFileSync.mockImplementation(
-				(command: string, args: string[], _options: unknown) => {
+				(_command: string, args: string[], _options: unknown) => {
 					if (args[0] === 'cat-file') return '';
 					if (args[0] === 'show') return 'old content';
 					throw new Error('unexpected git command');

--- a/src/hooks/guardrails.ts
+++ b/src/hooks/guardrails.ts
@@ -15,6 +15,7 @@ import QuickLRU from 'quick-lru';
 import { getSwarmAgents, resolveFallbackModel } from '../agents/index';
 import {
 	isLowCapabilityModel,
+	OPENCODE_NATIVE_AGENTS,
 	ORCHESTRATOR_NAME,
 	WRITE_TOOL_NAMES,
 } from '../config/constants';
@@ -109,6 +110,15 @@ function isWriteTool(toolName: string): boolean {
 	// Strip namespace prefix (e.g., "opencode:write" -> "write")
 	const normalized = normalizeToolName(toolName);
 	return (WRITE_TOOL_NAMES as readonly string[]).includes(normalized);
+}
+
+/**
+ * Returns true when agentName is one of opencode's built-in native agents.
+ * These agents are not part of the swarm workflow and must be fully exempt from
+ * swarm guardrails (authority checks, circuit breaker, loop detection, etc.).
+ */
+function isNativeOpencodeAgent(agentName: string): boolean {
+	return OPENCODE_NATIVE_AGENTS.has(agentName.toLowerCase() as never);
 }
 
 /**
@@ -1901,12 +1911,14 @@ export function createGuardrailsHooks(
 			? stripKnownSwarmPrefix(rawActiveAgent)
 			: undefined;
 		if (strippedAgent === ORCHESTRATOR_NAME) return null;
+		if (strippedAgent && isNativeOpencodeAgent(strippedAgent)) return null;
 
 		// Check 2: session state fallback
 		const existingSession = swarmState.agentSessions.get(sessionID);
 		if (existingSession) {
 			const sessionAgent = stripKnownSwarmPrefix(existingSession.agentName);
 			if (sessionAgent === ORCHESTRATOR_NAME) return null;
+			if (isNativeOpencodeAgent(sessionAgent)) return null;
 		}
 
 		const agentName =
@@ -1916,6 +1928,7 @@ export function createGuardrailsHooks(
 		// Check 3: after session resolution
 		const resolvedName = stripKnownSwarmPrefix(session.agentName);
 		if (resolvedName === ORCHESTRATOR_NAME) return null;
+		if (isNativeOpencodeAgent(resolvedName)) return null;
 
 		const agentConfig = resolveGuardrailsConfig(cfg, session.agentName);
 
@@ -3238,6 +3251,14 @@ type AgentRule = {
 };
 
 export const DEFAULT_AGENT_AUTHORITY_RULES: Record<string, AgentRule> = {
+	// Opencode native built-in agents — pass through with no swarm write restrictions.
+	// Opencode's own permission system governs what these agents may write; the swarm
+	// authority layer must not add further constraints on top of it.
+	build: {},
+	plan: {},
+	general: {},
+	explore: {},
+
 	architect: {
 		blockedExact: ['.swarm/plan.md', '.swarm/plan.json'],
 		blockedZones: ['generated'],

--- a/src/mutation/__tests__/engine.test.ts
+++ b/src/mutation/__tests__/engine.test.ts
@@ -24,7 +24,7 @@ function makeResult(
 }
 
 // Helper to create a MutationPatch
-function makePatch(
+function _makePatch(
 	id: string,
 	filePath = 'src/foo.ts',
 	functionName = 'foo',

--- a/src/mutation/__tests__/gate.adversarial.test.ts
+++ b/src/mutation/__tests__/gate.adversarial.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from 'bun:test';
+import { expect, test } from 'bun:test';
 import type { MutationReport, MutationResult } from '../engine.js';
 import { evaluateMutationGate } from '../gate.js';
 

--- a/src/state.rehydrate.test.ts
+++ b/src/state.rehydrate.test.ts
@@ -1011,7 +1011,7 @@ describe('adversarial council verdict rehydration', () => {
 	it('6. extremely long verdict string (>10KB) is safely rejected', async () => {
 		// Arrange: verdict string is 10000+ characters
 		writePlan([{ id: '1.1', status: 'in_progress' }]);
-		const longVerdict = 'APPROVE' + 'x'.repeat(10000);
+		const longVerdict = `APPROVE${'x'.repeat(10000)}`;
 		writeFileSync(
 			path.join(tmpDir, '.swarm', 'evidence', '1.1.json'),
 			JSON.stringify({

--- a/src/test-impact/__tests__/history-store.adversarial.test.ts
+++ b/src/test-impact/__tests__/history-store.adversarial.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 import {
@@ -105,7 +105,7 @@ describe('history-store adversarial security tests', () => {
 			}).not.toThrow();
 
 			// Null byte should be stripped or handled
-			const history = getTestHistory(maliciousPath, tempDir);
+			const _history = getTestHistory(maliciousPath, tempDir);
 			// The file is written with the path as-is; null byte handling is at OS level
 		});
 	});

--- a/src/tools/__tests__/diff-ast-fallback.test.ts
+++ b/src/tools/__tests__/diff-ast-fallback.test.ts
@@ -169,7 +169,7 @@ describe('AST diff fallback — regression: error results were silently dropped'
 			// we can verify the source code contains the fix.
 			//
 			// This test passes when the source code contains the fix.
-			const sourceCode = await Bun.file(import.meta.dir + '/../diff.ts').text();
+			const sourceCode = await Bun.file(`${import.meta.dir}/../diff.ts`).text();
 
 			// The fix adds || astResult.error to the guard condition
 			// Look for the pattern: (astResult.changes.length > 0 || astResult.error)
@@ -178,7 +178,7 @@ describe('AST diff fallback — regression: error results were silently dropped'
 
 		test('catch block pushes fallback with category other (lines 290-308)', async () => {
 			// Verify the catch block has the fallback entry structure
-			const sourceCode = await Bun.file(import.meta.dir + '/../diff.ts').text();
+			const sourceCode = await Bun.file(`${import.meta.dir}/../diff.ts`).text();
 
 			// The fallback should push a change with category 'other'
 			expect(sourceCode).toContain("category: 'other'");

--- a/src/tools/__tests__/diff-markdown-summary.test.ts
+++ b/src/tools/__tests__/diff-markdown-summary.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
-import * as child_process from 'node:child_process';
 import type { ASTChange, ASTDiffResult } from '../../diff/ast-diff.js';
 import type { ClassifiedChange } from '../../diff/semantic-classifier.js';
 import type { SemanticDiffSummary } from '../../diff/summary-generator.js';
@@ -129,7 +128,7 @@ describe('diff tool — generateSummaryMarkdown wiring', () => {
 		const { diff } = await import('../../tools/diff.js');
 
 		// --- git numstat ---
-		mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+		mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
 			if (args?.includes('--numstat')) {
 				return '10\t5\tsrc/api.ts';
 			}
@@ -201,7 +200,7 @@ describe('diff tool — generateSummaryMarkdown wiring', () => {
 		const { diff } = await import('../../tools/diff.js');
 
 		// --- git numstat ---
-		mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+		mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
 			if (args?.includes('--numstat')) {
 				return '10\t5\tsrc/broken.ts';
 			}
@@ -235,7 +234,7 @@ describe('diff tool — generateSummaryMarkdown wiring', () => {
 	test('markdownSummary is absent when AST returns zero changes (no semanticSummary)', async () => {
 		const { diff } = await import('../../tools/diff.js');
 
-		mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+		mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
 			if (args?.includes('--numstat')) {
 				return '10\t5\tsrc/unchanged.ts';
 			}
@@ -275,7 +274,7 @@ describe('diff tool — generateSummaryMarkdown wiring', () => {
 	test('markdownSummary is absent when generateSummaryMarkdown throws', async () => {
 		const { diff } = await import('../../tools/diff.js');
 
-		mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+		mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
 			if (args?.includes('--numstat')) {
 				return '10\t5\tsrc/api.ts';
 			}
@@ -334,7 +333,7 @@ describe('diff tool — generateSummaryMarkdown wiring', () => {
 	test('markdownSummary is absent when classifyChanges throws', async () => {
 		const { diff } = await import('../../tools/diff.js');
 
-		mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+		mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
 			if (args?.includes('--numstat')) {
 				return '10\t5\tsrc/api.ts';
 			}

--- a/src/tools/__tests__/diff-semantic.test.ts
+++ b/src/tools/__tests__/diff-semantic.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 import type { ASTChange, ASTDiffResult } from '../../diff/ast-diff.js';
 import { classifyChanges } from '../../diff/semantic-classifier.js';
 import { generateSummary } from '../../diff/summary-generator.js';
@@ -348,7 +348,7 @@ describe('semanticSummary undefined when astDiffs is empty', () => {
 // =============================================================================
 describe('Graceful fallback when classification throws', () => {
 	test('should continue without semanticSummary when classifyChanges throws', () => {
-		const astDiffs = [
+		const _astDiffs = [
 			makeASTDiffResult({
 				filePath: 'src/test.ts',
 				changes: [makeASTChange()],
@@ -378,7 +378,7 @@ describe('Graceful fallback when classification throws', () => {
 
 		let semanticSummary: any;
 		try {
-			const classifiedChanges = classifyChanges(astDiffs);
+			const _classifiedChanges = classifyChanges(astDiffs);
 			// Simulate generateSummary throwing
 			throw new Error('Summary generation failed');
 		} catch {

--- a/src/tools/__tests__/diff-summary.adversarial.test.ts
+++ b/src/tools/__tests__/diff-summary.adversarial.test.ts
@@ -1,6 +1,4 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
-import * as child_process from 'node:child_process';
-import * as fs from 'node:fs';
 import type { ASTChange, ASTDiffResult } from '../../diff/ast-diff.js';
 import type { ClassifiedChange } from '../../diff/semantic-classifier.js';
 import type { SemanticDiffSummary } from '../../diff/summary-generator.js';
@@ -345,7 +343,7 @@ describe('diff_summary ADVERSARIAL security tests', () => {
 	test('should never crash on 10000 char path - returns valid JSON', async () => {
 		setupHappyPath();
 		const { parsed, raw } = await invokeTool({
-			files: ['a'.repeat(10000) + '.ts'],
+			files: [`${'a'.repeat(10000)}.ts`],
 		});
 		expect(raw).toBeTruthy();
 		expect(typeof raw).toBe('string');

--- a/src/tools/__tests__/diff-summary.test.ts
+++ b/src/tools/__tests__/diff-summary.test.ts
@@ -1,6 +1,4 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
-import * as child_process from 'node:child_process';
-import * as fs from 'node:fs';
 import type { ASTChange, ASTDiffResult } from '../../diff/ast-diff.js';
 import type { ClassifiedChange } from '../../diff/semantic-classifier.js';
 import type { SemanticDiffSummary } from '../../diff/summary-generator.js';
@@ -323,7 +321,7 @@ describe('diff_summary tool', () => {
 			});
 		});
 
-		const result = await diff_summary.execute(
+		const _result = await diff_summary.execute(
 			{ files: ['src/api.ts'], classification: 'SIGNATURE_CHANGE' },
 			createToolContext('/fake/dir'),
 		);
@@ -379,7 +377,7 @@ describe('diff_summary tool', () => {
 			});
 		});
 
-		const result = await diff_summary.execute(
+		const _result = await diff_summary.execute(
 			{ files: ['src/api.ts'], riskLevel: 'Critical' },
 			createToolContext('/fake/dir'),
 		);
@@ -437,7 +435,7 @@ describe('diff_summary tool', () => {
 			});
 		});
 
-		const result = await diff_summary.execute(
+		const _result = await diff_summary.execute(
 			{
 				files: ['src/api.ts'],
 				classification: 'SIGNATURE_CHANGE',
@@ -463,7 +461,7 @@ describe('diff_summary tool', () => {
 		const { diff_summary } = await import('../../tools/diff-summary.js');
 
 		// Mock cat-file -e to throw (file not in HEAD)
-		mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+		mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
 			if (args[0] === 'cat-file' && args[1] === '-e') {
 				throw new Error('fatal: pathspec did not match any files');
 			}
@@ -533,7 +531,7 @@ describe('diff_summary tool', () => {
 		const { diff_summary } = await import('../../tools/diff-summary.js');
 
 		// Mock cat-file -e to throw for badge.tsx (simulating untracked file)
-		mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+		mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
 			if (
 				args[0] === 'cat-file' &&
 				args[1] === '-e' &&
@@ -726,7 +724,7 @@ describe('diff_summary tool', () => {
 		const { diff_summary } = await import('../../tools/diff-summary.js');
 
 		// Mock execFileSync to succeed for cat-file check (file exists in HEAD) and git show
-		mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+		mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
 			if (args[0] === 'cat-file' && args[1] === '-e') {
 				// File exists in HEAD
 				return '';
@@ -781,7 +779,7 @@ describe('diff_summary tool', () => {
 		const { diff_summary } = await import('../../tools/diff-summary.js');
 
 		// First file: git success, second file: git failure
-		mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+		mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
 			if (args[1] === 'HEAD:src/file1.ts') {
 				return 'old content 1';
 			}

--- a/src/tools/__tests__/test-runner-history.test.ts
+++ b/src/tools/__tests__/test-runner-history.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
+import { beforeEach, describe, expect, test, vi } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/src/tools/__tests__/test-runner-impact.adversarial.test.ts
+++ b/src/tools/__tests__/test-runner-impact.adversarial.test.ts
@@ -7,8 +7,6 @@ import {
 	mock,
 	test,
 } from 'bun:test';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 
 // We need to use mock.module which is set up in beforeEach
 // This allows us to properly intercept the module imports
@@ -352,7 +350,7 @@ describe('test-runner impact scope ADVERSARIAL security tests', () => {
 	test('impact: rejects 10000 character path', async () => {
 		const { parsed, raw } = await invokeTool({
 			scope: 'impact',
-			files: ['a'.repeat(10000) + '.ts'],
+			files: [`${'a'.repeat(10000)}.ts`],
 		});
 		expect(raw).toBeTruthy();
 		const obj = parsed as { success?: boolean; error?: string };
@@ -362,7 +360,7 @@ describe('test-runner impact scope ADVERSARIAL security tests', () => {
 	test('impact: rejects 50000 character path', async () => {
 		const { parsed, raw } = await invokeTool({
 			scope: 'impact',
-			files: ['a'.repeat(50000) + '.ts'],
+			files: [`${'a'.repeat(50000)}.ts`],
 		});
 		expect(raw).toBeTruthy();
 		const obj = parsed as { success?: boolean; error?: string };

--- a/src/tools/mutation-test.security.test.ts
+++ b/src/tools/mutation-test.security.test.ts
@@ -68,7 +68,7 @@ describe('mutation_test security tests', () => {
 
 		const tool = mutation_test;
 		// @ts-expect-error — security test bypasses type checking
-		const result = await tool.execute(args, '/project/root', {});
+		const _result = await tool.execute(args, '/project/root', {});
 
 		// Should not crash - tool should handle gracefully
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
@@ -83,7 +83,7 @@ describe('mutation_test security tests', () => {
 
 		const tool = mutation_test;
 		// @ts-expect-error — security test bypasses type checking
-		const result = await tool.execute(args, 'C:\\project\\root', {});
+		const _result = await tool.execute(args, 'C:\\project\\root', {});
 
 		// Should handle gracefully without crashing
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
@@ -100,7 +100,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// Should not crash - empty path should be skipped
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -117,7 +117,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// Number is coerced to string "12345" - tool doesn't crash, just tries to read
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -134,7 +134,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// Object is coerced to "[object Object]" - tool doesn't crash
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -151,7 +151,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// null is coerced to "null" string - tool doesn't crash
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -167,7 +167,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// Should handle null bytes gracefully
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -183,7 +183,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// Should handle long paths without crashing
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -199,7 +199,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
 
@@ -214,7 +214,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
 
@@ -258,7 +258,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// Should process legitimate files while skipping traversal attempts
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -278,7 +278,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// Should handle directory read error gracefully
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -307,7 +307,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// Should handle large patch arrays without crashing
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -327,7 +327,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
 
@@ -342,7 +342,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// Should handle special characters without command injection
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -359,7 +359,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// undefined is coerced to "undefined" string - tool doesn't crash
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -376,7 +376,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// Should handle binary in filePath without crashing
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -393,7 +393,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// Array is coerced to comma-separated string - tool doesn't crash
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -435,7 +435,7 @@ describe('mutation_test security tests', () => {
 			const filename = resolvedPath.split(/[/\\]/).pop();
 			if (filename === 'a.ts') return 'content a';
 			if (filename === 'b.ts') return 'content b';
-			throw new Error('File not found: ' + resolvedPath);
+			throw new Error(`File not found: ${resolvedPath}`);
 		});
 
 		const tool = mutation_test;
@@ -462,7 +462,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// Double dot in middle of valid path is legitimate
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -523,7 +523,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		// Should still call executeMutationSuite with empty sourceFiles
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 	});
@@ -542,7 +542,7 @@ describe('mutation_test security tests', () => {
 		// @ts-expect-error — security test bypasses type checking
 		const result = await tool.execute(args, '/project/root', {});
 
-		const parsed = JSON.parse(result);
+		const _parsed = JSON.parse(result);
 		expect(mockExecuteMutationSuite).toHaveBeenCalled();
 
 		const mockCalls = mockExecuteMutationSuite.mock.calls;

--- a/src/tools/test-runner.ts
+++ b/src/tools/test-runner.ts
@@ -399,7 +399,7 @@ export async function detectTestFramework(cwd: string): Promise<TestFramework> {
 }
 
 // ============ Test File Mapping (Convention Scope) ============
-const TEST_PATTERNS = [
+const _TEST_PATTERNS = [
 	// Common test file patterns
 	{ test: '.spec.', source: '.' },
 	{ test: '.test.', source: '.' },

--- a/tests/unit/hooks/guardrails-authority.test.ts
+++ b/tests/unit/hooks/guardrails-authority.test.ts
@@ -2190,3 +2190,60 @@ describe('patch authority hardening', () => {
 		);
 	});
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Regression: issue #559 — opencode native agents must not be blocked
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Opencode native agents — authority pass-through (issue #559)', () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'native-agent-auth-'));
+	});
+
+	afterEach(async () => {
+		try {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	it('build agent can write eslint.config.mts (exact repro from issue #559)', () => {
+		const result = checkFileAuthority('build', 'eslint.config.mts', tempDir);
+		expect(result.allowed).toBe(true);
+	});
+
+	it('build agent is not blocked with "Unknown agent" reason', () => {
+		const result = checkFileAuthority('build', 'src/index.ts', tempDir);
+		expect(result.allowed).toBe(true);
+		if (!result.allowed) {
+			expect((result as { reason: string }).reason).not.toContain(
+				'Unknown agent',
+			);
+		}
+	});
+
+	it('plan agent can write to arbitrary in-cwd paths', () => {
+		const result = checkFileAuthority('plan', 'src/app.ts', tempDir);
+		expect(result.allowed).toBe(true);
+	});
+
+	it('general agent can write to arbitrary in-cwd paths', () => {
+		const result = checkFileAuthority('general', 'lib/utils.ts', tempDir);
+		expect(result.allowed).toBe(true);
+	});
+
+	it('explore agent passes authority check (opencode permission layer enforces read-only)', () => {
+		const result = checkFileAuthority('explore', 'src/read-target.ts', tempDir);
+		expect(result.allowed).toBe(true);
+	});
+
+	it('truly unknown agents are still blocked', () => {
+		const result = checkFileAuthority('unknown-agent', 'src/file.ts', tempDir);
+		expect(result.allowed).toBe(false);
+		if (!result.allowed) {
+			expect((result as { reason: string }).reason).toContain('Unknown agent');
+		}
+	});
+});

--- a/tests/unit/hooks/guardrails-native-agents.test.ts
+++ b/tests/unit/hooks/guardrails-native-agents.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for opencode native agent exemption from swarm guardrails (issue #559).
+ *
+ * Native agents (build, plan, general, explore, …) are not part of the swarm
+ * workflow. They must be fully transparent to the swarm guardrail system:
+ *   - No write-authority blocks (DEFAULT_AGENT_AUTHORITY_RULES pass-through)
+ *   - No circuit-breaker / invocation-window tracking (resolveSessionAndWindow → null)
+ *
+ * Because resolveSessionAndWindow is a closure-local function, circuit-breaker
+ * exemption is verified indirectly: exhaust the max_tool_calls limit for a swarm
+ * agent to confirm limits apply, then verify native agents are not blocked even
+ * after the same number of calls.
+ */
+
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { OPENCODE_NATIVE_AGENTS } from '../../../src/config/constants.js';
+import type { GuardrailsConfig } from '../../../src/config/schema.js';
+import { createGuardrailsHooks } from '../../../src/hooks/guardrails.js';
+import {
+	resetSwarmState,
+	startAgentSession,
+	swarmState,
+} from '../../../src/state.js';
+
+const TEST_DIR = '/tmp';
+
+function cfg(overrides?: Partial<GuardrailsConfig>): GuardrailsConfig {
+	return {
+		enabled: true,
+		max_tool_calls: 5,
+		max_duration_minutes: 30,
+		idle_timeout_minutes: 60,
+		max_repetitions: 10,
+		max_consecutive_errors: 5,
+		warning_threshold: 0.75,
+		profiles: undefined,
+		...overrides,
+	};
+}
+
+describe('OPENCODE_NATIVE_AGENTS constant', () => {
+	it('contains the expected built-in agent names', () => {
+		expect(OPENCODE_NATIVE_AGENTS.has('build')).toBe(true);
+		expect(OPENCODE_NATIVE_AGENTS.has('plan')).toBe(true);
+		expect(OPENCODE_NATIVE_AGENTS.has('general')).toBe(true);
+		expect(OPENCODE_NATIVE_AGENTS.has('explore')).toBe(true);
+	});
+
+	it('does not contain swarm agent names', () => {
+		expect(OPENCODE_NATIVE_AGENTS.has('architect' as never)).toBe(false);
+		expect(OPENCODE_NATIVE_AGENTS.has('coder' as never)).toBe(false);
+		expect(OPENCODE_NATIVE_AGENTS.has('reviewer' as never)).toBe(false);
+	});
+});
+
+describe('Native agent write-authority pass-through via toolBefore (issue #559)', () => {
+	beforeEach(() => {
+		resetSwarmState();
+	});
+
+	it('build agent write is not blocked (exact repro: issue #559)', async () => {
+		const sid = 'native-build-session';
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, cfg());
+		startAgentSession(sid, 'build');
+
+		// Must not throw — was previously blocked with "Unknown agent: build"
+		await hooks.toolBefore(
+			{ tool: 'write', sessionID: sid, callID: 'call-1' },
+			{ args: { filePath: 'eslint.config.mts', content: '' } },
+		);
+	});
+
+	it('plan agent write is not blocked', async () => {
+		const sid = 'native-plan-session';
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, cfg());
+		startAgentSession(sid, 'plan');
+
+		await hooks.toolBefore(
+			{ tool: 'write', sessionID: sid, callID: 'call-2' },
+			{ args: { filePath: 'src/component.tsx', content: '' } },
+		);
+	});
+
+	it('general agent write is not blocked', async () => {
+		const sid = 'native-general-session';
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, cfg());
+		startAgentSession(sid, 'general');
+
+		await hooks.toolBefore(
+			{ tool: 'write', sessionID: sid, callID: 'call-3' },
+			{ args: { filePath: 'lib/utils.ts', content: '' } },
+		);
+	});
+
+	it('explore agent write is not blocked', async () => {
+		const sid = 'native-explore-session';
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, cfg());
+		startAgentSession(sid, 'explore');
+
+		await hooks.toolBefore(
+			{ tool: 'write', sessionID: sid, callID: 'call-4' },
+			{ args: { filePath: 'output.txt', content: '' } },
+		);
+	});
+});
+
+describe('Native agent circuit-breaker exemption via toolBefore', () => {
+	beforeEach(() => {
+		resetSwarmState();
+	});
+
+	it('swarm agent (coder) is blocked after exceeding max_tool_calls', async () => {
+		const limit = 3;
+		const sid = 'cb-swarm-session';
+		const hooks = createGuardrailsHooks(
+			TEST_DIR,
+			undefined,
+			cfg({
+				max_tool_calls: limit,
+				profiles: { coder: { max_tool_calls: limit } },
+			}),
+		);
+		startAgentSession(sid, 'coder');
+
+		// Fill to one below the limit (the limit-th call is the one that throws)
+		for (let i = 0; i < limit - 1; i++) {
+			await hooks.toolBefore(
+				{ tool: 'read', sessionID: sid, callID: `read-${i}` },
+				{ args: { filePath: `/test${i}.ts` } },
+			);
+		}
+
+		// The limit-th call must be blocked by the circuit breaker
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'read', sessionID: sid, callID: 'read-limit' },
+				{ args: { filePath: '/test-limit.ts' } },
+			),
+		).rejects.toThrow();
+	});
+
+	it('build agent is NOT blocked after exceeding swarm max_tool_calls limit', async () => {
+		const limit = 3;
+		const sid = 'cb-build-session';
+		const hooks = createGuardrailsHooks(
+			TEST_DIR,
+			undefined,
+			cfg({ max_tool_calls: limit }),
+		);
+		startAgentSession(sid, 'build');
+
+		// Make more calls than the limit — native agents must never be blocked
+		for (let i = 0; i <= limit + 2; i++) {
+			await hooks.toolBefore(
+				{ tool: 'read', sessionID: sid, callID: `read-${i}` },
+				{ args: { filePath: `/test${i}.ts` } },
+			);
+		}
+	});
+});

--- a/tests/unit/mutation/engine-enoent.test.ts
+++ b/tests/unit/mutation/engine-enoent.test.ts
@@ -75,8 +75,8 @@ describe('executeMutation — ENOENT error handling', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockSpawnSync.mockReturnValue(makeSuccess());
-		mockWriteFileSync.mockReturnValue(undefined as unknown as void);
-		mockUnlinkSync.mockReturnValue(undefined as unknown as void);
+		mockWriteFileSync.mockReturnValue(undefined as unknown as undefined);
+		mockUnlinkSync.mockReturnValue(undefined as unknown as undefined);
 	});
 
 	afterEach(() => {

--- a/tests/unit/mutation/engine-shell-injection.test.ts
+++ b/tests/unit/mutation/engine-shell-injection.test.ts
@@ -43,8 +43,8 @@ describe('executeMutation - shell injection mitigation', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 
-		mockWriteFileSync.mockReturnValue(undefined as unknown as void);
-		mockUnlinkSync.mockReturnValue(undefined as unknown as void);
+		mockWriteFileSync.mockReturnValue(undefined as unknown as undefined);
+		mockUnlinkSync.mockReturnValue(undefined as unknown as undefined);
 		mockPathJoin.mockImplementation((...args: string[]) => args.join('/'));
 
 		// Default: successful git apply and revert


### PR DESCRIPTION
## Summary
- Opencode's native agents (`build`, `plan`, `general`, `explore`) were being blocked by the swarm guardrails plugin with "Unknown agent" write-authority errors
- Added `OPENCODE_NATIVE_AGENTS` constant and exemptions to both write-authority check and circuit-breaker enforcement
- Native agents now operate transparently under opencode's own permission system only

## Test plan
- [x] Guardrails unit tests: 1032 pass, 0 fail (all guardrails tests included)
- [x] Authority pass-through tests for all native agents added
- [x] Circuit-breaker exemption verified via integration test
- [x] Regression test for exact issue #559 repro (eslint.config.mts) included
- [x] Pre-existing test failures in unrelated modules noted but not introduced by this change