### PR TITLE
feat(config): add auto_select_architect option to auto-select swarm architect on launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+* **config:** add `auto_select_architect` option to automatically select swarm architect and disable competing built-in agents ([#887](https://github.com/zaxbysauce/opencode-swarm/issues/887))
+
 ## [7.21.5](https://github.com/zaxbysauce/opencode-swarm/compare/v7.21.4...v7.21.5) (2026-05-17)
 
 

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.21.3",
+    version: "7.21.5",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -17397,7 +17397,7 @@ var init_schema = __esm(() => {
     enabled: exports_external.boolean().default(true),
     rules: exports_external.record(exports_external.string(), AgentAuthorityRuleSchema).default({}),
     universal_deny_prefixes: exports_external.array(exports_external.string().min(1)).default([]),
-    verifier_config_paths: exports_external.array(exports_external.string()).optional().describe("Additional glob patterns for verifier config files that should be protected from agent modification. These patterns are merged with the built-in verifier config globs (guardrails.ts).")
+    verifier_config_paths: exports_external.array(exports_external.string()).optional().describe("Additional glob patterns for verifier config files that are merged into the architect agent's blockedGlobs at plugin init. Writes to matching files are blocked by the authority layer.")
   });
   GeneralCouncilMemberConfigSchema = exports_external.object({
     memberId: exports_external.string().min(1),
@@ -17472,6 +17472,14 @@ var init_schema = __esm(() => {
         return;
       const trimmed = v.trim();
       return trimmed === "" ? undefined : trimmed;
+    }),
+    auto_select_architect: exports_external.union([exports_external.boolean(), exports_external.string()]).optional().transform((v) => {
+      if (v === undefined)
+        return;
+      if (typeof v === "boolean")
+        return v;
+      const trimmed = v.trim();
+      return trimmed === "" ? false : trimmed;
     }),
     swarms: exports_external.record(exports_external.string(), SwarmConfigSchema).optional(),
     max_iterations: exports_external.number().min(1).max(10).default(5),

--- a/dist/config/schema.d.ts
+++ b/dist/config/schema.d.ts
@@ -828,6 +828,7 @@ export declare const PluginConfigSchema: z.ZodObject<{
         fallback_models: z.ZodOptional<z.ZodArray<z.ZodString>>;
     }, z.core.$strip>>>;
     default_agent: z.ZodPipe<z.ZodOptional<z.ZodString>, z.ZodTransform<string | undefined, string | undefined>>;
+    auto_select_architect: z.ZodPipe<z.ZodOptional<z.ZodUnion<readonly [z.ZodBoolean, z.ZodString]>>, z.ZodTransform<string | boolean | undefined, string | boolean | undefined>>;
     swarms: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{
         name: z.ZodOptional<z.ZodString>;
         agents: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.21.3",
+    version: "7.21.5",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -15610,7 +15610,7 @@ var init_schema = __esm(() => {
     enabled: exports_external.boolean().default(true),
     rules: exports_external.record(exports_external.string(), AgentAuthorityRuleSchema).default({}),
     universal_deny_prefixes: exports_external.array(exports_external.string().min(1)).default([]),
-    verifier_config_paths: exports_external.array(exports_external.string()).optional().describe("Additional glob patterns for verifier config files that should be protected from agent modification. These patterns are merged with the built-in verifier config globs (guardrails.ts).")
+    verifier_config_paths: exports_external.array(exports_external.string()).optional().describe("Additional glob patterns for verifier config files that are merged into the architect agent's blockedGlobs at plugin init. Writes to matching files are blocked by the authority layer.")
   });
   GeneralCouncilMemberConfigSchema = exports_external.object({
     memberId: exports_external.string().min(1),
@@ -15685,6 +15685,14 @@ var init_schema = __esm(() => {
         return;
       const trimmed = v.trim();
       return trimmed === "" ? undefined : trimmed;
+    }),
+    auto_select_architect: exports_external.union([exports_external.boolean(), exports_external.string()]).optional().transform((v) => {
+      if (v === undefined)
+        return;
+      if (typeof v === "boolean")
+        return v;
+      const trimmed = v.trim();
+      return trimmed === "" ? false : trimmed;
     }),
     swarms: exports_external.record(exports_external.string(), SwarmConfigSchema).optional(),
     max_iterations: exports_external.number().min(1).max(10).default(5),
@@ -24747,6 +24755,17 @@ function createGuardrailsHooks(directory, directoryOrConfig, config2, authorityC
     };
   }
   const precomputedAuthorityRules = buildEffectiveRules(authorityConfig);
+  const verifierPaths = authorityConfig?.verifier_config_paths;
+  if (verifierPaths && verifierPaths.length > 0) {
+    const existingArchitect = precomputedAuthorityRules.architect ?? {};
+    precomputedAuthorityRules.architect = {
+      ...existingArchitect,
+      blockedGlobs: [
+        ...existingArchitect.blockedGlobs ?? [],
+        ...verifierPaths
+      ]
+    };
+  }
   const universalDenyPrefixes = authorityConfig?.universal_deny_prefixes ?? [];
   const cfg = guardrailsConfig;
   const requiredQaGates = cfg.qa_gates?.required_tools ?? [
@@ -26256,11 +26275,11 @@ function checkWriteTargetForSymlink(targetPath, cwd) {
 }
 function buildEffectiveRules(authorityConfig) {
   if (authorityConfig?.enabled === false || !authorityConfig?.rules) {
-    return DEFAULT_AGENT_AUTHORITY_RULES;
+    return { ...DEFAULT_AGENT_AUTHORITY_RULES };
   }
   const entries = Object.entries(authorityConfig.rules);
   if (entries.length === 0) {
-    return DEFAULT_AGENT_AUTHORITY_RULES;
+    return { ...DEFAULT_AGENT_AUTHORITY_RULES };
   }
   const merged = {
     ...DEFAULT_AGENT_AUTHORITY_RULES
@@ -26424,6 +26443,7 @@ var init_guardrails = __esm(() => {
     "**/.eslintrc*",
     "**/eslint.config.*",
     "**/.prettierrc*",
+    "**/prettier.config.*",
     "**/biome.jsonc",
     "**/.secretscanignore",
     "**/.golangci*"
@@ -26529,6 +26549,7 @@ var init_guardrails = __esm(() => {
         "**/.eslintrc*",
         "**/eslint.config.*",
         "**/.prettierrc*",
+        "**/prettier.config.*",
         "**/biome.jsonc",
         "**/.secretscanignore",
         "**/.golangci*"
@@ -65890,7 +65911,7 @@ DO (explicitly):
 When the declared scope includes a verifier/linter config file (biome.json, biome.jsonc, oxlintrc, oxlintrc.json, .eslintrc, .eslintrc.json, eslint.config.*, .prettierrc, .prettierrc.json, prettier.config.*, biome.jsonc, .secretscanignore, golangci-lint configs, tsconfig.json, tsconfig.*.json, or any other linter/formatter/security-tool configuration):
 
 - Verify the change does NOT reduce strictness of any existing rule
-- Reject changes that downgrade "error" to "warn", remove rules, weaken validation thresholds, or narrow file/sirectory scopes
+- Reject changes that downgrade "error" to "warn", remove rules, weaken validation thresholds, or narrow file/directory scopes
 - Allow changes that ADD new stricter rules, enable additional rule categories, fix syntax errors, or correct misconfigured paths
 - Document the specific config change and its impact on validation strictness in your review output
 - If a rule is changed from "error" to "warn" or a rule is removed: REJECT with STRICTNESS_REDUCTION: [rule name] — [original setting] → [new setting]
@@ -80757,8 +80778,8 @@ var ESCALATE_SHELL_PATTERNS = [
   /\bgit\s+rebase\b/i,
   /\bgit\s+merge\b/i,
   /\bgit\s+commit\b/i,
-  /\b(sed\s+-i|echo\s+|printf\s+)[^\n]*\b(biome\.jsonc?|eslintrc|eslint\.config|oxlintrc|prettierrc|secretscanignore|golangci|tsconfig\.json)\b/i,
-  /\b(?:cat|tee)\b[^\n]*>\s*[^\n]*\b(biome\.jsonc?|eslintrc|eslint\.config|oxlintrc|prettierrc|secretscanignore|golangci|tsconfig\.json)\b/i
+  /\b(sed\s+-i|echo\s+|printf\s+)[^\n]*\b(biome\.jsonc?|eslintrc|eslint\.config|oxlintrc|prettierrc|secretscanignore|golangci|tsconfig\.json|tsconfig\.[^.]+\.json)\b/i,
+  /\b(?:cat|tee)\b[^\n]*>\s*[^\n]*\b(biome\.jsonc?|eslintrc|eslint\.config|oxlintrc|prettierrc|secretscanignore|golangci|tsconfig\.json|tsconfig\.[^.]+\.json)\b/i
 ];
 function isReadOnlyTool(toolName) {
   if (!toolName)
@@ -105328,10 +105349,64 @@ async function initializeOpenCodeSwarm(ctx) {
       swarm_command: createSwarmCommandTool(agentDefinitionMap)
     },
     config: async (opencodeConfig) => {
+      if (!opencodeConfig.agent || typeof opencodeConfig.agent !== "object") {
+        opencodeConfig.agent = {};
+      }
       if (!opencodeConfig.agent) {
         opencodeConfig.agent = { ...agents };
       } else {
         Object.assign(opencodeConfig.agent, agents);
+      }
+      const autoSelect = config3?.auto_select_architect;
+      if (autoSelect) {
+        const hasArchitect = Object.keys(agents).some((name2) => stripKnownSwarmPrefix(name2) === "architect");
+        if (hasArchitect) {
+          for (const builtin of ["build", "plan"]) {
+            const existing = opencodeConfig.agent?.[builtin];
+            if (existing && typeof existing === "object" && existing.disable === true) {
+              continue;
+            }
+            opencodeConfig.agent[builtin] = {
+              ...existing && typeof existing === "object" ? existing : {},
+              disable: true
+            };
+          }
+          if (autoSelect === true) {
+            const primaryArchitects = Object.entries(agents).filter(([name2, cfg]) => stripKnownSwarmPrefix(name2) === "architect" && cfg.mode === "primary");
+            if (primaryArchitects.length > 1) {
+              const names = primaryArchitects.map(([n]) => n).join(", ");
+              addDeferredWarning(`[swarm] auto_select_architect is true but ${primaryArchitects.length} architect agents are primary (${names}). Consider setting auto_select_architect to a specific agent name.`);
+            }
+          }
+          if (typeof autoSelect === "string" && autoSelect !== "") {
+            const targetName = autoSelect;
+            const targetIsArchitect = Object.hasOwn(agents, targetName) && stripKnownSwarmPrefix(targetName) === "architect";
+            if (targetIsArchitect) {
+              for (const [name2, cfg] of Object.entries(agents)) {
+                if (stripKnownSwarmPrefix(name2) === "architect" && name2 !== targetName) {
+                  if (opencodeConfig.agent && typeof opencodeConfig.agent === "object") {
+                    opencodeConfig.agent[name2] = {
+                      ...cfg && typeof cfg === "object" ? cfg : {},
+                      mode: "subagent"
+                    };
+                  }
+                }
+              }
+              if (opencodeConfig.agent && typeof opencodeConfig.agent === "object") {
+                const targetExisting = opencodeConfig.agent[targetName];
+                opencodeConfig.agent[targetName] = {
+                  ...targetExisting && typeof targetExisting === "object" ? targetExisting : {},
+                  ...agents[targetName] && typeof agents[targetName] === "object" ? agents[targetName] : {},
+                  mode: "primary"
+                };
+              }
+            } else {
+              addDeferredWarning(`[swarm] auto_select_architect is set to "${targetName}" but that is not a known architect agent. No architect demotion applied.`);
+            }
+          }
+        } else {
+          addDeferredWarning("[swarm] auto_select_architect is enabled but no architect agents were found in the generated set. The option has no effect.");
+        }
       }
       opencodeConfig.command = {
         ...opencodeConfig.command || {},

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,36 @@ Empty or whitespace-only values are treated as omitted.
 
 > Why this matters: in v7.3.x the schema applied an implicit `.default("architect")`. In a multi-swarm config there is no agent literally named `architect` — they are all prefixed — so every architect was demoted to subagent and OpenCode showed only the native `build`/`plan` agents. The omitted-vs-explicit distinction is now load-bearing; do not re-introduce a schema default.
 
+## `auto_select_architect` — auto-select swarm architect on launch
+
+`auto_select_architect` (top-level, optional `boolean | string`) controls whether OpenCode's built-in `build` and `plan` agents are disabled so the swarm architect is automatically selected as the active agent on launch.
+
+| Value | Effect |
+|-------|--------|
+| `false` (default) | No auto-select — `build`/`plan` remain enabled; user manually picks the architect |
+| `true` | Disable `build` and `plan` so the swarm architect is the only selectable primary agent; emit a warning if multiple architect agents are primary |
+| `"<architect_name>"` | Same as `true`, but target a specific architect by its generated name (e.g. `"mega_architect"`) — all other architects are demoted to subagent |
+
+**Behavior details:**
+- Only `build` and `plan` are disabled. `general` and `explore` are always preserved.
+- If the user has already set `disable: true` on `build` or `plan` in their own config, the plugin respects that override.
+- If no architect agent exists in the generated set, a warning is emitted and the option has no effect.
+- If the string value does not match a known architect name, a warning is emitted and no demotion is applied.
+
+**Example — enable for any architect:**
+```json
+{
+  "auto_select_architect": true
+}
+```
+
+**Example — target a specific architect in a multi-swarm config:**
+```json
+{
+  "auto_select_architect": "mega_architect"
+}
+```
+
 ## How to verify the resolved config
 
 Run:

--- a/docs/releases/v7.22.0.md
+++ b/docs/releases/v7.22.0.md
@@ -1,0 +1,64 @@
+# v7.22.0
+
+## What changed
+
+### `auto_select_architect` — auto-select swarm architect on launch
+
+Added a new top-level config option `auto_select_architect` that controls whether the swarm architect is automatically selected as the active agent instead of OpenCode's built-in `build`/`plan` agents.
+
+#### Three modes
+
+| Value | Effect |
+|-------|--------|
+| `false` (default) | No auto-select — `build`/`plan` remain enabled; user manually picks the architect |
+| `true` | Disable `build` and `plan` built-in agents so the swarm architect is the only primary agent available; emit a warning if multiple architect agents are primary |
+| `"<architect_name>"` | Same as `true`, but target a specific architect by its generated name (e.g. `"mega_architect"`) — all other architects are demoted to subagent |
+
+#### How it works
+
+When `auto_select_architect` is truthy, the plugin's `config:` hook sets `disable: true` on OpenCode's built-in `build` and `plan` agents. With no competing defaults, OpenCode auto-selects the first available primary agent — which is the swarm architect.
+
+- Only `build` and `plan` are disabled. `general` and `explore` are always preserved.
+- If the user has already set `disable: true` on `build` or `plan` in their own config, the plugin respects that override and does not redundantly set it.
+- If no architect agent exists in the generated set, the option has no effect and a warning is emitted.
+- If `auto_select_architect` is set to a string that is not a known architect agent name, a warning is emitted and no demotion is applied.
+
+#### Example configs
+
+**Enable for any architect (first primary wins):**
+```json
+{
+  "auto_select_architect": true
+}
+```
+
+**Target a specific architect in a multi-swarm config:**
+```json
+{
+  "auto_select_architect": "mega_architect"
+}
+```
+
+**Disable (preserve existing behavior):**
+```json
+{
+  "auto_select_architect": false
+}
+```
+
+## New exported function: `stripKnownSwarmPrefix`
+
+`src/config/schema.ts` now exports `stripKnownSwarmPrefix(agentName: string): string`, which extracts the canonical role from a prefixed agent name (e.g. `"mega_architect"` → `"architect"`, `"local_coder"` → `"coder"`). This uses longest-suffix-wins matching against the known role set, so compound roles like `critic_oversight` take precedence over `critic`.
+
+## Why
+
+When OpenCode launches with the plugin loaded, OpenCode defaults to its own built-in agents (`build`, `plan`) regardless of what swarm agents are registered. Users must manually switch to the architect every time. This feature eliminates that friction by making the architect the only selectable primary agent when auto-select is enabled.
+
+## Migration steps
+
+None. The default value is `false`, so existing configurations are unaffected. To opt in, add `auto_select_architect: true` (or a specific architect name) to your config.
+
+## Known caveats
+
+- This feature targets `build` and `plan` only. Future OpenCode versions that add new competing built-in agents will require a plugin update.
+- String values are accepted as-is; there is no runtime validation that the string matches a real generated architect name until after agent generation completes. If the target is invalid, an advisory warning is emitted but no demotion occurs.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1143,7 +1143,7 @@ export const AuthorityConfigSchema = z.object({
 		.array(z.string())
 		.optional()
 		.describe(
-			'Additional glob patterns for verifier config files that are merged into the architect agent\'s blockedGlobs at plugin init. Writes to matching files are blocked by the authority layer.',
+			"Additional glob patterns for verifier config files that are merged into the architect agent's blockedGlobs at plugin init. Writes to matching files are blocked by the authority layer.",
 		),
 });
 
@@ -1352,6 +1352,31 @@ export const PluginConfigSchema = z.object({
 			if (v === undefined) return undefined;
 			const trimmed = v.trim();
 			return trimmed === '' ? undefined : trimmed;
+		}),
+
+	// Auto-select architect — controls whether the swarm architect is automatically
+	// chosen instead of OpenCode's built-in agents for new sessions.
+	//
+	// Three modes:
+	//   - `false` (default / omitted): no auto-select — user picks manually.
+	//   - `true`: enable auto-select and disable build/plan built-in agents so
+	//     only swarm architect agents are available.
+	//   - `"<architect_name>"` (e.g. "mega_architect"): same as `true`, but
+	//     targets a specific architect by name when multiple swarms are configured.
+	//
+	// Schema-level rules:
+	//   - Accepts boolean or string via Zod union.
+	//   - Empty / whitespace-only strings are normalized to `false`.
+	//   - Non-empty strings are trimmed.
+	//   - Omitted stays omitted (no `.default(...)` — fully backward compatible).
+	auto_select_architect: z
+		.union([z.boolean(), z.string()])
+		.optional()
+		.transform((v) => {
+			if (v === undefined) return undefined;
+			if (typeof v === 'boolean') return v;
+			const trimmed = v.trim();
+			return trimmed === '' ? false : trimmed;
 		}),
 
 	// Multiple swarms support

--- a/src/index.ts
+++ b/src/index.ts
@@ -975,11 +975,118 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 
 		// Configure OpenCode - merge agents into config
 		config: async (opencodeConfig: Record<string, unknown>) => {
+			// Normalize agent config to a plain object if it's absent or a non-object primitive
+			if (!opencodeConfig.agent || typeof opencodeConfig.agent !== 'object') {
+				(opencodeConfig as any).agent = {};
+			}
+
 			// Merge agent configs (don't override default_agent)
 			if (!opencodeConfig.agent) {
 				opencodeConfig.agent = { ...agents };
 			} else {
 				Object.assign(opencodeConfig.agent, agents);
+			}
+
+			// Auto-select architect: disable competing built-in agents when enabled
+			const autoSelect = config?.auto_select_architect;
+			if (autoSelect) {
+				// Check that at least one architect agent exists in the generated set
+				const hasArchitect = Object.keys(agents).some(
+					(name) => stripKnownSwarmPrefix(name) === 'architect',
+				);
+				if (hasArchitect) {
+					// Disable build and plan built-in agents
+					for (const builtin of ['build', 'plan'] as const) {
+						const existing = (opencodeConfig.agent as Record<string, any>)?.[
+							builtin
+						];
+						if (
+							existing &&
+							typeof existing === 'object' &&
+							existing.disable === true
+						) {
+							// User already disabled this agent — respect their override
+							continue;
+						}
+						(opencodeConfig.agent as Record<string, any>)[builtin] = {
+							...(existing && typeof existing === 'object' ? existing : {}),
+							disable: true,
+						};
+					}
+
+					// Warn when boolean true and multiple architects are primary
+					if (autoSelect === true) {
+						const primaryArchitects = Object.entries(agents).filter(
+							([name, cfg]) =>
+								stripKnownSwarmPrefix(name) === 'architect' &&
+								(cfg as any).mode === 'primary',
+						);
+						if (primaryArchitects.length > 1) {
+							const names = primaryArchitects.map(([n]) => n).join(', ');
+							addDeferredWarning(
+								`[swarm] auto_select_architect is true but ${primaryArchitects.length} architect agents are primary (${names}). Consider setting auto_select_architect to a specific agent name.`,
+							);
+						}
+					}
+
+					// When a specific architect name is provided, demote non-matching architects to subagent
+					if (typeof autoSelect === 'string' && autoSelect !== '') {
+						const targetName = autoSelect;
+						// Only proceed if the target is actually an architect-role agent
+						const targetIsArchitect =
+							Object.hasOwn(agents, targetName) &&
+							stripKnownSwarmPrefix(targetName) === 'architect';
+
+						if (targetIsArchitect) {
+							// Demote non-matching architects to subagent
+							for (const [name, cfg] of Object.entries(agents)) {
+								if (
+									stripKnownSwarmPrefix(name) === 'architect' &&
+									name !== targetName
+								) {
+									if (
+										opencodeConfig.agent &&
+										typeof opencodeConfig.agent === 'object'
+									) {
+										(opencodeConfig.agent as Record<string, any>)[name] = {
+											...(cfg && typeof cfg === 'object' ? cfg : {}),
+											mode: 'subagent',
+										};
+									}
+								}
+							}
+							// Promote the target architect to primary
+							if (
+								opencodeConfig.agent &&
+								typeof opencodeConfig.agent === 'object'
+							) {
+								const targetExisting = (
+									opencodeConfig.agent as Record<string, any>
+								)[targetName];
+								(opencodeConfig.agent as Record<string, any>)[targetName] = {
+									...(targetExisting && typeof targetExisting === 'object'
+										? targetExisting
+										: {}),
+									...(agents[targetName] &&
+									typeof agents[targetName] === 'object'
+										? agents[targetName]
+										: {}),
+									mode: 'primary',
+								};
+							}
+						} else {
+							// Target is not a valid architect — warn the user
+							addDeferredWarning(
+								`[swarm] auto_select_architect is set to "${targetName}" but that is not a known architect agent. No architect demotion applied.`,
+							);
+						}
+					}
+				} else {
+					// No architect agents found — warn the user
+					addDeferredWarning(
+						'[swarm] auto_select_architect is enabled but no architect agents were found in the generated set. The option has no effect.',
+					);
+				}
 			}
 
 			// Register /swarm command

--- a/tests/unit/config/auto-select-architect-adversarial.test.ts
+++ b/tests/unit/config/auto-select-architect-adversarial.test.ts
@@ -1,0 +1,636 @@
+/**
+ * ADVERSARIAL SECURITY TESTS for auto_select_architect config field
+ *
+ * Attack vectors covered:
+ * 1. Prototype pollution via agent.__proto__ / constructor
+ * 2. Extremely long string values (10KB+)
+ * 3. Unicode/emoji in agent names
+ * 4. Null bytes in agent name strings
+ * 5. Deeply nested objects in agent config
+ * 6. auto_select_architect as object (should reject — not boolean or string)
+ * 7. auto_select_architect: 0 / 1 (numbers — should reject)
+ * 8. auto_select_architect: "build" (non-architect string — schema accepts, runtime may warn)
+ * 9. auto_select_architect: "plan" (builtin agent name — schema accepts, runtime may warn)
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { PluginConfigSchema } from '../../../src/config/schema';
+
+describe('SECURITY: auto_select_architect adversarial attacks', () => {
+	// ===========================================================================
+	// ATTACK VECTOR 1: PROTOTYPE POLLUTION
+	// ===========================================================================
+
+	describe('Prototype pollution attacks on agent config', () => {
+		it('should not pollute prototype when agent has __proto__', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: true,
+				agent: {
+					__proto__: { admin: true },
+				},
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(true);
+				// Verify no prototype pollution
+				const obj: Record<string, unknown> = {};
+				expect(obj.admin).toBeUndefined();
+			}
+		});
+
+		it('should not pollute prototype when agent has constructor.prototype', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: true,
+				agent: {
+					constructor: { prototype: { admin: true } },
+				},
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(true);
+				// Verify no prototype pollution
+				const obj: Record<string, unknown> = {};
+				expect(obj.admin).toBeUndefined();
+			}
+		});
+
+		it('should not pollute prototype via hasOwnProperty in agent', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: true,
+				agent: {
+					hasOwnProperty: 'injected',
+				},
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(true);
+			}
+		});
+
+		it('should not pollute prototype via toString in agent', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: true,
+				agent: {
+					toString: { valueOf: 'injected' },
+				},
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(true);
+			}
+		});
+
+		it('should handle deeply nested malicious object in agent', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: true,
+				agent: {
+					__proto__: { polluted: true },
+					constructor: { prototype: { admin: true } },
+					nested: {
+						__proto__: { attack: true },
+					},
+				},
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(true);
+				// Verify no prototype pollution
+				const obj: Record<string, unknown> = {};
+				expect(obj.polluted).toBeUndefined();
+				expect(obj.admin).toBeUndefined();
+				expect(obj.attack).toBeUndefined();
+			}
+		});
+	});
+
+	// ===========================================================================
+	// ATTACK VECTOR 2: OVERSIZED INPUT
+	// ===========================================================================
+
+	describe('Oversized string attacks on auto_select_architect', () => {
+		it('should accept 10KB string (within reasonable bounds)', () => {
+			const largeString = 'a'.repeat(10 * 1024);
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: largeString,
+			});
+			// Schema accepts any string; the transform trims and returns false if empty
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(largeString);
+			}
+		});
+
+		it('should accept 100KB string', () => {
+			const largeString = 'a'.repeat(100 * 1024);
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: largeString,
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(largeString);
+			}
+		});
+
+		it('should accept 1MB string (DoS via memory exhaustion potential)', () => {
+			const hugeString = 'mega_architect'.repeat(100_000); // ~1.3MB
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: hugeString,
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				// Transform trims but doesn't reject large strings
+				expect(typeof result.data.auto_select_architect).toBe('string');
+			}
+		});
+	});
+
+	// ===========================================================================
+	// ATTACK VECTOR 3: UNICODE / EMOJI IN AGENT NAMES
+	// ===========================================================================
+
+	describe('Unicode/emoji injection in auto_select_architect string value', () => {
+		it('should accept emoji in agent name string', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'mega_architect_🔥',
+			});
+			// Schema accepts any non-empty string after trim
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('mega_architect_🔥');
+			}
+		});
+
+		it('should accept RTL override characters in agent name', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: '\u202Emega_architect\u202C', // RLO + PDF
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(
+					'\u202Emega_architect\u202C',
+				);
+			}
+		});
+
+		it('should accept zero-width space in agent name', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'mega_architect\u200B',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				// Zero-width space is preserved (not trimmed by String.prototype.trim)
+				expect(result.data.auto_select_architect).toBe('mega_architect\u200B');
+			}
+		});
+
+		it('should accept combining unicode characters in agent name', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'mega_architect\u0301', // combining acute accent
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('mega_architect\u0301');
+			}
+		});
+
+		it('should accept null codepoint in agent name', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'mega_architect\0',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('mega_architect\0');
+			}
+		});
+	});
+
+	// ===========================================================================
+	// ATTACK VECTOR 4: NULL BYTES IN AGENT NAME STRINGS
+	// ===========================================================================
+
+	describe('Null byte injection in auto_select_architect string value', () => {
+		it('should accept null byte prefix in agent name', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: '\0mega_architect',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('\0mega_architect');
+			}
+		});
+
+		it('should accept embedded null byte in agent name', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'mega\0_architect',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('mega\0_architect');
+			}
+		});
+
+		it('should accept multiple null bytes in agent name', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: '\0\0\0mega_architect',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('\0\0\0mega_architect');
+			}
+		});
+	});
+
+	// ===========================================================================
+	// ATTACK VECTOR 5: DEEPLY NESTED OBJECTS IN AGENT CONFIG
+	// ===========================================================================
+
+	describe('Deeply nested objects in agent config', () => {
+		it('should handle 50 levels of nesting in agent object', () => {
+			const config: Record<string, unknown> = { auto_select_architect: true };
+			let current = config;
+			for (let i = 0; i < 50; i++) {
+				(current as Record<string, unknown>).level = {};
+				current = (current as Record<string, unknown>).level as Record<
+					string,
+					unknown
+				>;
+			}
+			const result = PluginConfigSchema.safeParse(config);
+			// Should either succeed or fail gracefully without crash
+			expect(result.success === true || result.success === false).toBe(true);
+		});
+
+		it('should handle 100 levels of nesting in agent object', () => {
+			const config: Record<string, unknown> = { auto_select_architect: true };
+			let current = config;
+			for (let i = 0; i < 100; i++) {
+				(current as Record<string, unknown>).level = {};
+				current = (current as Record<string, unknown>).level as Record<
+					string,
+					unknown
+				>;
+			}
+			const result = PluginConfigSchema.safeParse(config);
+			expect(result.success === true || result.success === false).toBe(true);
+		});
+
+		it('should handle circular reference in agent object', () => {
+			const config: Record<string, unknown> = {
+				auto_select_architect: true,
+				agent: {},
+			};
+			(config.agent as Record<string, unknown>).self = config.agent;
+			const result = PluginConfigSchema.safeParse(config);
+			// Zod doesn't crash on circular refs but the circular part is ignored
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(true);
+			}
+		});
+	});
+
+	// ===========================================================================
+	// ATTACK VECTOR 6: auto_select_architect AS OBJECT (SHOULD REJECT)
+	// ===========================================================================
+
+	describe('Type confusion: auto_select_architect as object (should reject)', () => {
+		it('should reject auto_select_architect: {} (empty object)', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: {},
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject auto_select_architect: { valueOf: true }', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: { valueOf: true },
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject auto_select_architect: [] (empty array)', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: [],
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject auto_select_architect: ["architect"] (array with string)', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: ['architect'],
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject auto_select_architect: null', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: null,
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	// ===========================================================================
+	// ATTACK VECTOR 7: auto_select_architect AS NUMBER (SHOULD REJECT)
+	// ===========================================================================
+
+	describe('Type confusion: auto_select_architect as number (should reject)', () => {
+		it('should reject auto_select_architect: 0', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 0,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject auto_select_architect: 1', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 1,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject auto_select_architect: -1', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: -1,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject auto_select_architect: 0.1 (float)', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 0.1,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject auto_select_architect: NaN', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: NaN,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject auto_select_architect: Infinity', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: Infinity,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject auto_select_architect: -Infinity', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: -Infinity,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject auto_select_architect: Number.MAX_SAFE_INTEGER', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: Number.MAX_SAFE_INTEGER,
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	// ===========================================================================
+	// ATTACK VECTOR 8: auto_select_architect: "build" (NON-ARCHITECT AGENT NAME)
+	// Schema accepts any string; runtime config hook may warn
+	// ===========================================================================
+
+	describe('Non-architect agent name as auto_select_architect value', () => {
+		it('should accept "build" as auto_select_architect value (schema level)', () => {
+			// Schema accepts any string — validation of semantic correctness happens at runtime
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'build',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('build');
+			}
+		});
+
+		it('should accept "plan" as auto_select_architect value (schema level)', () => {
+			// Schema accepts any string — "plan" is a built-in agent name, not an architect
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'plan',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('plan');
+			}
+		});
+
+		it('should accept "coder" as auto_select_architect value (schema level)', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'coder',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('coder');
+			}
+		});
+
+		it('should accept "reviewer" as auto_select_architect value (schema level)', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'reviewer',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('reviewer');
+			}
+		});
+
+		it('should accept arbitrary string as auto_select_architect value', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'not_a_real_agent_name_12345',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(
+					'not_a_real_agent_name_12345',
+				);
+			}
+		});
+	});
+
+	// ===========================================================================
+	// ATTACK VECTOR 9: BUILT-IN AGENT NAME AS VALUE
+	// Schema accepts any string; these are valid canonical roles but not architects
+	// ===========================================================================
+
+	describe('Built-in agent names as auto_select_architect value', () => {
+		it('should accept "critic" as auto_select_architect value', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'critic',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('critic');
+			}
+		});
+
+		it('should accept "sme" as auto_select_architect value', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'sme',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('sme');
+			}
+		});
+
+		it('should accept "docs" as auto_select_architect value', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'docs',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('docs');
+			}
+		});
+	});
+
+	// ===========================================================================
+	// INJECTION ATTEMPTS IN STRING VALUE
+	// ===========================================================================
+
+	describe('Injection attacks in auto_select_architect string value', () => {
+		it('should accept template literal injection attempt (schema level)', () => {
+			// Schema accepts any string — the value is not executed
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: '${process.exit(1)}',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('${process.exit(1)}');
+			}
+		});
+
+		it('should accept os command injection attempt (schema level)', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: 'true; rm -rf /',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('true; rm -rf /');
+			}
+		});
+
+		it('should accept SQL injection pattern (schema level)', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: "' OR '1'='1",
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe("' OR '1'='1");
+			}
+		});
+
+		it('should accept HTML/script injection (schema level)', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: '<script>alert(1)</script>',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(
+					'<script>alert(1)</script>',
+				);
+			}
+		});
+
+		it('should accept path traversal attempt (schema level)', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: '../../../etc/passwd',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('../../../etc/passwd');
+			}
+		});
+	});
+
+	// ===========================================================================
+	// BOUNDARY CASES
+	// ===========================================================================
+
+	describe('Boundary cases for auto_select_architect', () => {
+		it('should accept empty string and transform to false', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: '',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(false);
+			}
+		});
+
+		it('should accept whitespace-only string and transform to false', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: '   ',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(false);
+			}
+		});
+
+		it('should accept string with whitespace padding and trim it', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: '  mega_architect  ',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe('mega_architect');
+			}
+		});
+
+		it('should accept undefined (field absent) and stay undefined', () => {
+			const result = PluginConfigSchema.safeParse({});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBeUndefined();
+			}
+		});
+
+		it('should accept true boolean', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: true,
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(true);
+			}
+		});
+
+		it('should accept false boolean', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: false,
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.auto_select_architect).toBe(false);
+			}
+		});
+
+		it('should reject auto_select_architect: Symbol', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: Symbol('test'),
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject auto_select_architect: BigInt', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: BigInt(1),
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('should reject auto_select_architect: Function', () => {
+			const result = PluginConfigSchema.safeParse({
+				auto_select_architect: () => {},
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+});

--- a/tests/unit/config/auto-select-architect-integration.test.ts
+++ b/tests/unit/config/auto-select-architect-integration.test.ts
@@ -1,0 +1,554 @@
+/**
+ * Integration tests for auto_select_architect config hook behavior.
+ *
+ * These tests simulate the logic inside the `config:` hook closure in
+ * src/index.ts (lines 977-1080) without importing the hook itself
+ * (which is not exportable). The hook operations are:
+ *
+ *  1. Normalize opencodeConfig.agent to {} if absent or non-object
+ *  2. Object.assign(opencodeConfig.agent, agents)
+ *  3. If auto_select_architect is truthy AND an architect exists:
+ *     a. Disable build/plan (respecting existing disable:true overrides)
+ *     b. If auto_select_architect === true && multiple primary architects: warn
+ *     c. If string value and target is a valid architect: demote non-target
+ *        architects, promote target to primary
+ *     d. If string value and target is NOT a valid architect: warn (no demotion)
+ *  4. If auto_select_architect is truthy but NO architect exists: warn
+ *
+ * We use the actual stripKnownSwarmPrefix and PluginConfigSchema from
+ * src/config/schema.ts to verify end-to-end behavior.
+ */
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import {
+	PluginConfigSchema,
+	stripKnownSwarmPrefix,
+	// Agents index to get getAgentConfigs type
+} from '../../../src/config/schema';
+
+// ─── Helpers that mirror the config: hook logic ────────────────────────────────
+
+/**
+ * Simulates the auto_select_architect branch of the config: hook.
+ * Returns { warnings } so we can assert on the warning condition without
+ * actually calling addDeferredWarning.
+ */
+function applyAutoSelectArchitectLogic({
+	opencodeConfig,
+	agents,
+	autoSelect,
+}: {
+	opencodeConfig: Record<string, unknown>;
+	agents: Record<string, unknown>;
+	autoSelect: boolean | string | undefined;
+}): { warnings: string[] } {
+	const warnings: string[] = [];
+
+	// Normalize agent config (from hook lines 978-981)
+	if (!opencodeConfig.agent || typeof opencodeConfig.agent !== 'object') {
+		(opencodeConfig as Record<string, unknown>).agent = {};
+	}
+
+	// Merge agent configs (from hook lines 983-988)
+	if (!opencodeConfig.agent) {
+		opencodeConfig.agent = { ...agents };
+	} else {
+		Object.assign(opencodeConfig.agent, agents);
+	}
+
+	// Auto-select architect (from hook lines 990-1080)
+	if (autoSelect) {
+		// Check that at least one architect agent exists in the generated set
+		const hasArchitect = Object.keys(agents).some(
+			(name) => stripKnownSwarmPrefix(name) === 'architect',
+		);
+
+		if (hasArchitect) {
+			// Disable build and plan built-in agents
+			for (const builtin of ['build', 'plan'] as const) {
+				const existing = (opencodeConfig.agent as Record<string, unknown>)?.[
+					builtin
+				] as Record<string, unknown> | undefined;
+
+				if (
+					existing &&
+					typeof existing === 'object' &&
+					existing.disable === true
+				) {
+					// User already disabled this agent — respect their override
+					continue;
+				}
+
+				(opencodeConfig.agent as Record<string, unknown>)[builtin] = {
+					...(existing && typeof existing === 'object' ? existing : {}),
+					disable: true,
+				};
+			}
+
+			// Warn when boolean true and multiple architects are primary
+			if (autoSelect === true) {
+				const primaryArchitects = Object.entries(agents).filter(
+					([name, cfg]) =>
+						stripKnownSwarmPrefix(name) === 'architect' &&
+						(cfg as Record<string, unknown>)?.mode === 'primary',
+				);
+
+				if (primaryArchitects.length > 1) {
+					const names = primaryArchitects.map(([n]) => n).join(', ');
+					warnings.push(
+						`[swarm] auto_select_architect is true but ${primaryArchitects.length} architect agents are primary (${names}). Consider setting auto_select_architect to a specific agent name.`,
+					);
+				}
+			}
+
+			// When a specific architect name is provided, demote non-matching
+			// architects to subagent
+			if (typeof autoSelect === 'string' && autoSelect !== '') {
+				const targetName = autoSelect;
+
+				// Only proceed if the target is actually an architect-role agent
+				const targetIsArchitect =
+					Object.hasOwn(agents, targetName) &&
+					stripKnownSwarmPrefix(targetName) === 'architect';
+
+				if (targetIsArchitect) {
+					// Demote non-matching architects to subagent
+					for (const [name, cfg] of Object.entries(agents)) {
+						if (
+							stripKnownSwarmPrefix(name) === 'architect' &&
+							name !== targetName
+						) {
+							if (
+								opencodeConfig.agent &&
+								typeof opencodeConfig.agent === 'object'
+							) {
+								(opencodeConfig.agent as Record<string, unknown>)[name] = {
+									...(cfg && typeof cfg === 'object' ? cfg : {}),
+									mode: 'subagent',
+								};
+							}
+						}
+					}
+
+					// Promote the target architect to primary
+					if (
+						opencodeConfig.agent &&
+						typeof opencodeConfig.agent === 'object'
+					) {
+						const targetExisting = (
+							opencodeConfig.agent as Record<string, unknown>
+						)[targetName] as Record<string, unknown> | undefined;
+
+						(opencodeConfig.agent as Record<string, unknown>)[targetName] = {
+							...(targetExisting && typeof targetExisting === 'object'
+								? targetExisting
+								: {}),
+							...(agents[targetName] && typeof agents[targetName] === 'object'
+								? (agents[targetName] as Record<string, unknown>)
+								: {}),
+							mode: 'primary',
+						};
+					}
+				} else {
+					// Target is not a valid architect — warn the user
+					warnings.push(
+						`[swarm] auto_select_architect is set to "${targetName}" but that is not a known architect agent. No architect demotion applied.`,
+					);
+				}
+			}
+		} else {
+			// No architect agents found — warn the user
+			warnings.push(
+				'[swarm] auto_select_architect is enabled but no architect agents were found in the generated set. The option has no effect.',
+			);
+		}
+	}
+
+	return { warnings };
+}
+
+// ─── Test cases ───────────────────────────────────────────────────────────────
+
+describe('auto_select_architect integration — config: hook simulation', () => {
+	afterEach(() => {
+		mock.restore();
+	});
+
+	// Test 1: Full flow — auto_select_architect=true disables build/plan
+	test('auto_select_architect=true disables build and plan agents', () => {
+		const agents = {
+			mega_architect: { name: 'mega_architect', mode: 'primary' as const },
+		};
+		const opencodeConfig: Record<string, unknown> = {};
+
+		const { warnings } = applyAutoSelectArchitectLogic({
+			opencodeConfig,
+			agents,
+			autoSelect: true,
+		});
+
+		// build and plan should be disabled
+		const agent = opencodeConfig.agent as Record<string, unknown>;
+		expect(agent.build).toEqual({ disable: true });
+		expect(agent.plan).toEqual({ disable: true });
+
+		// No warnings since only one primary architect
+		expect(warnings).toHaveLength(0);
+	});
+
+	// Test 2: Full flow — auto_select_architect="mega_architect" demotes
+	// non-matching architects and promotes the target
+	test('auto_select_architect="mega_architect" demotes non-target architects', () => {
+		const agents = {
+			mega_architect: {
+				name: 'mega_architect',
+				mode: 'primary' as const,
+			},
+			local_architect: {
+				name: 'local_architect',
+				mode: 'primary' as const,
+			},
+		};
+		const opencodeConfig: Record<string, unknown> = {};
+
+		const { warnings } = applyAutoSelectArchitectLogic({
+			opencodeConfig,
+			agents,
+			autoSelect: 'mega_architect',
+		});
+
+		const agent = opencodeConfig.agent as Record<string, unknown>;
+
+		// mega_architect should be promoted to primary
+		expect((agent.mega_architect as Record<string, unknown>)?.mode).toBe(
+			'primary',
+		);
+
+		// local_architect should be demoted to subagent
+		expect((agent.local_architect as Record<string, unknown>)?.mode).toBe(
+			'subagent',
+		);
+
+		// No warnings (string autoSelect doesn't trigger the boolean warning)
+		expect(warnings).toHaveLength(0);
+	});
+
+	// Test 3: User override respected — existing disable:true on build
+	// should not be overwritten
+	test('user override: existing disable:true on build is respected', () => {
+		const agents = {
+			architect: { name: 'architect', mode: 'primary' as const },
+		};
+		const opencodeConfig: Record<string, unknown> = {
+			agent: {
+				build: { disable: true, customField: 'preserved' },
+			},
+		};
+
+		const { warnings } = applyAutoSelectArchitectLogic({
+			opencodeConfig,
+			agents,
+			autoSelect: true,
+		});
+
+		const agent = opencodeConfig.agent as Record<string, unknown>;
+
+		// build.disable should remain true; customField preserved
+		expect(agent.build).toEqual({ disable: true, customField: 'preserved' });
+
+		// plan should still be disabled (no prior override)
+		expect(agent.plan).toEqual({ disable: true });
+
+		expect(warnings).toHaveLength(0);
+	});
+
+	// Test 4: No architect agents — build/plan should NOT be disabled
+	test('no architect agents: build and plan are NOT disabled', () => {
+		const agents = {
+			coder: { name: 'coder', mode: 'primary' as const },
+			reviewer: { name: 'reviewer', mode: 'primary' as const },
+		};
+		const opencodeConfig: Record<string, unknown> = {};
+
+		const { warnings } = applyAutoSelectArchitectLogic({
+			opencodeConfig,
+			agents,
+			autoSelect: true,
+		});
+
+		const agent = opencodeConfig.agent as Record<string, unknown>;
+
+		// build and plan should NOT be modified
+		expect(agent.build).toBeUndefined();
+		expect(agent.plan).toBeUndefined();
+
+		// No architect = advisory warning about no architects found
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('no architect agents were found');
+	});
+
+	// Test 5: Invalid string target — auto_select_architect="nonexistent_architect"
+	// should not cause demotion, but warns about invalid target
+	test('invalid string target: no demotion happens, warns about invalid target', () => {
+		const agents = {
+			mega_architect: {
+				name: 'mega_architect',
+				mode: 'primary' as const,
+			},
+			local_architect: {
+				name: 'local_architect',
+				mode: 'primary' as const,
+			},
+		};
+		const opencodeConfig: Record<string, unknown> = {};
+
+		const { warnings } = applyAutoSelectArchitectLogic({
+			opencodeConfig,
+			agents,
+			autoSelect: 'nonexistent_architect',
+		});
+
+		const agent = opencodeConfig.agent as Record<string, unknown>;
+
+		// Both architects should keep their original mode (no demotion)
+		expect((agent.mega_architect as Record<string, unknown>)?.mode).toBe(
+			'primary',
+		);
+		expect((agent.local_architect as Record<string, unknown>)?.mode).toBe(
+			'primary',
+		);
+
+		// build and plan should still be disabled (architect exists)
+		expect(agent.build).toEqual({ disable: true });
+		expect(agent.plan).toEqual({ disable: true });
+
+		// Warning should be emitted for invalid target (not a known architect agent)
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('not a known architect agent');
+		expect(warnings[0]).toContain('nonexistent_architect');
+	});
+
+	// Test 6: Primitive opencodeConfig.agent — should be normalized to {}
+	// before merging
+	test('primitive opencodeConfig.agent is normalized to {} before merging', () => {
+		const agents = {
+			architect: { name: 'architect', mode: 'primary' as const },
+		};
+
+		// Simulate the hook's normalization step directly
+		const opencodeConfig: Record<string, unknown> = {
+			agent: 'bad' as unknown as Record<string, unknown>,
+		};
+
+		// The hook checks typeof !== 'object' and replaces with {}
+		if (!opencodeConfig.agent || typeof opencodeConfig.agent !== 'object') {
+			(opencodeConfig as Record<string, unknown>).agent = {};
+		}
+
+		expect(opencodeConfig.agent).toEqual({});
+
+		// Now merge would happen
+		Object.assign(opencodeConfig.agent, agents);
+
+		const agent = opencodeConfig.agent as Record<string, unknown>;
+		expect(agent.architect).toEqual({ name: 'architect', mode: 'primary' });
+	});
+
+	// Test 7: Multiple primary architects warning — auto_select_architect=true
+	// with 2+ primary architects triggers warning condition
+	test('multiple primary architects: warning condition is satisfied', () => {
+		const agents = {
+			mega_architect: {
+				name: 'mega_architect',
+				mode: 'primary' as const,
+			},
+			local_architect: {
+				name: 'local_architect',
+				mode: 'primary' as const,
+			},
+		};
+		const opencodeConfig: Record<string, unknown> = {};
+
+		const { warnings } = applyAutoSelectArchitectLogic({
+			opencodeConfig,
+			agents,
+			autoSelect: true,
+		});
+
+		// Warning should be emitted for multiple primary architects
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('2 architect agents are primary');
+		expect(warnings[0]).toContain('mega_architect');
+		expect(warnings[0]).toContain('local_architect');
+
+		// Both architects should still be primary (warning only, not demotion)
+		const agent = opencodeConfig.agent as Record<string, unknown>;
+		expect((agent.mega_architect as Record<string, unknown>)?.mode).toBe(
+			'primary',
+		);
+		expect((agent.local_architect as Record<string, unknown>)?.mode).toBe(
+			'primary',
+		);
+	});
+
+	// Test 8: PluginConfigSchema parses auto_select_architect correctly
+	// (ensures the schema integration with the hook logic is sound)
+	test('PluginConfigSchema: auto_select_architect transforms are correct', () => {
+		const result1 = PluginConfigSchema.safeParse({
+			auto_select_architect: true,
+		});
+		expect(result1.success).toBe(true);
+		if (result1.success) {
+			expect(result1.data.auto_select_architect).toBe(true);
+		}
+
+		const result2 = PluginConfigSchema.safeParse({
+			auto_select_architect: 'mega_architect',
+		});
+		expect(result2.success).toBe(true);
+		if (result2.success) {
+			expect(result2.data.auto_select_architect).toBe('mega_architect');
+		}
+
+		const result3 = PluginConfigSchema.safeParse({
+			auto_select_architect: false,
+		});
+		expect(result3.success).toBe(true);
+		if (result3.success) {
+			expect(result3.data.auto_select_architect).toBe(false);
+		}
+
+		const result4 = PluginConfigSchema.safeParse({
+			auto_select_architect: 'nonexistent',
+		});
+		expect(result4.success).toBe(true);
+		if (result4.success) {
+			// Schema accepts any string; validation against agents set is semantic
+			expect(result4.data.auto_select_architect).toBe('nonexistent');
+		}
+	});
+
+	// Test 9: Mixed — auto_select_architect with string target that is also
+	// the ONLY architect (no demotion needed, just promotion)
+	test('single architect with string target: just promotes to primary', () => {
+		const agents = {
+			mega_architect: {
+				name: 'mega_architect',
+				// No mode set (undefined)
+			},
+		};
+		const opencodeConfig: Record<string, unknown> = {};
+
+		const { warnings } = applyAutoSelectArchitectLogic({
+			opencodeConfig,
+			agents,
+			autoSelect: 'mega_architect',
+		});
+
+		const agent = opencodeConfig.agent as Record<string, unknown>;
+
+		// mega_architect should be promoted to primary
+		expect((agent.mega_architect as Record<string, unknown>)?.mode).toBe(
+			'primary',
+		);
+
+		// build/plan should be disabled
+		expect(agent.build).toEqual({ disable: true });
+		expect(agent.plan).toEqual({ disable: true });
+
+		expect(warnings).toHaveLength(0);
+	});
+
+	// Test 10: auto_select_architect=false (explicit) — no hook changes
+	test('auto_select_architect=false: no hook changes applied', () => {
+		const agents = {
+			architect: { name: 'architect', mode: 'primary' as const },
+		};
+		const opencodeConfig: Record<string, unknown> = {};
+
+		const { warnings } = applyAutoSelectArchitectLogic({
+			opencodeConfig,
+			agents,
+			autoSelect: false,
+		});
+
+		const agent = opencodeConfig.agent as Record<string, unknown>;
+
+		// Nothing should be disabled (autoSelect is falsy)
+		expect(agent.build).toBeUndefined();
+		expect(agent.plan).toBeUndefined();
+
+		// Agent merged but not modified
+		expect(agent.architect).toEqual({ name: 'architect', mode: 'primary' });
+
+		expect(warnings).toHaveLength(0);
+	});
+
+	// Test 11: Non-architect string target (e.g., "mega_coder") warns but still disables build/plan
+	test('non-architect string target: warns and disables build/plan without demotion', () => {
+		const agents = {
+			mega_architect: {
+				name: 'mega_architect',
+				mode: 'primary' as const,
+			},
+			mega_coder: {
+				name: 'mega_coder',
+				mode: 'subagent' as const,
+			},
+		};
+		const opencodeConfig: Record<string, unknown> = {};
+
+		const { warnings } = applyAutoSelectArchitectLogic({
+			opencodeConfig,
+			agents,
+			autoSelect: 'mega_coder',
+		});
+
+		const agent = opencodeConfig.agent as Record<string, unknown>;
+
+		// build/plan should still be disabled (hasArchitect is true from mega_architect)
+		expect(agent.build).toEqual({ disable: true });
+		expect(agent.plan).toEqual({ disable: true });
+
+		// mega_architect should NOT be demoted (invalid target skips demotion)
+		expect((agent.mega_architect as Record<string, unknown>)?.mode).toBe(
+			'primary',
+		);
+
+		// mega_coder should NOT be promoted to primary
+		expect((agent.mega_coder as Record<string, unknown>)?.mode).toBe(
+			'subagent',
+		);
+
+		// Warning should be emitted for invalid target
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('not a known architect agent');
+		expect(warnings[0]).toContain('mega_coder');
+	});
+
+	// Test 12: No architect agents with string target warns
+	test('no architect agents with string target: warns and no changes', () => {
+		const agents = {
+			mega_coder: {
+				name: 'mega_coder',
+				mode: 'primary' as const,
+			},
+		};
+		const opencodeConfig: Record<string, unknown> = {};
+
+		const { warnings } = applyAutoSelectArchitectLogic({
+			opencodeConfig,
+			agents,
+			autoSelect: 'mega_coder',
+		});
+
+		const agent = opencodeConfig.agent as Record<string, unknown>;
+
+		// build/plan should NOT be disabled (no architects at all)
+		expect(agent.build).toBeUndefined();
+		expect(agent.plan).toBeUndefined();
+
+		// Warning should be emitted for no architects
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('no architect agents were found');
+	});
+});

--- a/tests/unit/config/auto-select-architect.test.ts
+++ b/tests/unit/config/auto-select-architect.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for auto_select_architect config logic.
+ *
+ * Covers:
+ * 1. stripKnownSwarmPrefix — suffix-based canonical role extraction
+ * 2. PluginConfigSchema parsing for auto_select_architect field
+ *
+ * The full config: hook (build/plan disabling) requires plugin initialization
+ * and is tested in the integration test for task 2.3.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+	PluginConfigSchema,
+	stripKnownSwarmPrefix,
+} from '../../../src/config/schema';
+
+// ─── stripKnownSwarmPrefix ──────────────────────────────────────────────────
+
+describe('stripKnownSwarmPrefix — suffix-based role extraction', () => {
+	// Required cases from task spec
+	test.each([
+		['mega_architect', 'architect'],
+		['local_coder', 'coder'],
+		['architect', 'architect'], // no prefix — unchanged
+		['unknown_agent', 'unknown_agent'], // no known suffix
+	])('%s -> %s', (input, expected) => {
+		expect(stripKnownSwarmPrefix(input)).toBe(expected);
+	});
+
+	test('handles case-insensitive prefix stripping', () => {
+		expect(stripKnownSwarmPrefix('MEGA_ARCHITECT')).toBe('architect');
+		expect(stripKnownSwarmPrefix('Local_Coder')).toBe('coder');
+	});
+
+	test('handles dash and space separators', () => {
+		expect(stripKnownSwarmPrefix('mega-architect')).toBe('architect');
+		expect(stripKnownSwarmPrefix('local coder')).toBe('coder');
+	});
+});
+
+// ─── auto_select_architect schema parsing ───────────────────────────────────
+
+describe('PluginConfigSchema — auto_select_architect field', () => {
+	test('auto_select_architect: true parses to true', () => {
+		const result = PluginConfigSchema.safeParse({
+			auto_select_architect: true,
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.auto_select_architect).toBe(true);
+		}
+	});
+
+	test('auto_select_architect: "mega_architect" parses to the string', () => {
+		const result = PluginConfigSchema.safeParse({
+			auto_select_architect: 'mega_architect',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.auto_select_architect).toBe('mega_architect');
+		}
+	});
+
+	test('auto_select_architect: "" (empty string) parses to false', () => {
+		const result = PluginConfigSchema.safeParse({
+			auto_select_architect: '',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.auto_select_architect).toBe(false);
+		}
+	});
+
+	test('auto_select_architect: undefined stays undefined (field absent)', () => {
+		const result = PluginConfigSchema.safeParse({});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.auto_select_architect).toBeUndefined();
+		}
+	});
+
+	test('auto_select_architect: false parses to false', () => {
+		const result = PluginConfigSchema.safeParse({
+			auto_select_architect: false,
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.auto_select_architect).toBe(false);
+		}
+	});
+
+	test('auto_select_architect: whitespace-only string parses to false', () => {
+		const result = PluginConfigSchema.safeParse({
+			auto_select_architect: '   ',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.auto_select_architect).toBe(false);
+		}
+	});
+
+	test('auto_select_architect: string is trimmed', () => {
+		const result = PluginConfigSchema.safeParse({
+			auto_select_architect: '  mega_architect  ',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.auto_select_architect).toBe('mega_architect');
+		}
+	});
+});

--- a/tests/unit/config/default-agent-config.test.ts
+++ b/tests/unit/config/default-agent-config.test.ts
@@ -107,6 +107,64 @@ describe('PluginConfigSchema — default_agent field (post-v7.3.5 semantics)', (
 	});
 });
 
+describe('PluginConfigSchema — auto_select_architect field', () => {
+	test('omitted ⇒ parsed result is undefined', () => {
+		const result = PluginConfigSchema.safeParse({});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.auto_select_architect).toBeUndefined();
+		}
+	});
+
+	test('auto_select_architect: true ⇒ parsed result is true', () => {
+		const result = PluginConfigSchema.safeParse({
+			auto_select_architect: true,
+		});
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.auto_select_architect).toBe(true);
+	});
+
+	test('auto_select_architect: false ⇒ parsed result is false', () => {
+		const result = PluginConfigSchema.safeParse({
+			auto_select_architect: false,
+		});
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.auto_select_architect).toBe(false);
+	});
+
+	test('auto_select_architect: "mega_architect" ⇒ parsed result is "mega_architect"', () => {
+		const result = PluginConfigSchema.safeParse({
+			auto_select_architect: 'mega_architect',
+		});
+		expect(result.success).toBe(true);
+		if (result.success)
+			expect(result.data.auto_select_architect).toBe('mega_architect');
+	});
+
+	test('auto_select_architect: "" ⇒ parsed result is false', () => {
+		const result = PluginConfigSchema.safeParse({ auto_select_architect: '' });
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.auto_select_architect).toBe(false);
+	});
+
+	test('auto_select_architect: "   " ⇒ parsed result is false', () => {
+		const result = PluginConfigSchema.safeParse({
+			auto_select_architect: '   ',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.auto_select_architect).toBe(false);
+	});
+
+	test('auto_select_architect: "  local_architect  " ⇒ parsed result is "local_architect" (trimmed)', () => {
+		const result = PluginConfigSchema.safeParse({
+			auto_select_architect: '  local_architect  ',
+		});
+		expect(result.success).toBe(true);
+		if (result.success)
+			expect(result.data.auto_select_architect).toBe('local_architect');
+	});
+});
+
 // ─── Resolver: resolvePrimaryAgentNames ────────────────────────────────────
 
 describe('resolvePrimaryAgentNames', () => {


### PR DESCRIPTION
## Summary

Adds `auto_select_architect` config option (default: `false`) that automatically disables OpenCode's built-in `build` and `plan` agents and selects the swarm architect on launch. Closes #889.

### Behavior
- **`true`**: auto-selects first available architect, disables built-in `build`/`plan` agents
- **String value** (e.g. `"mega_architect"`): targets a specific architect, promotes it to primary, demotes others to subagent
- Respects user's existing `disable` overrides on `build`/`plan` agents
- Advisory warnings for edge cases (no architects found, invalid target)

### Configuration
```json
{
  "swarm": {
    "auto_select_architect": true
  }
}
```

## Test plan
- [x] 123 tests across 4 test files (schema, utility, adversarial, integration)
- [x] All tests pass (`bun test` — 123/123)
- [x] Biome lint clean (0 errors)
- [x] TypeScript typecheck clean
- [x] Build succeeds
- [x] Pre-existing `index.test.ts` failures (4) confirmed on clean main — not caused by this change

## Invariant audit
- 1 (plugin init): not touched — no changes to plugin registration, entry point, or startup flow. Config hook logic runs at `config:` event time, not during plugin init.
- 2 (runtime portability): touched — `src/index.ts` modified (config hook addition only, no `bun:` imports, no `Bun.*` calls). Verified: `bun run build` succeeds, `dist/index.js` is valid ESM.
- 3 (subprocesses): not touched — no spawn calls added or modified.
- 4 (.swarm containment): not touched — no `.swarm/` path changes.
- 5 (plan durability): not touched — no plan/ledger changes.
- 6 (test_runner safety): not touched — no test_runner tool changes.
- 7 (test writing): touched — 4 test files added. All use `bun:test`. No `mock.module`. Integration tests use manual config object simulation. Adversarial tests use parameterized attack vectors.
- 8 (session state): not touched — no session/global state changes.
- 9 (guardrails/retry): not touched — no guardrail or retry logic changes.
- 10 (chat/system msg): not touched — no chat or system message hook changes.
- 11 (tool registration): not touched — no new tools or agent-map changes. `stripKnownSwarmPrefix` is exported from existing schema module.
- 12 (release/cache): touched — `CHANGELOG.md` updated (Unreleased section, standard format). `docs/releases/v7.22.0.md` release notes fragment added. No `package.json` version edits (release-please owns versioning).
