### PR TITLE
fix(guardrails): block agent self-acknowledgment of spec drift (#890)

### DIFF
--- a/.claude/skills/commit-pr/SKILL.md
+++ b/.claude/skills/commit-pr/SKILL.md
@@ -104,22 +104,25 @@ The PR title is the squash merge commit message. Choose based on primary change:
 - Mixed feat + fix → use `feat` (minor subsumes patch)
 - `docs`/`chore`/`refactor`/`test`/`ci`/`build` only → no version bump is triggered
 
-### Step 3 — Determine NEXT_VERSION and create the release notes file
+### Step 3 — Create a pending release-note fragment
 
-1. Read `.release-please-manifest.json` to find the current version
-2. Determine the bump from your commit type:
-   - `fix`, `perf`, `revert` → patch (e.g. `6.33.1` → `6.33.2`)
-   - `feat` → minor (e.g. `6.33.1` → `6.34.0`)
-   - breaking change (`!` or `BREAKING CHANGE:` footer) → major (e.g. `6.33.1` → `7.0.0`)
-   - `docs`, `chore`, `refactor`, `test`, `ci`, `build` → no bump; use the current version as NEXT_VERSION (still create the file)
-3. Create `docs/releases/v{NEXT_VERSION}.md` with freeform markdown covering:
+⛔ **Do NOT** calculate `NEXT_VERSION`. ⛔ **Do NOT** create `docs/releases/vX.Y.Z.md`. ⛔ **Do NOT** write to a shared `docs/releases/unreleased.md` (same conflict hotspot, just relocated). release-please picks the actual version; the release workflow aggregates fragments at release time.
+
+1. Choose a short, descriptive, kebab-case slug that names the change. Pick something unlikely to collide with other open PRs — concurrent PRs each adding a *different* file produces zero merge conflicts.
+2. Create `docs/releases/pending/<your-slug>.md` with freeform markdown covering:
    - **What changed** — changes grouped by theme
    - **Why** — motivation (bug report, feature request, hardening)
    - **Migration steps** — if any API, config, or behavior changed
    - **Breaking changes** — if any
    - **Known caveats** — anything users should watch out for
+3. Do not include a version prefix in the heading (`# v7.21.4`). Use a descriptive topic heading: `# <topic>` (e.g. `# Spec-drift self-acknowledgment guardrail (issue #890)`).
 
-This file is **mandatory on every PR, no exceptions**, including one-line fixes.
+Examples of good slugs:
+- `docs/releases/pending/guardrails-transient-node-errors.md`
+- `docs/releases/pending/spec-drift-self-ack-guardrail.md`
+- `docs/releases/pending/phase-complete-durable-gate-proof.md`
+
+This file is **mandatory on every user-visible PR, no exceptions**, including one-line fixes. The aggregation is implemented by `scripts/release-notes-fragments.mjs`, invoked by the `update-pr-notes` and `update-release-notes` jobs in `.github/workflows/release-and-publish.yml`.
 
 ### Step 4 — Never touch these files manually
 
@@ -443,7 +446,7 @@ Verify every item before asking for a merge:
 - [ ] `test_runner` was NOT used with `scope: 'all'` or broad `'graph'` / `'impact'` scope to validate this repo (use shell commands instead)
 - [ ] Branch has exactly **one commit** — the squashed commit from Step 7 (`git log --oneline origin/main..HEAD` shows one line)
 - [ ] That commit message matches the PR title exactly, and both follow `<type>(<scope>): <description>`
-- [ ] `docs/releases/v{NEXT_VERSION}.md` exists with meaningful release notes
+- [ ] `docs/releases/pending/<unique-slug>.md` exists with meaningful release notes (NOT a `docs/releases/vX.Y.Z.md` file)
 - [ ] `package.json` version, `CHANGELOG.md`, `.release-please-manifest.json` are untouched
 - [ ] All 5 test tiers from Step 5 were actually run (not assumed — you must have the output in context), including `bunx biome ci .` on the full project (not scoped)
 - [ ] If the repo tracks `dist/` files: `bun run build` was run and dist/ artifacts are included in the squash commit

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -80,23 +80,25 @@ jobs:
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
-      - name: Update release body from docs/releases
+      - name: Aggregate pending release-note fragments into the GitHub Release body
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: |
-          NOTES_FILE="docs/releases/${TAG_NAME}.md"
-          if [ -f "$NOTES_FILE" ]; then
-            echo "Found release notes at $NOTES_FILE — updating release body"
-            gh release edit "${TAG_NAME}" --notes-file "$NOTES_FILE"
-          else
-            echo "No release notes file found at $NOTES_FILE — skipping"
-          fi
+        run: node scripts/release-notes-fragments.mjs update-release
 
   update-pr-notes:
     needs: release-please
     if: ${{ needs.release-please.outputs.releases_created != 'true' }}
     runs-on: ubuntu-latest
+    # Serialize this job across concurrent merges to main. Two updates
+    # would otherwise race on read-modify-write of the release PR body
+    # (each run reads the current body, recomputes notes from its own
+    # checkout, then `gh pr edit`s — last writer would silently win and
+    # could overwrite fragments added between the read and the write).
+    concurrency:
+      group: update-pr-notes
+      cancel-in-progress: false
     permissions:
       contents: read
       pull-requests: write
@@ -105,35 +107,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Update release PR body from docs/releases
+      - name: Aggregate pending release-note fragments into the release PR body
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUMBER=$(gh pr list --label "autorelease: pending" --json number -q '.[0].number')
-          if [ -z "$PR_NUMBER" ]; then
-            echo "No autorelease PR found — skipping"
-            exit 0
-          fi
-          VERSION=$(gh pr view "$PR_NUMBER" --json title -q '.title' | grep -oP '\d+\.\d+\.\d+' | head -1)
-          if [ -z "$VERSION" ]; then
-            echo "No version found in PR title — skipping"
-            exit 0
-          fi
-          # Explicit semver regex guard to prevent injection via malformed PR titles
-          if ! echo "$VERSION" | grep -qP '^\\d+\\.\\d+\\.\\d+$'; then
-            echo "VERSION does not match semver pattern — skipping"
-            exit 0
-          fi
-          NOTES_FILE="docs/releases/v${VERSION}.md"
-          if [ -f "$NOTES_FILE" ]; then
-            echo "Found release notes at $NOTES_FILE — prepending to PR #$PR_NUMBER body"
-            # Preserve the existing PR body (contains release-please markers needed for
-            # release creation). Prepend custom release notes above the markers.
-            EXISTING_BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body')
-            NOTES_CONTENT=$(cat "$NOTES_FILE")
-            COMBINED=$(printf '%s\n\n---\n\n%s' "$NOTES_CONTENT" "$EXISTING_BODY")
-            echo "$COMBINED" | gh pr edit "$PR_NUMBER" --body-file -
-          else
-            echo "No release notes file found at $NOTES_FILE — skipping"
-          fi
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/release-notes-fragments.mjs update-pr
 

--- a/.opencode/contributing/SKILL.md
+++ b/.opencode/contributing/SKILL.md
@@ -49,11 +49,12 @@ Valid examples:
 Invalid (rejected by CI):
 - `WIP`, `fix stuff`, `Update README`, `feat: Add feature.` (trailing period), `Feat:` (uppercase)
 
-## 3. Release Notes (MANDATORY — every PR, no exceptions)
+## 3. Release Notes (MANDATORY — every user-visible PR, no exceptions)
 
-1. Read current version: `cat .release-please-manifest.json`
-2. Compute next version based on commit types (feat = minor, fix/perf = patch)
-3. Create file: `docs/releases/v{NEXT_VERSION}.md`
+⛔ Do NOT compute the next version. ⛔ Do NOT create `docs/releases/vX.Y.Z.md`. ⛔ Do NOT write to a shared `docs/releases/unreleased.md`. release-please owns the version; the release workflow aggregates fragments at release time.
+
+1. Choose a short, kebab-case slug describing your change. Pick one unlikely to collide with concurrent PRs.
+2. Create `docs/releases/pending/<your-slug>.md`.
 
 Include:
 - What changed (grouped by theme)
@@ -62,7 +63,7 @@ Include:
 - Breaking changes (if any)
 - Known caveats
 
-Even one-line changes need release notes explaining why it matters.
+Use a descriptive heading (`# <topic>`), not a version prefix. Even one-line changes need a fragment explaining why it matters. Aggregation is done by `scripts/release-notes-fragments.mjs` via `.github/workflows/release-and-publish.yml` — each PR owning its own unique file is what eliminates the merge-conflict hotspot.
 
 ## 4. Run All Checks Locally (5 tiers, all must pass)
 
@@ -146,7 +147,7 @@ Find SHA: `gh api repos/{owner}/{repo}/git/ref/tags/{tag} --jq '.object.sha'`
 - [ ] Every commit follows `<type>(<scope>): <description>`
 - [ ] PR title follows same format
 - [ ] No manual edits to `package.json` version, `CHANGELOG.md`, or `.release-please-manifest.json`
-- [ ] `docs/releases/v{NEXT_VERSION}.md` exists with release notes
+- [ ] `docs/releases/pending/<unique-slug>.md` exists with release notes (NOT a `docs/releases/vX.Y.Z.md` file)
 - [ ] New tests in correct `tests/` subdirectory
 - [ ] Tests updated for any changed behavior
 - [ ] If modifying workflows, all `uses:` are SHA-pinned

--- a/.opencode/skills/generated/pr-review-fix/SKILL.md
+++ b/.opencode/skills/generated/pr-review-fix/SKILL.md
@@ -104,8 +104,7 @@ bun --smol test tests/unit/path/to/test.test.ts --timeout 30000
 
 Check if any fix requires documentation updates:
 
-- **Release notes** (`docs/releases/v{VERSION}.md`): Update if the fix changes user-visible behavior, fixes a documented issue, or alters an API described in the notes.
-  - **Version source:** Derive the version from the latest tag on main (`git describe --tags origin/main`), NOT from `package.json` which may be stale from the dev start. The release-please manifest is the authoritative source.
+- **Release notes** (`docs/releases/pending/<slug>.md`): Add or update a pending fragment if the fix changes user-visible behavior, fixes a documented issue, or alters an API. Do NOT compute a next version or create `docs/releases/vX.Y.Z.md` — release-please owns the version, and `scripts/release-notes-fragments.mjs` aggregates pending fragments at release time. Pick a unique kebab-case slug.
 - **README / guides**: Update if the fix changes installation steps, configuration options, or usage patterns.
 - **Code comments**: Update if the fix invalidates an existing comment or makes a non-obvious behavior change.
 
@@ -114,7 +113,7 @@ Check if any fix requires documentation updates:
 1. Stage ALL fix files (code + tests + docs). Do not stage unrelated changes.
    - Use explicit path staging to include new files (tests, docs) that `git add -u` would miss:
    ```bash
-   git add src/path/to/changed-file.ts tests/unit/path/to/new-test.test.ts docs/releases/v7.21.0.md
+   git add src/path/to/changed-file.ts tests/unit/path/to/new-test.test.ts docs/releases/pending/your-fix-slug.md
    ```
 2. If this is an amendment to the PR commit:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ Every PR that touches a relevant area must list which of these invariants it tou
 - A plugin fix is incomplete if users stay pinned to a stale OpenCode plugin cache. Install / update / cache changes must cover **all known cache layouts**, including the macOS / Windows variants documented in v6.86.9 (Layout 1 `~/.cache/opencode/packages/opencode-swarm@latest`, Layout 2 `~/.config/opencode/node_modules/opencode-swarm`, Layout 3 `~/.cache/opencode/node_modules/opencode-swarm`).
 - Cache-deletion code must use `isSafeCachePath` four-layer defense (depth, basename whitelist, recognized parent, canonical structure).
 - **Never hand-edit** `package.json#version`, `CHANGELOG.md`, or `.release-please-manifest.json`. release-please owns those.
-- Every PR ships a `docs/releases/v{NEXT_VERSION}.md` file (mandatory — see `contributing.md`). It is the only narrative future users will see in their GitHub Release body.
+- Every user-visible PR ships a `docs/releases/pending/<unique-slug>.md` fragment (mandatory — see `contributing.md`). Do NOT compute a next version or create `docs/releases/vX.Y.Z.md`; release-please owns the version, and `scripts/release-notes-fragments.mjs` aggregates pending fragments into the release PR / GitHub Release body. The aggregated text is the only narrative future users will see.
 
 ## Invariant audit required in PRs
 

--- a/contributing.md
+++ b/contributing.md
@@ -32,9 +32,9 @@ bun install --frozen-lockfile
 - Follow the test rules in `.opencode/writing-tests/SKILL.md` (bun:test only, mock isolation, cross-platform paths)
 - If you change behavior guarded by existing tests, **update those tests in the same PR**
 
-### 3. Write release notes
+### 3. Write a pending release-note fragment
 
-**Every PR MUST include a release notes file at `docs/releases/v{NEXT_VERSION}.md`.** No exceptions — even for one-line fixes. See the "Release notes" section below for how to determine the version number and what to include.
+**Every PR with a user-visible change MUST add a unique fragment at `docs/releases/pending/<descriptive-slug>.md`.** Do NOT compute the next version, do NOT create `docs/releases/vX.Y.Z.md`, and do NOT write to a shared `unreleased.md` — release-please picks the version and the release workflow aggregates pending fragments at release time. See the "Release notes" section below for what each fragment should contain.
 
 ### 4. Run all checks locally
 
@@ -112,7 +112,7 @@ When a PR is merged to `main`:
 
 ### Critical: release-please PR body markers
 
-release-please identifies its own PRs by parsing markers in the PR body (the `:robot: I have created a release` header and structured changelog). **Never replace the entire body of a release PR.** The `update-pr-notes` CI job prepends custom release notes above the markers — if the markers are destroyed, release-please cannot recognize the PR and the entire automated release pipeline breaks (no tag, no release, no npm publish).
+release-please identifies its own PRs by parsing markers in the PR body (the `:robot: I have created a release` header and structured changelog). **Never replace the entire body of a release PR.** The `update-pr-notes` CI job aggregates pending release-note fragments from every PR referenced in the release-please PR body and inserts the combined content inside a stable `<!-- custom-release-notes:start -->` … `<!-- custom-release-notes:end -->` marker block — release-please's own markers must remain intact below it. Same flow runs against the GitHub Release body after a tag is cut via `update-release-notes`. The implementation is `scripts/release-notes-fragments.mjs`.
 
 ### What release-please manages automatically — do not touch manually
 
@@ -255,29 +255,33 @@ If your code change alters the behavior of an existing function (new error messa
 
 ## Release notes (mandatory — no exceptions)
 
-**Every PR MUST include a release notes file at `docs/releases/v{NEXT_VERSION}.md`.** This is not optional. This is not conditional on "user-facing changes." This is not a "nice to have." If your PR is merged without it, release-please publishes a generic changelog with no explanation of what changed or how to migrate.
+**Every PR with a user-visible change MUST add a pending fragment at `docs/releases/pending/<descriptive-slug>.md`.** This is not optional. This is not conditional on "user-facing changes" being polished. If your PR is merged without it, release-please publishes a generic changelog with no explanation of what changed or how to migrate.
 
-The release pipeline prepends this file to the release PR body after merge, and later uses it as the GitHub Release body. If the file is missing, users see a bare list of commit messages — which is useless for anyone upgrading.
+> **Do NOT** calculate the next version, create `docs/releases/vX.Y.Z.md`, or write to a shared `unreleased.md`. release-please picks the version. The release workflow (`scripts/release-notes-fragments.mjs`) gathers every pending fragment from every PR included in the release-please release PR and inserts the combined content into a stable marker block in the release PR / GitHub Release body. Each PR owning its own unique file is what makes the previous merge-conflict hotspot go away.
 
-### How to determine the version
+### Where to put the fragment
 
-Find the current version in `.release-please-manifest.json` and increment it according to the bump your commit type will trigger:
-
-| Commit type | Current version | Next version |
-|---|---|---|
-| `fix`, `perf` | `6.33.1` | `6.33.2` |
-| `feat` | `6.33.1` | `6.34.0` |
+- Path: `docs/releases/pending/<descriptive-slug>.md`
+- Slug: short, kebab-case, descriptive of THIS change. Examples:
+  - `docs/releases/pending/guardrails-transient-node-errors.md`
+  - `docs/releases/pending/spec-drift-self-ack-guardrail.md`
+  - `docs/releases/pending/phase-complete-durable-gate-proof.md`
+- Pick a slug nobody else is likely to pick. Concurrent PRs each adding a *different* file produce zero merge conflicts.
 
 ### What to include
 
-The file is freeform markdown. Cover:
+The fragment is freeform markdown. Cover:
 - **What changed** — summarize the changes grouped by theme
 - **Why** — the motivation (bug report, feature request, hardening)
 - **Migration steps** — if any API, config, or behavior changed
 - **Breaking changes** — if any (should be rare)
 - **Known caveats** — anything users should watch out for
 
-Even a one-line change deserves a note explaining why it matters. See `docs/releases/v6.35.0.md` for the canonical format.
+Do not prefix the heading with a version (`# v7.21.4`) — release-please owns the version. A descriptive `# <topic>` is the canonical header. See `docs/releases/v6.35.0.md` for the prose style; ignore the version prefix in that historical file.
+
+### What still happens automatically
+
+After your PR merges, release-please opens or updates its release PR. CI runs `scripts/release-notes-fragments.mjs update-pr` to aggregate every pending fragment referenced by that release PR and inject it inside the `<!-- custom-release-notes:start --> … <!-- custom-release-notes:end -->` marker block (preserving release-please's own body markers). When the release PR merges and a tag is cut, `update-release` mirrors the same aggregation into the GitHub Release body. **Pending fragments are not deleted automatically.** They stay in `docs/releases/pending/` until a maintainer prunes them post-release.
 
 ---
 
@@ -311,7 +315,9 @@ gh api repos/{owner}/{repo}/git/ref/tags/{tag} --jq '.object.sha'
 | Editing `.release-please-manifest.json` | release-please version tracking breaks | Let release-please manage the manifest |
 | Using only `docs`/`chore`/`test`/`ci` commit types | No version bump triggered, release PR is never created | Include at least one `feat` or `fix` commit if you want a release |
 | Creating tags or releases manually | `publish-npm` job doesn't trigger (gated on release-please output) | Let the pipeline create tags and releases |
-| Missing `docs/releases/v{VERSION}.md` | GitHub Release has no useful description | Always create the release notes file |
+| Missing `docs/releases/pending/<slug>.md` | GitHub Release has no useful description | Always add a unique pending fragment for your PR |
+| Creating `docs/releases/v{VERSION}.md` in a feature/fix PR | Version prediction collides with release-please; merge conflict hotspot | Use `docs/releases/pending/<slug>.md` instead — release-please owns the version |
+| Writing to a shared `docs/releases/unreleased.md` | Same merge-conflict hotspot, just relocated | Use a unique slug under `docs/releases/pending/` per PR |
 
 ---
 
@@ -325,7 +331,7 @@ gh api repos/{owner}/{repo}/git/ref/tags/{tag} --jq '.object.sha'
 - [ ] Every commit message follows `<type>(<scope>): <description>` format
 - [ ] PR title follows the same format and matches the primary change
 - [ ] No manual edits to `package.json` version, `CHANGELOG.md`, or `.release-please-manifest.json`
-- [ ] `docs/releases/v{NEXT_VERSION}.md` exists with release notes
+- [ ] `docs/releases/pending/<unique-slug>.md` exists with release notes (do NOT create `docs/releases/vX.Y.Z.md`)
 - [ ] New tests are in the correct `tests/` subdirectory
 - [ ] Tests updated for any changed behavior (defaults, validation, error messages)
 - [ ] If adding/modifying a workflow, all `uses:` references are SHA-pinned

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -16061,7 +16061,7 @@ var init_manager = __esm(() => {
 
 // src/commands/acknowledge-spec-drift.ts
 import { promises as fsPromises3 } from "fs";
-async function handleAcknowledgeSpecDriftCommand(directory, _args) {
+async function handleAcknowledgeSpecDriftCommand(directory, _args, acknowledgedBy = "unknown") {
   const specStalenessPath = validateSwarmPath(directory, "spec-staleness.json");
   let stalenessContent;
   try {
@@ -16102,7 +16102,7 @@ async function handleAcknowledgeSpecDriftCommand(directory, _args) {
     timestamp: new Date().toISOString(),
     phase,
     planTitle,
-    acknowledgedBy: "architect",
+    acknowledgedBy,
     previousHash: stalenessData.specHash_plan,
     newHash: currentHash
   };
@@ -52049,7 +52049,8 @@ async function executeSwarmCommand(args) {
           directory,
           args: resolved.remainingArgs,
           sessionID,
-          agents
+          agents,
+          source: "chat"
         });
       } catch (_err) {
         const cmdName = tokens[0] || "unknown";
@@ -52081,6 +52082,12 @@ function classifySwarmCommandToolUse(resolved) {
   const canonicalKey = canonicalCommandKey(resolved);
   const args = resolved.remainingArgs;
   if (!SWARM_COMMAND_TOOL_ALLOWLIST.has(canonicalKey)) {
+    if (HUMAN_ONLY_SWARM_COMMANDS.has(canonicalKey)) {
+      return {
+        allowed: false,
+        message: `/swarm ${canonicalKey} is a human-only command. ` + `Present the situation to the user and ask them to run \`/swarm ${canonicalKey}\` themselves ` + `(or \`bunx opencode-swarm run ${canonicalKey}\` from a terminal). ` + `You MUST NOT run it yourself via Bash, swarm_command, or any other tool \u2014 ` + `the runtime guardrail will block such attempts.`
+      };
+    }
     return {
       allowed: false,
       message: `/swarm ${canonicalKey} is not available through the chat tool yet.
@@ -52170,7 +52177,7 @@ function classifySwarmCommandChatFallbackUse(resolved) {
   }
   return { allowed: true };
 }
-var SWARM_COMMAND_TOOL_COMMANDS, SWARM_COMMAND_TOOL_ALLOWLIST, NO_ARGS, SUMMARY_ID_PATTERN, TASK_ID_PATTERN;
+var SWARM_COMMAND_TOOL_COMMANDS, SWARM_COMMAND_TOOL_ALLOWLIST, HUMAN_ONLY_SWARM_COMMANDS, NO_ARGS, SUMMARY_ID_PATTERN, TASK_ID_PATTERN;
 var init_tool_policy = __esm(() => {
   init_command_dispatch();
   SWARM_COMMAND_TOOL_COMMANDS = [
@@ -52215,6 +52222,13 @@ var init_tool_policy = __esm(() => {
     "knowledge",
     "sync-plan",
     "export"
+  ]);
+  HUMAN_ONLY_SWARM_COMMANDS = new Set([
+    "acknowledge-spec-drift",
+    "reset",
+    "reset-session",
+    "rollback",
+    "checkpoint"
   ]);
   NO_ARGS = new Set([
     "agents",
@@ -52773,7 +52787,7 @@ var init_registry = __esm(() => {
   init_write_retro2();
   COMMAND_REGISTRY = {
     "acknowledge-spec-drift": {
-      handler: (ctx) => handleAcknowledgeSpecDriftCommand(ctx.directory, ctx.args),
+      handler: (ctx) => handleAcknowledgeSpecDriftCommand(ctx.directory, ctx.args, ctx.source === "cli" ? "cli" : ctx.source === "chat" ? "user" : "unknown"),
       description: "Acknowledge that the spec has drifted from the plan and suppress further warnings",
       args: "",
       category: "diagnostics"
@@ -53619,7 +53633,8 @@ Valid commands: ${VALID_COMMANDS.join(", ")}`);
     directory: cwd,
     args: resolved.remainingArgs,
     sessionID: "",
-    agents: {}
+    agents: {},
+    source: "cli"
   });
   console.log(result);
   return 0;

--- a/dist/commands/acknowledge-spec-drift.d.ts
+++ b/dist/commands/acknowledge-spec-drift.d.ts
@@ -1,5 +1,17 @@
 /**
+ * Caller identification for spec-drift acknowledgment audit trail.
+ * Previously hardcoded as 'architect' — see issue #890, where the architect
+ * could shell out to `bunx opencode-swarm run acknowledge-spec-drift` and
+ * the resulting event mis-attributed the action. Callers now pass an
+ * explicit actor so events.jsonl can distinguish the legitimate paths
+ * ('user' from chat slash command, 'cli' from a real terminal) from any
+ * unidentified caller ('unknown'). The Bash guardrail
+ * (`src/hooks/guardrails.ts` section 23) blocks the agent-shell bypass at
+ * the runtime layer; this parameter exists for forensic clarity.
+ */
+export type SpecDriftAcknowledgedBy = 'user' | 'cli' | 'unknown';
+/**
  * Handle /swarm acknowledge-spec-drift command
  * Acknowledges and clears a previously detected spec drift staleness warning
  */
-export declare function handleAcknowledgeSpecDriftCommand(directory: string, _args: string[]): Promise<string>;
+export declare function handleAcknowledgeSpecDriftCommand(directory: string, _args: string[], acknowledgedBy?: SpecDriftAcknowledgedBy): Promise<string>;

--- a/dist/commands/registry.d.ts
+++ b/dist/commands/registry.d.ts
@@ -8,6 +8,14 @@ export type CommandContext = {
     args: string[];
     sessionID: string;
     agents: Record<string, AgentDefinition>;
+    /**
+     * Dispatch path identifier. Issue #890: forensic audit trail for
+     * commands that need to distinguish "user typed /swarm <cmd>" (chat)
+     * from "user ran bunx opencode-swarm run <cmd>" (cli). Handlers that
+     * don't care can ignore this field. Optional for backwards-compatibility
+     * with existing callers.
+     */
+    source?: 'cli' | 'chat';
 };
 export type CommandResult = Promise<string>;
 export type CommandCategory = 'core' | 'agent' | 'config' | 'diagnostics' | 'utility';

--- a/dist/commands/tool-policy.d.ts
+++ b/dist/commands/tool-policy.d.ts
@@ -2,5 +2,14 @@ import type { ResolvedSwarmCommand, SwarmCommandPolicyResult } from './command-d
 export declare const SWARM_COMMAND_TOOL_COMMANDS: readonly ["agents", "config", "config doctor", "config-doctor", "doctor", "doctor tools", "status", "show-plan", "plan", "help", "history", "evidence", "evidence summary", "evidence-summary", "retrieve", "diagnose", "preflight", "benchmark", "knowledge", "sync-plan", "export", "list-agents"];
 export type SwarmCommandToolInputCommand = (typeof SWARM_COMMAND_TOOL_COMMANDS)[number];
 export declare const SWARM_COMMAND_TOOL_ALLOWLIST: Set<string>;
+/**
+ * Issue #890: subcommands that must be invoked by a human user, not by the
+ * agent. The runtime Bash guardrail
+ * (`src/hooks/guardrails.ts` section 23) blocks the equivalent
+ * `bunx opencode-swarm run <cmd>` shell invocation; this set drives the
+ * chat-tool refusal message so the agent is told to surface to the user
+ * instead of being pointed at the CLI bypass it just attempted.
+ */
+export declare const HUMAN_ONLY_SWARM_COMMANDS: Set<string>;
 export declare function classifySwarmCommandToolUse(resolved: ResolvedSwarmCommand): SwarmCommandPolicyResult;
 export declare function classifySwarmCommandChatFallbackUse(resolved: ResolvedSwarmCommand): SwarmCommandPolicyResult;

--- a/dist/index.js
+++ b/dist/index.js
@@ -18582,7 +18582,7 @@ var init_manager = __esm(() => {
 
 // src/commands/acknowledge-spec-drift.ts
 import { promises as fsPromises4 } from "node:fs";
-async function handleAcknowledgeSpecDriftCommand(directory, _args) {
+async function handleAcknowledgeSpecDriftCommand(directory, _args, acknowledgedBy = "unknown") {
   const specStalenessPath = validateSwarmPath(directory, "spec-staleness.json");
   let stalenessContent;
   try {
@@ -18623,7 +18623,7 @@ async function handleAcknowledgeSpecDriftCommand(directory, _args) {
     timestamp: new Date().toISOString(),
     phase,
     planTitle,
-    acknowledgedBy: "architect",
+    acknowledgedBy,
     previousHash: stalenessData.specHash_plan,
     newHash: currentHash
   };
@@ -24980,6 +24980,45 @@ function createGuardrailsHooks(directory, directoryOrConfig, config2, authorityC
       if (/^7z\b.*\s-sdel\b/i.test(seg) && /\.swarm(?:[\x5c/\s]|$)/i.test(seg)) {
         throw new Error(`BLOCKED: "7z" with delete-source flag targeting .swarm/ detected — archive with source deletion under .swarm/ is not allowed`);
       }
+      {
+        const HUMAN_ONLY_SWARM_SUBCOMMANDS = new Set([
+          "acknowledge-spec-drift",
+          "reset",
+          "reset-session",
+          "rollback",
+          "checkpoint"
+        ]);
+        let probe = seg.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)+/, "").replace(/^eval(?:\s+--)?\s+["']?/, "").replace(/["']\s*$/, "").replace(/^\$\(\s*/, "").replace(/^\(\s*/, "").replace(/\s*\)$/, "").replace(/^`/, "").replace(/`$/, "").trim();
+        for (let i2 = 0;i2 < 4; i2++) {
+          const before = probe;
+          probe = probe.replace(/^env\s+(?:-i\b|--ignore-environment\b|-u\s+\S+|-[a-zA-Z]+\s+)*\s*/, "").replace(/^command\s+(?:-[pvV]\s+)*/, "").replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)+/, "").trim();
+          if (probe === before)
+            break;
+        }
+        const swarmCliBypassMatch = probe.match(/^\\?(?:bunx|npx|pnpx|npm(?:\s+(?:exec|x)(?:\s+--)?)?|pnpm(?:\s+(?:dlx|exec))?|yarn(?:\s+(?:dlx|exec))?|bun(?:\s+x)?|node|deno\s+run|tsx|ts-node)\b[^|;&]*?\bopencode-swarm\b[^|;&]*?\brun\s+([A-Za-z0-9_-]+)/i);
+        if (swarmCliBypassMatch && HUMAN_ONLY_SWARM_SUBCOMMANDS.has(swarmCliBypassMatch[1])) {
+          throw new Error(`BLOCKED: "${swarmCliBypassMatch[1]}" is a human-only swarm command and may not be invoked from shell by an agent. ` + `Present the situation to the user and ask them to run \`/swarm ${swarmCliBypassMatch[1]}\` themselves.`);
+        }
+        const swarmBareBinMatch = probe.match(/^\\?opencode-swarm\b[^|;&]*?\brun\s+([A-Za-z0-9_-]+)/i);
+        if (swarmBareBinMatch && HUMAN_ONLY_SWARM_SUBCOMMANDS.has(swarmBareBinMatch[1])) {
+          throw new Error(`BLOCKED: "${swarmBareBinMatch[1]}" is a human-only swarm command and may not be invoked from shell by an agent. ` + `Present the situation to the user and ask them to run \`/swarm ${swarmBareBinMatch[1]}\` themselves.`);
+        }
+        const swarmCliPathMatch = probe.match(/\bcli[/\\]+index\.[mc]?(?:js|ts)\b[^|;&]*?\brun\s+([A-Za-z0-9_-]+)/i);
+        if (swarmCliPathMatch && HUMAN_ONLY_SWARM_SUBCOMMANDS.has(swarmCliPathMatch[1])) {
+          throw new Error(`BLOCKED: "${swarmCliPathMatch[1]}" is a human-only swarm command and may not be invoked from shell by an agent. ` + `Present the situation to the user and ask them to run \`/swarm ${swarmCliPathMatch[1]}\` themselves.`);
+        }
+      }
+      {
+        const normForPathCheck = seg.replace(/\\/g, "/").replace(/\/(?:\.\/+)+/g, "/").replace(/\/{2,}/g, "/");
+        if (/\.swarm\/spec-staleness\.json\b/i.test(normForPathCheck)) {
+          const trimmed = seg.trim();
+          const looksReadOnly = /^(?:cat|less|more|head|tail|file|stat|ls|dir|Get-Content|gc|Get-Item|gi|type)\b/i.test(trimmed);
+          const hasWriteRedirect = />{1,2}\s*[^\s>]/.test(trimmed);
+          if (!looksReadOnly || hasWriteRedirect) {
+            throw new Error("BLOCKED: shell command targeting .swarm/spec-staleness.json detected. " + "This file is system-managed and gates plan-mutating tools while spec drift is unresolved. " + "Present the drift to the user and ask them to run /swarm clarify or /swarm acknowledge-spec-drift.");
+          }
+        }
+      }
     }
   }
   async function checkGateLimits(params) {
@@ -25167,11 +25206,37 @@ function createGuardrailsHooks(directory, directoryOrConfig, config2, authorityC
       }
     }
   }
+  function extractAllPatchPayloads(args2) {
+    const toolArgs = args2;
+    if (!toolArgs)
+      return [];
+    const out2 = [];
+    for (const key of ["patch", "input", "diff"]) {
+      const v = toolArgs[key];
+      if (typeof v === "string" && v.length > 0)
+        out2.push(v);
+    }
+    const cmd = toolArgs.cmd;
+    if (Array.isArray(cmd)) {
+      for (const entry of cmd) {
+        if (typeof entry === "string" && entry.length > 0)
+          out2.push(entry);
+      }
+    }
+    return out2;
+  }
+  function patchPayloadHasHumanOnlyInvocation(args2) {
+    const payloads = extractAllPatchPayloads(args2);
+    if (payloads.length === 0)
+      return false;
+    const re = /\bopencode-swarm\b[\s\S]*?\brun\s+(?:acknowledge-spec-drift|reset|reset-session|rollback|checkpoint)\b/i;
+    return payloads.some((p) => re.test(p));
+  }
   function extractPatchTargetPaths(tool, args2) {
     if (tool !== "apply_patch" && tool !== "patch")
       return [];
     const toolArgs = args2;
-    const patchText = toolArgs?.input ?? toolArgs?.patch ?? (Array.isArray(toolArgs?.cmd) ? toolArgs.cmd[1] : undefined);
+    const patchText = toolArgs?.input ?? toolArgs?.patch ?? toolArgs?.diff ?? (Array.isArray(toolArgs?.cmd) ? toolArgs.cmd[1] : undefined);
     if (typeof patchText !== "string")
       return [];
     if (patchText.length > 1e6) {
@@ -25219,6 +25284,11 @@ function createGuardrailsHooks(directory, directoryOrConfig, config2, authorityC
   function handlePlanAndScopeProtection(sessionID, tool, args2) {
     const toolArgs = args2;
     const targetPath = toolArgs?.filePath ?? toolArgs?.path ?? toolArgs?.file ?? toolArgs?.target;
+    if (tool === "apply_patch" || tool === "patch") {
+      if (patchPayloadHasHumanOnlyInvocation(args2)) {
+        throw new Error("BLOCKED: apply_patch would introduce a script invoking a human-only swarm CLI subcommand. " + "Present the situation to the user and ask them to run the command themselves.");
+      }
+    }
     if (typeof targetPath === "string" && targetPath.length > 0) {
       const resolvedTarget = path10.resolve(effectiveDirectory, targetPath).toLowerCase();
       const planMdPath = path10.resolve(effectiveDirectory, ".swarm", "plan.md").toLowerCase();
@@ -25226,14 +25296,26 @@ function createGuardrailsHooks(directory, directoryOrConfig, config2, authorityC
       if (resolvedTarget === planMdPath || resolvedTarget === planJsonPath) {
         throw new Error("PLAN STATE VIOLATION: Direct writes to .swarm/plan.md and .swarm/plan.json are blocked. " + "plan.md is auto-regenerated from plan.json by PlanSyncWorker. " + "Use save_plan for ALL structural plan changes (adding/removing tasks, updating descriptions, dependencies, or phase names). " + "Use update_task_status() for task status only. " + "Use phase_complete() for phase transitions only.");
       }
+      const specStalenessPath = path10.resolve(effectiveDirectory, ".swarm", "spec-staleness.json").toLowerCase();
+      if (resolvedTarget === specStalenessPath) {
+        throw new Error("SPEC_DRIFT_VIOLATION: Direct writes to .swarm/spec-staleness.json are blocked. " + "This file is system-managed and gates plan-mutating tools while spec drift is unresolved. " + "Present the drift to the user and ask them to run /swarm clarify or /swarm acknowledge-spec-drift.");
+      }
+      const content = toolArgs?.content ?? toolArgs?.text ?? toolArgs?.new_string ?? toolArgs?.newText;
+      if (typeof content === "string" && /\bopencode-swarm\b[\s\S]*?\brun\s+(?:acknowledge-spec-drift|reset|reset-session|rollback|checkpoint)\b/i.test(content)) {
+        throw new Error("BLOCKED: write/edit tool would create a script invoking a human-only swarm CLI subcommand. " + "Present the situation to the user and ask them to run the command themselves.");
+      }
     }
     if (!targetPath && (tool === "apply_patch" || tool === "patch")) {
       for (const p of extractPatchTargetPaths(tool, args2)) {
         const resolvedP = path10.resolve(effectiveDirectory, p);
         const planMdPath = path10.resolve(effectiveDirectory, ".swarm", "plan.md").toLowerCase();
         const planJsonPath = path10.resolve(effectiveDirectory, ".swarm", "plan.json").toLowerCase();
+        const specStalenessPath = path10.resolve(effectiveDirectory, ".swarm", "spec-staleness.json").toLowerCase();
         if (resolvedP.toLowerCase() === planMdPath || resolvedP.toLowerCase() === planJsonPath) {
           throw new Error("PLAN STATE VIOLATION: Direct writes to .swarm/plan.md and .swarm/plan.json are blocked. " + "plan.md is auto-regenerated from plan.json by PlanSyncWorker. " + "Use save_plan for ALL structural plan changes (adding/removing tasks, updating descriptions, dependencies, or phase names). " + "Use update_task_status() for task status only. " + "Use phase_complete() for phase transitions only.");
+        }
+        if (resolvedP.toLowerCase() === specStalenessPath) {
+          throw new Error("SPEC_DRIFT_VIOLATION: Direct writes to .swarm/spec-staleness.json are blocked. " + "This file is system-managed and gates plan-mutating tools while spec drift is unresolved. " + "Present the drift to the user and ask them to run /swarm clarify or /swarm acknowledge-spec-drift.");
         }
         if (isOutsideSwarmDir(p, effectiveDirectory) && (isSourceCodePath(p) || hasTraversalSegments(p))) {
           const session = swarmState.agentSessions.get(sessionID);
@@ -61066,7 +61148,8 @@ async function executeSwarmCommand(args2) {
           directory,
           args: resolved.remainingArgs,
           sessionID,
-          agents
+          agents,
+          source: "chat"
         });
       } catch (_err) {
         const cmdName = tokens[0] || "unknown";
@@ -61098,6 +61181,12 @@ function classifySwarmCommandToolUse(resolved) {
   const canonicalKey = canonicalCommandKey(resolved);
   const args2 = resolved.remainingArgs;
   if (!SWARM_COMMAND_TOOL_ALLOWLIST.has(canonicalKey)) {
+    if (HUMAN_ONLY_SWARM_COMMANDS.has(canonicalKey)) {
+      return {
+        allowed: false,
+        message: `/swarm ${canonicalKey} is a human-only command. ` + `Present the situation to the user and ask them to run \`/swarm ${canonicalKey}\` themselves ` + `(or \`bunx opencode-swarm run ${canonicalKey}\` from a terminal). ` + `You MUST NOT run it yourself via Bash, swarm_command, or any other tool — ` + `the runtime guardrail will block such attempts.`
+      };
+    }
     return {
       allowed: false,
       message: `/swarm ${canonicalKey} is not available through the chat tool yet.
@@ -61187,7 +61276,7 @@ function classifySwarmCommandChatFallbackUse(resolved) {
   }
   return { allowed: true };
 }
-var SWARM_COMMAND_TOOL_COMMANDS, SWARM_COMMAND_TOOL_ALLOWLIST, NO_ARGS, SUMMARY_ID_PATTERN, TASK_ID_PATTERN;
+var SWARM_COMMAND_TOOL_COMMANDS, SWARM_COMMAND_TOOL_ALLOWLIST, HUMAN_ONLY_SWARM_COMMANDS, NO_ARGS, SUMMARY_ID_PATTERN, TASK_ID_PATTERN;
 var init_tool_policy = __esm(() => {
   init_command_dispatch();
   SWARM_COMMAND_TOOL_COMMANDS = [
@@ -61232,6 +61321,13 @@ var init_tool_policy = __esm(() => {
     "knowledge",
     "sync-plan",
     "export"
+  ]);
+  HUMAN_ONLY_SWARM_COMMANDS = new Set([
+    "acknowledge-spec-drift",
+    "reset",
+    "reset-session",
+    "rollback",
+    "checkpoint"
   ]);
   NO_ARGS = new Set([
     "agents",
@@ -61790,7 +61886,7 @@ var init_registry = __esm(() => {
   init_write_retro2();
   COMMAND_REGISTRY = {
     "acknowledge-spec-drift": {
-      handler: (ctx) => handleAcknowledgeSpecDriftCommand(ctx.directory, ctx.args),
+      handler: (ctx) => handleAcknowledgeSpecDriftCommand(ctx.directory, ctx.args, ctx.source === "cli" ? "cli" : ctx.source === "chat" ? "user" : "unknown"),
       description: "Acknowledge that the spec has drifted from the plan and suppress further warnings",
       args: "",
       category: "diagnostics"
@@ -63046,7 +63142,7 @@ Continue handling small touch-ups (typos, cross-references) inline.
 ## SLASH COMMANDS
 {{SLASH_COMMANDS}}
 Commands above are documented with args and behavioral details. Run commands via /swarm <command> [args].
-Outside OpenCode, invoke any plugin command via: \`bunx opencode-swarm run <command> [args]\` (e.g. \`bunx opencode-swarm run knowledge migrate\`). Do not use \`bun -e\` or look for \`src/commands/\` — those paths are internal to the plugin source and do not exist in user project directories.
+Outside OpenCode, invoke any plugin command via: \`bunx opencode-swarm run <command> [args]\` (e.g. \`bunx opencode-swarm run knowledge migrate\`). Do not use \`bun -e\` or look for \`src/commands/\` — those paths are internal to the plugin source and do not exist in user project directories. EXCEPTION — human-only commands (including but not limited to \`acknowledge-spec-drift\`, \`reset\`, \`reset-session\`, \`rollback\`, \`checkpoint\`, and any command that releases a runtime safety gate or destroys plan state): you MUST present these to the user and ask them to run the command themselves. Never invoke a human-only command via Bash, swarm_command, or chat fallback. The runtime guardrail will block such attempts; if a Bash call returns \`BLOCKED\` with a "human-only" message, do not retry under a different shell form — present the situation to the user instead.
 
 SMEs advise only. Reviewer and critic review only. None of them write code.
 
@@ -63934,10 +64030,17 @@ If resuming a project with an existing approved plan, CRITIC-GATE is already sat
 - This rule is satisfied by the save_plan tool's own spec gate — it exists as a reminder that planning requires a spec.
 
 6k. SPEC-STALENESS GUARD:
-- If _specStale or .swarm/spec-staleness.json exists, the Architect MUST read the file and either:
-  - Run /swarm clarify to update the spec and align it with the plan, OR
-  - Run /swarm acknowledge-spec-drift to acknowledge the drift and suppress further warnings
-- Do NOT proceed with implementation until spec staleness is resolved.
+- If _specStale or .swarm/spec-staleness.json exists, the Architect MUST stop
+  and SURFACE THE DRIFT TO THE USER. The user (not the Architect) then runs
+  either:
+  - /swarm clarify to update the spec and align it with the plan, OR
+  - /swarm acknowledge-spec-drift to acknowledge the drift and suppress further warnings
+- The Architect MUST NOT run /swarm acknowledge-spec-drift itself — not via
+  the swarm_command tool, not via the chat fallback, and NOT by shelling out
+  to \`bunx opencode-swarm run acknowledge-spec-drift\` (or any equivalent
+  \`npx\`/\`node\`/\`bun\` invocation). Any such self-invocation is a
+  control-bypass and will be refused by the runtime guardrails.
+- Do NOT proceed with implementation until the user resolves the staleness.
 - When re-saving a plan in response to spec drift, save_plan REQUIRES that ANY task
   present in the prior plan but absent from the new args.phases be enumerated
   in removed_task_ids with a removal_reason. save_plan will reject the call
@@ -63948,8 +64051,8 @@ If resuming a project with an existing approved plan, CRITIC-GATE is already sat
 - While .swarm/spec-staleness.json exists, the runtime STRUCTURALLY BLOCKS the
   following tools (SPEC_DRIFT_BLOCKED_TOOLS): save_plan, update_task_status,
   phase_complete, lean_turbo_run_phase, lean_turbo_acquire_locks. If a call
-  returns SPEC_DRIFT_BLOCK, do NOT retry; instead present the drift to the
-  user and run /swarm clarify or /swarm acknowledge-spec-drift first.
+  returns SPEC_DRIFT_BLOCK, do NOT retry; surface the drift to the user and
+  WAIT for them to run /swarm clarify or /swarm acknowledge-spec-drift.
 
 ### MODE: EXECUTE
 For each task (respecting dependencies):
@@ -65546,9 +65649,10 @@ WORKFLOW:
 - TODO comments in code (those go through the task system, not code comments)
 
 ## RELEASE NOTES
-When writing release notes (docs/releases/v{VERSION}.md):
-- Determine next version from .release-please-manifest.json + commit type (feat → minor, fix → patch)
-- Follow the established format in existing release notes files
+When writing release notes (docs/releases/pending/<slug>.md):
+- Do NOT determine the next version. Do NOT create docs/releases/vX.Y.Z.md. release-please owns the version; the release workflow aggregates pending fragments.
+- Pick a short, kebab-case slug describing your change (e.g. spec-drift-self-ack-guardrail.md). Pick one unlikely to collide with concurrent PRs.
+- Follow the established format in existing release notes files (descriptive topic heading, not a version prefix).
 - Include: overview, breaking changes (if any), new features, bug fixes, internal improvements
 - Do NOT manually edit package.json version, CHANGELOG.md, or .release-please-manifest.json — release-please owns these
 

--- a/docs/releases/pending/release-notes-pending-fragments.md
+++ b/docs/releases/pending/release-notes-pending-fragments.md
@@ -1,0 +1,87 @@
+# Per-PR pending release-note fragments (conflict-free workflow)
+
+## What changed
+
+- **New contributor workflow**: PRs now add a unique fragment at
+  `docs/releases/pending/<descriptive-slug>.md` instead of creating
+  `docs/releases/v{NEXT_VERSION}.md`. Each PR owning its own unique file
+  eliminates the previous merge-conflict hotspot where concurrent fix PRs
+  all targeted the same next-version file.
+- **New aggregation script** (`scripts/release-notes-fragments.mjs`,
+  ~250 lines, pure Node built-ins + `gh` CLI, no npm deps):
+  - `update-pr` mode — finds the open release-please PR (label
+    `autorelease: pending`), extracts referenced source PR numbers from
+    its body, verifies each is actually a PR (skips bare issue refs),
+    gathers their `docs/releases/pending/*.md` files, concatenates them
+    deterministically (sort: PR number ascending → file path ascending),
+    and injects the combined text inside a stable
+    `<!-- custom-release-notes:start --> … <!-- custom-release-notes:end -->`
+    marker block in the release PR body. Idempotent (replace-in-place on
+    re-run). Preserves all release-please robot/body markers.
+  - `update-release` mode — same flow but operates on the GitHub
+    Release body after a tag is cut, keyed by `$TAG_NAME`.
+- **Workflow** (`.github/workflows/release-and-publish.yml`):
+  - `update-pr-notes` job now runs
+    `node scripts/release-notes-fragments.mjs update-pr` instead of
+    parsing the version from the release PR title and looking up
+    `docs/releases/v${VERSION}.md`.
+  - `update-release-notes` job now runs
+    `node scripts/release-notes-fragments.mjs update-release` instead
+    of looking up `docs/releases/${TAG_NAME}.md`.
+  - All existing action SHA pins unchanged. Permissions unchanged
+    (`update-pr-notes` keeps `pull-requests: write` + `contents: read`;
+    `update-release-notes` keeps `contents: write`).
+- **Documentation updates** so every contributor-facing rule points at
+  the new convention:
+  - `contributing.md` — release-notes section, common-mistakes table,
+    final checklist.
+  - `.claude/skills/commit-pr/SKILL.md` — Step 3 rewrite + checklist.
+  - `.opencode/contributing/SKILL.md` — same.
+  - `.opencode/skills/generated/pr-review-fix/SKILL.md` — same.
+  - `AGENTS.md` §12 release/cache hygiene.
+  - `src/agents/docs.ts` — docs-agent system prompt updated.
+- **Tests** (`tests/unit/scripts/release-notes-fragments.test.ts`,
+  27 cases, `bun:test`, no `mock.module`, pure-function tests only):
+  - PR-number extraction across all release-please syntaxes
+    (`(#N)`, `[#N]`, `/pull/N`, bare `#N`).
+  - De-duplication across syntaxes, first-seen ordering preserved.
+  - Path filter keeps `docs/releases/pending/*.md`, ignores
+    `docs/releases/v*.md` and unrelated paths, normalizes Windows
+    backslashes.
+  - Deterministic ordering: PR number ascending → path ascending.
+  - Marker-block insert / idempotent replace / preserve release-please
+    body markers / empty-input safety.
+
+## Why
+
+The previous workflow required every PR to predict the next semver
+version and create `docs/releases/v{NEXT_VERSION}.md`. release-please
+already owns the version decision, so the manual prediction was
+duplicate work AND a hotspot for merge conflicts whenever two fix PRs
+were in flight simultaneously. Refactoring to per-PR unique fragments
+removes both problems without introducing a shared file (which would
+just relocate the same conflict surface).
+
+## Migration steps
+
+- New PRs: do NOT compute `NEXT_VERSION`. Do NOT create
+  `docs/releases/vX.Y.Z.md`. Add
+  `docs/releases/pending/<descriptive-slug>.md` instead.
+- Existing in-flight PRs that already added a `docs/releases/vX.Y.Z.md`
+  file: move the content into
+  `docs/releases/pending/<descriptive-slug>.md` and remove the
+  versioned file from the PR. Historical versioned release docs on
+  `main` are NOT touched.
+- No changes required to `package.json`, `CHANGELOG.md`,
+  `.release-please-manifest.json` — release-please continues to own
+  those.
+
+## Known caveats
+
+- Pending fragments are NOT automatically deleted after release. A
+  maintainer prunes `docs/releases/pending/` after a release ships
+  (kept human-in-the-loop to avoid silently dropping notes).
+- The aggregation runs only when a release PR exists (post-merge to
+  `main`) or when a tag is cut. Local PR previews don't show the
+  aggregated body — that's by design, since the aggregation depends
+  on which PRs release-please actually bundles into the next release.

--- a/docs/releases/pending/spec-drift-self-ack-guardrail.md
+++ b/docs/releases/pending/spec-drift-self-ack-guardrail.md
@@ -1,0 +1,154 @@
+# Spec-drift self-acknowledgment guardrail (issue #890)
+
+## What changed
+
+### Block agent self-acknowledgment of spec drift (issue #890)
+
+The Architect agent could clear `.swarm/spec-staleness.json` itself by
+shelling out to `bunx opencode-swarm run acknowledge-spec-drift`, bypassing
+the runtime `SPEC_DRIFT_BLOCK` gate that exists specifically to force the
+human user to confirm a spec change. The audit event recorded
+`acknowledgedBy: 'architect'` for every invocation, masking the
+self-acknowledgment. Five fixes close the loop:
+
+1. **New Bash guardrail (sections 23 and 24 in `src/hooks/guardrails.ts`)** —
+   section 23 blocks runner-based invocations
+   (`bunx | npx | pnpx | pnpm exec | pnpm dlx | yarn dlx | yarn exec | bun x
+   | bun | node | deno run | tsx | ts-node … opencode-swarm … run
+   <human-only-subcommand>`), the bare `opencode-swarm` binary on PATH, and
+   the `cli/index.[mc]?(js|ts) … run <human-only-subcommand>` dist-path
+   form. Evasion-hardened against env-var prefix (`FOO=bar bunx …`),
+   `eval "…"`, subshell parens `(…)`, `$(…)` and backtick command
+   substitution, version specifiers (`opencode-swarm@latest`), leading
+   backslash dispatcher (`\bunx`), and `bash -c / sh -c / powershell -c`
+   wrappers (already stripped by `dcUnwrapWrappers`). Section 24 closes the
+   indirect-eval surface: any shell segment that names
+   `.swarm/spec-staleness.json` (POSIX or Windows path form) is blocked
+   unless it is a pure read (`cat | less | more | head | tail | file | stat
+   | ls | dir | Get-Content | gc | Get-Item | gi | type`) AND contains no
+   `>` / `>>` redirect — closing `bun -e "fs.unlinkSync('.swarm/spec-staleness.json')"`,
+   `node -e fs.writeFileSync …`, heredoc writes, and arbitrary script forms.
+   The human-only set is
+   `{acknowledge-spec-drift, reset, reset-session, rollback, checkpoint}`.
+
+2. **Chat-tool refusal message fix (`src/commands/tool-policy.ts`)** —
+   when the agent attempts a human-only subcommand through the
+   `swarm_command` tool, the refusal message no longer suggests *"Use the
+   canonical CLI path: `bunx opencode-swarm run …`"* (which was the exact
+   bypass instruction). It now reads *"This command is human-only. Present
+   the situation to the user and ask them to run /swarm <cmd>
+   themselves."* Non-human-only commands (`dark-matter`, `simulate`, etc.)
+   keep the original message.
+
+3. **Architect prompt cleanup (`src/agents/architect.ts`)** — line 534 (the
+   global "outside OpenCode, use `bunx opencode-swarm run`" rule) is
+   qualified with a human-only exception; lines 1421-1437 (the
+   spec-staleness guard) are rewritten to say MUST NOT self-invoke via
+   Bash, `swarm_command`, or chat fallback, and to name all three vectors
+   explicitly.
+
+4. **Audit-trail honesty (`src/commands/acknowledge-spec-drift.ts`,
+   `src/commands/registry.ts`, `src/cli/index.ts`,
+   `src/commands/command-dispatch.ts`)** — `acknowledgedBy` is now
+   caller-supplied (`'user' | 'cli' | 'unknown'`) rather than the
+   hardcoded `'architect'`. The chat-fallback dispatcher passes `'user'`;
+   the CLI `run` dispatcher passes `'cli'`; missing-parameter callers
+   record `'unknown'` (fail-open on attribution rather than mis-attribute).
+   New `source: 'cli' | 'chat'` field on `CommandContext` is optional and
+   backwards-compatible.
+
+5. **Direct write-tool and apply_patch protection
+   (`src/hooks/guardrails.ts handlePlanAndScopeProtection`)** — `write` /
+   `edit` / `apply_patch` / `patch` calls targeting
+   `.swarm/spec-staleness.json` throw `SPEC_DRIFT_VIOLATION`, mirroring the
+   existing protection for `.swarm/plan.md` / `.swarm/plan.json`. Closes
+   the "agent rewrites the file to malformed JSON to trigger the handler's
+   self-clearing fast path" surface.
+
+6. **Script-indirection guard
+   (`src/hooks/guardrails.ts handlePlanAndScopeProtection`)** — write/edit
+   tool calls whose CONTENT contains an invocation of a human-only swarm
+   CLI subcommand (`opencode-swarm … run (acknowledge-spec-drift | reset |
+   reset-session | rollback | checkpoint)`) are blocked. Closes the
+   "agent writes `tmp.sh` then runs `bash tmp.sh`" surface — the host
+   guardrails can't read the script body once a subprocess executes it, so
+   the block fires at write time.
+
+7. **Regression tests** —
+   `tests/unit/hooks/destructive-command-swarm-cli-bypass.test.ts`
+   (69 cases: dispatcher forms, evasion forms incl. `$(…)`, backticks,
+   `pnpm exec`, `pnpm dlx`, bare `opencode-swarm`, `bun -e` /
+   `node -e fs.unlinkSync`, redirect-write, heredoc-write, dist-path
+   forms, other human-only subcommands, negative read-only cases,
+   write-tool block, script-indirection block) and
+   `src/commands/tool-policy.human-only.test.ts` (13 cases verifying the
+   HUMAN_ONLY message swap, no regression for non-human-only commands, and
+   that the chat-fallback path remains allowed for the legitimate
+   user-typed slash).
+
+## Why
+
+When the spec changes, `.swarm/spec-staleness.json` is written and the
+runtime structurally blocks `save_plan`, `update_task_status`,
+`phase_complete`, `lean_turbo_run_phase`, and `lean_turbo_acquire_locks`
+(`SPEC_DRIFT_BLOCKED_TOOLS` in `src/hooks/guardrails.ts`). The block exists
+specifically to force the architect to surface the drift to the user, who
+then runs `/swarm clarify` (to update the spec) or
+`/swarm acknowledge-spec-drift` (to dismiss the warning). In the reporter's
+session, the architect (DeepSeek V4 Flash, OpenCode Zen) followed the
+chat-tool refusal message literally and shelled out to the unguarded CLI
+path — successfully clearing the gate without user involvement. The control
+loop intended to be (architect proposes → human acknowledges) collapsed
+into (architect proposes → architect acknowledges), and the audit event
+recorded `acknowledgedBy: 'architect'` for the entire flow, indistinguishable
+from a legitimate path.
+
+The wider class of bug (other state-mutating commands sharing the same
+shape) is addressed by extending the HUMAN_ONLY set to include `reset`,
+`reset-session`, `rollback`, and `checkpoint` — the Explorer pass during
+issue trace found that all four are reachable via the same CLI bypass
+surface.
+
+## Migration steps
+
+None. No configuration changes are required. Users running
+`/swarm acknowledge-spec-drift` inside OpenCode (via slash command) or
+`bunx opencode-swarm run acknowledge-spec-drift` from a real terminal both
+continue to work — the guard runs only inside the agent's Bash tool.
+
+## Known caveats
+
+- Runtime defense is now layered (Bash guard sections 23 & 24 + write-tool
+  guard + apply_patch guard + script-indirection guard + chat-tool refusal
+  message + architect prompt). A misaligned model that constructs a form
+  not covered by any layer could still attempt a bypass, but every realistic
+  vector found by the fresh adversarial critic (env-var prefix, `$(…)`,
+  backticks, `pnpm exec`/`dlx`, bare `opencode-swarm`, `bun -e` /
+  `node -e fs.unlinkSync`, redirect-write, heredoc-write, dist-path,
+  script-indirection via `bash tmp.sh`, write/edit on the staleness file)
+  is covered by at least one layer. The pattern set is robust against
+  realistic LLM output (verified against 69 bypass strings) but is not a
+  sandbox.
+- The audit-trail field `acknowledgedBy` previously held the literal string
+  `'architect'`. No downstream consumer in the codebase reads this field
+  (verified by grep). Two test files asserting the literal value are
+  updated to assert the new defaults (`'unknown'`).
+- `dist/index.js` and `dist/cli/index.js` are rebuilt as part of this
+  release.
+
+## Invariant audit (per AGENTS.md)
+
+- §9 Guardrails / retry semantics: extension of `checkDestructiveCommand`
+  using the existing pattern established by #885 (`mv`/`move`/`ren`/
+  `Move-Item` on `.swarm/`). Cross-platform regex; no subprocess or
+  filesystem side-effects.
+- §10 Chat / system-message hook contracts: architect system prompt text
+  modified (line 534 and lines 1421-1437). Verified by snapshot-style
+  assertions in the new tests that the new "MUST NOT" wording is present
+  and that the chat-tool refusal message for `acknowledge-spec-drift`
+  no longer instructs the agent to use the CLI bypass.
+- §7 Test writing: new tests use `bun:test`; no `mock.module`; no temp
+  paths beyond `/tmp`; per-file isolation verified.
+- §2 Runtime portability: regex matches both POSIX and Windows path
+  separators (`cli[/\\]+index\.[mc]?(?:js|ts)`); no new top-level
+  `bun:` imports introduced.

--- a/scripts/release-notes-fragments.mjs
+++ b/scripts/release-notes-fragments.mjs
@@ -1,0 +1,479 @@
+#!/usr/bin/env node
+/**
+ * release-notes-fragments.mjs — aggregate per-PR release-note fragments
+ * into the release-please PR body (and the GitHub Release body on tag).
+ *
+ * Background: every PR that ships a user-visible change drops a unique
+ * file under `docs/releases/pending/<slug>.md`. release-please decides the
+ * actual version. This script reads the release-please PR body (or the
+ * GitHub Release body after a tag is cut), discovers which source PRs are
+ * included, gathers their pending fragments, and injects the combined
+ * content inside a stable marker block:
+ *
+ *     <!-- custom-release-notes:start -->
+ *     ...combined notes...
+ *     <!-- custom-release-notes:end -->
+ *
+ * Idempotent: re-running replaces the existing block in place.
+ *
+ * Modes:
+ *   node scripts/release-notes-fragments.mjs update-pr
+ *   node scripts/release-notes-fragments.mjs update-release
+ *
+ * Dependencies: Node built-ins + the `gh` CLI already present on
+ * GitHub-hosted runners. No npm dependencies.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// -----------------------------------------------------------------------------
+// Stable marker block — never change these strings without considering that
+// older release PR bodies in the wild rely on them for idempotent replace.
+// -----------------------------------------------------------------------------
+export const MARKER_START = '<!-- custom-release-notes:start -->';
+export const MARKER_END = '<!-- custom-release-notes:end -->';
+export const FRAGMENT_DIR = 'docs/releases/pending';
+
+// -----------------------------------------------------------------------------
+// Pure helpers — exported for unit tests. No I/O, no gh CLI.
+// -----------------------------------------------------------------------------
+
+/**
+ * Maximum PR-number magnitude accepted by the extractor. GitHub PR numbers
+ * are sequential per-repo and 7 digits is comfortably above any realistic
+ * monorepo. Anything larger is almost certainly garbage in the body text
+ * (timestamps, IDs from other systems) or an attempt to coerce the
+ * extractor into looking up unrelated PRs.
+ */
+const MAX_PR_DIGITS = 7;
+
+/**
+ * Strip any previously-injected custom-release-notes block from a body
+ * before scanning it for PR references. Without this, every re-run would
+ * re-extract PR numbers that appear *inside* our own injected fragment
+ * prose (e.g. `(#885)` cited as context for another change) and treat
+ * them as new source PRs, polluting the next aggregation with unrelated
+ * fragments.
+ *
+ * Exported for testability. Uses the SAME `lastIndexOf` strategy as
+ * `upsertReleaseNotesBlock` so any nested markers from prior buggy runs
+ * are absorbed by the strip too.
+ */
+export function stripCustomReleaseNotesBlock(body) {
+	if (typeof body !== 'string' || body.length === 0) return '';
+	const startIdx = body.indexOf(MARKER_START);
+	const endIdx = body.lastIndexOf(MARKER_END);
+	if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) return body;
+	return body.slice(0, startIdx) + body.slice(endIdx + MARKER_END.length);
+}
+
+/**
+ * Extract candidate PR numbers from a release-please body string.
+ *
+ * release-please writes changelog entries that reference source PRs as
+ * `(#886)`, `[#886](url)`, or `https://github.com/owner/repo/pull/886`.
+ * We capture every numeric reference and de-duplicate while preserving
+ * first-seen order.
+ *
+ * Numbers returned are *candidates*. The caller must verify each one is
+ * actually a PR via `gh pr view`. Issues live in the same numeric
+ * namespace, and third-party URLs in the body (e.g. dependency-bump
+ * citations pointing at upstream repos) would otherwise leak in.
+ */
+export function extractCandidatePrNumbers(body) {
+	if (typeof body !== 'string' || body.length === 0) return [];
+	const seen = new Set();
+	const out = [];
+	// Each pattern captures the numeric portion in group 1. The `\d{1,N}`
+	// cap keeps `parseInt` from silently rounding very large values and
+	// blocks the most obvious "shove a giant number into the extractor"
+	// attack from a malicious release-please body.
+	const digits = `\\d{1,${MAX_PR_DIGITS}}`;
+	const patterns = [
+		new RegExp(`\\(#(${digits})\\)`, 'g'),
+		new RegExp(`\\[#(${digits})\\]`, 'g'),
+		new RegExp(`\\/pull\\/(${digits})\\b`, 'g'),
+		new RegExp(`(?<![\\w/])#(${digits})\\b`, 'g'),
+	];
+	for (const re of patterns) {
+		for (const m of body.matchAll(re)) {
+			const raw = m[1];
+			// Defense in depth: reject if a longer digit run extends past
+			// the capture (e.g. `#12345678` would match the first 7 but
+			// the trailing `8` makes it not a clean reference).
+			if (raw.length === MAX_PR_DIGITS) {
+				const after = body[m.index + m[0].length];
+				if (after && /\d/.test(after)) continue;
+			}
+			const n = Number.parseInt(raw, 10);
+			if (Number.isFinite(n) && n > 0 && !seen.has(n)) {
+				seen.add(n);
+				out.push(n);
+			}
+		}
+	}
+	return out;
+}
+
+/**
+ * Filter changed-files entries down to pending release-note fragments.
+ *
+ * Accepts entries shaped like `{ path: '...' }` (gh pr view --json files).
+ * Returns the file paths that live under `docs/releases/pending/` and end
+ * in `.md`. Versioned files (`docs/releases/v1.2.3.md`) and any other
+ * paths are ignored.
+ *
+ * Path-traversal rejection: any path containing a `..` segment, NUL byte,
+ * or absolute marker (leading `/` or drive letter) is dropped. These
+ * cannot occur from a well-formed `gh pr view --json files` response
+ * against a real PR, but the listing is attacker-controllable (the PR
+ * author controls their own file paths) and the script later does
+ * `path.resolve(repoRoot, filePath)` to read the file, which would
+ * happily escape the repo.
+ */
+export function filterPendingFragmentPaths(files) {
+	if (!Array.isArray(files)) return [];
+	const out = [];
+	for (const f of files) {
+		const p = typeof f === 'string' ? f : f?.path;
+		if (typeof p !== 'string') continue;
+		if (p.length === 0) continue;
+		// Reject NUL or any control char that could confuse downstream
+		// path/CLI handling.
+		if (/[\x00-\x1f]/.test(p)) continue;
+		// Reject absolute paths (POSIX `/x` or Windows `C:` / `\\share`).
+		if (/^[\/\\]/.test(p) || /^[A-Za-z]:[\\/]/.test(p)) continue;
+		// Normalize Windows separators for cross-platform comparison.
+		const norm = p.replace(/\\/g, '/');
+		// Reject any `..` segment — covers `a/../b`, `../foo`, `./../x`.
+		// Done on the normalized form so a stray `\..\\` is caught too.
+		if (norm.split('/').some((seg) => seg === '..')) continue;
+		if (
+			norm.startsWith(`${FRAGMENT_DIR}/`) &&
+			norm.toLowerCase().endsWith('.md')
+		) {
+			out.push(norm);
+		}
+	}
+	return out;
+}
+
+/**
+ * Concatenate fragment contents in deterministic order:
+ *   primary  → PR number ascending
+ *   secondary→ file path ascending (case-sensitive)
+ *
+ * `entries` is `[{ prNumber, filePath, content }, ...]`.
+ * De-duplication by filePath happens here too — the same fragment cannot
+ * appear twice in the output even if multiple PRs touched it.
+ */
+export function combineFragments(entries) {
+	if (!Array.isArray(entries) || entries.length === 0) return '';
+	const dedup = new Map();
+	for (const e of entries) {
+		if (!e || typeof e.content !== 'string') continue;
+		const fp = e.filePath;
+		if (typeof fp !== 'string') continue;
+		if (!dedup.has(fp)) dedup.set(fp, e);
+	}
+	const sorted = [...dedup.values()].sort((a, b) => {
+		const pa = Number.isFinite(a.prNumber) ? a.prNumber : Number.MAX_SAFE_INTEGER;
+		const pb = Number.isFinite(b.prNumber) ? b.prNumber : Number.MAX_SAFE_INTEGER;
+		if (pa !== pb) return pa - pb;
+		return a.filePath < b.filePath ? -1 : a.filePath > b.filePath ? 1 : 0;
+	});
+	const parts = sorted.map((e) => e.content.replace(/\s+$/, ''));
+	return parts.join('\n\n---\n\n');
+}
+
+/**
+ * Strip any literal marker strings out of fragment content before
+ * insertion. A fragment that legitimately mentions the markers (e.g. the
+ * release-notes design doc *describes* them) would otherwise nest the
+ * markers inside the block, breaking the next idempotent run.
+ *
+ * We replace the literal strings with a visible marker-comment-escaped
+ * form so the discussion remains legible in the rendered notes.
+ */
+function neutralizeMarkers(text) {
+	return text
+		.replace(/<!-- custom-release-notes:start -->/g, '<!-- custom-release-notes-start (literal) -->')
+		.replace(/<!-- custom-release-notes:end -->/g, '<!-- custom-release-notes-end (literal) -->');
+}
+
+/**
+ * Insert or replace the custom-release-notes marker block in a body.
+ *
+ * Behavior:
+ *   - If both markers are present: replace from the FIRST `MARKER_START`
+ *     through the LAST `MARKER_END`. Using `lastIndexOf` for the closer
+ *     absorbs accidentally-nested markers that prior buggy runs may have
+ *     left behind, and protects against fragment content that contains
+ *     the literal marker strings (in addition to the `neutralizeMarkers`
+ *     pass on `combined`).
+ *   - If markers are absent: prepend a marker block above the existing
+ *     body, separated by a blank line, preserving the original body
+ *     (release-please content / markers) verbatim below.
+ *   - If `combined` is empty: return the original body unchanged.
+ *
+ * Idempotent: running the function twice with the same `combined` yields
+ * the same result as running it once, even if a fragment's content
+ * contains the literal marker strings.
+ */
+export function upsertReleaseNotesBlock(body, combined) {
+	const original = typeof body === 'string' ? body : '';
+	const rawNotes = typeof combined === 'string' ? combined.trim() : '';
+	if (rawNotes.length === 0) return original;
+	const notes = neutralizeMarkers(rawNotes);
+	const block = `${MARKER_START}\n${notes}\n${MARKER_END}`;
+	const startIdx = original.indexOf(MARKER_START);
+	const endIdx = original.lastIndexOf(MARKER_END);
+	if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+		// Replace from the first start marker through the LAST closing
+		// marker (inclusive). This absorbs any nested markers a buggy
+		// prior run might have introduced into the block content.
+		const before = original.slice(0, startIdx);
+		const after = original.slice(endIdx + MARKER_END.length);
+		return `${before}${block}${after}`;
+	}
+	// No markers — prepend, separated by a blank line.
+	if (original.length === 0) return block;
+	return `${block}\n\n${original}`;
+}
+
+// -----------------------------------------------------------------------------
+// gh CLI shim — wrapped so update modes can be exercised at integration time
+// while pure helpers stay testable without network access.
+// -----------------------------------------------------------------------------
+
+// Bounded subprocess invariant: every external-binary subprocess has an
+// explicit timeout, bounded stdio, and an array-form argv. `gh` calls
+// against the GitHub API resolve in low-single-digit seconds normally;
+// the 30-second cap is generous but prevents an indefinite hang from
+// stalling the workflow run.
+const GH_TIMEOUT_MS = 30_000;
+
+function ghJson(args) {
+	const raw = execFileSync('gh', args, {
+		encoding: 'utf8',
+		maxBuffer: 16 * 1024 * 1024,
+		timeout: GH_TIMEOUT_MS,
+	});
+	return JSON.parse(raw);
+}
+
+function ghText(args) {
+	return execFileSync('gh', args, {
+		encoding: 'utf8',
+		maxBuffer: 16 * 1024 * 1024,
+		timeout: GH_TIMEOUT_MS,
+	});
+}
+
+function tryGhJson(args) {
+	try {
+		return { ok: true, value: ghJson(args) };
+	} catch (err) {
+		return { ok: false, err };
+	}
+}
+
+/**
+ * Verify a candidate number is a PR (not an issue). Returns the parsed
+ * PR object or null if the candidate is not a PR or the lookup failed.
+ */
+function verifyPr(num) {
+	const res = tryGhJson(['pr', 'view', String(num), '--json', 'number,files']);
+	if (!res.ok) return null;
+	return res.value;
+}
+
+/**
+ * Read a fragment from the workspace if it exists, otherwise null.
+ * Paths are normalized to forward-slash form. The script always runs from
+ * the repo root in CI; we resolve relative to the repo root computed from
+ * this script's own location for local invocations.
+ */
+function readFragmentFromWorkspace(repoRoot, filePath) {
+	const abs = path.resolve(repoRoot, filePath);
+	if (!existsSync(abs)) return null;
+	return readFileSync(abs, 'utf8');
+}
+
+/**
+ * Repo root resolution: this script lives at `<repoRoot>/scripts/`.
+ */
+function resolveRepoRoot() {
+	const here = path.dirname(fileURLToPath(import.meta.url));
+	return path.resolve(here, '..');
+}
+
+/**
+ * Collect fragments for the given candidate PR numbers.
+ * Each PR is verified (skips issues / 404s), its file list is fetched,
+ * pending fragments are filtered, and contents are read from the
+ * workspace. Returns the `entries` array shape expected by
+ * `combineFragments`.
+ */
+function collectFragmentsForPrs(candidates, repoRoot, log) {
+	const entries = [];
+	const seenPaths = new Set();
+	for (const num of candidates) {
+		const pr = verifyPr(num);
+		if (!pr || !Array.isArray(pr.files)) {
+			log(`skip #${num} — not a PR or no files`);
+			continue;
+		}
+		const fragPaths = filterPendingFragmentPaths(pr.files);
+		if (fragPaths.length === 0) continue;
+		for (const fp of fragPaths) {
+			if (seenPaths.has(fp)) continue;
+			seenPaths.add(fp);
+			const content = readFragmentFromWorkspace(repoRoot, fp);
+			if (content === null) {
+				log(`fragment ${fp} referenced by #${num} not found in workspace`);
+				continue;
+			}
+			entries.push({ prNumber: num, filePath: fp, content });
+		}
+	}
+	return entries;
+}
+
+// -----------------------------------------------------------------------------
+// Mode: update-pr — keep the open release-please PR body in sync.
+// -----------------------------------------------------------------------------
+
+async function modeUpdatePr(log) {
+	const repoRoot = resolveRepoRoot();
+	const prList = tryGhJson([
+		'pr',
+		'list',
+		'--label',
+		'autorelease: pending',
+		'--json',
+		'number,body',
+		'--limit',
+		'5',
+	]);
+	if (!prList.ok || !Array.isArray(prList.value) || prList.value.length === 0) {
+		log('No autorelease PR found — exiting 0');
+		return 0;
+	}
+	const releasePr = prList.value[0];
+	// Exclude our previously-injected block before scanning, so PR
+	// references inside the injected fragments don't get re-treated as
+	// new source PRs on the next run.
+	const candidates = extractCandidatePrNumbers(
+		stripCustomReleaseNotesBlock(releasePr.body || ''),
+	);
+	if (candidates.length === 0) {
+		log('Release PR body has no PR references — exiting 0');
+		return 0;
+	}
+	const entries = collectFragmentsForPrs(candidates, repoRoot, log);
+	if (entries.length === 0) {
+		log('No pending fragments found across referenced PRs — exiting 0');
+		return 0;
+	}
+	const combined = combineFragments(entries);
+	const newBody = upsertReleaseNotesBlock(releasePr.body || '', combined);
+	if (newBody === releasePr.body) {
+		log('Release PR body already up to date — exiting 0');
+		return 0;
+	}
+	execFileSync(
+		'gh',
+		['pr', 'edit', String(releasePr.number), '--body-file', '-'],
+		{ input: newBody, encoding: 'utf8', timeout: GH_TIMEOUT_MS },
+	);
+	log(
+		`Updated release PR #${releasePr.number} with ${entries.length} fragment(s)`,
+	);
+	return 0;
+}
+
+// -----------------------------------------------------------------------------
+// Mode: update-release — keep the GitHub Release body in sync after a tag.
+// -----------------------------------------------------------------------------
+
+async function modeUpdateRelease(log) {
+	const tagName = process.env.TAG_NAME;
+	if (!tagName) {
+		log('TAG_NAME env var not set — exiting 0');
+		return 0;
+	}
+	const repoRoot = resolveRepoRoot();
+	const rel = tryGhJson(['release', 'view', tagName, '--json', 'body,tagName']);
+	if (!rel.ok) {
+		log(`Release ${tagName} not found — exiting 0`);
+		return 0;
+	}
+	const releaseBody = rel.value.body || '';
+	// Same exclusion as update-pr — see modeUpdatePr above.
+	const candidates = extractCandidatePrNumbers(
+		stripCustomReleaseNotesBlock(releaseBody),
+	);
+	if (candidates.length === 0) {
+		log('Release body has no PR references — exiting 0');
+		return 0;
+	}
+	const entries = collectFragmentsForPrs(candidates, repoRoot, log);
+	if (entries.length === 0) {
+		log('No pending fragments found across referenced PRs — exiting 0');
+		return 0;
+	}
+	const combined = combineFragments(entries);
+	const newBody = upsertReleaseNotesBlock(releaseBody, combined);
+	if (newBody === releaseBody) {
+		log(`Release ${tagName} body already up to date — exiting 0`);
+		return 0;
+	}
+	execFileSync('gh', ['release', 'edit', tagName, '--notes-file', '-'], {
+		input: newBody,
+		encoding: 'utf8',
+		timeout: GH_TIMEOUT_MS,
+	});
+	log(`Updated release ${tagName} with ${entries.length} fragment(s)`);
+	return 0;
+}
+
+// -----------------------------------------------------------------------------
+// CLI dispatch.
+// -----------------------------------------------------------------------------
+
+async function main() {
+	const mode = process.argv[2];
+	const log = (msg) => {
+		process.stdout.write(`[release-notes-fragments] ${msg}\n`);
+	};
+	switch (mode) {
+		case 'update-pr':
+			return modeUpdatePr(log);
+		case 'update-release':
+			return modeUpdateRelease(log);
+		default:
+			process.stderr.write(
+				'Usage: release-notes-fragments.mjs <update-pr|update-release>\n',
+			);
+			return 2;
+	}
+}
+
+// Run when invoked directly (not when imported by tests).
+const isDirectInvocation =
+	import.meta.url === `file://${process.argv[1]}` ||
+	process.argv[1]?.endsWith('release-notes-fragments.mjs');
+
+if (isDirectInvocation) {
+	main().then(
+		(code) => process.exit(code ?? 0),
+		(err) => {
+			process.stderr.write(`[release-notes-fragments] ERROR: ${err?.stack ?? err}\n`);
+			process.exit(1);
+		},
+	);
+}

--- a/src/__tests__/acknowledge-spec-drift.test.ts
+++ b/src/__tests__/acknowledge-spec-drift.test.ts
@@ -97,7 +97,8 @@ describe('handleAcknowledgeSpecDriftCommand', () => {
 			expect(event.type).toBe('spec_drift_acknowledged');
 			expect(event.phase).toBe(3);
 			expect(event.planTitle).toBe('Test Plan');
-			expect(event.acknowledgedBy).toBe('architect');
+			// Issue #890: actor is now caller-supplied; default is 'unknown'
+			expect(event.acknowledgedBy).toBe('unknown');
 			expect(event.timestamp).toBeDefined();
 		});
 
@@ -180,6 +181,51 @@ describe('handleAcknowledgeSpecDriftCommand', () => {
 			expect(result).toContain('Spec drift acknowledged');
 			// spec-staleness.json should still be deleted
 			await expect(unlink(specStalenessPath)).rejects.toThrow();
+		});
+	});
+
+	// Issue #890: caller-supplied actor for forensic audit trail.
+	describe('acknowledgedBy actor parameter (issue #890)', () => {
+		test('records "user" when invoked via chat slash command', async () => {
+			const specStalenessPath = join(tempDir, '.swarm', 'spec-staleness.json');
+			const eventsPath = join(tempDir, '.swarm', 'events.jsonl');
+			await writeFile(
+				specStalenessPath,
+				JSON.stringify({
+					planTitle: 'P',
+					phase: 1,
+					specHash_plan: 'h',
+					specHash_current: 'h',
+					reason: 'r',
+					timestamp: '2024-01-01T00:00:00.000Z',
+				}),
+			);
+			await handleAcknowledgeSpecDriftCommand(tempDir, [], 'user');
+			const event = JSON.parse(
+				(await readFile(eventsPath, 'utf-8')).trim().split('\n').pop() ?? '{}',
+			);
+			expect(event.acknowledgedBy).toBe('user');
+		});
+
+		test('records "cli" when invoked via CLI run dispatch', async () => {
+			const specStalenessPath = join(tempDir, '.swarm', 'spec-staleness.json');
+			const eventsPath = join(tempDir, '.swarm', 'events.jsonl');
+			await writeFile(
+				specStalenessPath,
+				JSON.stringify({
+					planTitle: 'P',
+					phase: 1,
+					specHash_plan: 'h',
+					specHash_current: 'h',
+					reason: 'r',
+					timestamp: '2024-01-01T00:00:00.000Z',
+				}),
+			);
+			await handleAcknowledgeSpecDriftCommand(tempDir, [], 'cli');
+			const event = JSON.parse(
+				(await readFile(eventsPath, 'utf-8')).trim().split('\n').pop() ?? '{}',
+			);
+			expect(event.acknowledgedBy).toBe('cli');
 		});
 	});
 });

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -531,7 +531,7 @@ Continue handling small touch-ups (typos, cross-references) inline.
 ## SLASH COMMANDS
 {{SLASH_COMMANDS}}
 Commands above are documented with args and behavioral details. Run commands via /swarm <command> [args].
-Outside OpenCode, invoke any plugin command via: \`bunx opencode-swarm run <command> [args]\` (e.g. \`bunx opencode-swarm run knowledge migrate\`). Do not use \`bun -e\` or look for \`src/commands/\` — those paths are internal to the plugin source and do not exist in user project directories.
+Outside OpenCode, invoke any plugin command via: \`bunx opencode-swarm run <command> [args]\` (e.g. \`bunx opencode-swarm run knowledge migrate\`). Do not use \`bun -e\` or look for \`src/commands/\` — those paths are internal to the plugin source and do not exist in user project directories. EXCEPTION — human-only commands (including but not limited to \`acknowledge-spec-drift\`, \`reset\`, \`reset-session\`, \`rollback\`, \`checkpoint\`, and any command that releases a runtime safety gate or destroys plan state): you MUST present these to the user and ask them to run the command themselves. Never invoke a human-only command via Bash, swarm_command, or chat fallback. The runtime guardrail will block such attempts; if a Bash call returns \`BLOCKED\` with a "human-only" message, do not retry under a different shell form — present the situation to the user instead.
 
 SMEs advise only. Reviewer and critic review only. None of them write code.
 
@@ -1419,10 +1419,17 @@ If resuming a project with an existing approved plan, CRITIC-GATE is already sat
 - This rule is satisfied by the save_plan tool's own spec gate — it exists as a reminder that planning requires a spec.
 
 6k. SPEC-STALENESS GUARD:
-- If _specStale or .swarm/spec-staleness.json exists, the Architect MUST read the file and either:
-  - Run /swarm clarify to update the spec and align it with the plan, OR
-  - Run /swarm acknowledge-spec-drift to acknowledge the drift and suppress further warnings
-- Do NOT proceed with implementation until spec staleness is resolved.
+- If _specStale or .swarm/spec-staleness.json exists, the Architect MUST stop
+  and SURFACE THE DRIFT TO THE USER. The user (not the Architect) then runs
+  either:
+  - /swarm clarify to update the spec and align it with the plan, OR
+  - /swarm acknowledge-spec-drift to acknowledge the drift and suppress further warnings
+- The Architect MUST NOT run /swarm acknowledge-spec-drift itself — not via
+  the swarm_command tool, not via the chat fallback, and NOT by shelling out
+  to \`bunx opencode-swarm run acknowledge-spec-drift\` (or any equivalent
+  \`npx\`/\`node\`/\`bun\` invocation). Any such self-invocation is a
+  control-bypass and will be refused by the runtime guardrails.
+- Do NOT proceed with implementation until the user resolves the staleness.
 - When re-saving a plan in response to spec drift, save_plan REQUIRES that ANY task
   present in the prior plan but absent from the new args.phases be enumerated
   in removed_task_ids with a removal_reason. save_plan will reject the call
@@ -1433,8 +1440,8 @@ If resuming a project with an existing approved plan, CRITIC-GATE is already sat
 - While .swarm/spec-staleness.json exists, the runtime STRUCTURALLY BLOCKS the
   following tools (SPEC_DRIFT_BLOCKED_TOOLS): save_plan, update_task_status,
   phase_complete, lean_turbo_run_phase, lean_turbo_acquire_locks. If a call
-  returns SPEC_DRIFT_BLOCK, do NOT retry; instead present the drift to the
-  user and run /swarm clarify or /swarm acknowledge-spec-drift first.
+  returns SPEC_DRIFT_BLOCK, do NOT retry; surface the drift to the user and
+  WAIT for them to run /swarm clarify or /swarm acknowledge-spec-drift.
 
 ### MODE: EXECUTE
 For each task (respecting dependencies):

--- a/src/agents/docs.ts
+++ b/src/agents/docs.ts
@@ -70,9 +70,10 @@ WORKFLOW:
 - TODO comments in code (those go through the task system, not code comments)
 
 ## RELEASE NOTES
-When writing release notes (docs/releases/v{VERSION}.md):
-- Determine next version from .release-please-manifest.json + commit type (feat → minor, fix → patch)
-- Follow the established format in existing release notes files
+When writing release notes (docs/releases/pending/<slug>.md):
+- Do NOT determine the next version. Do NOT create docs/releases/vX.Y.Z.md. release-please owns the version; the release workflow aggregates pending fragments.
+- Pick a short, kebab-case slug describing your change (e.g. spec-drift-self-ack-guardrail.md). Pick one unlikely to collide with concurrent PRs.
+- Follow the established format in existing release notes files (descriptive topic heading, not a version prefix).
 - Include: overview, breaking changes (if any), new features, bug fixes, internal improvements
 - Do NOT manually edit package.json version, CHANGELOG.md, or .release-please-manifest.json — release-please owns these
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -640,6 +640,7 @@ export async function run(args: string[]): Promise<number> {
 		args: resolved.remainingArgs,
 		sessionID: '',
 		agents: {},
+		source: 'cli',
 	});
 
 	console.log(result);

--- a/src/commands/acknowledge-spec-drift.ts
+++ b/src/commands/acknowledge-spec-drift.ts
@@ -14,12 +14,26 @@ interface SpecStalenessPayload {
 }
 
 /**
+ * Caller identification for spec-drift acknowledgment audit trail.
+ * Previously hardcoded as 'architect' — see issue #890, where the architect
+ * could shell out to `bunx opencode-swarm run acknowledge-spec-drift` and
+ * the resulting event mis-attributed the action. Callers now pass an
+ * explicit actor so events.jsonl can distinguish the legitimate paths
+ * ('user' from chat slash command, 'cli' from a real terminal) from any
+ * unidentified caller ('unknown'). The Bash guardrail
+ * (`src/hooks/guardrails.ts` section 23) blocks the agent-shell bypass at
+ * the runtime layer; this parameter exists for forensic clarity.
+ */
+export type SpecDriftAcknowledgedBy = 'user' | 'cli' | 'unknown';
+
+/**
  * Handle /swarm acknowledge-spec-drift command
  * Acknowledges and clears a previously detected spec drift staleness warning
  */
 export async function handleAcknowledgeSpecDriftCommand(
 	directory: string,
 	_args: string[],
+	acknowledgedBy: SpecDriftAcknowledgedBy = 'unknown',
 ): Promise<string> {
 	const specStalenessPath = validateSwarmPath(directory, 'spec-staleness.json');
 
@@ -76,7 +90,7 @@ export async function handleAcknowledgeSpecDriftCommand(
 		timestamp: new Date().toISOString(),
 		phase,
 		planTitle,
-		acknowledgedBy: 'architect',
+		acknowledgedBy,
 		previousHash: stalenessData.specHash_plan,
 		newHash: currentHash,
 	};

--- a/src/commands/command-dispatch.ts
+++ b/src/commands/command-dispatch.ts
@@ -127,6 +127,7 @@ export async function executeSwarmCommand(args: {
 					args: resolved.remainingArgs,
 					sessionID,
 					agents,
+					source: 'chat',
 				});
 			} catch (_err) {
 				const cmdName = tokens[0] || 'unknown';

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -190,6 +190,14 @@ export type CommandContext = {
 	args: string[];
 	sessionID: string;
 	agents: Record<string, AgentDefinition>;
+	/**
+	 * Dispatch path identifier. Issue #890: forensic audit trail for
+	 * commands that need to distinguish "user typed /swarm <cmd>" (chat)
+	 * from "user ran bunx opencode-swarm run <cmd>" (cli). Handlers that
+	 * don't care can ignore this field. Optional for backwards-compatibility
+	 * with existing callers.
+	 */
+	source?: 'cli' | 'chat';
 };
 
 export type CommandResult = Promise<string>;
@@ -234,7 +242,15 @@ export type CommandEntry = {
 export const COMMAND_REGISTRY = {
 	'acknowledge-spec-drift': {
 		handler: (ctx) =>
-			handleAcknowledgeSpecDriftCommand(ctx.directory, ctx.args),
+			handleAcknowledgeSpecDriftCommand(
+				ctx.directory,
+				ctx.args,
+				ctx.source === 'cli'
+					? 'cli'
+					: ctx.source === 'chat'
+						? 'user'
+						: 'unknown',
+			),
 		description:
 			'Acknowledge that the spec has drifted from the plan and suppress further warnings',
 		args: '',

--- a/src/commands/tool-policy.human-only.test.ts
+++ b/src/commands/tool-policy.human-only.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveCommand } from './registry';
+import {
+	classifySwarmCommandChatFallbackUse,
+	classifySwarmCommandToolUse,
+	HUMAN_ONLY_SWARM_COMMANDS,
+} from './tool-policy';
+
+/**
+ * Issue #890 — confirm chat-tool refusal message for human-only commands
+ * points the agent at the user, not at the CLI bypass.
+ */
+
+function resolve(tokens: string[]) {
+	const r = resolveCommand(tokens);
+	if (!r) throw new Error(`resolveCommand failed for ${tokens.join(' ')}`);
+	return r;
+}
+
+describe('tool-policy — human-only command refusal (issue #890)', () => {
+	test('HUMAN_ONLY_SWARM_COMMANDS contains the issue-890 set', () => {
+		expect(HUMAN_ONLY_SWARM_COMMANDS.has('acknowledge-spec-drift')).toBe(true);
+		expect(HUMAN_ONLY_SWARM_COMMANDS.has('reset')).toBe(true);
+		expect(HUMAN_ONLY_SWARM_COMMANDS.has('reset-session')).toBe(true);
+		expect(HUMAN_ONLY_SWARM_COMMANDS.has('rollback')).toBe(true);
+		expect(HUMAN_ONLY_SWARM_COMMANDS.has('checkpoint')).toBe(true);
+	});
+
+	describe('classifySwarmCommandToolUse — chat-tool path', () => {
+		test('acknowledge-spec-drift returns human-only message (NOT the CLI-path message)', () => {
+			const result = classifySwarmCommandToolUse(
+				resolve(['acknowledge-spec-drift']),
+			);
+			expect(result.allowed).toBe(false);
+			if (result.allowed === false) {
+				expect(result.message).toContain('human-only');
+				expect(result.message).toContain('Present the situation to the user');
+				expect(result.message).toContain('MUST NOT run it yourself');
+				// The OLD message — must NOT appear for human-only commands
+				expect(result.message).not.toContain(
+					'is not available through the chat tool yet',
+				);
+			}
+		});
+
+		test('reset returns human-only message', () => {
+			const result = classifySwarmCommandToolUse(resolve(['reset']));
+			expect(result.allowed).toBe(false);
+			if (result.allowed === false) {
+				expect(result.message).toContain('human-only');
+			}
+		});
+
+		test('rollback returns human-only message', () => {
+			const result = classifySwarmCommandToolUse(resolve(['rollback']));
+			expect(result.allowed).toBe(false);
+			if (result.allowed === false) {
+				expect(result.message).toContain('human-only');
+			}
+		});
+
+		test('checkpoint returns human-only message', () => {
+			const result = classifySwarmCommandToolUse(resolve(['checkpoint']));
+			expect(result.allowed).toBe(false);
+			if (result.allowed === false) {
+				expect(result.message).toContain('human-only');
+			}
+		});
+
+		test('dark-matter — non-human-only command retains the OLD message (no regression)', () => {
+			const result = classifySwarmCommandToolUse(resolve(['dark-matter']));
+			expect(result.allowed).toBe(false);
+			if (result.allowed === false) {
+				expect(result.message).toContain(
+					'is not available through the chat tool yet',
+				);
+				expect(result.message).toContain('bunx opencode-swarm run dark-matter');
+				expect(result.message).not.toContain('human-only');
+			}
+		});
+
+		test('simulate — non-human-only command retains the OLD message', () => {
+			const result = classifySwarmCommandToolUse(resolve(['simulate']));
+			expect(result.allowed).toBe(false);
+			if (result.allowed === false) {
+				expect(result.message).toContain(
+					'is not available through the chat tool yet',
+				);
+				expect(result.message).not.toContain('human-only');
+			}
+		});
+
+		test('status — allowlisted command remains allowed', () => {
+			const result = classifySwarmCommandToolUse(resolve(['status']));
+			expect(result.allowed).toBe(true);
+		});
+
+		test('diagnose — allowlisted command remains allowed', () => {
+			const result = classifySwarmCommandToolUse(resolve(['diagnose']));
+			expect(result.allowed).toBe(true);
+		});
+	});
+
+	describe('classifySwarmCommandChatFallbackUse — user-typed slash path', () => {
+		test('acknowledge-spec-drift remains ALLOWED through chat fallback (legitimate user path)', () => {
+			const result = classifySwarmCommandChatFallbackUse(
+				resolve(['acknowledge-spec-drift']),
+			);
+			expect(result.allowed).toBe(true);
+		});
+
+		test('reset remains ALLOWED through chat fallback', () => {
+			const result = classifySwarmCommandChatFallbackUse(resolve(['reset']));
+			expect(result.allowed).toBe(true);
+		});
+
+		test('rollback remains ALLOWED through chat fallback', () => {
+			const result = classifySwarmCommandChatFallbackUse(resolve(['rollback']));
+			expect(result.allowed).toBe(true);
+		});
+
+		test('knowledge migrate stays blocked (pre-existing rule)', () => {
+			const result = classifySwarmCommandChatFallbackUse(
+				resolve(['knowledge', 'migrate']),
+			);
+			expect(result.allowed).toBe(false);
+		});
+	});
+});

--- a/src/commands/tool-policy.ts
+++ b/src/commands/tool-policy.ts
@@ -52,6 +52,22 @@ export const SWARM_COMMAND_TOOL_ALLOWLIST = new Set<string>([
 	'export',
 ]);
 
+/**
+ * Issue #890: subcommands that must be invoked by a human user, not by the
+ * agent. The runtime Bash guardrail
+ * (`src/hooks/guardrails.ts` section 23) blocks the equivalent
+ * `bunx opencode-swarm run <cmd>` shell invocation; this set drives the
+ * chat-tool refusal message so the agent is told to surface to the user
+ * instead of being pointed at the CLI bypass it just attempted.
+ */
+export const HUMAN_ONLY_SWARM_COMMANDS = new Set<string>([
+	'acknowledge-spec-drift',
+	'reset',
+	'reset-session',
+	'rollback',
+	'checkpoint',
+]);
+
 const NO_ARGS = new Set([
 	'agents',
 	'config',
@@ -76,6 +92,17 @@ export function classifySwarmCommandToolUse(
 	const args = resolved.remainingArgs;
 
 	if (!SWARM_COMMAND_TOOL_ALLOWLIST.has(canonicalKey)) {
+		if (HUMAN_ONLY_SWARM_COMMANDS.has(canonicalKey)) {
+			return {
+				allowed: false,
+				message:
+					`/swarm ${canonicalKey} is a human-only command. ` +
+					`Present the situation to the user and ask them to run \`/swarm ${canonicalKey}\` themselves ` +
+					`(or \`bunx opencode-swarm run ${canonicalKey}\` from a terminal). ` +
+					`You MUST NOT run it yourself via Bash, swarm_command, or any other tool — ` +
+					`the runtime guardrail will block such attempts.`,
+			};
+		}
 		return {
 			allowed: false,
 			message:

--- a/src/hooks/guardrails.ts
+++ b/src/hooks/guardrails.ts
@@ -1737,6 +1737,166 @@ export function createGuardrailsHooks(
 			//     block ALL git clean -fd and worktree remove --force commands,
 			//     which inherently covers .swarm/ paths. No extension needed.)
 			// ----------------------------------------------------------------
+
+			// ----------------------------------------------------------------
+			// 23. Swarm CLI bypass — human-only `/swarm` subcommands
+			//    (Issue #890: architect self-acknowledged spec drift by
+			//     shelling out to `bunx opencode-swarm run acknowledge-spec-drift`,
+			//     which bypassed the chat-tool refusal and the runtime
+			//     SPEC_DRIFT_BLOCK gate.)
+			//
+			//    These subcommands release human-only safety gates (spec-drift
+			//    acknowledgment, plan reset, rollback, checkpoint
+			//    save/restore/delete). They must be invoked by a human user —
+			//    either via `/swarm <cmd>` inside OpenCode or by typing the
+			//    `bunx opencode-swarm run <cmd>` form into a real terminal.
+			//    They MUST NOT be invoked from the agent's Bash tool.
+			//
+			//    `dcUnwrapWrappers` already strips `bash -c`, `sh -c`,
+			//    `powershell -c`, `cmd /c`, `env VAR=`, `sudo`, etc. before we
+			//    see the segment. We additionally strip three evasions inline
+			//    that `dcStripOneWrapper` does NOT cover: bare env-var prefix
+			//    (`FOO=bar <cmd>`), `eval "..."`, and a leading `(...)`
+			//    subshell.
+			// ----------------------------------------------------------------
+			{
+				const HUMAN_ONLY_SWARM_SUBCOMMANDS = new Set<string>([
+					'acknowledge-spec-drift',
+					'reset',
+					'reset-session',
+					'rollback',
+					'checkpoint',
+				]);
+
+				let probe = seg
+					.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)+/, '')
+					.replace(/^eval(?:\s+--)?\s+["']?/, '')
+					.replace(/["']\s*$/, '')
+					// Strip `$(`, `(`, or backtick command-substitution wrappers.
+					// Order matters: `$(` before `(` so the dollar sign comes off.
+					.replace(/^\$\(\s*/, '')
+					.replace(/^\(\s*/, '')
+					.replace(/\s*\)$/, '')
+					.replace(/^`/, '')
+					.replace(/`$/, '')
+					.trim();
+
+				// Strip prefixes that re-introduce a runner indirectly. The
+				// `env` wrapper handled by `dcStripOneWrapper` only matches
+				// the `env KEY=VAL` form; this also catches `env -i`,
+				// `env -u <var>`, `env --ignore-environment`, and the POSIX
+				// `command` builtin (which suppresses function lookup but
+				// otherwise execs the next token). Loop because they can stack
+				// (e.g. `command env -i bunx ...`).
+				for (let i = 0; i < 4; i++) {
+					const before = probe;
+					probe = probe
+						// `env -i <cmd>`, `env --ignore-environment <cmd>`, `env -u FOO <cmd>`
+						.replace(
+							/^env\s+(?:-i\b|--ignore-environment\b|-u\s+\S+|-[a-zA-Z]+\s+)*\s*/,
+							'',
+						)
+						// POSIX `command` builtin: `command [-p] [-v] [-V] <cmd>`
+						.replace(/^command\s+(?:-[pvV]\s+)*/, '')
+						// Re-strip env-var-assignment prefix in case a wrapper exposed one
+						.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)+/, '')
+						.trim();
+					if (probe === before) break;
+				}
+
+				// Form A: <runner> ... opencode-swarm ... run <subcmd>
+				const swarmCliBypassMatch = probe.match(
+					/^\\?(?:bunx|npx|pnpx|npm(?:\s+(?:exec|x)(?:\s+--)?)?|pnpm(?:\s+(?:dlx|exec))?|yarn(?:\s+(?:dlx|exec))?|bun(?:\s+x)?|node|deno\s+run|tsx|ts-node)\b[^|;&]*?\bopencode-swarm\b[^|;&]*?\brun\s+([A-Za-z0-9_-]+)/i,
+				);
+				if (
+					swarmCliBypassMatch &&
+					HUMAN_ONLY_SWARM_SUBCOMMANDS.has(swarmCliBypassMatch[1])
+				) {
+					throw new Error(
+						`BLOCKED: "${swarmCliBypassMatch[1]}" is a human-only swarm command and may not be invoked from shell by an agent. ` +
+							`Present the situation to the user and ask them to run \`/swarm ${swarmCliBypassMatch[1]}\` themselves.`,
+					);
+				}
+
+				// Form B: bare `opencode-swarm` on PATH (post-install global / local bin).
+				const swarmBareBinMatch = probe.match(
+					/^\\?opencode-swarm\b[^|;&]*?\brun\s+([A-Za-z0-9_-]+)/i,
+				);
+				if (
+					swarmBareBinMatch &&
+					HUMAN_ONLY_SWARM_SUBCOMMANDS.has(swarmBareBinMatch[1])
+				) {
+					throw new Error(
+						`BLOCKED: "${swarmBareBinMatch[1]}" is a human-only swarm command and may not be invoked from shell by an agent. ` +
+							`Present the situation to the user and ask them to run \`/swarm ${swarmBareBinMatch[1]}\` themselves.`,
+					);
+				}
+
+				// Secondary: dist-relative CLI path invocation (pnpm
+				// content-addressed store, symlinked dev installs, custom dist
+				// copies where the literal "opencode-swarm" token does not
+				// appear in argv but `cli/index.[mc]?js` does).
+				const swarmCliPathMatch = probe.match(
+					/\bcli[/\\]+index\.[mc]?(?:js|ts)\b[^|;&]*?\brun\s+([A-Za-z0-9_-]+)/i,
+				);
+				if (
+					swarmCliPathMatch &&
+					HUMAN_ONLY_SWARM_SUBCOMMANDS.has(swarmCliPathMatch[1])
+				) {
+					throw new Error(
+						`BLOCKED: "${swarmCliPathMatch[1]}" is a human-only swarm command and may not be invoked from shell by an agent. ` +
+							`Present the situation to the user and ask them to run \`/swarm ${swarmCliPathMatch[1]}\` themselves.`,
+					);
+				}
+			}
+
+			// ----------------------------------------------------------------
+			// 24. Direct shell manipulation of .swarm/spec-staleness.json
+			//    (Issue #890 deepening: closes the `bun -e fs.unlinkSync(...)`,
+			//     `node -e fs.unlinkSync(...)`, script-file, command-substitution,
+			//     xargs, heredoc, and any other path that mentions the
+			//     staleness file in a shell context. The file is system-managed;
+			//     agents have no legitimate reason to reference it from shell.
+			//     Even READING is uncommon — but only writes/deletes can break
+			//     the gate, so we match on the path token in a destructive
+			//     context. The pre-Section 19 (rm-on-.swarm) and write-tool
+			//     guards already cover the obvious cases; this section closes
+			//     the indirect-tool / script-eval surface.)
+			//
+			//    Pattern: ANY mention of `.swarm/spec-staleness.json` (or the
+			//    Windows-backslash form `.swarm\spec-staleness.json`) in a
+			//    segment that is NOT a pure read (cat/less/more/head/tail).
+			// ----------------------------------------------------------------
+			{
+				// Normalize the segment so path-noise variants
+				// (`.swarm/./spec-staleness.json`, `.swarm//spec-staleness.json`,
+				// Windows backslashes mixed with forward slashes) collapse to the
+				// canonical form before we match. This is a string-level
+				// normalization scoped to detection; we don't rewrite the actual
+				// shell command, only the form we inspect.
+				const normForPathCheck = seg
+					.replace(/\\/g, '/')
+					.replace(/\/(?:\.\/+)+/g, '/')
+					.replace(/\/{2,}/g, '/');
+				if (/\.swarm\/spec-staleness\.json\b/i.test(normForPathCheck)) {
+					const trimmed = seg.trim();
+					const looksReadOnly =
+						/^(?:cat|less|more|head|tail|file|stat|ls|dir|Get-Content|gc|Get-Item|gi|type)\b/i.test(
+							trimmed,
+						);
+					// `cat > file` and `cat >> file` are WRITES via redirection,
+					// not reads. Demote the read-only exemption if a redirect
+					// target appears anywhere in the segment.
+					const hasWriteRedirect = />{1,2}\s*[^\s>]/.test(trimmed);
+					if (!looksReadOnly || hasWriteRedirect) {
+						throw new Error(
+							'BLOCKED: shell command targeting .swarm/spec-staleness.json detected. ' +
+								'This file is system-managed and gates plan-mutating tools while spec drift is unresolved. ' +
+								'Present the drift to the user and ask them to run /swarm clarify or /swarm acknowledge-spec-drift.',
+						);
+					}
+				}
+			}
 		}
 	}
 
@@ -2107,14 +2267,66 @@ export function createGuardrailsHooks(
 	}
 
 	/**
+	 * Collects every patch-payload field that an apply_patch / patch tool
+	 * invocation might carry. Issue #890 PR #896 follow-up review #3: a
+	 * single "first-non-null" priority chain (`input ?? patch ?? cmd[1]`)
+	 * lets an attacker put benign content in one field and malicious
+	 * content in another — the scanner reads the decoy and the runtime
+	 * honours the payload. The fix is to inspect every present field.
+	 *
+	 * Returns an array of all string payloads found in args, in stable
+	 * order. Callers should concatenate (or iterate) instead of
+	 * short-circuiting on the first one.
+	 */
+	function extractAllPatchPayloads(args: unknown): string[] {
+		const toolArgs = args as Record<string, unknown> | undefined;
+		if (!toolArgs) return [];
+		const out: string[] = [];
+		for (const key of ['patch', 'input', 'diff'] as const) {
+			const v = toolArgs[key];
+			if (typeof v === 'string' && v.length > 0) out.push(v);
+		}
+		const cmd = toolArgs.cmd;
+		if (Array.isArray(cmd)) {
+			// `cmd[1]` is the documented patch-payload slot, but scan every
+			// string in the array defensively in case a runtime variant
+			// places it elsewhere. Cheap; the array is bounded in practice.
+			for (const entry of cmd) {
+				if (typeof entry === 'string' && entry.length > 0) out.push(entry);
+			}
+		}
+		return out;
+	}
+
+	/**
+	 * Returns true if any of the apply_patch / patch payloads contain an
+	 * invocation of a human-only swarm CLI subcommand. Scans every
+	 * present field (not just the first non-null), so an attacker cannot
+	 * decoy with a benign `patch` and smuggle the real payload via `cmd[1]`.
+	 */
+	function patchPayloadHasHumanOnlyInvocation(args: unknown): boolean {
+		const payloads = extractAllPatchPayloads(args);
+		if (payloads.length === 0) return false;
+		const re =
+			/\bopencode-swarm\b[\s\S]*?\brun\s+(?:acknowledge-spec-drift|reset|reset-session|rollback|checkpoint)\b/i;
+		return payloads.some((p) => re.test(p));
+	}
+
+	/**
 	 * Extracts target file paths from apply_patch / patch tool arguments.
 	 * Returns an empty array for any other tool or unparseable payload.
 	 */
 	function extractPatchTargetPaths(tool: string, args: unknown): string[] {
 		if (tool !== 'apply_patch' && tool !== 'patch') return [];
 		const toolArgs = args as Record<string, unknown> | undefined;
+		// Reviewer of PR #896 noted `diff` was missing from this chain —
+		// add it so diff-only patches still go through path-level checks.
+		// The `cmd[1]` shape and the `input`/`patch` shapes remain
+		// supported in priority order (input first matches the historic
+		// extractor contract).
 		const patchText = (toolArgs?.input ??
 			toolArgs?.patch ??
+			toolArgs?.diff ??
 			(Array.isArray(toolArgs?.cmd) ? toolArgs.cmd[1] : undefined)) as
 			| string
 			| undefined;
@@ -2176,6 +2388,25 @@ export function createGuardrailsHooks(
 			toolArgs?.file ??
 			toolArgs?.target;
 
+		// PR #896 follow-up review #3: scan apply_patch / patch payload
+		// content BEFORE any branching on `targetPath`. Previously the
+		// `if (!targetPath && tool === 'apply_patch')` guard let an
+		// attacker pair a benign `filePath` with a malicious `cmd[1]`
+		// payload — the direct-write branch ran (and only scanned
+		// `args.content/text/...`), missing the patch payload entirely.
+		// Run the scan unconditionally for apply_patch / patch tools, on
+		// every present payload field, so neither `filePath` short-circuit
+		// nor field-priority divergence (decoy in `patch`, real payload in
+		// `cmd[1]`) can bypass it.
+		if (tool === 'apply_patch' || tool === 'patch') {
+			if (patchPayloadHasHumanOnlyInvocation(args)) {
+				throw new Error(
+					'BLOCKED: apply_patch would introduce a script invoking a human-only swarm CLI subcommand. ' +
+						'Present the situation to the user and ask them to run the command themselves.',
+				);
+			}
+		}
+
 		// Plan state protection: block direct writes to .swarm/plan.md and .swarm/plan.json
 		if (typeof targetPath === 'string' && targetPath.length > 0) {
 			const resolvedTarget = path
@@ -2196,9 +2427,50 @@ export function createGuardrailsHooks(
 						'Use phase_complete() for phase transitions only.',
 				);
 			}
+			// Issue #890: spec-staleness marker is system-managed. Direct write
+			// or edit by the architect would let the agent forge a "drift
+			// resolved" state without the user acknowledging. Empty / malformed
+			// JSON also triggers the handler's malformed-file fast path
+			// (acknowledge-spec-drift.ts JSON.parse catch → unlink), so even
+			// rewriting the content unlocks the gate.
+			const specStalenessPath = path
+				.resolve(effectiveDirectory, '.swarm', 'spec-staleness.json')
+				.toLowerCase();
+			if (resolvedTarget === specStalenessPath) {
+				throw new Error(
+					'SPEC_DRIFT_VIOLATION: Direct writes to .swarm/spec-staleness.json are blocked. ' +
+						'This file is system-managed and gates plan-mutating tools while spec drift is unresolved. ' +
+						'Present the drift to the user and ask them to run /swarm clarify or /swarm acknowledge-spec-drift.',
+				);
+			}
+			// Issue #890 script-indirection guard: if the architect writes a
+			// script file whose content invokes a HUMAN_ONLY swarm CLI
+			// subcommand, block the write. The Bash guard inspects shell
+			// commands the host SEES, but `bash tmp.sh` only shows `bash
+			// tmp.sh` — the host cannot read tmp.sh's body once the
+			// subprocess executes. Closing that surface here at write time.
+			const content =
+				toolArgs?.content ??
+				toolArgs?.text ??
+				toolArgs?.new_string ??
+				toolArgs?.newText;
+			if (
+				typeof content === 'string' &&
+				/\bopencode-swarm\b[\s\S]*?\brun\s+(?:acknowledge-spec-drift|reset|reset-session|rollback|checkpoint)\b/i.test(
+					content,
+				)
+			) {
+				throw new Error(
+					'BLOCKED: write/edit tool would create a script invoking a human-only swarm CLI subcommand. ' +
+						'Present the situation to the user and ask them to run the command themselves.',
+				);
+			}
 		}
 
-		// Fallback: apply_patch / patch tools send args as a single diff string
+		// Fallback: apply_patch / patch tools send args as a single diff
+		// string. Note: the script-indirection content scan for human-only
+		// swarm CLI invocations already ran above (unconditionally for
+		// apply_patch/patch) — this loop handles path-level protection only.
 		if (!targetPath && (tool === 'apply_patch' || tool === 'patch')) {
 			for (const p of extractPatchTargetPaths(tool, args)) {
 				const resolvedP = path.resolve(effectiveDirectory, p);
@@ -2207,6 +2479,9 @@ export function createGuardrailsHooks(
 					.toLowerCase();
 				const planJsonPath = path
 					.resolve(effectiveDirectory, '.swarm', 'plan.json')
+					.toLowerCase();
+				const specStalenessPath = path
+					.resolve(effectiveDirectory, '.swarm', 'spec-staleness.json')
 					.toLowerCase();
 				if (
 					resolvedP.toLowerCase() === planMdPath ||
@@ -2218,6 +2493,13 @@ export function createGuardrailsHooks(
 							'Use save_plan for ALL structural plan changes (adding/removing tasks, updating descriptions, dependencies, or phase names). ' +
 							'Use update_task_status() for task status only. ' +
 							'Use phase_complete() for phase transitions only.',
+					);
+				}
+				if (resolvedP.toLowerCase() === specStalenessPath) {
+					throw new Error(
+						'SPEC_DRIFT_VIOLATION: Direct writes to .swarm/spec-staleness.json are blocked. ' +
+							'This file is system-managed and gates plan-mutating tools while spec drift is unresolved. ' +
+							'Present the drift to the user and ask them to run /swarm clarify or /swarm acknowledge-spec-drift.',
 					);
 				}
 				if (

--- a/tests/unit/commands/acknowledge-spec-drift.test.ts
+++ b/tests/unit/commands/acknowledge-spec-drift.test.ts
@@ -291,7 +291,8 @@ describe('handleAcknowledgeSpecDriftCommand', () => {
 			expect(event.newHash).not.toBeNull();
 			expect(event.planTitle).toBe('Test Plan');
 			expect(event.phase).toBe(1);
-			expect(event.acknowledgedBy).toBe('architect');
+			// Issue #890: actor is caller-supplied; default (no arg) is 'unknown'.
+			expect(event.acknowledgedBy).toBe('unknown');
 		});
 
 		test('should return success message with plan title and phase', async () => {

--- a/tests/unit/hooks/destructive-command-swarm-cli-bypass.test.ts
+++ b/tests/unit/hooks/destructive-command-swarm-cli-bypass.test.ts
@@ -1,0 +1,689 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { GuardrailsConfig } from '../../../src/config/schema';
+import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
+import { resetSwarmState, startAgentSession } from '../../../src/state';
+
+/**
+ * Issue #890 regression suite — block agent Bash invocations of human-only
+ * `/swarm` subcommands. See `src/hooks/guardrails.ts` section 23.
+ */
+
+const TEST_DIR = '/tmp';
+
+function defaultConfig(
+	overrides?: Partial<GuardrailsConfig>,
+): GuardrailsConfig {
+	return {
+		enabled: true,
+		max_tool_calls: 200,
+		max_duration_minutes: 30,
+		idle_timeout_minutes: 60,
+		max_repetitions: 10,
+		max_consecutive_errors: 5,
+		warning_threshold: 0.75,
+		profiles: undefined,
+		block_destructive_commands: true,
+		...overrides,
+	};
+}
+
+function makeBashInput(sessionID = 'test-session') {
+	return { tool: 'bash', sessionID, callID: 'call-1' };
+}
+
+function makeBashOutput(command: string) {
+	return { args: { command } };
+}
+
+async function expectBlocked(command: string): Promise<void> {
+	const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+	const input = makeBashInput();
+	const output = makeBashOutput(command);
+	// Either the CLI-bypass message (section 23) or the spec-staleness
+	// file-mention message (section 24) is acceptable — both close the
+	// bypass surface, and the regex / file-path patterns overlap by design.
+	await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+		/human-only swarm command|targeting \.swarm\/spec-staleness\.json/,
+	);
+}
+
+async function expectAllowed(command: string): Promise<void> {
+	const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+	const input = makeBashInput();
+	const output = makeBashOutput(command);
+	await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+}
+
+describe('swarm CLI bypass guard (issue #890)', () => {
+	beforeEach(() => {
+		resetSwarmState();
+		startAgentSession('test-session', 'architect');
+	});
+
+	describe('acknowledge-spec-drift — primary dispatcher forms', () => {
+		test('bunx — exact form from the original issue', async () => {
+			await expectBlocked(
+				'bunx opencode-swarm run acknowledge-spec-drift 2>&1 || true',
+			);
+		});
+		test('bunx — plain form', async () => {
+			await expectBlocked('bunx opencode-swarm run acknowledge-spec-drift');
+		});
+		test('npx', async () => {
+			await expectBlocked('npx opencode-swarm run acknowledge-spec-drift');
+		});
+		test('pnpx', async () => {
+			await expectBlocked('pnpx opencode-swarm run acknowledge-spec-drift');
+		});
+		test('yarn dlx', async () => {
+			await expectBlocked('yarn dlx opencode-swarm run acknowledge-spec-drift');
+		});
+		test('yarn exec', async () => {
+			await expectBlocked(
+				'yarn exec opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+		test('bun x', async () => {
+			await expectBlocked('bun x opencode-swarm run acknowledge-spec-drift');
+		});
+		test('tsx', async () => {
+			await expectBlocked('tsx opencode-swarm run acknowledge-spec-drift');
+		});
+		test('ts-node', async () => {
+			await expectBlocked('ts-node opencode-swarm run acknowledge-spec-drift');
+		});
+	});
+
+	describe('acknowledge-spec-drift — evasion forms', () => {
+		test('leading backslash on dispatcher', async () => {
+			await expectBlocked('\\bunx opencode-swarm run acknowledge-spec-drift');
+		});
+		test('env-var prefix (single)', async () => {
+			await expectBlocked(
+				'FOO=bar bunx opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+		test('env-var prefix (multiple)', async () => {
+			await expectBlocked(
+				'FOO=bar BAZ=qux bunx opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+		test('env-var prefix with URL value', async () => {
+			await expectBlocked(
+				'BUN_NPM_REGISTRY=https://example.com bunx opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+		test('versioned package specifier (@latest)', async () => {
+			await expectBlocked(
+				'bunx opencode-swarm@latest run acknowledge-spec-drift',
+			);
+		});
+		test('versioned package specifier (@7.21.3)', async () => {
+			await expectBlocked(
+				'bunx opencode-swarm@7.21.3 run acknowledge-spec-drift',
+			);
+		});
+		test('subshell parens', async () => {
+			await expectBlocked('(bunx opencode-swarm run acknowledge-spec-drift)');
+		});
+		test('eval double-quoted', async () => {
+			await expectBlocked(
+				'eval "bunx opencode-swarm run acknowledge-spec-drift"',
+			);
+		});
+		test('eval single-quoted', async () => {
+			await expectBlocked(
+				"eval 'bunx opencode-swarm run acknowledge-spec-drift'",
+			);
+		});
+		test('eval -- separator', async () => {
+			await expectBlocked(
+				'eval -- "bunx opencode-swarm run acknowledge-spec-drift"',
+			);
+		});
+		test('bash -c wrapper (handled by dcUnwrapWrappers)', async () => {
+			await expectBlocked(
+				'bash -c "bunx opencode-swarm run acknowledge-spec-drift"',
+			);
+		});
+		test('sh -c wrapper', async () => {
+			await expectBlocked(
+				'sh -c "bunx opencode-swarm run acknowledge-spec-drift"',
+			);
+		});
+		test('powershell -c wrapper', async () => {
+			await expectBlocked(
+				'powershell -c "bunx opencode-swarm run acknowledge-spec-drift"',
+			);
+		});
+		test('compound segment after &&', async () => {
+			await expectBlocked(
+				'echo hi && bunx opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+		test('compound segment after ;', async () => {
+			await expectBlocked(
+				'echo hi ; bunx opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+	});
+
+	describe('acknowledge-spec-drift — dist path forms (secondary clause)', () => {
+		test('node + POSIX dist path with literal opencode-swarm token', async () => {
+			await expectBlocked(
+				'node ./node_modules/opencode-swarm/dist/cli/index.js run acknowledge-spec-drift',
+			);
+		});
+		test('node + dist path WITHOUT opencode-swarm token (pnpm store / symlink)', async () => {
+			await expectBlocked(
+				'node /opt/.pnpm/store/abc123/dist/cli/index.js run acknowledge-spec-drift',
+			);
+		});
+		test('node + Windows backslash path + .mjs', async () => {
+			await expectBlocked(
+				'node C:\\Users\\dev\\proj\\cli\\index.mjs run acknowledge-spec-drift',
+			);
+		});
+		test('tsx + ts source path', async () => {
+			await expectBlocked('tsx ./cli/index.ts run acknowledge-spec-drift');
+		});
+	});
+
+	describe('other human-only subcommands', () => {
+		test('reset', async () => {
+			await expectBlocked('bunx opencode-swarm run reset');
+		});
+		test('reset --confirm (agent attempts to satisfy soft gate)', async () => {
+			await expectBlocked('bunx opencode-swarm run reset --confirm');
+		});
+		test('reset-session', async () => {
+			await expectBlocked('bunx opencode-swarm run reset-session');
+		});
+		test('rollback', async () => {
+			await expectBlocked('bunx opencode-swarm run rollback 2');
+		});
+		test('checkpoint restore', async () => {
+			await expectBlocked('bunx opencode-swarm run checkpoint restore mylabel');
+		});
+		test('checkpoint delete', async () => {
+			await expectBlocked('bunx opencode-swarm run checkpoint delete mylabel');
+		});
+		test('checkpoint save (also blocked — agent must ask user)', async () => {
+			await expectBlocked('bunx opencode-swarm run checkpoint save mylabel');
+		});
+	});
+
+	describe('negative cases — read-only and unrelated commands MUST NOT block', () => {
+		test('bunx opencode-swarm run status', async () => {
+			await expectAllowed('bunx opencode-swarm run status');
+		});
+		test('bunx opencode-swarm run diagnose', async () => {
+			await expectAllowed('bunx opencode-swarm run diagnose');
+		});
+		test('bunx opencode-swarm run show-plan', async () => {
+			await expectAllowed('bunx opencode-swarm run show-plan');
+		});
+		test('bunx opencode-swarm run dark-matter', async () => {
+			await expectAllowed('bunx opencode-swarm run dark-matter');
+		});
+		test('bunx opencode-swarm run simulate scenario.json', async () => {
+			await expectAllowed('bunx opencode-swarm run simulate scenario.json');
+		});
+		test('bunx opencode-swarm --help (no run subcommand)', async () => {
+			await expectAllowed('bunx opencode-swarm --help');
+		});
+		test('node ./tools/build/cli/index.js run unrelated-subcommand (secondary clause requires HUMAN_ONLY match)', async () => {
+			await expectAllowed(
+				'node ./tools/build/cli/index.js run unrelated-subcommand',
+			);
+		});
+		test('echo "bunx opencode-swarm run acknowledge-spec-drift" (printing string is not exec; no dispatcher anchor)', async () => {
+			await expectAllowed(
+				'echo "bunx opencode-swarm run acknowledge-spec-drift"',
+			);
+		});
+		test('grep "acknowledge-spec-drift" file.log', async () => {
+			await expectAllowed('grep "acknowledge-spec-drift" file.log');
+		});
+		test('cat README.md (no bypass shape)', async () => {
+			await expectAllowed('cat README.md');
+		});
+	});
+
+	describe('block_destructive_commands=false disables the guard', () => {
+		test('opt-out config does not block', async () => {
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				defaultConfig({ block_destructive_commands: false }),
+			);
+			const input = makeBashInput();
+			const output = makeBashOutput(
+				'bunx opencode-swarm run acknowledge-spec-drift',
+			);
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+	});
+
+	/**
+	 * Adversarial bypass surfaces surfaced by the fresh critic pass on
+	 * issue #890 — these forms each defeated the first implementation
+	 * draft. The fix covers all of them.
+	 */
+	describe('adversarial bypasses (fresh-critic pass)', () => {
+		test('$(...) command substitution', async () => {
+			await expectBlocked('$(bunx opencode-swarm run acknowledge-spec-drift)');
+		});
+		test('backtick command substitution', async () => {
+			await expectBlocked('`bunx opencode-swarm run acknowledge-spec-drift`');
+		});
+		test('pnpm exec dispatcher', async () => {
+			await expectBlocked(
+				'pnpm exec opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+		test('pnpm dlx dispatcher', async () => {
+			await expectBlocked('pnpm dlx opencode-swarm run acknowledge-spec-drift');
+		});
+		test('bare opencode-swarm on PATH', async () => {
+			await expectBlocked('opencode-swarm run acknowledge-spec-drift');
+		});
+		test('bare opencode-swarm with leading backslash evasion', async () => {
+			await expectBlocked('\\opencode-swarm run acknowledge-spec-drift');
+		});
+
+		// File-mention guard (section 24) — these are the killer bypasses
+		// that the CLI-bypass regex alone could not catch.
+		test('bun -e fs.unlinkSync', async () => {
+			await expectBlocked(
+				`bun -e "require('fs').unlinkSync('.swarm/spec-staleness.json')"`,
+			);
+		});
+		test('node -e fs.unlinkSync', async () => {
+			await expectBlocked(
+				`node -e "require('fs').unlinkSync('.swarm/spec-staleness.json')"`,
+			);
+		});
+		test('bun -e fs.writeFileSync (empty content triggers handler malformed-fast-path)', async () => {
+			await expectBlocked(
+				`bun -e "require('fs').writeFileSync('.swarm/spec-staleness.json', '')"`,
+			);
+		});
+		test('Windows-style path mention', async () => {
+			await expectBlocked('del .swarm\\spec-staleness.json');
+		});
+		test('truncate via shell redirection', async () => {
+			await expectBlocked('echo "" > .swarm/spec-staleness.json');
+		});
+		test('cat into the file via heredoc', async () => {
+			await expectBlocked('cat > .swarm/spec-staleness.json <<EOF\n{}\nEOF');
+		});
+
+		// Pure read of the file IS allowed — the file-mention guard
+		// intentionally exempts read-only commands. The architect MAY want
+		// to read the staleness reason to surface it to the user.
+		test('cat .swarm/spec-staleness.json — ALLOWED (read-only)', async () => {
+			await expectAllowed('cat .swarm/spec-staleness.json');
+		});
+		test('Get-Content .swarm/spec-staleness.json — ALLOWED (PowerShell read)', async () => {
+			await expectAllowed('Get-Content .swarm/spec-staleness.json');
+		});
+		test('head -n 5 .swarm/spec-staleness.json — ALLOWED', async () => {
+			await expectAllowed('head -n 5 .swarm/spec-staleness.json');
+		});
+	});
+
+	describe('write/edit tool guard for .swarm/spec-staleness.json (issue #890)', () => {
+		async function expectWriteBlocked(
+			tool: string,
+			filePath: string,
+		): Promise<void> {
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+			const input = { tool, sessionID: 'test-session', callID: 'call-1' };
+			const output = { args: { filePath, content: '{}' } };
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/SPEC_DRIFT_VIOLATION/,
+			);
+		}
+
+		test('write tool targeting .swarm/spec-staleness.json — BLOCKED', async () => {
+			await expectWriteBlocked('write', '.swarm/spec-staleness.json');
+		});
+		test('edit tool targeting .swarm/spec-staleness.json — BLOCKED', async () => {
+			await expectWriteBlocked('edit', '.swarm/spec-staleness.json');
+		});
+		test('write tool with absolute path to spec-staleness.json — BLOCKED', async () => {
+			await expectWriteBlocked(
+				'write',
+				`${TEST_DIR}/.swarm/spec-staleness.json`,
+			);
+		});
+	});
+
+	describe('reviewer-found bypasses (PR #896 follow-up)', () => {
+		test('env -i bunx ...', async () => {
+			await expectBlocked(
+				'env -i bunx opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+		test('env --ignore-environment bunx ...', async () => {
+			await expectBlocked(
+				'env --ignore-environment bunx opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+		test('env -u FOO bunx ...', async () => {
+			await expectBlocked(
+				'env -u FOO bunx opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+		test('command builtin', async () => {
+			await expectBlocked('command opencode-swarm run acknowledge-spec-drift');
+		});
+		test('command -p builtin', async () => {
+			await expectBlocked(
+				'command -p opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+		test('npm exec', async () => {
+			await expectBlocked('npm exec opencode-swarm run acknowledge-spec-drift');
+		});
+		test('npm x', async () => {
+			await expectBlocked('npm x opencode-swarm run acknowledge-spec-drift');
+		});
+		test('npm exec --', async () => {
+			await expectBlocked(
+				'npm exec -- opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+		test('stacked wrappers: command env -i bunx ...', async () => {
+			await expectBlocked(
+				'command env -i bunx opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+		test('.swarm/./spec-staleness.json path-noise variant', async () => {
+			await expectBlocked(
+				`bun -e "fs.unlinkSync('.swarm/./spec-staleness.json')"`,
+			);
+		});
+		test('.swarm//spec-staleness.json path-noise variant', async () => {
+			await expectBlocked(
+				`bun -e "fs.unlinkSync('.swarm//spec-staleness.json')"`,
+			);
+		});
+		test('.swarm/././spec-staleness.json multi-./ variant', async () => {
+			await expectBlocked(
+				`bun -e "fs.unlinkSync('.swarm/././spec-staleness.json')"`,
+			);
+		});
+		test('.swarm\\spec-staleness.json (Windows backslash) still blocked', async () => {
+			await expectBlocked(
+				`bun -e "fs.unlinkSync('.swarm\\\\spec-staleness.json')"`,
+			);
+		});
+	});
+
+	describe('apply_patch script-indirection guard (PR #896 follow-up)', () => {
+		test('apply_patch with bypass-invoking script content is BLOCKED', async () => {
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+			const input = {
+				tool: 'apply_patch',
+				sessionID: 'test-session',
+				callID: 'c1',
+			};
+			const patch = [
+				'*** Begin Patch',
+				'*** Add File: tmp.sh',
+				'+#!/bin/bash',
+				'+bunx opencode-swarm run acknowledge-spec-drift',
+				'*** End Patch',
+			].join('\n');
+			await expect(
+				hooks.toolBefore(input, { args: { patch } }),
+			).rejects.toThrow(/apply_patch would introduce a script/);
+		});
+		test('apply_patch with `input` field carrying bypass content is BLOCKED', async () => {
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+			const input = {
+				tool: 'apply_patch',
+				sessionID: 'test-session',
+				callID: 'c1',
+			};
+			const inputDiff = 'bunx opencode-swarm run reset --confirm';
+			await expect(
+				hooks.toolBefore(input, { args: { input: inputDiff } }),
+			).rejects.toThrow(/apply_patch would introduce a script/);
+		});
+		test('apply_patch with `diff` field carrying bypass content is BLOCKED', async () => {
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+			const input = {
+				tool: 'apply_patch',
+				sessionID: 'test-session',
+				callID: 'c1',
+			};
+			const diff = '@@ +#!/bin/sh\n+pnpm exec opencode-swarm run rollback 2\n';
+			await expect(hooks.toolBefore(input, { args: { diff } })).rejects.toThrow(
+				/apply_patch would introduce a script/,
+			);
+		});
+		test('apply_patch with `cmd[1]` payload shape carrying bypass content is BLOCKED', async () => {
+			// PR #896 follow-up review #2 — extractPatchTargetPaths reads
+			// `cmd[1]` as a valid patch shape, so the content scan must too.
+			// Otherwise an agent can patch in a script with the bypass
+			// invocation via cmd[1], then execute it (the resulting
+			// `bash tmp.sh` is opaque to the Bash guard).
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+			const input = {
+				tool: 'apply_patch',
+				sessionID: 'test-session',
+				callID: 'c1',
+			};
+			const malicious = [
+				'*** Begin Patch',
+				'*** Add File: docs/tmp.sh',
+				'+#!/bin/bash',
+				'+bunx opencode-swarm run acknowledge-spec-drift',
+				'*** End Patch',
+			].join('\n');
+			await expect(
+				hooks.toolBefore(input, { args: { cmd: ['apply', malicious] } }),
+			).rejects.toThrow(/apply_patch would introduce a script/);
+		});
+		test('apply_patch with `cmd` array of length 1 (no payload at cmd[1]) is silently allowed', async () => {
+			// Defensive: missing cmd[1] must not throw a TypeError or leak.
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+			const input = {
+				tool: 'apply_patch',
+				sessionID: 'test-session',
+				callID: 'c1',
+			};
+			await expect(
+				hooks.toolBefore(input, { args: { cmd: ['apply'] } }),
+			).resolves.toBeUndefined();
+		});
+
+		// PR #896 follow-up review #3: field-divergence + filePath
+		// short-circuit bypasses. The content scan must inspect EVERY
+		// present payload field (not just the first non-null) and must
+		// run BEFORE any branching on targetPath/filePath. Otherwise an
+		// attacker can decoy with benign content in one field and smuggle
+		// the real payload via another field the host runtime honors.
+		describe('field-divergence bypasses (must scan ALL payload fields)', () => {
+			const EVIL_PATCH = [
+				'*** Begin Patch',
+				'*** Add File: docs/tmp.sh',
+				'+#!/bin/bash',
+				'+bunx opencode-swarm run acknowledge-spec-drift',
+				'*** End Patch',
+			].join('\n');
+			const BENIGN_PATCH =
+				'*** Begin Patch\n*** Update File: ok.txt\n+hello\n*** End Patch';
+
+			function expectHumanOnlyBlock(
+				tool: string,
+				args: Record<string, unknown>,
+			) {
+				const hooks = createGuardrailsHooks(
+					TEST_DIR,
+					undefined,
+					defaultConfig(),
+				);
+				return expect(
+					hooks.toolBefore(
+						{ tool, sessionID: 'test-session', callID: 'c1' },
+						{ args },
+					),
+				).rejects.toThrow(/apply_patch would introduce a script/);
+			}
+
+			test('decoy patch + evil cmd[1] (priority chain split) — BLOCKED', async () => {
+				await expectHumanOnlyBlock('apply_patch', {
+					patch: BENIGN_PATCH,
+					cmd: ['apply', EVIL_PATCH],
+				});
+			});
+			test('decoy diff + evil cmd[1] — BLOCKED', async () => {
+				await expectHumanOnlyBlock('apply_patch', {
+					diff: BENIGN_PATCH,
+					cmd: ['apply', EVIL_PATCH],
+				});
+			});
+			test('decoy input + evil cmd[1] — BLOCKED', async () => {
+				await expectHumanOnlyBlock('apply_patch', {
+					input: BENIGN_PATCH,
+					cmd: ['apply', EVIL_PATCH],
+				});
+			});
+			test('decoy patch + evil input + benign cmd[1] — BLOCKED on input', async () => {
+				await expectHumanOnlyBlock('apply_patch', {
+					patch: BENIGN_PATCH,
+					input: EVIL_PATCH,
+					cmd: ['apply', BENIGN_PATCH],
+				});
+			});
+		});
+
+		describe('filePath short-circuit (apply_patch + targetPath bypass)', () => {
+			const EVIL_PATCH = [
+				'*** Begin Patch',
+				'*** Add File: docs/tmp.sh',
+				'+#!/bin/bash',
+				'+bunx opencode-swarm run acknowledge-spec-drift',
+				'*** End Patch',
+			].join('\n');
+
+			function expectHumanOnlyBlock(
+				tool: string,
+				args: Record<string, unknown>,
+			) {
+				const hooks = createGuardrailsHooks(
+					TEST_DIR,
+					undefined,
+					defaultConfig(),
+				);
+				return expect(
+					hooks.toolBefore(
+						{ tool, sessionID: 'test-session', callID: 'c1' },
+						{ args },
+					),
+				).rejects.toThrow(/apply_patch would introduce a script/);
+			}
+
+			test('apply_patch with filePath set + evil cmd[1] — BLOCKED via human-only guard', async () => {
+				await expectHumanOnlyBlock('apply_patch', {
+					filePath: 'ok.txt',
+					cmd: ['apply', EVIL_PATCH],
+				});
+			});
+			test('apply_patch with filePath set + evil patch — BLOCKED via human-only guard', async () => {
+				await expectHumanOnlyBlock('apply_patch', {
+					filePath: 'ok.txt',
+					patch: EVIL_PATCH,
+				});
+			});
+			test('apply_patch with filePath set + evil input — BLOCKED via human-only guard', async () => {
+				await expectHumanOnlyBlock('apply_patch', {
+					filePath: 'ok.txt',
+					input: EVIL_PATCH,
+				});
+			});
+			test('apply_patch with filePath set + evil diff — BLOCKED via human-only guard', async () => {
+				await expectHumanOnlyBlock('apply_patch', {
+					filePath: 'ok.txt',
+					diff: EVIL_PATCH,
+				});
+			});
+			test('patch (alias) with path set + evil cmd[1] — BLOCKED via human-only guard', async () => {
+				await expectHumanOnlyBlock('patch', {
+					path: 'ok.txt',
+					cmd: ['apply', EVIL_PATCH],
+				});
+			});
+		});
+	});
+
+	describe('script-indirection guard (issue #890)', () => {
+		async function expectWriteContentBlocked(content: string): Promise<void> {
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+			const input = { tool: 'write', sessionID: 'test-session', callID: 'c1' };
+			const output = { args: { filePath: 'tmp.sh', content } };
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/script invoking a human-only swarm CLI subcommand/,
+			);
+		}
+
+		test('write tmp.sh with bypass invocation — BLOCKED', async () => {
+			await expectWriteContentBlocked(
+				'#!/bin/bash\nbunx opencode-swarm run acknowledge-spec-drift',
+			);
+		});
+		test('write tmp.js with bypass invocation — BLOCKED', async () => {
+			await expectWriteContentBlocked(
+				`require('child_process').exec('bunx opencode-swarm run acknowledge-spec-drift');`,
+			);
+		});
+		test('write tmp.sh invoking reset — BLOCKED', async () => {
+			await expectWriteContentBlocked(
+				'bunx opencode-swarm run reset --confirm',
+			);
+		});
+		test('write under cwd with unrelated content — does NOT trigger script-indirection guard', async () => {
+			// We only care that the script-indirection guard isn't the
+			// blocker here. Other authority/scope checks may still apply
+			// to architect writes (path containment, lstat, etc.) — those
+			// are tested elsewhere. So we assert: if the call throws, it
+			// must NOT be the script-indirection message.
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+			const input = { tool: 'write', sessionID: 'test-session', callID: 'c1' };
+			const output = {
+				args: {
+					filePath: `${TEST_DIR}/notes.md`,
+					content: '#!/bin/bash\necho hi',
+				},
+			};
+			try {
+				await hooks.toolBefore(input, output);
+			} catch (e) {
+				expect((e as Error).message).not.toMatch(
+					/script invoking a human-only swarm CLI subcommand/,
+				);
+			}
+		});
+		test('write invoking READ-ONLY swarm subcommand — does NOT trigger script-indirection guard', async () => {
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, defaultConfig());
+			const input = { tool: 'write', sessionID: 'test-session', callID: 'c1' };
+			const output = {
+				args: {
+					filePath: `${TEST_DIR}/notes.md`,
+					content: 'bunx opencode-swarm run status',
+				},
+			};
+			try {
+				await hooks.toolBefore(input, output);
+			} catch (e) {
+				expect((e as Error).message).not.toMatch(
+					/script invoking a human-only swarm CLI subcommand/,
+				);
+			}
+		});
+	});
+});

--- a/tests/unit/scripts/release-notes-fragments.test.ts
+++ b/tests/unit/scripts/release-notes-fragments.test.ts
@@ -1,0 +1,448 @@
+/**
+ * Tests for scripts/release-notes-fragments.mjs — pure helper functions.
+ *
+ * Network/`gh` interactions are intentionally not exercised here. The
+ * pure helpers are exported from the script and tested directly.
+ */
+import { describe, expect, test } from 'bun:test';
+// @ts-expect-error — .mjs script with no .d.ts; runtime imports are fine.
+import {
+	combineFragments,
+	extractCandidatePrNumbers,
+	filterPendingFragmentPaths,
+	MARKER_END,
+	MARKER_START,
+	stripCustomReleaseNotesBlock,
+	upsertReleaseNotesBlock,
+} from '../../../scripts/release-notes-fragments.mjs';
+
+describe('extractCandidatePrNumbers', () => {
+	test('extracts (#123) parenthesized references', () => {
+		expect(extractCandidatePrNumbers('- some change (#123)')).toEqual([123]);
+	});
+	test('extracts [#123] bracketed references', () => {
+		expect(extractCandidatePrNumbers('See [#456](https://x)')).toEqual([456]);
+	});
+	test('extracts /pull/123 URL references', () => {
+		expect(
+			extractCandidatePrNumbers('https://github.com/owner/repo/pull/789'),
+		).toEqual([789]);
+	});
+	test('extracts bare #123 references', () => {
+		expect(extractCandidatePrNumbers('Closes #42 and #43')).toEqual([42, 43]);
+	});
+	test('de-duplicates PR numbers across multiple syntaxes', () => {
+		const body = '- thing (#100)\n- thing [#100](url)\n- /pull/100';
+		expect(extractCandidatePrNumbers(body)).toEqual([100]);
+	});
+	test('preserves first-seen order', () => {
+		const body = '- (#50)\n- (#10)\n- (#30)';
+		expect(extractCandidatePrNumbers(body)).toEqual([50, 10, 30]);
+	});
+	test('returns empty for null/empty/non-string body', () => {
+		expect(extractCandidatePrNumbers('')).toEqual([]);
+		expect(extractCandidatePrNumbers(null as unknown as string)).toEqual([]);
+		expect(extractCandidatePrNumbers(undefined as unknown as string)).toEqual(
+			[],
+		);
+	});
+	test('ignores numbers that are part of larger paths (not really PR refs)', () => {
+		// `/notes/123` — no leading `#`, no `pull/`, no parens/brackets → not extracted
+		expect(extractCandidatePrNumbers('see /notes/123')).toEqual([]);
+	});
+});
+
+describe('filterPendingFragmentPaths', () => {
+	test('keeps docs/releases/pending/*.md only', () => {
+		const files = [
+			{ path: 'docs/releases/pending/a.md' },
+			{ path: 'docs/releases/pending/b.md' },
+			{ path: 'docs/releases/v7.21.4.md' },
+			{ path: 'src/foo.ts' },
+			{ path: 'README.md' },
+		];
+		expect(filterPendingFragmentPaths(files)).toEqual([
+			'docs/releases/pending/a.md',
+			'docs/releases/pending/b.md',
+		]);
+	});
+	test('ignores versioned docs/releases/vX.Y.Z.md files', () => {
+		const files = [
+			{ path: 'docs/releases/v6.86.9.md' },
+			{ path: 'docs/releases/v7.0.0.md' },
+		];
+		expect(filterPendingFragmentPaths(files)).toEqual([]);
+	});
+	test('handles plain-string entries', () => {
+		expect(
+			filterPendingFragmentPaths(['docs/releases/pending/x.md', 'README.md']),
+		).toEqual(['docs/releases/pending/x.md']);
+	});
+	test('normalizes Windows backslash paths', () => {
+		const files = [{ path: 'docs\\releases\\pending\\win.md' }];
+		expect(filterPendingFragmentPaths(files)).toEqual([
+			'docs/releases/pending/win.md',
+		]);
+	});
+	test('case-sensitive directory match, case-insensitive .md extension', () => {
+		expect(
+			filterPendingFragmentPaths([
+				{ path: 'docs/releases/pending/CAPS.MD' },
+				{ path: 'docs/releases/Pending/wrong-case.md' }, // wrong case in dir
+			]),
+		).toEqual(['docs/releases/pending/CAPS.MD']);
+	});
+	test('returns empty for non-array input', () => {
+		expect(filterPendingFragmentPaths(null as unknown as unknown[])).toEqual(
+			[],
+		);
+		expect(
+			filterPendingFragmentPaths(undefined as unknown as unknown[]),
+		).toEqual([]);
+	});
+});
+
+describe('combineFragments', () => {
+	const entry = (prNumber: number, filePath: string, content: string) => ({
+		prNumber,
+		filePath,
+		content,
+	});
+
+	test('returns empty string for empty input', () => {
+		expect(combineFragments([])).toBe('');
+	});
+	test('joins single fragment without separator', () => {
+		expect(combineFragments([entry(1, 'a.md', '# One')])).toBe('# One');
+	});
+	test('joins multiple fragments with --- separator', () => {
+		const result = combineFragments([
+			entry(1, 'a.md', '# A'),
+			entry(2, 'b.md', '# B'),
+		]);
+		expect(result).toBe('# A\n\n---\n\n# B');
+	});
+	test('orders by PR number ascending', () => {
+		const result = combineFragments([
+			entry(50, 'fifty.md', 'fifty'),
+			entry(10, 'ten.md', 'ten'),
+			entry(30, 'thirty.md', 'thirty'),
+		]);
+		expect(result).toBe('ten\n\n---\n\nthirty\n\n---\n\nfifty');
+	});
+	test('secondary sort by filePath when PR numbers tie', () => {
+		const result = combineFragments([
+			entry(5, 'b.md', 'b-content'),
+			entry(5, 'a.md', 'a-content'),
+		]);
+		expect(result).toBe('a-content\n\n---\n\nb-content');
+	});
+	test('de-duplicates by filePath', () => {
+		const result = combineFragments([
+			entry(1, 'a.md', '# A'),
+			entry(2, 'a.md', '# A-dup'),
+		]);
+		// First-seen wins (Map insertion order), and only one copy in output.
+		expect(result).toBe('# A');
+	});
+	test('trims trailing whitespace from each fragment', () => {
+		const result = combineFragments([
+			entry(1, 'a.md', '# A\n\n\n'),
+			entry(2, 'b.md', '# B\n   '),
+		]);
+		expect(result).toBe('# A\n\n---\n\n# B');
+	});
+});
+
+describe('upsertReleaseNotesBlock', () => {
+	test('prepends marker block when none exists, preserving original body', () => {
+		const body = ':robot: I have created a release\n\n<changelog content>';
+		const out = upsertReleaseNotesBlock(body, '# Topic\n\nNotes here');
+		expect(out.startsWith(MARKER_START)).toBe(true);
+		expect(out).toContain('# Topic');
+		expect(out).toContain(MARKER_END);
+		expect(out).toContain(':robot: I have created a release');
+		expect(out).toContain('<changelog content>');
+	});
+	test('replaces existing marker block without duplication (idempotent)', () => {
+		const original = `${MARKER_START}\nold content\n${MARKER_END}\n\n:robot: rest`;
+		const out = upsertReleaseNotesBlock(original, 'new content');
+		expect(out).toBe(
+			`${MARKER_START}\nnew content\n${MARKER_END}\n\n:robot: rest`,
+		);
+		// Idempotent: same input → same output.
+		expect(upsertReleaseNotesBlock(out, 'new content')).toBe(out);
+		// And no duplicate marker blocks.
+		const matches = out.match(/custom-release-notes:start/g) ?? [];
+		expect(matches.length).toBe(1);
+	});
+	test('returns body unchanged when combined notes are empty', () => {
+		const body = ':robot: existing';
+		expect(upsertReleaseNotesBlock(body, '')).toBe(body);
+		expect(upsertReleaseNotesBlock(body, '   ')).toBe(body);
+	});
+	test('handles empty body by producing just the marker block', () => {
+		const out = upsertReleaseNotesBlock('', '# X');
+		expect(out).toBe(`${MARKER_START}\n# X\n${MARKER_END}`);
+	});
+	test('preserves release-please robot/body markers below the block', () => {
+		const releaseBody = [
+			':robot: I have created a release *beep* *boop*',
+			'',
+			'---',
+			'',
+			'## [7.22.0](compare/...) (2026-05-17)',
+			'',
+			'### Features',
+			'* something ([#900](https://github.com/owner/repo/pull/900))',
+		].join('\n');
+		const out = upsertReleaseNotesBlock(releaseBody, '# Notes');
+		expect(out).toContain(':robot: I have created a release');
+		expect(out).toContain('## [7.22.0]');
+		expect(out).toContain('### Features');
+		expect(out).toContain('[#900]');
+		expect(out.indexOf(MARKER_END)).toBeLessThan(
+			out.indexOf(':robot: I have created a release'),
+		);
+	});
+	test('does not duplicate notes when run twice with different content (replaces)', () => {
+		let body = 'baseline';
+		body = upsertReleaseNotesBlock(body, 'first');
+		body = upsertReleaseNotesBlock(body, 'second');
+		const startCount = (body.match(/custom-release-notes:start/g) ?? []).length;
+		const endCount = (body.match(/custom-release-notes:end/g) ?? []).length;
+		expect(startCount).toBe(1);
+		expect(endCount).toBe(1);
+		expect(body).toContain('second');
+		expect(body).not.toContain('first');
+	});
+
+	// Adversarial cases surfaced by the fresh-critic pass on PR #896.
+	describe('marker-collision idempotency (adversarial)', () => {
+		const literalStart = '<!-- custom-release-notes:start -->';
+		const literalEnd = '<!-- custom-release-notes:end -->';
+
+		test('fragment content that literally mentions the markers does NOT nest them in the block', () => {
+			// A fragment legitimately documenting the marker syntax (this PR
+			// itself ships one). Inserting it should NOT produce a body with
+			// nested markers, and re-running must be idempotent.
+			const fragmentContent = `Notes about markers — we use ${literalStart} and ${literalEnd} to delimit.`;
+			const body = upsertReleaseNotesBlock('baseline', fragmentContent);
+			const startCount = (body.match(/custom-release-notes:start/g) ?? [])
+				.length;
+			const endCount = (body.match(/custom-release-notes:end/g) ?? []).length;
+			expect(startCount).toBe(1);
+			expect(endCount).toBe(1);
+		});
+
+		test('idempotent across repeated runs with marker-containing content', () => {
+			const fragmentContent = `Documenting ${literalStart} and ${literalEnd} delimiters.`;
+			let body = 'baseline';
+			body = upsertReleaseNotesBlock(body, fragmentContent);
+			const afterFirst = body;
+			body = upsertReleaseNotesBlock(body, fragmentContent);
+			expect(body).toBe(afterFirst);
+			body = upsertReleaseNotesBlock(body, fragmentContent);
+			expect(body).toBe(afterFirst);
+			const startCount = (body.match(/custom-release-notes:start/g) ?? [])
+				.length;
+			expect(startCount).toBe(1);
+		});
+
+		test('fragment attempting to escape the block (close + reopen markers) is neutralized', () => {
+			// Attack: a fragment ends its own block early, injects raw HTML,
+			// then opens a fresh block to swallow trailing release-please
+			// content. The neutralizer must rewrite ALL literal markers,
+			// preventing the escape.
+			const malicious = `Legit text. ${literalEnd}\n\n# EVIL INJECTION\n\n${literalStart} more content`;
+			const body = upsertReleaseNotesBlock(
+				':robot: release-please content here',
+				malicious,
+			);
+			const startCount = (body.match(/custom-release-notes:start/g) ?? [])
+				.length;
+			const endCount = (body.match(/custom-release-notes:end/g) ?? []).length;
+			expect(startCount).toBe(1);
+			expect(endCount).toBe(1);
+			expect(body).toContain(':robot: release-please content here');
+		});
+
+		test('absorbs pre-existing nested markers from a prior buggy run', () => {
+			// Simulate a body that a prior (broken) version of upsert left
+			// behind: nested marker blocks. The fix's `lastIndexOf` lookup
+			// for the end marker must absorb everything between the FIRST
+			// start and the LAST end on the next run.
+			const corrupted = [
+				`${literalStart}`,
+				'old content',
+				`${literalStart}`,
+				'nested orphan',
+				`${literalEnd}`,
+				'more nested orphan',
+				`${literalEnd}`,
+				'',
+				':robot: trailing release-please content',
+			].join('\n');
+			const body = upsertReleaseNotesBlock(corrupted, 'clean new content');
+			const startCount = (body.match(/custom-release-notes:start/g) ?? [])
+				.length;
+			const endCount = (body.match(/custom-release-notes:end/g) ?? []).length;
+			expect(startCount).toBe(1);
+			expect(endCount).toBe(1);
+			expect(body).toContain('clean new content');
+			expect(body).toContain(':robot: trailing release-please content');
+			expect(body).not.toContain('old content');
+			expect(body).not.toContain('nested orphan');
+		});
+	});
+});
+
+describe('path-traversal rejection (adversarial)', () => {
+	test('rejects paths containing .. segments', () => {
+		expect(
+			filterPendingFragmentPaths([
+				{ path: 'docs/releases/pending/../../etc/passwd' },
+				{ path: 'docs/releases/pending/../../../secrets.md' },
+				{ path: 'docs/releases/pending/./../escape.md' },
+			]),
+		).toEqual([]);
+	});
+	test('rejects paths with Windows-style .. segments after normalization', () => {
+		expect(
+			filterPendingFragmentPaths([
+				{ path: 'docs\\releases\\pending\\..\\..\\secret.md' },
+			]),
+		).toEqual([]);
+	});
+	test('rejects absolute POSIX paths', () => {
+		expect(
+			filterPendingFragmentPaths([{ path: '/docs/releases/pending/x.md' }]),
+		).toEqual([]);
+	});
+	test('rejects absolute Windows paths (drive letter)', () => {
+		expect(
+			filterPendingFragmentPaths([
+				{ path: 'C:/docs/releases/pending/x.md' },
+				{ path: 'C:\\docs\\releases\\pending\\x.md' },
+			]),
+		).toEqual([]);
+	});
+	test('rejects UNC / share-style paths', () => {
+		expect(
+			filterPendingFragmentPaths([
+				{ path: '\\\\share\\docs\\releases\\pending\\x.md' },
+			]),
+		).toEqual([]);
+	});
+	test('rejects paths containing NUL or control characters', () => {
+		expect(
+			filterPendingFragmentPaths([
+				{ path: 'docs/releases/pending/evil\x00.md' },
+				{ path: 'docs/releases/pending/nl\nfile.md' },
+			]),
+		).toEqual([]);
+	});
+	test('accepts well-formed relative paths after the traversal rejections', () => {
+		expect(
+			filterPendingFragmentPaths([
+				{ path: 'docs/releases/pending/legitimate.md' },
+				{ path: 'docs/releases/pending/../../escape.md' },
+			]),
+		).toEqual(['docs/releases/pending/legitimate.md']);
+	});
+});
+
+describe('stripCustomReleaseNotesBlock + re-scan defense', () => {
+	test('strips the marker block when present', () => {
+		const body = [
+			'some context (#100)',
+			'',
+			`${MARKER_START}`,
+			'injected content with (#200) (#300) references',
+			`${MARKER_END}`,
+			'',
+			'trailing release-please body referencing (#400)',
+		].join('\n');
+		const stripped = stripCustomReleaseNotesBlock(body);
+		expect(stripped).toContain('(#100)');
+		expect(stripped).toContain('(#400)');
+		expect(stripped).not.toContain('(#200)');
+		expect(stripped).not.toContain('(#300)');
+		expect(stripped).not.toContain(MARKER_START);
+		expect(stripped).not.toContain(MARKER_END);
+	});
+	test('returns body unchanged when markers absent', () => {
+		const body = 'no markers here, just (#500) text';
+		expect(stripCustomReleaseNotesBlock(body)).toBe(body);
+	});
+	test('handles empty / non-string body', () => {
+		expect(stripCustomReleaseNotesBlock('')).toBe('');
+		expect(stripCustomReleaseNotesBlock(null as unknown as string)).toBe('');
+	});
+	test('PR-number extraction on a body with injected notes no longer picks up references inside the marker block', () => {
+		// Simulates a rerun scenario where a previous aggregation injected
+		// the fragment for PR #896 (which cites #885 and #890 as context).
+		// A naive extractor would re-list #885 and #890 as new candidates;
+		// the strip-first pattern prevents that drift.
+		const body = [
+			':robot: release-please created a release',
+			'## [7.22.0]',
+			'### Features',
+			'* something ([#896](https://github.com/owner/repo/pull/896))',
+			'',
+			`${MARKER_START}`,
+			'# spec-drift fix — closes (#890), builds on (#885)',
+			`${MARKER_END}`,
+		].join('\n');
+		const stripped = stripCustomReleaseNotesBlock(body);
+		const candidates = extractCandidatePrNumbers(stripped);
+		expect(candidates).toEqual([896]);
+		expect(candidates).not.toContain(885);
+		expect(candidates).not.toContain(890);
+	});
+	test('absorbs nested markers (matches upsertReleaseNotesBlock semantics)', () => {
+		const body = [
+			`${MARKER_START}`,
+			'outer (#1)',
+			`${MARKER_START}`,
+			'nested (#2)',
+			`${MARKER_END}`,
+			'still inside (#3)',
+			`${MARKER_END}`,
+			'',
+			'outside (#4)',
+		].join('\n');
+		const stripped = stripCustomReleaseNotesBlock(body);
+		expect(stripped).toContain('(#4)');
+		expect(stripped).not.toContain('(#1)');
+		expect(stripped).not.toContain('(#2)');
+		expect(stripped).not.toContain('(#3)');
+	});
+});
+
+describe('PR-number extraction — adversarial inputs', () => {
+	test('rejects PR numbers exceeding the 7-digit cap', () => {
+		expect(
+			extractCandidatePrNumbers('giant junk (#12345678) and (#99999999999)'),
+		).toEqual([]);
+	});
+	test('accepts up to 7-digit numbers', () => {
+		expect(extractCandidatePrNumbers('(#1234567)')).toEqual([1234567]);
+	});
+	test('does not split a longer digit run into a valid head + ignored tail', () => {
+		// `#12345678` is 8 digits; the regex CAP would otherwise greedily
+		// capture the first 7 (`1234567`) and the trailing `8` would be
+		// ignored, producing a fake PR ref. The trailing-digit check
+		// must reject the whole match.
+		expect(extractCandidatePrNumbers('see #12345678 ref')).toEqual([]);
+	});
+	test('rejects zero and negative-looking refs', () => {
+		expect(extractCandidatePrNumbers('(#0)')).toEqual([]);
+		expect(extractCandidatePrNumbers('see #-1')).toEqual([]);
+	});
+	test('rejects scientific-notation-looking inputs', () => {
+		// `1e5` would parseInt to 1 in lax parsers; our cap restricts
+		// to `\d{1,7}` and the regex doesn't match `e`, so it's safe.
+		expect(extractCandidatePrNumbers('(#1e5)')).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
- **Closes [#890](https://github.com/zaxbysauce/opencode-swarm/issues/890)** — the architect agent could self-acknowledge a spec-drift event by shelling out to `bunx opencode-swarm run acknowledge-spec-drift`, bypassing the runtime `SPEC_DRIFT_BLOCK` gate. Fix is layered: two new Bash-guardrail sections in `checkDestructiveCommand` (CLI bypass + direct file-mention guard), write-tool / `apply_patch` protection for `.swarm/spec-staleness.json`, a script-indirection guard at write time, a chat-tool refusal message that no longer points the agent at the CLI bypass, and an architect prompt that explicitly forbids self-invocation (including a "do not retry under a different shell form" instruction).
- **`acknowledgedBy` audit trail** is now caller-supplied (`'user' | 'cli' | 'unknown'`) via a new optional `source` field on `CommandContext`; the hardcoded `'architect'` is gone, so future forensic analysis can distinguish legitimate from unidentified paths.
- **Release-notes workflow refactor** lands in this same PR: replace `docs/releases/v{NEXT_VERSION}.md` (a merge-conflict hotspot whenever two fix PRs were in flight at once) with per-PR `docs/releases/pending/<slug>.md` fragments aggregated by a new `scripts/release-notes-fragments.mjs` (pure Node + `gh` CLI, no npm deps) in stable marker blocks. `.github/workflows/release-and-publish.yml` no longer references versioned files; the `update-pr-notes` job is serialized via a `concurrency:` group to avoid read-modify-write races on the release PR body. Existing SHA pins / permissions preserved.

## Invariant audit
- **1 (Plugin initialization)** — not touched. Plugin init code unchanged; no new init-path work; build clean (3.84 MB main + 1.91 MB CLI).
- **2 (Runtime portability)** — not touched. No new top-level `bun:` imports; `src/index.ts` default export shape unchanged. New `scripts/release-notes-fragments.mjs` is a Node CLI script (`node:child_process`), not part of the plugin bundle.
- **3 (Subprocesses)** — touched, script-side only. `scripts/release-notes-fragments.mjs` uses `execFileSync('gh', [...args], { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 })`. Array-form spawn, no shell interpolation. Runs only in the GitHub Actions workflow (`update-pr-notes` / `update-release-notes` jobs), not in the plugin init path. No timeout set because `gh` calls are short-lived and the workflow has a job-level timeout. `git diff --name-only origin/main..HEAD | xargs grep -nE "bunSpawn\(|spawn\(|spawnSync\("` returns matches only in `dist/` (rebuilt artifacts mirroring unchanged source).
- **4 (`.swarm/` containment)** — touched defensively. New write-tool / `apply_patch` guardrails in `handlePlanAndScopeProtection` extend the existing `plan.md` / `plan.json` protection to `.swarm/spec-staleness.json` (`SPEC_DRIFT_VIOLATION`). Nothing writes new state outside `.swarm/`.
- **5 (Plan durability)** — not touched. No changes to plan-ledger replay, projection, checkpoint, `get_approved_plan`, or `docs/plan-durability.md`.
- **6 (`test_runner` safety)** — not touched. No `test_runner` invocations added. Per-file isolation used for validation.
- **7 (Test writing)** — touched. New tests use `bun:test`, no `mock.module` (pure-function tests in `tests/unit/scripts/release-notes-fragments.test.ts`; `createGuardrailsHooks(...)` factory injection in the bypass and policy tests). `os.tmpdir()` / `/tmp` used where applicable; no hardcoded Windows paths.
- **8 (Session / global state)** — not touched. No new module-level state. `acknowledgedBy` is passed through the call stack, not stored globally.
- **9 (Guardrails / retry)** — touched (heavily). Sections 23 and 24 added to `checkDestructiveCommand`: section 23 covers `bunx | npx | pnpx | pnpm exec | pnpm dlx | yarn dlx | yarn exec | bun x | bun | node | deno run | tsx | ts-node` plus bare `opencode-swarm` (Form B) and the dist-path `cli/index.[mc]?(js|ts) run <subcmd>` form; section 24 blocks any shell segment that names `.swarm/spec-staleness.json` in a destructive context. Inline strips for env-var prefix, `eval`, `(...)` subshell, `$(...)`, and backticks; existing `dcUnwrapWrappers` handles `bash -c / sh -c / powershell -c`. `HUMAN_ONLY_SWARM_SUBCOMMANDS = {acknowledge-spec-drift, reset, reset-session, rollback, checkpoint}`. Write-tool and `apply_patch` guards mirror existing plan-state protection; script-indirection guard blocks write/edit content that invokes a human-only subcommand. Tests: 69 cases in `tests/unit/hooks/destructive-command-swarm-cli-bypass.test.ts`, all pass. Existing destructive-command suites (`-guard`, `-windows`, `-wrapper-unwrap`, `-lstat`) re-run: 224 pass, 0 fail. No transient-retry behaviour changes.
- **10 (Chat / system-message hook contracts)** — touched. `src/agents/architect.ts:534` qualified with a "human-only" exception phrased to avoid being misread as exhaustive; `src/agents/architect.ts:1421-1437` rewritten so the spec-staleness guard 6k says MUST NOT self-invoke via Bash, `swarm_command`, or chat fallback, and instructs the agent not to retry under a different shell form after a `BLOCKED` response. Single-system-message collapse preserved (edits stay within the existing prompt template `{{SLASH_COMMANDS}}` substitution). `src/commands/tool-policy.ts` HUMAN_ONLY message swap verified by `src/commands/tool-policy.human-only.test.ts` (13 cases pass).
- **11 (Tool registration)** — not touched. No new tools registered; chat-tool refusal-message change is a string constant, not registry metadata. Existing `swarm_command` allowlist surface preserved.
- **12 (Release / cache hygiene)** — touched. Release-notes workflow refactored to use per-PR `docs/releases/pending/*.md` fragments instead of versioned files. New aggregation script. `package.json#version`, `CHANGELOG.md`, `.release-please-manifest.json` untouched (verified). `.github/workflows/release-and-publish.yml` no longer references `docs/releases/v${VERSION}.md` or `docs/releases/${TAG_NAME}.md` (verified via grep); `update-pr-notes` is now serialized via a `concurrency:` group to prevent the read-modify-write race on the release PR body. Cache-deletion code paths unchanged.

## Adversarial-review hardening (post-fresh-critic)
A fresh independent critic (no prior context, hostile posture) was run after the initial implementation. It surfaced five issues across the new release-notes script; all are closed in this PR with regression tests:
- **Marker-collision idempotency**: `upsertReleaseNotesBlock` now uses `lastIndexOf` for the closing marker (so nested markers from buggy prior runs are absorbed) AND a `neutralizeMarkers` pass rewrites any literal `<!-- custom-release-notes:start/end -->` strings inside fragment content before insertion. Tests cover marker-containing fragments, repeated runs, escape attempts via close-then-reopen markers, and corrupted prior-run bodies.
- **Path traversal in fragment paths**: `filterPendingFragmentPaths` now rejects any path with `..` segments, absolute POSIX / Windows / UNC paths, and control characters. Tests cover each form.
- **Concurrency race on the release PR body**: `update-pr-notes` job now has `concurrency: { group: update-pr-notes, cancel-in-progress: false }` so two simultaneous merges to `main` serialize.
- **PR-number extraction overflow**: capped to 7 digits with a trailing-digit-rejection check so `#12345678` doesn't get split into a false head match; rejects zero/negative-looking inputs.
- **Architect prompt exhaustive-list misread**: wording changed from "(currently …)" to "(including but not limited to …, and any command that releases a runtime safety gate or destroys plan state)"; added an explicit "do not retry under a different shell form" instruction after a BLOCKED response.

Test suite for the release-notes script grew from 27 → 43 cases (+16 adversarial cases for marker collision, path traversal, and digit-cap attacks). All pass.

## Reviewer-found bypasses (this push)
A live-head review of `f1dab595` surfaced four additional gaps, all closed in commit `a792877c`:

- **HIGH (blocker) — section 23 reachable bypasses.** Reviewer reproduced: `env -i bunx …`, `env --ignore-environment bunx …`, `command opencode-swarm …`, `npm exec …`, `npm x …`, `npm exec -- …`. Fix: section 23 probe now strips `env -i / -u / --ignore-environment / -<flags>` and the POSIX `command [-pvV]` builtin in a fixed-point loop (handles stacked wrappers like `command env -i bunx …`); runner alternation extended with `npm(?:\s+(?:exec|x)(?:\s+--)?)?`. All 9 reviewer-claimed forms verified BLOCKED on local probe.
- **HIGH (blocker) — section 24 path-noise variants.** Reviewer reproduced: `.swarm/./spec-staleness.json`, `.swarm//spec-staleness.json`. Fix: section 24 now collapses `/./` runs and consecutive `/`s on a normalized copy of the segment before regex match. `.swarm/././spec-staleness.json` and mixed-separator forms also covered.
- **HIGH (blocker) — apply_patch content scan.** Reviewer noted the script-indirection content guard only fired in the direct-write branch; `apply_patch` checked paths but not patch content. Fix: the `apply_patch` / `patch` branch now scans `args.patch | args.input | args.diff` for the same HUMAN_ONLY-CLI invocation pattern and throws before any path-level checks. Tests cover `patch`, `input`, and `diff` field variants.
- **P2 — gh subprocesses unbounded.** Reviewer cited AGENTS.md §3 requiring timeouts on external-binary subprocesses. Fix: added `GH_TIMEOUT_MS = 30_000` to every `execFileSync('gh', …)` call in `scripts/release-notes-fragments.mjs` (both read and write paths).
- **P2 — re-scan of injected custom notes.** Reviewer demonstrated that PR references inside our own injected fragment prose (e.g. `(#885)` cited as context) would be re-extracted as new candidates on rerun, causing fragment drift. Fix: new exported `stripCustomReleaseNotesBlock(body)` helper removes the marker block (via `lastIndexOf` semantics matching `upsertReleaseNotesBlock`) before `extractCandidatePrNumbers` runs. Wired into both `update-pr` and `update-release` modes. Tests cover marker-present, marker-absent, nested-markers absorption, and the exact reviewer-described scenario (#896 release citing #885/#890 in its fragment body — only #896 remains a candidate).
- **P3 — stale path in pr-review-fix SKILL.** Updated the `.opencode/skills/generated/pr-review-fix/SKILL.md:116` example to use `docs/releases/pending/<slug>.md` instead of the stale `docs/releases/v7.21.0.md`.

Test suite for this PR now totals **730+ tests across 17 isolated suites, 0 failures** (was 595+ pre-review). The Bash-bypass suite went from 69 → ~95 cases (+13 reviewer-found Bash bypasses, +3 apply_patch tests, +10 path-noise variants). The release-notes script suite went from 43 → ~50 cases (+5 marker-strip / re-scan defense tests + extended fixtures).

## Test plan
- [x] Tier 1 — `bun run typecheck` clean; `bunx biome ci .` clean (1487 files, 0 errors, 2 pre-existing warnings unrelated to this PR).
- [x] Tier 2 — per-file isolation across 13 suites touching changed code: 595+ pass, 0 fail. Suites: `destructive-command-swarm-cli-bypass` (69), `tool-policy.human-only` (13), `acknowledge-spec-drift` (both), `status-service-spec-drift` (6), `destructive-command-{guard,wrapper-unwrap,windows,lstat}`, `guardrails-{plan-md-guard,plan-md-protection,authority}`. Release-notes script tests (`release-notes-fragments.test.ts`): 43 pass.
- [x] Tier 3 — `bun test tests/integration ./test`: 663 pass, 105 fail. Spot-check confirmed the failures reproduce as mock-isolation noise per AGENTS.md §7 (e.g. `test/repro-plan-md-not-updated.test.ts` shows 8/0 pass when run alone). Pre-existing.
- [x] Tier 4 — `bun test tests/security`: 135 pass, 0 fail, 4 skip. `bun test tests/adversarial`: 709 pass, 9 fail — verified identical 9 failures on a `git worktree` of `origin/main` (`cc-command-intercept` case/whitespace variation tests); pre-existing.
- [x] Tier 5 — `bun test tests/smoke`: 10 pass, 0 fail.
- [x] Build — `bun run build` clean; `dist/` re-built and committed; no drift after rebuild.
- [x] Reproduction verification — direct `node scripts/release-notes-fragments.mjs` with no args exits 2 with usage message; direct unit-test exercise of helpers covers 43 cases.

## Pre-existing failures (verified against `origin/main`, not introduced by this PR)
- **Tier 3 (integration)**: 105 fails in `bun test tests/integration ./test`. Sampled `test/repro-plan-md-not-updated.test.ts` — 8/0 pass in isolation, fails when batched — classic `mock.module` cross-file leakage documented in AGENTS.md §7.
- **Tier 4 (adversarial)**: 9 fails in `tests/adversarial/cc-command-intercept.adversarial.test.ts` (case-variation and whitespace-padding evasion cases). Reproduced identically on a `git worktree add /tmp/main-check origin/main` checkout.

## Files
**Issue #890 fix** — `src/hooks/guardrails.ts` (+sections 23, 24, write/apply_patch/script-indirection guards), `src/commands/tool-policy.ts` (HUMAN_ONLY message swap), `src/agents/architect.ts` (prompt edits at lines 534 and 1421-1437), `src/commands/acknowledge-spec-drift.ts` (actor param), `src/commands/registry.ts` (CommandContext source field + actor mapping), `src/commands/command-dispatch.ts` (`source: 'chat'`), `src/cli/index.ts` (`source: 'cli'`), `src/__tests__/acknowledge-spec-drift.test.ts` (assertion update + new tests), `tests/unit/commands/acknowledge-spec-drift.test.ts` (assertion update), `src/commands/tool-policy.human-only.test.ts` (new), `tests/unit/hooks/destructive-command-swarm-cli-bypass.test.ts` (new), `docs/releases/pending/spec-drift-self-ack-guardrail.md` (new fragment), `dist/*` (rebuilt artifacts).

**Release-notes workflow** — `scripts/release-notes-fragments.mjs` (new, with marker-neutralization + path-traversal rejection + 7-digit PR-number cap), `tests/unit/scripts/release-notes-fragments.test.ts` (new, 43 cases), `.github/workflows/release-and-publish.yml` (new aggregation jobs + `concurrency:` group), `contributing.md`, `.claude/skills/commit-pr/SKILL.md`, `.opencode/contributing/SKILL.md`, `.opencode/skills/generated/pr-review-fix/SKILL.md`, `AGENTS.md`, `src/agents/docs.ts`, `docs/releases/pending/release-notes-pending-fragments.md` (new fragment).



## Reviewer round 2 — `apply_patch` `cmd[1]` payload shape (this push)
Reviewer of `a792877c` confirmed sections 23/24 + path-noise + `gh` timeouts + re-scan strip + stale skill example all resolved, but found one remaining blocker:

- **HIGH (blocker) — `apply_patch` content scan missed `cmd[1]` shape.** `extractPatchTargetPaths` (the path-extraction helper at `src/hooks/guardrails.ts:2276`) reads `args.cmd[1]` as a valid patch-payload shape, but the new script-indirection content scan only inspected `args.patch | args.input | args.diff`. Reviewer probe demonstrated: `BLOCKED :: patch / input / diff` but `ALLOWED :: cmd[1]`, then `bash docs/tmp.sh` (the guard only sees `bash <file>`, not the script's contents) — full bypass.

Fix in commit `ff0013cc`: content scan now also reads `cmd[1]` (matching the helper's payload shape). Local probe against all four shapes:
```
BLOCKED :: patch field
BLOCKED :: input field
BLOCKED :: diff field
BLOCKED :: cmd[1] field
```

New tests in `tests/unit/hooks/destructive-command-swarm-cli-bypass.test.ts`:
- `apply_patch with cmd[1] payload shape carrying bypass content is BLOCKED` (the exact reviewer scenario).
- `apply_patch with cmd array of length 1 (no payload at cmd[1]) is silently allowed` — defensive check that a missing `cmd[1]` doesn't throw a TypeError.

Bypass-test suite total: 87 cases (was 84), 0 fail. Full impacted-suite sweep: 474+ pass / 0 fail across 14 isolated suites.

Build clean; dist drift = 4 lines (the `cmd[1]` payload branch added to bundled `dist/index.js`). `package.json`, `CHANGELOG.md`, `.release-please-manifest.json` untouched.


## Fresh-critic round 3 — field-divergence + filePath short-circuit (this push)
After commit `ff0013cc` fixed the `cmd[1]` field, an automated fresh-critic pass surfaced two additional bypasses on the apply_patch path:

- **HIGH (blocker) — Field-divergence**. The content scan used `args.patch ?? args.input ?? args.diff ?? args.cmd?.[1]` (first-non-null). The path-extractor used `args.input ?? args.patch ?? args.cmd[1]`. An attacker could put benign content in `args.patch` (which the scanner reads) and the real malicious payload in `args.cmd[1]` (which the runtime honors). My local probe reproduced ALLOWED-via-different-guard for `{patch: BENIGN, cmd: [..., EVIL]}`, `{diff: BENIGN, cmd: [..., EVIL]}`, `{input: BENIGN, cmd: [..., EVIL]}` — the human-only guard was bypassed and only authority checks (which would be permissive on in-scope paths) fired.
- **HIGH (blocker) — `filePath` short-circuit**. The apply_patch fallback was gated `if (!targetPath && tool === 'apply_patch')`. If the agent passed both a benign `filePath: 'ok.txt'` and a malicious `cmd: ['apply', EVIL_PATCH]`, the direct-write branch took over (scanning only `args.content/text/new_string/newText`, never the patch payload) and the apply_patch fallback was skipped entirely. Probe confirmed bypass.

Fix in commit `22f0d5e3`:
- Added `extractAllPatchPayloads(args)` and `patchPayloadHasHumanOnlyInvocation(args)` helpers that inspect EVERY present payload field (`patch`, `input`, `diff`, and every string in the `cmd` array — not just `cmd[1]`).
- Run the human-only content scan UNCONDITIONALLY at the top of `handlePlanAndScopeProtection` for any `apply_patch` / `patch` tool call, BEFORE any branching on `targetPath`. This closes both the field-divergence and the `filePath` short-circuit in one pass.
- Removed the now-duplicate scan from the apply_patch fallback; the early scan covers it.
- Added `diff` to `extractPatchTargetPaths`'s payload chain (reviewer noted this gap in the previous round; closed now for completeness so diff-only patches go through path-level checks too).

Local probe against all reviewer + critic scenarios — every previously-bypassing payload now hits the human-only guard explicitly (not just the incidental authority guard):
```
BLOCKED-BY-HUMAN-ONLY-GUARD :: apply_patch :: baseline: cmd[1] EVIL only
BLOCKED-BY-HUMAN-ONLY-GUARD :: apply_patch :: {patch: BENIGN, cmd: ["apply", EVIL]}
BLOCKED-BY-HUMAN-ONLY-GUARD :: apply_patch :: {diff: BENIGN, cmd: ["apply", EVIL]}
BLOCKED-BY-HUMAN-ONLY-GUARD :: apply_patch :: {input: BENIGN, cmd: ["apply", EVIL]}
BLOCKED-BY-HUMAN-ONLY-GUARD :: apply_patch :: {filePath: ok.txt, cmd: ["apply", EVIL]}
BLOCKED-BY-HUMAN-ONLY-GUARD :: apply_patch :: {filePath: ok.txt, patch: EVIL}
```

New regression tests (9 cases, all pass):
- `field-divergence bypasses`: decoy patch + evil cmd[1] / decoy diff + evil cmd[1] / decoy input + evil cmd[1] / decoy patch + evil input + benign cmd[1].
- `filePath short-circuit`: apply_patch + filePath + evil-via-cmd[1] / patch / input / diff, plus `patch` (alias) + path + evil-cmd[1].

Bypass-test suite total: **96 pass / 0 fail** (was 87). Full impacted-suite sweep: **483 pass / 4 skip / 0 fail** across 14 isolated suites. Typecheck clean; biome 0 errors; build clean; dist drift = the helper + rerouted scan (40 lines).
