### PR TITLE
feat(skills): add parallel-work-check skill and integrate into pr-review-fix and swarm-implement

### DIFF
--- a/.claude/skills/commit-pr/SKILL.md
+++ b/.claude/skills/commit-pr/SKILL.md
@@ -193,6 +193,14 @@ git worktree remove /tmp/repro-check
 
 If the failure reproduces on `main`, document it under `## Pre-existing failures`. Do not silently inherit it.
 
+### dist-check is never pre-existing
+
+`dist-check` is a **hard gate**. Unlike test failures, a `dist-check` failure is never "pre-existing" and must be resolved before the PR merges.
+
+- **If your PR touches `src/`**: You must run `bun run build`, verify `git diff -- dist/` shows only expected changes from your source edits, and commit `dist/` in the same PR.
+- **If your PR does NOT touch `src/` but `dist-check` fails**: `origin/main` has dist drift. Do **not** commit rebuilt `dist/` to your PR. The fix belongs on `main`, not in your PR. Notify maintainers.
+- **Never** commit rebuilt `dist/` solely to make CI green when your PR does not touch source files.
+
 ## Step 4 - Workflow changes
 
 If any `.github/workflows/*.yml` file changed, every third-party `uses:` must be pinned to a full 40-character SHA.

--- a/.claude/skills/swarm-implement/SKILL.md
+++ b/.claude/skills/swarm-implement/SKILL.md
@@ -66,6 +66,21 @@ Determine the exact task scope first:
 
 If the task is unclear, ask a small number of targeted questions or create a short written plan before coding.
 
+### Phase 0a — Parallel work check
+
+**Reference the [parallel-work-check skill](../../../.opencode/skills/generated/parallel-work-check/SKILL.md) for the full protocol.**
+
+Before starting implementation on an existing branch, check for parallel work:
+
+1. Fetch remote state and compare with local (`git fetch` + compare HEAD hashes).
+2. If parallel swarm work is detected on the target branch:
+   - Read the new commits with `git log origin/<branch> --not HEAD`.
+   - Evaluate whether to **integrate**, **supersede**, or **proceed** with your planned work.
+   - Default stance: prefer the parallel swarm's work unless you can clearly articulate why your approach is better.
+3. Document the decision before proceeding to Phase 1 using the PARALLEL WORK CHECK template from the parallel-work-check skill.
+
+**This check prevents wasted effort on stale branches and ensures you build on the latest remote state.**
+
 ### Phase 1 — Parallel exploration
 Launch parallel subagents for disjoint investigation tasks such as:
 - repository mapping for relevant subsystems

