### PR TITLE
docs(skills): add codex publish workflow guidance

### DIFF
--- a/.agents/skills/commit-pr/SKILL.md
+++ b/.agents/skills/commit-pr/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: commit-pr
+description: >
+  Codex-native adapter for the opencode-swarm publish workflow. Use when asked to
+  commit, push, open or update a PR, refresh PR body text, mark a PR ready, or
+  close out remote CI before merge.
+---
+
+# Commit & PR
+
+Use this skill for Codex-side publication work in `opencode-swarm`.
+
+## Source Of Truth
+
+Read and follow [`../../../.claude/skills/commit-pr/SKILL.md`](../../../.claude/skills/commit-pr/SKILL.md) in full before committing, pushing, opening, or updating a PR.
+
+That Claude skill remains the repository's canonical publish protocol. This Codex-native skill is the adapter layer: it tells Codex which tools to use, how to handle existing PRs, and how to finish the post-open lifecycle without drifting from the repo contract.
+
+If instructions conflict:
+
+1. `AGENTS.md`
+2. `docs/engineering-invariants.md`
+3. `../../../.claude/skills/commit-pr/SKILL.md`
+4. this file
+
+## Codex Execution Rules
+
+- Use `shell_command` for `git`, `gh`, build, test, and CI commands.
+- Use `apply_patch` for manual file edits.
+- Use `multi_tool_use.parallel` for independent reads, status checks, and non-conflicting repo inspections.
+- Do not stage `.Codex/`, IDE-local files, or unrelated worktree changes.
+- Do not open a second PR when one already exists for the branch. Update the existing PR instead.
+
+## Publish Modes
+
+Infer the mode from the user request and branch state:
+
+- `new-pr`: branch is ready to publish and no PR exists yet
+- `pr-followup`: a PR already exists and you are addressing review feedback or syncing validation
+- `closeout`: a PR already exists and you are updating body text, waiting on CI, marking ready, or confirming merge prerequisites
+
+## Required Follow-Through
+
+### Existing PR updates
+
+If the branch already has a PR:
+
+- update the existing PR body instead of creating a new PR
+- refresh `## Summary`, `## Invariant audit`, and `## Test plan` when validation counts, caveats, or evidence changed
+- verify the PR still points at the pushed branch head after any force-push
+
+### Draft vs ready
+
+Default behavior:
+
+- open or keep the PR as draft while follow-up edits are still expected, required checks are pending, or known caveats still need explanation
+- mark the PR ready only after the body is current and required remote checks are green
+
+If the user explicitly asks for a ready PR sooner, obey that request and document any remaining CI state clearly.
+
+### Remote checks are authoritative
+
+When the user asks to open, ship, ready, or close out a PR:
+
+1. inspect remote checks with `gh pr view <n> --json statusCheckRollup,...` or `gh pr checks <n>`
+2. wait for required checks to finish when practical
+3. if a required job is `cancelled` and downstream jobs are `skipped`, inspect the run and rerun failed/cancelled jobs
+4. do not call the PR merge-ready while a required check is `cancelled`, `skipped`, `in_progress`, or otherwise non-green unless the user explicitly accepts that state
+
+Recommended commands:
+
+```powershell
+gh pr view <number> --json body,headRefName,headRefOid,isDraft,state,statusCheckRollup,url
+gh pr checks <number> --watch --fail-fast
+gh run view <run-id> --json jobs,status,conclusion,url
+gh run rerun <run-id> --failed
+```
+
+### Issue comment requirement
+
+If the PR closes an issue:
+
+- confirm the issue comment exists with the PR link, what changed, how to use it, and migration notes
+- if the PR merged before the comment was posted, add the missing issue comment immediately
+
+## Working Pattern
+
+1. Read `AGENTS.md`, `docs/engineering-invariants.md` as needed, and the canonical Claude `commit-pr` skill.
+2. Run the required local validation from the canonical skill.
+3. Stage only intended files.
+4. Create or update the PR.
+5. Refresh PR body text if the branch changed after review feedback.
+6. Watch remote checks to a useful conclusion when the user asked for publication or closeout.
+7. Verify issue comments, ready/draft state, and merge-readiness claims before finishing.
+
+## Clean-Main And CI Reality Checks
+
+When local validation is noisy or host-limited:
+
+- compare suspicious failures against a clean `origin/main` worktree before blaming the branch
+- document proven pre-existing failures in the PR body
+- use remote CI as the cross-platform source of truth for merge-readiness
+
+## Final Sanity Check
+
+- one branch, one PR
+- PR head matches pushed `HEAD`
+- PR body matches current validation evidence
+- issue comment exists when the PR closes an issue
+- draft or ready state matches user intent
+- required remote checks are green, or any remaining non-green state is explicitly explained

--- a/.agents/skills/issue-tracer/SKILL.md
+++ b/.agents/skills/issue-tracer/SKILL.md
@@ -26,6 +26,7 @@ Infer the mode from the user request and newest instructions.
 - `plan-then-approval`: produce a reviewed plan and wait for explicit approval before production-code edits.
 - `approved implementation`: if the user already asked to fix or implement, continue through reproduction, localization, minimal patch, validation, and PR-ready summary.
 - `high-risk`: require approval before edits when the fix is destructive, broad, breaking, migration-heavy, or depends on unavailable secrets/data.
+- `review-followup`: if the user pastes PR review feedback, treat each finding as a claim to verify against the current branch or live PR head before editing. Classify items as confirmed, disproved, pre-existing, or unverified, and patch only the confirmed gaps.
 
 Do not force a blocking approval gate for ordinary Codex implementation work when the user already asked for the fix. Do force it for plan-only requests, high-risk work, destructive operations, or explicit user instructions.
 
@@ -37,7 +38,7 @@ For `opencode-swarm`, read the repo contract before meaningful work:
 2. `docs/engineering-invariants.md` when touching relevant invariants
 3. `.opencode/skills/writing-tests/SKILL.md` before writing or modifying tests
 4. `.opencode/skills/engineering-conventions/SKILL.md` before architecture, plugin init, subprocess, tool registration, plan durability, `.swarm` storage, runtime portability, session/global state, guardrails/retry, chat/system hook, or release/cache work
-5. `.claude/skills/commit-pr/SKILL.md` before commit, push, or PR creation unless a Codex publish skill supersedes it
+5. `.agents/skills/commit-pr/SKILL.md` before commit, push, or PR creation; use `.claude/skills/commit-pr/SKILL.md` as the underlying repo protocol it points to
 
 If `.Codex/session/swarm-mode.md` exists, read it before complex work and follow its quality gates.
 
