### PR TITLE
fix(#583,#698): confine SWARM_PLAN to .swarm/, prevent spiral commits, fix update across platforms

### DIFF
--- a/dist/cli/index.d.ts
+++ b/dist/cli/index.d.ts
@@ -1,4 +1,34 @@
 #!/usr/bin/env bun
+export declare function isSafeCachePath(p: string): boolean;
+/**
+ * Safety guard for lock file deletion. Lock files have different basenames
+ * than cache directories so they need a separate check. Mirrors
+ * isSafeCachePath()'s defense-in-depth: minimum segment depth, recognized
+ * basename, and parent directory must be 'opencode'.
+ */
+export declare function isSafeLockFilePath(p: string): boolean;
+/**
+ * Recursively delete every known opencode plugin cache location for
+ * opencode-swarm. Returns paths actually cleared and paths that errored.
+ * Skips paths that don't exist or fail the safety guard.
+ */
+export declare function evictPluginCaches(): {
+    cleared: string[];
+    failed: string[];
+};
+/**
+ * Delete every known opencode plugin lock file (bun.lock, bun.lockb,
+ * package-lock.json). Returns paths actually cleared and paths that
+ * errored. Skips paths that don't exist or fail the safety guard.
+ *
+ * Why: opencode runs `bun install` at startup; bun.lock pins the
+ * installed plugin version. Deleting the lock forces re-resolution
+ * from npm so users actually receive the @latest version after `update`.
+ */
+export declare function evictLockFiles(): {
+    cleared: string[];
+    failed: string[];
+};
 /**
  * Dispatch function for routing argv tokens to plugin command handlers.
  * Used by the "run" subcommand entry point.

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -14754,7 +14754,7 @@ async function loadPlan(directory) {
                   const rebuilt = await replayFromLedger(directory);
                   if (rebuilt) {
                     await rebuildPlan(directory, rebuilt);
-                    warn("[loadPlan] Rebuilt plan from ledger. Checkpoint available at SWARM_PLAN.md if it exists.");
+                    warn("[loadPlan] Rebuilt plan from ledger. Checkpoint available at .swarm/SWARM_PLAN.md if it exists.");
                     return rebuilt;
                   }
                 } catch (replayError) {
@@ -14775,7 +14775,7 @@ async function loadPlan(directory) {
                       return approved.plan;
                     }
                   } catch {}
-                  warn(`[loadPlan] Ledger replay failed during hash-mismatch rebuild: ${replayError instanceof Error ? replayError.message : String(replayError)}. Returning stale plan.json. To recover: check SWARM_PLAN.md for a checkpoint, or run /swarm reset-session.`);
+                  warn(`[loadPlan] Ledger replay failed during hash-mismatch rebuild: ${replayError instanceof Error ? replayError.message : String(replayError)}. Returning stale plan.json. To recover: check .swarm/SWARM_PLAN.md for a checkpoint, or run /swarm reset-session.`);
                 }
               }
             }
@@ -14821,7 +14821,7 @@ async function loadPlan(directory) {
         }
         return validated;
       } catch (error49) {
-        warn(`[loadPlan] plan.json validation failed: ${error49 instanceof Error ? error49.message : String(error49)}. Attempting rebuild from ledger. If rebuild fails, check SWARM_PLAN.md for a checkpoint.`);
+        warn(`[loadPlan] plan.json validation failed: ${error49 instanceof Error ? error49.message : String(error49)}. Attempting rebuild from ledger. If rebuild fails, check .swarm/SWARM_PLAN.md for a checkpoint.`);
         let rawPlanId = null;
         try {
           const rawParsed = JSON.parse(planJsonContent);
@@ -18595,11 +18595,11 @@ var init_evidence_summary_service = __esm(() => {
 // src/cli/index.ts
 import * as fs21 from "fs";
 import * as os7 from "os";
-import * as path33 from "path";
+import * as path34 from "path";
 // package.json
 var package_default = {
   name: "opencode-swarm",
-  version: "6.86.14",
+  version: "7.0.0",
   description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
   main: "dist/index.js",
   types: "dist/index.d.ts",
@@ -35510,22 +35510,20 @@ async function handleCloseCommand(directory, args) {
     }
   } catch {}
   let swarmPlanFilesRemoved = 0;
-  const swarmPlanJsonPath = path12.join(directory, "SWARM_PLAN.json");
-  const swarmPlanMdPath = path12.join(directory, "SWARM_PLAN.md");
-  try {
-    await fs7.unlink(swarmPlanJsonPath);
-    swarmPlanFilesRemoved++;
-  } catch (err) {
-    if (err?.code !== "ENOENT") {
-      warnings.push(`Failed to remove SWARM_PLAN.json: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
-  try {
-    await fs7.unlink(swarmPlanMdPath);
-    swarmPlanFilesRemoved++;
-  } catch (err) {
-    if (err?.code !== "ENOENT") {
-      warnings.push(`Failed to remove SWARM_PLAN.md: ${err instanceof Error ? err.message : String(err)}`);
+  const candidates = [
+    path12.join(directory, ".swarm", "SWARM_PLAN.json"),
+    path12.join(directory, ".swarm", "SWARM_PLAN.md"),
+    path12.join(directory, "SWARM_PLAN.json"),
+    path12.join(directory, "SWARM_PLAN.md")
+  ];
+  for (const candidate of candidates) {
+    try {
+      await fs7.unlink(candidate);
+      swarmPlanFilesRemoved++;
+    } catch (err) {
+      if (err?.code !== "ENOENT") {
+        warnings.push(`Failed to remove ${path12.basename(candidate)}: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
   }
   clearAllScopes(directory);
@@ -35600,9 +35598,7 @@ async function handleCloseCommand(directory, args) {
     "- Reset context.md for next session",
     "- Cleared agent sessions and delegation chains",
     ...configBackupsRemoved > 0 ? [`- Removed ${configBackupsRemoved} stale config backup file(s)`] : [],
-    ...swarmPlanFilesRemoved > 0 ? [
-      `- Removed ${swarmPlanFilesRemoved} root-level SWARM_PLAN checkpoint artifact(s)`
-    ] : [],
+    ...swarmPlanFilesRemoved > 0 ? [`- Removed ${swarmPlanFilesRemoved} SWARM_PLAN checkpoint artifact(s)`] : [],
     ...planExists && !planAlreadyDone ? ["- Set non-completed phases/tasks to closed status"] : [],
     ...curationSucceeded && allLessons.length > 0 ? [`- Committed ${allLessons.length} lesson(s) to knowledge store`] : [],
     "",
@@ -36489,11 +36485,39 @@ function getPluginConfigDir() {
 function getPluginCachePaths() {
   const cacheBase = process.env.XDG_CACHE_HOME || path17.join(os5.homedir(), ".cache");
   const configDir = getPluginConfigDir();
-  return [
+  const paths = [
+    path17.join(cacheBase, "opencode", "node_modules", "opencode-swarm"),
     path17.join(cacheBase, "opencode", "packages", "opencode-swarm@latest"),
-    path17.join(configDir, "node_modules", "opencode-swarm"),
-    path17.join(cacheBase, "opencode", "node_modules", "opencode-swarm")
+    path17.join(configDir, "node_modules", "opencode-swarm")
   ];
+  if (process.platform === "darwin") {
+    const libCaches = path17.join(os5.homedir(), "Library", "Caches");
+    paths.push(path17.join(libCaches, "opencode", "node_modules", "opencode-swarm"), path17.join(libCaches, "opencode", "packages", "opencode-swarm@latest"));
+  }
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA || path17.join(os5.homedir(), "AppData", "Local");
+    const appData = process.env.APPDATA || path17.join(os5.homedir(), "AppData", "Roaming");
+    paths.push(path17.join(localAppData, "opencode", "node_modules", "opencode-swarm"), path17.join(localAppData, "opencode", "packages", "opencode-swarm@latest"), path17.join(appData, "opencode", "node_modules", "opencode-swarm"));
+  }
+  return paths;
+}
+function getPluginLockFilePaths() {
+  const cacheBase = process.env.XDG_CACHE_HOME || path17.join(os5.homedir(), ".cache");
+  const configDir = getPluginConfigDir();
+  const paths = [
+    path17.join(cacheBase, "opencode", "bun.lock"),
+    path17.join(cacheBase, "opencode", "bun.lockb"),
+    path17.join(configDir, "package-lock.json")
+  ];
+  if (process.platform === "darwin") {
+    const libCaches = path17.join(os5.homedir(), "Library", "Caches");
+    paths.push(path17.join(libCaches, "opencode", "bun.lock"), path17.join(libCaches, "opencode", "bun.lockb"));
+  }
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA || path17.join(os5.homedir(), "AppData", "Local");
+    paths.push(path17.join(localAppData, "opencode", "bun.lock"), path17.join(localAppData, "opencode", "bun.lockb"));
+  }
+  return paths;
 }
 
 // src/services/diagnose-service.ts
@@ -44472,6 +44496,7 @@ async function handleQaGatesCommand(directory, args, sessionID) {
 
 // src/commands/reset.ts
 import * as fs18 from "fs";
+import * as path30 from "path";
 
 // src/background/manager.ts
 init_utils();
@@ -45159,7 +45184,7 @@ async function handleResetCommand(directory, args) {
     return [
       "## Swarm Reset",
       "",
-      "\u26A0\uFE0F This will delete plan.md and context.md from .swarm/",
+      "\u26A0\uFE0F This will delete all swarm state from .swarm/ (plan, context, checkpoints, SWARM_PLAN artifacts)",
       "",
       "**Tip**: Run `/swarm export` first to backup your state.",
       "",
@@ -45167,7 +45192,15 @@ async function handleResetCommand(directory, args) {
     ].join(`
 `);
   }
-  const filesToReset = ["plan.md", "context.md"];
+  const filesToReset = [
+    "plan.md",
+    "plan.json",
+    "context.md",
+    "SWARM_PLAN.md",
+    "SWARM_PLAN.json",
+    "checkpoints.json",
+    "events.jsonl"
+  ];
   const results = [];
   for (const filename of filesToReset) {
     try {
@@ -45181,6 +45214,15 @@ async function handleResetCommand(directory, args) {
     } catch {
       results.push(`- \u274C Failed to delete ${filename}`);
     }
+  }
+  for (const filename of ["SWARM_PLAN.md", "SWARM_PLAN.json"]) {
+    try {
+      const rootPath = path30.join(directory, filename);
+      if (fs18.existsSync(rootPath)) {
+        fs18.unlinkSync(rootPath);
+        results.push(`- \u2705 Deleted ${filename} (root)`);
+      }
+    } catch {}
   }
   try {
     resetAutomationManager();
@@ -45212,7 +45254,7 @@ async function handleResetCommand(directory, args) {
 // src/commands/reset-session.ts
 init_utils2();
 import * as fs19 from "fs";
-import * as path30 from "path";
+import * as path31 from "path";
 async function handleResetSessionCommand(directory, _args) {
   const results = [];
   try {
@@ -45227,13 +45269,13 @@ async function handleResetSessionCommand(directory, _args) {
     results.push("\u274C Failed to delete state.json");
   }
   try {
-    const sessionDir = path30.dirname(validateSwarmPath(directory, "session/state.json"));
+    const sessionDir = path31.dirname(validateSwarmPath(directory, "session/state.json"));
     if (fs19.existsSync(sessionDir)) {
       const files = fs19.readdirSync(sessionDir);
       const otherFiles = files.filter((f) => f !== "state.json");
       let deletedCount = 0;
       for (const file3 of otherFiles) {
-        const filePath = path30.join(sessionDir, file3);
+        const filePath = path31.join(sessionDir, file3);
         if (fs19.lstatSync(filePath).isFile()) {
           fs19.unlinkSync(filePath);
           deletedCount++;
@@ -45263,7 +45305,7 @@ async function handleResetSessionCommand(directory, _args) {
 // src/summaries/manager.ts
 init_utils2();
 init_utils();
-import * as path31 from "path";
+import * as path32 from "path";
 var SUMMARY_ID_REGEX = /^S\d+$/;
 function sanitizeSummaryId(id) {
   if (!id || id.length === 0) {
@@ -45287,7 +45329,7 @@ function sanitizeSummaryId(id) {
 }
 async function loadFullOutput(directory, id) {
   const sanitizedId = sanitizeSummaryId(id);
-  const relativePath = path31.join("summaries", `${sanitizedId}.json`);
+  const relativePath = path32.join("summaries", `${sanitizedId}.json`);
   validateSwarmPath(directory, relativePath);
   const content = await readSwarmFileAsync(directory, relativePath);
   if (content === null) {
@@ -45343,7 +45385,7 @@ init_plan_schema();
 init_utils2();
 init_ledger();
 import * as fs20 from "fs";
-import * as path32 from "path";
+import * as path33 from "path";
 async function handleRollbackCommand(directory, args) {
   const phaseArg = args[0];
   if (!phaseArg) {
@@ -45408,8 +45450,8 @@ async function handleRollbackCommand(directory, args) {
     if (EXCLUDE_FILES.has(file3) || file3.startsWith("plan-ledger.archived-")) {
       continue;
     }
-    const src = path32.join(checkpointDir, file3);
-    const dest = path32.join(swarmDir, file3);
+    const src = path33.join(checkpointDir, file3);
+    const dest = path33.join(swarmDir, file3);
     try {
       fs20.cpSync(src, dest, { recursive: true, force: true });
       successes.push(file3);
@@ -45428,12 +45470,12 @@ async function handleRollbackCommand(directory, args) {
     ].join(`
 `);
   }
-  const existingLedgerPath = path32.join(swarmDir, "plan-ledger.jsonl");
+  const existingLedgerPath = path33.join(swarmDir, "plan-ledger.jsonl");
   if (fs20.existsSync(existingLedgerPath)) {
     fs20.unlinkSync(existingLedgerPath);
   }
   try {
-    const planJsonPath = path32.join(swarmDir, "plan.json");
+    const planJsonPath = path33.join(swarmDir, "plan.json");
     if (fs20.existsSync(planJsonPath)) {
       const planRaw = fs20.readFileSync(planJsonPath, "utf-8");
       const plan = PlanSchema.parse(JSON.parse(planRaw));
@@ -45506,9 +45548,9 @@ async function handleSimulateCommand(directory, args) {
   const report = reportLines.filter(Boolean).join(`
 `);
   const fs21 = await import("fs/promises");
-  const path33 = await import("path");
-  const reportPath = path33.join(directory, ".swarm", "simulate-report.md");
-  await fs21.mkdir(path33.dirname(reportPath), { recursive: true });
+  const path34 = await import("path");
+  const reportPath = path34.join(directory, ".swarm", "simulate-report.md");
+  await fs21.mkdir(path34.dirname(reportPath), { recursive: true });
   await fs21.writeFile(reportPath, report, "utf-8");
   return `${darkMatterPairs.length} hidden coupling pairs detected`;
 }
@@ -46056,30 +46098,51 @@ function resolveCommand(tokens) {
 // src/cli/index.ts
 var { version: version4 } = package_default;
 var CONFIG_DIR = getPluginConfigDir();
-var OPENCODE_CONFIG_PATH = path33.join(CONFIG_DIR, "opencode.json");
-var PLUGIN_CONFIG_PATH = path33.join(CONFIG_DIR, "opencode-swarm.json");
-var PROMPTS_DIR = path33.join(CONFIG_DIR, "opencode-swarm");
+var OPENCODE_CONFIG_PATH = path34.join(CONFIG_DIR, "opencode.json");
+var PLUGIN_CONFIG_PATH = path34.join(CONFIG_DIR, "opencode-swarm.json");
+var PROMPTS_DIR = path34.join(CONFIG_DIR, "opencode-swarm");
 var OPENCODE_PLUGIN_CACHE_PATHS = getPluginCachePaths();
+var OPENCODE_PLUGIN_LOCK_FILE_PATHS = getPluginLockFilePaths();
 function isSafeCachePath(p) {
-  const resolved = path33.resolve(p);
-  const home = path33.resolve(os7.homedir());
+  const resolved = path34.resolve(p);
+  const home = path34.resolve(os7.homedir());
   if (resolved === "/" || resolved === home || resolved.length <= home.length) {
     return false;
   }
-  const segments = resolved.split(path33.sep).filter((s) => s.length > 0);
+  const segments = resolved.split(path34.sep).filter((s) => s.length > 0);
   if (segments.length < 4) {
     return false;
   }
-  const leaf = path33.basename(resolved);
+  const leaf = path34.basename(resolved);
   if (leaf !== "opencode-swarm@latest" && leaf !== "opencode-swarm") {
     return false;
   }
-  const parent = path33.basename(path33.dirname(resolved));
+  const parent = path34.basename(path34.dirname(resolved));
   if (parent !== "packages" && parent !== "node_modules") {
     return false;
   }
-  const grandparent = path33.basename(path33.dirname(path33.dirname(resolved)));
+  const grandparent = path34.basename(path34.dirname(path34.dirname(resolved)));
   if (grandparent !== "opencode") {
+    return false;
+  }
+  return true;
+}
+function isSafeLockFilePath(p) {
+  const resolved = path34.resolve(p);
+  const home = path34.resolve(os7.homedir());
+  if (resolved === "/" || resolved === home || resolved.length <= home.length) {
+    return false;
+  }
+  const segments = resolved.split(path34.sep).filter((s) => s.length > 0);
+  if (segments.length < 4) {
+    return false;
+  }
+  const leaf = path34.basename(resolved);
+  if (leaf !== "bun.lock" && leaf !== "bun.lockb" && leaf !== "package-lock.json") {
+    return false;
+  }
+  const parent = path34.basename(path34.dirname(resolved));
+  if (parent !== "opencode") {
     return false;
   }
   return true;
@@ -46104,8 +46167,8 @@ function saveJson(filepath, data) {
 }
 function writeProjectConfigIfMissing(cwd) {
   try {
-    const opencodeDir = path33.join(cwd, ".opencode");
-    const projectConfigPath = path33.join(opencodeDir, "opencode-swarm.json");
+    const opencodeDir = path34.join(cwd, ".opencode");
+    const projectConfigPath = path34.join(opencodeDir, "opencode-swarm.json");
     if (fs21.existsSync(projectConfigPath)) {
       return;
     }
@@ -46123,7 +46186,7 @@ async function install() {
 `);
   ensureDir(CONFIG_DIR);
   ensureDir(PROMPTS_DIR);
-  const LEGACY_CONFIG_PATH = path33.join(CONFIG_DIR, "config.json");
+  const LEGACY_CONFIG_PATH = path34.join(CONFIG_DIR, "config.json");
   let opencodeConfig = loadJson(OPENCODE_CONFIG_PATH);
   if (!opencodeConfig) {
     const legacyConfig = loadJson(LEGACY_CONFIG_PATH);
@@ -46160,6 +46223,14 @@ async function install() {
   }
   for (const failed of evicted.failed) {
     console.warn(`\u26A0 Could not clear opencode plugin cache \u2014 you may need to delete it manually:
+  ${failed}`);
+  }
+  const lockEvicted = evictLockFiles();
+  if (lockEvicted.cleared.length > 0) {
+    console.log(`\u2713 Cleared opencode lock file(s) (next start will fetch latest): ${lockEvicted.cleared.join(", ")}`);
+  }
+  for (const failed of lockEvicted.failed) {
+    console.warn(`\u26A0 Could not clear opencode lock file \u2014 you may need to delete it manually:
   ${failed}`);
   }
   if (!fs21.existsSync(PLUGIN_CONFIG_PATH)) {
@@ -46264,6 +46335,7 @@ async function update() {
   console.log(`\uD83D\uDC1D Refreshing OpenCode Swarm plugin cache...
 `);
   const result = evictPluginCaches();
+  const lockResult = evictLockFiles();
   if (result.cleared.length > 0) {
     for (const cleared of result.cleared) {
       console.log(`\u2713 Cleared: ${cleared}`);
@@ -46271,10 +46343,24 @@ async function update() {
     console.log(`
 Restart OpenCode to fetch the latest version from npm.`);
   }
-  if (result.cleared.length === 0 && result.failed.length === 0) {
+  if (lockResult.cleared.length > 0) {
+    for (const cleared of lockResult.cleared) {
+      console.log(`\u2713 Cleared lock file: ${cleared}`);
+    }
+  }
+  if (lockResult.failed.length > 0) {
+    for (const failed of lockResult.failed) {
+      console.error(`\u2717 Could not clear lock file: ${failed}`);
+    }
+  }
+  if (result.cleared.length === 0 && result.failed.length === 0 && lockResult.cleared.length === 0 && lockResult.failed.length === 0) {
     console.log("No cached plugin found. Restart OpenCode to fetch the latest version from npm.");
     console.log("Checked locations:");
     for (const p of OPENCODE_PLUGIN_CACHE_PATHS) {
+      console.log(`  - ${p}`);
+    }
+    console.log("Lock files checked:");
+    for (const p of OPENCODE_PLUGIN_LOCK_FILE_PATHS) {
       console.log(`  - ${p}`);
     }
   }
@@ -46282,6 +46368,8 @@ Restart OpenCode to fetch the latest version from npm.`);
     for (const failed of result.failed) {
       console.error(`\u2717 Could not clear: ${failed}`);
     }
+  }
+  if (result.failed.length > 0 || lockResult.failed.length > 0) {
     return 1;
   }
   return 0;
@@ -46301,6 +46389,30 @@ function evictPluginCaches() {
       cleared.push(cachePath);
     } catch (err) {
       failed.push(`${cachePath} (${err instanceof Error ? err.message : String(err)})`);
+    }
+  }
+  return { cleared, failed };
+}
+function evictLockFiles() {
+  const cleared = [];
+  const failed = [];
+  for (const lockPath of OPENCODE_PLUGIN_LOCK_FILE_PATHS) {
+    if (!fs21.existsSync(lockPath))
+      continue;
+    if (!isSafeLockFilePath(lockPath)) {
+      failed.push(`${lockPath} (refused: failed safety check)`);
+      continue;
+    }
+    try {
+      fs21.unlinkSync(lockPath);
+      cleared.push(lockPath);
+    } catch (err) {
+      const code = err?.code;
+      if (code === "EISDIR") {
+        failed.push(`${lockPath} (path is a directory, not a file)`);
+      } else {
+        failed.push(`${lockPath} (${err instanceof Error ? err.message : String(err)})`);
+      }
     }
   }
   return { cleared, failed };
@@ -46470,5 +46582,9 @@ Valid commands: ${VALID_COMMANDS.join(", ")}`);
   return 0;
 }
 export {
-  run
+  run,
+  isSafeLockFilePath,
+  isSafeCachePath,
+  evictPluginCaches,
+  evictLockFiles
 };

--- a/dist/commands/reset.d.ts
+++ b/dist/commands/reset.d.ts
@@ -1,6 +1,6 @@
 /**
  * Handles the /swarm reset command.
- * Clears plan.md and context.md from .swarm/ directory.
+ * Clears all swarm state files from .swarm/ and project root.
  * Stops background automation and resets in-memory queues.
  * Requires --confirm flag as a safety gate.
  */

--- a/dist/config/cache-paths.d.ts
+++ b/dist/config/cache-paths.d.ts
@@ -9,3 +9,9 @@ export declare function getPluginConfigDir(): string;
  * path at the top.
  */
 export declare function getPluginCachePaths(): readonly string[];
+/**
+ * All known locations where OpenCode stores npm lock files for the plugin
+ * environment. These pin the installed version of opencode-swarm and must
+ * be cleared during update/install to force a fresh resolution from npm.
+ */
+export declare function getPluginLockFilePaths(): readonly string[];

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "6.86.14",
+    version: "7.0.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -16768,7 +16768,7 @@ async function loadPlan(directory) {
                   const rebuilt = await replayFromLedger(directory);
                   if (rebuilt) {
                     await rebuildPlan(directory, rebuilt);
-                    warn("[loadPlan] Rebuilt plan from ledger. Checkpoint available at SWARM_PLAN.md if it exists.");
+                    warn("[loadPlan] Rebuilt plan from ledger. Checkpoint available at .swarm/SWARM_PLAN.md if it exists.");
                     return rebuilt;
                   }
                 } catch (replayError) {
@@ -16789,7 +16789,7 @@ async function loadPlan(directory) {
                       return approved.plan;
                     }
                   } catch {}
-                  warn(`[loadPlan] Ledger replay failed during hash-mismatch rebuild: ${replayError instanceof Error ? replayError.message : String(replayError)}. Returning stale plan.json. To recover: check SWARM_PLAN.md for a checkpoint, or run /swarm reset-session.`);
+                  warn(`[loadPlan] Ledger replay failed during hash-mismatch rebuild: ${replayError instanceof Error ? replayError.message : String(replayError)}. Returning stale plan.json. To recover: check .swarm/SWARM_PLAN.md for a checkpoint, or run /swarm reset-session.`);
                 }
               }
             }