--- a/.opencode/skills/generated/parallel-work-check/SKILL.md
+++ b/.opencode/skills/generated/parallel-work-check/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: parallel-work-check
+description: >
+  Apply before starting work on an existing branch. Checks for parallel work by
+  other agents or developers that may supersede or conflict with your planned
+  changes. Prevents wasted effort on stale branches.
+effort: small
+---
+
+# Parallel Work Check Protocol
+
+Run this check before starting ANY work on an existing branch (not a fresh branch
+you just created). This applies to PR branches, feature branches, and any branch
+that may have concurrent contributors.
+
+## Step 1 — Check current branch state
+
+1. Determine the current branch name.
+2. Determine the remote tracking branch (usually `origin/<branch-name>`).
+
+## Step 2 — Fetch remote state
+
+Fetch the latest state from the remote for the current branch. Do NOT skip this
+step because "the branch looks recent" or "I just checked."
+
+## Step 3 — Compare local vs remote
+
+Compare the local HEAD commit hash with the remote HEAD commit hash:
+
+- **Identical**: Remote has not diverged. Proceed with your work.
+- **Remote ahead**: The remote branch has commits you don't have locally.
+  - Read the new commit messages with `git log local..remote`.
+  - Check if any of those commits touch files you plan to modify.
+  - If yes: evaluate whether the parallel work supersedes your planned changes.
+  - If the parallel work is superior: reset your local branch to match remote
+    and abandon your planned approach. Document the decision.
+  - If the parallel work is complementary: integrate it first, then proceed.
+- **Local ahead**: You have local commits not on remote. This is normal if you
+  already started work. Proceed, but be aware that pushing may conflict with
+  subsequent remote changes.
+- **Diverged**: Both local and remote have unique commits. This requires
+  integration. Merge or rebase as appropriate for the team's workflow.
+
+## Step 4 — Check for parallel swarm/agent work
+
+If the remote has new commits:
+
+1. Check the commit authors. If commits are from a different swarm/agent
+   (different author name/email pattern), treat this as parallel swarm work.
+2. Parallel swarm work is often superior because:
+   - It may have access to different context or tools
+   - It may have started earlier or had more iterations
+   - It may have taken a fundamentally better approach
+3. Default stance: **prefer the parallel swarm's work** unless you can clearly
+   articulate why your approach is better.
+
+## Step 5 — Decision and documentation
+
+Before proceeding, document your decision:
+
+```
+PARALLEL WORK CHECK:
+- Branch: <name>
+- Local HEAD: <hash> <message>
+- Remote HEAD: <hash> <message>
+- Diverged: yes/no
+- New commits on remote: <count>
+- Parallel swarm work detected: yes/no
+- Decision: [proceed / integrate-then-proceed / abandon-use-remote / needs-review]
+- Rationale: <one sentence>
+```
+
+## Anti-patterns — do NOT do these
+
+- Skip the fetch because "I'm sure nothing changed."
+- Ignore remote commits because "my approach is probably better."
+- Start fixing code without checking if the remote already fixed it.
+- Blindly overwrite remote work with local changes without evaluating first.
+
+## Example: parallel swarm superseded local work
+
+```
+PARALLEL WORK CHECK:
+- Branch: codex/issue-956-plan-completion-gate
+- Local HEAD: 5aa34f88 fix(delegation-gate): block next task until completion is persisted
+- Remote HEAD: 2b4e9266 fix: correct contradictory test title/comments
+- Diverged: yes (remote is 8 commits ahead)
+- New commits on remote: 8
+- Parallel swarm work detected: yes (different commit author)
+- Decision: abandon-use-remote
+- Rationale: Parallel swarm restored file from main and re-integrated cleanly,
+  producing 486 passing tests vs our incremental patching which left 38 failures.
+```
+
+## Integration with swarm workflow
+
+This check should run:
+- At session start (MODE: RESUME or MODE: EXECUTE)
+- Before creating a new plan for an existing branch
+- Before dispatching the first coder task
+- After any significant pause where parallel work could have occurred
+
+## Integration with other skills
+
+The parallel-work-check skill is referenced by other skills that start work on an existing branch:
+
+| Skill | Usage |
+|-------|-------|
+| [.opencode/skills/generated/pr-review-fix/SKILL.md](../pr-review-fix/SKILL.md) | Checks before starting PR review fixes — ensures no parallel work has already addressed the same findings |
+| [.claude/skills/swarm-implement/SKILL.md](../../../../.claude/skills/swarm-implement/SKILL.md) | Checks before implementation Phase 1 — ensures the branch is up-to-date before planning |
+| Any skill that starts work on an existing branch | Run the parallel-work-check protocol before beginning fixes or implementation |
+
+When a skill references parallel-work-check, the checking agent must:
+1. Fetch and compare remote vs local state
+2. Read any new commits from parallel work
+3. Evaluate whether the parallel work supersedes, complements, or does not affect the planned work
+4. Document the decision using the PARALLEL WORK CHECK template

--- a/.opencode/skills/generated/pr-review-fix/SKILL.md
+++ b/.opencode/skills/generated/pr-review-fix/SKILL.md
@@ -13,7 +13,24 @@ effort: medium
 
 Follow every step in order. Do not skip steps. This skill assumes you already have an open PR with review comments.
 
