### PR TITLE
docs(skills): add codex adapters for repo skills

### DIFF
--- a/.agents/skills/commit-pr/SKILL.md
+++ b/.agents/skills/commit-pr/SKILL.md
@@ -25,7 +25,7 @@ If instructions conflict:
 
 ## Codex Execution Rules
 
-- Use `shell_command` for `git`, `gh`, build, test, and CI commands.
+- Use the available shell execution tool for `git`, `gh`, build, test, and CI commands.
 - Use `apply_patch` for manual file edits.
 - Use `multi_tool_use.parallel` for independent reads, status checks, and non-conflicting repo inspections.
 - Do not stage `.Codex/`, IDE-local files, or unrelated worktree changes.

--- a/.agents/skills/commit-pr/agents/openai.yaml
+++ b/.agents/skills/commit-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Commit PR"
+  short_description: "Publish opencode-swarm changes safely"
+  default_prompt: "Use $commit-pr to commit these changes, push the branch, and prepare the PR with the required invariant audit."

--- a/.agents/skills/contributing/SKILL.md
+++ b/.agents/skills/contributing/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: contributing
+description: Codex adapter for the opencode-swarm contribution checklist. Use when preparing user-visible changes, release note fragments, local validation, branch hygiene, PR checklist items, or contribution-policy compliance before publishing work.
+---
+
+# Contributing
+
+Read `.opencode/contributing/SKILL.md` for the canonical contribution checklist.
+
+Codex-specific execution notes:
+
+- For commits, pushes, PR creation, PR updates, and CI closeout, load `.agents/skills/commit-pr/SKILL.md`.
+- For test execution details, load `.agents/skills/running-tests/SKILL.md`.
+- For test authoring, load `.agents/skills/writing-tests/SKILL.md`.
+- For invariant-sensitive changes, load `.agents/skills/engineering-conventions/SKILL.md`.
+
+Do not hand-edit release-please-owned files. User-visible PRs need a pending release fragment under `docs/releases/pending/`.

--- a/.agents/skills/contributing/agents/openai.yaml
+++ b/.agents/skills/contributing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Contributing"
+  short_description: "Follow repo contribution rules"
+  default_prompt: "Use $contributing to prepare this opencode-swarm change for contribution."

--- a/.agents/skills/engineering-conventions/SKILL.md
+++ b/.agents/skills/engineering-conventions/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: engineering-conventions
+description: Codex adapter for opencode-swarm engineering invariants. Use before modifying plugin initialization, subprocesses, runtime portability, .swarm containment, plan durability, test_runner behavior, test-writing patterns, session/global state, guardrails/retry semantics, chat/system hooks, tool registration, release/cache hygiene, or related architecture.
+---
+
+# Engineering Conventions
+
+Use this adapter before any change that can touch a repository invariant.
+
+Read, in order:
+
+1. `AGENTS.md`
+2. `docs/engineering-invariants.md`
+3. `.opencode/skills/engineering-conventions/SKILL.md`
+
+If editing agent prompt strings or escaped template text, also skim `.claude/skills/engineering-conventions/SKILL.md` because it carries prompt-string pitfalls.
+
+Codex-specific execution notes:
+
+- Use `apply_patch` for manual edits.
+- Use the available shell execution tool for `rg`, `git`, build, smoke, and test commands.
+- Use `multi_tool_use.parallel` for independent file reads and searches.
+- Keep changes scoped and produce concrete invariant evidence for every touched invariant.
+
+The source of truth is always `AGENTS.md`. If an imported skill conflicts with it, `AGENTS.md` wins.

--- a/.agents/skills/engineering-conventions/agents/openai.yaml
+++ b/.agents/skills/engineering-conventions/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Engineering Conventions"
+  short_description: "Apply opencode-swarm invariants"
+  default_prompt: "Use $engineering-conventions before making this opencode-swarm architecture or runtime change."

--- a/.agents/skills/guardrail-patterns/SKILL.md
+++ b/.agents/skills/guardrail-patterns/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: guardrail-patterns
+description: Codex adapter for opencode-swarm destructive-command guardrail changes. Use before modifying src/hooks/guardrails.ts, checkDestructiveCommand, dcNormalizeCommand, shell-wrapper parsing, .swarm destructive-command blocking, or guardrails unit/adversarial tests.
+---
+
+# Guardrail Patterns
+
+Read, in order:
+
+1. `AGENTS.md`
+2. `.agents/skills/engineering-conventions/SKILL.md`
+3. `.agents/skills/writing-tests/SKILL.md` if tests are touched
+4. `.opencode/skills/generated/guardrail-patterns/SKILL.md`
+
+Codex-specific execution notes:
+
+- Use `rg` to locate the current guardrail section numbers before editing; line numbers in generated skills can drift.
+- Preserve wrapper-unwrapping, normalization, and per-segment evaluation order unless the task is specifically to change it.
+- Add or update adversarial tests for bypass surfaces, argument-order permutations, Windows shell forms, and `.swarm` path variants.
+- Run focused guardrail tests after the change and report exact commands.

