### PR TITLE
docs(skills): add running-tests skill and harden writing-tests and commit-pr

### DIFF
--- a/.claude/skills/commit-pr/SKILL.md
+++ b/.claude/skills/commit-pr/SKILL.md
@@ -209,6 +209,21 @@ When you rename a field in a Zod schema, TypeScript interface, or serialized for
 
 Failing to do this causes test fixtures to write stale-format JSON that passes Zod validation for the write but fails on the read path — a silent correctness hazard.
 
+**Agent prompt changes: extra step required.**
+When you edit any agent prompt (`src/agents/*.ts`), tests that assert on prompt content will silently break even if your change appears unrelated. Before pushing:
+1. Identify the text you changed or removed from the prompt.
+2. Grep for that text across all test files:
+   ```bash
+   # bash
+   grep -rn "the exact phrase you removed" tests/ --include="*.ts"
+   # PowerShell
+   Get-ChildItem -Recurse tests/ -Filter "*.test.ts" | Select-String "the exact phrase you removed"
+   ```
+3. Run every test file that matches: `bun --smol test <matching-file> --timeout 30000`.
+4. If any fail, update the assertion to match the new prompt text (or remove it if the concept no longer exists).
+
+Prompt-text tests are especially fragile because they test content, not behaviour — a refactor that seems unrelated (e.g. changing a delegation format example) can silently break assertions checking for specific template strings.
+
 ### Troubleshooting — CI fails on tests that seem unrelated to your changes
 
 If a test fails and you suspect it is pre-existing (unrelated to your changes):

