### PR TITLE
fix(tui): eliminate per-agent advisory spam from fallback_models warning

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -18598,7 +18598,7 @@ import * as path33 from "path";
 // package.json
 var package_default = {
   name: "opencode-swarm",
-  version: "6.86.9",
+  version: "6.86.10",
   description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
   main: "dist/index.js",
   types: "dist/index.d.ts",
@@ -19109,13 +19109,6 @@ var AgentOverrideConfigSchema = exports_external.object({
   temperature: exports_external.number().min(0).max(2).optional(),
   disabled: exports_external.boolean().optional(),
   fallback_models: exports_external.array(exports_external.string()).max(3).optional()
-}).refine((data) => {
-  if (data.model && !data.fallback_models) {
-    console.warn(`[opencode-swarm] WARNING: Agent configured with custom model "${data.model}" but no fallback_models. This means if the custom model fails, there is no fallback protection. Consider adding fallback_models for reliability.`);
-  }
-  return true;
-}, {
-  message: "Agent configuration warning: Custom model without fallback protection"
 });
 var SwarmConfigSchema = exports_external.object({
   name: exports_external.string().optional(),

--- a/dist/index.js
+++ b/dist/index.js
@@ -88789,18 +88789,19 @@ async function initializeOpenCodeSwarm(ctx) {
   }
   {
     const noFallback = [];
+    const hasNoFallback = (cfg) => cfg.model && (!cfg.fallback_models || cfg.fallback_models.length === 0);
     if (config3.agents) {
       for (const [name2, cfg] of Object.entries(config3.agents)) {
-        if (cfg.model && !cfg.fallback_models)
-          noFallback.push(name2);
+        if (hasNoFallback(cfg))
+          noFallback.push(`${name2}(${cfg.model})`);
       }
     }
     if (config3.swarms) {
       for (const [swarmId, swarm] of Object.entries(config3.swarms)) {
         if (swarm.agents) {
           for (const [name2, cfg] of Object.entries(swarm.agents)) {
-            if (cfg.model && !cfg.fallback_models)
-              noFallback.push(`${swarmId}/${name2}`);
+            if (hasNoFallback(cfg))
+              noFallback.push(`${swarmId}/${name2}(${cfg.model})`);
           }
         }
       }

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "6.86.9",
+    version: "6.86.10",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -14816,13 +14816,6 @@ var init_schema = __esm(() => {
     temperature: exports_external.number().min(0).max(2).optional(),
     disabled: exports_external.boolean().optional(),
     fallback_models: exports_external.array(exports_external.string()).max(3).optional()
-  }).refine((data) => {
-    if (data.model && !data.fallback_models) {
-      console.warn(`[opencode-swarm] WARNING: Agent configured with custom model "${data.model}" but no fallback_models. This means if the custom model fails, there is no fallback protection. Consider adding fallback_models for reliability.`);
-    }
-    return true;
-  }, {
-    message: "Agent configuration warning: Custom model without fallback protection"
   });
   SwarmConfigSchema = exports_external.object({
     name: exports_external.string().optional(),
@@ -88791,6 +88784,33 @@ async function initializeOpenCodeSwarm(ctx) {
         console.warn(warning);
       } else {
         addDeferredWarning(warning);
+      }
+    }
+  }
+  {
+    const noFallback = [];
+    if (config3.agents) {
+      for (const [name2, cfg] of Object.entries(config3.agents)) {
+        if (cfg.model && !cfg.fallback_models)
+          noFallback.push(name2);
+      }
+    }
+    if (config3.swarms) {
+      for (const [swarmId, swarm] of Object.entries(config3.swarms)) {
+        if (swarm.agents) {
+          for (const [name2, cfg] of Object.entries(swarm.agents)) {
+            if (cfg.model && !cfg.fallback_models)
+              noFallback.push(`${swarmId}/${name2}`);
+          }
+        }
+      }
+    }
+    if (noFallback.length > 0) {
+      const msg = `[opencode-swarm] WARNING: ${noFallback.length} agent(s) use a custom model without fallback_models: ` + noFallback.join(", ") + '. Add "fallback_models": ["model-a"] to each agent config for reliability.';
+      if (!config3.quiet) {
+        console.warn(msg);
+      } else {
+        addDeferredWarning(msg);
       }
     }
   }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -81,38 +81,21 @@ export function stripKnownSwarmPrefix(agentName: string): string {
 }
 
 // Agent override configuration
-export const AgentOverrideConfigSchema = z
-	.object({
-		model: z.string().optional(),
-		// Reasoning-effort / model variant (e.g. "low" | "medium" | "high" for
-		// gpt-5.x-codex or gpt-5.x). OpenCode treats variants as a separate field
-		// from the model id at the registry level — it is NOT a third
-		// "provider/model/variant" segment in the model string. We surface it as
-		// its own override field so users can pin reasoning effort per agent
-		// without encoding it into `model` (which OpenCode's basic 2-segment
-		// parser would mis-resolve as a missing model id and raise
-		// ProviderModelNotFoundError).
-		variant: z.string().min(1).optional(),
-		temperature: z.number().min(0).max(2).optional(),
-		disabled: z.boolean().optional(),
-		fallback_models: z.array(z.string()).max(3).optional(),
-	})
-	.refine(
-		(data) => {
-			// If model is explicitly set but fallback_models is not, warn about potential loss of protection
-			if (data.model && !data.fallback_models) {
-				console.warn(
-					`[opencode-swarm] WARNING: Agent configured with custom model "${data.model}" but no fallback_models. This means if the custom model fails, there is no fallback protection. Consider adding fallback_models for reliability.`,
-				);
-			}
-			// Always pass validation — this is a warning, not a block
-			return true;
-		},
-		{
-			message:
-				'Agent configuration warning: Custom model without fallback protection',
-		},
-	);
+export const AgentOverrideConfigSchema = z.object({
+	model: z.string().optional(),
+	// Reasoning-effort / model variant (e.g. "low" | "medium" | "high" for
+	// gpt-5.x-codex or gpt-5.x). OpenCode treats variants as a separate field
+	// from the model id at the registry level — it is NOT a third
+	// "provider/model/variant" segment in the model string. We surface it as
+	// its own override field so users can pin reasoning effort per agent
+	// without encoding it into `model` (which OpenCode's basic 2-segment
+	// parser would mis-resolve as a missing model id and raise
+	// ProviderModelNotFoundError).
+	variant: z.string().min(1).optional(),
+	temperature: z.number().min(0).max(2).optional(),
+	disabled: z.boolean().optional(),
+	fallback_models: z.array(z.string()).max(3).optional(),
+});
 
 export type AgentOverrideConfig = z.infer<typeof AgentOverrideConfigSchema>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,6 +236,39 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 		}
 	}
 
+	// Warn once about agents with custom models but no fallback_models configured.
+	// Collect all violating agent names across top-level agents and all swarms, then
+	// emit a single consolidated message so the TUI is not spammed per-agent.
+	{
+		const noFallback: string[] = [];
+		if (config.agents) {
+			for (const [name, cfg] of Object.entries(config.agents)) {
+				if (cfg.model && !cfg.fallback_models) noFallback.push(name);
+			}
+		}
+		if (config.swarms) {
+			for (const [swarmId, swarm] of Object.entries(config.swarms)) {
+				if (swarm.agents) {
+					for (const [name, cfg] of Object.entries(swarm.agents)) {
+						if (cfg.model && !cfg.fallback_models)
+							noFallback.push(`${swarmId}/${name}`);
+					}
+				}
+			}
+		}
+		if (noFallback.length > 0) {
+			const msg =
+				`[opencode-swarm] WARNING: ${noFallback.length} agent(s) use a custom model without fallback_models: ` +
+				noFallback.join(', ') +
+				'. Add "fallback_models": ["model-a"] to each agent config for reliability.';
+			if (!config.quiet) {
+				console.warn(msg);
+			} else {
+				addDeferredWarning(msg);
+			}
+		}
+	}
+
 	// Track whether full-auto mode is enabled in config
 	swarmState.fullAutoEnabledInConfig = config.full_auto?.enabled === true;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,21 +237,26 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 	}
 
 	// Warn once about agents with custom models but no fallback_models configured.
-	// Collect all violating agent names across top-level agents and all swarms, then
+	// Collect all violating agents across top-level agents and all swarms, then
 	// emit a single consolidated message so the TUI is not spammed per-agent.
+	// Note: fallback_models:[] is treated as "no fallback" — an empty array provides
+	// no runtime protection (resolveFallbackModel returns null for length === 0).
 	{
 		const noFallback: string[] = [];
+		const hasNoFallback = (cfg: { model?: string; fallback_models?: string[] }) =>
+			cfg.model && (!cfg.fallback_models || cfg.fallback_models.length === 0);
+
 		if (config.agents) {
 			for (const [name, cfg] of Object.entries(config.agents)) {
-				if (cfg.model && !cfg.fallback_models) noFallback.push(name);
+				if (hasNoFallback(cfg)) noFallback.push(`${name}(${cfg.model})`);
 			}
 		}
 		if (config.swarms) {
 			for (const [swarmId, swarm] of Object.entries(config.swarms)) {
 				if (swarm.agents) {
 					for (const [name, cfg] of Object.entries(swarm.agents)) {
-						if (cfg.model && !cfg.fallback_models)
-							noFallback.push(`${swarmId}/${name}`);
+						if (hasNoFallback(cfg))
+							noFallback.push(`${swarmId}/${name}(${cfg.model})`);
 					}
 				}
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,7 +243,10 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 	// no runtime protection (resolveFallbackModel returns null for length === 0).
 	{
 		const noFallback: string[] = [];
-		const hasNoFallback = (cfg: { model?: string; fallback_models?: string[] }) =>
+		const hasNoFallback = (cfg: {
+			model?: string;
+			fallback_models?: string[];
+		}) =>
 			cfg.model && (!cfg.fallback_models || cfg.fallback_models.length === 0);
 
 		if (config.agents) {

--- a/tests/unit/config/schema.test.ts
+++ b/tests/unit/config/schema.test.ts
@@ -173,6 +173,18 @@ describe('AgentOverrideConfigSchema', () => {
 		expect(warnings.some((w) => w.includes('fallback_models'))).toBe(false);
 	});
 
+	it('accepts empty fallback_models array (schema-valid; plugin-init warning catches it)', () => {
+		// fallback_models:[] is schema-valid but provides no runtime protection.
+		// The consolidated warning in initializeOpenCodeSwarm checks length===0
+		// and treats it identically to undefined.
+		const result = AgentOverrideConfigSchema.safeParse({
+			model: 'custom-model',
+			fallback_models: [],
+		});
+		expect(result.success).toBe(true);
+		expect(result.data?.fallback_models).toEqual([]);
+	});
+
 	// Variant (reasoning-effort) field tests
 	it('accepts variant field with model', () => {
 		const result = AgentOverrideConfigSchema.safeParse({

--- a/tests/unit/config/schema.test.ts
+++ b/tests/unit/config/schema.test.ts
@@ -99,7 +99,9 @@ describe('AgentOverrideConfigSchema', () => {
 	});
 
 	// Fallback models validation tests
-	it('warns when model is set without fallback_models', () => {
+	it('parses without side effects when model is set without fallback_models', () => {
+		// The schema no longer emits console.warn itself; the advisory is collected
+		// and emitted once at plugin initialization to avoid per-agent spam.
 		const originalWarn = console.warn;
 		const warnings: string[] = [];
 		console.warn = (...args: unknown[]) => {
@@ -113,8 +115,10 @@ describe('AgentOverrideConfigSchema', () => {
 		console.warn = originalWarn;
 
 		expect(result.success).toBe(true);
-		expect(warnings.some((w) => w.includes('custom-model'))).toBe(true);
-		expect(warnings.some((w) => w.includes('fallback_models'))).toBe(true);
+		expect(result.data?.model).toBe('custom-model');
+		expect(result.data?.fallback_models).toBeUndefined();
+		// Schema itself must not emit any warnings — advisory lives in initializeOpenCodeSwarm
+		expect(warnings.length).toBe(0);
 	});
 
 	it('does not warn when model is set with fallback_models', () => {


### PR DESCRIPTION
## Summary
- Fixed TUI being spammed with dozens of per-agent advisory messages about missing `fallback_models` on startup
- Moved warning from Zod schema refine (which fired once per agent per parse) to single consolidated check at plugin init
- Enhanced warning message to include model names alongside agent names for better actionability
- Fixed empty-array bypass: `fallback_models: []` now caught (previously silent despite providing zero runtime protection)

## Test plan
- [x] All 5-tier test suite passed: typecheck + biome, unit tests (938 pass, 1 pre-existing fail), integration (662 pass, 94 pre-existing fail), security (97 pass), adversarial (691 pass, 1 pre-existing fail), smoke (10 pass)
- [x] Biome auto-fixed formatting in src/index.ts and rebuilt dist artifacts
- [x] Pre-existing failures confirmed unchanged on baseline

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZNUbH2VyRoB8V4EQzNNK)_