### PR TITLE
ci: add engineering invariant checks, skills, and post-merge closeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Mock isolation compliance check
         shell: bash
         run: chmod +x scripts/check-mock-cleanup.sh && bash scripts/check-mock-cleanup.sh
+      - name: Engineering invariant checks
+        shell: bash
+        run: chmod +x scripts/check-invariants.sh && bash scripts/check-invariants.sh
 
   unit:
     needs: quality

--- a/.opencode/skills/generated/git-revert-safety/SKILL.md
+++ b/.opencode/skills/generated/git-revert-safety/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: git-revert-safety
+description: >
+  Apply when reverting commits, undoing merges, or recovering from branch contamination.
+  Covers collateral damage verification (manifest, package.json, CHANGELOG, lockfiles),
+  cherry-pick vs revert decision matrix, partial-revert detection, merge-parent handling,
+  and post-revert CI verification. Prevents the most common revert failure mode: version
+  metadata regression from git reverse-apply.
+effort: small
+triggers:
+  - git revert
+  - revert commit
+  - revert merge
+  - undo merge
+  - reverse-apply
+  - branch contamination
+  - cherry-pick recovery
+  - release-please duplicate tag
+generated_from_knowledge: []
+---
+
+# Git Revert Safety Protocol
+
+Two internal workflows: **Safe Git Revert** (Steps 1-4) and **Branch Contamination Recovery** (Steps 5-6).
+Use the first when reverting known commits. Use the second when the wrong code was merged and you need a clean slate.
+
+---
+
+## Workflow A — Safe Git Revert
+
+### Step 1 — Collateral Damage Assessment
+
+Before reverting, list ALL files touched by each commit being reverted. Use the correct command for the situation:
+
+**Single commit:**
+```bash
+git show --name-only --format= <sha>
+```
+
+**Multiple commits (contiguous range):**
+```bash
+git diff --name-only <commit-before-first>..<last-commit-sha>
+```
+
+**Merge commit — inspect all parents (handles octopus merges with 3+ parents):**
+```bash
+git show --format="%H %P" <merge-sha>   # Shows ALL parent SHAs
+git log --oneline <merge-sha>^1         # First parent (usually main)
+git log --oneline <merge-sha>^2         # Second parent (feature branch)
+# For octopus merges: also inspect ^3, ^4, etc.
+```
+
+Identify which files in the diff are NOT part of the feature being reverted:
+- `.release-please-manifest.json` — version state
+- `package.json` — version field + dependency additions/removals
+- `CHANGELOG.md` — release history
+- Lockfiles (`bun.lock`, `package-lock.json`) — dependency graph
+- `dist/` — build artifacts (will need rebuild)
+- Any config files modified by release PRs between the feature and now
+
+**Gate:** If ANY version metadata or dependency file appears in the diff, you MUST verify post-revert state (Step 3).
+
+### Step 2 — Choose Recovery Strategy
+
+| Scenario | Strategy | Caveat |
+|----------|----------|--------|
+| Single commit that does NOT touch release/build artifacts | `git revert <sha>` | Still verify metadata diff after |
+| Single commit that DOES touch release artifacts | Verify post-revert metadata manually | May need corrective commit |
+| Multi-commit revert, no releases between | `git revert <sha1> <sha2>...` | Verify each commit's file scope |
+| Multi-commit revert, releases between | Cherry-pick fix onto fresh branch | Avoids collateral damage from reverse-apply |
+| Merge commit revert | `git revert -m <parent-number> <merge-sha>` | Must specify correct parent (usually `-m 1` for main) |
+| Branch contamination (wrong code merged) | Fresh branch + cherry-pick | See Workflow B |
+| Revert of revert (re-apply feature) | `git revert <revert-sha>` | ⚠️ Code may have drifted — check for conflicts |
+| Squash merge revert | Fresh branch + cherry-pick preferred | Squash merges have no merge-parent metadata |
+| Octopus merge (3+ parents) | Fresh branch + cherry-pick unless parent is unambiguous | `-m` parent selection is error-prone; prefer clean slate |
+
+**Rule:** If commits to revert span across release-please merge commits, ALWAYS prefer cherry-pick over revert.
+
+### Step 3 — Post-Revert Verification
+
+After reverting, verify these files match expected state:
+
+1. **`.release-please-manifest.json`** — version must match the latest non-draft, non-prerelease GitHub release
+   ```bash
+   # List releases excluding drafts and prereleases
+   gh release list --limit 5 --json tagName,isDraft,isPrerelease --jq '.[] | select(.isDraft==false and .isPrerelease==false) | .tagName'
+   node -e "console.log(require('./.release-please-manifest.json')['.'])"
+   ```
+
+2. **`package.json` version field** — must match the manifest
+   ```bash
+   node -e "console.log(require('./package.json').version)"
+   ```
+
+3. **`CHANGELOG.md`** — must still contain entries for all released versions
+   ```bash
+   # Cross-platform: count version headings
+   node -e "const c=require('fs').readFileSync('CHANGELOG.md','utf8'); console.log((c.match(/^## \[/gm)||[]).length)"
+   # Compare against GitHub releases
+   gh release list --limit 10
+   ```
+
+4. **Dependencies** — if `package.json` dependencies changed, verify lockfile is consistent
+   ```bash
+   bun install --frozen-lockfile   # Must succeed
+   ```
+
+5. **`dist/`** — rebuild required after any source or dependency change
+   ```bash
+   bun run build
+   ```
+
+6. **Bundle size** — if dependencies were added/removed, verify smoke test thresholds still pass
+   ```bash
+   bun test tests/smoke --timeout 120000
+   ```
+
+**If any check fails:** Do NOT hand-edit release-please versions. Restore metadata from the known-good state of the latest release commit or re-run release-please. Apply a corrective commit restoring from the last known-good state before pushing.
+
+### Step 4 — CI Verification
+
+After pushing the revert:
+1. Wait for CI to start
+2. Check last-green-CI timestamp against the merge being reverted:
+   ```bash
+   gh run list --branch main --limit 10 --json databaseId,conclusion,createdAt --jq '.[] | select(.conclusion=="success")'
+   ```
+3. Do NOT dismiss any CI failure as "pre-existing" without timestamp evidence comparing the failure to the last known-green run
+4. If release-please fails with "Duplicate release tag", the manifest was regressed — return to Step 3
+
+---
+
+## Workflow B — Branch Contamination Recovery
+
+Use when the wrong code was merged to main and you need a clean recovery.
+
+### Step 5 — Assess Contamination Scope
+
+1. Identify the exact commits that should NOT be on the branch
+2. Identify the commits that SHOULD be there (fix commits, other features merged after)
+3. Check if release-please ran between the bad merge and now — if so, manifest/CHANGELOG/package.json version were all modified
+
+### Step 6 — Clean-Slate Recovery
+
+1. **Create a fresh branch from origin/main:**
+   ```bash
+   git fetch origin main
+   git checkout -b fix/<name> origin/main
+   ```
+
+2. **Cherry-pick ONLY the fix/feature commits** that should be on the branch:
+   ```bash
+   git cherry-pick <fix-sha>
+   ```
+
+3. **Verify the cherry-picked branch** has exactly the files you expect:
+   ```bash
+   git diff --name-only origin/main..HEAD
+   ```
+
+4. **Rebuild dist/** if any source files changed:
+   ```bash
+   bun run build
+   ```
+
+5. **Run full QA gates** before pushing (lint, build, tests, smoke tests)
+
+**Do NOT attempt incremental cleanup** (removing bad files one by one from a contaminated branch) when release metadata, generated bundles, or dependency graphs are involved. Clean-slate cherry-pick guarantees no contamination leaks.
+
+---
+
+## Conflict Resolution Gate
+
+After resolving any revert or cherry-pick conflicts:
+1. Run `git diff` to review ALL resolved files — not just the conflicted ones
+2. Pay special attention to dist/ and generated files — prefer accepting theirs and rebuilding
+3. For CHANGELOG/manifest conflicts — restore from known-good state, do NOT merge both versions
+4. Verify build succeeds before committing: `bun run build`
+
+---
+
+## Forbidden Shortcuts
+
+- NEVER assume version metadata survived a multi-commit revert unchanged — always verify
+- NEVER dismiss CI failures as pre-existing without comparing timestamps against last-green-CI
+- NEVER attempt incremental cleanup of contaminated branches when release metadata, generated bundles, or dependency graphs are involved
+- NEVER push a revert without rebuilding dist/ if source files changed
+- NEVER hand-invent release-please version numbers — restore from known-good state or re-run release-please
+- NEVER trust stale local SHAs after force-pushes — refetch and compare against remote before recovery
+
+## Delegation Template
+
+```
+SKILLS: file:.opencode/skills/generated/git-revert-safety/SKILL.md
+```

--- a/.opencode/skills/generated/subprocess-safety/SKILL.md
+++ b/.opencode/skills/generated/subprocess-safety/SKILL.md
@@ -1,0 +1,125 @@
+---
+generated: true
+generator: skill-improver
+generator_version: "2026-05-25"
+source_entries:
+  - AGENTS.md#invariant-3
+  - docs/engineering-invariants.md#subsection-3
+---
+
+# Subprocess Safety
+
+Load before modifying any file that calls `spawn`, `spawnSync`, `bunSpawn`,
+or `child_process` from Node/Bun.
+
+## When to use this skill
+
+- You are adding, modifying, or reviewing a subprocess call (`bunSpawn`, `spawn`,
+  `spawnSync`, `child_process.execFile`, etc.)
+- You are writing or updating tests that exercise subprocess-dependent code
+- A PR review flags a subprocess call missing timeout, cwd, or cleanup
+
+## Scope
+
+This skill applies to all files that spawn child processes:
+- `src/utils/git*.ts`
+- `src/hooks/*.ts`
+- `src/tools/*.ts`
+- `src/services/*.ts`
+- `src/plugins/*.ts`
+- `src/index.ts` (init-path subprocesses)
+- Any test file (`tests/**`) that stubs or exercises subprocess code
+
+## Canonical spawn shape
+
+Every subprocess call MUST follow this pattern:
+
+```typescript
+const PER_CALL_TIMEOUT_MS = 10_000; // module-level constant (choose an appropriate value)
+
+const proc = bunSpawn(['git', '-C', dir, 'rev-parse', '--show-toplevel'], {
+  stdin: 'ignore',
+  cwd: dir,
+  timeout: PER_CALL_TIMEOUT_MS,
+  // stdout/stderr: piped, bounded, or ignored
+});
+try {
+  const result = await proc;
+  // process result
+} finally {
+  proc.kill(); // best-effort cleanup
+}
+```
+
+## Six required properties
+
+| Property | Required | Rationale |
+|----------|----------|-----------|
+| Array-form args | Yes | No shell-string commands (injection risk, quoting hell) |
+| `cwd` or `git -C` | Yes | Never rely on inherited process.cwd() |
+| `stdin: 'ignore'` | Yes | A never-closed stdin pipe under Bun/Windows can block child exit (v7.3.3) |
+| `timeout: <ms>` | Yes | No subprocess is "always fast" on every platform |
+| stdout/stderr bounded | Yes | Never leave piped stream unattended on long-running child |
+| `proc.kill()` in `finally` | Yes | Outer withTimeout lets awaiter proceed but doesn't abort child |
+
+## Windows-specific notes
+
+- `.cmd` extensions: npm/bun binaries on Windows are `.cmd` wrappers. Resolve
+  the executable path explicitly using `which`/`where` or the project's
+  cross-platform helper. Do NOT enable `shell: true` or shell-mediated
+  execution to work around PATH resolution.
+- PATH differences: `cmd.exe` and PowerShell resolve PATH differently. Test on
+  Windows, not just macOS/Linux.
+- `child_process.spawn('bin', ...)` does not behave identically to running
+  under `cmd.exe`. Use array-form args and explicit `cwd`.
+- `fs.renameSync` cannot overwrite existing directories on Windows. Use a
+  remove-then-rename pattern or `fs.rename` with error handling.
+
+## Testing pattern: `_internals` DI seam, NOT `mock.module`
+
+`mock.module(...)` leaks across test files in Bun's shared test-runner process.
+Use dependency injection instead:
+
+```typescript
+// --- source file (e.g. src/utils/gitignore-warning.ts) ---
+import { bunSpawn } from './bun-compat';
+
+export const _internals: { bunSpawn: typeof bunSpawn } = { bunSpawn };
+
+// In production code, call _internals.bunSpawn(...) instead of bunSpawn(...)
+
+// --- test file ---
+import { _internals } from '../../src/utils/gitignore-warning';
+const real = _internals.bunSpawn;
+beforeEach(() => { _internals.bunSpawn = stub; });
+afterEach(() => { _internals.bunSpawn = real; });
+```
+
+For the full migration protocol, load the `mock-to-internals-migration` skill.
+
+## Verification grep
+
+After changing any file with subprocess calls, run:
+
+```bash
+grep -n "bunSpawn\|spawn(\|spawnSync(" src/<changed>/*.ts
+```
+
+Every match MUST have all of:
+1. `timeout` set to a concrete millisecond value
+2. `stdin: 'ignore'` (unless intentionally interactive)
+3. `cwd` or `git -C <directory>` for explicit working directory
+4. `proc.kill()` in a `finally` block or equivalent cleanup path
+
+## Historical failures
+
+- **v7.0.3 (#704)**: repo-graph Desktop hang -- unbounded filesystem scan on
+  plugin init. No timeout, no kill path. Result: "no agents in TUI/GUI" with
+  no error message.
+- **v7.3.3 (#732)**: Git-hygiene startup regression -- `ensureSwarmGitExcluded`
+  called git without timeout, stdin, or kill. Result: same silent failure on
+  Windows.
+
+Both caused OpenCode to silently drop the plugin manifest. Users saw no agents
+and no error. Every subprocess call is a potential repeat of these failures
+unless all six properties are enforced.

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.33.1",
+    version: "7.33.2",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/docs/releases/pending/ci-invariant-checks-post-merge-closeout.md
+++ b/docs/releases/pending/ci-invariant-checks-post-merge-closeout.md
@@ -1,0 +1,44 @@
+# CI engineering invariant checks and post-merge closeout
+
+## What changed
+
+- Added `scripts/check-invariants.sh` — a bash CI check that enforces three
+  grep-based engineering invariants from AGENTS.md:
+  1. **Subprocess timeout** (advisory): warns on files using `spawn`/`spawnSync`
+     without `timeout`/`timeoutMs`
+  2. **process.cwd() ban**: blocks new `process.cwd()` usage in `src/tools/`
+     and `src/hooks/` (7 legacy files exempted)
+  3. **mock.module allowlist**: blocks new `mock.module` targets not in
+     `scripts/mock-allowlist.txt` — exact-match with normalization, multiline
+     bypass detection, comment filtering
+- Added `scripts/mock-allowlist.txt` — complete baseline of 53 unique
+  normalized `mock.module` targets (one per path after deduplication)
+- Added `.opencode/skills/generated/subprocess-safety/SKILL.md` — generated
+  skill codifying AGENTS.md Invariant 3 (subprocess safety) as an actionable
+  coder reference
+- Added `.opencode/skills/generated/git-revert-safety/SKILL.md` — generated
+  skill for safe git revert patterns
+
+## Why
+
+Post-merge closeout for PR #1019 (plan state integrity fix #976). The skill
+improver identified three recommendations (R1, R3, R5) to prevent recurring
+violations of the engineering invariants that caused the original bug.
+
+## Migration steps
+
+None. The CI check runs automatically in the `quality` job on every PR.
+To add a new `mock.module` target, add the normalized path to
+`scripts/mock-allowlist.txt`.
+
+## Breaking changes
+
+None.
+
+## Known caveats
+
+- Check 1 (subprocess timeout) is advisory-only — file-level, not call-level.
+  Individual unbounded spawns within files that have `timeout` elsewhere will
+  not be caught by this grep-based check.
+- The `mock.module` allowlist must be manually maintained when new test mocks
+  are added.

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Engineering invariant checks for opencode-swarm.
+# Runs three grep-based checks corresponding to AGENTS.md invariants 3, 4, and 7.
+# Compatible with GitHub Actions (ubuntu-latest, bash).
+set -euo pipefail
+
+violations=0
+
+echo "=== Check 1: Subprocess timeout required (advisory) ==="
+# NOTE: This check is FILE-level — it verifies that any file using spawn/spawnSync
+# also contains timeout/timeoutMs SOMEWHERE in the file. This is intentionally loose
+# because call-level analysis from bash is unreliable. For precise enforcement, use
+# the tree-sitter-based AST checks in the build pipeline or rely on code review.
+# Violations here are WARNINGS, not hard failures.
+timeout_warnings=0
+while IFS= read -r file; do
+  # Exempt the Bun compatibility layer — allowed to use Bun.spawn without timeout
+  if [[ "$file" == *"bun-compat.ts" ]]; then
+    continue
+  fi
+  has_timeout=$(grep -cE "timeout:|timeoutMs" "$file" || true)
+  if [ "$has_timeout" -eq 0 ]; then
+    echo "WARNING: $file uses spawn/spawnSync but has no timeout property in file"
+    timeout_warnings=$((timeout_warnings + 1))
+  fi
+done < <(grep -rl --include="*.ts" -E '\bspawnSync\(|\bspawn\(' src/ \
+  --exclude="*.test.ts" --exclude="*.d.ts" \
+  --exclude-dir=node_modules --exclude-dir=dist || true)
+if [ "$timeout_warnings" -gt 0 ]; then
+  echo "  ($timeout_warnings file(s) have spawn/spawnSync but no timeout — advisory, not blocking)"
+fi
+
+echo "=== Check 2: process.cwd() ban in tools/hooks ==="
+# Grep for process.cwd() in src/tools/ and src/hooks/ (excluding test files).
+# Exempt known legacy usages — these predate the ctx.directory convention and
+# are wrapped in explicit fallback patterns (cwd ?? process.cwd()).
+LEGACY_EXEMPTS=(
+  "src/tools/create-tool.ts"
+  "src/tools/test-runner.ts"
+  "src/tools/resolve-working-directory.ts"
+  "src/tools/save-plan.ts"
+  "src/tools/sbom-generate.ts"
+  "src/hooks/guardrails.ts"
+  "src/hooks/scope-guard.ts"
+)
+while IFS= read -r file; do
+  exempt=false
+  for legacy in "${LEGACY_EXEMPTS[@]}"; do
+    if [[ "$file" == *"$legacy" ]]; then
+      exempt=true
+      break
+    fi
+  done
+  if $exempt; then
+    continue
+  fi
+  echo "ERROR: $file uses process.cwd() — tools must use ctx.directory via resolveWorkingDirectory"
+  violations=$((violations + 1))
+done < <(grep -rl --include="*.ts" 'process\.cwd()' src/tools/ src/hooks/ \
+  --exclude="*.test.ts" \
+  --exclude-dir=node_modules --exclude-dir=dist || true)
+
+echo "=== Check 3: mock.module allowlist ==="
+# Find all test files using mock.module( and validate each target is in the allowlist.
+# The allowlist is stored in scripts/mock-allowlist.txt — one normalized target per line.
+# To add a new mock target: add it to scripts/mock-allowlist.txt with a comment explaining why.
+ALLOWLIST_FILE="$(dirname "$0")/mock-allowlist.txt"
+if [ ! -f "$ALLOWLIST_FILE" ]; then
+  echo "ERROR: $ALLOWLIST_FILE not found — mock.module allowlist is required for Check 3"
+  echo "       To add a new mock target: append the normalized target to $ALLOWLIST_FILE with a comment"
+  violations=$((violations + 1))
+else
+  while IFS= read -r file; do
+    # Filter: only non-comment lines containing mock.module(
+    # This avoids false positives from commented-out code.
+    active_lines=$(grep -E 'mock\.module\(' "$file" | grep -vE '^\s*//' | grep -vE '^\s*\*' || true)
+    call_count=$(echo "$active_lines" | grep -cE 'mock\.module\(' || true)
+    target_count=$(echo "$active_lines" | grep -oP 'mock\.module\(\s*["\x27][^"\x27]+["\x27]' | wc -l || true)
+    if [ "$call_count" -ne "$target_count" ]; then
+      echo "ERROR: $file has $call_count mock.module call(s) but only $target_count target(s) extracted."
+      echo "       Multiline mock.module calls (target on a separate line from mock.module()) are not supported."
+      echo "       Rewrite to single-line format: mock.module('target', () => ({ ... }))"
+      echo "       The allowlist check cannot validate targets it cannot extract."
+      violations=$((violations + 1))
+      continue
+    fi
+    # Extract targets from the same filtered (non-comment) lines
+    while IFS= read -r target; do
+      # Skip empty lines
+      [ -n "$target" ] || continue
+
+      # Normalize: strip all ../ segments, then leading src/, then .js extension
+      # ../../../src/plan/manager.js -> src/plan/manager
+      # ../../src/tools/co-change-analyzer.js -> src/tools/co-change-analyzer
+      # node:child_process -> node:child_process (unchanged)
+      normalized="$(echo "$target" | sed 's|^\(\.\.\/\)\+||; s|^src/||; s|\.js$||')"
+      # Prepend src/ only for relative targets (not node: builtins)
+      if [[ "$normalized" != node:* ]]; then
+        normalized="src/$normalized"
+      fi
+
+      # Check against allowlist (exact match on normalized target)
+      allowed=false
+      while IFS= read -r pattern; do
+        # Skip empty lines and comments in allowlist
+        [[ -z "$pattern" || "$pattern" == \#* ]] && continue
+        if [ "$normalized" = "$pattern" ]; then
+          allowed=true
+          break
+        fi
+      done < "$ALLOWLIST_FILE"
+
+      if ! $allowed; then
+        echo "ERROR: $file mocks '$target' (normalized: '$normalized') — not in allowlist."
+        echo "       Use _internals DI seam, or add '$normalized' to $ALLOWLIST_FILE"
+        violations=$((violations + 1))
+      fi
+    done < <(echo "$active_lines" \
+      | grep -oP 'mock\.module\(\s*["\x27][^"\x27]+["\x27]' \
+      | sed "s/^mock\.module(\s*[\"']//;s/[\"']$//" || true)
+  done < <(grep -rl 'mock\.module(' tests/ --include="*.test.ts" \
+    --exclude-dir=node_modules --exclude-dir=dist || true)
+fi
+
+echo ""
+echo "=== Summary ==="
+if [ "$violations" -gt 0 ]; then
+  echo "$violations invariant violation(s) found."
+  exit 1
+fi
+
+echo "All engineering invariant checks passed."

--- a/scripts/mock-allowlist.txt
+++ b/scripts/mock-allowlist.txt
@@ -1,0 +1,105 @@
+# mock.module Allowlist — scripts/mock-allowlist.txt
+# One normalized target per line. Blank lines and # comments are ignored.
+# EXACT match only — each target must be listed individually.
+#
+# Normalization: strip leading ../ sequences -> replace with src/
+#                strip trailing .js
+# Example: '../../../src/plan/manager.js' -> 'src/plan/manager'
+#
+# To add a NEW mock target: append it here with a comment explaining why.
+# Prefer _internals DI seam for new code — mock.module is a legacy pattern.
+#
+# Last updated: 2026-05-25
+
+# --- Node builtins ---
+node:child_process
+node:fs
+node:fs/promises
+node:path
+
+# --- src/agents ---
+src/agents/critic
+
+# --- src/background ---
+src/background/event-bus
+src/background/manager
+
+# --- src/build ---
+src/build/discovery
+
+# --- src/config ---
+src/config
+src/config/index
+src/config/schema
+
+# --- src/db ---
+src/db/qa-gate-profile
+
+# --- src/evidence ---
+src/evidence/manager
+
+# --- src/git ---
+src/git/branch
+
+# --- src/hooks ---
+src/hooks/curator
+src/hooks/curator-drift
+src/hooks/extractors
+src/hooks/hive-promoter
+src/hooks/knowledge-curator
+src/hooks/knowledge-migrator
+src/hooks/knowledge-reader
+src/hooks/knowledge-store
+src/hooks/knowledge-validator
+src/hooks/utils
+
+# --- src/lang ---
+src/lang/detector
+src/lang/registry
+
+# --- src/mutation ---
+src/mutation/equivalence
+
+# --- src/parallel ---
+src/parallel/file-locks
+
+# --- src/plan ---
+src/plan/checkpoint
+src/plan/ledger
+src/plan/manager
+
+# --- src/sast ---
+src/sast/rules/index
+src/sast/semgrep
+
+# --- src/services ---
+src/services/evidence-summary-service
+src/services/handoff-service
+src/services/run-memory
+src/services/skill-improver
+
+# --- src/session ---
+src/session/snapshot-writer
+
+# --- src/state ---
+src/state
+
+# --- src/telemetry ---
+src/telemetry
+
+# --- src/tools ---
+src/tools/co-change-analyzer
+src/tools/knowledge-recall
+src/tools/lint
+src/tools/quality-budget
+src/tools/sast-baseline
+src/tools/sast-scan
+src/tools/secretscan
+src/tools/write-retro
+
+# --- src/utils ---
+src/utils/bun-compat
+src/utils/logger
+src/utils/path-security
+src/utils/spec-hash
+src/utils


### PR DESCRIPTION
﻿## Summary
- Add `scripts/check-invariants.sh` — a bash CI check that enforces three grep-based engineering invariants from AGENTS.md:
  1. **Subprocess timeout** (advisory): warns on files using `spawn`/`spawnSync` without `timeout`/`timeoutMs`
  2. **process.cwd() ban** (blocking): prevents new `process.cwd()` usage in `src/tools/` and `src/hooks/` (7 legacy files exempted)
  3. **mock.module allowlist** (blocking): blocks new `mock.module` targets not in `scripts/mock-allowlist.txt` with exact-match normalization, multiline bypass detection, and comment filtering
- Add `scripts/mock-allowlist.txt` — complete baseline of 53 unique normalized `mock.module` targets
- Add `.opencode/skills/generated/subprocess-safety/SKILL.md` — generated skill codifying AGENTS.md Invariant 3
- Add `.opencode/skills/generated/git-revert-safety/SKILL.md` — generated skill for safe git revert patterns

Post-merge closeout for PR #1019 (plan state integrity fix #976).

## Review findings resolved (post-push)

| Finding | Severity | Resolution |
|---------|----------|------------|
| F-001: Knowledge curation claim unverifiable | MEDIUM | Removed unverifiable knowledge count claim from release note |
| F-002: Allowlist count mismatch (58 vs 53) | MEDIUM | Fixed to correct count: 53 unique normalized targets |
| F-003: Multiline mock.module error message vague | MEDIUM | Expanded to 3-line explanation with format guidance |
| F-009: Stale knowledge IDs in git-revert-safety | MEDIUM | Removed 3 dangling IDs; added source refs for subprocess-safety |

Findings NOT fixed (by design or LOW):
- F-004 (test coverage for skills): Skills are markdown docs, not executable. CI script validated by CI itself.
- F-005 (bash-only platform): By design — CI quality job runs ubuntu-latest.
- F-006/F-007/F-008 (hardcoded lists, file-level check, different models): Documented design choices.
- F-010 (bun-compat exemption): Intentional — bun-compat wraps Bun.spawn, not child_process.

## Invariant audit
- 1 (plugin init): not touched — no changes to src/index.ts or init-path code
- 2 (runtime portability): not touched — no source code changes
- 3 (subprocesses): not touched — skill documents invariant 3 but no source spawn calls modified
- 4 (.swarm containment): not touched
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched
- 7 (test writing): not touched
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched
- 12 (release/cache): not touched — dist/ rebuilt only for version alignment with 7.33.2

## Test plan
- [x] `bun run build` passes
- [x] `bun run typecheck` passes
- [x] `pre_check_batch` passes on all changed files
- [x] `scripts/check-invariants.sh` verified — 0 violations on all 3 checks
- [x] All 53 mock.module targets normalize correctly to allowlist entries
- [x] Reviewer APPROVED (2 rounds for finding fixes)
- [ ] CI quality job confirms 0 violations on ubuntu-latest
