### PR TITLE
feat(memory): add sqlite provider foundation

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -4,6 +4,7 @@ var __create = Object.create;
 var __getProtoOf = Object.getPrototypeOf;
 var __defProp = Object.defineProperty;
 var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
 function __accessProp(key) {
   return this[key];
@@ -30,6 +31,23 @@ var __toESM = (mod, isNodeMode, target) => {
     cache.set(mod, to);
   return to;
 };
+var __toCommonJS = (from) => {
+  var entry = (__moduleCache ??= new WeakMap).get(from), desc;
+  if (entry)
+    return entry;
+  entry = __defProp({}, "__esModule", { value: true });
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (var key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(entry, key))
+        __defProp(entry, key, {
+          get: __accessProp.bind(from, key),
+          enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
+        });
+  }
+  __moduleCache.set(from, entry);
+  return entry;
+};
+var __moduleCache;
 var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 var __returnValue = (v) => v;
 function __exportSetter(name, newValue) {
@@ -21779,11 +21797,764 @@ var init_agents2 = __esm(() => {
     "thinking"
   ]);
 });
+// src/sandbox/capability-probe.ts
+var exports_capability_probe = {};
+__export(exports_capability_probe, {
+  isWindowsSandboxAvailable: () => isWindowsSandboxAvailable,
+  isSandboxExecAvailable: () => isSandboxExecAvailable,
+  isBubblewrapAvailable: () => isBubblewrapAvailable,
+  SandboxCapabilityProbe: () => SandboxCapabilityProbe
+});
+import { execFile } from "child_process";
+import * as os3 from "os";
+function withProbeTimeout(cmd, args, ms) {
+  return new Promise((resolve6, reject) => {
+    const controller = new AbortController;
+    const timer = setTimeout(() => {
+      controller.abort();
+      proc?.kill();
+    }, ms);
+    const unref = timer.unref;
+    if (typeof unref === "function") {
+      unref.call(timer);
+    }
+    let proc;
+    try {
+      proc = execFile(cmd, args, {
+        signal: controller.signal,
+        timeout: ms,
+        windowsHide: true,
+        cwd: os3.tmpdir()
+      }, (error52, stdout, _stderr) => {
+        clearTimeout(timer);
+        if (error52) {
+          const exc = error52;
+          if (exc.code === "ENOENT" || exc.code === "ENOTFOUND") {
+            reject(new Error("binary not found"));
+          } else {
+            reject(error52);
+          }
+          return;
+        }
+        resolve6(stdout?.trim() ?? "");
+      });
+    } catch (spawnError) {
+      clearTimeout(timer);
+      reject(spawnError);
+    }
+  });
+}
+async function probeLinux() {
+  try {
+    const output = await withProbeTimeout("bwrap", ["--version"], 2000);
+    if (output.length > 0) {
+      return {
+        status: "enabled",
+        mechanism: "Bubblewrap",
+        platform: "linux"
+      };
+    }
+    return {
+      status: "disabled",
+      mechanism: "Bubblewrap",
+      platform: "linux",
+      error: "binary returned empty version"
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg === "binary not found") {
+      return {
+        status: "unsupported",
+        mechanism: "Bubblewrap",
+        platform: "linux",
+        error: msg
+      };
+    }
+    return {
+      status: "disabled",
+      mechanism: "Bubblewrap",
+      platform: "linux",
+      error: msg
+    };
+  }
+}
+async function probeMacOS() {
+  try {
+    const output = await withProbeTimeout("sandbox-exec", ["--version"], 2000);
+    if (output.length > 0) {
+      return {
+        status: "enabled",
+        mechanism: "sandbox-exec",
+        platform: "darwin"
+      };
+    }
+    return {
+      status: "disabled",
+      mechanism: "sandbox-exec",
+      platform: "darwin",
+      error: "binary returned empty version"
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg === "binary not found") {
+      return {
+        status: "unsupported",
+        mechanism: "sandbox-exec",
+        platform: "darwin",
+        error: msg
+      };
+    }
+    return {
+      status: "disabled",
+      mechanism: "sandbox-exec",
+      platform: "darwin",
+      error: msg
+    };
+  }
+}
+function probeWindows() {
+  return {
+    status: "enabled",
+    mechanism: "Restricted Token",
+    platform: "win32"
+  };
+}
+function isBubblewrapAvailable() {
+  return _cached?.status === "enabled" && _cached?.platform === "linux";
+}
+function isSandboxExecAvailable() {
+  return _cached?.status === "enabled" && _cached?.platform === "darwin";
+}
+function isWindowsSandboxAvailable() {
+  return _cached?.status === "enabled" && _cached?.platform === "win32";
+}
+
+class SandboxCapabilityProbe {
+  async detect() {
+    if (_cached !== undefined) {
+      return _cached;
+    }
+    const platform = process.platform;
+    switch (platform) {
+      case "linux":
+        _cached = await probeLinux();
+        break;
+      case "darwin":
+        _cached = await probeMacOS();
+        break;
+      case "win32":
+        _cached = probeWindows();
+        break;
+      default:
+        _cached = {
+          status: "unsupported",
+          mechanism: "unknown",
+          platform,
+          error: `unsupported platform: ${platform}`
+        };
+    }
+    return _cached;
+  }
+}
+var _cached;
+var init_capability_probe = () => {};
+
+// src/sandbox/linux/bubblewrap-executor.ts
+import { spawnSync } from "child_process";
+function probeBwrap() {
+  try {
+    const result = spawnSync("bwrap", ["--version"], {
+      windowsHide: true,
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    if (result.error) {
+      const code = result.error.code;
+      if (code && BWRAP_UNAVAILABLE_CODES.has(code)) {
+        console.warn(`[bubblewrap] Sandbox disabled: bwrap error (${code}). Falling through to tool-layer enforcement.`);
+        return false;
+      }
+      console.warn(`[bubblewrap] Sandbox disabled: bwrap spawn error (${result.error.message}). Falling through to tool-layer enforcement.`);
+      return false;
+    }
+    return result.status === BWRAP_VERSION_EXIT && result.stdout.trim().length > 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[bubblewrap] Sandbox disabled: probe threw (${message}). Falling through to tool-layer enforcement.`);
+    return false;
+  }
+}
+function shellEscape(s) {
+  return s.replace(/'/g, "'\\''");
+}
+
+class BubblewrapSandboxExecutor {
+  mechanism = "Bubblewrap";
+  _scopePaths;
+  _tempDir;
+  _available;
+  _disabledReason;
+  constructor(scopePaths, tempDir) {
+    this._scopePaths = scopePaths;
+    this._tempDir = tempDir;
+    this._available = false;
+    this._disabledReason = null;
+    try {
+      if (!_internals7.probeBwrap()) {
+        this._disabledReason = "bwrap not available or not functional";
+        console.warn(`[bubblewrap] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
+      } else {
+        this._available = true;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this._disabledReason = `constructor threw: ${message}`;
+      this._available = false;
+      console.warn(`[bubblewrap] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
+    }
+  }
+  isAvailable() {
+    return this._available;
+  }
+  disable(reason) {
+    this._available = false;
+    this._disabledReason = reason;
+    console.warn(`[bubblewrap] Sandbox disabled: ${reason}. Falling through to tool-layer enforcement.`);
+  }
+  wrapCommand(command, scopePaths, tempDir) {
+    if (!this._available) {
+      return command;
+    }
+    if (!_internals7.probeBwrap()) {
+      this._available = false;
+      this._disabledReason = "bwrap became unavailable between calls";
+      console.warn(`[bubblewrap] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
+      return command;
+    }
+    const temp = tempDir ?? this._tempDir ?? "/tmp";
+    const allScopes = [...this._scopePaths, ...scopePaths];
+    const bindArgs = allScopes.flatMap((p) => ["--bind", p]);
+    const args = [
+      "--unshare-user",
+      "--unshare-net",
+      "--unshare-ipc",
+      "--die-with-parent",
+      "--new-session",
+      ...bindArgs,
+      "--tmpfs",
+      `${temp},size=500M`,
+      "--ro-bind",
+      "/etc",
+      "/etc",
+      "--ro-bind",
+      "/usr",
+      "/usr",
+      "--ro-bind",
+      "/lib",
+      "/lib",
+      "--ro-bind",
+      "/lib64",
+      "/lib64",
+      "--proc",
+      "/proc",
+      "--unshare-pid",
+      "--",
+      "bash",
+      "-c",
+      `'${shellEscape(command)}'`
+    ];
+    return `bwrap ${args.join(" ")}`;
+  }
+  getEnvOverrides() {
+    return {};
+  }
+}
+var BWRAP_VERSION_EXIT = 0, BWRAP_UNAVAILABLE_CODES, _internals7;
+var init_bubblewrap_executor = __esm(() => {
+  BWRAP_UNAVAILABLE_CODES = new Set(["ENOENT", "EACCES", "ENOSPC"]);
+  _internals7 = {
+    probeBwrap
+  };
+});
+
+// src/sandbox/executors/bubblewrap.ts
+var exports_bubblewrap = {};
+__export(exports_bubblewrap, {
+  BubblewrapSandboxExecutor: () => BubblewrapSandboxExecutor
+});
+var init_bubblewrap = __esm(() => {
+  init_bubblewrap_executor();
+});
+
+// src/sandbox/macos/sandbox-exec-executor.ts
+import { spawnSync as spawnSync2 } from "child_process";
+import { mkdtempSync, writeFileSync as writeFileSync3 } from "fs";
+import * as os4 from "os";
+import * as path8 from "path";
+function probeSandboxExec() {
+  try {
+    const result = spawnSync2("sandbox-exec", ["--version"], {
+      windowsHide: true,
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    if (result.error) {
+      const code = result.error.code;
+      if (code && SANDBOX_UNAVAILABLE_CODES.has(code)) {
+        console.warn(`[sandbox-exec] Sandbox disabled: sandbox-exec error (${code}). Falling through to tool-layer enforcement.`);
+        return false;
+      }
+      console.warn(`[sandbox-exec] Sandbox disabled: spawn error (${result.error.message}). Falling through to tool-layer enforcement.`);
+      return false;
+    }
+    return result.status === 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[sandbox-exec] Sandbox disabled: probe threw (${message}). Falling through to tool-layer enforcement.`);
+    return false;
+  }
+}
+function shellEscape2(s) {
+  return s.replace(/'/g, "'\\''");
+}
+function buildSandboxProfile(scopePaths, tempDir) {
+  const rwPaths = [...scopePaths];
+  if (tempDir) {
+    rwPaths.push(tempDir);
+  }
+  const rwAllowLines = rwPaths.map((p) => `(allow file-write* (subpath "${p}"))`).join(`
+`);
+  const profile = `(version 1)
+(allow default)
+(allow file-read* (subpath "/usr"))
+(allow file-read* (subpath "/bin"))
+(allow file-read* (subpath "/sbin"))
+(allow file-read* (subpath "/lib"))
+(allow file-read* (subpath "/lib64"))
+${rwAllowLines}
+(deny file-write*)`;
+  return profile;
+}
+
+class MacOSSandboxExecutor {
+  mechanism = "sandbox-exec";
+  _scopePaths;
+  _tempDir;
+  _available;
+  _disabledReason;
+  constructor(scopePaths = [], tempDir) {
+    if (process.platform !== "darwin") {
+      throw new Error("MacOSSandboxExecutor not yet implemented");
+    }
+    this._scopePaths = scopePaths;
+    this._tempDir = tempDir;
+    this._available = false;
+    this._disabledReason = null;
+    try {
+      if (!_internals8.probeSandboxExec()) {
+        this._disabledReason = "sandbox-exec not available or not functional";
+        console.warn(`[sandbox-exec] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
+      } else {
+        this._available = true;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this._disabledReason = `constructor threw: ${message}`;
+      this._available = false;
+      console.warn(`[sandbox-exec] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
+    }
+  }
+  isAvailable() {
+    return this._available;
+  }
+  disable(reason) {
+    this._available = false;
+    this._disabledReason = reason;
+    console.warn(`[sandbox-exec] Sandbox disabled: ${reason}. Falling through to tool-layer enforcement.`);
+  }
+  wrapCommand(command, scopePaths, tempDir) {
+    if (!this._available) {
+      return command;
+    }
+    if (!_internals8.probeSandboxExec()) {
+      this._available = false;
+      this._disabledReason = "sandbox-exec became unavailable between calls";
+      console.warn(`[sandbox-exec] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
+      return command;
+    }
+    const temp = tempDir ?? this._tempDir ?? os4.tmpdir();
+    const allScopes = [...this._scopePaths, ...scopePaths];
+    const profile = buildSandboxProfile(allScopes, temp);
+    let profilePath;
+    try {
+      const profileDir = mkdtempSync(path8.join(os4.tmpdir(), "sandbox-"));
+      profilePath = path8.join(profileDir, `profile-${process.pid}-${Date.now()}.sb`);
+      writeFileSync3(profilePath, profile, { mode: 384 });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[sandbox-exec] Sandbox disabled: failed to write profile (${message}). Falling through to tool-layer enforcement.`);
+      return command;
+    }
+    const escapedCommand = shellEscape2(command);
+    const escapedProfilePath = shellEscape2(profilePath);
+    return `sandbox-exec -f '${escapedProfilePath}' bash -c '${escapedCommand}'`;
+  }
+  getEnvOverrides() {
+    return {
+      DYLD_INSERT_LIBRARIES: null,
+      DYLD_LIBRARY_PATH: null,
+      DYLD_FRAMEWORK_PATH: null,
+      DYLD_ROOT_PATH: null,
+      PATH: "/usr/bin:/bin:/usr/sbin:/sbin"
+    };
+  }
+}
+var SANDBOX_UNAVAILABLE_CODES, _internals8;
+var init_sandbox_exec_executor = __esm(() => {
+  SANDBOX_UNAVAILABLE_CODES = new Set(["ENOENT", "EACCES", "ENOSPC"]);
+  _internals8 = {
+    probeSandboxExec
+  };
+});
+
+// src/sandbox/executors/macos.ts
+var exports_macos = {};
+__export(exports_macos, {
+  MacOSSandboxExecutor: () => MacOSSandboxExecutor
+});
+var init_macos = __esm(() => {
+  init_sandbox_exec_executor();
+});
+
+// src/sandbox/win32/edge-cases.ts
+function detectPathTraversal(command) {
+  if (process.platform !== "win32")
+    return false;
+  if (/\.\.[\\/]/.test(command)) {
+    return true;
+  }
+  if (/\.\.\//.test(command)) {
+    return true;
+  }
+  if (/\\\\[?]\\[\\]/.test(command)) {
+    return true;
+  }
+  if (/[A-Z]:[\\/]?\.\./i.test(command)) {
+    return true;
+  }
+  if (/[\\/]{2,3}\.\./.test(command)) {
+    return true;
+  }
+  if (/\\\\[^\\]+[\\/]\.\./i.test(command)) {
+    return true;
+  }
+  return false;
+}
+function detectPowerShellEscape(command) {
+  if (process.platform !== "win32")
+    return false;
+  const encodedCommandPattern = /-EncodedCommand/i;
+  if (encodedCommandPattern.test(command)) {
+    return true;
+  }
+  const executionPolicyBypassPattern = /-ExecutionPolicy\s+Bypass/i;
+  if (executionPolicyBypassPattern.test(command)) {
+    return true;
+  }
+  const executionPolicyUnrestrictedPattern = /-ExecutionPolicy\s+Unrestricted/i;
+  if (executionPolicyUnrestrictedPattern.test(command)) {
+    return true;
+  }
+  const windowStyleHiddenPattern = /-WindowStyle\s+Hidden/i;
+  if (windowStyleHiddenPattern.test(command)) {
+    return true;
+  }
+  const noProfileCommandPattern = /-NoProfile.*-Command/i;
+  if (noProfileCommandPattern.test(command)) {
+    return true;
+  }
+  const envVarCommandPattern = /-Command.*\$env:/i;
+  if (envVarCommandPattern.test(command)) {
+    return true;
+  }
+  const psVarPattern = /\$\w+:/i;
+  if (psVarPattern.test(command)) {
+    return true;
+  }
+  const powershellCommandPattern = /powershell(?:\.exe)?\s+-[c]\s+.+/i;
+  if (powershellCommandPattern.test(command)) {
+    if (detectPathTraversal(command)) {
+      return true;
+    }
+  }
+  const scopeBypassPattern = /-Scope\s+LocalMachine/i;
+  if (scopeBypassPattern.test(command)) {
+    return true;
+  }
+  const iexPattern = /Invoke-Expression\s+/i;
+  if (iexPattern.test(command)) {
+    return true;
+  }
+  return false;
+}
+
+// src/sandbox/win32/restricted-token-executor.ts
+import { spawnSync as spawnSync3 } from "child_process";
+import * as os5 from "os";
+function probeWindowsSandbox() {
+  try {
+    const result = spawnSync3("cmd", ["/c", "echo", "ok"], {
+      windowsHide: true,
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    if (result.error) {
+      const code = result.error.code;
+      if (code && SANDBOX_UNAVAILABLE_CODES2.has(code)) {
+        console.warn(`[restricted-token] Sandbox disabled: spawn error (${code}). Falling through to tool-layer enforcement.`);
+        return false;
+      }
+      console.warn(`[restricted-token] Sandbox disabled: spawn error (${result.error.message}). Falling through to tool-layer enforcement.`);
+      return false;
+    }
+    return result.status === 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[restricted-token] Sandbox disabled: probe threw (${message}). Falling through to tool-layer enforcement.`);
+    return false;
+  }
+}
+function psStringEscape(s) {
+  return s.replace(/[`"$]/g, "`$&");
+}
+function isPathInScopes(command, scopes) {
+  if (scopes.length === 0)
+    return true;
+  const pathPattern = /[A-Za-z]:(?:[^\\/:*?"<>|\r\n]+(?:\\[^\\/:*?"<>|\r\n]+)*)/g;
+  const paths = command.match(pathPattern) || [];
+  if (paths.length === 0)
+    return true;
+  const normalizedScopes = scopes.map((s) => s.toLowerCase().replace(/\\+$/, ""));
+  return paths.every((p) => {
+    const lower = p.toLowerCase();
+    return normalizedScopes.some((scope) => lower.startsWith(scope));
+  });
+}
+
+class WindowsSandboxExecutor {
+  mechanism = "restricted-token";
+  _scopePaths;
+  _tempDir;
+  _available;
+  _disabled;
+  _disabledReason;
+  constructor(scopePaths = [], tempDir) {
+    if (process.platform !== "win32") {
+      throw new Error("WindowsSandboxExecutor not yet implemented");
+    }
+    this._scopePaths = scopePaths;
+    this._tempDir = tempDir;
+    this._available = false;
+    this._disabled = false;
+    this._disabledReason = null;
+    try {
+      if (!_internals9.probeWindowsSandbox()) {
+        this._available = false;
+        this._disabledReason = "Windows sandbox not available or not functional";
+        console.warn(`[restricted-token] Sandbox unavailable: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
+      } else {
+        this._available = true;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this._available = false;
+      this._disabledReason = `constructor probe threw: ${message}`;
+      console.warn(`[restricted-token] Sandbox unavailable: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
+    }
+  }
+  isAvailable() {
+    return this._available && !this._disabled;
+  }
+  disable(reason) {
+    this._disabled = true;
+    this._disabledReason = reason;
+    console.warn(`[restricted-token] Sandbox disabled: ${reason}. Falling through to tool-layer enforcement.`);
+  }
+  wrapCommand(command, scopePaths, tempDir) {
+    if (!this.isAvailable()) {
+      return command;
+    }
+    if (!_internals9.probeWindowsSandbox()) {
+      this._available = false;
+      this._disabledReason = "Windows sandbox became unavailable between calls";
+      console.warn(`[restricted-token] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
+      return command;
+    }
+    const temp = tempDir ?? this._tempDir ?? os5.tmpdir();
+    const _allScopes = [...this._scopePaths, ...scopePaths];
+    if (detectPowerShellEscape(command)) {
+      throw new SandboxError("Command contains PowerShell escape patterns", "DETECT_POWERSHELL_ESCAPE");
+    }
+    if (!isPathInScopes(command, _allScopes)) {
+      throw new SandboxError("Command targets paths outside authorized scopes", "PATH_ESCAPE_SCOPE");
+    }
+    const safePath = "C:\\Windows\\System32;C:\\Windows";
+    const escapedTemp = psStringEscape(temp);
+    const escapedCommand = psStringEscape(command);
+    const psScript = `
+$ErrorActionPreference = 'Stop';
+try {
+  # Set scoped temp directory
+  $env:TEMP = '${escapedTemp}';
+  $env:TMP = '${escapedTemp}';
+
+  # Restrict PATH to safe system paths only
+  $env:PATH = '${safePath}';
+
+  # Remove dangerous environment variables that could be used to bypass restrictions
+  # Note: LD_PRELOAD, DYLD_* don't apply on Windows but we clear them for completeness
+  $dangerousVars = @(
+    'LD_PRELOAD',
+    'DYLD_INSERT_LIBRARIES',
+    'DYLD_LIBRARY_PATH',
+    'DYLD_FRAMEWORK_PATH',
+    'DYLD_ROOT_PATH',
+    'DYLD_FORCE_FLAT_NAMESPACE'
+  );
+  foreach ($v in $dangerousVars) {
+    if (Test-Path Env:\\$v) {
+      Remove-Item Env:\\$v -Force -ErrorAction SilentlyContinue;
+    }
+  }
+
+  # Execute the command via cmd /c
+  cmd /c "${escapedCommand}";
+} catch {
+  Write-Error $_.Exception.Message;
+  exit 1;
+}`;
+    return `powershell -ExecutionPolicy Bypass -NoProfile -WindowStyle Hidden -Command "${psScript.replace(/\n/g, " ").trim()}"`;
+  }
+  getEnvOverrides() {
+    return {
+      PATH: "C:\\Windows\\System32;C:\\Windows",
+      TEMP: null,
+      TMP: null,
+      LD_PRELOAD: null,
+      DYLD_INSERT_LIBRARIES: null,
+      DYLD_LIBRARY_PATH: null,
+      DYLD_FRAMEWORK_PATH: null,
+      DYLD_ROOT_PATH: null,
+      DYLD_FORCE_FLAT_NAMESPACE: null
+    };
+  }
+}
+var SANDBOX_UNAVAILABLE_CODES2, _internals9;
+var init_restricted_token_executor = __esm(() => {
+  init_executor();
+  SANDBOX_UNAVAILABLE_CODES2 = new Set([
+    "ENOENT",
+    "EACCES",
+    "EPERM",
+    "ENOSPC"
+  ]);
+  _internals9 = {
+    probeWindowsSandbox
+  };
+});
+
+// src/sandbox/executors/windows.ts
+var exports_windows = {};
+__export(exports_windows, {
+  WindowsSandboxExecutor: () => WindowsSandboxExecutor
+});
+var init_windows = __esm(() => {
+  init_restricted_token_executor();
+});
+
+// src/sandbox/executor.ts
+async function getExecutor() {
+  if (_cachedExecutorPromise !== undefined) {
+    return _cachedExecutorPromise;
+  }
+  _cachedExecutorPromise = _createExecutor();
+  return _cachedExecutorPromise;
+}
+async function _createExecutor() {
+  const platform = process.platform;
+  if (platform === "linux") {
+    return _createLinuxExecutor();
+  }
+  if (platform === "darwin") {
+    return _createMacOSExecutor();
+  }
+  if (platform === "win32") {
+    return _createWindowsExecutor();
+  }
+  return null;
+}
+async function _createLinuxExecutor() {
+  const { SandboxCapabilityProbe: SandboxCapabilityProbe2, isBubblewrapAvailable: isBubblewrapAvailable2 } = await Promise.resolve().then(() => (init_capability_probe(), exports_capability_probe));
+  await new SandboxCapabilityProbe2().detect();
+  if (!isBubblewrapAvailable2()) {
+    return null;
+  }
+  try {
+    const { BubblewrapSandboxExecutor: BubblewrapSandboxExecutor2 } = (init_bubblewrap(), __toCommonJS(exports_bubblewrap));
+    return new BubblewrapSandboxExecutor2;
+  } catch {
+    return null;
+  }
+}
+async function _createMacOSExecutor() {
+  const { SandboxCapabilityProbe: SandboxCapabilityProbe2, isSandboxExecAvailable: isSandboxExecAvailable2 } = await Promise.resolve().then(() => (init_capability_probe(), exports_capability_probe));
+  await new SandboxCapabilityProbe2().detect();
+  if (!isSandboxExecAvailable2()) {
+    return null;
+  }
+  try {
+    const { MacOSSandboxExecutor: MacOSSandboxExecutor2 } = (init_macos(), __toCommonJS(exports_macos));
+    return new MacOSSandboxExecutor2;
+  } catch {
+    return null;
+  }
+}
+async function _createWindowsExecutor() {
+  const { SandboxCapabilityProbe: SandboxCapabilityProbe2, isWindowsSandboxAvailable: isWindowsSandboxAvailable2 } = await Promise.resolve().then(() => (init_capability_probe(), exports_capability_probe));
+  await new SandboxCapabilityProbe2().detect();
+  if (!isWindowsSandboxAvailable2()) {
+    return null;
+  }
+  try {
+    const { WindowsSandboxExecutor: WindowsSandboxExecutor2 } = (init_windows(), __toCommonJS(exports_windows));
+    return new WindowsSandboxExecutor2;
+  } catch {
+    return null;
+  }
+}
+var SandboxError, _cachedExecutorPromise;
+var init_executor = __esm(() => {
+  SandboxError = class SandboxError extends Error {
+    code;
+    constructor(message, code) {
+      super(message);
+      this.code = code;
+      this.name = "SandboxError";
+    }
+  };
+});
+
+// src/sandbox/scope-resolver.ts
+var init_scope_resolver = () => {};
+
 // src/scope/scope-persistence.ts
 import * as fs5 from "fs";
-import * as path8 from "path";
+import * as path9 from "path";
 function getScopesDir(directory) {
-  return path8.join(directory, SCOPES_DIR);
+  return path9.join(directory, SCOPES_DIR);
 }
 function clearAllScopes(directory) {
   try {
@@ -21961,6 +22732,8 @@ var init_guardrails = __esm(() => {
   init_constants();
   init_schema();
   init_manager();
+  init_executor();
+  init_scope_resolver();
   init_scope_persistence();
   init_state();
   init_telemetry();
@@ -22744,10 +23517,10 @@ function mergeDefs2(...defs) {
 function cloneDef2(schema) {
   return mergeDefs2(schema._zod.def);
 }
-function getElementAtPath2(obj, path9) {
-  if (!path9)
+function getElementAtPath2(obj, path10) {
+  if (!path10)
     return obj;
-  return path9.reduce((acc, key) => acc?.[key], obj);
+  return path10.reduce((acc, key) => acc?.[key], obj);
 }
 function promiseAllObject2(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -23036,11 +23809,11 @@ function aborted2(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues2(path9, issues) {
+function prefixIssues2(path10, issues) {
   return issues.map((iss) => {
     var _a3;
     (_a3 = iss).path ?? (_a3.path = []);
-    iss.path.unshift(path9);
+    iss.path.unshift(path10);
     return iss;
   });
 }
@@ -23263,7 +24036,7 @@ function treeifyError2(error52, _mapper) {
     return issue3.message;
   };
   const result = { errors: [] };
-  const processError = (error53, path9 = []) => {
+  const processError = (error53, path10 = []) => {
     var _a3, _b;
     for (const issue3 of error53.issues) {
       if (issue3.code === "invalid_union" && issue3.errors.length) {
@@ -23273,7 +24046,7 @@ function treeifyError2(error52, _mapper) {
       } else if (issue3.code === "invalid_element") {
         processError({ issues: issue3.issues }, issue3.path);
       } else {
-        const fullpath = [...path9, ...issue3.path];
+        const fullpath = [...path10, ...issue3.path];
         if (fullpath.length === 0) {
           result.errors.push(mapper(issue3));
           continue;
@@ -23305,8 +24078,8 @@ function treeifyError2(error52, _mapper) {
 }
 function toDotPath2(_path) {
   const segs = [];
-  const path9 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
-  for (const seg of path9) {
+  const path10 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
+  for (const seg of path10) {
     if (typeof seg === "number")
       segs.push(`[${seg}]`);
     else if (typeof seg === "symbol")
@@ -33265,7 +34038,7 @@ class JSONSchemaGenerator2 {
     const flattenRef = (zodSchema, params2) => {
       const seen = this.seen.get(zodSchema);
       const schema2 = seen.def ?? seen.schema;
-      const _cached = { ...schema2 };
+      const _cached2 = { ...schema2 };
       if (seen.ref === null) {
         return;
       }
@@ -33279,7 +34052,7 @@ class JSONSchemaGenerator2 {
           schema2.allOf.push(refSchema);
         } else {
           Object.assign(schema2, refSchema);
-          Object.assign(schema2, _cached);
+          Object.assign(schema2, _cached2);
         }
       }
       if (!seen.isParent)
@@ -35208,7 +35981,7 @@ var init_create_tool = __esm(() => {
 // src/tools/checkpoint.ts
 import * as child_process from "child_process";
 import * as fs6 from "fs";
-import * as path9 from "path";
+import * as path10 from "path";
 function containsNonAsciiChars(label) {
   for (let i = 0;i < label.length; i++) {
     const charCode = label.charCodeAt(i);
@@ -35252,7 +36025,7 @@ function validateLabel(label) {
   return null;
 }
 function getCheckpointLogPath(directory) {
-  return path9.join(directory, CHECKPOINT_LOG_PATH);
+  return path10.join(directory, CHECKPOINT_LOG_PATH);
 }
 function readCheckpointLog(directory) {
   const logPath = getCheckpointLogPath(directory);
@@ -35270,7 +36043,7 @@ function readCheckpointLog(directory) {
 }
 function writeCheckpointLog(log2, directory) {
   const logPath = getCheckpointLogPath(directory);
-  const dir = path9.dirname(logPath);
+  const dir = path10.dirname(logPath);
   if (!fs6.existsSync(dir)) {
     fs6.mkdirSync(dir, { recursive: true });
   }
@@ -35292,7 +36065,7 @@ function gitExec(args) {
 }
 function appendRetentionEvent(directory, event) {
   try {
-    const eventsPath = path9.join(directory, ".swarm", "events.jsonl");
+    const eventsPath = path10.join(directory, ".swarm", "events.jsonl");
     const line = `${JSON.stringify({ ...event, timestamp: new Date().toISOString() })}
 `;
     fs6.appendFileSync(eventsPath, line);
@@ -35731,7 +36504,7 @@ function resetToRemoteBranch(cwd, options) {
   const prunedBranches = [];
   try {
     const currentBranch = getCurrentBranch(cwd);
-    const defaultRemoteBranch = _internals7.detectDefaultRemoteBranch(cwd);
+    const defaultRemoteBranch = _internals10.detectDefaultRemoteBranch(cwd);
     if (!defaultRemoteBranch) {
       return {
         success: false,
@@ -35913,7 +36686,7 @@ function resetToRemoteBranch(cwd, options) {
 function resetToMainAfterMerge(cwd, options) {
   const warnings = [];
   try {
-    const defaultBranch = _internals7.detectDefaultRemoteBranch(cwd);
+    const defaultBranch = _internals10.detectDefaultRemoteBranch(cwd);
     if (!defaultBranch) {
       return {
         success: false,
@@ -35940,7 +36713,7 @@ function resetToMainAfterMerge(cwd, options) {
     }
     if (currentBranch === defaultBranch) {
       try {
-        const logOutput = _internals7.gitExec(["log", `${targetBranch}..HEAD`, "--oneline"], cwd);
+        const logOutput = _internals10.gitExec(["log", `${targetBranch}..HEAD`, "--oneline"], cwd);
         if (logOutput.trim().length > 0) {
           return {
             success: false,
@@ -35955,11 +36728,11 @@ function resetToMainAfterMerge(cwd, options) {
       } catch {}
     } else {
       try {
-        _internals7.gitExec(["rev-parse", "--abbrev-ref", `${currentBranch}@{upstream}`], cwd);
+        _internals10.gitExec(["rev-parse", "--abbrev-ref", `${currentBranch}@{upstream}`], cwd);
       } catch {
         try {
-          const localSha = _internals7.gitExec(["rev-parse", "HEAD"], cwd).trim();
-          const remoteSha = _internals7.gitExec(["rev-parse", targetBranch], cwd).trim();
+          const localSha = _internals10.gitExec(["rev-parse", "HEAD"], cwd).trim();
+          const remoteSha = _internals10.gitExec(["rev-parse", targetBranch], cwd).trim();
           if (localSha !== remoteSha) {
             return {
               success: false,
@@ -35985,7 +36758,7 @@ function resetToMainAfterMerge(cwd, options) {
       }
     }
     try {
-      _internals7.gitExec(["fetch", "--prune", "origin"], cwd);
+      _internals10.gitExec(["fetch", "--prune", "origin"], cwd);
     } catch (err) {
       return {
         success: false,
@@ -36001,7 +36774,7 @@ function resetToMainAfterMerge(cwd, options) {
     let switchedBranch = false;
     if (currentBranch !== defaultBranch) {
       try {
-        _internals7.gitExec(["checkout", defaultBranch], cwd);
+        _internals10.gitExec(["checkout", defaultBranch], cwd);
         switchedBranch = true;
       } catch (err) {
         return {
@@ -36016,7 +36789,7 @@ function resetToMainAfterMerge(cwd, options) {
       }
     }
     try {
-      _internals7.gitExec(["reset", "--hard", targetBranch], cwd);
+      _internals10.gitExec(["reset", "--hard", targetBranch], cwd);
     } catch (err) {
       return {
         success: false,
@@ -36037,7 +36810,7 @@ function resetToMainAfterMerge(cwd, options) {
           while (Date.now() < endTime) {}
         }
         try {
-          _internals7.gitExec(["checkout", "--", "."], cwd);
+          _internals10.gitExec(["checkout", "--", "."], cwd);
           discardSucceeded = true;
           break;
         } catch {}
@@ -36048,18 +36821,18 @@ function resetToMainAfterMerge(cwd, options) {
       changesDiscarded = discardSucceeded;
     }
     try {
-      _internals7.gitExec(["clean", "-fd"], cwd);
+      _internals10.gitExec(["clean", "-fd"], cwd);
     } catch {
       warnings.push("Could not clean untracked files");
     }
     let branchDeleted = false;
     if (switchedBranch && previousBranch !== defaultBranch) {
       try {
-        const mergedOutput = _internals7.gitExec(["branch", "--merged", defaultBranch], cwd);
+        const mergedOutput = _internals10.gitExec(["branch", "--merged", defaultBranch], cwd);
         const isMerged = mergedOutput.split(`
 `).some((line) => line.trim() === previousBranch || line.trim() === `* ${previousBranch}`);
         if (isMerged) {
-          _internals7.gitExec(["branch", "-d", previousBranch], cwd);
+          _internals10.gitExec(["branch", "-d", previousBranch], cwd);
           branchDeleted = true;
         } else {
           warnings.push(`Branch ${previousBranch} is not merged into ${defaultBranch} \u2014 keeping it`);
@@ -36070,7 +36843,7 @@ function resetToMainAfterMerge(cwd, options) {
     }
     if (options?.pruneBranches) {
       try {
-        const mergedOutput = _internals7.gitExec(["branch", "--merged", defaultBranch], cwd);
+        const mergedOutput = _internals10.gitExec(["branch", "--merged", defaultBranch], cwd);
         const mergedLines = mergedOutput.split(`
 `);
         for (const line of mergedLines) {
@@ -36079,7 +36852,7 @@ function resetToMainAfterMerge(cwd, options) {
             continue;
           }
           try {
-            _internals7.gitExec(["branch", "-d", trimmedLine], cwd);
+            _internals10.gitExec(["branch", "-d", trimmedLine], cwd);
           } catch {
             warnings.push(`Could not prune branch: ${trimmedLine}`);
           }
@@ -36109,10 +36882,10 @@ function resetToMainAfterMerge(cwd, options) {
     };
   }
 }
-var GIT_TIMEOUT_MS2 = 30000, _internals7;
+var GIT_TIMEOUT_MS2 = 30000, _internals10;
 var init_branch = __esm(() => {
   init_logger();
-  _internals7 = {
+  _internals10 = {
     gitExec: gitExec2,
     detectDefaultRemoteBranch,
     getDefaultBaseBranch,
@@ -36194,33 +36967,33 @@ var init_event_bus = __esm(() => {
 // src/hooks/knowledge-store.ts
 import { existsSync as existsSync7 } from "fs";
 import { appendFile as appendFile2, mkdir as mkdir2, readFile as readFile3, writeFile as writeFile3 } from "fs/promises";
-import * as os3 from "os";
-import * as path10 from "path";
+import * as os6 from "os";
+import * as path11 from "path";
 function resolveSwarmKnowledgePath(directory) {
-  return path10.join(directory, ".swarm", "knowledge.jsonl");
+  return path11.join(directory, ".swarm", "knowledge.jsonl");
 }
 function resolveSwarmRejectedPath(directory) {
-  return path10.join(directory, ".swarm", "knowledge-rejected.jsonl");
+  return path11.join(directory, ".swarm", "knowledge-rejected.jsonl");
 }
 function resolveSwarmRetractionsPath(directory) {
-  return path10.join(directory, ".swarm", "knowledge-retractions.jsonl");
+  return path11.join(directory, ".swarm", "knowledge-retractions.jsonl");
 }
 function resolveHiveKnowledgePath() {
   const platform = process.platform;
-  const home = process.env.HOME || os3.homedir();
+  const home = process.env.HOME || os6.homedir();
   let dataDir;
   if (platform === "win32") {
-    dataDir = path10.join(process.env.LOCALAPPDATA || path10.join(home, "AppData", "Local"), "opencode-swarm", "Data");
+    dataDir = path11.join(process.env.LOCALAPPDATA || path11.join(home, "AppData", "Local"), "opencode-swarm", "Data");
   } else if (platform === "darwin") {
-    dataDir = path10.join(home, "Library", "Application Support", "opencode-swarm");
+    dataDir = path11.join(home, "Library", "Application Support", "opencode-swarm");
   } else {
-    dataDir = path10.join(process.env.XDG_DATA_HOME || path10.join(home, ".local", "share"), "opencode-swarm");
+    dataDir = path11.join(process.env.XDG_DATA_HOME || path11.join(home, ".local", "share"), "opencode-swarm");
   }
-  return path10.join(dataDir, "shared-learnings.jsonl");
+  return path11.join(dataDir, "shared-learnings.jsonl");
 }
 function resolveHiveRejectedPath() {
   const hivePath = resolveHiveKnowledgePath();
-  return path10.join(path10.dirname(hivePath), "shared-learnings-rejected.jsonl");
+  return path11.join(path11.dirname(hivePath), "shared-learnings-rejected.jsonl");
 }
 async function readKnowledge(filePath) {
   if (!existsSync7(filePath))
@@ -36310,12 +37083,12 @@ async function appendRetractionRecord(directory, record3) {
   await appendKnowledge(resolveSwarmRetractionsPath(directory), record3);
 }
 async function appendKnowledge(filePath, entry) {
-  await mkdir2(path10.dirname(filePath), { recursive: true });
+  await mkdir2(path11.dirname(filePath), { recursive: true });
   await appendFile2(filePath, `${JSON.stringify(entry)}
 `, "utf-8");
 }
 async function rewriteKnowledge(filePath, entries) {
-  const dir = path10.dirname(filePath);
+  const dir = path11.dirname(filePath);
   await mkdir2(dir, { recursive: true });
   let release = null;
   try {
@@ -36429,7 +37202,7 @@ var init_knowledge_store = __esm(() => {
 
 // src/hooks/knowledge-validator.ts
 import { appendFile as appendFile3, mkdir as mkdir3, writeFile as writeFile4 } from "fs/promises";
-import * as path11 from "path";
+import * as path12 from "path";
 function normalizeText(text) {
   return text.normalize("NFKC").toLowerCase().replace(/[^\w\s]/g, " ").replace(/\s+/g, " ").trim();
 }
@@ -36575,7 +37348,7 @@ function validateSkillPath(p) {
     return false;
   if (p.includes("\x00"))
     return false;
-  if (path11.isAbsolute(p))
+  if (path12.isAbsolute(p))
     return false;
   if (p.includes(".."))
     return false;
@@ -36597,10 +37370,10 @@ async function quarantineEntry(directory, entryId, reason, reportedBy) {
     return;
   }
   const sanitizedReason = reason.slice(0, 500).replace(/[\x00-\x08\x0b-\x0c\x0e-\x1f\x7f\x0d]/g, "");
-  const knowledgePath = path11.join(directory, ".swarm", "knowledge.jsonl");
-  const quarantinePath = path11.join(directory, ".swarm", "knowledge-quarantined.jsonl");
-  const rejectedPath = path11.join(directory, ".swarm", "knowledge-rejected.jsonl");
-  const swarmDir = path11.join(directory, ".swarm");
+  const knowledgePath = path12.join(directory, ".swarm", "knowledge.jsonl");
+  const quarantinePath = path12.join(directory, ".swarm", "knowledge-quarantined.jsonl");
+  const rejectedPath = path12.join(directory, ".swarm", "knowledge-rejected.jsonl");
+  const swarmDir = path12.join(directory, ".swarm");
   await mkdir3(swarmDir, { recursive: true });
   let release;
   try {
@@ -36659,10 +37432,10 @@ async function restoreEntry(directory, entryId) {
     warn("[knowledge-validator] restoreEntry: invalid entryId rejected");
     return;
   }
-  const knowledgePath = path11.join(directory, ".swarm", "knowledge.jsonl");
-  const quarantinePath = path11.join(directory, ".swarm", "knowledge-quarantined.jsonl");
-  const rejectedPath = path11.join(directory, ".swarm", "knowledge-rejected.jsonl");
-  const swarmDir = path11.join(directory, ".swarm");
+  const knowledgePath = path12.join(directory, ".swarm", "knowledge.jsonl");
+  const quarantinePath = path12.join(directory, ".swarm", "knowledge-quarantined.jsonl");
+  const rejectedPath = path12.join(directory, ".swarm", "knowledge-rejected.jsonl");
+  const swarmDir = path12.join(directory, ".swarm");
   await mkdir3(swarmDir, { recursive: true });
   let release;
   try {
@@ -36843,7 +37616,7 @@ var init_curator = __esm(() => {
 });
 
 // src/hooks/hive-promoter.ts
-import path12 from "path";
+import path13 from "path";
 function isAlreadyInHive(entry, hiveEntries, threshold) {
   return findNearDuplicate(entry.lesson, hiveEntries, threshold) !== undefined;
 }
@@ -37018,7 +37791,7 @@ async function promoteToHive(directory, lesson, category) {
     schema_version: 1,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
-    source_project: path12.basename(directory) || "unknown",
+    source_project: path13.basename(directory) || "unknown",
     encounter_score: 1
   };
   await appendKnowledge(resolveHiveKnowledgePath(), newHiveEntry);
@@ -37306,7 +38079,7 @@ async function curateAndStoreSwarm(lessons, projectName, phaseInfo, directory, c
     existingEntries.push(entry);
   }
   await enforceKnowledgeCap(knowledgePath, config3.swarm_max_entries);
-  await _internals8.runAutoPromotion(directory, config3);
+  await _internals11.runAutoPromotion(directory, config3);
   return { stored, skipped, rejected };
 }
 async function runAutoPromotion(directory, config3) {
@@ -37387,7 +38160,7 @@ function createKnowledgeCuratorHook(directory, config3) {
       });
       const projectName2 = evidenceData.project_name ?? "unknown";
       const phaseNumber2 = typeof evidenceData.phase_number === "number" ? evidenceData.phase_number : 1;
-      await _internals8.curateAndStoreSwarm(lessons, projectName2, { phase_number: phaseNumber2 }, directory, config3);
+      await _internals11.curateAndStoreSwarm(lessons, projectName2, { phase_number: phaseNumber2 }, directory, config3);
       return;
     }
     const planContent = await readSwarmFileAsync(directory, "plan.md");
@@ -37409,17 +38182,17 @@ function createKnowledgeCuratorHook(directory, config3) {
     const projectName = projectNameMatch ? projectNameMatch[1].trim() : "unknown";
     const phaseMatch = /^Phase:\s*(\d+)/m.exec(planContent);
     const phaseNumber = phaseMatch ? parseInt(phaseMatch[1], 10) : 1;
-    await _internals8.curateAndStoreSwarm(normalLessons, projectName, { phase_number: phaseNumber }, directory, config3);
+    await _internals11.curateAndStoreSwarm(normalLessons, projectName, { phase_number: phaseNumber }, directory, config3);
   };
   return safeHook(handler);
 }
-var seenRetroSections, _internals8;
+var seenRetroSections, _internals11;
 var init_knowledge_curator = __esm(() => {
   init_knowledge_store();
   init_knowledge_validator();
   init_utils2();
   seenRetroSections = new Map;
-  _internals8 = {
+  _internals11 = {
     isWriteToEvidenceFile,
     curateAndStoreSwarm,
     runAutoPromotion,
@@ -37539,7 +38312,7 @@ var init_skill_improver_llm_factory = __esm(() => {
 // src/services/skill-generator.ts
 import { existsSync as existsSync8 } from "fs";
 import { mkdir as mkdir4, readFile as readFile4, rename as rename3, writeFile as writeFile5 } from "fs/promises";
-import * as path13 from "path";
+import * as path14 from "path";
 function sanitizeSlug(input) {
   const lc = input.toLowerCase().trim();
   const mapped = lc.replace(/[^a-z0-9-]+/g, "-").replace(/-+/g, "-");
@@ -37550,10 +38323,10 @@ function isValidSlug(slug) {
   return SLUG_PATTERN.test(slug);
 }
 function proposalPath(directory, slug) {
-  return path13.join(directory, ".swarm", "skills", "proposals", `${slug}.md`);
+  return path14.join(directory, ".swarm", "skills", "proposals", `${slug}.md`);
 }
 function activePath(directory, slug) {
-  return path13.join(directory, ".opencode", "skills", "generated", slug, "SKILL.md");
+  return path14.join(directory, ".opencode", "skills", "generated", slug, "SKILL.md");
 }
 function activeRepoRelativePath(slug) {
   return `.opencode/skills/generated/${slug}/SKILL.md`;
@@ -37709,7 +38482,7 @@ function escapeMarkdown(s) {
   return s.replace(/[\r\n]+/g, " ").slice(0, 280);
 }
 async function atomicWrite(p, content) {
-  await mkdir4(path13.dirname(p), { recursive: true });
+  await mkdir4(path14.dirname(p), { recursive: true });
   const tmp = `${p}.tmp-${process.pid}-${Date.now()}`;
   await writeFile5(tmp, content, "utf-8");
   await rename3(tmp, p);
@@ -37754,7 +38527,7 @@ async function generateSkills(req) {
       continue;
     }
     const targetPath = req.mode === "active" ? activePath(req.directory, cluster.slug) : proposalPath(req.directory, cluster.slug);
-    const repoRel = path13.relative(req.directory, targetPath).replace(/\\/g, "/");
+    const repoRel = path14.relative(req.directory, targetPath).replace(/\\/g, "/");
     if (!validateSkillPath(repoRel)) {
       result.skipped.push({
         slug: cluster.slug,
@@ -37828,8 +38601,8 @@ async function listSkills(directory) {
     proposals: [],
     active: []
   };
-  const proposalsDir = path13.join(directory, ".swarm", "skills", "proposals");
-  const activeDir = path13.join(directory, ".opencode", "skills", "generated");
+  const proposalsDir = path14.join(directory, ".swarm", "skills", "proposals");
+  const activeDir = path14.join(directory, ".opencode", "skills", "generated");
   const fs7 = await import("fs/promises");
   if (existsSync8(proposalsDir)) {
     const entries = await fs7.readdir(proposalsDir);
@@ -37839,7 +38612,7 @@ async function listSkills(directory) {
       const slug = f.replace(/\.md$/, "");
       result.proposals.push({
         slug,
-        path: path13.join(proposalsDir, f)
+        path: path14.join(proposalsDir, f)
       });
     }
   }
@@ -37848,7 +38621,7 @@ async function listSkills(directory) {
     for (const e of entries) {
       if (!e.isDirectory())
         continue;
-      const skillPath = path13.join(activeDir, e.name, "SKILL.md");
+      const skillPath = path14.join(activeDir, e.name, "SKILL.md");
       if (existsSync8(skillPath)) {
         result.active.push({
           slug: e.name,
@@ -37870,7 +38643,7 @@ var init_skill_generator = __esm(() => {
 // src/services/skill-improver-quota.ts
 import { existsSync as existsSync9 } from "fs";
 import { mkdir as mkdir5, readFile as readFile5, rename as rename4, writeFile as writeFile6 } from "fs/promises";
-import * as path14 from "path";
+import * as path15 from "path";
 async function acquireLock(dir) {
   const acquire = import_proper_lockfile5.default.lock(dir, LOCK_RETRY_OPTS);
   let timer;
@@ -37888,7 +38661,7 @@ async function acquireLock(dir) {
   }
 }
 function resolveQuotaPath(directory) {
-  return path14.join(directory, ".swarm", "skill-improver-quota.json");
+  return path15.join(directory, ".swarm", "skill-improver-quota.json");
 }
 function todayKey(window, now = new Date) {
   if (window === "utc") {
@@ -37914,7 +38687,7 @@ async function readState(filePath) {
   }
 }
 async function writeState(filePath, state) {
-  await mkdir5(path14.dirname(filePath), { recursive: true });
+  await mkdir5(path15.dirname(filePath), { recursive: true });
   const tmp = `${filePath}.tmp-${process.pid}`;
   await writeFile6(tmp, JSON.stringify(state, null, 2), "utf-8");
   await rename4(tmp, filePath);
@@ -37937,10 +38710,10 @@ async function getQuotaState(directory, opts) {
 }
 async function reserveQuota(directory, opts) {
   const filePath = resolveQuotaPath(directory);
-  await mkdir5(path14.dirname(filePath), { recursive: true });
+  await mkdir5(path15.dirname(filePath), { recursive: true });
   let release = null;
   try {
-    release = await acquireLock(path14.dirname(filePath));
+    release = await acquireLock(path15.dirname(filePath));
     const state = await getQuotaState(directory, opts);
     if (state.calls_used + opts.nCalls > opts.maxCalls) {
       return {
@@ -37967,10 +38740,10 @@ async function reserveQuota(directory, opts) {
 }
 async function releaseQuota(directory, opts) {
   const filePath = resolveQuotaPath(directory);
-  await mkdir5(path14.dirname(filePath), { recursive: true });
+  await mkdir5(path15.dirname(filePath), { recursive: true });
   let release = null;
   try {
-    release = await acquireLock(path14.dirname(filePath));
+    release = await acquireLock(path15.dirname(filePath));
     const state = await getQuotaState(directory, opts);
     const next = {
       ...state,
@@ -38004,12 +38777,12 @@ var init_skill_improver_quota = __esm(() => {
 // src/services/skill-improver.ts
 import { existsSync as existsSync10 } from "fs";
 import { mkdir as mkdir6, rename as rename5, writeFile as writeFile7 } from "fs/promises";
-import * as path15 from "path";
+import * as path16 from "path";
 function timestampSlug(d) {
   return d.toISOString().replace(/[:.]/g, "-");
 }
 async function atomicWrite2(p, content) {
-  await mkdir6(path15.dirname(p), { recursive: true });
+  await mkdir6(path16.dirname(p), { recursive: true });
   const tmp = `${p}.tmp-${process.pid}-${Date.now()}`;
   await writeFile7(tmp, content, "utf-8");
   await rename5(tmp, p);
@@ -38290,8 +39063,8 @@ async function runSkillImprover(req) {
     }
     throw err;
   }
-  const proposalDir = path15.join(req.directory, ".swarm", "skill-improver", "proposals");
-  const proposalFile = path15.join(proposalDir, `${timestampSlug(now)}.md`);
+  const proposalDir = path16.join(req.directory, ".swarm", "skill-improver", "proposals");
+  const proposalFile = path16.join(proposalDir, `${timestampSlug(now)}.md`);
   const finalBody = source === "llm" ? buildLLMProposalFrame({
     body,
     targets,
@@ -38626,7 +39399,7 @@ async function executeWriteRetro(args, directory) {
     }, null, 2);
   }
 }
-var write_retro, _internals9;
+var write_retro, _internals12;
 var init_write_retro = __esm(() => {
   init_zod();
   init_evidence_schema();
@@ -38673,13 +39446,13 @@ var init_write_retro = __esm(() => {
           task_id: args.task_id !== undefined ? String(args.task_id) : undefined,
           metadata: args.metadata
         };
-        return await _internals9.executeWriteRetro(writeRetroArgs, directory);
+        return await _internals12.executeWriteRetro(writeRetroArgs, directory);
       } catch {
         return JSON.stringify({ success: false, phase: rawPhase, message: "Invalid arguments" }, null, 2);
       }
     }
   });
-  _internals9 = {
+  _internals12 = {
     executeWriteRetro,
     write_retro
   };
@@ -38687,7 +39460,7 @@ var init_write_retro = __esm(() => {
 
 // src/commands/close.ts
 import { promises as fs7 } from "fs";
-import path16 from "path";
+import path17 from "path";
 async function runAbortableSkillReview(req, timeoutMs) {
   const controller = new AbortController;
   let timeout;
@@ -38743,10 +39516,10 @@ function guaranteeAllPlansComplete(planData) {
 }
 async function handleCloseCommand(directory, args, options = {}) {
   const planPath = validateSwarmPath(directory, "plan.json");
-  const swarmDir = path16.join(directory, ".swarm");
+  const swarmDir = path17.join(directory, ".swarm");
   let planExists = false;
   let planData = {
-    title: path16.basename(directory) || "Ad-hoc session",
+    title: path17.basename(directory) || "Ad-hoc session",
     phases: []
   };
   try {
@@ -38855,7 +39628,7 @@ async function handleCloseCommand(directory, args, options = {}) {
       warnings.push(`Session retrospective write threw: ${retroError instanceof Error ? retroError.message : String(retroError)}`);
     }
   }
-  const lessonsFilePath = path16.join(swarmDir, "close-lessons.md");
+  const lessonsFilePath = path17.join(swarmDir, "close-lessons.md");
   let explicitLessons = [];
   try {
     const lessonsText = await fs7.readFile(lessonsFilePath, "utf-8");
@@ -38864,11 +39637,11 @@ async function handleCloseCommand(directory, args, options = {}) {
   } catch {}
   const retroLessons = [];
   try {
-    const evidenceDir = path16.join(swarmDir, "evidence");
+    const evidenceDir = path17.join(swarmDir, "evidence");
     const evidenceEntries = await fs7.readdir(evidenceDir);
     const retroDirs = evidenceEntries.filter((e) => e.startsWith("retro-")).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
     for (const retroDir of retroDirs) {
-      const evidencePath = path16.join(evidenceDir, retroDir, "evidence.json");
+      const evidencePath = path17.join(evidenceDir, retroDir, "evidence.json");
       try {
         const content = await fs7.readFile(evidencePath, "utf-8");
         const parsed = JSON.parse(content);
@@ -38993,7 +39766,7 @@ async function handleCloseCommand(directory, args, options = {}) {
   }
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const suffix = Math.random().toString(36).slice(2, 8);
-  const archiveDir = path16.join(swarmDir, "archive", `swarm-${timestamp}-${suffix}`);
+  const archiveDir = path17.join(swarmDir, "archive", `swarm-${timestamp}-${suffix}`);
   let archiveResult = "";
   let archivedFileCount = 0;
   const archivedActiveStateFiles = new Set;
@@ -39001,8 +39774,8 @@ async function handleCloseCommand(directory, args, options = {}) {
   try {
     await fs7.mkdir(archiveDir, { recursive: true });
     for (const artifact of ARCHIVE_ARTIFACTS) {
-      const srcPath = path16.join(swarmDir, artifact);
-      const destPath = path16.join(archiveDir, artifact);
+      const srcPath = path17.join(swarmDir, artifact);
+      const destPath = path17.join(archiveDir, artifact);
       try {
         await fs7.copyFile(srcPath, destPath);
         archivedFileCount++;
@@ -39012,22 +39785,22 @@ async function handleCloseCommand(directory, args, options = {}) {
       } catch {}
     }
     for (const dirName of ACTIVE_STATE_DIRS_TO_CLEAN) {
-      const srcDir = path16.join(swarmDir, dirName);
-      const destDir = path16.join(archiveDir, dirName);
+      const srcDir = path17.join(swarmDir, dirName);
+      const destDir = path17.join(archiveDir, dirName);
       try {
         const entries = await fs7.readdir(srcDir);
         if (entries.length > 0) {
           await fs7.mkdir(destDir, { recursive: true });
           for (const entry of entries) {
-            const srcEntry = path16.join(srcDir, entry);
-            const destEntry = path16.join(destDir, entry);
+            const srcEntry = path17.join(srcDir, entry);
+            const destEntry = path17.join(destDir, entry);
             try {
               const stat2 = await fs7.stat(srcEntry);
               if (stat2.isDirectory()) {
                 await fs7.mkdir(destEntry, { recursive: true });
                 const subEntries = await fs7.readdir(srcEntry);
                 for (const sub of subEntries) {
-                  await fs7.copyFile(path16.join(srcEntry, sub), path16.join(destEntry, sub)).catch(() => {});
+                  await fs7.copyFile(path17.join(srcEntry, sub), path17.join(destEntry, sub)).catch(() => {});
                 }
               } else {
                 await fs7.copyFile(srcEntry, destEntry);
@@ -39059,7 +39832,7 @@ async function handleCloseCommand(directory, args, options = {}) {
         warnings.push(`Preserved ${artifact} because it was not successfully archived.`);
         continue;
       }
-      const filePath = path16.join(swarmDir, artifact);
+      const filePath = path17.join(swarmDir, artifact);
       try {
         await fs7.unlink(filePath);
         cleanedFiles.push(artifact);
@@ -39072,7 +39845,7 @@ async function handleCloseCommand(directory, args, options = {}) {
     if (!archivedActiveStateDirs.has(dirName)) {
       continue;
     }
-    const dirPath = path16.join(swarmDir, dirName);
+    const dirPath = path17.join(swarmDir, dirName);
     try {
       await fs7.rm(dirPath, { recursive: true, force: true });
       cleanedFiles.push(`${dirName}/`);
@@ -39083,23 +39856,23 @@ async function handleCloseCommand(directory, args, options = {}) {
     const configBackups = swarmFiles.filter((f) => f.startsWith("config-backup-") && f.endsWith(".json"));
     for (const backup of configBackups) {
       try {
-        await fs7.unlink(path16.join(swarmDir, backup));
+        await fs7.unlink(path17.join(swarmDir, backup));
         configBackupsRemoved++;
       } catch {}
     }
     const ledgerSiblings = swarmFiles.filter((f) => (f.startsWith("plan-ledger.archived-") || f.startsWith("plan-ledger.backup-")) && f.endsWith(".jsonl"));
     for (const sibling of ledgerSiblings) {
       try {
-        await fs7.unlink(path16.join(swarmDir, sibling));
+        await fs7.unlink(path17.join(swarmDir, sibling));
       } catch {}
     }
   } catch {}
   let swarmPlanFilesRemoved = 0;
   const candidates = [
-    path16.join(directory, ".swarm", "SWARM_PLAN.json"),
-    path16.join(directory, ".swarm", "SWARM_PLAN.md"),
-    path16.join(directory, "SWARM_PLAN.json"),
-    path16.join(directory, "SWARM_PLAN.md")
+    path17.join(directory, ".swarm", "SWARM_PLAN.json"),
+    path17.join(directory, ".swarm", "SWARM_PLAN.md"),
+    path17.join(directory, "SWARM_PLAN.json"),
+    path17.join(directory, "SWARM_PLAN.md")
   ];
   for (const candidate of candidates) {
     try {
@@ -39107,12 +39880,12 @@ async function handleCloseCommand(directory, args, options = {}) {
       swarmPlanFilesRemoved++;
     } catch (err) {
       if (err?.code !== "ENOENT") {
-        warnings.push(`Failed to remove ${path16.basename(candidate)}: ${err instanceof Error ? err.message : String(err)}`);
+        warnings.push(`Failed to remove ${path17.basename(candidate)}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   }
   clearAllScopes(directory);
-  const contextPath = path16.join(swarmDir, "context.md");
+  const contextPath = path17.join(swarmDir, "context.md");
   const contextContent = [
     "# Context",
     "",
@@ -39330,15 +40103,15 @@ var init_close = __esm(() => {
 });
 
 // src/commands/config.ts
-import * as os4 from "os";
-import * as path17 from "path";
+import * as os7 from "os";
+import * as path18 from "path";
 function getUserConfigDir2() {
-  return process.env.XDG_CONFIG_HOME || path17.join(os4.homedir(), ".config");
+  return process.env.XDG_CONFIG_HOME || path18.join(os7.homedir(), ".config");
 }
 async function handleConfigCommand(directory, _args) {
   const config3 = loadPluginConfig(directory);
-  const userConfigPath = path17.join(getUserConfigDir2(), "opencode", "opencode-swarm.json");
-  const projectConfigPath = path17.join(directory, ".opencode", "opencode-swarm.json");
+  const userConfigPath = path18.join(getUserConfigDir2(), "opencode", "opencode-swarm.json");
+  const projectConfigPath = path18.join(directory, ".opencode", "opencode-swarm.json");
   const lines = [
     "## Swarm Configuration",
     "",
@@ -39465,7 +40238,7 @@ var init_curate = __esm(() => {
 import * as child_process3 from "child_process";
 import { randomUUID } from "crypto";
 import { readdir, readFile as readFile6, stat as stat2 } from "fs/promises";
-import * as path18 from "path";
+import * as path19 from "path";
 import { promisify } from "util";
 function getExecFileAsync() {
   return promisify(child_process3.execFile);
@@ -39567,7 +40340,7 @@ async function scanSourceFiles(dir) {
   try {
     const entries = await readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
-      const fullPath = path18.join(dir, entry.name);
+      const fullPath = path19.join(dir, entry.name);
       if (entry.isDirectory()) {
         if (skipDirs.has(entry.name)) {
           continue;
@@ -39575,7 +40348,7 @@ async function scanSourceFiles(dir) {
         const subFiles = await scanSourceFiles(fullPath);
         results.push(...subFiles);
       } else if (entry.isFile()) {
-        const ext = path18.extname(entry.name);
+        const ext = path19.extname(entry.name);
         if ([".ts", ".tsx", ".js", ".jsx", ".mjs"].includes(ext)) {
           results.push(fullPath);
         }
@@ -39597,8 +40370,8 @@ async function getStaticEdges(directory) {
           continue;
         }
         try {
-          const sourceDir = path18.dirname(sourceFile);
-          const resolvedPath = path18.resolve(sourceDir, importPath);
+          const sourceDir = path19.dirname(sourceFile);
+          const resolvedPath = path19.resolve(sourceDir, importPath);
           const extensions = [
             "",
             ".ts",
@@ -39623,8 +40396,8 @@ async function getStaticEdges(directory) {
           if (!targetFile) {
             continue;
           }
-          const relSource = path18.relative(directory, sourceFile).replace(/\\/g, "/");
-          const relTarget = path18.relative(directory, targetFile).replace(/\\/g, "/");
+          const relSource = path19.relative(directory, sourceFile).replace(/\\/g, "/");
+          const relTarget = path19.relative(directory, targetFile).replace(/\\/g, "/");
           const [key] = relSource < relTarget ? [`${relSource}::${relTarget}`, relSource, relTarget] : [`${relTarget}::${relSource}`, relTarget, relSource];
           edges.add(key);
         } catch {}
@@ -39636,7 +40409,7 @@ async function getStaticEdges(directory) {
 function isTestImplementationPair(fileA, fileB) {
   const testPatterns = [".test.ts", ".test.js", ".spec.ts", ".spec.js"];
   const getBaseName = (filePath) => {
-    const base = path18.basename(filePath);
+    const base = path19.basename(filePath);
     for (const pattern of testPatterns) {
       if (base.endsWith(pattern)) {
         return base.slice(0, -pattern.length);
@@ -39646,16 +40419,16 @@ function isTestImplementationPair(fileA, fileB) {
   };
   const baseA = getBaseName(fileA);
   const baseB = getBaseName(fileB);
-  return baseA === baseB && baseA !== path18.basename(fileA) && baseA !== path18.basename(fileB);
+  return baseA === baseB && baseA !== path19.basename(fileA) && baseA !== path19.basename(fileB);
 }
 function hasSharedPrefix(fileA, fileB) {
-  const dirA = path18.dirname(fileA);
-  const dirB = path18.dirname(fileB);
+  const dirA = path19.dirname(fileA);
+  const dirB = path19.dirname(fileB);
   if (dirA !== dirB) {
     return false;
   }
-  const baseA = path18.basename(fileA).replace(/\.(ts|js|tsx|jsx|mjs)$/, "");
-  const baseB = path18.basename(fileB).replace(/\.(ts|js|tsx|jsx|mjs)$/, "");
+  const baseA = path19.basename(fileA).replace(/\.(ts|js|tsx|jsx|mjs)$/, "");
+  const baseB = path19.basename(fileB).replace(/\.(ts|js|tsx|jsx|mjs)$/, "");
   if (baseA.startsWith(baseB) || baseB.startsWith(baseA)) {
     return true;
   }
@@ -39683,9 +40456,9 @@ async function detectDarkMatter(directory, options) {
   } catch {
     return [];
   }
-  const commitMap = await _internals10.parseGitLog(directory, maxCommitsToAnalyze);
-  const matrix = _internals10.buildCoChangeMatrix(commitMap);
-  const staticEdges = await _internals10.getStaticEdges(directory);
+  const commitMap = await _internals13.parseGitLog(directory, maxCommitsToAnalyze);
+  const matrix = _internals13.buildCoChangeMatrix(commitMap);
+  const staticEdges = await _internals13.getStaticEdges(directory);
   const results = [];
   for (const entry of matrix.values()) {
     const key = `${entry.fileA}::${entry.fileB}`;
@@ -39709,8 +40482,8 @@ function darkMatterToKnowledgeEntries(pairs, projectName) {
   const entries = [];
   const now = new Date().toISOString();
   for (const pair of pairs.slice(0, 10)) {
-    const baseA = path18.basename(pair.fileA);
-    const baseB = path18.basename(pair.fileB);
+    const baseA = path19.basename(pair.fileA);
+    const baseB = path19.basename(pair.fileB);
     let lesson = `Files ${pair.fileA} and ${pair.fileB} co-change with NPMI=${pair.npmi.toFixed(3)} but have no import relationship. This hidden coupling suggests a shared architectural concern \u2014 changes to one likely require changes to the other.`;
     if (lesson.length > 280) {
       lesson = `Files ${baseA} and ${baseB} co-change with NPMI=${pair.npmi.toFixed(3)} but have no import relationship. This hidden coupling suggests a shared architectural concern \u2014 changes to one likely require changes to the other.`;
@@ -39765,7 +40538,7 @@ ${rows}
 These pairs likely share an architectural concern invisible to static analysis.
 Consider adding explicit documentation or extracting the shared concern.`;
 }
-var co_change_analyzer, _internals10;
+var co_change_analyzer, _internals13;
 var init_co_change_analyzer = __esm(() => {
   init_zod();
   init_create_tool();
@@ -39797,11 +40570,11 @@ var init_co_change_analyzer = __esm(() => {
         npmiThreshold,
         maxCommitsToAnalyze
       };
-      const pairs = await _internals10.detectDarkMatter(directory, options);
-      return _internals10.formatDarkMatterOutput(pairs);
+      const pairs = await _internals13.detectDarkMatter(directory, options);
+      return _internals13.formatDarkMatterOutput(pairs);
     }
   });
-  _internals10 = {
+  _internals13 = {
     parseGitLog,
     buildCoChangeMatrix,
     getStaticEdges,
@@ -39812,7 +40585,7 @@ var init_co_change_analyzer = __esm(() => {
 });
 
 // src/commands/dark-matter.ts
-import path19 from "path";
+import path20 from "path";
 async function handleDarkMatterCommand(directory, args) {
   const options = {};
   for (let i = 0;i < args.length; i++) {
@@ -39832,7 +40605,7 @@ async function handleDarkMatterCommand(directory, args) {
   }
   let pairs;
   try {
-    pairs = await _internals10.detectDarkMatter(directory, options);
+    pairs = await _internals13.detectDarkMatter(directory, options);
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     return `## Dark Matter Analysis Failed
@@ -39844,7 +40617,7 @@ Ensure this is a git repository with commit history.`;
   const output = formatDarkMatterOutput(pairs);
   if (pairs.length > 0) {
     try {
-      const projectName = path19.basename(path19.resolve(directory));
+      const projectName = path20.basename(path20.resolve(directory));
       const entries = darkMatterToKnowledgeEntries(pairs, projectName);
       if (entries.length > 0) {
         const knowledgePath = resolveSwarmKnowledgePath(directory);
@@ -39980,68 +40753,68 @@ var init_deep_dive = __esm(() => {
 });
 
 // src/config/cache-paths.ts
-import * as os5 from "os";
-import * as path20 from "path";
+import * as os8 from "os";
+import * as path21 from "path";
 function getPluginConfigDir() {
-  return path20.join(process.env.XDG_CONFIG_HOME || path20.join(os5.homedir(), ".config"), "opencode");
+  return path21.join(process.env.XDG_CONFIG_HOME || path21.join(os8.homedir(), ".config"), "opencode");
 }
 function getPluginCachePaths() {
-  const cacheBase = process.env.XDG_CACHE_HOME || path20.join(os5.homedir(), ".cache");
+  const cacheBase = process.env.XDG_CACHE_HOME || path21.join(os8.homedir(), ".cache");
   const configDir = getPluginConfigDir();
   const paths = [
-    path20.join(cacheBase, "opencode", "node_modules", "opencode-swarm"),
-    path20.join(cacheBase, "opencode", "packages", "opencode-swarm@latest"),
-    path20.join(configDir, "node_modules", "opencode-swarm")
+    path21.join(cacheBase, "opencode", "node_modules", "opencode-swarm"),
+    path21.join(cacheBase, "opencode", "packages", "opencode-swarm@latest"),
+    path21.join(configDir, "node_modules", "opencode-swarm")
   ];
   if (process.platform === "darwin") {
-    const libCaches = path20.join(os5.homedir(), "Library", "Caches");
-    paths.push(path20.join(libCaches, "opencode", "node_modules", "opencode-swarm"), path20.join(libCaches, "opencode", "packages", "opencode-swarm@latest"));
+    const libCaches = path21.join(os8.homedir(), "Library", "Caches");
+    paths.push(path21.join(libCaches, "opencode", "node_modules", "opencode-swarm"), path21.join(libCaches, "opencode", "packages", "opencode-swarm@latest"));
   }
   if (process.platform === "win32") {
-    const localAppData = process.env.LOCALAPPDATA || path20.join(os5.homedir(), "AppData", "Local");
-    const appData = process.env.APPDATA || path20.join(os5.homedir(), "AppData", "Roaming");
-    paths.push(path20.join(localAppData, "opencode", "node_modules", "opencode-swarm"), path20.join(localAppData, "opencode", "packages", "opencode-swarm@latest"), path20.join(appData, "opencode", "node_modules", "opencode-swarm"));
+    const localAppData = process.env.LOCALAPPDATA || path21.join(os8.homedir(), "AppData", "Local");
+    const appData = process.env.APPDATA || path21.join(os8.homedir(), "AppData", "Roaming");
+    paths.push(path21.join(localAppData, "opencode", "node_modules", "opencode-swarm"), path21.join(localAppData, "opencode", "packages", "opencode-swarm@latest"), path21.join(appData, "opencode", "node_modules", "opencode-swarm"));
   }
   return paths;
 }
 function getPluginLockFilePaths() {
-  const cacheBase = process.env.XDG_CACHE_HOME || path20.join(os5.homedir(), ".cache");
+  const cacheBase = process.env.XDG_CACHE_HOME || path21.join(os8.homedir(), ".cache");
   const configDir = getPluginConfigDir();
   const paths = [
-    path20.join(cacheBase, "opencode", "bun.lock"),
-    path20.join(cacheBase, "opencode", "bun.lockb"),
-    path20.join(configDir, "package-lock.json")
+    path21.join(cacheBase, "opencode", "bun.lock"),
+    path21.join(cacheBase, "opencode", "bun.lockb"),
+    path21.join(configDir, "package-lock.json")
   ];
   if (process.platform === "darwin") {
-    const libCaches = path20.join(os5.homedir(), "Library", "Caches");
-    paths.push(path20.join(libCaches, "opencode", "bun.lock"), path20.join(libCaches, "opencode", "bun.lockb"));
+    const libCaches = path21.join(os8.homedir(), "Library", "Caches");
+    paths.push(path21.join(libCaches, "opencode", "bun.lock"), path21.join(libCaches, "opencode", "bun.lockb"));
   }
   if (process.platform === "win32") {
-    const localAppData = process.env.LOCALAPPDATA || path20.join(os5.homedir(), "AppData", "Local");
-    paths.push(path20.join(localAppData, "opencode", "bun.lock"), path20.join(localAppData, "opencode", "bun.lockb"));
+    const localAppData = process.env.LOCALAPPDATA || path21.join(os8.homedir(), "AppData", "Local");
+    paths.push(path21.join(localAppData, "opencode", "bun.lock"), path21.join(localAppData, "opencode", "bun.lockb"));
   }
   return paths;
 }
 var init_cache_paths = () => {};
 
 // src/services/version-check.ts
-import { existsSync as existsSync11, mkdirSync as mkdirSync7, readFileSync as readFileSync6, writeFileSync as writeFileSync4 } from "fs";
+import { existsSync as existsSync11, mkdirSync as mkdirSync7, readFileSync as readFileSync6, writeFileSync as writeFileSync5 } from "fs";
 import { homedir as homedir5 } from "os";
-import { join as join19 } from "path";
+import { join as join20 } from "path";
 function cacheDir() {
   const xdg = process.env.XDG_CACHE_HOME;
-  const base = xdg && xdg.length > 0 ? xdg : join19(homedir5(), ".cache");
-  return join19(base, "opencode-swarm");
+  const base = xdg && xdg.length > 0 ? xdg : join20(homedir5(), ".cache");
+  return join20(base, "opencode-swarm");
 }
 function cacheFile() {
-  return join19(cacheDir(), "version-check.json");
+  return join20(cacheDir(), "version-check.json");
 }
 function readVersionCache() {
   try {
-    const path21 = cacheFile();
-    if (!existsSync11(path21))
+    const path22 = cacheFile();
+    if (!existsSync11(path22))
       return null;
-    const raw = readFileSync6(path21, "utf-8");
+    const raw = readFileSync6(path22, "utf-8");
     const parsed = JSON.parse(raw);
     if (typeof parsed?.checkedAt !== "number")
       return null;
@@ -40081,7 +40854,7 @@ var init_version_check = __esm(() => {
 // src/services/diagnose-service.ts
 import * as child_process4 from "child_process";
 import { existsSync as existsSync12, readdirSync as readdirSync4, readFileSync as readFileSync7, statSync as statSync6 } from "fs";
-import path21 from "path";
+import path22 from "path";
 import { fileURLToPath } from "url";
 function validateTaskDag(plan) {
   const allTaskIds = new Set;
@@ -40378,7 +41151,7 @@ async function checkSpecStaleness(directory, plan) {
   };
 }
 async function checkConfigParseability(directory) {
-  const configPath = path21.join(directory, ".opencode/opencode-swarm.json");
+  const configPath = path22.join(directory, ".opencode/opencode-swarm.json");
   if (!existsSync12(configPath)) {
     return {
       name: "Config Parseability",
@@ -40407,7 +41180,7 @@ function resolveGrammarDir(thisDir) {
   const normalized = thisDir.replace(/\\/g, "/");
   const isSource = normalized.endsWith("/src/services");
   const isCliBundle = normalized.endsWith("/cli");
-  return isSource || isCliBundle ? path21.join(thisDir, "..", "lang", "grammars") : path21.join(thisDir, "lang", "grammars");
+  return isSource || isCliBundle ? path22.join(thisDir, "..", "lang", "grammars") : path22.join(thisDir, "lang", "grammars");
 }
 async function checkGrammarWasmFiles() {
   const grammarFiles = [
@@ -40431,14 +41204,14 @@ async function checkGrammarWasmFiles() {
     "tree-sitter-ini.wasm",
     "tree-sitter-regex.wasm"
   ];
-  const thisDir = path21.dirname(fileURLToPath(import.meta.url));
+  const thisDir = path22.dirname(fileURLToPath(import.meta.url));
   const grammarDir = resolveGrammarDir(thisDir);
   const missing = [];
-  if (!existsSync12(path21.join(grammarDir, "tree-sitter.wasm"))) {
+  if (!existsSync12(path22.join(grammarDir, "tree-sitter.wasm"))) {
     missing.push("tree-sitter.wasm (core runtime)");
   }
   for (const file3 of grammarFiles) {
-    if (!existsSync12(path21.join(grammarDir, file3))) {
+    if (!existsSync12(path22.join(grammarDir, file3))) {
       missing.push(file3);
     }
   }
@@ -40456,7 +41229,7 @@ async function checkGrammarWasmFiles() {
   };
 }
 async function checkCheckpointManifest(directory) {
-  const manifestPath = path21.join(directory, ".swarm/checkpoints.json");
+  const manifestPath = path22.join(directory, ".swarm/checkpoints.json");
   if (!existsSync12(manifestPath)) {
     return {
       name: "Checkpoint Manifest",
@@ -40508,7 +41281,7 @@ async function checkCheckpointManifest(directory) {
   }
 }
 async function checkEventStreamIntegrity(directory) {
-  const eventsPath = path21.join(directory, ".swarm/events.jsonl");
+  const eventsPath = path22.join(directory, ".swarm/events.jsonl");
   if (!existsSync12(eventsPath)) {
     return {
       name: "Event Stream",
@@ -40549,7 +41322,7 @@ async function checkEventStreamIntegrity(directory) {
   }
 }
 async function checkSteeringDirectives(directory) {
-  const eventsPath = path21.join(directory, ".swarm/events.jsonl");
+  const eventsPath = path22.join(directory, ".swarm/events.jsonl");
   if (!existsSync12(eventsPath)) {
     return {
       name: "Steering Directives",
@@ -40605,7 +41378,7 @@ async function checkCurator(directory) {
         detail: "Disabled (enable via curator.enabled)"
       };
     }
-    const summaryPath = path21.join(directory, ".swarm/curator-summary.json");
+    const summaryPath = path22.join(directory, ".swarm/curator-summary.json");
     if (!existsSync12(summaryPath)) {
       return {
         name: "Curator",
@@ -40771,7 +41544,7 @@ async function getDiagnoseData(directory) {
   checks5.push(await checkSteeringDirectives(directory));
   checks5.push(await checkCurator(directory));
   try {
-    const evidenceDir = path21.join(directory, ".swarm", "evidence");
+    const evidenceDir = path22.join(directory, ".swarm", "evidence");
     const snapshotFiles = existsSync12(evidenceDir) ? readdirSync4(evidenceDir).filter((f) => f.startsWith("agent-tools-") && f.endsWith(".json")) : [];
     if (snapshotFiles.length > 0) {
       const latest = snapshotFiles.sort().pop();
@@ -40809,7 +41582,7 @@ async function getDiagnoseData(directory) {
         cacheRows.push(`\u2B1C ${cachePath} \u2014 absent`);
         continue;
       }
-      const pkgJsonPath = path21.join(cachePath, "package.json");
+      const pkgJsonPath = path22.join(cachePath, "package.json");
       try {
         const raw = readFileSync7(pkgJsonPath, "utf-8");
         const parsed = JSON.parse(raw);
@@ -40898,14 +41671,14 @@ __export(exports_config_doctor, {
 });
 import * as crypto3 from "crypto";
 import * as fs8 from "fs";
-import * as os6 from "os";
-import * as path22 from "path";
+import * as os9 from "os";
+import * as path23 from "path";
 function getUserConfigDir3() {
-  return process.env.XDG_CONFIG_HOME || path22.join(os6.homedir(), ".config");
+  return process.env.XDG_CONFIG_HOME || path23.join(os9.homedir(), ".config");
 }
 function getConfigPaths(directory) {
-  const userConfigPath = path22.join(getUserConfigDir3(), "opencode", "opencode-swarm.json");
-  const projectConfigPath = path22.join(directory, ".opencode", "opencode-swarm.json");
+  const userConfigPath = path23.join(getUserConfigDir3(), "opencode", "opencode-swarm.json");
+  const projectConfigPath = path23.join(directory, ".opencode", "opencode-swarm.json");
   return { userConfigPath, projectConfigPath };
 }
 function computeHash(content) {
@@ -40930,9 +41703,9 @@ function isValidConfigPath(configPath, directory) {
   const normalizedUser = userConfigPath.replace(/\\/g, "/");
   const normalizedProject = projectConfigPath.replace(/\\/g, "/");
   try {
-    const resolvedConfig = path22.resolve(configPath);
-    const resolvedUser = path22.resolve(normalizedUser);
-    const resolvedProject = path22.resolve(normalizedProject);
+    const resolvedConfig = path23.resolve(configPath);
+    const resolvedUser = path23.resolve(normalizedUser);
+    const resolvedProject = path23.resolve(normalizedProject);
     return resolvedConfig === resolvedUser || resolvedConfig === resolvedProject;
   } catch {
     return false;
@@ -40972,12 +41745,12 @@ function createConfigBackup(directory) {
   };
 }
 function writeBackupArtifact(directory, backup) {
-  const swarmDir = path22.join(directory, ".swarm");
+  const swarmDir = path23.join(directory, ".swarm");
   if (!fs8.existsSync(swarmDir)) {
     fs8.mkdirSync(swarmDir, { recursive: true });
   }
   const backupFilename = `config-backup-${backup.createdAt}.json`;
-  const backupPath = path22.join(swarmDir, backupFilename);
+  const backupPath = path23.join(swarmDir, backupFilename);
   const artifact = {
     createdAt: backup.createdAt,
     configPath: backup.configPath,
@@ -41007,7 +41780,7 @@ function restoreFromBackup(backupPath, directory) {
       return null;
     }
     const targetPath = artifact.configPath;
-    const targetDir = path22.dirname(targetPath);
+    const targetDir = path23.dirname(targetPath);
     if (!fs8.existsSync(targetDir)) {
       fs8.mkdirSync(targetDir, { recursive: true });
     }
@@ -41038,9 +41811,9 @@ function readConfigFromFile(directory) {
     return null;
   }
 }
-function validateConfigKey(path23, value, _config) {
+function validateConfigKey(path24, value, _config) {
   const findings = [];
-  switch (path23) {
+  switch (path24) {
     case "agents": {
       if (value !== undefined) {
         findings.push({
@@ -41277,27 +42050,27 @@ function validateConfigKey(path23, value, _config) {
   }
   return findings;
 }
-function walkConfigAndValidate(obj, path23, config3, findings) {
+function walkConfigAndValidate(obj, path24, config3, findings) {
   if (obj === null || obj === undefined) {
     return;
   }
-  if (path23 && typeof obj === "object" && !Array.isArray(obj)) {
-    const keyFindings = validateConfigKey(path23, obj, config3);
+  if (path24 && typeof obj === "object" && !Array.isArray(obj)) {
+    const keyFindings = validateConfigKey(path24, obj, config3);
     findings.push(...keyFindings);
   }
   if (typeof obj !== "object") {
-    const keyFindings = validateConfigKey(path23, obj, config3);
+    const keyFindings = validateConfigKey(path24, obj, config3);
     findings.push(...keyFindings);
     return;
   }
   if (Array.isArray(obj)) {
     obj.forEach((item, index) => {
-      walkConfigAndValidate(item, `${path23}[${index}]`, config3, findings);
+      walkConfigAndValidate(item, `${path24}[${index}]`, config3, findings);
     });
     return;
   }
   for (const [key, value] of Object.entries(obj)) {
-    const newPath = path23 ? `${path23}.${key}` : key;
+    const newPath = path24 ? `${path24}.${key}` : key;
     walkConfigAndValidate(value, newPath, config3, findings);
   }
 }
@@ -41417,7 +42190,7 @@ function applySafeAutoFixes(directory, result) {
     }
   }
   if (appliedFixes.length > 0) {
-    const configDir = path22.dirname(configPath);
+    const configDir = path23.dirname(configPath);
     if (!fs8.existsSync(configDir)) {
       fs8.mkdirSync(configDir, { recursive: true });
     }
@@ -41427,12 +42200,12 @@ function applySafeAutoFixes(directory, result) {
   return { appliedFixes, updatedConfigPath };
 }
 function writeDoctorArtifact(directory, result) {
-  const swarmDir = path22.join(directory, ".swarm");
+  const swarmDir = path23.join(directory, ".swarm");
   if (!fs8.existsSync(swarmDir)) {
     fs8.mkdirSync(swarmDir, { recursive: true });
   }
   const artifactFilename = "config-doctor.json";
-  const artifactPath = path22.join(swarmDir, artifactFilename);
+  const artifactPath = path23.join(swarmDir, artifactFilename);
   const guiOutput = {
     timestamp: result.timestamp,
     summary: result.summary,
@@ -41528,17 +42301,17 @@ function detectStraySwarmDirs(projectRoot) {
       if (!entry.isDirectory())
         continue;
       const name = entry.name;
-      const fullPath = path22.join(dir, name);
+      const fullPath = path23.join(dir, name);
       if (SKIP_DIRS.has(name))
         continue;
-      const gitPath = path22.join(fullPath, ".git");
+      const gitPath = path23.join(fullPath, ".git");
       try {
         const gitStat = fs8.statSync(gitPath);
         if (gitStat.isFile() || gitStat.isDirectory())
           continue;
       } catch {}
       if (name === ".swarm") {
-        const parentDir = path22.dirname(fullPath);
+        const parentDir = path23.dirname(fullPath);
         if (parentDir === projectRoot)
           continue;
         let contents = [];
@@ -41548,7 +42321,7 @@ function detectStraySwarmDirs(projectRoot) {
           contents = ["<unreadable>"];
         }
         findings.push({
-          path: path22.relative(projectRoot, fullPath).replace(/\\/g, "/"),
+          path: path23.relative(projectRoot, fullPath).replace(/\\/g, "/"),
           absolutePath: fullPath,
           contents: contents.slice(0, MAX_CONTENTS_ENTRIES),
           totalEntries: contents.length
@@ -41566,21 +42339,21 @@ function removeStraySwarmDir(projectRoot, strayPath) {
   let canonicalStray;
   try {
     canonicalRoot = fs8.realpathSync(projectRoot);
-    canonicalStray = fs8.realpathSync(path22.isAbsolute(strayPath) ? strayPath : path22.resolve(projectRoot, strayPath));
+    canonicalStray = fs8.realpathSync(path23.isAbsolute(strayPath) ? strayPath : path23.resolve(projectRoot, strayPath));
   } catch (err) {
     return {
       success: false,
       message: `Failed to resolve paths: ${err instanceof Error ? err.message : String(err)}`
     };
   }
-  const rootSwarm = path22.join(canonicalRoot, ".swarm");
+  const rootSwarm = path23.join(canonicalRoot, ".swarm");
   if (canonicalStray === rootSwarm || canonicalStray === canonicalRoot) {
     return {
       success: false,
       message: "Refusing to remove root .swarm/ directory"
     };
   }
-  if (!canonicalStray.startsWith(canonicalRoot + path22.sep)) {
+  if (!canonicalStray.startsWith(canonicalRoot + path23.sep)) {
     return {
       success: false,
       message: "Path is outside project root \u2014 refusing to remove"
@@ -42669,7 +43442,7 @@ var init_profiles = __esm(() => {
 
 // src/lang/detector.ts
 import { access as access3, readdir as readdir2 } from "fs/promises";
-import { extname as extname2, join as join21 } from "path";
+import { extname as extname2, join as join22 } from "path";
 async function detectProjectLanguages(projectDir) {
   const detected = new Set;
   async function scanDir(dir) {
@@ -42685,7 +43458,7 @@ async function detectProjectLanguages(projectDir) {
         if (detectFile.includes("*") || detectFile.includes("?"))
           continue;
         try {
-          await access3(join21(dir, detectFile));
+          await access3(join22(dir, detectFile));
           detected.add(profile.id);
           break;
         } catch {}
@@ -42706,7 +43479,7 @@ async function detectProjectLanguages(projectDir) {
     const topEntries = await readdir2(projectDir, { withFileTypes: true });
     for (const entry of topEntries) {
       if (entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules") {
-        await scanDir(join21(projectDir, entry.name));
+        await scanDir(join22(projectDir, entry.name));
       }
     }
   } catch {}
@@ -42725,7 +43498,7 @@ var init_detector = __esm(() => {
 
 // src/build/discovery.ts
 import * as fs9 from "fs";
-import * as path23 from "path";
+import * as path24 from "path";
 function isCommandAvailable(command) {
   if (toolchainCache.has(command)) {
     return toolchainCache.get(command);
@@ -42733,7 +43506,7 @@ function isCommandAvailable(command) {
   const isWindows = process.platform === "win32";
   const cmd = isWindows ? `${command}.exe` : command;
   try {
-    const result = _internals11.spawnSyncImpl(isWindows ? ["where", cmd] : ["which", cmd], {
+    const result = _internals14.spawnSyncImpl(isWindows ? ["where", cmd] : ["which", cmd], {
       cwd: process.cwd(),
       stdin: "ignore",
       stdout: "ignore",
@@ -42760,11 +43533,11 @@ function findBuildFiles(workingDir, patterns) {
         const regex = simpleGlobToRegex(pattern);
         const matches = files.filter((f) => regex.test(f));
         if (matches.length > 0) {
-          return path23.join(dir, matches[0]);
+          return path24.join(dir, matches[0]);
         }
       } catch {}
     } else {
-      const filePath = path23.join(workingDir, pattern);
+      const filePath = path24.join(workingDir, pattern);
       if (fs9.existsSync(filePath)) {
         return filePath;
       }
@@ -42773,7 +43546,7 @@ function findBuildFiles(workingDir, patterns) {
   return null;
 }
 function getRepoDefinedScripts(workingDir, scripts) {
-  const packageJsonPath = path23.join(workingDir, "package.json");
+  const packageJsonPath = path24.join(workingDir, "package.json");
   if (!fs9.existsSync(packageJsonPath)) {
     return [];
   }
@@ -42814,7 +43587,7 @@ function findAllBuildFiles(workingDir) {
         const regex = simpleGlobToRegex(pattern);
         findFilesRecursive(workingDir, regex, allBuildFiles);
       } else {
-        const filePath = path23.join(workingDir, pattern);
+        const filePath = path24.join(workingDir, pattern);
         if (fs9.existsSync(filePath)) {
           allBuildFiles.add(filePath);
         }
@@ -42827,7 +43600,7 @@ function findFilesRecursive(dir, regex, results) {
   try {
     const entries = fs9.readdirSync(dir, { withFileTypes: true });
     for (const entry of entries) {
-      const fullPath = path23.join(dir, entry.name);
+      const fullPath = path24.join(dir, entry.name);
       if (entry.isDirectory() && !["node_modules", ".git", "dist", "build", "target"].includes(entry.name)) {
         findFilesRecursive(fullPath, regex, results);
       } else if (entry.isFile() && regex.test(entry.name)) {
@@ -42850,7 +43623,7 @@ async function discoverBuildCommandsFromProfiles(workingDir) {
     let foundCommand = false;
     for (const cmd of sortedCommands) {
       if (cmd.detectFile) {
-        const detectFilePath = path23.join(workingDir, cmd.detectFile);
+        const detectFilePath = path24.join(workingDir, cmd.detectFile);
         if (!fs9.existsSync(detectFilePath)) {
           continue;
         }
@@ -42883,7 +43656,7 @@ async function discoverBuildCommands(workingDir, options) {
   const scope = options?.scope ?? "all";
   const changedFiles = options?.changedFiles ?? [];
   const _filesToCheck = filterByScope(workingDir, scope, changedFiles);
-  const profileResult = await _internals11.discoverBuildCommandsFromProfiles(workingDir);
+  const profileResult = await _internals14.discoverBuildCommandsFromProfiles(workingDir);
   const profileCommands = profileResult.commands;
   const profileSkipped = profileResult.skipped;
   const coveredEcosystems = new Set;
@@ -42946,7 +43719,7 @@ function clearToolchainCache() {
 function getEcosystems() {
   return ECOSYSTEMS.map((e) => e.ecosystem);
 }
-var ECOSYSTEMS, PROFILE_TO_ECOSYSTEM_NAMES, toolchainCache, IS_COMMAND_AVAILABLE_TIMEOUT_MS = 3000, _internals11, build_discovery;
+var ECOSYSTEMS, PROFILE_TO_ECOSYSTEM_NAMES, toolchainCache, IS_COMMAND_AVAILABLE_TIMEOUT_MS = 3000, _internals14, build_discovery;
 var init_discovery = __esm(() => {
   init_dist();
   init_detector();
@@ -43064,7 +43837,7 @@ var init_discovery = __esm(() => {
     php: ["php-composer"]
   };
   toolchainCache = new Map;
-  _internals11 = {
+  _internals14 = {
     isCommandAvailable,
     discoverBuildCommandsFromProfiles,
     discoverBuildCommands,
@@ -43091,7 +43864,7 @@ var init_discovery = __esm(() => {
 
 // src/services/tool-doctor.ts
 import * as fs10 from "fs";
-import * as path24 from "path";
+import * as path25 from "path";
 function extractRegisteredToolKeys(indexPath) {
   const registeredKeys = new Set;
   try {
@@ -43146,8 +43919,8 @@ function checkBinaryReadiness() {
 }
 function runToolDoctor(_directory, pluginRoot) {
   const findings = [];
-  const resolvedPluginRoot = pluginRoot ?? path24.resolve(import.meta.dir, "..", "..");
-  const indexPath = path24.join(resolvedPluginRoot, "src", "index.ts");
+  const resolvedPluginRoot = pluginRoot ?? path25.resolve(import.meta.dir, "..", "..");
+  const indexPath = path25.join(resolvedPluginRoot, "src", "index.ts");
   if (!fs10.existsSync(indexPath)) {
     return {
       findings: [
@@ -43367,7 +44140,7 @@ var exports_evidence_summary_service = {};
 __export(exports_evidence_summary_service, {
   isAutoSummaryEnabled: () => isAutoSummaryEnabled,
   buildEvidenceSummary: () => buildEvidenceSummary,
-  _internals: () => _internals12,
+  _internals: () => _internals15,
   REQUIRED_EVIDENCE_TYPES: () => REQUIRED_EVIDENCE_TYPES,
   EVIDENCE_SUMMARY_VERSION: () => EVIDENCE_SUMMARY_VERSION
 });
@@ -43405,14 +44178,14 @@ function getTaskStatus(task, bundle) {
   if (task?.status) {
     return task.status;
   }
-  const entries = _internals12.normalizeBundleEntries(bundle);
+  const entries = _internals15.normalizeBundleEntries(bundle);
   if (entries.length > 0) {
     return "completed";
   }
   return "pending";
 }
 function isEvidenceComplete(bundle) {
-  const entries = _internals12.normalizeBundleEntries(bundle);
+  const entries = _internals15.normalizeBundleEntries(bundle);
   if (entries.length === 0) {
     return {
       isComplete: false,
@@ -43448,10 +44221,10 @@ async function buildTaskSummary(directory, task, taskId) {
   const result = await loadEvidence(directory, taskId);
   const bundle = result.status === "found" ? result.bundle : null;
   const phase = task?.phase ?? 0;
-  const status = _internals12.getTaskStatus(task, bundle);
-  const evidenceCheck = _internals12.isEvidenceComplete(bundle);
-  const blockers = _internals12.getTaskBlockers(task, evidenceCheck, status);
-  const entries = _internals12.normalizeBundleEntries(bundle);
+  const status = _internals15.getTaskStatus(task, bundle);
+  const evidenceCheck = _internals15.isEvidenceComplete(bundle);
+  const blockers = _internals15.getTaskBlockers(task, evidenceCheck, status);
+  const entries = _internals15.normalizeBundleEntries(bundle);
   const hasReview = entries.some((e) => e.type === "review");
   const hasTest = entries.some((e) => e.type === "test");
   const hasApproval = entries.some((e) => e.type === "approval");
@@ -43480,12 +44253,12 @@ async function buildPhaseSummary(directory, phase) {
   const taskSummaries = [];
   const _taskMap = new Map(phase.tasks.map((t) => [t.id, t]));
   for (const task of phase.tasks) {
-    const summary = await _internals12.buildTaskSummary(directory, task, task.id);
+    const summary = await _internals15.buildTaskSummary(directory, task, task.id);
     taskSummaries.push(summary);
   }
   const extraTaskIds = taskIds.filter((id) => !phaseTaskIds.has(id));
   for (const taskId of extraTaskIds) {
-    const summary = await _internals12.buildTaskSummary(directory, undefined, taskId);
+    const summary = await _internals15.buildTaskSummary(directory, undefined, taskId);
     if (summary.phase === phase.id) {
       taskSummaries.push(summary);
     }
@@ -43586,7 +44359,7 @@ async function buildEvidenceSummary(directory, currentPhase) {
   let totalTasks = 0;
   let completedTasks = 0;
   for (const phase of phasesToProcess) {
-    const summary = await _internals12.buildPhaseSummary(directory, phase);
+    const summary = await _internals15.buildPhaseSummary(directory, phase);
     phaseSummaries.push(summary);
     totalTasks += summary.totalTasks;
     completedTasks += summary.completedTasks;
@@ -43608,7 +44381,7 @@ async function buildEvidenceSummary(directory, currentPhase) {
     overallBlockers,
     summaryText: ""
   };
-  artifact.summaryText = _internals12.generateSummaryText(artifact);
+  artifact.summaryText = _internals15.generateSummaryText(artifact);
   log("[EvidenceSummary] Summary built", {
     phases: phaseSummaries.length,
     totalTasks,
@@ -43627,7 +44400,7 @@ function isAutoSummaryEnabled(automationConfig) {
   }
   return automationConfig.capabilities?.evidence_auto_summaries === true;
 }
-var VALID_EVIDENCE_TYPES2, REQUIRED_EVIDENCE_TYPES, EVIDENCE_SUMMARY_VERSION = "1.0.0", _internals12;
+var VALID_EVIDENCE_TYPES2, REQUIRED_EVIDENCE_TYPES, EVIDENCE_SUMMARY_VERSION = "1.0.0", _internals15;
 var init_evidence_summary_service = __esm(() => {
   init_manager2();
   init_manager();
@@ -43641,7 +44414,7 @@ var init_evidence_summary_service = __esm(() => {
     "retrospective"
   ]);
   REQUIRED_EVIDENCE_TYPES = ["review", "test"];
-  _internals12 = {
+  _internals15 = {
     buildEvidenceSummary,
     isAutoSummaryEnabled,
     normalizeBundleEntries,
@@ -43696,7 +44469,7 @@ function getVerdictEmoji(verdict) {
   return getVerdictIcon(verdict);
 }
 async function getTaskEvidenceData(directory, taskId) {
-  const result = await _internals13.loadEvidence(directory, taskId);
+  const result = await _internals16.loadEvidence(directory, taskId);
   if (result.status !== "found") {
     return {
       hasEvidence: false,
@@ -43719,13 +44492,13 @@ async function getTaskEvidenceData(directory, taskId) {
   };
 }
 async function getEvidenceListData(directory) {
-  const taskIds = await _internals13.listEvidenceTaskIds(directory);
+  const taskIds = await _internals16.listEvidenceTaskIds(directory);
   if (taskIds.length === 0) {
     return { hasEvidence: false, tasks: [] };
   }
   const tasks = [];
   for (const taskId of taskIds) {
-    const result = await _internals13.loadEvidence(directory, taskId);
+    const result = await _internals16.loadEvidence(directory, taskId);
     if (result.status === "found") {
       tasks.push({
         taskId,
@@ -43839,10 +44612,10 @@ async function handleEvidenceSummaryCommand(directory) {
   return lines.join(`
 `);
 }
-var _internals13;
+var _internals16;
 var init_evidence_service = __esm(() => {
   init_manager2();
-  _internals13 = {
+  _internals16 = {
     loadEvidence,
     listEvidenceTaskIds
   };
@@ -43893,12 +44666,12 @@ var init_export = __esm(() => {
 
 // src/full-auto/state.ts
 import * as fs11 from "fs";
-import * as path25 from "path";
+import * as path26 from "path";
 function nowISO() {
   return new Date().toISOString();
 }
 function ensureSwarmDir(directory) {
-  const swarmDir = path25.resolve(directory, ".swarm");
+  const swarmDir = path26.resolve(directory, ".swarm");
   if (!fs11.existsSync(swarmDir)) {
     fs11.mkdirSync(swarmDir, { recursive: true });
   }
@@ -44249,7 +45022,7 @@ function extractCurrentPhaseFromPlan2(plan) {
   if (!plan) {
     return { currentPhase: null, currentTask: null, incompleteTasks: [] };
   }
-  if (!_internals14.validatePlanPhases(plan)) {
+  if (!_internals17.validatePlanPhases(plan)) {
     return { currentPhase: null, currentTask: null, incompleteTasks: [] };
   }
   let currentPhase = null;
@@ -44391,9 +45164,9 @@ function extractPhaseMetrics(content) {
 async function getHandoffData(directory) {
   const now = new Date().toISOString();
   const sessionContent = await readSwarmFileAsync(directory, "session/state.json");
-  const sessionState = _internals14.parseSessionState(sessionContent);
+  const sessionState = _internals17.parseSessionState(sessionContent);
   const plan = await loadPlanJsonOnly(directory);
-  const planInfo = _internals14.extractCurrentPhaseFromPlan(plan);
+  const planInfo = _internals17.extractCurrentPhaseFromPlan(plan);
   if (!plan) {
     const planMdContent = await readSwarmFileAsync(directory, "plan.md");
     if (planMdContent) {
@@ -44412,8 +45185,8 @@ async function getHandoffData(directory) {
     }
   }
   const contextContent = await readSwarmFileAsync(directory, "context.md");
-  const recentDecisions = _internals14.extractDecisions(contextContent);
-  const rawPhaseMetrics = _internals14.extractPhaseMetrics(contextContent);
+  const recentDecisions = _internals17.extractDecisions(contextContent);
+  const rawPhaseMetrics = _internals17.extractPhaseMetrics(contextContent);
   const phaseMetrics = sanitizeString(rawPhaseMetrics, 1000);
   let delegationState = null;
   if (sessionState?.delegationState) {
@@ -44577,13 +45350,13 @@ ${lines.join(`
 `)}
 \`\`\``;
 }
-var RTL_OVERRIDE_PATTERN, MAX_TASK_ID_LENGTH = 100, MAX_DECISION_LENGTH = 500, MAX_INCOMPLETE_TASKS = 20, _internals14;
+var RTL_OVERRIDE_PATTERN, MAX_TASK_ID_LENGTH = 100, MAX_DECISION_LENGTH = 500, MAX_INCOMPLETE_TASKS = 20, _internals17;
 var init_handoff_service = __esm(() => {
   init_utils2();
   init_manager();
   init_utils();
   RTL_OVERRIDE_PATTERN = /[\u202e\u202d\u202c\u200f]/g;
-  _internals14 = {
+  _internals17 = {
     getHandoffData,
     formatHandoffMarkdown,
     formatContinuationPrompt,
@@ -44599,7 +45372,7 @@ var init_handoff_service = __esm(() => {
 
 // src/session/snapshot-writer.ts
 import { closeSync as closeSync3, fsyncSync as fsyncSync2, mkdirSync as mkdirSync10, openSync as openSync3, renameSync as renameSync6 } from "fs";
-import * as path26 from "path";
+import * as path27 from "path";
 function serializeAgentSession(s) {
   const gateLog = {};
   const rawGateLog = s.gateLog ?? new Map;
@@ -44696,7 +45469,7 @@ async function writeSnapshot(directory, state) {
     }
     const content = JSON.stringify(snapshot, null, 2);
     const resolvedPath = validateSwarmPath(directory, "session/state.json");
-    const dir = path26.dirname(resolvedPath);
+    const dir = path27.dirname(resolvedPath);
     mkdirSync10(dir, { recursive: true });
     const tempPath = `${resolvedPath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2)}`;
     await bunWrite(tempPath, content);
@@ -44717,22 +45490,22 @@ async function writeSnapshot(directory, state) {
 }
 function createSnapshotWriterHook(directory) {
   return (_input, _output) => {
-    _writeInFlight = _writeInFlight.then(() => _internals15.writeSnapshot(directory, swarmState), () => _internals15.writeSnapshot(directory, swarmState));
+    _writeInFlight = _writeInFlight.then(() => _internals18.writeSnapshot(directory, swarmState), () => _internals18.writeSnapshot(directory, swarmState));
     return _writeInFlight;
   };
 }
 async function flushPendingSnapshot(directory) {
-  _writeInFlight = _writeInFlight.then(() => _internals15.writeSnapshot(directory, swarmState), () => _internals15.writeSnapshot(directory, swarmState));
+  _writeInFlight = _writeInFlight.then(() => _internals18.writeSnapshot(directory, swarmState), () => _internals18.writeSnapshot(directory, swarmState));
   await _writeInFlight;
 }
-var _writeInFlight, _internals15;
+var _writeInFlight, _internals18;
 var init_snapshot_writer = __esm(() => {
   init_utils2();
   init_state();
   init_utils();
   init_bun_compat();
   _writeInFlight = Promise.resolve();
-  _internals15 = {
+  _internals18 = {
     writeSnapshot,
     createSnapshotWriterHook,
     flushPendingSnapshot
@@ -45155,7 +45928,7 @@ var init_issue = __esm(() => {
 import { randomUUID as randomUUID2 } from "crypto";
 import { existsSync as existsSync17, readFileSync as readFileSync12 } from "fs";
 import { mkdir as mkdir7, readFile as readFile7, writeFile as writeFile8 } from "fs/promises";
-import * as path27 from "path";
+import * as path28 from "path";
 async function migrateKnowledgeToExternal(_directory, _config) {
   return {
     migrated: false,
@@ -45166,8 +45939,8 @@ async function migrateKnowledgeToExternal(_directory, _config) {
   };
 }
 async function migrateContextToKnowledge(directory, config3) {
-  const sentinelPath = path27.join(directory, ".swarm", ".knowledge-migrated");
-  const contextPath = path27.join(directory, ".swarm", "context.md");
+  const sentinelPath = path28.join(directory, ".swarm", ".knowledge-migrated");
+  const contextPath = path28.join(directory, ".swarm", "context.md");
   const knowledgePath = resolveSwarmKnowledgePath(directory);
   if (existsSync17(sentinelPath)) {
     return {
@@ -45197,9 +45970,9 @@ async function migrateContextToKnowledge(directory, config3) {
       skippedReason: "empty-context"
     };
   }
-  const rawEntries = _internals16.parseContextMd(contextContent);
+  const rawEntries = _internals19.parseContextMd(contextContent);
   if (rawEntries.length === 0) {
-    await _internals16.writeSentinel(sentinelPath, 0, 0);
+    await _internals19.writeSentinel(sentinelPath, 0, 0);
     return {
       migrated: true,
       entriesMigrated: 0,
@@ -45210,10 +45983,10 @@ async function migrateContextToKnowledge(directory, config3) {
   const existing = await readKnowledge(knowledgePath);
   let migrated = 0;
   let dropped = 0;
-  const projectName = _internals16.inferProjectName(directory);
+  const projectName = _internals19.inferProjectName(directory);
   for (const raw of rawEntries) {
     if (config3.validation_enabled !== false) {
-      const category = raw.categoryHint ?? _internals16.inferCategoryFromText(raw.text);
+      const category = raw.categoryHint ?? _internals19.inferCategoryFromText(raw.text);
       const result = validateLesson(raw.text, existing.map((e) => e.lesson), {
         category,
         scope: "global",
@@ -45233,8 +46006,8 @@ async function migrateContextToKnowledge(directory, config3) {
     const entry = {
       id: randomUUID2(),
       tier: "swarm",
-      lesson: _internals16.truncateLesson(raw.text),
-      category: raw.categoryHint ?? _internals16.inferCategoryFromText(raw.text),
+      lesson: _internals19.truncateLesson(raw.text),
+      category: raw.categoryHint ?? _internals19.inferCategoryFromText(raw.text),
       tags: [...inferredTags, `migration:${raw.sourceSection}`],
       scope: "global",
       confidence: 0.3,
@@ -45257,7 +46030,7 @@ async function migrateContextToKnowledge(directory, config3) {
   if (migrated > 0) {
     await rewriteKnowledge(knowledgePath, existing);
   }
-  await _internals16.writeSentinel(sentinelPath, migrated, dropped);
+  await _internals19.writeSentinel(sentinelPath, migrated, dropped);
   log(`[knowledge-migrator] Migrated ${migrated} entries, dropped ${dropped}`);
   return {
     migrated: true,
@@ -45267,7 +46040,7 @@ async function migrateContextToKnowledge(directory, config3) {
   };
 }
 function parseContextMd(content) {
-  const sections = _internals16.splitIntoSections(content);
+  const sections = _internals19.splitIntoSections(content);
   const entries = [];
   const seen = new Set;
   const sectionPatterns = [
@@ -45283,7 +46056,7 @@ function parseContextMd(content) {
     const match = sectionPatterns.find((sp) => sp.pattern.test(section.heading));
     if (!match)
       continue;
-    const bullets = _internals16.extractBullets(section.body);
+    const bullets = _internals19.extractBullets(section.body);
     for (const bullet of bullets) {
       if (bullet.length < 15)
         continue;
@@ -45292,9 +46065,9 @@ function parseContextMd(content) {
         continue;
       seen.add(normalized);
       entries.push({
-        text: _internals16.truncateLesson(bullet),
+        text: _internals19.truncateLesson(bullet),
         sourceSection: match.sourceSection,
-        categoryHint: _internals16.inferCategoryFromText(bullet)
+        categoryHint: _internals19.inferCategoryFromText(bullet)
       });
     }
   }
@@ -45363,7 +46136,7 @@ function truncateLesson(text) {
   return `${text.slice(0, 277)}...`;
 }
 function inferProjectName(directory) {
-  const packageJsonPath = path27.join(directory, "package.json");
+  const packageJsonPath = path28.join(directory, "package.json");
   if (existsSync17(packageJsonPath)) {
     try {
       const pkg = JSON.parse(readFileSync12(packageJsonPath, "utf-8"));
@@ -45372,7 +46145,7 @@ function inferProjectName(directory) {
       }
     } catch {}
   }
-  return path27.basename(directory);
+  return path28.basename(directory);
 }
 async function writeSentinel(sentinelPath, migrated, dropped) {
   const sentinel = {
@@ -45384,15 +46157,15 @@ async function writeSentinel(sentinelPath, migrated, dropped) {
     schema_version: 1,
     migration_tool: "knowledge-migrator.ts"
   };
-  await mkdir7(path27.dirname(sentinelPath), { recursive: true });
+  await mkdir7(path28.dirname(sentinelPath), { recursive: true });
   await writeFile8(sentinelPath, JSON.stringify(sentinel, null, 2), "utf-8");
 }
-var _internals16;
+var _internals19;
 var init_knowledge_migrator = __esm(() => {
   init_logger();
   init_knowledge_store();
   init_knowledge_validator();
-  _internals16 = {
+  _internals19 = {
     migrateContextToKnowledge,
     migrateKnowledgeToExternal,
     parseContextMd,
@@ -45406,7 +46179,7 @@ var init_knowledge_migrator = __esm(() => {
 });
 
 // src/commands/knowledge.ts
-import { join as join25 } from "path";
+import { join as join26 } from "path";
 function resolveEntryByPrefix(entries, inputId) {
   const exact = entries.find((e) => e.id === inputId);
   if (exact)
@@ -45457,7 +46230,7 @@ async function handleKnowledgeRestoreCommand(directory, args) {
     return "Invalid entry ID. IDs must be 1-64 characters: letters, digits, hyphens, underscores only.";
   }
   try {
-    const quarantinePath = join25(directory, ".swarm", "knowledge-quarantined.jsonl");
+    const quarantinePath = join26(directory, ".swarm", "knowledge-quarantined.jsonl");
     const entries = await readKnowledge(quarantinePath);
     const resolved = resolveEntryByPrefix(entries, inputId);
     if ("error" in resolved) {
@@ -45529,9 +46302,9 @@ var init_knowledge = __esm(() => {
 
 // src/services/plan-service.ts
 async function getPlanData(directory, phaseArg) {
-  const plan = await _internals17.loadPlanJsonOnly(directory);
+  const plan = await _internals20.loadPlanJsonOnly(directory);
   if (plan) {
-    const fullMarkdown = _internals17.derivePlanMarkdown(plan);
+    const fullMarkdown = _internals20.derivePlanMarkdown(plan);
     if (phaseArg === undefined || phaseArg === null || phaseArg === "") {
       return {
         hasPlan: true,
@@ -45574,7 +46347,7 @@ async function getPlanData(directory, phaseArg) {
       isLegacy: false
     };
   }
-  const planContent = await _internals17.readSwarmFileAsync(directory, "plan.md");
+  const planContent = await _internals20.readSwarmFileAsync(directory, "plan.md");
   if (!planContent) {
     return {
       hasPlan: false,
@@ -45670,11 +46443,11 @@ async function handlePlanCommand(directory, args) {
   const planData = await getPlanData(directory, phaseArg);
   return formatPlanMarkdown(planData);
 }
-var _internals17;
+var _internals20;
 var init_plan_service = __esm(() => {
   init_utils2();
   init_manager();
-  _internals17 = {
+  _internals20 = {
     loadPlanJsonOnly,
     derivePlanMarkdown,
     readSwarmFileAsync
@@ -45912,7 +46685,7 @@ var init_path_security = () => {};
 
 // src/tools/lint.ts
 import * as fs12 from "fs";
-import * as path28 from "path";
+import * as path29 from "path";
 function validateArgs(args) {
   if (typeof args !== "object" || args === null)
     return false;
@@ -45923,9 +46696,9 @@ function validateArgs(args) {
 }
 function getLinterCommand(linter, mode, projectDir) {
   const isWindows = process.platform === "win32";
-  const binDir = path28.join(projectDir, "node_modules", ".bin");
-  const biomeBin = isWindows ? path28.join(binDir, "biome.EXE") : path28.join(binDir, "biome");
-  const eslintBin = isWindows ? path28.join(binDir, "eslint.cmd") : path28.join(binDir, "eslint");
+  const binDir = path29.join(projectDir, "node_modules", ".bin");
+  const biomeBin = isWindows ? path29.join(binDir, "biome.EXE") : path29.join(binDir, "biome");
+  const eslintBin = isWindows ? path29.join(binDir, "eslint.cmd") : path29.join(binDir, "eslint");
   switch (linter) {
     case "biome":
       if (mode === "fix") {
@@ -45941,7 +46714,7 @@ function getLinterCommand(linter, mode, projectDir) {
 }
 function getAdditionalLinterCommand(linter, mode, cwd) {
   const gradlewName = process.platform === "win32" ? "gradlew.bat" : "gradlew";
-  const gradlew = fs12.existsSync(path28.join(cwd, gradlewName)) ? path28.join(cwd, gradlewName) : null;
+  const gradlew = fs12.existsSync(path29.join(cwd, gradlewName)) ? path29.join(cwd, gradlewName) : null;
   switch (linter) {
     case "ruff":
       return mode === "fix" ? ["ruff", "check", "--fix", "."] : ["ruff", "check", "."];
@@ -45975,10 +46748,10 @@ function getAdditionalLinterCommand(linter, mode, cwd) {
   }
 }
 function detectRuff(cwd) {
-  if (fs12.existsSync(path28.join(cwd, "ruff.toml")))
+  if (fs12.existsSync(path29.join(cwd, "ruff.toml")))
     return isCommandAvailable("ruff");
   try {
-    const pyproject = path28.join(cwd, "pyproject.toml");
+    const pyproject = path29.join(cwd, "pyproject.toml");
     if (fs12.existsSync(pyproject)) {
       const content = fs12.readFileSync(pyproject, "utf-8");
       if (content.includes("[tool.ruff]"))
@@ -45988,19 +46761,19 @@ function detectRuff(cwd) {
   return false;
 }
 function detectClippy(cwd) {
-  return fs12.existsSync(path28.join(cwd, "Cargo.toml")) && isCommandAvailable("cargo");
+  return fs12.existsSync(path29.join(cwd, "Cargo.toml")) && isCommandAvailable("cargo");
 }
 function detectGolangciLint(cwd) {
-  return fs12.existsSync(path28.join(cwd, "go.mod")) && isCommandAvailable("golangci-lint");
+  return fs12.existsSync(path29.join(cwd, "go.mod")) && isCommandAvailable("golangci-lint");
 }
 function detectCheckstyle(cwd) {
-  const hasMaven = fs12.existsSync(path28.join(cwd, "pom.xml"));
-  const hasGradle = fs12.existsSync(path28.join(cwd, "build.gradle")) || fs12.existsSync(path28.join(cwd, "build.gradle.kts"));
-  const hasBinary = hasMaven && isCommandAvailable("mvn") || hasGradle && (fs12.existsSync(path28.join(cwd, "gradlew")) || isCommandAvailable("gradle"));
+  const hasMaven = fs12.existsSync(path29.join(cwd, "pom.xml"));
+  const hasGradle = fs12.existsSync(path29.join(cwd, "build.gradle")) || fs12.existsSync(path29.join(cwd, "build.gradle.kts"));
+  const hasBinary = hasMaven && isCommandAvailable("mvn") || hasGradle && (fs12.existsSync(path29.join(cwd, "gradlew")) || isCommandAvailable("gradle"));
   return (hasMaven || hasGradle) && hasBinary;
 }
 function detectKtlint(cwd) {
-  const hasKotlin = fs12.existsSync(path28.join(cwd, "build.gradle.kts")) || fs12.existsSync(path28.join(cwd, "build.gradle")) || (() => {
+  const hasKotlin = fs12.existsSync(path29.join(cwd, "build.gradle.kts")) || fs12.existsSync(path29.join(cwd, "build.gradle")) || (() => {
     try {
       return fs12.readdirSync(cwd).some((f) => f.endsWith(".kt") || f.endsWith(".kts"));
     } catch {
@@ -46019,11 +46792,11 @@ function detectDotnetFormat(cwd) {
   }
 }
 function detectCppcheck(cwd) {
-  if (fs12.existsSync(path28.join(cwd, "CMakeLists.txt"))) {
+  if (fs12.existsSync(path29.join(cwd, "CMakeLists.txt"))) {
     return isCommandAvailable("cppcheck");
   }
   try {
-    const dirsToCheck = [cwd, path28.join(cwd, "src")];
+    const dirsToCheck = [cwd, path29.join(cwd, "src")];
     const hasCpp = dirsToCheck.some((dir) => {
       try {
         return fs12.readdirSync(dir).some((f) => /\.(c|cpp|cc|cxx|h|hpp)$/.test(f));
@@ -46037,13 +46810,13 @@ function detectCppcheck(cwd) {
   }
 }
 function detectSwiftlint(cwd) {
-  return fs12.existsSync(path28.join(cwd, "Package.swift")) && isCommandAvailable("swiftlint");
+  return fs12.existsSync(path29.join(cwd, "Package.swift")) && isCommandAvailable("swiftlint");
 }
 function detectDartAnalyze(cwd) {
-  return fs12.existsSync(path28.join(cwd, "pubspec.yaml")) && (isCommandAvailable("dart") || isCommandAvailable("flutter"));
+  return fs12.existsSync(path29.join(cwd, "pubspec.yaml")) && (isCommandAvailable("dart") || isCommandAvailable("flutter"));
 }
 function detectRubocop(cwd) {
-  return (fs12.existsSync(path28.join(cwd, "Gemfile")) || fs12.existsSync(path28.join(cwd, "gems.rb")) || fs12.existsSync(path28.join(cwd, ".rubocop.yml"))) && (isCommandAvailable("rubocop") || isCommandAvailable("bundle"));
+  return (fs12.existsSync(path29.join(cwd, "Gemfile")) || fs12.existsSync(path29.join(cwd, "gems.rb")) || fs12.existsSync(path29.join(cwd, ".rubocop.yml"))) && (isCommandAvailable("rubocop") || isCommandAvailable("bundle"));
 }
 function detectAdditionalLinter(cwd) {
   if (detectRuff(cwd))
@@ -46071,10 +46844,10 @@ function detectAdditionalLinter(cwd) {
 function findBinInAncestors(startDir, binName) {
   let dir = startDir;
   while (true) {
-    const candidate = path28.join(dir, "node_modules", ".bin", binName);
+    const candidate = path29.join(dir, "node_modules", ".bin", binName);
     if (fs12.existsSync(candidate))
       return candidate;
-    const parent = path28.dirname(dir);
+    const parent = path29.dirname(dir);
     if (parent === dir)
       break;
     dir = parent;
@@ -46083,10 +46856,10 @@ function findBinInAncestors(startDir, binName) {
 }
 function findBinInEnvPath(binName) {
   const searchPath = process.env.PATH ?? "";
-  for (const dir of searchPath.split(path28.delimiter)) {
+  for (const dir of searchPath.split(path29.delimiter)) {
     if (!dir)
       continue;
-    const candidate = path28.join(dir, binName);
+    const candidate = path29.join(dir, binName);
     if (fs12.existsSync(candidate))
       return candidate;
   }
@@ -46099,13 +46872,13 @@ async function detectAvailableLinter(directory) {
     return null;
   const projectDir = directory;
   const isWindows = process.platform === "win32";
-  const biomeBin = isWindows ? path28.join(projectDir, "node_modules", ".bin", "biome.EXE") : path28.join(projectDir, "node_modules", ".bin", "biome");
-  const eslintBin = isWindows ? path28.join(projectDir, "node_modules", ".bin", "eslint.cmd") : path28.join(projectDir, "node_modules", ".bin", "eslint");
+  const biomeBin = isWindows ? path29.join(projectDir, "node_modules", ".bin", "biome.EXE") : path29.join(projectDir, "node_modules", ".bin", "biome");
+  const eslintBin = isWindows ? path29.join(projectDir, "node_modules", ".bin", "eslint.cmd") : path29.join(projectDir, "node_modules", ".bin", "eslint");
   const localResult = await _detectAvailableLinter(projectDir, biomeBin, eslintBin);
   if (localResult)
     return localResult;
-  const biomeAncestor = findBinInAncestors(path28.dirname(projectDir), isWindows ? "biome.EXE" : "biome");
-  const eslintAncestor = findBinInAncestors(path28.dirname(projectDir), isWindows ? "eslint.cmd" : "eslint");
+  const biomeAncestor = findBinInAncestors(path29.dirname(projectDir), isWindows ? "biome.EXE" : "biome");
+  const eslintAncestor = findBinInAncestors(path29.dirname(projectDir), isWindows ? "eslint.cmd" : "eslint");
   if (biomeAncestor || eslintAncestor) {
     return _detectAvailableLinter(projectDir, biomeAncestor ?? biomeBin, eslintAncestor ?? eslintBin);
   }
@@ -46264,7 +47037,7 @@ async function runAdditionalLint(linter, mode, cwd) {
     };
   }
 }
-var MAX_OUTPUT_BYTES = 512000, MAX_COMMAND_LENGTH = 500, lint, _internals18;
+var MAX_OUTPUT_BYTES = 512000, MAX_COMMAND_LENGTH = 500, lint, _internals21;
 var init_lint = __esm(() => {
   init_zod();
   init_discovery();
@@ -46296,15 +47069,15 @@ var init_lint = __esm(() => {
       }
       const { mode } = args;
       const cwd = directory;
-      const linter = await _internals18.detectAvailableLinter(directory);
+      const linter = await _internals21.detectAvailableLinter(directory);
       if (linter) {
-        const result = await _internals18.runLint(linter, mode, directory);
+        const result = await _internals21.runLint(linter, mode, directory);
         return JSON.stringify(result, null, 2);
       }
-      const additionalLinter = _internals18.detectAdditionalLinter(cwd);
+      const additionalLinter = _internals21.detectAdditionalLinter(cwd);
       if (additionalLinter) {
         warn(`[lint] Using ${additionalLinter} linter for this project`);
-        const result = await _internals18.runAdditionalLint(additionalLinter, mode, cwd);
+        const result = await _internals21.runAdditionalLint(additionalLinter, mode, cwd);
         return JSON.stringify(result, null, 2);
       }
       const errorResult = {
@@ -46318,7 +47091,7 @@ For Rust: rustup component add clippy`
       return JSON.stringify(errorResult, null, 2);
     }
   });
-  _internals18 = {
+  _internals21 = {
     detectAvailableLinter,
     runLint,
     detectAdditionalLinter,
@@ -46328,7 +47101,7 @@ For Rust: rustup component add clippy`
 
 // src/tools/secretscan.ts
 import * as fs13 from "fs";
-import * as path29 from "path";
+import * as path30 from "path";
 function calculateShannonEntropy(str) {
   if (str.length === 0)
     return 0;
@@ -46376,7 +47149,7 @@ function isGlobOrPathPattern(pattern) {
   return pattern.includes("/") || pattern.includes("\\") || /[*?[\]{}]/.test(pattern);
 }
 function loadSecretScanIgnore(scanDir) {
-  const ignorePath = path29.join(scanDir, ".secretscanignore");
+  const ignorePath = path30.join(scanDir, ".secretscanignore");
   try {
     if (!fs13.existsSync(ignorePath))
       return [];
@@ -46399,7 +47172,7 @@ function isExcluded(entry, relPath, exactNames, globPatterns) {
   if (exactNames.has(entry))
     return true;
   for (const pattern of globPatterns) {
-    if (path29.matchesGlob(relPath, pattern))
+    if (path30.matchesGlob(relPath, pattern))
       return true;
   }
   return false;
@@ -46420,7 +47193,7 @@ function validateDirectoryInput(dir) {
   return null;
 }
 function isBinaryFile(filePath, buffer) {
-  const ext = path29.extname(filePath).toLowerCase();
+  const ext = path30.extname(filePath).toLowerCase();
   if (DEFAULT_EXCLUDE_EXTENSIONS.has(ext)) {
     return true;
   }
@@ -46556,9 +47329,9 @@ function isSymlinkLoop(realPath, visited) {
   return false;
 }
 function isPathWithinScope(realPath, scanDir) {
-  const resolvedScanDir = path29.resolve(scanDir);
-  const resolvedRealPath = path29.resolve(realPath);
-  return resolvedRealPath === resolvedScanDir || resolvedRealPath.startsWith(resolvedScanDir + path29.sep) || resolvedRealPath.startsWith(`${resolvedScanDir}/`) || resolvedRealPath.startsWith(`${resolvedScanDir}\\`);
+  const resolvedScanDir = path30.resolve(scanDir);
+  const resolvedRealPath = path30.resolve(realPath);
+  return resolvedRealPath === resolvedScanDir || resolvedRealPath.startsWith(resolvedScanDir + path30.sep) || resolvedRealPath.startsWith(`${resolvedScanDir}/`) || resolvedRealPath.startsWith(`${resolvedScanDir}\\`);
 }
 function findScannableFiles(dir, excludeExact, excludeGlobs, scanDir, visited, stats = {
   skippedDirs: 0,
@@ -46584,8 +47357,8 @@ function findScannableFiles(dir, excludeExact, excludeGlobs, scanDir, visited, s
     return a.localeCompare(b);
   });
   for (const entry of entries) {
-    const fullPath = path29.join(dir, entry);
-    const relPath = path29.relative(scanDir, fullPath).replace(/\\/g, "/");
+    const fullPath = path30.join(dir, entry);
+    const relPath = path30.relative(scanDir, fullPath).replace(/\\/g, "/");
     if (isExcluded(entry, relPath, excludeExact, excludeGlobs)) {
       stats.skippedDirs++;
       continue;
@@ -46620,7 +47393,7 @@ function findScannableFiles(dir, excludeExact, excludeGlobs, scanDir, visited, s
       const subFiles = findScannableFiles(fullPath, excludeExact, excludeGlobs, scanDir, visited, stats);
       files.push(...subFiles);
     } else if (lstat.isFile()) {
-      const ext = path29.extname(fullPath).toLowerCase();
+      const ext = path30.extname(fullPath).toLowerCase();
       if (!DEFAULT_EXCLUDE_EXTENSIONS.has(ext)) {
         files.push(fullPath);
       } else {
@@ -46632,7 +47405,7 @@ function findScannableFiles(dir, excludeExact, excludeGlobs, scanDir, visited, s
 }
 async function runSecretscan(directory) {
   try {
-    const result = await _internals19.secretscan.execute({ directory }, {});
+    const result = await _internals22.secretscan.execute({ directory }, {});
     const jsonStr = typeof result === "string" ? result : result.output;
     return JSON.parse(jsonStr);
   } catch (e) {
@@ -46647,7 +47420,7 @@ async function runSecretscan(directory) {
     return errorResult;
   }
 }
-var MAX_FILE_PATH_LENGTH = 500, MAX_FILE_SIZE_BYTES, MAX_FILES_SCANNED = 1000, MAX_FINDINGS = 100, MAX_OUTPUT_BYTES2 = 512000, MAX_LINE_LENGTH = 1e4, MAX_CONTENT_BYTES, BINARY_SIGNATURES, BINARY_PREFIX_BYTES = 4, BINARY_NULL_CHECK_BYTES = 8192, BINARY_NULL_THRESHOLD = 0.1, DEFAULT_EXCLUDE_DIRS, DEFAULT_EXCLUDE_EXTENSIONS, SECRET_PATTERNS, O_NOFOLLOW, secretscan, _internals19;
+var MAX_FILE_PATH_LENGTH = 500, MAX_FILE_SIZE_BYTES, MAX_FILES_SCANNED = 1000, MAX_FINDINGS = 100, MAX_OUTPUT_BYTES2 = 512000, MAX_LINE_LENGTH = 1e4, MAX_CONTENT_BYTES, BINARY_SIGNATURES, BINARY_PREFIX_BYTES = 4, BINARY_NULL_CHECK_BYTES = 8192, BINARY_NULL_THRESHOLD = 0.1, DEFAULT_EXCLUDE_DIRS, DEFAULT_EXCLUDE_EXTENSIONS, SECRET_PATTERNS, O_NOFOLLOW, secretscan, _internals22;
 var init_secretscan = __esm(() => {
   init_zod();
   init_path_security();
@@ -46880,7 +47653,7 @@ var init_secretscan = __esm(() => {
         }
       }
       try {
-        const _scanDirRaw = path29.resolve(directory);
+        const _scanDirRaw = path30.resolve(directory);
         const scanDir = (() => {
           try {
             return fs13.realpathSync(_scanDirRaw);
@@ -47019,7 +47792,7 @@ var init_secretscan = __esm(() => {
       }
     }
   });
-  _internals19 = {
+  _internals22 = {
     secretscan,
     runSecretscan
   };
@@ -47027,7 +47800,7 @@ var init_secretscan = __esm(() => {
 
 // src/lang/default-backend.ts
 import * as fs14 from "fs";
-import * as path30 from "path";
+import * as path31 from "path";
 function detectFileExists(dir, pattern) {
   if (pattern.includes("*") || pattern.includes("?")) {
     try {
@@ -47039,7 +47812,7 @@ function detectFileExists(dir, pattern) {
     }
   }
   try {
-    fs14.accessSync(path30.join(dir, pattern));
+    fs14.accessSync(path31.join(dir, pattern));
     return true;
   } catch {
     return false;
@@ -47167,8 +47940,8 @@ function defaultBuildTestCommand(profile, framework, files, dir = ".", opts = {}
       return ["mvn", "test"];
     case "gradle": {
       const isWindows = process.platform === "win32";
-      const hasGradlewBat = fs14.existsSync(path30.join(dir, "gradlew.bat"));
-      const hasGradlew = fs14.existsSync(path30.join(dir, "gradlew"));
+      const hasGradlewBat = fs14.existsSync(path31.join(dir, "gradlew.bat"));
+      const hasGradlew = fs14.existsSync(path31.join(dir, "gradlew"));
       if (hasGradlewBat && isWindows)
         return ["gradlew.bat", "test"];
       if (hasGradlew)
@@ -47185,7 +47958,7 @@ function defaultBuildTestCommand(profile, framework, files, dir = ".", opts = {}
         "cmake-build-release",
         "out"
       ];
-      const actualBuildDir = buildDirCandidates.find((d) => fs14.existsSync(path30.join(dir, d, "CMakeCache.txt"))) ?? "build";
+      const actualBuildDir = buildDirCandidates.find((d) => fs14.existsSync(path31.join(dir, d, "CMakeCache.txt"))) ?? "build";
       return ["ctest", "--test-dir", actualBuildDir];
     }
     case "swift-test":
@@ -47472,17 +48245,17 @@ async function defaultSelectBuildCommand(profile, dir) {
   return null;
 }
 async function defaultTestFilesFor(profile, sourceFile, dir) {
-  const ext = path30.extname(sourceFile);
+  const ext = path31.extname(sourceFile);
   if (!profile.extensions.includes(ext))
     return [];
-  const base = path30.basename(sourceFile, ext);
-  const rel = path30.relative(dir, sourceFile);
-  const relDir = path30.dirname(rel);
+  const base = path31.basename(sourceFile, ext);
+  const rel = path31.relative(dir, sourceFile);
+  const relDir = path31.dirname(rel);
   const stripSrc = relDir.replace(/^src(\/|\\)/, "");
   const candidates = new Set;
   for (const tDir of ["tests", "test", "__tests__", "spec"]) {
     for (const suffix of ["", "_test", ".test", "_spec", ".spec"]) {
-      candidates.add(path30.join(dir, tDir, stripSrc, `${base}${suffix}${ext}`));
+      candidates.add(path31.join(dir, tDir, stripSrc, `${base}${suffix}${ext}`));
     }
   }
   const existing = [];
@@ -47523,7 +48296,7 @@ var init_default_backend = __esm(() => {
 
 // src/lang/backends/go.ts
 import * as fs15 from "fs";
-import * as path31 from "path";
+import * as path32 from "path";
 function extractImports(_sourceFile, source) {
   const out = new Set;
   IMPORT_REGEX_SINGLE.lastIndex = 0;
@@ -47549,7 +48322,7 @@ function extractImports(_sourceFile, source) {
 async function selectFramework(dir) {
   let content;
   try {
-    content = fs15.readFileSync(path31.join(dir, "go.mod"), "utf-8");
+    content = fs15.readFileSync(path32.join(dir, "go.mod"), "utf-8");
   } catch {
     return null;
   }
@@ -47570,16 +48343,16 @@ async function selectFramework(dir) {
 async function selectEntryPoints(dir) {
   const points = [];
   try {
-    fs15.accessSync(path31.join(dir, "main.go"));
+    fs15.accessSync(path32.join(dir, "main.go"));
     points.push("main.go");
   } catch {}
   try {
-    const cmdDir = path31.join(dir, "cmd");
+    const cmdDir = path32.join(dir, "cmd");
     const subdirs = fs15.readdirSync(cmdDir, { withFileTypes: true }).filter((d) => d.isDirectory());
     for (const sub of subdirs) {
-      const main = path31.join("cmd", sub.name, "main.go");
+      const main = path32.join("cmd", sub.name, "main.go");
       try {
-        fs15.accessSync(path31.join(dir, main));
+        fs15.accessSync(path32.join(dir, main));
         points.push(main);
       } catch {}
     }
@@ -47598,19 +48371,19 @@ function buildGoBackend() {
     selectEntryPoints
   };
 }
-var PROFILE_ID = "go", IMPORT_REGEX_SINGLE, IMPORT_REGEX_GROUP, IMPORT_REGEX_GROUP_LINE, _internals20;
+var PROFILE_ID = "go", IMPORT_REGEX_SINGLE, IMPORT_REGEX_GROUP, IMPORT_REGEX_GROUP_LINE, _internals23;
 var init_go = __esm(() => {
   init_default_backend();
   init_profiles();
   IMPORT_REGEX_SINGLE = /^\s*import\s+(?:[a-zA-Z_.][a-zA-Z0-9_]*\s+)?"([^"]+)"/gm;
   IMPORT_REGEX_GROUP = /^\s*import\s*\(([\s\S]*?)\)/gm;
   IMPORT_REGEX_GROUP_LINE = /(?:[a-zA-Z_.][a-zA-Z0-9_]*\s+)?"([^"]+)"/g;
-  _internals20 = { extractImports };
+  _internals23 = { extractImports };
 });
 
 // src/lang/backends/python.ts
 import * as fs16 from "fs";
-import * as path32 from "path";
+import * as path33 from "path";
 function parseImportTargets(rawTargets) {
   const cleaned = rawTargets.replace(/[()]/g, "").split(`
 `).map((line) => line.replace(/#.*$/, "").replace(/\\\s*$/, "")).join(" ");
@@ -47670,7 +48443,7 @@ async function selectFramework2(dir) {
   ];
   for (const candidate of ["pyproject.toml", "requirements.txt", "setup.py"]) {
     try {
-      const content = fs16.readFileSync(path32.join(dir, candidate), "utf-8");
+      const content = fs16.readFileSync(path33.join(dir, candidate), "utf-8");
       const lower = content.toLowerCase();
       for (const [pkg, name] of candidates) {
         if (lower.includes(pkg)) {
@@ -47684,7 +48457,7 @@ async function selectFramework2(dir) {
 async function selectEntryPoints2(dir) {
   const points = new Set;
   try {
-    const content = fs16.readFileSync(path32.join(dir, "pyproject.toml"), "utf-8");
+    const content = fs16.readFileSync(path33.join(dir, "pyproject.toml"), "utf-8");
     const scriptsBlock = content.match(/\[project\.scripts\][\s\S]*?(?=\n\[|$)/);
     if (scriptsBlock) {
       for (const line of scriptsBlock[0].split(`
@@ -47699,7 +48472,7 @@ async function selectEntryPoints2(dir) {
   } catch {}
   for (const name of ["manage.py", "main.py", "app.py", "__main__.py"]) {
     try {
-      fs16.accessSync(path32.join(dir, name));
+      fs16.accessSync(path33.join(dir, name));
       points.add(name);
     } catch {}
   }
@@ -47717,18 +48490,18 @@ function buildPythonBackend() {
     selectEntryPoints: selectEntryPoints2
   };
 }
-var PROFILE_ID2 = "python", IMPORT_REGEX_FROM_WITH_TARGETS, IMPORT_REGEX_IMPORT, _internals21;
+var PROFILE_ID2 = "python", IMPORT_REGEX_FROM_WITH_TARGETS, IMPORT_REGEX_IMPORT, _internals24;
 var init_python = __esm(() => {
   init_default_backend();
   init_profiles();
   IMPORT_REGEX_FROM_WITH_TARGETS = /^\s*from\s+(\.*[\w.]*)\s+import\s+(\([^)]*\)|[^\n#]+)/gm;
   IMPORT_REGEX_IMPORT = /^\s*import\s+([^\n#]+)/gm;
-  _internals21 = { extractImports: extractImports2 };
+  _internals24 = { extractImports: extractImports2 };
 });
 
 // src/test-impact/analyzer.ts
 import fs17 from "fs";
-import path33 from "path";
+import path34 from "path";
 function normalizePath(p) {
   return p.replace(/\\/g, "/");
 }
@@ -47749,8 +48522,8 @@ function resolveRelativeImport(fromDir, importPath) {
   if (!importPath.startsWith(".")) {
     return null;
   }
-  const resolved = path33.resolve(fromDir, importPath);
-  if (path33.extname(resolved)) {
+  const resolved = path34.resolve(fromDir, importPath);
+  if (path34.extname(resolved)) {
     if (fs17.existsSync(resolved) && fs17.statSync(resolved).isFile()) {
       return normalizePath(resolved);
     }
@@ -47770,20 +48543,20 @@ function resolvePythonImport(fromDir, module) {
   const leadingDots = module.match(/^\.+/)?.[0].length ?? 0;
   let baseDir = fromDir;
   for (let i = 1;i < leadingDots; i++) {
-    baseDir = path33.dirname(baseDir);
+    baseDir = path34.dirname(baseDir);
   }
   const rest = module.slice(leadingDots);
   if (rest.length === 0) {
-    const initPath = path33.join(baseDir, "__init__.py");
+    const initPath = path34.join(baseDir, "__init__.py");
     if (fs17.existsSync(initPath) && fs17.statSync(initPath).isFile()) {
       return normalizePath(initPath);
     }
     return null;
   }
-  const subpath = rest.replace(/\./g, path33.sep);
+  const subpath = rest.replace(/\./g, path34.sep);
   const candidates = [
-    `${path33.join(baseDir, subpath)}.py`,
-    path33.join(baseDir, subpath, "__init__.py")
+    `${path34.join(baseDir, subpath)}.py`,
+    path34.join(baseDir, subpath, "__init__.py")
   ];
   for (const c of candidates) {
     if (fs17.existsSync(c) && fs17.statSync(c).isFile())
@@ -47792,7 +48565,7 @@ function resolvePythonImport(fromDir, module) {
   return null;
 }
 function findGoModule(fromDir) {
-  const resolved = path33.resolve(fromDir);
+  const resolved = path34.resolve(fromDir);
   let cur = resolved;
   const walked = [];
   for (let i = 0;i < 16; i++) {
@@ -47804,7 +48577,7 @@ function findGoModule(fromDir) {
     }
     walked.push(cur);
     try {
-      const goMod = path33.join(cur, "go.mod");
+      const goMod = path34.join(cur, "go.mod");
       const content = fs17.readFileSync(goMod, "utf-8");
       const moduleMatch = content.match(/^\s*module\s+"?([^"\s/]+(?:\/[^"\s]+)*)"?/m);
       if (moduleMatch) {
@@ -47815,10 +48588,10 @@ function findGoModule(fromDir) {
       }
     } catch {}
     try {
-      fs17.accessSync(path33.join(cur, ".git"));
+      fs17.accessSync(path34.join(cur, ".git"));
       break;
     } catch {}
-    const parent = path33.dirname(cur);
+    const parent = path34.dirname(cur);
     if (parent === cur)
       break;
     cur = parent;
@@ -47830,12 +48603,12 @@ function findGoModule(fromDir) {
 function resolveGoImport(fromDir, importPath) {
   let dir = null;
   if (importPath.startsWith(".")) {
-    dir = path33.resolve(fromDir, importPath);
+    dir = path34.resolve(fromDir, importPath);
   } else {
     const mod = findGoModule(fromDir);
     if (mod && (importPath === mod.modulePath || importPath.startsWith(`${mod.modulePath}/`))) {
       const subpath = importPath.slice(mod.modulePath.length);
-      dir = path33.join(mod.moduleRoot, subpath);
+      dir = path34.join(mod.moduleRoot, subpath);
     }
   }
   if (dir === null)
@@ -47843,7 +48616,7 @@ function resolveGoImport(fromDir, importPath) {
   if (!fs17.existsSync(dir) || !fs17.statSync(dir).isDirectory())
     return [];
   try {
-    return fs17.readdirSync(dir).filter((f) => f.endsWith(".go") && !f.endsWith("_test.go")).map((f) => normalizePath(path33.join(dir, f)));
+    return fs17.readdirSync(dir).filter((f) => f.endsWith(".go") && !f.endsWith("_test.go")).map((f) => normalizePath(path34.join(dir, f)));
   } catch {
     return [];
   }
@@ -47882,15 +48655,15 @@ function findTestFilesSync(cwd) {
     for (const entry of entries) {
       if (entry.isDirectory()) {
         if (!skipDirs.has(entry.name)) {
-          walk(path33.join(dir, entry.name), visitedInodes);
+          walk(path34.join(dir, entry.name), visitedInodes);
         }
       } else if (entry.isFile()) {
         const name = entry.name;
         const isTsTest = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(name) || dir.includes("__tests__") && /\.(ts|tsx|js|jsx)$/.test(name);
-        const isPyTest = /^test_.+\.py$/.test(name) || /.+_test\.py$/.test(name) || dir.includes(`${path33.sep}tests${path33.sep}`) && name.endsWith(".py");
+        const isPyTest = /^test_.+\.py$/.test(name) || /.+_test\.py$/.test(name) || dir.includes(`${path34.sep}tests${path34.sep}`) && name.endsWith(".py");
         const isGoTest = /.+_test\.go$/.test(name);
         if (isTsTest || isPyTest || isGoTest) {
-          testFiles.push(normalizePath(path33.join(dir, entry.name)));
+          testFiles.push(normalizePath(path34.join(dir, entry.name)));
         }
       }
     }
@@ -47915,8 +48688,8 @@ function extractImports3(content) {
   ];
 }
 function addImpactEdgesForTestFile(testFile, content, impactMap) {
-  const ext = path33.extname(testFile).toLowerCase();
-  const testDir = path33.dirname(testFile);
+  const ext = path34.extname(testFile).toLowerCase();
+  const testDir = path34.dirname(testFile);
   function addEdge(source) {
     if (!impactMap[source])
       impactMap[source] = [];
@@ -47934,7 +48707,7 @@ function addImpactEdgesForTestFile(testFile, content, impactMap) {
     return;
   }
   if (PYTHON_EXTENSIONS.has(ext)) {
-    const modules = _internals21.extractImports(testFile, content);
+    const modules = _internals24.extractImports(testFile, content);
     for (const mod of modules) {
       const resolved = resolvePythonImport(testDir, mod);
       if (resolved !== null)
@@ -47943,7 +48716,7 @@ function addImpactEdgesForTestFile(testFile, content, impactMap) {
     return;
   }
   if (GO_EXTENSIONS.has(ext)) {
-    const imports = _internals20.extractImports(testFile, content);
+    const imports = _internals23.extractImports(testFile, content);
     for (const importPath of imports) {
       const sourceFiles = resolveGoImport(testDir, importPath);
       for (const source of sourceFiles)
@@ -47970,12 +48743,12 @@ async function buildImpactMapInternal(cwd) {
   return impactMap;
 }
 async function buildImpactMap(cwd) {
-  const impactMap = await _internals22.buildImpactMapInternal(cwd);
-  await _internals22.saveImpactMap(cwd, impactMap);
+  const impactMap = await _internals25.buildImpactMapInternal(cwd);
+  await _internals25.saveImpactMap(cwd, impactMap);
   return impactMap;
 }
 async function loadImpactMap(cwd, options) {
-  const cachePath = path33.join(cwd, ".swarm", "cache", "impact-map.json");
+  const cachePath = path34.join(cwd, ".swarm", "cache", "impact-map.json");
   if (fs17.existsSync(cachePath)) {
     try {
       const content = fs17.readFileSync(cachePath, "utf-8");
@@ -47985,7 +48758,7 @@ async function loadImpactMap(cwd, options) {
         const hasValidValues = Object.values(map3).every((v) => Array.isArray(v) && v.every((item) => typeof item === "string"));
         if (hasValidValues) {
           const generatedAt = new Date(data.generatedAt).getTime();
-          if (!_internals22.isCacheStale(map3, generatedAt)) {
+          if (!_internals25.isCacheStale(map3, generatedAt)) {
             return map3;
           }
           if (options?.skipRebuild) {
@@ -48005,15 +48778,15 @@ async function loadImpactMap(cwd, options) {
   if (options?.skipRebuild) {
     return {};
   }
-  return _internals22.buildImpactMap(cwd);
+  return _internals25.buildImpactMap(cwd);
 }
 async function saveImpactMap(cwd, impactMap) {
-  if (!path33.isAbsolute(cwd)) {
+  if (!path34.isAbsolute(cwd)) {
     throw new Error(`saveImpactMap requires an absolute project root path, got: "${cwd}"`);
   }
-  _internals22.validateProjectRoot(cwd);
-  const cacheDir2 = path33.join(cwd, ".swarm", "cache");
-  const cachePath = path33.join(cacheDir2, "impact-map.json");
+  _internals25.validateProjectRoot(cwd);
+  const cacheDir2 = path34.join(cwd, ".swarm", "cache");
+  const cachePath = path34.join(cacheDir2, "impact-map.json");
   if (!fs17.existsSync(cacheDir2)) {
     fs17.mkdirSync(cacheDir2, { recursive: true });
   }
@@ -48035,7 +48808,7 @@ async function analyzeImpact(changedFiles, cwd, budget) {
     };
   }
   const validFiles = changedFiles.filter((f) => typeof f === "string" && f.length > 0 && !f.includes("\x00"));
-  const impactMap = await _internals22.loadImpactMap(cwd);
+  const impactMap = await _internals25.loadImpactMap(cwd);
   const impactedTestsSet = new Set;
   const untestedFiles = [];
   let visitedCount = 0;
@@ -48045,7 +48818,7 @@ async function analyzeImpact(changedFiles, cwd, budget) {
       budgetExceeded = true;
       break;
     }
-    const normalizedChanged = normalizePath(path33.resolve(changedFile));
+    const normalizedChanged = normalizePath(path34.resolve(changedFile));
     const tests = impactMap[normalizedChanged];
     if (tests && tests.length > 0) {
       for (const test of tests) {
@@ -48102,7 +48875,7 @@ async function analyzeImpact(changedFiles, cwd, budget) {
     budgetExceeded
   };
 }
-var IMPORT_REGEX_ES, IMPORT_REGEX_REQUIRE, IMPORT_REGEX_REEXPORT, TS_EXTENSIONS, PYTHON_EXTENSIONS, GO_EXTENSIONS, EXTENSIONS_TO_TRY, goModuleCache, _internals22;
+var IMPORT_REGEX_ES, IMPORT_REGEX_REQUIRE, IMPORT_REGEX_REEXPORT, TS_EXTENSIONS, PYTHON_EXTENSIONS, GO_EXTENSIONS, EXTENSIONS_TO_TRY, goModuleCache, _internals25;
 var init_analyzer = __esm(() => {
   init_manager2();
   init_go();
@@ -48115,7 +48888,7 @@ var init_analyzer = __esm(() => {
   GO_EXTENSIONS = new Set([".go"]);
   EXTENSIONS_TO_TRY = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
   goModuleCache = new Map;
-  _internals22 = {
+  _internals25 = {
     validateProjectRoot,
     normalizePath,
     isCacheStale,
@@ -48338,15 +49111,15 @@ var FLAKY_THRESHOLD = 0.3, MIN_RUNS_FOR_QUARANTINE = 5, MAX_HISTORY_RUNS = 20;
 
 // src/test-impact/history-store.ts
 import fs18 from "fs";
-import path34 from "path";
+import path35 from "path";
 function getHistoryPath(workingDir) {
   if (!workingDir) {
     throw new Error("getHistoryPath requires a working directory \u2014 project root must be provided by the caller");
   }
-  if (!path34.isAbsolute(workingDir)) {
+  if (!path35.isAbsolute(workingDir)) {
     throw new Error(`getHistoryPath requires an absolute project root path, got: "${workingDir}"`);
   }
-  return path34.join(workingDir, ".swarm", "cache", "test-history.jsonl");
+  return path35.join(workingDir, ".swarm", "cache", "test-history.jsonl");
 }
 function sanitizeErrorMessage(errorMessage) {
   if (errorMessage === undefined) {
@@ -48433,8 +49206,8 @@ function batchAppendTestRuns(records, workingDir) {
     }
   }
   const historyPath = getHistoryPath(workingDir);
-  const historyDir = path34.dirname(historyPath);
-  _internals23.validateProjectRoot(workingDir);
+  const historyDir = path35.dirname(historyPath);
+  _internals26.validateProjectRoot(workingDir);
   if (!fs18.existsSync(historyDir)) {
     fs18.mkdirSync(historyDir, { recursive: true });
   }
@@ -48514,7 +49287,7 @@ function getAllHistory(workingDir) {
   records.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
   return records;
 }
-var MAX_HISTORY_PER_TEST = 20, MAX_ERROR_LENGTH = 500, MAX_STACK_LENGTH = 200, MAX_CHANGED_FILES = 50, DANGEROUS_PROPERTY_NAMES, _internals23;
+var MAX_HISTORY_PER_TEST = 20, MAX_ERROR_LENGTH = 500, MAX_STACK_LENGTH = 200, MAX_CHANGED_FILES = 50, DANGEROUS_PROPERTY_NAMES, _internals26;
 var init_history_store = __esm(() => {
   init_manager2();
   DANGEROUS_PROPERTY_NAMES = new Set([
@@ -48522,14 +49295,14 @@ var init_history_store = __esm(() => {
     "constructor",
     "prototype"
   ]);
-  _internals23 = {
+  _internals26 = {
     validateProjectRoot
   };
 });
 
 // src/tools/resolve-working-directory.ts
 import * as fs19 from "fs";
-import * as path35 from "path";
+import * as path36 from "path";
 function resolveWorkingDirectory(workingDirectory, fallbackDirectory) {
   if (workingDirectory == null || workingDirectory === "") {
     return { success: true, directory: fallbackDirectory };
@@ -48549,15 +49322,15 @@ function resolveWorkingDirectory(workingDirectory, fallbackDirectory) {
       };
     }
   }
-  const normalizedDir = path35.normalize(workingDirectory);
-  const pathParts = normalizedDir.split(path35.sep);
+  const normalizedDir = path36.normalize(workingDirectory);
+  const pathParts = normalizedDir.split(path36.sep);
   if (pathParts.includes("..")) {
     return {
       success: false,
       message: "Invalid working_directory: path traversal sequences (..) are not allowed"
     };
   }
-  const resolvedDir = path35.resolve(normalizedDir);
+  const resolvedDir = path36.resolve(normalizedDir);
   let statResult;
   try {
     statResult = fs19.statSync(resolvedDir);
@@ -48573,7 +49346,7 @@ function resolveWorkingDirectory(workingDirectory, fallbackDirectory) {
       message: `Invalid working_directory: path "${resolvedDir}" is not a directory`
     };
   }
-  const resolvedFallback = path35.resolve(fallbackDirectory);
+  const resolvedFallback = path36.resolve(fallbackDirectory);
   let fallbackExists = false;
   try {
     fs19.statSync(resolvedFallback);
@@ -48583,7 +49356,7 @@ function resolveWorkingDirectory(workingDirectory, fallbackDirectory) {
   }
   if (workingDirectory != null && workingDirectory !== "") {
     if (fallbackExists) {
-      const isSubdirectory = resolvedDir.startsWith(resolvedFallback + path35.sep);
+      const isSubdirectory = resolvedDir.startsWith(resolvedFallback + path36.sep);
       if (isSubdirectory) {
         return {
           success: false,
@@ -48638,17 +49411,17 @@ var init_registry_backend = __esm(() => {
 
 // src/lang/backends/typescript.ts
 import * as fs20 from "fs";
-import * as path36 from "path";
+import * as path37 from "path";
 function readPackageJsonRaw(dir) {
   try {
-    const content = fs20.readFileSync(path36.join(dir, "package.json"), "utf-8");
+    const content = fs20.readFileSync(path37.join(dir, "package.json"), "utf-8");
     return JSON.parse(content);
   } catch {
     return null;
   }
 }
 function readPackageJson(dir) {
-  return _internals24.readPackageJsonRaw(dir);
+  return _internals27.readPackageJsonRaw(dir);
 }
 function readPackageJsonTestScript(dir) {
   return readPackageJson(dir)?.scripts?.test ?? null;
@@ -48818,7 +49591,7 @@ function buildTypescriptBackend() {
     selectEntryPoints: selectEntryPoints3
   };
 }
-var PROFILE_ID3 = "typescript", IMPORT_REGEX_ES2, IMPORT_REGEX_BARE, IMPORT_REGEX_REQUIRE2, IMPORT_REGEX_DYNAMIC, IMPORT_REGEX_REEXPORT2, _internals24;
+var PROFILE_ID3 = "typescript", IMPORT_REGEX_ES2, IMPORT_REGEX_BARE, IMPORT_REGEX_REQUIRE2, IMPORT_REGEX_DYNAMIC, IMPORT_REGEX_REEXPORT2, _internals27;
 var init_typescript = __esm(() => {
   init_default_backend();
   init_profiles();
@@ -48827,7 +49600,7 @@ var init_typescript = __esm(() => {
   IMPORT_REGEX_REQUIRE2 = /require\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
   IMPORT_REGEX_DYNAMIC = /import\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
   IMPORT_REGEX_REEXPORT2 = /export\s+(?:\{[^}]*\}|\*)\s+from\s+['"]([^'"]+)['"]/g;
-  _internals24 = {
+  _internals27 = {
     readPackageJsonRaw,
     readPackageJsonTestScript,
     frameworkFromScriptsTest
@@ -48858,10 +49631,10 @@ __export(exports_dispatch, {
   pickedProfiles: () => pickedProfiles,
   pickBackend: () => pickBackend,
   clearDispatchCache: () => clearDispatchCache,
-  _internals: () => _internals25
+  _internals: () => _internals28
 });
 import * as fs21 from "fs";
-import * as path37 from "path";
+import * as path38 from "path";
 function safeReaddirSet(dir) {
   try {
     return new Set(fs21.readdirSync(dir));
@@ -48878,14 +49651,14 @@ function manifestHash(dir) {
     if (!entries.has(name))
       continue;
     try {
-      const stat3 = fs21.statSync(path37.join(dir, name));
+      const stat3 = fs21.statSync(path38.join(dir, name));
       parts.push(`${name}:${stat3.size}:${stat3.mtimeMs}:${stat3.ino}`);
     } catch {}
   }
   return parts.join("|");
 }
 function findManifestRoot(start) {
-  const resolved = path37.resolve(start);
+  const resolved = path38.resolve(start);
   const cached3 = manifestRootCache.get(resolved);
   if (cached3 !== undefined)
     return cached3;
@@ -48904,7 +49677,7 @@ function findManifestRoot(start) {
         return cur;
       }
     }
-    const parent = path37.dirname(cur);
+    const parent = path38.dirname(cur);
     if (parent === cur)
       break;
     cur = parent;
@@ -48913,7 +49686,7 @@ function findManifestRoot(start) {
   return start;
 }
 function evictIfNeeded() {
-  if (cache.size <= _internals25.cacheCapacity)
+  if (cache.size <= _internals28.cacheCapacity)
     return;
   let oldestKey;
   let oldestOrder = Infinity;
@@ -48944,7 +49717,7 @@ async function pickBackend(dir) {
     evictIfNeeded();
     return null;
   }
-  const profiles = await _internals25.detectProjectLanguages(root);
+  const profiles = await _internals28.detectProjectLanguages(root);
   if (profiles.length === 0) {
     cache.set(cacheKey, {
       hash: hash3,
@@ -48976,12 +49749,12 @@ function clearDispatchCache() {
   manifestRootCache.clear();
   insertCounter = 0;
 }
-var _internals25, cache, insertCounter = 0, MANIFEST_FILES, _MANIFEST_SET, manifestRootCache;
+var _internals28, cache, insertCounter = 0, MANIFEST_FILES, _MANIFEST_SET, manifestRootCache;
 var init_dispatch = __esm(() => {
   init_backends();
   init_detector();
   init_registry_backend();
-  _internals25 = {
+  _internals28 = {
     detectProjectLanguages,
     cacheCapacity: 64
   };
@@ -49014,13 +49787,13 @@ var init_dispatch = __esm(() => {
 
 // src/tools/test-runner.ts
 import * as fs22 from "fs";
-import * as path38 from "path";
+import * as path39 from "path";
 async function estimateFanOut(sourceFiles, cwd) {
   try {
     const impactMap = await loadImpactMap(cwd, { skipRebuild: true });
     const uniqueTestFiles = new Set;
     for (const sourceFile of sourceFiles) {
-      const resolvedPath = path38.resolve(cwd, sourceFile);
+      const resolvedPath = path39.resolve(cwd, sourceFile);
       const normalizedPath = resolvedPath.replace(/\\/g, "/");
       const testFiles = impactMap[normalizedPath];
       if (testFiles) {
@@ -49098,14 +49871,14 @@ function hasDevDependency(devDeps, ...patterns) {
   return hasPackageJsonDependency(devDeps, ...patterns);
 }
 function detectGoTest(cwd) {
-  return fs22.existsSync(path38.join(cwd, "go.mod")) && isCommandAvailable("go");
+  return fs22.existsSync(path39.join(cwd, "go.mod")) && isCommandAvailable("go");
 }
 function detectJavaMaven(cwd) {
-  return fs22.existsSync(path38.join(cwd, "pom.xml")) && isCommandAvailable("mvn");
+  return fs22.existsSync(path39.join(cwd, "pom.xml")) && isCommandAvailable("mvn");
 }
 function detectGradle(cwd) {
-  const hasBuildFile = fs22.existsSync(path38.join(cwd, "build.gradle")) || fs22.existsSync(path38.join(cwd, "build.gradle.kts"));
-  const hasGradlew = fs22.existsSync(path38.join(cwd, "gradlew")) || fs22.existsSync(path38.join(cwd, "gradlew.bat"));
+  const hasBuildFile = fs22.existsSync(path39.join(cwd, "build.gradle")) || fs22.existsSync(path39.join(cwd, "build.gradle.kts"));
+  const hasGradlew = fs22.existsSync(path39.join(cwd, "gradlew")) || fs22.existsSync(path39.join(cwd, "gradlew.bat"));
   return hasBuildFile && (hasGradlew || isCommandAvailable("gradle"));
 }
 function detectDotnetTest(cwd) {
@@ -49118,25 +49891,25 @@ function detectDotnetTest(cwd) {
   }
 }
 function detectCTest(cwd) {
-  const hasSource = fs22.existsSync(path38.join(cwd, "CMakeLists.txt"));
-  const hasBuildCache = fs22.existsSync(path38.join(cwd, "CMakeCache.txt")) || fs22.existsSync(path38.join(cwd, "build", "CMakeCache.txt"));
+  const hasSource = fs22.existsSync(path39.join(cwd, "CMakeLists.txt"));
+  const hasBuildCache = fs22.existsSync(path39.join(cwd, "CMakeCache.txt")) || fs22.existsSync(path39.join(cwd, "build", "CMakeCache.txt"));
   return (hasSource || hasBuildCache) && isCommandAvailable("ctest");
 }
 function detectSwiftTest(cwd) {
-  return fs22.existsSync(path38.join(cwd, "Package.swift")) && isCommandAvailable("swift");
+  return fs22.existsSync(path39.join(cwd, "Package.swift")) && isCommandAvailable("swift");
 }
 function detectDartTest(cwd) {
-  return fs22.existsSync(path38.join(cwd, "pubspec.yaml")) && (isCommandAvailable("dart") || isCommandAvailable("flutter"));
+  return fs22.existsSync(path39.join(cwd, "pubspec.yaml")) && (isCommandAvailable("dart") || isCommandAvailable("flutter"));
 }
 function detectRSpec(cwd) {
-  const hasRSpecFile = fs22.existsSync(path38.join(cwd, ".rspec"));
-  const hasGemfile = fs22.existsSync(path38.join(cwd, "Gemfile"));
-  const hasSpecDir = fs22.existsSync(path38.join(cwd, "spec"));
+  const hasRSpecFile = fs22.existsSync(path39.join(cwd, ".rspec"));
+  const hasGemfile = fs22.existsSync(path39.join(cwd, "Gemfile"));
+  const hasSpecDir = fs22.existsSync(path39.join(cwd, "spec"));
   const hasRSpec = hasRSpecFile || hasGemfile && hasSpecDir;
   return hasRSpec && (isCommandAvailable("bundle") || isCommandAvailable("rspec"));
 }
 function detectMinitest(cwd) {
-  return fs22.existsSync(path38.join(cwd, "test")) && (fs22.existsSync(path38.join(cwd, "Gemfile")) || fs22.existsSync(path38.join(cwd, "Rakefile"))) && isCommandAvailable("ruby");
+  return fs22.existsSync(path39.join(cwd, "test")) && (fs22.existsSync(path39.join(cwd, "Gemfile")) || fs22.existsSync(path39.join(cwd, "Rakefile"))) && isCommandAvailable("ruby");
 }
 async function detectTestFrameworkViaDispatch(cwd) {
   try {
@@ -49198,7 +49971,7 @@ async function parseTestOutputViaDispatch(framework, output, baseDir) {
 async function detectTestFramework(cwd) {
   const baseDir = cwd;
   try {
-    const packageJsonPath = path38.join(baseDir, "package.json");
+    const packageJsonPath = path39.join(baseDir, "package.json");
     if (fs22.existsSync(packageJsonPath)) {
       const content = fs22.readFileSync(packageJsonPath, "utf-8");
       const pkg = JSON.parse(content);
@@ -49219,16 +49992,16 @@ async function detectTestFramework(cwd) {
         return "jest";
       if (hasDevDependency(devDeps, "mocha", "@types/mocha"))
         return "mocha";
-      if (fs22.existsSync(path38.join(baseDir, "bun.lockb")) || fs22.existsSync(path38.join(baseDir, "bun.lock"))) {
+      if (fs22.existsSync(path39.join(baseDir, "bun.lockb")) || fs22.existsSync(path39.join(baseDir, "bun.lock"))) {
         if (scripts.test?.includes("bun"))
           return "bun";
       }
     }
   } catch {}
   try {
-    const pyprojectTomlPath = path38.join(baseDir, "pyproject.toml");
-    const setupCfgPath = path38.join(baseDir, "setup.cfg");
-    const requirementsTxtPath = path38.join(baseDir, "requirements.txt");
+    const pyprojectTomlPath = path39.join(baseDir, "pyproject.toml");
+    const setupCfgPath = path39.join(baseDir, "setup.cfg");
+    const requirementsTxtPath = path39.join(baseDir, "requirements.txt");
     if (fs22.existsSync(pyprojectTomlPath)) {
       const content = fs22.readFileSync(pyprojectTomlPath, "utf-8");
       if (content.includes("[tool.pytest"))
@@ -49248,7 +50021,7 @@ async function detectTestFramework(cwd) {
     }
   } catch {}
   try {
-    const cargoTomlPath = path38.join(baseDir, "Cargo.toml");
+    const cargoTomlPath = path39.join(baseDir, "Cargo.toml");
     if (fs22.existsSync(cargoTomlPath)) {
       const content = fs22.readFileSync(cargoTomlPath, "utf-8");
       if (content.includes("[dev-dependencies]")) {
@@ -49259,9 +50032,9 @@ async function detectTestFramework(cwd) {
     }
   } catch {}
   try {
-    const pesterConfigPath = path38.join(baseDir, "pester.config.ps1");
-    const pesterConfigJsonPath = path38.join(baseDir, "pester.config.ps1.json");
-    const pesterPs1Path = path38.join(baseDir, "tests.ps1");
+    const pesterConfigPath = path39.join(baseDir, "pester.config.ps1");
+    const pesterConfigJsonPath = path39.join(baseDir, "pester.config.ps1.json");
+    const pesterPs1Path = path39.join(baseDir, "tests.ps1");
     if (fs22.existsSync(pesterConfigPath) || fs22.existsSync(pesterConfigJsonPath) || fs22.existsSync(pesterPs1Path)) {
       return "pester";
     }
@@ -49290,12 +50063,12 @@ function isTestDirectoryPath(normalizedPath) {
   return normalizedPath.split("/").some((segment) => TEST_DIRECTORY_NAMES.includes(segment));
 }
 function resolveWorkspacePath(file3, workingDir) {
-  return path38.isAbsolute(file3) ? path38.resolve(file3) : path38.resolve(workingDir, file3);
+  return path39.isAbsolute(file3) ? path39.resolve(file3) : path39.resolve(workingDir, file3);
 }
 function toWorkspaceOutputPath(absolutePath, workingDir, preferRelative) {
   if (!preferRelative)
     return absolutePath;
-  return path38.relative(workingDir, absolutePath);
+  return path39.relative(workingDir, absolutePath);
 }
 function dedupePush(target, value) {
   if (!target.includes(value)) {
@@ -49332,18 +50105,18 @@ function buildLanguageSpecificTestNames(nameWithoutExt, ext) {
   }
 }
 function getRepoLevelCandidateDirectories(workingDir, relativePath, ext) {
-  const relativeDir = path38.dirname(relativePath);
+  const relativeDir = path39.dirname(relativePath);
   const nestedRelativeDir = relativeDir === "." ? "" : relativeDir;
   const directories = TEST_DIRECTORY_NAMES.flatMap((dirName) => {
-    const rootDir = path38.join(workingDir, dirName);
-    return nestedRelativeDir ? [rootDir, path38.join(rootDir, nestedRelativeDir)] : [rootDir];
+    const rootDir = path39.join(workingDir, dirName);
+    return nestedRelativeDir ? [rootDir, path39.join(rootDir, nestedRelativeDir)] : [rootDir];
   });
   const normalizedRelativePath = relativePath.replace(/\\/g, "/");
   if (ext === ".java" && normalizedRelativePath.startsWith("src/main/java/")) {
-    directories.push(path38.join(workingDir, "src/test/java", path38.dirname(normalizedRelativePath.slice("src/main/java/".length))));
+    directories.push(path39.join(workingDir, "src/test/java", path39.dirname(normalizedRelativePath.slice("src/main/java/".length))));
   }
   if ((ext === ".kt" || ext === ".java") && normalizedRelativePath.startsWith("src/main/kotlin/")) {
-    directories.push(path38.join(workingDir, "src/test/kotlin", path38.dirname(normalizedRelativePath.slice("src/main/kotlin/".length))));
+    directories.push(path39.join(workingDir, "src/test/kotlin", path39.dirname(normalizedRelativePath.slice("src/main/kotlin/".length))));
   }
   return [...new Set(directories)];
 }
@@ -49371,23 +50144,23 @@ function isLanguageSpecificTestFile(basename6) {
 }
 function isConventionTestFilePath(filePath) {
   const normalizedPath = filePath.replace(/\\/g, "/");
-  const basename6 = path38.basename(filePath);
+  const basename6 = path39.basename(filePath);
   return hasCompoundTestExtension(basename6) || basename6.includes(".spec.") || basename6.includes(".test.") || isLanguageSpecificTestFile(basename6) || isTestDirectoryPath(normalizedPath);
 }
 function getTestFilesFromConvention(sourceFiles, workingDir = process.cwd()) {
   const testFiles = [];
   for (const file3 of sourceFiles) {
     const absoluteFile = resolveWorkspacePath(file3, workingDir);
-    const relativeFile = path38.relative(workingDir, absoluteFile);
-    const basename6 = path38.basename(absoluteFile);
-    const dirname17 = path38.dirname(absoluteFile);
-    const preferRelativeOutput = !path38.isAbsolute(file3);
+    const relativeFile = path39.relative(workingDir, absoluteFile);
+    const basename6 = path39.basename(absoluteFile);
+    const dirname17 = path39.dirname(absoluteFile);
+    const preferRelativeOutput = !path39.isAbsolute(file3);
     if (isConventionTestFilePath(relativeFile) || isConventionTestFilePath(file3)) {
       dedupePush(testFiles, toWorkspaceOutputPath(absoluteFile, workingDir, preferRelativeOutput));
       continue;
     }
     const nameWithoutExt = basename6.replace(/\.[^.]+$/, "");
-    const ext = path38.extname(basename6);
+    const ext = path39.extname(basename6);
     const genericTestNames = [
       `${nameWithoutExt}.spec${ext}`,
       `${nameWithoutExt}.test${ext}`
@@ -49396,7 +50169,7 @@ function getTestFilesFromConvention(sourceFiles, workingDir = process.cwd()) {
     const colocatedCandidates = [
       ...genericTestNames,
       ...languageSpecificTestNames
-    ].map((candidateName) => path38.join(dirname17, candidateName));
+    ].map((candidateName) => path39.join(dirname17, candidateName));
     const testDirectoryNames = [
       basename6,
       ...genericTestNames,
@@ -49405,8 +50178,8 @@ function getTestFilesFromConvention(sourceFiles, workingDir = process.cwd()) {
     const repoLevelDirectories = getRepoLevelCandidateDirectories(workingDir, relativeFile, ext);
     const possibleTestFiles = [
       ...colocatedCandidates,
-      ...TEST_DIRECTORY_NAMES.flatMap((dirName) => testDirectoryNames.map((candidateName) => path38.join(dirname17, dirName, candidateName))),
-      ...repoLevelDirectories.flatMap((candidateDir) => testDirectoryNames.map((candidateName) => path38.join(candidateDir, candidateName)))
+      ...TEST_DIRECTORY_NAMES.flatMap((dirName) => testDirectoryNames.map((candidateName) => path39.join(dirname17, dirName, candidateName))),
+      ...repoLevelDirectories.flatMap((candidateDir) => testDirectoryNames.map((candidateName) => path39.join(candidateDir, candidateName)))
     ];
     for (const testFile of possibleTestFiles) {
       if (fs22.existsSync(testFile)) {
@@ -49427,7 +50200,7 @@ async function getTestFilesFromGraph(sourceFiles, workingDir) {
     try {
       const absoluteTestFile = resolveWorkspacePath(testFile, workingDir);
       const content = fs22.readFileSync(absoluteTestFile, "utf-8");
-      const testDir = path38.dirname(absoluteTestFile);
+      const testDir = path39.dirname(absoluteTestFile);
       const importRegex = /import\s+.*?\s+from\s+['"]([^'"]+)['"]/g;
       let match;
       match = importRegex.exec(content);
@@ -49435,8 +50208,8 @@ async function getTestFilesFromGraph(sourceFiles, workingDir) {
         const importPath = match[1];
         let resolvedImport;
         if (importPath.startsWith(".")) {
-          resolvedImport = path38.resolve(testDir, importPath);
-          const existingExt = path38.extname(resolvedImport);
+          resolvedImport = path39.resolve(testDir, importPath);
+          const existingExt = path39.extname(resolvedImport);
           if (!existingExt) {
             for (const extToTry of [
               ".ts",
@@ -49456,12 +50229,12 @@ async function getTestFilesFromGraph(sourceFiles, workingDir) {
         } else {
           continue;
         }
-        const importBasename = path38.basename(resolvedImport, path38.extname(resolvedImport));
-        const importDir = path38.dirname(resolvedImport);
+        const importBasename = path39.basename(resolvedImport, path39.extname(resolvedImport));
+        const importDir = path39.dirname(resolvedImport);
         for (const sourceFile of absoluteSourceFiles) {
-          const sourceDir = path38.dirname(sourceFile);
-          const sourceBasename = path38.basename(sourceFile, path38.extname(sourceFile));
-          const isRelatedDir = importDir === sourceDir || importDir === path38.join(sourceDir, "__tests__") || importDir === path38.join(sourceDir, "tests") || importDir === path38.join(sourceDir, "test") || importDir === path38.join(sourceDir, "spec");
+          const sourceDir = path39.dirname(sourceFile);
+          const sourceBasename = path39.basename(sourceFile, path39.extname(sourceFile));
+          const isRelatedDir = importDir === sourceDir || importDir === path39.join(sourceDir, "__tests__") || importDir === path39.join(sourceDir, "tests") || importDir === path39.join(sourceDir, "test") || importDir === path39.join(sourceDir, "spec");
           if (resolvedImport === sourceFile || importBasename === sourceBasename && isRelatedDir) {
             dedupePush(testFiles, testFile);
             break;
@@ -49474,8 +50247,8 @@ async function getTestFilesFromGraph(sourceFiles, workingDir) {
       while (match !== null) {
         const importPath = match[1];
         if (importPath.startsWith(".")) {
-          let resolvedImport = path38.resolve(testDir, importPath);
-          const existingExt = path38.extname(resolvedImport);
+          let resolvedImport = path39.resolve(testDir, importPath);
+          const existingExt = path39.extname(resolvedImport);
           if (!existingExt) {
             for (const extToTry of [
               ".ts",
@@ -49492,12 +50265,12 @@ async function getTestFilesFromGraph(sourceFiles, workingDir) {
               }
             }
           }
-          const importDir = path38.dirname(resolvedImport);
-          const importBasename = path38.basename(resolvedImport, path38.extname(resolvedImport));
+          const importDir = path39.dirname(resolvedImport);
+          const importBasename = path39.basename(resolvedImport, path39.extname(resolvedImport));
           for (const sourceFile of absoluteSourceFiles) {
-            const sourceDir = path38.dirname(sourceFile);
-            const sourceBasename = path38.basename(sourceFile, path38.extname(sourceFile));
-            const isRelatedDir = importDir === sourceDir || importDir === path38.join(sourceDir, "__tests__") || importDir === path38.join(sourceDir, "tests") || importDir === path38.join(sourceDir, "test") || importDir === path38.join(sourceDir, "spec");
+            const sourceDir = path39.dirname(sourceFile);
+            const sourceBasename = path39.basename(sourceFile, path39.extname(sourceFile));
+            const isRelatedDir = importDir === sourceDir || importDir === path39.join(sourceDir, "__tests__") || importDir === path39.join(sourceDir, "tests") || importDir === path39.join(sourceDir, "test") || importDir === path39.join(sourceDir, "spec");
             if (resolvedImport === sourceFile || importBasename === sourceBasename && isRelatedDir) {
               dedupePush(testFiles, testFile);
               break;
@@ -49607,8 +50380,8 @@ function buildTestCommand2(framework, scope, files, coverage, baseDir) {
       return ["mvn", "test"];
     case "gradle": {
       const isWindows = process.platform === "win32";
-      const hasGradlewBat = fs22.existsSync(path38.join(baseDir, "gradlew.bat"));
-      const hasGradlew = fs22.existsSync(path38.join(baseDir, "gradlew"));
+      const hasGradlewBat = fs22.existsSync(path39.join(baseDir, "gradlew.bat"));
+      const hasGradlew = fs22.existsSync(path39.join(baseDir, "gradlew"));
       if (hasGradlewBat && isWindows)
         return ["gradlew.bat", "test"];
       if (hasGradlew)
@@ -49625,7 +50398,7 @@ function buildTestCommand2(framework, scope, files, coverage, baseDir) {
         "cmake-build-release",
         "out"
       ];
-      const actualBuildDir = buildDirCandidates.find((d) => fs22.existsSync(path38.join(baseDir, d, "CMakeCache.txt"))) ?? "build";
+      const actualBuildDir = buildDirCandidates.find((d) => fs22.existsSync(path39.join(baseDir, d, "CMakeCache.txt"))) ?? "build";
       return ["ctest", "--test-dir", actualBuildDir];
     }
     case "swift-test":
@@ -50057,11 +50830,11 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
     };
   }
   const startTime = Date.now();
-  const vitestJsonOutputPath = framework === "vitest" ? path38.join(cwd, ".swarm", "cache", "test-runner-vitest.json") : undefined;
+  const vitestJsonOutputPath = framework === "vitest" ? path39.join(cwd, ".swarm", "cache", "test-runner-vitest.json") : undefined;
   try {
     if (vitestJsonOutputPath) {
       try {
-        fs22.mkdirSync(path38.dirname(vitestJsonOutputPath), { recursive: true });
+        fs22.mkdirSync(path39.dirname(vitestJsonOutputPath), { recursive: true });
         if (fs22.existsSync(vitestJsonOutputPath)) {
           fs22.unlinkSync(vitestJsonOutputPath);
         }
@@ -50177,10 +50950,10 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
 }
 function normalizeHistoryTestFile(testFile, workingDir) {
   const normalized = testFile.replace(/\\/g, "/");
-  if (!path38.isAbsolute(testFile))
+  if (!path39.isAbsolute(testFile))
     return normalized;
-  const relative9 = path38.relative(workingDir, testFile);
-  if (relative9.startsWith("..") || path38.isAbsolute(relative9)) {
+  const relative9 = path39.relative(workingDir, testFile);
+  if (relative9.startsWith("..") || path39.isAbsolute(relative9)) {
     return normalized;
   }
   return relative9.replace(/\\/g, "/");
@@ -50518,7 +51291,7 @@ var init_test_runner = __esm(() => {
         const sourceFiles = args.files.filter((file3) => {
           if (directTestFiles.includes(file3))
             return false;
-          const ext = path38.extname(file3).toLowerCase();
+          const ext = path39.extname(file3).toLowerCase();
           return SOURCE_EXTENSIONS.has(ext);
         });
         const invalidFiles = args.files.filter((file3) => !directTestFiles.includes(file3) && !sourceFiles.includes(file3));
@@ -50564,7 +51337,7 @@ var init_test_runner = __esm(() => {
           if (isConventionTestFilePath(f)) {
             return false;
           }
-          const ext = path38.extname(f).toLowerCase();
+          const ext = path39.extname(f).toLowerCase();
           return SOURCE_EXTENSIONS.has(ext);
         });
         if (sourceFiles.length === 0) {
@@ -50614,7 +51387,7 @@ var init_test_runner = __esm(() => {
           if (isConventionTestFilePath(f)) {
             return false;
           }
-          const ext = path38.extname(f).toLowerCase();
+          const ext = path39.extname(f).toLowerCase();
           return SOURCE_EXTENSIONS.has(ext);
         });
         if (sourceFiles.length === 0) {
@@ -50666,8 +51439,8 @@ var init_test_runner = __esm(() => {
           }
           if (impactResult.impactedTests.length > 0) {
             testFiles = impactResult.impactedTests.map((absPath) => {
-              const relativePath = path38.relative(workingDir, absPath);
-              return path38.isAbsolute(relativePath) ? absPath : relativePath;
+              const relativePath = path39.relative(workingDir, absPath);
+              return path39.isAbsolute(relativePath) ? absPath : relativePath;
             });
           } else {
             graphFallbackReason = "no impacted tests found via impact analysis, falling back to graph";
@@ -50743,7 +51516,7 @@ var init_test_runner = __esm(() => {
 
 // src/services/preflight-service.ts
 import * as fs23 from "fs";
-import * as path39 from "path";
+import * as path40 from "path";
 function validateDirectoryPath(dir) {
   if (!dir || typeof dir !== "string") {
     throw new Error("Directory path is required");
@@ -50751,8 +51524,8 @@ function validateDirectoryPath(dir) {
   if (dir.includes("..")) {
     throw new Error("Directory path must not contain path traversal sequences");
   }
-  const normalized = path39.normalize(dir);
-  const absolutePath = path39.isAbsolute(normalized) ? normalized : path39.resolve(normalized);
+  const normalized = path40.normalize(dir);
+  const absolutePath = path40.isAbsolute(normalized) ? normalized : path40.resolve(normalized);
   return absolutePath;
 }
 function validateTimeout(timeoutMs, defaultValue) {
@@ -50775,7 +51548,7 @@ function validateTimeout(timeoutMs, defaultValue) {
 }
 function getPackageVersion(dir) {
   try {
-    const packagePath = path39.join(dir, "package.json");
+    const packagePath = path40.join(dir, "package.json");
     if (fs23.existsSync(packagePath)) {
       const content = fs23.readFileSync(packagePath, "utf-8");
       const pkg = JSON.parse(content);
@@ -50786,7 +51559,7 @@ function getPackageVersion(dir) {
 }
 function getChangelogVersion(dir) {
   try {
-    const changelogPath = path39.join(dir, "CHANGELOG.md");
+    const changelogPath = path40.join(dir, "CHANGELOG.md");
     if (fs23.existsSync(changelogPath)) {
       const content = fs23.readFileSync(changelogPath, "utf-8");
       const match = content.match(/^##\s*\[?(\d+\.\d+\.\d+)\]?/m);
@@ -50800,7 +51573,7 @@ function getChangelogVersion(dir) {
 function getVersionFileVersion(dir) {
   const possibleFiles = ["VERSION.txt", "version.txt", "VERSION", "version"];
   for (const file3 of possibleFiles) {
-    const filePath = path39.join(dir, file3);
+    const filePath = path40.join(dir, file3);
     if (fs23.existsSync(filePath)) {
       try {
         const content = fs23.readFileSync(filePath, "utf-8").trim();
@@ -50816,9 +51589,9 @@ function getVersionFileVersion(dir) {
 async function runVersionCheck(dir, _timeoutMs) {
   const startTime = Date.now();
   try {
-    const packageVersion = _internals26.getPackageVersion(dir);
-    const changelogVersion = _internals26.getChangelogVersion(dir);
-    const versionFileVersion = _internals26.getVersionFileVersion(dir);
+    const packageVersion = _internals29.getPackageVersion(dir);
+    const changelogVersion = _internals29.getChangelogVersion(dir);
+    const versionFileVersion = _internals29.getVersionFileVersion(dir);
     const versions3 = [];
     if (packageVersion)
       versions3.push(`package.json: ${packageVersion}`);
@@ -51127,7 +51900,7 @@ async function runEvidenceCheck(dir) {
 async function runRequirementCoverageCheck(dir, currentPhase) {
   const startTime = Date.now();
   try {
-    const specPath = path39.join(dir, ".swarm", "spec.md");
+    const specPath = path40.join(dir, ".swarm", "spec.md");
     if (!fs23.existsSync(specPath)) {
       return {
         type: "req_coverage",
@@ -51168,7 +51941,7 @@ async function runPreflight(dir, phase, config3) {
   const reportId = `preflight-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   let validatedDir;
   try {
-    validatedDir = _internals26.validateDirectoryPath(dir);
+    validatedDir = _internals29.validateDirectoryPath(dir);
   } catch (error96) {
     return {
       id: reportId,
@@ -51188,7 +51961,7 @@ async function runPreflight(dir, phase, config3) {
   }
   let validatedTimeout;
   try {
-    validatedTimeout = _internals26.validateTimeout(config3?.checkTimeoutMs, DEFAULT_CONFIG.checkTimeoutMs);
+    validatedTimeout = _internals29.validateTimeout(config3?.checkTimeoutMs, DEFAULT_CONFIG.checkTimeoutMs);
   } catch (error96) {
     return {
       id: reportId,
@@ -51229,12 +52002,12 @@ async function runPreflight(dir, phase, config3) {
   });
   const checks5 = [];
   log("[Preflight] Running lint check...");
-  const lintResult = await _internals26.runLintCheck(validatedDir, cfg.linter, cfg.checkTimeoutMs);
+  const lintResult = await _internals29.runLintCheck(validatedDir, cfg.linter, cfg.checkTimeoutMs);
   checks5.push(lintResult);
   log(`[Preflight] Lint check: ${lintResult.status} ${lintResult.message}`);
   if (!cfg.skipTests) {
     log("[Preflight] Running tests check...");
-    const testsResult = await _internals26.runTestsCheck(validatedDir, cfg.testScope, cfg.checkTimeoutMs);
+    const testsResult = await _internals29.runTestsCheck(validatedDir, cfg.testScope, cfg.checkTimeoutMs);
     checks5.push(testsResult);
     log(`[Preflight] Tests check: ${testsResult.status} ${testsResult.message}`);
   } else {
@@ -51246,7 +52019,7 @@ async function runPreflight(dir, phase, config3) {
   }
   if (!cfg.skipSecrets) {
     log("[Preflight] Running secrets check...");
-    const secretsResult = await _internals26.runSecretsCheck(validatedDir, cfg.checkTimeoutMs);
+    const secretsResult = await _internals29.runSecretsCheck(validatedDir, cfg.checkTimeoutMs);
     checks5.push(secretsResult);
     log(`[Preflight] Secrets check: ${secretsResult.status} ${secretsResult.message}`);
   } else {
@@ -51258,7 +52031,7 @@ async function runPreflight(dir, phase, config3) {
   }
   if (!cfg.skipEvidence) {
     log("[Preflight] Running evidence check...");
-    const evidenceResult = await _internals26.runEvidenceCheck(validatedDir);
+    const evidenceResult = await _internals29.runEvidenceCheck(validatedDir);
     checks5.push(evidenceResult);
     log(`[Preflight] Evidence check: ${evidenceResult.status} ${evidenceResult.message}`);
   } else {
@@ -51269,12 +52042,12 @@ async function runPreflight(dir, phase, config3) {
     });
   }
   log("[Preflight] Running requirement coverage check...");
-  const reqCoverageResult = await _internals26.runRequirementCoverageCheck(validatedDir, phase);
+  const reqCoverageResult = await _internals29.runRequirementCoverageCheck(validatedDir, phase);
   checks5.push(reqCoverageResult);
   log(`[Preflight] Requirement coverage check: ${reqCoverageResult.status} ${reqCoverageResult.message}`);
   if (!cfg.skipVersion) {
     log("[Preflight] Running version check...");
-    const versionResult = await _internals26.runVersionCheck(validatedDir, cfg.checkTimeoutMs);
+    const versionResult = await _internals29.runVersionCheck(validatedDir, cfg.checkTimeoutMs);
     checks5.push(versionResult);
     log(`[Preflight] Version check: ${versionResult.status} ${versionResult.message}`);
   } else {
@@ -51337,10 +52110,10 @@ function formatPreflightMarkdown(report) {
 async function handlePreflightCommand(directory, _args) {
   const plan = await loadPlan(directory);
   const phase = plan?.current_phase ?? 1;
-  const report = await _internals26.runPreflight(directory, phase);
-  return _internals26.formatPreflightMarkdown(report);
+  const report = await _internals29.runPreflight(directory, phase);
+  return _internals29.formatPreflightMarkdown(report);
 }
-var MIN_CHECK_TIMEOUT_MS = 5000, MAX_CHECK_TIMEOUT_MS = 300000, DEFAULT_CONFIG, _internals26;
+var MIN_CHECK_TIMEOUT_MS = 5000, MAX_CHECK_TIMEOUT_MS = 300000, DEFAULT_CONFIG, _internals29;
 var init_preflight_service = __esm(() => {
   init_manager2();
   init_manager();
@@ -51357,7 +52130,7 @@ var init_preflight_service = __esm(() => {
     testScope: "convention",
     linter: "biome"
   };
-  _internals26 = {
+  _internals29 = {
     runPreflight,
     formatPreflightMarkdown,
     handlePreflightCommand,
@@ -52244,7 +53017,7 @@ var init_manager3 = __esm(() => {
 
 // src/commands/reset.ts
 import * as fs24 from "fs";
-import * as path40 from "path";
+import * as path41 from "path";
 async function handleResetCommand(directory, args) {
   const hasConfirm = args.includes("--confirm");
   if (!hasConfirm) {
@@ -52284,7 +53057,7 @@ async function handleResetCommand(directory, args) {
   }
   for (const filename of ["SWARM_PLAN.md", "SWARM_PLAN.json"]) {
     try {
-      const rootPath = path40.join(directory, filename);
+      const rootPath = path41.join(directory, filename);
       if (fs24.existsSync(rootPath)) {
         fs24.unlinkSync(rootPath);
         results.push(`- \u2705 Deleted ${filename} (root)`);
@@ -52324,7 +53097,7 @@ var init_reset = __esm(() => {
 
 // src/commands/reset-session.ts
 import * as fs25 from "fs";
-import * as path41 from "path";
+import * as path42 from "path";
 async function handleResetSessionCommand(directory, _args) {
   const results = [];
   try {
@@ -52339,13 +53112,13 @@ async function handleResetSessionCommand(directory, _args) {
     results.push("\u274C Failed to delete state.json");
   }
   try {
-    const sessionDir = path41.dirname(validateSwarmPath(directory, "session/state.json"));
+    const sessionDir = path42.dirname(validateSwarmPath(directory, "session/state.json"));
     if (fs25.existsSync(sessionDir)) {
       const files = fs25.readdirSync(sessionDir);
       const otherFiles = files.filter((f) => f !== "state.json");
       let deletedCount = 0;
       for (const file3 of otherFiles) {
-        const filePath = path41.join(sessionDir, file3);
+        const filePath = path42.join(sessionDir, file3);
         if (fs25.lstatSync(filePath).isFile()) {
           fs25.unlinkSync(filePath);
           deletedCount++;
@@ -52377,7 +53150,7 @@ var init_reset_session = __esm(() => {
 });
 
 // src/summaries/manager.ts
-import * as path42 from "path";
+import * as path43 from "path";
 function sanitizeSummaryId(id) {
   if (!id || id.length === 0) {
     throw new Error("Invalid summary ID: empty string");
@@ -52400,7 +53173,7 @@ function sanitizeSummaryId(id) {
 }
 async function loadFullOutput(directory, id) {
   const sanitizedId = sanitizeSummaryId(id);
-  const relativePath = path42.join("summaries", `${sanitizedId}.json`);
+  const relativePath = path43.join("summaries", `${sanitizedId}.json`);
   validateSwarmPath(directory, relativePath);
   const content = await readSwarmFileAsync(directory, relativePath);
   if (content === null) {
@@ -52463,7 +53236,7 @@ var init_retrieve = __esm(() => {
 
 // src/commands/rollback.ts
 import * as fs26 from "fs";
-import * as path43 from "path";
+import * as path44 from "path";
 async function handleRollbackCommand(directory, args) {
   const phaseArg = args[0];
   if (!phaseArg) {
@@ -52528,8 +53301,8 @@ async function handleRollbackCommand(directory, args) {
     if (EXCLUDE_FILES.has(file3) || file3.startsWith("plan-ledger.archived-")) {
       continue;
     }
-    const src = path43.join(checkpointDir, file3);
-    const dest = path43.join(swarmDir, file3);
+    const src = path44.join(checkpointDir, file3);
+    const dest = path44.join(swarmDir, file3);
     try {
       fs26.cpSync(src, dest, { recursive: true, force: true });
       successes.push(file3);
@@ -52548,12 +53321,12 @@ async function handleRollbackCommand(directory, args) {
     ].join(`
 `);
   }
-  const existingLedgerPath = path43.join(swarmDir, "plan-ledger.jsonl");
+  const existingLedgerPath = path44.join(swarmDir, "plan-ledger.jsonl");
   if (fs26.existsSync(existingLedgerPath)) {
     fs26.unlinkSync(existingLedgerPath);
   }
   try {
-    const planJsonPath = path43.join(swarmDir, "plan.json");
+    const planJsonPath = path44.join(swarmDir, "plan.json");
     if (fs26.existsSync(planJsonPath)) {
       const planRaw = fs26.readFileSync(planJsonPath, "utf-8");
       const plan = PlanSchema.parse(JSON.parse(planRaw));
@@ -52614,7 +53387,7 @@ async function handleSimulateCommand(directory, args) {
   }
   let darkMatterPairs;
   try {
-    darkMatterPairs = await _internals10.detectDarkMatter(directory, options);
+    darkMatterPairs = await _internals13.detectDarkMatter(directory, options);
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     return `## Simulate Report
@@ -52644,9 +53417,9 @@ Ensure this is a git repository with commit history.`;
 `);
   try {
     const fs27 = await import("fs/promises");
-    const path44 = await import("path");
-    const reportPath = path44.join(directory, ".swarm", "simulate-report.md");
-    await fs27.mkdir(path44.dirname(reportPath), { recursive: true });
+    const path45 = await import("path");
+    const reportPath = path45.join(directory, ".swarm", "simulate-report.md");
+    await fs27.mkdir(path45.dirname(reportPath), { recursive: true });
     await fs27.writeFile(reportPath, report, "utf-8");
   } catch (err) {
     const writeErr = err instanceof Error ? err.message : String(err);
@@ -52670,12 +53443,12 @@ async function handleSpecifyCommand(_directory, args) {
 
 // src/turbo/lean/state.ts
 import * as fs27 from "fs";
-import * as path44 from "path";
+import * as path45 from "path";
 function nowISO2() {
   return new Date().toISOString();
 }
 function ensureSwarmDir2(directory) {
-  const swarmDir = path44.resolve(directory, ".swarm");
+  const swarmDir = path45.resolve(directory, ".swarm");
   if (!fs27.existsSync(swarmDir)) {
     fs27.mkdirSync(swarmDir, { recursive: true });
   }
@@ -52719,7 +53492,7 @@ function markStateUnreadable2(directory, reason) {
 }
 function readPersisted2(directory) {
   try {
-    const filePath = path44.join(directory, ".swarm", STATE_FILE2);
+    const filePath = path45.join(directory, ".swarm", STATE_FILE2);
     if (!fs27.existsSync(filePath)) {
       const seed = emptyPersisted2();
       try {
@@ -52755,7 +53528,7 @@ function writePersisted2(directory, persisted) {
   let payload;
   try {
     ensureSwarmDir2(directory);
-    filePath = path44.join(directory, ".swarm", STATE_FILE2);
+    filePath = path45.join(directory, ".swarm", STATE_FILE2);
     tmpPath = `${filePath}.tmp.${Date.now()}`;
     persisted.updatedAt = nowISO2();
     payload = `${JSON.stringify(persisted, null, 2)}
@@ -52882,10 +53655,23 @@ var init_context_budget_service = __esm(() => {
 
 // src/services/status-service.ts
 import * as fsSync2 from "fs";
-import * as path45 from "path";
+import * as path46 from "path";
+async function getSandboxStatus() {
+  const probe = new SandboxCapabilityProbe;
+  const capability = await probe.detect();
+  const executor = await getExecutor();
+  const executorAvailable = executor !== null;
+  return {
+    status: capability.status,
+    mechanism: capability.mechanism,
+    platform: capability.platform,
+    error: capability.error,
+    executorAvailable
+  };
+}
 function readSpecStalenessSnapshot(directory) {
   try {
-    const p = path45.join(directory, ".swarm", "spec-staleness.json");
+    const p = path46.join(directory, ".swarm", "spec-staleness.json");
     if (!fsSync2.existsSync(p))
       return { stale: false };
     const raw = fsSync2.readFileSync(p, "utf-8");
@@ -52975,11 +53761,13 @@ async function getStatusData(directory, agents) {
     status.specStale = true;
     status.specStaleReason = plan._specStaleReason;
   }
-  return enrichWithLeanTurbo(status, directory);
+  status = enrichWithLeanTurbo(status, directory);
+  status.sandbox = await getSandboxStatus();
+  return status;
 }
 function enrichWithLeanTurbo(status, directory) {
   const turboMode = hasActiveTurboMode();
-  const leanActive = _internals27.hasActiveLeanTurbo();
+  const leanActive = _internals30.hasActiveLeanTurbo();
   let turboStrategy = "off";
   if (leanActive) {
     turboStrategy = "lean";
@@ -52998,7 +53786,7 @@ function enrichWithLeanTurbo(status, directory) {
     }
   }
   if (leanSessionID) {
-    const runState = _internals27.loadLeanTurboRunState(directory, leanSessionID);
+    const runState = _internals30.loadLeanTurboRunState(directory, leanSessionID);
     if (runState) {
       status.leanTurboPhase = runState.phase;
       status.leanMaxParallelCoders = runState.maxParallelCoders;
@@ -53030,7 +53818,7 @@ function enrichWithLeanTurbo(status, directory) {
       }
     }
   }
-  status.fullAutoActive = _internals27.hasActiveFullAuto();
+  status.fullAutoActive = _internals30.hasActiveFullAuto();
   return status;
 }
 function formatStatusMarkdown(status) {
@@ -53090,6 +53878,9 @@ function formatStatusMarkdown(status) {
       lines.push(`**Last snapshot**: ${status.lastSnapshotAt}`);
     }
   }
+  if (status.sandbox) {
+    lines.push(...formatSandboxLines(status.sandbox));
+  }
   return lines.join(`
 `);
 }
@@ -53100,28 +53891,62 @@ async function handleStatusCommand(directory, agents) {
       const reason = statusData.specStaleReason ?? "spec.md changed since plan saved";
       const stored = statusData.specStaleStoredHash ?? "unknown";
       const current = statusData.specStaleCurrentHash ?? "(spec.md missing)";
-      return [
+      const lines = [
         "No active swarm plan found.",
         "",
         `**Spec drift detected**: ${reason} (stored: ${stored}, current: ${current})`,
         "Run `/swarm clarify` to update the spec or `/swarm acknowledge-spec-drift` to dismiss."
-      ].join(`
+      ];
+      if (statusData.sandbox) {
+        lines.push(...formatSandboxLines(statusData.sandbox));
+      }
+      return lines.join(`
+`);
+    }
+    if (statusData.sandbox) {
+      const lines = ["No active swarm plan found.", ""];
+      lines.push(...formatSandboxLines(statusData.sandbox));
+      return lines.join(`
 `);
     }
     return "No active swarm plan found.";
   }
   return formatStatusMarkdown(statusData);
 }
-var _internals27;
+function formatSandboxLines(sandbox) {
+  const lines = [];
+  const {
+    status: sandboxStatus,
+    mechanism,
+    executorAvailable,
+    error: error96
+  } = sandbox;
+  lines.push("");
+  if (sandboxStatus === "enabled") {
+    if (executorAvailable) {
+      lines.push(`**Sandbox**: ${mechanism} (enabled)`);
+    } else {
+      lines.push(`**Sandbox**: ${mechanism} (probe ok, executor unavailable)`);
+    }
+  } else if (sandboxStatus === "disabled") {
+    lines.push(`**Sandbox**: ${mechanism} (disabled${error96 ? ` \u2014 ${error96}` : ""})`);
+  } else {
+    lines.push(`**Sandbox**: ${mechanism} (unsupported) \u2014 Sandbox enforcement not active on this platform`);
+  }
+  return lines;
+}
+var _internals30;
 var init_status_service = __esm(() => {
   init_extractors();
   init_utils2();
   init_manager();
+  init_capability_probe();
+  init_executor();
   init_state();
   init_state3();
   init_compaction_service();
   init_context_budget_service();
-  _internals27 = {
+  _internals30 = {
     loadLeanTurboRunState,
     hasActiveLeanTurbo,
     hasActiveFullAuto
@@ -53212,7 +54037,7 @@ async function handleTurboCommand(directory, args, sessionID) {
   if (arg0 === "on") {
     let strategy = "standard";
     try {
-      const { config: config3 } = _internals28.loadPluginConfigWithMeta(directory);
+      const { config: config3 } = _internals31.loadPluginConfigWithMeta(directory);
       if (config3.turbo?.strategy === "lean") {
         strategy = "lean";
       }
@@ -53267,7 +54092,7 @@ function enableLeanTurbo(session, directory, sessionID) {
   let maxParallelCoders = 4;
   let conflictPolicy = "serialize";
   try {
-    const { config: config3 } = _internals28.loadPluginConfigWithMeta(directory);
+    const { config: config3 } = _internals31.loadPluginConfigWithMeta(directory);
     const leanConfig = config3.turbo?.lean;
     if (leanConfig) {
       maxParallelCoders = leanConfig.max_parallel_coders ?? 4;
@@ -53337,13 +54162,13 @@ function buildStatusMessage(session, directory, sessionID) {
   ].join(`
 `);
 }
-var _internals28;
+var _internals31;
 var init_turbo = __esm(() => {
   init_config();
   init_state();
   init_state3();
   init_logger();
-  _internals28 = {
+  _internals31 = {
     loadPluginConfigWithMeta
   };
 });
@@ -53411,7 +54236,7 @@ var init_write_retro2 = __esm(() => {
 
 // src/commands/command-dispatch.ts
 import fs28 from "fs";
-import path46 from "path";
+import path47 from "path";
 function normalizeSwarmCommandInput(command, argumentText) {
   if (command !== "swarm" && !command.startsWith("swarm-")) {
     return { isSwarmCommand: false, tokens: [] };
@@ -53436,7 +54261,7 @@ function formatCommandNotFound(tokens) {
   const attemptedCommand = tokens[0] || "";
   const MAX_DISPLAY = 100;
   const displayCommand = attemptedCommand.length > MAX_DISPLAY ? `${attemptedCommand.slice(0, MAX_DISPLAY)}...` : attemptedCommand;
-  const similar = _internals29.findSimilarCommands(attemptedCommand);
+  const similar = _internals32.findSimilarCommands(attemptedCommand);
   const header = `Command \`/swarm ${displayCommand}\` not found.`;
   const suggestions = similar.length > 0 ? `Did you mean:
 ${similar.map((cmd) => `  - /swarm ${cmd}`).join(`
@@ -53447,9 +54272,9 @@ ${similar.map((cmd) => `  - /swarm ${cmd}`).join(`
 `);
 }
 function maybeMarkFirstRun(directory) {
-  const sentinelPath = path46.join(directory, ".swarm", ".first-run-complete");
+  const sentinelPath = path47.join(directory, ".swarm", ".first-run-complete");
   try {
-    const swarmDir = path46.join(directory, ".swarm");
+    const swarmDir = path47.join(directory, ".swarm");
     fs28.mkdirSync(swarmDir, { recursive: true });
     fs28.writeFileSync(sentinelPath, `first-run-complete: ${new Date().toISOString()}
 `, { flag: "wx" });
@@ -53885,7 +54710,7 @@ async function buildSwarmCommandPrompt(args) {
     activeAgentName,
     registeredAgents
   } = args;
-  const resolved = _internals29.resolveCommand(tokens);
+  const resolved = _internals32.resolveCommand(tokens);
   if (!resolved) {
     if (tokens.length === 0) {
       return buildHelpText();
@@ -54036,7 +54861,7 @@ function findSimilarCommands(query) {
   }
   const scored = VALID_COMMANDS.map((cmd) => {
     const cmdLower = cmd.toLowerCase();
-    const fullScore = _internals29.levenshteinDistance(q, cmdLower);
+    const fullScore = _internals32.levenshteinDistance(q, cmdLower);
     let tokenScore = Infinity;
     if (cmd.includes(" ") || cmd.includes("-")) {
       const qTokens = q.split(/[\s-]+/);
@@ -54049,7 +54874,7 @@ function findSimilarCommands(query) {
         for (const ct of cmdTokens) {
           if (ct.length === 0)
             continue;
-          const dist = _internals29.levenshteinDistance(qt, ct);
+          const dist = _internals32.levenshteinDistance(qt, ct);
           if (dist < minDist)
             minDist = dist;
         }
@@ -54059,7 +54884,7 @@ function findSimilarCommands(query) {
     }
     const dashStrippedQ = q.replace(/-/g, "");
     const dashStrippedCmd = cmdLower.replace(/-/g, "");
-    const dashScore = _internals29.levenshteinDistance(dashStrippedQ, dashStrippedCmd);
+    const dashScore = _internals32.levenshteinDistance(dashStrippedQ, dashStrippedCmd);
     const score = Math.min(fullScore, tokenScore, dashScore);
     return { cmd, score };
   });
@@ -54091,11 +54916,11 @@ async function handleHelpCommand(ctx) {
     return buildHelpText2();
   }
   const tokens = targetCommand.split(/\s+/);
-  const resolved = _internals29.resolveCommand(tokens);
+  const resolved = _internals32.resolveCommand(tokens);
   if (resolved) {
-    return _internals29.buildDetailedHelp(resolved.key, resolved.entry);
+    return _internals32.buildDetailedHelp(resolved.key, resolved.entry);
   }
-  const similar = _internals29.findSimilarCommands(targetCommand);
+  const similar = _internals32.findSimilarCommands(targetCommand);
   const { buildHelpText: fullHelp } = await Promise.resolve().then(() => (init_commands(), exports_commands));
   if (similar.length > 0) {
     return `Command '/swarm ${targetCommand}' not found.
@@ -54131,24 +54956,24 @@ function validateAliases() {
       }
       aliasTargets.get(target).push(name);
       const visited = new Set;
-      const path47 = [];
+      const path48 = [];
       let current = target;
       while (current) {
         const currentEntry = COMMAND_REGISTRY[current];
         if (!currentEntry)
           break;
         if (visited.has(current)) {
-          const cycleStart = path47.indexOf(current);
+          const cycleStart = path48.indexOf(current);
           const fullChain = [
             name,
-            ...path47.slice(0, cycleStart > 0 ? cycleStart : path47.length),
+            ...path48.slice(0, cycleStart > 0 ? cycleStart : path48.length),
             current
           ].join(" \u2192 ");
           errors5.push(`Circular alias detected: ${fullChain}`);
           break;
         }
         visited.add(current);
-        path47.push(current);
+        path48.push(current);
         current = currentEntry.aliasOf || "";
       }
     }
@@ -54189,7 +55014,7 @@ function resolveCommand(tokens) {
   }
   return null;
 }
-var COMMAND_REGISTRY, VALID_COMMANDS, _internals29, validation;
+var COMMAND_REGISTRY, VALID_COMMANDS, _internals32, validation;
 var init_registry = __esm(() => {
   init_acknowledge_spec_drift();
   init_agents();
@@ -54259,7 +55084,7 @@ var init_registry = __esm(() => {
       clashesWithNativeCcCommand: "/agents"
     },
     help: {
-      handler: (ctx) => _internals29.handleHelpCommand(ctx),
+      handler: (ctx) => _internals32.handleHelpCommand(ctx),
       description: "Show help for swarm commands",
       category: "core",
       args: "[command]",
@@ -54631,7 +55456,7 @@ Subcommands:
     }
   };
   VALID_COMMANDS = Object.keys(COMMAND_REGISTRY);
-  _internals29 = {
+  _internals32 = {
     handleHelpCommand,
     validateAliases,
     resolveCommand,
@@ -54639,7 +55464,7 @@ Subcommands:
     findSimilarCommands,
     buildDetailedHelp
   };
-  validation = _internals29.validateAliases();
+  validation = _internals32.validateAliases();
   if (!validation.valid) {
     throw new Error(`COMMAND_REGISTRY alias validation failed:
 ${validation.errors.join(`
@@ -54658,54 +55483,54 @@ init_registry();
 init_cache_paths();
 init_constants();
 import * as fs29 from "fs";
-import * as os7 from "os";
-import * as path47 from "path";
+import * as os10 from "os";
+import * as path48 from "path";
 var { version: version4 } = package_default;
 var CONFIG_DIR = getPluginConfigDir();
-var OPENCODE_CONFIG_PATH = path47.join(CONFIG_DIR, "opencode.json");
-var PLUGIN_CONFIG_PATH = path47.join(CONFIG_DIR, "opencode-swarm.json");
-var PROMPTS_DIR = path47.join(CONFIG_DIR, "opencode-swarm");
+var OPENCODE_CONFIG_PATH = path48.join(CONFIG_DIR, "opencode.json");
+var PLUGIN_CONFIG_PATH = path48.join(CONFIG_DIR, "opencode-swarm.json");
+var PROMPTS_DIR = path48.join(CONFIG_DIR, "opencode-swarm");
 var OPENCODE_PLUGIN_CACHE_PATHS = getPluginCachePaths();
 var OPENCODE_PLUGIN_LOCK_FILE_PATHS = getPluginLockFilePaths();
 function isSafeCachePath(p) {
-  const resolved = path47.resolve(p);
-  const home = path47.resolve(os7.homedir());
+  const resolved = path48.resolve(p);
+  const home = path48.resolve(os10.homedir());
   if (resolved === "/" || resolved === home || resolved.length <= home.length) {
     return false;
   }
-  const segments = resolved.split(path47.sep).filter((s) => s.length > 0);
+  const segments = resolved.split(path48.sep).filter((s) => s.length > 0);
   if (segments.length < 4) {
     return false;
   }
-  const leaf = path47.basename(resolved);
+  const leaf = path48.basename(resolved);
   if (leaf !== "opencode-swarm@latest" && leaf !== "opencode-swarm") {
     return false;
   }
-  const parent = path47.basename(path47.dirname(resolved));
+  const parent = path48.basename(path48.dirname(resolved));
   if (parent !== "packages" && parent !== "node_modules") {
     return false;
   }
-  const grandparent = path47.basename(path47.dirname(path47.dirname(resolved)));
+  const grandparent = path48.basename(path48.dirname(path48.dirname(resolved)));
   if (grandparent !== "opencode") {
     return false;
   }
   return true;
 }
 function isSafeLockFilePath(p) {
-  const resolved = path47.resolve(p);
-  const home = path47.resolve(os7.homedir());
+  const resolved = path48.resolve(p);
+  const home = path48.resolve(os10.homedir());
   if (resolved === "/" || resolved === home || resolved.length <= home.length) {
     return false;
   }
-  const segments = resolved.split(path47.sep).filter((s) => s.length > 0);
+  const segments = resolved.split(path48.sep).filter((s) => s.length > 0);
   if (segments.length < 4) {
     return false;
   }
-  const leaf = path47.basename(resolved);
+  const leaf = path48.basename(resolved);
   if (leaf !== "bun.lock" && leaf !== "bun.lockb" && leaf !== "package-lock.json") {
     return false;
   }
-  const parent = path47.basename(path47.dirname(resolved));
+  const parent = path48.basename(path48.dirname(resolved));
   if (parent !== "opencode") {
     return false;
   }
@@ -54731,8 +55556,8 @@ function saveJson(filepath, data) {
 }
 function writeProjectConfigIfMissing(cwd) {
   try {
-    const opencodeDir = path47.join(cwd, ".opencode");
-    const projectConfigPath = path47.join(opencodeDir, "opencode-swarm.json");
+    const opencodeDir = path48.join(cwd, ".opencode");
+    const projectConfigPath = path48.join(opencodeDir, "opencode-swarm.json");
     if (fs29.existsSync(projectConfigPath)) {
       return;
     }
@@ -54749,7 +55574,7 @@ async function install() {
 `);
   ensureDir(CONFIG_DIR);
   ensureDir(PROMPTS_DIR);
-  const LEGACY_CONFIG_PATH = path47.join(CONFIG_DIR, "config.json");
+  const LEGACY_CONFIG_PATH = path48.join(CONFIG_DIR, "config.json");
   let opencodeConfig = loadJson(OPENCODE_CONFIG_PATH);
   if (!opencodeConfig) {
     const legacyConfig = loadJson(LEGACY_CONFIG_PATH);

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -694,10 +694,10 @@ function $constructor(name, initializer, params) {
   }
   Object.defineProperty(Definition, "name", { value: name });
   function _(def) {
-    var _a2;
+    var _a;
     const inst = params?.Parent ? new Definition : this;
     init(inst, def);
-    (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
+    (_a = inst._zod).deferred ?? (_a.deferred = []);
     for (const fn of inst._zod.deferred) {
       fn();
     }
@@ -719,9 +719,9 @@ function config(newConfig) {
     Object.assign(globalConfig, newConfig);
   return globalConfig;
 }
-var _a, NEVER, $brand, $ZodAsyncError, $ZodEncodeError, globalConfig;
+var NEVER, $brand, $ZodAsyncError, $ZodEncodeError, globalConfig;
 var init_core = __esm(() => {
-  NEVER = /* @__PURE__ */ Object.freeze({
+  NEVER = Object.freeze({
     status: "aborted"
   });
   $brand = Symbol("zod_brand");
@@ -736,8 +736,7 @@ var init_core = __esm(() => {
       this.name = "ZodEncodeError";
     }
   };
-  (_a = globalThis).__zod_globalConfig ?? (_a.__zod_globalConfig = {});
-  globalConfig = globalThis.__zod_globalConfig;
+  globalConfig = {};
 });
 
 // node_modules/zod/v4/core/util.js
@@ -782,7 +781,6 @@ __export(exports_util, {
   floatSafeRemainder: () => floatSafeRemainder,
   finalizeIssue: () => finalizeIssue,
   extend: () => extend,
-  explicitlyAborted: () => explicitlyAborted,
   escapeRegex: () => escapeRegex2,
   esc: () => esc,
   defineLazy: () => defineLazy,
@@ -853,12 +851,19 @@ function cleanRegex(source) {
   return source.slice(start, end);
 }
 function floatSafeRemainder(val, step) {
-  const ratio = val / step;
-  const roundedRatio = Math.round(ratio);
-  const tolerance = Number.EPSILON * Math.max(Math.abs(ratio), 1);
-  if (Math.abs(ratio - roundedRatio) < tolerance)
-    return 0;
-  return ratio - roundedRatio;
+  const valDecCount = (val.toString().split(".")[1] || "").length;
+  const stepString = step.toString();
+  let stepDecCount = (stepString.split(".")[1] || "").length;
+  if (stepDecCount === 0 && /\d?e-\d?/.test(stepString)) {
+    const match = stepString.match(/\d?e-(\d?)/);
+    if (match?.[1]) {
+      stepDecCount = Number.parseInt(match[1]);
+    }
+  }
+  const decCount = valDecCount > stepDecCount ? valDecCount : stepDecCount;
+  const valInt = Number.parseInt(val.toFixed(decCount).replace(".", ""));
+  const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
+  return valInt % stepInt / 10 ** decCount;
 }
 function defineLazy(object, key, getter) {
   let value = undefined;
@@ -957,10 +962,6 @@ function shallowClone(o) {
     return { ...o };
   if (Array.isArray(o))
     return [...o];
-  if (o instanceof Map)
-    return new Map(o);
-  if (o instanceof Set)
-    return new Set(o);
   return o;
 }
 function numKeys(data) {
@@ -1129,9 +1130,6 @@ function safeExtend(schema, shape) {
   return clone(schema, def);
 }
 function merge(a, b) {
-  if (a._zod.def.checks?.length) {
-    throw new Error(".merge() cannot be used on object schemas containing refinements. Use .safeExtend() instead.");
-  }
   const def = mergeDefs(a._zod.def, {
     get shape() {
       const _shape = { ...a._zod.def.shape, ...b._zod.def.shape };
@@ -1141,7 +1139,7 @@ function merge(a, b) {
     get catchall() {
       return b._zod.def.catchall;
     },
-    checks: b._zod.def.checks ?? []
+    checks: []
   });
   return clone(a, def);
 }
@@ -1224,20 +1222,10 @@ function aborted(x, startIndex = 0) {
   }
   return false;
 }
-function explicitlyAborted(x, startIndex = 0) {
-  if (x.aborted === true)
-    return true;
-  for (let i = startIndex;i < x.issues.length; i++) {
-    if (x.issues[i]?.continue === false) {
-      return true;
-    }
-  }
-  return false;
-}
 function prefixIssues(path3, issues) {
   return issues.map((iss) => {
-    var _a2;
-    (_a2 = iss).path ?? (_a2.path = []);
+    var _a;
+    (_a = iss).path ?? (_a.path = []);
     iss.path.unshift(path3);
     return iss;
   });
@@ -1246,14 +1234,17 @@ function unwrapMessage(message) {
   return typeof message === "string" ? message : message?.message;
 }
 function finalizeIssue(iss, ctx, config2) {
-  const message = iss.message ? iss.message : unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ?? unwrapMessage(ctx?.error?.(iss)) ?? unwrapMessage(config2.customError?.(iss)) ?? unwrapMessage(config2.localeError?.(iss)) ?? "Invalid input";
-  const { inst: _inst, continue: _continue, input: _input, ...rest } = iss;
-  rest.path ?? (rest.path = []);
-  rest.message = message;
-  if (ctx?.reportInput) {
-    rest.input = _input;
+  const full = { ...iss, path: iss.path ?? [] };
+  if (!iss.message) {
+    const message = unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ?? unwrapMessage(ctx?.error?.(iss)) ?? unwrapMessage(config2.customError?.(iss)) ?? unwrapMessage(config2.localeError?.(iss)) ?? "Invalid input";
+    full.message = message;
   }
-  return rest;
+  delete full.inst;
+  delete full.continue;
+  if (!ctx?.reportInput) {
+    delete full.input;
+  }
+  return full;
 }
 function getSizableOrigin(input) {
   if (input instanceof Set)
@@ -1395,13 +1386,9 @@ var EVALUATING, captureStackTrace, allowsEval, getParsedType = (data) => {
   }
 }, propertyKeyTypes, primitiveTypes, NUMBER_FORMAT_RANGES, BIGINT_FORMAT_RANGES;
 var init_util = __esm(() => {
-  init_core();
-  EVALUATING = /* @__PURE__ */ Symbol("evaluating");
+  EVALUATING = Symbol("evaluating");
   captureStackTrace = "captureStackTrace" in Error ? Error.captureStackTrace : (..._args) => {};
-  allowsEval = /* @__PURE__ */ cached(() => {
-    if (globalConfig.jitless) {
-      return false;
-    }
+  allowsEval = cached(() => {
     if (typeof navigator !== "undefined" && navigator?.userAgent?.includes("Cloudflare")) {
       return false;
     }
@@ -1413,15 +1400,8 @@ var init_util = __esm(() => {
       return false;
     }
   });
-  propertyKeyTypes = /* @__PURE__ */ new Set(["string", "number", "symbol"]);
-  primitiveTypes = /* @__PURE__ */ new Set([
-    "string",
-    "number",
-    "bigint",
-    "boolean",
-    "symbol",
-    "undefined"
-  ]);
+  propertyKeyTypes = new Set(["string", "number", "symbol"]);
+  primitiveTypes = new Set(["string", "number", "bigint", "boolean", "symbol", "undefined"]);
   NUMBER_FORMAT_RANGES = {
     safeint: [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
     int32: [-2147483648, 2147483647],
@@ -1451,33 +1431,30 @@ function flattenError(error2, mapper = (issue2) => issue2.message) {
 }
 function formatError(error2, mapper = (issue2) => issue2.message) {
   const fieldErrors = { _errors: [] };
-  const processError = (error3, path3 = []) => {
+  const processError = (error3) => {
     for (const issue2 of error3.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path3, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
+        processError({ issues: issue2.issues });
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
+        processError({ issues: issue2.issues });
+      } else if (issue2.path.length === 0) {
+        fieldErrors._errors.push(mapper(issue2));
       } else {
-        const fullpath = [...path3, ...issue2.path];
-        if (fullpath.length === 0) {
-          fieldErrors._errors.push(mapper(issue2));
-        } else {
-          let curr = fieldErrors;
-          let i = 0;
-          while (i < fullpath.length) {
-            const el = fullpath[i];
-            const terminal = i === fullpath.length - 1;
-            if (!terminal) {
-              curr[el] = curr[el] || { _errors: [] };
-            } else {
-              curr[el] = curr[el] || { _errors: [] };
-              curr[el]._errors.push(mapper(issue2));
-            }
-            curr = curr[el];
-            i++;
+        let curr = fieldErrors;
+        let i = 0;
+        while (i < issue2.path.length) {
+          const el = issue2.path[i];
+          const terminal = i === issue2.path.length - 1;
+          if (!terminal) {
+            curr[el] = curr[el] || { _errors: [] };
+          } else {
+            curr[el] = curr[el] || { _errors: [] };
+            curr[el]._errors.push(mapper(issue2));
           }
+          curr = curr[el];
+          i++;
         }
       }
     }
@@ -1488,14 +1465,14 @@ function formatError(error2, mapper = (issue2) => issue2.message) {
 function treeifyError(error2, mapper = (issue2) => issue2.message) {
   const result = { errors: [] };
   const processError = (error3, path3 = []) => {
-    var _a2, _b;
+    var _a, _b;
     for (const issue2 of error3.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path3, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, issue2.path));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
+        processError({ issues: issue2.issues }, issue2.path);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
+        processError({ issues: issue2.issues }, issue2.path);
       } else {
         const fullpath = [...path3, ...issue2.path];
         if (fullpath.length === 0) {
@@ -1509,7 +1486,7 @@ function treeifyError(error2, mapper = (issue2) => issue2.message) {
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
             curr.properties ?? (curr.properties = {});
-            (_a2 = curr.properties)[el] ?? (_a2[el] = { errors: [] });
+            (_a = curr.properties)[el] ?? (_a[el] = { errors: [] });
             curr = curr.properties[el];
           } else {
             curr.items ?? (curr.items = []);
@@ -1581,7 +1558,7 @@ var init_errors2 = __esm(() => {
 
 // node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
-  const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
+  const ctx = _ctx ? Object.assign(_ctx, { async: false }) : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) {
     throw new $ZodAsyncError;
@@ -1593,7 +1570,7 @@ var _parse = (_Err) => (schema, value, _ctx, _params) => {
   }
   return result.value;
 }, parse, _parseAsync = (_Err) => async (schema, value, _ctx, params) => {
-  const ctx = _ctx ? { ..._ctx, async: true } : { async: true };
+  const ctx = _ctx ? Object.assign(_ctx, { async: true }) : { async: true };
   let result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise)
     result = await result;
@@ -1614,7 +1591,7 @@ var _parse = (_Err) => (schema, value, _ctx, _params) => {
     error: new (_Err ?? $ZodError)(result.issues.map((iss) => finalizeIssue(iss, ctx, config())))
   } : { success: true, data: result.value };
 }, safeParse, _safeParseAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? { ..._ctx, async: true } : { async: true };
+  const ctx = _ctx ? Object.assign(_ctx, { async: true }) : { async: true };
   let result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise)
     result = await result;
@@ -1623,22 +1600,22 @@ var _parse = (_Err) => (schema, value, _ctx, _params) => {
     error: new _Err(result.issues.map((iss) => finalizeIssue(iss, ctx, config())))
   } : { success: true, data: result.value };
 }, safeParseAsync, _encode = (_Err) => (schema, value, _ctx) => {
-  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
+  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
   return _parse(_Err)(schema, value, ctx);
 }, encode, _decode = (_Err) => (schema, value, _ctx) => {
   return _parse(_Err)(schema, value, _ctx);
 }, decode, _encodeAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
+  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
   return _parseAsync(_Err)(schema, value, ctx);
 }, encodeAsync, _decodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _parseAsync(_Err)(schema, value, _ctx);
 }, decodeAsync, _safeEncode = (_Err) => (schema, value, _ctx) => {
-  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
+  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
   return _safeParse(_Err)(schema, value, ctx);
 }, safeEncode, _safeDecode = (_Err) => (schema, value, _ctx) => {
   return _safeParse(_Err)(schema, value, _ctx);
 }, safeDecode, _safeEncodeAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
+  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
   return _safeParseAsync(_Err)(schema, value, ctx);
 }, safeEncodeAsync, _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);
@@ -1701,7 +1678,6 @@ __export(exports_regexes, {
   ipv4: () => ipv4,
   integer: () => integer,
   idnEmail: () => idnEmail,
-  httpProtocol: () => httpProtocol,
   html5Email: () => html5Email,
   hostname: () => hostname,
   hex: () => hex,
@@ -1758,13 +1734,13 @@ var cuid, cuid2, ulid, xid, ksuid, nanoid, duration, extendedDuration, guid, uui
 }, uuid4, uuid6, uuid7, email, html5Email, rfc5322Email, unicodeEmail, idnEmail, browserEmail, _emoji = `^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$`, ipv4, ipv6, mac = (delimiter) => {
   const escapedDelim = escapeRegex2(delimiter ?? ":");
   return new RegExp(`^(?:[0-9A-F]{2}${escapedDelim}){5}[0-9A-F]{2}$|^(?:[0-9a-f]{2}${escapedDelim}){5}[0-9a-f]{2}$`);
-}, cidrv4, cidrv6, base64, base64url, hostname, domain, httpProtocol, e164, dateSource = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`, date, string = (params) => {
+}, cidrv4, cidrv6, base64, base64url, hostname, domain, e164, dateSource = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`, date, string = (params) => {
   const regex = params ? `[\\s\\S]{${params?.minimum ?? 0},${params?.maximum ?? ""}}` : `[\\s\\S]*`;
   return new RegExp(`^${regex}$`);
 }, bigint, integer, number, boolean, _null, _undefined, lowercase, uppercase, hex, md5_hex, md5_base64, md5_base64url, sha1_hex, sha1_base64, sha1_base64url, sha256_hex, sha256_base64, sha256_base64url, sha384_hex, sha384_base64, sha384_base64url, sha512_hex, sha512_base64, sha512_base64url;
 var init_regexes = __esm(() => {
   init_util();
-  cuid = /^[cC][0-9a-z]{6,}$/;
+  cuid = /^[cC][^\s-]{8,}$/;
   cuid2 = /^[0-9a-z]+$/;
   ulid = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/;
   xid = /^[0-9a-vA-V]{20}$/;
@@ -1790,7 +1766,6 @@ var init_regexes = __esm(() => {
   base64url = /^[A-Za-z0-9_-]*$/;
   hostname = /^(?=.{1,253}\.?$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[-0-9a-zA-Z]{0,61}[0-9a-zA-Z])?)*\.?$/;
   domain = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
-  httpProtocol = /^https?$/;
   e164 = /^\+[1-9]\d{6,14}$/;
   date = /* @__PURE__ */ new RegExp(`^${dateSource}$`);
   bigint = /^-?\d+n?$/;
@@ -1831,10 +1806,10 @@ var init_checks = __esm(() => {
   init_regexes();
   init_util();
   $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
-    var _a2;
+    var _a;
     inst._zod ?? (inst._zod = {});
     inst._zod.def = def;
-    (_a2 = inst._zod).onattach ?? (_a2.onattach = []);
+    (_a = inst._zod).onattach ?? (_a.onattach = []);
   });
   numericOriginMap = {
     number: "number",
@@ -1900,8 +1875,8 @@ var init_checks = __esm(() => {
   $ZodCheckMultipleOf = /* @__PURE__ */ $constructor("$ZodCheckMultipleOf", (inst, def) => {
     $ZodCheck.init(inst, def);
     inst._zod.onattach.push((inst2) => {
-      var _a2;
-      (_a2 = inst2._zod.bag).multipleOf ?? (_a2.multipleOf = def.value);
+      var _a;
+      (_a = inst2._zod.bag).multipleOf ?? (_a.multipleOf = def.value);
     });
     inst._zod.check = (payload) => {
       if (typeof payload.value !== typeof def.value)
@@ -2034,9 +2009,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMaxSize = /* @__PURE__ */ $constructor("$ZodCheckMaxSize", (inst, def) => {
-    var _a2;
+    var _a;
     $ZodCheck.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.size !== undefined;
     });
@@ -2062,9 +2037,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMinSize = /* @__PURE__ */ $constructor("$ZodCheckMinSize", (inst, def) => {
-    var _a2;
+    var _a;
     $ZodCheck.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.size !== undefined;
     });
@@ -2090,9 +2065,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckSizeEquals = /* @__PURE__ */ $constructor("$ZodCheckSizeEquals", (inst, def) => {
-    var _a2;
+    var _a;
     $ZodCheck.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.size !== undefined;
     });
@@ -2120,9 +2095,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMaxLength = /* @__PURE__ */ $constructor("$ZodCheckMaxLength", (inst, def) => {
-    var _a2;
+    var _a;
     $ZodCheck.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.length !== undefined;
     });
@@ -2149,9 +2124,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMinLength = /* @__PURE__ */ $constructor("$ZodCheckMinLength", (inst, def) => {
-    var _a2;
+    var _a;
     $ZodCheck.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.length !== undefined;
     });
@@ -2178,9 +2153,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckLengthEquals = /* @__PURE__ */ $constructor("$ZodCheckLengthEquals", (inst, def) => {
-    var _a2;
+    var _a;
     $ZodCheck.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.length !== undefined;
     });
@@ -2209,7 +2184,7 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckStringFormat = /* @__PURE__ */ $constructor("$ZodCheckStringFormat", (inst, def) => {
-    var _a2, _b;
+    var _a, _b;
     $ZodCheck.init(inst, def);
     inst._zod.onattach.push((inst2) => {
       const bag = inst2._zod.bag;
@@ -2220,7 +2195,7 @@ var init_checks = __esm(() => {
       }
     });
     if (def.pattern)
-      (_a2 = inst._zod).check ?? (_a2.check = (payload) => {
+      (_a = inst._zod).check ?? (_a.check = (payload) => {
         def.pattern.lastIndex = 0;
         if (def.pattern.test(payload.value))
           return;
@@ -2415,8 +2390,8 @@ var version;
 var init_versions = __esm(() => {
   version = {
     major: 4,
-    minor: 4,
-    patch: 3
+    minor: 3,
+    patch: 6
   };
 });
 
@@ -2424,8 +2399,6 @@ var init_versions = __esm(() => {
 function isValidBase64(data) {
   if (data === "")
     return true;
-  if (/\s/.test(data))
-    return false;
   if (data.length % 4 !== 0)
     return false;
   try {
@@ -2468,27 +2441,15 @@ function handleArrayResult(result, final, index) {
   }
   final.value[index] = result.value;
 }
-function handlePropertyResult(result, final, key, input, isOptionalIn, isOptionalOut) {
-  const isPresent = key in input;
+function handlePropertyResult(result, final, key, input, isOptionalOut) {
   if (result.issues.length) {
-    if (isOptionalIn && isOptionalOut && !isPresent) {
+    if (isOptionalOut && !(key in input)) {
       return;
     }
     final.issues.push(...prefixIssues(key, result.issues));
   }
-  if (!isPresent && !isOptionalIn) {
-    if (!result.issues.length) {
-      final.issues.push({
-        code: "invalid_type",
-        expected: "nonoptional",
-        input: undefined,
-        path: [key]
-      });
-    }
-    return;
-  }
   if (result.value === undefined) {
-    if (isPresent) {
+    if (key in input) {
       final.value[key] = undefined;
     }
   } else {
@@ -2516,11 +2477,8 @@ function handleCatchall(proms, input, payload, ctx, def, inst) {
   const keySet = def.keySet;
   const _catchall = def.catchall._zod;
   const t = _catchall.def.type;
-  const isOptionalIn = _catchall.optin === "optional";
   const isOptionalOut = _catchall.optout === "optional";
   for (const key in input) {
-    if (key === "__proto__")
-      continue;
     if (keySet.has(key))
       continue;
     if (t === "never") {
@@ -2529,9 +2487,9 @@ function handleCatchall(proms, input, payload, ctx, def, inst) {
     }
     const r = _catchall.run({ value: input[key], issues: [] }, ctx);
     if (r instanceof Promise) {
-      proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalIn, isOptionalOut)));
+      proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalOut)));
     } else {
-      handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
+      handlePropertyResult(r, payload, key, input, isOptionalOut);
     }
   }
   if (unrecognized.length) {
@@ -2675,40 +2633,11 @@ function handleIntersectionResults(result, left, right) {
   result.value = merged.data;
   return result;
 }
-function getTupleOptStart(items, key) {
-  for (let i = items.length - 1;i >= 0; i--) {
-    if (items[i]._zod[key] !== "optional")
-      return i + 1;
-  }
-  return 0;
-}
 function handleTupleResult(result, final, index) {
   if (result.issues.length) {
     final.issues.push(...prefixIssues(index, result.issues));
   }
   final.value[index] = result.value;
-}
-function handleTupleResults(itemResults, final, items, input, optoutStart) {
-  for (let i = 0;i < items.length; i++) {
-    const r = itemResults[i];
-    const isPresent = i < input.length;
-    if (r.issues.length) {
-      if (!isPresent && i >= optoutStart) {
-        final.value.length = i;
-        break;
-      }
-      final.issues.push(...prefixIssues(i, r.issues));
-    }
-    final.value[i] = r.value;
-  }
-  for (let i = final.value.length - 1;i >= input.length; i--) {
-    if (items[i]._zod.optout === "optional" && final.value[i] === undefined) {
-      final.value.length = i;
-    } else {
-      break;
-    }
-  }
-  return final;
 }
 function handleMapResult(keyResult, valueResult, final, key, input, inst, ctx) {
   if (keyResult.issues.length) {
@@ -2747,7 +2676,7 @@ function handleSetResult(result, final) {
   final.value.add(result.value);
 }
 function handleOptionalResult(result, input) {
-  if (input === undefined && (result.issues.length || result.fallback)) {
+  if (result.issues.length && input === undefined) {
     return { issues: [], value: undefined };
   }
   return result;
@@ -2774,7 +2703,7 @@ function handlePipeResult(left, next, ctx) {
     left.aborted = true;
     return left;
   }
-  return next._zod.run({ value: left.value, issues: left.issues, fallback: left.fallback }, ctx);
+  return next._zod.run({ value: left.value, issues: left.issues }, ctx);
 }
 function handleCodecAResult(result, def, ctx) {
   if (result.issues.length) {
@@ -2821,7 +2750,7 @@ function handleRefineResult(result, payload, input, inst) {
     payload.issues.push(issue(_iss));
   }
 }
-var $ZodType, $ZodString, $ZodStringFormat, $ZodGUID, $ZodUUID, $ZodEmail, $ZodURL, $ZodEmoji, $ZodNanoID, $ZodCUID, $ZodCUID2, $ZodULID, $ZodXID, $ZodKSUID, $ZodISODateTime, $ZodISODate, $ZodISOTime, $ZodISODuration, $ZodIPv4, $ZodIPv6, $ZodMAC, $ZodCIDRv4, $ZodCIDRv6, $ZodBase64, $ZodBase64URL, $ZodE164, $ZodJWT, $ZodCustomStringFormat, $ZodNumber, $ZodNumberFormat, $ZodBoolean, $ZodBigInt, $ZodBigIntFormat, $ZodSymbol, $ZodUndefined, $ZodNull, $ZodAny, $ZodUnknown, $ZodNever, $ZodVoid, $ZodDate, $ZodArray, $ZodObject, $ZodObjectJIT, $ZodUnion, $ZodXor, $ZodDiscriminatedUnion, $ZodIntersection, $ZodTuple, $ZodRecord, $ZodMap, $ZodSet, $ZodEnum, $ZodLiteral, $ZodFile, $ZodTransform, $ZodOptional, $ZodExactOptional, $ZodNullable, $ZodDefault, $ZodPrefault, $ZodNonOptional, $ZodSuccess, $ZodCatch, $ZodNaN, $ZodPipe, $ZodCodec, $ZodPreprocess, $ZodReadonly, $ZodTemplateLiteral, $ZodFunction, $ZodPromise, $ZodLazy, $ZodCustom;
+var $ZodType, $ZodString, $ZodStringFormat, $ZodGUID, $ZodUUID, $ZodEmail, $ZodURL, $ZodEmoji, $ZodNanoID, $ZodCUID, $ZodCUID2, $ZodULID, $ZodXID, $ZodKSUID, $ZodISODateTime, $ZodISODate, $ZodISOTime, $ZodISODuration, $ZodIPv4, $ZodIPv6, $ZodMAC, $ZodCIDRv4, $ZodCIDRv6, $ZodBase64, $ZodBase64URL, $ZodE164, $ZodJWT, $ZodCustomStringFormat, $ZodNumber, $ZodNumberFormat, $ZodBoolean, $ZodBigInt, $ZodBigIntFormat, $ZodSymbol, $ZodUndefined, $ZodNull, $ZodAny, $ZodUnknown, $ZodNever, $ZodVoid, $ZodDate, $ZodArray, $ZodObject, $ZodObjectJIT, $ZodUnion, $ZodXor, $ZodDiscriminatedUnion, $ZodIntersection, $ZodTuple, $ZodRecord, $ZodMap, $ZodSet, $ZodEnum, $ZodLiteral, $ZodFile, $ZodTransform, $ZodOptional, $ZodExactOptional, $ZodNullable, $ZodDefault, $ZodPrefault, $ZodNonOptional, $ZodSuccess, $ZodCatch, $ZodNaN, $ZodPipe, $ZodCodec, $ZodReadonly, $ZodTemplateLiteral, $ZodFunction, $ZodPromise, $ZodLazy, $ZodCustom;
 var init_schemas = __esm(() => {
   init_checks();
   init_core();
@@ -2831,7 +2760,7 @@ var init_schemas = __esm(() => {
   init_versions();
   init_util();
   $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
-    var _a2;
+    var _a;
     inst ?? (inst = {});
     inst._zod.def = def;
     inst._zod.bag = inst._zod.bag || {};
@@ -2846,7 +2775,7 @@ var init_schemas = __esm(() => {
       }
     }
     if (checks.length === 0) {
-      (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
+      (_a = inst._zod).deferred ?? (_a.deferred = []);
       inst._zod.deferred?.push(() => {
         inst._zod.run = inst._zod.parse;
       });
@@ -2856,8 +2785,6 @@ var init_schemas = __esm(() => {
         let asyncResult;
         for (const ch of checks2) {
           if (ch._zod.def.when) {
-            if (explicitlyAborted(payload))
-              continue;
             const shouldRun = ch._zod.def.when(payload);
             if (!shouldRun)
               continue;
@@ -2997,19 +2924,6 @@ var init_schemas = __esm(() => {
     inst._zod.check = (payload) => {
       try {
         const trimmed = payload.value.trim();
-        if (!def.normalize && def.protocol?.source === httpProtocol.source) {
-          if (!/^https?:\/\//i.test(trimmed)) {
-            payload.issues.push({
-              code: "invalid_format",
-              format: "url",
-              note: "Invalid URL format",
-              input: payload.value,
-              inst,
-              continue: !def.abort
-            });
-            return;
-          }
-        }
         const url = new URL(trimmed);
         if (def.hostname) {
           def.hostname.lastIndex = 0;
@@ -3313,6 +3227,8 @@ var init_schemas = __esm(() => {
     $ZodType.init(inst, def);
     inst._zod.pattern = _undefined;
     inst._zod.values = new Set([undefined]);
+    inst._zod.optin = "optional";
+    inst._zod.optout = "optional";
     inst._zod.parse = (payload, _ctx) => {
       const input = payload.value;
       if (typeof input === "undefined")
@@ -3483,13 +3399,12 @@ var init_schemas = __esm(() => {
       const shape = value.shape;
       for (const key of value.keys) {
         const el = shape[key];
-        const isOptionalIn = el._zod.optin === "optional";
         const isOptionalOut = el._zod.optout === "optional";
         const r = el._zod.run({ value: input[key], issues: [] }, ctx);
         if (r instanceof Promise) {
-          proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalIn, isOptionalOut)));
+          proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalOut)));
         } else {
-          handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
+          handlePropertyResult(r, payload, key, input, isOptionalOut);
         }
       }
       if (!catchall) {
@@ -3520,10 +3435,9 @@ var init_schemas = __esm(() => {
         const id = ids[key];
         const k = esc(key);
         const schema = shape[key];
-        const isOptionalIn = schema?._zod?.optin === "optional";
         const isOptionalOut = schema?._zod?.optout === "optional";
         doc.write(`const ${id} = ${parseStr(key)};`);
-        if (isOptionalIn && isOptionalOut) {
+        if (isOptionalOut) {
           doc.write(`
         if (${id}.issues.length) {
           if (${k} in input) {
@@ -3542,33 +3456,6 @@ var init_schemas = __esm(() => {
           newResult[${k}] = ${id}.value;
         }
         
-      `);
-        } else if (!isOptionalIn) {
-          doc.write(`
-        const ${id}_present = ${k} in input;
-        if (${id}.issues.length) {
-          payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
-            ...iss,
-            path: iss.path ? [${k}, ...iss.path] : [${k}]
-          })));
-        }
-        if (!${id}_present && !${id}.issues.length) {
-          payload.issues.push({
-            code: "invalid_type",
-            expected: "nonoptional",
-            input: undefined,
-            path: [${k}]
-          });
-        }
-
-        if (${id}_present) {
-          if (${id}.value === undefined) {
-            newResult[${k}] = undefined;
-          } else {
-            newResult[${k}] = ${id}.value;
-          }
-        }
-
       `);
         } else {
           doc.write(`
@@ -3642,9 +3529,10 @@ var init_schemas = __esm(() => {
       }
       return;
     });
-    const first = def.options.length === 1 ? def.options[0]._zod.run : null;
+    const single = def.options.length === 1;
+    const first = def.options[0]._zod.run;
     inst._zod.parse = (payload, ctx) => {
-      if (first) {
+      if (single) {
         return first(payload, ctx);
       }
       let async = false;
@@ -3673,9 +3561,10 @@ var init_schemas = __esm(() => {
   $ZodXor = /* @__PURE__ */ $constructor("$ZodXor", (inst, def) => {
     $ZodUnion.init(inst, def);
     def.inclusive = false;
-    const first = def.options.length === 1 ? def.options[0]._zod.run : null;
+    const single = def.options.length === 1;
+    const first = def.options[0]._zod.run;
     inst._zod.parse = (payload, ctx) => {
-      if (first) {
+      if (single) {
         return first(payload, ctx);
       }
       let async = false;
@@ -3750,7 +3639,7 @@ var init_schemas = __esm(() => {
       if (opt) {
         return opt._zod.run(payload, ctx);
       }
-      if (def.unionFallback || ctx.direction === "backward") {
+      if (def.unionFallback) {
         return _super(payload, ctx);
       }
       payload.issues.push({
@@ -3758,7 +3647,6 @@ var init_schemas = __esm(() => {
         errors: [],
         note: "No matching discriminator",
         discriminator: def.discriminator,
-        options: Array.from(disc.value.keys()),
         input,
         path: [def.discriminator],
         inst
@@ -3797,59 +3685,56 @@ var init_schemas = __esm(() => {
       }
       payload.value = [];
       const proms = [];
-      const optinStart = getTupleOptStart(items, "optin");
-      const optoutStart = getTupleOptStart(items, "optout");
+      const reversedIndex = [...items].reverse().findIndex((item) => item._zod.optin !== "optional");
+      const optStart = reversedIndex === -1 ? 0 : items.length - reversedIndex;
       if (!def.rest) {
-        if (input.length < optinStart) {
+        const tooBig = input.length > items.length;
+        const tooSmall = input.length < optStart - 1;
+        if (tooBig || tooSmall) {
           payload.issues.push({
-            code: "too_small",
-            minimum: optinStart,
-            inclusive: true,
+            ...tooBig ? { code: "too_big", maximum: items.length, inclusive: true } : { code: "too_small", minimum: items.length },
             input,
             inst,
             origin: "array"
           });
           return payload;
         }
-        if (input.length > items.length) {
-          payload.issues.push({
-            code: "too_big",
-            maximum: items.length,
-            inclusive: true,
-            input,
-            inst,
-            origin: "array"
-          });
-        }
       }
-      const itemResults = new Array(items.length);
-      for (let i = 0;i < items.length; i++) {
-        const r = items[i]._zod.run({ value: input[i], issues: [] }, ctx);
-        if (r instanceof Promise) {
-          proms.push(r.then((rr) => {
-            itemResults[i] = rr;
-          }));
+      let i = -1;
+      for (const item of items) {
+        i++;
+        if (i >= input.length) {
+          if (i >= optStart)
+            continue;
+        }
+        const result = item._zod.run({
+          value: input[i],
+          issues: []
+        }, ctx);
+        if (result instanceof Promise) {
+          proms.push(result.then((result2) => handleTupleResult(result2, payload, i)));
         } else {
-          itemResults[i] = r;
+          handleTupleResult(result, payload, i);
         }
       }
       if (def.rest) {
-        let i = items.length - 1;
         const rest = input.slice(items.length);
         for (const el of rest) {
           i++;
-          const result = def.rest._zod.run({ value: el, issues: [] }, ctx);
+          const result = def.rest._zod.run({
+            value: el,
+            issues: []
+          }, ctx);
           if (result instanceof Promise) {
-            proms.push(result.then((r) => handleTupleResult(r, payload, i)));
+            proms.push(result.then((result2) => handleTupleResult(result2, payload, i)));
           } else {
             handleTupleResult(result, payload, i);
           }
         }
       }
-      if (proms.length) {
-        return Promise.all(proms).then(() => handleTupleResults(itemResults, payload, items, input, optoutStart));
-      }
-      return handleTupleResults(itemResults, payload, items, input, optoutStart);
+      if (proms.length)
+        return Promise.all(proms).then(() => payload);
+      return payload;
     };
   });
   $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
@@ -3873,35 +3758,19 @@ var init_schemas = __esm(() => {
         for (const key of values) {
           if (typeof key === "string" || typeof key === "number" || typeof key === "symbol") {
             recordKeys.add(typeof key === "number" ? key.toString() : key);
-            const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
-            if (keyResult instanceof Promise) {
-              throw new Error("Async schemas not supported in object keys currently");
-            }
-            if (keyResult.issues.length) {
-              payload.issues.push({
-                code: "invalid_key",
-                origin: "record",
-                issues: keyResult.issues.map((iss) => finalizeIssue(iss, ctx, config())),
-                input: key,
-                path: [key],
-                inst
-              });
-              continue;
-            }
-            const outKey = keyResult.value;
             const result = def.valueType._zod.run({ value: input[key], issues: [] }, ctx);
             if (result instanceof Promise) {
               proms.push(result.then((result2) => {
                 if (result2.issues.length) {
                   payload.issues.push(...prefixIssues(key, result2.issues));
                 }
-                payload.value[outKey] = result2.value;
+                payload.value[key] = result2.value;
               }));
             } else {
               if (result.issues.length) {
                 payload.issues.push(...prefixIssues(key, result.issues));
               }
-              payload.value[outKey] = result.value;
+              payload.value[key] = result.value;
             }
           }
         }
@@ -3924,8 +3793,6 @@ var init_schemas = __esm(() => {
         payload.value = {};
         for (const key of Reflect.ownKeys(input)) {
           if (key === "__proto__")
-            continue;
-          if (!Object.prototype.propertyIsEnumerable.call(input, key))
             continue;
           let keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
           if (keyResult instanceof Promise) {
@@ -4095,7 +3962,6 @@ var init_schemas = __esm(() => {
   });
   $ZodTransform = /* @__PURE__ */ $constructor("$ZodTransform", (inst, def) => {
     $ZodType.init(inst, def);
-    inst._zod.optin = "optional";
     inst._zod.parse = (payload, ctx) => {
       if (ctx.direction === "backward") {
         throw new $ZodEncodeError(inst.constructor.name);
@@ -4105,7 +3971,6 @@ var init_schemas = __esm(() => {
         const output = _out instanceof Promise ? _out : Promise.resolve(_out);
         return output.then((output2) => {
           payload.value = output2;
-          payload.fallback = true;
           return payload;
         });
       }
@@ -4113,7 +3978,6 @@ var init_schemas = __esm(() => {
         throw new $ZodAsyncError;
       }
       payload.value = _out;
-      payload.fallback = true;
       return payload;
     };
   });
@@ -4130,11 +3994,10 @@ var init_schemas = __esm(() => {
     });
     inst._zod.parse = (payload, ctx) => {
       if (def.innerType._zod.optin === "optional") {
-        const input = payload.value;
         const result = def.innerType._zod.run(payload, ctx);
         if (result instanceof Promise)
-          return result.then((r) => handleOptionalResult(r, input));
-        return handleOptionalResult(result, input);
+          return result.then((r) => handleOptionalResult(r, payload.value));
+        return handleOptionalResult(result, payload.value);
       }
       if (payload.value === undefined) {
         return payload;
@@ -4233,7 +4096,7 @@ var init_schemas = __esm(() => {
   });
   $ZodCatch = /* @__PURE__ */ $constructor("$ZodCatch", (inst, def) => {
     $ZodType.init(inst, def);
-    inst._zod.optin = "optional";
+    defineLazy(inst._zod, "optin", () => def.innerType._zod.optin);
     defineLazy(inst._zod, "optout", () => def.innerType._zod.optout);
     defineLazy(inst._zod, "values", () => def.innerType._zod.values);
     inst._zod.parse = (payload, ctx) => {
@@ -4253,7 +4116,6 @@ var init_schemas = __esm(() => {
               input: payload.value
             });
             payload.issues = [];
-            payload.fallback = true;
           }
           return payload;
         });
@@ -4268,7 +4130,6 @@ var init_schemas = __esm(() => {
           input: payload.value
         });
         payload.issues = [];
-        payload.fallback = true;
       }
       return payload;
     };
@@ -4331,9 +4192,6 @@ var init_schemas = __esm(() => {
         return handleCodecAResult(right, def, ctx);
       }
     };
-  });
-  $ZodPreprocess = /* @__PURE__ */ $constructor("$ZodPreprocess", (inst, def) => {
-    $ZodPipe.init(inst, def);
   });
   $ZodReadonly = /* @__PURE__ */ $constructor("$ZodReadonly", (inst, def) => {
     $ZodType.init(inst, def);
@@ -4482,12 +4340,7 @@ var init_schemas = __esm(() => {
   });
   $ZodLazy = /* @__PURE__ */ $constructor("$ZodLazy", (inst, def) => {
     $ZodType.init(inst, def);
-    defineLazy(inst._zod, "innerType", () => {
-      const d = def;
-      if (!d._cachedInner)
-        d._cachedInner = def.getter();
-      return d._cachedInner;
-    });
+    defineLazy(inst._zod, "innerType", () => def.getter());
     defineLazy(inst._zod, "pattern", () => inst._zod.innerType?._zod?.pattern);
     defineLazy(inst._zod, "propValues", () => inst._zod.innerType?._zod?.propValues);
     defineLazy(inst._zod, "optin", () => inst._zod.innerType?._zod?.optin ?? undefined);
@@ -5475,126 +5328,13 @@ var init_de = __esm(() => {
   init_util();
 });
 
-// node_modules/zod/v4/locales/el.js
-function el_default() {
+// node_modules/zod/v4/locales/en.js
+function en_default() {
   return {
     localeError: error10()
   };
 }
 var error10 = () => {
-  const Sizable = {
-    string: { unit: "\u03C7\u03B1\u03C1\u03B1\u03BA\u03C4\u03AE\u03C1\u03B5\u03C2", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
-    file: { unit: "bytes", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
-    array: { unit: "\u03C3\u03C4\u03BF\u03B9\u03C7\u03B5\u03AF\u03B1", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
-    set: { unit: "\u03C3\u03C4\u03BF\u03B9\u03C7\u03B5\u03AF\u03B1", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
-    map: { unit: "\u03BA\u03B1\u03C4\u03B1\u03C7\u03C9\u03C1\u03AE\u03C3\u03B5\u03B9\u03C2", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" }
-  };
-  function getSizing(origin) {
-    return Sizable[origin] ?? null;
-  }
-  const FormatDictionary = {
-    regex: "\u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2",
-    email: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 email",
-    url: "URL",
-    emoji: "emoji",
-    uuid: "UUID",
-    uuidv4: "UUIDv4",
-    uuidv6: "UUIDv6",
-    nanoid: "nanoid",
-    guid: "GUID",
-    cuid: "cuid",
-    cuid2: "cuid2",
-    ulid: "ULID",
-    xid: "XID",
-    ksuid: "KSUID",
-    datetime: "ISO \u03B7\u03BC\u03B5\u03C1\u03BF\u03BC\u03B7\u03BD\u03AF\u03B1 \u03BA\u03B1\u03B9 \u03CE\u03C1\u03B1",
-    date: "ISO \u03B7\u03BC\u03B5\u03C1\u03BF\u03BC\u03B7\u03BD\u03AF\u03B1",
-    time: "ISO \u03CE\u03C1\u03B1",
-    duration: "ISO \u03B4\u03B9\u03AC\u03C1\u03BA\u03B5\u03B9\u03B1",
-    ipv4: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 IPv4",
-    ipv6: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 IPv6",
-    mac: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 MAC",
-    cidrv4: "\u03B5\u03CD\u03C1\u03BF\u03C2 IPv4",
-    cidrv6: "\u03B5\u03CD\u03C1\u03BF\u03C2 IPv6",
-    base64: "\u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC \u03BA\u03C9\u03B4\u03B9\u03BA\u03BF\u03C0\u03BF\u03B9\u03B7\u03BC\u03AD\u03BD\u03B7 \u03C3\u03B5 base64",
-    base64url: "\u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC \u03BA\u03C9\u03B4\u03B9\u03BA\u03BF\u03C0\u03BF\u03B9\u03B7\u03BC\u03AD\u03BD\u03B7 \u03C3\u03B5 base64url",
-    json_string: "\u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC JSON",
-    e164: "\u03B1\u03C1\u03B9\u03B8\u03BC\u03CC\u03C2 E.164",
-    jwt: "JWT",
-    template_literal: "\u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2"
-  };
-  const TypeDictionary = {
-    nan: "NaN"
-  };
-  return (issue2) => {
-    switch (issue2.code) {
-      case "invalid_type": {
-        const expected = TypeDictionary[issue2.expected] ?? issue2.expected;
-        const receivedType = parsedType(issue2.input);
-        const received = TypeDictionary[receivedType] ?? receivedType;
-        if (typeof issue2.expected === "string" && /^[A-Z]/.test(issue2.expected)) {
-          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD instanceof ${issue2.expected}, \u03BB\u03AE\u03C6\u03B8\u03B7\u03BA\u03B5 ${received}`;
-        }
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${expected}, \u03BB\u03AE\u03C6\u03B8\u03B7\u03BA\u03B5 ${received}`;
-      }
-      case "invalid_value":
-        if (issue2.values.length === 1)
-          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${stringifyPrimitive(issue2.values[0])}`;
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03C0\u03B9\u03BB\u03BF\u03B3\u03AE: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD \u03AD\u03BD\u03B1 \u03B1\u03C0\u03CC ${joinValues(issue2.values, "|")}`;
-      case "too_big": {
-        const adj = issue2.inclusive ? "<=" : "<";
-        const sizing = getSizing(issue2.origin);
-        if (sizing)
-          return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B5\u03B3\u03AC\u03BB\u03BF: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin ?? "\u03C4\u03B9\u03BC\u03AE"} \u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9 ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "\u03C3\u03C4\u03BF\u03B9\u03C7\u03B5\u03AF\u03B1"}`;
-        return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B5\u03B3\u03AC\u03BB\u03BF: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin ?? "\u03C4\u03B9\u03BC\u03AE"} \u03BD\u03B1 \u03B5\u03AF\u03BD\u03B1\u03B9 ${adj}${issue2.maximum.toString()}`;
-      }
-      case "too_small": {
-        const adj = issue2.inclusive ? ">=" : ">";
-        const sizing = getSizing(issue2.origin);
-        if (sizing) {
-          return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B9\u03BA\u03C1\u03CC: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin} \u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9 ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
-        }
-        return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B9\u03BA\u03C1\u03CC: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin} \u03BD\u03B1 \u03B5\u03AF\u03BD\u03B1\u03B9 ${adj}${issue2.minimum.toString()}`;
-      }
-      case "invalid_format": {
-        const _issue = issue2;
-        if (_issue.format === "starts_with") {
-          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03BE\u03B5\u03BA\u03B9\u03BD\u03AC \u03BC\u03B5 "${_issue.prefix}"`;
-        }
-        if (_issue.format === "ends_with")
-          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03C4\u03B5\u03BB\u03B5\u03B9\u03CE\u03BD\u03B5\u03B9 \u03BC\u03B5 "${_issue.suffix}"`;
-        if (_issue.format === "includes")
-          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03C0\u03B5\u03C1\u03B9\u03AD\u03C7\u03B5\u03B9 "${_issue.includes}"`;
-        if (_issue.format === "regex")
-          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03C4\u03B1\u03B9\u03C1\u03B9\u03AC\u03B6\u03B5\u03B9 \u03BC\u03B5 \u03C4\u03BF \u03BC\u03BF\u03C4\u03AF\u03B2\u03BF ${_issue.pattern}`;
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03BF: ${FormatDictionary[_issue.format] ?? issue2.format}`;
-      }
-      case "not_multiple_of":
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03BF\u03C2 \u03B1\u03C1\u03B9\u03B8\u03BC\u03CC\u03C2: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03B5\u03AF\u03BD\u03B1\u03B9 \u03C0\u03BF\u03BB\u03BB\u03B1\u03C0\u03BB\u03AC\u03C3\u03B9\u03BF \u03C4\u03BF\u03C5 ${issue2.divisor}`;
-      case "unrecognized_keys":
-        return `\u0386\u03B3\u03BD\u03C9\u03C3\u03C4${issue2.keys.length > 1 ? "\u03B1" : "\u03BF"} \u03BA\u03BB\u03B5\u03B9\u03B4${issue2.keys.length > 1 ? "\u03B9\u03AC" : "\u03AF"}: ${joinValues(issue2.keys, ", ")}`;
-      case "invalid_key":
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03BF \u03BA\u03BB\u03B5\u03B9\u03B4\u03AF \u03C3\u03C4\u03BF ${issue2.origin}`;
-      case "invalid_union":
-        return "\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2";
-      case "invalid_element":
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C4\u03B9\u03BC\u03AE \u03C3\u03C4\u03BF ${issue2.origin}`;
-      default:
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2`;
-    }
-  };
-};
-var init_el = __esm(() => {
-  init_util();
-});
-
-// node_modules/zod/v4/locales/en.js
-function en_default() {
-  return {
-    localeError: error11()
-  };
-}
-var error11 = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
     file: { unit: "bytes", verb: "to have" },
@@ -5686,10 +5426,6 @@ var error11 = () => {
       case "invalid_key":
         return `Invalid key in ${issue2.origin}`;
       case "invalid_union":
-        if (issue2.options && Array.isArray(issue2.options) && issue2.options.length > 0) {
-          const opts = issue2.options.map((o) => `'${o}'`).join(" | ");
-          return `Invalid discriminator value. Expected ${opts}`;
-        }
         return "Invalid input";
       case "invalid_element":
         return `Invalid value in ${issue2.origin}`;
@@ -5705,10 +5441,10 @@ var init_en = __esm(() => {
 // node_modules/zod/v4/locales/eo.js
 function eo_default() {
   return {
-    localeError: error12()
+    localeError: error11()
   };
 }
-var error12 = () => {
+var error11 = () => {
   const Sizable = {
     string: { unit: "karaktrojn", verb: "havi" },
     file: { unit: "bajtojn", verb: "havi" },
@@ -5818,10 +5554,10 @@ var init_eo = __esm(() => {
 // node_modules/zod/v4/locales/es.js
 function es_default() {
   return {
-    localeError: error13()
+    localeError: error12()
   };
 }
-var error13 = () => {
+var error12 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "tener" },
     file: { unit: "bytes", verb: "tener" },
@@ -5954,10 +5690,10 @@ var init_es = __esm(() => {
 // node_modules/zod/v4/locales/fa.js
 function fa_default() {
   return {
-    localeError: error14()
+    localeError: error13()
   };
 }
-var error14 = () => {
+var error13 = () => {
   const Sizable = {
     string: { unit: "\u06A9\u0627\u0631\u0627\u06A9\u062A\u0631", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
     file: { unit: "\u0628\u0627\u06CC\u062A", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
@@ -6072,10 +5808,10 @@ var init_fa = __esm(() => {
 // node_modules/zod/v4/locales/fi.js
 function fi_default() {
   return {
-    localeError: error15()
+    localeError: error14()
   };
 }
-var error15 = () => {
+var error14 = () => {
   const Sizable = {
     string: { unit: "merkki\xE4", subject: "merkkijonon" },
     file: { unit: "tavua", subject: "tiedoston" },
@@ -6188,10 +5924,10 @@ var init_fi = __esm(() => {
 // node_modules/zod/v4/locales/fr.js
 function fr_default() {
   return {
-    localeError: error16()
+    localeError: error15()
   };
 }
-var error16 = () => {
+var error15 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -6232,27 +5968,9 @@ var error16 = () => {
     template_literal: "entr\xE9e"
   };
   const TypeDictionary = {
-    string: "cha\xEEne",
-    number: "nombre",
-    int: "entier",
-    boolean: "bool\xE9en",
-    bigint: "grand entier",
-    symbol: "symbole",
-    undefined: "ind\xE9fini",
-    null: "null",
-    never: "jamais",
-    void: "vide",
-    date: "date",
-    array: "tableau",
-    object: "objet",
-    tuple: "tuple",
-    record: "enregistrement",
-    map: "carte",
-    set: "ensemble",
-    file: "fichier",
-    nonoptional: "non-optionnel",
     nan: "NaN",
-    function: "fonction"
+    number: "nombre",
+    array: "tableau"
   };
   return (issue2) => {
     switch (issue2.code) {
@@ -6273,15 +5991,16 @@ var error16 = () => {
         const adj = issue2.inclusive ? "<=" : "<";
         const sizing = getSizing(issue2.origin);
         if (sizing)
-          return `Trop grand : ${TypeDictionary[issue2.origin] ?? "valeur"} doit ${sizing.verb} ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "\xE9l\xE9ment(s)"}`;
-        return `Trop grand : ${TypeDictionary[issue2.origin] ?? "valeur"} doit \xEAtre ${adj}${issue2.maximum.toString()}`;
+          return `Trop grand : ${issue2.origin ?? "valeur"} doit ${sizing.verb} ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "\xE9l\xE9ment(s)"}`;
+        return `Trop grand : ${issue2.origin ?? "valeur"} doit \xEAtre ${adj}${issue2.maximum.toString()}`;
       }
       case "too_small": {
         const adj = issue2.inclusive ? ">=" : ">";
         const sizing = getSizing(issue2.origin);
-        if (sizing)
-          return `Trop petit : ${TypeDictionary[issue2.origin] ?? "valeur"} doit ${sizing.verb} ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
-        return `Trop petit : ${TypeDictionary[issue2.origin] ?? "valeur"} doit \xEAtre ${adj}${issue2.minimum.toString()}`;
+        if (sizing) {
+          return `Trop petit : ${issue2.origin} doit ${sizing.verb} ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
+        }
+        return `Trop petit : ${issue2.origin} doit \xEAtre ${adj}${issue2.minimum.toString()}`;
       }
       case "invalid_format": {
         const _issue = issue2;
@@ -6317,10 +6036,10 @@ var init_fr = __esm(() => {
 // node_modules/zod/v4/locales/fr-CA.js
 function fr_CA_default() {
   return {
-    localeError: error17()
+    localeError: error16()
   };
 }
-var error17 = () => {
+var error16 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -6428,10 +6147,10 @@ var init_fr_CA = __esm(() => {
 // node_modules/zod/v4/locales/he.js
 function he_default() {
   return {
-    localeError: error18()
+    localeError: error17()
   };
 }
-var error18 = () => {
+var error17 = () => {
   const TypeNames = {
     string: { label: "\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA", gender: "f" },
     number: { label: "\u05DE\u05E1\u05E4\u05E8", gender: "m" },
@@ -6622,139 +6341,13 @@ var init_he = __esm(() => {
   init_util();
 });
 
-// node_modules/zod/v4/locales/hr.js
-function hr_default() {
-  return {
-    localeError: error19()
-  };
-}
-var error19 = () => {
-  const Sizable = {
-    string: { unit: "znakova", verb: "imati" },
-    file: { unit: "bajtova", verb: "imati" },
-    array: { unit: "stavki", verb: "imati" },
-    set: { unit: "stavki", verb: "imati" }
-  };
-  function getSizing(origin) {
-    return Sizable[origin] ?? null;
-  }
-  const FormatDictionary = {
-    regex: "unos",
-    email: "email adresa",
-    url: "URL",
-    emoji: "emoji",
-    uuid: "UUID",
-    uuidv4: "UUIDv4",
-    uuidv6: "UUIDv6",
-    nanoid: "nanoid",
-    guid: "GUID",
-    cuid: "cuid",
-    cuid2: "cuid2",
-    ulid: "ULID",
-    xid: "XID",
-    ksuid: "KSUID",
-    datetime: "ISO datum i vrijeme",
-    date: "ISO datum",
-    time: "ISO vrijeme",
-    duration: "ISO trajanje",
-    ipv4: "IPv4 adresa",
-    ipv6: "IPv6 adresa",
-    cidrv4: "IPv4 raspon",
-    cidrv6: "IPv6 raspon",
-    base64: "base64 kodirani tekst",
-    base64url: "base64url kodirani tekst",
-    json_string: "JSON tekst",
-    e164: "E.164 broj",
-    jwt: "JWT",
-    template_literal: "unos"
-  };
-  const TypeDictionary = {
-    nan: "NaN",
-    string: "tekst",
-    number: "broj",
-    boolean: "boolean",
-    array: "niz",
-    object: "objekt",
-    set: "skup",
-    file: "datoteka",
-    date: "datum",
-    bigint: "bigint",
-    symbol: "simbol",
-    undefined: "undefined",
-    null: "null",
-    function: "funkcija",
-    map: "mapa"
-  };
-  return (issue2) => {
-    switch (issue2.code) {
-      case "invalid_type": {
-        const expected = TypeDictionary[issue2.expected] ?? issue2.expected;
-        const receivedType = parsedType(issue2.input);
-        const received = TypeDictionary[receivedType] ?? receivedType;
-        if (/^[A-Z]/.test(issue2.expected)) {
-          return `Neispravan unos: o\u010Dekuje se instanceof ${issue2.expected}, a primljeno je ${received}`;
-        }
-        return `Neispravan unos: o\u010Dekuje se ${expected}, a primljeno je ${received}`;
-      }
-      case "invalid_value":
-        if (issue2.values.length === 1)
-          return `Neispravna vrijednost: o\u010Dekivano ${stringifyPrimitive(issue2.values[0])}`;
-        return `Neispravna opcija: o\u010Dekivano jedno od ${joinValues(issue2.values, "|")}`;
-      case "too_big": {
-        const adj = issue2.inclusive ? "<=" : "<";
-        const sizing = getSizing(issue2.origin);
-        const origin = TypeDictionary[issue2.origin] ?? issue2.origin;
-        if (sizing)
-          return `Preveliko: o\u010Dekivano da ${origin ?? "vrijednost"} ima ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "elemenata"}`;
-        return `Preveliko: o\u010Dekivano da ${origin ?? "vrijednost"} bude ${adj}${issue2.maximum.toString()}`;
-      }
-      case "too_small": {
-        const adj = issue2.inclusive ? ">=" : ">";
-        const sizing = getSizing(issue2.origin);
-        const origin = TypeDictionary[issue2.origin] ?? issue2.origin;
-        if (sizing) {
-          return `Premalo: o\u010Dekivano da ${origin} ima ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
-        }
-        return `Premalo: o\u010Dekivano da ${origin} bude ${adj}${issue2.minimum.toString()}`;
-      }
-      case "invalid_format": {
-        const _issue = issue2;
-        if (_issue.format === "starts_with")
-          return `Neispravan tekst: mora zapo\u010Dinjati s "${_issue.prefix}"`;
-        if (_issue.format === "ends_with")
-          return `Neispravan tekst: mora zavr\u0161avati s "${_issue.suffix}"`;
-        if (_issue.format === "includes")
-          return `Neispravan tekst: mora sadr\u017Eavati "${_issue.includes}"`;
-        if (_issue.format === "regex")
-          return `Neispravan tekst: mora odgovarati uzorku ${_issue.pattern}`;
-        return `Neispravna ${FormatDictionary[_issue.format] ?? issue2.format}`;
-      }
-      case "not_multiple_of":
-        return `Neispravan broj: mora biti vi\u0161ekratnik od ${issue2.divisor}`;
-      case "unrecognized_keys":
-        return `Neprepoznat${issue2.keys.length > 1 ? "i klju\u010Devi" : " klju\u010D"}: ${joinValues(issue2.keys, ", ")}`;
-      case "invalid_key":
-        return `Neispravan klju\u010D u ${TypeDictionary[issue2.origin] ?? issue2.origin}`;
-      case "invalid_union":
-        return "Neispravan unos";
-      case "invalid_element":
-        return `Neispravna vrijednost u ${TypeDictionary[issue2.origin] ?? issue2.origin}`;
-      default:
-        return `Neispravan unos`;
-    }
-  };
-};
-var init_hr = __esm(() => {
-  init_util();
-});
-
 // node_modules/zod/v4/locales/hu.js
 function hu_default() {
   return {
-    localeError: error20()
+    localeError: error18()
   };
 }
-var error20 = () => {
+var error18 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "legyen" },
     file: { unit: "byte", verb: "legyen" },
@@ -6873,10 +6466,10 @@ function withDefiniteArticle(word) {
 }
 function hy_default() {
   return {
-    localeError: error21()
+    localeError: error19()
   };
 }
-var error21 = () => {
+var error19 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -7014,10 +6607,10 @@ var init_hy = __esm(() => {
 // node_modules/zod/v4/locales/id.js
 function id_default() {
   return {
-    localeError: error22()
+    localeError: error20()
   };
 }
-var error22 = () => {
+var error20 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "memiliki" },
     file: { unit: "byte", verb: "memiliki" },
@@ -7124,10 +6717,10 @@ var init_id = __esm(() => {
 // node_modules/zod/v4/locales/is.js
 function is_default() {
   return {
-    localeError: error23()
+    localeError: error21()
   };
 }
-var error23 = () => {
+var error21 = () => {
   const Sizable = {
     string: { unit: "stafi", verb: "a\xF0 hafa" },
     file: { unit: "b\xE6ti", verb: "a\xF0 hafa" },
@@ -7237,10 +6830,10 @@ var init_is = __esm(() => {
 // node_modules/zod/v4/locales/it.js
 function it_default() {
   return {
-    localeError: error24()
+    localeError: error22()
   };
 }
-var error24 = () => {
+var error22 = () => {
   const Sizable = {
     string: { unit: "caratteri", verb: "avere" },
     file: { unit: "byte", verb: "avere" },
@@ -7325,7 +6918,7 @@ var error24 = () => {
           return `Stringa non valida: deve includere "${_issue.includes}"`;
         if (_issue.format === "regex")
           return `Stringa non valida: deve corrispondere al pattern ${_issue.pattern}`;
-        return `Input non valido: ${FormatDictionary[_issue.format] ?? issue2.format}`;
+        return `Invalid ${FormatDictionary[_issue.format] ?? issue2.format}`;
       }
       case "not_multiple_of":
         return `Numero non valido: deve essere un multiplo di ${issue2.divisor}`;
@@ -7349,10 +6942,10 @@ var init_it = __esm(() => {
 // node_modules/zod/v4/locales/ja.js
 function ja_default() {
   return {
-    localeError: error25()
+    localeError: error23()
   };
 }
-var error25 = () => {
+var error23 = () => {
   const Sizable = {
     string: { unit: "\u6587\u5B57", verb: "\u3067\u3042\u308B" },
     file: { unit: "\u30D0\u30A4\u30C8", verb: "\u3067\u3042\u308B" },
@@ -7460,10 +7053,10 @@ var init_ja = __esm(() => {
 // node_modules/zod/v4/locales/ka.js
 function ka_default() {
   return {
-    localeError: error26()
+    localeError: error24()
   };
 }
-var error26 = () => {
+var error24 = () => {
   const Sizable = {
     string: { unit: "\u10E1\u10D8\u10DB\u10D1\u10DD\u10DA\u10DD", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
     file: { unit: "\u10D1\u10D0\u10D8\u10E2\u10D8", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
@@ -7496,9 +7089,9 @@ var error26 = () => {
     ipv6: "IPv6 \u10DB\u10D8\u10E1\u10D0\u10DB\u10D0\u10E0\u10D7\u10D8",
     cidrv4: "IPv4 \u10D3\u10D8\u10D0\u10DE\u10D0\u10D6\u10DD\u10DC\u10D8",
     cidrv6: "IPv6 \u10D3\u10D8\u10D0\u10DE\u10D0\u10D6\u10DD\u10DC\u10D8",
-    base64: "base64-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10D5\u10D4\u10DA\u10D8",
-    base64url: "base64url-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10D5\u10D4\u10DA\u10D8",
-    json_string: "JSON \u10D5\u10D4\u10DA\u10D8",
+    base64: "base64-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
+    base64url: "base64url-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
+    json_string: "JSON \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
     e164: "E.164 \u10DC\u10DD\u10DB\u10D4\u10E0\u10D8",
     jwt: "JWT",
     template_literal: "\u10E8\u10D4\u10E7\u10D5\u10D0\u10DC\u10D0"
@@ -7506,7 +7099,7 @@ var error26 = () => {
   const TypeDictionary = {
     nan: "NaN",
     number: "\u10E0\u10D8\u10EA\u10EE\u10D5\u10D8",
-    string: "\u10D5\u10D4\u10DA\u10D8",
+    string: "\u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
     boolean: "\u10D1\u10E3\u10DA\u10D4\u10D0\u10DC\u10D8",
     function: "\u10E4\u10E3\u10DC\u10E5\u10EA\u10D8\u10D0",
     array: "\u10DB\u10D0\u10E1\u10D8\u10D5\u10D8"
@@ -7544,14 +7137,14 @@ var error26 = () => {
       case "invalid_format": {
         const _issue = issue2;
         if (_issue.format === "starts_with") {
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10D8\u10EC\u10E7\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.prefix}"-\u10D8\u10D7`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10D8\u10EC\u10E7\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.prefix}"-\u10D8\u10D7`;
         }
         if (_issue.format === "ends_with")
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10DB\u10D7\u10D0\u10D5\u10E0\u10D3\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.suffix}"-\u10D8\u10D7`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10DB\u10D7\u10D0\u10D5\u10E0\u10D3\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.suffix}"-\u10D8\u10D7`;
         if (_issue.format === "includes")
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1 "${_issue.includes}"-\u10E1`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1 "${_issue.includes}"-\u10E1`;
         if (_issue.format === "regex")
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D4\u10E1\u10D0\u10D1\u10D0\u10DB\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 \u10E8\u10D0\u10D1\u10DA\u10DD\u10DC\u10E1 ${_issue.pattern}`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D4\u10E1\u10D0\u10D1\u10D0\u10DB\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 \u10E8\u10D0\u10D1\u10DA\u10DD\u10DC\u10E1 ${_issue.pattern}`;
         return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 ${FormatDictionary[_issue.format] ?? issue2.format}`;
       }
       case "not_multiple_of":
@@ -7576,10 +7169,10 @@ var init_ka = __esm(() => {
 // node_modules/zod/v4/locales/km.js
 function km_default() {
   return {
-    localeError: error27()
+    localeError: error25()
   };
 }
-var error27 = () => {
+var error25 = () => {
   const Sizable = {
     string: { unit: "\u178F\u17BD\u17A2\u1780\u17D2\u179F\u179A", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
     file: { unit: "\u1794\u17C3", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
@@ -7698,10 +7291,10 @@ var init_kh = __esm(() => {
 // node_modules/zod/v4/locales/ko.js
 function ko_default() {
   return {
-    localeError: error28()
+    localeError: error26()
   };
 }
-var error28 = () => {
+var error26 = () => {
   const Sizable = {
     string: { unit: "\uBB38\uC790", verb: "to have" },
     file: { unit: "\uBC14\uC774\uD2B8", verb: "to have" },
@@ -7823,12 +7416,12 @@ function getUnitTypeFromNumber(number2) {
 }
 function lt_default() {
   return {
-    localeError: error29()
+    localeError: error27()
   };
 }
 var capitalizeFirstCharacter = (text) => {
   return text.charAt(0).toUpperCase() + text.slice(1);
-}, error29 = () => {
+}, error27 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -8019,10 +7612,10 @@ var init_lt = __esm(() => {
 // node_modules/zod/v4/locales/mk.js
 function mk_default() {
   return {
-    localeError: error30()
+    localeError: error28()
   };
 }
-var error30 = () => {
+var error28 = () => {
   const Sizable = {
     string: { unit: "\u0437\u043D\u0430\u0446\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
     file: { unit: "\u0431\u0430\u0458\u0442\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
@@ -8132,10 +7725,10 @@ var init_mk = __esm(() => {
 // node_modules/zod/v4/locales/ms.js
 function ms_default() {
   return {
-    localeError: error31()
+    localeError: error29()
   };
 }
-var error31 = () => {
+var error29 = () => {
   const Sizable = {
     string: { unit: "aksara", verb: "mempunyai" },
     file: { unit: "bait", verb: "mempunyai" },
@@ -8243,10 +7836,10 @@ var init_ms = __esm(() => {
 // node_modules/zod/v4/locales/nl.js
 function nl_default() {
   return {
-    localeError: error32()
+    localeError: error30()
   };
 }
-var error32 = () => {
+var error30 = () => {
   const Sizable = {
     string: { unit: "tekens", verb: "heeft" },
     file: { unit: "bytes", verb: "heeft" },
@@ -8357,10 +7950,10 @@ var init_nl = __esm(() => {
 // node_modules/zod/v4/locales/no.js
 function no_default() {
   return {
-    localeError: error33()
+    localeError: error31()
   };
 }
-var error33 = () => {
+var error31 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "\xE5 ha" },
     file: { unit: "bytes", verb: "\xE5 ha" },
@@ -8469,10 +8062,10 @@ var init_no = __esm(() => {
 // node_modules/zod/v4/locales/ota.js
 function ota_default() {
   return {
-    localeError: error34()
+    localeError: error32()
   };
 }
-var error34 = () => {
+var error32 = () => {
   const Sizable = {
     string: { unit: "harf", verb: "olmal\u0131d\u0131r" },
     file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
@@ -8582,10 +8175,10 @@ var init_ota = __esm(() => {
 // node_modules/zod/v4/locales/ps.js
 function ps_default() {
   return {
-    localeError: error35()
+    localeError: error33()
   };
 }
-var error35 = () => {
+var error33 = () => {
   const Sizable = {
     string: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
     file: { unit: "\u0628\u0627\u06CC\u067C\u0633", verb: "\u0648\u0644\u0631\u064A" },
@@ -8700,10 +8293,10 @@ var init_ps = __esm(() => {
 // node_modules/zod/v4/locales/pl.js
 function pl_default() {
   return {
-    localeError: error36()
+    localeError: error34()
   };
 }
-var error36 = () => {
+var error34 = () => {
   const Sizable = {
     string: { unit: "znak\xF3w", verb: "mie\u0107" },
     file: { unit: "bajt\xF3w", verb: "mie\u0107" },
@@ -8813,10 +8406,10 @@ var init_pl = __esm(() => {
 // node_modules/zod/v4/locales/pt.js
 function pt_default() {
   return {
-    localeError: error37()
+    localeError: error35()
   };
 }
-var error37 = () => {
+var error35 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "ter" },
     file: { unit: "bytes", verb: "ter" },
@@ -8922,129 +8515,6 @@ var init_pt = __esm(() => {
   init_util();
 });
 
-// node_modules/zod/v4/locales/ro.js
-function ro_default() {
-  return {
-    localeError: error38()
-  };
-}
-var error38 = () => {
-  const Sizable = {
-    string: { unit: "caractere", verb: "s\u0103 aib\u0103" },
-    file: { unit: "octe\u021Bi", verb: "s\u0103 aib\u0103" },
-    array: { unit: "elemente", verb: "s\u0103 aib\u0103" },
-    set: { unit: "elemente", verb: "s\u0103 aib\u0103" },
-    map: { unit: "intr\u0103ri", verb: "s\u0103 aib\u0103" }
-  };
-  function getSizing(origin) {
-    return Sizable[origin] ?? null;
-  }
-  const FormatDictionary = {
-    regex: "intrare",
-    email: "adres\u0103 de email",
-    url: "URL",
-    emoji: "emoji",
-    uuid: "UUID",
-    uuidv4: "UUIDv4",
-    uuidv6: "UUIDv6",
-    nanoid: "nanoid",
-    guid: "GUID",
-    cuid: "cuid",
-    cuid2: "cuid2",
-    ulid: "ULID",
-    xid: "XID",
-    ksuid: "KSUID",
-    datetime: "dat\u0103 \u0219i or\u0103 ISO",
-    date: "dat\u0103 ISO",
-    time: "or\u0103 ISO",
-    duration: "durat\u0103 ISO",
-    ipv4: "adres\u0103 IPv4",
-    ipv6: "adres\u0103 IPv6",
-    mac: "adres\u0103 MAC",
-    cidrv4: "interval IPv4",
-    cidrv6: "interval IPv6",
-    base64: "\u0219ir codat base64",
-    base64url: "\u0219ir codat base64url",
-    json_string: "\u0219ir JSON",
-    e164: "num\u0103r E.164",
-    jwt: "JWT",
-    template_literal: "intrare"
-  };
-  const TypeDictionary = {
-    nan: "NaN",
-    string: "\u0219ir",
-    number: "num\u0103r",
-    boolean: "boolean",
-    function: "func\u021Bie",
-    array: "matrice",
-    object: "obiect",
-    undefined: "nedefinit",
-    symbol: "simbol",
-    bigint: "num\u0103r mare",
-    void: "void",
-    never: "never",
-    map: "hart\u0103",
-    set: "set"
-  };
-  return (issue2) => {
-    switch (issue2.code) {
-      case "invalid_type": {
-        const expected = TypeDictionary[issue2.expected] ?? issue2.expected;
-        const receivedType = parsedType(issue2.input);
-        const received = TypeDictionary[receivedType] ?? receivedType;
-        return `Intrare invalid\u0103: a\u0219teptat ${expected}, primit ${received}`;
-      }
-      case "invalid_value":
-        if (issue2.values.length === 1)
-          return `Intrare invalid\u0103: a\u0219teptat ${stringifyPrimitive(issue2.values[0])}`;
-        return `Op\u021Biune invalid\u0103: a\u0219teptat una dintre ${joinValues(issue2.values, "|")}`;
-      case "too_big": {
-        const adj = issue2.inclusive ? "<=" : "<";
-        const sizing = getSizing(issue2.origin);
-        if (sizing)
-          return `Prea mare: a\u0219teptat ca ${issue2.origin ?? "valoarea"} ${sizing.verb} ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "elemente"}`;
-        return `Prea mare: a\u0219teptat ca ${issue2.origin ?? "valoarea"} s\u0103 fie ${adj}${issue2.maximum.toString()}`;
-      }
-      case "too_small": {
-        const adj = issue2.inclusive ? ">=" : ">";
-        const sizing = getSizing(issue2.origin);
-        if (sizing) {
-          return `Prea mic: a\u0219teptat ca ${issue2.origin} ${sizing.verb} ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
-        }
-        return `Prea mic: a\u0219teptat ca ${issue2.origin} s\u0103 fie ${adj}${issue2.minimum.toString()}`;
-      }
-      case "invalid_format": {
-        const _issue = issue2;
-        if (_issue.format === "starts_with") {
-          return `\u0218ir invalid: trebuie s\u0103 \xEEnceap\u0103 cu "${_issue.prefix}"`;
-        }
-        if (_issue.format === "ends_with")
-          return `\u0218ir invalid: trebuie s\u0103 se termine cu "${_issue.suffix}"`;
-        if (_issue.format === "includes")
-          return `\u0218ir invalid: trebuie s\u0103 includ\u0103 "${_issue.includes}"`;
-        if (_issue.format === "regex")
-          return `\u0218ir invalid: trebuie s\u0103 se potriveasc\u0103 cu modelul ${_issue.pattern}`;
-        return `Format invalid: ${FormatDictionary[_issue.format] ?? issue2.format}`;
-      }
-      case "not_multiple_of":
-        return `Num\u0103r invalid: trebuie s\u0103 fie multiplu de ${issue2.divisor}`;
-      case "unrecognized_keys":
-        return `Chei nerecunoscute: ${joinValues(issue2.keys, ", ")}`;
-      case "invalid_key":
-        return `Cheie invalid\u0103 \xEEn ${issue2.origin}`;
-      case "invalid_union":
-        return "Intrare invalid\u0103";
-      case "invalid_element":
-        return `Valoare invalid\u0103 \xEEn ${issue2.origin}`;
-      default:
-        return `Intrare invalid\u0103`;
-    }
-  };
-};
-var init_ro = __esm(() => {
-  init_util();
-});
-
 // node_modules/zod/v4/locales/ru.js
 function getRussianPlural(count, one, few, many) {
   const absCount = Math.abs(count);
@@ -9063,10 +8533,10 @@ function getRussianPlural(count, one, few, many) {
 }
 function ru_default() {
   return {
-    localeError: error39()
+    localeError: error36()
   };
 }
-var error39 = () => {
+var error36 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -9208,10 +8678,10 @@ var init_ru = __esm(() => {
 // node_modules/zod/v4/locales/sl.js
 function sl_default() {
   return {
-    localeError: error40()
+    localeError: error37()
   };
 }
-var error40 = () => {
+var error37 = () => {
   const Sizable = {
     string: { unit: "znakov", verb: "imeti" },
     file: { unit: "bajtov", verb: "imeti" },
@@ -9321,10 +8791,10 @@ var init_sl = __esm(() => {
 // node_modules/zod/v4/locales/sv.js
 function sv_default() {
   return {
-    localeError: error41()
+    localeError: error38()
   };
 }
-var error41 = () => {
+var error38 = () => {
   const Sizable = {
     string: { unit: "tecken", verb: "att ha" },
     file: { unit: "bytes", verb: "att ha" },
@@ -9435,10 +8905,10 @@ var init_sv = __esm(() => {
 // node_modules/zod/v4/locales/ta.js
 function ta_default() {
   return {
-    localeError: error42()
+    localeError: error39()
   };
 }
-var error42 = () => {
+var error39 = () => {
   const Sizable = {
     string: { unit: "\u0B8E\u0BB4\u0BC1\u0BA4\u0BCD\u0BA4\u0BC1\u0B95\u0BCD\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
     file: { unit: "\u0BAA\u0BC8\u0B9F\u0BCD\u0B9F\u0BC1\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
@@ -9549,10 +9019,10 @@ var init_ta = __esm(() => {
 // node_modules/zod/v4/locales/th.js
 function th_default() {
   return {
-    localeError: error43()
+    localeError: error40()
   };
 }
-var error43 = () => {
+var error40 = () => {
   const Sizable = {
     string: { unit: "\u0E15\u0E31\u0E27\u0E2D\u0E31\u0E01\u0E29\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
     file: { unit: "\u0E44\u0E1A\u0E15\u0E4C", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
@@ -9663,10 +9133,10 @@ var init_th = __esm(() => {
 // node_modules/zod/v4/locales/tr.js
 function tr_default() {
   return {
-    localeError: error44()
+    localeError: error41()
   };
 }
-var error44 = () => {
+var error41 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "olmal\u0131" },
     file: { unit: "bayt", verb: "olmal\u0131" },
@@ -9772,10 +9242,10 @@ var init_tr = __esm(() => {
 // node_modules/zod/v4/locales/uk.js
 function uk_default() {
   return {
-    localeError: error45()
+    localeError: error42()
   };
 }
-var error45 = () => {
+var error42 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
     file: { unit: "\u0431\u0430\u0439\u0442\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
@@ -9892,10 +9362,10 @@ var init_ua = __esm(() => {
 // node_modules/zod/v4/locales/ur.js
 function ur_default() {
   return {
-    localeError: error46()
+    localeError: error43()
   };
 }
-var error46 = () => {
+var error43 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0648\u0641", verb: "\u06C1\u0648\u0646\u0627" },
     file: { unit: "\u0628\u0627\u0626\u0679\u0633", verb: "\u06C1\u0648\u0646\u0627" },
@@ -10006,16 +9476,15 @@ var init_ur = __esm(() => {
 // node_modules/zod/v4/locales/uz.js
 function uz_default() {
   return {
-    localeError: error47()
+    localeError: error44()
   };
 }
-var error47 = () => {
+var error44 = () => {
   const Sizable = {
     string: { unit: "belgi", verb: "bo\u2018lishi kerak" },
     file: { unit: "bayt", verb: "bo\u2018lishi kerak" },
     array: { unit: "element", verb: "bo\u2018lishi kerak" },
-    set: { unit: "element", verb: "bo\u2018lishi kerak" },
-    map: { unit: "yozuv", verb: "bo\u2018lishi kerak" }
+    set: { unit: "element", verb: "bo\u2018lishi kerak" }
   };
   function getSizing(origin) {
     return Sizable[origin] ?? null;
@@ -10120,10 +9589,10 @@ var init_uz = __esm(() => {
 // node_modules/zod/v4/locales/vi.js
 function vi_default() {
   return {
-    localeError: error48()
+    localeError: error45()
   };
 }
-var error48 = () => {
+var error45 = () => {
   const Sizable = {
     string: { unit: "k\xFD t\u1EF1", verb: "c\xF3" },
     file: { unit: "byte", verb: "c\xF3" },
@@ -10232,10 +9701,10 @@ var init_vi = __esm(() => {
 // node_modules/zod/v4/locales/zh-CN.js
 function zh_CN_default() {
   return {
-    localeError: error49()
+    localeError: error46()
   };
 }
-var error49 = () => {
+var error46 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u7B26", verb: "\u5305\u542B" },
     file: { unit: "\u5B57\u8282", verb: "\u5305\u542B" },
@@ -10345,10 +9814,10 @@ var init_zh_CN = __esm(() => {
 // node_modules/zod/v4/locales/zh-TW.js
 function zh_TW_default() {
   return {
-    localeError: error50()
+    localeError: error47()
   };
 }
-var error50 = () => {
+var error47 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u5143", verb: "\u64C1\u6709" },
     file: { unit: "\u4F4D\u5143\u7D44", verb: "\u64C1\u6709" },
@@ -10456,10 +9925,10 @@ var init_zh_TW = __esm(() => {
 // node_modules/zod/v4/locales/yo.js
 function yo_default() {
   return {
-    localeError: error51()
+    localeError: error48()
   };
 }
-var error51 = () => {
+var error48 = () => {
   const Sizable = {
     string: { unit: "\xE0mi", verb: "n\xED" },
     file: { unit: "bytes", verb: "n\xED" },
@@ -10581,7 +10050,6 @@ __export(exports_locales, {
   sv: () => sv_default,
   sl: () => sl_default,
   ru: () => ru_default,
-  ro: () => ro_default,
   pt: () => pt_default,
   ps: () => ps_default,
   pl: () => pl_default,
@@ -10601,7 +10069,6 @@ __export(exports_locales, {
   id: () => id_default,
   hy: () => hy_default,
   hu: () => hu_default,
-  hr: () => hr_default,
   he: () => he_default,
   frCA: () => fr_CA_default,
   fr: () => fr_default,
@@ -10610,7 +10077,6 @@ __export(exports_locales, {
   es: () => es_default,
   eo: () => eo_default,
   en: () => en_default,
-  el: () => el_default,
   de: () => de_default,
   da: () => da_default,
   cs: () => cs_default,
@@ -10629,7 +10095,6 @@ var init_locales = __esm(() => {
   init_cs();
   init_da();
   init_de();
-  init_el();
   init_en();
   init_eo();
   init_es();
@@ -10638,7 +10103,6 @@ var init_locales = __esm(() => {
   init_fr();
   init_fr_CA();
   init_he();
-  init_hr();
   init_hu();
   init_hy();
   init_id();
@@ -10658,7 +10122,6 @@ var init_locales = __esm(() => {
   init_ps();
   init_pl();
   init_pt();
-  init_ro();
   init_ru();
   init_sl();
   init_sv();
@@ -10719,11 +10182,11 @@ class $ZodRegistry {
 function registry() {
   return new $ZodRegistry;
 }
-var _a2, $output, $input, globalRegistry;
+var _a, $output, $input, globalRegistry;
 var init_registries = __esm(() => {
   $output = Symbol("ZodOutput");
   $input = Symbol("ZodInput");
-  (_a2 = globalThis).__zod_globalRegistry ?? (_a2.__zod_globalRegistry = registry());
+  (_a = globalThis).__zod_globalRegistry ?? (_a.__zod_globalRegistry = registry());
   globalRegistry = globalThis.__zod_globalRegistry;
 });
 
@@ -11524,7 +10987,7 @@ function _refine(Class2, fn, _params) {
   });
   return schema;
 }
-function _superRefine(fn, params) {
+function _superRefine(fn) {
   const ch = _check((payload) => {
     payload.addIssue = (issue2) => {
       if (typeof issue2 === "string") {
@@ -11541,7 +11004,7 @@ function _superRefine(fn, params) {
       }
     };
     return fn(payload.value, payload);
-  }, params);
+  });
   return ch;
 }
 function _check(fn, params) {
@@ -11677,7 +11140,7 @@ function initializeContext(params) {
   };
 }
 function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
-  var _a3;
+  var _a2;
   const def = schema._zod.def;
   const seen = ctx.seen.get(schema);
   if (seen) {
@@ -11724,8 +11187,8 @@ function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
     delete result.schema.examples;
     delete result.schema.default;
   }
-  if (ctx.io === "input" && "_prefault" in result.schema)
-    (_a3 = result.schema).default ?? (_a3.default = result.schema._prefault);
+  if (ctx.io === "input" && result.schema._prefault)
+    (_a2 = result.schema).default ?? (_a2.default = result.schema._prefault);
   delete result.schema._prefault;
   const _result = ctx.seen.get(schema);
   return _result.schema;
@@ -11902,15 +11365,10 @@ function finalize(ctx, schema) {
     result.$id = ctx.external.uri(id);
   }
   Object.assign(result, root.def ?? root.schema);
-  const rootMetaId = ctx.metadataRegistry.get(schema)?.id;
-  if (rootMetaId !== undefined && result.id === rootMetaId)
-    delete result.id;
   const defs = ctx.external?.defs ?? {};
   for (const entry of ctx.seen.entries()) {
     const seen = entry[1];
     if (seen.def && seen.defId) {
-      if (seen.def.id === seen.defId)
-        delete seen.def.id;
       defs[seen.defId] = seen.def;
     }
   }
@@ -11965,8 +11423,6 @@ function isTransforming(_schema, _ctx) {
     return isTransforming(def.keyType, ctx) || isTransforming(def.valueType, ctx);
   }
   if (def.type === "pipe") {
-    if (_schema._zod.traits.has("$ZodCodec"))
-      return true;
     return isTransforming(def.in, ctx) || isTransforming(def.out, ctx);
   }
   if (def.type === "object") {
@@ -12083,28 +11539,39 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
     json.type = "integer";
   else
     json.type = "number";
-  const exMin = typeof exclusiveMinimum === "number" && exclusiveMinimum >= (minimum ?? Number.NEGATIVE_INFINITY);
-  const exMax = typeof exclusiveMaximum === "number" && exclusiveMaximum <= (maximum ?? Number.POSITIVE_INFINITY);
-  const legacy = ctx.target === "draft-04" || ctx.target === "openapi-3.0";
-  if (exMin) {
-    if (legacy) {
+  if (typeof exclusiveMinimum === "number") {
+    if (ctx.target === "draft-04" || ctx.target === "openapi-3.0") {
       json.minimum = exclusiveMinimum;
       json.exclusiveMinimum = true;
     } else {
       json.exclusiveMinimum = exclusiveMinimum;
     }
-  } else if (typeof minimum === "number") {
-    json.minimum = minimum;
   }
-  if (exMax) {
-    if (legacy) {
+  if (typeof minimum === "number") {
+    json.minimum = minimum;
+    if (typeof exclusiveMinimum === "number" && ctx.target !== "draft-04") {
+      if (exclusiveMinimum >= minimum)
+        delete json.minimum;
+      else
+        delete json.exclusiveMinimum;
+    }
+  }
+  if (typeof exclusiveMaximum === "number") {
+    if (ctx.target === "draft-04" || ctx.target === "openapi-3.0") {
       json.maximum = exclusiveMaximum;
       json.exclusiveMaximum = true;
     } else {
       json.exclusiveMaximum = exclusiveMaximum;
     }
-  } else if (typeof maximum === "number") {
+  }
+  if (typeof maximum === "number") {
     json.maximum = maximum;
+    if (typeof exclusiveMaximum === "number" && ctx.target !== "draft-04") {
+      if (exclusiveMaximum <= maximum)
+        delete json.maximum;
+      else
+        delete json.exclusiveMaximum;
+    }
   }
   if (typeof multipleOf === "number")
     json.multipleOf = multipleOf;
@@ -12250,10 +11717,7 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
   if (typeof maximum === "number")
     json.maxItems = maximum;
   json.type = "array";
-  json.items = process2(def.element, ctx, {
-    ...params,
-    path: [...params.path, "items"]
-  });
+  json.items = process2(def.element, ctx, { ...params, path: [...params.path, "items"] });
 }, objectProcessor = (schema, ctx, _json, params) => {
   const json = _json;
   const def = schema._zod.def;
@@ -12435,8 +11899,7 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
   json.default = catchValue;
 }, pipeProcessor = (schema, ctx, _json, params) => {
   const def = schema._zod.def;
-  const inIsTransform = def.in._zod.traits.has("$ZodTransform");
-  const innerType = ctx.io === "input" ? inIsTransform ? def.out : def.in : def.out;
+  const innerType = ctx.io === "input" ? def.in._zod.def.type === "transform" ? def.out : def.in : def.out;
   process2(innerType, ctx, params);
   const seen = ctx.seen.get(schema);
   seen.ref = innerType;
@@ -12782,7 +12245,6 @@ __export(exports_core2, {
   $ZodRealError: () => $ZodRealError,
   $ZodReadonly: () => $ZodReadonly,
   $ZodPromise: () => $ZodPromise,
-  $ZodPreprocess: () => $ZodPreprocess,
   $ZodPrefault: () => $ZodPrefault,
   $ZodPipe: () => $ZodPipe,
   $ZodOptional: () => $ZodOptional,
@@ -12996,8 +12458,8 @@ var init_errors3 = __esm(() => {
   init_core2();
   init_core2();
   init_util();
-  ZodError = /* @__PURE__ */ $constructor("ZodError", initializer2);
-  ZodRealError = /* @__PURE__ */ $constructor("ZodError", initializer2, {
+  ZodError = $constructor("ZodError", initializer2);
+  ZodRealError = $constructor("ZodError", initializer2, {
     Parent: Error
   });
 });
@@ -13081,7 +12543,6 @@ __export(exports_schemas2, {
   json: () => json,
   ipv6: () => ipv62,
   ipv4: () => ipv42,
-  invertCodec: () => invertCodec,
   intersection: () => intersection,
   int64: () => int64,
   int32: () => int32,
@@ -13142,7 +12603,6 @@ __export(exports_schemas2, {
   ZodRecord: () => ZodRecord,
   ZodReadonly: () => ZodReadonly,
   ZodPromise: () => ZodPromise,
-  ZodPreprocess: () => ZodPreprocess,
   ZodPrefault: () => ZodPrefault,
   ZodPipe: () => ZodPipe,
   ZodOptional: () => ZodOptional,
@@ -13191,42 +12651,6 @@ __export(exports_schemas2, {
   ZodArray: () => ZodArray,
   ZodAny: () => ZodAny
 });
-function _installLazyMethods(inst, group, methods) {
-  const proto = Object.getPrototypeOf(inst);
-  let installed = _installedGroups.get(proto);
-  if (!installed) {
-    installed = new Set;
-    _installedGroups.set(proto, installed);
-  }
-  if (installed.has(group))
-    return;
-  installed.add(group);
-  for (const key in methods) {
-    const fn = methods[key];
-    Object.defineProperty(proto, key, {
-      configurable: true,
-      enumerable: false,
-      get() {
-        const bound = fn.bind(this);
-        Object.defineProperty(this, key, {
-          configurable: true,
-          writable: true,
-          enumerable: true,
-          value: bound
-        });
-        return bound;
-      },
-      set(v) {
-        Object.defineProperty(this, key, {
-          configurable: true,
-          writable: true,
-          enumerable: true,
-          value: v
-        });
-      }
-    });
-  }
-}
 function string2(params) {
   return _string(ZodString, params);
 }
@@ -13253,7 +12677,7 @@ function url(params) {
 }
 function httpUrl(params) {
   return _url(ZodURL, {
-    protocol: exports_regexes.httpProtocol,
+    protocol: /^https?$/,
     hostname: exports_regexes.domain,
     ...exports_util.normalizeParams(params)
   });
@@ -13450,14 +12874,6 @@ function tuple(items, _paramsOrRest, _params) {
   });
 }
 function record(keyType, valueType, params) {
-  if (!valueType || !valueType._zod) {
-    return new ZodRecord({
-      type: "record",
-      keyType: string2(),
-      valueType: keyType,
-      ...exports_util.normalizeParams(valueType)
-    });
-  }
   return new ZodRecord({
     type: "record",
     keyType,
@@ -13608,16 +13024,6 @@ function codec(in_, out, params) {
     reverseTransform: params.encode
   });
 }
-function invertCodec(codec2) {
-  const def = codec2._zod.def;
-  return new ZodCodec({
-    type: "pipe",
-    in: def.out,
-    out: def.in,
-    transform: def.reverseTransform,
-    reverseTransform: def.transform
-  });
-}
 function readonly(innerType) {
   return new ZodReadonly({
     type: "readonly",
@@ -13663,8 +13069,8 @@ function custom(fn, _params) {
 function refine(fn, _params = {}) {
   return _refine(ZodCustom, fn, _params);
 }
-function superRefine(fn, params) {
-  return _superRefine(fn, params);
+function superRefine(fn) {
+  return _superRefine(fn);
 }
 function _instanceof(cls, params = {}) {
   const inst = new ZodCustom({
@@ -13695,13 +13101,9 @@ function json(params) {
   return jsonSchema;
 }
 function preprocess(fn, schema) {
-  return new ZodPreprocess({
-    type: "pipe",
-    in: transform(fn),
-    out: schema
-  });
+  return pipe(transform(fn), schema);
 }
-var _installedGroups, ZodType, _ZodString, ZodString, ZodStringFormat, ZodEmail, ZodGUID, ZodUUID, ZodURL, ZodEmoji, ZodNanoID, ZodCUID, ZodCUID2, ZodULID, ZodXID, ZodKSUID, ZodIPv4, ZodMAC, ZodIPv6, ZodCIDRv4, ZodCIDRv6, ZodBase64, ZodBase64URL, ZodE164, ZodJWT, ZodCustomStringFormat, ZodNumber, ZodNumberFormat, ZodBoolean, ZodBigInt, ZodBigIntFormat, ZodSymbol, ZodUndefined, ZodNull, ZodAny, ZodUnknown, ZodNever, ZodVoid, ZodDate, ZodArray, ZodObject, ZodUnion, ZodXor, ZodDiscriminatedUnion, ZodIntersection, ZodTuple, ZodRecord, ZodMap, ZodSet, ZodEnum, ZodLiteral, ZodFile, ZodTransform, ZodOptional, ZodExactOptional, ZodNullable, ZodDefault, ZodPrefault, ZodNonOptional, ZodSuccess, ZodCatch, ZodNaN, ZodPipe, ZodCodec, ZodPreprocess, ZodReadonly, ZodTemplateLiteral, ZodLazy, ZodPromise, ZodFunction, ZodCustom, describe2, meta2, stringbool = (...args) => _stringbool({
+var ZodType, _ZodString, ZodString, ZodStringFormat, ZodEmail, ZodGUID, ZodUUID, ZodURL, ZodEmoji, ZodNanoID, ZodCUID, ZodCUID2, ZodULID, ZodXID, ZodKSUID, ZodIPv4, ZodMAC, ZodIPv6, ZodCIDRv4, ZodCIDRv6, ZodBase64, ZodBase64URL, ZodE164, ZodJWT, ZodCustomStringFormat, ZodNumber, ZodNumberFormat, ZodBoolean, ZodBigInt, ZodBigIntFormat, ZodSymbol, ZodUndefined, ZodNull, ZodAny, ZodUnknown, ZodNever, ZodVoid, ZodDate, ZodArray, ZodObject, ZodUnion, ZodXor, ZodDiscriminatedUnion, ZodIntersection, ZodTuple, ZodRecord, ZodMap, ZodSet, ZodEnum, ZodLiteral, ZodFile, ZodTransform, ZodOptional, ZodExactOptional, ZodNullable, ZodDefault, ZodPrefault, ZodNonOptional, ZodSuccess, ZodCatch, ZodNaN, ZodPipe, ZodCodec, ZodReadonly, ZodTemplateLiteral, ZodLazy, ZodPromise, ZodFunction, ZodCustom, describe2, meta2, stringbool = (...args) => _stringbool({
   Codec: ZodCodec,
   Boolean: ZodBoolean,
   String: ZodString
@@ -13714,7 +13116,6 @@ var init_schemas2 = __esm(() => {
   init_checks2();
   init_iso();
   init_parse2();
-  _installedGroups = /* @__PURE__ */ new WeakMap;
   ZodType = /* @__PURE__ */ $constructor("ZodType", (inst, def) => {
     $ZodType.init(inst, def);
     Object.assign(inst["~standard"], {
@@ -13727,6 +13128,23 @@ var init_schemas2 = __esm(() => {
     inst.def = def;
     inst.type = def.type;
     Object.defineProperty(inst, "_def", { value: def });
+    inst.check = (...checks2) => {
+      return inst.clone(exports_util.mergeDefs(def, {
+        checks: [
+          ...def.checks ?? [],
+          ...checks2.map((ch) => typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch)
+        ]
+      }), {
+        parent: true
+      });
+    };
+    inst.with = inst.check;
+    inst.clone = (def2, params) => clone(inst, def2, params);
+    inst.brand = () => inst;
+    inst.register = (reg, meta2) => {
+      reg.add(inst, meta2);
+      return inst;
+    };
     inst.parse = (data, params) => parse3(inst, data, params, { callee: inst.parse });
     inst.safeParse = (data, params) => safeParse2(inst, data, params);
     inst.parseAsync = async (data, params) => parseAsync2(inst, data, params, { callee: inst.parseAsync });
@@ -13740,108 +13158,45 @@ var init_schemas2 = __esm(() => {
     inst.safeDecode = (data, params) => safeDecode2(inst, data, params);
     inst.safeEncodeAsync = async (data, params) => safeEncodeAsync2(inst, data, params);
     inst.safeDecodeAsync = async (data, params) => safeDecodeAsync2(inst, data, params);
-    _installLazyMethods(inst, "ZodType", {
-      check(...chks) {
-        const def2 = this.def;
-        return this.clone(exports_util.mergeDefs(def2, {
-          checks: [
-            ...def2.checks ?? [],
-            ...chks.map((ch) => typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch)
-          ]
-        }), { parent: true });
-      },
-      with(...chks) {
-        return this.check(...chks);
-      },
-      clone(def2, params) {
-        return clone(this, def2, params);
-      },
-      brand() {
-        return this;
-      },
-      register(reg, meta2) {
-        reg.add(this, meta2);
-        return this;
-      },
-      refine(check, params) {
-        return this.check(refine(check, params));
-      },
-      superRefine(refinement, params) {
-        return this.check(superRefine(refinement, params));
-      },
-      overwrite(fn) {
-        return this.check(_overwrite(fn));
-      },
-      optional() {
-        return optional(this);
-      },
-      exactOptional() {
-        return exactOptional(this);
-      },
-      nullable() {
-        return nullable(this);
-      },
-      nullish() {
-        return optional(nullable(this));
-      },
-      nonoptional(params) {
-        return nonoptional(this, params);
-      },
-      array() {
-        return array(this);
-      },
-      or(arg) {
-        return union([this, arg]);
-      },
-      and(arg) {
-        return intersection(this, arg);
-      },
-      transform(tx) {
-        return pipe(this, transform(tx));
-      },
-      default(d) {
-        return _default2(this, d);
-      },
-      prefault(d) {
-        return prefault(this, d);
-      },
-      catch(params) {
-        return _catch2(this, params);
-      },
-      pipe(target) {
-        return pipe(this, target);
-      },
-      readonly() {
-        return readonly(this);
-      },
-      describe(description) {
-        const cl = this.clone();
-        globalRegistry.add(cl, { description });
-        return cl;
-      },
-      meta(...args) {
-        if (args.length === 0)
-          return globalRegistry.get(this);
-        const cl = this.clone();
-        globalRegistry.add(cl, args[0]);
-        return cl;
-      },
-      isOptional() {
-        return this.safeParse(undefined).success;
-      },
-      isNullable() {
-        return this.safeParse(null).success;
-      },
-      apply(fn) {
-        return fn(this);
-      }
-    });
+    inst.refine = (check, params) => inst.check(refine(check, params));
+    inst.superRefine = (refinement) => inst.check(superRefine(refinement));
+    inst.overwrite = (fn) => inst.check(_overwrite(fn));
+    inst.optional = () => optional(inst);
+    inst.exactOptional = () => exactOptional(inst);
+    inst.nullable = () => nullable(inst);
+    inst.nullish = () => optional(nullable(inst));
+    inst.nonoptional = (params) => nonoptional(inst, params);
+    inst.array = () => array(inst);
+    inst.or = (arg) => union([inst, arg]);
+    inst.and = (arg) => intersection(inst, arg);
+    inst.transform = (tx) => pipe(inst, transform(tx));
+    inst.default = (def2) => _default2(inst, def2);
+    inst.prefault = (def2) => prefault(inst, def2);
+    inst.catch = (params) => _catch2(inst, params);
+    inst.pipe = (target) => pipe(inst, target);
+    inst.readonly = () => readonly(inst);
+    inst.describe = (description) => {
+      const cl = inst.clone();
+      globalRegistry.add(cl, { description });
+      return cl;
+    };
     Object.defineProperty(inst, "description", {
       get() {
         return globalRegistry.get(inst)?.description;
       },
       configurable: true
     });
+    inst.meta = (...args) => {
+      if (args.length === 0) {
+        return globalRegistry.get(inst);
+      }
+      const cl = inst.clone();
+      globalRegistry.add(cl, args[0]);
+      return cl;
+    };
+    inst.isOptional = () => inst.safeParse(undefined).success;
+    inst.isNullable = () => inst.safeParse(null).success;
+    inst.apply = (fn) => fn(inst);
     return inst;
   });
   _ZodString = /* @__PURE__ */ $constructor("_ZodString", (inst, def) => {
@@ -13852,53 +13207,21 @@ var init_schemas2 = __esm(() => {
     inst.format = bag.format ?? null;
     inst.minLength = bag.minimum ?? null;
     inst.maxLength = bag.maximum ?? null;
-    _installLazyMethods(inst, "_ZodString", {
-      regex(...args) {
-        return this.check(_regex(...args));
-      },
-      includes(...args) {
-        return this.check(_includes(...args));
-      },
-      startsWith(...args) {
-        return this.check(_startsWith(...args));
-      },
-      endsWith(...args) {
-        return this.check(_endsWith(...args));
-      },
-      min(...args) {
-        return this.check(_minLength(...args));
-      },
-      max(...args) {
-        return this.check(_maxLength(...args));
-      },
-      length(...args) {
-        return this.check(_length(...args));
-      },
-      nonempty(...args) {
-        return this.check(_minLength(1, ...args));
-      },
-      lowercase(params) {
-        return this.check(_lowercase(params));
-      },
-      uppercase(params) {
-        return this.check(_uppercase(params));
-      },
-      trim() {
-        return this.check(_trim());
-      },
-      normalize(...args) {
-        return this.check(_normalize(...args));
-      },
-      toLowerCase() {
-        return this.check(_toLowerCase());
-      },
-      toUpperCase() {
-        return this.check(_toUpperCase());
-      },
-      slugify() {
-        return this.check(_slugify());
-      }
-    });
+    inst.regex = (...args) => inst.check(_regex(...args));
+    inst.includes = (...args) => inst.check(_includes(...args));
+    inst.startsWith = (...args) => inst.check(_startsWith(...args));
+    inst.endsWith = (...args) => inst.check(_endsWith(...args));
+    inst.min = (...args) => inst.check(_minLength(...args));
+    inst.max = (...args) => inst.check(_maxLength(...args));
+    inst.length = (...args) => inst.check(_length(...args));
+    inst.nonempty = (...args) => inst.check(_minLength(1, ...args));
+    inst.lowercase = (params) => inst.check(_lowercase(params));
+    inst.uppercase = (params) => inst.check(_uppercase(params));
+    inst.trim = () => inst.check(_trim());
+    inst.normalize = (...args) => inst.check(_normalize(...args));
+    inst.toLowerCase = () => inst.check(_toLowerCase());
+    inst.toUpperCase = () => inst.check(_toUpperCase());
+    inst.slugify = () => inst.check(_slugify());
   });
   ZodString = /* @__PURE__ */ $constructor("ZodString", (inst, def) => {
     $ZodString.init(inst, def);
@@ -14023,53 +13346,21 @@ var init_schemas2 = __esm(() => {
     $ZodNumber.init(inst, def);
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => numberProcessor(inst, ctx, json, params);
-    _installLazyMethods(inst, "ZodNumber", {
-      gt(value, params) {
-        return this.check(_gt(value, params));
-      },
-      gte(value, params) {
-        return this.check(_gte(value, params));
-      },
-      min(value, params) {
-        return this.check(_gte(value, params));
-      },
-      lt(value, params) {
-        return this.check(_lt(value, params));
-      },
-      lte(value, params) {
-        return this.check(_lte(value, params));
-      },
-      max(value, params) {
-        return this.check(_lte(value, params));
-      },
-      int(params) {
-        return this.check(int(params));
-      },
-      safe(params) {
-        return this.check(int(params));
-      },
-      positive(params) {
-        return this.check(_gt(0, params));
-      },
-      nonnegative(params) {
-        return this.check(_gte(0, params));
-      },
-      negative(params) {
-        return this.check(_lt(0, params));
-      },
-      nonpositive(params) {
-        return this.check(_lte(0, params));
-      },
-      multipleOf(value, params) {
-        return this.check(_multipleOf(value, params));
-      },
-      step(value, params) {
-        return this.check(_multipleOf(value, params));
-      },
-      finite() {
-        return this;
-      }
-    });
+    inst.gt = (value, params) => inst.check(_gt(value, params));
+    inst.gte = (value, params) => inst.check(_gte(value, params));
+    inst.min = (value, params) => inst.check(_gte(value, params));
+    inst.lt = (value, params) => inst.check(_lt(value, params));
+    inst.lte = (value, params) => inst.check(_lte(value, params));
+    inst.max = (value, params) => inst.check(_lte(value, params));
+    inst.int = (params) => inst.check(int(params));
+    inst.safe = (params) => inst.check(int(params));
+    inst.positive = (params) => inst.check(_gt(0, params));
+    inst.nonnegative = (params) => inst.check(_gte(0, params));
+    inst.negative = (params) => inst.check(_lt(0, params));
+    inst.nonpositive = (params) => inst.check(_lte(0, params));
+    inst.multipleOf = (value, params) => inst.check(_multipleOf(value, params));
+    inst.step = (value, params) => inst.check(_multipleOf(value, params));
+    inst.finite = () => inst;
     const bag = inst._zod.bag;
     inst.minValue = Math.max(bag.minimum ?? Number.NEGATIVE_INFINITY, bag.exclusiveMinimum ?? Number.NEGATIVE_INFINITY) ?? null;
     inst.maxValue = Math.min(bag.maximum ?? Number.POSITIVE_INFINITY, bag.exclusiveMaximum ?? Number.POSITIVE_INFINITY) ?? null;
@@ -14162,23 +13453,11 @@ var init_schemas2 = __esm(() => {
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => arrayProcessor(inst, ctx, json, params);
     inst.element = def.element;
-    _installLazyMethods(inst, "ZodArray", {
-      min(n, params) {
-        return this.check(_minLength(n, params));
-      },
-      nonempty(params) {
-        return this.check(_minLength(1, params));
-      },
-      max(n, params) {
-        return this.check(_maxLength(n, params));
-      },
-      length(n, params) {
-        return this.check(_length(n, params));
-      },
-      unwrap() {
-        return this.element;
-      }
-    });
+    inst.min = (minLength, params) => inst.check(_minLength(minLength, params));
+    inst.nonempty = (params) => inst.check(_minLength(1, params));
+    inst.max = (maxLength, params) => inst.check(_maxLength(maxLength, params));
+    inst.length = (len, params) => inst.check(_length(len, params));
+    inst.unwrap = () => inst.element;
   });
   ZodObject = /* @__PURE__ */ $constructor("ZodObject", (inst, def) => {
     $ZodObjectJIT.init(inst, def);
@@ -14187,47 +13466,23 @@ var init_schemas2 = __esm(() => {
     exports_util.defineLazy(inst, "shape", () => {
       return def.shape;
     });
-    _installLazyMethods(inst, "ZodObject", {
-      keyof() {
-        return _enum2(Object.keys(this._zod.def.shape));
-      },
-      catchall(catchall) {
-        return this.clone({ ...this._zod.def, catchall });
-      },
-      passthrough() {
-        return this.clone({ ...this._zod.def, catchall: unknown() });
-      },
-      loose() {
-        return this.clone({ ...this._zod.def, catchall: unknown() });
-      },
-      strict() {
-        return this.clone({ ...this._zod.def, catchall: never() });
-      },
-      strip() {
-        return this.clone({ ...this._zod.def, catchall: undefined });
-      },
-      extend(incoming) {
-        return exports_util.extend(this, incoming);
-      },
-      safeExtend(incoming) {
-        return exports_util.safeExtend(this, incoming);
-      },
-      merge(other) {
-        return exports_util.merge(this, other);
-      },
-      pick(mask) {
-        return exports_util.pick(this, mask);
-      },
-      omit(mask) {
-        return exports_util.omit(this, mask);
-      },
-      partial(...args) {
-        return exports_util.partial(ZodOptional, this, args[0]);
-      },
-      required(...args) {
-        return exports_util.required(ZodNonOptional, this, args[0]);
-      }
-    });
+    inst.keyof = () => _enum2(Object.keys(inst._zod.def.shape));
+    inst.catchall = (catchall) => inst.clone({ ...inst._zod.def, catchall });
+    inst.passthrough = () => inst.clone({ ...inst._zod.def, catchall: unknown() });
+    inst.loose = () => inst.clone({ ...inst._zod.def, catchall: unknown() });
+    inst.strict = () => inst.clone({ ...inst._zod.def, catchall: never() });
+    inst.strip = () => inst.clone({ ...inst._zod.def, catchall: undefined });
+    inst.extend = (incoming) => {
+      return exports_util.extend(inst, incoming);
+    };
+    inst.safeExtend = (incoming) => {
+      return exports_util.safeExtend(inst, incoming);
+    };
+    inst.merge = (other) => exports_util.merge(inst, other);
+    inst.pick = (mask) => exports_util.pick(inst, mask);
+    inst.omit = (mask) => exports_util.omit(inst, mask);
+    inst.partial = (...args) => exports_util.partial(ZodOptional, inst, args[0]);
+    inst.required = (...args) => exports_util.required(ZodNonOptional, inst, args[0]);
   });
   ZodUnion = /* @__PURE__ */ $constructor("ZodUnion", (inst, def) => {
     $ZodUnion.init(inst, def);
@@ -14371,12 +13626,10 @@ var init_schemas2 = __esm(() => {
       if (output instanceof Promise) {
         return output.then((output2) => {
           payload.value = output2;
-          payload.fallback = true;
           return payload;
         });
       }
       payload.value = output;
-      payload.fallback = true;
       return payload;
     };
   });
@@ -14445,10 +13698,6 @@ var init_schemas2 = __esm(() => {
   ZodCodec = /* @__PURE__ */ $constructor("ZodCodec", (inst, def) => {
     ZodPipe.init(inst, def);
     $ZodCodec.init(inst, def);
-  });
-  ZodPreprocess = /* @__PURE__ */ $constructor("ZodPreprocess", (inst, def) => {
-    ZodPipe.init(inst, def);
-    $ZodPreprocess.init(inst, def);
   });
   ZodReadonly = /* @__PURE__ */ $constructor("ZodReadonly", (inst, def) => {
     $ZodReadonly.init(inst, def);
@@ -14831,6 +14080,12 @@ function convertBaseSchema(schema, ctx) {
     default:
       throw new Error(`Unsupported type: ${type}`);
   }
+  if (schema.description) {
+    zodSchema = zodSchema.describe(schema.description);
+  }
+  if (schema.default !== undefined) {
+    zodSchema = zodSchema.default(schema.default);
+  }
   return zodSchema;
 }
 function convertSchema(schema, ctx) {
@@ -14867,9 +14122,6 @@ function convertSchema(schema, ctx) {
   if (schema.readOnly === true) {
     baseSchema = z.readonly(baseSchema);
   }
-  if (schema.default !== undefined) {
-    baseSchema = baseSchema.default(schema.default);
-  }
   const extraMeta = {};
   const coreMetadataKeys = ["$id", "id", "$comment", "$anchor", "$vocabulary", "$dynamicRef", "$dynamicAnchor"];
   for (const key of coreMetadataKeys) {
@@ -14891,32 +14143,23 @@ function convertSchema(schema, ctx) {
   if (Object.keys(extraMeta).length > 0) {
     ctx.registry.add(baseSchema, extraMeta);
   }
-  if (schema.description) {
-    baseSchema = baseSchema.describe(schema.description);
-  }
   return baseSchema;
 }
 function fromJSONSchema(schema, params) {
   if (typeof schema === "boolean") {
     return schema ? z.any() : z.never();
   }
-  let normalized;
-  try {
-    normalized = JSON.parse(JSON.stringify(schema));
-  } catch {
-    throw new Error("fromJSONSchema input is not valid JSON (possibly cyclic); use $defs/$ref for recursive schemas");
-  }
-  const version2 = detectVersion(normalized, params?.defaultTarget);
-  const defs = normalized.$defs || normalized.definitions || {};
+  const version2 = detectVersion(schema, params?.defaultTarget);
+  const defs = schema.$defs || schema.definitions || {};
   const ctx = {
     version: version2,
     defs,
     refs: new Map,
     processing: new Set,
-    rootSchema: normalized,
+    rootSchema: schema,
     registry: params?.registry ?? globalRegistry
   };
-  return convertSchema(normalized, ctx);
+  return convertSchema(schema, ctx);
 }
 var z, RECOGNIZED_KEYS;
 var init_from_json_schema = __esm(() => {
@@ -14929,7 +14172,7 @@ var init_from_json_schema = __esm(() => {
     ...exports_checks2,
     iso: exports_iso
   };
-  RECOGNIZED_KEYS = /* @__PURE__ */ new Set([
+  RECOGNIZED_KEYS = new Set([
     "$schema",
     "$ref",
     "$defs",
@@ -15121,7 +14364,6 @@ __export(exports_external, {
   iso: () => exports_iso,
   ipv6: () => ipv62,
   ipv4: () => ipv42,
-  invertCodec: () => invertCodec,
   intersection: () => intersection,
   int64: () => int64,
   int32: () => int32,
@@ -15200,7 +14442,6 @@ __export(exports_external, {
   ZodRealError: () => ZodRealError,
   ZodReadonly: () => ZodReadonly,
   ZodPromise: () => ZodPromise,
-  ZodPreprocess: () => ZodPreprocess,
   ZodPrefault: () => ZodPrefault,
   ZodPipe: () => ZodPipe,
   ZodOptional: () => ZodOptional,
@@ -15390,9 +14631,9 @@ async function computeSpecHash(directory) {
   try {
     const content = await readFile2(specPath, "utf-8");
     hash2 = createHash("sha256").update(content, "utf-8").digest("hex");
-  } catch (error52) {
-    if (error52.code !== "ENOENT") {
-      throw error52;
+  } catch (error49) {
+    if (error49.code !== "ENOENT") {
+      throw error49;
     }
   }
   return hash2;
@@ -15871,9 +15112,9 @@ async function retryCasWithBackoff(directory, eventInput, options) {
         expectedHash: currentExpected,
         planHashAfter: options.planHashAfter
       });
-    } catch (error52) {
-      if (!(error52 instanceof LedgerStaleWriterError) || attempt >= maxRetries) {
-        throw error52;
+    } catch (error49) {
+      if (!(error49 instanceof LedgerStaleWriterError) || attempt >= maxRetries) {
+        throw error49;
       }
       attempt++;
       const base = Math.min(CAS_BACKOFF_START_MS * 2 ** (attempt - 1), CAS_BACKOFF_CAP_MS);
@@ -15905,8 +15146,8 @@ async function loadPlanJsonOnly(directory) {
       const parsed = JSON.parse(planJsonContent);
       const validated = PlanSchema.parse(parsed);
       return validated;
-    } catch (error52) {
-      warn(`Plan validation failed for .swarm/plan.json: ${error52 instanceof Error ? error52.message : String(error52)}`);
+    } catch (error49) {
+      warn(`Plan validation failed for .swarm/plan.json: ${error49 instanceof Error ? error49.message : String(error49)}`);
     }
   }
   return null;
@@ -16103,8 +15344,8 @@ async function loadPlan(directory) {
           }
         }
         return validated;
-      } catch (error52) {
-        warn(`[loadPlan] plan.json validation failed: ${error52 instanceof Error ? error52.message : String(error52)}. Attempting rebuild from ledger. If rebuild fails, check .swarm/SWARM_PLAN.md for a checkpoint.`);
+      } catch (error49) {
+        warn(`[loadPlan] plan.json validation failed: ${error49 instanceof Error ? error49.message : String(error49)}. Attempting rebuild from ledger. If rebuild fails, check .swarm/SWARM_PLAN.md for a checkpoint.`);
         let rawPlanId = null;
         try {
           const rawParsed = JSON.parse(planJsonContent);
@@ -16430,11 +15671,11 @@ async function savePlan(directory, plan, options) {
             }
           });
         }
-      } catch (error52) {
-        if (error52 instanceof LedgerStaleWriterError) {
-          throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error52.message}. Please retry the operation.`);
+      } catch (error49) {
+        if (error49 instanceof LedgerStaleWriterError) {
+          throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error49.message}. Please retry the operation.`);
         }
-        throw error52;
+        throw error49;
       }
     }
     try {
@@ -16472,11 +15713,11 @@ async function savePlan(directory, plan, options) {
           }
         }
       }
-    } catch (error52) {
-      if (error52 instanceof LedgerStaleWriterError) {
-        throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error52.message}. Please retry the operation.`);
+    } catch (error49) {
+      if (error49 instanceof LedgerStaleWriterError) {
+        throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error49.message}. Please retry the operation.`);
       }
-      throw error52;
+      throw error49;
     }
   }
   const SNAPSHOT_INTERVAL = 50;
@@ -16877,11 +16118,11 @@ async function handleAcknowledgeSpecDriftCommand(directory, _args, acknowledgedB
   let stalenessContent;
   try {
     stalenessContent = await fsPromises3.readFile(specStalenessPath, "utf-8");
-  } catch (error52) {
-    if (error52?.code === "ENOENT") {
+  } catch (error49) {
+    if (error49?.code === "ENOENT") {
       return "No spec drift detected.";
     }
-    throw error52;
+    throw error49;
   }
   let stalenessData;
   try {
@@ -18650,10 +17891,10 @@ function loadRawConfigFromPath(configPath) {
       fileExisted: true,
       hadError: false
     };
-  } catch (error52) {
-    const isFileNotFoundError = error52 instanceof Error && "code" in error52 && error52.code === "ENOENT";
+  } catch (error49) {
+    const isFileNotFoundError = error49 instanceof Error && "code" in error49 && error49.code === "ENOENT";
     if (!isFileNotFoundError) {
-      const errorMessage = error52 instanceof Error ? error52.message : String(error52);
+      const errorMessage = error49 instanceof Error ? error49.message : String(error49);
       console.warn(`[opencode-swarm] \u26A0\uFE0F CONFIG LOAD FAILURE \u2014 config exists at ${configPath} but could not be loaded: ${errorMessage}`);
       console.warn("[opencode-swarm] \u26A0\uFE0F SECURITY: Config load failed. Falling back to safe defaults with guardrails ENABLED.");
       return { config: null, fileExisted: true, hadError: true };
@@ -19181,7 +18422,7 @@ var require_polyfills = __commonJS((exports, module) => {
           return ret;
         };
       } else if (fs4.futimes) {
-        fs4.lutimes = function(_a3, _b, _c, cb) {
+        fs4.lutimes = function(_a2, _b, _c, cb) {
           if (cb)
             process.nextTick(cb);
         };
@@ -19877,12 +19118,12 @@ var require_retry_operation = __commonJS((exports, module) => {
     var mainError = null;
     var mainErrorCount = 0;
     for (var i = 0;i < this._errors.length; i++) {
-      var error52 = this._errors[i];
-      var message = error52.message;
+      var error49 = this._errors[i];
+      var message = error49.message;
       var count = (counts[message] || 0) + 1;
       counts[message] = count;
       if (count >= mainErrorCount) {
-        mainError = error52;
+        mainError = error49;
         mainErrorCount = count;
       }
     }
@@ -20721,8 +19962,8 @@ function validateProjectRoot(directory) {
               hasProjectIndicator = true;
               break;
             }
-          } catch (error52) {
-            if (error52 instanceof Error && "code" in error52 && error52.code === "ENOENT") {} else {
+          } catch (error49) {
+            if (error49 instanceof Error && "code" in error49 && error49.code === "ENOENT") {} else {
               hasProjectIndicator = true;
               break;
             }
@@ -20733,9 +19974,9 @@ function validateProjectRoot(directory) {
           throw new Error(`Cannot write evidence in "${resolved}" \u2014 parent directory "${parent}" already contains a .swarm/ folder. Evidence must be written to the project root.`);
         }
       }
-    } catch (error52) {
-      if (error52 instanceof Error && error52.message.startsWith("Cannot write evidence")) {
-        throw error52;
+    } catch (error49) {
+      if (error49 instanceof Error && error49.message.startsWith("Cannot write evidence")) {
+        throw error49;
       }
     }
     current = parent;
@@ -20755,8 +19996,8 @@ async function saveEvidence(directory, taskId, evidence) {
       try {
         const parsed = JSON.parse(existingContent);
         bundle = EvidenceBundleSchema.parse(parsed);
-      } catch (error52) {
-        warn(`Existing evidence bundle invalid for task ${sanitizedTaskId}, creating new: ${error52 instanceof Error ? error52.message : String(error52)}`);
+      } catch (error49) {
+        warn(`Existing evidence bundle invalid for task ${sanitizedTaskId}, creating new: ${error49 instanceof Error ? error49.message : String(error49)}`);
         const now = new Date().toISOString();
         bundle = {
           schema_version: "1.0.0",
@@ -20795,11 +20036,11 @@ async function saveEvidence(directory, taskId, evidence) {
     try {
       await bunWrite(tempPath, bundleJson);
       await fs4.rename(tempPath, evidencePath);
-    } catch (error52) {
+    } catch (error49) {
       try {
         rmSync(tempPath, { force: true });
       } catch {}
-      throw error52;
+      throw error49;
     }
     return updatedBundle;
   });
@@ -20865,18 +20106,18 @@ async function loadEvidence(directory, taskId) {
         warn(`Evidence lock failed during flat-retrospective write-back for task ${sanitizedTaskId}: ${lockErr instanceof Error ? lockErr.message : String(lockErr)}`);
       }
       return { status: "found", bundle: validated };
-    } catch (error52) {
-      warn(`Wrapped flat retrospective failed validation for task ${sanitizedTaskId}: ${error52 instanceof Error ? error52.message : String(error52)}`);
-      const errors3 = error52 instanceof ZodError ? error52.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error52 instanceof Error ? error52.message : String(error52)];
+    } catch (error49) {
+      warn(`Wrapped flat retrospective failed validation for task ${sanitizedTaskId}: ${error49 instanceof Error ? error49.message : String(error49)}`);
+      const errors3 = error49 instanceof ZodError ? error49.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error49 instanceof Error ? error49.message : String(error49)];
       return { status: "invalid_schema", errors: errors3 };
     }
   }
   try {
     const validated = EvidenceBundleSchema.parse(parsed);
     return { status: "found", bundle: validated };
-  } catch (error52) {
-    warn(`Evidence bundle validation failed for task ${sanitizedTaskId}: ${error52 instanceof Error ? error52.message : String(error52)}`);
-    const errors3 = error52 instanceof ZodError ? error52.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error52 instanceof Error ? error52.message : String(error52)];
+  } catch (error49) {
+    warn(`Evidence bundle validation failed for task ${sanitizedTaskId}: ${error49 instanceof Error ? error49.message : String(error49)}`);
+    const errors3 = error49 instanceof ZodError ? error49.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error49 instanceof Error ? error49.message : String(error49)];
     return { status: "invalid_schema", errors: errors3 };
   }
 }
@@ -20903,9 +20144,9 @@ async function listEvidenceTaskIds(directory) {
       }
       sanitizeTaskId2(entry);
       taskIds.push(entry);
-    } catch (error52) {
-      if (error52 instanceof Error && !error52.message.startsWith("Invalid task ID")) {
-        warn(`Error reading evidence entry '${entry}': ${error52.message}`);
+    } catch (error49) {
+      if (error49 instanceof Error && !error49.message.startsWith("Invalid task ID")) {
+        warn(`Error reading evidence entry '${entry}': ${error49.message}`);
       }
     }
   }
@@ -20923,8 +20164,8 @@ async function deleteEvidence(directory, taskId) {
   try {
     rmSync(evidenceDir, { recursive: true, force: true });
     return true;
-  } catch (error52) {
-    warn(`Failed to delete evidence for task ${sanitizedTaskId}: ${error52 instanceof Error ? error52.message : String(error52)}`);
+  } catch (error49) {
+    warn(`Failed to delete evidence for task ${sanitizedTaskId}: ${error49 instanceof Error ? error49.message : String(error49)}`);
     return false;
   }
 }
@@ -21825,14 +21066,14 @@ function withProbeTimeout(cmd, args, ms) {
         timeout: ms,
         windowsHide: true,
         cwd: os3.tmpdir()
-      }, (error52, stdout, _stderr) => {
+      }, (error49, stdout, _stderr) => {
         clearTimeout(timer);
-        if (error52) {
-          const exc = error52;
+        if (error49) {
+          const exc = error49;
           if (exc.code === "ENOENT" || exc.code === "ENOTFOUND") {
             reject(new Error("binary not found"));
           } else {
-            reject(error52);
+            reject(error49);
           }
           return;
         }
@@ -23284,12 +22525,12 @@ async function handleBrainstormCommand(_directory, args) {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/core/core.js
 function $constructor2(name, initializer3, params) {
   function init(inst, def) {
-    var _a3;
+    var _a2;
     Object.defineProperty(inst, "_zod", {
       value: inst._zod ?? {},
       enumerable: false
     });
-    (_a3 = inst._zod).traits ?? (_a3.traits = new Set);
+    (_a2 = inst._zod).traits ?? (_a2.traits = new Set);
     inst._zod.traits.add(name);
     initializer3(inst, def);
     for (const k in _.prototype) {
@@ -23305,10 +22546,10 @@ function $constructor2(name, initializer3, params) {
   }
   Object.defineProperty(Definition, "name", { value: name });
   function _(def) {
-    var _a3;
+    var _a2;
     const inst = params?.Parent ? new Definition : this;
     init(inst, def);
-    (_a3 = inst._zod).deferred ?? (_a3.deferred = []);
+    (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
     for (const fn of inst._zod.deferred) {
       fn();
     }
@@ -23811,8 +23052,8 @@ function aborted2(x, startIndex = 0) {
 }
 function prefixIssues2(path10, issues) {
   return issues.map((iss) => {
-    var _a3;
-    (_a3 = iss).path ?? (_a3.path = []);
+    var _a2;
+    (_a2 = iss).path ?? (_a2.path = []);
     iss.path.unshift(path10);
     return iss;
   });
@@ -23982,10 +23223,10 @@ var init_util2 = __esm(() => {
 });
 
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/core/errors.js
-function flattenError2(error52, mapper = (issue3) => issue3.message) {
+function flattenError2(error49, mapper = (issue3) => issue3.message) {
   const fieldErrors = {};
   const formErrors = [];
-  for (const sub of error52.issues) {
+  for (const sub of error49.issues) {
     if (sub.path.length > 0) {
       fieldErrors[sub.path[0]] = fieldErrors[sub.path[0]] || [];
       fieldErrors[sub.path[0]].push(mapper(sub));
@@ -23995,13 +23236,13 @@ function flattenError2(error52, mapper = (issue3) => issue3.message) {
   }
   return { formErrors, fieldErrors };
 }
-function formatError2(error52, _mapper) {
+function formatError2(error49, _mapper) {
   const mapper = _mapper || function(issue3) {
     return issue3.message;
   };
   const fieldErrors = { _errors: [] };
-  const processError = (error53) => {
-    for (const issue3 of error53.issues) {
+  const processError = (error50) => {
+    for (const issue3 of error50.issues) {
       if (issue3.code === "invalid_union" && issue3.errors.length) {
         issue3.errors.map((issues) => processError({ issues }));
       } else if (issue3.code === "invalid_key") {
@@ -24028,17 +23269,17 @@ function formatError2(error52, _mapper) {
       }
     }
   };
-  processError(error52);
+  processError(error49);
   return fieldErrors;
 }
-function treeifyError2(error52, _mapper) {
+function treeifyError2(error49, _mapper) {
   const mapper = _mapper || function(issue3) {
     return issue3.message;
   };
   const result = { errors: [] };
-  const processError = (error53, path10 = []) => {
-    var _a3, _b;
-    for (const issue3 of error53.issues) {
+  const processError = (error50, path10 = []) => {
+    var _a2, _b;
+    for (const issue3 of error50.issues) {
       if (issue3.code === "invalid_union" && issue3.errors.length) {
         issue3.errors.map((issues) => processError({ issues }, issue3.path));
       } else if (issue3.code === "invalid_key") {
@@ -24058,7 +23299,7 @@ function treeifyError2(error52, _mapper) {
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
             curr.properties ?? (curr.properties = {});
-            (_a3 = curr.properties)[el] ?? (_a3[el] = { errors: [] });
+            (_a2 = curr.properties)[el] ?? (_a2[el] = { errors: [] });
             curr = curr.properties[el];
           } else {
             curr.items ?? (curr.items = []);
@@ -24073,7 +23314,7 @@ function treeifyError2(error52, _mapper) {
       }
     }
   };
-  processError(error52);
+  processError(error49);
   return result;
 }
 function toDotPath2(_path) {
@@ -24094,9 +23335,9 @@ function toDotPath2(_path) {
   }
   return segs.join("");
 }
-function prettifyError2(error52) {
+function prettifyError2(error49) {
   const lines = [];
-  const issues = [...error52.issues].sort((a, b) => (a.path ?? []).length - (b.path ?? []).length);
+  const issues = [...error49.issues].sort((a, b) => (a.path ?? []).length - (b.path ?? []).length);
   for (const issue3 of issues) {
     lines.push(`\u2716 ${issue3.message}`);
     if (issue3.path?.length)
@@ -24373,10 +23614,10 @@ var init_checks3 = __esm(() => {
   init_regexes2();
   init_util2();
   $ZodCheck2 = /* @__PURE__ */ $constructor2("$ZodCheck", (inst, def) => {
-    var _a3;
+    var _a2;
     inst._zod ?? (inst._zod = {});
     inst._zod.def = def;
-    (_a3 = inst._zod).onattach ?? (_a3.onattach = []);
+    (_a2 = inst._zod).onattach ?? (_a2.onattach = []);
   });
   numericOriginMap2 = {
     number: "number",
@@ -24442,8 +23683,8 @@ var init_checks3 = __esm(() => {
   $ZodCheckMultipleOf2 = /* @__PURE__ */ $constructor2("$ZodCheckMultipleOf", (inst, def) => {
     $ZodCheck2.init(inst, def);
     inst._zod.onattach.push((inst2) => {
-      var _a3;
-      (_a3 = inst2._zod.bag).multipleOf ?? (_a3.multipleOf = def.value);
+      var _a2;
+      (_a2 = inst2._zod.bag).multipleOf ?? (_a2.multipleOf = def.value);
     });
     inst._zod.check = (payload) => {
       if (typeof payload.value !== typeof def.value)
@@ -24570,9 +23811,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMaxSize2 = /* @__PURE__ */ $constructor2("$ZodCheckMaxSize", (inst, def) => {
-    var _a3;
+    var _a2;
     $ZodCheck2.init(inst, def);
-    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.size !== undefined;
     });
@@ -24598,9 +23839,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMinSize2 = /* @__PURE__ */ $constructor2("$ZodCheckMinSize", (inst, def) => {
-    var _a3;
+    var _a2;
     $ZodCheck2.init(inst, def);
-    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.size !== undefined;
     });
@@ -24626,9 +23867,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckSizeEquals2 = /* @__PURE__ */ $constructor2("$ZodCheckSizeEquals", (inst, def) => {
-    var _a3;
+    var _a2;
     $ZodCheck2.init(inst, def);
-    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.size !== undefined;
     });
@@ -24656,9 +23897,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMaxLength2 = /* @__PURE__ */ $constructor2("$ZodCheckMaxLength", (inst, def) => {
-    var _a3;
+    var _a2;
     $ZodCheck2.init(inst, def);
-    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.length !== undefined;
     });
@@ -24685,9 +23926,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMinLength2 = /* @__PURE__ */ $constructor2("$ZodCheckMinLength", (inst, def) => {
-    var _a3;
+    var _a2;
     $ZodCheck2.init(inst, def);
-    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.length !== undefined;
     });
@@ -24714,9 +23955,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckLengthEquals2 = /* @__PURE__ */ $constructor2("$ZodCheckLengthEquals", (inst, def) => {
-    var _a3;
+    var _a2;
     $ZodCheck2.init(inst, def);
-    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.length !== undefined;
     });
@@ -24745,7 +23986,7 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckStringFormat2 = /* @__PURE__ */ $constructor2("$ZodCheckStringFormat", (inst, def) => {
-    var _a3, _b;
+    var _a2, _b;
     $ZodCheck2.init(inst, def);
     inst._zod.onattach.push((inst2) => {
       const bag = inst2._zod.bag;
@@ -24756,7 +23997,7 @@ var init_checks3 = __esm(() => {
       }
     });
     if (def.pattern)
-      (_a3 = inst._zod).check ?? (_a3.check = (payload) => {
+      (_a2 = inst._zod).check ?? (_a2.check = (payload) => {
         def.pattern.lastIndex = 0;
         if (def.pattern.test(payload.value))
           return;
@@ -25270,7 +24511,7 @@ var init_schemas3 = __esm(() => {
   init_versions2();
   init_util2();
   $ZodType2 = /* @__PURE__ */ $constructor2("$ZodType", (inst, def) => {
-    var _a3;
+    var _a2;
     inst ?? (inst = {});
     inst._zod.def = def;
     inst._zod.bag = inst._zod.bag || {};
@@ -25285,7 +24526,7 @@ var init_schemas3 = __esm(() => {
       }
     }
     if (checks3.length === 0) {
-      (_a3 = inst._zod).deferred ?? (_a3.deferred = []);
+      (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
       inst._zod.deferred?.push(() => {
         inst._zod.run = inst._zod.parse;
       });
@@ -26793,10 +26034,10 @@ var init_schemas3 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ar.js
 function ar_default2() {
   return {
-    localeError: error52()
+    localeError: error49()
   };
 }
-var error52 = () => {
+var error49 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0641", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
     file: { unit: "\u0628\u0627\u064A\u062A", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
@@ -26913,10 +26154,10 @@ var init_ar2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/az.js
 function az_default2() {
   return {
-    localeError: error53()
+    localeError: error50()
   };
 }
-var error53 = () => {
+var error50 = () => {
   const Sizable = {
     string: { unit: "simvol", verb: "olmal\u0131d\u0131r" },
     file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
@@ -27047,10 +26288,10 @@ function getBelarusianPlural2(count, one, few, many) {
 }
 function be_default2() {
   return {
-    localeError: error54()
+    localeError: error51()
   };
 }
-var error54 = () => {
+var error51 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -27200,10 +26441,10 @@ var init_be2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ca.js
 function ca_default2() {
   return {
-    localeError: error55()
+    localeError: error52()
   };
 }
-var error55 = () => {
+var error52 = () => {
   const Sizable = {
     string: { unit: "car\xE0cters", verb: "contenir" },
     file: { unit: "bytes", verb: "contenir" },
@@ -27321,10 +26562,10 @@ var init_ca2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/cs.js
 function cs_default2() {
   return {
-    localeError: error56()
+    localeError: error53()
   };
 }
-var error56 = () => {
+var error53 = () => {
   const Sizable = {
     string: { unit: "znak\u016F", verb: "m\xEDt" },
     file: { unit: "bajt\u016F", verb: "m\xEDt" },
@@ -27460,10 +26701,10 @@ var init_cs2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/da.js
 function da_default2() {
   return {
-    localeError: error57()
+    localeError: error54()
   };
 }
-var error57 = () => {
+var error54 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "havde" },
     file: { unit: "bytes", verb: "havde" },
@@ -27595,10 +26836,10 @@ var init_da2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/de.js
 function de_default2() {
   return {
-    localeError: error58()
+    localeError: error55()
   };
 }
-var error58 = () => {
+var error55 = () => {
   const Sizable = {
     string: { unit: "Zeichen", verb: "zu haben" },
     file: { unit: "Bytes", verb: "zu haben" },
@@ -27715,7 +26956,7 @@ var init_de2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/en.js
 function en_default2() {
   return {
-    localeError: error59()
+    localeError: error56()
   };
 }
 var parsedType2 = (data) => {
@@ -27737,7 +26978,7 @@ var parsedType2 = (data) => {
     }
   }
   return t;
-}, error59 = () => {
+}, error56 = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
     file: { unit: "bytes", verb: "to have" },
@@ -27835,7 +27076,7 @@ var init_en2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/eo.js
 function eo_default2() {
   return {
-    localeError: error60()
+    localeError: error57()
   };
 }
 var parsedType3 = (data) => {
@@ -27857,7 +27098,7 @@ var parsedType3 = (data) => {
     }
   }
   return t;
-}, error60 = () => {
+}, error57 = () => {
   const Sizable = {
     string: { unit: "karaktrojn", verb: "havi" },
     file: { unit: "bajtojn", verb: "havi" },
@@ -27954,10 +27195,10 @@ var init_eo2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/es.js
 function es_default2() {
   return {
-    localeError: error61()
+    localeError: error58()
   };
 }
-var error61 = () => {
+var error58 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "tener" },
     file: { unit: "bytes", verb: "tener" },
@@ -28106,10 +27347,10 @@ var init_es2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fa.js
 function fa_default2() {
   return {
-    localeError: error62()
+    localeError: error59()
   };
 }
-var error62 = () => {
+var error59 = () => {
   const Sizable = {
     string: { unit: "\u06A9\u0627\u0631\u0627\u06A9\u062A\u0631", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
     file: { unit: "\u0628\u0627\u06CC\u062A", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
@@ -28232,10 +27473,10 @@ var init_fa2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fi.js
 function fi_default2() {
   return {
-    localeError: error63()
+    localeError: error60()
   };
 }
-var error63 = () => {
+var error60 = () => {
   const Sizable = {
     string: { unit: "merkki\xE4", subject: "merkkijonon" },
     file: { unit: "tavua", subject: "tiedoston" },
@@ -28358,10 +27599,10 @@ var init_fi2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fr.js
 function fr_default2() {
   return {
-    localeError: error64()
+    localeError: error61()
   };
 }
-var error64 = () => {
+var error61 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -28478,10 +27719,10 @@ var init_fr2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fr-CA.js
 function fr_CA_default2() {
   return {
-    localeError: error65()
+    localeError: error62()
   };
 }
-var error65 = () => {
+var error62 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -28599,10 +27840,10 @@ var init_fr_CA2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/he.js
 function he_default2() {
   return {
-    localeError: error66()
+    localeError: error63()
   };
 }
-var error66 = () => {
+var error63 = () => {
   const Sizable = {
     string: { unit: "\u05D0\u05D5\u05EA\u05D9\u05D5\u05EA", verb: "\u05DC\u05DB\u05DC\u05D5\u05DC" },
     file: { unit: "\u05D1\u05D9\u05D9\u05D8\u05D9\u05DD", verb: "\u05DC\u05DB\u05DC\u05D5\u05DC" },
@@ -28719,10 +27960,10 @@ var init_he2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/hu.js
 function hu_default2() {
   return {
-    localeError: error67()
+    localeError: error64()
   };
 }
-var error67 = () => {
+var error64 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "legyen" },
     file: { unit: "byte", verb: "legyen" },
@@ -28839,10 +28080,10 @@ var init_hu2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/id.js
 function id_default2() {
   return {
-    localeError: error68()
+    localeError: error65()
   };
 }
-var error68 = () => {
+var error65 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "memiliki" },
     file: { unit: "byte", verb: "memiliki" },
@@ -28959,7 +28200,7 @@ var init_id2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/is.js
 function is_default2() {
   return {
-    localeError: error69()
+    localeError: error66()
   };
 }
 var parsedType4 = (data) => {
@@ -28981,7 +28222,7 @@ var parsedType4 = (data) => {
     }
   }
   return t;
-}, error69 = () => {
+}, error66 = () => {
   const Sizable = {
     string: { unit: "stafi", verb: "a\xF0 hafa" },
     file: { unit: "b\xE6ti", verb: "a\xF0 hafa" },
@@ -29079,10 +28320,10 @@ var init_is2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/it.js
 function it_default2() {
   return {
-    localeError: error70()
+    localeError: error67()
   };
 }
-var error70 = () => {
+var error67 = () => {
   const Sizable = {
     string: { unit: "caratteri", verb: "avere" },
     file: { unit: "byte", verb: "avere" },
@@ -29199,10 +28440,10 @@ var init_it2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ja.js
 function ja_default2() {
   return {
-    localeError: error71()
+    localeError: error68()
   };
 }
-var error71 = () => {
+var error68 = () => {
   const Sizable = {
     string: { unit: "\u6587\u5B57", verb: "\u3067\u3042\u308B" },
     file: { unit: "\u30D0\u30A4\u30C8", verb: "\u3067\u3042\u308B" },
@@ -29318,7 +28559,7 @@ var init_ja2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ka.js
 function ka_default2() {
   return {
-    localeError: error72()
+    localeError: error69()
   };
 }
 var parsedType5 = (data) => {
@@ -29348,7 +28589,7 @@ var parsedType5 = (data) => {
     function: "\u10E4\u10E3\u10DC\u10E5\u10EA\u10D8\u10D0"
   };
   return typeMap[t] ?? t;
-}, error72 = () => {
+}, error69 = () => {
   const Sizable = {
     string: { unit: "\u10E1\u10D8\u10DB\u10D1\u10DD\u10DA\u10DD", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
     file: { unit: "\u10D1\u10D0\u10D8\u10E2\u10D8", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
@@ -29446,10 +28687,10 @@ var init_ka2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/km.js
 function km_default2() {
   return {
-    localeError: error73()
+    localeError: error70()
   };
 }
-var error73 = () => {
+var error70 = () => {
   const Sizable = {
     string: { unit: "\u178F\u17BD\u17A2\u1780\u17D2\u179F\u179A", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
     file: { unit: "\u1794\u17C3", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
@@ -29575,10 +28816,10 @@ var init_kh2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ko.js
 function ko_default2() {
   return {
-    localeError: error74()
+    localeError: error71()
   };
 }
-var error74 = () => {
+var error71 = () => {
   const Sizable = {
     string: { unit: "\uBB38\uC790", verb: "to have" },
     file: { unit: "\uBC14\uC774\uD2B8", verb: "to have" },
@@ -29710,7 +28951,7 @@ function getUnitTypeFromNumber2(number5) {
 }
 function lt_default2() {
   return {
-    localeError: error75()
+    localeError: error72()
   };
 }
 var parsedType6 = (data) => {
@@ -29759,7 +29000,7 @@ var parsedType6 = (data) => {
   return t;
 }, capitalizeFirstCharacter2 = (text) => {
   return text.charAt(0).toUpperCase() + text.slice(1);
-}, error75 = () => {
+}, error72 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -29930,10 +29171,10 @@ var init_lt2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/mk.js
 function mk_default2() {
   return {
-    localeError: error76()
+    localeError: error73()
   };
 }
-var error76 = () => {
+var error73 = () => {
   const Sizable = {
     string: { unit: "\u0437\u043D\u0430\u0446\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
     file: { unit: "\u0431\u0430\u0458\u0442\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
@@ -30051,10 +29292,10 @@ var init_mk2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ms.js
 function ms_default2() {
   return {
-    localeError: error77()
+    localeError: error74()
   };
 }
-var error77 = () => {
+var error74 = () => {
   const Sizable = {
     string: { unit: "aksara", verb: "mempunyai" },
     file: { unit: "bait", verb: "mempunyai" },
@@ -30171,10 +29412,10 @@ var init_ms2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/nl.js
 function nl_default2() {
   return {
-    localeError: error78()
+    localeError: error75()
   };
 }
-var error78 = () => {
+var error75 = () => {
   const Sizable = {
     string: { unit: "tekens" },
     file: { unit: "bytes" },
@@ -30292,10 +29533,10 @@ var init_nl2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/no.js
 function no_default2() {
   return {
-    localeError: error79()
+    localeError: error76()
   };
 }
-var error79 = () => {
+var error76 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "\xE5 ha" },
     file: { unit: "bytes", verb: "\xE5 ha" },
@@ -30412,10 +29653,10 @@ var init_no2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ota.js
 function ota_default2() {
   return {
-    localeError: error80()
+    localeError: error77()
   };
 }
-var error80 = () => {
+var error77 = () => {
   const Sizable = {
     string: { unit: "harf", verb: "olmal\u0131d\u0131r" },
     file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
@@ -30532,10 +29773,10 @@ var init_ota2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ps.js
 function ps_default2() {
   return {
-    localeError: error81()
+    localeError: error78()
   };
 }
-var error81 = () => {
+var error78 = () => {
   const Sizable = {
     string: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
     file: { unit: "\u0628\u0627\u06CC\u067C\u0633", verb: "\u0648\u0644\u0631\u064A" },
@@ -30658,10 +29899,10 @@ var init_ps2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/pl.js
 function pl_default2() {
   return {
-    localeError: error82()
+    localeError: error79()
   };
 }
-var error82 = () => {
+var error79 = () => {
   const Sizable = {
     string: { unit: "znak\xF3w", verb: "mie\u0107" },
     file: { unit: "bajt\xF3w", verb: "mie\u0107" },
@@ -30779,10 +30020,10 @@ var init_pl2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/pt.js
 function pt_default2() {
   return {
-    localeError: error83()
+    localeError: error80()
   };
 }
-var error83 = () => {
+var error80 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "ter" },
     file: { unit: "bytes", verb: "ter" },
@@ -30914,10 +30155,10 @@ function getRussianPlural2(count, one, few, many) {
 }
 function ru_default2() {
   return {
-    localeError: error84()
+    localeError: error81()
   };
 }
-var error84 = () => {
+var error81 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -31067,10 +30308,10 @@ var init_ru2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/sl.js
 function sl_default2() {
   return {
-    localeError: error85()
+    localeError: error82()
   };
 }
-var error85 = () => {
+var error82 = () => {
   const Sizable = {
     string: { unit: "znakov", verb: "imeti" },
     file: { unit: "bajtov", verb: "imeti" },
@@ -31188,10 +30429,10 @@ var init_sl2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/sv.js
 function sv_default2() {
   return {
-    localeError: error86()
+    localeError: error83()
   };
 }
-var error86 = () => {
+var error83 = () => {
   const Sizable = {
     string: { unit: "tecken", verb: "att ha" },
     file: { unit: "bytes", verb: "att ha" },
@@ -31310,10 +30551,10 @@ var init_sv2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ta.js
 function ta_default2() {
   return {
-    localeError: error87()
+    localeError: error84()
   };
 }
-var error87 = () => {
+var error84 = () => {
   const Sizable = {
     string: { unit: "\u0B8E\u0BB4\u0BC1\u0BA4\u0BCD\u0BA4\u0BC1\u0B95\u0BCD\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
     file: { unit: "\u0BAA\u0BC8\u0B9F\u0BCD\u0B9F\u0BC1\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
@@ -31431,10 +30672,10 @@ var init_ta2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/th.js
 function th_default2() {
   return {
-    localeError: error88()
+    localeError: error85()
   };
 }
-var error88 = () => {
+var error85 = () => {
   const Sizable = {
     string: { unit: "\u0E15\u0E31\u0E27\u0E2D\u0E31\u0E01\u0E29\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
     file: { unit: "\u0E44\u0E1A\u0E15\u0E4C", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
@@ -31552,7 +30793,7 @@ var init_th2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/tr.js
 function tr_default2() {
   return {
-    localeError: error89()
+    localeError: error86()
   };
 }
 var parsedType7 = (data) => {
@@ -31574,7 +30815,7 @@ var parsedType7 = (data) => {
     }
   }
   return t;
-}, error89 = () => {
+}, error86 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "olmal\u0131" },
     file: { unit: "bayt", verb: "olmal\u0131" },
@@ -31670,10 +30911,10 @@ var init_tr2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/uk.js
 function uk_default2() {
   return {
-    localeError: error90()
+    localeError: error87()
   };
 }
-var error90 = () => {
+var error87 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
     file: { unit: "\u0431\u0430\u0439\u0442\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
@@ -31798,10 +31039,10 @@ var init_ua2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ur.js
 function ur_default2() {
   return {
-    localeError: error91()
+    localeError: error88()
   };
 }
-var error91 = () => {
+var error88 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0648\u0641", verb: "\u06C1\u0648\u0646\u0627" },
     file: { unit: "\u0628\u0627\u0626\u0679\u0633", verb: "\u06C1\u0648\u0646\u0627" },
@@ -31919,10 +31160,10 @@ var init_ur2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/vi.js
 function vi_default2() {
   return {
-    localeError: error92()
+    localeError: error89()
   };
 }
-var error92 = () => {
+var error89 = () => {
   const Sizable = {
     string: { unit: "k\xFD t\u1EF1", verb: "c\xF3" },
     file: { unit: "byte", verb: "c\xF3" },
@@ -32039,10 +31280,10 @@ var init_vi2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/zh-CN.js
 function zh_CN_default2() {
   return {
-    localeError: error93()
+    localeError: error90()
   };
 }
-var error93 = () => {
+var error90 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u7B26", verb: "\u5305\u542B" },
     file: { unit: "\u5B57\u8282", verb: "\u5305\u542B" },
@@ -32159,10 +31400,10 @@ var init_zh_CN2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/zh-TW.js
 function zh_TW_default2() {
   return {
-    localeError: error94()
+    localeError: error91()
   };
 }
-var error94 = () => {
+var error91 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u5143", verb: "\u64C1\u6709" },
     file: { unit: "\u4F4D\u5143\u7D44", verb: "\u64C1\u6709" },
@@ -32280,10 +31521,10 @@ var init_zh_TW2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/yo.js
 function yo_default2() {
   return {
-    localeError: error95()
+    localeError: error92()
   };
 }
-var error95 = () => {
+var error92 = () => {
   const Sizable = {
     string: { unit: "\xE0mi", verb: "n\xED" },
     file: { unit: "bytes", verb: "n\xED" },
@@ -33446,7 +32687,7 @@ class JSONSchemaGenerator2 {
     this.seen = new Map;
   }
   process(schema, _params = { path: [], schemaPath: [] }) {
-    var _a3;
+    var _a2;
     const def = schema._zod.def;
     const formatMap2 = {
       guid: "uuid",
@@ -33949,7 +33190,7 @@ class JSONSchemaGenerator2 {
       delete result.schema.default;
     }
     if (this.io === "input" && result.schema._prefault)
-      (_a3 = result.schema).default ?? (_a3.default = result.schema._prefault);
+      (_a2 = result.schema).default ?? (_a2.default = result.schema._prefault);
     delete result.schema._prefault;
     const _result = this.seen.get(schema);
     return _result.schema;
@@ -35943,8 +35184,8 @@ var init_dist = __esm(() => {
 });
 
 // src/tools/create-tool.ts
-function classifyToolError(error96) {
-  const msg = (error96 instanceof Error ? error96.message ?? "" : String(error96)).toLowerCase();
+function classifyToolError(error93) {
+  const msg = (error93 instanceof Error ? error93.message ?? "" : String(error93)).toLowerCase();
   if (msg.includes("not registered") || msg.includes("unknown tool"))
     return "not_registered";
   if (msg.includes("not whitelisted") || msg.includes("not allowed"))
@@ -35962,11 +35203,11 @@ function createSwarmTool(opts) {
       try {
         const result = await opts.execute(args, directory, ctx);
         return result;
-      } catch (error96) {
-        const message = error96 instanceof Error ? error96.message : String(error96);
+      } catch (error93) {
+        const message = error93 instanceof Error ? error93.message : String(error93);
         return JSON.stringify({
           success: false,
-          failure_class: classifyToolError(error96),
+          failure_class: classifyToolError(error93),
           message: "Tool execution failed",
           errors: [message]
         }, null, 2);
@@ -36336,8 +35577,8 @@ async function handleSave2(directory, label) {
     } else {
       return `Error: ${parsed.error || "Failed to save checkpoint"}`;
     }
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     return `Error: ${msg}`;
   }
 }
@@ -36355,8 +35596,8 @@ async function handleRestore2(directory, label) {
     } else {
       return `Error: ${parsed.error || "Failed to restore checkpoint"}`;
     }
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     return `Error: ${msg}`;
   }
 }
@@ -36374,8 +35615,8 @@ async function handleDelete2(directory, label) {
     } else {
       return `Error: ${parsed.error || "Failed to delete checkpoint"}`;
     }
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     return `Error: ${msg}`;
   }
 }
@@ -36404,8 +35645,8 @@ async function handleList2(directory) {
     ];
     return lines.join(`
 `);
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     return `Error: ${msg}`;
   }
 }
@@ -36931,8 +36172,8 @@ class AutomationEventBus {
       await Promise.all(Array.from(listeners).map(async (listener) => {
         try {
           await listener(event);
-        } catch (error96) {
-          log(`[EventBus] Listener error for ${type}`, { error: error96 });
+        } catch (error93) {
+          log(`[EventBus] Listener error for ${type}`, { error: error93 });
         }
       }));
     }
@@ -39391,11 +38632,11 @@ async function executeWriteRetro(args, directory) {
       phase,
       message: `Retrospective evidence written to .swarm/evidence/${taskId}/evidence.json`
     }, null, 2);
-  } catch (error96) {
+  } catch (error93) {
     return JSON.stringify({
       success: false,
       phase,
-      message: error96 instanceof Error ? error96.message : String(error96)
+      message: error93 instanceof Error ? error93.message : String(error93)
     }, null, 2);
   }
 }
@@ -39526,9 +38767,9 @@ async function handleCloseCommand(directory, args, options = {}) {
     const content = await fs7.readFile(planPath, "utf-8");
     planData = JSON.parse(content);
     planExists = true;
-  } catch (error96) {
-    if (error96?.code !== "ENOENT") {
-      return `\u274C Failed to read plan.json: ${error96 instanceof Error ? error96.message : String(error96)}`;
+  } catch (error93) {
+    if (error93?.code !== "ENOENT") {
+      return `\u274C Failed to read plan.json: ${error93 instanceof Error ? error93.message : String(error93)}`;
     }
     const swarmDirExists = await fs7.access(swarmDir).then(() => true).catch(() => false);
     if (!swarmDirExists) {
@@ -39664,10 +38905,10 @@ async function handleCloseCommand(directory, args, options = {}) {
   try {
     curationResult = await curateAndStoreSwarm(allLessons, projectName, { phase_number: 0 }, directory, config3);
     curationSucceeded = true;
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     warnings.push(`Lessons curation failed: ${msg}`);
-    console.warn("[close-command] curateAndStoreSwarm error:", error96);
+    console.warn("[close-command] curateAndStoreSwarm error:", error93);
   }
   if (curationSucceeded && allLessons.length > 0) {
     await fs7.unlink(lessonsFilePath).catch(() => {});
@@ -39757,10 +38998,10 @@ async function handleCloseCommand(directory, args, options = {}) {
     if (!planAlreadyDone || guaranteeResult.closedPhaseIds.length > 0 || guaranteeResult.closedTaskIds.length > 0) {
       try {
         await fs7.writeFile(planPath, JSON.stringify(planData, null, 2), "utf-8");
-      } catch (error96) {
-        const msg = error96 instanceof Error ? error96.message : String(error96);
+      } catch (error93) {
+        const msg = error93 instanceof Error ? error93.message : String(error93);
         warnings.push(`Failed to persist terminal plan.json state: ${msg}`);
-        console.warn("[close-command] Failed to write plan.json:", error96);
+        console.warn("[close-command] Failed to write plan.json:", error93);
       }
     }
   }
@@ -39819,10 +39060,10 @@ async function handleCloseCommand(directory, args, options = {}) {
   }
   try {
     await archiveEvidence(directory, 30, 10);
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     warnings.push(`Evidence retention archive failed: ${msg}`);
-    console.warn("[close-command] archiveEvidence error:", error96);
+    console.warn("[close-command] archiveEvidence error:", error93);
   }
   let configBackupsRemoved = 0;
   const cleanedFiles = [];
@@ -39899,10 +39140,10 @@ async function handleCloseCommand(directory, args, options = {}) {
 `);
   try {
     await fs7.writeFile(contextPath, contextContent, "utf-8");
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     warnings.push(`Failed to reset context.md: ${msg}`);
-    console.warn("[close-command] Failed to write context.md:", error96);
+    console.warn("[close-command] Failed to write context.md:", error93);
   }
   const pruneBranches = args.includes("--prune-branches");
   let gitAlignResult = "";
@@ -39985,10 +39226,10 @@ async function handleCloseCommand(directory, args, options = {}) {
 `);
   try {
     await fs7.writeFile(closeSummaryPath, summaryContent, "utf-8");
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     warnings.push(`Failed to write close-summary.md: ${msg}`);
-    console.warn("[close-command] Failed to write close-summary.md:", error96);
+    console.warn("[close-command] Failed to write close-summary.md:", error93);
   }
   const preservedClient = swarmState.opencodeClient;
   const preservedFullAutoFlag = swarmState.fullAutoEnabledInConfig;
@@ -40209,11 +39450,11 @@ async function handleCurateCommand(directory, _args) {
     const swarmEntries = await readKnowledge(swarmPath) ?? [];
     const summary = await checkHivePromotions(swarmEntries, config3);
     return formatCurationSummary(summary);
-  } catch (error96) {
-    if (error96 instanceof Error) {
-      return `\u274C Curation failed: ${error96.message}`;
+  } catch (error93) {
+    if (error93 instanceof Error) {
+      return `\u274C Curation failed: ${error93.message}`;
     }
-    return `\u274C Curation failed: ${error96 instanceof Error ? error96.message : String(error96)}`;
+    return `\u274C Curation failed: ${error93 instanceof Error ? error93.message : String(error93)}`;
   }
 }
 function formatCurationSummary(summary) {
@@ -41718,9 +40959,9 @@ function createConfigBackup(directory) {
   if (fs8.existsSync(projectConfigPath)) {
     try {
       content = fs8.readFileSync(projectConfigPath, "utf-8");
-    } catch (error96) {
+    } catch (error93) {
       log("[ConfigDoctor] project config read failed", {
-        error: error96 instanceof Error ? error96.message : String(error96)
+        error: error93 instanceof Error ? error93.message : String(error93)
       });
     }
   }
@@ -41728,9 +40969,9 @@ function createConfigBackup(directory) {
     configPath = userConfigPath;
     try {
       content = fs8.readFileSync(userConfigPath, "utf-8");
-    } catch (error96) {
+    } catch (error93) {
       log("[ConfigDoctor] user config read failed", {
-        error: error96 instanceof Error ? error96.message : String(error96)
+        error: error93 instanceof Error ? error93.message : String(error93)
       });
     }
   }
@@ -44720,8 +43961,8 @@ function withStateLock(directory, fn) {
       retries: { retries: 5, minTimeout: 5, maxTimeout: 50 },
       stale: 5000
     });
-  } catch (error96) {
-    warn(`[full-auto/state] cross-process lock unavailable; proceeding unlocked: ${error96 instanceof Error ? error96.message : String(error96)}`);
+  } catch (error93) {
+    warn(`[full-auto/state] cross-process lock unavailable; proceeding unlocked: ${error93 instanceof Error ? error93.message : String(error93)}`);
   }
   try {
     return fn();
@@ -44772,8 +44013,8 @@ function readPersisted(directory) {
       oversightSequence: typeof parsed.oversightSequence === "number" ? parsed.oversightSequence : 0,
       sessions: parsed.sessions
     };
-  } catch (error96) {
-    const reason = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const reason = error93 instanceof Error ? error93.message : String(error93);
     error(`[full-auto/state] Failed to read ${STATE_FILE}: ${reason} \u2014 attempting .bak recovery`);
     try {
       const bakPath = validateSwarmPath(directory, `${STATE_FILE}.bak`);
@@ -44811,8 +44052,8 @@ function writePersisted(directory, persisted) {
     persisted.updatedAt = nowISO();
     payload = `${JSON.stringify(persisted, null, 2)}
 `;
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     error(`[full-auto/state] Failed to prepare ${STATE_FILE} write: ${msg}`);
     throw new Error(`Full-Auto state persistence prepare failed: ${msg}`);
   }
@@ -44837,8 +44078,8 @@ function writePersisted(directory, persisted) {
     if (parsed?.version !== 2) {
       throw new Error("Round-trip readback returned wrong version");
     }
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     error(`[full-auto/state] Failed to persist ${STATE_FILE} atomically: ${msg}`);
     throw new Error(`Full-Auto state persistence failed: ${msg}`);
   }
@@ -44954,8 +44195,8 @@ async function handleFullAutoCommand(directory, args, sessionID) {
       }
       v2Status = "paused";
     }
-  } catch (error96) {
-    durableError = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    durableError = error93 instanceof Error ? error93.message : String(error93);
     error(`[full-auto] durable run-state write failed: ${durableError}`);
   }
   if (newFullAutoMode && durableError) {
@@ -45103,9 +44344,9 @@ function parseSessionState(content) {
       }
     }
     return { activeAgent, delegationState, pendingQA };
-  } catch (error96) {
+  } catch (error93) {
     log("[HandoffService] state extraction failed", {
-      error: error96 instanceof Error ? error96.message : String(error96)
+      error: error93 instanceof Error ? error93.message : String(error93)
     });
     return null;
   }
@@ -45482,9 +44723,9 @@ async function writeSnapshot(directory, state) {
       }
     } catch {}
     renameSync6(tempPath, resolvedPath);
-  } catch (error96) {
+  } catch (error93) {
     log("[snapshot-writer] write failed", {
-      error: error96 instanceof Error ? error96.message : String(error96)
+      error: error93 instanceof Error ? error93.message : String(error93)
     });
   }
 }
@@ -46216,8 +45457,8 @@ async function handleKnowledgeQuarantineCommand(directory, args) {
     const fullId = resolved.entry.id;
     await quarantineEntry(directory, fullId, reason, "user");
     return `\u2705 Entry ${fullId} quarantined successfully.`;
-  } catch (error96) {
-    console.warn("[knowledge-command] quarantineEntry error:", error96 instanceof Error ? error96.message : String(error96));
+  } catch (error93) {
+    console.warn("[knowledge-command] quarantineEntry error:", error93 instanceof Error ? error93.message : String(error93));
     return `\u274C Failed to quarantine entry. Check the entry ID and try again.`;
   }
 }
@@ -46239,8 +45480,8 @@ async function handleKnowledgeRestoreCommand(directory, args) {
     const fullId = resolved.entry.id;
     await restoreEntry(directory, fullId);
     return `\u2705 Entry ${fullId} restored successfully.`;
-  } catch (error96) {
-    console.warn("[knowledge-command] restoreEntry error:", error96 instanceof Error ? error96.message : String(error96));
+  } catch (error93) {
+    console.warn("[knowledge-command] restoreEntry error:", error93 instanceof Error ? error93.message : String(error93));
     return `\u274C Failed to restore entry. Check the entry ID and try again.`;
   }
 }
@@ -46261,8 +45502,8 @@ async function handleKnowledgeMigrateCommand(directory, args) {
       }
     }
     return `\u2705 Migration complete: ${result.entriesMigrated} entries added, ${result.entriesDropped} dropped (validation/dedup), ${result.entriesTotal} total processed.`;
-  } catch (error96) {
-    console.warn("[knowledge-command] migrateContextToKnowledge error:", error96 instanceof Error ? error96.message : String(error96));
+  } catch (error93) {
+    console.warn("[knowledge-command] migrateContextToKnowledge error:", error93 instanceof Error ? error93.message : String(error93));
     return "\u274C Migration failed. Check .swarm/context.md is readable.";
   }
 }
@@ -46288,8 +45529,8 @@ async function handleKnowledgeListCommand(directory, _args) {
     lines.push("Use `/swarm knowledge quarantine <id-prefix>` to hide an entry. Prefix matching is supported \u2014 the 12-character prefix shown is unique in most stores.");
     return lines.join(`
 `);
-  } catch (error96) {
-    console.warn("[knowledge-command] list error:", error96 instanceof Error ? error96.message : String(error96));
+  } catch (error93) {
+    console.warn("[knowledge-command] list error:", error93 instanceof Error ? error93.message : String(error93));
     return "\u274C Failed to list knowledge entries. Ensure .swarm/knowledge.jsonl exists.";
   }
 }
@@ -46969,13 +46210,13 @@ async function runLint(linter, mode, directory) {
       result.message = `${linter} check found issues (exit code ${exitCode}).`;
     }
     return result;
-  } catch (error96) {
+  } catch (error93) {
     return {
       success: false,
       mode,
       linter,
       command,
-      error: error96 instanceof Error ? `Execution failed: ${error96.message}` : "Execution failed: unknown error"
+      error: error93 instanceof Error ? `Execution failed: ${error93.message}` : "Execution failed: unknown error"
     };
   }
 }
@@ -47027,13 +46268,13 @@ async function runAdditionalLint(linter, mode, cwd) {
       result.message = `${linter} check found issues (exit code ${exitCode}).`;
     }
     return result;
-  } catch (error96) {
+  } catch (error93) {
     return {
       success: false,
       mode,
       linter,
       command,
-      error: error96 instanceof Error ? `Execution failed: ${error96.message}` : "Execution failed: unknown error"
+      error: error93 instanceof Error ? `Execution failed: ${error93.message}` : "Execution failed: unknown error"
     };
   }
 }
@@ -50934,7 +50175,7 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
       }
       return result;
     }
-  } catch (error96) {
+  } catch (error93) {
     const duration_ms = Date.now() - startTime;
     return {
       success: false,
@@ -50943,7 +50184,7 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
       command,
       timeout_ms,
       duration_ms,
-      error: error96 instanceof Error ? `Execution failed: ${error96.message}` : "Execution failed: unknown error",
+      error: error93 instanceof Error ? `Execution failed: ${error93.message}` : "Execution failed: unknown error",
       outcome: "error"
     };
   }
@@ -51633,11 +50874,11 @@ async function runVersionCheck(dir, _timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error96) {
+  } catch (error93) {
     return {
       type: "version",
       status: "error",
-      message: `Version check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
+      message: `Version check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -51691,12 +50932,12 @@ async function runLintCheck(dir, linter, timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error96) {
-    if (error96 instanceof Error && error96.message.includes("timed out")) {
+  } catch (error93) {
+    if (error93 instanceof Error && error93.message.includes("timed out")) {
       return {
         type: "lint",
         status: "error",
-        message: error96.message,
+        message: error93.message,
         details: { linter },
         durationMs: Date.now() - startTime
       };
@@ -51704,7 +50945,7 @@ async function runLintCheck(dir, linter, timeoutMs) {
     return {
       type: "lint",
       status: "error",
-      message: `Lint check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
+      message: `Lint check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
       details: { linter },
       durationMs: Date.now() - startTime
     };
@@ -51760,8 +51001,8 @@ async function runTestsCheck(_dir, scope, timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error96) {
-    if (error96 instanceof Error && (error96.message.includes("timeout") || error96.message.includes("ETIMEDOUT"))) {
+  } catch (error93) {
+    if (error93 instanceof Error && (error93.message.includes("timeout") || error93.message.includes("ETIMEDOUT"))) {
       return {
         type: "tests",
         status: "error",
@@ -51772,7 +51013,7 @@ async function runTestsCheck(_dir, scope, timeoutMs) {
     return {
       type: "tests",
       status: "error",
-      message: `Tests check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
+      message: `Tests check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -51815,8 +51056,8 @@ async function runSecretsCheck(dir, timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error96) {
-    if (error96 instanceof Error && error96.name === "AbortError") {
+  } catch (error93) {
+    if (error93 instanceof Error && error93.name === "AbortError") {
       return {
         type: "secrets",
         status: "error",
@@ -51827,7 +51068,7 @@ async function runSecretsCheck(dir, timeoutMs) {
     return {
       type: "secrets",
       status: "error",
-      message: `Secrets check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
+      message: `Secrets check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -51888,11 +51129,11 @@ async function runEvidenceCheck(dir) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error96) {
+  } catch (error93) {
     return {
       type: "evidence",
       status: "error",
-      message: `Evidence check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
+      message: `Evidence check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -51927,11 +51168,11 @@ async function runRequirementCoverageCheck(dir, currentPhase) {
       details: { expectedPath: coverage.path },
       durationMs: Date.now() - startTime
     };
-  } catch (error96) {
+  } catch (error93) {
     return {
       type: "req_coverage",
       status: "error",
-      message: `Requirement coverage check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
+      message: `Requirement coverage check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -51942,7 +51183,7 @@ async function runPreflight(dir, phase, config3) {
   let validatedDir;
   try {
     validatedDir = _internals29.validateDirectoryPath(dir);
-  } catch (error96) {
+  } catch (error93) {
     return {
       id: reportId,
       timestamp: startTime,
@@ -51952,7 +51193,7 @@ async function runPreflight(dir, phase, config3) {
         {
           type: "lint",
           status: "error",
-          message: `Invalid directory: ${error96 instanceof Error ? error96.message : String(error96)}`
+          message: `Invalid directory: ${error93 instanceof Error ? error93.message : String(error93)}`
         }
       ],
       totalDurationMs: Date.now() - startTime,
@@ -51962,7 +51203,7 @@ async function runPreflight(dir, phase, config3) {
   let validatedTimeout;
   try {
     validatedTimeout = _internals29.validateTimeout(config3?.checkTimeoutMs, DEFAULT_CONFIG.checkTimeoutMs);
-  } catch (error96) {
+  } catch (error93) {
     return {
       id: reportId,
       timestamp: startTime,
@@ -51972,7 +51213,7 @@ async function runPreflight(dir, phase, config3) {
         {
           type: "lint",
           status: "error",
-          message: `Invalid config: ${error96 instanceof Error ? error96.message : String(error96)}`
+          message: `Invalid config: ${error93 instanceof Error ? error93.message : String(error93)}`
         }
       ],
       totalDurationMs: Date.now() - startTime,
@@ -52177,20 +51418,20 @@ async function handlePromoteCommand(directory, args) {
   if (lessonId) {
     try {
       return await promoteFromSwarm(directory, lessonId);
-    } catch (error96) {
-      if (error96 instanceof Error) {
-        return error96.message;
+    } catch (error93) {
+      if (error93 instanceof Error) {
+        return error93.message;
       }
-      return `Failed to promote lesson: ${error96 instanceof Error ? error96.message : String(error96)}`;
+      return `Failed to promote lesson: ${error93 instanceof Error ? error93.message : String(error93)}`;
     }
   }
   try {
     return await promoteToHive(directory, lessonText, category);
-  } catch (error96) {
-    if (error96 instanceof Error) {
-      return error96.message;
+  } catch (error93) {
+    if (error93 instanceof Error) {
+      return error93.message;
     }
-    return `Failed to promote lesson: ${error96 instanceof Error ? error96.message : String(error96)}`;
+    return `Failed to promote lesson: ${error93 instanceof Error ? error93.message : String(error93)}`;
   }
 }
 var init_promote = __esm(() => {
@@ -52359,8 +51600,8 @@ class CircuitBreaker {
   async execute(fn) {
     const state = this.getState();
     if (state === "open") {
-      const error96 = new Error(`Circuit breaker '${this.name}' is open`);
-      throw error96;
+      const error93 = new Error(`Circuit breaker '${this.name}' is open`);
+      throw error93;
     }
     const startTime = Date.now();
     try {
@@ -52368,10 +51609,10 @@ class CircuitBreaker {
       const duration5 = Date.now() - startTime;
       this.recordSuccess(duration5);
       return result;
-    } catch (error96) {
+    } catch (error93) {
       const duration5 = Date.now() - startTime;
-      this.recordFailure(error96, duration5);
-      throw error96;
+      this.recordFailure(error93, duration5);
+      throw error93;
     }
   }
   async executeWithTimeout(fn) {
@@ -52385,9 +51626,9 @@ class CircuitBreaker {
       fn().then((result) => {
         clearTimeout(timeout);
         resolve15(result);
-      }).catch((error96) => {
+      }).catch((error93) => {
         clearTimeout(timeout);
-        reject(error96);
+        reject(error93);
       });
     });
   }
@@ -52401,7 +51642,7 @@ class CircuitBreaker {
     }
     this.onStateChange?.("callSuccess", { duration: duration5 });
   }
-  recordFailure(error96, duration5) {
+  recordFailure(error93, duration5) {
     this.failureCount++;
     this.lastFailureTime = Date.now();
     if (this.state === "half-open") {
@@ -52409,7 +51650,7 @@ class CircuitBreaker {
     } else if (this.state === "closed" && this.failureCount >= this.config.failureThreshold) {
       this.transitionTo("open");
     }
-    this.onStateChange?.("callFailure", { error: error96, duration: duration5 });
+    this.onStateChange?.("callFailure", { error: error93, duration: duration5 });
   }
   transitionTo(newState) {
     const oldState = this.state;
@@ -52747,11 +51988,11 @@ class WorkerManager {
         });
       }
     };
-    processLoop().catch((error96) => {
+    processLoop().catch((error93) => {
       this.eventBus.publish("worker.error", {
         workerName: worker.name,
         itemId: "loop",
-        error: error96
+        error: error93
       });
     });
   }
@@ -52766,15 +52007,15 @@ class WorkerManager {
         worker.lastError = result.error;
         worker.queue.retry(item.id, result.error);
       }
-    } catch (error96) {
+    } catch (error93) {
       worker.errorCount++;
-      worker.lastError = error96;
+      worker.lastError = error93;
       this.eventBus.publish("worker.error", {
         workerName: worker.name,
         itemId: item.id,
-        error: error96
+        error: error93
       });
-      worker.queue.retry(item.id, error96);
+      worker.queue.retry(item.id, error93);
     }
   }
   stop(name) {
@@ -53186,8 +52427,8 @@ async function loadFullOutput(directory, id) {
     }
     warn(`Summary entry ${sanitizedId} missing valid fullOutput field`);
     return null;
-  } catch (error96) {
-    warn(`Summary entry validation failed for ${sanitizedId}: ${error96 instanceof Error ? error96.message : String(error96)}`);
+  } catch (error93) {
+    warn(`Summary entry validation failed for ${sanitizedId}: ${error93 instanceof Error ? error93.message : String(error93)}`);
     return null;
   }
 }
@@ -53224,10 +52465,10 @@ No stored output found for ID \`${summaryId}\`.
 Use a valid summary ID (e.g., S1, S2, S3).`;
     }
     return fullOutput;
-  } catch (error96) {
+  } catch (error93) {
     return `## Retrieve Failed
 
-${error96 instanceof Error ? error96.message : String(error96)}`;
+${error93 instanceof Error ? error93.message : String(error93)}`;
   }
 }
 var init_retrieve = __esm(() => {
@@ -53306,8 +52547,8 @@ async function handleRollbackCommand(directory, args) {
     try {
       fs26.cpSync(src, dest, { recursive: true, force: true });
       successes.push(file3);
-    } catch (error96) {
-      failures.push({ file: file3, error: error96.message });
+    } catch (error93) {
+      failures.push({ file: file3, error: error93.message });
     }
   }
   if (failures.length > 0) {
@@ -53357,8 +52598,8 @@ async function handleRollbackCommand(directory, args) {
   try {
     fs26.appendFileSync(eventsPath, `${JSON.stringify(rollbackEvent)}
 `);
-  } catch (error96) {
-    console.error("Failed to write rollback event:", error96 instanceof Error ? error96.message : String(error96));
+  } catch (error93) {
+    console.error("Failed to write rollback event:", error93 instanceof Error ? error93.message : String(error93));
   }
   return `Rolled back to phase ${targetPhase}: ${checkpoint2.label || "no label"}`;
 }
@@ -53513,8 +52754,8 @@ function readPersisted2(directory) {
       updatedAt: parsed.updatedAt ?? nowISO2(),
       sessions: parsed.sessions
     };
-  } catch (error96) {
-    const reason = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const reason = error93 instanceof Error ? error93.message : String(error93);
     markStateUnreadable2(directory, reason);
     return null;
   }
@@ -53533,16 +52774,16 @@ function writePersisted2(directory, persisted) {
     persisted.updatedAt = nowISO2();
     payload = `${JSON.stringify(persisted, null, 2)}
 `;
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     error(`[turbo/lean/state] Failed to prepare ${STATE_FILE2} write: ${msg}`);
     throw new Error(`Lean Turbo state persistence prepare failed: ${msg}`);
   }
   try {
     fs27.writeFileSync(tmpPath, payload, "utf-8");
     fs27.renameSync(tmpPath, filePath);
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     error(`[turbo/lean/state] Failed to persist ${STATE_FILE2} atomically: ${msg}`);
     try {
       if (fs27.existsSync(tmpPath)) {
@@ -53919,7 +53160,7 @@ function formatSandboxLines(sandbox) {
     status: sandboxStatus,
     mechanism,
     executorAvailable,
-    error: error96
+    error: error93
   } = sandbox;
   lines.push("");
   if (sandboxStatus === "enabled") {
@@ -53929,7 +53170,7 @@ function formatSandboxLines(sandbox) {
       lines.push(`**Sandbox**: ${mechanism} (probe ok, executor unavailable)`);
     }
   } else if (sandboxStatus === "disabled") {
-    lines.push(`**Sandbox**: ${mechanism} (disabled${error96 ? ` \u2014 ${error96}` : ""})`);
+    lines.push(`**Sandbox**: ${mechanism} (disabled${error93 ? ` \u2014 ${error93}` : ""})`);
   } else {
     lines.push(`**Sandbox**: ${mechanism} (unsupported) \u2014 Sandbox enforcement not active on this platform`);
   }
@@ -54005,8 +53246,8 @@ async function handleTurboCommand(directory, args, sessionID) {
     if (isLeanActive) {
       try {
         pauseLeanTurboRun(directory, sessionID, reason);
-      } catch (error96) {
-        error(`[turbo] pauseLeanTurboRun failed: ${error96 instanceof Error ? error96.message : String(error96)}`);
+      } catch (error93) {
+        error(`[turbo] pauseLeanTurboRun failed: ${error93 instanceof Error ? error93.message : String(error93)}`);
       }
     }
     session.turboMode = false;
@@ -54041,8 +53282,8 @@ async function handleTurboCommand(directory, args, sessionID) {
       if (config3.turbo?.strategy === "lean") {
         strategy = "lean";
       }
-    } catch (error96) {
-      warn(`[turbo] could not read config for strategy default: ${error96 instanceof Error ? error96.message : String(error96)}`);
+    } catch (error93) {
+      warn(`[turbo] could not read config for strategy default: ${error93 instanceof Error ? error93.message : String(error93)}`);
     }
     if (strategy === "lean") {
       return enableLeanTurbo(session, directory, sessionID);
@@ -54098,16 +53339,16 @@ function enableLeanTurbo(session, directory, sessionID) {
       maxParallelCoders = leanConfig.max_parallel_coders ?? 4;
       conflictPolicy = leanConfig.conflict_policy ?? "serialize";
     }
-  } catch (error96) {
-    warn(`[turbo] could not read lean config: ${error96 instanceof Error ? error96.message : String(error96)}`);
+  } catch (error93) {
+    warn(`[turbo] could not read lean config: ${error93 instanceof Error ? error93.message : String(error93)}`);
   }
   let durableError;
   try {
     const state = emptyRunState(sessionID, maxParallelCoders);
     state.status = "running";
     saveLeanTurboRunState(directory, state);
-  } catch (error96) {
-    durableError = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    durableError = error93 instanceof Error ? error93.message : String(error93);
     error(`[turbo] durable run-state write failed: ${durableError}`);
   }
   if (durableError) {
@@ -55564,9 +54805,9 @@ function writeProjectConfigIfMissing(cwd) {
     ensureDir(opencodeDir);
     saveJson(projectConfigPath, { agents: {} });
     console.log("\u2713 Created project config at:", projectConfigPath);
-  } catch (error96) {
+  } catch (error93) {
     console.warn("\u26A0 Could not create project config \u2014 installation will continue:");
-    console.warn(`  ${error96 instanceof Error ? error96.message : String(error96)}`);
+    console.warn(`  ${error93 instanceof Error ? error93.message : String(error93)}`);
   }
 }
 async function install() {
@@ -55794,8 +55035,8 @@ async function uninstall() {
     console.log(`
 \u2705 Uninstall complete!`);
     return 0;
-  } catch (error96) {
-    console.log("\u2717 Uninstall failed: " + (error96 instanceof Error ? error96.message : String(error96)));
+  } catch (error93) {
+    console.log("\u2717 Uninstall failed: " + (error93 instanceof Error ? error93.message : String(error93)));
     return 1;
   }
 }

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.32.2",
+    version: "7.32.3",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -676,10 +676,10 @@ function $constructor(name, initializer, params) {
   }
   Object.defineProperty(Definition, "name", { value: name });
   function _(def) {
-    var _a;
+    var _a2;
     const inst = params?.Parent ? new Definition : this;
     init(inst, def);
-    (_a = inst._zod).deferred ?? (_a.deferred = []);
+    (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
     for (const fn of inst._zod.deferred) {
       fn();
     }
@@ -701,9 +701,9 @@ function config(newConfig) {
     Object.assign(globalConfig, newConfig);
   return globalConfig;
 }
-var NEVER, $brand, $ZodAsyncError, $ZodEncodeError, globalConfig;
+var _a, NEVER, $brand, $ZodAsyncError, $ZodEncodeError, globalConfig;
 var init_core = __esm(() => {
-  NEVER = Object.freeze({
+  NEVER = /* @__PURE__ */ Object.freeze({
     status: "aborted"
   });
   $brand = Symbol("zod_brand");
@@ -718,7 +718,8 @@ var init_core = __esm(() => {
       this.name = "ZodEncodeError";
     }
   };
-  globalConfig = {};
+  (_a = globalThis).__zod_globalConfig ?? (_a.__zod_globalConfig = {});
+  globalConfig = globalThis.__zod_globalConfig;
 });
 
 // node_modules/zod/v4/core/util.js
@@ -763,6 +764,7 @@ __export(exports_util, {
   floatSafeRemainder: () => floatSafeRemainder,
   finalizeIssue: () => finalizeIssue,
   extend: () => extend,
+  explicitlyAborted: () => explicitlyAborted,
   escapeRegex: () => escapeRegex2,
   esc: () => esc,
   defineLazy: () => defineLazy,
@@ -833,19 +835,12 @@ function cleanRegex(source) {
   return source.slice(start, end);
 }
 function floatSafeRemainder(val, step) {
-  const valDecCount = (val.toString().split(".")[1] || "").length;
-  const stepString = step.toString();
-  let stepDecCount = (stepString.split(".")[1] || "").length;
-  if (stepDecCount === 0 && /\d?e-\d?/.test(stepString)) {
-    const match = stepString.match(/\d?e-(\d?)/);
-    if (match?.[1]) {
-      stepDecCount = Number.parseInt(match[1]);
-    }
-  }
-  const decCount = valDecCount > stepDecCount ? valDecCount : stepDecCount;
-  const valInt = Number.parseInt(val.toFixed(decCount).replace(".", ""));
-  const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
-  return valInt % stepInt / 10 ** decCount;
+  const ratio = val / step;
+  const roundedRatio = Math.round(ratio);
+  const tolerance = Number.EPSILON * Math.max(Math.abs(ratio), 1);
+  if (Math.abs(ratio - roundedRatio) < tolerance)
+    return 0;
+  return ratio - roundedRatio;
 }
 function defineLazy(object, key, getter) {
   let value = undefined;
@@ -944,6 +939,10 @@ function shallowClone(o) {
     return { ...o };
   if (Array.isArray(o))
     return [...o];
+  if (o instanceof Map)
+    return new Map(o);
+  if (o instanceof Set)
+    return new Set(o);
   return o;
 }
 function numKeys(data) {
@@ -1112,6 +1111,9 @@ function safeExtend(schema, shape) {
   return clone(schema, def);
 }
 function merge(a, b) {
+  if (a._zod.def.checks?.length) {
+    throw new Error(".merge() cannot be used on object schemas containing refinements. Use .safeExtend() instead.");
+  }
   const def = mergeDefs(a._zod.def, {
     get shape() {
       const _shape = { ...a._zod.def.shape, ...b._zod.def.shape };
@@ -1121,7 +1123,7 @@ function merge(a, b) {
     get catchall() {
       return b._zod.def.catchall;
     },
-    checks: []
+    checks: b._zod.def.checks ?? []
   });
   return clone(a, def);
 }
@@ -1204,10 +1206,20 @@ function aborted(x, startIndex = 0) {
   }
   return false;
 }
+function explicitlyAborted(x, startIndex = 0) {
+  if (x.aborted === true)
+    return true;
+  for (let i = startIndex;i < x.issues.length; i++) {
+    if (x.issues[i]?.continue === false) {
+      return true;
+    }
+  }
+  return false;
+}
 function prefixIssues(path3, issues) {
   return issues.map((iss) => {
-    var _a;
-    (_a = iss).path ?? (_a.path = []);
+    var _a2;
+    (_a2 = iss).path ?? (_a2.path = []);
     iss.path.unshift(path3);
     return iss;
   });
@@ -1216,17 +1228,14 @@ function unwrapMessage(message) {
   return typeof message === "string" ? message : message?.message;
 }
 function finalizeIssue(iss, ctx, config2) {
-  const full = { ...iss, path: iss.path ?? [] };
-  if (!iss.message) {
-    const message = unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ?? unwrapMessage(ctx?.error?.(iss)) ?? unwrapMessage(config2.customError?.(iss)) ?? unwrapMessage(config2.localeError?.(iss)) ?? "Invalid input";
-    full.message = message;
+  const message = iss.message ? iss.message : unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ?? unwrapMessage(ctx?.error?.(iss)) ?? unwrapMessage(config2.customError?.(iss)) ?? unwrapMessage(config2.localeError?.(iss)) ?? "Invalid input";
+  const { inst: _inst, continue: _continue, input: _input, ...rest } = iss;
+  rest.path ?? (rest.path = []);
+  rest.message = message;
+  if (ctx?.reportInput) {
+    rest.input = _input;
   }
-  delete full.inst;
-  delete full.continue;
-  if (!ctx?.reportInput) {
-    delete full.input;
-  }
-  return full;
+  return rest;
 }
 function getSizableOrigin(input) {
   if (input instanceof Set)
@@ -1368,9 +1377,13 @@ var EVALUATING, captureStackTrace, allowsEval, getParsedType = (data) => {
   }
 }, propertyKeyTypes, primitiveTypes, NUMBER_FORMAT_RANGES, BIGINT_FORMAT_RANGES;
 var init_util = __esm(() => {
-  EVALUATING = Symbol("evaluating");
+  init_core();
+  EVALUATING = /* @__PURE__ */ Symbol("evaluating");
   captureStackTrace = "captureStackTrace" in Error ? Error.captureStackTrace : (..._args) => {};
-  allowsEval = cached(() => {
+  allowsEval = /* @__PURE__ */ cached(() => {
+    if (globalConfig.jitless) {
+      return false;
+    }
     if (typeof navigator !== "undefined" && navigator?.userAgent?.includes("Cloudflare")) {
       return false;
     }
@@ -1382,8 +1395,15 @@ var init_util = __esm(() => {
       return false;
     }
   });
-  propertyKeyTypes = new Set(["string", "number", "symbol"]);
-  primitiveTypes = new Set(["string", "number", "bigint", "boolean", "symbol", "undefined"]);
+  propertyKeyTypes = /* @__PURE__ */ new Set(["string", "number", "symbol"]);
+  primitiveTypes = /* @__PURE__ */ new Set([
+    "string",
+    "number",
+    "bigint",
+    "boolean",
+    "symbol",
+    "undefined"
+  ]);
   NUMBER_FORMAT_RANGES = {
     safeint: [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
     int32: [-2147483648, 2147483647],
@@ -1413,30 +1433,33 @@ function flattenError(error2, mapper = (issue2) => issue2.message) {
 }
 function formatError(error2, mapper = (issue2) => issue2.message) {
   const fieldErrors = { _errors: [] };
-  const processError = (error3) => {
+  const processError = (error3, path3 = []) => {
     for (const issue2 of error3.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }));
+        issue2.errors.map((issues) => processError({ issues }, [...path3, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues });
+        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues });
-      } else if (issue2.path.length === 0) {
-        fieldErrors._errors.push(mapper(issue2));
+        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
       } else {
-        let curr = fieldErrors;
-        let i = 0;
-        while (i < issue2.path.length) {
-          const el = issue2.path[i];
-          const terminal = i === issue2.path.length - 1;
-          if (!terminal) {
-            curr[el] = curr[el] || { _errors: [] };
-          } else {
-            curr[el] = curr[el] || { _errors: [] };
-            curr[el]._errors.push(mapper(issue2));
+        const fullpath = [...path3, ...issue2.path];
+        if (fullpath.length === 0) {
+          fieldErrors._errors.push(mapper(issue2));
+        } else {
+          let curr = fieldErrors;
+          let i = 0;
+          while (i < fullpath.length) {
+            const el = fullpath[i];
+            const terminal = i === fullpath.length - 1;
+            if (!terminal) {
+              curr[el] = curr[el] || { _errors: [] };
+            } else {
+              curr[el] = curr[el] || { _errors: [] };
+              curr[el]._errors.push(mapper(issue2));
+            }
+            curr = curr[el];
+            i++;
           }
-          curr = curr[el];
-          i++;
         }
       }
     }
@@ -1447,14 +1470,14 @@ function formatError(error2, mapper = (issue2) => issue2.message) {
 function treeifyError(error2, mapper = (issue2) => issue2.message) {
   const result = { errors: [] };
   const processError = (error3, path3 = []) => {
-    var _a, _b;
+    var _a2, _b;
     for (const issue2 of error3.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, issue2.path));
+        issue2.errors.map((issues) => processError({ issues }, [...path3, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, issue2.path);
+        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, issue2.path);
+        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
       } else {
         const fullpath = [...path3, ...issue2.path];
         if (fullpath.length === 0) {
@@ -1468,7 +1491,7 @@ function treeifyError(error2, mapper = (issue2) => issue2.message) {
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
             curr.properties ?? (curr.properties = {});
-            (_a = curr.properties)[el] ?? (_a[el] = { errors: [] });
+            (_a2 = curr.properties)[el] ?? (_a2[el] = { errors: [] });
             curr = curr.properties[el];
           } else {
             curr.items ?? (curr.items = []);
@@ -1540,7 +1563,7 @@ var init_errors2 = __esm(() => {
 
 // node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
-  const ctx = _ctx ? Object.assign(_ctx, { async: false }) : { async: false };
+  const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) {
     throw new $ZodAsyncError;
@@ -1552,7 +1575,7 @@ var _parse = (_Err) => (schema, value, _ctx, _params) => {
   }
   return result.value;
 }, parse, _parseAsync = (_Err) => async (schema, value, _ctx, params) => {
-  const ctx = _ctx ? Object.assign(_ctx, { async: true }) : { async: true };
+  const ctx = _ctx ? { ..._ctx, async: true } : { async: true };
   let result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise)
     result = await result;
@@ -1573,7 +1596,7 @@ var _parse = (_Err) => (schema, value, _ctx, _params) => {
     error: new (_Err ?? $ZodError)(result.issues.map((iss) => finalizeIssue(iss, ctx, config())))
   } : { success: true, data: result.value };
 }, safeParse, _safeParseAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { async: true }) : { async: true };
+  const ctx = _ctx ? { ..._ctx, async: true } : { async: true };
   let result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise)
     result = await result;
@@ -1582,22 +1605,22 @@ var _parse = (_Err) => (schema, value, _ctx, _params) => {
     error: new _Err(result.issues.map((iss) => finalizeIssue(iss, ctx, config())))
   } : { success: true, data: result.value };
 }, safeParseAsync, _encode = (_Err) => (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
+  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
   return _parse(_Err)(schema, value, ctx);
 }, encode, _decode = (_Err) => (schema, value, _ctx) => {
   return _parse(_Err)(schema, value, _ctx);
 }, decode, _encodeAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
+  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
   return _parseAsync(_Err)(schema, value, ctx);
 }, encodeAsync, _decodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _parseAsync(_Err)(schema, value, _ctx);
 }, decodeAsync, _safeEncode = (_Err) => (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
+  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
   return _safeParse(_Err)(schema, value, ctx);
 }, safeEncode, _safeDecode = (_Err) => (schema, value, _ctx) => {
   return _safeParse(_Err)(schema, value, _ctx);
 }, safeDecode, _safeEncodeAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
+  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
   return _safeParseAsync(_Err)(schema, value, ctx);
 }, safeEncodeAsync, _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);
@@ -1660,6 +1683,7 @@ __export(exports_regexes, {
   ipv4: () => ipv4,
   integer: () => integer,
   idnEmail: () => idnEmail,
+  httpProtocol: () => httpProtocol,
   html5Email: () => html5Email,
   hostname: () => hostname,
   hex: () => hex,
@@ -1716,13 +1740,13 @@ var cuid, cuid2, ulid, xid, ksuid, nanoid, duration, extendedDuration, guid, uui
 }, uuid4, uuid6, uuid7, email, html5Email, rfc5322Email, unicodeEmail, idnEmail, browserEmail, _emoji = `^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$`, ipv4, ipv6, mac = (delimiter) => {
   const escapedDelim = escapeRegex2(delimiter ?? ":");
   return new RegExp(`^(?:[0-9A-F]{2}${escapedDelim}){5}[0-9A-F]{2}$|^(?:[0-9a-f]{2}${escapedDelim}){5}[0-9a-f]{2}$`);
-}, cidrv4, cidrv6, base64, base64url, hostname, domain, e164, dateSource = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`, date, string = (params) => {
+}, cidrv4, cidrv6, base64, base64url, hostname, domain, httpProtocol, e164, dateSource = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`, date, string = (params) => {
   const regex = params ? `[\\s\\S]{${params?.minimum ?? 0},${params?.maximum ?? ""}}` : `[\\s\\S]*`;
   return new RegExp(`^${regex}$`);
 }, bigint, integer, number, boolean, _null, _undefined, lowercase, uppercase, hex, md5_hex, md5_base64, md5_base64url, sha1_hex, sha1_base64, sha1_base64url, sha256_hex, sha256_base64, sha256_base64url, sha384_hex, sha384_base64, sha384_base64url, sha512_hex, sha512_base64, sha512_base64url;
 var init_regexes = __esm(() => {
   init_util();
-  cuid = /^[cC][^\s-]{8,}$/;
+  cuid = /^[cC][0-9a-z]{6,}$/;
   cuid2 = /^[0-9a-z]+$/;
   ulid = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/;
   xid = /^[0-9a-vA-V]{20}$/;
@@ -1748,6 +1772,7 @@ var init_regexes = __esm(() => {
   base64url = /^[A-Za-z0-9_-]*$/;
   hostname = /^(?=.{1,253}\.?$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[-0-9a-zA-Z]{0,61}[0-9a-zA-Z])?)*\.?$/;
   domain = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+  httpProtocol = /^https?$/;
   e164 = /^\+[1-9]\d{6,14}$/;
   date = /* @__PURE__ */ new RegExp(`^${dateSource}$`);
   bigint = /^-?\d+n?$/;
@@ -1788,10 +1813,10 @@ var init_checks = __esm(() => {
   init_regexes();
   init_util();
   $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
-    var _a;
+    var _a2;
     inst._zod ?? (inst._zod = {});
     inst._zod.def = def;
-    (_a = inst._zod).onattach ?? (_a.onattach = []);
+    (_a2 = inst._zod).onattach ?? (_a2.onattach = []);
   });
   numericOriginMap = {
     number: "number",
@@ -1857,8 +1882,8 @@ var init_checks = __esm(() => {
   $ZodCheckMultipleOf = /* @__PURE__ */ $constructor("$ZodCheckMultipleOf", (inst, def) => {
     $ZodCheck.init(inst, def);
     inst._zod.onattach.push((inst2) => {
-      var _a;
-      (_a = inst2._zod.bag).multipleOf ?? (_a.multipleOf = def.value);
+      var _a2;
+      (_a2 = inst2._zod.bag).multipleOf ?? (_a2.multipleOf = def.value);
     });
     inst._zod.check = (payload) => {
       if (typeof payload.value !== typeof def.value)
@@ -1991,9 +2016,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMaxSize = /* @__PURE__ */ $constructor("$ZodCheckMaxSize", (inst, def) => {
-    var _a;
+    var _a2;
     $ZodCheck.init(inst, def);
-    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.size !== undefined;
     });
@@ -2019,9 +2044,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMinSize = /* @__PURE__ */ $constructor("$ZodCheckMinSize", (inst, def) => {
-    var _a;
+    var _a2;
     $ZodCheck.init(inst, def);
-    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.size !== undefined;
     });
@@ -2047,9 +2072,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckSizeEquals = /* @__PURE__ */ $constructor("$ZodCheckSizeEquals", (inst, def) => {
-    var _a;
+    var _a2;
     $ZodCheck.init(inst, def);
-    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.size !== undefined;
     });
@@ -2077,9 +2102,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMaxLength = /* @__PURE__ */ $constructor("$ZodCheckMaxLength", (inst, def) => {
-    var _a;
+    var _a2;
     $ZodCheck.init(inst, def);
-    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.length !== undefined;
     });
@@ -2106,9 +2131,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMinLength = /* @__PURE__ */ $constructor("$ZodCheckMinLength", (inst, def) => {
-    var _a;
+    var _a2;
     $ZodCheck.init(inst, def);
-    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.length !== undefined;
     });
@@ -2135,9 +2160,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckLengthEquals = /* @__PURE__ */ $constructor("$ZodCheckLengthEquals", (inst, def) => {
-    var _a;
+    var _a2;
     $ZodCheck.init(inst, def);
-    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.length !== undefined;
     });
@@ -2166,7 +2191,7 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckStringFormat = /* @__PURE__ */ $constructor("$ZodCheckStringFormat", (inst, def) => {
-    var _a, _b;
+    var _a2, _b;
     $ZodCheck.init(inst, def);
     inst._zod.onattach.push((inst2) => {
       const bag = inst2._zod.bag;
@@ -2177,7 +2202,7 @@ var init_checks = __esm(() => {
       }
     });
     if (def.pattern)
-      (_a = inst._zod).check ?? (_a.check = (payload) => {
+      (_a2 = inst._zod).check ?? (_a2.check = (payload) => {
         def.pattern.lastIndex = 0;
         if (def.pattern.test(payload.value))
           return;
@@ -2372,8 +2397,8 @@ var version;
 var init_versions = __esm(() => {
   version = {
     major: 4,
-    minor: 3,
-    patch: 6
+    minor: 4,
+    patch: 3
   };
 });
 
@@ -2381,6 +2406,8 @@ var init_versions = __esm(() => {
 function isValidBase64(data) {
   if (data === "")
     return true;
+  if (/\s/.test(data))
+    return false;
   if (data.length % 4 !== 0)
     return false;
   try {
@@ -2423,15 +2450,27 @@ function handleArrayResult(result, final, index) {
   }
   final.value[index] = result.value;
 }
-function handlePropertyResult(result, final, key, input, isOptionalOut) {
+function handlePropertyResult(result, final, key, input, isOptionalIn, isOptionalOut) {
+  const isPresent = key in input;
   if (result.issues.length) {
-    if (isOptionalOut && !(key in input)) {
+    if (isOptionalIn && isOptionalOut && !isPresent) {
       return;
     }
     final.issues.push(...prefixIssues(key, result.issues));
   }
+  if (!isPresent && !isOptionalIn) {
+    if (!result.issues.length) {
+      final.issues.push({
+        code: "invalid_type",
+        expected: "nonoptional",
+        input: undefined,
+        path: [key]
+      });
+    }
+    return;
+  }
   if (result.value === undefined) {
-    if (key in input) {
+    if (isPresent) {
       final.value[key] = undefined;
     }
   } else {
@@ -2459,8 +2498,11 @@ function handleCatchall(proms, input, payload, ctx, def, inst) {
   const keySet = def.keySet;
   const _catchall = def.catchall._zod;
   const t = _catchall.def.type;
+  const isOptionalIn = _catchall.optin === "optional";
   const isOptionalOut = _catchall.optout === "optional";
   for (const key in input) {
+    if (key === "__proto__")
+      continue;
     if (keySet.has(key))
       continue;
     if (t === "never") {
@@ -2469,9 +2511,9 @@ function handleCatchall(proms, input, payload, ctx, def, inst) {
     }
     const r = _catchall.run({ value: input[key], issues: [] }, ctx);
     if (r instanceof Promise) {
-      proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalOut)));
+      proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalIn, isOptionalOut)));
     } else {
-      handlePropertyResult(r, payload, key, input, isOptionalOut);
+      handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
     }
   }
   if (unrecognized.length) {
@@ -2615,11 +2657,40 @@ function handleIntersectionResults(result, left, right) {
   result.value = merged.data;
   return result;
 }
+function getTupleOptStart(items, key) {
+  for (let i = items.length - 1;i >= 0; i--) {
+    if (items[i]._zod[key] !== "optional")
+      return i + 1;
+  }
+  return 0;
+}
 function handleTupleResult(result, final, index) {
   if (result.issues.length) {
     final.issues.push(...prefixIssues(index, result.issues));
   }
   final.value[index] = result.value;
+}
+function handleTupleResults(itemResults, final, items, input, optoutStart) {
+  for (let i = 0;i < items.length; i++) {
+    const r = itemResults[i];
+    const isPresent = i < input.length;
+    if (r.issues.length) {
+      if (!isPresent && i >= optoutStart) {
+        final.value.length = i;
+        break;
+      }
+      final.issues.push(...prefixIssues(i, r.issues));
+    }
+    final.value[i] = r.value;
+  }
+  for (let i = final.value.length - 1;i >= input.length; i--) {
+    if (items[i]._zod.optout === "optional" && final.value[i] === undefined) {
+      final.value.length = i;
+    } else {
+      break;
+    }
+  }
+  return final;
 }
 function handleMapResult(keyResult, valueResult, final, key, input, inst, ctx) {
   if (keyResult.issues.length) {
@@ -2658,7 +2729,7 @@ function handleSetResult(result, final) {
   final.value.add(result.value);
 }
 function handleOptionalResult(result, input) {
-  if (result.issues.length && input === undefined) {
+  if (input === undefined && (result.issues.length || result.fallback)) {
     return { issues: [], value: undefined };
   }
   return result;
@@ -2685,7 +2756,7 @@ function handlePipeResult(left, next, ctx) {
     left.aborted = true;
     return left;
   }
-  return next._zod.run({ value: left.value, issues: left.issues }, ctx);
+  return next._zod.run({ value: left.value, issues: left.issues, fallback: left.fallback }, ctx);
 }
 function handleCodecAResult(result, def, ctx) {
   if (result.issues.length) {
@@ -2732,7 +2803,7 @@ function handleRefineResult(result, payload, input, inst) {
     payload.issues.push(issue(_iss));
   }
 }
-var $ZodType, $ZodString, $ZodStringFormat, $ZodGUID, $ZodUUID, $ZodEmail, $ZodURL, $ZodEmoji, $ZodNanoID, $ZodCUID, $ZodCUID2, $ZodULID, $ZodXID, $ZodKSUID, $ZodISODateTime, $ZodISODate, $ZodISOTime, $ZodISODuration, $ZodIPv4, $ZodIPv6, $ZodMAC, $ZodCIDRv4, $ZodCIDRv6, $ZodBase64, $ZodBase64URL, $ZodE164, $ZodJWT, $ZodCustomStringFormat, $ZodNumber, $ZodNumberFormat, $ZodBoolean, $ZodBigInt, $ZodBigIntFormat, $ZodSymbol, $ZodUndefined, $ZodNull, $ZodAny, $ZodUnknown, $ZodNever, $ZodVoid, $ZodDate, $ZodArray, $ZodObject, $ZodObjectJIT, $ZodUnion, $ZodXor, $ZodDiscriminatedUnion, $ZodIntersection, $ZodTuple, $ZodRecord, $ZodMap, $ZodSet, $ZodEnum, $ZodLiteral, $ZodFile, $ZodTransform, $ZodOptional, $ZodExactOptional, $ZodNullable, $ZodDefault, $ZodPrefault, $ZodNonOptional, $ZodSuccess, $ZodCatch, $ZodNaN, $ZodPipe, $ZodCodec, $ZodReadonly, $ZodTemplateLiteral, $ZodFunction, $ZodPromise, $ZodLazy, $ZodCustom;
+var $ZodType, $ZodString, $ZodStringFormat, $ZodGUID, $ZodUUID, $ZodEmail, $ZodURL, $ZodEmoji, $ZodNanoID, $ZodCUID, $ZodCUID2, $ZodULID, $ZodXID, $ZodKSUID, $ZodISODateTime, $ZodISODate, $ZodISOTime, $ZodISODuration, $ZodIPv4, $ZodIPv6, $ZodMAC, $ZodCIDRv4, $ZodCIDRv6, $ZodBase64, $ZodBase64URL, $ZodE164, $ZodJWT, $ZodCustomStringFormat, $ZodNumber, $ZodNumberFormat, $ZodBoolean, $ZodBigInt, $ZodBigIntFormat, $ZodSymbol, $ZodUndefined, $ZodNull, $ZodAny, $ZodUnknown, $ZodNever, $ZodVoid, $ZodDate, $ZodArray, $ZodObject, $ZodObjectJIT, $ZodUnion, $ZodXor, $ZodDiscriminatedUnion, $ZodIntersection, $ZodTuple, $ZodRecord, $ZodMap, $ZodSet, $ZodEnum, $ZodLiteral, $ZodFile, $ZodTransform, $ZodOptional, $ZodExactOptional, $ZodNullable, $ZodDefault, $ZodPrefault, $ZodNonOptional, $ZodSuccess, $ZodCatch, $ZodNaN, $ZodPipe, $ZodCodec, $ZodPreprocess, $ZodReadonly, $ZodTemplateLiteral, $ZodFunction, $ZodPromise, $ZodLazy, $ZodCustom;
 var init_schemas = __esm(() => {
   init_checks();
   init_core();
@@ -2742,7 +2813,7 @@ var init_schemas = __esm(() => {
   init_versions();
   init_util();
   $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
-    var _a;
+    var _a2;
     inst ?? (inst = {});
     inst._zod.def = def;
     inst._zod.bag = inst._zod.bag || {};
@@ -2757,7 +2828,7 @@ var init_schemas = __esm(() => {
       }
     }
     if (checks.length === 0) {
-      (_a = inst._zod).deferred ?? (_a.deferred = []);
+      (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
       inst._zod.deferred?.push(() => {
         inst._zod.run = inst._zod.parse;
       });
@@ -2767,6 +2838,8 @@ var init_schemas = __esm(() => {
         let asyncResult;
         for (const ch of checks2) {
           if (ch._zod.def.when) {
+            if (explicitlyAborted(payload))
+              continue;
             const shouldRun = ch._zod.def.when(payload);
             if (!shouldRun)
               continue;
@@ -2906,6 +2979,19 @@ var init_schemas = __esm(() => {
     inst._zod.check = (payload) => {
       try {
         const trimmed = payload.value.trim();
+        if (!def.normalize && def.protocol?.source === httpProtocol.source) {
+          if (!/^https?:\/\//i.test(trimmed)) {
+            payload.issues.push({
+              code: "invalid_format",
+              format: "url",
+              note: "Invalid URL format",
+              input: payload.value,
+              inst,
+              continue: !def.abort
+            });
+            return;
+          }
+        }
         const url = new URL(trimmed);
         if (def.hostname) {
           def.hostname.lastIndex = 0;
@@ -3209,8 +3295,6 @@ var init_schemas = __esm(() => {
     $ZodType.init(inst, def);
     inst._zod.pattern = _undefined;
     inst._zod.values = new Set([undefined]);
-    inst._zod.optin = "optional";
-    inst._zod.optout = "optional";
     inst._zod.parse = (payload, _ctx) => {
       const input = payload.value;
       if (typeof input === "undefined")
@@ -3381,12 +3465,13 @@ var init_schemas = __esm(() => {
       const shape = value.shape;
       for (const key of value.keys) {
         const el = shape[key];
+        const isOptionalIn = el._zod.optin === "optional";
         const isOptionalOut = el._zod.optout === "optional";
         const r = el._zod.run({ value: input[key], issues: [] }, ctx);
         if (r instanceof Promise) {
-          proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalOut)));
+          proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalIn, isOptionalOut)));
         } else {
-          handlePropertyResult(r, payload, key, input, isOptionalOut);
+          handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
         }
       }
       if (!catchall) {
@@ -3417,9 +3502,10 @@ var init_schemas = __esm(() => {
         const id = ids[key];
         const k = esc(key);
         const schema = shape[key];
+        const isOptionalIn = schema?._zod?.optin === "optional";
         const isOptionalOut = schema?._zod?.optout === "optional";
         doc.write(`const ${id} = ${parseStr(key)};`);
-        if (isOptionalOut) {
+        if (isOptionalIn && isOptionalOut) {
           doc.write(`
         if (${id}.issues.length) {
           if (${k} in input) {
@@ -3438,6 +3524,33 @@ var init_schemas = __esm(() => {
           newResult[${k}] = ${id}.value;
         }
         
+      `);
+        } else if (!isOptionalIn) {
+          doc.write(`
+        const ${id}_present = ${k} in input;
+        if (${id}.issues.length) {
+          payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
+            ...iss,
+            path: iss.path ? [${k}, ...iss.path] : [${k}]
+          })));
+        }
+        if (!${id}_present && !${id}.issues.length) {
+          payload.issues.push({
+            code: "invalid_type",
+            expected: "nonoptional",
+            input: undefined,
+            path: [${k}]
+          });
+        }
+
+        if (${id}_present) {
+          if (${id}.value === undefined) {
+            newResult[${k}] = undefined;
+          } else {
+            newResult[${k}] = ${id}.value;
+          }
+        }
+
       `);
         } else {
           doc.write(`
@@ -3511,10 +3624,9 @@ var init_schemas = __esm(() => {
       }
       return;
     });
-    const single = def.options.length === 1;
-    const first = def.options[0]._zod.run;
+    const first = def.options.length === 1 ? def.options[0]._zod.run : null;
     inst._zod.parse = (payload, ctx) => {
-      if (single) {
+      if (first) {
         return first(payload, ctx);
       }
       let async = false;
@@ -3543,10 +3655,9 @@ var init_schemas = __esm(() => {
   $ZodXor = /* @__PURE__ */ $constructor("$ZodXor", (inst, def) => {
     $ZodUnion.init(inst, def);
     def.inclusive = false;
-    const single = def.options.length === 1;
-    const first = def.options[0]._zod.run;
+    const first = def.options.length === 1 ? def.options[0]._zod.run : null;
     inst._zod.parse = (payload, ctx) => {
-      if (single) {
+      if (first) {
         return first(payload, ctx);
       }
       let async = false;
@@ -3621,7 +3732,7 @@ var init_schemas = __esm(() => {
       if (opt) {
         return opt._zod.run(payload, ctx);
       }
-      if (def.unionFallback) {
+      if (def.unionFallback || ctx.direction === "backward") {
         return _super(payload, ctx);
       }
       payload.issues.push({
@@ -3629,6 +3740,7 @@ var init_schemas = __esm(() => {
         errors: [],
         note: "No matching discriminator",
         discriminator: def.discriminator,
+        options: Array.from(disc.value.keys()),
         input,
         path: [def.discriminator],
         inst
@@ -3667,56 +3779,59 @@ var init_schemas = __esm(() => {
       }
       payload.value = [];
       const proms = [];
-      const reversedIndex = [...items].reverse().findIndex((item) => item._zod.optin !== "optional");
-      const optStart = reversedIndex === -1 ? 0 : items.length - reversedIndex;
+      const optinStart = getTupleOptStart(items, "optin");
+      const optoutStart = getTupleOptStart(items, "optout");
       if (!def.rest) {
-        const tooBig = input.length > items.length;
-        const tooSmall = input.length < optStart - 1;
-        if (tooBig || tooSmall) {
+        if (input.length < optinStart) {
           payload.issues.push({
-            ...tooBig ? { code: "too_big", maximum: items.length, inclusive: true } : { code: "too_small", minimum: items.length },
+            code: "too_small",
+            minimum: optinStart,
+            inclusive: true,
             input,
             inst,
             origin: "array"
           });
           return payload;
         }
-      }
-      let i = -1;
-      for (const item of items) {
-        i++;
-        if (i >= input.length) {
-          if (i >= optStart)
-            continue;
+        if (input.length > items.length) {
+          payload.issues.push({
+            code: "too_big",
+            maximum: items.length,
+            inclusive: true,
+            input,
+            inst,
+            origin: "array"
+          });
         }
-        const result = item._zod.run({
-          value: input[i],
-          issues: []
-        }, ctx);
-        if (result instanceof Promise) {
-          proms.push(result.then((result2) => handleTupleResult(result2, payload, i)));
+      }
+      const itemResults = new Array(items.length);
+      for (let i = 0;i < items.length; i++) {
+        const r = items[i]._zod.run({ value: input[i], issues: [] }, ctx);
+        if (r instanceof Promise) {
+          proms.push(r.then((rr) => {
+            itemResults[i] = rr;
+          }));
         } else {
-          handleTupleResult(result, payload, i);
+          itemResults[i] = r;
         }
       }
       if (def.rest) {
+        let i = items.length - 1;
         const rest = input.slice(items.length);
         for (const el of rest) {
           i++;
-          const result = def.rest._zod.run({
-            value: el,
-            issues: []
-          }, ctx);
+          const result = def.rest._zod.run({ value: el, issues: [] }, ctx);
           if (result instanceof Promise) {
-            proms.push(result.then((result2) => handleTupleResult(result2, payload, i)));
+            proms.push(result.then((r) => handleTupleResult(r, payload, i)));
           } else {
             handleTupleResult(result, payload, i);
           }
         }
       }
-      if (proms.length)
-        return Promise.all(proms).then(() => payload);
-      return payload;
+      if (proms.length) {
+        return Promise.all(proms).then(() => handleTupleResults(itemResults, payload, items, input, optoutStart));
+      }
+      return handleTupleResults(itemResults, payload, items, input, optoutStart);
     };
   });
   $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
@@ -3740,19 +3855,35 @@ var init_schemas = __esm(() => {
         for (const key of values) {
           if (typeof key === "string" || typeof key === "number" || typeof key === "symbol") {
             recordKeys.add(typeof key === "number" ? key.toString() : key);
+            const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
+            if (keyResult instanceof Promise) {
+              throw new Error("Async schemas not supported in object keys currently");
+            }
+            if (keyResult.issues.length) {
+              payload.issues.push({
+                code: "invalid_key",
+                origin: "record",
+                issues: keyResult.issues.map((iss) => finalizeIssue(iss, ctx, config())),
+                input: key,
+                path: [key],
+                inst
+              });
+              continue;
+            }
+            const outKey = keyResult.value;
             const result = def.valueType._zod.run({ value: input[key], issues: [] }, ctx);
             if (result instanceof Promise) {
               proms.push(result.then((result2) => {
                 if (result2.issues.length) {
                   payload.issues.push(...prefixIssues(key, result2.issues));
                 }
-                payload.value[key] = result2.value;
+                payload.value[outKey] = result2.value;
               }));
             } else {
               if (result.issues.length) {
                 payload.issues.push(...prefixIssues(key, result.issues));
               }
-              payload.value[key] = result.value;
+              payload.value[outKey] = result.value;
             }
           }
         }
@@ -3775,6 +3906,8 @@ var init_schemas = __esm(() => {
         payload.value = {};
         for (const key of Reflect.ownKeys(input)) {
           if (key === "__proto__")
+            continue;
+          if (!Object.prototype.propertyIsEnumerable.call(input, key))
             continue;
           let keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
           if (keyResult instanceof Promise) {
@@ -3944,6 +4077,7 @@ var init_schemas = __esm(() => {
   });
   $ZodTransform = /* @__PURE__ */ $constructor("$ZodTransform", (inst, def) => {
     $ZodType.init(inst, def);
+    inst._zod.optin = "optional";
     inst._zod.parse = (payload, ctx) => {
       if (ctx.direction === "backward") {
         throw new $ZodEncodeError(inst.constructor.name);
@@ -3953,6 +4087,7 @@ var init_schemas = __esm(() => {
         const output = _out instanceof Promise ? _out : Promise.resolve(_out);
         return output.then((output2) => {
           payload.value = output2;
+          payload.fallback = true;
           return payload;
         });
       }
@@ -3960,6 +4095,7 @@ var init_schemas = __esm(() => {
         throw new $ZodAsyncError;
       }
       payload.value = _out;
+      payload.fallback = true;
       return payload;
     };
   });
@@ -3976,10 +4112,11 @@ var init_schemas = __esm(() => {
     });
     inst._zod.parse = (payload, ctx) => {
       if (def.innerType._zod.optin === "optional") {
+        const input = payload.value;
         const result = def.innerType._zod.run(payload, ctx);
         if (result instanceof Promise)
-          return result.then((r) => handleOptionalResult(r, payload.value));
-        return handleOptionalResult(result, payload.value);
+          return result.then((r) => handleOptionalResult(r, input));
+        return handleOptionalResult(result, input);
       }
       if (payload.value === undefined) {
         return payload;
@@ -4078,7 +4215,7 @@ var init_schemas = __esm(() => {
   });
   $ZodCatch = /* @__PURE__ */ $constructor("$ZodCatch", (inst, def) => {
     $ZodType.init(inst, def);
-    defineLazy(inst._zod, "optin", () => def.innerType._zod.optin);
+    inst._zod.optin = "optional";
     defineLazy(inst._zod, "optout", () => def.innerType._zod.optout);
     defineLazy(inst._zod, "values", () => def.innerType._zod.values);
     inst._zod.parse = (payload, ctx) => {
@@ -4098,6 +4235,7 @@ var init_schemas = __esm(() => {
               input: payload.value
             });
             payload.issues = [];
+            payload.fallback = true;
           }
           return payload;
         });
@@ -4112,6 +4250,7 @@ var init_schemas = __esm(() => {
           input: payload.value
         });
         payload.issues = [];
+        payload.fallback = true;
       }
       return payload;
     };
@@ -4174,6 +4313,9 @@ var init_schemas = __esm(() => {
         return handleCodecAResult(right, def, ctx);
       }
     };
+  });
+  $ZodPreprocess = /* @__PURE__ */ $constructor("$ZodPreprocess", (inst, def) => {
+    $ZodPipe.init(inst, def);
   });
   $ZodReadonly = /* @__PURE__ */ $constructor("$ZodReadonly", (inst, def) => {
     $ZodType.init(inst, def);
@@ -4322,7 +4464,12 @@ var init_schemas = __esm(() => {
   });
   $ZodLazy = /* @__PURE__ */ $constructor("$ZodLazy", (inst, def) => {
     $ZodType.init(inst, def);
-    defineLazy(inst._zod, "innerType", () => def.getter());
+    defineLazy(inst._zod, "innerType", () => {
+      const d = def;
+      if (!d._cachedInner)
+        d._cachedInner = def.getter();
+      return d._cachedInner;
+    });
     defineLazy(inst._zod, "pattern", () => inst._zod.innerType?._zod?.pattern);
     defineLazy(inst._zod, "propValues", () => inst._zod.innerType?._zod?.propValues);
     defineLazy(inst._zod, "optin", () => inst._zod.innerType?._zod?.optin ?? undefined);
@@ -5310,13 +5457,126 @@ var init_de = __esm(() => {
   init_util();
 });
 
-// node_modules/zod/v4/locales/en.js
-function en_default() {
+// node_modules/zod/v4/locales/el.js
+function el_default() {
   return {
     localeError: error10()
   };
 }
 var error10 = () => {
+  const Sizable = {
+    string: { unit: "\u03C7\u03B1\u03C1\u03B1\u03BA\u03C4\u03AE\u03C1\u03B5\u03C2", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
+    file: { unit: "bytes", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
+    array: { unit: "\u03C3\u03C4\u03BF\u03B9\u03C7\u03B5\u03AF\u03B1", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
+    set: { unit: "\u03C3\u03C4\u03BF\u03B9\u03C7\u03B5\u03AF\u03B1", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
+    map: { unit: "\u03BA\u03B1\u03C4\u03B1\u03C7\u03C9\u03C1\u03AE\u03C3\u03B5\u03B9\u03C2", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" }
+  };
+  function getSizing(origin) {
+    return Sizable[origin] ?? null;
+  }
+  const FormatDictionary = {
+    regex: "\u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2",
+    email: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 email",
+    url: "URL",
+    emoji: "emoji",
+    uuid: "UUID",
+    uuidv4: "UUIDv4",
+    uuidv6: "UUIDv6",
+    nanoid: "nanoid",
+    guid: "GUID",
+    cuid: "cuid",
+    cuid2: "cuid2",
+    ulid: "ULID",
+    xid: "XID",
+    ksuid: "KSUID",
+    datetime: "ISO \u03B7\u03BC\u03B5\u03C1\u03BF\u03BC\u03B7\u03BD\u03AF\u03B1 \u03BA\u03B1\u03B9 \u03CE\u03C1\u03B1",
+    date: "ISO \u03B7\u03BC\u03B5\u03C1\u03BF\u03BC\u03B7\u03BD\u03AF\u03B1",
+    time: "ISO \u03CE\u03C1\u03B1",
+    duration: "ISO \u03B4\u03B9\u03AC\u03C1\u03BA\u03B5\u03B9\u03B1",
+    ipv4: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 IPv4",
+    ipv6: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 IPv6",
+    mac: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 MAC",
+    cidrv4: "\u03B5\u03CD\u03C1\u03BF\u03C2 IPv4",
+    cidrv6: "\u03B5\u03CD\u03C1\u03BF\u03C2 IPv6",
+    base64: "\u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC \u03BA\u03C9\u03B4\u03B9\u03BA\u03BF\u03C0\u03BF\u03B9\u03B7\u03BC\u03AD\u03BD\u03B7 \u03C3\u03B5 base64",
+    base64url: "\u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC \u03BA\u03C9\u03B4\u03B9\u03BA\u03BF\u03C0\u03BF\u03B9\u03B7\u03BC\u03AD\u03BD\u03B7 \u03C3\u03B5 base64url",
+    json_string: "\u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC JSON",
+    e164: "\u03B1\u03C1\u03B9\u03B8\u03BC\u03CC\u03C2 E.164",
+    jwt: "JWT",
+    template_literal: "\u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2"
+  };
+  const TypeDictionary = {
+    nan: "NaN"
+  };
+  return (issue2) => {
+    switch (issue2.code) {
+      case "invalid_type": {
+        const expected = TypeDictionary[issue2.expected] ?? issue2.expected;
+        const receivedType = parsedType(issue2.input);
+        const received = TypeDictionary[receivedType] ?? receivedType;
+        if (typeof issue2.expected === "string" && /^[A-Z]/.test(issue2.expected)) {
+          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD instanceof ${issue2.expected}, \u03BB\u03AE\u03C6\u03B8\u03B7\u03BA\u03B5 ${received}`;
+        }
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${expected}, \u03BB\u03AE\u03C6\u03B8\u03B7\u03BA\u03B5 ${received}`;
+      }
+      case "invalid_value":
+        if (issue2.values.length === 1)
+          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${stringifyPrimitive(issue2.values[0])}`;
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03C0\u03B9\u03BB\u03BF\u03B3\u03AE: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD \u03AD\u03BD\u03B1 \u03B1\u03C0\u03CC ${joinValues(issue2.values, "|")}`;
+      case "too_big": {
+        const adj = issue2.inclusive ? "<=" : "<";
+        const sizing = getSizing(issue2.origin);
+        if (sizing)
+          return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B5\u03B3\u03AC\u03BB\u03BF: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin ?? "\u03C4\u03B9\u03BC\u03AE"} \u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9 ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "\u03C3\u03C4\u03BF\u03B9\u03C7\u03B5\u03AF\u03B1"}`;
+        return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B5\u03B3\u03AC\u03BB\u03BF: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin ?? "\u03C4\u03B9\u03BC\u03AE"} \u03BD\u03B1 \u03B5\u03AF\u03BD\u03B1\u03B9 ${adj}${issue2.maximum.toString()}`;
+      }
+      case "too_small": {
+        const adj = issue2.inclusive ? ">=" : ">";
+        const sizing = getSizing(issue2.origin);
+        if (sizing) {
+          return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B9\u03BA\u03C1\u03CC: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin} \u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9 ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
+        }
+        return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B9\u03BA\u03C1\u03CC: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin} \u03BD\u03B1 \u03B5\u03AF\u03BD\u03B1\u03B9 ${adj}${issue2.minimum.toString()}`;
+      }
+      case "invalid_format": {
+        const _issue = issue2;
+        if (_issue.format === "starts_with") {
+          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03BE\u03B5\u03BA\u03B9\u03BD\u03AC \u03BC\u03B5 "${_issue.prefix}"`;
+        }
+        if (_issue.format === "ends_with")
+          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03C4\u03B5\u03BB\u03B5\u03B9\u03CE\u03BD\u03B5\u03B9 \u03BC\u03B5 "${_issue.suffix}"`;
+        if (_issue.format === "includes")
+          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03C0\u03B5\u03C1\u03B9\u03AD\u03C7\u03B5\u03B9 "${_issue.includes}"`;
+        if (_issue.format === "regex")
+          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03C4\u03B1\u03B9\u03C1\u03B9\u03AC\u03B6\u03B5\u03B9 \u03BC\u03B5 \u03C4\u03BF \u03BC\u03BF\u03C4\u03AF\u03B2\u03BF ${_issue.pattern}`;
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03BF: ${FormatDictionary[_issue.format] ?? issue2.format}`;
+      }
+      case "not_multiple_of":
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03BF\u03C2 \u03B1\u03C1\u03B9\u03B8\u03BC\u03CC\u03C2: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03B5\u03AF\u03BD\u03B1\u03B9 \u03C0\u03BF\u03BB\u03BB\u03B1\u03C0\u03BB\u03AC\u03C3\u03B9\u03BF \u03C4\u03BF\u03C5 ${issue2.divisor}`;
+      case "unrecognized_keys":
+        return `\u0386\u03B3\u03BD\u03C9\u03C3\u03C4${issue2.keys.length > 1 ? "\u03B1" : "\u03BF"} \u03BA\u03BB\u03B5\u03B9\u03B4${issue2.keys.length > 1 ? "\u03B9\u03AC" : "\u03AF"}: ${joinValues(issue2.keys, ", ")}`;
+      case "invalid_key":
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03BF \u03BA\u03BB\u03B5\u03B9\u03B4\u03AF \u03C3\u03C4\u03BF ${issue2.origin}`;
+      case "invalid_union":
+        return "\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2";
+      case "invalid_element":
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C4\u03B9\u03BC\u03AE \u03C3\u03C4\u03BF ${issue2.origin}`;
+      default:
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2`;
+    }
+  };
+};
+var init_el = __esm(() => {
+  init_util();
+});
+
+// node_modules/zod/v4/locales/en.js
+function en_default() {
+  return {
+    localeError: error11()
+  };
+}
+var error11 = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
     file: { unit: "bytes", verb: "to have" },
@@ -5408,6 +5668,10 @@ var error10 = () => {
       case "invalid_key":
         return `Invalid key in ${issue2.origin}`;
       case "invalid_union":
+        if (issue2.options && Array.isArray(issue2.options) && issue2.options.length > 0) {
+          const opts = issue2.options.map((o) => `'${o}'`).join(" | ");
+          return `Invalid discriminator value. Expected ${opts}`;
+        }
         return "Invalid input";
       case "invalid_element":
         return `Invalid value in ${issue2.origin}`;
@@ -5423,10 +5687,10 @@ var init_en = __esm(() => {
 // node_modules/zod/v4/locales/eo.js
 function eo_default() {
   return {
-    localeError: error11()
+    localeError: error12()
   };
 }
-var error11 = () => {
+var error12 = () => {
   const Sizable = {
     string: { unit: "karaktrojn", verb: "havi" },
     file: { unit: "bajtojn", verb: "havi" },
@@ -5536,10 +5800,10 @@ var init_eo = __esm(() => {
 // node_modules/zod/v4/locales/es.js
 function es_default() {
   return {
-    localeError: error12()
+    localeError: error13()
   };
 }
-var error12 = () => {
+var error13 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "tener" },
     file: { unit: "bytes", verb: "tener" },
@@ -5672,10 +5936,10 @@ var init_es = __esm(() => {
 // node_modules/zod/v4/locales/fa.js
 function fa_default() {
   return {
-    localeError: error13()
+    localeError: error14()
   };
 }
-var error13 = () => {
+var error14 = () => {
   const Sizable = {
     string: { unit: "\u06A9\u0627\u0631\u0627\u06A9\u062A\u0631", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
     file: { unit: "\u0628\u0627\u06CC\u062A", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
@@ -5790,10 +6054,10 @@ var init_fa = __esm(() => {
 // node_modules/zod/v4/locales/fi.js
 function fi_default() {
   return {
-    localeError: error14()
+    localeError: error15()
   };
 }
-var error14 = () => {
+var error15 = () => {
   const Sizable = {
     string: { unit: "merkki\xE4", subject: "merkkijonon" },
     file: { unit: "tavua", subject: "tiedoston" },
@@ -5906,10 +6170,10 @@ var init_fi = __esm(() => {
 // node_modules/zod/v4/locales/fr.js
 function fr_default() {
   return {
-    localeError: error15()
+    localeError: error16()
   };
 }
-var error15 = () => {
+var error16 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -5950,9 +6214,27 @@ var error15 = () => {
     template_literal: "entr\xE9e"
   };
   const TypeDictionary = {
-    nan: "NaN",
+    string: "cha\xEEne",
     number: "nombre",
-    array: "tableau"
+    int: "entier",
+    boolean: "bool\xE9en",
+    bigint: "grand entier",
+    symbol: "symbole",
+    undefined: "ind\xE9fini",
+    null: "null",
+    never: "jamais",
+    void: "vide",
+    date: "date",
+    array: "tableau",
+    object: "objet",
+    tuple: "tuple",
+    record: "enregistrement",
+    map: "carte",
+    set: "ensemble",
+    file: "fichier",
+    nonoptional: "non-optionnel",
+    nan: "NaN",
+    function: "fonction"
   };
   return (issue2) => {
     switch (issue2.code) {
@@ -5973,16 +6255,15 @@ var error15 = () => {
         const adj = issue2.inclusive ? "<=" : "<";
         const sizing = getSizing(issue2.origin);
         if (sizing)
-          return `Trop grand : ${issue2.origin ?? "valeur"} doit ${sizing.verb} ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "\xE9l\xE9ment(s)"}`;
-        return `Trop grand : ${issue2.origin ?? "valeur"} doit \xEAtre ${adj}${issue2.maximum.toString()}`;
+          return `Trop grand : ${TypeDictionary[issue2.origin] ?? "valeur"} doit ${sizing.verb} ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "\xE9l\xE9ment(s)"}`;
+        return `Trop grand : ${TypeDictionary[issue2.origin] ?? "valeur"} doit \xEAtre ${adj}${issue2.maximum.toString()}`;
       }
       case "too_small": {
         const adj = issue2.inclusive ? ">=" : ">";
         const sizing = getSizing(issue2.origin);
-        if (sizing) {
-          return `Trop petit : ${issue2.origin} doit ${sizing.verb} ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
-        }
-        return `Trop petit : ${issue2.origin} doit \xEAtre ${adj}${issue2.minimum.toString()}`;
+        if (sizing)
+          return `Trop petit : ${TypeDictionary[issue2.origin] ?? "valeur"} doit ${sizing.verb} ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
+        return `Trop petit : ${TypeDictionary[issue2.origin] ?? "valeur"} doit \xEAtre ${adj}${issue2.minimum.toString()}`;
       }
       case "invalid_format": {
         const _issue = issue2;
@@ -6018,10 +6299,10 @@ var init_fr = __esm(() => {
 // node_modules/zod/v4/locales/fr-CA.js
 function fr_CA_default() {
   return {
-    localeError: error16()
+    localeError: error17()
   };
 }
-var error16 = () => {
+var error17 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -6129,10 +6410,10 @@ var init_fr_CA = __esm(() => {
 // node_modules/zod/v4/locales/he.js
 function he_default() {
   return {
-    localeError: error17()
+    localeError: error18()
   };
 }
-var error17 = () => {
+var error18 = () => {
   const TypeNames = {
     string: { label: "\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA", gender: "f" },
     number: { label: "\u05DE\u05E1\u05E4\u05E8", gender: "m" },
@@ -6323,13 +6604,139 @@ var init_he = __esm(() => {
   init_util();
 });
 
+// node_modules/zod/v4/locales/hr.js
+function hr_default() {
+  return {
+    localeError: error19()
+  };
+}
+var error19 = () => {
+  const Sizable = {
+    string: { unit: "znakova", verb: "imati" },
+    file: { unit: "bajtova", verb: "imati" },
+    array: { unit: "stavki", verb: "imati" },
+    set: { unit: "stavki", verb: "imati" }
+  };
+  function getSizing(origin) {
+    return Sizable[origin] ?? null;
+  }
+  const FormatDictionary = {
+    regex: "unos",
+    email: "email adresa",
+    url: "URL",
+    emoji: "emoji",
+    uuid: "UUID",
+    uuidv4: "UUIDv4",
+    uuidv6: "UUIDv6",
+    nanoid: "nanoid",
+    guid: "GUID",
+    cuid: "cuid",
+    cuid2: "cuid2",
+    ulid: "ULID",
+    xid: "XID",
+    ksuid: "KSUID",
+    datetime: "ISO datum i vrijeme",
+    date: "ISO datum",
+    time: "ISO vrijeme",
+    duration: "ISO trajanje",
+    ipv4: "IPv4 adresa",
+    ipv6: "IPv6 adresa",
+    cidrv4: "IPv4 raspon",
+    cidrv6: "IPv6 raspon",
+    base64: "base64 kodirani tekst",
+    base64url: "base64url kodirani tekst",
+    json_string: "JSON tekst",
+    e164: "E.164 broj",
+    jwt: "JWT",
+    template_literal: "unos"
+  };
+  const TypeDictionary = {
+    nan: "NaN",
+    string: "tekst",
+    number: "broj",
+    boolean: "boolean",
+    array: "niz",
+    object: "objekt",
+    set: "skup",
+    file: "datoteka",
+    date: "datum",
+    bigint: "bigint",
+    symbol: "simbol",
+    undefined: "undefined",
+    null: "null",
+    function: "funkcija",
+    map: "mapa"
+  };
+  return (issue2) => {
+    switch (issue2.code) {
+      case "invalid_type": {
+        const expected = TypeDictionary[issue2.expected] ?? issue2.expected;
+        const receivedType = parsedType(issue2.input);
+        const received = TypeDictionary[receivedType] ?? receivedType;
+        if (/^[A-Z]/.test(issue2.expected)) {
+          return `Neispravan unos: o\u010Dekuje se instanceof ${issue2.expected}, a primljeno je ${received}`;
+        }
+        return `Neispravan unos: o\u010Dekuje se ${expected}, a primljeno je ${received}`;
+      }
+      case "invalid_value":
+        if (issue2.values.length === 1)
+          return `Neispravna vrijednost: o\u010Dekivano ${stringifyPrimitive(issue2.values[0])}`;
+        return `Neispravna opcija: o\u010Dekivano jedno od ${joinValues(issue2.values, "|")}`;
+      case "too_big": {
+        const adj = issue2.inclusive ? "<=" : "<";
+        const sizing = getSizing(issue2.origin);
+        const origin = TypeDictionary[issue2.origin] ?? issue2.origin;
+        if (sizing)
+          return `Preveliko: o\u010Dekivano da ${origin ?? "vrijednost"} ima ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "elemenata"}`;
+        return `Preveliko: o\u010Dekivano da ${origin ?? "vrijednost"} bude ${adj}${issue2.maximum.toString()}`;
+      }
+      case "too_small": {
+        const adj = issue2.inclusive ? ">=" : ">";
+        const sizing = getSizing(issue2.origin);
+        const origin = TypeDictionary[issue2.origin] ?? issue2.origin;
+        if (sizing) {
+          return `Premalo: o\u010Dekivano da ${origin} ima ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
+        }
+        return `Premalo: o\u010Dekivano da ${origin} bude ${adj}${issue2.minimum.toString()}`;
+      }
+      case "invalid_format": {
+        const _issue = issue2;
+        if (_issue.format === "starts_with")
+          return `Neispravan tekst: mora zapo\u010Dinjati s "${_issue.prefix}"`;
+        if (_issue.format === "ends_with")
+          return `Neispravan tekst: mora zavr\u0161avati s "${_issue.suffix}"`;
+        if (_issue.format === "includes")
+          return `Neispravan tekst: mora sadr\u017Eavati "${_issue.includes}"`;
+        if (_issue.format === "regex")
+          return `Neispravan tekst: mora odgovarati uzorku ${_issue.pattern}`;
+        return `Neispravna ${FormatDictionary[_issue.format] ?? issue2.format}`;
+      }
+      case "not_multiple_of":
+        return `Neispravan broj: mora biti vi\u0161ekratnik od ${issue2.divisor}`;
+      case "unrecognized_keys":
+        return `Neprepoznat${issue2.keys.length > 1 ? "i klju\u010Devi" : " klju\u010D"}: ${joinValues(issue2.keys, ", ")}`;
+      case "invalid_key":
+        return `Neispravan klju\u010D u ${TypeDictionary[issue2.origin] ?? issue2.origin}`;
+      case "invalid_union":
+        return "Neispravan unos";
+      case "invalid_element":
+        return `Neispravna vrijednost u ${TypeDictionary[issue2.origin] ?? issue2.origin}`;
+      default:
+        return `Neispravan unos`;
+    }
+  };
+};
+var init_hr = __esm(() => {
+  init_util();
+});
+
 // node_modules/zod/v4/locales/hu.js
 function hu_default() {
   return {
-    localeError: error18()
+    localeError: error20()
   };
 }
-var error18 = () => {
+var error20 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "legyen" },
     file: { unit: "byte", verb: "legyen" },
@@ -6448,10 +6855,10 @@ function withDefiniteArticle(word) {
 }
 function hy_default() {
   return {
-    localeError: error19()
+    localeError: error21()
   };
 }
-var error19 = () => {
+var error21 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -6589,10 +6996,10 @@ var init_hy = __esm(() => {
 // node_modules/zod/v4/locales/id.js
 function id_default() {
   return {
-    localeError: error20()
+    localeError: error22()
   };
 }
-var error20 = () => {
+var error22 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "memiliki" },
     file: { unit: "byte", verb: "memiliki" },
@@ -6699,10 +7106,10 @@ var init_id = __esm(() => {
 // node_modules/zod/v4/locales/is.js
 function is_default() {
   return {
-    localeError: error21()
+    localeError: error23()
   };
 }
-var error21 = () => {
+var error23 = () => {
   const Sizable = {
     string: { unit: "stafi", verb: "a\xF0 hafa" },
     file: { unit: "b\xE6ti", verb: "a\xF0 hafa" },
@@ -6812,10 +7219,10 @@ var init_is = __esm(() => {
 // node_modules/zod/v4/locales/it.js
 function it_default() {
   return {
-    localeError: error22()
+    localeError: error24()
   };
 }
-var error22 = () => {
+var error24 = () => {
   const Sizable = {
     string: { unit: "caratteri", verb: "avere" },
     file: { unit: "byte", verb: "avere" },
@@ -6900,7 +7307,7 @@ var error22 = () => {
           return `Stringa non valida: deve includere "${_issue.includes}"`;
         if (_issue.format === "regex")
           return `Stringa non valida: deve corrispondere al pattern ${_issue.pattern}`;
-        return `Invalid ${FormatDictionary[_issue.format] ?? issue2.format}`;
+        return `Input non valido: ${FormatDictionary[_issue.format] ?? issue2.format}`;
       }
       case "not_multiple_of":
         return `Numero non valido: deve essere un multiplo di ${issue2.divisor}`;
@@ -6924,10 +7331,10 @@ var init_it = __esm(() => {
 // node_modules/zod/v4/locales/ja.js
 function ja_default() {
   return {
-    localeError: error23()
+    localeError: error25()
   };
 }
-var error23 = () => {
+var error25 = () => {
   const Sizable = {
     string: { unit: "\u6587\u5B57", verb: "\u3067\u3042\u308B" },
     file: { unit: "\u30D0\u30A4\u30C8", verb: "\u3067\u3042\u308B" },
@@ -7035,10 +7442,10 @@ var init_ja = __esm(() => {
 // node_modules/zod/v4/locales/ka.js
 function ka_default() {
   return {
-    localeError: error24()
+    localeError: error26()
   };
 }
-var error24 = () => {
+var error26 = () => {
   const Sizable = {
     string: { unit: "\u10E1\u10D8\u10DB\u10D1\u10DD\u10DA\u10DD", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
     file: { unit: "\u10D1\u10D0\u10D8\u10E2\u10D8", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
@@ -7071,9 +7478,9 @@ var error24 = () => {
     ipv6: "IPv6 \u10DB\u10D8\u10E1\u10D0\u10DB\u10D0\u10E0\u10D7\u10D8",
     cidrv4: "IPv4 \u10D3\u10D8\u10D0\u10DE\u10D0\u10D6\u10DD\u10DC\u10D8",
     cidrv6: "IPv6 \u10D3\u10D8\u10D0\u10DE\u10D0\u10D6\u10DD\u10DC\u10D8",
-    base64: "base64-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
-    base64url: "base64url-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
-    json_string: "JSON \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
+    base64: "base64-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10D5\u10D4\u10DA\u10D8",
+    base64url: "base64url-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10D5\u10D4\u10DA\u10D8",
+    json_string: "JSON \u10D5\u10D4\u10DA\u10D8",
     e164: "E.164 \u10DC\u10DD\u10DB\u10D4\u10E0\u10D8",
     jwt: "JWT",
     template_literal: "\u10E8\u10D4\u10E7\u10D5\u10D0\u10DC\u10D0"
@@ -7081,7 +7488,7 @@ var error24 = () => {
   const TypeDictionary = {
     nan: "NaN",
     number: "\u10E0\u10D8\u10EA\u10EE\u10D5\u10D8",
-    string: "\u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
+    string: "\u10D5\u10D4\u10DA\u10D8",
     boolean: "\u10D1\u10E3\u10DA\u10D4\u10D0\u10DC\u10D8",
     function: "\u10E4\u10E3\u10DC\u10E5\u10EA\u10D8\u10D0",
     array: "\u10DB\u10D0\u10E1\u10D8\u10D5\u10D8"
@@ -7119,14 +7526,14 @@ var error24 = () => {
       case "invalid_format": {
         const _issue = issue2;
         if (_issue.format === "starts_with") {
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10D8\u10EC\u10E7\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.prefix}"-\u10D8\u10D7`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10D8\u10EC\u10E7\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.prefix}"-\u10D8\u10D7`;
         }
         if (_issue.format === "ends_with")
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10DB\u10D7\u10D0\u10D5\u10E0\u10D3\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.suffix}"-\u10D8\u10D7`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10DB\u10D7\u10D0\u10D5\u10E0\u10D3\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.suffix}"-\u10D8\u10D7`;
         if (_issue.format === "includes")
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1 "${_issue.includes}"-\u10E1`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1 "${_issue.includes}"-\u10E1`;
         if (_issue.format === "regex")
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D4\u10E1\u10D0\u10D1\u10D0\u10DB\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 \u10E8\u10D0\u10D1\u10DA\u10DD\u10DC\u10E1 ${_issue.pattern}`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D4\u10E1\u10D0\u10D1\u10D0\u10DB\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 \u10E8\u10D0\u10D1\u10DA\u10DD\u10DC\u10E1 ${_issue.pattern}`;
         return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 ${FormatDictionary[_issue.format] ?? issue2.format}`;
       }
       case "not_multiple_of":
@@ -7151,10 +7558,10 @@ var init_ka = __esm(() => {
 // node_modules/zod/v4/locales/km.js
 function km_default() {
   return {
-    localeError: error25()
+    localeError: error27()
   };
 }
-var error25 = () => {
+var error27 = () => {
   const Sizable = {
     string: { unit: "\u178F\u17BD\u17A2\u1780\u17D2\u179F\u179A", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
     file: { unit: "\u1794\u17C3", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
@@ -7273,10 +7680,10 @@ var init_kh = __esm(() => {
 // node_modules/zod/v4/locales/ko.js
 function ko_default() {
   return {
-    localeError: error26()
+    localeError: error28()
   };
 }
-var error26 = () => {
+var error28 = () => {
   const Sizable = {
     string: { unit: "\uBB38\uC790", verb: "to have" },
     file: { unit: "\uBC14\uC774\uD2B8", verb: "to have" },
@@ -7398,12 +7805,12 @@ function getUnitTypeFromNumber(number2) {
 }
 function lt_default() {
   return {
-    localeError: error27()
+    localeError: error29()
   };
 }
 var capitalizeFirstCharacter = (text) => {
   return text.charAt(0).toUpperCase() + text.slice(1);
-}, error27 = () => {
+}, error29 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -7594,10 +8001,10 @@ var init_lt = __esm(() => {
 // node_modules/zod/v4/locales/mk.js
 function mk_default() {
   return {
-    localeError: error28()
+    localeError: error30()
   };
 }
-var error28 = () => {
+var error30 = () => {
   const Sizable = {
     string: { unit: "\u0437\u043D\u0430\u0446\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
     file: { unit: "\u0431\u0430\u0458\u0442\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
@@ -7707,10 +8114,10 @@ var init_mk = __esm(() => {
 // node_modules/zod/v4/locales/ms.js
 function ms_default() {
   return {
-    localeError: error29()
+    localeError: error31()
   };
 }
-var error29 = () => {
+var error31 = () => {
   const Sizable = {
     string: { unit: "aksara", verb: "mempunyai" },
     file: { unit: "bait", verb: "mempunyai" },
@@ -7818,10 +8225,10 @@ var init_ms = __esm(() => {
 // node_modules/zod/v4/locales/nl.js
 function nl_default() {
   return {
-    localeError: error30()
+    localeError: error32()
   };
 }
-var error30 = () => {
+var error32 = () => {
   const Sizable = {
     string: { unit: "tekens", verb: "heeft" },
     file: { unit: "bytes", verb: "heeft" },
@@ -7932,10 +8339,10 @@ var init_nl = __esm(() => {
 // node_modules/zod/v4/locales/no.js
 function no_default() {
   return {
-    localeError: error31()
+    localeError: error33()
   };
 }
-var error31 = () => {
+var error33 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "\xE5 ha" },
     file: { unit: "bytes", verb: "\xE5 ha" },
@@ -8044,10 +8451,10 @@ var init_no = __esm(() => {
 // node_modules/zod/v4/locales/ota.js
 function ota_default() {
   return {
-    localeError: error32()
+    localeError: error34()
   };
 }
-var error32 = () => {
+var error34 = () => {
   const Sizable = {
     string: { unit: "harf", verb: "olmal\u0131d\u0131r" },
     file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
@@ -8157,10 +8564,10 @@ var init_ota = __esm(() => {
 // node_modules/zod/v4/locales/ps.js
 function ps_default() {
   return {
-    localeError: error33()
+    localeError: error35()
   };
 }
-var error33 = () => {
+var error35 = () => {
   const Sizable = {
     string: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
     file: { unit: "\u0628\u0627\u06CC\u067C\u0633", verb: "\u0648\u0644\u0631\u064A" },
@@ -8275,10 +8682,10 @@ var init_ps = __esm(() => {
 // node_modules/zod/v4/locales/pl.js
 function pl_default() {
   return {
-    localeError: error34()
+    localeError: error36()
   };
 }
-var error34 = () => {
+var error36 = () => {
   const Sizable = {
     string: { unit: "znak\xF3w", verb: "mie\u0107" },
     file: { unit: "bajt\xF3w", verb: "mie\u0107" },
@@ -8388,10 +8795,10 @@ var init_pl = __esm(() => {
 // node_modules/zod/v4/locales/pt.js
 function pt_default() {
   return {
-    localeError: error35()
+    localeError: error37()
   };
 }
-var error35 = () => {
+var error37 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "ter" },
     file: { unit: "bytes", verb: "ter" },
@@ -8497,6 +8904,129 @@ var init_pt = __esm(() => {
   init_util();
 });
 
+// node_modules/zod/v4/locales/ro.js
+function ro_default() {
+  return {
+    localeError: error38()
+  };
+}
+var error38 = () => {
+  const Sizable = {
+    string: { unit: "caractere", verb: "s\u0103 aib\u0103" },
+    file: { unit: "octe\u021Bi", verb: "s\u0103 aib\u0103" },
+    array: { unit: "elemente", verb: "s\u0103 aib\u0103" },
+    set: { unit: "elemente", verb: "s\u0103 aib\u0103" },
+    map: { unit: "intr\u0103ri", verb: "s\u0103 aib\u0103" }
+  };
+  function getSizing(origin) {
+    return Sizable[origin] ?? null;
+  }
+  const FormatDictionary = {
+    regex: "intrare",
+    email: "adres\u0103 de email",
+    url: "URL",
+    emoji: "emoji",
+    uuid: "UUID",
+    uuidv4: "UUIDv4",
+    uuidv6: "UUIDv6",
+    nanoid: "nanoid",
+    guid: "GUID",
+    cuid: "cuid",
+    cuid2: "cuid2",
+    ulid: "ULID",
+    xid: "XID",
+    ksuid: "KSUID",
+    datetime: "dat\u0103 \u0219i or\u0103 ISO",
+    date: "dat\u0103 ISO",
+    time: "or\u0103 ISO",
+    duration: "durat\u0103 ISO",
+    ipv4: "adres\u0103 IPv4",
+    ipv6: "adres\u0103 IPv6",
+    mac: "adres\u0103 MAC",
+    cidrv4: "interval IPv4",
+    cidrv6: "interval IPv6",
+    base64: "\u0219ir codat base64",
+    base64url: "\u0219ir codat base64url",
+    json_string: "\u0219ir JSON",
+    e164: "num\u0103r E.164",
+    jwt: "JWT",
+    template_literal: "intrare"
+  };
+  const TypeDictionary = {
+    nan: "NaN",
+    string: "\u0219ir",
+    number: "num\u0103r",
+    boolean: "boolean",
+    function: "func\u021Bie",
+    array: "matrice",
+    object: "obiect",
+    undefined: "nedefinit",
+    symbol: "simbol",
+    bigint: "num\u0103r mare",
+    void: "void",
+    never: "never",
+    map: "hart\u0103",
+    set: "set"
+  };
+  return (issue2) => {
+    switch (issue2.code) {
+      case "invalid_type": {
+        const expected = TypeDictionary[issue2.expected] ?? issue2.expected;
+        const receivedType = parsedType(issue2.input);
+        const received = TypeDictionary[receivedType] ?? receivedType;
+        return `Intrare invalid\u0103: a\u0219teptat ${expected}, primit ${received}`;
+      }
+      case "invalid_value":
+        if (issue2.values.length === 1)
+          return `Intrare invalid\u0103: a\u0219teptat ${stringifyPrimitive(issue2.values[0])}`;
+        return `Op\u021Biune invalid\u0103: a\u0219teptat una dintre ${joinValues(issue2.values, "|")}`;
+      case "too_big": {
+        const adj = issue2.inclusive ? "<=" : "<";
+        const sizing = getSizing(issue2.origin);
+        if (sizing)
+          return `Prea mare: a\u0219teptat ca ${issue2.origin ?? "valoarea"} ${sizing.verb} ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "elemente"}`;
+        return `Prea mare: a\u0219teptat ca ${issue2.origin ?? "valoarea"} s\u0103 fie ${adj}${issue2.maximum.toString()}`;
+      }
+      case "too_small": {
+        const adj = issue2.inclusive ? ">=" : ">";
+        const sizing = getSizing(issue2.origin);
+        if (sizing) {
+          return `Prea mic: a\u0219teptat ca ${issue2.origin} ${sizing.verb} ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
+        }
+        return `Prea mic: a\u0219teptat ca ${issue2.origin} s\u0103 fie ${adj}${issue2.minimum.toString()}`;
+      }
+      case "invalid_format": {
+        const _issue = issue2;
+        if (_issue.format === "starts_with") {
+          return `\u0218ir invalid: trebuie s\u0103 \xEEnceap\u0103 cu "${_issue.prefix}"`;
+        }
+        if (_issue.format === "ends_with")
+          return `\u0218ir invalid: trebuie s\u0103 se termine cu "${_issue.suffix}"`;
+        if (_issue.format === "includes")
+          return `\u0218ir invalid: trebuie s\u0103 includ\u0103 "${_issue.includes}"`;
+        if (_issue.format === "regex")
+          return `\u0218ir invalid: trebuie s\u0103 se potriveasc\u0103 cu modelul ${_issue.pattern}`;
+        return `Format invalid: ${FormatDictionary[_issue.format] ?? issue2.format}`;
+      }
+      case "not_multiple_of":
+        return `Num\u0103r invalid: trebuie s\u0103 fie multiplu de ${issue2.divisor}`;
+      case "unrecognized_keys":
+        return `Chei nerecunoscute: ${joinValues(issue2.keys, ", ")}`;
+      case "invalid_key":
+        return `Cheie invalid\u0103 \xEEn ${issue2.origin}`;
+      case "invalid_union":
+        return "Intrare invalid\u0103";
+      case "invalid_element":
+        return `Valoare invalid\u0103 \xEEn ${issue2.origin}`;
+      default:
+        return `Intrare invalid\u0103`;
+    }
+  };
+};
+var init_ro = __esm(() => {
+  init_util();
+});
+
 // node_modules/zod/v4/locales/ru.js
 function getRussianPlural(count, one, few, many) {
   const absCount = Math.abs(count);
@@ -8515,10 +9045,10 @@ function getRussianPlural(count, one, few, many) {
 }
 function ru_default() {
   return {
-    localeError: error36()
+    localeError: error39()
   };
 }
-var error36 = () => {
+var error39 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -8660,10 +9190,10 @@ var init_ru = __esm(() => {
 // node_modules/zod/v4/locales/sl.js
 function sl_default() {
   return {
-    localeError: error37()
+    localeError: error40()
   };
 }
-var error37 = () => {
+var error40 = () => {
   const Sizable = {
     string: { unit: "znakov", verb: "imeti" },
     file: { unit: "bajtov", verb: "imeti" },
@@ -8773,10 +9303,10 @@ var init_sl = __esm(() => {
 // node_modules/zod/v4/locales/sv.js
 function sv_default() {
   return {
-    localeError: error38()
+    localeError: error41()
   };
 }
-var error38 = () => {
+var error41 = () => {
   const Sizable = {
     string: { unit: "tecken", verb: "att ha" },
     file: { unit: "bytes", verb: "att ha" },
@@ -8887,10 +9417,10 @@ var init_sv = __esm(() => {
 // node_modules/zod/v4/locales/ta.js
 function ta_default() {
   return {
-    localeError: error39()
+    localeError: error42()
   };
 }
-var error39 = () => {
+var error42 = () => {
   const Sizable = {
     string: { unit: "\u0B8E\u0BB4\u0BC1\u0BA4\u0BCD\u0BA4\u0BC1\u0B95\u0BCD\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
     file: { unit: "\u0BAA\u0BC8\u0B9F\u0BCD\u0B9F\u0BC1\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
@@ -9001,10 +9531,10 @@ var init_ta = __esm(() => {
 // node_modules/zod/v4/locales/th.js
 function th_default() {
   return {
-    localeError: error40()
+    localeError: error43()
   };
 }
-var error40 = () => {
+var error43 = () => {
   const Sizable = {
     string: { unit: "\u0E15\u0E31\u0E27\u0E2D\u0E31\u0E01\u0E29\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
     file: { unit: "\u0E44\u0E1A\u0E15\u0E4C", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
@@ -9115,10 +9645,10 @@ var init_th = __esm(() => {
 // node_modules/zod/v4/locales/tr.js
 function tr_default() {
   return {
-    localeError: error41()
+    localeError: error44()
   };
 }
-var error41 = () => {
+var error44 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "olmal\u0131" },
     file: { unit: "bayt", verb: "olmal\u0131" },
@@ -9224,10 +9754,10 @@ var init_tr = __esm(() => {
 // node_modules/zod/v4/locales/uk.js
 function uk_default() {
   return {
-    localeError: error42()
+    localeError: error45()
   };
 }
-var error42 = () => {
+var error45 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
     file: { unit: "\u0431\u0430\u0439\u0442\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
@@ -9344,10 +9874,10 @@ var init_ua = __esm(() => {
 // node_modules/zod/v4/locales/ur.js
 function ur_default() {
   return {
-    localeError: error43()
+    localeError: error46()
   };
 }
-var error43 = () => {
+var error46 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0648\u0641", verb: "\u06C1\u0648\u0646\u0627" },
     file: { unit: "\u0628\u0627\u0626\u0679\u0633", verb: "\u06C1\u0648\u0646\u0627" },
@@ -9458,15 +9988,16 @@ var init_ur = __esm(() => {
 // node_modules/zod/v4/locales/uz.js
 function uz_default() {
   return {
-    localeError: error44()
+    localeError: error47()
   };
 }
-var error44 = () => {
+var error47 = () => {
   const Sizable = {
     string: { unit: "belgi", verb: "bo\u2018lishi kerak" },
     file: { unit: "bayt", verb: "bo\u2018lishi kerak" },
     array: { unit: "element", verb: "bo\u2018lishi kerak" },
-    set: { unit: "element", verb: "bo\u2018lishi kerak" }
+    set: { unit: "element", verb: "bo\u2018lishi kerak" },
+    map: { unit: "yozuv", verb: "bo\u2018lishi kerak" }
   };
   function getSizing(origin) {
     return Sizable[origin] ?? null;
@@ -9571,10 +10102,10 @@ var init_uz = __esm(() => {
 // node_modules/zod/v4/locales/vi.js
 function vi_default() {
   return {
-    localeError: error45()
+    localeError: error48()
   };
 }
-var error45 = () => {
+var error48 = () => {
   const Sizable = {
     string: { unit: "k\xFD t\u1EF1", verb: "c\xF3" },
     file: { unit: "byte", verb: "c\xF3" },
@@ -9683,10 +10214,10 @@ var init_vi = __esm(() => {
 // node_modules/zod/v4/locales/zh-CN.js
 function zh_CN_default() {
   return {
-    localeError: error46()
+    localeError: error49()
   };
 }
-var error46 = () => {
+var error49 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u7B26", verb: "\u5305\u542B" },
     file: { unit: "\u5B57\u8282", verb: "\u5305\u542B" },
@@ -9796,10 +10327,10 @@ var init_zh_CN = __esm(() => {
 // node_modules/zod/v4/locales/zh-TW.js
 function zh_TW_default() {
   return {
-    localeError: error47()
+    localeError: error50()
   };
 }
-var error47 = () => {
+var error50 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u5143", verb: "\u64C1\u6709" },
     file: { unit: "\u4F4D\u5143\u7D44", verb: "\u64C1\u6709" },
@@ -9907,10 +10438,10 @@ var init_zh_TW = __esm(() => {
 // node_modules/zod/v4/locales/yo.js
 function yo_default() {
   return {
-    localeError: error48()
+    localeError: error51()
   };
 }
-var error48 = () => {
+var error51 = () => {
   const Sizable = {
     string: { unit: "\xE0mi", verb: "n\xED" },
     file: { unit: "bytes", verb: "n\xED" },
@@ -10032,6 +10563,7 @@ __export(exports_locales, {
   sv: () => sv_default,
   sl: () => sl_default,
   ru: () => ru_default,
+  ro: () => ro_default,
   pt: () => pt_default,
   ps: () => ps_default,
   pl: () => pl_default,
@@ -10051,6 +10583,7 @@ __export(exports_locales, {
   id: () => id_default,
   hy: () => hy_default,
   hu: () => hu_default,
+  hr: () => hr_default,
   he: () => he_default,
   frCA: () => fr_CA_default,
   fr: () => fr_default,
@@ -10059,6 +10592,7 @@ __export(exports_locales, {
   es: () => es_default,
   eo: () => eo_default,
   en: () => en_default,
+  el: () => el_default,
   de: () => de_default,
   da: () => da_default,
   cs: () => cs_default,
@@ -10077,6 +10611,7 @@ var init_locales = __esm(() => {
   init_cs();
   init_da();
   init_de();
+  init_el();
   init_en();
   init_eo();
   init_es();
@@ -10085,6 +10620,7 @@ var init_locales = __esm(() => {
   init_fr();
   init_fr_CA();
   init_he();
+  init_hr();
   init_hu();
   init_hy();
   init_id();
@@ -10104,6 +10640,7 @@ var init_locales = __esm(() => {
   init_ps();
   init_pl();
   init_pt();
+  init_ro();
   init_ru();
   init_sl();
   init_sv();
@@ -10164,11 +10701,11 @@ class $ZodRegistry {
 function registry() {
   return new $ZodRegistry;
 }
-var _a, $output, $input, globalRegistry;
+var _a2, $output, $input, globalRegistry;
 var init_registries = __esm(() => {
   $output = Symbol("ZodOutput");
   $input = Symbol("ZodInput");
-  (_a = globalThis).__zod_globalRegistry ?? (_a.__zod_globalRegistry = registry());
+  (_a2 = globalThis).__zod_globalRegistry ?? (_a2.__zod_globalRegistry = registry());
   globalRegistry = globalThis.__zod_globalRegistry;
 });
 
@@ -10969,7 +11506,7 @@ function _refine(Class2, fn, _params) {
   });
   return schema;
 }
-function _superRefine(fn) {
+function _superRefine(fn, params) {
   const ch = _check((payload) => {
     payload.addIssue = (issue2) => {
       if (typeof issue2 === "string") {
@@ -10986,7 +11523,7 @@ function _superRefine(fn) {
       }
     };
     return fn(payload.value, payload);
-  });
+  }, params);
   return ch;
 }
 function _check(fn, params) {
@@ -11122,7 +11659,7 @@ function initializeContext(params) {
   };
 }
 function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
-  var _a2;
+  var _a3;
   const def = schema._zod.def;
   const seen = ctx.seen.get(schema);
   if (seen) {
@@ -11169,8 +11706,8 @@ function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
     delete result.schema.examples;
     delete result.schema.default;
   }
-  if (ctx.io === "input" && result.schema._prefault)
-    (_a2 = result.schema).default ?? (_a2.default = result.schema._prefault);
+  if (ctx.io === "input" && "_prefault" in result.schema)
+    (_a3 = result.schema).default ?? (_a3.default = result.schema._prefault);
   delete result.schema._prefault;
   const _result = ctx.seen.get(schema);
   return _result.schema;
@@ -11347,10 +11884,15 @@ function finalize(ctx, schema) {
     result.$id = ctx.external.uri(id);
   }
   Object.assign(result, root.def ?? root.schema);
+  const rootMetaId = ctx.metadataRegistry.get(schema)?.id;
+  if (rootMetaId !== undefined && result.id === rootMetaId)
+    delete result.id;
   const defs = ctx.external?.defs ?? {};
   for (const entry of ctx.seen.entries()) {
     const seen = entry[1];
     if (seen.def && seen.defId) {
+      if (seen.def.id === seen.defId)
+        delete seen.def.id;
       defs[seen.defId] = seen.def;
     }
   }
@@ -11405,6 +11947,8 @@ function isTransforming(_schema, _ctx) {
     return isTransforming(def.keyType, ctx) || isTransforming(def.valueType, ctx);
   }
   if (def.type === "pipe") {
+    if (_schema._zod.traits.has("$ZodCodec"))
+      return true;
     return isTransforming(def.in, ctx) || isTransforming(def.out, ctx);
   }
   if (def.type === "object") {
@@ -11521,39 +12065,28 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
     json.type = "integer";
   else
     json.type = "number";
-  if (typeof exclusiveMinimum === "number") {
-    if (ctx.target === "draft-04" || ctx.target === "openapi-3.0") {
+  const exMin = typeof exclusiveMinimum === "number" && exclusiveMinimum >= (minimum ?? Number.NEGATIVE_INFINITY);
+  const exMax = typeof exclusiveMaximum === "number" && exclusiveMaximum <= (maximum ?? Number.POSITIVE_INFINITY);
+  const legacy = ctx.target === "draft-04" || ctx.target === "openapi-3.0";
+  if (exMin) {
+    if (legacy) {
       json.minimum = exclusiveMinimum;
       json.exclusiveMinimum = true;
     } else {
       json.exclusiveMinimum = exclusiveMinimum;
     }
-  }
-  if (typeof minimum === "number") {
+  } else if (typeof minimum === "number") {
     json.minimum = minimum;
-    if (typeof exclusiveMinimum === "number" && ctx.target !== "draft-04") {
-      if (exclusiveMinimum >= minimum)
-        delete json.minimum;
-      else
-        delete json.exclusiveMinimum;
-    }
   }
-  if (typeof exclusiveMaximum === "number") {
-    if (ctx.target === "draft-04" || ctx.target === "openapi-3.0") {
+  if (exMax) {
+    if (legacy) {
       json.maximum = exclusiveMaximum;
       json.exclusiveMaximum = true;
     } else {
       json.exclusiveMaximum = exclusiveMaximum;
     }
-  }
-  if (typeof maximum === "number") {
+  } else if (typeof maximum === "number") {
     json.maximum = maximum;
-    if (typeof exclusiveMaximum === "number" && ctx.target !== "draft-04") {
-      if (exclusiveMaximum <= maximum)
-        delete json.maximum;
-      else
-        delete json.exclusiveMaximum;
-    }
   }
   if (typeof multipleOf === "number")
     json.multipleOf = multipleOf;
@@ -11699,7 +12232,10 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
   if (typeof maximum === "number")
     json.maxItems = maximum;
   json.type = "array";
-  json.items = process2(def.element, ctx, { ...params, path: [...params.path, "items"] });
+  json.items = process2(def.element, ctx, {
+    ...params,
+    path: [...params.path, "items"]
+  });
 }, objectProcessor = (schema, ctx, _json, params) => {
   const json = _json;
   const def = schema._zod.def;
@@ -11881,7 +12417,8 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
   json.default = catchValue;
 }, pipeProcessor = (schema, ctx, _json, params) => {
   const def = schema._zod.def;
-  const innerType = ctx.io === "input" ? def.in._zod.def.type === "transform" ? def.out : def.in : def.out;
+  const inIsTransform = def.in._zod.traits.has("$ZodTransform");
+  const innerType = ctx.io === "input" ? inIsTransform ? def.out : def.in : def.out;
   process2(innerType, ctx, params);
   const seen = ctx.seen.get(schema);
   seen.ref = innerType;
@@ -12227,6 +12764,7 @@ __export(exports_core2, {
   $ZodRealError: () => $ZodRealError,
   $ZodReadonly: () => $ZodReadonly,
   $ZodPromise: () => $ZodPromise,
+  $ZodPreprocess: () => $ZodPreprocess,
   $ZodPrefault: () => $ZodPrefault,
   $ZodPipe: () => $ZodPipe,
   $ZodOptional: () => $ZodOptional,
@@ -12440,8 +12978,8 @@ var init_errors3 = __esm(() => {
   init_core2();
   init_core2();
   init_util();
-  ZodError = $constructor("ZodError", initializer2);
-  ZodRealError = $constructor("ZodError", initializer2, {
+  ZodError = /* @__PURE__ */ $constructor("ZodError", initializer2);
+  ZodRealError = /* @__PURE__ */ $constructor("ZodError", initializer2, {
     Parent: Error
   });
 });
@@ -12525,6 +13063,7 @@ __export(exports_schemas2, {
   json: () => json,
   ipv6: () => ipv62,
   ipv4: () => ipv42,
+  invertCodec: () => invertCodec,
   intersection: () => intersection,
   int64: () => int64,
   int32: () => int32,
@@ -12585,6 +13124,7 @@ __export(exports_schemas2, {
   ZodRecord: () => ZodRecord,
   ZodReadonly: () => ZodReadonly,
   ZodPromise: () => ZodPromise,
+  ZodPreprocess: () => ZodPreprocess,
   ZodPrefault: () => ZodPrefault,
   ZodPipe: () => ZodPipe,
   ZodOptional: () => ZodOptional,
@@ -12633,6 +13173,42 @@ __export(exports_schemas2, {
   ZodArray: () => ZodArray,
   ZodAny: () => ZodAny
 });
+function _installLazyMethods(inst, group, methods) {
+  const proto = Object.getPrototypeOf(inst);
+  let installed = _installedGroups.get(proto);
+  if (!installed) {
+    installed = new Set;
+    _installedGroups.set(proto, installed);
+  }
+  if (installed.has(group))
+    return;
+  installed.add(group);
+  for (const key in methods) {
+    const fn = methods[key];
+    Object.defineProperty(proto, key, {
+      configurable: true,
+      enumerable: false,
+      get() {
+        const bound = fn.bind(this);
+        Object.defineProperty(this, key, {
+          configurable: true,
+          writable: true,
+          enumerable: true,
+          value: bound
+        });
+        return bound;
+      },
+      set(v) {
+        Object.defineProperty(this, key, {
+          configurable: true,
+          writable: true,
+          enumerable: true,
+          value: v
+        });
+      }
+    });
+  }
+}
 function string2(params) {
   return _string(ZodString, params);
 }
@@ -12659,7 +13235,7 @@ function url(params) {
 }
 function httpUrl(params) {
   return _url(ZodURL, {
-    protocol: /^https?$/,
+    protocol: exports_regexes.httpProtocol,
     hostname: exports_regexes.domain,
     ...exports_util.normalizeParams(params)
   });
@@ -12856,6 +13432,14 @@ function tuple(items, _paramsOrRest, _params) {
   });
 }
 function record(keyType, valueType, params) {
+  if (!valueType || !valueType._zod) {
+    return new ZodRecord({
+      type: "record",
+      keyType: string2(),
+      valueType: keyType,
+      ...exports_util.normalizeParams(valueType)
+    });
+  }
   return new ZodRecord({
     type: "record",
     keyType,
@@ -13006,6 +13590,16 @@ function codec(in_, out, params) {
     reverseTransform: params.encode
   });
 }
+function invertCodec(codec2) {
+  const def = codec2._zod.def;
+  return new ZodCodec({
+    type: "pipe",
+    in: def.out,
+    out: def.in,
+    transform: def.reverseTransform,
+    reverseTransform: def.transform
+  });
+}
 function readonly(innerType) {
   return new ZodReadonly({
     type: "readonly",
@@ -13051,8 +13645,8 @@ function custom(fn, _params) {
 function refine(fn, _params = {}) {
   return _refine(ZodCustom, fn, _params);
 }
-function superRefine(fn) {
-  return _superRefine(fn);
+function superRefine(fn, params) {
+  return _superRefine(fn, params);
 }
 function _instanceof(cls, params = {}) {
   const inst = new ZodCustom({
@@ -13083,9 +13677,13 @@ function json(params) {
   return jsonSchema;
 }
 function preprocess(fn, schema) {
-  return pipe(transform(fn), schema);
+  return new ZodPreprocess({
+    type: "pipe",
+    in: transform(fn),
+    out: schema
+  });
 }
-var ZodType, _ZodString, ZodString, ZodStringFormat, ZodEmail, ZodGUID, ZodUUID, ZodURL, ZodEmoji, ZodNanoID, ZodCUID, ZodCUID2, ZodULID, ZodXID, ZodKSUID, ZodIPv4, ZodMAC, ZodIPv6, ZodCIDRv4, ZodCIDRv6, ZodBase64, ZodBase64URL, ZodE164, ZodJWT, ZodCustomStringFormat, ZodNumber, ZodNumberFormat, ZodBoolean, ZodBigInt, ZodBigIntFormat, ZodSymbol, ZodUndefined, ZodNull, ZodAny, ZodUnknown, ZodNever, ZodVoid, ZodDate, ZodArray, ZodObject, ZodUnion, ZodXor, ZodDiscriminatedUnion, ZodIntersection, ZodTuple, ZodRecord, ZodMap, ZodSet, ZodEnum, ZodLiteral, ZodFile, ZodTransform, ZodOptional, ZodExactOptional, ZodNullable, ZodDefault, ZodPrefault, ZodNonOptional, ZodSuccess, ZodCatch, ZodNaN, ZodPipe, ZodCodec, ZodReadonly, ZodTemplateLiteral, ZodLazy, ZodPromise, ZodFunction, ZodCustom, describe2, meta2, stringbool = (...args) => _stringbool({
+var _installedGroups, ZodType, _ZodString, ZodString, ZodStringFormat, ZodEmail, ZodGUID, ZodUUID, ZodURL, ZodEmoji, ZodNanoID, ZodCUID, ZodCUID2, ZodULID, ZodXID, ZodKSUID, ZodIPv4, ZodMAC, ZodIPv6, ZodCIDRv4, ZodCIDRv6, ZodBase64, ZodBase64URL, ZodE164, ZodJWT, ZodCustomStringFormat, ZodNumber, ZodNumberFormat, ZodBoolean, ZodBigInt, ZodBigIntFormat, ZodSymbol, ZodUndefined, ZodNull, ZodAny, ZodUnknown, ZodNever, ZodVoid, ZodDate, ZodArray, ZodObject, ZodUnion, ZodXor, ZodDiscriminatedUnion, ZodIntersection, ZodTuple, ZodRecord, ZodMap, ZodSet, ZodEnum, ZodLiteral, ZodFile, ZodTransform, ZodOptional, ZodExactOptional, ZodNullable, ZodDefault, ZodPrefault, ZodNonOptional, ZodSuccess, ZodCatch, ZodNaN, ZodPipe, ZodCodec, ZodPreprocess, ZodReadonly, ZodTemplateLiteral, ZodLazy, ZodPromise, ZodFunction, ZodCustom, describe2, meta2, stringbool = (...args) => _stringbool({
   Codec: ZodCodec,
   Boolean: ZodBoolean,
   String: ZodString
@@ -13098,6 +13696,7 @@ var init_schemas2 = __esm(() => {
   init_checks2();
   init_iso();
   init_parse2();
+  _installedGroups = /* @__PURE__ */ new WeakMap;
   ZodType = /* @__PURE__ */ $constructor("ZodType", (inst, def) => {
     $ZodType.init(inst, def);
     Object.assign(inst["~standard"], {
@@ -13110,23 +13709,6 @@ var init_schemas2 = __esm(() => {
     inst.def = def;
     inst.type = def.type;
     Object.defineProperty(inst, "_def", { value: def });
-    inst.check = (...checks2) => {
-      return inst.clone(exports_util.mergeDefs(def, {
-        checks: [
-          ...def.checks ?? [],
-          ...checks2.map((ch) => typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch)
-        ]
-      }), {
-        parent: true
-      });
-    };
-    inst.with = inst.check;
-    inst.clone = (def2, params) => clone(inst, def2, params);
-    inst.brand = () => inst;
-    inst.register = (reg, meta2) => {
-      reg.add(inst, meta2);
-      return inst;
-    };
     inst.parse = (data, params) => parse3(inst, data, params, { callee: inst.parse });
     inst.safeParse = (data, params) => safeParse2(inst, data, params);
     inst.parseAsync = async (data, params) => parseAsync2(inst, data, params, { callee: inst.parseAsync });
@@ -13140,45 +13722,108 @@ var init_schemas2 = __esm(() => {
     inst.safeDecode = (data, params) => safeDecode2(inst, data, params);
     inst.safeEncodeAsync = async (data, params) => safeEncodeAsync2(inst, data, params);
     inst.safeDecodeAsync = async (data, params) => safeDecodeAsync2(inst, data, params);
-    inst.refine = (check, params) => inst.check(refine(check, params));
-    inst.superRefine = (refinement) => inst.check(superRefine(refinement));
-    inst.overwrite = (fn) => inst.check(_overwrite(fn));
-    inst.optional = () => optional(inst);
-    inst.exactOptional = () => exactOptional(inst);
-    inst.nullable = () => nullable(inst);
-    inst.nullish = () => optional(nullable(inst));
-    inst.nonoptional = (params) => nonoptional(inst, params);
-    inst.array = () => array(inst);
-    inst.or = (arg) => union([inst, arg]);
-    inst.and = (arg) => intersection(inst, arg);
-    inst.transform = (tx) => pipe(inst, transform(tx));
-    inst.default = (def2) => _default2(inst, def2);
-    inst.prefault = (def2) => prefault(inst, def2);
-    inst.catch = (params) => _catch2(inst, params);
-    inst.pipe = (target) => pipe(inst, target);
-    inst.readonly = () => readonly(inst);
-    inst.describe = (description) => {
-      const cl = inst.clone();
-      globalRegistry.add(cl, { description });
-      return cl;
-    };
+    _installLazyMethods(inst, "ZodType", {
+      check(...chks) {
+        const def2 = this.def;
+        return this.clone(exports_util.mergeDefs(def2, {
+          checks: [
+            ...def2.checks ?? [],
+            ...chks.map((ch) => typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch)
+          ]
+        }), { parent: true });
+      },
+      with(...chks) {
+        return this.check(...chks);
+      },
+      clone(def2, params) {
+        return clone(this, def2, params);
+      },
+      brand() {
+        return this;
+      },
+      register(reg, meta2) {
+        reg.add(this, meta2);
+        return this;
+      },
+      refine(check, params) {
+        return this.check(refine(check, params));
+      },
+      superRefine(refinement, params) {
+        return this.check(superRefine(refinement, params));
+      },
+      overwrite(fn) {
+        return this.check(_overwrite(fn));
+      },
+      optional() {
+        return optional(this);
+      },
+      exactOptional() {
+        return exactOptional(this);
+      },
+      nullable() {
+        return nullable(this);
+      },
+      nullish() {
+        return optional(nullable(this));
+      },
+      nonoptional(params) {
+        return nonoptional(this, params);
+      },
+      array() {
+        return array(this);
+      },
+      or(arg) {
+        return union([this, arg]);
+      },
+      and(arg) {
+        return intersection(this, arg);
+      },
+      transform(tx) {
+        return pipe(this, transform(tx));
+      },
+      default(d) {
+        return _default2(this, d);
+      },
+      prefault(d) {
+        return prefault(this, d);
+      },
+      catch(params) {
+        return _catch2(this, params);
+      },
+      pipe(target) {
+        return pipe(this, target);
+      },
+      readonly() {
+        return readonly(this);
+      },
+      describe(description) {
+        const cl = this.clone();
+        globalRegistry.add(cl, { description });
+        return cl;
+      },
+      meta(...args) {
+        if (args.length === 0)
+          return globalRegistry.get(this);
+        const cl = this.clone();
+        globalRegistry.add(cl, args[0]);
+        return cl;
+      },
+      isOptional() {
+        return this.safeParse(undefined).success;
+      },
+      isNullable() {
+        return this.safeParse(null).success;
+      },
+      apply(fn) {
+        return fn(this);
+      }
+    });
     Object.defineProperty(inst, "description", {
       get() {
         return globalRegistry.get(inst)?.description;
       },
       configurable: true
     });
-    inst.meta = (...args) => {
-      if (args.length === 0) {
-        return globalRegistry.get(inst);
-      }
-      const cl = inst.clone();
-      globalRegistry.add(cl, args[0]);
-      return cl;
-    };
-    inst.isOptional = () => inst.safeParse(undefined).success;
-    inst.isNullable = () => inst.safeParse(null).success;
-    inst.apply = (fn) => fn(inst);
     return inst;
   });
   _ZodString = /* @__PURE__ */ $constructor("_ZodString", (inst, def) => {
@@ -13189,21 +13834,53 @@ var init_schemas2 = __esm(() => {
     inst.format = bag.format ?? null;
     inst.minLength = bag.minimum ?? null;
     inst.maxLength = bag.maximum ?? null;
-    inst.regex = (...args) => inst.check(_regex(...args));
-    inst.includes = (...args) => inst.check(_includes(...args));
-    inst.startsWith = (...args) => inst.check(_startsWith(...args));
-    inst.endsWith = (...args) => inst.check(_endsWith(...args));
-    inst.min = (...args) => inst.check(_minLength(...args));
-    inst.max = (...args) => inst.check(_maxLength(...args));
-    inst.length = (...args) => inst.check(_length(...args));
-    inst.nonempty = (...args) => inst.check(_minLength(1, ...args));
-    inst.lowercase = (params) => inst.check(_lowercase(params));
-    inst.uppercase = (params) => inst.check(_uppercase(params));
-    inst.trim = () => inst.check(_trim());
-    inst.normalize = (...args) => inst.check(_normalize(...args));
-    inst.toLowerCase = () => inst.check(_toLowerCase());
-    inst.toUpperCase = () => inst.check(_toUpperCase());
-    inst.slugify = () => inst.check(_slugify());
+    _installLazyMethods(inst, "_ZodString", {
+      regex(...args) {
+        return this.check(_regex(...args));
+      },
+      includes(...args) {
+        return this.check(_includes(...args));
+      },
+      startsWith(...args) {
+        return this.check(_startsWith(...args));
+      },
+      endsWith(...args) {
+        return this.check(_endsWith(...args));
+      },
+      min(...args) {
+        return this.check(_minLength(...args));
+      },
+      max(...args) {
+        return this.check(_maxLength(...args));
+      },
+      length(...args) {
+        return this.check(_length(...args));
+      },
+      nonempty(...args) {
+        return this.check(_minLength(1, ...args));
+      },
+      lowercase(params) {
+        return this.check(_lowercase(params));
+      },
+      uppercase(params) {
+        return this.check(_uppercase(params));
+      },
+      trim() {
+        return this.check(_trim());
+      },
+      normalize(...args) {
+        return this.check(_normalize(...args));
+      },
+      toLowerCase() {
+        return this.check(_toLowerCase());
+      },
+      toUpperCase() {
+        return this.check(_toUpperCase());
+      },
+      slugify() {
+        return this.check(_slugify());
+      }
+    });
   });
   ZodString = /* @__PURE__ */ $constructor("ZodString", (inst, def) => {
     $ZodString.init(inst, def);
@@ -13328,21 +14005,53 @@ var init_schemas2 = __esm(() => {
     $ZodNumber.init(inst, def);
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => numberProcessor(inst, ctx, json, params);
-    inst.gt = (value, params) => inst.check(_gt(value, params));
-    inst.gte = (value, params) => inst.check(_gte(value, params));
-    inst.min = (value, params) => inst.check(_gte(value, params));
-    inst.lt = (value, params) => inst.check(_lt(value, params));
-    inst.lte = (value, params) => inst.check(_lte(value, params));
-    inst.max = (value, params) => inst.check(_lte(value, params));
-    inst.int = (params) => inst.check(int(params));
-    inst.safe = (params) => inst.check(int(params));
-    inst.positive = (params) => inst.check(_gt(0, params));
-    inst.nonnegative = (params) => inst.check(_gte(0, params));
-    inst.negative = (params) => inst.check(_lt(0, params));
-    inst.nonpositive = (params) => inst.check(_lte(0, params));
-    inst.multipleOf = (value, params) => inst.check(_multipleOf(value, params));
-    inst.step = (value, params) => inst.check(_multipleOf(value, params));
-    inst.finite = () => inst;
+    _installLazyMethods(inst, "ZodNumber", {
+      gt(value, params) {
+        return this.check(_gt(value, params));
+      },
+      gte(value, params) {
+        return this.check(_gte(value, params));
+      },
+      min(value, params) {
+        return this.check(_gte(value, params));
+      },
+      lt(value, params) {
+        return this.check(_lt(value, params));
+      },
+      lte(value, params) {
+        return this.check(_lte(value, params));
+      },
+      max(value, params) {
+        return this.check(_lte(value, params));
+      },
+      int(params) {
+        return this.check(int(params));
+      },
+      safe(params) {
+        return this.check(int(params));
+      },
+      positive(params) {
+        return this.check(_gt(0, params));
+      },
+      nonnegative(params) {
+        return this.check(_gte(0, params));
+      },
+      negative(params) {
+        return this.check(_lt(0, params));
+      },
+      nonpositive(params) {
+        return this.check(_lte(0, params));
+      },
+      multipleOf(value, params) {
+        return this.check(_multipleOf(value, params));
+      },
+      step(value, params) {
+        return this.check(_multipleOf(value, params));
+      },
+      finite() {
+        return this;
+      }
+    });
     const bag = inst._zod.bag;
     inst.minValue = Math.max(bag.minimum ?? Number.NEGATIVE_INFINITY, bag.exclusiveMinimum ?? Number.NEGATIVE_INFINITY) ?? null;
     inst.maxValue = Math.min(bag.maximum ?? Number.POSITIVE_INFINITY, bag.exclusiveMaximum ?? Number.POSITIVE_INFINITY) ?? null;
@@ -13435,11 +14144,23 @@ var init_schemas2 = __esm(() => {
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => arrayProcessor(inst, ctx, json, params);
     inst.element = def.element;
-    inst.min = (minLength, params) => inst.check(_minLength(minLength, params));
-    inst.nonempty = (params) => inst.check(_minLength(1, params));
-    inst.max = (maxLength, params) => inst.check(_maxLength(maxLength, params));
-    inst.length = (len, params) => inst.check(_length(len, params));
-    inst.unwrap = () => inst.element;
+    _installLazyMethods(inst, "ZodArray", {
+      min(n, params) {
+        return this.check(_minLength(n, params));
+      },
+      nonempty(params) {
+        return this.check(_minLength(1, params));
+      },
+      max(n, params) {
+        return this.check(_maxLength(n, params));
+      },
+      length(n, params) {
+        return this.check(_length(n, params));
+      },
+      unwrap() {
+        return this.element;
+      }
+    });
   });
   ZodObject = /* @__PURE__ */ $constructor("ZodObject", (inst, def) => {
     $ZodObjectJIT.init(inst, def);
@@ -13448,23 +14169,47 @@ var init_schemas2 = __esm(() => {
     exports_util.defineLazy(inst, "shape", () => {
       return def.shape;
     });
-    inst.keyof = () => _enum2(Object.keys(inst._zod.def.shape));
-    inst.catchall = (catchall) => inst.clone({ ...inst._zod.def, catchall });
-    inst.passthrough = () => inst.clone({ ...inst._zod.def, catchall: unknown() });
-    inst.loose = () => inst.clone({ ...inst._zod.def, catchall: unknown() });
-    inst.strict = () => inst.clone({ ...inst._zod.def, catchall: never() });
-    inst.strip = () => inst.clone({ ...inst._zod.def, catchall: undefined });
-    inst.extend = (incoming) => {
-      return exports_util.extend(inst, incoming);
-    };
-    inst.safeExtend = (incoming) => {
-      return exports_util.safeExtend(inst, incoming);
-    };
-    inst.merge = (other) => exports_util.merge(inst, other);
-    inst.pick = (mask) => exports_util.pick(inst, mask);
-    inst.omit = (mask) => exports_util.omit(inst, mask);
-    inst.partial = (...args) => exports_util.partial(ZodOptional, inst, args[0]);
-    inst.required = (...args) => exports_util.required(ZodNonOptional, inst, args[0]);
+    _installLazyMethods(inst, "ZodObject", {
+      keyof() {
+        return _enum2(Object.keys(this._zod.def.shape));
+      },
+      catchall(catchall) {
+        return this.clone({ ...this._zod.def, catchall });
+      },
+      passthrough() {
+        return this.clone({ ...this._zod.def, catchall: unknown() });
+      },
+      loose() {
+        return this.clone({ ...this._zod.def, catchall: unknown() });
+      },
+      strict() {
+        return this.clone({ ...this._zod.def, catchall: never() });
+      },
+      strip() {
+        return this.clone({ ...this._zod.def, catchall: undefined });
+      },
+      extend(incoming) {
+        return exports_util.extend(this, incoming);
+      },
+      safeExtend(incoming) {
+        return exports_util.safeExtend(this, incoming);
+      },
+      merge(other) {
+        return exports_util.merge(this, other);
+      },
+      pick(mask) {
+        return exports_util.pick(this, mask);
+      },
+      omit(mask) {
+        return exports_util.omit(this, mask);
+      },
+      partial(...args) {
+        return exports_util.partial(ZodOptional, this, args[0]);
+      },
+      required(...args) {
+        return exports_util.required(ZodNonOptional, this, args[0]);
+      }
+    });
   });
   ZodUnion = /* @__PURE__ */ $constructor("ZodUnion", (inst, def) => {
     $ZodUnion.init(inst, def);
@@ -13608,10 +14353,12 @@ var init_schemas2 = __esm(() => {
       if (output instanceof Promise) {
         return output.then((output2) => {
           payload.value = output2;
+          payload.fallback = true;
           return payload;
         });
       }
       payload.value = output;
+      payload.fallback = true;
       return payload;
     };
   });
@@ -13680,6 +14427,10 @@ var init_schemas2 = __esm(() => {
   ZodCodec = /* @__PURE__ */ $constructor("ZodCodec", (inst, def) => {
     ZodPipe.init(inst, def);
     $ZodCodec.init(inst, def);
+  });
+  ZodPreprocess = /* @__PURE__ */ $constructor("ZodPreprocess", (inst, def) => {
+    ZodPipe.init(inst, def);
+    $ZodPreprocess.init(inst, def);
   });
   ZodReadonly = /* @__PURE__ */ $constructor("ZodReadonly", (inst, def) => {
     $ZodReadonly.init(inst, def);
@@ -14062,12 +14813,6 @@ function convertBaseSchema(schema, ctx) {
     default:
       throw new Error(`Unsupported type: ${type}`);
   }
-  if (schema.description) {
-    zodSchema = zodSchema.describe(schema.description);
-  }
-  if (schema.default !== undefined) {
-    zodSchema = zodSchema.default(schema.default);
-  }
   return zodSchema;
 }
 function convertSchema(schema, ctx) {
@@ -14104,6 +14849,9 @@ function convertSchema(schema, ctx) {
   if (schema.readOnly === true) {
     baseSchema = z.readonly(baseSchema);
   }
+  if (schema.default !== undefined) {
+    baseSchema = baseSchema.default(schema.default);
+  }
   const extraMeta = {};
   const coreMetadataKeys = ["$id", "id", "$comment", "$anchor", "$vocabulary", "$dynamicRef", "$dynamicAnchor"];
   for (const key of coreMetadataKeys) {
@@ -14125,23 +14873,32 @@ function convertSchema(schema, ctx) {
   if (Object.keys(extraMeta).length > 0) {
     ctx.registry.add(baseSchema, extraMeta);
   }
+  if (schema.description) {
+    baseSchema = baseSchema.describe(schema.description);
+  }
   return baseSchema;
 }
 function fromJSONSchema(schema, params) {
   if (typeof schema === "boolean") {
     return schema ? z.any() : z.never();
   }
-  const version2 = detectVersion(schema, params?.defaultTarget);
-  const defs = schema.$defs || schema.definitions || {};
+  let normalized;
+  try {
+    normalized = JSON.parse(JSON.stringify(schema));
+  } catch {
+    throw new Error("fromJSONSchema input is not valid JSON (possibly cyclic); use $defs/$ref for recursive schemas");
+  }
+  const version2 = detectVersion(normalized, params?.defaultTarget);
+  const defs = normalized.$defs || normalized.definitions || {};
   const ctx = {
     version: version2,
     defs,
     refs: new Map,
     processing: new Set,
-    rootSchema: schema,
+    rootSchema: normalized,
     registry: params?.registry ?? globalRegistry
   };
-  return convertSchema(schema, ctx);
+  return convertSchema(normalized, ctx);
 }
 var z, RECOGNIZED_KEYS;
 var init_from_json_schema = __esm(() => {
@@ -14154,7 +14911,7 @@ var init_from_json_schema = __esm(() => {
     ...exports_checks2,
     iso: exports_iso
   };
-  RECOGNIZED_KEYS = new Set([
+  RECOGNIZED_KEYS = /* @__PURE__ */ new Set([
     "$schema",
     "$ref",
     "$defs",
@@ -14346,6 +15103,7 @@ __export(exports_external, {
   iso: () => exports_iso,
   ipv6: () => ipv62,
   ipv4: () => ipv42,
+  invertCodec: () => invertCodec,
   intersection: () => intersection,
   int64: () => int64,
   int32: () => int32,
@@ -14424,6 +15182,7 @@ __export(exports_external, {
   ZodRealError: () => ZodRealError,
   ZodReadonly: () => ZodReadonly,
   ZodPromise: () => ZodPromise,
+  ZodPreprocess: () => ZodPreprocess,
   ZodPrefault: () => ZodPrefault,
   ZodPipe: () => ZodPipe,
   ZodOptional: () => ZodOptional,
@@ -14613,9 +15372,9 @@ async function computeSpecHash(directory) {
   try {
     const content = await readFile2(specPath, "utf-8");
     hash2 = createHash("sha256").update(content, "utf-8").digest("hex");
-  } catch (error49) {
-    if (error49.code !== "ENOENT") {
-      throw error49;
+  } catch (error52) {
+    if (error52.code !== "ENOENT") {
+      throw error52;
     }
   }
   return hash2;
@@ -15094,9 +15853,9 @@ async function retryCasWithBackoff(directory, eventInput, options) {
         expectedHash: currentExpected,
         planHashAfter: options.planHashAfter
       });
-    } catch (error49) {
-      if (!(error49 instanceof LedgerStaleWriterError) || attempt >= maxRetries) {
-        throw error49;
+    } catch (error52) {
+      if (!(error52 instanceof LedgerStaleWriterError) || attempt >= maxRetries) {
+        throw error52;
       }
       attempt++;
       const base = Math.min(CAS_BACKOFF_START_MS * 2 ** (attempt - 1), CAS_BACKOFF_CAP_MS);
@@ -15128,8 +15887,8 @@ async function loadPlanJsonOnly(directory) {
       const parsed = JSON.parse(planJsonContent);
       const validated = PlanSchema.parse(parsed);
       return validated;
-    } catch (error49) {
-      warn(`Plan validation failed for .swarm/plan.json: ${error49 instanceof Error ? error49.message : String(error49)}`);
+    } catch (error52) {
+      warn(`Plan validation failed for .swarm/plan.json: ${error52 instanceof Error ? error52.message : String(error52)}`);
     }
   }
   return null;
@@ -15326,8 +16085,8 @@ async function loadPlan(directory) {
           }
         }
         return validated;
-      } catch (error49) {
-        warn(`[loadPlan] plan.json validation failed: ${error49 instanceof Error ? error49.message : String(error49)}. Attempting rebuild from ledger. If rebuild fails, check .swarm/SWARM_PLAN.md for a checkpoint.`);
+      } catch (error52) {
+        warn(`[loadPlan] plan.json validation failed: ${error52 instanceof Error ? error52.message : String(error52)}. Attempting rebuild from ledger. If rebuild fails, check .swarm/SWARM_PLAN.md for a checkpoint.`);
         let rawPlanId = null;
         try {
           const rawParsed = JSON.parse(planJsonContent);
@@ -15653,11 +16412,11 @@ async function savePlan(directory, plan, options) {
             }
           });
         }
-      } catch (error49) {
-        if (error49 instanceof LedgerStaleWriterError) {
-          throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error49.message}. Please retry the operation.`);
+      } catch (error52) {
+        if (error52 instanceof LedgerStaleWriterError) {
+          throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error52.message}. Please retry the operation.`);
         }
-        throw error49;
+        throw error52;
       }
     }
     try {
@@ -15695,11 +16454,11 @@ async function savePlan(directory, plan, options) {
           }
         }
       }
-    } catch (error49) {
-      if (error49 instanceof LedgerStaleWriterError) {
-        throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error49.message}. Please retry the operation.`);
+    } catch (error52) {
+      if (error52 instanceof LedgerStaleWriterError) {
+        throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error52.message}. Please retry the operation.`);
       }
-      throw error49;
+      throw error52;
     }
   }
   const SNAPSHOT_INTERVAL = 50;
@@ -16100,11 +16859,11 @@ async function handleAcknowledgeSpecDriftCommand(directory, _args, acknowledgedB
   let stalenessContent;
   try {
     stalenessContent = await fsPromises3.readFile(specStalenessPath, "utf-8");
-  } catch (error49) {
-    if (error49?.code === "ENOENT") {
+  } catch (error52) {
+    if (error52?.code === "ENOENT") {
       return "No spec drift detected.";
     }
-    throw error49;
+    throw error52;
   }
   let stalenessData;
   try {
@@ -17344,8 +18103,12 @@ var init_schema = __esm(() => {
   });
   MemoryConfigSchema = exports_external.object({
     enabled: exports_external.boolean().default(false),
-    provider: exports_external.literal("local-jsonl").default("local-jsonl"),
+    provider: exports_external.enum(["local-jsonl", "sqlite"]).default("local-jsonl"),
     storageDir: exports_external.string().default(".swarm/memory"),
+    sqlite: exports_external.object({
+      path: exports_external.string().default(".swarm/memory/memory.db"),
+      busyTimeoutMs: exports_external.number().int().min(0).max(60000).default(5000)
+    }).default({ path: ".swarm/memory/memory.db", busyTimeoutMs: 5000 }),
     recall: exports_external.object({
       defaultMaxItems: exports_external.number().int().min(1).max(20).default(8),
       defaultTokenBudget: exports_external.number().int().min(100).max(5000).default(1200),
@@ -17869,10 +18632,10 @@ function loadRawConfigFromPath(configPath) {
       fileExisted: true,
       hadError: false
     };
-  } catch (error49) {
-    const isFileNotFoundError = error49 instanceof Error && "code" in error49 && error49.code === "ENOENT";
+  } catch (error52) {
+    const isFileNotFoundError = error52 instanceof Error && "code" in error52 && error52.code === "ENOENT";
     if (!isFileNotFoundError) {
-      const errorMessage = error49 instanceof Error ? error49.message : String(error49);
+      const errorMessage = error52 instanceof Error ? error52.message : String(error52);
       console.warn(`[opencode-swarm] \u26A0\uFE0F CONFIG LOAD FAILURE \u2014 config exists at ${configPath} but could not be loaded: ${errorMessage}`);
       console.warn("[opencode-swarm] \u26A0\uFE0F SECURITY: Config load failed. Falling back to safe defaults with guardrails ENABLED.");
       return { config: null, fileExisted: true, hadError: true };
@@ -18400,7 +19163,7 @@ var require_polyfills = __commonJS((exports, module) => {
           return ret;
         };
       } else if (fs4.futimes) {
-        fs4.lutimes = function(_a2, _b, _c, cb) {
+        fs4.lutimes = function(_a3, _b, _c, cb) {
           if (cb)
             process.nextTick(cb);
         };
@@ -19096,12 +19859,12 @@ var require_retry_operation = __commonJS((exports, module) => {
     var mainError = null;
     var mainErrorCount = 0;
     for (var i = 0;i < this._errors.length; i++) {
-      var error49 = this._errors[i];
-      var message = error49.message;
+      var error52 = this._errors[i];
+      var message = error52.message;
       var count = (counts[message] || 0) + 1;
       counts[message] = count;
       if (count >= mainErrorCount) {
-        mainError = error49;
+        mainError = error52;
         mainErrorCount = count;
       }
     }
@@ -19940,8 +20703,8 @@ function validateProjectRoot(directory) {
               hasProjectIndicator = true;
               break;
             }
-          } catch (error49) {
-            if (error49 instanceof Error && "code" in error49 && error49.code === "ENOENT") {} else {
+          } catch (error52) {
+            if (error52 instanceof Error && "code" in error52 && error52.code === "ENOENT") {} else {
               hasProjectIndicator = true;
               break;
             }
@@ -19952,9 +20715,9 @@ function validateProjectRoot(directory) {
           throw new Error(`Cannot write evidence in "${resolved}" \u2014 parent directory "${parent}" already contains a .swarm/ folder. Evidence must be written to the project root.`);
         }
       }
-    } catch (error49) {
-      if (error49 instanceof Error && error49.message.startsWith("Cannot write evidence")) {
-        throw error49;
+    } catch (error52) {
+      if (error52 instanceof Error && error52.message.startsWith("Cannot write evidence")) {
+        throw error52;
       }
     }
     current = parent;
@@ -19974,8 +20737,8 @@ async function saveEvidence(directory, taskId, evidence) {
       try {
         const parsed = JSON.parse(existingContent);
         bundle = EvidenceBundleSchema.parse(parsed);
-      } catch (error49) {
-        warn(`Existing evidence bundle invalid for task ${sanitizedTaskId}, creating new: ${error49 instanceof Error ? error49.message : String(error49)}`);
+      } catch (error52) {
+        warn(`Existing evidence bundle invalid for task ${sanitizedTaskId}, creating new: ${error52 instanceof Error ? error52.message : String(error52)}`);
         const now = new Date().toISOString();
         bundle = {
           schema_version: "1.0.0",
@@ -20014,11 +20777,11 @@ async function saveEvidence(directory, taskId, evidence) {
     try {
       await bunWrite(tempPath, bundleJson);
       await fs4.rename(tempPath, evidencePath);
-    } catch (error49) {
+    } catch (error52) {
       try {
         rmSync(tempPath, { force: true });
       } catch {}
-      throw error49;
+      throw error52;
     }
     return updatedBundle;
   });
@@ -20084,18 +20847,18 @@ async function loadEvidence(directory, taskId) {
         warn(`Evidence lock failed during flat-retrospective write-back for task ${sanitizedTaskId}: ${lockErr instanceof Error ? lockErr.message : String(lockErr)}`);
       }
       return { status: "found", bundle: validated };
-    } catch (error49) {
-      warn(`Wrapped flat retrospective failed validation for task ${sanitizedTaskId}: ${error49 instanceof Error ? error49.message : String(error49)}`);
-      const errors3 = error49 instanceof ZodError ? error49.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error49 instanceof Error ? error49.message : String(error49)];
+    } catch (error52) {
+      warn(`Wrapped flat retrospective failed validation for task ${sanitizedTaskId}: ${error52 instanceof Error ? error52.message : String(error52)}`);
+      const errors3 = error52 instanceof ZodError ? error52.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error52 instanceof Error ? error52.message : String(error52)];
       return { status: "invalid_schema", errors: errors3 };
     }
   }
   try {
     const validated = EvidenceBundleSchema.parse(parsed);
     return { status: "found", bundle: validated };
-  } catch (error49) {
-    warn(`Evidence bundle validation failed for task ${sanitizedTaskId}: ${error49 instanceof Error ? error49.message : String(error49)}`);
-    const errors3 = error49 instanceof ZodError ? error49.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error49 instanceof Error ? error49.message : String(error49)];
+  } catch (error52) {
+    warn(`Evidence bundle validation failed for task ${sanitizedTaskId}: ${error52 instanceof Error ? error52.message : String(error52)}`);
+    const errors3 = error52 instanceof ZodError ? error52.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error52 instanceof Error ? error52.message : String(error52)];
     return { status: "invalid_schema", errors: errors3 };
   }
 }
@@ -20122,9 +20885,9 @@ async function listEvidenceTaskIds(directory) {
       }
       sanitizeTaskId2(entry);
       taskIds.push(entry);
-    } catch (error49) {
-      if (error49 instanceof Error && !error49.message.startsWith("Invalid task ID")) {
-        warn(`Error reading evidence entry '${entry}': ${error49.message}`);
+    } catch (error52) {
+      if (error52 instanceof Error && !error52.message.startsWith("Invalid task ID")) {
+        warn(`Error reading evidence entry '${entry}': ${error52.message}`);
       }
     }
   }
@@ -20142,8 +20905,8 @@ async function deleteEvidence(directory, taskId) {
   try {
     rmSync(evidenceDir, { recursive: true, force: true });
     return true;
-  } catch (error49) {
-    warn(`Failed to delete evidence for task ${sanitizedTaskId}: ${error49 instanceof Error ? error49.message : String(error49)}`);
+  } catch (error52) {
+    warn(`Failed to delete evidence for task ${sanitizedTaskId}: ${error52 instanceof Error ? error52.message : String(error52)}`);
     return false;
   }
 }
@@ -21748,12 +22511,12 @@ async function handleBrainstormCommand(_directory, args) {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/core/core.js
 function $constructor2(name, initializer3, params) {
   function init(inst, def) {
-    var _a2;
+    var _a3;
     Object.defineProperty(inst, "_zod", {
       value: inst._zod ?? {},
       enumerable: false
     });
-    (_a2 = inst._zod).traits ?? (_a2.traits = new Set);
+    (_a3 = inst._zod).traits ?? (_a3.traits = new Set);
     inst._zod.traits.add(name);
     initializer3(inst, def);
     for (const k in _.prototype) {
@@ -21769,10 +22532,10 @@ function $constructor2(name, initializer3, params) {
   }
   Object.defineProperty(Definition, "name", { value: name });
   function _(def) {
-    var _a2;
+    var _a3;
     const inst = params?.Parent ? new Definition : this;
     init(inst, def);
-    (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
+    (_a3 = inst._zod).deferred ?? (_a3.deferred = []);
     for (const fn of inst._zod.deferred) {
       fn();
     }
@@ -22275,8 +23038,8 @@ function aborted2(x, startIndex = 0) {
 }
 function prefixIssues2(path9, issues) {
   return issues.map((iss) => {
-    var _a2;
-    (_a2 = iss).path ?? (_a2.path = []);
+    var _a3;
+    (_a3 = iss).path ?? (_a3.path = []);
     iss.path.unshift(path9);
     return iss;
   });
@@ -22446,10 +23209,10 @@ var init_util2 = __esm(() => {
 });
 
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/core/errors.js
-function flattenError2(error49, mapper = (issue3) => issue3.message) {
+function flattenError2(error52, mapper = (issue3) => issue3.message) {
   const fieldErrors = {};
   const formErrors = [];
-  for (const sub of error49.issues) {
+  for (const sub of error52.issues) {
     if (sub.path.length > 0) {
       fieldErrors[sub.path[0]] = fieldErrors[sub.path[0]] || [];
       fieldErrors[sub.path[0]].push(mapper(sub));
@@ -22459,13 +23222,13 @@ function flattenError2(error49, mapper = (issue3) => issue3.message) {
   }
   return { formErrors, fieldErrors };
 }
-function formatError2(error49, _mapper) {
+function formatError2(error52, _mapper) {
   const mapper = _mapper || function(issue3) {
     return issue3.message;
   };
   const fieldErrors = { _errors: [] };
-  const processError = (error50) => {
-    for (const issue3 of error50.issues) {
+  const processError = (error53) => {
+    for (const issue3 of error53.issues) {
       if (issue3.code === "invalid_union" && issue3.errors.length) {
         issue3.errors.map((issues) => processError({ issues }));
       } else if (issue3.code === "invalid_key") {
@@ -22492,17 +23255,17 @@ function formatError2(error49, _mapper) {
       }
     }
   };
-  processError(error49);
+  processError(error52);
   return fieldErrors;
 }
-function treeifyError2(error49, _mapper) {
+function treeifyError2(error52, _mapper) {
   const mapper = _mapper || function(issue3) {
     return issue3.message;
   };
   const result = { errors: [] };
-  const processError = (error50, path9 = []) => {
-    var _a2, _b;
-    for (const issue3 of error50.issues) {
+  const processError = (error53, path9 = []) => {
+    var _a3, _b;
+    for (const issue3 of error53.issues) {
       if (issue3.code === "invalid_union" && issue3.errors.length) {
         issue3.errors.map((issues) => processError({ issues }, issue3.path));
       } else if (issue3.code === "invalid_key") {
@@ -22522,7 +23285,7 @@ function treeifyError2(error49, _mapper) {
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
             curr.properties ?? (curr.properties = {});
-            (_a2 = curr.properties)[el] ?? (_a2[el] = { errors: [] });
+            (_a3 = curr.properties)[el] ?? (_a3[el] = { errors: [] });
             curr = curr.properties[el];
           } else {
             curr.items ?? (curr.items = []);
@@ -22537,7 +23300,7 @@ function treeifyError2(error49, _mapper) {
       }
     }
   };
-  processError(error49);
+  processError(error52);
   return result;
 }
 function toDotPath2(_path) {
@@ -22558,9 +23321,9 @@ function toDotPath2(_path) {
   }
   return segs.join("");
 }
-function prettifyError2(error49) {
+function prettifyError2(error52) {
   const lines = [];
-  const issues = [...error49.issues].sort((a, b) => (a.path ?? []).length - (b.path ?? []).length);
+  const issues = [...error52.issues].sort((a, b) => (a.path ?? []).length - (b.path ?? []).length);
   for (const issue3 of issues) {
     lines.push(`\u2716 ${issue3.message}`);
     if (issue3.path?.length)
@@ -22837,10 +23600,10 @@ var init_checks3 = __esm(() => {
   init_regexes2();
   init_util2();
   $ZodCheck2 = /* @__PURE__ */ $constructor2("$ZodCheck", (inst, def) => {
-    var _a2;
+    var _a3;
     inst._zod ?? (inst._zod = {});
     inst._zod.def = def;
-    (_a2 = inst._zod).onattach ?? (_a2.onattach = []);
+    (_a3 = inst._zod).onattach ?? (_a3.onattach = []);
   });
   numericOriginMap2 = {
     number: "number",
@@ -22906,8 +23669,8 @@ var init_checks3 = __esm(() => {
   $ZodCheckMultipleOf2 = /* @__PURE__ */ $constructor2("$ZodCheckMultipleOf", (inst, def) => {
     $ZodCheck2.init(inst, def);
     inst._zod.onattach.push((inst2) => {
-      var _a2;
-      (_a2 = inst2._zod.bag).multipleOf ?? (_a2.multipleOf = def.value);
+      var _a3;
+      (_a3 = inst2._zod.bag).multipleOf ?? (_a3.multipleOf = def.value);
     });
     inst._zod.check = (payload) => {
       if (typeof payload.value !== typeof def.value)
@@ -23034,9 +23797,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMaxSize2 = /* @__PURE__ */ $constructor2("$ZodCheckMaxSize", (inst, def) => {
-    var _a2;
+    var _a3;
     $ZodCheck2.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.size !== undefined;
     });
@@ -23062,9 +23825,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMinSize2 = /* @__PURE__ */ $constructor2("$ZodCheckMinSize", (inst, def) => {
-    var _a2;
+    var _a3;
     $ZodCheck2.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.size !== undefined;
     });
@@ -23090,9 +23853,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckSizeEquals2 = /* @__PURE__ */ $constructor2("$ZodCheckSizeEquals", (inst, def) => {
-    var _a2;
+    var _a3;
     $ZodCheck2.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.size !== undefined;
     });
@@ -23120,9 +23883,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMaxLength2 = /* @__PURE__ */ $constructor2("$ZodCheckMaxLength", (inst, def) => {
-    var _a2;
+    var _a3;
     $ZodCheck2.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.length !== undefined;
     });
@@ -23149,9 +23912,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMinLength2 = /* @__PURE__ */ $constructor2("$ZodCheckMinLength", (inst, def) => {
-    var _a2;
+    var _a3;
     $ZodCheck2.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.length !== undefined;
     });
@@ -23178,9 +23941,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckLengthEquals2 = /* @__PURE__ */ $constructor2("$ZodCheckLengthEquals", (inst, def) => {
-    var _a2;
+    var _a3;
     $ZodCheck2.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.length !== undefined;
     });
@@ -23209,7 +23972,7 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckStringFormat2 = /* @__PURE__ */ $constructor2("$ZodCheckStringFormat", (inst, def) => {
-    var _a2, _b;
+    var _a3, _b;
     $ZodCheck2.init(inst, def);
     inst._zod.onattach.push((inst2) => {
       const bag = inst2._zod.bag;
@@ -23220,7 +23983,7 @@ var init_checks3 = __esm(() => {
       }
     });
     if (def.pattern)
-      (_a2 = inst._zod).check ?? (_a2.check = (payload) => {
+      (_a3 = inst._zod).check ?? (_a3.check = (payload) => {
         def.pattern.lastIndex = 0;
         if (def.pattern.test(payload.value))
           return;
@@ -23734,7 +24497,7 @@ var init_schemas3 = __esm(() => {
   init_versions2();
   init_util2();
   $ZodType2 = /* @__PURE__ */ $constructor2("$ZodType", (inst, def) => {
-    var _a2;
+    var _a3;
     inst ?? (inst = {});
     inst._zod.def = def;
     inst._zod.bag = inst._zod.bag || {};
@@ -23749,7 +24512,7 @@ var init_schemas3 = __esm(() => {
       }
     }
     if (checks3.length === 0) {
-      (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
+      (_a3 = inst._zod).deferred ?? (_a3.deferred = []);
       inst._zod.deferred?.push(() => {
         inst._zod.run = inst._zod.parse;
       });
@@ -25257,10 +26020,10 @@ var init_schemas3 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ar.js
 function ar_default2() {
   return {
-    localeError: error49()
+    localeError: error52()
   };
 }
-var error49 = () => {
+var error52 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0641", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
     file: { unit: "\u0628\u0627\u064A\u062A", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
@@ -25377,10 +26140,10 @@ var init_ar2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/az.js
 function az_default2() {
   return {
-    localeError: error50()
+    localeError: error53()
   };
 }
-var error50 = () => {
+var error53 = () => {
   const Sizable = {
     string: { unit: "simvol", verb: "olmal\u0131d\u0131r" },
     file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
@@ -25511,10 +26274,10 @@ function getBelarusianPlural2(count, one, few, many) {
 }
 function be_default2() {
   return {
-    localeError: error51()
+    localeError: error54()
   };
 }
-var error51 = () => {
+var error54 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -25664,10 +26427,10 @@ var init_be2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ca.js
 function ca_default2() {
   return {
-    localeError: error52()
+    localeError: error55()
   };
 }
-var error52 = () => {
+var error55 = () => {
   const Sizable = {
     string: { unit: "car\xE0cters", verb: "contenir" },
     file: { unit: "bytes", verb: "contenir" },
@@ -25785,10 +26548,10 @@ var init_ca2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/cs.js
 function cs_default2() {
   return {
-    localeError: error53()
+    localeError: error56()
   };
 }
-var error53 = () => {
+var error56 = () => {
   const Sizable = {
     string: { unit: "znak\u016F", verb: "m\xEDt" },
     file: { unit: "bajt\u016F", verb: "m\xEDt" },
@@ -25924,10 +26687,10 @@ var init_cs2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/da.js
 function da_default2() {
   return {
-    localeError: error54()
+    localeError: error57()
   };
 }
-var error54 = () => {
+var error57 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "havde" },
     file: { unit: "bytes", verb: "havde" },
@@ -26059,10 +26822,10 @@ var init_da2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/de.js
 function de_default2() {
   return {
-    localeError: error55()
+    localeError: error58()
   };
 }
-var error55 = () => {
+var error58 = () => {
   const Sizable = {
     string: { unit: "Zeichen", verb: "zu haben" },
     file: { unit: "Bytes", verb: "zu haben" },
@@ -26179,7 +26942,7 @@ var init_de2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/en.js
 function en_default2() {
   return {
-    localeError: error56()
+    localeError: error59()
   };
 }
 var parsedType2 = (data) => {
@@ -26201,7 +26964,7 @@ var parsedType2 = (data) => {
     }
   }
   return t;
-}, error56 = () => {
+}, error59 = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
     file: { unit: "bytes", verb: "to have" },
@@ -26299,7 +27062,7 @@ var init_en2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/eo.js
 function eo_default2() {
   return {
-    localeError: error57()
+    localeError: error60()
   };
 }
 var parsedType3 = (data) => {
@@ -26321,7 +27084,7 @@ var parsedType3 = (data) => {
     }
   }
   return t;
-}, error57 = () => {
+}, error60 = () => {
   const Sizable = {
     string: { unit: "karaktrojn", verb: "havi" },
     file: { unit: "bajtojn", verb: "havi" },
@@ -26418,10 +27181,10 @@ var init_eo2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/es.js
 function es_default2() {
   return {
-    localeError: error58()
+    localeError: error61()
   };
 }
-var error58 = () => {
+var error61 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "tener" },
     file: { unit: "bytes", verb: "tener" },
@@ -26570,10 +27333,10 @@ var init_es2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fa.js
 function fa_default2() {
   return {
-    localeError: error59()
+    localeError: error62()
   };
 }
-var error59 = () => {
+var error62 = () => {
   const Sizable = {
     string: { unit: "\u06A9\u0627\u0631\u0627\u06A9\u062A\u0631", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
     file: { unit: "\u0628\u0627\u06CC\u062A", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
@@ -26696,10 +27459,10 @@ var init_fa2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fi.js
 function fi_default2() {
   return {
-    localeError: error60()
+    localeError: error63()
   };
 }
-var error60 = () => {
+var error63 = () => {
   const Sizable = {
     string: { unit: "merkki\xE4", subject: "merkkijonon" },
     file: { unit: "tavua", subject: "tiedoston" },
@@ -26822,10 +27585,10 @@ var init_fi2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fr.js
 function fr_default2() {
   return {
-    localeError: error61()
+    localeError: error64()
   };
 }
-var error61 = () => {
+var error64 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -26942,10 +27705,10 @@ var init_fr2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fr-CA.js
 function fr_CA_default2() {
   return {
-    localeError: error62()
+    localeError: error65()
   };
 }
-var error62 = () => {
+var error65 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -27063,10 +27826,10 @@ var init_fr_CA2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/he.js
 function he_default2() {
   return {
-    localeError: error63()
+    localeError: error66()
   };
 }
-var error63 = () => {
+var error66 = () => {
   const Sizable = {
     string: { unit: "\u05D0\u05D5\u05EA\u05D9\u05D5\u05EA", verb: "\u05DC\u05DB\u05DC\u05D5\u05DC" },
     file: { unit: "\u05D1\u05D9\u05D9\u05D8\u05D9\u05DD", verb: "\u05DC\u05DB\u05DC\u05D5\u05DC" },
@@ -27183,10 +27946,10 @@ var init_he2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/hu.js
 function hu_default2() {
   return {
-    localeError: error64()
+    localeError: error67()
   };
 }
-var error64 = () => {
+var error67 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "legyen" },
     file: { unit: "byte", verb: "legyen" },
@@ -27303,10 +28066,10 @@ var init_hu2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/id.js
 function id_default2() {
   return {
-    localeError: error65()
+    localeError: error68()
   };
 }
-var error65 = () => {
+var error68 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "memiliki" },
     file: { unit: "byte", verb: "memiliki" },
@@ -27423,7 +28186,7 @@ var init_id2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/is.js
 function is_default2() {
   return {
-    localeError: error66()
+    localeError: error69()
   };
 }
 var parsedType4 = (data) => {
@@ -27445,7 +28208,7 @@ var parsedType4 = (data) => {
     }
   }
   return t;
-}, error66 = () => {
+}, error69 = () => {
   const Sizable = {
     string: { unit: "stafi", verb: "a\xF0 hafa" },
     file: { unit: "b\xE6ti", verb: "a\xF0 hafa" },
@@ -27543,10 +28306,10 @@ var init_is2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/it.js
 function it_default2() {
   return {
-    localeError: error67()
+    localeError: error70()
   };
 }
-var error67 = () => {
+var error70 = () => {
   const Sizable = {
     string: { unit: "caratteri", verb: "avere" },
     file: { unit: "byte", verb: "avere" },
@@ -27663,10 +28426,10 @@ var init_it2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ja.js
 function ja_default2() {
   return {
-    localeError: error68()
+    localeError: error71()
   };
 }
-var error68 = () => {
+var error71 = () => {
   const Sizable = {
     string: { unit: "\u6587\u5B57", verb: "\u3067\u3042\u308B" },
     file: { unit: "\u30D0\u30A4\u30C8", verb: "\u3067\u3042\u308B" },
@@ -27782,7 +28545,7 @@ var init_ja2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ka.js
 function ka_default2() {
   return {
-    localeError: error69()
+    localeError: error72()
   };
 }
 var parsedType5 = (data) => {
@@ -27812,7 +28575,7 @@ var parsedType5 = (data) => {
     function: "\u10E4\u10E3\u10DC\u10E5\u10EA\u10D8\u10D0"
   };
   return typeMap[t] ?? t;
-}, error69 = () => {
+}, error72 = () => {
   const Sizable = {
     string: { unit: "\u10E1\u10D8\u10DB\u10D1\u10DD\u10DA\u10DD", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
     file: { unit: "\u10D1\u10D0\u10D8\u10E2\u10D8", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
@@ -27910,10 +28673,10 @@ var init_ka2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/km.js
 function km_default2() {
   return {
-    localeError: error70()
+    localeError: error73()
   };
 }
-var error70 = () => {
+var error73 = () => {
   const Sizable = {
     string: { unit: "\u178F\u17BD\u17A2\u1780\u17D2\u179F\u179A", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
     file: { unit: "\u1794\u17C3", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
@@ -28039,10 +28802,10 @@ var init_kh2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ko.js
 function ko_default2() {
   return {
-    localeError: error71()
+    localeError: error74()
   };
 }
-var error71 = () => {
+var error74 = () => {
   const Sizable = {
     string: { unit: "\uBB38\uC790", verb: "to have" },
     file: { unit: "\uBC14\uC774\uD2B8", verb: "to have" },
@@ -28174,7 +28937,7 @@ function getUnitTypeFromNumber2(number5) {
 }
 function lt_default2() {
   return {
-    localeError: error72()
+    localeError: error75()
   };
 }
 var parsedType6 = (data) => {
@@ -28223,7 +28986,7 @@ var parsedType6 = (data) => {
   return t;
 }, capitalizeFirstCharacter2 = (text) => {
   return text.charAt(0).toUpperCase() + text.slice(1);
-}, error72 = () => {
+}, error75 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -28394,10 +29157,10 @@ var init_lt2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/mk.js
 function mk_default2() {
   return {
-    localeError: error73()
+    localeError: error76()
   };
 }
-var error73 = () => {
+var error76 = () => {
   const Sizable = {
     string: { unit: "\u0437\u043D\u0430\u0446\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
     file: { unit: "\u0431\u0430\u0458\u0442\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
@@ -28515,10 +29278,10 @@ var init_mk2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ms.js
 function ms_default2() {
   return {
-    localeError: error74()
+    localeError: error77()
   };
 }
-var error74 = () => {
+var error77 = () => {
   const Sizable = {
     string: { unit: "aksara", verb: "mempunyai" },
     file: { unit: "bait", verb: "mempunyai" },
@@ -28635,10 +29398,10 @@ var init_ms2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/nl.js
 function nl_default2() {
   return {
-    localeError: error75()
+    localeError: error78()
   };
 }
-var error75 = () => {
+var error78 = () => {
   const Sizable = {
     string: { unit: "tekens" },
     file: { unit: "bytes" },
@@ -28756,10 +29519,10 @@ var init_nl2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/no.js
 function no_default2() {
   return {
-    localeError: error76()
+    localeError: error79()
   };
 }
-var error76 = () => {
+var error79 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "\xE5 ha" },
     file: { unit: "bytes", verb: "\xE5 ha" },
@@ -28876,10 +29639,10 @@ var init_no2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ota.js
 function ota_default2() {
   return {
-    localeError: error77()
+    localeError: error80()
   };
 }
-var error77 = () => {
+var error80 = () => {
   const Sizable = {
     string: { unit: "harf", verb: "olmal\u0131d\u0131r" },
     file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
@@ -28996,10 +29759,10 @@ var init_ota2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ps.js
 function ps_default2() {
   return {
-    localeError: error78()
+    localeError: error81()
   };
 }
-var error78 = () => {
+var error81 = () => {
   const Sizable = {
     string: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
     file: { unit: "\u0628\u0627\u06CC\u067C\u0633", verb: "\u0648\u0644\u0631\u064A" },
@@ -29122,10 +29885,10 @@ var init_ps2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/pl.js
 function pl_default2() {
   return {
-    localeError: error79()
+    localeError: error82()
   };
 }
-var error79 = () => {
+var error82 = () => {
   const Sizable = {
     string: { unit: "znak\xF3w", verb: "mie\u0107" },
     file: { unit: "bajt\xF3w", verb: "mie\u0107" },
@@ -29243,10 +30006,10 @@ var init_pl2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/pt.js
 function pt_default2() {
   return {
-    localeError: error80()
+    localeError: error83()
   };
 }
-var error80 = () => {
+var error83 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "ter" },
     file: { unit: "bytes", verb: "ter" },
@@ -29378,10 +30141,10 @@ function getRussianPlural2(count, one, few, many) {
 }
 function ru_default2() {
   return {
-    localeError: error81()
+    localeError: error84()
   };
 }
-var error81 = () => {
+var error84 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -29531,10 +30294,10 @@ var init_ru2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/sl.js
 function sl_default2() {
   return {
-    localeError: error82()
+    localeError: error85()
   };
 }
-var error82 = () => {
+var error85 = () => {
   const Sizable = {
     string: { unit: "znakov", verb: "imeti" },
     file: { unit: "bajtov", verb: "imeti" },
@@ -29652,10 +30415,10 @@ var init_sl2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/sv.js
 function sv_default2() {
   return {
-    localeError: error83()
+    localeError: error86()
   };
 }
-var error83 = () => {
+var error86 = () => {
   const Sizable = {
     string: { unit: "tecken", verb: "att ha" },
     file: { unit: "bytes", verb: "att ha" },
@@ -29774,10 +30537,10 @@ var init_sv2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ta.js
 function ta_default2() {
   return {
-    localeError: error84()
+    localeError: error87()
   };
 }
-var error84 = () => {
+var error87 = () => {
   const Sizable = {
     string: { unit: "\u0B8E\u0BB4\u0BC1\u0BA4\u0BCD\u0BA4\u0BC1\u0B95\u0BCD\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
     file: { unit: "\u0BAA\u0BC8\u0B9F\u0BCD\u0B9F\u0BC1\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
@@ -29895,10 +30658,10 @@ var init_ta2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/th.js
 function th_default2() {
   return {
-    localeError: error85()
+    localeError: error88()
   };
 }
-var error85 = () => {
+var error88 = () => {
   const Sizable = {
     string: { unit: "\u0E15\u0E31\u0E27\u0E2D\u0E31\u0E01\u0E29\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
     file: { unit: "\u0E44\u0E1A\u0E15\u0E4C", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
@@ -30016,7 +30779,7 @@ var init_th2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/tr.js
 function tr_default2() {
   return {
-    localeError: error86()
+    localeError: error89()
   };
 }
 var parsedType7 = (data) => {
@@ -30038,7 +30801,7 @@ var parsedType7 = (data) => {
     }
   }
   return t;
-}, error86 = () => {
+}, error89 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "olmal\u0131" },
     file: { unit: "bayt", verb: "olmal\u0131" },
@@ -30134,10 +30897,10 @@ var init_tr2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/uk.js
 function uk_default2() {
   return {
-    localeError: error87()
+    localeError: error90()
   };
 }
-var error87 = () => {
+var error90 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
     file: { unit: "\u0431\u0430\u0439\u0442\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
@@ -30262,10 +31025,10 @@ var init_ua2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ur.js
 function ur_default2() {
   return {
-    localeError: error88()
+    localeError: error91()
   };
 }
-var error88 = () => {
+var error91 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0648\u0641", verb: "\u06C1\u0648\u0646\u0627" },
     file: { unit: "\u0628\u0627\u0626\u0679\u0633", verb: "\u06C1\u0648\u0646\u0627" },
@@ -30383,10 +31146,10 @@ var init_ur2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/vi.js
 function vi_default2() {
   return {
-    localeError: error89()
+    localeError: error92()
   };
 }
-var error89 = () => {
+var error92 = () => {
   const Sizable = {
     string: { unit: "k\xFD t\u1EF1", verb: "c\xF3" },
     file: { unit: "byte", verb: "c\xF3" },
@@ -30503,10 +31266,10 @@ var init_vi2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/zh-CN.js
 function zh_CN_default2() {
   return {
-    localeError: error90()
+    localeError: error93()
   };
 }
-var error90 = () => {
+var error93 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u7B26", verb: "\u5305\u542B" },
     file: { unit: "\u5B57\u8282", verb: "\u5305\u542B" },
@@ -30623,10 +31386,10 @@ var init_zh_CN2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/zh-TW.js
 function zh_TW_default2() {
   return {
-    localeError: error91()
+    localeError: error94()
   };
 }
-var error91 = () => {
+var error94 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u5143", verb: "\u64C1\u6709" },
     file: { unit: "\u4F4D\u5143\u7D44", verb: "\u64C1\u6709" },
@@ -30744,10 +31507,10 @@ var init_zh_TW2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/yo.js
 function yo_default2() {
   return {
-    localeError: error92()
+    localeError: error95()
   };
 }
-var error92 = () => {
+var error95 = () => {
   const Sizable = {
     string: { unit: "\xE0mi", verb: "n\xED" },
     file: { unit: "bytes", verb: "n\xED" },
@@ -31910,7 +32673,7 @@ class JSONSchemaGenerator2 {
     this.seen = new Map;
   }
   process(schema, _params = { path: [], schemaPath: [] }) {
-    var _a2;
+    var _a3;
     const def = schema._zod.def;
     const formatMap2 = {
       guid: "uuid",
@@ -32413,7 +33176,7 @@ class JSONSchemaGenerator2 {
       delete result.schema.default;
     }
     if (this.io === "input" && result.schema._prefault)
-      (_a2 = result.schema).default ?? (_a2.default = result.schema._prefault);
+      (_a3 = result.schema).default ?? (_a3.default = result.schema._prefault);
     delete result.schema._prefault;
     const _result = this.seen.get(schema);
     return _result.schema;
@@ -34407,8 +35170,8 @@ var init_dist = __esm(() => {
 });
 
 // src/tools/create-tool.ts
-function classifyToolError(error93) {
-  const msg = (error93 instanceof Error ? error93.message ?? "" : String(error93)).toLowerCase();
+function classifyToolError(error96) {
+  const msg = (error96 instanceof Error ? error96.message ?? "" : String(error96)).toLowerCase();
   if (msg.includes("not registered") || msg.includes("unknown tool"))
     return "not_registered";
   if (msg.includes("not whitelisted") || msg.includes("not allowed"))
@@ -34426,11 +35189,11 @@ function createSwarmTool(opts) {
       try {
         const result = await opts.execute(args, directory, ctx);
         return result;
-      } catch (error93) {
-        const message = error93 instanceof Error ? error93.message : String(error93);
+      } catch (error96) {
+        const message = error96 instanceof Error ? error96.message : String(error96);
         return JSON.stringify({
           success: false,
-          failure_class: classifyToolError(error93),
+          failure_class: classifyToolError(error96),
           message: "Tool execution failed",
           errors: [message]
         }, null, 2);
@@ -34800,8 +35563,8 @@ async function handleSave2(directory, label) {
     } else {
       return `Error: ${parsed.error || "Failed to save checkpoint"}`;
     }
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     return `Error: ${msg}`;
   }
 }
@@ -34819,8 +35582,8 @@ async function handleRestore2(directory, label) {
     } else {
       return `Error: ${parsed.error || "Failed to restore checkpoint"}`;
     }
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     return `Error: ${msg}`;
   }
 }
@@ -34838,8 +35601,8 @@ async function handleDelete2(directory, label) {
     } else {
       return `Error: ${parsed.error || "Failed to delete checkpoint"}`;
     }
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     return `Error: ${msg}`;
   }
 }
@@ -34868,8 +35631,8 @@ async function handleList2(directory) {
     ];
     return lines.join(`
 `);
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     return `Error: ${msg}`;
   }
 }
@@ -35395,8 +36158,8 @@ class AutomationEventBus {
       await Promise.all(Array.from(listeners).map(async (listener) => {
         try {
           await listener(event);
-        } catch (error93) {
-          log(`[EventBus] Listener error for ${type}`, { error: error93 });
+        } catch (error96) {
+          log(`[EventBus] Listener error for ${type}`, { error: error96 });
         }
       }));
     }
@@ -37855,11 +38618,11 @@ async function executeWriteRetro(args, directory) {
       phase,
       message: `Retrospective evidence written to .swarm/evidence/${taskId}/evidence.json`
     }, null, 2);
-  } catch (error93) {
+  } catch (error96) {
     return JSON.stringify({
       success: false,
       phase,
-      message: error93 instanceof Error ? error93.message : String(error93)
+      message: error96 instanceof Error ? error96.message : String(error96)
     }, null, 2);
   }
 }
@@ -37990,9 +38753,9 @@ async function handleCloseCommand(directory, args, options = {}) {
     const content = await fs7.readFile(planPath, "utf-8");
     planData = JSON.parse(content);
     planExists = true;
-  } catch (error93) {
-    if (error93?.code !== "ENOENT") {
-      return `\u274C Failed to read plan.json: ${error93 instanceof Error ? error93.message : String(error93)}`;
+  } catch (error96) {
+    if (error96?.code !== "ENOENT") {
+      return `\u274C Failed to read plan.json: ${error96 instanceof Error ? error96.message : String(error96)}`;
     }
     const swarmDirExists = await fs7.access(swarmDir).then(() => true).catch(() => false);
     if (!swarmDirExists) {
@@ -38128,10 +38891,10 @@ async function handleCloseCommand(directory, args, options = {}) {
   try {
     curationResult = await curateAndStoreSwarm(allLessons, projectName, { phase_number: 0 }, directory, config3);
     curationSucceeded = true;
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     warnings.push(`Lessons curation failed: ${msg}`);
-    console.warn("[close-command] curateAndStoreSwarm error:", error93);
+    console.warn("[close-command] curateAndStoreSwarm error:", error96);
   }
   if (curationSucceeded && allLessons.length > 0) {
     await fs7.unlink(lessonsFilePath).catch(() => {});
@@ -38221,10 +38984,10 @@ async function handleCloseCommand(directory, args, options = {}) {
     if (!planAlreadyDone || guaranteeResult.closedPhaseIds.length > 0 || guaranteeResult.closedTaskIds.length > 0) {
       try {
         await fs7.writeFile(planPath, JSON.stringify(planData, null, 2), "utf-8");
-      } catch (error93) {
-        const msg = error93 instanceof Error ? error93.message : String(error93);
+      } catch (error96) {
+        const msg = error96 instanceof Error ? error96.message : String(error96);
         warnings.push(`Failed to persist terminal plan.json state: ${msg}`);
-        console.warn("[close-command] Failed to write plan.json:", error93);
+        console.warn("[close-command] Failed to write plan.json:", error96);
       }
     }
   }
@@ -38283,10 +39046,10 @@ async function handleCloseCommand(directory, args, options = {}) {
   }
   try {
     await archiveEvidence(directory, 30, 10);
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     warnings.push(`Evidence retention archive failed: ${msg}`);
-    console.warn("[close-command] archiveEvidence error:", error93);
+    console.warn("[close-command] archiveEvidence error:", error96);
   }
   let configBackupsRemoved = 0;
   const cleanedFiles = [];
@@ -38363,10 +39126,10 @@ async function handleCloseCommand(directory, args, options = {}) {
 `);
   try {
     await fs7.writeFile(contextPath, contextContent, "utf-8");
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     warnings.push(`Failed to reset context.md: ${msg}`);
-    console.warn("[close-command] Failed to write context.md:", error93);
+    console.warn("[close-command] Failed to write context.md:", error96);
   }
   const pruneBranches = args.includes("--prune-branches");
   let gitAlignResult = "";
@@ -38449,10 +39212,10 @@ async function handleCloseCommand(directory, args, options = {}) {
 `);
   try {
     await fs7.writeFile(closeSummaryPath, summaryContent, "utf-8");
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     warnings.push(`Failed to write close-summary.md: ${msg}`);
-    console.warn("[close-command] Failed to write close-summary.md:", error93);
+    console.warn("[close-command] Failed to write close-summary.md:", error96);
   }
   const preservedClient = swarmState.opencodeClient;
   const preservedFullAutoFlag = swarmState.fullAutoEnabledInConfig;
@@ -38673,11 +39436,11 @@ async function handleCurateCommand(directory, _args) {
     const swarmEntries = await readKnowledge(swarmPath) ?? [];
     const summary = await checkHivePromotions(swarmEntries, config3);
     return formatCurationSummary(summary);
-  } catch (error93) {
-    if (error93 instanceof Error) {
-      return `\u274C Curation failed: ${error93.message}`;
+  } catch (error96) {
+    if (error96 instanceof Error) {
+      return `\u274C Curation failed: ${error96.message}`;
     }
-    return `\u274C Curation failed: ${error93 instanceof Error ? error93.message : String(error93)}`;
+    return `\u274C Curation failed: ${error96 instanceof Error ? error96.message : String(error96)}`;
   }
 }
 function formatCurationSummary(summary) {
@@ -40182,9 +40945,9 @@ function createConfigBackup(directory) {
   if (fs8.existsSync(projectConfigPath)) {
     try {
       content = fs8.readFileSync(projectConfigPath, "utf-8");
-    } catch (error93) {
+    } catch (error96) {
       log("[ConfigDoctor] project config read failed", {
-        error: error93 instanceof Error ? error93.message : String(error93)
+        error: error96 instanceof Error ? error96.message : String(error96)
       });
     }
   }
@@ -40192,9 +40955,9 @@ function createConfigBackup(directory) {
     configPath = userConfigPath;
     try {
       content = fs8.readFileSync(userConfigPath, "utf-8");
-    } catch (error93) {
+    } catch (error96) {
       log("[ConfigDoctor] user config read failed", {
-        error: error93 instanceof Error ? error93.message : String(error93)
+        error: error96 instanceof Error ? error96.message : String(error96)
       });
     }
   }
@@ -43184,8 +43947,8 @@ function withStateLock(directory, fn) {
       retries: { retries: 5, minTimeout: 5, maxTimeout: 50 },
       stale: 5000
     });
-  } catch (error93) {
-    warn(`[full-auto/state] cross-process lock unavailable; proceeding unlocked: ${error93 instanceof Error ? error93.message : String(error93)}`);
+  } catch (error96) {
+    warn(`[full-auto/state] cross-process lock unavailable; proceeding unlocked: ${error96 instanceof Error ? error96.message : String(error96)}`);
   }
   try {
     return fn();
@@ -43236,8 +43999,8 @@ function readPersisted(directory) {
       oversightSequence: typeof parsed.oversightSequence === "number" ? parsed.oversightSequence : 0,
       sessions: parsed.sessions
     };
-  } catch (error93) {
-    const reason = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const reason = error96 instanceof Error ? error96.message : String(error96);
     error(`[full-auto/state] Failed to read ${STATE_FILE}: ${reason} \u2014 attempting .bak recovery`);
     try {
       const bakPath = validateSwarmPath(directory, `${STATE_FILE}.bak`);
@@ -43275,8 +44038,8 @@ function writePersisted(directory, persisted) {
     persisted.updatedAt = nowISO();
     payload = `${JSON.stringify(persisted, null, 2)}
 `;
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     error(`[full-auto/state] Failed to prepare ${STATE_FILE} write: ${msg}`);
     throw new Error(`Full-Auto state persistence prepare failed: ${msg}`);
   }
@@ -43301,8 +44064,8 @@ function writePersisted(directory, persisted) {
     if (parsed?.version !== 2) {
       throw new Error("Round-trip readback returned wrong version");
     }
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     error(`[full-auto/state] Failed to persist ${STATE_FILE} atomically: ${msg}`);
     throw new Error(`Full-Auto state persistence failed: ${msg}`);
   }
@@ -43418,8 +44181,8 @@ async function handleFullAutoCommand(directory, args, sessionID) {
       }
       v2Status = "paused";
     }
-  } catch (error93) {
-    durableError = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    durableError = error96 instanceof Error ? error96.message : String(error96);
     error(`[full-auto] durable run-state write failed: ${durableError}`);
   }
   if (newFullAutoMode && durableError) {
@@ -43567,9 +44330,9 @@ function parseSessionState(content) {
       }
     }
     return { activeAgent, delegationState, pendingQA };
-  } catch (error93) {
+  } catch (error96) {
     log("[HandoffService] state extraction failed", {
-      error: error93 instanceof Error ? error93.message : String(error93)
+      error: error96 instanceof Error ? error96.message : String(error96)
     });
     return null;
   }
@@ -43946,9 +44709,9 @@ async function writeSnapshot(directory, state) {
       }
     } catch {}
     renameSync6(tempPath, resolvedPath);
-  } catch (error93) {
+  } catch (error96) {
     log("[snapshot-writer] write failed", {
-      error: error93 instanceof Error ? error93.message : String(error93)
+      error: error96 instanceof Error ? error96.message : String(error96)
     });
   }
 }
@@ -44680,8 +45443,8 @@ async function handleKnowledgeQuarantineCommand(directory, args) {
     const fullId = resolved.entry.id;
     await quarantineEntry(directory, fullId, reason, "user");
     return `\u2705 Entry ${fullId} quarantined successfully.`;
-  } catch (error93) {
-    console.warn("[knowledge-command] quarantineEntry error:", error93 instanceof Error ? error93.message : String(error93));
+  } catch (error96) {
+    console.warn("[knowledge-command] quarantineEntry error:", error96 instanceof Error ? error96.message : String(error96));
     return `\u274C Failed to quarantine entry. Check the entry ID and try again.`;
   }
 }
@@ -44703,8 +45466,8 @@ async function handleKnowledgeRestoreCommand(directory, args) {
     const fullId = resolved.entry.id;
     await restoreEntry(directory, fullId);
     return `\u2705 Entry ${fullId} restored successfully.`;
-  } catch (error93) {
-    console.warn("[knowledge-command] restoreEntry error:", error93 instanceof Error ? error93.message : String(error93));
+  } catch (error96) {
+    console.warn("[knowledge-command] restoreEntry error:", error96 instanceof Error ? error96.message : String(error96));
     return `\u274C Failed to restore entry. Check the entry ID and try again.`;
   }
 }
@@ -44725,8 +45488,8 @@ async function handleKnowledgeMigrateCommand(directory, args) {
       }
     }
     return `\u2705 Migration complete: ${result.entriesMigrated} entries added, ${result.entriesDropped} dropped (validation/dedup), ${result.entriesTotal} total processed.`;
-  } catch (error93) {
-    console.warn("[knowledge-command] migrateContextToKnowledge error:", error93 instanceof Error ? error93.message : String(error93));
+  } catch (error96) {
+    console.warn("[knowledge-command] migrateContextToKnowledge error:", error96 instanceof Error ? error96.message : String(error96));
     return "\u274C Migration failed. Check .swarm/context.md is readable.";
   }
 }
@@ -44752,8 +45515,8 @@ async function handleKnowledgeListCommand(directory, _args) {
     lines.push("Use `/swarm knowledge quarantine <id-prefix>` to hide an entry. Prefix matching is supported \u2014 the 12-character prefix shown is unique in most stores.");
     return lines.join(`
 `);
-  } catch (error93) {
-    console.warn("[knowledge-command] list error:", error93 instanceof Error ? error93.message : String(error93));
+  } catch (error96) {
+    console.warn("[knowledge-command] list error:", error96 instanceof Error ? error96.message : String(error96));
     return "\u274C Failed to list knowledge entries. Ensure .swarm/knowledge.jsonl exists.";
   }
 }
@@ -45433,13 +46196,13 @@ async function runLint(linter, mode, directory) {
       result.message = `${linter} check found issues (exit code ${exitCode}).`;
     }
     return result;
-  } catch (error93) {
+  } catch (error96) {
     return {
       success: false,
       mode,
       linter,
       command,
-      error: error93 instanceof Error ? `Execution failed: ${error93.message}` : "Execution failed: unknown error"
+      error: error96 instanceof Error ? `Execution failed: ${error96.message}` : "Execution failed: unknown error"
     };
   }
 }
@@ -45491,13 +46254,13 @@ async function runAdditionalLint(linter, mode, cwd) {
       result.message = `${linter} check found issues (exit code ${exitCode}).`;
     }
     return result;
-  } catch (error93) {
+  } catch (error96) {
     return {
       success: false,
       mode,
       linter,
       command,
-      error: error93 instanceof Error ? `Execution failed: ${error93.message}` : "Execution failed: unknown error"
+      error: error96 instanceof Error ? `Execution failed: ${error96.message}` : "Execution failed: unknown error"
     };
   }
 }
@@ -49398,7 +50161,7 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
       }
       return result;
     }
-  } catch (error93) {
+  } catch (error96) {
     const duration_ms = Date.now() - startTime;
     return {
       success: false,
@@ -49407,7 +50170,7 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
       command,
       timeout_ms,
       duration_ms,
-      error: error93 instanceof Error ? `Execution failed: ${error93.message}` : "Execution failed: unknown error",
+      error: error96 instanceof Error ? `Execution failed: ${error96.message}` : "Execution failed: unknown error",
       outcome: "error"
     };
   }
@@ -50097,11 +50860,11 @@ async function runVersionCheck(dir, _timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error93) {
+  } catch (error96) {
     return {
       type: "version",
       status: "error",
-      message: `Version check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
+      message: `Version check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -50155,12 +50918,12 @@ async function runLintCheck(dir, linter, timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error93) {
-    if (error93 instanceof Error && error93.message.includes("timed out")) {
+  } catch (error96) {
+    if (error96 instanceof Error && error96.message.includes("timed out")) {
       return {
         type: "lint",
         status: "error",
-        message: error93.message,
+        message: error96.message,
         details: { linter },
         durationMs: Date.now() - startTime
       };
@@ -50168,7 +50931,7 @@ async function runLintCheck(dir, linter, timeoutMs) {
     return {
       type: "lint",
       status: "error",
-      message: `Lint check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
+      message: `Lint check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
       details: { linter },
       durationMs: Date.now() - startTime
     };
@@ -50224,8 +50987,8 @@ async function runTestsCheck(_dir, scope, timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error93) {
-    if (error93 instanceof Error && (error93.message.includes("timeout") || error93.message.includes("ETIMEDOUT"))) {
+  } catch (error96) {
+    if (error96 instanceof Error && (error96.message.includes("timeout") || error96.message.includes("ETIMEDOUT"))) {
       return {
         type: "tests",
         status: "error",
@@ -50236,7 +50999,7 @@ async function runTestsCheck(_dir, scope, timeoutMs) {
     return {
       type: "tests",
       status: "error",
-      message: `Tests check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
+      message: `Tests check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -50279,8 +51042,8 @@ async function runSecretsCheck(dir, timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error93) {
-    if (error93 instanceof Error && error93.name === "AbortError") {
+  } catch (error96) {
+    if (error96 instanceof Error && error96.name === "AbortError") {
       return {
         type: "secrets",
         status: "error",
@@ -50291,7 +51054,7 @@ async function runSecretsCheck(dir, timeoutMs) {
     return {
       type: "secrets",
       status: "error",
-      message: `Secrets check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
+      message: `Secrets check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -50352,11 +51115,11 @@ async function runEvidenceCheck(dir) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error93) {
+  } catch (error96) {
     return {
       type: "evidence",
       status: "error",
-      message: `Evidence check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
+      message: `Evidence check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -50391,11 +51154,11 @@ async function runRequirementCoverageCheck(dir, currentPhase) {
       details: { expectedPath: coverage.path },
       durationMs: Date.now() - startTime
     };
-  } catch (error93) {
+  } catch (error96) {
     return {
       type: "req_coverage",
       status: "error",
-      message: `Requirement coverage check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
+      message: `Requirement coverage check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -50406,7 +51169,7 @@ async function runPreflight(dir, phase, config3) {
   let validatedDir;
   try {
     validatedDir = _internals26.validateDirectoryPath(dir);
-  } catch (error93) {
+  } catch (error96) {
     return {
       id: reportId,
       timestamp: startTime,
@@ -50416,7 +51179,7 @@ async function runPreflight(dir, phase, config3) {
         {
           type: "lint",
           status: "error",
-          message: `Invalid directory: ${error93 instanceof Error ? error93.message : String(error93)}`
+          message: `Invalid directory: ${error96 instanceof Error ? error96.message : String(error96)}`
         }
       ],
       totalDurationMs: Date.now() - startTime,
@@ -50426,7 +51189,7 @@ async function runPreflight(dir, phase, config3) {
   let validatedTimeout;
   try {
     validatedTimeout = _internals26.validateTimeout(config3?.checkTimeoutMs, DEFAULT_CONFIG.checkTimeoutMs);
-  } catch (error93) {
+  } catch (error96) {
     return {
       id: reportId,
       timestamp: startTime,
@@ -50436,7 +51199,7 @@ async function runPreflight(dir, phase, config3) {
         {
           type: "lint",
           status: "error",
-          message: `Invalid config: ${error93 instanceof Error ? error93.message : String(error93)}`
+          message: `Invalid config: ${error96 instanceof Error ? error96.message : String(error96)}`
         }
       ],
       totalDurationMs: Date.now() - startTime,
@@ -50641,20 +51404,20 @@ async function handlePromoteCommand(directory, args) {
   if (lessonId) {
     try {
       return await promoteFromSwarm(directory, lessonId);
-    } catch (error93) {
-      if (error93 instanceof Error) {
-        return error93.message;
+    } catch (error96) {
+      if (error96 instanceof Error) {
+        return error96.message;
       }
-      return `Failed to promote lesson: ${error93 instanceof Error ? error93.message : String(error93)}`;
+      return `Failed to promote lesson: ${error96 instanceof Error ? error96.message : String(error96)}`;
     }
   }
   try {
     return await promoteToHive(directory, lessonText, category);
-  } catch (error93) {
-    if (error93 instanceof Error) {
-      return error93.message;
+  } catch (error96) {
+    if (error96 instanceof Error) {
+      return error96.message;
     }
-    return `Failed to promote lesson: ${error93 instanceof Error ? error93.message : String(error93)}`;
+    return `Failed to promote lesson: ${error96 instanceof Error ? error96.message : String(error96)}`;
   }
 }
 var init_promote = __esm(() => {
@@ -50823,8 +51586,8 @@ class CircuitBreaker {
   async execute(fn) {
     const state = this.getState();
     if (state === "open") {
-      const error93 = new Error(`Circuit breaker '${this.name}' is open`);
-      throw error93;
+      const error96 = new Error(`Circuit breaker '${this.name}' is open`);
+      throw error96;
     }
     const startTime = Date.now();
     try {
@@ -50832,10 +51595,10 @@ class CircuitBreaker {
       const duration5 = Date.now() - startTime;
       this.recordSuccess(duration5);
       return result;
-    } catch (error93) {
+    } catch (error96) {
       const duration5 = Date.now() - startTime;
-      this.recordFailure(error93, duration5);
-      throw error93;
+      this.recordFailure(error96, duration5);
+      throw error96;
     }
   }
   async executeWithTimeout(fn) {
@@ -50849,9 +51612,9 @@ class CircuitBreaker {
       fn().then((result) => {
         clearTimeout(timeout);
         resolve15(result);
-      }).catch((error93) => {
+      }).catch((error96) => {
         clearTimeout(timeout);
-        reject(error93);
+        reject(error96);
       });
     });
   }
@@ -50865,7 +51628,7 @@ class CircuitBreaker {
     }
     this.onStateChange?.("callSuccess", { duration: duration5 });
   }
-  recordFailure(error93, duration5) {
+  recordFailure(error96, duration5) {
     this.failureCount++;
     this.lastFailureTime = Date.now();
     if (this.state === "half-open") {
@@ -50873,7 +51636,7 @@ class CircuitBreaker {
     } else if (this.state === "closed" && this.failureCount >= this.config.failureThreshold) {
       this.transitionTo("open");
     }
-    this.onStateChange?.("callFailure", { error: error93, duration: duration5 });
+    this.onStateChange?.("callFailure", { error: error96, duration: duration5 });
   }
   transitionTo(newState) {
     const oldState = this.state;
@@ -51211,11 +51974,11 @@ class WorkerManager {
         });
       }
     };
-    processLoop().catch((error93) => {
+    processLoop().catch((error96) => {
       this.eventBus.publish("worker.error", {
         workerName: worker.name,
         itemId: "loop",
-        error: error93
+        error: error96
       });
     });
   }
@@ -51230,15 +51993,15 @@ class WorkerManager {
         worker.lastError = result.error;
         worker.queue.retry(item.id, result.error);
       }
-    } catch (error93) {
+    } catch (error96) {
       worker.errorCount++;
-      worker.lastError = error93;
+      worker.lastError = error96;
       this.eventBus.publish("worker.error", {
         workerName: worker.name,
         itemId: item.id,
-        error: error93
+        error: error96
       });
-      worker.queue.retry(item.id, error93);
+      worker.queue.retry(item.id, error96);
     }
   }
   stop(name) {
@@ -51650,8 +52413,8 @@ async function loadFullOutput(directory, id) {
     }
     warn(`Summary entry ${sanitizedId} missing valid fullOutput field`);
     return null;
-  } catch (error93) {
-    warn(`Summary entry validation failed for ${sanitizedId}: ${error93 instanceof Error ? error93.message : String(error93)}`);
+  } catch (error96) {
+    warn(`Summary entry validation failed for ${sanitizedId}: ${error96 instanceof Error ? error96.message : String(error96)}`);
     return null;
   }
 }
@@ -51688,10 +52451,10 @@ No stored output found for ID \`${summaryId}\`.
 Use a valid summary ID (e.g., S1, S2, S3).`;
     }
     return fullOutput;
-  } catch (error93) {
+  } catch (error96) {
     return `## Retrieve Failed
 
-${error93 instanceof Error ? error93.message : String(error93)}`;
+${error96 instanceof Error ? error96.message : String(error96)}`;
   }
 }
 var init_retrieve = __esm(() => {
@@ -51770,8 +52533,8 @@ async function handleRollbackCommand(directory, args) {
     try {
       fs26.cpSync(src, dest, { recursive: true, force: true });
       successes.push(file3);
-    } catch (error93) {
-      failures.push({ file: file3, error: error93.message });
+    } catch (error96) {
+      failures.push({ file: file3, error: error96.message });
     }
   }
   if (failures.length > 0) {
@@ -51821,8 +52584,8 @@ async function handleRollbackCommand(directory, args) {
   try {
     fs26.appendFileSync(eventsPath, `${JSON.stringify(rollbackEvent)}
 `);
-  } catch (error93) {
-    console.error("Failed to write rollback event:", error93 instanceof Error ? error93.message : String(error93));
+  } catch (error96) {
+    console.error("Failed to write rollback event:", error96 instanceof Error ? error96.message : String(error96));
   }
   return `Rolled back to phase ${targetPhase}: ${checkpoint2.label || "no label"}`;
 }
@@ -51977,8 +52740,8 @@ function readPersisted2(directory) {
       updatedAt: parsed.updatedAt ?? nowISO2(),
       sessions: parsed.sessions
     };
-  } catch (error93) {
-    const reason = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const reason = error96 instanceof Error ? error96.message : String(error96);
     markStateUnreadable2(directory, reason);
     return null;
   }
@@ -51997,16 +52760,16 @@ function writePersisted2(directory, persisted) {
     persisted.updatedAt = nowISO2();
     payload = `${JSON.stringify(persisted, null, 2)}
 `;
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     error(`[turbo/lean/state] Failed to prepare ${STATE_FILE2} write: ${msg}`);
     throw new Error(`Lean Turbo state persistence prepare failed: ${msg}`);
   }
   try {
     fs27.writeFileSync(tmpPath, payload, "utf-8");
     fs27.renameSync(tmpPath, filePath);
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     error(`[turbo/lean/state] Failed to persist ${STATE_FILE2} atomically: ${msg}`);
     try {
       if (fs27.existsSync(tmpPath)) {
@@ -52417,8 +53180,8 @@ async function handleTurboCommand(directory, args, sessionID) {
     if (isLeanActive) {
       try {
         pauseLeanTurboRun(directory, sessionID, reason);
-      } catch (error93) {
-        error(`[turbo] pauseLeanTurboRun failed: ${error93 instanceof Error ? error93.message : String(error93)}`);
+      } catch (error96) {
+        error(`[turbo] pauseLeanTurboRun failed: ${error96 instanceof Error ? error96.message : String(error96)}`);
       }
     }
     session.turboMode = false;
@@ -52453,8 +53216,8 @@ async function handleTurboCommand(directory, args, sessionID) {
       if (config3.turbo?.strategy === "lean") {
         strategy = "lean";
       }
-    } catch (error93) {
-      warn(`[turbo] could not read config for strategy default: ${error93 instanceof Error ? error93.message : String(error93)}`);
+    } catch (error96) {
+      warn(`[turbo] could not read config for strategy default: ${error96 instanceof Error ? error96.message : String(error96)}`);
     }
     if (strategy === "lean") {
       return enableLeanTurbo(session, directory, sessionID);
@@ -52510,16 +53273,16 @@ function enableLeanTurbo(session, directory, sessionID) {
       maxParallelCoders = leanConfig.max_parallel_coders ?? 4;
       conflictPolicy = leanConfig.conflict_policy ?? "serialize";
     }
-  } catch (error93) {
-    warn(`[turbo] could not read lean config: ${error93 instanceof Error ? error93.message : String(error93)}`);
+  } catch (error96) {
+    warn(`[turbo] could not read lean config: ${error96 instanceof Error ? error96.message : String(error96)}`);
   }
   let durableError;
   try {
     const state = emptyRunState(sessionID, maxParallelCoders);
     state.status = "running";
     saveLeanTurboRunState(directory, state);
-  } catch (error93) {
-    durableError = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    durableError = error96 instanceof Error ? error96.message : String(error96);
     error(`[turbo] durable run-state write failed: ${durableError}`);
   }
   if (durableError) {
@@ -53976,9 +54739,9 @@ function writeProjectConfigIfMissing(cwd) {
     ensureDir(opencodeDir);
     saveJson(projectConfigPath, { agents: {} });
     console.log("\u2713 Created project config at:", projectConfigPath);
-  } catch (error93) {
+  } catch (error96) {
     console.warn("\u26A0 Could not create project config \u2014 installation will continue:");
-    console.warn(`  ${error93 instanceof Error ? error93.message : String(error93)}`);
+    console.warn(`  ${error96 instanceof Error ? error96.message : String(error96)}`);
   }
 }
 async function install() {
@@ -54206,8 +54969,8 @@ async function uninstall() {
     console.log(`
 \u2705 Uninstall complete!`);
     return 0;
-  } catch (error93) {
-    console.log("\u2717 Uninstall failed: " + (error93 instanceof Error ? error93.message : String(error93)));
+  } catch (error96) {
+    console.log("\u2717 Uninstall failed: " + (error96 instanceof Error ? error96.message : String(error96)));
     return 1;
   }
 }

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -4,7 +4,6 @@ var __create = Object.create;
 var __getProtoOf = Object.getPrototypeOf;
 var __defProp = Object.defineProperty;
 var __getOwnPropNames = Object.getOwnPropertyNames;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
 function __accessProp(key) {
   return this[key];
@@ -31,23 +30,6 @@ var __toESM = (mod, isNodeMode, target) => {
     cache.set(mod, to);
   return to;
 };
-var __toCommonJS = (from) => {
-  var entry = (__moduleCache ??= new WeakMap).get(from), desc;
-  if (entry)
-    return entry;
-  entry = __defProp({}, "__esModule", { value: true });
-  if (from && typeof from === "object" || typeof from === "function") {
-    for (var key of __getOwnPropNames(from))
-      if (!__hasOwnProp.call(entry, key))
-        __defProp(entry, key, {
-          get: __accessProp.bind(from, key),
-          enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
-        });
-  }
-  __moduleCache.set(from, entry);
-  return entry;
-};
-var __moduleCache;
 var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 var __returnValue = (v) => v;
 function __exportSetter(name, newValue) {
@@ -21038,764 +21020,11 @@ var init_agents2 = __esm(() => {
     "thinking"
   ]);
 });
-// src/sandbox/capability-probe.ts
-var exports_capability_probe = {};
-__export(exports_capability_probe, {
-  isWindowsSandboxAvailable: () => isWindowsSandboxAvailable,
-  isSandboxExecAvailable: () => isSandboxExecAvailable,
-  isBubblewrapAvailable: () => isBubblewrapAvailable,
-  SandboxCapabilityProbe: () => SandboxCapabilityProbe
-});
-import { execFile } from "child_process";
-import * as os3 from "os";
-function withProbeTimeout(cmd, args, ms) {
-  return new Promise((resolve6, reject) => {
-    const controller = new AbortController;
-    const timer = setTimeout(() => {
-      controller.abort();
-      proc?.kill();
-    }, ms);
-    const unref = timer.unref;
-    if (typeof unref === "function") {
-      unref.call(timer);
-    }
-    let proc;
-    try {
-      proc = execFile(cmd, args, {
-        signal: controller.signal,
-        timeout: ms,
-        windowsHide: true,
-        cwd: os3.tmpdir()
-      }, (error49, stdout, _stderr) => {
-        clearTimeout(timer);
-        if (error49) {
-          const exc = error49;
-          if (exc.code === "ENOENT" || exc.code === "ENOTFOUND") {
-            reject(new Error("binary not found"));
-          } else {
-            reject(error49);
-          }
-          return;
-        }
-        resolve6(stdout?.trim() ?? "");
-      });
-    } catch (spawnError) {
-      clearTimeout(timer);
-      reject(spawnError);
-    }
-  });
-}
-async function probeLinux() {
-  try {
-    const output = await withProbeTimeout("bwrap", ["--version"], 2000);
-    if (output.length > 0) {
-      return {
-        status: "enabled",
-        mechanism: "Bubblewrap",
-        platform: "linux"
-      };
-    }
-    return {
-      status: "disabled",
-      mechanism: "Bubblewrap",
-      platform: "linux",
-      error: "binary returned empty version"
-    };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg === "binary not found") {
-      return {
-        status: "unsupported",
-        mechanism: "Bubblewrap",
-        platform: "linux",
-        error: msg
-      };
-    }
-    return {
-      status: "disabled",
-      mechanism: "Bubblewrap",
-      platform: "linux",
-      error: msg
-    };
-  }
-}
-async function probeMacOS() {
-  try {
-    const output = await withProbeTimeout("sandbox-exec", ["--version"], 2000);
-    if (output.length > 0) {
-      return {
-        status: "enabled",
-        mechanism: "sandbox-exec",
-        platform: "darwin"
-      };
-    }
-    return {
-      status: "disabled",
-      mechanism: "sandbox-exec",
-      platform: "darwin",
-      error: "binary returned empty version"
-    };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg === "binary not found") {
-      return {
-        status: "unsupported",
-        mechanism: "sandbox-exec",
-        platform: "darwin",
-        error: msg
-      };
-    }
-    return {
-      status: "disabled",
-      mechanism: "sandbox-exec",
-      platform: "darwin",
-      error: msg
-    };
-  }
-}
-function probeWindows() {
-  return {
-    status: "enabled",
-    mechanism: "Restricted Token",
-    platform: "win32"
-  };
-}
-function isBubblewrapAvailable() {
-  return _cached?.status === "enabled" && _cached?.platform === "linux";
-}
-function isSandboxExecAvailable() {
-  return _cached?.status === "enabled" && _cached?.platform === "darwin";
-}
-function isWindowsSandboxAvailable() {
-  return _cached?.status === "enabled" && _cached?.platform === "win32";
-}
-
-class SandboxCapabilityProbe {
-  async detect() {
-    if (_cached !== undefined) {
-      return _cached;
-    }
-    const platform = process.platform;
-    switch (platform) {
-      case "linux":
-        _cached = await probeLinux();
-        break;
-      case "darwin":
-        _cached = await probeMacOS();
-        break;
-      case "win32":
-        _cached = probeWindows();
-        break;
-      default:
-        _cached = {
-          status: "unsupported",
-          mechanism: "unknown",
-          platform,
-          error: `unsupported platform: ${platform}`
-        };
-    }
-    return _cached;
-  }
-}
-var _cached;
-var init_capability_probe = () => {};
-
-// src/sandbox/linux/bubblewrap-executor.ts
-import { spawnSync } from "child_process";
-function probeBwrap() {
-  try {
-    const result = spawnSync("bwrap", ["--version"], {
-      windowsHide: true,
-      encoding: "utf-8",
-      timeout: 5000,
-      stdio: ["ignore", "pipe", "ignore"]
-    });
-    if (result.error) {
-      const code = result.error.code;
-      if (code && BWRAP_UNAVAILABLE_CODES.has(code)) {
-        console.warn(`[bubblewrap] Sandbox disabled: bwrap error (${code}). Falling through to tool-layer enforcement.`);
-        return false;
-      }
-      console.warn(`[bubblewrap] Sandbox disabled: bwrap spawn error (${result.error.message}). Falling through to tool-layer enforcement.`);
-      return false;
-    }
-    return result.status === BWRAP_VERSION_EXIT && result.stdout.trim().length > 0;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.warn(`[bubblewrap] Sandbox disabled: probe threw (${message}). Falling through to tool-layer enforcement.`);
-    return false;
-  }
-}
-function shellEscape(s) {
-  return s.replace(/'/g, "'\\''");
-}
-
-class BubblewrapSandboxExecutor {
-  mechanism = "Bubblewrap";
-  _scopePaths;
-  _tempDir;
-  _available;
-  _disabledReason;
-  constructor(scopePaths, tempDir) {
-    this._scopePaths = scopePaths;
-    this._tempDir = tempDir;
-    this._available = false;
-    this._disabledReason = null;
-    try {
-      if (!_internals7.probeBwrap()) {
-        this._disabledReason = "bwrap not available or not functional";
-        console.warn(`[bubblewrap] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
-      } else {
-        this._available = true;
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this._disabledReason = `constructor threw: ${message}`;
-      this._available = false;
-      console.warn(`[bubblewrap] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
-    }
-  }
-  isAvailable() {
-    return this._available;
-  }
-  disable(reason) {
-    this._available = false;
-    this._disabledReason = reason;
-    console.warn(`[bubblewrap] Sandbox disabled: ${reason}. Falling through to tool-layer enforcement.`);
-  }
-  wrapCommand(command, scopePaths, tempDir) {
-    if (!this._available) {
-      return command;
-    }
-    if (!_internals7.probeBwrap()) {
-      this._available = false;
-      this._disabledReason = "bwrap became unavailable between calls";
-      console.warn(`[bubblewrap] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
-      return command;
-    }
-    const temp = tempDir ?? this._tempDir ?? "/tmp";
-    const allScopes = [...this._scopePaths, ...scopePaths];
-    const bindArgs = allScopes.flatMap((p) => ["--bind", p]);
-    const args = [
-      "--unshare-user",
-      "--unshare-net",
-      "--unshare-ipc",
-      "--die-with-parent",
-      "--new-session",
-      ...bindArgs,
-      "--tmpfs",
-      `${temp},size=500M`,
-      "--ro-bind",
-      "/etc",
-      "/etc",
-      "--ro-bind",
-      "/usr",
-      "/usr",
-      "--ro-bind",
-      "/lib",
-      "/lib",
-      "--ro-bind",
-      "/lib64",
-      "/lib64",
-      "--proc",
-      "/proc",
-      "--unshare-pid",
-      "--",
-      "bash",
-      "-c",
-      `'${shellEscape(command)}'`
-    ];
-    return `bwrap ${args.join(" ")}`;
-  }
-  getEnvOverrides() {
-    return {};
-  }
-}
-var BWRAP_VERSION_EXIT = 0, BWRAP_UNAVAILABLE_CODES, _internals7;
-var init_bubblewrap_executor = __esm(() => {
-  BWRAP_UNAVAILABLE_CODES = new Set(["ENOENT", "EACCES", "ENOSPC"]);
-  _internals7 = {
-    probeBwrap
-  };
-});
-
-// src/sandbox/executors/bubblewrap.ts
-var exports_bubblewrap = {};
-__export(exports_bubblewrap, {
-  BubblewrapSandboxExecutor: () => BubblewrapSandboxExecutor
-});
-var init_bubblewrap = __esm(() => {
-  init_bubblewrap_executor();
-});
-
-// src/sandbox/macos/sandbox-exec-executor.ts
-import { spawnSync as spawnSync2 } from "child_process";
-import { mkdtempSync, writeFileSync as writeFileSync3 } from "fs";
-import * as os4 from "os";
-import * as path8 from "path";
-function probeSandboxExec() {
-  try {
-    const result = spawnSync2("sandbox-exec", ["--version"], {
-      windowsHide: true,
-      encoding: "utf-8",
-      timeout: 5000,
-      stdio: ["ignore", "pipe", "ignore"]
-    });
-    if (result.error) {
-      const code = result.error.code;
-      if (code && SANDBOX_UNAVAILABLE_CODES.has(code)) {
-        console.warn(`[sandbox-exec] Sandbox disabled: sandbox-exec error (${code}). Falling through to tool-layer enforcement.`);
-        return false;
-      }
-      console.warn(`[sandbox-exec] Sandbox disabled: spawn error (${result.error.message}). Falling through to tool-layer enforcement.`);
-      return false;
-    }
-    return result.status === 0;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.warn(`[sandbox-exec] Sandbox disabled: probe threw (${message}). Falling through to tool-layer enforcement.`);
-    return false;
-  }
-}
-function shellEscape2(s) {
-  return s.replace(/'/g, "'\\''");
-}
-function buildSandboxProfile(scopePaths, tempDir) {
-  const rwPaths = [...scopePaths];
-  if (tempDir) {
-    rwPaths.push(tempDir);
-  }
-  const rwAllowLines = rwPaths.map((p) => `(allow file-write* (subpath "${p}"))`).join(`
-`);
-  const profile = `(version 1)
-(allow default)
-(allow file-read* (subpath "/usr"))
-(allow file-read* (subpath "/bin"))
-(allow file-read* (subpath "/sbin"))
-(allow file-read* (subpath "/lib"))
-(allow file-read* (subpath "/lib64"))
-${rwAllowLines}
-(deny file-write*)`;
-  return profile;
-}
-
-class MacOSSandboxExecutor {
-  mechanism = "sandbox-exec";
-  _scopePaths;
-  _tempDir;
-  _available;
-  _disabledReason;
-  constructor(scopePaths = [], tempDir) {
-    if (process.platform !== "darwin") {
-      throw new Error("MacOSSandboxExecutor not yet implemented");
-    }
-    this._scopePaths = scopePaths;
-    this._tempDir = tempDir;
-    this._available = false;
-    this._disabledReason = null;
-    try {
-      if (!_internals8.probeSandboxExec()) {
-        this._disabledReason = "sandbox-exec not available or not functional";
-        console.warn(`[sandbox-exec] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
-      } else {
-        this._available = true;
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this._disabledReason = `constructor threw: ${message}`;
-      this._available = false;
-      console.warn(`[sandbox-exec] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
-    }
-  }
-  isAvailable() {
-    return this._available;
-  }
-  disable(reason) {
-    this._available = false;
-    this._disabledReason = reason;
-    console.warn(`[sandbox-exec] Sandbox disabled: ${reason}. Falling through to tool-layer enforcement.`);
-  }
-  wrapCommand(command, scopePaths, tempDir) {
-    if (!this._available) {
-      return command;
-    }
-    if (!_internals8.probeSandboxExec()) {
-      this._available = false;
-      this._disabledReason = "sandbox-exec became unavailable between calls";
-      console.warn(`[sandbox-exec] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
-      return command;
-    }
-    const temp = tempDir ?? this._tempDir ?? os4.tmpdir();
-    const allScopes = [...this._scopePaths, ...scopePaths];
-    const profile = buildSandboxProfile(allScopes, temp);
-    let profilePath;
-    try {
-      const profileDir = mkdtempSync(path8.join(os4.tmpdir(), "sandbox-"));
-      profilePath = path8.join(profileDir, `profile-${process.pid}-${Date.now()}.sb`);
-      writeFileSync3(profilePath, profile, { mode: 384 });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.warn(`[sandbox-exec] Sandbox disabled: failed to write profile (${message}). Falling through to tool-layer enforcement.`);
-      return command;
-    }
-    const escapedCommand = shellEscape2(command);
-    const escapedProfilePath = shellEscape2(profilePath);
-    return `sandbox-exec -f '${escapedProfilePath}' bash -c '${escapedCommand}'`;
-  }
-  getEnvOverrides() {
-    return {
-      DYLD_INSERT_LIBRARIES: null,
-      DYLD_LIBRARY_PATH: null,
-      DYLD_FRAMEWORK_PATH: null,
-      DYLD_ROOT_PATH: null,
-      PATH: "/usr/bin:/bin:/usr/sbin:/sbin"
-    };
-  }
-}
-var SANDBOX_UNAVAILABLE_CODES, _internals8;
-var init_sandbox_exec_executor = __esm(() => {
-  SANDBOX_UNAVAILABLE_CODES = new Set(["ENOENT", "EACCES", "ENOSPC"]);
-  _internals8 = {
-    probeSandboxExec
-  };
-});
-
-// src/sandbox/executors/macos.ts
-var exports_macos = {};
-__export(exports_macos, {
-  MacOSSandboxExecutor: () => MacOSSandboxExecutor
-});
-var init_macos = __esm(() => {
-  init_sandbox_exec_executor();
-});
-
-// src/sandbox/win32/edge-cases.ts
-function detectPathTraversal(command) {
-  if (process.platform !== "win32")
-    return false;
-  if (/\.\.[\\/]/.test(command)) {
-    return true;
-  }
-  if (/\.\.\//.test(command)) {
-    return true;
-  }
-  if (/\\\\[?]\\[\\]/.test(command)) {
-    return true;
-  }
-  if (/[A-Z]:[\\/]?\.\./i.test(command)) {
-    return true;
-  }
-  if (/[\\/]{2,3}\.\./.test(command)) {
-    return true;
-  }
-  if (/\\\\[^\\]+[\\/]\.\./i.test(command)) {
-    return true;
-  }
-  return false;
-}
-function detectPowerShellEscape(command) {
-  if (process.platform !== "win32")
-    return false;
-  const encodedCommandPattern = /-EncodedCommand/i;
-  if (encodedCommandPattern.test(command)) {
-    return true;
-  }
-  const executionPolicyBypassPattern = /-ExecutionPolicy\s+Bypass/i;
-  if (executionPolicyBypassPattern.test(command)) {
-    return true;
-  }
-  const executionPolicyUnrestrictedPattern = /-ExecutionPolicy\s+Unrestricted/i;
-  if (executionPolicyUnrestrictedPattern.test(command)) {
-    return true;
-  }
-  const windowStyleHiddenPattern = /-WindowStyle\s+Hidden/i;
-  if (windowStyleHiddenPattern.test(command)) {
-    return true;
-  }
-  const noProfileCommandPattern = /-NoProfile.*-Command/i;
-  if (noProfileCommandPattern.test(command)) {
-    return true;
-  }
-  const envVarCommandPattern = /-Command.*\$env:/i;
-  if (envVarCommandPattern.test(command)) {
-    return true;
-  }
-  const psVarPattern = /\$\w+:/i;
-  if (psVarPattern.test(command)) {
-    return true;
-  }
-  const powershellCommandPattern = /powershell(?:\.exe)?\s+-[c]\s+.+/i;
-  if (powershellCommandPattern.test(command)) {
-    if (detectPathTraversal(command)) {
-      return true;
-    }
-  }
-  const scopeBypassPattern = /-Scope\s+LocalMachine/i;
-  if (scopeBypassPattern.test(command)) {
-    return true;
-  }
-  const iexPattern = /Invoke-Expression\s+/i;
-  if (iexPattern.test(command)) {
-    return true;
-  }
-  return false;
-}
-
-// src/sandbox/win32/restricted-token-executor.ts
-import { spawnSync as spawnSync3 } from "child_process";
-import * as os5 from "os";
-function probeWindowsSandbox() {
-  try {
-    const result = spawnSync3("cmd", ["/c", "echo", "ok"], {
-      windowsHide: true,
-      encoding: "utf-8",
-      timeout: 5000,
-      stdio: ["ignore", "pipe", "ignore"]
-    });
-    if (result.error) {
-      const code = result.error.code;
-      if (code && SANDBOX_UNAVAILABLE_CODES2.has(code)) {
-        console.warn(`[restricted-token] Sandbox disabled: spawn error (${code}). Falling through to tool-layer enforcement.`);
-        return false;
-      }
-      console.warn(`[restricted-token] Sandbox disabled: spawn error (${result.error.message}). Falling through to tool-layer enforcement.`);
-      return false;
-    }
-    return result.status === 0;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.warn(`[restricted-token] Sandbox disabled: probe threw (${message}). Falling through to tool-layer enforcement.`);
-    return false;
-  }
-}
-function psStringEscape(s) {
-  return s.replace(/[`"$]/g, "`$&");
-}
-function isPathInScopes(command, scopes) {
-  if (scopes.length === 0)
-    return true;
-  const pathPattern = /[A-Za-z]:(?:[^\\/:*?"<>|\r\n]+(?:\\[^\\/:*?"<>|\r\n]+)*)/g;
-  const paths = command.match(pathPattern) || [];
-  if (paths.length === 0)
-    return true;
-  const normalizedScopes = scopes.map((s) => s.toLowerCase().replace(/\\+$/, ""));
-  return paths.every((p) => {
-    const lower = p.toLowerCase();
-    return normalizedScopes.some((scope) => lower.startsWith(scope));
-  });
-}
-
-class WindowsSandboxExecutor {
-  mechanism = "restricted-token";
-  _scopePaths;
-  _tempDir;
-  _available;
-  _disabled;
-  _disabledReason;
-  constructor(scopePaths = [], tempDir) {
-    if (process.platform !== "win32") {
-      throw new Error("WindowsSandboxExecutor not yet implemented");
-    }
-    this._scopePaths = scopePaths;
-    this._tempDir = tempDir;
-    this._available = false;
-    this._disabled = false;
-    this._disabledReason = null;
-    try {
-      if (!_internals9.probeWindowsSandbox()) {
-        this._available = false;
-        this._disabledReason = "Windows sandbox not available or not functional";
-        console.warn(`[restricted-token] Sandbox unavailable: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
-      } else {
-        this._available = true;
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this._available = false;
-      this._disabledReason = `constructor probe threw: ${message}`;
-      console.warn(`[restricted-token] Sandbox unavailable: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
-    }
-  }
-  isAvailable() {
-    return this._available && !this._disabled;
-  }
-  disable(reason) {
-    this._disabled = true;
-    this._disabledReason = reason;
-    console.warn(`[restricted-token] Sandbox disabled: ${reason}. Falling through to tool-layer enforcement.`);
-  }
-  wrapCommand(command, scopePaths, tempDir) {
-    if (!this.isAvailable()) {
-      return command;
-    }
-    if (!_internals9.probeWindowsSandbox()) {
-      this._available = false;
-      this._disabledReason = "Windows sandbox became unavailable between calls";
-      console.warn(`[restricted-token] Sandbox disabled: ${this._disabledReason}. Falling through to tool-layer enforcement.`);
-      return command;
-    }
-    const temp = tempDir ?? this._tempDir ?? os5.tmpdir();
-    const _allScopes = [...this._scopePaths, ...scopePaths];
-    if (detectPowerShellEscape(command)) {
-      throw new SandboxError("Command contains PowerShell escape patterns", "DETECT_POWERSHELL_ESCAPE");
-    }
-    if (!isPathInScopes(command, _allScopes)) {
-      throw new SandboxError("Command targets paths outside authorized scopes", "PATH_ESCAPE_SCOPE");
-    }
-    const safePath = "C:\\Windows\\System32;C:\\Windows";
-    const escapedTemp = psStringEscape(temp);
-    const escapedCommand = psStringEscape(command);
-    const psScript = `
-$ErrorActionPreference = 'Stop';
-try {
-  # Set scoped temp directory
-  $env:TEMP = '${escapedTemp}';
-  $env:TMP = '${escapedTemp}';
-
-  # Restrict PATH to safe system paths only
-  $env:PATH = '${safePath}';
-
-  # Remove dangerous environment variables that could be used to bypass restrictions
-  # Note: LD_PRELOAD, DYLD_* don't apply on Windows but we clear them for completeness
-  $dangerousVars = @(
-    'LD_PRELOAD',
-    'DYLD_INSERT_LIBRARIES',
-    'DYLD_LIBRARY_PATH',
-    'DYLD_FRAMEWORK_PATH',
-    'DYLD_ROOT_PATH',
-    'DYLD_FORCE_FLAT_NAMESPACE'
-  );
-  foreach ($v in $dangerousVars) {
-    if (Test-Path Env:\\$v) {
-      Remove-Item Env:\\$v -Force -ErrorAction SilentlyContinue;
-    }
-  }
-
-  # Execute the command via cmd /c
-  cmd /c "${escapedCommand}";
-} catch {
-  Write-Error $_.Exception.Message;
-  exit 1;
-}`;
-    return `powershell -ExecutionPolicy Bypass -NoProfile -WindowStyle Hidden -Command "${psScript.replace(/\n/g, " ").trim()}"`;
-  }
-  getEnvOverrides() {
-    return {
-      PATH: "C:\\Windows\\System32;C:\\Windows",
-      TEMP: null,
-      TMP: null,
-      LD_PRELOAD: null,
-      DYLD_INSERT_LIBRARIES: null,
-      DYLD_LIBRARY_PATH: null,
-      DYLD_FRAMEWORK_PATH: null,
-      DYLD_ROOT_PATH: null,
-      DYLD_FORCE_FLAT_NAMESPACE: null
-    };
-  }
-}
-var SANDBOX_UNAVAILABLE_CODES2, _internals9;
-var init_restricted_token_executor = __esm(() => {
-  init_executor();
-  SANDBOX_UNAVAILABLE_CODES2 = new Set([
-    "ENOENT",
-    "EACCES",
-    "EPERM",
-    "ENOSPC"
-  ]);
-  _internals9 = {
-    probeWindowsSandbox
-  };
-});
-
-// src/sandbox/executors/windows.ts
-var exports_windows = {};
-__export(exports_windows, {
-  WindowsSandboxExecutor: () => WindowsSandboxExecutor
-});
-var init_windows = __esm(() => {
-  init_restricted_token_executor();
-});
-
-// src/sandbox/executor.ts
-async function getExecutor() {
-  if (_cachedExecutorPromise !== undefined) {
-    return _cachedExecutorPromise;
-  }
-  _cachedExecutorPromise = _createExecutor();
-  return _cachedExecutorPromise;
-}
-async function _createExecutor() {
-  const platform = process.platform;
-  if (platform === "linux") {
-    return _createLinuxExecutor();
-  }
-  if (platform === "darwin") {
-    return _createMacOSExecutor();
-  }
-  if (platform === "win32") {
-    return _createWindowsExecutor();
-  }
-  return null;
-}
-async function _createLinuxExecutor() {
-  const { SandboxCapabilityProbe: SandboxCapabilityProbe2, isBubblewrapAvailable: isBubblewrapAvailable2 } = await Promise.resolve().then(() => (init_capability_probe(), exports_capability_probe));
-  await new SandboxCapabilityProbe2().detect();
-  if (!isBubblewrapAvailable2()) {
-    return null;
-  }
-  try {
-    const { BubblewrapSandboxExecutor: BubblewrapSandboxExecutor2 } = (init_bubblewrap(), __toCommonJS(exports_bubblewrap));
-    return new BubblewrapSandboxExecutor2;
-  } catch {
-    return null;
-  }
-}
-async function _createMacOSExecutor() {
-  const { SandboxCapabilityProbe: SandboxCapabilityProbe2, isSandboxExecAvailable: isSandboxExecAvailable2 } = await Promise.resolve().then(() => (init_capability_probe(), exports_capability_probe));
-  await new SandboxCapabilityProbe2().detect();
-  if (!isSandboxExecAvailable2()) {
-    return null;
-  }
-  try {
-    const { MacOSSandboxExecutor: MacOSSandboxExecutor2 } = (init_macos(), __toCommonJS(exports_macos));
-    return new MacOSSandboxExecutor2;
-  } catch {
-    return null;
-  }
-}
-async function _createWindowsExecutor() {
-  const { SandboxCapabilityProbe: SandboxCapabilityProbe2, isWindowsSandboxAvailable: isWindowsSandboxAvailable2 } = await Promise.resolve().then(() => (init_capability_probe(), exports_capability_probe));
-  await new SandboxCapabilityProbe2().detect();
-  if (!isWindowsSandboxAvailable2()) {
-    return null;
-  }
-  try {
-    const { WindowsSandboxExecutor: WindowsSandboxExecutor2 } = (init_windows(), __toCommonJS(exports_windows));
-    return new WindowsSandboxExecutor2;
-  } catch {
-    return null;
-  }
-}
-var SandboxError, _cachedExecutorPromise;
-var init_executor = __esm(() => {
-  SandboxError = class SandboxError extends Error {
-    code;
-    constructor(message, code) {
-      super(message);
-      this.code = code;
-      this.name = "SandboxError";
-    }
-  };
-});
-
-// src/sandbox/scope-resolver.ts
-var init_scope_resolver = () => {};
-
 // src/scope/scope-persistence.ts
 import * as fs5 from "fs";
-import * as path9 from "path";
+import * as path8 from "path";
 function getScopesDir(directory) {
-  return path9.join(directory, SCOPES_DIR);
+  return path8.join(directory, SCOPES_DIR);
 }
 function clearAllScopes(directory) {
   try {
@@ -21973,8 +21202,6 @@ var init_guardrails = __esm(() => {
   init_constants();
   init_schema();
   init_manager();
-  init_executor();
-  init_scope_resolver();
   init_scope_persistence();
   init_state();
   init_telemetry();
@@ -22758,10 +21985,10 @@ function mergeDefs2(...defs) {
 function cloneDef2(schema) {
   return mergeDefs2(schema._zod.def);
 }
-function getElementAtPath2(obj, path10) {
-  if (!path10)
+function getElementAtPath2(obj, path9) {
+  if (!path9)
     return obj;
-  return path10.reduce((acc, key) => acc?.[key], obj);
+  return path9.reduce((acc, key) => acc?.[key], obj);
 }
 function promiseAllObject2(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -23050,11 +22277,11 @@ function aborted2(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues2(path10, issues) {
+function prefixIssues2(path9, issues) {
   return issues.map((iss) => {
     var _a2;
     (_a2 = iss).path ?? (_a2.path = []);
-    iss.path.unshift(path10);
+    iss.path.unshift(path9);
     return iss;
   });
 }
@@ -23277,7 +22504,7 @@ function treeifyError2(error49, _mapper) {
     return issue3.message;
   };
   const result = { errors: [] };
-  const processError = (error50, path10 = []) => {
+  const processError = (error50, path9 = []) => {
     var _a2, _b;
     for (const issue3 of error50.issues) {
       if (issue3.code === "invalid_union" && issue3.errors.length) {
@@ -23287,7 +22514,7 @@ function treeifyError2(error49, _mapper) {
       } else if (issue3.code === "invalid_element") {
         processError({ issues: issue3.issues }, issue3.path);
       } else {
-        const fullpath = [...path10, ...issue3.path];
+        const fullpath = [...path9, ...issue3.path];
         if (fullpath.length === 0) {
           result.errors.push(mapper(issue3));
           continue;
@@ -23319,8 +22546,8 @@ function treeifyError2(error49, _mapper) {
 }
 function toDotPath2(_path) {
   const segs = [];
-  const path10 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
-  for (const seg of path10) {
+  const path9 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
+  for (const seg of path9) {
     if (typeof seg === "number")
       segs.push(`[${seg}]`);
     else if (typeof seg === "symbol")
@@ -33279,7 +32506,7 @@ class JSONSchemaGenerator2 {
     const flattenRef = (zodSchema, params2) => {
       const seen = this.seen.get(zodSchema);
       const schema2 = seen.def ?? seen.schema;
-      const _cached2 = { ...schema2 };
+      const _cached = { ...schema2 };
       if (seen.ref === null) {
         return;
       }
@@ -33293,7 +32520,7 @@ class JSONSchemaGenerator2 {
           schema2.allOf.push(refSchema);
         } else {
           Object.assign(schema2, refSchema);
-          Object.assign(schema2, _cached2);
+          Object.assign(schema2, _cached);
         }
       }
       if (!seen.isParent)
@@ -35222,7 +34449,7 @@ var init_create_tool = __esm(() => {
 // src/tools/checkpoint.ts
 import * as child_process from "child_process";
 import * as fs6 from "fs";
-import * as path10 from "path";
+import * as path9 from "path";
 function containsNonAsciiChars(label) {
   for (let i = 0;i < label.length; i++) {
     const charCode = label.charCodeAt(i);
@@ -35266,7 +34493,7 @@ function validateLabel(label) {
   return null;
 }
 function getCheckpointLogPath(directory) {
-  return path10.join(directory, CHECKPOINT_LOG_PATH);
+  return path9.join(directory, CHECKPOINT_LOG_PATH);
 }
 function readCheckpointLog(directory) {
   const logPath = getCheckpointLogPath(directory);
@@ -35284,7 +34511,7 @@ function readCheckpointLog(directory) {
 }
 function writeCheckpointLog(log2, directory) {
   const logPath = getCheckpointLogPath(directory);
-  const dir = path10.dirname(logPath);
+  const dir = path9.dirname(logPath);
   if (!fs6.existsSync(dir)) {
     fs6.mkdirSync(dir, { recursive: true });
   }
@@ -35306,7 +34533,7 @@ function gitExec(args) {
 }
 function appendRetentionEvent(directory, event) {
   try {
-    const eventsPath = path10.join(directory, ".swarm", "events.jsonl");
+    const eventsPath = path9.join(directory, ".swarm", "events.jsonl");
     const line = `${JSON.stringify({ ...event, timestamp: new Date().toISOString() })}
 `;
     fs6.appendFileSync(eventsPath, line);
@@ -35745,7 +34972,7 @@ function resetToRemoteBranch(cwd, options) {
   const prunedBranches = [];
   try {
     const currentBranch = getCurrentBranch(cwd);
-    const defaultRemoteBranch = _internals10.detectDefaultRemoteBranch(cwd);
+    const defaultRemoteBranch = _internals7.detectDefaultRemoteBranch(cwd);
     if (!defaultRemoteBranch) {
       return {
         success: false,
@@ -35927,7 +35154,7 @@ function resetToRemoteBranch(cwd, options) {
 function resetToMainAfterMerge(cwd, options) {
   const warnings = [];
   try {
-    const defaultBranch = _internals10.detectDefaultRemoteBranch(cwd);
+    const defaultBranch = _internals7.detectDefaultRemoteBranch(cwd);
     if (!defaultBranch) {
       return {
         success: false,
@@ -35954,7 +35181,7 @@ function resetToMainAfterMerge(cwd, options) {
     }
     if (currentBranch === defaultBranch) {
       try {
-        const logOutput = _internals10.gitExec(["log", `${targetBranch}..HEAD`, "--oneline"], cwd);
+        const logOutput = _internals7.gitExec(["log", `${targetBranch}..HEAD`, "--oneline"], cwd);
         if (logOutput.trim().length > 0) {
           return {
             success: false,
@@ -35969,11 +35196,11 @@ function resetToMainAfterMerge(cwd, options) {
       } catch {}
     } else {
       try {
-        _internals10.gitExec(["rev-parse", "--abbrev-ref", `${currentBranch}@{upstream}`], cwd);
+        _internals7.gitExec(["rev-parse", "--abbrev-ref", `${currentBranch}@{upstream}`], cwd);
       } catch {
         try {
-          const localSha = _internals10.gitExec(["rev-parse", "HEAD"], cwd).trim();
-          const remoteSha = _internals10.gitExec(["rev-parse", targetBranch], cwd).trim();
+          const localSha = _internals7.gitExec(["rev-parse", "HEAD"], cwd).trim();
+          const remoteSha = _internals7.gitExec(["rev-parse", targetBranch], cwd).trim();
           if (localSha !== remoteSha) {
             return {
               success: false,
@@ -35999,7 +35226,7 @@ function resetToMainAfterMerge(cwd, options) {
       }
     }
     try {
-      _internals10.gitExec(["fetch", "--prune", "origin"], cwd);
+      _internals7.gitExec(["fetch", "--prune", "origin"], cwd);
     } catch (err) {
       return {
         success: false,
@@ -36015,7 +35242,7 @@ function resetToMainAfterMerge(cwd, options) {
     let switchedBranch = false;
     if (currentBranch !== defaultBranch) {
       try {
-        _internals10.gitExec(["checkout", defaultBranch], cwd);
+        _internals7.gitExec(["checkout", defaultBranch], cwd);
         switchedBranch = true;
       } catch (err) {
         return {
@@ -36030,7 +35257,7 @@ function resetToMainAfterMerge(cwd, options) {
       }
     }
     try {
-      _internals10.gitExec(["reset", "--hard", targetBranch], cwd);
+      _internals7.gitExec(["reset", "--hard", targetBranch], cwd);
     } catch (err) {
       return {
         success: false,
@@ -36051,7 +35278,7 @@ function resetToMainAfterMerge(cwd, options) {
           while (Date.now() < endTime) {}
         }
         try {
-          _internals10.gitExec(["checkout", "--", "."], cwd);
+          _internals7.gitExec(["checkout", "--", "."], cwd);
           discardSucceeded = true;
           break;
         } catch {}
@@ -36062,18 +35289,18 @@ function resetToMainAfterMerge(cwd, options) {
       changesDiscarded = discardSucceeded;
     }
     try {
-      _internals10.gitExec(["clean", "-fd"], cwd);
+      _internals7.gitExec(["clean", "-fd"], cwd);
     } catch {
       warnings.push("Could not clean untracked files");
     }
     let branchDeleted = false;
     if (switchedBranch && previousBranch !== defaultBranch) {
       try {
-        const mergedOutput = _internals10.gitExec(["branch", "--merged", defaultBranch], cwd);
+        const mergedOutput = _internals7.gitExec(["branch", "--merged", defaultBranch], cwd);
         const isMerged = mergedOutput.split(`
 `).some((line) => line.trim() === previousBranch || line.trim() === `* ${previousBranch}`);
         if (isMerged) {
-          _internals10.gitExec(["branch", "-d", previousBranch], cwd);
+          _internals7.gitExec(["branch", "-d", previousBranch], cwd);
           branchDeleted = true;
         } else {
           warnings.push(`Branch ${previousBranch} is not merged into ${defaultBranch} \u2014 keeping it`);
@@ -36084,7 +35311,7 @@ function resetToMainAfterMerge(cwd, options) {
     }
     if (options?.pruneBranches) {
       try {
-        const mergedOutput = _internals10.gitExec(["branch", "--merged", defaultBranch], cwd);
+        const mergedOutput = _internals7.gitExec(["branch", "--merged", defaultBranch], cwd);
         const mergedLines = mergedOutput.split(`
 `);
         for (const line of mergedLines) {
@@ -36093,7 +35320,7 @@ function resetToMainAfterMerge(cwd, options) {
             continue;
           }
           try {
-            _internals10.gitExec(["branch", "-d", trimmedLine], cwd);
+            _internals7.gitExec(["branch", "-d", trimmedLine], cwd);
           } catch {
             warnings.push(`Could not prune branch: ${trimmedLine}`);
           }
@@ -36123,10 +35350,10 @@ function resetToMainAfterMerge(cwd, options) {
     };
   }
 }
-var GIT_TIMEOUT_MS2 = 30000, _internals10;
+var GIT_TIMEOUT_MS2 = 30000, _internals7;
 var init_branch = __esm(() => {
   init_logger();
-  _internals10 = {
+  _internals7 = {
     gitExec: gitExec2,
     detectDefaultRemoteBranch,
     getDefaultBaseBranch,
@@ -36208,33 +35435,33 @@ var init_event_bus = __esm(() => {
 // src/hooks/knowledge-store.ts
 import { existsSync as existsSync7 } from "fs";
 import { appendFile as appendFile2, mkdir as mkdir2, readFile as readFile3, writeFile as writeFile3 } from "fs/promises";
-import * as os6 from "os";
-import * as path11 from "path";
+import * as os3 from "os";
+import * as path10 from "path";
 function resolveSwarmKnowledgePath(directory) {
-  return path11.join(directory, ".swarm", "knowledge.jsonl");
+  return path10.join(directory, ".swarm", "knowledge.jsonl");
 }
 function resolveSwarmRejectedPath(directory) {
-  return path11.join(directory, ".swarm", "knowledge-rejected.jsonl");
+  return path10.join(directory, ".swarm", "knowledge-rejected.jsonl");
 }
 function resolveSwarmRetractionsPath(directory) {
-  return path11.join(directory, ".swarm", "knowledge-retractions.jsonl");
+  return path10.join(directory, ".swarm", "knowledge-retractions.jsonl");
 }
 function resolveHiveKnowledgePath() {
   const platform = process.platform;
-  const home = process.env.HOME || os6.homedir();
+  const home = process.env.HOME || os3.homedir();
   let dataDir;
   if (platform === "win32") {
-    dataDir = path11.join(process.env.LOCALAPPDATA || path11.join(home, "AppData", "Local"), "opencode-swarm", "Data");
+    dataDir = path10.join(process.env.LOCALAPPDATA || path10.join(home, "AppData", "Local"), "opencode-swarm", "Data");
   } else if (platform === "darwin") {
-    dataDir = path11.join(home, "Library", "Application Support", "opencode-swarm");
+    dataDir = path10.join(home, "Library", "Application Support", "opencode-swarm");
   } else {
-    dataDir = path11.join(process.env.XDG_DATA_HOME || path11.join(home, ".local", "share"), "opencode-swarm");
+    dataDir = path10.join(process.env.XDG_DATA_HOME || path10.join(home, ".local", "share"), "opencode-swarm");
   }
-  return path11.join(dataDir, "shared-learnings.jsonl");
+  return path10.join(dataDir, "shared-learnings.jsonl");
 }
 function resolveHiveRejectedPath() {
   const hivePath = resolveHiveKnowledgePath();
-  return path11.join(path11.dirname(hivePath), "shared-learnings-rejected.jsonl");
+  return path10.join(path10.dirname(hivePath), "shared-learnings-rejected.jsonl");
 }
 async function readKnowledge(filePath) {
   if (!existsSync7(filePath))
@@ -36324,12 +35551,12 @@ async function appendRetractionRecord(directory, record3) {
   await appendKnowledge(resolveSwarmRetractionsPath(directory), record3);
 }
 async function appendKnowledge(filePath, entry) {
-  await mkdir2(path11.dirname(filePath), { recursive: true });
+  await mkdir2(path10.dirname(filePath), { recursive: true });
   await appendFile2(filePath, `${JSON.stringify(entry)}
 `, "utf-8");
 }
 async function rewriteKnowledge(filePath, entries) {
-  const dir = path11.dirname(filePath);
+  const dir = path10.dirname(filePath);
   await mkdir2(dir, { recursive: true });
   let release = null;
   try {
@@ -36443,7 +35670,7 @@ var init_knowledge_store = __esm(() => {
 
 // src/hooks/knowledge-validator.ts
 import { appendFile as appendFile3, mkdir as mkdir3, writeFile as writeFile4 } from "fs/promises";
-import * as path12 from "path";
+import * as path11 from "path";
 function normalizeText(text) {
   return text.normalize("NFKC").toLowerCase().replace(/[^\w\s]/g, " ").replace(/\s+/g, " ").trim();
 }
@@ -36589,7 +35816,7 @@ function validateSkillPath(p) {
     return false;
   if (p.includes("\x00"))
     return false;
-  if (path12.isAbsolute(p))
+  if (path11.isAbsolute(p))
     return false;
   if (p.includes(".."))
     return false;
@@ -36611,10 +35838,10 @@ async function quarantineEntry(directory, entryId, reason, reportedBy) {
     return;
   }
   const sanitizedReason = reason.slice(0, 500).replace(/[\x00-\x08\x0b-\x0c\x0e-\x1f\x7f\x0d]/g, "");
-  const knowledgePath = path12.join(directory, ".swarm", "knowledge.jsonl");
-  const quarantinePath = path12.join(directory, ".swarm", "knowledge-quarantined.jsonl");
-  const rejectedPath = path12.join(directory, ".swarm", "knowledge-rejected.jsonl");
-  const swarmDir = path12.join(directory, ".swarm");
+  const knowledgePath = path11.join(directory, ".swarm", "knowledge.jsonl");
+  const quarantinePath = path11.join(directory, ".swarm", "knowledge-quarantined.jsonl");
+  const rejectedPath = path11.join(directory, ".swarm", "knowledge-rejected.jsonl");
+  const swarmDir = path11.join(directory, ".swarm");
   await mkdir3(swarmDir, { recursive: true });
   let release;
   try {
@@ -36673,10 +35900,10 @@ async function restoreEntry(directory, entryId) {
     warn("[knowledge-validator] restoreEntry: invalid entryId rejected");
     return;
   }
-  const knowledgePath = path12.join(directory, ".swarm", "knowledge.jsonl");
-  const quarantinePath = path12.join(directory, ".swarm", "knowledge-quarantined.jsonl");
-  const rejectedPath = path12.join(directory, ".swarm", "knowledge-rejected.jsonl");
-  const swarmDir = path12.join(directory, ".swarm");
+  const knowledgePath = path11.join(directory, ".swarm", "knowledge.jsonl");
+  const quarantinePath = path11.join(directory, ".swarm", "knowledge-quarantined.jsonl");
+  const rejectedPath = path11.join(directory, ".swarm", "knowledge-rejected.jsonl");
+  const swarmDir = path11.join(directory, ".swarm");
   await mkdir3(swarmDir, { recursive: true });
   let release;
   try {
@@ -36857,7 +36084,7 @@ var init_curator = __esm(() => {
 });
 
 // src/hooks/hive-promoter.ts
-import path13 from "path";
+import path12 from "path";
 function isAlreadyInHive(entry, hiveEntries, threshold) {
   return findNearDuplicate(entry.lesson, hiveEntries, threshold) !== undefined;
 }
@@ -37032,7 +36259,7 @@ async function promoteToHive(directory, lesson, category) {
     schema_version: 1,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
-    source_project: path13.basename(directory) || "unknown",
+    source_project: path12.basename(directory) || "unknown",
     encounter_score: 1
   };
   await appendKnowledge(resolveHiveKnowledgePath(), newHiveEntry);
@@ -37320,7 +36547,7 @@ async function curateAndStoreSwarm(lessons, projectName, phaseInfo, directory, c
     existingEntries.push(entry);
   }
   await enforceKnowledgeCap(knowledgePath, config3.swarm_max_entries);
-  await _internals11.runAutoPromotion(directory, config3);
+  await _internals8.runAutoPromotion(directory, config3);
   return { stored, skipped, rejected };
 }
 async function runAutoPromotion(directory, config3) {
@@ -37401,7 +36628,7 @@ function createKnowledgeCuratorHook(directory, config3) {
       });
       const projectName2 = evidenceData.project_name ?? "unknown";
       const phaseNumber2 = typeof evidenceData.phase_number === "number" ? evidenceData.phase_number : 1;
-      await _internals11.curateAndStoreSwarm(lessons, projectName2, { phase_number: phaseNumber2 }, directory, config3);
+      await _internals8.curateAndStoreSwarm(lessons, projectName2, { phase_number: phaseNumber2 }, directory, config3);
       return;
     }
     const planContent = await readSwarmFileAsync(directory, "plan.md");
@@ -37423,17 +36650,17 @@ function createKnowledgeCuratorHook(directory, config3) {
     const projectName = projectNameMatch ? projectNameMatch[1].trim() : "unknown";
     const phaseMatch = /^Phase:\s*(\d+)/m.exec(planContent);
     const phaseNumber = phaseMatch ? parseInt(phaseMatch[1], 10) : 1;
-    await _internals11.curateAndStoreSwarm(normalLessons, projectName, { phase_number: phaseNumber }, directory, config3);
+    await _internals8.curateAndStoreSwarm(normalLessons, projectName, { phase_number: phaseNumber }, directory, config3);
   };
   return safeHook(handler);
 }
-var seenRetroSections, _internals11;
+var seenRetroSections, _internals8;
 var init_knowledge_curator = __esm(() => {
   init_knowledge_store();
   init_knowledge_validator();
   init_utils2();
   seenRetroSections = new Map;
-  _internals11 = {
+  _internals8 = {
     isWriteToEvidenceFile,
     curateAndStoreSwarm,
     runAutoPromotion,
@@ -37553,7 +36780,7 @@ var init_skill_improver_llm_factory = __esm(() => {
 // src/services/skill-generator.ts
 import { existsSync as existsSync8 } from "fs";
 import { mkdir as mkdir4, readFile as readFile4, rename as rename3, writeFile as writeFile5 } from "fs/promises";
-import * as path14 from "path";
+import * as path13 from "path";
 function sanitizeSlug(input) {
   const lc = input.toLowerCase().trim();
   const mapped = lc.replace(/[^a-z0-9-]+/g, "-").replace(/-+/g, "-");
@@ -37564,10 +36791,10 @@ function isValidSlug(slug) {
   return SLUG_PATTERN.test(slug);
 }
 function proposalPath(directory, slug) {
-  return path14.join(directory, ".swarm", "skills", "proposals", `${slug}.md`);
+  return path13.join(directory, ".swarm", "skills", "proposals", `${slug}.md`);
 }
 function activePath(directory, slug) {
-  return path14.join(directory, ".opencode", "skills", "generated", slug, "SKILL.md");
+  return path13.join(directory, ".opencode", "skills", "generated", slug, "SKILL.md");
 }
 function activeRepoRelativePath(slug) {
   return `.opencode/skills/generated/${slug}/SKILL.md`;
@@ -37723,7 +36950,7 @@ function escapeMarkdown(s) {
   return s.replace(/[\r\n]+/g, " ").slice(0, 280);
 }
 async function atomicWrite(p, content) {
-  await mkdir4(path14.dirname(p), { recursive: true });
+  await mkdir4(path13.dirname(p), { recursive: true });
   const tmp = `${p}.tmp-${process.pid}-${Date.now()}`;
   await writeFile5(tmp, content, "utf-8");
   await rename3(tmp, p);
@@ -37768,7 +36995,7 @@ async function generateSkills(req) {
       continue;
     }
     const targetPath = req.mode === "active" ? activePath(req.directory, cluster.slug) : proposalPath(req.directory, cluster.slug);
-    const repoRel = path14.relative(req.directory, targetPath).replace(/\\/g, "/");
+    const repoRel = path13.relative(req.directory, targetPath).replace(/\\/g, "/");
     if (!validateSkillPath(repoRel)) {
       result.skipped.push({
         slug: cluster.slug,
@@ -37842,8 +37069,8 @@ async function listSkills(directory) {
     proposals: [],
     active: []
   };
-  const proposalsDir = path14.join(directory, ".swarm", "skills", "proposals");
-  const activeDir = path14.join(directory, ".opencode", "skills", "generated");
+  const proposalsDir = path13.join(directory, ".swarm", "skills", "proposals");
+  const activeDir = path13.join(directory, ".opencode", "skills", "generated");
   const fs7 = await import("fs/promises");
   if (existsSync8(proposalsDir)) {
     const entries = await fs7.readdir(proposalsDir);
@@ -37853,7 +37080,7 @@ async function listSkills(directory) {
       const slug = f.replace(/\.md$/, "");
       result.proposals.push({
         slug,
-        path: path14.join(proposalsDir, f)
+        path: path13.join(proposalsDir, f)
       });
     }
   }
@@ -37862,7 +37089,7 @@ async function listSkills(directory) {
     for (const e of entries) {
       if (!e.isDirectory())
         continue;
-      const skillPath = path14.join(activeDir, e.name, "SKILL.md");
+      const skillPath = path13.join(activeDir, e.name, "SKILL.md");
       if (existsSync8(skillPath)) {
         result.active.push({
           slug: e.name,
@@ -37884,7 +37111,7 @@ var init_skill_generator = __esm(() => {
 // src/services/skill-improver-quota.ts
 import { existsSync as existsSync9 } from "fs";
 import { mkdir as mkdir5, readFile as readFile5, rename as rename4, writeFile as writeFile6 } from "fs/promises";
-import * as path15 from "path";
+import * as path14 from "path";
 async function acquireLock(dir) {
   const acquire = import_proper_lockfile5.default.lock(dir, LOCK_RETRY_OPTS);
   let timer;
@@ -37902,7 +37129,7 @@ async function acquireLock(dir) {
   }
 }
 function resolveQuotaPath(directory) {
-  return path15.join(directory, ".swarm", "skill-improver-quota.json");
+  return path14.join(directory, ".swarm", "skill-improver-quota.json");
 }
 function todayKey(window, now = new Date) {
   if (window === "utc") {
@@ -37928,7 +37155,7 @@ async function readState(filePath) {
   }
 }
 async function writeState(filePath, state) {
-  await mkdir5(path15.dirname(filePath), { recursive: true });
+  await mkdir5(path14.dirname(filePath), { recursive: true });
   const tmp = `${filePath}.tmp-${process.pid}`;
   await writeFile6(tmp, JSON.stringify(state, null, 2), "utf-8");
   await rename4(tmp, filePath);
@@ -37951,10 +37178,10 @@ async function getQuotaState(directory, opts) {
 }
 async function reserveQuota(directory, opts) {
   const filePath = resolveQuotaPath(directory);
-  await mkdir5(path15.dirname(filePath), { recursive: true });
+  await mkdir5(path14.dirname(filePath), { recursive: true });
   let release = null;
   try {
-    release = await acquireLock(path15.dirname(filePath));
+    release = await acquireLock(path14.dirname(filePath));
     const state = await getQuotaState(directory, opts);
     if (state.calls_used + opts.nCalls > opts.maxCalls) {
       return {
@@ -37981,10 +37208,10 @@ async function reserveQuota(directory, opts) {
 }
 async function releaseQuota(directory, opts) {
   const filePath = resolveQuotaPath(directory);
-  await mkdir5(path15.dirname(filePath), { recursive: true });
+  await mkdir5(path14.dirname(filePath), { recursive: true });
   let release = null;
   try {
-    release = await acquireLock(path15.dirname(filePath));
+    release = await acquireLock(path14.dirname(filePath));
     const state = await getQuotaState(directory, opts);
     const next = {
       ...state,
@@ -38018,12 +37245,12 @@ var init_skill_improver_quota = __esm(() => {
 // src/services/skill-improver.ts
 import { existsSync as existsSync10 } from "fs";
 import { mkdir as mkdir6, rename as rename5, writeFile as writeFile7 } from "fs/promises";
-import * as path16 from "path";
+import * as path15 from "path";
 function timestampSlug(d) {
   return d.toISOString().replace(/[:.]/g, "-");
 }
 async function atomicWrite2(p, content) {
-  await mkdir6(path16.dirname(p), { recursive: true });
+  await mkdir6(path15.dirname(p), { recursive: true });
   const tmp = `${p}.tmp-${process.pid}-${Date.now()}`;
   await writeFile7(tmp, content, "utf-8");
   await rename5(tmp, p);
@@ -38304,8 +37531,8 @@ async function runSkillImprover(req) {
     }
     throw err;
   }
-  const proposalDir = path16.join(req.directory, ".swarm", "skill-improver", "proposals");
-  const proposalFile = path16.join(proposalDir, `${timestampSlug(now)}.md`);
+  const proposalDir = path15.join(req.directory, ".swarm", "skill-improver", "proposals");
+  const proposalFile = path15.join(proposalDir, `${timestampSlug(now)}.md`);
   const finalBody = source === "llm" ? buildLLMProposalFrame({
     body,
     targets,
@@ -38640,7 +37867,7 @@ async function executeWriteRetro(args, directory) {
     }, null, 2);
   }
 }
-var write_retro, _internals12;
+var write_retro, _internals9;
 var init_write_retro = __esm(() => {
   init_zod();
   init_evidence_schema();
@@ -38687,13 +37914,13 @@ var init_write_retro = __esm(() => {
           task_id: args.task_id !== undefined ? String(args.task_id) : undefined,
           metadata: args.metadata
         };
-        return await _internals12.executeWriteRetro(writeRetroArgs, directory);
+        return await _internals9.executeWriteRetro(writeRetroArgs, directory);
       } catch {
         return JSON.stringify({ success: false, phase: rawPhase, message: "Invalid arguments" }, null, 2);
       }
     }
   });
-  _internals12 = {
+  _internals9 = {
     executeWriteRetro,
     write_retro
   };
@@ -38701,7 +37928,7 @@ var init_write_retro = __esm(() => {
 
 // src/commands/close.ts
 import { promises as fs7 } from "fs";
-import path17 from "path";
+import path16 from "path";
 async function runAbortableSkillReview(req, timeoutMs) {
   const controller = new AbortController;
   let timeout;
@@ -38757,10 +37984,10 @@ function guaranteeAllPlansComplete(planData) {
 }
 async function handleCloseCommand(directory, args, options = {}) {
   const planPath = validateSwarmPath(directory, "plan.json");
-  const swarmDir = path17.join(directory, ".swarm");
+  const swarmDir = path16.join(directory, ".swarm");
   let planExists = false;
   let planData = {
-    title: path17.basename(directory) || "Ad-hoc session",
+    title: path16.basename(directory) || "Ad-hoc session",
     phases: []
   };
   try {
@@ -38869,7 +38096,7 @@ async function handleCloseCommand(directory, args, options = {}) {
       warnings.push(`Session retrospective write threw: ${retroError instanceof Error ? retroError.message : String(retroError)}`);
     }
   }
-  const lessonsFilePath = path17.join(swarmDir, "close-lessons.md");
+  const lessonsFilePath = path16.join(swarmDir, "close-lessons.md");
   let explicitLessons = [];
   try {
     const lessonsText = await fs7.readFile(lessonsFilePath, "utf-8");
@@ -38878,11 +38105,11 @@ async function handleCloseCommand(directory, args, options = {}) {
   } catch {}
   const retroLessons = [];
   try {
-    const evidenceDir = path17.join(swarmDir, "evidence");
+    const evidenceDir = path16.join(swarmDir, "evidence");
     const evidenceEntries = await fs7.readdir(evidenceDir);
     const retroDirs = evidenceEntries.filter((e) => e.startsWith("retro-")).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
     for (const retroDir of retroDirs) {
-      const evidencePath = path17.join(evidenceDir, retroDir, "evidence.json");
+      const evidencePath = path16.join(evidenceDir, retroDir, "evidence.json");
       try {
         const content = await fs7.readFile(evidencePath, "utf-8");
         const parsed = JSON.parse(content);
@@ -39007,7 +38234,7 @@ async function handleCloseCommand(directory, args, options = {}) {
   }
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const suffix = Math.random().toString(36).slice(2, 8);
-  const archiveDir = path17.join(swarmDir, "archive", `swarm-${timestamp}-${suffix}`);
+  const archiveDir = path16.join(swarmDir, "archive", `swarm-${timestamp}-${suffix}`);
   let archiveResult = "";
   let archivedFileCount = 0;
   const archivedActiveStateFiles = new Set;
@@ -39015,8 +38242,8 @@ async function handleCloseCommand(directory, args, options = {}) {
   try {
     await fs7.mkdir(archiveDir, { recursive: true });
     for (const artifact of ARCHIVE_ARTIFACTS) {
-      const srcPath = path17.join(swarmDir, artifact);
-      const destPath = path17.join(archiveDir, artifact);
+      const srcPath = path16.join(swarmDir, artifact);
+      const destPath = path16.join(archiveDir, artifact);
       try {
         await fs7.copyFile(srcPath, destPath);
         archivedFileCount++;
@@ -39026,22 +38253,22 @@ async function handleCloseCommand(directory, args, options = {}) {
       } catch {}
     }
     for (const dirName of ACTIVE_STATE_DIRS_TO_CLEAN) {
-      const srcDir = path17.join(swarmDir, dirName);
-      const destDir = path17.join(archiveDir, dirName);
+      const srcDir = path16.join(swarmDir, dirName);
+      const destDir = path16.join(archiveDir, dirName);
       try {
         const entries = await fs7.readdir(srcDir);
         if (entries.length > 0) {
           await fs7.mkdir(destDir, { recursive: true });
           for (const entry of entries) {
-            const srcEntry = path17.join(srcDir, entry);
-            const destEntry = path17.join(destDir, entry);
+            const srcEntry = path16.join(srcDir, entry);
+            const destEntry = path16.join(destDir, entry);
             try {
               const stat2 = await fs7.stat(srcEntry);
               if (stat2.isDirectory()) {
                 await fs7.mkdir(destEntry, { recursive: true });
                 const subEntries = await fs7.readdir(srcEntry);
                 for (const sub of subEntries) {
-                  await fs7.copyFile(path17.join(srcEntry, sub), path17.join(destEntry, sub)).catch(() => {});
+                  await fs7.copyFile(path16.join(srcEntry, sub), path16.join(destEntry, sub)).catch(() => {});
                 }
               } else {
                 await fs7.copyFile(srcEntry, destEntry);
@@ -39073,7 +38300,7 @@ async function handleCloseCommand(directory, args, options = {}) {
         warnings.push(`Preserved ${artifact} because it was not successfully archived.`);
         continue;
       }
-      const filePath = path17.join(swarmDir, artifact);
+      const filePath = path16.join(swarmDir, artifact);
       try {
         await fs7.unlink(filePath);
         cleanedFiles.push(artifact);
@@ -39086,7 +38313,7 @@ async function handleCloseCommand(directory, args, options = {}) {
     if (!archivedActiveStateDirs.has(dirName)) {
       continue;
     }
-    const dirPath = path17.join(swarmDir, dirName);
+    const dirPath = path16.join(swarmDir, dirName);
     try {
       await fs7.rm(dirPath, { recursive: true, force: true });
       cleanedFiles.push(`${dirName}/`);
@@ -39097,23 +38324,23 @@ async function handleCloseCommand(directory, args, options = {}) {
     const configBackups = swarmFiles.filter((f) => f.startsWith("config-backup-") && f.endsWith(".json"));
     for (const backup of configBackups) {
       try {
-        await fs7.unlink(path17.join(swarmDir, backup));
+        await fs7.unlink(path16.join(swarmDir, backup));
         configBackupsRemoved++;
       } catch {}
     }
     const ledgerSiblings = swarmFiles.filter((f) => (f.startsWith("plan-ledger.archived-") || f.startsWith("plan-ledger.backup-")) && f.endsWith(".jsonl"));
     for (const sibling of ledgerSiblings) {
       try {
-        await fs7.unlink(path17.join(swarmDir, sibling));
+        await fs7.unlink(path16.join(swarmDir, sibling));
       } catch {}
     }
   } catch {}
   let swarmPlanFilesRemoved = 0;
   const candidates = [
-    path17.join(directory, ".swarm", "SWARM_PLAN.json"),
-    path17.join(directory, ".swarm", "SWARM_PLAN.md"),
-    path17.join(directory, "SWARM_PLAN.json"),
-    path17.join(directory, "SWARM_PLAN.md")
+    path16.join(directory, ".swarm", "SWARM_PLAN.json"),
+    path16.join(directory, ".swarm", "SWARM_PLAN.md"),
+    path16.join(directory, "SWARM_PLAN.json"),
+    path16.join(directory, "SWARM_PLAN.md")
   ];
   for (const candidate of candidates) {
     try {
@@ -39121,12 +38348,12 @@ async function handleCloseCommand(directory, args, options = {}) {
       swarmPlanFilesRemoved++;
     } catch (err) {
       if (err?.code !== "ENOENT") {
-        warnings.push(`Failed to remove ${path17.basename(candidate)}: ${err instanceof Error ? err.message : String(err)}`);
+        warnings.push(`Failed to remove ${path16.basename(candidate)}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   }
   clearAllScopes(directory);
-  const contextPath = path17.join(swarmDir, "context.md");
+  const contextPath = path16.join(swarmDir, "context.md");
   const contextContent = [
     "# Context",
     "",
@@ -39344,15 +38571,15 @@ var init_close = __esm(() => {
 });
 
 // src/commands/config.ts
-import * as os7 from "os";
-import * as path18 from "path";
+import * as os4 from "os";
+import * as path17 from "path";
 function getUserConfigDir2() {
-  return process.env.XDG_CONFIG_HOME || path18.join(os7.homedir(), ".config");
+  return process.env.XDG_CONFIG_HOME || path17.join(os4.homedir(), ".config");
 }
 async function handleConfigCommand(directory, _args) {
   const config3 = loadPluginConfig(directory);
-  const userConfigPath = path18.join(getUserConfigDir2(), "opencode", "opencode-swarm.json");
-  const projectConfigPath = path18.join(directory, ".opencode", "opencode-swarm.json");
+  const userConfigPath = path17.join(getUserConfigDir2(), "opencode", "opencode-swarm.json");
+  const projectConfigPath = path17.join(directory, ".opencode", "opencode-swarm.json");
   const lines = [
     "## Swarm Configuration",
     "",
@@ -39479,7 +38706,7 @@ var init_curate = __esm(() => {
 import * as child_process3 from "child_process";
 import { randomUUID } from "crypto";
 import { readdir, readFile as readFile6, stat as stat2 } from "fs/promises";
-import * as path19 from "path";
+import * as path18 from "path";
 import { promisify } from "util";
 function getExecFileAsync() {
   return promisify(child_process3.execFile);
@@ -39581,7 +38808,7 @@ async function scanSourceFiles(dir) {
   try {
     const entries = await readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
-      const fullPath = path19.join(dir, entry.name);
+      const fullPath = path18.join(dir, entry.name);
       if (entry.isDirectory()) {
         if (skipDirs.has(entry.name)) {
           continue;
@@ -39589,7 +38816,7 @@ async function scanSourceFiles(dir) {
         const subFiles = await scanSourceFiles(fullPath);
         results.push(...subFiles);
       } else if (entry.isFile()) {
-        const ext = path19.extname(entry.name);
+        const ext = path18.extname(entry.name);
         if ([".ts", ".tsx", ".js", ".jsx", ".mjs"].includes(ext)) {
           results.push(fullPath);
         }
@@ -39611,8 +38838,8 @@ async function getStaticEdges(directory) {
           continue;
         }
         try {
-          const sourceDir = path19.dirname(sourceFile);
-          const resolvedPath = path19.resolve(sourceDir, importPath);
+          const sourceDir = path18.dirname(sourceFile);
+          const resolvedPath = path18.resolve(sourceDir, importPath);
           const extensions = [
             "",
             ".ts",
@@ -39637,8 +38864,8 @@ async function getStaticEdges(directory) {
           if (!targetFile) {
             continue;
           }
-          const relSource = path19.relative(directory, sourceFile).replace(/\\/g, "/");
-          const relTarget = path19.relative(directory, targetFile).replace(/\\/g, "/");
+          const relSource = path18.relative(directory, sourceFile).replace(/\\/g, "/");
+          const relTarget = path18.relative(directory, targetFile).replace(/\\/g, "/");
           const [key] = relSource < relTarget ? [`${relSource}::${relTarget}`, relSource, relTarget] : [`${relTarget}::${relSource}`, relTarget, relSource];
           edges.add(key);
         } catch {}
@@ -39650,7 +38877,7 @@ async function getStaticEdges(directory) {
 function isTestImplementationPair(fileA, fileB) {
   const testPatterns = [".test.ts", ".test.js", ".spec.ts", ".spec.js"];
   const getBaseName = (filePath) => {
-    const base = path19.basename(filePath);
+    const base = path18.basename(filePath);
     for (const pattern of testPatterns) {
       if (base.endsWith(pattern)) {
         return base.slice(0, -pattern.length);
@@ -39660,16 +38887,16 @@ function isTestImplementationPair(fileA, fileB) {
   };
   const baseA = getBaseName(fileA);
   const baseB = getBaseName(fileB);
-  return baseA === baseB && baseA !== path19.basename(fileA) && baseA !== path19.basename(fileB);
+  return baseA === baseB && baseA !== path18.basename(fileA) && baseA !== path18.basename(fileB);
 }
 function hasSharedPrefix(fileA, fileB) {
-  const dirA = path19.dirname(fileA);
-  const dirB = path19.dirname(fileB);
+  const dirA = path18.dirname(fileA);
+  const dirB = path18.dirname(fileB);
   if (dirA !== dirB) {
     return false;
   }
-  const baseA = path19.basename(fileA).replace(/\.(ts|js|tsx|jsx|mjs)$/, "");
-  const baseB = path19.basename(fileB).replace(/\.(ts|js|tsx|jsx|mjs)$/, "");
+  const baseA = path18.basename(fileA).replace(/\.(ts|js|tsx|jsx|mjs)$/, "");
+  const baseB = path18.basename(fileB).replace(/\.(ts|js|tsx|jsx|mjs)$/, "");
   if (baseA.startsWith(baseB) || baseB.startsWith(baseA)) {
     return true;
   }
@@ -39697,9 +38924,9 @@ async function detectDarkMatter(directory, options) {
   } catch {
     return [];
   }
-  const commitMap = await _internals13.parseGitLog(directory, maxCommitsToAnalyze);
-  const matrix = _internals13.buildCoChangeMatrix(commitMap);
-  const staticEdges = await _internals13.getStaticEdges(directory);
+  const commitMap = await _internals10.parseGitLog(directory, maxCommitsToAnalyze);
+  const matrix = _internals10.buildCoChangeMatrix(commitMap);
+  const staticEdges = await _internals10.getStaticEdges(directory);
   const results = [];
   for (const entry of matrix.values()) {
     const key = `${entry.fileA}::${entry.fileB}`;
@@ -39723,8 +38950,8 @@ function darkMatterToKnowledgeEntries(pairs, projectName) {
   const entries = [];
   const now = new Date().toISOString();
   for (const pair of pairs.slice(0, 10)) {
-    const baseA = path19.basename(pair.fileA);
-    const baseB = path19.basename(pair.fileB);
+    const baseA = path18.basename(pair.fileA);
+    const baseB = path18.basename(pair.fileB);
     let lesson = `Files ${pair.fileA} and ${pair.fileB} co-change with NPMI=${pair.npmi.toFixed(3)} but have no import relationship. This hidden coupling suggests a shared architectural concern \u2014 changes to one likely require changes to the other.`;
     if (lesson.length > 280) {
       lesson = `Files ${baseA} and ${baseB} co-change with NPMI=${pair.npmi.toFixed(3)} but have no import relationship. This hidden coupling suggests a shared architectural concern \u2014 changes to one likely require changes to the other.`;
@@ -39779,7 +39006,7 @@ ${rows}
 These pairs likely share an architectural concern invisible to static analysis.
 Consider adding explicit documentation or extracting the shared concern.`;
 }
-var co_change_analyzer, _internals13;
+var co_change_analyzer, _internals10;
 var init_co_change_analyzer = __esm(() => {
   init_zod();
   init_create_tool();
@@ -39811,11 +39038,11 @@ var init_co_change_analyzer = __esm(() => {
         npmiThreshold,
         maxCommitsToAnalyze
       };
-      const pairs = await _internals13.detectDarkMatter(directory, options);
-      return _internals13.formatDarkMatterOutput(pairs);
+      const pairs = await _internals10.detectDarkMatter(directory, options);
+      return _internals10.formatDarkMatterOutput(pairs);
     }
   });
-  _internals13 = {
+  _internals10 = {
     parseGitLog,
     buildCoChangeMatrix,
     getStaticEdges,
@@ -39826,7 +39053,7 @@ var init_co_change_analyzer = __esm(() => {
 });
 
 // src/commands/dark-matter.ts
-import path20 from "path";
+import path19 from "path";
 async function handleDarkMatterCommand(directory, args) {
   const options = {};
   for (let i = 0;i < args.length; i++) {
@@ -39846,7 +39073,7 @@ async function handleDarkMatterCommand(directory, args) {
   }
   let pairs;
   try {
-    pairs = await _internals13.detectDarkMatter(directory, options);
+    pairs = await _internals10.detectDarkMatter(directory, options);
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     return `## Dark Matter Analysis Failed
@@ -39858,7 +39085,7 @@ Ensure this is a git repository with commit history.`;
   const output = formatDarkMatterOutput(pairs);
   if (pairs.length > 0) {
     try {
-      const projectName = path20.basename(path20.resolve(directory));
+      const projectName = path19.basename(path19.resolve(directory));
       const entries = darkMatterToKnowledgeEntries(pairs, projectName);
       if (entries.length > 0) {
         const knowledgePath = resolveSwarmKnowledgePath(directory);
@@ -39994,68 +39221,68 @@ var init_deep_dive = __esm(() => {
 });
 
 // src/config/cache-paths.ts
-import * as os8 from "os";
-import * as path21 from "path";
+import * as os5 from "os";
+import * as path20 from "path";
 function getPluginConfigDir() {
-  return path21.join(process.env.XDG_CONFIG_HOME || path21.join(os8.homedir(), ".config"), "opencode");
+  return path20.join(process.env.XDG_CONFIG_HOME || path20.join(os5.homedir(), ".config"), "opencode");
 }
 function getPluginCachePaths() {
-  const cacheBase = process.env.XDG_CACHE_HOME || path21.join(os8.homedir(), ".cache");
+  const cacheBase = process.env.XDG_CACHE_HOME || path20.join(os5.homedir(), ".cache");
   const configDir = getPluginConfigDir();
   const paths = [
-    path21.join(cacheBase, "opencode", "node_modules", "opencode-swarm"),
-    path21.join(cacheBase, "opencode", "packages", "opencode-swarm@latest"),
-    path21.join(configDir, "node_modules", "opencode-swarm")
+    path20.join(cacheBase, "opencode", "node_modules", "opencode-swarm"),
+    path20.join(cacheBase, "opencode", "packages", "opencode-swarm@latest"),
+    path20.join(configDir, "node_modules", "opencode-swarm")
   ];
   if (process.platform === "darwin") {
-    const libCaches = path21.join(os8.homedir(), "Library", "Caches");
-    paths.push(path21.join(libCaches, "opencode", "node_modules", "opencode-swarm"), path21.join(libCaches, "opencode", "packages", "opencode-swarm@latest"));
+    const libCaches = path20.join(os5.homedir(), "Library", "Caches");
+    paths.push(path20.join(libCaches, "opencode", "node_modules", "opencode-swarm"), path20.join(libCaches, "opencode", "packages", "opencode-swarm@latest"));
   }
   if (process.platform === "win32") {
-    const localAppData = process.env.LOCALAPPDATA || path21.join(os8.homedir(), "AppData", "Local");
-    const appData = process.env.APPDATA || path21.join(os8.homedir(), "AppData", "Roaming");
-    paths.push(path21.join(localAppData, "opencode", "node_modules", "opencode-swarm"), path21.join(localAppData, "opencode", "packages", "opencode-swarm@latest"), path21.join(appData, "opencode", "node_modules", "opencode-swarm"));
+    const localAppData = process.env.LOCALAPPDATA || path20.join(os5.homedir(), "AppData", "Local");
+    const appData = process.env.APPDATA || path20.join(os5.homedir(), "AppData", "Roaming");
+    paths.push(path20.join(localAppData, "opencode", "node_modules", "opencode-swarm"), path20.join(localAppData, "opencode", "packages", "opencode-swarm@latest"), path20.join(appData, "opencode", "node_modules", "opencode-swarm"));
   }
   return paths;
 }
 function getPluginLockFilePaths() {
-  const cacheBase = process.env.XDG_CACHE_HOME || path21.join(os8.homedir(), ".cache");
+  const cacheBase = process.env.XDG_CACHE_HOME || path20.join(os5.homedir(), ".cache");
   const configDir = getPluginConfigDir();
   const paths = [
-    path21.join(cacheBase, "opencode", "bun.lock"),
-    path21.join(cacheBase, "opencode", "bun.lockb"),
-    path21.join(configDir, "package-lock.json")
+    path20.join(cacheBase, "opencode", "bun.lock"),
+    path20.join(cacheBase, "opencode", "bun.lockb"),
+    path20.join(configDir, "package-lock.json")
   ];
   if (process.platform === "darwin") {
-    const libCaches = path21.join(os8.homedir(), "Library", "Caches");
-    paths.push(path21.join(libCaches, "opencode", "bun.lock"), path21.join(libCaches, "opencode", "bun.lockb"));
+    const libCaches = path20.join(os5.homedir(), "Library", "Caches");
+    paths.push(path20.join(libCaches, "opencode", "bun.lock"), path20.join(libCaches, "opencode", "bun.lockb"));
   }
   if (process.platform === "win32") {
-    const localAppData = process.env.LOCALAPPDATA || path21.join(os8.homedir(), "AppData", "Local");
-    paths.push(path21.join(localAppData, "opencode", "bun.lock"), path21.join(localAppData, "opencode", "bun.lockb"));
+    const localAppData = process.env.LOCALAPPDATA || path20.join(os5.homedir(), "AppData", "Local");
+    paths.push(path20.join(localAppData, "opencode", "bun.lock"), path20.join(localAppData, "opencode", "bun.lockb"));
   }
   return paths;
 }
 var init_cache_paths = () => {};
 
 // src/services/version-check.ts
-import { existsSync as existsSync11, mkdirSync as mkdirSync7, readFileSync as readFileSync6, writeFileSync as writeFileSync5 } from "fs";
+import { existsSync as existsSync11, mkdirSync as mkdirSync7, readFileSync as readFileSync6, writeFileSync as writeFileSync4 } from "fs";
 import { homedir as homedir5 } from "os";
-import { join as join20 } from "path";
+import { join as join19 } from "path";
 function cacheDir() {
   const xdg = process.env.XDG_CACHE_HOME;
-  const base = xdg && xdg.length > 0 ? xdg : join20(homedir5(), ".cache");
-  return join20(base, "opencode-swarm");
+  const base = xdg && xdg.length > 0 ? xdg : join19(homedir5(), ".cache");
+  return join19(base, "opencode-swarm");
 }
 function cacheFile() {
-  return join20(cacheDir(), "version-check.json");
+  return join19(cacheDir(), "version-check.json");
 }
 function readVersionCache() {
   try {
-    const path22 = cacheFile();
-    if (!existsSync11(path22))
+    const path21 = cacheFile();
+    if (!existsSync11(path21))
       return null;
-    const raw = readFileSync6(path22, "utf-8");
+    const raw = readFileSync6(path21, "utf-8");
     const parsed = JSON.parse(raw);
     if (typeof parsed?.checkedAt !== "number")
       return null;
@@ -40095,7 +39322,7 @@ var init_version_check = __esm(() => {
 // src/services/diagnose-service.ts
 import * as child_process4 from "child_process";
 import { existsSync as existsSync12, readdirSync as readdirSync4, readFileSync as readFileSync7, statSync as statSync6 } from "fs";
-import path22 from "path";
+import path21 from "path";
 import { fileURLToPath } from "url";
 function validateTaskDag(plan) {
   const allTaskIds = new Set;
@@ -40392,7 +39619,7 @@ async function checkSpecStaleness(directory, plan) {
   };
 }
 async function checkConfigParseability(directory) {
-  const configPath = path22.join(directory, ".opencode/opencode-swarm.json");
+  const configPath = path21.join(directory, ".opencode/opencode-swarm.json");
   if (!existsSync12(configPath)) {
     return {
       name: "Config Parseability",
@@ -40421,7 +39648,7 @@ function resolveGrammarDir(thisDir) {
   const normalized = thisDir.replace(/\\/g, "/");
   const isSource = normalized.endsWith("/src/services");
   const isCliBundle = normalized.endsWith("/cli");
-  return isSource || isCliBundle ? path22.join(thisDir, "..", "lang", "grammars") : path22.join(thisDir, "lang", "grammars");
+  return isSource || isCliBundle ? path21.join(thisDir, "..", "lang", "grammars") : path21.join(thisDir, "lang", "grammars");
 }
 async function checkGrammarWasmFiles() {
   const grammarFiles = [
@@ -40445,14 +39672,14 @@ async function checkGrammarWasmFiles() {
     "tree-sitter-ini.wasm",
     "tree-sitter-regex.wasm"
   ];
-  const thisDir = path22.dirname(fileURLToPath(import.meta.url));
+  const thisDir = path21.dirname(fileURLToPath(import.meta.url));
   const grammarDir = resolveGrammarDir(thisDir);
   const missing = [];
-  if (!existsSync12(path22.join(grammarDir, "tree-sitter.wasm"))) {
+  if (!existsSync12(path21.join(grammarDir, "tree-sitter.wasm"))) {
     missing.push("tree-sitter.wasm (core runtime)");
   }
   for (const file3 of grammarFiles) {
-    if (!existsSync12(path22.join(grammarDir, file3))) {
+    if (!existsSync12(path21.join(grammarDir, file3))) {
       missing.push(file3);
     }
   }
@@ -40470,7 +39697,7 @@ async function checkGrammarWasmFiles() {
   };
 }
 async function checkCheckpointManifest(directory) {
-  const manifestPath = path22.join(directory, ".swarm/checkpoints.json");
+  const manifestPath = path21.join(directory, ".swarm/checkpoints.json");
   if (!existsSync12(manifestPath)) {
     return {
       name: "Checkpoint Manifest",
@@ -40522,7 +39749,7 @@ async function checkCheckpointManifest(directory) {
   }
 }
 async function checkEventStreamIntegrity(directory) {
-  const eventsPath = path22.join(directory, ".swarm/events.jsonl");
+  const eventsPath = path21.join(directory, ".swarm/events.jsonl");
   if (!existsSync12(eventsPath)) {
     return {
       name: "Event Stream",
@@ -40563,7 +39790,7 @@ async function checkEventStreamIntegrity(directory) {
   }
 }
 async function checkSteeringDirectives(directory) {
-  const eventsPath = path22.join(directory, ".swarm/events.jsonl");
+  const eventsPath = path21.join(directory, ".swarm/events.jsonl");
   if (!existsSync12(eventsPath)) {
     return {
       name: "Steering Directives",
@@ -40619,7 +39846,7 @@ async function checkCurator(directory) {
         detail: "Disabled (enable via curator.enabled)"
       };
     }
-    const summaryPath = path22.join(directory, ".swarm/curator-summary.json");
+    const summaryPath = path21.join(directory, ".swarm/curator-summary.json");
     if (!existsSync12(summaryPath)) {
       return {
         name: "Curator",
@@ -40785,7 +40012,7 @@ async function getDiagnoseData(directory) {
   checks5.push(await checkSteeringDirectives(directory));
   checks5.push(await checkCurator(directory));
   try {
-    const evidenceDir = path22.join(directory, ".swarm", "evidence");
+    const evidenceDir = path21.join(directory, ".swarm", "evidence");
     const snapshotFiles = existsSync12(evidenceDir) ? readdirSync4(evidenceDir).filter((f) => f.startsWith("agent-tools-") && f.endsWith(".json")) : [];
     if (snapshotFiles.length > 0) {
       const latest = snapshotFiles.sort().pop();
@@ -40823,7 +40050,7 @@ async function getDiagnoseData(directory) {
         cacheRows.push(`\u2B1C ${cachePath} \u2014 absent`);
         continue;
       }
-      const pkgJsonPath = path22.join(cachePath, "package.json");
+      const pkgJsonPath = path21.join(cachePath, "package.json");
       try {
         const raw = readFileSync7(pkgJsonPath, "utf-8");
         const parsed = JSON.parse(raw);
@@ -40912,14 +40139,14 @@ __export(exports_config_doctor, {
 });
 import * as crypto3 from "crypto";
 import * as fs8 from "fs";
-import * as os9 from "os";
-import * as path23 from "path";
+import * as os6 from "os";
+import * as path22 from "path";
 function getUserConfigDir3() {
-  return process.env.XDG_CONFIG_HOME || path23.join(os9.homedir(), ".config");
+  return process.env.XDG_CONFIG_HOME || path22.join(os6.homedir(), ".config");
 }
 function getConfigPaths(directory) {
-  const userConfigPath = path23.join(getUserConfigDir3(), "opencode", "opencode-swarm.json");
-  const projectConfigPath = path23.join(directory, ".opencode", "opencode-swarm.json");
+  const userConfigPath = path22.join(getUserConfigDir3(), "opencode", "opencode-swarm.json");
+  const projectConfigPath = path22.join(directory, ".opencode", "opencode-swarm.json");
   return { userConfigPath, projectConfigPath };
 }
 function computeHash(content) {
@@ -40944,9 +40171,9 @@ function isValidConfigPath(configPath, directory) {
   const normalizedUser = userConfigPath.replace(/\\/g, "/");
   const normalizedProject = projectConfigPath.replace(/\\/g, "/");
   try {
-    const resolvedConfig = path23.resolve(configPath);
-    const resolvedUser = path23.resolve(normalizedUser);
-    const resolvedProject = path23.resolve(normalizedProject);
+    const resolvedConfig = path22.resolve(configPath);
+    const resolvedUser = path22.resolve(normalizedUser);
+    const resolvedProject = path22.resolve(normalizedProject);
     return resolvedConfig === resolvedUser || resolvedConfig === resolvedProject;
   } catch {
     return false;
@@ -40986,12 +40213,12 @@ function createConfigBackup(directory) {
   };
 }
 function writeBackupArtifact(directory, backup) {
-  const swarmDir = path23.join(directory, ".swarm");
+  const swarmDir = path22.join(directory, ".swarm");
   if (!fs8.existsSync(swarmDir)) {
     fs8.mkdirSync(swarmDir, { recursive: true });
   }
   const backupFilename = `config-backup-${backup.createdAt}.json`;
-  const backupPath = path23.join(swarmDir, backupFilename);
+  const backupPath = path22.join(swarmDir, backupFilename);
   const artifact = {
     createdAt: backup.createdAt,
     configPath: backup.configPath,
@@ -41021,7 +40248,7 @@ function restoreFromBackup(backupPath, directory) {
       return null;
     }
     const targetPath = artifact.configPath;
-    const targetDir = path23.dirname(targetPath);
+    const targetDir = path22.dirname(targetPath);
     if (!fs8.existsSync(targetDir)) {
       fs8.mkdirSync(targetDir, { recursive: true });
     }
@@ -41052,9 +40279,9 @@ function readConfigFromFile(directory) {
     return null;
   }
 }
-function validateConfigKey(path24, value, _config) {
+function validateConfigKey(path23, value, _config) {
   const findings = [];
-  switch (path24) {
+  switch (path23) {
     case "agents": {
       if (value !== undefined) {
         findings.push({
@@ -41291,27 +40518,27 @@ function validateConfigKey(path24, value, _config) {
   }
   return findings;
 }
-function walkConfigAndValidate(obj, path24, config3, findings) {
+function walkConfigAndValidate(obj, path23, config3, findings) {
   if (obj === null || obj === undefined) {
     return;
   }
-  if (path24 && typeof obj === "object" && !Array.isArray(obj)) {
-    const keyFindings = validateConfigKey(path24, obj, config3);
+  if (path23 && typeof obj === "object" && !Array.isArray(obj)) {
+    const keyFindings = validateConfigKey(path23, obj, config3);
     findings.push(...keyFindings);
   }
   if (typeof obj !== "object") {
-    const keyFindings = validateConfigKey(path24, obj, config3);
+    const keyFindings = validateConfigKey(path23, obj, config3);
     findings.push(...keyFindings);
     return;
   }
   if (Array.isArray(obj)) {
     obj.forEach((item, index) => {
-      walkConfigAndValidate(item, `${path24}[${index}]`, config3, findings);
+      walkConfigAndValidate(item, `${path23}[${index}]`, config3, findings);
     });
     return;
   }
   for (const [key, value] of Object.entries(obj)) {
-    const newPath = path24 ? `${path24}.${key}` : key;
+    const newPath = path23 ? `${path23}.${key}` : key;
     walkConfigAndValidate(value, newPath, config3, findings);
   }
 }
@@ -41431,7 +40658,7 @@ function applySafeAutoFixes(directory, result) {
     }
   }
   if (appliedFixes.length > 0) {
-    const configDir = path23.dirname(configPath);
+    const configDir = path22.dirname(configPath);
     if (!fs8.existsSync(configDir)) {
       fs8.mkdirSync(configDir, { recursive: true });
     }
@@ -41441,12 +40668,12 @@ function applySafeAutoFixes(directory, result) {
   return { appliedFixes, updatedConfigPath };
 }
 function writeDoctorArtifact(directory, result) {
-  const swarmDir = path23.join(directory, ".swarm");
+  const swarmDir = path22.join(directory, ".swarm");
   if (!fs8.existsSync(swarmDir)) {
     fs8.mkdirSync(swarmDir, { recursive: true });
   }
   const artifactFilename = "config-doctor.json";
-  const artifactPath = path23.join(swarmDir, artifactFilename);
+  const artifactPath = path22.join(swarmDir, artifactFilename);
   const guiOutput = {
     timestamp: result.timestamp,
     summary: result.summary,
@@ -41542,17 +40769,17 @@ function detectStraySwarmDirs(projectRoot) {
       if (!entry.isDirectory())
         continue;
       const name = entry.name;
-      const fullPath = path23.join(dir, name);
+      const fullPath = path22.join(dir, name);
       if (SKIP_DIRS.has(name))
         continue;
-      const gitPath = path23.join(fullPath, ".git");
+      const gitPath = path22.join(fullPath, ".git");
       try {
         const gitStat = fs8.statSync(gitPath);
         if (gitStat.isFile() || gitStat.isDirectory())
           continue;
       } catch {}
       if (name === ".swarm") {
-        const parentDir = path23.dirname(fullPath);
+        const parentDir = path22.dirname(fullPath);
         if (parentDir === projectRoot)
           continue;
         let contents = [];
@@ -41562,7 +40789,7 @@ function detectStraySwarmDirs(projectRoot) {
           contents = ["<unreadable>"];
         }
         findings.push({
-          path: path23.relative(projectRoot, fullPath).replace(/\\/g, "/"),
+          path: path22.relative(projectRoot, fullPath).replace(/\\/g, "/"),
           absolutePath: fullPath,
           contents: contents.slice(0, MAX_CONTENTS_ENTRIES),
           totalEntries: contents.length
@@ -41580,21 +40807,21 @@ function removeStraySwarmDir(projectRoot, strayPath) {
   let canonicalStray;
   try {
     canonicalRoot = fs8.realpathSync(projectRoot);
-    canonicalStray = fs8.realpathSync(path23.isAbsolute(strayPath) ? strayPath : path23.resolve(projectRoot, strayPath));
+    canonicalStray = fs8.realpathSync(path22.isAbsolute(strayPath) ? strayPath : path22.resolve(projectRoot, strayPath));
   } catch (err) {
     return {
       success: false,
       message: `Failed to resolve paths: ${err instanceof Error ? err.message : String(err)}`
     };
   }
-  const rootSwarm = path23.join(canonicalRoot, ".swarm");
+  const rootSwarm = path22.join(canonicalRoot, ".swarm");
   if (canonicalStray === rootSwarm || canonicalStray === canonicalRoot) {
     return {
       success: false,
       message: "Refusing to remove root .swarm/ directory"
     };
   }
-  if (!canonicalStray.startsWith(canonicalRoot + path23.sep)) {
+  if (!canonicalStray.startsWith(canonicalRoot + path22.sep)) {
     return {
       success: false,
       message: "Path is outside project root \u2014 refusing to remove"
@@ -42683,7 +41910,7 @@ var init_profiles = __esm(() => {
 
 // src/lang/detector.ts
 import { access as access3, readdir as readdir2 } from "fs/promises";
-import { extname as extname2, join as join22 } from "path";
+import { extname as extname2, join as join21 } from "path";
 async function detectProjectLanguages(projectDir) {
   const detected = new Set;
   async function scanDir(dir) {
@@ -42699,7 +41926,7 @@ async function detectProjectLanguages(projectDir) {
         if (detectFile.includes("*") || detectFile.includes("?"))
           continue;
         try {
-          await access3(join22(dir, detectFile));
+          await access3(join21(dir, detectFile));
           detected.add(profile.id);
           break;
         } catch {}
@@ -42720,7 +41947,7 @@ async function detectProjectLanguages(projectDir) {
     const topEntries = await readdir2(projectDir, { withFileTypes: true });
     for (const entry of topEntries) {
       if (entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules") {
-        await scanDir(join22(projectDir, entry.name));
+        await scanDir(join21(projectDir, entry.name));
       }
     }
   } catch {}
@@ -42739,7 +41966,7 @@ var init_detector = __esm(() => {
 
 // src/build/discovery.ts
 import * as fs9 from "fs";
-import * as path24 from "path";
+import * as path23 from "path";
 function isCommandAvailable(command) {
   if (toolchainCache.has(command)) {
     return toolchainCache.get(command);
@@ -42747,7 +41974,7 @@ function isCommandAvailable(command) {
   const isWindows = process.platform === "win32";
   const cmd = isWindows ? `${command}.exe` : command;
   try {
-    const result = _internals14.spawnSyncImpl(isWindows ? ["where", cmd] : ["which", cmd], {
+    const result = _internals11.spawnSyncImpl(isWindows ? ["where", cmd] : ["which", cmd], {
       cwd: process.cwd(),
       stdin: "ignore",
       stdout: "ignore",
@@ -42774,11 +42001,11 @@ function findBuildFiles(workingDir, patterns) {
         const regex = simpleGlobToRegex(pattern);
         const matches = files.filter((f) => regex.test(f));
         if (matches.length > 0) {
-          return path24.join(dir, matches[0]);
+          return path23.join(dir, matches[0]);
         }
       } catch {}
     } else {
-      const filePath = path24.join(workingDir, pattern);
+      const filePath = path23.join(workingDir, pattern);
       if (fs9.existsSync(filePath)) {
         return filePath;
       }
@@ -42787,7 +42014,7 @@ function findBuildFiles(workingDir, patterns) {
   return null;
 }
 function getRepoDefinedScripts(workingDir, scripts) {
-  const packageJsonPath = path24.join(workingDir, "package.json");
+  const packageJsonPath = path23.join(workingDir, "package.json");
   if (!fs9.existsSync(packageJsonPath)) {
     return [];
   }
@@ -42828,7 +42055,7 @@ function findAllBuildFiles(workingDir) {
         const regex = simpleGlobToRegex(pattern);
         findFilesRecursive(workingDir, regex, allBuildFiles);
       } else {
-        const filePath = path24.join(workingDir, pattern);
+        const filePath = path23.join(workingDir, pattern);
         if (fs9.existsSync(filePath)) {
           allBuildFiles.add(filePath);
         }
@@ -42841,7 +42068,7 @@ function findFilesRecursive(dir, regex, results) {
   try {
     const entries = fs9.readdirSync(dir, { withFileTypes: true });
     for (const entry of entries) {
-      const fullPath = path24.join(dir, entry.name);
+      const fullPath = path23.join(dir, entry.name);
       if (entry.isDirectory() && !["node_modules", ".git", "dist", "build", "target"].includes(entry.name)) {
         findFilesRecursive(fullPath, regex, results);
       } else if (entry.isFile() && regex.test(entry.name)) {
@@ -42864,7 +42091,7 @@ async function discoverBuildCommandsFromProfiles(workingDir) {
     let foundCommand = false;
     for (const cmd of sortedCommands) {
       if (cmd.detectFile) {
-        const detectFilePath = path24.join(workingDir, cmd.detectFile);
+        const detectFilePath = path23.join(workingDir, cmd.detectFile);
         if (!fs9.existsSync(detectFilePath)) {
           continue;
         }
@@ -42897,7 +42124,7 @@ async function discoverBuildCommands(workingDir, options) {
   const scope = options?.scope ?? "all";
   const changedFiles = options?.changedFiles ?? [];
   const _filesToCheck = filterByScope(workingDir, scope, changedFiles);
-  const profileResult = await _internals14.discoverBuildCommandsFromProfiles(workingDir);
+  const profileResult = await _internals11.discoverBuildCommandsFromProfiles(workingDir);
   const profileCommands = profileResult.commands;
   const profileSkipped = profileResult.skipped;
   const coveredEcosystems = new Set;
@@ -42960,7 +42187,7 @@ function clearToolchainCache() {
 function getEcosystems() {
   return ECOSYSTEMS.map((e) => e.ecosystem);
 }
-var ECOSYSTEMS, PROFILE_TO_ECOSYSTEM_NAMES, toolchainCache, IS_COMMAND_AVAILABLE_TIMEOUT_MS = 3000, _internals14, build_discovery;
+var ECOSYSTEMS, PROFILE_TO_ECOSYSTEM_NAMES, toolchainCache, IS_COMMAND_AVAILABLE_TIMEOUT_MS = 3000, _internals11, build_discovery;
 var init_discovery = __esm(() => {
   init_dist();
   init_detector();
@@ -43078,7 +42305,7 @@ var init_discovery = __esm(() => {
     php: ["php-composer"]
   };
   toolchainCache = new Map;
-  _internals14 = {
+  _internals11 = {
     isCommandAvailable,
     discoverBuildCommandsFromProfiles,
     discoverBuildCommands,
@@ -43105,7 +42332,7 @@ var init_discovery = __esm(() => {
 
 // src/services/tool-doctor.ts
 import * as fs10 from "fs";
-import * as path25 from "path";
+import * as path24 from "path";
 function extractRegisteredToolKeys(indexPath) {
   const registeredKeys = new Set;
   try {
@@ -43160,8 +42387,8 @@ function checkBinaryReadiness() {
 }
 function runToolDoctor(_directory, pluginRoot) {
   const findings = [];
-  const resolvedPluginRoot = pluginRoot ?? path25.resolve(import.meta.dir, "..", "..");
-  const indexPath = path25.join(resolvedPluginRoot, "src", "index.ts");
+  const resolvedPluginRoot = pluginRoot ?? path24.resolve(import.meta.dir, "..", "..");
+  const indexPath = path24.join(resolvedPluginRoot, "src", "index.ts");
   if (!fs10.existsSync(indexPath)) {
     return {
       findings: [
@@ -43381,7 +42608,7 @@ var exports_evidence_summary_service = {};
 __export(exports_evidence_summary_service, {
   isAutoSummaryEnabled: () => isAutoSummaryEnabled,
   buildEvidenceSummary: () => buildEvidenceSummary,
-  _internals: () => _internals15,
+  _internals: () => _internals12,
   REQUIRED_EVIDENCE_TYPES: () => REQUIRED_EVIDENCE_TYPES,
   EVIDENCE_SUMMARY_VERSION: () => EVIDENCE_SUMMARY_VERSION
 });
@@ -43419,14 +42646,14 @@ function getTaskStatus(task, bundle) {
   if (task?.status) {
     return task.status;
   }
-  const entries = _internals15.normalizeBundleEntries(bundle);
+  const entries = _internals12.normalizeBundleEntries(bundle);
   if (entries.length > 0) {
     return "completed";
   }
   return "pending";
 }
 function isEvidenceComplete(bundle) {
-  const entries = _internals15.normalizeBundleEntries(bundle);
+  const entries = _internals12.normalizeBundleEntries(bundle);
   if (entries.length === 0) {
     return {
       isComplete: false,
@@ -43462,10 +42689,10 @@ async function buildTaskSummary(directory, task, taskId) {
   const result = await loadEvidence(directory, taskId);
   const bundle = result.status === "found" ? result.bundle : null;
   const phase = task?.phase ?? 0;
-  const status = _internals15.getTaskStatus(task, bundle);
-  const evidenceCheck = _internals15.isEvidenceComplete(bundle);
-  const blockers = _internals15.getTaskBlockers(task, evidenceCheck, status);
-  const entries = _internals15.normalizeBundleEntries(bundle);
+  const status = _internals12.getTaskStatus(task, bundle);
+  const evidenceCheck = _internals12.isEvidenceComplete(bundle);
+  const blockers = _internals12.getTaskBlockers(task, evidenceCheck, status);
+  const entries = _internals12.normalizeBundleEntries(bundle);
   const hasReview = entries.some((e) => e.type === "review");
   const hasTest = entries.some((e) => e.type === "test");
   const hasApproval = entries.some((e) => e.type === "approval");
@@ -43494,12 +42721,12 @@ async function buildPhaseSummary(directory, phase) {
   const taskSummaries = [];
   const _taskMap = new Map(phase.tasks.map((t) => [t.id, t]));
   for (const task of phase.tasks) {
-    const summary = await _internals15.buildTaskSummary(directory, task, task.id);
+    const summary = await _internals12.buildTaskSummary(directory, task, task.id);
     taskSummaries.push(summary);
   }
   const extraTaskIds = taskIds.filter((id) => !phaseTaskIds.has(id));
   for (const taskId of extraTaskIds) {
-    const summary = await _internals15.buildTaskSummary(directory, undefined, taskId);
+    const summary = await _internals12.buildTaskSummary(directory, undefined, taskId);
     if (summary.phase === phase.id) {
       taskSummaries.push(summary);
     }
@@ -43600,7 +42827,7 @@ async function buildEvidenceSummary(directory, currentPhase) {
   let totalTasks = 0;
   let completedTasks = 0;
   for (const phase of phasesToProcess) {
-    const summary = await _internals15.buildPhaseSummary(directory, phase);
+    const summary = await _internals12.buildPhaseSummary(directory, phase);
     phaseSummaries.push(summary);
     totalTasks += summary.totalTasks;
     completedTasks += summary.completedTasks;
@@ -43622,7 +42849,7 @@ async function buildEvidenceSummary(directory, currentPhase) {
     overallBlockers,
     summaryText: ""
   };
-  artifact.summaryText = _internals15.generateSummaryText(artifact);
+  artifact.summaryText = _internals12.generateSummaryText(artifact);
   log("[EvidenceSummary] Summary built", {
     phases: phaseSummaries.length,
     totalTasks,
@@ -43641,7 +42868,7 @@ function isAutoSummaryEnabled(automationConfig) {
   }
   return automationConfig.capabilities?.evidence_auto_summaries === true;
 }
-var VALID_EVIDENCE_TYPES2, REQUIRED_EVIDENCE_TYPES, EVIDENCE_SUMMARY_VERSION = "1.0.0", _internals15;
+var VALID_EVIDENCE_TYPES2, REQUIRED_EVIDENCE_TYPES, EVIDENCE_SUMMARY_VERSION = "1.0.0", _internals12;
 var init_evidence_summary_service = __esm(() => {
   init_manager2();
   init_manager();
@@ -43655,7 +42882,7 @@ var init_evidence_summary_service = __esm(() => {
     "retrospective"
   ]);
   REQUIRED_EVIDENCE_TYPES = ["review", "test"];
-  _internals15 = {
+  _internals12 = {
     buildEvidenceSummary,
     isAutoSummaryEnabled,
     normalizeBundleEntries,
@@ -43710,7 +42937,7 @@ function getVerdictEmoji(verdict) {
   return getVerdictIcon(verdict);
 }
 async function getTaskEvidenceData(directory, taskId) {
-  const result = await _internals16.loadEvidence(directory, taskId);
+  const result = await _internals13.loadEvidence(directory, taskId);
   if (result.status !== "found") {
     return {
       hasEvidence: false,
@@ -43733,13 +42960,13 @@ async function getTaskEvidenceData(directory, taskId) {
   };
 }
 async function getEvidenceListData(directory) {
-  const taskIds = await _internals16.listEvidenceTaskIds(directory);
+  const taskIds = await _internals13.listEvidenceTaskIds(directory);
   if (taskIds.length === 0) {
     return { hasEvidence: false, tasks: [] };
   }
   const tasks = [];
   for (const taskId of taskIds) {
-    const result = await _internals16.loadEvidence(directory, taskId);
+    const result = await _internals13.loadEvidence(directory, taskId);
     if (result.status === "found") {
       tasks.push({
         taskId,
@@ -43853,10 +43080,10 @@ async function handleEvidenceSummaryCommand(directory) {
   return lines.join(`
 `);
 }
-var _internals16;
+var _internals13;
 var init_evidence_service = __esm(() => {
   init_manager2();
-  _internals16 = {
+  _internals13 = {
     loadEvidence,
     listEvidenceTaskIds
   };
@@ -43907,12 +43134,12 @@ var init_export = __esm(() => {
 
 // src/full-auto/state.ts
 import * as fs11 from "fs";
-import * as path26 from "path";
+import * as path25 from "path";
 function nowISO() {
   return new Date().toISOString();
 }
 function ensureSwarmDir(directory) {
-  const swarmDir = path26.resolve(directory, ".swarm");
+  const swarmDir = path25.resolve(directory, ".swarm");
   if (!fs11.existsSync(swarmDir)) {
     fs11.mkdirSync(swarmDir, { recursive: true });
   }
@@ -44263,7 +43490,7 @@ function extractCurrentPhaseFromPlan2(plan) {
   if (!plan) {
     return { currentPhase: null, currentTask: null, incompleteTasks: [] };
   }
-  if (!_internals17.validatePlanPhases(plan)) {
+  if (!_internals14.validatePlanPhases(plan)) {
     return { currentPhase: null, currentTask: null, incompleteTasks: [] };
   }
   let currentPhase = null;
@@ -44405,9 +43632,9 @@ function extractPhaseMetrics(content) {
 async function getHandoffData(directory) {
   const now = new Date().toISOString();
   const sessionContent = await readSwarmFileAsync(directory, "session/state.json");
-  const sessionState = _internals17.parseSessionState(sessionContent);
+  const sessionState = _internals14.parseSessionState(sessionContent);
   const plan = await loadPlanJsonOnly(directory);
-  const planInfo = _internals17.extractCurrentPhaseFromPlan(plan);
+  const planInfo = _internals14.extractCurrentPhaseFromPlan(plan);
   if (!plan) {
     const planMdContent = await readSwarmFileAsync(directory, "plan.md");
     if (planMdContent) {
@@ -44426,8 +43653,8 @@ async function getHandoffData(directory) {
     }
   }
   const contextContent = await readSwarmFileAsync(directory, "context.md");
-  const recentDecisions = _internals17.extractDecisions(contextContent);
-  const rawPhaseMetrics = _internals17.extractPhaseMetrics(contextContent);
+  const recentDecisions = _internals14.extractDecisions(contextContent);
+  const rawPhaseMetrics = _internals14.extractPhaseMetrics(contextContent);
   const phaseMetrics = sanitizeString(rawPhaseMetrics, 1000);
   let delegationState = null;
   if (sessionState?.delegationState) {
@@ -44591,13 +43818,13 @@ ${lines.join(`
 `)}
 \`\`\``;
 }
-var RTL_OVERRIDE_PATTERN, MAX_TASK_ID_LENGTH = 100, MAX_DECISION_LENGTH = 500, MAX_INCOMPLETE_TASKS = 20, _internals17;
+var RTL_OVERRIDE_PATTERN, MAX_TASK_ID_LENGTH = 100, MAX_DECISION_LENGTH = 500, MAX_INCOMPLETE_TASKS = 20, _internals14;
 var init_handoff_service = __esm(() => {
   init_utils2();
   init_manager();
   init_utils();
   RTL_OVERRIDE_PATTERN = /[\u202e\u202d\u202c\u200f]/g;
-  _internals17 = {
+  _internals14 = {
     getHandoffData,
     formatHandoffMarkdown,
     formatContinuationPrompt,
@@ -44613,7 +43840,7 @@ var init_handoff_service = __esm(() => {
 
 // src/session/snapshot-writer.ts
 import { closeSync as closeSync3, fsyncSync as fsyncSync2, mkdirSync as mkdirSync10, openSync as openSync3, renameSync as renameSync6 } from "fs";
-import * as path27 from "path";
+import * as path26 from "path";
 function serializeAgentSession(s) {
   const gateLog = {};
   const rawGateLog = s.gateLog ?? new Map;
@@ -44710,7 +43937,7 @@ async function writeSnapshot(directory, state) {
     }
     const content = JSON.stringify(snapshot, null, 2);
     const resolvedPath = validateSwarmPath(directory, "session/state.json");
-    const dir = path27.dirname(resolvedPath);
+    const dir = path26.dirname(resolvedPath);
     mkdirSync10(dir, { recursive: true });
     const tempPath = `${resolvedPath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2)}`;
     await bunWrite(tempPath, content);
@@ -44731,22 +43958,22 @@ async function writeSnapshot(directory, state) {
 }
 function createSnapshotWriterHook(directory) {
   return (_input, _output) => {
-    _writeInFlight = _writeInFlight.then(() => _internals18.writeSnapshot(directory, swarmState), () => _internals18.writeSnapshot(directory, swarmState));
+    _writeInFlight = _writeInFlight.then(() => _internals15.writeSnapshot(directory, swarmState), () => _internals15.writeSnapshot(directory, swarmState));
     return _writeInFlight;
   };
 }
 async function flushPendingSnapshot(directory) {
-  _writeInFlight = _writeInFlight.then(() => _internals18.writeSnapshot(directory, swarmState), () => _internals18.writeSnapshot(directory, swarmState));
+  _writeInFlight = _writeInFlight.then(() => _internals15.writeSnapshot(directory, swarmState), () => _internals15.writeSnapshot(directory, swarmState));
   await _writeInFlight;
 }
-var _writeInFlight, _internals18;
+var _writeInFlight, _internals15;
 var init_snapshot_writer = __esm(() => {
   init_utils2();
   init_state();
   init_utils();
   init_bun_compat();
   _writeInFlight = Promise.resolve();
-  _internals18 = {
+  _internals15 = {
     writeSnapshot,
     createSnapshotWriterHook,
     flushPendingSnapshot
@@ -45169,7 +44396,7 @@ var init_issue = __esm(() => {
 import { randomUUID as randomUUID2 } from "crypto";
 import { existsSync as existsSync17, readFileSync as readFileSync12 } from "fs";
 import { mkdir as mkdir7, readFile as readFile7, writeFile as writeFile8 } from "fs/promises";
-import * as path28 from "path";
+import * as path27 from "path";
 async function migrateKnowledgeToExternal(_directory, _config) {
   return {
     migrated: false,
@@ -45180,8 +44407,8 @@ async function migrateKnowledgeToExternal(_directory, _config) {
   };
 }
 async function migrateContextToKnowledge(directory, config3) {
-  const sentinelPath = path28.join(directory, ".swarm", ".knowledge-migrated");
-  const contextPath = path28.join(directory, ".swarm", "context.md");
+  const sentinelPath = path27.join(directory, ".swarm", ".knowledge-migrated");
+  const contextPath = path27.join(directory, ".swarm", "context.md");
   const knowledgePath = resolveSwarmKnowledgePath(directory);
   if (existsSync17(sentinelPath)) {
     return {
@@ -45211,9 +44438,9 @@ async function migrateContextToKnowledge(directory, config3) {
       skippedReason: "empty-context"
     };
   }
-  const rawEntries = _internals19.parseContextMd(contextContent);
+  const rawEntries = _internals16.parseContextMd(contextContent);
   if (rawEntries.length === 0) {
-    await _internals19.writeSentinel(sentinelPath, 0, 0);
+    await _internals16.writeSentinel(sentinelPath, 0, 0);
     return {
       migrated: true,
       entriesMigrated: 0,
@@ -45224,10 +44451,10 @@ async function migrateContextToKnowledge(directory, config3) {
   const existing = await readKnowledge(knowledgePath);
   let migrated = 0;
   let dropped = 0;
-  const projectName = _internals19.inferProjectName(directory);
+  const projectName = _internals16.inferProjectName(directory);
   for (const raw of rawEntries) {
     if (config3.validation_enabled !== false) {
-      const category = raw.categoryHint ?? _internals19.inferCategoryFromText(raw.text);
+      const category = raw.categoryHint ?? _internals16.inferCategoryFromText(raw.text);
       const result = validateLesson(raw.text, existing.map((e) => e.lesson), {
         category,
         scope: "global",
@@ -45247,8 +44474,8 @@ async function migrateContextToKnowledge(directory, config3) {
     const entry = {
       id: randomUUID2(),
       tier: "swarm",
-      lesson: _internals19.truncateLesson(raw.text),
-      category: raw.categoryHint ?? _internals19.inferCategoryFromText(raw.text),
+      lesson: _internals16.truncateLesson(raw.text),
+      category: raw.categoryHint ?? _internals16.inferCategoryFromText(raw.text),
       tags: [...inferredTags, `migration:${raw.sourceSection}`],
       scope: "global",
       confidence: 0.3,
@@ -45271,7 +44498,7 @@ async function migrateContextToKnowledge(directory, config3) {
   if (migrated > 0) {
     await rewriteKnowledge(knowledgePath, existing);
   }
-  await _internals19.writeSentinel(sentinelPath, migrated, dropped);
+  await _internals16.writeSentinel(sentinelPath, migrated, dropped);
   log(`[knowledge-migrator] Migrated ${migrated} entries, dropped ${dropped}`);
   return {
     migrated: true,
@@ -45281,7 +44508,7 @@ async function migrateContextToKnowledge(directory, config3) {
   };
 }
 function parseContextMd(content) {
-  const sections = _internals19.splitIntoSections(content);
+  const sections = _internals16.splitIntoSections(content);
   const entries = [];
   const seen = new Set;
   const sectionPatterns = [
@@ -45297,7 +44524,7 @@ function parseContextMd(content) {
     const match = sectionPatterns.find((sp) => sp.pattern.test(section.heading));
     if (!match)
       continue;
-    const bullets = _internals19.extractBullets(section.body);
+    const bullets = _internals16.extractBullets(section.body);
     for (const bullet of bullets) {
       if (bullet.length < 15)
         continue;
@@ -45306,9 +44533,9 @@ function parseContextMd(content) {
         continue;
       seen.add(normalized);
       entries.push({
-        text: _internals19.truncateLesson(bullet),
+        text: _internals16.truncateLesson(bullet),
         sourceSection: match.sourceSection,
-        categoryHint: _internals19.inferCategoryFromText(bullet)
+        categoryHint: _internals16.inferCategoryFromText(bullet)
       });
     }
   }
@@ -45377,7 +44604,7 @@ function truncateLesson(text) {
   return `${text.slice(0, 277)}...`;
 }
 function inferProjectName(directory) {
-  const packageJsonPath = path28.join(directory, "package.json");
+  const packageJsonPath = path27.join(directory, "package.json");
   if (existsSync17(packageJsonPath)) {
     try {
       const pkg = JSON.parse(readFileSync12(packageJsonPath, "utf-8"));
@@ -45386,7 +44613,7 @@ function inferProjectName(directory) {
       }
     } catch {}
   }
-  return path28.basename(directory);
+  return path27.basename(directory);
 }
 async function writeSentinel(sentinelPath, migrated, dropped) {
   const sentinel = {
@@ -45398,15 +44625,15 @@ async function writeSentinel(sentinelPath, migrated, dropped) {
     schema_version: 1,
     migration_tool: "knowledge-migrator.ts"
   };
-  await mkdir7(path28.dirname(sentinelPath), { recursive: true });
+  await mkdir7(path27.dirname(sentinelPath), { recursive: true });
   await writeFile8(sentinelPath, JSON.stringify(sentinel, null, 2), "utf-8");
 }
-var _internals19;
+var _internals16;
 var init_knowledge_migrator = __esm(() => {
   init_logger();
   init_knowledge_store();
   init_knowledge_validator();
-  _internals19 = {
+  _internals16 = {
     migrateContextToKnowledge,
     migrateKnowledgeToExternal,
     parseContextMd,
@@ -45420,7 +44647,7 @@ var init_knowledge_migrator = __esm(() => {
 });
 
 // src/commands/knowledge.ts
-import { join as join26 } from "path";
+import { join as join25 } from "path";
 function resolveEntryByPrefix(entries, inputId) {
   const exact = entries.find((e) => e.id === inputId);
   if (exact)
@@ -45471,7 +44698,7 @@ async function handleKnowledgeRestoreCommand(directory, args) {
     return "Invalid entry ID. IDs must be 1-64 characters: letters, digits, hyphens, underscores only.";
   }
   try {
-    const quarantinePath = join26(directory, ".swarm", "knowledge-quarantined.jsonl");
+    const quarantinePath = join25(directory, ".swarm", "knowledge-quarantined.jsonl");
     const entries = await readKnowledge(quarantinePath);
     const resolved = resolveEntryByPrefix(entries, inputId);
     if ("error" in resolved) {
@@ -45543,9 +44770,9 @@ var init_knowledge = __esm(() => {
 
 // src/services/plan-service.ts
 async function getPlanData(directory, phaseArg) {
-  const plan = await _internals20.loadPlanJsonOnly(directory);
+  const plan = await _internals17.loadPlanJsonOnly(directory);
   if (plan) {
-    const fullMarkdown = _internals20.derivePlanMarkdown(plan);
+    const fullMarkdown = _internals17.derivePlanMarkdown(plan);
     if (phaseArg === undefined || phaseArg === null || phaseArg === "") {
       return {
         hasPlan: true,
@@ -45588,7 +44815,7 @@ async function getPlanData(directory, phaseArg) {
       isLegacy: false
     };
   }
-  const planContent = await _internals20.readSwarmFileAsync(directory, "plan.md");
+  const planContent = await _internals17.readSwarmFileAsync(directory, "plan.md");
   if (!planContent) {
     return {
       hasPlan: false,
@@ -45684,11 +44911,11 @@ async function handlePlanCommand(directory, args) {
   const planData = await getPlanData(directory, phaseArg);
   return formatPlanMarkdown(planData);
 }
-var _internals20;
+var _internals17;
 var init_plan_service = __esm(() => {
   init_utils2();
   init_manager();
-  _internals20 = {
+  _internals17 = {
     loadPlanJsonOnly,
     derivePlanMarkdown,
     readSwarmFileAsync
@@ -45926,7 +45153,7 @@ var init_path_security = () => {};
 
 // src/tools/lint.ts
 import * as fs12 from "fs";
-import * as path29 from "path";
+import * as path28 from "path";
 function validateArgs(args) {
   if (typeof args !== "object" || args === null)
     return false;
@@ -45937,9 +45164,9 @@ function validateArgs(args) {
 }
 function getLinterCommand(linter, mode, projectDir) {
   const isWindows = process.platform === "win32";
-  const binDir = path29.join(projectDir, "node_modules", ".bin");
-  const biomeBin = isWindows ? path29.join(binDir, "biome.EXE") : path29.join(binDir, "biome");
-  const eslintBin = isWindows ? path29.join(binDir, "eslint.cmd") : path29.join(binDir, "eslint");
+  const binDir = path28.join(projectDir, "node_modules", ".bin");
+  const biomeBin = isWindows ? path28.join(binDir, "biome.EXE") : path28.join(binDir, "biome");
+  const eslintBin = isWindows ? path28.join(binDir, "eslint.cmd") : path28.join(binDir, "eslint");
   switch (linter) {
     case "biome":
       if (mode === "fix") {
@@ -45955,7 +45182,7 @@ function getLinterCommand(linter, mode, projectDir) {
 }
 function getAdditionalLinterCommand(linter, mode, cwd) {
   const gradlewName = process.platform === "win32" ? "gradlew.bat" : "gradlew";
-  const gradlew = fs12.existsSync(path29.join(cwd, gradlewName)) ? path29.join(cwd, gradlewName) : null;
+  const gradlew = fs12.existsSync(path28.join(cwd, gradlewName)) ? path28.join(cwd, gradlewName) : null;
   switch (linter) {
     case "ruff":
       return mode === "fix" ? ["ruff", "check", "--fix", "."] : ["ruff", "check", "."];
@@ -45989,10 +45216,10 @@ function getAdditionalLinterCommand(linter, mode, cwd) {
   }
 }
 function detectRuff(cwd) {
-  if (fs12.existsSync(path29.join(cwd, "ruff.toml")))
+  if (fs12.existsSync(path28.join(cwd, "ruff.toml")))
     return isCommandAvailable("ruff");
   try {
-    const pyproject = path29.join(cwd, "pyproject.toml");
+    const pyproject = path28.join(cwd, "pyproject.toml");
     if (fs12.existsSync(pyproject)) {
       const content = fs12.readFileSync(pyproject, "utf-8");
       if (content.includes("[tool.ruff]"))
@@ -46002,19 +45229,19 @@ function detectRuff(cwd) {
   return false;
 }
 function detectClippy(cwd) {
-  return fs12.existsSync(path29.join(cwd, "Cargo.toml")) && isCommandAvailable("cargo");
+  return fs12.existsSync(path28.join(cwd, "Cargo.toml")) && isCommandAvailable("cargo");
 }
 function detectGolangciLint(cwd) {
-  return fs12.existsSync(path29.join(cwd, "go.mod")) && isCommandAvailable("golangci-lint");
+  return fs12.existsSync(path28.join(cwd, "go.mod")) && isCommandAvailable("golangci-lint");
 }
 function detectCheckstyle(cwd) {
-  const hasMaven = fs12.existsSync(path29.join(cwd, "pom.xml"));
-  const hasGradle = fs12.existsSync(path29.join(cwd, "build.gradle")) || fs12.existsSync(path29.join(cwd, "build.gradle.kts"));
-  const hasBinary = hasMaven && isCommandAvailable("mvn") || hasGradle && (fs12.existsSync(path29.join(cwd, "gradlew")) || isCommandAvailable("gradle"));
+  const hasMaven = fs12.existsSync(path28.join(cwd, "pom.xml"));
+  const hasGradle = fs12.existsSync(path28.join(cwd, "build.gradle")) || fs12.existsSync(path28.join(cwd, "build.gradle.kts"));
+  const hasBinary = hasMaven && isCommandAvailable("mvn") || hasGradle && (fs12.existsSync(path28.join(cwd, "gradlew")) || isCommandAvailable("gradle"));
   return (hasMaven || hasGradle) && hasBinary;
 }
 function detectKtlint(cwd) {
-  const hasKotlin = fs12.existsSync(path29.join(cwd, "build.gradle.kts")) || fs12.existsSync(path29.join(cwd, "build.gradle")) || (() => {
+  const hasKotlin = fs12.existsSync(path28.join(cwd, "build.gradle.kts")) || fs12.existsSync(path28.join(cwd, "build.gradle")) || (() => {
     try {
       return fs12.readdirSync(cwd).some((f) => f.endsWith(".kt") || f.endsWith(".kts"));
     } catch {
@@ -46033,11 +45260,11 @@ function detectDotnetFormat(cwd) {
   }
 }
 function detectCppcheck(cwd) {
-  if (fs12.existsSync(path29.join(cwd, "CMakeLists.txt"))) {
+  if (fs12.existsSync(path28.join(cwd, "CMakeLists.txt"))) {
     return isCommandAvailable("cppcheck");
   }
   try {
-    const dirsToCheck = [cwd, path29.join(cwd, "src")];
+    const dirsToCheck = [cwd, path28.join(cwd, "src")];
     const hasCpp = dirsToCheck.some((dir) => {
       try {
         return fs12.readdirSync(dir).some((f) => /\.(c|cpp|cc|cxx|h|hpp)$/.test(f));
@@ -46051,13 +45278,13 @@ function detectCppcheck(cwd) {
   }
 }
 function detectSwiftlint(cwd) {
-  return fs12.existsSync(path29.join(cwd, "Package.swift")) && isCommandAvailable("swiftlint");
+  return fs12.existsSync(path28.join(cwd, "Package.swift")) && isCommandAvailable("swiftlint");
 }
 function detectDartAnalyze(cwd) {
-  return fs12.existsSync(path29.join(cwd, "pubspec.yaml")) && (isCommandAvailable("dart") || isCommandAvailable("flutter"));
+  return fs12.existsSync(path28.join(cwd, "pubspec.yaml")) && (isCommandAvailable("dart") || isCommandAvailable("flutter"));
 }
 function detectRubocop(cwd) {
-  return (fs12.existsSync(path29.join(cwd, "Gemfile")) || fs12.existsSync(path29.join(cwd, "gems.rb")) || fs12.existsSync(path29.join(cwd, ".rubocop.yml"))) && (isCommandAvailable("rubocop") || isCommandAvailable("bundle"));
+  return (fs12.existsSync(path28.join(cwd, "Gemfile")) || fs12.existsSync(path28.join(cwd, "gems.rb")) || fs12.existsSync(path28.join(cwd, ".rubocop.yml"))) && (isCommandAvailable("rubocop") || isCommandAvailable("bundle"));
 }
 function detectAdditionalLinter(cwd) {
   if (detectRuff(cwd))
@@ -46085,10 +45312,10 @@ function detectAdditionalLinter(cwd) {
 function findBinInAncestors(startDir, binName) {
   let dir = startDir;
   while (true) {
-    const candidate = path29.join(dir, "node_modules", ".bin", binName);
+    const candidate = path28.join(dir, "node_modules", ".bin", binName);
     if (fs12.existsSync(candidate))
       return candidate;
-    const parent = path29.dirname(dir);
+    const parent = path28.dirname(dir);
     if (parent === dir)
       break;
     dir = parent;
@@ -46097,10 +45324,10 @@ function findBinInAncestors(startDir, binName) {
 }
 function findBinInEnvPath(binName) {
   const searchPath = process.env.PATH ?? "";
-  for (const dir of searchPath.split(path29.delimiter)) {
+  for (const dir of searchPath.split(path28.delimiter)) {
     if (!dir)
       continue;
-    const candidate = path29.join(dir, binName);
+    const candidate = path28.join(dir, binName);
     if (fs12.existsSync(candidate))
       return candidate;
   }
@@ -46113,13 +45340,13 @@ async function detectAvailableLinter(directory) {
     return null;
   const projectDir = directory;
   const isWindows = process.platform === "win32";
-  const biomeBin = isWindows ? path29.join(projectDir, "node_modules", ".bin", "biome.EXE") : path29.join(projectDir, "node_modules", ".bin", "biome");
-  const eslintBin = isWindows ? path29.join(projectDir, "node_modules", ".bin", "eslint.cmd") : path29.join(projectDir, "node_modules", ".bin", "eslint");
+  const biomeBin = isWindows ? path28.join(projectDir, "node_modules", ".bin", "biome.EXE") : path28.join(projectDir, "node_modules", ".bin", "biome");
+  const eslintBin = isWindows ? path28.join(projectDir, "node_modules", ".bin", "eslint.cmd") : path28.join(projectDir, "node_modules", ".bin", "eslint");
   const localResult = await _detectAvailableLinter(projectDir, biomeBin, eslintBin);
   if (localResult)
     return localResult;
-  const biomeAncestor = findBinInAncestors(path29.dirname(projectDir), isWindows ? "biome.EXE" : "biome");
-  const eslintAncestor = findBinInAncestors(path29.dirname(projectDir), isWindows ? "eslint.cmd" : "eslint");
+  const biomeAncestor = findBinInAncestors(path28.dirname(projectDir), isWindows ? "biome.EXE" : "biome");
+  const eslintAncestor = findBinInAncestors(path28.dirname(projectDir), isWindows ? "eslint.cmd" : "eslint");
   if (biomeAncestor || eslintAncestor) {
     return _detectAvailableLinter(projectDir, biomeAncestor ?? biomeBin, eslintAncestor ?? eslintBin);
   }
@@ -46278,7 +45505,7 @@ async function runAdditionalLint(linter, mode, cwd) {
     };
   }
 }
-var MAX_OUTPUT_BYTES = 512000, MAX_COMMAND_LENGTH = 500, lint, _internals21;
+var MAX_OUTPUT_BYTES = 512000, MAX_COMMAND_LENGTH = 500, lint, _internals18;
 var init_lint = __esm(() => {
   init_zod();
   init_discovery();
@@ -46310,15 +45537,15 @@ var init_lint = __esm(() => {
       }
       const { mode } = args;
       const cwd = directory;
-      const linter = await _internals21.detectAvailableLinter(directory);
+      const linter = await _internals18.detectAvailableLinter(directory);
       if (linter) {
-        const result = await _internals21.runLint(linter, mode, directory);
+        const result = await _internals18.runLint(linter, mode, directory);
         return JSON.stringify(result, null, 2);
       }
-      const additionalLinter = _internals21.detectAdditionalLinter(cwd);
+      const additionalLinter = _internals18.detectAdditionalLinter(cwd);
       if (additionalLinter) {
         warn(`[lint] Using ${additionalLinter} linter for this project`);
-        const result = await _internals21.runAdditionalLint(additionalLinter, mode, cwd);
+        const result = await _internals18.runAdditionalLint(additionalLinter, mode, cwd);
         return JSON.stringify(result, null, 2);
       }
       const errorResult = {
@@ -46332,7 +45559,7 @@ For Rust: rustup component add clippy`
       return JSON.stringify(errorResult, null, 2);
     }
   });
-  _internals21 = {
+  _internals18 = {
     detectAvailableLinter,
     runLint,
     detectAdditionalLinter,
@@ -46342,7 +45569,7 @@ For Rust: rustup component add clippy`
 
 // src/tools/secretscan.ts
 import * as fs13 from "fs";
-import * as path30 from "path";
+import * as path29 from "path";
 function calculateShannonEntropy(str) {
   if (str.length === 0)
     return 0;
@@ -46390,7 +45617,7 @@ function isGlobOrPathPattern(pattern) {
   return pattern.includes("/") || pattern.includes("\\") || /[*?[\]{}]/.test(pattern);
 }
 function loadSecretScanIgnore(scanDir) {
-  const ignorePath = path30.join(scanDir, ".secretscanignore");
+  const ignorePath = path29.join(scanDir, ".secretscanignore");
   try {
     if (!fs13.existsSync(ignorePath))
       return [];
@@ -46413,7 +45640,7 @@ function isExcluded(entry, relPath, exactNames, globPatterns) {
   if (exactNames.has(entry))
     return true;
   for (const pattern of globPatterns) {
-    if (path30.matchesGlob(relPath, pattern))
+    if (path29.matchesGlob(relPath, pattern))
       return true;
   }
   return false;
@@ -46434,7 +45661,7 @@ function validateDirectoryInput(dir) {
   return null;
 }
 function isBinaryFile(filePath, buffer) {
-  const ext = path30.extname(filePath).toLowerCase();
+  const ext = path29.extname(filePath).toLowerCase();
   if (DEFAULT_EXCLUDE_EXTENSIONS.has(ext)) {
     return true;
   }
@@ -46570,9 +45797,9 @@ function isSymlinkLoop(realPath, visited) {
   return false;
 }
 function isPathWithinScope(realPath, scanDir) {
-  const resolvedScanDir = path30.resolve(scanDir);
-  const resolvedRealPath = path30.resolve(realPath);
-  return resolvedRealPath === resolvedScanDir || resolvedRealPath.startsWith(resolvedScanDir + path30.sep) || resolvedRealPath.startsWith(`${resolvedScanDir}/`) || resolvedRealPath.startsWith(`${resolvedScanDir}\\`);
+  const resolvedScanDir = path29.resolve(scanDir);
+  const resolvedRealPath = path29.resolve(realPath);
+  return resolvedRealPath === resolvedScanDir || resolvedRealPath.startsWith(resolvedScanDir + path29.sep) || resolvedRealPath.startsWith(`${resolvedScanDir}/`) || resolvedRealPath.startsWith(`${resolvedScanDir}\\`);
 }
 function findScannableFiles(dir, excludeExact, excludeGlobs, scanDir, visited, stats = {
   skippedDirs: 0,
@@ -46598,8 +45825,8 @@ function findScannableFiles(dir, excludeExact, excludeGlobs, scanDir, visited, s
     return a.localeCompare(b);
   });
   for (const entry of entries) {
-    const fullPath = path30.join(dir, entry);
-    const relPath = path30.relative(scanDir, fullPath).replace(/\\/g, "/");
+    const fullPath = path29.join(dir, entry);
+    const relPath = path29.relative(scanDir, fullPath).replace(/\\/g, "/");
     if (isExcluded(entry, relPath, excludeExact, excludeGlobs)) {
       stats.skippedDirs++;
       continue;
@@ -46634,7 +45861,7 @@ function findScannableFiles(dir, excludeExact, excludeGlobs, scanDir, visited, s
       const subFiles = findScannableFiles(fullPath, excludeExact, excludeGlobs, scanDir, visited, stats);
       files.push(...subFiles);
     } else if (lstat.isFile()) {
-      const ext = path30.extname(fullPath).toLowerCase();
+      const ext = path29.extname(fullPath).toLowerCase();
       if (!DEFAULT_EXCLUDE_EXTENSIONS.has(ext)) {
         files.push(fullPath);
       } else {
@@ -46646,7 +45873,7 @@ function findScannableFiles(dir, excludeExact, excludeGlobs, scanDir, visited, s
 }
 async function runSecretscan(directory) {
   try {
-    const result = await _internals22.secretscan.execute({ directory }, {});
+    const result = await _internals19.secretscan.execute({ directory }, {});
     const jsonStr = typeof result === "string" ? result : result.output;
     return JSON.parse(jsonStr);
   } catch (e) {
@@ -46661,7 +45888,7 @@ async function runSecretscan(directory) {
     return errorResult;
   }
 }
-var MAX_FILE_PATH_LENGTH = 500, MAX_FILE_SIZE_BYTES, MAX_FILES_SCANNED = 1000, MAX_FINDINGS = 100, MAX_OUTPUT_BYTES2 = 512000, MAX_LINE_LENGTH = 1e4, MAX_CONTENT_BYTES, BINARY_SIGNATURES, BINARY_PREFIX_BYTES = 4, BINARY_NULL_CHECK_BYTES = 8192, BINARY_NULL_THRESHOLD = 0.1, DEFAULT_EXCLUDE_DIRS, DEFAULT_EXCLUDE_EXTENSIONS, SECRET_PATTERNS, O_NOFOLLOW, secretscan, _internals22;
+var MAX_FILE_PATH_LENGTH = 500, MAX_FILE_SIZE_BYTES, MAX_FILES_SCANNED = 1000, MAX_FINDINGS = 100, MAX_OUTPUT_BYTES2 = 512000, MAX_LINE_LENGTH = 1e4, MAX_CONTENT_BYTES, BINARY_SIGNATURES, BINARY_PREFIX_BYTES = 4, BINARY_NULL_CHECK_BYTES = 8192, BINARY_NULL_THRESHOLD = 0.1, DEFAULT_EXCLUDE_DIRS, DEFAULT_EXCLUDE_EXTENSIONS, SECRET_PATTERNS, O_NOFOLLOW, secretscan, _internals19;
 var init_secretscan = __esm(() => {
   init_zod();
   init_path_security();
@@ -46894,7 +46121,7 @@ var init_secretscan = __esm(() => {
         }
       }
       try {
-        const _scanDirRaw = path30.resolve(directory);
+        const _scanDirRaw = path29.resolve(directory);
         const scanDir = (() => {
           try {
             return fs13.realpathSync(_scanDirRaw);
@@ -47033,7 +46260,7 @@ var init_secretscan = __esm(() => {
       }
     }
   });
-  _internals22 = {
+  _internals19 = {
     secretscan,
     runSecretscan
   };
@@ -47041,7 +46268,7 @@ var init_secretscan = __esm(() => {
 
 // src/lang/default-backend.ts
 import * as fs14 from "fs";
-import * as path31 from "path";
+import * as path30 from "path";
 function detectFileExists(dir, pattern) {
   if (pattern.includes("*") || pattern.includes("?")) {
     try {
@@ -47053,7 +46280,7 @@ function detectFileExists(dir, pattern) {
     }
   }
   try {
-    fs14.accessSync(path31.join(dir, pattern));
+    fs14.accessSync(path30.join(dir, pattern));
     return true;
   } catch {
     return false;
@@ -47181,8 +46408,8 @@ function defaultBuildTestCommand(profile, framework, files, dir = ".", opts = {}
       return ["mvn", "test"];
     case "gradle": {
       const isWindows = process.platform === "win32";
-      const hasGradlewBat = fs14.existsSync(path31.join(dir, "gradlew.bat"));
-      const hasGradlew = fs14.existsSync(path31.join(dir, "gradlew"));
+      const hasGradlewBat = fs14.existsSync(path30.join(dir, "gradlew.bat"));
+      const hasGradlew = fs14.existsSync(path30.join(dir, "gradlew"));
       if (hasGradlewBat && isWindows)
         return ["gradlew.bat", "test"];
       if (hasGradlew)
@@ -47199,7 +46426,7 @@ function defaultBuildTestCommand(profile, framework, files, dir = ".", opts = {}
         "cmake-build-release",
         "out"
       ];
-      const actualBuildDir = buildDirCandidates.find((d) => fs14.existsSync(path31.join(dir, d, "CMakeCache.txt"))) ?? "build";
+      const actualBuildDir = buildDirCandidates.find((d) => fs14.existsSync(path30.join(dir, d, "CMakeCache.txt"))) ?? "build";
       return ["ctest", "--test-dir", actualBuildDir];
     }
     case "swift-test":
@@ -47486,17 +46713,17 @@ async function defaultSelectBuildCommand(profile, dir) {
   return null;
 }
 async function defaultTestFilesFor(profile, sourceFile, dir) {
-  const ext = path31.extname(sourceFile);
+  const ext = path30.extname(sourceFile);
   if (!profile.extensions.includes(ext))
     return [];
-  const base = path31.basename(sourceFile, ext);
-  const rel = path31.relative(dir, sourceFile);
-  const relDir = path31.dirname(rel);
+  const base = path30.basename(sourceFile, ext);
+  const rel = path30.relative(dir, sourceFile);
+  const relDir = path30.dirname(rel);
   const stripSrc = relDir.replace(/^src(\/|\\)/, "");
   const candidates = new Set;
   for (const tDir of ["tests", "test", "__tests__", "spec"]) {
     for (const suffix of ["", "_test", ".test", "_spec", ".spec"]) {
-      candidates.add(path31.join(dir, tDir, stripSrc, `${base}${suffix}${ext}`));
+      candidates.add(path30.join(dir, tDir, stripSrc, `${base}${suffix}${ext}`));
     }
   }
   const existing = [];
@@ -47537,7 +46764,7 @@ var init_default_backend = __esm(() => {
 
 // src/lang/backends/go.ts
 import * as fs15 from "fs";
-import * as path32 from "path";
+import * as path31 from "path";
 function extractImports(_sourceFile, source) {
   const out = new Set;
   IMPORT_REGEX_SINGLE.lastIndex = 0;
@@ -47563,7 +46790,7 @@ function extractImports(_sourceFile, source) {
 async function selectFramework(dir) {
   let content;
   try {
-    content = fs15.readFileSync(path32.join(dir, "go.mod"), "utf-8");
+    content = fs15.readFileSync(path31.join(dir, "go.mod"), "utf-8");
   } catch {
     return null;
   }
@@ -47584,16 +46811,16 @@ async function selectFramework(dir) {
 async function selectEntryPoints(dir) {
   const points = [];
   try {
-    fs15.accessSync(path32.join(dir, "main.go"));
+    fs15.accessSync(path31.join(dir, "main.go"));
     points.push("main.go");
   } catch {}
   try {
-    const cmdDir = path32.join(dir, "cmd");
+    const cmdDir = path31.join(dir, "cmd");
     const subdirs = fs15.readdirSync(cmdDir, { withFileTypes: true }).filter((d) => d.isDirectory());
     for (const sub of subdirs) {
-      const main = path32.join("cmd", sub.name, "main.go");
+      const main = path31.join("cmd", sub.name, "main.go");
       try {
-        fs15.accessSync(path32.join(dir, main));
+        fs15.accessSync(path31.join(dir, main));
         points.push(main);
       } catch {}
     }
@@ -47612,19 +46839,19 @@ function buildGoBackend() {
     selectEntryPoints
   };
 }
-var PROFILE_ID = "go", IMPORT_REGEX_SINGLE, IMPORT_REGEX_GROUP, IMPORT_REGEX_GROUP_LINE, _internals23;
+var PROFILE_ID = "go", IMPORT_REGEX_SINGLE, IMPORT_REGEX_GROUP, IMPORT_REGEX_GROUP_LINE, _internals20;
 var init_go = __esm(() => {
   init_default_backend();
   init_profiles();
   IMPORT_REGEX_SINGLE = /^\s*import\s+(?:[a-zA-Z_.][a-zA-Z0-9_]*\s+)?"([^"]+)"/gm;
   IMPORT_REGEX_GROUP = /^\s*import\s*\(([\s\S]*?)\)/gm;
   IMPORT_REGEX_GROUP_LINE = /(?:[a-zA-Z_.][a-zA-Z0-9_]*\s+)?"([^"]+)"/g;
-  _internals23 = { extractImports };
+  _internals20 = { extractImports };
 });
 
 // src/lang/backends/python.ts
 import * as fs16 from "fs";
-import * as path33 from "path";
+import * as path32 from "path";
 function parseImportTargets(rawTargets) {
   const cleaned = rawTargets.replace(/[()]/g, "").split(`
 `).map((line) => line.replace(/#.*$/, "").replace(/\\\s*$/, "")).join(" ");
@@ -47684,7 +46911,7 @@ async function selectFramework2(dir) {
   ];
   for (const candidate of ["pyproject.toml", "requirements.txt", "setup.py"]) {
     try {
-      const content = fs16.readFileSync(path33.join(dir, candidate), "utf-8");
+      const content = fs16.readFileSync(path32.join(dir, candidate), "utf-8");
       const lower = content.toLowerCase();
       for (const [pkg, name] of candidates) {
         if (lower.includes(pkg)) {
@@ -47698,7 +46925,7 @@ async function selectFramework2(dir) {
 async function selectEntryPoints2(dir) {
   const points = new Set;
   try {
-    const content = fs16.readFileSync(path33.join(dir, "pyproject.toml"), "utf-8");
+    const content = fs16.readFileSync(path32.join(dir, "pyproject.toml"), "utf-8");
     const scriptsBlock = content.match(/\[project\.scripts\][\s\S]*?(?=\n\[|$)/);
     if (scriptsBlock) {
       for (const line of scriptsBlock[0].split(`
@@ -47713,7 +46940,7 @@ async function selectEntryPoints2(dir) {
   } catch {}
   for (const name of ["manage.py", "main.py", "app.py", "__main__.py"]) {
     try {
-      fs16.accessSync(path33.join(dir, name));
+      fs16.accessSync(path32.join(dir, name));
       points.add(name);
     } catch {}
   }
@@ -47731,18 +46958,18 @@ function buildPythonBackend() {
     selectEntryPoints: selectEntryPoints2
   };
 }
-var PROFILE_ID2 = "python", IMPORT_REGEX_FROM_WITH_TARGETS, IMPORT_REGEX_IMPORT, _internals24;
+var PROFILE_ID2 = "python", IMPORT_REGEX_FROM_WITH_TARGETS, IMPORT_REGEX_IMPORT, _internals21;
 var init_python = __esm(() => {
   init_default_backend();
   init_profiles();
   IMPORT_REGEX_FROM_WITH_TARGETS = /^\s*from\s+(\.*[\w.]*)\s+import\s+(\([^)]*\)|[^\n#]+)/gm;
   IMPORT_REGEX_IMPORT = /^\s*import\s+([^\n#]+)/gm;
-  _internals24 = { extractImports: extractImports2 };
+  _internals21 = { extractImports: extractImports2 };
 });
 
 // src/test-impact/analyzer.ts
 import fs17 from "fs";
-import path34 from "path";
+import path33 from "path";
 function normalizePath(p) {
   return p.replace(/\\/g, "/");
 }
@@ -47763,8 +46990,8 @@ function resolveRelativeImport(fromDir, importPath) {
   if (!importPath.startsWith(".")) {
     return null;
   }
-  const resolved = path34.resolve(fromDir, importPath);
-  if (path34.extname(resolved)) {
+  const resolved = path33.resolve(fromDir, importPath);
+  if (path33.extname(resolved)) {
     if (fs17.existsSync(resolved) && fs17.statSync(resolved).isFile()) {
       return normalizePath(resolved);
     }
@@ -47784,20 +47011,20 @@ function resolvePythonImport(fromDir, module) {
   const leadingDots = module.match(/^\.+/)?.[0].length ?? 0;
   let baseDir = fromDir;
   for (let i = 1;i < leadingDots; i++) {
-    baseDir = path34.dirname(baseDir);
+    baseDir = path33.dirname(baseDir);
   }
   const rest = module.slice(leadingDots);
   if (rest.length === 0) {
-    const initPath = path34.join(baseDir, "__init__.py");
+    const initPath = path33.join(baseDir, "__init__.py");
     if (fs17.existsSync(initPath) && fs17.statSync(initPath).isFile()) {
       return normalizePath(initPath);
     }
     return null;
   }
-  const subpath = rest.replace(/\./g, path34.sep);
+  const subpath = rest.replace(/\./g, path33.sep);
   const candidates = [
-    `${path34.join(baseDir, subpath)}.py`,
-    path34.join(baseDir, subpath, "__init__.py")
+    `${path33.join(baseDir, subpath)}.py`,
+    path33.join(baseDir, subpath, "__init__.py")
   ];
   for (const c of candidates) {
     if (fs17.existsSync(c) && fs17.statSync(c).isFile())
@@ -47806,7 +47033,7 @@ function resolvePythonImport(fromDir, module) {
   return null;
 }
 function findGoModule(fromDir) {
-  const resolved = path34.resolve(fromDir);
+  const resolved = path33.resolve(fromDir);
   let cur = resolved;
   const walked = [];
   for (let i = 0;i < 16; i++) {
@@ -47818,7 +47045,7 @@ function findGoModule(fromDir) {
     }
     walked.push(cur);
     try {
-      const goMod = path34.join(cur, "go.mod");
+      const goMod = path33.join(cur, "go.mod");
       const content = fs17.readFileSync(goMod, "utf-8");
       const moduleMatch = content.match(/^\s*module\s+"?([^"\s/]+(?:\/[^"\s]+)*)"?/m);
       if (moduleMatch) {
@@ -47829,10 +47056,10 @@ function findGoModule(fromDir) {
       }
     } catch {}
     try {
-      fs17.accessSync(path34.join(cur, ".git"));
+      fs17.accessSync(path33.join(cur, ".git"));
       break;
     } catch {}
-    const parent = path34.dirname(cur);
+    const parent = path33.dirname(cur);
     if (parent === cur)
       break;
     cur = parent;
@@ -47844,12 +47071,12 @@ function findGoModule(fromDir) {
 function resolveGoImport(fromDir, importPath) {
   let dir = null;
   if (importPath.startsWith(".")) {
-    dir = path34.resolve(fromDir, importPath);
+    dir = path33.resolve(fromDir, importPath);
   } else {
     const mod = findGoModule(fromDir);
     if (mod && (importPath === mod.modulePath || importPath.startsWith(`${mod.modulePath}/`))) {
       const subpath = importPath.slice(mod.modulePath.length);
-      dir = path34.join(mod.moduleRoot, subpath);
+      dir = path33.join(mod.moduleRoot, subpath);
     }
   }
   if (dir === null)
@@ -47857,7 +47084,7 @@ function resolveGoImport(fromDir, importPath) {
   if (!fs17.existsSync(dir) || !fs17.statSync(dir).isDirectory())
     return [];
   try {
-    return fs17.readdirSync(dir).filter((f) => f.endsWith(".go") && !f.endsWith("_test.go")).map((f) => normalizePath(path34.join(dir, f)));
+    return fs17.readdirSync(dir).filter((f) => f.endsWith(".go") && !f.endsWith("_test.go")).map((f) => normalizePath(path33.join(dir, f)));
   } catch {
     return [];
   }
@@ -47896,15 +47123,15 @@ function findTestFilesSync(cwd) {
     for (const entry of entries) {
       if (entry.isDirectory()) {
         if (!skipDirs.has(entry.name)) {
-          walk(path34.join(dir, entry.name), visitedInodes);
+          walk(path33.join(dir, entry.name), visitedInodes);
         }
       } else if (entry.isFile()) {
         const name = entry.name;
         const isTsTest = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(name) || dir.includes("__tests__") && /\.(ts|tsx|js|jsx)$/.test(name);
-        const isPyTest = /^test_.+\.py$/.test(name) || /.+_test\.py$/.test(name) || dir.includes(`${path34.sep}tests${path34.sep}`) && name.endsWith(".py");
+        const isPyTest = /^test_.+\.py$/.test(name) || /.+_test\.py$/.test(name) || dir.includes(`${path33.sep}tests${path33.sep}`) && name.endsWith(".py");
         const isGoTest = /.+_test\.go$/.test(name);
         if (isTsTest || isPyTest || isGoTest) {
-          testFiles.push(normalizePath(path34.join(dir, entry.name)));
+          testFiles.push(normalizePath(path33.join(dir, entry.name)));
         }
       }
     }
@@ -47929,8 +47156,8 @@ function extractImports3(content) {
   ];
 }
 function addImpactEdgesForTestFile(testFile, content, impactMap) {
-  const ext = path34.extname(testFile).toLowerCase();
-  const testDir = path34.dirname(testFile);
+  const ext = path33.extname(testFile).toLowerCase();
+  const testDir = path33.dirname(testFile);
   function addEdge(source) {
     if (!impactMap[source])
       impactMap[source] = [];
@@ -47948,7 +47175,7 @@ function addImpactEdgesForTestFile(testFile, content, impactMap) {
     return;
   }
   if (PYTHON_EXTENSIONS.has(ext)) {
-    const modules = _internals24.extractImports(testFile, content);
+    const modules = _internals21.extractImports(testFile, content);
     for (const mod of modules) {
       const resolved = resolvePythonImport(testDir, mod);
       if (resolved !== null)
@@ -47957,7 +47184,7 @@ function addImpactEdgesForTestFile(testFile, content, impactMap) {
     return;
   }
   if (GO_EXTENSIONS.has(ext)) {
-    const imports = _internals23.extractImports(testFile, content);
+    const imports = _internals20.extractImports(testFile, content);
     for (const importPath of imports) {
       const sourceFiles = resolveGoImport(testDir, importPath);
       for (const source of sourceFiles)
@@ -47984,12 +47211,12 @@ async function buildImpactMapInternal(cwd) {
   return impactMap;
 }
 async function buildImpactMap(cwd) {
-  const impactMap = await _internals25.buildImpactMapInternal(cwd);
-  await _internals25.saveImpactMap(cwd, impactMap);
+  const impactMap = await _internals22.buildImpactMapInternal(cwd);
+  await _internals22.saveImpactMap(cwd, impactMap);
   return impactMap;
 }
 async function loadImpactMap(cwd, options) {
-  const cachePath = path34.join(cwd, ".swarm", "cache", "impact-map.json");
+  const cachePath = path33.join(cwd, ".swarm", "cache", "impact-map.json");
   if (fs17.existsSync(cachePath)) {
     try {
       const content = fs17.readFileSync(cachePath, "utf-8");
@@ -47999,7 +47226,7 @@ async function loadImpactMap(cwd, options) {
         const hasValidValues = Object.values(map3).every((v) => Array.isArray(v) && v.every((item) => typeof item === "string"));
         if (hasValidValues) {
           const generatedAt = new Date(data.generatedAt).getTime();
-          if (!_internals25.isCacheStale(map3, generatedAt)) {
+          if (!_internals22.isCacheStale(map3, generatedAt)) {
             return map3;
           }
           if (options?.skipRebuild) {
@@ -48019,15 +47246,15 @@ async function loadImpactMap(cwd, options) {
   if (options?.skipRebuild) {
     return {};
   }
-  return _internals25.buildImpactMap(cwd);
+  return _internals22.buildImpactMap(cwd);
 }
 async function saveImpactMap(cwd, impactMap) {
-  if (!path34.isAbsolute(cwd)) {
+  if (!path33.isAbsolute(cwd)) {
     throw new Error(`saveImpactMap requires an absolute project root path, got: "${cwd}"`);
   }
-  _internals25.validateProjectRoot(cwd);
-  const cacheDir2 = path34.join(cwd, ".swarm", "cache");
-  const cachePath = path34.join(cacheDir2, "impact-map.json");
+  _internals22.validateProjectRoot(cwd);
+  const cacheDir2 = path33.join(cwd, ".swarm", "cache");
+  const cachePath = path33.join(cacheDir2, "impact-map.json");
   if (!fs17.existsSync(cacheDir2)) {
     fs17.mkdirSync(cacheDir2, { recursive: true });
   }
@@ -48049,7 +47276,7 @@ async function analyzeImpact(changedFiles, cwd, budget) {
     };
   }
   const validFiles = changedFiles.filter((f) => typeof f === "string" && f.length > 0 && !f.includes("\x00"));
-  const impactMap = await _internals25.loadImpactMap(cwd);
+  const impactMap = await _internals22.loadImpactMap(cwd);
   const impactedTestsSet = new Set;
   const untestedFiles = [];
   let visitedCount = 0;
@@ -48059,7 +47286,7 @@ async function analyzeImpact(changedFiles, cwd, budget) {
       budgetExceeded = true;
       break;
     }
-    const normalizedChanged = normalizePath(path34.resolve(changedFile));
+    const normalizedChanged = normalizePath(path33.resolve(changedFile));
     const tests = impactMap[normalizedChanged];
     if (tests && tests.length > 0) {
       for (const test of tests) {
@@ -48116,7 +47343,7 @@ async function analyzeImpact(changedFiles, cwd, budget) {
     budgetExceeded
   };
 }
-var IMPORT_REGEX_ES, IMPORT_REGEX_REQUIRE, IMPORT_REGEX_REEXPORT, TS_EXTENSIONS, PYTHON_EXTENSIONS, GO_EXTENSIONS, EXTENSIONS_TO_TRY, goModuleCache, _internals25;
+var IMPORT_REGEX_ES, IMPORT_REGEX_REQUIRE, IMPORT_REGEX_REEXPORT, TS_EXTENSIONS, PYTHON_EXTENSIONS, GO_EXTENSIONS, EXTENSIONS_TO_TRY, goModuleCache, _internals22;
 var init_analyzer = __esm(() => {
   init_manager2();
   init_go();
@@ -48129,7 +47356,7 @@ var init_analyzer = __esm(() => {
   GO_EXTENSIONS = new Set([".go"]);
   EXTENSIONS_TO_TRY = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
   goModuleCache = new Map;
-  _internals25 = {
+  _internals22 = {
     validateProjectRoot,
     normalizePath,
     isCacheStale,
@@ -48352,15 +47579,15 @@ var FLAKY_THRESHOLD = 0.3, MIN_RUNS_FOR_QUARANTINE = 5, MAX_HISTORY_RUNS = 20;
 
 // src/test-impact/history-store.ts
 import fs18 from "fs";
-import path35 from "path";
+import path34 from "path";
 function getHistoryPath(workingDir) {
   if (!workingDir) {
     throw new Error("getHistoryPath requires a working directory \u2014 project root must be provided by the caller");
   }
-  if (!path35.isAbsolute(workingDir)) {
+  if (!path34.isAbsolute(workingDir)) {
     throw new Error(`getHistoryPath requires an absolute project root path, got: "${workingDir}"`);
   }
-  return path35.join(workingDir, ".swarm", "cache", "test-history.jsonl");
+  return path34.join(workingDir, ".swarm", "cache", "test-history.jsonl");
 }
 function sanitizeErrorMessage(errorMessage) {
   if (errorMessage === undefined) {
@@ -48447,8 +47674,8 @@ function batchAppendTestRuns(records, workingDir) {
     }
   }
   const historyPath = getHistoryPath(workingDir);
-  const historyDir = path35.dirname(historyPath);
-  _internals26.validateProjectRoot(workingDir);
+  const historyDir = path34.dirname(historyPath);
+  _internals23.validateProjectRoot(workingDir);
   if (!fs18.existsSync(historyDir)) {
     fs18.mkdirSync(historyDir, { recursive: true });
   }
@@ -48528,7 +47755,7 @@ function getAllHistory(workingDir) {
   records.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
   return records;
 }
-var MAX_HISTORY_PER_TEST = 20, MAX_ERROR_LENGTH = 500, MAX_STACK_LENGTH = 200, MAX_CHANGED_FILES = 50, DANGEROUS_PROPERTY_NAMES, _internals26;
+var MAX_HISTORY_PER_TEST = 20, MAX_ERROR_LENGTH = 500, MAX_STACK_LENGTH = 200, MAX_CHANGED_FILES = 50, DANGEROUS_PROPERTY_NAMES, _internals23;
 var init_history_store = __esm(() => {
   init_manager2();
   DANGEROUS_PROPERTY_NAMES = new Set([
@@ -48536,14 +47763,14 @@ var init_history_store = __esm(() => {
     "constructor",
     "prototype"
   ]);
-  _internals26 = {
+  _internals23 = {
     validateProjectRoot
   };
 });
 
 // src/tools/resolve-working-directory.ts
 import * as fs19 from "fs";
-import * as path36 from "path";
+import * as path35 from "path";
 function resolveWorkingDirectory(workingDirectory, fallbackDirectory) {
   if (workingDirectory == null || workingDirectory === "") {
     return { success: true, directory: fallbackDirectory };
@@ -48563,15 +47790,15 @@ function resolveWorkingDirectory(workingDirectory, fallbackDirectory) {
       };
     }
   }
-  const normalizedDir = path36.normalize(workingDirectory);
-  const pathParts = normalizedDir.split(path36.sep);
+  const normalizedDir = path35.normalize(workingDirectory);
+  const pathParts = normalizedDir.split(path35.sep);
   if (pathParts.includes("..")) {
     return {
       success: false,
       message: "Invalid working_directory: path traversal sequences (..) are not allowed"
     };
   }
-  const resolvedDir = path36.resolve(normalizedDir);
+  const resolvedDir = path35.resolve(normalizedDir);
   let statResult;
   try {
     statResult = fs19.statSync(resolvedDir);
@@ -48587,7 +47814,7 @@ function resolveWorkingDirectory(workingDirectory, fallbackDirectory) {
       message: `Invalid working_directory: path "${resolvedDir}" is not a directory`
     };
   }
-  const resolvedFallback = path36.resolve(fallbackDirectory);
+  const resolvedFallback = path35.resolve(fallbackDirectory);
   let fallbackExists = false;
   try {
     fs19.statSync(resolvedFallback);
@@ -48597,7 +47824,7 @@ function resolveWorkingDirectory(workingDirectory, fallbackDirectory) {
   }
   if (workingDirectory != null && workingDirectory !== "") {
     if (fallbackExists) {
-      const isSubdirectory = resolvedDir.startsWith(resolvedFallback + path36.sep);
+      const isSubdirectory = resolvedDir.startsWith(resolvedFallback + path35.sep);
       if (isSubdirectory) {
         return {
           success: false,
@@ -48652,17 +47879,17 @@ var init_registry_backend = __esm(() => {
 
 // src/lang/backends/typescript.ts
 import * as fs20 from "fs";
-import * as path37 from "path";
+import * as path36 from "path";
 function readPackageJsonRaw(dir) {
   try {
-    const content = fs20.readFileSync(path37.join(dir, "package.json"), "utf-8");
+    const content = fs20.readFileSync(path36.join(dir, "package.json"), "utf-8");
     return JSON.parse(content);
   } catch {
     return null;
   }
 }
 function readPackageJson(dir) {
-  return _internals27.readPackageJsonRaw(dir);
+  return _internals24.readPackageJsonRaw(dir);
 }
 function readPackageJsonTestScript(dir) {
   return readPackageJson(dir)?.scripts?.test ?? null;
@@ -48832,7 +48059,7 @@ function buildTypescriptBackend() {
     selectEntryPoints: selectEntryPoints3
   };
 }
-var PROFILE_ID3 = "typescript", IMPORT_REGEX_ES2, IMPORT_REGEX_BARE, IMPORT_REGEX_REQUIRE2, IMPORT_REGEX_DYNAMIC, IMPORT_REGEX_REEXPORT2, _internals27;
+var PROFILE_ID3 = "typescript", IMPORT_REGEX_ES2, IMPORT_REGEX_BARE, IMPORT_REGEX_REQUIRE2, IMPORT_REGEX_DYNAMIC, IMPORT_REGEX_REEXPORT2, _internals24;
 var init_typescript = __esm(() => {
   init_default_backend();
   init_profiles();
@@ -48841,7 +48068,7 @@ var init_typescript = __esm(() => {
   IMPORT_REGEX_REQUIRE2 = /require\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
   IMPORT_REGEX_DYNAMIC = /import\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
   IMPORT_REGEX_REEXPORT2 = /export\s+(?:\{[^}]*\}|\*)\s+from\s+['"]([^'"]+)['"]/g;
-  _internals27 = {
+  _internals24 = {
     readPackageJsonRaw,
     readPackageJsonTestScript,
     frameworkFromScriptsTest
@@ -48872,10 +48099,10 @@ __export(exports_dispatch, {
   pickedProfiles: () => pickedProfiles,
   pickBackend: () => pickBackend,
   clearDispatchCache: () => clearDispatchCache,
-  _internals: () => _internals28
+  _internals: () => _internals25
 });
 import * as fs21 from "fs";
-import * as path38 from "path";
+import * as path37 from "path";
 function safeReaddirSet(dir) {
   try {
     return new Set(fs21.readdirSync(dir));
@@ -48892,14 +48119,14 @@ function manifestHash(dir) {
     if (!entries.has(name))
       continue;
     try {
-      const stat3 = fs21.statSync(path38.join(dir, name));
+      const stat3 = fs21.statSync(path37.join(dir, name));
       parts.push(`${name}:${stat3.size}:${stat3.mtimeMs}:${stat3.ino}`);
     } catch {}
   }
   return parts.join("|");
 }
 function findManifestRoot(start) {
-  const resolved = path38.resolve(start);
+  const resolved = path37.resolve(start);
   const cached3 = manifestRootCache.get(resolved);
   if (cached3 !== undefined)
     return cached3;
@@ -48918,7 +48145,7 @@ function findManifestRoot(start) {
         return cur;
       }
     }
-    const parent = path38.dirname(cur);
+    const parent = path37.dirname(cur);
     if (parent === cur)
       break;
     cur = parent;
@@ -48927,7 +48154,7 @@ function findManifestRoot(start) {
   return start;
 }
 function evictIfNeeded() {
-  if (cache.size <= _internals28.cacheCapacity)
+  if (cache.size <= _internals25.cacheCapacity)
     return;
   let oldestKey;
   let oldestOrder = Infinity;
@@ -48958,7 +48185,7 @@ async function pickBackend(dir) {
     evictIfNeeded();
     return null;
   }
-  const profiles = await _internals28.detectProjectLanguages(root);
+  const profiles = await _internals25.detectProjectLanguages(root);
   if (profiles.length === 0) {
     cache.set(cacheKey, {
       hash: hash3,
@@ -48990,12 +48217,12 @@ function clearDispatchCache() {
   manifestRootCache.clear();
   insertCounter = 0;
 }
-var _internals28, cache, insertCounter = 0, MANIFEST_FILES, _MANIFEST_SET, manifestRootCache;
+var _internals25, cache, insertCounter = 0, MANIFEST_FILES, _MANIFEST_SET, manifestRootCache;
 var init_dispatch = __esm(() => {
   init_backends();
   init_detector();
   init_registry_backend();
-  _internals28 = {
+  _internals25 = {
     detectProjectLanguages,
     cacheCapacity: 64
   };
@@ -49028,13 +48255,13 @@ var init_dispatch = __esm(() => {
 
 // src/tools/test-runner.ts
 import * as fs22 from "fs";
-import * as path39 from "path";
+import * as path38 from "path";
 async function estimateFanOut(sourceFiles, cwd) {
   try {
     const impactMap = await loadImpactMap(cwd, { skipRebuild: true });
     const uniqueTestFiles = new Set;
     for (const sourceFile of sourceFiles) {
-      const resolvedPath = path39.resolve(cwd, sourceFile);
+      const resolvedPath = path38.resolve(cwd, sourceFile);
       const normalizedPath = resolvedPath.replace(/\\/g, "/");
       const testFiles = impactMap[normalizedPath];
       if (testFiles) {
@@ -49112,14 +48339,14 @@ function hasDevDependency(devDeps, ...patterns) {
   return hasPackageJsonDependency(devDeps, ...patterns);
 }
 function detectGoTest(cwd) {
-  return fs22.existsSync(path39.join(cwd, "go.mod")) && isCommandAvailable("go");
+  return fs22.existsSync(path38.join(cwd, "go.mod")) && isCommandAvailable("go");
 }
 function detectJavaMaven(cwd) {
-  return fs22.existsSync(path39.join(cwd, "pom.xml")) && isCommandAvailable("mvn");
+  return fs22.existsSync(path38.join(cwd, "pom.xml")) && isCommandAvailable("mvn");
 }
 function detectGradle(cwd) {
-  const hasBuildFile = fs22.existsSync(path39.join(cwd, "build.gradle")) || fs22.existsSync(path39.join(cwd, "build.gradle.kts"));
-  const hasGradlew = fs22.existsSync(path39.join(cwd, "gradlew")) || fs22.existsSync(path39.join(cwd, "gradlew.bat"));
+  const hasBuildFile = fs22.existsSync(path38.join(cwd, "build.gradle")) || fs22.existsSync(path38.join(cwd, "build.gradle.kts"));
+  const hasGradlew = fs22.existsSync(path38.join(cwd, "gradlew")) || fs22.existsSync(path38.join(cwd, "gradlew.bat"));
   return hasBuildFile && (hasGradlew || isCommandAvailable("gradle"));
 }
 function detectDotnetTest(cwd) {
@@ -49132,25 +48359,25 @@ function detectDotnetTest(cwd) {
   }
 }
 function detectCTest(cwd) {
-  const hasSource = fs22.existsSync(path39.join(cwd, "CMakeLists.txt"));
-  const hasBuildCache = fs22.existsSync(path39.join(cwd, "CMakeCache.txt")) || fs22.existsSync(path39.join(cwd, "build", "CMakeCache.txt"));
+  const hasSource = fs22.existsSync(path38.join(cwd, "CMakeLists.txt"));
+  const hasBuildCache = fs22.existsSync(path38.join(cwd, "CMakeCache.txt")) || fs22.existsSync(path38.join(cwd, "build", "CMakeCache.txt"));
   return (hasSource || hasBuildCache) && isCommandAvailable("ctest");
 }
 function detectSwiftTest(cwd) {
-  return fs22.existsSync(path39.join(cwd, "Package.swift")) && isCommandAvailable("swift");
+  return fs22.existsSync(path38.join(cwd, "Package.swift")) && isCommandAvailable("swift");
 }
 function detectDartTest(cwd) {
-  return fs22.existsSync(path39.join(cwd, "pubspec.yaml")) && (isCommandAvailable("dart") || isCommandAvailable("flutter"));
+  return fs22.existsSync(path38.join(cwd, "pubspec.yaml")) && (isCommandAvailable("dart") || isCommandAvailable("flutter"));
 }
 function detectRSpec(cwd) {
-  const hasRSpecFile = fs22.existsSync(path39.join(cwd, ".rspec"));
-  const hasGemfile = fs22.existsSync(path39.join(cwd, "Gemfile"));
-  const hasSpecDir = fs22.existsSync(path39.join(cwd, "spec"));
+  const hasRSpecFile = fs22.existsSync(path38.join(cwd, ".rspec"));
+  const hasGemfile = fs22.existsSync(path38.join(cwd, "Gemfile"));
+  const hasSpecDir = fs22.existsSync(path38.join(cwd, "spec"));
   const hasRSpec = hasRSpecFile || hasGemfile && hasSpecDir;
   return hasRSpec && (isCommandAvailable("bundle") || isCommandAvailable("rspec"));
 }
 function detectMinitest(cwd) {
-  return fs22.existsSync(path39.join(cwd, "test")) && (fs22.existsSync(path39.join(cwd, "Gemfile")) || fs22.existsSync(path39.join(cwd, "Rakefile"))) && isCommandAvailable("ruby");
+  return fs22.existsSync(path38.join(cwd, "test")) && (fs22.existsSync(path38.join(cwd, "Gemfile")) || fs22.existsSync(path38.join(cwd, "Rakefile"))) && isCommandAvailable("ruby");
 }
 async function detectTestFrameworkViaDispatch(cwd) {
   try {
@@ -49212,7 +48439,7 @@ async function parseTestOutputViaDispatch(framework, output, baseDir) {
 async function detectTestFramework(cwd) {
   const baseDir = cwd;
   try {
-    const packageJsonPath = path39.join(baseDir, "package.json");
+    const packageJsonPath = path38.join(baseDir, "package.json");
     if (fs22.existsSync(packageJsonPath)) {
       const content = fs22.readFileSync(packageJsonPath, "utf-8");
       const pkg = JSON.parse(content);
@@ -49233,16 +48460,16 @@ async function detectTestFramework(cwd) {
         return "jest";
       if (hasDevDependency(devDeps, "mocha", "@types/mocha"))
         return "mocha";
-      if (fs22.existsSync(path39.join(baseDir, "bun.lockb")) || fs22.existsSync(path39.join(baseDir, "bun.lock"))) {
+      if (fs22.existsSync(path38.join(baseDir, "bun.lockb")) || fs22.existsSync(path38.join(baseDir, "bun.lock"))) {
         if (scripts.test?.includes("bun"))
           return "bun";
       }
     }
   } catch {}
   try {
-    const pyprojectTomlPath = path39.join(baseDir, "pyproject.toml");
-    const setupCfgPath = path39.join(baseDir, "setup.cfg");
-    const requirementsTxtPath = path39.join(baseDir, "requirements.txt");
+    const pyprojectTomlPath = path38.join(baseDir, "pyproject.toml");
+    const setupCfgPath = path38.join(baseDir, "setup.cfg");
+    const requirementsTxtPath = path38.join(baseDir, "requirements.txt");
     if (fs22.existsSync(pyprojectTomlPath)) {
       const content = fs22.readFileSync(pyprojectTomlPath, "utf-8");
       if (content.includes("[tool.pytest"))
@@ -49262,7 +48489,7 @@ async function detectTestFramework(cwd) {
     }
   } catch {}
   try {
-    const cargoTomlPath = path39.join(baseDir, "Cargo.toml");
+    const cargoTomlPath = path38.join(baseDir, "Cargo.toml");
     if (fs22.existsSync(cargoTomlPath)) {
       const content = fs22.readFileSync(cargoTomlPath, "utf-8");
       if (content.includes("[dev-dependencies]")) {
@@ -49273,9 +48500,9 @@ async function detectTestFramework(cwd) {
     }
   } catch {}
   try {
-    const pesterConfigPath = path39.join(baseDir, "pester.config.ps1");
-    const pesterConfigJsonPath = path39.join(baseDir, "pester.config.ps1.json");
-    const pesterPs1Path = path39.join(baseDir, "tests.ps1");
+    const pesterConfigPath = path38.join(baseDir, "pester.config.ps1");
+    const pesterConfigJsonPath = path38.join(baseDir, "pester.config.ps1.json");
+    const pesterPs1Path = path38.join(baseDir, "tests.ps1");
     if (fs22.existsSync(pesterConfigPath) || fs22.existsSync(pesterConfigJsonPath) || fs22.existsSync(pesterPs1Path)) {
       return "pester";
     }
@@ -49304,12 +48531,12 @@ function isTestDirectoryPath(normalizedPath) {
   return normalizedPath.split("/").some((segment) => TEST_DIRECTORY_NAMES.includes(segment));
 }
 function resolveWorkspacePath(file3, workingDir) {
-  return path39.isAbsolute(file3) ? path39.resolve(file3) : path39.resolve(workingDir, file3);
+  return path38.isAbsolute(file3) ? path38.resolve(file3) : path38.resolve(workingDir, file3);
 }
 function toWorkspaceOutputPath(absolutePath, workingDir, preferRelative) {
   if (!preferRelative)
     return absolutePath;
-  return path39.relative(workingDir, absolutePath);
+  return path38.relative(workingDir, absolutePath);
 }
 function dedupePush(target, value) {
   if (!target.includes(value)) {
@@ -49346,18 +48573,18 @@ function buildLanguageSpecificTestNames(nameWithoutExt, ext) {
   }
 }
 function getRepoLevelCandidateDirectories(workingDir, relativePath, ext) {
-  const relativeDir = path39.dirname(relativePath);
+  const relativeDir = path38.dirname(relativePath);
   const nestedRelativeDir = relativeDir === "." ? "" : relativeDir;
   const directories = TEST_DIRECTORY_NAMES.flatMap((dirName) => {
-    const rootDir = path39.join(workingDir, dirName);
-    return nestedRelativeDir ? [rootDir, path39.join(rootDir, nestedRelativeDir)] : [rootDir];
+    const rootDir = path38.join(workingDir, dirName);
+    return nestedRelativeDir ? [rootDir, path38.join(rootDir, nestedRelativeDir)] : [rootDir];
   });
   const normalizedRelativePath = relativePath.replace(/\\/g, "/");
   if (ext === ".java" && normalizedRelativePath.startsWith("src/main/java/")) {
-    directories.push(path39.join(workingDir, "src/test/java", path39.dirname(normalizedRelativePath.slice("src/main/java/".length))));
+    directories.push(path38.join(workingDir, "src/test/java", path38.dirname(normalizedRelativePath.slice("src/main/java/".length))));
   }
   if ((ext === ".kt" || ext === ".java") && normalizedRelativePath.startsWith("src/main/kotlin/")) {
-    directories.push(path39.join(workingDir, "src/test/kotlin", path39.dirname(normalizedRelativePath.slice("src/main/kotlin/".length))));
+    directories.push(path38.join(workingDir, "src/test/kotlin", path38.dirname(normalizedRelativePath.slice("src/main/kotlin/".length))));
   }
   return [...new Set(directories)];
 }
@@ -49385,23 +48612,23 @@ function isLanguageSpecificTestFile(basename6) {
 }
 function isConventionTestFilePath(filePath) {
   const normalizedPath = filePath.replace(/\\/g, "/");
-  const basename6 = path39.basename(filePath);
+  const basename6 = path38.basename(filePath);
   return hasCompoundTestExtension(basename6) || basename6.includes(".spec.") || basename6.includes(".test.") || isLanguageSpecificTestFile(basename6) || isTestDirectoryPath(normalizedPath);
 }
 function getTestFilesFromConvention(sourceFiles, workingDir = process.cwd()) {
   const testFiles = [];
   for (const file3 of sourceFiles) {
     const absoluteFile = resolveWorkspacePath(file3, workingDir);
-    const relativeFile = path39.relative(workingDir, absoluteFile);
-    const basename6 = path39.basename(absoluteFile);
-    const dirname17 = path39.dirname(absoluteFile);
-    const preferRelativeOutput = !path39.isAbsolute(file3);
+    const relativeFile = path38.relative(workingDir, absoluteFile);
+    const basename6 = path38.basename(absoluteFile);
+    const dirname17 = path38.dirname(absoluteFile);
+    const preferRelativeOutput = !path38.isAbsolute(file3);
     if (isConventionTestFilePath(relativeFile) || isConventionTestFilePath(file3)) {
       dedupePush(testFiles, toWorkspaceOutputPath(absoluteFile, workingDir, preferRelativeOutput));
       continue;
     }
     const nameWithoutExt = basename6.replace(/\.[^.]+$/, "");
-    const ext = path39.extname(basename6);
+    const ext = path38.extname(basename6);
     const genericTestNames = [
       `${nameWithoutExt}.spec${ext}`,
       `${nameWithoutExt}.test${ext}`
@@ -49410,7 +48637,7 @@ function getTestFilesFromConvention(sourceFiles, workingDir = process.cwd()) {
     const colocatedCandidates = [
       ...genericTestNames,
       ...languageSpecificTestNames
-    ].map((candidateName) => path39.join(dirname17, candidateName));
+    ].map((candidateName) => path38.join(dirname17, candidateName));
     const testDirectoryNames = [
       basename6,
       ...genericTestNames,
@@ -49419,8 +48646,8 @@ function getTestFilesFromConvention(sourceFiles, workingDir = process.cwd()) {
     const repoLevelDirectories = getRepoLevelCandidateDirectories(workingDir, relativeFile, ext);
     const possibleTestFiles = [
       ...colocatedCandidates,
-      ...TEST_DIRECTORY_NAMES.flatMap((dirName) => testDirectoryNames.map((candidateName) => path39.join(dirname17, dirName, candidateName))),
-      ...repoLevelDirectories.flatMap((candidateDir) => testDirectoryNames.map((candidateName) => path39.join(candidateDir, candidateName)))
+      ...TEST_DIRECTORY_NAMES.flatMap((dirName) => testDirectoryNames.map((candidateName) => path38.join(dirname17, dirName, candidateName))),
+      ...repoLevelDirectories.flatMap((candidateDir) => testDirectoryNames.map((candidateName) => path38.join(candidateDir, candidateName)))
     ];
     for (const testFile of possibleTestFiles) {
       if (fs22.existsSync(testFile)) {
@@ -49441,7 +48668,7 @@ async function getTestFilesFromGraph(sourceFiles, workingDir) {
     try {
       const absoluteTestFile = resolveWorkspacePath(testFile, workingDir);
       const content = fs22.readFileSync(absoluteTestFile, "utf-8");
-      const testDir = path39.dirname(absoluteTestFile);
+      const testDir = path38.dirname(absoluteTestFile);
       const importRegex = /import\s+.*?\s+from\s+['"]([^'"]+)['"]/g;
       let match;
       match = importRegex.exec(content);
@@ -49449,8 +48676,8 @@ async function getTestFilesFromGraph(sourceFiles, workingDir) {
         const importPath = match[1];
         let resolvedImport;
         if (importPath.startsWith(".")) {
-          resolvedImport = path39.resolve(testDir, importPath);
-          const existingExt = path39.extname(resolvedImport);
+          resolvedImport = path38.resolve(testDir, importPath);
+          const existingExt = path38.extname(resolvedImport);
           if (!existingExt) {
             for (const extToTry of [
               ".ts",
@@ -49470,12 +48697,12 @@ async function getTestFilesFromGraph(sourceFiles, workingDir) {
         } else {
           continue;
         }
-        const importBasename = path39.basename(resolvedImport, path39.extname(resolvedImport));
-        const importDir = path39.dirname(resolvedImport);
+        const importBasename = path38.basename(resolvedImport, path38.extname(resolvedImport));
+        const importDir = path38.dirname(resolvedImport);
         for (const sourceFile of absoluteSourceFiles) {
-          const sourceDir = path39.dirname(sourceFile);
-          const sourceBasename = path39.basename(sourceFile, path39.extname(sourceFile));
-          const isRelatedDir = importDir === sourceDir || importDir === path39.join(sourceDir, "__tests__") || importDir === path39.join(sourceDir, "tests") || importDir === path39.join(sourceDir, "test") || importDir === path39.join(sourceDir, "spec");
+          const sourceDir = path38.dirname(sourceFile);
+          const sourceBasename = path38.basename(sourceFile, path38.extname(sourceFile));
+          const isRelatedDir = importDir === sourceDir || importDir === path38.join(sourceDir, "__tests__") || importDir === path38.join(sourceDir, "tests") || importDir === path38.join(sourceDir, "test") || importDir === path38.join(sourceDir, "spec");
           if (resolvedImport === sourceFile || importBasename === sourceBasename && isRelatedDir) {
             dedupePush(testFiles, testFile);
             break;
@@ -49488,8 +48715,8 @@ async function getTestFilesFromGraph(sourceFiles, workingDir) {
       while (match !== null) {
         const importPath = match[1];
         if (importPath.startsWith(".")) {
-          let resolvedImport = path39.resolve(testDir, importPath);
-          const existingExt = path39.extname(resolvedImport);
+          let resolvedImport = path38.resolve(testDir, importPath);
+          const existingExt = path38.extname(resolvedImport);
           if (!existingExt) {
             for (const extToTry of [
               ".ts",
@@ -49506,12 +48733,12 @@ async function getTestFilesFromGraph(sourceFiles, workingDir) {
               }
             }
           }
-          const importDir = path39.dirname(resolvedImport);
-          const importBasename = path39.basename(resolvedImport, path39.extname(resolvedImport));
+          const importDir = path38.dirname(resolvedImport);
+          const importBasename = path38.basename(resolvedImport, path38.extname(resolvedImport));
           for (const sourceFile of absoluteSourceFiles) {
-            const sourceDir = path39.dirname(sourceFile);
-            const sourceBasename = path39.basename(sourceFile, path39.extname(sourceFile));
-            const isRelatedDir = importDir === sourceDir || importDir === path39.join(sourceDir, "__tests__") || importDir === path39.join(sourceDir, "tests") || importDir === path39.join(sourceDir, "test") || importDir === path39.join(sourceDir, "spec");
+            const sourceDir = path38.dirname(sourceFile);
+            const sourceBasename = path38.basename(sourceFile, path38.extname(sourceFile));
+            const isRelatedDir = importDir === sourceDir || importDir === path38.join(sourceDir, "__tests__") || importDir === path38.join(sourceDir, "tests") || importDir === path38.join(sourceDir, "test") || importDir === path38.join(sourceDir, "spec");
             if (resolvedImport === sourceFile || importBasename === sourceBasename && isRelatedDir) {
               dedupePush(testFiles, testFile);
               break;
@@ -49621,8 +48848,8 @@ function buildTestCommand2(framework, scope, files, coverage, baseDir) {
       return ["mvn", "test"];
     case "gradle": {
       const isWindows = process.platform === "win32";
-      const hasGradlewBat = fs22.existsSync(path39.join(baseDir, "gradlew.bat"));
-      const hasGradlew = fs22.existsSync(path39.join(baseDir, "gradlew"));
+      const hasGradlewBat = fs22.existsSync(path38.join(baseDir, "gradlew.bat"));
+      const hasGradlew = fs22.existsSync(path38.join(baseDir, "gradlew"));
       if (hasGradlewBat && isWindows)
         return ["gradlew.bat", "test"];
       if (hasGradlew)
@@ -49639,7 +48866,7 @@ function buildTestCommand2(framework, scope, files, coverage, baseDir) {
         "cmake-build-release",
         "out"
       ];
-      const actualBuildDir = buildDirCandidates.find((d) => fs22.existsSync(path39.join(baseDir, d, "CMakeCache.txt"))) ?? "build";
+      const actualBuildDir = buildDirCandidates.find((d) => fs22.existsSync(path38.join(baseDir, d, "CMakeCache.txt"))) ?? "build";
       return ["ctest", "--test-dir", actualBuildDir];
     }
     case "swift-test":
@@ -50071,11 +49298,11 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
     };
   }
   const startTime = Date.now();
-  const vitestJsonOutputPath = framework === "vitest" ? path39.join(cwd, ".swarm", "cache", "test-runner-vitest.json") : undefined;
+  const vitestJsonOutputPath = framework === "vitest" ? path38.join(cwd, ".swarm", "cache", "test-runner-vitest.json") : undefined;
   try {
     if (vitestJsonOutputPath) {
       try {
-        fs22.mkdirSync(path39.dirname(vitestJsonOutputPath), { recursive: true });
+        fs22.mkdirSync(path38.dirname(vitestJsonOutputPath), { recursive: true });
         if (fs22.existsSync(vitestJsonOutputPath)) {
           fs22.unlinkSync(vitestJsonOutputPath);
         }
@@ -50191,10 +49418,10 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
 }
 function normalizeHistoryTestFile(testFile, workingDir) {
   const normalized = testFile.replace(/\\/g, "/");
-  if (!path39.isAbsolute(testFile))
+  if (!path38.isAbsolute(testFile))
     return normalized;
-  const relative9 = path39.relative(workingDir, testFile);
-  if (relative9.startsWith("..") || path39.isAbsolute(relative9)) {
+  const relative9 = path38.relative(workingDir, testFile);
+  if (relative9.startsWith("..") || path38.isAbsolute(relative9)) {
     return normalized;
   }
   return relative9.replace(/\\/g, "/");
@@ -50532,7 +49759,7 @@ var init_test_runner = __esm(() => {
         const sourceFiles = args.files.filter((file3) => {
           if (directTestFiles.includes(file3))
             return false;
-          const ext = path39.extname(file3).toLowerCase();
+          const ext = path38.extname(file3).toLowerCase();
           return SOURCE_EXTENSIONS.has(ext);
         });
         const invalidFiles = args.files.filter((file3) => !directTestFiles.includes(file3) && !sourceFiles.includes(file3));
@@ -50578,7 +49805,7 @@ var init_test_runner = __esm(() => {
           if (isConventionTestFilePath(f)) {
             return false;
           }
-          const ext = path39.extname(f).toLowerCase();
+          const ext = path38.extname(f).toLowerCase();
           return SOURCE_EXTENSIONS.has(ext);
         });
         if (sourceFiles.length === 0) {
@@ -50628,7 +49855,7 @@ var init_test_runner = __esm(() => {
           if (isConventionTestFilePath(f)) {
             return false;
           }
-          const ext = path39.extname(f).toLowerCase();
+          const ext = path38.extname(f).toLowerCase();
           return SOURCE_EXTENSIONS.has(ext);
         });
         if (sourceFiles.length === 0) {
@@ -50680,8 +49907,8 @@ var init_test_runner = __esm(() => {
           }
           if (impactResult.impactedTests.length > 0) {
             testFiles = impactResult.impactedTests.map((absPath) => {
-              const relativePath = path39.relative(workingDir, absPath);
-              return path39.isAbsolute(relativePath) ? absPath : relativePath;
+              const relativePath = path38.relative(workingDir, absPath);
+              return path38.isAbsolute(relativePath) ? absPath : relativePath;
             });
           } else {
             graphFallbackReason = "no impacted tests found via impact analysis, falling back to graph";
@@ -50757,7 +49984,7 @@ var init_test_runner = __esm(() => {
 
 // src/services/preflight-service.ts
 import * as fs23 from "fs";
-import * as path40 from "path";
+import * as path39 from "path";
 function validateDirectoryPath(dir) {
   if (!dir || typeof dir !== "string") {
     throw new Error("Directory path is required");
@@ -50765,8 +49992,8 @@ function validateDirectoryPath(dir) {
   if (dir.includes("..")) {
     throw new Error("Directory path must not contain path traversal sequences");
   }
-  const normalized = path40.normalize(dir);
-  const absolutePath = path40.isAbsolute(normalized) ? normalized : path40.resolve(normalized);
+  const normalized = path39.normalize(dir);
+  const absolutePath = path39.isAbsolute(normalized) ? normalized : path39.resolve(normalized);
   return absolutePath;
 }
 function validateTimeout(timeoutMs, defaultValue) {
@@ -50789,7 +50016,7 @@ function validateTimeout(timeoutMs, defaultValue) {
 }
 function getPackageVersion(dir) {
   try {
-    const packagePath = path40.join(dir, "package.json");
+    const packagePath = path39.join(dir, "package.json");
     if (fs23.existsSync(packagePath)) {
       const content = fs23.readFileSync(packagePath, "utf-8");
       const pkg = JSON.parse(content);
@@ -50800,7 +50027,7 @@ function getPackageVersion(dir) {
 }
 function getChangelogVersion(dir) {
   try {
-    const changelogPath = path40.join(dir, "CHANGELOG.md");
+    const changelogPath = path39.join(dir, "CHANGELOG.md");
     if (fs23.existsSync(changelogPath)) {
       const content = fs23.readFileSync(changelogPath, "utf-8");
       const match = content.match(/^##\s*\[?(\d+\.\d+\.\d+)\]?/m);
@@ -50814,7 +50041,7 @@ function getChangelogVersion(dir) {
 function getVersionFileVersion(dir) {
   const possibleFiles = ["VERSION.txt", "version.txt", "VERSION", "version"];
   for (const file3 of possibleFiles) {
-    const filePath = path40.join(dir, file3);
+    const filePath = path39.join(dir, file3);
     if (fs23.existsSync(filePath)) {
       try {
         const content = fs23.readFileSync(filePath, "utf-8").trim();
@@ -50830,9 +50057,9 @@ function getVersionFileVersion(dir) {
 async function runVersionCheck(dir, _timeoutMs) {
   const startTime = Date.now();
   try {
-    const packageVersion = _internals29.getPackageVersion(dir);
-    const changelogVersion = _internals29.getChangelogVersion(dir);
-    const versionFileVersion = _internals29.getVersionFileVersion(dir);
+    const packageVersion = _internals26.getPackageVersion(dir);
+    const changelogVersion = _internals26.getChangelogVersion(dir);
+    const versionFileVersion = _internals26.getVersionFileVersion(dir);
     const versions3 = [];
     if (packageVersion)
       versions3.push(`package.json: ${packageVersion}`);
@@ -51141,7 +50368,7 @@ async function runEvidenceCheck(dir) {
 async function runRequirementCoverageCheck(dir, currentPhase) {
   const startTime = Date.now();
   try {
-    const specPath = path40.join(dir, ".swarm", "spec.md");
+    const specPath = path39.join(dir, ".swarm", "spec.md");
     if (!fs23.existsSync(specPath)) {
       return {
         type: "req_coverage",
@@ -51182,7 +50409,7 @@ async function runPreflight(dir, phase, config3) {
   const reportId = `preflight-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   let validatedDir;
   try {
-    validatedDir = _internals29.validateDirectoryPath(dir);
+    validatedDir = _internals26.validateDirectoryPath(dir);
   } catch (error93) {
     return {
       id: reportId,
@@ -51202,7 +50429,7 @@ async function runPreflight(dir, phase, config3) {
   }
   let validatedTimeout;
   try {
-    validatedTimeout = _internals29.validateTimeout(config3?.checkTimeoutMs, DEFAULT_CONFIG.checkTimeoutMs);
+    validatedTimeout = _internals26.validateTimeout(config3?.checkTimeoutMs, DEFAULT_CONFIG.checkTimeoutMs);
   } catch (error93) {
     return {
       id: reportId,
@@ -51243,12 +50470,12 @@ async function runPreflight(dir, phase, config3) {
   });
   const checks5 = [];
   log("[Preflight] Running lint check...");
-  const lintResult = await _internals29.runLintCheck(validatedDir, cfg.linter, cfg.checkTimeoutMs);
+  const lintResult = await _internals26.runLintCheck(validatedDir, cfg.linter, cfg.checkTimeoutMs);
   checks5.push(lintResult);
   log(`[Preflight] Lint check: ${lintResult.status} ${lintResult.message}`);
   if (!cfg.skipTests) {
     log("[Preflight] Running tests check...");
-    const testsResult = await _internals29.runTestsCheck(validatedDir, cfg.testScope, cfg.checkTimeoutMs);
+    const testsResult = await _internals26.runTestsCheck(validatedDir, cfg.testScope, cfg.checkTimeoutMs);
     checks5.push(testsResult);
     log(`[Preflight] Tests check: ${testsResult.status} ${testsResult.message}`);
   } else {
@@ -51260,7 +50487,7 @@ async function runPreflight(dir, phase, config3) {
   }
   if (!cfg.skipSecrets) {
     log("[Preflight] Running secrets check...");
-    const secretsResult = await _internals29.runSecretsCheck(validatedDir, cfg.checkTimeoutMs);
+    const secretsResult = await _internals26.runSecretsCheck(validatedDir, cfg.checkTimeoutMs);
     checks5.push(secretsResult);
     log(`[Preflight] Secrets check: ${secretsResult.status} ${secretsResult.message}`);
   } else {
@@ -51272,7 +50499,7 @@ async function runPreflight(dir, phase, config3) {
   }
   if (!cfg.skipEvidence) {
     log("[Preflight] Running evidence check...");
-    const evidenceResult = await _internals29.runEvidenceCheck(validatedDir);
+    const evidenceResult = await _internals26.runEvidenceCheck(validatedDir);
     checks5.push(evidenceResult);
     log(`[Preflight] Evidence check: ${evidenceResult.status} ${evidenceResult.message}`);
   } else {
@@ -51283,12 +50510,12 @@ async function runPreflight(dir, phase, config3) {
     });
   }
   log("[Preflight] Running requirement coverage check...");
-  const reqCoverageResult = await _internals29.runRequirementCoverageCheck(validatedDir, phase);
+  const reqCoverageResult = await _internals26.runRequirementCoverageCheck(validatedDir, phase);
   checks5.push(reqCoverageResult);
   log(`[Preflight] Requirement coverage check: ${reqCoverageResult.status} ${reqCoverageResult.message}`);
   if (!cfg.skipVersion) {
     log("[Preflight] Running version check...");
-    const versionResult = await _internals29.runVersionCheck(validatedDir, cfg.checkTimeoutMs);
+    const versionResult = await _internals26.runVersionCheck(validatedDir, cfg.checkTimeoutMs);
     checks5.push(versionResult);
     log(`[Preflight] Version check: ${versionResult.status} ${versionResult.message}`);
   } else {
@@ -51351,10 +50578,10 @@ function formatPreflightMarkdown(report) {
 async function handlePreflightCommand(directory, _args) {
   const plan = await loadPlan(directory);
   const phase = plan?.current_phase ?? 1;
-  const report = await _internals29.runPreflight(directory, phase);
-  return _internals29.formatPreflightMarkdown(report);
+  const report = await _internals26.runPreflight(directory, phase);
+  return _internals26.formatPreflightMarkdown(report);
 }
-var MIN_CHECK_TIMEOUT_MS = 5000, MAX_CHECK_TIMEOUT_MS = 300000, DEFAULT_CONFIG, _internals29;
+var MIN_CHECK_TIMEOUT_MS = 5000, MAX_CHECK_TIMEOUT_MS = 300000, DEFAULT_CONFIG, _internals26;
 var init_preflight_service = __esm(() => {
   init_manager2();
   init_manager();
@@ -51371,7 +50598,7 @@ var init_preflight_service = __esm(() => {
     testScope: "convention",
     linter: "biome"
   };
-  _internals29 = {
+  _internals26 = {
     runPreflight,
     formatPreflightMarkdown,
     handlePreflightCommand,
@@ -52258,7 +51485,7 @@ var init_manager3 = __esm(() => {
 
 // src/commands/reset.ts
 import * as fs24 from "fs";
-import * as path41 from "path";
+import * as path40 from "path";
 async function handleResetCommand(directory, args) {
   const hasConfirm = args.includes("--confirm");
   if (!hasConfirm) {
@@ -52298,7 +51525,7 @@ async function handleResetCommand(directory, args) {
   }
   for (const filename of ["SWARM_PLAN.md", "SWARM_PLAN.json"]) {
     try {
-      const rootPath = path41.join(directory, filename);
+      const rootPath = path40.join(directory, filename);
       if (fs24.existsSync(rootPath)) {
         fs24.unlinkSync(rootPath);
         results.push(`- \u2705 Deleted ${filename} (root)`);
@@ -52338,7 +51565,7 @@ var init_reset = __esm(() => {
 
 // src/commands/reset-session.ts
 import * as fs25 from "fs";
-import * as path42 from "path";
+import * as path41 from "path";
 async function handleResetSessionCommand(directory, _args) {
   const results = [];
   try {
@@ -52353,13 +51580,13 @@ async function handleResetSessionCommand(directory, _args) {
     results.push("\u274C Failed to delete state.json");
   }
   try {
-    const sessionDir = path42.dirname(validateSwarmPath(directory, "session/state.json"));
+    const sessionDir = path41.dirname(validateSwarmPath(directory, "session/state.json"));
     if (fs25.existsSync(sessionDir)) {
       const files = fs25.readdirSync(sessionDir);
       const otherFiles = files.filter((f) => f !== "state.json");
       let deletedCount = 0;
       for (const file3 of otherFiles) {
-        const filePath = path42.join(sessionDir, file3);
+        const filePath = path41.join(sessionDir, file3);
         if (fs25.lstatSync(filePath).isFile()) {
           fs25.unlinkSync(filePath);
           deletedCount++;
@@ -52391,7 +51618,7 @@ var init_reset_session = __esm(() => {
 });
 
 // src/summaries/manager.ts
-import * as path43 from "path";
+import * as path42 from "path";
 function sanitizeSummaryId(id) {
   if (!id || id.length === 0) {
     throw new Error("Invalid summary ID: empty string");
@@ -52414,7 +51641,7 @@ function sanitizeSummaryId(id) {
 }
 async function loadFullOutput(directory, id) {
   const sanitizedId = sanitizeSummaryId(id);
-  const relativePath = path43.join("summaries", `${sanitizedId}.json`);
+  const relativePath = path42.join("summaries", `${sanitizedId}.json`);
   validateSwarmPath(directory, relativePath);
   const content = await readSwarmFileAsync(directory, relativePath);
   if (content === null) {
@@ -52477,7 +51704,7 @@ var init_retrieve = __esm(() => {
 
 // src/commands/rollback.ts
 import * as fs26 from "fs";
-import * as path44 from "path";
+import * as path43 from "path";
 async function handleRollbackCommand(directory, args) {
   const phaseArg = args[0];
   if (!phaseArg) {
@@ -52542,8 +51769,8 @@ async function handleRollbackCommand(directory, args) {
     if (EXCLUDE_FILES.has(file3) || file3.startsWith("plan-ledger.archived-")) {
       continue;
     }
-    const src = path44.join(checkpointDir, file3);
-    const dest = path44.join(swarmDir, file3);
+    const src = path43.join(checkpointDir, file3);
+    const dest = path43.join(swarmDir, file3);
     try {
       fs26.cpSync(src, dest, { recursive: true, force: true });
       successes.push(file3);
@@ -52562,12 +51789,12 @@ async function handleRollbackCommand(directory, args) {
     ].join(`
 `);
   }
-  const existingLedgerPath = path44.join(swarmDir, "plan-ledger.jsonl");
+  const existingLedgerPath = path43.join(swarmDir, "plan-ledger.jsonl");
   if (fs26.existsSync(existingLedgerPath)) {
     fs26.unlinkSync(existingLedgerPath);
   }
   try {
-    const planJsonPath = path44.join(swarmDir, "plan.json");
+    const planJsonPath = path43.join(swarmDir, "plan.json");
     if (fs26.existsSync(planJsonPath)) {
       const planRaw = fs26.readFileSync(planJsonPath, "utf-8");
       const plan = PlanSchema.parse(JSON.parse(planRaw));
@@ -52628,7 +51855,7 @@ async function handleSimulateCommand(directory, args) {
   }
   let darkMatterPairs;
   try {
-    darkMatterPairs = await _internals13.detectDarkMatter(directory, options);
+    darkMatterPairs = await _internals10.detectDarkMatter(directory, options);
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     return `## Simulate Report
@@ -52658,9 +51885,9 @@ Ensure this is a git repository with commit history.`;
 `);
   try {
     const fs27 = await import("fs/promises");
-    const path45 = await import("path");
-    const reportPath = path45.join(directory, ".swarm", "simulate-report.md");
-    await fs27.mkdir(path45.dirname(reportPath), { recursive: true });
+    const path44 = await import("path");
+    const reportPath = path44.join(directory, ".swarm", "simulate-report.md");
+    await fs27.mkdir(path44.dirname(reportPath), { recursive: true });
     await fs27.writeFile(reportPath, report, "utf-8");
   } catch (err) {
     const writeErr = err instanceof Error ? err.message : String(err);
@@ -52684,12 +51911,12 @@ async function handleSpecifyCommand(_directory, args) {
 
 // src/turbo/lean/state.ts
 import * as fs27 from "fs";
-import * as path45 from "path";
+import * as path44 from "path";
 function nowISO2() {
   return new Date().toISOString();
 }
 function ensureSwarmDir2(directory) {
-  const swarmDir = path45.resolve(directory, ".swarm");
+  const swarmDir = path44.resolve(directory, ".swarm");
   if (!fs27.existsSync(swarmDir)) {
     fs27.mkdirSync(swarmDir, { recursive: true });
   }
@@ -52733,7 +51960,7 @@ function markStateUnreadable2(directory, reason) {
 }
 function readPersisted2(directory) {
   try {
-    const filePath = path45.join(directory, ".swarm", STATE_FILE2);
+    const filePath = path44.join(directory, ".swarm", STATE_FILE2);
     if (!fs27.existsSync(filePath)) {
       const seed = emptyPersisted2();
       try {
@@ -52769,7 +51996,7 @@ function writePersisted2(directory, persisted) {
   let payload;
   try {
     ensureSwarmDir2(directory);
-    filePath = path45.join(directory, ".swarm", STATE_FILE2);
+    filePath = path44.join(directory, ".swarm", STATE_FILE2);
     tmpPath = `${filePath}.tmp.${Date.now()}`;
     persisted.updatedAt = nowISO2();
     payload = `${JSON.stringify(persisted, null, 2)}
@@ -52896,23 +52123,10 @@ var init_context_budget_service = __esm(() => {
 
 // src/services/status-service.ts
 import * as fsSync2 from "fs";
-import * as path46 from "path";
-async function getSandboxStatus() {
-  const probe = new SandboxCapabilityProbe;
-  const capability = await probe.detect();
-  const executor = await getExecutor();
-  const executorAvailable = executor !== null;
-  return {
-    status: capability.status,
-    mechanism: capability.mechanism,
-    platform: capability.platform,
-    error: capability.error,
-    executorAvailable
-  };
-}
+import * as path45 from "path";
 function readSpecStalenessSnapshot(directory) {
   try {
-    const p = path46.join(directory, ".swarm", "spec-staleness.json");
+    const p = path45.join(directory, ".swarm", "spec-staleness.json");
     if (!fsSync2.existsSync(p))
       return { stale: false };
     const raw = fsSync2.readFileSync(p, "utf-8");
@@ -53002,13 +52216,11 @@ async function getStatusData(directory, agents) {
     status.specStale = true;
     status.specStaleReason = plan._specStaleReason;
   }
-  status = enrichWithLeanTurbo(status, directory);
-  status.sandbox = await getSandboxStatus();
-  return status;
+  return enrichWithLeanTurbo(status, directory);
 }
 function enrichWithLeanTurbo(status, directory) {
   const turboMode = hasActiveTurboMode();
-  const leanActive = _internals30.hasActiveLeanTurbo();
+  const leanActive = _internals27.hasActiveLeanTurbo();
   let turboStrategy = "off";
   if (leanActive) {
     turboStrategy = "lean";
@@ -53027,7 +52239,7 @@ function enrichWithLeanTurbo(status, directory) {
     }
   }
   if (leanSessionID) {
-    const runState = _internals30.loadLeanTurboRunState(directory, leanSessionID);
+    const runState = _internals27.loadLeanTurboRunState(directory, leanSessionID);
     if (runState) {
       status.leanTurboPhase = runState.phase;
       status.leanMaxParallelCoders = runState.maxParallelCoders;
@@ -53059,7 +52271,7 @@ function enrichWithLeanTurbo(status, directory) {
       }
     }
   }
-  status.fullAutoActive = _internals30.hasActiveFullAuto();
+  status.fullAutoActive = _internals27.hasActiveFullAuto();
   return status;
 }
 function formatStatusMarkdown(status) {
@@ -53119,9 +52331,6 @@ function formatStatusMarkdown(status) {
       lines.push(`**Last snapshot**: ${status.lastSnapshotAt}`);
     }
   }
-  if (status.sandbox) {
-    lines.push(...formatSandboxLines(status.sandbox));
-  }
   return lines.join(`
 `);
 }
@@ -53132,62 +52341,28 @@ async function handleStatusCommand(directory, agents) {
       const reason = statusData.specStaleReason ?? "spec.md changed since plan saved";
       const stored = statusData.specStaleStoredHash ?? "unknown";
       const current = statusData.specStaleCurrentHash ?? "(spec.md missing)";
-      const lines = [
+      return [
         "No active swarm plan found.",
         "",
         `**Spec drift detected**: ${reason} (stored: ${stored}, current: ${current})`,
         "Run `/swarm clarify` to update the spec or `/swarm acknowledge-spec-drift` to dismiss."
-      ];
-      if (statusData.sandbox) {
-        lines.push(...formatSandboxLines(statusData.sandbox));
-      }
-      return lines.join(`
-`);
-    }
-    if (statusData.sandbox) {
-      const lines = ["No active swarm plan found.", ""];
-      lines.push(...formatSandboxLines(statusData.sandbox));
-      return lines.join(`
+      ].join(`
 `);
     }
     return "No active swarm plan found.";
   }
   return formatStatusMarkdown(statusData);
 }
-function formatSandboxLines(sandbox) {
-  const lines = [];
-  const {
-    status: sandboxStatus,
-    mechanism,
-    executorAvailable,
-    error: error93
-  } = sandbox;
-  lines.push("");
-  if (sandboxStatus === "enabled") {
-    if (executorAvailable) {
-      lines.push(`**Sandbox**: ${mechanism} (enabled)`);
-    } else {
-      lines.push(`**Sandbox**: ${mechanism} (probe ok, executor unavailable)`);
-    }
-  } else if (sandboxStatus === "disabled") {
-    lines.push(`**Sandbox**: ${mechanism} (disabled${error93 ? ` \u2014 ${error93}` : ""})`);
-  } else {
-    lines.push(`**Sandbox**: ${mechanism} (unsupported) \u2014 Sandbox enforcement not active on this platform`);
-  }
-  return lines;
-}
-var _internals30;
+var _internals27;
 var init_status_service = __esm(() => {
   init_extractors();
   init_utils2();
   init_manager();
-  init_capability_probe();
-  init_executor();
   init_state();
   init_state3();
   init_compaction_service();
   init_context_budget_service();
-  _internals30 = {
+  _internals27 = {
     loadLeanTurboRunState,
     hasActiveLeanTurbo,
     hasActiveFullAuto
@@ -53278,7 +52453,7 @@ async function handleTurboCommand(directory, args, sessionID) {
   if (arg0 === "on") {
     let strategy = "standard";
     try {
-      const { config: config3 } = _internals31.loadPluginConfigWithMeta(directory);
+      const { config: config3 } = _internals28.loadPluginConfigWithMeta(directory);
       if (config3.turbo?.strategy === "lean") {
         strategy = "lean";
       }
@@ -53333,7 +52508,7 @@ function enableLeanTurbo(session, directory, sessionID) {
   let maxParallelCoders = 4;
   let conflictPolicy = "serialize";
   try {
-    const { config: config3 } = _internals31.loadPluginConfigWithMeta(directory);
+    const { config: config3 } = _internals28.loadPluginConfigWithMeta(directory);
     const leanConfig = config3.turbo?.lean;
     if (leanConfig) {
       maxParallelCoders = leanConfig.max_parallel_coders ?? 4;
@@ -53403,13 +52578,13 @@ function buildStatusMessage(session, directory, sessionID) {
   ].join(`
 `);
 }
-var _internals31;
+var _internals28;
 var init_turbo = __esm(() => {
   init_config();
   init_state();
   init_state3();
   init_logger();
-  _internals31 = {
+  _internals28 = {
     loadPluginConfigWithMeta
   };
 });
@@ -53477,7 +52652,7 @@ var init_write_retro2 = __esm(() => {
 
 // src/commands/command-dispatch.ts
 import fs28 from "fs";
-import path47 from "path";
+import path46 from "path";
 function normalizeSwarmCommandInput(command, argumentText) {
   if (command !== "swarm" && !command.startsWith("swarm-")) {
     return { isSwarmCommand: false, tokens: [] };
@@ -53502,7 +52677,7 @@ function formatCommandNotFound(tokens) {
   const attemptedCommand = tokens[0] || "";
   const MAX_DISPLAY = 100;
   const displayCommand = attemptedCommand.length > MAX_DISPLAY ? `${attemptedCommand.slice(0, MAX_DISPLAY)}...` : attemptedCommand;
-  const similar = _internals32.findSimilarCommands(attemptedCommand);
+  const similar = _internals29.findSimilarCommands(attemptedCommand);
   const header = `Command \`/swarm ${displayCommand}\` not found.`;
   const suggestions = similar.length > 0 ? `Did you mean:
 ${similar.map((cmd) => `  - /swarm ${cmd}`).join(`
@@ -53513,9 +52688,9 @@ ${similar.map((cmd) => `  - /swarm ${cmd}`).join(`
 `);
 }
 function maybeMarkFirstRun(directory) {
-  const sentinelPath = path47.join(directory, ".swarm", ".first-run-complete");
+  const sentinelPath = path46.join(directory, ".swarm", ".first-run-complete");
   try {
-    const swarmDir = path47.join(directory, ".swarm");
+    const swarmDir = path46.join(directory, ".swarm");
     fs28.mkdirSync(swarmDir, { recursive: true });
     fs28.writeFileSync(sentinelPath, `first-run-complete: ${new Date().toISOString()}
 `, { flag: "wx" });
@@ -53951,7 +53126,7 @@ async function buildSwarmCommandPrompt(args) {
     activeAgentName,
     registeredAgents
   } = args;
-  const resolved = _internals32.resolveCommand(tokens);
+  const resolved = _internals29.resolveCommand(tokens);
   if (!resolved) {
     if (tokens.length === 0) {
       return buildHelpText();
@@ -54102,7 +53277,7 @@ function findSimilarCommands(query) {
   }
   const scored = VALID_COMMANDS.map((cmd) => {
     const cmdLower = cmd.toLowerCase();
-    const fullScore = _internals32.levenshteinDistance(q, cmdLower);
+    const fullScore = _internals29.levenshteinDistance(q, cmdLower);
     let tokenScore = Infinity;
     if (cmd.includes(" ") || cmd.includes("-")) {
       const qTokens = q.split(/[\s-]+/);
@@ -54115,7 +53290,7 @@ function findSimilarCommands(query) {
         for (const ct of cmdTokens) {
           if (ct.length === 0)
             continue;
-          const dist = _internals32.levenshteinDistance(qt, ct);
+          const dist = _internals29.levenshteinDistance(qt, ct);
           if (dist < minDist)
             minDist = dist;
         }
@@ -54125,7 +53300,7 @@ function findSimilarCommands(query) {
     }
     const dashStrippedQ = q.replace(/-/g, "");
     const dashStrippedCmd = cmdLower.replace(/-/g, "");
-    const dashScore = _internals32.levenshteinDistance(dashStrippedQ, dashStrippedCmd);
+    const dashScore = _internals29.levenshteinDistance(dashStrippedQ, dashStrippedCmd);
     const score = Math.min(fullScore, tokenScore, dashScore);
     return { cmd, score };
   });
@@ -54157,11 +53332,11 @@ async function handleHelpCommand(ctx) {
     return buildHelpText2();
   }
   const tokens = targetCommand.split(/\s+/);
-  const resolved = _internals32.resolveCommand(tokens);
+  const resolved = _internals29.resolveCommand(tokens);
   if (resolved) {
-    return _internals32.buildDetailedHelp(resolved.key, resolved.entry);
+    return _internals29.buildDetailedHelp(resolved.key, resolved.entry);
   }
-  const similar = _internals32.findSimilarCommands(targetCommand);
+  const similar = _internals29.findSimilarCommands(targetCommand);
   const { buildHelpText: fullHelp } = await Promise.resolve().then(() => (init_commands(), exports_commands));
   if (similar.length > 0) {
     return `Command '/swarm ${targetCommand}' not found.
@@ -54197,24 +53372,24 @@ function validateAliases() {
       }
       aliasTargets.get(target).push(name);
       const visited = new Set;
-      const path48 = [];
+      const path47 = [];
       let current = target;
       while (current) {
         const currentEntry = COMMAND_REGISTRY[current];
         if (!currentEntry)
           break;
         if (visited.has(current)) {
-          const cycleStart = path48.indexOf(current);
+          const cycleStart = path47.indexOf(current);
           const fullChain = [
             name,
-            ...path48.slice(0, cycleStart > 0 ? cycleStart : path48.length),
+            ...path47.slice(0, cycleStart > 0 ? cycleStart : path47.length),
             current
           ].join(" \u2192 ");
           errors5.push(`Circular alias detected: ${fullChain}`);
           break;
         }
         visited.add(current);
-        path48.push(current);
+        path47.push(current);
         current = currentEntry.aliasOf || "";
       }
     }
@@ -54255,7 +53430,7 @@ function resolveCommand(tokens) {
   }
   return null;
 }
-var COMMAND_REGISTRY, VALID_COMMANDS, _internals32, validation;
+var COMMAND_REGISTRY, VALID_COMMANDS, _internals29, validation;
 var init_registry = __esm(() => {
   init_acknowledge_spec_drift();
   init_agents();
@@ -54325,7 +53500,7 @@ var init_registry = __esm(() => {
       clashesWithNativeCcCommand: "/agents"
     },
     help: {
-      handler: (ctx) => _internals32.handleHelpCommand(ctx),
+      handler: (ctx) => _internals29.handleHelpCommand(ctx),
       description: "Show help for swarm commands",
       category: "core",
       args: "[command]",
@@ -54697,7 +53872,7 @@ Subcommands:
     }
   };
   VALID_COMMANDS = Object.keys(COMMAND_REGISTRY);
-  _internals32 = {
+  _internals29 = {
     handleHelpCommand,
     validateAliases,
     resolveCommand,
@@ -54705,7 +53880,7 @@ Subcommands:
     findSimilarCommands,
     buildDetailedHelp
   };
-  validation = _internals32.validateAliases();
+  validation = _internals29.validateAliases();
   if (!validation.valid) {
     throw new Error(`COMMAND_REGISTRY alias validation failed:
 ${validation.errors.join(`
@@ -54724,54 +53899,54 @@ init_registry();
 init_cache_paths();
 init_constants();
 import * as fs29 from "fs";
-import * as os10 from "os";
-import * as path48 from "path";
+import * as os7 from "os";
+import * as path47 from "path";
 var { version: version4 } = package_default;
 var CONFIG_DIR = getPluginConfigDir();
-var OPENCODE_CONFIG_PATH = path48.join(CONFIG_DIR, "opencode.json");
-var PLUGIN_CONFIG_PATH = path48.join(CONFIG_DIR, "opencode-swarm.json");
-var PROMPTS_DIR = path48.join(CONFIG_DIR, "opencode-swarm");
+var OPENCODE_CONFIG_PATH = path47.join(CONFIG_DIR, "opencode.json");
+var PLUGIN_CONFIG_PATH = path47.join(CONFIG_DIR, "opencode-swarm.json");
+var PROMPTS_DIR = path47.join(CONFIG_DIR, "opencode-swarm");
 var OPENCODE_PLUGIN_CACHE_PATHS = getPluginCachePaths();
 var OPENCODE_PLUGIN_LOCK_FILE_PATHS = getPluginLockFilePaths();
 function isSafeCachePath(p) {
-  const resolved = path48.resolve(p);
-  const home = path48.resolve(os10.homedir());
+  const resolved = path47.resolve(p);
+  const home = path47.resolve(os7.homedir());
   if (resolved === "/" || resolved === home || resolved.length <= home.length) {
     return false;
   }
-  const segments = resolved.split(path48.sep).filter((s) => s.length > 0);
+  const segments = resolved.split(path47.sep).filter((s) => s.length > 0);
   if (segments.length < 4) {
     return false;
   }
-  const leaf = path48.basename(resolved);
+  const leaf = path47.basename(resolved);
   if (leaf !== "opencode-swarm@latest" && leaf !== "opencode-swarm") {
     return false;
   }
-  const parent = path48.basename(path48.dirname(resolved));
+  const parent = path47.basename(path47.dirname(resolved));
   if (parent !== "packages" && parent !== "node_modules") {
     return false;
   }
-  const grandparent = path48.basename(path48.dirname(path48.dirname(resolved)));
+  const grandparent = path47.basename(path47.dirname(path47.dirname(resolved)));
   if (grandparent !== "opencode") {
     return false;
   }
   return true;
 }
 function isSafeLockFilePath(p) {
-  const resolved = path48.resolve(p);
-  const home = path48.resolve(os10.homedir());
+  const resolved = path47.resolve(p);
+  const home = path47.resolve(os7.homedir());
   if (resolved === "/" || resolved === home || resolved.length <= home.length) {
     return false;
   }
-  const segments = resolved.split(path48.sep).filter((s) => s.length > 0);
+  const segments = resolved.split(path47.sep).filter((s) => s.length > 0);
   if (segments.length < 4) {
     return false;
   }
-  const leaf = path48.basename(resolved);
+  const leaf = path47.basename(resolved);
   if (leaf !== "bun.lock" && leaf !== "bun.lockb" && leaf !== "package-lock.json") {
     return false;
   }
-  const parent = path48.basename(path48.dirname(resolved));
+  const parent = path47.basename(path47.dirname(resolved));
   if (parent !== "opencode") {
     return false;
   }
@@ -54797,8 +53972,8 @@ function saveJson(filepath, data) {
 }
 function writeProjectConfigIfMissing(cwd) {
   try {
-    const opencodeDir = path48.join(cwd, ".opencode");
-    const projectConfigPath = path48.join(opencodeDir, "opencode-swarm.json");
+    const opencodeDir = path47.join(cwd, ".opencode");
+    const projectConfigPath = path47.join(opencodeDir, "opencode-swarm.json");
     if (fs29.existsSync(projectConfigPath)) {
       return;
     }
@@ -54815,7 +53990,7 @@ async function install() {
 `);
   ensureDir(CONFIG_DIR);
   ensureDir(PROMPTS_DIR);
-  const LEGACY_CONFIG_PATH = path48.join(CONFIG_DIR, "config.json");
+  const LEGACY_CONFIG_PATH = path47.join(CONFIG_DIR, "config.json");
   let opencodeConfig = loadJson(OPENCODE_CONFIG_PATH);
   if (!opencodeConfig) {
     const legacyConfig = loadJson(LEGACY_CONFIG_PATH);

--- a/dist/config/schema.d.ts
+++ b/dist/config/schema.d.ts
@@ -504,8 +504,15 @@ export declare const KnowledgeConfigSchema: z.ZodObject<{
 export type KnowledgeConfig = z.infer<typeof KnowledgeConfigSchema>;
 export declare const MemoryConfigSchema: z.ZodObject<{
     enabled: z.ZodDefault<z.ZodBoolean>;
-    provider: z.ZodDefault<z.ZodLiteral<"local-jsonl">>;
+    provider: z.ZodDefault<z.ZodEnum<{
+        "local-jsonl": "local-jsonl";
+        sqlite: "sqlite";
+    }>>;
     storageDir: z.ZodDefault<z.ZodString>;
+    sqlite: z.ZodDefault<z.ZodObject<{
+        path: z.ZodDefault<z.ZodString>;
+        busyTimeoutMs: z.ZodDefault<z.ZodNumber>;
+    }, z.core.$strip>>;
     recall: z.ZodDefault<z.ZodObject<{
         defaultMaxItems: z.ZodDefault<z.ZodNumber>;
         defaultTokenBudget: z.ZodDefault<z.ZodNumber>;
@@ -1162,8 +1169,15 @@ export declare const PluginConfigSchema: z.ZodObject<{
     }, z.core.$strip>>;
     memory: z.ZodOptional<z.ZodObject<{
         enabled: z.ZodDefault<z.ZodBoolean>;
-        provider: z.ZodDefault<z.ZodLiteral<"local-jsonl">>;
+        provider: z.ZodDefault<z.ZodEnum<{
+            "local-jsonl": "local-jsonl";
+            sqlite: "sqlite";
+        }>>;
         storageDir: z.ZodDefault<z.ZodString>;
+        sqlite: z.ZodDefault<z.ZodObject<{
+            path: z.ZodDefault<z.ZodString>;
+            busyTimeoutMs: z.ZodDefault<z.ZodNumber>;
+        }, z.core.$strip>>;
         recall: z.ZodDefault<z.ZodObject<{
             defaultMaxItems: z.ZodDefault<z.ZodNumber>;
             defaultTokenBudget: z.ZodDefault<z.ZodNumber>;

--- a/dist/hooks/skill-usage-log.d.ts
+++ b/dist/hooks/skill-usage-log.d.ts
@@ -62,7 +62,7 @@ export declare const _internals: {
     renameSync: typeof fs.renameSync;
     mkdirSync: typeof fs.mkdirSync;
     existsSync: typeof fs.existsSync;
-    statSync: typeof fs.statSync;
+    statSync: any;
     openSync: typeof fs.openSync;
     readSync: typeof fs.readSync;
     closeSync: typeof fs.closeSync;

--- a/dist/hooks/skill-usage-log.d.ts
+++ b/dist/hooks/skill-usage-log.d.ts
@@ -62,7 +62,7 @@ export declare const _internals: {
     renameSync: typeof fs.renameSync;
     mkdirSync: typeof fs.mkdirSync;
     existsSync: typeof fs.existsSync;
-    statSync: any;
+    statSync: typeof fs.statSync;
     openSync: typeof fs.openSync;
     readSync: typeof fs.readSync;
     closeSync: typeof fs.closeSync;

--- a/dist/memory/config.d.ts
+++ b/dist/memory/config.d.ts
@@ -1,8 +1,12 @@
 import type { MemoryKind } from './types';
 export interface MemoryConfig {
     enabled: boolean;
-    provider: 'local-jsonl';
+    provider: 'local-jsonl' | 'sqlite';
     storageDir: string;
+    sqlite: {
+        path: string;
+        busyTimeoutMs: number;
+    };
     recall: {
         defaultMaxItems: number;
         defaultTokenBudget: number;

--- a/dist/memory/gateway.d.ts
+++ b/dist/memory/gateway.d.ts
@@ -34,6 +34,7 @@ export declare class MemoryGateway {
     private readonly now;
     constructor(context: MemoryContext, options?: MemoryGatewayOptions);
     isEnabled(): boolean;
+    dispose(): Promise<void>;
     deriveAllowedScopes(): MemoryScopeRef[];
     recall(input: RecallMemoryInput): Promise<RecallBundle>;
     propose(input: ProposeMemoryInput): Promise<MemoryProposal>;

--- a/dist/memory/gateway.d.ts
+++ b/dist/memory/gateway.d.ts
@@ -52,3 +52,4 @@ export declare class MemoryGateway {
     private assertEnabled;
 }
 export declare function createMemoryGateway(context: MemoryContext, options?: MemoryGatewayOptions): MemoryGateway;
+export declare function createConfiguredMemoryProvider(directory: string, config: MemoryConfig): MemoryProvider & MemoryProposalStore;

--- a/dist/memory/index.d.ts
+++ b/dist/memory/index.d.ts
@@ -11,6 +11,6 @@ export { buildMemoryRecallPlan, type MemoryRecallPlan, type MemoryRecallPlannerI
 export { findSecrets, redactSecrets } from './redaction';
 export { MEMORY_RECALL_PROFILES, type MemoryRecallProfile, normalizeMemoryAgentRole, resolveMemoryRecallProfile, } from './role-profiles';
 export { appendMemoryRunLog, sanitizeRunId } from './run-log';
-export { SQLiteMemoryProvider } from './sqlite-provider';
 export { computeMemoryContentHash, createBundleId, createMemoryId, createProposalId, isExpired, normalizeMemoryText, validateMemoryProposal, validateMemoryRecordRules, } from './schema';
+export { SQLiteMemoryProvider } from './sqlite-provider';
 export type { MemoryContext, MemoryKind, MemoryListFilter, MemoryProposal, MemoryRecord, MemoryScopeRef, MemoryScopeType, RecallBundle, RecallInjectionSkipReason, RecallMode, RecallRequest, RecallResultItem, } from './types';

--- a/dist/memory/index.d.ts
+++ b/dist/memory/index.d.ts
@@ -2,7 +2,7 @@ export type { MemoryConfig } from './config';
 export { DEFAULT_MEMORY_CONFIG, resolveMemoryConfig } from './config';
 export { MemoryDisabledError, MemoryValidationError } from './errors';
 export type { MemoryGatewayOptions, ProposeMemoryInput, RecallMemoryInput, } from './gateway';
-export { createMemoryGateway, MemoryGateway } from './gateway';
+export { createConfiguredMemoryProvider, createMemoryGateway, MemoryGateway, } from './gateway';
 export { createMemoryLifecycleHooks, type MemoryLifecycleHookOptions, type MemoryLifecycleHooks, } from './injector';
 export { LocalJsonlMemoryProvider } from './local-jsonl-provider';
 export { buildRecallPromptBlock } from './prompt-block';
@@ -11,5 +11,6 @@ export { buildMemoryRecallPlan, type MemoryRecallPlan, type MemoryRecallPlannerI
 export { findSecrets, redactSecrets } from './redaction';
 export { MEMORY_RECALL_PROFILES, type MemoryRecallProfile, normalizeMemoryAgentRole, resolveMemoryRecallProfile, } from './role-profiles';
 export { appendMemoryRunLog, sanitizeRunId } from './run-log';
+export { SQLiteMemoryProvider } from './sqlite-provider';
 export { computeMemoryContentHash, createBundleId, createMemoryId, createProposalId, isExpired, normalizeMemoryText, validateMemoryProposal, validateMemoryRecordRules, } from './schema';
 export type { MemoryContext, MemoryKind, MemoryListFilter, MemoryProposal, MemoryRecord, MemoryScopeRef, MemoryScopeType, RecallBundle, RecallInjectionSkipReason, RecallMode, RecallRequest, RecallResultItem, } from './types';

--- a/dist/memory/provider.d.ts
+++ b/dist/memory/provider.d.ts
@@ -19,6 +19,7 @@ export interface MemoryRecallUsageEvent {
 export interface MemoryProvider {
     readonly name: string;
     initialize?(): Promise<void>;
+    close?(): Promise<void> | void;
     upsert(record: MemoryRecord): Promise<MemoryRecord>;
     get(id: string): Promise<MemoryRecord | null>;
     delete(id: string, reason?: string): Promise<void>;

--- a/dist/memory/sqlite-provider.d.ts
+++ b/dist/memory/sqlite-provider.d.ts
@@ -1,0 +1,39 @@
+import { type MemoryConfig } from './config';
+import type { MemoryProposalStore, MemoryProvider, MemoryRecallUsageEvent } from './provider';
+import type { RecallScoringDiagnostics } from './scoring';
+import type { MemoryListFilter, MemoryProposal, MemoryRecord, RecallRequest, RecallResultItem } from './types';
+export declare class SQLiteMemoryProvider implements MemoryProvider, MemoryProposalStore {
+    readonly name = "sqlite";
+    private readonly rootDirectory;
+    private readonly config;
+    private initialized;
+    private db;
+    private memories;
+    private proposals;
+    constructor(rootDirectory: string, config?: Partial<MemoryConfig>);
+    private databasePath;
+    initialize(): Promise<void>;
+    upsert(record: MemoryRecord): Promise<MemoryRecord>;
+    get(id: string): Promise<MemoryRecord | null>;
+    delete(id: string, reason?: string): Promise<void>;
+    recall(request: RecallRequest): Promise<RecallResultItem[]>;
+    recallWithDiagnostics(request: RecallRequest): Promise<{
+        items: RecallResultItem[];
+        diagnostics: RecallScoringDiagnostics;
+    }>;
+    recordRecallUsage(event: MemoryRecallUsageEvent): Promise<void>;
+    list(filter?: MemoryListFilter): Promise<MemoryRecord[]>;
+    createProposal(proposal: MemoryProposal): Promise<MemoryProposal>;
+    listProposals(filter?: {
+        status?: MemoryProposal['status'];
+        limit?: number;
+    }): Promise<MemoryProposal[]>;
+    close(): void;
+    private runMigrations;
+    private loadMemories;
+    private loadProposals;
+    private writeMemory;
+    private event;
+    private insertEvent;
+    private requireDb;
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,8 +214,10 @@ Optional scoped memory substrate for recall and proposal-only memory writes.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | boolean | `false` | Enable agent access to `swarm_memory_recall` and `swarm_memory_propose` |
-| `provider` | string | `"local-jsonl"` | Memory provider. PR 1 supports only local JSONL |
+| `provider` | string | `"local-jsonl"` | Memory provider. Supports `"local-jsonl"` and opt-in `"sqlite"` |
 | `storageDir` | string | `".swarm/memory"` | Local storage directory under the project root |
+| `sqlite.path` | string | `".swarm/memory/memory.db"` | SQLite database path. Must remain inside `.swarm/` |
+| `sqlite.busyTimeoutMs` | number | `5000` | SQLite busy timeout in milliseconds |
 | `recall.defaultMaxItems` | number | `8` | Default max recalled memories |
 | `recall.defaultTokenBudget` | number | `1200` | Default recall prompt-block token budget |
 | `recall.minScore` | number | `0.05` | Minimum lexical recall score |
@@ -227,7 +229,7 @@ Optional scoped memory substrate for recall and proposal-only memory writes.
 | `writes.mode` | string | `"propose"` | Normal agents can only create proposals |
 | `redaction.rejectDurableSecrets` | boolean | `true` | Reject durable memories that contain likely secrets |
 
-Memory stores local JSONL files under `.swarm/memory/`. Recall is scope-filtered and labels retrieved memory as untrusted background. Proposals are written to `.swarm/memory/proposals.jsonl` and do not become durable memory without curator or trusted gateway review. See [Swarm Memory](memory.md).
+Memory stores local JSONL files under `.swarm/memory/` by default. The opt-in SQLite provider stores `.swarm/memory/memory.db` and preserves the same gateway behavior. Recall is scope-filtered and labels retrieved memory as untrusted background. Proposals do not become durable memory without curator or trusted gateway review. See [Swarm Memory](memory.md).
 
 ### todo_gate
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -19,6 +19,10 @@ Enable local memory in `.opencode/opencode-swarm.json`:
     "enabled": true,
     "provider": "local-jsonl",
     "storageDir": ".swarm/memory",
+    "sqlite": {
+      "path": ".swarm/memory/memory.db",
+      "busyTimeoutMs": 5000
+    },
     "recall": {
       "defaultMaxItems": 8,
       "defaultTokenBudget": 1200,
@@ -34,7 +38,22 @@ Enable local memory in `.opencode/opencode-swarm.json`:
 }
 ```
 
-Only `local-jsonl` is supported today. Qdrant, embeddings, SQLite migration, and curator approval are separate follow-up features. Recall injection uses the gateway/provider seam, so future storage providers should not change agent behavior.
+`local-jsonl` remains the default provider. `sqlite` is available as an opt-in provider foundation for the same gateway behavior:
+
+```json
+{
+  "memory": {
+    "enabled": true,
+    "provider": "sqlite",
+    "sqlite": {
+      "path": ".swarm/memory/memory.db",
+      "busyTimeoutMs": 5000
+    }
+  }
+}
+```
+
+Qdrant, embeddings, JSONL-to-SQLite migration, and curator approval are separate follow-up features. Recall injection uses the gateway/provider seam, so storage providers do not change agent behavior.
 
 ## Storage
 
@@ -47,6 +66,8 @@ Local memory lives under the project root:
 ```
 
 `memories.jsonl` stores durable records after they are curated or otherwise inserted through the gateway. `proposals.jsonl` stores pending or policy-rejected proposals from agents. `audit.jsonl` records upsert, delete, proposal, recall, and compaction events.
+
+When `provider` is `sqlite`, the database defaults to `.swarm/memory/memory.db` and stores the provider tables `memory_items`, `memory_proposals`, `memory_events`, `memory_recall_usage`, and `schema_migrations`.
 
 Deletes tombstone records by default instead of physically erasing them. Hard delete is available only through internal provider configuration and is not exposed to normal agents.
 

--- a/docs/releases/pending/sqlite-memory-provider-foundation.md
+++ b/docs/releases/pending/sqlite-memory-provider-foundation.md
@@ -1,0 +1,18 @@
+---
+title: SQLite memory provider foundation
+category: added
+---
+
+## Summary
+
+Adds an opt-in SQLite memory provider behind the existing memory gateway/provider seam. `local-jsonl` remains the default provider, so existing agent prompts and default behavior are unchanged.
+
+## Details
+
+- Added `memory.provider: "sqlite"` with `memory.sqlite.path` and `memory.sqlite.busyTimeoutMs` settings.
+- Added SQLite provider parity for memory items, proposals, recall usage, and provider events under `.swarm/memory/memory.db`.
+- Kept the Bun SQLite driver lazily resolved when the SQLite provider initializes so the Node-compatible plugin bundle remains loadable when SQLite is not selected.
+
+## Migration
+
+No migration is required. Existing memory storage remains local JSONL unless users explicitly set `memory.provider` to `"sqlite"`.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -948,10 +948,17 @@ export type KnowledgeConfig = z.infer<typeof KnowledgeConfigSchema>;
 export const MemoryConfigSchema = z.object({
 	/** Enable Swarm memory tools and local memory storage. Default: false. */
 	enabled: z.boolean().default(false),
-	/** Memory provider. PR 1 supports local JSONL only. */
-	provider: z.literal('local-jsonl').default('local-jsonl'),
+	/** Memory provider. SQLite is opt-in; local JSONL remains the default. */
+	provider: z.enum(['local-jsonl', 'sqlite']).default('local-jsonl'),
 	/** Storage directory under the project root. Must remain inside .swarm/. */
 	storageDir: z.string().default('.swarm/memory'),
+	sqlite: z
+		.object({
+			/** SQLite database path under the project root .swarm/ directory. */
+			path: z.string().default('.swarm/memory/memory.db'),
+			busyTimeoutMs: z.number().int().min(0).max(60000).default(5000),
+		})
+		.default({ path: '.swarm/memory/memory.db', busyTimeoutMs: 5000 }),
 	recall: z
 		.object({
 			defaultMaxItems: z.number().int().min(1).max(20).default(8),

--- a/src/index.ts
+++ b/src/index.ts
@@ -988,17 +988,22 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 
 		// Configure OpenCode - merge agents into config
 		config: async (opencodeConfig: Record<string, unknown>) => {
+			const isObjectRecord = (
+				value: unknown,
+			): value is Record<string, unknown> =>
+				typeof value === 'object' && value !== null;
+			const pluginConfig = opencodeConfig as Record<string, unknown> & {
+				agent?: Record<string, unknown>;
+			};
+
 			// Normalize agent config to a plain object if it's absent or a non-object primitive
-			if (!opencodeConfig.agent || typeof opencodeConfig.agent !== 'object') {
-				(opencodeConfig as any).agent = {};
+			if (!isObjectRecord(pluginConfig.agent)) {
+				pluginConfig.agent = {};
 			}
+			const agentConfig = pluginConfig.agent;
 
 			// Merge agent configs (don't override default_agent)
-			if (!opencodeConfig.agent) {
-				opencodeConfig.agent = { ...agents };
-			} else {
-				Object.assign(opencodeConfig.agent, agents);
-			}
+			Object.assign(agentConfig, agents);
 
 			// Auto-select architect: disable competing built-in agents when enabled
 			const autoSelect = config?.auto_select_architect;
@@ -1010,19 +1015,13 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 				if (hasArchitect) {
 					// Disable build and plan built-in agents
 					for (const builtin of ['build', 'plan'] as const) {
-						const existing = (opencodeConfig.agent as Record<string, any>)?.[
-							builtin
-						];
-						if (
-							existing &&
-							typeof existing === 'object' &&
-							existing.disable === true
-						) {
+						const existing = agentConfig[builtin];
+						if (isObjectRecord(existing) && existing.disable === true) {
 							// User already disabled this agent — respect their override
 							continue;
 						}
-						(opencodeConfig.agent as Record<string, any>)[builtin] = {
-							...(existing && typeof existing === 'object' ? existing : {}),
+						agentConfig[builtin] = {
+							...(isObjectRecord(existing) ? existing : {}),
 							disable: true,
 						};
 					}
@@ -1032,7 +1031,8 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 						const primaryArchitects = Object.entries(agents).filter(
 							([name, cfg]) =>
 								stripKnownSwarmPrefix(name) === 'architect' &&
-								(cfg as any).mode === 'primary',
+								isObjectRecord(cfg) &&
+								cfg.mode === 'primary',
 						);
 						if (primaryArchitects.length > 1) {
 							const names = primaryArchitects.map(([n]) => n).join(', ');
@@ -1057,36 +1057,20 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 									stripKnownSwarmPrefix(name) === 'architect' &&
 									name !== targetName
 								) {
-									if (
-										opencodeConfig.agent &&
-										typeof opencodeConfig.agent === 'object'
-									) {
-										(opencodeConfig.agent as Record<string, any>)[name] = {
-											...(cfg && typeof cfg === 'object' ? cfg : {}),
-											mode: 'subagent',
-										};
-									}
+									agentConfig[name] = {
+										...(isObjectRecord(cfg) ? cfg : {}),
+										mode: 'subagent',
+									};
 								}
 							}
 							// Promote the target architect to primary
-							if (
-								opencodeConfig.agent &&
-								typeof opencodeConfig.agent === 'object'
-							) {
-								const targetExisting = (
-									opencodeConfig.agent as Record<string, any>
-								)[targetName];
-								(opencodeConfig.agent as Record<string, any>)[targetName] = {
-									...(targetExisting && typeof targetExisting === 'object'
-										? targetExisting
-										: {}),
-									...(agents[targetName] &&
-									typeof agents[targetName] === 'object'
-										? agents[targetName]
-										: {}),
-									mode: 'primary',
-								};
-							}
+							const targetExisting = agentConfig[targetName];
+							const targetAgent = agents[targetName];
+							agentConfig[targetName] = {
+								...(isObjectRecord(targetExisting) ? targetExisting : {}),
+								...(isObjectRecord(targetAgent) ? targetAgent : {}),
+								mode: 'primary',
+							};
 						} else {
 							// Target is not a valid architect — warn the user
 							addDeferredWarning(

--- a/src/memory/config.ts
+++ b/src/memory/config.ts
@@ -2,8 +2,12 @@ import type { MemoryKind } from './types';
 
 export interface MemoryConfig {
 	enabled: boolean;
-	provider: 'local-jsonl';
+	provider: 'local-jsonl' | 'sqlite';
 	storageDir: string;
+	sqlite: {
+		path: string;
+		busyTimeoutMs: number;
+	};
 	recall: {
 		defaultMaxItems: number;
 		defaultTokenBudget: number;
@@ -29,6 +33,10 @@ export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
 	enabled: false,
 	provider: 'local-jsonl',
 	storageDir: '.swarm/memory',
+	sqlite: {
+		path: '.swarm/memory/memory.db',
+		busyTimeoutMs: 5000,
+	},
 	recall: {
 		defaultMaxItems: 8,
 		defaultTokenBudget: 1200,
@@ -73,6 +81,10 @@ export function resolveMemoryConfig(
 	return {
 		...DEFAULT_MEMORY_CONFIG,
 		...(input ?? {}),
+		sqlite: {
+			...DEFAULT_MEMORY_CONFIG.sqlite,
+			...(input?.sqlite ?? {}),
+		},
 		recall: {
 			...DEFAULT_MEMORY_CONFIG.recall,
 			...(input?.recall ?? {}),

--- a/src/memory/gateway.ts
+++ b/src/memory/gateway.ts
@@ -83,6 +83,10 @@ export class MemoryGateway {
 		return this.config.enabled;
 	}
 
+	async dispose(): Promise<void> {
+		await this.provider.close?.();
+	}
+
 	deriveAllowedScopes(): MemoryScopeRef[] {
 		const resolvedRoot = path.resolve(this.context.directory);
 		const repoId = createStableId(

--- a/src/memory/gateway.ts
+++ b/src/memory/gateway.ts
@@ -20,6 +20,7 @@ import {
 	validateMemoryRecordRules,
 } from './schema';
 import type { RecallScoringDiagnostics } from './scoring';
+import { SQLiteMemoryProvider } from './sqlite-provider';
 import type {
 	MemoryContext,
 	MemoryKind,
@@ -74,7 +75,7 @@ export class MemoryGateway {
 		this.config = resolveMemoryConfig(options.config ?? DEFAULT_MEMORY_CONFIG);
 		this.provider =
 			options.provider ??
-			new LocalJsonlMemoryProvider(context.directory, this.config);
+			createConfiguredMemoryProvider(context.directory, this.config);
 		this.now = options.now ?? (() => new Date());
 	}
 
@@ -366,6 +367,16 @@ export function createMemoryGateway(
 	options: MemoryGatewayOptions = {},
 ): MemoryGateway {
 	return new MemoryGateway(context, options);
+}
+
+export function createConfiguredMemoryProvider(
+	directory: string,
+	config: MemoryConfig,
+): MemoryProvider & MemoryProposalStore {
+	if (config.provider === 'sqlite') {
+		return new SQLiteMemoryProvider(directory, config);
+	}
+	return new LocalJsonlMemoryProvider(directory, config);
 }
 
 function sourceFromEvidence(

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -32,7 +32,6 @@ export {
 	resolveMemoryRecallProfile,
 } from './role-profiles';
 export { appendMemoryRunLog, sanitizeRunId } from './run-log';
-export { SQLiteMemoryProvider } from './sqlite-provider';
 export {
 	computeMemoryContentHash,
 	createBundleId,
@@ -43,6 +42,7 @@ export {
 	validateMemoryProposal,
 	validateMemoryRecordRules,
 } from './schema';
+export { SQLiteMemoryProvider } from './sqlite-provider';
 export type {
 	MemoryContext,
 	MemoryKind,

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -6,7 +6,11 @@ export type {
 	ProposeMemoryInput,
 	RecallMemoryInput,
 } from './gateway';
-export { createMemoryGateway, MemoryGateway } from './gateway';
+export {
+	createConfiguredMemoryProvider,
+	createMemoryGateway,
+	MemoryGateway,
+} from './gateway';
 export {
 	createMemoryLifecycleHooks,
 	type MemoryLifecycleHookOptions,
@@ -28,6 +32,7 @@ export {
 	resolveMemoryRecallProfile,
 } from './role-profiles';
 export { appendMemoryRunLog, sanitizeRunId } from './run-log';
+export { SQLiteMemoryProvider } from './sqlite-provider';
 export {
 	computeMemoryContentHash,
 	createBundleId,

--- a/src/memory/provider.ts
+++ b/src/memory/provider.ts
@@ -28,6 +28,7 @@ export interface MemoryRecallUsageEvent {
 export interface MemoryProvider {
 	readonly name: string;
 	initialize?(): Promise<void>;
+	close?(): Promise<void> | void;
 	upsert(record: MemoryRecord): Promise<MemoryRecord>;
 	get(id: string): Promise<MemoryRecord | null>;
 	delete(id: string, reason?: string): Promise<void>;

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -1,0 +1,500 @@
+import { randomUUID } from 'node:crypto';
+import { mkdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import type { Database } from 'bun:sqlite';
+import { validateSwarmPath } from '../hooks/utils';
+import { DEFAULT_MEMORY_CONFIG, type MemoryConfig } from './config';
+import { MemoryValidationError } from './errors';
+import type {
+	MemoryProposalStore,
+	MemoryProvider,
+	MemoryRecallUsageEvent,
+} from './provider';
+import { validateMemoryProposal, validateMemoryRecordRules } from './schema';
+import type { RecallScoringDiagnostics } from './scoring';
+import { scopeAllowed, scoreMemoryRecordsWithDiagnostics } from './scoring';
+import type {
+	MemoryListFilter,
+	MemoryProposal,
+	MemoryRecord,
+	RecallRequest,
+	RecallResultItem,
+} from './types';
+
+// See src/db/project-db.ts for the portability rationale. The main plugin bundle
+// is Node-ESM-loadable, so the Bun SQLite driver must be resolved only when the
+// SQLite memory provider is selected and initialized.
+let _DatabaseCtor: typeof Database | null = null;
+function loadDatabaseCtor(): typeof Database {
+	if (_DatabaseCtor) return _DatabaseCtor;
+	const req = createRequire(import.meta.url);
+	_DatabaseCtor = (req('bun:sqlite') as { Database: typeof Database }).Database;
+	return _DatabaseCtor;
+}
+
+type EventOperation =
+	| 'upsert'
+	| 'delete'
+	| 'proposal'
+	| 'recall'
+	| 'migration'
+	| 'invalid_load';
+
+interface Migration {
+	version: number;
+	name: string;
+	sql: string;
+}
+
+const MIGRATIONS: Migration[] = [
+	{
+		version: 1,
+		name: 'create_memory_provider_tables',
+		sql: `
+			CREATE TABLE IF NOT EXISTS memory_items (
+				id TEXT PRIMARY KEY,
+				scope_key TEXT NOT NULL,
+				kind TEXT NOT NULL,
+				updated_at TEXT NOT NULL,
+				expires_at TEXT,
+				superseded_by TEXT,
+				deleted INTEGER NOT NULL DEFAULT 0,
+				record_json TEXT NOT NULL
+			);
+			CREATE INDEX IF NOT EXISTS idx_memory_items_scope_kind
+				ON memory_items(scope_key, kind);
+			CREATE INDEX IF NOT EXISTS idx_memory_items_updated_at
+				ON memory_items(updated_at);
+
+			CREATE TABLE IF NOT EXISTS memory_proposals (
+				id TEXT PRIMARY KEY,
+				status TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				proposal_json TEXT NOT NULL
+			);
+			CREATE INDEX IF NOT EXISTS idx_memory_proposals_status_created
+				ON memory_proposals(status, created_at);
+
+			CREATE TABLE IF NOT EXISTS memory_events (
+				id TEXT PRIMARY KEY,
+				operation TEXT NOT NULL,
+				target_id TEXT NOT NULL,
+				reason TEXT,
+				timestamp TEXT NOT NULL,
+				event_json TEXT
+			);
+
+			CREATE TABLE IF NOT EXISTS memory_recall_usage (
+				id TEXT PRIMARY KEY,
+				bundle_id TEXT NOT NULL,
+				timestamp TEXT NOT NULL,
+				usage_json TEXT NOT NULL
+			);
+			CREATE INDEX IF NOT EXISTS idx_memory_recall_usage_bundle
+				ON memory_recall_usage(bundle_id);
+		`,
+	},
+];
+
+interface MemoryItemRow {
+	id: string;
+	record_json: string;
+}
+
+interface ProposalRow {
+	id: string;
+	proposal_json: string;
+}
+
+export class SQLiteMemoryProvider
+	implements MemoryProvider, MemoryProposalStore
+{
+	readonly name = 'sqlite';
+	private readonly rootDirectory: string;
+	private readonly config: MemoryConfig;
+	private initialized = false;
+	private db: Database | null = null;
+	private memories = new Map<string, MemoryRecord>();
+	private proposals = new Map<string, MemoryProposal>();
+
+	constructor(rootDirectory: string, config: Partial<MemoryConfig> = {}) {
+		this.rootDirectory = rootDirectory;
+		this.config = {
+			...DEFAULT_MEMORY_CONFIG,
+			...config,
+			sqlite: {
+				...DEFAULT_MEMORY_CONFIG.sqlite,
+				...(config.sqlite ?? {}),
+			},
+			recall: {
+				...DEFAULT_MEMORY_CONFIG.recall,
+				...(config.recall ?? {}),
+				injection: {
+					...DEFAULT_MEMORY_CONFIG.recall.injection,
+					...(config.recall?.injection ?? {}),
+				},
+			},
+			writes: {
+				...DEFAULT_MEMORY_CONFIG.writes,
+				...(config.writes ?? {}),
+			},
+			redaction: {
+				...DEFAULT_MEMORY_CONFIG.redaction,
+				...(config.redaction ?? {}),
+			},
+		};
+	}
+
+	private databasePath(): string {
+		const relativePath = this.config.sqlite.path.replace(/^\.swarm[/\\]?/, '');
+		return validateSwarmPath(this.rootDirectory, relativePath);
+	}
+
+	async initialize(): Promise<void> {
+		if (this.initialized) return;
+		const dbPath = this.databasePath();
+		mkdirSync(path.dirname(dbPath), { recursive: true });
+		const Db = loadDatabaseCtor();
+		this.db = new Db(dbPath);
+		this.db.run('PRAGMA journal_mode = WAL;');
+		this.db.run('PRAGMA synchronous = NORMAL;');
+		const busyTimeoutMs = Math.min(
+			60000,
+			Math.max(0, Math.trunc(this.config.sqlite.busyTimeoutMs)),
+		);
+		this.db.run(`PRAGMA busy_timeout = ${busyTimeoutMs};`);
+		this.db.run('PRAGMA foreign_keys = ON;');
+		this.runMigrations();
+		const memoryLoad = this.loadMemories();
+		const proposalLoad = this.loadProposals();
+		this.memories = new Map(
+			memoryLoad.records.map((record) => [record.id, record]),
+		);
+		this.proposals = new Map(
+			proposalLoad.records.map((proposal) => [proposal.id, proposal]),
+		);
+		this.initialized = true;
+		if (memoryLoad.invalidCount > 0) {
+			await this.event(
+				'invalid_load',
+				'memory_items',
+				`${memoryLoad.invalidCount} invalid SQLite memory row(s) skipped`,
+			);
+		}
+		if (proposalLoad.invalidCount > 0) {
+			await this.event(
+				'invalid_load',
+				'memory_proposals',
+				`${proposalLoad.invalidCount} invalid SQLite proposal row(s) skipped`,
+			);
+		}
+	}
+
+	async upsert(record: MemoryRecord): Promise<MemoryRecord> {
+		await this.initialize();
+		const existing = this.memories.get(record.id);
+		if (existing?.metadata.deleted === true) {
+			throw new MemoryValidationError(
+				'memory is tombstoned and cannot be upserted',
+			);
+		}
+		const next = validateMemoryRecordRules(
+			{
+				...record,
+				createdAt: existing?.createdAt ?? record.createdAt,
+			},
+			{ rejectDurableSecrets: this.config.redaction.rejectDurableSecrets },
+		);
+		this.memories.set(next.id, next);
+		this.writeMemory(next);
+		await this.event('upsert', next.id);
+		return next;
+	}
+
+	async get(id: string): Promise<MemoryRecord | null> {
+		await this.initialize();
+		return this.memories.get(id) ?? null;
+	}
+
+	async delete(id: string, reason?: string): Promise<void> {
+		await this.initialize();
+		const existing = this.memories.get(id);
+		if (!existing) return;
+		if (this.config.hardDelete) {
+			this.memories.delete(id);
+			this.requireDb().run('DELETE FROM memory_items WHERE id = ?', [id]);
+		} else {
+			const tombstone: MemoryRecord = {
+				...existing,
+				updatedAt: new Date().toISOString(),
+				metadata: { ...existing.metadata, deleted: true, deleteReason: reason },
+			};
+			this.memories.set(id, tombstone);
+			this.writeMemory(tombstone);
+		}
+		await this.event('delete', id, reason);
+	}
+
+	async recall(request: RecallRequest): Promise<RecallResultItem[]> {
+		return (await this.recallWithDiagnostics(request)).items;
+	}
+
+	async recallWithDiagnostics(request: RecallRequest): Promise<{
+		items: RecallResultItem[];
+		diagnostics: RecallScoringDiagnostics;
+	}> {
+		await this.initialize();
+		const records = await this.list({
+			scopes: request.scopes,
+			kinds: request.kinds,
+			includeExpired: request.includeExpired,
+		});
+		const result = scoreMemoryRecordsWithDiagnostics(records, request);
+		return {
+			items: result.items.slice(0, request.maxItems),
+			diagnostics: {
+				...result.diagnostics,
+				returnedCount: Math.min(
+					result.diagnostics.returnedCount,
+					request.maxItems,
+				),
+			},
+		};
+	}
+
+	async recordRecallUsage(event: MemoryRecallUsageEvent): Promise<void> {
+		await this.initialize();
+		this.requireDb().run(
+			`INSERT INTO memory_recall_usage (
+				id,
+				bundle_id,
+				timestamp,
+				usage_json
+			) VALUES (?, ?, ?, ?)`,
+			[randomUUID(), event.bundleId, event.timestamp, JSON.stringify(event)],
+		);
+		await this.event('recall', event.bundleId, JSON.stringify(event));
+	}
+
+	async list(filter: MemoryListFilter = {}): Promise<MemoryRecord[]> {
+		await this.initialize();
+		let records = Array.from(this.memories.values());
+		if (filter.scopes && filter.scopes.length > 0) {
+			records = records.filter((record) =>
+				scopeAllowed(record.scope, filter.scopes ?? []),
+			);
+		}
+		if (filter.kinds && filter.kinds.length > 0) {
+			records = records.filter((record) => filter.kinds?.includes(record.kind));
+		}
+		if (!filter.includeExpired) {
+			const now = Date.now();
+			records = records.filter((record) => {
+				if (!record.expiresAt) return true;
+				const expires = Date.parse(record.expiresAt);
+				return !Number.isFinite(expires) || expires > now;
+			});
+		}
+		records = records.filter(
+			(record) => !record.supersededBy && record.metadata.deleted !== true,
+		);
+		records.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+		return records.slice(0, filter.limit ?? records.length);
+	}
+
+	async createProposal(proposal: MemoryProposal): Promise<MemoryProposal> {
+		await this.initialize();
+		const next = validateMemoryProposal(proposal);
+		if (next.proposedRecord) {
+			validateMemoryRecordRules(next.proposedRecord, {
+				rejectDurableSecrets: this.config.redaction.rejectDurableSecrets,
+			});
+		}
+		this.proposals.set(next.id, next);
+		this.requireDb().run(
+			`INSERT OR REPLACE INTO memory_proposals (
+				id,
+				status,
+				created_at,
+				proposal_json
+			) VALUES (?, ?, ?, ?)`,
+			[next.id, next.status, next.createdAt, JSON.stringify(next)],
+		);
+		await this.event('proposal', next.id);
+		return next;
+	}
+
+	async listProposals(
+		filter: { status?: MemoryProposal['status']; limit?: number } = {},
+	): Promise<MemoryProposal[]> {
+		await this.initialize();
+		let proposals = Array.from(this.proposals.values());
+		if (filter.status) {
+			proposals = proposals.filter(
+				(proposal) => proposal.status === filter.status,
+			);
+		}
+		proposals.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+		return proposals.slice(0, filter.limit ?? proposals.length);
+	}
+
+	close(): void {
+		if (!this.db) return;
+		this.db.close();
+		this.db = null;
+		this.initialized = false;
+	}
+
+	private runMigrations(): void {
+		const db = this.requireDb();
+		db.run(`CREATE TABLE IF NOT EXISTS schema_migrations (
+			version INTEGER PRIMARY KEY,
+			name TEXT NOT NULL,
+			applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+		)`);
+		const row = db
+			.query<{ version: number | null }, []>(
+				'SELECT MAX(version) as version FROM schema_migrations',
+			)
+			.get();
+		const currentVersion = row?.version ?? 0;
+		for (const migration of MIGRATIONS) {
+			if (migration.version <= currentVersion) continue;
+			const apply = db.transaction(() => {
+				for (const statement of splitSql(migration.sql)) {
+					db.run(statement);
+				}
+				db.run('INSERT INTO schema_migrations (version, name) VALUES (?, ?)', [
+					migration.version,
+					migration.name,
+				]);
+				this.insertEvent(
+					'migration',
+					String(migration.version),
+					migration.name,
+				);
+			});
+			apply();
+		}
+	}
+
+	private loadMemories(): { records: MemoryRecord[]; invalidCount: number } {
+		const rows = this.requireDb()
+			.query<MemoryItemRow, []>(
+				'SELECT id, record_json FROM memory_items ORDER BY updated_at ASC',
+			)
+			.all();
+		const records: MemoryRecord[] = [];
+		let invalidCount = 0;
+		for (const row of rows) {
+			try {
+				records.push(
+					validateMemoryRecordRules(JSON.parse(row.record_json), {
+						rejectDurableSecrets: this.config.redaction.rejectDurableSecrets,
+					}),
+				);
+			} catch {
+				invalidCount++;
+			}
+		}
+		return { records, invalidCount };
+	}
+
+	private loadProposals(): {
+		records: MemoryProposal[];
+		invalidCount: number;
+	} {
+		const rows = this.requireDb()
+			.query<ProposalRow, []>(
+				'SELECT id, proposal_json FROM memory_proposals ORDER BY created_at ASC',
+			)
+			.all();
+		const records: MemoryProposal[] = [];
+		let invalidCount = 0;
+		for (const row of rows) {
+			try {
+				const proposal = validateMemoryProposal(JSON.parse(row.proposal_json));
+				if (proposal.proposedRecord) {
+					validateMemoryRecordRules(proposal.proposedRecord, {
+						rejectDurableSecrets: this.config.redaction.rejectDurableSecrets,
+					});
+				}
+				records.push(proposal);
+			} catch {
+				invalidCount++;
+			}
+		}
+		return { records, invalidCount };
+	}
+
+	private writeMemory(record: MemoryRecord): void {
+		this.requireDb().run(
+			`INSERT OR REPLACE INTO memory_items (
+				id,
+				scope_key,
+				kind,
+				updated_at,
+				expires_at,
+				superseded_by,
+				deleted,
+				record_json
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			[
+				record.id,
+				JSON.stringify(record.scope),
+				record.kind,
+				record.updatedAt,
+				record.expiresAt ?? null,
+				record.supersededBy ?? null,
+				record.metadata.deleted === true ? 1 : 0,
+				JSON.stringify(record),
+			],
+		);
+	}
+
+	private async event(
+		operation: EventOperation,
+		targetId: string,
+		reason?: string,
+	): Promise<void> {
+		this.insertEvent(operation, targetId, reason);
+	}
+
+	private insertEvent(
+		operation: EventOperation,
+		targetId: string,
+		reason?: string,
+	): void {
+		this.requireDb().run(
+			`INSERT INTO memory_events (
+				id,
+				operation,
+				target_id,
+				reason,
+				timestamp,
+				event_json
+			) VALUES (?, ?, ?, ?, ?, ?)`,
+			[
+				randomUUID(),
+				operation,
+				targetId,
+				reason ?? null,
+				new Date().toISOString(),
+				reason ? JSON.stringify({ reason }) : null,
+			],
+		);
+	}
+
+	private requireDb(): Database {
+		if (!this.db) throw new Error('SQLite memory provider is not initialized');
+		return this.db;
+	}
+}
+
+function splitSql(sql: string): string[] {
+	return sql
+		.split(';')
+		.map((statement) => statement.trim())
+		.filter(Boolean);
+}

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -1,8 +1,8 @@
+import type { Database } from 'bun:sqlite';
 import { randomUUID } from 'node:crypto';
 import { mkdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
-import type { Database } from 'bun:sqlite';
 import { validateSwarmPath } from '../hooks/utils';
 import { DEFAULT_MEMORY_CONFIG, type MemoryConfig } from './config';
 import { MemoryValidationError } from './errors';

--- a/src/tools/swarm-memory-propose.ts
+++ b/src/tools/swarm-memory-propose.ts
@@ -103,23 +103,27 @@ export const swarm_memory_propose: ReturnType<typeof createSwarmTool> =
 					config: config.memory,
 				},
 			);
-			const proposal = await gateway.propose(parsed.data);
-			return JSON.stringify(
-				{
-					success: proposal.status !== 'rejected',
-					proposal_id: proposal.id,
-					status: proposal.status,
-					operation: proposal.operation,
-					memory_id: proposal.proposedRecord?.id,
-					rejection_reason: proposal.rejectionReason,
-					message:
-						proposal.status === 'pending'
-							? 'Memory proposal created. Durable memory was not written.'
-							: 'Memory proposal was captured with policy rejection metadata.',
-				},
-				null,
-				2,
-			);
+			try {
+				const proposal = await gateway.propose(parsed.data);
+				return JSON.stringify(
+					{
+						success: proposal.status !== 'rejected',
+						proposal_id: proposal.id,
+						status: proposal.status,
+						operation: proposal.operation,
+						memory_id: proposal.proposedRecord?.id,
+						rejection_reason: proposal.rejectionReason,
+						message:
+							proposal.status === 'pending'
+								? 'Memory proposal created. Durable memory was not written.'
+								: 'Memory proposal was captured with policy rejection metadata.',
+					},
+					null,
+					2,
+				);
+			} finally {
+				await gateway.dispose();
+			}
 		},
 	});
 

--- a/src/tools/swarm-memory-recall.ts
+++ b/src/tools/swarm-memory-recall.ts
@@ -65,23 +65,27 @@ export const swarm_memory_recall: ReturnType<typeof createSwarmTool> =
 					config: config.memory,
 				},
 			);
-			const bundle = await gateway.recall(parsed.data);
-			return JSON.stringify(
-				{
-					success: true,
-					bundle_id: bundle.id,
-					memory_ids: bundle.items.map((item) => item.record.id),
-					total: bundle.items.length,
-					token_estimate: bundle.tokenEstimate,
-					signals: bundle.items.map((item) => ({
-						memory_id: item.record.id,
-						...item.signals,
-					})),
-					prompt_block: bundle.promptBlock,
-				},
-				null,
-				2,
-			);
+			try {
+				const bundle = await gateway.recall(parsed.data);
+				return JSON.stringify(
+					{
+						success: true,
+						bundle_id: bundle.id,
+						memory_ids: bundle.items.map((item) => item.record.id),
+						total: bundle.items.length,
+						token_estimate: bundle.tokenEstimate,
+						signals: bundle.items.map((item) => ({
+							memory_id: item.record.id,
+							...item.signals,
+						})),
+						prompt_block: bundle.promptBlock,
+					},
+					null,
+					2,
+				);
+			} finally {
+				await gateway.dispose();
+			}
 		},
 	});
 

--- a/tests/unit/config/memory-config.test.ts
+++ b/tests/unit/config/memory-config.test.ts
@@ -19,6 +19,10 @@ describe('MemoryConfigSchema', () => {
 			enabled: false,
 			provider: 'local-jsonl',
 			storageDir: '.swarm/memory',
+			sqlite: {
+				path: '.swarm/memory/memory.db',
+				busyTimeoutMs: 5000,
+			},
 			recall: {
 				defaultMaxItems: 8,
 				defaultTokenBudget: 1200,
@@ -83,9 +87,27 @@ describe('MemoryConfigSchema', () => {
 		).toThrow();
 	});
 
+	test('accepts sqlite provider settings without changing the default provider', () => {
+		const parsed = MemoryConfigSchema.parse({
+			provider: 'sqlite',
+			sqlite: {
+				path: '.swarm/memory/custom.db',
+				busyTimeoutMs: 2500,
+			},
+		});
+
+		expect(parsed.provider).toBe('sqlite');
+		expect(parsed.sqlite).toEqual({
+			path: '.swarm/memory/custom.db',
+			busyTimeoutMs: 2500,
+		});
+		expect(MemoryConfigSchema.parse({}).provider).toBe('local-jsonl');
+	});
+
 	test('exports a usable MemoryConfig type', () => {
 		const config: MemoryConfig = MemoryConfigSchema.parse({ enabled: true });
 
 		expect(config.provider).toBe('local-jsonl');
+		expect(config.sqlite.path).toBe('.swarm/memory/memory.db');
 	});
 });

--- a/tests/unit/memory/gateway.test.ts
+++ b/tests/unit/memory/gateway.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import {
 	MemoryDisabledError,
 	MemoryGateway,
+	SQLiteMemoryProvider,
 	type MemoryProvider,
 	type MemoryRecord,
 } from '../../../src/memory';
@@ -148,6 +149,48 @@ describe('MemoryGateway', () => {
 		expect(bundle.promptBlock).toContain('untrusted retrieved facts');
 		expect(bundle.promptBlock).toContain(record.id);
 		expect(bundle.promptBlock).toContain('age=today');
+	});
+
+	test('gateway behavior is unchanged through the SQLite provider seam', async () => {
+		const provider = new SQLiteMemoryProvider(tmpDir, {
+			enabled: true,
+			provider: 'sqlite',
+		});
+		try {
+			const gateway = new MemoryGateway(
+				{ directory: tmpDir, sessionID: 'session-a', agentRole: 'coder' },
+				{
+					config: { enabled: true },
+					provider,
+					now: () => new Date('2026-05-24T12:00:00.000Z'),
+				},
+			);
+			const proposal = await gateway.propose({
+				operation: 'add',
+				kind: 'repo_convention',
+				text: 'This repo uses bun for SQLite memory tests.',
+				rationale: 'Future agents need the test command.',
+				evidenceRefs: ['package.json'],
+			});
+			const record = gateway.createRecord({
+				kind: 'repo_convention',
+				text: 'This repo uses bun for SQLite memory tests.',
+				evidenceRefs: ['package.json'],
+				confidence: 0.95,
+			}) as MemoryRecord;
+			await gateway.upsertCurated(record);
+
+			const bundle = await gateway.recall({
+				query: 'bun SQLite memory tests',
+				minScore: 0,
+			});
+
+			expect(proposal.status).toBe('pending');
+			expect(bundle.items.map((item) => item.record.id)).toEqual([record.id]);
+			expect(bundle.promptBlock).toContain('## Retrieved Swarm Memory');
+		} finally {
+			provider.close();
+		}
 	});
 
 	test('recall no-ops when provider omits optional usage recording', async () => {

--- a/tests/unit/memory/gateway.test.ts
+++ b/tests/unit/memory/gateway.test.ts
@@ -5,9 +5,9 @@ import * as path from 'node:path';
 import {
 	MemoryDisabledError,
 	MemoryGateway,
-	SQLiteMemoryProvider,
 	type MemoryProvider,
 	type MemoryRecord,
+	SQLiteMemoryProvider,
 } from '../../../src/memory';
 
 let tmpDir: string;

--- a/tests/unit/memory/provider-contract.test.ts
+++ b/tests/unit/memory/provider-contract.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { Database } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { existsSync } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
@@ -9,11 +9,11 @@ import {
 	createMemoryId,
 	createProposalId,
 	LocalJsonlMemoryProvider,
-	SQLiteMemoryProvider,
 	type MemoryProposal,
 	type MemoryProposalStore,
 	type MemoryProvider,
 	type MemoryRecord,
+	SQLiteMemoryProvider,
 } from '../../../src/memory';
 
 type ContractProvider = MemoryProvider &

--- a/tests/unit/memory/provider-contract.test.ts
+++ b/tests/unit/memory/provider-contract.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { existsSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	computeMemoryContentHash,
+	createMemoryId,
+	createProposalId,
+	LocalJsonlMemoryProvider,
+	SQLiteMemoryProvider,
+	type MemoryProposal,
+	type MemoryProposalStore,
+	type MemoryProvider,
+	type MemoryRecord,
+} from '../../../src/memory';
+
+type ContractProvider = MemoryProvider &
+	MemoryProposalStore & { close?: () => void };
+
+interface ProviderCase {
+	name: 'local-jsonl' | 'sqlite';
+	create(root: string): ContractProvider;
+	reopen(root: string): ContractProvider;
+}
+
+const providerCases: ProviderCase[] = [
+	{
+		name: 'local-jsonl',
+		create: (root) => new LocalJsonlMemoryProvider(root, { enabled: true }),
+		reopen: (root) => new LocalJsonlMemoryProvider(root, { enabled: true }),
+	},
+	{
+		name: 'sqlite',
+		create: (root) =>
+			new SQLiteMemoryProvider(root, {
+				enabled: true,
+				provider: 'sqlite',
+			}),
+		reopen: (root) =>
+			new SQLiteMemoryProvider(root, {
+				enabled: true,
+				provider: 'sqlite',
+			}),
+	},
+];
+
+let tmpDir: string;
+const openProviders: ContractProvider[] = [];
+
+beforeEach(async () => {
+	tmpDir = await fs.realpath(
+		await fs.mkdtemp(path.join(os.tmpdir(), 'swarm-memory-contract-')),
+	);
+	openProviders.length = 0;
+});
+
+afterEach(async () => {
+	for (const provider of openProviders.splice(0)) {
+		provider.close?.();
+	}
+	await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function track(provider: ContractProvider): ContractProvider {
+	openProviders.push(provider);
+	return provider;
+}
+
+async function providerRoot(providerName: string): Promise<string> {
+	const root = path.join(tmpDir, providerName);
+	await fs.mkdir(root, { recursive: true });
+	return root;
+}
+
+function makeRecord(text: string, repoId = 'repo-a'): MemoryRecord {
+	const base = {
+		scope: {
+			type: 'repository' as const,
+			repoId,
+			repoRoot: path.join(tmpDir, repoId),
+		},
+		kind: 'repo_convention' as const,
+		text,
+	};
+	return {
+		id: createMemoryId(base),
+		...base,
+		tags: ['testing'],
+		confidence: 0.9,
+		stability: 'durable',
+		source: { type: 'file', filePath: 'package.json' },
+		createdAt: '2026-05-24T12:00:00.000Z',
+		updatedAt: '2026-05-24T12:00:00.000Z',
+		contentHash: computeMemoryContentHash(base),
+		metadata: {},
+	};
+}
+
+function makeProposal(record: MemoryRecord): MemoryProposal {
+	const createdAt = '2026-05-24T12:00:00.000Z';
+	return {
+		id: createProposalId({
+			createdAt,
+			proposer: 'coder',
+			text: record.text,
+		}),
+		operation: 'add',
+		proposedRecord: record,
+		proposedBy: { agentRole: 'coder', runId: 'session-a' },
+		rationale: 'Useful test command convention.',
+		evidenceRefs: ['package.json'],
+		status: 'pending',
+		createdAt,
+		metadata: {},
+	};
+}
+
+describe('MemoryProvider contract parity', () => {
+	for (const providerCase of providerCases) {
+		describe(providerCase.name, () => {
+			test('stores, lists, gets, and reloads memory records', async () => {
+				const root = await providerRoot(providerCase.name);
+				const provider = track(providerCase.create(root));
+				const record = makeRecord('This repo uses bun for memory tests.');
+
+				await provider.upsert(record);
+
+				expect(await provider.get(record.id)).toEqual(record);
+				expect(await provider.list({})).toEqual([record]);
+
+				const reloaded = track(providerCase.reopen(root));
+				expect(await reloaded.get(record.id)).toEqual(record);
+				expect(await reloaded.list({})).toEqual([record]);
+			});
+
+			test('recalls only allowed scopes and records recall usage', async () => {
+				const root = await providerRoot(providerCase.name);
+				const provider = track(providerCase.create(root));
+				const repoA = makeRecord('Repo A uses bun for tests.', 'repo-a');
+				const repoB = makeRecord('Repo B uses npm for tests.', 'repo-b');
+				await provider.upsert(repoA);
+				await provider.upsert(repoB);
+
+				const results = await provider.recall({
+					query: 'what test command should I run',
+					scopes: [repoA.scope],
+					maxItems: 5,
+					tokenBudget: 1000,
+					minScore: 0,
+				});
+				await provider.recordRecallUsage({
+					bundleId: 'bundle_20260524_abcd',
+					query: 'bun tests',
+					scopes: [repoA.scope],
+					kinds: ['repo_convention'],
+					memoryIds: results.map((item) => item.record.id),
+					scores: results.map((item) => item.score),
+					tokenEstimate: 100,
+					agentRole: 'coder',
+					runId: 'session-a',
+					timestamp: '2026-05-24T12:00:00.000Z',
+				});
+
+				expect(results.map((item) => item.record.id)).toEqual([repoA.id]);
+			});
+
+			test('tombstones deletes and refuses to upsert over tombstones', async () => {
+				const root = await providerRoot(providerCase.name);
+				const provider = track(providerCase.create(root));
+				const record = makeRecord('Do not resurrect this convention.');
+				await provider.upsert(record);
+				await provider.delete(record.id, 'obsolete');
+
+				expect(await provider.get(record.id)).toMatchObject({
+					id: record.id,
+					metadata: { deleted: true, deleteReason: 'obsolete' },
+				});
+				expect(await provider.list({})).toHaveLength(0);
+				await expect(
+					provider.upsert({
+						...record,
+						updatedAt: '2026-05-24T13:00:00.000Z',
+					}),
+				).rejects.toThrow('tombstoned');
+			});
+
+			test('stores pending proposals without creating durable memory', async () => {
+				const root = await providerRoot(providerCase.name);
+				const provider = track(providerCase.create(root));
+				const proposal = makeProposal(makeRecord('This repo uses bun.'));
+
+				await provider.createProposal(proposal);
+
+				expect(await provider.list({})).toHaveLength(0);
+				expect(await provider.listProposals({ status: 'pending' })).toEqual([
+					proposal,
+				]);
+			});
+		});
+	}
+});
+
+describe('SQLiteMemoryProvider', () => {
+	test('creates the required tables inside .swarm memory storage', async () => {
+		const root = await providerRoot('sqlite-schema');
+		const provider = track(
+			new SQLiteMemoryProvider(root, { enabled: true, provider: 'sqlite' }),
+		);
+		await provider.initialize();
+		provider.close?.();
+
+		const dbPath = path.join(root, '.swarm', 'memory', 'memory.db');
+		expect(existsSync(dbPath)).toBe(true);
+		const db = new Database(dbPath, { readonly: true });
+		try {
+			const tables = db
+				.query<{ name: string }, []>(
+					"SELECT name FROM sqlite_master WHERE type='table'",
+				)
+				.all()
+				.map((row) => row.name)
+				.sort();
+
+			expect(tables).toEqual(
+				expect.arrayContaining([
+					'memory_items',
+					'memory_proposals',
+					'memory_events',
+					'memory_recall_usage',
+					'schema_migrations',
+				]),
+			);
+		} finally {
+			db.close();
+		}
+	});
+
+	test('rejects sqlite database paths that escape .swarm', async () => {
+		const root = await providerRoot('sqlite-containment');
+		const provider = track(
+			new SQLiteMemoryProvider(root, {
+				enabled: true,
+				provider: 'sqlite',
+				sqlite: {
+					path: '../memory.db',
+					busyTimeoutMs: 5000,
+				},
+			}),
+		);
+
+		await expect(provider.initialize()).rejects.toThrow('path traversal');
+		expect(existsSync(path.join(root, 'memory.db'))).toBe(false);
+	});
+});

--- a/tests/unit/tools/swarm-memory-tools.test.ts
+++ b/tests/unit/tools/swarm-memory-tools.test.ts
@@ -41,6 +41,7 @@ describe('swarm memory tools', () => {
 		recallInternals.loadPluginConfigWithMeta = mock(() => ({
 			config: { memory: { enabled: true } },
 		})) as any;
+		const dispose = mock(async () => {});
 		recallInternals.createMemoryGateway = mock(() => ({
 			recall: mock(async () => ({
 				id: 'bundle_20260524120000_abcdef12',
@@ -48,6 +49,7 @@ describe('swarm memory tools', () => {
 				tokenEstimate: 42,
 				promptBlock: '## Retrieved Swarm Memory\n- [mem_aaaaaaaaaaaaaaaa] fact',
 			})),
+			dispose,
 		})) as any;
 
 		const result = await swarm_memory_recall.execute(
@@ -60,6 +62,7 @@ describe('swarm memory tools', () => {
 		expect(parsed.success).toBe(true);
 		expect(parsed.memory_ids).toEqual(['mem_aaaaaaaaaaaaaaaa']);
 		expect(parsed.prompt_block).toContain('Retrieved Swarm Memory');
+		expect(dispose).toHaveBeenCalledTimes(1);
 	});
 
 	test('propose returns disabled without writing when memory is absent', async () => {
@@ -87,6 +90,7 @@ describe('swarm memory tools', () => {
 		proposeInternals.loadPluginConfigWithMeta = mock(() => ({
 			config: { memory: { enabled: true } },
 		})) as any;
+		const dispose = mock(async () => {});
 		proposeInternals.createMemoryGateway = mock(() => ({
 			propose: mock(async () => ({
 				id: 'prop_aaaaaaaaaaaaaaaa',
@@ -94,6 +98,7 @@ describe('swarm memory tools', () => {
 				operation: 'add',
 				proposedRecord: { id: 'mem_bbbbbbbbbbbbbbbb' },
 			})),
+			dispose,
 		})) as any;
 
 		const result = await swarm_memory_propose.execute(
@@ -113,5 +118,6 @@ describe('swarm memory tools', () => {
 		expect(parsed.proposal_id).toBe('prop_aaaaaaaaaaaaaaaa');
 		expect(parsed.memory_id).toBe('mem_bbbbbbbbbbbbbbbb');
 		expect(parsed.message).toContain('Durable memory was not written');
+		expect(dispose).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
﻿## Summary
- add an opt-in SQLite memory provider that implements `MemoryProvider` and `MemoryProposalStore` behind the existing gateway provider seam
- extend memory config/schema with `provider: local-jsonl | sqlite` and `sqlite.path`/`sqlite.busyTimeoutMs` while keeping `local-jsonl` as default
- add provider parity tests that run shared contract behavior against both providers, plus docs and release fragment updates

## Invariant audit
- 1 (plugin init): not touched - no init-path logic changed; `node scripts/repro-704.mjs` passed (`T1/T2/T3 OK`)
- 2 (runtime portability): touched - SQLite driver is lazy-loaded via `createRequire` in `src/memory/sqlite-provider.ts`; `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-node-load.test.ts tests/unit/build/bundle-plugin-shape.test.ts --timeout 30000` passed and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` passed
- 3 (subprocesses): not touched - no new `bunSpawn`/`spawn`/`spawnSync` callsites added
- 4 (.swarm containment): touched - SQLite DB path is validated through `validateSwarmPath` and constrained to `.swarm`; `bun --smol test tests/unit/memory/provider-contract.test.ts --timeout 30000` covers escape rejection
- 5 (plan durability): not touched - no plan ledger/projection code changed
- 6 (test_runner safety): not touched - validation used shell `bun --smol test` commands, not broad `test_runner`
- 7 (test writing): touched - added `bun:test` provider contract coverage in `tests/unit/memory/provider-contract.test.ts` with no cross-file `mock.module` usage
- 8 (session state): not touched - no session/global state maps changed
- 9 (guardrails/retry): not touched - no guardrail/retry classifier changes
- 10 (chat/system msg): not touched - no chat/system transform changes
- 11 (tool registration): not touched - no tool exports/agent maps changed
- 12 (release/cache): touched - added pending release fragment `docs/releases/pending/sqlite-memory-provider-foundation.md`; version/changelog/manifest files were not edited

## Test plan
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun --smol test tests/unit/memory/local-jsonl-provider.test.ts tests/unit/memory/provider-contract.test.ts tests/unit/memory/gateway.test.ts tests/unit/memory/recall-injection.test.ts tests/unit/config/memory-config.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-node-load.test.ts tests/unit/build/bundle-plugin-shape.test.ts --timeout 30000`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `node scripts/repro-704.mjs`
