### PR TITLE
fix(qa-gate): run final council as project-scoped 5-member council

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.17.0",
+    version: "7.17.1",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/dist/council/council-service.d.ts
+++ b/dist/council/council-service.d.ts
@@ -8,7 +8,7 @@
  * No I/O — fully unit-testable with mock inputs. All file reads/writes happen in
  * sibling modules (criteria-store, council-evidence-writer).
  */
-import type { CouncilConfig, CouncilCriteria, CouncilMemberVerdict, CouncilSynthesis, PhaseCouncilSynthesis } from './types';
+import type { CouncilConfig, CouncilCriteria, CouncilMemberVerdict, CouncilSynthesis, FinalCouncilSynthesis, PhaseCouncilSynthesis } from './types';
 export declare function synthesizeCouncilVerdicts(taskId: string, swarmId: string, verdicts: CouncilMemberVerdict[], criteria: CouncilCriteria | null, roundNumber: number, config?: Partial<CouncilConfig>): CouncilSynthesis;
 /**
  * Synthesize phase-level council verdicts into a PhaseCouncilSynthesis.
@@ -19,3 +19,9 @@ export declare function synthesizeCouncilVerdicts(taskId: string, swarmId: strin
  * (see writePhaseCouncilEvidence in submit-phase-council-verdicts.ts).
  */
 export declare function synthesizePhaseCouncilAdvisory(phaseNumber: number, phaseSummary: string, verdicts: CouncilMemberVerdict[], roundNumber: number, config?: Partial<CouncilConfig>, _workingDir?: string): PhaseCouncilSynthesis;
+/**
+ * Synthesize project-level final council verdicts into a FinalCouncilSynthesis.
+ * This uses the same five-member verdict semantics as phase council, but the
+ * output is scoped to completed-project review and the final_council gate.
+ */
+export declare function synthesizeFinalCouncilAdvisory(projectSummary: string, verdicts: CouncilMemberVerdict[], roundNumber: number, config?: Partial<CouncilConfig>): FinalCouncilSynthesis;

--- a/dist/council/types.d.ts
+++ b/dist/council/types.d.ts
@@ -87,6 +87,38 @@ export interface PhaseCouncilSynthesis {
     /** Summary of the phase being reviewed */
     phaseSummary?: string;
 }
+/**
+ * Project-level final council synthesis result.
+ * Distinct from task-level and phase-level council results: this is the
+ * final project close gate and writes to .swarm/evidence/final-council.json.
+ */
+export interface FinalCouncilSynthesis {
+    /** Always 'project' - distinguishes final council from task/phase councils */
+    scope: 'project';
+    /** ISO 8601 */
+    timestamp: string;
+    overallVerdict: CouncilVerdict;
+    vetoedBy: CouncilAgent[] | null;
+    memberVerdicts: CouncilMemberVerdict[];
+    unresolvedConflicts: string[];
+    /** Severity HIGH + MEDIUM from veto members */
+    requiredFixes: CouncilFinding[];
+    /** Severity LOW or from non-veto members */
+    advisoryFindings: CouncilFinding[];
+    /** Project-level advisory notes for the architect */
+    advisoryNotes: string[];
+    /** Single markdown document for final project review */
+    unifiedFeedbackMd: string;
+    /** 1-indexed */
+    roundNumber: number;
+    allCriteriaMet: boolean;
+    /** Distinct council members that produced verdicts */
+    quorumSize: number;
+    /** Path where evidence was written */
+    evidencePath: '.swarm/evidence/final-council.json';
+    /** Summary of the completed project being reviewed */
+    projectSummary: string;
+}
 export interface CouncilCriteriaItem {
     id: string;
     description: string;

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.17.0",
+    version: "7.17.1",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -61457,7 +61457,7 @@ Present the eleven gates with their defaults (DEFAULT_QA_GATES) as a single user
 - mutation_test (default: OFF) — when enabled, runs mutation testing on source files touched this phase via generate_mutants + mutation_test + write_mutation_evidence at PHASE-WRAP; FAIL verdict blocks phase_complete; WARN is non-blocking (recommended for projects with coverage gaps or safety-critical code)
 - council_general_review (default: OFF) — when enabled, MODE: SPECIFY runs convene_general_council on the draft spec before the critic-gate; the architect runs a curated web_search pass, dispatches council_generalist / council_skeptic / council_domain_expert in parallel with a shared RESEARCH CONTEXT block, deliberates on disagreements, and synthesizes the result directly into the spec (recommended for novel architecture, unclear best practices, or high-risk design decisions). Requires council.general.enabled: true and a configured search API key.
 - drift_check (default: ON) — when enabled, mandatory per-phase drift verification via critic_drift_verifier at PHASE-WRAP; compares implemented changes against spec.md intent; hard-blocks phase_complete when spec.md exists and drift evidence is missing or REJECTED; advisory-only when no spec.md exists (recommended for all projects with a specification)
-- final_council (default: OFF) — when enabled, after all phases complete the architect convenes a holistic general council review of the entire body of work before project close. Requires council.general.enabled: true in plugin config. Recommended for multi-phase projects with high architectural complexity.
+- final_council (default: OFF) - when enabled, after all phases complete the architect dispatches the same five phase-council members (\`critic\`, \`reviewer\`, \`sme\`, \`test_engineer\`, \`explorer\`) at project scope, collects \`CouncilMemberVerdict\` objects, and calls \`write_final_council_evidence\`. This is not General Council mode and does not require \`council.general.enabled\`.
 
 One question, one message, defaults pre-stated. Wait for the user's answer.
 
@@ -63297,19 +63297,15 @@ The tool will automatically write the retrospective to \`.swarm/evidence/retro-{
    - \`.swarm/evidence/{phase}/mutation-gate.json\` exists with verdict 'pass' or 'warn' (written by YOU via the \`write_mutation_evidence\` tool after step 5.56) — ONLY required when \`mutation_test\` is enabled in the QA gate profile
    If any required file is missing, run the missing gate first. Turbo mode skips all gates automatically.
    NOTE: Steps 5.5, 5.55, and 5.56 are enforced by runtime hooks. If \`hallucination_guard\` is enabled and you skip the critic_hallucination_verifier delegation (or fail to call \`write_hallucination_evidence\`), phase_complete will be BLOCKED by the plugin. Similarly, if \`mutation_test\` is enabled and you skip step 5.56 (or fail to call \`write_mutation_evidence\`), phase_complete will be BLOCKED. These are not suggestions — they are hard enforcement mechanisms.
-5.7. **Final Council (conditional on QA gate — last phase only)**: Check whether \`final_council\` is enabled in the effective QA gate profile (visible via \`get_qa_gate_profile\`). If disabled, skip silently and proceed to step 6.
+5.7. **Final Council (conditional on QA gate - last phase only)**: Check whether \`final_council\` is enabled in the effective QA gate profile (visible via \`get_qa_gate_profile\`). If disabled, skip silently and proceed to step 6.
    If enabled AND this is the LAST phase in the plan (all other phases have status 'complete' and no more phases remain):
-    1. Verify \`council.general.enabled: true\` in plugin config. If not enabled, warn the user: "final_council gate is enabled but General Council is not configured. Skipping final council." Then proceed to step 6. Check that \`convene_general_council\` is available in your tool list. If the tool is unavailable (filtered by config), warn the user and skip.
-   2. Run 1-3 targeted \`web_search\` queries relevant to the project domain.
-   3. Compile a RESEARCH CONTEXT block from search results.
-   4. Dispatch \`{{AGENT_PREFIX}}council_generalist\`, \`{{AGENT_PREFIX}}council_skeptic\`, and \`{{AGENT_PREFIX}}council_domain_expert\` in PARALLEL. Pass: the full body of work (all phase summaries, all evidence artifacts), the RESEARCH CONTEXT block, round number 1. Instruction: "Review the entire body of work holistically. Identify cross-cutting issues, architectural coherence, and overall quality."
-   5. Collect all three JSON responses.
-   6. Call \`convene_general_council\` with mode: 'general', the project summary as question, and the collected round1Responses.
-   7. If disagreements exist, re-dispute as in MODE: COUNCIL step 5-6.
-   8. Present the final synthesis to the user as a project-close summary.
-   9. Write the final council result to \`.swarm/evidence/final-council.json\`.
-   10. Do NOT call \`/swarm close\` until the final council completes (if enabled). The evidence file \`.swarm/evidence/final-council.json\` must exist with an APPROVED verdict before \`/swarm close\` is permitted when final_council is enabled.
-   If enabled but NOT the last phase, skip silently — final council only runs once, after all phases.
+   1. Build a PROJECT DOSSIER from the completed plan, all phase summaries, changed-file summaries, and all relevant evidence artifacts. This is a completed-project review, not General Council mode.
+   2. Dispatch \`{{AGENT_PREFIX}}critic\`, \`{{AGENT_PREFIX}}reviewer\`, \`{{AGENT_PREFIX}}sme\`, \`{{AGENT_PREFIX}}test_engineer\`, and \`{{AGENT_PREFIX}}explorer\` in PARALLEL with project-scoped context. Each member must review the entire completed body of work and return a \`CouncilMemberVerdict\` JSON object using \`agent\`, \`verdict\` (APPROVE|CONCERNS|REJECT), \`confidence\`, \`findings[]\`, \`criteriaAssessed[]\`, \`criteriaUnmet[]\`, and \`durationMs\`.
+   3. Collect the five returned verdict objects. Do NOT fabricate, infer, or substitute verdicts. If a member does not return valid JSON, re-dispatch that member.
+   4. Call \`write_final_council_evidence\` with \`phase\`, \`projectSummary\`, \`roundNumber\`, and the collected \`verdicts\` array. This writes \`.swarm/evidence/final-council.json\` with plan binding, member verdicts, and quorum metadata.
+   5. Do NOT call \`convene_general_council\`, do NOT dispatch \`council_generalist\`, \`council_skeptic\`, or \`council_domain_expert\`, and do NOT require \`council.general.enabled\` for this gate. \`final_council\` is the same five-member phase council rerun at project scope.
+   6. Do NOT call \`phase_complete\` or \`/swarm close\` until \`.swarm/evidence/final-council.json\` exists with an approved, plan-bound, quorumed final-council verdict. When \`final_council\` is enabled, \`phase_complete\` will block until that evidence exists.
+   If enabled but NOT the last phase, skip silently - final council only runs once, after all phases.
 6. Summarize to user
 7. Ask: "Ready for Phase [N+1]?"
 
@@ -85374,6 +85370,99 @@ function buildPhaseCouncilFeedback(phaseNumber, phaseSummary, verdict, vetoedBy,
   return lines.join(`
 `);
 }
+function synthesizeFinalCouncilAdvisory(projectSummary, verdicts, roundNumber, config3 = {}) {
+  const cfg = { ...COUNCIL_DEFAULTS, ...config3 };
+  const timestamp = new Date().toISOString();
+  const quorumSize = new Set(verdicts.map((v) => v.agent)).size;
+  const rejectingMembers = verdicts.filter((v) => v.verdict === "REJECT").map((v) => v.agent);
+  let overallVerdict;
+  if (cfg.vetoPriority && rejectingMembers.length > 0) {
+    overallVerdict = "REJECT";
+  } else if (verdicts.some((v) => v.verdict === "CONCERNS") || !cfg.vetoPriority && rejectingMembers.length > 0) {
+    overallVerdict = "CONCERNS";
+  } else {
+    overallVerdict = "APPROVE";
+  }
+  const unresolvedConflicts = detectConflicts(verdicts);
+  const rejectingSet = new Set(rejectingMembers);
+  const vetoFindings = verdicts.filter((v) => rejectingSet.has(v.agent)).flatMap((v) => v.findings);
+  const requiredFixes = vetoFindings.filter((f) => f.severity === "HIGH" || f.severity === "MEDIUM");
+  const advisoryFindings = [
+    ...vetoFindings.filter((f) => f.severity === "LOW"),
+    ...verdicts.filter((v) => !rejectingSet.has(v.agent)).flatMap((v) => v.findings)
+  ];
+  const advisoryNotes = [];
+  if (advisoryFindings.length > 0) {
+    advisoryNotes.push(`Final council found ${advisoryFindings.length} advisory finding(s). Review before project close.`);
+  }
+  if (quorumSize < 3) {
+    advisoryNotes.push(`Final council quorum is ${quorumSize} members - dispatch additional project-scoped council members before closing the project.`);
+  }
+  const allUnmetIds = new Set(verdicts.flatMap((v) => v.criteriaUnmet));
+  const allCriteriaMet = allUnmetIds.size === 0 && verdicts.length > 0;
+  const unifiedFeedbackMd = buildFinalCouncilFeedback(projectSummary, overallVerdict, rejectingMembers, requiredFixes, advisoryFindings, unresolvedConflicts, roundNumber, cfg.maxRounds);
+  return {
+    scope: "project",
+    timestamp,
+    overallVerdict,
+    vetoedBy: rejectingMembers.length > 0 ? rejectingMembers : null,
+    memberVerdicts: verdicts,
+    unresolvedConflicts,
+    requiredFixes,
+    advisoryFindings,
+    advisoryNotes,
+    unifiedFeedbackMd,
+    roundNumber,
+    allCriteriaMet,
+    quorumSize,
+    evidencePath: ".swarm/evidence/final-council.json",
+    projectSummary
+  };
+}
+function buildFinalCouncilFeedback(projectSummary, verdict, vetoedBy, requiredFixes, advisoryFindings, conflicts, roundNumber, maxRounds) {
+  const lines = [
+    `## Final Council Review - Round ${roundNumber}/${maxRounds}`,
+    `**Scope:** completed project  **Overall verdict:** ${verdict}`,
+    ""
+  ];
+  if (projectSummary) {
+    lines.push(`**Project Summary:** ${projectSummary}`);
+    lines.push("");
+  }
+  if (vetoedBy.length > 0) {
+    lines.push(`> BLOCKED: project close is blocked by ${vetoedBy.join(", ")}`);
+    lines.push("");
+  }
+  if (requiredFixes.length > 0) {
+    lines.push("### Required Fixes (must resolve before project close)");
+    for (const f of requiredFixes) {
+      lines.push(`- **[${f.severity}]** \`${f.location}\` - ${f.detail}`, `  _Evidence:_ ${f.evidence}`);
+    }
+    lines.push("");
+  }
+  if (conflicts.length > 0) {
+    lines.push("### Conflicts to Resolve");
+    lines.push("_The following council members gave contradictory project-close instructions. Architect must resolve before closing the project._");
+    for (const c of conflicts) {
+      lines.push(`- ${c}`);
+    }
+    lines.push("");
+  }
+  if (advisoryFindings.length > 0) {
+    lines.push("### Advisory Findings (non-blocking)");
+    for (const f of advisoryFindings) {
+      lines.push(`- **[${f.severity}]** \`${f.location}\` - ${f.detail}`);
+    }
+    lines.push("");
+  }
+  if (verdict === "APPROVE") {
+    lines.push("> Final council approved. Project may proceed to close.");
+  } else if (roundNumber >= maxRounds) {
+    lines.push(`> Max rounds (${maxRounds}) reached. Escalate to user - do not close the project automatically.`);
+  }
+  return lines.join(`
+`);
+}
 
 // src/council/criteria-store.ts
 import { existsSync as existsSync50, mkdirSync as mkdirSync23, readFileSync as readFileSync42, writeFileSync as writeFileSync16 } from "node:fs";
