### PR TITLE
docs(skills): add 5 targeted fixes from PR session retrospective

### DIFF
--- a/.claude/skills/commit-pr/SKILL.md
+++ b/.claude/skills/commit-pr/SKILL.md
@@ -74,7 +74,16 @@ rm -f .swarm/evidence/*.json
 git status --short
 ```
 
-If `git status` shows uncommitted changes, either commit them (if they're part of this PR) or stash them (if they're from a prior session).
+If `git status` shows uncommitted changes, either commit them (if they're part of this PR) or move them aside. **On Windows, `git stash` is unreliable** — it can silently drop untracked files and fail with `EBUSY` errors when file handles are held by running processes. Prefer one of these safer alternatives:
+
+```bash
+# Option A — commit work-in-progress to a temporary branch, then switch back
+git switch -c save/prior-session
+git add -A && git commit -m "chore: save prior session state"
+git switch -c my-feature-branch origin/main
+```
+
+If you must use stash, always pass `--include-untracked` (`git stash push --include-untracked`) to avoid silently losing untracked files, and verify with `git stash show -p` that all expected files were captured before proceeding.
 
 ### Step 1 — Format every commit message correctly
 
@@ -296,7 +305,36 @@ git push --force-with-lease -u origin <branch-name>
 
 **Why:** Interim commits (`fix attempt 1`, `wip`, `address review`) are noise in the project history. A single well-named commit makes `git log`, `git bisect`, and release notes meaningful. The PR title doubles as the squash commit message — both must be correct conventional-commit format.
 
+#### Pushing to a PR branch owned by another agent or bot
+
+When a PR was created by Copilot, another agent, or an automated tool, its head branch (e.g. `copilot/fix-skills-passing-to-subagents`) will not exist in your local repo. Pushing your local branch to a different remote name will create a second branch and leave the PR pointing at the wrong one. Correct pattern:
+
+```bash
+# 1. Identify the PR's actual head branch
+gh pr view <number> --json headRefName --jq '.headRefName'
+# e.g. → copilot/fix-skills-passing-to-subagents
+
+# 2. Fetch it so git knows the remote ref
+git fetch origin copilot/fix-skills-passing-to-subagents
+
+# 3. Push your local branch to the PR's remote branch
+git push origin <your-local-branch>:copilot/fix-skills-passing-to-subagents --force-with-lease
+```
+
+```powershell
+# PowerShell equivalent
+$prBranch = gh pr view <number> --json headRefName --jq '.headRefName'
+git fetch origin $prBranch
+git push origin "<your-local-branch>:$prBranch" --force-with-lease
+```
+
+Verify the PR is now tracking your commit: `gh pr view <number> --json headRefOid` should match `git rev-parse HEAD`.
+
 ### Step 8 — Open the PR with the correct body format
+
+`## Summary` must have 1–3 bullets explaining what and why. `## Test plan` must be a markdown checklist. Do not replace the body of an existing release-please PR — prepend only.
+
+#### bash (Linux / macOS)
 
 ```bash
 gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
@@ -313,7 +351,26 @@ EOF
 )" --base main
 ```
 
-`## Summary` must have 1–3 bullets explaining what and why. `## Test plan` must be a markdown checklist. Do not replace the body of an existing release-please PR — prepend only.
+#### PowerShell (Windows)
+
+`<<'EOF'` heredoc syntax is **invalid in PowerShell** and will produce a parse error. Use a here-string written to a temp file instead:
+
+```powershell
+$body = @"
+## Summary
+- <bullet 1>
+- <bullet 2 if needed>
+- <bullet 3 if needed>
+
+## Test plan
+- [ ] <what you tested>
+- [ ] <additional test step>
+"@
+$body | Out-File "$env:TEMP\pr_body.txt" -Encoding UTF8
+gh pr create --title "<type>(<scope>): <description>" --body-file "$env:TEMP\pr_body.txt" --base main
+```
+
+Note: Inside a PowerShell here-string (`@"..."@`), backticks are literal — no escaping needed. Double-quotes inside the here-string do not need escaping either.
 
 ### Step 9 — Pre-merge checklist
 

--- a/.claude/skills/engineering-conventions/SKILL.md
+++ b/.claude/skills/engineering-conventions/SKILL.md
@@ -51,6 +51,39 @@ The OpenCode `test_runner` tool is for **targeted agent validation** with explic
 - For repo validation, run the shell commands in `contributing.md` / `TESTING.md` directly (per-file isolation loops + tier orchestration).
 - `scope: 'all'` requires `allow_full_suite: true` and is intended for opt-in CI mirrors only. Default to `files: [...]` instead.
 
+## Agent prompt strings — escaping pitfalls
+
+Agent prompts in `src/agents/*.ts` are large TypeScript template literals. They frequently contain characters that have special meaning inside template literals and cause silent parse errors if unescaped:
+
+| Character | Inside template literal | Correct escape |
+|-----------|------------------------|----------------|
+| Backtick `` ` `` | Terminates the literal | `` \` `` (single backslash — renders as `` ` `` in output) |
+| `${` | Starts an interpolation | `\${` (single backslash) |
+| Literal backslash `\` | Consumed by escape processing | `\\` (double backslash renders as `\` in output) |
+
+**The most common failure pattern:** A coder adds an inline code example containing backticks to an agent prompt string. The unescaped backtick silently terminates the template literal, producing a `SyntaxError: Unexpected identifier` or `Unexpected token` at the character *after* the backtick — which appears unrelated to the actual cause.
+
+```typescript
+// WRONG — unescaped backtick terminates the template literal
+const PROMPT = `
+Use `bun:test` for all tests.   // ← bare backtick before "bun" closes the literal
+`;
+
+// CORRECT — single backslash before each backtick; renders as Use `bun:test` in output
+const PROMPT = `
+Use \`bun:test\` for all tests.
+`;
+
+// OVER-ESCAPED (also wrong) — triple backslash produces literal \` in the rendered prompt
+const PROMPT = `
+Use \\\`bun:test\\\` for all tests.  // renders as: Use \`bun:test\` (backslashes visible)
+`;
+```
+
+**Detection:** If `bun run build` or `bun --smol test` reports a parse error at a line number that seems far from any recent change, search the surrounding lines for an unescaped backtick inside a template literal.
+
+**Prevention:** After adding any inline code example to an agent prompt, run `bun run build` immediately — the TypeScript compiler catches unescaped backticks as a syntax error before any tests run.
+
 ## The invariant-audit gate (PR-time)
 
 Every PR that touches a relevant area must include an `## Invariant audit` section in its description. The format is in `AGENTS.md` ("Invariant audit required in PRs"). The `commit-pr` skill enforces this gate before push/PR — load it before committing.

--- a/.opencode/skills/running-tests/SKILL.md
+++ b/.opencode/skills/running-tests/SKILL.md
@@ -196,6 +196,8 @@ git worktree remove "$env:TEMP\repro-check"
 - Fails on `main` too → pre-existing. Document under `## Pre-existing failures` in PR body. Continue.
 - Fails only on your branch → you introduced it. Fix before pushing.
 
+**⚠️ Check your own session history first.** Before documenting anything as pre-existing, confirm you did not fix or update this test earlier in the current session. A test you fixed 20 messages ago is not pre-existing — listing it as such in the table or PR body is incorrect and will be caught in review.
+
 ---
 
 ## Failure Classification


### PR DESCRIPTION
﻿## Summary
- Fix inverted WRONG/CORRECT labels in template literal escaping section (engineering-conventions) — caught by reviewer
- Add PowerShell-compatible `gh pr create` body pattern to commit-pr Step 8 (`@"..."@` here-string + `--body-file`)
- Add subsection for pushing to PR branch owned by another agent/bot in commit-pr Step 7
- Warn that `git stash` is unreliable on Windows in commit-pr Step 0; add safe alternatives
- Add one-sentence session-history check to running-tests pre-existing verification block

## Invariant audit
- 1 (plugin init):        not touched -- no src/ changes
- 2 (runtime portability): not touched -- no src/ changes
- 3 (subprocesses):        not touched -- no src/ changes
- 4 (.swarm containment):  not touched -- no src/ changes
- 5 (plan durability):     not touched -- no src/ changes
- 6 (test_runner safety):  not touched -- skill files only
- 7 (test writing):        not touched -- documentation only
- 8 (session state):       not touched -- no src/ changes
- 9 (guardrails/retry):    not touched -- no src/ changes
- 10 (chat/system msg):    not touched -- no src/ changes
- 11 (tool registration):  not touched -- no src/ changes
- 12 (release/cache):      not touched -- no src/ changes

## Test plan
- [x] paid_reviewer APPROVED (round 2 after escaping fix)
- [x] placeholder_scan PASS -- 0 findings
- [x] Skill files outside biome/sast scope -- no lint failures expected
- [x] No source code changed -- all test tiers unaffected
