### PR TITLE
fix(guardrails): classify structured provider errors as transient

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.19.1",
+    version: "7.19.2",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.19.1",
+    version: "7.19.2",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -24201,6 +24201,91 @@ function extractStatusCode(errorMsg) {
   }
   return null;
 }
+function isPlainObject2(value) {
+  return typeof value === "object" && value !== null && (value.constructor === Object || Object.getPrototypeOf(value) === null);
+}
+function readSignalField(source, key) {
+  try {
+    return source[key];
+  } catch {
+    return;
+  }
+}
+function pushSignalValue(parts2, value) {
+  if (typeof value === "string") {
+    parts2.push(value);
+    return;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    parts2.push(String(value));
+  }
+}
+function appendSelectedFields(parts2, source, keys) {
+  for (const key of keys) {
+    pushSignalValue(parts2, readSignalField(source, key));
+  }
+}
+function appendNestedErrorSignal(parts2, value) {
+  if (typeof value === "string") {
+    parts2.push(value);
+    return;
+  }
+  if (value instanceof Error) {
+    parts2.push(value.name, value.message);
+    appendSelectedFields(parts2, value, [
+      "code",
+      "status",
+      "statusCode"
+    ]);
+    return;
+  }
+  if (!isPlainObject2(value))
+    return;
+  appendSelectedFields(parts2, value, [
+    "code",
+    "status",
+    "statusCode",
+    "message",
+    "error_type"
+  ]);
+}
+function extractErrorSignal(errorContent) {
+  if (typeof errorContent === "string")
+    return errorContent;
+  if (errorContent == null)
+    return "";
+  const parts2 = [];
+  try {
+    if (errorContent instanceof Error) {
+      parts2.push(errorContent.name, errorContent.message);
+      appendSelectedFields(parts2, errorContent, ["code", "status", "statusCode"]);
+      return parts2.join(" ");
+    }
+    if (!isPlainObject2(errorContent))
+      return "";
+    appendSelectedFields(parts2, errorContent, [
+      "code",
+      "status",
+      "statusCode",
+      "message",
+      "error_type"
+    ]);
+    appendNestedErrorSignal(parts2, readSignalField(errorContent, "error"));
+    const metadata2 = readSignalField(errorContent, "metadata");
+    if (isPlainObject2(metadata2)) {
+      appendSelectedFields(parts2, metadata2, [
+        "code",
+        "status",
+        "statusCode",
+        "error_type"
+      ]);
+    }
+    appendNestedErrorSignal(parts2, readSignalField(errorContent, "cause"));
+  } catch {
+    return parts2.join(" ");
+  }
+  return parts2.join(" ");
+}
 function getStoredInputArgs(callID) {
   return storedInputArgs.get(callID);
 }
