### PR TITLE
fix(delegation): resume plan tasks through coder dispatch

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.29.0",
+    version: "7.29.1",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/docs/releases/pending/issue-985-delegation-continuation.md
+++ b/docs/releases/pending/issue-985-delegation-continuation.md
@@ -1,0 +1,11 @@
+## Fix
+
+- Strengthened architect continuation guidance so resumed plan work points at the durable current task, requires scoped coder dispatch, and preserves parallel execution profiles instead of falling back to broad rediscovery.
+
+## Why
+
+- Fixes #985, where "continue with the plan" could lead the architect to inspect files directly instead of moving the current task through `update_task_status`, `declare_scope`, and coder Task delegation.
+
+## Validation
+
+- Added focused unit coverage for serial continuation guidance, sorted current-task selection, parallel coder-slot guidance, and the architect resume prompt.

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -901,6 +901,7 @@ If .swarm/plan.md exists:
      - Update context.md Swarm field to "{{SWARM_ID}}"
      - Inform user: "Resuming project from [other] swarm. Cleared stale context. Ready to continue."
      - Resume at current task
+Resume execution rule: after identifying the current task, do not restart broad discovery. Move into EXECUTE: call \`update_task_status\` if the task is not already in progress, call \`declare_scope\` for the task files, then dispatch coder Task call(s) according to \`execution_profile\`. Preserve ONE atomic task per coder Task call; parallel profiles may dispatch up to the available coder slots.
 If .swarm/plan.md does not exist → New project, proceed to MODE: CLARIFY
 If new project: Run \`complexity_hotspots\` tool (90 days) to generate a risk map. Note modules with recommendation "security_review" or "full_gates" in context.md for stricter QA gates during Phase 5. Optionally run \`todo_extract\` to capture existing technical debt for plan consideration. After initial discovery, run \`sbom_generate\` with scope='all' to capture baseline dependency inventory (saved to .swarm/evidence/sbom/).
 

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -15,7 +15,7 @@ import {
 	routeReviewForChanges,
 	shouldParallelizeReview,
 } from '../parallel/review-router.js';
-import { getCurrentTaskId, loadPlanJsonOnly } from '../plan/manager';
+import { loadPlanJsonOnly } from '../plan/manager';
 import type { AgentSessionState } from '../state';
 import {
 	advanceTaskState,
@@ -531,7 +531,7 @@ async function buildPlanContinuationGuidance(
 	if (!directory) return null;
 
 	const plan: Plan | null = await loadPlanJsonOnly(directory);
-	const currentTaskId = getCurrentTaskId(plan);
+	const currentTaskId = getPlanContinuationTaskId(plan);
 	if (!currentTaskId) return null;
 
 	return (
@@ -539,6 +539,38 @@ async function buildPlanContinuationGuidance(
 		`then call declare_scope for the task files and dispatch coder Task call(s) according to the execution profile. ` +
 		`Preserve ONE atomic task per coder Task call; when parallel execution is enabled, use available coder slots instead of forcing a single coder.`
 	);
+}
+
+function getPlanContinuationTaskId(
+	plan: Plan | null | undefined,
+): string | undefined {
+	if (!plan) return undefined;
+	const currentPhase = plan.current_phase ?? 1;
+	const phase = plan.phases.find((p) => p.id === currentPhase);
+	if (!phase) return undefined;
+	const sortedTasks = [...phase.tasks].sort((a, b) =>
+		comparePlanTaskIds(a.id, b.id),
+	);
+	const inProgress = sortedTasks.find((task) => task.status === 'in_progress');
+	if (inProgress) return inProgress.id;
+	const incomplete = sortedTasks.find(
+		(task) => task.status !== 'completed' && task.status !== 'closed',
+	);
+	return incomplete?.id;
+}
+
+function comparePlanTaskIds(a: string, b: string): number {
+	const partsA = a.split('.').map((part) => Number.parseInt(part, 10));
+	const partsB = b.split('.').map((part) => Number.parseInt(part, 10));
+	const maxLength = Math.max(partsA.length, partsB.length);
+
+	for (let i = 0; i < maxLength; i++) {
+		const numA = partsA[i] ?? 0;
+		const numB = partsB[i] ?? 0;
+		if (numA !== numB) return numA - numB;
+	}
+
+	return 0;
 }
 
 function isParallelGuidancePhaseComplete(phase: Phase): boolean {

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -533,12 +533,24 @@ async function buildPlanContinuationGuidance(
 	const plan: Plan | null = await loadPlanJsonOnly(directory);
 	const currentTaskId = getPlanContinuationTaskId(plan);
 	if (!currentTaskId) return null;
+	const sanitizedTaskId = sanitizeGuidanceValue(currentTaskId, 32);
 
 	return (
-		`[NEXT] Continue plan task ${currentTaskId}: if it is not already in progress, call update_task_status with task_id="${currentTaskId}" and status="in_progress"; ` +
+		`[NEXT] Continue plan task ${sanitizedTaskId}: if it is not already in progress, call update_task_status with task_id="${sanitizedTaskId}" and status="in_progress"; ` +
 		`then call declare_scope for the task files and dispatch coder Task call(s) according to the execution profile. ` +
 		`Preserve ONE atomic task per coder Task call; when parallel execution is enabled, use available coder slots instead of forcing a single coder.`
 	);
+}
+
+function sanitizeGuidanceValue(value: string, maxLength: number): string {
+	return value
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/\[ \]/g, '()')
+		.replace(/\[/g, '(')
+		.replace(/\]/g, ')')
+		.replace(/[\r\n]/g, ' ')
+		.slice(0, maxLength);
 }
 
 function getPlanContinuationTaskId(
@@ -1754,21 +1766,11 @@ export function createDelegationGateHook(
 						} else if (lastGate?.taskId) {
 							const gateResult = lastGate.passed ? 'PASSED' : 'FAILED';
 							// Sanitize interpolated values
-							const sanitizedGate = lastGate.gate
-								.replace(/</g, '&lt;')
-								.replace(/>/g, '&gt;')
-								.replace(/\[ \]/g, '()')
-								.replace(/\[/g, '(')
-								.replace(/\]/g, ')')
-								.replace(/[\r\n]/g, ' ')
-								.slice(0, 64);
-							const sanitizedTaskId = lastGate.taskId
-								.replace(/</g, '&lt;')
-								.replace(/>/g, '&gt;')
-								.replace(/\[/g, '(')
-								.replace(/\]/g, ')')
-								.replace(/[\r\n]/g, ' ')
-								.slice(0, 32);
+							const sanitizedGate = sanitizeGuidanceValue(lastGate.gate, 64);
+							const sanitizedTaskId = sanitizeGuidanceValue(
+								lastGate.taskId,
+								32,
+							);
 							// Concise [NEXT] directive with last-gate status
 							guidance = `[Last gate: ${sanitizedGate} ${gateResult} for task ${sanitizedTaskId}]\n${
 								parallelGuidance ??

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -15,7 +15,7 @@ import {
 	routeReviewForChanges,
 	shouldParallelizeReview,
 } from '../parallel/review-router.js';
-import { loadPlanJsonOnly } from '../plan/manager';
+import { getCurrentTaskId, loadPlanJsonOnly } from '../plan/manager';
 import type { AgentSessionState } from '../state';
 import {
 	advanceTaskState,
@@ -522,7 +522,23 @@ async function buildParallelExecutionGuidance(
 		return `[PARALLEL EXECUTION PROFILE] parallelization_enabled=true max_concurrent_tasks=${maxConcurrent}; no dependency-ready pending tasks are available for a new coder slot. Continue the current task/gate.`;
 	}
 
-	return `[PARALLEL EXECUTION PROFILE] parallelization_enabled=true max_concurrent_tasks=${maxConcurrent}; ${occupied.size} slot(s) occupied. Eligible now: ${eligible.join(', ')}. [NEXT] dispatch up to ${availableSlots} eligible coder task(s) before waiting; preserve ONE task per coder call and call declare_scope for each task.`;
+	return `[PARALLEL EXECUTION PROFILE] parallelization_enabled=true max_concurrent_tasks=${maxConcurrent}; ${occupied.size} slot(s) occupied. Eligible now: ${eligible.join(', ')}. [NEXT] dispatch up to ${availableSlots} eligible coder task(s) before waiting; for each dispatched task, call update_task_status(in_progress), call declare_scope, then send the coder Task. Preserve ONE atomic task per coder Task call.`;
+}
+
+async function buildPlanContinuationGuidance(
+	directory: string | undefined,
+): Promise<string | null> {
+	if (!directory) return null;
+
+	const plan: Plan | null = await loadPlanJsonOnly(directory);
+	const currentTaskId = getCurrentTaskId(plan);
+	if (!currentTaskId) return null;
+
+	return (
+		`[NEXT] Continue plan task ${currentTaskId}: if it is not already in progress, call update_task_status with task_id="${currentTaskId}" and status="in_progress"; ` +
+		`then call declare_scope for the task files and dispatch coder Task call(s) according to the execution profile. ` +
+		`Preserve ONE atomic task per coder Task call; when parallel execution is enabled, use available coder slots instead of forcing a single coder.`
+	);
 }
 
 function isParallelGuidancePhaseComplete(phase: Phase): boolean {
@@ -1690,6 +1706,10 @@ export function createDelegationGateHook(
 							deliberationSessionID,
 							deliberationSession,
 						);
+						const planContinuationGuidance =
+							parallelGuidance === null
+								? await buildPlanContinuationGuidance(directory)
+								: null;
 						const taskAwaitingCompletion = await findTaskAwaitingCompletion(
 							directory,
 							deliberationSession,
@@ -1723,10 +1743,11 @@ export function createDelegationGateHook(
 								'[NEXT] Execute the next gate for the current task.'
 							}`;
 						} else {
-							// Concise [NEXT] directive to begin first plan task
+							// Concise [NEXT] directive to continue from the durable plan cursor
 							// Also handles case where lastGate exists but taskId is missing
 							guidance =
 								parallelGuidance ??
+								planContinuationGuidance ??
 								'[NEXT] Begin the first plan task and run gates sequentially.';
 						}
 

--- a/tests/unit/agents/architect-v6-prompt.test.ts
+++ b/tests/unit/agents/architect-v6-prompt.test.ts
@@ -61,6 +61,18 @@ describe('Architect Agent - All MODE Sections', () => {
 			expect(positions[i]).toBeGreaterThan(positions[i - 1]);
 		}
 	});
+
+	it('MODE: RESUME moves directly to scoped coder dispatch', () => {
+		const resumeIdx = p.indexOf('### MODE: RESUME');
+		const clarifyIdx = p.indexOf('### MODE: CLARIFY', resumeIdx);
+		const section = p.slice(resumeIdx, clarifyIdx);
+		expect(section).toContain('do not restart broad discovery');
+		expect(section).toContain('declare_scope');
+		expect(section).toContain('ONE atomic task per coder Task call');
+		expect(section).toContain(
+			'parallel profiles may dispatch up to the available coder slots',
+		);
+	});
 });
 
 describe('Architect Agent - Key Structural Elements', () => {

--- a/tests/unit/hooks/delegation-gate-task-1-5.test.ts
+++ b/tests/unit/hooks/delegation-gate-task-1-5.test.ts
@@ -651,6 +651,114 @@ describe('Task 1.5: [NEXT] Guidance - Model-Only System Message', () => {
 			expect(systemText).not.toContain('Continue plan task 1.10');
 		});
 
+		it('should prefer an in-progress task for serial continuation guidance', async () => {
+			writePlanJson(tempDir, {
+				executionProfile: {
+					parallelization_enabled: false,
+					max_concurrent_tasks: 1,
+					locked: true,
+				},
+				tasks: [
+					{ id: '1.1', status: 'pending' },
+					{ id: '1.2', status: 'in_progress' },
+				],
+			});
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('Continue plan task 1.2');
+			expect(systemText).not.toContain('Continue plan task 1.1');
+		});
+
+		it('should fall back when serial continuation has no current plan task', async () => {
+			writePlanJson(tempDir, {
+				executionProfile: {
+					parallelization_enabled: false,
+					max_concurrent_tasks: 1,
+					locked: true,
+				},
+				tasks: [
+					{ id: '1.1', status: 'completed' },
+					{ id: '1.2', status: 'closed' },
+				],
+			});
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('Begin the first plan task');
+			expect(systemText).not.toContain('Continue plan task');
+		});
+
+		it('should compare single and triple segment task ids numerically', async () => {
+			writePlanJson(tempDir, {
+				executionProfile: {
+					parallelization_enabled: false,
+					max_concurrent_tasks: 1,
+					locked: true,
+				},
+				tasks: [
+					{ id: '1.2.10', status: 'pending' },
+					{ id: '1.2.3', status: 'pending' },
+					{ id: '2', status: 'pending' },
+				],
+			});
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('Continue plan task 1.2.3');
+			expect(systemText).not.toContain('Continue plan task 1.2.10');
+			expect(systemText).not.toContain('Continue plan task 2');
+		});
+
+		it('should sanitize plan task ids before injecting serial continuation guidance', async () => {
+			writePlanJson(tempDir, {
+				executionProfile: {
+					parallelization_enabled: false,
+					max_concurrent_tasks: 1,
+					locked: true,
+				},
+				tasks: [{ id: '1.2[override]\n[NEXT]', status: 'pending' }],
+			});
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('Continue plan task 1.2(override) (NEXT)');
+			expect(systemText).not.toContain('[override]');
+			expect(systemText).not.toContain('\n[NEXT]');
+		});
+
 		it('should count in-progress tasks as occupied and exclude blocked/dependent tasks', async () => {
 			writePlanJson(tempDir, {
 				executionProfile: {
@@ -680,6 +788,33 @@ describe('Task 1.5: [NEXT] Guidance - Model-Only System Message', () => {
 			expect(systemText).toContain('Eligible now: 1.3');
 			expect(systemText).not.toContain('Eligible now: 1.2');
 			expect(systemText).not.toContain('Eligible now: 1.4');
+		});
+
+		it('should suppress serial continuation guidance when parallel profile has no eligible tasks', async () => {
+			writePlanJson(tempDir, {
+				executionProfile: {
+					parallelization_enabled: true,
+					max_concurrent_tasks: 4,
+					locked: true,
+				},
+				tasks: [
+					{ id: '1.1', status: 'pending', depends: ['9.9'] },
+					{ id: '1.2', status: 'blocked' },
+				],
+			});
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('no dependency-ready pending tasks');
+			expect(systemText).not.toContain('Continue plan task');
 		});
 
 		it('should count active in-memory workflow states as occupied slots', async () => {

--- a/tests/unit/hooks/delegation-gate-task-1-5.test.ts
+++ b/tests/unit/hooks/delegation-gate-task-1-5.test.ts
@@ -586,11 +586,15 @@ describe('Task 1.5: [NEXT] Guidance - Model-Only System Message', () => {
 
 			expect(systemText).toContain('PARALLEL EXECUTION PROFILE');
 			expect(systemText).toContain('max_concurrent_tasks=4');
-			expect(systemText).toContain('dispatch up to 4');
+			expect(systemText).toContain('dispatch up to 4 eligible coder task(s)');
 			expect(systemText).toContain('Eligible now: 1.1, 1.2, 1.3, 1.4');
+			expect(systemText).toContain('update_task_status(in_progress)');
+			expect(systemText).toContain('declare_scope');
+			expect(systemText).toContain('coder Task');
+			expect(systemText).toContain('ONE atomic task per coder Task call');
 		});
 
-		it('should keep serial guidance when profile is disabled or serial', async () => {
+		it('should continue the durable plan task when profile is disabled or serial', async () => {
 			writePlanJson(tempDir, {
 				executionProfile: {
 					parallelization_enabled: false,
@@ -609,8 +613,42 @@ describe('Task 1.5: [NEXT] Guidance - Model-Only System Message', () => {
 				.map((m) => m.parts[0].text)
 				.join('\n');
 
-			expect(systemText).toContain('run gates sequentially');
+			expect(systemText).toContain('Continue plan task 1.1');
+			expect(systemText).toContain('declare_scope');
+			expect(systemText).toContain('coder Task call(s)');
+			expect(systemText).toContain(
+				'Preserve ONE atomic task per coder Task call',
+			);
+			expect(systemText).toContain('use available coder slots');
 			expect(systemText).not.toContain('PARALLEL EXECUTION PROFILE');
+			expect(systemText).not.toContain('dispatch up to');
+		});
+
+		it('should use the sorted current task cursor for serial continuation guidance', async () => {
+			writePlanJson(tempDir, {
+				executionProfile: {
+					parallelization_enabled: false,
+					max_concurrent_tasks: 1,
+					locked: true,
+				},
+				tasks: [
+					{ id: '1.10', status: 'pending' },
+					{ id: '1.2', status: 'pending' },
+				],
+			});
+
+			const hook = createDelegationGateHook(makeConfig(), tempDir);
+			const messages = makeMessages('TASK: Continue work', 'architect');
+
+			await hook.messagesTransform({}, messages);
+
+			const systemText = messages.messages
+				.filter((m) => m?.info?.role === 'system')
+				.map((m) => m.parts[0].text)
+				.join('\n');
+
+			expect(systemText).toContain('Continue plan task 1.2');
+			expect(systemText).not.toContain('Continue plan task 1.10');
 		});
 
 		it('should count in-progress tasks as occupied and exclude blocked/dependent tasks', async () => {

--- a/tests/unit/hooks/delegation-gate.test.ts
+++ b/tests/unit/hooks/delegation-gate.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { PluginConfig } from '../../../src/config';
 import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
 import {
@@ -48,6 +51,16 @@ function makeMessages(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type MessageWithParts = any;
 
+const tempDirs: string[] = [];
+
+function makeTempProject(prefix: string): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	const real = fs.realpathSync(dir);
+	fs.mkdirSync(path.join(real, '.swarm'), { recursive: true });
+	tempDirs.push(real);
+	return real;
+}
+
 // Helper to find user messages in the array (accounts for injected system messages)
 function findUserMessage(messages: { messages: MessageWithParts[] }) {
 	return messages.messages.find(
@@ -91,6 +104,9 @@ describe('delegation gate hook', () => {
 	afterEach(() => {
 		// Clean up after each test
 		resetSwarmState();
+		for (const dir of tempDirs.splice(0)) {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
 	});
 
 	it('no-op when disabled', async () => {
@@ -2525,7 +2541,8 @@ describe('delegation gate hook', () => {
 
 		it('null lastGateOutcome → [NEXT] guidance injected as model-only system message', async () => {
 			const config = makeConfig();
-			const hook = createDelegationGateHook(config, process.cwd());
+			const tempDir = makeTempProject('delegation-gate-next-');
+			const hook = createDelegationGateHook(config, tempDir);
 			const sessionID = 'deliberation-test-1';
 
 			// Setup session with no lastGateOutcome (null)


### PR DESCRIPTION
﻿Closes #985

## Summary
- Fixes resumed plan continuation guidance so the architect follows the durable current task cursor before delegating.
- Directs continuation through update_task_status, declare_scope, and coder Task dispatch.
- Preserves parallel execution profiles: dispatch up to available coder slots while keeping one atomic task per coder Task call.
- Addresses PR review feedback by isolating the fallback `[NEXT]` test from ambient `.swarm/plan.json` state and sanitizing plan-derived task IDs in model-only guidance.
- Adds a pending release fragment and regenerated dist artifacts.

## PR Review Fixes
| ID | Severity | Verdict | Fix |
|----|----------|---------|-----|
| F-001 | MEDIUM | VALID | Updated `delegation-gate.test.ts` to use an isolated temp project for the no-plan fallback assertion so ambient workspace `.swarm/plan.json` cannot change the expected guidance. |
| F-002 | LOW | VALID | Reused the guidance sanitizer for plan-derived `currentTaskId` before interpolating it into `[NEXT]` system text. |
| F-003 | LOW | ACKNOWLEDGED | Kept the local cursor helper intentionally decoupled from `plan/manager` to avoid the mock coupling that previously broke the hook tests; added targeted regression coverage to reduce drift risk. |

## Tests
- `bun install --frozen-lockfile`
- `bun --smol test tests/unit/hooks/delegation-gate-task-1-5.test.ts --timeout 30000`
- `bun --smol test tests/unit/hooks/delegation-gate.test.ts --timeout 30000`
- `bun --smol test tests/unit/hooks/system-enhancer-load-evidence.test.ts --timeout 30000`
- `bun --smol test tests/unit/agents/architect-v6-prompt.test.ts --timeout 30000`
- `bun --smol run typecheck`
- `bun --smol run build`
- `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- `git diff --check`
- `bun --smol run lint` (passes with existing `src/index.ts` noExplicitAny warnings)

## Invariant audit
- 1 (plugin init):       not touched - no plugin initialization path changed; validation included `bun --smol run build`.
- 2 (runtime portability): touched - regenerated `dist/index.js` after source changes; `bun --smol run build` and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` passed.
- 3 (subprocesses):       not touched - no subprocess or spawn code changed.
- 4 (.swarm containment): not touched - new tests create `.swarm/` only under `os.tmpdir()` temp projects and clean them in `afterEach`; runtime code adds no new `.swarm` write path.
- 5 (plan durability):    not touched - no ledger, projection, checkpoint, or plan schema code changed; the patch uses a local pure current-task cursor only for model guidance.
- 6 (test_runner safety): not touched - validation used shell commands, not broad `test_runner` scope.
- 7 (test writing):       touched - updated bun:test files using temp dirs and no new `mock.module`; focused hook and prompt suites passed.
- 8 (session state):      not touched - no new session/global state or eviction behavior; existing delegation-gate session tests passed in `tests/unit/hooks/delegation-gate.test.ts`.
- 9 (guardrails/retry):   not touched - no guardrail, transient retry, fallback, or circuit-breaker code changed.
- 10 (chat/system msg):   touched - changed model-only `[NEXT]` guidance and architect resume prompt; covered by `tests/unit/hooks/delegation-gate-task-1-5.test.ts`, `tests/unit/hooks/delegation-gate.test.ts`, and `tests/unit/agents/architect-v6-prompt.test.ts`.
- 11 (tool registration): not touched - no tool exports, `TOOL_NAMES`, `AGENT_TOOL_MAP`, help, or registration code changed.
- 12 (release/cache):     touched - added `docs/releases/pending/issue-985-delegation-continuation.md`; no cache/update/install code changed.
