### PR TITLE
fix(qa-gate): harden final council evidence writes

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.17.2",
+    version: "7.17.3",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.17.2",
+    version: "7.17.3",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -70839,7 +70839,7 @@ var init_curator_drift = __esm(() => {
 var exports_project_context = {};
 __export(exports_project_context, {
   buildProjectContext: () => buildProjectContext,
-  _internals: () => _internals49,
+  _internals: () => _internals50,
   LANG_BACKEND_DETECTION_TIMEOUT_MS: () => LANG_BACKEND_DETECTION_TIMEOUT_MS
 });
 import * as fs110 from "node:fs";
@@ -70923,7 +70923,7 @@ function selectLintCommand(backend, directory) {
   return null;
 }
 async function buildProjectContext(directory) {
-  const backend = await _internals49.pickBackend(directory);
+  const backend = await _internals50.pickBackend(directory);
   if (!backend)
     return null;
   const ctx = emptyProjectContext();
@@ -70954,16 +70954,16 @@ async function buildProjectContext(directory) {
   if (backend.prompts.reviewerChecklist.length > 0) {
     ctx.REVIEWER_CHECKLIST = bulletList(backend.prompts.reviewerChecklist);
   }
-  const profiles = _internals49.pickedProfiles(directory);
+  const profiles = _internals50.pickedProfiles(directory);
   if (profiles.length > 1) {
     ctx.PROJECT_CONTEXT_SECONDARY_LANGUAGES = profiles.slice(1).map((p) => p.id).join(", ");
   }
   return ctx;
 }
-var LANG_BACKEND_DETECTION_TIMEOUT_MS = 300, _internals49;
+var LANG_BACKEND_DETECTION_TIMEOUT_MS = 300, _internals50;
 var init_project_context = __esm(() => {
   init_dispatch();
-  _internals49 = {
+  _internals50 = {
     pickBackend,
     pickedProfiles
   };
@@ -102463,6 +102463,7 @@ var write_drift_evidence = createSwarmTool({
 // src/tools/write-final-council-evidence.ts
 init_zod();
 init_loader();
+import { randomUUID as randomUUID9 } from "node:crypto";
 import fs107 from "node:fs";
 import path135 from "node:path";
 init_utils2();
@@ -102499,6 +102500,90 @@ var ArgsSchema6 = exports_external.object({
 function normalizeFinalVerdict(verdict) {
   return verdict === "APPROVE" ? "approved" : "rejected";
 }
+var replacementLocks = new Map;
+var _internals49 = {
+  loadPluginConfig,
+  synthesizeFinalCouncilAdvisory,
+  loadPlan,
+  derivePlanId,
+  validateSwarmPath
+};
+function getErrnoCode(error93) {
+  return error93 && typeof error93 === "object" ? error93.code : undefined;
+}
+async function replaceEvidenceFile(tempPath, finalPath) {
+  const previous = replacementLocks.get(finalPath)?.catch(() => {});
+  let release;
+  const current = new Promise((resolve51) => {
+    release = resolve51;
+  });
+  replacementLocks.set(finalPath, current);
+  if (previous) {
+    await previous;
+  }
+  try {
+    await replaceEvidenceFileLocked(tempPath, finalPath);
+  } finally {
+    release();
+    if (replacementLocks.get(finalPath) === current) {
+      replacementLocks.delete(finalPath);
+    }
+  }
+}
+async function replaceEvidenceFileLocked(tempPath, finalPath) {
+  try {
+    await fs107.promises.rename(tempPath, finalPath);
+    return;
+  } catch (error93) {
+    const code = getErrnoCode(error93);
+    if (!["EEXIST", "EPERM", "EACCES"].includes(code ?? "")) {
+      throw error93;
+    }
+  }
+  const backupPath = `${finalPath}.${randomUUID9()}.bak`;
+  let backupCreated = false;
+  try {
+    try {
+      await fs107.promises.rename(finalPath, backupPath);
+      backupCreated = true;
+    } catch (error93) {
+      if (getErrnoCode(error93) !== "ENOENT") {
+        throw error93;
+      }
+    }
+    try {
+      await fs107.promises.rename(tempPath, finalPath);
+    } catch (error93) {
+      if (backupCreated) {
+        if (!await restoreEvidenceBackup(backupPath, finalPath)) {
+          await fs107.promises.rm(backupPath, { force: true }).catch(() => {});
+        }
+        backupCreated = false;
+      }
+      throw error93;
+    }
+    if (backupCreated) {
+      await fs107.promises.rm(backupPath, { force: true }).catch(() => {});
+      backupCreated = false;
+    }
+  } finally {
+    await fs107.promises.rm(tempPath, { force: true }).catch(() => {});
+  }
+}
+async function restoreEvidenceBackup(backupPath, finalPath) {
+  try {
+    await fs107.promises.rename(backupPath, finalPath);
+    return true;
+  } catch {
+    try {
+      await fs107.promises.copyFile(backupPath, finalPath);
+      await fs107.promises.rm(backupPath, { force: true }).catch(() => {});
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
 async function executeWriteFinalCouncilEvidence(args2, directory) {
   const parsed = ArgsSchema6.safeParse(args2);
   if (!parsed.success) {
@@ -102512,7 +102597,7 @@ async function executeWriteFinalCouncilEvidence(args2, directory) {
     }, null, 2);
   }
   const input = parsed.data;
-  const config3 = loadPluginConfig(directory);
+  const config3 = _internals49.loadPluginConfig(directory);
   const requiredMembers = FINAL_COUNCIL_MEMBERS.length;
   const distinctMembers = new Set(input.verdicts.map((v) => v.agent));
   const membersVoted = [...distinctMembers];
@@ -102527,9 +102612,27 @@ async function executeWriteFinalCouncilEvidence(args2, directory) {
       quorumRequired: requiredMembers
     }, null, 2);
   }
-  const synthesis = synthesizeFinalCouncilAdvisory(input.projectSummary.trim(), input.verdicts, input.roundNumber ?? 1, config3.council);
-  const plan = await loadPlan(directory);
-  const planId = plan ? derivePlanId(plan) : "unknown";
+  let synthesis;
+  try {
+    synthesis = _internals49.synthesizeFinalCouncilAdvisory(input.projectSummary.trim(), input.verdicts, input.roundNumber ?? 1, config3.council);
+  } catch (error93) {
+    return JSON.stringify({
+      success: false,
+      phase: input.phase,
+      message: error93 instanceof Error ? error93.message : "Failed to synthesize final council evidence"
+    }, null, 2);
+  }
+  let planId = "unknown";
+  try {
+    const plan = await _internals49.loadPlan(directory);
+    planId = plan ? _internals49.derivePlanId(plan) : "unknown";
+  } catch (error93) {
+    return JSON.stringify({
+      success: false,
+      phase: input.phase,
+      message: error93 instanceof Error ? error93.message : "Failed to load project plan"
+    }, null, 2);
+  }
   const normalizedVerdict = normalizeFinalVerdict(synthesis.overallVerdict);
   const evidenceEntry = {
     type: "final-council",
@@ -102555,7 +102658,7 @@ async function executeWriteFinalCouncilEvidence(args2, directory) {
   const relativePath = path135.join("evidence", filename);
   let validatedPath;
   try {
-    validatedPath = validateSwarmPath(directory, relativePath);
+    validatedPath = _internals49.validateSwarmPath(directory, relativePath);
   } catch (error93) {
     return JSON.stringify({
       success: false,
@@ -102569,9 +102672,9 @@ async function executeWriteFinalCouncilEvidence(args2, directory) {
   const evidenceDir = path135.dirname(validatedPath);
   try {
     await fs107.promises.mkdir(evidenceDir, { recursive: true });
-    const tempPath = path135.join(evidenceDir, `.${filename}.tmp`);
+    const tempPath = path135.join(evidenceDir, `.${filename}.${randomUUID9()}.tmp`);
     await fs107.promises.writeFile(tempPath, JSON.stringify(evidenceContent, null, 2), "utf-8");
-    await fs107.promises.rename(tempPath, validatedPath);
+    await replaceEvidenceFile(tempPath, validatedPath);
     return JSON.stringify({
       success: true,
       phase: input.phase,

--- a/dist/tools/write-final-council-evidence.d.ts
+++ b/dist/tools/write-final-council-evidence.d.ts
@@ -7,7 +7,12 @@
  */
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
 import { z } from 'zod';
+import { loadPluginConfig } from '../config/loader';
+import { synthesizeFinalCouncilAdvisory } from '../council/council-service';
 import type { CouncilMemberVerdict } from '../council/types';
+import { validateSwarmPath } from '../hooks/utils';
+import { loadPlan } from '../plan/manager.js';
+import { derivePlanId } from '../plan/utils.js';
 export declare const ArgsSchema: z.ZodObject<{
     phase: z.ZodNumber;
     projectSummary: z.ZodString;
@@ -55,6 +60,13 @@ export interface WriteFinalCouncilEvidenceArgs {
     /** Collected verdicts from critic, reviewer, sme, test_engineer, explorer */
     verdicts: CouncilMemberVerdict[];
 }
+export declare const _internals: {
+    loadPluginConfig: typeof loadPluginConfig;
+    synthesizeFinalCouncilAdvisory: typeof synthesizeFinalCouncilAdvisory;
+    loadPlan: typeof loadPlan;
+    derivePlanId: typeof derivePlanId;
+    validateSwarmPath: typeof validateSwarmPath;
+};
 /**
  * Execute the write_final_council_evidence tool.
  * Validates input, synthesizes project-scoped council evidence, and writes it.

--- a/docs/releases/v7.17.4.md
+++ b/docs/releases/v7.17.4.md
@@ -1,0 +1,25 @@
+# v7.17.4
+
+## What changed
+
+- Hardened final-council evidence writes so concurrent `write_final_council_evidence` calls use unique temporary files and serialize replacement of `.swarm/evidence/final-council.json`.
+- Preserved existing final-council evidence when a Windows-style replace failure happens after the previous file has been moved aside, including a copy-based restore fallback.
+- Added regression coverage for oversized final-council payloads, concurrent five-member writes, `CONCERNS` verdict normalization, restore failure, and backup cleanup failure.
+
+## Why
+
+PR feedback on the project-scoped final council change identified missing coverage around payload size behavior, concurrent writes, and the `CONCERNS` normalization path. The added concurrency test also exposed a real Windows-sensitive replacement hazard where a failed retry could leave behind temporary files or risk losing the previous evidence file.
+
+## Migration steps
+
+No user migration is required. Existing final-council evidence remains at `.swarm/evidence/final-council.json`.
+
+## Breaking changes
+
+None.
+
+## Known caveats
+
+Final-council payload size remains intentionally uncapped in this release; the new oversized-payload test documents current behavior so any future size limits can be introduced deliberately.
+
+The concurrent-write guarantee is process-local. Separate OpenCode/plugin processes can still race on `.swarm/evidence/final-council.json`, and a host filesystem operation that never settles may require process-level recovery rather than an in-tool timeout.

--- a/src/tools/write-final-council-evidence.ts
+++ b/src/tools/write-final-council-evidence.ts
@@ -6,6 +6,7 @@
  * at completed-project scope.
  */
 
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
@@ -69,6 +70,105 @@ function normalizeFinalVerdict(verdict: 'APPROVE' | 'CONCERNS' | 'REJECT') {
 	return verdict === 'APPROVE' ? 'approved' : 'rejected';
 }
 
+const replacementLocks = new Map<string, Promise<void>>();
+
+export const _internals = {
+	loadPluginConfig,
+	synthesizeFinalCouncilAdvisory,
+	loadPlan,
+	derivePlanId,
+	validateSwarmPath,
+};
+
+function getErrnoCode(error: unknown) {
+	return error && typeof error === 'object'
+		? (error as NodeJS.ErrnoException).code
+		: undefined;
+}
+
+async function replaceEvidenceFile(tempPath: string, finalPath: string) {
+	const previous = replacementLocks.get(finalPath)?.catch(() => {});
+	let release!: () => void;
+	const current = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	replacementLocks.set(finalPath, current);
+	if (previous) {
+		await previous;
+	}
+
+	// This lock serializes same-process writes only; filesystem calls are expected
+	// to settle. A hung host filesystem operation may still require process-level
+	// recovery.
+	try {
+		await replaceEvidenceFileLocked(tempPath, finalPath);
+	} finally {
+		release();
+		if (replacementLocks.get(finalPath) === current) {
+			replacementLocks.delete(finalPath);
+		}
+	}
+}
+
+async function replaceEvidenceFileLocked(tempPath: string, finalPath: string) {
+	try {
+		await fs.promises.rename(tempPath, finalPath);
+		return;
+	} catch (error) {
+		const code = getErrnoCode(error);
+		if (!['EEXIST', 'EPERM', 'EACCES'].includes(code ?? '')) {
+			throw error;
+		}
+	}
+
+	const backupPath = `${finalPath}.${randomUUID()}.bak`;
+	let backupCreated = false;
+	try {
+		try {
+			await fs.promises.rename(finalPath, backupPath);
+			backupCreated = true;
+		} catch (error) {
+			if (getErrnoCode(error) !== 'ENOENT') {
+				throw error;
+			}
+		}
+
+		try {
+			await fs.promises.rename(tempPath, finalPath);
+		} catch (error) {
+			if (backupCreated) {
+				if (!(await restoreEvidenceBackup(backupPath, finalPath))) {
+					await fs.promises.rm(backupPath, { force: true }).catch(() => {});
+				}
+				backupCreated = false;
+			}
+			throw error;
+		}
+
+		if (backupCreated) {
+			await fs.promises.rm(backupPath, { force: true }).catch(() => {});
+			backupCreated = false;
+		}
+	} finally {
+		await fs.promises.rm(tempPath, { force: true }).catch(() => {});
+	}
+}
+
+async function restoreEvidenceBackup(backupPath: string, finalPath: string) {
+	try {
+		await fs.promises.rename(backupPath, finalPath);
+		return true;
+	} catch {
+		try {
+			await fs.promises.copyFile(backupPath, finalPath);
+			await fs.promises.rm(backupPath, { force: true }).catch(() => {});
+			return true;
+		} catch {
+			return false;
+		}
+	}
+}
+
 /**
  * Execute the write_final_council_evidence tool.
  * Validates input, synthesizes project-scoped council evidence, and writes it.
@@ -94,7 +194,7 @@ export async function executeWriteFinalCouncilEvidence(
 	}
 	const input = parsed.data;
 
-	const config = loadPluginConfig(directory);
+	const config = _internals.loadPluginConfig(directory);
 	const requiredMembers = FINAL_COUNCIL_MEMBERS.length;
 	const distinctMembers = new Set<CouncilAgent>(
 		input.verdicts.map((v) => v.agent),
@@ -123,15 +223,47 @@ export async function executeWriteFinalCouncilEvidence(
 		);
 	}
 
-	const synthesis = synthesizeFinalCouncilAdvisory(
-		input.projectSummary.trim(),
-		input.verdicts as CouncilMemberVerdict[],
-		input.roundNumber ?? 1,
-		config.council,
-	);
+	let synthesis: ReturnType<typeof synthesizeFinalCouncilAdvisory>;
+	try {
+		synthesis = _internals.synthesizeFinalCouncilAdvisory(
+			input.projectSummary.trim(),
+			input.verdicts as CouncilMemberVerdict[],
+			input.roundNumber ?? 1,
+			config.council,
+		);
+	} catch (error) {
+		return JSON.stringify(
+			{
+				success: false,
+				phase: input.phase,
+				message:
+					error instanceof Error
+						? error.message
+						: 'Failed to synthesize final council evidence',
+			},
+			null,
+			2,
+		);
+	}
 
-	const plan = await loadPlan(directory);
-	const planId = plan ? derivePlanId(plan) : 'unknown';
+	let planId = 'unknown';
+	try {
+		const plan = await _internals.loadPlan(directory);
+		planId = plan ? _internals.derivePlanId(plan) : 'unknown';
+	} catch (error) {
+		return JSON.stringify(
+			{
+				success: false,
+				phase: input.phase,
+				message:
+					error instanceof Error
+						? error.message
+						: 'Failed to load project plan',
+			},
+			null,
+			2,
+		);
+	}
 	const normalizedVerdict = normalizeFinalVerdict(synthesis.overallVerdict);
 
 	const evidenceEntry = {
@@ -159,7 +291,7 @@ export async function executeWriteFinalCouncilEvidence(
 	const relativePath = path.join('evidence', filename);
 	let validatedPath: string;
 	try {
-		validatedPath = validateSwarmPath(directory, relativePath);
+		validatedPath = _internals.validateSwarmPath(directory, relativePath);
 	} catch (error) {
 		return JSON.stringify(
 			{
@@ -180,13 +312,13 @@ export async function executeWriteFinalCouncilEvidence(
 
 	try {
 		await fs.promises.mkdir(evidenceDir, { recursive: true });
-		const tempPath = path.join(evidenceDir, `.${filename}.tmp`);
+		const tempPath = path.join(evidenceDir, `.${filename}.${randomUUID()}.tmp`);
 		await fs.promises.writeFile(
 			tempPath,
 			JSON.stringify(evidenceContent, null, 2),
 			'utf-8',
 		);
-		await fs.promises.rename(tempPath, validatedPath);
+		await replaceEvidenceFile(tempPath, validatedPath);
 
 		return JSON.stringify(
 			{

--- a/tests/unit/tools/write-final-council-evidence.adversarial.test.ts
+++ b/tests/unit/tools/write-final-council-evidence.adversarial.test.ts
@@ -185,6 +185,77 @@ describe('write_final_council_evidence adversarial security tests', () => {
 		expect(entry.requiredFixes[0].evidence).toContain('process.env.SECRET');
 	});
 
+	test('documents current behavior for oversized project summaries and finding details', async () => {
+		const projectSummary = `completed-project:${'A'.repeat(256_000)}`;
+		const largeDetail = `finding-detail:${'B'.repeat(128_000)}`;
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 1,
+				projectSummary,
+				verdicts: [
+					verdict('critic', {
+						verdict: 'REJECT',
+						findings: [
+							{
+								severity: 'HIGH',
+								category: 'payload-size',
+								location: 'src/large.ts:1',
+								detail: largeDetail,
+								evidence: 'Large payload is preserved as JSON data.',
+							},
+						],
+						criteriaUnmet: ['project-close'],
+					}),
+					...members
+						.filter((member) => member !== 'critic')
+						.map((member) => verdict(member)),
+				],
+			},
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.verdict).toBe('rejected');
+
+		const evidence = await readEvidence(tempDir);
+		const entry = evidence.entries[0];
+		expect(entry.projectSummary).toHaveLength(projectSummary.length);
+		expect(entry.requiredFixes[0].detail).toHaveLength(largeDetail.length);
+		expect(entry.requiredFixes[0].detail).toStartWith('finding-detail:');
+	});
+
+	test('concurrent five-member writes remain valid JSON with no shared temp-file collision', async () => {
+		const attempts = Array.from({ length: 8 }, (_, index) => index + 1);
+		const results = await Promise.all(
+			attempts.map((phase) =>
+				executeWriteFinalCouncilEvidence(
+					{
+						phase,
+						projectSummary: `Concurrent final council write ${phase}`,
+						verdicts: allVerdicts(),
+					},
+					tempDir,
+				),
+			),
+		);
+
+		for (const result of results) {
+			expect(JSON.parse(result).success).toBe(true);
+		}
+
+		const evidence = await readEvidence(tempDir);
+		expect(evidence.entries).toHaveLength(1);
+		expect(attempts).toContain(evidence.entries[0].phase);
+		expect(evidence.entries[0].memberVerdicts).toHaveLength(5);
+
+		const evidenceDir = path.join(tempDir, '.swarm', 'evidence');
+		const leftovers = (await fs.promises.readdir(evidenceDir)).filter((name) =>
+			name.endsWith('.tmp'),
+		);
+		expect(leftovers).toEqual([]);
+	});
+
 	test('rapid sequential writes remain valid JSON and last write wins', async () => {
 		for (let i = 1; i <= 20; i++) {
 			const result = await executeWriteFinalCouncilEvidence(

--- a/tests/unit/tools/write-final-council-evidence.test.ts
+++ b/tests/unit/tools/write-final-council-evidence.test.ts
@@ -8,7 +8,10 @@ import os from 'node:os';
 import path from 'node:path';
 
 import type { CouncilMemberVerdict } from '../../../src/council/types';
-import { executeWriteFinalCouncilEvidence } from '../../../src/tools/write-final-council-evidence';
+import {
+	_internals,
+	executeWriteFinalCouncilEvidence,
+} from '../../../src/tools/write-final-council-evidence';
 
 const members = [
 	'critic',
@@ -17,6 +20,8 @@ const members = [
 	'test_engineer',
 	'explorer',
 ] as const;
+
+const originalInternals = { ..._internals };
 
 function verdict(
 	agent: (typeof members)[number],
@@ -70,6 +75,7 @@ describe('executeWriteFinalCouncilEvidence', () => {
 	});
 
 	afterEach(async () => {
+		Object.assign(_internals, originalInternals);
 		try {
 			await fs.promises.rm(tempDir, { recursive: true, force: true });
 		} catch {
@@ -147,6 +153,106 @@ describe('executeWriteFinalCouncilEvidence', () => {
 		expect(entry.allCriteriaMet).toBe(false);
 	});
 
+	test('normalizes CONCERNS member verdicts to rejected evidence with raw CONCERNS verdict', async () => {
+		const concernVerdicts = [
+			verdict('critic', {
+				verdict: 'CONCERNS',
+				findings: [
+					{
+						severity: 'MEDIUM',
+						category: 'release-readiness',
+						location: 'docs/releases/v7.17.2.md',
+						detail: 'Release note needs one more migration caveat.',
+						evidence: 'critic concern',
+					},
+				],
+			}),
+			...members
+				.filter((member) => member !== 'critic')
+				.map((member) => verdict(member)),
+		];
+
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 2,
+				projectSummary: 'Project complete with final council concerns.',
+				verdicts: concernVerdicts,
+			},
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.overallVerdict).toBe('CONCERNS');
+		expect(parsed.verdict).toBe('rejected');
+
+		const content = await fs.promises.readFile(
+			path.join(tempDir, '.swarm', 'evidence', 'final-council.json'),
+			'utf-8',
+		);
+		const entry = JSON.parse(content).entries[0];
+		expect(entry.verdict).toBe('rejected');
+		expect(entry.rawCouncilVerdict).toBe('CONCERNS');
+		expect(entry.advisoryFindings).toHaveLength(1);
+		expect(entry.requiredFixes).toHaveLength(0);
+	});
+
+	test('aggregates multiple CONCERNS member verdicts into conflicts and rejected evidence', async () => {
+		const concernVerdicts = [
+			verdict('critic', {
+				verdict: 'CONCERNS',
+				findings: [
+					{
+						severity: 'MEDIUM',
+						category: 'readiness',
+						location: 'src/a.ts:1',
+						detail: 'Add final readiness guard before project close.',
+						evidence: 'critic concern',
+					},
+				],
+			}),
+			verdict('reviewer', {
+				verdict: 'CONCERNS',
+				findings: [
+					{
+						severity: 'LOW',
+						category: 'docs',
+						location: 'src/a.ts:1',
+						detail: 'Remove final readiness guard before project close.',
+						evidence: 'reviewer concern',
+					},
+				],
+			}),
+			...members
+				.filter((member) => member !== 'critic' && member !== 'reviewer')
+				.map((member) => verdict(member)),
+		];
+
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 2,
+				projectSummary: 'Project complete with multiple concerns.',
+				verdicts: concernVerdicts,
+			},
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.overallVerdict).toBe('CONCERNS');
+		expect(parsed.verdict).toBe('rejected');
+		expect(parsed.unresolvedConflictsCount).toBeGreaterThan(0);
+
+		const content = await fs.promises.readFile(
+			path.join(tempDir, '.swarm', 'evidence', 'final-council.json'),
+			'utf-8',
+		);
+		const entry = JSON.parse(content).entries[0];
+		expect(entry.rawCouncilVerdict).toBe('CONCERNS');
+		expect(entry.unresolvedConflicts.length).toBeGreaterThan(0);
+		expect(entry.advisoryFindings).toHaveLength(2);
+	});
+
 	test('rejects invalid phase and missing project summary', async () => {
 		const badPhase = JSON.parse(
 			await executeWriteFinalCouncilEvidence(
@@ -175,6 +281,52 @@ describe('executeWriteFinalCouncilEvidence', () => {
 		expect(missingSummary.success).toBe(false);
 		expect(missingSummary.reason).toBe('invalid arguments');
 		expect(missingSummary.errors[0].path).toBe('projectSummary');
+	});
+
+	test('validates roundNumber boundaries and defaults to round 1', async () => {
+		const defaultRound = JSON.parse(
+			await executeWriteFinalCouncilEvidence(
+				{
+					phase: 1,
+					projectSummary: 'Default round number',
+					verdicts: allApprovedVerdicts(),
+				},
+				tempDir,
+			),
+		);
+		expect(defaultRound.success).toBe(true);
+		expect(defaultRound.roundNumber).toBe(1);
+
+		const maxRound = JSON.parse(
+			await executeWriteFinalCouncilEvidence(
+				{
+					phase: 1,
+					projectSummary: 'Max round number',
+					roundNumber: 10,
+					verdicts: allApprovedVerdicts(),
+				},
+				tempDir,
+			),
+		);
+		expect(maxRound.success).toBe(true);
+		expect(maxRound.roundNumber).toBe(10);
+
+		for (const roundNumber of [0, 11]) {
+			const invalidRound = JSON.parse(
+				await executeWriteFinalCouncilEvidence(
+					{
+						phase: 1,
+						projectSummary: 'Invalid round number',
+						roundNumber,
+						verdicts: allApprovedVerdicts(),
+					},
+					tempDir,
+				),
+			);
+			expect(invalidRound.success).toBe(false);
+			expect(invalidRound.reason).toBe('invalid arguments');
+			expect(invalidRound.errors[0].path).toBe('roundNumber');
+		}
 	});
 
 	test('rejects legacy verdict and summary payloads', async () => {
@@ -216,34 +368,369 @@ describe('executeWriteFinalCouncilEvidence', () => {
 		expect(parsed.quorumRequired).toBe(5);
 	});
 
-	test('uses atomic temp+rename pattern', async () => {
-		const writeFileSpy = spyOn(fs.promises, 'writeFile');
-		const renameSpy = spyOn(fs.promises, 'rename');
+	test('returns a graceful error when final council synthesis throws', async () => {
+		_internals.synthesizeFinalCouncilAdvisory = () => {
+			throw new Error('synthesis unavailable');
+		};
 
-		await executeWriteFinalCouncilEvidence(
+		const result = await executeWriteFinalCouncilEvidence(
 			{
 				phase: 1,
-				projectSummary: 'Atomic write test',
+				projectSummary: 'Synthesis failure test',
 				verdicts: allApprovedVerdicts(),
 			},
 			tempDir,
 		);
+		const parsed = JSON.parse(result);
 
-		expect(writeFileSpy).toHaveBeenCalledTimes(1);
-		expect(renameSpy).toHaveBeenCalledTimes(1);
+		expect(parsed.success).toBe(false);
+		expect(parsed.phase).toBe(1);
+		expect(parsed.message).toBe('synthesis unavailable');
+	});
 
-		const tempPath = writeFileSpy.mock.calls[0][0] as string;
-		const renameFrom = renameSpy.mock.calls[0][0] as string;
-		const renameTo = renameSpy.mock.calls[0][1] as string;
+	test('returns a graceful error when plan loading throws', async () => {
+		_internals.loadPlan = async () => {
+			throw new Error('plan ledger unavailable');
+		};
 
-		expect(tempPath).toContain('.swarm');
-		expect(tempPath).toContain('.final-council.json.tmp');
-		expect(renameFrom).toBe(tempPath);
-		expect(renameTo).toBe(
-			path.join(tempDir, '.swarm', 'evidence', 'final-council.json'),
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 1,
+				projectSummary: 'Plan failure test',
+				verdicts: allApprovedVerdicts(),
+			},
+			tempDir,
 		);
+		const parsed = JSON.parse(result);
 
-		writeFileSpy.mockRestore();
-		renameSpy.mockRestore();
+		expect(parsed.success).toBe(false);
+		expect(parsed.phase).toBe(1);
+		expect(parsed.message).toBe('plan ledger unavailable');
+	});
+
+	test('returns a graceful error when swarm path validation fails', async () => {
+		_internals.validateSwarmPath = () => {
+			throw new Error('path escaped .swarm');
+		};
+
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 1,
+				projectSummary: 'Path validation failure test',
+				verdicts: allApprovedVerdicts(),
+			},
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.phase).toBe(1);
+		expect(parsed.message).toBe('path escaped .swarm');
+	});
+
+	test('uses atomic temp+rename pattern', async () => {
+		const writeFileSpy = spyOn(fs.promises, 'writeFile');
+		const renameSpy = spyOn(fs.promises, 'rename');
+
+		try {
+			await executeWriteFinalCouncilEvidence(
+				{
+					phase: 1,
+					projectSummary: 'Atomic write test',
+					verdicts: allApprovedVerdicts(),
+				},
+				tempDir,
+			);
+
+			expect(writeFileSpy).toHaveBeenCalledTimes(1);
+			expect(renameSpy).toHaveBeenCalledTimes(1);
+
+			const tempPath = writeFileSpy.mock.calls[0][0] as string;
+			const renameFrom = renameSpy.mock.calls[0][0] as string;
+			const renameTo = renameSpy.mock.calls[0][1] as string;
+
+			expect(tempPath).toContain('.swarm');
+			expect(tempPath).toContain('.final-council.json.');
+			expect(tempPath.endsWith('.tmp')).toBe(true);
+			expect(renameFrom).toBe(tempPath);
+			expect(renameTo).toBe(
+				path.join(tempDir, '.swarm', 'evidence', 'final-council.json'),
+			);
+		} finally {
+			writeFileSpy.mockRestore();
+			renameSpy.mockRestore();
+		}
+	});
+
+	test('preserves previous evidence when replacement fails after backup', async () => {
+		const finalPath = path.join(
+			tempDir,
+			'.swarm',
+			'evidence',
+			'final-council.json',
+		);
+		const firstResult = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 1,
+				projectSummary: 'Original final council evidence',
+				verdicts: allApprovedVerdicts(),
+			},
+			tempDir,
+		);
+		expect(JSON.parse(firstResult).success).toBe(true);
+		const originalContent = await fs.promises.readFile(finalPath, 'utf-8');
+
+		const originalRename = fs.promises.rename;
+		const renameSpy = spyOn(fs.promises, 'rename');
+		let tempToFinalAttempts = 0;
+		renameSpy.mockImplementation(async (from, to) => {
+			const fromPath = from.toString();
+			const toPath = to.toString();
+			if (fromPath.endsWith('.tmp') && toPath === finalPath) {
+				tempToFinalAttempts++;
+				const error = new Error(
+					tempToFinalAttempts === 1
+						? 'destination already exists'
+						: 'replacement denied',
+				) as NodeJS.ErrnoException;
+				error.code = tempToFinalAttempts === 1 ? 'EEXIST' : 'EACCES';
+				throw error;
+			}
+			await originalRename(from, to);
+		});
+
+		try {
+			const secondResult = await executeWriteFinalCouncilEvidence(
+				{
+					phase: 2,
+					projectSummary: 'Replacement should fail safely',
+					verdicts: allApprovedVerdicts(),
+				},
+				tempDir,
+			);
+			const parsed = JSON.parse(secondResult);
+
+			expect(parsed.success).toBe(false);
+			expect(parsed.message).toContain('replacement denied');
+			expect(await fs.promises.readFile(finalPath, 'utf-8')).toBe(
+				originalContent,
+			);
+
+			const leftovers = (
+				await fs.promises.readdir(path.dirname(finalPath))
+			).filter((name) => name.endsWith('.tmp') || name.endsWith('.bak'));
+			expect(leftovers).toEqual([]);
+		} finally {
+			renameSpy.mockRestore();
+		}
+	});
+
+	test('falls back to copying backup when restore rename fails', async () => {
+		const finalPath = path.join(
+			tempDir,
+			'.swarm',
+			'evidence',
+			'final-council.json',
+		);
+		const firstResult = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 1,
+				projectSummary: 'Original final council evidence',
+				verdicts: allApprovedVerdicts(),
+			},
+			tempDir,
+		);
+		expect(JSON.parse(firstResult).success).toBe(true);
+		const originalContent = await fs.promises.readFile(finalPath, 'utf-8');
+
+		const originalRename = fs.promises.rename;
+		const renameSpy = spyOn(fs.promises, 'rename');
+		let tempToFinalAttempts = 0;
+		renameSpy.mockImplementation(async (from, to) => {
+			const fromPath = from.toString();
+			const toPath = to.toString();
+			if (fromPath.endsWith('.tmp') && toPath === finalPath) {
+				tempToFinalAttempts++;
+				const error = new Error(
+					tempToFinalAttempts === 1
+						? 'destination already exists'
+						: 'replacement denied',
+				) as NodeJS.ErrnoException;
+				error.code = tempToFinalAttempts === 1 ? 'EEXIST' : 'EACCES';
+				throw error;
+			}
+			if (fromPath.endsWith('.bak') && toPath === finalPath) {
+				const error = new Error('restore denied') as NodeJS.ErrnoException;
+				error.code = 'EACCES';
+				throw error;
+			}
+			await originalRename(from, to);
+		});
+
+		try {
+			const secondResult = await executeWriteFinalCouncilEvidence(
+				{
+					phase: 2,
+					projectSummary: 'Replacement should restore via copy fallback',
+					verdicts: allApprovedVerdicts(),
+				},
+				tempDir,
+			);
+			const parsed = JSON.parse(secondResult);
+
+			expect(parsed.success).toBe(false);
+			expect(parsed.message).toContain('replacement denied');
+			expect(await fs.promises.readFile(finalPath, 'utf-8')).toBe(
+				originalContent,
+			);
+
+			const leftovers = (
+				await fs.promises.readdir(path.dirname(finalPath))
+			).filter((name) => name.endsWith('.tmp') || name.endsWith('.bak'));
+			expect(leftovers).toEqual([]);
+		} finally {
+			renameSpy.mockRestore();
+		}
+	});
+
+	test('removes backup when both restore rename and copy fallback fail', async () => {
+		const finalPath = path.join(
+			tempDir,
+			'.swarm',
+			'evidence',
+			'final-council.json',
+		);
+		const firstResult = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 1,
+				projectSummary: 'Original final council evidence',
+				verdicts: allApprovedVerdicts(),
+			},
+			tempDir,
+		);
+		expect(JSON.parse(firstResult).success).toBe(true);
+
+		const originalRename = fs.promises.rename;
+		const renameSpy = spyOn(fs.promises, 'rename');
+		let tempToFinalAttempts = 0;
+		renameSpy.mockImplementation(async (from, to) => {
+			const fromPath = from.toString();
+			const toPath = to.toString();
+			if (fromPath.endsWith('.tmp') && toPath === finalPath) {
+				tempToFinalAttempts++;
+				const error = new Error(
+					tempToFinalAttempts === 1
+						? 'destination already exists'
+						: 'replacement denied',
+				) as NodeJS.ErrnoException;
+				error.code = tempToFinalAttempts === 1 ? 'EEXIST' : 'EACCES';
+				throw error;
+			}
+			if (fromPath.endsWith('.bak') && toPath === finalPath) {
+				const error = new Error('restore denied') as NodeJS.ErrnoException;
+				error.code = 'EACCES';
+				throw error;
+			}
+			await originalRename(from, to);
+		});
+
+		const copyFileSpy = spyOn(fs.promises, 'copyFile');
+		copyFileSpy.mockImplementation(async () => {
+			const error = new Error('copy fallback denied') as NodeJS.ErrnoException;
+			error.code = 'EACCES';
+			throw error;
+		});
+
+		try {
+			const secondResult = await executeWriteFinalCouncilEvidence(
+				{
+					phase: 2,
+					projectSummary: 'Replacement should clean failed backup',
+					verdicts: allApprovedVerdicts(),
+				},
+				tempDir,
+			);
+			const parsed = JSON.parse(secondResult);
+
+			expect(parsed.success).toBe(false);
+			expect(parsed.message).toContain('replacement denied');
+			const leftovers = (
+				await fs.promises.readdir(path.dirname(finalPath))
+			).filter((name) => name.endsWith('.tmp') || name.endsWith('.bak'));
+			expect(leftovers).toEqual([]);
+		} finally {
+			renameSpy.mockRestore();
+			copyFileSpy.mockRestore();
+		}
+	});
+
+	test('reports success when backup cleanup fails after replacement', async () => {
+		const finalPath = path.join(
+			tempDir,
+			'.swarm',
+			'evidence',
+			'final-council.json',
+		);
+		const firstResult = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 1,
+				projectSummary: 'Original final council evidence',
+				verdicts: allApprovedVerdicts(),
+			},
+			tempDir,
+		);
+		expect(JSON.parse(firstResult).success).toBe(true);
+
+		const originalRename = fs.promises.rename;
+		const renameSpy = spyOn(fs.promises, 'rename');
+		let tempToFinalAttempts = 0;
+		renameSpy.mockImplementation(async (from, to) => {
+			const fromPath = from.toString();
+			const toPath = to.toString();
+			if (fromPath.endsWith('.tmp') && toPath === finalPath) {
+				tempToFinalAttempts++;
+				if (tempToFinalAttempts === 1) {
+					const error = new Error(
+						'destination already exists',
+					) as NodeJS.ErrnoException;
+					error.code = 'EEXIST';
+					throw error;
+				}
+			}
+			await originalRename(from, to);
+		});
+
+		const originalRm = fs.promises.rm;
+		const rmSpy = spyOn(fs.promises, 'rm');
+		rmSpy.mockImplementation(async (target, options) => {
+			if (target.toString().endsWith('.bak')) {
+				const error = new Error(
+					'backup cleanup denied',
+				) as NodeJS.ErrnoException;
+				error.code = 'EACCES';
+				throw error;
+			}
+			await originalRm(target, options);
+		});
+
+		try {
+			const secondResult = await executeWriteFinalCouncilEvidence(
+				{
+					phase: 2,
+					projectSummary: 'Replacement should succeed despite cleanup issue',
+					verdicts: allApprovedVerdicts(),
+				},
+				tempDir,
+			);
+			const parsed = JSON.parse(secondResult);
+
+			expect(parsed.success).toBe(true);
+			const entry = JSON.parse(await fs.promises.readFile(finalPath, 'utf-8'))
+				.entries[0];
+			expect(entry.phase).toBe(2);
+		} finally {
+			renameSpy.mockRestore();
+			rmSpy.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
﻿## Summary
- Hardened `write_final_council_evidence` replacement so concurrent final-council writes use unique temp files plus per-path serialization, with the process-local concurrency caveat documented in `docs/releases/v7.17.4.md`.
- Preserved existing `.swarm/evidence/final-council.json` on Windows-style replace failures with backup restore, copy fallback behavior, and failed-backup cleanup.
- Added regression coverage for oversized payload behavior, concurrent five-member writes, `CONCERNS` normalization, multi-`CONCERNS` conflict reporting, synthesis/plan/path error returns, `roundNumber` boundaries, restore failure, and backup-cleanup failure.

## Invariant audit
- 1 (plugin init):       not touched — no plugin initialization path changes; `node scripts/repro-704.mjs` T1/T2/T3 all printed OK locally, but the harness did not exit on this Windows host on either branch or clean `origin/main` and had to be killed after 30s.
- 2 (runtime portability): touched — rebuilt `dist/` with `npm exec --yes bun@1.3.13 -- run build`; `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts --timeout 30000` passed 4/4; `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` printed `dist import OK`.
- 3 (subprocesses):       not touched — `git diff --name-only origin/main -- src/**/*.ts | Select-String -Pattern 'spawn\(|spawnSync\(|bunSpawn\('` returned no matches.
- 4 (.swarm containment): touched — final-council evidence still writes through `validateSwarmPath(directory, path.join('evidence', 'final-council.json'))`; focused tests verify writes remain under `.swarm/evidence/final-council.json` and cover the defensive validation failure branch.
- 5 (plan durability):    not touched — no ledger, projection, checkpoint, or plan schema changes.
- 6 (test_runner safety): not touched — no OpenCode `test_runner` validation was used; validation used shell `bun` commands only.
- 7 (test writing):       touched — loaded `.opencode/skills/writing-tests/SKILL.md`; tests use `bun:test` spies, temp dirs, and a local `_internals` DI seam with no `mock.module` additions.
- 8 (session state):      not touched — no session/global swarm state changes; the new in-process replacement lock is local to the evidence file path and deletes its map entry after each write.
- 9 (guardrails/retry):   not touched — no guardrail, retry, or circuit-breaker logic changed.
- 10 (chat/system msg):   not touched — no prompt, hook message, or chat-visible stream changes.
- 11 (tool registration): not touched — `write_final_council_evidence` implementation/tests changed, but exports, `TOOL_NAMES`, `AGENT_TOOL_MAP`, and plugin registration are unchanged.
- 12 (release/cache):     touched — added `docs/releases/v7.17.4.md`; verified `package.json`, `CHANGELOG.md`, and `.release-please-manifest.json` are untouched by `git diff --name-only origin/main -- package.json CHANGELOG.md .release-please-manifest.json`.

## Test plan
- [x] `npm exec --yes bun@1.3.13 -- run build`
- [x] `bun run typecheck`
- [x] `bunx biome ci .` (passes with existing warning in `src/turbo/lean/runner.ts:307`)
- [x] `bun --smol test tests/unit/tools/write-final-council-evidence.test.ts tests/unit/tools/write-final-council-evidence.adversarial.test.ts tests/unit/tools/phase-complete-final-council.test.ts --timeout 30000` (39 pass)
- [x] `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts --timeout 30000` (4 pass)
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `git diff --check`
- [x] `bun test tests/security --timeout 120000` (135 pass, 4 skip)
- [x] `bun test tests/smoke --timeout 120000` (10 pass)

## Pre-existing local validation failures
- `node scripts/repro-704.mjs`: T1/T2/T3 print OK on this branch and clean `origin/main`, but the process does not exit on this Windows host and had to be killed after 30s in both cases.
- Tier 2 per-file tools sweep encountered unrelated failures in `tests/unit/tools/diagnostic-gating.test.ts` and `tests/unit/tools/doc-scan.adversarial.test.ts`; neither file nor its source area is touched by this PR. `diagnostic-gating.test.ts` reproduced on clean `origin/main`; the clean-main `doc-scan.adversarial.test.ts` check could not load dependencies in the throwaway worktree, but the file/source remain outside this PR diff.
- Earlier broad local validation on this branch also found unrelated failures in `tests/unit/tools/doc-scan.test.ts`, `tests/unit/tools/phase-complete-lean-turbo-critic.test.ts`, `bun test tests/integration ./test --timeout 120000`, and `bun test tests/adversarial --timeout 120000`; no corresponding source areas are touched here.
