### PR TITLE
docs(swarm-pr-review): add branch checkout pre-condition

### DIFF
--- a/.claude/skills/swarm-pr-review/SKILL.md
+++ b/.claude/skills/swarm-pr-review/SKILL.md
@@ -24,6 +24,12 @@ Determine review scope using this priority:
 3. staged changes
 4. latest commit
 
+> ⚠️ **PRE-CONDITION — Branch checkout required before Phase 2**
+> The PR branch must be checked out locally **before** dispatching any parallel explorer agents in Phase 2.
+> Explorer agents read filesystem code directly. If the branch is not checked out, they read **main branch code** and report "function does not exist" for any new or changed functions — producing invalid findings that require a full re-run of all lanes.
+> Checkout command: `git fetch origin <branch> && git checkout <branch>` (or `gh pr checkout <number>`).
+> This pre-condition is the single most important setup step for the 6-lane parallel review to produce valid results.
+
 ---
 
 ## 6-Phase Review Workflow

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.24.1",
+    version: "7.26.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,7 +51,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.24.1",
+    version: "7.26.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/docs/releases/pending/swarm-pr-review-checkout-precondition.md
+++ b/docs/releases/pending/swarm-pr-review-checkout-precondition.md
@@ -1,0 +1,22 @@
+---
+title: swarm-pr-review skill adds branch checkout pre-condition
+labels: bug
+---
+
+## What changed
+
+Added an explicit pre-condition note to the `swarm-pr-review` skill's Scope Detection section: the PR branch must be checked out locally **before** dispatching any parallel explorer agents in Phase 2.
+
+## Why
+
+During PR review of #932, the 6-lane parallel explorer agents read main branch code instead of the PR branch because the branch was not checked out. This produced invalid "function does not exist" findings requiring a full re-run of all lanes — wasting significant cycles.
+
+The fix adds a mandatory pre-condition note to the skill with the specific checkout command.
+
+## How to use
+
+No behavior change — this is documentation only.
+
+## Migration
+
+No migration required.


### PR DESCRIPTION
﻿docs(swarm-pr-review): add branch checkout pre-condition to skill

## Summary
- Added explicit pre-condition note to the swarm-pr-review skill's Scope Detection section
- Documents that the PR branch must be checked out locally before dispatching parallel explorer agents in Phase 2
- This prevents invalid \"function does not exist\" findings from agents reading main branch code instead of PR branch code

## Invariant audit
- 1 (plugin init): not touched
- 2 (runtime portability): not touched
- 3 (subprocesses): not touched
- 4 (.swarm containment): not touched
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched
- 7 (test writing): not touched
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched
- 12 (release/cache): not touched

## Test plan
- [ ] Visual inspection of skill file confirms pre-condition note is present in Scope Detection section
