### PR TITLE
fix(turbo): update registry metadata and fix 5 pre-existing test failures via _internals DI seam

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.17.1",
+    version: "7.17.2",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -51438,7 +51438,7 @@ async function handleTurboCommand(directory, args, sessionID) {
   if (arg0 === "on") {
     let strategy = "standard";
     try {
-      const { config: config3 } = loadPluginConfigWithMeta(directory);
+      const { config: config3 } = _internals25.loadPluginConfigWithMeta(directory);
       if (config3.turbo?.strategy === "lean") {
         strategy = "lean";
       }
@@ -51493,7 +51493,7 @@ function enableLeanTurbo(session, directory, sessionID) {
   let maxParallelCoders = 4;
   let conflictPolicy = "serialize";
   try {
-    const { config: config3 } = loadPluginConfigWithMeta(directory);
+    const { config: config3 } = _internals25.loadPluginConfigWithMeta(directory);
     const leanConfig = config3.turbo?.lean;
     if (leanConfig) {
       maxParallelCoders = leanConfig.max_parallel_coders ?? 4;
@@ -51563,11 +51563,15 @@ function buildStatusMessage(session, directory, sessionID) {
   ].join(`
 `);
 }
+var _internals25;
 var init_turbo = __esm(() => {
   init_config();
   init_state();
   init_state3();
   init_logger();
+  _internals25 = {
+    loadPluginConfigWithMeta
+  };
 });
 
 // src/commands/write-retro.ts
@@ -51820,7 +51824,7 @@ function createSwarmCommandHandler(directory, agents) {
         const attemptedCommand = tokens[0] || "";
         const MAX_DISPLAY = 100;
         const displayCommand = attemptedCommand.length > MAX_DISPLAY ? `${attemptedCommand.slice(0, MAX_DISPLAY)}...` : attemptedCommand;
-        const similar = _internals25.findSimilarCommands(attemptedCommand);
+        const similar = _internals26.findSimilarCommands(attemptedCommand);
         const header = `Command \`/swarm ${displayCommand}\` not found.`;
         const suggestions = similar.length > 0 ? `Did you mean:
 ${similar.map((cmd) => `  \u2022 /swarm ${cmd}`).join(`
@@ -51927,7 +51931,7 @@ function findSimilarCommands(query) {
   }
   const scored = VALID_COMMANDS.map((cmd) => {
     const cmdLower = cmd.toLowerCase();
-    const fullScore = _internals25.levenshteinDistance(q, cmdLower);
+    const fullScore = _internals26.levenshteinDistance(q, cmdLower);
     let tokenScore = Infinity;
     if (cmd.includes(" ") || cmd.includes("-")) {
       const qTokens = q.split(/[\s-]+/);
@@ -51940,7 +51944,7 @@ function findSimilarCommands(query) {
         for (const ct of cmdTokens) {
           if (ct.length === 0)
             continue;
-          const dist = _internals25.levenshteinDistance(qt, ct);
+          const dist = _internals26.levenshteinDistance(qt, ct);
           if (dist < minDist)
             minDist = dist;
         }
@@ -51950,7 +51954,7 @@ function findSimilarCommands(query) {
     }
     const dashStrippedQ = q.replace(/-/g, "");
     const dashStrippedCmd = cmdLower.replace(/-/g, "");
-    const dashScore = _internals25.levenshteinDistance(dashStrippedQ, dashStrippedCmd);
+    const dashScore = _internals26.levenshteinDistance(dashStrippedQ, dashStrippedCmd);
     const score = Math.min(fullScore, tokenScore, dashScore);
     return { cmd, score };
   });
@@ -51982,11 +51986,11 @@ async function handleHelpCommand(ctx) {
     return buildHelpText2();
   }
   const tokens = targetCommand.split(/\s+/);
-  const resolved = _internals25.resolveCommand(tokens);
+  const resolved = _internals26.resolveCommand(tokens);
   if (resolved) {
-    return _internals25.buildDetailedHelp(resolved.key, resolved.entry);
+    return _internals26.buildDetailedHelp(resolved.key, resolved.entry);
   }
-  const similar = _internals25.findSimilarCommands(targetCommand);
+  const similar = _internals26.findSimilarCommands(targetCommand);
   const { buildHelpText: fullHelp } = await Promise.resolve().then(() => (init_commands(), exports_commands));
   if (similar.length > 0) {
     return `Command '/swarm ${targetCommand}' not found.
@@ -52080,7 +52084,7 @@ function resolveCommand(tokens) {
   }
   return null;
 }
-var COMMAND_REGISTRY, VALID_COMMANDS, _internals25, validation;
+var COMMAND_REGISTRY, VALID_COMMANDS, _internals26, validation;
 var init_registry = __esm(() => {
   init_acknowledge_spec_drift();
   init_agents();
@@ -52150,7 +52154,7 @@ var init_registry = __esm(() => {
       clashesWithNativeCcCommand: "/agents"
     },
     help: {
-      handler: (ctx) => _internals25.handleHelpCommand(ctx),
+      handler: (ctx) => _internals26.handleHelpCommand(ctx),
       description: "Show help for swarm commands",
       category: "core",
       args: "[command]",
@@ -52449,9 +52453,24 @@ var init_registry = __esm(() => {
     },
     turbo: {
       handler: (ctx) => handleTurboCommand(ctx.directory, ctx.args, ctx.sessionID),
-      description: "Toggle Turbo Mode for the active session [on|off]",
-      args: "on, off",
-      details: 'Toggles Turbo Mode which skips non-critical QA gates for faster iteration. When enabled, the architect can proceed without waiting for all automated checks. Session-scoped \u2014 resets on new session. Use "on" or "off" to set explicitly, or toggle with no argument.',
+      description: "Toggle Turbo Mode strategy for the active session [on|off|lean|standard|status]",
+      args: "on, off, lean, standard, status",
+      details: `Toggles Turbo Mode for the current session. Supports two strategies:
+
+` + `**Standard turbo** \u2014 skips non-critical QA gates for faster iteration.
+` + `**Lean turbo** \u2014 parallel lane execution with per-lane reviewer gates and file-lock conflict detection.
+` + `
+Subcommands:
+` + `  turbo on           \u2014 enable turbo (uses lean when config turbo.strategy is "lean", otherwise standard)
+` + `  turbo off          \u2014 disable all turbo modes
+` + `  turbo lean on      \u2014 enable Lean Turbo explicitly
+` + `  turbo lean off     \u2014 disable Lean Turbo
+` + `  turbo lean         \u2014 toggle Lean Turbo on/off
+` + `  turbo standard on  \u2014 force standard turbo (disables lean even if config says lean)
+` + `  turbo standard off \u2014 disable standard turbo (falls back to lean if config strategy is lean)
+` + `  turbo status       \u2014 show detailed status including active strategy and lanes
+` + `
+` + "Session-scoped \u2014 resets on new session.",
       category: "utility"
     },
     "full-auto": {
@@ -52507,7 +52526,7 @@ var init_registry = __esm(() => {
     }
   };
   VALID_COMMANDS = Object.keys(COMMAND_REGISTRY);
-  _internals25 = {
+  _internals26 = {
     handleHelpCommand,
     validateAliases,
     resolveCommand,
@@ -52515,7 +52534,7 @@ var init_registry = __esm(() => {
     findSimilarCommands,
     buildDetailedHelp
   };
-  validation = _internals25.validateAliases();
+  validation = _internals26.validateAliases();
   if (!validation.valid) {
     throw new Error(`COMMAND_REGISTRY alias validation failed:
 ${validation.errors.join(`

--- a/dist/commands/registry.d.ts
+++ b/dist/commands/registry.d.ts
@@ -366,9 +366,9 @@ export declare const COMMAND_REGISTRY: {
     };
     readonly turbo: {
         readonly handler: (ctx: CommandContext) => Promise<string>;
-        readonly description: "Toggle Turbo Mode for the active session [on|off]";
-        readonly args: "on, off";
-        readonly details: "Toggles Turbo Mode which skips non-critical QA gates for faster iteration. When enabled, the architect can proceed without waiting for all automated checks. Session-scoped — resets on new session. Use \"on\" or \"off\" to set explicitly, or toggle with no argument.";
+        readonly description: "Toggle Turbo Mode strategy for the active session [on|off|lean|standard|status]";
+        readonly args: "on, off, lean, standard, status";
+        readonly details: string;
         readonly category: "utility";
     };
     readonly 'full-auto': {

--- a/dist/commands/turbo.d.ts
+++ b/dist/commands/turbo.d.ts
@@ -1,3 +1,14 @@
+import { loadPluginConfigWithMeta } from '../config';
+/**
+ * Test-only dependency-injection seam. Production code calls
+ * `_internals.loadPluginConfigWithMeta(...)` so tests can replace the function
+ * on this object without using `mock.module` from `bun:test`, which leaks
+ * across files in Bun's shared test-runner process (AGENTS.md §7).
+ * Mutating this local object is file-scoped and trivially restorable via afterEach.
+ */
+export declare const _internals: {
+    loadPluginConfigWithMeta: typeof loadPluginConfigWithMeta;
+};
 /**
  * Handles the /swarm turbo command.
  * Supports standard turbo toggle, lean turbo mode, and status reporting.

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.17.1",
+    version: "7.17.2",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -60236,7 +60236,7 @@ async function handleTurboCommand(directory, args2, sessionID) {
   if (arg0 === "on") {
     let strategy = "standard";
     try {
-      const { config: config3 } = loadPluginConfigWithMeta(directory);
+      const { config: config3 } = _internals31.loadPluginConfigWithMeta(directory);
       if (config3.turbo?.strategy === "lean") {
         strategy = "lean";
       }
@@ -60291,7 +60291,7 @@ function enableLeanTurbo(session, directory, sessionID) {
   let maxParallelCoders = 4;
   let conflictPolicy = "serialize";
   try {
-    const { config: config3 } = loadPluginConfigWithMeta(directory);
+    const { config: config3 } = _internals31.loadPluginConfigWithMeta(directory);
     const leanConfig = config3.turbo?.lean;
     if (leanConfig) {
       maxParallelCoders = leanConfig.max_parallel_coders ?? 4;
@@ -60361,11 +60361,15 @@ function buildStatusMessage(session, directory, sessionID) {
   ].join(`
 `);
 }
+var _internals31;
 var init_turbo = __esm(() => {
   init_config();
   init_state();
   init_state3();
   init_logger();
+  _internals31 = {
+    loadPluginConfigWithMeta
+  };
 });
 
 // src/commands/write-retro.ts
@@ -60618,7 +60622,7 @@ function createSwarmCommandHandler(directory, agents) {
         const attemptedCommand = tokens[0] || "";
         const MAX_DISPLAY = 100;
         const displayCommand = attemptedCommand.length > MAX_DISPLAY ? `${attemptedCommand.slice(0, MAX_DISPLAY)}...` : attemptedCommand;
-        const similar = _internals31.findSimilarCommands(attemptedCommand);
+        const similar = _internals32.findSimilarCommands(attemptedCommand);
         const header = `Command \`/swarm ${displayCommand}\` not found.`;
         const suggestions = similar.length > 0 ? `Did you mean:
 ${similar.map((cmd) => `  • /swarm ${cmd}`).join(`
@@ -60725,7 +60729,7 @@ function findSimilarCommands(query) {
   }
   const scored = VALID_COMMANDS.map((cmd) => {
     const cmdLower = cmd.toLowerCase();
-    const fullScore = _internals31.levenshteinDistance(q, cmdLower);
+    const fullScore = _internals32.levenshteinDistance(q, cmdLower);
     let tokenScore = Infinity;
     if (cmd.includes(" ") || cmd.includes("-")) {
       const qTokens = q.split(/[\s-]+/);
@@ -60738,7 +60742,7 @@ function findSimilarCommands(query) {
         for (const ct of cmdTokens) {
           if (ct.length === 0)
             continue;
-          const dist = _internals31.levenshteinDistance(qt, ct);
+          const dist = _internals32.levenshteinDistance(qt, ct);
           if (dist < minDist)
             minDist = dist;
         }
@@ -60748,7 +60752,7 @@ function findSimilarCommands(query) {
     }
     const dashStrippedQ = q.replace(/-/g, "");
     const dashStrippedCmd = cmdLower.replace(/-/g, "");
-    const dashScore = _internals31.levenshteinDistance(dashStrippedQ, dashStrippedCmd);
+    const dashScore = _internals32.levenshteinDistance(dashStrippedQ, dashStrippedCmd);
     const score = Math.min(fullScore, tokenScore, dashScore);
     return { cmd, score };
   });
@@ -60780,11 +60784,11 @@ async function handleHelpCommand(ctx) {
     return buildHelpText2();
   }
   const tokens = targetCommand.split(/\s+/);
-  const resolved = _internals31.resolveCommand(tokens);
+  const resolved = _internals32.resolveCommand(tokens);
   if (resolved) {
-    return _internals31.buildDetailedHelp(resolved.key, resolved.entry);
+    return _internals32.buildDetailedHelp(resolved.key, resolved.entry);
   }
-  const similar = _internals31.findSimilarCommands(targetCommand);
+  const similar = _internals32.findSimilarCommands(targetCommand);
   const { buildHelpText: fullHelp } = await Promise.resolve().then(() => (init_commands(), exports_commands));
   if (similar.length > 0) {
     return `Command '/swarm ${targetCommand}' not found.
@@ -60878,7 +60882,7 @@ function resolveCommand(tokens) {
   }
   return null;
 }
-var COMMAND_REGISTRY, VALID_COMMANDS, _internals31, validation;
+var COMMAND_REGISTRY, VALID_COMMANDS, _internals32, validation;
 var init_registry = __esm(() => {
   init_acknowledge_spec_drift();
   init_agents();
@@ -60948,7 +60952,7 @@ var init_registry = __esm(() => {
       clashesWithNativeCcCommand: "/agents"
     },
     help: {
-      handler: (ctx) => _internals31.handleHelpCommand(ctx),
+      handler: (ctx) => _internals32.handleHelpCommand(ctx),
       description: "Show help for swarm commands",
       category: "core",
       args: "[command]",
@@ -61247,9 +61251,24 @@ var init_registry = __esm(() => {
     },
     turbo: {
       handler: (ctx) => handleTurboCommand(ctx.directory, ctx.args, ctx.sessionID),
-      description: "Toggle Turbo Mode for the active session [on|off]",
-      args: "on, off",
-      details: 'Toggles Turbo Mode which skips non-critical QA gates for faster iteration. When enabled, the architect can proceed without waiting for all automated checks. Session-scoped — resets on new session. Use "on" or "off" to set explicitly, or toggle with no argument.',
+      description: "Toggle Turbo Mode strategy for the active session [on|off|lean|standard|status]",
+      args: "on, off, lean, standard, status",
+      details: `Toggles Turbo Mode for the current session. Supports two strategies:
+
+` + `**Standard turbo** — skips non-critical QA gates for faster iteration.
+` + `**Lean turbo** — parallel lane execution with per-lane reviewer gates and file-lock conflict detection.
+` + `
+Subcommands:
+` + `  turbo on           — enable turbo (uses lean when config turbo.strategy is "lean", otherwise standard)
+` + `  turbo off          — disable all turbo modes
+` + `  turbo lean on      — enable Lean Turbo explicitly
+` + `  turbo lean off     — disable Lean Turbo
+` + `  turbo lean         — toggle Lean Turbo on/off
+` + `  turbo standard on  — force standard turbo (disables lean even if config says lean)
+` + `  turbo standard off — disable standard turbo (falls back to lean if config strategy is lean)
+` + `  turbo status       — show detailed status including active strategy and lanes
+` + `
+` + "Session-scoped — resets on new session.",
       category: "utility"
     },
     "full-auto": {
@@ -61305,7 +61324,7 @@ var init_registry = __esm(() => {
     }
   };
   VALID_COMMANDS = Object.keys(COMMAND_REGISTRY);
-  _internals31 = {
+  _internals32 = {
     handleHelpCommand,
     validateAliases,
     resolveCommand,
@@ -61313,7 +61332,7 @@ var init_registry = __esm(() => {
     findSimilarCommands,
     buildDetailedHelp
   };
-  validation = _internals31.validateAliases();
+  validation = _internals32.validateAliases();
   if (!validation.valid) {
     throw new Error(`COMMAND_REGISTRY alias validation failed:
 ${validation.errors.join(`
@@ -69926,7 +69945,7 @@ __export(exports_runtime, {
   getSupportedLanguages: () => getSupportedLanguages,
   getInitializedLanguages: () => getInitializedLanguages,
   clearParserCache: () => clearParserCache,
-  _internals: () => _internals32
+  _internals: () => _internals33
 });
 import * as path76 from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
@@ -69936,10 +69955,10 @@ async function initTreeSitter() {
       const thisDir = path76.dirname(fileURLToPath2(import.meta.url));
       const isSource = thisDir.replace(/\\/g, "/").endsWith("/src/lang");
       if (isSource) {
-        await _internals32.parserInit();
+        await _internals33.parserInit();
       } else {
         const grammarsDir = getGrammarsDirAbsolute();
-        await _internals32.parserInit({
+        await _internals33.parserInit({
           locateFile(scriptName) {
             return path76.join(grammarsDir, scriptName);
           }
@@ -70041,12 +70060,12 @@ function getInitializedLanguages() {
 function getSupportedLanguages() {
   return Object.keys(LANGUAGE_WASM_MAP);
 }
-var parserCache, initializedLanguages, treeSitterInitPromise = null, _internals32, LANGUAGE_WASM_MAP;
+var parserCache, initializedLanguages, treeSitterInitPromise = null, _internals33, LANGUAGE_WASM_MAP;
 var init_runtime = __esm(() => {
   init_tree_sitter();
   parserCache = new Map;
   initializedLanguages = new Set;
-  _internals32 = {
+  _internals33 = {
     parserInit: Parser.init
   };
   LANGUAGE_WASM_MAP = {
@@ -70503,9 +70522,9 @@ var init_doc_scan = __esm(() => {
 var exports_knowledge_recall = {};
 __export(exports_knowledge_recall, {
   knowledge_recall: () => knowledge_recall,
-  _internals: () => _internals33
+  _internals: () => _internals34
 });
-var knowledge_recall, _internals33;
+var knowledge_recall, _internals34;
 var init_knowledge_recall = __esm(() => {
   init_zod();
   init_knowledge_store();
@@ -70591,7 +70610,7 @@ var init_knowledge_recall = __esm(() => {
       return JSON.stringify(result);
     }
   });
-  _internals33 = {
+  _internals34 = {
     knowledge_recall
   };
 });
@@ -70646,7 +70665,7 @@ __export(exports_curator_drift, {
   runDeterministicDriftCheck: () => runDeterministicDriftCheck,
   readPriorDriftReports: () => readPriorDriftReports,
   buildDriftInjectionText: () => buildDriftInjectionText,
-  _internals: () => _internals35
+  _internals: () => _internals36
 });
 import * as fs60 from "node:fs";
 import * as path84 from "node:path";
@@ -70691,7 +70710,7 @@ async function runDeterministicDriftCheck(directory, phase, curatorResult, confi
   try {
     const planMd = await readSwarmFileAsync(directory, "plan.md");
     const specMd = await readSwarmFileAsync(directory, "spec.md");
-    const priorReports = await _internals35.readPriorDriftReports(directory);
+    const priorReports = await _internals36.readPriorDriftReports(directory);
     const complianceCount = curatorResult.compliance.length;
     const warningCompliance = curatorResult.compliance.filter((obs) => obs.severity === "warning");
     let alignment = "ALIGNED";
@@ -70740,7 +70759,7 @@ async function runDeterministicDriftCheck(directory, phase, curatorResult, confi
       scope_additions: [],
       injection_summary: injectionSummary
     };
-    const reportPath = await _internals35.writeDriftReport(directory, report);
+    const reportPath = await _internals36.writeDriftReport(directory, report);
     getGlobalEventBus().publish("curator.drift.completed", {
       phase,
       alignment,
@@ -70803,12 +70822,12 @@ function buildDriftInjectionText(report, maxChars) {
   }
   return text.slice(0, maxChars);
 }
-var DRIFT_REPORT_PREFIX = "drift-report-phase-", _internals35;
+var DRIFT_REPORT_PREFIX = "drift-report-phase-", _internals36;
 var init_curator_drift = __esm(() => {
   init_event_bus();
   init_logger();
   init_utils2();
-  _internals35 = {
+  _internals36 = {
     readPriorDriftReports,
     writeDriftReport,
     runDeterministicDriftCheck,
@@ -70820,7 +70839,7 @@ var init_curator_drift = __esm(() => {
 var exports_project_context = {};
 __export(exports_project_context, {
   buildProjectContext: () => buildProjectContext,
-  _internals: () => _internals48,
+  _internals: () => _internals49,
   LANG_BACKEND_DETECTION_TIMEOUT_MS: () => LANG_BACKEND_DETECTION_TIMEOUT_MS
 });
 import * as fs110 from "node:fs";
@@ -70904,7 +70923,7 @@ function selectLintCommand(backend, directory) {
   return null;
 }
 async function buildProjectContext(directory) {
-  const backend = await _internals48.pickBackend(directory);
+  const backend = await _internals49.pickBackend(directory);
   if (!backend)
     return null;
   const ctx = emptyProjectContext();
@@ -70935,16 +70954,16 @@ async function buildProjectContext(directory) {
   if (backend.prompts.reviewerChecklist.length > 0) {
     ctx.REVIEWER_CHECKLIST = bulletList(backend.prompts.reviewerChecklist);
   }
-  const profiles = _internals48.pickedProfiles(directory);
+  const profiles = _internals49.pickedProfiles(directory);
   if (profiles.length > 1) {
     ctx.PROJECT_CONTEXT_SECONDARY_LANGUAGES = profiles.slice(1).map((p) => p.id).join(", ");
   }
   return ctx;
 }
-var LANG_BACKEND_DETECTION_TIMEOUT_MS = 300, _internals48;
+var LANG_BACKEND_DETECTION_TIMEOUT_MS = 300, _internals49;
 var init_project_context = __esm(() => {
   init_dispatch();
-  _internals48 = {
+  _internals49 = {
     pickBackend,
     pickedProfiles
   };
@@ -81335,10 +81354,10 @@ async function getRunMemorySummary(directory) {
   if (entries.length === 0) {
     return null;
   }
-  const groups = _internals34.groupByTaskId(entries);
+  const groups = _internals35.groupByTaskId(entries);
   const summaries = [];
   for (const [taskId, taskEntries] of groups) {
-    const summary = _internals34.summarizeTask(taskId, taskEntries);
+    const summary = _internals35.summarizeTask(taskId, taskEntries);
     if (summary) {
       summaries.push(summary);
     }
@@ -81371,7 +81390,7 @@ Use this data to avoid repeating known failure patterns.`;
   }
   return prefix + summaryText + suffix;
 }
-var _internals34 = {
+var _internals35 = {
   generateTaskFingerprint,
   recordOutcome,
   getTaskHistory,
@@ -88884,7 +88903,7 @@ function listLaneEvidenceSync(directory, phase) {
   }
   return laneIds;
 }
-var _internals36 = {
+var _internals37 = {
   listActiveLocks,
   readPersisted: readPersisted2,
   readPlanJson: defaultReadPlanJson,
@@ -88945,7 +88964,7 @@ function verifyLeanTurboPhaseReady(directory, phase, sessionIDOrConfig, config3)
       reason: "Lean Turbo state unreadable or missing"
     };
   }
-  const persisted = _internals36.readPersisted(directory);
+  const persisted = _internals37.readPersisted(directory);
   if (!persisted) {
     return {
       ok: false,
@@ -89009,7 +89028,7 @@ function verifyLeanTurboPhaseReady(directory, phase, sessionIDOrConfig, config3)
     }
   }
   if (runState.lanes.length > 0) {
-    const evidenceLaneIds = new Set(_internals36.listLaneEvidenceSync(directory, phase));
+    const evidenceLaneIds = new Set(_internals37.listLaneEvidenceSync(directory, phase));
     for (const lane of runState.lanes) {
       if ((lane.status === "completed" || lane.status === "failed") && !evidenceLaneIds.has(lane.laneId)) {
         return {
@@ -89019,7 +89038,7 @@ function verifyLeanTurboPhaseReady(directory, phase, sessionIDOrConfig, config3)
       }
     }
   }
-  const activeLocks = _internals36.listActiveLocks(directory);
+  const activeLocks = _internals37.listActiveLocks(directory);
   const phaseLaneIds = new Set(laneIds);
   for (const lock of activeLocks) {
     if (lock.laneId && phaseLaneIds.has(lock.laneId)) {
@@ -89039,7 +89058,7 @@ function verifyLeanTurboPhaseReady(directory, phase, sessionIDOrConfig, config3)
   }
   const serialDegradedTasks = runState.degradedTasks.filter((dt) => !laneTaskIds.has(dt.taskId));
   if (serialDegradedTasks.length > 0) {
-    const plan = _internals36.readPlanJson(directory);
+    const plan = _internals37.readPlanJson(directory);
     if (!plan) {
       return {
         ok: false,
@@ -89083,7 +89102,7 @@ function verifyLeanTurboPhaseReady(directory, phase, sessionIDOrConfig, config3)
   }
   const serializedTasks = runState.serializedTasks;
   if (Array.isArray(serializedTasks) && serializedTasks.length > 0) {
-    const plan = _internals36.readPlanJson(directory);
+    const plan = _internals37.readPlanJson(directory);
     if (!plan) {
       return {
         ok: false,
@@ -89142,7 +89161,7 @@ function verifyLeanTurboPhaseReady(directory, phase, sessionIDOrConfig, config3)
   }
   let reviewerVerdict = runState.lastReviewerVerdict;
   if (!reviewerVerdict) {
-    const evidence = _internals36.readReviewerEvidence(directory, phase);
+    const evidence = _internals37.readReviewerEvidence(directory, phase);
     reviewerVerdict = evidence?.verdict ?? undefined;
   }
   if (mergedConfig.phase_reviewer) {
@@ -89155,7 +89174,7 @@ function verifyLeanTurboPhaseReady(directory, phase, sessionIDOrConfig, config3)
   }
   let criticVerdict = runState.lastCriticVerdict;
   if (!criticVerdict) {
-    const evidence = _internals36.readCriticEvidence(directory, phase);
+    const evidence = _internals37.readCriticEvidence(directory, phase);
     criticVerdict = evidence?.verdict ?? undefined;
   }
   if (mergedConfig.phase_critic) {
@@ -90058,7 +90077,7 @@ Advisory notes: ${advisoryNotes.join("; ")}` : "";
       phase_critic: leanConfig.phase_critic,
       integrated_diff_required: leanConfig.integrated_diff_required
     } : undefined;
-    const leanCheck = _internals36.verifyLeanTurboPhaseReady(dir, phase, sessionID, leanPhaseReadyConfig);
+    const leanCheck = _internals37.verifyLeanTurboPhaseReady(dir, phase, sessionID, leanPhaseReadyConfig);
     if (!leanCheck.ok) {
       return JSON.stringify({
         success: false,
@@ -92246,11 +92265,11 @@ var quality_budget = createSwarmTool({
     }).optional().describe("Quality budget thresholds")
   },
   async execute(args2, directory) {
-    const result = await _internals37.qualityBudget(args2, directory);
+    const result = await _internals38.qualityBudget(args2, directory);
     return JSON.stringify(result);
   }
 });
-var _internals37 = {
+var _internals38 = {
   qualityBudget
 };
 
@@ -92979,7 +92998,7 @@ import * as path109 from "node:path";
 var semgrepAvailableCache = null;
 var DEFAULT_RULES_DIR = ".swarm/semgrep-rules";
 var DEFAULT_TIMEOUT_MS3 = 30000;
-var _internals38 = {
+var _internals39 = {
   isSemgrepAvailable,
   checkSemgrepAvailable,
   resetSemgrepCache,
@@ -93004,7 +93023,7 @@ function isSemgrepAvailable() {
   }
 }
 async function checkSemgrepAvailable() {
-  return _internals38.isSemgrepAvailable();
+  return _internals39.isSemgrepAvailable();
 }
 function resetSemgrepCache() {
   semgrepAvailableCache = null;
@@ -93101,12 +93120,12 @@ async function runSemgrep(options) {
   const timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS3;
   if (files.length === 0) {
     return {
-      available: _internals38.isSemgrepAvailable(),
+      available: _internals39.isSemgrepAvailable(),
       findings: [],
       engine: "tier_a"
     };
   }
-  if (!_internals38.isSemgrepAvailable()) {
+  if (!_internals39.isSemgrepAvailable()) {
     return {
       available: false,
       findings: [],
@@ -93265,7 +93284,7 @@ function assignOccurrenceIndices(findings, directory) {
     }
     const occIdx = countMap.get(baseKey) ?? 0;
     countMap.set(baseKey, occIdx + 1);
-    const fp = _internals39.fingerprintFinding(finding, directory, occIdx);
+    const fp = _internals40.fingerprintFinding(finding, directory, occIdx);
     return {
       finding,
       index: occIdx,
@@ -93334,7 +93353,7 @@ async function captureOrMergeBaseline(directory, phase, findings, engine, scanne
       }
     } catch {}
     const scannedRelFiles = new Set(scannedFiles.map((f) => normalizeFindingPath(directory, f)));
-    const indexed = _internals39.assignOccurrenceIndices(findings, directory);
+    const indexed = _internals40.assignOccurrenceIndices(findings, directory);
     if (existing && !opts?.force) {
       const prunedFingerprints = existing.fingerprints.filter((fp) => {
         const relFile = fp.slice(0, fp.indexOf("|"));
@@ -93474,7 +93493,7 @@ function loadBaseline(directory, phase) {
     };
   }
 }
-var _internals39 = {
+var _internals40 = {
   fingerprintFinding,
   assignOccurrenceIndices,
   captureOrMergeBaseline,
@@ -93884,11 +93903,11 @@ var sast_scan = createSwarmTool({
       capture_baseline: safeArgs.capture_baseline,
       phase: safeArgs.phase
     };
-    const result = await _internals40.sastScan(input, directory);
+    const result = await _internals41.sastScan(input, directory);
     return JSON.stringify(result, null, 2);
   }
 });
-var _internals40 = {
+var _internals41 = {
   sastScan,
   sast_scan
 };
@@ -99071,7 +99090,7 @@ function resolveDefaultReviewerAgent(generatedAgentNames) {
 }
 async function compileReviewPackage(directory, phase, sessionID, requireDiffSummary) {
   const lanes = await listLaneEvidence(directory, phase);
-  const persisted = _internals41.readPersisted?.(directory) ?? null;
+  const persisted = _internals42.readPersisted?.(directory) ?? null;
   if (persisted) {
     let matchingRunState = null;
     for (const sessionState of Object.values(persisted.sessions)) {
@@ -99263,7 +99282,7 @@ Be specific and evidence-based. Do not approve a phase with unresolved degraded 
     client.session.delete({ path: { id: sessionId } }).catch(() => {});
   }
 }
-var _internals41 = {
+var _internals42 = {
   compileReviewPackage,
   parseReviewerVerdict,
   writeReviewerEvidence,
@@ -99280,28 +99299,28 @@ async function dispatchPhaseReviewer(directory, phase, sessionID, config3) {
   };
   const generatedAgentNames = swarmState.generatedAgentNames;
   const agentName = mergedConfig.reviewerAgent || resolveDefaultReviewerAgent(generatedAgentNames);
-  const pkg = await _internals41.compileReviewPackage(directory, phase, sessionID, mergedConfig.requireDiffSummary);
+  const pkg = await _internals42.compileReviewPackage(directory, phase, sessionID, mergedConfig.requireDiffSummary);
   let responseText;
   try {
-    responseText = await _internals41.dispatchReviewerAgent(directory, pkg, agentName, mergedConfig.timeoutMs);
+    responseText = await _internals42.dispatchReviewerAgent(directory, pkg, agentName, mergedConfig.timeoutMs);
   } catch (error93) {
-    const evidencePath2 = await _internals41.writeReviewerEvidence(directory, phase, "REJECTED", error93 instanceof Error ? error93.message : String(error93));
+    const evidencePath2 = await _internals42.writeReviewerEvidence(directory, phase, "REJECTED", error93 instanceof Error ? error93.message : String(error93));
     return {
       verdict: "REJECTED",
       reason: `Reviewer dispatch failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
       evidencePath: evidencePath2
     };
   }
-  const parsed = _internals41.parseReviewerVerdict(responseText);
+  const parsed = _internals42.parseReviewerVerdict(responseText);
   if (!parsed) {
-    const evidencePath2 = await _internals41.writeReviewerEvidence(directory, phase, "REJECTED", "Reviewer response could not be parsed");
+    const evidencePath2 = await _internals42.writeReviewerEvidence(directory, phase, "REJECTED", "Reviewer response could not be parsed");
     return {
       verdict: "REJECTED",
       reason: "Reviewer response could not be parsed",
       evidencePath: evidencePath2
     };
   }
-  const evidencePath = await _internals41.writeReviewerEvidence(directory, phase, parsed.verdict, parsed.reason);
+  const evidencePath = await _internals42.writeReviewerEvidence(directory, phase, parsed.verdict, parsed.reason);
   return {
     verdict: parsed.verdict,
     reason: parsed.reason,
@@ -99807,7 +99826,7 @@ ${fileList}
 
 // src/tools/lean-turbo-run-phase.ts
 init_create_tool();
-var _internals42 = {
+var _internals43 = {
   LeanTurboRunner,
   loadPluginConfigWithMeta
 };
@@ -99817,9 +99836,9 @@ async function executeLeanTurboRunPhase(args2) {
   let runError = null;
   let runner = null;
   try {
-    const { config: config3 } = _internals42.loadPluginConfigWithMeta(directory);
+    const { config: config3 } = _internals43.loadPluginConfigWithMeta(directory);
     const leanConfig = config3.turbo?.strategy === "lean" ? config3.turbo.lean : undefined;
-    runner = new _internals42.LeanTurboRunner({
+    runner = new _internals43.LeanTurboRunner({
       directory,
       sessionID,
       opencodeClient: swarmState.opencodeClient ?? null,
@@ -100173,7 +100192,7 @@ function isStaticallyEquivalent(originalCode, mutatedCode) {
   const strippedMutated = stripCode(mutatedCode);
   return strippedOriginal === strippedMutated;
 }
-var _internals43 = {
+var _internals44 = {
   isStaticallyEquivalent,
   checkEquivalence,
   batchCheckEquivalence
@@ -100213,7 +100232,7 @@ async function batchCheckEquivalence(patches, llmJudge) {
   const results = [];
   for (const { patch, originalCode, mutatedCode } of patches) {
     try {
-      const result = await _internals43.checkEquivalence(patch, originalCode, mutatedCode, llmJudge);
+      const result = await _internals44.checkEquivalence(patch, originalCode, mutatedCode, llmJudge);
       results.push(result);
     } catch (err3) {
       results.push({
@@ -100513,7 +100532,7 @@ async function executeMutationSuite(patches, testCommand, testFiles, workingDir,
 }
 
 // src/mutation/gate.ts
-var _internals44 = {
+var _internals45 = {
   evaluateMutationGate,
   buildTestImprovementPrompt,
   buildMessage
@@ -100534,8 +100553,8 @@ function evaluateMutationGate(report, passThreshold = PASS_THRESHOLD, warnThresh
   } else {
     verdict = "fail";
   }
-  const testImprovementPrompt = _internals44.buildTestImprovementPrompt(report, passThreshold, verdict);
-  const message = _internals44.buildMessage(verdict, adjustedKillRate, report.killed, report.totalMutants, report.equivalent, warnThreshold);
+  const testImprovementPrompt = _internals45.buildTestImprovementPrompt(report, passThreshold, verdict);
+  const message = _internals45.buildMessage(verdict, adjustedKillRate, report.killed, report.totalMutants, report.equivalent, warnThreshold);
   return {
     verdict,
     killRate: report.killRate,
@@ -101152,7 +101171,7 @@ import * as path131 from "node:path";
 init_bun_compat();
 import * as fs102 from "node:fs";
 import * as path130 from "node:path";
-var _internals45 = { bunSpawn };
+var _internals46 = { bunSpawn };
 var _swarmGitExcludedChecked = false;
 function fileCoversSwarm(content) {
   for (const rawLine of content.split(`
@@ -101185,7 +101204,7 @@ async function ensureSwarmGitExcluded(directory, options = {}) {
       checkIgnoreExitCode
     ] = await Promise.all([
       (async () => {
-        const proc = _internals45.bunSpawn(["git", "-C", directory, "rev-parse", "--show-toplevel"], GIT_SPAWN_OPTIONS);
+        const proc = _internals46.bunSpawn(["git", "-C", directory, "rev-parse", "--show-toplevel"], GIT_SPAWN_OPTIONS);
         try {
           return await Promise.all([proc.exited, proc.stdout.text()]);
         } finally {
@@ -101195,7 +101214,7 @@ async function ensureSwarmGitExcluded(directory, options = {}) {
         }
       })(),
       (async () => {
-        const proc = _internals45.bunSpawn(["git", "-C", directory, "rev-parse", "--git-path", "info/exclude"], GIT_SPAWN_OPTIONS);
+        const proc = _internals46.bunSpawn(["git", "-C", directory, "rev-parse", "--git-path", "info/exclude"], GIT_SPAWN_OPTIONS);
         try {
           return await Promise.all([proc.exited, proc.stdout.text()]);
         } finally {
@@ -101205,7 +101224,7 @@ async function ensureSwarmGitExcluded(directory, options = {}) {
         }
       })(),
       (async () => {
-        const proc = _internals45.bunSpawn(["git", "-C", directory, "check-ignore", "-q", ".swarm/.gitkeep"], GIT_SPAWN_OPTIONS);
+        const proc = _internals46.bunSpawn(["git", "-C", directory, "check-ignore", "-q", ".swarm/.gitkeep"], GIT_SPAWN_OPTIONS);
         try {
           return await proc.exited;
         } finally {
@@ -101244,7 +101263,7 @@ async function ensureSwarmGitExcluded(directory, options = {}) {
         }
       } catch {}
     }
-    const trackedProc = _internals45.bunSpawn(["git", "-C", directory, "ls-files", "--", ".swarm"], GIT_SPAWN_OPTIONS);
+    const trackedProc = _internals46.bunSpawn(["git", "-C", directory, "ls-files", "--", ".swarm"], GIT_SPAWN_OPTIONS);
     let trackedExitCode;
     let trackedOutput;
     try {
@@ -101269,7 +101288,7 @@ async function ensureSwarmGitExcluded(directory, options = {}) {
 }
 
 // src/hooks/diff-scope.ts
-var _internals46 = { bunSpawn };
+var _internals47 = { bunSpawn };
 function getDeclaredScope(taskId, directory) {
   try {
     const planPath = path131.join(directory, ".swarm", "plan.json");
@@ -101304,7 +101323,7 @@ var GIT_DIFF_SPAWN_OPTIONS = {
 };
 async function getChangedFiles(directory) {
   try {
-    const proc = _internals46.bunSpawn(["git", "diff", "--name-only", "HEAD~1"], {
+    const proc = _internals47.bunSpawn(["git", "diff", "--name-only", "HEAD~1"], {
       cwd: directory,
       ...GIT_DIFF_SPAWN_OPTIONS
     });
@@ -101321,7 +101340,7 @@ async function getChangedFiles(directory) {
       return stdout.trim().split(`
 `).map((f) => f.trim()).filter((f) => f.length > 0);
     }
-    const proc2 = _internals46.bunSpawn(["git", "diff", "--name-only", "HEAD"], {
+    const proc2 = _internals47.bunSpawn(["git", "diff", "--name-only", "HEAD"], {
       cwd: directory,
       ...GIT_DIFF_SPAWN_OPTIONS
     });
@@ -101379,7 +101398,7 @@ init_telemetry();
 init_file_locks();
 import * as fs104 from "node:fs";
 import * as path132 from "node:path";
-var _internals47 = {
+var _internals48 = {
   listActiveLocks,
   verifyLeanTurboTaskCompletion
 };
@@ -101521,7 +101540,7 @@ function verifyLeanTurboTaskCompletion(directory, taskId, sessionID) {
       }
     };
   }
-  const activeLocks = _internals47.listActiveLocks(directory);
+  const activeLocks = _internals48.listActiveLocks(directory);
   const laneLocks = activeLocks.filter((lock) => lock.laneId === lane.laneId);
   if (laneLocks.length > 0) {
     return {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -215,9 +215,14 @@ Run preflight automation checks before starting a phase. Validates plan complete
 
 ## Execution Modes
 
-### `/swarm turbo [on|off]`
+### `/swarm turbo [on|off|lean|standard|status]`
 
-Toggle Turbo Mode for the current session. Skips non-critical QA gates for faster iteration. Session-scoped; resets on new session.
+Toggle Turbo Mode for the current session. Supports two strategies:
+
+- **Standard** — skips non-critical QA gates for faster iteration
+- **Lean** — parallel lane execution with per-lane reviewer gates and file-lock conflict detection
+
+Session-scoped; resets on new session.
 
 ```text
 /swarm turbo              # toggle standard turbo
@@ -227,6 +232,7 @@ Toggle Turbo Mode for the current session. Skips non-critical QA gates for faste
 /swarm turbo lean off     # disable Lean Turbo
 /swarm turbo lean         # toggle Lean Turbo explicitly
 /swarm turbo standard on  # force standard turbo
+/swarm turbo standard off # disable standard turbo
 /swarm turbo status       # show detailed status
 ```
 

--- a/docs/releases/v7.17.3.md
+++ b/docs/releases/v7.17.3.md
@@ -1,0 +1,28 @@
+# v7.17.3
+
+## What changed
+
+### Lean Turbo command visibility (registry metadata)
+- Updated the `/swarm turbo` command registry entry (`src/commands/registry.ts`) to document lean and standard strategies in the description, args (`on, off, lean, standard, status`), and details fields
+- Added `turbo standard off` subcommand to registry and docs (was supported at runtime but undocumented)
+- Updated `docs/commands.md` to describe both standard and lean turbo strategies
+
+### Pre-existing turbo test failures fixed
+- Added `_internals` DI seam to `src/commands/turbo.ts` for `loadPluginConfigWithMeta`, following the AGENTS.md §7 pattern (established in `gitignore-warning.ts` and `diff-scope.ts`)
+- Fixed 5 pre-existing test failures across 3 test files (`turbo.test.ts`, `turbo-registration.test.ts`, `turbo.regression.test.ts`) by mocking `_internals.loadPluginConfigWithMeta` to return standard strategy config in `beforeEach`/`afterEach` pairs
+- Added `turbo.internals.test.ts` — 7 tests verifying the `_internals` DI seam (swap, restore, isolation)
+
+## Why
+
+PR #820 added Lean Turbo parallel lane execution but didn't update the command registry metadata or existing turbo tests. This caused:
+1. Architects couldn't discover lean turbo subcommands from the registry description/details
+2. 5 tests failed because `handleTurboCommand('on')` read the project's lean config and returned "Lean Turbo enabled..." instead of expected "Turbo Mode enabled"
+
+## Migration steps
+
+No migration needed. No API or config changes.
+
+## Known caveats
+
+- The `_internals` DI seam pattern is intentional per AGENTS.md §7 — `mock.module` leaks across files in Bun's shared test-runner process
+- Pre-existing lint warnings in `src/turbo/lean/` code (unused imports, explicit any) are unrelated to this change

--- a/src/commands/index.help-text.test.ts
+++ b/src/commands/index.help-text.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, it, test } from 'bun:test';
 import { buildHelpText } from './index';
 import type { CommandEntry, RegisteredCommand } from './registry';
 import { COMMAND_REGISTRY, VALID_COMMANDS } from './registry';
@@ -202,5 +202,20 @@ describe('buildHelpText()', () => {
 			expect(positions[2]).toBeLessThan(positions[3]); // evidence < summary
 			expect(positions[4]).toBeLessThan(positions[5]); // config < doctor
 		});
+	});
+});
+
+describe('turbo command registry', () => {
+	it('description mentions lean turbo', () => {
+		expect(COMMAND_REGISTRY.turbo.description).toMatch(/lean/i);
+	});
+
+	it('args include lean and status subcommands', () => {
+		expect(COMMAND_REGISTRY.turbo.args).toContain('lean');
+		expect(COMMAND_REGISTRY.turbo.args).toContain('status');
+	});
+
+	it('details document lean turbo subcommands', () => {
+		expect(COMMAND_REGISTRY.turbo.details).toMatch(/lean/i);
 	});
 });

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -619,10 +619,26 @@ export const COMMAND_REGISTRY = {
 	turbo: {
 		handler: (ctx) =>
 			handleTurboCommand(ctx.directory, ctx.args, ctx.sessionID),
-		description: 'Toggle Turbo Mode for the active session [on|off]',
-		args: 'on, off',
+		description:
+			'Toggle Turbo Mode strategy for the active session [on|off|lean|standard|status]',
+		args: 'on, off, lean, standard, status',
 		details:
-			'Toggles Turbo Mode which skips non-critical QA gates for faster iteration. When enabled, the architect can proceed without waiting for all automated checks. Session-scoped — resets on new session. Use "on" or "off" to set explicitly, or toggle with no argument.',
+			'Toggles Turbo Mode for the current session. Supports two strategies:\n' +
+			'\n' +
+			'**Standard turbo** — skips non-critical QA gates for faster iteration.\n' +
+			'**Lean turbo** — parallel lane execution with per-lane reviewer gates and file-lock conflict detection.\n' +
+			'\n' +
+			'Subcommands:\n' +
+			'  turbo on           — enable turbo (uses lean when config turbo.strategy is "lean", otherwise standard)\n' +
+			'  turbo off          — disable all turbo modes\n' +
+			'  turbo lean on      — enable Lean Turbo explicitly\n' +
+			'  turbo lean off     — disable Lean Turbo\n' +
+			'  turbo lean         — toggle Lean Turbo on/off\n' +
+			'  turbo standard on  — force standard turbo (disables lean even if config says lean)\n' +
+			'  turbo standard off — disable standard turbo (falls back to lean if config strategy is lean)\n' +
+			'  turbo status       — show detailed status including active strategy and lanes\n' +
+			'\n' +
+			'Session-scoped — resets on new session.',
 		category: 'utility',
 	},
 	'full-auto': {

--- a/src/commands/turbo-registration.test.ts
+++ b/src/commands/turbo-registration.test.ts
@@ -6,7 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import * as commandsIndex from '../commands/index';
 import { COMMAND_REGISTRY, VALID_COMMANDS } from '../commands/registry';
-import { handleTurboCommand } from '../commands/turbo';
+import { _internals, handleTurboCommand } from '../commands/turbo';
 import { getAgentSession, swarmState } from '../state';
 
 // Test the switch case routing by creating a mock handler
@@ -75,8 +75,17 @@ describe('Task 3.12: Turbo Command Registration', () => {
 
 	describe('Switch Case Routing', () => {
 		let testSessionId: string;
+		const originalLoad = _internals.loadPluginConfigWithMeta;
 
 		beforeEach(() => {
+			// Stub config loading so tests don't read the real project config
+			_internals.loadPluginConfigWithMeta = () => ({
+				config: {
+					turbo: { strategy: 'standard' },
+				} as unknown as import('../config').PluginConfig,
+				loadedFromFile: false,
+			});
+
 			// Create a test session with turboMode = false
 			testSessionId = `switch-test-${Date.now()}`;
 			swarmState.agentSessions.set(testSessionId, {
@@ -129,6 +138,7 @@ describe('Task 3.12: Turbo Command Registration', () => {
 
 		afterEach(() => {
 			swarmState.agentSessions.delete(testSessionId);
+			_internals.loadPluginConfigWithMeta = originalLoad;
 		});
 
 		it('switch case should route "turbo" subcommand to handleTurboCommand', async () => {

--- a/src/commands/turbo.internals.test.ts
+++ b/src/commands/turbo.internals.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { getAgentSession, swarmState } from '../state';
+import { _internals, handleTurboCommand } from './turbo';
+
+// Track the original for restoration
+type LoadPluginConfigWithMetaType = typeof _internals.loadPluginConfigWithMeta;
+let original_loadPluginConfigWithMeta: LoadPluginConfigWithMetaType;
+
+let testSessionId: string;
+let tmpDir: string;
+
+describe('turbo _internals DI seam', () => {
+	beforeEach(() => {
+		// Save original before each test
+		original_loadPluginConfigWithMeta = _internals.loadPluginConfigWithMeta;
+
+		// Create a temp directory for turbo state persistence (avoids writes outside repo sandbox)
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'turbo-internals-test-'));
+
+		// Create a test session via swarmState (same pattern as other turbo test files)
+		testSessionId = `internals-test-${Date.now()}`;
+		swarmState.agentSessions.set(testSessionId, {
+			agentName: 'architect',
+			lastToolCallTime: Date.now(),
+			lastAgentEventTime: Date.now(),
+			delegationActive: false,
+			activeInvocationId: 0,
+			lastInvocationIdByAgent: {},
+			windows: {},
+			lastCompactionHint: 0,
+			architectWriteCount: 0,
+			lastCoderDelegationTaskId: null,
+			currentTaskId: '1.1',
+			gateLog: new Map(),
+			reviewerCallCount: new Map(),
+			lastGateFailure: null,
+			partialGateWarningsIssuedForTask: new Set<string>(),
+			selfFixAttempted: false,
+			selfCodingWarnedAtCount: 0,
+			catastrophicPhaseWarnings: new Set<number>(),
+			qaSkipCount: 0,
+			qaSkipTaskIds: [],
+			taskWorkflowStates: new Map(),
+			stageBCompletion: new Map(),
+			taskCouncilApproved: new Map(),
+			lastGateOutcome: null,
+			declaredCoderScope: null,
+			turboMode: false,
+			turboStrategy: undefined as string | undefined,
+			leanTurboActive: false,
+			leanTurboCurrentPhase: undefined as number | undefined,
+			fullAutoMode: false,
+		});
+	});
+
+	afterEach(() => {
+		// Restore original _internals
+		_internals.loadPluginConfigWithMeta = original_loadPluginConfigWithMeta;
+
+		// Clean up session
+		swarmState.agentSessions.delete(testSessionId);
+
+		// Clean up temp directory
+		if (tmpDir) {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	test('_internals is exported', () => {
+		expect(_internals).toBeDefined();
+		expect(typeof _internals).toBe('object');
+	});
+
+	test('_internals.loadPluginConfigWithMeta is a function', () => {
+		expect(typeof _internals.loadPluginConfigWithMeta).toBe('function');
+	});
+
+	test('swapping _internals.loadPluginConfigWithMeta with a mock works — turbo on path (line 114)', async () => {
+		// Arrange: swap with a mock
+		const mockFn = mock(() => ({
+			config: { turbo: { strategy: 'standard' } },
+		}));
+		_internals.loadPluginConfigWithMeta = mockFn;
+
+		// Act: call handleTurboCommand with 'on' arg (exercises line 114)
+		const result = await handleTurboCommand(tmpDir, ['on'], testSessionId);
+
+		// Assert: mock was called
+		expect(mockFn).toHaveBeenCalledWith(tmpDir);
+		// Result should be 'Turbo Mode enabled' since strategy is 'standard'
+		expect(result).toBe('Turbo Mode enabled');
+	});
+
+	test('swapping _internals.loadPluginConfigWithMeta with a mock works — lean turbo on path (line 196)', async () => {
+		// Arrange: swap with a mock that returns lean strategy
+		const mockFn = mock(() => ({
+			config: {
+				turbo: {
+					strategy: 'lean',
+					lean: { max_parallel_coders: 2, conflict_policy: 'degrade' as const },
+				},
+			},
+		}));
+		_internals.loadPluginConfigWithMeta = mockFn;
+
+		// Act: call handleTurboCommand with 'lean on' args (exercises line 196)
+		const result = await handleTurboCommand(
+			tmpDir,
+			['lean', 'on'],
+			testSessionId,
+		);
+
+		// Assert: mock was called
+		expect(mockFn).toHaveBeenCalledWith(tmpDir);
+		// Result should indicate lean turbo was enabled
+		expect(result).toContain('Lean Turbo enabled');
+	});
+
+	test('restoring the original works correctly', () => {
+		// Arrange: swap with mock
+		const mockFn = mock(() => ({ config: {} }));
+		_internals.loadPluginConfigWithMeta = mockFn;
+
+		// Act: restore
+		_internals.loadPluginConfigWithMeta = original_loadPluginConfigWithMeta;
+
+		// Assert: original function is restored
+		expect(_internals.loadPluginConfigWithMeta).toBe(
+			original_loadPluginConfigWithMeta,
+		);
+		// Verify it points to the actual imported function
+		expect(typeof _internals.loadPluginConfigWithMeta).toBe('function');
+	});
+
+	test('original loadPluginConfigWithMeta is the real function', () => {
+		// Verify the original is the actual imported function
+		expect(original_loadPluginConfigWithMeta.name).toBe(
+			'loadPluginConfigWithMeta',
+		);
+	});
+
+	test('swap persists within a test (verifies isolated mutation)', async () => {
+		// This test verifies that swapping _internals in one call affects subsequent calls
+		// First call: mock returns lean strategy
+		const mockFn = mock(() => ({
+			config: { turbo: { strategy: 'lean', lean: { max_parallel_coders: 8 } } },
+		}));
+		_internals.loadPluginConfigWithMeta = mockFn;
+
+		const result1 = await handleTurboCommand(
+			tmpDir,
+			['lean', 'on'],
+			testSessionId,
+		);
+		expect(result1).toContain('Lean Turbo enabled');
+		expect(result1).toContain('maxParallelCoders=8');
+
+		// Second call with same mock should also use lean (mock still in place)
+		const result2 = await handleTurboCommand(
+			tmpDir,
+			['lean', 'on'],
+			testSessionId,
+		);
+		expect(result2).toContain('Lean Turbo enabled');
+		expect(result2).toContain('maxParallelCoders=8');
+
+		// Verify mock was called twice
+		expect(mockFn).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/commands/turbo.regression.test.ts
+++ b/src/commands/turbo.regression.test.ts
@@ -22,11 +22,12 @@ import {
 } from '../services/status-service';
 import { getAgentSession, hasActiveTurboMode, swarmState } from '../state';
 import { checkReviewerGate } from '../tools/update-task-status';
-import { handleTurboCommand } from './turbo';
+import { _internals, handleTurboCommand } from './turbo';
 
 describe('Task 4: Turbo Mode Regression Tests', () => {
 	let testSessionId: string;
 	let tmpDir: string;
+	let originalLoadPluginConfigWithMeta: typeof _internals.loadPluginConfigWithMeta;
 
 	beforeEach(() => {
 		// Create a test session
@@ -80,6 +81,15 @@ describe('Task 4: Turbo Mode Regression Tests', () => {
 
 		// Create temp directory for plan.json
 		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'turbo-regression-'));
+
+		// Mock loadPluginConfigWithMeta to return standard turbo strategy,
+		// preventing handleTurboCommand from reading the project's lean turbo config
+		// and returning "Lean Turbo enabled..." instead of "Turbo Mode enabled".
+		originalLoadPluginConfigWithMeta = _internals.loadPluginConfigWithMeta;
+		_internals.loadPluginConfigWithMeta = () => ({
+			config: { turbo: { strategy: 'standard' } },
+			loadedFromFile: false,
+		});
 	});
 
 	afterEach(() => {
@@ -92,6 +102,9 @@ describe('Task 4: Turbo Mode Regression Tests', () => {
 		} catch {
 			// Ignore cleanup errors
 		}
+
+		// Restore original loadPluginConfigWithMeta
+		_internals.loadPluginConfigWithMeta = originalLoadPluginConfigWithMeta;
 	});
 
 	// ============================================

--- a/src/commands/turbo.test.ts
+++ b/src/commands/turbo.test.ts
@@ -4,13 +4,21 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { handleTurboCommand } from '../commands/turbo';
+import { _internals, handleTurboCommand } from '../commands/turbo';
 import { getAgentSession, swarmState } from '../state';
 
 describe('handleTurboCommand', () => {
 	let testSessionId: string;
+	let originalLoadPluginConfigWithMeta: typeof _internals.loadPluginConfigWithMeta;
 
 	beforeEach(() => {
+		// Stub _internals DI seam so tests get standard turbo config
+		// instead of whatever the real project's .swarm/ settings contain.
+		originalLoadPluginConfigWithMeta = _internals.loadPluginConfigWithMeta;
+		_internals.loadPluginConfigWithMeta = () => ({
+			config: { turbo: { strategy: 'standard' } },
+			loadedFromFile: false,
+		});
 		// Create a test session
 		testSessionId = `turbo-test-${Date.now()}`;
 		swarmState.agentSessions.set(testSessionId, {
@@ -62,6 +70,8 @@ describe('handleTurboCommand', () => {
 	});
 
 	afterEach(() => {
+		// Restore the original _internals seam
+		_internals.loadPluginConfigWithMeta = originalLoadPluginConfigWithMeta;
 		// Clean up test session
 		swarmState.agentSessions.delete(testSessionId);
 	});

--- a/src/commands/turbo.ts
+++ b/src/commands/turbo.ts
@@ -10,6 +10,19 @@ import {
 import * as logger from '../utils/logger';
 
 /**
+ * Test-only dependency-injection seam. Production code calls
+ * `_internals.loadPluginConfigWithMeta(...)` so tests can replace the function
+ * on this object without using `mock.module` from `bun:test`, which leaks
+ * across files in Bun's shared test-runner process (AGENTS.md §7).
+ * Mutating this local object is file-scoped and trivially restorable via afterEach.
+ */
+export const _internals: {
+	loadPluginConfigWithMeta: typeof loadPluginConfigWithMeta;
+} = {
+	loadPluginConfigWithMeta,
+};
+
+/**
  * Handles the /swarm turbo command.
  * Supports standard turbo toggle, lean turbo mode, and status reporting.
  *
@@ -98,7 +111,7 @@ export async function handleTurboCommand(
 		// turbo on → enable standard UNLESS config says lean
 		let strategy: 'standard' | 'lean' = 'standard';
 		try {
-			const { config } = loadPluginConfigWithMeta(directory);
+			const { config } = _internals.loadPluginConfigWithMeta(directory);
 			if (config.turbo?.strategy === 'lean') {
 				strategy = 'lean';
 			}
@@ -180,7 +193,7 @@ function enableLeanTurbo(
 
 	// Read config for lean settings
 	try {
-		const { config } = loadPluginConfigWithMeta(directory);
+		const { config } = _internals.loadPluginConfigWithMeta(directory);
 		const leanConfig = config.turbo?.lean;
 		if (leanConfig) {
 			maxParallelCoders = leanConfig.max_parallel_coders ?? 4;


### PR DESCRIPTION
﻿## Summary
- Updated `/swarm turbo` command registry metadata (description, args, details) to document lean and standard turbo strategies, making lean turbo subcommands discoverable by architects
- Added `_internals` DI seam to `src/commands/turbo.ts` for `loadPluginConfigWithMeta` per AGENTS.md §7, avoiding `mock.module` cross-file leakage in Bun's shared test runner
- Fixed 5 pre-existing test failures across `turbo.test.ts`, `turbo-registration.test.ts`, and `turbo.regression.test.ts` by mocking `_internals.loadPluginConfigWithMeta` to return standard strategy config
- Added `turbo standard off` subcommand to registry and docs (was missing from documentation)

## Invariant audit
- 1 (plugin init):       not touched — no init-path changes
- 2 (runtime portability): not touched — no top-level bun: imports or export shape changes
- 3 (subprocesses):       not touched — no spawn calls changed
- 4 (.swarm containment): not touched — no tool working directory changes
- 5 (plan durability):    not touched — no plan schema changes
- 6 (test_runner safety): not touched — used shell `bun --smol test` commands, never test_runner tool with scope:graph
- 7 (test writing):       touched — added _internals DI seam pattern per AGENTS.md S7, verified with `bunx biome ci .` and 71/71 turbo tests passing; test uses `os.tmpdir()` + `mkdtempSync` with `rmSync` cleanup in afterEach
- 8 (session state):      not touched — no session state changes
- 9 (guardrails/retry):   not touched — no guardrail changes
- 10 (chat/system msg):   not touched — no hook changes
- 11 (tool registration): touched — updated command registry entry in `src/commands/registry.ts` (description, args, details for turbo command); config unit tests 1159/1162 pass (3 pre-existing failures on main); help-text regression tests 17/17 pass
- 12 (release/cache):     not touched — no cache or package.json version changes

## Test plan
- [x] `bunx biome ci .` passes (1 pre-existing warning in src/turbo/lean/runner.ts)
- [x] `bun run typecheck` passes
- [x] 71 turbo + help-text tests pass (0 failures)
- [x] 135 security tests pass (0 failures)
- [x] 10 smoke tests pass (0 failures)
- [x] 98 integration test failures confirmed pre-existing on main (verified via git stash + clean main checkout)
- [x] 3 config test failures confirmed pre-existing on main
- [x] `bun run build` succeeds, dist/ artifacts committed
- [x] Test file uses `os.tmpdir()` + `mkdtempSync` with cleanup — no writes outside temp sandbox

## Pre-existing failures
- 3 config unit test failures (critic_sounding_board model name, loader defaults) — exist on origin/main
- 98 integration test failures (curator, dark matter, full-auto, system-enhancer) — exist on origin/main
