### PR TITLE
chore(skill): add codex issue tracer workflow

### DIFF
--- a/.agents/skills/issue-tracer/SKILL.md
+++ b/.agents/skills/issue-tracer/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: issue-tracer
+description: Evidence-first issue and bug investigation for Codex. Use when asked to trace, investigate, root-cause, plan, fix, close, or prepare a PR for a GitHub issue, bug report, regression, failing test, or confusing runtime behavior. Drives intake, reproduction, localization, critic review, implementation, validation, invariant-aware PR closure, and no-gap evidence capture.
+---
+
+# Issue Tracer
+
+## Overview
+
+Use this skill to take a GitHub issue or bug report from intake to a verified fix or a reviewed plan. Preserve evidence over polish: reproduce before localizing, localize before fixing, and validate the runtime path before declaring closure.
+
+This is the Codex-native version. Use Codex tools and workflow defaults:
+
+- Use `shell_command` for repository commands, `rg`, `git`, `gh`, tests, builds, and local validation.
+- Use `apply_patch` for manual file edits.
+- Use `update_plan` for phase tracking on substantial work.
+- Use the GitHub app or `gh` for issue and PR metadata when available.
+- Use `web` only for current external framework/API behavior, advisories, or release notes; cite URLs for external claims.
+- Use parallel reads/searches when independent files or subsystems can be inspected safely.
+
+## Mode Selection
+
+Infer the mode from the user request and newest instructions.
+
+- `plan-only`: trace, reproduce/localize where possible, run critic review, and stop with a reviewed plan.
+- `plan-then-approval`: produce a reviewed plan and wait for explicit approval before production-code edits.
+- `approved implementation`: if the user already asked to fix or implement, continue through reproduction, localization, minimal patch, validation, and PR-ready summary.
+- `high-risk`: require approval before edits when the fix is destructive, broad, breaking, migration-heavy, or depends on unavailable secrets/data.
+
+Do not force a blocking approval gate for ordinary Codex implementation work when the user already asked for the fix. Do force it for plan-only requests, high-risk work, destructive operations, or explicit user instructions.
+
+## Repo Contract
+
+For `opencode-swarm`, read the repo contract before meaningful work:
+
+1. `AGENTS.md`
+2. `docs/engineering-invariants.md` when touching relevant invariants
+3. `.opencode/skills/writing-tests/SKILL.md` before writing or modifying tests
+4. `.opencode/skills/engineering-conventions/SKILL.md` before architecture, plugin init, subprocess, tool registration, plan durability, `.swarm` storage, runtime portability, session/global state, guardrails/retry, chat/system hook, or release/cache work
+5. `.claude/skills/commit-pr/SKILL.md` before commit, push, or PR creation unless a Codex publish skill supersedes it
+
+If `.Codex/session/swarm-mode.md` exists, read it before complex work and follow its quality gates.
+
+Every PR for this repo must include an invariant audit for touched areas. Evidence must be concrete: commands, test output, source inspection, or grep results.
+
+## Trace Artifacts
+
+For deep issue tracing, create a resumable trace directory:
+
+```text
+.Codex/issue-traces/<issue-id-or-slug>/
+|-- 01-issue-summary.md
+|-- 02-reproduction.md
+|-- 03-localization-log.md
+|-- 04-root-cause.md
+|-- 05-fix-plan.md
+|-- 06-critic-review.md
+|-- 07-approved-plan.md
+|-- 08-test-results.md
+|-- 09-pr-body.md
+`-- state.md
+```
+
+For small fixes, a compact in-thread evidence trail is acceptable unless the user requests trace artifacts, context may be long-running, or the issue is ambiguous/high-risk. When artifacts are used, update `state.md` at phase boundaries with phase, completed gates, active hypothesis, selected fix, risks, and next action.
+
+Read the phase reference before using it:
+
+- `references/evidence-artifacts.md` for artifact templates
+- `references/localization-playbook.md` for root-cause localization
+- `references/critic-gate.md` for independent or fallback critic review
+- `assets/pr-template.md` for PR-ready closure text
+
+## Phase 0: Setup
+
+1. Parse the issue URL, number, PR link, failing command, or bug description.
+2. Identify repo root, branch, remotes, and worktree safety with `git status --short`.
+3. Inspect project instructions, manifests, test configs, CI configs, and relevant local skills.
+4. Create trace artifacts when warranted.
+5. Start or update an `update_plan` checklist for substantial work.
+
+Gate: proceed only when the target, repo state, and applicable instructions are known or the missing inputs are documented.
+
+## Phase 1: Intake and Reproduction
+
+1. Fetch issue metadata with the GitHub app or:
+
+```powershell
+gh issue view <id> --comments --json number,title,body,author,labels,state,comments,createdAt,updatedAt,url
+```
+
+2. Read linked PRs, commits, logs, screenshots, discussions, and external docs referenced by the issue.
+3. Extract observed behavior, expected behavior, exact errors, reproduction steps, environment, acceptance criteria, and ambiguities.
+4. Discover verification commands from actual repo files, not memory.
+5. Reproduce with the smallest faithful command or scenario.
+6. If direct reproduction is impossible, create or describe a minimal failing test/script/checklist that targets the reported behavior.
+
+Gate: continue only when the issue is reproduced, a faithful failing regression exists, or non-reproducibility is documented with missing inputs.
+
+## Phase 2: Localization
+
+Use `references/localization-playbook.md`.
+
+1. Build candidate locations from traces, failing tests, UI/API/CLI names, labels, linked PRs, and recent commits.
+2. Search with `rg` and read every referenced file before making claims.
+3. Follow call chains from entry point to failure and backward from failure to origin.
+4. Track hypotheses, evidence for/against, ruled-out paths, and files read.
+5. Stop only when root cause is localized to file, symbol, line range or function, broken contract, and triggering conditions.
+
+Gate: at least two plausible hypotheses are considered unless the trace uniquely identifies the fault; selected root cause has direct code and command/test evidence.
+
+## Phase 3: Plan and Critic Review
+
+Use `references/critic-gate.md`.
+
+1. Generate candidate fixes when realistic; for trivial defects include the selected fix and at least one rejected alternative.
+2. Rank by correctness, minimality, regression risk, API compatibility, architectural fit, testability, and rollback simplicity.
+3. Analyze callers/importers, config, docs, UI/API/CLI paths, persistence, concurrency, retry, cancellation, security, and privacy where relevant.
+4. Write a fix plan with exact files, functions, test plan, unwired-functionality checklist, risks, and rollback.
+5. Run an independent critic only when a separate subagent/delegation mechanism is available and the user/session has authorized it.
+6. If no independent critic is available, run the full fallback self-critic and label it exactly: `Fallback self-critic: independent critic unavailable.`
+7. Revise until critic blockers are resolved or explicitly escalated.
+
+Gate: implementation may begin only when mode permits it and critic blockers are resolved. In `plan-only` or `plan-then-approval`, stop for user approval.
+
+## Phase 4: Implementation
+
+1. Re-check `git status --short`.
+2. Protect unrelated user changes. Do not revert or overwrite them.
+3. Write/update the failing regression first when feasible, and confirm it fails for the expected reason.
+4. Apply the minimal fix with `apply_patch`.
+5. Re-read changed files and verify all runtime entry points are wired.
+6. Run focused regression tests, impacted tests, and repo-required checks. For `opencode-swarm`, use shell commands for repo validation; do not use broad OpenCode `test_runner` scopes.
+7. Record commands, exit codes, and meaningful output.
+
+Gate: changed behavior matches the reviewed plan or the deviation is documented; regression protection exists or infeasibility is justified; impacted checks pass or unrelated failures are proven.
+
+## Phase 5: Closure
+
+1. Inspect `git diff --stat`, `git diff`, and `git diff --check`.
+2. Verify no unrelated files changed.
+3. Prepare PR text with `assets/pr-template.md`.
+4. Include root cause with file/line references, change summary, tests/checks, regression coverage, invariant audit evidence for touched areas, and residual risks.
+5. Commit, push, or open a PR only when the user explicitly asked and the repo publish instructions have been loaded.
+
+## No-Gap Checklist
+
+- Reported symptom is reproduced or non-reproducibility is proven.
+- Root cause is localized to exact code and triggering conditions.
+- Fix addresses the root cause, not only the visible symptom.
+- Every changed path is wired into the actual runtime path.
+- Public API, CLI, UI, persistence, config, docs, and generated surfaces are checked where relevant.
+- Positive, negative, boundary, and adversarial cases are covered or explicitly ruled out.
+- Regression test fails before the fix and passes after the fix when feasible.
+- Impacted tests and quality checks are run.
+- Critic review completed before approval or implementation gate.
+- PR-ready summary is complete.

--- a/.agents/skills/issue-tracer/agents/openai.yaml
+++ b/.agents/skills/issue-tracer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Issue Tracer"
+  short_description: "Evidence-first bug tracing and fixes"
+  default_prompt: "Use $issue-tracer to investigate this bug report, find the root cause, and prepare a verified fix."

--- a/.agents/skills/issue-tracer/assets/pr-template.md
+++ b/.agents/skills/issue-tracer/assets/pr-template.md
@@ -1,0 +1,50 @@
+# PR Description Template
+
+## Root Cause
+
+[One paragraph explaining what was broken, where, and why. Include file paths, symbols, line ranges, and triggering conditions.]
+
+## Fix
+
+[Concise description of the minimal patch and why it is necessary and sufficient.]
+
+- [Specific code change]
+- [Specific code change]
+- [Specific code change]
+
+## Tests
+
+- Regression test: `[command]` -> PASS
+- Impacted suite: `[command]` -> PASS
+- Lint/type/build/security checks: `[commands]` -> PASS
+
+## Regression Protection
+
+- [New/updated test path and scenario]
+- [Negative/boundary/adversarial case if relevant]
+- [Test drift review result]
+
+## Invariant Audit
+
+- 1 (plugin init): touched / not touched - <evidence>
+- 2 (runtime portability): touched / not touched - <evidence>
+- 3 (subprocesses): touched / not touched - <evidence>
+- 4 (.swarm containment): touched / not touched - <evidence>
+- 5 (plan durability): touched / not touched - <evidence>
+- 6 (test_runner safety): touched / not touched - <evidence>
+- 7 (test writing): touched / not touched - <evidence>
+- 8 (session state): touched / not touched - <evidence>
+- 9 (guardrails/retry): touched / not touched - <evidence>
+- 10 (chat/system msg): touched / not touched - <evidence>
+- 11 (tool registration): touched / not touched - <evidence>
+- 12 (release/cache): touched / not touched - <evidence>
+
+## Risk and Rollback
+
+- Risk level: [low/medium/high]
+- Rollback: [revert commit / disable flag / restore config / migration rollback]
+- Residual risk: [none or explicit risk]
+
+## Issue Closure
+
+Closes #[issue-number]

--- a/.agents/skills/issue-tracer/references/critic-gate.md
+++ b/.agents/skills/issue-tracer/references/critic-gate.md
@@ -1,0 +1,116 @@
+# Critic Gate
+
+Use this reference before implementation or before presenting a plan as ready.
+
+## Mission
+
+The critic is adversarial. It tries to prove that the plan will fail to fully close the issue. It reviews evidence and plan quality, not prose style, and it does not write production code.
+
+## Preferred Invocation
+
+Use a separate critic context only if a subagent/delegation mechanism is available and the user/session has authorized it. Pass the trace artifacts and the plan, not your private conclusions.
+
+Prompt:
+
+```markdown
+You are an independent critic reviewing an issue-tracer fix plan before implementation.
+
+Find gaps, unwired functionality, unsupported assumptions, missed edge cases, missing tests, unsafe scope, and root-cause errors.
+
+Read these artifacts:
+- 01-issue-summary.md
+- 02-reproduction.md
+- 03-localization-log.md
+- 04-root-cause.md
+- 05-fix-plan.md
+
+Also inspect any files referenced in the plan. Do not trust summaries if the underlying code is available. Do not edit files.
+
+Return exactly:
+
+# Critic Review
+
+## Verdict
+APPROVE / NEEDS_REVISION / BLOCKED
+
+## Evidence Sufficiency
+[Is root cause proven? What evidence is missing?]
+
+## Plan Correctness
+[Would the selected fix address the root cause?]
+
+## Unwired Functionality
+[Any entry point, export, caller, config, route, UI path, CLI path, docs path, or test path not connected?]
+
+## Edge Cases
+[Missed null/empty/error/concurrent/idempotent/security/backward-compat cases.]
+
+## Test Gaps
+[Positive, negative, regression, integration, fixture, drift, and adversarial gaps.]
+
+## Scope Risk
+[Overreach, underreach, public API, migration, external service, or rollout risks.]
+
+## Required Revisions
+- [Required change or NONE]
+```
+
+## Fallback Invocation
+
+If no independent critic is available, create or report the same review with this disclosure:
+
+```markdown
+# Critic Review
+
+Fallback self-critic: independent critic unavailable.
+
+## Verdict
+APPROVE / NEEDS_REVISION / BLOCKED
+
+## Evidence Sufficiency
+[Is root cause proven? What evidence is missing?]
+
+## Plan Correctness
+[Would the selected fix address the root cause?]
+
+## Unwired Functionality
+[Any entry point, export, caller, config, route, UI path, CLI path, docs path, or test path not connected?]
+
+## Edge Cases
+[Missed null/empty/error/concurrent/idempotent/security/backward-compat cases.]
+
+## Test Gaps
+[Positive, negative, regression, integration, fixture, drift, and adversarial gaps.]
+
+## Scope Risk
+[Overreach, underreach, public API, migration, external service, or rollout risks.]
+
+## Required Revisions
+- [Required change or NONE]
+```
+
+Write the full fallback review in one pass. Do not leave a stub artifact containing only the disclosure.
+
+## Required Questions
+
+The critic must answer:
+
+1. Does reproduction match the issue, or only a nearby symptom?
+2. Is the claimed root cause necessary and sufficient?
+3. Could the fix make tests pass while leaving the real runtime path unwired?
+4. Are all callers, importers, and entry points covered?
+5. Are config defaults, feature flags, docs, generated code, and release surfaces considered?
+6. Are positive and negative tests included?
+7. Are boundary cases covered: null, empty, missing, malformed, duplicate, concurrent, retry, cancellation, timeout, permission denied, and partial failure?
+8. Does the patch preserve public API and backward compatibility?
+9. Does the plan avoid broad refactors and unrelated cleanup?
+10. Is rollback straightforward?
+11. For `opencode-swarm`, does the plan identify every touched invariant and concrete evidence needed for the PR audit?
+
+## Verdict Semantics
+
+- `APPROVE`: No blocker remains. Implementation may proceed when mode/user approval allows it.
+- `NEEDS_REVISION`: The plan is probably fixable, but one or more revisions are required first.
+- `BLOCKED`: The plan lacks evidence, has the wrong root cause, requires a product decision, or needs unavailable context.
+
+If the critic returns `NEEDS_REVISION` or `BLOCKED`, revise the plan, record the response to every item, and re-run or repeat the critic pass before proceeding.

--- a/.agents/skills/issue-tracer/references/evidence-artifacts.md
+++ b/.agents/skills/issue-tracer/references/evidence-artifacts.md
@@ -1,0 +1,246 @@
+# Evidence Artifacts
+
+Use these templates when a trace directory is warranted. Default path:
+
+```text
+.Codex/issue-traces/<issue-id-or-slug>/
+```
+
+## `01-issue-summary.md`
+
+```markdown
+# Issue Summary
+
+## Source
+- Issue: [URL or user-provided text]
+- Repo: [owner/repo or local path]
+- Labels: [labels]
+- State: [open/closed/unknown]
+
+## Observed Behavior
+[What actually happens. Include exact errors and stack traces.]
+
+## Expected Behavior
+[What should happen.]
+
+## Reproduction Steps
+1. [Step]
+2. [Step]
+3. [Step]
+
+## Environment
+- Runtime:
+- OS/platform:
+- Browser/device:
+- Feature flags/config:
+- External services:
+
+## Acceptance Criteria
+- [ ] [Measurable behavior]
+- [ ] [Measurable behavior]
+
+## Ambiguities
+- [Question or missing input]
+```
+
+## `02-reproduction.md`
+
+```markdown
+# Reproduction Evidence
+
+## Commands Tried
+
+### Attempt 1
+- Command:
+- Exit code:
+- Result: CONFIRMED / NOT REPRODUCED / BLOCKED
+
+```text
+[Exact output]
+```
+
+## Minimal Reproduction
+- Test/script/checklist:
+- Why it matches the reported issue:
+
+## Reproduction Verdict
+[Confirmed, blocked, or non-reproducible with reason.]
+```
+
+## `03-localization-log.md`
+
+```markdown
+# Localization Log
+
+## Active Hypotheses
+
+### H1: [Hypothesis]
+- Status: active / confirmed / ruled_out / inconclusive
+- Suspected file/symbol:
+- Evidence for:
+- Evidence against:
+- Commands/tests:
+- Verdict:
+
+## Files Read
+- `path/file.ext:lines` - [why read] - [what was learned]
+
+## Searches Run
+- `rg "pattern"` - [result]
+
+## Tests/Commands Run
+- `command` - PASS/FAIL/BLOCKED - [meaning]
+
+## Ruled-Out Paths
+- [Path] - [why ruled out]
+```
+
+## `04-root-cause.md`
+
+```markdown
+# Root Cause
+
+## Summary
+[What failed, where, and why.]
+
+## Exact Location
+- File:
+- Symbol:
+- Lines:
+
+## Broken Contract
+[Invariant or behavioral contract violated.]
+
+## Triggering Conditions
+[Inputs/state/environment required.]
+
+## Evidence Chain
+1. [Symptom]
+2. [Code evidence]
+3. [Command/test evidence]
+4. [Ruled-out alternatives]
+
+## Confidence
+[0-100% with reason. Stop below 90%.]
+```
+
+## `05-fix-plan.md`
+
+```markdown
+# Fix Plan
+
+## Issue
+[Short summary.]
+
+## Root Cause
+[From 04-root-cause.md.]
+
+## Candidate Fixes
+| Candidate | Approach | Files | Pros | Cons | Verdict |
+|---|---|---|---|---|---|
+| A | [Minimal guard/logic/config/state/API fix] | [files] | [pros] | [cons] | selected/rejected |
+
+## Selected Fix
+[Exact behavioral change and why it is necessary and sufficient.]
+
+## Files Expected to Change
+- `path/file.ext` - [exact reason]
+
+## Impact Analysis
+- Callers/importers:
+- Tests/fixtures:
+- Config/docs:
+- API/UI/CLI:
+- Persistence/migrations:
+- Security/privacy:
+- Concurrency/idempotency:
+- opencode-swarm invariants touched:
+
+## Edge Cases
+- [edge] - covered by [test/check]
+
+## Test Plan
+1. [Failing regression test]
+2. [Impacted suite]
+3. [Lint/type/build/security checks]
+
+## Unwired Functionality Checklist
+- [ ] Entry point reaches new/changed logic.
+- [ ] All callers use the updated contract correctly.
+- [ ] Error path is observable and handled.
+- [ ] No new branch lacks tests or manual verification.
+- [ ] Documentation/comments match actual behavior.
+
+## Risk and Rollback
+- Risk:
+- Rollback:
+
+## Critic Status
+- Critic verdict:
+- Required revisions:
+```
+
+## `06-critic-review.md`
+
+Use `references/critic-gate.md`.
+
+## `07-approved-plan.md`
+
+```markdown
+# Reviewed Plan
+
+[Copy final 05-fix-plan.md here.]
+
+## User Approval
+- [ ] User explicitly approved implementation on [date/time/session note]
+```
+
+In approved-implementation mode, record why approval was already implied by the user's request instead of blocking.
+
+## `08-test-results.md`
+
+```markdown
+# Test Results
+
+## Regression Test
+- Command:
+- Before fix: FAIL / not run with reason
+- After fix: PASS / FAIL
+
+## Impacted Tests
+- Command:
+- Result:
+
+## Quality Checks
+- Lint:
+- Typecheck:
+- Build:
+- Format:
+- Security/static checks:
+
+## Verification Reasoning
+[Why the fix is correct beyond merely making tests pass.]
+
+## Test Drift Review
+[Any stale tests found and how they were handled.]
+
+## Invariant Audit Evidence
+[For opencode-swarm touched invariants, list concrete command/source evidence.]
+```
+
+## `09-pr-body.md`
+
+Use `assets/pr-template.md`.
+
+## `state.md`
+
+```markdown
+# Trace State
+
+- Phase:
+- Completed gates:
+- Active hypothesis:
+- Selected fix:
+- Unresolved risks:
+- Next action:
+```

--- a/.agents/skills/issue-tracer/references/localization-playbook.md
+++ b/.agents/skills/issue-tracer/references/localization-playbook.md
@@ -1,0 +1,103 @@
+# Localization Playbook
+
+Use this playbook during root-cause localization. The goal is not to read the most code; it is to build the shortest evidence chain from symptom to root cause.
+
+## Tier 1: Trace-Driven Localization
+
+Use when the issue includes a stack trace, failing test output, panic, exception, compiler error, log line, request ID, or command output.
+
+1. Extract file paths, symbols, line numbers, route names, command names, config keys, and exact error strings.
+2. Start from the first project-owned frame, not framework/library frames.
+3. Read the frame, its immediate caller, and any input validation or error-mapping code.
+4. Confirm whether the visible crash site is the cause or only the symptom.
+5. If the trace points to generic error handling, walk backward to the first domain-specific invariant break.
+
+Common interpretations:
+
+- Null/undefined/type errors often originate at a missing guard or wrong contract before the crash line.
+- Index/bounds errors often originate in filtering, slicing, pagination, or off-by-one logic.
+- Assertion failures often indicate an upstream invariant break.
+- Timeout/deadlock symptoms require call-chain, lock, retry, cancellation, and external-service review.
+- Serialization errors often require checking producer and consumer schemas.
+
+## Tier 2: Semantic and Structural Localization
+
+Use when the stack trace is missing, generic, misleading, or incomplete.
+
+1. Convert issue text into search terms: user-visible strings, endpoint names, component labels, command flags, config keys, domain nouns, and verbs.
+2. Search broadly, then narrow:
+   - `rg "<exact error>"`
+   - `rg "<route-or-command>"`
+   - `rg "<domain term>|<config key>|<flag>"`
+   - `git grep "<tracked symbol>"`
+3. Build a candidate file table:
+   - file
+   - relevant symbol
+   - why it could cause the symptom
+   - confidence
+   - next evidence needed
+4. Inspect dependency direction:
+   - who calls this code
+   - what this code calls
+   - where state/config enters
+   - where errors are transformed
+5. Use git archaeology deliberately:
+   - `git log --oneline -- <path>`
+   - `git show <commit> -- <path>`
+   - `git blame -L <start>,<end> -- <path>`
+
+## Tier 3: Hypothesis-Driven Localization
+
+Use when multiple plausible locations remain.
+
+1. Generate 2-5 competing hypotheses.
+2. For each hypothesis, define the evidence that would confirm it and the evidence that would falsify it.
+3. Test hypotheses in likelihood order.
+4. Keep no more than three active hypotheses.
+5. Drop weak hypotheses once evidence contradicts them.
+
+Hypothesis format:
+
+```markdown
+### H[N]: [short name]
+The bug is in `path:symbol` because [specific condition] violates [specific contract], causing [reported symptom] when [triggering input/state].
+
+- Confirm if:
+- Falsify if:
+- Evidence:
+- Verdict:
+```
+
+## Granularity Rules
+
+Localize at multiple levels before planning a patch:
+
+1. File-level: which file owns the failing behavior.
+2. Element-level: which function/class/config/test helper is responsible.
+3. Line-level: which condition, call, assignment, invariant, or boundary check is wrong.
+
+Function-level evidence is usually the most useful planning granularity. Line-level evidence is required before editing, but avoid overfitting the plan to one line if the issue is a broken contract across a whole function.
+
+## Call-Chain Exploration
+
+When failure propagates across components:
+
+1. Start at the failing entry point.
+2. Follow calls one layer at a time.
+3. At each layer, ask:
+   - what data enters
+   - what contract is assumed
+   - what state changes
+   - what errors are swallowed or transformed
+   - what output leaves
+4. Backtrack when evidence weakens.
+5. Record pruned branches in `03-localization-log.md`.
+
+## Stop Conditions
+
+Stop and escalate if:
+
+- root cause requires unavailable production-only data
+- two hypotheses remain equally supported
+- the issue requires a product decision rather than a code correction
+- the suspected fix crosses subsystem boundaries beyond approved scope

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.19.0",
+    version: "7.19.1",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.19.0",
+    version: "7.19.1",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/docs/releases/v7.19.1.md
+++ b/docs/releases/v7.19.1.md
@@ -120,3 +120,15 @@ the result tells the caller (or architect) what to pass.
 | 10 | Chat / system msg | Yes | Layer A pushes onto `output.system`, surviving the single-system-message collapse at `experimental.chat.system.transform`. |
 | 11 | Tool registration coherence | Yes | `SPEC_DRIFT_BLOCKED_TOOLS` enumerates registered tool names; parity verified by `tests/unit/hooks/spec-drift-block.test.ts`. |
 | 12 | Release / cache | Yes | This file (`docs/releases/v7.19.0.md`) added. `package.json#version`, `CHANGELOG.md`, and `.release-please-manifest.json` will be updated by release-please. |
