### PR TITLE
fix(architect): honor parallel execution profiles

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.21.5",
+    version: "7.22.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -21041,9 +21041,10 @@ var init_guardrails = __esm(() => {
 function clearPendingCoderScope() {
   pendingCoderScopeByTaskId.clear();
 }
-var pendingCoderScopeByTaskId;
+var pendingCoderScopeByTaskId, ACTIVE_PARALLEL_TASK_STATES;
 var init_delegation_gate = __esm(() => {
   init_schema();
+  init_manager();
   init_state();
   init_telemetry();
   init_logger();
@@ -21052,6 +21053,12 @@ var init_delegation_gate = __esm(() => {
   init_normalize_tool_name();
   init_utils2();
   pendingCoderScopeByTaskId = new Map;
+  ACTIVE_PARALLEL_TASK_STATES = new Set([
+    "coder_delegated",
+    "pre_check_passed",
+    "reviewer_run",
+    "tests_run"
+  ]);
 });
 
 // src/state/agent-run-context.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.21.5",
+    version: "7.22.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -26792,6 +26792,70 @@ function extractPlanTaskId(text) {
 function getSeedTaskId(session) {
   return session.currentTaskId ?? session.lastCoderDelegationTaskId;
 }
+function isTaskCompletedForParallelGuidance(task) {
+  const status = task.status ?? "pending";
+  return status === "completed" || status === "closed";
+}
+async function buildParallelExecutionGuidance(directory, sessionID, session) {
+  if (!directory)
+    return null;
+  const plan = await loadPlanJsonOnly(directory);
+  if (!plan) {
+    return null;
+  }
+  const profile = plan.execution_profile;
+  const enabled = profile?.parallelization_enabled === true;
+  const maxConcurrent = profile?.max_concurrent_tasks ?? 1;
+  if (!enabled || maxConcurrent <= 1)
+    return null;
+  if (hasActiveLeanTurbo(sessionID)) {
+    return "[NEXT] Lean Turbo is active; use lean_turbo_run_phase and Lean Turbo lane guidance instead of standard execution-profile slot filling.";
+  }
+  const currentPhase = plan.current_phase !== undefined ? plan.phases.find((phase) => phase.id === plan.current_phase) : plan.phases.find((phase) => !isParallelGuidancePhaseComplete(phase));
+  if (!currentPhase)
+    return null;
+  const tasks = currentPhase.tasks;
+  if (tasks.length === 0)
+    return null;
+  const allTasks = plan.phases.flatMap((phase) => phase.tasks);
+  const completed = new Set;
+  for (const task of allTasks) {
+    const taskId = task.id;
+    if (isTaskCompletedForParallelGuidance(task))
+      completed.add(taskId);
+    if (getTaskState(session, taskId) === "complete")
+      completed.add(taskId);
+  }
+  const occupied = new Set;
+  for (const task of allTasks) {
+    const taskId = task.id;
+    if (task.status === "in_progress")
+      occupied.add(taskId);
+    const state = getTaskState(session, taskId);
+    if (ACTIVE_PARALLEL_TASK_STATES.has(state))
+      occupied.add(taskId);
+  }
+  const availableSlots = Math.max(0, maxConcurrent - occupied.size);
+  if (availableSlots <= 0) {
+    return `[PARALLEL EXECUTION PROFILE] parallelization_enabled=true max_concurrent_tasks=${maxConcurrent}; all standard execution slots are occupied. Continue current active task gates before starting more coder work.`;
+  }
+  const eligible = tasks.filter((task) => {
+    const taskId = task.id;
+    const status = task.status ?? "pending";
+    if (status !== "pending")
+      return false;
+    if (occupied.has(taskId))
+      return false;
+    return task.depends.every((dep) => completed.has(dep));
+  }).map((task) => task.id).slice(0, availableSlots);
+  if (eligible.length === 0) {
+    return `[PARALLEL EXECUTION PROFILE] parallelization_enabled=true max_concurrent_tasks=${maxConcurrent}; no dependency-ready pending tasks are available for a new coder slot. Continue the current task/gate.`;
+  }
+  return `[PARALLEL EXECUTION PROFILE] parallelization_enabled=true max_concurrent_tasks=${maxConcurrent}; ${occupied.size} slot(s) occupied. Eligible now: ${eligible.join(", ")}. [NEXT] dispatch up to ${availableSlots} eligible coder task(s) before waiting; preserve ONE task per coder call and call declare_scope for each task.`;
+}
+function isParallelGuidancePhaseComplete(phase) {
+  return phase.status === "complete" || phase.status === "completed" || phase.status === "closed";
+}
 async function getEvidenceTaskId(session, directory) {
   const primary = session.currentTaskId ?? session.lastCoderDelegationTaskId;
   if (primary)
@@ -27297,15 +27361,16 @@ ${trimComment}${after}`;
           if (!/^[a-zA-Z0-9_-]{1,128}$/.test(deliberationSessionID)) {} else {
             const deliberationSession = ensureAgentSession(deliberationSessionID);
             const lastGate = deliberationSession.lastGateOutcome;
+            const parallelGuidance = await buildParallelExecutionGuidance(directory, deliberationSessionID, deliberationSession);
             let guidance;
             if (lastGate?.taskId) {
               const gateResult = lastGate.passed ? "PASSED" : "FAILED";
               const sanitizedGate = lastGate.gate.replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\[ \]/g, "()").replace(/\[/g, "(").replace(/\]/g, ")").replace(/[\r\n]/g, " ").slice(0, 64);
               const sanitizedTaskId = lastGate.taskId.replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\[/g, "(").replace(/\]/g, ")").replace(/[\r\n]/g, " ").slice(0, 32);
               guidance = `[Last gate: ${sanitizedGate} ${gateResult} for task ${sanitizedTaskId}]
-[NEXT] Execute the next gate for the current task.`;
+${parallelGuidance ?? "[NEXT] Execute the next gate for the current task."}`;
             } else {
-              guidance = "[NEXT] Begin the first plan task and run gates sequentially.";
+              guidance = parallelGuidance ?? "[NEXT] Begin the first plan task and run gates sequentially.";
             }
             const systemMsgIdx = messages.findIndex((m) => m && m.info?.role === "system");
             const insertIdx = systemMsgIdx >= 0 ? systemMsgIdx + 1 : 0;
@@ -27398,9 +27463,10 @@ ${warningLines.join(`
     toolAfter
   };
 }
-var pendingCoderScopeByTaskId;
+var pendingCoderScopeByTaskId, ACTIVE_PARALLEL_TASK_STATES;
 var init_delegation_gate = __esm(() => {
   init_schema();
+  init_manager();
   init_state();
   init_telemetry();
   init_logger();
@@ -27409,6 +27475,12 @@ var init_delegation_gate = __esm(() => {
   init_normalize_tool_name();
   init_utils2();
   pendingCoderScopeByTaskId = new Map;
+  ACTIVE_PARALLEL_TASK_STATES = new Set([
+    "coder_delegated",
+    "pre_check_passed",
+    "reviewer_run",
+    "tests_run"
+  ]);
 });
 
 // src/state/agent-run-context.ts
@@ -62871,6 +62943,8 @@ If a tool modifies a file, it is a CODER tool. Delegate.
   - Rationale: declare_scope persists the allowed set to disk (.swarm/scopes/scope-\${taskId}.json) so it survives cross-process delegation. Without a call, the coder process reads an empty scope and every Edit/Write is denied.
 <!-- BEHAVIORAL_GUIDANCE_END -->
 2. ONE agent per message. Send, STOP, wait for response.
+   Exception: Stage B reviewer/test_engineer gate agents for the SAME completed coder task may be dispatched together before waiting when both gates are required.
+   This exception NEVER applies to coder delegations. Preserve ONE task per coder call.
 3. ONE task per {{AGENT_PREFIX}}coder call. Never batch.
 3a. PRE-DELEGATION SCOPE CALL (required): BEFORE every {{AGENT_PREFIX}}coder delegation, you MUST call \`declare_scope\` with { taskId, files } listing the exact file(s) this task will modify (including generated/lockfile paths). No \`declare_scope\` call → no coder delegation. See Rule 1a.
 <!-- BEHAVIORAL_GUIDANCE_START -->
@@ -63011,7 +63085,7 @@ VERIFICATION PROTOCOL: After the coder reports DONE, and before running Stage B 
 The reviewer's verdict MUST include a REUSE_RE_VERIFICATION field — do NOT accept an APPROVED verdict without it. Validate the field value against context: if the coder's EXPORTS_ADDED was non-empty, REUSE_RE_VERIFICATION must be VERIFIED or DUPLICATION_DETECTED (not SKIPPED). If EXPORTS_ADDED was "none", REUSE_RE_VERIFICATION must be SKIPPED.
 Stage B runs by default for TIER 1-3 classifications. Stage A passing does not satisfy Stage B.
 Stage B is where logic errors, security flaws, edge cases, and behavioral bugs are caught.
-You MUST delegate to each Stage B agent and wait for their response.
+You MUST delegate to each required Stage B agent. For the standard reviewer + test_engineer pair, dispatch both before waiting so Stage B actually runs in parallel.
 
 Stage B (reviewer + test_engineer) **always runs per-task** regardless of council mode — it is never replaced, never omitted, never deferred. When \`council_mode\` is enabled in the QA gate profile, a **phase-level** council review is additionally required before calling \`phase_complete\`: dispatch all 5 council members, collect their verdicts, call \`submit_phase_council_verdicts\`, then call \`phase_complete\` (Gate 5 validates the resulting \`phase-council.json\` evidence). Stage A (\`pre_check_batch\`) still runs as the pre-review gate for each task.
 

--- a/docs/releases/pending/parallel-execution-profile-guidance.md
+++ b/docs/releases/pending/parallel-execution-profile-guidance.md
@@ -1,0 +1,25 @@
+# Parallel execution-profile guidance for architects
+
+## What changed
+
+- Architect deliberation guidance now honors standard execution profiles. When `.swarm/plan.json` has `execution_profile.parallelization_enabled=true` and `max_concurrent_tasks > 1`, the model-only `[NEXT]` guidance lists dependency-ready pending tasks up to the available slot count.
+- Active coder and gate work counts against the slot budget, so architects are nudged to fill open slots without over-dispatching.
+- The guidance reads `plan.json` through the schema-backed safe loader and fails open to serial guidance when the plan is missing or invalid.
+- Active Lean Turbo sessions suppress standard execution-profile slot filling and continue to point at the Lean Turbo phase runner.
+- Stage B reviewer/test_engineer instructions now explicitly allow dispatching both gate agents for the same completed coder task before waiting, while preserving one task per coder call.
+
+## Why
+
+Fixes Issue #892. Standard execution profiles could record `max_concurrent_tasks`, but the architect's normal deliberation path did not surface dependency-ready work or available slots, so agents often drifted back into serial reviewer/test_engineer and coder dispatch behavior.
+
+## Migration steps
+
+None. Existing plans with `parallelization_enabled=false` or `max_concurrent_tasks=1` keep the prior serial guidance.
+
+## Breaking changes
+
+None.
+
+## Known caveats
+
+This change adds deterministic model guidance for standard execution-profile slot filling. Lean Turbo remains the deterministic lane runner for full phase-level parallel execution.

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -151,6 +151,8 @@ If a tool modifies a file, it is a CODER tool. Delegate.
   - Rationale: declare_scope persists the allowed set to disk (.swarm/scopes/scope-\${taskId}.json) so it survives cross-process delegation. Without a call, the coder process reads an empty scope and every Edit/Write is denied.
 <!-- BEHAVIORAL_GUIDANCE_END -->
 2. ONE agent per message. Send, STOP, wait for response.
+   Exception: Stage B reviewer/test_engineer gate agents for the SAME completed coder task may be dispatched together before waiting when both gates are required.
+   This exception NEVER applies to coder delegations. Preserve ONE task per coder call.
 3. ONE task per {{AGENT_PREFIX}}coder call. Never batch.
 3a. PRE-DELEGATION SCOPE CALL (required): BEFORE every {{AGENT_PREFIX}}coder delegation, you MUST call \`declare_scope\` with { taskId, files } listing the exact file(s) this task will modify (including generated/lockfile paths). No \`declare_scope\` call → no coder delegation. See Rule 1a.
 <!-- BEHAVIORAL_GUIDANCE_START -->
@@ -291,7 +293,7 @@ VERIFICATION PROTOCOL: After the coder reports DONE, and before running Stage B 
 The reviewer's verdict MUST include a REUSE_RE_VERIFICATION field — do NOT accept an APPROVED verdict without it. Validate the field value against context: if the coder's EXPORTS_ADDED was non-empty, REUSE_RE_VERIFICATION must be VERIFIED or DUPLICATION_DETECTED (not SKIPPED). If EXPORTS_ADDED was "none", REUSE_RE_VERIFICATION must be SKIPPED.
 Stage B runs by default for TIER 1-3 classifications. Stage A passing does not satisfy Stage B.
 Stage B is where logic errors, security flaws, edge cases, and behavioral bugs are caught.
-You MUST delegate to each Stage B agent and wait for their response.
+You MUST delegate to each required Stage B agent. For the standard reviewer + test_engineer pair, dispatch both before waiting so Stage B actually runs in parallel.
 
 Stage B (reviewer + test_engineer) **always runs per-task** regardless of council mode — it is never replaced, never omitted, never deferred. When \`council_mode\` is enabled in the QA gate profile, a **phase-level** council review is additionally required before calling \`phase_complete\`: dispatch all 5 council members, collect their verdicts, call \`submit_phase_council_verdicts\`, then call \`phase_complete\` (Gate 5 validates the resulting \`phase-council.json\` evidence). Stage A (\`pre_check_batch\`) still runs as the pre-review gate for each task.
 

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -9,17 +9,20 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import type { PluginConfig } from '../config';
+import type { Phase, Plan, Task } from '../config/plan-schema';
 import { stripKnownSwarmPrefix } from '../config/schema';
 import {
 	routeReviewForChanges,
 	shouldParallelizeReview,
 } from '../parallel/review-router.js';
+import { loadPlanJsonOnly } from '../plan/manager';
 import type { AgentSessionState } from '../state';
 import {
 	advanceTaskState,
 	advanceTaskStateAndPersist,
 	ensureAgentSession,
 	getTaskState,
+	hasActiveLeanTurbo,
 	hasActiveTurboMode,
 	hasBothStageBCompletions,
 	isCouncilGateActive,
@@ -349,6 +352,97 @@ function extractPlanTaskId(text: string): string | null {
  */
 function getSeedTaskId(session: AgentSessionState): string | null {
 	return session.currentTaskId ?? session.lastCoderDelegationTaskId;
+}
+
+const ACTIVE_PARALLEL_TASK_STATES = new Set([
+	'coder_delegated',
+	'pre_check_passed',
+	'reviewer_run',
+	'tests_run',
+]);
+
+function isTaskCompletedForParallelGuidance(task: Task): boolean {
+	const status = task.status ?? 'pending';
+	return status === 'completed' || status === 'closed';
+}
+
+async function buildParallelExecutionGuidance(
+	directory: string | undefined,
+	sessionID: string,
+	session: AgentSessionState,
+): Promise<string | null> {
+	if (!directory) return null;
+
+	const plan: Plan | null = await loadPlanJsonOnly(directory);
+	if (!plan) {
+		return null;
+	}
+
+	const profile = plan.execution_profile;
+	const enabled = profile?.parallelization_enabled === true;
+	const maxConcurrent = profile?.max_concurrent_tasks ?? 1;
+	if (!enabled || maxConcurrent <= 1) return null;
+
+	if (hasActiveLeanTurbo(sessionID)) {
+		return '[NEXT] Lean Turbo is active; use lean_turbo_run_phase and Lean Turbo lane guidance instead of standard execution-profile slot filling.';
+	}
+
+	const currentPhase =
+		plan.current_phase !== undefined
+			? plan.phases.find((phase) => phase.id === plan.current_phase)
+			: plan.phases.find((phase) => !isParallelGuidancePhaseComplete(phase));
+	if (!currentPhase) return null;
+
+	const tasks = currentPhase.tasks;
+	if (tasks.length === 0) return null;
+
+	const allTasks = plan.phases.flatMap((phase) => phase.tasks);
+	const completed = new Set<string>();
+	for (const task of allTasks) {
+		const taskId = task.id;
+		if (isTaskCompletedForParallelGuidance(task)) completed.add(taskId);
+		if (getTaskState(session, taskId) === 'complete') completed.add(taskId);
+	}
+
+	// max_concurrent_tasks is a plan-level budget, so active work in earlier or
+	// later phases still occupies a standard execution slot.
+	const occupied = new Set<string>();
+	for (const task of allTasks) {
+		const taskId = task.id;
+		if (task.status === 'in_progress') occupied.add(taskId);
+		const state = getTaskState(session, taskId);
+		if (ACTIVE_PARALLEL_TASK_STATES.has(state)) occupied.add(taskId);
+	}
+
+	const availableSlots = Math.max(0, maxConcurrent - occupied.size);
+	if (availableSlots <= 0) {
+		return `[PARALLEL EXECUTION PROFILE] parallelization_enabled=true max_concurrent_tasks=${maxConcurrent}; all standard execution slots are occupied. Continue current active task gates before starting more coder work.`;
+	}
+
+	const eligible = tasks
+		.filter((task) => {
+			const taskId = task.id;
+			const status = task.status ?? 'pending';
+			if (status !== 'pending') return false;
+			if (occupied.has(taskId)) return false;
+			return task.depends.every((dep) => completed.has(dep));
+		})
+		.map((task) => task.id)
+		.slice(0, availableSlots);
+
+	if (eligible.length === 0) {
+		return `[PARALLEL EXECUTION PROFILE] parallelization_enabled=true max_concurrent_tasks=${maxConcurrent}; no dependency-ready pending tasks are available for a new coder slot. Continue the current task/gate.`;
+	}
+
+	return `[PARALLEL EXECUTION PROFILE] parallelization_enabled=true max_concurrent_tasks=${maxConcurrent}; ${occupied.size} slot(s) occupied. Eligible now: ${eligible.join(', ')}. [NEXT] dispatch up to ${availableSlots} eligible coder task(s) before waiting; preserve ONE task per coder call and call declare_scope for each task.`;
+}
+
+function isParallelGuidancePhaseComplete(phase: Phase): boolean {
+	return (
+		phase.status === 'complete' ||
+		phase.status === 'completed' ||
+		phase.status === 'closed'
+	);
 }
 
 /**
@@ -1350,6 +1444,11 @@ export function createDelegationGateHook(
 							deliberationSessionID,
 						);
 						const lastGate = deliberationSession.lastGateOutcome;
+						const parallelGuidance = await buildParallelExecutionGuidance(
+							directory,
+							deliberationSessionID,
+							deliberationSession,
+						);
 						let guidance: string;
 						if (lastGate?.taskId) {
 							const gateResult = lastGate.passed ? 'PASSED' : 'FAILED';
@@ -1370,11 +1469,15 @@ export function createDelegationGateHook(
 								.replace(/[\r\n]/g, ' ')
 								.slice(0, 32);
 							// Concise [NEXT] directive with last-gate status
-							guidance = `[Last gate: ${sanitizedGate} ${gateResult} for task ${sanitizedTaskId}]\n[NEXT] Execute the next gate for the current task.`;
+							guidance = `[Last gate: ${sanitizedGate} ${gateResult} for task ${sanitizedTaskId}]\n${
+								parallelGuidance ??
+								'[NEXT] Execute the next gate for the current task.'
+							}`;
 						} else {
 							// Concise [NEXT] directive to begin first plan task
 							// Also handles case where lastGate exists but taskId is missing
 							guidance =
+								parallelGuidance ??
 								'[NEXT] Begin the first plan task and run gates sequentially.';
 						}
 

--- a/tests/unit/agents/architect-workflow-security.test.ts
+++ b/tests/unit/agents/architect-workflow-security.test.ts
@@ -43,7 +43,8 @@ describe('ARCHITECT WORKFLOW: Sequence Bypass Prevention', () => {
 		);
 		const stripped = between45and5
 			.replace(/SWARM_SKIP_SPEC_GATE/gi, '')
-			.replace(/env var bypass/gi, '');
+			.replace(/env var bypass/gi, '')
+			.replace(/control-bypass/gi, '');
 		const lowerStripped = stripped.toLowerCase();
 		expect(lowerStripped).not.toContain('skip');
 		expect(lowerStripped).not.toContain('bypass');
@@ -343,6 +344,17 @@ describe('ARCHITECT WORKFLOW: Delegation Safety', () => {
 	test('SECURITY: One agent per message (Rule 2)', () => {
 		expect(prompt).toContain('ONE agent per message');
 		expect(prompt).toContain('Send, STOP, wait for response');
+	});
+
+	test('SECURITY: Stage B parallel exception is narrow and does not weaken coder task isolation', () => {
+		expect(prompt).toContain(
+			'Exception: Stage B reviewer/test_engineer gate agents for the SAME completed coder task',
+		);
+		expect(prompt).toContain(
+			'This exception NEVER applies to coder delegations',
+		);
+		expect(prompt).toContain('ONE task per {{AGENT_PREFIX}}coder call');
+		expect(prompt).toContain('Never batch');
 	});
 
 	test('SECURITY: One task per coder call (Rule 3)', () => {

--- a/tests/unit/hooks/delegation-gate-task-1-5.test.ts
+++ b/tests/unit/hooks/delegation-gate-task-1-5.test.ts
@@ -12,9 +12,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { PluginConfig } from '../../../src/config';
 import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
 import {
+	advanceTaskState,
 	ensureAgentSession,
 	resetSwarmState,
 	swarmState,
@@ -51,6 +55,62 @@ function makeMessages(
 			},
 		],
 	};
+}
+
+function makeTempProject(prefix: string): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	const real = fs.realpathSync(dir);
+	fs.mkdirSync(path.join(real, '.swarm'), { recursive: true });
+	return real;
+}
+
+function writePlanJson(
+	dir: string,
+	options: {
+		executionProfile?: Record<string, unknown>;
+		tasks?: Array<{
+			id: string;
+			status?: string;
+			depends?: string[];
+			phase?: number;
+		}>;
+		currentPhase?: number;
+	},
+): void {
+	const phase = options.currentPhase ?? 1;
+	const tasks = options.tasks ?? [
+		{ id: '1.1', status: 'pending' },
+		{ id: '1.2', status: 'pending' },
+	];
+	const plan = {
+		schema_version: '1.0.0',
+		title: 'Parallel Test Plan',
+		swarm: 'test-swarm',
+		current_phase: phase,
+		phases: [
+			{
+				id: phase,
+				name: `Phase ${phase}`,
+				status: 'in_progress',
+				tasks: tasks.map((task) => ({
+					id: task.id,
+					phase: task.phase ?? phase,
+					status: task.status ?? 'pending',
+					size: 'small',
+					description: `Task ${task.id}`,
+					depends: task.depends ?? [],
+					files_touched: [],
+				})),
+			},
+		],
+		...(options.executionProfile
+			? { execution_profile: options.executionProfile }
+			: {}),
+	};
+	fs.writeFileSync(
+		path.join(dir, '.swarm', 'plan.json'),
+		JSON.stringify(plan, null, 2),
+	);
 }
 
 describe('Task 1.5: [NEXT] Guidance - Model-Only System Message', () => {
@@ -146,6 +206,394 @@ describe('Task 1.5: [NEXT] Guidance - Model-Only System Message', () => {
 			);
 
 			expect(systemMessages[0].parts[0].text).toContain('FAILED');
+		});
+	});
+
+	describe('parallel execution_profile [NEXT] guidance', () => {
+		let tempDir: string;
+
+		beforeEach(() => {
+			tempDir = makeTempProject('delegation-gate-parallel-next-');
+		});
+
+		afterEach(() => {
+			try {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			} catch {
+				// best-effort cleanup
+			}
+		});
+
+		it('should list eligible pending tasks up to available parallel slots', async () => {
+			writePlanJson(tempDir, {
+				executionProfile: {
+					parallelization_enabled: true,
+					max_concurrent_tasks: 4,
+					locked: true,
+				},
+				tasks: [
+					{ id: '1.1', status: 'pending' },
+					{ id: '1.2', status: 'pending' },
+					{ id: '1.3', status: 'pending' },
+					{ id: '1.4', status: 'pending' },
+				],
+			});
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('PARALLEL EXECUTION PROFILE');
+			expect(systemText).toContain('max_concurrent_tasks=4');
+			expect(systemText).toContain('dispatch up to 4');
+			expect(systemText).toContain('Eligible now: 1.1, 1.2, 1.3, 1.4');
+		});
+
+		it('should keep serial guidance when profile is disabled or serial', async () => {
+			writePlanJson(tempDir, {
+				executionProfile: {
+					parallelization_enabled: false,
+					max_concurrent_tasks: 4,
+					locked: true,
+				},
+			});
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('run gates sequentially');
+			expect(systemText).not.toContain('PARALLEL EXECUTION PROFILE');
+		});
+
+		it('should count in-progress tasks as occupied and exclude blocked/dependent tasks', async () => {
+			writePlanJson(tempDir, {
+				executionProfile: {
+					parallelization_enabled: true,
+					max_concurrent_tasks: 3,
+					locked: true,
+				},
+				tasks: [
+					{ id: '1.1', status: 'in_progress' },
+					{ id: '1.2', status: 'pending', depends: ['1.1'] },
+					{ id: '1.3', status: 'pending' },
+					{ id: '1.4', status: 'blocked' },
+				],
+			});
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('dispatch up to 2');
+			expect(systemText).toContain('Eligible now: 1.3');
+			expect(systemText).not.toContain('Eligible now: 1.2');
+			expect(systemText).not.toContain('Eligible now: 1.4');
+		});
+
+		it('should count active in-memory workflow states as occupied slots', async () => {
+			writePlanJson(tempDir, {
+				executionProfile: {
+					parallelization_enabled: true,
+					max_concurrent_tasks: 4,
+					locked: true,
+				},
+				tasks: [
+					{ id: '1.1', status: 'pending' },
+					{ id: '1.2', status: 'pending' },
+					{ id: '1.3', status: 'pending' },
+					{ id: '1.4', status: 'pending' },
+				],
+			});
+			const session = ensureAgentSession('test-session');
+			advanceTaskState(session, '1.1', 'coder_delegated');
+			advanceTaskState(session, '1.2', 'coder_delegated');
+			advanceTaskState(session, '1.2', 'pre_check_passed');
+			advanceTaskState(session, '1.3', 'coder_delegated');
+			advanceTaskState(session, '1.3', 'pre_check_passed');
+			advanceTaskState(session, '1.3', 'reviewer_run');
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('3 slot(s) occupied');
+			expect(systemText).toContain('dispatch up to 1');
+			expect(systemText).toContain('Eligible now: 1.4');
+			expect(systemText).not.toContain('Eligible now: 1.1');
+		});
+
+		it('should count tests_run bridge state as an occupied slot', async () => {
+			writePlanJson(tempDir, {
+				executionProfile: {
+					parallelization_enabled: true,
+					max_concurrent_tasks: 2,
+					locked: true,
+				},
+				tasks: [
+					{ id: '1.1', status: 'pending' },
+					{ id: '1.2', status: 'pending' },
+					{ id: '1.3', status: 'pending' },
+				],
+			});
+			const session = ensureAgentSession('test-session');
+			advanceTaskState(session, '1.1', 'coder_delegated');
+			advanceTaskState(session, '1.1', 'pre_check_passed');
+			advanceTaskState(session, '1.1', 'reviewer_run');
+			advanceTaskState(session, '1.1', 'tests_run');
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('1 slot(s) occupied');
+			expect(systemText).toContain('dispatch up to 1');
+			expect(systemText).toContain('Eligible now: 1.2');
+			expect(systemText).not.toContain('Eligible now: 1.1');
+			expect(systemText).not.toContain('Eligible now: 1.3');
+		});
+
+		it('should count active work across phases against the plan-level slot budget', async () => {
+			const plan = {
+				schema_version: '1.0.0',
+				title: 'Cross Phase Occupancy Test Plan',
+				swarm: 'test-swarm',
+				current_phase: 2,
+				execution_profile: {
+					parallelization_enabled: true,
+					max_concurrent_tasks: 2,
+					locked: true,
+				},
+				phases: [
+					{
+						id: 1,
+						name: 'Phase 1',
+						status: 'in_progress',
+						tasks: [
+							{
+								id: '1.1',
+								phase: 1,
+								status: 'in_progress',
+								size: 'small',
+								description: 'Active earlier-phase task',
+								depends: [],
+								files_touched: [],
+							},
+						],
+					},
+					{
+						id: 2,
+						name: 'Phase 2',
+						status: 'in_progress',
+						tasks: [
+							{
+								id: '2.1',
+								phase: 2,
+								status: 'pending',
+								size: 'small',
+								description: 'Ready task one',
+								depends: [],
+								files_touched: [],
+							},
+							{
+								id: '2.2',
+								phase: 2,
+								status: 'pending',
+								size: 'small',
+								description: 'Ready task two',
+								depends: [],
+								files_touched: [],
+							},
+						],
+					},
+				],
+			};
+			fs.writeFileSync(
+				path.join(tempDir, '.swarm', 'plan.json'),
+				JSON.stringify(plan, null, 2),
+			);
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('1 slot(s) occupied');
+			expect(systemText).toContain('dispatch up to 1');
+			expect(systemText).toContain('Eligible now: 2.1');
+			expect(systemText).not.toContain('Eligible now: 2.2');
+		});
+
+		it('should treat completed dependencies from earlier phases as eligible inputs', async () => {
+			const plan = {
+				schema_version: '1.0.0',
+				title: 'Cross Phase Parallel Test Plan',
+				swarm: 'test-swarm',
+				current_phase: 2,
+				execution_profile: {
+					parallelization_enabled: true,
+					max_concurrent_tasks: 2,
+					locked: true,
+				},
+				phases: [
+					{
+						id: 1,
+						name: 'Phase 1',
+						status: 'complete',
+						tasks: [
+							{
+								id: '1.1',
+								phase: 1,
+								status: 'completed',
+								size: 'small',
+								description: 'Completed prerequisite',
+								depends: [],
+								files_touched: [],
+							},
+						],
+					},
+					{
+						id: 2,
+						name: 'Phase 2',
+						status: 'in_progress',
+						tasks: [
+							{
+								id: '2.1',
+								phase: 2,
+								status: 'pending',
+								size: 'small',
+								description: 'Ready task',
+								depends: ['1.1'],
+								files_touched: [],
+							},
+							{
+								id: '2.2',
+								phase: 2,
+								status: 'pending',
+								size: 'small',
+								description: 'Blocked by unmet dependency',
+								depends: ['2.9'],
+								files_touched: [],
+							},
+						],
+					},
+				],
+			};
+			fs.writeFileSync(
+				path.join(tempDir, '.swarm', 'plan.json'),
+				JSON.stringify(plan, null, 2),
+			);
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('Eligible now: 2.1');
+			expect(systemText).not.toContain('Eligible now: 2.2');
+		});
+
+		it('should fail open to serial guidance when plan.json is missing', async () => {
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('run gates sequentially');
+			expect(systemText).not.toContain('PARALLEL EXECUTION PROFILE');
+		});
+
+		it('should fail open to serial guidance when plan.json is malformed', async () => {
+			fs.writeFileSync(path.join(tempDir, '.swarm', 'plan.json'), '{nope');
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('run gates sequentially');
+			expect(systemText).not.toContain('PARALLEL EXECUTION PROFILE');
+		});
+
+		it('should suppress standard slot-filling guidance when Lean Turbo is active', async () => {
+			writePlanJson(tempDir, {
+				executionProfile: {
+					parallelization_enabled: true,
+					max_concurrent_tasks: 4,
+					locked: true,
+				},
+				tasks: [
+					{ id: '1.1', status: 'pending' },
+					{ id: '1.2', status: 'pending' },
+				],
+			});
+			const session = ensureAgentSession('test-session');
+			session.turboMode = true;
+			session.turboStrategy = 'lean';
+			session.leanTurboActive = true;
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('Lean Turbo is active');
+			expect(systemText).not.toContain('Eligible now:');
 		});
 	});
 


### PR DESCRIPTION
﻿Closes #892

## Summary
- Add execution-profile-aware architect [NEXT] guidance that reads the validated `.swarm/plan.json`, computes dependency-ready pending tasks, and tells the architect how many coder slots to fill.
- Keep Lean Turbo on its own lane-runner path and fail open to the existing serial guidance when no valid parallel profile exists.
- Make the Stage B reviewer/test_engineer parallel exception explicit while preserving one task per coder delegation.

## Invariant audit
- 1 (plugin init): not touched — no plugin initialization path changes; remote CI passed all required jobs for the original PR run.
- 2 (runtime portability): touched — `bun run build`, `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`, local smoke, remote dist-check, and remote smoke on Ubuntu/macOS/Windows passed after rebuilding tracked `dist/`.
- 3 (subprocesses): not touched — source-only grep over changed source/tests/docs for `bunSpawn\(|spawn\(|spawnSync\(` returned no matches; generated dist contains pre-existing bundled spawn code.
- 4 (.swarm containment): touched — new hook guidance reads `.swarm/plan.json` only through `loadPlanJsonOnly(directory)`; tests cover missing and malformed `plan.json` fail-open behavior.
- 5 (plan durability): touched — guidance consumes validated plan projections without migration or writes; tests cover enabled, disabled, missing, malformed, cross-phase dependency, cross-phase occupied budget, and active-slot cases.
- 6 (test_runner safety): not touched — no OpenCode `test_runner` broad-scope validation was used; all validation used shell/CI commands.
- 7 (test writing): touched — writing-tests guidance was loaded before editing tests; new tests use filesystem temp dirs and state helpers, with no `mock.module` additions.
- 8 (session state): touched — active slot counting uses existing per-session task workflow state; regression covers `coder_delegated`, `pre_check_passed`, `reviewer_run`, and `tests_run` as occupied slots.
- 9 (guardrails/retry): not touched — no retry/circuit-breaker/transient-error code changed.
- 10 (chat/system msg): touched — model-only [NEXT] guidance and architect prompt text changed; focused hook and architect prompt security suites pass.
- 11 (tool registration): not touched — no tool names, tool maps, registrations, or help surfaces changed.
- 12 (release/cache): touched — added `docs/releases/pending/parallel-execution-profile-guidance.md`; verified `package.json`, `CHANGELOG.md`, `.release-please-manifest.json`, and `.github/workflows/` are untouched.

## Test plan
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bunx biome ci .` — exits 0 with existing upstream warnings in `src/index.ts` and `src/turbo/lean/runner.ts`
- [x] `bun --smol test tests/unit/hooks/delegation-gate-task-1-5.test.ts tests/unit/agents/architect-workflow-security.test.ts --timeout 60000` — 82 pass
- [x] `bun --smol test tests/unit/tools/save-plan-execution-profile.test.ts tests/unit/parallel/parallel-dispatcher.test.ts tests/unit/hooks/delegation-gate.stage-b-parallel.adversarial.test.ts --timeout 60000` — 56 pass
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `bun test tests/security --timeout 120000` — 135 pass, 4 skip
- [x] `bun test tests/smoke --timeout 120000` — 10 pass
- [x] `git diff --check`
- [x] Remote CI before follow-up: quality, duplicate/title checks, unit (Ubuntu/macOS/Windows), dist-check, security, php-validation, integration, smoke (Ubuntu/macOS/Windows) all passed

## Local validation notes
- `node scripts/repro-704.mjs` is unreliable on this Windows host: on this branch it failed the 400 ms tight deadline and then hit `C:\SCCM` cleanup EPERM; on a clean origin/main worktree it timed out after 300 seconds. Remote CI is the authoritative cross-platform signal.
- `bun test tests/adversarial --timeout 120000` locally fails only in `tests/adversarial/cc-command-intercept.adversarial.test.ts` with 9 failures; the same file fails the same way on clean origin/main at 468d8c9e. Remote CI is green on the pre-follow-up run and rerunning after the amended push.
