### PR TITLE
fix: add 'diagnosis' as alias for 'diagnose' command (issue #588)

### DIFF
--- a/.claude/skills/swarm/SKILL.md
+++ b/.claude/skills/swarm/SKILL.md
@@ -17,7 +17,7 @@ Argument handling:
 
 Known plugin subcommands (do NOT interpret these as tasks):
 <!-- Keep in sync with COMMAND_REGISTRY in src/commands/registry.ts -->
-`status`, `plan`, `agents`, `history`, `config`, `evidence`, `handoff`, `archive`, `diagnose`, `preflight`, `sync-plan`, `benchmark`, `export`, `reset`, `rollback`, `retrieve`, `clarify`, `analyze`, `specify`, `brainstorm`, `qa-gates`, `dark-matter`, `knowledge`, `curate`, `turbo`, `full-auto`, `write-retro`, `reset-session`, `simulate`, `promote`, `checkpoint`, `close`
+`status`, `plan`, `agents`, `history`, `config`, `evidence`, `handoff`, `archive`, `diagnose`, `diagnosis`, `preflight`, `sync-plan`, `benchmark`, `export`, `reset`, `rollback`, `retrieve`, `clarify`, `analyze`, `specify`, `brainstorm`, `qa-gates`, `dark-matter`, `knowledge`, `curate`, `turbo`, `full-auto`, `write-retro`, `reset-session`, `simulate`, `promote`, `checkpoint`, `close`
 
 Examples:
 - `/swarm` — enable swarm mode only

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -44872,6 +44872,10 @@ var COMMAND_REGISTRY = {
     handler: (ctx) => handleDiagnoseCommand(ctx.directory, ctx.args),
     description: "Run health check on swarm state"
   },
+  diagnosis: {
+    handler: (ctx) => handleDiagnoseCommand(ctx.directory, ctx.args),
+    description: "Run health check on swarm state"
+  },
   preflight: {
     handler: (ctx) => handlePreflightCommand(ctx.directory, ctx.args),
     description: "Run preflight automation checks"

--- a/dist/commands/registry.d.ts
+++ b/dist/commands/registry.d.ts
@@ -68,6 +68,10 @@ export declare const COMMAND_REGISTRY: {
         readonly handler: (ctx: CommandContext) => Promise<string>;
         readonly description: "Run health check on swarm state";
     };
+    readonly diagnosis: {
+        readonly handler: (ctx: CommandContext) => Promise<string>;
+        readonly description: "Run health check on swarm state";
+    };
     readonly preflight: {
         readonly handler: (ctx: CommandContext) => Promise<string>;
         readonly description: "Run preflight automation checks";

--- a/dist/index.js
+++ b/dist/index.js
@@ -53974,6 +53974,10 @@ var init_registry = __esm(() => {
       handler: (ctx) => handleDiagnoseCommand(ctx.directory, ctx.args),
       description: "Run health check on swarm state"
     },
+    diagnosis: {
+      handler: (ctx) => handleDiagnoseCommand(ctx.directory, ctx.args),
+      description: "Run health check on swarm state"
+    },
     preflight: {
       handler: (ctx) => handlePreflightCommand(ctx.directory, ctx.args),
       description: "Run preflight automation checks"
@@ -88396,7 +88400,7 @@ var OpenCodeSwarm = async (ctx) => {
         ...opencodeConfig.command || {},
         swarm: {
           template: "/swarm $ARGUMENTS",
-          description: "Swarm management commands: /swarm [status|plan|agents|history|config|evidence|handoff|archive|diagnose|preflight|sync-plan|benchmark|export|reset|rollback|retrieve|clarify|analyze|specify|brainstorm|qa-gates|dark-matter|knowledge|curate|turbo|full-auto|write-retro|reset-session|simulate|promote|checkpoint|acknowledge-spec-drift|doctor-tools|close]"
+          description: "Swarm management commands: /swarm [status|plan|agents|history|config|evidence|handoff|archive|diagnose|diagnosis|preflight|sync-plan|benchmark|export|reset|rollback|retrieve|clarify|analyze|specify|brainstorm|qa-gates|dark-matter|knowledge|curate|turbo|full-auto|write-retro|reset-session|simulate|promote|checkpoint|acknowledge-spec-drift|doctor-tools|close]"
         },
         "swarm-status": {
           template: "/swarm status",
@@ -88433,6 +88437,10 @@ var OpenCodeSwarm = async (ctx) => {
         "swarm-diagnose": {
           template: "/swarm diagnose",
           description: "Use /swarm diagnose to run health checks on swarm state"
+        },
+        "swarm-diagnosis": {
+          template: "/swarm diagnosis",
+          description: "Use /swarm diagnosis to run health checks on swarm state"
         },
         "swarm-preflight": {
           template: "/swarm preflight",

--- a/docs/releases/v6.84.3.md
+++ b/docs/releases/v6.84.3.md
@@ -1,0 +1,27 @@
+# v6.84.3
+
+## What changed
+
+Fixed a bug where users typing `/swarm diagnosis` in Claude Code would trigger the swarm task workflow instead of executing the health check command.
+
+## Why
+
+The health check command is registered as `diagnose`, but users naturally type the noun form `diagnosis`. Without an alias, the swarm skill did not recognize `diagnosis` as a known plugin subcommand and instead treated it as a task description, causing Claude to reason about it rather than execute the health check.
+
+## Changes
+
+- Added `diagnosis` as a registry alias pointing to the same handler as `diagnose`
+- Added `diagnosis` to the skill's known-subcommand guard list so Claude Code CLI correctly routes it as a plugin command
+- Registered `swarm-diagnosis` OpenCode shortcut for UI discoverability
+- Added regression tests covering both generic and shortcut command paths
+
+## Migration steps
+
+None — this is a backward-compatible alias. Existing `/swarm diagnose` commands continue to work unchanged.
+
+## Known behavior change
+
+- **Claude Code CLI**: `/swarm diagnosis` now tells the user to run the command in OpenCode (same behavior as other plugin commands like `/swarm close`)
+- **OpenCode UI**: `/swarm diagnosis` now executes the health check, identical to `/swarm diagnose`
+
+## No breaking changes

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -124,6 +124,11 @@ export const COMMAND_REGISTRY = {
 		handler: (ctx) => handleDiagnoseCommand(ctx.directory, ctx.args),
 		description: 'Run health check on swarm state',
 	},
+	// Alias: users commonly type 'diagnosis' — route to the same handler as 'diagnose'.
+	diagnosis: {
+		handler: (ctx) => handleDiagnoseCommand(ctx.directory, ctx.args),
+		description: 'Run health check on swarm state',
+	},
 	preflight: {
 		handler: (ctx) => handlePreflightCommand(ctx.directory, ctx.args),
 		description: 'Run preflight automation checks',

--- a/src/commands/shortcut-routing.test.ts
+++ b/src/commands/shortcut-routing.test.ts
@@ -335,6 +335,65 @@ describe('swarm-* shortcut command routing', () => {
 		});
 	});
 
+	// Regression: 'diagnosis' alias — users commonly type this instead of 'diagnose'.
+	// Both the generic swarm handler and the swarm-diagnosis shortcut must resolve correctly.
+	describe("'diagnosis' alias routes to health check (issue #588)", () => {
+		it('/swarm diagnosis (generic handler) returns health check output', async () => {
+			const handler = createSwarmCommandHandler(tempDir, {});
+			const output = { parts: [] as unknown[] };
+
+			await handler(
+				{ command: 'swarm', arguments: 'diagnosis', sessionID: sessionId },
+				output,
+			);
+
+			expect(output.parts).toHaveLength(1);
+			const text = (output.parts[0] as { text: string }).text;
+			expect(text).not.toContain('## Swarm Commands');
+			expect(text).toContain('## Swarm Health Check');
+		});
+
+		it('swarm-diagnosis shortcut routes to health check output', async () => {
+			const handler = createSwarmCommandHandler(tempDir, {});
+			const output = { parts: [] as unknown[] };
+
+			await handler(
+				{ command: 'swarm-diagnosis', arguments: '', sessionID: sessionId },
+				output,
+			);
+
+			expect(output.parts).toHaveLength(1);
+			const text = (output.parts[0] as { text: string }).text;
+			expect(text).not.toContain('## Swarm Commands');
+			expect(text).toContain('## Swarm Health Check');
+		});
+
+		it('/swarm diagnose and /swarm diagnosis return the same kind of output', async () => {
+			const handler = createSwarmCommandHandler(tempDir, {});
+			const out1 = { parts: [] as unknown[] };
+			const out2 = { parts: [] as unknown[] };
+
+			await handler(
+				{ command: 'swarm', arguments: 'diagnose', sessionID: sessionId },
+				out1,
+			);
+			await handler(
+				{ command: 'swarm', arguments: 'diagnosis', sessionID: sessionId },
+				out2,
+			);
+
+			expect(out1.parts).toHaveLength(1);
+			expect(out2.parts).toHaveLength(1);
+			// Both must contain the health-check heading
+			expect((out1.parts[0] as { text: string }).text).toContain(
+				'## Swarm Health Check',
+			);
+			expect((out2.parts[0] as { text: string }).text).toContain(
+				'## Swarm Health Check',
+			);
+		});
+	});
+
 	// Regression: adding 'config-doctor' (dash) alias must not break the original
 	// space-based path '/swarm config doctor' which uses the generic swarm handler.
 	describe('Backward compatibility: space-based compound commands still work', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -647,7 +647,7 @@ const OpenCodeSwarm: Plugin = async (ctx) => {
 					// The actual command is handled by command.execute.before hook.
 					template: '/swarm $ARGUMENTS',
 					description:
-						'Swarm management commands: /swarm [status|plan|agents|history|config|evidence|handoff|archive|diagnose|preflight|sync-plan|benchmark|export|reset|rollback|retrieve|clarify|analyze|specify|brainstorm|qa-gates|dark-matter|knowledge|curate|turbo|full-auto|write-retro|reset-session|simulate|promote|checkpoint|acknowledge-spec-drift|doctor-tools|close]',
+						'Swarm management commands: /swarm [status|plan|agents|history|config|evidence|handoff|archive|diagnose|diagnosis|preflight|sync-plan|benchmark|export|reset|rollback|retrieve|clarify|analyze|specify|brainstorm|qa-gates|dark-matter|knowledge|curate|turbo|full-auto|write-retro|reset-session|simulate|promote|checkpoint|acknowledge-spec-drift|doctor-tools|close]',
 				},
 				// Individual subcommands for discoverability by weaker models (Haiku-class)
 				'swarm-status': {
@@ -690,6 +690,11 @@ const OpenCodeSwarm: Plugin = async (ctx) => {
 					template: '/swarm diagnose',
 					description:
 						'Use /swarm diagnose to run health checks on swarm state',
+				},
+				'swarm-diagnosis': {
+					template: '/swarm diagnosis',
+					description:
+						'Use /swarm diagnosis to run health checks on swarm state',
 				},
 				'swarm-preflight': {
 					template: '/swarm preflight',

--- a/tests/unit/index-commands.test.ts
+++ b/tests/unit/index-commands.test.ts
@@ -21,7 +21,7 @@ describe('Swarm subcommand registration', () => {
 		expect(typeof plugin.config).toBe('function');
 	});
 
-	it('should register 36 individual subcommands plus catch-all', async () => {
+	it('should register 37 individual subcommands plus catch-all', async () => {
 		const plugin = await OpenCodeSwarm(mockPluginInput);
 		const mockConfig: Record<string, unknown> = {};
 
@@ -34,8 +34,8 @@ describe('Swarm subcommand registration', () => {
 		expect(commands).toBeDefined();
 		const commandKeys = Object.keys(commands);
 
-		// Should have catch-all + 36 subcommands = 37 total
-		expect(commandKeys.length).toBe(37);
+		// Should have catch-all + 37 subcommands = 38 total
+		expect(commandKeys.length).toBe(38);
 
 		// Verify catch-all exists
 		expect(commands.swarm).toBeDefined();
@@ -54,11 +54,11 @@ describe('Swarm subcommand registration', () => {
 		expect(commands.swarm).toBeDefined();
 		expect(commands.swarm.template).toBe('/swarm $ARGUMENTS');
 		expect(commands.swarm.description).toBe(
-			'Swarm management commands: /swarm [status|plan|agents|history|config|evidence|handoff|archive|diagnose|preflight|sync-plan|benchmark|export|reset|rollback|retrieve|clarify|analyze|specify|brainstorm|qa-gates|dark-matter|knowledge|curate|turbo|full-auto|write-retro|reset-session|simulate|promote|checkpoint|acknowledge-spec-drift|doctor-tools|close]',
+			'Swarm management commands: /swarm [status|plan|agents|history|config|evidence|handoff|archive|diagnose|diagnosis|preflight|sync-plan|benchmark|export|reset|rollback|retrieve|clarify|analyze|specify|brainstorm|qa-gates|dark-matter|knowledge|curate|turbo|full-auto|write-retro|reset-session|simulate|promote|checkpoint|acknowledge-spec-drift|doctor-tools|close]',
 		);
 	});
 
-	it('should register all 36 individual subcommands with correct keys', async () => {
+	it('should register all 37 individual subcommands with correct keys', async () => {
 		const plugin = await OpenCodeSwarm(mockPluginInput);
 		const mockConfig: Record<string, unknown> = {};
 
@@ -105,6 +105,7 @@ describe('Swarm subcommand registration', () => {
 			'swarm-acknowledge-spec-drift',
 			'swarm-doctor-tools',
 			'swarm-close',
+			'swarm-diagnosis',
 		];
 
 		// Verify all expected subcommands exist


### PR DESCRIPTION
## Summary
- Fixed issue #588: `/swarm diagnosis` now executes the health check instead of triggering swarm task reasoning
- Added `diagnosis` as a registry alias to `diagnose` command
- Added `diagnosis` to the skill's known-subcommand guard list for Claude Code CLI routing
- Registered `swarm-diagnosis` OpenCode shortcut for improved discoverability

## Test plan
- [x] Tier 1: `bun run typecheck` (passed) and `bunx biome ci .` (86 pre-existing warnings, no new errors)
- [x] Tier 2: Unit tests on tools, services, agents, hooks, cli, commands, config (all direct tests passed; pre-existing failures in unrelated test suites)
- [x] Tier 3: Integration tests (660/748 passed; pre-existing failures unrelated to this change)
- [x] Tier 4: Security (97/97 passed); Adversarial (670/692 passed; pre-existing failures)
- [x] Tier 5: `bun run build` (succeeded); `bun test tests/smoke` (10/10 passed)
- [x] Shortcut routing regression tests: 20/20 pass including 3 new tests for the `diagnosis` alias
- [x] Built dist artifacts and included in commit

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyfCEs4virJmQFVGNjVxv6)_