### PR TITLE
fix(onboarding): validate configured swarm models

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ bunx opencode-swarm install
 
 > This single command installs the package, registers it as an OpenCode plugin, disables conflicting default agents, and creates a ready-to-edit config at `~/.config/opencode/opencode-swarm.json`. Requires [Bun](https://bun.sh) (`bun --version` to check). If you must use npm: `npm install -g opencode-swarm && opencode-swarm install`.
 
-> ⚠️ **On first run, Swarm auto-selects the architect and shows a welcome message.** The default OpenCode `Build` and `Plan` modes **bypass this plugin entirely** — none of the gates, reviewers, or test agents below run. If you ever need to switch architect manually, open the OpenCode mode/agent picker and choose the Swarm architect; it then coordinates every other agent automatically. If you ever see Swarm "do nothing," this is almost always the cause.
+> ⚠️ **Select a Swarm architect before starting work.** The installer registers Swarm architect agents as primary choices, but the default OpenCode `Build` and `Plan` modes **bypass this plugin entirely** — none of the gates, reviewers, or test agents below run. Open the OpenCode mode/agent picker and choose `architect` or a `*_architect`; it then coordinates every other agent automatically. If you ever see Swarm "do nothing," this is almost always the cause.
 
 ### Why Swarm?
 
@@ -41,7 +41,7 @@ Most AI coding tools let one model write code and ask that same model whether th
 - 🆓 **Free tier** — works with OpenCode Zen's free model roster
 - ⚙️ **Fully configurable** — override any agent's model, disable agents, tune guardrails
 
-> **The Swarm architect is auto-selected on first run and coordinates all other agents automatically.** You never manually switch between internal roles. If you use the default OpenCode `Build` / `Plan` modes, the plugin is bypassed entirely (see the install warning above).
+> **The Swarm architect coordinates all other agents automatically after you select it.** You never manually switch between internal roles. If you use the default OpenCode `Build` / `Plan` modes, the plugin is bypassed entirely (see the install warning above).
 
 ---
 
@@ -126,9 +126,9 @@ The 15-minute guide covers:
 - Troubleshooting common issues
 
 On first run, Swarm automatically:
-- Creates project config at `.opencode/opencode-swarm.json` with all agents enabled
-- Selects the Swarm architect as the default
-- Shows a welcome message with next steps
+- Creates project config at `.opencode/opencode-swarm.json` if missing
+- Registers Swarm architect agents as primary choices in OpenCode
+- Shows a welcome message with next steps the first time you run `/swarm`
 
 ---
 
@@ -142,8 +142,7 @@ No animated GIF is shipped in the repo — instead, here is the exact terminal s
 # 1. Install the plugin (5s)
 bunx opencode-swarm install
 
-# 2. Open opencode — Swarm auto-selects architect on first run
-#    (the architect is auto-selected; manual selection is only needed to override)
+# 2. Open opencode and select the Swarm architect in the agent/mode picker
 opencode
 
 # 3. Inside the OpenCode session, verify Swarm is live (5s)
@@ -167,7 +166,7 @@ Build me a JWT auth helper with tests.
 │ ✓ created .opencode/opencode-swarm.json                     │
 │                                                              │
 │ $ opencode                                                   │
-│ [Swarm] Welcome! Architect auto-selected. Type /swarm help  │
+│ [Swarm] Welcome! Run /swarm diagnose, then /swarm agents    │
 │                                                              │
 │ > /swarm help                                                │
 │ Available commands: status, plan, agents, help, diagnose... │
@@ -218,7 +217,7 @@ in your `opencode-swarm.json`.
 
 ## Commands
 
-All 43 subcommands at a glance:
+Core subcommands at a glance:
 
 ```bash
 /swarm help [command]      # List all commands or get detailed help for a specific command
@@ -234,7 +233,7 @@ Use `/swarm help` to see all available commands categorized by function. Use `/s
 
 Nine commands display a ⚠️ warning in help output because they share names with Claude Code built-in slash commands (e.g., `/plan`, `/reset`, `/status`). The warning reminds you to always use `/swarm <command>` — the bare CC command does something different and sometimes destructive. See [docs/commands.md#claude-code-command-conflicts](docs/commands.md#claude-code-command-conflicts) for the full conflict registry.
 
-See [docs/commands.md](docs/commands.md) for the full reference (43 commands).
+See [docs/commands.md](docs/commands.md) for the full command reference.
 
 ## Command Aliases
 
@@ -368,10 +367,13 @@ No API key required. Excellent starting point:
   "agents": {
     "coder": { "model": "opencode/minimax-m2.5-free" },
     "reviewer": { "model": "opencode/big-pickle" },
+    "critic": { "model": "opencode/big-pickle" },
     "explorer": { "model": "opencode/big-pickle" }
   }
 }
 ```
+
+Zen's roster changes. Always confirm current IDs with `/models` in OpenCode or `https://opencode.ai/zen/v1/models` before pasting a model into config. Do not copy private workspace providers such as `grove-openai/*` unless that provider appears in your own OpenCode model list.
 
 ### Paid Providers
 
@@ -381,10 +383,13 @@ For production, mix providers by role:
 |---|---|---|
 | architect | OpenCode UI selection | Needs strongest reasoning |
 | coder | minimax-coding-plan/MiniMax-M2.5 | Fast, accurate code generation |
-| reviewer | zai-coding-plan/glm-5 | Different training from coder |
-| test_engineer | minimax-coding-plan/MiniMax-M2.5 | Same strengths as coder |
+| critic | opencode/gpt-5.5 or your strongest reasoning model | Challenges the architect before coding |
+| reviewer | zai-coding-plan/glm-5 or a different strong model | Different training from coder |
+| test_engineer | opencode/big-pickle or another model distinct from coder | Catches test blind spots |
 | explorer | google/gemini-2.5-flash | Fast read-heavy analysis |
 | sme | kimi-for-coding/k2p5 | Strong domain expertise |
+
+Model assignment rule of thumb: architect and critic should be your strongest pair, and they should not be the same blind spot. Coder/test_engineer can be faster coding models; explorer/docs/curator can be cheaper readers. Do not put a premium model on `designer` while leaving `critic` on a weaker model.
 
 ### Provider Formats
 
@@ -406,7 +411,7 @@ Automatic fallback to a secondary model on transient errors:
   "agents": {
     "coder": {
       "model": "anthropic/claude-sonnet-4-20250514",
-      "fallback_models": ["opencode/gpt-5-nano"]
+      "fallback_models": ["opencode/big-pickle"]
     }
   }
 }