@@ -89841,6 +89930,41 @@ Advisory notes: ${advisoryNotes.join("; ")}` : "";
                         }, null, 2);
                       }
                     }
+                    if (typeof entry.quorumSize !== "number" || !Number.isFinite(entry.quorumSize) || entry.quorumSize < 5) {
+                      return JSON.stringify({
+                        success: false,
+                        phase,
+                        status: "blocked",
+                        reason: "FINAL_COUNCIL_MISSING_QUORUM",
+                        message: `Phase ${phase} (last phase) cannot be completed: final council evidence is missing valid quorum metadata. Re-run the project-scoped five-member final council and call write_final_council_evidence to generate quorumed evidence.`,
+                        agentsDispatched,
+                        agentsMissing: [],
+                        warnings: []
+                      }, null, 2);
+                    }
+                    const requiredFinalCouncilMembers = [
+                      "critic",
+                      "reviewer",
+                      "sme",
+                      "test_engineer",
+                      "explorer"
+                    ];
+                    const membersVoted = Array.isArray(entry.membersVoted) ? entry.membersVoted.filter((member) => typeof member === "string") : [];
+                    const membersAbsent = Array.isArray(entry.membersAbsent) ? entry.membersAbsent.filter((member) => typeof member === "string") : [];
+                    const distinctMembersVoted = new Set(membersVoted);
+                    const hasAllRequiredMembers = requiredFinalCouncilMembers.every((member) => distinctMembersVoted.has(member)) && distinctMembersVoted.size === requiredFinalCouncilMembers.length && membersAbsent.length === 0;
+                    if (!hasAllRequiredMembers) {
+                      return JSON.stringify({
+                        success: false,
+                        phase,
+                        status: "blocked",
+                        reason: "FINAL_COUNCIL_MISSING_QUORUM",
+                        message: `Phase ${phase} (last phase) cannot be completed: final council evidence does not prove all five required members voted. Re-run the project-scoped five-member final council and call write_final_council_evidence to generate complete evidence.`,
+                        agentsDispatched,
+                        agentsMissing: [],
+                        warnings: []
+                      }, null, 2);
+                    }
                     if (entry.verdict === "rejected" || entry.verdict === "REJECTED") {
                       return JSON.stringify({
                         success: false,
@@ -89880,11 +90004,11 @@ Advisory notes: ${advisoryNotes.join("; ")}` : "";
                   status: "blocked",
                   reason: "FINAL_COUNCIL_REQUIRED",
                   final_council_required: true,
-                  message: `Phase ${phase} (last phase) cannot be completed: final_council is enabled and final council evidence not found at .swarm/evidence/final-council.json. Convene a final holistic council (use convene_general_council with mode 'general') and call write_final_council_evidence to persist the verdict before completing the project.`,
+                  message: `Phase ${phase} (last phase) cannot be completed: final_council is enabled and final council evidence not found at .swarm/evidence/final-council.json. Dispatch critic, reviewer, sme, test_engineer, and explorer with project-scoped context, collect their CouncilMemberVerdict JSON, and call write_final_council_evidence before completing the project. Do not use convene_general_council for this gate.`,
                   agentsDispatched,
                   agentsMissing: [],
                   warnings: [
-                    `Final council required — convene a holistic project review using convene_general_council, then call write_final_council_evidence to persist the verdict.`
+                    `Final council required - dispatch the five project-scoped council members, then call write_final_council_evidence to persist quorumed evidence.`
                   ]
                 }, null, 2);
               }