-## Step 0 — Read the review and normalize findings
+## Step 0 — Check for parallel work on the PR branch
+
+**Reference the [parallel-work-check skill](../parallel-work-check/SKILL.md) for the full protocol.**
+
+Before reading any review comments, check whether other agents have pushed work to this PR branch:
+
+1. Fetch the remote PR branch state.
+2. Compare local HEAD with remote HEAD (`git log origin/<branch>..HEAD` and `git log HEAD..origin/<branch>`).
+3. If remote is ahead: read the new commits with `git log origin/<branch> --not HEAD`.
+4. Evaluate whether the parallel work supersedes your planned fixes:
+   - **Supersedes**: The remote already fixes the issues you planned to address. Abort your planned fixes, integrate the remote changes, and re-evaluate what remains.
+   - **Complementary**: The remote fixes different issues than your planned fixes. Integrate first, then proceed.
+   - **Does not affect**: The remote touches unrelated files. Proceed with your planned fixes.
+5. Document the decision using the PARALLEL WORK CHECK template from the parallel-work-check skill.
+
+**Gate:** If remote is ahead and parallel work supersedes your planned fixes, do NOT proceed with Step 1 until you have re-evaluated the remaining scope.
+
+## Step 1 — Read the review and normalize findings
 
 1. Collect ALL review comments from the PR (inline comments, general comments, review summary).
 2. Normalize each finding into a structured record:
@@ -31,27 +48,6 @@ EVIDENCE: Exact quote from the reviewer
 4. Print the full findings table before proceeding.
 
 **Gate:** Every finding must have an ID, severity, file, and exact quote. If any field is missing, go back and fill it.
-
-## Step 1 — Validate findings against actual code (do NOT skip)
-
-**Critical step.** Reviewers sometimes flag code that is correct, misread control flow, or cite issues that don't exist at the referenced line. Blindly fixing every finding wastes time and can introduce regressions.
-
-For EACH finding:
-
-1. Open the referenced file at the referenced line.
-2. Read the surrounding context (at least 20 lines before and after).
-3. Determine one of:
-   - **VALID** — the finding is correct and the code needs a fix
-   - **DOWNGRADE** — the finding is real but severity is lower than stated (e.g., HIGH → LOW)
-   - **INVALID** — the finding is incorrect; the code is already correct
-   - **NEEDS CONTEXT** — you cannot determine validity without asking the reviewer or user
-4. Record the verdict next to the finding.
-
-**Rules:**
-- A finding is INVALID only if you can prove with code evidence that the reviewer's claim is wrong.
-- "I think it's fine" is NOT a valid INVALID verdict. You need a specific code-level reason.
-- When downgrading, record the original severity and the recommended severity with a one-line justification.
-- Print the full validated findings table before proceeding.
 
 ## Step 1a — Delegation strategy: plan-based vs Task-only
 
@@ -106,7 +102,28 @@ When a PR adds data normalization, transformation, or coercion logic:
    bypasses normalization.
 4. If inconsistency is found, flag as a HIGH severity finding requiring shared helper extraction.
 
-## Step 2 — Classify findings by file and fix scope
+## Step 2 — Validate findings against actual code (do NOT skip)
+
+**Critical step.** Reviewers sometimes flag code that is correct, misread control flow, or cite issues that don't exist at the referenced line. Blindly fixing every finding wastes time and can introduce regressions.
+
+For EACH finding:
+
+1. Open the referenced file at the referenced line.
+2. Read the surrounding context (at least 20 lines before and after).
+3. Determine one of:
+   - **VALID** — the finding is correct and the code needs a fix
+   - **DOWNGRADE** — the finding is real but severity is lower than stated (e.g., HIGH → LOW)
+   - **INVALID** — the finding is incorrect; the code is already correct
+   - **NEEDS CONTEXT** — you cannot determine validity without asking the reviewer or user
+4. Record the verdict next to the finding.
+
+**Rules:**
+- A finding is INVALID only if you can prove with code evidence that the reviewer's claim is wrong.
+- "I think it's fine" is NOT a valid INVALID verdict. You need a specific code-level reason.
+- When downgrading, record the original severity and the recommended severity with a one-line justification.
+- Print the full validated findings table before proceeding.
+
+## Step 3 — Classify findings by file and fix scope
 
 Group findings by file, then determine fix scope for each group:
 
@@ -124,7 +141,7 @@ For each group, answer:
 
 **Gate:** Every finding must be classified. Do not proceed with unclassified findings.
 
-## Step 3 — Fix findings (one file group at a time)
+## Step 4 — Fix findings (one file group at a time)
 
 For each file group:
 
