### PR TITLE
feat(config): add variant field with backward-compatible auto-split

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -18991,6 +18991,7 @@ for (const [agentName, tools] of Object.entries(AGENT_TOOL_MAP)) {
 // src/config/schema.ts
 var AgentOverrideConfigSchema = exports_external.object({
   model: exports_external.string().optional(),
+  variant: exports_external.string().min(1).optional(),
   temperature: exports_external.number().min(0).max(2).optional(),
   disabled: exports_external.boolean().optional(),
   fallback_models: exports_external.array(exports_external.string()).max(3).optional()

--- a/dist/config/schema.d.ts
+++ b/dist/config/schema.d.ts
@@ -16,6 +16,7 @@ import { z } from 'zod';
 export declare function stripKnownSwarmPrefix(agentName: string): string;
 export declare const AgentOverrideConfigSchema: z.ZodObject<{
     model: z.ZodOptional<z.ZodString>;
+    variant: z.ZodOptional<z.ZodString>;
     temperature: z.ZodOptional<z.ZodNumber>;
     disabled: z.ZodOptional<z.ZodBoolean>;
     fallback_models: z.ZodOptional<z.ZodArray<z.ZodString>>;
@@ -25,6 +26,7 @@ export declare const SwarmConfigSchema: z.ZodObject<{
     name: z.ZodOptional<z.ZodString>;
     agents: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{
         model: z.ZodOptional<z.ZodString>;
+        variant: z.ZodOptional<z.ZodString>;
         temperature: z.ZodOptional<z.ZodNumber>;
         disabled: z.ZodOptional<z.ZodBoolean>;
         fallback_models: z.ZodOptional<z.ZodArray<z.ZodString>>;
@@ -627,6 +629,7 @@ export type ParallelizationConfig = z.infer<typeof ParallelizationConfigSchema>;
 export declare const PluginConfigSchema: z.ZodObject<{
     agents: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{
         model: z.ZodOptional<z.ZodString>;
+        variant: z.ZodOptional<z.ZodString>;
         temperature: z.ZodOptional<z.ZodNumber>;
         disabled: z.ZodOptional<z.ZodBoolean>;
         fallback_models: z.ZodOptional<z.ZodArray<z.ZodString>>;
@@ -635,6 +638,7 @@ export declare const PluginConfigSchema: z.ZodObject<{
         name: z.ZodOptional<z.ZodString>;
         agents: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{
             model: z.ZodOptional<z.ZodString>;
+            variant: z.ZodOptional<z.ZodString>;
             temperature: z.ZodOptional<z.ZodNumber>;
             disabled: z.ZodOptional<z.ZodBoolean>;
             fallback_models: z.ZodOptional<z.ZodArray<z.ZodString>>;

--- a/dist/index.js
+++ b/dist/index.js
@@ -57733,7 +57733,15 @@ function applyOverrides(agent, swarmAgents, swarmPrefix) {
     agent.config.temperature = tempOverride;
   }
   const variantOverride = getVariantOverride(agent.name, swarmAgents, swarmPrefix);
-  if (variantOverride !== undefined) {
+  const modelSegments = agent.config.model?.split("/") ?? [];
+  if (modelSegments.length >= 3) {
+    const autoVariant = modelSegments[modelSegments.length - 1];
+    const cleanedModel = modelSegments.slice(0, -1).join("/");
+    const effectiveVariant = variantOverride ?? autoVariant;
+    console.warn(`[swarm] Deprecation: model "${agent.config.model}" embeds variant. ` + `Use "model": "${cleanedModel}", "variant": "${effectiveVariant}" instead.`);
+    agent.config.model = cleanedModel;
+    agent.config.variant = effectiveVariant;
+  } else if (variantOverride !== undefined) {
     agent.config.variant = variantOverride;
   }
   return agent;

--- a/dist/index.js
+++ b/dist/index.js
@@ -14739,6 +14739,7 @@ var init_schema = __esm(() => {
   SEPARATORS = ["_", "-", " "];
   AgentOverrideConfigSchema = exports_external.object({
     model: exports_external.string().optional(),
+    variant: exports_external.string().min(1).optional(),
     temperature: exports_external.number().min(0).max(2).optional(),
     disabled: exports_external.boolean().optional(),
     fallback_models: exports_external.array(exports_external.string()).max(3).optional()
@@ -57722,10 +57723,18 @@ function getTemperatureOverride(agentName, swarmAgents, swarmPrefix) {
   const baseAgentName = stripSwarmPrefix(agentName, swarmPrefix);
   return swarmAgents?.[baseAgentName]?.temperature;
 }
+function getVariantOverride(agentName, swarmAgents, swarmPrefix) {
+  const baseAgentName = stripSwarmPrefix(agentName, swarmPrefix);
+  return swarmAgents?.[baseAgentName]?.variant;
+}
 function applyOverrides(agent, swarmAgents, swarmPrefix) {
   const tempOverride = getTemperatureOverride(agent.name, swarmAgents, swarmPrefix);
   if (tempOverride !== undefined) {
     agent.config.temperature = tempOverride;
+  }
+  const variantOverride = getVariantOverride(agent.name, swarmAgents, swarmPrefix);
+  if (variantOverride !== undefined) {
+    agent.config.variant = variantOverride;
   }
   return agent;
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,35 @@ OpenCode's TUI accepts the shorthand `provider/model/variant` (e.g. `grove-opena
 }
 ```
 
+### Backward compatibility
+
+If you currently have a config like `{ "model": "grove-openai/gpt-5.3-codex/medium" }`, it will still work — the variant is automatically extracted and a deprecation warning is logged.
+
+**Before** (deprecated — produces a warning):
+
+```json
+{
+  "agents": {
+    "coder": {
+      "model": "grove-openai/gpt-5.3-codex/medium"
+    }
+  }
+}
+```
+
+**After** (recommended — silences the warning):
+
+```json
+{
+  "agents": {
+    "coder": {
+      "model": "grove-openai/gpt-5.3-codex",
+      "variant": "medium"
+    }
+  }
+}
+```
+
 ## How to verify the resolved config
 
 Run:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,37 @@ You only need to define the agents you want to override.
 
 > If `architect` is not set explicitly, it inherits the currently selected OpenCode UI model.
 
+## Per-agent override fields
+
+Each entry under `agents` accepts the following optional fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `model` | `"<provider>/<model>"` | Model id. **Do not** include a third `/<variant>` segment — see `variant` below. |
+| `variant` | `string` | Reasoning-effort variant for models that support it (e.g. `"low"`, `"medium"`, `"high"`, `"xhigh"` for `gpt-5.x` / `gpt-5.x-codex`). |
+| `temperature` | `0–2` | Sampling temperature override. |
+| `disabled` | `boolean` | Skip this agent entirely (it will not be registered). |
+| `fallback_models` | `string[]` (max 3) | Models to retry on transient errors (429/503/timeout). |
+
+### Why `variant` is its own field
+
+OpenCode's TUI accepts the shorthand `provider/model/variant` (e.g. `grove-openai/gpt-5.3-codex/medium`) in its model picker — the picker rewrites that input through a variant-aware resolver before applying it to the session. The agent loader, by contrast, uses a basic 2-segment parser, so embedding the variant into `model` resolves to a non-existent model id (`gpt-5.3-codex/medium`) and produces `ProviderModelNotFoundError`. Use the `variant` field instead:
+
+```json
+{
+  "agents": {
+    "test_engineer": {
+      "model": "grove-openai/gpt-5.3-codex",
+      "variant": "medium"
+    },
+    "designer": {
+      "model": "grove-openai/gpt-5.4",
+      "variant": "high"
+    }
+  }
+}
+```
+
 ## How to verify the resolved config
 
 Run:

--- a/docs/releases/v6.86.0.md
+++ b/docs/releases/v6.86.0.md
@@ -1,0 +1,74 @@
+# Release Notes — v6.86.0
+
+**Minor Release**
+
+---
+
+## Overview
+
+This release adds first-class support for **reasoning-effort variants** in per-agent overrides. Previously, configuring an agent with a model like `grove-openai/gpt-5.3-codex/medium` (the form OpenCode's TUI model picker uses) caused the subagent to fail to spin up with `ProviderModelNotFoundError`, because the agent loader uses OpenCode's basic 2-segment `provider/model` parser — not the variant-aware resolver the TUI applies. The variant ended up baked into the model id (`gpt-5.3-codex/medium`), which does not exist in the registry.
+
+`AgentOverrideConfigSchema` now exposes `variant` as a sibling field alongside `model`, mirroring how OpenCode's runtime Agent struct already represents reasoning effort internally.
+
+---
+
+## New Features
+
+### `variant` field in per-agent overrides
+
+```json
+{
+  "agents": {
+    "test_engineer": {
+      "model": "grove-openai/gpt-5.3-codex",
+      "variant": "medium"
+    },
+    "designer": {
+      "model": "grove-openai/gpt-5.4",
+      "variant": "high"
+    }
+  }
+}
+```
+
+When set, `variant` is plumbed through `applyOverrides` onto `agent.config.variant`, which OpenCode reads at session-prompt time as the reasoning-effort selector. Models without variant support simply ignore the field.
+
+The schema rejects empty strings and non-string values; absence is a no-op (the agent inherits whatever default the model exposes).
+
+---
+
+## Migration Notes
+
+If your `opencode-swarm.json` currently encodes a variant inside the model string:
+
+```json
+// before — fails at subagent dispatch with ProviderModelNotFoundError
+"test_engineer": { "model": "grove-openai/gpt-5.3-codex/medium" }
+```
+
+split it into two fields:
+
+```json
+// after
+"test_engineer": {
+  "model": "grove-openai/gpt-5.3-codex",
+  "variant": "medium"
+}
+```
+
+No changes required for agents using models without effort variants (e.g. Claude Opus, Kimi, Grok).
+
+---
+
+## Why this matters
+
+The previous behavior was a silent footgun: the same model string worked when typed into the TUI model picker but failed when copy-pasted into a swarm config, with an opaque `ProviderModelNotFoundError`. Splitting `variant` into its own field matches the underlying OpenCode Agent schema and makes the failure mode impossible to reach via configuration.
+
+---
+
+## Internal Changes
+
+- `AgentOverrideConfigSchema` (`src/config/schema.ts`) — new `variant: z.string().min(1).optional()` field
+- `applyOverrides` (`src/agents/index.ts`) — copies `variant` from swarm config onto `agent.config.variant`; new `getVariantOverride` helper alongside `getTemperatureOverride`
+- Documentation: `docs/configuration.md` gains a per-agent override reference table and a "Why `variant` is its own field" explainer
+- Tests: 5 new schema tests in `tests/unit/config/schema.test.ts` (accept with model, accept without model, reject empty string, reject non-string, omit when unset) and 2 new factory tests in `tests/unit/agents/factory.test.ts` (override applies, omitted when unconfigured)

--- a/docs/releases/v6.86.0.md
+++ b/docs/releases/v6.86.0.md
@@ -60,6 +60,18 @@ No changes required for agents using models without effort variants (e.g. Claude
 
 ---
 
+### Backward compatibility
+
+Existing configs that embed the variant in the model string (e.g. `"model": "grove-openai/gpt-5.3-codex/medium"`) continue to work — the variant is automatically extracted at load time and the following deprecation warning is logged:
+
+```
+[swarm] Deprecation: model "grove-openai/gpt-5.3-codex/medium" embeds variant. Use "model": "grove-openai/gpt-5.3-codex", "variant": "medium" instead.
+```
+
+To silence the warning, split the variant into its own `variant` field as shown in the migration notes above.
+
+---
+
 ## Why this matters
 
 The previous behavior was a silent footgun: the same model string worked when typed into the TUI model picker but failed when copy-pasted into a swarm config, with an opaque `ProviderModelNotFoundError`. Splitting `variant` into its own field matches the underlying OpenCode Agent schema and makes the failure mode impossible to reach via configuration.

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -174,11 +174,31 @@ function getTemperatureOverride(
 }
 
 /**
+ * Get variant (reasoning-effort) override for an agent.
+ *
+ * OpenCode reads the agent's reasoning effort from a top-level `variant` field
+ * on the agent definition (sibling to `model`), NOT from a third `/variant`
+ * segment in the model string. The TUI accepts `provider/model/variant` only
+ * because its model picker rewrites the input through a variant-aware resolver
+ * before applying it to the session; the agent loader uses the basic
+ * 2-segment parser, so encoding the variant in `model` raises
+ * ProviderModelNotFoundError. We expose `variant` as its own override field.
+ */
+function getVariantOverride(
+	agentName: string,
+	swarmAgents?: Record<string, { variant?: string }>,
+	swarmPrefix?: string,
+): string | undefined {
+	const baseAgentName = stripSwarmPrefix(agentName, swarmPrefix);
+	return swarmAgents?.[baseAgentName]?.variant;
+}
+
+/**
  * Apply config overrides to an agent definition
  */
 function applyOverrides(
 	agent: AgentDefinition,
-	swarmAgents?: Record<string, { temperature?: number }>,
+	swarmAgents?: Record<string, { temperature?: number; variant?: string }>,
 	swarmPrefix?: string,
 ): AgentDefinition {
 	const tempOverride = getTemperatureOverride(
@@ -188,6 +208,19 @@ function applyOverrides(
 	);
 	if (tempOverride !== undefined) {
 		agent.config.temperature = tempOverride;
+	}
+	const variantOverride = getVariantOverride(
+		agent.name,
+		swarmAgents,
+		swarmPrefix,
+	);
+	if (variantOverride !== undefined) {
+		// `variant` is not declared on @opencode-ai/sdk's AgentConfig type but
+		// the runtime Agent struct includes it (see opencode source:
+		// `variant: r.optional(r.String)` in the Agent schema). The SDK type
+		// has an open-ended index signature so this is structurally valid;
+		// the cast just satisfies the strict known-keys check.
+		(agent.config as { variant?: string }).variant = variantOverride;
 	}
 	return agent;
 }

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -214,7 +214,22 @@ function applyOverrides(
 		swarmAgents,
 		swarmPrefix,
 	);
-	if (variantOverride !== undefined) {
+	// Auto-split variant from model string for backward compatibility.
+	// If the model has 3+ segments (provider/model/variant), always clean it
+	// and use either the auto-split variant or the explicit variant override.
+	const modelSegments = agent.config.model?.split('/') ?? [];
+	if (modelSegments.length >= 3) {
+		const autoVariant = modelSegments[modelSegments.length - 1];
+		const cleanedModel = modelSegments.slice(0, -1).join('/');
+		const effectiveVariant = variantOverride ?? autoVariant;
+		console.warn(
+			`[swarm] Deprecation: model "${agent.config.model}" embeds variant. ` +
+				`Use "model": "${cleanedModel}", "variant": "${effectiveVariant}" instead.`,
+		);
+		agent.config.model = cleanedModel;
+		// Use explicit variant override if set, otherwise use auto-split variant
+		(agent.config as { variant?: string }).variant = effectiveVariant;
+	} else if (variantOverride !== undefined) {
 		// `variant` is not declared on @opencode-ai/sdk's AgentConfig type but
 		// the runtime Agent struct includes it (see opencode source:
 		// `variant: r.optional(r.String)` in the Agent schema). The SDK type

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -84,6 +84,15 @@ export function stripKnownSwarmPrefix(agentName: string): string {
 export const AgentOverrideConfigSchema = z
 	.object({
 		model: z.string().optional(),
+		// Reasoning-effort / model variant (e.g. "low" | "medium" | "high" for
+		// gpt-5.x-codex or gpt-5.x). OpenCode treats variants as a separate field
+		// from the model id at the registry level — it is NOT a third
+		// "provider/model/variant" segment in the model string. We surface it as
+		// its own override field so users can pin reasoning effort per agent
+		// without encoding it into `model` (which OpenCode's basic 2-segment
+		// parser would mis-resolve as a missing model id and raise
+		// ProviderModelNotFoundError).
+		variant: z.string().min(1).optional(),
 		temperature: z.number().min(0).max(2).optional(),
 		disabled: z.boolean().optional(),
 		fallback_models: z.array(z.string()).max(3).optional(),

--- a/tests/unit/agents/factory.test.ts
+++ b/tests/unit/agents/factory.test.ts
@@ -112,6 +112,38 @@ describe('createAgents', () => {
 			expect(coder?.config.temperature).toBe(0.5);
 		});
 
+		it('variant override applies correctly', () => {
+			const config = {
+				agents: {
+					test_engineer: {
+						model: 'grove-openai/gpt-5.3-codex',
+						variant: 'medium',
+					},
+				},
+			};
+
+			const agents = createAgents(config as unknown as PluginConfig);
+			const te = agents.find((a) => a.name === 'test_engineer');
+			expect(te?.config.model).toBe('grove-openai/gpt-5.3-codex');
+			expect((te?.config as { variant?: string } | undefined)?.variant).toBe(
+				'medium',
+			);
+		});
+
+		it('variant is omitted when not configured', () => {
+			const config = {
+				agents: {
+					coder: { model: 'custom/model' },
+				},
+			};
+
+			const agents = createAgents(config as unknown as PluginConfig);
+			const coder = agents.find((a) => a.name === 'coder');
+			expect(
+				(coder?.config as { variant?: string } | undefined)?.variant,
+			).toBeUndefined();
+		});
+
 		it('disabled agent is filtered out', () => {
 			const config = {
 				agents: {

--- a/tests/unit/agents/factory.test.ts
+++ b/tests/unit/agents/factory.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -142,6 +142,65 @@ describe('createAgents', () => {
 			expect(
 				(coder?.config as { variant?: string } | undefined)?.variant,
 			).toBeUndefined();
+		});
+
+		it('auto-splits variant from 3-segment model string', () => {
+			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+			const config = {
+				agents: {
+					coder: {
+						model: 'grove-openai/gpt-5.3-codex/medium',
+					},
+				},
+			};
+
+			const agents = createAgents(config as unknown as PluginConfig);
+			const coder = agents.find((a) => a.name === 'coder');
+			expect(coder?.config.model).toBe('grove-openai/gpt-5.3-codex');
+			expect((coder?.config as { variant?: string } | undefined)?.variant).toBe(
+				'medium',
+			);
+			expect(warnSpy).toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+
+		it('explicit variant override takes precedence over auto-split', () => {
+			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+			const config = {
+				agents: {
+					coder: {
+						model: 'grove-openai/gpt-5.3-codex/medium',
+						variant: 'high',
+					},
+				},
+			};
+
+			const agents = createAgents(config as unknown as PluginConfig);
+			const coder = agents.find((a) => a.name === 'coder');
+			expect(coder?.config.model).toBe('grove-openai/gpt-5.3-codex');
+			expect((coder?.config as { variant?: string } | undefined)?.variant).toBe(
+				'high',
+			);
+			expect(warnSpy).toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+
+		it('does not modify 2-segment model string', () => {
+			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+			const config = {
+				agents: {
+					coder: { model: 'custom/model' },
+				},
+			};
+
+			const agents = createAgents(config as unknown as PluginConfig);
+			const coder = agents.find((a) => a.name === 'coder');
+			expect(coder?.config.model).toBe('custom/model');
+			expect(
+				(coder?.config as { variant?: string } | undefined)?.variant,
+			).toBeUndefined();
+			expect(warnSpy).not.toHaveBeenCalled();
+			warnSpy.mockRestore();
 		});
 
 		it('disabled agent is filtered out', () => {

--- a/tests/unit/config/schema.test.ts
+++ b/tests/unit/config/schema.test.ts
@@ -165,6 +165,47 @@ describe('AgentOverrideConfigSchema', () => {
 		expect(warnings.some((w) => w.includes('fallback_models'))).toBe(false);
 	});
 
+	// Variant (reasoning-effort) field tests
+	it('accepts variant field with model', () => {
+		const result = AgentOverrideConfigSchema.safeParse({
+			model: 'grove-openai/gpt-5.3-codex',
+			variant: 'medium',
+			fallback_models: ['fallback-1'],
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.variant).toBe('medium');
+			expect(result.data.model).toBe('grove-openai/gpt-5.3-codex');
+		}
+	});
+
+	it('accepts variant field without model', () => {
+		const result = AgentOverrideConfigSchema.safeParse({ variant: 'high' });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.variant).toBe('high');
+			expect(result.data.model).toBeUndefined();
+		}
+	});
+
+	it('rejects empty-string variant', () => {
+		const result = AgentOverrideConfigSchema.safeParse({ variant: '' });
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects non-string variant', () => {
+		const result = AgentOverrideConfigSchema.safeParse({ variant: 5 });
+		expect(result.success).toBe(false);
+	});
+
+	it('omits variant when not set', () => {
+		const result = AgentOverrideConfigSchema.safeParse({ model: 'm' });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.variant).toBeUndefined();
+		}
+	});
+
 	it('accepts valid fallback_models array with up to 3 items', () => {
 		const result = AgentOverrideConfigSchema.safeParse({
 			fallback_models: ['fallback-1', 'fallback-2', 'fallback-3'],


### PR DESCRIPTION
## Summary

Extends PR #647 with backward-compatible auto-split for variant in model strings.

### Changes from #647
- Adds `variant` field to `AgentOverrideConfigSchema` for reasoning effort
- Plumbs `variant` through `applyOverrides` to `agent.config.variant`

### New in this PR
- **Backward-compatible auto-split**: 3-segment model strings (`provider/model/variant`) are automatically split with a deprecation warning
- **3 new tests** for backward-compat behavior
- **Updated docs** with backward compatibility notes

### Behavior

| Config | Result |
|---|---|
| `{ "model": "p/m/v" }` | Auto-splits to `model="p/m"`, `variant="v"`, logs deprecation warning |
| `{ "model": "p/m", "variant": "v" }` | Uses explicit variant (recommended) |
| `{ "model": "p/m/v", "variant": "x" }` | Cleans model, uses explicit variant, warns |
| `{ "model": "p/m" }` | Unchanged, no variant |

### Test Plan
- [x] `bun test tests/unit/agents/factory.test.ts` — 29 pass
- [x] `bun run typecheck` — clean
- [x] `bunx biome ci .` — no new issues
- [x] `bun run build` — bundles cleanly

Closes #647
