### PR TITLE
fix(phase-complete): require durable gate proof

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -90244,6 +90244,7 @@ function phaseIsExplicitlyNonCode(directory, phase) {
 }
 
 // src/tools/phase-complete.ts
+init_gate_evidence();
 init_curator();
 init_knowledge_curator();
 init_knowledge_reader();
@@ -90779,6 +90780,23 @@ function safeWarn(message, error93) {
     warn(message, error93 instanceof Error ? error93.message : String(error93));
   } catch {}
 }
+var TASK_GATE_INFERABLE_AGENTS = new Set([
+  "coder",
+  "reviewer",
+  "test_engineer"
+]);
+function canInferMissingAgentsFromTaskGates(agentsMissing) {
+  return agentsMissing.every((agent) => TASK_GATE_INFERABLE_AGENTS.has(agent));
+}
+async function allCompletedTasksHavePassedGateEvidence(directory, tasks) {
+  for (const task of tasks) {
+    if (task.status !== "completed")
+      return false;
+    if (!await hasPassedAllGates(directory, task.id))
+      return false;
+  }
+  return tasks.length > 0;
+}
 function collectCrossSessionDispatchedAgents(phaseReferenceTimestamp, callerSessionId) {
   const agents = new Set;
   const contributorSessionIds = [];
@@ -90790,12 +90808,9 @@ function collectCrossSessionDispatchedAgents(phaseReferenceTimestamp, callerSess
         agents.add(agent);
       }
     }
-    const callerDelegations = swarmState.delegationChains.get(callerSessionId);
-    if (callerDelegations) {
-      for (const delegation of callerDelegations) {
-        agents.add(stripKnownSwarmPrefix(delegation.from));
-        agents.add(stripKnownSwarmPrefix(delegation.to));
-      }
+    for (const delegation of _getDelegationsSince(callerSessionId, phaseReferenceTimestamp)) {
+      agents.add(stripKnownSwarmPrefix(delegation.from));
+      agents.add(stripKnownSwarmPrefix(delegation.to));
     }
   }
   for (const [sessionId, session] of swarmState.agentSessions) {
@@ -90814,16 +90829,23 @@ function collectCrossSessionDispatchedAgents(phaseReferenceTimestamp, callerSess
           agents.add(agent);
         }
       }
-      const delegations2 = swarmState.delegationChains.get(sessionId);
-      if (delegations2) {
-        for (const delegation of delegations2) {
-          agents.add(stripKnownSwarmPrefix(delegation.from));
-          agents.add(stripKnownSwarmPrefix(delegation.to));
-        }
+      for (const delegation of _getDelegationsSince(sessionId, phaseReferenceTimestamp)) {
+        agents.add(stripKnownSwarmPrefix(delegation.from));
+        agents.add(stripKnownSwarmPrefix(delegation.to));
       }
     }
   }
   return { agents, contributorSessionIds };