+
+## Codex workflow tooling
+
+This follow-up adds a Codex-native `issue-tracer` skill under `.agents/skills/`.
+The skill ports the existing evidence-first issue investigation workflow into
+Codex conventions: Codex skill metadata, `apply_patch`-based edits,
+`update_plan` phase tracking, optional trace artifacts under `.Codex/`, and
+opencode-swarm invariant-audit hooks.
+
+This is workflow-only repository tooling. It does not change plugin runtime
+behavior, package exports, generated `dist/` artifacts, or user-facing OpenCode
+behavior.


### PR DESCRIPTION
## Summary
- Add a Codex-native `issue-tracer` skill under `.agents/skills/issue-tracer`, with Codex frontmatter, UI metadata, evidence artifacts, localization guidance, critic review guidance, and PR closure template.
- Preserve the existing Claude issue-tracer skill unchanged while adapting the workflow to Codex tools (`apply_patch`, `update_plan`, `shell_command`) and `.Codex/issue-traces/` trace artifacts.
- Include release-note coverage and generated `dist/` version sync exposed by the required build preflight.

## Invariant audit
- 1 (plugin init): not touched - no plugin initialization source changed. Validation attempted `node scripts\repro-704.mjs` twice; both local runs timed out at 120s and 300s, documented below.
- 2 (runtime portability): touched - generated `dist/index.js` and `dist/cli/index.js` only changed embedded package version from `7.19.0` to `7.19.1`; `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` passed.
- 3 (subprocesses): not touched - no source subprocess call sites changed.
- 4 (.swarm containment): not touched - runtime `.swarm/` behavior unchanged; skill documentation only references optional `.Codex/issue-traces/` artifacts.
- 5 (plan durability): not touched - no plan schema, ledger, checkpoint, or projection code changed.
- 6 (test_runner safety): not touched - OpenCode `test_runner` was not used.
- 7 (test writing): not touched - no test files changed.
- 8 (session state): not touched - no session/global state code changed.
- 9 (guardrails/retry): not touched - no guardrail or retry logic changed.
- 10 (chat/system msg): not touched - no hook or chat message code changed.
- 11 (tool registration): not touched - no plugin tools, agent maps, or command registry entries changed.
- 12 (release/cache): touched - `docs/releases/v7.19.1.md` documents the Codex workflow tooling; build preflight synced generated `dist/` version strings.