--- a/.opencode/skills/running-tests/SKILL.md
+++ b/.opencode/skills/running-tests/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: running-tests
+description: >
+  Safe test execution patterns for opencode-swarm. Covers when to use the test_runner
+  tool vs shell bun commands, scope safety rules, per-file isolation loops (bash and
+  PowerShell), pre-existing failure verification, CI log reading, and failure
+  classification. Load this skill when you need to run tests — not when you need to
+  write them (see writing-tests for authoring guidance).
+---
+
+# Running Tests for opencode-swarm
+
+This skill is about **executing** tests safely. For **writing** tests, see `writing-tests`.
+
+---
+
+## ⛔ The One Rule That Prevents Session Kills
+
+**Never use `test_runner` with `scope: 'graph'` or `scope: 'impact'` on multiple files.**
+
+Each file fans out to its own import tree. The union blows past `MAX_SAFE_TEST_FILES = 50`
+(`src/tools/test-runner.ts:26`), which stalls or kills the OpenCode session before the guard fires.
+
+---
+
+## Decision Tree: test_runner tool vs bun shell command
+
+```
+Do you need to run tests?
+│
+├─ Single test file, targeted validation
+│   └─ Either works. Prefer shell: bun --smol test <file> --timeout 30000
+│
+├─ Multiple files in the same directory (e.g. all agents tests)
+│   └─ Shell only — per-file loop. Never test_runner with multiple files.
+│
+├─ Find tests related to ONE changed source file
+│   └─ test_runner is fine: { scope: 'graph', files: ['src/agents/coder.ts'] }
+│      (single file → bounded fan-out)
+│
+├─ Find tests related to MULTIPLE changed source files
+│   └─ Shell only — per-file loop over the changed files, or run the whole directory.
+│      test_runner with scope:'graph' + multiple files = session kill.
+│
+└─ Validate the entire repo (pre-push)
+    └─ Shell only — 5-tier suite from commit-pr skill. Never test_runner scope:'all'.
+```
+
+---
+
+## Scope Safety Reference
+
+| Scope | With `files: [one]` | With `files: [many]` | Notes |
+|-------|--------------------|--------------------|-------|
+| `'convention'` | ✅ Safe | ✅ Safe | Maps source → test by filename convention only |
+| `'graph'` | ✅ Safe | ❌ Session kill | Traces imports — fan-out multiplies per file |
+| `'impact'` | ✅ Safe | ❌ Session kill | Same fan-out risk as graph |
+| `'all'` | ❌ Never | ❌ Never | Requires `allow_full_suite: true`; CI mirror only |
+
+**Rule of thumb:** If you're passing more than one file to `test_runner`, use shell instead.
+
+---
+
+## Per-File Isolation Loops
+
+CI runs agents/tools/services in per-file isolation (one `bun --smol` process per file).
+Reproduce this locally with the following loops.
+
+### bash (Linux / macOS)
+
+```bash
+# Single directory — per-file isolation
+for f in tests/unit/agents/*.test.ts; do
+  bun --smol test "$f" --timeout 30000
+done
+
+# Multiple directories
+for dir in tests/unit/tools tests/unit/services tests/unit/agents; do
+  for f in "$dir"/*.test.ts; do
+    bun --smol test "$f" --timeout 30000
+  done
+done
+
+# Stop on first failure (useful for debugging)
+for f in tests/unit/agents/*.test.ts; do
+  bun --smol test "$f" --timeout 30000 || { echo "FAILED: $f"; break; }
+done
+```
+
+### PowerShell (Windows)
+
+```powershell
+# Single directory — per-file isolation
+Get-ChildItem tests/unit/agents/*.test.ts | ForEach-Object {
+  bun --smol test $_.FullName --timeout 30000
+}
+
+# Multiple directories
+@('tests/unit/tools', 'tests/unit/services', 'tests/unit/agents') | ForEach-Object {
+  Get-ChildItem "$_/*.test.ts" | ForEach-Object {
+    bun --smol test $_.FullName --timeout 30000
+  }
+}
+
+# Capture output (avoids truncation on large output)
+Get-ChildItem tests/unit/agents/*.test.ts | ForEach-Object {
+  bun --smol test $_.FullName --timeout 30000
+} | Out-File "$env:TEMP\test_out.txt"
+Get-Content "$env:TEMP\test_out.txt" | Select-Object -Last 50
+```
+
+**Common PowerShell pitfalls:**
+- `for f in ...; do` — invalid, use `Get-ChildItem | ForEach-Object`
+- `Select-String -Last N` — invalid parameter, use `Select-Object -Last N`
+- `2>&1 2>&1` — duplicate redirection, causes parse error; use `2>&1` once
+- `&&` — not supported in PowerShell 5.1; use `; if ($?) { cmd2 }` instead
+
+---
+
+## Batch vs Per-File: Which Directories Need Isolation?
+
+| Directory | Mode | Reason |
+|-----------|------|--------|
+| `tests/unit/tools/` | Per-file loop | Heavy `mock.module` usage; cache poisoning risk |
+| `tests/unit/services/` | Per-file loop | Same |
+| `tests/unit/agents/` | Per-file loop | Same |
+| `tests/unit/hooks/` | Per-file loop | Same |
+| `tests/unit/cli/` | Batch OK | Fewer mock conflicts |
+| `tests/unit/commands/` | Batch OK | Fewer mock conflicts |
+| `tests/unit/config/` | Batch OK | Fewer mock conflicts |
+| `tests/integration/` | Batch OK | Integration fixtures, not mock-heavy |
+| `tests/security/` | Batch OK | Adversarial inputs, no module mocks |
+| `tests/smoke/` | Batch OK | Built-package tests |
+
+---
+
+## Truncated Output Recovery
+
+When `bun test` output exceeds the bash tool's buffer, it is saved to a file with an ID
+like `tool_dff778...`. This ID format is **not** accepted by `retrieve_summary` (which only
+reads `S1`, `S2` etc. format IDs). The output is effectively lost.
+
+**Prevention — pipe to a file explicitly:**
+
+```powershell
+# PowerShell
+bun --smol test tests/unit/agents --timeout 60000 |
+  Out-File "$env:TEMP\test_out.txt"
+Get-Content "$env:TEMP\test_out.txt" | Select-Object -Last 50
+```
+
+```bash
+# bash
+bun --smol test tests/unit/agents --timeout 60000 2>&1 | tee /tmp/test_out.txt
+tail -50 /tmp/test_out.txt
+```
+
+**To get a clean pass/fail summary only**, filter immediately:
+
+```powershell
+# PowerShell — show only summary lines
+bun --smol test tests/unit/agents --timeout 60000 |
+  Select-String "pass|fail|error" |
+  Select-Object -Last 10
+```
+
+```bash
+# bash
+bun --smol test tests/unit/agents --timeout 60000 2>&1 | grep -E "pass|fail|error" | tail -10
+```
+
+---
+
+## Verifying Pre-Existing Failures
+
+Before documenting a failure as "pre-existing," prove it exists on `main` without affecting
+your working tree. Use a Git worktree — safer than `git stash` (stash can drop untracked
+files, fail on locked files on Windows, and leave you in an inconsistent state).
+
+```bash
+# bash — create a throwaway checkout of main
+git worktree add /tmp/repro-check origin/main
+bun --smol test /tmp/repro-check/tests/unit/agents/architect-workflow-security.test.ts --timeout 30000
+git worktree remove /tmp/repro-check
+```
+
+```powershell
+# PowerShell — same pattern (use Join-Path for robust separator handling)
+git worktree add "$env:TEMP\repro-check" origin/main
+$testPath = Join-Path "$env:TEMP\repro-check" "tests\unit\agents\architect-workflow-security.test.ts"
+bun --smol test $testPath --timeout 30000
+git worktree remove "$env:TEMP\repro-check"
+```
+
+**Decision after checking:**
+- Fails on `main` too → pre-existing. Document under `## Pre-existing failures` in PR body. Continue.
+- Fails only on your branch → you introduced it. Fix before pushing.
+
+---
+
+## Failure Classification
+
+Not all failures are equal. Before deciding what to do, classify the failure:
+
+| Class | Definition | Example | What to do |
+|-------|-----------|---------|------------|
+| **Stale assertion** | Test checks for text/value that was deliberately removed | `expect(prompt).toContain('CONSTRAINT: [what NOT to do]')` — template removed in refactor | Update the assertion to match current state |
+| **Soft regression indicator** | Test checks a threshold the codebase has since exceeded | `expect(tokenCount).toBeLessThan(35000)` — prompt grew past limit | Fix the threshold or reduce the prompt; do not just document and ignore |
+| **Genuine pre-existing** | Failure exists on `main` unrelated to any recent change | `full-auto-intercept.test.ts` logger gating issue | Document in PR body; do not fix unless scoped |
+| **New regression** | Failure introduced by your changes | Tests for prompt text you removed without updating tests | Fix before pushing |
+
+**Stale assertions and soft regression indicators are actionable** — they signal drift between
+tests and code. Genuine pre-existing failures are not your responsibility to fix in this PR,
+but they must be documented.
+
+---
+
+## Reading CI Failure Logs
+
+When a CI job fails, the GitHub Actions log shows the exact `file:line` of the failure.
+Do not guess — read the log.
+
+```bash
+# Get the failing job URL from the PR
+gh pr view <number> --json statusCheckRollup --jq '.statusCheckRollup[] | select(.conclusion=="FAILURE") | .detailsUrl'
+
+# Fetch and search the log (if gh CLI available)
+gh run view --log <run-id> | grep -E "FAIL|error" | head -20
+```
+
+Or open the `detailsUrl` directly in a browser / via WebFetch and search for:
+- `(fail)` — Bun test failure marker
+- `error:` — parse or runtime error
+- `at <anonymous>` — stack frame pointing to the test file and line
+
+Once you have `tests/unit/agents/some-file.test.ts:354`, reproduce locally:
+```bash
+bun --smol test tests/unit/agents/some-file.test.ts --timeout 30000
+```
+
+---
+
+## Quick Reference: Common Failures and Causes
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Session killed during test_runner | `scope:'graph'` or `scope:'impact'` on multiple files | Switch to per-file shell loop |
+| `mock.module` breaks unrelated tests | Missing spread of real module exports | Add `...realModule` spread |
+| Windows tests fail with EBUSY | `mock.restore()` called while child process holds lock | Add `test.skipIf(process.platform === 'win32')` |
+| Test output truncated, ID unreadable | Bash tool buffer exceeded | Pipe to `Out-File`/`tee` explicitly |
+| `for f in ...; do` parse error | Bash syntax in PowerShell | Use `Get-ChildItem | ForEach-Object` |
+| `Select-String -Last N` error | Invalid PowerShell parameter | Use `Select-Object -Last N` |
+| Token budget test failure | Prompt grew past hardcoded threshold | Treat as soft regression; update threshold |
+| CONSTRAINT assertion fails after refactor | Test checks for removed format template | Update assertion to match current prompt |
+| dist-check CI failure | `src/` change not rebuilt before commit | Run `bun run build` and stage `dist/` |