--- a/.agents/skills/guardrail-patterns/agents/openai.yaml
+++ b/.agents/skills/guardrail-patterns/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Guardrail Patterns"
+  short_description: "Change command guardrails safely"
+  default_prompt: "Use $guardrail-patterns before changing opencode-swarm shell guardrails."

--- a/.agents/skills/mock-to-internals-migration/SKILL.md
+++ b/.agents/skills/mock-to-internals-migration/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: mock-to-internals-migration
+description: Codex adapter for migrating opencode-swarm tests away from Bun mock.module leakage toward _internals dependency-injection seams. Use when touching tests with mock.module, adding test seams, fixing Bun mock isolation failures, or updating source modules for injectable internals.
+---
+
+# Mock To Internals Migration
+
+Read `.opencode/skills/generated/mock-to-internals-migration/SKILL.md` for the canonical migration protocol.
+
+Also load:
+
+1. `.agents/skills/writing-tests/SKILL.md`
+2. `.agents/skills/engineering-conventions/SKILL.md` if the seam touches runtime-sensitive code
+
+Codex-specific execution notes:
+
+- Use `apply_patch` for source and test edits.
+- Use focused per-file `bun --smol test <file> --timeout 30000` validation first.
+- Restore any `_internals` overrides in `afterEach`.
+- Prefer small seams that expose only the dependency under test.

--- a/.agents/skills/mock-to-internals-migration/agents/openai.yaml
+++ b/.agents/skills/mock-to-internals-migration/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Mock Migration"
+  short_description: "Replace leaky mocks with seams"
+  default_prompt: "Use $mock-to-internals-migration to convert this test away from mock.module."

--- a/.agents/skills/pr-review-fix/SKILL.md
+++ b/.agents/skills/pr-review-fix/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: pr-review-fix
+description: Codex adapter for addressing pull request review feedback in opencode-swarm. Use when the user asks to fix PR review comments, requested changes, reviewer findings, CI-review notes, or a pasted review summary with low false-positive tolerance.
+---
+
+# PR Review Fix
+
+Read `.opencode/skills/generated/pr-review-fix/SKILL.md` for the canonical workflow.
+
+Codex-specific execution notes:
+
+- Treat each review item as a claim to verify against the current branch or live PR head before editing.
+- Use the GitHub app when available, or `gh`, to inspect unresolved review threads and PR metadata.
+- Use `rg`, file reads, and tests to classify each item as confirmed, disproved, pre-existing, or unverified.
+- Patch only confirmed gaps unless the user explicitly asks for speculative cleanup.
+- Load `.agents/skills/commit-pr/SKILL.md` before committing, pushing, or updating the PR.
+
+When review feedback involves tests, also load `$writing-tests`; when it involves runtime invariants, also load `$engineering-conventions`.

--- a/.agents/skills/pr-review-fix/agents/openai.yaml
+++ b/.agents/skills/pr-review-fix/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Review Fix"
+  short_description: "Verify and fix review feedback"
+  default_prompt: "Use $pr-review-fix to verify and address these PR review comments."

--- a/.agents/skills/qa-sweep/SKILL.md
+++ b/.agents/skills/qa-sweep/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: qa-sweep
+description: Codex adapter for independent QA review of opencode-swarm changes. Use after implementation or debugging when the user asks for a QA sweep, regression check, review pass, quality gate, or confidence check before publishing.
+---
+
+# QA Sweep
+
+Read `.claude/skills/qa-sweep/SKILL.md` for the source protocol, then translate it to Codex tools.
+
+Codex-specific execution notes:
+
+- Review the diff first with `git status --short` and `git diff --stat`.
+- Inspect changed files directly; do not rely only on summaries.
+- Run focused validation commands that match the changed surface.
+- For code-review output, lead with findings by severity and file/line references.
+- For implementation QA, report residual risks and tests run.
+
+Also load `$running-tests` when executing tests and `$engineering-conventions` when invariant-sensitive areas changed.

--- a/.agents/skills/qa-sweep/agents/openai.yaml
+++ b/.agents/skills/qa-sweep/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "QA Sweep"
+  short_description: "Run a focused quality review"
+  default_prompt: "Use $qa-sweep to review this change and identify remaining risks."