@@ -97361,7 +97485,7 @@ var set_qa_gates = createSwarmTool({
     mutation_test: exports_external.boolean().optional().describe("Enable the mutation-testing gate (default: off). Requires mutation " + "tests to achieve a passing kill rate before phase completion; " + "WARN verdict allows advancement, FAIL blocks."),
     council_general_review: exports_external.boolean().optional().describe("Enable the council_general_review gate (default: off). When on, " + "MODE: SPECIFY runs convene_general_council on the draft spec " + "before the critic-gate, folding multi-model deliberation into " + "the spec. Requires council.general.enabled and a search API key."),
     drift_check: exports_external.boolean().optional().describe("Enable drift verification gate (default: on). Blocks phase_complete " + "until drift-verifier.json has an approved verdict. When disabled, " + "drift verification is skipped entirely."),
-    final_council: exports_external.boolean().optional().describe("Enable the final_council gate (default: off). When on, " + "after all phases complete the architect runs a holistic " + "general council review against the entire body of work. " + "Requires council.general.enabled: true in plugin config."),
+    final_council: exports_external.boolean().optional().describe("Enable the final_council gate (default: off). When on, " + "after all phases complete the architect dispatches critic, reviewer, " + "sme, test_engineer, and explorer with project-scoped context, " + "collects their CouncilMemberVerdict objects, and calls " + "write_final_council_evidence. This is not General Council mode " + "and does not require council.general.enabled."),
     project_type: exports_external.string().optional().describe('Project type label (e.g. "ts", "python"). Only applied when the profile is being created for the first time.')
   },
   execute: async (args2, directory) => {
@@ -102319,59 +102443,94 @@ var write_drift_evidence = createSwarmTool({
 });
 // src/tools/write-final-council-evidence.ts
 init_zod();
+init_loader();
+import fs107 from "node:fs";
+import path135 from "node:path";
 init_utils2();
 init_manager();
 init_create_tool();
-import fs107 from "node:fs";
-import path135 from "node:path";
-function normalizeVerdict2(verdict) {
-  switch (verdict) {
-    case "APPROVED":
-      return "approved";
-    case "NEEDS_REVISION":
-      return "rejected";
-    default:
-      throw new Error(`Invalid verdict: must be 'APPROVED' or 'NEEDS_REVISION', got '${verdict}'`);
-  }
+var FINAL_COUNCIL_MEMBERS = [
+  "critic",
+  "reviewer",
+  "sme",
+  "test_engineer",
+  "explorer"
+];
+var VerdictSchema3 = exports_external.object({
+  agent: exports_external.enum(FINAL_COUNCIL_MEMBERS),
+  verdict: exports_external.enum(["APPROVE", "CONCERNS", "REJECT"]),
+  confidence: exports_external.number().min(0).max(1),
+  findings: exports_external.array(exports_external.object({
+    severity: exports_external.enum(["HIGH", "MEDIUM", "LOW"]),
+    category: exports_external.string().min(1),
+    location: exports_external.string(),
+    detail: exports_external.string(),
+    evidence: exports_external.string()
+  })),
+  criteriaAssessed: exports_external.array(exports_external.string()),
+  criteriaUnmet: exports_external.array(exports_external.string()),
+  durationMs: exports_external.number().nonnegative()
+});
+var ArgsSchema6 = exports_external.object({
+  phase: exports_external.number().int().min(1),
+  projectSummary: exports_external.string().min(1),
+  roundNumber: exports_external.number().int().min(1).max(10).optional(),
+  verdicts: exports_external.array(VerdictSchema3).min(1).max(5)
+});
+function normalizeFinalVerdict(verdict) {
+  return verdict === "APPROVE" ? "approved" : "rejected";
 }
 async function executeWriteFinalCouncilEvidence(args2, directory) {
-  const phase = args2.phase;
-  if (!Number.isInteger(phase) || phase < 1) {
+  const parsed = ArgsSchema6.safeParse(args2);
+  if (!parsed.success) {
     return JSON.stringify({
       success: false,
-      phase,
-      message: "Invalid phase: must be a positive integer"
+      reason: "invalid arguments",
+      errors: parsed.error.issues.map((i2) => ({
+        path: i2.path.join("."),
+        message: i2.message
+      }))
     }, null, 2);
   }
-  const validVerdicts = ["APPROVED", "NEEDS_REVISION"];
-  if (!validVerdicts.includes(args2.verdict)) {
+  const input = parsed.data;
+  const config3 = loadPluginConfig(directory);
+  const requiredMembers = FINAL_COUNCIL_MEMBERS.length;
+  const distinctMembers = new Set(input.verdicts.map((v) => v.agent));
+  const membersVoted = [...distinctMembers];
+  const membersAbsent = FINAL_COUNCIL_MEMBERS.filter((m) => !distinctMembers.has(m));
+  if (membersVoted.length < requiredMembers) {
     return JSON.stringify({
       success: false,
-      phase,
-      message: "Invalid verdict: must be 'APPROVED' or 'NEEDS_REVISION'"
+      reason: "insufficient_quorum",
+      message: `Final council quorum not met: ${membersVoted.length} of ${requiredMembers} required members provided verdicts. ` + `Members voted: [${membersVoted.join(", ")}]. ` + `Members absent: [${membersAbsent.join(", ")}]. ` + `Dispatch the absent council members with project-scoped context and collect their verdicts before calling write_final_council_evidence.`,
+      membersVoted,
+      membersAbsent,
+      quorumRequired: requiredMembers
     }, null, 2);
   }
-  const summary = args2.summary;
-  if (typeof summary !== "string" || summary.trim().length === 0) {
-    return JSON.stringify({
-      success: false,
-      phase,
-      message: "Invalid summary: must be a non-empty string"
-    }, null, 2);
-  }
-  const normalizedVerdict = normalizeVerdict2(args2.verdict);
+  const synthesis = synthesizeFinalCouncilAdvisory(input.projectSummary.trim(), input.verdicts, input.roundNumber ?? 1, config3.council);
   const plan = await loadPlan(directory);
   const planId = plan ? derivePlanId(plan) : "unknown";
+  const normalizedVerdict = normalizeFinalVerdict(synthesis.overallVerdict);
   const evidenceEntry = {
     type: "final-council",
-    phase,
+    phase: input.phase,
     plan_id: planId,
     verdict: normalizedVerdict,
-    summary: summary.trim(),
-    timestamp: new Date().toISOString()
-  };
-  const evidenceContent = {
-    entries: [evidenceEntry]
+    rawCouncilVerdict: synthesis.overallVerdict,
+    quorumSize: synthesis.quorumSize,
+    membersVoted,
+    membersAbsent,
+    requiredFixes: synthesis.requiredFixes,
+    advisoryFindings: synthesis.advisoryFindings,
+    advisoryNotes: synthesis.advisoryNotes,
+    unresolvedConflicts: synthesis.unresolvedConflicts,
+    roundNumber: synthesis.roundNumber,
+    allCriteriaMet: synthesis.allCriteriaMet,
+    memberVerdicts: synthesis.memberVerdicts,
+    unifiedFeedbackMd: synthesis.unifiedFeedbackMd,
+    projectSummary: synthesis.projectSummary,
+    timestamp: synthesis.timestamp
   };
   const filename = "final-council.json";
   const relativePath = path135.join("evidence", filename);
@@ -102381,10 +102540,13 @@ async function executeWriteFinalCouncilEvidence(args2, directory) {
   } catch (error93) {
     return JSON.stringify({
       success: false,
-      phase,
+      phase: input.phase,
       message: error93 instanceof Error ? error93.message : "Failed to validate path"
     }, null, 2);
   }
+  const evidenceContent = {
+    entries: [evidenceEntry]
+  };
   const evidenceDir = path135.dirname(validatedPath);
   try {
     await fs107.promises.mkdir(evidenceDir, { recursive: true });
@@ -102393,41 +102555,53 @@ async function executeWriteFinalCouncilEvidence(args2, directory) {
     await fs107.promises.rename(tempPath, validatedPath);
     return JSON.stringify({
       success: true,
-      phase,
+      phase: input.phase,
+      overallVerdict: synthesis.overallVerdict,
       verdict: normalizedVerdict,
-      message: `Final council evidence written to .swarm/evidence/final-council.json`
+      vetoedBy: synthesis.vetoedBy,
+      roundNumber: synthesis.roundNumber,
+      allCriteriaMet: synthesis.allCriteriaMet,
+      requiredFixesCount: synthesis.requiredFixes.length,
+      advisoryFindingsCount: synthesis.advisoryFindings.length,
+      unresolvedConflictsCount: synthesis.unresolvedConflicts.length,
+      advisoryNotes: synthesis.advisoryNotes,
+      membersVoted,
+      membersAbsent,
+      quorumSize: synthesis.quorumSize,
+      quorumMet: true,
+      evidencePath: synthesis.evidencePath,
+      unifiedFeedbackMd: synthesis.unifiedFeedbackMd,
+      message: "Final council evidence written to .swarm/evidence/final-council.json"
     }, null, 2);
   } catch (error93) {
     return JSON.stringify({
       success: false,
-      phase,
+      phase: input.phase,
       message: error93 instanceof Error ? error93.message : String(error93)
     }, null, 2);
   }
 }
 var write_final_council_evidence = createSwarmTool({
-  description: "Write final council evidence for a completed project. Accepts phase, verdict (APPROVED/NEEDS_REVISION), summary, and writes structured evidence to .swarm/evidence/final-council.json. Normalizes verdict to lowercase. Use this after convening a final holistic council to persist the verdict.",
+  description: "Write final council evidence for a completed project. This is not General Council mode and does not use convene_general_council. PREREQUISITE: dispatch critic, reviewer, sme, test_engineer, and explorer as project-scoped Agent tasks, collect their CouncilMemberVerdict JSON, then call this tool to synthesize and persist .swarm/evidence/final-council.json.",
   args: {
-    phase: exports_external.number().int().min(1).describe("The phase number for the final council verdict (e.g., 1, 2, 3)"),
-    verdict: exports_external.enum(["APPROVED", "NEEDS_REVISION"]).describe("Verdict of the final council: 'APPROVED' or 'NEEDS_REVISION'"),
-    summary: exports_external.string().describe("Human-readable summary of the final council verdict")
+    phase: exports_external.number().int().min(1).describe("The final phase number for the project being reviewed"),
+    projectSummary: exports_external.string().min(1).describe("Summary of the completed project and total work reviewed"),
+    roundNumber: exports_external.number().int().min(1).max(10).optional().describe("1-indexed final council round number. Defaults to 1."),
+    verdicts: exports_external.array(VerdictSchema3).min(1).max(5).describe("Collected CouncilMemberVerdict objects from critic, reviewer, sme, test_engineer, and explorer.")
   },
   execute: async (args2, directory) => {
-    const rawPhase = args2.phase !== undefined ? Number(args2.phase) : 0;
-    try {
-      const writeFinalCouncilEvidenceArgs = {
-        phase: Number(args2.phase),
-        verdict: String(args2.verdict),
-        summary: String(args2.summary ?? "")
-      };
-      return await executeWriteFinalCouncilEvidence(writeFinalCouncilEvidenceArgs, directory);
-    } catch (error93) {
+    const parsed = ArgsSchema6.safeParse(args2);
+    if (!parsed.success) {
       return JSON.stringify({
         success: false,
-        phase: rawPhase,
-        message: error93 instanceof Error ? error93.message : "Unknown error"
+        reason: "invalid arguments",
+        errors: parsed.error.issues.map((i2) => ({
+          path: i2.path.join("."),
+          message: i2.message
+        }))
       }, null, 2);
     }
+    return await executeWriteFinalCouncilEvidence(parsed.data, directory);
   }
 });
 // src/tools/write-hallucination-evidence.ts
@@ -102436,7 +102610,7 @@ init_utils2();
 init_create_tool();
 import fs108 from "node:fs";
 import path136 from "node:path";
-function normalizeVerdict3(verdict) {
+function normalizeVerdict2(verdict) {
   switch (verdict) {
     case "APPROVED":
       return "approved";
@@ -102471,7 +102645,7 @@ async function executeWriteHallucinationEvidence(args2, directory) {
       message: "Invalid summary: must be a non-empty string"
     }, null, 2);
   }
-  const normalizedVerdict = normalizeVerdict3(args2.verdict);
+  const normalizedVerdict = normalizeVerdict2(args2.verdict);
   const evidenceEntry = {
     type: "hallucination-verification",
     verdict: normalizedVerdict,
@@ -102547,7 +102721,7 @@ init_utils2();
 init_create_tool();
 import fs109 from "node:fs";
 import path137 from "node:path";
-function normalizeVerdict4(verdict) {
+function normalizeVerdict3(verdict) {
   switch (verdict) {
     case "PASS":
       return "pass";
@@ -102604,7 +102778,7 @@ async function executeWriteMutationEvidence(args2, directory) {
       message: "Invalid summary: must be a non-empty string"
     }, null, 2);
   }
-  const normalizedVerdict = normalizeVerdict4(args2.verdict);
+  const normalizedVerdict = normalizeVerdict3(args2.verdict);
   const evidenceEntry = {
     type: "mutation-gate",
     verdict: normalizedVerdict,

--- a/dist/tools/write-final-council-evidence.d.ts
+++ b/dist/tools/write-final-council-evidence.d.ts
@@ -1,29 +1,66 @@
 /**
- * Write final council evidence tool for persisting final holistic council verdicts.
- * Accepts phase, verdict, and summary from the Architect and writes
- * a structured evidence file to the flat evidence root (not per-phase).
+ * Write final council evidence for the project-scoped final council gate.
+ *
+ * The final council is not General Council mode. It accepts the same
+ * five-member CouncilMemberVerdict objects used by phase council, synthesized
+ * at completed-project scope.
  */
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
+import { z } from 'zod';
+import type { CouncilMemberVerdict } from '../council/types';
+export declare const ArgsSchema: z.ZodObject<{
+    phase: z.ZodNumber;
+    projectSummary: z.ZodString;
+    roundNumber: z.ZodOptional<z.ZodNumber>;
+    verdicts: z.ZodArray<z.ZodObject<{
+        agent: z.ZodEnum<{
+            reviewer: "reviewer";
+            test_engineer: "test_engineer";
+            explorer: "explorer";
+            sme: "sme";
+            critic: "critic";
+        }>;
+        verdict: z.ZodEnum<{
+            APPROVE: "APPROVE";
+            REJECT: "REJECT";
+            CONCERNS: "CONCERNS";
+        }>;
+        confidence: z.ZodNumber;
+        findings: z.ZodArray<z.ZodObject<{
+            severity: z.ZodEnum<{
+                HIGH: "HIGH";
+                MEDIUM: "MEDIUM";
+                LOW: "LOW";
+            }>;
+            category: z.ZodString;
+            location: z.ZodString;
+            detail: z.ZodString;
+            evidence: z.ZodString;
+        }, z.core.$strip>>;
+        criteriaAssessed: z.ZodArray<z.ZodString>;
+        criteriaUnmet: z.ZodArray<z.ZodString>;
+        durationMs: z.ZodNumber;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
 /**
- * Arguments for the write_final_council_evidence tool
+ * Arguments for the write_final_council_evidence tool.
  */
 export interface WriteFinalCouncilEvidenceArgs {
     /** The phase number for the final council verdict */
     phase: number;
-    /** Verdict of the final council: 'APPROVED' or 'NEEDS_REVISION' */
-    verdict: 'APPROVED' | 'NEEDS_REVISION';
-    /** Human-readable summary of the final council verdict */
-    summary: string;
+    /** Summary of the completed project being reviewed */
+    projectSummary: string;
+    /** 1-indexed final council round number */
+    roundNumber?: number;
+    /** Collected verdicts from critic, reviewer, sme, test_engineer, explorer */
+    verdicts: CouncilMemberVerdict[];
 }
 /**
  * Execute the write_final_council_evidence tool.
- * Validates input, builds an evidence entry, and writes to disk.
- * @param args - The write final council evidence arguments
- * @param directory - Working directory
- * @returns JSON string with success status and details
+ * Validates input, synthesizes project-scoped council evidence, and writes it.
  */
-export declare function executeWriteFinalCouncilEvidence(args: WriteFinalCouncilEvidenceArgs, directory: string): Promise<string>;
+export declare function executeWriteFinalCouncilEvidence(args: unknown, directory: string): Promise<string>;
 /**
- * Tool definition for write_final_council_evidence
+ * Tool definition for write_final_council_evidence.
  */
 export declare const write_final_council_evidence: ToolDefinition;

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -265,12 +265,14 @@ View or modify QA gate profile for the current plan.
 - `enable`: persist gate(s) into the locked profile. Architect-only. Rejected after critic approval lock.
 - `override`: session-only ratchet-tighter enable.
 
-Valid gates: `reviewer`, `test_engineer`, `council_mode`, `sme_enabled`, `critic_pre_plan`, `hallucination_guard`, `sast_enabled`, `mutation_test`, `council_general_review`.
+Valid gates: `reviewer`, `test_engineer`, `council_mode`, `sme_enabled`, `critic_pre_plan`, `hallucination_guard`, `sast_enabled`, `mutation_test`, `drift_check`, `council_general_review`, `final_council`.
 
 **Gate descriptions:**
 
 - `council_mode` — Multi-member phase-level council gate. When enabled, council runs at phase completion for holistic review of the full phase body of work. Stage B (reviewer + test_engineer in parallel) always runs per-task regardless. Council is additive — never replaces Stage B.
 
+
+- `final_council` - Multi-member project-level council gate. When enabled, the last phase requires approved `.swarm/evidence/final-council.json` from the same five phase-council members (`critic`, `reviewer`, `sme`, `test_engineer`, `explorer`) rerun at project scope. This is not General Council mode and does not use `convene_general_council`.
 ---
 
 ## Evidence and Telemetry

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -239,6 +239,9 @@ Skips the compaction service. Use when you're hitting context pressure on short 
 
 When enabled, a phase-level council of 5 members (critic, reviewer, sme, test_engineer, explorer) reviews the entire phase's work holistically at `phase_complete` time. Stage B gates (reviewer + test_engineer in parallel) always run per-task — council is additive, never a replacement. Evidence is written to `.swarm/evidence/{phase}/phase-council.json` and validated for verdict, quorum, timestamp, and phase number.
 
+### `final_council` (Project-Level Final Council)
+
+When enabled, the final phase cannot complete until the architect dispatches the same 5 council members used by phase council (`critic`, `reviewer`, `sme`, `test_engineer`, `explorer`) with completed-project context and calls `write_final_council_evidence` with their collected `CouncilMemberVerdict` objects. Evidence is written to `.swarm/evidence/final-council.json` and validated for approved verdict, plan binding, and quorum metadata. This is not General Council mode and does not use `convene_general_council`.
 ---
 
 ## Lean Turbo Lane Planning Engine

--- a/docs/releases/v7.17.2.md
+++ b/docs/releases/v7.17.2.md
@@ -1,0 +1,19 @@
+# v7.17.2
+
+## fix(qa-gate): run final council as project-scoped 5-member council
+
+`final_council` now uses the same five-member council as phase completion
+(`critic`, `reviewer`, `sme`, `test_engineer`, `explorer`) rerun at completed
+project scope. It is no longer modeled as General Council mode and does not use
+`convene_general_council`.
+
+`write_final_council_evidence` now accepts collected `CouncilMemberVerdict`
+objects, synthesizes a project-scoped verdict, and writes plan-bound evidence to
+`.swarm/evidence/final-council.json` with quorum, member-verdict, required-fix,
+advisory-finding, and unified feedback metadata.
+
+`phase_complete` now rejects legacy minimal final-council evidence that lacks
+quorum metadata, forged quorum metadata, or fewer than all five required member
+votes. Projects with `final_council` enabled must rerun the project-scoped
+five-member council and regenerate final-council evidence before closing the
+last phase.

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -1671,19 +1671,15 @@ The tool will automatically write the retrospective to \`.swarm/evidence/retro-{
    - \`.swarm/evidence/{phase}/mutation-gate.json\` exists with verdict 'pass' or 'warn' (written by YOU via the \`write_mutation_evidence\` tool after step 5.56) — ONLY required when \`mutation_test\` is enabled in the QA gate profile
    If any required file is missing, run the missing gate first. Turbo mode skips all gates automatically.
    NOTE: Steps 5.5, 5.55, and 5.56 are enforced by runtime hooks. If \`hallucination_guard\` is enabled and you skip the critic_hallucination_verifier delegation (or fail to call \`write_hallucination_evidence\`), phase_complete will be BLOCKED by the plugin. Similarly, if \`mutation_test\` is enabled and you skip step 5.56 (or fail to call \`write_mutation_evidence\`), phase_complete will be BLOCKED. These are not suggestions — they are hard enforcement mechanisms.
-5.7. **Final Council (conditional on QA gate — last phase only)**: Check whether \`final_council\` is enabled in the effective QA gate profile (visible via \`get_qa_gate_profile\`). If disabled, skip silently and proceed to step 6.
+5.7. **Final Council (conditional on QA gate - last phase only)**: Check whether \`final_council\` is enabled in the effective QA gate profile (visible via \`get_qa_gate_profile\`). If disabled, skip silently and proceed to step 6.
    If enabled AND this is the LAST phase in the plan (all other phases have status 'complete' and no more phases remain):
-    1. Verify \`council.general.enabled: true\` in plugin config. If not enabled, warn the user: "final_council gate is enabled but General Council is not configured. Skipping final council." Then proceed to step 6. Check that \`convene_general_council\` is available in your tool list. If the tool is unavailable (filtered by config), warn the user and skip.
-   2. Run 1-3 targeted \`web_search\` queries relevant to the project domain.
-   3. Compile a RESEARCH CONTEXT block from search results.
-   4. Dispatch \`{{AGENT_PREFIX}}council_generalist\`, \`{{AGENT_PREFIX}}council_skeptic\`, and \`{{AGENT_PREFIX}}council_domain_expert\` in PARALLEL. Pass: the full body of work (all phase summaries, all evidence artifacts), the RESEARCH CONTEXT block, round number 1. Instruction: "Review the entire body of work holistically. Identify cross-cutting issues, architectural coherence, and overall quality."
-   5. Collect all three JSON responses.
-   6. Call \`convene_general_council\` with mode: 'general', the project summary as question, and the collected round1Responses.
-   7. If disagreements exist, re-dispute as in MODE: COUNCIL step 5-6.
-   8. Present the final synthesis to the user as a project-close summary.
-   9. Write the final council result to \`.swarm/evidence/final-council.json\`.
-   10. Do NOT call \`/swarm close\` until the final council completes (if enabled). The evidence file \`.swarm/evidence/final-council.json\` must exist with an APPROVED verdict before \`/swarm close\` is permitted when final_council is enabled.
-   If enabled but NOT the last phase, skip silently — final council only runs once, after all phases.
+   1. Build a PROJECT DOSSIER from the completed plan, all phase summaries, changed-file summaries, and all relevant evidence artifacts. This is a completed-project review, not General Council mode.
+   2. Dispatch \`{{AGENT_PREFIX}}critic\`, \`{{AGENT_PREFIX}}reviewer\`, \`{{AGENT_PREFIX}}sme\`, \`{{AGENT_PREFIX}}test_engineer\`, and \`{{AGENT_PREFIX}}explorer\` in PARALLEL with project-scoped context. Each member must review the entire completed body of work and return a \`CouncilMemberVerdict\` JSON object using \`agent\`, \`verdict\` (APPROVE|CONCERNS|REJECT), \`confidence\`, \`findings[]\`, \`criteriaAssessed[]\`, \`criteriaUnmet[]\`, and \`durationMs\`.
+   3. Collect the five returned verdict objects. Do NOT fabricate, infer, or substitute verdicts. If a member does not return valid JSON, re-dispatch that member.
+   4. Call \`write_final_council_evidence\` with \`phase\`, \`projectSummary\`, \`roundNumber\`, and the collected \`verdicts\` array. This writes \`.swarm/evidence/final-council.json\` with plan binding, member verdicts, and quorum metadata.
+   5. Do NOT call \`convene_general_council\`, do NOT dispatch \`council_generalist\`, \`council_skeptic\`, or \`council_domain_expert\`, and do NOT require \`council.general.enabled\` for this gate. \`final_council\` is the same five-member phase council rerun at project scope.
+   6. Do NOT call \`phase_complete\` or \`/swarm close\` until \`.swarm/evidence/final-council.json\` exists with an approved, plan-bound, quorumed final-council verdict. When \`final_council\` is enabled, \`phase_complete\` will block until that evidence exists.
+   If enabled but NOT the last phase, skip silently - final council only runs once, after all phases.
 6. Summarize to user
 7. Ask: "Ready for Phase [N+1]?"
 
@@ -1942,7 +1938,7 @@ Present the eleven gates with their defaults (DEFAULT_QA_GATES) as a single user
 - mutation_test (default: OFF) — when enabled, runs mutation testing on source files touched this phase via generate_mutants + mutation_test + write_mutation_evidence at PHASE-WRAP; FAIL verdict blocks phase_complete; WARN is non-blocking (recommended for projects with coverage gaps or safety-critical code)
 - council_general_review (default: OFF) — when enabled, MODE: SPECIFY runs convene_general_council on the draft spec before the critic-gate; the architect runs a curated web_search pass, dispatches council_generalist / council_skeptic / council_domain_expert in parallel with a shared RESEARCH CONTEXT block, deliberates on disagreements, and synthesizes the result directly into the spec (recommended for novel architecture, unclear best practices, or high-risk design decisions). Requires council.general.enabled: true and a configured search API key.
 - drift_check (default: ON) — when enabled, mandatory per-phase drift verification via critic_drift_verifier at PHASE-WRAP; compares implemented changes against spec.md intent; hard-blocks phase_complete when spec.md exists and drift evidence is missing or REJECTED; advisory-only when no spec.md exists (recommended for all projects with a specification)
-- final_council (default: OFF) — when enabled, after all phases complete the architect convenes a holistic general council review of the entire body of work before project close. Requires council.general.enabled: true in plugin config. Recommended for multi-phase projects with high architectural complexity.
+- final_council (default: OFF) - when enabled, after all phases complete the architect dispatches the same five phase-council members (\`critic\`, \`reviewer\`, \`sme\`, \`test_engineer\`, \`explorer\`) at project scope, collects \`CouncilMemberVerdict\` objects, and calls \`write_final_council_evidence\`. This is not General Council mode and does not require \`council.general.enabled\`.
 
 One question, one message, defaults pre-stated. Wait for the user's answer.
 

--- a/src/council/council-service.ts
+++ b/src/council/council-service.ts
@@ -17,6 +17,7 @@ import type {
 	CouncilMemberVerdict,
 	CouncilSynthesis,
 	CouncilVerdict,
+	FinalCouncilSynthesis,
 	PhaseCouncilSynthesis,
 } from './types';
 import { COUNCIL_DEFAULTS } from './types';
@@ -412,6 +413,165 @@ function buildPhaseCouncilFeedback(
 	} else if (roundNumber >= maxRounds) {
 		lines.push(
 			`> ⚠️ **Max rounds (${maxRounds}) reached.** Escalate to user — do not auto-advance.`,
+		);
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Synthesize project-level final council verdicts into a FinalCouncilSynthesis.
+ * This uses the same five-member verdict semantics as phase council, but the
+ * output is scoped to completed-project review and the final_council gate.
+ */
+export function synthesizeFinalCouncilAdvisory(
+	projectSummary: string,
+	verdicts: CouncilMemberVerdict[],
+	roundNumber: number,
+	config: Partial<CouncilConfig> = {},
+): FinalCouncilSynthesis {
+	const cfg: CouncilConfig = { ...COUNCIL_DEFAULTS, ...config };
+	const timestamp = new Date().toISOString();
+	const quorumSize = new Set(verdicts.map((v) => v.agent)).size;
+
+	const rejectingMembers: CouncilAgent[] = verdicts
+		.filter((v) => v.verdict === 'REJECT')
+		.map((v) => v.agent);
+
+	let overallVerdict: CouncilVerdict;
+	if (cfg.vetoPriority && rejectingMembers.length > 0) {
+		overallVerdict = 'REJECT';
+	} else if (
+		verdicts.some((v) => v.verdict === 'CONCERNS') ||
+		(!cfg.vetoPriority && rejectingMembers.length > 0)
+	) {
+		overallVerdict = 'CONCERNS';
+	} else {
+		overallVerdict = 'APPROVE';
+	}
+
+	const unresolvedConflicts = detectConflicts(verdicts);
+
+	const rejectingSet = new Set<CouncilAgent>(rejectingMembers);
+	const vetoFindings = verdicts
+		.filter((v) => rejectingSet.has(v.agent))
+		.flatMap((v) => v.findings);
+	const requiredFixes = vetoFindings.filter(
+		(f) => f.severity === 'HIGH' || f.severity === 'MEDIUM',
+	);
+	const advisoryFindings: CouncilFinding[] = [
+		...vetoFindings.filter((f) => f.severity === 'LOW'),
+		...verdicts
+			.filter((v) => !rejectingSet.has(v.agent))
+			.flatMap((v) => v.findings),
+	];
+
+	const advisoryNotes: string[] = [];
+	if (advisoryFindings.length > 0) {
+		advisoryNotes.push(
+			`Final council found ${advisoryFindings.length} advisory finding(s). Review before project close.`,
+		);
+	}
+	if (quorumSize < 3) {
+		advisoryNotes.push(
+			`Final council quorum is ${quorumSize} members - dispatch additional project-scoped council members before closing the project.`,
+		);
+	}
+
+	const allUnmetIds = new Set(verdicts.flatMap((v) => v.criteriaUnmet));
+	const allCriteriaMet = allUnmetIds.size === 0 && verdicts.length > 0;
+
+	const unifiedFeedbackMd = buildFinalCouncilFeedback(
+		projectSummary,
+		overallVerdict,
+		rejectingMembers,
+		requiredFixes,
+		advisoryFindings,
+		unresolvedConflicts,
+		roundNumber,
+		cfg.maxRounds,
+	);
+
+	return {
+		scope: 'project',
+		timestamp,
+		overallVerdict,
+		vetoedBy: rejectingMembers.length > 0 ? rejectingMembers : null,
+		memberVerdicts: verdicts,
+		unresolvedConflicts,
+		requiredFixes,
+		advisoryFindings,
+		advisoryNotes,
+		unifiedFeedbackMd,
+		roundNumber,
+		allCriteriaMet,
+		quorumSize,
+		evidencePath: '.swarm/evidence/final-council.json',
+		projectSummary,
+	};
+}
+
+function buildFinalCouncilFeedback(
+	projectSummary: string,
+	verdict: CouncilVerdict,
+	vetoedBy: CouncilAgent[],
+	requiredFixes: CouncilFinding[],
+	advisoryFindings: CouncilFinding[],
+	conflicts: string[],
+	roundNumber: number,
+	maxRounds: number,
+): string {
+	const lines: string[] = [
+		`## Final Council Review - Round ${roundNumber}/${maxRounds}`,
+		`**Scope:** completed project  **Overall verdict:** ${verdict}`,
+		'',
+	];
+
+	if (projectSummary) {
+		lines.push(`**Project Summary:** ${projectSummary}`);
+		lines.push('');
+	}
+
+	if (vetoedBy.length > 0) {
+		lines.push(`> BLOCKED: project close is blocked by ${vetoedBy.join(', ')}`);
+		lines.push('');
+	}
+
+	if (requiredFixes.length > 0) {
+		lines.push('### Required Fixes (must resolve before project close)');
+		for (const f of requiredFixes) {
+			lines.push(
+				`- **[${f.severity}]** \`${f.location}\` - ${f.detail}`,
+				`  _Evidence:_ ${f.evidence}`,
+			);
+		}
+		lines.push('');
+	}
+
+	if (conflicts.length > 0) {
+		lines.push('### Conflicts to Resolve');
+		lines.push(
+			'_The following council members gave contradictory project-close instructions. Architect must resolve before closing the project._',
+		);
+		for (const c of conflicts) {
+			lines.push(`- ${c}`);
+		}
+		lines.push('');
+	}
+
+	if (advisoryFindings.length > 0) {
+		lines.push('### Advisory Findings (non-blocking)');
+		for (const f of advisoryFindings) {
+			lines.push(`- **[${f.severity}]** \`${f.location}\` - ${f.detail}`);
+		}
+		lines.push('');
+	}
+
+	if (verdict === 'APPROVE') {
+		lines.push('> Final council approved. Project may proceed to close.');
+	} else if (roundNumber >= maxRounds) {
+		lines.push(
+			`> Max rounds (${maxRounds}) reached. Escalate to user - do not close the project automatically.`,
 		);
 	}
 

--- a/src/council/types.ts
+++ b/src/council/types.ts
@@ -119,6 +119,39 @@ export interface PhaseCouncilSynthesis {
 	phaseSummary?: string;
 }
 
+/**
+ * Project-level final council synthesis result.
+ * Distinct from task-level and phase-level council results: this is the
+ * final project close gate and writes to .swarm/evidence/final-council.json.
+ */
+export interface FinalCouncilSynthesis {
+	/** Always 'project' - distinguishes final council from task/phase councils */
+	scope: 'project';
+	/** ISO 8601 */
+	timestamp: string;
+	overallVerdict: CouncilVerdict;
+	vetoedBy: CouncilAgent[] | null;
+	memberVerdicts: CouncilMemberVerdict[];
+	unresolvedConflicts: string[];
+	/** Severity HIGH + MEDIUM from veto members */
+	requiredFixes: CouncilFinding[];
+	/** Severity LOW or from non-veto members */
+	advisoryFindings: CouncilFinding[];
+	/** Project-level advisory notes for the architect */
+	advisoryNotes: string[];
+	/** Single markdown document for final project review */
+	unifiedFeedbackMd: string;
+	/** 1-indexed */
+	roundNumber: number;
+	allCriteriaMet: boolean;
+	/** Distinct council members that produced verdicts */
+	quorumSize: number;
+	/** Path where evidence was written */
+	evidencePath: '.swarm/evidence/final-council.json';
+	/** Summary of the completed project being reviewed */
+	projectSummary: string;
+}
+
 export interface CouncilCriteriaItem {
 	id: string;
 	description: string;

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -1395,6 +1395,71 @@ export async function executePhaseComplete(
 										}
 
 										if (
+											typeof entry.quorumSize !== 'number' ||
+											!Number.isFinite(entry.quorumSize) ||
+											entry.quorumSize < 5
+										) {
+											return JSON.stringify(
+												{
+													success: false,
+													phase,
+													status: 'blocked' as const,
+													reason: 'FINAL_COUNCIL_MISSING_QUORUM',
+													message: `Phase ${phase} (last phase) cannot be completed: final council evidence is missing valid quorum metadata. Re-run the project-scoped five-member final council and call write_final_council_evidence to generate quorumed evidence.`,
+													agentsDispatched,
+													agentsMissing: [],
+													warnings: [],
+												},
+												null,
+												2,
+											);
+										}
+
+										const requiredFinalCouncilMembers = [
+											'critic',
+											'reviewer',
+											'sme',
+											'test_engineer',
+											'explorer',
+										];
+										const membersVoted = Array.isArray(entry.membersVoted)
+											? entry.membersVoted.filter(
+													(member: unknown): member is string =>
+														typeof member === 'string',
+												)
+											: [];
+										const membersAbsent = Array.isArray(entry.membersAbsent)
+											? entry.membersAbsent.filter(
+													(member: unknown): member is string =>
+														typeof member === 'string',
+												)
+											: [];
+										const distinctMembersVoted = new Set(membersVoted);
+										const hasAllRequiredMembers =
+											requiredFinalCouncilMembers.every((member) =>
+												distinctMembersVoted.has(member),
+											) &&
+											distinctMembersVoted.size ===
+												requiredFinalCouncilMembers.length &&
+											membersAbsent.length === 0;
+										if (!hasAllRequiredMembers) {
+											return JSON.stringify(
+												{
+													success: false,
+													phase,
+													status: 'blocked' as const,
+													reason: 'FINAL_COUNCIL_MISSING_QUORUM',
+													message: `Phase ${phase} (last phase) cannot be completed: final council evidence does not prove all five required members voted. Re-run the project-scoped five-member final council and call write_final_council_evidence to generate complete evidence.`,
+													agentsDispatched,
+													agentsMissing: [],
+													warnings: [],
+												},
+												null,
+												2,
+											);
+										}
+
+										if (
 											entry.verdict === 'rejected' ||
 											entry.verdict === 'REJECTED'
 										) {
@@ -1453,11 +1518,11 @@ export async function executePhaseComplete(
 										status: 'blocked' as const,
 										reason: 'FINAL_COUNCIL_REQUIRED',
 										final_council_required: true,
-										message: `Phase ${phase} (last phase) cannot be completed: final_council is enabled and final council evidence not found at .swarm/evidence/final-council.json. Convene a final holistic council (use convene_general_council with mode 'general') and call write_final_council_evidence to persist the verdict before completing the project.`,
+										message: `Phase ${phase} (last phase) cannot be completed: final_council is enabled and final council evidence not found at .swarm/evidence/final-council.json. Dispatch critic, reviewer, sme, test_engineer, and explorer with project-scoped context, collect their CouncilMemberVerdict JSON, and call write_final_council_evidence before completing the project. Do not use convene_general_council for this gate.`,
 										agentsDispatched,
 										agentsMissing: [],
 										warnings: [
-											`Final council required — convene a holistic project review using convene_general_council, then call write_final_council_evidence to persist the verdict.`,
+											`Final council required - dispatch the five project-scoped council members, then call write_final_council_evidence to persist quorumed evidence.`,
 										],
 									},
 									null,

--- a/src/tools/set-qa-gates.ts
+++ b/src/tools/set-qa-gates.ts
@@ -184,9 +184,11 @@ export const set_qa_gates: ReturnType<typeof tool> = createSwarmTool({
 			.optional()
 			.describe(
 				'Enable the final_council gate (default: off). When on, ' +
-					'after all phases complete the architect runs a holistic ' +
-					'general council review against the entire body of work. ' +
-					'Requires council.general.enabled: true in plugin config.',
+					'after all phases complete the architect dispatches critic, reviewer, ' +
+					'sme, test_engineer, and explorer with project-scoped context, ' +
+					'collects their CouncilMemberVerdict objects, and calls ' +
+					'write_final_council_evidence. This is not General Council mode ' +
+					'and does not require council.general.enabled.',
 			),
 		project_type: z
 			.string()

--- a/src/tools/write-final-council-evidence.ts
+++ b/src/tools/write-final-council-evidence.ts
@@ -1,125 +1,160 @@
 /**
- * Write final council evidence tool for persisting final holistic council verdicts.
- * Accepts phase, verdict, and summary from the Architect and writes
- * a structured evidence file to the flat evidence root (not per-phase).
+ * Write final council evidence for the project-scoped final council gate.
+ *
+ * The final council is not General Council mode. It accepts the same
+ * five-member CouncilMemberVerdict objects used by phase council, synthesized
+ * at completed-project scope.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
 import { z } from 'zod';
+import { loadPluginConfig } from '../config/loader';
+import { synthesizeFinalCouncilAdvisory } from '../council/council-service';
+import type { CouncilAgent, CouncilMemberVerdict } from '../council/types';
 import { validateSwarmPath } from '../hooks/utils';
 import { loadPlan } from '../plan/manager.js';
 import { derivePlanId } from '../plan/utils.js';
 import { createSwarmTool } from './create-tool';
 
+const FINAL_COUNCIL_MEMBERS = [
+	'critic',
+	'reviewer',
+	'sme',
+	'test_engineer',
+	'explorer',
+] as const;
+
+const VerdictSchema = z.object({
+	agent: z.enum(FINAL_COUNCIL_MEMBERS),
+	verdict: z.enum(['APPROVE', 'CONCERNS', 'REJECT']),
+	confidence: z.number().min(0).max(1),
+	findings: z.array(
+		z.object({
+			severity: z.enum(['HIGH', 'MEDIUM', 'LOW']),
+			category: z.string().min(1),
+			location: z.string(),
+			detail: z.string(),
+			evidence: z.string(),
+		}),
+	),
+	criteriaAssessed: z.array(z.string()),
+	criteriaUnmet: z.array(z.string()),
+	durationMs: z.number().nonnegative(),
+});
+
+export const ArgsSchema = z.object({
+	phase: z.number().int().min(1),
+	projectSummary: z.string().min(1),
+	roundNumber: z.number().int().min(1).max(10).optional(),
+	verdicts: z.array(VerdictSchema).min(1).max(5),
+});
+
 /**
- * Arguments for the write_final_council_evidence tool
+ * Arguments for the write_final_council_evidence tool.
  */
 export interface WriteFinalCouncilEvidenceArgs {
 	/** The phase number for the final council verdict */
 	phase: number;
-	/** Verdict of the final council: 'APPROVED' or 'NEEDS_REVISION' */
-	verdict: 'APPROVED' | 'NEEDS_REVISION';
-	/** Human-readable summary of the final council verdict */
-	summary: string;
+	/** Summary of the completed project being reviewed */
+	projectSummary: string;
+	/** 1-indexed final council round number */
+	roundNumber?: number;
+	/** Collected verdicts from critic, reviewer, sme, test_engineer, explorer */
+	verdicts: CouncilMemberVerdict[];
 }
 
-/**
- * Normalize verdict string to lowercase format
- * @param verdict - Raw verdict from caller
- * @returns Normalized verdict: 'approved' | 'rejected'
- */
-function normalizeVerdict(verdict: string): 'approved' | 'rejected' {
-	switch (verdict) {
-		case 'APPROVED':
-			return 'approved';
-		case 'NEEDS_REVISION':
-			return 'rejected';
-		default:
-			throw new Error(
-				`Invalid verdict: must be 'APPROVED' or 'NEEDS_REVISION', got '${verdict}'`,
-			);
-	}
+function normalizeFinalVerdict(verdict: 'APPROVE' | 'CONCERNS' | 'REJECT') {
+	return verdict === 'APPROVE' ? 'approved' : 'rejected';
 }
 
 /**
  * Execute the write_final_council_evidence tool.
- * Validates input, builds an evidence entry, and writes to disk.
- * @param args - The write final council evidence arguments
- * @param directory - Working directory
- * @returns JSON string with success status and details
+ * Validates input, synthesizes project-scoped council evidence, and writes it.
  */
 export async function executeWriteFinalCouncilEvidence(
-	args: WriteFinalCouncilEvidenceArgs,
+	args: unknown,
 	directory: string,
 ): Promise<string> {
-	// Validate phase is a positive integer
-	const phase = args.phase;
-	if (!Number.isInteger(phase) || phase < 1) {
+	const parsed = ArgsSchema.safeParse(args);
+	if (!parsed.success) {
 		return JSON.stringify(
 			{
 				success: false,
-				phase: phase,
-				message: 'Invalid phase: must be a positive integer',
+				reason: 'invalid arguments',
+				errors: parsed.error.issues.map((i) => ({
+					path: i.path.join('.'),
+					message: i.message,
+				})),
+			},
+			null,
+			2,
+		);
+	}
+	const input = parsed.data;
+
+	const config = loadPluginConfig(directory);
+	const requiredMembers = FINAL_COUNCIL_MEMBERS.length;
+	const distinctMembers = new Set<CouncilAgent>(
+		input.verdicts.map((v) => v.agent),
+	);
+	const membersVoted = [...distinctMembers];
+	const membersAbsent = FINAL_COUNCIL_MEMBERS.filter(
+		(m) => !distinctMembers.has(m),
+	);
+
+	if (membersVoted.length < requiredMembers) {
+		return JSON.stringify(
+			{
+				success: false,
+				reason: 'insufficient_quorum',
+				message:
+					`Final council quorum not met: ${membersVoted.length} of ${requiredMembers} required members provided verdicts. ` +
+					`Members voted: [${membersVoted.join(', ')}]. ` +
+					`Members absent: [${membersAbsent.join(', ')}]. ` +
+					`Dispatch the absent council members with project-scoped context and collect their verdicts before calling write_final_council_evidence.`,
+				membersVoted,
+				membersAbsent,
+				quorumRequired: requiredMembers,
 			},
 			null,
 			2,
 		);
 	}
 
-	// Validate verdict is one of the allowed values
-	const validVerdicts = ['APPROVED', 'NEEDS_REVISION'] as const;
-	if (!validVerdicts.includes(args.verdict)) {
-		return JSON.stringify(
-			{
-				success: false,
-				phase: phase,
-				message: "Invalid verdict: must be 'APPROVED' or 'NEEDS_REVISION'",
-			},
-			null,
-			2,
-		);
-	}
+	const synthesis = synthesizeFinalCouncilAdvisory(
+		input.projectSummary.trim(),
+		input.verdicts as CouncilMemberVerdict[],
+		input.roundNumber ?? 1,
+		config.council,
+	);
 
-	// Validate summary is non-empty string
-	const summary = args.summary;
-	if (typeof summary !== 'string' || summary.trim().length === 0) {
-		return JSON.stringify(
-			{
-				success: false,
-				phase: phase,
-				message: 'Invalid summary: must be a non-empty string',
-			},
-			null,
-			2,
-		);
-	}
-
-	// Normalize verdict
-	const normalizedVerdict = normalizeVerdict(args.verdict);
-
-	// Compute plan_id for evidence binding
 	const plan = await loadPlan(directory);
 	const planId = plan ? derivePlanId(plan) : 'unknown';
+	const normalizedVerdict = normalizeFinalVerdict(synthesis.overallVerdict);
 
-	// Build the evidence entry
 	const evidenceEntry = {
 		type: 'final-council',
-		phase,
+		phase: input.phase,
 		plan_id: planId,
 		verdict: normalizedVerdict,
-		summary: summary.trim(),
-		timestamp: new Date().toISOString(),
+		rawCouncilVerdict: synthesis.overallVerdict,
+		quorumSize: synthesis.quorumSize,
+		membersVoted,
+		membersAbsent,
+		requiredFixes: synthesis.requiredFixes,
+		advisoryFindings: synthesis.advisoryFindings,
+		advisoryNotes: synthesis.advisoryNotes,
+		unresolvedConflicts: synthesis.unresolvedConflicts,
+		roundNumber: synthesis.roundNumber,
+		allCriteriaMet: synthesis.allCriteriaMet,
+		memberVerdicts: synthesis.memberVerdicts,
+		unifiedFeedbackMd: synthesis.unifiedFeedbackMd,
+		projectSummary: synthesis.projectSummary,
+		timestamp: synthesis.timestamp,
 	};
 
-	// Build the gate-contract format
-	const evidenceContent = {
-		entries: [evidenceEntry],
-	};
-
-	// Validate and construct the file path using validateSwarmPath
-	// Final council evidence goes to flat evidence root, not per-phase directory
 	const filename = 'final-council.json';
 	const relativePath = path.join('evidence', filename);
 	let validatedPath: string;
@@ -129,7 +164,7 @@ export async function executeWriteFinalCouncilEvidence(
 		return JSON.stringify(
 			{
 				success: false,
-				phase: phase,
+				phase: input.phase,
 				message:
 					error instanceof Error ? error.message : 'Failed to validate path',
 			},
@@ -138,14 +173,13 @@ export async function executeWriteFinalCouncilEvidence(
 		);
 	}
 
+	const evidenceContent = {
+		entries: [evidenceEntry],
+	};
 	const evidenceDir = path.dirname(validatedPath);
 
-	// Write the evidence file
 	try {
-		// Ensure the directory exists
 		await fs.promises.mkdir(evidenceDir, { recursive: true });
-
-		// Write the file atomically by writing to a temp file then renaming
 		const tempPath = path.join(evidenceDir, `.${filename}.tmp`);
 		await fs.promises.writeFile(
 			tempPath,
@@ -157,9 +191,24 @@ export async function executeWriteFinalCouncilEvidence(
 		return JSON.stringify(
 			{
 				success: true,
-				phase: phase,
+				phase: input.phase,
+				overallVerdict: synthesis.overallVerdict,
 				verdict: normalizedVerdict,
-				message: `Final council evidence written to .swarm/evidence/final-council.json`,
+				vetoedBy: synthesis.vetoedBy,
+				roundNumber: synthesis.roundNumber,
+				allCriteriaMet: synthesis.allCriteriaMet,
+				requiredFixesCount: synthesis.requiredFixes.length,
+				advisoryFindingsCount: synthesis.advisoryFindings.length,
+				unresolvedConflictsCount: synthesis.unresolvedConflicts.length,
+				advisoryNotes: synthesis.advisoryNotes,
+				membersVoted,
+				membersAbsent,
+				quorumSize: synthesis.quorumSize,
+				quorumMet: true,
+				evidencePath: synthesis.evidencePath,
+				unifiedFeedbackMd: synthesis.unifiedFeedbackMd,
+				message:
+					'Final council evidence written to .swarm/evidence/final-council.json',
 			},
 			null,
 			2,
@@ -168,7 +217,7 @@ export async function executeWriteFinalCouncilEvidence(
 		return JSON.stringify(
 			{
 				success: false,
-				phase: phase,
+				phase: input.phase,
 				message: error instanceof Error ? error.message : String(error),
 			},
 			null,
@@ -178,48 +227,55 @@ export async function executeWriteFinalCouncilEvidence(
 }
 
 /**
- * Tool definition for write_final_council_evidence
+ * Tool definition for write_final_council_evidence.
  */
 export const write_final_council_evidence: ToolDefinition = createSwarmTool({
 	description:
-		'Write final council evidence for a completed project. Accepts phase, verdict (APPROVED/NEEDS_REVISION), summary, and writes structured evidence to .swarm/evidence/final-council.json. Normalizes verdict to lowercase. Use this after convening a final holistic council to persist the verdict.',
+		'Write final council evidence for a completed project. This is not General Council mode and does not use convene_general_council. PREREQUISITE: dispatch critic, reviewer, sme, test_engineer, and explorer as project-scoped Agent tasks, collect their CouncilMemberVerdict JSON, then call this tool to synthesize and persist .swarm/evidence/final-council.json.',
 	args: {
 		phase: z
 			.number()
 			.int()
 			.min(1)
-			.describe(
-				'The phase number for the final council verdict (e.g., 1, 2, 3)',
-			),
-		verdict: z
-			.enum(['APPROVED', 'NEEDS_REVISION'])
-			.describe("Verdict of the final council: 'APPROVED' or 'NEEDS_REVISION'"),
-		summary: z
+			.describe('The final phase number for the project being reviewed'),
+		projectSummary: z
 			.string()
-			.describe('Human-readable summary of the final council verdict'),
+			.min(1)
+			.describe('Summary of the completed project and total work reviewed'),
+		roundNumber: z
+			.number()
+			.int()
+			.min(1)
+			.max(10)
+			.optional()
+			.describe('1-indexed final council round number. Defaults to 1.'),
+		verdicts: z
+			.array(VerdictSchema)
+			.min(1)
+			.max(5)
+			.describe(
+				'Collected CouncilMemberVerdict objects from critic, reviewer, sme, test_engineer, and explorer.',
+			),
 	},
 	execute: async (args, directory) => {
-		const rawPhase = args.phase !== undefined ? Number(args.phase) : 0;
-		try {
-			const writeFinalCouncilEvidenceArgs: WriteFinalCouncilEvidenceArgs = {
-				phase: Number(args.phase),
-				verdict: String(args.verdict) as 'APPROVED' | 'NEEDS_REVISION',
-				summary: String(args.summary ?? ''),
-			};
-			return await executeWriteFinalCouncilEvidence(
-				writeFinalCouncilEvidenceArgs,
-				directory,
-			);
-		} catch (error) {
+		const parsed = ArgsSchema.safeParse(args);
+		if (!parsed.success) {
 			return JSON.stringify(
 				{
 					success: false,
-					phase: rawPhase,
-					message: error instanceof Error ? error.message : 'Unknown error',
+					reason: 'invalid arguments',
+					errors: parsed.error.issues.map((i) => ({
+						path: i.path.join('.'),
+						message: i.message,
+					})),
 				},
 				null,
 				2,
 			);
 		}
+		return await executeWriteFinalCouncilEvidence(
+			parsed.data as WriteFinalCouncilEvidenceArgs,
+			directory,
+		);
 	},
 });

--- a/tests/unit/tools/phase-complete-final-council.adversarial.test.ts
+++ b/tests/unit/tools/phase-complete-final-council.adversarial.test.ts
@@ -146,7 +146,16 @@ describe('final_council gate (Gate 6) — adversarial attack vectors', () => {
 
 	afterEach(() => {
 		closeProjectDb(tempDir);
-		rmSync(tempDir, { recursive: true, force: true });
+		try {
+			rmSync(tempDir, {
+				recursive: true,
+				force: true,
+				maxRetries: 5,
+				retryDelay: 100,
+			});
+		} catch {
+			// Windows can briefly retain SQLite handles after closeProjectDb.
+		}
 	});
 
 	// =======================================================================
@@ -274,6 +283,15 @@ describe('final_council gate (Gate 6) — adversarial attack vectors', () => {
 						plan_id: PLAN_ID,
 						verdict: 'rejected',
 						summary: 'First verdict - rejected',
+						quorumSize: 5,
+						membersVoted: [
+							'critic',
+							'reviewer',
+							'sme',
+							'test_engineer',
+							'explorer',
+						],
+						membersAbsent: [],
 					},
 					{
 						type: 'final-council',
@@ -281,6 +299,15 @@ describe('final_council gate (Gate 6) — adversarial attack vectors', () => {
 						plan_id: PLAN_ID,
 						verdict: 'approved',
 						summary: 'Second verdict - approved',
+						quorumSize: 5,
+						membersVoted: [
+							'critic',
+							'reviewer',
+							'sme',
+							'test_engineer',
+							'explorer',
+						],
+						membersAbsent: [],
 					},
 				],
 			}),

--- a/tests/unit/tools/phase-complete-final-council.test.ts
+++ b/tests/unit/tools/phase-complete-final-council.test.ts
@@ -108,6 +108,10 @@ function enableFinalCouncil() {
 function writeFinalCouncilEvidence(options: {
 	verdict: string;
 	summary?: string;
+	quorumSize?: number;
+	omitQuorum?: boolean;
+	membersVoted?: string[];
+	membersAbsent?: string[];
 }) {
 	const evidencePath = join(tempDir, '.swarm', 'evidence');
 	mkdirSync(evidencePath, { recursive: true });
@@ -126,6 +130,19 @@ function writeFinalCouncilEvidence(options: {
 					plan_id: PLAN_ID,
 					verdict: options.verdict,
 					summary: options.summary ?? 'Final council verdict',
+					...(options.omitQuorum
+						? {}
+						: {
+								quorumSize: options.quorumSize ?? 5,
+								membersVoted: options.membersVoted ?? [
+									'critic',
+									'reviewer',
+									'sme',
+									'test_engineer',
+									'explorer',
+								],
+								membersAbsent: options.membersAbsent ?? [],
+							}),
 				},
 			],
 		}),
@@ -203,7 +220,16 @@ beforeEach(() => {
 
 afterEach(() => {
 	closeProjectDb(tempDir);
-	rmSync(tempDir, { recursive: true, force: true });
+	try {
+		rmSync(tempDir, {
+			recursive: true,
+			force: true,
+			maxRetries: 5,
+			retryDelay: 100,
+		});
+	} catch {
+		// Windows can briefly retain SQLite handles after closeProjectDb.
+	}
 });
 
 // ---------------------------------------------------------------------------
@@ -309,6 +335,65 @@ describe('final_council gate (Gate 6)', () => {
 			const parsed = JSON.parse(result);
 			expect(parsed.success).toBe(true);
 			expect(parsed.status).toBe('success');
+		});
+
+		test('blocks approved evidence without quorum metadata', async () => {
+			setupLastPhaseOnly(true);
+			writeFinalCouncilEvidence({
+				verdict: 'approved',
+				summary: 'Old minimal final council evidence',
+				omitQuorum: true,
+			});
+			const result = await executePhaseComplete(
+				{ phase: 3, summary: 'test', sessionID: SESSION_ID },
+				tempDir,
+				tempDir,
+			);
+			const parsed = JSON.parse(result);
+			expect(parsed.success).toBe(false);
+			expect(parsed.status).toBe('blocked');
+			expect(parsed.reason).toBe('FINAL_COUNCIL_MISSING_QUORUM');
+			expect(parsed.message).toContain('quorum metadata');
+		});
+
+		test('blocks approved evidence with fewer than five council members', async () => {
+			setupLastPhaseOnly(true);
+			writeFinalCouncilEvidence({
+				verdict: 'approved',
+				summary: 'Partial final council evidence',
+				quorumSize: 3,
+			});
+			const result = await executePhaseComplete(
+				{ phase: 3, summary: 'test', sessionID: SESSION_ID },
+				tempDir,
+				tempDir,
+			);
+			const parsed = JSON.parse(result);
+			expect(parsed.success).toBe(false);
+			expect(parsed.status).toBe('blocked');
+			expect(parsed.reason).toBe('FINAL_COUNCIL_MISSING_QUORUM');
+			expect(parsed.message).toContain('five-member final council');
+		});
+
+		test('blocks approved evidence with quorumSize 5 but malformed member metadata', async () => {
+			setupLastPhaseOnly(true);
+			writeFinalCouncilEvidence({
+				verdict: 'approved',
+				summary: 'Forged final council evidence',
+				quorumSize: 5,
+				membersVoted: ['critic'],
+				membersAbsent: ['reviewer', 'sme', 'test_engineer', 'explorer'],
+			});
+			const result = await executePhaseComplete(
+				{ phase: 3, summary: 'test', sessionID: SESSION_ID },
+				tempDir,
+				tempDir,
+			);
+			const parsed = JSON.parse(result);
+			expect(parsed.success).toBe(false);
+			expect(parsed.status).toBe('blocked');
+			expect(parsed.reason).toBe('FINAL_COUNCIL_MISSING_QUORUM');
+			expect(parsed.message).toContain('all five required members voted');
 		});
 
 		test('blocks with FINAL_COUNCIL_INVALID_VERDICT when evidence has unrecognized verdict', async () => {

--- a/tests/unit/tools/write-final-council-evidence.adversarial.test.ts
+++ b/tests/unit/tools/write-final-council-evidence.adversarial.test.ts
@@ -1,13 +1,52 @@
 /**
- * Adversarial security tests for write_final_council_evidence tool
- * Attack vectors: malformed inputs, oversized payloads, injection attempts, boundary violations
+ * Adversarial tests for write_final_council_evidence.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import type { CouncilMemberVerdict } from '../../../src/council/types';
 import { executeWriteFinalCouncilEvidence } from '../../../src/tools/write-final-council-evidence';
+
+const members = [
+	'critic',
+	'reviewer',
+	'sme',
+	'test_engineer',
+	'explorer',
+] as const;
+
+function verdict(
+	agent: (typeof members)[number],
+	overrides: Partial<CouncilMemberVerdict> = {},
+): CouncilMemberVerdict {
+	return {
+		agent,
+		verdict: 'APPROVE',
+		confidence: 0.9,
+		findings: [],
+		criteriaAssessed: ['project-close'],
+		criteriaUnmet: [],
+		durationMs: 10,
+		...overrides,
+	};
+}
+
+function allVerdicts(): CouncilMemberVerdict[] {
+	return members.map((member) => verdict(member));
+}
+
+async function readEvidence(tempDir: string) {
+	const filePath = path.join(
+		tempDir,
+		'.swarm',
+		'evidence',
+		'final-council.json',
+	);
+	const content = await fs.promises.readFile(filePath, 'utf-8');
+	return JSON.parse(content);
+}
 
 describe('write_final_council_evidence adversarial security tests', () => {
 	let tempDir: string;
@@ -16,7 +55,6 @@ describe('write_final_council_evidence adversarial security tests', () => {
 		tempDir = fs.realpathSync(
 			await fs.promises.mkdtemp(path.join(os.tmpdir(), 'final-council-adv-')),
 		);
-		// Create minimal .swarm structure (but not evidence/ - to test creation)
 		await fs.promises.mkdir(path.join(tempDir, '.swarm'), { recursive: true });
 	});
 
@@ -24,974 +62,146 @@ describe('write_final_council_evidence adversarial security tests', () => {
 		try {
 			await fs.promises.rm(tempDir, { recursive: true, force: true });
 		} catch {
-			// Ignore cleanup errors
+			// Ignore cleanup errors.
 		}
 	});
 
-	// ============================================
-	// ATTACK VECTOR 1: Path traversal attempts
-	// ============================================
-	describe('path traversal attacks', () => {
-		test('writes safely to .swarm subdirectory when directory contains traversal', async () => {
-			// The tool writes to directory/.swarm/evidence/ regardless of directory value.
-			// The directory parameter comes from the trusted plugin host, not user input.
-			// Even with ../ in directory path, tool correctly creates .swarm under that path.
-			const maliciousDir = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'..',
-				'..',
-				'..',
-				'etc',
-			);
-			await fs.promises.mkdir(maliciousDir, { recursive: true });
+	test('rejects four valid members because final council requires all five', async () => {
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 1,
+				projectSummary: 'Project summary',
+				verdicts: allVerdicts().slice(0, 4),
+			},
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
 
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: 'test' },
-				maliciousDir,
-			);
-			const parsed = JSON.parse(result);
-
-			// Tool correctly succeeds - it writes to maliciousDir/.swarm/evidence/
-			// The attacker is just writing to their own directory's .swarm subdirectory
-			expect(parsed.success).toBe(true);
-		});
-
-		test('rejects absolute path traversal attempt', async () => {
-			// Attempt to escape using Windows-style absolute path
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: 'test' },
-				'C:\\Windows\\System32',
-			);
-			const parsed = JSON.parse(result);
-
-			// validateSwarmPath resolves paths relative to the provided directory,
-			// so this should still work but write to the correct .swarm location
-			// The directory argument is from plugin host, not user input
-			// So we just verify it succeeds or fails gracefully
-			expect(typeof parsed.success).toBe('boolean');
-		});
-
-		test('handles traversal with backslash separator on POSIX', async () => {
-			// Test that ..\\ pattern is also rejected on all platforms
-			// This tests the regex in validateSwarmPath
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-			expect(parsed.success).toBe(true);
-		});
+		expect(parsed.success).toBe(false);
+		expect(parsed.reason).toBe('insufficient_quorum');
+		expect(parsed.quorumRequired).toBe(5);
+		expect(parsed.membersAbsent).toEqual(['explorer']);
 	});
 
-	// ============================================
-	// ATTACK VECTOR 2: Extremely large summary (1MB string)
-	// ============================================
-	describe('oversized payload attacks', () => {
-		test('handles maximum sized summary (1MB)', async () => {
-			const largeSummary = 'A'.repeat(1024 * 1024); // 1MB
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: largeSummary },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
+	test('rejects duplicate-member payloads even when five verdict objects are present', async () => {
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 1,
+				projectSummary: 'Project summary',
+				verdicts: [
+					verdict('critic'),
+					verdict('critic'),
+					verdict('reviewer'),
+					verdict('sme'),
+					verdict('test_engineer'),
+				],
+			},
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
 
-			// Should succeed - no size limit imposed
-			expect(parsed.success).toBe(true);
-			expect(parsed.verdict).toBe('approved');
-
-			// Verify the file was actually written with large content
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			const parsedContent = JSON.parse(content);
-			expect(parsedContent.entries[0].summary.length).toBe(1024 * 1024);
-		});
-
-		test('handles 10MB summary without crashing', async () => {
-			const hugeSummary = 'X'.repeat(10 * 1024 * 1024); // 10MB
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: hugeSummary },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			// Should succeed - no size limit
-			expect(parsed.success).toBe(true);
-		});
-
-		test('handles empty string summary correctly', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: '' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('non-empty');
-		});
+		expect(parsed.success).toBe(false);
+		expect(parsed.reason).toBe('insufficient_quorum');
+		expect(parsed.membersVoted).toEqual([
+			'critic',
+			'reviewer',
+			'sme',
+			'test_engineer',
+		]);
+		expect(parsed.membersAbsent).toEqual(['explorer']);
 	});
 
-	// ============================================
-	// ATTACK VECTOR 3: Phase boundary violations
-	// ============================================
-	describe('phase boundary violations', () => {
-		test('accepts Number.MAX_SAFE_INTEGER as phase (latent bug: no upper bound)', async () => {
-			// NOTE: Number.isInteger(MAX_SAFE_INTEGER) is true, so validation passes.
-			// This is a latent bug - the tool should have an upper bound on phase.
+	test('rejects invalid council member and verdict casing', async () => {
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 1,
+				projectSummary: 'Project summary',
+				verdicts: [
+					{ ...verdict('critic'), agent: 'council_generalist' },
+					{ ...verdict('reviewer'), verdict: 'approved' },
+					verdict('sme'),
+					verdict('test_engineer'),
+					verdict('explorer'),
+				],
+			},
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.reason).toBe('invalid arguments');
+		expect(
+			parsed.errors.map((error: { path: string }) => error.path),
+		).toContain('verdicts.0.agent');
+		expect(
+			parsed.errors.map((error: { path: string }) => error.path),
+		).toContain('verdicts.1.verdict');
+	});
+
+	test('preserves hostile strings as inert JSON data', async () => {
+		const projectSummary =
+			'<script>alert("xss")</script>\x00 ${process.env.SECRET} \u202E';
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 1,
+				projectSummary,
+				verdicts: [
+					verdict('critic', {
+						verdict: 'REJECT',
+						findings: [
+							{
+								severity: 'HIGH',
+								category: 'security',
+								location: 'src/example.ts:1',
+								detail: 'Null byte \x00 and SQL-ish text; DROP TABLE evidence;',
+								evidence: 'Literal ${process.env.SECRET} stayed data-only.',
+							},
+						],
+						criteriaUnmet: ['project-close'],
+					}),
+					...members
+						.filter((member) => member !== 'critic')
+						.map((member) => verdict(member)),
+				],
+			},
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.verdict).toBe('rejected');
+
+		const raw = await fs.promises.readFile(
+			path.join(tempDir, '.swarm', 'evidence', 'final-council.json'),
+			'utf-8',
+		);
+		expect(raw).not.toContain('\x00');
+		expect(raw).toContain('\\u0000');
+
+		const evidence = JSON.parse(raw);
+		const entry = evidence.entries[0];
+		expect(entry.projectSummary).toBe(projectSummary);
+		expect(entry.requiredFixes[0].detail).toContain('DROP TABLE');
+		expect(entry.requiredFixes[0].evidence).toContain('process.env.SECRET');
+	});
+
+	test('rapid sequential writes remain valid JSON and last write wins', async () => {
+		for (let i = 1; i <= 20; i++) {
 			const result = await executeWriteFinalCouncilEvidence(
 				{
-					phase: Number.MAX_SAFE_INTEGER,
-					verdict: 'APPROVED',
-					summary: 'test',
+					phase: i,
+					projectSummary: `Project close attempt ${i}`,
+					verdicts: allVerdicts(),
 				},
 				tempDir,
 			);
-			const parsed = JSON.parse(result);
-
-			// Currently the tool accepts this - but it probably shouldn't
-			// as phase=9007199254740991 is nonsensical
-			expect(parsed.success).toBe(true);
-		});
-
-		test('rejects Number.MIN_VALUE as phase', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: Number.MIN_VALUE, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('positive integer');
-		});
-
-		test('rejects -Infinity as phase', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: -Infinity, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('positive integer');
-		});
-
-		test('rejects Infinity as phase', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: Infinity, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('positive integer');
-		});
-
-		test('rejects negative phase (-100)', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: -100, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('positive integer');
-		});
-
-		test('accepts phase 1 (minimum valid)', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-			expect(parsed.phase).toBe(1);
-		});
-
-		test('accepts very large valid integer phase', async () => {
-			const largePhase = 2 ** 31 - 1; // Max 32-bit signed int
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: largePhase, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-			expect(parsed.phase).toBe(largePhase);
-		});
-	});
-
-	// ============================================
-	// ATTACK VECTOR 4: Mixed case verdict variations
-	// ============================================
-	describe('verdict case variations', () => {
-		test('rejects lowercase "approved"', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'approved' as any, summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('APPROVED');
-		});
-
-		test('rejects mixed case "Approved"', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'Approved' as any, summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('APPROVED');
-		});
-
-		test('rejects mixed case "ApPrOvEd"', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'ApPrOvEd' as any, summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('APPROVED');
-		});
-
-		test('rejects lowercase "rejected"', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'rejected' as any, summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-		});
-
-		test('rejects mixed case "Needs_Revision"', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'Needs_Revision' as any, summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-		});
-
-		test('accepts exact "APPROVED"', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-			expect(parsed.verdict).toBe('approved');
-		});
-
-		test('accepts exact "NEEDS_REVISION"', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'NEEDS_REVISION', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-			expect(parsed.verdict).toBe('rejected');
-		});
-	});
-
-	// ============================================
-	// ATTACK VECTOR 5: Summary injection attempts
-	// ============================================
-	describe('summary injection attacks', () => {
-		test('handles null byte in summary', async () => {
-			const summaryWithNull = 'test\x00injection';
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: summaryWithNull },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			// The tool accepts the string as-is, but JSON.stringify will escape the null
-			expect(parsed.success).toBe(true);
-
-			// Verify null byte was properly escaped in JSON
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			expect(content).not.toContain('\x00');
-			expect(content).toContain('\\u0000');
-		});
-
-		test('handles unicode emoji in summary', async () => {
-			const unicodeSummary = 'Test with emoji 🚀 and unicode ✓';
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: unicodeSummary },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-
-			// Verify unicode was preserved
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			const parsedContent = JSON.parse(content);
-			expect(parsedContent.entries[0].summary).toBe(unicodeSummary);
-		});
-
-		test('handles RTL unicode override characters', async () => {
-			// Unicode RTL override - potential XSS in some contexts
-			const rtlSummary = 'test\u202Ejavascript:alert(1)';
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: rtlSummary },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-
-			// Verify the content is stored as-is (not sanitized, but not executable in JSON context)
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			const parsedContent = JSON.parse(content);
-			expect(parsedContent.entries[0].summary).toBe(rtlSummary);
-		});
-
-		test('handles control characters in summary', async () => {
-			const controlSummary = 'test\x00\x01\x02inject';
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: controlSummary },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-
-			// Verify control chars were escaped in JSON
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			expect(content).not.toContain('\x00');
-			expect(content).toContain('\\u0000');
-		});
-
-		test('handles HTML/script tags in summary', async () => {
-			const htmlSummary = '<script>alert("xss")</script>';
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: htmlSummary },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-
-			// Verify HTML is preserved as string (not executable in JSON context)
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			const parsedContent = JSON.parse(content);
-			expect(parsedContent.entries[0].summary).toBe(htmlSummary);
-		});
-
-		test('handles SQL injection pattern in summary', async () => {
-			const sqlSummary = "'; DROP TABLE evidence; --";
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: sqlSummary },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-
-			// Verify SQL pattern is preserved as string
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			const parsedContent = JSON.parse(content);
-			expect(parsedContent.entries[0].summary).toBe(sqlSummary);
-		});
-
-		test('handles template literal injection pattern', async () => {
-			const templateSummary = '${process.env.SECRET}';
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: templateSummary },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			const parsedContent = JSON.parse(content);
-			expect(parsedContent.entries[0].summary).toBe(templateSummary);
-		});
-
-		test('handles combining unicode characters', async () => {
-			// Combining character that could obscure text
-			const combiningSummary = 'Suspense\u0301text'; // combines accent
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: combiningSummary },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			const parsedContent = JSON.parse(content);
-			expect(parsedContent.entries[0].summary).toBe(combiningSummary);
-		});
-
-		test('handles zero-width characters', async () => {
-			const zwcSummary = 'test\u200Bzero\u200Cwidth\u200Dchars';
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: zwcSummary },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			const parsedContent = JSON.parse(content);
-			expect(parsedContent.entries[0].summary).toBe(zwcSummary);
-		});
-	});
-
-	// ============================================
-	// ATTACK VECTOR 6: Concurrent writes
-	// ============================================
-	describe('concurrent write attacks', () => {
-		test('handles concurrent writes without data corruption', async () => {
-			const numConcurrent = 10;
-			const promises: Promise<string>[] = [];
-
-			for (let i = 0; i < numConcurrent; i++) {
-				promises.push(
-					executeWriteFinalCouncilEvidence(
-						{
-							phase: i + 1,
-							verdict: 'APPROVED',
-							summary: `Concurrent write ${i}`,
-						},
-						tempDir,
-					),
-				);
-			}
-
-			const results = await Promise.all(promises);
-
-			// On Windows, renameSync may fail when multiple writers target the same file.
-			// At least one write must succeed (last-writer-wins is acceptable).
-			const successCount = results.filter((r) => {
-				try {
-					return JSON.parse(r).success === true;
-				} catch {
-					return false;
-				}
-			}).length;
-			expect(successCount).toBeGreaterThanOrEqual(1);
-
-			// On Windows, concurrent writes using the same temp-file path can
-			// corrupt the final file. We only assert that at least one write
-			// succeeded and the target file exists. Content integrity is verified
-			// in the sequential overwrite test below.
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			expect(successCount).toBeGreaterThanOrEqual(1);
-			const fileExists = fs.existsSync(filePath);
-			expect(fileExists).toBe(true);
-		});
-
-		test('handles rapid sequential overwrites', async () => {
-			for (let i = 1; i <= 100; i++) {
-				const result = await executeWriteFinalCouncilEvidence(
-					{ phase: i, verdict: 'APPROVED', summary: `Write ${i}` },
-					tempDir,
-				);
-				const parsed = JSON.parse(result);
-				expect(parsed.success).toBe(true);
-			}
-
-			// Final file should be valid
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			const parsedContent = JSON.parse(content);
-			expect(parsedContent.entries[0].summary).toBe('Write 100');
-		});
-	});
-
-	// ============================================
-	// ATTACK VECTOR 7: Non-existent deep directory
-	// ============================================
-	describe('non-existent directory attacks', () => {
-		test('handles deeply non-existent evidence directory', async () => {
-			// Create a temp dir but DON'T create .swarm/evidence
-			// The tool should create it via mkdir with recursive: true
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-
-			// Verify directory was created
-			const evidenceDir = path.join(tempDir, '.swarm', 'evidence');
-			const dirExists = await fs.promises
-				.access(evidenceDir)
-				.then(() => true)
-				.catch(() => false);
-			expect(dirExists).toBe(true);
-		});
-
-		test('handles missing parent directories in path', async () => {
-			// Create a nested structure that doesn't exist
-			const missingDir = path.join(
-				tempDir,
-				'.swarm',
-				'missing',
-				'nested',
-				'evidence',
-			);
-			await fs.promises.mkdir(path.join(tempDir, '.swarm'), {
-				recursive: true,
-			});
-			//故意不创建 missing/nested/evidence
-
-			// 使用一个假的directory让它找不到.swarm
-			const noSwarmDir = path.join(tempDir, 'no-swarm-here');
-			await fs.promises.mkdir(noSwarmDir, { recursive: true });
-
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: 'test' },
-				noSwarmDir,
-			);
-			const parsed = JSON.parse(result);
-
-			// Should succeed - mkdir should create the directory
-			expect(parsed.success).toBe(true);
-		});
-	});
-
-	// ============================================
-	// ATTACK VECTOR 8: Float phase values
-	// ============================================
-	describe('float phase attacks', () => {
-		test('rejects float phase (1.9999999)', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1.9999999, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('positive integer');
-		});
-
-		test('rejects float phase (1.5)', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1.5, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('positive integer');
-		});
-
-		test('rejects float phase (3.14159)', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 3.14159, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('positive integer');
-		});
-
-		test('rejects phase that truncates to valid integer (1.0000001)', async () => {
-			// Even though Math.floor would give 1, Number.isInteger should reject it
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1.0000001, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('positive integer');
-		});
-
-		test('rejects very small float (0.0000001)', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 0.0000001, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('positive integer');
-		});
-
-		test('accepts integer stored as float (2.0)', async () => {
-			// 2.0 is technically an integer
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 2.0, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			// Number.isInteger(2.0) returns true
-			expect(parsed.success).toBe(true);
-			expect(parsed.phase).toBe(2);
-		});
-	});
-
-	// ============================================
-	// BOUNDARY: Whitespace-only and special summaries
-	// ============================================
-	describe('whitespace and special summary edge cases', () => {
-		test('rejects whitespace-only summary', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: '   \t\n  ' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('non-empty');
-		});
-
-		test('accepts summary with leading/trailing whitespace', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: '  trimmed content  ' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-
-			// Verify whitespace was trimmed in stored content
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			const parsedContent = JSON.parse(content);
-			expect(parsedContent.entries[0].summary).toBe('trimmed content');
-		});
-
-		test('handles only emoji in summary', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: '🎉🎊✨' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-		});
-
-		test('handles very long single word', async () => {
-			const longWord = 'A'.repeat(10000);
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: longWord },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-		});
-	});
-
-	// ============================================
-	// TYPE CONFUSION ATTACKS
-	// ============================================
-	describe('type confusion attacks', () => {
-		test('rejects null verdict', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: null as any, summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-		});
-
-		test('rejects undefined verdict', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: undefined as any, summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-		});
-
-		test('rejects number verdict', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 123 as any, summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-		});
-
-		test('rejects object verdict', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: { value: 'APPROVED' } as any, summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-		});
-
-		test('rejects array verdict', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: ['APPROVED'] as any, summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-		});
-
-		test('rejects NaN verdict', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: NaN as any, summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-		});
-	});
-
-	// ============================================
-	// NaN and special number handling
-	// ============================================
-	describe('NaN and special number handling', () => {
-		test('rejects NaN phase', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: NaN, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-			expect(parsed.message).toContain('positive integer');
-		});
-
-		test('rejects undefined phase', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: undefined as any, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-		});
-
-		test('rejects null phase', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: null as any, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-		});
-
-		test('rejects string phase', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: '1' as any, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-		});
-
-		test('rejects object phase', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: { value: 1 } as any, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-		});
-
-		test('rejects array phase', async () => {
-			const result = await executeWriteFinalCouncilEvidence(
-				{ phase: [1] as any, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(false);
-		});
-	});
-
-	// ============================================
-	// JSON structure verification
-	// ============================================
-	describe('JSON structure integrity', () => {
-		test('produces valid JSON even with special characters', async () => {
-			const complexSummary = `
-				{
-					"test": "value",
-					"unicode": "🎉",
-					"null byte": "\x00",
-					"control": "\x01\x02"
-				}
-			`;
-
-			await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: complexSummary },
-				tempDir,
-			);
-
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-
-			// Should be valid JSON
-			expect(() => JSON.parse(content)).not.toThrow();
-
-			// The content should properly escape the special chars
-			expect(content).not.toContain('\x00');
-			expect(content).toContain('\\u0000');
-		});
-
-		test('timestamp is valid ISO format', async () => {
-			await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			const parsed = JSON.parse(content);
-
-			const timestamp = parsed.entries[0].timestamp;
-			const date = new Date(timestamp);
-
-			// Should be valid date
-			expect(date.toISOString()).toBe(timestamp);
-			expect(Number.isNaN(date.getTime())).toBe(false);
-		});
-
-		test('entry type is always "final-council"', async () => {
-			await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'APPROVED', summary: 'test' },
-				tempDir,
-			);
-
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			const parsed = JSON.parse(content);
-
-			expect(parsed.entries[0].type).toBe('final-council');
-		});
-
-		test('verdict is always normalized (lowercase)', async () => {
-			await executeWriteFinalCouncilEvidence(
-				{ phase: 1, verdict: 'NEEDS_REVISION', summary: 'test' },
-				tempDir,
-			);
-
-			const filePath = path.join(
-				tempDir,
-				'.swarm',
-				'evidence',
-				'final-council.json',
-			);
-			const content = await fs.promises.readFile(filePath, 'utf-8');
-			const parsed = JSON.parse(content);
-
-			expect(parsed.entries[0].verdict).toBe('rejected');
-			expect(parsed.entries[0].verdict).not.toBe('approved');
-			expect(parsed.entries[0].verdict).not.toBe('REJECTED');
-		});
+			expect(JSON.parse(result).success).toBe(true);
+		}
+
+		const evidence = await readEvidence(tempDir);
+		expect(evidence.entries).toHaveLength(1);
+		expect(evidence.entries[0].phase).toBe(20);
+		expect(evidence.entries[0].projectSummary).toBe('Project close attempt 20');
+		expect(evidence.entries[0].memberVerdicts).toHaveLength(5);
 	});
 });

--- a/tests/unit/tools/write-final-council-evidence.test.ts
+++ b/tests/unit/tools/write-final-council-evidence.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for write_final_council_evidence tool
+ * Tests for write_final_council_evidence tool.
  */
 
 import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
@@ -7,36 +7,82 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import type { CouncilMemberVerdict } from '../../../src/council/types';
 import { executeWriteFinalCouncilEvidence } from '../../../src/tools/write-final-council-evidence';
+
+const members = [
+	'critic',
+	'reviewer',
+	'sme',
+	'test_engineer',
+	'explorer',
+] as const;
+
+function verdict(
+	agent: (typeof members)[number],
+	overrides: Partial<CouncilMemberVerdict> = {},
+): CouncilMemberVerdict {
+	return {
+		agent,
+		verdict: 'APPROVE',
+		confidence: 0.9,
+		findings: [],
+		criteriaAssessed: ['project-scope'],
+		criteriaUnmet: [],
+		durationMs: 25,
+		...overrides,
+	};
+}
+
+function allApprovedVerdicts(): CouncilMemberVerdict[] {
+	return members.map((member) => verdict(member));
+}
+
+function rejectingVerdicts(): CouncilMemberVerdict[] {
+	return [
+		verdict('critic', {
+			verdict: 'REJECT',
+			findings: [
+				{
+					severity: 'HIGH',
+					category: 'logic',
+					location: 'src/example.ts:10',
+					detail: 'Project close would ship an unresolved runtime bug.',
+					evidence: 'critic found failing path',
+				},
+			],
+			criteriaUnmet: ['project-scope'],
+		}),
+		...members
+			.filter((member) => member !== 'critic')
+			.map((member) => verdict(member)),
+	];
+}
 
 describe('executeWriteFinalCouncilEvidence', () => {
 	let tempDir: string;
 
 	beforeEach(async () => {
-		// Create a temp directory for each test
 		tempDir = await fs.promises.mkdtemp(
 			path.join(os.tmpdir(), 'final-council-evidence-test-'),
 		);
-		// Create the .swarm directory structure (but not evidence/)
 		await fs.promises.mkdir(path.join(tempDir, '.swarm'), { recursive: true });
 	});
 
 	afterEach(async () => {
-		// Clean up temp directory
 		try {
 			await fs.promises.rm(tempDir, { recursive: true, force: true });
 		} catch {
-			// Ignore cleanup errors
+			// Ignore cleanup errors.
 		}
 	});
 
-	// Test 1: Writes valid evidence bundle to .swarm/evidence/final-council.json
-	test('writes valid evidence bundle to .swarm/evidence/final-council.json', async () => {
+	test('writes project-scoped five-member final council evidence', async () => {
 		const result = await executeWriteFinalCouncilEvidence(
 			{
 				phase: 3,
-				verdict: 'APPROVED',
-				summary: 'All checks passed',
+				projectSummary: 'All planned project phases are complete.',
+				verdicts: allApprovedVerdicts(),
 			},
 			tempDir,
 		);
@@ -45,168 +91,10 @@ describe('executeWriteFinalCouncilEvidence', () => {
 		expect(parsed.success).toBe(true);
 		expect(parsed.phase).toBe(3);
 		expect(parsed.verdict).toBe('approved');
-		expect(parsed.message).toBe(
-			'Final council evidence written to .swarm/evidence/final-council.json',
-		);
-
-		// Verify file exists at the correct path
-		const expectedPath = path.join(
-			tempDir,
-			'.swarm',
-			'evidence',
-			'final-council.json',
-		);
-		const fileExists = await fs.promises
-			.access(expectedPath)
-			.then(() => true)
-			.catch(() => false);
-		expect(fileExists).toBe(true);
-	});
-
-	// Test 2: Normalizes APPROVED to 'approved'
-	test('normalizes APPROVED verdict to lowercase approved', async () => {
-		const result = await executeWriteFinalCouncilEvidence(
-			{ phase: 1, verdict: 'APPROVED', summary: 'test summary' },
-			tempDir,
-		);
-		const parsed = JSON.parse(result);
-
-		expect(parsed.success).toBe(true);
-		expect(parsed.verdict).toBe('approved');
-	});
-
-	// Test 3: Normalizes NEEDS_REVISION to 'rejected'
-	test('normalizes NEEDS_REVISION verdict to lowercase rejected', async () => {
-		const result = await executeWriteFinalCouncilEvidence(
-			{ phase: 1, verdict: 'NEEDS_REVISION', summary: 'test summary' },
-			tempDir,
-		);
-		const parsed = JSON.parse(result);
-
-		expect(parsed.success).toBe(true);
-		expect(parsed.verdict).toBe('rejected');
-	});
-
-	// Test 4a: Rejects invalid phase (0)
-	test('rejects phase 0', async () => {
-		const result = await executeWriteFinalCouncilEvidence(
-			{ phase: 0, verdict: 'APPROVED', summary: 'test summary' },
-			tempDir,
-		);
-		const parsed = JSON.parse(result);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.phase).toBe(0);
-		expect(parsed.message).toBe('Invalid phase: must be a positive integer');
-	});
-
-	// Test 4b: Rejects invalid phase (-1)
-	test('rejects negative phase numbers', async () => {
-		const result = await executeWriteFinalCouncilEvidence(
-			{ phase: -1, verdict: 'APPROVED', summary: 'test summary' },
-			tempDir,
-		);
-		const parsed = JSON.parse(result);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.phase).toBe(-1);
-		expect(parsed.message).toBe('Invalid phase: must be a positive integer');
-	});
-
-	// Test 4c: Rejects non-integer phase (1.5)
-	test('rejects non-integer phase numbers', async () => {
-		const result = await executeWriteFinalCouncilEvidence(
-			{ phase: 1.5, verdict: 'APPROVED', summary: 'test summary' },
-			tempDir,
-		);
-		const parsed = JSON.parse(result);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.message).toBe('Invalid phase: must be a positive integer');
-	});
-
-	// Test 4d: Rejects NaN phase
-	test('rejects NaN phase', async () => {
-		const result = await executeWriteFinalCouncilEvidence(
-			{ phase: NaN, verdict: 'APPROVED', summary: 'test summary' } as any,
-			tempDir,
-		);
-		const parsed = JSON.parse(result);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.message).toBe('Invalid phase: must be a positive integer');
-	});
-
-	// Test 5a: Rejects invalid verdict ('MAYBE')
-	test('rejects invalid verdict MAYBE', async () => {
-		const result = await executeWriteFinalCouncilEvidence(
-			{ phase: 1, verdict: 'MAYBE' as any, summary: 'test summary' },
-			tempDir,
-		);
-		const parsed = JSON.parse(result);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.message).toBe(
-			"Invalid verdict: must be 'APPROVED' or 'NEEDS_REVISION'",
-		);
-	});
-
-	// Test 5b: Rejects invalid verdict ('INVALID')
-	test('rejects invalid verdict INVALID', async () => {
-		const result = await executeWriteFinalCouncilEvidence(
-			{ phase: 1, verdict: 'INVALID' as any, summary: 'test summary' },
-			tempDir,
-		);
-		const parsed = JSON.parse(result);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.message).toBe(
-			"Invalid verdict: must be 'APPROVED' or 'NEEDS_REVISION'",
-		);
-	});
-
-	// Test 6a: Rejects empty summary
-	test('rejects empty summary', async () => {
-		const result = await executeWriteFinalCouncilEvidence(
-			{ phase: 1, verdict: 'APPROVED', summary: '' },
-			tempDir,
-		);
-		const parsed = JSON.parse(result);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.message).toBe('Invalid summary: must be a non-empty string');
-	});
-
-	// Test 6b: Rejects whitespace-only summary
-	test('rejects whitespace-only summary', async () => {
-		const result = await executeWriteFinalCouncilEvidence(
-			{ phase: 1, verdict: 'APPROVED', summary: '   ' },
-			tempDir,
-		);
-		const parsed = JSON.parse(result);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.message).toBe('Invalid summary: must be a non-empty string');
-	});
-
-	// Test 6c: Rejects missing summary (undefined cast as any)
-	test('rejects missing summary', async () => {
-		const result = await executeWriteFinalCouncilEvidence(
-			{ phase: 1, verdict: 'APPROVED', summary: undefined } as any,
-			tempDir,
-		);
-		const parsed = JSON.parse(result);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.message).toBe('Invalid summary: must be a non-empty string');
-	});
-
-	// Test 7: Evidence file contains correct structure
-	test('evidence file contains correct structure with entries array', async () => {
-		await executeWriteFinalCouncilEvidence(
-			{ phase: 3, verdict: 'APPROVED', summary: 'Final council approved' },
-			tempDir,
-		);
+		expect(parsed.overallVerdict).toBe('APPROVE');
+		expect(parsed.quorumSize).toBe(5);
+		expect(parsed.membersVoted).toEqual([...members]);
+		expect(parsed.evidencePath).toBe('.swarm/evidence/final-council.json');
 
 		const expectedPath = path.join(
 			tempDir,
@@ -215,54 +103,132 @@ describe('executeWriteFinalCouncilEvidence', () => {
 			'final-council.json',
 		);
 		const content = await fs.promises.readFile(expectedPath, 'utf-8');
-		const parsed = JSON.parse(content);
+		const evidence = JSON.parse(content);
+		const entry = evidence.entries[0];
 
-		// Verify structure: { entries: [{ type, verdict, summary, timestamp }] }
-		expect(parsed).toHaveProperty('entries');
-		expect(Array.isArray(parsed.entries)).toBe(true);
-		expect(parsed.entries).toHaveLength(1);
-
-		const entry = parsed.entries[0];
 		expect(entry.type).toBe('final-council');
+		expect(entry.phase).toBe(3);
 		expect(entry.verdict).toBe('approved');
-		expect(entry.summary).toBe('Final council approved');
-		expect(typeof entry.timestamp).toBe('string');
-		// Verify timestamp is ISO format
+		expect(entry.rawCouncilVerdict).toBe('APPROVE');
+		expect(entry.quorumSize).toBe(5);
+		expect(entry.memberVerdicts).toHaveLength(5);
+		expect(entry.membersAbsent).toEqual([]);
+		expect(entry.projectSummary).toBe(
+			'All planned project phases are complete.',
+		);
+		expect(entry.unifiedFeedbackMd).toContain('## Final Council Review');
+		expect(entry.unifiedFeedbackMd).not.toContain('Phase Council Review');
 		expect(new Date(entry.timestamp).toISOString()).toBe(entry.timestamp);
 	});
 
-	// Test 7b: Evidence file with NEEDS_REVISION verdict
-	test('evidence file with rejected verdict contains correct structure', async () => {
-		await executeWriteFinalCouncilEvidence(
-			{ phase: 2, verdict: 'NEEDS_REVISION', summary: 'Requires more work' },
+	test('normalizes rejecting or concern final council verdicts to rejected evidence verdict', async () => {
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 2,
+				projectSummary: 'Project complete pending final review.',
+				verdicts: rejectingVerdicts(),
+			},
 			tempDir,
 		);
+		const parsed = JSON.parse(result);
 
-		const expectedPath = path.join(
-			tempDir,
-			'.swarm',
-			'evidence',
-			'final-council.json',
+		expect(parsed.success).toBe(true);
+		expect(parsed.overallVerdict).toBe('REJECT');
+		expect(parsed.verdict).toBe('rejected');
+		expect(parsed.requiredFixesCount).toBe(1);
+
+		const content = await fs.promises.readFile(
+			path.join(tempDir, '.swarm', 'evidence', 'final-council.json'),
+			'utf-8',
 		);
-		const content = await fs.promises.readFile(expectedPath, 'utf-8');
-		const parsed = JSON.parse(content);
-
-		expect(parsed.entries[0].verdict).toBe('rejected');
-		expect(parsed.entries[0].summary).toBe('Requires more work');
+		const entry = JSON.parse(content).entries[0];
+		expect(entry.verdict).toBe('rejected');
+		expect(entry.requiredFixes).toHaveLength(1);
+		expect(entry.allCriteriaMet).toBe(false);
 	});
 
-	// Test 8: Uses atomic temp+rename pattern
-	test('uses atomic temp+rename pattern (file exists after write)', async () => {
-		// Spy on fs.promises.writeFile and fs.promises.rename
+	test('rejects invalid phase and missing project summary', async () => {
+		const badPhase = JSON.parse(
+			await executeWriteFinalCouncilEvidence(
+				{
+					phase: 0,
+					projectSummary: 'Project summary',
+					verdicts: allApprovedVerdicts(),
+				},
+				tempDir,
+			),
+		);
+		expect(badPhase.success).toBe(false);
+		expect(badPhase.reason).toBe('invalid arguments');
+		expect(badPhase.errors[0].path).toBe('phase');
+
+		const missingSummary = JSON.parse(
+			await executeWriteFinalCouncilEvidence(
+				{
+					phase: 1,
+					projectSummary: '',
+					verdicts: allApprovedVerdicts(),
+				},
+				tempDir,
+			),
+		);
+		expect(missingSummary.success).toBe(false);
+		expect(missingSummary.reason).toBe('invalid arguments');
+		expect(missingSummary.errors[0].path).toBe('projectSummary');
+	});
+
+	test('rejects legacy verdict and summary payloads', async () => {
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 1,
+				verdict: 'APPROVED',
+				summary: 'Legacy simple payload',
+			},
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.reason).toBe('invalid arguments');
+		expect(
+			parsed.errors.map((error: { path: string }) => error.path),
+		).toContain('projectSummary');
+		expect(
+			parsed.errors.map((error: { path: string }) => error.path),
+		).toContain('verdicts');
+	});
+
+	test('rejects insufficient quorum with actionable absent-member metadata', async () => {
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 1,
+				projectSummary: 'Project summary',
+				verdicts: [verdict('critic'), verdict('reviewer')],
+			},
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.reason).toBe('insufficient_quorum');
+		expect(parsed.membersVoted).toEqual(['critic', 'reviewer']);
+		expect(parsed.membersAbsent).toEqual(['sme', 'test_engineer', 'explorer']);
+		expect(parsed.quorumRequired).toBe(5);
+	});
+
+	test('uses atomic temp+rename pattern', async () => {
 		const writeFileSpy = spyOn(fs.promises, 'writeFile');
 		const renameSpy = spyOn(fs.promises, 'rename');
 
 		await executeWriteFinalCouncilEvidence(
-			{ phase: 1, verdict: 'APPROVED', summary: 'Atomic write test' },
+			{
+				phase: 1,
+				projectSummary: 'Atomic write test',
+				verdicts: allApprovedVerdicts(),
+			},
 			tempDir,
 		);
 
-		// Verify atomic write pattern: write to temp then rename
 		expect(writeFileSpy).toHaveBeenCalledTimes(1);
 		expect(renameSpy).toHaveBeenCalledTimes(1);
 
@@ -270,77 +236,14 @@ describe('executeWriteFinalCouncilEvidence', () => {
 		const renameFrom = renameSpy.mock.calls[0][0] as string;
 		const renameTo = renameSpy.mock.calls[0][1] as string;
 
-		// Temp file should be in the evidence directory with .tmp extension
 		expect(tempPath).toContain('.swarm');
 		expect(tempPath).toContain('.final-council.json.tmp');
-
-		// Rename from temp to final location
 		expect(renameFrom).toBe(tempPath);
 		expect(renameTo).toBe(
 			path.join(tempDir, '.swarm', 'evidence', 'final-council.json'),
 		);
 
-		// Verify the final file exists after the operation
-		const finalPath = path.join(
-			tempDir,
-			'.swarm',
-			'evidence',
-			'final-council.json',
-		);
-		const fileExists = await fs.promises
-			.access(finalPath)
-			.then(() => true)
-			.catch(() => false);
-		expect(fileExists).toBe(true);
-
 		writeFileSpy.mockRestore();
 		renameSpy.mockRestore();
-	});
-
-	// Test: Summary is trimmed in output
-	test('summary is trimmed in output', async () => {
-		await executeWriteFinalCouncilEvidence(
-			{ phase: 1, verdict: 'APPROVED', summary: '  trimmed summary  ' },
-			tempDir,
-		);
-
-		const expectedPath = path.join(
-			tempDir,
-			'.swarm',
-			'evidence',
-			'final-council.json',
-		);
-		const content = await fs.promises.readFile(expectedPath, 'utf-8');
-		const parsed = JSON.parse(content);
-		expect(parsed.entries[0].summary).toBe('trimmed summary');
-	});
-
-	// Test: Multiple writes overwrite (atomic replace)
-	test('second write overwrites previous content', async () => {
-		// First write
-		await executeWriteFinalCouncilEvidence(
-			{ phase: 1, verdict: 'APPROVED', summary: 'First verdict' },
-			tempDir,
-		);
-
-		// Second write
-		await executeWriteFinalCouncilEvidence(
-			{ phase: 2, verdict: 'NEEDS_REVISION', summary: 'Second verdict' },
-			tempDir,
-		);
-
-		const expectedPath = path.join(
-			tempDir,
-			'.swarm',
-			'evidence',
-			'final-council.json',
-		);
-		const content = await fs.promises.readFile(expectedPath, 'utf-8');
-		const parsed = JSON.parse(content);
-
-		// Should have only one entry (latest)
-		expect(parsed.entries).toHaveLength(1);
-		expect(parsed.entries[0].verdict).toBe('rejected');
-		expect(parsed.entries[0].summary).toBe('Second verdict');
 	});
 });


### PR DESCRIPTION
﻿## Summary
- Reworked `final_council` so it is a project-scoped rerun of the phase-end five-member council (`critic`, `reviewer`, `sme`, `test_engineer`, `explorer`) instead of the advisory General Council path.
- Updated `write_final_council_evidence`, final-council synthesis, and `phase_complete` enforcement so final evidence is plan-bound, quorumed, member-verdict based, and blocked when legacy/minimal evidence is supplied.
- Updated architect prompts, QA-gate docs, release notes, dist artifacts, and focused regression/adversarial tests for the new final-council contract.

## Invariant audit
- 1 (plugin init):       not touched — no plugin registration/startup path changes in this diff; `node scripts/repro-704.mjs` was attempted on branch and clean `origin/main` and timed out in both environments.
- 2 (runtime portability): touched — `bun run build` passed, `git diff --exit-code -- dist/` passed after staging rebuilt artifacts, `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts --timeout 30000` passed, `bun test tests/smoke --timeout 120000` passed, and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` printed `dist import OK`.
- 3 (subprocesses):       not touched — no subprocess call sites were added or changed; mock-contract/source scan found no changed source files requiring subprocess/mock updates.
- 4 (.swarm containment): touched — `write_final_council_evidence` still writes `evidence/final-council.json` through `validateSwarmPath`; source grep showed `validateSwarmPath(directory, relativePath)` and `.swarm/evidence/final-council.json` evidence path usage.
- 5 (plan durability):    not touched — no ledger replay, projection, checkpoint import/export, or plan schema files were changed.
- 6 (test_runner safety): not touched — validation used shell `bun`/`node` commands only; the OpenCode `test_runner` tool was not used.
- 7 (test writing):       touched — loaded the writing-tests skill before modifying tests; focused tests use `bun:test`; mock-contract discovery reported `MOCK_CONTRACT_MATCH_COUNT=0`.
- 8 (session state):      not touched — no session/global-state modules were changed.
- 9 (guardrails/retry):   not touched — no retry/circuit-breaker/guardrail retry semantics were changed.
- 10 (chat/system msg):   touched — architect prompt text changed; `bun run typecheck` passed and focused prompt/doc grep confirms final_council now instructs the five project-scoped members and explicitly forbids `convene_general_council`.
- 11 (tool registration): touched — `write_final_council_evidence` contract/description changed, tool registration unchanged; focused final-council tests passed, config/command tests were run and their failures were reproduced on clean `origin/main` as pre-existing.
- 12 (release/cache):     touched — added `docs/releases/v7.17.2.md`; `git diff -- .release-please-manifest.json package.json CHANGELOG.md` produced no diff.

## Test plan
- [x] `bun run build`
- [x] `git diff --exit-code -- dist/`
- [x] `bun run typecheck`
- [x] `bunx biome ci .` (exit 0; existing warning in `src/turbo/lean/runner.ts:307`)
- [x] `bun --smol test tests/unit/tools/write-final-council-evidence.test.ts tests/unit/tools/write-final-council-evidence.adversarial.test.ts tests/unit/tools/phase-complete-final-council.test.ts tests/unit/tools/phase-complete-final-council.adversarial.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts --timeout 30000`
- [x] `bun test tests/security --timeout 120000`
- [x] `bun test tests/smoke --timeout 120000`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `git diff --check`
- [x] Full commit-pr tiers attempted as required; unrelated failures below were reproduced on clean `origin/main`.

## Pre-existing failures
These failures reproduce on a disposable clean `origin/main` worktree at `213f64a4` and are not introduced by this branch:
- `for f in tests/unit/tools/*.test.ts; do bun --smol test "$f" --timeout 30000; done` — clean main failed 17 files; this branch now fails 16 after fixing `tests/unit/tools/phase-complete-final-council.adversarial.test.ts` Windows cleanup.
- `bun --smol test tests/unit/services/skill-generator.test.ts --timeout 30000` — fails on Windows path-separator expectations on clean main and branch.
- `bun --smol test tests/unit/cli tests/unit/commands tests/unit/config --timeout 120000` — fails broadly on clean main and branch, including `Bun.spawn(['bun', ...])` ENOENT and stale command/tool-map expectations.
- Hooks tier — `tests/unit/hooks/repo-graph-builder.test.ts` timed out on clean main and branch; `tests/unit/hooks/write-lstat-authority.test.ts` fails on clean main and branch due symlink permission/message expectations.
- `bun test tests/integration ./test --timeout 120000` — fails 106 tests on clean main and branch.
- `bun test tests/adversarial --timeout 120000` — fails 16 tests on clean main and branch.
- `node scripts/repro-704.mjs` — timed out on clean main and branch; leftover node processes were stopped after timeout.