--- a/.opencode/skills/writing-tests/SKILL.md
+++ b/.opencode/skills/writing-tests/SKILL.md
@@ -11,6 +11,30 @@ description: >
 
 > **⚠️ Do NOT use the OpenCode `test_runner` tool to validate the full repo.** It is for targeted agent validation with explicit `files: [...]` or small targeted scopes. `scope: 'all'` requires `allow_full_suite: true` and is intended for opt-in CI mirrors only. Broad scopes can stall or kill OpenCode before the `MAX_SAFE_TEST_FILES = 50` (`src/tools/test-runner.ts:26`) guard fires. For repo validation, use the shell commands in this file — per-file isolation loops match CI behavior. `allow_full_suite` should be used only when intentional and justified in the PR description. See [`AGENTS.md`](../../../AGENTS.md) invariant 6 for the full contract.
 
+## ⛔ STOP — Read Before Running Any Tests
+
+**`test_runner` scope safety — one rule, no exceptions:**
+
+| Scope | Files param | Safe? |
+|-------|------------|-------|
+| `'convention'` | any | ✅ Safe |
+| `'graph'` | single file | ✅ Safe |
+| `'graph'` | **multiple files** | ❌ **SESSION KILL** — each file fans out to its own import tree; union blows past MAX_SAFE_TEST_FILES=50 |
+| `'impact'` | multiple files | ❌ **SESSION KILL** — same reason |
+| `'all'` | any | ❌ **Never in agent context** |
+
+**If you need to run tests across multiple source files: use a per-file shell loop, not `test_runner`.**
+
+**Truncated output recovery:** When `bun test` output exceeds the bash tool buffer it is saved to a file whose ID (`tool_abc123...`) cannot be retrieved via `retrieve_summary` (which only accepts `S1`, `S2` format). Workaround — pipe to a temp file instead:
+```powershell
+# PowerShell (Windows)
+bun --smol test tests/unit/agents --timeout 60000 | Out-File "$env:TEMP\test_out.txt"; Get-Content "$env:TEMP\test_out.txt" | Select-Object -Last 30
+```
+```bash
+# bash (Linux/macOS)
+bun --smol test tests/unit/agents --timeout 60000 2>&1 | tee /tmp/test_out.txt | tail -30
+```
+
 ## Framework: bun:test Only
 
 All test files MUST import from `bun:test`:
@@ -301,6 +325,8 @@ if (isWindows) test.skip('reason', () => {});
 
 ## Running Tests
 
+### bash (Linux / macOS)
+
 ```bash
 # Single file
 bun test tests/unit/hooks/scope-guard.test.ts
@@ -315,6 +341,28 @@ for f in tests/unit/tools/*.test.ts; do bun --smol test "$f" --timeout 30000; do
 bun --smol test tests/unit/cli --timeout 120000
 bun --smol test tests/unit/commands tests/unit/config --timeout 120000
 ```
+
+### PowerShell (Windows)
+
+```powershell
+# Single file
+bun test tests/unit/hooks/scope-guard.test.ts
+
+# Batch directory (safe for dirs without mock conflicts)
+bun --smol test tests/unit/hooks --timeout 30000
+
+# Per-file loop (required for tools/services/agents — prevents mock poisoning)
+Get-ChildItem tests/unit/tools/*.test.ts | ForEach-Object { bun --smol test $_.FullName --timeout 30000 }
+
+# CI-equivalent run for batch steps
+bun --smol test tests/unit/cli --timeout 120000
+bun --smol test tests/unit/commands tests/unit/config --timeout 120000
+
+# Capture output to file (avoids truncation when output is large)
+bun --smol test tests/unit/agents --timeout 60000 | Out-File "$env:TEMP\test_out.txt"; Get-Content "$env:TEMP\test_out.txt" | Select-Object -Last 50
+```
+
+**Note:** `for f in ...; do` bash syntax is invalid in PowerShell. Use `Get-ChildItem | ForEach-Object` instead. `Select-String -Last N` is also invalid — use `Select-Object -Last N`.
 
 **Warning:** Running `bun --smol test tests/unit/tools` as a single batch will cause mock poisoning failures. Always use the per-file loop for directories in CI steps 4-6 (tools, services, agents, etc.).
 
@@ -342,6 +390,7 @@ The following test failures are pre-existing and unrelated to mock isolation:
 | `tests/unit/commands/index.test.ts` | Multiple | Command routing issues | Pre-existing |
 | `tests/unit/commands/issue-command.test.ts` | Multiple | Command routing issues | Pre-existing |
 | `src/__tests__/preflight-phase.test.ts` | 3/3 | `loadPlan` called twice per invocation (lines 930 + 545) | Bug exposed by cleanup |
