### PR TITLE
docs(skills): Issue #849 follow-up — generated migration skill and writing-tests updates

### DIFF
--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -93,6 +93,19 @@ afterEach(() => {
   mock.restore();
 });
 ```
+
+**CRITICAL: When using `mockImplementation()` on a `mock()` function, call `mockReset()` in `afterEach`.** `mock.restore()` only restores `mock.module` state — it does NOT reset `mockImplementation` on individual `mock()` functions. Without `mockReset()`, the implementation set in one test leaks into the next test's active window:
+```typescript
+const mockFn = mock(() => 'default');
+
+beforeEach(() => {
+  mockFn.mockClear();  // Clear call history before each test
+});
+
+afterEach(() => {
+  mockFn.mockReset();  // Clear call history and any mockImplementation set during the test
+});
+```
 **Exception — Windows EBUSY:** Test files that spawn async child processes (e.g. `pre-check-batch` tests) must **NOT** call `mock.restore()` on Windows. Child process handles can hold directory locks, and `mock.restore()` triggers cleanup that causes `EBUSY` errors. These files must use `describe.skipIf(process.platform === 'win32')` or `test.skipIf(process.platform === 'win32')` for affected tests.
 
 Intentionally skipped on Windows (async child process handles cause EBUSY):
@@ -135,8 +148,16 @@ For mocking functions within the same module, source files export an `_internals
 
 ```typescript
 // In source file (src/services/my-service.ts)
-export const _internals = {
-  helperFn: () => { /* real implementation */ }
+import { spawnSync } from 'node:child_process';
+
+type SpawnSyncFn = typeof spawnSync;  // Use typeof alias, NOT type import
+
+export const _internals: {
+  helperFn: typeof helperFn;
+  spawnSync: SpawnSyncFn;  // ← expose for test injection
+} = {
+  helperFn,
+  spawnSync,
 };
 
 export function mainFn() {
@@ -190,6 +211,8 @@ afterEach(() => mock.restore());
 | Mocking a Node built-in (fs, child_process, etc.) | `mock.module` + spread real | `mock.module('node:fs/promises', () => ({ ...realFs, readFile: mockFn }))` |
 | Mocking another application module | `mock.module` + cleanup | `mock.module('../../../src/utils/logger', ...)` + `afterEach(mock.restore())` |
 | File-scoped mock (applies to all tests in file) | `mock.module` at top level + `mockReset()` in `beforeEach` | Preflight tests with `mockLoadPlan.mockReset()` |
+
+**Migrating from `mock.module` to `_internals`:** See the `mock-to-internals-migration` generated skill for the step-by-step protocol.
 
 ## mock.module() Export Completeness
 
@@ -374,6 +397,7 @@ When CI reports a `unit (ubuntu|macos|windows)` failure:
 - **Do not hardcode version numbers.** Version bumps are automated — a test asserting `version === '6.31.3'` breaks on every release.
 - **Do not use `sleep` or `setTimeout` for synchronization.** Use explicit signals, resolved promises, or `Bun.sleep()` with tight bounds.
 - **Do not spawn `cat /dev/zero`, `yes`, or other infinite-output commands.** Use `sleep 30` for "blocking command" tests.
+- **Do not use weak assertions in adversarial tests.** `expect(result !== undefined).toBe(true)` and `expect(result).toBeDefined()` only verify "didn't crash" — they do NOT verify the system's actual response to the attack vector. Always assert specific behavior: `expect(result).toBeNull()`, `expect(result.status).toBe('invalid_schema')`, `expect(result.message).toContain('ERROR')`. Weak assertions hide regressions in graceful-degradation logic.
 
 ## Cross-Platform Requirements
 
@@ -494,7 +518,6 @@ The following source modules export `_internals` but have no test consumers (as 
 - `src/tools/sast-baseline.ts`
 - `src/mutation/gate.ts`
 - `src/mutation/equivalence.ts`
-- `src/mutation/engine.ts`
 - `src/db/qa-gate-profile.ts`
 - `src/config/schema.ts`
 - `src/config/index.ts`

--- a/.opencode/skills/generated/mock-to-internals-migration/SKILL.md
+++ b/.opencode/skills/generated/mock-to-internals-migration/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: mock-to-internals-migration
+description: >
+  Apply when converting test files from mock.module('node:child_process') to _internals DI seam pattern.
+  Guides the complete migration: adding spawnSync/_internals to source files, converting test files,
+  adding proper beforeEach/afterEach save/restore lifecycle, mockReset() cleanup, and temp directory cleanup.
+  Prevents mock.module leaks across Bun's shared test-runner process.
+effort: medium
+---
+
+# mock.module → _internals DI Seam Migration Protocol
+
+Follow every step in order. Do not skip steps.
+
+## When to use this skill
+
+- A test file uses `mock.module('node:child_process')` or `mock.module('node:fs')` or similar
+- The production code already has an `_internals` export (or needs one added)
+- The goal is to eliminate `mock.module` usage per AGENTS.md invariant 7 and the writing-tests skill
+
+**Benefit:** This migration also sidesteps the Windows EBUSY risk documented in the writing-tests skill — tests using `_internals` seams do not need `mock.restore()`, which on Windows can conflict with async child process handles.
+
+## Step 0 — Identify the target module and its _internals seam
+
+1. Find where the test imports from:
+   ```typescript
+   import { _internals as engineInternals } from '../../mutation/engine.js';
+   ```
+2. Read the source module (e.g., `src/mutation/engine.ts`)
+3. Check if `_internals` already exists:
+   ```typescript
+   export const _internals = { ... };
+   ```
+4. Identify which function/method the mock.module was intercepting (usually `spawnSync`, `execFileSync`, `readFileSync`, etc.)
+
+## Step 1 — Add the function to _internals in the source file
+
+**CRITICAL:** Do NOT import type aliases from Node.js built-ins (e.g., `type SpawnSyncFn` from `node:child_process`). Use `typeof` instead.
+
+```typescript
+// BAD — fails build
+import { spawnSync, type SpawnSyncFn } from 'node:child_process';
+
+// GOOD — works at build time
+import { spawnSync } from 'node:child_process';
+type SpawnSyncFn = typeof spawnSync;
+```
+
+Add the function to `_internals`:
+```typescript
+export const _internals: {
+  executeMutation: typeof executeMutation;
+  computeReport: typeof computeReport;
+  executeMutationSuite: typeof executeMutationSuite;
+  spawnSync: SpawnSyncFn;  // ← ADD THIS
+} = {
+  executeMutation,
+  computeReport,
+  executeMutationSuite,
+  spawnSync,  // ← ADD THIS
+} as const;
+```
+
+> **Note:** The explicit type annotation on `_internals` (the `{ ... }` shape on the left side of `=`) overrides `as const` readonly inference. If you omit the explicit type annotation, `as const` will make properties `readonly` and test injection (`engineInternals.spawnSync = mockSpawnSync`) will fail at TypeScript compile time. Always include the explicit type annotation.
+
+Replace all direct calls in the module with `_internals.spawnSync(...)`:
+```typescript
+// BEFORE
+const result = spawnSync('git', ['apply', patchFile], { cwd: workingDir });
+
+// AFTER
+const result = _internals.spawnSync('git', ['apply', patchFile], { cwd: workingDir });
+```
+
+**Verify:** Run `bun run build` to ensure the type alias compiles.
+
+## Step 2 — Convert the test file
+
+### 2a. Remove mock.module block
+
+Delete the entire `mock.module(...)` block and any related mock setup.
+
+### 2b. Add module-level variables for save/restore
+
+```typescript
+// Module-level reference to the original function (saved/restored in beforeEach/afterEach)
+let originalSpawnSync: typeof import('node:child_process').spawnSync | undefined;
+
+// Module-level mock that logs calls and delegates to original
+const mockSpawnSync = mock(
+  (cmd: string, args: string[], opts: Record<string, unknown>) => {
+    spawnCallLog.push({ cmd, args, opts: { ...opts } });
+    if (originalSpawnSync) {
+      return originalSpawnSync(cmd, args, opts);
+    }
+    return {
+      pid: 12345,
+      output: Buffer.alloc(0),
+      stdout: Buffer.from('ok'),
+      stderr: Buffer.alloc(0),
+      status: 0,
+      signal: null,
+      error: undefined,
+    } as ReturnType<typeof import('node:child_process').spawnSync>;
+  },
+);
+```
+
+### 2c. Update beforeEach
+
+```typescript
+beforeEach(() => {
+  // Save original and replace with mock
+  originalSpawnSync = engineInternals.spawnSync;
+  engineInternals.spawnSync = mockSpawnSync;
+  spawnCallLog.length = 0;
+  tempDir = makeTempDir();
+});
+```
+
+### 2d. Update afterEach
+
+**CRITICAL:** Must include ALL of these in order:
+1. Restore original function
+2. Call `mockReset()` to clear mockImplementation state
+3. Clean up temp directories
+4. Clear call logs
+
+```typescript
+afterEach(() => {
+  // 1. Restore original
+  engineInternals.spawnSync = originalSpawnSync;
+  // 2. Reset mock implementation to prevent leak between tests
+  mockSpawnSync.mockReset();
+  // 3. Clean up temp directory
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+  // 4. Clear call log
+  spawnCallLog.length = 0;
+});
+```
+
+**WARNING:** Omitting `mockReset()` causes `mockImplementation` state from one test to leak into the next test's active window.
+
+### 2e. Update test assertions
+
+Replace assertions that checked `mockSpawnSync.mock.calls` with assertions that check `spawnCallLog`:
+```typescript
+// BEFORE (with mock.module)
+expect(mockSpawnSync).toHaveBeenCalledWith('git', ['apply', ...]);
+
+// AFTER (with _internals seam)
+const gitCalls = spawnCallLog.filter(c => c.cmd === 'git');
+expect(gitCalls.length).toBeGreaterThan(0);
+```
+
+## Step 3 — Verify no mock.module remains
+
+```bash
+grep -n "mock.module" <your-test-file>
+```
+Must return no matches.
+
+## Step 4 — Run tests
+
+```bash
+bun --smol test src/tools/__tests__/mutation-test.adversarial.test.ts --timeout 30000
+```
+
+## Step 5 — Check for helpers that bypass the seam
+
+Some test helpers (like `initGitRepo`) may use `require('node:child_process')` directly to bypass the mock. This is INTENTIONAL and CORRECT — they need the real subprocess to set up test fixtures.
+
+```typescript
+function initGitRepo(dir: string): void {
+  const { spawnSync: s } = require('node:child_process');
+  s('git', ['init'], { cwd: dir });
+}
+```
+
+Do NOT change these helpers to use the DI seam.
+
+## Common mistakes
+
+| Mistake | Why it fails |
+|---------|-------------|
+| Forgetting `mockReset()` in `afterEach` | `mockImplementation` state leaks between tests |
+| Using `type SpawnSyncFn` import from `node:child_process` | Type export doesn't exist at runtime; build fails |
+| Forgetting to restore `_internals.spawnSync` | Subsequent tests or other files get the mock |
+| Using async `fs.rm` in `afterEach` without `await` | Temp directories not cleaned up; use `rmSync` |
+| Converting `initGitRepo`-style helpers | These need the REAL subprocess; keep them as `require()` |
+
+## Verification checklist
+
+- [ ] Source file `_internals` includes the function
+- [ ] All calls in source use `_internals.fn(...)`
+- [ ] Test file has no `mock.module` calls
+- [ ] `beforeEach` saves original and assigns mock
+- [ ] `afterEach` restores original, calls `mockReset()`, cleans temp dir
+- [ ] All tests pass
+- [ ] `bun run build` passes

--- a/docs/releases/pending/issue-849-skills-followup.md
+++ b/docs/releases/pending/issue-849-skills-followup.md
@@ -1,0 +1,39 @@
+# Follow-up: Generated skills from Issue #849 resolution
+
+## What changed
+
+Created `.opencode/skills/generated/mock-to-internals-migration/SKILL.md` — a
+project-generated skill documenting the complete protocol for converting test
+files from `mock.module('node:child_process')` to the `_internals` dependency
+injection seam pattern.
+
+Updated `.claude/skills/writing-tests/SKILL.md` with three new sections:
+
+1. **Mock lifecycle cleanup** — `mockReset()` must be called in `afterEach` (not
+   `beforeEach`) to clear `mockImplementation` state between tests; `mockClear()`
+   in `beforeEach` only clears call history.
+
+2. **TypeScript alias pattern for DI seams** — use `type SpawnSyncFn = typeof
+   spawnSync` instead of importing named type exports from `node:child_process`
+   that don't exist at runtime.
+
+3. **Weak assertion anti-pattern** — `expect(result !== undefined).toBe(true)`
+   must be replaced with precise assertions like `expect(result).toBeNull()` or
+   `expect(result).toBeDefined()`.
+
+## Why
+
+These skills capture the lessons learned during the Issue #849 fix so that
+future migrations and test authoring follow the same patterns without
+rediscovering the pitfalls (Bun `mock.module` isolation leaks, runtime type
+errors, vague assertions).
+
+## Migration
+
+No migration required. These are additive documentation changes.
+
+## Known caveats
+
+- The `mock-to-internals-migration` skill is generated (not hand-written) and
+  should be reviewed before being promoted to a permanent team skill.
+- The `writing-tests` skill updates apply immediately to all agents that load it.


### PR DESCRIPTION
﻿Closes #849

## Summary
- Created .opencode/skills/generated/mock-to-internals-migration/SKILL.md documenting the complete protocol for converting mock.module('node:child_process') to the _internals DI seam pattern.
- Updated .claude/skills/writing-tests/SKILL.md with three new guidance sections:
  1. Mock lifecycle cleanup (mockReset() in fterEach, mockClear() in eforeEach)
  2. TypeScript alias pattern for DI seams (	ype SpawnSyncFn = typeof spawnSync)
  3. Weak assertion anti-pattern (replace expect(result !== undefined).toBe(true) with precise assertions)
- Added release note fragment docs/releases/pending/issue-849-skills-followup.md.

## Invariant audit
- 1 (plugin init): not touched - no source code changes
- 2 (runtime portability): not touched - no source code changes
- 3 (subprocesses): not touched - no source code changes
- 4 (.swarm containment): not touched - no source code changes
- 5 (plan durability): not touched - no source code changes
- 6 (test_runner safety): not touched - no source code changes
- 7 (test writing): touched - updated writing-tests skill with mock lifecycle, DI seam alias pattern, and weak assertion anti-pattern guidance; added new mock-to-internals-migration skill
- 8 (session state): not touched - no source code changes
- 9 (guardrails/retry): not touched - no source code changes
- 10 (chat/system msg): not touched - no source code changes
- 11 (tool registration): not touched - no source code changes
- 12 (release/cache): touched - added pending release note fragment

## Test plan
- [x] Verified skill files render correctly in Markdown preview
- [x] Confirmed no source code files were modified (only .claude/skills/ and .opencode/skills/)
- [x] Confirmed no package.json, CHANGELOG.md, or version files were touched
