### PR TITLE
feat(memory): add curator-approved memory decision workflow

### DIFF
--- a/.agents/skills/swarm-pr-review/SKILL.md
+++ b/.agents/skills/swarm-pr-review/SKILL.md
@@ -206,6 +206,20 @@ For each obligation, record:
 
 Tests are claims. A passing or added test does not prove the obligation unless the reviewer inspects the assertion strength and relevant code path.
 
+### Quantitative claim verification
+
+PR body numerical claims (test counts, coverage percentages, assertion counts, performance benchmarks) are obligations, not proof. For each quantitative claim:
+
+1. Extract the claim and its source (PR body, comment, commit message).
+2. Verify against actual tool output or CI artifacts when available.
+3. If the claim cannot be independently verified, mark the obligation `UNVERIFIABLE` with reason.
+4. If the claim is disproved by evidence, create a finding linking the discrepancy.
+
+Common patterns to verify:
+- "N tests pass" → count actual test results from CI logs or test runner output
+- "N% coverage" → compare against coverage report
+- "No regressions" → verify against test runner failure count
+
 ---
 
 ## Phase 2: Deterministic Signal Ingestion
@@ -261,7 +275,7 @@ Explorers optimize for recall. Over-reporting is expected. Explorers produce can
 | Lane 2: Security and trust boundaries | Injection, authz/authn bypass, SSRF, path traversal, secret exposure, unsafe deserialization, prompt injection | untrusted input sources, sanitization, credential handling, permission boundary, private network access, output escaping |
 | Lane 3: Dependencies and deployment safety | Import changes, version bumps, lockfile drift, breaking APIs, package scripts, runtime assumptions | lockfile consistency, new transitive deps, Node/Bun/runtime compatibility, platform assumptions, license red flags |
 | Lane 4: Docs, intent, and drift | PR claims vs implementation, docs mismatch, migration/changelog gaps, stale examples | obligation mapping, changed behavior not documented, docs promising behavior not implemented |
-| Lane 5: Tests and falsifiability | Weak assertions, missing edge tests, flaky patterns, mock leakage, fixture drift | assertion strength, negative paths, isolation, deterministic timing, cross-platform path coverage |
+| Lane 5: Tests and falsifiability | Weak assertions, missing edge tests, flaky patterns, mock leakage, fixture drift | assertion strength, tautology patterns (`expect(true).toBe(true)`, `expect(res).toBeDefined()` without further checks, `assertDoesNotThrow` wrapping trivial code), negative paths, isolation, deterministic timing, cross-platform path coverage |
 | Lane 6: Performance and architecture | Complexity regressions, memory leaks, over-coupling, inefficient graph scans, global mutable state | algorithmic deltas, caching, resource lifecycle, state ownership, architectural boundary violations |
 
 ### Explorer context contract
@@ -533,6 +547,38 @@ Knowledge writeback rules:
 - Mark repo-specific lessons as project-tier unless there is strong evidence they generalize.
 - Never promote quarantined or unvalidated knowledge to hive-tier.
 - Never store secrets, private tokens, or raw sensitive logs.
+
+---
+
+## Phase 11: Post-Fix Re-verification
+
+When the PR author pushes fixes after a review, perform a targeted re-verification before updating the verdict.
+
+### Re-verification scope
+
+Only re-verify findings the author claims to have fixed. Do not re-run the full review pipeline.
+
+### Re-verification steps
+
+1. For each finding the author claims fixed:
+   a. Read the changed file(s) from the updated branch at the specific lines referenced in the original finding.
+   b. Verify the fix addresses the root cause, not just the symptom.
+   c. Check that the fix does not introduce a new issue in the same area.
+2. Run CI checks on the updated branch to confirm no regressions.
+3. For findings the author did not address, carry forward the original finding with unchanged status.
+
+### Re-verification output
+
+```
+[REVERIFIED] | finding_id | FIXED / PARTIALLY_FIXED / NOT_FIXED / NEW_ISSUE | evidence | updated_severity
+```
+
+- `FIXED`: the root cause is resolved and no new issue introduced.
+- `PARTIALLY_FIXED`: the root cause is partially addressed or a residual concern remains.
+- `NOT_FIXED`: the root cause persists unchanged.
+- `NEW_ISSUE`: the fix introduced a new problem at the same location.
+
+Update the verdict only after re-verifying all previously blocking findings.
 
 ---
 

--- a/.claude/skills/swarm-pr-review/SKILL.md
+++ b/.claude/skills/swarm-pr-review/SKILL.md
@@ -79,6 +79,20 @@ For each obligation, record:
 - Verification status (UNVERIFIED → IN_PROGRESS → MET / NOT MET / UNVERIFIABLE)
 - Link to corresponding finding if non-met
 
+### Quantitative claim verification
+
+PR body numerical claims (test counts, coverage percentages, assertion counts, performance benchmarks) are obligations, not proof. For each quantitative claim:
+
+1. Extract the claim and its source (PR body, comment, commit message).
+2. Verify against actual tool output or CI artifacts when available.
+3. If the claim cannot be independently verified, mark the obligation `UNVERIFIABLE` with reason.
+4. If the claim is disproved by evidence, create a finding linking the discrepancy.
+
+Common patterns to verify:
+- "N tests pass" → count actual test results from CI logs or test runner output
+- "N% coverage" → compare against coverage report
+- "No regressions" → verify against test runner failure count
+
 ---
 
 ### Phase 2: Parallel Explorer Lanes (6 lanes, launch in single message)
@@ -91,7 +105,7 @@ Launch all 6 lanes in parallel in a **single message with multiple Agent tool ca
 | **Lane 2: Security** | Injection, auth bypass, secret exposure, privilege escalation, SSRF, path traversal, unsafe deserialization | Input sanitization, authnz enforcement points, credential handling, permission boundaries |
 | **Lane 3: Dependencies** | Import changes, version bumps, breaking API changes, new transitive deps, license issues | `package.json`/`requirements.txt`/Cargo.toml changes, lockfile drift, breaking API replacements |
 | **Lane 4: Docs vs Intent** | PR claims vs actual code changes, undocumented behavior, misleading variable names, absent changelog entries | Claims made in PR text vs what diff actually does, side effects not mentioned |
-| **Lane 5: Tests** | Coverage gaps, flaky patterns, weak assertions, test isolation violations, missing edge case tests | Assertion quality, mock isolation, happy-path-only coverage, missing error-path tests |
+| **Lane 5: Tests** | Coverage gaps, flaky patterns, weak assertions, test isolation violations, missing edge case tests | Assertion quality, tautology patterns (`expect(true).toBe(true)`, `expect(res).toBeDefined()` without further checks, `assertDoesNotThrow` wrapping trivial code), mock isolation, happy-path-only coverage, missing error-path tests |
 | **Lane 6: Performance/Architecture** | Complexity changes, memory leaks, algorithmic regressions, coupling between modules, architectural debt | Cyclomatic complexity deltas, GC pressure, connection pool usage, shared mutable state |
 
 **Explorer output format per finding:**
@@ -202,6 +216,38 @@ When user requests council review or uses phrases like "independent review", "5-
 5. Apply critic challenge to reviewer-confirmed HIGH/CRITICAL findings
 6. **Council findings are supplementary, not authoritative overrides.** Council may miss context the main thread has. Do not adopt council severities verbatim without independent validation.
 7. Final synthesis merges validated council findings with main-thread-only findings, clearly labeled by source
+
+---
+
+## Post-Fix Re-verification
+
+When the PR author pushes fixes after a review, perform a targeted re-verification before updating the verdict.
+
+### Re-verification scope
+
+Only re-verify findings the author claims to have fixed. Do not re-run the full review pipeline.
+
+### Re-verification steps
+
+1. For each finding the author claims fixed:
+   a. Read the changed file(s) from the updated branch at the specific lines referenced in the original finding.
+   b. Verify the fix addresses the root cause, not just the symptom.
+   c. Check that the fix does not introduce a new issue in the same area.
+2. Run CI checks on the updated branch to confirm no regressions.
+3. For findings the author did not address, carry forward the original finding with unchanged status.
+
+### Re-verification output
+
+```
+[REVERIFIED] | finding_id | FIXED / PARTIALLY_FIXED / NOT_FIXED / NEW_ISSUE | evidence | updated_severity
+```
+
+- `FIXED`: the root cause is resolved and no new issue introduced.
+- `PARTIALLY_FIXED`: the root cause is partially addressed or a residual concern remains.
+- `NOT_FIXED`: the root cause persists unchanged.
+- `NEW_ISSUE`: the fix introduced a new problem at the same location.
+
+Update the verdict only after re-verifying all previously blocking findings.
 
 ---
 

--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -103,6 +103,14 @@ Record:
 
 If scope cannot be determined, review the narrowest safe scope available and state the limitation.
 
+### Pre-flight git ref availability
+
+Before launching explorers (Phase 3), confirm the PR branch refs are available:
+- If `head_ref` is a remote branch that is not checked out locally, fetch it via `git fetch origin <head_ref>`
+- Explicitly pass the commit range (`base_ref..head_ref`) in every explorer delegation so explorers read from the correct revision
+
+If refs cannot be fetched, state the limitation in the context pack.
+
 ---
 
 # Default Review Workflow
@@ -207,6 +215,20 @@ For each obligation, record:
 
 Tests are claims. A passing or added test does not prove the obligation unless the reviewer inspects the assertion strength and relevant code path.
 
+### Quantitative claim verification
+
+PR body numerical claims (test counts, coverage percentages, assertion counts, performance benchmarks) are obligations, not proof. For each quantitative claim:
+
+1. Extract the claim and its source (PR body, comment, commit message).
+2. Verify against actual tool output or CI artifacts when available.
+3. If the claim cannot be independently verified, mark the obligation `UNVERIFIABLE` with reason.
+4. If the claim is disproved by evidence, create a finding linking the discrepancy.
+
+Common patterns to verify:
+- "N tests pass" → count actual test results from CI logs or test runner output
+- "N% coverage" → compare against coverage report
+- "No regressions" → verify against test runner failure count
+
 ---
 
 ## Phase 2: Deterministic Signal Ingestion
@@ -262,7 +284,7 @@ Explorers optimize for recall. Over-reporting is expected. Explorers produce can
 | Lane 2: Security and trust boundaries | Injection, authz/authn bypass, SSRF, path traversal, secret exposure, unsafe deserialization, prompt injection | untrusted input sources, sanitization, credential handling, permission boundary, private network access, output escaping |
 | Lane 3: Dependencies and deployment safety | Import changes, version bumps, lockfile drift, breaking APIs, package scripts, runtime assumptions | lockfile consistency, new transitive deps, Node/Bun/runtime compatibility, platform assumptions, license red flags |
 | Lane 4: Docs, intent, and drift | PR claims vs implementation, docs mismatch, migration/changelog gaps, stale examples | obligation mapping, changed behavior not documented, docs promising behavior not implemented |
-| Lane 5: Tests and falsifiability | Weak assertions, missing edge tests, flaky patterns, mock leakage, fixture drift | assertion strength, negative paths, isolation, deterministic timing, cross-platform path coverage |
+| Lane 5: Tests and falsifiability | Weak assertions, missing edge tests, flaky patterns, mock leakage, fixture drift | assertion strength, tautology patterns (`expect(true).toBe(true)`, `expect(res).toBeDefined()` without further checks, `assertDoesNotThrow` wrapping trivial code), negative paths, isolation, deterministic timing, cross-platform path coverage |
 | Lane 6: Performance and architecture | Complexity regressions, memory leaks, over-coupling, inefficient graph scans, global mutable state | algorithmic deltas, caching, resource lifecycle, state ownership, architectural boundary violations |
 
 ### Explorer context contract
@@ -276,6 +298,7 @@ Every explorer must inspect or explicitly mark unavailable:
 5. the nearest relevant test or missing-test location,
 6. deterministic signal entries mapped to its files/symbols,
 7. relevant Swarm knowledge/evidence entries, if present.
+8. the commit range to analyze (`base_ref..head_ref`),
 
 Explorer output format:
 
@@ -537,6 +560,38 @@ Knowledge writeback rules:
 
 ---
 
+## Phase 11: Post-Fix Re-verification
+
+When the PR author pushes fixes after a review, perform a targeted re-verification before updating the verdict.
+
+### Re-verification scope
+
+Only re-verify findings the author claims to have fixed. Do not re-run the full review pipeline.
+
+### Re-verification steps
+
+1. For each finding the author claims fixed:
+   a. Read the changed file(s) from the updated branch at the specific lines referenced in the original finding.
+   b. Verify the fix addresses the root cause, not just the symptom.
+   c. Check that the fix does not introduce a new issue in the same area.
+2. Run CI checks on the updated branch to confirm no regressions.
+3. For findings the author did not address, carry forward the original finding with unchanged status.
+
+### Re-verification output
+
+```
+[REVERIFIED] | finding_id | FIXED / PARTIALLY_FIXED / NOT_FIXED / NEW_ISSUE | evidence | updated_severity
+```
+
+- `FIXED`: the root cause is resolved and no new issue introduced.
+- `PARTIALLY_FIXED`: the root cause is partially addressed or a residual concern remains.
+- `NOT_FIXED`: the root cause persists unchanged.
+- `NEW_ISSUE`: the fix introduced a new problem at the same location.
+
+Update the verdict only after re-verifying all previously blocking findings.
+
+---
+
 # Council Mode Workflow
 
 Council mode is opt-in only and adversarial.
@@ -639,6 +694,7 @@ Before writing the final output, print this checklist with filled values. Every 
 [VALIDATION] falsification probes included: ___
 [VALIDATION] grouped root-cause findings: ___
 [VALIDATION] metrics / knowledge writeback: ___
