### PR TITLE
fix(gate-tracking): close cross-phase evidence-routing and state leaks

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.17.4",
+    version: "7.18.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.17.4",
+    version: "7.18.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -26373,9 +26373,9 @@ async function getEvidenceTaskId(session, directory) {
   const primary = session.currentTaskId ?? session.lastCoderDelegationTaskId;
   if (primary)
     return primary;
-  if (session.taskWorkflowStates && session.taskWorkflowStates.size > 0) {
-    return session.taskWorkflowStates.keys().next().value ?? null;
-  }
+  const onlyTaskId = getOnlyWorkflowTaskId(session);
+  if (onlyTaskId)
+    return onlyTaskId;
   try {
     if (typeof directory !== "string" || directory.length === 0) {
       return null;
@@ -26725,18 +26725,25 @@ function createDelegationGateHook(config2, directory) {
           const explicitEvidenceTaskId = extractTaskIdFromTaskArgs(mergedTaskArgs);
           const stageBEvidenceTaskId = gateForEvidence === "reviewer" || gateForEvidence === "test_engineer" || gateForEvidence === "adversarial_test_engineer" ? resolveScopedStageBTaskId(session, mergedTaskArgs) : null;
           const evidenceTaskId = stageBEvidenceTaskId ?? explicitEvidenceTaskId ?? await getEvidenceTaskId(session, directory);
+          const gateAgents = [
+            "reviewer",
+            "test_engineer",
+            "docs",
+            "designer",
+            "critic",
+            "explorer",
+            "sme"
+          ];
+          if (evidenceTaskId === null && gateAgents.includes(targetAgentForEvidence)) {
+            session.pendingAdvisoryMessages ??= [];
+            if (!session.pendingAdvisoryMessages.some((m) => m.includes("evidence-task-id-unresolved"))) {
+              session.pendingAdvisoryMessages.push(`[evidence-task-id-unresolved] Gate evidence has NOT been written for one or more recent gate-agent dispatches because the current task id is unresolved. Call update_task_status(<task_id>, 'in_progress') BEFORE dispatching gate agents (e.g. reviewer/test_engineer). Most recent affected agent: ${targetAgentForEvidence}.`);
+            }
+            console.warn(`[delegation-gate] evidence-task-id-unresolved sessionID=${input.sessionID} subagentType=${targetAgentForEvidence} reason=evidence-task-id-unresolved`);
+          }
           if (evidenceTaskId && typeof directory === "string") {
             const turbo = hasActiveTurboMode(input.sessionID);
             const parallelRuntime = resolveStandardParallelizationConfig(config2, directory);
-            const gateAgents = [
-              "reviewer",
-              "test_engineer",
-              "docs",
-              "designer",
-              "critic",
-              "explorer",
-              "sme"
-            ];
             if (gateAgents.includes(targetAgentForEvidence)) {
               const { recordGateEvidence: recordGateEvidence2 } = await Promise.resolve().then(() => (init_gate_evidence(), exports_gate_evidence));
               await recordGateEvidence2(directory, evidenceTaskId, gateForEvidence, input.sessionID, turbo, parallelRuntime.evidenceLockTimeoutMs);
@@ -26746,7 +26753,7 @@ function createDelegationGateHook(config2, directory) {
             }
           }
         } catch (err2) {
-          console.warn(`[delegation-gate] evidence recording failed: ${err2 instanceof Error ? err2.message : String(err2)}`);
+          console.warn(`[delegation-gate] evidence recording failed reason=evidence-write-failed: ${err2 instanceof Error ? err2.message : String(err2)}`);
         }
       }
       if (storedArgs !== undefined) {
@@ -89521,12 +89528,22 @@ function verifyLeanTurboPhaseReady(directory, phase, sessionIDOrConfig, config3)
 }
 
 // src/tools/phase-complete.ts
+init_task_id();
 init_create_tool();
 init_resolve_working_directory();
 function safeWarn(message, error93) {
   try {
     console.warn(message, error93 instanceof Error ? error93.message : String(error93));
   } catch {}
+}
+function taskIdToPhase(taskId) {
+  if (typeof taskId !== "string")
+    return null;
+  if (!isStrictTaskId(taskId))
+    return null;
+  const head = taskId.split(".")[0];
+  const n = Number.parseInt(head, 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
 }
 function collectCrossSessionDispatchedAgents(phaseReferenceTimestamp, callerSessionId) {
   const agents = new Set;
@@ -90640,6 +90657,52 @@ Advisory notes: ${advisoryNotes.join("; ")}` : "";
         const oldPhase = contributorSession.lastPhaseCompletePhase;
         contributorSession.lastPhaseCompletePhase = phase;
         telemetry.phaseChanged(contributorSessionId, oldPhase ?? 0, phase);
+        const currentTid = contributorSession.currentTaskId;
+        if (currentTid) {
+          const tp = taskIdToPhase(currentTid);
+          if (tp !== null && tp <= phase) {
+            contributorSession.currentTaskId = null;
+          }
+        }
+        const lastCoderTid = contributorSession.lastCoderDelegationTaskId;
+        if (lastCoderTid) {
+          const tp = taskIdToPhase(lastCoderTid);
+          if (tp !== null && tp <= phase) {
+            contributorSession.lastCoderDelegationTaskId = null;
+          }
+        }
+        const openStates = new Set([
+          "coder_delegated",
+          "pre_check_passed",
+          "reviewer_run"
+        ]);
+        if (contributorSession.taskWorkflowStates instanceof Map) {
+          for (const [taskId, state] of Array.from(contributorSession.taskWorkflowStates.entries())) {
+            const tp = taskIdToPhase(taskId);
+            if (tp === null || tp > phase)
+              continue;
+            if (openStates.has(state)) {
+              console.warn(`[phase-complete] dropping open task state at phase boundary: taskId=${taskId} state=${state} phaseCompleted=${phase}`);
+            }
+            contributorSession.taskWorkflowStates.delete(taskId);
+          }
+        }
+        if (contributorSession.stageBCompletion instanceof Map) {
+          for (const taskId of Array.from(contributorSession.stageBCompletion.keys())) {
+            const tp = taskIdToPhase(taskId);
+            if (tp !== null && tp <= phase) {
+              contributorSession.stageBCompletion.delete(taskId);
+            }
+          }
+        }
+        if (contributorSession.requiredStageBGates instanceof Map) {
+          for (const taskId of Array.from(contributorSession.requiredStageBGates.keys())) {
+            const tp = taskIdToPhase(taskId);
+            if (tp !== null && tp <= phase) {
+              contributorSession.requiredStageBGates.delete(taskId);
+            }
+          }
+        }
       }
     }
     try {

--- a/docs/releases/v7.18.1.md
+++ b/docs/releases/v7.18.1.md
@@ -1,0 +1,25 @@
+# v7.18.1
+
+## What changed
+
+- Hardened the cross-phase gate-evidence pipeline in `delegation-gate.ts` so that a stale `taskWorkflowStates` entry from an earlier phase can no longer be returned by `getEvidenceTaskId` as a fallback. The first-key fallback is replaced with `getOnlyWorkflowTaskId`, which returns `null` whenever more than one strict task id is present. Non-gate agents (docs/designer/critic/explorer/sme) dispatched after a phase boundary therefore stop routing evidence under a prior-phase task id.
+- When the primary evidence-write block in `delegation-gate.ts` cannot resolve a task id and the dispatched agent is a gate agent (reviewer/test_engineer/docs/designer/critic/explorer/sme), the hook now pushes a deduped advisory (keyed by `evidence-task-id-unresolved`) to `session.pendingAdvisoryMessages`. The next architect system message includes a `[ADVISORIES]` nudge to call `update_task_status(<task_id>, 'in_progress')` before the next gate dispatch. Resolution failures and write failures both use `console.warn` (not the debug-gated `logger.warn`) so the failure surface stays visible in production.
+- The post-success reset block in `phase_complete` now prunes prior-phase entries from `session.taskWorkflowStates`, `session.stageBCompletion`, and the v7.18.0 `session.requiredStageBGates` map for every contributor session, and conditionally clears `currentTaskId` / `lastCoderDelegationTaskId` only when those reference Phase-N or earlier. `taskIdToPhase` is strictly guarded by `isStrictTaskId`, so non-plan keys (`retro-1`, `1-debug`) are never pruned. Open task states (`coder_delegated` / `pre_check_passed` / `reviewer_run`) dropped at the boundary log a `console.warn` because their survival past `phase_complete(N)` indicates an invariant violation.
+- Added regression coverage under `tests/unit/`: routing fallback no longer leaks stale Phase-1 ids for non-gate agents, dedup advisory fires exactly once across repeated gate-agent dispatches, future-phase entries survive `phase_complete`, non-strict task ids survive pruning.
+
+## Why
+
+A two-phase reproduction trace showed that after `phase_complete(1)`, the architect's subsequent `update_task_status('2.x', 'completed')` on Phase-2 reviewer/test_engineer gate tasks was being blocked because (a) the stale-id fallback in `getEvidenceTaskId` returned a Phase-1 id for non-gate dispatches, (b) the primary evidence-write block silently no-oped for gate dispatches with no resolvable task id, and (c) `phase_complete` left prior-phase entries (now including v7.18.0's `requiredStageBGates`) in the contributor sessions. The combination polluted Phase-2 state and made the gate-tracking failure mode invisible to the architect.
+
+## Migration steps
+
+No user migration required. Existing `.swarm/evidence/<task_id>.json` files are untouched; behavior changes only affect in-memory session state and the evidence-id resolution path.
+
+## Breaking changes
+
+None. The "make `task_id` a required argument of the `Task` tool for gate agents" change discussed during planning is intentionally deferred to a separate breaking-change PR.
+
+## Known caveats
+
+- The advisory is a corrective nudge surfaced in the architect's next system message; it does not retroactively rewrite evidence for the gate dispatch that just ran without a resolvable task id. Architects must re-dispatch the gate after calling `update_task_status(<id>, 'in_progress')`.
+- `delegationChains` is intentionally not pruned at the phase boundary so the unscoped Pass-2 fallback in `update_task_status` remains available as a last-ditch recovery for sessions that lost their primary state.

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -433,11 +433,11 @@ async function getEvidenceTaskId(
 	const primary = session.currentTaskId ?? session.lastCoderDelegationTaskId;
 	if (primary) return primary;
 
-	// Fallback: derive from taskWorkflowStates if it has entries
-	if (session.taskWorkflowStates && session.taskWorkflowStates.size > 0) {
-		// Return any key from the map (deterministic: first entry)
-		return session.taskWorkflowStates.keys().next().value ?? null;
-	}
+	// Fallback: only when exactly one strict task id is in the map.
+	// Previously this returned `keys().next().value`, which leaked a stale
+	// prior-phase id across phase boundaries (cross-phase contamination).
+	const onlyTaskId = getOnlyWorkflowTaskId(session);
+	if (onlyTaskId) return onlyTaskId;
 
 	// Fallback: read from .swarm/plan.json to find first in_progress task
 	// Security hardening: validate and resolve paths safely
@@ -1152,21 +1152,47 @@ export function createDelegationGateHook(
 						stageBEvidenceTaskId ??
 						explicitEvidenceTaskId ??
 						(await getEvidenceTaskId(session, directory));
+					const gateAgents = [
+						'reviewer',
+						'test_engineer',
+						'docs',
+						'designer',
+						'critic',
+						'explorer',
+						'sme',
+					];
+					if (
+						evidenceTaskId === null &&
+						gateAgents.includes(targetAgentForEvidence)
+					) {
+						// Fail-loud: gate-agent dispatch with no resolvable task id means
+						// no evidence file will be written. Surface this to the architect
+						// via the pendingAdvisoryMessages drain in guardrails so the next
+						// system message includes a corrective nudge. Dedup with the
+						// `evidence-task-id-unresolved` key embedded in the message body.
+						session.pendingAdvisoryMessages ??= [];
+						if (
+							!session.pendingAdvisoryMessages.some((m: string) =>
+								m.includes('evidence-task-id-unresolved'),
+							)
+						) {
+							session.pendingAdvisoryMessages.push(
+								`[evidence-task-id-unresolved] Gate evidence has NOT been written for one or more recent gate-agent dispatches because the current task id is unresolved. Call update_task_status(<task_id>, 'in_progress') BEFORE dispatching gate agents (e.g. reviewer/test_engineer). Most recent affected agent: ${targetAgentForEvidence}.`,
+							);
+						}
+						// Use console.warn (not logger.warn) so resolution failures stay
+						// visible in production. logger.warn is debug-gated, which would
+						// hide a strictly worse failure mode than the catch-path below.
+						console.warn(
+							`[delegation-gate] evidence-task-id-unresolved sessionID=${input.sessionID} subagentType=${targetAgentForEvidence} reason=evidence-task-id-unresolved`,
+						);
+					}
 					if (evidenceTaskId && typeof directory === 'string') {
 						const turbo = hasActiveTurboMode(input.sessionID);
 						const parallelRuntime = resolveStandardParallelizationConfig(
 							config,
 							directory,
 						);
-						const gateAgents = [
-							'reviewer',
-							'test_engineer',
-							'docs',
-							'designer',
-							'critic',
-							'explorer',
-							'sme',
-						];
 						if (gateAgents.includes(targetAgentForEvidence)) {
 							const { recordGateEvidence } = await import('../gate-evidence');
 							await recordGateEvidence(
@@ -1189,9 +1215,11 @@ export function createDelegationGateHook(
 						}
 					}
 				} catch (err) {
-					/* non-fatal — evidence is additive, never blocks delegation */
+					/* non-fatal — evidence is additive, never blocks delegation.
+					 * Use console.warn (not logger.warn) so the failure surface stays
+					 * visible in production; logger.warn is gated on OPENCODE_SWARM_DEBUG. */
 					console.warn(
-						`[delegation-gate] evidence recording failed: ${err instanceof Error ? err.message : String(err)}`,
+						`[delegation-gate] evidence recording failed reason=evidence-write-failed: ${err instanceof Error ? err.message : String(err)}`,
 					);
 				}
 			}

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -60,6 +60,7 @@ import {
 } from '../state';
 import { telemetry } from '../telemetry';
 import { _internals as leanPhaseInternals } from '../turbo/lean/phase-ready';
+import { isStrictTaskId } from '../validation/task-id';
 import { executeCompletionVerify } from './completion-verify';
 import { createSwarmTool } from './create-tool';
 import { resolveWorkingDirectory } from './resolve-working-directory';
@@ -110,6 +111,17 @@ function safeWarn(message: string, error: unknown): void {
 	} catch {
 		// Ignore logger failures to keep phase_complete non-blocking
 	}
+}
+
+function taskIdToPhase(taskId: string): number | null {
+	if (typeof taskId !== 'string') return null;
+	// Strict guard: only `N.M(.P)*` plan task ids participate in phase pruning.
+	// Without this, `parseInt('1-debug', 10)` returns 1 and would silently
+	// prune non-plan keys like `'1-debug'` or `'retro-1'` from the workflow maps.
+	if (!isStrictTaskId(taskId)) return null;
+	const head = taskId.split('.')[0];
+	const n = Number.parseInt(head, 10);
+	return Number.isFinite(n) && n > 0 ? n : null;
 }
 
 /**
@@ -2026,6 +2038,66 @@ export async function executePhaseComplete(
 				const oldPhase = contributorSession.lastPhaseCompletePhase;
 				contributorSession.lastPhaseCompletePhase = phase;
 				telemetry.phaseChanged(contributorSessionId, oldPhase ?? 0, phase);
+
+				// Phase-boundary cleanup: drop task state from completed phase and
+				// earlier so it cannot leak across into the next phase's gate-evidence
+				// resolution. Conditional clears keep already-staged next-phase ids
+				// intact (otherwise the architect's pre-staged update_task_status for
+				// phase N+1 would be wiped here).
+				const currentTid = contributorSession.currentTaskId;
+				if (currentTid) {
+					const tp = taskIdToPhase(currentTid);
+					if (tp !== null && tp <= phase) {
+						contributorSession.currentTaskId = null;
+					}
+				}
+				const lastCoderTid = contributorSession.lastCoderDelegationTaskId;
+				if (lastCoderTid) {
+					const tp = taskIdToPhase(lastCoderTid);
+					if (tp !== null && tp <= phase) {
+						contributorSession.lastCoderDelegationTaskId = null;
+					}
+				}
+
+				const openStates = new Set([
+					'coder_delegated',
+					'pre_check_passed',
+					'reviewer_run',
+				]);
+				if (contributorSession.taskWorkflowStates instanceof Map) {
+					for (const [taskId, state] of Array.from(
+						contributorSession.taskWorkflowStates.entries(),
+					)) {
+						const tp = taskIdToPhase(taskId);
+						if (tp === null || tp > phase) continue;
+						if (openStates.has(state)) {
+							console.warn(
+								`[phase-complete] dropping open task state at phase boundary: taskId=${taskId} state=${state} phaseCompleted=${phase}`,
+							);
+						}
+						contributorSession.taskWorkflowStates.delete(taskId);
+					}
+				}
+				if (contributorSession.stageBCompletion instanceof Map) {
+					for (const taskId of Array.from(
+						contributorSession.stageBCompletion.keys(),
+					)) {
+						const tp = taskIdToPhase(taskId);
+						if (tp !== null && tp <= phase) {
+							contributorSession.stageBCompletion.delete(taskId);
+						}
+					}
+				}
+				if (contributorSession.requiredStageBGates instanceof Map) {
+					for (const taskId of Array.from(
+						contributorSession.requiredStageBGates.keys(),
+					)) {
+						const tp = taskIdToPhase(taskId);
+						if (tp !== null && tp <= phase) {
+							contributorSession.requiredStageBGates.delete(taskId);
+						}
+					}
+				}
 			}
 		}
 

--- a/tests/unit/hooks/delegation-gate-evidence-advisory.test.ts
+++ b/tests/unit/hooks/delegation-gate-evidence-advisory.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Fail-loud advisory coverage for gate-agent dispatches with unresolved task id.
+ *
+ * When the primary evidence-write block in `delegation-gate.ts` cannot
+ * resolve a task id and the dispatched agent is a gate agent
+ * (reviewer/test_engineer/docs/designer/critic/explorer/sme), the hook
+ * now pushes a deduped advisory to `pendingAdvisoryMessages` so the next
+ * architect system message will surface the corrective nudge.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import {
+	ensureAgentSession,
+	resetSwarmState,
+	startAgentSession,
+} from '../../../src/state';
+
+const testConfig = {
+	hooks: { delegation_gate: true },
+} as unknown as Parameters<typeof createDelegationGateHook>[0];
+
+const DEDUP_TOKEN = 'evidence-task-id-unresolved';
+
+describe('delegation-gate: fail-loud advisory for unresolved gate-evidence task id', () => {
+	let projectDir: string;
+
+	beforeEach(() => {
+		resetSwarmState();
+		projectDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'dg-evidence-advisory-')),
+		);
+		fs.mkdirSync(path.join(projectDir, '.swarm', 'evidence'), {
+			recursive: true,
+		});
+	});
+
+	afterEach(() => {
+		try {
+			fs.rmSync(projectDir, { recursive: true, force: true });
+		} catch {
+			/* best effort */
+		}
+		resetSwarmState();
+	});
+
+	it('pushes exactly one advisory across repeated gate-agent dispatches when task id is unresolvable', async () => {
+		const hook = createDelegationGateHook(testConfig, projectDir);
+
+		startAgentSession('sess-adv-1', 'architect');
+		const session = ensureAgentSession('sess-adv-1');
+		// No currentTaskId, no lastCoderDelegationTaskId, multiple stale workflow
+		// states so the `getOnlyWorkflowTaskId` fallback also returns null.
+		session.currentTaskId = null;
+		session.lastCoderDelegationTaskId = null;
+		session.taskWorkflowStates.set('1.1', 'tests_run');
+		session.taskWorkflowStates.set('1.2', 'tests_run');
+		session.pendingAdvisoryMessages = [];
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 'sess-adv-1',
+				callID: 'call-adv-1',
+				args: { subagent_type: 'reviewer' },
+			},
+			{},
+		);
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 'sess-adv-1',
+				callID: 'call-adv-2',
+				args: { subagent_type: 'reviewer' },
+			},
+			{},
+		);
+
+		const matches = (session.pendingAdvisoryMessages ?? []).filter((m) =>
+			m.includes(DEDUP_TOKEN),
+		);
+		expect(matches.length).toBe(1);
+		expect(matches[0]).toContain('Gate evidence has NOT been written');
+		expect(matches[0]).toContain('reviewer');
+	});
+
+	it('does NOT push an advisory when the gate-agent dispatch resolves a task id', async () => {
+		const hook = createDelegationGateHook(testConfig, projectDir);
+
+		startAgentSession('sess-adv-2', 'architect');
+		const session = ensureAgentSession('sess-adv-2');
+		session.currentTaskId = '2.1';
+		session.pendingAdvisoryMessages = [];
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 'sess-adv-2',
+				callID: 'call-adv-3',
+				args: { subagent_type: 'reviewer', task_id: '2.1' },
+			},
+			{},
+		);
+
+		const matches = (session.pendingAdvisoryMessages ?? []).filter((m) =>
+			m.includes(DEDUP_TOKEN),
+		);
+		expect(matches.length).toBe(0);
+	});
+
+	it('does NOT push an advisory for a non-gate agent (coder) with unresolvable task id', async () => {
+		// The gate at delegation-gate.ts only fires for the gateAgents allowlist
+		// (reviewer/test_engineer/docs/designer/critic/explorer/sme). A coder
+		// dispatch with no resolvable task id must stay silent — otherwise every
+		// coder delegation in a fresh session would spam the architect.
+		const hook = createDelegationGateHook(testConfig, projectDir);
+
+		startAgentSession('sess-adv-3', 'architect');
+		const session = ensureAgentSession('sess-adv-3');
+		session.currentTaskId = null;
+		session.lastCoderDelegationTaskId = null;
+		session.taskWorkflowStates.set('1.1', 'tests_run');
+		session.taskWorkflowStates.set('1.2', 'tests_run');
+		session.pendingAdvisoryMessages = [];
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 'sess-adv-3',
+				callID: 'call-adv-4',
+				args: { subagent_type: 'coder' },
+			},
+			{},
+		);
+
+		const matches = (session.pendingAdvisoryMessages ?? []).filter((m) =>
+			m.includes(DEDUP_TOKEN),
+		);
+		expect(matches.length).toBe(0);
+	});
+
+	it('initializes pendingAdvisoryMessages when undefined before pushing the advisory', async () => {
+		// The source uses `session.pendingAdvisoryMessages ??= []` to handle a
+		// session rehydrated without the field. Cover the undefined branch.
+		const hook = createDelegationGateHook(testConfig, projectDir);
+
+		startAgentSession('sess-adv-4', 'architect');
+		const session = ensureAgentSession('sess-adv-4');
+		session.currentTaskId = null;
+		session.lastCoderDelegationTaskId = null;
+		session.taskWorkflowStates.set('1.1', 'tests_run');
+		session.taskWorkflowStates.set('1.2', 'tests_run');
+		// Force the undefined branch (default-initialized sessions get `[]`).
+		(
+			session as { pendingAdvisoryMessages?: string[] }
+		).pendingAdvisoryMessages = undefined;
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 'sess-adv-4',
+				callID: 'call-adv-5',
+				args: { subagent_type: 'reviewer' },
+			},
+			{},
+		);
+
+		expect(Array.isArray(session.pendingAdvisoryMessages)).toBe(true);
+		const matches = (session.pendingAdvisoryMessages ?? []).filter((m) =>
+			m.includes(DEDUP_TOKEN),
+		);
+		expect(matches.length).toBe(1);
+	});
+});

--- a/tests/unit/hooks/delegation-gate-evidence-routing.test.ts
+++ b/tests/unit/hooks/delegation-gate-evidence-routing.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Cross-phase evidence-routing regression coverage.
+ *
+ * Before the fix, `getEvidenceTaskId` in `src/hooks/delegation-gate.ts`
+ * had a fallback `session.taskWorkflowStates.keys().next().value` that
+ * returned a *stale* Phase-N-1 task id when `currentTaskId` and
+ * `lastCoderDelegationTaskId` were both null after a phase boundary.
+ * That caused `recordAgentDispatch` to write evidence under the wrong
+ * (prior-phase) task id when the architect dispatched a non-gate agent
+ * (docs/designer/critic/explorer/sme).
+ *
+ * The fix routes the fallback through `getOnlyWorkflowTaskId` which
+ * returns null when more than one strict task id is present. With no
+ * `plan.json`, the resolver returns null and no evidence file is written.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import {
+	ensureAgentSession,
+	resetSwarmState,
+	startAgentSession,
+} from '../../../src/state';
+
+const testConfig = {
+	hooks: { delegation_gate: true },
+} as unknown as Parameters<typeof createDelegationGateHook>[0];
+
+describe('delegation-gate: cross-phase evidence-routing fallback', () => {
+	let projectDir: string;
+
+	beforeEach(() => {
+		resetSwarmState();
+		projectDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'dg-evidence-routing-')),
+		);
+		fs.mkdirSync(path.join(projectDir, '.swarm', 'evidence'), {
+			recursive: true,
+		});
+	});
+
+	afterEach(() => {
+		try {
+			fs.rmSync(projectDir, { recursive: true, force: true });
+		} catch {
+			/* best effort */
+		}
+		resetSwarmState();
+	});
+
+	it('does NOT write evidence for stale Phase-1 task id when current task is unset and multiple workflow states exist', async () => {
+		const hook = createDelegationGateHook(testConfig, projectDir);
+
+		startAgentSession('sess-routing-1', 'architect');
+		const session = ensureAgentSession('sess-routing-1');
+		// Seed two stale Phase-1 entries; both should be ignored by the
+		// post-fix resolver because the count > 1.
+		session.taskWorkflowStates.set('1.1', 'tests_run');
+		session.taskWorkflowStates.set('1.2', 'tests_run');
+		session.currentTaskId = null;
+		session.lastCoderDelegationTaskId = null;
+
+		// Dispatch a non-gate agent (docs) — pre-fix path routes through
+		// recordAgentDispatch which would write `.swarm/evidence/1.1.json`.
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 'sess-routing-1',
+				callID: 'call-routing-1',
+				args: { subagent_type: 'docs' },
+			},
+			{},
+		);
+
+		const evidenceDir = path.join(projectDir, '.swarm', 'evidence');
+		const stale = path.join(evidenceDir, '1.1.json');
+		const staleAlt = path.join(evidenceDir, '1.2.json');
+		expect(fs.existsSync(stale)).toBe(false);
+		expect(fs.existsSync(staleAlt)).toBe(false);
+	});
+
+	it('does NOT write evidence when taskWorkflowStates is empty and no plan.json exists', async () => {
+		// Empty-map path: `getOnlyWorkflowTaskId` returns null, the plan.json
+		// scan finds no file, and `getEvidenceTaskId` returns null.
+		// No evidence file must be created under any task id.
+		const hook = createDelegationGateHook(testConfig, projectDir);
+
+		startAgentSession('sess-routing-empty', 'architect');
+		const session = ensureAgentSession('sess-routing-empty');
+		session.currentTaskId = null;
+		session.lastCoderDelegationTaskId = null;
+		// Intentionally leave taskWorkflowStates empty.
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 'sess-routing-empty',
+				callID: 'call-routing-empty',
+				args: { subagent_type: 'docs' },
+			},
+			{},
+		);
+
+		const evidenceDir = path.join(projectDir, '.swarm', 'evidence');
+		const evidenceFiles = fs
+			.readdirSync(evidenceDir)
+			.filter((f) => f.endsWith('.json'));
+		expect(evidenceFiles).toEqual([]);
+	});
+
+	it('still writes evidence under the only workflow task id when exactly one entry exists', async () => {
+		const hook = createDelegationGateHook(testConfig, projectDir);
+
+		startAgentSession('sess-routing-2', 'architect');
+		const session = ensureAgentSession('sess-routing-2');
+		// Exactly one strict task id — fallback should resolve to it.
+		session.taskWorkflowStates.set('2.1', 'coder_delegated');
+		session.currentTaskId = null;
+		session.lastCoderDelegationTaskId = null;
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 'sess-routing-2',
+				callID: 'call-routing-2',
+				args: { subagent_type: 'docs' },
+			},
+			{},
+		);
+
+		const evidencePath = path.join(
+			projectDir,
+			'.swarm',
+			'evidence',
+			'2.1.json',
+		);
+		expect(fs.existsSync(evidencePath)).toBe(true);
+	});
+});

--- a/tests/unit/tools/phase-complete-cleanup.test.ts
+++ b/tests/unit/tools/phase-complete-cleanup.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Phase-boundary cleanup for contributor session state.
+ *
+ * After a successful `phase_complete(N)`, the post-success reset block
+ * must prune Phase-N-and-earlier entries from:
+ *   - session.taskWorkflowStates
+ *   - session.stageBCompletion
+ *   - session.requiredStageBGates
+ * and conditionally clear `currentTaskId` / `lastCoderDelegationTaskId`
+ * when those reference Phase-N or earlier.
+ *
+ * Future-phase entries (Phase N+1+) must survive — they may have been
+ * pre-staged by the architect's next `update_task_status` call.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+	ensureAgentSession,
+	resetSwarmState,
+	swarmState,
+} from '../../../src/state';
+
+const { phase_complete } = await import('../../../src/tools/phase-complete');
+
+describe('phase_complete: phase-boundary contributor-session cleanup', () => {
+	let tempDir: string;
+	let originalCwd: string;
+
+	beforeEach(() => {
+		resetSwarmState();
+		tempDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'pc-cleanup-test-')),
+		);
+		originalCwd = process.cwd();
+		process.chdir(tempDir);
+
+		execSync('git init', { encoding: 'utf-8' });
+		execSync('git config --local commit.gpgsign false', { encoding: 'utf-8' });
+		execSync('git config user.email "test@test.com"', { encoding: 'utf-8' });
+		execSync('git config user.name "Test"', { encoding: 'utf-8' });
+		fs.writeFileSync(path.join(tempDir, 'initial.txt'), 'initial');
+		execSync('git add .', { encoding: 'utf-8' });
+		execSync('git commit -m "initial"', { encoding: 'utf-8' });
+
+		fs.mkdirSync(path.join(tempDir, '.swarm', 'evidence'), { recursive: true });
+		fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+		fs.writeFileSync(
+			path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+			JSON.stringify({
+				phase_complete: {
+					enabled: true,
+					required_agents: [],
+					require_docs: false,
+					policy: 'warn',
+				},
+			}),
+		);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			/* best effort */
+		}
+		resetSwarmState();
+	});
+
+	function writeRetroBundle(phase: number) {
+		const retroDir = path.join(tempDir, '.swarm', 'evidence', `retro-${phase}`);
+		fs.mkdirSync(retroDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(retroDir, 'evidence.json'),
+			JSON.stringify({
+				schema_version: '1.0.0',
+				task_id: `retro-${phase}`,
+				entries: [
+					{
+						task_id: `retro-${phase}`,
+						type: 'retrospective',
+						timestamp: new Date().toISOString(),
+						agent: 'architect',
+						verdict: 'pass',
+						summary: 'Phase retrospective',
+						metadata: {},
+						phase_number: phase,
+						total_tool_calls: 1,
+						coder_revisions: 0,
+						reviewer_rejections: 0,
+						test_failures: 0,
+						security_findings: 0,
+						integration_issues: 0,
+						task_count: 1,
+						task_complexity: 'simple',
+						top_rejection_reasons: [],
+						lessons_learned: ['lesson'],
+					},
+				],
+				created_at: new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+			}),
+		);
+	}
+
+	test('prior-phase task state is pruned; next-phase entries survive (and open-state drop logs a warn)', async () => {
+		const sessionId = 'sess-cleanup-1';
+		const session = ensureAgentSession(sessionId);
+
+		// Seed stale Phase-1 entries (everything must be cleared) and a
+		// pre-staged Phase-2 entry that MUST survive.
+		session.taskWorkflowStates.set('1.1', 'tests_run');
+		session.taskWorkflowStates.set('1.2', 'coder_delegated'); // open state
+		session.taskWorkflowStates.set('2.1', 'coder_delegated');
+
+		session.stageBCompletion = new Map();
+		session.stageBCompletion.set('1.1', new Set(['reviewer']));
+		session.stageBCompletion.set('2.1', new Set(['reviewer']));
+
+		// Capture console.warn so we can assert the open-state drop warning
+		// fires for 1.2 (state `coder_delegated`, classified as an "open" state).
+		const originalWarn = console.warn;
+		const warnCalls: string[] = [];
+		console.warn = (...args: unknown[]) => {
+			warnCalls.push(args.map(String).join(' '));
+		};
+		try {
+			session.requiredStageBGates = new Map();
+			session.requiredStageBGates.set('1.1', new Set(['reviewer']));
+			session.requiredStageBGates.set('2.1', new Set(['reviewer']));
+
+			session.currentTaskId = '1.2';
+			session.lastCoderDelegationTaskId = '1.2';
+
+			writeRetroBundle(1);
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: sessionId,
+			});
+			const parsed = JSON.parse(result);
+			expect(parsed.success).toBe(true);
+
+			const refreshed = swarmState.agentSessions.get(sessionId);
+			expect(refreshed).toBeDefined();
+
+			// Prior-phase entries pruned across all three maps.
+			expect(refreshed?.taskWorkflowStates.has('1.1')).toBe(false);
+			expect(refreshed?.taskWorkflowStates.has('1.2')).toBe(false);
+			expect(refreshed?.stageBCompletion?.has('1.1')).toBe(false);
+			expect(refreshed?.requiredStageBGates?.has('1.1')).toBe(false);
+
+			// Next-phase entries survive.
+			expect(refreshed?.taskWorkflowStates.has('2.1')).toBe(true);
+			expect(refreshed?.stageBCompletion?.has('2.1')).toBe(true);
+			expect(refreshed?.requiredStageBGates?.has('2.1')).toBe(true);
+
+			// Prior-phase `currentTaskId` cleared; would be Phase-2 if re-staged.
+			expect(refreshed?.currentTaskId).toBeNull();
+			expect(refreshed?.lastCoderDelegationTaskId).toBeNull();
+
+			// Open-state drop warning: `1.2` was in state `coder_delegated`
+			// (an "open" state) when pruned, so the boundary log must fire.
+			const dropWarn = warnCalls.find(
+				(m) =>
+					m.includes('dropping open task state at phase boundary') &&
+					m.includes('taskId=1.2') &&
+					m.includes('state=coder_delegated') &&
+					m.includes('phaseCompleted=1'),
+			);
+			expect(dropWarn).toBeDefined();
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
+
+	test('non-strict task ids (e.g. "1-debug", "retro-1") are NEVER pruned by phase boundary', async () => {
+		// Regression: `parseInt('1-debug', 10)` returns 1; an early version of
+		// `taskIdToPhase` would have wrongly classified `'1-debug'` as a Phase-1
+		// id and pruned it. The hardened version uses `isStrictTaskId` first.
+		const sessionId = 'sess-cleanup-nonstrict';
+		const session = ensureAgentSession(sessionId);
+		session.taskWorkflowStates.set('1-debug', 'tests_run');
+		session.taskWorkflowStates.set('retro-1', 'tests_run');
+		session.stageBCompletion = new Map();
+		session.stageBCompletion.set('1-debug', new Set(['reviewer']));
+		session.requiredStageBGates = new Map();
+		session.requiredStageBGates.set('retro-1', new Set(['reviewer']));
+
+		writeRetroBundle(1);
+
+		const result = await phase_complete.execute({
+			phase: 1,
+			sessionID: sessionId,
+		});
+		const parsed = JSON.parse(result);
+		expect(parsed.success).toBe(true);
+
+		const refreshed = swarmState.agentSessions.get(sessionId);
+		expect(refreshed?.taskWorkflowStates.has('1-debug')).toBe(true);
+		expect(refreshed?.taskWorkflowStates.has('retro-1')).toBe(true);
+		expect(refreshed?.stageBCompletion?.has('1-debug')).toBe(true);
+		expect(refreshed?.requiredStageBGates?.has('retro-1')).toBe(true);
+	});
+
+	test('next-phase currentTaskId is preserved across phase boundary', async () => {
+		const sessionId = 'sess-cleanup-2';
+		const session = ensureAgentSession(sessionId);
+
+		// Architect has already pre-staged Phase-2 work before calling
+		// phase_complete(1). That state must NOT be wiped.
+		session.taskWorkflowStates.set('2.1', 'coder_delegated');
+		session.currentTaskId = '2.1';
+		session.lastCoderDelegationTaskId = '2.1';
+
+		writeRetroBundle(1);
+
+		const result = await phase_complete.execute({
+			phase: 1,
+			sessionID: sessionId,
+		});
+		const parsed = JSON.parse(result);
+		expect(parsed.success).toBe(true);
+
+		const refreshed = swarmState.agentSessions.get(sessionId);
+		expect(refreshed?.currentTaskId).toBe('2.1');
+		expect(refreshed?.lastCoderDelegationTaskId).toBe('2.1');
+		expect(refreshed?.taskWorkflowStates.has('2.1')).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- Replace the `taskWorkflowStates.keys().next().value` fallback in `getEvidenceTaskId` with `getOnlyWorkflowTaskId`, eliminating stale Phase-N-1 task-id leakage to `recordAgentDispatch` for non-gate-agent dispatches after a phase boundary.
- Fail loud on gate-agent dispatches with no resolvable task id: deduped advisory (key `evidence-task-id-unresolved`) pushed to `session.pendingAdvisoryMessages` so the architect's next system message surfaces a corrective nudge; resolution failures and write failures both use `console.warn` (not debug-gated `logger.warn`) to stay visible in production.
- On successful `phase_complete(N)`, prune Phase-N-and-earlier entries from `taskWorkflowStates`, `stageBCompletion`, and the v7.18.0 `requiredStageBGates` map for every contributor session; conditionally clear `currentTaskId` / `lastCoderDelegationTaskId` when those reference Phase-N or earlier. `taskIdToPhase` is `isStrictTaskId`-guarded so non-plan keys (`retro-N`, `1-debug`) are never pruned.

## Invariant audit
- 1 (plugin init):       not touched — no changes under `src/index.ts`; `node scripts/repro-704.mjs` still passes (T1 133.5 ms / T2 18.8 ms / T3 19.2 ms).
- 2 (runtime portability): not touched — no top-level `bun:` imports or `Bun.*` calls added (`git diff origin/main..HEAD -- src/ | grep -E "Bun\.|from ['\"]bun:"` empty); `node --input-type=module -e "await import('./dist/index.js')"` prints `dist import OK`.
- 3 (subprocesses):       not touched — no new spawn call sites (`git diff origin/main..HEAD -- src/ | grep -nE "bunSpawn\(|spawn\(|spawnSync\("` empty).
- 4 (.swarm containment): not touched — no new `.swarm/` paths or `process.cwd()` callers; only in-memory `AgentSessionState` maps are mutated.
- 5 (plan durability):    not touched — no writes to `.swarm/plan-ledger.jsonl`, `plan.json`, or `plan.md`; only contributor-session maps are pruned post-success.
- 6 (test_runner safety): not touched — repo validation done via shell `bun --smol test` per-file loops; `test_runner` tool not invoked.
- 7 (test writing):       touched — three new files under `tests/unit/{hooks,tools}/` use `bun:test` only, `os.tmpdir() + path.join`, `realpathSync(mkdtempSync(...))`, no `mock.module`, no DI seam required (tests exercise real code paths via `createDelegationGateHook` / `phase_complete.execute`).
- 8 (session state):      touched — all changes operate on per-session `AgentSessionState` (`taskWorkflowStates`, `stageBCompletion`, `requiredStageBGates`, `currentTaskId`, `lastCoderDelegationTaskId`, `pendingAdvisoryMessages`); evidence: `phase-complete-cleanup.test.ts` asserts contributor-session-keyed pruning, `delegation-gate-evidence-advisory.test.ts` asserts dedup per-session.
- 9 (guardrails/retry):   not touched — no transient-retry or circuit-breaker code paths altered; the `pendingAdvisoryMessages` drain in `guardrails.ts` is consumed unchanged.
- 10 (chat/system msg):   not touched — append to existing `pendingAdvisoryMessages` array surfaces via the existing `[ADVISORIES]` drainer in `src/hooks/guardrails.ts:2852`; no new system-message entries.
- 11 (tool registration): not touched — no new tools or agent-map changes; `src/index.ts`, `TOOL_NAMES`, `AGENT_TOOL_MAP` untouched.
- 12 (release/cache):     touched — adds `docs/releases/v7.18.1.md`; `package.json`, `CHANGELOG.md`, and `.release-please-manifest.json` are untouched (release-please-managed).

## Test plan
- [x] Tier 1 quality: `bun run typecheck` clean; `bunx biome ci .` exit 0 (1 pre-existing warning in `src/turbo/lean/runner.ts:307`, not in my diff).
- [x] Tier 2 unit (per-file isolation, 30s timeout): `tests/unit/tools/*` and `tests/unit/hooks/*` per-file loops. All my three new tests pass (`delegation-gate-evidence-routing.test.ts`, `delegation-gate-evidence-advisory.test.ts`, `phase-complete-cleanup.test.ts` — 7 tests / 22 assertions). 8 tool files and 10 hook files fail on my branch — each verified to **also fail on `origin/main`** via `git worktree add /tmp/repro-main origin/main` (pre-existing failures, see below).
- [x] Tier 2 services / agents / cli+commands+config: `0 fail` on services + agents; cli+commands+config = 2031 pass / 649 fail, byte-identical to `origin/main` baseline (zero new regressions).
- [x] Tier 3 integration: 668 pass / 100 fail — byte-identical to `origin/main` baseline (zero new regressions).
- [x] Tier 4 security: 139 pass / 0 fail; adversarial: 16 fail (origin/main: 17 fail — my branch passes one additional test).
- [x] Tier 5 smoke: 10 pass / 0 fail.
- [x] Build pre-flight: `bun run build` clean; `dist/cli/index.js` + `dist/index.js` re-bundled artifacts committed in this squash.
- [x] Plugin portability: `node scripts/repro-704.mjs` passes all three test cases; `node --input-type=module -e "await import('./dist/index.js')"` succeeds.
- [x] Adversarial sub-agent review of diff completed; HIGH-3 (`taskIdToPhase` strictness), LOW-1 (asymmetric logging), and MEDIUM-5 (advisory wording) findings addressed in the same squash. HIGH-1 / HIGH-2 explicitly scope-acknowledged (advisory is a nudge by design; "make `task_id` required for gate-agent Task calls" deferred to a separate breaking-change PR).

## Pre-existing failures
The following test files fail on both this branch and `origin/main` at `aabd1ac` (unrelated to this PR; flagged per the troubleshooting protocol):
- `tests/unit/tools/`: `diagnostic-gating.test.ts`, `doc-scan{,.adversarial}.test.ts`, `knowledge-remove.test.ts`, `phase-complete-lean-turbo-{critic,reviewer,.adversarial}.test.ts`, `sast-and-cochanger-tools.test.ts`.
- `tests/unit/hooks/`: `agent-activity.test.ts`, `full-auto-intercept{.adversarial,.dispatch,}.test.ts`, `guardrails-{authority-enhanced,model-fallback}.test.ts`, `knowledge-contextual-retrieval.test.ts`, `repo-graph-builder.adversarial.test.ts`, `system-enhancer-lean-turbo.test.ts`, `write-lstat-authority.test.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L62fqT6wFY8wwmoHAuWUwq)_