@@ -89,10 +90,11 @@ gh issue view <id> --comments --json number,title,body,author,labels,state,comme
 ```
 
 2. Read linked PRs, commits, logs, screenshots, discussions, and external docs referenced by the issue.
-3. Extract observed behavior, expected behavior, exact errors, reproduction steps, environment, acceptance criteria, and ambiguities.
-4. Discover verification commands from actual repo files, not memory.
-5. Reproduce with the smallest faithful command or scenario.
-6. If direct reproduction is impossible, create or describe a minimal failing test/script/checklist that targets the reported behavior.
+3. If the input includes PR review feedback, refresh the live PR head or active branch before trusting any pasted claim.
+4. Extract observed behavior, expected behavior, exact errors, reproduction steps, environment, acceptance criteria, and ambiguities.
+5. Discover verification commands from actual repo files, not memory.
+6. Reproduce with the smallest faithful command or scenario.
+7. If direct reproduction is impossible, create or describe a minimal failing test/script/checklist that targets the reported behavior.
 
 Gate: continue only when the issue is reproduced, a faithful failing regression exists, or non-reproducibility is documented with missing inputs.
 
@@ -130,7 +132,8 @@ Gate: implementation may begin only when mode permits it and critic blockers are
 4. Apply the minimal fix with `apply_patch`.
 5. Re-read changed files and verify all runtime entry points are wired.
 6. Run focused regression tests, impacted tests, and repo-required checks. For `opencode-swarm`, use shell commands for repo validation; do not use broad OpenCode `test_runner` scopes.
-7. Record commands, exit codes, and meaningful output.
+7. When broad local suites are noisy, host-specific, or plausibly pre-existing, compare the failing path against a clean `origin/main` worktree and document the result. Use remote CI as the final cross-platform publish signal when local host behavior is not authoritative.
+8. Record commands, exit codes, and meaningful output.
 
 Gate: changed behavior matches the reviewed plan or the deviation is documented; regression protection exists or infeasibility is justified; impacted checks pass or unrelated failures are proven.
 
@@ -140,7 +143,8 @@ Gate: changed behavior matches the reviewed plan or the deviation is documented;
 2. Verify no unrelated files changed.
 3. Prepare PR text with `assets/pr-template.md`.
 4. Include root cause with file/line references, change summary, tests/checks, regression coverage, invariant audit evidence for touched areas, and residual risks.
-5. Commit, push, or open a PR only when the user explicitly asked and the repo publish instructions have been loaded.
+5. If this is review follow-up work, refresh the existing PR body and validation summary when pass counts, caveats, or invariant evidence changed.
+6. Commit, push, or open a PR only when the user explicitly asked and the repo publish instructions have been loaded.
 
 ## No-Gap Checklist
 
@@ -152,5 +156,6 @@ Gate: changed behavior matches the reviewed plan or the deviation is documented;
 - Positive, negative, boundary, and adversarial cases are covered or explicitly ruled out.
 - Regression test fails before the fix and passes after the fix when feasible.
 - Impacted tests and quality checks are run.
+- Suspected pre-existing or host-specific failures are compared against clean `origin/main` or explicitly documented as unverified.
 - Critic review completed before approval or implementation gate.
 - PR-ready summary is complete.

--- a/.claude/skills/commit-pr/SKILL.md
+++ b/.claude/skills/commit-pr/SKILL.md
@@ -1,29 +1,47 @@
 ---
 name: commit-pr
 description: >
-  Apply when committing, pushing, opening a PR, writing a pull request, creating release
-  notes, or updating a changelog. Enforces conventional commit format, mandatory release
-  notes, 5-tier test suite, SHA-pinning for workflow changes, and correct PR body format.
+  Apply when committing, pushing, opening or updating a PR, writing a pull request,
+  creating release notes, or closing out remote CI. Enforces the opencode-swarm
+  invariant audit, release-note fragment workflow, full validation suite, issue
+  comment requirement, and post-PR lifecycle rules.
 effort: medium
 ---
 
-## Commit & PR Protocol
+# Commit & PR Protocol
 
 Follow every step in order. Do not skip steps.
 
-### Step −1 — ⛔ MANDATORY: Engineering invariant audit (read AGENTS.md, not "looks fine")
+## Step -1 - Mandatory invariant audit
 
-**Before** running any test tier, before any build, before any push: read [`AGENTS.md`](../../../AGENTS.md) at the repo root and audit your change against the 12 non-negotiable invariants. The invariant list and the historical failure map are in [`docs/engineering-invariants.md`](../../../docs/engineering-invariants.md).
+Before any build, test, push, or PR action, read:
 
-For every invariant **touched** by this PR (not "maybe touched" — actually touched), produce a one-line entry of the form `<id> (<short name>): touched — <evidence>`. Evidence must be a concrete artifact: a command + its output, a test that proves the invariant, a grep showing no remaining anti-patterns, or a quoted spec citation. "Looks fine" is not evidence. The PR body must include a `## Invariant audit` section in the format shown in `AGENTS.md` (12 lines, one per invariant, each marked touched/not-touched with evidence).
+1. [`../../../AGENTS.md`](../../../AGENTS.md)
+2. [`../../../docs/engineering-invariants.md`](../../../docs/engineering-invariants.md)
 
-Hard stop:
+For every touched invariant, prepare concrete evidence for the PR body. The PR body must include:
 
-> **If any touched invariant cannot be proven from source and test output, do not push.**
+```md
+## Invariant audit
+- 1 (plugin init): touched / not touched - <evidence>
+- 2 (runtime portability): touched / not touched - <evidence>
+- 3 (subprocesses): touched / not touched - <evidence>
+- 4 (.swarm containment): touched / not touched - <evidence>
+- 5 (plan durability): touched / not touched - <evidence>
+- 6 (test_runner safety): touched / not touched - <evidence>
+- 7 (test writing): touched / not touched - <evidence>
+- 8 (session state): touched / not touched - <evidence>
+- 9 (guardrails/retry): touched / not touched - <evidence>
+- 10 (chat/system msg): touched / not touched - <evidence>
+- 11 (tool registration): touched / not touched - <evidence>
+- 12 (release/cache): touched / not touched - <evidence>
+```
 
-#### Required invariant-specific validations (run when the named invariants are touched)
+If a touched invariant cannot be proven from source and test output, do not push.
 
-**(1, 2, 3) Plugin initialization, runtime portability, or any subprocess change** — run all three:
+### Required validations for touched invariants
+
+If invariants 1, 2, or 3 are touched, run all three:
 
 ```bash
 bun run build
@@ -31,494 +49,206 @@ node scripts/repro-704.mjs
 node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"
 ```
 