--- a/.agents/skills/research-first/SKILL.md
+++ b/.agents/skills/research-first/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: research-first
+description: Codex adapter for research-before-planning work. Use when a task depends on current external facts, unfamiliar libraries, APIs, standards, security advisories, release notes, product behavior, or repo behavior that must be verified before planning or implementation.
+---
+
+# Research First
+
+Read `.claude/skills/research-first/SKILL.md` for the source protocol.
+
+Codex-specific execution notes:
+
+- For current or unstable external facts, browse or use primary sources and cite URLs.
+- For repo facts, prefer `rg`, file reads, tests, and local source over memory.
+- Separate verified facts from assumptions.
+- Do not plan implementation until the relevant unknowns are resolved or explicitly marked as risks.
+
+When research affects OpenAI product usage, use the `openai-docs` skill and official sources only.

--- a/.agents/skills/research-first/agents/openai.yaml
+++ b/.agents/skills/research-first/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Research First"
+  short_description: "Verify facts before planning"
+  default_prompt: "Use $research-first to investigate this before proposing an implementation plan."

--- a/.agents/skills/running-tests/SKILL.md
+++ b/.agents/skills/running-tests/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: running-tests
+description: Codex adapter for safely executing opencode-swarm tests. Use whenever Codex needs to run focused tests, per-file isolation loops, CI-equivalent validation, test-impact checks, or diagnose failing/truncated test output without stalling the session.
+---
+
+# Running Tests
+
+Use this adapter when executing tests in `opencode-swarm`. For writing tests, load `$writing-tests` instead.
+
+Read, in order:
+
+1. `AGENTS.md`
+2. `.opencode/skills/running-tests/SKILL.md`
+
+Codex-specific execution notes:
+
+- Use the available shell execution tool for `bun --smol test` and PowerShell/bash loops.
+- Prefer `rg` and repo scripts to rediscover exact commands from source.
+- Capture long output to a temp file when needed and report the important tail or failure lines.
+- Do not use broad OpenCode `test_runner` scopes for repo validation.
+
+Default rule: one source file or one explicit test file can be targeted narrowly; multiple files or directories should use shell loops or the documented tier commands.

--- a/.agents/skills/running-tests/agents/openai.yaml
+++ b/.agents/skills/running-tests/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Running Tests"
+  short_description: "Run opencode-swarm tests safely"
+  default_prompt: "Use $running-tests to choose and run the right opencode-swarm validation commands."

--- a/.agents/skills/swarm-implement/SKILL.md
+++ b/.agents/skills/swarm-implement/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: swarm-implement
+description: Codex adapter for complex implementation work using a swarm-like workflow. Use for multi-file features, bug fixes, refactors, risky code changes, or tasks that benefit from exploration, scoped planning, implementation, review, and validation.
+---
+
+# Swarm Implement
+
+Read `.claude/skills/swarm-implement/SKILL.md` for the source workflow, then apply Codex-native tooling.
+
+Codex-specific execution notes:
+
+- Use `update_plan` for substantial multi-step work.
+- Use `multi_tool_use.parallel` for independent repo reads and searches.
+- Use `apply_patch` for manual edits.
+- Use focused shell validation after each meaningful change.
+- Bring in narrower skills as needed: `$engineering-conventions`, `$writing-tests`, `$running-tests`, `$qa-sweep`, or `$issue-tracer`.
+
+Do not invoke OpenCode `/swarm` commands from Codex unless the user explicitly asks to operate OpenCode Swarm itself.

--- a/.agents/skills/swarm-implement/agents/openai.yaml
+++ b/.agents/skills/swarm-implement/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Swarm Implement"
+  short_description: "Implement with structured rigor"
+  default_prompt: "Use $swarm-implement to plan, implement, review, and validate this change."

--- a/.agents/skills/swarm-pr-review/SKILL.md
+++ b/.agents/skills/swarm-pr-review/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: swarm-pr-review
+description: Codex adapter for deep pull request review with swarm-like breadth and low false-positive tolerance. Use when asked to review a PR, inspect a branch diff, find regressions, validate review claims, or produce merge-risk recommendations.
+---
+
+# Swarm PR Review
+
+Read `.claude/skills/swarm-pr-review/SKILL.md` for the source review protocol, then apply Codex's review rules.
+
+Codex-specific execution notes:
+
+- Default to code-review stance: findings first, ordered by severity, with file/line references.
+- Inspect the diff, touched contracts, tests, docs, and relevant invariants.
+- Verify suspected issues against actual code paths before reporting them.
+- Use the GitHub app or `gh` for PR metadata when available.
+- Run targeted checks only when they materially improve confidence.
+
+For opencode-swarm invariant-sensitive PRs, also load `$engineering-conventions`; for test changes, load `$writing-tests`.

