### PR TITLE
docs(skills): add test-execution gate to swarm-pr-review and delegation strategy to pr-review-fix

### DIFF
--- a/.claude/skills/swarm-pr-review/SKILL.md
+++ b/.claude/skills/swarm-pr-review/SKILL.md
@@ -94,6 +94,26 @@ Launch all 6 lanes in parallel in a **single message with multiple Agent tool ca
 
 Explorers optimize for **recall and speed** — over-reporting is expected. Do not interpret explorer output as final findings.
 
+Determine the affected test suite using the `test_impact` tool (maps changed files to
+consumers) or `test_runner` with `scope: 'impact'` (auto-detects impacted tests from the
+diff). Avoid `scope: 'all'` or broad `scope: 'graph'` — these can trigger `scope_exceeded`
+and stall the review.
+
+Run the affected test suite:
+```bash
+bun test tests/unit/path/to/affected.test.ts --timeout 30000
+```
+This confirms candidate regressions are real (not static-analysis noise) and surfaces
+behavioral issues that code review alone cannot detect. Example: PR #959 had 15 regressions
+that only test execution revealed.
+
+**If tests fail:** classify each failure as REGRESSION (introduced by the PR) or PRE_EXISTING
+(on the base branch). Route regression failures to the coder for investigation alongside
+other confirmed findings.
+
+**Blocking gate:** If regression count > 0 after investigation, BLOCK approval.
+The review must not proceed to final output until all PR-introduced regressions are resolved.
+
 ---
 
 ### Phase 3: Independent Reviewer Confirmation
@@ -240,7 +260,14 @@ If **any** answer is yes and unaccounted for in the finding, the finding is down
 Before writing the final output, you MUST print this checklist to stdout with filled values.
 Every blank field = gate not run = final output is INVALID.
 