-The `repro-704.mjs` harness asserts plugin entry resolves under a deadline; the `dist import` line catches Node-ESM regressions (top-level `bun:` imports, broken default export shape) before CI does.
-
-**(3) Subprocesses** — grep every changed file for spawn call sites and account for each one in the audit:
+If invariant 3 is touched, audit changed source files for subprocess use:
 
 ```bash
 git diff --name-only origin/main..HEAD | xargs -r grep -nE "bunSpawn\(|spawn\(|spawnSync\(" || true
 ```
 
-For every match, the `## Invariant audit` evidence must confirm the call passes `cwd` (or `git -C <directory>` for Git CLI calls), `stdin: 'ignore'` (unless intentionally interactive), `timeout`, bounded stdio, and `proc.kill()` in `finally`.
-
-**(11) Tool registration** — run the tool / config tests:
+If invariant 11 is touched, run:
 
 ```bash
 bun --smol test tests/unit/config --timeout 60000
 for f in tests/unit/tools/*.test.ts; do bun --smol test "$f" --timeout 30000; done
 ```
 
-`/swarm doctor tools` is the runtime equivalent — its tests must remain green.
+If invariant 7 is touched, confirm the writing-tests skill was loaded and that new test seams avoid leaking `mock.module`.
 
-**(7) Test writing** — confirm you loaded the writing-tests skill (`.claude/skills/writing-tests/SKILL.md` or `.opencode/skills/writing-tests/SKILL.md`). Confirm any new mocks use a file-scoped `_internals` DI seam, not `mock.module`, OR are isolated to a test file whose `mock.module` cannot leak into other suites.
+## Step 0 - Session start hygiene
 
-**(6) `test_runner` safety** — the OpenCode `test_runner` tool is for targeted agent validation only. Do NOT use it with `scope: 'all'` or broad `'graph'` / `'impact'` scope for repo validation. For repo validation, use the shell commands in Step 5 below.
-
-### Step 0 — Session start hygiene
-
-**Run before anything else.** Prevents the three most common CI failures (stale state, stale base, dirty working tree).
+Run before publication work:
 
 ```bash
-# Ensure you're on the latest main as your branch point
 git fetch origin main
-
-# Create (or verify) a branch rooted at the latest main
-# If already on a feature branch, skip this line
-# git switch -c <branch> origin/main
-
-# Clear stale evidence files from prior sessions — these pollute
-# evidence-first gate checks and cause non-deterministic test failures
 rm -f .swarm/evidence/*.json
-
-# Verify working tree is clean — no uncommitted changes from prior sessions
 git status --short
 ```
 