@@ -25410,16 +25495,17 @@ function createGuardrailsHooks(directory, directoryOrConfig, config2, authorityC
       if (hasError) {
         const outputStr = typeof output.output === "string" ? output.output : "";
         const errorContent = output.error ?? outputStr;
-        const extractedStatus = typeof errorContent === "string" ? extractStatusCode(errorContent) : null;
+        const errorSignal = extractErrorSignal(errorContent);
+        const extractedStatus = extractStatusCode(errorSignal);
         const isTransientStatusCode = extractedStatus !== null && TRANSIENT_STATUS_CODES.has(extractedStatus);
-        const isTransientPatternMatch = typeof errorContent === "string" && TRANSIENT_MODEL_ERROR_PATTERN.test(errorContent);
+        const isTransientPatternMatch = TRANSIENT_MODEL_ERROR_PATTERN.test(errorSignal);
         const isTransientMatch = isTransientStatusCode || isTransientPatternMatch;
         const isTransient = !!session && isTransientMatch && window2.transientRetryCount < cfg.max_transient_retries;
-        const isDegraded = !isTransient && typeof errorContent === "string" && DEGRADED_ERROR_PATTERN.test(errorContent);
+        const isDegraded = !isTransient && DEGRADED_ERROR_PATTERN.test(errorSignal);
         if (isTransient) {
           window2.transientRetryCount++;
         } else if (isDegraded) {
-          const isContentFilter = typeof errorContent === "string" && CONTENT_FILTER_PATTERN.test(errorContent);
+          const isContentFilter = CONTENT_FILTER_PATTERN.test(errorSignal);
           if (session && !session.modelFallbackExhausted) {
             session.model_fallback_index++;
             const baseAgentName = session.agentName ? session.agentName.replace(/^[^_]+[_]/, "") : "";
@@ -26076,7 +26162,7 @@ var init_guardrails = __esm(() => {
   ]);
   storedInputArgs = new Map;
   TRANSIENT_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504, 529]);
-  TRANSIENT_MODEL_ERROR_PATTERN = /rate.?limit|429|500|502|503|504|529|timeout|overloaded|model.?not.?found|temporarily.?unavailable|server.?error|connection.?(refused|reset|timeout)|bad.?gateway|gateway.?timeout|internal.?server.?error|service.?unavailable/i;
+  TRANSIENT_MODEL_ERROR_PATTERN = /rate.?limit|429|500|502|503|504|529|timeout|overloaded|model.?not.?found|temporarily.?unavailable|provider.?unavailable|server.?error|connection.?(refused|reset|timeout|lost)|bad.?gateway|gateway.?timeout|internal.?server.?error|service.?unavailable/i;
   DEGRADED_ERROR_PATTERN = /context.?length|token.?(limit|budget)|input.?too.?long|content.?filter|exceeds?.?(maximum.?)?tokens|maximum.?context|context.?window|too.?many.?tokens|prompt.?too.?long|message.?too.?long|request.?too.?large|max.?tokens/i;
   CONTENT_FILTER_PATTERN = /content.?filter/i;
   toolCallsSinceLastWrite = new Map;
@@ -28275,7 +28361,7 @@ __export(exports_util2, {
   jsonStringifyReplacer: () => jsonStringifyReplacer2,
   joinValues: () => joinValues2,
   issue: () => issue2,
-  isPlainObject: () => isPlainObject2,
+  isPlainObject: () => isPlainObject3,
   isObject: () => isObject2,
   hexToUint8Array: () => hexToUint8Array2,
   getSizableOrigin: () => getSizableOrigin2,
@@ -28443,7 +28529,7 @@ function esc2(str) {
 function isObject2(data) {
   return typeof data === "object" && data !== null && !Array.isArray(data);
 }
-function isPlainObject2(o) {
+function isPlainObject3(o) {
   if (isObject2(o) === false)
     return false;
   const ctor = o.constructor;
@@ -28458,7 +28544,7 @@ function isPlainObject2(o) {
   return true;
 }
 function shallowClone2(o) {
-  if (isPlainObject2(o))
+  if (isPlainObject3(o))
     return { ...o };
   if (Array.isArray(o))
     return [...o];
@@ -28584,7 +28670,7 @@ function omit2(schema, mask) {
   return clone2(schema, def);
 }
 function extend2(schema, shape) {
-  if (!isPlainObject2(shape)) {
+  if (!isPlainObject3(shape)) {
     throw new Error("Invalid input to extend: expected a plain object");
   }
   const checks3 = schema._zod.def.checks;
@@ -28603,7 +28689,7 @@ function extend2(schema, shape) {
   return clone2(schema, def);
 }
 function safeExtend2(schema, shape) {
-  if (!isPlainObject2(shape)) {
+  if (!isPlainObject3(shape)) {
     throw new Error("Invalid input to safeExtend: expected a plain object");
   }
   const def = {
@@ -29986,7 +30072,7 @@ function mergeValues2(a, b) {
   if (a instanceof Date && b instanceof Date && +a === +b) {
     return { valid: true, data: a };
   }
-  if (isPlainObject2(a) && isPlainObject2(b)) {
+  if (isPlainObject3(a) && isPlainObject3(b)) {
     const bKeys = Object.keys(b);
     const sharedKeys = Object.keys(a).filter((key) => bKeys.indexOf(key) !== -1);
     const newObj = { ...a, ...b };
@@ -31083,7 +31169,7 @@ var init_schemas3 = __esm(() => {
     $ZodType2.init(inst, def);
     inst._zod.parse = (payload, ctx) => {
       const input = payload.value;
-      if (!isPlainObject2(input)) {
+      if (!isPlainObject3(input)) {
         payload.issues.push({
           expected: "record",
           code: "invalid_type",

--- a/docs/releases/v7.19.3.md
+++ b/docs/releases/v7.19.3.md
@@ -1,0 +1,47 @@
+# v7.19.3
+
+## What changed
+
+OpenRouter provider/network errors that arrive as structured objects now use
+the same transient retry path as string provider errors. Guardrails extracts a
+bounded set of provider error fields such as `code`, `status`, `message`, and
+`metadata.error_type`, then runs the existing transient/degraded classification
+logic.
+
+This fixes issue #856, where a short OpenRouter outage like:
+
+```json
+{"code":502,"message":"Network connection lost.","metadata":{"error_type":"provider_unavailable"}}
+```
+
+could be counted as a normal consecutive tool error instead of consuming the
+transient retry budget.
+
+## Why
+
+The transient retry classifier already recognized `502` and provider outage
+strings, but `toolAfter` only classified string-shaped `output.error` values.
+Some providers surface model failures as objects, so those errors skipped
+status-code extraction and keyword matching.
+
+## Migration steps
+
+No config changes are required. Existing `max_transient_retries` and
+`fallback_models` settings continue to apply.
+
+## Invariant audit
+
+| # | Invariant | Touched | Notes |
+|---|---|---|---|
+| 1 | Plugin init | No | No plugin initialization changes. |
+| 2 | Runtime portability | Yes | `src/hooks/guardrails.ts` is in the plugin bundle; build, bundle tests, and direct Node ESM import validate portability. |
+| 3 | Subprocesses | No | No subprocess changes. |
+| 4 | `.swarm` containment | No | No `.swarm` storage changes. |
+| 5 | Plan durability | No | No plan persistence changes. |
+| 6 | `test_runner` safety | No | Validation uses shell `bun` commands, not broad `test_runner`. |
+| 7 | Test writing | Yes | Regression tests use `bun:test` and existing hook test helpers. |
+| 8 | Session state | No | No session state shape or persistence changes. |
+| 9 | Guardrails / retry | Yes | Structured provider errors now enter the existing transient/degraded guardrails classification path; focused hook tests cover positive, negative, adversarial, and no-throw object payloads. |
+| 10 | Chat / system msg | No | No chat/system message shape changes. |
+| 11 | Tool registration coherence | No | No tools or agent maps changed. |
+| 12 | Release / cache | Yes | This release note was added; release-please owns version files. |

--- a/src/hooks/guardrails.ts
+++ b/src/hooks/guardrails.ts
@@ -116,12 +116,125 @@ function extractStatusCode(errorMsg: string): number | null {
 	return null;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value.constructor === Object || Object.getPrototypeOf(value) === null)
+	);
+}
+
+function readSignalField(
+	source: Record<string, unknown>,
+	key: string,
+): unknown {
+	try {
+		return source[key];
+	} catch {
+		return undefined;
+	}
+}
+
+function pushSignalValue(parts: string[], value: unknown): void {
+	if (typeof value === 'string') {
+		parts.push(value);
+		return;
+	}
+	if (typeof value === 'number' || typeof value === 'boolean') {
+		parts.push(String(value));
+	}
+}
+
+function appendSelectedFields(
+	parts: string[],
+	source: Record<string, unknown>,
+	keys: readonly string[],
+): void {
+	for (const key of keys) {
+		pushSignalValue(parts, readSignalField(source, key));
+	}
+}
+
+function appendNestedErrorSignal(parts: string[], value: unknown): void {
+	if (typeof value === 'string') {
+		parts.push(value);
+		return;
+	}
+	if (value instanceof Error) {
+		parts.push(value.name, value.message);
+		appendSelectedFields(parts, value as unknown as Record<string, unknown>, [
+			'code',
+			'status',
+			'statusCode',
+		]);
+		return;
+	}
+	if (!isPlainObject(value)) return;
+	appendSelectedFields(parts, value, [
+		'code',
+		'status',
+		'statusCode',
+		'message',
+		'error_type',
+	]);
+}
+
+/**
+ * Extracts bounded provider/error signal from unknown hook error payloads.
+ * Do not stringify arbitrary objects here: unrelated fields like `phase: 502`
+ * must not accidentally become transient provider errors.
+ */
+function extractErrorSignal(errorContent: unknown): string {
+	if (typeof errorContent === 'string') return errorContent;
+	if (errorContent == null) return '';
+
+	const parts: string[] = [];
+
+	try {
+		if (errorContent instanceof Error) {
+			parts.push(errorContent.name, errorContent.message);
+			appendSelectedFields(
+				parts,
+				errorContent as unknown as Record<string, unknown>,
+				['code', 'status', 'statusCode'],
+			);
+			return parts.join(' ');
+		}
+
+		if (!isPlainObject(errorContent)) return '';
+
+		appendSelectedFields(parts, errorContent, [
+			'code',
+			'status',
+			'statusCode',
+			'message',
+			'error_type',
+		]);
+
+		appendNestedErrorSignal(parts, readSignalField(errorContent, 'error'));
+		const metadata = readSignalField(errorContent, 'metadata');
+		if (isPlainObject(metadata)) {
+			appendSelectedFields(parts, metadata, [
+				'code',
+				'status',
+				'statusCode',
+				'error_type',
+			]);
+		}
+		appendNestedErrorSignal(parts, readSignalField(errorContent, 'cause'));
+	} catch {
+		return parts.join(' ');
+	}
+
+	return parts.join(' ');
+}
+
 /**
  * v6.33: Regex pattern for transient model errors that should trigger fallback.
  * Matches: rate limits, overloaded, timeouts, model not found, temporary failures.
  */
 const TRANSIENT_MODEL_ERROR_PATTERN =
-	/rate.?limit|429|500|502|503|504|529|timeout|overloaded|model.?not.?found|temporarily.?unavailable|server.?error|connection.?(refused|reset|timeout)|bad.?gateway|gateway.?timeout|internal.?server.?error|service.?unavailable/i;
+	/rate.?limit|429|500|502|503|504|529|timeout|overloaded|model.?not.?found|temporarily.?unavailable|provider.?unavailable|server.?error|connection.?(refused|reset|timeout|lost)|bad.?gateway|gateway.?timeout|internal.?server.?error|service.?unavailable/i;
 
 /**
  * v7.12: Regex pattern for degraded model errors — context-length/token-limit/content-filter
@@ -2534,6 +2647,7 @@ export function createGuardrailsHooks(
 				// output.error may contain error message for failed tool calls (not in TS type but present at runtime)
 				const errorContent =
 					(output as Record<string, unknown>).error ?? outputStr;
+				const errorSignal = extractErrorSignal(errorContent);
 
 				// v6.34: Transient model errors (429, 503, 529, timeout, overloaded) bypass
 				// consecutiveErrors for up to cfg.max_transient_retries attempts per invocation
@@ -2541,18 +2655,14 @@ export function createGuardrailsHooks(
 				// !modelFallbackExhausted, which expired immediately when no fallback_models were
 				// configured, causing the circuit breaker to fire after a single transient error.
 				// Check HTTP status code first (more reliable than keyword matching)
-				const extractedStatus =
-					typeof errorContent === 'string'
-						? extractStatusCode(errorContent)
-						: null;
+				const extractedStatus = extractStatusCode(errorSignal);
 				const isTransientStatusCode =
 					extractedStatus !== null &&
 					TRANSIENT_STATUS_CODES.has(extractedStatus);
 
 				// Fall back to keyword matching if no status code found
 				const isTransientPatternMatch =
-					typeof errorContent === 'string' &&
-					TRANSIENT_MODEL_ERROR_PATTERN.test(errorContent);
+					TRANSIENT_MODEL_ERROR_PATTERN.test(errorSignal);
 
 				const isTransientMatch =
 					isTransientStatusCode || isTransientPatternMatch;
@@ -2564,18 +2674,14 @@ export function createGuardrailsHooks(
 
 				// Degraded errors (context-length, token-limit) bypass both counters
 				const isDegraded =
-					!isTransient &&
-					typeof errorContent === 'string' &&
-					DEGRADED_ERROR_PATTERN.test(errorContent);
+					!isTransient && DEGRADED_ERROR_PATTERN.test(errorSignal);
 
 				if (isTransient) {
 					window.transientRetryCount++;
 				} else if (isDegraded) {
 					// Degraded errors do NOT increment consecutiveErrors or transientRetryCount
 					// They indicate the provider is rejecting this specific input, not a logic error
-					const isContentFilter =
-						typeof errorContent === 'string' &&
-						CONTENT_FILTER_PATTERN.test(errorContent);
+					const isContentFilter = CONTENT_FILTER_PATTERN.test(errorSignal);
 
 					if (session && !session.modelFallbackExhausted) {
 						session.model_fallback_index++;

--- a/src/transient-retry.test.ts
+++ b/src/transient-retry.test.ts
@@ -23,7 +23,7 @@ import {
 // The regex is private to guardrails.ts; test it inline against the same
 // source pattern so that any future change to the constant triggers a test failure.
 const TRANSIENT_MODEL_ERROR_PATTERN =
-	/rate.?limit|429|503|529|timeout|overloaded|model.?not.?found|temporarily unavailable|server error/i;
+	/rate.?limit|429|500|502|503|504|529|timeout|overloaded|model.?not.?found|temporarily.?unavailable|provider.?unavailable|server.?error|connection.?(refused|reset|timeout|lost)|bad.?gateway|gateway.?timeout|internal.?server.?error|service.?unavailable/i;
 
 let testSessionId: string;
 
@@ -89,6 +89,18 @@ describe('TRANSIENT_MODEL_ERROR_PATTERN regex — pre-existing terms (regression
 		expect(
 			TRANSIENT_MODEL_ERROR_PATTERN.test('service temporarily unavailable'),
 		).toBe(true);
+	});
+
+	it('1.8a matches provider_unavailable', () => {
+		expect(TRANSIENT_MODEL_ERROR_PATTERN.test('provider_unavailable')).toBe(
+			true,
+		);
+	});
+
+	it('1.8b matches connection lost', () => {
+		expect(TRANSIENT_MODEL_ERROR_PATTERN.test('Network connection lost.')).toBe(
+			true,
+		);
 	});
 
 	it('1.9 does NOT match a generic non-transient error', () => {

--- a/tests/unit/hooks/guardrails-error-classification.test.ts
+++ b/tests/unit/hooks/guardrails-error-classification.test.ts
@@ -521,6 +521,30 @@ describe('guardrails transient error classification (toolAfter)', () => {
 			expect(window?.consecutiveErrors).toBe(0);
 			expect(window?.transientRetryCount).toBe(1);
 		});
+
+		test('OpenRouter 502 object payload â†’ transient with fallback accounting', async () => {
+			const sessionId = 'session-openrouter-object-502';
+			const session = await setupSubagentSessionWithWindow(hooks, sessionId);
+
+			const input = { tool: 'bash', sessionID: sessionId, callID: 'call-1' };
+			const output = {
+				title: 'bash',
+				output: null,
+				error: {
+					code: 502,
+					message: 'Network connection lost.',
+					metadata: { error_type: 'provider_unavailable' },
+				},
+				metadata: {},
+			};
+
+			await hooks.toolAfter(input as any, output as any);
+
+			const window = getActiveWindow(sessionId);
+			expect(window?.consecutiveErrors).toBe(0);
+			expect(window?.transientRetryCount).toBe(1);
+			expect(session.model_fallback_index).toBe(1);
+		});
 	});
 
 	describe('permanent errors increment consecutiveErrors', () => {
@@ -590,6 +614,97 @@ describe('guardrails transient error classification (toolAfter)', () => {
 				title: 'bash',
 				output: null,
 				error: 'file not found at /path/to/file',
+				metadata: {},
+			};
+
+			await hooks.toolAfter(input as any, output as any);
+
+			const window = getActiveWindow(sessionId);
+			expect(window?.consecutiveErrors).toBe(1);
+			expect(window?.transientRetryCount).toBe(0);
+		});
+
+		test('non-transient object payload â†’ permanent', async () => {
+			const sessionId = 'session-object-auth-error';
+			await setupSubagentSessionWithWindow(hooks, sessionId);
+
+			const input = { tool: 'bash', sessionID: sessionId, callID: 'call-1' };
+			const output = {
+				title: 'bash',
+				output: null,
+				error: {
+					code: 401,
+					message: 'unauthorized: invalid API key',
+					metadata: { error_type: 'invalid_key' },
+				},
+				metadata: {},
+			};
+
+			await hooks.toolAfter(input as any, output as any);
+
+			const window = getActiveWindow(sessionId);
+			expect(window?.consecutiveErrors).toBe(1);
+			expect(window?.transientRetryCount).toBe(0);
+		});
+
+		test('structured type server_error with non-transient status remains permanent', async () => {
+			const sessionId = 'session-object-auth-server-error-type';
+			await setupSubagentSessionWithWindow(hooks, sessionId);
+
+			const input = { tool: 'bash', sessionID: sessionId, callID: 'call-1' };
+			const output = {
+				title: 'bash',
+				output: null,
+				error: {
+					code: 401,
+					type: 'server_error',
+					message: 'invalid credentials',
+				},
+				metadata: {},
+			};
+
+			await hooks.toolAfter(input as any, output as any);
+
+			const window = getActiveWindow(sessionId);
+			expect(window?.consecutiveErrors).toBe(1);
+			expect(window?.transientRetryCount).toBe(0);
+		});
+
+		test('transient-looking unrelated object fields are ignored', async () => {
+			const sessionId = 'session-object-unrelated-transient-looking-fields';
+			await setupSubagentSessionWithWindow(hooks, sessionId);
+
+			const input = { tool: 'bash', sessionID: sessionId, callID: 'call-1' };
+			const output = {
+				title: 'bash',
+				output: null,
+				error: {
+					message: 'validation failed',
+					phase: 502,
+					details: 'retry after timeout',
+				},
+				metadata: {},
+			};
+
+			await hooks.toolAfter(input as any, output as any);
+
+			const window = getActiveWindow(sessionId);
+			expect(window?.consecutiveErrors).toBe(1);
+			expect(window?.transientRetryCount).toBe(0);
+		});
+
+		test('cyclic object payload does not throw and remains permanent without provider signal', async () => {
+			const sessionId = 'session-object-cyclic';
+			await setupSubagentSessionWithWindow(hooks, sessionId);
+
+			const cyclic: Record<string, unknown> = { message: 'validation failed' };
+			cyclic.self = cyclic;
+
+			const input = { tool: 'bash', sessionID: sessionId, callID: 'call-1' };
+			const output = {
+				title: 'bash',
+				output: null,
+				error: cyclic,
 				metadata: {},
 			};
 
@@ -942,6 +1057,29 @@ describe('guardrails transient error classification (toolAfter)', () => {
 				title: 'bash',
 				output: null,
 				error: 'content filter triggered',
+				metadata: {},
+			};
+
+			await hooks.toolAfter(input as any, output as any);
+
+			const window = getActiveWindow(sessionId);
+			expect(window?.consecutiveErrors).toBe(0);
+			expect(window?.transientRetryCount).toBe(0);
+			expect(session.model_fallback_index).toBe(1);
+		});
+
+		test('object-shaped content-filter error is degraded', async () => {
+			const sessionId = 'session-object-content-filter';
+			const session = await setupSubagentSessionWithWindow(hooks, sessionId);
+
+			const input = { tool: 'bash', sessionID: sessionId, callID: 'call-1' };
+			const output = {
+				title: 'bash',
+				output: null,
+				error: {
+					message: 'content filter triggered',
+					metadata: { error_type: 'policy_violation' },
+				},
 				metadata: {},
 			};
 


### PR DESCRIPTION
﻿## Summary
- classify structured provider error payloads as transient/degraded/content-filter signals without stringifying arbitrary objects
- include OpenRouter-style provider_unavailable / Network connection lost signals in retry classification
- add release note and regression/adversarial coverage for object-shaped guardrail errors

## Invariant audit
- 1 (plugin init): not touched - no plugin initialization files or startup work changed.
- 2 (runtime portability): touched - `bun run build`, bundle-portability/plugin-shape/node-load tests, and direct Node ESM import passed after bundling.
- 3 (subprocesses): not touched - changed source files do not introduce spawn, exec, or direct Bun usage.
- 4 (.swarm containment): not touched - no runtime storage/path containment changes.
- 5 (plan durability): not touched - no ledger, projection, checkpoint, or plan schema changes.
- 6 (test_runner safety): not touched - validation used shell/Bun commands, not broad OpenCode test_runner scopes.
- 7 (test writing): touched - loaded the repo writing-tests skill before modifying tests; added focused behavior tests plus adversarial object-payload coverage.
- 8 (session state): not touched - no session-scoped global state changes.
- 9 (guardrails/retry): touched - guardrails error-classification and transient-retry tests passed, covering structured transient, auth-negative, adversarial object, cyclic object, and content-filter paths.
- 10 (chat/system msg): not touched - no message-shape or chat-visible stream changes.
- 11 (tool registration): not touched - no tool, agent-map, command, or help registration changes.
- 12 (release/cache): touched - added `docs/releases/v7.19.3.md`; did not edit release-please managed version/changelog/manifest files.

## Test plan
- PASS `bun --smol test ./.Codex/issue-traces/856/repro-object-error.test.ts --timeout 30000`
- PASS `bun --smol test tests/unit/hooks/guardrails-error-classification.test.ts --timeout 30000`
- PASS `bun --smol test src/transient-retry.test.ts --timeout 30000`
- PASS `bun run typecheck`
- PASS `bunx biome ci .` with existing warnings in `src/turbo/lean/runner.ts`
- PASS `bun run build`
- PASS `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts tests/unit/build/bundle-node-load.test.ts --timeout 120000`
- PASS direct Node ESM import of `./dist/index.js`
- PASS `bun --smol test tests/smoke/packaging.test.ts --timeout 120000`
- PASS `git diff --check`

## Pre-existing failures / environment notes
- `node scripts/repro-704.mjs` timed out on this branch and on clean `origin/main` (`6cb3dd15`), so it is not introduced by this guardrails change.
- `bun --smol test tests/unit/tools/diagnostic-gating.test.ts --timeout 30000` fails on this branch and on clean `origin/main` (`6cb3dd15`) with the same three source-pattern assertions: curator warn gating expected true, all diagnostic locations gated expected true, and DEBUG_SWARM check count expected 10 but found 8.
- The remaining commit-pr suite was run around the known diagnostic-gating failure; additional local Windows/environment-sensitive failures appeared in unrelated config tests, including `project-init.test.ts` symlink/child-process cases and quiet-config warning expectations. Focused guardrails, typecheck, lint, build, bundle, import, and smoke packaging validation passed.