+[VALIDATION] all explorers verified to diff against PR branch, not HEAD: YES/NO
 ```
 
 If the reviewer returned `REJECTED` or `CONCERNS`, route the issue back to implementation context or mark the candidate invalid with reason. Do not silently downgrade a rejection.

--- a/dist/agents/agent-output-schema.d.ts
+++ b/dist/agents/agent-output-schema.d.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { ProposeMemoryInput } from '../memory/gateway';
+import type { CuratorMemoryDecision, ProposeMemoryInput } from '../memory';
 export declare const AgentOutputMemorySchema: z.ZodObject<{
     memoryProposals: z.ZodOptional<z.ZodArray<z.ZodObject<{
         operation: z.ZodEnum<{
@@ -31,8 +31,16 @@ export declare const AgentOutputMemorySchema: z.ZodObject<{
         evidenceRefs: z.ZodOptional<z.ZodArray<z.ZodString>>;
     }, z.core.$strict>>>;
 }, z.core.$loose>;
+export declare const CuratorOutputMemoryDecisionSchema: z.ZodObject<{
+    curatorMemoryDecisions: z.ZodOptional<z.ZodArray<z.ZodType<CuratorMemoryDecision, unknown, z.core.$ZodTypeInternals<CuratorMemoryDecision, unknown>>>>;
+}, z.core.$loose>;
 export interface ExtractedAgentMemoryProposals {
     proposals: ProposeMemoryInput[];
     error?: string;
 }
+export interface ExtractedCuratorMemoryDecisions {
+    decisions: CuratorMemoryDecision[];
+    error?: string;
+}
 export declare function extractMemoryProposalsFromAgentOutput(outputText: string): ExtractedAgentMemoryProposals;
+export declare function extractCuratorMemoryDecisionsFromAgentOutput(outputText: string): ExtractedCuratorMemoryDecisions;

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -45491,7 +45491,7 @@ function validateMemoryRecordRules(record3, options) {
 function validateMemoryProposal(proposal) {
   return MemoryProposalSchema.parse(proposal);
 }
-var MemoryScopeTypeSchema, MemoryScopeRefSchema, MemoryKindSchema, MemorySourceSchema, MemoryRecordSchema, MemoryProposalSchema;
+var MemoryScopeTypeSchema, MemoryScopeRefSchema, MemoryKindSchema, MemorySourceSchema, MemoryRecordSchema, MemoryProposalSchema, NewMemoryRecordSchema, MemoryPatchSchema, ProposalIdSchema, MemoryIdSchema, CuratorDecisionReasonSchema, CuratorMemoryDecisionSchema;
 var init_schema2 = __esm(() => {
   init_zod();
   init_config3();
@@ -45598,6 +45598,138 @@ var init_schema2 = __esm(() => {
     createdAt: exports_external.string().datetime(),
     metadata: exports_external.record(exports_external.string(), exports_external.unknown())
   }).strict();
+  NewMemoryRecordSchema = exports_external.object({
+    scope: MemoryScopeRefSchema.optional(),
+    kind: MemoryKindSchema,
+    text: exports_external.string().min(1).max(2000),
+    tags: exports_external.array(exports_external.string().min(1).max(64)).max(32).optional(),
+    confidence: exports_external.number().min(0).max(1).optional(),
+    stability: exports_external.enum(["ephemeral", "session", "durable"]).optional(),
+    source: MemorySourceSchema.optional(),
+    expiresAt: exports_external.string().datetime().optional(),
+    metadata: exports_external.record(exports_external.string(), exports_external.unknown()).optional()
+  }).strict();
+  MemoryPatchSchema = exports_external.object({
+    scope: MemoryScopeRefSchema.optional(),
+    kind: MemoryKindSchema.optional(),
+    text: exports_external.string().min(1).max(2000).optional(),
+    tags: exports_external.array(exports_external.string().min(1).max(64)).max(32).optional(),
+    confidence: exports_external.number().min(0).max(1).optional(),
+    stability: exports_external.enum(["ephemeral", "session", "durable"]).optional(),
+    source: MemorySourceSchema.optional(),
+    expiresAt: exports_external.string().datetime().optional(),
+    metadata: exports_external.record(exports_external.string(), exports_external.unknown()).optional()
+  }).strict().refine((patch) => Object.keys(patch).length > 0, {
+    message: "memory patch must not be empty"
+  });
+  ProposalIdSchema = exports_external.string().regex(/^prop_[a-f0-9]{16}$/);
+  MemoryIdSchema = exports_external.string().regex(/^mem_[a-f0-9]{16}$/);
+  CuratorDecisionReasonSchema = exports_external.string().min(1).max(2000);
+  CuratorMemoryDecisionSchema = exports_external.discriminatedUnion("action", [
+    exports_external.object({
+      action: exports_external.literal("add"),
+      proposalId: ProposalIdSchema,
+      memory: NewMemoryRecordSchema
+    }).strict(),
+    exports_external.object({
+      action: exports_external.literal("update"),
+      proposalId: ProposalIdSchema,
+      targetMemoryId: MemoryIdSchema,
+      patch: MemoryPatchSchema,
+      reason: CuratorDecisionReasonSchema
+    }).strict(),
+    exports_external.object({
+      action: exports_external.literal("supersede"),
+      proposalId: ProposalIdSchema,
+      oldMemoryId: MemoryIdSchema,
+      replacement: NewMemoryRecordSchema,
+      reason: CuratorDecisionReasonSchema
+    }).strict(),
+    exports_external.object({
+      action: exports_external.literal("reject"),
+      proposalId: ProposalIdSchema,
+      reason: CuratorDecisionReasonSchema
+    }).strict(),
+    exports_external.object({
+      action: exports_external.literal("noop"),
+      proposalId: ProposalIdSchema,
+      reason: CuratorDecisionReasonSchema
+    }).strict()
+  ]);
+});
+
+// src/memory/curator-decision-helpers.ts
+function validateDecisionMatchesProposal(decision, proposal) {
+  if (decision.action === "add" && proposal.operation !== "add" || decision.action === "update" && proposal.operation !== "update" || decision.action === "supersede" && proposal.operation !== "supersede") {
+    throw new MemoryValidationError(`curator ${decision.action} decision does not match ${proposal.operation} proposal`);
+  }
+  if (decision.action === "update" && proposal.targetMemoryId && proposal.targetMemoryId !== decision.targetMemoryId) {
+    throw new MemoryValidationError("curator update decision target does not match proposal target");
+  }
+  if (decision.action === "supersede" && proposal.targetMemoryId && proposal.targetMemoryId !== decision.oldMemoryId) {
+    throw new MemoryValidationError("curator supersede decision target does not match proposal target");
+  }
+}
+function applyPatchToMemory(existing, patch, updatedAt) {
+  const base = {
+    scope: patch.scope ?? existing.scope,
+    kind: patch.kind ?? existing.kind,
+    text: patch.text === undefined ? existing.text : normalizeMemoryText(patch.text)
+  };
+  const tags = patch.tags === undefined ? existing.tags : normalizeTags(patch.tags);
+  return {
+    ...existing,
+    ...patch,
+    ...base,
+    id: createMemoryId(base),
+    tags,
+    updatedAt,
+    contentHash: computeMemoryContentHash(base),
+    metadata: patch.metadata === undefined ? existing.metadata : { ...existing.metadata, ...patch.metadata }
+  };
+}
+function markProposalReviewed(proposal, decision, status, reviewedAt, ids) {
+  const reason = curatorDecisionReason(decision);
+  return validateMemoryProposal({
+    ...proposal,
+    status,
+    reviewer: "curator_agent",
+    reviewedAt,
+    rejectionReason: decision.action === "reject" ? reason : undefined,
+    metadata: {
+      ...proposal.metadata,
+      curatorDecision: {
+        action: decision.action,
+        reason,
+        ...ids,
+        appliedAt: reviewedAt
+      }
+    }
+  });
+}
+function curatorDecisionReason(decision) {
+  switch (decision.action) {
+    case "add":
+      return;
+    case "update":
+    case "supersede":
+    case "reject":
+    case "noop":
+      return decision.reason;
+  }
+}
+function buildCuratorDecisionEvent(change, proposal) {
+  return {
+    ...change,
+    proposalOperation: proposal.operation
+  };
+}
+function normalizeTags(tags) {
+  return Array.from(new Set(tags.map((tag) => tag.toLowerCase().replace(/[^\w-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "")).filter(Boolean))).slice(0, 32);
+}
+var init_curator_decision_helpers = __esm(() => {
+  init_errors6();
+  init_schema2();
 });
 
 // src/memory/scoring.ts
@@ -45913,20 +46045,125 @@ class LocalJsonlMemoryProvider {
     proposals.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
     return proposals.slice(0, filter.limit ?? proposals.length);
   }
+  async applyCuratorDecision(decision) {
+    await this.initialize();
+    const appliedAt = new Date().toISOString();
+    const proposal = this.proposals.get(decision.proposalId);
+    if (!proposal) {
+      throw new MemoryValidationError("memory proposal was not found");
+    }
+    if (proposal.status !== "pending") {
+      throw new MemoryValidationError("memory proposal is not pending");
+    }
+    validateDecisionMatchesProposal(decision, proposal);
+    let memoryId;
+    let targetMemoryId;
+    let oldMemoryId;
+    let replacementMemoryId;
+    if (decision.action === "add") {
+      const memory = this.validateDecisionMemory({
+        ...decision.memory,
+        updatedAt: appliedAt
+      });
+      this.memories.set(memory.id, memory);
+      await appendJsonl(this.pathFor("memories"), memory);
+      memoryId = memory.id;
+    } else if (decision.action === "update") {
+      const existing = this.activeMemory(decision.targetMemoryId);
+      const updated = this.validateDecisionMemory(applyPatchToMemory(existing, decision.patch, appliedAt));
+      if (updated.id !== existing.id) {
+        const tombstone = this.validateDecisionMemory({
+          ...existing,
+          updatedAt: appliedAt,
+          metadata: {
+            ...existing.metadata,
+            deleted: true,
+            deleteReason: decision.reason,
+            updateReplacementId: updated.id
+          }
+        });
+        this.memories.set(tombstone.id, tombstone);
+        await appendJsonl(this.pathFor("memories"), tombstone);
+      }
+      this.memories.set(updated.id, updated);
+      await appendJsonl(this.pathFor("memories"), updated);
+      memoryId = updated.id;
+      targetMemoryId = existing.id;
+    } else if (decision.action === "supersede") {
+      const oldMemory = this.activeMemory(decision.oldMemoryId);
+      const replacement = this.validateDecisionMemory({
+        ...decision.replacement,
+        updatedAt: appliedAt,
+        supersedes: Array.from(new Set([...decision.replacement.supersedes ?? [], oldMemory.id]))
+      });
+      const superseded = this.validateDecisionMemory({
+        ...oldMemory,
+        updatedAt: appliedAt,
+        supersededBy: replacement.id,
+        metadata: {
+          ...oldMemory.metadata,
+          supersedeReason: decision.reason
+        }
+      });
+      this.memories.set(superseded.id, superseded);
+      this.memories.set(replacement.id, replacement);
+      await appendJsonl(this.pathFor("memories"), superseded);
+      await appendJsonl(this.pathFor("memories"), replacement);
+      oldMemoryId = oldMemory.id;
+      replacementMemoryId = replacement.id;
+      memoryId = replacement.id;
+    }
+    const proposalStatus = decision.action === "reject" ? "rejected" : "applied";
+    const reviewedProposal = markProposalReviewed(proposal, decision, proposalStatus, appliedAt, { memoryId, targetMemoryId, oldMemoryId, replacementMemoryId });
+    this.proposals.set(reviewedProposal.id, reviewedProposal);
+    await appendJsonl(this.pathFor("proposals"), reviewedProposal);
+    const change = {
+      action: decision.action,
+      proposalId: decision.proposalId,
+      proposalStatus,
+      appliedAt,
+      memoryId,
+      targetMemoryId,
+      oldMemoryId,
+      replacementMemoryId,
+      reason: curatorDecisionReason(decision)
+    };
+    await this.audit("curator_decision", decision.proposalId, change.reason, buildCuratorDecisionEvent(change, proposal));
+    return change;
+  }
   async compact() {
     await this.initialize();
     await writeJsonlAtomic(this.pathFor("memories"), Array.from(this.memories.values()));
     await this.audit("compact", "memories");
   }
-  async audit(operation, targetId, reason) {
+  async audit(operation, targetId, reason, eventJson) {
     const event = {
       id: randomUUID3(),
       operation,
       targetId,
       reason,
+      eventJson,
       timestamp: new Date().toISOString()
     };
     await appendJsonl(this.pathFor("audit"), event);
+  }
+  activeMemory(memoryId) {
+    const memory = this.memories.get(memoryId);
+    if (!memory) {
+      throw new MemoryValidationError("target memory was not found");
+    }
+    if (memory.metadata.deleted === true) {
+      throw new MemoryValidationError("target memory is deleted");
+    }
+    if (memory.supersededBy) {
+      throw new MemoryValidationError("target memory is superseded");
+    }
+    return memory;
+  }
+  validateDecisionMemory(record3) {
+    return validateMemoryRecordRules(record3, {
+      rejectDurableSecrets: this.config.redaction.rejectDurableSecrets
+    });
   }
 }
 function validateLoadedMemories(values, config3) {
@@ -45994,6 +46231,7 @@ async function writeJsonlAtomic(filePath, values) {
 var init_local_jsonl_provider = __esm(() => {
   init_utils2();
   init_config3();
+  init_curator_decision_helpers();
   init_errors6();
   init_schema2();
   init_scoring();
@@ -46396,6 +46634,33 @@ class SQLiteMemoryProvider {
     proposals.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
     return proposals.slice(0, filter.limit ?? proposals.length);
   }
+  async applyCuratorDecision(decision) {
+    await this.initialize();
+    const db = this.requireDb();
+    const apply = db.transaction(() => {
+      const appliedAt = new Date().toISOString();
+      const proposal = this.readPendingProposal(decision.proposalId);
+      validateDecisionMatchesProposal(decision, proposal);
+      const result2 = this.applyDecisionToStorage(decision, proposal, appliedAt);
+      this.writeProposal(result2.proposal);
+      const eventId = randomUUID4();
+      const eventJson = JSON.stringify(buildCuratorDecisionEvent(result2.change, proposal));
+      this.insertEvent("curator_decision", decision.proposalId, result2.change.reason, eventJson, eventId);
+      return {
+        ...result2,
+        change: { ...result2.change, eventId }
+      };
+    });
+    const result = apply();
+    this.proposals.set(result.proposal.id, result.proposal);
+    for (const id of result.removeMemoryIds) {
+      this.memories.delete(id);
+    }
+    for (const memory of result.memories) {
+      this.memories.set(memory.id, memory);
+    }
+    return result.change;
+  }
   close() {
     if (!this.db)
       return;
@@ -46523,6 +46788,125 @@ class SQLiteMemoryProvider {
       JSON.stringify(proposal)
     ]);
   }
+  applyDecisionToStorage(decision, proposal, appliedAt) {
+    const memories = [];
+    const removeMemoryIds = [];
+    let memoryId;
+    let targetMemoryId;
+    let oldMemoryId;
+    let replacementMemoryId;
+    if (decision.action === "add") {
+      const memory = this.validateDecisionMemory({
+        ...decision.memory,
+        updatedAt: appliedAt
+      });
+      this.writeMemory(memory);
+      memories.push(memory);
+      memoryId = memory.id;
+    } else if (decision.action === "update") {
+      const existing = this.readActiveMemory(decision.targetMemoryId);
+      const updated = this.validateDecisionMemory(applyPatchToMemory(existing, decision.patch, appliedAt));
+      if (updated.id !== existing.id) {
+        const tombstone = this.validateDecisionMemory({
+          ...existing,
+          updatedAt: appliedAt,
+          metadata: {
+            ...existing.metadata,
+            deleted: true,
+            deleteReason: decision.reason,
+            updateReplacementId: updated.id
+          }
+        });
+        this.writeMemory(tombstone);
+        memories.push(tombstone);
+      }
+      this.writeMemory(updated);
+      memories.push(updated);
+      memoryId = updated.id;
+      targetMemoryId = existing.id;
+    } else if (decision.action === "supersede") {
+      const oldMemory = this.readActiveMemory(decision.oldMemoryId);
+      const replacement = this.validateDecisionMemory({
+        ...decision.replacement,
+        updatedAt: appliedAt,
+        supersedes: Array.from(new Set([...decision.replacement.supersedes ?? [], oldMemory.id]))
+      });
+      const superseded = this.validateDecisionMemory({
+        ...oldMemory,
+        updatedAt: appliedAt,
+        supersededBy: replacement.id,
+        metadata: {
+          ...oldMemory.metadata,
+          supersedeReason: decision.reason
+        }
+      });
+      this.writeMemory(superseded);
+      this.writeMemory(replacement);
+      memories.push(superseded, replacement);
+      oldMemoryId = oldMemory.id;
+      replacementMemoryId = replacement.id;
+      memoryId = replacement.id;
+    }
+    const proposalStatus = decision.action === "reject" ? "rejected" : "applied";
+    const reviewedProposal = markProposalReviewed(proposal, decision, proposalStatus, appliedAt, {
+      memoryId,
+      targetMemoryId,
+      oldMemoryId,
+      replacementMemoryId
+    });
+    const change = {
+      action: decision.action,
+      proposalId: decision.proposalId,
+      proposalStatus,
+      appliedAt,
+      memoryId,
+      targetMemoryId,
+      oldMemoryId,
+      replacementMemoryId,
+      reason: curatorDecisionReason(decision)
+    };
+    return {
+      change,
+      proposal: reviewedProposal,
+      memories,
+      removeMemoryIds
+    };
+  }
+  readPendingProposal(proposalId) {
+    const row = this.requireDb().query("SELECT id, proposal_json FROM memory_proposals WHERE id = ? LIMIT 1").get(proposalId);
+    if (!row) {
+      throw new MemoryValidationError("memory proposal was not found");
+    }
+    const proposal = validateMemoryProposal(JSON.parse(row.proposal_json));
+    if (proposal.status !== "pending") {
+      throw new MemoryValidationError("memory proposal is not pending");
+    }
+    if (proposal.proposedRecord) {
+      validateMemoryRecordRules(proposal.proposedRecord, {
+        rejectDurableSecrets: this.config.redaction.rejectDurableSecrets
+      });
+    }
+    return proposal;
+  }
+  readActiveMemory(memoryId) {
+    const row = this.requireDb().query("SELECT id, record_json FROM memory_items WHERE id = ? LIMIT 1").get(memoryId);
+    if (!row) {
+      throw new MemoryValidationError("target memory was not found");
+    }
+    const memory = this.validateDecisionMemory(JSON.parse(row.record_json));
+    if (memory.metadata.deleted === true) {
+      throw new MemoryValidationError("target memory is deleted");
+    }
+    if (memory.supersededBy) {
+      throw new MemoryValidationError("target memory is superseded");
+    }
+    return memory;
+  }
+  validateDecisionMemory(record3) {
+    return validateMemoryRecordRules(record3, {
+      rejectDurableSecrets: this.config.redaction.rejectDurableSecrets
+    });
+  }
   async migrateLegacyJsonlIfNeeded() {
     if (this.hasMigration(LEGACY_JSONL_MIGRATION_NAME))
       return;
@@ -46564,7 +46948,7 @@ class SQLiteMemoryProvider {
   async event(operation, targetId, reason) {
     this.insertEvent(operation, targetId, reason);
   }
-  insertEvent(operation, targetId, reason) {
+  insertEvent(operation, targetId, reason, eventJson, id = randomUUID4()) {
     this.requireDb().run(`INSERT INTO memory_events (
 				id,
 				operation,
@@ -46573,12 +46957,12 @@ class SQLiteMemoryProvider {
 				timestamp,
 				event_json
 			) VALUES (?, ?, ?, ?, ?, ?)`, [
-      randomUUID4(),
+      id,
       operation,
       targetId,
       reason ?? null,
       new Date().toISOString(),
-      reason ? JSON.stringify({ reason }) : null
+      eventJson ?? (reason ? JSON.stringify({ reason }) : null)
     ]);
   }
   requireDb() {
@@ -46594,6 +46978,7 @@ var _DatabaseCtor2 = null, MIGRATIONS2;
 var init_sqlite_provider = __esm(() => {
   init_utils2();
   init_config3();
+  init_curator_decision_helpers();
   init_errors6();
   init_jsonl_migration();
   init_schema2();
@@ -46669,7 +47054,7 @@ var init_gateway = __esm(() => {
 });
 
 // src/agents/agent-output-schema.ts
-var AgentMemoryProposalSchema, AgentOutputMemorySchema;
+var AgentMemoryProposalSchema, AgentOutputMemorySchema, CuratorOutputMemoryDecisionSchema;
 var init_agent_output_schema = __esm(() => {
   init_zod();
   init_schema2();
@@ -46691,6 +47076,9 @@ var init_agent_output_schema = __esm(() => {
   }).strict();
   AgentOutputMemorySchema = exports_external.object({
     memoryProposals: exports_external.array(AgentMemoryProposalSchema).max(20).optional()
+  }).passthrough();
+  CuratorOutputMemoryDecisionSchema = exports_external.object({
+    curatorMemoryDecisions: exports_external.array(CuratorMemoryDecisionSchema).max(20).optional()
   }).passthrough();
 });
 

--- a/dist/memory/curator-decision-helpers.d.ts
+++ b/dist/memory/curator-decision-helpers.d.ts
@@ -1,0 +1,14 @@
+import type { AppliedMemoryChange, MemoryPatch, MemoryProposal, MemoryRecord, ResolvedCuratorMemoryDecision } from './types';
+export declare function validateDecisionMatchesProposal(decision: ResolvedCuratorMemoryDecision, proposal: MemoryProposal): void;
+export declare function applyPatchToMemory(existing: MemoryRecord, patch: MemoryPatch, updatedAt: string): MemoryRecord;
+export declare function markProposalReviewed(proposal: MemoryProposal, decision: ResolvedCuratorMemoryDecision, status: MemoryProposal['status'], reviewedAt: string, ids: {
+    memoryId?: string;
+    targetMemoryId?: string;
+    oldMemoryId?: string;
+    replacementMemoryId?: string;
+}): MemoryProposal;
+export declare function curatorDecisionReason(decision: ResolvedCuratorMemoryDecision): string | undefined;
+export declare function buildCuratorDecisionEvent(change: AppliedMemoryChange, proposal: MemoryProposal): AppliedMemoryChange & {
+    proposalOperation: MemoryProposal['operation'];
+};
+export declare function normalizeTags(tags: string[]): string[];

--- a/dist/memory/gateway.d.ts
+++ b/dist/memory/gateway.d.ts
@@ -1,6 +1,6 @@
 import { type MemoryConfig } from './config';
 import type { MemoryProposalStore, MemoryProvider } from './provider';
-import type { MemoryContext, MemoryKind, MemoryProposal, MemoryRecord, MemoryScopeRef, MemorySource, RecallBundle, RecallMode } from './types';
+import type { AppliedMemoryChange, CuratorMemoryDecision, MemoryContext, MemoryKind, MemoryProposal, MemoryRecord, MemoryScopeRef, MemorySource, RecallBundle, RecallMode } from './types';
 export interface MemoryGatewayOptions {
     config?: Partial<MemoryConfig>;
     provider?: MemoryProvider & Partial<MemoryProposalStore>;
@@ -39,6 +39,7 @@ export declare class MemoryGateway {
     recall(input: RecallMemoryInput): Promise<RecallBundle>;
     propose(input: ProposeMemoryInput): Promise<MemoryProposal>;
     upsertCurated(record: MemoryRecord): Promise<MemoryRecord>;
+    applyCuratorDecision(decision: CuratorMemoryDecision): Promise<AppliedMemoryChange>;
     createRecord(input: {
         kind: MemoryKind;
         text: string;
@@ -50,6 +51,9 @@ export declare class MemoryGateway {
         tags?: string[];
         metadata?: Record<string, unknown>;
     }): MemoryRecord;
+    private resolveCuratorDecision;
+    private createRecordFromNew;
+    private resolveRecordScope;
     private assertEnabled;
 }
 export declare function createMemoryGateway(context: MemoryContext, options?: MemoryGatewayOptions): MemoryGateway;

--- a/dist/memory/index.d.ts
+++ b/dist/memory/index.d.ts
@@ -12,6 +12,6 @@ export { buildMemoryRecallPlan, type MemoryRecallPlan, type MemoryRecallPlannerI
 export { findSecrets, redactSecrets } from './redaction';
 export { MEMORY_RECALL_PROFILES, type MemoryRecallProfile, normalizeMemoryAgentRole, resolveMemoryRecallProfile, } from './role-profiles';
 export { appendMemoryRunLog, sanitizeRunId } from './run-log';
-export { computeMemoryContentHash, createBundleId, createMemoryId, createProposalId, isExpired, normalizeMemoryText, validateMemoryProposal, validateMemoryRecordRules, } from './schema';
+export { computeMemoryContentHash, createBundleId, createMemoryId, createProposalId, isExpired, normalizeMemoryText, validateCuratorMemoryDecision, validateMemoryProposal, validateMemoryRecordRules, } from './schema';
 export { SQLiteMemoryProvider } from './sqlite-provider';
-export type { MemoryContext, MemoryKind, MemoryListFilter, MemoryProposal, MemoryRecord, MemoryScopeRef, MemoryScopeType, RecallBundle, RecallInjectionSkipReason, RecallMode, RecallRequest, RecallResultItem, } from './types';
+export type { AppliedMemoryChange, CuratorMemoryDecision, MemoryContext, MemoryKind, MemoryListFilter, MemoryPatch, MemoryProposal, MemoryRecord, MemoryScopeRef, MemoryScopeType, NewMemoryRecord, RecallBundle, RecallInjectionSkipReason, RecallMode, RecallRequest, RecallResultItem, ResolvedCuratorMemoryDecision, } from './types';

--- a/dist/memory/injector.d.ts
+++ b/dist/memory/injector.d.ts
@@ -14,7 +14,7 @@ export interface MemoryLifecycleHookOptions {
         runId?: string;
     }, options: {
         config?: Partial<MemoryConfig>;
-    }) => Pick<MemoryGateway, 'isEnabled' | 'deriveAllowedScopes' | 'recall' | 'propose'>;
+    }) => Pick<MemoryGateway, 'isEnabled' | 'deriveAllowedScopes' | 'recall' | 'propose'> & Partial<Pick<MemoryGateway, 'applyCuratorDecision' | 'dispose'>>;
     appendRunLog?: typeof appendMemoryRunLog;
 }
 export interface MemoryLifecycleHooks {

--- a/dist/memory/local-jsonl-provider.d.ts
+++ b/dist/memory/local-jsonl-provider.d.ts
@@ -1,7 +1,7 @@
 import { type MemoryConfig } from './config';
 import type { MemoryProposalStore, MemoryProvider, MemoryRecallUsageEvent } from './provider';
 import type { RecallScoringDiagnostics } from './scoring';
-import type { MemoryListFilter, MemoryProposal, MemoryRecord, RecallRequest, RecallResultItem } from './types';
+import type { AppliedMemoryChange, MemoryListFilter, MemoryProposal, MemoryRecord, RecallRequest, RecallResultItem, ResolvedCuratorMemoryDecision } from './types';
 export declare class LocalJsonlMemoryProvider implements MemoryProvider, MemoryProposalStore {
     readonly name = "local-jsonl";
     private readonly rootDirectory;
@@ -27,6 +27,9 @@ export declare class LocalJsonlMemoryProvider implements MemoryProvider, MemoryP
         status?: MemoryProposal['status'];
         limit?: number;
     }): Promise<MemoryProposal[]>;
+    applyCuratorDecision(decision: ResolvedCuratorMemoryDecision): Promise<AppliedMemoryChange>;
     compact(): Promise<void>;
     private audit;
+    private activeMemory;
+    private validateDecisionMemory;
 }

--- a/dist/memory/provider.d.ts
+++ b/dist/memory/provider.d.ts
@@ -1,5 +1,5 @@
 import type { RecallScoringDiagnostics } from './scoring';
-import type { MemoryListFilter, MemoryProposal, MemoryRecord, RecallRequest, RecallResultItem } from './types';
+import type { AppliedMemoryChange, MemoryListFilter, MemoryProposal, MemoryRecord, RecallRequest, RecallResultItem, ResolvedCuratorMemoryDecision } from './types';
 export interface MemoryRecallResult {
     items: RecallResultItem[];
     diagnostics?: RecallScoringDiagnostics;
@@ -34,4 +34,5 @@ export interface MemoryProposalStore {
         status?: MemoryProposal['status'];
         limit?: number;
     }): Promise<MemoryProposal[]>;
+    applyCuratorDecision?(decision: ResolvedCuratorMemoryDecision): Promise<AppliedMemoryChange>;
 }

--- a/dist/memory/run-log.d.ts
+++ b/dist/memory/run-log.d.ts
@@ -1,4 +1,4 @@
-export type MemoryRunLogEventName = 'recall_requested' | 'recall_returned' | 'prompt_injection_skipped' | 'prompt_injected' | 'proposal_created' | 'proposal_rejected_by_validation';
+export type MemoryRunLogEventName = 'recall_requested' | 'recall_returned' | 'prompt_injection_skipped' | 'prompt_injected' | 'proposal_created' | 'proposal_rejected_by_validation' | 'curator_decision_applied' | 'curator_decision_rejected_by_validation';
 export interface MemoryRunLogEvent {
     event: MemoryRunLogEventName;
     runId: string;

--- a/dist/memory/schema.d.ts
+++ b/dist/memory/schema.d.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { MemoryKind, MemoryProposal, MemoryRecord, MemoryScopeRef } from './types';
+import type { CuratorMemoryDecision, MemoryKind, MemoryPatch, MemoryProposal, MemoryRecord, MemoryScopeRef, NewMemoryRecord } from './types';
 export declare const MemoryScopeTypeSchema: z.ZodEnum<{
     agent: "agent";
     project: "project";
@@ -230,6 +230,9 @@ export declare const MemoryProposalSchema: z.ZodObject<{
     createdAt: z.ZodString;
     metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
 }, z.core.$strict>;
+export declare const NewMemoryRecordSchema: z.ZodType<NewMemoryRecord>;
+export declare const MemoryPatchSchema: z.ZodType<MemoryPatch>;
+export declare const CuratorMemoryDecisionSchema: z.ZodType<CuratorMemoryDecision>;
 export declare function normalizeMemoryText(text: string): string;
 export declare function stableScopeKey(scope: MemoryScopeRef): string;
 export declare function computeMemoryContentHash(recordLike: {
@@ -254,3 +257,4 @@ export declare function validateMemoryRecordRules(record: MemoryRecord, options:
     rejectDurableSecrets: boolean;
 }): MemoryRecord;
 export declare function validateMemoryProposal(proposal: MemoryProposal): MemoryProposal;
+export declare function validateCuratorMemoryDecision(decision: unknown): CuratorMemoryDecision;

--- a/dist/memory/sqlite-provider.d.ts
+++ b/dist/memory/sqlite-provider.d.ts
@@ -2,7 +2,7 @@ import { type MemoryConfig } from './config';
 import { type JsonlMigrationReport } from './jsonl-migration';
 import type { MemoryProposalStore, MemoryProvider, MemoryRecallUsageEvent } from './provider';
 import type { RecallScoringDiagnostics } from './scoring';
-import type { MemoryListFilter, MemoryProposal, MemoryRecord, RecallRequest, RecallResultItem } from './types';
+import type { AppliedMemoryChange, MemoryListFilter, MemoryProposal, MemoryRecord, RecallRequest, RecallResultItem, ResolvedCuratorMemoryDecision } from './types';
 export interface SQLiteJsonlImportResult {
     importedMemories: number;
     importedProposals: number;
@@ -36,6 +36,7 @@ export declare class SQLiteMemoryProvider implements MemoryProvider, MemoryPropo
         status?: MemoryProposal['status'];
         limit?: number;
     }): Promise<MemoryProposal[]>;
+    applyCuratorDecision(decision: ResolvedCuratorMemoryDecision): Promise<AppliedMemoryChange>;
     close(): void;
     importJsonl(): Promise<SQLiteJsonlImportResult>;
     exportJsonl(): Promise<{
@@ -52,6 +53,10 @@ export declare class SQLiteMemoryProvider implements MemoryProvider, MemoryPropo
     private loadProposals;
     private writeMemory;
     private writeProposal;
+    private applyDecisionToStorage;
+    private readPendingProposal;
+    private readActiveMemory;
+    private validateDecisionMemory;
     private migrateLegacyJsonlIfNeeded;
     private importLegacyJsonlRows;
     private event;

--- a/dist/memory/types.d.ts
+++ b/dist/memory/types.d.ts
@@ -56,6 +56,80 @@ export interface MemoryProposal {
     createdAt: string;
     metadata: Record<string, unknown>;
 }
+export interface NewMemoryRecord {
+    scope?: MemoryScopeRef;
+    kind: MemoryKind;
+    text: string;
+    tags?: string[];
+    confidence?: number;
+    stability?: MemoryRecord['stability'];
+    source?: MemorySource;
+    expiresAt?: string;
+    metadata?: Record<string, unknown>;
+}
+export type MemoryPatch = Partial<Pick<NewMemoryRecord, 'scope' | 'kind' | 'text' | 'tags' | 'confidence' | 'stability' | 'source' | 'expiresAt' | 'metadata'>>;
+export type CuratorMemoryDecision = {
+    action: 'add';
+    proposalId: string;
+    memory: NewMemoryRecord;
+} | {
+    action: 'update';
+    proposalId: string;
+    targetMemoryId: string;
+    patch: MemoryPatch;
+    reason: string;
+} | {
+    action: 'supersede';
+    proposalId: string;
+    oldMemoryId: string;
+    replacement: NewMemoryRecord;
+    reason: string;
+} | {
+    action: 'reject';
+    proposalId: string;
+    reason: string;
+} | {
+    action: 'noop';
+    proposalId: string;
+    reason: string;
+};
+export type ResolvedCuratorMemoryDecision = {
+    action: 'add';
+    proposalId: string;
+    memory: MemoryRecord;
+} | {
+    action: 'update';
+    proposalId: string;
+    targetMemoryId: string;
+    patch: MemoryPatch;
+    reason: string;
+} | {
+    action: 'supersede';
+    proposalId: string;
+    oldMemoryId: string;
+    replacement: MemoryRecord;
+    reason: string;
+} | {
+    action: 'reject';
+    proposalId: string;
+    reason: string;
+} | {
+    action: 'noop';
+    proposalId: string;
+    reason: string;
+};
+export interface AppliedMemoryChange {
+    action: CuratorMemoryDecision['action'];
+    proposalId: string;
+    proposalStatus: MemoryProposal['status'];
+    appliedAt: string;
+    eventId?: string;
+    memoryId?: string;
+    targetMemoryId?: string;
+    oldMemoryId?: string;
+    replacementMemoryId?: string;
+    reason?: string;
+}
 export type RecallMode = 'manual' | 'injection' | 'curator' | 'evaluation';
 export type RecallInjectionSkipReason = 'disabled' | 'no_signal' | 'below_threshold' | 'no_results';
 export interface RecallRequest {

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -49,7 +49,7 @@ Enable local memory in `.opencode/opencode-swarm.json`:
 }
 ```
 
-Qdrant, embeddings, and curator approval are separate follow-up features. Recall injection uses the gateway/provider seam, so storage providers do not change agent behavior.
+Qdrant and embeddings are separate follow-up features. Recall injection uses the gateway/provider seam, so storage providers do not change agent behavior.
 
 ## Storage
 
@@ -170,11 +170,15 @@ Normal agents only propose memory:
 }
 ```
 
-The proposal is stored as `pending` in `proposals.jsonl`. It is not durable memory until reviewed by a future curator workflow or another trusted gateway caller.
+The proposal is stored as `pending`. It is not durable memory until reviewed by the curator decision path or another trusted gateway caller.
 
 If proposal text contains a likely secret, Swarm stores the proposal only with the secret redacted and marks it rejected by `auto_policy`.
 
 Agents may also return an optional JSON `memoryProposals` array in Task output. The controller validates those proposals through `MemoryGateway.propose`; invalid proposals are logged and dropped without crashing the run. This path still creates pending proposals only.
+
+Curator agents may return an optional JSON `curatorMemoryDecisions` array in Task output. The controller accepts that key only from curator roles, schema-validates each decision, and applies it through `MemoryGateway.applyCuratorDecision`. Supported decisions are `add`, `update`, `supersede`, `reject`, and `noop`.
+
+In SQLite, decision application is transactional: Swarm loads the pending proposal, validates the decision and resulting memory record, applies the memory change, updates proposal status, and appends a `curator_decision` event in one transaction. Superseded memories are marked with `supersededBy` and stop appearing in recall.
 
 ## Secret Handling
 

--- a/docs/releases/pending/curator-memory-decisions.md
+++ b/docs/releases/pending/curator-memory-decisions.md
@@ -1,0 +1,3 @@
+### Curator-approved memory decisions
+
+Pending Swarm memory proposals can now be applied through a schema-validated curator decision path. Normal agents still only create pending proposals; curator decisions are applied by the gateway/provider, update proposal status durably, log each decision event, and atomically mutate SQLite memory rows for add, update, supersede, reject, and noop decisions.

--- a/src/agents/agent-output-schema.ts
+++ b/src/agents/agent-output-schema.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
-import type { ProposeMemoryInput } from '../memory/gateway';
-import { MemoryKindSchema } from '../memory/schema';
+import type { CuratorMemoryDecision, ProposeMemoryInput } from '../memory';
+import {
+	CuratorMemoryDecisionSchema,
+	MemoryKindSchema,
+} from '../memory/schema';
 
 const AgentMemoryProposalSchema = z
 	.object({
@@ -27,8 +30,22 @@ export const AgentOutputMemorySchema = z
 	})
 	.passthrough();
 
+export const CuratorOutputMemoryDecisionSchema = z
+	.object({
+		curatorMemoryDecisions: z
+			.array(CuratorMemoryDecisionSchema)
+			.max(20)
+			.optional(),
+	})
+	.passthrough();
+
 export interface ExtractedAgentMemoryProposals {
 	proposals: ProposeMemoryInput[];
+	error?: string;
+}
+
+export interface ExtractedCuratorMemoryDecisions {
+	decisions: CuratorMemoryDecision[];
 	error?: string;
 }
 
@@ -51,6 +68,27 @@ export function extractMemoryProposalsFromAgentOutput(
 		}
 	}
 	return { proposals: [] };
+}
+
+export function extractCuratorMemoryDecisionsFromAgentOutput(
+	outputText: string,
+): ExtractedCuratorMemoryDecisions {
+	const candidates = candidateJsonBlocks(outputText);
+	for (const candidate of candidates) {
+		const parsedJson = parseJsonObject(candidate);
+		if (parsedJson === null) continue;
+		const parsed = CuratorOutputMemoryDecisionSchema.safeParse(parsedJson);
+		if (!parsed.success) {
+			return {
+				decisions: [],
+				error: parsed.error.issues.map((issue) => issue.message).join('; '),
+			};
+		}
+		if (parsed.data.curatorMemoryDecisions) {
+			return { decisions: parsed.data.curatorMemoryDecisions };
+		}
+	}
+	return { decisions: [] };
 }
 
 function candidateJsonBlocks(outputText: string): string[] {

--- a/src/memory/curator-decision-helpers.ts
+++ b/src/memory/curator-decision-helpers.ts
@@ -1,0 +1,148 @@
+import { MemoryValidationError } from './errors';
+import {
+	computeMemoryContentHash,
+	createMemoryId,
+	normalizeMemoryText,
+	validateMemoryProposal,
+} from './schema';
+import type {
+	AppliedMemoryChange,
+	MemoryPatch,
+	MemoryProposal,
+	MemoryRecord,
+	ResolvedCuratorMemoryDecision,
+} from './types';
+
+export function validateDecisionMatchesProposal(
+	decision: ResolvedCuratorMemoryDecision,
+	proposal: MemoryProposal,
+): void {
+	if (
+		(decision.action === 'add' && proposal.operation !== 'add') ||
+		(decision.action === 'update' && proposal.operation !== 'update') ||
+		(decision.action === 'supersede' && proposal.operation !== 'supersede')
+	) {
+		throw new MemoryValidationError(
+			`curator ${decision.action} decision does not match ${proposal.operation} proposal`,
+		);
+	}
+	if (
+		decision.action === 'update' &&
+		proposal.targetMemoryId &&
+		proposal.targetMemoryId !== decision.targetMemoryId
+	) {
+		throw new MemoryValidationError(
+			'curator update decision target does not match proposal target',
+		);
+	}
+	if (
+		decision.action === 'supersede' &&
+		proposal.targetMemoryId &&
+		proposal.targetMemoryId !== decision.oldMemoryId
+	) {
+		throw new MemoryValidationError(
+			'curator supersede decision target does not match proposal target',
+		);
+	}
+}
+
+export function applyPatchToMemory(
+	existing: MemoryRecord,
+	patch: MemoryPatch,
+	updatedAt: string,
+): MemoryRecord {
+	const base = {
+		scope: patch.scope ?? existing.scope,
+		kind: patch.kind ?? existing.kind,
+		text:
+			patch.text === undefined
+				? existing.text
+				: normalizeMemoryText(patch.text),
+	};
+	const tags =
+		patch.tags === undefined ? existing.tags : normalizeTags(patch.tags);
+	return {
+		...existing,
+		...patch,
+		...base,
+		id: createMemoryId(base),
+		tags,
+		updatedAt,
+		contentHash: computeMemoryContentHash(base),
+		metadata:
+			patch.metadata === undefined
+				? existing.metadata
+				: { ...existing.metadata, ...patch.metadata },
+	};
+}
+
+export function markProposalReviewed(
+	proposal: MemoryProposal,
+	decision: ResolvedCuratorMemoryDecision,
+	status: MemoryProposal['status'],
+	reviewedAt: string,
+	ids: {
+		memoryId?: string;
+		targetMemoryId?: string;
+		oldMemoryId?: string;
+		replacementMemoryId?: string;
+	},
+): MemoryProposal {
+	const reason = curatorDecisionReason(decision);
+	return validateMemoryProposal({
+		...proposal,
+		status,
+		reviewer: 'curator_agent',
+		reviewedAt,
+		rejectionReason: decision.action === 'reject' ? reason : undefined,
+		metadata: {
+			...proposal.metadata,
+			curatorDecision: {
+				action: decision.action,
+				reason,
+				...ids,
+				appliedAt: reviewedAt,
+			},
+		},
+	});
+}
+
+export function curatorDecisionReason(
+	decision: ResolvedCuratorMemoryDecision,
+): string | undefined {
+	switch (decision.action) {
+		case 'add':
+			return undefined;
+		case 'update':
+		case 'supersede':
+		case 'reject':
+		case 'noop':
+			return decision.reason;
+	}
+}
+
+export function buildCuratorDecisionEvent(
+	change: AppliedMemoryChange,
+	proposal: MemoryProposal,
+): AppliedMemoryChange & { proposalOperation: MemoryProposal['operation'] } {
+	return {
+		...change,
+		proposalOperation: proposal.operation,
+	};
+}
+
+export function normalizeTags(tags: string[]): string[] {
+	return Array.from(
+		new Set(
+			tags
+				.map((tag) =>
+					tag
+						.toLowerCase()
+						.replace(/[^\w-]/g, '-')
+						.replace(/-+/g, '-')
+						.replace(/^-|-$/g, ''),
+				)
+				.filter(Boolean),
+		),
+	).slice(0, 32);
+}

--- a/src/memory/gateway.ts
+++ b/src/memory/gateway.ts
@@ -17,17 +17,22 @@ import {
 	createMemoryId,
 	createProposalId,
 	normalizeMemoryText,
+	validateCuratorMemoryDecision,
 	validateMemoryRecordRules,
 } from './schema';
 import type { RecallScoringDiagnostics } from './scoring';
 import { SQLiteMemoryProvider } from './sqlite-provider';
 import type {
+	AppliedMemoryChange,
+	CuratorMemoryDecision,
 	MemoryContext,
 	MemoryKind,
+	MemoryPatch,
 	MemoryProposal,
 	MemoryRecord,
 	MemoryScopeRef,
 	MemorySource,
+	NewMemoryRecord,
 	RecallBundle,
 	RecallInjectionSkipReason,
 	RecallMode,
@@ -319,6 +324,20 @@ export class MemoryGateway {
 		return this.provider.upsert(parsed);
 	}
 
+	async applyCuratorDecision(
+		decision: CuratorMemoryDecision,
+	): Promise<AppliedMemoryChange> {
+		this.assertEnabled();
+		if (!this.provider.applyCuratorDecision) {
+			throw new MemoryValidationError(
+				'memory provider does not support curator decisions',
+			);
+		}
+		const parsed = validateCuratorMemoryDecision(decision);
+		const resolved = this.resolveCuratorDecision(parsed);
+		return this.provider.applyCuratorDecision(resolved);
+	}
+
 	createRecord(input: {
 		kind: MemoryKind;
 		text: string;
@@ -332,7 +351,7 @@ export class MemoryGateway {
 	}): MemoryRecord {
 		const now = this.now().toISOString();
 		const text = normalizeMemoryText(input.text);
-		const scope = input.scope ?? this.deriveAllowedScopes()[1];
+		const scope = this.resolveRecordScope(input.scope);
 		const kind = input.kind;
 		const stability =
 			input.stability ?? (kind === 'scratch' ? 'ephemeral' : 'durable');
@@ -359,6 +378,85 @@ export class MemoryGateway {
 			metadata: input.metadata ?? {},
 		};
 		return record;
+	}
+
+	private resolveCuratorDecision(decision: CuratorMemoryDecision) {
+		switch (decision.action) {
+			case 'add':
+				return {
+					action: 'add' as const,
+					proposalId: decision.proposalId,
+					memory: this.createRecordFromNew(decision.memory),
+				};
+			case 'supersede':
+				return {
+					action: 'supersede' as const,
+					proposalId: decision.proposalId,
+					oldMemoryId: decision.oldMemoryId,
+					replacement: this.createRecordFromNew(decision.replacement),
+					reason: normalizeMemoryText(decision.reason),
+				};
+			case 'update': {
+				const patch = normalizeMemoryPatch(decision.patch);
+				if (patch.scope) {
+					patch.scope = this.resolveRecordScope(patch.scope);
+				}
+				return {
+					action: 'update' as const,
+					proposalId: decision.proposalId,
+					targetMemoryId: decision.targetMemoryId,
+					patch,
+					reason: normalizeMemoryText(decision.reason),
+				};
+			}
+			case 'reject':
+			case 'noop':
+				return {
+					action: decision.action,
+					proposalId: decision.proposalId,
+					reason: normalizeMemoryText(decision.reason),
+				};
+		}
+	}
+
+	private createRecordFromNew(input: NewMemoryRecord): MemoryRecord {
+		const record = this.createRecord({
+			kind: input.kind,
+			text: input.text,
+			scope: input.scope,
+			tags: input.tags,
+			confidence: input.confidence,
+			stability: input.stability,
+			source: input.source,
+			metadata: input.metadata,
+		});
+		const next = input.expiresAt
+			? { ...record, expiresAt: input.expiresAt }
+			: record;
+		return validateMemoryRecordRules(next, {
+			rejectDurableSecrets: this.config.redaction.rejectDurableSecrets,
+		});
+	}
+
+	private resolveRecordScope(scope?: MemoryScopeRef): MemoryScopeRef {
+		const allowedScopes = this.deriveAllowedScopes();
+		if (!scope) {
+			// Curator-supplied NewMemoryRecord omits scope by default; bind it to
+			// the repository scope derived from this gateway context.
+			const defaultScope = allowedScopes[1] ?? allowedScopes[0];
+			if (!defaultScope) {
+				throw new MemoryValidationError(
+					'memory scope is not available for this context',
+				);
+			}
+			return defaultScope;
+		}
+		validateRequestedScopes(
+			[scope],
+			allowedScopes,
+			'memory scope is not allowed for this context',
+		);
+		return scope;
 	}
 
 	private assertEnabled(): void {
@@ -433,6 +531,7 @@ function readGitRemoteUrl(directory: string): string | undefined {
 function validateRequestedScopes(
 	requested: MemoryScopeRef[],
 	allowed: MemoryScopeRef[],
+	disallowedMessage = 'recall scope is not allowed for this context',
 ): MemoryScopeRef[] {
 	if (requested.length === 0) {
 		throw new MemoryValidationError('recall scopes must not be empty');
@@ -440,9 +539,7 @@ function validateRequestedScopes(
 	const allowedKeys = new Set(allowed.map(scopeKey));
 	for (const scope of requested) {
 		if (!allowedKeys.has(scopeKey(scope))) {
-			throw new MemoryValidationError(
-				'recall scope is not allowed for this context',
-			);
+			throw new MemoryValidationError(disallowedMessage);
 		}
 	}
 	return requested;
@@ -501,6 +598,15 @@ function normalizeTags(tags: string[]): string[] {
 				.filter(Boolean),
 		),
 	).slice(0, 32);
+}
+
+function normalizeMemoryPatch(patch: MemoryPatch): MemoryPatch {
+	return {
+		...patch,
+		text:
+			patch.text === undefined ? undefined : normalizeMemoryText(patch.text),
+		tags: patch.tags === undefined ? undefined : normalizeTags(patch.tags),
+	};
 }
 
 function inferTags(text: string): string[] {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -55,21 +55,27 @@ export {
 	createProposalId,
 	isExpired,
 	normalizeMemoryText,
+	validateCuratorMemoryDecision,
 	validateMemoryProposal,
 	validateMemoryRecordRules,
 } from './schema';
 export { SQLiteMemoryProvider } from './sqlite-provider';
 export type {
+	AppliedMemoryChange,
+	CuratorMemoryDecision,
 	MemoryContext,
 	MemoryKind,
 	MemoryListFilter,
+	MemoryPatch,
 	MemoryProposal,
 	MemoryRecord,
 	MemoryScopeRef,
 	MemoryScopeType,
+	NewMemoryRecord,
 	RecallBundle,
 	RecallInjectionSkipReason,
 	RecallMode,
 	RecallRequest,
 	RecallResultItem,
+	ResolvedCuratorMemoryDecision,
 } from './types';

--- a/src/memory/injector.ts
+++ b/src/memory/injector.ts
@@ -1,4 +1,7 @@
-import { extractMemoryProposalsFromAgentOutput } from '../agents/agent-output-schema';
+import {
+	extractCuratorMemoryDecisionsFromAgentOutput,
+	extractMemoryProposalsFromAgentOutput,
+} from '../agents/agent-output-schema';
 import { stripKnownSwarmPrefix } from '../config/schema';
 import type { MessageWithParts } from '../hooks/knowledge-types';
 import { normalizeToolName } from '../hooks/normalize-tool-name';
@@ -39,7 +42,8 @@ export interface MemoryLifecycleHookOptions {
 	) => Pick<
 		MemoryGateway,
 		'isEnabled' | 'deriveAllowedScopes' | 'recall' | 'propose'
-	>;
+	> &
+		Partial<Pick<MemoryGateway, 'applyCuratorDecision' | 'dispose'>>;
 	appendRunLog?: typeof appendMemoryRunLog;
 }
 
@@ -124,11 +128,14 @@ async function captureTaskOutputProposals(
 	const outputText = (output as { output?: unknown })?.output;
 	if (
 		typeof outputText !== 'string' ||
-		!outputText.includes('memoryProposals')
+		(!outputText.includes('memoryProposals') &&
+			!outputText.includes('curatorMemoryDecisions'))
 	) {
 		return;
 	}
-	const extracted = extractMemoryProposalsFromAgentOutput(outputText);
+	const extracted = outputText.includes('memoryProposals')
+		? extractMemoryProposalsFromAgentOutput(outputText)
+		: { proposals: [] };
 	if (extracted.error) {
 		await internals.appendRunLog(options.directory, task.sessionID, {
 			event: 'proposal_rejected_by_validation',
@@ -139,7 +146,25 @@ async function captureTaskOutputProposals(
 		});
 		return;
 	}
-	if (extracted.proposals.length === 0) return;
+	const decisionExtraction = outputText.includes('curatorMemoryDecisions')
+		? extractCuratorMemoryDecisionsFromAgentOutput(outputText)
+		: { decisions: [] };
+	if (decisionExtraction.error) {
+		await internals.appendRunLog(options.directory, task.sessionID, {
+			event: 'curator_decision_rejected_by_validation',
+			runId: task.sessionID ?? 'unknown',
+			agentRole: task.agentRole,
+			agentId: task.agentRole,
+			rejectionReason: decisionExtraction.error,
+		});
+		return;
+	}
+	if (
+		extracted.proposals.length === 0 &&
+		decisionExtraction.decisions.length === 0
+	) {
+		return;
+	}
 	const gateway = internals.createGateway(
 		{
 			directory: options.directory,
@@ -150,30 +175,98 @@ async function captureTaskOutputProposals(
 		},
 		{ config: options.config },
 	);
-	if (!gateway.isEnabled()) return;
-	for (const proposalInput of extracted.proposals) {
-		try {
-			const proposal = await gateway.propose(proposalInput);
-			await internals.appendRunLog(options.directory, task.sessionID, {
-				event:
-					proposal.status === 'pending'
-						? 'proposal_created'
-						: 'proposal_rejected_by_validation',
-				runId: task.sessionID ?? 'unknown',
-				agentRole: task.agentRole,
-				agentId: task.agentRole,
-				proposalId: proposal.id,
-				rejectionReason: proposal.rejectionReason,
-			});
-		} catch (err) {
-			await internals.appendRunLog(options.directory, task.sessionID, {
-				event: 'proposal_rejected_by_validation',
-				runId: task.sessionID ?? 'unknown',
-				agentRole: task.agentRole,
-				agentId: task.agentRole,
-				rejectionReason: err instanceof Error ? err.message : String(err),
-			});
+	if (!gateway.isEnabled()) {
+		await gateway.dispose?.();
+		return;
+	}
+	try {
+		for (const proposalInput of extracted.proposals) {
+			try {
+				const proposal = await gateway.propose(proposalInput);
+				await internals.appendRunLog(options.directory, task.sessionID, {
+					event:
+						proposal.status === 'pending'
+							? 'proposal_created'
+							: 'proposal_rejected_by_validation',
+					runId: task.sessionID ?? 'unknown',
+					agentRole: task.agentRole,
+					agentId: task.agentRole,
+					proposalId: proposal.id,
+					rejectionReason: proposal.rejectionReason,
+				});
+			} catch (err) {
+				await internals.appendRunLog(options.directory, task.sessionID, {
+					event: 'proposal_rejected_by_validation',
+					runId: task.sessionID ?? 'unknown',
+					agentRole: task.agentRole,
+					agentId: task.agentRole,
+					rejectionReason: err instanceof Error ? err.message : String(err),
+				});
+			}
 		}
+		if (
+			decisionExtraction.decisions.length > 0 &&
+			!isCuratorAgent(task.agentRole)
+		) {
+			await internals.appendRunLog(options.directory, task.sessionID, {
+				event: 'curator_decision_rejected_by_validation',
+				runId: task.sessionID ?? 'unknown',
+				agentRole: task.agentRole,
+				agentId: task.agentRole,
+				rejectionReason: 'only curator agents may emit curatorMemoryDecisions',
+			});
+			return;
+		}
+		if (decisionExtraction.decisions.length > 0) {
+			const applyCuratorDecisionMethod = gateway.applyCuratorDecision;
+			if (!applyCuratorDecisionMethod) {
+				await internals.appendRunLog(options.directory, task.sessionID, {
+					event: 'curator_decision_rejected_by_validation',
+					runId: task.sessionID ?? 'unknown',
+					agentRole: task.agentRole,
+					agentId: task.agentRole,
+					rejectionReason: 'memory gateway does not support curator decisions',
+				});
+				return;
+			}
+			const applyCuratorDecision = applyCuratorDecisionMethod.bind(gateway);
+			for (const decision of decisionExtraction.decisions) {
+				try {
+					const change = await applyCuratorDecision(decision);
+					await internals.appendRunLog(options.directory, task.sessionID, {
+						event: 'curator_decision_applied',
+						runId: task.sessionID ?? 'unknown',
+						agentRole: task.agentRole,
+						agentId: task.agentRole,
+						proposalId: change.proposalId,
+						memoryIds: [
+							change.memoryId,
+							change.targetMemoryId,
+							change.oldMemoryId,
+							change.replacementMemoryId,
+						].filter((id): id is string => Boolean(id)),
+						rejectionReason: change.reason,
+						metadata: {
+							action: change.action,
+							proposalStatus: change.proposalStatus,
+							eventId: change.eventId,
+						},
+					});
+				} catch (err) {
+					await internals.appendRunLog(options.directory, task.sessionID, {
+						event: 'curator_decision_rejected_by_validation',
+						runId: task.sessionID ?? 'unknown',
+						agentRole: task.agentRole,
+						agentId: task.agentRole,
+						proposalId: decision.proposalId,
+						rejectionReason: err instanceof Error ? err.message : String(err),
+						metadata: { action: decision.action },
+					});
+				}
+			}
+		}
+	} finally {
+		await gateway.dispose?.();
 	}
 }
 
@@ -330,6 +423,14 @@ function parseTaskToolInput(input: unknown): ParsedTaskInput | null {
 		agentRole: stripKnownSwarmPrefix(target),
 		prompt,
 	};
+}
+
+function isCuratorAgent(agentRole: string): boolean {
+	return (
+		agentRole === 'curator' ||
+		agentRole === 'curator_init' ||
+		agentRole === 'curator_phase'
+	);
 }
 
 function messagesContainRecall(messages: unknown[]): boolean {

--- a/src/memory/local-jsonl-provider.ts
+++ b/src/memory/local-jsonl-provider.ts
@@ -10,6 +10,13 @@ import {
 import * as path from 'node:path';
 import { validateSwarmPath } from '../hooks/utils';
 import { DEFAULT_MEMORY_CONFIG, type MemoryConfig } from './config';
+import {
+	applyPatchToMemory,
+	buildCuratorDecisionEvent,
+	curatorDecisionReason,
+	markProposalReviewed,
+	validateDecisionMatchesProposal,
+} from './curator-decision-helpers';
 import { MemoryValidationError } from './errors';
 import type {
 	MemoryProposalStore,
@@ -20,11 +27,13 @@ import { validateMemoryProposal, validateMemoryRecordRules } from './schema';
 import type { RecallScoringDiagnostics } from './scoring';
 import { scopeAllowed, scoreMemoryRecordsWithDiagnostics } from './scoring';
 import type {
+	AppliedMemoryChange,
 	MemoryListFilter,
 	MemoryProposal,
 	MemoryRecord,
 	RecallRequest,
 	RecallResultItem,
+	ResolvedCuratorMemoryDecision,
 } from './types';
 
 type AuditOperation =
@@ -32,6 +41,7 @@ type AuditOperation =
 	| 'delete'
 	| 'proposal'
 	| 'recall'
+	| 'curator_decision'
 	| 'compact'
 	| 'invalid_load';
 
@@ -40,6 +50,7 @@ interface AuditEvent {
 	operation: AuditOperation;
 	targetId: string;
 	reason?: string;
+	eventJson?: unknown;
 	timestamp: string;
 }
 
@@ -246,6 +257,116 @@ export class LocalJsonlMemoryProvider
 		return proposals.slice(0, filter.limit ?? proposals.length);
 	}
 
+	async applyCuratorDecision(
+		decision: ResolvedCuratorMemoryDecision,
+	): Promise<AppliedMemoryChange> {
+		await this.initialize();
+		const appliedAt = new Date().toISOString();
+		const proposal = this.proposals.get(decision.proposalId);
+		if (!proposal) {
+			throw new MemoryValidationError('memory proposal was not found');
+		}
+		if (proposal.status !== 'pending') {
+			throw new MemoryValidationError('memory proposal is not pending');
+		}
+		validateDecisionMatchesProposal(decision, proposal);
+
+		let memoryId: string | undefined;
+		let targetMemoryId: string | undefined;
+		let oldMemoryId: string | undefined;
+		let replacementMemoryId: string | undefined;
+
+		if (decision.action === 'add') {
+			const memory = this.validateDecisionMemory({
+				...decision.memory,
+				updatedAt: appliedAt,
+			});
+			this.memories.set(memory.id, memory);
+			await appendJsonl(this.pathFor('memories'), memory);
+			memoryId = memory.id;
+		} else if (decision.action === 'update') {
+			const existing = this.activeMemory(decision.targetMemoryId);
+			const updated = this.validateDecisionMemory(
+				applyPatchToMemory(existing, decision.patch, appliedAt),
+			);
+			if (updated.id !== existing.id) {
+				// Update replacements are linked through updateReplacementId; the
+				// supersedes graph is reserved for explicit supersede decisions.
+				const tombstone = this.validateDecisionMemory({
+					...existing,
+					updatedAt: appliedAt,
+					metadata: {
+						...existing.metadata,
+						deleted: true,
+						deleteReason: decision.reason,
+						updateReplacementId: updated.id,
+					},
+				});
+				this.memories.set(tombstone.id, tombstone);
+				await appendJsonl(this.pathFor('memories'), tombstone);
+			}
+			this.memories.set(updated.id, updated);
+			await appendJsonl(this.pathFor('memories'), updated);
+			memoryId = updated.id;
+			targetMemoryId = existing.id;
+		} else if (decision.action === 'supersede') {
+			const oldMemory = this.activeMemory(decision.oldMemoryId);
+			const replacement = this.validateDecisionMemory({
+				...decision.replacement,
+				updatedAt: appliedAt,
+				supersedes: Array.from(
+					new Set([...(decision.replacement.supersedes ?? []), oldMemory.id]),
+				),
+			});
+			const superseded = this.validateDecisionMemory({
+				...oldMemory,
+				updatedAt: appliedAt,
+				supersededBy: replacement.id,
+				metadata: {
+					...oldMemory.metadata,
+					supersedeReason: decision.reason,
+				},
+			});
+			this.memories.set(superseded.id, superseded);
+			this.memories.set(replacement.id, replacement);
+			await appendJsonl(this.pathFor('memories'), superseded);
+			await appendJsonl(this.pathFor('memories'), replacement);
+			oldMemoryId = oldMemory.id;
+			replacementMemoryId = replacement.id;
+			memoryId = replacement.id;
+		}
+
+		const proposalStatus =
+			decision.action === 'reject' ? 'rejected' : 'applied';
+		const reviewedProposal = markProposalReviewed(
+			proposal,
+			decision,
+			proposalStatus,
+			appliedAt,
+			{ memoryId, targetMemoryId, oldMemoryId, replacementMemoryId },
+		);
+		this.proposals.set(reviewedProposal.id, reviewedProposal);
+		await appendJsonl(this.pathFor('proposals'), reviewedProposal);
+		const change: AppliedMemoryChange = {
+			action: decision.action,
+			proposalId: decision.proposalId,
+			proposalStatus,
+			appliedAt,
+			memoryId,
+			targetMemoryId,
+			oldMemoryId,
+			replacementMemoryId,
+			reason: curatorDecisionReason(decision),
+		};
+		await this.audit(
+			'curator_decision',
+			decision.proposalId,
+			change.reason,
+			buildCuratorDecisionEvent(change, proposal),
+		);
+		return change;
+	}
+
 	async compact(): Promise<void> {
 		await this.initialize();
 		await writeJsonlAtomic(
@@ -259,15 +380,37 @@ export class LocalJsonlMemoryProvider
 		operation: AuditOperation,
 		targetId: string,
 		reason?: string,
+		eventJson?: unknown,
 	): Promise<void> {
 		const event: AuditEvent = {
 			id: randomUUID(),
 			operation,
 			targetId,
 			reason,
+			eventJson,
 			timestamp: new Date().toISOString(),
 		};
 		await appendJsonl(this.pathFor('audit'), event);
+	}
+
+	private activeMemory(memoryId: string): MemoryRecord {
+		const memory = this.memories.get(memoryId);
+		if (!memory) {
+			throw new MemoryValidationError('target memory was not found');
+		}
+		if (memory.metadata.deleted === true) {
+			throw new MemoryValidationError('target memory is deleted');
+		}
+		if (memory.supersededBy) {
+			throw new MemoryValidationError('target memory is superseded');
+		}
+		return memory;
+	}
+
+	private validateDecisionMemory(record: MemoryRecord): MemoryRecord {
+		return validateMemoryRecordRules(record, {
+			rejectDurableSecrets: this.config.redaction.rejectDurableSecrets,
+		});
 	}
 }
 

--- a/src/memory/provider.ts
+++ b/src/memory/provider.ts
@@ -1,10 +1,12 @@
 import type { RecallScoringDiagnostics } from './scoring';
 import type {
+	AppliedMemoryChange,
 	MemoryListFilter,
 	MemoryProposal,
 	MemoryRecord,
 	RecallRequest,
 	RecallResultItem,
+	ResolvedCuratorMemoryDecision,
 } from './types';
 
 export interface MemoryRecallResult {
@@ -44,4 +46,7 @@ export interface MemoryProposalStore {
 		status?: MemoryProposal['status'];
 		limit?: number;
 	}): Promise<MemoryProposal[]>;
+	applyCuratorDecision?(
+		decision: ResolvedCuratorMemoryDecision,
+	): Promise<AppliedMemoryChange>;
 }

--- a/src/memory/run-log.ts
+++ b/src/memory/run-log.ts
@@ -8,7 +8,9 @@ export type MemoryRunLogEventName =
 	| 'prompt_injection_skipped'
 	| 'prompt_injected'
 	| 'proposal_created'
-	| 'proposal_rejected_by_validation';
+	| 'proposal_rejected_by_validation'
+	| 'curator_decision_applied'
+	| 'curator_decision_rejected_by_validation';
 
 export interface MemoryRunLogEvent {
 	event: MemoryRunLogEventName;

--- a/src/memory/schema.ts
+++ b/src/memory/schema.ts
@@ -4,10 +4,13 @@ import { DURABLE_MEMORY_KINDS, EVIDENCE_REQUIRED_KINDS } from './config';
 import { MemoryValidationError } from './errors';
 import { containsSecret } from './redaction';
 import type {
+	CuratorMemoryDecision,
 	MemoryKind,
+	MemoryPatch,
 	MemoryProposal,
 	MemoryRecord,
 	MemoryScopeRef,
+	NewMemoryRecord,
 } from './types';
 
 export const MemoryScopeTypeSchema = z.enum([
@@ -128,6 +131,84 @@ export const MemoryProposalSchema = z
 		metadata: z.record(z.string(), z.unknown()),
 	})
 	.strict();
+
+export const NewMemoryRecordSchema: z.ZodType<NewMemoryRecord> = z
+	.object({
+		scope: MemoryScopeRefSchema.optional(),
+		kind: MemoryKindSchema,
+		text: z.string().min(1).max(2000),
+		tags: z.array(z.string().min(1).max(64)).max(32).optional(),
+		confidence: z.number().min(0).max(1).optional(),
+		stability: z.enum(['ephemeral', 'session', 'durable']).optional(),
+		source: MemorySourceSchema.optional(),
+		expiresAt: z.string().datetime().optional(),
+		metadata: z.record(z.string(), z.unknown()).optional(),
+	})
+	.strict();
+
+export const MemoryPatchSchema: z.ZodType<MemoryPatch> = z
+	.object({
+		scope: MemoryScopeRefSchema.optional(),
+		kind: MemoryKindSchema.optional(),
+		text: z.string().min(1).max(2000).optional(),
+		tags: z.array(z.string().min(1).max(64)).max(32).optional(),
+		confidence: z.number().min(0).max(1).optional(),
+		stability: z.enum(['ephemeral', 'session', 'durable']).optional(),
+		source: MemorySourceSchema.optional(),
+		expiresAt: z.string().datetime().optional(),
+		metadata: z.record(z.string(), z.unknown()).optional(),
+	})
+	.strict()
+	.refine((patch) => Object.keys(patch).length > 0, {
+		message: 'memory patch must not be empty',
+	});
+
+const ProposalIdSchema = z.string().regex(/^prop_[a-f0-9]{16}$/);
+const MemoryIdSchema = z.string().regex(/^mem_[a-f0-9]{16}$/);
+const CuratorDecisionReasonSchema = z.string().min(1).max(2000);
+
+export const CuratorMemoryDecisionSchema: z.ZodType<CuratorMemoryDecision> =
+	z.discriminatedUnion('action', [
+		z
+			.object({
+				action: z.literal('add'),
+				proposalId: ProposalIdSchema,
+				memory: NewMemoryRecordSchema,
+			})
+			.strict(),
+		z
+			.object({
+				action: z.literal('update'),
+				proposalId: ProposalIdSchema,
+				targetMemoryId: MemoryIdSchema,
+				patch: MemoryPatchSchema,
+				reason: CuratorDecisionReasonSchema,
+			})
+			.strict(),
+		z
+			.object({
+				action: z.literal('supersede'),
+				proposalId: ProposalIdSchema,
+				oldMemoryId: MemoryIdSchema,
+				replacement: NewMemoryRecordSchema,
+				reason: CuratorDecisionReasonSchema,
+			})
+			.strict(),
+		z
+			.object({
+				action: z.literal('reject'),
+				proposalId: ProposalIdSchema,
+				reason: CuratorDecisionReasonSchema,
+			})
+			.strict(),
+		z
+			.object({
+				action: z.literal('noop'),
+				proposalId: ProposalIdSchema,
+				reason: CuratorDecisionReasonSchema,
+			})
+			.strict(),
+	]);
 
 export function normalizeMemoryText(text: string): string {
 	return text.replace(/\s+/g, ' ').trim();
@@ -275,4 +356,10 @@ export function validateMemoryProposal(
 	proposal: MemoryProposal,
 ): MemoryProposal {
 	return MemoryProposalSchema.parse(proposal);
+}
+
+export function validateCuratorMemoryDecision(
+	decision: unknown,
+): CuratorMemoryDecision {
+	return CuratorMemoryDecisionSchema.parse(decision);
 }

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -5,6 +5,13 @@ import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { validateSwarmPath } from '../hooks/utils';
 import { DEFAULT_MEMORY_CONFIG, type MemoryConfig } from './config';
+import {
+	applyPatchToMemory,
+	buildCuratorDecisionEvent,
+	curatorDecisionReason,
+	markProposalReviewed,
+	validateDecisionMatchesProposal,
+} from './curator-decision-helpers';
 import { MemoryValidationError } from './errors';
 import {
 	backupLegacyJsonl,
@@ -24,11 +31,13 @@ import { validateMemoryProposal, validateMemoryRecordRules } from './schema';
 import type { RecallScoringDiagnostics } from './scoring';
 import { scopeAllowed, scoreMemoryRecordsWithDiagnostics } from './scoring';
 import type {
+	AppliedMemoryChange,
 	MemoryListFilter,
 	MemoryProposal,
 	MemoryRecord,
 	RecallRequest,
 	RecallResultItem,
+	ResolvedCuratorMemoryDecision,
 } from './types';
 
 // See src/db/project-db.ts for the portability rationale. The main plugin bundle
@@ -48,6 +57,7 @@ type EventOperation =
 	| 'proposal'
 	| 'recall'
 	| 'migration'
+	| 'curator_decision'
 	| 'invalid_load';
 
 interface Migration {
@@ -114,6 +124,13 @@ interface MemoryItemRow {
 interface ProposalRow {
 	id: string;
 	proposal_json: string;
+}
+
+interface DecisionTransactionResult {
+	change: AppliedMemoryChange;
+	proposal: MemoryProposal;
+	memories: MemoryRecord[];
+	removeMemoryIds: string[];
 }
 
 interface MigrationRow {
@@ -355,6 +372,44 @@ export class SQLiteMemoryProvider
 		return proposals.slice(0, filter.limit ?? proposals.length);
 	}
 
+	async applyCuratorDecision(
+		decision: ResolvedCuratorMemoryDecision,
+	): Promise<AppliedMemoryChange> {
+		await this.initialize();
+		const db = this.requireDb();
+		const apply = db.transaction((): DecisionTransactionResult => {
+			const appliedAt = new Date().toISOString();
+			const proposal = this.readPendingProposal(decision.proposalId);
+			validateDecisionMatchesProposal(decision, proposal);
+			const result = this.applyDecisionToStorage(decision, proposal, appliedAt);
+			this.writeProposal(result.proposal);
+			const eventId = randomUUID();
+			const eventJson = JSON.stringify(
+				buildCuratorDecisionEvent(result.change, proposal),
+			);
+			this.insertEvent(
+				'curator_decision',
+				decision.proposalId,
+				result.change.reason,
+				eventJson,
+				eventId,
+			);
+			return {
+				...result,
+				change: { ...result.change, eventId },
+			};
+		});
+		const result = apply();
+		this.proposals.set(result.proposal.id, result.proposal);
+		for (const id of result.removeMemoryIds) {
+			this.memories.delete(id);
+		}
+		for (const memory of result.memories) {
+			this.memories.set(memory.id, memory);
+		}
+		return result.change;
+	}
+
 	close(): void {
 		if (!this.db) return;
 		this.db.close();
@@ -535,6 +590,158 @@ export class SQLiteMemoryProvider
 		);
 	}
 
+	private applyDecisionToStorage(
+		decision: ResolvedCuratorMemoryDecision,
+		proposal: MemoryProposal,
+		appliedAt: string,
+	): Omit<DecisionTransactionResult, 'change'> & {
+		change: Omit<AppliedMemoryChange, 'eventId'>;
+	} {
+		const memories: MemoryRecord[] = [];
+		const removeMemoryIds: string[] = [];
+		let memoryId: string | undefined;
+		let targetMemoryId: string | undefined;
+		let oldMemoryId: string | undefined;
+		let replacementMemoryId: string | undefined;
+
+		if (decision.action === 'add') {
+			const memory = this.validateDecisionMemory({
+				...decision.memory,
+				updatedAt: appliedAt,
+			});
+			this.writeMemory(memory);
+			memories.push(memory);
+			memoryId = memory.id;
+		} else if (decision.action === 'update') {
+			const existing = this.readActiveMemory(decision.targetMemoryId);
+			const updated = this.validateDecisionMemory(
+				applyPatchToMemory(existing, decision.patch, appliedAt),
+			);
+			if (updated.id !== existing.id) {
+				// Update replacements are linked through updateReplacementId; the
+				// supersedes graph is reserved for explicit supersede decisions.
+				const tombstone = this.validateDecisionMemory({
+					...existing,
+					updatedAt: appliedAt,
+					metadata: {
+						...existing.metadata,
+						deleted: true,
+						deleteReason: decision.reason,
+						updateReplacementId: updated.id,
+					},
+				});
+				this.writeMemory(tombstone);
+				memories.push(tombstone);
+			}
+			this.writeMemory(updated);
+			memories.push(updated);
+			memoryId = updated.id;
+			targetMemoryId = existing.id;
+		} else if (decision.action === 'supersede') {
+			const oldMemory = this.readActiveMemory(decision.oldMemoryId);
+			const replacement = this.validateDecisionMemory({
+				...decision.replacement,
+				updatedAt: appliedAt,
+				supersedes: Array.from(
+					new Set([...(decision.replacement.supersedes ?? []), oldMemory.id]),
+				),
+			});
+			const superseded = this.validateDecisionMemory({
+				...oldMemory,
+				updatedAt: appliedAt,
+				supersededBy: replacement.id,
+				metadata: {
+					...oldMemory.metadata,
+					supersedeReason: decision.reason,
+				},
+			});
+			this.writeMemory(superseded);
+			this.writeMemory(replacement);
+			memories.push(superseded, replacement);
+			oldMemoryId = oldMemory.id;
+			replacementMemoryId = replacement.id;
+			memoryId = replacement.id;
+		}
+
+		const proposalStatus =
+			decision.action === 'reject' ? 'rejected' : 'applied';
+		const reviewedProposal = markProposalReviewed(
+			proposal,
+			decision,
+			proposalStatus,
+			appliedAt,
+			{
+				memoryId,
+				targetMemoryId,
+				oldMemoryId,
+				replacementMemoryId,
+			},
+		);
+		const change: Omit<AppliedMemoryChange, 'eventId'> = {
+			action: decision.action,
+			proposalId: decision.proposalId,
+			proposalStatus,
+			appliedAt,
+			memoryId,
+			targetMemoryId,
+			oldMemoryId,
+			replacementMemoryId,
+			reason: curatorDecisionReason(decision),
+		};
+		return {
+			change,
+			proposal: reviewedProposal,
+			memories,
+			removeMemoryIds,
+		};
+	}
+
+	private readPendingProposal(proposalId: string): MemoryProposal {
+		const row = this.requireDb()
+			.query<ProposalRow, [string]>(
+				'SELECT id, proposal_json FROM memory_proposals WHERE id = ? LIMIT 1',
+			)
+			.get(proposalId);
+		if (!row) {
+			throw new MemoryValidationError('memory proposal was not found');
+		}
+		const proposal = validateMemoryProposal(JSON.parse(row.proposal_json));
+		if (proposal.status !== 'pending') {
+			throw new MemoryValidationError('memory proposal is not pending');
+		}
+		if (proposal.proposedRecord) {
+			validateMemoryRecordRules(proposal.proposedRecord, {
+				rejectDurableSecrets: this.config.redaction.rejectDurableSecrets,
+			});
+		}
+		return proposal;
+	}
+
+	private readActiveMemory(memoryId: string): MemoryRecord {
+		const row = this.requireDb()
+			.query<MemoryItemRow, [string]>(
+				'SELECT id, record_json FROM memory_items WHERE id = ? LIMIT 1',
+			)
+			.get(memoryId);
+		if (!row) {
+			throw new MemoryValidationError('target memory was not found');
+		}
+		const memory = this.validateDecisionMemory(JSON.parse(row.record_json));
+		if (memory.metadata.deleted === true) {
+			throw new MemoryValidationError('target memory is deleted');
+		}
+		if (memory.supersededBy) {
+			throw new MemoryValidationError('target memory is superseded');
+		}
+		return memory;
+	}
+
+	private validateDecisionMemory(record: MemoryRecord): MemoryRecord {
+		return validateMemoryRecordRules(record, {
+			rejectDurableSecrets: this.config.redaction.rejectDurableSecrets,
+		});
+	}
+
 	private async migrateLegacyJsonlIfNeeded(): Promise<void> {
 		if (this.hasMigration(LEGACY_JSONL_MIGRATION_NAME)) return;
 		const backups = await backupLegacyJsonl(this.rootDirectory, this.config);
@@ -593,6 +800,8 @@ export class SQLiteMemoryProvider
 		operation: EventOperation,
 		targetId: string,
 		reason?: string,
+		eventJson?: string,
+		id = randomUUID(),
 	): void {
 		this.requireDb().run(
 			`INSERT INTO memory_events (
@@ -604,12 +813,12 @@ export class SQLiteMemoryProvider
 				event_json
 			) VALUES (?, ?, ?, ?, ?, ?)`,
 			[
-				randomUUID(),
+				id,
 				operation,
 				targetId,
 				reason ?? null,
 				new Date().toISOString(),
-				reason ? JSON.stringify({ reason }) : null,
+				eventJson ?? (reason ? JSON.stringify({ reason }) : null),
 			],
 		);
 	}

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -89,6 +89,84 @@ export interface MemoryProposal {
 	metadata: Record<string, unknown>;
 }
 
+export interface NewMemoryRecord {
+	scope?: MemoryScopeRef;
+	kind: MemoryKind;
+	text: string;
+	tags?: string[];
+	confidence?: number;
+	stability?: MemoryRecord['stability'];
+	source?: MemorySource;
+	expiresAt?: string;
+	metadata?: Record<string, unknown>;
+}
+
+export type MemoryPatch = Partial<
+	Pick<
+		NewMemoryRecord,
+		| 'scope'
+		| 'kind'
+		| 'text'
+		| 'tags'
+		| 'confidence'
+		| 'stability'
+		| 'source'
+		| 'expiresAt'
+		| 'metadata'
+	>
+>;
+
+export type CuratorMemoryDecision =
+	| { action: 'add'; proposalId: string; memory: NewMemoryRecord }
+	| {
+			action: 'update';
+			proposalId: string;
+			targetMemoryId: string;
+			patch: MemoryPatch;
+			reason: string;
+	  }
+	| {
+			action: 'supersede';
+			proposalId: string;
+			oldMemoryId: string;
+			replacement: NewMemoryRecord;
+			reason: string;
+	  }
+	| { action: 'reject'; proposalId: string; reason: string }
+	| { action: 'noop'; proposalId: string; reason: string };
+
+export type ResolvedCuratorMemoryDecision =
+	| { action: 'add'; proposalId: string; memory: MemoryRecord }
+	| {
+			action: 'update';
+			proposalId: string;
+			targetMemoryId: string;
+			patch: MemoryPatch;
+			reason: string;
+	  }
+	| {
+			action: 'supersede';
+			proposalId: string;
+			oldMemoryId: string;
+			replacement: MemoryRecord;
+			reason: string;
+	  }
+	| { action: 'reject'; proposalId: string; reason: string }
+	| { action: 'noop'; proposalId: string; reason: string };
+
+export interface AppliedMemoryChange {
+	action: CuratorMemoryDecision['action'];
+	proposalId: string;
+	proposalStatus: MemoryProposal['status'];
+	appliedAt: string;
+	eventId?: string;
+	memoryId?: string;
+	targetMemoryId?: string;
+	oldMemoryId?: string;
+	replacementMemoryId?: string;
+	reason?: string;
+}
+
 export type RecallMode = 'manual' | 'injection' | 'curator' | 'evaluation';
 export type RecallInjectionSkipReason =
 	| 'disabled'

--- a/tests/unit/memory/gateway.test.ts
+++ b/tests/unit/memory/gateway.test.ts
@@ -193,6 +193,108 @@ describe('MemoryGateway', () => {
 		}
 	});
 
+	test('applyCuratorDecision materializes approved proposals into durable memory', async () => {
+		const gateway = new MemoryGateway(
+			{ directory: tmpDir, sessionID: 'session-a', agentRole: 'curator_phase' },
+			{
+				config: { enabled: true, provider: 'sqlite' },
+				now: () => new Date('2026-05-24T12:00:00.000Z'),
+			},
+		);
+		try {
+			const proposal = await gateway.propose({
+				operation: 'add',
+				kind: 'repo_convention',
+				text: 'Curator-approved memory uses SQLite.',
+				rationale: 'Pending proposal needs review.',
+				evidenceRefs: ['docs/memory.md'],
+			});
+
+			const change = await gateway.applyCuratorDecision({
+				action: 'add',
+				proposalId: proposal.id,
+				memory: {
+					kind: 'repo_convention',
+					text: 'Curator-approved memory uses SQLite.',
+					source: { type: 'file', filePath: 'docs/memory.md' },
+					confidence: 0.95,
+					tags: ['memory', 'sqlite'],
+				},
+			});
+			const recall = await gateway.recall({
+				query: 'curator approved SQLite memory',
+				minScore: 0,
+			});
+
+			expect(change).toMatchObject({
+				action: 'add',
+				proposalId: proposal.id,
+				proposalStatus: 'applied',
+			});
+			expect(recall.items.map((item) => item.record.id)).toEqual([
+				change.memoryId,
+			]);
+		} finally {
+			await gateway.dispose();
+		}
+	});
+
+	test('applyCuratorDecision schema rejects malformed curator output', async () => {
+		const gateway = new MemoryGateway(
+			{ directory: tmpDir, sessionID: 'session-a', agentRole: 'curator_phase' },
+			{ config: { enabled: true, provider: 'sqlite' } },
+		);
+		try {
+			await expect(
+				gateway.applyCuratorDecision({
+					action: 'reject',
+					proposalId: 'not-a-proposal-id',
+					reason: 'Invalid id should fail schema validation.',
+				} as any),
+			).rejects.toThrow();
+		} finally {
+			await gateway.dispose();
+		}
+	});
+
+	test('applyCuratorDecision rejects memory scopes outside the gateway context', async () => {
+		const gateway = new MemoryGateway(
+			{ directory: tmpDir, sessionID: 'session-a', agentRole: 'curator_phase' },
+			{
+				config: { enabled: true, provider: 'sqlite' },
+				now: () => new Date('2026-05-24T12:00:00.000Z'),
+			},
+		);
+		try {
+			const proposal = await gateway.propose({
+				operation: 'add',
+				kind: 'repo_convention',
+				text: 'Curator scope hardening is enforced.',
+				rationale: 'Pending proposal needs review.',
+				evidenceRefs: ['docs/memory.md'],
+			});
+
+			await expect(
+				gateway.applyCuratorDecision({
+					action: 'add',
+					proposalId: proposal.id,
+					memory: {
+						scope: {
+							type: 'repository',
+							repoId: 'different-repository',
+							repoRoot: path.join(tmpDir, '..', 'different-repository'),
+						},
+						kind: 'repo_convention',
+						text: 'Curator scope hardening is enforced.',
+						source: { type: 'file', filePath: 'docs/memory.md' },
+					},
+				}),
+			).rejects.toThrow('memory scope is not allowed');
+		} finally {
+			await gateway.dispose();
+		}
+	});
+
 	test('recall no-ops when provider omits optional usage recording', async () => {
 		const provider: MemoryProvider = {
 			name: 'fake-no-usage-recording',

--- a/tests/unit/memory/provider-contract.test.ts
+++ b/tests/unit/memory/provider-contract.test.ts
@@ -203,8 +203,343 @@ describe('MemoryProvider contract parity', () => {
 					proposal,
 				]);
 			});
+
+			test('applies curator add decisions and durably marks proposals applied', async () => {
+				const root = await providerRoot(providerCase.name);
+				const provider = track(providerCase.create(root));
+				const record = makeRecord('Curator approved this memory.');
+				const proposal = makeProposal(record);
+				await provider.createProposal(proposal);
+
+				const change = await provider.applyCuratorDecision?.({
+					action: 'add',
+					proposalId: proposal.id,
+					memory: record,
+				});
+
+				expect(change).toMatchObject({
+					action: 'add',
+					proposalId: proposal.id,
+					proposalStatus: 'applied',
+					memoryId: record.id,
+				});
+				expect(await provider.list({})).toEqual([
+					expect.objectContaining({ id: record.id, text: record.text }),
+				]);
+				const reloaded = track(providerCase.reopen(root));
+				expect(await reloaded.list({})).toEqual([
+					expect.objectContaining({ id: record.id, text: record.text }),
+				]);
+				expect(await reloaded.listProposals({ status: 'applied' })).toEqual([
+					expect.objectContaining({
+						id: proposal.id,
+						status: 'applied',
+						reviewer: 'curator_agent',
+					}),
+				]);
+			});
+
+			test('applies curator reject decisions without durable memory writes', async () => {
+				const root = await providerRoot(providerCase.name);
+				const provider = track(providerCase.create(root));
+				const proposal = makeProposal(makeRecord('Rejected memory candidate.'));
+				await provider.createProposal(proposal);
+
+				const change = await provider.applyCuratorDecision?.({
+					action: 'reject',
+					proposalId: proposal.id,
+					reason: 'Insufficient evidence.',
+				});
+
+				expect(change).toMatchObject({
+					action: 'reject',
+					proposalId: proposal.id,
+					proposalStatus: 'rejected',
+					reason: 'Insufficient evidence.',
+				});
+				expect(await provider.list({})).toHaveLength(0);
+				expect(await provider.listProposals({ status: 'rejected' })).toEqual([
+					expect.objectContaining({
+						id: proposal.id,
+						status: 'rejected',
+						reviewer: 'curator_agent',
+						rejectionReason: 'Insufficient evidence.',
+					}),
+				]);
+			});
+
+			test('applies curator noop decisions as durable proposal decisions only', async () => {
+				const root = await providerRoot(providerCase.name);
+				const provider = track(providerCase.create(root));
+				const proposal = makeProposal(makeRecord('Noop memory candidate.'));
+				await provider.createProposal(proposal);
+
+				const change = await provider.applyCuratorDecision?.({
+					action: 'noop',
+					proposalId: proposal.id,
+					reason: 'Already captured by existing memory.',
+				});
+
+				expect(change).toMatchObject({
+					action: 'noop',
+					proposalId: proposal.id,
+					proposalStatus: 'applied',
+					reason: 'Already captured by existing memory.',
+				});
+				expect(await provider.list({})).toHaveLength(0);
+				expect(await provider.listProposals({ status: 'applied' })).toEqual([
+					expect.objectContaining({
+						id: proposal.id,
+						status: 'applied',
+						reviewer: 'curator_agent',
+						metadata: expect.objectContaining({
+							curatorDecision: expect.objectContaining({
+								action: 'noop',
+								reason: 'Already captured by existing memory.',
+							}),
+						}),
+					}),
+				]);
+			});
+
+			test('applies curator update decisions with partial patch merging', async () => {
+				const root = await providerRoot(providerCase.name);
+				const provider = track(providerCase.create(root));
+				const existing = {
+					...makeRecord('Keep using bun --smol for memory tests.'),
+					tags: ['testing', 'memory'],
+					metadata: { source: 'original' },
+				};
+				await provider.upsert(existing);
+				const proposal: MemoryProposal = {
+					...makeProposal(existing),
+					operation: 'update',
+					targetMemoryId: existing.id,
+				};
+				await provider.createProposal(proposal);
+
+				const change = await provider.applyCuratorDecision?.({
+					action: 'update',
+					proposalId: proposal.id,
+					targetMemoryId: existing.id,
+					patch: {
+						confidence: 0.72,
+						tags: ['Memory Review', 'testing'],
+						metadata: { reviewed: true },
+					},
+					reason: 'Curator adjusted confidence and tags.',
+				});
+
+				expect(change).toMatchObject({
+					action: 'update',
+					proposalId: proposal.id,
+					proposalStatus: 'applied',
+					memoryId: existing.id,
+					targetMemoryId: existing.id,
+				});
+				const oldAfterUpdate = await provider.get(existing.id);
+				expect(oldAfterUpdate).toMatchObject({
+					id: existing.id,
+					text: existing.text,
+					confidence: 0.72,
+					tags: ['memory-review', 'testing'],
+					metadata: { source: 'original', reviewed: true },
+				});
+			});
+
+			test('content-changing curator updates tombstone the old memory id', async () => {
+				const root = await providerRoot(providerCase.name);
+				const provider = track(providerCase.create(root));
+				const existing = makeRecord('Run the outdated memory command.');
+				await provider.upsert(existing);
+				const proposal: MemoryProposal = {
+					...makeProposal(existing),
+					operation: 'update',
+					targetMemoryId: existing.id,
+				};
+				await provider.createProposal(proposal);
+
+				const change = await provider.applyCuratorDecision?.({
+					action: 'update',
+					proposalId: proposal.id,
+					targetMemoryId: existing.id,
+					patch: {
+						text: 'Run the current memory command.',
+						metadata: { reviewed: true },
+					},
+					reason: 'The command changed.',
+				});
+
+				expect(change?.memoryId).toBeDefined();
+				expect(change?.memoryId).not.toBe(existing.id);
+				const oldAfterUpdate = await provider.get(existing.id);
+				expect(oldAfterUpdate?.id).toBe(existing.id);
+				expect(oldAfterUpdate?.metadata.deleted).toBe(true);
+				expect(oldAfterUpdate?.metadata.deleteReason).toBe(
+					'The command changed.',
+				);
+				expect(oldAfterUpdate?.metadata.updateReplacementId).toBe(
+					change?.memoryId,
+				);
+				const listed = await provider.list({});
+				expect(listed.map((item) => item.id)).toEqual([change?.memoryId]);
+				const recall = await provider.recall({
+					query: 'current memory command',
+					scopes: [existing.scope],
+					maxItems: 5,
+					tokenBudget: 1000,
+					minScore: 0,
+				});
+				expect(recall.map((item) => item.record.id)).toEqual([
+					change?.memoryId,
+				]);
+			});
+
+			test('superseded memories stop appearing in recall and list results', async () => {
+				const root = await providerRoot(providerCase.name);
+				const provider = track(providerCase.create(root));
+				const oldMemory = makeRecord('Use the old memory command.');
+				const replacement = makeRecord('Use the new memory command.');
+				await provider.upsert(oldMemory);
+				const proposal = {
+					...makeProposal(replacement),
+					operation: 'supersede' as const,
+					targetMemoryId: oldMemory.id,
+				};
+				await provider.createProposal(proposal);
+
+				const change = await provider.applyCuratorDecision?.({
+					action: 'supersede',
+					proposalId: proposal.id,
+					oldMemoryId: oldMemory.id,
+					replacement,
+					reason: 'The command changed.',
+				});
+
+				expect(change).toMatchObject({
+					action: 'supersede',
+					oldMemoryId: oldMemory.id,
+					replacementMemoryId: replacement.id,
+					proposalStatus: 'applied',
+				});
+				expect((await provider.get(oldMemory.id))?.supersededBy).toBe(
+					replacement.id,
+				);
+				expect((await provider.list({})).map((item) => item.id)).toEqual([
+					replacement.id,
+				]);
+				const recall = await provider.recall({
+					query: 'memory command',
+					scopes: [oldMemory.scope],
+					maxItems: 5,
+					tokenBudget: 1000,
+					minScore: 0,
+				});
+				expect(recall.map((item) => item.record.id)).toEqual([replacement.id]);
+			});
+
+			test('rejects curator decisions that target a different memory than the proposal', async () => {
+				const root = await providerRoot(providerCase.name);
+				const provider = track(providerCase.create(root));
+				const oldMemory = makeRecord('Original memory target.');
+				const otherMemory = makeRecord('Different memory target.');
+				const replacement = makeRecord('Replacement memory target.');
+				await provider.upsert(oldMemory);
+				await provider.upsert(otherMemory);
+				const proposal = {
+					...makeProposal(replacement),
+					operation: 'supersede' as const,
+					targetMemoryId: oldMemory.id,
+				};
+				await provider.createProposal(proposal);
+
+				await expect(
+					provider.applyCuratorDecision?.({
+						action: 'supersede',
+						proposalId: proposal.id,
+						oldMemoryId: otherMemory.id,
+						replacement,
+						reason: 'Wrong target must be rejected.',
+					}),
+				).rejects.toThrow('target does not match');
+
+				expect(await provider.listProposals({ status: 'pending' })).toEqual([
+					proposal,
+				]);
+				expect(
+					(await provider.get(otherMemory.id))?.supersededBy,
+				).toBeUndefined();
+			});
+
+			test('rejects curator decisions whose action does not match the proposal operation', async () => {
+				const root = await providerRoot(providerCase.name);
+				const provider = track(providerCase.create(root));
+				const existing = makeRecord('Update action mismatch source.');
+				const approved = makeRecord('Action mismatch approved memory.');
+				await provider.upsert(existing);
+				const proposal: MemoryProposal = {
+					...makeProposal(approved),
+					operation: 'update',
+					targetMemoryId: existing.id,
+				};
+				await provider.createProposal(proposal);
+
+				await expect(
+					provider.applyCuratorDecision?.({
+						action: 'add',
+						proposalId: proposal.id,
+						memory: approved,
+					}),
+				).rejects.toThrow('does not match update proposal');
+
+				expect(await provider.listProposals({ status: 'pending' })).toEqual([
+					proposal,
+				]);
+				expect(await provider.get(approved.id)).toBeNull();
+			});
 		});
 	}
+});
+
+describe('LocalJsonlMemoryProvider', () => {
+	test('event-logs curator decisions with the structured provider payload', async () => {
+		const root = await providerRoot('local-jsonl-events');
+		const provider = track(
+			new LocalJsonlMemoryProvider(root, { enabled: true }),
+		);
+		const record = makeRecord('Local JSONL logs curator decisions.');
+		const proposal = makeProposal(record);
+		await provider.createProposal(proposal);
+
+		const change = await provider.applyCuratorDecision({
+			action: 'add',
+			proposalId: proposal.id,
+			memory: record,
+		});
+
+		const auditPath = path.join(root, '.swarm', 'memory', 'audit.jsonl');
+		const events = (await fs.readFile(auditPath, 'utf-8'))
+			.trim()
+			.split('\n')
+			.map((line) => JSON.parse(line));
+		const decisionEvent = events.find(
+			(event) => event.operation === 'curator_decision',
+		);
+		expect(decisionEvent).toMatchObject({
+			targetId: proposal.id,
+			eventJson: {
+				action: 'add',
+				proposalId: proposal.id,
+				proposalOperation: 'add',
+				memoryId: record.id,
+			},
+		});
+		expect(decisionEvent.reason).toBeUndefined();
+		expect(change).toMatchObject({
+			action: 'add',
+			memoryId: record.id,
+		});
+	});
 });
 
 describe('SQLiteMemoryProvider', () => {
@@ -346,6 +681,95 @@ describe('SQLiteMemoryProvider', () => {
 				version: LEGACY_JSONL_MIGRATION_VERSION,
 				name: LEGACY_JSONL_MIGRATION_NAME,
 			});
+		} finally {
+			db.close();
+		}
+	});
+
+	test('event-logs every curator decision in SQLite', async () => {
+		const root = await providerRoot('sqlite-decision-events');
+		const provider = track(
+			new SQLiteMemoryProvider(root, { enabled: true, provider: 'sqlite' }),
+		);
+		const record = makeRecord('SQLite logs curator decisions.');
+		const proposal = makeProposal(record);
+		await provider.createProposal(proposal);
+
+		const change = await provider.applyCuratorDecision({
+			action: 'add',
+			proposalId: proposal.id,
+			memory: record,
+		});
+		provider.close?.();
+
+		const db = new Database(path.join(root, '.swarm', 'memory', 'memory.db'), {
+			readonly: true,
+		});
+		try {
+			const row = db
+				.query<
+					{
+						operation: string;
+						target_id: string;
+						event_json: string;
+					},
+					[]
+				>(
+					'SELECT operation, target_id, event_json FROM memory_events WHERE id = ?',
+				)
+				.get(change.eventId ?? '');
+			expect(row?.operation).toBe('curator_decision');
+			expect(row?.target_id).toBe(proposal.id);
+			expect(JSON.parse(row?.event_json ?? '{}')).toMatchObject({
+				action: 'add',
+				proposalId: proposal.id,
+				proposalOperation: 'add',
+				memoryId: record.id,
+			});
+		} finally {
+			db.close();
+		}
+	});
+
+	test('curator decision application is atomic when validation fails', async () => {
+		const root = await providerRoot('sqlite-decision-atomic');
+		const provider = track(
+			new SQLiteMemoryProvider(root, { enabled: true, provider: 'sqlite' }),
+		);
+		const record = makeRecord(
+			'Invalid approved memory is rejected atomically.',
+		);
+		const proposal = makeProposal(record);
+		await provider.createProposal(proposal);
+
+		await expect(
+			provider.applyCuratorDecision({
+				action: 'add',
+				proposalId: proposal.id,
+				memory: {
+					...record,
+					contentHash:
+						'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+				},
+			}),
+		).rejects.toThrow('contentHash does not match');
+
+		expect(await provider.list({})).toEqual([]);
+		expect(await provider.listProposals({ status: 'pending' })).toEqual([
+			proposal,
+		]);
+		provider.close?.();
+
+		const db = new Database(path.join(root, '.swarm', 'memory', 'memory.db'), {
+			readonly: true,
+		});
+		try {
+			const row = db
+				.query<{ count: number }, []>(
+					"SELECT COUNT(*) as count FROM memory_events WHERE operation = 'curator_decision'",
+				)
+				.get();
+			expect(row?.count).toBe(0);
 		} finally {
 			db.close();
 		}

--- a/tests/unit/memory/recall-injection.test.ts
+++ b/tests/unit/memory/recall-injection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import type {
+	CuratorMemoryDecision,
 	MemoryLifecycleHookOptions,
 	ProposeMemoryInput,
 	RecallMemoryInput,
@@ -82,6 +83,13 @@ function makeHooks(
 	enabled = true,
 	options: {
 		propose?: (input: ProposeMemoryInput) => Promise<MemoryProposal>;
+		applyDecision?: (input: CuratorMemoryDecision) => Promise<{
+			action: CuratorMemoryDecision['action'];
+			proposalId: string;
+			proposalStatus: MemoryProposal['status'];
+			appliedAt: string;
+			memoryId?: string;
+		}>;
 		activeAgent?: string;
 		config?: MemoryLifecycleHookOptions['config'];
 	} = {},
@@ -89,10 +97,12 @@ function makeHooks(
 	hooks: ReturnType<typeof createMemoryLifecycleHooks>;
 	recalls: RecallMemoryInput[];
 	proposals: ProposeMemoryInput[];
+	decisions: CuratorMemoryDecision[];
 	logs: unknown[];
 } {
 	const recalls: RecallMemoryInput[] = [];
 	const proposals: ProposeMemoryInput[] = [];
+	const decisions: CuratorMemoryDecision[] = [];
 	const logs: unknown[] = [];
 	const createGateway: MemoryLifecycleHookOptions['createGateway'] = () => ({
 		isEnabled: () => enabled,
@@ -116,6 +126,18 @@ function makeHooks(
 			};
 			return proposal;
 		},
+		applyCuratorDecision: async (input) => {
+			if (options.applyDecision) return options.applyDecision(input);
+			decisions.push(input);
+			return {
+				action: input.action,
+				proposalId: input.proposalId,
+				proposalStatus: input.action === 'reject' ? 'rejected' : 'applied',
+				appliedAt: '2026-05-24T00:00:00.000Z',
+				memoryId: input.action === 'add' ? 'mem_1111111111111111' : undefined,
+			};
+		},
+		dispose: async () => {},
 	});
 	const hooks = createMemoryLifecycleHooks({
 		directory: 'C:/repo-a',
@@ -126,7 +148,7 @@ function makeHooks(
 			logs.push(event);
 		},
 	});
-	return { hooks, recalls, proposals, logs };
+	return { hooks, recalls, proposals, decisions, logs };
 }
 
 describe('memory recall role profiles', () => {
@@ -492,6 +514,151 @@ describe('memory lifecycle injection', () => {
 				expect.objectContaining({
 					event: 'proposal_created',
 					proposalId: 'prop_1111111111111111',
+				}),
+			]),
+		);
+	});
+
+	test('curator Task output decisions are applied through the gateway', async () => {
+		const { hooks, decisions, logs } = makeHooks(
+			makeBundle(makeRecord('repo_convention', 'unused')),
+		);
+
+		await hooks.toolAfter(
+			{
+				tool: 'task',
+				sessionID: 'session-a',
+				args: { subagent_type: 'curator_phase', prompt: 'TASK: review memory' },
+			},
+			{
+				output: JSON.stringify({
+					curatorMemoryDecisions: [
+						{
+							action: 'add',
+							proposalId: 'prop_1111111111111111',
+							memory: {
+								kind: 'repo_convention',
+								text: 'This repo uses bun.',
+								source: { type: 'file', filePath: 'package.json' },
+							},
+						},
+					],
+				}),
+			},
+		);
+
+		expect(decisions).toHaveLength(1);
+		expect(decisions[0].action).toBe('add');
+		expect(logs).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					event: 'curator_decision_applied',
+					proposalId: 'prop_1111111111111111',
+				}),
+			]),
+		);
+	});
+
+	test('curator decision application preserves the gateway method receiver', async () => {
+		const logs: unknown[] = [];
+		const applied: CuratorMemoryDecision[] = [];
+		const hooks = createMemoryLifecycleHooks({
+			directory: 'C:/repo-a',
+			config: { enabled: true },
+			createGateway: () =>
+				({
+					receiverMarker: true,
+					isEnabled: () => true,
+					deriveAllowedScopes: () => allowedScopes,
+					recall: async () =>
+						makeBundle(makeRecord('repo_convention', 'unused')),
+					propose: async () => {
+						throw new Error('unexpected proposal call');
+					},
+					async applyCuratorDecision(
+						this: { receiverMarker?: boolean },
+						input,
+					) {
+						if (this.receiverMarker !== true) {
+							throw new Error('lost gateway receiver');
+						}
+						applied.push(input);
+						return {
+							action: input.action,
+							proposalId: input.proposalId,
+							proposalStatus: 'applied',
+							appliedAt: '2026-05-24T00:00:00.000Z',
+						};
+					},
+					dispose: async () => {},
+				}) as MemoryLifecycleHookOptions['createGateway'] extends (
+					...args: never[]
+				) => infer T
+					? T
+					: never,
+			appendRunLog: async (_directory, _runId, event) => {
+				logs.push(event);
+			},
+		});
+
+		await hooks.toolAfter(
+			{
+				tool: 'task',
+				sessionID: 'session-a',
+				args: { subagent_type: 'curator_phase', prompt: 'TASK: review memory' },
+			},
+			{
+				output: JSON.stringify({
+					curatorMemoryDecisions: [
+						{
+							action: 'reject',
+							proposalId: 'prop_1111111111111111',
+							reason: 'Not durable enough.',
+						},
+					],
+				}),
+			},
+		);
+
+		expect(applied).toHaveLength(1);
+		expect(logs).not.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ rejectionReason: 'lost gateway receiver' }),
+			]),
+		);
+	});
+
+	test('normal Task agents cannot apply curator memory decisions', async () => {
+		const { hooks, decisions, logs } = makeHooks(
+			makeBundle(makeRecord('repo_convention', 'unused')),
+		);
+
+		await hooks.toolAfter(
+			{
+				tool: 'task',
+				sessionID: 'session-a',
+				args: { subagent_type: 'coder', prompt: 'TASK: implement' },
+			},
+			{
+				output: JSON.stringify({
+					curatorMemoryDecisions: [
+						{
+							action: 'reject',
+							proposalId: 'prop_1111111111111111',
+							reason: 'Not durable enough.',
+						},
+					],
+				}),
+			},
+		);
+
+		expect(decisions).toHaveLength(0);
+		expect(logs).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					event: 'curator_decision_rejected_by_validation',
+					rejectionReason:
+						'only curator agents may emit curatorMemoryDecisions',
 				}),
 			]),
 		);


### PR DESCRIPTION
﻿## Summary
- add curator decision types and schema validation (`add|update|supersede|reject|noop`) plus `MemoryGateway.applyCuratorDecision`
- implement durable decision application in both providers, with SQLite applying proposal load, validation, memory mutation, proposal status update, and `memory_events` write in one transaction
- address final review feedback: export `ResolvedCuratorMemoryDecision`, extract shared decision helpers, standardize local/SQLite curator event payloads, add explicit scope guards, document update replacement lineage, and expand decision-path coverage

## Review feedback closure
- F-001 missing public type export: fixed - `ResolvedCuratorMemoryDecision` is exported from `src/memory/index.ts` and `dist/memory/index.d.ts`
- F-002 duplicated provider helpers: fixed - common proposal/action validation, patching, proposal review metadata, reason handling, tag normalization, and event payload building moved to `src/memory/curator-decision-helpers.ts`
- F-003 provider audit event drift: fixed - local JSONL now writes structured `eventJson` with the same `proposalOperation` payload shape used by SQLite
- F-004 redundant reason guard: fixed - providers now use shared `curatorDecisionReason()` instead of `'reason' in decision`
- F-005 scope hardening: fixed - gateway validates curator-provided record and patch scopes against the current context and defaults omitted scopes to the derived repository scope
- F-006 update lineage semantics: fixed/documented - content-changing updates tombstone the old record with `updateReplacementId`; supersede graph links remain reserved for explicit `supersede` decisions
- Coverage gaps: fixed - added tests for `noop`, same-id `update`, content-changing update tombstones and recall exclusion, action/proposal mismatch, structured local audit payloads, partial patch merge, and disallowed curator scopes; existing SQLite rollback/schema tests remain passing

## Invariant audit
- 1 (plugin init): not touched - no changes under `src/index.ts` init path
- 2 (runtime portability): touched - rebuilt `dist`; verified `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` and bundle portability/node-load/plugin-shape tests
- 3 (subprocesses): not touched - no subprocess/spawn changes in edited source files
- 4 (.swarm containment): touched - provider storage still routes through `validateSwarmPath(...)`; verified by provider contract tests including SQLite path containment
- 5 (plan durability): not touched - no `src/plan/*` or `.swarm/plan-*` changes
- 6 (test_runner safety): not touched - validation used shell `bun --smol test` commands; no broad `test_runner` use
- 7 (test writing): touched - loaded writing-tests skill and added focused `bun:test` coverage without `mock.module`
- 8 (session state): not touched - no global session map/state changes
- 9 (guardrails/retry): not touched - no guardrail/retry logic changes
- 10 (chat/system msg): not touched - no system-message contract changes
- 11 (tool registration): not touched - no new tool exports or `TOOL_NAMES`/agent-map registration changes
- 12 (release/cache): touched - pending release fragment `docs/releases/pending/curator-memory-decisions.md` is present; version-managed files were not hand-edited

## Test plan
- [x] `bun run build`
- [x] `git diff --exit-code -- dist`
- [x] `bun run typecheck`
- [x] `bunx biome check .`
- [x] `bun --smol test tests/unit/memory/provider-contract.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/memory/gateway.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/memory/recall-injection.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/memory/scoring.test.ts tests/unit/memory/schema.test.ts tests/unit/memory/redaction.test.ts tests/unit/memory/prompt-block.test.ts tests/unit/memory/local-jsonl-provider.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/tools/swarm-memory-tools.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-node-load.test.ts tests/unit/build/bundle-plugin-shape.test.ts --timeout 30000`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `git diff --check`