+| `tests/unit/agents/architect-sounding-board-protocol.adversarial.test.ts` | 1 | Token budget threshold `35000` exceeded by prompt growth; soft regression indicator that prompt size needs attention | Pre-existing |
 
 ## Known Cross-module mock.module Locations
 

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.5.4",
+    version: "7.6.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.5.4",
+    version: "7.6.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/docs/releases/v7.6.0.md
+++ b/docs/releases/v7.6.0.md
@@ -1,0 +1,46 @@
+# v7.6.0
+
+## What changed
+
+### New skill: `running-tests`
+
+Added `.opencode/skills/running-tests/SKILL.md` — a dedicated reference for safely executing tests in the opencode-swarm project. Covers:
+
+- **Scope safety table** for the `test_runner` tool — which scope values are safe with single vs multiple files (`scope:'graph'` on multiple files causes session kills)
+- **Decision tree** for choosing between the `test_runner` tool and `bun --smol test` shell commands
+- **Per-file isolation loops** in both bash and PowerShell, side-by-side
+- **Batch vs per-file directory reference table** matching CI pipeline step structure
+- **Truncated output recovery** — `Out-File`/`tee` workaround for when bash tool buffer is exceeded
+- **Pre-existing failure verification** using `git worktree` (safer than `git stash` on Windows)
+- **Failure classification** (stale assertion / soft regression indicator / genuine pre-existing / new regression) with recommended action for each
+- **CI log reading** instructions for identifying the exact `file:line` from a GitHub Actions failure
+- **Quick reference table** of common failure symptoms and their causes
+
+### Updated skill: `writing-tests`
+
+- Added a prominent **⛔ STOP warning block** at the top with a scope safety table — previously the warning was buried in a preamble paragraph and easy to skip
+- Added **PowerShell equivalents** for all bash test-running commands (per-file loop, batch, output capture), with a note on common PowerShell syntax pitfalls (`Select-String -Last` vs `Select-Object -Last`, etc.)
+- Added **truncated output recovery** snippets (PowerShell and bash)
+- Added **one new row** to the Known Pre-existing Test Failures table:
+  - `architect-sounding-board-protocol.adversarial.test.ts` — token budget threshold exceeded by prompt growth
+
+### Updated skill: `commit-pr`
+
+- Added **"Agent prompt changes: extra step required"** to Step 5 — instructs contributors to grep test files for strings they removed from agent prompts and run matching tests before pushing. Prompt-text assertions break silently on content refactors.
+
+## Why
+
+These changes address real failures observed during a PR review session:
+
+1. The `test_runner` tool with `scope:'graph'` on multiple agent source files killed the OpenCode session three times before the root cause was understood. The existing warning in `writing-tests` was easy to skip.
+2. PowerShell syntax errors (bash `for f in` loops, `Select-String -Last`) caused repeated friction on Windows.
+3. A test in `architect-workflow-security.test.ts` broke silently because the delegation format template it checked (`CONSTRAINT: [what NOT to do]`) was removed in a refactor without grepping for dependent tests.
+4. Truncated test output was unrecoverable because `retrieve_summary` only accepts `S1`/`S2` format IDs.
+
+## Migration steps
+
+None — these are skill documentation files read by agents. No source code, configuration, or test files changed.
+
+## Breaking changes
+
+None.


### PR DESCRIPTION
﻿## Summary
- Add new `running-tests` skill covering safe test execution -- scope safety table, bash+PowerShell isolation loops, truncated output recovery, git worktree pre-existing failure verification, and failure classification
- Harden `writing-tests` with a prominent scope-safety warning block, PowerShell equivalents for all bash commands, and truncated output recovery snippets
- Add agent prompt change step to `commit-pr` Step 5 to prevent silent test breakage after prompt refactors

## Motivation
Three `test_runner` session kills and repeated PowerShell syntax failures during PR #778 review revealed gaps in the existing skill documentation. These changes surface the rules where they are needed, not buried in prose.

## Invariant audit
- 1 (plugin init):        not touched -- no src/ changes
- 2 (runtime portability): not touched -- no src/ changes
- 3 (subprocesses):        not touched -- no src/ changes
- 4 (.swarm containment):  not touched -- no src/ changes
- 5 (plan durability):     not touched -- no src/ changes
- 6 (test_runner safety):  not touched -- skill files only; no test_runner calls added
- 7 (test writing):        not touched -- documentation updates only
- 8 (session state):       not touched -- no src/ changes
- 9 (guardrails/retry):    not touched -- no src/ changes
- 10 (chat/system msg):    not touched -- no src/ changes
- 11 (tool registration):  not touched -- no src/ changes
- 12 (release/cache):      not touched -- no src/ changes

## Test plan
- [x] paid_reviewer APPROVED (round 2) -- accuracy verified against codebase
- [x] Skill files outside biome/sast scope -- no lint failures expected
- [x] dist/ rebuilt and staged to match v7.6.0 -- dist-check will pass
- [x] No source code changed -- unit/integration/smoke tiers unaffected
