### PR TITLE
fix(agents): restore multi-swarm primary architects after v7.3.x regression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ Every PR that touches a relevant area must list which of these invariants it tou
 - A tool addition is **incomplete** until: (a) export from `src/tools/index.ts`, (b) registration in the plugin `tool: {}` block in `src/index.ts`, (c) entry in `TOOL_NAMES` and `AGENT_TOOL_MAP` in `src/config/constants.ts`, (d) help/documentation surfaces, (e) tests covering the new entry.
 - Run `tests/unit/config/*.test.ts` and `/swarm doctor tools` after any tool, agent-map, command, or help change. See v6.48.0.
 - Parity assertions across sibling map entries are intentional. If a parity test fails, mirror the change to siblings (most common) or update the invariant test if the design intent has actually changed.
+- **Agent registration changes must test both legacy unprefixed AND multi-swarm prefixed agent names.** v7.3.x regression: a schema default on `default_agent` ("architect") combined with strict equality demoted every `*_architect` to subagent in multi-swarm configs, so OpenCode showed the plugin as loaded but no swarm architect agents appeared. Tests that only used legacy unprefixed `architect` missed the bug entirely. Any change to primary/subagent selection, `default_agent`, or `getAgentConfigs` MUST include a multi-swarm `swarms: { local: ..., mega: ... }` test that asserts at least one prefixed agent is `mode: 'primary'`.
 
 ### 12. Release / cache hygiene
 

--- a/README.md
+++ b/README.md
@@ -788,6 +788,17 @@ Prefixed agents (e.g., `paid_coder`, `mega_reviewer`, `local_architect`) inherit
 
 In this example, `paid_coder` gets its own explicit rule, while other prefixed coders (e.g., `mega_coder`) fall back to `coder`.
 
+#### Selecting the primary agent in multi-swarm configs (`default_agent`)
+
+The top-level `default_agent` field controls which generated agents OpenCode treats as primary. **It is optional.** Behavior:
+
+- **Omitted** — every architect-role agent is primary. In a multi-swarm config that means each swarm exposes its own architect (`local_architect`, `mega_architect`, `paid_architect`, `modelrelay_architect`, …) as a selectable session default. This is the v7.0.0-compatible behavior and the recommended setup.
+- **Base role** (e.g. `"coder"`) — every generated agent whose canonical base role matches becomes primary (`local_coder`, `mega_coder`, …).
+- **Exact generated name** (e.g. `"local_architect"`) — only that agent is primary.
+- **Unknown / invalid value** — a one-time warning is logged and the resolver falls back to architect-role primaries (or the first generated agent if architects are disabled). The plugin never produces zero primaries when at least one agent exists.
+
+See [`docs/configuration.md`](docs/configuration.md) for the full table.
+
 ### Runtime Enforcement
 
 Architect direct writes are enforced at runtime via `toolBefore` hook. This tracks writes to source code paths outside `.swarm/` and protects `.swarm/plan.md` and `.swarm/plan.json` from direct modification.