@@ -1144,15 +1149,15 @@ Config file location: `~/.config/opencode/opencode-swarm.json` (global) or `.ope
 ```json
 {
   "agents": {
-    "architect": { "model": "anthropic/claude-opus-4-6" },
-    "coder": { "model": "minimax-coding-plan/MiniMax-M2.5", "fallback_models": ["minimax-coding-plan/MiniMax-M2.1"] },
-    "explorer": { "model": "minimax-coding-plan/MiniMax-M2.1" },
-    "sme": { "model": "kimi-for-coding/k2p5" },
-    "critic": { "model": "zai-coding-plan/glm-5" },
+    "architect": { "model": "opencode/claude-opus-4-6" },
+    "coder": { "model": "opencode/minimax-m2.5", "fallback_models": ["opencode/big-pickle"] },
+    "explorer": { "model": "opencode/big-pickle" },
+    "sme": { "model": "opencode/kimi-k2.6" },
+    "critic": { "model": "opencode/gpt-5.5" },
     "reviewer": { "model": "zai-coding-plan/glm-5", "fallback_models": ["opencode/big-pickle"] },
-    "test_engineer": { "model": "minimax-coding-plan/MiniMax-M2.5" },
-    "docs": { "model": "zai-coding-plan/glm-4.7-flash" },
-    "designer": { "model": "kimi-for-coding/k2p5" }
+    "test_engineer": { "model": "opencode/minimax-m2.5" },
+    "docs": { "model": "opencode/big-pickle" },
+    "designer": { "model": "opencode/kimi-k2.6" }
   },
   "guardrails": {
     "max_tool_calls": 200,
@@ -1401,7 +1406,7 @@ bun test
 - [Installation Guide](docs/installation.md) — comprehensive reference
 - [Architecture Deep Dive](docs/architecture.md) — control model, pipeline, tools
 - [Design Rationale](docs/design-rationale.md) — why every major decision
-- [Commands Reference](docs/commands.md) — all 41 `/swarm` subcommands
+- [Commands Reference](docs/commands.md) — full `/swarm` command reference
 - [Modes Guide](docs/modes.md) — session modes (Turbo, Full-Auto) and project modes (strict/balanced/fast)
 - [Configuration](docs/configuration.md) — all config keys and examples
 - [Planning Guide](docs/planning.md) — task format, phase structure, sizing

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.18.0",
+    version: "7.18.1",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -16519,8 +16519,7 @@ var init_constants = __esm(() => {
       "skill_improve",
       "search",
       "doc_scan",
-      "doc_extract",
-      "web_search"
+      "doc_extract"
     ],
     spec_writer: [
       "search",
@@ -16620,67 +16619,67 @@ var init_constants = __esm(() => {
   DEFAULT_AGENT_CONFIGS = {
     coder: {
       model: "opencode/minimax-m2.5-free",
-      fallback_models: ["opencode/gpt-5-nano", "opencode/big-pickle"]
+      fallback_models: ["opencode/big-pickle"]
     },
     reviewer: {
       model: "opencode/big-pickle",
-      fallback_models: ["opencode/gpt-5-nano", "opencode/big-pickle"]
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     test_engineer: {
-      model: "opencode/gpt-5-nano",
-      fallback_models: ["opencode/big-pickle"]
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     explorer: {
       model: "opencode/big-pickle",
-      fallback_models: ["opencode/gpt-5-nano", "opencode/big-pickle"]
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     sme: {
       model: "opencode/big-pickle",
-      fallback_models: ["opencode/gpt-5-nano", "opencode/big-pickle"]
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     critic: {
       model: "opencode/big-pickle",
-      fallback_models: ["opencode/gpt-5-nano", "opencode/big-pickle"]
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     docs: {
       model: "opencode/big-pickle",
-      fallback_models: ["opencode/gpt-5-nano", "opencode/big-pickle"]
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     designer: {
       model: "opencode/big-pickle",
-      fallback_models: ["opencode/gpt-5-nano", "opencode/big-pickle"]
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     critic_sounding_board: {
-      model: "opencode/gpt-5-nano",
-      fallback_models: ["opencode/big-pickle"]
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     critic_drift_verifier: {
-      model: "opencode/gpt-5-nano",
-      fallback_models: ["opencode/big-pickle"]
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     critic_hallucination_verifier: {
-      model: "opencode/gpt-5-nano",
-      fallback_models: ["opencode/big-pickle"]
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     critic_oversight: {
-      model: "opencode/gpt-5-nano",
-      fallback_models: ["opencode/big-pickle"]
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     curator_init: {
-      model: "opencode/gpt-5-nano",
-      fallback_models: ["opencode/big-pickle"]
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     curator_phase: {
-      model: "opencode/gpt-5-nano",
-      fallback_models: ["opencode/big-pickle"]
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     skill_improver: {
       model: "opencode/big-pickle",
-      fallback_models: ["opencode/gpt-5-nano"]
+      fallback_models: ["opencode/minimax-m2.5-free"]
     },
     spec_writer: {
       model: "opencode/big-pickle",
-      fallback_models: ["opencode/gpt-5-nano"]
+      fallback_models: ["opencode/minimax-m2.5-free"]
     }
   };
 });
@@ -17563,7 +17562,8 @@ function handleAgentsCommand(agents, guardrails) {
   if (hasUnregistered) {
     lines.push("", "### Unregistered Subagents");
     for (const name of unregistered) {
-      lines.push(`- **${name}** (requires configuration)`);
+      const hint = UNREGISTERED_AGENT_HINTS[name] ?? "requires configuration";
+      lines.push(`- **${name}** (${hint})`);
     }
   }
   if (guardrails?.profiles && Object.keys(guardrails.profiles).length > 0) {
@@ -17592,9 +17592,18 @@ function handleAgentsCommand(agents, guardrails) {
   return lines.join(`
 `);
 }
+var UNREGISTERED_AGENT_HINTS;
 var init_agents = __esm(() => {
   init_constants();
   init_schema();
+  UNREGISTERED_AGENT_HINTS = {
+    designer: "enable ui_review.enabled",
+    council_generalist: "enable council.general.enabled",
+    council_skeptic: "enable council.general.enabled",
+    council_domain_expert: "enable council.general.enabled",
+    skill_improver: "registered by default unless agents.skill_improver.disabled is true",
+    spec_writer: "registered by default unless agents.spec_writer.disabled is true"
+  };
 });
 
 // src/commands/analyze.ts
@@ -38265,11 +38274,30 @@ function parseArgs(args) {
   }
   return out;
 }
-async function handleCouncilCommand(_directory, args) {
+async function handleCouncilCommand(directory, args) {
   const parsed = parseArgs(args);
   const question = sanitizeQuestion(parsed.rest.join(" "));
   if (!question) {
     return USAGE;
+  }
+  const config3 = loadPluginConfig(directory);
+  if (config3.council?.general?.enabled !== true) {
+    return [
+      "General Council is not enabled for this project.",
+      "",
+      "Enable it in `.opencode/opencode-swarm.json` or `~/.config/opencode/opencode-swarm.json`:",
+      "",
+      "```json",
+      "{",
+      '  "council": {',
+      '    "general": { "enabled": true }',
+      "  }",
+      "}",
+      "```",
+      "",
+      "Then restart OpenCode and run `/swarm config doctor` before trying `/swarm council` again."
+    ].join(`
+`);
   }
   const tokens = ["MODE: COUNCIL"];
   if (parsed.preset) {
@@ -38282,6 +38310,7 @@ async function handleCouncilCommand(_directory, args) {
 }
 var MAX_QUESTION_LEN = 2000, USAGE;
 var init_council = __esm(() => {
+  init_loader();
   USAGE = [
     "Usage: /swarm council <question> [--preset <name>] [--spec-review]",
     "",
@@ -39758,6 +39787,7 @@ __export(exports_config_doctor, {
   restoreFromBackup: () => restoreFromBackup,
   getConfigPaths: () => getConfigPaths,
   createConfigBackup: () => createConfigBackup,
+  collectConfiguredModelRefs: () => collectConfiguredModelRefs,
   applySafeAutoFixes: () => applySafeAutoFixes
 });
 import * as crypto3 from "crypto";
@@ -40151,6 +40181,129 @@ function validateConfigKey(path24, value, _config) {
   }
   return findings;
 }
+function addConfiguredModel(refs, model, configPath) {
+  if (typeof model !== "string")
+    return;
+  const trimmed = model.trim();
+  if (!trimmed)
+    return;
+  const paths = refs.get(trimmed) ?? new Set;
+  paths.add(configPath);
+  refs.set(trimmed, paths);
+}
+function addConfiguredAgentModels(refs, agents, prefix) {
+  if (!agents || typeof agents !== "object" || Array.isArray(agents))
+    return;
+  for (const [agentName, value] of Object.entries(agents)) {
+    if (!value || typeof value !== "object" || Array.isArray(value))
+      continue;
+    const agent = value;
+    addConfiguredModel(refs, agent.model, `${prefix}.${agentName}.model`);
+    if (Array.isArray(agent.fallback_models)) {
+      agent.fallback_models.forEach((model, index) => {
+        addConfiguredModel(refs, model, `${prefix}.${agentName}.fallback_models[${index}]`);
+      });
+    }
+  }
+}
+function collectConfiguredModelRefs(config3) {
+  const refs = new Map;
+  const rawConfig = config3;
+  addConfiguredAgentModels(refs, rawConfig.agents, "agents");
+  if (rawConfig.swarms && typeof rawConfig.swarms === "object" && !Array.isArray(rawConfig.swarms)) {
+    for (const [swarmId, value] of Object.entries(rawConfig.swarms)) {
+      if (!value || typeof value !== "object" || Array.isArray(value))
+        continue;
+      addConfiguredAgentModels(refs, value.agents, `swarms.${swarmId}.agents`);
+    }
+  }
+  if (rawConfig.full_auto && typeof rawConfig.full_auto === "object" && !Array.isArray(rawConfig.full_auto)) {
+    addConfiguredModel(refs, rawConfig.full_auto.critic_model, "full_auto.critic_model");
+  }
+  if (rawConfig.skill_improver && typeof rawConfig.skill_improver === "object" && !Array.isArray(rawConfig.skill_improver)) {
+    const skillImprover = rawConfig.skill_improver;
+    addConfiguredModel(refs, skillImprover.model, "skill_improver.model");
+    if (Array.isArray(skillImprover.fallback_models)) {
+      skillImprover.fallback_models.forEach((model, index) => {
+        addConfiguredModel(refs, model, `skill_improver.fallback_models[${index}]`);
+      });
+    }
+  }
+  if (rawConfig.spec_writer && typeof rawConfig.spec_writer === "object" && !Array.isArray(rawConfig.spec_writer)) {
+    const specWriter = rawConfig.spec_writer;
+    addConfiguredModel(refs, specWriter.model, "spec_writer.model");
+    if (Array.isArray(specWriter.fallback_models)) {
+      specWriter.fallback_models.forEach((model, index) => {
+        addConfiguredModel(refs, model, `spec_writer.fallback_models[${index}]`);
+      });
+    }
+  }
+  const council = rawConfig.council;
+  const general = council && typeof council === "object" && !Array.isArray(council) ? council.general : undefined;
+  if (general && typeof general === "object" && !Array.isArray(general)) {
+    addConfiguredModel(refs, general.moderatorModel, "council.general.moderatorModel");
+    if (Array.isArray(general.members)) {
+      general.members.forEach((member, index) => {
+        if (!member || typeof member !== "object" || Array.isArray(member)) {
+          return;
+        }
+        addConfiguredModel(refs, member.model, `council.general.members[${index}].model`);
+      });
+    }
+    if (general.presets && typeof general.presets === "object" && !Array.isArray(general.presets)) {
+      for (const [presetName, members] of Object.entries(general.presets)) {
+        if (!Array.isArray(members))
+          continue;
+        members.forEach((member, index) => {
+          if (!member || typeof member !== "object" || Array.isArray(member)) {
+            return;
+          }
+          addConfiguredModel(refs, member.model, `council.general.presets.${presetName}[${index}].model`);
+        });
+      }
+    }
+  }
+  return refs;
+}
+function validateConfiguredModels(config3, modelAvailability) {
+  const refs = collectConfiguredModelRefs(config3);
+  const findings = [];
+  if (modelAvailability.error) {
+    findings.push({
+      id: "model-availability-unchecked",
+      title: "Model availability check skipped",
+      description: `Could not load OpenCode provider models from ${modelAvailability.source}: ` + modelAvailability.error,
+      severity: "info",
+      path: "agents",
+      autoFixable: false
+    });
+    return findings;
+  }
+  if (refs.size === 0)
+    return findings;
+  for (const [modelId, paths] of refs.entries()) {
+    if (modelAvailability.availableModelIds.has(modelId))
+      continue;
+    findings.push({
+      id: "configured-model-unavailable",
+      title: "Configured model is unavailable",
+      description: `Configured model ${formatModelIdForDoctor(modelId)} was not found in the active OpenCode provider model registry. ` + "Run `/models` to choose a currently available model, then update opencode-swarm.json.",
+      severity: "error",
+      path: [...paths].sort().join(", "),
+      currentValue: modelId,
+      autoFixable: false
+    });
+  }
+  return findings;
+}
+function formatModelIdForDoctor(modelId) {
+  const json3 = JSON.stringify(modelId);
+  if (!json3)
+    return '"<invalid model id>"';
+  if (json3.length <= 160)
+    return json3;
+  return `${json3.slice(0, 157)}..."`;
+}
 function walkConfigAndValidate(obj, path24, config3, findings) {
   if (obj === null || obj === undefined) {
     return;
@@ -40175,9 +40328,12 @@ function walkConfigAndValidate(obj, path24, config3, findings) {
     walkConfigAndValidate(value, newPath, config3, findings);
   }
 }
-function runConfigDoctor(config3, directory) {
+function runConfigDoctor(config3, directory, options = {}) {
   const findings = [];
   walkConfigAndValidate(config3, "", config3, findings);
+  if (options.modelAvailability) {
+    findings.push(...validateConfiguredModels(config3, options.modelAvailability));
+  }
   const summary = {
     info: findings.filter((f) => f.severity === "info").length,
     warn: findings.filter((f) => f.severity === "warn").length,
@@ -40339,8 +40495,8 @@ function shouldRunOnStartup(automationConfig) {
   }
   return automationConfig.capabilities?.config_doctor_on_startup === true;
 }
-async function runConfigDoctorWithFixes(directory, config3, autoFix = false) {
-  const result = runConfigDoctor(config3, directory);
+async function runConfigDoctorWithFixes(directory, config3, autoFix = false, options = {}) {
+  const result = runConfigDoctor(config3, directory, options);
   const artifactPath = writeDoctorArtifact(directory, result);
   if (!autoFix) {
     return {
@@ -40360,7 +40516,7 @@ async function runConfigDoctorWithFixes(directory, config3, autoFix = false) {
   if (appliedFixes.length > 0) {
     const freshConfig = readConfigFromFile(directory);
     if (freshConfig) {
-      const newResult = runConfigDoctor(freshConfig.config, directory);
+      const newResult = runConfigDoctor(freshConfig.config, directory, options);
       writeDoctorArtifact(directory, newResult);
     }
   }
@@ -41982,6 +42138,23 @@ var init_tool_doctor = __esm(() => {
   ];
 });
 
+// src/utils/timeout.ts
+async function withTimeout(promise3, ms, timeoutError) {
+  let timer;
+  const timeoutPromise = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(timeoutError), ms);
+    if (typeof timer.unref === "function") {
+      timer.unref();
+    }
+  });
+  try {
+    return await Promise.race([promise3, timeoutPromise]);
+  } finally {
+    if (timer !== undefined)
+      clearTimeout(timer);
+  }
+}
+
 // src/commands/doctor.ts
 function formatToolDoctorMarkdown(result) {
   const lines = [
@@ -42055,13 +42228,67 @@ function formatDoctorMarkdown(result) {
   return lines.join(`
 `);
 }
-async function handleDoctorCommand(directory, args) {
+function extractAvailableModelIds(response) {
+  const available = new Set;
+  if (response?.providers !== undefined && !Array.isArray(response.providers)) {
+    throw new Error("provider registry returned malformed provider list");
+  }
+  for (const provider of response?.providers ?? []) {
+    if (!provider || typeof provider !== "object" || !provider.id || !provider.models || typeof provider.models !== "object" || Array.isArray(provider.models)) {
+      continue;
+    }
+    for (const [modelKey, modelInfo] of Object.entries(provider.models)) {
+      available.add(`${provider.id}/${modelKey}`);
+      if (modelInfo && typeof modelInfo === "object" && modelInfo.id) {
+        available.add(`${provider.id}/${modelInfo.id}`);
+      }
+    }
+  }
+  return available;
+}
+async function loadModelAvailability(directory, client, options = {}) {
+  const providerClient = client;
+  const providers = providerClient?.config?.providers;
+  if (typeof providers !== "function") {
+    return;
+  }
+  try {
+    const response = await withTimeout(providers({ directory }), options.timeoutMs ?? MODEL_REGISTRY_TIMEOUT_MS, new Error(`OpenCode provider model registry lookup exceeded ${options.timeoutMs ?? MODEL_REGISTRY_TIMEOUT_MS}ms`));
+    if (response.error) {
+      return {
+        availableModelIds: new Set,
+        source: MODEL_REGISTRY_SOURCE,
+        error: typeof response.error === "string" ? response.error : JSON.stringify(response.error)
+      };
+    }
+    if (!response.data) {
+      return {
+        availableModelIds: new Set,
+        source: MODEL_REGISTRY_SOURCE,
+        error: "provider registry returned no data"
+      };
+    }
+    return {
+      availableModelIds: extractAvailableModelIds(response.data),
+      source: MODEL_REGISTRY_SOURCE
+    };
+  } catch (error93) {
+    return {
+      availableModelIds: new Set,
+      source: MODEL_REGISTRY_SOURCE,
+      error: error93 instanceof Error ? error93.message : String(error93)
+    };
+  }
+}
+async function handleDoctorCommand(directory, args, options = {}) {
   const enableAutoFix = args.includes("--fix") || args.includes("-f");
   const config3 = loadPluginConfig(directory);
-  const result = runConfigDoctor(config3, directory);
+  const modelAvailability = await loadModelAvailability(directory, options.client);
+  const doctorOptions = { modelAvailability };
+  const result = runConfigDoctor(config3, directory, doctorOptions);
   if (enableAutoFix && result.hasAutoFixableIssues) {
     const { runConfigDoctorWithFixes: runConfigDoctorWithFixes2 } = await Promise.resolve().then(() => (init_config_doctor(), exports_config_doctor));
-    const fixResult = await runConfigDoctorWithFixes2(directory, config3, true);
+    const fixResult = await runConfigDoctorWithFixes2(directory, config3, true, doctorOptions);
     return formatDoctorMarkdown(fixResult.result);
   }
   return formatDoctorMarkdown(result);
@@ -42070,6 +42297,7 @@ async function handleDoctorToolsCommand(directory, _args) {
   const result = runToolDoctor(directory);
   return formatToolDoctorMarkdown(result);
 }
+var MODEL_REGISTRY_TIMEOUT_MS = 3000, MODEL_REGISTRY_SOURCE = "OpenCode config.providers";
 var init_doctor = __esm(() => {
   init_loader();
   init_config_doctor();
@@ -51801,7 +52029,7 @@ function buildHelpText() {
   return lines.join(`
 `);
 }
-function createSwarmCommandHandler(directory, agents) {
+function createSwarmCommandHandler(directory, agents, client) {
   return async (input, output) => {
     if (input.command !== "swarm" && !input.command.startsWith("swarm-")) {
       return;
@@ -51848,7 +52076,8 @@ ${similar.map((cmd) => `  \u2022 /swarm ${cmd}`).join(`
           directory,
           args: resolved.remainingArgs,
           sessionID: input.sessionID,
-          agents
+          agents,
+          client
         });
       } catch (_err) {
         const cmdName = tokens[0] || "unknown";
@@ -51864,7 +52093,10 @@ ${text}`;
     if (isFirstRun) {
       const welcomeMessage = `Welcome to OpenCode Swarm! \uD83D\uDC1D
 ` + `
-` + `Run \`/swarm help\` to see all available commands, or \`/swarm config\` to review your configuration.
+` + `Start here: run \`/swarm diagnose\`, then \`/swarm agents\` to confirm the plugin loaded and see the exact models in use.
+` + `If a model is unavailable, edit \`.opencode/opencode-swarm.json\` or \`~/.config/opencode/opencode-swarm.json\` and run \`/swarm config doctor\`.
+` + `Useful next steps: \`/swarm brainstorm <task>\` for guided planning, \`/swarm full-auto on\` for autonomous runs after enabling it in config, and \`/swarm council <question>\` after enabling council.general.
+
 `;
       text = welcomeMessage + text;
     }
@@ -52181,13 +52413,13 @@ var init_registry = __esm(() => {
       clashesWithNativeCcCommand: "/config"
     },
     "config doctor": {
-      handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args),
+      handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args, { client: ctx.client }),
       description: "Run config doctor checks",
       subcommandOf: "config",
       category: "diagnostics"
     },
     "config-doctor": {
-      handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args),
+      handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args, { client: ctx.client }),
       description: "Run config doctor checks",
       subcommandOf: "config",
       category: "diagnostics",
@@ -52262,7 +52494,7 @@ var init_registry = __esm(() => {
       deprecated: true
     },
     doctor: {
-      handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args),
+      handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args, { client: ctx.client }),
       description: "Run config doctor checks",
       category: "diagnostics",
       aliasOf: "config doctor",

--- a/dist/commands/council.d.ts
+++ b/dist/commands/council.d.ts
@@ -14,4 +14,4 @@
  * Sanitizes the question to prevent prompt injection of rival MODE: headers
  * or control sequences (mirrors brainstorm.ts).
  */
-export declare function handleCouncilCommand(_directory: string, args: string[]): Promise<string>;
+export declare function handleCouncilCommand(directory: string, args: string[]): Promise<string>;

--- a/dist/commands/doctor.d.ts
+++ b/dist/commands/doctor.d.ts
@@ -1,15 +1,20 @@
-import { type ConfigDoctorResult } from '../services/config-doctor';
+import { type ConfigDoctorResult, type ModelAvailability } from '../services/config-doctor';
 /**
  * Format tool doctor result as markdown for command output.
  *
  * Exported for unit testing of the BLOCKING footer enforcement path.
  */
 export declare function formatToolDoctorMarkdown(result: ConfigDoctorResult): string;
+export declare function loadModelAvailability(directory: string, client: unknown, options?: {
+    timeoutMs?: number;
+}): Promise<ModelAvailability | undefined>;
 /**
  * Handle /swarm config doctor command.
  * Maps to: config doctor service (runConfigDoctor)
  */
-export declare function handleDoctorCommand(directory: string, args: string[]): Promise<string>;
+export declare function handleDoctorCommand(directory: string, args: string[], options?: {
+    client?: unknown;
+}): Promise<string>;
 /**
  * Handle /swarm doctor tools command.
  * Maps to: tool doctor service (runToolDoctor)

--- a/dist/commands/index.d.ts
+++ b/dist/commands/index.d.ts
@@ -45,7 +45,7 @@ export declare function buildHelpText(): string;
  * Creates a command.execute.before handler for /swarm commands.
  * Uses factory pattern to close over directory and agents.
  */
-export declare function createSwarmCommandHandler(directory: string, agents: Record<string, AgentDefinition>): (input: {
+export declare function createSwarmCommandHandler(directory: string, agents: Record<string, AgentDefinition>, client?: unknown): (input: {
     command: string;
     sessionID: string;
     arguments: string;

--- a/dist/commands/registry.d.ts
+++ b/dist/commands/registry.d.ts
@@ -8,6 +8,7 @@ export type CommandContext = {
     args: string[];
     sessionID: string;
     agents: Record<string, AgentDefinition>;
+    client?: unknown;
 };
 export type CommandResult = Promise<string>;
 export type CommandCategory = 'core' | 'agent' | 'config' | 'diagnostics' | 'utility';

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.18.0",
+    version: "7.18.1",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -271,7 +271,7 @@ function isLowCapabilityModel(modelId) {
   const lower = (modelId || "").toLowerCase();
   return LOW_CAPABILITY_MODELS.some((substr) => lower.includes(substr));
 }
-var QA_AGENTS, PIPELINE_AGENTS, ORCHESTRATOR_NAME = "architect", ALL_SUBAGENT_NAMES, ALL_AGENT_NAMES, OPENCODE_NATIVE_AGENTS, CLAUDE_CODE_NATIVE_COMMANDS, AGENT_TOOL_MAP, WRITE_TOOL_NAMES, TOOL_DESCRIPTIONS, DEFAULT_MODELS, DEFAULT_SCORING_CONFIG, LOW_CAPABILITY_MODELS, TURBO_MODE_BANNER = `## \uD83D\uDE80 TURBO MODE ACTIVE
+var QA_AGENTS, PIPELINE_AGENTS, ORCHESTRATOR_NAME = "architect", ALL_SUBAGENT_NAMES, ALL_AGENT_NAMES, OPENCODE_NATIVE_AGENTS, CLAUDE_CODE_NATIVE_COMMANDS, AGENT_TOOL_MAP, WRITE_TOOL_NAMES, TOOL_DESCRIPTIONS, DEFAULT_MODELS, DEFAULT_AGENT_CONFIGS, DEFAULT_SCORING_CONFIG, LOW_CAPABILITY_MODELS, TURBO_MODE_BANNER = `## \uD83D\uDE80 TURBO MODE ACTIVE
 
 **Speed optimization enabled for this session.**
 
@@ -705,8 +705,7 @@ var init_constants = __esm(() => {
       "skill_improve",
       "search",
       "doc_scan",
-      "doc_extract",
-      "web_search"
+      "doc_extract"
     ],
     spec_writer: [
       "search",
@@ -818,20 +817,86 @@ var init_constants = __esm(() => {
     explorer: "opencode/big-pickle",
     coder: "opencode/minimax-m2.5-free",
     reviewer: "opencode/big-pickle",
-    test_engineer: "opencode/gpt-5-nano",
+    test_engineer: "opencode/big-pickle",
     sme: "opencode/big-pickle",
     critic: "opencode/big-pickle",
-    critic_sounding_board: "opencode/gpt-5-nano",
-    critic_drift_verifier: "opencode/gpt-5-nano",
-    critic_hallucination_verifier: "opencode/gpt-5-nano",
-    critic_oversight: "opencode/gpt-5-nano",
+    critic_sounding_board: "opencode/big-pickle",
+    critic_drift_verifier: "opencode/big-pickle",
+    critic_hallucination_verifier: "opencode/big-pickle",
+    critic_oversight: "opencode/big-pickle",
     docs: "opencode/big-pickle",
     designer: "opencode/big-pickle",
-    curator_init: "opencode/gpt-5-nano",
-    curator_phase: "opencode/gpt-5-nano",
+    curator_init: "opencode/big-pickle",
+    curator_phase: "opencode/big-pickle",
     skill_improver: "opencode/big-pickle",
     spec_writer: "opencode/big-pickle",
     default: "opencode/big-pickle"
+  };
+  DEFAULT_AGENT_CONFIGS = {
+    coder: {
+      model: "opencode/minimax-m2.5-free",
+      fallback_models: ["opencode/big-pickle"]
+    },
+    reviewer: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    test_engineer: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    explorer: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    sme: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    critic: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    docs: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    designer: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    critic_sounding_board: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    critic_drift_verifier: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    critic_hallucination_verifier: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    critic_oversight: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    curator_init: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    curator_phase: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    skill_improver: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    },
+    spec_writer: {
+      model: "opencode/big-pickle",
+      fallback_models: ["opencode/minimax-m2.5-free"]
+    }
   };
   DEFAULT_SCORING_CONFIG = {
     enabled: false,
@@ -18550,7 +18615,8 @@ function handleAgentsCommand(agents, guardrails) {
   if (hasUnregistered) {
     lines.push("", "### Unregistered Subagents");
     for (const name2 of unregistered) {
-      lines.push(`- **${name2}** (requires configuration)`);
+      const hint = UNREGISTERED_AGENT_HINTS[name2] ?? "requires configuration";
+      lines.push(`- **${name2}** (${hint})`);
     }
   }
   if (guardrails?.profiles && Object.keys(guardrails.profiles).length > 0) {
@@ -18579,9 +18645,18 @@ function handleAgentsCommand(agents, guardrails) {
   return lines.join(`
 `);
 }
+var UNREGISTERED_AGENT_HINTS;
 var init_agents = __esm(() => {
   init_constants();
   init_schema();
+  UNREGISTERED_AGENT_HINTS = {
+    designer: "enable ui_review.enabled",
+    council_generalist: "enable council.general.enabled",
+    council_skeptic: "enable council.general.enabled",
+    council_domain_expert: "enable council.general.enabled",
+    skill_improver: "registered by default unless agents.skill_improver.disabled is true",
+    spec_writer: "registered by default unless agents.spec_writer.disabled is true"
+  };
 });
 
 // src/commands/analyze.ts
@@ -46843,11 +46918,30 @@ function parseArgs(args2) {
   }
   return out2;
 }
-async function handleCouncilCommand(_directory, args2) {
+async function handleCouncilCommand(directory, args2) {
   const parsed = parseArgs(args2);
   const question = sanitizeQuestion(parsed.rest.join(" "));
   if (!question) {
     return USAGE;
+  }
+  const config3 = loadPluginConfig(directory);
+  if (config3.council?.general?.enabled !== true) {
+    return [
+      "General Council is not enabled for this project.",
+      "",
+      "Enable it in `.opencode/opencode-swarm.json` or `~/.config/opencode/opencode-swarm.json`:",
+      "",
+      "```json",
+      "{",
+      '  "council": {',
+      '    "general": { "enabled": true }',
+      "  }",
+      "}",
+      "```",
+      "",
+      "Then restart OpenCode and run `/swarm config doctor` before trying `/swarm council` again."
+    ].join(`
+`);
   }
   const tokens = ["MODE: COUNCIL"];
   if (parsed.preset) {
@@ -46860,6 +46954,7 @@ async function handleCouncilCommand(_directory, args2) {
 }
 var MAX_QUESTION_LEN = 2000, USAGE;
 var init_council = __esm(() => {
+  init_loader();
   USAGE = [
     "Usage: /swarm council <question> [--preset <name>] [--spec-review]",
     "",
@@ -48387,6 +48482,7 @@ __export(exports_config_doctor, {
   restoreFromBackup: () => restoreFromBackup,
   getConfigPaths: () => getConfigPaths,
   createConfigBackup: () => createConfigBackup,
+  collectConfiguredModelRefs: () => collectConfiguredModelRefs,
   applySafeAutoFixes: () => applySafeAutoFixes
 });
 import * as crypto3 from "node:crypto";
@@ -48780,6 +48876,129 @@ function validateConfigKey(path31, value, _config) {
   }
   return findings;
 }
+function addConfiguredModel(refs, model, configPath) {
+  if (typeof model !== "string")
+    return;
+  const trimmed = model.trim();
+  if (!trimmed)
+    return;
+  const paths = refs.get(trimmed) ?? new Set;
+  paths.add(configPath);
+  refs.set(trimmed, paths);
+}
+function addConfiguredAgentModels(refs, agents, prefix) {
+  if (!agents || typeof agents !== "object" || Array.isArray(agents))
+    return;
+  for (const [agentName, value] of Object.entries(agents)) {
+    if (!value || typeof value !== "object" || Array.isArray(value))
+      continue;
+    const agent = value;
+    addConfiguredModel(refs, agent.model, `${prefix}.${agentName}.model`);
+    if (Array.isArray(agent.fallback_models)) {
+      agent.fallback_models.forEach((model, index) => {
+        addConfiguredModel(refs, model, `${prefix}.${agentName}.fallback_models[${index}]`);
+      });
+    }
+  }
+}
+function collectConfiguredModelRefs(config3) {
+  const refs = new Map;
+  const rawConfig = config3;
+  addConfiguredAgentModels(refs, rawConfig.agents, "agents");
+  if (rawConfig.swarms && typeof rawConfig.swarms === "object" && !Array.isArray(rawConfig.swarms)) {
+    for (const [swarmId, value] of Object.entries(rawConfig.swarms)) {
+      if (!value || typeof value !== "object" || Array.isArray(value))
+        continue;
+      addConfiguredAgentModels(refs, value.agents, `swarms.${swarmId}.agents`);
+    }
+  }
+  if (rawConfig.full_auto && typeof rawConfig.full_auto === "object" && !Array.isArray(rawConfig.full_auto)) {
+    addConfiguredModel(refs, rawConfig.full_auto.critic_model, "full_auto.critic_model");
+  }
+  if (rawConfig.skill_improver && typeof rawConfig.skill_improver === "object" && !Array.isArray(rawConfig.skill_improver)) {
+    const skillImprover = rawConfig.skill_improver;
+    addConfiguredModel(refs, skillImprover.model, "skill_improver.model");
+    if (Array.isArray(skillImprover.fallback_models)) {
+      skillImprover.fallback_models.forEach((model, index) => {
+        addConfiguredModel(refs, model, `skill_improver.fallback_models[${index}]`);
+      });
+    }
+  }
+  if (rawConfig.spec_writer && typeof rawConfig.spec_writer === "object" && !Array.isArray(rawConfig.spec_writer)) {
+    const specWriter = rawConfig.spec_writer;
+    addConfiguredModel(refs, specWriter.model, "spec_writer.model");
+    if (Array.isArray(specWriter.fallback_models)) {
+      specWriter.fallback_models.forEach((model, index) => {
+        addConfiguredModel(refs, model, `spec_writer.fallback_models[${index}]`);
+      });
+    }
+  }
+  const council = rawConfig.council;
+  const general = council && typeof council === "object" && !Array.isArray(council) ? council.general : undefined;
+  if (general && typeof general === "object" && !Array.isArray(general)) {
+    addConfiguredModel(refs, general.moderatorModel, "council.general.moderatorModel");
+    if (Array.isArray(general.members)) {
+      general.members.forEach((member, index) => {
+        if (!member || typeof member !== "object" || Array.isArray(member)) {
+          return;
+        }
+        addConfiguredModel(refs, member.model, `council.general.members[${index}].model`);
+      });
+    }
+    if (general.presets && typeof general.presets === "object" && !Array.isArray(general.presets)) {
+      for (const [presetName, members] of Object.entries(general.presets)) {
+        if (!Array.isArray(members))
+          continue;
+        members.forEach((member, index) => {
+          if (!member || typeof member !== "object" || Array.isArray(member)) {
+            return;
+          }
+          addConfiguredModel(refs, member.model, `council.general.presets.${presetName}[${index}].model`);
+        });
+      }
+    }
+  }
+  return refs;
+}
+function validateConfiguredModels(config3, modelAvailability) {
+  const refs = collectConfiguredModelRefs(config3);
+  const findings = [];
+  if (modelAvailability.error) {
+    findings.push({
+      id: "model-availability-unchecked",
+      title: "Model availability check skipped",
+      description: `Could not load OpenCode provider models from ${modelAvailability.source}: ` + modelAvailability.error,
+      severity: "info",
+      path: "agents",
+      autoFixable: false
+    });
+    return findings;
+  }
+  if (refs.size === 0)
+    return findings;
+  for (const [modelId, paths] of refs.entries()) {
+    if (modelAvailability.availableModelIds.has(modelId))
+      continue;
+    findings.push({
+      id: "configured-model-unavailable",
+      title: "Configured model is unavailable",
+      description: `Configured model ${formatModelIdForDoctor(modelId)} was not found in the active OpenCode provider model registry. ` + "Run `/models` to choose a currently available model, then update opencode-swarm.json.",
+      severity: "error",
+      path: [...paths].sort().join(", "),
+      currentValue: modelId,
+      autoFixable: false
+    });
+  }
+  return findings;
+}
+function formatModelIdForDoctor(modelId) {
+  const json3 = JSON.stringify(modelId);
+  if (!json3)
+    return '"<invalid model id>"';
+  if (json3.length <= 160)
+    return json3;
+  return `${json3.slice(0, 157)}..."`;
+}
 function walkConfigAndValidate(obj, path31, config3, findings) {
   if (obj === null || obj === undefined) {
     return;
@@ -48804,9 +49023,12 @@ function walkConfigAndValidate(obj, path31, config3, findings) {
     walkConfigAndValidate(value, newPath, config3, findings);
   }
 }
-function runConfigDoctor(config3, directory) {
+function runConfigDoctor(config3, directory, options = {}) {
   const findings = [];
   walkConfigAndValidate(config3, "", config3, findings);
+  if (options.modelAvailability) {
+    findings.push(...validateConfiguredModels(config3, options.modelAvailability));
+  }
   const summary = {
     info: findings.filter((f) => f.severity === "info").length,
     warn: findings.filter((f) => f.severity === "warn").length,
@@ -48968,8 +49190,8 @@ function shouldRunOnStartup(automationConfig) {
   }
   return automationConfig.capabilities?.config_doctor_on_startup === true;
 }
-async function runConfigDoctorWithFixes(directory, config3, autoFix = false) {
-  const result = runConfigDoctor(config3, directory);
+async function runConfigDoctorWithFixes(directory, config3, autoFix = false, options = {}) {
+  const result = runConfigDoctor(config3, directory, options);
   const artifactPath = writeDoctorArtifact(directory, result);
   if (!autoFix) {
     return {
@@ -48989,7 +49211,7 @@ async function runConfigDoctorWithFixes(directory, config3, autoFix = false) {
   if (appliedFixes.length > 0) {
     const freshConfig = readConfigFromFile(directory);
     if (freshConfig) {
-      const newResult = runConfigDoctor(freshConfig.config, directory);
+      const newResult = runConfigDoctor(freshConfig.config, directory, options);
       writeDoctorArtifact(directory, newResult);
     }
   }
@@ -50634,6 +50856,31 @@ var init_tool_doctor = __esm(() => {
   ];
 });
 
+// src/utils/timeout.ts
+async function withTimeout(promise3, ms, timeoutError) {
+  let timer;
+  const timeoutPromise = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(timeoutError), ms);
+    if (typeof timer.unref === "function") {
+      timer.unref();
+    }
+  });
+  try {
+    return await Promise.race([promise3, timeoutPromise]);
+  } finally {
+    if (timer !== undefined)
+      clearTimeout(timer);
+  }
+}
+function yieldToEventLoop() {
+  return new Promise((resolve11) => {
+    const t = setTimeout(resolve11, 0);
+    if (typeof t.unref === "function") {
+      t.unref();
+    }
+  });
+}
+
 // src/commands/doctor.ts
 function formatToolDoctorMarkdown(result) {
   const lines = [
@@ -50707,13 +50954,67 @@ function formatDoctorMarkdown(result) {
   return lines.join(`
 `);
 }
-async function handleDoctorCommand(directory, args2) {
+function extractAvailableModelIds(response) {
+  const available = new Set;
+  if (response?.providers !== undefined && !Array.isArray(response.providers)) {
+    throw new Error("provider registry returned malformed provider list");
+  }
+  for (const provider of response?.providers ?? []) {
+    if (!provider || typeof provider !== "object" || !provider.id || !provider.models || typeof provider.models !== "object" || Array.isArray(provider.models)) {
+      continue;
+    }
+    for (const [modelKey, modelInfo] of Object.entries(provider.models)) {
+      available.add(`${provider.id}/${modelKey}`);
+      if (modelInfo && typeof modelInfo === "object" && modelInfo.id) {
+        available.add(`${provider.id}/${modelInfo.id}`);
+      }
+    }
+  }
+  return available;
+}
+async function loadModelAvailability(directory, client, options = {}) {
+  const providerClient = client;
+  const providers = providerClient?.config?.providers;
+  if (typeof providers !== "function") {
+    return;
+  }
+  try {
+    const response = await withTimeout(providers({ directory }), options.timeoutMs ?? MODEL_REGISTRY_TIMEOUT_MS, new Error(`OpenCode provider model registry lookup exceeded ${options.timeoutMs ?? MODEL_REGISTRY_TIMEOUT_MS}ms`));
+    if (response.error) {
+      return {
+        availableModelIds: new Set,
+        source: MODEL_REGISTRY_SOURCE,
+        error: typeof response.error === "string" ? response.error : JSON.stringify(response.error)
+      };
+    }
+    if (!response.data) {
+      return {
+        availableModelIds: new Set,
+        source: MODEL_REGISTRY_SOURCE,
+        error: "provider registry returned no data"
+      };
+    }
+    return {
+      availableModelIds: extractAvailableModelIds(response.data),
+      source: MODEL_REGISTRY_SOURCE
+    };
+  } catch (error93) {
+    return {
+      availableModelIds: new Set,
+      source: MODEL_REGISTRY_SOURCE,
+      error: error93 instanceof Error ? error93.message : String(error93)
+    };
+  }
+}
+async function handleDoctorCommand(directory, args2, options = {}) {
   const enableAutoFix = args2.includes("--fix") || args2.includes("-f");
   const config3 = loadPluginConfig(directory);
-  const result = runConfigDoctor(config3, directory);
+  const modelAvailability = await loadModelAvailability(directory, options.client);
+  const doctorOptions = { modelAvailability };
+  const result = runConfigDoctor(config3, directory, doctorOptions);
   if (enableAutoFix && result.hasAutoFixableIssues) {
     const { runConfigDoctorWithFixes: runConfigDoctorWithFixes2 } = await Promise.resolve().then(() => (init_config_doctor(), exports_config_doctor));
-    const fixResult = await runConfigDoctorWithFixes2(directory, config3, true);
+    const fixResult = await runConfigDoctorWithFixes2(directory, config3, true, doctorOptions);
     return formatDoctorMarkdown(fixResult.result);
   }
   return formatDoctorMarkdown(result);
@@ -50722,6 +51023,7 @@ async function handleDoctorToolsCommand(directory, _args) {
   const result = runToolDoctor(directory);
   return formatToolDoctorMarkdown(result);
 }
+var MODEL_REGISTRY_TIMEOUT_MS = 3000, MODEL_REGISTRY_SOURCE = "OpenCode config.providers";
 var init_doctor = __esm(() => {
   init_loader();
   init_config_doctor();
@@ -60892,7 +61194,7 @@ function buildHelpText() {
   return lines.join(`
 `);
 }
-function createSwarmCommandHandler(directory, agents) {
+function createSwarmCommandHandler(directory, agents, client) {
   return async (input, output) => {
     if (input.command !== "swarm" && !input.command.startsWith("swarm-")) {
       return;
@@ -60939,7 +61241,8 @@ ${similar.map((cmd) => `  • /swarm ${cmd}`).join(`
           directory,
           args: resolved.remainingArgs,
           sessionID: input.sessionID,
-          agents
+          agents,
+          client
         });
       } catch (_err) {
         const cmdName = tokens[0] || "unknown";
@@ -60955,7 +61258,10 @@ ${text}`;
     if (isFirstRun) {
       const welcomeMessage = `Welcome to OpenCode Swarm! \uD83D\uDC1D
 ` + `
-` + `Run \`/swarm help\` to see all available commands, or \`/swarm config\` to review your configuration.
+` + `Start here: run \`/swarm diagnose\`, then \`/swarm agents\` to confirm the plugin loaded and see the exact models in use.
+` + `If a model is unavailable, edit \`.opencode/opencode-swarm.json\` or \`~/.config/opencode/opencode-swarm.json\` and run \`/swarm config doctor\`.
+` + `Useful next steps: \`/swarm brainstorm <task>\` for guided planning, \`/swarm full-auto on\` for autonomous runs after enabling it in config, and \`/swarm council <question>\` after enabling council.general.
+
 `;
       text = welcomeMessage + text;
     }
@@ -61272,13 +61578,13 @@ var init_registry = __esm(() => {
       clashesWithNativeCcCommand: "/config"
     },
     "config doctor": {
-      handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args),
+      handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args, { client: ctx.client }),
       description: "Run config doctor checks",
       subcommandOf: "config",
       category: "diagnostics"
     },
     "config-doctor": {
-      handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args),
+      handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args, { client: ctx.client }),
       description: "Run config doctor checks",
       subcommandOf: "config",
       category: "diagnostics",
@@ -61353,7 +61659,7 @@ var init_registry = __esm(() => {
       deprecated: true
     },
     doctor: {
-      handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args),
+      handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args, { client: ctx.client }),
       description: "Run config doctor checks",
       category: "diagnostics",
       aliasOf: "config doctor",
@@ -71641,13 +71947,7 @@ function writeSwarmConfigExampleIfNew(projectDirectory) {
       fs40.mkdirSync(swarmDir, { recursive: true });
     }
     const example = {
-      agents: Object.fromEntries(Object.entries(DEFAULT_MODELS).filter(([name2]) => name2 !== "default").map(([name2, model]) => [
-        name2,
-        {
-          model,
-          fallback_models: ["opencode/gpt-5-nano", "opencode/big-pickle"]
-        }
-      ])),
+      agents: DEFAULT_AGENT_CONFIGS,
       max_iterations: 5
     };
     fs40.writeFileSync(dest, `${JSON.stringify(example, null, 2)}
@@ -74088,31 +74388,6 @@ import { existsSync as existsSync36, realpathSync as realpathSync6 } from "node:
 import * as fsPromises5 from "node:fs/promises";
 import * as os7 from "node:os";
 import * as path66 from "node:path";
-
-// src/utils/timeout.ts
-async function withTimeout(promise3, ms, timeoutError) {
-  let timer;
-  const timeoutPromise = new Promise((_, reject) => {
-    timer = setTimeout(() => reject(timeoutError), ms);
-    if (typeof timer.unref === "function") {
-      timer.unref();
-    }
-  });
-  try {
-    return await Promise.race([promise3, timeoutPromise]);
-  } finally {
-    if (timer !== undefined)
-      clearTimeout(timer);
-  }
-}
-function yieldToEventLoop() {
-  return new Promise((resolve19) => {
-    const t = setTimeout(resolve19, 0);
-    if (typeof t.unref === "function") {
-      t.unref();
-    }
-  });
-}
 
 // src/tools/symbols.ts
 init_zod();
@@ -103411,7 +103686,6 @@ init_write_retro();
 
 // src/index.ts
 init_utils();
-
 // src/utils/tool-output.ts
 function truncateToolOutput(output, maxLines, toolName, tailLines = 10) {
   if (!output) {
@@ -103554,7 +103828,7 @@ async function initializeOpenCodeSwarm(ctx) {
   const systemEnhancerHook = createSystemEnhancerHook(config3, ctx.directory);
   const compactionHook = createCompactionCustomizerHook(config3, ctx.directory);
   const contextBudgetHandler = createContextBudgetHandler(config3);
-  const commandHandler = createSwarmCommandHandler(ctx.directory, Object.fromEntries(agentDefinitions.map((agent) => [agent.name, agent])));
+  const commandHandler = createSwarmCommandHandler(ctx.directory, Object.fromEntries(agentDefinitions.map((agent) => [agent.name, agent])), ctx.client);
   const activityHooks = createAgentActivityHooks(config3, ctx.directory);
   const prmHook = createPrmHook(config3.prm ?? PrmConfigSchema.parse({}), ctx.directory);
   const trajectoryLoggerHook = createTrajectoryLoggerHook({

--- a/dist/services/config-doctor.d.ts
+++ b/dist/services/config-doctor.d.ts
@@ -56,6 +56,18 @@ export interface ConfigDoctorResult {
     /** The config that was analyzed */
     configSource: string;
 }
+/** Model availability snapshot from the active OpenCode provider registry. */
+export interface ModelAvailability {
+    /** Fully-qualified model IDs in provider/model form. */
+    availableModelIds: ReadonlySet<string>;
+    /** Human-readable source for diagnostics. */
+    source: string;
+    /** Optional failure message when the registry could not be loaded. */
+    error?: string;
+}
+export interface ConfigDoctorOptions {
+    modelAvailability?: ModelAvailability;
+}
 /** Backup artifact for rollback */
 export interface ConfigBackup {
     /** When the backup was created */
@@ -90,10 +102,11 @@ export declare function writeBackupArtifact(directory: string, backup: ConfigBac
  * @returns the path to the restored config file, or null if restore failed
  */
 export declare function restoreFromBackup(backupPath: string, directory: string): string | null;
+export declare function collectConfiguredModelRefs(config: PluginConfig): Map<string, Set<string>>;
 /**
  * Run the config doctor on a loaded config
  */
-export declare function runConfigDoctor(config: PluginConfig, directory: string): ConfigDoctorResult;
+export declare function runConfigDoctor(config: PluginConfig, directory: string, options?: ConfigDoctorOptions): ConfigDoctorResult;
 /**
  * Apply safe auto-fixes to config
  * Only applies low-risk, non-destructive fixes
@@ -116,7 +129,7 @@ export declare function shouldRunOnStartup(automationConfig: {
 /**
  * Full config doctor run with backup and fix application
  */
-export declare function runConfigDoctorWithFixes(directory: string, config: PluginConfig, autoFix?: boolean): Promise<{
+export declare function runConfigDoctorWithFixes(directory: string, config: PluginConfig, autoFix?: boolean, options?: ConfigDoctorOptions): Promise<{
     result: ConfigDoctorResult;
     backupPath: string | null;
     appliedFixes: ConfigFix[];

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 # Commands Reference
 
-All `/swarm` subcommands available in OpenCode Swarm v6.81.0. The authoritative source is `src/commands/registry.ts`.
+All `/swarm` subcommands available in the current OpenCode Swarm command registry. The authoritative source is `src/commands/registry.ts`; run `/swarm help` in OpenCode for the live list in your installed version.
 
 Commands are grouped by function. Compound commands (e.g., `/swarm config doctor`) resolve the two-word form first, then fall back to the first token.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,26 @@ You only need to define the agents you want to override.
 
 > If `architect` is not set explicitly, it inherits the currently selected OpenCode UI model.
 
+## Model setup without walls
+
+New users should start with either no model overrides or the free Zen starter models above. Run `/swarm agents` after OpenCode starts; it shows the resolved model for every registered agent. If any model reports `ProviderModelNotFoundError`, replace it with one from OpenCode's live model list (`/models` in the TUI, or `https://opencode.ai/zen/v1/models`) and run `/swarm config doctor`.
+
+Avoid copy-pasting provider IDs from private workspaces, incubators, or screenshots. In particular, do not use `grove-openai/*` unless you personally have access to that provider in OpenCode. For public Zen models, use the `opencode/<model-id>` form shown by `/models`.
+
+`/swarm config doctor` performs a best-effort live check against OpenCode's provider registry. The lookup is capped at 3 seconds so doctor never blocks startup or interactive use; if OpenCode is offline, slow, or returns malformed provider data, doctor reports an informational "model availability check skipped" finding instead of raising model-not-found errors.
+
+Role guidance:
+
+| Role | Good default | Upgrade first when you have paid models |
+|---|---|---|
+| architect | OpenCode UI selection | strongest reasoning model you have |
+| critic / reviewer | `opencode/big-pickle` | a different strong model from the architect/coder |
+| coder | `opencode/minimax-m2.5-free` | fast coding model with reliable tool use |
+| test_engineer | `opencode/big-pickle` | separate model from coder for test blind spots |
+| explorer / docs / curator | `opencode/big-pickle` | cheaper fast reader/writer |
+
+Do not spend your strongest model on `designer` while leaving `critic` weaker. The critic's job is to fight the plan and catch blind spots before implementation starts.
+
 ## Per-agent override fields
 
 Each entry under `agents` accepts the following optional fields:
@@ -49,17 +69,17 @@ Each entry under `agents` accepts the following optional fields:
 
 ### Why `variant` is its own field
 
-OpenCode's TUI accepts the shorthand `provider/model/variant` (e.g. `grove-openai/gpt-5.3-codex/medium`) in its model picker — the picker rewrites that input through a variant-aware resolver before applying it to the session. The agent loader, by contrast, uses a basic 2-segment parser, so embedding the variant into `model` resolves to a non-existent model id (`gpt-5.3-codex/medium`) and produces `ProviderModelNotFoundError`. Use the `variant` field instead:
+OpenCode's TUI accepts the shorthand `provider/model/variant` (e.g. `opencode/gpt-5.3-codex/medium`) in its model picker — the picker rewrites that input through a variant-aware resolver before applying it to the session. The agent loader, by contrast, uses a basic 2-segment parser, so embedding the variant into `model` resolves to a non-existent model id (`gpt-5.3-codex/medium`) and produces `ProviderModelNotFoundError`. Use the `variant` field instead:
 
 ```json
 {
   "agents": {
     "test_engineer": {
-      "model": "grove-openai/gpt-5.3-codex",
+      "model": "opencode/gpt-5.3-codex",
       "variant": "medium"
     },
-    "designer": {
-      "model": "grove-openai/gpt-5.4",
+    "critic": {
+      "model": "opencode/gpt-5.4",
       "variant": "high"
     }
   }
@@ -68,7 +88,7 @@ OpenCode's TUI accepts the shorthand `provider/model/variant` (e.g. `grove-opena
 
 ### Backward compatibility
 
-If you currently have a config like `{ "model": "grove-openai/gpt-5.3-codex/medium" }`, it will still work — the variant is automatically extracted and a deprecation warning is logged.
+If you currently have a config like `{ "model": "opencode/gpt-5.3-codex/medium" }`, it will still work — the variant is automatically extracted and a deprecation warning is logged.
 
 **Before** (deprecated — produces a warning):
 
@@ -76,7 +96,7 @@ If you currently have a config like `{ "model": "grove-openai/gpt-5.3-codex/medi
 {
   "agents": {
     "coder": {
-      "model": "grove-openai/gpt-5.3-codex/medium"
+      "model": "opencode/gpt-5.3-codex/medium"
     }
   }
 }
@@ -88,7 +108,7 @@ If you currently have a config like `{ "model": "grove-openai/gpt-5.3-codex/medi
 {
   "agents": {
     "coder": {
-      "model": "grove-openai/gpt-5.3-codex",
+      "model": "opencode/gpt-5.3-codex",
       "variant": "medium"
     }
   }

--- a/docs/examples/web-app.md
+++ b/docs/examples/web-app.md
@@ -459,4 +459,4 @@ The coder receives structured failure feedback from the reviewer and test engine
 /swarm history              Completed phases with status icons
 ```
 
-For all 41 subcommands and their options, see [`docs/commands.md`](../commands.md).
+For the full command reference and options, see [`docs/commands.md`](../commands.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -252,7 +252,7 @@ Swarm resumes from `.swarm/plan.md` instead of redoing discovery. This is expect
 /swarm reset --confirm   # Clear swarm state and start over
 ```
 
-See [`docs/commands.md`](commands.md) for all 41 subcommands and their options.
+See [`docs/commands.md`](commands.md) for the full command reference and options.
 
 ### Configure Models (Optional)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # OpenCode Swarm Documentation
 
-OpenCode Swarm (v6.81.0) is an architect-centric agentic swarm plugin for OpenCode that orchestrates 11 specialized agents for planning, code generation, review, testing, and documentation. This documentation covers installation, configuration, usage, and architecture.
+OpenCode Swarm is an architect-centric agentic swarm plugin for OpenCode that orchestrates specialized core, optional, and conditional agents for planning, code generation, review, testing, documentation, and verification. This documentation covers installation, configuration, usage, and architecture.
 
 ---
 
@@ -27,7 +27,7 @@ OpenCode Swarm (v6.81.0) is an architect-centric agentic swarm plugin for OpenCo
 | Document | Covers |
 |----------|--------|
 | [Configuration Reference](configuration.md) | Config file locations, minimal example, all configuration keys |
-| [Commands Reference](commands.md) | All 43 `/swarm` subcommands, flags, and examples |
+| [Commands Reference](commands.md) | Full `/swarm` command reference, flags, and examples |
 | [Modes: Swarm vs Turbo vs Full-Auto](modes.md) | Execution modes, safety gates, when to use each |
 | [Pre-Swarm Planning Guide](planning.md) | How to plan tasks before running, task field reference, multi-model planning, spec pipeline |
 | [Swarm Briefing for LLMs](swarm-briefing.md) | Pipeline steps, task format, state machine — written for LLM plan authors |
@@ -52,7 +52,7 @@ OpenCode Swarm (v6.81.0) is an architect-centric agentic swarm plugin for OpenCo
 
 | Document | Covers |
 |----------|--------|
-| [Architecture Deep Dive](architecture.md) | Control model, 11 agent roles, full execution pipeline, tools, evidence schema, modes, guardrails |
+| [Architecture Deep Dive](architecture.md) | Control model, agent roles, full execution pipeline, tools, evidence schema, modes, guardrails |
 | [Adding a Language](adding-a-language.md) | Extending the language registry with a new profile and (optionally) a custom backend; backend invariants and tests |
 | [Design Rationale](design-rationale.md) | Core design decisions: serial execution, phased planning, persistent memory, gated QA |
 | [Plan Durability](plan-durability.md) | How `.swarm/plan-ledger.jsonl` provides crash-safe plan persistence |
@@ -61,16 +61,15 @@ OpenCode Swarm (v6.81.0) is an architect-centric agentic swarm plugin for OpenCo
 
 ## Release History
 
-**Latest version: v6.81.0** (released 2026-04-22)
-
-The full release history is documented in [CHANGELOG.md](../CHANGELOG.md) (v6.15.0 through v6.81.0).
+The full release history is documented in [CHANGELOG.md](../CHANGELOG.md). Release notes also live under `/docs/releases/`.
 
 Recent highlights:
 
 | Version | Highlights |
 |---------|-----------|
-| [v6.81.0](releases/v6.81.0.md) | Current version — documentation refresh |
-| [v6.80.2](releases/v6.80.2.md) | Latest stable release with notes |
+| [v7.18.2](releases/v7.18.2.md) | Latest documented release |
+| [v7.18.1](releases/v7.18.1.md) | Recent release |
+| [v7.18.0](releases/v7.18.0.md) | Recent release |
 | [v6.80.1](releases/v6.80.1.md) | Patch release |
 | [v6.78.0](releases/v6.78.0.md) | Stability improvements |
 | [v6.77.0](releases/v6.77.0.md) | Feature releases and hardening |
@@ -123,4 +122,4 @@ See [Archive](archive/ARCHIVE.md) for:
 
 ---
 
-*Last updated: 2026-04-22. Covers opencode-swarm v6.81.0.*
+*Last updated: 2026-05-13.*

--- a/docs/installation-linux-docker.md
+++ b/docs/installation-linux-docker.md
@@ -104,15 +104,14 @@ Create `~/.config/opencode/opencode-swarm.json`:
     "mega": {
       "name": "Mega",
       "agents": {
-        "architect": { "model": "opencode/gpt-5-nano" },
-        "coder": { "model": "minimax-coding-plan/MiniMax-M2.5" },
-        "explorer": { "model": "minimax-coding-plan/MiniMax-M2.1" },
-        "sme": { "model": "kimi-for-coding/k2p5" },
-        "critic": { "model": "zai-coding-plan/glm-5" },
-        "reviewer": { "model": "zai-coding-plan/glm-5" },
-        "test_engineer": { "model": "minimax-coding-plan/MiniMax-M2.5" },
-        "docs": { "model": "zai-coding-plan/glm-4.7-flash" },
-        "designer": { "model": "kimi-for-coding/k2p5" }
+        "coder": { "model": "opencode/minimax-m2.5-free" },
+        "explorer": { "model": "opencode/big-pickle" },
+        "sme": { "model": "opencode/big-pickle" },
+        "critic": { "model": "opencode/big-pickle" },
+        "reviewer": { "model": "opencode/big-pickle" },
+        "test_engineer": { "model": "opencode/big-pickle" },
+        "docs": { "model": "opencode/big-pickle" },
+        "designer": { "model": "opencode/big-pickle" }
       }
     }
   },

--- a/docs/installation-llm-operator.md
+++ b/docs/installation-llm-operator.md
@@ -97,15 +97,14 @@ Use the user-approved config. If not provided, use this minimum valid config:
     "mega": {
       "name": "Mega",
       "agents": {
-        "architect": { "model": "opencode/gpt-5-nano" },
-        "coder": { "model": "minimax-coding-plan/MiniMax-M2.5" },
-        "explorer": { "model": "minimax-coding-plan/MiniMax-M2.1" },
-        "sme": { "model": "kimi-for-coding/k2p5" },
-        "critic": { "model": "zai-coding-plan/glm-5" },
-        "reviewer": { "model": "zai-coding-plan/glm-5" },
-        "test_engineer": { "model": "minimax-coding-plan/MiniMax-M2.5" },
-        "docs": { "model": "zai-coding-plan/glm-4.7-flash" },
-        "designer": { "model": "kimi-for-coding/k2p5" }
+        "coder": { "model": "opencode/minimax-m2.5-free" },
+        "explorer": { "model": "opencode/big-pickle" },
+        "sme": { "model": "opencode/big-pickle" },
+        "critic": { "model": "opencode/big-pickle" },
+        "reviewer": { "model": "opencode/big-pickle" },
+        "test_engineer": { "model": "opencode/big-pickle" },
+        "docs": { "model": "opencode/big-pickle" },
+        "designer": { "model": "opencode/big-pickle" }
       }
     }
   },

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,18 +38,16 @@ Create `~/.config/opencode/opencode-swarm.json`:
 ```json
 {
   "agents": {
-    "architect": { "model": "anthropic/claude-sonnet-4-20250514" },
-    "explorer": { "model": "google/gemini-2.5-flash" },
-    "coder": { "model": "anthropic/claude-sonnet-4-20250514" },
-    "sme": { "model": "google/gemini-2.5-flash" },
-    "reviewer": { "model": "google/gemini-2.5-flash" },
-    "critic": { "model": "google/gemini-2.5-flash" },
-    "test_engineer": { "model": "google/gemini-2.5-flash" },
-    "docs": { "model": "google/gemini-2.5-flash" },
-    "designer": { "model": "google/gemini-2.5-flash" }
+    "coder": { "model": "opencode/minimax-m2.5-free" },
+    "reviewer": { "model": "opencode/big-pickle" },
+    "critic": { "model": "opencode/big-pickle" },
+    "test_engineer": { "model": "opencode/big-pickle" },
+    "explorer": { "model": "opencode/big-pickle" }
   }
 }
 ```
+
+You can also skip this file at first; the installer creates a starter global config and the architect inherits the model you select in OpenCode. Confirm current Zen model IDs with `/models` before copying examples.
 
 ### 3. Start OpenCode
 
@@ -88,9 +86,9 @@ Each agent can use a different model:
 ```json
 {
   "agents": {
-    "architect": { "model": "anthropic/claude-sonnet-4-20250514" },
-    "coder": { "model": "anthropic/claude-sonnet-4-20250514" },
-    "explorer": { "model": "google/gemini-2.5-flash" }
+    "coder": { "model": "opencode/minimax-m2.5-free" },
+    "reviewer": { "model": "opencode/big-pickle" },
+    "critic": { "model": "opencode/big-pickle" }
   }
 }
 ```

--- a/docs/releases/v7.18.2.md
+++ b/docs/releases/v7.18.2.md
@@ -1,0 +1,27 @@
+# v7.18.2
+
+## Onboarding hardening
+
+- Replaced starter model defaults and generated configs that referenced paid or stale Zen models with public free Zen starter models.
+- Made first-run documentation explicit that users must select a Swarm architect from OpenCode's agent/mode picker before Swarm gates run.
+- Added clearer model-assignment guidance so `critic` / `reviewer` are not accidentally left weaker than lower-risk roles.
+- Added feature-specific hints for conditional agents in `/swarm agents`, including council, UI review, skill improver, and spec writer enablement.
+- Made `/swarm council` fail early with configuration instructions when `council.general.enabled` is not enabled.
+- Made `/swarm config doctor` validate configured agent, fallback, full-auto, skill/spec, and General Council models against OpenCode's active provider registry so removed/private model IDs fail before a user starts a swarm run.
+- Documented that provider-model validation is best-effort and capped at 3 seconds; slow/offline provider registries produce an informational skipped-check finding.
+- Added docs drift tests for stale command counts, stale release/version claims, architect auto-selection claims, and known model copy-paste traps.
+
+## Invariant audit
+
+- 1 (plugin init): touched - `src/index.ts` now passes the OpenCode client into command handling; startup resolution verified by `node scripts/repro-704.mjs` timing output.
+- 2 (runtime portability): touched - `src/index.ts` and `dist/` changed; verified with bundle portability/plugin-shape tests and Node ESM import.
+- 3 (subprocesses): not touched - no subprocess changes.
+- 4 (.swarm containment): touched - `.swarm/config.example.json` generation now uses the same starter config constants as the installer; covered by targeted config tests.
+- 5 (plan durability): not touched.
+- 6 (test_runner safety): not touched - validation uses shell `bun test`, not broad test_runner.
+- 7 (test writing): touched - added focused `bun:test` coverage without `mock.module`.
+- 8 (session state): not touched.
+- 9 (guardrails/retry): not touched.
+- 10 (chat/system msg): not touched.
+- 11 (tool registration): touched - `AGENT_TOOL_MAP` and command registry wiring changed; verified by focused tool/config registration tests.
+- 12 (release/cache): touched - release note added for this onboarding fix.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -252,8 +252,8 @@ async function install(): Promise<number> {
 	if (!fs.existsSync(PLUGIN_CONFIG_PATH)) {
 		const defaultConfig = {
 			// Must match PluginConfigSchema in src/config/schema.ts
-			// v6.14: free OpenCode Zen models; v6.73+ switched to big-pickle with gpt-5-nano fallback; architect inherits OpenCode UI selection
-			// v6.85+: Multi-level fallback chains - only big-pickle and gpt-5-nano are consistently available in free tier
+			// Public OpenCode Zen free models only; architect inherits OpenCode UI selection.
+			// Do not place paid/private/incubator models in the generated starter config.
 			// General Council agents (council_generalist, council_skeptic, council_domain_expert)
 			// derive their models from reviewer/critic/sme entries above. No separate config
 			// entries are needed; if you want to override per-council-agent, set

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -3,6 +3,17 @@ import { ALL_SUBAGENT_NAMES } from '../config/constants.js';
 import type { GuardrailsConfig } from '../config/schema';
 import { stripKnownSwarmPrefix } from '../config/schema.js';
 
+const UNREGISTERED_AGENT_HINTS: Record<string, string> = {
+	designer: 'enable ui_review.enabled',
+	council_generalist: 'enable council.general.enabled',
+	council_skeptic: 'enable council.general.enabled',
+	council_domain_expert: 'enable council.general.enabled',
+	skill_improver:
+		'registered by default unless agents.skill_improver.disabled is true',
+	spec_writer:
+		'registered by default unless agents.spec_writer.disabled is true',
+};
+
 export function handleAgentsCommand(
 	agents: Record<string, AgentDefinition>,
 	guardrails?: GuardrailsConfig,
@@ -65,7 +76,8 @@ export function handleAgentsCommand(
 	if (hasUnregistered) {
 		lines.push('', '### Unregistered Subagents');
 		for (const name of unregistered) {
-			lines.push(`- **${name}** (requires configuration)`);
+			const hint = UNREGISTERED_AGENT_HINTS[name] ?? 'requires configuration';
+			lines.push(`- **${name}** (${hint})`);
 		}
 	}
 

--- a/src/commands/commands.test.ts
+++ b/src/commands/commands.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { handleDoctorCommand } from '../commands/doctor';
+import { handleDoctorCommand, loadModelAvailability } from '../commands/doctor';
 import { handlePreflightCommand } from '../commands/preflight';
 import { handleSyncPlanCommand } from '../commands/sync-plan';
 
@@ -34,12 +34,20 @@ function createTestConfig(dir: string, config: object): string {
 
 describe('Command Adapters', () => {
 	let tempDir: string;
+	let originalXdgConfigHome: string | undefined;
 
 	beforeEach(() => {
 		tempDir = createTempDir();
+		originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+		process.env.XDG_CONFIG_HOME = path.join(tempDir, '.isolated-config');
 	});
 
 	afterEach(() => {
+		if (originalXdgConfigHome === undefined) {
+			delete process.env.XDG_CONFIG_HOME;
+		} else {
+			process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+		}
 		cleanupDir(tempDir);
 	});
 
@@ -77,6 +85,120 @@ describe('Command Adapters', () => {
 
 			expect(result).toContain('## Config Doctor Report');
 			expect(result).toContain('Summary');
+		});
+
+		it('should validate configured models against the active OpenCode provider registry', async () => {
+			createTestConfig(tempDir, {
+				agents: {
+					coder: { model: 'opencode/minimax-m2.5-free' },
+					critic: { model: 'opencode/removed-model' },
+				},
+			});
+
+			const client = {
+				config: {
+					providers: async () => ({
+						data: {
+							providers: [
+								{
+									id: 'opencode',
+									models: {
+										'minimax-m2.5-free': { id: 'minimax-m2.5-free' },
+									},
+								},
+							],
+						},
+					}),
+				},
+			};
+
+			const result = await handleDoctorCommand(tempDir, [], { client });
+
+			expect(result).toContain('Configured model "opencode/removed-model"');
+			expect(result).toContain('Run `/models`');
+			expect(result).toContain('**Errors**: 1');
+		});
+
+		it('should report when OpenCode provider models cannot be loaded', async () => {
+			createTestConfig(tempDir, {
+				agents: {
+					coder: { model: 'opencode/minimax-m2.5-free' },
+				},
+			});
+
+			const client = {
+				config: {
+					providers: async () => ({
+						error: { name: 'ProviderRegistryError', message: 'unavailable' },
+					}),
+				},
+			};
+
+			const result = await handleDoctorCommand(tempDir, [], { client });
+
+			expect(result).toContain('Could not load OpenCode provider models');
+			expect(result).toContain('ProviderRegistryError');
+			expect(result).toContain('**Info**: 1');
+		});
+
+		it('should load available provider/model IDs from OpenCode config providers', async () => {
+			const availability = await loadModelAvailability(tempDir, {
+				config: {
+					providers: async () => ({
+						data: {
+							providers: [
+								{
+									id: 'opencode',
+									models: {
+										'big-pickle': { id: 'big-pickle' },
+										alias: { id: 'canonical-model' },
+									},
+								},
+							],
+						},
+					}),
+				},
+			});
+
+			expect(availability?.availableModelIds.has('opencode/big-pickle')).toBe(
+				true,
+			);
+			expect(availability?.availableModelIds.has('opencode/alias')).toBe(true);
+			expect(
+				availability?.availableModelIds.has('opencode/canonical-model'),
+			).toBe(true);
+		});
+
+		it('should report a provider lookup timeout as best-effort skipped validation', async () => {
+			const availability = await loadModelAvailability(
+				tempDir,
+				{
+					config: {
+						providers: async () => new Promise(() => {}),
+					},
+				},
+				{ timeoutMs: 5 },
+			);
+
+			expect(availability?.availableModelIds.size).toBe(0);
+			expect(availability?.error).toContain(
+				'OpenCode provider model registry lookup exceeded 5ms',
+			);
+		});
+
+		it('should report malformed provider registry data without throwing', async () => {
+			const availability = await loadModelAvailability(tempDir, {
+				config: {
+					providers: async () => ({
+						data: {
+							providers: { opencode: { models: {} } },
+						},
+					}),
+				},
+			});
+
+			expect(availability?.availableModelIds.size).toBe(0);
+			expect(availability?.error).toContain('malformed provider list');
 		});
 
 		it('should run config doctor with auto-fix flag', async () => {

--- a/src/commands/council.test.ts
+++ b/src/commands/council.test.ts
@@ -2,19 +2,57 @@
  * Tests for /swarm council command handler.
  */
 
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { handleCouncilCommand } from './council';
 
 describe('handleCouncilCommand', () => {
-	test('no args → returns usage string', async () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-council-test-'));
+		fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+		fs.writeFileSync(
+			path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+			JSON.stringify({ council: { general: { enabled: true } } }),
+		);
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test('no args returns usage string', async () => {
 		const result = await handleCouncilCommand('/tmp', []);
 		expect(result).toContain('Usage: /swarm council');
 		expect(result).toContain('--preset');
 		expect(result).toContain('--spec-review');
 	});
 
-	test('plain question → [MODE: COUNCIL] <question>', async () => {
-		const result = await handleCouncilCommand('/tmp', [
+	test('with question but disabled council returns enablement instructions', async () => {
+		const disabledDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), 'swarm-council-disabled-'),
+		);
+		try {
+			fs.mkdirSync(path.join(disabledDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(disabledDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({ council: { general: { enabled: false } } }),
+			);
+			const result = await handleCouncilCommand(disabledDir, ['Should', 'we?']);
+			expect(result).toContain('General Council is not enabled');
+			expect(result).toContain('"general": { "enabled": true }');
+			expect(result).toContain('/swarm config doctor');
+			expect(result).not.toContain('[MODE: COUNCIL]');
+		} finally {
+			fs.rmSync(disabledDir, { recursive: true, force: true });
+		}
+	});
+
+	test('plain question returns council mode header', async () => {
+		const result = await handleCouncilCommand(tempDir, [
 			'What',
 			'database',
 			'should',
@@ -24,8 +62,8 @@ describe('handleCouncilCommand', () => {
 		expect(result).toBe('[MODE: COUNCIL] What database should we use?');
 	});
 
-	test('--preset <name> "question" → [MODE: COUNCIL preset=<name>] <question>', async () => {
-		const result = await handleCouncilCommand('/tmp', [
+	test('preset flag adds preset to council mode header', async () => {
+		const result = await handleCouncilCommand(tempDir, [
 			'--preset',
 			'tech',
 			'Pick',
@@ -35,8 +73,8 @@ describe('handleCouncilCommand', () => {
 		expect(result).toBe('[MODE: COUNCIL preset=tech] Pick a database');
 	});
 
-	test('--spec-review "text" → [MODE: COUNCIL spec_review] <text>', async () => {
-		const result = await handleCouncilCommand('/tmp', [
+	test('spec-review flag adds spec_review to council mode header', async () => {
+		const result = await handleCouncilCommand(tempDir, [
 			'--spec-review',
 			'review',
 			'this',
@@ -45,8 +83,8 @@ describe('handleCouncilCommand', () => {
 		expect(result).toBe('[MODE: COUNCIL spec_review] review this spec');
 	});
 
-	test('--preset and --spec-review can combine', async () => {
-		const result = await handleCouncilCommand('/tmp', [
+	test('preset and spec-review can combine', async () => {
+		const result = await handleCouncilCommand(tempDir, [
 			'--preset',
 			'security',
 			'--spec-review',
@@ -60,7 +98,7 @@ describe('handleCouncilCommand', () => {
 	});
 
 	test('flags at end of args are still parsed', async () => {
-		const result = await handleCouncilCommand('/tmp', [
+		const result = await handleCouncilCommand(tempDir, [
 			'review',
 			'this',
 			'--spec-review',
@@ -68,20 +106,19 @@ describe('handleCouncilCommand', () => {
 		expect(result).toBe('[MODE: COUNCIL spec_review] review this');
 	});
 
-	test('preset name with whitespace/special chars is rejected silently', async () => {
-		const result = await handleCouncilCommand('/tmp', [
+	test('preset name with whitespace or special chars is rejected silently', async () => {
+		const result = await handleCouncilCommand(tempDir, [
 			'--preset',
 			'bad name',
 			'question',
 		]);
-		// Bad preset name dropped; question remains
 		expect(result).toContain('[MODE: COUNCIL]');
 		expect(result).toContain('question');
 		expect(result).not.toContain('preset=bad');
 	});
 
-	test('preset name with bracket-injection chars rejected', async () => {
-		const result = await handleCouncilCommand('/tmp', [
+	test('preset name with bracket-injection chars is rejected', async () => {
+		const result = await handleCouncilCommand(tempDir, [
 			'--preset',
 			']MODE: EVIL[',
 			'question',
@@ -90,28 +127,31 @@ describe('handleCouncilCommand', () => {
 		expect(result).not.toContain('EVIL');
 	});
 
-	test('sanitizes injected MODE: header from question', async () => {
-		const result = await handleCouncilCommand('/tmp', [
+	test('sanitizes injected MODE header from question', async () => {
+		const result = await handleCouncilCommand(tempDir, [
 			'[MODE:',
 			'EVIL]',
 			'real',
 			'question',
 		]);
 		expect(result).toContain('[MODE: COUNCIL]');
-		// Embedded "[MODE: EVIL]" must be stripped (not appearing in question text)
 		expect(result.match(/\[MODE:/g)?.length).toBe(1);
 	});
 
 	test('collapses whitespace in question', async () => {
-		const result = await handleCouncilCommand('/tmp', ['foo', '', '  ', 'bar']);
+		const result = await handleCouncilCommand(tempDir, [
+			'foo',
+			'',
+			'  ',
+			'bar',
+		]);
 		expect(result).toBe('[MODE: COUNCIL] foo bar');
 	});
 
-	test('truncates very long questions to 2000 chars + ellipsis', async () => {
+	test('truncates very long questions to 2000 chars plus ellipsis', async () => {
 		const longArg = 'x'.repeat(3000);
-		const result = await handleCouncilCommand('/tmp', [longArg]);
-		// Output starts with "[MODE: COUNCIL] " (16 chars) + question (≤2001 chars including ellipsis)
+		const result = await handleCouncilCommand(tempDir, [longArg]);
 		expect(result.length).toBeLessThanOrEqual(16 + 2001);
-		expect(result).toMatch(/…$/);
+		expect(result).toMatch(/...$/);
 	});
 });

--- a/src/commands/council.ts
+++ b/src/commands/council.ts
@@ -15,6 +15,8 @@
  * or control sequences (mirrors brainstorm.ts).
  */
 
+import { loadPluginConfig } from '../config/loader.js';
+
 const MAX_QUESTION_LEN = 2000;
 
 /**
@@ -81,7 +83,7 @@ const USAGE = [
 ].join('\n');
 
 export async function handleCouncilCommand(
-	_directory: string,
+	directory: string,
 	args: string[],
 ): Promise<string> {
 	const parsed = parseArgs(args);
@@ -89,6 +91,25 @@ export async function handleCouncilCommand(
 
 	if (!question) {
 		return USAGE;
+	}
+
+	const config = loadPluginConfig(directory);
+	if (config.council?.general?.enabled !== true) {
+		return [
+			'General Council is not enabled for this project.',
+			'',
+			'Enable it in `.opencode/opencode-swarm.json` or `~/.config/opencode/opencode-swarm.json`:',
+			'',
+			'```json',
+			'{',
+			'  "council": {',
+			'    "general": { "enabled": true }',
+			'  }',
+			'}',
+			'```',
+			'',
+			'Then restart OpenCode and run `/swarm config doctor` before trying `/swarm council` again.',
+		].join('\n');
 	}
 
 	const tokens: string[] = ['MODE: COUNCIL'];

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,9 +1,28 @@
 import { loadPluginConfig } from '../config/loader';
 import {
 	type ConfigDoctorResult,
+	type ModelAvailability,
 	runConfigDoctor,
 } from '../services/config-doctor';
 import { runToolDoctor } from '../services/tool-doctor';
+import { withTimeout } from '../utils/timeout';
+
+type ProviderModelClient = {
+	config?: {
+		providers?: (parameters?: { directory?: string }) => Promise<{
+			data?: {
+				providers?: Array<{
+					id?: string;
+					models?: Record<string, { id?: string }>;
+				}>;
+			};
+			error?: unknown;
+		}>;
+	};
+};
+
+const MODEL_REGISTRY_TIMEOUT_MS = 3_000;
+const MODEL_REGISTRY_SOURCE = 'OpenCode config.providers';
 
 /**
  * Format tool doctor result as markdown for command output.
@@ -122,6 +141,89 @@ function formatDoctorMarkdown(result: ConfigDoctorResult): string {
 	return lines.join('\n');
 }
 
+function extractAvailableModelIds(
+	response: Awaited<
+		ReturnType<
+			NonNullable<NonNullable<ProviderModelClient['config']>['providers']>
+		>
+	>['data'],
+): Set<string> {
+	const available = new Set<string>();
+	if (response?.providers !== undefined && !Array.isArray(response.providers)) {
+		throw new Error('provider registry returned malformed provider list');
+	}
+	for (const provider of response?.providers ?? []) {
+		if (
+			!provider ||
+			typeof provider !== 'object' ||
+			!provider.id ||
+			!provider.models ||
+			typeof provider.models !== 'object' ||
+			Array.isArray(provider.models)
+		) {
+			continue;
+		}
+		for (const [modelKey, modelInfo] of Object.entries(provider.models)) {
+			available.add(`${provider.id}/${modelKey}`);
+			if (modelInfo && typeof modelInfo === 'object' && modelInfo.id) {
+				available.add(`${provider.id}/${modelInfo.id}`);
+			}
+		}
+	}
+	return available;
+}
+
+export async function loadModelAvailability(
+	directory: string,
+	client: unknown,
+	options: { timeoutMs?: number } = {},
+): Promise<ModelAvailability | undefined> {
+	const providerClient = client as ProviderModelClient | undefined;
+	const providers = providerClient?.config?.providers;
+	if (typeof providers !== 'function') {
+		return undefined;
+	}
+
+	try {
+		const response = await withTimeout(
+			providers({ directory }),
+			options.timeoutMs ?? MODEL_REGISTRY_TIMEOUT_MS,
+			new Error(
+				`OpenCode provider model registry lookup exceeded ${
+					options.timeoutMs ?? MODEL_REGISTRY_TIMEOUT_MS
+				}ms`,
+			),
+		);
+		if (response.error) {
+			return {
+				availableModelIds: new Set<string>(),
+				source: MODEL_REGISTRY_SOURCE,
+				error:
+					typeof response.error === 'string'
+						? response.error
+						: JSON.stringify(response.error),
+			};
+		}
+		if (!response.data) {
+			return {
+				availableModelIds: new Set<string>(),
+				source: MODEL_REGISTRY_SOURCE,
+				error: 'provider registry returned no data',
+			};
+		}
+		return {
+			availableModelIds: extractAvailableModelIds(response.data),
+			source: MODEL_REGISTRY_SOURCE,
+		};
+	} catch (error) {
+		return {
+			availableModelIds: new Set<string>(),
+			source: MODEL_REGISTRY_SOURCE,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
 /**
  * Handle /swarm config doctor command.
  * Maps to: config doctor service (runConfigDoctor)
@@ -129,11 +231,17 @@ function formatDoctorMarkdown(result: ConfigDoctorResult): string {
 export async function handleDoctorCommand(
 	directory: string,
 	args: string[],
+	options: { client?: unknown } = {},
 ): Promise<string> {
 	const enableAutoFix = args.includes('--fix') || args.includes('-f');
 
 	const config = loadPluginConfig(directory);
-	const result = runConfigDoctor(config, directory);
+	const modelAvailability = await loadModelAvailability(
+		directory,
+		options.client,
+	);
+	const doctorOptions = { modelAvailability };
+	const result = runConfigDoctor(config, directory, doctorOptions);
 
 	// If auto-fix is requested and there are auto-fixable issues
 	if (enableAutoFix && result.hasAutoFixableIssues) {
@@ -141,7 +249,12 @@ export async function handleDoctorCommand(
 		const { runConfigDoctorWithFixes } = await import(
 			'../services/config-doctor'
 		);
-		const fixResult = await runConfigDoctorWithFixes(directory, config, true);
+		const fixResult = await runConfigDoctorWithFixes(
+			directory,
+			config,
+			true,
+			doctorOptions,
+		);
 		return formatDoctorMarkdown(fixResult.result);
 	}
 

--- a/src/commands/first-run.test.ts
+++ b/src/commands/first-run.test.ts
@@ -285,10 +285,11 @@ describe('Error handling catch block', () => {
 			output,
 		);
 
-		// Should return help text, not an error
+		// Should return an unknown-command suggestion, not an execution error
 		expect(output.parts).toHaveLength(1);
 		const text = (output.parts[0] as { text: string }).text;
-		expect(text).toContain('## Swarm Commands');
+		expect(text).toContain('Command `/swarm nonexistentcommand` not found.');
+		expect(text).toContain('Run `/swarm help` for all commands.');
 		// Should NOT contain error prefix
 		expect(text).not.toContain('Error executing /swarm');
 	});
@@ -308,9 +309,9 @@ describe('Error handling catch block', () => {
 
 		expect(output.parts).toHaveLength(1);
 		const text = (output.parts[0] as { text: string }).text;
-		expect(text).toContain('## Swarm Commands');
-		// This is not an error - the command just isn't registered
-		// so help text is shown
+		expect(text).toContain('Command `/swarm definitelynotacommand` not found.');
+		expect(text).toContain('Run `/swarm help` for all commands.');
+		// This is not an error - the command just isn't registered.
 		expect(text).not.toContain('Error executing');
 	});
 });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -222,6 +222,7 @@ export function buildHelpText(): string {
 export function createSwarmCommandHandler(
 	directory: string,
 	agents: Record<string, AgentDefinition>,
+	client?: unknown,
 ): (
 	input: { command: string; sessionID: string; arguments: string },
 	output: { parts: unknown[] },
@@ -299,6 +300,7 @@ export function createSwarmCommandHandler(
 					args: resolved.remainingArgs,
 					sessionID: input.sessionID,
 					agents,
+					client,
 				});
 			} catch (_err) {
 				const cmdName = tokens[0] || 'unknown';
@@ -317,7 +319,9 @@ export function createSwarmCommandHandler(
 			const welcomeMessage =
 				`Welcome to OpenCode Swarm! 🐝\n` +
 				`\n` +
-				`Run \`/swarm help\` to see all available commands, or \`/swarm config\` to review your configuration.\n`;
+				`Start here: run \`/swarm diagnose\`, then \`/swarm agents\` to confirm the plugin loaded and see the exact models in use.\n` +
+				`If a model is unavailable, edit \`.opencode/opencode-swarm.json\` or \`~/.config/opencode/opencode-swarm.json\` and run \`/swarm config doctor\`.\n` +
+				`Useful next steps: \`/swarm brainstorm <task>\` for guided planning, \`/swarm full-auto on\` for autonomous runs after enabling it in config, and \`/swarm council <question>\` after enabling council.general.\n\n`;
 			text = welcomeMessage + text;
 		}
 

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -190,6 +190,7 @@ export type CommandContext = {
 	args: string[];
 	sessionID: string;
 	agents: Record<string, AgentDefinition>;
+	client?: unknown;
 };
 
 export type CommandResult = Promise<string>;
@@ -289,7 +290,8 @@ export const COMMAND_REGISTRY = {
 		clashesWithNativeCcCommand: '/config',
 	},
 	'config doctor': {
-		handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args),
+		handler: (ctx) =>
+			handleDoctorCommand(ctx.directory, ctx.args, { client: ctx.client }),
 		description: 'Run config doctor checks',
 		subcommandOf: 'config',
 		category: 'diagnostics',
@@ -297,7 +299,8 @@ export const COMMAND_REGISTRY = {
 	// Alias for TUI shortcut 'swarm-config-doctor' which extracts subcommand as 'config-doctor' (dash).
 	// Without this alias the shortcut resolves to null and shows help text instead of running the command.
 	'config-doctor': {
-		handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args),
+		handler: (ctx) =>
+			handleDoctorCommand(ctx.directory, ctx.args, { client: ctx.client }),
 		description: 'Run config doctor checks',
 		subcommandOf: 'config',
 		category: 'diagnostics',
@@ -380,7 +383,8 @@ export const COMMAND_REGISTRY = {
 	},
 	// Deprecation aliases for confusing command names
 	doctor: {
-		handler: (ctx) => handleDoctorCommand(ctx.directory, ctx.args),
+		handler: (ctx) =>
+			handleDoctorCommand(ctx.directory, ctx.args, { client: ctx.client }),
 		description: 'Run config doctor checks',
 		category: 'diagnostics',
 		aliasOf: 'config doctor',

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -475,7 +475,6 @@ export const AGENT_TOOL_MAP: Record<AgentName, ToolName[]> = {
 		'search',
 		'doc_scan',
 		'doc_extract',
-		'web_search',
 	],
 	// v2: spec_writer — independent agent for authoring .swarm/spec.md. Has
 	// read tools and the safe spec_write tool only.
@@ -642,9 +641,9 @@ for (const [agentName, tools] of Object.entries(AGENT_TOOL_MAP)) {
 	}
 }
 
-// Default models for each agent/category
-// v6.14: switched to free OpenCode Zen models; architect key intentionally
-// omitted so it inherits the OpenCode UI model selection.
+// Default models for each agent/category.
+// Keep these on the public OpenCode Zen free roster. The architect key is
+// intentionally omitted so it inherits the OpenCode UI model selection.
 export const DEFAULT_MODELS: Record<string, string> = {
 	// Explorer — fast read-heavy analysis
 	explorer: 'opencode/big-pickle',
@@ -652,21 +651,21 @@ export const DEFAULT_MODELS: Record<string, string> = {
 	// Pipeline agents — differentiated models for writing vs reviewing
 	coder: 'opencode/minimax-m2.5-free',
 	reviewer: 'opencode/big-pickle',
-	test_engineer: 'opencode/gpt-5-nano',
+	test_engineer: 'opencode/big-pickle',
 
 	// SME, Critic variants, Docs, Designer — reasoning/general tasks
 	sme: 'opencode/big-pickle',
 	critic: 'opencode/big-pickle',
-	critic_sounding_board: 'opencode/gpt-5-nano',
-	critic_drift_verifier: 'opencode/gpt-5-nano',
-	critic_hallucination_verifier: 'opencode/gpt-5-nano',
-	critic_oversight: 'opencode/gpt-5-nano',
+	critic_sounding_board: 'opencode/big-pickle',
+	critic_drift_verifier: 'opencode/big-pickle',
+	critic_hallucination_verifier: 'opencode/big-pickle',
+	critic_oversight: 'opencode/big-pickle',
 	docs: 'opencode/big-pickle',
 	designer: 'opencode/big-pickle',
 
 	// Curator agents — lightweight read-only analysis (same model family as explorer)
-	curator_init: 'opencode/gpt-5-nano',
-	curator_phase: 'opencode/gpt-5-nano',
+	curator_init: 'opencode/big-pickle',
+	curator_phase: 'opencode/big-pickle',
 
 	// v2: Skill improver — defaults to a strong reasoning model, but is gated
 	// behind skill_improver.enabled and a daily quota (issue #629).
@@ -690,67 +689,67 @@ export const DEFAULT_AGENT_CONFIGS: Record<
 > = {
 	coder: {
 		model: 'opencode/minimax-m2.5-free',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
+		fallback_models: ['opencode/big-pickle'],
 	},
 	reviewer: {
 		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	test_engineer: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
+		model: 'opencode/big-pickle',
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	explorer: {
 		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	sme: {
 		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	critic: {
 		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	docs: {
 		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	designer: {
 		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	critic_sounding_board: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
+		model: 'opencode/big-pickle',
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	critic_drift_verifier: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
+		model: 'opencode/big-pickle',
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	critic_hallucination_verifier: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
+		model: 'opencode/big-pickle',
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	critic_oversight: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
+		model: 'opencode/big-pickle',
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	curator_init: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
+		model: 'opencode/big-pickle',
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	curator_phase: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
+		model: 'opencode/big-pickle',
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	skill_improver: {
 		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano'],
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 	spec_writer: {
 		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano'],
+		fallback_models: ['opencode/minimax-m2.5-free'],
 	},
 };
 

--- a/src/config/project-init.ts
+++ b/src/config/project-init.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { DEFAULT_MODELS } from './constants';
+import { DEFAULT_AGENT_CONFIGS } from './constants';
 
 const STARTER_CONTENT = '{}\n';
 
@@ -68,17 +68,7 @@ export function writeSwarmConfigExampleIfNew(projectDirectory: string): void {
 			fs.mkdirSync(swarmDir, { recursive: true });
 		}
 		const example = {
-			agents: Object.fromEntries(
-				Object.entries(DEFAULT_MODELS)
-					.filter(([name]) => name !== 'default')
-					.map(([name, model]) => [
-						name,
-						{
-							model,
-							fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
-						},
-					]),
-			),
+			agents: DEFAULT_AGENT_CONFIGS,
 			max_iterations: 5,
 		};
 		fs.writeFileSync(dest, `${JSON.stringify(example, null, 2)}\n`, 'utf-8');

--- a/src/index.ts
+++ b/src/index.ts
@@ -447,6 +447,7 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 	const commandHandler = createSwarmCommandHandler(
 		ctx.directory,
 		Object.fromEntries(agentDefinitions.map((agent) => [agent.name, agent])),
+		ctx.client,
 	);
 	const activityHooks = createAgentActivityHooks(config, ctx.directory);
 	const prmHook = createPrmHook(

--- a/src/services/config-doctor.test.ts
+++ b/src/services/config-doctor.test.ts
@@ -7,6 +7,7 @@ import {
 	applySafeAutoFixes,
 	type ConfigBackup,
 	type ConfigDoctorResult,
+	collectConfiguredModelRefs,
 	createConfigBackup,
 	getConfigPaths,
 	restoreFromBackup,
@@ -220,6 +221,156 @@ describe('Config Doctor Service', () => {
 			expect(result.findings.some((f) => f.id === 'unknown-swarm-agent')).toBe(
 				true,
 			);
+		});
+
+		it('should collect configured model refs across agents, swarms, fallbacks, and council presets', () => {
+			const config = createTestConfigObj({
+				agents: {
+					coder: {
+						model: 'opencode/minimax-m2.5-free',
+						fallback_models: ['opencode/big-pickle'],
+					},
+				},
+				swarms: {
+					mega: {
+						agents: {
+							critic: { model: 'openai/gpt-5.4' },
+						},
+					},
+				},
+				full_auto: {
+					enabled: true,
+					critic_model: 'openai/gpt-5.5',
+				},
+				council: {
+					general: {
+						enabled: true,
+						members: [
+							{
+								name: 'skeptic',
+								model: 'anthropic/claude-opus-4-5',
+								role: 'skeptic',
+							},
+						],
+						presets: {
+							review: [
+								{
+									name: 'generalist',
+									model: 'google/gemini-3-pro',
+									role: 'generalist',
+								},
+							],
+						},
+						moderatorModel: 'openai/gpt-5.4',
+					},
+				},
+			});
+
+			const refs = collectConfiguredModelRefs(config);
+
+			expect(
+				refs.get('opencode/minimax-m2.5-free')?.has('agents.coder.model'),
+			).toBe(true);
+			expect(
+				refs.get('opencode/big-pickle')?.has('agents.coder.fallback_models[0]'),
+			).toBe(true);
+			expect(
+				refs.get('openai/gpt-5.4')?.has('swarms.mega.agents.critic.model'),
+			).toBe(true);
+			expect(refs.get('openai/gpt-5.5')?.has('full_auto.critic_model')).toBe(
+				true,
+			);
+			expect(
+				refs
+					.get('anthropic/claude-opus-4-5')
+					?.has('council.general.members[0].model'),
+			).toBe(true);
+			expect(
+				refs
+					.get('google/gemini-3-pro')
+					?.has('council.general.presets.review[0].model'),
+			).toBe(true);
+			expect(
+				refs.get('openai/gpt-5.4')?.has('council.general.moderatorModel'),
+			).toBe(true);
+		});
+
+		it('should report configured models missing from the active provider registry', () => {
+			const config = createTestConfigObj({
+				agents: {
+					coder: {
+						model: 'opencode/minimax-m2.5-free',
+						fallback_models: ['opencode/missing-free'],
+					},
+					critic: { model: 'grove-openai/private-preview' },
+				},
+			});
+
+			const result = runConfigDoctor(config, tempDir, {
+				modelAvailability: {
+					availableModelIds: new Set(['opencode/minimax-m2.5-free']),
+					source: 'test provider registry',
+				},
+			});
+
+			const missing = result.findings.filter(
+				(f) => f.id === 'configured-model-unavailable',
+			);
+			expect(missing).toHaveLength(2);
+			expect(missing.map((f) => f.currentValue).sort()).toEqual([
+				'grove-openai/private-preview',
+				'opencode/missing-free',
+			]);
+			expect(result.summary.error).toBe(2);
+			expect(missing[0]!.autoFixable).toBe(false);
+		});
+
+		it('should escape user-controlled model IDs in doctor descriptions', () => {
+			const hostileModelId = 'opencode/bad-model\n**fake heading**';
+			const config = createTestConfigObj({
+				agents: {
+					coder: { model: hostileModelId },
+				},
+			});
+
+			const result = runConfigDoctor(config, tempDir, {
+				modelAvailability: {
+					availableModelIds: new Set(),
+					source: 'test provider registry',
+				},
+			});
+
+			const finding = result.findings.find(
+				(f) => f.id === 'configured-model-unavailable',
+			);
+			expect(finding).toBeDefined();
+			expect(finding!.description).toContain(
+				'"opencode/bad-model\\n**fake heading**"',
+			);
+			expect(finding!.description).not.toContain(hostileModelId);
+			expect(finding!.currentValue).toBe(hostileModelId);
+		});
+
+		it('should surface provider registry lookup failures without blocking other checks', () => {
+			const config = createTestConfigObj({
+				agents: {
+					coder: { model: 'opencode/minimax-m2.5-free' },
+				},
+			});
+
+			const result = runConfigDoctor(config, tempDir, {
+				modelAvailability: {
+					availableModelIds: new Set(),
+					source: 'test provider registry',
+					error: 'local OpenCode server unavailable',
+				},
+			});
+
+			expect(
+				result.findings.some((f) => f.id === 'model-availability-unchecked'),
+			).toBe(true);
+			expect(result.summary.info).toBe(1);
+			expect(result.summary.error).toBe(0);
 		});
 	});
 

--- a/src/services/config-doctor.ts
+++ b/src/services/config-doctor.ts
@@ -78,6 +78,20 @@ export interface ConfigDoctorResult {
 	configSource: string;
 }
 
+/** Model availability snapshot from the active OpenCode provider registry. */
+export interface ModelAvailability {
+	/** Fully-qualified model IDs in provider/model form. */
+	availableModelIds: ReadonlySet<string>;
+	/** Human-readable source for diagnostics. */
+	source: string;
+	/** Optional failure message when the registry could not be loaded. */
+	error?: string;
+}
+
+export interface ConfigDoctorOptions {
+	modelAvailability?: ModelAvailability;
+}
+
 /** Backup artifact for rollback */
 export interface ConfigBackup {
 	/** When the backup was created */
@@ -627,6 +641,214 @@ function validateConfigKey(
 	return findings;
 }
 
+function addConfiguredModel(
+	refs: Map<string, Set<string>>,
+	model: unknown,
+	configPath: string,
+): void {
+	if (typeof model !== 'string') return;
+	const trimmed = model.trim();
+	if (!trimmed) return;
+	const paths = refs.get(trimmed) ?? new Set<string>();
+	paths.add(configPath);
+	refs.set(trimmed, paths);
+}
+
+function addConfiguredAgentModels(
+	refs: Map<string, Set<string>>,
+	agents: unknown,
+	prefix: string,
+): void {
+	if (!agents || typeof agents !== 'object' || Array.isArray(agents)) return;
+
+	for (const [agentName, value] of Object.entries(
+		agents as Record<string, unknown>,
+	)) {
+		if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+		const agent = value as Record<string, unknown>;
+		addConfiguredModel(refs, agent.model, `${prefix}.${agentName}.model`);
+		if (Array.isArray(agent.fallback_models)) {
+			agent.fallback_models.forEach((model, index) => {
+				addConfiguredModel(
+					refs,
+					model,
+					`${prefix}.${agentName}.fallback_models[${index}]`,
+				);
+			});
+		}
+	}
+}
+
+export function collectConfiguredModelRefs(
+	config: PluginConfig,
+): Map<string, Set<string>> {
+	const refs = new Map<string, Set<string>>();
+	const rawConfig = config as unknown as Record<string, unknown>;
+
+	addConfiguredAgentModels(refs, rawConfig.agents, 'agents');
+
+	if (
+		rawConfig.swarms &&
+		typeof rawConfig.swarms === 'object' &&
+		!Array.isArray(rawConfig.swarms)
+	) {
+		for (const [swarmId, value] of Object.entries(
+			rawConfig.swarms as Record<string, unknown>,
+		)) {
+			if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+			addConfiguredAgentModels(
+				refs,
+				(value as Record<string, unknown>).agents,
+				`swarms.${swarmId}.agents`,
+			);
+		}
+	}
+
+	if (
+		rawConfig.full_auto &&
+		typeof rawConfig.full_auto === 'object' &&
+		!Array.isArray(rawConfig.full_auto)
+	) {
+		addConfiguredModel(
+			refs,
+			(rawConfig.full_auto as Record<string, unknown>).critic_model,
+			'full_auto.critic_model',
+		);
+	}
+
+	if (
+		rawConfig.skill_improver &&
+		typeof rawConfig.skill_improver === 'object' &&
+		!Array.isArray(rawConfig.skill_improver)
+	) {
+		const skillImprover = rawConfig.skill_improver as Record<string, unknown>;
+		addConfiguredModel(refs, skillImprover.model, 'skill_improver.model');
+		if (Array.isArray(skillImprover.fallback_models)) {
+			skillImprover.fallback_models.forEach((model, index) => {
+				addConfiguredModel(
+					refs,
+					model,
+					`skill_improver.fallback_models[${index}]`,
+				);
+			});
+		}
+	}
+
+	if (
+		rawConfig.spec_writer &&
+		typeof rawConfig.spec_writer === 'object' &&
+		!Array.isArray(rawConfig.spec_writer)
+	) {
+		const specWriter = rawConfig.spec_writer as Record<string, unknown>;
+		addConfiguredModel(refs, specWriter.model, 'spec_writer.model');
+		if (Array.isArray(specWriter.fallback_models)) {
+			specWriter.fallback_models.forEach((model, index) => {
+				addConfiguredModel(
+					refs,
+					model,
+					`spec_writer.fallback_models[${index}]`,
+				);
+			});
+		}
+	}
+
+	const council = rawConfig.council as Record<string, unknown> | undefined;
+	const general =
+		council && typeof council === 'object' && !Array.isArray(council)
+			? (council.general as Record<string, unknown> | undefined)
+			: undefined;
+	if (general && typeof general === 'object' && !Array.isArray(general)) {
+		addConfiguredModel(
+			refs,
+			general.moderatorModel,
+			'council.general.moderatorModel',
+		);
+		if (Array.isArray(general.members)) {
+			general.members.forEach((member, index) => {
+				if (!member || typeof member !== 'object' || Array.isArray(member)) {
+					return;
+				}
+				addConfiguredModel(
+					refs,
+					(member as Record<string, unknown>).model,
+					`council.general.members[${index}].model`,
+				);
+			});
+		}
+		if (
+			general.presets &&
+			typeof general.presets === 'object' &&
+			!Array.isArray(general.presets)
+		) {
+			for (const [presetName, members] of Object.entries(
+				general.presets as Record<string, unknown>,
+			)) {
+				if (!Array.isArray(members)) continue;
+				members.forEach((member, index) => {
+					if (!member || typeof member !== 'object' || Array.isArray(member)) {
+						return;
+					}
+					addConfiguredModel(
+						refs,
+						(member as Record<string, unknown>).model,
+						`council.general.presets.${presetName}[${index}].model`,
+					);
+				});
+			}
+		}
+	}
+
+	return refs;
+}
+
+function validateConfiguredModels(
+	config: PluginConfig,
+	modelAvailability: ModelAvailability,
+): ConfigFinding[] {
+	const refs = collectConfiguredModelRefs(config);
+	const findings: ConfigFinding[] = [];
+
+	if (modelAvailability.error) {
+		findings.push({
+			id: 'model-availability-unchecked',
+			title: 'Model availability check skipped',
+			description:
+				`Could not load OpenCode provider models from ${modelAvailability.source}: ` +
+				modelAvailability.error,
+			severity: 'info',
+			path: 'agents',
+			autoFixable: false,
+		});
+		return findings;
+	}
+
+	if (refs.size === 0) return findings;
+
+	for (const [modelId, paths] of refs.entries()) {
+		if (modelAvailability.availableModelIds.has(modelId)) continue;
+		findings.push({
+			id: 'configured-model-unavailable',
+			title: 'Configured model is unavailable',
+			description:
+				`Configured model ${formatModelIdForDoctor(modelId)} was not found in the active OpenCode provider model registry. ` +
+				'Run `/models` to choose a currently available model, then update opencode-swarm.json.',
+			severity: 'error',
+			path: [...paths].sort().join(', '),
+			currentValue: modelId,
+			autoFixable: false,
+		});
+	}
+
+	return findings;
+}
+
+function formatModelIdForDoctor(modelId: string): string {
+	const json = JSON.stringify(modelId);
+	if (!json) return '"<invalid model id>"';
+	if (json.length <= 160) return json;
+	return `${json.slice(0, 157)}..."`;
+}
+
 /**
  * Recursively walk a config object and validate all keys
  */
@@ -674,11 +896,17 @@ function walkConfigAndValidate(
 export function runConfigDoctor(
 	config: PluginConfig,
 	directory: string,
+	options: ConfigDoctorOptions = {},
 ): ConfigDoctorResult {
 	const findings: ConfigFinding[] = [];
 
 	// Walk the config and validate
 	walkConfigAndValidate(config, '', config, findings);
+	if (options.modelAvailability) {
+		findings.push(
+			...validateConfiguredModels(config, options.modelAvailability),
+		);
+	}
 
 	// Count by severity
 	const summary = {
@@ -967,6 +1195,7 @@ export async function runConfigDoctorWithFixes(
 	directory: string,
 	config: PluginConfig,
 	autoFix: boolean = false,
+	options: ConfigDoctorOptions = {},
 ): Promise<{
 	result: ConfigDoctorResult;
 	backupPath: string | null;
@@ -975,7 +1204,7 @@ export async function runConfigDoctorWithFixes(
 	artifactPath: string | null;
 }> {
 	// Run the doctor
-	const result = runConfigDoctor(config, directory);
+	const result = runConfigDoctor(config, directory, options);
 
 	// Write artifact
 	const artifactPath = writeDoctorArtifact(directory, result);
@@ -1013,6 +1242,7 @@ export async function runConfigDoctorWithFixes(
 			const newResult = runConfigDoctor(
 				freshConfig.config as unknown as PluginConfig,
 				directory,
+				options,
 			);
 			writeDoctorArtifact(directory, newResult);
 		}

--- a/tests/unit/cli/install-default-agent-configs.test.ts
+++ b/tests/unit/cli/install-default-agent-configs.test.ts
@@ -47,9 +47,8 @@ describe('DEFAULT_AGENT_CONFIGS', () => {
 			}
 		});
 
-		// Note: The same model may appear in both model and fallback_models by design
-		// (e.g. big-pickle as primary and gpt-5-nano with big-pickle as fallback).
-		// This is intentional - big-pickle is a reliable fallback target.
+		// Note: starter defaults should stay on public Zen free models so fresh
+		// installs do not strand users on paid, private, or removed providers.
 	});
 
 	describe('coverage', () => {

--- a/tests/unit/commands/agents.test.ts
+++ b/tests/unit/commands/agents.test.ts
@@ -7,7 +7,22 @@ import type { GuardrailsConfig } from '../../../src/config/schema';
 /** Generate the unregistered subagents list string for test assertions */
 function unregisteredList(names: readonly string[]): string {
 	return (
-		'\n' + names.map((n) => `- **${n}** (requires configuration)`).join('\n')
+		'\n' +
+		names
+			.map((n) => {
+				const hints: Record<string, string> = {
+					designer: 'enable ui_review.enabled',
+					council_generalist: 'enable council.general.enabled',
+					council_skeptic: 'enable council.general.enabled',
+					council_domain_expert: 'enable council.general.enabled',
+					skill_improver:
+						'registered by default unless agents.skill_improver.disabled is true',
+					spec_writer:
+						'registered by default unless agents.spec_writer.disabled is true',
+				};
+				return `- **${n}** (${hints[n] ?? 'requires configuration'})`;
+			})
+			.join('\n')
 	);
 }
 
@@ -649,7 +664,7 @@ describe('unregistered subagents', () => {
 		expect(result).not.toContain('### Unregistered Subagents');
 	});
 
-	test('When some subagents are missing, they appear in unregistered section with "requires configuration" label', () => {
+	test('When some subagents are missing, they appear in unregistered section with enablement hints', () => {
 		// Only register 'coder' and 'explorer' — rest are missing
 		const partialAgents: Record<string, AgentDefinition> = {
 			coder: {
@@ -673,13 +688,19 @@ describe('unregistered subagents', () => {
 		);
 		// Unregistered section should exist
 		expect(result).toContain('### Unregistered Subagents');
-		// Each unregistered subagent should have "(requires configuration)" label
 		const missingSubagents = ALL_SUBAGENT_NAMES.filter(
 			(n) => n !== 'coder' && n !== 'explorer',
 		);
 		for (const name of missingSubagents) {
-			expect(result).toContain(`**${name}** (requires configuration)`);
+			expect(result).toContain(`**${name}** (`);
 		}
+		expect(result).toContain(
+			'**council_generalist** (enable council.general.enabled)',
+		);
+		expect(result).toContain('**designer** (enable ui_review.enabled)');
+		expect(result).toContain(
+			'**skill_improver** (registered by default unless agents.skill_improver.disabled is true)',
+		);
 	});
 
 	test('Shows read-write for agents without tool restrictions', () => {
@@ -728,7 +749,7 @@ describe('unregistered subagents', () => {
 		expect(result).toContain('### Unregistered Subagents');
 		// All ALL_SUBAGENT_NAMES listed as unregistered
 		for (const name of ALL_SUBAGENT_NAMES) {
-			expect(result).toContain(`**${name}** (requires configuration)`);
+			expect(result).toContain(`**${name}** (`);
 		}
 	});
 });
@@ -745,7 +766,7 @@ describe('prefixed agent name matching', () => {
 
 		const result = handleAgentsCommand(agents);
 
-		expect(result).not.toContain('**coder** (requires configuration)');
+		expect(result).not.toContain('**coder** (');
 	});
 
 	test('local_ prefixed agent counts as its base name being registered', () => {
@@ -759,7 +780,7 @@ describe('prefixed agent name matching', () => {
 
 		const result = handleAgentsCommand(agents);
 
-		expect(result).not.toContain('**reviewer** (requires configuration)');
+		expect(result).not.toContain('**reviewer** (');
 	});
 
 	test('all subagents registered via prefix variants shows "N total" header', () => {

--- a/tests/unit/config/multilevel-fallback.test.ts
+++ b/tests/unit/config/multilevel-fallback.test.ts
@@ -1,271 +1,74 @@
 import { describe, expect, test } from 'bun:test';
-import { z } from 'zod';
+import {
+	DEFAULT_AGENT_CONFIGS,
+	DEFAULT_MODELS,
+} from '../../../src/config/constants';
+import { AgentOverrideConfigSchema } from '../../../src/config/schema';
 
-/**
- * Test suite for multi-level fallback configuration (v6.85+)
- *
- * Validates that:
- * 1. Default agent configs have 2-level fallback chains for primary agents
- * 2. Fallback chains only use consistently-available models (big-pickle, gpt-5-nano)
- * 3. Schema constraints are respected (max 3 fallbacks per agent)
- * 4. Fallback chains provide meaningful recovery paths
- */
+const PUBLIC_FREE_ZEN_MODELS = new Set([
+	'opencode/big-pickle',
+	'opencode/minimax-m2.5-free',
+]);
 
-// Schema from src/config/schema.ts
-const AgentOverrideConfigSchema = z.object({
-	model: z.string().optional(),
-	temperature: z.number().min(0).max(2).optional(),
-	disabled: z.boolean().optional(),
-	fallback_models: z.array(z.string()).max(3).optional(),
-});
+const REMOVED_OR_PAID_STARTER_MODELS = [
+	'opencode/trinity-large-preview-free',
+	'opencode/gpt-5-nano',
+];
 
-type AgentOverrideConfig = z.infer<typeof AgentOverrideConfigSchema>;
-
-// Default config from src/cli/index.ts (lines 146-211)
-const DEFAULT_AGENTS: Record<string, AgentOverrideConfig> = {
-	coder: {
-		model: 'opencode/minimax-m2.5-free',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
-	},
-	reviewer: {
-		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
-	},
-	test_engineer: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
-	},
-	explorer: {
-		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
-	},
-	sme: {
-		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
-	},
-	critic: {
-		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
-	},
-	docs: {
-		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
-	},
-	designer: {
-		model: 'opencode/big-pickle',
-		fallback_models: ['opencode/gpt-5-nano', 'opencode/big-pickle'],
-	},
-	critic_sounding_board: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
-	},
-	critic_drift_verifier: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
-	},
-	critic_hallucination_verifier: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
-	},
-	critic_oversight: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
-	},
-	curator_init: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
-	},
-	curator_phase: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
-	},
-	council_member: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
-	},
-	council_moderator: {
-		model: 'opencode/gpt-5-nano',
-		fallback_models: ['opencode/big-pickle'],
-	},
-};
-
-describe('Multi-Level Fallback Configuration', () => {
-	test('All default agents have valid schema-compliant configurations', () => {
-		for (const [agent, config] of Object.entries(DEFAULT_AGENTS)) {
+describe('starter model configuration', () => {
+	test('all default agent configs are schema-compliant', () => {
+		for (const [agent, config] of Object.entries(DEFAULT_AGENT_CONFIGS)) {
 			const result = AgentOverrideConfigSchema.safeParse(config);
-			expect(result.success).toBe(true);
-			if (!result.success) {
-				console.error(
-					`Agent ${agent} failed validation:`,
-					result.error.message,
+			expect(result.success, `${agent} should validate`).toBe(true);
+		}
+	});
+
+	test('starter configs only use public free Zen models', () => {
+		for (const [agent, config] of Object.entries(DEFAULT_AGENT_CONFIGS)) {
+			expect(
+				PUBLIC_FREE_ZEN_MODELS.has(config.model),
+				`${agent} primary model ${config.model} should be starter-safe`,
+			).toBe(true);
+
+			for (const fallback of config.fallback_models) {
+				expect(
+					PUBLIC_FREE_ZEN_MODELS.has(fallback),
+					`${agent} fallback model ${fallback} should be starter-safe`,
+				).toBe(true);
+			}
+		}
+	});
+
+	test('default model map excludes removed or paid starter traps', () => {
+		const allModels = Object.entries(DEFAULT_MODELS).filter(
+			([name]) => name !== 'default',
+		);
+
+		for (const [agent, model] of allModels) {
+			for (const disallowed of REMOVED_OR_PAID_STARTER_MODELS) {
+				expect(model, `${agent} should not default to ${disallowed}`).not.toBe(
+					disallowed,
 				);
 			}
 		}
 	});
 
-	test('Agents with primary big-pickle have 2-level fallback', () => {
-		const bigPickleAgents = [
-			'reviewer',
-			'explorer',
-			'sme',
-			'critic',
-			'docs',
-			'designer',
-		];
-
-		for (const agent of bigPickleAgents) {
-			const config = DEFAULT_AGENTS[agent];
-			expect(config.model).toBe('opencode/big-pickle');
-			expect(config.fallback_models).toBeDefined();
-			expect(config.fallback_models?.length).toBe(2);
-			expect(config.fallback_models?.[0]).toBe('opencode/gpt-5-nano');
-			expect(config.fallback_models?.[1]).toBe('opencode/big-pickle');
+	test('fallback chains provide a different recovery model without cycles', () => {
+		for (const [agent, config] of Object.entries(DEFAULT_AGENT_CONFIGS)) {
+			expect(config.fallback_models.length, `${agent} fallback depth`).toBe(1);
+			expect(config.fallback_models[0]).not.toBe(config.model);
 		}
 	});
 
-	test('Coder agent has 2-level fallback (minimax → gpt-5-nano → big-pickle)', () => {
-		const config = DEFAULT_AGENTS.coder;
-		expect(config.model).toBe('opencode/minimax-m2.5-free');
-		expect(config.fallback_models).toEqual([
-			'opencode/gpt-5-nano',
-			'opencode/big-pickle',
-		]);
-	});
-
-	test('Lightweight agents (test_engineer, curator, council) have 1-level fallback', () => {
-		const lightweightAgents = [
-			'test_engineer',
-			'critic_sounding_board',
-			'critic_drift_verifier',
-			'critic_hallucination_verifier',
-			'critic_oversight',
-			'curator_init',
-			'curator_phase',
-			'council_member',
-			'council_moderator',
-		];
-
-		for (const agent of lightweightAgents) {
-			const config = DEFAULT_AGENTS[agent];
-			expect(config.fallback_models).toBeDefined();
-			expect(config.fallback_models?.length).toBe(1);
-			expect(config.fallback_models?.[0]).toBe('opencode/big-pickle');
-		}
-	});
-
-	test('All fallback models are from consistently-available set (big-pickle, gpt-5-nano)', () => {
-		const allowedModels = new Set([
-			'opencode/big-pickle',
-			'opencode/gpt-5-nano',
-			'opencode/minimax-m2.5-free', // Only as primary, allowed as sometimes-available
-		]);
-
-		for (const [agent, config] of Object.entries(DEFAULT_AGENTS)) {
-			if (config.model && !allowedModels.has(config.model)) {
-				throw new Error(
-					`Agent ${agent} has disallowed primary model: ${config.model}`,
-				);
-			}
-
-			for (const fallback of config.fallback_models || []) {
-				const isConsistent =
-					fallback === 'opencode/big-pickle' ||
-					fallback === 'opencode/gpt-5-nano';
-				expect(isConsistent).toBe(true);
-			}
-		}
-	});
-
-	test('Schema respects max 3 fallbacks limit', () => {
-		for (const [agent, config] of Object.entries(DEFAULT_AGENTS)) {
-			const fallbackCount = config.fallback_models?.length || 0;
-			expect(fallbackCount).toBeLessThanOrEqual(3);
-		}
-	});
-
-	test('Fallback chains provide meaningful recovery', () => {
-		// Scenario 1: Coder primary unavailable
-		const coderChain = [
+	test('coder and test_engineer use different starter primaries', () => {
+		expect(DEFAULT_AGENT_CONFIGS.coder.model).toBe(
 			'opencode/minimax-m2.5-free',
-			...(DEFAULT_AGENTS.coder.fallback_models || []),
-		];
-		const coderAvailableFallback = coderChain.find(
-			(m) => m !== 'opencode/minimax-m2.5-free',
 		);
-		expect(coderAvailableFallback).toBeDefined();
-
-		// Scenario 2: Critic with both big-pickle and gpt-5-nano unavailable (exhaustion)
-		// This is the intended edge case — fallback to third level
-		const criticChain = [
+		expect(DEFAULT_AGENT_CONFIGS.test_engineer.model).toBe(
 			'opencode/big-pickle',
-			...(DEFAULT_AGENTS.critic.fallback_models || []),
-		];
-		expect(criticChain).toHaveLength(3);
-		expect(criticChain[0]).toBe('opencode/big-pickle');
-		expect(criticChain[1]).toBe('opencode/gpt-5-nano');
-		expect(criticChain[2]).toBe('opencode/big-pickle');
-
-		// Scenario 3: Only big-pickle available ensures no complete failure
-		const testEngineerChain = [
-			'opencode/gpt-5-nano',
-			...(DEFAULT_AGENTS.test_engineer.fallback_models || []),
-		];
-		expect(testEngineerChain).toEqual([
-			'opencode/gpt-5-nano',
-			'opencode/big-pickle',
-		]);
-	});
-
-	test('Each agent has a model assignment (explicit or inherited)', () => {
-		const agentsWithoutModel = Object.entries(DEFAULT_AGENTS).filter(
-			([_, config]) => !config.model,
 		);
-		expect(agentsWithoutModel).toHaveLength(0);
-	});
-
-	test('Fallback models exclude removed/inconsistent models', () => {
-		const disallowedModels = [
-			'opencode/trinity-large-preview-free', // v6.84.6 removed
-		];
-
-		for (const [agent, config] of Object.entries(DEFAULT_AGENTS)) {
-			for (const fallback of config.fallback_models || []) {
-				for (const disallowed of disallowedModels) {
-					expect(fallback).not.toBe(disallowed);
-				}
-			}
-		}
-	});
-
-	test('Resilience summary: agents have recovery depth', () => {
-		const resilienceCounts: Record<string, number> = {};
-
-		for (const [agent, config] of Object.entries(DEFAULT_AGENTS)) {
-			const depth = (config.fallback_models?.length || 0) + 1; // +1 for primary
-			resilienceCounts[agent] = depth;
-		}
-
-		// Primary agents should have depth 3 (primary + 2 fallbacks)
-		[
-			'coder',
-			'reviewer',
-			'explorer',
-			'sme',
-			'critic',
-			'docs',
-			'designer',
-		].forEach((agent) => {
-			expect(resilienceCounts[agent]).toBe(3);
-		});
-
-		// Lightweight agents should have depth 2 (primary + 1 fallback)
-		[
-			'test_engineer',
-			'critic_sounding_board',
-			'curator_init',
-			'council_member',
-		].forEach((agent) => {
-			expect(resilienceCounts[agent]).toBe(2);
-		});
+		expect(DEFAULT_AGENT_CONFIGS.coder.model).not.toBe(
+			DEFAULT_AGENT_CONFIGS.test_engineer.model,
+		);
 	});
 });

--- a/tests/unit/docs/onboarding-docs.test.ts
+++ b/tests/unit/docs/onboarding-docs.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dir, '../../..');
+
+function read(relativePath: string): string {
+	return fs.readFileSync(path.join(ROOT, relativePath), 'utf-8');
+}
+
+const ONBOARDING_DOCS = [
+	'README.md',
+	'docs/getting-started.md',
+	'docs/configuration.md',
+	'docs/installation.md',
+	'docs/installation-linux-docker.md',
+	'docs/installation-llm-operator.md',
+	'docs/examples/web-app.md',
+	'docs/commands.md',
+	'docs/index.md',
+];
+
+describe('onboarding documentation drift guards', () => {
+	test('new-user docs do not claim architect auto-selection', () => {
+		const combined = ONBOARDING_DOCS.map(read).join('\n');
+		expect(combined).not.toMatch(/auto-selects? the architect/i);
+		expect(combined).not.toMatch(/architect is auto-selected/i);
+		expect(combined).not.toMatch(/Selects the Swarm architect as the default/i);
+	});
+
+	test('new-user model examples avoid known stale or private provider traps', () => {
+		const combined = ONBOARDING_DOCS.map(read).join('\n');
+		expect(combined).not.toContain('opencode/gpt-5-nano');
+		expect(combined).not.toContain('opencode/trinity-large-preview-free');
+		expect(combined).not.toMatch(/"model":\s*"grove-openai\//);
+	});
+
+	test('command docs avoid hard-coded stale command counts and versions', () => {
+		const combined = [
+			read('README.md'),
+			read('docs/getting-started.md'),
+			read('docs/examples/web-app.md'),
+			read('docs/commands.md'),
+			read('docs/index.md'),
+		].join('\n');
+
+		expect(combined).not.toMatch(/all\s+4[13]\s+[`/"]?\/swarm/i);
+		expect(combined).not.toContain('v6.81.0');
+		expect(combined).toContain('full command reference');
+	});
+
+	test('docs index points at the newest local release note', () => {
+		const releaseNames = fs
+			.readdirSync(path.join(ROOT, 'docs', 'releases'))
+			.filter((name) => /^v\d+\.\d+\.\d+\.md$/.test(name))
+			.sort((a, b) =>
+				a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }),
+			);
+		const newest = releaseNames.at(-1);
+		expect(newest).toBeDefined();
+
+		const version = newest!.replace(/\.md$/, '');
+		const index = read('docs/index.md');
+		expect(index).toContain(`[${version}](releases/${newest})`);
+		expect(index).toContain(
+			`${version}](releases/${newest}) | Latest documented release`,
+		);
+	});
+});


### PR DESCRIPTION
﻿## Summary
- Hardens first-run onboarding docs, generated starter config, and command guidance so new users are not led into stale/private model IDs or hidden feature gates.
- Adds best-effort `/swarm config doctor` validation against OpenCode provider model availability for agent, fallback, full-auto, skill/spec, and General Council model refs, with explicit timeout/malformed-response handling.
- Adds focused drift tests for onboarding docs/model defaults and updates release notes for v7.18.2.

## Review follow-ups
- Documented that provider-model validation requires OpenCode provider data within the 3-second budget and degrades to an informational skipped-check finding.
- Added timeout and malformed provider-registry response tests for `loadModelAvailability`.
- Escaped user-controlled model IDs in doctor descriptions while preserving raw `currentValue` in structured findings.

## Invariant audit
- 1 (plugin init): touched — `src/index.ts` now passes `ctx.client` into command handling; `bun run build` passed; `node scripts/repro-704.mjs` timing checks passed for T1/T2/T3 (`server()` resolved in 166.8ms, 52.9ms, 48.3ms in the captured run), but the script still does not clean-exit on this branch or `origin/main` and was killed after 45s in both cases.
- 2 (runtime portability): touched — `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-node-load.test.ts tests/unit/build/bundle-plugin-shape.test.ts --timeout 60000` passed (5 pass, 0 fail); `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` printed `dist import OK`.
- 3 (subprocesses): not touched — `git diff --name-only origin/main..HEAD -- src/**/*.ts | Select-String ... "bunSpawn\(|spawn\(|spawnSync\("` found no changed source spawn call sites.
- 4 (.swarm containment): touched — generated `.swarm/config.example.json` now reuses `DEFAULT_AGENT_CONFIGS`; `bun --smol test tests/unit/config/multilevel-fallback.test.ts --timeout 60000` covered starter config shape/model safety in the focused suite.
- 5 (plan durability): not touched — no plan ledger/projection/checkpoint code changed.
- 6 (test_runner safety): not touched — no OpenCode `test_runner` validation was used; validation used shell `bun`/`node` commands.
- 7 (test writing): touched — `.opencode/skills/writing-tests/SKILL.md` was loaded; added `bun:test` coverage without new `mock.module` usage.
- 8 (session state): not touched — no session-scoped/global state maps or eviction behavior changed.
- 9 (guardrails/retry): not touched — no retry/circuit-breaker/fallback accounting code changed.
- 10 (chat/system msg): not touched — no chat/system-message hook contracts changed.
- 11 (tool registration): touched — `AGENT_TOOL_MAP` and command registry/client wiring changed; `bun --smol test tests/unit/config/critic-registration.test.ts tests/unit/tools/tool-names.test.ts tests/unit/tools/tool-registration-conformance.test.ts tests/unit/services/plugin-tool-registration.test.ts --timeout 60000` passed (24 pass, 0 fail).
- 12 (release/cache): touched — added `docs/releases/v7.18.2.md`; final diff excludes `package.json`, `CHANGELOG.md`, and `.release-please-manifest.json`.

## Test plan
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bunx biome ci .` (exited 0; reports existing warning in `src/turbo/lean/runner.ts:307`)
- [x] `bun --smol test src/commands/commands.test.ts src/services/config-doctor.test.ts --timeout 60000` (65 pass, 0 fail)
- [x] `bun --smol test src/services/config-doctor.test.ts src/commands/commands.test.ts tests/unit/commands/agents.test.ts tests/unit/docs/onboarding-docs.test.ts tests/unit/config/multilevel-fallback.test.ts --timeout 60000` (104 pass, 0 fail)
- [x] `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-node-load.test.ts tests/unit/build/bundle-plugin-shape.test.ts --timeout 60000` (5 pass, 0 fail)
- [x] `bun --smol test tests/unit/config/critic-registration.test.ts tests/unit/tools/tool-names.test.ts tests/unit/tools/tool-registration-conformance.test.ts tests/unit/services/plugin-tool-registration.test.ts --timeout 60000` (24 pass, 0 fail)
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `node scripts/repro-704.mjs` timing checks pass, but direct command does not clean-exit; confirmed same behavior on `origin/main` with a disposable worktree.

## Pre-existing failures
- `bun --smol test tests/unit/commands tests/unit/config src/services/config-doctor.test.ts src/commands/commands.test.ts --timeout 120000` still fails in the broad command/config batch (2,150 pass / 313 fail), concentrated in stale command-registry/help-text expectations and existing simulate/turbo/config tests. Focused touched tests pass.
- `node scripts/repro-704.mjs` passes all three startup timing checks but leaves the Node process alive past 45s on both this branch and `origin/main`.