-If `git status` shows uncommitted changes, either commit them (if they're part of this PR) or move them aside. **On Windows, `git stash` is unreliable** — it can silently drop untracked files and fail with `EBUSY` errors when file handles are held by running processes. Prefer one of these safer alternatives:
+On Windows, prefer temporary save branches over `git stash`. If you must stash, use `git stash push --include-untracked` and verify the stash contents.
 
-```bash
-# Option A — commit work-in-progress to a temporary branch, then switch back
-git switch -c save/prior-session
-git add -A && git commit -m "chore: save prior session state"
-git switch -c my-feature-branch origin/main
+## Step 1 - Commit and PR titles
+
+Use `<type>(<scope>): <description>` exactly.
+
+- description is lowercase and does not end with a period
+- allowed types: `feat`, `fix`, `perf`, `revert`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`
+
+Choose the PR title type by the main change:
+
+- new capability -> `feat`
+- bug fix only -> `fix`
+- docs or chore only -> non-bump types
+
+The squash merge commit message must match the PR title exactly.
+
+## Step 2 - Release note fragment
+
+Create a pending release fragment and do not calculate a version manually.
+
+Required file shape:
+
+```text
+docs/releases/pending/<unique-slug>.md
 ```
 
-If you must use stash, always pass `--include-untracked` (`git stash push --include-untracked`) to avoid silently losing untracked files, and verify with `git stash show -p` that all expected files were captured before proceeding.
+The fragment should cover:
 
-### Step 1 — Format every commit message correctly
+- what changed
+- why
+- migration steps, if any
+- breaking changes, if any
+- known caveats
 
-Use `<type>(<scope>): <description>` exactly:
-- Description must be **lowercase** and **not end with a period**
-- Scope is optional but encouraged
-- Allowed types: `feat`, `fix`, `perf`, `revert`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`
-- For a breaking change, append `!` to the type (e.g. `feat!:`) or add a `BREAKING CHANGE:` footer
+Do not manually edit:
 
-Valid: `feat(architect): add retry backoff to SME delegation`
-Invalid: `Fix stuff`, `feat: Add new feature.`, `feature: new thing`
+- `package.json` version
+- `CHANGELOG.md`
+- `.release-please-manifest.json`
 
-### Step 2 — Choose the correct PR title type
+## Step 3 - Mandatory validation suite
 
-The PR title is the squash merge commit message. Choose based on primary change:
-- New capability → `feat` (minor bump)
-- Bug fix only → `fix` (patch bump)
-- Mixed feat + fix → use `feat` (minor subsumes patch)
-- `docs`/`chore`/`refactor`/`test`/`ci`/`build` only → no version bump is triggered
+Run the full validation stack before pushing. The exact commands may be narrowed only when the repo contract or current task explicitly justifies it in evidence, not by intuition.
 
-### Step 3 — Create a pending release-note fragment
-
-⛔ **Do NOT** calculate `NEXT_VERSION`. ⛔ **Do NOT** create `docs/releases/vX.Y.Z.md`. ⛔ **Do NOT** write to a shared `docs/releases/unreleased.md` (same conflict hotspot, just relocated). release-please picks the actual version; the release workflow aggregates fragments at release time.
-
-1. Choose a short, descriptive, kebab-case slug that names the change. Pick something unlikely to collide with other open PRs — concurrent PRs each adding a *different* file produces zero merge conflicts.
-2. Create `docs/releases/pending/<your-slug>.md` with freeform markdown covering:
-   - **What changed** — changes grouped by theme
-   - **Why** — motivation (bug report, feature request, hardening)
-   - **Migration steps** — if any API, config, or behavior changed
-   - **Breaking changes** — if any
-   - **Known caveats** — anything users should watch out for
-3. Do not include a version prefix in the heading (`# v7.21.4`). Use a descriptive topic heading: `# <topic>` (e.g. `# Spec-drift self-acknowledgment guardrail (issue #890)`).
-
-Examples of good slugs:
-- `docs/releases/pending/guardrails-transient-node-errors.md`
-- `docs/releases/pending/spec-drift-self-ack-guardrail.md`
-- `docs/releases/pending/phase-complete-durable-gate-proof.md`
-
-This file is **mandatory on every user-visible PR, no exceptions**, including one-line fixes. The aggregation is implemented by `scripts/release-notes-fragments.mjs`, invoked by the `update-pr-notes` and `update-release-notes` jobs in `.github/workflows/release-and-publish.yml`.
-
-### Step 4 — Never touch these files manually
-
-Do **not** edit `package.json` version field, `CHANGELOG.md`, or `.release-please-manifest.json`. Release-please manages them; manual edits cause merge conflicts and break the pipeline.
-
-### Step 5 — ⛔ MANDATORY: Build + run the full 5-tier test suite before pushing
-
-**This step is MANDATORY. It is not optional, skippable, or conditional.**
-
-Every tier MUST be run in order, regardless of:
-- Whether the swarm's internal QA gates already ran lint/checks (swarm scope ≠ CI scope)
-- Whether the change looks trivial or cosmetic
-- Whether tests passed locally in isolation
-- Whether you are in a hurry
-
-Skipping this step WILL cause CI failures that waste time and require a follow-up commit.
-
-#### Pre-flight: build and check dist/ drift (runs before all test tiers)
-
-Build first. If `dist/` is tracked in the repo, verify a fresh build produces no uncommitted diffs.
-CI's dist-check passes by comparing committed `dist/` against a fresh build; any diff is a hard failure.
+### Pre-flight
 
 ```bash
 bun run build
-
-# Check for dist drift — MUST be clean before proceeding to tests
-if git diff --exit-code -- dist/; then
-    echo "dist/ is clean"
-else
-    echo "dist/ has uncommitted changes after build — stage and commit them:"
-    echo "  git add dist/ && git commit -m \"chore: update dist artifacts\""
-    echo "Then re-run this pre-flight check."
-    exit 1
-fi
+git diff --exit-code -- dist/
 ```
 
-If the build produces non-deterministic diffs on every run (no source changes), investigate before proceeding — this will also fail CI on every subsequent PR.
-
-#### Run every tier in order. Fix failures before proceeding.
+### Tier 1 - quality
 
 ```bash
-# Tier 1 — quality
 bun run typecheck
-bunx biome ci .   # MUST run on the full project — never scope to modified files only.
-                  # CI runs it on all files; a scoped run will miss errors in files you
-                  # touched indirectly (e.g. reformatted by another tool, or modified via
-                  # biome --write on one file but not re-checked globally).
-                  #
-                  # If you ran `bunx biome check --write` to auto-fix formatting,
-                  # re-run `bunx biome ci .` afterwards and commit the auto-fixed files
-                  # BEFORE pushing — biome --write produces unstaged changes that will
-                  # cause the quality CI check to fail on the un-fixed commit.
+bunx biome ci .
+```
 
-# Tier 2 — unit tests (per-file isolation to match CI and prevent mock conflicts)
+### Tier 2 - unit tests
+
+```bash
 for f in tests/unit/tools/*.test.ts; do bun --smol test "$f" --timeout 30000; done
 for f in tests/unit/services/*.test.ts; do bun --smol test "$f" --timeout 30000; done
 for f in tests/unit/agents/*.test.ts; do bun --smol test "$f" --timeout 30000; done
-# hooks must run per-file — batch mode can mask failures that CI's per-file isolation catches
 for f in tests/unit/hooks/*.test.ts; do bun --smol test "$f" --timeout 30000; done
 bun --smol test tests/unit/cli tests/unit/commands tests/unit/config --timeout 120000
+```
 
-**Pre-push mock contract verification: run after Tier 2.**
-After unit tests pass, verify that no mock contract was silently broken by a refactor.
+If agent prompt text changed, grep for the changed text in tests and rerun every matching file individually.
 
-1. Identify test files that mock modules you changed:
-   ```bash
-   # bash — match by filename stem (robust across relative path depths)
-   for src_file in $(git diff --name-only origin/main..HEAD -- 'src/**/*.ts'); do
-     stem=$(basename "$src_file" .ts)
-     grep -rl "mock.module\|vi.mock" tests/ --include="*.ts" | while read test_file; do
-       if grep -q "$stem" "$test_file"; then
-         echo "$test_file"
-       fi
-     done
-   done | sort -u
-   ```
-   ```powershell
-   # PowerShell — match by filename stem
-   $changed = git diff --name-only origin/main..HEAD -- 'src/**/*.ts'
-   foreach ($src in $changed) {
-     $stem = [System.IO.Path]::GetFileNameWithoutExtension($src)
-     Get-ChildItem -Recurse tests/ -Filter "*.test.ts" |
-       Select-String -Pattern "mock\.module|vi\.mock" |
-       Where-Object { $_.Line -match [regex]::Escape($stem) } |
-       ForEach-Object { $_.Path }
-   } | Sort-Object -Unique
-   ```
-2. Run each matching test file individually:
-   ```bash
-   for f in <matching-test-files>; do bun --smol test "$f" --timeout 30000 || exit 1; done
-   ```
-   ```powershell
-   foreach ($f in @("tests/path/to/test1.test.ts")) { bun --smol test $f --timeout 30000 }
-   ```
-3. If any fail with `SyntaxError: Export named 'X' not found`, the `mock.module()` factory is missing exports — update it per the writing-tests skill's "mock.module() Export Completeness" section.
-4. If any fail with `TypeError: undefined is not an object` or empty assertion values, the mock return shape doesn't match the new function contract — update the mock's `mockResolvedValue()` to include new required fields.
+### Tier 3 - integration
 
-# Tier 3 — integration tests
-# IMPORTANT: always run Tier 3 after fixing Tier 2 failures — the same root cause
-# often appears in integration test fixtures that unit tests don't cover.
+```bash
 bun test tests/integration ./test --timeout 120000
+```
 
-# Tier 4 — security and adversarial tests
+### Tier 4 - security and adversarial
+
+```bash
 bun test tests/security --timeout 120000
 bun test tests/adversarial --timeout 120000
+```
 
-# Tier 5 — smoke (no rebuild — already done in pre-flight)
+### Tier 5 - smoke
+
+```bash
 bun test tests/smoke --timeout 120000
 ```
 
-**Routing console calls through a debug-gated logger: extra step required.**
-When you change `console.log/warn/error` to `logger.log/warn()` (which gates output behind `OPENCODE_SWARM_DEBUG=1`):
-1. Grep for all tests that spy on those console methods and assert they ARE called:
-   ```bash
-   grep -rn "spyOn(console" tests/ --include="*.ts"
-   grep -rn "toHaveBeenCalled\|console\.warn\|console\.log\|console\.error" tests/ --include="*.ts"
-   ```
-2. For every spy that asserts the call IS made: determine whether the original call was an operational error (e.g., `catch` block reporting a real failure). Operational errors must remain as direct `console.warn/error` — never gate them behind `logger.warn()`. Only diagnostic/trace messages should be routed through the debug-gated logger.
-3. Run the affected hook test files per-file after the fix to confirm spy assertions pass.
+### Pre-existing failure handling
 
-Failing to do this breaks tests silently in isolation but fails loudly in CI's per-file run.
+If a failure looks unrelated, prove it on clean `origin/main` before carrying it into the PR body:
 
-**Schema or field name changes: extra step required.**
-When you rename a field in a Zod schema, TypeScript interface, or serialized format (e.g. `task_id` → `taskId`):
-1. Grep for the old field name across ALL test files — unit AND integration:
-   ```bash
-   grep -rn "old_field_name" tests/ --include="*.ts"
-   ```
-2. Update every test fixture that writes JSON with the old field name.
-3. Update every assertion that reads the old field name from parsed JSON.
-4. Run Tier 2 and Tier 3 together after fixing all fixtures.
-
-Failing to do this causes test fixtures to write stale-format JSON that passes Zod validation for the write but fails on the read path — a silent correctness hazard.
-
-**Import rename or function signature change: extra step required.**
-When a refactor renames an import, changes a function signature, or changes which function a module calls (e.g. `readMergedKnowledge` → `readContextualKnowledge`):
-1. Search for the old function name across test files, scoped to imports and mock references:
-   ```bash
-   # bash — scoped to imports, mock factories, and mock state calls
-   grep -rnE "import.*oldFunctionName|mock\(.*oldFunctionName|mockResolvedValue|mockClear|mockReset" tests/ --include="*.ts" | grep oldFunctionName
-   ```
-   ```powershell
-   # PowerShell — scoped to imports and mock references
-   Get-ChildItem -Recurse tests/ -Filter "*.test.ts" | Select-String -Pattern "oldFunctionName" | Where-Object { $_.Line -match "import|mock\(|mockResolvedValue|mockClear|mockReset" }
-   ```
-2. For every match, determine if the test's mock must be updated:
-   - If the test imports the old name → update the import
-   - If the test's `mock.module()` / `vi.mock()` provides the old name → update to the new name
-   - If the test's `mockResolvedValue()` / `mockClear()` / `mockReset()` calls reference the old mock variable → update to the new variable name
-3. If the new function signature requires additional data (e.g., a new required field on the return type), update all mock return values and test fixtures to include it.
-4. Run each affected test file individually after fixing:
-   ```bash
-   for f in <affected-test-files>; do bun --smol test "$f" --timeout 30000; done
-   ```
-   ```powershell
-   foreach ($f in @("tests/path/to/test1.test.ts", "tests/path/to/test2.test.ts")) { bun --smol test $f --timeout 30000 }
-   ```
-
-Failing to do this causes tests to reference stale function names in mocks — the mock intercepts nothing, the real function (which doesn't exist) throws, and CI fails with cryptic "received value is empty" errors.
-
-**Agent prompt changes: extra step required.**
-When you edit any agent prompt (`src/agents/*.ts`), tests that assert on prompt content will silently break even if your change appears unrelated. Before pushing:
-1. Identify the text you changed or removed from the prompt.
-2. Grep for that text across all test files:
-   ```bash
-   # bash
-   grep -rn "the exact phrase you removed" tests/ --include="*.ts"
-   # PowerShell
-   Get-ChildItem -Recurse tests/ -Filter "*.test.ts" | Select-String "the exact phrase you removed"
-   ```
-3. Run every test file that matches: `bun --smol test <matching-file> --timeout 30000`.
-4. If any fail, update the assertion to match the new prompt text (or remove it if the concept no longer exists).
-
-Prompt-text tests are especially fragile because they test content, not behaviour — a refactor that seems unrelated (e.g. changing a delegation format example) can silently break assertions checking for specific template strings.
-
-### Troubleshooting — Release workflow automation gaps
-
-When release-please creates a release (`releases_created=true`), the `update-pr-notes` job is **skipped** because its `if` condition checks `releases_created != 'true'`. This means pending release-note fragments are NOT automatically injected into the next release PR body.
-
-**Symptom**: A new release PR exists but its body only contains the release-please auto-generated changelog, missing the `<!-- custom-release-notes:start -->` block with aggregated fragments.
-
-**Fix**: Manually aggregate fragments into the release PR body:
-```powershell
-# Read the current PR body
-$prBody = (gh pr view <number> --json body | ConvertFrom-Json).body
-
-# Read the pending fragment(s)
-$fragment = Get-Content docs/releases/pending/<slug>.md -Raw
-
-# Append to PR body
-$newBody = "$prBody`n`n---`n`n$fragment"
-$newBody | Out-File "$env:TEMP\pr_body_update.txt" -Encoding UTF8
-gh pr edit <number> --body-file "$env:TEMP\pr_body_update.txt"
-```
-
-Also update the GitHub Release body for the just-created release (append, don't replace):
-```powershell
-$existingNotes = (gh release view v7.X.Y --json body | ConvertFrom-Json).body
-$fragment = Get-Content docs/releases/pending/<slug>.md -Raw
-$combined = "$existingNotes`n`n---`n`n$fragment"
-$combined | Out-File "$env:TEMP\release_notes_update.txt" -Encoding UTF8
-gh release edit v7.X.Y --notes-file "$env:TEMP\release_notes_update.txt"
-```
-
-**PowerShell note**: `gh` CLI `--jq` expressions containing `$` (e.g. `--jq '.[] | .id'`) fail in PowerShell because `$` is interpreted as a variable prefix. Use `--json` output piped to `ConvertFrom-Json` instead. Note that `--notes "$(Get-Content ...)"` also has the same `$` expansion risk — always use `--body-file` / `--notes-file` with `Out-File` for multiline content.
-
-### Troubleshooting — CI fails on tests that seem unrelated to your changes
-
-If a test fails and you suspect it is pre-existing (unrelated to your changes):
-
-1. **Confirm on a clean main checkout** using a disposable Git worktree:
-   ```bash
-   git worktree add /tmp/repro-check origin/main
-   bun --smol test /tmp/repro-check/<path-to-failing-test> --timeout 30000
-   git worktree remove /tmp/repro-check
-   ```
-   This avoids the risks of `git stash` (lost state, untracked files, locked files on Windows).
-
-2. **If it also fails on main**: note the failure and its test file name in the PR description under `## Pre-existing failures`. Do NOT skip the other test tiers — a pre-existing failure in one tier does not exempt you from running the others. The PR will be evaluated on net change; pre-existing failures are flagged separately.
-
-3. **If it only fails on your branch**: the failure was introduced by your changes. Fix it before proceeding.
-
-### Step 6 — SHA-pin any workflow changes
-
-If you add or modify any file in `.github/workflows/`, every `uses:` reference to a third-party action must be pinned to a full 40-character commit SHA with the version as a comment:
-
-```yaml
-# Correct
-- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-# Wrong — will fail security tests
-- uses: actions/checkout@v4
-- uses: actions/checkout@main
-```
-
-Find the SHA for a tag:
 ```bash
-gh api repos/{owner}/{repo}/git/ref/tags/{tag} --jq '.object.sha'
+git worktree add /tmp/repro-check origin/main
+bun --smol test /tmp/repro-check/<path-to-failing-test> --timeout 30000
+git worktree remove /tmp/repro-check
 ```
 
-### Step 7 — Squash to a single clean commit
+If the failure reproduces on `main`, document it under `## Pre-existing failures`. Do not silently inherit it.
 
-Before pushing, collapse all interim commits into one. The PR must land as a single commit whose message is the canonical record of the change.
+## Step 4 - Workflow changes
 
-**Before squashing, verify no tool or IDE files were accidentally staged:**
+If any `.github/workflows/*.yml` file changed, every third-party `uses:` must be pinned to a full 40-character SHA.
+
+## Step 5 - History shape
+
+Before opening a PR, verify no local-only files are staged:
+
 ```bash
 git diff --name-only HEAD origin/main | grep -E '\.(local\.json|vscode|idea)' || true
-# Look for: .claude/settings.local.json, .vscode/, .idea/, etc.
-# If any appear, remove them: git checkout origin/main -- <path>
 ```
-These files are modified by Claude Code and IDEs during a session but must never be committed.
+
+Prefer a single clean commit for the branch before initial PR publication:
 
 ```bash
-# Fetch main to ensure origin/main is current (CI may have merged main into your branch)
 git fetch origin main
-
-# See what you're about to squash (sanity check)
 git log --oneline origin/main..HEAD
-
-# Squash everything relative to current main
-# Using origin/main instead of git merge-base HEAD main is important because
-# CI may have auto-merged main into your branch, creating a merge commit
-# that would confuse merge-base.
 git reset --soft origin/main
 git commit -m "type(scope): description"
-
-# Force-push with lease (never plain --force)
 git push --force-with-lease -u origin <branch-name>
 ```
 
-**Rules:**
-- The squash commit message must match the PR title exactly — they are the same thing.
-- Use `--force-with-lease`, never `--force`. Lease rejects the push if the remote has commits you haven't seen.
-- If a review cycle is already in progress (reviewer comments reference specific commit SHAs), do **not** squash until all review threads are resolved — squashing rewrites history and orphans inline comments.
-- Any dist/ build artifact commits must be included in the squash (stage them before `git commit`).
+If a review cycle is already active and inline comments depend on current SHAs, avoid resquashing until threads are resolved.
 
-**Why:** Interim commits (`fix attempt 1`, `wip`, `address review`) are noise in the project history. A single well-named commit makes `git log`, `git bisect`, and release notes meaningful. The PR title doubles as the squash commit message — both must be correct conventional-commit format.
-
-#### Pushing to a PR branch owned by another agent or bot
-
-When a PR was created by Copilot, another agent, or an automated tool, its head branch (e.g. `copilot/fix-skills-passing-to-subagents`) will not exist in your local repo. Pushing your local branch to a different remote name will create a second branch and leave the PR pointing at the wrong one. Correct pattern:
-
-```bash
-# 1. Identify the PR's actual head branch
-gh pr view <number> --json headRefName --jq '.headRefName'
-# e.g. → copilot/fix-skills-passing-to-subagents
-
-# 2. Fetch it so git knows the remote ref
-git fetch origin copilot/fix-skills-passing-to-subagents
-
-# 3. Push your local branch to the PR's remote branch
-git push origin <your-local-branch>:copilot/fix-skills-passing-to-subagents --force-with-lease
-```
+If pushing to a PR branch owned by another agent or bot, push to the PR's actual head branch:
 
 ```powershell
-# PowerShell equivalent
 $prBranch = gh pr view <number> --json headRefName --jq '.headRefName'
 git fetch origin $prBranch
 git push origin "<your-local-branch>:$prBranch" --force-with-lease
 ```
 
-Verify the PR is now tracking your commit: `gh pr view <number> --json headRefOid` should match `git rev-parse HEAD`.
+## Step 6 - PR creation
 
-### Step 8 — Open the PR with the correct body format
+PR body requirements:
 
-`## Summary` must have 1–3 bullets explaining what and why. `## Test plan` must be a markdown checklist. Do not replace the body of an existing release-please PR — prepend only.
+- `Closes #<issue-number>` as the first line when the PR resolves an issue
+- `## Summary`
+- `## Invariant audit`
+- `## Test plan`
 
-**PR body MUST include `Closes #<issue-number>` as the first line** when the PR resolves a specific issue. This auto-closes the issue on merge. For PRs that don't close an issue, skip this line.
-
-**After opening the PR, comment on the issue** with a summary of what changed, so issue subscribers get notified. Use `gh issue comment <number> --body "..."`.
-
-#### bash (Linux / macOS)
-
-```bash
-# Include the Closes line only when the PR resolves an issue
-gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
-Closes #<issue-number>
-
-## Summary
-- <bullet 1>
-- <bullet 2 if needed>
-- <bullet 3 if needed>
-
-## Test plan
-- [ ] <what you tested>
-- [ ] <additional test step>
-
-## Pre-existing failures
-- <test name> — <reason> (if any pre-existing failures exist)
-EOF
-)" --base main
-
-# After creating the PR, comment on the issue with a summary of changes
-gh issue comment <issue-number> --body "Fixed in PR #<pr-number>. <bullet summary of changes>"
-```
-
-#### PowerShell (Windows)
-
-`<<'EOF'` heredoc syntax is **invalid in PowerShell** and will produce a parse error. Use a here-string written to a temp file instead:
+PowerShell-safe pattern:
 
 ```powershell
-# Include the Closes line only when the PR resolves an issue
 $body = @"
 Closes #<issue-number>
 
 ## Summary
 - <bullet 1>
-- <bullet 2 if needed>
-- <bullet 3 if needed>
+- <bullet 2>
+
+## Invariant audit
+- 1 (plugin init): not touched - <evidence>
 
 ## Test plan
-- [ ] <what you tested>
-- [ ] <additional test step>
-
-## Pre-existing failures
-- <test name> — <reason> (if any pre-existing failures exist)
+- [ ] <validation item>
 "@
 $body | Out-File "$env:TEMP\pr_body.txt" -Encoding UTF8
 gh pr create --title "<type>(<scope>): <description>" --body-file "$env:TEMP\pr_body.txt" --base main
-
-# After creating the PR, comment on the issue with a summary of changes
-gh issue comment <issue-number> --body "Fixed in PR #<pr-number>. <bullet summary of changes>"
 ```
 
-Note: Inside a PowerShell here-string (`@"..."@`), backticks are literal — no escaping needed. Double-quotes inside the here-string do not need escaping either.
+## Step 6.5 - Issue comment
 
-### Step 8.5 — Comment on the originating issue
+If the PR closes an issue, post a comment on the issue. This is mandatory.
 
-If the PR resolves a GitHub issue (i.e. the PR body contains `Closes #<N>` or `Fixes #<N>`), post a comment on that issue summarizing the resolution. This is NOT optional — the issue author may never read the PR body.
+The issue comment must include:
 
-The comment MUST include:
+1. the PR link
+2. what changed
+3. how to use it
+4. migration steps or "No migration required"
 
-1. **Link to the PR** — `Fixed in PR #<N>`
-2. **What changed** — bullet-point summary of the implementation (2-5 bullets)
-3. **How to use it** — config examples, API usage snippets, or command-line examples showing how to enable/use the new feature
-4. **Migration steps** — if any behavior changed, document what users need to do (or explicitly state "No migration required" if the default is backward-compatible)
-
-#### bash (Linux / macOS)
-
-```bash
-gh issue comment <issue-number> --body "Fixed in PR #<pr-number>.
-
-## What changed
-- <bullet 1>
-- <bullet 2>
-
-## How to use
-\`\`\`json
-{ \"config\": \"example\" }
-\`\`\`
-
-## Migration
-<No migration required / migration steps>"
-```
-
-#### PowerShell (Windows)
+PowerShell-safe pattern:
 
 ````powershell
 $comment = @"
@@ -534,28 +264,69 @@ Fixed in PR #<pr-number>.
 ```
 
 ## Migration
-<No migration required / migration steps>
+No migration required.
 "@
 $comment | Out-File "$env:TEMP\issue-comment.txt" -Encoding UTF8
 gh issue comment <issue-number> --body-file "$env:TEMP\issue-comment.txt"
 ````
 
-Do NOT skip this step even if the change seems self-explanatory. The issue author asked for a feature or reported a bug — they deserve a direct response with actionable instructions.
+If the PR merged before this was done, post the missing issue comment immediately.
 
-### Step 9 — Pre-merge checklist
+## Step 7 - Existing PR follow-up and closeout
 
-Verify every item before asking for a merge:
-- [ ] Step −1 invariant audit completed; `## Invariant audit` section present in the PR body in the format from `AGENTS.md`
-- [ ] If the audit lists invariants 1, 2, or 3 as touched: `bun run build`, `node scripts/repro-704.mjs`, and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` all ran cleanly with output in context
-- [ ] If invariant 3 (subprocesses) is touched: every `bunSpawn` / `spawn` / `spawnSync` call in changed files passes `cwd` (or `git -C <directory>` for Git CLI calls), `stdin: 'ignore'`, `timeout`, bounded stdio, and `proc.kill()` in `finally`
-- [ ] `test_runner` was NOT used with `scope: 'all'` or broad `'graph'` / `'impact'` scope to validate this repo (use shell commands instead)
-- [ ] Branch has exactly **one commit** — the squashed commit from Step 7 (`git log --oneline origin/main..HEAD` shows one line)
-- [ ] That commit message matches the PR title exactly, and both follow `<type>(<scope>): <description>`
-- [ ] `docs/releases/pending/<unique-slug>.md` exists with meaningful release notes (NOT a `docs/releases/vX.Y.Z.md` file)
-- [ ] `package.json` version, `CHANGELOG.md`, `.release-please-manifest.json` are untouched
-- [ ] All 5 test tiers from Step 5 were actually run (not assumed — you must have the output in context), including `bunx biome ci .` on the full project (not scoped)
-- [ ] If the repo tracks `dist/` files: `bun run build` was run and dist/ artifacts are included in the squash commit
-- [ ] All workflow `uses:` references are SHA-pinned (if workflows changed)
-- [ ] PR body has `## Summary`, `## Invariant audit`, and `## Test plan`
-- [ ] If the PR resolves an issue: PR body starts with `Closes #<number>` (first line) and a `gh issue comment` was posted per Step 8.5 with what changed, how to use it, and migration steps
-- [ ] All CI checks are green before merging
+If a PR already exists for the branch:
+
+1. do not open a second PR
+2. update the existing PR body when summary, invariant evidence, test counts, caveats, or pre-existing failure notes changed
+3. keep the PR draft while follow-up edits are still expected or required checks are still pending
+4. mark the PR ready only after the body is current and required remote checks are green, unless the user explicitly wants it ready earlier
+5. after any follow-up push or force-push, verify the PR head matches the expected commit:
+
+```powershell
+gh pr view <number> --json headRefOid,body,isDraft,state,statusCheckRollup,url
+```
+
+Useful commands:
+
+```powershell
+gh pr edit <number> --body-file "$env:TEMP\pr_body.txt"
+gh pr ready <number>
+gh pr checks <number> --watch --fail-fast
+```
+
+## Step 8 - Cancelled jobs and skipped dependents
+
+If a required GitHub Actions job is `cancelled` and downstream jobs are `skipped`:
+
+1. inspect the run:
+
+```powershell
+gh run view <run-id> --json status,conclusion,jobs,url
+```
+
+2. if the cancellation looks like orchestration or infrastructure rather than a code failure, rerun the failed or cancelled jobs:
+
+```powershell
+gh run rerun <run-id> --failed
+```
+
+3. re-check the PR until required jobs are green:
+
+```powershell
+gh pr checks <number> --watch --fail-fast
+```
+
+Do not call the PR green or merge-ready while a required job is `cancelled`, `skipped`, `in_progress`, or otherwise non-green unless the user explicitly accepts that state.
+
+## Step 9 - Pre-merge checklist
+
+- [ ] invariant audit is complete and current
+- [ ] required build and validation commands ran for touched invariants
+- [ ] `test_runner` was not used with broad repo-validation scopes
+- [ ] release fragment exists and version files are untouched
+- [ ] `dist/` was rebuilt and staged when tracked outputs changed
+- [ ] PR body has `Closes`, `## Summary`, `## Invariant audit`, and `## Test plan`
+- [ ] if this was review follow-up, the PR body was refreshed to match current evidence
+- [ ] if the PR resolves an issue, the issue comment was posted with PR link, what changed, how to use it, and migration notes
+- [ ] if any required job was cancelled and dependent jobs skipped, the run was rerun or the non-green state was explicitly accepted by the user
+- [ ] all required CI checks are green before calling the PR merge-ready

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.22.0",
+    version: "7.22.1",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.22.0",
+    version: "7.22.1",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/docs/releases/pending/codex-publish-skill-and-issue-tracer-followup.md
+++ b/docs/releases/pending/codex-publish-skill-and-issue-tracer-followup.md
@@ -1,0 +1,23 @@
+# Codex publish skill and issue-tracer follow-up
+
+## What changed
+
+- Added a Codex-native `commit-pr` skill for `opencode-swarm` under `.agents/skills/commit-pr/`.
+- Updated the Codex `issue-tracer` skill to treat pasted PR review findings as claims that must be validated against the live branch or PR head before editing.
+- Tightened the canonical `commit-pr` workflow so existing-PR follow-up, ready-vs-draft transitions, and cancelled-check reruns are part of the documented closeout path.
+
+## Why
+
+This repository already had a strong publish protocol, but this run exposed a gap between Codex-native issue work and the repo's publish lifecycle. The missing Codex-side `commit-pr` skill and weaker review-follow-up guidance made the closeout path rely on ad hoc repo memory instead of a first-class local workflow.
+
+## Migration steps
+
+No migration required.
+
+## Breaking changes
+
+None.
+
+## Known caveats
+
+- The Codex-native `commit-pr` skill intentionally defers to `.claude/skills/commit-pr/SKILL.md` as the canonical repository publish contract, so future publish changes should keep both files aligned.


### PR DESCRIPTION
﻿## Summary
- add a Codex-native `.agents/skills/commit-pr/SKILL.md` adapter so Codex publish work follows the repository's canonical PR protocol without borrowing the Claude skill ad hoc
- update `.agents/skills/issue-tracer/SKILL.md` for review-followup validation, clean-`origin/main` comparison when local validation is noisy, and PR-body refresh expectations after follow-up pushes
- normalize `.claude/skills/commit-pr/SKILL.md` with explicit existing-PR closeout, cancelled-job rerun guidance, and the mandatory issue-comment workflow
- add a pending release fragment documenting the new Codex publish path and issue-tracer follow-up behavior
- regenerate `dist/index.js` and `dist/cli/index.js` so the tracked bundle version banners match `package.json` `7.22.1` and CI `dist-check` stops failing

## Invariant audit
- 1 (plugin init): not touched - `git diff --name-only origin/main..HEAD` shows no init-path source changes under `src/`.
- 2 (runtime portability): touched - regenerated tracked runtime bundles with `bun run build`; verified with `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` and `bun test tests/smoke --timeout 120000`.
- 3 (subprocesses): not touched - `git diff --name-only origin/main..HEAD` shows no runtime command-execution source changes.
- 4 (.swarm containment): not touched - `git diff --name-only origin/main..HEAD` shows no `.swarm` runtime code changes.
- 5 (plan durability): not touched - `git diff --name-only origin/main..HEAD` shows no ledger, projection, or plan persistence code changes.
- 6 (test_runner safety): not touched - `git diff --name-only origin/main..HEAD` shows no `test_runner` implementation or contract changes.
- 7 (test writing): not touched - no test files changed in this branch.
- 8 (session state): not touched - `git diff --name-only origin/main..HEAD` shows no session/global state implementation changes.
- 9 (guardrails/retry): not touched - `git diff --name-only origin/main..HEAD` shows no guardrail or retry-path code changes.
- 10 (chat/system msg): not touched - `git diff --name-only origin/main..HEAD` shows no chat hook runtime code changes.
- 11 (tool registration): not touched - `git diff --name-only origin/main..HEAD` shows no `src/tools`, `src/index.ts`, or config registration changes.
- 12 (release/cache): touched - added `docs/releases/pending/codex-publish-skill-and-issue-tracer-followup.md`; regenerated tracked `dist/` outputs without touching `package.json`, `CHANGELOG.md`, or `.release-please-manifest.json`.

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `bun run build`
- [x] `git diff --check`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `bun run typecheck`
- [x] `bunx biome ci .` (passes with existing warnings in `src/index.ts` and `src/turbo/lean/runner.ts`)
- [x] `bun test tests/security --timeout 120000`
- [x] `bun test tests/smoke --timeout 120000`
- [x] `bun --smol test tests/unit/tools/checkpoint.adversarial.test.ts --timeout 30000` on this branch (passes in isolation after a long serialized unit sweep timed out once)
- [x] `bun --smol test tests/unit/tools/checkpoint.adversarial.test.ts --timeout 30000` on clean `origin/main` (passes in isolation)
- [x] `bun --smol test tests/unit/tools/diagnostic-gating.test.ts --timeout 30000` on clean `origin/main` (fails; reproduced pre-existing)
- [x] `bun --smol test tests/unit/tools/doc-scan.adversarial.test.ts --timeout 30000` on clean `origin/main` (fails; reproduced pre-existing)
- [x] `bun test tests/adversarial/cc-command-intercept.adversarial.test.ts --timeout 120000` on clean `origin/main` (fails; reproduced pre-existing)
- [ ] `bun test tests/integration ./test --timeout 120000` on the working branch is noisy in many unrelated suites; representative clean-main spot check `bun test tests/integration/curator-pipeline-health.test.ts --timeout 120000` passes, so the broad integration failure appears to be local/stateful suite contamination rather than this docs-only branch
- [ ] `bun test tests/adversarial --timeout 120000` is red because `cc-command-intercept.adversarial.test.ts` already fails on clean `origin/main`

## Pre-existing failures and validation notes
- A long serialized unit sweep hit an order-dependent timeout in `tests/unit/tools/checkpoint.adversarial.test.ts`, but the file passes in isolation on both this branch and clean `origin/main`.
- `tests/unit/tools/diagnostic-gating.test.ts` fails on clean `origin/main` because its expected `DEBUG_SWARM` gating assertions no longer match current source.
- `tests/unit/tools/doc-scan.adversarial.test.ts` fails on clean `origin/main` because the expected `"Warning"` marker is no longer present in the truncated summary path.
- `tests/adversarial/cc-command-intercept.adversarial.test.ts` fails on clean `origin/main` for uppercase/whitespace `/plan` interception expectations.
- The branch now includes the regenerated `dist` version banners required to keep tracked bundles aligned with `package.json` `7.22.1`; that was the direct cause of the failing `dist-check` run on PR #908.
