### PR TITLE
fix(commands): mutate output.parts in place + document LLM-mediation gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ Core subcommands at a glance:
 
 Use `/swarm help` to see all available commands categorized by function. Use `/swarm help <command>` for detailed usage information on a specific command.
 
+> ⚠️ **Chat-typed `/swarm` is currently LLM-mediated.** The OpenCode runtime invokes the model unconditionally after the plugin handles a `command.execute.before` slash command (upstream issue [anomalyco/opencode#9306](https://github.com/anomalyco/opencode/issues/9306)). What you see in chat is the model's reformulation of the canonical handler output, which can drift on weak models or in long sessions. For deterministic, scriptable output, run the underlying command directly:
+>
+> ```bash
+> bunx opencode-swarm run <subcommand>   # e.g. bunx opencode-swarm run agents
+> ```
+>
+> This is a temporary mitigation. A deterministic in-chat path (either a `swarm` MCP tool or upstream `noReply` support) is tracked separately.
+
 Nine commands display a ⚠️ warning in help output because they share names with Claude Code built-in slash commands (e.g., `/plan`, `/reset`, `/status`). The warning reminds you to always use `/swarm <command>` — the bare CC command does something different and sometimes destructive. See [docs/commands.md#claude-code-command-conflicts](docs/commands.md#claude-code-command-conflicts) for the full conflict registry.
 
 See [docs/commands.md](docs/commands.md) for the full command reference.

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.18.1",
+    version: "7.18.2",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -51927,6 +51927,7 @@ __export(exports_commands, {
   createSwarmCommandHandler: () => createSwarmCommandHandler,
   buildHelpText: () => buildHelpText,
   VALID_COMMANDS: () => VALID_COMMANDS,
+  LLM_MEDIATION_WARNING: () => LLM_MEDIATION_WARNING,
   COMMAND_REGISTRY: () => COMMAND_REGISTRY,
   COMMAND_NAME_SET: () => COMMAND_NAME_SET,
   COMMAND_NAMES: () => COMMAND_NAMES
@@ -51934,7 +51935,7 @@ __export(exports_commands, {
 import fs28 from "fs";
 import path46 from "path";
 function buildHelpText() {
-  const lines = ["## Swarm Commands", ""];
+  const lines = ["## Swarm Commands", "", LLM_MEDIATION_WARNING, ""];
   const CATEGORIES = [
     "core",
     "agent",
@@ -52100,11 +52101,13 @@ ${text}`;
 `;
       text = welcomeMessage + text;
     }
-    output.parts = [
-      { type: "text", text }
-    ];
+    output.parts.splice(0, output.parts.length, {
+      type: "text",
+      text
+    });
   };
 }
+var LLM_MEDIATION_WARNING;
 var init_commands = __esm(() => {
   init_registry();
   init_acknowledge_spec_drift();
@@ -52142,6 +52145,8 @@ var init_commands = __esm(() => {
   init_sync_plan();
   init_turbo();
   init_write_retro2();
+  LLM_MEDIATION_WARNING = "> \u26A0\uFE0F Chat-typed `/swarm` is LLM-mediated in current OpenCode (see anomalyco/opencode#9306).\n" + `> The text below is the canonical handler output, but the model may rephrase it before display.
+` + "> For deterministic output, run `bunx opencode-swarm run <subcommand>` from a terminal.";
 });
 
 // src/commands/registry.ts

--- a/dist/commands/index.d.ts
+++ b/dist/commands/index.d.ts
@@ -40,6 +40,7 @@ export { handleStatusCommand } from './status';
 export { handleSyncPlanCommand } from './sync-plan';
 export { handleTurboCommand } from './turbo';
 export { handleWriteRetroCommand } from './write-retro';
+export declare const LLM_MEDIATION_WARNING: string;
 export declare function buildHelpText(): string;
 /**
  * Creates a command.execute.before handler for /swarm commands.

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.18.1",
+    version: "7.18.2",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -61092,6 +61092,7 @@ __export(exports_commands, {
   createSwarmCommandHandler: () => createSwarmCommandHandler,
   buildHelpText: () => buildHelpText,
   VALID_COMMANDS: () => VALID_COMMANDS,
+  LLM_MEDIATION_WARNING: () => LLM_MEDIATION_WARNING,
   COMMAND_REGISTRY: () => COMMAND_REGISTRY,
   COMMAND_NAME_SET: () => COMMAND_NAME_SET,
   COMMAND_NAMES: () => COMMAND_NAMES
@@ -61099,7 +61100,7 @@ __export(exports_commands, {
 import fs37 from "node:fs";
 import path55 from "node:path";
 function buildHelpText() {
-  const lines = ["## Swarm Commands", ""];
+  const lines = ["## Swarm Commands", "", LLM_MEDIATION_WARNING, ""];
   const CATEGORIES = [
     "core",
     "agent",
@@ -61265,11 +61266,13 @@ ${text}`;
 `;
       text = welcomeMessage + text;
     }
-    output.parts = [
-      { type: "text", text }
-    ];
+    output.parts.splice(0, output.parts.length, {
+      type: "text",
+      text
+    });
   };
 }
+var LLM_MEDIATION_WARNING;
 var init_commands = __esm(() => {
   init_registry();
   init_acknowledge_spec_drift();
@@ -61307,6 +61310,8 @@ var init_commands = __esm(() => {
   init_sync_plan();
   init_turbo();
   init_write_retro2();
+  LLM_MEDIATION_WARNING = "> ⚠️ Chat-typed `/swarm` is LLM-mediated in current OpenCode (see anomalyco/opencode#9306).\n" + `> The text below is the canonical handler output, but the model may rephrase it before display.
+` + "> For deterministic output, run `bunx opencode-swarm run <subcommand>` from a terminal.";
 });
 
 // src/commands/registry.ts

--- a/docs/releases/v7.18.3.md
+++ b/docs/releases/v7.18.3.md
@@ -1,0 +1,79 @@
+# v7.18.3
+
+## Slash-command in-place mutation fix + LLM-mediation transparency
+
+The `command.execute.before` hook in `src/commands/index.ts` was reassigning
+`output.parts = [{type: 'text', text}]` to deliver handler output back to
+the OpenCode runtime. That assignment only mutated the throwaway wrapper
+object `Plugin.trigger` constructs, so the handler's text never reached
+the model as its input. Verified against current upstream OpenCode source
+(`packages/opencode/src/session/prompt.ts`, `packages/opencode/src/plugin/index.ts`,
+`packages/plugin/src/index.ts` on `dev`).
+
+Even with the assignment-vs-mutation bug fixed, current OpenCode still
+invokes `prompt(...)` unconditionally after the hook returns (upstream
+issue [anomalyco/opencode#9306](https://github.com/anomalyco/opencode/issues/9306),
+closed without shipping `noReply`). The user-visible response in chat is
+therefore always the model's rephrasing of the canonical handler output —
+which can drift dramatically on weak models or in subagent contexts. The
+release documents this limitation and points users to the deterministic
+CLI path until a structural fix lands.
+
+## What changed
+
+- `src/commands/index.ts`:
+  - `createSwarmCommandHandler` now calls `output.parts.splice(0, output.parts.length, ...)` instead of reassigning `output.parts`. The shared array reference is mutated in place so OpenCode's outer `parts` variable observes the handler output.
+  - Removed an outdated comment claiming `output.parts` "overrides the LLM response". The new comment cites the upstream gap.
+  - Exported a new `LLM_MEDIATION_WARNING` banner. `buildHelpText()` now prepends it so `/swarm help` is the first place users see the limitation.
+- `src/commands/index.parts-mutation.test.ts` (new): five regression tests pinning the in-place mutation contract for `/swarm`, `/swarm-*` shortcuts, the not-found path, the non-swarm early-return path, and the pre-populated-parts replacement case.
+- `README.md`: warning callout under `## Commands` directing users to `bunx opencode-swarm run <subcommand>` for canonical output until the structural fix lands.
+
+## Why
+
+Users (and other agents reading swarm state) have been treating LLM-rephrased
+`/swarm` output as authoritative. The original bug report showed a weak
+subagent fabricating `"There is no .swarm/agents.json"` — a string that
+exists nowhere in the codebase. A second screenshot showed a strong
+orchestrator producing plausible-looking-but-still-fabricated output. The
+plugin handler did run in both cases (it resolved the command, executed
+the handler, and wrote to `output.parts`), but because of the
+assignment-vs-mutation bug the canonical handler output never propagated
+to OpenCode's outer `parts` array — so the LLM saw only the raw
+`/swarm <subcommand>` text as its input and answered freeform.
+
+This release does not fully fix the user-visible problem (only OpenCode
+upstream can), but it removes the silent failure mode (no-op assignment)
+and tells users when they cannot trust chat output.
+
+## Follow-up tracking
+
+- [#843](https://github.com/zaxbysauce/opencode-swarm/issues/843) — design and ship a `swarm` MCP tool so the orchestrator can call read-only subcommands deterministically.
+- [#844](https://github.com/zaxbysauce/opencode-swarm/issues/844) — file an upstream PR against `anomalyco/opencode` adding `noReply` / `abort` to `command.execute.before`. Once that lands, the banner can be removed and the hook can fully suppress the LLM.
+
+## Migration
+
+None required. Behavior change is:
+
+- `bunx opencode-swarm run <subcommand>` output is unchanged.
+- Chat-typed `/swarm <subcommand>` output is unchanged in shape (still LLM-rephrased) but now has the canonical handler text in the model's input context, which on strong models produces noticeably more accurate rephrasings. Weak models will still drift.
+- `/swarm help` output now starts with a one-paragraph banner before the command list.
+
+## Known caveats
+
+- The LLM-mediation gap is unfixed at the plugin layer. Users running `/swarm` in chat on free or weak models should expect drift and prefer the CLI for anything they depend on (CI scripts, automation, state checks).
+- The banner relies on the model relaying its input. On models that ignore long preambles, users may not see the warning even though it is present in the handler output.
+
+## Invariant audit
+
+- 1 (plugin init):        not touched — change is inside the `command.execute.before` hook body, not in plugin init; verified by `git diff origin/main..HEAD -- src/index.ts` returning no output.
+- 2 (runtime portability): touched — `dist/cli/index.js`, `dist/commands/index.d.ts`, and `dist/index.js` were rebuilt and committed. No `bun:` imports added, no `Bun.*` calls outside `bun-compat.ts` (verified by `grep -n "bun:" src/commands/index.ts src/commands/index.parts-mutation.test.ts` returning no top-level `bun:` imports). Bundle integrity verified: `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts tests/unit/build/bundle-node-load.test.ts` → 5/5 pass; `node --input-type=module -e "await import('./dist/index.js')"` → loads cleanly.
+- 3 (subprocesses):       not touched — no `spawn`/`spawnSync`/`bunSpawn` calls in changed files; verified by `git diff --name-only origin/main..HEAD | xargs -r grep -nE "bunSpawn\(|spawn\(|spawnSync\("` returning empty.
+- 4 (.swarm containment): not touched — no new `.swarm/` paths; existing first-run sentinel write unchanged.
+- 5 (plan durability):    not touched.
+- 6 (test_runner safety): not touched — validation used per-file `bun --smol test` shell invocations, never `test_runner` with broad scope.
+- 7 (test writing):       touched — new `src/commands/index.parts-mutation.test.ts` uses `bun:test` directly, no `mock.module`, no shared state. Verified by `bun --smol test src/commands/index.parts-mutation.test.ts` → 5/5 pass.
+- 8 (session state):      not touched.
+- 9 (guardrails/retry):   not touched.
+- 10 (chat/system msg):   touched — `command.execute.before` is part of the chat-message hook surface. The fix changes how the hook mutates the user-message parts array (in-place vs reassignment), and adds a warning banner to `/swarm help`. Verified by `bun --smol test src/commands/index.help-text.test.ts src/commands/shortcut-routing.test.ts src/commands/index.not-found.test.ts src/commands/index.parts-mutation.test.ts` → 49/49 of the tests affected by this change pass; 3 unrelated pre-existing shortcut-routing failures confirmed on `origin/main` via `git stash` + re-run.
+- 11 (tool registration): not touched.
+- 12 (release/cache):     touched — this release-notes file added; `package.json`, `CHANGELOG.md`, `.release-please-manifest.json` untouched.

--- a/src/commands/index.help-text.test.ts
+++ b/src/commands/index.help-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from 'bun:test';
-import { buildHelpText } from './index';
+import { buildHelpText, LLM_MEDIATION_WARNING } from './index';
 import type { CommandEntry, RegisteredCommand } from './registry';
 import { COMMAND_REGISTRY, VALID_COMMANDS } from './registry';
 
@@ -12,6 +12,21 @@ describe('buildHelpText()', () => {
 	describe('header', () => {
 		test('starts with "## Swarm Commands"', () => {
 			expect(helpText.startsWith('## Swarm Commands')).toBe(true);
+		});
+
+		test('includes the LLM-mediation warning banner', () => {
+			expect(helpText).toContain(LLM_MEDIATION_WARNING);
+			// Banner must appear before the first command category so users
+			// see it before scrolling.
+			const bannerIdx = helpText.indexOf(LLM_MEDIATION_WARNING);
+			const firstCategoryIdx = helpText.indexOf('### ');
+			expect(bannerIdx).toBeGreaterThan(-1);
+			expect(firstCategoryIdx).toBeGreaterThan(bannerIdx);
+		});
+
+		test('banner cites the upstream issue', () => {
+			expect(LLM_MEDIATION_WARNING).toContain('anomalyco/opencode#9306');
+			expect(LLM_MEDIATION_WARNING).toContain('bunx opencode-swarm run');
 		});
 	});
 

--- a/src/commands/index.parts-mutation.test.ts
+++ b/src/commands/index.parts-mutation.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression test for the `output.parts` in-place mutation contract.
+ *
+ * Background: the OpenCode runtime invokes `command.execute.before` like
+ *
+ *     yield* plugin.trigger("command.execute.before", input, { parts })
+ *
+ * where the second argument is an inline wrapper around the outer `parts`
+ * array. After the trigger returns, OpenCode discards the wrapper and uses
+ * its outer `parts` variable to call `prompt(...)`.
+ *
+ * If the handler REASSIGNS `output.parts = [newArray]`, only the wrapper's
+ * property changes — the outer `parts` reference still points at the old,
+ * empty array and the LLM never sees the handler's text. This was the bug
+ * fixed by switching the handler to in-place mutation (`splice`).
+ *
+ * Reference: upstream `packages/opencode/src/session/prompt.ts` discards
+ * the trigger return value and reads from the local `parts` variable;
+ * upstream `packages/opencode/src/plugin/index.ts` `Plugin.trigger` does
+ * not propagate the wrapper object back.
+ *
+ * Note: This test does NOT assert LLM suppression. Current OpenCode runs
+ * `prompt()` unconditionally after the hook (upstream issue
+ * anomalyco/opencode#9306). All we can do plugin-side is ensure the
+ * handler text reaches the LLM as its input.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { swarmState } from '../state';
+import { createSwarmCommandHandler } from './index';
+
+function makeTempDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), 'cmd-parts-mutation-test-'));
+}
+
+function makeSession(id: string): void {
+	swarmState.agentSessions.set(id, {
+		agentName: 'architect',
+		lastToolCallTime: Date.now(),
+		lastAgentEventTime: Date.now(),
+		delegationActive: false,
+		activeInvocationId: 0,
+		lastInvocationIdByAgent: {},
+		windows: {},
+		lastCompactionHint: 0,
+		architectWriteCount: 0,
+		lastCoderDelegationTaskId: null,
+		currentTaskId: null,
+		gateLog: new Map(),
+		reviewerCallCount: new Map(),
+		lastGateFailure: null,
+		partialGateWarningsIssuedForTask: new Set(),
+		selfFixAttempted: false,
+		selfCodingWarnedAtCount: 0,
+		catastrophicPhaseWarnings: new Set(),
+		qaSkipCount: 0,
+		qaSkipTaskIds: [],
+		taskWorkflowStates: new Map(),
+	});
+}
+
+describe('createSwarmCommandHandler — output.parts in-place mutation', () => {
+	let tempDir: string;
+	const sessionId = 'parts-mutation-test-session';
+
+	beforeEach(() => {
+		tempDir = makeTempDir();
+		makeSession(sessionId);
+		// Pre-create first-run sentinel so welcome banner does not appear
+		const swarmDir = path.join(tempDir, '.swarm');
+		fs.mkdirSync(swarmDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(swarmDir, '.first-run-complete'),
+			`first-run-complete: ${new Date().toISOString()}\n`,
+		);
+	});
+
+	afterEach(() => {
+		swarmState.agentSessions.delete(sessionId);
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it('mutates the existing parts array in place rather than reassigning', async () => {
+		const handler = createSwarmCommandHandler(tempDir, {});
+		const originalPartsRef: unknown[] = [];
+		const output = { parts: originalPartsRef };
+
+		await handler(
+			{ command: 'swarm', arguments: 'help', sessionID: sessionId },
+			output,
+		);
+
+		expect(output.parts).toBe(originalPartsRef);
+		expect(output.parts).toHaveLength(1);
+		const text = (output.parts[0] as { text: string }).text;
+		expect(typeof text).toBe('string');
+		expect(text.length).toBeGreaterThan(0);
+	});
+
+	it('mutates in place for swarm-* shortcut commands too', async () => {
+		const handler = createSwarmCommandHandler(tempDir, {});
+		const originalPartsRef: unknown[] = [];
+		const output = { parts: originalPartsRef };
+
+		await handler(
+			{ command: 'swarm-agents', arguments: '', sessionID: sessionId },
+			output,
+		);
+
+		expect(output.parts).toBe(originalPartsRef);
+		expect(output.parts).toHaveLength(1);
+	});
+
+	it('mutates in place for the not-found path', async () => {
+		const handler = createSwarmCommandHandler(tempDir, {});
+		const originalPartsRef: unknown[] = [];
+		const output = { parts: originalPartsRef };
+
+		await handler(
+			{
+				command: 'swarm',
+				arguments: 'definitely-not-a-real-subcommand',
+				sessionID: sessionId,
+			},
+			output,
+		);
+
+		expect(output.parts).toBe(originalPartsRef);
+		expect(output.parts).toHaveLength(1);
+		const text = (output.parts[0] as { text: string }).text;
+		expect(text).toContain('not found');
+	});
+
+	it('does NOT mutate parts when the command is not a swarm command', async () => {
+		const handler = createSwarmCommandHandler(tempDir, {});
+		const originalPartsRef: unknown[] = [];
+		const output = { parts: originalPartsRef };
+
+		await handler(
+			{ command: 'unrelated', arguments: '', sessionID: sessionId },
+			output,
+		);
+
+		expect(output.parts).toBe(originalPartsRef);
+		expect(output.parts).toHaveLength(0);
+	});
+
+	it('replaces pre-existing parts entries on a swarm command', async () => {
+		const handler = createSwarmCommandHandler(tempDir, {});
+		const originalPartsRef: unknown[] = [
+			{ type: 'text', text: 'pre-existing user input' },
+		];
+		const output = { parts: originalPartsRef };
+
+		await handler(
+			{ command: 'swarm', arguments: 'help', sessionID: sessionId },
+			output,
+		);
+
+		expect(output.parts).toBe(originalPartsRef);
+		expect(output.parts).toHaveLength(1);
+		const text = (output.parts[0] as { text: string }).text;
+		expect(text).not.toContain('pre-existing user input');
+	});
+});

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -69,8 +69,19 @@ export { handleSyncPlanCommand } from './sync-plan';
 export { handleTurboCommand } from './turbo';
 export { handleWriteRetroCommand } from './write-retro';
 
+// Banner prepended to `/swarm help`. Chat-typed `/swarm` is currently
+// LLM-mediated: OpenCode invokes the model after `command.execute.before`
+// runs (see upstream issue anomalyco/opencode#9306), so the text the user
+// sees is the model's reformulation of the canonical handler output rather
+// than the handler output itself. For deterministic, scriptable output,
+// users should run `bunx opencode-swarm run <subcommand>` from a terminal.
+export const LLM_MEDIATION_WARNING =
+	'> ⚠️ Chat-typed `/swarm` is LLM-mediated in current OpenCode (see anomalyco/opencode#9306).\n' +
+	'> The text below is the canonical handler output, but the model may rephrase it before display.\n' +
+	'> For deterministic output, run `bunx opencode-swarm run <subcommand>` from a terminal.';
+
 export function buildHelpText(): string {
-	const lines: string[] = ['## Swarm Commands', ''];
+	const lines: string[] = ['## Swarm Commands', '', LLM_MEDIATION_WARNING, ''];
 
 	// Valid categories in display order
 	const CATEGORIES = [
@@ -255,8 +266,15 @@ export function createSwarmCommandHandler(
 			// EEXIST means file already existed — not first run; other errors: proceed silently
 		}
 
-		// Verified: input.arguments receives the expanded $ARGUMENTS from the template.
-		// The hook output.parts overrides the LLM response in the UI.
+		// input.arguments receives the expanded $ARGUMENTS from the template.
+		// `output.parts` is the user command's `parts` array (shared by reference
+		// with the OpenCode caller). Mutating it in-place propagates to the
+		// outer caller's `parts` variable that is then passed to `prompt()`.
+		// REASSIGNING `output.parts = [...]` would NOT propagate because the
+		// wrapper object is discarded by `Plugin.trigger` — only mutations to
+		// the existing array reference are observable. This call does NOT
+		// suppress the LLM; current OpenCode invokes `prompt()` unconditionally
+		// after the hook returns (upstream issue anomalyco/opencode#9306).
 		// Parse arguments
 		let tokens: string[];
 		if (input.command === 'swarm') {
@@ -325,9 +343,15 @@ export function createSwarmCommandHandler(
 			text = welcomeMessage + text;
 		}
 
-		// Convert string result to Part[]
-		output.parts = [
-			{ type: 'text', text } as unknown as (typeof output.parts)[number],
-		];
+		// Replace output.parts contents in place. Using assignment
+		// (`output.parts = [...]`) would mutate only the wrapper object that
+		// `Plugin.trigger` constructs and then discards — the OpenCode caller's
+		// outer `parts` variable would still reference the original array and
+		// the LLM input would never see this text. `splice` modifies the shared
+		// array reference, which IS observed by the outer caller.
+		output.parts.splice(0, output.parts.length, {
+			type: 'text',
+			text,
+		} as unknown as (typeof output.parts)[number]);
 	};
 }


### PR DESCRIPTION
## Summary

- `createSwarmCommandHandler` was reassigning `output.parts = [...]`, but OpenCode's `Plugin.trigger` discards the wrapper object and `packages/opencode/src/session/prompt.ts` calls `prompt(...)` against its own local `parts` variable — so the assignment was a silent no-op and the handler's text never reached the model as its input. Switching to `output.parts.splice(0, output.parts.length, ...)` mutates the shared array reference so the canonical handler output does propagate. (Note: the handler still runs in both cases; only the propagation was broken.)
- This change does NOT suppress the LLM round-trip (current OpenCode runs `prompt(...)` unconditionally after the hook; see upstream [anomalyco/opencode#9306](https://github.com/anomalyco/opencode/issues/9306)). The release adds an `LLM_MEDIATION_WARNING` banner to `/swarm help` output and a matching note in the README under `## Commands`, directing users to `bunx opencode-swarm run <subcommand>` for deterministic output until a structural fix lands.
- Follow-up tracked in #843 (a `swarm` MCP tool exposing read-only subcommands deterministically) and #844 (upstream PR adding `noReply` / `abort` to `command.execute.before`).

## Invariant audit
- 1 (plugin init):       not touched — change is inside the `command.execute.before` hook body, not in plugin init; `git diff --name-only origin/main..HEAD -- src/index.ts` returns no output.
- 2 (runtime portability): touched — `dist/cli/index.js`, `dist/commands/index.d.ts`, and `dist/index.js` were rebuilt and committed. No `bun:` imports added, no `Bun.*` calls outside `bun-compat.ts` (verified by `grep -n "^import .*bun:" src/commands/index.ts src/commands/index.parts-mutation.test.ts` returning no top-level `bun:` imports). Bundle integrity verified: `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts tests/unit/build/bundle-node-load.test.ts` → 5/5 pass; `node --input-type=module -e "await import('./dist/index.js')"` → loads cleanly.
- 3 (subprocesses):       not touched — no `spawn`/`spawnSync`/`bunSpawn` calls in changed files; verified by `git diff --name-only origin/main..HEAD | xargs -r grep -nE "bunSpawn\(|spawn\(|spawnSync\("` returning empty.
- 4 (.swarm containment): not touched — no new `.swarm/` paths; existing first-run sentinel write unchanged.
- 5 (plan durability):    not touched.
- 6 (test_runner safety): not touched — validation used per-file `bun --smol test` shell invocations, never `test_runner` with broad scope.
- 7 (test writing):       touched — new `src/commands/index.parts-mutation.test.ts` and added `LLM_MEDIATION_WARNING` coverage in `src/commands/index.help-text.test.ts` both use `bun:test` directly, no `mock.module`, no shared state. `bun --smol test src/commands/index.parts-mutation.test.ts src/commands/index.help-text.test.ts --timeout 60000` → 24/24 pass.
- 8 (session state):      not touched.
- 9 (guardrails/retry):   not touched.
- 10 (chat/system msg):   touched — `command.execute.before` is part of the chat-message hook surface. Change is the in-place mutation pattern and the help-text banner. `bun --smol test src/commands/index.help-text.test.ts src/commands/index.not-found.test.ts src/commands/index.not-found.adversarial.test.ts src/commands/index.parts-mutation.test.ts --timeout 60000` → 62/62 pass.
- 11 (tool registration): not touched.
- 12 (release/cache):     touched — `docs/releases/v7.18.3.md` added; `package.json`, `CHANGELOG.md`, `.release-please-manifest.json` untouched.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bunx biome ci .` — only the pre-existing `noExplicitAny` warning in `src/turbo/lean/runner.ts:307` remains
- [x] `bun run build` runs cleanly; `dist/` artifacts staged into the squash commit
- [x] Invariant-2 bundle checks: `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts tests/unit/build/bundle-node-load.test.ts` → 5/5 pass; `node --input-type=module -e "await import('./dist/index.js')"` → loads cleanly
- [x] Focused tests on impacted files: `bun --smol test src/commands/index.parts-mutation.test.ts src/commands/index.help-text.test.ts src/commands/index.not-found.test.ts src/commands/index.not-found.adversarial.test.ts --timeout 60000` → 62/62 pass
- [x] Tier 2 (`bun --smol test tests/unit/commands tests/unit/config tests/unit/cli`): identical pass/fail count on this branch and `origin/main` (2022 pass / 653 pre-existing fail) — verified via `git stash --include-untracked` + re-run
- [x] Tier 3 (`bun test tests/integration`): identical pass/fail count on this branch and `origin/main` (536 pass / 94 pre-existing fail)
- [x] Tier 4 security (`bun test tests/security`): 139/139 pass
- [x] Tier 4 adversarial (`bun test tests/adversarial`): identical to `origin/main` (703 pass / 16 pre-existing fail)
- [x] Tier 5 smoke (`bun test tests/smoke`): 10/10 pass

## Pre-existing failures

All confirmed by stashing this branch's changes and re-running the same command on `origin/main` (currently `a7759ca`, v7.18.2). Pass/fail counts are identical, so this PR introduces zero new failures.

- `tests/unit/{commands,config,cli}`: 653 failures, including `tests/unit/commands/rollback-integration.test.ts` (`COMMAND_REGISTRY.rollback` undefined) and many fixture-shape tests.
- `tests/integration`: 94 failures across various integration suites.
- `tests/adversarial`: 16 failures.
- `src/turbo/lean/runner.ts:307`: pre-existing `noExplicitAny` Biome warning.

The size of the pre-existing failure set is worth flagging separately — but it is not caused by, fixed by, or scoped to this PR.

## Notes for reviewer

- The fix only restores **handler output propagating to the LLM as input**. The handler itself was already running before this change (it resolves the command, executes the handler, and writes to `output.parts`); the bug was that the reassigned-but-discarded wrapper meant the handler's text never reached OpenCode's outer `parts` array. It does not suppress the LLM. Users on weak/free models will still see drift. The banner in `/swarm help` and the README warning communicate this honestly.
- Closes the silent failure mode where users (and other agents reading swarm state) were treating LLM hallucinations as authoritative `/swarm` output.
- Companion issues with concrete next-step plans:
  - #843 — `swarm` MCP tool (deterministic in-chat path for read-only subcommands; explicitly excludes destructive ones).
  - #844 — upstream PR drafted against `anomalyco/opencode` for `noReply` support; includes ready-to-apply patches against `packages/plugin/src/index.ts` and `packages/opencode/src/session/prompt.ts`.
