### PR TITLE
docs(skill): harden pr-review-fix with pre-push validation, concurrency, and template literal guidance

### DIFF
--- a/.opencode/skills/generated/pr-review-fix/SKILL.md
+++ b/.opencode/skills/generated/pr-review-fix/SKILL.md
@@ -85,6 +85,7 @@ For each file group:
 - Batch-fixing all findings in one pass without reading each file individually.
 - "While I'm here" changes — only fix what was flagged.
 - Changing unrelated code to "improve" the area around the finding.
+- Accepting coder edits to template literal strings (backtick-delimited `.ts` content) without verifying that internal backticks are escaped. Unescaped backticks cause `SyntaxError` at build time even when the text looks correct in Read output.
 
 ## Step 4 — Update tests
 
@@ -129,7 +130,15 @@ git commit -m "fix(pr-review): address findings C-01, C-02, T-01, W-01"
 
 3. Verify the commit message follows conventional commit format.
 
-## Step 7 — Push and update PR
+## Step 7 — Pre-push validation
+
+Before pushing, run local validation to catch formatting and style issues that CI would reject:
+
+1. **Lint/format check**: Run the project's local linting tool on all modified files. This catches formatting-only issues without burning a CI cycle. On this project, check that any coder-written test files pass formatting validation.
+2. **Build check**: Run the project build command to verify no syntax errors (especially important when coders modify template literal strings — unescaped backticks cause build failures).
+3. Stage and commit.
+
+## Step 8 — Push and update PR
 
 ```bash
 # For amended commits:
@@ -157,21 +166,23 @@ Addressed N findings from PR review:
 Skipped: none
 ```
 
-## Step 8 — Monitor CI
+## Step 9 — Monitor CI
 
 1. Wait for CI to start.
-2. If CI fails:
-   - Read the failure log carefully.
-   - Determine if the failure is caused by your fix or is a pre-existing issue.
-   - If caused by your fix: return to Step 3 for that finding.
-   - If pre-existing (infrastructure flake, unrelated test):
-     a. Rerun the failed job once.
-     b. If the rerun passes: the failure was infrastructure. Proceed.
-     c. If the rerun fails the same way: this is a real pre-existing issue. Document it separately in the PR thread (do NOT mark CI as green). The PR author or maintainer must decide whether to merge with a known pre-existing failure or fix it first.
-3. CI outcomes:
-   - **Green (all checks pass)**: You're done.
-   - **Pre-existing failure confirmed after rerun**: Document in PR, flag to maintainer. Do NOT claim CI is green.
-   - **Blocked (job stuck/queued >30 min)**: May be a GitHub Actions capacity issue. Re-trigger the workflow.
+2. **If a CI run appears stuck (queued >10 minutes)**: check for stale in-progress runs from prior pushes. Cancel them with `gh run cancel <run-id>` — GitHub Actions concurrency groups queue new runs behind in-progress ones.
+3. If CI fails:
+    - Read the failure log carefully.
+    - Determine if the failure is caused by your fix or is a pre-existing issue.
+    - If caused by your fix: return to Step 3 for that finding.
+    - If caused by formatting/style: fix locally, rebuild, amend, and push again.
+    - If pre-existing (infrastructure flake, unrelated test):
+      a. Rerun the failed job once.
+      b. If the rerun passes: the failure was infrastructure. Proceed.
+      c. If the rerun fails the same way: this is a real pre-existing issue. Document it separately in the PR thread (do NOT mark CI as green). The PR author or maintainer must decide whether to merge with a known pre-existing failure or fix it first.
+4. CI outcomes:
+    - **Green (all checks pass)**: You're done.
+    - **Pre-existing failure confirmed after rerun**: Document in PR, flag to maintainer. Do NOT claim CI is green.
+    - **Blocked (job stuck/queued >30 min after cancellation)**: Re-trigger the workflow.
 
 ## Platform-specific notes
 

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.23.1",
+    version: "7.24.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.23.1",
+    version: "7.24.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Updates the `pr-review-fix` agent skill with three improvements based on lessons from PR #913 review-fix cycle.

**Changes:**
- Added **Step 7 (pre-push validation)** — run local lint/format + build checks before pushing to catch issues that would fail CI (formatting mismatches, syntax errors from unescaped template literal backticks)
- Renumbered push to **Step 8**, CI monitoring to **Step 9**
- Added **CI concurrency cancellation** guidance — cancel stale in-progress runs with `gh run cancel` before force-push to avoid concurrency group queueing
- Added **formatting failure** as explicit CI outcome path (fix locally, rebuild, amend, push)
- Added **template literal backtick escaping** anti-pattern to Step 3 — coder edits to template literal strings may introduce unescaped backticks that look correct in Read output but fail at build time

## Motivation

During the PR #913 review-fix cycle, three avoidable CI failures occurred:
1. Biome format rejection on coder-written test files (would have been caught by local lint check)
2. CI run stuck in queue behind stale in-progress run from prior push (would have been resolved by cancelling stale run)
3. Build failure from unescaped backticks in a template literal (would have been caught by build check)

These are now documented as mandatory pre-push steps.

## Invariant audit
- 1 (plugin init): not touched
- 2 (runtime portability): not touched
- 3 (subprocesses): not touched
- 4 (.swarm containment): not touched
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched
- 7 (test writing): not touched
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched
- 12 (release/cache): not touched
