### PR TITLE
fix(system-transform): collapse output.system to single entry for Qwen3.6/Gemma compatibility

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -88733,7 +88733,15 @@ var OpenCodeSwarm = async (ctx) => {
         } catch {}
         return Promise.resolve();
       },
-      automationConfig.capabilities?.phase_preflight === true && preflightTriggerManager ? createPhaseMonitorHook(ctx.directory, preflightTriggerManager, undefined, (sessionId) => createCuratorLLMDelegate(ctx.directory, "init", sessionId)) : knowledgeConfig.enabled ? createPhaseMonitorHook(ctx.directory, undefined, undefined, (sessionId) => createCuratorLLMDelegate(ctx.directory, "init", sessionId)) : undefined
+      automationConfig.capabilities?.phase_preflight === true && preflightTriggerManager ? createPhaseMonitorHook(ctx.directory, preflightTriggerManager, undefined, (sessionId) => createCuratorLLMDelegate(ctx.directory, "init", sessionId)) : knowledgeConfig.enabled ? createPhaseMonitorHook(ctx.directory, undefined, undefined, (sessionId) => createCuratorLLMDelegate(ctx.directory, "init", sessionId)) : undefined,
+      (_input, output) => {
+        if (Array.isArray(output.system) && output.system.length > 1) {
+          output.system = [output.system.join(`
+
+`)];
+        }
+        return Promise.resolve();
+      }
     ].filter(Boolean)),
     "experimental.session.compacting": compactionHook["experimental.session.compacting"],
     "command.execute.before": safeHook(commandHandler),

--- a/docs/releases/v6.85.1.md
+++ b/docs/releases/v6.85.1.md
@@ -1,0 +1,27 @@
+# OpenCode Swarm v6.85.1
+
+**Released:** 2026-04-26
+
+## What Changed
+
+### Bug Fix
+
+- **Single system message for local models (Qwen3.6, Gemma)** — Adds a final collapsing step to the `experimental.chat.system.transform` pipeline that joins all `output.system` entries into one string before OpenCode materializes them into the messages array. Models that require exactly one `{ role: "system" }` message at index 0 (Qwen3.6, Gemma, and similar local models) no longer crash or silently degrade when a plan.md with an active phase is present. (Resolves #608)
+
+## Why
+
+When a `plan.md` exists with an active phase, the swarm plugin's `system-enhancer` hook appends multiple strings to `output.system` via successive `output.system.push(...)` calls. OpenCode materializes each `output.system` entry into a separate `{ role: "system" }` message. Local models that enforce the single-system-message constraint crash or produce degraded output as a result.
+
+The existing `consolidateSystemMessages` utility runs in `experimental.chat.messages.transform`, but OpenCode materializes `output.system` entries *after* that hook runs, so it never saw the swarm-injected entries. The fix runs the collapse inside `experimental.chat.system.transform` itself, as the last step, ensuring materialization always receives a single entry.
+
+## Migration Steps
+
+None. The change is fully backward-compatible. Cloud models that accept multiple system messages are unaffected — the collapse only triggers when `output.system.length > 1`.
+
+## Breaking Changes
+
+None.
+
+## Known Caveats
+
+None.

--- a/src/index.ts
+++ b/src/index.ts
@@ -961,6 +961,12 @@ const OpenCodeSwarm: Plugin = async (ctx) => {
 									createCuratorLLMDelegate(ctx.directory, 'init', sessionId),
 							)
 						: undefined,
+				(_input: unknown, output: { system?: string[] }): Promise<void> => {
+					if (Array.isArray(output.system) && output.system.length > 1) {
+						output.system = [output.system.join('\n\n')];
+					}
+					return Promise.resolve();
+				},
 			].filter(Boolean) as Array<
 				(input: unknown, output: unknown) => Promise<void>
 			>),


### PR DESCRIPTION
## Summary
- Adds a final collapsing step as the last handler in `experimental.chat.system.transform` that joins all `output.system` entries into one string with `\n\n` before OpenCode materializes them into the messages array
- Fixes Qwen3.6, Gemma, and other local models that require exactly one `{ role: "system" }` message — previously they crashed or silently degraded when a `plan.md` with an active phase was present (each `output.system.push()` call in `system-enhancer` produced a separate system message)
- Root cause: `consolidateSystemMessages` runs in `messages.transform` but OpenCode materializes `output.system` entries *after* that hook, so the fix must live inside `system.transform` itself as the last step

## Test plan
- [x] `bun test tests/unit/hooks/system-enhancer-context-budget-wiring.test.ts` — 6 pass, 0 fail (existing assertion `expect(output.system.length).toBeGreaterThan(1)` unchanged; test calls hook in isolation, not through the composed pipeline)
- [x] `bun test tests/unit/hooks/messages-transform.test.ts tests/unit/hooks/system-message-consolidation.test.ts` — 52 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bunx biome ci .` — 81 pre-existing warnings, 0 errors, no fixes applied
- [x] Tier 2 unit tests (tools/services/agents/hooks per-file) — all pass; pre-existing failures confirmed identical with and without this change
- [x] Tier 3 integration tests — 88 pre-existing failures, identical baseline
- [x] Tier 4 security tests — 97 pass, 0 fail
- [x] Tier 4 adversarial tests — 22 pre-existing failures, identical baseline
- [x] `bun run build` — clean, dist/index.js updated and included in commit
- [x] `bun test tests/smoke` — 10 pass, 0 fail
- [x] Independent reviewer (7 checks) — all CONFIRMED
- [x] Critic challenge — all findings DISPROVED or overclaimed (pre-existing type pattern)

Closes #608