### PR TITLE
fix(guardrails): scope-aware destructive command guard for coder declared scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Most AI coding tools let one model write code and ask that same model whether th
 - 🌐 **20 languages** — TypeScript, Python, Go, Rust, Java, Kotlin, C/C++, C#, Ruby, Swift, Dart, PHP, JavaScript, CSS, Bash, PowerShell, INI, Regex (extending: see [docs/adding-a-language.md](docs/adding-a-language.md))
 - 🛡️ **Built-in security** — SAST, secrets scanning, dependency audit per task
 - 📝 **Shell write detection** — Static analysis of POSIX/PowerShell/cmd commands to detect file writes (redirects, builtins, in-place editors, network downloads, archive extraction, git destructive ops) before execution
-- 🔒 **Scope enforcement** — Validates write targets against declared scope with cross-process persistence and TTL expiry
+- 🔒 **Scope enforcement** — Validates write targets against declared scope with cross-process persistence, TTL expiry, and scope-aware destructive command blocking
 - 🆓 **Free tier** — works with OpenCode Zen's free model roster
 - ⚙️ **Fully configurable** — override any agent's model, disable agents, tune guardrails
 
@@ -76,6 +76,7 @@ Swarm includes comprehensive static analysis for shell commands to detect and in
   - TTL expiry (default 24 hours)
   - Symlink guards (O_NOFOLLOW + realpath containment)
   - Schema versioning and fail-closed validation
+  - **Scope-aware destructive command blocking** — Recursive delete patterns (`rm -rf`, `rmdir /s`, `del /s`, `Remove-Item -Recurse`, `rsync --delete`) are blocked unless ALL target paths are within the declared scope (coder agents only)
 
 ### Security Patterns
 

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.25.2",
+    version: "7.26.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/docs/releases/pending/fix-scope-aware-destructive-guard.md
+++ b/docs/releases/pending/fix-scope-aware-destructive-guard.md
@@ -1,0 +1,7 @@
+## Scope-aware destructive command guard for coder declared scope
+
+`checkDestructiveCommand` now accepts a `sessionID` parameter and resolves the coder agent's declared scope. When ALL target paths of a recursive delete command (`rm -rf`, `rmdir /s`, `del /s`, `Remove-Item -Recurse`, `rsync --delete`) are within the declared scope, the operation is allowed instead of being blocked by the hardcoded safe-target allowlist.
+
+This fixes the scenario where a coder agent was tasked to delete a stale project directory like `plugins/oxlint-plugin-effect` but got blocked on every shell command (`rm -rf`, `rmdir`, `Remove-Item`) and had to resort to workarounds like `node -e fs.rmdirSync`.
+
+**Migration:** No migration required. This is additive — existing safe-target allowlist behavior is unchanged. When `declare_scope` is not used, behavior is identical to before.