--- a/dist/agents/index.d.ts
+++ b/dist/agents/index.d.ts
@@ -35,6 +35,34 @@ export declare function getSwarmAgents(): Record<string, {
  */
 export declare function createAgents(config?: PluginConfig): AgentDefinition[];
 /**
+ * Resolve the set of generated agent names that should be marked as primary
+ * for OpenCode's session-default-agent resolution.
+ *
+ * Resolution rules (see schema.ts default_agent comment for full semantics):
+ *   - default_agent omitted ⇒ every architect-role agent is primary
+ *     (canonical base role === "architect"). This restores v7.0.0 behavior in
+ *     multi-swarm configs where there is no unprefixed `architect` agent.
+ *   - default_agent exactly matches a generated agent name ⇒ only that agent.
+ *     Exact match wins over base-role match — `local_architect` resolves to
+ *     just `local_architect`, never the entire architect role.
+ *   - default_agent is a base role in ALL_AGENT_NAMES ⇒ every generated agent
+ *     whose canonical base role matches that role.
+ *   - default_agent is invalid (matches nothing) ⇒ fall back to architect-role
+ *     primaries; if no architect roles exist (architects disabled), fall back
+ *     to the first generated agent. Always warns. Never returns empty when
+ *     `agentNames` is non-empty.
+ *
+ * Important matching detail: a value like "not_an_architect" is NOT treated
+ * as a base-role request even though stripKnownSwarmPrefix() returns
+ * "architect" for it. Base-role matching only fires when the user-supplied
+ * value is itself one of ALL_AGENT_NAMES.
+ */
+export declare function resolvePrimaryAgentNames(agentNames: string[], defaultAgent?: string): {
+    primaryNames: Set<string>;
+    reason: 'implicit-architects' | 'exact' | 'base-role' | 'fallback-architects' | 'fallback-first';
+    warning?: string;
+};
+/**
  * Get agent configurations formatted for the OpenCode SDK.
  */
 export declare function getAgentConfigs(config?: PluginConfig, directory?: string, sessionId?: string): Record<string, SDKAgentConfig>;

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.3.3",
+    version: "7.3.4",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -16933,7 +16933,12 @@ var init_schema = __esm(() => {
   });
   PluginConfigSchema = exports_external.object({
     agents: exports_external.record(exports_external.string(), AgentOverrideConfigSchema).optional(),
-    default_agent: exports_external.enum(ALL_AGENT_NAMES).default("architect").optional(),
+    default_agent: exports_external.string().optional().transform((v) => {
+      if (v === undefined)
+        return;
+      const trimmed = v.trim();
+      return trimmed === "" ? undefined : trimmed;
+    }),
     swarms: exports_external.record(exports_external.string(), SwarmConfigSchema).optional(),
     max_iterations: exports_external.number().min(1).max(10).default(5),
     pipeline: PipelineConfigSchema.optional(),

--- a/dist/config/schema.d.ts
+++ b/dist/config/schema.d.ts
@@ -643,26 +643,7 @@ export declare const PluginConfigSchema: z.ZodObject<{
         disabled: z.ZodOptional<z.ZodBoolean>;
         fallback_models: z.ZodOptional<z.ZodArray<z.ZodString>>;
     }, z.core.$strip>>>;
-    default_agent: z.ZodOptional<z.ZodDefault<z.ZodEnum<{
-        architect: "architect";
-        sme: "sme";
-        docs: "docs";
-        designer: "designer";
-        critic_sounding_board: "critic_sounding_board";
-        critic_drift_verifier: "critic_drift_verifier";
-        critic_hallucination_verifier: "critic_hallucination_verifier";
-        curator_init: "curator_init";
-        curator_phase: "curator_phase";
-        council_generalist: "council_generalist";
-        council_skeptic: "council_skeptic";
-        council_domain_expert: "council_domain_expert";
-        reviewer: "reviewer";
-        critic: "critic";
-        critic_oversight: "critic_oversight";
-        explorer: "explorer";
-        coder: "coder";
-        test_engineer: "test_engineer";
-    }>>>;
+    default_agent: z.ZodPipe<z.ZodOptional<z.ZodString>, z.ZodTransform<string | undefined, string | undefined>>;
     swarms: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{
         name: z.ZodOptional<z.ZodString>;
         agents: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.3.3",
+    version: "7.3.4",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -15370,7 +15370,12 @@ var init_schema = __esm(() => {
   });
   PluginConfigSchema = exports_external.object({
     agents: exports_external.record(exports_external.string(), AgentOverrideConfigSchema).optional(),
-    default_agent: exports_external.enum(ALL_AGENT_NAMES).default("architect").optional(),
+    default_agent: exports_external.string().optional().transform((v) => {
+      if (v === undefined)
+        return;
+      const trimmed = v.trim();
+      return trimmed === "" ? undefined : trimmed;
+    }),
     swarms: exports_external.record(exports_external.string(), SwarmConfigSchema).optional(),
     max_iterations: exports_external.number().min(1).max(10).default(5),
     pipeline: PipelineConfigSchema.optional(),
@@ -60004,6 +60009,52 @@ function createAgents(config3) {
   }
   return allAgents;
 }
+function resolvePrimaryAgentNames(agentNames, defaultAgent) {
+  const collectArchitectRole = () => agentNames.filter((n) => stripKnownSwarmPrefix(n) === "architect");
+  const trimmed = typeof defaultAgent === "string" ? defaultAgent.trim() : undefined;
+  const value = trimmed === "" ? undefined : trimmed;
+  if (agentNames.length === 0) {
+    return { primaryNames: new Set, reason: "implicit-architects" };
+  }
+  if (value === undefined) {
+    const architects2 = collectArchitectRole();
+    if (architects2.length > 0) {
+      return {
+        primaryNames: new Set(architects2),
+        reason: "implicit-architects"
+      };
+    }
+    const first2 = agentNames[0];
+    return {
+      primaryNames: new Set([first2]),
+      reason: "fallback-first",
+      warning: `[swarm] No architect-role agents are registered and default_agent is unset; falling back to '${first2}' as primary. Re-enable an architect agent or set default_agent to silence this warning.`
+    };
+  }
+  if (ALL_AGENT_NAMES.includes(value)) {
+    const matching = agentNames.filter((n) => stripKnownSwarmPrefix(n) === value);
+    if (matching.length > 0) {
+      return { primaryNames: new Set(matching), reason: "base-role" };
+    }
+  }
+  if (agentNames.includes(value)) {
+    return { primaryNames: new Set([value]), reason: "exact" };
+  }
+  const architects = collectArchitectRole();
+  if (architects.length > 0) {
+    return {
+      primaryNames: new Set(architects),
+      reason: "fallback-architects",
+      warning: `[swarm] default_agent '${value}' did not match any registered agent; falling back to architect-role primaries: ${architects.join(", ")}.`
+    };
+  }
+  const first = agentNames[0];
+  return {
+    primaryNames: new Set([first]),
+    reason: "fallback-first",
+    warning: `[swarm] default_agent '${value}' did not match any registered agent and no architect-role agents are registered; falling back to '${first}' as primary.`
+  };
+}
 function getAgentConfigs(config3, directory, sessionId) {
   const agents = createAgents(config3);
   const toolFilterEnabled = config3?.tool_filter?.enabled ?? true;
@@ -60011,21 +60062,29 @@ function getAgentConfigs(config3, directory, sessionId) {
   const quiet = config3?.quiet ?? true;
   const warnedMissingWhitelist = new Set;
   const agentToolSnapshot = {};
+  const resolution = resolvePrimaryAgentNames(agents.map((a) => a.name), config3?.default_agent);
+  if (resolution.warning) {
+    if (!quiet) {
+      console.warn(resolution.warning);
+    } else {
+      addDeferredWarning(resolution.warning);
+    }
+  }
+  if (agents.length > 0 && resolution.primaryNames.size === 0) {
+    const generated = agents.map((a) => a.name).join(", ");
+    const diagnostic = `[swarm] DIAGNOSTIC: ${agents.length} generated agents but zero primaries. Likely cause: a regression in resolvePrimaryAgentNames. Generated: ${generated}.`;
+    if (!quiet) {
+      console.warn(diagnostic);
+    } else {
+      addDeferredWarning(diagnostic);
+    }
+  }
   const result = Object.fromEntries(agents.map((agent) => {
     const sdkConfig = {
       ...agent.config,
       description: agent.description
     };
-    let defaultAgent = config3?.default_agent ?? "architect";
-    if (defaultAgent !== "architect" && !ALL_AGENT_NAMES.includes(defaultAgent)) {
-      if (!quiet) {
-        console.warn(`[swarm] Invalid default_agent '${defaultAgent}' — falling back to 'architect'. Valid values: ${ALL_AGENT_NAMES.join(", ")}`);
-      } else {
-        addDeferredWarning(`[swarm] Invalid default_agent '${defaultAgent}' — falling back to 'architect'. Valid values: ${ALL_AGENT_NAMES.join(", ")}`);
-      }
-      defaultAgent = "architect";
-    }
-    const isPrimaryAgent = agent.name === defaultAgent;
+    const isPrimaryAgent = resolution.primaryNames.has(agent.name);
     if (isPrimaryAgent) {
       sdkConfig.mode = "primary";
       sdkConfig.permission = { task: "allow" };

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,21 @@ If you currently have a config like `{ "model": "grove-openai/gpt-5.3-codex/medi
 }
 ```
 
+## `default_agent` — selecting which agents are exposed as primary
+
+`default_agent` (top-level, optional `string`) controls which generated agents OpenCode treats as **primary** (selectable as the session's default agent and given `task: allow` permission). All other generated agents become `subagent`s.
+
+| Value | Effect |
+|---|---|
+| _(omitted)_ | Every architect-role agent is primary. In a legacy single-swarm config that means `architect`. In a multi-swarm config it means `architect` (if a `default` swarm is defined) plus every `*_architect` (`local_architect`, `mega_architect`, `paid_architect`, `modelrelay_architect`, …). This restores v7.0.0 behavior. |
+| `"architect"` _(or any other base role)_ | Every generated agent whose canonical base role matches becomes primary. `default_agent: "coder"` exposes `coder` in legacy mode and every `*_coder` in multi-swarm mode. |
+| `"local_architect"` _(or any other exact generated name)_ | Only that exact generated agent becomes primary. Useful for pinning a single swarm. |
+| Unknown / invalid value | A one-time warning is logged and the resolver falls back to architect-role primaries (or, if all architect roles are disabled, the first generated agent). The plugin never produces zero primaries when at least one agent exists. |
+
+Empty or whitespace-only values are treated as omitted.
+
+> Why this matters: in v7.3.x the schema applied an implicit `.default("architect")`. In a multi-swarm config there is no agent literally named `architect` — they are all prefixed — so every architect was demoted to subagent and OpenCode showed only the native `build`/`plan` agents. The omitted-vs-explicit distinction is now load-bearing; do not re-introduce a schema default.
+
 ## How to verify the resolved config
 
 Run:

--- a/docs/releases/v7.3.5.md
+++ b/docs/releases/v7.3.5.md
@@ -1,0 +1,74 @@
+# v7.3.5 — Restore multi-swarm primary architects (no agents in TUI/GUI after v7.3.x)
+
+## What changed
+
+### Primary fix — multi-swarm `*_architect` agents are visible again
+
+After upgrading to v7.3.x, users with multi-swarm configs (`swarms: { local: …, mega: …, paid: …, modelrelay: … }`) reported that OpenCode showed the plugin as loaded but **no swarm architect agents appeared in the GUI/TUI** — only the native `build` and `plan` agents were selectable.
+
+The plugin was importing successfully, `server()` was returning 90 agents and 58 tools, and the config hook was injecting all 90 agents into `opencodeConfig.agent`. The injected agents were all prefixed (`mega_architect`, `paid_architect`, `lowtier_architect`, `modelrelay_architect`, `local_architect`, …). None of them were marked `mode: "primary"`, so OpenCode could not surface any of them as a selectable session default.
+
+Root cause:
+
+- v7.0.0 marked an agent primary if `agent.name === "architect"` **or** `agent.name.endsWith("_architect")`.
+- v7.3.x added `default_agent` with a `.default("architect")` schema default and switched to exact-string matching (`agent.name === defaultAgent`). In multi-swarm configs there is no agent literally named `architect` — they are all prefixed — so every architect was demoted to subagent.
+- Previous tests for `default_agent` only used the legacy unprefixed agent set, so the regression went undetected.
+
+Fix (no OpenCode-side changes; PR #735's Windows / plugin-loading hardening is preserved):
+
+- **`src/config/schema.ts`** — `default_agent` is now an optional string with no schema default, so omitted vs explicit `"architect"` are distinguishable. Empty / whitespace-only values normalize to `undefined`. Arbitrary strings parse without invalidating the entire plugin config; semantic validation now happens at agent-generation time.
+- **`src/agents/index.ts`** — new exported helper `resolvePrimaryAgentNames(agentNames, defaultAgent)` returns the set of generated agents that should be primary plus a `reason` tag and an optional `warning`. Resolution rules:
+  - Omitted ⇒ every architect-role agent (canonical base role `=== "architect"`) is primary. Restores v7.0.0 multi-swarm behavior.
+  - Exact generated-name match (e.g. `"local_architect"`) ⇒ only that agent.
+  - Base role in `ALL_AGENT_NAMES` (e.g. `"coder"`) ⇒ every generated agent whose canonical base role matches.
+  - Unknown / unmatched ⇒ warns once, falls back to architect-role primaries; if no architect role exists, falls back to the first generated agent. Never returns zero primaries when at least one agent exists.
+  - `"not_an_architect"` is **not** treated as a base-role request even though `stripKnownSwarmPrefix()` returns `"architect"` for it — base-role matching only fires when the literal user value is itself one of `ALL_AGENT_NAMES`.
+- **`src/agents/index.ts:getAgentConfigs`** — calls the resolver once after `createAgents(config)`, marks `mode: "primary"` for agents in the resolver's set (with `permission.task: "allow"` and `model` deleted as before), and `mode: "subagent"` otherwise. Tool-filter behavior, tool snapshots, council validation, prompt/model/variant logic, and existing swarm-prefix behavior are unchanged.
+- **Diagnostic invariant** — `getAgentConfigs` now emits a deferred warning if a non-empty generated agent set produces zero primaries (defense in depth against a future regression in the resolver). The check is non-blocking.
+
+### Tests
+
+- `tests/unit/config/default-agent-config.test.ts` — fully replaced. Removes the now-incorrect assertions that the schema rejects arbitrary strings and defaults `default_agent` to `"architect"`. Adds direct unit tests for `resolvePrimaryAgentNames` (every resolution branch, plus the `not_an_architect` matching guard) and end-to-end `getAgentConfigs` tests against **real multi-swarm configs**, not legacy unprefixed agents. Covers:
+  - omitted `default_agent` with prefixed-only swarms ⇒ every `*_architect` primary
+  - omitted `default_agent` with a `default` swarm + extras ⇒ `architect` AND every `*_architect` primary
+  - exact `default_agent: "local_architect"` ⇒ only `local_architect` primary
+  - base `default_agent: "architect"` ⇒ all generated architect-role agents primary
+  - exact `default_agent: "local_coder"` ⇒ only `local_coder` primary
+  - base `default_agent: "coder"` ⇒ every generated coder-role agent primary
+  - invalid `default_agent` ⇒ falls back to architect-role primaries
+  - all architects disabled + invalid `default_agent` ⇒ falls back to one primary, never zero
+  - schema accepts omitted/base-role/prefixed/arbitrary strings, normalizes whitespace
+- `tests/unit/config/schema.test.ts` — the "empty object applies defaults" test no longer expects `default_agent: "architect"` in the parsed output (the schema default was the proximate cause of the bug).
+- `tests/integration/config-hook-multi-swarm.test.ts` (new) — boots the plugin via `default.server(ctx)` against a temp project with a multi-swarm config, calls `hooks.config({})`, and asserts that `opencodeConfig.agent` contains prefixed primary architects. This is the exact path OpenCode exercises in production.
+
+## Why
+
+`AGENTS.md` invariant 11 (tool registration + agent-map coherence) now requires that any change to primary/subagent selection or `default_agent` test **both legacy unprefixed and multi-swarm prefixed agent names**. The v7.3.x test suite passed because it only used legacy single-swarm fixtures; the regression slipped past CI on every push between v7.3.0 and v7.3.4.
+
+## Migration steps
+
+No user action required. Existing configs without `default_agent` now resolve every `*_architect` to primary, restoring the v7.0.0-compatible multi-swarm experience. Configs that explicitly set `default_agent` to a base role or exact generated name continue to work and now also accept arbitrary strings without invalidating the entire config (semantic validation issues a warning and falls back to architect-role primaries instead).
+
+If you previously upgraded to v7.3.0–v7.3.4 and the plugin loaded but showed no swarm architect agents in the TUI/GUI: upgrade to v7.3.5 and run `bunx opencode-swarm update` to refresh OpenCode's plugin cache, then restart OpenCode.
+
+## Breaking changes
+
+None. `default_agent` accepts a strictly larger set of values than before; legacy explicit values (`"architect"`, `"coder"`, `"reviewer"`, etc.) keep working unchanged.
+
+## Known caveats
+
+- An invalid `default_agent` no longer causes the merged plugin config to fail Zod validation and trigger the `loadPluginConfig` safe-defaults fallback. Instead the resolver warns once and falls back to architect-role primaries. This is intentional — losing an entire user config because of a typo in `default_agent` was the wrong failure mode.
+
+## Invariant audit
+- 1 (plugin init):       not touched
+- 2 (runtime portability): not touched
+- 3 (subprocesses):       not touched
+- 4 (.swarm containment): not touched
+- 5 (plan durability):    not touched
+- 6 (test_runner safety): not touched
+- 7 (test writing):       touched — new tests use `bun:test`, real `swarms` fixtures (not legacy unprefixed agents), temp dirs via `os.tmpdir()` + `realpathSync`. `tests/unit/config/default-agent-config.test.ts` calls `mock.module('node:fs/promises', ...)` to stub the agent-tool-snapshot writer — this matches the existing convention in `tests/unit/tools/co-change-analyzer.adversarial.test.ts` and is covered by the per-file CI isolation loop. Evidence: `bun --smol test tests/unit/config/default-agent-config.test.ts tests/unit/config/schema.test.ts tests/integration/config-hook-multi-swarm.test.ts` all green; full `tests/unit/config` group: 1051 pass / 30 fail (all 30 pre-existing on `be21cf0` baseline; my changes net −1 failure).
+- 8 (session state):      not touched
+- 9 (guardrails/retry):   not touched
+- 10 (chat/system msg):   not touched
+- 11 (tool registration): touched — primary-vs-subagent selection rewritten via `resolvePrimaryAgentNames`. Multi-swarm coverage added (see test list above) and `AGENTS.md` invariant 11 amended to require both legacy unprefixed and multi-swarm prefixed test fixtures.
+- 12 (release/cache):     not touched — `package.json#version`, `CHANGELOG.md`, and `.release-please-manifest.json` were NOT manually edited. release-please owns those.

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -623,6 +623,119 @@ export function createAgents(config?: PluginConfig): AgentDefinition[] {
 }
 
 /**
+ * Resolve the set of generated agent names that should be marked as primary
+ * for OpenCode's session-default-agent resolution.
+ *
+ * Resolution rules (see schema.ts default_agent comment for full semantics):
+ *   - default_agent omitted ⇒ every architect-role agent is primary
+ *     (canonical base role === "architect"). This restores v7.0.0 behavior in
+ *     multi-swarm configs where there is no unprefixed `architect` agent.
+ *   - default_agent exactly matches a generated agent name ⇒ only that agent.
+ *     Exact match wins over base-role match — `local_architect` resolves to
+ *     just `local_architect`, never the entire architect role.
+ *   - default_agent is a base role in ALL_AGENT_NAMES ⇒ every generated agent
+ *     whose canonical base role matches that role.
+ *   - default_agent is invalid (matches nothing) ⇒ fall back to architect-role
+ *     primaries; if no architect roles exist (architects disabled), fall back
+ *     to the first generated agent. Always warns. Never returns empty when
+ *     `agentNames` is non-empty.
+ *
+ * Important matching detail: a value like "not_an_architect" is NOT treated
+ * as a base-role request even though stripKnownSwarmPrefix() returns
+ * "architect" for it. Base-role matching only fires when the user-supplied
+ * value is itself one of ALL_AGENT_NAMES.
+ */
+export function resolvePrimaryAgentNames(
+	agentNames: string[],
+	defaultAgent?: string,
+): {
+	primaryNames: Set<string>;
+	reason:
+		| 'implicit-architects'
+		| 'exact'
+		| 'base-role'
+		| 'fallback-architects'
+		| 'fallback-first';
+	warning?: string;
+} {
+	const collectArchitectRole = (): string[] =>
+		agentNames.filter((n) => stripKnownSwarmPrefix(n) === 'architect');
+
+	const trimmed =
+		typeof defaultAgent === 'string' ? defaultAgent.trim() : undefined;
+	const value = trimmed === '' ? undefined : trimmed;
+
+	if (agentNames.length === 0) {
+		return { primaryNames: new Set(), reason: 'implicit-architects' };
+	}
+
+	// Implicit: omitted default_agent ⇒ all architect-role agents.
+	if (value === undefined) {
+		const architects = collectArchitectRole();
+		if (architects.length > 0) {
+			return {
+				primaryNames: new Set(architects),
+				reason: 'implicit-architects',
+			};
+		}
+		// No architects at all (e.g. all disabled). Fall back to the first
+		// generated agent so OpenCode always has at least one primary. Warn.
+		const first = agentNames[0];
+		return {
+			primaryNames: new Set([first]),
+			reason: 'fallback-first',
+			warning: `[swarm] No architect-role agents are registered and default_agent is unset; falling back to '${first}' as primary. Re-enable an architect agent or set default_agent to silence this warning.`,
+		};
+	}
+
+	// Base-role match (preferred when the value is itself a canonical base
+	// role like "architect" / "coder"): mark every generated agent whose
+	// canonical base role matches. We deliberately do NOT call
+	// stripKnownSwarmPrefix on the user value — "not_an_architect" must not
+	// collapse to "architect". Putting base-role BEFORE exact-match here is
+	// load-bearing for the "default swarm + extra swarms + default_agent:
+	// 'architect'" case: the user expects all architect-role agents primary
+	// (including unprefixed `architect` AND every `*_architect`), not just the
+	// agent literally named "architect".
+	if ((ALL_AGENT_NAMES as readonly string[]).includes(value)) {
+		const matching = agentNames.filter(
+			(n) => stripKnownSwarmPrefix(n) === value,
+		);
+		if (matching.length > 0) {
+			return { primaryNames: new Set(matching), reason: 'base-role' };
+		}
+		// Known role but no generated agent for it (entire role disabled).
+		// Fall through to fallback so the user still gets a usable primary.
+	}
+
+	// Exact generated-name match: only fires when the value is NOT a base role
+	// in ALL_AGENT_NAMES (handled above), so this path serves prefixed names
+	// like "local_architect" / "paid_coder". `agentNames.includes(value)` is
+	// the literal-string match — no stripping — which is what the spec means
+	// by "exact generated-name matching".
+	if (agentNames.includes(value)) {
+		return { primaryNames: new Set([value]), reason: 'exact' };
+	}
+
+	// Invalid / unmatched: fall back to architect-role agents, or to the first
+	// generated agent if no architect role exists. Always warn.
+	const architects = collectArchitectRole();
+	if (architects.length > 0) {
+		return {
+			primaryNames: new Set(architects),
+			reason: 'fallback-architects',
+			warning: `[swarm] default_agent '${value}' did not match any registered agent; falling back to architect-role primaries: ${architects.join(', ')}.`,
+		};
+	}
+	const first = agentNames[0];
+	return {
+		primaryNames: new Set([first]),
+		reason: 'fallback-first',
+		warning: `[swarm] default_agent '${value}' did not match any registered agent and no architect-role agents are registered; falling back to '${first}' as primary.`,
+	};
+}
+
+/**
  * Get agent configurations formatted for the OpenCode SDK.
  */
 export function getAgentConfigs(
@@ -643,6 +756,32 @@ export function getAgentConfigs(
 	// Accumulate per-agent tool snapshot for evidence writing
 	const agentToolSnapshot: Record<string, string[]> = {};
 
+	// Resolve which agents are primary once, before mapping over agents.
+	const resolution = resolvePrimaryAgentNames(
+		agents.map((a) => a.name),
+		config?.default_agent,
+	);
+	if (resolution.warning) {
+		if (!quiet) {
+			console.warn(resolution.warning);
+		} else {
+			addDeferredWarning(resolution.warning);
+		}
+	}
+	// Diagnostic invariant: a non-empty generated agent set must produce at least
+	// one primary. resolvePrimaryAgentNames already guarantees this; this is a
+	// defense-in-depth check that surfaces a deferred warning if the invariant
+	// is ever violated by future changes. It must never block plugin startup.
+	if (agents.length > 0 && resolution.primaryNames.size === 0) {
+		const generated = agents.map((a) => a.name).join(', ');
+		const diagnostic = `[swarm] DIAGNOSTIC: ${agents.length} generated agents but zero primaries. Likely cause: a regression in resolvePrimaryAgentNames. Generated: ${generated}.`;
+		if (!quiet) {
+			console.warn(diagnostic);
+		} else {
+			addDeferredWarning(diagnostic);
+		}
+	}
+
 	const result = Object.fromEntries(
 		agents.map((agent) => {
 			const sdkConfig: SDKAgentConfig = {
@@ -650,28 +789,7 @@ export function getAgentConfigs(
 				description: agent.description,
 			};
 
-			// Apply mode based on agent type
-			// The default_agent config field controls which agent is set as primary mode.
-			// If not specified, 'architect' (or agents ending with '_architect') is primary by default.
-			// Other agents are subagents unless explicitly set as default_agent.
-			// Defensive fallback: if default_agent is set but invalid, fall back to 'architect'.
-			let defaultAgent = config?.default_agent ?? 'architect';
-			if (
-				defaultAgent !== 'architect' &&
-				!(ALL_AGENT_NAMES as readonly string[]).includes(defaultAgent)
-			) {
-				if (!quiet) {
-					console.warn(
-						`[swarm] Invalid default_agent '${defaultAgent}' — falling back to 'architect'. Valid values: ${ALL_AGENT_NAMES.join(', ')}`,
-					);
-				} else {
-					addDeferredWarning(
-						`[swarm] Invalid default_agent '${defaultAgent}' — falling back to 'architect'. Valid values: ${ALL_AGENT_NAMES.join(', ')}`,
-					);
-				}
-				defaultAgent = 'architect';
-			}
-			const isPrimaryAgent = agent.name === defaultAgent;
+			const isPrimaryAgent = resolution.primaryNames.has(agent.name);
 
 			if (isPrimaryAgent) {
 				sdkConfig.mode = 'primary';

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1135,9 +1135,35 @@ export const PluginConfigSchema = z.object({
 	agents: z.record(z.string(), AgentOverrideConfigSchema).optional(),
 
 	// Default agent — specifies which agent is set as primary mode.
-	// When not specified, 'architect' is the default primary agent.
-	// Valid values are restricted to known agent names via ALL_AGENT_NAMES enum.
-	default_agent: z.enum(ALL_AGENT_NAMES).default('architect').optional(),
+	//
+	// Semantics (resolved by resolvePrimaryAgentNames in src/agents/index.ts):
+	//   - Omitted: every generated *_architect role is primary (multi-swarm-aware,
+	//     restores v7.0.0 behavior — see #735 follow-up / v7.3.5).
+	//   - Exact generated name (e.g. "local_architect"): only that agent is primary.
+	//   - Base role name in ALL_AGENT_NAMES (e.g. "coder"): every generated agent
+	//     whose canonical base role matches is primary.
+	//   - Unknown / invalid string: warns once and falls back to architect-role
+	//     primaries (or the first generated agent if architects are disabled).
+	//
+	// Schema-level rules:
+	//   - The field MUST stay optional (no `.default(...)`) so omitted vs explicit
+	//     "architect" are distinguishable. The previous `.default("architect")` was
+	//     the root cause of all *_architect agents being demoted to subagents in
+	//     multi-swarm configs (issue: GUI/TUI showed plugin loaded but no swarm
+	//     architect agents).
+	//   - Accepts arbitrary strings here. Validation against the generated agent
+	//     set happens semantically at agent-generation time so an unknown value
+	//     does not invalidate the entire plugin config and trigger a fallback to
+	//     safe defaults.
+	//   - Empty / whitespace-only strings are normalized to `undefined`.
+	default_agent: z
+		.string()
+		.optional()
+		.transform((v) => {
+			if (v === undefined) return undefined;
+			const trimmed = v.trim();
+			return trimmed === '' ? undefined : trimmed;
+		}),
 
 	// Multiple swarms support
 	// Keys are swarm IDs (e.g., "cloud", "local", "fast")

--- a/tests/integration/config-hook-multi-swarm.test.ts
+++ b/tests/integration/config-hook-multi-swarm.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { realpathSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import OpenCodeSwarmPlugin from '../../src/index';
+
+/**
+ * Regression test (v7.3.5): plugin-side config hook must inject prefixed
+ * primary architects into opencodeConfig.agent for a multi-swarm config.
+ *
+ * Prior bug (v7.3.x):
+ *   - PluginConfigSchema applied .default("architect") to default_agent.
+ *   - getAgentConfigs() then performed strict equality `agent.name === "architect"`.
+ *   - In a multi-swarm config (no unprefixed `architect`), every *_architect
+ *     was demoted to subagent and OpenCode's TUI/GUI showed only the native
+ *     build/plan agents — "plugin loaded but no swarm architect agents".
+ *
+ * The fix removes the schema default, makes default_agent an optional string
+ * with semantic resolution at agent-generation time, and treats the omitted
+ * case as "every architect-role agent is primary".
+ */
+describe('plugin config hook — multi-swarm primary architect injection', () => {
+	let tempDir: string;
+
+	const ctxFor = (directory: string) => ({
+		client: {} as unknown,
+		project: {} as unknown,
+		directory,
+		worktree: directory,
+		serverUrl: new URL('http://localhost:3000'),
+		$: {} as unknown,
+	});
+
+	beforeEach(async () => {
+		// realpath wrapper to defang macOS /tmp -> /private/tmp symlink
+		tempDir = realpathSync(
+			await mkdtemp(path.join(tmpdir(), 'swarm-cfg-hook-')),
+		);
+	});
+
+	afterEach(async () => {
+		try {
+			await rm(tempDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	async function bootPlugin(swarmConfig: Record<string, unknown>) {
+		// loadPluginConfig reads from <directory>/.opencode/opencode-swarm.json
+		const opencodeDir = path.join(tempDir, '.opencode');
+		await mkdir(opencodeDir, { recursive: true });
+		await writeFile(
+			path.join(opencodeDir, 'opencode-swarm.json'),
+			JSON.stringify(swarmConfig, null, 2),
+		);
+		// New default export shape (post #735): { id, server }
+		const result = await (
+			OpenCodeSwarmPlugin as unknown as {
+				server: (ctx: ReturnType<typeof ctxFor>) => Promise<unknown>;
+			}
+		).server(ctxFor(tempDir));
+		return result as {
+			agent?: Record<string, { mode?: string }>;
+			config?: (oc: Record<string, unknown>) => Promise<void> | void;
+		};
+	}
+
+	test('top-level agent map exposes prefixed primary architects (no default_agent)', async () => {
+		const plugin = await bootPlugin({
+			version_check: false,
+			swarms: {
+				local: { name: 'Local', agents: { coder: { model: 'm-local' } } },
+				mega: { name: 'Mega', agents: { coder: { model: 'm-mega' } } },
+				paid: { name: 'Paid', agents: { coder: { model: 'm-paid' } } },
+				modelrelay: {
+					name: 'Modelrelay',
+					agents: { coder: { model: 'm-relay' } },
+				},
+			},
+		});
+
+		expect(plugin.agent).toBeDefined();
+		const agents = plugin.agent as Record<string, { mode?: string }>;
+
+		// Each *_architect must be primary.
+		for (const name of [
+			'local_architect',
+			'mega_architect',
+			'paid_architect',
+			'modelrelay_architect',
+		]) {
+			expect(agents[name], `${name} should exist`).toBeDefined();
+			expect(agents[name].mode, `${name} must be primary`).toBe('primary');
+		}
+
+		// At least one primary must exist (the regression-zeroing case).
+		const primaries = Object.values(agents).filter((a) => a.mode === 'primary');
+		expect(primaries.length).toBeGreaterThan(0);
+	});
+
+	test('config hook injects prefixed primary architects into opencodeConfig.agent', async () => {
+		const plugin = await bootPlugin({
+			version_check: false,
+			swarms: {
+				local: { name: 'Local', agents: { coder: { model: 'm-local' } } },
+				mega: { name: 'Mega', agents: { coder: { model: 'm-mega' } } },
+			},
+		});
+
+		expect(plugin.config).toBeTypeOf('function');
+		const opencodeConfig: Record<string, unknown> = {};
+		await plugin.config!(opencodeConfig);
+
+		const injected = opencodeConfig.agent as
+			| Record<string, { mode?: string }>
+			| undefined;
+		expect(injected).toBeDefined();
+		expect(injected!['local_architect']).toBeDefined();
+		expect(injected!['local_architect'].mode).toBe('primary');
+		expect(injected!['mega_architect']).toBeDefined();
+		expect(injected!['mega_architect'].mode).toBe('primary');
+	});
+
+	test('explicit default_agent: "local_architect" narrows primary to that one agent', async () => {
+		const plugin = await bootPlugin({
+			version_check: false,
+			default_agent: 'local_architect',
+			swarms: {
+				local: { name: 'Local', agents: { coder: { model: 'm-local' } } },
+				mega: { name: 'Mega', agents: { coder: { model: 'm-mega' } } },
+			},
+		});
+
+		const agents = plugin.agent as Record<string, { mode?: string }>;
+		expect(agents['local_architect'].mode).toBe('primary');
+		expect(agents['mega_architect'].mode).toBe('subagent');
+	});
+
+	test('invariant: any non-empty generated agent set has at least one primary', async () => {
+		// Sanity-check the diagnostic invariant against a config that previously
+		// produced zero primaries (the v7.3.x bug).
+		const plugin = await bootPlugin({
+			version_check: false,
+			swarms: {
+				local: { name: 'Local', agents: { coder: { model: 'm-local' } } },
+				mega: { name: 'Mega', agents: { coder: { model: 'm-mega' } } },
+				paid: { name: 'Paid', agents: { coder: { model: 'm-paid' } } },
+				modelrelay: {
+					name: 'Modelrelay',
+					agents: { coder: { model: 'm-relay' } },
+				},
+				lowtier: {
+					name: 'Lowtier',
+					agents: { coder: { model: 'm-low' } },
+				},
+			},
+		});
+		const agents = plugin.agent as Record<string, { mode?: string }>;
+		expect(Object.keys(agents).length).toBeGreaterThan(0);
+		const primaries = Object.values(agents).filter((a) => a.mode === 'primary');
+		expect(primaries.length).toBeGreaterThan(0);
+	});
+});

--- a/tests/unit/config/default-agent-config.test.ts
+++ b/tests/unit/config/default-agent-config.test.ts
@@ -1,306 +1,446 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
-import { getAgentConfigs } from '../../../src/agents/index';
+import {
+	getAgentConfigs,
+	resolvePrimaryAgentNames,
+} from '../../../src/agents/index';
 import { PluginConfigSchema } from '../../../src/config/schema';
 
-// Mock the fs/promises module to avoid file system operations in getAgentConfigs
-// The agent tool snapshot writing calls mkdir + writeFile
+// Mock node:fs/promises to avoid the agent-tool snapshot writer touching disk.
 mock.module('node:fs/promises', () => ({
 	mkdir: mock(() => Promise.resolve()),
 	writeFile: mock(() => Promise.resolve()),
 }));
 
-describe('PluginConfigSchema — default_agent field', () => {
-	describe('acceptance and validation', () => {
-		test('accepts valid default_agent value', () => {
-			const result = PluginConfigSchema.safeParse({
-				default_agent: 'coder',
-			});
-			expect(result.success).toBe(true);
-			if (result.success) {
-				expect(result.data.default_agent).toBe('coder');
-			}
-		});
-
-		test('accepts all valid agent names as default_agent', () => {
-			const validAgents = [
-				'architect',
-				'coder',
-				'reviewer',
-				'test_engineer',
-				'explorer',
-				'critic',
-				'sme',
-				'docs',
-				'designer',
-			];
-
-			for (const agent of validAgents) {
-				const result = PluginConfigSchema.safeParse({
-					default_agent: agent,
-				});
-				expect(result.success, `${agent} should be valid`).toBe(true);
-			}
-		});
-
-		test('accepts empty object (backward compatibility)', () => {
-			const result = PluginConfigSchema.safeParse({});
-			expect(result.success).toBe(true);
-		});
-
-		test('accepts null/undefined default_agent (treated as missing)', () => {
-			// default_agent is optional, so undefined is fine
-			const result = PluginConfigSchema.safeParse({
-				default_agent: undefined,
-			});
-			expect(result.success).toBe(true);
-		});
-
-		test('rejects invalid default_agent value', () => {
-			// Invalid values like 'foo' should be rejected by the schema
-			const result = PluginConfigSchema.safeParse({
-				default_agent: 'foo',
-			});
-			expect(result.success).toBe(false);
-		});
-
-		test('rejects arbitrary string as default_agent', () => {
-			const result = PluginConfigSchema.safeParse({
-				default_agent: 'nonexistent',
-			});
-			expect(result.success).toBe(false);
-		});
-	});
-
-	describe('default value', () => {
-		test('defaults to architect when not specified', () => {
-			const result = PluginConfigSchema.safeParse({});
-			expect(result.success).toBe(true);
-			if (result.success) {
-				// The .default('architect') ensures this
-				expect(result.data.default_agent).toBe('architect');
-			}
-		});
-
-		test('explicit architect value is accepted', () => {
-			const result = PluginConfigSchema.safeParse({
-				default_agent: 'architect',
-			});
-			expect(result.success).toBe(true);
-			if (result.success) {
-				expect(result.data.default_agent).toBe('architect');
-			}
-		});
-	});
-});
-
-describe('getAgentConfigs — primary mode based on default_agent', () => {
-	beforeEach(() => {
-		// Reset any module state if needed
-	});
-
-	describe('architect as default primary when default_agent not specified', () => {
-		test('sets architect to primary mode when default_agent absent', () => {
-			const config: Record<string, unknown> = {};
-			const result = getAgentConfigs(config as any);
-
-			// architect should be primary
-			expect(result['architect']).toBeDefined();
-			expect(result['architect'].mode).toBe('primary');
-
-			// other agents should be subagents
-			expect(result['coder'].mode).toBe('subagent');
-			expect(result['reviewer'].mode).toBe('subagent');
-			expect(result['test_engineer'].mode).toBe('subagent');
-			expect(result['explorer'].mode).toBe('subagent');
-		});
-
-		test('sets architect to primary mode when default_agent is architect', () => {
-			const config = { default_agent: 'architect' };
-			const result = getAgentConfigs(config as any);
-
-			expect(result['architect'].mode).toBe('primary');
-			expect(result['coder'].mode).toBe('subagent');
-		});
-	});
-
-	describe('specified agent as primary when default_agent is set', () => {
-		test('sets coder as primary when default_agent is coder', () => {
-			const config = { default_agent: 'coder' };
-			const result = getAgentConfigs(config as any);
-
-			expect(result['architect'].mode).toBe('subagent');
-			expect(result['coder'].mode).toBe('primary');
-			expect(result['reviewer'].mode).toBe('subagent');
-		});
-
-		test('sets reviewer as primary when default_agent is reviewer', () => {
-			const config = { default_agent: 'reviewer' };
-			const result = getAgentConfigs(config as any);
-
-			expect(result['architect'].mode).toBe('subagent');
-			expect(result['coder'].mode).toBe('subagent');
-			expect(result['reviewer'].mode).toBe('primary');
-		});
-
-		test('sets test_engineer as primary when default_agent is test_engineer', () => {
-			const config = { default_agent: 'test_engineer' };
-			const result = getAgentConfigs(config as any);
-
-			expect(result['architect'].mode).toBe('subagent');
-			expect(result['test_engineer'].mode).toBe('primary');
-		});
-
-		test('sets explorer as primary when default_agent is explorer', () => {
-			const config = { default_agent: 'explorer' };
-			const result = getAgentConfigs(config as any);
-
-			expect(result['architect'].mode).toBe('subagent');
-			expect(result['explorer'].mode).toBe('primary');
-		});
-	});
-
-	describe('primary agent permission handling', () => {
-		test('primary agent has task:allow permission', () => {
-			const config = { default_agent: 'coder' };
-			const result = getAgentConfigs(config as any);
-
-			// Primary agent should have task permission
-			expect(result['coder'].permission).toEqual({ task: 'allow' });
-		});
-
-		test('subagent does not have task:allow permission', () => {
-			const config = { default_agent: 'coder' };
-			const result = getAgentConfigs(config as any);
-
-			// Subagent should not have task permission
-			expect(result['architect'].permission).toBeUndefined();
-		});
-
-		test('primary agent has no model (orchestrator selects)', () => {
-			const config = { default_agent: 'architect' };
-			const result = getAgentConfigs(config as any);
-
-			// Primary agent should have model deleted (orchestrator handles model selection)
-			expect(result['architect'].model).toBeUndefined();
-		});
-	});
-
-	describe('backward compatibility', () => {
-		test('existing config without default_agent still works', () => {
-			// Simulate existing config that was used before default_agent was added
-			const existingConfig = {
-				agents: {
-					coder: { model: 'opencode/gpt-5' },
-					reviewer: { model: 'opencode/gpt-5' },
-				},
-				max_iterations: 5,
-				execution_mode: 'balanced' as const,
-			};
-
-			const result = getAgentConfigs(existingConfig as any);
-
-			// Should still work and architect should be primary
-			expect(result['architect'].mode).toBe('primary');
-			expect(result['coder'].mode).toBe('subagent');
-			expect(result['reviewer'].mode).toBe('subagent');
-		});
-
-		test('minimal empty config defaults to architect as primary', () => {
-			const result = getAgentConfigs({} as any);
-
-			expect(result['architect'].mode).toBe('primary');
-		});
-
-		test('undefined config still works', () => {
-			const result = getAgentConfigs(undefined);
-
-			expect(result['architect'].mode).toBe('primary');
-			expect(result['coder'].mode).toBe('subagent');
-		});
-	});
-
-	describe('agent name matching with prefixes', () => {
-		test('handles prefixed agent names (cloud_coder)', () => {
-			// When using swarms, agents can have prefixes like 'cloud_coder'
-			// The default_agent matching should handle this via endsWith check
-			const config = { default_agent: 'coder' };
-			const result = getAgentConfigs(config as any);
-
-			// The coder agent name 'coder' should match default_agent 'coder'
-			expect(result['coder'].mode).toBe('primary');
-		});
-
-		test('handles hyphenated agent names (cloud-coder)', () => {
-			// Hyphe nation separators are also supported
-			const config = { default_agent: 'coder' };
-			const result = getAgentConfigs(config as any);
-
-			// The matching logic checks endsWith(`_${defaultAgent}`) and endsWith(`-${defaultAgent}`)
-			expect(result['coder'].mode).toBe('primary');
-		});
-	});
-
-	describe('invalid default_agent fallback', () => {
-		test('falls back to architect when default_agent is invalid string', () => {
-			// An invalid default_agent like 'foo' should not cause all agents to be subagents
-			// Instead, it should fall back to architect being primary
-			const config = { default_agent: 'foo' } as any;
-			const result = getAgentConfigs(config);
-
-			// architect should be primary due to fallback
-			expect(result['architect'].mode).toBe('primary');
-			// all other agents should be subagents
-			expect(result['coder'].mode).toBe('subagent');
-			expect(result['reviewer'].mode).toBe('subagent');
-			expect(result['test_engineer'].mode).toBe('subagent');
-			expect(result['explorer'].mode).toBe('subagent');
-		});
-
-		test('falls back to architect when default_agent is arbitrary unknown value', () => {
-			const config = { default_agent: 'nonexistent_agent_xyz' } as any;
-			const result = getAgentConfigs(config);
-
-			// Should still have exactly one primary agent (architect)
-			const primaryAgents = Object.values(result).filter(
-				(a) => a.mode === 'primary',
-			);
-			expect(primaryAgents).toHaveLength(1);
-			expect(result['architect'].mode).toBe('primary');
-		});
-	});
-});
-
-describe('Integration: Schema validation + getAgentConfigs', () => {
-	test('parsed schema value flows correctly to getAgentConfigs', () => {
-		const input = {
-			default_agent: 'reviewer',
-			agents: {
-				coder: { model: 'opencode/gpt-5' },
+// ─── Helper: build a multi-swarm PluginConfig ──────────────────────────────
+function multiSwarmConfig(extra: Record<string, unknown> = {}) {
+	return {
+		swarms: {
+			local: { name: 'Local', agents: { coder: { model: 'm-local' } } },
+			mega: { name: 'Mega', agents: { coder: { model: 'm-mega' } } },
+			paid: { name: 'Paid', agents: { coder: { model: 'm-paid' } } },
+			modelrelay: {
+				name: 'Modelrelay',
+				agents: { coder: { model: 'm-relay' } },
 			},
-		};
+		},
+		...extra,
+	} as Record<string, unknown>;
+}
 
-		const parsed = PluginConfigSchema.safeParse(input);
-		expect(parsed.success).toBe(true);
+function multiSwarmWithDefaultConfig(extra: Record<string, unknown> = {}) {
+	return {
+		swarms: {
+			default: {
+				name: 'Default',
+				agents: { coder: { model: 'm-default' } },
+			},
+			local: { name: 'Local', agents: { coder: { model: 'm-local' } } },
+			mega: { name: 'Mega', agents: { coder: { model: 'm-mega' } } },
+		},
+		...extra,
+	} as Record<string, unknown>;
+}
 
-		if (parsed.success) {
-			const result = getAgentConfigs(parsed.data);
-			expect(result['reviewer'].mode).toBe('primary');
-			expect(result['architect'].mode).toBe('subagent');
+// ─── Schema semantics ──────────────────────────────────────────────────────
+
+describe('PluginConfigSchema — default_agent field (post-v7.3.5 semantics)', () => {
+	test('omitted default_agent is preserved as undefined (no schema default)', () => {
+		const result = PluginConfigSchema.safeParse({});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			// CRITICAL regression: previously schema applied .default("architect").
+			// That default broke multi-swarm configs because no agent in those
+			// configs is literally named "architect" — they are all prefixed.
+			expect(result.data.default_agent).toBeUndefined();
 		}
 	});
 
-	test('schema default flows to getAgentConfigs primary selection', () => {
-		const input = {};
+	test('explicit "architect" is preserved (distinct from omitted)', () => {
+		const result = PluginConfigSchema.safeParse({ default_agent: 'architect' });
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.default_agent).toBe('architect');
+	});
 
-		const parsed = PluginConfigSchema.safeParse(input);
-		expect(parsed.success).toBe(true);
-
-		if (parsed.success) {
-			// parsed.data.default_agent should be 'architect' due to schema default
-			expect(parsed.data.default_agent).toBe('architect');
-
-			const result = getAgentConfigs(parsed.data);
-			expect(result['architect'].mode).toBe('primary');
+	test('accepts base role names (coder, reviewer, explorer, test_engineer)', () => {
+		for (const v of ['coder', 'reviewer', 'explorer', 'test_engineer']) {
+			const r = PluginConfigSchema.safeParse({ default_agent: v });
+			expect(r.success, `${v} should parse`).toBe(true);
+			if (r.success) expect(r.data.default_agent).toBe(v);
 		}
+	});
+
+	test('accepts prefixed/generated agent names (local_architect, paid_coder, modelrelay_reviewer)', () => {
+		for (const v of [
+			'local_architect',
+			'mega_architect',
+			'paid_coder',
+			'modelrelay_reviewer',
+		]) {
+			const r = PluginConfigSchema.safeParse({ default_agent: v });
+			expect(r.success, `${v} should parse`).toBe(true);
+			if (r.success) expect(r.data.default_agent).toBe(v);
+		}
+	});
+
+	test('does not reject arbitrary strings at parse time (semantic validation only)', () => {
+		// Previously the schema rejected anything not in the enum, which made an
+		// invalid default_agent invalidate the entire plugin config and trigger
+		// the loader's safe-defaults fallback. Now the schema accepts arbitrary
+		// strings and the resolver issues a warning + falls back at agent-gen.
+		const r = PluginConfigSchema.safeParse({
+			default_agent: 'not_a_real_agent',
+		});
+		expect(r.success).toBe(true);
+		if (r.success) expect(r.data.default_agent).toBe('not_a_real_agent');
+	});
+
+	test('treats whitespace-only / empty default_agent as omitted', () => {
+		for (const v of ['', '   ', '\t', '\n']) {
+			const r = PluginConfigSchema.safeParse({ default_agent: v });
+			expect(r.success, `'${v}' should parse`).toBe(true);
+			if (r.success) expect(r.data.default_agent).toBeUndefined();
+		}
+	});
+});
+
+// ─── Resolver: resolvePrimaryAgentNames ────────────────────────────────────
+
+describe('resolvePrimaryAgentNames', () => {
+	test('omitted ⇒ all architect-role agents are primary (multi-swarm)', () => {
+		const names = [
+			'local_architect',
+			'mega_architect',
+			'paid_coder',
+			'local_coder',
+		];
+		const r = resolvePrimaryAgentNames(names);
+		expect(r.reason).toBe('implicit-architects');
+		expect([...r.primaryNames].sort()).toEqual([
+			'local_architect',
+			'mega_architect',
+		]);
+		expect(r.warning).toBeUndefined();
+	});
+
+	test('omitted with single legacy architect ⇒ that architect is primary', () => {
+		const r = resolvePrimaryAgentNames(['architect', 'coder', 'reviewer']);
+		expect(r.reason).toBe('implicit-architects');
+		expect([...r.primaryNames]).toEqual(['architect']);
+	});
+
+	test('exact generated-name match wins over base role for prefixed names', () => {
+		// "local_architect" is NOT a base role (not in ALL_AGENT_NAMES), so the
+		// resolver hits the exact-match branch.
+		const names = ['local_architect', 'mega_architect', 'paid_architect'];
+		const r = resolvePrimaryAgentNames(names, 'local_architect');
+		expect(r.reason).toBe('exact');
+		expect([...r.primaryNames]).toEqual(['local_architect']);
+	});
+
+	test('base role "architect" beats exact match when both are present (default swarm + extras)', () => {
+		// Subtle: when the user passes "architect" AND there is a literal
+		// "architect" agent registered AND there are *_architect agents, the
+		// spec requires ALL architect-role agents to be primary (not just the
+		// unprefixed one). "architect" is in ALL_AGENT_NAMES, so the resolver
+		// takes the base-role branch first.
+		const names = ['architect', 'local_architect', 'mega_architect', 'coder'];
+		const r = resolvePrimaryAgentNames(names, 'architect');
+		expect(r.reason).toBe('base-role');
+		expect([...r.primaryNames].sort()).toEqual([
+			'architect',
+			'local_architect',
+			'mega_architect',
+		]);
+	});
+
+	test('base role "architect" ⇒ all architect-role agents primary', () => {
+		const names = [
+			'local_architect',
+			'mega_architect',
+			'local_coder',
+			'mega_coder',
+		];
+		const r = resolvePrimaryAgentNames(names, 'architect');
+		expect(r.reason).toBe('base-role');
+		expect([...r.primaryNames].sort()).toEqual([
+			'local_architect',
+			'mega_architect',
+		]);
+	});
+
+	test('base role "coder" ⇒ all coder-role agents primary in multi-swarm', () => {
+		const names = [
+			'local_architect',
+			'local_coder',
+			'mega_coder',
+			'paid_coder',
+		];
+		const r = resolvePrimaryAgentNames(names, 'coder');
+		expect(r.reason).toBe('base-role');
+		expect([...r.primaryNames].sort()).toEqual([
+			'local_coder',
+			'mega_coder',
+			'paid_coder',
+		]);
+	});
+
+	test('arbitrary "not_an_architect" is NOT treated as base-role architect', () => {
+		// Important matching detail from the spec: stripKnownSwarmPrefix returns
+		// "architect" for a name ending in "_architect", but the literal user
+		// value here is not in ALL_AGENT_NAMES, so it must fall back rather
+		// than match the architect role.
+		const names = ['local_architect', 'mega_architect', 'local_coder'];
+		const r = resolvePrimaryAgentNames(names, 'not_an_architect');
+		// Falls back to architect-role agents and emits a warning.
+		expect(r.reason).toBe('fallback-architects');
+		expect(r.warning).toBeDefined();
+		expect([...r.primaryNames].sort()).toEqual([
+			'local_architect',
+			'mega_architect',
+		]);
+	});
+
+	test('invalid default_agent ⇒ warns and falls back to architect-role primaries', () => {
+		const names = ['local_architect', 'local_coder'];
+		const r = resolvePrimaryAgentNames(names, 'totally_made_up_xyz');
+		expect(r.reason).toBe('fallback-architects');
+		expect(r.warning).toMatch(/totally_made_up_xyz/);
+		expect([...r.primaryNames]).toEqual(['local_architect']);
+	});
+
+	test('no architects + invalid default_agent ⇒ first agent primary, warns', () => {
+		const names = ['local_coder', 'mega_coder'];
+		const r = resolvePrimaryAgentNames(names, 'totally_made_up');
+		expect(r.reason).toBe('fallback-first');
+		expect(r.warning).toMatch(/local_coder/);
+		expect([...r.primaryNames]).toEqual(['local_coder']);
+	});
+
+	test('no architects + omitted default_agent ⇒ first agent primary, warns', () => {
+		const r = resolvePrimaryAgentNames(['local_coder', 'mega_coder']);
+		expect(r.reason).toBe('fallback-first');
+		expect(r.warning).toMatch(/local_coder/);
+		expect([...r.primaryNames]).toEqual(['local_coder']);
+	});
+
+	test('whitespace default_agent treated as omitted', () => {
+		const r = resolvePrimaryAgentNames(
+			['local_architect', 'local_coder'],
+			'  ',
+		);
+		expect(r.reason).toBe('implicit-architects');
+		expect([...r.primaryNames]).toEqual(['local_architect']);
+	});
+
+	test('empty agent list ⇒ empty primaries (no crash)', () => {
+		const r = resolvePrimaryAgentNames([], 'architect');
+		expect(r.primaryNames.size).toBe(0);
+	});
+});
+
+// ─── getAgentConfigs end-to-end ────────────────────────────────────────────
+
+describe('getAgentConfigs — primary mode resolution', () => {
+	beforeEach(() => {
+		// no-op, kept for symmetry with prior file
+	});
+	afterEach(() => {});
+
+	describe('legacy single-swarm', () => {
+		test('undefined config ⇒ unprefixed architect primary', () => {
+			const r = getAgentConfigs(undefined);
+			expect(r['architect'].mode).toBe('primary');
+			expect(r['coder'].mode).toBe('subagent');
+			expect(r['reviewer'].mode).toBe('subagent');
+			expect(r['test_engineer'].mode).toBe('subagent');
+		});
+
+		test('empty config ⇒ unprefixed architect primary', () => {
+			expect(getAgentConfigs({} as never)['architect'].mode).toBe('primary');
+		});
+
+		test('legacy config with agents only ⇒ architect primary', () => {
+			const cfg = {
+				agents: { coder: { model: 'opencode/gpt-5' } },
+				max_iterations: 5,
+				execution_mode: 'balanced',
+			} as never;
+			const r = getAgentConfigs(cfg);
+			expect(r['architect'].mode).toBe('primary');
+			expect(r['coder'].mode).toBe('subagent');
+		});
+
+		test('default_agent: "coder" ⇒ coder primary', () => {
+			const r = getAgentConfigs({ default_agent: 'coder' } as never);
+			expect(r['architect'].mode).toBe('subagent');
+			expect(r['coder'].mode).toBe('primary');
+			expect(r['coder'].permission).toEqual({ task: 'allow' });
+		});
+
+		test('default_agent: "reviewer" ⇒ reviewer primary', () => {
+			const r = getAgentConfigs({ default_agent: 'reviewer' } as never);
+			expect(r['architect'].mode).toBe('subagent');
+			expect(r['reviewer'].mode).toBe('primary');
+		});
+	});
+
+	describe('multi-swarm (the bug surface)', () => {
+		test('only prefixed swarms, no default_agent ⇒ every *_architect is primary', () => {
+			const r = getAgentConfigs(multiSwarmConfig() as never);
+			// Each swarm registers its own architect under a prefix.
+			expect(r['local_architect'].mode).toBe('primary');
+			expect(r['mega_architect'].mode).toBe('primary');
+			expect(r['paid_architect'].mode).toBe('primary');
+			expect(r['modelrelay_architect'].mode).toBe('primary');
+			// Coders are subagents.
+			expect(r['local_coder'].mode).toBe('subagent');
+			expect(r['mega_coder'].mode).toBe('subagent');
+			// There is no unprefixed architect agent in this config.
+			expect(r['architect']).toBeUndefined();
+		});
+
+		test('regression: at least one primary agent exists when only prefixed swarms (no default)', () => {
+			const r = getAgentConfigs(multiSwarmConfig() as never);
+			const primaries = Object.entries(r).filter(
+				([, v]) => v.mode === 'primary',
+			);
+			// Previous v7.3.x bug zeroed this out — no agent was primary because
+			// PluginConfigSchema defaulted default_agent to "architect" and no
+			// agent literally named "architect" existed.
+			expect(primaries.length).toBeGreaterThan(0);
+		});
+
+		test('default swarm + extra swarms, no default_agent ⇒ architect AND every *_architect primary', () => {
+			const r = getAgentConfigs(multiSwarmWithDefaultConfig() as never);
+			expect(r['architect'].mode).toBe('primary');
+			expect(r['local_architect'].mode).toBe('primary');
+			expect(r['mega_architect'].mode).toBe('primary');
+			expect(r['local_coder'].mode).toBe('subagent');
+		});
+
+		test('default_agent: "local_architect" ⇒ only local_architect primary', () => {
+			const r = getAgentConfigs(
+				multiSwarmConfig({ default_agent: 'local_architect' }) as never,
+			);
+			expect(r['local_architect'].mode).toBe('primary');
+			expect(r['mega_architect'].mode).toBe('subagent');
+			expect(r['paid_architect'].mode).toBe('subagent');
+			expect(r['modelrelay_architect'].mode).toBe('subagent');
+		});
+
+		test('default_agent: "architect" ⇒ all generated architect-role agents primary', () => {
+			const r = getAgentConfigs(
+				multiSwarmConfig({ default_agent: 'architect' }) as never,
+			);
+			expect(r['local_architect'].mode).toBe('primary');
+			expect(r['mega_architect'].mode).toBe('primary');
+			expect(r['paid_architect'].mode).toBe('primary');
+			expect(r['modelrelay_architect'].mode).toBe('primary');
+			expect(r['local_coder'].mode).toBe('subagent');
+		});
+
+		test('default_agent: "architect" with default swarm + extras ⇒ unprefixed AND all *_architect primary', () => {
+			// Tests the base-role-beats-exact-match ordering when both forms of
+			// architect agent exist in the same plugin config.
+			const r = getAgentConfigs(
+				multiSwarmWithDefaultConfig({ default_agent: 'architect' }) as never,
+			);
+			expect(r['architect'].mode).toBe('primary');
+			expect(r['local_architect'].mode).toBe('primary');
+			expect(r['mega_architect'].mode).toBe('primary');
+			expect(r['local_coder'].mode).toBe('subagent');
+		});
+
+		test('default_agent: "local_coder" ⇒ only local_coder primary', () => {
+			const r = getAgentConfigs(
+				multiSwarmConfig({ default_agent: 'local_coder' }) as never,
+			);
+			expect(r['local_coder'].mode).toBe('primary');
+			expect(r['mega_coder'].mode).toBe('subagent');
+			expect(r['local_architect'].mode).toBe('subagent');
+		});
+
+		test('default_agent: "coder" ⇒ all generated coder-role agents primary', () => {
+			const r = getAgentConfigs(
+				multiSwarmConfig({ default_agent: 'coder' }) as never,
+			);
+			expect(r['local_coder'].mode).toBe('primary');
+			expect(r['mega_coder'].mode).toBe('primary');
+			expect(r['paid_coder'].mode).toBe('primary');
+			expect(r['modelrelay_coder'].mode).toBe('primary');
+			expect(r['local_architect'].mode).toBe('subagent');
+		});
+
+		test('invalid default_agent in multi-swarm ⇒ falls back to architect-role agents', () => {
+			const r = getAgentConfigs(
+				multiSwarmConfig({ default_agent: 'totally_invalid_xyz' }) as never,
+			);
+			expect(r['local_architect'].mode).toBe('primary');
+			expect(r['mega_architect'].mode).toBe('primary');
+			expect(r['paid_architect'].mode).toBe('primary');
+			expect(r['modelrelay_architect'].mode).toBe('primary');
+			// Did not zero out primaries.
+			const primaries = Object.values(r).filter((c) => c.mode === 'primary');
+			expect(primaries.length).toBeGreaterThan(0);
+		});
+
+		test('all architects disabled + invalid default_agent ⇒ falls back to one primary, never zero', () => {
+			const cfg = {
+				swarms: {
+					local: {
+						name: 'Local',
+						agents: {
+							architect: { disabled: true },
+							coder: { model: 'm' },
+						},
+					},
+					mega: {
+						name: 'Mega',
+						agents: {
+							architect: { disabled: true },
+							coder: { model: 'm' },
+						},
+					},
+				},
+				default_agent: 'made_up_xyz',
+			} as never;
+			const r = getAgentConfigs(cfg);
+			const primaries = Object.entries(r).filter(
+				([, v]) => v.mode === 'primary',
+			);
+			expect(primaries.length).toBeGreaterThanOrEqual(1);
+			expect(r['local_architect']).toBeUndefined();
+			expect(r['mega_architect']).toBeUndefined();
+		});
+	});
+
+	describe('primary agent permissions and model handling', () => {
+		test('primary has task:allow and no model; subagents retain model', () => {
+			const r = getAgentConfigs({ default_agent: 'coder' } as never);
+			expect(r['coder'].permission).toEqual({ task: 'allow' });
+			expect(r['coder'].model).toBeUndefined();
+			// architect (subagent now) keeps its model field untouched
+			expect(r['architect'].permission).toBeUndefined();
+		});
+
+		test('multi-swarm primary architects have permission set; subagent coders do not', () => {
+			const r = getAgentConfigs(multiSwarmConfig() as never);
+			expect(r['local_architect'].permission).toEqual({ task: 'allow' });
+			expect(r['mega_architect'].permission).toEqual({ task: 'allow' });
+			expect(r['local_coder'].permission).toBeUndefined();
+		});
+	});
+
+	describe('integration: schema parse → resolver', () => {
+		test('parsed schema flows to resolver, omitted default_agent stays undefined', () => {
+			const parsed = PluginConfigSchema.safeParse(multiSwarmConfig());
+			expect(parsed.success).toBe(true);
+			if (parsed.success) {
+				expect(parsed.data.default_agent).toBeUndefined();
+				const r = getAgentConfigs(parsed.data);
+				expect(r['local_architect'].mode).toBe('primary');
+				expect(r['mega_architect'].mode).toBe('primary');
+			}
+		});
 	});
 });

--- a/tests/unit/config/default-agent-config.test.ts
+++ b/tests/unit/config/default-agent-config.test.ts
@@ -184,6 +184,23 @@ describe('resolvePrimaryAgentNames', () => {
 		]);
 	});
 
+	test('known base role with zero matching agents ⇒ falls through to architect fallback', () => {
+		// Exercises the fall-through path at src/agents/index.ts:707-708:
+		// ALL_AGENT_NAMES.includes('reviewer') is true, but no generated agent
+		// has base role 'reviewer', so the base-role block finds nothing and
+		// falls through. The exact-match check also misses ('reviewer' is not
+		// a generated name), so the resolver falls back to architect-role primaries.
+		const names = ['local_architect', 'mega_architect', 'mega_coder'];
+		const r = resolvePrimaryAgentNames(names, 'reviewer');
+		expect(r.reason).toBe('fallback-architects');
+		expect(r.warning).toBeDefined();
+		expect(r.warning).toMatch(/reviewer/);
+		expect([...r.primaryNames].sort()).toEqual([
+			'local_architect',
+			'mega_architect',
+		]);
+	});
+
 	test('arbitrary "not_an_architect" is NOT treated as base-role architect', () => {
 		// Important matching detail from the spec: stripKnownSwarmPrefix returns
 		// "architect" for a name ending in "_architect", but the literal user

--- a/tests/unit/config/schema.test.ts
+++ b/tests/unit/config/schema.test.ts
@@ -298,12 +298,14 @@ describe('PluginConfigSchema', () => {
 		const result = PluginConfigSchema.safeParse({});
 		expect(result.success).toBe(true);
 		if (result.success) {
-			// adversarial_testing has a schema-level default so it appears in the output
+			// adversarial_testing has a schema-level default so it appears in the output.
+			// default_agent is intentionally optional with NO schema default — see
+			// src/config/schema.ts for the full rationale (issue: multi-swarm
+			// prefixed architects disappearing from OpenCode after v7.3.x).
 			expect(result.data).toEqual({
 				max_iterations: 5,
 				qa_retry_limit: 3,
 				inject_phase_reminders: true,
-				default_agent: 'architect',
 				execution_mode: 'balanced',
 				turbo_mode: false,
 				quiet: true,
@@ -316,6 +318,10 @@ describe('PluginConfigSchema', () => {
 					escalation_mode: 'pause',
 				},
 			});
+			// default_agent is omitted from the output because no schema default
+			// applies — distinguishing omitted from explicit "architect" is a
+			// load-bearing semantic.
+			expect(result.data.default_agent).toBeUndefined();
 		}
 	});
 


### PR DESCRIPTION
## Summary
- v7.3.x added `.default('architect')` to `PluginConfigSchema.default_agent` and switched primary-agent selection to exact-string matching (`agent.name === defaultAgent`). In multi-swarm configs every architect is prefixed (`mega_architect`, `paid_architect`, `lowtier_architect`, `modelrelay_architect`, `local_architect`, …) so none ever matched the literal `"architect"` — all became subagents and OpenCode showed no swarm agents in the TUI/GUI.
- Fix: remove `.default('architect')` so omitted vs explicit are distinguishable; introduce `resolvePrimaryAgentNames` with five resolution branches (implicit architects → exact generated name → base role → fallback architects → fallback first); wire the resolver through `getAgentConfigs`.
- New multi-swarm test coverage in unit (`tests/unit/config/default-agent-config.test.ts` fully replaced) and integration (`tests/integration/config-hook-multi-swarm.test.ts` new) tiers.

## Invariant audit
- 1 (plugin init):        not touched — no changes to `src/index.ts` server entry or plugin registration
- 2 (runtime portability): not touched — no `process.platform`, `__dirname`, Bun-only imports, or path separators changed
- 3 (subprocesses):        not touched — no `bunSpawn`/`spawn`/`spawnSync` sites added or modified; `grep -E "bunSpawn\(|spawn\(|spawnSync\(" src/config/schema.ts src/agents/index.ts` → no matches
- 4 (.swarm containment):  not touched — no `.swarm/` reads/writes
- 5 (plan durability):     not touched — no plan serialization code changed
- 6 (test_runner safety):  not touched — `test_runner` was not used for repo validation; all tiers run via shell
- 7 (test writing):        touched — new and replaced tests use `bun:test`; `mock.module('node:fs/promises', …)` in `default-agent-config.test.ts` matches existing convention in `tests/unit/tools/co-change-analyzer.adversarial.test.ts` and is isolated to a single file (per-file CI loop prevents cross-file leakage); `tests/integration/config-hook-multi-swarm.test.ts` uses `os.tmpdir()` + `realpathSync` + `afterEach` cleanup, no `_internals` seam needed (no subprocess DI). Evidence: `bun --smol test tests/unit/config/default-agent-config.test.ts tests/unit/config/schema.test.ts tests/integration/config-hook-multi-swarm.test.ts` → 4 pass / 0 fail for integration; config group 1051 pass / 30 fail (all 30 pre-existing on `be21cf0`).
- 8 (session state):       not touched
- 9 (guardrails/retry):    not touched
- 10 (chat/system msg):    not touched
- 11 (tool registration):  touched — primary-vs-subagent selection rewritten via `resolvePrimaryAgentNames`. Evidence: `bun --smol test tests/unit/config --timeout 60000` → 1051 pass / 30 fail (all 30 pre-existing); new tests cover legacy unprefixed and multi-swarm prefixed agent sets for all resolver branches. `AGENTS.md` Invariant 11 amended to require both.
- 12 (release/cache):      not touched — `package.json#version`, `CHANGELOG.md`, `.release-please-manifest.json` not manually edited; `docs/releases/v7.3.5.md` created as required by commit-pr skill

## Test plan
- [x] `bun run build` → clean (Bundled in 870ms, dist/ drift check: no uncommitted changes)
- [x] `bun run typecheck` → clean (tsc --noEmit, 0 errors)
- [x] `bunx biome ci .` → clean (1274 files, no fixes applied)
- [x] Tier 2 unit/tools: 0 new failures (2 pre-existing files with failures confirmed identical on `be21cf0`)
- [x] Tier 2 unit/services: all pass
- [x] Tier 2 unit/agents: all pass
- [x] Tier 2 unit/hooks: all pass
- [x] Tier 2 unit/config: 1051 pass / 30 fail — all 30 pre-existing on `be21cf0` baseline; net −1 failure vs main
- [x] Tier 3 integration: `tests/integration/config-hook-multi-swarm.test.ts` → 4 pass / 0 fail; other integration failures confirmed pre-existing
- [x] Tier 4 security: 97 pass / 0 fail
- [x] Tier 4 adversarial: 690 pass / 3 fail (all 3 pre-existing — main has 45 fail in the same suite)
- [x] Tier 5 smoke: 10 pass / 0 fail

## Pre-existing failures
`tests/unit/tools/diagnostic-gating.test.ts` (3 fail) and `tests/unit/tools/registration-smoke.test.ts` (2 fail) fail identically on `be21cf0` (confirmed via `git worktree add /tmp/repro-check origin/main`). My branch improves the total adversarial count from 45 fail on main to 3 fail.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSHWTA3YgMqUutRGzbQgj2)_