### PR TITLE
fix(agents): route prefixed spec writer delegations

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.28.2",
+    version: "7.29.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -40278,19 +40278,9 @@ function validateConfigKey(path24, value, _config) {
     case "guardrails.profiles": {
       const profiles = value;
       if (profiles) {
-        const validAgents = [
-          "architect",
-          "coder",
-          "test_engineer",
-          "explorer",
-          "reviewer",
-          "critic",
-          "sme",
-          "docs",
-          "designer"
-        ];
+        const validAgents = new Set(ALL_AGENT_NAMES);
         for (const [agentName, profile] of Object.entries(profiles)) {
-          if (!validAgents.includes(agentName)) {
+          if (!validAgents.has(agentName)) {
             findings.push({
               id: "unknown-agent-profile",
               title: "Unknown agent profile",
@@ -40451,23 +40441,23 @@ function validateConfigKey(path24, value, _config) {
     case "swarms": {
       const swarms = value;
       if (swarms && typeof swarms === "object") {
+        const validAgents = new Set(ALL_AGENT_NAMES);
         for (const [swarmId, swarmConfig] of Object.entries(swarms)) {
           const swarm = swarmConfig;
           if (swarm.agents && typeof swarm.agents === "object") {
             for (const [agentName] of Object.entries(swarm.agents)) {
-              const validAgents = [
-                "architect",
-                "coder",
-                "test_engineer",
-                "explorer",
-                "reviewer",
-                "critic",
-                "sme",
-                "docs",
-                "designer"
-              ];
-              const baseName = agentName.replace(/^[a-zA-Z0-9]+_/, "");
-              if (!validAgents.includes(baseName)) {
+              const baseName = stripKnownSwarmPrefix(agentName);
+              if (baseName !== agentName && agentName.startsWith(`${swarmId}_`) && validAgents.has(baseName)) {
+                findings.push({
+                  id: "prefixed-swarm-agent-override",
+                  title: "Prefixed agent override is ignored",
+                  description: `Agent "${agentName}" in swarm "${swarmId}" uses a generated agent name. ` + `Per-swarm overrides must use the canonical key "${baseName}", e.g. ` + `"swarms.${swarmId}.agents.${baseName}.model". Otherwise the override is ignored and the agent falls back to its default model.`,
+                  severity: "warn",
+                  path: `swarms.${swarmId}.agents.${agentName}`,
+                  currentValue: swarm.agents[agentName],
+                  autoFixable: false
+                });
+              } else if (!validAgents.has(baseName)) {
                 findings.push({
                   id: "unknown-swarm-agent",
                   title: "Unknown agent in swarm",
@@ -40818,6 +40808,8 @@ function removeStraySwarmDir(projectRoot, strayPath) {
 }
 var VALID_CONFIG_PATTERNS, DANGEROUS_PATH_SEGMENTS;
 var init_config_doctor = __esm(() => {
+  init_constants();
+  init_schema();
   init_utils();
   VALID_CONFIG_PATTERNS = [
     /^\.config[\\/]opencode[\\/]opencode-swarm\.json$/,

--- a/docs/releases/pending/prefixed-spec-writer-routing.md
+++ b/docs/releases/pending/prefixed-spec-writer-routing.md
@@ -1,0 +1,46 @@
+# Prefixed spec writer routing
+
+## What changed
+
+- Multi-swarm architect prompts now name the generated `*_spec_writer` and
+  `*_skill_improver` agents instead of bare unprefixed names.
+- Config doctor now warns when a per-swarm override uses a generated prefixed
+  key such as `swarms.modelrelay.agents.modelrelay_spec_writer`; the canonical
+  key is `swarms.modelrelay.agents.spec_writer`.
+
+## Why
+
+In named swarms, the generated spec writer is registered as
+`<swarm>_spec_writer`, but the architect prompt still pointed at bare
+`spec_writer`. A user could also configure the prefixed generated key, which
+looked natural but was ignored and caused the agent to fall back to its default
+model.
+
+## Migration
+
+Use canonical per-swarm override keys:
+
+```json
+{
+  "swarms": {
+    "modelrelay": {
+      "agents": {
+        "spec_writer": { "model": "provider/custom-spec" }
+      }
+    }
+  }
+}
+```
+
+## Breaking changes
+
+None for default configurations. Configurations that explicitly disable
+`spec_writer` now stop SPECIFY/BRAINSTORM spec creation and ask the user to
+re-enable `spec_writer` before creating or revising `.swarm/spec.md`, rather
+than trying to draft the spec inline.
+
+## Known caveats
+
+Config doctor reports the prefixed override but does not auto-fix it, because
+both the prefixed and canonical keys may be present and user intent can be
+ambiguous.

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -73,7 +73,7 @@ ANTI-RATIONALIZATION: Context does not clarify. Models revert to CC training.
 ## IDENTITY
 
 Swarm: {{SWARM_ID}}
-Your agents: {{AGENT_PREFIX}}explorer, {{AGENT_PREFIX}}sme, {{AGENT_PREFIX}}coder, {{AGENT_PREFIX}}reviewer, {{AGENT_PREFIX}}test_engineer, {{AGENT_PREFIX}}critic, {{AGENT_PREFIX}}critic_sounding_board, {{AGENT_PREFIX}}docs, {{AGENT_PREFIX}}designer
+Your agents: {{AGENT_PREFIX}}explorer, {{AGENT_PREFIX}}sme, {{AGENT_PREFIX}}coder, {{AGENT_PREFIX}}reviewer, {{AGENT_PREFIX}}test_engineer, {{AGENT_PREFIX}}critic, {{AGENT_PREFIX}}critic_sounding_board, {{AGENT_PREFIX}}skill_improver, {{AGENT_PREFIX}}spec_writer, {{AGENT_PREFIX}}docs, {{AGENT_PREFIX}}designer
 
 ## PROJECT CONTEXT
 Session-start priming block. Use any known values immediately; if a field is still unresolved, run MODE: DISCOVER before relying on it.
@@ -414,6 +414,8 @@ SECURITY_KEYWORDS: password, secret, token, credential, auth, login, encryption,
 {{AGENT_PREFIX}}test_engineer - Test generation AND execution (writes tests, runs them, reports PASS/FAIL)
 {{AGENT_PREFIX}}critic - Plan review gate (reviews plan BEFORE implementation)
 {{AGENT_PREFIX}}critic_sounding_board - Pre-escalation pushback (honest engineer review before user contact)
+{{AGENT_PREFIX}}skill_improver - Low-frequency skill / knowledge / prompt improvement adviser
+{{AGENT_PREFIX}}spec_writer - .swarm/spec.md authoring via spec_write
 {{AGENT_PREFIX}}docs - Documentation updates (README, API docs, guides — NOT .swarm/ files)
 {{AGENT_PREFIX}}designer - UI/UX design specs (scaffold generation for UI components — runs BEFORE coder on UI tasks)
 
@@ -464,30 +466,20 @@ For every applicable directive in the block:
 
 You may also call the \`knowledge_ack\` tool to record an outcome explicitly when chat-text markers would be ambiguous (e.g. inside structured tool args).
 
-## SKILL IMPROVER (low-frequency, expensive-model adviser)
+## SKILL IMPROVER
 
-The \`skill_improver\` agent and the \`skill_improve\` tool exist for rare, deep
-review of accumulated knowledge / skills / spec / architect prompt. They are
-quota-bounded (default 10 calls/day) and disabled by default. Suggest running
-\`skill_improve\` only after one of:
-- repeated reviewer rejections in a row,
-- many \`KNOWLEDGE_IGNORED\` outcomes for the same cluster,
-- stale skills (no updates while their target area changed),
-- a fresh spec mismatch with shipped behaviour.
+\`{{AGENT_PREFIX}}skill_improver\` / \`skill_improve\`: rare, quota-bounded,
+disabled by default, proposal-only. Use for repeated rejections,
+\`KNOWLEDGE_IGNORED\`, stale skills, or spec drift.
 
 When \`skill_improver.require_user_approval\` is true (default), ASK the user
 before running. Default outputs are proposals only — they never modify source.
 
 ## SPEC WRITER
 
-For substantial spec authoring or revision, prefer delegating to the
-\`spec_writer\` agent (independent model from architect). It writes only via
-the safe \`spec_write\` tool. Use it when:
-- the user requests a new spec or major spec revision,
-- requirements decomposition is non-trivial,
-- you would otherwise inline-author \`.swarm/spec.md\` yourself.
-
-Continue handling small touch-ups (typos, cross-references) inline.
+For substantial spec authoring/revision, prefer \`{{AGENT_PREFIX}}spec_writer\`;
+it writes via \`spec_write\`. Use for major specs or non-trivial
+decomposition. Handle small touch-ups.
 
 ### ANTI-RATIONALIZATION
 - ✗ "The coder already knows these conventions" → Skills contain project-specific rules the model cannot know from training. Always pass.
@@ -668,11 +660,12 @@ MODE: BRAINSTORM runs seven phases in strict order. Do not skip phases. Do not c
 - Exit with a design outline the user can skim in under two minutes.
 
 **Phase 5: SPEC WRITE + SELF-REVIEW (architect + reviewer).**
-- Generate \`.swarm/spec.md\` following the same SPEC CONTENT RULES that MODE: SPECIFY uses: WHAT/WHY only, no tech stack, no implementation details, FR-### / SC-### numbering, Given/When/Then scenarios, \`[NEEDS CLARIFICATION]\` markers (max 3).
+- Delegate substantial spec drafting to \`{{AGENT_PREFIX}}spec_writer\` with the chosen design, dialogue notes, SME context, and SPEC CONTENT RULES. The spec writer must persist \`.swarm/spec.md\` through \`spec_write\`.
+- The spec must follow the same SPEC CONTENT RULES that MODE: SPECIFY uses: WHAT/WHY only, no tech stack, no implementation details, FR-### / SC-### numbering, Given/When/Then scenarios, \`[NEEDS CLARIFICATION]\` markers (max 3).
 - Cross-reference design sections by name where relevant context helps (but keep HOW out of the spec).
 - Delegate to \`{{AGENT_PREFIX}}reviewer\` for an independent review of the draft spec. Reviewer must flag: requirements that encode HOW, untestable requirements, missing edge cases, silent assumptions.
 - Apply reviewer feedback. If reviewer rejects, iterate once and re-review. After two rounds, surface remaining disagreements to the user.
-- Write the final spec to \`.swarm/spec.md\`.
+- Read back and lint the final spec after \`{{AGENT_PREFIX}}spec_writer\` writes it.
 - Exit when reviewer signs off (or user explicitly accepts remaining disagreements).
 
 **Phase 6: QA GATE SELECTION (architect, dialogue only).**
@@ -744,7 +737,7 @@ Activates when: user asks to "specify", "define requirements", "write a spec", o
 1b. Run CODEBASE REALITY CHECK for any codebase references mentioned by the user or implied by the feature. Skip if work is purely greenfield (no existing codebase to check). Report discrepancies before proceeding to explorer.
 2. Delegate to \`{{AGENT_PREFIX}}explorer\` to scan the codebase for relevant context (existing patterns, related code, affected areas).
 3. Delegate to \`{{AGENT_PREFIX}}sme\` for domain research on the feature area to surface known constraints, best practices, and integration concerns.
-4. Generate \`.swarm/spec.md\` capturing:
+4. Delegate substantial spec drafting to \`{{AGENT_PREFIX}}spec_writer\`. Include the user requirements, explorer findings, SME constraints, and these required contents:
    - First line must be: \`# Specification: <feature-name>\`
    - Feature description: WHAT users need and WHY — never HOW to implement
    - User scenarios with acceptance criteria (Given/When/Then format)
@@ -753,7 +746,7 @@ Activates when: user asks to "specify", "define requirements", "write a spec", o
    - Key entities if data is involved (no schema or field definitions — entity names only)
    - Edge cases and known failure modes
    - \`[NEEDS CLARIFICATION]\` markers (max 3) for items where uncertainty could change scope, security, or core behavior; prefer informed defaults over asking
-5. Write the spec to \`.swarm/spec.md\`.
+5. Require \`{{AGENT_PREFIX}}spec_writer\` to write the spec via \`spec_write\`, then read back and lint \`.swarm/spec.md\`.
 5b. **QA GATE SELECTION (dialogue only).**
 {{QA_GATE_DIALOGUE_SPECIFY}}
 

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -378,9 +378,79 @@ function createSwarmAgents(
 				projectContext.PROJECT_CONTEXT_SECONDARY_LANGUAGES,
 			);
 
+		const skillImproverEnabled = !isAgentDisabled(
+			'skill_improver',
+			swarmAgents,
+			swarmPrefix,
+		);
+		const specWriterEnabled = !isAgentDisabled(
+			'spec_writer',
+			swarmAgents,
+			swarmPrefix,
+		);
+
+		if (!skillImproverEnabled) {
+			architect.config.prompt = architect.config.prompt
+				?.replace(`, ${agentPrefix}skill_improver`, '')
+				.replace(
+					`\n${agentPrefix}skill_improver - Low-frequency skill / knowledge / prompt improvement adviser`,
+					'',
+				)
+				.replace(/\n## SKILL IMPROVER[\s\S]*?(?=\n\n## SPEC WRITER)/, '');
+		}
+
+		if (!specWriterEnabled) {
+			const escapedAgentPrefix = agentPrefix.replace(
+				/[.*+?^${}()|[\]\\]/g,
+				'\\$&',
+			);
+			architect.config.prompt = architect.config.prompt
+				?.replace(`, ${agentPrefix}spec_writer`, '')
+				.replace(
+					`\n${agentPrefix}spec_writer - .swarm/spec.md authoring via spec_write`,
+					'',
+				)
+				.replace(/\n## SPEC WRITER[\s\S]*?(?=\n\n### ANTI-RATIONALIZATION)/, '')
+				.replace(
+					new RegExp(
+						`- Delegate substantial spec drafting to \`${escapedAgentPrefix}spec_writer\`[^\\n]*\\n`,
+						'g',
+					),
+					'- spec_writer is disabled. Ask the user to enable the spec_writer agent before creating or revising `.swarm/spec.md`.\n',
+				)
+				.replace(
+					new RegExp(
+						`4\\. Delegate substantial spec drafting to \`${escapedAgentPrefix}spec_writer\`[^\\n]*`,
+					),
+					'4. spec_writer is disabled. Ask the user to enable the spec_writer agent before creating or revising `.swarm/spec.md`.',
+				)
+				.replace(
+					new RegExp(
+						`5\\. Require \`${escapedAgentPrefix}spec_writer\` to write the spec via \`spec_write\`, then read back and lint \`\\.swarm/spec\\.md\`\\.`,
+					),
+					'5. Do not continue SPECIFY until spec_writer is available.',
+				)
+				.replace(
+					new RegExp(
+						`- Read back and lint the final spec after \`${escapedAgentPrefix}spec_writer\` writes it\\.`,
+					),
+					'- Do not continue BRAINSTORM spec writing until spec_writer is available.',
+				);
+		}
+
 		// Add swarm identity header for non-default swarms
 		if (!isDefault) {
 			architect.description = `[${swarmName}] ${architect.description}`;
+			const optionalAgentLines = [
+				skillImproverEnabled
+					? `- @${swarmId}_skill_improver (not @skill_improver)`
+					: undefined,
+				specWriterEnabled
+					? `- @${swarmId}_spec_writer (not @spec_writer)`
+					: undefined,
+			]
+				.filter((line): line is string => Boolean(line))
+				.join('\n');
 			const swarmHeader = `## ⚠️ YOU ARE THE ${swarmName.toUpperCase()} SWARM ARCHITECT
 
 Your swarm ID is "${swarmId}". ALL your agents have the "${swarmId}_" prefix:
@@ -388,7 +458,7 @@ Your swarm ID is "${swarmId}". ALL your agents have the "${swarmId}_" prefix:
 - @${swarmId}_coder (not @coder)
 - @${swarmId}_sme (not @sme)
 - @${swarmId}_reviewer (not @reviewer)
-- etc.
+${optionalAgentLines ? `${optionalAgentLines}\n` : ''}- etc.
 
 CRITICAL: Agents without the "${swarmId}_" prefix DO NOT EXIST or belong to a DIFFERENT swarm.
 If you call @coder instead of @${swarmId}_coder, the call will FAIL or go to the wrong swarm.

--- a/src/services/config-doctor.test.ts
+++ b/src/services/config-doctor.test.ts
@@ -176,6 +176,28 @@ describe('Config Doctor Service', () => {
 			expect(result.findings[0]!.autoFixable).toBe(true);
 		});
 
+		it('should accept guardrails profiles for optional spec_writer and skill_improver agents', () => {
+			const config = createTestConfigObj({
+				guardrails: {
+					enabled: true,
+					max_tool_calls: 200,
+					max_duration_minutes: 30,
+					max_repetitions: 10,
+					max_consecutive_errors: 5,
+					warning_threshold: 0.75,
+					idle_timeout_minutes: 60,
+					profiles: {
+						spec_writer: { max_tool_calls: 20 },
+						skill_improver: { max_tool_calls: 30 },
+					},
+				},
+			});
+
+			const result = runConfigDoctor(config, tempDir);
+
+			expect(result.findings).toHaveLength(0);
+		});
+
 		it('should detect unknown hook fields', () => {
 			const config = createTestConfigObj({
 				hooks: {
@@ -220,6 +242,62 @@ describe('Config Doctor Service', () => {
 			expect(result.findings.some((f) => f.id === 'unknown-swarm-agent')).toBe(
 				true,
 			);
+		});
+
+		it('should warn when per-swarm config uses a generated prefixed agent key', () => {
+			const config = createTestConfigObj({
+				swarms: {
+					modelrelay: {
+						agents: {
+							modelrelay_spec_writer: { model: 'provider/custom-spec' },
+						},
+					},
+				},
+			});
+
+			const result = runConfigDoctor(config, tempDir);
+
+			expect(result.findings).toHaveLength(1);
+			expect(result.findings[0]!.id).toBe('prefixed-swarm-agent-override');
+			expect(result.findings[0]!.severity).toBe('warn');
+			expect(result.findings[0]!.description).toContain(
+				'swarms.modelrelay.agents.spec_writer.model',
+			);
+			expect(result.findings[0]!.autoFixable).toBe(false);
+		});
+
+		it('should accept canonical spec_writer and skill_improver swarm agent keys', () => {
+			const config = createTestConfigObj({
+				swarms: {
+					modelrelay: {
+						agents: {
+							spec_writer: { model: 'provider/custom-spec' },
+							skill_improver: { model: 'provider/custom-skill' },
+							test_engineer: { model: 'provider/test' },
+						},
+					},
+				},
+			});
+
+			const result = runConfigDoctor(config, tempDir);
+
+			expect(result.findings).toHaveLength(0);
+		});
+
+		it('should accept canonical agent keys that start with the swarm id', () => {
+			const config = createTestConfigObj({
+				swarms: {
+					critic: {
+						agents: {
+							critic_sounding_board: { model: 'provider/critic-board' },
+						},
+					},
+				},
+			});
+
+			const result = runConfigDoctor(config, tempDir);
+
+			expect(result.findings).toHaveLength(0);
 		});
 	});
 

--- a/src/services/config-doctor.ts
+++ b/src/services/config-doctor.ts
@@ -9,7 +9,9 @@ import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { ALL_AGENT_NAMES } from '../config/constants';
 import type { PluginConfig } from '../config/schema';
+import { stripKnownSwarmPrefix } from '../config/schema';
 import { log } from '../utils';
 
 /**
@@ -398,19 +400,9 @@ function validateConfigKey(
 		case 'guardrails.profiles': {
 			const profiles = value as Record<string, unknown> | undefined;
 			if (profiles) {
-				const validAgents = [
-					'architect',
-					'coder',
-					'test_engineer',
-					'explorer',
-					'reviewer',
-					'critic',
-					'sme',
-					'docs',
-					'designer',
-				];
+				const validAgents = new Set(ALL_AGENT_NAMES as readonly string[]);
 				for (const [agentName, profile] of Object.entries(profiles)) {
-					if (!validAgents.includes(agentName)) {
+					if (!validAgents.has(agentName)) {
 						findings.push({
 							id: 'unknown-agent-profile',
 							title: 'Unknown agent profile',
@@ -584,26 +576,34 @@ function validateConfigKey(
 		case 'swarms': {
 			const swarms = value as Record<string, unknown> | undefined;
 			if (swarms && typeof swarms === 'object') {
+				const validAgents = new Set(ALL_AGENT_NAMES as readonly string[]);
 				for (const [swarmId, swarmConfig] of Object.entries(swarms)) {
 					const swarm = swarmConfig as Record<string, unknown>;
 					if (swarm.agents && typeof swarm.agents === 'object') {
 						for (const [agentName] of Object.entries(
 							swarm.agents as Record<string, unknown>,
 						)) {
-							const validAgents = [
-								'architect',
-								'coder',
-								'test_engineer',
-								'explorer',
-								'reviewer',
-								'critic',
-								'sme',
-								'docs',
-								'designer',
-							];
-							// Allow swarm-prefixed agents like "local_coder"
-							const baseName = agentName.replace(/^[a-zA-Z0-9]+_/, '');
-							if (!validAgents.includes(baseName)) {
+							const baseName = stripKnownSwarmPrefix(agentName);
+							if (
+								baseName !== agentName &&
+								agentName.startsWith(`${swarmId}_`) &&
+								validAgents.has(baseName)
+							) {
+								findings.push({
+									id: 'prefixed-swarm-agent-override',
+									title: 'Prefixed agent override is ignored',
+									description:
+										`Agent "${agentName}" in swarm "${swarmId}" uses a generated agent name. ` +
+										`Per-swarm overrides must use the canonical key "${baseName}", e.g. ` +
+										`"swarms.${swarmId}.agents.${baseName}.model". Otherwise the override is ignored and the agent falls back to its default model.`,
+									severity: 'warn',
+									path: `swarms.${swarmId}.agents.${agentName}`,
+									currentValue: (swarm.agents as Record<string, unknown>)[
+										agentName
+									],
+									autoFixable: false,
+								});
+							} else if (!validAgents.has(baseName)) {
 								findings.push({
 									id: 'unknown-swarm-agent',
 									title: 'Unknown agent in swarm',

--- a/tests/unit/agents/new-agents-registration.test.ts
+++ b/tests/unit/agents/new-agents-registration.test.ts
@@ -103,6 +103,21 @@ describe('multi-swarm prefix registration for new agents', () => {
 	let originalXDG: string | undefined;
 	let tempDir: string | undefined;
 
+	function sectionBetween(
+		text: string,
+		startMarker: string,
+		endMarker: string,
+	): string {
+		const start = text.indexOf(startMarker);
+		expect(start).toBeGreaterThan(-1);
+		const end = text.indexOf(endMarker, start + startMarker.length);
+		return text.slice(start, end === -1 ? text.length : end);
+	}
+
+	function countOccurrences(text: string, needle: string): number {
+		return text.split(needle).length - 1;
+	}
+
 	beforeEach(() => {
 		originalXDG = process.env.XDG_CONFIG_HOME;
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'multi-swarm-new-agents-'));
@@ -153,6 +168,195 @@ describe('multi-swarm prefix registration for new agents', () => {
 		for (const name of primaryArchitects) {
 			expect(configs[name].model).toBeUndefined();
 		}
+	});
+
+	it('resolves modelrelay spec_writer prompt and model through the prefixed registered agent', () => {
+		const config = {
+			swarms: {
+				modelrelay: {
+					name: 'Modelrelay',
+					agents: {
+						spec_writer: { model: 'modelrelay/high-spec' },
+					},
+				},
+			},
+		} as unknown as PluginConfig;
+
+		const configs = getAgentConfigs(config);
+		const architectPrompt = configs.modelrelay_architect.prompt ?? '';
+		const specWriterSection = sectionBetween(
+			architectPrompt,
+			'## SPEC WRITER',
+			'### ANTI-RATIONALIZATION',
+		);
+		const agentsSection = sectionBetween(
+			architectPrompt,
+			'## AGENTS',
+			'## SKILLS PROPAGATION',
+		);
+		const specifySection = sectionBetween(
+			architectPrompt,
+			'### MODE: SPECIFY',
+			'### MODE:',
+		);
+		const brainstormSection = sectionBetween(
+			architectPrompt,
+			'### MODE: BRAINSTORM',
+			'### MODE: SPECIFY',
+		);
+
+		expect(configs.modelrelay_spec_writer).toBeDefined();
+		expect(configs.modelrelay_spec_writer.mode).toBe('subagent');
+		expect(configs.modelrelay_spec_writer.model).toBe('modelrelay/high-spec');
+		expect(architectPrompt).toContain(
+			'Your agents: modelrelay_explorer, modelrelay_sme, modelrelay_coder, modelrelay_reviewer, modelrelay_test_engineer, modelrelay_critic, modelrelay_critic_sounding_board, modelrelay_skill_improver, modelrelay_spec_writer',
+		);
+		expect(agentsSection).toContain('modelrelay_spec_writer');
+		expect(specWriterSection).toContain('prefer `modelrelay_spec_writer`');
+		expect(specifySection).toContain(
+			'Delegate substantial spec drafting to `modelrelay_spec_writer`',
+		);
+		expect(brainstormSection).toContain(
+			'Delegate substantial spec drafting to `modelrelay_spec_writer`',
+		);
+		expect(architectPrompt).not.toContain('prefer `spec_writer`');
+	});
+
+	it('documents spec_writer default model fallback without inheriting architect model', () => {
+		const configs = getAgentConfigs({
+			swarms: {
+				modelrelay: {
+					name: 'Modelrelay',
+					agents: {
+						architect: { model: 'modelrelay/deepseek-v4-flash' },
+					},
+				},
+			},
+		} as unknown as PluginConfig);
+
+		expect(configs.modelrelay_spec_writer).toBeDefined();
+		expect(configs.modelrelay_spec_writer.model).toBe(
+			DEFAULT_MODELS.spec_writer,
+		);
+		expect(configs.modelrelay_spec_writer.model).not.toBe(
+			'modelrelay/deepseek-v4-flash',
+		);
+	});
+
+	it('does not advertise modelrelay spec_writer when the role is disabled', () => {
+		const configs = getAgentConfigs({
+			swarms: {
+				modelrelay: {
+					name: 'Modelrelay',
+					agents: {
+						spec_writer: { disabled: true },
+					},
+				},
+			},
+		} as unknown as PluginConfig);
+
+		const architectPrompt = configs.modelrelay_architect.prompt ?? '';
+		const agentsSection = sectionBetween(
+			architectPrompt,
+			'## AGENTS',
+			'## SKILLS PROPAGATION',
+		);
+		const specifySection = sectionBetween(
+			architectPrompt,
+			'### MODE: SPECIFY',
+			'### MODE:',
+		);
+		const brainstormSection = sectionBetween(
+			architectPrompt,
+			'### MODE: BRAINSTORM',
+			'### MODE: SPECIFY',
+		);
+
+		expect(configs.modelrelay_spec_writer).toBeUndefined();
+		expect(architectPrompt).not.toContain('modelrelay_spec_writer');
+		expect(architectPrompt).not.toContain('@modelrelay_spec_writer');
+		expect(architectPrompt).not.toContain('## SPEC WRITER');
+		expect(agentsSection).not.toContain('spec_writer');
+		expect(specifySection).toContain('spec_writer is disabled');
+		expect(specifySection).toContain(
+			'Do not continue SPECIFY until spec_writer is available.',
+		);
+		expect(specifySection).not.toContain('Delegate substantial spec drafting');
+		expect(specifySection).not.toContain('Require `modelrelay_spec_writer`');
+		expect(brainstormSection).toContain('spec_writer is disabled');
+		expect(brainstormSection).toContain(
+			'Do not continue BRAINSTORM spec writing until spec_writer is available.',
+		);
+		expect(brainstormSection).not.toContain(
+			'Delegate substantial spec drafting',
+		);
+		expect(brainstormSection).not.toContain('modelrelay_spec_writer');
+		expect(countOccurrences(architectPrompt, 'spec_writer is disabled')).toBe(
+			2,
+		);
+	});
+
+	it('does not advertise modelrelay skill_improver as an agent when the role is disabled', () => {
+		const configs = getAgentConfigs({
+			swarms: {
+				modelrelay: {
+					name: 'Modelrelay',
+					agents: {
+						skill_improver: { disabled: true },
+					},
+				},
+			},
+		} as unknown as PluginConfig);
+
+		const architectPrompt = configs.modelrelay_architect.prompt ?? '';
+		const agentsSection = sectionBetween(
+			architectPrompt,
+			'## AGENTS',
+			'## SKILLS PROPAGATION',
+		);
+
+		expect(configs.modelrelay_skill_improver).toBeUndefined();
+		// Disabled optional agents may still be mentioned as config/tool concepts,
+		// but they must not be advertised as callable swarm agents.
+		expect(architectPrompt).not.toContain('modelrelay_skill_improver');
+		expect(architectPrompt).not.toContain('@modelrelay_skill_improver');
+		expect(architectPrompt).not.toContain('## SKILL IMPROVER');
+		expect(agentsSection).not.toContain('skill_improver');
+	});
+
+	it('does not advertise disabled optional agents when both optional roles are disabled', () => {
+		const configs = getAgentConfigs({
+			swarms: {
+				modelrelay: {
+					name: 'Modelrelay',
+					agents: {
+						skill_improver: { disabled: true },
+						spec_writer: { disabled: true },
+					},
+				},
+			},
+		} as unknown as PluginConfig);
+
+		const architectPrompt = configs.modelrelay_architect.prompt ?? '';
+		const agentsSection = sectionBetween(
+			architectPrompt,
+			'## AGENTS',
+			'## SKILLS PROPAGATION',
+		);
+
+		expect(configs.modelrelay_skill_improver).toBeUndefined();
+		expect(configs.modelrelay_spec_writer).toBeUndefined();
+		expect(architectPrompt).not.toContain('modelrelay_skill_improver');
+		expect(architectPrompt).not.toContain('modelrelay_spec_writer');
+		expect(architectPrompt).not.toContain('@modelrelay_skill_improver');
+		expect(architectPrompt).not.toContain('@modelrelay_spec_writer');
+		expect(architectPrompt).not.toContain('## SKILL IMPROVER');
+		expect(architectPrompt).not.toContain('## SPEC WRITER');
+		expect(agentsSection).not.toContain('skill_improver');
+		expect(agentsSection).not.toContain('spec_writer');
+		expect(countOccurrences(architectPrompt, 'spec_writer is disabled')).toBe(
+			2,
+		);
 	});
 
 	it('default (unprefixed) registration still produces skill_improver and spec_writer as subagents', () => {


### PR DESCRIPTION
﻿﻿## Summary
- Route named-swarm architect delegation text to the generated prefixed optional agents, including `*_spec_writer` and `*_skill_improver`.
- Keep disabled optional agents out of architect prompt surfaces and add config-doctor guidance for ignored prefixed override keys.
- Reconcile PR review findings: guardrails profile validation now accepts optional agents, release notes document disabled `spec_writer` behavior, and disabled optional-agent prompt stripping has stronger coverage.

## PR review fixes
- F-001 (valid): `guardrails.profiles` validation now uses `ALL_AGENT_NAMES`, preventing the remove auto-fix from deleting valid `spec_writer` / `skill_improver` profiles; added a regression test.
- F-002 (valid): release notes now document that configs explicitly disabling `spec_writer` block SPECIFY/BRAINSTORM spec creation until `spec_writer` is re-enabled.
- A-001/A-002/A-003 (valid advisories): added disabled `skill_improver` coverage, both-optionals-disabled coverage, and stronger disabled `spec_writer` assertions across AGENTS/SPECIFY/BRAINSTORM prompt surfaces.
- F-003 (pre-existing): noted by review as pre-existing prompt-injection risk in `swarmId`; not changed in this PR.

## Invariant audit
- 1 (plugin init): not touched - no init-path behavior was changed; `bunx bun@1.3.13 run build` completed and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` printed `dist import OK`.
- 2 (runtime portability): touched - bundled `dist/` changed; verified with `bunx bun@1.3.13 run build`, `bun run typecheck`, bundle portability/plugin-shape/node-load tests, and Node ESM import of `dist/index.js`.
- 3 (subprocesses): not touched - source changes are agent prompt/config-doctor/test updates only, with no subprocess helpers or spawn call sites changed.
- 4 (.swarm containment): not touched - no runtime state paths or tool storage behavior changed.
- 5 (plan durability): not touched - no plan ledger, projections, import/export, or plan schema code changed.
- 6 (test_runner safety): not touched - validation used shell `bun`/`node`/`biome`/`gh` commands; no broad OpenCode `test_runner` validation was used.
- 7 (test writing): touched - writing-tests guidance was loaded before test edits; added tests use `bun:test` patterns and do not add `mock.module` leakage.
- 8 (session state): not touched - no session-scoped globals or eviction behavior changed.
- 9 (guardrails/retry): not touched - config-doctor diagnostics for guardrail profile keys changed, but runtime guardrail, retry, fallback, and circuit-breaker code were not changed.
- 10 (chat/system msg): not touched - changes are static agent prompt content and config diagnostics, not chat/system-message hook shape.
- 11 (tool registration): touched - agent registration/prompt surfaces for prefixed optional agents changed; focused agent/config coverage passed, including disabled optional-agent cases.
- 12 (release/cache): touched - updated `docs/releases/pending/prefixed-spec-writer-routing.md`; did not hand-edit release-please-owned version files. `dist/` was rebuilt with CI-pinned Bun 1.3.13.

## Test plan
- [x] `bun --smol test src/services/config-doctor.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/agents/new-agents-registration.test.ts --timeout 30000`
- [x] `bun --smol test src/services/config-doctor.test.ts src/services/config-doctor.security.test.ts tests/unit/services/config-doctor-stray.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/agents/new-agents-registration.test.ts tests/unit/agents/architect-sounding-board-protocol.adversarial.test.ts tests/unit/agents/factory.test.ts tests/unit/agents/architect-spec-writing-discipline.test.ts tests/unit/agents/architect-brainstorm-gates.test.ts tests/unit/agents/architect-specify-gates.test.ts tests/unit/agents/architect-knowledge-directives-contract.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts tests/unit/build/bundle-node-load.test.ts --timeout 30000`
- [x] `bunx biome ci src/services/config-doctor.ts src/services/config-doctor.test.ts tests/unit/agents/new-agents-registration.test.ts docs/releases/pending/prefixed-spec-writer-routing.md`
- [x] `bunx biome ci .` - passed with existing `src/index.ts` `any` warnings
- [x] `bunx bun@1.3.13 run build`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `bun run typecheck`
- [x] `git diff --check` and `git diff --cached --check`
- [x] Independent swarm review: no blocking findings after review-fix patch.
- [x] Remote CI after amended push: `quality`, `dist-check`, `php-validation`, `security`, `unit` on Ubuntu/macOS/Windows, `integration`, and `smoke` on Ubuntu/macOS/Windows all passed on PR #991.

## Pre-existing local caveats
- Earlier local `bun --smol test tests/unit/config --timeout 120000` failed 5 tests unrelated to this branch: `critic_sounding_board uses big-pickle model`, `loadPluginConfig returns defaults when no config files exist`, Windows `EPERM` symlink handling, and two quiet-warning expectation tests.
- Per-file service validation exposed Windows path-separator assertions in untouched `tests/unit/services/skill-generator.test.ts`.
- Per-file tool validation exposed `tests/unit/tools/diagnostic-gating.test.ts` failures; those reproduced in a clean `origin/main` worktree.

