### PR TITLE
fix(council): serialize council evidence write under shared evidence lock with atomic write

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -11339,7 +11339,7 @@ function finalize(ctx, schema) {
     result.$schema = "http://json-schema.org/draft-07/schema#";
   } else if (ctx.target === "draft-04") {
     result.$schema = "http://json-schema.org/draft-04/schema#";
-  } else if (ctx.target === "openapi-3.0") {}
+  } else if (ctx.target === "openapi-3.0") {} else {}
   if (ctx.external?.uri) {
     const id = ctx.external.registry.get(schema)?.id;
     if (!id)
@@ -11604,7 +11604,7 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
     if (val === undefined) {
       if (ctx.unrepresentable === "throw") {
         throw new Error("Literal `undefined` cannot be represented in JSON Schema");
-      }
+      } else {}
     } else if (typeof val === "bigint") {
       if (ctx.unrepresentable === "throw") {
         throw new Error("BigInt literals cannot be represented in JSON Schema");
@@ -32212,7 +32212,7 @@ class JSONSchemaGenerator2 {
               if (val === undefined) {
                 if (this.unrepresentable === "throw") {
                   throw new Error("Literal `undefined` cannot be represented in JSON Schema");
-                }
+                } else {}
               } else if (typeof val === "bigint") {
                 if (this.unrepresentable === "throw") {
                   throw new Error("BigInt literals cannot be represented in JSON Schema");

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.31.0",
+    version: "7.32.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -11339,7 +11339,7 @@ function finalize(ctx, schema) {
     result.$schema = "http://json-schema.org/draft-07/schema#";
   } else if (ctx.target === "draft-04") {
     result.$schema = "http://json-schema.org/draft-04/schema#";
-  } else if (ctx.target === "openapi-3.0") {} else {}
+  } else if (ctx.target === "openapi-3.0") {}
   if (ctx.external?.uri) {
     const id = ctx.external.registry.get(schema)?.id;
     if (!id)
@@ -11604,7 +11604,7 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
     if (val === undefined) {
       if (ctx.unrepresentable === "throw") {
         throw new Error("Literal `undefined` cannot be represented in JSON Schema");
-      } else {}
+      }
     } else if (typeof val === "bigint") {
       if (ctx.unrepresentable === "throw") {
         throw new Error("BigInt literals cannot be represented in JSON Schema");
@@ -32212,7 +32212,7 @@ class JSONSchemaGenerator2 {
               if (val === undefined) {
                 if (this.unrepresentable === "throw") {
                   throw new Error("Literal `undefined` cannot be represented in JSON Schema");
-                } else {}
+                }
               } else if (typeof val === "bigint") {
                 if (this.unrepresentable === "throw") {
                   throw new Error("BigInt literals cannot be represented in JSON Schema");

--- a/dist/config/schema.d.ts
+++ b/dist/config/schema.d.ts
@@ -287,8 +287,8 @@ export type ReviewPassesConfig = z.infer<typeof ReviewPassesConfigSchema>;
 export declare const AdversarialDetectionConfigSchema: z.ZodObject<{
     enabled: z.ZodDefault<z.ZodBoolean>;
     policy: z.ZodDefault<z.ZodEnum<{
-        gate: "gate";
         ignore: "ignore";
+        gate: "gate";
         warn: "warn";
     }>>;
     pairs: z.ZodDefault<z.ZodArray<z.ZodTuple<[z.ZodString, z.ZodString], null>>>;
@@ -1053,8 +1053,8 @@ export declare const PluginConfigSchema: z.ZodObject<{
     adversarial_detection: z.ZodOptional<z.ZodObject<{
         enabled: z.ZodDefault<z.ZodBoolean>;
         policy: z.ZodDefault<z.ZodEnum<{
-            gate: "gate";
             ignore: "ignore";
+            gate: "gate";
             warn: "warn";
         }>>;
         pairs: z.ZodDefault<z.ZodArray<z.ZodTuple<[z.ZodString, z.ZodString], null>>>;

--- a/dist/council/council-evidence-writer.d.ts
+++ b/dist/council/council-evidence-writer.d.ts
@@ -15,4 +15,4 @@
  * any filesystem op.
  */
 import type { CouncilSynthesis } from './types';
-export declare function writeCouncilEvidence(workingDir: string, synthesis: CouncilSynthesis): void;
+export declare function writeCouncilEvidence(workingDir: string, synthesis: CouncilSynthesis): Promise<void>;

--- a/dist/council/council-evidence-writer.d.ts
+++ b/dist/council/council-evidence-writer.d.ts
@@ -14,5 +14,14 @@
  * filename; defense-in-depth regex validation rejects malformed IDs before
  * any filesystem op.
  */
+import { withTaskEvidenceLock } from '../evidence/task-file.js';
 import type { CouncilSynthesis } from './types';
+/**
+ * Dependency-injection seam for testing. Tests can temporarily replace
+ * `withTaskEvidenceLock` to exercise error paths (e.g. EvidenceLockTimeoutError)
+ * without mock.module leakage. Restore the entry in afterEach.
+ */
+export declare const _internals: {
+    withTaskEvidenceLock: typeof withTaskEvidenceLock;
+};
 export declare function writeCouncilEvidence(workingDir: string, synthesis: CouncilSynthesis): Promise<void>;

--- a/dist/evidence/task-file.d.ts
+++ b/dist/evidence/task-file.d.ts
@@ -17,6 +17,7 @@
  * This module deliberately holds no schema/validation logic — each caller keeps
  * its own taskId validation and read/merge semantics.
  */
+import { renameSync, unlinkSync } from 'node:fs';
 /**
  * Relative path (under `.swarm/`) of the flat task evidence file.
  * This is also the lock key — it MUST be identical across all writers to the
@@ -25,6 +26,15 @@
 export declare function taskEvidenceRelPath(taskId: string): string;
 /** Absolute path of the flat task evidence file under `<directory>/.swarm/`. */
 export declare function taskEvidencePath(directory: string, taskId: string): string;
+/**
+ * Dependency-injection seam for testing. Tests can temporarily replace these
+ * to exercise failure paths (e.g. EPERM on renameSync) without mock.module leakage.
+ * Restore each entry in afterEach via the saved original reference.
+ */
+export declare const _internals: {
+    renameSync: typeof renameSync;
+    unlinkSync: typeof unlinkSync;
+};
 /**
  * Atomic write: write to a unique temp file, then rename over the target.
  * The rename is atomic on POSIX and Windows, so readers never observe a torn

--- a/dist/evidence/task-file.d.ts
+++ b/dist/evidence/task-file.d.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared write primitives for the flat task-scoped evidence file
+ * `.swarm/evidence/{taskId}.json`.
+ *
+ * This file is the single source of truth for *where* the flat task evidence
+ * file lives and *how* it is written safely. Multiple writers target the same
+ * `{taskId}.json` (the delegation-gate hook via `gate-evidence.ts`, and the
+ * Work-Complete council via `council-evidence-writer.ts`). They MUST coordinate
+ * through the same lock key and use the same atomic temp-file+rename write, or
+ * one writer's read-modify-write can clobber the other's (lost update) or
+ * observe a torn file.
+ *
+ * The lock is keyed by the *relative* evidence path, so every writer has to
+ * pass the identical relative path to `withEvidenceLock`. Centralizing that
+ * derivation here (`taskEvidenceRelPath`) guarantees the keys match.
+ *
+ * This module deliberately holds no schema/validation logic — each caller keeps
+ * its own taskId validation and read/merge semantics.
+ */
+/**
+ * Relative path (under `.swarm/`) of the flat task evidence file.
+ * This is also the lock key — it MUST be identical across all writers to the
+ * same task file so their locks coordinate.
+ */
+export declare function taskEvidenceRelPath(taskId: string): string;
+/** Absolute path of the flat task evidence file under `<directory>/.swarm/`. */
+export declare function taskEvidencePath(directory: string, taskId: string): string;
+/**
+ * Atomic write: write to a unique temp file, then rename over the target.
+ * The rename is atomic on POSIX and Windows, so readers never observe a torn
+ * file. The temp file is cleaned up in `finally` (no-op once renamed away).
+ */
+export declare function atomicWriteFile(targetPath: string, content: string): Promise<void>;
+/**
+ * Acquire the exclusive lock for a task's flat evidence file, run `fn`, release.
+ * Thin wrapper over `withEvidenceLock` that fixes the lock-key convention so all
+ * writers to `{taskId}.json` serialize against each other.
+ */
+export declare function withTaskEvidenceLock<T>(directory: string, taskId: string, agent: string, fn: () => Promise<T>): Promise<T>;

--- a/dist/memory/schema.d.ts
+++ b/dist/memory/schema.d.ts
@@ -41,8 +41,8 @@ export declare const MemoryKindSchema: z.ZodEnum<{
 }>;
 export declare const MemorySourceSchema: z.ZodObject<{
     type: z.ZodEnum<{
-        agent: "agent";
         file: "file";
+        agent: "agent";
         manual: "manual";
         test: "test";
         tool: "tool";
@@ -100,8 +100,8 @@ export declare const MemoryRecordSchema: z.ZodObject<{
     }>;
     source: z.ZodObject<{
         type: z.ZodEnum<{
-            agent: "agent";
             file: "file";
+            agent: "agent";
             manual: "manual";
             test: "test";
             tool: "tool";
@@ -178,8 +178,8 @@ export declare const MemoryProposalSchema: z.ZodObject<{
         }>;
         source: z.ZodObject<{
             type: z.ZodEnum<{
-                agent: "agent";
                 file: "file";
+                agent: "agent";
                 manual: "manual";
                 test: "test";
                 tool: "tool";

--- a/docs/releases/pending/978-council-evidence-lock.md
+++ b/docs/releases/pending/978-council-evidence-lock.md
@@ -1,0 +1,25 @@
+# Council Evidence Write Lock + Atomic Write
+
+## Overview
+
+Fixes a lost-update / torn-write race on `.swarm/evidence/{taskId}.json`. The Work-Complete council evidence writer performed an **unlocked, non-atomic** read-modify-write on the same task evidence file that the delegation-gate hook guards with an exclusive lock and an atomic temp+rename write. When a council write and a gate-evidence write for the same task interleaved, the council write could clobber a freshly-recorded gate entry (e.g. drop the `test_engineer` gate, producing a false "gate not passed" completion block) or leave a torn file.
+
+This is distinct from #970: that issue fixed task-ID *resolution* on the hook path. `submit_council_verdicts` already receives an explicit, validated `taskId`, so it was never affected by misattribution — the defect here is concurrency/atomicity, not task-ID resolution.
+
+## What changed
+
+- Added `src/evidence/task-file.ts` as the single source of truth for safe writes to the flat `.swarm/evidence/{taskId}.json`: `taskEvidenceRelPath` (the shared lock key), `taskEvidencePath`, `atomicWriteFile` (temp+rename), and `withTaskEvidenceLock`.
+- `writeCouncilEvidence` (`src/council/council-evidence-writer.ts`) is now async and performs its read-modify-write inside `withTaskEvidenceLock`, writing via `atomicWriteFile`. It now serializes against the delegation-gate hook on the same task file.
+- `src/gate-evidence.ts` was refactored onto the shared helpers (behavior-preserving — identical lock key, identical atomic write, identical output).
+- `submit_council_verdicts` (`src/tools/convene-council.ts`) now awaits the evidence write; a lock-timeout surfaces as a structured tool failure via the existing `createSwarmTool` error wrapper.
+
+## How to use
+
+No changes needed. Council and gate evidence writes to the same task file are now mutually exclusive and atomic.
+
+## Migration
+
+No migration required. No change to the evidence file path or JSON shape.
+
+Closes: #978
+Related: #970, PR #971

--- a/src/council/council-evidence-writer.ts
+++ b/src/council/council-evidence-writer.ts
@@ -15,14 +15,13 @@
  * any filesystem op.
  */
 
-import {
-	appendFileSync,
-	existsSync,
-	mkdirSync,
-	readFileSync,
-	writeFileSync,
-} from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import {
+	atomicWriteFile,
+	taskEvidencePath,
+	withTaskEvidenceLock,
+} from '../evidence/task-file.js';
 import type { CouncilSynthesis } from './types';
 
 const EVIDENCE_DIR = '.swarm/evidence';
@@ -70,10 +69,10 @@ function safeAssignOwnProps(
 	return target;
 }
 
-export function writeCouncilEvidence(
+export async function writeCouncilEvidence(
 	workingDir: string,
 	synthesis: CouncilSynthesis,
-): void {
+): Promise<void> {
 	// Defense in depth — library-level writer should not trust upstream validation.
 	if (!VALID_TASK_ID.test(synthesis.taskId)) {
 		throw new Error(
@@ -84,64 +83,76 @@ export function writeCouncilEvidence(
 	const dir = join(workingDir, EVIDENCE_DIR);
 	mkdirSync(dir, { recursive: true });
 
-	const filePath = join(dir, `${synthesis.taskId}.json`);
+	const filePath = taskEvidencePath(workingDir, synthesis.taskId);
 
-	// Read existing evidence (if any) and start from a clean prototype-free object.
-	const existingRoot: Record<string, unknown> = Object.create(null);
-	if (existsSync(filePath)) {
-		try {
-			const parsed = JSON.parse(readFileSync(filePath, 'utf-8'));
-			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-				safeAssignOwnProps(existingRoot, parsed as Record<string, unknown>);
+	// Acquire the shared evidence lock and write atomically so this
+	// read-modify-write cannot interleave with the delegation-gate hook's
+	// read-modify-write on the same {taskId}.json — otherwise the unlocked,
+	// non-atomic write could clobber concurrently-recorded gate evidence
+	// (lost update) or leave a torn file (#978).
+	await withTaskEvidenceLock(
+		workingDir,
+		synthesis.taskId,
+		COUNCIL_AGENT_ID,
+		async () => {
+			// Read existing evidence (if any) and start from a clean prototype-free object.
+			const existingRoot: Record<string, unknown> = Object.create(null);
+			if (existsSync(filePath)) {
+				try {
+					const parsed = JSON.parse(readFileSync(filePath, 'utf-8'));
+					if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+						safeAssignOwnProps(existingRoot, parsed as Record<string, unknown>);
+					}
+					// Arrays, nulls, or corrupt JSON all fall through to a fresh start.
+				} catch {
+					// Corrupted evidence file — start fresh rather than crashing.
+				}
 			}
-			// Arrays, nulls, or corrupt JSON all fall through to a fresh start.
-		} catch {
-			// Corrupted evidence file — start fresh rather than crashing.
-		}
-	}
 
-	// Preserve any prior gates entries alongside the council entry.
-	const existingGatesRaw = existingRoot.gates;
-	const mergedGates: Record<string, unknown> = Object.create(null);
-	if (
-		existingGatesRaw &&
-		typeof existingGatesRaw === 'object' &&
-		!Array.isArray(existingGatesRaw)
-	) {
-		safeAssignOwnProps(
-			mergedGates,
-			existingGatesRaw as Record<string, unknown>,
-		);
-	}
+			// Preserve any prior gates entries alongside the council entry.
+			const existingGatesRaw = existingRoot.gates;
+			const mergedGates: Record<string, unknown> = Object.create(null);
+			if (
+				existingGatesRaw &&
+				typeof existingGatesRaw === 'object' &&
+				!Array.isArray(existingGatesRaw)
+			) {
+				safeAssignOwnProps(
+					mergedGates,
+					existingGatesRaw as Record<string, unknown>,
+				);
+			}
 
-	mergedGates[COUNCIL_GATE_NAME] = {
-		// Standard GateInfo fields so check_gate_status / update_task_status see it.
-		sessionId: synthesis.swarmId,
-		timestamp: synthesis.timestamp,
-		agent: COUNCIL_AGENT_ID,
-		// Council-specific extras — safe to carry; existing readers only check presence.
-		verdict: synthesis.overallVerdict,
-		vetoedBy: synthesis.vetoedBy,
-		roundNumber: synthesis.roundNumber,
-		allCriteriaMet: synthesis.allCriteriaMet,
-		// Quorum metadata — read by applyRehydrationCache and the council
-		// fast-path to validate the APPROVE was recorded with sufficient
-		// distinct members. Old evidence files (pre-quorum) lack this field
-		// and are conservatively rehydrated as quorumSize: 1.
-		quorumSize: synthesis.quorumSize,
-	};
+			mergedGates[COUNCIL_GATE_NAME] = {
+				// Standard GateInfo fields so check_gate_status / update_task_status see it.
+				sessionId: synthesis.swarmId,
+				timestamp: synthesis.timestamp,
+				agent: COUNCIL_AGENT_ID,
+				// Council-specific extras — safe to carry; existing readers only check presence.
+				verdict: synthesis.overallVerdict,
+				vetoedBy: synthesis.vetoedBy,
+				roundNumber: synthesis.roundNumber,
+				allCriteriaMet: synthesis.allCriteriaMet,
+				// Quorum metadata — read by applyRehydrationCache and the council
+				// fast-path to validate the APPROVE was recorded with sufficient
+				// distinct members. Old evidence files (pre-quorum) lack this field
+				// and are conservatively rehydrated as quorumSize: 1.
+				quorumSize: synthesis.quorumSize,
+			};
 
-	const updated: Record<string, unknown> = Object.create(null);
-	safeAssignOwnProps(updated, existingRoot);
-	updated.gates = mergedGates;
-	// Ensure TaskEvidence schema-required fields are always present.
-	// readTaskEvidenceRaw validates against TaskEvidenceSchema (requires taskId +
-	// required_gates); council-only writes omit them when no prior gate evidence
-	// exists, causing ZodError → false "gate not run" block in checkCouncilGate.
-	if (!updated.taskId) updated.taskId = synthesis.taskId;
-	if (!Array.isArray(updated.required_gates)) updated.required_gates = [];
+			const updated: Record<string, unknown> = Object.create(null);
+			safeAssignOwnProps(updated, existingRoot);
+			updated.gates = mergedGates;
+			// Ensure TaskEvidence schema-required fields are always present.
+			// readTaskEvidenceRaw validates against TaskEvidenceSchema (requires taskId +
+			// required_gates); council-only writes omit them when no prior gate evidence
+			// exists, causing ZodError → false "gate not run" block in checkCouncilGate.
+			if (!updated.taskId) updated.taskId = synthesis.taskId;
+			if (!Array.isArray(updated.required_gates)) updated.required_gates = [];
 
-	writeFileSync(filePath, JSON.stringify(updated, null, 2));
+			await atomicWriteFile(filePath, JSON.stringify(updated, null, 2));
+		},
+	);
 
 	// ── Round-history audit log (non-blocking) ────────────────────────────
 	// Append-only log of every council round for multi-round tasks.

--- a/src/council/council-evidence-writer.ts
+++ b/src/council/council-evidence-writer.ts
@@ -34,6 +34,15 @@ const COUNCIL_GATE_NAME = 'council';
 const COUNCIL_AGENT_ID = 'architect';
 
 /**
+ * Dependency-injection seam for testing. Tests can temporarily replace
+ * `withTaskEvidenceLock` to exercise error paths (e.g. EvidenceLockTimeoutError)
+ * without mock.module leakage. Restore the entry in afterEach.
+ */
+export const _internals = {
+	withTaskEvidenceLock,
+};
+
+/**
  * Merge existing own properties into the target, skipping keys that would
  * pollute the prototype chain even though object spread does not linkify them.
  * We still filter these defensively so malicious evidence files cannot add
@@ -90,7 +99,7 @@ export async function writeCouncilEvidence(
 	// read-modify-write on the same {taskId}.json — otherwise the unlocked,
 	// non-atomic write could clobber concurrently-recorded gate evidence
 	// (lost update) or leave a torn file (#978).
-	await withTaskEvidenceLock(
+	await _internals.withTaskEvidenceLock(
 		workingDir,
 		synthesis.taskId,
 		COUNCIL_AGENT_ID,

--- a/src/evidence/task-file.ts
+++ b/src/evidence/task-file.ts
@@ -38,6 +38,16 @@ export function taskEvidencePath(directory: string, taskId: string): string {
 }
 
 /**
+ * Dependency-injection seam for testing. Tests can temporarily replace these
+ * to exercise failure paths (e.g. EPERM on renameSync) without mock.module leakage.
+ * Restore each entry in afterEach via the saved original reference.
+ */
+export const _internals = {
+	renameSync,
+	unlinkSync,
+};
+
+/**
  * Atomic write: write to a unique temp file, then rename over the target.
  * The rename is atomic on POSIX and Windows, so readers never observe a torn
  * file. The temp file is cleaned up in `finally` (no-op once renamed away).
@@ -49,10 +59,10 @@ export async function atomicWriteFile(
 	const tempPath = `${targetPath}.tmp.${Date.now()}.${Math.floor(Math.random() * 1e9)}`;
 	try {
 		await bunWrite(tempPath, content);
-		renameSync(tempPath, targetPath);
+		_internals.renameSync(tempPath, targetPath);
 	} finally {
 		try {
-			unlinkSync(tempPath);
+			_internals.unlinkSync(tempPath);
 		} catch {
 			/* already renamed or never created */
 		}

--- a/src/evidence/task-file.ts
+++ b/src/evidence/task-file.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared write primitives for the flat task-scoped evidence file
+ * `.swarm/evidence/{taskId}.json`.
+ *
+ * This file is the single source of truth for *where* the flat task evidence
+ * file lives and *how* it is written safely. Multiple writers target the same
+ * `{taskId}.json` (the delegation-gate hook via `gate-evidence.ts`, and the
+ * Work-Complete council via `council-evidence-writer.ts`). They MUST coordinate
+ * through the same lock key and use the same atomic temp-file+rename write, or
+ * one writer's read-modify-write can clobber the other's (lost update) or
+ * observe a torn file.
+ *
+ * The lock is keyed by the *relative* evidence path, so every writer has to
+ * pass the identical relative path to `withEvidenceLock`. Centralizing that
+ * derivation here (`taskEvidenceRelPath`) guarantees the keys match.
+ *
+ * This module deliberately holds no schema/validation logic — each caller keeps
+ * its own taskId validation and read/merge semantics.
+ */
+
+import { renameSync, unlinkSync } from 'node:fs';
+import * as path from 'node:path';
+import { bunWrite } from '../utils/bun-compat';
+import { withEvidenceLock } from './lock.js';
+
+/**
+ * Relative path (under `.swarm/`) of the flat task evidence file.
+ * This is also the lock key — it MUST be identical across all writers to the
+ * same task file so their locks coordinate.
+ */
+export function taskEvidenceRelPath(taskId: string): string {
+	return path.join('evidence', `${taskId}.json`);
+}
+
+/** Absolute path of the flat task evidence file under `<directory>/.swarm/`. */
+export function taskEvidencePath(directory: string, taskId: string): string {
+	return path.join(directory, '.swarm', taskEvidenceRelPath(taskId));
+}
+
+/**
+ * Atomic write: write to a unique temp file, then rename over the target.
+ * The rename is atomic on POSIX and Windows, so readers never observe a torn
+ * file. The temp file is cleaned up in `finally` (no-op once renamed away).
+ */
+export async function atomicWriteFile(
+	targetPath: string,
+	content: string,
+): Promise<void> {
+	const tempPath = `${targetPath}.tmp.${Date.now()}.${Math.floor(Math.random() * 1e9)}`;
+	try {
+		await bunWrite(tempPath, content);
+		renameSync(tempPath, targetPath);
+	} finally {
+		try {
+			unlinkSync(tempPath);
+		} catch {
+			/* already renamed or never created */
+		}
+	}
+}
+
+/**
+ * Acquire the exclusive lock for a task's flat evidence file, run `fn`, release.
+ * Thin wrapper over `withEvidenceLock` that fixes the lock-key convention so all
+ * writers to `{taskId}.json` serialize against each other.
+ */
+export function withTaskEvidenceLock<T>(
+	directory: string,
+	taskId: string,
+	agent: string,
+	fn: () => Promise<T>,
+): Promise<T> {
+	return withEvidenceLock(
+		directory,
+		taskEvidenceRelPath(taskId),
+		agent,
+		taskId,
+		fn,
+	);
+}

--- a/src/gate-evidence.ts
+++ b/src/gate-evidence.ts
@@ -11,12 +11,15 @@
  * Gates are append-only: required_gates can only grow, never shrink.
  */
 
-import { mkdirSync, readFileSync, renameSync, unlinkSync } from 'node:fs';
+import { mkdirSync, readFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { z } from 'zod';
-import { withEvidenceLock } from './evidence/lock.js';
+import {
+	atomicWriteFile,
+	taskEvidencePath,
+	withTaskEvidenceLock,
+} from './evidence/task-file.js';
 import { telemetry } from './telemetry.js';
-import { bunWrite } from './utils/bun-compat';
 import { assertStrictTaskId, isStrictTaskId } from './validation/task-id';
 
 export interface GateEvidence {
@@ -108,7 +111,7 @@ function getEvidenceDir(directory: string): string {
 
 function getEvidencePath(directory: string, taskId: string): string {
 	assertValidTaskId(taskId);
-	return path.join(getEvidenceDir(directory), `${taskId}.json`);
+	return taskEvidencePath(directory, taskId);
 }
 
 function readExisting(
@@ -122,20 +125,6 @@ function readExisting(
 		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
 		telemetry.gateParseError(taskId, error as Error);
 		throw error;
-	}
-}
-
-async function atomicWrite(targetPath: string, content: string): Promise<void> {
-	const tempPath = `${targetPath}.tmp.${Date.now()}.${Math.floor(Math.random() * 1e9)}`;
-	try {
-		await bunWrite(tempPath, content);
-		renameSync(tempPath, targetPath);
-	} finally {
-		try {
-			unlinkSync(tempPath);
-		} catch {
-			/* already renamed or never created */
-		}
 	}
 }
 
@@ -156,8 +145,7 @@ export async function recordGateEvidence(
 	const evidenceDir = getEvidenceDir(directory);
 	mkdirSync(evidenceDir, { recursive: true });
 
-	const lockRelPath = path.join('evidence', `${taskId}.json`);
-	await withEvidenceLock(directory, lockRelPath, gate, taskId, async () => {
+	await withTaskEvidenceLock(directory, taskId, gate, async () => {
 		const evidencePath = getEvidencePath(directory, taskId);
 		let existing: TaskEvidence | null = null;
 		try {
@@ -184,7 +172,7 @@ export async function recordGateEvidence(
 			},
 		};
 
-		await atomicWrite(evidencePath, JSON.stringify(updated, null, 2));
+		await atomicWriteFile(evidencePath, JSON.stringify(updated, null, 2));
 	});
 	telemetry.gatePassed(sessionId, gate, taskId);
 }
@@ -204,35 +192,28 @@ export async function recordAgentDispatch(
 	const evidenceDir = getEvidenceDir(directory);
 	mkdirSync(evidenceDir, { recursive: true });
 
-	const lockRelPath = path.join('evidence', `${taskId}.json`);
-	await withEvidenceLock(
-		directory,
-		lockRelPath,
-		agentType,
-		taskId,
-		async () => {
-			const evidencePath = getEvidencePath(directory, taskId);
-			let existing: TaskEvidence | null = null;
-			try {
-				existing = readExisting(evidencePath, taskId);
-			} catch (error) {
-				telemetry.gateParseError(taskId, error as Error);
-				throw error;
-			}
-			const requiredGates = existing
-				? expandRequiredGates(existing.required_gates, agentType)
-				: deriveRequiredGates(agentType);
+	await withTaskEvidenceLock(directory, taskId, agentType, async () => {
+		const evidencePath = getEvidencePath(directory, taskId);
+		let existing: TaskEvidence | null = null;
+		try {
+			existing = readExisting(evidencePath, taskId);
+		} catch (error) {
+			telemetry.gateParseError(taskId, error as Error);
+			throw error;
+		}
+		const requiredGates = existing
+			? expandRequiredGates(existing.required_gates, agentType)
+			: deriveRequiredGates(agentType);
 
-			const updated: TaskEvidence = {
-				taskId,
-				required_gates: requiredGates,
-				turbo: turbo === true ? true : existing?.turbo,
-				gates: existing?.gates ?? {},
-			};
+		const updated: TaskEvidence = {
+			taskId,
+			required_gates: requiredGates,
+			turbo: turbo === true ? true : existing?.turbo,
+			gates: existing?.gates ?? {},
+		};
 
-			await atomicWrite(evidencePath, JSON.stringify(updated, null, 2));
-		},
-	);
+		await atomicWriteFile(evidencePath, JSON.stringify(updated, null, 2));
+	});
 }
 
 /**

--- a/src/tools/convene-council.ts
+++ b/src/tools/convene-council.ts
@@ -230,7 +230,10 @@ export const submit_council_verdicts: ReturnType<typeof tool> = createSwarmTool(
 			);
 
 			// ── Evidence write ────────────────────────────────────────────────
-			writeCouncilEvidence(workingDir, synthesis);
+			// Awaited: writeCouncilEvidence now acquires the shared evidence lock
+			// and writes atomically (#978). A lock-timeout throw is caught by the
+			// createSwarmTool wrapper and surfaced as a structured failure.
+			await writeCouncilEvidence(workingDir, synthesis);
 
 			// ── Architect self-echo advisory ──────────────────────────────────
 			// When the tool is invoked inside an architect session, push the

--- a/tests/unit/council/adversarial.test.ts
+++ b/tests/unit/council/adversarial.test.ts
@@ -203,7 +203,7 @@ describe('adversarial — evidence writer defense in depth', () => {
 			roundNumber: 1,
 			allCriteriaMet: true,
 		};
-		expect(() => writeCouncilEvidence('/tmp', badSynthesis)).toThrow(
+		await expect(writeCouncilEvidence('/tmp', badSynthesis)).rejects.toThrow(
 			/invalid taskId/,
 		);
 	});
@@ -226,7 +226,7 @@ describe('adversarial — evidence writer defense in depth', () => {
 			roundNumber: 1,
 			allCriteriaMet: true,
 		};
-		expect(() => writeCouncilEvidence('/tmp', badSynthesis)).toThrow(
+		await expect(writeCouncilEvidence('/tmp', badSynthesis)).rejects.toThrow(
 			/invalid taskId/,
 		);
 	});

--- a/tests/unit/council/council-evidence-concurrency.test.ts
+++ b/tests/unit/council/council-evidence-concurrency.test.ts
@@ -14,8 +14,12 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { writeCouncilEvidence } from '../../../src/council/council-evidence-writer';
+import {
+	_internals,
+	writeCouncilEvidence,
+} from '../../../src/council/council-evidence-writer';
 import type { CouncilSynthesis } from '../../../src/council/types';
+import { EvidenceLockTimeoutError } from '../../../src/evidence/lock';
 import {
 	taskEvidencePath,
 	withTaskEvidenceLock,
@@ -112,5 +116,70 @@ describe('council evidence writer — regression: serializes via shared evidence
 		);
 		expect(evidence.gates.council).toBeDefined();
 		expect(evidence.gates.reviewer).toBeDefined();
+	});
+
+	test('concurrent gate write and council write both land (Promise.all interleave)', async () => {
+		// F-010: both writers start simultaneously via Promise.all. With the shared
+		// lock they must serialize — neither read-modify-write can clobber the other.
+		// All entries must survive in the final file regardless of which writer wins
+		// the lock race.
+		await Promise.all([
+			recordGateEvidence(tempDir, '1.1', 'reviewer', 'sess-concurrent'),
+			writeCouncilEvidence(tempDir, makeSynthesis()),
+		]);
+
+		const evidence = JSON.parse(
+			readFileSync(taskEvidencePath(tempDir, '1.1'), 'utf-8'),
+		);
+		expect(evidence.gates.reviewer).toBeDefined();
+		expect(evidence.gates.council).toBeDefined();
+		expect(evidence.gates.council.verdict).toBe('APPROVE');
+	});
+});
+
+describe('council evidence writer — EvidenceLockTimeoutError propagation (#978 F-002)', () => {
+	// Save the real withTaskEvidenceLock so we can restore it after each test.
+	const realWithTaskEvidenceLock = _internals.withTaskEvidenceLock;
+
+	afterEach(() => {
+		_internals.withTaskEvidenceLock = realWithTaskEvidenceLock;
+	});
+
+	test('EvidenceLockTimeoutError from the lock propagates out of writeCouncilEvidence', async () => {
+		// Arrange: inject a lock that immediately throws EvidenceLockTimeoutError,
+		// simulating a deadlocked writer that holds the lock past the timeout.
+		const timeout = new EvidenceLockTimeoutError(
+			tempDir,
+			'evidence/1.1.json',
+			'architect',
+			'1.1',
+			60000,
+		);
+		_internals.withTaskEvidenceLock = () => Promise.reject(timeout);
+
+		// Act + Assert: the async signature means the error surfaces as a rejection.
+		await expect(
+			writeCouncilEvidence(tempDir, makeSynthesis()),
+		).rejects.toBeInstanceOf(EvidenceLockTimeoutError);
+
+		await expect(
+			writeCouncilEvidence(tempDir, makeSynthesis()),
+		).rejects.toThrow('Evidence lock timeout after 60000ms');
+	});
+
+	test('EvidenceLockTimeoutError carries the correct metadata fields', () => {
+		const err = new EvidenceLockTimeoutError(
+			'/swarm',
+			'evidence/2.3.json',
+			'architect',
+			'2.3',
+			30000,
+		);
+		expect(err.name).toBe('EvidenceLockTimeoutError');
+		expect(err.directory).toBe('/swarm');
+		expect(err.evidencePath).toBe('evidence/2.3.json');
+		expect(err.agent).toBe('architect');
+		expect(err.taskId).toBe('2.3');
+		expect(err.message).toContain('30000ms');
 	});
 });

--- a/tests/unit/council/council-evidence-concurrency.test.ts
+++ b/tests/unit/council/council-evidence-concurrency.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression: writeCouncilEvidence must serialize with the delegation-gate
+ * hook's gate-evidence writes on the same .swarm/evidence/{taskId}.json (#978).
+ *
+ * Before the fix, writeCouncilEvidence did an unlocked, non-atomic
+ * read-modify-write while gate-evidence.ts guarded the same file with
+ * withEvidenceLock + atomic temp+rename. Concurrent writers could lose updates
+ * (a council write clobbering a freshly-recorded gate entry) or read a torn
+ * file. The fix routes the council write through the same shared lock + atomic
+ * write.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeCouncilEvidence } from '../../../src/council/council-evidence-writer';
+import type { CouncilSynthesis } from '../../../src/council/types';
+import {
+	taskEvidencePath,
+	withTaskEvidenceLock,
+} from '../../../src/evidence/task-file';
+import { recordGateEvidence } from '../../../src/gate-evidence';
+
+let tempDir: string;
+
+const makeSynthesis = (
+	overrides: Partial<CouncilSynthesis> = {},
+): CouncilSynthesis => ({
+	taskId: '1.1',
+	swarmId: 'swarm-1',
+	timestamp: '2026-04-13T00:00:00.000Z',
+	overallVerdict: 'APPROVE',
+	vetoedBy: null,
+	memberVerdicts: [],
+	unresolvedConflicts: [],
+	requiredFixes: [],
+	advisoryFindings: [],
+	unifiedFeedbackMd: '',
+	roundNumber: 1,
+	allCriteriaMet: true,
+	quorumSize: 3,
+	...overrides,
+});
+
+beforeEach(() => {
+	tempDir = mkdtempSync(join(tmpdir(), 'council-concurrency-'));
+});
+
+afterEach(() => {
+	rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('council evidence writer — regression: serializes via shared evidence lock (#978)', () => {
+	test('council write blocks until the shared lock is released', async () => {
+		// Previously the council write ignored the lock and ran immediately,
+		// so it could land between another writer's read and write. With the fix
+		// it must wait for the held lock before writing.
+		const order: string[] = [];
+		let councilPromise: Promise<void> | undefined;
+
+		await withTaskEvidenceLock(tempDir, '1.1', 'holder', async () => {
+			// Start the council write while we still hold the lock. Do NOT await it
+			// here — capture the promise so we can await it after releasing.
+			councilPromise = writeCouncilEvidence(tempDir, makeSynthesis()).then(
+				() => {
+					order.push('council-wrote');
+				},
+			);
+			// Give the council write a window to run if it (incorrectly) bypassed
+			// the lock. A broken writer would push 'council-wrote' before this line.
+			await Bun.sleep(50);
+			order.push('holder-releasing');
+		});
+
+		await councilPromise;
+
+		// The held lock must have forced the council write to wait.
+		expect(order).toEqual(['holder-releasing', 'council-wrote']);
+	});
+
+	test('council write preserves gate entries recorded by the hook path', async () => {
+		// Seed the shared {taskId}.json with gate evidence via the locked+atomic
+		// gate path, then write council evidence. All entries must coexist — the
+		// council write must not clobber the reviewer/test_engineer gates.
+		await recordGateEvidence(tempDir, '1.1', 'reviewer', 'sess-1');
+		await recordGateEvidence(tempDir, '1.1', 'test_engineer', 'sess-1');
+
+		await writeCouncilEvidence(tempDir, makeSynthesis());
+
+		const evidence = JSON.parse(
+			readFileSync(taskEvidencePath(tempDir, '1.1'), 'utf-8'),
+		);
+		expect(evidence.gates.reviewer).toBeDefined();
+		expect(evidence.gates.test_engineer).toBeDefined();
+		expect(evidence.gates.council).toBeDefined();
+		expect(evidence.gates.council.verdict).toBe('APPROVE');
+		// required_gates set by the gate path must survive the council write.
+		expect(evidence.required_gates).toEqual(
+			expect.arrayContaining(['reviewer', 'test_engineer']),
+		);
+	});
+
+	test('gate write after council preserves the council entry', async () => {
+		// Reverse order: council first, then a gate write. The gate path's
+		// read-modify-write must preserve the council entry.
+		await writeCouncilEvidence(tempDir, makeSynthesis());
+		await recordGateEvidence(tempDir, '1.1', 'reviewer', 'sess-1');
+
+		const evidence = JSON.parse(
+			readFileSync(taskEvidencePath(tempDir, '1.1'), 'utf-8'),
+		);
+		expect(evidence.gates.council).toBeDefined();
+		expect(evidence.gates.reviewer).toBeDefined();
+	});
+});

--- a/tests/unit/council/evidence-writer-gaps.test.ts
+++ b/tests/unit/council/evidence-writer-gaps.test.ts
@@ -52,8 +52,8 @@ afterEach(() => {
 });
 
 describe('evidence writer — gates.council integration', () => {
-	test('writes to evidence.gates.council with standard GateInfo fields', () => {
-		writeCouncilEvidence(tempDir, makeSynthesis());
+	test('writes to evidence.gates.council with standard GateInfo fields', async () => {
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(
 			readFileSync(join(tempDir, '.swarm', 'evidence', '1.1.json'), 'utf-8'),
 		);
@@ -67,8 +67,8 @@ describe('evidence writer — gates.council integration', () => {
 		expect(evidence.gates.council.quorumSize).toBe(3);
 	});
 
-	test('does NOT write council at top-level (must be under gates)', () => {
-		writeCouncilEvidence(tempDir, makeSynthesis());
+	test('does NOT write council at top-level (must be under gates)', async () => {
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(
 			readFileSync(join(tempDir, '.swarm', 'evidence', '1.1.json'), 'utf-8'),
 		);
@@ -77,7 +77,7 @@ describe('evidence writer — gates.council integration', () => {
 });
 
 describe('evidence writer — preservation of existing evidence', () => {
-	test('preserves existing non-council gate entries', () => {
+	test('preserves existing non-council gate entries', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(
@@ -95,7 +95,7 @@ describe('evidence writer — preservation of existing evidence', () => {
 			}),
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 
 		// Existing reviewer gate entry survives
@@ -108,12 +108,12 @@ describe('evidence writer — preservation of existing evidence', () => {
 		expect(evidence.gates.council).toBeDefined();
 	});
 
-	test('second write overwrites council but keeps other gates', () => {
-		writeCouncilEvidence(
+	test('second write overwrites council but keeps other gates', async () => {
+		await writeCouncilEvidence(
 			tempDir,
 			makeSynthesis({ roundNumber: 1, overallVerdict: 'REJECT' }),
 		);
-		writeCouncilEvidence(
+		await writeCouncilEvidence(
 			tempDir,
 			makeSynthesis({ roundNumber: 2, overallVerdict: 'APPROVE' }),
 		);
@@ -127,7 +127,7 @@ describe('evidence writer — preservation of existing evidence', () => {
 });
 
 describe('evidence writer — prototype pollution defence', () => {
-	test('poisoned __proto__ in existing evidence does not pollute Object.prototype', () => {
+	test('poisoned __proto__ in existing evidence does not pollute Object.prototype', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(
@@ -135,7 +135,7 @@ describe('evidence writer — prototype pollution defence', () => {
 			'{"__proto__": {"polluted": true}, "gates": {}}',
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 
 		// Global Object.prototype must not have gained a `polluted` key.
 		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
@@ -146,7 +146,7 @@ describe('evidence writer — prototype pollution defence', () => {
 		expect(Object.hasOwn(evidence, '__proto__')).toBe(false);
 	});
 
-	test('poisoned constructor / prototype keys are dropped', () => {
+	test('poisoned constructor / prototype keys are dropped', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(
@@ -154,7 +154,7 @@ describe('evidence writer — prototype pollution defence', () => {
 			'{"constructor": "evil", "prototype": "bad", "gates": {"__proto__": {"x":1}}}',
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const raw = readFileSync(
 			join(tempDir, '.swarm', 'evidence', '1.1.json'),
 			'utf-8',
@@ -166,23 +166,25 @@ describe('evidence writer — prototype pollution defence', () => {
 });
 
 describe('evidence writer — malformed input recovery', () => {
-	test('corrupted existing JSON falls through to fresh start', () => {
+	test('corrupted existing JSON falls through to fresh start', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(join(dir, '1.1.json'), 'not valid json at all');
 
 		// Must not throw; must write a valid council entry.
-		expect(() => writeCouncilEvidence(tempDir, makeSynthesis())).not.toThrow();
+		await expect(
+			writeCouncilEvidence(tempDir, makeSynthesis()),
+		).resolves.toBeUndefined();
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 		expect(evidence.gates.council.verdict).toBe('APPROVE');
 	});
 
-	test('existing file containing a JSON array triggers fresh start (not spread)', () => {
+	test('existing file containing a JSON array triggers fresh start (not spread)', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(join(dir, '1.1.json'), '["not","an","object"]');
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 		// Result must be a plain object with gates.council, not an array.
 		expect(Array.isArray(evidence)).toBe(false);
@@ -191,21 +193,23 @@ describe('evidence writer — malformed input recovery', () => {
 		expect(Object.hasOwn(evidence, '0')).toBe(false);
 	});
 
-	test('existing JSON null triggers fresh start', () => {
+	test('existing JSON null triggers fresh start', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(join(dir, '1.1.json'), 'null');
 
-		expect(() => writeCouncilEvidence(tempDir, makeSynthesis())).not.toThrow();
+		await expect(
+			writeCouncilEvidence(tempDir, makeSynthesis()),
+		).resolves.toBeUndefined();
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 		expect(evidence.gates.council.verdict).toBe('APPROVE');
 	});
 
-	test('file with gates field of wrong type (array) is gracefully replaced', () => {
+	test('file with gates field of wrong type (array) is gracefully replaced', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(join(dir, '1.1.json'), '{"taskId":"1.1","gates":["oops"]}');
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 		expect(Array.isArray(evidence.gates)).toBe(false);
 		expect(evidence.gates.council).toBeDefined();
@@ -227,7 +231,7 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 		}
 	}
 
-	test('forbidden key at level 3 (deeply nested) is filtered', () => {
+	test('forbidden key at level 3 (deeply nested) is filtered', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		// { gates: { reviewer: { __proto__: { polluted: true } } } }
@@ -244,7 +248,7 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 			}),
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 
 		// The nested __proto__ must be completely absent
@@ -254,7 +258,7 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 		assertNoForbiddenKeys(evidence);
 	});
 
-	test('array of objects with forbidden keys — forbidden keys sanitized within each item', () => {
+	test('array of objects with forbidden keys — forbidden keys sanitized within each item', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		// { gates: { items: [{ __proto__: {} }, { constructor: {} }, { name: 'ok' }] } }
@@ -272,7 +276,7 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 			}),
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 
 		// Array length preserved; forbidden keys sanitized within each object
@@ -283,7 +287,7 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 		assertNoForbiddenKeys(evidence);
 	});
 
-	test('array of arrays containing objects with forbidden keys — inner objects sanitized', () => {
+	test('array of arrays containing objects with forbidden keys — inner objects sanitized', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		// Deeply nested: gates.data = [[[{ __proto__: {} }, { safe: 1 }]]]
@@ -297,7 +301,7 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 			}),
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 
 		// Both objects preserved but __proto__ sanitized from first
@@ -307,7 +311,7 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 		assertNoForbiddenKeys(evidence);
 	});
 
-	test('mixed nesting: object → array → object with forbidden key at level 3', () => {
+	test('mixed nesting: object → array → object with forbidden key at level 3', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		// gates.levels: [{ inner: { __proto__: {} } }]
@@ -325,7 +329,7 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 			}),
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 
 		expect(evidence.gates.levels[0].inner.safe).toBe('present');
@@ -335,7 +339,7 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 		assertNoForbiddenKeys(evidence);
 	});
 
-	test('gates.reviewer.__proto__ nested forbidden key is filtered', () => {
+	test('gates.reviewer.__proto__ nested forbidden key is filtered', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		// The exact shape: gates.reviewer.__proto__ = { polluted: true }
@@ -354,7 +358,7 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 			}),
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 
 		// reviewer entry survives with safe fields
@@ -363,7 +367,7 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 		assertNoForbiddenKeys(evidence);
 	});
 
-	test('round-trip: write evidence with nested forbidden keys, read back, keys are gone', () => {
+	test('round-trip: write evidence with nested forbidden keys, read back, keys are gone', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 
@@ -385,13 +389,13 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 		);
 
 		// First read via writeCouncilEvidence (which re-reads and sanitizes)
-		writeCouncilEvidence(
+		await writeCouncilEvidence(
 			tempDir,
 			makeSynthesis({ overallVerdict: 'REJECT', roundNumber: 1 }),
 		);
 
 		// Write again with new synthesis
-		writeCouncilEvidence(
+		await writeCouncilEvidence(
 			tempDir,
 			makeSynthesis({ overallVerdict: 'APPROVE', roundNumber: 2 }),
 		);
@@ -406,7 +410,7 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 		assertNoForbiddenKeys(evidence);
 	});
 
-	test('all three forbidden keys (__proto__, constructor, prototype) filtered at all depths', () => {
+	test('all three forbidden keys (__proto__, constructor, prototype) filtered at all depths', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(
@@ -428,7 +432,7 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 			}),
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 
 		// All safe paths survive
@@ -446,8 +450,8 @@ describe('evidence writer — safeAssignOwnProps recursive filtering', () => {
 });
 
 describe('evidence writer — idempotency / no directory pollution', () => {
-	test('writer only creates files under .swarm/evidence/', () => {
-		writeCouncilEvidence(tempDir, makeSynthesis());
+	test('writer only creates files under .swarm/evidence/', async () => {
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		expect(existsSync(join(tempDir, '.swarm', 'evidence', '1.1.json'))).toBe(
 			true,
 		);
@@ -463,7 +467,7 @@ describe('evidence writer — idempotency / no directory pollution', () => {
 });
 
 describe('evidence writer — primitive gates value handling', () => {
-	test('gates as string primitive is discarded and replaced with council entry', () => {
+	test('gates as string primitive is discarded and replaced with council entry', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(
@@ -475,7 +479,7 @@ describe('evidence writer — primitive gates value handling', () => {
 			}),
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 
 		// gates must be a valid object, not the original string
@@ -488,7 +492,7 @@ describe('evidence writer — primitive gates value handling', () => {
 		expect(evidence.status).toBe('pending');
 	});
 
-	test('gates as number primitive is discarded and replaced with council entry', () => {
+	test('gates as number primitive is discarded and replaced with council entry', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(
@@ -499,7 +503,7 @@ describe('evidence writer — primitive gates value handling', () => {
 			}),
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 
 		// gates must be a valid object, not the original number
@@ -509,7 +513,7 @@ describe('evidence writer — primitive gates value handling', () => {
 		expect(evidence.gates.council.verdict).toBe('APPROVE');
 	});
 
-	test('absent gates key results in gates.council being created', () => {
+	test('absent gates key results in gates.council being created', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(
@@ -520,7 +524,7 @@ describe('evidence writer — primitive gates value handling', () => {
 			}),
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 
 		// gates must now exist with council entry
@@ -533,7 +537,7 @@ describe('evidence writer — primitive gates value handling', () => {
 		expect(evidence.status).toBe('pending');
 	});
 
-	test('gates as array is discarded and replaced with council entry', () => {
+	test('gates as array is discarded and replaced with council entry', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(
@@ -545,7 +549,7 @@ describe('evidence writer — primitive gates value handling', () => {
 			}),
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 
 		// gates must be an object, not the original array
@@ -559,7 +563,7 @@ describe('evidence writer — primitive gates value handling', () => {
 		expect(evidence.status).toBe('pending');
 	});
 
-	test('gates as null is discarded and replaced with council entry', () => {
+	test('gates as null is discarded and replaced with council entry', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(
@@ -571,7 +575,7 @@ describe('evidence writer — primitive gates value handling', () => {
 			}),
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 
 		// gates must be an object, not null
@@ -588,7 +592,7 @@ describe('evidence writer — primitive gates value handling', () => {
 });
 
 describe('evidence writer — Object.hasOwn constructor/prototype filtering', () => {
-	test('constructor and prototype are not own properties of gates after write', () => {
+	test('constructor and prototype are not own properties of gates after write', async () => {
 		const dir = join(tempDir, '.swarm', 'evidence');
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(
@@ -608,7 +612,7 @@ describe('evidence writer — Object.hasOwn constructor/prototype filtering', ()
 			}),
 		);
 
-		writeCouncilEvidence(tempDir, makeSynthesis());
+		await writeCouncilEvidence(tempDir, makeSynthesis());
 		const evidence = JSON.parse(readFileSync(join(dir, '1.1.json'), 'utf-8'));
 
 		// Verify with Object.hasOwn — stronger than string search
@@ -643,15 +647,15 @@ describe('evidence writer — round-history audit log', () => {
 		...overrides,
 	});
 
-	test('creates .swarm/council/{taskId}.rounds.jsonl after write', () => {
-		writeCouncilEvidence(tempDir, makeRoundSynthesis());
+	test('creates .swarm/council/{taskId}.rounds.jsonl after write', async () => {
+		await writeCouncilEvidence(tempDir, makeRoundSynthesis());
 
 		const roundsPath = join(tempDir, '.swarm', 'council', '1.1.rounds.jsonl');
 		expect(existsSync(roundsPath)).toBe(true);
 	});
 
-	test('JSONL line contains {round, verdict, timestamp, vetoedBy}', () => {
-		writeCouncilEvidence(
+	test('JSONL line contains {round, verdict, timestamp, vetoedBy}', async () => {
+		await writeCouncilEvidence(
 			tempDir,
 			makeRoundSynthesis({
 				roundNumber: 3,
@@ -673,8 +677,8 @@ describe('evidence writer — round-history audit log', () => {
 		});
 	});
 
-	test('multiple calls append multiple lines (not overwrite)', () => {
-		writeCouncilEvidence(
+	test('multiple calls append multiple lines (not overwrite)', async () => {
+		await writeCouncilEvidence(
 			tempDir,
 			makeRoundSynthesis({
 				roundNumber: 1,
@@ -682,7 +686,7 @@ describe('evidence writer — round-history audit log', () => {
 				vetoedBy: ['reviewer'],
 			}),
 		);
-		writeCouncilEvidence(
+		await writeCouncilEvidence(
 			tempDir,
 			makeRoundSynthesis({
 				roundNumber: 2,
@@ -690,7 +694,7 @@ describe('evidence writer — round-history audit log', () => {
 				vetoedBy: null,
 			}),
 		);
-		writeCouncilEvidence(
+		await writeCouncilEvidence(
 			tempDir,
 			makeRoundSynthesis({
 				roundNumber: 3,
@@ -730,7 +734,8 @@ describe('evidence writer — round-history audit log', () => {
 		console.warn = (msg: string) => warnings.push(msg);
 
 		// Mock appendFileSync to throw on audit log paths — simulating permission error.
-		// We use mock.module so the real writeFileSync (primary path) still works.
+		// The primary evidence write uses atomicWriteFile (bunWrite + rename), not
+		// appendFileSync, so mocking appendFileSync only affects the audit log path.
 		const realFs = await import('node:fs');
 		const mockAppendFileSync = mock((path: string, data: string) => {
 			if (path.includes('.rounds.jsonl')) {
@@ -745,9 +750,9 @@ describe('evidence writer — round-history audit log', () => {
 		}));
 
 		// Primary evidence write must succeed even when audit log fails.
-		expect(() =>
+		await expect(
 			writeCouncilEvidence(tempDir, makeRoundSynthesis()),
-		).not.toThrow();
+		).resolves.toBeUndefined();
 
 		// Verify the primary evidence file was written correctly.
 		const evidence = JSON.parse(

--- a/tests/unit/evidence/task-file.test.ts
+++ b/tests/unit/evidence/task-file.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the shared flat-task-file evidence write primitives (#978).
+ * Covers the lock that serializes concurrent read-modify-writes to the same
+ * .swarm/evidence/{taskId}.json and the atomic temp+rename write.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	atomicWriteFile,
+	taskEvidencePath,
+	taskEvidenceRelPath,
+	withTaskEvidenceLock,
+} from '../../../src/evidence/task-file';
+
+let tempDir: string;
+
+beforeEach(() => {
+	tempDir = mkdtempSync(join(tmpdir(), 'task-file-'));
+});
+
+afterEach(() => {
+	rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('taskEvidenceRelPath / taskEvidencePath', () => {
+	test('rel path is evidence/{taskId}.json and is the lock key', () => {
+		expect(taskEvidenceRelPath('1.1')).toBe(join('evidence', '1.1.json'));
+	});
+
+	test('absolute path is under <directory>/.swarm/evidence', () => {
+		expect(taskEvidencePath(tempDir, '2.3.1')).toBe(
+			join(tempDir, '.swarm', 'evidence', '2.3.1.json'),
+		);
+	});
+});
+
+describe('withTaskEvidenceLock — mutual exclusion', () => {
+	test('concurrent callbacks on the SAME taskId do not interleave', async () => {
+		const order: string[] = [];
+
+		await Promise.all([
+			withTaskEvidenceLock(tempDir, '1.1', 'agentA', async () => {
+				order.push('A-start');
+				await Bun.sleep(20);
+				order.push('A-end');
+			}),
+			withTaskEvidenceLock(tempDir, '1.1', 'agentB', async () => {
+				order.push('B-start');
+				await Bun.sleep(20);
+				order.push('B-end');
+			}),
+		]);
+
+		// Whichever ran first, its start/end must be adjacent — no interleave.
+		// A broken lock would produce [A-start, B-start, A-end, B-end].
+		expect(order).toHaveLength(4);
+		expect(order.indexOf('A-end')).toBe(order.indexOf('A-start') + 1);
+		expect(order.indexOf('B-end')).toBe(order.indexOf('B-start') + 1);
+	});
+
+	test('callbacks on DISJOINT taskIds both complete (no deadlock)', async () => {
+		const results = await Promise.all([
+			withTaskEvidenceLock(tempDir, '1.1', 'agentA', async () => 'a'),
+			withTaskEvidenceLock(tempDir, '2.2', 'agentB', async () => 'b'),
+		]);
+		expect(results).toEqual(['a', 'b']);
+	});
+
+	test('lock is released even when the callback throws', async () => {
+		await expect(
+			withTaskEvidenceLock(tempDir, '1.1', 'agentA', async () => {
+				throw new Error('boom');
+			}),
+		).rejects.toThrow('boom');
+
+		// A subsequent acquisition on the same taskId must succeed (lock freed).
+		const result = await withTaskEvidenceLock(
+			tempDir,
+			'1.1',
+			'agentB',
+			async () => 'ok',
+		);
+		expect(result).toBe('ok');
+	});
+});
+
+describe('atomicWriteFile', () => {
+	test('writes the content and leaves no leftover .tmp file', async () => {
+		const target = join(tempDir, 'out.json');
+		await atomicWriteFile(target, '{"a":1}');
+
+		expect(readFileSync(target, 'utf-8')).toBe('{"a":1}');
+		const leftovers = readdirSync(tempDir).filter((f) => f.includes('.tmp'));
+		expect(leftovers).toHaveLength(0);
+		expect(readdirSync(tempDir)).toEqual(['out.json']);
+	});
+
+	test('overwrites an existing target atomically', async () => {
+		const target = join(tempDir, 'out.json');
+		await atomicWriteFile(target, 'first');
+		await atomicWriteFile(target, 'second');
+		expect(readFileSync(target, 'utf-8')).toBe('second');
+		expect(readdirSync(tempDir).filter((f) => f.includes('.tmp'))).toHaveLength(
+			0,
+		);
+	});
+});

--- a/tests/unit/evidence/task-file.test.ts
+++ b/tests/unit/evidence/task-file.test.ts
@@ -9,6 +9,7 @@ import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+	_internals,
 	atomicWriteFile,
 	taskEvidencePath,
 	taskEvidenceRelPath,
@@ -106,5 +107,40 @@ describe('atomicWriteFile', () => {
 		expect(readdirSync(tempDir).filter((f) => f.includes('.tmp'))).toHaveLength(
 			0,
 		);
+	});
+});
+
+describe('atomicWriteFile — failure paths', () => {
+	// Save the real renameSync so we can restore it after each test.
+	const realRenameSync = _internals.renameSync;
+
+	afterEach(() => {
+		// Restore the seam so subsequent tests (and other files) use the real fs.
+		_internals.renameSync = realRenameSync;
+	});
+
+	test('renameSync failure cleans up the temp file and propagates the error', async () => {
+		// Arrange: replace renameSync with one that simulates EPERM.
+		const epermError = Object.assign(
+			new Error('EPERM: operation not permitted'),
+			{ code: 'EPERM' },
+		);
+		_internals.renameSync = () => {
+			throw epermError;
+		};
+
+		const target = join(tempDir, 'out.json');
+
+		// Act + Assert: error propagates.
+		await expect(atomicWriteFile(target, '{}')).rejects.toThrow(
+			'EPERM: operation not permitted',
+		);
+
+		// Assert: no .tmp file left behind (finally block cleaned up).
+		const leftovers = readdirSync(tempDir).filter((f) => f.includes('.tmp'));
+		expect(leftovers).toHaveLength(0);
+
+		// Assert: target was never written (rename never completed).
+		expect(readdirSync(tempDir)).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
﻿Closes #978

## Summary
- Add src/evidence/task-file.ts as the single source of truth for safe writes to the flat .swarm/evidence/{taskId}.json: shared 	askEvidenceRelPath (lock key), 	askEvidencePath, tomicWriteFile (temp+rename), and withTaskEvidenceLock.
- writeCouncilEvidence is now sync, wraps its read-modify-write in withTaskEvidenceLock, and writes via tomicWriteFile — serializing against the delegation-gate hook on the same task file.
- gate-evidence.ts refactored onto the shared helpers (behavior-preserving: identical lock key, identical atomic write, identical output bytes).
- convene-council.ts awaits the council write; a lock-timeout surfaces as a structured {success:false} failure via the existing createSwarmTool wrapper.
- 61 tests added/migrated: 6 lock-respect/timeout regression tests, 8 atomicity/mutual-exclusion unit tests, 32 call-site async migrations, 9 behavior-preservation tests, 3 concurrent interleaving tests, 3 timeout-propagation tests.
- **Post-review additions**: _internals seams on 	ask-file.ts and council-evidence-writer.ts for DI-based test injection (AGENTS.md §7); resolved F-002 (EvidenceLockTimeoutError propagation), F-004 (renameSync failure cleanup), F-010 (concurrent Promise.all interleaving test).

## Root Cause

writeCouncilEvidence (src/council/council-evidence-writer.ts:73-144) performed an **unlocked, non-atomic** read-modify-write (existsSync→eadFileSync→merge→writeFileSync) on .swarm/evidence/{taskId}.json — the same flat task evidence file that gate-evidence.ts guards with withEvidenceLock + atomic temp+rename. The lock module documents the invariant that *every* evidence read-modify-write must hold the lock (src/evidence/lock.ts:3-7). When a council write and a gate-evidence write for the same task interleaved, the unlocked council write could clobber a concurrently-recorded gate entry (lost update — e.g. dropping the 	est_engineer gate → false completion block) or leave a torn file that breaks the gate reader's eadTaskEvidenceRaw parse.

This is **not** the #970 task-ID misattribution class: submit_council_verdicts receives an explicit, zod-validated 	askId (src/tools/convene-council.ts:52-64) and never guesses, so esolveEvidenceTaskId does not apply.

## Fix

Route the council write through the same shared lock + atomic write as the gate path, and extract those primitives so both writers structurally share one lock key.

- New src/evidence/task-file.ts: 	askEvidenceRelPath (shared lock key), 	askEvidencePath, tomicWriteFile (temp+rename), withTaskEvidenceLock, _internals seam.
- writeCouncilEvidence is now sync, wraps its read-modify-write in _internals.withTaskEvidenceLock, and writes via tomicWriteFile.
- src/gate-evidence.ts refactored onto the shared helpers (behavior-preserving).
- src/tools/convene-council.ts:233 awaits the write; a lock-timeout surfaces as a structured failure via the existing createSwarmTool wrapper.

## Tests

- Regression test: un --smol test tests/unit/council/council-evidence-concurrency.test.ts → 6 PASS (incl. deterministic lock-respect, concurrent Promise.all interleave, EvidenceLockTimeoutError propagation).
- New unit: un --smol test tests/unit/evidence/task-file.test.ts → 8 PASS (lock mutual-exclusion, release-on-throw, atomic write + no .tmp, **renameSync failure cleanup**).
- Migrated: un --smol test tests/unit/council/evidence-writer-gaps.test.ts (28) + 	ests/unit/council/adversarial.test.ts (13) → PASS.
- Behavior-preservation: src/gate-evidence.test.ts (33), gate-evidence.adversarial (1), 	ests/integration/gate-evidence-e2e.test.ts (7), delegation-gate.evidence (18), delegation-gate.turbo-evidence (16), state.rehydrate (75), evidence-check (36) → PASS.
- Lint/type/build: 	sc --noEmit, unx biome ci <changed-files>, un run build, 
ode --input-type=module -e "await import('./dist/index.js')" → all PASS.

## Regression Protection

- 	ests/unit/council/council-evidence-concurrency.test.ts — deterministic lock-respect test + concurrent Promise.all interleave (gate+council simultaneously) + EvidenceLockTimeoutError propagation.
- 	ests/unit/evidence/task-file.test.ts — mutual exclusion, no-interleave, release-on-throw, atomic write, **renameSync failure cleans up .tmp**.
- Test-drift review: writeCouncilEvidence became async → migrated all 32 call sites in evidence-writer-gaps.test.ts and both .toThrow() sites in dversarial.test.ts.

## Risk and Rollback

- Risk level: low-medium. No change to the evidence file path or JSON shape. Riskiest piece (gate-evidence refactor) is behavior-preserving, proven by the unmodified gate-evidence suite passing.
- Rollback: revert the commit. No persisted-format or migration change.
- Residual risk: runtime frequency of council/gate write overlap is workload-dependent; the fix is correct regardless of frequency.

## Invariant audit
- 1 (plugin init): not touched — no init-path code changed.
- 2 (runtime portability): touched — tomicWriteFile uses unWrite (via src/utils/bun-compat), no top-level un: import; verified 
ode --input-type=module -e "await import('./dist/index.js')" → LOADED OK; default export shape unchanged.
- 3 (subprocesses): not touched — no spawn.
- 4 (.swarm containment): touched — all writes target <directory>/.swarm/evidence/{taskId}.json via the injected directory/workingDir; no new process.cwd() callers; council still resolves via esolveWorkingDirectory.
- 5 (plan durability): not touched — no ledger/projection/checkpoint change.
- 6 (test_runner safety): not touched — tests run via shell per-file loops, not 	est_runner.
- 7 (test writing): touched — un:test, os.tmpdir()+path.join, per-test temp dirs cleaned in fterEach; new concurrency tests use real fs; _internals seams restored in fterEach (AGENTS.md §7 compliant, no mock.module leakage introduced by this PR).
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no new tool/agent-map entry; submit_council_verdicts signature and registration unchanged.
- 12 (release/cache): touched — added docs/releases/pending/978-council-evidence-lock.md; did not edit version/CHANGELOG/manifest.

## Review findings addressed
| Finding | Severity | Status | Resolution |
|---------|----------|--------|-----------|
| F-002 — EvidenceLockTimeoutError not tested | MEDIUM | ✅ Resolved | _internals.withTaskEvidenceLock seam + 2 tests in council-evidence-concurrency.test.ts |
| F-004 — atomicWriteFile renameSync failure untested | MEDIUM | ✅ Resolved | _internals.renameSync seam + test in 	ask-file.test.ts |
| F-010 — Sequential-only merge test | LOW | ✅ Resolved | Promise.all([recordGateEvidence, writeCouncilEvidence]) concurrent test added |
| F-001 — Pre-existing mock.module leak | MEDIUM→downgraded | ℹ️ Pre-existing | Not introduced by this PR; _internals approach prevents new leakage |
| F-007 — 3+ writer stress test | LOW→downgraded | ℹ️ Future enhancement | Same lock mechanism; not blocking |
| F-009 — VALID_TASK_ID copy-paste | LOW | ℹ️ Pre-existing | Import from alidation/task-id.ts is a follow-up refactor |

## Pre-existing failures (baseline-confirmed)
- update-task-status.gates.test.ts: 4 fail — stash-confirmed pre-existing.
- 	ests/unit/evidence/{archive,manager.adversarial,validateProjectRoot.adversarial}.test.ts: 25 fail — untouched manager.ts.
- write-retro*.test.ts, 	est-runner*.test.ts, 	ool-registration-conformance.test.ts: confirmed identical counts on origin/main worktree.
- 	ests/unit/cli, 	ests/unit/commands, 	ests/unit/config: 469 fail — identical on origin/main worktree.

## Test plan
- [x] un --smol test tests/unit/council/council-evidence-concurrency.test.ts → 6 pass
- [x] un --smol test tests/unit/evidence/task-file.test.ts → 8 pass
- [x] un --smol test tests/unit/council/evidence-writer-gaps.test.ts → 28 pass
- [x] un --smol test tests/unit/council/adversarial.test.ts → 13 pass
- [x] un --smol test src/gate-evidence.test.ts src/hooks/delegation-gate.evidence.test.ts src/hooks/delegation-gate.turbo-evidence.test.ts → all pass
- [x] un run typecheck → PASS
- [x] unx biome ci <changed-files> → PASS
- [x] un run build → PASS
- [x] 
ode --input-type=module -e "await import('./dist/index.js')" → LOADED OK
- [x] un test tests/security → 135 pass, 0 fail
- [x] un test tests/smoke → 10 pass, 0 fail
- [x] All other failures confirmed pre-existing on origin/main worktree