@@ -16835,7 +16835,7 @@ async function loadPlan(directory) {
         }
         return validated;
       } catch (error49) {
-        warn(`[loadPlan] plan.json validation failed: ${error49 instanceof Error ? error49.message : String(error49)}. Attempting rebuild from ledger. If rebuild fails, check SWARM_PLAN.md for a checkpoint.`);
+        warn(`[loadPlan] plan.json validation failed: ${error49 instanceof Error ? error49.message : String(error49)}. Attempting rebuild from ledger. If rebuild fails, check .swarm/SWARM_PLAN.md for a checkpoint.`);
         let rawPlanId = null;
         try {
           const rawParsed = JSON.parse(planJsonContent);
@@ -39481,6 +39481,7 @@ var init_create_tool = __esm(() => {
 // src/tools/checkpoint.ts
 var exports_checkpoint = {};
 __export(exports_checkpoint, {
+  saveCheckpointRecord: () => saveCheckpointRecord,
   checkpoint: () => checkpoint
 });
 import * as child_process from "node:child_process";
@@ -39633,6 +39634,38 @@ function handleSave(label, directory) {
       success: false,
       error: errorMessage
     }, null, 2);
+  }
+}
+function saveCheckpointRecord(label, directory) {
+  const labelError = validateLabel(label);
+  if (labelError) {
+    return { success: false, error: labelError };
+  }
+  try {
+    const log2 = readCheckpointLog(directory);
+    if (log2.checkpoints.find((c) => c.label === label)) {
+      return { success: false, error: `duplicate label: "${label}"` };
+    }
+    let sha = "";
+    if (isGitRepo()) {
+      try {
+        sha = getCurrentSha();
+      } catch {
+        sha = "";
+      }
+    }
+    log2.checkpoints.push({
+      label,
+      sha,
+      timestamp: new Date().toISOString()
+    });
+    writeCheckpointLog(log2, directory);
+    return { success: true, sha };
+  } catch (e) {
+    return {
+      success: false,
+      error: e instanceof Error ? e.message : "unknown error"
+    };
   }
 }
 function handleRestore(label, directory) {
@@ -42102,22 +42135,20 @@ async function handleCloseCommand(directory, args2) {
     }
   } catch {}
   let swarmPlanFilesRemoved = 0;
-  const swarmPlanJsonPath = path18.join(directory, "SWARM_PLAN.json");
-  const swarmPlanMdPath = path18.join(directory, "SWARM_PLAN.md");
-  try {
-    await fs12.unlink(swarmPlanJsonPath);
-    swarmPlanFilesRemoved++;
-  } catch (err2) {
-    if (err2?.code !== "ENOENT") {
-      warnings.push(`Failed to remove SWARM_PLAN.json: ${err2 instanceof Error ? err2.message : String(err2)}`);
-    }
-  }
-  try {
-    await fs12.unlink(swarmPlanMdPath);
-    swarmPlanFilesRemoved++;
-  } catch (err2) {
-    if (err2?.code !== "ENOENT") {
-      warnings.push(`Failed to remove SWARM_PLAN.md: ${err2 instanceof Error ? err2.message : String(err2)}`);
+  const candidates = [
+    path18.join(directory, ".swarm", "SWARM_PLAN.json"),
+    path18.join(directory, ".swarm", "SWARM_PLAN.md"),
+    path18.join(directory, "SWARM_PLAN.json"),
+    path18.join(directory, "SWARM_PLAN.md")
+  ];
+  for (const candidate of candidates) {
+    try {
+      await fs12.unlink(candidate);
+      swarmPlanFilesRemoved++;
+    } catch (err2) {
+      if (err2?.code !== "ENOENT") {
+        warnings.push(`Failed to remove ${path18.basename(candidate)}: ${err2 instanceof Error ? err2.message : String(err2)}`);
+      }
     }
   }
   clearAllScopes(directory);
@@ -42192,9 +42223,7 @@ async function handleCloseCommand(directory, args2) {
     "- Reset context.md for next session",
     "- Cleared agent sessions and delegation chains",
     ...configBackupsRemoved > 0 ? [`- Removed ${configBackupsRemoved} stale config backup file(s)`] : [],
-    ...swarmPlanFilesRemoved > 0 ? [
-      `- Removed ${swarmPlanFilesRemoved} root-level SWARM_PLAN checkpoint artifact(s)`
-    ] : [],
+    ...swarmPlanFilesRemoved > 0 ? [`- Removed ${swarmPlanFilesRemoved} SWARM_PLAN checkpoint artifact(s)`] : [],
     ...planExists && !planAlreadyDone ? ["- Set non-completed phases/tasks to closed status"] : [],
     ...curationSucceeded && allLessons.length > 0 ? [`- Committed ${allLessons.length} lesson(s) to knowledge store`] : [],
     "",
@@ -44112,11 +44141,21 @@ function getPluginConfigDir() {
 function getPluginCachePaths() {
   const cacheBase = process.env.XDG_CACHE_HOME || path24.join(os5.homedir(), ".cache");
   const configDir = getPluginConfigDir();
-  return [
+  const paths = [
+    path24.join(cacheBase, "opencode", "node_modules", "opencode-swarm"),
     path24.join(cacheBase, "opencode", "packages", "opencode-swarm@latest"),
-    path24.join(configDir, "node_modules", "opencode-swarm"),
-    path24.join(cacheBase, "opencode", "node_modules", "opencode-swarm")
+    path24.join(configDir, "node_modules", "opencode-swarm")
   ];
+  if (process.platform === "darwin") {
+    const libCaches = path24.join(os5.homedir(), "Library", "Caches");
+    paths.push(path24.join(libCaches, "opencode", "node_modules", "opencode-swarm"), path24.join(libCaches, "opencode", "packages", "opencode-swarm@latest"));
+  }
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA || path24.join(os5.homedir(), "AppData", "Local");
+    const appData = process.env.APPDATA || path24.join(os5.homedir(), "AppData", "Roaming");
+    paths.push(path24.join(localAppData, "opencode", "node_modules", "opencode-swarm"), path24.join(localAppData, "opencode", "packages", "opencode-swarm@latest"), path24.join(appData, "opencode", "node_modules", "opencode-swarm"));
+  }
+  return paths;
 }
 var init_cache_paths = () => {};
 
@@ -53958,13 +53997,14 @@ var init_manager3 = __esm(() => {
 
 // src/commands/reset.ts
 import * as fs25 from "node:fs";
+import * as path38 from "node:path";
 async function handleResetCommand(directory, args2) {
   const hasConfirm = args2.includes("--confirm");
   if (!hasConfirm) {
     return [
       "## Swarm Reset",
       "",
-      "⚠️ This will delete plan.md and context.md from .swarm/",
+      "⚠️ This will delete all swarm state from .swarm/ (plan, context, checkpoints, SWARM_PLAN artifacts)",
       "",
       "**Tip**: Run `/swarm export` first to backup your state.",
       "",
@@ -53972,7 +54012,15 @@ async function handleResetCommand(directory, args2) {
     ].join(`
 `);
   }
-  const filesToReset = ["plan.md", "context.md"];
+  const filesToReset = [
+    "plan.md",
+    "plan.json",
+    "context.md",
+    "SWARM_PLAN.md",
+    "SWARM_PLAN.json",
+    "checkpoints.json",
+    "events.jsonl"
+  ];
   const results = [];
   for (const filename of filesToReset) {
     try {
@@ -53986,6 +54034,15 @@ async function handleResetCommand(directory, args2) {
     } catch {
       results.push(`- ❌ Failed to delete ${filename}`);
     }
+  }
+  for (const filename of ["SWARM_PLAN.md", "SWARM_PLAN.json"]) {
+    try {
+      const rootPath = path38.join(directory, filename);
+      if (fs25.existsSync(rootPath)) {
+        fs25.unlinkSync(rootPath);
+        results.push(`- ✅ Deleted ${filename} (root)`);
+      }
+    } catch {}
   }
   try {
     resetAutomationManager();
@@ -54020,7 +54077,7 @@ var init_reset = __esm(() => {
 
 // src/commands/reset-session.ts
 import * as fs26 from "node:fs";
-import * as path38 from "node:path";
+import * as path39 from "node:path";
 async function handleResetSessionCommand(directory, _args) {
   const results = [];
   try {
@@ -54035,13 +54092,13 @@ async function handleResetSessionCommand(directory, _args) {
     results.push("❌ Failed to delete state.json");
   }
   try {
-    const sessionDir = path38.dirname(validateSwarmPath(directory, "session/state.json"));
+    const sessionDir = path39.dirname(validateSwarmPath(directory, "session/state.json"));
     if (fs26.existsSync(sessionDir)) {
       const files = fs26.readdirSync(sessionDir);
       const otherFiles = files.filter((f) => f !== "state.json");
       let deletedCount = 0;
       for (const file3 of otherFiles) {
-        const filePath = path38.join(sessionDir, file3);
+        const filePath = path39.join(sessionDir, file3);
         if (fs26.lstatSync(filePath).isFile()) {
           fs26.unlinkSync(filePath);
           deletedCount++;
@@ -54074,7 +54131,7 @@ var init_reset_session = __esm(() => {
 
 // src/summaries/manager.ts
 import { mkdirSync as mkdirSync13, readdirSync as readdirSync10, renameSync as renameSync10, rmSync as rmSync4, statSync as statSync10 } from "node:fs";
-import * as path39 from "node:path";
+import * as path40 from "node:path";
 function sanitizeSummaryId(id) {
   if (!id || id.length === 0) {
     throw new Error("Invalid summary ID: empty string");
@@ -54108,9 +54165,9 @@ async function storeSummary(directory, id, fullOutput, summaryText, maxStoredByt
   if (serializedSize > maxStoredBytes) {
     throw new Error(`Summary entry size (${serializedSize} bytes) exceeds maximum (${maxStoredBytes} bytes)`);
   }
-  const relativePath = path39.join("summaries", `${sanitizedId}.json`);
+  const relativePath = path40.join("summaries", `${sanitizedId}.json`);
   const summaryPath = validateSwarmPath(directory, relativePath);
-  const summaryDir = path39.dirname(summaryPath);
+  const summaryDir = path40.dirname(summaryPath);
   const entry = {
     id: sanitizedId,
     summaryText,
@@ -54120,7 +54177,7 @@ async function storeSummary(directory, id, fullOutput, summaryText, maxStoredByt
   };
   const entryJson = JSON.stringify(entry);
   mkdirSync13(summaryDir, { recursive: true });
-  const tempPath = path39.join(summaryDir, `${sanitizedId}.json.tmp.${Date.now()}.${process.pid}`);
+  const tempPath = path40.join(summaryDir, `${sanitizedId}.json.tmp.${Date.now()}.${process.pid}`);
   try {
     await Bun.write(tempPath, entryJson);
     renameSync10(tempPath, summaryPath);
@@ -54133,7 +54190,7 @@ async function storeSummary(directory, id, fullOutput, summaryText, maxStoredByt
 }
 async function loadFullOutput(directory, id) {
   const sanitizedId = sanitizeSummaryId(id);
-  const relativePath = path39.join("summaries", `${sanitizedId}.json`);
+  const relativePath = path40.join("summaries", `${sanitizedId}.json`);
   validateSwarmPath(directory, relativePath);
   const content = await readSwarmFileAsync(directory, relativePath);
   if (content === null) {
@@ -54195,7 +54252,7 @@ var init_retrieve = __esm(() => {
 
 // src/commands/rollback.ts
 import * as fs27 from "node:fs";
-import * as path40 from "node:path";
+import * as path41 from "node:path";
 async function handleRollbackCommand(directory, args2) {
   const phaseArg = args2[0];
   if (!phaseArg) {
@@ -54260,8 +54317,8 @@ async function handleRollbackCommand(directory, args2) {
     if (EXCLUDE_FILES.has(file3) || file3.startsWith("plan-ledger.archived-")) {
       continue;
     }
-    const src = path40.join(checkpointDir, file3);
-    const dest = path40.join(swarmDir, file3);
+    const src = path41.join(checkpointDir, file3);
+    const dest = path41.join(swarmDir, file3);
     try {
       fs27.cpSync(src, dest, { recursive: true, force: true });
       successes.push(file3);
@@ -54280,12 +54337,12 @@ async function handleRollbackCommand(directory, args2) {
     ].join(`
 `);
   }
-  const existingLedgerPath = path40.join(swarmDir, "plan-ledger.jsonl");
+  const existingLedgerPath = path41.join(swarmDir, "plan-ledger.jsonl");
   if (fs27.existsSync(existingLedgerPath)) {
     fs27.unlinkSync(existingLedgerPath);
   }
   try {
-    const planJsonPath = path40.join(swarmDir, "plan.json");
+    const planJsonPath = path41.join(swarmDir, "plan.json");
     if (fs27.existsSync(planJsonPath)) {
       const planRaw = fs27.readFileSync(planJsonPath, "utf-8");
       const plan = PlanSchema.parse(JSON.parse(planRaw));
@@ -54363,9 +54420,9 @@ async function handleSimulateCommand(directory, args2) {
   const report = reportLines.filter(Boolean).join(`
 `);
   const fs28 = await import("node:fs/promises");
-  const path41 = await import("node:path");
-  const reportPath = path41.join(directory, ".swarm", "simulate-report.md");
-  await fs28.mkdir(path41.dirname(reportPath), { recursive: true });
+  const path42 = await import("node:path");
+  const reportPath = path42.join(directory, ".swarm", "simulate-report.md");
+  await fs28.mkdir(path42.dirname(reportPath), { recursive: true });
   await fs28.writeFile(reportPath, report, "utf-8");
   return `${darkMatterPairs.length} hidden coupling pairs detected`;
 }
@@ -54384,7 +54441,7 @@ async function handleSpecifyCommand(_directory, args2) {
 
 // src/services/compaction-service.ts
 import * as fs28 from "node:fs";
-import * as path41 from "node:path";
+import * as path42 from "node:path";
 function makeInitialState() {
   return {
     lastObservationAt: 0,
@@ -54406,7 +54463,7 @@ function getSessionState(sessionId) {
 }
 function appendSnapshot(directory, tier, budgetPct, message) {
   try {
-    const snapshotPath = path41.join(directory, ".swarm", "context-snapshot.md");
+    const snapshotPath = path42.join(directory, ".swarm", "context-snapshot.md");
     const timestamp = new Date().toISOString();
     const entry = `
 ## [${tier.toUpperCase()}] ${timestamp} — ${budgetPct.toFixed(1)}% used
@@ -58787,7 +58844,7 @@ COVERAGE REPORTING:
 
 // src/agents/index.ts
 import { mkdir as mkdir6, writeFile as writeFile6 } from "node:fs/promises";
-import * as path42 from "node:path";
+import * as path43 from "node:path";
 function stripSwarmPrefix(agentName, swarmPrefix) {
   if (!swarmPrefix || !agentName)
     return agentName;
@@ -59098,14 +59155,14 @@ function getAgentConfigs(config3, directory, sessionId) {
   }));
   if (directory) {
     const sid = sessionId ?? `init-${Date.now()}`;
-    const evidenceDir = path42.join(directory, ".swarm", "evidence");
+    const evidenceDir = path43.join(directory, ".swarm", "evidence");
     const filename = `agent-tools-${sid}.json`;
     const snapshotData = JSON.stringify({
       sessionId: sid,
       generatedAt: new Date().toISOString(),
       agents: agentToolSnapshot
     }, null, 2);
-    mkdir6(evidenceDir, { recursive: true }).then(() => writeFile6(path42.join(evidenceDir, filename), snapshotData)).catch(() => {});
+    mkdir6(evidenceDir, { recursive: true }).then(() => writeFile6(path43.join(evidenceDir, filename), snapshotData)).catch(() => {});
   }
   return result;
 }
@@ -59131,13 +59188,13 @@ __export(exports_evidence_summary_integration, {
   EvidenceSummaryIntegration: () => EvidenceSummaryIntegration
 });
 import { existsSync as existsSync24, mkdirSync as mkdirSync14, writeFileSync as writeFileSync6 } from "node:fs";
-import * as path43 from "node:path";
+import * as path44 from "node:path";
 function persistSummary(projectDir, artifact, filename) {
-  const swarmPath = path43.join(projectDir, ".swarm");
+  const swarmPath = path44.join(projectDir, ".swarm");
   if (!existsSync24(swarmPath)) {
     mkdirSync14(swarmPath, { recursive: true });
   }
-  const artifactPath = path43.join(swarmPath, filename);
+  const artifactPath = path44.join(swarmPath, filename);
   const content = JSON.stringify(artifact, null, 2);
   writeFileSync6(artifactPath, content, "utf-8");
   log("[EvidenceSummaryIntegration] Summary persisted", {
@@ -59256,7 +59313,7 @@ __export(exports_status_artifact, {
   AutomationStatusArtifact: () => AutomationStatusArtifact
 });
 import * as fs30 from "node:fs";
-import * as path45 from "node:path";
+import * as path46 from "node:path";
 function createEmptySnapshot(mode, capabilities) {
   return {
     timestamp: Date.now(),
@@ -59315,7 +59372,7 @@ class AutomationStatusArtifact {
     });
   }
   getFilePath() {
-    return path45.join(this.swarmDir, this.filename);
+    return path46.join(this.swarmDir, this.filename);
   }
   load() {
     const filePath = this.getFilePath();
@@ -59728,12 +59785,12 @@ __export(exports_review_receipt, {
 });
 import * as crypto5 from "node:crypto";
 import * as fs34 from "node:fs";
-import * as path46 from "node:path";
+import * as path47 from "node:path";
 function resolveReceiptsDir(directory) {
-  return path46.join(directory, ".swarm", "review-receipts");
+  return path47.join(directory, ".swarm", "review-receipts");
 }
 function resolveReceiptIndexPath(directory) {
-  return path46.join(resolveReceiptsDir(directory), "index.json");
+  return path47.join(resolveReceiptsDir(directory), "index.json");
 }
 function buildReceiptFilename(id, date9) {
   const dateStr = date9.toISOString().slice(0, 10);
@@ -59772,7 +59829,7 @@ async function readReceiptIndex(directory) {
 }
 async function writeReceiptIndex(directory, index) {
   const indexPath = resolveReceiptIndexPath(directory);
-  const dir = path46.dirname(indexPath);
+  const dir = path47.dirname(indexPath);
   await fs34.promises.mkdir(dir, { recursive: true });
   const tmpPath = `${indexPath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2)}`;
   await fs34.promises.writeFile(tmpPath, JSON.stringify(index, null, 2), "utf-8");
@@ -59783,7 +59840,7 @@ async function persistReviewReceipt(directory, receipt) {
   await fs34.promises.mkdir(receiptsDir, { recursive: true });
   const now = new Date(receipt.reviewed_at);
   const filename = buildReceiptFilename(receipt.id, now);
-  const receiptPath = path46.join(receiptsDir, filename);
+  const receiptPath = path47.join(receiptsDir, filename);
   const tmpPath = `${receiptPath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2)}`;
   await fs34.promises.writeFile(tmpPath, JSON.stringify(receipt, null, 2), "utf-8");
   fs34.renameSync(tmpPath, receiptPath);
@@ -59805,7 +59862,7 @@ async function readReceiptById(directory, receiptId) {
   const entry = index.entries.find((e) => e.id === receiptId);
   if (!entry)
     return null;
-  const receiptPath = path46.join(resolveReceiptsDir(directory), entry.filename);
+  const receiptPath = path47.join(resolveReceiptsDir(directory), entry.filename);
   try {
     const content = await fs34.promises.readFile(receiptPath, "utf-8");
     return JSON.parse(content);
@@ -59818,7 +59875,7 @@ async function readReceiptsByScopeHash(directory, scopeHash) {
   const matching = index.entries.filter((e) => e.scope_hash === scopeHash).sort((a, b) => b.reviewed_at.localeCompare(a.reviewed_at));
   const receipts = [];
   for (const entry of matching) {
-    const receiptPath = path46.join(resolveReceiptsDir(directory), entry.filename);
+    const receiptPath = path47.join(resolveReceiptsDir(directory), entry.filename);
     try {
       const content = await fs34.promises.readFile(receiptPath, "utf-8");
       receipts.push(JSON.parse(content));
@@ -59831,7 +59888,7 @@ async function readAllReceipts(directory) {
   const sorted = [...index.entries].sort((a, b) => b.reviewed_at.localeCompare(a.reviewed_at));
   const receipts = [];
   for (const entry of sorted) {
-    const receiptPath = path46.join(resolveReceiptsDir(directory), entry.filename);
+    const receiptPath = path47.join(resolveReceiptsDir(directory), entry.filename);
     try {
       const content = await fs34.promises.readFile(receiptPath, "utf-8");
       receipts.push(JSON.parse(content));
@@ -61419,11 +61476,11 @@ ${JSON.stringify(symbolNames, null, 2)}`);
         throw toThrow;
       }, "quit_");
       var scriptDirectory = "";
-      function locateFile(path57) {
+      function locateFile(path58) {
         if (Module["locateFile"]) {
-          return Module["locateFile"](path57, scriptDirectory);
+          return Module["locateFile"](path58, scriptDirectory);
         }
-        return scriptDirectory + path57;
+        return scriptDirectory + path58;
       }
       __name(locateFile, "locateFile");
       var readAsync, readBinary;
@@ -63172,13 +63229,13 @@ __export(exports_runtime, {
   getInitializedLanguages: () => getInitializedLanguages,
   clearParserCache: () => clearParserCache
 });
-import * as path57 from "node:path";
+import * as path58 from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 async function initTreeSitter() {
   if (treeSitterInitialized) {
     return;
   }
-  const thisDir = path57.dirname(fileURLToPath2(import.meta.url));
+  const thisDir = path58.dirname(fileURLToPath2(import.meta.url));
   const isSource = thisDir.replace(/\\/g, "/").endsWith("/src/lang");
   if (isSource) {
     await Parser.init();
@@ -63186,7 +63243,7 @@ async function initTreeSitter() {
     const grammarsDir = getGrammarsDirAbsolute();
     await Parser.init({
       locateFile(scriptName) {
-        return path57.join(grammarsDir, scriptName);
+        return path58.join(grammarsDir, scriptName);
       }
     });
   }
@@ -63207,11 +63264,11 @@ function getWasmFileName(languageId) {
   return `tree-sitter-${sanitized}.wasm`;
 }
 function getGrammarsDirAbsolute() {
-  const thisDir = path57.dirname(fileURLToPath2(import.meta.url));
+  const thisDir = path58.dirname(fileURLToPath2(import.meta.url));
   const normalized = thisDir.replace(/\\/g, "/");
   const isSource = normalized.endsWith("/src/lang");
   const isCliBundle = normalized.endsWith("/cli");
-  return isSource ? path57.join(thisDir, "grammars") : isCliBundle ? path57.join(thisDir, "..", "lang", "grammars") : path57.join(thisDir, "lang", "grammars");
+  return isSource ? path58.join(thisDir, "grammars") : isCliBundle ? path58.join(thisDir, "..", "lang", "grammars") : path58.join(thisDir, "lang", "grammars");
 }
 async function loadGrammar(languageId) {
   if (typeof languageId !== "string" || languageId.length > 100) {
@@ -63227,7 +63284,7 @@ async function loadGrammar(languageId) {
   await initTreeSitter();
   const parser = new Parser;
   const wasmFileName = getWasmFileName(normalizedId);
-  const wasmPath = path57.join(getGrammarsDirAbsolute(), wasmFileName);
+  const wasmPath = path58.join(getGrammarsDirAbsolute(), wasmFileName);
   const { existsSync: existsSync30 } = await import("node:fs");
   if (!existsSync30(wasmPath)) {
     throw new Error(`Grammar file not found for ${languageId}: ${wasmPath}
@@ -63262,7 +63319,7 @@ async function isGrammarAvailable(languageId) {
   }
   try {
     const wasmFileName = getWasmFileName(normalizedId);
-    const wasmPath = path57.join(getGrammarsDirAbsolute(), wasmFileName);
+    const wasmPath = path58.join(getGrammarsDirAbsolute(), wasmFileName);
     const { statSync: statSync18 } = await import("node:fs");
     statSync18(wasmPath);
     return true;
@@ -63321,13 +63378,13 @@ __export(exports_doc_scan, {
 import * as crypto7 from "node:crypto";
 import * as fs43 from "node:fs";
 import { mkdir as mkdir9, readFile as readFile8, writeFile as writeFile8 } from "node:fs/promises";
-import * as path59 from "node:path";
+import * as path60 from "node:path";
 function normalizeSeparators(filePath) {
   return filePath.replace(/\\/g, "/");
 }
 function matchesDocPattern(filePath, patterns) {
   const normalizedPath = normalizeSeparators(filePath);
-  const basename8 = path59.basename(filePath);
+  const basename8 = path60.basename(filePath);
   for (const pattern of patterns) {
     if (!pattern.includes("/") && !pattern.includes("\\")) {
       if (basename8 === pattern) {
@@ -63383,7 +63440,7 @@ function stripMarkdown(text) {
   return text.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1").replace(/\*\*([^*]+)\*\*/g, "$1").replace(/`([^`]+)`/g, "$1").replace(/^\s*[-*•]\s+/gm, "").replace(/^\s*\d+\.\s+/gm, "").trim();
 }
 async function scanDocIndex(directory) {
-  const manifestPath = path59.join(directory, ".swarm", "doc-manifest.json");
+  const manifestPath = path60.join(directory, ".swarm", "doc-manifest.json");
   const defaultPatterns = DocsConfigSchema.parse({}).doc_patterns;
   const extraPatterns = [
     "ARCHITECTURE.md",
@@ -63400,7 +63457,7 @@ async function scanDocIndex(directory) {
       let cacheValid = true;
       for (const file3 of existingManifest.files) {
         try {
-          const fullPath = path59.join(directory, file3.path);
+          const fullPath = path60.join(directory, file3.path);
           const stat3 = fs43.statSync(fullPath);
           if (stat3.mtimeMs > file3.mtime) {
             cacheValid = false;
@@ -63430,7 +63487,7 @@ async function scanDocIndex(directory) {
   }
   const entries = rawEntries.filter((e) => typeof e === "string");
   for (const entry of entries) {
-    const fullPath = path59.join(directory, entry);
+    const fullPath = path60.join(directory, entry);
     let stat3;
     try {
       stat3 = fs43.statSync(fullPath);
@@ -63466,7 +63523,7 @@ async function scanDocIndex(directory) {
     } catch {
       continue;
     }
-    const { title, summary } = extractTitleAndSummary(content, path59.basename(entry));
+    const { title, summary } = extractTitleAndSummary(content, path60.basename(entry));
     const lineCount = content.split(`
 `).length;
     discoveredFiles.push({
@@ -63492,7 +63549,7 @@ async function scanDocIndex(directory) {
     files: discoveredFiles
   };
   try {
-    await mkdir9(path59.dirname(manifestPath), { recursive: true });
+    await mkdir9(path60.dirname(manifestPath), { recursive: true });
     await writeFile8(manifestPath, JSON.stringify(manifest, null, 2), "utf-8");
   } catch {}
   return { manifest, cached: false };
@@ -63531,7 +63588,7 @@ function extractConstraintsFromContent(content) {
   return constraints;
 }
 async function extractDocConstraints(directory, taskFiles, taskDescription) {
-  const manifestPath = path59.join(directory, ".swarm", "doc-manifest.json");
+  const manifestPath = path60.join(directory, ".swarm", "doc-manifest.json");
   let manifest;
   try {
     const content = await readFile8(manifestPath, "utf-8");
@@ -63557,7 +63614,7 @@ async function extractDocConstraints(directory, taskFiles, taskDescription) {
     }
     let fullContent;
     try {
-      fullContent = await readFile8(path59.join(directory, docFile.path), "utf-8");
+      fullContent = await readFile8(path60.join(directory, docFile.path), "utf-8");
     } catch {
       skippedCount++;
       continue;
@@ -63580,7 +63637,7 @@ async function extractDocConstraints(directory, taskFiles, taskDescription) {
           tier: "swarm",
           lesson: constraint,
           category: "architecture",
-          tags: ["doc-scan", path59.basename(docFile.path)],
+          tags: ["doc-scan", path60.basename(docFile.path)],
           scope: "global",
           confidence: 0.5,
           status: "candidate",
@@ -63653,7 +63710,7 @@ var init_doc_scan = __esm(() => {
         }
       } catch {}
       if (force) {
-        const manifestPath = path59.join(directory, ".swarm", "doc-manifest.json");
+        const manifestPath = path60.join(directory, ".swarm", "doc-manifest.json");
         try {
           fs43.unlinkSync(manifestPath);
         } catch {}
@@ -63844,9 +63901,9 @@ __export(exports_curator_drift, {
   buildDriftInjectionText: () => buildDriftInjectionText
 });
 import * as fs46 from "node:fs";
-import * as path62 from "node:path";
+import * as path63 from "node:path";
 async function readPriorDriftReports(directory) {
-  const swarmDir = path62.join(directory, ".swarm");
+  const swarmDir = path63.join(directory, ".swarm");
   const entries = await fs46.promises.readdir(swarmDir).catch(() => null);
   if (entries === null)
     return [];
@@ -63873,7 +63930,7 @@ async function readPriorDriftReports(directory) {
 async function writeDriftReport(directory, report) {
   const filename = `${DRIFT_REPORT_PREFIX}${report.phase}.json`;
   const filePath = validateSwarmPath(directory, filename);
-  const swarmDir = path62.dirname(filePath);
+  const swarmDir = path63.dirname(filePath);
   await fs46.promises.mkdir(swarmDir, { recursive: true });
   try {
     await fs46.promises.writeFile(filePath, JSON.stringify(report, null, 2), "utf-8");
@@ -64009,7 +64066,7 @@ var init_curator_drift = __esm(() => {
 init_package();
 init_agents2();
 import * as fs87 from "node:fs";
-import * as path105 from "node:path";
+import * as path106 from "node:path";
 
 // src/background/index.ts
 init_event_bus();
@@ -64020,7 +64077,7 @@ init_manager3();
 init_manager();
 init_utils();
 import * as fs29 from "node:fs";
-import * as path44 from "node:path";
+import * as path45 from "node:path";
 
 class PlanSyncWorker {
   directory;
@@ -64044,10 +64101,10 @@ class PlanSyncWorker {
     this.onSyncComplete = options.onSyncComplete;
   }
   getSwarmDir() {
-    return path44.resolve(this.directory, ".swarm");
+    return path45.resolve(this.directory, ".swarm");
   }
   getPlanJsonPath() {
-    return path44.join(this.getSwarmDir(), "plan.json");
+    return path45.join(this.getSwarmDir(), "plan.json");
   }
   start() {
     if (this.disposed) {
@@ -64266,8 +64323,8 @@ class PlanSyncWorker {
   checkForUnauthorizedWrite() {
     try {
       const swarmDir = this.getSwarmDir();
-      const planJsonPath = path44.join(swarmDir, "plan.json");
-      const markerPath = path44.join(swarmDir, ".plan-write-marker");
+      const planJsonPath = path45.join(swarmDir, "plan.json");
+      const markerPath = path45.join(swarmDir, ".plan-write-marker");
       const planStats = fs29.statSync(planJsonPath);
       const planMtimeMs = Math.floor(planStats.mtimeMs);
       const markerContent = fs29.readFileSync(markerPath, "utf8");
@@ -64504,11 +64561,11 @@ async function doFlush(directory) {
     const activitySection = renderActivitySection();
     const updated = replaceOrAppendSection(existing, "## Agent Activity", activitySection);
     const flushedCount = swarmState.pendingEvents;
-    const path46 = nodePath2.join(directory, ".swarm", "context.md");
-    const tempPath = `${path46}.tmp`;
+    const path47 = nodePath2.join(directory, ".swarm", "context.md");
+    const tempPath = `${path47}.tmp`;
     try {
       await Bun.write(tempPath, updated);
-      renameSync11(tempPath, path46);
+      renameSync11(tempPath, path47);
     } catch (writeError) {
       try {
         unlinkSync8(tempPath);
@@ -64559,7 +64616,7 @@ ${content.substring(endIndex + 1)}`;
 init_manager();
 init_utils2();
 import * as fs31 from "node:fs";
-import { join as join42 } from "node:path";
+import { join as join43 } from "node:path";
 function createCompactionCustomizerHook(config3, directory) {
   const enabled = config3.hooks?.compaction !== false;
   if (!enabled) {
@@ -64604,7 +64661,7 @@ function createCompactionCustomizerHook(config3, directory) {
         }
       }
       try {
-        const summariesDir = join42(directory, ".swarm", "summaries");
+        const summariesDir = join43(directory, ".swarm", "summaries");
         const files = await fs31.promises.readdir(summariesDir);
         if (files.length > 0) {
           const count = files.length;
@@ -65869,7 +65926,7 @@ init_schema();
 init_manager();
 init_curator();
 init_utils2();
-import * as path47 from "node:path";
+import * as path48 from "node:path";
 function createPhaseMonitorHook(directory, preflightManager, curatorRunner, delegateFactory) {
   let lastKnownPhase = null;
   const handler = async (input, _output) => {
@@ -65889,9 +65946,9 @@ function createPhaseMonitorHook(directory, preflightManager, curatorRunner, dele
           const llmDelegate = delegateFactory?.(sessionId);
           const initResult = await runner(directory, curatorConfig, llmDelegate);
           if (initResult.briefing) {
-            const briefingPath = path47.join(directory, ".swarm", "curator-briefing.md");
+            const briefingPath = path48.join(directory, ".swarm", "curator-briefing.md");
             const { mkdir: mkdir7, writeFile: writeFile7 } = await import("node:fs/promises");
-            await mkdir7(path47.dirname(briefingPath), { recursive: true });
+            await mkdir7(path48.dirname(briefingPath), { recursive: true });
             await writeFile7(briefingPath, initResult.briefing, "utf-8");
             const { buildApprovedReceipt: buildApprovedReceipt2, persistReviewReceipt: persistReviewReceipt2 } = await Promise.resolve().then(() => (init_review_receipt(), exports_review_receipt));
             const initReceipt = buildApprovedReceipt2({
@@ -66016,7 +66073,7 @@ ${originalText}`;
 }
 // src/hooks/repo-graph-builder.ts
 init_constants();
-import * as path50 from "node:path";
+import * as path51 from "node:path";
 
 // src/tools/repo-graph.ts
 init_utils2();
@@ -66025,14 +66082,14 @@ init_path_security();
 import * as fsSync2 from "node:fs";
 import { constants as constants3, existsSync as existsSync28, realpathSync as realpathSync6 } from "node:fs";
 import * as fsPromises3 from "node:fs/promises";
-import * as path49 from "node:path";
+import * as path50 from "node:path";
 
 // src/tools/symbols.ts
 init_zod();
 init_create_tool();
 init_path_security();
 import * as fs35 from "node:fs";
-import * as path48 from "node:path";
+import * as path49 from "node:path";
 var MAX_FILE_SIZE_BYTES2 = 1024 * 1024;
 var WINDOWS_RESERVED_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|:|$)/i;
 function containsWindowsAttacks(str) {
@@ -66049,11 +66106,11 @@ function containsWindowsAttacks(str) {
 }
 function isPathInWorkspace(filePath, workspace) {
   try {
-    const resolvedPath = path48.resolve(workspace, filePath);
+    const resolvedPath = path49.resolve(workspace, filePath);
     const realWorkspace = fs35.realpathSync(workspace);
     const realResolvedPath = fs35.realpathSync(resolvedPath);
-    const relativePath = path48.relative(realWorkspace, realResolvedPath);
-    if (relativePath.startsWith("..") || path48.isAbsolute(relativePath)) {
+    const relativePath = path49.relative(realWorkspace, realResolvedPath);
+    if (relativePath.startsWith("..") || path49.isAbsolute(relativePath)) {
       return false;
     }
     return true;
@@ -66065,7 +66122,7 @@ function validatePathForRead(filePath, workspace) {
   return isPathInWorkspace(filePath, workspace);
 }
 function extractTSSymbols(filePath, cwd) {
-  const fullPath = path48.join(cwd, filePath);
+  const fullPath = path49.join(cwd, filePath);
   if (!validatePathForRead(fullPath, cwd)) {
     return [];
   }
@@ -66217,7 +66274,7 @@ function extractTSSymbols(filePath, cwd) {
   });
 }
 function extractPythonSymbols(filePath, cwd) {
-  const fullPath = path48.join(cwd, filePath);
+  const fullPath = path49.join(cwd, filePath);
   if (!validatePathForRead(fullPath, cwd)) {
     return [];
   }
@@ -66300,7 +66357,7 @@ var symbols = createSwarmTool({
       }, null, 2);
     }
     const cwd = directory;
-    const ext = path48.extname(file3);
+    const ext = path49.extname(file3);
     if (containsControlChars(file3)) {
       return JSON.stringify({
         file: file3,
@@ -66364,7 +66421,7 @@ var symbols = createSwarmTool({
 var WINDOWS_RENAME_MAX_RETRIES = 3;
 var WINDOWS_RENAME_RETRY_DELAY_MS = 50;
 function normalizeGraphPath(filePath) {
-  return path49.normalize(filePath).replace(/\\/g, "/");
+  return path50.normalize(filePath).replace(/\\/g, "/");
 }
 var REPO_GRAPH_FILENAME = "repo-graph.json";
 var GRAPH_SCHEMA_VERSION = "1.0.0";
@@ -66473,8 +66530,8 @@ function resolveModuleSpecifier(workspaceRoot, sourceFile, specifier) {
   }
   try {
     if (specifier.startsWith(".")) {
-      const sourceDir = path49.dirname(sourceFile);
-      let resolved = path49.resolve(sourceDir, specifier);
+      const sourceDir = path50.dirname(sourceFile);
+      let resolved = path50.resolve(sourceDir, specifier);
       let realResolved;
       try {
         realResolved = realpathSync6(resolved);
@@ -66485,7 +66542,7 @@ function resolveModuleSpecifier(workspaceRoot, sourceFile, specifier) {
       try {
         realRoot = realpathSync6(workspaceRoot);
       } catch {
-        realRoot = path49.normalize(workspaceRoot);
+        realRoot = path50.normalize(workspaceRoot);
       }
       if (!existsSync28(resolved)) {
         const EXTENSIONS = [
@@ -66517,9 +66574,9 @@ function resolveModuleSpecifier(workspaceRoot, sourceFile, specifier) {
           return null;
         }
       }
-      const normalizedResolved = path49.normalize(realResolved);
-      const normalizedRoot = path49.normalize(realRoot);
-      if (!normalizedResolved.startsWith(normalizedRoot + path49.sep) && normalizedResolved !== normalizedRoot) {
+      const normalizedResolved = path50.normalize(realResolved);
+      const normalizedRoot = path50.normalize(realRoot);
+      if (!normalizedResolved.startsWith(normalizedRoot + path50.sep) && normalizedResolved !== normalizedRoot) {
         return null;
       }
       return resolved;
@@ -66532,7 +66589,7 @@ function resolveModuleSpecifier(workspaceRoot, sourceFile, specifier) {
 function createEmptyGraph(workspaceRoot) {
   return {
     schema_version: GRAPH_SCHEMA_VERSION,
-    workspaceRoot: path49.normalize(workspaceRoot),
+    workspaceRoot: path50.normalize(workspaceRoot),
     nodes: {},
     edges: [],
     metadata: {
@@ -66566,10 +66623,10 @@ function addEdge(graph, edge) {
   }
 }
 function getCachedGraph(workspace) {
-  return graphCache.get(path49.normalize(workspace));
+  return graphCache.get(path50.normalize(workspace));
 }
 function setCachedGraph(workspace, graph, mtime) {
-  const normalized = path49.normalize(workspace);
+  const normalized = path50.normalize(workspace);
   graphCache.set(normalized, graph);
   dirtyFlags.set(normalized, false);
   if (mtime !== undefined) {
@@ -66577,10 +66634,10 @@ function setCachedGraph(workspace, graph, mtime) {
   }
 }
 function isDirty(workspace) {
-  return dirtyFlags.get(path49.normalize(workspace)) ?? false;
+  return dirtyFlags.get(path50.normalize(workspace)) ?? false;
 }
 function clearCache(workspace) {
-  const normalized = path49.normalize(workspace);
+  const normalized = path50.normalize(workspace);
   graphCache.delete(normalized);
   dirtyFlags.delete(normalized);
   mtimeCache.delete(normalized);
@@ -66593,7 +66650,7 @@ function getGraphPath(workspace) {
 }
 async function loadGraph(workspace) {
   validateWorkspace(workspace);
-  const normalized = path49.normalize(workspace);
+  const normalized = path50.normalize(workspace);
   const cached3 = getCachedGraph(normalized);
   if (cached3 && !isDirty(normalized)) {
     try {
@@ -66687,28 +66744,28 @@ async function saveGraph(workspace, graph, options) {
   if (!Array.isArray(graph.edges)) {
     throw new Error("Graph must have edges array");
   }
-  const normalizedWorkspace = path49.normalize(workspace);
+  const normalizedWorkspace = path50.normalize(workspace);
   let realWorkspace;
   try {
     realWorkspace = realpathSync6(workspace);
   } catch {
     realWorkspace = normalizedWorkspace;
   }
-  const normalizedGraphRoot = path49.normalize(graph.workspaceRoot);
+  const normalizedGraphRoot = path50.normalize(graph.workspaceRoot);
   let realGraphRoot;
   try {
     realGraphRoot = realpathSync6(graph.workspaceRoot);
   } catch {
     realGraphRoot = normalizedGraphRoot;
   }
-  if (path49.normalize(realWorkspace) !== path49.normalize(realGraphRoot)) {
+  if (path50.normalize(realWorkspace) !== path50.normalize(realGraphRoot)) {
     throw new Error(`Graph workspaceRoot mismatch: graph was built for "${graph.workspaceRoot}" but save was called for "${workspace}"`);
   }
   const normalized = normalizedWorkspace;
   const graphPath = getGraphPath(workspace);
   updateGraphMetadata(graph);
   const tempPath = `${graphPath}.tmp.${Date.now()}.${Math.floor(Math.random() * 1e9)}`;
-  await fsPromises3.mkdir(path49.dirname(tempPath), { recursive: true });
+  await fsPromises3.mkdir(path50.dirname(tempPath), { recursive: true });
   let lastError = null;
   try {
     if (options?.createAtomic) {
@@ -66839,7 +66896,7 @@ function findSourceFiles(dir, stats) {
       stats.skippedDirs++;
       continue;
     }
-    const fullPath = path49.join(dir, entry);
+    const fullPath = path50.join(dir, entry);
     let stat3;
     try {
       stat3 = fsSync2.statSync(fullPath);
@@ -66850,7 +66907,7 @@ function findSourceFiles(dir, stats) {
       const subFiles = findSourceFiles(fullPath, stats);
       files.push(...subFiles);
     } else if (stat3.isFile()) {
-      const ext = path49.extname(fullPath).toLowerCase();
+      const ext = path50.extname(fullPath).toLowerCase();
       if (SUPPORTED_EXTENSIONS.includes(ext)) {
         files.push(fullPath);
       }
@@ -66859,11 +66916,11 @@ function findSourceFiles(dir, stats) {
   return files;
 }
 function toModuleName(filePath, workspaceRoot) {
-  const relative9 = path49.relative(workspaceRoot, filePath);
-  return relative9.split(path49.sep).join("/");
+  const relative9 = path50.relative(workspaceRoot, filePath);
+  return relative9.split(path50.sep).join("/");
 }
 function getLanguage(filePath) {
-  const ext = path49.extname(filePath).toLowerCase();
+  const ext = path50.extname(filePath).toLowerCase();
   return EXTENSION_TO_LANGUAGE[ext] ?? "unknown";
 }
 function isBinaryContent(content) {
@@ -66876,7 +66933,7 @@ function buildWorkspaceGraph(workspaceRoot, options) {
   validateWorkspace(workspaceRoot);
   const maxFileSize = options?.maxFileSizeBytes ?? 1024 * 1024;
   const maxFiles = options?.maxFiles ?? 1e4;
-  const absoluteRoot = path49.resolve(workspaceRoot);
+  const absoluteRoot = path50.resolve(workspaceRoot);
   if (!existsSync28(absoluteRoot)) {
     throw new Error(`Workspace directory does not exist: ${workspaceRoot}`);
   }
@@ -66917,16 +66974,16 @@ function buildWorkspaceGraph(workspaceRoot, options) {
       continue;
     }
     stats.filesScanned++;
-    const ext = path49.extname(filePath).toLowerCase();
+    const ext = path50.extname(filePath).toLowerCase();
     let exports = [];
     let parsedImports = [];
     try {
       if ([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"].includes(ext)) {
-        const relativePath = path49.relative(absoluteRoot, filePath);
+        const relativePath = path50.relative(absoluteRoot, filePath);
         const symbols2 = extractTSSymbols(relativePath, absoluteRoot);
         exports = symbols2.filter((s) => s.exported).map((s) => s.name);
       } else if (ext === ".py") {
-        const relativePath = path49.relative(absoluteRoot, filePath);
+        const relativePath = path50.relative(absoluteRoot, filePath);
         const symbols2 = extractPythonSymbols(relativePath, absoluteRoot);
         exports = symbols2.filter((s) => s.exported).map((s) => s.name);
       }
@@ -66983,15 +67040,15 @@ function scanFile(filePath, absoluteRoot, maxFileSize) {
   if (isBinaryContent(content)) {
     return { node: null, edges: [] };
   }
-  const ext = path49.extname(filePath).toLowerCase();
+  const ext = path50.extname(filePath).toLowerCase();
   let exports = [];
   try {
     if ([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"].includes(ext)) {
-      const relativePath = path49.relative(absoluteRoot, filePath);
+      const relativePath = path50.relative(absoluteRoot, filePath);
       const symbols2 = extractTSSymbols(relativePath, absoluteRoot);
       exports = symbols2.filter((s) => s.exported).map((s) => s.name);
     } else if (ext === ".py") {
-      const relativePath = path49.relative(absoluteRoot, filePath);
+      const relativePath = path50.relative(absoluteRoot, filePath);
       const symbols2 = extractPythonSymbols(relativePath, absoluteRoot);
       exports = symbols2.filter((s) => s.exported).map((s) => s.name);
     }
@@ -67035,7 +67092,7 @@ async function updateGraphForFiles(workspaceRoot, filePaths, options) {
     return graph2;
   }
   const graph = existingGraph;
-  const absoluteRoot = path49.resolve(workspaceRoot);
+  const absoluteRoot = path50.resolve(workspaceRoot);
   const maxFileSize = 1024 * 1024;
   const updatedPaths = new Set;
   for (const rawFilePath of filePaths) {
@@ -67148,7 +67205,7 @@ function createRepoGraphBuilderHook(workspaceRoot, deps) {
       if (!isSupportedSourceFile(filePath)) {
         return;
       }
-      const absoluteFilePath = path50.isAbsolute(filePath) ? filePath : path50.resolve(workspaceRoot, filePath);
+      const absoluteFilePath = path51.isAbsolute(filePath) ? filePath : path51.resolve(workspaceRoot, filePath);
       const normalizedAbsolute = absoluteFilePath.replace(/\\/g, "/");
       const normalizedWorkspace = workspaceRoot.replace(/\\/g, "/");
       if (!normalizedAbsolute.startsWith(`${normalizedWorkspace}/`) && normalizedAbsolute !== normalizedWorkspace) {
@@ -67156,7 +67213,7 @@ function createRepoGraphBuilderHook(workspaceRoot, deps) {
       }
       try {
         await _updateGraphForFiles(workspaceRoot, [absoluteFilePath]);
-        log(`[repo-graph] Incremental update for ${path50.basename(filePath)}`);
+        log(`[repo-graph] Incremental update for ${path51.basename(filePath)}`);
       } catch (error93) {
         const message = error93 instanceof Error ? error93.message : String(error93);
         error48(`[repo-graph] Incremental update failed: ${message}`);
@@ -67175,14 +67232,14 @@ init_manager2();
 init_detector();
 init_manager();
 import * as fs44 from "node:fs";
-import * as path60 from "node:path";
+import * as path61 from "node:path";
 
 // src/services/decision-drift-analyzer.ts
 init_utils2();
 init_manager();
 init_utils();
 import * as fs36 from "node:fs";
-import * as path51 from "node:path";
+import * as path52 from "node:path";
 var DEFAULT_DRIFT_CONFIG = {
   staleThresholdPhases: 1,
   detectContradictions: true,
@@ -67336,7 +67393,7 @@ async function analyzeDecisionDrift(directory, config3 = {}) {
         currentPhase = legacyPhase;
       }
     }
-    const contextPath = path51.join(directory, ".swarm", "context.md");
+    const contextPath = path52.join(directory, ".swarm", "context.md");
     let contextContent = "";
     try {
       if (fs36.existsSync(contextPath)) {
@@ -67475,7 +67532,7 @@ init_utils();
 init_constants();
 init_schema();
 import * as fs37 from "node:fs/promises";
-import * as path52 from "node:path";
+import * as path53 from "node:path";
 function safeGet(obj, key) {
   if (!obj || !Object.hasOwn(obj, key))
     return;
@@ -67707,23 +67764,18 @@ async function handleDebuggingSpiral(match, taskId, directory) {
   let eventLogged = false;
   let checkpointCreated = false;
   try {
-    const swarmDir = path52.join(directory, ".swarm");
+    const swarmDir = path53.join(directory, ".swarm");
     await fs37.mkdir(swarmDir, { recursive: true });
-    const eventsPath = path52.join(swarmDir, "events.jsonl");
+    const eventsPath = path53.join(swarmDir, "events.jsonl");
     await fs37.appendFile(eventsPath, `${formatDebuggingSpiralEvent(match, taskId)}
 `);
     eventLogged = true;
   } catch {}
   const checkpointLabel = `spiral-${taskId}-${Date.now()}`;
   try {
-    const { checkpoint: checkpoint2 } = await Promise.resolve().then(() => (init_checkpoint(), exports_checkpoint));
-    const result = await checkpoint2.execute({ action: "save", label: checkpointLabel }, { directory });
-    try {
-      const parsed = JSON.parse(result);
-      checkpointCreated = parsed.success === true;
-    } catch {
-      checkpointCreated = false;
-    }
+    const { saveCheckpointRecord: saveCheckpointRecord2 } = await Promise.resolve().then(() => (init_checkpoint(), exports_checkpoint));
+    const result = saveCheckpointRecord2(checkpointLabel, directory);
+    checkpointCreated = result.success === true;
   } catch {
     checkpointCreated = false;
   }
@@ -67849,7 +67901,7 @@ import * as fs41 from "node:fs";
 
 // src/graph/graph-builder.ts
 import * as fs39 from "node:fs";
-import * as path55 from "node:path";
+import * as path56 from "node:path";
 
 // node_modules/yocto-queue/index.js
 class Node {
@@ -68010,7 +68062,7 @@ function validateConcurrency(concurrency) {
 // src/graph/import-extractor.ts
 init_path_security();
 import * as fs38 from "node:fs";
-import * as path53 from "node:path";
+import * as path54 from "node:path";
 var SOURCE_EXTENSIONS2 = [
   ".ts",
   ".tsx",
@@ -68055,14 +68107,14 @@ function getLanguageFromExtension(ext) {
   return null;
 }
 function toRelForwardSlash(absPath, root) {
-  return path53.relative(root, absPath).replace(/\\/g, "/");
+  return path54.relative(root, absPath).replace(/\\/g, "/");
 }
 function tryResolveTSJS(rawModule, sourceFileAbs) {
   if (!rawModule.startsWith(".") && !rawModule.startsWith("/")) {
     return null;
   }
-  const sourceDir = path53.dirname(sourceFileAbs);
-  const baseAbs = path53.resolve(sourceDir, rawModule);
+  const sourceDir = path54.dirname(sourceFileAbs);
+  const baseAbs = path54.resolve(sourceDir, rawModule);
   const probe = (basePath) => {
     for (const ext of RESOLVE_EXTENSION_CANDIDATES) {
       const test = basePath + ext;
@@ -68073,7 +68125,7 @@ function tryResolveTSJS(rawModule, sourceFileAbs) {
       } catch {}
     }
     for (const indexFile of RESOLVE_INDEX_CANDIDATES) {
-      const test = path53.join(basePath, indexFile);
+      const test = path54.join(basePath, indexFile);
       try {
         const stat3 = fs38.statSync(test);
         if (stat3.isFile())
@@ -68103,13 +68155,13 @@ function tryResolvePython(rawModule, sourceFileAbs, workspaceRoot) {
   }
   const remainder = rawModule.slice(leadingDots).replace(/\./g, "/");
   const upDirs = "../".repeat(Math.max(0, leadingDots - 1));
-  const sourceDir = path53.dirname(sourceFileAbs);
-  const baseAbs = path53.resolve(sourceDir, upDirs + remainder);
+  const sourceDir = path54.dirname(sourceFileAbs);
+  const baseAbs = path54.resolve(sourceDir, upDirs + remainder);
   const accept = (test) => {
     try {
       const stat3 = fs38.statSync(test);
       if (stat3.isFile()) {
-        const rel = path53.relative(workspaceRoot, test).replace(/\\/g, "/");
+        const rel = path54.relative(workspaceRoot, test).replace(/\\/g, "/");
         if (rel.startsWith(".."))
           return null;
         return test;
@@ -68123,7 +68175,7 @@ function tryResolvePython(rawModule, sourceFileAbs, workspaceRoot) {
       return hit;
   }
   for (const indexFile of PY_INDEX_CANDIDATES) {
-    const hit = accept(path53.join(baseAbs, indexFile));
+    const hit = accept(path54.join(baseAbs, indexFile));
     if (hit)
       return hit;
   }
@@ -68494,7 +68546,7 @@ function parseRustUses(content) {
 }
 function extractImports2(opts) {
   const { absoluteFilePath, workspaceRoot } = opts;
-  const ext = path53.extname(absoluteFilePath).toLowerCase();
+  const ext = path54.extname(absoluteFilePath).toLowerCase();
   const language = getLanguageFromExtension(ext);
   if (!language)
     return [];
@@ -68545,9 +68597,9 @@ function extractImports2(opts) {
 }
 
 // src/graph/symbol-extractor.ts
-import * as path54 from "node:path";
+import * as path55 from "node:path";
 function extractExportedSymbols(relativeFilePath, workspaceRoot) {
-  const ext = path54.extname(relativeFilePath).toLowerCase();
+  const ext = path55.extname(relativeFilePath).toLowerCase();
   const language = getLanguageFromExtension(ext);
   if (!language)
     return [];
@@ -68636,15 +68688,15 @@ function findSourceFiles2(workspaceRoot, skipDirs = DEFAULT_SKIP_DIRS) {
       if (entry.isDirectory()) {
         if (skipDirs.has(entry.name))
           continue;
-        stack.push(path55.join(dir, entry.name));
+        stack.push(path56.join(dir, entry.name));
         continue;
       }
       if (!entry.isFile())
         continue;
-      const ext = path55.extname(entry.name).toLowerCase();
+      const ext = path56.extname(entry.name).toLowerCase();
       if (!SOURCE_EXT_SET.has(ext))
         continue;
-      out2.push(path55.join(dir, entry.name));
+      out2.push(path56.join(dir, entry.name));
     }
   }
   return out2;
@@ -68672,7 +68724,7 @@ async function buildRepoGraph(workspaceRoot, options = {}) {
   };
 }
 async function processFile(absoluteFilePath, workspaceRoot) {
-  const ext = path55.extname(absoluteFilePath).toLowerCase();
+  const ext = path56.extname(absoluteFilePath).toLowerCase();
   const language = getLanguageFromExtension(ext);
   if (!language)
     return null;
@@ -68692,7 +68744,7 @@ async function processFile(absoluteFilePath, workspaceRoot) {
   } catch {
     return null;
   }
-  const relPath = path55.relative(workspaceRoot, absoluteFilePath).replace(/\\/g, "/");
+  const relPath = path56.relative(workspaceRoot, absoluteFilePath).replace(/\\/g, "/");
   const imports = extractImports2({
     absoluteFilePath,
     workspaceRoot,
@@ -68934,10 +68986,10 @@ function formatSummary(opts) {
 // src/graph/graph-store.ts
 import * as crypto6 from "node:crypto";
 import * as fs40 from "node:fs";
-import * as path56 from "node:path";
+import * as path57 from "node:path";
 var SWARM_DIR = ".swarm";
 function getGraphPath2(workspaceRoot) {
-  return path56.join(workspaceRoot, SWARM_DIR, REPO_GRAPH_FILENAME2);
+  return path57.join(workspaceRoot, SWARM_DIR, REPO_GRAPH_FILENAME2);
 }
 function loadGraph2(workspaceRoot) {
   const file3 = getGraphPath2(workspaceRoot);
@@ -68959,7 +69011,7 @@ function loadGraph2(workspaceRoot) {
 }
 function saveGraph2(workspaceRoot, graph) {
   const file3 = getGraphPath2(workspaceRoot);
-  const dir = path56.dirname(file3);
+  const dir = path57.dirname(file3);
   try {
     const stat3 = fs40.lstatSync(dir);
     if (stat3.isSymbolicLink()) {
@@ -69065,7 +69117,7 @@ function buildReviewerBlastRadiusBlock(directory, changedFiles) {
 // src/hooks/semantic-diff-injection.ts
 import * as child_process5 from "node:child_process";
 import * as fs42 from "node:fs";
-import * as path58 from "node:path";
+import * as path59 from "node:path";
 
 // src/diff/ast-diff.ts
 init_tree_sitter();
@@ -69812,17 +69864,17 @@ async function buildSemanticDiffBlock(directory, changedFiles, maxFiles = 10) {
     const fileConsumers = {};
     if (graph) {
       for (const f of filesToProcess) {
-        const relativePath = path58.isAbsolute(f) ? path58.relative(directory, f) : f;
+        const relativePath = path59.isAbsolute(f) ? path59.relative(directory, f) : f;
         const normalized = normalizeGraphPath2(relativePath);
         fileConsumers[normalized] = getImporters(graph, normalized).length;
         fileConsumers[f] = fileConsumers[normalized];
       }
     }
     for (const filePath of filesToProcess) {
-      const normalizedPath = path58.normalize(filePath);
-      const resolvedPath = path58.resolve(directory, normalizedPath);
-      const relativeToDir = path58.relative(directory, resolvedPath);
-      if (relativeToDir.startsWith("..") || path58.isAbsolute(relativeToDir)) {
+      const normalizedPath = path59.normalize(filePath);
+      const resolvedPath = path59.resolve(directory, normalizedPath);
+      const relativeToDir = path59.relative(directory, resolvedPath);
+      if (relativeToDir.startsWith("..") || path59.isAbsolute(relativeToDir)) {
         continue;
       }
       try {
@@ -69849,7 +69901,7 @@ async function buildSemanticDiffBlock(directory, changedFiles, maxFiles = 10) {
           stdio: "pipe",
           maxBuffer: 5 * 1024 * 1024
         }) : "";
-        const newContent = fs42.readFileSync(path58.join(directory, filePath), "utf-8");
+        const newContent = fs42.readFileSync(path59.join(directory, filePath), "utf-8");
         const astResult = await computeASTDiff(filePath, oldContent, newContent);
         if (astResult && (astResult.changes.length > 0 || astResult.error !== undefined)) {
           astDiffs.push(astResult);
@@ -70191,7 +70243,7 @@ function createSystemEnhancerHook(config3, directory) {
               await fs44.promises.writeFile(darkMatterPath, darkMatterReport, "utf-8");
               warn(`[system-enhancer] Dark matter scan complete: ${darkMatter.length} co-change patterns found`);
               try {
-                const projectName = path60.basename(path60.resolve(directory));
+                const projectName = path61.basename(path61.resolve(directory));
                 const knowledgeEntries = darkMatterToKnowledgeEntries2(darkMatter, projectName);
                 const knowledgePath = resolveSwarmKnowledgePath(directory);
                 const existingEntries = await readKnowledge(knowledgePath);
@@ -70390,7 +70442,7 @@ ${lines.join(`
             try {
               const taskId_ccp = ccpSession?.currentTaskId;
               if (taskId_ccp && !taskId_ccp.includes("..") && !taskId_ccp.includes("/") && !taskId_ccp.includes("\\") && !taskId_ccp.includes("\x00")) {
-                const evidencePath = path60.join(directory, ".swarm", "evidence", `${taskId_ccp}.json`);
+                const evidencePath = path61.join(directory, ".swarm", "evidence", `${taskId_ccp}.json`);
                 if (fs44.existsSync(evidencePath)) {
                   const evidenceContent = fs44.readFileSync(evidencePath, "utf-8");
                   const evidenceData = JSON.parse(evidenceContent);
@@ -71536,7 +71588,7 @@ init_hive_promoter();
 
 // src/hooks/incremental-verify.ts
 import * as fs45 from "node:fs";
-import * as path61 from "node:path";
+import * as path62 from "node:path";
 
 // src/hooks/spawn-helper.ts
 import * as child_process6 from "node:child_process";
@@ -71614,18 +71666,18 @@ function spawnAsync(command, cwd, timeoutMs) {
 // src/hooks/incremental-verify.ts
 var emittedSkipAdvisories = new Set;
 function detectPackageManager(projectDir) {
-  if (fs45.existsSync(path61.join(projectDir, "bun.lockb")))
+  if (fs45.existsSync(path62.join(projectDir, "bun.lockb")))
     return "bun";
-  if (fs45.existsSync(path61.join(projectDir, "pnpm-lock.yaml")))
+  if (fs45.existsSync(path62.join(projectDir, "pnpm-lock.yaml")))
     return "pnpm";
-  if (fs45.existsSync(path61.join(projectDir, "yarn.lock")))
+  if (fs45.existsSync(path62.join(projectDir, "yarn.lock")))
     return "yarn";
-  if (fs45.existsSync(path61.join(projectDir, "package-lock.json")))
+  if (fs45.existsSync(path62.join(projectDir, "package-lock.json")))
     return "npm";
   return "bun";
 }
 function detectTypecheckCommand(projectDir) {
-  const pkgPath = path61.join(projectDir, "package.json");
+  const pkgPath = path62.join(projectDir, "package.json");
   if (fs45.existsSync(pkgPath)) {
     try {
       const pkg = JSON.parse(fs45.readFileSync(pkgPath, "utf8"));
@@ -71642,8 +71694,8 @@ function detectTypecheckCommand(projectDir) {
         ...pkg.dependencies,
         ...pkg.devDependencies
       };
-      if (!deps?.typescript && !fs45.existsSync(path61.join(projectDir, "tsconfig.json"))) {}
-      const hasTSMarkers = deps?.typescript || fs45.existsSync(path61.join(projectDir, "tsconfig.json"));
+      if (!deps?.typescript && !fs45.existsSync(path62.join(projectDir, "tsconfig.json"))) {}
+      const hasTSMarkers = deps?.typescript || fs45.existsSync(path62.join(projectDir, "tsconfig.json"));
       if (hasTSMarkers) {
         return { command: ["npx", "tsc", "--noEmit"], language: "typescript" };
       }
@@ -71651,13 +71703,13 @@ function detectTypecheckCommand(projectDir) {
       return null;
     }
   }
-  if (fs45.existsSync(path61.join(projectDir, "go.mod"))) {
+  if (fs45.existsSync(path62.join(projectDir, "go.mod"))) {
     return { command: ["go", "vet", "./..."], language: "go" };
   }
-  if (fs45.existsSync(path61.join(projectDir, "Cargo.toml"))) {
+  if (fs45.existsSync(path62.join(projectDir, "Cargo.toml"))) {
     return { command: ["cargo", "check"], language: "rust" };
   }
-  if (fs45.existsSync(path61.join(projectDir, "pyproject.toml")) || fs45.existsSync(path61.join(projectDir, "requirements.txt")) || fs45.existsSync(path61.join(projectDir, "setup.py"))) {
+  if (fs45.existsSync(path62.join(projectDir, "pyproject.toml")) || fs45.existsSync(path62.join(projectDir, "requirements.txt")) || fs45.existsSync(path62.join(projectDir, "setup.py"))) {
     return { command: null, language: "python" };
   }
   try {
@@ -72007,7 +72059,7 @@ init_scope_persistence();
 init_state();
 init_delegation_gate();
 init_normalize_tool_name();
-import * as path63 from "node:path";
+import * as path64 from "node:path";
 var WRITE_TOOLS = new Set(WRITE_TOOL_NAMES);
 function createScopeGuardHook(config3, directory, injectAdvisory) {
   const enabled = config3.enabled ?? true;
@@ -72065,13 +72117,13 @@ function createScopeGuardHook(config3, directory, injectAdvisory) {
 }
 function isFileInScope(filePath, scopeEntries, directory) {
   const dir = directory ?? process.cwd();
-  const resolvedFile = path63.resolve(dir, filePath);
+  const resolvedFile = path64.resolve(dir, filePath);
   return scopeEntries.some((scope) => {
-    const resolvedScope = path63.resolve(dir, scope);
+    const resolvedScope = path64.resolve(dir, scope);
     if (resolvedFile === resolvedScope)
       return true;
-    const rel = path63.relative(resolvedScope, resolvedFile);
-    return rel.length > 0 && !rel.startsWith("..") && !path63.isAbsolute(rel);
+    const rel = path64.relative(resolvedScope, resolvedFile);
+    return rel.length > 0 && !rel.startsWith("..") && !path64.isAbsolute(rel);
   });
 }
 
@@ -72123,7 +72175,7 @@ function createSelfReviewHook(config3, injectAdvisory) {
 
 // src/hooks/slop-detector.ts
 import * as fs47 from "node:fs";
-import * as path64 from "node:path";
+import * as path65 from "node:path";
 var WRITE_EDIT_TOOLS = new Set([
   "write",
   "edit",
@@ -72173,7 +72225,7 @@ function walkFiles(dir, exts, deadline) {
         break;
       if (entry.isSymbolicLink())
         continue;
-      const full = path64.join(dir, entry.name);
+      const full = path65.join(dir, entry.name);
       if (entry.isDirectory()) {
         if (entry.name === "node_modules" || entry.name === ".git")
           continue;
@@ -72188,7 +72240,7 @@ function walkFiles(dir, exts, deadline) {
   return results;
 }
 function checkDeadExports(content, projectDir, startTime) {
-  const hasPackageJson = fs47.existsSync(path64.join(projectDir, "package.json"));
+  const hasPackageJson = fs47.existsSync(path65.join(projectDir, "package.json"));
   if (!hasPackageJson)
     return null;
   const exportMatches = content.matchAll(/^\+(?:export)\s+(?:function|class|const|type|interface)\s+(\w{3,})/gm);
@@ -72396,14 +72448,14 @@ function createSteeringConsumedHook(directory) {
 // src/hooks/trajectory-logger.ts
 init_manager2();
 import * as fs50 from "node:fs/promises";
-import * as path66 from "node:path";
+import * as path67 from "node:path";
 
 // src/prm/trajectory-store.ts
 init_utils2();
 import * as fs49 from "node:fs/promises";
-import * as path65 from "node:path";
+import * as path66 from "node:path";
 function getTrajectoryPath(sessionId, directory) {
-  const relativePath = path65.join("trajectories", `${sessionId}.jsonl`);
+  const relativePath = path66.join("trajectories", `${sessionId}.jsonl`);
   return validateSwarmPath(directory, relativePath);
 }
 var _inMemoryTrajectoryCache = new Map;
@@ -72422,7 +72474,7 @@ async function appendTrajectoryEntry(sessionId, entry, directory, maxLines = 100
       _inMemoryTrajectoryCache.set(sessionId, cached3);
     }
     const trajectoryPath = getTrajectoryPath(sessionId, directory);
-    await fs49.mkdir(path65.dirname(trajectoryPath), { recursive: true });
+    await fs49.mkdir(path66.dirname(trajectoryPath), { recursive: true });
     const line = `${JSON.stringify(entry)}
 `;
     await fs49.appendFile(trajectoryPath, line, "utf-8");
@@ -72461,7 +72513,7 @@ async function cleanupOldTrajectoryFiles(directory, maxAgeDays = 7) {
       for (const entry of entries) {
         if (!entry.isFile())
           continue;
-        const filePath = path65.join(dirPath, entry.name);
+        const filePath = path66.join(dirPath, entry.name);
         try {
           const stat4 = await fs49.stat(filePath);
           if (now - stat4.mtimeMs > cutoffMs) {
@@ -72653,10 +72705,10 @@ function createTrajectoryLoggerHook(config3, _directory) {
         elapsed_ms
       };
       const sanitized = sanitizeTaskId2(taskId);
-      const relativePath = path66.join("evidence", sanitized, "trajectory.jsonl");
+      const relativePath = path67.join("evidence", sanitized, "trajectory.jsonl");
       const trajectoryPath = validateSwarmPath(_directory, relativePath);
       try {
-        await fs50.mkdir(path66.dirname(trajectoryPath), { recursive: true });
+        await fs50.mkdir(path67.dirname(trajectoryPath), { recursive: true });
         const line = `${JSON.stringify(entry)}
 `;
         await fs50.appendFile(trajectoryPath, line, "utf-8");
@@ -73207,16 +73259,16 @@ init_telemetry();
 
 // src/prm/replay.ts
 import { promises as fs51 } from "node:fs";
-import path67 from "node:path";
+import path68 from "node:path";
 function isPathSafe2(targetPath, basePath) {
-  const resolvedTarget = path67.resolve(targetPath);
-  const resolvedBase = path67.resolve(basePath);
-  const rel = path67.relative(resolvedBase, resolvedTarget);
-  return !rel.startsWith("..") && !path67.isAbsolute(rel);
+  const resolvedTarget = path68.resolve(targetPath);
+  const resolvedBase = path68.resolve(basePath);
+  const rel = path68.relative(resolvedBase, resolvedTarget);
+  return !rel.startsWith("..") && !path68.isAbsolute(rel);
 }
 function isWithinReplaysDir(targetPath) {
-  const resolved = path67.resolve(targetPath);
-  const parts2 = resolved.split(path67.sep);
+  const resolved = path68.resolve(targetPath);
+  const parts2 = resolved.split(path68.sep);
   for (let i2 = 0;i2 < parts2.length - 1; i2++) {
     if (parts2[i2] === ".swarm" && parts2[i2 + 1] === "replays") {
       return true;
@@ -73229,10 +73281,10 @@ function sanitizeFilename(input) {
 }
 async function startReplayRecording(sessionID, directory) {
   try {
-    const replayDir = path67.join(directory, ".swarm", "replays");
+    const replayDir = path68.join(directory, ".swarm", "replays");
     const safeSessionID = sanitizeFilename(sessionID);
     const filename = `${safeSessionID}-${Date.now()}.jsonl`;
-    const filepath = path67.join(replayDir, filename);
+    const filepath = path68.join(replayDir, filename);
     if (!isPathSafe2(filepath, replayDir)) {
       console.warn(`[replay] Invalid path detected - path traversal attempt blocked for session ${sessionID}`);
       return null;
@@ -73605,7 +73657,7 @@ init_telemetry();
 init_dist();
 init_create_tool();
 import * as fs52 from "node:fs";
-import * as path68 from "node:path";
+import * as path69 from "node:path";
 init_path_security();
 var WINDOWS_RESERVED_NAMES2 = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|:|$)/i;
 function containsWindowsAttacks2(str) {
@@ -73622,14 +73674,14 @@ function containsWindowsAttacks2(str) {
 }
 function isPathInWorkspace2(filePath, workspace) {
   try {
-    const resolvedPath = path68.resolve(workspace, filePath);
+    const resolvedPath = path69.resolve(workspace, filePath);
     if (!fs52.existsSync(resolvedPath)) {
       return true;
     }
     const realWorkspace = fs52.realpathSync(workspace);
     const realResolvedPath = fs52.realpathSync(resolvedPath);
-    const relativePath = path68.relative(realWorkspace, realResolvedPath);
-    if (relativePath.startsWith("..") || path68.isAbsolute(relativePath)) {
+    const relativePath = path69.relative(realWorkspace, realResolvedPath);
+    if (relativePath.startsWith("..") || path69.isAbsolute(relativePath)) {
       return false;
     }
     return true;
@@ -73638,7 +73690,7 @@ function isPathInWorkspace2(filePath, workspace) {
   }
 }
 function processFile2(file3, cwd, exportedOnly) {
-  const ext = path68.extname(file3);
+  const ext = path69.extname(file3);
   if (containsControlChars(file3)) {
     return {
       file: file3,
@@ -73671,7 +73723,7 @@ function processFile2(file3, cwd, exportedOnly) {
       errorType: "path-outside-workspace"
     };
   }
-  const fullPath = path68.join(cwd, file3);
+  const fullPath = path69.join(cwd, file3);
   if (!fs52.existsSync(fullPath)) {
     return {
       file: file3,
@@ -73963,15 +74015,15 @@ init_task_id();
 init_create_tool();
 init_resolve_working_directory();
 import * as fs53 from "node:fs";
-import * as path69 from "node:path";
+import * as path70 from "node:path";
 var EVIDENCE_DIR = ".swarm/evidence";
 function isValidTaskId3(taskId) {
   return isStrictTaskId(taskId);
 }
 function isPathWithinSwarm(filePath, workspaceRoot) {
-  const normalizedWorkspace = path69.resolve(workspaceRoot);
-  const swarmPath = path69.join(normalizedWorkspace, ".swarm", "evidence");
-  const normalizedPath = path69.resolve(filePath);
+  const normalizedWorkspace = path70.resolve(workspaceRoot);
+  const swarmPath = path70.join(normalizedWorkspace, ".swarm", "evidence");
+  const normalizedPath = path70.resolve(filePath);
   return normalizedPath.startsWith(swarmPath);
 }
 function readEvidenceFile(evidencePath) {
@@ -74052,7 +74104,7 @@ var check_gate_status = createSwarmTool({
       };
       return JSON.stringify(errorResult, null, 2);
     }
-    const evidencePath = path69.join(directory, EVIDENCE_DIR, `${taskIdInput}.json`);
+    const evidencePath = path70.join(directory, EVIDENCE_DIR, `${taskIdInput}.json`);
     if (!isPathWithinSwarm(evidencePath, directory)) {
       const errorResult = {
         taskId: taskIdInput,
@@ -74149,7 +74201,7 @@ init_state();
 init_create_tool();
 init_resolve_working_directory();
 import * as fs54 from "node:fs";
-import * as path70 from "node:path";
+import * as path71 from "node:path";
 function extractMatches(regex, text) {
   return Array.from(text.matchAll(regex));
 }
@@ -74301,10 +74353,10 @@ async function executeCompletionVerify(args2, directory) {
     let hasFileReadFailure = false;
     for (const filePath of fileTargets) {
       const normalizedPath = filePath.replace(/\\/g, "/");
-      const resolvedPath = path70.resolve(directory, normalizedPath);
-      const projectRoot = path70.resolve(directory);
-      const relative16 = path70.relative(projectRoot, resolvedPath);
-      const withinProject = relative16 === "" || !relative16.startsWith("..") && !path70.isAbsolute(relative16);
+      const resolvedPath = path71.resolve(directory, normalizedPath);
+      const projectRoot = path71.resolve(directory);
+      const relative16 = path71.relative(projectRoot, resolvedPath);
+      const withinProject = relative16 === "" || !relative16.startsWith("..") && !path71.isAbsolute(relative16);
       if (!withinProject) {
         blockedTasks.push({
           task_id: task.id,
@@ -74359,8 +74411,8 @@ async function executeCompletionVerify(args2, directory) {
     blockedTasks
   };
   try {
-    const evidenceDir = path70.join(directory, ".swarm", "evidence", `${phase}`);
-    const evidencePath = path70.join(evidenceDir, "completion-verify.json");
+    const evidenceDir = path71.join(directory, ".swarm", "evidence", `${phase}`);
+    const evidencePath = path71.join(evidenceDir, "completion-verify.json");
     fs54.mkdirSync(evidenceDir, { recursive: true });
     const evidenceBundle = {
       schema_version: "1.0.0",
@@ -74437,11 +74489,11 @@ var completion_verify = createSwarmTool({
 // src/tools/complexity-hotspots.ts
 init_zod();
 import * as fs56 from "node:fs";
-import * as path72 from "node:path";
+import * as path73 from "node:path";
 
 // src/quality/metrics.ts
 import * as fs55 from "node:fs";
-import * as path71 from "node:path";
+import * as path72 from "node:path";
 var MAX_FILE_SIZE_BYTES4 = 256 * 1024;
 var MIN_DUPLICATION_LINES = 10;
 function estimateCyclomaticComplexity(content) {
@@ -74493,7 +74545,7 @@ async function computeComplexityDelta(files, workingDir) {
   let totalComplexity = 0;
   const analyzedFiles = [];
   for (const file3 of files) {
-    const fullPath = path71.isAbsolute(file3) ? file3 : path71.join(workingDir, file3);
+    const fullPath = path72.isAbsolute(file3) ? file3 : path72.join(workingDir, file3);
     if (!fs55.existsSync(fullPath)) {
       continue;
     }
@@ -74616,7 +74668,7 @@ function countGoExports(content) {
 function getExportCountForFile(filePath) {
   try {
     const content = fs55.readFileSync(filePath, "utf-8");
-    const ext = path71.extname(filePath).toLowerCase();
+    const ext = path72.extname(filePath).toLowerCase();
     switch (ext) {
       case ".ts":
       case ".tsx":
@@ -74642,7 +74694,7 @@ async function computePublicApiDelta(files, workingDir) {
   let totalExports = 0;
   const analyzedFiles = [];
   for (const file3 of files) {
-    const fullPath = path71.isAbsolute(file3) ? file3 : path71.join(workingDir, file3);
+    const fullPath = path72.isAbsolute(file3) ? file3 : path72.join(workingDir, file3);
     if (!fs55.existsSync(fullPath)) {
       continue;
     }
@@ -74676,7 +74728,7 @@ async function computeDuplicationRatio(files, workingDir) {
   let duplicateLines = 0;
   const analyzedFiles = [];
   for (const file3 of files) {
-    const fullPath = path71.isAbsolute(file3) ? file3 : path71.join(workingDir, file3);
+    const fullPath = path72.isAbsolute(file3) ? file3 : path72.join(workingDir, file3);
     if (!fs55.existsSync(fullPath)) {
       continue;
     }
@@ -74709,8 +74761,8 @@ function countCodeLines(content) {
   return lines.length;
 }
 function isTestFile(filePath) {
-  const basename10 = path71.basename(filePath);
-  const _ext = path71.extname(filePath).toLowerCase();
+  const basename10 = path72.basename(filePath);
+  const _ext = path72.extname(filePath).toLowerCase();
   const testPatterns = [
     ".test.",
     ".spec.",
@@ -74791,8 +74843,8 @@ function matchGlobSegment(globSegments, pathSegments) {
   }
   return gIndex === globSegments.length && pIndex === pathSegments.length;
 }
-function matchesGlobSegment(path72, glob) {
-  const normalizedPath = path72.replace(/\\/g, "/");
+function matchesGlobSegment(path73, glob) {
+  const normalizedPath = path73.replace(/\\/g, "/");
   const normalizedGlob = glob.replace(/\\/g, "/");
   if (normalizedPath.includes("//")) {
     return false;
@@ -74823,8 +74875,8 @@ function simpleGlobToRegex2(glob) {
 function hasGlobstar(glob) {
   return glob.includes("**");
 }
-function globMatches(path72, glob) {
-  const normalizedPath = path72.replace(/\\/g, "/");
+function globMatches(path73, glob) {
+  const normalizedPath = path73.replace(/\\/g, "/");
   if (!glob || glob === "") {
     if (normalizedPath.includes("//")) {
       return false;
@@ -74860,7 +74912,7 @@ function shouldExcludeFile(filePath, excludeGlobs) {
 async function computeTestToCodeRatio(workingDir, enforceGlobs, excludeGlobs) {
   let testLines = 0;
   let codeLines = 0;
-  const srcDir = path71.join(workingDir, "src");
+  const srcDir = path72.join(workingDir, "src");
   if (fs55.existsSync(srcDir)) {
     await scanDirectoryForLines(srcDir, enforceGlobs, excludeGlobs, false, (lines) => {
       codeLines += lines;
@@ -74868,14 +74920,14 @@ async function computeTestToCodeRatio(workingDir, enforceGlobs, excludeGlobs) {
   }
   const possibleSrcDirs = ["lib", "app", "source", "core"];
   for (const dir of possibleSrcDirs) {
-    const dirPath = path71.join(workingDir, dir);
+    const dirPath = path72.join(workingDir, dir);
     if (fs55.existsSync(dirPath)) {
       await scanDirectoryForLines(dirPath, enforceGlobs, excludeGlobs, false, (lines) => {
         codeLines += lines;
       });
     }
   }
-  const testsDir = path71.join(workingDir, "tests");
+  const testsDir = path72.join(workingDir, "tests");
   if (fs55.existsSync(testsDir)) {
     await scanDirectoryForLines(testsDir, ["**"], ["node_modules", "dist"], true, (lines) => {
       testLines += lines;
@@ -74883,7 +74935,7 @@ async function computeTestToCodeRatio(workingDir, enforceGlobs, excludeGlobs) {
   }
   const possibleTestDirs = ["test", "__tests__", "specs"];
   for (const dir of possibleTestDirs) {
-    const dirPath = path71.join(workingDir, dir);
+    const dirPath = path72.join(workingDir, dir);
     if (fs55.existsSync(dirPath) && dirPath !== testsDir) {
       await scanDirectoryForLines(dirPath, ["**"], ["node_modules", "dist"], true, (lines) => {
         testLines += lines;
@@ -74898,7 +74950,7 @@ async function scanDirectoryForLines(dirPath, includeGlobs, excludeGlobs, isTest
   try {
     const entries = fs55.readdirSync(dirPath, { withFileTypes: true });
     for (const entry of entries) {
-      const fullPath = path71.join(dirPath, entry.name);
+      const fullPath = path72.join(dirPath, entry.name);
       if (entry.isDirectory()) {
         if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "build" || entry.name === ".git") {
           continue;
@@ -74906,7 +74958,7 @@ async function scanDirectoryForLines(dirPath, includeGlobs, excludeGlobs, isTest
         await scanDirectoryForLines(fullPath, includeGlobs, excludeGlobs, isTestScan, callback);
       } else if (entry.isFile()) {
         const relativePath = fullPath.replace(`${dirPath}/`, "");
-        const ext = path71.extname(entry.name).toLowerCase();
+        const ext = path72.extname(entry.name).toLowerCase();
         const validExts = [
           ".ts",
           ".tsx",
@@ -75159,7 +75211,7 @@ async function analyzeHotspots(days, topN, extensions, directory) {
   const extSet = new Set(extensions.map((e) => e.startsWith(".") ? e : `.${e}`));
   const filteredChurn = new Map;
   for (const [file3, count] of churnMap) {
-    const ext = path72.extname(file3).toLowerCase();
+    const ext = path73.extname(file3).toLowerCase();
     if (extSet.has(ext)) {
       filteredChurn.set(file3, count);
     }
@@ -75170,7 +75222,7 @@ async function analyzeHotspots(days, topN, extensions, directory) {
   for (const [file3, churnCount] of filteredChurn) {
     let fullPath = file3;
     if (!fs56.existsSync(fullPath)) {
-      fullPath = path72.join(cwd, file3);
+      fullPath = path73.join(cwd, file3);
     }
     const complexity = getComplexityForFile2(fullPath);
     if (complexity !== null) {
@@ -75344,7 +75396,7 @@ import {
   readFileSync as readFileSync36,
   writeFileSync as writeFileSync11
 } from "node:fs";
-import { join as join66 } from "node:path";
+import { join as join67 } from "node:path";
 var EVIDENCE_DIR2 = ".swarm/evidence";
 var VALID_TASK_ID = /^\d+\.\d+(\.\d+)*$/;
 var COUNCIL_GATE_NAME = "council";
@@ -75378,9 +75430,9 @@ function writeCouncilEvidence(workingDir, synthesis) {
   if (!VALID_TASK_ID.test(synthesis.taskId)) {
     throw new Error(`writeCouncilEvidence: invalid taskId "${synthesis.taskId}" — must match N.M or N.M.P format`);
   }
-  const dir = join66(workingDir, EVIDENCE_DIR2);
+  const dir = join67(workingDir, EVIDENCE_DIR2);
   mkdirSync18(dir, { recursive: true });
-  const filePath = join66(dir, `${synthesis.taskId}.json`);
+  const filePath = join67(dir, `${synthesis.taskId}.json`);
   const existingRoot = Object.create(null);
   if (existsSync37(filePath)) {
     try {
@@ -75414,7 +75466,7 @@ function writeCouncilEvidence(workingDir, synthesis) {
     updated.required_gates = [];
   writeFileSync11(filePath, JSON.stringify(updated, null, 2));
   try {
-    const councilDir = join66(workingDir, ".swarm", "council");
+    const councilDir = join67(workingDir, ".swarm", "council");
     mkdirSync18(councilDir, { recursive: true });
     const auditLine = JSON.stringify({
       round: synthesis.roundNumber,
@@ -75422,7 +75474,7 @@ function writeCouncilEvidence(workingDir, synthesis) {
       timestamp: synthesis.timestamp,
       vetoedBy: synthesis.vetoedBy
     });
-    appendFileSync6(join66(councilDir, `${synthesis.taskId}.rounds.jsonl`), `${auditLine}
+    appendFileSync6(join67(councilDir, `${synthesis.taskId}.rounds.jsonl`), `${auditLine}
 `);
   } catch (auditError) {
     console.warn(`writeCouncilEvidence: failed to append round-history audit log: ${auditError instanceof Error ? auditError.message : String(auditError)}`);
@@ -75556,20 +75608,20 @@ function buildUnifiedFeedback(taskId, verdict, vetoedBy, requiredFixes, advisory
 
 // src/council/criteria-store.ts
 import { existsSync as existsSync38, mkdirSync as mkdirSync19, readFileSync as readFileSync37, writeFileSync as writeFileSync12 } from "node:fs";
-import { join as join67 } from "node:path";
+import { join as join68 } from "node:path";
 var COUNCIL_DIR = ".swarm/council";
 function writeCriteria(workingDir, taskId, criteria) {
-  const dir = join67(workingDir, COUNCIL_DIR);
+  const dir = join68(workingDir, COUNCIL_DIR);
   mkdirSync19(dir, { recursive: true });
   const payload = {
     taskId,
     criteria,
     declaredAt: new Date().toISOString()
   };
-  writeFileSync12(join67(dir, `${safeId(taskId)}.json`), JSON.stringify(payload, null, 2));
+  writeFileSync12(join68(dir, `${safeId(taskId)}.json`), JSON.stringify(payload, null, 2));
 }
 function readCriteria(workingDir, taskId) {
-  const filePath = join67(workingDir, COUNCIL_DIR, `${safeId(taskId)}.json`);
+  const filePath = join68(workingDir, COUNCIL_DIR, `${safeId(taskId)}.json`);
   if (!existsSync38(filePath))
     return null;
   try {
@@ -75722,7 +75774,7 @@ var submit_council_verdicts = createSwarmTool({
 init_zod();
 init_loader();
 import * as fs57 from "node:fs";
-import * as path73 from "node:path";
+import * as path74 from "node:path";
 
 // src/council/general-council-advisory.ts
 var ADVISORY_HEADER = "[general_council] (advisory; not blocking)";
@@ -76170,10 +76222,10 @@ var convene_general_council = createSwarmTool({
     const round1 = input.round1Responses;
     const round2 = input.round2Responses ?? [];
     const result = synthesizeGeneralCouncil(input.question, input.mode, round1, round2);
-    const evidenceDir = path73.join(workingDir, ".swarm", "council", "general");
+    const evidenceDir = path74.join(workingDir, ".swarm", "council", "general");
     const safeTimestamp = result.timestamp.replace(/[:.]/g, "-");
     const evidenceFile = `${safeTimestamp}-${input.mode}.json`;
-    const evidencePath = path73.join(evidenceDir, evidenceFile);
+    const evidencePath = path74.join(evidenceDir, evidenceFile);
     try {
       await fs57.promises.mkdir(evidenceDir, { recursive: true });
       await fs57.promises.writeFile(evidencePath, JSON.stringify(result, null, 2));
@@ -76410,7 +76462,7 @@ init_state();
 init_task_id();
 init_create_tool();
 import * as fs58 from "node:fs";
-import * as path74 from "node:path";
+import * as path75 from "node:path";
 function validateTaskIdFormat2(taskId) {
   return validateTaskIdFormat(taskId);
 }
@@ -76484,8 +76536,8 @@ async function executeDeclareScope(args2, fallbackDir) {
         };
       }
     }
-    normalizedDir = path74.normalize(args2.working_directory);
-    const pathParts = normalizedDir.split(path74.sep);
+    normalizedDir = path75.normalize(args2.working_directory);
+    const pathParts = normalizedDir.split(path75.sep);
     if (pathParts.includes("..")) {
       return {
         success: false,
@@ -76495,10 +76547,10 @@ async function executeDeclareScope(args2, fallbackDir) {
         ]
       };
     }
-    const resolvedDir = path74.resolve(normalizedDir);
+    const resolvedDir = path75.resolve(normalizedDir);
     try {
       const realPath = fs58.realpathSync(resolvedDir);
-      const planPath2 = path74.join(realPath, ".swarm", "plan.json");
+      const planPath2 = path75.join(realPath, ".swarm", "plan.json");
       if (!fs58.existsSync(planPath2)) {
         return {
           success: false,
@@ -76522,7 +76574,7 @@ async function executeDeclareScope(args2, fallbackDir) {
     console.warn("[declare-scope] fallbackDir is undefined, falling back to process.cwd()");
   }
   const directory = normalizedDir || fallbackDir;
-  const planPath = path74.resolve(directory, ".swarm", "plan.json");
+  const planPath = path75.resolve(directory, ".swarm", "plan.json");
   if (!fs58.existsSync(planPath)) {
     return {
       success: false,
@@ -76562,8 +76614,8 @@ async function executeDeclareScope(args2, fallbackDir) {
   const normalizeErrors = [];
   const dir = normalizedDir || fallbackDir || process.cwd();
   const mergedFiles = rawMergedFiles.map((file3) => {
-    if (path74.isAbsolute(file3)) {
-      const relativePath = path74.relative(dir, file3).replace(/\\/g, "/");
+    if (path75.isAbsolute(file3)) {
+      const relativePath = path75.relative(dir, file3).replace(/\\/g, "/");
       if (relativePath.startsWith("..")) {
         normalizeErrors.push(`Path '${file3}' resolves outside the project directory`);
         return file3;
@@ -76624,7 +76676,7 @@ var declare_scope = createSwarmTool({
 init_zod();
 import * as child_process7 from "node:child_process";
 import * as fs59 from "node:fs";
-import * as path75 from "node:path";
+import * as path76 from "node:path";
 init_create_tool();
 var MAX_DIFF_LINES = 500;
 var DIFF_TIMEOUT_MS = 30000;
@@ -76653,20 +76705,20 @@ function validateBase(base) {
 function validatePaths(paths) {
   if (!paths)
     return null;
-  for (const path76 of paths) {
-    if (!path76 || path76.length === 0) {
+  for (const path77 of paths) {
+    if (!path77 || path77.length === 0) {
       return "empty path not allowed";
     }
-    if (path76.length > MAX_PATH_LENGTH) {
+    if (path77.length > MAX_PATH_LENGTH) {
       return `path exceeds maximum length of ${MAX_PATH_LENGTH}`;
     }
-    if (SHELL_METACHARACTERS2.test(path76)) {
+    if (SHELL_METACHARACTERS2.test(path77)) {
       return "path contains shell metacharacters";
     }
-    if (path76.startsWith("-")) {
+    if (path77.startsWith("-")) {
       return 'path cannot start with "-" (option-like arguments not allowed)';
     }
-    if (CONTROL_CHAR_PATTERN2.test(path76)) {
+    if (CONTROL_CHAR_PATTERN2.test(path77)) {
       return "path contains control characters";
     }
   }
@@ -76772,8 +76824,8 @@ var diff = createSwarmTool({
         if (parts2.length >= 3) {
           const additions = parseInt(parts2[0], 10) || 0;
           const deletions = parseInt(parts2[1], 10) || 0;
-          const path76 = parts2[2];
-          files.push({ path: path76, additions, deletions });
+          const path77 = parts2[2];
+          files.push({ path: path77, additions, deletions });
         }
       }
       const contractChanges = [];
@@ -76813,7 +76865,7 @@ var diff = createSwarmTool({
           } else if (base === "unstaged") {
             const oldRef = `:${file3.path}`;
             oldContent = fileExistsInRef(oldRef) ? getContentFromRef(oldRef) : "";
-            newContent = fs59.readFileSync(path75.join(directory, file3.path), "utf-8");
+            newContent = fs59.readFileSync(path76.join(directory, file3.path), "utf-8");
           } else {
             const oldRef = `${base}:${file3.path}`;
             oldContent = fileExistsInRef(oldRef) ? getContentFromRef(oldRef) : "";
@@ -76888,7 +76940,7 @@ var diff = createSwarmTool({
 init_zod();
 import * as child_process8 from "node:child_process";
 import * as fs60 from "node:fs";
-import * as path76 from "node:path";
+import * as path77 from "node:path";
 init_create_tool();
 var diff_summary = createSwarmTool({
   description: "Generate a filtered semantic diff summary from AST analysis. Returns SemanticDiffSummary with optional filtering by classification or riskLevel.",
@@ -76936,7 +76988,7 @@ var diff_summary = createSwarmTool({
         }
         try {
           let oldContent;
-          const newContent = fs60.readFileSync(path76.join(workingDir, filePath), "utf-8");
+          const newContent = fs60.readFileSync(path77.join(workingDir, filePath), "utf-8");
           if (fileExistsInHead) {
             oldContent = child_process8.execFileSync("git", ["show", `HEAD:${filePath}`], {
               encoding: "utf-8",
@@ -77165,7 +77217,7 @@ init_zod();
 init_create_tool();
 init_path_security();
 import * as fs61 from "node:fs";
-import * as path77 from "node:path";
+import * as path78 from "node:path";
 var MAX_FILE_SIZE_BYTES6 = 1024 * 1024;
 var MAX_EVIDENCE_FILES = 1000;
 var EVIDENCE_DIR3 = ".swarm/evidence";
@@ -77192,9 +77244,9 @@ function validateRequiredTypes(input) {
   return null;
 }
 function isPathWithinSwarm2(filePath, cwd) {
-  const normalizedCwd = path77.resolve(cwd);
-  const swarmPath = path77.join(normalizedCwd, ".swarm");
-  const normalizedPath = path77.resolve(filePath);
+  const normalizedCwd = path78.resolve(cwd);
+  const swarmPath = path78.join(normalizedCwd, ".swarm");
+  const normalizedPath = path78.resolve(filePath);
   return normalizedPath.startsWith(swarmPath);
 }
 function parseCompletedTasks(planContent) {
@@ -77224,10 +77276,10 @@ function readEvidenceFiles(evidenceDir, _cwd) {
     if (!VALID_EVIDENCE_FILENAME_REGEX.test(filename)) {
       continue;
     }
-    const filePath = path77.join(evidenceDir, filename);
+    const filePath = path78.join(evidenceDir, filename);
     try {
-      const resolvedPath = path77.resolve(filePath);
-      const evidenceDirResolved = path77.resolve(evidenceDir);
+      const resolvedPath = path78.resolve(filePath);
+      const evidenceDirResolved = path78.resolve(evidenceDir);
       if (!resolvedPath.startsWith(evidenceDirResolved)) {
         continue;
       }
@@ -77345,7 +77397,7 @@ var evidence_check = createSwarmTool({
       return JSON.stringify(errorResult, null, 2);
     }
     const requiredTypes = requiredTypesValue.split(",").map((t) => t.trim()).filter((t) => t.length > 0).map(normalizeEvidenceType);
-    const planPath = path77.join(cwd, PLAN_FILE);
+    const planPath = path78.join(cwd, PLAN_FILE);
     if (!isPathWithinSwarm2(planPath, cwd)) {
       const errorResult = {
         error: "plan file path validation failed",
@@ -77377,7 +77429,7 @@ var evidence_check = createSwarmTool({
       };
       return JSON.stringify(result2, null, 2);
     }
-    const evidenceDir = path77.join(cwd, EVIDENCE_DIR3);
+    const evidenceDir = path78.join(cwd, EVIDENCE_DIR3);
     const evidence = readEvidenceFiles(evidenceDir, cwd);
     const { tasksWithFullEvidence, gaps } = analyzeGaps(completedTasks, evidence, requiredTypes);
     const completeness = completedTasks.length > 0 ? Math.round(tasksWithFullEvidence.length / completedTasks.length * 100) / 100 : 1;
@@ -77395,7 +77447,7 @@ var evidence_check = createSwarmTool({
 init_zod();
 init_create_tool();
 import * as fs62 from "node:fs";
-import * as path78 from "node:path";
+import * as path79 from "node:path";
 var EXT_MAP = {
   python: ".py",
   py: ".py",
@@ -77476,12 +77528,12 @@ var extract_code_blocks = createSwarmTool({
       if (prefix) {
         filename = `${prefix}_${filename}`;
       }
-      let filepath = path78.join(targetDir, filename);
-      const base = path78.basename(filepath, path78.extname(filepath));
-      const ext = path78.extname(filepath);
+      let filepath = path79.join(targetDir, filename);
+      const base = path79.basename(filepath, path79.extname(filepath));
+      const ext = path79.extname(filepath);
       let counter = 1;
       while (fs62.existsSync(filepath)) {
-        filepath = path78.join(targetDir, `${base}_${counter}${ext}`);
+        filepath = path79.join(targetDir, `${base}_${counter}${ext}`);
         counter++;
       }
       try {
@@ -77745,7 +77797,7 @@ init_zod();
 init_create_tool();
 init_path_security();
 import * as fs63 from "node:fs";
-import * as path79 from "node:path";
+import * as path80 from "node:path";
 var MAX_FILE_PATH_LENGTH2 = 500;
 var MAX_SYMBOL_LENGTH = 256;
 var MAX_FILE_SIZE_BYTES7 = 1024 * 1024;
@@ -77793,7 +77845,7 @@ function validateSymbolInput(symbol3) {
   return null;
 }
 function isBinaryFile2(filePath, buffer) {
-  const ext = path79.extname(filePath).toLowerCase();
+  const ext = path80.extname(filePath).toLowerCase();
   if (ext === ".json" || ext === ".md" || ext === ".txt") {
     return false;
   }
@@ -77817,15 +77869,15 @@ function parseImports(content, targetFile, targetSymbol) {
   const imports = [];
   let _resolvedTarget;
   try {
-    _resolvedTarget = path79.resolve(targetFile);
+    _resolvedTarget = path80.resolve(targetFile);
   } catch {
     _resolvedTarget = targetFile;
   }
-  const targetBasename = path79.basename(targetFile, path79.extname(targetFile));
+  const targetBasename = path80.basename(targetFile, path80.extname(targetFile));
   const targetWithExt = targetFile;
   const targetWithoutExt = targetFile.replace(/\.(ts|tsx|js|jsx|mjs|cjs)$/i, "");
-  const normalizedTargetWithExt = path79.normalize(targetWithExt).replace(/\\/g, "/");
-  const normalizedTargetWithoutExt = path79.normalize(targetWithoutExt).replace(/\\/g, "/");
+  const normalizedTargetWithExt = path80.normalize(targetWithExt).replace(/\\/g, "/");
+  const normalizedTargetWithoutExt = path80.normalize(targetWithoutExt).replace(/\\/g, "/");
   const importRegex = /import\s+(?:\{[\s\S]*?\}|(?:\*\s+as\s+\w+)|\w+)\s+from\s+['"`]([^'"`]+)['"`]|import\s+['"`]([^'"`]+)['"`]|require\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/g;
   for (let match = importRegex.exec(content);match !== null; match = importRegex.exec(content)) {
     const modulePath = match[1] || match[2] || match[3];
@@ -77848,9 +77900,9 @@ function parseImports(content, targetFile, targetSymbol) {
     }
     const _normalizedModule = modulePath.replace(/^\.\//, "").replace(/^\.\.\\/, "../");
     let isMatch = false;
-    const _targetDir = path79.dirname(targetFile);
-    const targetExt = path79.extname(targetFile);
-    const targetBasenameNoExt = path79.basename(targetFile, targetExt);
+    const _targetDir = path80.dirname(targetFile);
+    const targetExt = path80.extname(targetFile);
+    const targetBasenameNoExt = path80.basename(targetFile, targetExt);
     const moduleNormalized = modulePath.replace(/\\/g, "/").replace(/^\.\//, "");
     const moduleName = modulePath.split(/[/\\]/).pop() || "";
     const moduleNameNoExt = moduleName.replace(/\.(ts|tsx|js|jsx|mjs|cjs)$/i, "");
@@ -77918,10 +77970,10 @@ function findSourceFiles3(dir, files = [], stats = { skippedDirs: [], skippedFil
   entries.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
   for (const entry of entries) {
     if (SKIP_DIRECTORIES4.has(entry)) {
-      stats.skippedDirs.push(path79.join(dir, entry));
+      stats.skippedDirs.push(path80.join(dir, entry));
       continue;
     }
-    const fullPath = path79.join(dir, entry);
+    const fullPath = path80.join(dir, entry);
     let stat4;
     try {
       stat4 = fs63.statSync(fullPath);
@@ -77935,7 +77987,7 @@ function findSourceFiles3(dir, files = [], stats = { skippedDirs: [], skippedFil
     if (stat4.isDirectory()) {
       findSourceFiles3(fullPath, files, stats);
     } else if (stat4.isFile()) {
-      const ext = path79.extname(fullPath).toLowerCase();
+      const ext = path80.extname(fullPath).toLowerCase();
       if (SUPPORTED_EXTENSIONS3.includes(ext)) {
         files.push(fullPath);
       }
@@ -77992,7 +78044,7 @@ var imports = createSwarmTool({
       return JSON.stringify(errorResult, null, 2);
     }
     try {
-      const targetFile = path79.resolve(file3);
+      const targetFile = path80.resolve(file3);
       if (!fs63.existsSync(targetFile)) {
         const errorResult = {
           error: `target file not found: ${file3}`,
@@ -78014,7 +78066,7 @@ var imports = createSwarmTool({
         };
         return JSON.stringify(errorResult, null, 2);
       }
-      const baseDir = path79.dirname(targetFile);
+      const baseDir = path80.dirname(targetFile);
       const scanStats = {
         skippedDirs: [],
         skippedFiles: 0,
@@ -78560,7 +78612,7 @@ init_qa_gate_profile();
 init_manager2();
 init_curator();
 import * as fs65 from "node:fs";
-import * as path81 from "node:path";
+import * as path82 from "node:path";
 init_knowledge_curator();
 init_knowledge_reader();
 init_knowledge_store();
@@ -78573,14 +78625,16 @@ init_plan_schema();
 init_ledger();
 init_manager();
 import * as fs64 from "node:fs";
-import * as path80 from "node:path";
+import * as path81 from "node:path";
 async function writeCheckpoint(directory) {
   try {
     const plan = await loadPlan(directory);
     if (!plan)
       return;
-    const jsonPath = path80.join(directory, "SWARM_PLAN.json");
-    const mdPath = path80.join(directory, "SWARM_PLAN.md");
+    const swarmDir = path81.join(directory, ".swarm");
+    fs64.mkdirSync(swarmDir, { recursive: true });
+    const jsonPath = path81.join(swarmDir, "SWARM_PLAN.json");
+    const mdPath = path81.join(swarmDir, "SWARM_PLAN.md");
     fs64.writeFileSync(jsonPath, JSON.stringify(plan, null, 2), "utf8");
     const md = derivePlanMarkdown(plan);
     fs64.writeFileSync(mdPath, md, "utf8");
@@ -78815,7 +78869,7 @@ async function executePhaseComplete(args2, workingDirectory, directory) {
     let driftCheckEnabled = true;
     let driftHasSpecMd = false;
     try {
-      const specMdPath = path81.join(dir, ".swarm", "spec.md");
+      const specMdPath = path82.join(dir, ".swarm", "spec.md");
       driftHasSpecMd = fs65.existsSync(specMdPath);
       const gatePlan = await loadPlan(dir);
       if (gatePlan) {
@@ -78837,7 +78891,7 @@ async function executePhaseComplete(args2, workingDirectory, directory) {
     } else {
       let phaseType;
       try {
-        const planPath = path81.join(dir, ".swarm", "plan.json");
+        const planPath = path82.join(dir, ".swarm", "plan.json");
         if (fs65.existsSync(planPath)) {
           const planRaw = fs65.readFileSync(planPath, "utf-8");
           const plan = JSON.parse(planRaw);
@@ -78850,7 +78904,7 @@ async function executePhaseComplete(args2, workingDirectory, directory) {
         warnings.push(`Phase ${phase} is annotated as 'non-code'. Drift verification was skipped per phase type annotation.`);
       } else {
         try {
-          const driftEvidencePath = path81.join(dir, ".swarm", "evidence", String(phase), "drift-verifier.json");
+          const driftEvidencePath = path82.join(dir, ".swarm", "evidence", String(phase), "drift-verifier.json");
           let driftVerdictFound = false;
           let driftVerdictApproved = false;
           try {
@@ -78888,7 +78942,7 @@ async function executePhaseComplete(args2, workingDirectory, directory) {
               let incompleteTaskCount = 0;
               let planParseable = false;
               try {
-                const planPath = path81.join(dir, ".swarm", "plan.json");
+                const planPath = path82.join(dir, ".swarm", "plan.json");
                 if (fs65.existsSync(planPath)) {
                   const planRaw = fs65.readFileSync(planPath, "utf-8");
                   const plan = JSON.parse(planRaw);
@@ -78955,7 +79009,7 @@ async function executePhaseComplete(args2, workingDirectory, directory) {
           const overrides = session2?.qaGateSessionOverrides ?? {};
           const effective = getEffectiveGates(profile, overrides);
           if (effective.hallucination_guard === true) {
-            const hgPath = path81.join(dir, ".swarm", "evidence", String(phase), "hallucination-guard.json");
+            const hgPath = path82.join(dir, ".swarm", "evidence", String(phase), "hallucination-guard.json");
             let hgVerdictFound = false;
             let hgVerdictApproved = false;
             try {
@@ -79027,7 +79081,7 @@ async function executePhaseComplete(args2, workingDirectory, directory) {
           const overrides = session2?.qaGateSessionOverrides ?? {};
           const effective = getEffectiveGates(profile, overrides);
           if (effective.mutation_test === true) {
-            const mgPath = path81.join(dir, ".swarm", "evidence", String(phase), "mutation-gate.json");
+            const mgPath = path82.join(dir, ".swarm", "evidence", String(phase), "mutation-gate.json");
             let mgVerdictFound = false;
             let mgVerdict;
             try {
@@ -79101,7 +79155,7 @@ async function executePhaseComplete(args2, workingDirectory, directory) {
           const effective = getEffectiveGates(profile, overrides);
           if (effective.council_mode === true) {
             councilModeEnabled = true;
-            const pcPath = path81.join(dir, ".swarm", "evidence", String(phase), "phase-council.json");
+            const pcPath = path82.join(dir, ".swarm", "evidence", String(phase), "phase-council.json");
             let pcVerdictFound = false;
             let _pcVerdict;
             let pcQuorumSize;
@@ -79303,7 +79357,7 @@ Advisory notes: ${advisoryNotes.join("; ")}` : "";
   }
   if (retroFound && retroEntry?.lessons_learned && retroEntry.lessons_learned.length > 0) {
     try {
-      const projectName = path81.basename(dir);
+      const projectName = path82.basename(dir);
       const curationResult = await curateAndStoreSwarm(retroEntry.lessons_learned, projectName, { phase_number: phase }, dir, knowledgeConfig);
       if (curationResult) {
         const sessionState = swarmState.agentSessions.get(sessionID);
@@ -79672,7 +79726,7 @@ init_discovery();
 init_utils();
 init_create_tool();
 import * as fs66 from "node:fs";
-import * as path82 from "node:path";
+import * as path83 from "node:path";
 var MAX_OUTPUT_BYTES5 = 52428800;
 var AUDIT_TIMEOUT_MS = 120000;
 function isValidEcosystem(value) {
@@ -79700,16 +79754,16 @@ function validateArgs3(args2) {
 function detectEcosystems(directory) {
   const ecosystems = [];
   const cwd = directory;
-  if (fs66.existsSync(path82.join(cwd, "package.json"))) {
+  if (fs66.existsSync(path83.join(cwd, "package.json"))) {
     ecosystems.push("npm");
   }
-  if (fs66.existsSync(path82.join(cwd, "pyproject.toml")) || fs66.existsSync(path82.join(cwd, "requirements.txt"))) {
+  if (fs66.existsSync(path83.join(cwd, "pyproject.toml")) || fs66.existsSync(path83.join(cwd, "requirements.txt"))) {
     ecosystems.push("pip");
   }
-  if (fs66.existsSync(path82.join(cwd, "Cargo.toml"))) {
+  if (fs66.existsSync(path83.join(cwd, "Cargo.toml"))) {
     ecosystems.push("cargo");
   }
-  if (fs66.existsSync(path82.join(cwd, "go.mod"))) {
+  if (fs66.existsSync(path83.join(cwd, "go.mod"))) {
     ecosystems.push("go");
   }
   try {
@@ -79718,13 +79772,13 @@ function detectEcosystems(directory) {
       ecosystems.push("dotnet");
     }
   } catch {}
-  if (fs66.existsSync(path82.join(cwd, "Gemfile")) || fs66.existsSync(path82.join(cwd, "Gemfile.lock"))) {
+  if (fs66.existsSync(path83.join(cwd, "Gemfile")) || fs66.existsSync(path83.join(cwd, "Gemfile.lock"))) {
     ecosystems.push("ruby");
   }
-  if (fs66.existsSync(path82.join(cwd, "pubspec.yaml"))) {
+  if (fs66.existsSync(path83.join(cwd, "pubspec.yaml"))) {
     ecosystems.push("dart");
   }
-  if (fs66.existsSync(path82.join(cwd, "composer.lock"))) {
+  if (fs66.existsSync(path83.join(cwd, "composer.lock"))) {
     ecosystems.push("composer");
   }
   return ecosystems;
@@ -80884,7 +80938,7 @@ var pkg_audit = createSwarmTool({
 init_zod();
 init_manager2();
 import * as fs67 from "node:fs";
-import * as path83 from "node:path";
+import * as path84 from "node:path";
 init_utils();
 init_create_tool();
 var MAX_FILE_SIZE = 1024 * 1024;
@@ -81007,7 +81061,7 @@ function isScaffoldFile(filePath) {
   if (SCAFFOLD_PATH_PATTERNS.some((pattern) => pattern.test(normalizedPath))) {
     return true;
   }
-  const filename = path83.basename(filePath);
+  const filename = path84.basename(filePath);
   if (SCAFFOLD_FILENAME_PATTERNS.some((pattern) => pattern.test(filename))) {
     return true;
   }
@@ -81024,7 +81078,7 @@ function isAllowedByGlobs(filePath, allowGlobs) {
     if (regex.test(normalizedPath)) {
       return true;
     }
-    const filename = path83.basename(filePath);
+    const filename = path84.basename(filePath);
     const filenameRegex = new RegExp(`^${regexPattern}$`, "i");
     if (filenameRegex.test(filename)) {
       return true;
@@ -81033,7 +81087,7 @@ function isAllowedByGlobs(filePath, allowGlobs) {
   return false;
 }
 function isParserSupported(filePath) {
-  const ext = path83.extname(filePath).toLowerCase();
+  const ext = path84.extname(filePath).toLowerCase();
   return SUPPORTED_PARSER_EXTENSIONS.has(ext);
 }
 function isPlanFile(filePath) {
@@ -81280,9 +81334,9 @@ async function placeholderScan(input, directory) {
   let filesScanned = 0;
   const filesWithFindings = new Set;
   for (const filePath of changed_files) {
-    const fullPath = path83.isAbsolute(filePath) ? filePath : path83.resolve(directory, filePath);
-    const resolvedDirectory = path83.resolve(directory);
-    if (!fullPath.startsWith(resolvedDirectory + path83.sep) && fullPath !== resolvedDirectory) {
+    const fullPath = path84.isAbsolute(filePath) ? filePath : path84.resolve(directory, filePath);
+    const resolvedDirectory = path84.resolve(directory);
+    if (!fullPath.startsWith(resolvedDirectory + path84.sep) && fullPath !== resolvedDirectory) {
       continue;
     }
     if (!fs67.existsSync(fullPath)) {
@@ -81291,7 +81345,7 @@ async function placeholderScan(input, directory) {
     if (isAllowedByGlobs(filePath, allow_globs)) {
       continue;
     }
-    const relativeFilePath = path83.relative(directory, fullPath).replace(/\\/g, "/");
+    const relativeFilePath = path84.relative(directory, fullPath).replace(/\\/g, "/");
     if (FILE_ALLOWLIST.some((allowed) => relativeFilePath.endsWith(allowed))) {
       continue;
     }
@@ -81363,7 +81417,7 @@ var placeholder_scan = createSwarmTool({
 });
 // src/tools/pre-check-batch.ts
 import * as fs70 from "node:fs";
-import * as path86 from "node:path";
+import * as path87 from "node:path";
 init_zod();
 init_manager2();
 init_utils();
@@ -81500,7 +81554,7 @@ init_zod();
 init_manager2();
 init_detector();
 import * as fs69 from "node:fs";
-import * as path85 from "node:path";
+import * as path86 from "node:path";
 import { extname as extname18 } from "node:path";
 
 // src/sast/rules/c.ts
@@ -82394,24 +82448,24 @@ init_create_tool();
 init_utils2();
 import * as crypto8 from "node:crypto";
 import * as fs68 from "node:fs";
-import * as path84 from "node:path";
+import * as path85 from "node:path";
 var BASELINE_SCHEMA_VERSION = "1.0.0";
 var MAX_BASELINE_FINDINGS = 2000;
 var MAX_BASELINE_BYTES = 2 * 1048576;
 var LOCK_RETRY_DELAYS_MS = [50, 100, 200, 400, 800];
 function normalizeFindingPath(directory, file3) {
-  const resolved = path84.isAbsolute(file3) ? file3 : path84.resolve(directory, file3);
-  const rel = path84.relative(path84.resolve(directory), resolved);
+  const resolved = path85.isAbsolute(file3) ? file3 : path85.resolve(directory, file3);
+  const rel = path85.relative(path85.resolve(directory), resolved);
   return rel.replace(/\\/g, "/");
 }
 function baselineRelPath(phase) {
-  return path84.join("evidence", String(phase), "sast-baseline.json");
+  return path85.join("evidence", String(phase), "sast-baseline.json");
 }
 function tempRelPath(phase) {
-  return path84.join("evidence", String(phase), `sast-baseline.json.tmp.${Date.now()}.${process.pid}`);
+  return path85.join("evidence", String(phase), `sast-baseline.json.tmp.${Date.now()}.${process.pid}`);
 }
 function lockRelPath(phase) {
-  return path84.join("evidence", String(phase), "sast-baseline.json.lock");
+  return path85.join("evidence", String(phase), "sast-baseline.json.lock");
 }
 function getLine(lines, idx) {
   if (idx < 0 || idx >= lines.length)
@@ -82532,8 +82586,8 @@ async function captureOrMergeBaseline(directory, phase, findings, engine, scanne
       message: e instanceof Error ? e.message : "Path validation failed"
     };
   }
-  fs68.mkdirSync(path84.dirname(baselinePath), { recursive: true });
-  fs68.mkdirSync(path84.dirname(tempPath), { recursive: true });
+  fs68.mkdirSync(path85.dirname(baselinePath), { recursive: true });
+  fs68.mkdirSync(path85.dirname(tempPath), { recursive: true });
   const releaseLock = await acquireLock(lockPath);
   try {
     let existing = null;
@@ -82800,9 +82854,9 @@ async function sastScan(input, directory, config3) {
       _filesSkipped++;
       continue;
     }
-    const resolvedPath = path85.isAbsolute(filePath) ? filePath : path85.resolve(directory, filePath);
-    const resolvedDirectory = path85.resolve(directory);
-    if (!resolvedPath.startsWith(resolvedDirectory + path85.sep) && resolvedPath !== resolvedDirectory) {
+    const resolvedPath = path86.isAbsolute(filePath) ? filePath : path86.resolve(directory, filePath);
+    const resolvedDirectory = path86.resolve(directory);
+    if (!resolvedPath.startsWith(resolvedDirectory + path86.sep) && resolvedPath !== resolvedDirectory) {
       _filesSkipped++;
       continue;
     }
@@ -83113,18 +83167,18 @@ function validatePath(inputPath, baseDir, workspaceDir) {
   let resolved;
   const isWinAbs = isWindowsAbsolutePath(inputPath);
   if (isWinAbs) {
-    resolved = path86.win32.resolve(inputPath);
-  } else if (path86.isAbsolute(inputPath)) {
-    resolved = path86.resolve(inputPath);
+    resolved = path87.win32.resolve(inputPath);
+  } else if (path87.isAbsolute(inputPath)) {
+    resolved = path87.resolve(inputPath);
   } else {
-    resolved = path86.resolve(baseDir, inputPath);
+    resolved = path87.resolve(baseDir, inputPath);
   }
-  const workspaceResolved = path86.resolve(workspaceDir);
+  const workspaceResolved = path87.resolve(workspaceDir);
   let relative20;
   if (isWinAbs) {
-    relative20 = path86.win32.relative(workspaceResolved, resolved);
+    relative20 = path87.win32.relative(workspaceResolved, resolved);
   } else {
-    relative20 = path86.relative(workspaceResolved, resolved);
+    relative20 = path87.relative(workspaceResolved, resolved);
   }
   if (relative20.startsWith("..")) {
     return "path traversal detected";
@@ -83189,7 +83243,7 @@ async function runLintOnFiles(linter, files, workspaceDir) {
     if (typeof file3 !== "string") {
       continue;
     }
-    const resolvedPath = path86.resolve(file3);
+    const resolvedPath = path87.resolve(file3);
     const validationError = validatePath(resolvedPath, workspaceDir, workspaceDir);
     if (validationError) {
       continue;
@@ -83346,7 +83400,7 @@ async function runSecretscanWithFiles(files, directory) {
         skippedFiles++;
         continue;
       }
-      const resolvedPath = path86.resolve(file3);
+      const resolvedPath = path87.resolve(file3);
       const validationError = validatePath(resolvedPath, directory, directory);
       if (validationError) {
         skippedFiles++;
@@ -83364,7 +83418,7 @@ async function runSecretscanWithFiles(files, directory) {
       };
     }
     for (const file3 of validatedFiles) {
-      const ext = path86.extname(file3).toLowerCase();
+      const ext = path87.extname(file3).toLowerCase();
       if (DEFAULT_EXCLUDE_EXTENSIONS2.has(ext)) {
         skippedFiles++;
         continue;
@@ -83583,7 +83637,7 @@ function classifySastFindings(findings, changedLineRanges, directory) {
   const preexistingFindings = [];
   for (const finding of findings) {
     const filePath = finding.location.file;
-    const normalised = path86.relative(directory, filePath).replace(/\\/g, "/");
+    const normalised = path87.relative(directory, filePath).replace(/\\/g, "/");
     const changedLines = changedLineRanges.get(normalised);
     if (changedLines?.has(finding.location.line)) {
       newFindings.push(finding);
@@ -83634,7 +83688,7 @@ async function runPreCheckBatch(input, workspaceDir, contextDir) {
       warn(`pre_check_batch: Invalid file path: ${file3}`);
       continue;
     }
-    changedFiles.push(path86.resolve(directory, file3));
+    changedFiles.push(path87.resolve(directory, file3));
   }
   if (changedFiles.length === 0) {
     warn("pre_check_batch: No valid files after validation, skipping all tools (fail-closed)");
@@ -83835,7 +83889,7 @@ var pre_check_batch = createSwarmTool({
       };
       return JSON.stringify(errorResult, null, 2);
     }
-    const resolvedDirectory = path86.resolve(typedArgs.directory);
+    const resolvedDirectory = path87.resolve(typedArgs.directory);
     const workspaceAnchor = resolvedDirectory;
     const dirError = validateDirectory2(resolvedDirectory, workspaceAnchor);
     if (dirError) {
@@ -83876,7 +83930,7 @@ var pre_check_batch = createSwarmTool({
 });
 // src/tools/repo-map.ts
 init_zod();
-import * as path87 from "node:path";
+import * as path88 from "node:path";
 init_path_security();
 init_create_tool();
 var VALID_ACTIONS = [
@@ -83901,7 +83955,7 @@ function validateFile(p) {
     return "file contains control characters";
   if (containsPathTraversal(p))
     return "file contains path traversal";
-  if (path87.isAbsolute(p) || /^[a-zA-Z]:[\\/]/.test(p)) {
+  if (path88.isAbsolute(p) || /^[a-zA-Z]:[\\/]/.test(p)) {
     return "file must be a workspace-relative path, not absolute";
   }
   return null;
@@ -83924,8 +83978,8 @@ function ok(action, payload) {
 }
 function toRelativeGraphPath(input, workspaceRoot) {
   const normalized = input.replace(/\\/g, "/");
-  if (path87.isAbsolute(normalized)) {
-    const rel = path87.relative(workspaceRoot, normalized).replace(/\\/g, "/");
+  if (path88.isAbsolute(normalized)) {
+    const rel = path88.relative(workspaceRoot, normalized).replace(/\\/g, "/");
     return normalizeGraphPath2(rel);
   }
   return normalizeGraphPath2(normalized);
@@ -84070,7 +84124,7 @@ var repo_map = createSwarmTool({
 init_zod();
 init_create_tool();
 import * as fs71 from "node:fs";
-import * as path88 from "node:path";
+import * as path89 from "node:path";
 var SPEC_FILE = ".swarm/spec.md";
 var EVIDENCE_DIR4 = ".swarm/evidence";
 var OBLIGATION_KEYWORDS = ["MUST", "SHOULD", "SHALL"];
@@ -84139,7 +84193,7 @@ function readTouchedFiles(evidenceDir, phase, cwd) {
     return [];
   }
   for (const entry of entries) {
-    const entryPath = path88.join(evidenceDir, entry);
+    const entryPath = path89.join(evidenceDir, entry);
     try {
       const stat4 = fs71.statSync(entryPath);
       if (!stat4.isDirectory()) {
@@ -84155,11 +84209,11 @@ function readTouchedFiles(evidenceDir, phase, cwd) {
     if (entryPhase !== String(phase)) {
       continue;
     }
-    const evidenceFilePath = path88.join(entryPath, "evidence.json");
+    const evidenceFilePath = path89.join(entryPath, "evidence.json");
     try {
-      const resolvedPath = path88.resolve(evidenceFilePath);
-      const evidenceDirResolved = path88.resolve(evidenceDir);
-      if (!resolvedPath.startsWith(evidenceDirResolved + path88.sep)) {
+      const resolvedPath = path89.resolve(evidenceFilePath);
+      const evidenceDirResolved = path89.resolve(evidenceDir);
+      if (!resolvedPath.startsWith(evidenceDirResolved + path89.sep)) {
         continue;
       }
       const stat4 = fs71.lstatSync(evidenceFilePath);
@@ -84193,7 +84247,7 @@ function readTouchedFiles(evidenceDir, phase, cwd) {
             if (Array.isArray(diffEntry.files_changed)) {
               for (const file3 of diffEntry.files_changed) {
                 if (typeof file3 === "string") {
-                  touchedFiles.add(path88.resolve(cwd, file3));
+                  touchedFiles.add(path89.resolve(cwd, file3));
                 }
               }
             }
@@ -84206,8 +84260,8 @@ function readTouchedFiles(evidenceDir, phase, cwd) {
 }
 function searchFileForKeywords(filePath, keywords, cwd) {
   try {
-    const resolvedPath = path88.resolve(filePath);
-    const cwdResolved = path88.resolve(cwd);
+    const resolvedPath = path89.resolve(filePath);
+    const cwdResolved = path89.resolve(cwd);
     if (!resolvedPath.startsWith(cwdResolved)) {
       return false;
     }
@@ -84341,7 +84395,7 @@ var req_coverage = createSwarmTool({
       }, null, 2);
     }
     const cwd = inputDirectory || directory;
-    const specPath = path88.join(cwd, SPEC_FILE);
+    const specPath = path89.join(cwd, SPEC_FILE);
     let specContent;
     try {
       specContent = fs71.readFileSync(specPath, "utf-8");
@@ -84368,7 +84422,7 @@ var req_coverage = createSwarmTool({
         message: "No FR requirements found in spec.md"
       }, null, 2);
     }
-    const evidenceDir = path88.join(cwd, EVIDENCE_DIR4);
+    const evidenceDir = path89.join(cwd, EVIDENCE_DIR4);
     const touchedFiles = readTouchedFiles(evidenceDir, phase, cwd);
     const analyzedRequirements = [];
     let coveredCount = 0;
@@ -84394,7 +84448,7 @@ var req_coverage = createSwarmTool({
       requirements: analyzedRequirements
     };
     const reportFilename = `req-coverage-phase-${phase}.json`;
-    const reportPath = path88.join(evidenceDir, reportFilename);
+    const reportPath = path89.join(evidenceDir, reportFilename);
     try {
       if (!fs71.existsSync(evidenceDir)) {
         fs71.mkdirSync(evidenceDir, { recursive: true });
@@ -84482,7 +84536,7 @@ init_qa_gate_profile();
 init_file_locks();
 import * as crypto9 from "node:crypto";
 import * as fs72 from "node:fs";
-import * as path89 from "node:path";
+import * as path90 from "node:path";
 init_ledger();
 init_manager();
 init_state();
@@ -84560,8 +84614,8 @@ async function executeSavePlan(args2, fallbackDir) {
     };
   }
   if (args2.working_directory && fallbackDir) {
-    const resolvedTarget = path89.resolve(args2.working_directory);
-    const resolvedRoot = path89.resolve(fallbackDir);
+    const resolvedTarget = path90.resolve(args2.working_directory);
+    const resolvedRoot = path90.resolve(fallbackDir);
     let fallbackExists = false;
     try {
       fs72.accessSync(resolvedRoot, fs72.constants.F_OK);
@@ -84570,7 +84624,7 @@ async function executeSavePlan(args2, fallbackDir) {
       fallbackExists = false;
     }
     if (fallbackExists) {
-      const isSubdirectory = resolvedTarget.startsWith(resolvedRoot + path89.sep);
+      const isSubdirectory = resolvedTarget.startsWith(resolvedRoot + path90.sep);
       if (isSubdirectory) {
         return {
           success: false,
@@ -84586,7 +84640,7 @@ async function executeSavePlan(args2, fallbackDir) {
   let specMtime;
   let specHash;
   if (process.env.SWARM_SKIP_SPEC_GATE !== "1") {
-    const specPath = path89.join(targetWorkspace, ".swarm", "spec.md");
+    const specPath = path90.join(targetWorkspace, ".swarm", "spec.md");
     try {
       const stat4 = await fs72.promises.stat(specPath);
       specMtime = stat4.mtime.toISOString();
@@ -84602,7 +84656,7 @@ async function executeSavePlan(args2, fallbackDir) {
     }
   }
   if (process.env.SWARM_SKIP_GATE_SELECTION !== "1") {
-    const contextPath = path89.join(targetWorkspace, ".swarm", "context.md");
+    const contextPath = path90.join(targetWorkspace, ".swarm", "context.md");
     let contextContent = "";
     try {
       contextContent = await fs72.promises.readFile(contextPath, "utf8");
@@ -84752,7 +84806,7 @@ async function executeSavePlan(args2, fallbackDir) {
       }
       await writeCheckpoint(dir).catch(() => {});
       try {
-        const markerPath = path89.join(dir, ".swarm", ".plan-write-marker");
+        const markerPath = path90.join(dir, ".swarm", ".plan-write-marker");
         const marker = JSON.stringify({
           source: "save_plan",
           timestamp: new Date().toISOString(),
@@ -84775,7 +84829,7 @@ async function executeSavePlan(args2, fallbackDir) {
       return {
         success: true,
         message: "Plan saved successfully",
-        plan_path: path89.join(dir, ".swarm", "plan.json"),
+        plan_path: path90.join(dir, ".swarm", "plan.json"),
         phases_count: plan.phases.length,
         tasks_count: tasksCount,
         ...resolvedProfile !== undefined ? { execution_profile: resolvedProfile } : {},
@@ -84828,7 +84882,7 @@ var save_plan = createSwarmTool({
 init_zod();
 init_manager2();
 import * as fs73 from "node:fs";
-import * as path90 from "node:path";
+import * as path91 from "node:path";
 
 // src/sbom/detectors/index.ts
 init_utils();
@@ -85678,7 +85732,7 @@ function findManifestFiles(rootDir) {
     try {
       const entries = fs73.readdirSync(dir, { withFileTypes: true });
       for (const entry of entries) {
-        const fullPath = path90.join(dir, entry.name);
+        const fullPath = path91.join(dir, entry.name);
         if (entry.name.startsWith(".") || entry.name === "node_modules" || entry.name === "dist" || entry.name === "build" || entry.name === "target") {
           continue;
         }
@@ -85687,7 +85741,7 @@ function findManifestFiles(rootDir) {
         } else if (entry.isFile()) {
           for (const pattern of patterns) {
             if (simpleGlobToRegex(pattern).test(entry.name)) {
-              manifestFiles.push(path90.relative(rootDir, fullPath));
+              manifestFiles.push(path91.relative(rootDir, fullPath));
               break;
             }
           }
@@ -85705,11 +85759,11 @@ function findManifestFilesInDirs(directories, workingDir) {
     try {
       const entries = fs73.readdirSync(dir, { withFileTypes: true });
       for (const entry of entries) {
-        const fullPath = path90.join(dir, entry.name);
+        const fullPath = path91.join(dir, entry.name);
         if (entry.isFile()) {
           for (const pattern of patterns) {
             if (simpleGlobToRegex(pattern).test(entry.name)) {
-              found.push(path90.relative(workingDir, fullPath));
+              found.push(path91.relative(workingDir, fullPath));
               break;
             }
           }
@@ -85722,11 +85776,11 @@ function findManifestFilesInDirs(directories, workingDir) {
 function getDirectoriesFromChangedFiles(changedFiles, workingDir) {
   const dirs = new Set;
   for (const file3 of changedFiles) {
-    let currentDir = path90.dirname(file3);
+    let currentDir = path91.dirname(file3);
     while (true) {
-      if (currentDir && currentDir !== "." && currentDir !== path90.sep) {
-        dirs.add(path90.join(workingDir, currentDir));
-        const parent = path90.dirname(currentDir);
+      if (currentDir && currentDir !== "." && currentDir !== path91.sep) {
+        dirs.add(path91.join(workingDir, currentDir));
+        const parent = path91.dirname(currentDir);
         if (parent === currentDir)
           break;
         currentDir = parent;
@@ -85810,7 +85864,7 @@ var sbom_generate = createSwarmTool({
     const changedFiles = obj.changed_files;
     const relativeOutputDir = obj.output_dir || DEFAULT_OUTPUT_DIR;
     const workingDir = directory;
-    const outputDir = path90.isAbsolute(relativeOutputDir) ? relativeOutputDir : path90.join(workingDir, relativeOutputDir);
+    const outputDir = path91.isAbsolute(relativeOutputDir) ? relativeOutputDir : path91.join(workingDir, relativeOutputDir);
     let manifestFiles = [];
     if (scope === "all") {
       manifestFiles = findManifestFiles(workingDir);
@@ -85833,7 +85887,7 @@ var sbom_generate = createSwarmTool({
     const processedFiles = [];
     for (const manifestFile of manifestFiles) {
       try {
-        const fullPath = path90.isAbsolute(manifestFile) ? manifestFile : path90.join(workingDir, manifestFile);
+        const fullPath = path91.isAbsolute(manifestFile) ? manifestFile : path91.join(workingDir, manifestFile);
         if (!fs73.existsSync(fullPath)) {
           continue;
         }
@@ -85850,7 +85904,7 @@ var sbom_generate = createSwarmTool({
     const bom = generateCycloneDX(allComponents);
     const bomJson = serializeCycloneDX(bom);
     const filename = generateSbomFilename();
-    const outputPath = path90.join(outputDir, filename);
+    const outputPath = path91.join(outputDir, filename);
     fs73.writeFileSync(outputPath, bomJson, "utf-8");
     const verdict = processedFiles.length > 0 ? "pass" : "pass";
     try {
@@ -85894,7 +85948,7 @@ var sbom_generate = createSwarmTool({
 init_zod();
 init_create_tool();
 import * as fs74 from "node:fs";
-import * as path91 from "node:path";
+import * as path92 from "node:path";
 var SPEC_CANDIDATES = [
   "openapi.json",
   "openapi.yaml",
@@ -85926,12 +85980,12 @@ function normalizePath3(p) {
 }
 function discoverSpecFile(cwd, specFileArg) {
   if (specFileArg) {
-    const resolvedPath = path91.resolve(cwd, specFileArg);
-    const normalizedCwd = cwd.endsWith(path91.sep) ? cwd : cwd + path91.sep;
+    const resolvedPath = path92.resolve(cwd, specFileArg);
+    const normalizedCwd = cwd.endsWith(path92.sep) ? cwd : cwd + path92.sep;
     if (!resolvedPath.startsWith(normalizedCwd) && resolvedPath !== cwd) {
       throw new Error("Invalid spec_file: path traversal detected");
     }
-    const ext = path91.extname(resolvedPath).toLowerCase();
+    const ext = path92.extname(resolvedPath).toLowerCase();
     if (!ALLOWED_EXTENSIONS.includes(ext)) {
       throw new Error(`Invalid spec_file: must end in .json, .yaml, or .yml, got ${ext}`);
     }
@@ -85945,7 +85999,7 @@ function discoverSpecFile(cwd, specFileArg) {
     return resolvedPath;
   }
   for (const candidate of SPEC_CANDIDATES) {
-    const candidatePath = path91.resolve(cwd, candidate);
+    const candidatePath = path92.resolve(cwd, candidate);
     if (fs74.existsSync(candidatePath)) {
       const stats = fs74.statSync(candidatePath);
       if (stats.size <= MAX_SPEC_SIZE) {
@@ -85957,7 +86011,7 @@ function discoverSpecFile(cwd, specFileArg) {
 }
 function parseSpec(specFile) {
   const content = fs74.readFileSync(specFile, "utf-8");
-  const ext = path91.extname(specFile).toLowerCase();
+  const ext = path92.extname(specFile).toLowerCase();
   if (ext === ".json") {
     return parseJsonSpec(content);
   }
@@ -86033,7 +86087,7 @@ function extractRoutes(cwd) {
       return;
     }
     for (const entry of entries) {
-      const fullPath = path91.join(dir, entry.name);
+      const fullPath = path92.join(dir, entry.name);
       if (entry.isSymbolicLink()) {
         continue;
       }
@@ -86043,7 +86097,7 @@ function extractRoutes(cwd) {
         }
         walkDir(fullPath);
       } else if (entry.isFile()) {
-        const ext = path91.extname(entry.name).toLowerCase();
+        const ext = path92.extname(entry.name).toLowerCase();
         const baseName = entry.name.toLowerCase();
         if (![".ts", ".js", ".mjs"].includes(ext)) {
           continue;
@@ -86210,7 +86264,7 @@ init_zod();
 init_path_security();
 init_create_tool();
 import * as fs75 from "node:fs";
-import * as path92 from "node:path";
+import * as path93 from "node:path";
 var DEFAULT_MAX_RESULTS = 100;
 var DEFAULT_MAX_LINES = 200;
 var REGEX_TIMEOUT_MS = 5000;
@@ -86246,11 +86300,11 @@ function containsWindowsAttacks3(str) {
 }
 function isPathInWorkspace3(filePath, workspace) {
   try {
-    const resolvedPath = path92.resolve(workspace, filePath);
+    const resolvedPath = path93.resolve(workspace, filePath);
     const realWorkspace = fs75.realpathSync(workspace);
     const realResolvedPath = fs75.realpathSync(resolvedPath);
-    const relativePath = path92.relative(realWorkspace, realResolvedPath);
-    if (relativePath.startsWith("..") || path92.isAbsolute(relativePath)) {
+    const relativePath = path93.relative(realWorkspace, realResolvedPath);
+    if (relativePath.startsWith("..") || path93.isAbsolute(relativePath)) {
       return false;
     }
     return true;
@@ -86263,11 +86317,11 @@ function validatePathForRead2(filePath, workspace) {
 }
 function findRgInEnvPath() {
   const searchPath = process.env.PATH ?? "";
-  for (const dir of searchPath.split(path92.delimiter)) {
+  for (const dir of searchPath.split(path93.delimiter)) {
     if (!dir)
       continue;
     const isWindows = process.platform === "win32";
-    const candidate = path92.join(dir, isWindows ? "rg.exe" : "rg");
+    const candidate = path93.join(dir, isWindows ? "rg.exe" : "rg");
     if (fs75.existsSync(candidate))
       return candidate;
   }
@@ -86397,8 +86451,8 @@ function collectFiles(dir, workspace, includeGlobs, excludeGlobs) {
   try {
     const entries = fs75.readdirSync(dir, { withFileTypes: true });
     for (const entry of entries) {
-      const fullPath = path92.join(dir, entry.name);
-      const relativePath = path92.relative(workspace, fullPath);
+      const fullPath = path93.join(dir, entry.name);
+      const relativePath = path93.relative(workspace, fullPath);
       if (!validatePathForRead2(fullPath, workspace)) {
         continue;
       }
@@ -86439,7 +86493,7 @@ async function fallbackSearch(opts) {
   const matches = [];
   let total = 0;
   for (const file3 of files) {
-    const fullPath = path92.join(opts.workspace, file3);
+    const fullPath = path93.join(opts.workspace, file3);
     if (!validatePathForRead2(fullPath, opts.workspace)) {
       continue;
     }
@@ -86696,7 +86750,7 @@ init_zod();
 init_path_security();
 init_create_tool();
 import * as fs76 from "node:fs";
-import * as path93 from "node:path";
+import * as path94 from "node:path";
 var WINDOWS_RESERVED_NAMES4 = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|:|$)/i;
 function containsWindowsAttacks4(str) {
   if (/:[^\\/]/.test(str))
@@ -86710,14 +86764,14 @@ function containsWindowsAttacks4(str) {
 }
 function isPathInWorkspace4(filePath, workspace) {
   try {
-    const resolvedPath = path93.resolve(workspace, filePath);
+    const resolvedPath = path94.resolve(workspace, filePath);
     if (!fs76.existsSync(resolvedPath)) {
       return true;
     }
     const realWorkspace = fs76.realpathSync(workspace);
     const realResolvedPath = fs76.realpathSync(resolvedPath);
-    const relativePath = path93.relative(realWorkspace, realResolvedPath);
-    if (relativePath.startsWith("..") || path93.isAbsolute(relativePath)) {
+    const relativePath = path94.relative(realWorkspace, realResolvedPath);
+    if (relativePath.startsWith("..") || path94.isAbsolute(relativePath)) {
       return false;
     }
     return true;
@@ -86925,7 +86979,7 @@ var suggestPatch = createSwarmTool({
         });
         continue;
       }
-      const fullPath = path93.resolve(directory, change.file);
+      const fullPath = path94.resolve(directory, change.file);
       if (!fs76.existsSync(fullPath)) {
         errors5.push({
           success: false,
@@ -87188,7 +87242,7 @@ var generate_mutants = createSwarmTool({
 init_spec_schema();
 init_create_tool();
 import * as fs77 from "node:fs";
-import * as path94 from "node:path";
+import * as path95 from "node:path";
 var SPEC_FILE_NAME = "spec.md";
 var SWARM_DIR2 = ".swarm";
 var OBLIGATION_KEYWORDS2 = ["MUST", "SHALL", "SHOULD", "MAY"];
@@ -87241,7 +87295,7 @@ var lint_spec = createSwarmTool({
   async execute(_args, directory) {
     const errors5 = [];
     const warnings = [];
-    const specPath = path94.join(directory, SWARM_DIR2, SPEC_FILE_NAME);
+    const specPath = path95.join(directory, SWARM_DIR2, SPEC_FILE_NAME);
     if (!fs77.existsSync(specPath)) {
       const result2 = {
         valid: false,
@@ -87312,12 +87366,12 @@ var lint_spec = createSwarmTool({
 // src/tools/mutation-test.ts
 init_zod();
 import * as fs78 from "node:fs";
-import * as path96 from "node:path";
+import * as path97 from "node:path";
 
 // src/mutation/engine.ts
 import { spawnSync as spawnSync3 } from "node:child_process";
 import { unlinkSync as unlinkSync13, writeFileSync as writeFileSync19 } from "node:fs";
-import * as path95 from "node:path";
+import * as path96 from "node:path";
 
 // src/mutation/equivalence.ts
 function isStaticallyEquivalent(originalCode, mutatedCode) {
@@ -87452,7 +87506,7 @@ async function executeMutation(patch, testCommand, _testFiles, workingDir) {
   let patchFile;
   try {
     const safeId2 = patch.id.replace(/[^a-zA-Z0-9_-]/g, "_");
-    patchFile = path95.join(workingDir, `.mutation_patch_${safeId2}.diff`);
+    patchFile = path96.join(workingDir, `.mutation_patch_${safeId2}.diff`);
     try {
       writeFileSync19(patchFile, patch.patch);
     } catch (writeErr) {
@@ -87846,7 +87900,7 @@ var mutation_test = createSwarmTool({
       ];
       for (const filePath of uniquePaths) {
         try {
-          const resolvedPath = path96.resolve(cwd, filePath);
+          const resolvedPath = path97.resolve(cwd, filePath);
           sourceFiles.set(filePath, fs78.readFileSync(resolvedPath, "utf-8"));
         } catch {}
       }
@@ -87866,7 +87920,7 @@ init_zod();
 init_manager2();
 init_detector();
 import * as fs79 from "node:fs";
-import * as path97 from "node:path";
+import * as path98 from "node:path";
 init_create_tool();
 var MAX_FILE_SIZE2 = 2 * 1024 * 1024;
 var BINARY_CHECK_BYTES = 8192;
@@ -87932,7 +87986,7 @@ async function syntaxCheck(input, directory, config3) {
   if (languages?.length) {
     const lowerLangs = languages.map((l) => l.toLowerCase());
     filesToCheck = filesToCheck.filter((file3) => {
-      const ext = path97.extname(file3.path).toLowerCase();
+      const ext = path98.extname(file3.path).toLowerCase();
       const langDef = getLanguageForExtension(ext);
       const fileProfile = getProfileForFile(file3.path);
       const langId = fileProfile?.id || langDef?.id;
@@ -87945,7 +87999,7 @@ async function syntaxCheck(input, directory, config3) {
   let skippedCount = 0;
   for (const fileInfo of filesToCheck) {
     const { path: filePath } = fileInfo;
-    const fullPath = path97.isAbsolute(filePath) ? filePath : path97.join(directory, filePath);
+    const fullPath = path98.isAbsolute(filePath) ? filePath : path98.join(directory, filePath);
     const result = {
       path: filePath,
       language: "",
@@ -87994,7 +88048,7 @@ async function syntaxCheck(input, directory, config3) {
         results.push(result);
         continue;
       }
-      const ext = path97.extname(filePath).toLowerCase();
+      const ext = path98.extname(filePath).toLowerCase();
       const langDef = getLanguageForExtension(ext);
       result.language = profile?.id || langDef?.id || "unknown";
       const errors5 = extractSyntaxErrors(parser, content);
@@ -88087,7 +88141,7 @@ init_utils();
 init_create_tool();
 init_path_security();
 import * as fs80 from "node:fs";
-import * as path98 from "node:path";
+import * as path99 from "node:path";
 var MAX_TEXT_LENGTH = 200;
 var MAX_FILE_SIZE_BYTES11 = 1024 * 1024;
 var SUPPORTED_EXTENSIONS4 = new Set([
@@ -88153,9 +88207,9 @@ function validatePathsInput(paths, cwd) {
     return { error: "paths contains path traversal", resolvedPath: null };
   }
   try {
-    const resolvedPath = path98.resolve(paths);
-    const normalizedCwd = path98.resolve(cwd);
-    const normalizedResolved = path98.resolve(resolvedPath);
+    const resolvedPath = path99.resolve(paths);
+    const normalizedCwd = path99.resolve(cwd);
+    const normalizedResolved = path99.resolve(resolvedPath);
     if (!normalizedResolved.startsWith(normalizedCwd)) {
       return {
         error: "paths must be within the current working directory",
@@ -88171,7 +88225,7 @@ function validatePathsInput(paths, cwd) {
   }
 }
 function isSupportedExtension(filePath) {
-  const ext = path98.extname(filePath).toLowerCase();
+  const ext = path99.extname(filePath).toLowerCase();
   return SUPPORTED_EXTENSIONS4.has(ext);
 }
 function findSourceFiles4(dir, files = []) {
@@ -88186,7 +88240,7 @@ function findSourceFiles4(dir, files = []) {
     if (SKIP_DIRECTORIES5.has(entry)) {
       continue;
     }
-    const fullPath = path98.join(dir, entry);
+    const fullPath = path99.join(dir, entry);
     let stat4;
     try {
       stat4 = fs80.statSync(fullPath);
@@ -88298,7 +88352,7 @@ var todo_extract = createSwarmTool({
         filesToScan.push(scanPath);
       } else {
         const errorResult = {
-          error: `unsupported file extension: ${path98.extname(scanPath)}`,
+          error: `unsupported file extension: ${path99.extname(scanPath)}`,
           total: 0,
           byPriority: { high: 0, medium: 0, low: 0 },
           entries: []
@@ -88347,14 +88401,14 @@ init_schema();
 init_qa_gate_profile();
 init_gate_evidence();
 import * as fs82 from "node:fs";
-import * as path100 from "node:path";
+import * as path101 from "node:path";
 
 // src/hooks/diff-scope.ts
 import * as fs81 from "node:fs";
-import * as path99 from "node:path";
+import * as path100 from "node:path";
 function getDeclaredScope(taskId, directory) {
   try {
-    const planPath = path99.join(directory, ".swarm", "plan.json");
+    const planPath = path100.join(directory, ".swarm", "plan.json");
     if (!fs81.existsSync(planPath))
       return null;
     const raw = fs81.readFileSync(planPath, "utf-8");
@@ -88473,7 +88527,7 @@ var TIER_3_PATTERNS = [
 ];
 function matchesTier3Pattern(files) {
   for (const file3 of files) {
-    const fileName = path100.basename(file3);
+    const fileName = path101.basename(file3);
     for (const pattern of TIER_3_PATTERNS) {
       if (pattern.test(fileName)) {
         return true;
@@ -88487,7 +88541,7 @@ function checkReviewerGate(taskId, workingDirectory, stageBParallelEnabled = fal
     if (hasActiveTurboMode()) {
       const resolvedDir2 = workingDirectory;
       try {
-        const planPath = path100.join(resolvedDir2, ".swarm", "plan.json");
+        const planPath = path101.join(resolvedDir2, ".swarm", "plan.json");
         const planRaw = fs82.readFileSync(planPath, "utf-8");
         const plan = JSON.parse(planRaw);
         for (const planPhase of plan.phases ?? []) {
@@ -88557,7 +88611,7 @@ function checkReviewerGate(taskId, workingDirectory, stageBParallelEnabled = fal
     }
     try {
       const resolvedDir2 = workingDirectory;
-      const planPath = path100.join(resolvedDir2, ".swarm", "plan.json");
+      const planPath = path101.join(resolvedDir2, ".swarm", "plan.json");
       const planRaw = fs82.readFileSync(planPath, "utf-8");
       const plan = JSON.parse(planRaw);
       for (const planPhase of plan.phases ?? []) {
@@ -88715,7 +88769,7 @@ function checkCouncilGate(workingDirectory, taskId) {
     return { blocked: false, reason: "" };
   }
   try {
-    const planPath = path100.join(workingDirectory, ".swarm", "plan.json");
+    const planPath = path101.join(workingDirectory, ".swarm", "plan.json");
     const planRaw = fs82.readFileSync(planPath, "utf-8");
     const planObj = JSON.parse(planRaw);
     if (planObj.swarm && planObj.title) {
@@ -88806,8 +88860,8 @@ async function executeUpdateTaskStatus(args2, fallbackDir) {
         };
       }
     }
-    normalizedDir = path100.normalize(args2.working_directory);
-    const pathParts = normalizedDir.split(path100.sep);
+    normalizedDir = path101.normalize(args2.working_directory);
+    const pathParts = normalizedDir.split(path101.sep);
     if (pathParts.includes("..")) {
       return {
         success: false,
@@ -88817,10 +88871,10 @@ async function executeUpdateTaskStatus(args2, fallbackDir) {
         ]
       };
     }
-    const resolvedDir = path100.resolve(normalizedDir);
+    const resolvedDir = path101.resolve(normalizedDir);
     try {
       const realPath = fs82.realpathSync(resolvedDir);
-      const planPath = path100.join(realPath, ".swarm", "plan.json");
+      const planPath = path101.join(realPath, ".swarm", "plan.json");
       if (!fs82.existsSync(planPath)) {
         return {
           success: false,
@@ -88852,8 +88906,8 @@ async function executeUpdateTaskStatus(args2, fallbackDir) {
   }
   if (args2.status === "in_progress") {
     try {
-      const evidencePath = path100.join(directory, ".swarm", "evidence", `${args2.task_id}.json`);
-      fs82.mkdirSync(path100.dirname(evidencePath), { recursive: true });
+      const evidencePath = path101.join(directory, ".swarm", "evidence", `${args2.task_id}.json`);
+      fs82.mkdirSync(path101.dirname(evidencePath), { recursive: true });
       const fd = fs82.openSync(evidencePath, "wx");
       let writeOk = false;
       try {
@@ -88877,7 +88931,7 @@ async function executeUpdateTaskStatus(args2, fallbackDir) {
     recoverTaskStateFromDelegations(args2.task_id);
     let phaseRequiresReviewer = true;
     try {
-      const planPath = path100.join(directory, ".swarm", "plan.json");
+      const planPath = path101.join(directory, ".swarm", "plan.json");
       const planRaw = fs82.readFileSync(planPath, "utf-8");
       const plan = JSON.parse(planRaw);
       const taskPhase = plan.phases.find((p) => p.tasks.some((t) => t.id === args2.task_id));
@@ -89197,7 +89251,7 @@ init_ledger();
 init_manager();
 init_create_tool();
 import fs83 from "node:fs";
-import path101 from "node:path";
+import path102 from "node:path";
 function derivePlanId5(plan) {
   return `${plan.swarm}-${plan.title}`.replace(/[^a-zA-Z0-9-_]/g, "_");
 }
@@ -89248,7 +89302,7 @@ async function executeWriteDriftEvidence(args2, directory) {
     entries: [evidenceEntry]
   };
   const filename = "drift-verifier.json";
-  const relativePath = path101.join("evidence", String(phase), filename);
+  const relativePath = path102.join("evidence", String(phase), filename);
   let validatedPath;
   try {
     validatedPath = validateSwarmPath(directory, relativePath);
@@ -89259,10 +89313,10 @@ async function executeWriteDriftEvidence(args2, directory) {
       message: error93 instanceof Error ? error93.message : "Failed to validate path"
     }, null, 2);
   }
-  const evidenceDir = path101.dirname(validatedPath);
+  const evidenceDir = path102.dirname(validatedPath);
   try {
     await fs83.promises.mkdir(evidenceDir, { recursive: true });
-    const tempPath = path101.join(evidenceDir, `.${filename}.tmp`);
+    const tempPath = path102.join(evidenceDir, `.${filename}.tmp`);
     await fs83.promises.writeFile(tempPath, JSON.stringify(evidenceContent, null, 2), "utf-8");
     await fs83.promises.rename(tempPath, validatedPath);
     let snapshotInfo;
@@ -89359,7 +89413,7 @@ init_zod();
 init_utils2();
 init_create_tool();
 import fs84 from "node:fs";
-import path102 from "node:path";
+import path103 from "node:path";
 function normalizeVerdict2(verdict) {
   switch (verdict) {
     case "APPROVED":
@@ -89407,7 +89461,7 @@ async function executeWriteHallucinationEvidence(args2, directory) {
     entries: [evidenceEntry]
   };
   const filename = "hallucination-guard.json";
-  const relativePath = path102.join("evidence", String(phase), filename);
+  const relativePath = path103.join("evidence", String(phase), filename);
   let validatedPath;
   try {
     validatedPath = validateSwarmPath(directory, relativePath);
@@ -89418,10 +89472,10 @@ async function executeWriteHallucinationEvidence(args2, directory) {
       message: error93 instanceof Error ? error93.message : "Failed to validate path"
     }, null, 2);
   }
-  const evidenceDir = path102.dirname(validatedPath);
+  const evidenceDir = path103.dirname(validatedPath);
   try {
     await fs84.promises.mkdir(evidenceDir, { recursive: true });
-    const tempPath = path102.join(evidenceDir, `.${filename}.tmp`);
+    const tempPath = path103.join(evidenceDir, `.${filename}.tmp`);
     await fs84.promises.writeFile(tempPath, JSON.stringify(evidenceContent, null, 2), "utf-8");
     await fs84.promises.rename(tempPath, validatedPath);
     return JSON.stringify({
@@ -89470,7 +89524,7 @@ init_zod();
 init_utils2();
 init_create_tool();
 import fs85 from "node:fs";
-import path103 from "node:path";
+import path104 from "node:path";
 function normalizeVerdict3(verdict) {
   switch (verdict) {
     case "PASS":
@@ -89544,7 +89598,7 @@ async function executeWriteMutationEvidence(args2, directory) {
     entries: [evidenceEntry]
   };
   const filename = "mutation-gate.json";
-  const relativePath = path103.join("evidence", String(phase), filename);
+  const relativePath = path104.join("evidence", String(phase), filename);
   let validatedPath;
   try {
     validatedPath = validateSwarmPath(directory, relativePath);
@@ -89555,10 +89609,10 @@ async function executeWriteMutationEvidence(args2, directory) {
       message: error93 instanceof Error ? error93.message : "Failed to validate path"
     }, null, 2);
   }
-  const evidenceDir = path103.dirname(validatedPath);
+  const evidenceDir = path104.dirname(validatedPath);
   try {
     await fs85.promises.mkdir(evidenceDir, { recursive: true });
-    const tempPath = path103.join(evidenceDir, `.${filename}.tmp`);
+    const tempPath = path104.join(evidenceDir, `.${filename}.tmp`);
     await fs85.promises.writeFile(tempPath, JSON.stringify(evidenceContent, null, 2), "utf-8");
     await fs85.promises.rename(tempPath, validatedPath);
     return JSON.stringify({
@@ -89615,19 +89669,19 @@ init_utils();
 
 // src/utils/gitignore-warning.ts
 import * as fs86 from "node:fs";
-import * as path104 from "node:path";
+import * as path105 from "node:path";
 var _gitignoreWarningEmitted = false;
 function findGitRoot(startDir) {
   let current = startDir;
   while (true) {
     try {
-      const gitPath = path104.join(current, ".git");
+      const gitPath = path105.join(current, ".git");
       const stat4 = fs86.statSync(gitPath);
       if (stat4.isDirectory()) {
         return current;
       }
     } catch {}
-    const parent = path104.dirname(current);
+    const parent = path105.dirname(current);
     if (parent === current) {
       return null;
     }
@@ -89659,12 +89713,12 @@ function warnIfSwarmNotGitignored(directory, quiet = false) {
     const gitRoot = findGitRoot(directory);
     if (!gitRoot)
       return;
-    const gitignoreContent = readFileSafe(path104.join(gitRoot, ".gitignore"));
+    const gitignoreContent = readFileSafe(path105.join(gitRoot, ".gitignore"));
     if (gitignoreContent !== null && fileCoversSwarm(gitignoreContent)) {
       _gitignoreWarningEmitted = true;
       return;
     }
-    const excludeContent = readFileSafe(path104.join(gitRoot, ".git", "info", "exclude"));
+    const excludeContent = readFileSafe(path105.join(gitRoot, ".git", "info", "exclude"));
     if (excludeContent !== null && fileCoversSwarm(excludeContent)) {
       _gitignoreWarningEmitted = true;
       return;
@@ -89712,8 +89766,8 @@ init_warning_buffer();
 var _heartbeatTimers = new Map;
 function writeSwarmConfigExampleIfNew(projectDirectory) {
   try {
-    const swarmDir = path105.join(projectDirectory, ".swarm");
-    const dest = path105.join(swarmDir, "config.example.json");
+    const swarmDir = path106.join(projectDirectory, ".swarm");
+    const dest = path106.join(swarmDir, "config.example.json");
     if (fs87.existsSync(dest))
       return;
     const example = {
@@ -89917,7 +89971,7 @@ async function initializeOpenCodeSwarm(ctx) {
     const { PreflightTriggerManager: PTM } = await Promise.resolve().then(() => (init_trigger(), exports_trigger));
     preflightTriggerManager = new PTM(automationConfig);
     const { AutomationStatusArtifact: ASA } = await Promise.resolve().then(() => (init_status_artifact(), exports_status_artifact));
-    const swarmDir = path105.resolve(ctx.directory, ".swarm");
+    const swarmDir = path106.resolve(ctx.directory, ".swarm");
     statusArtifact = new ASA(swarmDir);
     statusArtifact.updateConfig(automationConfig.mode, automationConfig.capabilities);
     if (automationConfig.capabilities?.evidence_auto_summaries === true) {

--- a/dist/plan/checkpoint.d.ts
+++ b/dist/plan/checkpoint.d.ts
@@ -1,6 +1,6 @@
 import { type Plan } from '../config/plan-schema';
 /**
- * Write SWARM_PLAN.json and SWARM_PLAN.md to the project root directory.
+ * Write SWARM_PLAN.json and SWARM_PLAN.md inside the .swarm/ directory under the project root.
  * Non-blocking: logs a warning on failure but never throws.
  * @param directory - The working directory (project root)
  */
@@ -14,7 +14,7 @@ export interface ImportCheckpointResult {
     error?: string;
 }
 /**
- * Import a checkpoint from SWARM_PLAN.json at the project root.
+ * Import a checkpoint from .swarm/SWARM_PLAN.json (with backward-compat fallback to project root).
  * Validates the checkpoint against PlanSchema, persists it as the live plan
  * via savePlan, and appends a 'plan_rebuilt' ledger event.
  *

--- a/dist/tools/checkpoint.d.ts
+++ b/dist/tools/checkpoint.d.ts
@@ -1,2 +1,12 @@
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
+/**
+ * Record a checkpoint without staging or committing changes.
+ * Writes only to .swarm/checkpoints.json with the current HEAD SHA.
+ * Used by spiral detection to avoid silently committing mid-flight user work.
+ */
+export declare function saveCheckpointRecord(label: string, directory: string): {
+    success: boolean;
+    sha?: string;
+    error?: string;
+};
 export declare const checkpoint: ToolDefinition;

--- a/docs/plan-durability.md
+++ b/docs/plan-durability.md
@@ -11,8 +11,10 @@
 | `.swarm/plan-ledger.jsonl` | Durable runtime record of all plan events | **Authoritative** — append-only, never delete |
 | `.swarm/plan.json` | Machine-readable projection of current plan state | Derived — can be rebuilt from ledger |
 | `.swarm/plan.md` | Human-readable plan view | Derived — generated from plan.json |
-| `SWARM_PLAN.md` | Operator checkpoint artifact | Export-only — not live source of truth |
-| `SWARM_PLAN.json` | Machine-readable checkpoint artifact | Export-only — for import/export workflows |
+| `.swarm/SWARM_PLAN.md` | Operator checkpoint artifact | Export-only — not live source of truth |
+| `.swarm/SWARM_PLAN.json` | Machine-readable checkpoint artifact | Export-only — for import/export workflows |
+
+> **Migration note:** As of v7.x, SWARM_PLAN files live inside `.swarm/` instead of the project root. The `/swarm close` command cleans up both locations during the transition window.
 
 ### Ledger Event Types
 
@@ -25,7 +27,7 @@
 {"type":"phase_completed","phase":1,"ts":"ISO8601"}
 {"type":"snapshot","data":{"plan":{...},"payload_hash":"abc123"},"ts":"ISO8601"}
 {"type":"plan_rebuilt","ts":"ISO8601"}
-{"type":"plan_exported","path":"SWARM_PLAN.json","ts":"ISO8601"}
+{"type":"plan_exported","path":".swarm/SWARM_PLAN.json","ts":"ISO8601"}
 {"type":"plan_reset","ts":"ISO8601"}
 {"type":"execution_profile_set","data":{"execution_profile":{...}},"ts":"ISO8601"}
 {"type":"execution_profile_locked","ts":"ISO8601"}
@@ -45,10 +47,10 @@ loadPlan()
 
 ### Import
 
-`importCheckpoint()` reads `SWARM_PLAN.json` → validates schema → calls `savePlan()` → appends `plan_rebuilt` event to ledger.
+`importCheckpoint()` reads `.swarm/SWARM_PLAN.json` (falling back to a legacy root-level `SWARM_PLAN.json` with a deprecation warning) → validates schema → calls `savePlan()` → appends `plan_rebuilt` event to ledger.
 
 ```
-importCheckpoint(SWARM_PLAN.json)
+importCheckpoint(.swarm/SWARM_PLAN.json)
   → validateSchema()
   → savePlan(planData)
   → append {type:"plan_rebuilt"} to plan-ledger.jsonl
@@ -61,7 +63,7 @@ importCheckpoint(SWARM_PLAN.json)
 - `phase_complete` command  
 - `/swarm close` command
 
-Writes `SWARM_PLAN.md` and `SWARM_PLAN.json` to the working directory.
+Writes `.swarm/SWARM_PLAN.md` and `.swarm/SWARM_PLAN.json` inside the working directory's `.swarm/` folder.
 
 ## Snapshot System
 
@@ -129,7 +131,7 @@ once pre-check succeeds.
 - **Fail-closed enforcement**: the delegation gate enforces a locked profile — `parallelization_enabled: false` blocks Stage B parallel dispatch regardless of global plugin config.
 - **Ledger authority**: profile changes are recorded as `execution_profile_set` / `execution_profile_locked` events. Replay rebuilds the profile deterministically from these events.
 - **Hash coverage**: `execution_profile` is included in `computePlanHash`, so profile changes are always reflected in the ledger's `plan_hash_after` chain.
-- **All surfaces carry the profile**: snapshot events, checkpoint export (`SWARM_PLAN.json`), handoff data, export data, and `get_approved_plan` output all include `execution_profile`.
+- **All surfaces carry the profile**: snapshot events, checkpoint export (`.swarm/SWARM_PLAN.json`), handoff data, export data, and `get_approved_plan` output all include `execution_profile`.
 
 ### Lifecycle
 
@@ -149,7 +151,7 @@ once pre-check succeeds.
 | `plan.json` | ✅ Persisted in schema |
 | Ledger replay | ✅ Via `execution_profile_set` events |
 | Snapshot events | ✅ Embedded in Plan payload |
-| `SWARM_PLAN.json` checkpoint | ✅ Via full Plan payload |
+| `.swarm/SWARM_PLAN.json` checkpoint | ✅ Via full Plan payload |
 | `get_approved_plan` tool | ✅ Explicit `execution_profile` field |
 | Handoff data | ✅ In `HandoffData.execution_profile` |
 | Export data | ✅ In `ExportData.execution_profile` |

--- a/docs/releases/v7.0.1.md
+++ b/docs/releases/v7.0.1.md
@@ -1,0 +1,40 @@
+# v7.0.1
+
+## What changed
+
+### Issue #583: Housekeeping
+
+- **SWARM_PLAN relocation**: Moved `SWARM_PLAN.{json,md}` from project root to `.swarm/` directory for better artifact containment and cleaner project structure
+- **Backward compatibility**: `importCheckpoint()` gracefully falls back to root-level `SWARM_PLAN.json` for pre-v7.x sessions with deprecation warning
+- **Cleanup during transition**: `/swarm close` deletes SWARM_PLAN artifacts from both `.swarm/` and root locations during the migration window
+- **Spiral detection fix**: New `saveCheckpointRecord()` function records checkpoint state without staging or committing user work, eliminating unwanted mid-flight git commits
+- **Documentation update**: Updated plan-durability.md and recovery-guide.md to reflect the new `.swarm/` location; updated log messages in src/plan/manager.ts
+
+### Issue #698: Update/install cache fixes
+
+- **Platform-specific cache paths**: Extended `getPluginCachePaths()` to include:
+  - macOS: `~/Library/Caches/opencode/` paths in addition to XDG standard
+  - Windows: `%LOCALAPPDATA%\opencode\` and `%APPDATA%\opencode\` paths with env-var fallbacks
+  - Fixes detection of plugin caches across all platform layout variations
+- **Lock file eviction**: New `getPluginLockFilePaths()` and `evictLockFiles()` functions clear bun.lock/bun.lockb/package-lock.json candidates so bun re-resolves `@latest` on next start
+- **Safety guards**: Multi-layer validation for lock file paths:
+  - ≥4 segment depth check (prevents root/home directory accidents)
+  - Basename whitelist (bun.lock, bun.lockb, package-lock.json only)
+  - Parent directory must be named `opencode`
+  - EISDIR-safe unlink handling
+- **Integrated eviction**: Both `update()` and `install()` commands now evict lock files in addition to plugin cache
+- **User feedback**: Improved output lists lock file locations checked in the no-cache-found diagnostic branch
+
+## Migration steps
+
+No user action required. The migration from root-level to `.swarm/` SWARM_PLAN is automatic and backward compatible:
+- New sessions create `.swarm/SWARM_PLAN.json`
+- Sessions resuming from pre-v7.x checkpoints load from root with a deprecation warning (visible with `OPENCODE_SWARM_DEBUG=1`)
+- Running `/swarm close` migrates and cleans up both locations
+
+## Test coverage
+
+- 11 new tests for lock file eviction, safety guards, and cross-platform cache path detection
+- New `cache-paths.test.ts` with platform-specific path generation tests (macOS, Windows, Linux)
+- Checkpoint tests updated for `.swarm/` paths with backward-compat coverage
+- All 5 test tiers verified (quality, unit, integration, security/adversarial, build+smoke)

--- a/docs/troubleshooting/recovery-guide.md
+++ b/docs/troubleshooting/recovery-guide.md
@@ -14,7 +14,7 @@ This guide covers common recovery scenarios for the opencode-swarm plan durabili
 import { importCheckpoint } from './src/plan/checkpoint'
 await importCheckpoint()
 
-# Option 2: Restore from SWARM_PLAN.json by copying it to `.swarm/plan.json`
+# Option 2: Restore from .swarm/SWARM_PLAN.json by copying it to `.swarm/plan.json`
 ```
 
 ---
@@ -40,7 +40,7 @@ await importCheckpoint()
 
 **Fix:** Automatic rebuild from ledger. If rebuild fails:
 ```bash
-# Restore from SWARM_PLAN.json by copying it to `.swarm/plan.json`
+# Restore from .swarm/SWARM_PLAN.json by copying it to `.swarm/plan.json`
 ```
 
 ---
@@ -54,7 +54,7 @@ await importCheckpoint()
 
 **Do NOT use for:**
 - Ledger corruption (use rebuild/import instead)
-- Missing plan files (use `importCheckpoint()` programmatically or restore from SWARM_PLAN.json instead)
+- Missing plan files (use `importCheckpoint()` programmatically or restore from .swarm/SWARM_PLAN.json instead)
 
 ---
 
@@ -65,7 +65,7 @@ await importCheckpoint()
 - Ledger is intact but plan projection is corrupted
 
 **Use import when:**
-- Starting fresh in a new repo with an existing `SWARM_PLAN.json` checkpoint
+- Starting fresh in a new repo with an existing `.swarm/SWARM_PLAN.json` checkpoint
 - Ledger is also missing/corrupted and you have a checkpoint backup
 
 ---

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { resolveCommand, VALID_COMMANDS } from '../commands/registry.js';
 import {
 	getPluginCachePaths,
 	getPluginConfigDir,
+	getPluginLockFilePaths,
 } from '../config/cache-paths.js';
 
 const { version } = packageJson;
@@ -18,6 +19,7 @@ const PLUGIN_CONFIG_PATH = path.join(CONFIG_DIR, 'opencode-swarm.json');
 const PROMPTS_DIR = path.join(CONFIG_DIR, 'opencode-swarm');
 
 const OPENCODE_PLUGIN_CACHE_PATHS = getPluginCachePaths();
+const OPENCODE_PLUGIN_LOCK_FILE_PATHS = getPluginLockFilePaths();
 
 // Safety floor: refuse to recursively delete a path that could catastrophically
 // damage the user's filesystem if XDG_CACHE_HOME or XDG_CONFIG_HOME are
@@ -35,7 +37,7 @@ const OPENCODE_PLUGIN_CACHE_PATHS = getPluginCachePaths();
 //      that happens to have a recognized leaf but isn't the actual cache.
 // Issue #675 hardening — round 3 (depth-based guard replaces home-containment
 // after critic's cross-platform CI regression finding).
-function isSafeCachePath(p: string): boolean {
+export function isSafeCachePath(p: string): boolean {
 	const resolved = path.resolve(p);
 	const home = path.resolve(os.homedir());
 	// 1. Catastrophic-path floor.
@@ -61,6 +63,37 @@ function isSafeCachePath(p: string): boolean {
 	}
 	const grandparent = path.basename(path.dirname(path.dirname(resolved)));
 	if (grandparent !== 'opencode') {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Safety guard for lock file deletion. Lock files have different basenames
+ * than cache directories so they need a separate check. Mirrors
+ * isSafeCachePath()'s defense-in-depth: minimum segment depth, recognized
+ * basename, and parent directory must be 'opencode'.
+ */
+export function isSafeLockFilePath(p: string): boolean {
+	const resolved = path.resolve(p);
+	const home = path.resolve(os.homedir());
+	if (resolved === '/' || resolved === home || resolved.length <= home.length) {
+		return false;
+	}
+	const segments = resolved.split(path.sep).filter((s) => s.length > 0);
+	if (segments.length < 4) {
+		return false;
+	}
+	const leaf = path.basename(resolved);
+	if (
+		leaf !== 'bun.lock' &&
+		leaf !== 'bun.lockb' &&
+		leaf !== 'package-lock.json'
+	) {
+		return false;
+	}
+	const parent = path.basename(path.dirname(resolved));
+	if (parent !== 'opencode') {
 		return false;
 	}
 	return true;
@@ -204,6 +237,17 @@ async function install(): Promise<number> {
 			`⚠ Could not clear opencode plugin cache — you may need to delete it manually:\n  ${failed}`,
 		);
 	}
+	const lockEvicted = evictLockFiles();
+	if (lockEvicted.cleared.length > 0) {
+		console.log(
+			`✓ Cleared opencode lock file(s) (next start will fetch latest): ${lockEvicted.cleared.join(', ')}`,
+		);
+	}
+	for (const failed of lockEvicted.failed) {
+		console.warn(
+			`⚠ Could not clear opencode lock file — you may need to delete it manually:\n  ${failed}`,
+		);
+	}
 
 	// Create default plugin config if not exists
 	if (!fs.existsSync(PLUGIN_CONFIG_PATH)) {
@@ -332,13 +376,29 @@ async function install(): Promise<number> {
 async function update(): Promise<number> {
 	console.log('🐝 Refreshing OpenCode Swarm plugin cache...\n');
 	const result = evictPluginCaches();
+	const lockResult = evictLockFiles();
 	if (result.cleared.length > 0) {
 		for (const cleared of result.cleared) {
 			console.log(`✓ Cleared: ${cleared}`);
 		}
 		console.log('\nRestart OpenCode to fetch the latest version from npm.');
 	}
-	if (result.cleared.length === 0 && result.failed.length === 0) {
+	if (lockResult.cleared.length > 0) {
+		for (const cleared of lockResult.cleared) {
+			console.log(`✓ Cleared lock file: ${cleared}`);
+		}
+	}
+	if (lockResult.failed.length > 0) {
+		for (const failed of lockResult.failed) {
+			console.error(`✗ Could not clear lock file: ${failed}`);
+		}
+	}
+	if (
+		result.cleared.length === 0 &&
+		result.failed.length === 0 &&
+		lockResult.cleared.length === 0 &&
+		lockResult.failed.length === 0
+	) {
 		console.log(
 			'No cached plugin found. Restart OpenCode to fetch the latest version from npm.',
 		);
@@ -346,11 +406,17 @@ async function update(): Promise<number> {
 		for (const p of OPENCODE_PLUGIN_CACHE_PATHS) {
 			console.log(`  - ${p}`);
 		}
+		console.log('Lock files checked:');
+		for (const p of OPENCODE_PLUGIN_LOCK_FILE_PATHS) {
+			console.log(`  - ${p}`);
+		}
 	}
 	if (result.failed.length > 0) {
 		for (const failed of result.failed) {
 			console.error(`✗ Could not clear: ${failed}`);
 		}
+	}
+	if (result.failed.length > 0 || lockResult.failed.length > 0) {
 		return 1;
 	}
 	return 0;
@@ -361,7 +427,7 @@ async function update(): Promise<number> {
  * opencode-swarm. Returns paths actually cleared and paths that errored.
  * Skips paths that don't exist or fail the safety guard.
  */
-function evictPluginCaches(): { cleared: string[]; failed: string[] } {
+export function evictPluginCaches(): { cleared: string[]; failed: string[] } {
 	const cleared: string[] = [];
 	const failed: string[] = [];
 	for (const cachePath of OPENCODE_PLUGIN_CACHE_PATHS) {
@@ -377,6 +443,41 @@ function evictPluginCaches(): { cleared: string[]; failed: string[] } {
 			failed.push(
 				`${cachePath} (${err instanceof Error ? err.message : String(err)})`,
 			);
+		}
+	}
+	return { cleared, failed };
+}
+
+/**
+ * Delete every known opencode plugin lock file (bun.lock, bun.lockb,
+ * package-lock.json). Returns paths actually cleared and paths that
+ * errored. Skips paths that don't exist or fail the safety guard.
+ *
+ * Why: opencode runs `bun install` at startup; bun.lock pins the
+ * installed plugin version. Deleting the lock forces re-resolution
+ * from npm so users actually receive the @latest version after `update`.
+ */
+export function evictLockFiles(): { cleared: string[]; failed: string[] } {
+	const cleared: string[] = [];
+	const failed: string[] = [];
+	for (const lockPath of OPENCODE_PLUGIN_LOCK_FILE_PATHS) {
+		if (!fs.existsSync(lockPath)) continue;
+		if (!isSafeLockFilePath(lockPath)) {
+			failed.push(`${lockPath} (refused: failed safety check)`);
+			continue;
+		}
+		try {
+			fs.unlinkSync(lockPath);
+			cleared.push(lockPath);
+		} catch (err: unknown) {
+			const code = (err as NodeJS.ErrnoException)?.code;
+			if (code === 'EISDIR') {
+				failed.push(`${lockPath} (path is a directory, not a file)`);
+			} else {
+				failed.push(
+					`${lockPath} (${err instanceof Error ? err.message : String(err)})`,
+				);
+			}
 		}
 	}
 	return { cleared, failed };

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -561,30 +561,27 @@ export async function handleCloseCommand(
 		// readdir failure is non-blocking
 	}
 
-	// Remove root-level SWARM_PLAN checkpoint artifacts written by writeCheckpoint().
-	// These are redundant copies of plan.json/plan.md (already archived) and should
-	// not be left behind at the project root after close.
+	// Remove SWARM_PLAN checkpoint artifacts written by writeCheckpoint().
+	// Cleans both the canonical .swarm/ location and any legacy root-level
+	// artifacts from pre-7.0 sessions. These are redundant copies of
+	// plan.json/plan.md (already archived) and should not be left behind.
 	let swarmPlanFilesRemoved = 0;
-	const swarmPlanJsonPath = path.join(directory, 'SWARM_PLAN.json');
-	const swarmPlanMdPath = path.join(directory, 'SWARM_PLAN.md');
-	try {
-		await fs.unlink(swarmPlanJsonPath);
-		swarmPlanFilesRemoved++;
-	} catch (err: unknown) {
-		if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
-			warnings.push(
-				`Failed to remove SWARM_PLAN.json: ${err instanceof Error ? err.message : String(err)}`,
-			);
-		}
-	}
-	try {
-		await fs.unlink(swarmPlanMdPath);
-		swarmPlanFilesRemoved++;
-	} catch (err: unknown) {
-		if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
-			warnings.push(
-				`Failed to remove SWARM_PLAN.md: ${err instanceof Error ? err.message : String(err)}`,
-			);
+	const candidates = [
+		path.join(directory, '.swarm', 'SWARM_PLAN.json'),
+		path.join(directory, '.swarm', 'SWARM_PLAN.md'),
+		path.join(directory, 'SWARM_PLAN.json'),
+		path.join(directory, 'SWARM_PLAN.md'),
+	];
+	for (const candidate of candidates) {
+		try {
+			await fs.unlink(candidate);
+			swarmPlanFilesRemoved++;
+		} catch (err: unknown) {
+			if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+				warnings.push(
+					`Failed to remove ${path.basename(candidate)}: ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
 		}
 	}
 
@@ -693,9 +690,7 @@ export async function handleCloseCommand(
 			? [`- Removed ${configBackupsRemoved} stale config backup file(s)`]
 			: []),
 		...(swarmPlanFilesRemoved > 0
-			? [
-					`- Removed ${swarmPlanFilesRemoved} root-level SWARM_PLAN checkpoint artifact(s)`,
-				]
+			? [`- Removed ${swarmPlanFilesRemoved} SWARM_PLAN checkpoint artifact(s)`]
 			: []),
 		...(planExists && !planAlreadyDone
 			? ['- Set non-completed phases/tasks to closed status']
@@ -728,7 +723,7 @@ export async function handleCloseCommand(
 
 	// NOTE: writeCheckpoint is intentionally NOT called here. SWARM_PLAN.json and
 	// SWARM_PLAN.md are redundant copies of plan.json/plan.md (already archived in
-	// .swarm/archive/) and should not be written to the project root during close.
+	// .swarm/archive/) and should not be written to the .swarm/ directory during close.
 	// Stage 3 cleanup removes any pre-existing SWARM_PLAN artifacts from prior sessions.
 
 	// Full session reset so subsequent /swarm invocations start from a clean slate.

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -1,10 +1,11 @@
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { resetAutomationManager } from '../background/manager';
 import { validateSwarmPath } from '../hooks/utils';
 
 /**
  * Handles the /swarm reset command.
- * Clears plan.md and context.md from .swarm/ directory.
+ * Clears all swarm state files from .swarm/ and project root.
  * Stops background automation and resets in-memory queues.
  * Requires --confirm flag as a safety gate.
  */
@@ -18,7 +19,7 @@ export async function handleResetCommand(
 		return [
 			'## Swarm Reset',
 			'',
-			'⚠️ This will delete plan.md and context.md from .swarm/',
+			'⚠️ This will delete all swarm state from .swarm/ (plan, context, checkpoints, SWARM_PLAN artifacts)',
 			'',
 			'**Tip**: Run `/swarm export` first to backup your state.',
 			'',
@@ -26,7 +27,16 @@ export async function handleResetCommand(
 		].join('\n');
 	}
 
-	const filesToReset = ['plan.md', 'context.md'];
+	// Individual files inside .swarm/ that are always safe to delete
+	const filesToReset = [
+		'plan.md',
+		'plan.json',
+		'context.md',
+		'SWARM_PLAN.md',
+		'SWARM_PLAN.json',
+		'checkpoints.json',
+		'events.jsonl',
+	];
 	const results: string[] = [];
 
 	for (const filename of filesToReset) {
@@ -40,6 +50,19 @@ export async function handleResetCommand(
 			}
 		} catch {
 			results.push(`- ❌ Failed to delete ${filename}`);
+		}
+	}
+
+	// Also clean up legacy root-level SWARM_PLAN artifacts (pre-v7.x sessions)
+	for (const filename of ['SWARM_PLAN.md', 'SWARM_PLAN.json']) {
+		try {
+			const rootPath = path.join(directory, filename);
+			if (fs.existsSync(rootPath)) {
+				fs.unlinkSync(rootPath);
+				results.push(`- ✅ Deleted ${filename} (root)`);
+			}
+		} catch {
+			// Non-fatal: root-level cleanup is best-effort
 		}
 	}
 

--- a/src/config/cache-paths.ts
+++ b/src/config/cache-paths.ts
@@ -14,6 +14,10 @@
  * 3. CANONICAL XDG cache node_modules (current OpenCode v20+, all platforms,
  *    documented at https://opencode.ai/docs/plugins/):
  *    `<XDG_CACHE_HOME or ~/.cache>/opencode/node_modules/opencode-swarm/`
+ *
+ * Lock files (bun.lock, bun.lockb, package-lock.json) live alongside the
+ * cache and pin which plugin version is installed. They are exposed via
+ * getPluginLockFilePaths() and cleared during update/install.
  */
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -38,9 +42,60 @@ export function getPluginCachePaths(): readonly string[] {
 	const cacheBase =
 		process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
 	const configDir = getPluginConfigDir();
-	return [
+	const paths: string[] = [
+		path.join(cacheBase, 'opencode', 'node_modules', 'opencode-swarm'),
 		path.join(cacheBase, 'opencode', 'packages', 'opencode-swarm@latest'),
 		path.join(configDir, 'node_modules', 'opencode-swarm'),
-		path.join(cacheBase, 'opencode', 'node_modules', 'opencode-swarm'),
 	];
+	if (process.platform === 'darwin') {
+		const libCaches = path.join(os.homedir(), 'Library', 'Caches');
+		paths.push(
+			path.join(libCaches, 'opencode', 'node_modules', 'opencode-swarm'),
+			path.join(libCaches, 'opencode', 'packages', 'opencode-swarm@latest'),
+		);
+	}
+	if (process.platform === 'win32') {
+		const localAppData =
+			process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+		const appData =
+			process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+		paths.push(
+			path.join(localAppData, 'opencode', 'node_modules', 'opencode-swarm'),
+			path.join(localAppData, 'opencode', 'packages', 'opencode-swarm@latest'),
+			path.join(appData, 'opencode', 'node_modules', 'opencode-swarm'),
+		);
+	}
+	return paths;
+}
+
+/**
+ * All known locations where OpenCode stores npm lock files for the plugin
+ * environment. These pin the installed version of opencode-swarm and must
+ * be cleared during update/install to force a fresh resolution from npm.
+ */
+export function getPluginLockFilePaths(): readonly string[] {
+	const cacheBase =
+		process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
+	const configDir = getPluginConfigDir();
+	const paths: string[] = [
+		path.join(cacheBase, 'opencode', 'bun.lock'),
+		path.join(cacheBase, 'opencode', 'bun.lockb'),
+		path.join(configDir, 'package-lock.json'),
+	];
+	if (process.platform === 'darwin') {
+		const libCaches = path.join(os.homedir(), 'Library', 'Caches');
+		paths.push(
+			path.join(libCaches, 'opencode', 'bun.lock'),
+			path.join(libCaches, 'opencode', 'bun.lockb'),
+		);
+	}
+	if (process.platform === 'win32') {
+		const localAppData =
+			process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+		paths.push(
+			path.join(localAppData, 'opencode', 'bun.lock'),
+			path.join(localAppData, 'opencode', 'bun.lockb'),
+		);
+	}
+	return paths;
 }

--- a/src/hooks/adversarial-detector.ts
+++ b/src/hooks/adversarial-detector.ts
@@ -1,6 +1,5 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import type { ToolContext } from '@opencode-ai/plugin';
 import type { PluginConfig } from '../config';
 import { DEFAULT_MODELS } from '../config/constants';
 import { stripKnownSwarmPrefix } from '../config/schema';
@@ -440,17 +439,9 @@ export async function handleDebuggingSpiral(
 
 	const checkpointLabel = `spiral-${taskId}-${Date.now()}`;
 	try {
-		const { checkpoint } = await import('../tools/checkpoint.js');
-		const result = await checkpoint.execute(
-			{ action: 'save', label: checkpointLabel },
-			{ directory } as ToolContext,
-		);
-		try {
-			const parsed = JSON.parse(result as string) as { success?: boolean };
-			checkpointCreated = parsed.success === true;
-		} catch {
-			checkpointCreated = false;
-		}
+		const { saveCheckpointRecord } = await import('../tools/checkpoint.js');
+		const result = saveCheckpointRecord(checkpointLabel, directory);
+		checkpointCreated = result.success === true;
 	} catch {
 		checkpointCreated = false;
 	}

--- a/src/plan/checkpoint.test.ts
+++ b/src/plan/checkpoint.test.ts
@@ -48,7 +48,7 @@ describe('writeCheckpoint', () => {
 		],
 	};
 
-	describe('writes SWARM_PLAN.json at project root', () => {
+	describe('writes SWARM_PLAN.json inside .swarm/', () => {
 		test('writes valid JSON matching the plan', async () => {
 			const tmpDir = createTempDir();
 			try {
@@ -60,7 +60,7 @@ describe('writeCheckpoint', () => {
 				await writeCheckpoint(tmpDir);
 
 				// Verify SWARM_PLAN.json exists and contains valid JSON
-				const jsonPath = join(tmpDir, 'SWARM_PLAN.json');
+				const jsonPath = join(tmpDir, '.swarm', 'SWARM_PLAN.json');
 				expect(existsSync(jsonPath)).toBe(true);
 
 				const content = readFileSync(jsonPath, 'utf8');
@@ -82,7 +82,7 @@ describe('writeCheckpoint', () => {
 		});
 	});
 
-	describe('writes SWARM_PLAN.md at project root', () => {
+	describe('writes SWARM_PLAN.md inside .swarm/', () => {
 		test('writes markdown content with plan details', async () => {
 			const tmpDir = createTempDir();
 			try {
@@ -91,7 +91,7 @@ describe('writeCheckpoint', () => {
 
 				await writeCheckpoint(tmpDir);
 
-				const mdPath = join(tmpDir, 'SWARM_PLAN.md');
+				const mdPath = join(tmpDir, '.swarm', 'SWARM_PLAN.md');
 				expect(existsSync(mdPath)).toBe(true);
 
 				const content = readFileSync(mdPath, 'utf8');
@@ -133,7 +133,7 @@ describe('writeCheckpoint', () => {
 
 				await writeCheckpoint(tmpDir);
 
-				const jsonPath = join(tmpDir, 'SWARM_PLAN.json');
+				const jsonPath = join(tmpDir, '.swarm', 'SWARM_PLAN.json');
 				const originalContent = readFileSync(jsonPath, 'utf8');
 
 				// Modify the plan and save again
@@ -160,7 +160,7 @@ describe('writeCheckpoint', () => {
 
 				await writeCheckpoint(tmpDir);
 
-				const mdPath = join(tmpDir, 'SWARM_PLAN.md');
+				const mdPath = join(tmpDir, '.swarm', 'SWARM_PLAN.md');
 				const originalContent = readFileSync(mdPath, 'utf8');
 
 				// Modify the plan and save again
@@ -190,7 +190,7 @@ describe('writeCheckpoint', () => {
 				await writeCheckpoint(tmpDir);
 
 				// Read both files
-				const checkpointPath = join(tmpDir, 'SWARM_PLAN.json');
+				const checkpointPath = join(tmpDir, '.swarm', 'SWARM_PLAN.json');
 				const planPath = join(tmpDir, '.swarm', 'plan.json');
 
 				const checkpointContent = readFileSync(checkpointPath, 'utf8');
@@ -242,10 +242,10 @@ describe('importCheckpoint', () => {
 		const tmpDir = createTempDir();
 		try {
 			mkdirSync(join(tmpDir, '.swarm'), { recursive: true });
-			// Write a SWARM_PLAN.json at root
+			// Write a SWARM_PLAN.json inside .swarm/
 			const { writeFileSync } = await import('node:fs');
 			writeFileSync(
-				join(tmpDir, 'SWARM_PLAN.json'),
+				join(tmpDir, '.swarm', 'SWARM_PLAN.json'),
 				JSON.stringify(validPlan, null, 2),
 				'utf8',
 			);
@@ -276,7 +276,11 @@ describe('importCheckpoint', () => {
 		try {
 			mkdirSync(join(tmpDir, '.swarm'), { recursive: true });
 			const { writeFileSync } = await import('node:fs');
-			writeFileSync(join(tmpDir, 'SWARM_PLAN.json'), 'not valid json', 'utf8');
+			writeFileSync(
+				join(tmpDir, '.swarm', 'SWARM_PLAN.json'),
+				'not valid json',
+				'utf8',
+			);
 			const result = await importCheckpoint(tmpDir);
 			expect(result.success).toBe(false);
 			expect(result.error).toBeDefined();
@@ -297,6 +301,29 @@ describe('importCheckpoint', () => {
 			expect(result.success).toBe(true);
 			expect(result.plan!.title).toBe('Import Test Plan');
 			expect(result.plan!.phases[0].tasks[0].id).toBe('1.1');
+		} finally {
+			cleanupTempDir(tmpDir);
+		}
+	});
+
+	test('imports legacy root-level SWARM_PLAN.json with deprecation warning', async () => {
+		const tmpDir = createTempDir();
+		try {
+			// Note: do NOT create .swarm/SWARM_PLAN.json — we're testing the
+			// legacy fallback to the project-root location.
+			mkdirSync(join(tmpDir, '.swarm'), { recursive: true });
+			const { writeFileSync } = await import('node:fs');
+			const rootPath = join(tmpDir, 'SWARM_PLAN.json');
+			writeFileSync(rootPath, JSON.stringify(validPlan, null, 2), 'utf8');
+
+			const result = await importCheckpoint(tmpDir);
+			expect(result.success).toBe(true);
+			expect(result.plan).not.toBeNull();
+			expect(result.plan!.title).toBe('Import Test Plan');
+
+			// Verify the savePlan side effect created .swarm/plan.json
+			const savedPlanPath = join(tmpDir, '.swarm', 'plan.json');
+			expect(existsSync(savedPlanPath)).toBe(true);
 		} finally {
 			cleanupTempDir(tmpDir);
 		}

--- a/src/plan/checkpoint.ts
+++ b/src/plan/checkpoint.ts
@@ -1,6 +1,6 @@
 /**
  * Checkpoint artifact writer.
- * Writes SWARM_PLAN.md and SWARM_PLAN.json at the project root (not inside .swarm/).
+ * Writes SWARM_PLAN.md and SWARM_PLAN.json inside .swarm/.
  * Export-only — not a live runtime source of truth.
  * Called on: save_plan, phase completion, /swarm close.
  * NOT called on every task update.
@@ -12,7 +12,7 @@ import { appendLedgerEvent } from '../plan/ledger';
 import { derivePlanMarkdown, loadPlan, savePlan } from './manager';
 
 /**
- * Write SWARM_PLAN.json and SWARM_PLAN.md to the project root directory.
+ * Write SWARM_PLAN.json and SWARM_PLAN.md inside the .swarm/ directory under the project root.
  * Non-blocking: logs a warning on failure but never throws.
  * @param directory - The working directory (project root)
  */
@@ -21,8 +21,10 @@ export async function writeCheckpoint(directory: string): Promise<void> {
 		const plan = await loadPlan(directory);
 		if (!plan) return;
 
-		const jsonPath = path.join(directory, 'SWARM_PLAN.json');
-		const mdPath = path.join(directory, 'SWARM_PLAN.md');
+		const swarmDir = path.join(directory, '.swarm');
+		fs.mkdirSync(swarmDir, { recursive: true });
+		const jsonPath = path.join(swarmDir, 'SWARM_PLAN.json');
+		const mdPath = path.join(swarmDir, 'SWARM_PLAN.md');
 
 		// Write JSON checkpoint
 		fs.writeFileSync(jsonPath, JSON.stringify(plan, null, 2), 'utf8');
@@ -48,7 +50,7 @@ export interface ImportCheckpointResult {
 }
 
 /**
- * Import a checkpoint from SWARM_PLAN.json at the project root.
+ * Import a checkpoint from .swarm/SWARM_PLAN.json (with backward-compat fallback to project root).
  * Validates the checkpoint against PlanSchema, persists it as the live plan
  * via savePlan, and appends a 'plan_rebuilt' ledger event.
  *
@@ -61,8 +63,25 @@ export async function importCheckpoint(
 	source?: string,
 ): Promise<ImportCheckpointResult> {
 	try {
-		const checkpointPath = path.join(directory, 'SWARM_PLAN.json');
-		const rawContent = fs.readFileSync(checkpointPath, 'utf8');
+		const swarmDirPath = path.join(directory, '.swarm', 'SWARM_PLAN.json');
+		const rootPath = path.join(directory, 'SWARM_PLAN.json');
+		let checkpointPath: string;
+		let rawContent: string;
+		if (fs.existsSync(swarmDirPath)) {
+			checkpointPath = swarmDirPath;
+			rawContent = fs.readFileSync(checkpointPath, 'utf8');
+		} else if (fs.existsSync(rootPath)) {
+			checkpointPath = rootPath;
+			rawContent = fs.readFileSync(checkpointPath, 'utf8');
+			console.warn(
+				'[checkpoint] importCheckpoint: using legacy root-level SWARM_PLAN.json. Consider running /swarm close to migrate.',
+			);
+		} else {
+			return {
+				success: false,
+				error: 'SWARM_PLAN.json not found in .swarm/ or project root',
+			};
+		}
 		const parsed = JSON.parse(rawContent);
 		const plan = PlanSchema.parse(parsed) as Plan;
 

--- a/src/plan/manager.ts
+++ b/src/plan/manager.ts
@@ -393,7 +393,7 @@ export async function loadPlan(directory: string): Promise<RuntimePlan | null> {
 									if (rebuilt) {
 										await rebuildPlan(directory, rebuilt);
 										warn(
-											'[loadPlan] Rebuilt plan from ledger. Checkpoint available at SWARM_PLAN.md if it exists.',
+											'[loadPlan] Rebuilt plan from ledger. Checkpoint available at .swarm/SWARM_PLAN.md if it exists.',
 										);
 										return rebuilt;
 									}
@@ -442,7 +442,7 @@ export async function loadPlan(directory: string): Promise<RuntimePlan | null> {
 										// Fall through to the stale-plan warning below
 									}
 									warn(
-										`[loadPlan] Ledger replay failed during hash-mismatch rebuild: ${replayError instanceof Error ? replayError.message : String(replayError)}. Returning stale plan.json. To recover: check SWARM_PLAN.md for a checkpoint, or run /swarm reset-session.`,
+										`[loadPlan] Ledger replay failed during hash-mismatch rebuild: ${replayError instanceof Error ? replayError.message : String(replayError)}. Returning stale plan.json. To recover: check .swarm/SWARM_PLAN.md for a checkpoint, or run /swarm reset-session.`,
 									);
 								}
 								// Fall through and return the validated plan.json
@@ -521,7 +521,7 @@ export async function loadPlan(directory: string): Promise<RuntimePlan | null> {
 			} catch (error) {
 				// Step 2: Validation failed, log warning and fall through to legacy
 				warn(
-					`[loadPlan] plan.json validation failed: ${error instanceof Error ? error.message : String(error)}. Attempting rebuild from ledger. If rebuild fails, check SWARM_PLAN.md for a checkpoint.`,
+					`[loadPlan] plan.json validation failed: ${error instanceof Error ? error.message : String(error)}. Attempting rebuild from ledger. If rebuild fails, check .swarm/SWARM_PLAN.md for a checkpoint.`,
 				);
 				// MIGRATION GUARD (catch path): Extract swarm+title from the raw JSON
 				// before schema validation even though validation failed. If we can determine

--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -285,6 +285,47 @@ function handleSave(label: string, directory: string): string {
 }
 
 /**
+ * Record a checkpoint without staging or committing changes.
+ * Writes only to .swarm/checkpoints.json with the current HEAD SHA.
+ * Used by spiral detection to avoid silently committing mid-flight user work.
+ */
+export function saveCheckpointRecord(
+	label: string,
+	directory: string,
+): { success: boolean; sha?: string; error?: string } {
+	const labelError = validateLabel(label);
+	if (labelError) {
+		return { success: false, error: labelError };
+	}
+	try {
+		const log = readCheckpointLog(directory);
+		if (log.checkpoints.find((c) => c.label === label)) {
+			return { success: false, error: `duplicate label: "${label}"` };
+		}
+		let sha = '';
+		if (isGitRepo()) {
+			try {
+				sha = getCurrentSha();
+			} catch {
+				sha = '';
+			}
+		}
+		log.checkpoints.push({
+			label,
+			sha,
+			timestamp: new Date().toISOString(),
+		});
+		writeCheckpointLog(log, directory);
+		return { success: true, sha };
+	} catch (e) {
+		return {
+			success: false,
+			error: e instanceof Error ? e.message : 'unknown error',
+		};
+	}
+}
+
+/**
  * Handle 'restore' action - soft reset to saved SHA
  */
 function handleRestore(label: string, directory: string): string {

--- a/tests/unit/cli/update-command.test.ts
+++ b/tests/unit/cli/update-command.test.ts
@@ -11,6 +11,11 @@ import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import {
+	evictLockFiles,
+	isSafeCachePath,
+	isSafeLockFilePath,
+} from '../../../src/cli/index.js';
 
 const CLI_PATH = join(
 	import.meta.dir,
@@ -275,5 +280,178 @@ describe('CLI update command', () => {
 		expect(result.stdout).not.toMatch(
 			/✓ Cleared:[\s]*[\\/]opencode[\\/]node_modules[\\/]opencode-swarm/,
 		);
+	});
+});
+
+describe('evictLockFiles', () => {
+	let tempDir: string;
+	let xdgCacheHome: string;
+	let xdgConfigHome: string;
+	const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+	const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), 'opencode-swarm-lock-'));
+		xdgCacheHome = join(tempDir, 'cache');
+		xdgConfigHome = join(tempDir, 'config');
+		process.env.XDG_CACHE_HOME = xdgCacheHome;
+		process.env.XDG_CONFIG_HOME = xdgConfigHome;
+	});
+
+	afterEach(async () => {
+		if (originalXdgCacheHome === undefined) {
+			delete process.env.XDG_CACHE_HOME;
+		} else {
+			process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+		}
+		if (originalXdgConfigHome === undefined) {
+			delete process.env.XDG_CONFIG_HOME;
+		} else {
+			process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+		}
+		if (existsSync(tempDir)) {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test('deletes bun.lock file when it exists in ~/.cache/opencode/', async () => {
+		// Note: evictLockFiles() reads OPENCODE_PLUGIN_LOCK_FILE_PATHS which is
+		// captured at module-load time. We verify behavior via the CLI subprocess
+		// since the env vars must be set before module import.
+		const lockDir = join(xdgCacheHome, 'opencode');
+		const lockPath = join(lockDir, 'bun.lock');
+		await mkdir(lockDir, { recursive: true });
+		await writeFile(lockPath, '{}');
+
+		const proc = Bun.spawn([process.execPath, 'run', CLI_PATH, 'update'], {
+			env: {
+				...process.env,
+				XDG_CACHE_HOME: xdgCacheHome,
+				XDG_CONFIG_HOME: xdgConfigHome,
+			},
+			stdout: 'pipe',
+			stderr: 'pipe',
+		});
+		const exitCode = await proc.exited;
+		const stdout = await new Response(proc.stdout).text();
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain('✓ Cleared lock file:');
+		expect(stdout).toContain('bun.lock');
+		expect(existsSync(lockPath)).toBe(false);
+	});
+
+	test('reports EISDIR when bun.lock is actually a directory', async () => {
+		// If a path that should be a file is a directory, unlinkSync throws
+		// EISDIR. The handler converts this to a friendly message.
+		const lockDir = join(xdgCacheHome, 'opencode');
+		const lockAsDir = join(lockDir, 'bun.lock');
+		await mkdir(lockAsDir, { recursive: true });
+
+		const proc = Bun.spawn([process.execPath, 'run', CLI_PATH, 'update'], {
+			env: {
+				...process.env,
+				XDG_CACHE_HOME: xdgCacheHome,
+				XDG_CONFIG_HOME: xdgConfigHome,
+			},
+			stdout: 'pipe',
+			stderr: 'pipe',
+		});
+		const exitCode = await proc.exited;
+		const stdout = await new Response(proc.stdout).text();
+		const stderr = await new Response(proc.stderr).text();
+		// Lock file failure → exit 1
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain('Could not clear lock file');
+		expect(stderr).toContain('path is a directory');
+	});
+
+	test('no-cache-found path lists lock file paths in console output', async () => {
+		// No cache, no lock files — should list both.
+		const proc = Bun.spawn([process.execPath, 'run', CLI_PATH, 'update'], {
+			env: {
+				...process.env,
+				XDG_CACHE_HOME: xdgCacheHome,
+				XDG_CONFIG_HOME: xdgConfigHome,
+			},
+			stdout: 'pipe',
+			stderr: 'pipe',
+		});
+		const exitCode = await proc.exited;
+		const stdout = await new Response(proc.stdout).text();
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain('No cached plugin found');
+		expect(stdout).toContain('Checked locations:');
+		expect(stdout).toContain('Lock files checked:');
+		expect(stdout).toMatch(/cache[\\/]opencode[\\/]bun\.lock/);
+		expect(stdout).toMatch(/cache[\\/]opencode[\\/]bun\.lockb/);
+		expect(stdout).toMatch(/config[\\/]opencode[\\/]package-lock\.json/);
+	});
+});
+
+describe('isSafeLockFilePath', () => {
+	test('rejects /bun.lock (too shallow)', () => {
+		expect(isSafeLockFilePath('/bun.lock')).toBe(false);
+	});
+
+	test('rejects ~/bun.lock (in home directly)', () => {
+		const homeFile = join(process.env.HOME || '/home/user', 'bun.lock');
+		expect(isSafeLockFilePath(homeFile)).toBe(false);
+	});
+
+	test('rejects /some/random/dir/bun.lock (parent not opencode)', () => {
+		expect(isSafeLockFilePath('/some/random/dir/bun.lock')).toBe(false);
+	});
+
+	test('rejects ~/.cache/opencode/random.lock (wrong basename)', () => {
+		const home = process.env.HOME || '/home/user';
+		expect(
+			isSafeLockFilePath(join(home, '.cache', 'opencode', 'random.lock')),
+		).toBe(false);
+	});
+
+	test('accepts <tmpDir>/.cache/opencode/bun.lock when path is deep enough', async () => {
+		// Use a real tmpDir (which is on Linux CI deep enough: /tmp/xxx/.cache/opencode/bun.lock).
+		const tmp = await mkdtemp(join(tmpdir(), 'opencode-lock-safe-'));
+		try {
+			const lockPath = join(tmp, '.cache', 'opencode', 'bun.lock');
+			expect(isSafeLockFilePath(lockPath)).toBe(true);
+			// Also verify other recognized basenames:
+			expect(
+				isSafeLockFilePath(join(tmp, '.cache', 'opencode', 'bun.lockb')),
+			).toBe(true);
+			expect(
+				isSafeLockFilePath(
+					join(tmp, '.config', 'opencode', 'package-lock.json'),
+				),
+			).toBe(true);
+		} finally {
+			await rm(tmp, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('isSafeCachePath cross-platform path acceptance', () => {
+	test('accepts a darwin-style ~/Library/Caches/opencode/node_modules/opencode-swarm path', () => {
+		// String-only check: build the path manually. We do NOT create it on disk
+		// because Library/Caches doesn't exist on Linux CI.
+		const darwinPath =
+			'/Users/testuser/Library/Caches/opencode/node_modules/opencode-swarm';
+		expect(isSafeCachePath(darwinPath)).toBe(true);
+	});
+
+	test('accepts a Windows-style %LOCALAPPDATA%/opencode/node_modules/opencode-swarm path', () => {
+		// Use forward slashes for cross-platform compatibility on Linux CI.
+		// path.resolve will normalize. The key invariants are:
+		// segments ≥ 4, leaf is opencode-swarm, parent is node_modules,
+		// grandparent is opencode.
+		const winPath =
+			'/c/Users/testuser/AppData/Local/opencode/node_modules/opencode-swarm';
+		expect(isSafeCachePath(winPath)).toBe(true);
+	});
+
+	test('accepts a darwin packages-style path', () => {
+		const darwinPkg =
+			'/Users/testuser/Library/Caches/opencode/packages/opencode-swarm@latest';
+		expect(isSafeCachePath(darwinPkg)).toBe(true);
 	});
 });

--- a/tests/unit/commands/close-finalizer.test.ts
+++ b/tests/unit/commands/close-finalizer.test.ts
@@ -224,7 +224,9 @@ describe('handleCloseCommand — finalizer stages', () => {
 
 		it('removes root-level SWARM_PLAN.json and SWARM_PLAN.md after close', async () => {
 			writePlan();
-			// Create root-level SWARM_PLAN checkpoint artifacts
+			// Create root-level SWARM_PLAN checkpoint artifacts (legacy
+			// location — close still cleans these for backward compatibility
+			// during the transition window).
 			writeFileSync(path.join(testDir, 'SWARM_PLAN.json'), '{"title":"Test"}');
 			writeFileSync(path.join(testDir, 'SWARM_PLAN.md'), '# Test Plan');
 
@@ -233,6 +235,22 @@ describe('handleCloseCommand — finalizer stages', () => {
 			// Root-level SWARM_PLAN artifacts must be removed
 			expect(existsSync(path.join(testDir, 'SWARM_PLAN.json'))).toBe(false);
 			expect(existsSync(path.join(testDir, 'SWARM_PLAN.md'))).toBe(false);
+		});
+
+		it('removes .swarm/SWARM_PLAN.json and .swarm/SWARM_PLAN.md after close', async () => {
+			writePlan();
+			// Create canonical .swarm/-level SWARM_PLAN checkpoint artifacts
+			writeFileSync(
+				path.join(swarmDir(), 'SWARM_PLAN.json'),
+				'{"title":"Test"}',
+			);
+			writeFileSync(path.join(swarmDir(), 'SWARM_PLAN.md'), '# Test Plan');
+
+			await handleCloseCommand(testDir, []);
+
+			// .swarm/-level SWARM_PLAN artifacts must be removed
+			expect(existsSync(path.join(swarmDir(), 'SWARM_PLAN.json'))).toBe(false);
+			expect(existsSync(path.join(swarmDir(), 'SWARM_PLAN.md'))).toBe(false);
 		});
 
 		it('SWARM_PLAN cleanup is non-blocking — close succeeds even if removal fails', async () => {

--- a/tests/unit/commands/reset.test.ts
+++ b/tests/unit/commands/reset.test.ts
@@ -38,9 +38,7 @@ describe('handleResetCommand', () => {
 		const result = await handleResetCommand(tempDir, []);
 
 		expect(result).toContain('## Swarm Reset');
-		expect(result).toContain(
-			'⚠️ This will delete plan.md and context.md from .swarm/',
-		);
+		expect(result).toContain('⚠️ This will delete all swarm state from .swarm/');
 		expect(result).toContain(
 			'Tip**: Run `/swarm export` first to backup your state.',
 		);
@@ -156,5 +154,62 @@ describe('handleResetCommand', () => {
 		expect(result).toContain('## Swarm Reset Complete');
 		expect(result).toContain('✅ Deleted plan.md');
 		expect(result).toContain('✅ Deleted context.md');
+	});
+
+	test('With --confirm - also deletes plan.json when present', async () => {
+		await writeFile(
+			join(tempDir, '.swarm', 'plan.json'),
+			JSON.stringify({ swarm: 'test', title: 'Test Plan', phases: [] }),
+		);
+
+		const result = await handleResetCommand(tempDir, ['--confirm']);
+
+		expect(result).toContain('## Swarm Reset Complete');
+		expect(result).toContain('✅ Deleted plan.json');
+		expect(existsSync(join(tempDir, '.swarm', 'plan.json'))).toBe(false);
+	});
+
+	test('With --confirm - deletes SWARM_PLAN artifacts from .swarm/', async () => {
+		await writeFile(join(tempDir, '.swarm', 'SWARM_PLAN.json'), '{}');
+		await writeFile(join(tempDir, '.swarm', 'SWARM_PLAN.md'), '# Plan');
+		await writeFile(join(tempDir, '.swarm', 'checkpoints.json'), '[]');
+		await writeFile(join(tempDir, '.swarm', 'events.jsonl'), '');
+
+		const result = await handleResetCommand(tempDir, ['--confirm']);
+
+		expect(result).toContain('## Swarm Reset Complete');
+		expect(result).toContain('✅ Deleted SWARM_PLAN.json');
+		expect(result).toContain('✅ Deleted SWARM_PLAN.md');
+		expect(result).toContain('✅ Deleted checkpoints.json');
+		expect(result).toContain('✅ Deleted events.jsonl');
+		expect(existsSync(join(tempDir, '.swarm', 'SWARM_PLAN.json'))).toBe(false);
+		expect(existsSync(join(tempDir, '.swarm', 'SWARM_PLAN.md'))).toBe(false);
+	});
+
+	test('With --confirm - deletes legacy root-level SWARM_PLAN artifacts', async () => {
+		await writeFile(join(tempDir, 'SWARM_PLAN.json'), '{}');
+		await writeFile(join(tempDir, 'SWARM_PLAN.md'), '# Plan');
+
+		const result = await handleResetCommand(tempDir, ['--confirm']);
+
+		expect(result).toContain('## Swarm Reset Complete');
+		expect(result).toContain('✅ Deleted SWARM_PLAN.json (root)');
+		expect(result).toContain('✅ Deleted SWARM_PLAN.md (root)');
+		expect(existsSync(join(tempDir, 'SWARM_PLAN.json'))).toBe(false);
+		expect(existsSync(join(tempDir, 'SWARM_PLAN.md'))).toBe(false);
+	});
+
+	test('With --confirm - skips missing optional artifacts silently', async () => {
+		// Only create plan.md; all other files absent
+		await writeFile(join(tempDir, '.swarm', 'plan.md'), '# Plan');
+
+		const result = await handleResetCommand(tempDir, ['--confirm']);
+
+		expect(result).toContain('## Swarm Reset Complete');
+		expect(result).toContain('✅ Deleted plan.md');
+		expect(result).toContain('⏭️ plan.json not found (skipped)');
+		expect(result).toContain('⏭️ SWARM_PLAN.json not found (skipped)');
+		expect(result).toContain('⏭️ checkpoints.json not found (skipped)');
+		expect(result).toContain('⏭️ events.jsonl not found (skipped)');
 	});
 });

--- a/tests/unit/config/cache-paths.test.ts
+++ b/tests/unit/config/cache-paths.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for cache-paths.ts — verifies that getPluginCachePaths() and
+ * getPluginLockFilePaths() emit the right set of paths for each platform.
+ *
+ * Linux CI cannot create real macOS/Windows paths, so platform-specific
+ * branches are validated by mocking process.platform via Object.defineProperty.
+ * The original platform value is restored in afterEach to prevent leakage.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	getPluginCachePaths,
+	getPluginLockFilePaths,
+} from '../../../src/config/cache-paths.js';
+
+const originalPlatform = process.platform;
+const originalLocalAppData = process.env.LOCALAPPDATA;
+const originalAppData = process.env.APPDATA;
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+
+function setPlatform(value: NodeJS.Platform): void {
+	Object.defineProperty(process, 'platform', {
+		value,
+		configurable: true,
+	});
+}
+
+function restorePlatform(): void {
+	Object.defineProperty(process, 'platform', {
+		value: originalPlatform,
+		configurable: true,
+	});
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[name];
+	} else {
+		process.env[name] = value;
+	}
+}
+
+describe('getPluginCachePaths', () => {
+	afterEach(() => {
+		restorePlatform();
+		restoreEnv('LOCALAPPDATA', originalLocalAppData);
+		restoreEnv('APPDATA', originalAppData);
+		restoreEnv('XDG_CACHE_HOME', originalXdgCacheHome);
+		restoreEnv('XDG_CONFIG_HOME', originalXdgConfigHome);
+	});
+
+	test('on linux returns exactly 3 XDG paths and no platform-specific paths', () => {
+		setPlatform('linux');
+		const paths = getPluginCachePaths();
+		expect(paths.length).toBe(3);
+		// No darwin or win32 paths
+		for (const p of paths) {
+			expect(p).not.toContain('Library/Caches');
+			expect(p).not.toContain('AppData');
+		}
+		// All three XDG layouts present
+		expect(
+			paths.some((p) =>
+				p.endsWith(path.join('node_modules', 'opencode-swarm')),
+			),
+		).toBe(true);
+		expect(paths.some((p) => p.endsWith('opencode-swarm@latest'))).toBe(true);
+	});
+
+	test('on darwin adds ~/Library/Caches paths', () => {
+		setPlatform('darwin');
+		const paths = getPluginCachePaths();
+		const home = os.homedir();
+		const libCaches = path.join(home, 'Library', 'Caches');
+		expect(
+			paths.some(
+				(p) =>
+					p ===
+					path.join(libCaches, 'opencode', 'node_modules', 'opencode-swarm'),
+			),
+		).toBe(true);
+		expect(
+			paths.some(
+				(p) =>
+					p ===
+					path.join(libCaches, 'opencode', 'packages', 'opencode-swarm@latest'),
+			),
+		).toBe(true);
+	});
+
+	test('on win32 adds %LOCALAPPDATA% paths when env is set', () => {
+		setPlatform('win32');
+		process.env.LOCALAPPDATA = 'C:/Users/test/AppData/Local';
+		process.env.APPDATA = 'C:/Users/test/AppData/Roaming';
+		const paths = getPluginCachePaths();
+		expect(
+			paths.some(
+				(p) =>
+					p ===
+					path.join(
+						'C:/Users/test/AppData/Local',
+						'opencode',
+						'node_modules',
+						'opencode-swarm',
+					),
+			),
+		).toBe(true);
+		expect(
+			paths.some(
+				(p) =>
+					p ===
+					path.join(
+						'C:/Users/test/AppData/Local',
+						'opencode',
+						'packages',
+						'opencode-swarm@latest',
+					),
+			),
+		).toBe(true);
+		expect(
+			paths.some(
+				(p) =>
+					p ===
+					path.join(
+						'C:/Users/test/AppData/Roaming',
+						'opencode',
+						'node_modules',
+						'opencode-swarm',
+					),
+			),
+		).toBe(true);
+	});
+
+	test('on win32 falls back to ~/AppData/Local when LOCALAPPDATA is unset', () => {
+		setPlatform('win32');
+		delete process.env.LOCALAPPDATA;
+		delete process.env.APPDATA;
+		const paths = getPluginCachePaths();
+		const home = os.homedir();
+		const fallbackLocal = path.join(home, 'AppData', 'Local');
+		const fallbackRoaming = path.join(home, 'AppData', 'Roaming');
+		expect(
+			paths.some(
+				(p) =>
+					p ===
+					path.join(
+						fallbackLocal,
+						'opencode',
+						'node_modules',
+						'opencode-swarm',
+					),
+			),
+		).toBe(true);
+		expect(
+			paths.some(
+				(p) =>
+					p ===
+					path.join(
+						fallbackRoaming,
+						'opencode',
+						'node_modules',
+						'opencode-swarm',
+					),
+			),
+		).toBe(true);
+	});
+
+	test('on win32 falls back to ~/AppData/Roaming when APPDATA is unset', () => {
+		setPlatform('win32');
+		process.env.LOCALAPPDATA = 'C:/custom/local';
+		delete process.env.APPDATA;
+		const paths = getPluginCachePaths();
+		const home = os.homedir();
+		const fallbackRoaming = path.join(home, 'AppData', 'Roaming');
+		expect(
+			paths.some(
+				(p) =>
+					p ===
+					path.join(
+						fallbackRoaming,
+						'opencode',
+						'node_modules',
+						'opencode-swarm',
+					),
+			),
+		).toBe(true);
+	});
+});
+
+describe('getPluginLockFilePaths', () => {
+	afterEach(() => {
+		restorePlatform();
+		restoreEnv('LOCALAPPDATA', originalLocalAppData);
+		restoreEnv('APPDATA', originalAppData);
+		restoreEnv('XDG_CACHE_HOME', originalXdgCacheHome);
+		restoreEnv('XDG_CONFIG_HOME', originalXdgConfigHome);
+	});
+
+	test('on linux returns exactly 3 XDG/legacy lock paths', () => {
+		setPlatform('linux');
+		const paths = getPluginLockFilePaths();
+		expect(paths.length).toBe(3);
+		// Should include bun.lock, bun.lockb, package-lock.json
+		const basenames = paths.map((p) => path.basename(p));
+		expect(basenames).toContain('bun.lock');
+		expect(basenames).toContain('bun.lockb');
+		expect(basenames).toContain('package-lock.json');
+		// No platform-specific paths
+		for (const p of paths) {
+			expect(p).not.toContain('Library/Caches');
+			expect(p).not.toContain('AppData');
+		}
+	});
+
+	test('on darwin adds ~/Library/Caches lock paths', () => {
+		setPlatform('darwin');
+		const paths = getPluginLockFilePaths();
+		const home = os.homedir();
+		const libCaches = path.join(home, 'Library', 'Caches');
+		expect(
+			paths.some((p) => p === path.join(libCaches, 'opencode', 'bun.lock')),
+		).toBe(true);
+		expect(
+			paths.some((p) => p === path.join(libCaches, 'opencode', 'bun.lockb')),
+		).toBe(true);
+	});
+
+	test('on win32 adds %LOCALAPPDATA% lock paths when env is set', () => {
+		setPlatform('win32');
+		process.env.LOCALAPPDATA = 'C:/Users/test/AppData/Local';
+		const paths = getPluginLockFilePaths();
+		expect(
+			paths.some(
+				(p) =>
+					p ===
+					path.join('C:/Users/test/AppData/Local', 'opencode', 'bun.lock'),
+			),
+		).toBe(true);
+		expect(
+			paths.some(
+				(p) =>
+					p ===
+					path.join('C:/Users/test/AppData/Local', 'opencode', 'bun.lockb'),
+			),
+		).toBe(true);
+	});
+
+	test('on win32 falls back to ~/AppData/Local when LOCALAPPDATA is unset', () => {
+		setPlatform('win32');
+		delete process.env.LOCALAPPDATA;
+		const paths = getPluginLockFilePaths();
+		const home = os.homedir();
+		const fallbackLocal = path.join(home, 'AppData', 'Local');
+		expect(
+			paths.some((p) => p === path.join(fallbackLocal, 'opencode', 'bun.lock')),
+		).toBe(true);
+	});
+});

--- a/tests/unit/hooks/adversarial-detector-spiral-handler.test.ts
+++ b/tests/unit/hooks/adversarial-detector-spiral-handler.test.ts
@@ -14,12 +14,12 @@ import {
 
 // Mock the checkpoint module
 jest.mock('../../../src/tools/checkpoint.js', () => ({
-	checkpoint: {
-		execute: jest.fn(),
-	},
+	saveCheckpointRecord: jest.fn(),
 }));
 
-import { checkpoint } from '../../../src/tools/checkpoint.js';
+import * as checkpointModule from '../../../src/tools/checkpoint.js';
+
+const { saveCheckpointRecord } = checkpointModule;
 
 describe('handleDebuggingSpiral', () => {
 	let tempDir: string;
@@ -61,9 +61,7 @@ describe('handleDebuggingSpiral', () => {
 			};
 
 			// Mock checkpoint to succeed
-			(checkpoint.execute as jest.Mock).mockResolvedValue(
-				JSON.stringify({ success: true }),
-			);
+			(saveCheckpointRecord as jest.Mock).mockReturnValue({ success: true });
 
 			await handleDebuggingSpiral(match, '1.1', tempDir);
 
@@ -92,9 +90,7 @@ describe('handleDebuggingSpiral', () => {
 			};
 
 			// Mock checkpoint to succeed
-			(checkpoint.execute as jest.Mock).mockResolvedValue(
-				JSON.stringify({ success: true }),
-			);
+			(saveCheckpointRecord as jest.Mock).mockReturnValue({ success: true });
 
 			// Call with invalid directory - should not throw
 			const result = await handleDebuggingSpiral(
@@ -111,7 +107,7 @@ describe('handleDebuggingSpiral', () => {
 	});
 
 	describe('2. handleDebuggingSpiral creates checkpoint', () => {
-		test('calls checkpoint.execute with save action', async () => {
+		test('calls saveCheckpointRecord with label and directory', async () => {
 			const match: AdversarialPatternMatch = {
 				pattern: 'DEBUGGING_SPIRAL',
 				severity: 'HIGH',
@@ -120,20 +116,19 @@ describe('handleDebuggingSpiral', () => {
 			};
 
 			// Mock checkpoint to succeed
-			(checkpoint.execute as jest.Mock).mockResolvedValue(
-				JSON.stringify({ success: true }),
-			);
+			(saveCheckpointRecord as jest.Mock).mockReturnValue({ success: true });
 
 			await handleDebuggingSpiral(match, '1.1', tempDir);
 
-			// Verify checkpoint.execute was called
-			expect(checkpoint.execute).toHaveBeenCalledTimes(1);
+			// Verify saveCheckpointRecord was called
+			expect(saveCheckpointRecord).toHaveBeenCalledTimes(1);
 
-			const callArgs = (checkpoint.execute as jest.Mock).mock.calls[0];
-			expect(callArgs[0]).toEqual({
-				action: 'save',
-				label: expect.any(String),
-			});
+			const callArgs = (saveCheckpointRecord as jest.Mock).mock.calls[0];
+			const label = callArgs[0];
+			const directory = callArgs[1];
+
+			expect(label).toMatch(/^spiral-1\.1-\d+$/);
+			expect(directory).toBe(tempDir);
 		});
 
 		test('sets checkpointCreated to true when checkpoint succeeds', async () => {
@@ -145,9 +140,7 @@ describe('handleDebuggingSpiral', () => {
 			};
 
 			// Mock checkpoint to succeed
-			(checkpoint.execute as jest.Mock).mockResolvedValue(
-				JSON.stringify({ success: true }),
-			);
+			(saveCheckpointRecord as jest.Mock).mockReturnValue({ success: true });
 
 			const result = await handleDebuggingSpiral(match, '1.1', tempDir);
 
@@ -163,9 +156,10 @@ describe('handleDebuggingSpiral', () => {
 			};
 
 			// Mock checkpoint to fail
-			(checkpoint.execute as jest.Mock).mockResolvedValue(
-				JSON.stringify({ success: false, error: 'No changes to save' }),
-			);
+			(saveCheckpointRecord as jest.Mock).mockReturnValue({
+				success: false,
+				error: 'No changes to save',
+			});
 
 			const result = await handleDebuggingSpiral(match, '1.1', tempDir);
 
@@ -182,9 +176,7 @@ describe('handleDebuggingSpiral', () => {
 				confidence: 'HIGH',
 			};
 
-			(checkpoint.execute as jest.Mock).mockResolvedValue(
-				JSON.stringify({ success: true }),
-			);
+			(saveCheckpointRecord as jest.Mock).mockReturnValue({ success: true });
 
 			const result = await handleDebuggingSpiral(match, '1.1', tempDir);
 
@@ -206,9 +198,7 @@ describe('handleDebuggingSpiral', () => {
 				confidence: 'HIGH',
 			};
 
-			(checkpoint.execute as jest.Mock).mockResolvedValue(
-				JSON.stringify({ success: true }),
-			);
+			(saveCheckpointRecord as jest.Mock).mockReturnValue({ success: true });
 
 			const result = await handleDebuggingSpiral(match, '1.1', tempDir);
 
@@ -223,9 +213,7 @@ describe('handleDebuggingSpiral', () => {
 				confidence: 'HIGH',
 			};
 
-			(checkpoint.execute as jest.Mock).mockResolvedValue(
-				JSON.stringify({ success: false }),
-			);
+			(saveCheckpointRecord as jest.Mock).mockReturnValue({ success: false });
 
 			const result = await handleDebuggingSpiral(match, '1.1', tempDir);
 
@@ -240,9 +228,7 @@ describe('handleDebuggingSpiral', () => {
 				confidence: 'HIGH',
 			};
 
-			(checkpoint.execute as jest.Mock).mockResolvedValue(
-				JSON.stringify({ success: true }),
-			);
+			(saveCheckpointRecord as jest.Mock).mockReturnValue({ success: true });
 
 			const result = await handleDebuggingSpiral(match, '1.1', tempDir);
 
@@ -256,7 +242,7 @@ describe('handleDebuggingSpiral', () => {
 	});
 
 	describe('4. Checkpoint failure is non-fatal', () => {
-		test('does not throw when checkpoint.execute throws', async () => {
+		test('does not throw when saveCheckpointRecord throws', async () => {
 			const match: AdversarialPatternMatch = {
 				pattern: 'DEBUGGING_SPIRAL',
 				severity: 'HIGH',
@@ -265,9 +251,9 @@ describe('handleDebuggingSpiral', () => {
 			};
 
 			// Mock checkpoint to throw
-			(checkpoint.execute as jest.Mock).mockRejectedValue(
-				new Error('Checkpoint service unavailable'),
-			);
+			(saveCheckpointRecord as jest.Mock).mockImplementation(() => {
+				throw new Error('Checkpoint service unavailable');
+			});
 
 			// Should not throw
 			const result = await handleDebuggingSpiral(match, '1.1', tempDir);
@@ -278,7 +264,7 @@ describe('handleDebuggingSpiral', () => {
 			expect(result.eventLogged).toBe(true);
 		});
 
-		test('does not throw when checkpoint returns invalid JSON', async () => {
+		test('does not throw when checkpoint returns invalid result', async () => {
 			const match: AdversarialPatternMatch = {
 				pattern: 'DEBUGGING_SPIRAL',
 				severity: 'HIGH',
@@ -286,8 +272,8 @@ describe('handleDebuggingSpiral', () => {
 				confidence: 'HIGH',
 			};
 
-			// Mock checkpoint to return invalid JSON
-			(checkpoint.execute as jest.Mock).mockResolvedValue('invalid json');
+			// Mock checkpoint to return undefined (falsy)
+			(saveCheckpointRecord as jest.Mock).mockReturnValue(null);
 
 			// Should not throw
 			const result = await handleDebuggingSpiral(match, '1.1', tempDir);
@@ -307,9 +293,9 @@ describe('handleDebuggingSpiral', () => {
 			};
 
 			// Both should fail
-			(checkpoint.execute as jest.Mock).mockRejectedValue(
-				new Error('Service unavailable'),
-			);
+			(saveCheckpointRecord as jest.Mock).mockImplementation(() => {
+				throw new Error('Service unavailable');
+			});
 
 			// Should not throw
 			const result = await handleDebuggingSpiral(match, '1.1', '/nonexistent');
@@ -330,14 +316,12 @@ describe('handleDebuggingSpiral', () => {
 				confidence: 'HIGH',
 			};
 
-			(checkpoint.execute as jest.Mock).mockResolvedValue(
-				JSON.stringify({ success: true }),
-			);
+			(saveCheckpointRecord as jest.Mock).mockReturnValue({ success: true });
 
 			await handleDebuggingSpiral(match, '5.7.1', tempDir);
 
-			const callArgs = (checkpoint.execute as jest.Mock).mock.calls[0];
-			const label = callArgs[0].label;
+			const callArgs = (saveCheckpointRecord as jest.Mock).mock.calls[0];
+			const label = callArgs[0];
 
 			// Check format: spiral-{taskId}-{timestamp}
 			expect(label).toMatch(/^spiral-5\.7\.1-\d+$/);
@@ -351,14 +335,12 @@ describe('handleDebuggingSpiral', () => {
 				confidence: 'HIGH',
 			};
 
-			(checkpoint.execute as jest.Mock).mockResolvedValue(
-				JSON.stringify({ success: true }),
-			);
+			(saveCheckpointRecord as jest.Mock).mockReturnValue({ success: true });
 
 			await handleDebuggingSpiral(match, '1.1', tempDir);
 
-			const callArgs = (checkpoint.execute as jest.Mock).mock.calls[0];
-			const label = callArgs[0].label;
+			const callArgs = (saveCheckpointRecord as jest.Mock).mock.calls[0];
+			const label = callArgs[0];
 			const timestampPart = label.split('-')[2];
 			const timestamp = parseInt(timestampPart, 10);
 
@@ -375,14 +357,12 @@ describe('handleDebuggingSpiral', () => {
 				confidence: 'HIGH',
 			};
 
-			(checkpoint.execute as jest.Mock).mockResolvedValue(
-				JSON.stringify({ success: true }),
-			);
+			(saveCheckpointRecord as jest.Mock).mockReturnValue({ success: true });
 
 			const result = await handleDebuggingSpiral(match, '3.2', tempDir);
 
-			const callArgs = (checkpoint.execute as jest.Mock).mock.calls[0];
-			const label = callArgs[0].label;
+			const callArgs = (saveCheckpointRecord as jest.Mock).mock.calls[0];
+			const label = callArgs[0];
 
 			expect(result.message).toContain(`✓ Auto-checkpoint created: ${label}`);
 		});
@@ -397,9 +377,7 @@ describe('handleDebuggingSpiral', () => {
 				confidence: 'MEDIUM',
 			};
 
-			(checkpoint.execute as jest.Mock).mockResolvedValue(
-				JSON.stringify({ success: true }),
-			);
+			(saveCheckpointRecord as jest.Mock).mockReturnValue({ success: true });
 
 			const result = await handleDebuggingSpiral(match, '5.7', tempDir);
 
@@ -425,7 +403,7 @@ describe('handleDebuggingSpiral', () => {
 			expect(event.taskId).toBe('5.7');
 
 			// Verify checkpoint was called
-			expect(checkpoint.execute).toHaveBeenCalledTimes(1);
+			expect(saveCheckpointRecord).toHaveBeenCalledTimes(1);
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Move SWARM_PLAN artifacts from project root to `.swarm/` directory with backward-compatible fallback
- Fix `/swarm reset --confirm` to also delete `plan.json`, `SWARM_PLAN.*`, `checkpoints.json`, `events.jsonl`, and legacy root-level SWARM_PLAN files (previously left behind, reported in #583)
- Add non-commit spiral detection checkpoint recording to prevent mid-flight git commits
- Extend platform-specific cache/lock file detection to macOS (Library/Caches) and Windows (LOCALAPPDATA/APPDATA)
- Evict lock files (bun.lock/package-lock.json) to force fresh npm resolution on plugin update/install

## Test plan
- [x] Typecheck passes (bun run typecheck)
- [x] Biome format passes (bunx biome ci .)
- [x] Reset command: 11 tests pass including 4 new tests for SWARM_PLAN/plan.json/checkpoints/events cleanup
- [x] Unit tests pass: cache-paths (9 pass), checkpoint (29 pass), hooks spiral-handler (14 pass)
- [x] Build succeeds and dist/ artifacts updated
- [x] Smoke tests pass (10 pass)
- [x] Single squashed commit

Note: Pre-existing test failures (439 in broader cli/commands suite) are documented and pre-date this branch — confirmed against v7.0.0 base.