--- a/.agents/skills/swarm-pr-review/agents/openai.yaml
+++ b/.agents/skills/swarm-pr-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Swarm PR Review"
+  short_description: "Review PRs with high rigor"
+  default_prompt: "Use $swarm-pr-review to perform a deep review of this pull request."

--- a/.agents/skills/swarm/SKILL.md
+++ b/.agents/skills/swarm/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: swarm
+description: Codex adapter for enabling a higher-rigor swarm-like workflow in the current Codex thread. Use when the user asks for swarm mode, maximum quality, parallel investigation, extra review rigor, or a swarm-style approach without necessarily invoking the OpenCode Swarm plugin.
+---
+
+# Swarm
+
+Read `.claude/skills/swarm/SKILL.md` for the source behavior model, then adapt it to Codex.
+
+Codex-specific execution notes:
+
+- Treat this as a workflow posture, not an instruction to call OpenCode `/swarm` commands.
+- Use parallel local reads/searches where safe.
+- Use `update_plan` for visible task tracking on substantial work.
+- Add independent review pressure through `$qa-sweep`, `$swarm-pr-review`, or self-critic checks when subagents are unavailable.
+- Keep the user looped in with short progress updates during longer work.
+
+For implementation tasks, prefer `$swarm-implement`; for PR review, prefer `$swarm-pr-review`; for bug tracing, prefer `$issue-tracer`.

--- a/.agents/skills/swarm/agents/openai.yaml
+++ b/.agents/skills/swarm/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Swarm"
+  short_description: "Use a higher-rigor workflow"
+  default_prompt: "Use $swarm to approach this task with a swarm-style workflow."

--- a/.agents/skills/tech-debt-ci-review/SKILL.md
+++ b/.agents/skills/tech-debt-ci-review/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: tech-debt-ci-review
+description: Codex adapter for deep technical-debt and CI-stability audits. Use when asked to find test theater, flaky tests, missing or mis-scoped tests, brittle CI/toolchain behavior, structural debt blocking green PRs, or a remediation order for opencode-swarm.
+---
+
+# Tech Debt CI Review
+
+Read `.claude/skills/tech-debt-ci-review/SKILL.md` for the canonical audit structure.
+
+Codex-specific execution notes:
+
+- Start from actual CI/workflow files, test scripts, recent failures, and current repo state.
+- Use shell commands and `rg` to gather evidence; avoid broad `test_runner` scopes.
+- Prioritize findings that can cause false green, false red, flaky CI, or blocked release flow.
+- Produce findings with file/line references, impact, evidence, and a remediation order.
+
+Load `$running-tests` for validation command selection and `$engineering-conventions` when findings touch repo invariants.

--- a/.agents/skills/tech-debt-ci-review/agents/openai.yaml
+++ b/.agents/skills/tech-debt-ci-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Tech Debt CI Review"
+  short_description: "Audit CI and test reliability"
+  default_prompt: "Use $tech-debt-ci-review to audit this repo's CI and test debt."

--- a/.agents/skills/unswarm/SKILL.md
+++ b/.agents/skills/unswarm/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: unswarm
+description: Codex adapter for disabling a previously requested swarm-like workflow in the current thread. Use when the user says unswarm, stop swarm mode, return to normal mode, simplify the workflow, or stop using extra review/delegation rigor.
+---
+
+# Unswarm
+
+Read `.claude/skills/unswarm/SKILL.md` only if you need the original Claude command semantics.
+
+For Codex, this skill means:
+
+- Stop applying `$swarm` or `$swarm-implement` as an ongoing workflow posture unless the user explicitly asks for it again.
+- Keep following repository instructions, safety rules, and any task-specific skills that still apply.
+- Prefer direct execution and concise updates over extra planning/review layers.
+- Do not make file changes solely to "disable" swarm mode.

--- a/.agents/skills/unswarm/agents/openai.yaml
+++ b/.agents/skills/unswarm/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Unswarm"
+  short_description: "Return to normal workflow"
+  default_prompt: "Use $unswarm to stop applying swarm-mode workflow behavior in this thread."