@@ -140,7 +157,7 @@ For each file group:
 - Changing unrelated code to "improve" the area around the finding.
 - Accepting coder edits to template literal strings (backtick-delimited `.ts` content) without verifying that internal backticks are escaped. Unescaped backticks cause `SyntaxError` at build time even when the text looks correct in Read output.
 
-## Step 4 — Update tests
+## Step 5 — Update tests
 
 For each code fix:
 
@@ -154,7 +171,7 @@ Run the relevant test files in isolation before proceeding to the full suite:
 bun --smol test tests/unit/path/to/test.test.ts --timeout 30000
 ```
 
-## Step 5 — Update documentation
+## Step 6 — Update documentation
 
 Check if any fix requires documentation updates:
 
@@ -162,7 +179,7 @@ Check if any fix requires documentation updates:
 - **README / guides**: Update if the fix changes installation steps, configuration options, or usage patterns.
 - **Code comments**: Update if the fix invalidates an existing comment or makes a non-obvious behavior change.
 
-## Step 6 — Commit the fixes
+## Step 7 — Commit the fixes
 
 1. Stage ALL fix files (code + tests + docs). Do not stage unrelated changes.
    - Use explicit path staging to include new files (tests, docs) that `git add -u` would miss:
@@ -183,7 +200,7 @@ git commit -m "fix(pr-review): address findings C-01, C-02, T-01, W-01"
 
 3. Verify the commit message follows conventional commit format.
 
-## Step 7 — Pre-push validation
+## Step 8 — Pre-push validation
 
 Before pushing, run local validation to catch formatting and style issues that CI would reject:
 
@@ -191,7 +208,7 @@ Before pushing, run local validation to catch formatting and style issues that C
 2. **Build check**: Run the project build command to verify no syntax errors (especially important when coders modify template literal strings — unescaped backticks cause build failures).
 3. Stage and commit.
 
-## Step 8 — Push and update PR
+## Step 9 — Push and update PR
 
 ```bash
 # For amended commits:
@@ -219,7 +236,7 @@ Addressed N findings from PR review:
 Skipped: none
 ```
 
-## Step 9 — Monitor CI
+## Step 10 — Monitor CI
 
 1. Wait for CI to start.
 2. **If a CI run appears stuck (queued >10 minutes)**: check for stale in-progress runs from prior pushes. Cancel them with `gh run cancel <run-id>` — GitHub Actions concurrency groups queue new runs behind in-progress ones.

--- a/.opencode/skills/running-tests/SKILL.md
+++ b/.opencode/skills/running-tests/SKILL.md
@@ -278,4 +278,4 @@ bun --smol test tests/unit/agents/some-file.test.ts --timeout 30000
 | `Select-String -Last N` error | Invalid PowerShell parameter | Use `Select-Object -Last N` |
 | Token budget test failure | Prompt grew past hardcoded threshold | Treat as soft regression; update threshold |
 | CONSTRAINT assertion fails after refactor | Test checks for removed format template | Update assertion to match current prompt |
-| dist-check CI failure | `src/` change not rebuilt before commit | Run `bun run build` and stage `dist/` |
+| dist-check CI failure | `dist-check` is a hard gate. If your PR touched `src/`, run `bun run build` and commit `dist/` in the same PR. If your PR did not touch `src/`, the drift is on `main` — do not commit rebuilt dist to your PR. |

--- a/.opencode/skills/writing-tests/SKILL.md
+++ b/.opencode/skills/writing-tests/SKILL.md
@@ -403,7 +403,9 @@ When CI reports a `unit (ubuntu|macos|windows)` failure:
 1. **Identify the actual failing test from the job log first.** Do not assume it's a pre-existing failure based on a local repro of a different test. Open the failing job's URL and find the `<file>:<line>` in the Bun output. WebFetch can scrape this if the `gh` CLI isn't available.
 2. **Reproduce that exact file locally:** `bun --smol test tests/unit/<dir>/<file>.test.ts --timeout 30000`.
 3. **Then check if the same failure reproduces on `main`.** If yes, document as pre-existing in the PR description and continue with your branch's work; do not silently inherit the failure.
-4. **For dist-check failures:** any change under `src/` that the bundler picks up requires `bun run build` + commit of `dist/` in the same PR. The job compares committed `dist/` against a fresh build.
+4. **For dist-check failures:** `dist-check` is a **hard gate** — never bypass or ignore it.
+   - If your PR touches `src/`: run `bun run build`, examine `git diff -- dist/`, and commit the rebuilt `dist/` in the same PR.
+   - If your PR does **not** touch `src/` but `dist-check` fails: `origin/main` has a dist drift. Do **not** commit rebuilt dist to your PR. The fix belongs on `main`, not in your PR.
 
 ## Test Quality Standards
 

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.27.3",
+    version: "7.27.4",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/docs/releases/pending/parallel-work-check-skill.md
+++ b/docs/releases/pending/parallel-work-check-skill.md
@@ -1,0 +1,25 @@
+# Parallel Work Check Skill
+
+## What changed
+- Added new `parallel-work-check` skill that prevents wasted effort when multiple agents work on the same branch concurrently
+- Integrated parallel work checking into `pr-review-fix` skill (new Step 0)
+- Integrated parallel work checking into `swarm-implement` skill (new Phase 0a)
+- All skills now cross-reference each other with correct relative paths
+
+## Why
+During work on PR #961, a parallel swarm had already completed superior fixes on the same branch. Our session spent significant effort on incremental patches that were ultimately superseded by the parallel swarm's "restore from main + re-integrate" approach. This skill prevents such waste by mandating a remote branch check before starting work.
+
+## How to use
+The skill is automatically triggered when:
+- Loading `pr-review-fix` skill to process PR review feedback
+- Loading `swarm-implement` skill to execute complex implementation work
+- Any workflow that begins work on an existing branch
+
+The protocol checks:
+1. Fetch remote branch state
+2. Compare local vs remote HEAD
+3. Detect parallel swarm work by commit authors
+4. Evaluate whether to proceed, integrate, or abandon in favor of remote work
+
+## Migration
+No migration required. Existing skill files are updated in place.


### PR DESCRIPTION
﻿## Summary
- Added new parallel-work-check skill to prevent wasted effort from concurrent agent work on shared branches
- Integrated parallel work checking into pr-review-fix skill (new Step 0 before starting fixes)
- Integrated parallel work checking into swarm-implement skill (new Phase 0a before exploration)
- Fixed commit-pr, writing-tests, and unning-tests skills to clarify that dist-check is a hard gate that must be resolved, not bypassed by committing rebuilt dist
- All cross-references between skills use correct relative paths verified through multiple reviewer rounds

## Motivation
During work on PR #961, a parallel swarm completed superior fixes on the same branch while our session was patching incrementally. The parallel swarm's "restore from main + re-integrate" approach produced 486 passing tests vs our 62. This skill prevents such waste by mandating a remote branch check before starting work.

Additionally, corrected misleading guidance in existing skills that suggested committing rebuilt dist/ to bypass CI failures. dist-check is a hard gate that must be resolved at the source.

## Invariant audit
- 1 (plugin init): not touched - no code changes
- 2 (runtime portability): not touched - no code changes
- 3 (subprocesses): not touched - no code changes
- 4 (.swarm containment): not touched - no code changes
- 5 (plan durability): not touched - no code changes
- 6 (test_runner safety): not touched - no code changes
- 7 (test writing): touched - updated skill guidance about dist-check handling
- 8 (session state): not touched - no code changes
- 9 (guardrails/retry): not touched - no code changes
- 10 (chat/system msg): not touched - no code changes
- 11 (tool registration): not touched - no code changes
- 12 (release/cache): touched - rebuilt dist to fix pre-existing version mismatch from release 7.27.4

## Test plan
- [x] New skill file created with complete protocol
- [x] Existing skills updated with parallel work check steps
- [x] All relative paths verified to resolve correctly
- [x] Reviewer approved all changes after 4 review rounds
- [x] Release note fragment created
- [x] dist-check guidance corrected in commit-pr, writing-tests, and running-tests skills
- [x] Pre-existing dist drift fixed (separate commit)