--- a/src/hooks/guardrails.ts
+++ b/src/hooks/guardrails.ts
@@ -1378,9 +1378,22 @@ export function createGuardrailsHooks(
 	 *   - Remote filesystem path rejection
 	 *   - POSIX long-form flags (--recursive --force)
 	 */
-	function checkDestructiveCommand(tool: string, args: unknown): void {
+	function checkDestructiveCommand(
+		sessionID: string,
+		tool: string,
+		args: unknown,
+	): void {
 		if (tool !== 'bash' && tool !== 'shell') return;
 		if (cfg.block_destructive_commands === false) return;
+
+		// Only coder agents get scope exemption for destructive commands
+		const rawAgent = swarmState.activeAgent.get(sessionID);
+		const agentRole = rawAgent
+			? stripKnownSwarmPrefix(rawAgent).toLowerCase()
+			: 'unknown';
+		const isCoder = agentRole === 'coder';
+
+		const declaredScope = isCoder ? resolveDeclaredScope(sessionID) : null;
 		const toolArgs = args as Record<string, unknown> | undefined;
 		const rawCommand =
 			typeof toolArgs?.command === 'string' ? toolArgs.command.trim() : '';
@@ -1443,9 +1456,21 @@ export function createGuardrailsHooks(
 					DC_SAFE_TARGETS.has(t.replace(/^["']|["']$/g, '').trim()),
 				);
 				if (!allSafe) {
-					throw new Error(
-						`BLOCKED: Potentially destructive shell command: rm with recursive/force flags on unsafe path(s): ${targetPart}`,
-					);
+					const scopeExempt =
+						declaredScope != null &&
+						declaredScope.length > 0 &&
+						targets.every((t) =>
+							isInDeclaredScope(
+								t.replace(/^["']|["']$/g, '').trim(),
+								declaredScope,
+								cwd,
+							),
+						);
+					if (!scopeExempt) {
+						throw new Error(
+							`BLOCKED: Potentially destructive shell command: rm with recursive/force flags on unsafe path(s): ${targetPart}`,
+						);
+					}
 				}
 			}
 
@@ -1465,9 +1490,17 @@ export function createGuardrailsHooks(
 				if (validateBlock) throw new Error(validateBlock);
 				const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.trim()));
 				if (!allSafe) {
-					throw new Error(
-						`BLOCKED: Windows recursive directory delete on unsafe path(s): ${targets.join(', ')}`,
-					);
+					const scopeExempt =
+						declaredScope != null &&
+						declaredScope.length > 0 &&
+						targets.every((t) =>
+							isInDeclaredScope(t.trim(), declaredScope, cwd),
+						);
+					if (!scopeExempt) {
+						throw new Error(
+							`BLOCKED: Windows recursive directory delete on unsafe path(s): ${targets.join(', ')}`,
+						);
+					}
 				}
 			}
 
@@ -1482,9 +1515,17 @@ export function createGuardrailsHooks(
 					if (validateBlock) throw new Error(validateBlock);
 					const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.trim()));
 					if (!allSafe) {
-						throw new Error(
-							`BLOCKED: Windows recursive file delete (del /s) on unsafe path(s): ${targets.join(', ')}`,
-						);
+						const scopeExempt =
+							declaredScope != null &&
+							declaredScope.length > 0 &&
+							targets.every((t) =>
+								isInDeclaredScope(t.trim(), declaredScope, cwd),
+							);
+						if (!scopeExempt) {
+							throw new Error(
+								`BLOCKED: Windows recursive file delete (del /s) on unsafe path(s): ${targets.join(', ')}`,
+							);
+						}
 					}
 				}
 			}
@@ -1505,9 +1546,17 @@ export function createGuardrailsHooks(
 					if (validateBlock) throw new Error(validateBlock);
 					const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.trim()));
 					if (!allSafe) {
-						throw new Error(
-							`BLOCKED: PowerShell recursive delete on unsafe path(s): ${targets.join(', ')}`,
-						);
+						const scopeExempt =
+							declaredScope != null &&
+							declaredScope.length > 0 &&
+							targets.every((t) =>
+								isInDeclaredScope(t.trim(), declaredScope, cwd),
+							);
+						if (!scopeExempt) {
+							throw new Error(
+								`BLOCKED: PowerShell recursive delete on unsafe path(s): ${targets.join(', ')}`,
+							);
+						}
 					}
 				} else {
 					throw new Error(
@@ -1642,9 +1691,21 @@ export function createGuardrailsHooks(
 			// 12. rsync mirror / sync with delete
 			// ----------------------------------------------------------------
 			if (/^rsync\b.*--delete(?:-after|-before|-during|-delay)?\b/.test(seg)) {
-				throw new Error(
-					`BLOCKED: "rsync --delete" detected — can delete files in the destination. Verify source is not empty.`,
-				);
+				// Extract destination (last non-flag, non-remote positional arg)
+				const rsyncArgs = seg.split(/\s+/).slice(1);
+				const rsyncTarget = rsyncArgs
+					.filter((a) => !a.startsWith('-') && !a.includes('@'))
+					.pop();
+				const scopeExempt =
+					rsyncTarget != null &&
+					declaredScope != null &&
+					declaredScope.length > 0 &&
+					isInDeclaredScope(rsyncTarget, declaredScope, cwd);
+				if (!scopeExempt) {
+					throw new Error(
+						`BLOCKED: "rsync --delete" detected — can delete files in the destination. Verify source is not empty.`,
+					);
+				}
 			}
 
 			// ----------------------------------------------------------------
@@ -2969,7 +3030,7 @@ export function createGuardrailsHooks(
 			handleInterpreterGating(input.sessionID, input.tool);
 
 			// Block destructive shell commands (rm -rf, force push, kubectl delete, etc.)
-			checkDestructiveCommand(input.tool, output.args);
+			checkDestructiveCommand(input.sessionID, input.tool, output.args);
 
 			// Shell write scope enforcement: block bash/shell writes outside declared scope
 			checkShellWriteScope(input.sessionID, input.tool, output.args);

--- a/tests/unit/hooks/destructive-command-guard.test.ts
+++ b/tests/unit/hooks/destructive-command-guard.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import type { GuardrailsConfig } from '../../../src/config/schema';
 import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
-import { resetSwarmState, startAgentSession } from '../../../src/state';
+import {
+	getAgentSession,
+	resetSwarmState,
+	startAgentSession,
+} from '../../../src/state';
 
 const TEST_DIR = '/tmp';
 
@@ -287,6 +291,169 @@ describe('destructive command guard', () => {
 			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
 				/BLOCKED: Disk format command \(mkfs\) detected/,
 			);
+		});
+	});
+
+	describe('scope-aware destructive command guard', () => {
+		describe('POSIX rm -rf with scope', () => {
+			test('rm -rf plugins/oxlint-plugin-effect with scope → ALLOWED', async () => {
+				const config = defaultConfig();
+				const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+				const session = getAgentSession('test-session');
+				if (session)
+					session.declaredCoderScope = ['plugins/oxlint-plugin-effect'];
+				const input = makeBashInput(
+					'test-session',
+					'rm -rf plugins/oxlint-plugin-effect',
+				);
+				const output = makeBashOutput('rm -rf plugins/oxlint-plugin-effect');
+				await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+			});
+
+			test('rm -rf plugins/oxlint-plugin-effect without scope → BLOCKED', async () => {
+				const config = defaultConfig();
+				const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+				// No scope declared
+				const input = makeBashInput(
+					'test-session',
+					'rm -rf plugins/oxlint-plugin-effect',
+				);
+				const output = makeBashOutput('rm -rf plugins/oxlint-plugin-effect');
+				await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+					/BLOCKED/,
+				);
+			});
+
+			test('rm -rf mixed targets — one in scope, one not → BLOCKED', async () => {
+				const config = defaultConfig();
+				const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+				const session = getAgentSession('test-session');
+				if (session)
+					session.declaredCoderScope = ['plugins/oxlint-plugin-effect'];
+				const input = makeBashInput(
+					'test-session',
+					'rm -rf plugins/oxlint-plugin-effect src/other-dir',
+				);
+				const output = makeBashOutput(
+					'rm -rf plugins/oxlint-plugin-effect src/other-dir',
+				);
+				await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+					/BLOCKED/,
+				);
+			});
+		});
+
+		describe('rmdir with scope (Windows cmd.exe)', () => {
+			test('rmdir /s plugins with scope → ALLOWED', async () => {
+				const config = defaultConfig();
+				const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+				const session = getAgentSession('test-session');
+				if (session)
+					session.declaredCoderScope = ['plugins/oxlint-plugin-effect'];
+				const input = makeBashInput(
+					'test-session',
+					'rmdir /s plugins/oxlint-plugin-effect',
+				);
+				const output = makeBashOutput('rmdir /s plugins/oxlint-plugin-effect');
+				await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+			});
+		});
+
+		describe('del /s with scope (Windows cmd.exe)', () => {
+			test('del /s plugins with scope → ALLOWED', async () => {
+				const config = defaultConfig();
+				const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+				const session = getAgentSession('test-session');
+				if (session)
+					session.declaredCoderScope = ['plugins/oxlint-plugin-effect'];
+				const input = makeBashInput(
+					'test-session',
+					'del /s plugins/oxlint-plugin-effect',
+				);
+				const output = makeBashOutput('del /s plugins/oxlint-plugin-effect');
+				await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+			});
+		});
+
+		describe('Remove-Item with scope (PowerShell)', () => {
+			test('Remove-Item -Recurse plugins with scope → ALLOWED', async () => {
+				const config = defaultConfig();
+				const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+				const session = getAgentSession('test-session');
+				if (session)
+					session.declaredCoderScope = ['plugins/oxlint-plugin-effect'];
+				const input = makeBashInput(
+					'test-session',
+					'Remove-Item -Recurse plugins/oxlint-plugin-effect',
+				);
+				const output = makeBashOutput(
+					'Remove-Item -Recurse plugins/oxlint-plugin-effect',
+				);
+				await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+			});
+		});
+
+		describe('non-coder agents do not get scope exemption', () => {
+			test('rm -rf path in scope when agent is not coder → still BLOCKED', async () => {
+				const config = defaultConfig();
+				const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+				// Start agent as 'reviewer' (not coder)
+				resetSwarmState();
+				startAgentSession('test-session', 'reviewer');
+				const session = getAgentSession('test-session');
+				if (session)
+					session.declaredCoderScope = ['plugins/oxlint-plugin-effect'];
+				const input = makeBashInput(
+					'test-session',
+					'rm -rf plugins/oxlint-plugin-effect',
+				);
+				const output = makeBashOutput('rm -rf plugins/oxlint-plugin-effect');
+				await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+					/BLOCKED/,
+				);
+			});
+		});
+
+		describe('safety checks still apply within scope', () => {
+			test('rm -rf system path not in scope → still BLOCKED even with scope declared', async () => {
+				const config = defaultConfig();
+				const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+				const session = getAgentSession('test-session');
+				if (session) session.declaredCoderScope = ['plugins'];
+				const input = makeBashInput('test-session', 'rm -rf /etc');
+				const output = makeBashOutput('rm -rf /etc');
+				await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+					/BLOCKED/,
+				);
+			});
+		});
+
+		describe('rsync --delete with scope', () => {
+			test('rsync --delete plugins-dest with scope → ALLOWED', async () => {
+				const config = defaultConfig();
+				const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+				const session = getAgentSession('test-session');
+				if (session) session.declaredCoderScope = ['plugins'];
+				const input = makeBashInput(
+					'test-session',
+					'rsync -av --delete src/other plugins',
+				);
+				const output = makeBashOutput('rsync -av --delete src/other plugins');
+				await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+			});
+
+			test('rsync --delete without scope → BLOCKED', async () => {
+				const config = defaultConfig();
+				const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+				const input = makeBashInput(
+					'test-session',
+					'rsync -av --delete src/ plugins',
+				);
+				const output = makeBashOutput('rsync -av --delete src/ plugins');
+				await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+					/BLOCKED/,
+				);
+			});
 		});
 	});
 });