--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: writing-tests
+description: Codex adapter for opencode-swarm test authoring rules. Use before creating or modifying any test file in this repository, especially bun:test files, mock.module usage, _internals seams, temp directories, cross-platform tests, or CI-sensitive test structure.
+---
+
+# Writing Tests
+
+Use this Codex-facing adapter before touching tests in `opencode-swarm`.
+
+Read, in order:
+
+1. `AGENTS.md`
+2. `.opencode/skills/writing-tests/SKILL.md`
+
+If the task also touches architecture, plugin initialization, subprocesses, tool registration, plan durability, `.swarm` storage, runtime portability, session/global state, guardrails/retry, chat/system hooks, or release/cache behavior, also load `.agents/skills/engineering-conventions/SKILL.md`.
+
+Codex-specific execution notes:
+
+- Use `apply_patch` for manual test/source edits.
+- Use the available shell execution tool for `bun --smol test`, per-file loops, `rg`, and validation commands.
+- Prefer shell test commands for repo validation. Do not use broad OpenCode `test_runner` scopes.
+- Preserve unrelated user changes in the worktree.
+
+Carry forward the source skill's core rules: `bun:test` only, dependency injection or `_internals` over `mock.module` where possible, real module spreading when mocking Node built-ins, `os.tmpdir()` plus `path.join(...)` for temp paths, and per-file isolation for mock-heavy directories.

--- a/.agents/skills/writing-tests/agents/openai.yaml
+++ b/.agents/skills/writing-tests/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Writing Tests"
+  short_description: "Author bun:test suites safely"
+  default_prompt: "Use $writing-tests before adding or changing tests in opencode-swarm."

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.27.3",
+    version: "7.27.4",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/docs/releases/pending/codex-skill-adapters.md
+++ b/docs/releases/pending/codex-skill-adapters.md
@@ -1,0 +1,5 @@
+# Codex skill adapters for repo workflows
+
+- Added Codex-native `.agents/skills/` adapters for the existing `.opencode` and `.claude` repository skills so Codex can discover and trigger the same workflows from this repo.
+- The adapters point at the canonical source skills instead of duplicating long bodies, with Codex-specific tool guidance for shell execution, `apply_patch`, `multi_tool_use.parallel`, validation, and review behavior.
+- Added `agents/openai.yaml` metadata for the Codex-facing skills to improve skill list display and default prompts.


### PR DESCRIPTION
﻿## Summary
- Add Codex-discoverable `.agents/skills/` adapters for the existing repo skill workflows from `.opencode` and `.claude`.
- Add `agents/openai.yaml` display metadata/default prompts for the Codex-facing skills.
- Add a pending release fragment for the new Codex skill adapters.
- Sync committed dist version constants with `package.json` to satisfy `dist-check`.

## Invariant audit
- 1 (plugin init): not touched - branch diff changes `.agents/skills/**`, `docs/releases/pending/codex-skill-adapters.md`, and generated dist package-version constants only; no plugin init source changed.
- 2 (runtime portability): touched - dist bundle metadata changed only from `7.27.3` to `7.27.4`; `dist-check` rerun on CI after this update.
- 3 (subprocesses): not touched - no source subprocess code changed.
- 4 (.swarm containment): not touched - no `.swarm` runtime code or working-directory helpers changed.
- 5 (plan durability): not touched - no plan ledger/projection/checkpoint code changed.
- 6 (test_runner safety): not touched - no `test_runner` implementation changed; adapters explicitly warn not to use broad scopes.
- 7 (test writing): not touched - no test files changed; `writing-tests` adapter points at the canonical test-writing skill.
- 8 (session state): not touched - no session/global state code changed.
- 9 (guardrails/retry): not touched - no guardrail/retry runtime code changed.
- 10 (chat/system msg): not touched - no chat/system hook code changed.
- 11 (tool registration): not touched - no tools, agent maps, or plugin registration changed.
- 12 (release/cache): touched - added `docs/releases/pending/codex-skill-adapters.md`; did not edit release-please-owned version, changelog, or manifest files.

## Test plan
- [x] `python -m pip install --user PyYAML` to satisfy the local skill validator dependency.
- [x] `python C:\Users\Brett\.codex\skills\.system\skill-creator\scripts\quick_validate.py <skill-dir>` for all 16 `.agents/skills` directories - all reported `Skill is valid!`.
- [x] Source/Codex skill coverage check: `all source skill names imported: 16`.
- [x] `rg -n "shell_command|TODO|FIXME" .agents\skills docs\releases\pending\codex-skill-adapters.md` - no matches.
- [x] `bun run typecheck` - passed.
- [x] `bunx biome ci .` - completed with 7 pre-existing `noExplicitAny` warnings in `src/index.ts`; no changed files flagged and no fixes applied.
- [x] `bun run build` - passed locally; Windows build produced broader bundle churn, so only the CI-reported version-constant drift was committed.

## Notes
- Local plain `git push` continued to hang in Git Credential Manager, but `gh` auth is now working. The final dist fix was pushed using the `gh auth token` as an in-memory Git HTTP header.