+Test execution is a mandatory prerequisite (see Phase 2): run the affected test suite in
+parallel with explorer lanes to confirm candidate regressions are real.
+
 ```
+[TEST EXECUTION] tests run: ___ (command used)
+[TEST EXECUTION] result: ___ (N pass, N fail)
+[TEST EXECUTION] regression failures (PR-introduced): ___ (count)
+[TEST EXECUTION] pre-existing failures (base branch): ___ (count)
 [VALIDATION] reviewer dispatched: ___ (agent type, task description)
 [VALIDATION] reviewer returned: ___ (APPROVED / REJECTED / CONCERNS — copy verdict text)
 [VALIDATION] critic dispatched: ___ (agent type, task description) OR "SKIPPED — no reviewer-confirmed HIGH or borderline-confidence findings"

--- a/.opencode/skills/generated/pr-review-fix/SKILL.md
+++ b/.opencode/skills/generated/pr-review-fix/SKILL.md
@@ -53,13 +53,57 @@ For EACH finding:
 - When downgrading, record the original severity and the recommended severity with a one-line justification.
 - Print the full validated findings table before proceeding.
 
-## Step 1a — Check normalization consistency (when applicable)
+## Step 1a — Delegation strategy: plan-based vs Task-only
+
+When fixing findings on a PR branch (no active swarm plan), the plan system's scaffolding
+requirements (spec.md, plan.json, QA gate selection) may block `declare_scope`. Choose
+the delegation strategy based on context:
+
+**Plan-based delegation (use when a plan is active):**
+- Creates `.swarm/scopes/scope-{taskId}.json` for the coder agent
+- Coder has restricted write access (only files in scope)
+- Preferred for multi-file changes where scope discipline matters
+- Requires: `.swarm/plan.json` + `.swarm/spec.md` + QA gate selection
+
+**Task-only delegation (use when fixing PR review findings without a swarm plan):**
+- Delegate to coder via **Task tool** with exact change specification
+- The coder accepts the delegation, applies fixes, runs tests, and validates changes
+  without scope restrictions (no scope file means the coder can write any file)
+- After the Task returns, verify: `syntax_check` passes on changed files,
+  relevant tests pass, no unintended file modifications
+- The architect MUST NOT edit source files directly — all code changes go through
+  the coder even when no scope is active
+
+**Mechanical vs complex:**
+- **Mechanical** (e.g., updating test expectations, renaming a parameter): one-line
+  Task delegation specifying the exact old→new text and file path
+- **Complex** (e.g., logic restructure, adding a new function): detailed Task delegation
+  with acceptance criteria, test expectations, and skill references
+
+**Enforcement: regardless of delegation strategy, the architect MUST NOT edit source files
+directly.** All code changes must go through the coder agent. The architect orchestrates,
+specifies, and validates — never edits.
+
+**Validation after Task delegation (any strategy):**
+- `syntax_check` passes on all changed files
+- No unintended files were modified by the coder
+- Relevant test suite passes
+- Diff matches the intended fix scope only
+
+**Gate:** Print your delegation strategy before proceeding:
+`DELEGATION STRATEGY: plan-based / Task-only`
+
+## Step 1b — Check normalization consistency (when applicable)
 
 When a PR adds data normalization, transformation, or coercion logic:
 
 1. Identify ALL consumer paths that read the transformed data.
 2. Verify that normalization is applied consistently across EVERY path.
 3. Common failure mode: normalization applied in one read path (e.g., gate-check) but not in another (e.g., write/update), causing silent data loss or inconsistent behavior.
+   Example: if a PR normalizes file paths during read (via `path.resolve`), verify the
+   same normalization is applied during write/update operations. Missing normalization
+   on the write path creates an asymmetry: the read gate passes but the stored value
+   bypasses normalization.
 4. If inconsistency is found, flag as a HIGH severity finding requiring shared helper extraction.
 
 ## Step 2 — Classify findings by file and fix scope

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.27.2",
+    version: "7.27.3",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/docs/releases/pending/docs-skill-test-execution-gate.md
+++ b/docs/releases/pending/docs-skill-test-execution-gate.md
@@ -1,0 +1,11 @@
+# Skill Updates: Test Execution Gate and Delegation Strategy
+
+## What changed
+- **`swarm-pr-review` skill**: Added mandatory test execution phase to the pre-synthesis gate. When reviewing a PR, the orchestrator now runs the affected test suite in parallel with explorer lanes and classifies failures as REGRESSION or PRE_EXISTING before producing the final output.
+- **`pr-review-fix` skill**: Added Step 1a — delegation strategy documentation covering plan-based vs Task-only approaches when fixing PR review findings on branches without a swarm plan.
+
+## Why
+PR #959 uncovered 15 regressions that only test execution revealed — code review alone did not surface them. The test execution gate closes this gap. The delegation strategy section documents the Task-only fallback for PR fix branches where the plan system's scaffolding (spec.md, plan.json, QA gate) is unavailable.
+
+## Migration
+No migration required. Skills are self-documenting workflow guidance.


### PR DESCRIPTION
﻿## Summary
- **swarm-pr-review skill**: Added mandatory test execution phase to the pre-synthesis gate. Reviewers now run the affected test suite in parallel with explorer lanes, classify failures as REGRESSION or PRE_EXISTING, and block approval if regression count > 0.
- **pr-review-fix skill**: Added Step 1a covering delegation strategy (plan-based vs Task-only) for PR fix branches. Explicit enforcement: architect MUST NOT edit source files directly regardless of strategy.

## Invariant audit
- 1 (plugin init): not touched - skill documentation only
- 2 (runtime portability): not touched - skill documentation only
- 3 (subprocesses): not touched - skill documentation only
- 4 (.swarm containment): not touched - skill documentation only
- 5 (plan durability): not touched - skill documentation only
- 6 (test_runner safety): not touched - skill documentation only
- 7 (test writing): not touched - skill documentation only
- 8 (session state): not touched - skill documentation only
- 9 (guardrails/retry): not touched - skill documentation only
- 10 (chat/system msg): not touched - skill documentation only
- 11 (tool registration): not touched - skill documentation only
- 12 (release/cache): not touched - skill documentation only

## Test plan
- [x] bun run build passes
- [x] Skill Markdown files parse correctly
- [x] check-title CI passes
- [ ] Remaining CI pending (docs-only change, no code impact)