### PR DESCRIPTION
﻿Closes #958

## Summary

checkDestructiveCommand in src/hooks/guardrails.ts now checks the coder agent's declared scope (set via declare_scope) before blocking recursive delete operations. Previously, it unconditionally blocked m -rf, mdir /s, Remove-Item -Recurse, etc. unless the target was in a hardcoded safe list (
ode_modules, dist, .git). This forced coder agents to use workarounds like 
ode -e fs.rmdirSync when deleting legitimate project directories.

### What changed

- Added sessionID parameter to checkDestructiveCommand
- Resolves declared scope via esolveDeclaredScope(sessionID)
- Before blocking, checks if ALL target paths are within declared scope using isInDeclaredScope
- Applied to 5 blocking patterns: POSIX rm -rf, Windows rmdir /s, Windows del /s, PowerShell Remove-Item -Recurse, rsync --delete
- Non-coder agents don't get scope exemption
- All existing safety checks preserved (lstat/symlink detection, system path blocks, remote FS, UNC, FS roots)
- 10 new test cases (36 total, all passing)

## Invariant audit
- 1 (plugin init): not touched
- 2 (runtime portability): not touched
- 3 (subprocesses): not touched
- 4 (.swarm containment): touched - scope checking uses isInDeclaredScope with path.resolve/path.relative containment semantics
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched
- 7 (test writing): touched - 10 new test cases added to destructive-command-guard.test.ts using proper beforeEach isolation and getAgentSession
- 8 (session state): touched - checkDestructiveCommand now accepts sessionID parameter to look up session-scoped declared scope via resolveDeclaredScope
- 9 (guardrails/retry): touched - modified guardrails.ts checkDestructiveCommand function with scope-aware exit from destructive command blocking
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched
- 12 (release/cache): not touched

## Test plan
- [x] un run build - passes (532+328 modules, tsc declarations)
- [x] un test tests/unit/hooks/destructive-command-guard.test.ts - 36/36 pass
- [x] un test tests/unit/hooks/guardrails-model-fallback.test.ts - 25/25 pass
- [x] un test tests/unit/hooks/guardrails-pre-check-batch.test.ts - 26/26 pass
