### PR TITLE
fix(skills): propagate descriptions to subagents

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.27.4",
+    version: "7.28.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/dist/hooks/skill-propagation-gate.d.ts
+++ b/dist/hooks/skill-propagation-gate.d.ts
@@ -58,6 +58,7 @@ export declare const _internals: {
     appendSkillUsageEntry: typeof appendSkillUsageEntry;
     readSkillUsageEntries: typeof readSkillUsageEntries;
     readSkillUsageEntriesTail: typeof readSkillUsageEntriesTail;
+    extractSkillsFieldFromPrompt: typeof extractSkillsFieldFromPrompt;
     parseSkillPaths: typeof parseSkillPaths;
     extractTaskIdFromPrompt: typeof extractTaskIdFromPrompt;
     computeSkillRelevanceScore: typeof computeSkillRelevanceScore;
@@ -82,6 +83,15 @@ export declare function parseDelegationArgs(args: unknown): {
     targetAgent: string;
     skillsField: string;
 } | null;
+/**
+ * Extracts the value of a SKILLS field from a delegation prompt. Supports both
+ * legacy one-line fields (`SKILLS: file:...`) and description-rich blocks:
+ *
+ *   SKILLS:
+ *   - file:.claude/skills/writing-tests/SKILL.md - test conventions
+ *   - file:.claude/skills/react/SKILL.md - React UI patterns
+ */
+export declare function extractSkillsFieldFromPrompt(prompt: string): string;
 /** Write a warning event to .swarm/events.jsonl (sync, best-effort). */
 export declare function writeWarnEvent(directory: string, record: Record<string, unknown>): void;
 /**

--- a/dist/hooks/skill-scoring.d.ts
+++ b/dist/hooks/skill-scoring.d.ts
@@ -33,11 +33,22 @@ export interface SkillStats {
         count: number;
     }>;
 }
+/** Metadata extracted from a SKILL.md frontmatter block. */
+export interface SkillMetadata {
+    /** Repo-relative path to the skill file. */
+    path: string;
+    /** Human-readable skill name. */
+    name: string;
+    /** Short description from frontmatter, or a fallback when absent. */
+    description: string;
+}
 export declare const _internals: {
     computeSkillRelevanceScore: typeof computeSkillRelevanceScore;
     rankSkillsForContext: typeof rankSkillsForContext;
     getSkillStats: typeof getSkillStats;
     formatSkillIndexWithContext: typeof formatSkillIndexWithContext;
+    parseSkillFrontmatter: typeof parseSkillFrontmatter;
+    readSkillMetadata: typeof readSkillMetadata;
     extractSkillName: typeof extractSkillName;
     computeRecencyScore: typeof computeRecencyScore;
     computeContextMatchScore: typeof computeContextMatchScore;
@@ -47,6 +58,18 @@ export declare const _internals: {
  * E.g. `.claude/skills/writing-tests/SKILL.md` → `writing-tests`
  */
 declare function extractSkillName(skillPath: string): string;
+/**
+ * Parse the YAML-like frontmatter from a SKILL.md file. This intentionally
+ * supports only the small subset skills use today: scalar `name` and scalar,
+ * folded (`>`), or literal (`|`) `description`.
+ */
+export declare function parseSkillFrontmatter(content: string, skillPath: string): SkillMetadata;
+/**
+ * Extract skill metadata from a repo-relative SKILL.md path. Fails open to
+ * path-derived metadata when the file is missing, outside the project, or has
+ * malformed frontmatter.
+ */
+export declare function readSkillMetadata(skillPath: string, directory: string): SkillMetadata;
 /**
  * Computes a recency score in [0, 1] based on how recently the skill was used.
  * Full score (1.0) for usage within 24 hours, linearly decaying to 0 over 30 days.

--- a/docs/releases/pending/skill-description-aware-propagation-957.md
+++ b/docs/releases/pending/skill-description-aware-propagation-957.md
@@ -1,0 +1,21 @@
+# Skill Description-Aware Propagation
+
+## What changed
+
+- Skill indexes now include each skill's frontmatter name, description, and repo-relative path, so architects and subagents can choose relevant skills from descriptions instead of bare filenames.
+- `SKILLS:` parsing now accepts multi-line catalog entries such as `file:.claude/skills/writing-tests/SKILL.md - Guidelines for writing tests` and records only the file reference in usage logs.
+- Skill discovery normalizes paths to forward-slash repo-relative references on Windows.
+- Agent prompts now tell subagents to read skill descriptions first and load the applicable full skill bodies on demand.
+- Architect prompt guidance now explicitly checks project contract files such as `AGENTS.md` before delegation and passes relevant MUST/NEVER rules to the receiving agent.
+
+## Why
+
+Issue #957 reported that subagents often received only a skill link, or no useful skill context, so smaller models missed task-specific conventions like project testing rules. Description-aware catalogs make the relevant skill easier to route and let agents avoid loading unrelated skill bodies.
+
+## Migration steps
+
+None. Existing one-line `SKILLS: file:...` delegations continue to work.
+
+## Known caveats
+
+The skill propagation gate remains warn-only unless the caller wires enforce mode programmatically.

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -419,64 +419,58 @@ SECURITY_KEYWORDS: password, secret, token, credential, auth, login, encryption,
 
 ## SKILLS PROPAGATION
 
-Subagents run in isolated contexts. Any project-specific skill constraints loaded into your session (e.g. \`writing-tests\`, \`engineering-conventions\`, coding standards, security guidelines) are NOT automatically visible to them. Passing full skill bodies inline for every delegation duplicates thousands of tokens and bloats context, so prefer repo-relative skill file references when the receiving agent can load them. Subagents without skills produce generic output that may violate project conventions.
+Subagents run in isolated contexts. Project-specific skills loaded in your session are NOT automatically visible to them. Prefer repo-relative \`file:\` references; inline bodies bloat context and are fallback only.
 
 ### Step 1 — Discover available skills (once per session)
 
 At session start, before your first delegation:
-1. Prefer skills already loaded into your context via \`<skill-context>\` blocks; reuse those immediately.
-2. When you need to inspect on-disk skills, use the \`search\` tool with \`include\` patterns like \`.opencode/skills/*/SKILL.md,.claude/skills/*/SKILL.md\` and frontmatter queries such as \`^name:\` / \`^description:\` so you only read the YAML lines you need.
-3. Write a brief skill index to \`.swarm/context.md\` under \`## Available Skills\`:
+1. Read contract files first: \`AGENTS.md\`, \`CLAUDE.md\`, \`CONTRIBUTING.md\`, \`TESTING.md\` when present. Extract task-relevant MUST/NEVER rules and pass them in INPUT/CONSTRAINT.
+2. Reuse \`<skill-context>\` skills when present.
+3. Otherwise use \`search\` with \`include\` patterns like \`.opencode/skills/*/SKILL.md,.claude/skills/*/SKILL.md\` and frontmatter queries \`^name:\` / \`^description:\`.
+4. Cache a short \`.swarm/context.md\` \`## Available Skills\` index. Include the repo-relative \`file:\` path and description so subagents can load on demand:
    - writing-tests: Guidelines for writing tests (used: 12, compliance: 95%) → test_engineer, coder
    - engineering-conventions: Engineering invariants (used: 8, compliance: 100%) → coder, reviewer, test_engineer
    - [name]: [description] (used: N, compliance: N%) → [applicable agents]
 
-   If \`.swarm/skill-usage.jsonl\` exists, read it at session start to inform skill prioritization. Skills with 5+ compliant usages across sessions should be considered mandatory for relevant tasks. Read \`.swarm/skill-usage.jsonl\` and summarize usage counts and compliance rates for each skill to enrich the skill index with metadata.
+   Use \`.swarm/skill-usage.jsonl\` when present; otherwise weight skills equally.
 
    If skill-usage.jsonl does not exist, proceed with equal weighting — no enrichment needed.
 
-4. When discovery is ambiguous, prefer the canonical repo-relative skill file path in the delegation and let the receiving agent load it directly.
 
 ### Step 2 — Route skills to agents
 
-Include a skill in a delegation when ANY of the following match:
+Include a skill when its name/description matches:
 
 | Skill description / name contains…               | Pass to agents…                       |
-|---------------------------------------------------|---------------------------------------|
-| "test", "testing", "test files", "writing tests"  | test_engineer, coder                  |
-| "engineering", "conventions", "invariants", "rules" | coder, reviewer, test_engineer      |
-| "code", "implementation", "coding standards"      | coder, reviewer                       |
-| "review", "security audit", "security guidelines" | reviewer                              |
-| "documentation", "docs", "writing docs"           | docs                                  |
-| "architecture", "design patterns", "ui"           | designer, sme                         |
-| domain-specific (database, cloud, mobile, etc.)   | sme                                   |
+Route tests to test_engineer/coder; conventions to coder/reviewer/test_engineer; implementation to coder/reviewer; review/security to reviewer; docs to docs; architecture/ui/domain topics to designer or sme.
 
-When uncertain: pass the skill. Subagents ignore irrelevant content. A missing applicable skill degrades output quality.
+When uncertain, pass the skill. Missing applicable skills cause convention drift.
 
 ### Step 3 — Include skill references in delegations
 
-Add a \`SKILLS:\` field to every delegation that goes to an implementation or review agent (coder, reviewer, test_engineer, sme, docs, designer). Use one of:
+Add \`SKILLS:\` to every coder, reviewer, test_engineer, sme, docs, and designer delegation:
 
 - \`SKILLS: none\` — only when no project-specific skill applies to that delegation
 - \`SKILLS: file:.claude/skills/writing-tests/SKILL.md\` — preferred for skills that exist on disk; use repo-relative \`file:\` references, comma-separated when multiple skills apply
-- Inline block fallback:
+- Descriptive multi-line catalog:
+  SKILLS:
+  - file:.claude/skills/writing-tests/SKILL.md - Guidelines for writing tests
+  - file:.claude/skills/engineering-conventions/SKILL.md - Engineering invariants for safe changes
+- Inline fallback:
   SKILLS:
   --- [skill-name] ---
   [full SKILL.md body content pasted here]
-  --- [skill-name-2] ---
-  [full SKILL.md body content pasted here]
 
-Default to repo-relative \`file:\` references for coder, reviewer, test_engineer, and sme. Use inline skill bodies only when the skill exists only in live context (no stable repo file path) or a prior agent explicitly reported \`SKILL_LOAD_FAILED\`.
+Default to repo-relative \`file:\` references. Use inline skill bodies only when no stable repo path exists or a prior agent reported \`SKILL_LOAD_FAILED\`.
 
-**SKILL_LOAD_FAILED recovery:** If a subagent reports SKILL_LOAD_FAILED for a \`file:\` reference, do NOT retry with the same reference. Instead, re-delegate with either: (a) the full skill body pasted inline, or (b) \`SKILLS: none\` if no applicable skill content is available. Never re-use a file: reference that has already failed.
+**SKILL_LOAD_FAILED recovery:** do NOT retry with the same reference. Re-delegate with the full skill body inline, or \`SKILLS: none\` if no applicable content exists.
 
-**Mandatory for coding tasks:** Always provide \`writing-tests\` to test_engineer and \`engineering-conventions\` to coder + reviewer when those skills are present in the project. Prefer \`file:\` references when the files exist.
+**Mandatory for coding tasks:** provide \`writing-tests\` to test_engineer and \`engineering-conventions\` to coder + reviewer when present.
 
 ### Step 4 — Forward skills to reviewer
 
-When delegating to the reviewer after a coder task, include a \`SKILLS_USED_BY_CODER: [comma-separated list of skill paths from the coder delegation]\` field. The reviewer must receive the same skill context the coder received so it can verify skill compliance.
+When delegating to reviewer after coder, include \`SKILLS_USED_BY_CODER: [comma-separated skill paths from coder]\` plus reviewer \`SKILLS:\` so compliance can be checked.
 
-Example: If the coder received \`SKILLS: file:.claude/skills/writing-tests/SKILL.md\`, the reviewer delegation must include \`SKILLS_USED_BY_CODER: file:.claude/skills/writing-tests/SKILL.md\` in addition to the reviewer's own \`SKILLS:\` field.
 
 ## SWARM KNOWLEDGE DIRECTIVES (v2 acknowledgment contract)
 
@@ -499,28 +493,14 @@ You may also call the \`knowledge_ack\` tool to record an outcome explicitly whe
 
 ## SKILL IMPROVER (low-frequency, expensive-model adviser)
 
-The \`skill_improver\` agent and the \`skill_improve\` tool exist for rare, deep
-review of accumulated knowledge / skills / spec / architect prompt. They are
-quota-bounded (default 10 calls/day) and disabled by default. Suggest running
-\`skill_improve\` only after one of:
-- repeated reviewer rejections in a row,
-- many \`KNOWLEDGE_IGNORED\` outcomes for the same cluster,
-- stale skills (no updates while their target area changed),
-- a fresh spec mismatch with shipped behaviour.
+Use \`skill_improver\` / \`skill_improve\` rarely for repeated review failures, ignored knowledge clusters, stale skills, or fresh spec drift. It is quota-bounded and proposal-only.
 
 When \`skill_improver.require_user_approval\` is true (default), ASK the user
 before running. Default outputs are proposals only — they never modify source.
 
 ## SPEC WRITER
 
-For substantial spec authoring or revision, prefer delegating to the
-\`spec_writer\` agent (independent model from architect). It writes only via
-the safe \`spec_write\` tool. Use it when:
-- the user requests a new spec or major spec revision,
-- requirements decomposition is non-trivial,
-- you would otherwise inline-author \`.swarm/spec.md\` yourself.
-
-Continue handling small touch-ups (typos, cross-references) inline.
+For substantial spec authoring/revision, prefer \`spec_writer\`; it writes only via \`spec_write\`. Use it for new/major specs, non-trivial requirements decomposition, or when you would otherwise inline-author \`.swarm/spec.md\`. Handle small typos/cross-references inline.
 
 ### ANTI-RATIONALIZATION
 - ✗ "The coder already knows these conventions" → Skills contain project-specific rules the model cannot know from training. Always pass.
@@ -533,7 +513,7 @@ Continue handling small touch-ups (typos, cross-references) inline.
 ## SLASH COMMANDS
 {{SLASH_COMMANDS}}
 Commands above are documented with args and behavioral details. Run commands via /swarm <command> [args].
-Outside OpenCode, invoke any plugin command via: \`bunx opencode-swarm run <command> [args]\` (e.g. \`bunx opencode-swarm run knowledge migrate\`). Do not use \`bun -e\` or look for \`src/commands/\` — those paths are internal to the plugin source and do not exist in user project directories. EXCEPTION — human-only commands (including but not limited to \`acknowledge-spec-drift\`, \`reset\`, \`reset-session\`, \`rollback\`, \`checkpoint\`, and any command that releases a runtime safety gate or destroys plan state): you MUST present these to the user and ask them to run the command themselves. Never invoke a human-only command via Bash, swarm_command, or chat fallback. The runtime guardrail will block such attempts; if a Bash call returns \`BLOCKED\` with a "human-only" message, do not retry under a different shell form — present the situation to the user instead.
+Outside OpenCode, use \`bunx opencode-swarm run <command> [args]\`; never use \`bun -e\` or internal \`src/commands/\` paths. Human-only commands (\`acknowledge-spec-drift\`, \`reset\`, \`reset-session\`, \`rollback\`, \`checkpoint\`, safety-gate release, plan-state destruction) MUST be presented to the user to run. Never invoke them via Bash, swarm_command, or chat fallback; if blocked as human-only, present it to the user.
 
 SMEs advise only. Reviewer and critic review only. None of them write code.
 
@@ -541,15 +521,15 @@ Available Tools: {{AVAILABLE_TOOLS}}
 
 ## DELEGATION FORMAT
 
-Delegations are performed ONLY by calling the **Task** tool. Writing delegation text into the chat does nothing — the agent will not receive it. Every delegation below is the content you pass to the Task tool, not text you output to the conversation.
+Delegations happen ONLY through the **Task** tool; chat text is not delivered to agents. Examples below are Task content.
 
-All delegations MUST follow the receiving agent's INPUT FORMAT exactly. Do NOT invent fields, omit required fields, or force one agent's schema onto another. Every delegation MUST begin with the agent name, include \`TASK:\`, and include \`SKILLS:\` when that agent prompt supports skills.
+follow the receiving agent's INPUT FORMAT exactly; do NOT invent/omit fields. Begin with agent name, \`TASK:\`, and \`SKILLS:\` when supported.
 Do NOT add conversational preamble before the agent prefix. Begin directly with the agent name.
 
 {{AGENT_PREFIX}}[agent]
 TASK: [single objective]
 [agent-specific fields required by that agent's INPUT FORMAT]
-SKILLS: [either "none", repo-relative file: references, or inline skill bodies — see SKILLS PROPAGATION; use "none" only when no project-specific skill applies]
+SKILLS: [either "none", repo-relative file references with descriptions, or inline skill bodies — see SKILLS PROPAGATION; use "none" only when no project-specific skill applies]
 
 Examples:
 
@@ -582,22 +562,22 @@ FILE: src/auth/login.ts
 INPUT: Validate email format, password >= 8 chars
 OUTPUT: Modified file
 CONSTRAINT: Do not modify other functions
-SKILLS: file:.claude/skills/engineering-conventions/SKILL.md
+SKILLS: file:.claude/skills/engineering-conventions/SKILL.md - safe code changes
 
 {{AGENT_PREFIX}}reviewer
 TASK: Review login validation
 FILE: src/auth/login.ts
 CHECK: [security, correctness, edge-cases]
 GATES: lint=PASS, sast_scan=PASS, secretscan=PASS
-SKILLS_USED_BY_CODER: file:.claude/skills/engineering-conventions/SKILL.md
+SKILLS_USED_BY_CODER: file:.claude/skills/engineering-conventions/SKILL.md - safe code changes
 OUTPUT: VERDICT + RISK + ISSUES
-SKILLS: file:.claude/skills/engineering-conventions/SKILL.md
+SKILLS: file:.claude/skills/engineering-conventions/SKILL.md - safe code changes
 
 {{AGENT_PREFIX}}test_engineer
 TASK: Generate and run login validation tests
 FILE: src/auth/login.ts
 OUTPUT: Test file at src/auth/login.test.ts + VERDICT: PASS/FAIL with failure details
-SKILLS: file:.claude/skills/writing-tests/SKILL.md
+SKILLS: file:.claude/skills/writing-tests/SKILL.md - tests
 
 {{AGENT_PREFIX}}critic
 TASK: Review plan for user authentication feature
@@ -612,14 +592,14 @@ FILE: src/auth/login.ts
 CHECK: [security-only] — evaluate against OWASP Top 10, scan for hardcoded secrets, injection vectors, insecure crypto, missing input validation
 GATES: lint=PASS, sast_scan=PASS, secretscan=PASS
 OUTPUT: VERDICT + RISK + SECURITY ISSUES ONLY
-SKILLS: file:.claude/skills/engineering-conventions/SKILL.md
+SKILLS: file:.claude/skills/engineering-conventions/SKILL.md - safe code changes
 
 {{AGENT_PREFIX}}test_engineer
 TASK: Adversarial security testing
 FILE: src/auth/login.ts
 CONSTRAINT: ONLY attack vectors — malformed inputs, oversized payloads, injection attempts, auth bypass, boundary violations
 OUTPUT: Test file + VERDICT: PASS/FAIL
-SKILLS: file:.claude/skills/writing-tests/SKILL.md
+SKILLS: file:.claude/skills/writing-tests/SKILL.md - tests
 
 {{AGENT_PREFIX}}explorer
 TASK: Integration impact analysis

--- a/src/agents/coder.ts
+++ b/src/agents/coder.ts
@@ -16,7 +16,8 @@ OUTPUT: [expected deliverable]
 CONSTRAINT: [what NOT to do]
 SKILLS: [optional — either "none", repo-relative file: references (preferred), or inline skill content pasted by architect]
 
-SKILLS HANDLING: If SKILLS is present and not "none", load EVERY referenced skill before writing any code.
+SKILLS HANDLING: If SKILLS is present and not "none", read the skill names/descriptions first, then load every referenced skill that applies to your TASK before writing any code. If uncertain whether a skill applies, load it.
+- A file entry may include a short description after the path; use the description to decide whether the full skill body is relevant.
 - For \`file:\` entries, use the search tool to read the referenced \`SKILL.md\` file with \`include\` set to that exact repo-relative path, \`mode: regex\`, \`query: .*\`, \`max_results: 1000\`, and \`max_lines: 1000\`.
 - After running search, inspect the result: if \`total === 0\` (file does not exist or is empty) OR \`truncated\` is \`true\` (file was too large and content was cut off), stop and report \`SKILL_LOAD_FAILED: <path>\`. Do NOT continue without the complete skill.
 - If the search result has \`total > 0\` and \`truncated\` is \`false\`, reconstruct the full skill content from the line-by-line matches and apply it.

--- a/src/agents/designer.ts
+++ b/src/agents/designer.ts
@@ -15,7 +15,8 @@ FRAMEWORK: [React/Vue/Svelte/SwiftUI/Flutter/etc.]
 EXISTING PATTERNS: [current design system, component library, styling approach]
 SKILLS: [optional — either "none", repo-relative file: references (preferred), or inline skill content pasted by architect]
 
-SKILLS HANDLING: If SKILLS is present and not "none", load EVERY referenced skill before producing the design specification.
+SKILLS HANDLING: If SKILLS is present and not "none", read the skill names/descriptions first, then load every referenced skill that applies before producing the design specification. If uncertain whether a skill applies, load it.
+- A file entry may include a short description after the path; use the description to decide whether the full skill body is relevant.
 - For \`file:\` entries, use the search tool to read the referenced \`SKILL.md\` file with \`include\` set to that exact repo-relative path, \`mode: regex\`, \`query: .*\`, \`max_results: 1000\`, and \`max_lines: 1000\`.
 - After running search, inspect the result: if \`total === 0\` (file does not exist or is empty) OR \`truncated\` is \`true\` (file was too large and content was cut off), stop and report \`SKILL_LOAD_FAILED: <path>\`. Do NOT continue without the complete skill.
 - If the search result has \`total > 0\` and \`truncated\` is \`false\`, reconstruct the full skill content from the line-by-line matches and apply it.

--- a/src/agents/docs.ts
+++ b/src/agents/docs.ts
@@ -15,7 +15,8 @@ CHANGES SUMMARY: [what was added/modified/removed]
 DOC FILES: [list of documentation files to update]
 SKILLS: [optional — either "none", repo-relative file: references (preferred), or inline skill content pasted by architect]
 
-SKILLS HANDLING: If SKILLS is present and not "none", load EVERY referenced skill before updating docs.
+SKILLS HANDLING: If SKILLS is present and not "none", read the skill names/descriptions first, then load every referenced skill that applies before updating docs. If uncertain whether a skill applies, load it.
+- A file entry may include a short description after the path; use the description to decide whether the full skill body is relevant.
 - For \`file:\` entries, use the search tool to read the referenced \`SKILL.md\` file with \`include\` set to that exact repo-relative path, \`mode: regex\`, \`query: .*\`, \`max_results: 1000\`, and \`max_lines: 1000\`.
 - After running search, inspect the result: if \`total === 0\` (file does not exist or is empty) OR \`truncated\` is \`true\` (file was too large and content was cut off), stop and report \`SKILL_LOAD_FAILED: <path>\`. Do NOT continue without the complete skill.
 - If the search result has \`total > 0\` and \`truncated\` is \`false\`, reconstruct the full skill content from the line-by-line matches and apply it.

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -220,7 +220,8 @@ GATES: [pre-completed gate results (lint, SAST, secretscan, etc.), or "none" if 
 SKILLS: [optional — either "none", repo-relative file: references (preferred), or inline skill content pasted by architect]
 SKILLS_USED_BY_CODER: [list of skill paths that were passed to the coder for this task, or "none" if no skills were used]
 
-SKILLS HANDLING: If SKILLS is present and not "none", load EVERY referenced skill before beginning your review.
+SKILLS HANDLING: If SKILLS is present and not "none", read the skill names/descriptions first, then load every referenced skill that applies before beginning your review. If uncertain whether a skill applies, load it.
+- A file entry may include a short description after the path; use the description to decide whether the full skill body is relevant.
 - For \`file:\` entries, use the search tool to read the referenced \`SKILL.md\` file with \`include\` set to that exact repo-relative path, \`mode: regex\`, \`query: .*\`, \`max_results: 1000\`, and \`max_lines: 1000\`.
 - After running search, inspect the result: if \`total === 0\` (file does not exist or is empty) OR \`truncated\` is \`true\` (file was too large and content was cut off), stop and report \`SKILL_LOAD_FAILED: <path>\`. Do NOT continue without the complete skill.
 - If the search result has \`total > 0\` and \`truncated\` is \`false\`, reconstruct the full skill content from the line-by-line matches and apply it.

--- a/src/agents/sme.ts
+++ b/src/agents/sme.ts
@@ -50,7 +50,8 @@ DOMAIN: [the domain - e.g., security, ios, android, rust, kubernetes]
 INPUT: [context/requirements]
 SKILLS: [optional — either "none", repo-relative file: references (preferred), or inline skill content pasted by architect]
 
-SKILLS HANDLING: If SKILLS is present and not "none", load EVERY referenced skill before formulating your recommendation.
+SKILLS HANDLING: If SKILLS is present and not "none", read the skill names/descriptions first, then load every referenced skill that applies before formulating your recommendation. If uncertain whether a skill applies, load it.
+- A file entry may include a short description after the path; use the description to decide whether the full skill body is relevant.
 - For \`file:\` entries, use the search tool to read the referenced \`SKILL.md\` file with \`include\` set to that exact repo-relative path, \`mode: regex\`, \`query: .*\`, \`max_results: 1000\`, and \`max_lines: 1000\`.
 - After running search, inspect the result: if \`total === 0\` (file does not exist or is empty) OR \`truncated\` is \`true\` (file was too large and content was cut off), stop and report \`SKILL_LOAD_FAILED: <path>\`. Do NOT continue without the complete skill.
 - If the search result has \`total > 0\` and \`truncated\` is \`false\`, reconstruct the full skill content from the line-by-line matches and apply it.

--- a/src/agents/test-engineer.ts
+++ b/src/agents/test-engineer.ts
@@ -42,7 +42,8 @@ FILE: [source file path]
 OUTPUT: [test file path]
 SKILLS: [optional — either "none", repo-relative file: references (preferred), or inline skill content pasted by architect]
 
-SKILLS HANDLING: If SKILLS is present and not "none", load EVERY referenced skill before writing any test code.
+SKILLS HANDLING: If SKILLS is present and not "none", read the skill names/descriptions first, then load every referenced skill that applies before writing any test code. If uncertain whether a skill applies, load it.
+- A file entry may include a short description after the path; use the description to decide whether the full skill body is relevant.
 - For \`file:\` entries, use the search tool to read the referenced \`SKILL.md\` file with \`include\` set to that exact repo-relative path, \`mode: regex\`, \`query: .*\`, \`max_results: 1000\`, and \`max_lines: 1000\`.
 - After running search, inspect the result: if \`total === 0\` (file does not exist or is empty) OR \`truncated\` is \`true\` (file was too large and content was cut off), stop and report \`SKILL_LOAD_FAILED: <path>\`. Do NOT continue without the complete skill.
 - If the search result has \`total > 0\` and \`truncated\` is \`false\`, reconstruct the full skill content from the line-by-line matches and apply it.

--- a/src/hooks/skill-propagation-gate.ts
+++ b/src/hooks/skill-propagation-gate.ts
@@ -101,6 +101,7 @@ export const _internals: {
 	appendSkillUsageEntry: typeof appendSkillUsageEntry;
 	readSkillUsageEntries: typeof readSkillUsageEntries;
 	readSkillUsageEntriesTail: typeof readSkillUsageEntriesTail;
+	extractSkillsFieldFromPrompt: typeof extractSkillsFieldFromPrompt;
 	parseSkillPaths: typeof parseSkillPaths;
 	extractTaskIdFromPrompt: typeof extractTaskIdFromPrompt;
 	computeSkillRelevanceScore: typeof computeSkillRelevanceScore;
@@ -126,6 +127,8 @@ export const _internals: {
 	appendSkillUsageEntry,
 	readSkillUsageEntries,
 	readSkillUsageEntriesTail,
+	extractSkillsFieldFromPrompt:
+		null as unknown as typeof extractSkillsFieldFromPrompt,
 	parseSkillPaths: null as unknown as typeof parseSkillPaths,
 	extractTaskIdFromPrompt: null as unknown as typeof extractTaskIdFromPrompt,
 	computeSkillRelevanceScore,
@@ -164,7 +167,7 @@ export function discoverAvailableSkills(directory: string): string[] {
 					_internals.statSync(skillDir).isDirectory() &&
 					_internals.existsSync(skillFile)
 				) {
-					results.push(path.join(root, entry, 'SKILL.md'));
+					results.push(path.join(root, entry, 'SKILL.md').replace(/\\/g, '/'));
 				}
 			} catch (err) {
 				warn(
@@ -221,19 +224,51 @@ export function parseDelegationArgs(
 	if (!targetAgent) return null;
 
 	// Extract SKILLS: field value from prompt text only
-	let skillsField = '';
-	if (prompt) {
-		const lines = prompt.split('\n');
-		for (const line of lines) {
-			const trimmed = line.trim();
-			if (trimmed.startsWith('SKILLS:')) {
-				skillsField = trimmed.slice('SKILLS:'.length).trim();
-				break;
-			}
-		}
-	}
+	const skillsField = prompt
+		? _internals.extractSkillsFieldFromPrompt(prompt)
+		: '';
 
 	return { targetAgent, skillsField };
+}
+
+/**
+ * Extracts the value of a SKILLS field from a delegation prompt. Supports both
+ * legacy one-line fields (`SKILLS: file:...`) and description-rich blocks:
+ *
+ *   SKILLS:
+ *   - file:.claude/skills/writing-tests/SKILL.md - test conventions
+ *   - file:.claude/skills/react/SKILL.md - React UI patterns
+ */
+export function extractSkillsFieldFromPrompt(prompt: string): string {
+	const lines = prompt.split('\n');
+	for (let i = 0; i < lines.length; i++) {
+		const trimmed = lines[i].trim();
+		if (!/^SKILLS\s*:/i.test(trimmed)) continue;
+
+		const firstLine = trimmed.replace(/^SKILLS\s*:/i, '').trim();
+		const collected: string[] = [];
+		if (firstLine) collected.push(firstLine);
+
+		for (let j = i + 1; j < lines.length; j++) {
+			const next = lines[j];
+			const nextTrimmed = next.trim();
+			if (!nextTrimmed) {
+				if (collected.length === 0) continue;
+				break;
+			}
+			if (/^[A-Z][A-Z0-9_ -]{1,40}\s*:/i.test(nextTrimmed)) break;
+			if (/^(?:-|\*|\d+\.)\s+/.test(nextTrimmed) || /^\s+/.test(next)) {
+				collected.push(nextTrimmed);
+				continue;
+			}
+			if (collected.length === 0) collected.push(nextTrimmed);
+			break;
+		}
+
+		return collected.join('\n').trim();
+	}
+
+	return '';
 }
 
 // ============================================================================
@@ -273,10 +308,33 @@ export function parseSkillPaths(fieldValue: string): string[] {
 	const trimmed = fieldValue.trim();
 	if (trimmed.toLowerCase() === 'none' || trimmed === '') return [];
 
-	return trimmed
-		.split(',')
-		.map((s) => s.trim())
-		.filter((s) => s.length > 0);
+	const lines = trimmed.split(/\r?\n/);
+	const hasCatalogLines = lines.some((line) =>
+		/^(?:-|\*|\d+\.)\s+/.test(line.trim()),
+	);
+	const parts = hasCatalogLines ? lines : trimmed.split(',');
+
+	const paths: string[] = [];
+	for (const rawPart of parts) {
+		const part = rawPart
+			.trim()
+			.replace(/^(?:-|\*|\d+\.)\s+/, '')
+			.trim();
+		if (!part || part.toLowerCase() === 'none') continue;
+
+		const fileRef = part.match(/\bfile:[^\s,;)\]]+/);
+		if (fileRef) {
+			paths.push(fileRef[0].replace(/\\/g, '/'));
+			continue;
+		}
+
+		// Legacy shorthand: `writing-tests`, `code`, `.claude/.../SKILL.md`,
+		// or even arbitrary path strings. Preserve these verbatim for backwards
+		// compatibility with the existing audit log contract.
+		paths.push(part);
+	}
+
+	return [...new Set(paths)];
 }
 
 /**
@@ -786,7 +844,9 @@ export async function skillPropagationTransformScan(
 		let currentTargetAgent = '';
 		let skillsField = '';
 
-		for (const line of text.split('\n')) {
+		const textLines = text.split('\n');
+		for (let lineIndex = 0; lineIndex < textLines.length; lineIndex++) {
+			const line = textLines[lineIndex] ?? '';
 			const trimmed = line.trim();
 
 			// Detect delegation to a skill-capable agent
@@ -800,7 +860,9 @@ export async function skillPropagationTransformScan(
 			}
 
 			if (trimmed.startsWith('SKILLS:')) {
-				skillsField = trimmed.slice('SKILLS:'.length).trim();
+				skillsField = _internals.extractSkillsFieldFromPrompt(
+					textLines.slice(lineIndex).join('\n'),
+				);
 			}
 
 			// When we have both, record and reset
@@ -850,6 +912,7 @@ _internals.skillPropagationTransformScan = skillPropagationTransformScan;
 _internals.writeWarnEvent = writeWarnEvent;
 _internals.discoverAvailableSkills = discoverAvailableSkills;
 _internals.parseDelegationArgs = parseDelegationArgs;
+_internals.extractSkillsFieldFromPrompt = extractSkillsFieldFromPrompt;
 _internals.parseSkillPaths = parseSkillPaths;
 _internals.extractTaskIdFromPrompt = extractTaskIdFromPrompt;
 _internals.formatSkillIndexWithContext = formatSkillIndexWithContext;

--- a/src/hooks/skill-scoring.ts
+++ b/src/hooks/skill-scoring.ts
@@ -8,6 +8,7 @@
  * and `skill-propagation-gate.ts` for testability.
  */
 
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
 	readSkillUsageEntries,
@@ -39,6 +40,9 @@ const CONTEXT_WEIGHT = 0.2;
 /** Age in milliseconds at which recency score decays to zero (30 days). */
 const RECENCY_DECAY_MS = 30 * 24 * 60 * 60 * 1000;
 
+/** Maximum bytes read from a SKILL.md when extracting frontmatter metadata. */
+const SKILL_FRONTMATTER_READ_BYTES = 16 * 1024;
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -67,6 +71,16 @@ export interface SkillStats {
 	topAgents: Array<{ agent: string; count: number }>;
 }
 
+/** Metadata extracted from a SKILL.md frontmatter block. */
+export interface SkillMetadata {
+	/** Repo-relative path to the skill file. */
+	path: string;
+	/** Human-readable skill name. */
+	name: string;
+	/** Short description from frontmatter, or a fallback when absent. */
+	description: string;
+}
+
 // ============================================================================
 // DI seam — function references assigned after their declarations at end of file
 // ============================================================================
@@ -76,6 +90,8 @@ export const _internals: {
 	rankSkillsForContext: typeof rankSkillsForContext;
 	getSkillStats: typeof getSkillStats;
 	formatSkillIndexWithContext: typeof formatSkillIndexWithContext;
+	parseSkillFrontmatter: typeof parseSkillFrontmatter;
+	readSkillMetadata: typeof readSkillMetadata;
 	extractSkillName: typeof extractSkillName;
 	computeRecencyScore: typeof computeRecencyScore;
 	computeContextMatchScore: typeof computeContextMatchScore;
@@ -86,6 +102,8 @@ export const _internals: {
 	getSkillStats: null as unknown as typeof getSkillStats,
 	formatSkillIndexWithContext:
 		null as unknown as typeof formatSkillIndexWithContext,
+	parseSkillFrontmatter: null as unknown as typeof parseSkillFrontmatter,
+	readSkillMetadata: null as unknown as typeof readSkillMetadata,
 	extractSkillName: null as unknown as typeof extractSkillName,
 	computeRecencyScore: null as unknown as typeof computeRecencyScore,
 	computeContextMatchScore: null as unknown as typeof computeContextMatchScore,
@@ -105,6 +123,139 @@ function extractSkillName(skillPath: string): string {
 	// Fall back to parent directory name
 	const parent = path.basename(path.dirname(skillPath));
 	return parent;
+}
+
+function stripQuotes(value: string): string {
+	const trimmed = value.trim();
+	if (
+		(trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+		(trimmed.startsWith("'") && trimmed.endsWith("'"))
+	) {
+		return trimmed.slice(1, -1).trim();
+	}
+	return trimmed;
+}
+
+function normalizeDescription(description: string): string {
+	const singleLine = description.replace(/\s+/g, ' ').trim();
+	if (!singleLine) return 'No description provided';
+	return singleLine.length > 240
+		? `${singleLine.slice(0, 237)}...`
+		: singleLine;
+}
+
+/**
+ * Parse the YAML-like frontmatter from a SKILL.md file. This intentionally
+ * supports only the small subset skills use today: scalar `name` and scalar,
+ * folded (`>`), or literal (`|`) `description`.
+ */
+export function parseSkillFrontmatter(
+	content: string,
+	skillPath: string,
+): SkillMetadata {
+	const normalizedPath = skillPath.replace(/^file:/, '').replace(/\\/g, '/');
+	const fallbackName = extractSkillName(normalizedPath);
+	const fallback: SkillMetadata = {
+		path: normalizedPath,
+		name: fallbackName,
+		description: 'No description provided',
+	};
+
+	const lines = content.split(/\r?\n/);
+	if (lines[0]?.trim() !== '---') return fallback;
+
+	const end = lines.findIndex(
+		(line, index) => index > 0 && line.trim() === '---',
+	);
+	if (end === -1) return fallback;
+
+	let name = fallbackName;
+	let description = '';
+
+	for (let i = 1; i < end; i++) {
+		const line = lines[i] ?? '';
+		const match = line.match(/^([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*)$/);
+		if (!match) continue;
+
+		const key = match[1].toLowerCase();
+		const rawValue = match[2].trim();
+
+		if (key === 'name') {
+			const parsed = stripQuotes(rawValue);
+			if (parsed) name = parsed;
+			continue;
+		}
+
+		if (key !== 'description') continue;
+
+		if (rawValue === '>' || rawValue === '|') {
+			const collected: string[] = [];
+			for (let j = i + 1; j < end; j++) {
+				const next = lines[j] ?? '';
+				if (/^[A-Za-z_][A-Za-z0-9_-]*\s*:/.test(next)) break;
+				collected.push(next.trim());
+				i = j;
+			}
+			description = collected.join(' ');
+		} else {
+			description = stripQuotes(rawValue);
+		}
+	}
+
+	return {
+		path: normalizedPath,
+		name: name || fallbackName,
+		description: normalizeDescription(description),
+	};
+}
+
+function readFilePrefix(filePath: string): string {
+	const fd = fs.openSync(filePath, 'r');
+	try {
+		const buffer = Buffer.alloc(SKILL_FRONTMATTER_READ_BYTES);
+		const bytesRead = fs.readSync(
+			fd,
+			buffer,
+			0,
+			SKILL_FRONTMATTER_READ_BYTES,
+			0,
+		);
+		return buffer.toString('utf-8', 0, bytesRead);
+	} finally {
+		fs.closeSync(fd);
+	}
+}
+
+/**
+ * Extract skill metadata from a repo-relative SKILL.md path. Fails open to
+ * path-derived metadata when the file is missing, outside the project, or has
+ * malformed frontmatter.
+ */
+export function readSkillMetadata(
+	skillPath: string,
+	directory: string,
+): SkillMetadata {
+	const normalizedPath = skillPath.replace(/^file:/, '').replace(/\\/g, '/');
+	const fallback = parseSkillFrontmatter('', normalizedPath);
+
+	try {
+		if (
+			path.isAbsolute(normalizedPath) ||
+			normalizedPath.split('/').includes('..')
+		) {
+			return fallback;
+		}
+		const root = path.resolve(directory);
+		const absolutePath = path.resolve(directory, normalizedPath);
+		if (absolutePath !== root && !absolutePath.startsWith(root + path.sep)) {
+			return fallback;
+		}
+
+		const content = readFilePrefix(absolutePath);
+		return parseSkillFrontmatter(content, normalizedPath);
+	} catch {
+		return fallback;
+	}
 }
 
 /**
@@ -393,15 +544,21 @@ export function formatSkillIndexWithContext(
 	const hasHistory = allEntries.length > 0;
 
 	if (!hasHistory) {
-		// Simple index without stats
-		return skills.map((sp) => `  - ${extractSkillName(sp)}`).join('\n');
+		// Simple index without stats, but with enough metadata for agents to
+		// decide whether to load the full skill body on demand.
+		return skills
+			.map((sp) => {
+				const meta = _internals.readSkillMetadata(sp, directory);
+				return `  - file:${meta.path} - ${meta.name}: ${meta.description}`;
+			})
+			.join('\n');
 	}
 
 	const lines: string[] = [];
 
 	for (const skillPath of skills) {
 		const stats = getSkillStats(skillPath, directory);
-		const name = extractSkillName(skillPath);
+		const meta = _internals.readSkillMetadata(skillPath, directory);
 		const compliancePct = Math.round(stats.complianceRate * 100);
 		const topAgentNames = stats.topAgents
 			.slice(0, 3)
@@ -409,7 +566,7 @@ export function formatSkillIndexWithContext(
 			.join(', ');
 
 		lines.push(
-			`  ${name}: ${skillPath} (used: ${stats.totalUsage}, compliance: ${compliancePct}%)` +
+			`  - file:${meta.path} - ${meta.name}: ${meta.description} (used: ${stats.totalUsage}, compliance: ${compliancePct}%)` +
 				(stats.topAgents.length > 0 ? ` → ${topAgentNames}` : ''),
 		);
 	}
@@ -425,6 +582,8 @@ _internals.computeSkillRelevanceScore = computeSkillRelevanceScore;
 _internals.rankSkillsForContext = rankSkillsForContext;
 _internals.getSkillStats = getSkillStats;
 _internals.formatSkillIndexWithContext = formatSkillIndexWithContext;
+_internals.parseSkillFrontmatter = parseSkillFrontmatter;
+_internals.readSkillMetadata = readSkillMetadata;
 _internals.extractSkillName = extractSkillName;
 _internals.computeRecencyScore = computeRecencyScore;
 _internals.computeContextMatchScore = computeContextMatchScore;

--- a/tests/unit/agents/skills-propagation.test.ts
+++ b/tests/unit/agents/skills-propagation.test.ts
@@ -66,6 +66,20 @@ describe('Skills Propagation to Subagents', () => {
 			expect(skillsSection).toContain('Use inline skill bodies only');
 		});
 
+		it('instructs architect to inspect project contract files before delegation', () => {
+			const skillsSection = prompt.slice(prompt.indexOf('SKILLS PROPAGATION'));
+			expect(skillsSection).toContain('AGENTS.md');
+			expect(skillsSection).toContain('MUST/NEVER rules');
+			expect(skillsSection).toContain('INPUT/CONSTRAINT');
+		});
+
+		it('requires descriptions next to file references for on-demand skill loading', () => {
+			const skillsSection = prompt.slice(prompt.indexOf('SKILLS PROPAGATION'));
+			expect(skillsSection).toContain('file:` path and description');
+			expect(skillsSection).toContain('load on demand');
+			expect(skillsSection).toContain('Guidelines for writing tests');
+		});
+
 		it('includes anti-rationalization rules against skipping skills', () => {
 			const skillsSection = prompt.slice(prompt.indexOf('SKILLS PROPAGATION'));
 			expect(skillsSection).toContain('ANTI-RATIONALIZATION');
@@ -179,7 +193,12 @@ describe('Skills Propagation to Subagents', () => {
 
 		it('SKILLS HANDLING instructs to load file-based skills before writing code', () => {
 			const skillsHandling = prompt.slice(prompt.indexOf('SKILLS HANDLING'));
-			expect(skillsHandling).toContain('load EVERY referenced skill');
+			expect(skillsHandling).toContain(
+				'read the skill names/descriptions first',
+			);
+			expect(skillsHandling).toContain(
+				'load every referenced skill that applies',
+			);
 			expect(skillsHandling).toContain('use the search tool');
 			expect(skillsHandling).toContain('before writing any code');
 		});
@@ -220,7 +239,12 @@ describe('Skills Propagation to Subagents', () => {
 
 		it('SKILLS HANDLING instructs to load file-based skills before review', () => {
 			const skillsHandling = prompt.slice(prompt.indexOf('SKILLS HANDLING'));
-			expect(skillsHandling).toContain('load EVERY referenced skill');
+			expect(skillsHandling).toContain(
+				'read the skill names/descriptions first',
+			);
+			expect(skillsHandling).toContain(
+				'load every referenced skill that applies',
+			);
 			expect(skillsHandling).toContain('use the search tool');
 			expect(skillsHandling).toContain('before beginning');
 		});
@@ -274,7 +298,12 @@ describe('Skills Propagation to Subagents', () => {
 
 		it('SKILLS HANDLING instructs to load file-based skills before writing tests', () => {
 			const skillsHandling = prompt.slice(prompt.indexOf('SKILLS HANDLING'));
-			expect(skillsHandling).toContain('load EVERY referenced skill');
+			expect(skillsHandling).toContain(
+				'read the skill names/descriptions first',
+			);
+			expect(skillsHandling).toContain(
+				'load every referenced skill that applies',
+			);
 			expect(skillsHandling).toContain('use the search tool');
 			expect(skillsHandling).toContain('before writing any test code');
 		});
@@ -312,7 +341,12 @@ describe('Skills Propagation to Subagents', () => {
 
 		it('SKILLS HANDLING instructs to load file-based skills before recommendation', () => {
 			const skillsHandling = prompt.slice(prompt.indexOf('SKILLS HANDLING'));
-			expect(skillsHandling).toContain('load EVERY referenced skill');
+			expect(skillsHandling).toContain(
+				'read the skill names/descriptions first',
+			);
+			expect(skillsHandling).toContain(
+				'load every referenced skill that applies',
+			);
 			expect(skillsHandling).toContain('use the search tool');
 			expect(skillsHandling).toContain('before formulating');
 		});

--- a/tests/unit/hooks/skill-propagation-gate.test.ts
+++ b/tests/unit/hooks/skill-propagation-gate.test.ts
@@ -7,6 +7,7 @@ import * as path from 'node:path';
 import {
 	_internals,
 	discoverAvailableSkills,
+	extractSkillsFieldFromPrompt,
 	parseDelegationArgs,
 	parseSkillPaths,
 	SKILL_CAPABLE_AGENTS,
@@ -172,6 +173,55 @@ describe('parseDelegationArgs', () => {
 	});
 });
 
+describe('description-rich SKILLS field parsing', () => {
+	test('extracts multiline SKILLS catalog entries until the next field', () => {
+		const prompt = [
+			'TASK: implement tests',
+			'SKILLS:',
+			'- file:.claude/skills/writing-tests/SKILL.md - Guidelines for tests',
+			'- file:.claude/skills/engineering-conventions/SKILL.md - Invariants',
+			'OUTPUT: patch',
+		].join('\n');
+
+		const field = extractSkillsFieldFromPrompt(prompt);
+
+		expect(field).toContain('writing-tests/SKILL.md');
+		expect(field).toContain('Guidelines for tests');
+		expect(field).not.toContain('OUTPUT: patch');
+	});
+
+	test('parseDelegationArgs preserves description-rich multiline SKILLS fields', () => {
+		const parsed = parseDelegationArgs({
+			subagent_type: 'coder',
+			prompt: [
+				'TASK: implement tests',
+				'SKILLS:',
+				'- file:.claude/skills/writing-tests/SKILL.md - Guidelines for tests',
+				'- file:.claude/skills/engineering-conventions/SKILL.md - Invariants',
+				'OUTPUT: patch',
+			].join('\n'),
+		});
+
+		expect(parsed?.targetAgent).toBe('coder');
+		expect(parsed?.skillsField).toContain('Guidelines for tests');
+		expect(parsed?.skillsField).not.toContain('OUTPUT: patch');
+	});
+
+	test('parseSkillPaths extracts file refs while ignoring descriptions', () => {
+		const paths = parseSkillPaths(
+			[
+				'- file:.claude/skills/writing-tests/SKILL.md - Guidelines for tests',
+				'- file:.claude/skills/engineering-conventions/SKILL.md - Invariants',
+			].join('\n'),
+		);
+
+		expect(paths).toEqual([
+			'file:.claude/skills/writing-tests/SKILL.md',
+			'file:.claude/skills/engineering-conventions/SKILL.md',
+		]);
+	});
+});
+
 // ============================================================================
 // discoverAvailableSkills — original tests
 // ============================================================================
@@ -248,6 +298,16 @@ describe('discoverAvailableSkills', () => {
 
 		const result = discoverAvailableSkills(tmp);
 		expect(normalizePath(result[0])).toBe('.claude/skills/my-skill/SKILL.md');
+	});
+
+	test('returns repo-relative paths with forward slashes on every platform', () => {
+		const skillDir = path.join(tmp, '.claude', 'skills', 'windows-safe');
+		fs.mkdirSync(skillDir, { recursive: true });
+		fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# Skill');
+
+		const result = discoverAvailableSkills(tmp);
+		expect(result).toContain('.claude/skills/windows-safe/SKILL.md');
+		expect(result[0]).not.toContain('\\');
 	});
 
 	test('ignores dot-prefixed entries in skill root', () => {

--- a/tests/unit/hooks/skill-scoring.test.ts
+++ b/tests/unit/hooks/skill-scoring.test.ts
@@ -11,6 +11,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import { parseSkillPaths } from '../../../src/hooks/skill-propagation-gate.js';
 import {
 	_internals,
 	computeSkillRelevanceScore,
@@ -487,7 +488,7 @@ describe('rankSkillsForContext', () => {
 
 		expect(results).toHaveLength(2);
 		// They have identical scores and identical usage counts, order is stable
-		expect(results[0].score).toBe(results[1].score);
+		expect(results[0].score).toBeCloseTo(results[1].score, 10);
 	});
 });
 
@@ -673,6 +674,81 @@ describe('formatSkillIndexWithContext', () => {
 		expect(output).toContain('writing-tests');
 		expect(output).toContain('used: 2');
 		expect(output).toContain('compliance: 100%');
+	});
+
+	test('includes skill frontmatter description and repo-relative path when no usage log exists', () => {
+		const skillDir = path.join(tempDir, '.claude', 'skills', 'vitest-patterns');
+		fs.mkdirSync(skillDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(skillDir, 'SKILL.md'),
+			[
+				'---',
+				'name: vitest-patterns',
+				'description: Effect-TS 4 Vitest patterns for tests',
+				'---',
+				'# Body',
+			].join('\n'),
+		);
+
+		const output = _internals.formatSkillIndexWithContext(
+			['.claude/skills/vitest-patterns/SKILL.md'],
+			tempDir,
+		);
+
+		expect(output).toContain('vitest-patterns');
+		expect(output).toContain('Effect-TS 4 Vitest patterns for tests');
+		expect(output).toContain('file:.claude/skills/vitest-patterns/SKILL.md');
+		expect(parseSkillPaths(output)).toEqual([
+			'file:.claude/skills/vitest-patterns/SKILL.md',
+		]);
+	});
+
+	test('parses folded frontmatter descriptions for skill index output', () => {
+		const skillDir = path.join(tempDir, '.opencode', 'skills', 'writing-tests');
+		fs.mkdirSync(skillDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(skillDir, 'SKILL.md'),
+			[
+				'---',
+				'name: writing-tests',
+				'description: >',
+				'  Guidelines for writing, organizing,',
+				'  and maintaining tests.',
+				'---',
+				'# Body',
+			].join('\n'),
+		);
+
+		const output = _internals.formatSkillIndexWithContext(
+			['.opencode/skills/writing-tests/SKILL.md'],
+			tempDir,
+		);
+
+		expect(output).toContain(
+			'Guidelines for writing, organizing, and maintaining tests.',
+		);
+	});
+
+	test('reads metadata when the input skill path already has a file: prefix', () => {
+		const skillDir = path.join(tempDir, '.claude', 'skills', 'prefixed');
+		fs.mkdirSync(skillDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(skillDir, 'SKILL.md'),
+			[
+				'---',
+				'name: prefixed',
+				'description: Prefix-safe metadata',
+				'---',
+			].join('\n'),
+		);
+
+		const metadata = _internals.readSkillMetadata(
+			'file:.claude/skills/prefixed/SKILL.md',
+			tempDir,
+		);
+
+		expect(metadata.path).toBe('.claude/skills/prefixed/SKILL.md');
+		expect(metadata.description).toBe('Prefix-safe metadata');
 	});
 
 	test('falls back to simple index when log is empty', () => {


### PR DESCRIPTION
﻿Closes #957

## Summary
- Add description-aware skill index entries from bounded `SKILL.md` frontmatter reads so architects can pass `file:<path> - name: description` entries to subagents.
- Parse multiline description-rich `SKILLS:` catalogs while preserving legacy skill-path parsing and Windows-safe slash normalization.
- Update architect and subagent prompts so project contract files and skill descriptions are passed before agents decide which skill bodies to load on demand.

## Invariant audit
- 1 (plugin init):       not touched - no plugin registration/init-path behavior changed; `bun run build` and the dist ESM import check passed.
- 2 (runtime portability): touched - rebuilt tracked `dist/` output and verified `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` prints `dist import OK`.
- 3 (subprocesses):       not touched - changed source does not add subprocess execution paths.
- 4 (.swarm containment): touched - skill propagation continues to write through the existing `.swarm/context.md` gate; focused skill-propagation tests passed.
- 5 (plan durability):    not touched - no ledger, projection, checkpoint import/export, or plan schema code changed.
- 6 (test_runner safety): not touched - validation used shell `bun --smol test` commands, not broad OpenCode `test_runner` scopes.
- 7 (test writing):       touched - writing-tests skill loaded; new tests use `bun:test` and no new `mock.module`; targeted suites passed.
- 8 (session state):      not touched - no session/global state maps changed.
- 9 (guardrails/retry):   not touched - retry/circuit-breaker behavior unchanged.
- 10 (chat/system msg):   not touched - chat/system-message hooks unchanged.
- 11 (tool registration): not touched - no tool map, command, help, or registration changes.
- 12 (release/cache):     touched - added `docs/releases/pending/skill-description-aware-propagation-957.md`; no release-please-owned version files edited.

## Test plan
- [x] `bun run build`
- [x] `git diff --exit-code -- dist/`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `bun run typecheck`
- [x] `bunx biome ci .` (passes with 7 existing `src/index.ts` `noExplicitAny` warnings)
- [x] `bun --smol test tests/unit/hooks/skill-scoring.test.ts tests/unit/hooks/skill-propagation-gate.test.ts tests/unit/hooks/skill-propagation-gate.adversarial.test.ts tests/unit/agents/skills-propagation.test.ts tests/unit/agents/architect-sounding-board-protocol.adversarial.test.ts --timeout 30000` (351 pass)
- [x] `bun --smol test tests/unit/hooks/skill-propagation-integration.test.ts tests/unit/hooks/skill-scoring-e2e.test.ts --timeout 30000` (45 pass)
- [x] `git diff --check`

## Pre-existing failures checked against origin/main
- `bun --smol test tests/unit/hooks/adversarial-detection-schema.adversarial.test.ts --timeout 30000` fails the same way on clean `origin/main`: expected Zod issue code `invalid_type`, got `too_small` (30 pass, 1 fail).
- `bun --smol test tests/unit/services/skill-generator.test.ts --timeout 30000` fails the same way on clean `origin/main` on Windows path separators in two assertions (7 pass, 2 fail).