+}
+function _getDelegationsSince(sessionID, sinceTimestamp) {
+  const chain = swarmState.delegationChains.get(sessionID);
+  if (!chain) {
+    return [];
+  }
+  if (sinceTimestamp === 0) {
+    return chain;
+  }
+  return chain.filter((entry) => entry.timestamp > sinceTimestamp);
 }
 function isValidRetroEntry(entry, phase) {
   return entry.type === "retrospective" && "phase_number" in entry && entry.phase_number === phase && "verdict" in entry && entry.verdict === "pass";
@@ -91770,8 +91792,8 @@ Advisory notes: ${advisoryNotes.join("; ")}` : "";
       const planRaw = fs84.readFileSync(planPath, "utf-8");
       const plan = JSON.parse(planRaw);
       const targetPhase = plan.phases.find((p) => p.id === phase);
-      if (targetPhase && targetPhase.tasks.length > 0 && targetPhase.tasks.every((t) => t.status === "completed")) {
-        warnings.push(`Agent dispatch fallback: all ${targetPhase.tasks.length} tasks in phase ${phase} are completed in plan.json. Clearing missing agents: ${agentsMissing.join(", ")}.`);
+      if (targetPhase && targetPhase.tasks.length > 0 && canInferMissingAgentsFromTaskGates(agentsMissing) && await allCompletedTasksHavePassedGateEvidence(dir, targetPhase.tasks)) {
+        warnings.push(`Agent dispatch fallback: all ${targetPhase.tasks.length} tasks in phase ${phase} are completed in plan.json and durable gate evidence passed. Clearing missing agents: ${agentsMissing.join(", ")}.`);
         agentsMissing = [];
       }
     } catch {}
@@ -103361,6 +103383,13 @@ function matchesTier3Pattern2(files) {
   }
   return false;
 }
+function hasPassedDurableGateEvidence(workingDirectory, taskId) {
+  const evidence = readTaskEvidenceRaw(workingDirectory, taskId);
+  if (!evidence || !Array.isArray(evidence.required_gates) || evidence.required_gates.length === 0) {
+    return false;
+  }
+  return evidence.required_gates.every((gate) => evidence.gates?.[gate] != null);
+}
 function checkReviewerGate(taskId, workingDirectory, stageBParallelEnabled = false, sessionID) {
   try {
     let skipStandardTurboBypass = false;
@@ -103407,12 +103436,11 @@ function checkReviewerGate(taskId, workingDirectory, stageBParallelEnabled = fal
     try {
       const evidence = readTaskEvidenceRaw(resolvedDir, taskId);
       if (evidence === null) {} else if (evidence.required_gates && Array.isArray(evidence.required_gates) && evidence.gates) {
-        const allGatesMet = evidence.required_gates.every((gate) => evidence.gates[gate] != null);
-        if (allGatesMet) {
+        if (evidence.required_gates.length > 0 && evidence.required_gates.every((gate) => evidence.gates[gate] != null)) {
           return { blocked: false, reason: "" };
         }
         const missingGates = evidence.required_gates.filter((gate) => evidence.gates[gate] == null);
-        evidenceIncompleteReason = `Task ${taskId} is missing required gates: [${missingGates.join(", ")}]. ` + `Required: [${evidence.required_gates.join(", ")}]. ` + `Completed: [${Object.keys(evidence.gates).join(", ")}]. ` + `Delegate the missing gate agents before marking task as completed.`;
+        evidenceIncompleteReason = evidence.required_gates.length === 0 ? `Task ${taskId} has an evidence file with no required gates. Delegate reviewer and test_engineer before marking task as completed.` : `Task ${taskId} is missing required gates: [${missingGates.join(", ")}]. ` + `Required: [${evidence.required_gates.join(", ")}]. ` + `Completed: [${Object.keys(evidence.gates).join(", ")}]. ` + `Delegate the missing gate agents before marking task as completed.`;
       }
     } catch (error93) {
       console.warn(`[gate-evidence] Evidence file for task ${taskId} is corrupt or unreadable:`, error93 instanceof Error ? error93.message : String(error93));
@@ -103422,7 +103450,7 @@ function checkReviewerGate(taskId, workingDirectory, stageBParallelEnabled = fal
         reason: `Evidence file for task ${taskId} is corrupt or unreadable. ` + `Fix the file at .swarm/evidence/${taskId}.json or delete it to fall through to session state.`
       };
     }
-    if (swarmState.agentSessions.size === 0) {
+    if (swarmState.agentSessions.size === 0 && !evidenceIncompleteReason) {
       return { blocked: false, reason: "" };
     }
     let validSessionCount = 0;
@@ -103439,7 +103467,7 @@ function checkReviewerGate(taskId, workingDirectory, stageBParallelEnabled = fal
         return { blocked: false, reason: "" };
       }
     }
-    if (validSessionCount === 0) {
+    if (validSessionCount === 0 && !evidenceIncompleteReason) {
       return { blocked: false, reason: "" };
     }
     const stateEntries = [];
@@ -103456,7 +103484,7 @@ function checkReviewerGate(taskId, workingDirectory, stageBParallelEnabled = fal
       const plan = JSON.parse(planRaw);
       for (const planPhase of plan.phases ?? []) {
         for (const task of planPhase.tasks ?? []) {
-          if (task.id === taskId && task.status === "completed") {
+          if (task.id === taskId && task.status === "completed" && hasPassedDurableGateEvidence(resolvedDir2, taskId)) {
             return { blocked: false, reason: "" };
           }
         }
@@ -103470,26 +103498,6 @@ function checkReviewerGate(taskId, workingDirectory, stageBParallelEnabled = fal
         if (session && (session.currentTaskId === taskId || session.lastCoderDelegationTaskId === taskId)) {
           for (const delegation of chain) {
             const target = stripKnownSwarmPrefix(delegation.to);
-            if (target === "reviewer")
-              hasReviewer = true;
-            if (target === "test_engineer")
-              hasTestEngineer = true;
-          }
-        }
-      }
-      if (!hasReviewer && !hasTestEngineer) {
-        for (const [, chain] of swarmState.delegationChains) {
-          let lastCoderIndex = -1;
-          for (let i2 = chain.length - 1;i2 >= 0; i2--) {
-            const target = stripKnownSwarmPrefix(chain[i2].to);
-            if (target === "coder") {
-              lastCoderIndex = i2;
-              break;
-            }
-          }
-          const searchStart = lastCoderIndex === -1 ? 0 : lastCoderIndex + 1;
-          for (let i2 = searchStart;i2 < chain.length; i2++) {
-            const target = stripKnownSwarmPrefix(chain[i2].to);
             if (target === "reviewer")
               hasReviewer = true;
             if (target === "test_engineer")
@@ -103532,26 +103540,6 @@ function recoverTaskStateFromDelegations(taskId) {
     if (session && (session.currentTaskId === taskId || session.lastCoderDelegationTaskId === taskId)) {
       for (const delegation of chain) {
         const target = stripKnownSwarmPrefix(delegation.to);
-        if (target === "reviewer")
-          hasReviewer = true;
-        if (target === "test_engineer")
-          hasTestEngineer = true;
-      }
-    }
-  }
-  if (!hasReviewer && !hasTestEngineer) {
-    for (const [, chain] of swarmState.delegationChains) {
-      let lastCoderIndex = -1;
-      for (let i2 = chain.length - 1;i2 >= 0; i2--) {
-        const target = stripKnownSwarmPrefix(chain[i2].to);
-        if (target === "coder") {
-          lastCoderIndex = i2;
-          break;
-        }
-      }
-      const searchStart = lastCoderIndex === -1 ? 0 : lastCoderIndex + 1;
-      for (let i2 = searchStart;i2 < chain.length; i2++) {
-        const target = stripKnownSwarmPrefix(chain[i2].to);
         if (target === "reviewer")
           hasReviewer = true;
         if (target === "test_engineer")

--- a/dist/tools/update-task-status.d.ts
+++ b/dist/tools/update-task-status.d.ts
@@ -66,11 +66,10 @@ export declare function checkReviewerGate(taskId: string, workingDirectory?: str
 export declare function checkReviewerGateWithScope(taskId: string, workingDirectory?: string, sessionID?: string): Promise<ReviewerGateResult>;
 /**
  * Recovery mechanism: reconcile task state with delegation history.
- * When reviewer/test_engineer delegations occurred but the state machine
- * was not advanced (e.g., toolAfter didn't fire, subagent_type missing,
- * cross-session gaps, or pure verification tasks without coder delegation),
- * this function walks all delegation chains and advances the task state
- * so that checkReviewerGate can make an accurate decision.
+ * When task-scoped reviewer/test_engineer delegations occurred but the state
+ * machine was not advanced (e.g., toolAfter didn't fire or subagent_type was
+ * missing), this function advances the task state so that checkReviewerGate can
+ * make an accurate decision without attributing unrelated delegation activity.
  *
  * @param taskId - The task ID to recover state for
  */

--- a/docs/releases/v7.21.1.md
+++ b/docs/releases/v7.21.1.md
@@ -1,0 +1,36 @@
+# Release 7.21.1
+
+## What changed
+
+- **phase_complete: completed-plan fallback now requires durable gate evidence** (`src/tools/phase-complete.ts`)
+  - Missing coder/reviewer/test_engineer agents are only inferred from completed tasks when every task in the phase has passed durable `.swarm/evidence/<taskId>.json` gates.
+  - Completed `plan.json` task status alone no longer clears missing required agents.
+  - Docs and other non-task gates are not inferred from task gate evidence.
+
+- **phase_complete: delegation chains are phase-scoped** (`src/tools/phase-complete.ts`)
+  - Caller and non-caller delegation-chain entries from before the current phase boundary no longer satisfy required agents for the next phase.
+  - Other-session freshness behavior still determines which sessions can contribute to the current phase.
+
+- **update_task_status: completion recovery now requires task-scoped proof** (`src/tools/update-task-status.ts`)
+  - A task already marked `completed` in `plan.json` no longer bypasses reviewer/test_engineer gating unless durable evidence proves all required gates passed.
+  - Empty `required_gates` evidence is treated as incomplete instead of vacuously passing.
+  - Unscoped reviewer/test_engineer delegation chains no longer recover unrelated tasks to completed state.
+  - Legitimate restart recovery still works when task-scoped state or durable gate evidence is present.
+
+## Why
+
+Fixes Issue #866. The orchestrator could reach completed-looking state after doing coding or refactor work itself, then rely on completed plan state or stale delegation state instead of proving that the coder, reviewer, and test_engineer workflow actually ran.
+
+The fix keeps restart recovery, but moves the proof surface from mutable plan projections and unscoped delegation chains to durable or task-scoped gate evidence.
+
+## Migration steps
+
+None. Existing completed tasks with valid gate evidence continue to pass restart recovery. Tasks that were only marked completed in `plan.json` without gate evidence now require the missing reviewer/test_engineer workflow before completion.
+
+## Breaking changes
+
+None.
+
+## Known caveats
+
+- Architect direct source writes are still detected and surfaced through the existing self-coding warning path. This release hardens completion gates so skipped delegation cannot be laundered through completed plan state.

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -19,6 +19,7 @@ import {
 import { getEffectiveGates, getProfile } from '../db/qa-gate-profile.js';
 import { listEvidenceTaskIds, loadEvidence } from '../evidence/manager';
 import { verifyFullAutoPhaseApproval } from '../full-auto/phase-approval';
+import { hasPassedAllGates } from '../gate-evidence';
 import {
 	applyCuratorKnowledgeUpdates,
 	runCuratorPhase,
@@ -117,6 +118,27 @@ function safeWarn(message: string, error: unknown): void {
 	}
 }
 
+const TASK_GATE_INFERABLE_AGENTS = new Set([
+	'coder',
+	'reviewer',
+	'test_engineer',
+]);
+
+function canInferMissingAgentsFromTaskGates(agentsMissing: string[]): boolean {
+	return agentsMissing.every((agent) => TASK_GATE_INFERABLE_AGENTS.has(agent));
+}
+
+async function allCompletedTasksHavePassedGateEvidence(
+	directory: string,
+	tasks: Array<{ id: string; status: string }>,
+): Promise<boolean> {
+	for (const task of tasks) {
+		if (task.status !== 'completed') return false;
+		if (!(await hasPassedAllGates(directory, task.id))) return false;
+	}
+	return tasks.length > 0;
+}
+
 /**
  * Collect dispatched agents across contributor sessions.
  * Contributor sessions are defined as those with activity since a phase reference timestamp,
@@ -145,13 +167,15 @@ function collectCrossSessionDispatchedAgents(
 			}
 		}
 
-		// Collect agents from caller's delegation chains
-		const callerDelegations = swarmState.delegationChains.get(callerSessionId);
-		if (callerDelegations) {
-			for (const delegation of callerDelegations) {
-				agents.add(stripKnownSwarmPrefix(delegation.from));
-				agents.add(stripKnownSwarmPrefix(delegation.to));
-			}
+		// Collect only caller delegation chains from the current phase window.
+		// The caller session itself is always a contributor, but old delegations from
+		// before the phase boundary must not satisfy this phase's required agents.
+		for (const delegation of _getDelegationsSince(
+			callerSessionId,
+			phaseReferenceTimestamp,
+		)) {
+			agents.add(stripKnownSwarmPrefix(delegation.from));
+			agents.add(stripKnownSwarmPrefix(delegation.to));
 		}
 	}
 
@@ -198,13 +222,15 @@ function collectCrossSessionDispatchedAgents(
 				}
 			}
 
-			// Collect agents from this session's delegation chains
-			const delegations = swarmState.delegationChains.get(sessionId);
-			if (delegations) {
-				for (const delegation of delegations) {
-					agents.add(stripKnownSwarmPrefix(delegation.from));
-					agents.add(stripKnownSwarmPrefix(delegation.to));
-				}
+			// Collect only delegation chains from this phase window. A session can
+			// have recent activity and still carry old chain entries from a previous
+			// phase; those older entries must not satisfy this phase's required agents.
+			for (const delegation of _getDelegationsSince(
+				sessionId,
+				phaseReferenceTimestamp,
+			)) {
+				agents.add(stripKnownSwarmPrefix(delegation.from));
+				agents.add(stripKnownSwarmPrefix(delegation.to));
 			}
 		}
 	}
@@ -1821,9 +1847,10 @@ export async function executePhaseComplete(
 
 	// Build warnings and determine success based on policy
 
-	// Plan.json fallback: if agents are missing but all tasks in the phase are
-	// completed in plan.json, treat the phase as closeable. Completed tasks prove
-	// agents were dispatched (update_task_status requires QA gates to pass).
+	// Plan.json fallback: if agents are missing after a session restart but all
+	// tasks in the phase are completed, treat the phase as closeable only when
+	// durable per-task gate evidence also proves the QA gates ran. A completed
+	// plan alone is not proof; it can be stale or hand-edited.
 	if (agentsMissing.length > 0) {
 		try {
 			const planPath = validateSwarmPath(dir, 'plan.json');
@@ -1839,10 +1866,11 @@ export async function executePhaseComplete(
 			if (
 				targetPhase &&
 				targetPhase.tasks.length > 0 &&
-				targetPhase.tasks.every((t) => t.status === 'completed')
+				canInferMissingAgentsFromTaskGates(agentsMissing) &&
+				(await allCompletedTasksHavePassedGateEvidence(dir, targetPhase.tasks))
 			) {
 				warnings.push(
-					`Agent dispatch fallback: all ${targetPhase.tasks.length} tasks in phase ${phase} are completed in plan.json. Clearing missing agents: ${agentsMissing.join(', ')}.`,
+					`Agent dispatch fallback: all ${targetPhase.tasks.length} tasks in phase ${phase} are completed in plan.json and durable gate evidence passed. Clearing missing agents: ${agentsMissing.join(', ')}.`,
 				);
 				agentsMissing = [];
 			}

--- a/src/tools/update-task-status.ts
+++ b/src/tools/update-task-status.ts
@@ -130,6 +130,23 @@ function matchesTier3Pattern(files: string[]): boolean {
 	return false;
 }
 
+function hasPassedDurableGateEvidence(
+	workingDirectory: string,
+	taskId: string,
+): boolean {
+	const evidence = readTaskEvidenceRaw(workingDirectory, taskId);
+	if (
+		!evidence ||
+		!Array.isArray(evidence.required_gates) ||
+		evidence.required_gates.length === 0
+	) {
+		return false;
+	}
+	return evidence.required_gates.every(
+		(gate) => evidence.gates?.[gate] != null,
+	);
+}
+
 /**
  * Check if a task has passed required QA gates using the state machine.
  * Requires the task to be in 'tests_run' or 'complete' state, which means
@@ -232,10 +249,12 @@ export function checkReviewerGate(
 				Array.isArray(evidence.required_gates) &&
 				evidence.gates
 			) {
-				const allGatesMet = evidence.required_gates.every(
-					(gate: string) => evidence.gates![gate] != null,
-				);
-				if (allGatesMet) {
+				if (
+					evidence.required_gates.length > 0 &&
+					evidence.required_gates.every(
+						(gate: string) => evidence.gates![gate] != null,
+					)
+				) {
 					return { blocked: false, reason: '' };
 				}
 				// Evidence file shows incomplete gates — save the reason and fall through to
@@ -246,10 +265,12 @@ export function checkReviewerGate(
 					(gate: string) => evidence.gates![gate] == null,
 				);
 				evidenceIncompleteReason =
-					`Task ${taskId} is missing required gates: [${missingGates.join(', ')}]. ` +
-					`Required: [${evidence.required_gates.join(', ')}]. ` +
-					`Completed: [${Object.keys(evidence.gates).join(', ')}]. ` +
-					`Delegate the missing gate agents before marking task as completed.`;
+					evidence.required_gates.length === 0
+						? `Task ${taskId} has an evidence file with no required gates. Delegate reviewer and test_engineer before marking task as completed.`
+						: `Task ${taskId} is missing required gates: [${missingGates.join(', ')}]. ` +
+							`Required: [${evidence.required_gates.join(', ')}]. ` +
+							`Completed: [${Object.keys(evidence.gates).join(', ')}]. ` +
+							`Delegate the missing gate agents before marking task as completed.`;
 			}
 		} catch (error) {
 			// Malformed JSON, permission error, or other non-ENOENT issue — BLOCK
@@ -273,8 +294,10 @@ export function checkReviewerGate(
 
 		// === session state check (fallback for pre-evidence tasks) ===
 
-		// If no active sessions, allow through (test context)
-		if (swarmState.agentSessions.size === 0) {
+		// If no active sessions, allow through only when no evidence file asserted
+		// incomplete/invalid gate state. This preserves test-context behavior for
+		// missing evidence while preventing empty evidence from vacuously passing.
+		if (swarmState.agentSessions.size === 0 && !evidenceIncompleteReason) {
 			return { blocked: false, reason: '' };
 		}
 
@@ -304,7 +327,7 @@ export function checkReviewerGate(
 
 		// If all sessions had corrupt workflow state, allow through —
 		// we cannot make a reliable gate assertion without valid state.
-		if (validSessionCount === 0) {
+		if (validSessionCount === 0 && !evidenceIncompleteReason) {
 			return { blocked: false, reason: '' };
 		}
 
@@ -318,8 +341,8 @@ export function checkReviewerGate(
 		}
 
 		// Bug 3 fix: no session has this task in tests_run or complete state.
-		// Check plan.json as fallback — covers session restarts where task was
-		// completed in a prior session and plan.json is the source of truth.
+		// Trust plan.json restart recovery only when durable gate evidence proves
+		// the required reviewer/test_engineer gates passed before completion.
 		try {
 			const resolvedDir = workingDirectory!;
 			const planPath = path.join(resolvedDir, '.swarm', 'plan.json');
@@ -329,7 +352,11 @@ export function checkReviewerGate(
 			};
 			for (const planPhase of plan.phases ?? []) {
 				for (const task of planPhase.tasks ?? []) {
-					if (task.id === taskId && task.status === 'completed') {
+					if (
+						task.id === taskId &&
+						task.status === 'completed' &&
+						hasPassedDurableGateEvidence(resolvedDir, taskId)
+					) {
 						return { blocked: false, reason: '' };
 					}
 				}
@@ -338,12 +365,10 @@ export function checkReviewerGate(
 			// plan.json missing or unreadable — fall through to blocked:true
 		}
 
-		// Final fallback: scan delegation chains directly for reviewer+test_engineer.
+		// Final fallback: scan task-scoped delegation chains directly for reviewer+test_engineer.
 		// This covers cases where:
 		// - Session was restarted (in-memory state lost)
-		// - Pure-verification/code-organization tasks with no coder delegation
 		// - toolAfter hook didn't fire (subagent_type not captured)
-		// Uses the same unscoped scan as recoverTaskStateFromDelegations.
 		{
 			let hasReviewer = false;
 			let hasTestEngineer = false;
@@ -358,26 +383,6 @@ export function checkReviewerGate(
 				) {
 					for (const delegation of chain) {
 						const target = stripKnownSwarmPrefix(delegation.to);
-						if (target === 'reviewer') hasReviewer = true;
-						if (target === 'test_engineer') hasTestEngineer = true;
-					}
-				}
-			}
-
-			// Pass 2: unscoped fallback when no task-scoped sessions found
-			if (!hasReviewer && !hasTestEngineer) {
-				for (const [, chain] of swarmState.delegationChains) {
-					let lastCoderIndex = -1;
-					for (let i = chain.length - 1; i >= 0; i--) {
-						const target = stripKnownSwarmPrefix(chain[i].to);
-						if (target === 'coder') {
-							lastCoderIndex = i;
-							break;
-						}
-					}
-					const searchStart = lastCoderIndex === -1 ? 0 : lastCoderIndex + 1;
-					for (let i = searchStart; i < chain.length; i++) {
-						const target = stripKnownSwarmPrefix(chain[i].to);
 						if (target === 'reviewer') hasReviewer = true;
 						if (target === 'test_engineer') hasTestEngineer = true;
 					}
@@ -449,11 +454,10 @@ export async function checkReviewerGateWithScope(
 
 /**
  * Recovery mechanism: reconcile task state with delegation history.
- * When reviewer/test_engineer delegations occurred but the state machine
- * was not advanced (e.g., toolAfter didn't fire, subagent_type missing,
- * cross-session gaps, or pure verification tasks without coder delegation),
- * this function walks all delegation chains and advances the task state
- * so that checkReviewerGate can make an accurate decision.
+ * When task-scoped reviewer/test_engineer delegations occurred but the state
+ * machine was not advanced (e.g., toolAfter didn't fire or subagent_type was
+ * missing), this function advances the task state so that checkReviewerGate can
+ * make an accurate decision without attributing unrelated delegation activity.
  *
  * @param taskId - The task ID to recover state for
  */
@@ -472,34 +476,6 @@ export function recoverTaskStateFromDelegations(taskId: string): void {
 		) {
 			for (const delegation of chain) {
 				const target = stripKnownSwarmPrefix(delegation.to);
-				if (target === 'reviewer') hasReviewer = true;
-				if (target === 'test_engineer') hasTestEngineer = true;
-			}
-		}
-	}
-
-	// Pass 2 (unscoped fallback): when no task-scoped sessions were found,
-	// scan ALL delegation chains. This covers pure-verification tasks and
-	// code-organization tasks where no coder delegation occurred, so
-	// currentTaskId / lastCoderDelegationTaskId were never set to this taskId.
-	// Safety: only scan delegations that occurred after the last coder delegation
-	// in each chain (or from the start if no coder delegation exists), to avoid
-	// attributing reviewer/test_engineer from a prior task to this one.
-	if (!hasReviewer && !hasTestEngineer) {
-		for (const [, chain] of swarmState.delegationChains) {
-			// Find the last coder delegation index in this chain
-			let lastCoderIndex = -1;
-			for (let i = chain.length - 1; i >= 0; i--) {
-				const target = stripKnownSwarmPrefix(chain[i].to);
-				if (target === 'coder') {
-					lastCoderIndex = i;
-					break;
-				}
-			}
-			// Scan from after the last coder delegation (or from start if no coder)
-			const searchStart = lastCoderIndex === -1 ? 0 : lastCoderIndex + 1;
-			for (let i = searchStart; i < chain.length; i++) {
-				const target = stripKnownSwarmPrefix(chain[i].to);
 				if (target === 'reviewer') hasReviewer = true;
 				if (target === 'test_engineer') hasTestEngineer = true;
 			}

--- a/tests/unit/tools/phase-complete-final-council.test.ts
+++ b/tests/unit/tools/phase-complete-final-council.test.ts
@@ -17,6 +17,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { closeProjectDb } from '../../../src/db/project-db';
 import { getOrCreateProfile, setGates } from '../../../src/db/qa-gate-profile';
+import { resetSwarmState } from '../../../src/state';
 import { executePhaseComplete } from '../../../src/tools/phase-complete';
 
 let tempDir: string;
@@ -60,7 +61,12 @@ function writePluginConfig() {
 	writeFileSync(
 		join(tempDir, '.opencode', 'opencode-swarm.json'),
 		JSON.stringify({
-			phase_complete: { enabled: true, required_agents: [], policy: 'warn' },
+			phase_complete: {
+				enabled: true,
+				required_agents: [],
+				require_docs: false,
+				policy: 'warn',
+			},
 		}),
 	);
 }
@@ -215,10 +221,12 @@ function setupIntermediatePhase(finalCouncilEnabled: boolean) {
 }
 
 beforeEach(() => {
+	resetSwarmState();
 	tempDir = mkdtempSync(join(tmpdir(), 'pc-final-council-'));
 });
 
 afterEach(() => {
+	resetSwarmState();
 	closeProjectDb(tempDir);
 	try {
 		rmSync(tempDir, {

--- a/tests/unit/tools/phase-complete-phase-council.adversarial.test.ts
+++ b/tests/unit/tools/phase-complete-phase-council.adversarial.test.ts
@@ -4,6 +4,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { closeProjectDb } from '../../../src/db/project-db';
 import { getOrCreateProfile, setGates } from '../../../src/db/qa-gate-profile';
+import {
+	ensureAgentSession,
+	recordPhaseAgentDispatch,
+	resetSwarmState,
+} from '../../../src/state';
 import { executePhaseComplete } from '../../../src/tools/phase-complete';
 
 let tempDir: string;
@@ -50,7 +55,12 @@ function writePluginConfig(
 ) {
 	mkdirSync(join(tempDir, '.opencode'), { recursive: true });
 	const config: Record<string, unknown> = {
-		phase_complete: { enabled: true, required_agents: [], policy: 'warn' },
+		phase_complete: {
+			enabled: true,
+			required_agents: [],
+			require_docs: false,
+			policy: 'warn',
+		},
 		...extraConfig,
 	};
 	if (councilOverrides === null) {
@@ -148,6 +158,11 @@ function setup(councilMode: boolean) {
 	writePlan();
 	writePluginConfig();
 	writeRetro();
+	ensureAgentSession(SESSION_ID);
+	recordPhaseAgentDispatch(SESSION_ID, 'coder');
+	recordPhaseAgentDispatch(SESSION_ID, 'reviewer');
+	recordPhaseAgentDispatch(SESSION_ID, 'test_engineer');
+	recordPhaseAgentDispatch(SESSION_ID, 'docs');
 	if (councilMode) enableCouncilMode();
 }
 
@@ -160,10 +175,12 @@ async function phaseComplete() {
 }
 
 beforeEach(() => {
+	resetSwarmState();
 	tempDir = mkdtempSync(join(tmpdir(), 'pc-adv-'));
 });
 
 afterEach(() => {
+	resetSwarmState();
 	closeProjectDb(tempDir);
 	rmSync(tempDir, { recursive: true, force: true });
 });
@@ -450,7 +467,12 @@ describe('adversarial: config.council empty object', () => {
 		writeFileSync(
 			join(tempDir, '.opencode', 'opencode-swarm.json'),
 			JSON.stringify({
-				phase_complete: { enabled: true, required_agents: [], policy: 'warn' },
+				phase_complete: {
+					enabled: true,
+					required_agents: [],
+					require_docs: false,
+					policy: 'warn',
+				},
 				council: {},
 			}),
 		);
@@ -481,7 +503,12 @@ describe('adversarial: extra unknown keys in council config', () => {
 		writeFileSync(
 			join(tempDir, '.opencode', 'opencode-swarm.json'),
 			JSON.stringify({
-				phase_complete: { enabled: true, required_agents: [], policy: 'warn' },
+				phase_complete: {
+					enabled: true,
+					required_agents: [],
+					require_docs: false,
+					policy: 'warn',
+				},
 				council: {
 					phaseConcernsAllowComplete: true,
 					unknownField: 'should cause strict rejection',

--- a/tests/unit/tools/phase-complete-phase-council.test.ts
+++ b/tests/unit/tools/phase-complete-phase-council.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { closeProjectDb } from '../../../src/db/project-db';
 import { getOrCreateProfile, setGates } from '../../../src/db/qa-gate-profile';
+import { resetSwarmState } from '../../../src/state';
 import { executePhaseComplete } from '../../../src/tools/phase-complete';
 
 let tempDir: string;
@@ -45,7 +46,12 @@ function writePluginConfig(overrides?: { council?: Record<string, unknown> }) {
 	writeFileSync(
 		join(tempDir, '.opencode', 'opencode-swarm.json'),
 		JSON.stringify({
-			phase_complete: { enabled: true, required_agents: [], policy: 'warn' },
+			phase_complete: {
+				enabled: true,
+				required_agents: [],
+				require_docs: false,
+				policy: 'warn',
+			},
 			...(overrides?.council ? { council: overrides.council } : {}),
 		}),
 	);
@@ -134,10 +140,12 @@ function setup(councilMode: boolean) {
 }
 
 beforeEach(() => {
+	resetSwarmState();
 	tempDir = mkdtempSync(join(tmpdir(), 'pc-council-'));
 });
 
 afterEach(() => {
+	resetSwarmState();
 	closeProjectDb(tempDir);
 	rmSync(tempDir, { recursive: true, force: true });
 });

--- a/tests/unit/tools/phase-complete.test.ts
+++ b/tests/unit/tools/phase-complete.test.ts
@@ -14,6 +14,7 @@ import {
 const { phase_complete, executePhaseComplete } = await import(
 	'../../../src/tools/phase-complete'
 );
+const { recordGateEvidence } = await import('../../../src/gate-evidence');
 
 /**
  * Helper function to write a valid retro bundle for a phase
@@ -622,6 +623,50 @@ describe('phase_complete tool', () => {
 			expect(parsed.agentsDispatched).toContain('coder');
 			expect(parsed.agentsDispatched).toContain('reviewer');
 		});
+
+		test('ignores caller delegation chains from before the phase reference timestamp', async () => {
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({
+					phase_complete: {
+						enabled: true,
+						required_agents: ['coder', 'reviewer'],
+						require_docs: false,
+						policy: 'enforce',
+					},
+				}),
+			);
+
+			const referenceTimestamp = Date.now();
+			ensureAgentSession('sess1');
+			swarmState.agentSessions.get('sess1')!.lastPhaseCompleteTimestamp =
+				referenceTimestamp;
+			swarmState.delegationChains.set('sess1', [
+				{
+					from: 'architect',
+					to: 'coder',
+					timestamp: referenceTimestamp - 5000,
+				},
+				{
+					from: 'coder',
+					to: 'reviewer',
+					timestamp: referenceTimestamp - 3000,
+				},
+			]);
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'sess1',
+			});
+			const parsed = JSON.parse(result);
+
+			expect(parsed.success).toBe(false);
+			expect(parsed.agentsDispatched).not.toContain('coder');
+			expect(parsed.agentsDispatched).not.toContain('reviewer');
+			expect(parsed.agentsMissing).toContain('coder');
+			expect(parsed.agentsMissing).toContain('reviewer');
+		});
 	});
 
 	describe('summary truncation', () => {
@@ -1142,6 +1187,59 @@ describe('phase_complete tool', () => {
 			expect(sess2After?.lastPhaseCompleteTimestamp).toBe(0);
 		});
 
+		test('ignores stale non-caller delegation chains even when the session has recent activity', async () => {
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({
+					phase_complete: {
+						enabled: true,
+						required_agents: ['coder', 'reviewer'],
+						require_docs: false,
+						policy: 'enforce',
+					},
+				}),
+			);
+
+			const referenceTimestamp = Date.now();
+			ensureAgentSession('caller');
+			swarmState.agentSessions.get('caller')!.lastPhaseCompleteTimestamp =
+				referenceTimestamp;
+
+			ensureAgentSession('worker');
+			swarmState.agentSessions.get('worker')!.lastToolCallTime =
+				referenceTimestamp + 1000;
+			swarmState.delegationChains.set('worker', [
+				{
+					from: 'architect',
+					to: 'coder',
+					timestamp: referenceTimestamp - 5000,
+				},
+				{
+					from: 'coder',
+					to: 'reviewer',
+					timestamp: referenceTimestamp - 3000,
+				},
+				{
+					from: 'architect',
+					to: 'noop',
+					timestamp: referenceTimestamp + 500,
+				},
+			]);
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'caller',
+			});
+			const parsed = JSON.parse(result);
+
+			expect(parsed.success).toBe(false);
+			expect(parsed.agentsDispatched).not.toContain('coder');
+			expect(parsed.agentsDispatched).not.toContain('reviewer');
+			expect(parsed.agentsMissing).toContain('coder');
+			expect(parsed.agentsMissing).toContain('reviewer');
+		});
+
 		test('includes restored session agents when lastPhaseCompleteTimestamp matches reference', async () => {
 			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
 			fs.writeFileSync(
@@ -1444,7 +1542,7 @@ describe('phase_complete tool', () => {
 	});
 
 	describe('plan.json agent dispatch fallback', () => {
-		test('fallback activates when all tasks completed and agents missing', async () => {
+		test('fallback does NOT activate when all tasks completed but gate evidence is missing', async () => {
 			// Set up permissive config with required_agents
 			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
 			fs.writeFileSync(
@@ -1502,6 +1600,84 @@ describe('phase_complete tool', () => {
 			// Set up session with NO agents dispatched (agents missing)
 			ensureAgentSession('sess1');
 			// No recordPhaseAgentDispatch call - simulating session restart
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'sess1',
+			});
+			const parsed = JSON.parse(result);
+
+			expect(parsed.success).toBe(false);
+			expect(parsed.status).toBe('incomplete');
+			expect(parsed.agentsMissing).toContain('coder');
+			expect(
+				parsed.warnings.some((w: string) =>
+					w.includes('Agent dispatch fallback'),
+				),
+			).toBe(false);
+		});
+
+		test('fallback activates when all tasks completed and durable gate evidence passed', async () => {
+			// Set up permissive config with required_agents
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({
+					phase_complete: {
+						enabled: true,
+						required_agents: ['coder'],
+						require_docs: false,
+						policy: 'enforce',
+					},
+				}),
+			);
+
+			// Create source file so completion-verify can find identifiers
+			fs.mkdirSync(path.join(tempDir, 'src'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, 'src', 'setup.ts'),
+				'export function setupProject() {}\n',
+			);
+
+			const planJson = {
+				schema_version: '1.0.0',
+				title: 'Test Plan',
+				swarm: 'mega',
+				current_phase: 1,
+				phases: [
+					{
+						id: 1,
+						name: 'Phase 1',
+						status: 'pending',
+						tasks: [
+							{
+								id: '1.1',
+								phase: 1,
+								status: 'completed',
+								description: 'Implement `setupProject` in src/setup.ts',
+							},
+							{
+								id: '1.2',
+								phase: 1,
+								status: 'completed',
+								description: 'Implement `setupProject` in src/setup.ts',
+							},
+						],
+					},
+				],
+			};
+			fs.writeFileSync(
+				path.join(tempDir, '.swarm', 'plan.json'),
+				JSON.stringify(planJson, null, 2),
+			);
+
+			await recordGateEvidence(tempDir, '1.1', 'reviewer', 'reviewer-sess');
+			await recordGateEvidence(tempDir, '1.1', 'test_engineer', 'test-sess');
+			await recordGateEvidence(tempDir, '1.2', 'reviewer', 'reviewer-sess');
+			await recordGateEvidence(tempDir, '1.2', 'test_engineer', 'test-sess');
+
+			// Set up session with NO agents dispatched, as after a session restart.
+			ensureAgentSession('sess1');
 
 			const result = await phase_complete.execute({
 				phase: 1,
@@ -1902,10 +2078,12 @@ describe('phase_complete tool', () => {
 				path.join(tempDir, '.swarm', 'plan.json'),
 				JSON.stringify(planJson, null, 2),
 			);
+			await recordGateEvidence(tempDir, '1.1', 'reviewer', 'reviewer-sess');
+			await recordGateEvidence(tempDir, '1.1', 'test_engineer', 'test-sess');
 
 			// Set up session with NO agents dispatched
 			ensureAgentSession('sess1');
-			// No agents dispatched - fallback should activate
+			// No agents dispatched, but durable gate evidence proves restart recovery is safe.
 
 			const result = await phase_complete.execute({
 				phase: 1,
@@ -1913,7 +2091,7 @@ describe('phase_complete tool', () => {
 			});
 			const parsed = JSON.parse(result);
 
-			// Should succeed due to fallback
+			// Should succeed due to evidence-backed fallback
 			expect(parsed.success).toBe(true);
 			expect(parsed.status).toBe('success');
 			expect(

--- a/tests/unit/tools/update-task-status.gates.test.ts
+++ b/tests/unit/tools/update-task-status.gates.test.ts
@@ -163,6 +163,62 @@ describe('Gate restart-recovery: evidence-file durability', () => {
 		expect(result.blocked).toBe(false);
 	});
 
+	it('gate check blocks when plan.json says completed but durable gate evidence is absent', () => {
+		const completedPlan = JSON.parse(PLAN_JSON);
+		completedPlan.phases[0].tasks[0].status = 'completed';
+		fs.writeFileSync(
+			path.join(tmpDir, '.swarm', 'plan.json'),
+			JSON.stringify(completedPlan),
+		);
+		resetSwarmState();
+		swarmState.agentSessions.set('test-session', {
+			id: 'test-session',
+			taskWorkflowStates: new Map([['1.1', 'idle']]),
+			currentTaskId: '1.1',
+		});
+
+		const result = checkReviewerGate('1.1', tmpDir);
+		expect(result.blocked).toBe(true);
+		expect(result.reason).toContain('has not passed QA gates');
+		expect(result.reason).toContain('1.1');
+	});
+
+	it('gate check blocks when evidence has no required gates', () => {
+		fs.mkdirSync(path.join(tmpDir, '.swarm', 'evidence'), { recursive: true });
+		fs.writeFileSync(
+			evidencePath(tmpDir, '1.1'),
+			JSON.stringify({ taskId: '1.1', required_gates: [], gates: {} }),
+		);
+		resetSwarmState();
+
+		const result = checkReviewerGate('1.1', tmpDir);
+		expect(result.blocked).toBe(true);
+		expect(result.reason).toContain('no required gates');
+	});
+
+	it('executeUpdateTaskStatus does not recover completion from unscoped delegation chains', async () => {
+		resetSwarmState();
+		swarmState.agentSessions.set('test-session', {
+			id: 'test-session',
+			taskWorkflowStates: new Map([['1.1', 'idle']]),
+		});
+		swarmState.delegationChains.set('test-session', [
+			{ from: 'architect', to: 'reviewer', timestamp: Date.now() - 1000 },
+			{
+				from: 'reviewer',
+				to: 'test_engineer',
+				timestamp: Date.now() - 500,
+			},
+		]);
+
+		const result = await executeUpdateTaskStatus(
+			{ task_id: '1.1', status: 'completed' },
+			tmpDir,
+		);
+		expect(result.success).toBe(false);
+		expect(result.errors?.join('\n')).toContain('has not passed QA gates');
+	});
+
 	// -----------------------------------------------------------------------
 	// Seed evidence file created on in_progress transition
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
﻿## Summary
- Require durable task gate evidence before `phase_complete` infers missing coder/reviewer/test_engineer participation from completed plan tasks.
- Tighten `update_task_status` restart recovery so incomplete, empty, or missing gate evidence cannot be bypassed by stale delegation chains or completed-plan fallback.
- Add regression coverage for missing/empty evidence, stale delegation chains, council fixtures, and ship `docs/releases/v7.21.1.md` for the next release body.

Closes #866.

## Invariant audit
- 1 (plugin init):       not touched - no plugin init path files changed; `git diff --name-only origin/main..HEAD` is limited to phase/update task tools, tests, dist, and release note.
- 2 (runtime portability): touched - `bun run build`; `git diff --exit-code -- dist`; `node --input-type=module -e "await import('./dist/index.js')"`; `bun --smol test tests\\unit\\build\\bundle-portability.test.ts tests\\unit\\build\\bundle-plugin-shape.test.ts tests\\unit\\build\\bundle-node-load.test.ts --timeout 60000` (5 pass).
- 3 (subprocesses):       not touched - `Select-String` over changed source files for `spawn(`, `spawnSync(`, and `bunSpawn(` returned no matches.
- 4 (.swarm containment): touched - evidence lookup remains under `.swarm/evidence`; covered by `phase-complete.test.ts`, `update-task-status.gates.test.ts`, and `gate-evidence-e2e.test.ts`.
- 5 (plan durability):    touched - completed-plan fallback now requires durable gate evidence; covered by focused phase/update tests and integration gate-evidence round trips.
- 6 (test_runner safety): not touched - validation used shell `bun`/`node` commands only; no broad OpenCode `test_runner` invocation.
- 7 (test writing):       touched - loaded the writing-tests skill before test edits; new/updated tests use `bun:test`, temp dirs, and existing state reset helpers.
- 8 (session state):      touched - stale caller and non-caller delegation-chain recovery is windowed by phase reference time; covered by new stale-chain tests.
- 9 (guardrails/retry):   touched - QA gate restart/recovery and enforcement paths now fail closed on incomplete durable evidence; covered by `update-task-status.gates.test.ts`.
- 10 (chat/system msg):   not touched - no chat hook or system-message transformation files changed.
- 11 (tool registration): not touched - no tool registration, constants, or help-map files changed.
- 12 (release/cache):     touched - added `docs/releases/v7.21.1.md`; did not hand-edit package version, changelog, or release-please manifest; build and dist checks passed.

## Validation
- `git fetch origin main`; latest `origin/main` is `57828479`; `.release-please-manifest.json` and `package.json` are both `7.21.0`; branch rebased cleanly onto that commit.
- `bun install --frozen-lockfile`
- `bun run build`
- `git diff --exit-code -- dist`
- `bun run typecheck`
- `bunx biome ci .` (passes with two existing warnings in `src/turbo/lean/runner.ts`)
- `bun --smol test tests\\unit\\tools\\phase-complete.test.ts tests\\unit\\tools\\update-task-status.gates.test.ts tests\\unit\\tools\\phase-complete-final-council.test.ts tests\\unit\\tools\\phase-complete-phase-council.test.ts tests\\unit\\tools\\phase-complete-phase-council.adversarial.test.ts --timeout 60000` (112 pass)
- `bun --smol test tests\\integration\\reviewer-gate-enforcement.test.ts tests\\integration\\gate-evidence-e2e.test.ts --timeout 60000` (12 pass)
- `bun --smol test tests\\unit\\hooks\\delegation-gate.test.ts tests\\unit\\hooks\\self-coding-detection.test.ts tests\\unit\\hooks\\guardrails-self-coding-gate.test.ts --timeout 60000` (188 pass)
- `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- `bun --smol test tests\\unit\\build\\bundle-portability.test.ts tests\\unit\\build\\bundle-plugin-shape.test.ts tests\\unit\\build\\bundle-node-load.test.ts --timeout 60000` (5 pass)

## Existing main failures observed while widening validation
The broad `tests/unit/tools` chunking still has unrelated failures that also reproduce from a clean `origin/main` worktree:
- `tests/unit/tools/doc-scan.test.ts` and `tests/unit/tools/doc-scan.adversarial.test.ts` expect a truncation warning that current main does not emit.
- `tests/unit/tools/phase-complete.lock-adversarial.test.ts`, `tests/unit/tools/pre-check-batch.test.ts`, `tests/unit/tools/repo-graph.adversarial.test.ts`, and `tests/unit/tools/repo-graph-codex-adversarial.test.ts` hit Windows symlink/test.skip behavior on clean main.
- `tests/unit/tools/phase-complete-lean-turbo-reviewer.test.ts`, `tests/unit/tools/phase-complete-lean-turbo-critic.test.ts`, and `tests/unit/tools/phase-complete-lean-turbo.adversarial.test.ts` fail on clean main with missing lane-evidence expectations.