## Test plan
- [x] `python C:\Users\Brett\.codex\skills\.system\skill-creator\scripts\quick_validate.py .agents\skills\issue-tracer` - pass
- [x] `rg -n "allowed-tools|TodoWrite|WebFetch|\bBash\b|MultiEdit|\.claude/issue-traces|\.claude\\issue-traces|Claude Code|TODO|[^\x00-\x7F]|[ \t]+$" .agents\skills\issue-tracer -S` - no matches
- [x] `bun install` - installed missing dependencies in clean worktree
- [x] `bun run build` - pass
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` - pass
- [x] `bun run typecheck` - pass
- [x] `bunx biome ci .` - pass with 2 existing warnings in `src/turbo/lean/runner.ts`
- [x] Per-file `tests/unit/agents/*.test.ts` - pass
- [ ] Per-file `tests/unit/tools/*.test.ts` - blocked by unrelated existing failure in `tests/unit/tools/diagnostic-gating.test.ts`
- [ ] Per-file `tests/unit/services/*.test.ts` - blocked by unrelated existing Windows path separator failures in `tests/unit/services/skill-generator.test.ts`
- [ ] Per-file `tests/unit/hooks/*.test.ts` - blocked by unrelated existing aggregate-count failures in `tests/unit/hooks/agent-activity.test.ts`
- [ ] `bun --smol test tests\unit\cli tests\unit\commands tests\unit\config --timeout 120000` - blocked by unrelated existing failures, including `uv_spawn 'bun'` in `tests/unit/cli/install.test.ts` and broad command-handler expectation failures
- [ ] `node scripts\repro-704.mjs` - timed out locally at both 120s and 300s

## Pre-existing / unrelated validation failures
This branch does not change `src/` or `tests/`. The failures above are outside the skill/docs/dist-version surface and should be handled separately if they are not already known on `main`.
