### PR TITLE
feat(memory): add maintenance observability commands

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.38.0",
+    version: "7.39.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -677,10 +677,10 @@ function $constructor(name, initializer, params) {
   }
   Object.defineProperty(Definition, "name", { value: name });
   function _(def) {
-    var _a2;
+    var _a;
     const inst = params?.Parent ? new Definition : this;
     init(inst, def);
-    (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
+    (_a = inst._zod).deferred ?? (_a.deferred = []);
     for (const fn of inst._zod.deferred) {
       fn();
     }
@@ -702,9 +702,9 @@ function config(newConfig) {
     Object.assign(globalConfig, newConfig);
   return globalConfig;
 }
-var _a, NEVER, $brand, $ZodAsyncError, $ZodEncodeError, globalConfig;
+var NEVER, $brand, $ZodAsyncError, $ZodEncodeError, globalConfig;
 var init_core = __esm(() => {
-  NEVER = /* @__PURE__ */ Object.freeze({
+  NEVER = Object.freeze({
     status: "aborted"
   });
   $brand = Symbol("zod_brand");
@@ -719,8 +719,7 @@ var init_core = __esm(() => {
       this.name = "ZodEncodeError";
     }
   };
-  (_a = globalThis).__zod_globalConfig ?? (_a.__zod_globalConfig = {});
-  globalConfig = globalThis.__zod_globalConfig;
+  globalConfig = {};
 });
 
 // node_modules/zod/v4/core/util.js
@@ -765,7 +764,6 @@ __export(exports_util, {
   floatSafeRemainder: () => floatSafeRemainder,
   finalizeIssue: () => finalizeIssue,
   extend: () => extend,
-  explicitlyAborted: () => explicitlyAborted,
   escapeRegex: () => escapeRegex2,
   esc: () => esc,
   defineLazy: () => defineLazy,
@@ -836,12 +834,19 @@ function cleanRegex(source) {
   return source.slice(start, end);
 }
 function floatSafeRemainder(val, step) {
-  const ratio = val / step;
-  const roundedRatio = Math.round(ratio);
-  const tolerance = Number.EPSILON * Math.max(Math.abs(ratio), 1);
-  if (Math.abs(ratio - roundedRatio) < tolerance)
-    return 0;
-  return ratio - roundedRatio;
+  const valDecCount = (val.toString().split(".")[1] || "").length;
+  const stepString = step.toString();
+  let stepDecCount = (stepString.split(".")[1] || "").length;
+  if (stepDecCount === 0 && /\d?e-\d?/.test(stepString)) {
+    const match = stepString.match(/\d?e-(\d?)/);
+    if (match?.[1]) {
+      stepDecCount = Number.parseInt(match[1]);
+    }
+  }
+  const decCount = valDecCount > stepDecCount ? valDecCount : stepDecCount;
+  const valInt = Number.parseInt(val.toFixed(decCount).replace(".", ""));
+  const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
+  return valInt % stepInt / 10 ** decCount;
 }
 function defineLazy(object, key, getter) {
   let value = undefined;
@@ -940,10 +945,6 @@ function shallowClone(o) {
     return { ...o };
   if (Array.isArray(o))
     return [...o];
-  if (o instanceof Map)
-    return new Map(o);
-  if (o instanceof Set)
-    return new Set(o);
   return o;
 }
 function numKeys(data) {
@@ -1112,9 +1113,6 @@ function safeExtend(schema, shape) {
   return clone(schema, def);
 }
 function merge(a, b) {
-  if (a._zod.def.checks?.length) {
-    throw new Error(".merge() cannot be used on object schemas containing refinements. Use .safeExtend() instead.");
-  }
   const def = mergeDefs(a._zod.def, {
     get shape() {
       const _shape = { ...a._zod.def.shape, ...b._zod.def.shape };
@@ -1124,7 +1122,7 @@ function merge(a, b) {
     get catchall() {
       return b._zod.def.catchall;
     },
-    checks: b._zod.def.checks ?? []
+    checks: []
   });
   return clone(a, def);
 }
@@ -1207,20 +1205,10 @@ function aborted(x, startIndex = 0) {
   }
   return false;
 }
-function explicitlyAborted(x, startIndex = 0) {
-  if (x.aborted === true)
-    return true;
-  for (let i = startIndex;i < x.issues.length; i++) {
-    if (x.issues[i]?.continue === false) {
-      return true;
-    }
-  }
-  return false;
-}
 function prefixIssues(path3, issues) {
   return issues.map((iss) => {
-    var _a2;
-    (_a2 = iss).path ?? (_a2.path = []);
+    var _a;
+    (_a = iss).path ?? (_a.path = []);
     iss.path.unshift(path3);
     return iss;
   });
@@ -1229,14 +1217,17 @@ function unwrapMessage(message) {
   return typeof message === "string" ? message : message?.message;
 }
 function finalizeIssue(iss, ctx, config2) {
-  const message = iss.message ? iss.message : unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ?? unwrapMessage(ctx?.error?.(iss)) ?? unwrapMessage(config2.customError?.(iss)) ?? unwrapMessage(config2.localeError?.(iss)) ?? "Invalid input";
-  const { inst: _inst, continue: _continue, input: _input, ...rest } = iss;
-  rest.path ?? (rest.path = []);
-  rest.message = message;
-  if (ctx?.reportInput) {
-    rest.input = _input;
+  const full = { ...iss, path: iss.path ?? [] };
+  if (!iss.message) {
+    const message = unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ?? unwrapMessage(ctx?.error?.(iss)) ?? unwrapMessage(config2.customError?.(iss)) ?? unwrapMessage(config2.localeError?.(iss)) ?? "Invalid input";
+    full.message = message;
   }
-  return rest;
+  delete full.inst;
+  delete full.continue;
+  if (!ctx?.reportInput) {
+    delete full.input;
+  }
+  return full;
 }
 function getSizableOrigin(input) {
   if (input instanceof Set)
@@ -1378,13 +1369,9 @@ var EVALUATING, captureStackTrace, allowsEval, getParsedType = (data) => {
   }
 }, propertyKeyTypes, primitiveTypes, NUMBER_FORMAT_RANGES, BIGINT_FORMAT_RANGES;
 var init_util = __esm(() => {
-  init_core();
-  EVALUATING = /* @__PURE__ */ Symbol("evaluating");
+  EVALUATING = Symbol("evaluating");
   captureStackTrace = "captureStackTrace" in Error ? Error.captureStackTrace : (..._args) => {};
-  allowsEval = /* @__PURE__ */ cached(() => {
-    if (globalConfig.jitless) {
-      return false;
-    }
+  allowsEval = cached(() => {
     if (typeof navigator !== "undefined" && navigator?.userAgent?.includes("Cloudflare")) {
       return false;
     }
@@ -1396,15 +1383,8 @@ var init_util = __esm(() => {
       return false;
     }
   });
-  propertyKeyTypes = /* @__PURE__ */ new Set(["string", "number", "symbol"]);
-  primitiveTypes = /* @__PURE__ */ new Set([
-    "string",
-    "number",
-    "bigint",
-    "boolean",
-    "symbol",
-    "undefined"
-  ]);
+  propertyKeyTypes = new Set(["string", "number", "symbol"]);
+  primitiveTypes = new Set(["string", "number", "bigint", "boolean", "symbol", "undefined"]);
   NUMBER_FORMAT_RANGES = {
     safeint: [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
     int32: [-2147483648, 2147483647],
@@ -1434,33 +1414,30 @@ function flattenError(error2, mapper = (issue2) => issue2.message) {
 }
 function formatError(error2, mapper = (issue2) => issue2.message) {
   const fieldErrors = { _errors: [] };
-  const processError = (error3, path3 = []) => {
+  const processError = (error3) => {
     for (const issue2 of error3.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path3, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
+        processError({ issues: issue2.issues });
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
+        processError({ issues: issue2.issues });
+      } else if (issue2.path.length === 0) {
+        fieldErrors._errors.push(mapper(issue2));
       } else {
-        const fullpath = [...path3, ...issue2.path];
-        if (fullpath.length === 0) {
-          fieldErrors._errors.push(mapper(issue2));
-        } else {
-          let curr = fieldErrors;
-          let i = 0;
-          while (i < fullpath.length) {
-            const el = fullpath[i];
-            const terminal = i === fullpath.length - 1;
-            if (!terminal) {
-              curr[el] = curr[el] || { _errors: [] };
-            } else {
-              curr[el] = curr[el] || { _errors: [] };
-              curr[el]._errors.push(mapper(issue2));
-            }
-            curr = curr[el];
-            i++;
+        let curr = fieldErrors;
+        let i = 0;
+        while (i < issue2.path.length) {
+          const el = issue2.path[i];
+          const terminal = i === issue2.path.length - 1;
+          if (!terminal) {
+            curr[el] = curr[el] || { _errors: [] };
+          } else {
+            curr[el] = curr[el] || { _errors: [] };
+            curr[el]._errors.push(mapper(issue2));
           }
+          curr = curr[el];
+          i++;
         }
       }
     }
@@ -1471,14 +1448,14 @@ function formatError(error2, mapper = (issue2) => issue2.message) {
 function treeifyError(error2, mapper = (issue2) => issue2.message) {
   const result = { errors: [] };
   const processError = (error3, path3 = []) => {
-    var _a2, _b;
+    var _a, _b;
     for (const issue2 of error3.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path3, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, issue2.path));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
+        processError({ issues: issue2.issues }, issue2.path);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
+        processError({ issues: issue2.issues }, issue2.path);
       } else {
         const fullpath = [...path3, ...issue2.path];
         if (fullpath.length === 0) {
@@ -1492,7 +1469,7 @@ function treeifyError(error2, mapper = (issue2) => issue2.message) {
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
             curr.properties ?? (curr.properties = {});
-            (_a2 = curr.properties)[el] ?? (_a2[el] = { errors: [] });
+            (_a = curr.properties)[el] ?? (_a[el] = { errors: [] });
             curr = curr.properties[el];
           } else {
             curr.items ?? (curr.items = []);
@@ -1564,7 +1541,7 @@ var init_errors2 = __esm(() => {
 
 // node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
-  const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
+  const ctx = _ctx ? Object.assign(_ctx, { async: false }) : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) {
     throw new $ZodAsyncError;
@@ -1576,7 +1553,7 @@ var _parse = (_Err) => (schema, value, _ctx, _params) => {
   }
   return result.value;
 }, parse, _parseAsync = (_Err) => async (schema, value, _ctx, params) => {
-  const ctx = _ctx ? { ..._ctx, async: true } : { async: true };
+  const ctx = _ctx ? Object.assign(_ctx, { async: true }) : { async: true };
   let result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise)
     result = await result;
@@ -1597,7 +1574,7 @@ var _parse = (_Err) => (schema, value, _ctx, _params) => {
     error: new (_Err ?? $ZodError)(result.issues.map((iss) => finalizeIssue(iss, ctx, config())))
   } : { success: true, data: result.value };
 }, safeParse, _safeParseAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? { ..._ctx, async: true } : { async: true };
+  const ctx = _ctx ? Object.assign(_ctx, { async: true }) : { async: true };
   let result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise)
     result = await result;
@@ -1606,22 +1583,22 @@ var _parse = (_Err) => (schema, value, _ctx, _params) => {
     error: new _Err(result.issues.map((iss) => finalizeIssue(iss, ctx, config())))
   } : { success: true, data: result.value };
 }, safeParseAsync, _encode = (_Err) => (schema, value, _ctx) => {
-  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
+  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
   return _parse(_Err)(schema, value, ctx);
 }, encode, _decode = (_Err) => (schema, value, _ctx) => {
   return _parse(_Err)(schema, value, _ctx);
 }, decode, _encodeAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
+  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
   return _parseAsync(_Err)(schema, value, ctx);
 }, encodeAsync, _decodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _parseAsync(_Err)(schema, value, _ctx);
 }, decodeAsync, _safeEncode = (_Err) => (schema, value, _ctx) => {
-  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
+  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
   return _safeParse(_Err)(schema, value, ctx);
 }, safeEncode, _safeDecode = (_Err) => (schema, value, _ctx) => {
   return _safeParse(_Err)(schema, value, _ctx);
 }, safeDecode, _safeEncodeAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
+  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
   return _safeParseAsync(_Err)(schema, value, ctx);
 }, safeEncodeAsync, _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);
@@ -1684,7 +1661,6 @@ __export(exports_regexes, {
   ipv4: () => ipv4,
   integer: () => integer,
   idnEmail: () => idnEmail,
-  httpProtocol: () => httpProtocol,
   html5Email: () => html5Email,
   hostname: () => hostname,
   hex: () => hex,
@@ -1741,13 +1717,13 @@ var cuid, cuid2, ulid, xid, ksuid, nanoid, duration, extendedDuration, guid, uui
 }, uuid4, uuid6, uuid7, email, html5Email, rfc5322Email, unicodeEmail, idnEmail, browserEmail, _emoji = `^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$`, ipv4, ipv6, mac = (delimiter) => {
   const escapedDelim = escapeRegex2(delimiter ?? ":");
   return new RegExp(`^(?:[0-9A-F]{2}${escapedDelim}){5}[0-9A-F]{2}$|^(?:[0-9a-f]{2}${escapedDelim}){5}[0-9a-f]{2}$`);
-}, cidrv4, cidrv6, base64, base64url, hostname, domain, httpProtocol, e164, dateSource = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`, date, string = (params) => {
+}, cidrv4, cidrv6, base64, base64url, hostname, domain, e164, dateSource = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`, date, string = (params) => {
   const regex = params ? `[\\s\\S]{${params?.minimum ?? 0},${params?.maximum ?? ""}}` : `[\\s\\S]*`;
   return new RegExp(`^${regex}$`);
 }, bigint, integer, number, boolean, _null, _undefined, lowercase, uppercase, hex, md5_hex, md5_base64, md5_base64url, sha1_hex, sha1_base64, sha1_base64url, sha256_hex, sha256_base64, sha256_base64url, sha384_hex, sha384_base64, sha384_base64url, sha512_hex, sha512_base64, sha512_base64url;
 var init_regexes = __esm(() => {
   init_util();
-  cuid = /^[cC][0-9a-z]{6,}$/;
+  cuid = /^[cC][^\s-]{8,}$/;
   cuid2 = /^[0-9a-z]+$/;
   ulid = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/;
   xid = /^[0-9a-vA-V]{20}$/;
@@ -1773,7 +1749,6 @@ var init_regexes = __esm(() => {
   base64url = /^[A-Za-z0-9_-]*$/;
   hostname = /^(?=.{1,253}\.?$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[-0-9a-zA-Z]{0,61}[0-9a-zA-Z])?)*\.?$/;
   domain = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
-  httpProtocol = /^https?$/;
   e164 = /^\+[1-9]\d{6,14}$/;
   date = /* @__PURE__ */ new RegExp(`^${dateSource}$`);
   bigint = /^-?\d+n?$/;
@@ -1814,10 +1789,10 @@ var init_checks = __esm(() => {
   init_regexes();
   init_util();
   $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
-    var _a2;
+    var _a;
     inst._zod ?? (inst._zod = {});
     inst._zod.def = def;
-    (_a2 = inst._zod).onattach ?? (_a2.onattach = []);
+    (_a = inst._zod).onattach ?? (_a.onattach = []);
   });
   numericOriginMap = {
     number: "number",
@@ -1883,8 +1858,8 @@ var init_checks = __esm(() => {
   $ZodCheckMultipleOf = /* @__PURE__ */ $constructor("$ZodCheckMultipleOf", (inst, def) => {
     $ZodCheck.init(inst, def);
     inst._zod.onattach.push((inst2) => {
-      var _a2;
-      (_a2 = inst2._zod.bag).multipleOf ?? (_a2.multipleOf = def.value);
+      var _a;
+      (_a = inst2._zod.bag).multipleOf ?? (_a.multipleOf = def.value);
     });
     inst._zod.check = (payload) => {
       if (typeof payload.value !== typeof def.value)
@@ -2017,9 +1992,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMaxSize = /* @__PURE__ */ $constructor("$ZodCheckMaxSize", (inst, def) => {
-    var _a2;
+    var _a;
     $ZodCheck.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.size !== undefined;
     });
@@ -2045,9 +2020,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMinSize = /* @__PURE__ */ $constructor("$ZodCheckMinSize", (inst, def) => {
-    var _a2;
+    var _a;
     $ZodCheck.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.size !== undefined;
     });
@@ -2073,9 +2048,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckSizeEquals = /* @__PURE__ */ $constructor("$ZodCheckSizeEquals", (inst, def) => {
-    var _a2;
+    var _a;
     $ZodCheck.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.size !== undefined;
     });
@@ -2103,9 +2078,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMaxLength = /* @__PURE__ */ $constructor("$ZodCheckMaxLength", (inst, def) => {
-    var _a2;
+    var _a;
     $ZodCheck.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.length !== undefined;
     });
@@ -2132,9 +2107,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMinLength = /* @__PURE__ */ $constructor("$ZodCheckMinLength", (inst, def) => {
-    var _a2;
+    var _a;
     $ZodCheck.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.length !== undefined;
     });
@@ -2161,9 +2136,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckLengthEquals = /* @__PURE__ */ $constructor("$ZodCheckLengthEquals", (inst, def) => {
-    var _a2;
+    var _a;
     $ZodCheck.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.length !== undefined;
     });
@@ -2192,7 +2167,7 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckStringFormat = /* @__PURE__ */ $constructor("$ZodCheckStringFormat", (inst, def) => {
-    var _a2, _b;
+    var _a, _b;
     $ZodCheck.init(inst, def);
     inst._zod.onattach.push((inst2) => {
       const bag = inst2._zod.bag;
@@ -2203,7 +2178,7 @@ var init_checks = __esm(() => {
       }
     });
     if (def.pattern)
-      (_a2 = inst._zod).check ?? (_a2.check = (payload) => {
+      (_a = inst._zod).check ?? (_a.check = (payload) => {
         def.pattern.lastIndex = 0;
         if (def.pattern.test(payload.value))
           return;
@@ -2398,8 +2373,8 @@ var version;
 var init_versions = __esm(() => {
   version = {
     major: 4,
-    minor: 4,
-    patch: 3
+    minor: 3,
+    patch: 6
   };
 });
 
@@ -2407,8 +2382,6 @@ var init_versions = __esm(() => {
 function isValidBase64(data) {
   if (data === "")
     return true;
-  if (/\s/.test(data))
-    return false;
   if (data.length % 4 !== 0)
     return false;
   try {
@@ -2451,27 +2424,15 @@ function handleArrayResult(result, final, index) {
   }
   final.value[index] = result.value;
 }
-function handlePropertyResult(result, final, key, input, isOptionalIn, isOptionalOut) {
-  const isPresent = key in input;
+function handlePropertyResult(result, final, key, input, isOptionalOut) {
   if (result.issues.length) {
-    if (isOptionalIn && isOptionalOut && !isPresent) {
+    if (isOptionalOut && !(key in input)) {
       return;
     }
     final.issues.push(...prefixIssues(key, result.issues));
   }
-  if (!isPresent && !isOptionalIn) {
-    if (!result.issues.length) {
-      final.issues.push({
-        code: "invalid_type",
-        expected: "nonoptional",
-        input: undefined,
-        path: [key]
-      });
-    }
-    return;
-  }
   if (result.value === undefined) {
-    if (isPresent) {
+    if (key in input) {
       final.value[key] = undefined;
     }
   } else {
@@ -2499,11 +2460,8 @@ function handleCatchall(proms, input, payload, ctx, def, inst) {
   const keySet = def.keySet;
   const _catchall = def.catchall._zod;
   const t = _catchall.def.type;
-  const isOptionalIn = _catchall.optin === "optional";
   const isOptionalOut = _catchall.optout === "optional";
   for (const key in input) {
-    if (key === "__proto__")
-      continue;
     if (keySet.has(key))
       continue;
     if (t === "never") {
@@ -2512,9 +2470,9 @@ function handleCatchall(proms, input, payload, ctx, def, inst) {
     }
     const r = _catchall.run({ value: input[key], issues: [] }, ctx);
     if (r instanceof Promise) {
-      proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalIn, isOptionalOut)));
+      proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalOut)));
     } else {
-      handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
+      handlePropertyResult(r, payload, key, input, isOptionalOut);
     }
   }
   if (unrecognized.length) {
@@ -2658,40 +2616,11 @@ function handleIntersectionResults(result, left, right) {
   result.value = merged.data;
   return result;
 }
-function getTupleOptStart(items, key) {
-  for (let i = items.length - 1;i >= 0; i--) {
-    if (items[i]._zod[key] !== "optional")
-      return i + 1;
-  }
-  return 0;
-}
 function handleTupleResult(result, final, index) {
   if (result.issues.length) {
     final.issues.push(...prefixIssues(index, result.issues));
   }
   final.value[index] = result.value;
-}
-function handleTupleResults(itemResults, final, items, input, optoutStart) {
-  for (let i = 0;i < items.length; i++) {
-    const r = itemResults[i];
-    const isPresent = i < input.length;
-    if (r.issues.length) {
-      if (!isPresent && i >= optoutStart) {
-        final.value.length = i;
-        break;
-      }
-      final.issues.push(...prefixIssues(i, r.issues));
-    }
-    final.value[i] = r.value;
-  }
-  for (let i = final.value.length - 1;i >= input.length; i--) {
-    if (items[i]._zod.optout === "optional" && final.value[i] === undefined) {
-      final.value.length = i;
-    } else {
-      break;
-    }
-  }
-  return final;
 }
 function handleMapResult(keyResult, valueResult, final, key, input, inst, ctx) {
   if (keyResult.issues.length) {
@@ -2730,7 +2659,7 @@ function handleSetResult(result, final) {
   final.value.add(result.value);
 }
 function handleOptionalResult(result, input) {
-  if (input === undefined && (result.issues.length || result.fallback)) {
+  if (result.issues.length && input === undefined) {
     return { issues: [], value: undefined };
   }
   return result;
@@ -2757,7 +2686,7 @@ function handlePipeResult(left, next, ctx) {
     left.aborted = true;
     return left;
   }
-  return next._zod.run({ value: left.value, issues: left.issues, fallback: left.fallback }, ctx);
+  return next._zod.run({ value: left.value, issues: left.issues }, ctx);
 }
 function handleCodecAResult(result, def, ctx) {
   if (result.issues.length) {
@@ -2804,7 +2733,7 @@ function handleRefineResult(result, payload, input, inst) {
     payload.issues.push(issue(_iss));
   }
 }
-var $ZodType, $ZodString, $ZodStringFormat, $ZodGUID, $ZodUUID, $ZodEmail, $ZodURL, $ZodEmoji, $ZodNanoID, $ZodCUID, $ZodCUID2, $ZodULID, $ZodXID, $ZodKSUID, $ZodISODateTime, $ZodISODate, $ZodISOTime, $ZodISODuration, $ZodIPv4, $ZodIPv6, $ZodMAC, $ZodCIDRv4, $ZodCIDRv6, $ZodBase64, $ZodBase64URL, $ZodE164, $ZodJWT, $ZodCustomStringFormat, $ZodNumber, $ZodNumberFormat, $ZodBoolean, $ZodBigInt, $ZodBigIntFormat, $ZodSymbol, $ZodUndefined, $ZodNull, $ZodAny, $ZodUnknown, $ZodNever, $ZodVoid, $ZodDate, $ZodArray, $ZodObject, $ZodObjectJIT, $ZodUnion, $ZodXor, $ZodDiscriminatedUnion, $ZodIntersection, $ZodTuple, $ZodRecord, $ZodMap, $ZodSet, $ZodEnum, $ZodLiteral, $ZodFile, $ZodTransform, $ZodOptional, $ZodExactOptional, $ZodNullable, $ZodDefault, $ZodPrefault, $ZodNonOptional, $ZodSuccess, $ZodCatch, $ZodNaN, $ZodPipe, $ZodCodec, $ZodPreprocess, $ZodReadonly, $ZodTemplateLiteral, $ZodFunction, $ZodPromise, $ZodLazy, $ZodCustom;
+var $ZodType, $ZodString, $ZodStringFormat, $ZodGUID, $ZodUUID, $ZodEmail, $ZodURL, $ZodEmoji, $ZodNanoID, $ZodCUID, $ZodCUID2, $ZodULID, $ZodXID, $ZodKSUID, $ZodISODateTime, $ZodISODate, $ZodISOTime, $ZodISODuration, $ZodIPv4, $ZodIPv6, $ZodMAC, $ZodCIDRv4, $ZodCIDRv6, $ZodBase64, $ZodBase64URL, $ZodE164, $ZodJWT, $ZodCustomStringFormat, $ZodNumber, $ZodNumberFormat, $ZodBoolean, $ZodBigInt, $ZodBigIntFormat, $ZodSymbol, $ZodUndefined, $ZodNull, $ZodAny, $ZodUnknown, $ZodNever, $ZodVoid, $ZodDate, $ZodArray, $ZodObject, $ZodObjectJIT, $ZodUnion, $ZodXor, $ZodDiscriminatedUnion, $ZodIntersection, $ZodTuple, $ZodRecord, $ZodMap, $ZodSet, $ZodEnum, $ZodLiteral, $ZodFile, $ZodTransform, $ZodOptional, $ZodExactOptional, $ZodNullable, $ZodDefault, $ZodPrefault, $ZodNonOptional, $ZodSuccess, $ZodCatch, $ZodNaN, $ZodPipe, $ZodCodec, $ZodReadonly, $ZodTemplateLiteral, $ZodFunction, $ZodPromise, $ZodLazy, $ZodCustom;
 var init_schemas = __esm(() => {
   init_checks();
   init_core();
@@ -2814,7 +2743,7 @@ var init_schemas = __esm(() => {
   init_versions();
   init_util();
   $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
-    var _a2;
+    var _a;
     inst ?? (inst = {});
     inst._zod.def = def;
     inst._zod.bag = inst._zod.bag || {};
@@ -2829,7 +2758,7 @@ var init_schemas = __esm(() => {
       }
     }
     if (checks.length === 0) {
-      (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
+      (_a = inst._zod).deferred ?? (_a.deferred = []);
       inst._zod.deferred?.push(() => {
         inst._zod.run = inst._zod.parse;
       });
@@ -2839,8 +2768,6 @@ var init_schemas = __esm(() => {
         let asyncResult;
         for (const ch of checks2) {
           if (ch._zod.def.when) {
-            if (explicitlyAborted(payload))
-              continue;
             const shouldRun = ch._zod.def.when(payload);
             if (!shouldRun)
               continue;
@@ -2980,19 +2907,6 @@ var init_schemas = __esm(() => {
     inst._zod.check = (payload) => {
       try {
         const trimmed = payload.value.trim();
-        if (!def.normalize && def.protocol?.source === httpProtocol.source) {
-          if (!/^https?:\/\//i.test(trimmed)) {
-            payload.issues.push({
-              code: "invalid_format",
-              format: "url",
-              note: "Invalid URL format",
-              input: payload.value,
-              inst,
-              continue: !def.abort
-            });
-            return;
-          }
-        }
         const url = new URL(trimmed);
         if (def.hostname) {
           def.hostname.lastIndex = 0;
@@ -3296,6 +3210,8 @@ var init_schemas = __esm(() => {
     $ZodType.init(inst, def);
     inst._zod.pattern = _undefined;
     inst._zod.values = new Set([undefined]);
+    inst._zod.optin = "optional";
+    inst._zod.optout = "optional";
     inst._zod.parse = (payload, _ctx) => {
       const input = payload.value;
       if (typeof input === "undefined")
@@ -3466,13 +3382,12 @@ var init_schemas = __esm(() => {
       const shape = value.shape;
       for (const key of value.keys) {
         const el = shape[key];
-        const isOptionalIn = el._zod.optin === "optional";
         const isOptionalOut = el._zod.optout === "optional";
         const r = el._zod.run({ value: input[key], issues: [] }, ctx);
         if (r instanceof Promise) {
-          proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalIn, isOptionalOut)));
+          proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalOut)));
         } else {
-          handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
+          handlePropertyResult(r, payload, key, input, isOptionalOut);
         }
       }
       if (!catchall) {
@@ -3503,10 +3418,9 @@ var init_schemas = __esm(() => {
         const id = ids[key];
         const k = esc(key);
         const schema = shape[key];
-        const isOptionalIn = schema?._zod?.optin === "optional";
         const isOptionalOut = schema?._zod?.optout === "optional";
         doc.write(`const ${id} = ${parseStr(key)};`);
-        if (isOptionalIn && isOptionalOut) {
+        if (isOptionalOut) {
           doc.write(`
         if (${id}.issues.length) {
           if (${k} in input) {
@@ -3525,33 +3439,6 @@ var init_schemas = __esm(() => {
           newResult[${k}] = ${id}.value;
         }
         
-      `);
-        } else if (!isOptionalIn) {
-          doc.write(`
-        const ${id}_present = ${k} in input;
-        if (${id}.issues.length) {
-          payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
-            ...iss,
-            path: iss.path ? [${k}, ...iss.path] : [${k}]
-          })));
-        }
-        if (!${id}_present && !${id}.issues.length) {
-          payload.issues.push({
-            code: "invalid_type",
-            expected: "nonoptional",
-            input: undefined,
-            path: [${k}]
-          });
-        }
-
-        if (${id}_present) {
-          if (${id}.value === undefined) {
-            newResult[${k}] = undefined;
-          } else {
-            newResult[${k}] = ${id}.value;
-          }
-        }
-
       `);
         } else {
           doc.write(`
@@ -3625,9 +3512,10 @@ var init_schemas = __esm(() => {
       }
       return;
     });
-    const first = def.options.length === 1 ? def.options[0]._zod.run : null;
+    const single = def.options.length === 1;
+    const first = def.options[0]._zod.run;
     inst._zod.parse = (payload, ctx) => {
-      if (first) {
+      if (single) {
         return first(payload, ctx);
       }
       let async = false;
@@ -3656,9 +3544,10 @@ var init_schemas = __esm(() => {
   $ZodXor = /* @__PURE__ */ $constructor("$ZodXor", (inst, def) => {
     $ZodUnion.init(inst, def);
     def.inclusive = false;
-    const first = def.options.length === 1 ? def.options[0]._zod.run : null;
+    const single = def.options.length === 1;
+    const first = def.options[0]._zod.run;
     inst._zod.parse = (payload, ctx) => {
-      if (first) {
+      if (single) {
         return first(payload, ctx);
       }
       let async = false;
@@ -3733,7 +3622,7 @@ var init_schemas = __esm(() => {
       if (opt) {
         return opt._zod.run(payload, ctx);
       }
-      if (def.unionFallback || ctx.direction === "backward") {
+      if (def.unionFallback) {
         return _super(payload, ctx);
       }
       payload.issues.push({
@@ -3741,7 +3630,6 @@ var init_schemas = __esm(() => {
         errors: [],
         note: "No matching discriminator",
         discriminator: def.discriminator,
-        options: Array.from(disc.value.keys()),
         input,
         path: [def.discriminator],
         inst
@@ -3780,59 +3668,56 @@ var init_schemas = __esm(() => {
       }
       payload.value = [];
       const proms = [];
-      const optinStart = getTupleOptStart(items, "optin");
-      const optoutStart = getTupleOptStart(items, "optout");
+      const reversedIndex = [...items].reverse().findIndex((item) => item._zod.optin !== "optional");
+      const optStart = reversedIndex === -1 ? 0 : items.length - reversedIndex;
       if (!def.rest) {
-        if (input.length < optinStart) {
+        const tooBig = input.length > items.length;
+        const tooSmall = input.length < optStart - 1;
+        if (tooBig || tooSmall) {
           payload.issues.push({
-            code: "too_small",
-            minimum: optinStart,
-            inclusive: true,
+            ...tooBig ? { code: "too_big", maximum: items.length, inclusive: true } : { code: "too_small", minimum: items.length },
             input,
             inst,
             origin: "array"
           });
           return payload;
         }
-        if (input.length > items.length) {
-          payload.issues.push({
-            code: "too_big",
-            maximum: items.length,
-            inclusive: true,
-            input,
-            inst,
-            origin: "array"
-          });
-        }
       }
-      const itemResults = new Array(items.length);
-      for (let i = 0;i < items.length; i++) {
-        const r = items[i]._zod.run({ value: input[i], issues: [] }, ctx);
-        if (r instanceof Promise) {
-          proms.push(r.then((rr) => {
-            itemResults[i] = rr;
-          }));
+      let i = -1;
+      for (const item of items) {
+        i++;
+        if (i >= input.length) {
+          if (i >= optStart)
+            continue;
+        }
+        const result = item._zod.run({
+          value: input[i],
+          issues: []
+        }, ctx);
+        if (result instanceof Promise) {
+          proms.push(result.then((result2) => handleTupleResult(result2, payload, i)));
         } else {
-          itemResults[i] = r;
+          handleTupleResult(result, payload, i);
         }
       }
       if (def.rest) {
-        let i = items.length - 1;
         const rest = input.slice(items.length);
         for (const el of rest) {
           i++;
-          const result = def.rest._zod.run({ value: el, issues: [] }, ctx);
+          const result = def.rest._zod.run({
+            value: el,
+            issues: []
+          }, ctx);
           if (result instanceof Promise) {
-            proms.push(result.then((r) => handleTupleResult(r, payload, i)));
+            proms.push(result.then((result2) => handleTupleResult(result2, payload, i)));
           } else {
             handleTupleResult(result, payload, i);
           }
         }
       }
-      if (proms.length) {
-        return Promise.all(proms).then(() => handleTupleResults(itemResults, payload, items, input, optoutStart));
-      }
-      return handleTupleResults(itemResults, payload, items, input, optoutStart);
+      if (proms.length)
+        return Promise.all(proms).then(() => payload);
+      return payload;
     };
   });
   $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
@@ -3856,35 +3741,19 @@ var init_schemas = __esm(() => {
         for (const key of values) {
           if (typeof key === "string" || typeof key === "number" || typeof key === "symbol") {
             recordKeys.add(typeof key === "number" ? key.toString() : key);
-            const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
-            if (keyResult instanceof Promise) {
-              throw new Error("Async schemas not supported in object keys currently");
-            }
-            if (keyResult.issues.length) {
-              payload.issues.push({
-                code: "invalid_key",
-                origin: "record",
-                issues: keyResult.issues.map((iss) => finalizeIssue(iss, ctx, config())),
-                input: key,
-                path: [key],
-                inst
-              });
-              continue;
-            }
-            const outKey = keyResult.value;
             const result = def.valueType._zod.run({ value: input[key], issues: [] }, ctx);
             if (result instanceof Promise) {
               proms.push(result.then((result2) => {
                 if (result2.issues.length) {
                   payload.issues.push(...prefixIssues(key, result2.issues));
                 }
-                payload.value[outKey] = result2.value;
+                payload.value[key] = result2.value;
               }));
             } else {
               if (result.issues.length) {
                 payload.issues.push(...prefixIssues(key, result.issues));
               }
-              payload.value[outKey] = result.value;
+              payload.value[key] = result.value;
             }
           }
         }
@@ -3907,8 +3776,6 @@ var init_schemas = __esm(() => {
         payload.value = {};
         for (const key of Reflect.ownKeys(input)) {
           if (key === "__proto__")
-            continue;
-          if (!Object.prototype.propertyIsEnumerable.call(input, key))
             continue;
           let keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
           if (keyResult instanceof Promise) {
@@ -4078,7 +3945,6 @@ var init_schemas = __esm(() => {
   });
   $ZodTransform = /* @__PURE__ */ $constructor("$ZodTransform", (inst, def) => {
     $ZodType.init(inst, def);
-    inst._zod.optin = "optional";
     inst._zod.parse = (payload, ctx) => {
       if (ctx.direction === "backward") {
         throw new $ZodEncodeError(inst.constructor.name);
@@ -4088,7 +3954,6 @@ var init_schemas = __esm(() => {
         const output = _out instanceof Promise ? _out : Promise.resolve(_out);
         return output.then((output2) => {
           payload.value = output2;
-          payload.fallback = true;
           return payload;
         });
       }
@@ -4096,7 +3961,6 @@ var init_schemas = __esm(() => {
         throw new $ZodAsyncError;
       }
       payload.value = _out;
-      payload.fallback = true;
       return payload;
     };
   });
@@ -4113,11 +3977,10 @@ var init_schemas = __esm(() => {
     });
     inst._zod.parse = (payload, ctx) => {
       if (def.innerType._zod.optin === "optional") {
-        const input = payload.value;
         const result = def.innerType._zod.run(payload, ctx);
         if (result instanceof Promise)
-          return result.then((r) => handleOptionalResult(r, input));
-        return handleOptionalResult(result, input);
+          return result.then((r) => handleOptionalResult(r, payload.value));
+        return handleOptionalResult(result, payload.value);
       }
       if (payload.value === undefined) {
         return payload;
@@ -4216,7 +4079,7 @@ var init_schemas = __esm(() => {
   });
   $ZodCatch = /* @__PURE__ */ $constructor("$ZodCatch", (inst, def) => {
     $ZodType.init(inst, def);
-    inst._zod.optin = "optional";
+    defineLazy(inst._zod, "optin", () => def.innerType._zod.optin);
     defineLazy(inst._zod, "optout", () => def.innerType._zod.optout);
     defineLazy(inst._zod, "values", () => def.innerType._zod.values);
     inst._zod.parse = (payload, ctx) => {
@@ -4236,7 +4099,6 @@ var init_schemas = __esm(() => {
               input: payload.value
             });
             payload.issues = [];
-            payload.fallback = true;
           }
           return payload;
         });
@@ -4251,7 +4113,6 @@ var init_schemas = __esm(() => {
           input: payload.value
         });
         payload.issues = [];
-        payload.fallback = true;
       }
       return payload;
     };
@@ -4314,9 +4175,6 @@ var init_schemas = __esm(() => {
         return handleCodecAResult(right, def, ctx);
       }
     };
-  });
-  $ZodPreprocess = /* @__PURE__ */ $constructor("$ZodPreprocess", (inst, def) => {
-    $ZodPipe.init(inst, def);
   });
   $ZodReadonly = /* @__PURE__ */ $constructor("$ZodReadonly", (inst, def) => {
     $ZodType.init(inst, def);
@@ -4465,12 +4323,7 @@ var init_schemas = __esm(() => {
   });
   $ZodLazy = /* @__PURE__ */ $constructor("$ZodLazy", (inst, def) => {
     $ZodType.init(inst, def);
-    defineLazy(inst._zod, "innerType", () => {
-      const d = def;
-      if (!d._cachedInner)
-        d._cachedInner = def.getter();
-      return d._cachedInner;
-    });
+    defineLazy(inst._zod, "innerType", () => def.getter());
     defineLazy(inst._zod, "pattern", () => inst._zod.innerType?._zod?.pattern);
     defineLazy(inst._zod, "propValues", () => inst._zod.innerType?._zod?.propValues);
     defineLazy(inst._zod, "optin", () => inst._zod.innerType?._zod?.optin ?? undefined);
@@ -5458,126 +5311,13 @@ var init_de = __esm(() => {
   init_util();
 });
 
-// node_modules/zod/v4/locales/el.js
-function el_default() {
+// node_modules/zod/v4/locales/en.js
+function en_default() {
   return {
     localeError: error10()
   };
 }
 var error10 = () => {
-  const Sizable = {
-    string: { unit: "\u03C7\u03B1\u03C1\u03B1\u03BA\u03C4\u03AE\u03C1\u03B5\u03C2", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
-    file: { unit: "bytes", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
-    array: { unit: "\u03C3\u03C4\u03BF\u03B9\u03C7\u03B5\u03AF\u03B1", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
-    set: { unit: "\u03C3\u03C4\u03BF\u03B9\u03C7\u03B5\u03AF\u03B1", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
-    map: { unit: "\u03BA\u03B1\u03C4\u03B1\u03C7\u03C9\u03C1\u03AE\u03C3\u03B5\u03B9\u03C2", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" }
-  };
-  function getSizing(origin) {
-    return Sizable[origin] ?? null;
-  }
-  const FormatDictionary = {
-    regex: "\u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2",
-    email: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 email",
-    url: "URL",
-    emoji: "emoji",
-    uuid: "UUID",
-    uuidv4: "UUIDv4",
-    uuidv6: "UUIDv6",
-    nanoid: "nanoid",
-    guid: "GUID",
-    cuid: "cuid",
-    cuid2: "cuid2",
-    ulid: "ULID",
-    xid: "XID",
-    ksuid: "KSUID",
-    datetime: "ISO \u03B7\u03BC\u03B5\u03C1\u03BF\u03BC\u03B7\u03BD\u03AF\u03B1 \u03BA\u03B1\u03B9 \u03CE\u03C1\u03B1",
-    date: "ISO \u03B7\u03BC\u03B5\u03C1\u03BF\u03BC\u03B7\u03BD\u03AF\u03B1",
-    time: "ISO \u03CE\u03C1\u03B1",
-    duration: "ISO \u03B4\u03B9\u03AC\u03C1\u03BA\u03B5\u03B9\u03B1",
-    ipv4: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 IPv4",
-    ipv6: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 IPv6",
-    mac: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 MAC",
-    cidrv4: "\u03B5\u03CD\u03C1\u03BF\u03C2 IPv4",
-    cidrv6: "\u03B5\u03CD\u03C1\u03BF\u03C2 IPv6",
-    base64: "\u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC \u03BA\u03C9\u03B4\u03B9\u03BA\u03BF\u03C0\u03BF\u03B9\u03B7\u03BC\u03AD\u03BD\u03B7 \u03C3\u03B5 base64",
-    base64url: "\u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC \u03BA\u03C9\u03B4\u03B9\u03BA\u03BF\u03C0\u03BF\u03B9\u03B7\u03BC\u03AD\u03BD\u03B7 \u03C3\u03B5 base64url",
-    json_string: "\u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC JSON",
-    e164: "\u03B1\u03C1\u03B9\u03B8\u03BC\u03CC\u03C2 E.164",
-    jwt: "JWT",
-    template_literal: "\u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2"
-  };
-  const TypeDictionary = {
-    nan: "NaN"
-  };
-  return (issue2) => {
-    switch (issue2.code) {
-      case "invalid_type": {
-        const expected = TypeDictionary[issue2.expected] ?? issue2.expected;
-        const receivedType = parsedType(issue2.input);
-        const received = TypeDictionary[receivedType] ?? receivedType;
-        if (typeof issue2.expected === "string" && /^[A-Z]/.test(issue2.expected)) {
-          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD instanceof ${issue2.expected}, \u03BB\u03AE\u03C6\u03B8\u03B7\u03BA\u03B5 ${received}`;
-        }
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${expected}, \u03BB\u03AE\u03C6\u03B8\u03B7\u03BA\u03B5 ${received}`;
-      }
-      case "invalid_value":
-        if (issue2.values.length === 1)
-          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${stringifyPrimitive(issue2.values[0])}`;
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03C0\u03B9\u03BB\u03BF\u03B3\u03AE: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD \u03AD\u03BD\u03B1 \u03B1\u03C0\u03CC ${joinValues(issue2.values, "|")}`;
-      case "too_big": {
-        const adj = issue2.inclusive ? "<=" : "<";
-        const sizing = getSizing(issue2.origin);
-        if (sizing)
-          return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B5\u03B3\u03AC\u03BB\u03BF: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin ?? "\u03C4\u03B9\u03BC\u03AE"} \u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9 ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "\u03C3\u03C4\u03BF\u03B9\u03C7\u03B5\u03AF\u03B1"}`;
-        return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B5\u03B3\u03AC\u03BB\u03BF: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin ?? "\u03C4\u03B9\u03BC\u03AE"} \u03BD\u03B1 \u03B5\u03AF\u03BD\u03B1\u03B9 ${adj}${issue2.maximum.toString()}`;
-      }
-      case "too_small": {
-        const adj = issue2.inclusive ? ">=" : ">";
-        const sizing = getSizing(issue2.origin);
-        if (sizing) {
-          return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B9\u03BA\u03C1\u03CC: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin} \u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9 ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
-        }
-        return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B9\u03BA\u03C1\u03CC: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin} \u03BD\u03B1 \u03B5\u03AF\u03BD\u03B1\u03B9 ${adj}${issue2.minimum.toString()}`;
-      }
-      case "invalid_format": {
-        const _issue = issue2;
-        if (_issue.format === "starts_with") {
-          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03BE\u03B5\u03BA\u03B9\u03BD\u03AC \u03BC\u03B5 "${_issue.prefix}"`;
-        }
-        if (_issue.format === "ends_with")
-          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03C4\u03B5\u03BB\u03B5\u03B9\u03CE\u03BD\u03B5\u03B9 \u03BC\u03B5 "${_issue.suffix}"`;
-        if (_issue.format === "includes")
-          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03C0\u03B5\u03C1\u03B9\u03AD\u03C7\u03B5\u03B9 "${_issue.includes}"`;
-        if (_issue.format === "regex")
-          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03C4\u03B1\u03B9\u03C1\u03B9\u03AC\u03B6\u03B5\u03B9 \u03BC\u03B5 \u03C4\u03BF \u03BC\u03BF\u03C4\u03AF\u03B2\u03BF ${_issue.pattern}`;
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03BF: ${FormatDictionary[_issue.format] ?? issue2.format}`;
-      }
-      case "not_multiple_of":
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03BF\u03C2 \u03B1\u03C1\u03B9\u03B8\u03BC\u03CC\u03C2: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03B5\u03AF\u03BD\u03B1\u03B9 \u03C0\u03BF\u03BB\u03BB\u03B1\u03C0\u03BB\u03AC\u03C3\u03B9\u03BF \u03C4\u03BF\u03C5 ${issue2.divisor}`;
-      case "unrecognized_keys":
-        return `\u0386\u03B3\u03BD\u03C9\u03C3\u03C4${issue2.keys.length > 1 ? "\u03B1" : "\u03BF"} \u03BA\u03BB\u03B5\u03B9\u03B4${issue2.keys.length > 1 ? "\u03B9\u03AC" : "\u03AF"}: ${joinValues(issue2.keys, ", ")}`;
-      case "invalid_key":
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03BF \u03BA\u03BB\u03B5\u03B9\u03B4\u03AF \u03C3\u03C4\u03BF ${issue2.origin}`;
-      case "invalid_union":
-        return "\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2";
-      case "invalid_element":
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C4\u03B9\u03BC\u03AE \u03C3\u03C4\u03BF ${issue2.origin}`;
-      default:
-        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2`;
-    }
-  };
-};
-var init_el = __esm(() => {
-  init_util();
-});
-
-// node_modules/zod/v4/locales/en.js
-function en_default() {
-  return {
-    localeError: error11()
-  };
-}
-var error11 = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
     file: { unit: "bytes", verb: "to have" },
@@ -5669,10 +5409,6 @@ var error11 = () => {
       case "invalid_key":
         return `Invalid key in ${issue2.origin}`;
       case "invalid_union":
-        if (issue2.options && Array.isArray(issue2.options) && issue2.options.length > 0) {
-          const opts = issue2.options.map((o) => `'${o}'`).join(" | ");
-          return `Invalid discriminator value. Expected ${opts}`;
-        }
         return "Invalid input";
       case "invalid_element":
         return `Invalid value in ${issue2.origin}`;
@@ -5688,10 +5424,10 @@ var init_en = __esm(() => {
 // node_modules/zod/v4/locales/eo.js
 function eo_default() {
   return {
-    localeError: error12()
+    localeError: error11()
   };
 }
-var error12 = () => {
+var error11 = () => {
   const Sizable = {
     string: { unit: "karaktrojn", verb: "havi" },
     file: { unit: "bajtojn", verb: "havi" },
@@ -5801,10 +5537,10 @@ var init_eo = __esm(() => {
 // node_modules/zod/v4/locales/es.js
 function es_default() {
   return {
-    localeError: error13()
+    localeError: error12()
   };
 }
-var error13 = () => {
+var error12 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "tener" },
     file: { unit: "bytes", verb: "tener" },
@@ -5937,10 +5673,10 @@ var init_es = __esm(() => {
 // node_modules/zod/v4/locales/fa.js
 function fa_default() {
   return {
-    localeError: error14()
+    localeError: error13()
   };
 }
-var error14 = () => {
+var error13 = () => {
   const Sizable = {
     string: { unit: "\u06A9\u0627\u0631\u0627\u06A9\u062A\u0631", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
     file: { unit: "\u0628\u0627\u06CC\u062A", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
@@ -6055,10 +5791,10 @@ var init_fa = __esm(() => {
 // node_modules/zod/v4/locales/fi.js
 function fi_default() {
   return {
-    localeError: error15()
+    localeError: error14()
   };
 }
-var error15 = () => {
+var error14 = () => {
   const Sizable = {
     string: { unit: "merkki\xE4", subject: "merkkijonon" },
     file: { unit: "tavua", subject: "tiedoston" },
@@ -6171,10 +5907,10 @@ var init_fi = __esm(() => {
 // node_modules/zod/v4/locales/fr.js
 function fr_default() {
   return {
-    localeError: error16()
+    localeError: error15()
   };
 }
-var error16 = () => {
+var error15 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -6215,27 +5951,9 @@ var error16 = () => {
     template_literal: "entr\xE9e"
   };
   const TypeDictionary = {
-    string: "cha\xEEne",
-    number: "nombre",
-    int: "entier",
-    boolean: "bool\xE9en",
-    bigint: "grand entier",
-    symbol: "symbole",
-    undefined: "ind\xE9fini",
-    null: "null",
-    never: "jamais",
-    void: "vide",
-    date: "date",
-    array: "tableau",
-    object: "objet",
-    tuple: "tuple",
-    record: "enregistrement",
-    map: "carte",
-    set: "ensemble",
-    file: "fichier",
-    nonoptional: "non-optionnel",
     nan: "NaN",
-    function: "fonction"
+    number: "nombre",
+    array: "tableau"
   };
   return (issue2) => {
     switch (issue2.code) {
@@ -6256,15 +5974,16 @@ var error16 = () => {
         const adj = issue2.inclusive ? "<=" : "<";
         const sizing = getSizing(issue2.origin);
         if (sizing)
-          return `Trop grand : ${TypeDictionary[issue2.origin] ?? "valeur"} doit ${sizing.verb} ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "\xE9l\xE9ment(s)"}`;
-        return `Trop grand : ${TypeDictionary[issue2.origin] ?? "valeur"} doit \xEAtre ${adj}${issue2.maximum.toString()}`;
+          return `Trop grand : ${issue2.origin ?? "valeur"} doit ${sizing.verb} ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "\xE9l\xE9ment(s)"}`;
+        return `Trop grand : ${issue2.origin ?? "valeur"} doit \xEAtre ${adj}${issue2.maximum.toString()}`;
       }
       case "too_small": {
         const adj = issue2.inclusive ? ">=" : ">";
         const sizing = getSizing(issue2.origin);
-        if (sizing)
-          return `Trop petit : ${TypeDictionary[issue2.origin] ?? "valeur"} doit ${sizing.verb} ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
-        return `Trop petit : ${TypeDictionary[issue2.origin] ?? "valeur"} doit \xEAtre ${adj}${issue2.minimum.toString()}`;
+        if (sizing) {
+          return `Trop petit : ${issue2.origin} doit ${sizing.verb} ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
+        }
+        return `Trop petit : ${issue2.origin} doit \xEAtre ${adj}${issue2.minimum.toString()}`;
       }
       case "invalid_format": {
         const _issue = issue2;
@@ -6300,10 +6019,10 @@ var init_fr = __esm(() => {
 // node_modules/zod/v4/locales/fr-CA.js
 function fr_CA_default() {
   return {
-    localeError: error17()
+    localeError: error16()
   };
 }
-var error17 = () => {
+var error16 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -6411,10 +6130,10 @@ var init_fr_CA = __esm(() => {
 // node_modules/zod/v4/locales/he.js
 function he_default() {
   return {
-    localeError: error18()
+    localeError: error17()
   };
 }
-var error18 = () => {
+var error17 = () => {
   const TypeNames = {
     string: { label: "\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA", gender: "f" },
     number: { label: "\u05DE\u05E1\u05E4\u05E8", gender: "m" },
@@ -6605,139 +6324,13 @@ var init_he = __esm(() => {
   init_util();
 });
 
-// node_modules/zod/v4/locales/hr.js
-function hr_default() {
-  return {
-    localeError: error19()
-  };
-}
-var error19 = () => {
-  const Sizable = {
-    string: { unit: "znakova", verb: "imati" },
-    file: { unit: "bajtova", verb: "imati" },
-    array: { unit: "stavki", verb: "imati" },
-    set: { unit: "stavki", verb: "imati" }
-  };
-  function getSizing(origin) {
-    return Sizable[origin] ?? null;
-  }
-  const FormatDictionary = {
-    regex: "unos",
-    email: "email adresa",
-    url: "URL",
-    emoji: "emoji",
-    uuid: "UUID",
-    uuidv4: "UUIDv4",
-    uuidv6: "UUIDv6",
-    nanoid: "nanoid",
-    guid: "GUID",
-    cuid: "cuid",
-    cuid2: "cuid2",
-    ulid: "ULID",
-    xid: "XID",
-    ksuid: "KSUID",
-    datetime: "ISO datum i vrijeme",
-    date: "ISO datum",
-    time: "ISO vrijeme",
-    duration: "ISO trajanje",
-    ipv4: "IPv4 adresa",
-    ipv6: "IPv6 adresa",
-    cidrv4: "IPv4 raspon",
-    cidrv6: "IPv6 raspon",
-    base64: "base64 kodirani tekst",
-    base64url: "base64url kodirani tekst",
-    json_string: "JSON tekst",
-    e164: "E.164 broj",
-    jwt: "JWT",
-    template_literal: "unos"
-  };
-  const TypeDictionary = {
-    nan: "NaN",
-    string: "tekst",
-    number: "broj",
-    boolean: "boolean",
-    array: "niz",
-    object: "objekt",
-    set: "skup",
-    file: "datoteka",
-    date: "datum",
-    bigint: "bigint",
-    symbol: "simbol",
-    undefined: "undefined",
-    null: "null",
-    function: "funkcija",
-    map: "mapa"
-  };
-  return (issue2) => {
-    switch (issue2.code) {
-      case "invalid_type": {
-        const expected = TypeDictionary[issue2.expected] ?? issue2.expected;
-        const receivedType = parsedType(issue2.input);
-        const received = TypeDictionary[receivedType] ?? receivedType;
-        if (/^[A-Z]/.test(issue2.expected)) {
-          return `Neispravan unos: o\u010Dekuje se instanceof ${issue2.expected}, a primljeno je ${received}`;
-        }
-        return `Neispravan unos: o\u010Dekuje se ${expected}, a primljeno je ${received}`;
-      }
-      case "invalid_value":
-        if (issue2.values.length === 1)
-          return `Neispravna vrijednost: o\u010Dekivano ${stringifyPrimitive(issue2.values[0])}`;
-        return `Neispravna opcija: o\u010Dekivano jedno od ${joinValues(issue2.values, "|")}`;
-      case "too_big": {
-        const adj = issue2.inclusive ? "<=" : "<";
-        const sizing = getSizing(issue2.origin);
-        const origin = TypeDictionary[issue2.origin] ?? issue2.origin;
-        if (sizing)
-          return `Preveliko: o\u010Dekivano da ${origin ?? "vrijednost"} ima ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "elemenata"}`;
-        return `Preveliko: o\u010Dekivano da ${origin ?? "vrijednost"} bude ${adj}${issue2.maximum.toString()}`;
-      }
-      case "too_small": {
-        const adj = issue2.inclusive ? ">=" : ">";
-        const sizing = getSizing(issue2.origin);
-        const origin = TypeDictionary[issue2.origin] ?? issue2.origin;
-        if (sizing) {
-          return `Premalo: o\u010Dekivano da ${origin} ima ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
-        }
-        return `Premalo: o\u010Dekivano da ${origin} bude ${adj}${issue2.minimum.toString()}`;
-      }
-      case "invalid_format": {
-        const _issue = issue2;
-        if (_issue.format === "starts_with")
-          return `Neispravan tekst: mora zapo\u010Dinjati s "${_issue.prefix}"`;
-        if (_issue.format === "ends_with")
-          return `Neispravan tekst: mora zavr\u0161avati s "${_issue.suffix}"`;
-        if (_issue.format === "includes")
-          return `Neispravan tekst: mora sadr\u017Eavati "${_issue.includes}"`;
-        if (_issue.format === "regex")
-          return `Neispravan tekst: mora odgovarati uzorku ${_issue.pattern}`;
-        return `Neispravna ${FormatDictionary[_issue.format] ?? issue2.format}`;
-      }
-      case "not_multiple_of":
-        return `Neispravan broj: mora biti vi\u0161ekratnik od ${issue2.divisor}`;
-      case "unrecognized_keys":
-        return `Neprepoznat${issue2.keys.length > 1 ? "i klju\u010Devi" : " klju\u010D"}: ${joinValues(issue2.keys, ", ")}`;
-      case "invalid_key":
-        return `Neispravan klju\u010D u ${TypeDictionary[issue2.origin] ?? issue2.origin}`;
-      case "invalid_union":
-        return "Neispravan unos";
-      case "invalid_element":
-        return `Neispravna vrijednost u ${TypeDictionary[issue2.origin] ?? issue2.origin}`;
-      default:
-        return `Neispravan unos`;
-    }
-  };
-};
-var init_hr = __esm(() => {
-  init_util();
-});
-
 // node_modules/zod/v4/locales/hu.js
 function hu_default() {
   return {
-    localeError: error20()
+    localeError: error18()
   };
 }
-var error20 = () => {
+var error18 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "legyen" },
     file: { unit: "byte", verb: "legyen" },
@@ -6856,10 +6449,10 @@ function withDefiniteArticle(word) {
 }
 function hy_default() {
   return {
-    localeError: error21()
+    localeError: error19()
   };
 }
-var error21 = () => {
+var error19 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -6997,10 +6590,10 @@ var init_hy = __esm(() => {
 // node_modules/zod/v4/locales/id.js
 function id_default() {
   return {
-    localeError: error22()
+    localeError: error20()
   };
 }
-var error22 = () => {
+var error20 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "memiliki" },
     file: { unit: "byte", verb: "memiliki" },
@@ -7107,10 +6700,10 @@ var init_id = __esm(() => {
 // node_modules/zod/v4/locales/is.js
 function is_default() {
   return {
-    localeError: error23()
+    localeError: error21()
   };
 }
-var error23 = () => {
+var error21 = () => {
   const Sizable = {
     string: { unit: "stafi", verb: "a\xF0 hafa" },
     file: { unit: "b\xE6ti", verb: "a\xF0 hafa" },
@@ -7220,10 +6813,10 @@ var init_is = __esm(() => {
 // node_modules/zod/v4/locales/it.js
 function it_default() {
   return {
-    localeError: error24()
+    localeError: error22()
   };
 }
-var error24 = () => {
+var error22 = () => {
   const Sizable = {
     string: { unit: "caratteri", verb: "avere" },
     file: { unit: "byte", verb: "avere" },
@@ -7308,7 +6901,7 @@ var error24 = () => {
           return `Stringa non valida: deve includere "${_issue.includes}"`;
         if (_issue.format === "regex")
           return `Stringa non valida: deve corrispondere al pattern ${_issue.pattern}`;
-        return `Input non valido: ${FormatDictionary[_issue.format] ?? issue2.format}`;
+        return `Invalid ${FormatDictionary[_issue.format] ?? issue2.format}`;
       }
       case "not_multiple_of":
         return `Numero non valido: deve essere un multiplo di ${issue2.divisor}`;
@@ -7332,10 +6925,10 @@ var init_it = __esm(() => {
 // node_modules/zod/v4/locales/ja.js
 function ja_default() {
   return {
-    localeError: error25()
+    localeError: error23()
   };
 }
-var error25 = () => {
+var error23 = () => {
   const Sizable = {
     string: { unit: "\u6587\u5B57", verb: "\u3067\u3042\u308B" },
     file: { unit: "\u30D0\u30A4\u30C8", verb: "\u3067\u3042\u308B" },
@@ -7443,10 +7036,10 @@ var init_ja = __esm(() => {
 // node_modules/zod/v4/locales/ka.js
 function ka_default() {
   return {
-    localeError: error26()
+    localeError: error24()
   };
 }
-var error26 = () => {
+var error24 = () => {
   const Sizable = {
     string: { unit: "\u10E1\u10D8\u10DB\u10D1\u10DD\u10DA\u10DD", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
     file: { unit: "\u10D1\u10D0\u10D8\u10E2\u10D8", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
@@ -7479,9 +7072,9 @@ var error26 = () => {
     ipv6: "IPv6 \u10DB\u10D8\u10E1\u10D0\u10DB\u10D0\u10E0\u10D7\u10D8",
     cidrv4: "IPv4 \u10D3\u10D8\u10D0\u10DE\u10D0\u10D6\u10DD\u10DC\u10D8",
     cidrv6: "IPv6 \u10D3\u10D8\u10D0\u10DE\u10D0\u10D6\u10DD\u10DC\u10D8",
-    base64: "base64-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10D5\u10D4\u10DA\u10D8",
-    base64url: "base64url-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10D5\u10D4\u10DA\u10D8",
-    json_string: "JSON \u10D5\u10D4\u10DA\u10D8",
+    base64: "base64-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
+    base64url: "base64url-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
+    json_string: "JSON \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
     e164: "E.164 \u10DC\u10DD\u10DB\u10D4\u10E0\u10D8",
     jwt: "JWT",
     template_literal: "\u10E8\u10D4\u10E7\u10D5\u10D0\u10DC\u10D0"
@@ -7489,7 +7082,7 @@ var error26 = () => {
   const TypeDictionary = {
     nan: "NaN",
     number: "\u10E0\u10D8\u10EA\u10EE\u10D5\u10D8",
-    string: "\u10D5\u10D4\u10DA\u10D8",
+    string: "\u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
     boolean: "\u10D1\u10E3\u10DA\u10D4\u10D0\u10DC\u10D8",
     function: "\u10E4\u10E3\u10DC\u10E5\u10EA\u10D8\u10D0",
     array: "\u10DB\u10D0\u10E1\u10D8\u10D5\u10D8"
@@ -7527,14 +7120,14 @@ var error26 = () => {
       case "invalid_format": {
         const _issue = issue2;
         if (_issue.format === "starts_with") {
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10D8\u10EC\u10E7\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.prefix}"-\u10D8\u10D7`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10D8\u10EC\u10E7\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.prefix}"-\u10D8\u10D7`;
         }
         if (_issue.format === "ends_with")
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10DB\u10D7\u10D0\u10D5\u10E0\u10D3\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.suffix}"-\u10D8\u10D7`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10DB\u10D7\u10D0\u10D5\u10E0\u10D3\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.suffix}"-\u10D8\u10D7`;
         if (_issue.format === "includes")
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1 "${_issue.includes}"-\u10E1`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1 "${_issue.includes}"-\u10E1`;
         if (_issue.format === "regex")
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D4\u10E1\u10D0\u10D1\u10D0\u10DB\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 \u10E8\u10D0\u10D1\u10DA\u10DD\u10DC\u10E1 ${_issue.pattern}`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D4\u10E1\u10D0\u10D1\u10D0\u10DB\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 \u10E8\u10D0\u10D1\u10DA\u10DD\u10DC\u10E1 ${_issue.pattern}`;
         return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 ${FormatDictionary[_issue.format] ?? issue2.format}`;
       }
       case "not_multiple_of":
@@ -7559,10 +7152,10 @@ var init_ka = __esm(() => {
 // node_modules/zod/v4/locales/km.js
 function km_default() {
   return {
-    localeError: error27()
+    localeError: error25()
   };
 }
-var error27 = () => {
+var error25 = () => {
   const Sizable = {
     string: { unit: "\u178F\u17BD\u17A2\u1780\u17D2\u179F\u179A", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
     file: { unit: "\u1794\u17C3", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
@@ -7681,10 +7274,10 @@ var init_kh = __esm(() => {
 // node_modules/zod/v4/locales/ko.js
 function ko_default() {
   return {
-    localeError: error28()
+    localeError: error26()
   };
 }
-var error28 = () => {
+var error26 = () => {
   const Sizable = {
     string: { unit: "\uBB38\uC790", verb: "to have" },
     file: { unit: "\uBC14\uC774\uD2B8", verb: "to have" },
@@ -7806,12 +7399,12 @@ function getUnitTypeFromNumber(number2) {
 }
 function lt_default() {
   return {
-    localeError: error29()
+    localeError: error27()
   };
 }
 var capitalizeFirstCharacter = (text) => {
   return text.charAt(0).toUpperCase() + text.slice(1);
-}, error29 = () => {
+}, error27 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -8002,10 +7595,10 @@ var init_lt = __esm(() => {
 // node_modules/zod/v4/locales/mk.js
 function mk_default() {
   return {
-    localeError: error30()
+    localeError: error28()
   };
 }
-var error30 = () => {
+var error28 = () => {
   const Sizable = {
     string: { unit: "\u0437\u043D\u0430\u0446\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
     file: { unit: "\u0431\u0430\u0458\u0442\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
@@ -8115,10 +7708,10 @@ var init_mk = __esm(() => {
 // node_modules/zod/v4/locales/ms.js
 function ms_default() {
   return {
-    localeError: error31()
+    localeError: error29()
   };
 }
-var error31 = () => {
+var error29 = () => {
   const Sizable = {
     string: { unit: "aksara", verb: "mempunyai" },
     file: { unit: "bait", verb: "mempunyai" },
@@ -8226,10 +7819,10 @@ var init_ms = __esm(() => {
 // node_modules/zod/v4/locales/nl.js
 function nl_default() {
   return {
-    localeError: error32()
+    localeError: error30()
   };
 }
-var error32 = () => {
+var error30 = () => {
   const Sizable = {
     string: { unit: "tekens", verb: "heeft" },
     file: { unit: "bytes", verb: "heeft" },
@@ -8340,10 +7933,10 @@ var init_nl = __esm(() => {
 // node_modules/zod/v4/locales/no.js
 function no_default() {
   return {
-    localeError: error33()
+    localeError: error31()
   };
 }
-var error33 = () => {
+var error31 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "\xE5 ha" },
     file: { unit: "bytes", verb: "\xE5 ha" },
@@ -8452,10 +8045,10 @@ var init_no = __esm(() => {
 // node_modules/zod/v4/locales/ota.js
 function ota_default() {
   return {
-    localeError: error34()
+    localeError: error32()
   };
 }
-var error34 = () => {
+var error32 = () => {
   const Sizable = {
     string: { unit: "harf", verb: "olmal\u0131d\u0131r" },
     file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
@@ -8565,10 +8158,10 @@ var init_ota = __esm(() => {
 // node_modules/zod/v4/locales/ps.js
 function ps_default() {
   return {
-    localeError: error35()
+    localeError: error33()
   };
 }
-var error35 = () => {
+var error33 = () => {
   const Sizable = {
     string: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
     file: { unit: "\u0628\u0627\u06CC\u067C\u0633", verb: "\u0648\u0644\u0631\u064A" },
@@ -8683,10 +8276,10 @@ var init_ps = __esm(() => {
 // node_modules/zod/v4/locales/pl.js
 function pl_default() {
   return {
-    localeError: error36()
+    localeError: error34()
   };
 }
-var error36 = () => {
+var error34 = () => {
   const Sizable = {
     string: { unit: "znak\xF3w", verb: "mie\u0107" },
     file: { unit: "bajt\xF3w", verb: "mie\u0107" },
@@ -8796,10 +8389,10 @@ var init_pl = __esm(() => {
 // node_modules/zod/v4/locales/pt.js
 function pt_default() {
   return {
-    localeError: error37()
+    localeError: error35()
   };
 }
-var error37 = () => {
+var error35 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "ter" },
     file: { unit: "bytes", verb: "ter" },
@@ -8905,129 +8498,6 @@ var init_pt = __esm(() => {
   init_util();
 });
 
-// node_modules/zod/v4/locales/ro.js
-function ro_default() {
-  return {
-    localeError: error38()
-  };
-}
-var error38 = () => {
-  const Sizable = {
-    string: { unit: "caractere", verb: "s\u0103 aib\u0103" },
-    file: { unit: "octe\u021Bi", verb: "s\u0103 aib\u0103" },
-    array: { unit: "elemente", verb: "s\u0103 aib\u0103" },
-    set: { unit: "elemente", verb: "s\u0103 aib\u0103" },
-    map: { unit: "intr\u0103ri", verb: "s\u0103 aib\u0103" }
-  };
-  function getSizing(origin) {
-    return Sizable[origin] ?? null;
-  }
-  const FormatDictionary = {
-    regex: "intrare",
-    email: "adres\u0103 de email",
-    url: "URL",
-    emoji: "emoji",
-    uuid: "UUID",
-    uuidv4: "UUIDv4",
-    uuidv6: "UUIDv6",
-    nanoid: "nanoid",
-    guid: "GUID",
-    cuid: "cuid",
-    cuid2: "cuid2",
-    ulid: "ULID",
-    xid: "XID",
-    ksuid: "KSUID",
-    datetime: "dat\u0103 \u0219i or\u0103 ISO",
-    date: "dat\u0103 ISO",
-    time: "or\u0103 ISO",
-    duration: "durat\u0103 ISO",
-    ipv4: "adres\u0103 IPv4",
-    ipv6: "adres\u0103 IPv6",
-    mac: "adres\u0103 MAC",
-    cidrv4: "interval IPv4",
-    cidrv6: "interval IPv6",
-    base64: "\u0219ir codat base64",
-    base64url: "\u0219ir codat base64url",
-    json_string: "\u0219ir JSON",
-    e164: "num\u0103r E.164",
-    jwt: "JWT",
-    template_literal: "intrare"
-  };
-  const TypeDictionary = {
-    nan: "NaN",
-    string: "\u0219ir",
-    number: "num\u0103r",
-    boolean: "boolean",
-    function: "func\u021Bie",
-    array: "matrice",
-    object: "obiect",
-    undefined: "nedefinit",
-    symbol: "simbol",
-    bigint: "num\u0103r mare",
-    void: "void",
-    never: "never",
-    map: "hart\u0103",
-    set: "set"
-  };
-  return (issue2) => {
-    switch (issue2.code) {
-      case "invalid_type": {
-        const expected = TypeDictionary[issue2.expected] ?? issue2.expected;
-        const receivedType = parsedType(issue2.input);
-        const received = TypeDictionary[receivedType] ?? receivedType;
-        return `Intrare invalid\u0103: a\u0219teptat ${expected}, primit ${received}`;
-      }
-      case "invalid_value":
-        if (issue2.values.length === 1)
-          return `Intrare invalid\u0103: a\u0219teptat ${stringifyPrimitive(issue2.values[0])}`;
-        return `Op\u021Biune invalid\u0103: a\u0219teptat una dintre ${joinValues(issue2.values, "|")}`;
-      case "too_big": {
-        const adj = issue2.inclusive ? "<=" : "<";
-        const sizing = getSizing(issue2.origin);
-        if (sizing)
-          return `Prea mare: a\u0219teptat ca ${issue2.origin ?? "valoarea"} ${sizing.verb} ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "elemente"}`;
-        return `Prea mare: a\u0219teptat ca ${issue2.origin ?? "valoarea"} s\u0103 fie ${adj}${issue2.maximum.toString()}`;
-      }
-      case "too_small": {
-        const adj = issue2.inclusive ? ">=" : ">";
-        const sizing = getSizing(issue2.origin);
-        if (sizing) {
-          return `Prea mic: a\u0219teptat ca ${issue2.origin} ${sizing.verb} ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
-        }
-        return `Prea mic: a\u0219teptat ca ${issue2.origin} s\u0103 fie ${adj}${issue2.minimum.toString()}`;
-      }
-      case "invalid_format": {
-        const _issue = issue2;
-        if (_issue.format === "starts_with") {
-          return `\u0218ir invalid: trebuie s\u0103 \xEEnceap\u0103 cu "${_issue.prefix}"`;
-        }
-        if (_issue.format === "ends_with")
-          return `\u0218ir invalid: trebuie s\u0103 se termine cu "${_issue.suffix}"`;
-        if (_issue.format === "includes")
-          return `\u0218ir invalid: trebuie s\u0103 includ\u0103 "${_issue.includes}"`;
-        if (_issue.format === "regex")
-          return `\u0218ir invalid: trebuie s\u0103 se potriveasc\u0103 cu modelul ${_issue.pattern}`;
-        return `Format invalid: ${FormatDictionary[_issue.format] ?? issue2.format}`;
-      }
-      case "not_multiple_of":
-        return `Num\u0103r invalid: trebuie s\u0103 fie multiplu de ${issue2.divisor}`;
-      case "unrecognized_keys":
-        return `Chei nerecunoscute: ${joinValues(issue2.keys, ", ")}`;
-      case "invalid_key":
-        return `Cheie invalid\u0103 \xEEn ${issue2.origin}`;
-      case "invalid_union":
-        return "Intrare invalid\u0103";
-      case "invalid_element":
-        return `Valoare invalid\u0103 \xEEn ${issue2.origin}`;
-      default:
-        return `Intrare invalid\u0103`;
-    }
-  };
-};
-var init_ro = __esm(() => {
-  init_util();
-});
-
 // node_modules/zod/v4/locales/ru.js
 function getRussianPlural(count, one, few, many) {
   const absCount = Math.abs(count);
@@ -9046,10 +8516,10 @@ function getRussianPlural(count, one, few, many) {
 }
 function ru_default() {
   return {
-    localeError: error39()
+    localeError: error36()
   };
 }
-var error39 = () => {
+var error36 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -9191,10 +8661,10 @@ var init_ru = __esm(() => {
 // node_modules/zod/v4/locales/sl.js
 function sl_default() {
   return {
-    localeError: error40()
+    localeError: error37()
   };
 }
-var error40 = () => {
+var error37 = () => {
   const Sizable = {
     string: { unit: "znakov", verb: "imeti" },
     file: { unit: "bajtov", verb: "imeti" },
@@ -9304,10 +8774,10 @@ var init_sl = __esm(() => {
 // node_modules/zod/v4/locales/sv.js
 function sv_default() {
   return {
-    localeError: error41()
+    localeError: error38()
   };
 }
-var error41 = () => {
+var error38 = () => {
   const Sizable = {
     string: { unit: "tecken", verb: "att ha" },
     file: { unit: "bytes", verb: "att ha" },
@@ -9418,10 +8888,10 @@ var init_sv = __esm(() => {
 // node_modules/zod/v4/locales/ta.js
 function ta_default() {
   return {
-    localeError: error42()
+    localeError: error39()
   };
 }
-var error42 = () => {
+var error39 = () => {
   const Sizable = {
     string: { unit: "\u0B8E\u0BB4\u0BC1\u0BA4\u0BCD\u0BA4\u0BC1\u0B95\u0BCD\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
     file: { unit: "\u0BAA\u0BC8\u0B9F\u0BCD\u0B9F\u0BC1\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
@@ -9532,10 +9002,10 @@ var init_ta = __esm(() => {
 // node_modules/zod/v4/locales/th.js
 function th_default() {
   return {
-    localeError: error43()
+    localeError: error40()
   };
 }
-var error43 = () => {
+var error40 = () => {
   const Sizable = {
     string: { unit: "\u0E15\u0E31\u0E27\u0E2D\u0E31\u0E01\u0E29\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
     file: { unit: "\u0E44\u0E1A\u0E15\u0E4C", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
@@ -9646,10 +9116,10 @@ var init_th = __esm(() => {
 // node_modules/zod/v4/locales/tr.js
 function tr_default() {
   return {
-    localeError: error44()
+    localeError: error41()
   };
 }
-var error44 = () => {
+var error41 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "olmal\u0131" },
     file: { unit: "bayt", verb: "olmal\u0131" },
@@ -9755,10 +9225,10 @@ var init_tr = __esm(() => {
 // node_modules/zod/v4/locales/uk.js
 function uk_default() {
   return {
-    localeError: error45()
+    localeError: error42()
   };
 }
-var error45 = () => {
+var error42 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
     file: { unit: "\u0431\u0430\u0439\u0442\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
@@ -9875,10 +9345,10 @@ var init_ua = __esm(() => {
 // node_modules/zod/v4/locales/ur.js
 function ur_default() {
   return {
-    localeError: error46()
+    localeError: error43()
   };
 }
-var error46 = () => {
+var error43 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0648\u0641", verb: "\u06C1\u0648\u0646\u0627" },
     file: { unit: "\u0628\u0627\u0626\u0679\u0633", verb: "\u06C1\u0648\u0646\u0627" },
@@ -9989,16 +9459,15 @@ var init_ur = __esm(() => {
 // node_modules/zod/v4/locales/uz.js
 function uz_default() {
   return {
-    localeError: error47()
+    localeError: error44()
   };
 }
-var error47 = () => {
+var error44 = () => {
   const Sizable = {
     string: { unit: "belgi", verb: "bo\u2018lishi kerak" },
     file: { unit: "bayt", verb: "bo\u2018lishi kerak" },
     array: { unit: "element", verb: "bo\u2018lishi kerak" },
-    set: { unit: "element", verb: "bo\u2018lishi kerak" },
-    map: { unit: "yozuv", verb: "bo\u2018lishi kerak" }
+    set: { unit: "element", verb: "bo\u2018lishi kerak" }
   };
   function getSizing(origin) {
     return Sizable[origin] ?? null;
@@ -10103,10 +9572,10 @@ var init_uz = __esm(() => {
 // node_modules/zod/v4/locales/vi.js
 function vi_default() {
   return {
-    localeError: error48()
+    localeError: error45()
   };
 }
-var error48 = () => {
+var error45 = () => {
   const Sizable = {
     string: { unit: "k\xFD t\u1EF1", verb: "c\xF3" },
     file: { unit: "byte", verb: "c\xF3" },
@@ -10215,10 +9684,10 @@ var init_vi = __esm(() => {
 // node_modules/zod/v4/locales/zh-CN.js
 function zh_CN_default() {
   return {
-    localeError: error49()
+    localeError: error46()
   };
 }
-var error49 = () => {
+var error46 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u7B26", verb: "\u5305\u542B" },
     file: { unit: "\u5B57\u8282", verb: "\u5305\u542B" },
@@ -10328,10 +9797,10 @@ var init_zh_CN = __esm(() => {
 // node_modules/zod/v4/locales/zh-TW.js
 function zh_TW_default() {
   return {
-    localeError: error50()
+    localeError: error47()
   };
 }
-var error50 = () => {
+var error47 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u5143", verb: "\u64C1\u6709" },
     file: { unit: "\u4F4D\u5143\u7D44", verb: "\u64C1\u6709" },
@@ -10439,10 +9908,10 @@ var init_zh_TW = __esm(() => {
 // node_modules/zod/v4/locales/yo.js
 function yo_default() {
   return {
-    localeError: error51()
+    localeError: error48()
   };
 }
-var error51 = () => {
+var error48 = () => {
   const Sizable = {
     string: { unit: "\xE0mi", verb: "n\xED" },
     file: { unit: "bytes", verb: "n\xED" },
@@ -10564,7 +10033,6 @@ __export(exports_locales, {
   sv: () => sv_default,
   sl: () => sl_default,
   ru: () => ru_default,
-  ro: () => ro_default,
   pt: () => pt_default,
   ps: () => ps_default,
   pl: () => pl_default,
@@ -10584,7 +10052,6 @@ __export(exports_locales, {
   id: () => id_default,
   hy: () => hy_default,
   hu: () => hu_default,
-  hr: () => hr_default,
   he: () => he_default,
   frCA: () => fr_CA_default,
   fr: () => fr_default,
@@ -10593,7 +10060,6 @@ __export(exports_locales, {
   es: () => es_default,
   eo: () => eo_default,
   en: () => en_default,
-  el: () => el_default,
   de: () => de_default,
   da: () => da_default,
   cs: () => cs_default,
@@ -10612,7 +10078,6 @@ var init_locales = __esm(() => {
   init_cs();
   init_da();
   init_de();
-  init_el();
   init_en();
   init_eo();
   init_es();
@@ -10621,7 +10086,6 @@ var init_locales = __esm(() => {
   init_fr();
   init_fr_CA();
   init_he();
-  init_hr();
   init_hu();
   init_hy();
   init_id();
@@ -10641,7 +10105,6 @@ var init_locales = __esm(() => {
   init_ps();
   init_pl();
   init_pt();
-  init_ro();
   init_ru();
   init_sl();
   init_sv();
@@ -10702,11 +10165,11 @@ class $ZodRegistry {
 function registry() {
   return new $ZodRegistry;
 }
-var _a2, $output, $input, globalRegistry;
+var _a, $output, $input, globalRegistry;
 var init_registries = __esm(() => {
   $output = Symbol("ZodOutput");
   $input = Symbol("ZodInput");
-  (_a2 = globalThis).__zod_globalRegistry ?? (_a2.__zod_globalRegistry = registry());
+  (_a = globalThis).__zod_globalRegistry ?? (_a.__zod_globalRegistry = registry());
   globalRegistry = globalThis.__zod_globalRegistry;
 });
 
@@ -11507,7 +10970,7 @@ function _refine(Class2, fn, _params) {
   });
   return schema;
 }
-function _superRefine(fn, params) {
+function _superRefine(fn) {
   const ch = _check((payload) => {
     payload.addIssue = (issue2) => {
       if (typeof issue2 === "string") {
@@ -11524,7 +10987,7 @@ function _superRefine(fn, params) {
       }
     };
     return fn(payload.value, payload);
-  }, params);
+  });
   return ch;
 }
 function _check(fn, params) {
@@ -11660,7 +11123,7 @@ function initializeContext(params) {
   };
 }
 function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
-  var _a3;
+  var _a2;
   const def = schema._zod.def;
   const seen = ctx.seen.get(schema);
   if (seen) {
@@ -11707,8 +11170,8 @@ function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
     delete result.schema.examples;
     delete result.schema.default;
   }
-  if (ctx.io === "input" && "_prefault" in result.schema)
-    (_a3 = result.schema).default ?? (_a3.default = result.schema._prefault);
+  if (ctx.io === "input" && result.schema._prefault)
+    (_a2 = result.schema).default ?? (_a2.default = result.schema._prefault);
   delete result.schema._prefault;
   const _result = ctx.seen.get(schema);
   return _result.schema;
@@ -11885,15 +11348,10 @@ function finalize(ctx, schema) {
     result.$id = ctx.external.uri(id);
   }
   Object.assign(result, root.def ?? root.schema);
-  const rootMetaId = ctx.metadataRegistry.get(schema)?.id;
-  if (rootMetaId !== undefined && result.id === rootMetaId)
-    delete result.id;
   const defs = ctx.external?.defs ?? {};
   for (const entry of ctx.seen.entries()) {
     const seen = entry[1];
     if (seen.def && seen.defId) {
-      if (seen.def.id === seen.defId)
-        delete seen.def.id;
       defs[seen.defId] = seen.def;
     }
   }
@@ -11948,8 +11406,6 @@ function isTransforming(_schema, _ctx) {
     return isTransforming(def.keyType, ctx) || isTransforming(def.valueType, ctx);
   }
   if (def.type === "pipe") {
-    if (_schema._zod.traits.has("$ZodCodec"))
-      return true;
     return isTransforming(def.in, ctx) || isTransforming(def.out, ctx);
   }
   if (def.type === "object") {
@@ -12066,28 +11522,39 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
     json.type = "integer";
   else
     json.type = "number";
-  const exMin = typeof exclusiveMinimum === "number" && exclusiveMinimum >= (minimum ?? Number.NEGATIVE_INFINITY);
-  const exMax = typeof exclusiveMaximum === "number" && exclusiveMaximum <= (maximum ?? Number.POSITIVE_INFINITY);
-  const legacy = ctx.target === "draft-04" || ctx.target === "openapi-3.0";
-  if (exMin) {
-    if (legacy) {
+  if (typeof exclusiveMinimum === "number") {
+    if (ctx.target === "draft-04" || ctx.target === "openapi-3.0") {
       json.minimum = exclusiveMinimum;
       json.exclusiveMinimum = true;
     } else {
       json.exclusiveMinimum = exclusiveMinimum;
     }
-  } else if (typeof minimum === "number") {
-    json.minimum = minimum;
   }
-  if (exMax) {
-    if (legacy) {
+  if (typeof minimum === "number") {
+    json.minimum = minimum;
+    if (typeof exclusiveMinimum === "number" && ctx.target !== "draft-04") {
+      if (exclusiveMinimum >= minimum)
+        delete json.minimum;
+      else
+        delete json.exclusiveMinimum;
+    }
+  }
+  if (typeof exclusiveMaximum === "number") {
+    if (ctx.target === "draft-04" || ctx.target === "openapi-3.0") {
       json.maximum = exclusiveMaximum;
       json.exclusiveMaximum = true;
     } else {
       json.exclusiveMaximum = exclusiveMaximum;
     }
-  } else if (typeof maximum === "number") {
+  }
+  if (typeof maximum === "number") {
     json.maximum = maximum;
+    if (typeof exclusiveMaximum === "number" && ctx.target !== "draft-04") {
+      if (exclusiveMaximum <= maximum)
+        delete json.maximum;
+      else
+        delete json.exclusiveMaximum;
+    }
   }
   if (typeof multipleOf === "number")
     json.multipleOf = multipleOf;
@@ -12233,10 +11700,7 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
   if (typeof maximum === "number")
     json.maxItems = maximum;
   json.type = "array";
-  json.items = process2(def.element, ctx, {
-    ...params,
-    path: [...params.path, "items"]
-  });
+  json.items = process2(def.element, ctx, { ...params, path: [...params.path, "items"] });
 }, objectProcessor = (schema, ctx, _json, params) => {
   const json = _json;
   const def = schema._zod.def;
@@ -12418,8 +11882,7 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
   json.default = catchValue;
 }, pipeProcessor = (schema, ctx, _json, params) => {
   const def = schema._zod.def;
-  const inIsTransform = def.in._zod.traits.has("$ZodTransform");
-  const innerType = ctx.io === "input" ? inIsTransform ? def.out : def.in : def.out;
+  const innerType = ctx.io === "input" ? def.in._zod.def.type === "transform" ? def.out : def.in : def.out;
   process2(innerType, ctx, params);
   const seen = ctx.seen.get(schema);
   seen.ref = innerType;
@@ -12765,7 +12228,6 @@ __export(exports_core2, {
   $ZodRealError: () => $ZodRealError,
   $ZodReadonly: () => $ZodReadonly,
   $ZodPromise: () => $ZodPromise,
-  $ZodPreprocess: () => $ZodPreprocess,
   $ZodPrefault: () => $ZodPrefault,
   $ZodPipe: () => $ZodPipe,
   $ZodOptional: () => $ZodOptional,
@@ -12979,8 +12441,8 @@ var init_errors3 = __esm(() => {
   init_core2();
   init_core2();
   init_util();
-  ZodError = /* @__PURE__ */ $constructor("ZodError", initializer2);
-  ZodRealError = /* @__PURE__ */ $constructor("ZodError", initializer2, {
+  ZodError = $constructor("ZodError", initializer2);
+  ZodRealError = $constructor("ZodError", initializer2, {
     Parent: Error
   });
 });
@@ -13064,7 +12526,6 @@ __export(exports_schemas2, {
   json: () => json,
   ipv6: () => ipv62,
   ipv4: () => ipv42,
-  invertCodec: () => invertCodec,
   intersection: () => intersection,
   int64: () => int64,
   int32: () => int32,
@@ -13125,7 +12586,6 @@ __export(exports_schemas2, {
   ZodRecord: () => ZodRecord,
   ZodReadonly: () => ZodReadonly,
   ZodPromise: () => ZodPromise,
-  ZodPreprocess: () => ZodPreprocess,
   ZodPrefault: () => ZodPrefault,
   ZodPipe: () => ZodPipe,
   ZodOptional: () => ZodOptional,
@@ -13174,42 +12634,6 @@ __export(exports_schemas2, {
   ZodArray: () => ZodArray,
   ZodAny: () => ZodAny
 });
-function _installLazyMethods(inst, group, methods) {
-  const proto = Object.getPrototypeOf(inst);
-  let installed = _installedGroups.get(proto);
-  if (!installed) {
-    installed = new Set;
-    _installedGroups.set(proto, installed);
-  }
-  if (installed.has(group))
-    return;
-  installed.add(group);
-  for (const key in methods) {
-    const fn = methods[key];
-    Object.defineProperty(proto, key, {
-      configurable: true,
-      enumerable: false,
-      get() {
-        const bound = fn.bind(this);
-        Object.defineProperty(this, key, {
-          configurable: true,
-          writable: true,
-          enumerable: true,
-          value: bound
-        });
-        return bound;
-      },
-      set(v) {
-        Object.defineProperty(this, key, {
-          configurable: true,
-          writable: true,
-          enumerable: true,
-          value: v
-        });
-      }
-    });
-  }
-}
 function string2(params) {
   return _string(ZodString, params);
 }
@@ -13236,7 +12660,7 @@ function url(params) {
 }
 function httpUrl(params) {
   return _url(ZodURL, {
-    protocol: exports_regexes.httpProtocol,
+    protocol: /^https?$/,
     hostname: exports_regexes.domain,
     ...exports_util.normalizeParams(params)
   });
@@ -13433,14 +12857,6 @@ function tuple(items, _paramsOrRest, _params) {
   });
 }
 function record(keyType, valueType, params) {
-  if (!valueType || !valueType._zod) {
-    return new ZodRecord({
-      type: "record",
-      keyType: string2(),
-      valueType: keyType,
-      ...exports_util.normalizeParams(valueType)
-    });
-  }
   return new ZodRecord({
     type: "record",
     keyType,
@@ -13591,16 +13007,6 @@ function codec(in_, out, params) {
     reverseTransform: params.encode
   });
 }
-function invertCodec(codec2) {
-  const def = codec2._zod.def;
-  return new ZodCodec({
-    type: "pipe",
-    in: def.out,
-    out: def.in,
-    transform: def.reverseTransform,
-    reverseTransform: def.transform
-  });
-}
 function readonly(innerType) {
   return new ZodReadonly({
     type: "readonly",
@@ -13646,8 +13052,8 @@ function custom(fn, _params) {
 function refine(fn, _params = {}) {
   return _refine(ZodCustom, fn, _params);
 }
-function superRefine(fn, params) {
-  return _superRefine(fn, params);
+function superRefine(fn) {
+  return _superRefine(fn);
 }
 function _instanceof(cls, params = {}) {
   const inst = new ZodCustom({
@@ -13678,13 +13084,9 @@ function json(params) {
   return jsonSchema;
 }
 function preprocess(fn, schema) {
-  return new ZodPreprocess({
-    type: "pipe",
-    in: transform(fn),
-    out: schema
-  });
+  return pipe(transform(fn), schema);
 }
-var _installedGroups, ZodType, _ZodString, ZodString, ZodStringFormat, ZodEmail, ZodGUID, ZodUUID, ZodURL, ZodEmoji, ZodNanoID, ZodCUID, ZodCUID2, ZodULID, ZodXID, ZodKSUID, ZodIPv4, ZodMAC, ZodIPv6, ZodCIDRv4, ZodCIDRv6, ZodBase64, ZodBase64URL, ZodE164, ZodJWT, ZodCustomStringFormat, ZodNumber, ZodNumberFormat, ZodBoolean, ZodBigInt, ZodBigIntFormat, ZodSymbol, ZodUndefined, ZodNull, ZodAny, ZodUnknown, ZodNever, ZodVoid, ZodDate, ZodArray, ZodObject, ZodUnion, ZodXor, ZodDiscriminatedUnion, ZodIntersection, ZodTuple, ZodRecord, ZodMap, ZodSet, ZodEnum, ZodLiteral, ZodFile, ZodTransform, ZodOptional, ZodExactOptional, ZodNullable, ZodDefault, ZodPrefault, ZodNonOptional, ZodSuccess, ZodCatch, ZodNaN, ZodPipe, ZodCodec, ZodPreprocess, ZodReadonly, ZodTemplateLiteral, ZodLazy, ZodPromise, ZodFunction, ZodCustom, describe2, meta2, stringbool = (...args) => _stringbool({
+var ZodType, _ZodString, ZodString, ZodStringFormat, ZodEmail, ZodGUID, ZodUUID, ZodURL, ZodEmoji, ZodNanoID, ZodCUID, ZodCUID2, ZodULID, ZodXID, ZodKSUID, ZodIPv4, ZodMAC, ZodIPv6, ZodCIDRv4, ZodCIDRv6, ZodBase64, ZodBase64URL, ZodE164, ZodJWT, ZodCustomStringFormat, ZodNumber, ZodNumberFormat, ZodBoolean, ZodBigInt, ZodBigIntFormat, ZodSymbol, ZodUndefined, ZodNull, ZodAny, ZodUnknown, ZodNever, ZodVoid, ZodDate, ZodArray, ZodObject, ZodUnion, ZodXor, ZodDiscriminatedUnion, ZodIntersection, ZodTuple, ZodRecord, ZodMap, ZodSet, ZodEnum, ZodLiteral, ZodFile, ZodTransform, ZodOptional, ZodExactOptional, ZodNullable, ZodDefault, ZodPrefault, ZodNonOptional, ZodSuccess, ZodCatch, ZodNaN, ZodPipe, ZodCodec, ZodReadonly, ZodTemplateLiteral, ZodLazy, ZodPromise, ZodFunction, ZodCustom, describe2, meta2, stringbool = (...args) => _stringbool({
   Codec: ZodCodec,
   Boolean: ZodBoolean,
   String: ZodString
@@ -13697,7 +13099,6 @@ var init_schemas2 = __esm(() => {
   init_checks2();
   init_iso();
   init_parse2();
-  _installedGroups = /* @__PURE__ */ new WeakMap;
   ZodType = /* @__PURE__ */ $constructor("ZodType", (inst, def) => {
     $ZodType.init(inst, def);
     Object.assign(inst["~standard"], {
@@ -13710,6 +13111,23 @@ var init_schemas2 = __esm(() => {
     inst.def = def;
     inst.type = def.type;
     Object.defineProperty(inst, "_def", { value: def });
+    inst.check = (...checks2) => {
+      return inst.clone(exports_util.mergeDefs(def, {
+        checks: [
+          ...def.checks ?? [],
+          ...checks2.map((ch) => typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch)
+        ]
+      }), {
+        parent: true
+      });
+    };
+    inst.with = inst.check;
+    inst.clone = (def2, params) => clone(inst, def2, params);
+    inst.brand = () => inst;
+    inst.register = (reg, meta2) => {
+      reg.add(inst, meta2);
+      return inst;
+    };
     inst.parse = (data, params) => parse3(inst, data, params, { callee: inst.parse });
     inst.safeParse = (data, params) => safeParse2(inst, data, params);
     inst.parseAsync = async (data, params) => parseAsync2(inst, data, params, { callee: inst.parseAsync });
@@ -13723,108 +13141,45 @@ var init_schemas2 = __esm(() => {
     inst.safeDecode = (data, params) => safeDecode2(inst, data, params);
     inst.safeEncodeAsync = async (data, params) => safeEncodeAsync2(inst, data, params);
     inst.safeDecodeAsync = async (data, params) => safeDecodeAsync2(inst, data, params);
-    _installLazyMethods(inst, "ZodType", {
-      check(...chks) {
-        const def2 = this.def;
-        return this.clone(exports_util.mergeDefs(def2, {
-          checks: [
-            ...def2.checks ?? [],
-            ...chks.map((ch) => typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch)
-          ]
-        }), { parent: true });
-      },
-      with(...chks) {
-        return this.check(...chks);
-      },
-      clone(def2, params) {
-        return clone(this, def2, params);
-      },
-      brand() {
-        return this;
-      },
-      register(reg, meta2) {
-        reg.add(this, meta2);
-        return this;
-      },
-      refine(check, params) {
-        return this.check(refine(check, params));
-      },
-      superRefine(refinement, params) {
-        return this.check(superRefine(refinement, params));
-      },
-      overwrite(fn) {
-        return this.check(_overwrite(fn));
-      },
-      optional() {
-        return optional(this);
-      },
-      exactOptional() {
-        return exactOptional(this);
-      },
-      nullable() {
-        return nullable(this);
-      },
-      nullish() {
-        return optional(nullable(this));
-      },
-      nonoptional(params) {
-        return nonoptional(this, params);
-      },
-      array() {
-        return array(this);
-      },
-      or(arg) {
-        return union([this, arg]);
-      },
-      and(arg) {
-        return intersection(this, arg);
-      },
-      transform(tx) {
-        return pipe(this, transform(tx));
-      },
-      default(d) {
-        return _default2(this, d);
-      },
-      prefault(d) {
-        return prefault(this, d);
-      },
-      catch(params) {
-        return _catch2(this, params);
-      },
-      pipe(target) {
-        return pipe(this, target);
-      },
-      readonly() {
-        return readonly(this);
-      },
-      describe(description) {
-        const cl = this.clone();
-        globalRegistry.add(cl, { description });
-        return cl;
-      },
-      meta(...args) {
-        if (args.length === 0)
-          return globalRegistry.get(this);
-        const cl = this.clone();
-        globalRegistry.add(cl, args[0]);
-        return cl;
-      },
-      isOptional() {
-        return this.safeParse(undefined).success;
-      },
-      isNullable() {
-        return this.safeParse(null).success;
-      },
-      apply(fn) {
-        return fn(this);
-      }
-    });
+    inst.refine = (check, params) => inst.check(refine(check, params));
+    inst.superRefine = (refinement) => inst.check(superRefine(refinement));
+    inst.overwrite = (fn) => inst.check(_overwrite(fn));
+    inst.optional = () => optional(inst);
+    inst.exactOptional = () => exactOptional(inst);
+    inst.nullable = () => nullable(inst);
+    inst.nullish = () => optional(nullable(inst));
+    inst.nonoptional = (params) => nonoptional(inst, params);
+    inst.array = () => array(inst);
+    inst.or = (arg) => union([inst, arg]);
+    inst.and = (arg) => intersection(inst, arg);
+    inst.transform = (tx) => pipe(inst, transform(tx));
+    inst.default = (def2) => _default2(inst, def2);
+    inst.prefault = (def2) => prefault(inst, def2);
+    inst.catch = (params) => _catch2(inst, params);
+    inst.pipe = (target) => pipe(inst, target);
+    inst.readonly = () => readonly(inst);
+    inst.describe = (description) => {
+      const cl = inst.clone();
+      globalRegistry.add(cl, { description });
+      return cl;
+    };
     Object.defineProperty(inst, "description", {
       get() {
         return globalRegistry.get(inst)?.description;
       },
       configurable: true
     });
+    inst.meta = (...args) => {
+      if (args.length === 0) {
+        return globalRegistry.get(inst);
+      }
+      const cl = inst.clone();
+      globalRegistry.add(cl, args[0]);
+      return cl;
+    };
+    inst.isOptional = () => inst.safeParse(undefined).success;
+    inst.isNullable = () => inst.safeParse(null).success;
+    inst.apply = (fn) => fn(inst);
     return inst;
   });
   _ZodString = /* @__PURE__ */ $constructor("_ZodString", (inst, def) => {
@@ -13835,53 +13190,21 @@ var init_schemas2 = __esm(() => {
     inst.format = bag.format ?? null;
     inst.minLength = bag.minimum ?? null;
     inst.maxLength = bag.maximum ?? null;
-    _installLazyMethods(inst, "_ZodString", {
-      regex(...args) {
-        return this.check(_regex(...args));
-      },
-      includes(...args) {
-        return this.check(_includes(...args));
-      },
-      startsWith(...args) {
-        return this.check(_startsWith(...args));
-      },
-      endsWith(...args) {
-        return this.check(_endsWith(...args));
-      },
-      min(...args) {
-        return this.check(_minLength(...args));
-      },
-      max(...args) {
-        return this.check(_maxLength(...args));
-      },
-      length(...args) {
-        return this.check(_length(...args));
-      },
-      nonempty(...args) {
-        return this.check(_minLength(1, ...args));
-      },
-      lowercase(params) {
-        return this.check(_lowercase(params));
-      },
-      uppercase(params) {
-        return this.check(_uppercase(params));
-      },
-      trim() {
-        return this.check(_trim());
-      },
-      normalize(...args) {
-        return this.check(_normalize(...args));
-      },
-      toLowerCase() {
-        return this.check(_toLowerCase());
-      },
-      toUpperCase() {
-        return this.check(_toUpperCase());
-      },
-      slugify() {
-        return this.check(_slugify());
-      }
-    });
+    inst.regex = (...args) => inst.check(_regex(...args));
+    inst.includes = (...args) => inst.check(_includes(...args));
+    inst.startsWith = (...args) => inst.check(_startsWith(...args));
+    inst.endsWith = (...args) => inst.check(_endsWith(...args));
+    inst.min = (...args) => inst.check(_minLength(...args));
+    inst.max = (...args) => inst.check(_maxLength(...args));
+    inst.length = (...args) => inst.check(_length(...args));
+    inst.nonempty = (...args) => inst.check(_minLength(1, ...args));
+    inst.lowercase = (params) => inst.check(_lowercase(params));
+    inst.uppercase = (params) => inst.check(_uppercase(params));
+    inst.trim = () => inst.check(_trim());
+    inst.normalize = (...args) => inst.check(_normalize(...args));
+    inst.toLowerCase = () => inst.check(_toLowerCase());
+    inst.toUpperCase = () => inst.check(_toUpperCase());
+    inst.slugify = () => inst.check(_slugify());
   });
   ZodString = /* @__PURE__ */ $constructor("ZodString", (inst, def) => {
     $ZodString.init(inst, def);
@@ -14006,53 +13329,21 @@ var init_schemas2 = __esm(() => {
     $ZodNumber.init(inst, def);
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => numberProcessor(inst, ctx, json, params);
-    _installLazyMethods(inst, "ZodNumber", {
-      gt(value, params) {
-        return this.check(_gt(value, params));
-      },
-      gte(value, params) {
-        return this.check(_gte(value, params));
-      },
-      min(value, params) {
-        return this.check(_gte(value, params));
-      },
-      lt(value, params) {
-        return this.check(_lt(value, params));
-      },
-      lte(value, params) {
-        return this.check(_lte(value, params));
-      },
-      max(value, params) {
-        return this.check(_lte(value, params));
-      },
-      int(params) {
-        return this.check(int(params));
-      },
-      safe(params) {
-        return this.check(int(params));
-      },
-      positive(params) {
-        return this.check(_gt(0, params));
-      },
-      nonnegative(params) {
-        return this.check(_gte(0, params));
-      },
-      negative(params) {
-        return this.check(_lt(0, params));
-      },
-      nonpositive(params) {
-        return this.check(_lte(0, params));
-      },
-      multipleOf(value, params) {
-        return this.check(_multipleOf(value, params));
-      },
-      step(value, params) {
-        return this.check(_multipleOf(value, params));
-      },
-      finite() {
-        return this;
-      }
-    });
+    inst.gt = (value, params) => inst.check(_gt(value, params));
+    inst.gte = (value, params) => inst.check(_gte(value, params));
+    inst.min = (value, params) => inst.check(_gte(value, params));
+    inst.lt = (value, params) => inst.check(_lt(value, params));
+    inst.lte = (value, params) => inst.check(_lte(value, params));
+    inst.max = (value, params) => inst.check(_lte(value, params));
+    inst.int = (params) => inst.check(int(params));
+    inst.safe = (params) => inst.check(int(params));
+    inst.positive = (params) => inst.check(_gt(0, params));
+    inst.nonnegative = (params) => inst.check(_gte(0, params));
+    inst.negative = (params) => inst.check(_lt(0, params));
+    inst.nonpositive = (params) => inst.check(_lte(0, params));
+    inst.multipleOf = (value, params) => inst.check(_multipleOf(value, params));
+    inst.step = (value, params) => inst.check(_multipleOf(value, params));
+    inst.finite = () => inst;
     const bag = inst._zod.bag;
     inst.minValue = Math.max(bag.minimum ?? Number.NEGATIVE_INFINITY, bag.exclusiveMinimum ?? Number.NEGATIVE_INFINITY) ?? null;
     inst.maxValue = Math.min(bag.maximum ?? Number.POSITIVE_INFINITY, bag.exclusiveMaximum ?? Number.POSITIVE_INFINITY) ?? null;
@@ -14145,23 +13436,11 @@ var init_schemas2 = __esm(() => {
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => arrayProcessor(inst, ctx, json, params);
     inst.element = def.element;
-    _installLazyMethods(inst, "ZodArray", {
-      min(n, params) {
-        return this.check(_minLength(n, params));
-      },
-      nonempty(params) {
-        return this.check(_minLength(1, params));
-      },
-      max(n, params) {
-        return this.check(_maxLength(n, params));
-      },
-      length(n, params) {
-        return this.check(_length(n, params));
-      },
-      unwrap() {
-        return this.element;
-      }
-    });
+    inst.min = (minLength, params) => inst.check(_minLength(minLength, params));
+    inst.nonempty = (params) => inst.check(_minLength(1, params));
+    inst.max = (maxLength, params) => inst.check(_maxLength(maxLength, params));
+    inst.length = (len, params) => inst.check(_length(len, params));
+    inst.unwrap = () => inst.element;
   });
   ZodObject = /* @__PURE__ */ $constructor("ZodObject", (inst, def) => {
     $ZodObjectJIT.init(inst, def);
@@ -14170,47 +13449,23 @@ var init_schemas2 = __esm(() => {
     exports_util.defineLazy(inst, "shape", () => {
       return def.shape;
     });
-    _installLazyMethods(inst, "ZodObject", {
-      keyof() {
-        return _enum2(Object.keys(this._zod.def.shape));
-      },
-      catchall(catchall) {
-        return this.clone({ ...this._zod.def, catchall });
-      },
-      passthrough() {
-        return this.clone({ ...this._zod.def, catchall: unknown() });
-      },
-      loose() {
-        return this.clone({ ...this._zod.def, catchall: unknown() });
-      },
-      strict() {
-        return this.clone({ ...this._zod.def, catchall: never() });
-      },
-      strip() {
-        return this.clone({ ...this._zod.def, catchall: undefined });
-      },
-      extend(incoming) {
-        return exports_util.extend(this, incoming);
-      },
-      safeExtend(incoming) {
-        return exports_util.safeExtend(this, incoming);
-      },
-      merge(other) {
-        return exports_util.merge(this, other);
-      },
-      pick(mask) {
-        return exports_util.pick(this, mask);
-      },
-      omit(mask) {
-        return exports_util.omit(this, mask);
-      },
-      partial(...args) {
-        return exports_util.partial(ZodOptional, this, args[0]);
-      },
-      required(...args) {
-        return exports_util.required(ZodNonOptional, this, args[0]);
-      }
-    });
+    inst.keyof = () => _enum2(Object.keys(inst._zod.def.shape));
+    inst.catchall = (catchall) => inst.clone({ ...inst._zod.def, catchall });
+    inst.passthrough = () => inst.clone({ ...inst._zod.def, catchall: unknown() });
+    inst.loose = () => inst.clone({ ...inst._zod.def, catchall: unknown() });
+    inst.strict = () => inst.clone({ ...inst._zod.def, catchall: never() });
+    inst.strip = () => inst.clone({ ...inst._zod.def, catchall: undefined });
+    inst.extend = (incoming) => {
+      return exports_util.extend(inst, incoming);
+    };
+    inst.safeExtend = (incoming) => {
+      return exports_util.safeExtend(inst, incoming);
+    };
+    inst.merge = (other) => exports_util.merge(inst, other);
+    inst.pick = (mask) => exports_util.pick(inst, mask);
+    inst.omit = (mask) => exports_util.omit(inst, mask);
+    inst.partial = (...args) => exports_util.partial(ZodOptional, inst, args[0]);
+    inst.required = (...args) => exports_util.required(ZodNonOptional, inst, args[0]);
   });
   ZodUnion = /* @__PURE__ */ $constructor("ZodUnion", (inst, def) => {
     $ZodUnion.init(inst, def);
@@ -14354,12 +13609,10 @@ var init_schemas2 = __esm(() => {
       if (output instanceof Promise) {
         return output.then((output2) => {
           payload.value = output2;
-          payload.fallback = true;
           return payload;
         });
       }
       payload.value = output;
-      payload.fallback = true;
       return payload;
     };
   });
@@ -14428,10 +13681,6 @@ var init_schemas2 = __esm(() => {
   ZodCodec = /* @__PURE__ */ $constructor("ZodCodec", (inst, def) => {
     ZodPipe.init(inst, def);
     $ZodCodec.init(inst, def);
-  });
-  ZodPreprocess = /* @__PURE__ */ $constructor("ZodPreprocess", (inst, def) => {
-    ZodPipe.init(inst, def);
-    $ZodPreprocess.init(inst, def);
   });
   ZodReadonly = /* @__PURE__ */ $constructor("ZodReadonly", (inst, def) => {
     $ZodReadonly.init(inst, def);
@@ -14814,6 +14063,12 @@ function convertBaseSchema(schema, ctx) {
     default:
       throw new Error(`Unsupported type: ${type}`);
   }
+  if (schema.description) {
+    zodSchema = zodSchema.describe(schema.description);
+  }
+  if (schema.default !== undefined) {
+    zodSchema = zodSchema.default(schema.default);
+  }
   return zodSchema;
 }
 function convertSchema(schema, ctx) {
@@ -14850,9 +14105,6 @@ function convertSchema(schema, ctx) {
   if (schema.readOnly === true) {
     baseSchema = z.readonly(baseSchema);
   }
-  if (schema.default !== undefined) {
-    baseSchema = baseSchema.default(schema.default);
-  }
   const extraMeta = {};
   const coreMetadataKeys = ["$id", "id", "$comment", "$anchor", "$vocabulary", "$dynamicRef", "$dynamicAnchor"];
   for (const key of coreMetadataKeys) {
@@ -14874,32 +14126,23 @@ function convertSchema(schema, ctx) {
   if (Object.keys(extraMeta).length > 0) {
     ctx.registry.add(baseSchema, extraMeta);
   }
-  if (schema.description) {
-    baseSchema = baseSchema.describe(schema.description);
-  }
   return baseSchema;
 }
 function fromJSONSchema(schema, params) {
   if (typeof schema === "boolean") {
     return schema ? z.any() : z.never();
   }
-  let normalized;
-  try {
-    normalized = JSON.parse(JSON.stringify(schema));
-  } catch {
-    throw new Error("fromJSONSchema input is not valid JSON (possibly cyclic); use $defs/$ref for recursive schemas");
-  }
-  const version2 = detectVersion(normalized, params?.defaultTarget);
-  const defs = normalized.$defs || normalized.definitions || {};
+  const version2 = detectVersion(schema, params?.defaultTarget);
+  const defs = schema.$defs || schema.definitions || {};
   const ctx = {
     version: version2,
     defs,
     refs: new Map,
     processing: new Set,
-    rootSchema: normalized,
+    rootSchema: schema,
     registry: params?.registry ?? globalRegistry
   };
-  return convertSchema(normalized, ctx);
+  return convertSchema(schema, ctx);
 }
 var z, RECOGNIZED_KEYS;
 var init_from_json_schema = __esm(() => {
@@ -14912,7 +14155,7 @@ var init_from_json_schema = __esm(() => {
     ...exports_checks2,
     iso: exports_iso
   };
-  RECOGNIZED_KEYS = /* @__PURE__ */ new Set([
+  RECOGNIZED_KEYS = new Set([
     "$schema",
     "$ref",
     "$defs",
@@ -15104,7 +14347,6 @@ __export(exports_external, {
   iso: () => exports_iso,
   ipv6: () => ipv62,
   ipv4: () => ipv42,
-  invertCodec: () => invertCodec,
   intersection: () => intersection,
   int64: () => int64,
   int32: () => int32,
@@ -15183,7 +14425,6 @@ __export(exports_external, {
   ZodRealError: () => ZodRealError,
   ZodReadonly: () => ZodReadonly,
   ZodPromise: () => ZodPromise,
-  ZodPreprocess: () => ZodPreprocess,
   ZodPrefault: () => ZodPrefault,
   ZodPipe: () => ZodPipe,
   ZodOptional: () => ZodOptional,
@@ -15388,11 +14629,11 @@ var init_telemetry = __esm(() => {
     gatePassed(sessionId, gate, taskId) {
       _internals2.emit("gate_passed", { sessionId, gate, taskId });
     },
-    gateParseError(taskId, error52) {
+    gateParseError(taskId, error49) {
       _internals2.emit("gate_parse_error", {
         taskId,
-        errorName: error52.name,
-        errorMessage: error52.message.slice(0, 200)
+        errorName: error49.name,
+        errorMessage: error49.message.slice(0, 200)
       });
     },
     gateFailed(sessionId, gate, taskId, reason) {
@@ -15502,9 +14743,9 @@ async function computeSpecHash(directory) {
   try {
     const content = await readFile2(specPath, "utf-8");
     hash2 = createHash("sha256").update(content, "utf-8").digest("hex");
-  } catch (error52) {
-    if (error52.code !== "ENOENT") {
-      throw error52;
+  } catch (error49) {
+    if (error49.code !== "ENOENT") {
+      throw error49;
     }
   }
   return hash2;
@@ -16010,9 +15251,9 @@ async function retryCasWithBackoff(directory, eventInput, options) {
         expectedHash: currentExpected,
         planHashAfter: options.planHashAfter
       });
-    } catch (error52) {
-      if (!(error52 instanceof LedgerStaleWriterError) || attempt >= maxRetries) {
-        throw error52;
+    } catch (error49) {
+      if (!(error49 instanceof LedgerStaleWriterError) || attempt >= maxRetries) {
+        throw error49;
       }
       attempt++;
       const base = Math.min(CAS_BACKOFF_START_MS * 2 ** (attempt - 1), CAS_BACKOFF_CAP_MS);
@@ -16044,8 +15285,8 @@ async function loadPlanJsonOnly(directory) {
       const parsed = JSON.parse(planJsonContent);
       const validated = PlanSchema.parse(parsed);
       return validated;
-    } catch (error52) {
-      warn(`Plan validation failed for .swarm/plan.json: ${error52 instanceof Error ? error52.message : String(error52)}`);
+    } catch (error49) {
+      warn(`Plan validation failed for .swarm/plan.json: ${error49 instanceof Error ? error49.message : String(error49)}`);
     }
   }
   return null;
@@ -16246,8 +15487,8 @@ async function loadPlan(directory) {
           }
         }
         return validated;
-      } catch (error52) {
-        warn(`[loadPlan] plan.json validation failed: ${error52 instanceof Error ? error52.message : String(error52)}. Attempting rebuild from ledger. If rebuild fails, check .swarm/SWARM_PLAN.md for a checkpoint.`);
+      } catch (error49) {
+        warn(`[loadPlan] plan.json validation failed: ${error49 instanceof Error ? error49.message : String(error49)}. Attempting rebuild from ledger. If rebuild fails, check .swarm/SWARM_PLAN.md for a checkpoint.`);
         let rawPlanId = null;
         try {
           const rawParsed = JSON.parse(planJsonContent);
@@ -16575,11 +15816,11 @@ async function savePlan(directory, plan, options) {
             }
           });
         }
-      } catch (error52) {
-        if (error52 instanceof LedgerStaleWriterError) {
-          throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error52.message}. Please retry the operation.`);
+      } catch (error49) {
+        if (error49 instanceof LedgerStaleWriterError) {
+          throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error49.message}. Please retry the operation.`);
         }
-        throw error52;
+        throw error49;
       }
     }
     try {
@@ -16617,11 +15858,11 @@ async function savePlan(directory, plan, options) {
           }
         }
       }
-    } catch (error52) {
-      if (error52 instanceof LedgerStaleWriterError) {
-        throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error52.message}. Please retry the operation.`);
+    } catch (error49) {
+      if (error49 instanceof LedgerStaleWriterError) {
+        throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error49.message}. Please retry the operation.`);
       }
-      throw error52;
+      throw error49;
     }
   }
   const SNAPSHOT_INTERVAL = 50;
@@ -17135,11 +16376,11 @@ async function handleAcknowledgeSpecDriftCommand(directory, _args, acknowledgedB
   let stalenessContent;
   try {
     stalenessContent = await fsPromises3.readFile(specStalenessPath, "utf-8");
-  } catch (error52) {
-    if (error52?.code === "ENOENT") {
+  } catch (error49) {
+    if (error49?.code === "ENOENT") {
       return "No spec drift detected.";
     }
-    throw error52;
+    throw error49;
   }
   let stalenessData;
   try {
@@ -18915,10 +18156,10 @@ function loadRawConfigFromPath(configPath) {
       fileExisted: true,
       hadError: false
     };
-  } catch (error52) {
-    const isFileNotFoundError = error52 instanceof Error && "code" in error52 && error52.code === "ENOENT";
+  } catch (error49) {
+    const isFileNotFoundError = error49 instanceof Error && "code" in error49 && error49.code === "ENOENT";
     if (!isFileNotFoundError) {
-      const errorMessage = error52 instanceof Error ? error52.message : String(error52);
+      const errorMessage = error49 instanceof Error ? error49.message : String(error49);
       console.warn(`[opencode-swarm] \u26A0\uFE0F CONFIG LOAD FAILURE \u2014 config exists at ${configPath} but could not be loaded: ${errorMessage}`);
       console.warn("[opencode-swarm] \u26A0\uFE0F SECURITY: Config load failed. Falling back to safe defaults with guardrails ENABLED.");
       return { config: null, fileExisted: true, hadError: true };
@@ -19446,7 +18687,7 @@ var require_polyfills = __commonJS((exports, module) => {
           return ret;
         };
       } else if (fs4.futimes) {
-        fs4.lutimes = function(_a3, _b, _c, cb) {
+        fs4.lutimes = function(_a2, _b, _c, cb) {
           if (cb)
             process.nextTick(cb);
         };
@@ -20142,12 +19383,12 @@ var require_retry_operation = __commonJS((exports, module) => {
     var mainError = null;
     var mainErrorCount = 0;
     for (var i = 0;i < this._errors.length; i++) {
-      var error52 = this._errors[i];
-      var message = error52.message;
+      var error49 = this._errors[i];
+      var message = error49.message;
       var count = (counts[message] || 0) + 1;
       counts[message] = count;
       if (count >= mainErrorCount) {
-        mainError = error52;
+        mainError = error49;
         mainErrorCount = count;
       }
     }
@@ -20999,8 +20240,8 @@ function validateProjectRoot(directory) {
               hasProjectIndicator = true;
               break;
             }
-          } catch (error52) {
-            if (error52 instanceof Error && "code" in error52 && error52.code === "ENOENT") {} else {
+          } catch (error49) {
+            if (error49 instanceof Error && "code" in error49 && error49.code === "ENOENT") {} else {
               hasProjectIndicator = true;
               break;
             }
@@ -21011,9 +20252,9 @@ function validateProjectRoot(directory) {
           throw new Error(`Cannot write evidence in "${resolved}" \u2014 parent directory "${parent}" already contains a .swarm/ folder. Evidence must be written to the project root.`);
         }
       }
-    } catch (error52) {
-      if (error52 instanceof Error && error52.message.startsWith("Cannot write evidence")) {
-        throw error52;
+    } catch (error49) {
+      if (error49 instanceof Error && error49.message.startsWith("Cannot write evidence")) {
+        throw error49;
       }
     }
     current = parent;
@@ -21033,8 +20274,8 @@ async function saveEvidence(directory, taskId, evidence) {
       try {
         const parsed = JSON.parse(existingContent);
         bundle = EvidenceBundleSchema.parse(parsed);
-      } catch (error52) {
-        warn(`Existing evidence bundle invalid for task ${sanitizedTaskId}, creating new: ${error52 instanceof Error ? error52.message : String(error52)}`);
+      } catch (error49) {
+        warn(`Existing evidence bundle invalid for task ${sanitizedTaskId}, creating new: ${error49 instanceof Error ? error49.message : String(error49)}`);
         const now = new Date().toISOString();
         bundle = {
           schema_version: "1.0.0",
@@ -21073,11 +20314,11 @@ async function saveEvidence(directory, taskId, evidence) {
     try {
       await bunWrite(tempPath, bundleJson);
       await fs4.rename(tempPath, evidencePath);
-    } catch (error52) {
+    } catch (error49) {
       try {
         rmSync(tempPath, { force: true });
       } catch {}
-      throw error52;
+      throw error49;
     }
     return updatedBundle;
   });
@@ -21143,18 +20384,18 @@ async function loadEvidence(directory, taskId) {
         warn(`Evidence lock failed during flat-retrospective write-back for task ${sanitizedTaskId}: ${lockErr instanceof Error ? lockErr.message : String(lockErr)}`);
       }
       return { status: "found", bundle: validated };
-    } catch (error52) {
-      warn(`Wrapped flat retrospective failed validation for task ${sanitizedTaskId}: ${error52 instanceof Error ? error52.message : String(error52)}`);
-      const errors3 = error52 instanceof ZodError ? error52.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error52 instanceof Error ? error52.message : String(error52)];
+    } catch (error49) {
+      warn(`Wrapped flat retrospective failed validation for task ${sanitizedTaskId}: ${error49 instanceof Error ? error49.message : String(error49)}`);
+      const errors3 = error49 instanceof ZodError ? error49.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error49 instanceof Error ? error49.message : String(error49)];
       return { status: "invalid_schema", errors: errors3 };
     }
   }
   try {
     const validated = EvidenceBundleSchema.parse(parsed);
     return { status: "found", bundle: validated };
-  } catch (error52) {
-    warn(`Evidence bundle validation failed for task ${sanitizedTaskId}: ${error52 instanceof Error ? error52.message : String(error52)}`);
-    const errors3 = error52 instanceof ZodError ? error52.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error52 instanceof Error ? error52.message : String(error52)];
+  } catch (error49) {
+    warn(`Evidence bundle validation failed for task ${sanitizedTaskId}: ${error49 instanceof Error ? error49.message : String(error49)}`);
+    const errors3 = error49 instanceof ZodError ? error49.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error49 instanceof Error ? error49.message : String(error49)];
     return { status: "invalid_schema", errors: errors3 };
   }
 }
@@ -21181,9 +20422,9 @@ async function listEvidenceTaskIds(directory) {
       }
       sanitizeTaskId2(entry);
       taskIds.push(entry);
-    } catch (error52) {
-      if (error52 instanceof Error && !error52.message.startsWith("Invalid task ID")) {
-        warn(`Error reading evidence entry '${entry}': ${error52.message}`);
+    } catch (error49) {
+      if (error49 instanceof Error && !error49.message.startsWith("Invalid task ID")) {
+        warn(`Error reading evidence entry '${entry}': ${error49.message}`);
       }
     }
   }
@@ -21201,8 +20442,8 @@ async function deleteEvidence(directory, taskId) {
   try {
     rmSync(evidenceDir, { recursive: true, force: true });
     return true;
-  } catch (error52) {
-    warn(`Failed to delete evidence for task ${sanitizedTaskId}: ${error52 instanceof Error ? error52.message : String(error52)}`);
+  } catch (error49) {
+    warn(`Failed to delete evidence for task ${sanitizedTaskId}: ${error49 instanceof Error ? error49.message : String(error49)}`);
     return false;
   }
 }
@@ -22815,12 +22056,12 @@ async function handleBrainstormCommand(_directory, args) {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/core/core.js
 function $constructor2(name, initializer3, params) {
   function init(inst, def) {
-    var _a3;
+    var _a2;
     Object.defineProperty(inst, "_zod", {
       value: inst._zod ?? {},
       enumerable: false
     });
-    (_a3 = inst._zod).traits ?? (_a3.traits = new Set);
+    (_a2 = inst._zod).traits ?? (_a2.traits = new Set);
     inst._zod.traits.add(name);
     initializer3(inst, def);
     for (const k in _.prototype) {
@@ -22836,10 +22077,10 @@ function $constructor2(name, initializer3, params) {
   }
   Object.defineProperty(Definition, "name", { value: name });
   function _(def) {
-    var _a3;
+    var _a2;
     const inst = params?.Parent ? new Definition : this;
     init(inst, def);
-    (_a3 = inst._zod).deferred ?? (_a3.deferred = []);
+    (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
     for (const fn of inst._zod.deferred) {
       fn();
     }
@@ -23342,8 +22583,8 @@ function aborted2(x, startIndex = 0) {
 }
 function prefixIssues2(path9, issues) {
   return issues.map((iss) => {
-    var _a3;
-    (_a3 = iss).path ?? (_a3.path = []);
+    var _a2;
+    (_a2 = iss).path ?? (_a2.path = []);
     iss.path.unshift(path9);
     return iss;
   });
@@ -23513,10 +22754,10 @@ var init_util2 = __esm(() => {
 });
 
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/core/errors.js
-function flattenError2(error52, mapper = (issue3) => issue3.message) {
+function flattenError2(error49, mapper = (issue3) => issue3.message) {
   const fieldErrors = {};
   const formErrors = [];
-  for (const sub of error52.issues) {
+  for (const sub of error49.issues) {
     if (sub.path.length > 0) {
       fieldErrors[sub.path[0]] = fieldErrors[sub.path[0]] || [];
       fieldErrors[sub.path[0]].push(mapper(sub));
@@ -23526,13 +22767,13 @@ function flattenError2(error52, mapper = (issue3) => issue3.message) {
   }
   return { formErrors, fieldErrors };
 }
-function formatError2(error52, _mapper) {
+function formatError2(error49, _mapper) {
   const mapper = _mapper || function(issue3) {
     return issue3.message;
   };
   const fieldErrors = { _errors: [] };
-  const processError = (error53) => {
-    for (const issue3 of error53.issues) {
+  const processError = (error50) => {
+    for (const issue3 of error50.issues) {
       if (issue3.code === "invalid_union" && issue3.errors.length) {
         issue3.errors.map((issues) => processError({ issues }));
       } else if (issue3.code === "invalid_key") {
@@ -23559,17 +22800,17 @@ function formatError2(error52, _mapper) {
       }
     }
   };
-  processError(error52);
+  processError(error49);
   return fieldErrors;
 }
-function treeifyError2(error52, _mapper) {
+function treeifyError2(error49, _mapper) {
   const mapper = _mapper || function(issue3) {
     return issue3.message;
   };
   const result = { errors: [] };
-  const processError = (error53, path9 = []) => {
-    var _a3, _b;
-    for (const issue3 of error53.issues) {
+  const processError = (error50, path9 = []) => {
+    var _a2, _b;
+    for (const issue3 of error50.issues) {
       if (issue3.code === "invalid_union" && issue3.errors.length) {
         issue3.errors.map((issues) => processError({ issues }, issue3.path));
       } else if (issue3.code === "invalid_key") {
@@ -23589,7 +22830,7 @@ function treeifyError2(error52, _mapper) {
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
             curr.properties ?? (curr.properties = {});
-            (_a3 = curr.properties)[el] ?? (_a3[el] = { errors: [] });
+            (_a2 = curr.properties)[el] ?? (_a2[el] = { errors: [] });
             curr = curr.properties[el];
           } else {
             curr.items ?? (curr.items = []);
@@ -23604,7 +22845,7 @@ function treeifyError2(error52, _mapper) {
       }
     }
   };
-  processError(error52);
+  processError(error49);
   return result;
 }
 function toDotPath2(_path) {
@@ -23625,9 +22866,9 @@ function toDotPath2(_path) {
   }
   return segs.join("");
 }
-function prettifyError2(error52) {
+function prettifyError2(error49) {
   const lines = [];
-  const issues = [...error52.issues].sort((a, b) => (a.path ?? []).length - (b.path ?? []).length);
+  const issues = [...error49.issues].sort((a, b) => (a.path ?? []).length - (b.path ?? []).length);
   for (const issue3 of issues) {
     lines.push(`\u2716 ${issue3.message}`);
     if (issue3.path?.length)
@@ -23904,10 +23145,10 @@ var init_checks3 = __esm(() => {
   init_regexes2();
   init_util2();
   $ZodCheck2 = /* @__PURE__ */ $constructor2("$ZodCheck", (inst, def) => {
-    var _a3;
+    var _a2;
     inst._zod ?? (inst._zod = {});
     inst._zod.def = def;
-    (_a3 = inst._zod).onattach ?? (_a3.onattach = []);
+    (_a2 = inst._zod).onattach ?? (_a2.onattach = []);
   });
   numericOriginMap2 = {
     number: "number",
@@ -23973,8 +23214,8 @@ var init_checks3 = __esm(() => {
   $ZodCheckMultipleOf2 = /* @__PURE__ */ $constructor2("$ZodCheckMultipleOf", (inst, def) => {
     $ZodCheck2.init(inst, def);
     inst._zod.onattach.push((inst2) => {
-      var _a3;
-      (_a3 = inst2._zod.bag).multipleOf ?? (_a3.multipleOf = def.value);
+      var _a2;
+      (_a2 = inst2._zod.bag).multipleOf ?? (_a2.multipleOf = def.value);
     });
     inst._zod.check = (payload) => {
       if (typeof payload.value !== typeof def.value)
@@ -24101,9 +23342,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMaxSize2 = /* @__PURE__ */ $constructor2("$ZodCheckMaxSize", (inst, def) => {
-    var _a3;
+    var _a2;
     $ZodCheck2.init(inst, def);
-    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.size !== undefined;
     });
@@ -24129,9 +23370,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMinSize2 = /* @__PURE__ */ $constructor2("$ZodCheckMinSize", (inst, def) => {
-    var _a3;
+    var _a2;
     $ZodCheck2.init(inst, def);
-    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.size !== undefined;
     });
@@ -24157,9 +23398,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckSizeEquals2 = /* @__PURE__ */ $constructor2("$ZodCheckSizeEquals", (inst, def) => {
-    var _a3;
+    var _a2;
     $ZodCheck2.init(inst, def);
-    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.size !== undefined;
     });
@@ -24187,9 +23428,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMaxLength2 = /* @__PURE__ */ $constructor2("$ZodCheckMaxLength", (inst, def) => {
-    var _a3;
+    var _a2;
     $ZodCheck2.init(inst, def);
-    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.length !== undefined;
     });
@@ -24216,9 +23457,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMinLength2 = /* @__PURE__ */ $constructor2("$ZodCheckMinLength", (inst, def) => {
-    var _a3;
+    var _a2;
     $ZodCheck2.init(inst, def);
-    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.length !== undefined;
     });
@@ -24245,9 +23486,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckLengthEquals2 = /* @__PURE__ */ $constructor2("$ZodCheckLengthEquals", (inst, def) => {
-    var _a3;
+    var _a2;
     $ZodCheck2.init(inst, def);
-    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.length !== undefined;
     });
@@ -24276,7 +23517,7 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckStringFormat2 = /* @__PURE__ */ $constructor2("$ZodCheckStringFormat", (inst, def) => {
-    var _a3, _b;
+    var _a2, _b;
     $ZodCheck2.init(inst, def);
     inst._zod.onattach.push((inst2) => {
       const bag = inst2._zod.bag;
@@ -24287,7 +23528,7 @@ var init_checks3 = __esm(() => {
       }
     });
     if (def.pattern)
-      (_a3 = inst._zod).check ?? (_a3.check = (payload) => {
+      (_a2 = inst._zod).check ?? (_a2.check = (payload) => {
         def.pattern.lastIndex = 0;
         if (def.pattern.test(payload.value))
           return;
@@ -24801,7 +24042,7 @@ var init_schemas3 = __esm(() => {
   init_versions2();
   init_util2();
   $ZodType2 = /* @__PURE__ */ $constructor2("$ZodType", (inst, def) => {
-    var _a3;
+    var _a2;
     inst ?? (inst = {});
     inst._zod.def = def;
     inst._zod.bag = inst._zod.bag || {};
@@ -24816,7 +24057,7 @@ var init_schemas3 = __esm(() => {
       }
     }
     if (checks3.length === 0) {
-      (_a3 = inst._zod).deferred ?? (_a3.deferred = []);
+      (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
       inst._zod.deferred?.push(() => {
         inst._zod.run = inst._zod.parse;
       });
@@ -26324,10 +25565,10 @@ var init_schemas3 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ar.js
 function ar_default2() {
   return {
-    localeError: error52()
+    localeError: error49()
   };
 }
-var error52 = () => {
+var error49 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0641", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
     file: { unit: "\u0628\u0627\u064A\u062A", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
@@ -26444,10 +25685,10 @@ var init_ar2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/az.js
 function az_default2() {
   return {
-    localeError: error53()
+    localeError: error50()
   };
 }
-var error53 = () => {
+var error50 = () => {
   const Sizable = {
     string: { unit: "simvol", verb: "olmal\u0131d\u0131r" },
     file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
@@ -26578,10 +25819,10 @@ function getBelarusianPlural2(count, one, few, many) {
 }
 function be_default2() {
   return {
-    localeError: error54()
+    localeError: error51()
   };
 }
-var error54 = () => {
+var error51 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -26731,10 +25972,10 @@ var init_be2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ca.js
 function ca_default2() {
   return {
-    localeError: error55()
+    localeError: error52()
   };
 }
-var error55 = () => {
+var error52 = () => {
   const Sizable = {
     string: { unit: "car\xE0cters", verb: "contenir" },
     file: { unit: "bytes", verb: "contenir" },
@@ -26852,10 +26093,10 @@ var init_ca2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/cs.js
 function cs_default2() {
   return {
-    localeError: error56()
+    localeError: error53()
   };
 }
-var error56 = () => {
+var error53 = () => {
   const Sizable = {
     string: { unit: "znak\u016F", verb: "m\xEDt" },
     file: { unit: "bajt\u016F", verb: "m\xEDt" },
@@ -26991,10 +26232,10 @@ var init_cs2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/da.js
 function da_default2() {
   return {
-    localeError: error57()
+    localeError: error54()
   };
 }
-var error57 = () => {
+var error54 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "havde" },
     file: { unit: "bytes", verb: "havde" },
@@ -27126,10 +26367,10 @@ var init_da2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/de.js
 function de_default2() {
   return {
-    localeError: error58()
+    localeError: error55()
   };
 }
-var error58 = () => {
+var error55 = () => {
   const Sizable = {
     string: { unit: "Zeichen", verb: "zu haben" },
     file: { unit: "Bytes", verb: "zu haben" },
@@ -27246,7 +26487,7 @@ var init_de2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/en.js
 function en_default2() {
   return {
-    localeError: error59()
+    localeError: error56()
   };
 }
 var parsedType2 = (data) => {
@@ -27268,7 +26509,7 @@ var parsedType2 = (data) => {
     }
   }
   return t;
-}, error59 = () => {
+}, error56 = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
     file: { unit: "bytes", verb: "to have" },
@@ -27366,7 +26607,7 @@ var init_en2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/eo.js
 function eo_default2() {
   return {
-    localeError: error60()
+    localeError: error57()
   };
 }
 var parsedType3 = (data) => {
@@ -27388,7 +26629,7 @@ var parsedType3 = (data) => {
     }
   }
   return t;
-}, error60 = () => {
+}, error57 = () => {
   const Sizable = {
     string: { unit: "karaktrojn", verb: "havi" },
     file: { unit: "bajtojn", verb: "havi" },
@@ -27485,10 +26726,10 @@ var init_eo2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/es.js
 function es_default2() {
   return {
-    localeError: error61()
+    localeError: error58()
   };
 }
-var error61 = () => {
+var error58 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "tener" },
     file: { unit: "bytes", verb: "tener" },
@@ -27637,10 +26878,10 @@ var init_es2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fa.js
 function fa_default2() {
   return {
-    localeError: error62()
+    localeError: error59()
   };
 }
-var error62 = () => {
+var error59 = () => {
   const Sizable = {
     string: { unit: "\u06A9\u0627\u0631\u0627\u06A9\u062A\u0631", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
     file: { unit: "\u0628\u0627\u06CC\u062A", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
@@ -27763,10 +27004,10 @@ var init_fa2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fi.js
 function fi_default2() {
   return {
-    localeError: error63()
+    localeError: error60()
   };
 }
-var error63 = () => {
+var error60 = () => {
   const Sizable = {
     string: { unit: "merkki\xE4", subject: "merkkijonon" },
     file: { unit: "tavua", subject: "tiedoston" },
@@ -27889,10 +27130,10 @@ var init_fi2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fr.js
 function fr_default2() {
   return {
-    localeError: error64()
+    localeError: error61()
   };
 }
-var error64 = () => {
+var error61 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -28009,10 +27250,10 @@ var init_fr2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fr-CA.js
 function fr_CA_default2() {
   return {
-    localeError: error65()
+    localeError: error62()
   };
 }
-var error65 = () => {
+var error62 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -28130,10 +27371,10 @@ var init_fr_CA2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/he.js
 function he_default2() {
   return {
-    localeError: error66()
+    localeError: error63()
   };
 }
-var error66 = () => {
+var error63 = () => {
   const Sizable = {
     string: { unit: "\u05D0\u05D5\u05EA\u05D9\u05D5\u05EA", verb: "\u05DC\u05DB\u05DC\u05D5\u05DC" },
     file: { unit: "\u05D1\u05D9\u05D9\u05D8\u05D9\u05DD", verb: "\u05DC\u05DB\u05DC\u05D5\u05DC" },
@@ -28250,10 +27491,10 @@ var init_he2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/hu.js
 function hu_default2() {
   return {
-    localeError: error67()
+    localeError: error64()
   };
 }
-var error67 = () => {
+var error64 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "legyen" },
     file: { unit: "byte", verb: "legyen" },
@@ -28370,10 +27611,10 @@ var init_hu2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/id.js
 function id_default2() {
   return {
-    localeError: error68()
+    localeError: error65()
   };
 }
-var error68 = () => {
+var error65 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "memiliki" },
     file: { unit: "byte", verb: "memiliki" },
@@ -28490,7 +27731,7 @@ var init_id2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/is.js
 function is_default2() {
   return {
-    localeError: error69()
+    localeError: error66()
   };
 }
 var parsedType4 = (data) => {
@@ -28512,7 +27753,7 @@ var parsedType4 = (data) => {
     }
   }
   return t;
-}, error69 = () => {
+}, error66 = () => {
   const Sizable = {
     string: { unit: "stafi", verb: "a\xF0 hafa" },
     file: { unit: "b\xE6ti", verb: "a\xF0 hafa" },
@@ -28610,10 +27851,10 @@ var init_is2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/it.js
 function it_default2() {
   return {
-    localeError: error70()
+    localeError: error67()
   };
 }
-var error70 = () => {
+var error67 = () => {
   const Sizable = {
     string: { unit: "caratteri", verb: "avere" },
     file: { unit: "byte", verb: "avere" },
@@ -28730,10 +27971,10 @@ var init_it2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ja.js
 function ja_default2() {
   return {
-    localeError: error71()
+    localeError: error68()
   };
 }
-var error71 = () => {
+var error68 = () => {
   const Sizable = {
     string: { unit: "\u6587\u5B57", verb: "\u3067\u3042\u308B" },
     file: { unit: "\u30D0\u30A4\u30C8", verb: "\u3067\u3042\u308B" },
@@ -28849,7 +28090,7 @@ var init_ja2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ka.js
 function ka_default2() {
   return {
-    localeError: error72()
+    localeError: error69()
   };
 }
 var parsedType5 = (data) => {
@@ -28879,7 +28120,7 @@ var parsedType5 = (data) => {
     function: "\u10E4\u10E3\u10DC\u10E5\u10EA\u10D8\u10D0"
   };
   return typeMap[t] ?? t;
-}, error72 = () => {
+}, error69 = () => {
   const Sizable = {
     string: { unit: "\u10E1\u10D8\u10DB\u10D1\u10DD\u10DA\u10DD", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
     file: { unit: "\u10D1\u10D0\u10D8\u10E2\u10D8", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
@@ -28977,10 +28218,10 @@ var init_ka2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/km.js
 function km_default2() {
   return {
-    localeError: error73()
+    localeError: error70()
   };
 }
-var error73 = () => {
+var error70 = () => {
   const Sizable = {
     string: { unit: "\u178F\u17BD\u17A2\u1780\u17D2\u179F\u179A", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
     file: { unit: "\u1794\u17C3", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
@@ -29106,10 +28347,10 @@ var init_kh2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ko.js
 function ko_default2() {
   return {
-    localeError: error74()
+    localeError: error71()
   };
 }
-var error74 = () => {
+var error71 = () => {
   const Sizable = {
     string: { unit: "\uBB38\uC790", verb: "to have" },
     file: { unit: "\uBC14\uC774\uD2B8", verb: "to have" },
@@ -29241,7 +28482,7 @@ function getUnitTypeFromNumber2(number5) {
 }
 function lt_default2() {
   return {
-    localeError: error75()
+    localeError: error72()
   };
 }
 var parsedType6 = (data) => {
@@ -29290,7 +28531,7 @@ var parsedType6 = (data) => {
   return t;
 }, capitalizeFirstCharacter2 = (text) => {
   return text.charAt(0).toUpperCase() + text.slice(1);
-}, error75 = () => {
+}, error72 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -29461,10 +28702,10 @@ var init_lt2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/mk.js
 function mk_default2() {
   return {
-    localeError: error76()
+    localeError: error73()
   };
 }
-var error76 = () => {
+var error73 = () => {
   const Sizable = {
     string: { unit: "\u0437\u043D\u0430\u0446\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
     file: { unit: "\u0431\u0430\u0458\u0442\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
@@ -29582,10 +28823,10 @@ var init_mk2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ms.js
 function ms_default2() {
   return {
-    localeError: error77()
+    localeError: error74()
   };
 }
-var error77 = () => {
+var error74 = () => {
   const Sizable = {
     string: { unit: "aksara", verb: "mempunyai" },
     file: { unit: "bait", verb: "mempunyai" },
@@ -29702,10 +28943,10 @@ var init_ms2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/nl.js
 function nl_default2() {
   return {
-    localeError: error78()
+    localeError: error75()
   };
 }
-var error78 = () => {
+var error75 = () => {
   const Sizable = {
     string: { unit: "tekens" },
     file: { unit: "bytes" },
@@ -29823,10 +29064,10 @@ var init_nl2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/no.js
 function no_default2() {
   return {
-    localeError: error79()
+    localeError: error76()
   };
 }
-var error79 = () => {
+var error76 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "\xE5 ha" },
     file: { unit: "bytes", verb: "\xE5 ha" },
@@ -29943,10 +29184,10 @@ var init_no2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ota.js
 function ota_default2() {
   return {
-    localeError: error80()
+    localeError: error77()
   };
 }
-var error80 = () => {
+var error77 = () => {
   const Sizable = {
     string: { unit: "harf", verb: "olmal\u0131d\u0131r" },
     file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
@@ -30063,10 +29304,10 @@ var init_ota2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ps.js
 function ps_default2() {
   return {
-    localeError: error81()
+    localeError: error78()
   };
 }
-var error81 = () => {
+var error78 = () => {
   const Sizable = {
     string: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
     file: { unit: "\u0628\u0627\u06CC\u067C\u0633", verb: "\u0648\u0644\u0631\u064A" },
@@ -30189,10 +29430,10 @@ var init_ps2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/pl.js
 function pl_default2() {
   return {
-    localeError: error82()
+    localeError: error79()
   };
 }
-var error82 = () => {
+var error79 = () => {
   const Sizable = {
     string: { unit: "znak\xF3w", verb: "mie\u0107" },
     file: { unit: "bajt\xF3w", verb: "mie\u0107" },
@@ -30310,10 +29551,10 @@ var init_pl2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/pt.js
 function pt_default2() {
   return {
-    localeError: error83()
+    localeError: error80()
   };
 }
-var error83 = () => {
+var error80 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "ter" },
     file: { unit: "bytes", verb: "ter" },
@@ -30445,10 +29686,10 @@ function getRussianPlural2(count, one, few, many) {
 }
 function ru_default2() {
   return {
-    localeError: error84()
+    localeError: error81()
   };
 }
-var error84 = () => {
+var error81 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -30598,10 +29839,10 @@ var init_ru2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/sl.js
 function sl_default2() {
   return {
-    localeError: error85()
+    localeError: error82()
   };
 }
-var error85 = () => {
+var error82 = () => {
   const Sizable = {
     string: { unit: "znakov", verb: "imeti" },
     file: { unit: "bajtov", verb: "imeti" },
@@ -30719,10 +29960,10 @@ var init_sl2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/sv.js
 function sv_default2() {
   return {
-    localeError: error86()
+    localeError: error83()
   };
 }
-var error86 = () => {
+var error83 = () => {
   const Sizable = {
     string: { unit: "tecken", verb: "att ha" },
     file: { unit: "bytes", verb: "att ha" },
@@ -30841,10 +30082,10 @@ var init_sv2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ta.js
 function ta_default2() {
   return {
-    localeError: error87()
+    localeError: error84()
   };
 }
-var error87 = () => {
+var error84 = () => {
   const Sizable = {
     string: { unit: "\u0B8E\u0BB4\u0BC1\u0BA4\u0BCD\u0BA4\u0BC1\u0B95\u0BCD\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
     file: { unit: "\u0BAA\u0BC8\u0B9F\u0BCD\u0B9F\u0BC1\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
@@ -30962,10 +30203,10 @@ var init_ta2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/th.js
 function th_default2() {
   return {
-    localeError: error88()
+    localeError: error85()
   };
 }
-var error88 = () => {
+var error85 = () => {
   const Sizable = {
     string: { unit: "\u0E15\u0E31\u0E27\u0E2D\u0E31\u0E01\u0E29\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
     file: { unit: "\u0E44\u0E1A\u0E15\u0E4C", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
@@ -31083,7 +30324,7 @@ var init_th2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/tr.js
 function tr_default2() {
   return {
-    localeError: error89()
+    localeError: error86()
   };
 }
 var parsedType7 = (data) => {
@@ -31105,7 +30346,7 @@ var parsedType7 = (data) => {
     }
   }
   return t;
-}, error89 = () => {
+}, error86 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "olmal\u0131" },
     file: { unit: "bayt", verb: "olmal\u0131" },
@@ -31201,10 +30442,10 @@ var init_tr2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/uk.js
 function uk_default2() {
   return {
-    localeError: error90()
+    localeError: error87()
   };
 }
-var error90 = () => {
+var error87 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
     file: { unit: "\u0431\u0430\u0439\u0442\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
@@ -31329,10 +30570,10 @@ var init_ua2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ur.js
 function ur_default2() {
   return {
-    localeError: error91()
+    localeError: error88()
   };
 }
-var error91 = () => {
+var error88 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0648\u0641", verb: "\u06C1\u0648\u0646\u0627" },
     file: { unit: "\u0628\u0627\u0626\u0679\u0633", verb: "\u06C1\u0648\u0646\u0627" },
@@ -31450,10 +30691,10 @@ var init_ur2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/vi.js
 function vi_default2() {
   return {
-    localeError: error92()
+    localeError: error89()
   };
 }
-var error92 = () => {
+var error89 = () => {
   const Sizable = {
     string: { unit: "k\xFD t\u1EF1", verb: "c\xF3" },
     file: { unit: "byte", verb: "c\xF3" },
@@ -31570,10 +30811,10 @@ var init_vi2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/zh-CN.js
 function zh_CN_default2() {
   return {
-    localeError: error93()
+    localeError: error90()
   };
 }
-var error93 = () => {
+var error90 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u7B26", verb: "\u5305\u542B" },
     file: { unit: "\u5B57\u8282", verb: "\u5305\u542B" },
@@ -31690,10 +30931,10 @@ var init_zh_CN2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/zh-TW.js
 function zh_TW_default2() {
   return {
-    localeError: error94()
+    localeError: error91()
   };
 }
-var error94 = () => {
+var error91 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u5143", verb: "\u64C1\u6709" },
     file: { unit: "\u4F4D\u5143\u7D44", verb: "\u64C1\u6709" },
@@ -31811,10 +31052,10 @@ var init_zh_TW2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/yo.js
 function yo_default2() {
   return {
-    localeError: error95()
+    localeError: error92()
   };
 }
-var error95 = () => {
+var error92 = () => {
   const Sizable = {
     string: { unit: "\xE0mi", verb: "n\xED" },
     file: { unit: "bytes", verb: "n\xED" },
@@ -32977,7 +32218,7 @@ class JSONSchemaGenerator2 {
     this.seen = new Map;
   }
   process(schema, _params = { path: [], schemaPath: [] }) {
-    var _a3;
+    var _a2;
     const def = schema._zod.def;
     const formatMap2 = {
       guid: "uuid",
@@ -33480,7 +32721,7 @@ class JSONSchemaGenerator2 {
       delete result.schema.default;
     }
     if (this.io === "input" && result.schema._prefault)
-      (_a3 = result.schema).default ?? (_a3.default = result.schema._prefault);
+      (_a2 = result.schema).default ?? (_a2.default = result.schema._prefault);
     delete result.schema._prefault;
     const _result = this.seen.get(schema);
     return _result.schema;
@@ -35474,8 +34715,8 @@ var init_dist = __esm(() => {
 });
 
 // src/tools/create-tool.ts
-function classifyToolError(error96) {
-  const msg = (error96 instanceof Error ? error96.message ?? "" : String(error96)).toLowerCase();
+function classifyToolError(error93) {
+  const msg = (error93 instanceof Error ? error93.message ?? "" : String(error93)).toLowerCase();
   if (msg.includes("not registered") || msg.includes("unknown tool"))
     return "not_registered";
   if (msg.includes("not whitelisted") || msg.includes("not allowed"))
@@ -35493,11 +34734,11 @@ function createSwarmTool(opts) {
       try {
         const result = await opts.execute(args, directory, ctx);
         return result;
-      } catch (error96) {
-        const message = error96 instanceof Error ? error96.message : String(error96);
+      } catch (error93) {
+        const message = error93 instanceof Error ? error93.message : String(error93);
         return JSON.stringify({
           success: false,
-          failure_class: classifyToolError(error96),
+          failure_class: classifyToolError(error93),
           message: "Tool execution failed",
           errors: [message]
         }, null, 2);
@@ -35867,8 +35108,8 @@ async function handleSave2(directory, label) {
     } else {
       return `Error: ${parsed.error || "Failed to save checkpoint"}`;
     }
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     return `Error: ${msg}`;
   }
 }
@@ -35886,8 +35127,8 @@ async function handleRestore2(directory, label) {
     } else {
       return `Error: ${parsed.error || "Failed to restore checkpoint"}`;
     }
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     return `Error: ${msg}`;
   }
 }
@@ -35905,8 +35146,8 @@ async function handleDelete2(directory, label) {
     } else {
       return `Error: ${parsed.error || "Failed to delete checkpoint"}`;
     }
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     return `Error: ${msg}`;
   }
 }
@@ -35935,8 +35176,8 @@ async function handleList2(directory) {
     ];
     return lines.join(`
 `);
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     return `Error: ${msg}`;
   }
 }
@@ -36462,8 +35703,8 @@ class AutomationEventBus {
       await Promise.all(Array.from(listeners).map(async (listener) => {
         try {
           await listener(event);
-        } catch (error96) {
-          log(`[EventBus] Listener error for ${type}`, { error: error96 });
+        } catch (error93) {
+          log(`[EventBus] Listener error for ${type}`, { error: error93 });
         }
       }));
     }
@@ -38922,11 +38163,11 @@ async function executeWriteRetro(args, directory) {
       phase,
       message: `Retrospective evidence written to .swarm/evidence/${taskId}/evidence.json`
     }, null, 2);
-  } catch (error96) {
+  } catch (error93) {
     return JSON.stringify({
       success: false,
       phase,
-      message: error96 instanceof Error ? error96.message : String(error96)
+      message: error93 instanceof Error ? error93.message : String(error93)
     }, null, 2);
   }
 }
@@ -39057,9 +38298,9 @@ async function handleCloseCommand(directory, args, options = {}) {
     const content = await fs7.readFile(planPath, "utf-8");
     planData = JSON.parse(content);
     planExists = true;
-  } catch (error96) {
-    if (error96?.code !== "ENOENT") {
-      return `\u274C Failed to read plan.json: ${error96 instanceof Error ? error96.message : String(error96)}`;
+  } catch (error93) {
+    if (error93?.code !== "ENOENT") {
+      return `\u274C Failed to read plan.json: ${error93 instanceof Error ? error93.message : String(error93)}`;
     }
     const swarmDirExists = await fs7.access(swarmDir).then(() => true).catch(() => false);
     if (!swarmDirExists) {
@@ -39195,10 +38436,10 @@ async function handleCloseCommand(directory, args, options = {}) {
   try {
     curationResult = await curateAndStoreSwarm(allLessons, projectName, { phase_number: 0 }, directory, config3);
     curationSucceeded = true;
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     warnings.push(`Lessons curation failed: ${msg}`);
-    console.warn("[close-command] curateAndStoreSwarm error:", error96);
+    console.warn("[close-command] curateAndStoreSwarm error:", error93);
   }
   if (curationSucceeded && allLessons.length > 0) {
     await fs7.unlink(lessonsFilePath).catch(() => {});
@@ -39298,10 +38539,10 @@ async function handleCloseCommand(directory, args, options = {}) {
           closedTaskIds: guaranteeResult.closedTaskIds,
           originalStatuses
         });
-      } catch (error96) {
-        const msg = error96 instanceof Error ? error96.message : String(error96);
+      } catch (error93) {
+        const msg = error93 instanceof Error ? error93.message : String(error93);
         warnings.push(`Failed to persist terminal plan state: ${msg}`);
-        console.warn("[close-command] Failed to write terminal plan state:", error96);
+        console.warn("[close-command] Failed to write terminal plan state:", error93);
       }
     }
   }
@@ -39360,10 +38601,10 @@ async function handleCloseCommand(directory, args, options = {}) {
   }
   try {
     await archiveEvidence(directory, 30, 10);
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     warnings.push(`Evidence retention archive failed: ${msg}`);
-    console.warn("[close-command] archiveEvidence error:", error96);
+    console.warn("[close-command] archiveEvidence error:", error93);
   }
   let configBackupsRemoved = 0;
   const cleanedFiles = [];
@@ -39440,10 +38681,10 @@ async function handleCloseCommand(directory, args, options = {}) {
 `);
   try {
     await fs7.writeFile(contextPath, contextContent, "utf-8");
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     warnings.push(`Failed to reset context.md: ${msg}`);
-    console.warn("[close-command] Failed to write context.md:", error96);
+    console.warn("[close-command] Failed to write context.md:", error93);
   }
   const pruneBranches = args.includes("--prune-branches");
   let gitAlignResult = "";
@@ -39526,10 +38767,10 @@ async function handleCloseCommand(directory, args, options = {}) {
 `);
   try {
     await fs7.writeFile(closeSummaryPath, summaryContent, "utf-8");
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     warnings.push(`Failed to write close-summary.md: ${msg}`);
-    console.warn("[close-command] Failed to write close-summary.md:", error96);
+    console.warn("[close-command] Failed to write close-summary.md:", error93);
   }
   const preservedClient = swarmState.opencodeClient;
   const preservedFullAutoFlag = swarmState.fullAutoEnabledInConfig;
@@ -39855,11 +39096,11 @@ async function handleCurateCommand(directory, _args) {
     const swarmEntries = await readKnowledge(swarmPath) ?? [];
     const summary = await checkHivePromotions(swarmEntries, config3);
     return formatCurationSummary(summary);
-  } catch (error96) {
-    if (error96 instanceof Error) {
-      return `\u274C Curation failed: ${error96.message}`;
+  } catch (error93) {
+    if (error93 instanceof Error) {
+      return `\u274C Curation failed: ${error93.message}`;
     }
-    return `\u274C Curation failed: ${error96 instanceof Error ? error96.message : String(error96)}`;
+    return `\u274C Curation failed: ${error93 instanceof Error ? error93.message : String(error93)}`;
   }
 }
 function formatCurationSummary(summary) {
@@ -40475,11 +39716,11 @@ function readExisting(evidencePath, taskId) {
   try {
     const raw = readFileSync6(evidencePath, "utf-8");
     return TaskEvidenceSchema.parse(JSON.parse(raw));
-  } catch (error96) {
-    if (error96.code === "ENOENT")
+  } catch (error93) {
+    if (error93.code === "ENOENT")
       return null;
-    telemetry.gateParseError(taskId, error96);
-    throw error96;
+    telemetry.gateParseError(taskId, error93);
+    throw error93;
   }
 }
 async function readTaskEvidence(directory, taskId) {
@@ -40496,10 +39737,10 @@ function readTaskEvidenceRaw(directory, taskId) {
   try {
     const raw = readFileSync6(evidencePath, "utf-8");
     return TaskEvidenceSchema.parse(JSON.parse(raw));
-  } catch (error96) {
-    if (error96.code === "ENOENT")
+  } catch (error93) {
+    if (error93.code === "ENOENT")
       return null;
-    throw error96;
+    throw error93;
   }
 }
 var GateEvidenceSchema, TaskEvidenceSchema;
@@ -41571,9 +40812,9 @@ function createConfigBackup(directory) {
   if (fs8.existsSync(projectConfigPath)) {
     try {
       content = fs8.readFileSync(projectConfigPath, "utf-8");
-    } catch (error96) {
+    } catch (error93) {
       log("[ConfigDoctor] project config read failed", {
-        error: error96 instanceof Error ? error96.message : String(error96)
+        error: error93 instanceof Error ? error93.message : String(error93)
       });
     }
   }
@@ -41581,9 +40822,9 @@ function createConfigBackup(directory) {
     configPath = userConfigPath;
     try {
       content = fs8.readFileSync(userConfigPath, "utf-8");
-    } catch (error96) {
+    } catch (error93) {
       log("[ConfigDoctor] user config read failed", {
-        error: error96 instanceof Error ? error96.message : String(error96)
+        error: error93 instanceof Error ? error93.message : String(error93)
       });
     }
   }
@@ -44585,8 +43826,8 @@ function withStateLock(directory, fn) {
       retries: { retries: 5, minTimeout: 5, maxTimeout: 50 },
       stale: 5000
     });
-  } catch (error96) {
-    warn(`[full-auto/state] cross-process lock unavailable; proceeding unlocked: ${error96 instanceof Error ? error96.message : String(error96)}`);
+  } catch (error93) {
+    warn(`[full-auto/state] cross-process lock unavailable; proceeding unlocked: ${error93 instanceof Error ? error93.message : String(error93)}`);
   }
   try {
     return fn();
@@ -44637,8 +43878,8 @@ function readPersisted(directory) {
       oversightSequence: typeof parsed.oversightSequence === "number" ? parsed.oversightSequence : 0,
       sessions: parsed.sessions
     };
-  } catch (error96) {
-    const reason = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const reason = error93 instanceof Error ? error93.message : String(error93);
     error(`[full-auto/state] Failed to read ${STATE_FILE}: ${reason} \u2014 attempting .bak recovery`);
     try {
       const bakPath = validateSwarmPath(directory, `${STATE_FILE}.bak`);
@@ -44676,8 +43917,8 @@ function writePersisted(directory, persisted) {
     persisted.updatedAt = nowISO();
     payload = `${JSON.stringify(persisted, null, 2)}
 `;
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     error(`[full-auto/state] Failed to prepare ${STATE_FILE} write: ${msg}`);
     throw new Error(`Full-Auto state persistence prepare failed: ${msg}`);
   }
@@ -44702,8 +43943,8 @@ function writePersisted(directory, persisted) {
     if (parsed?.version !== 2) {
       throw new Error("Round-trip readback returned wrong version");
     }
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     error(`[full-auto/state] Failed to persist ${STATE_FILE} atomically: ${msg}`);
     throw new Error(`Full-Auto state persistence failed: ${msg}`);
   }
@@ -44819,8 +44060,8 @@ async function handleFullAutoCommand(directory, args, sessionID) {
       }
       v2Status = "paused";
     }
-  } catch (error96) {
-    durableError = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    durableError = error93 instanceof Error ? error93.message : String(error93);
     error(`[full-auto] durable run-state write failed: ${durableError}`);
   }
   if (newFullAutoMode && durableError) {
@@ -44968,9 +44209,9 @@ function parseSessionState(content) {
       }
     }
     return { activeAgent, delegationState, pendingQA };
-  } catch (error96) {
+  } catch (error93) {
     log("[HandoffService] state extraction failed", {
-      error: error96 instanceof Error ? error96.message : String(error96)
+      error: error93 instanceof Error ? error93.message : String(error93)
     });
     return null;
   }
@@ -45350,9 +44591,9 @@ async function writeSnapshot(directory, state) {
       }
     } catch {}
     renameSync6(tempPath, resolvedPath);
-  } catch (error96) {
+  } catch (error93) {
     log("[snapshot-writer] write failed", {
-      error: error96 instanceof Error ? error96.message : String(error96)
+      error: error93 instanceof Error ? error93.message : String(error93)
     });
   }
 }
@@ -46084,8 +45325,8 @@ async function handleKnowledgeQuarantineCommand(directory, args) {
     const fullId = resolved.entry.id;
     await quarantineEntry(directory, fullId, reason, "user");
     return `\u2705 Entry ${fullId} quarantined successfully.`;
-  } catch (error96) {
-    console.warn("[knowledge-command] quarantineEntry error:", error96 instanceof Error ? error96.message : String(error96));
+  } catch (error93) {
+    console.warn("[knowledge-command] quarantineEntry error:", error93 instanceof Error ? error93.message : String(error93));
     return `\u274C Failed to quarantine entry. Check the entry ID and try again.`;
   }
 }
@@ -46107,8 +45348,8 @@ async function handleKnowledgeRestoreCommand(directory, args) {
     const fullId = resolved.entry.id;
     await restoreEntry(directory, fullId);
     return `\u2705 Entry ${fullId} restored successfully.`;
-  } catch (error96) {
-    console.warn("[knowledge-command] restoreEntry error:", error96 instanceof Error ? error96.message : String(error96));
+  } catch (error93) {
+    console.warn("[knowledge-command] restoreEntry error:", error93 instanceof Error ? error93.message : String(error93));
     return `\u274C Failed to restore entry. Check the entry ID and try again.`;
   }
 }
@@ -46129,8 +45370,8 @@ async function handleKnowledgeMigrateCommand(directory, args) {
       }
     }
     return `\u2705 Migration complete: ${result.entriesMigrated} entries added, ${result.entriesDropped} dropped (validation/dedup), ${result.entriesTotal} total processed.`;
-  } catch (error96) {
-    console.warn("[knowledge-command] migrateContextToKnowledge error:", error96 instanceof Error ? error96.message : String(error96));
+  } catch (error93) {
+    console.warn("[knowledge-command] migrateContextToKnowledge error:", error93 instanceof Error ? error93.message : String(error93));
     return "\u274C Migration failed. Check .swarm/context.md is readable.";
   }
 }
@@ -46156,8 +45397,8 @@ async function handleKnowledgeListCommand(directory, _args) {
     lines.push("Use `/swarm knowledge quarantine <id-prefix>` to hide an entry. Prefix matching is supported \u2014 the 12-character prefix shown is unique in most stores.");
     return lines.join(`
 `);
-  } catch (error96) {
-    console.warn("[knowledge-command] list error:", error96 instanceof Error ? error96.message : String(error96));
+  } catch (error93) {
+    console.warn("[knowledge-command] list error:", error93 instanceof Error ? error93.message : String(error93));
     return "\u274C Failed to list knowledge entries. Ensure .swarm/knowledge.jsonl exists.";
   }
 }
@@ -50148,13 +49389,13 @@ async function runLint(linter, mode, directory) {
       result.message = `${linter} check found issues (exit code ${exitCode}).`;
     }
     return result;
-  } catch (error96) {
+  } catch (error93) {
     return {
       success: false,
       mode,
       linter,
       command,
-      error: error96 instanceof Error ? `Execution failed: ${error96.message}` : "Execution failed: unknown error"
+      error: error93 instanceof Error ? `Execution failed: ${error93.message}` : "Execution failed: unknown error"
     };
   }
 }
@@ -50206,13 +49447,13 @@ async function runAdditionalLint(linter, mode, cwd) {
       result.message = `${linter} check found issues (exit code ${exitCode}).`;
     }
     return result;
-  } catch (error96) {
+  } catch (error93) {
     return {
       success: false,
       mode,
       linter,
       command,
-      error: error96 instanceof Error ? `Execution failed: ${error96.message}` : "Execution failed: unknown error"
+      error: error93 instanceof Error ? `Execution failed: ${error93.message}` : "Execution failed: unknown error"
     };
   }
 }
@@ -54113,7 +53354,7 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
       }
       return result;
     }
-  } catch (error96) {
+  } catch (error93) {
     const duration_ms = Date.now() - startTime;
     return {
       success: false,
@@ -54122,7 +53363,7 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
       command,
       timeout_ms,
       duration_ms,
-      error: error96 instanceof Error ? `Execution failed: ${error96.message}` : "Execution failed: unknown error",
+      error: error93 instanceof Error ? `Execution failed: ${error93.message}` : "Execution failed: unknown error",
       outcome: "error"
     };
   }
@@ -54812,11 +54053,11 @@ async function runVersionCheck(dir, _timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error96) {
+  } catch (error93) {
     return {
       type: "version",
       status: "error",
-      message: `Version check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
+      message: `Version check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -54870,12 +54111,12 @@ async function runLintCheck(dir, linter, timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error96) {
-    if (error96 instanceof Error && error96.message.includes("timed out")) {
+  } catch (error93) {
+    if (error93 instanceof Error && error93.message.includes("timed out")) {
       return {
         type: "lint",
         status: "error",
-        message: error96.message,
+        message: error93.message,
         details: { linter },
         durationMs: Date.now() - startTime
       };
@@ -54883,7 +54124,7 @@ async function runLintCheck(dir, linter, timeoutMs) {
     return {
       type: "lint",
       status: "error",
-      message: `Lint check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
+      message: `Lint check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
       details: { linter },
       durationMs: Date.now() - startTime
     };
@@ -54939,8 +54180,8 @@ async function runTestsCheck(_dir, scope, timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error96) {
-    if (error96 instanceof Error && (error96.message.includes("timeout") || error96.message.includes("ETIMEDOUT"))) {
+  } catch (error93) {
+    if (error93 instanceof Error && (error93.message.includes("timeout") || error93.message.includes("ETIMEDOUT"))) {
       return {
         type: "tests",
         status: "error",
@@ -54951,7 +54192,7 @@ async function runTestsCheck(_dir, scope, timeoutMs) {
     return {
       type: "tests",
       status: "error",
-      message: `Tests check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
+      message: `Tests check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -54994,8 +54235,8 @@ async function runSecretsCheck(dir, timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error96) {
-    if (error96 instanceof Error && error96.name === "AbortError") {
+  } catch (error93) {
+    if (error93 instanceof Error && error93.name === "AbortError") {
       return {
         type: "secrets",
         status: "error",
@@ -55006,7 +54247,7 @@ async function runSecretsCheck(dir, timeoutMs) {
     return {
       type: "secrets",
       status: "error",
-      message: `Secrets check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
+      message: `Secrets check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -55082,11 +54323,11 @@ async function runEvidenceCheck(dir) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error96) {
+  } catch (error93) {
     return {
       type: "evidence",
       status: "error",
-      message: `Evidence check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
+      message: `Evidence check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -55121,11 +54362,11 @@ async function runRequirementCoverageCheck(dir, currentPhase) {
       details: { expectedPath: coverage.path },
       durationMs: Date.now() - startTime
     };
-  } catch (error96) {
+  } catch (error93) {
     return {
       type: "req_coverage",
       status: "error",
-      message: `Requirement coverage check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
+      message: `Requirement coverage check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -55136,7 +54377,7 @@ async function runPreflight(dir, phase, config3) {
   let validatedDir;
   try {
     validatedDir = _internals27.validateDirectoryPath(dir);
-  } catch (error96) {
+  } catch (error93) {
     return {
       id: reportId,
       timestamp: startTime,
@@ -55146,7 +54387,7 @@ async function runPreflight(dir, phase, config3) {
         {
           type: "lint",
           status: "error",
-          message: `Invalid directory: ${error96 instanceof Error ? error96.message : String(error96)}`
+          message: `Invalid directory: ${error93 instanceof Error ? error93.message : String(error93)}`
         }
       ],
       totalDurationMs: Date.now() - startTime,
@@ -55156,7 +54397,7 @@ async function runPreflight(dir, phase, config3) {
   let validatedTimeout;
   try {
     validatedTimeout = _internals27.validateTimeout(config3?.checkTimeoutMs, DEFAULT_CONFIG.checkTimeoutMs);
-  } catch (error96) {
+  } catch (error93) {
     return {
       id: reportId,
       timestamp: startTime,
@@ -55166,7 +54407,7 @@ async function runPreflight(dir, phase, config3) {
         {
           type: "lint",
           status: "error",
-          message: `Invalid config: ${error96 instanceof Error ? error96.message : String(error96)}`
+          message: `Invalid config: ${error93 instanceof Error ? error93.message : String(error93)}`
         }
       ],
       totalDurationMs: Date.now() - startTime,
@@ -55372,20 +54613,20 @@ async function handlePromoteCommand(directory, args) {
   if (lessonId) {
     try {
       return await promoteFromSwarm(directory, lessonId);
-    } catch (error96) {
-      if (error96 instanceof Error) {
-        return error96.message;
+    } catch (error93) {
+      if (error93 instanceof Error) {
+        return error93.message;
       }
-      return `Failed to promote lesson: ${error96 instanceof Error ? error96.message : String(error96)}`;
+      return `Failed to promote lesson: ${error93 instanceof Error ? error93.message : String(error93)}`;
     }
   }
   try {
     return await promoteToHive(directory, lessonText, category);
-  } catch (error96) {
-    if (error96 instanceof Error) {
-      return error96.message;
+  } catch (error93) {
+    if (error93 instanceof Error) {
+      return error93.message;
     }
-    return `Failed to promote lesson: ${error96 instanceof Error ? error96.message : String(error96)}`;
+    return `Failed to promote lesson: ${error93 instanceof Error ? error93.message : String(error93)}`;
   }
 }
 var init_promote = __esm(() => {
@@ -55554,8 +54795,8 @@ class CircuitBreaker {
   async execute(fn) {
     const state = this.getState();
     if (state === "open") {
-      const error96 = new Error(`Circuit breaker '${this.name}' is open`);
-      throw error96;
+      const error93 = new Error(`Circuit breaker '${this.name}' is open`);
+      throw error93;
     }
     const startTime = Date.now();
     try {
@@ -55563,10 +54804,10 @@ class CircuitBreaker {
       const duration5 = Date.now() - startTime;
       this.recordSuccess(duration5);
       return result;
-    } catch (error96) {
+    } catch (error93) {
       const duration5 = Date.now() - startTime;
-      this.recordFailure(error96, duration5);
-      throw error96;
+      this.recordFailure(error93, duration5);
+      throw error93;
     }
   }
   async executeWithTimeout(fn) {
@@ -55580,9 +54821,9 @@ class CircuitBreaker {
       fn().then((result) => {
         clearTimeout(timeout);
         resolve17(result);
-      }).catch((error96) => {
+      }).catch((error93) => {
         clearTimeout(timeout);
-        reject(error96);
+        reject(error93);
       });
     });
   }
@@ -55596,7 +54837,7 @@ class CircuitBreaker {
     }
     this.onStateChange?.("callSuccess", { duration: duration5 });
   }
-  recordFailure(error96, duration5) {
+  recordFailure(error93, duration5) {
     this.failureCount++;
     this.lastFailureTime = Date.now();
     if (this.state === "half-open") {
@@ -55604,7 +54845,7 @@ class CircuitBreaker {
     } else if (this.state === "closed" && this.failureCount >= this.config.failureThreshold) {
       this.transitionTo("open");
     }
-    this.onStateChange?.("callFailure", { error: error96, duration: duration5 });
+    this.onStateChange?.("callFailure", { error: error93, duration: duration5 });
   }
   transitionTo(newState) {
     const oldState = this.state;
@@ -55942,11 +55183,11 @@ class WorkerManager {
         });
       }
     };
-    processLoop().catch((error96) => {
+    processLoop().catch((error93) => {
       this.eventBus.publish("worker.error", {
         workerName: worker.name,
         itemId: "loop",
-        error: error96
+        error: error93
       });
     });
   }
@@ -55961,15 +55202,15 @@ class WorkerManager {
         worker.lastError = result.error;
         worker.queue.retry(item.id, result.error);
       }
-    } catch (error96) {
+    } catch (error93) {
       worker.errorCount++;
-      worker.lastError = error96;
+      worker.lastError = error93;
       this.eventBus.publish("worker.error", {
         workerName: worker.name,
         itemId: item.id,
-        error: error96
+        error: error93
       });
-      worker.queue.retry(item.id, error96);
+      worker.queue.retry(item.id, error93);
     }
   }
   stop(name) {
@@ -56381,8 +55622,8 @@ async function loadFullOutput(directory, id) {
     }
     warn(`Summary entry ${sanitizedId} missing valid fullOutput field`);
     return null;
-  } catch (error96) {
-    warn(`Summary entry validation failed for ${sanitizedId}: ${error96 instanceof Error ? error96.message : String(error96)}`);
+  } catch (error93) {
+    warn(`Summary entry validation failed for ${sanitizedId}: ${error93 instanceof Error ? error93.message : String(error93)}`);
     return null;
   }
 }
@@ -56419,10 +55660,10 @@ No stored output found for ID \`${summaryId}\`.
 Use a valid summary ID (e.g., S1, S2, S3).`;
     }
     return fullOutput;
-  } catch (error96) {
+  } catch (error93) {
     return `## Retrieve Failed
 
-${error96 instanceof Error ? error96.message : String(error96)}`;
+${error93 instanceof Error ? error93.message : String(error93)}`;
   }
 }
 var init_retrieve = __esm(() => {
@@ -56501,8 +55742,8 @@ async function handleRollbackCommand(directory, args) {
     try {
       fs27.cpSync(src, dest, { recursive: true, force: true });
       successes.push(file3);
-    } catch (error96) {
-      failures.push({ file: file3, error: error96.message });
+    } catch (error93) {
+      failures.push({ file: file3, error: error93.message });
     }
   }
   if (failures.length > 0) {
@@ -56552,8 +55793,8 @@ async function handleRollbackCommand(directory, args) {
   try {
     fs27.appendFileSync(eventsPath, `${JSON.stringify(rollbackEvent)}
 `);
-  } catch (error96) {
-    console.error("Failed to write rollback event:", error96 instanceof Error ? error96.message : String(error96));
+  } catch (error93) {
+    console.error("Failed to write rollback event:", error93 instanceof Error ? error93.message : String(error93));
   }
   return `Rolled back to phase ${targetPhase}: ${checkpoint2.label || "no label"}`;
 }
@@ -56708,8 +55949,8 @@ function readPersisted2(directory) {
       updatedAt: parsed.updatedAt ?? nowISO2(),
       sessions: parsed.sessions
     };
-  } catch (error96) {
-    const reason = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const reason = error93 instanceof Error ? error93.message : String(error93);
     markStateUnreadable2(directory, reason);
     return null;
   }
@@ -56728,16 +55969,16 @@ function writePersisted2(directory, persisted) {
     persisted.updatedAt = nowISO2();
     payload = `${JSON.stringify(persisted, null, 2)}
 `;
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     error(`[turbo/lean/state] Failed to prepare ${STATE_FILE2} write: ${msg}`);
     throw new Error(`Lean Turbo state persistence prepare failed: ${msg}`);
   }
   try {
     fs28.writeFileSync(tmpPath, payload, "utf-8");
     fs28.renameSync(tmpPath, filePath);
-  } catch (error96) {
-    const msg = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    const msg = error93 instanceof Error ? error93.message : String(error93);
     error(`[turbo/lean/state] Failed to persist ${STATE_FILE2} atomically: ${msg}`);
     try {
       if (fs28.existsSync(tmpPath)) {
@@ -57148,8 +56389,8 @@ async function handleTurboCommand(directory, args, sessionID) {
     if (isLeanActive) {
       try {
         pauseLeanTurboRun(directory, sessionID, reason);
-      } catch (error96) {
-        error(`[turbo] pauseLeanTurboRun failed: ${error96 instanceof Error ? error96.message : String(error96)}`);
+      } catch (error93) {
+        error(`[turbo] pauseLeanTurboRun failed: ${error93 instanceof Error ? error93.message : String(error93)}`);
       }
     }
     session.turboMode = false;
@@ -57184,8 +56425,8 @@ async function handleTurboCommand(directory, args, sessionID) {
       if (config3.turbo?.strategy === "lean") {
         strategy = "lean";
       }
-    } catch (error96) {
-      warn(`[turbo] could not read config for strategy default: ${error96 instanceof Error ? error96.message : String(error96)}`);
+    } catch (error93) {
+      warn(`[turbo] could not read config for strategy default: ${error93 instanceof Error ? error93.message : String(error93)}`);
     }
     if (strategy === "lean") {
       return enableLeanTurbo(session, directory, sessionID);
@@ -57241,16 +56482,16 @@ function enableLeanTurbo(session, directory, sessionID) {
       maxParallelCoders = leanConfig.max_parallel_coders ?? 4;
       conflictPolicy = leanConfig.conflict_policy ?? "serialize";
     }
-  } catch (error96) {
-    warn(`[turbo] could not read lean config: ${error96 instanceof Error ? error96.message : String(error96)}`);
+  } catch (error93) {
+    warn(`[turbo] could not read lean config: ${error93 instanceof Error ? error93.message : String(error93)}`);
   }
   let durableError;
   try {
     const state = emptyRunState(sessionID, maxParallelCoders);
     state.status = "running";
     saveLeanTurboRunState(directory, state);
-  } catch (error96) {
-    durableError = error96 instanceof Error ? error96.message : String(error96);
+  } catch (error93) {
+    durableError = error93 instanceof Error ? error93.message : String(error93);
     error(`[turbo] durable run-state write failed: ${durableError}`);
   }
   if (durableError) {
@@ -58854,9 +58095,9 @@ function writeProjectConfigIfMissing(cwd) {
     ensureDir(opencodeDir);
     saveJson(projectConfigPath, { agents: {} });
     console.log("\u2713 Created project config at:", projectConfigPath);
-  } catch (error96) {
+  } catch (error93) {
     console.warn("\u26A0 Could not create project config \u2014 installation will continue:");
-    console.warn(`  ${error96 instanceof Error ? error96.message : String(error96)}`);
+    console.warn(`  ${error93 instanceof Error ? error93.message : String(error93)}`);
   }
 }
 async function install() {
@@ -59084,8 +58325,8 @@ async function uninstall() {
     console.log(`
 \u2705 Uninstall complete!`);
     return 0;
-  } catch (error96) {
-    console.log("\u2717 Uninstall failed: " + (error96 instanceof Error ? error96.message : String(error96)));
+  } catch (error93) {
+    console.log("\u2717 Uninstall failed: " + (error93 instanceof Error ? error93.message : String(error93)));
     return 1;
   }
 }

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -677,10 +677,10 @@ function $constructor(name, initializer, params) {
   }
   Object.defineProperty(Definition, "name", { value: name });
   function _(def) {
-    var _a;
+    var _a2;
     const inst = params?.Parent ? new Definition : this;
     init(inst, def);
-    (_a = inst._zod).deferred ?? (_a.deferred = []);
+    (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
     for (const fn of inst._zod.deferred) {
       fn();
     }
@@ -702,9 +702,9 @@ function config(newConfig) {
     Object.assign(globalConfig, newConfig);
   return globalConfig;
 }
-var NEVER, $brand, $ZodAsyncError, $ZodEncodeError, globalConfig;
+var _a, NEVER, $brand, $ZodAsyncError, $ZodEncodeError, globalConfig;
 var init_core = __esm(() => {
-  NEVER = Object.freeze({
+  NEVER = /* @__PURE__ */ Object.freeze({
     status: "aborted"
   });
   $brand = Symbol("zod_brand");
@@ -719,7 +719,8 @@ var init_core = __esm(() => {
       this.name = "ZodEncodeError";
     }
   };
-  globalConfig = {};
+  (_a = globalThis).__zod_globalConfig ?? (_a.__zod_globalConfig = {});
+  globalConfig = globalThis.__zod_globalConfig;
 });
 
 // node_modules/zod/v4/core/util.js
@@ -764,6 +765,7 @@ __export(exports_util, {
   floatSafeRemainder: () => floatSafeRemainder,
   finalizeIssue: () => finalizeIssue,
   extend: () => extend,
+  explicitlyAborted: () => explicitlyAborted,
   escapeRegex: () => escapeRegex2,
   esc: () => esc,
   defineLazy: () => defineLazy,
@@ -834,19 +836,12 @@ function cleanRegex(source) {
   return source.slice(start, end);
 }
 function floatSafeRemainder(val, step) {
-  const valDecCount = (val.toString().split(".")[1] || "").length;
-  const stepString = step.toString();
-  let stepDecCount = (stepString.split(".")[1] || "").length;
-  if (stepDecCount === 0 && /\d?e-\d?/.test(stepString)) {
-    const match = stepString.match(/\d?e-(\d?)/);
-    if (match?.[1]) {
-      stepDecCount = Number.parseInt(match[1]);
-    }
-  }
-  const decCount = valDecCount > stepDecCount ? valDecCount : stepDecCount;
-  const valInt = Number.parseInt(val.toFixed(decCount).replace(".", ""));
-  const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
-  return valInt % stepInt / 10 ** decCount;
+  const ratio = val / step;
+  const roundedRatio = Math.round(ratio);
+  const tolerance = Number.EPSILON * Math.max(Math.abs(ratio), 1);
+  if (Math.abs(ratio - roundedRatio) < tolerance)
+    return 0;
+  return ratio - roundedRatio;
 }
 function defineLazy(object, key, getter) {
   let value = undefined;
@@ -945,6 +940,10 @@ function shallowClone(o) {
     return { ...o };
   if (Array.isArray(o))
     return [...o];
+  if (o instanceof Map)
+    return new Map(o);
+  if (o instanceof Set)
+    return new Set(o);
   return o;
 }
 function numKeys(data) {
@@ -1113,6 +1112,9 @@ function safeExtend(schema, shape) {
   return clone(schema, def);
 }
 function merge(a, b) {
+  if (a._zod.def.checks?.length) {
+    throw new Error(".merge() cannot be used on object schemas containing refinements. Use .safeExtend() instead.");
+  }
   const def = mergeDefs(a._zod.def, {
     get shape() {
       const _shape = { ...a._zod.def.shape, ...b._zod.def.shape };
@@ -1122,7 +1124,7 @@ function merge(a, b) {
     get catchall() {
       return b._zod.def.catchall;
     },
-    checks: []
+    checks: b._zod.def.checks ?? []
   });
   return clone(a, def);
 }
@@ -1205,10 +1207,20 @@ function aborted(x, startIndex = 0) {
   }
   return false;
 }
+function explicitlyAborted(x, startIndex = 0) {
+  if (x.aborted === true)
+    return true;
+  for (let i = startIndex;i < x.issues.length; i++) {
+    if (x.issues[i]?.continue === false) {
+      return true;
+    }
+  }
+  return false;
+}
 function prefixIssues(path3, issues) {
   return issues.map((iss) => {
-    var _a;
-    (_a = iss).path ?? (_a.path = []);
+    var _a2;
+    (_a2 = iss).path ?? (_a2.path = []);
     iss.path.unshift(path3);
     return iss;
   });
@@ -1217,17 +1229,14 @@ function unwrapMessage(message) {
   return typeof message === "string" ? message : message?.message;
 }
 function finalizeIssue(iss, ctx, config2) {
-  const full = { ...iss, path: iss.path ?? [] };
-  if (!iss.message) {
-    const message = unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ?? unwrapMessage(ctx?.error?.(iss)) ?? unwrapMessage(config2.customError?.(iss)) ?? unwrapMessage(config2.localeError?.(iss)) ?? "Invalid input";
-    full.message = message;
+  const message = iss.message ? iss.message : unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ?? unwrapMessage(ctx?.error?.(iss)) ?? unwrapMessage(config2.customError?.(iss)) ?? unwrapMessage(config2.localeError?.(iss)) ?? "Invalid input";
+  const { inst: _inst, continue: _continue, input: _input, ...rest } = iss;
+  rest.path ?? (rest.path = []);
+  rest.message = message;
+  if (ctx?.reportInput) {
+    rest.input = _input;
   }
-  delete full.inst;
-  delete full.continue;
-  if (!ctx?.reportInput) {
-    delete full.input;
-  }
-  return full;
+  return rest;
 }
 function getSizableOrigin(input) {
   if (input instanceof Set)
@@ -1369,9 +1378,13 @@ var EVALUATING, captureStackTrace, allowsEval, getParsedType = (data) => {
   }
 }, propertyKeyTypes, primitiveTypes, NUMBER_FORMAT_RANGES, BIGINT_FORMAT_RANGES;
 var init_util = __esm(() => {
-  EVALUATING = Symbol("evaluating");
+  init_core();
+  EVALUATING = /* @__PURE__ */ Symbol("evaluating");
   captureStackTrace = "captureStackTrace" in Error ? Error.captureStackTrace : (..._args) => {};
-  allowsEval = cached(() => {
+  allowsEval = /* @__PURE__ */ cached(() => {
+    if (globalConfig.jitless) {
+      return false;
+    }
     if (typeof navigator !== "undefined" && navigator?.userAgent?.includes("Cloudflare")) {
       return false;
     }
@@ -1383,8 +1396,15 @@ var init_util = __esm(() => {
       return false;
     }
   });
-  propertyKeyTypes = new Set(["string", "number", "symbol"]);
-  primitiveTypes = new Set(["string", "number", "bigint", "boolean", "symbol", "undefined"]);
+  propertyKeyTypes = /* @__PURE__ */ new Set(["string", "number", "symbol"]);
+  primitiveTypes = /* @__PURE__ */ new Set([
+    "string",
+    "number",
+    "bigint",
+    "boolean",
+    "symbol",
+    "undefined"
+  ]);
   NUMBER_FORMAT_RANGES = {
     safeint: [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
     int32: [-2147483648, 2147483647],
@@ -1414,30 +1434,33 @@ function flattenError(error2, mapper = (issue2) => issue2.message) {
 }
 function formatError(error2, mapper = (issue2) => issue2.message) {
   const fieldErrors = { _errors: [] };
-  const processError = (error3) => {
+  const processError = (error3, path3 = []) => {
     for (const issue2 of error3.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }));
+        issue2.errors.map((issues) => processError({ issues }, [...path3, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues });
+        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues });
-      } else if (issue2.path.length === 0) {
-        fieldErrors._errors.push(mapper(issue2));
+        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
       } else {
-        let curr = fieldErrors;
-        let i = 0;
-        while (i < issue2.path.length) {
-          const el = issue2.path[i];
-          const terminal = i === issue2.path.length - 1;
-          if (!terminal) {
-            curr[el] = curr[el] || { _errors: [] };
-          } else {
-            curr[el] = curr[el] || { _errors: [] };
-            curr[el]._errors.push(mapper(issue2));
+        const fullpath = [...path3, ...issue2.path];
+        if (fullpath.length === 0) {
+          fieldErrors._errors.push(mapper(issue2));
+        } else {
+          let curr = fieldErrors;
+          let i = 0;
+          while (i < fullpath.length) {
+            const el = fullpath[i];
+            const terminal = i === fullpath.length - 1;
+            if (!terminal) {
+              curr[el] = curr[el] || { _errors: [] };
+            } else {
+              curr[el] = curr[el] || { _errors: [] };
+              curr[el]._errors.push(mapper(issue2));
+            }
+            curr = curr[el];
+            i++;
           }
-          curr = curr[el];
-          i++;
         }
       }
     }
@@ -1448,14 +1471,14 @@ function formatError(error2, mapper = (issue2) => issue2.message) {
 function treeifyError(error2, mapper = (issue2) => issue2.message) {
   const result = { errors: [] };
   const processError = (error3, path3 = []) => {
-    var _a, _b;
+    var _a2, _b;
     for (const issue2 of error3.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, issue2.path));
+        issue2.errors.map((issues) => processError({ issues }, [...path3, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, issue2.path);
+        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, issue2.path);
+        processError({ issues: issue2.issues }, [...path3, ...issue2.path]);
       } else {
         const fullpath = [...path3, ...issue2.path];
         if (fullpath.length === 0) {
@@ -1469,7 +1492,7 @@ function treeifyError(error2, mapper = (issue2) => issue2.message) {
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
             curr.properties ?? (curr.properties = {});
-            (_a = curr.properties)[el] ?? (_a[el] = { errors: [] });
+            (_a2 = curr.properties)[el] ?? (_a2[el] = { errors: [] });
             curr = curr.properties[el];
           } else {
             curr.items ?? (curr.items = []);
@@ -1541,7 +1564,7 @@ var init_errors2 = __esm(() => {
 
 // node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
-  const ctx = _ctx ? Object.assign(_ctx, { async: false }) : { async: false };
+  const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) {
     throw new $ZodAsyncError;
@@ -1553,7 +1576,7 @@ var _parse = (_Err) => (schema, value, _ctx, _params) => {
   }
   return result.value;
 }, parse, _parseAsync = (_Err) => async (schema, value, _ctx, params) => {
-  const ctx = _ctx ? Object.assign(_ctx, { async: true }) : { async: true };
+  const ctx = _ctx ? { ..._ctx, async: true } : { async: true };
   let result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise)
     result = await result;
@@ -1574,7 +1597,7 @@ var _parse = (_Err) => (schema, value, _ctx, _params) => {
     error: new (_Err ?? $ZodError)(result.issues.map((iss) => finalizeIssue(iss, ctx, config())))
   } : { success: true, data: result.value };
 }, safeParse, _safeParseAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { async: true }) : { async: true };
+  const ctx = _ctx ? { ..._ctx, async: true } : { async: true };
   let result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise)
     result = await result;
@@ -1583,22 +1606,22 @@ var _parse = (_Err) => (schema, value, _ctx, _params) => {
     error: new _Err(result.issues.map((iss) => finalizeIssue(iss, ctx, config())))
   } : { success: true, data: result.value };
 }, safeParseAsync, _encode = (_Err) => (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
+  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
   return _parse(_Err)(schema, value, ctx);
 }, encode, _decode = (_Err) => (schema, value, _ctx) => {
   return _parse(_Err)(schema, value, _ctx);
 }, decode, _encodeAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
+  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
   return _parseAsync(_Err)(schema, value, ctx);
 }, encodeAsync, _decodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _parseAsync(_Err)(schema, value, _ctx);
 }, decodeAsync, _safeEncode = (_Err) => (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
+  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
   return _safeParse(_Err)(schema, value, ctx);
 }, safeEncode, _safeDecode = (_Err) => (schema, value, _ctx) => {
   return _safeParse(_Err)(schema, value, _ctx);
 }, safeDecode, _safeEncodeAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" }) : { direction: "backward" };
+  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
   return _safeParseAsync(_Err)(schema, value, ctx);
 }, safeEncodeAsync, _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);
@@ -1661,6 +1684,7 @@ __export(exports_regexes, {
   ipv4: () => ipv4,
   integer: () => integer,
   idnEmail: () => idnEmail,
+  httpProtocol: () => httpProtocol,
   html5Email: () => html5Email,
   hostname: () => hostname,
   hex: () => hex,
@@ -1717,13 +1741,13 @@ var cuid, cuid2, ulid, xid, ksuid, nanoid, duration, extendedDuration, guid, uui
 }, uuid4, uuid6, uuid7, email, html5Email, rfc5322Email, unicodeEmail, idnEmail, browserEmail, _emoji = `^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$`, ipv4, ipv6, mac = (delimiter) => {
   const escapedDelim = escapeRegex2(delimiter ?? ":");
   return new RegExp(`^(?:[0-9A-F]{2}${escapedDelim}){5}[0-9A-F]{2}$|^(?:[0-9a-f]{2}${escapedDelim}){5}[0-9a-f]{2}$`);
-}, cidrv4, cidrv6, base64, base64url, hostname, domain, e164, dateSource = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`, date, string = (params) => {
+}, cidrv4, cidrv6, base64, base64url, hostname, domain, httpProtocol, e164, dateSource = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`, date, string = (params) => {
   const regex = params ? `[\\s\\S]{${params?.minimum ?? 0},${params?.maximum ?? ""}}` : `[\\s\\S]*`;
   return new RegExp(`^${regex}$`);
 }, bigint, integer, number, boolean, _null, _undefined, lowercase, uppercase, hex, md5_hex, md5_base64, md5_base64url, sha1_hex, sha1_base64, sha1_base64url, sha256_hex, sha256_base64, sha256_base64url, sha384_hex, sha384_base64, sha384_base64url, sha512_hex, sha512_base64, sha512_base64url;
 var init_regexes = __esm(() => {
   init_util();
-  cuid = /^[cC][^\s-]{8,}$/;
+  cuid = /^[cC][0-9a-z]{6,}$/;
   cuid2 = /^[0-9a-z]+$/;
   ulid = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/;
   xid = /^[0-9a-vA-V]{20}$/;
@@ -1749,6 +1773,7 @@ var init_regexes = __esm(() => {
   base64url = /^[A-Za-z0-9_-]*$/;
   hostname = /^(?=.{1,253}\.?$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[-0-9a-zA-Z]{0,61}[0-9a-zA-Z])?)*\.?$/;
   domain = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+  httpProtocol = /^https?$/;
   e164 = /^\+[1-9]\d{6,14}$/;
   date = /* @__PURE__ */ new RegExp(`^${dateSource}$`);
   bigint = /^-?\d+n?$/;
@@ -1789,10 +1814,10 @@ var init_checks = __esm(() => {
   init_regexes();
   init_util();
   $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
-    var _a;
+    var _a2;
     inst._zod ?? (inst._zod = {});
     inst._zod.def = def;
-    (_a = inst._zod).onattach ?? (_a.onattach = []);
+    (_a2 = inst._zod).onattach ?? (_a2.onattach = []);
   });
   numericOriginMap = {
     number: "number",
@@ -1858,8 +1883,8 @@ var init_checks = __esm(() => {
   $ZodCheckMultipleOf = /* @__PURE__ */ $constructor("$ZodCheckMultipleOf", (inst, def) => {
     $ZodCheck.init(inst, def);
     inst._zod.onattach.push((inst2) => {
-      var _a;
-      (_a = inst2._zod.bag).multipleOf ?? (_a.multipleOf = def.value);
+      var _a2;
+      (_a2 = inst2._zod.bag).multipleOf ?? (_a2.multipleOf = def.value);
     });
     inst._zod.check = (payload) => {
       if (typeof payload.value !== typeof def.value)
@@ -1992,9 +2017,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMaxSize = /* @__PURE__ */ $constructor("$ZodCheckMaxSize", (inst, def) => {
-    var _a;
+    var _a2;
     $ZodCheck.init(inst, def);
-    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.size !== undefined;
     });
@@ -2020,9 +2045,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMinSize = /* @__PURE__ */ $constructor("$ZodCheckMinSize", (inst, def) => {
-    var _a;
+    var _a2;
     $ZodCheck.init(inst, def);
-    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.size !== undefined;
     });
@@ -2048,9 +2073,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckSizeEquals = /* @__PURE__ */ $constructor("$ZodCheckSizeEquals", (inst, def) => {
-    var _a;
+    var _a2;
     $ZodCheck.init(inst, def);
-    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.size !== undefined;
     });
@@ -2078,9 +2103,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMaxLength = /* @__PURE__ */ $constructor("$ZodCheckMaxLength", (inst, def) => {
-    var _a;
+    var _a2;
     $ZodCheck.init(inst, def);
-    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.length !== undefined;
     });
@@ -2107,9 +2132,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckMinLength = /* @__PURE__ */ $constructor("$ZodCheckMinLength", (inst, def) => {
-    var _a;
+    var _a2;
     $ZodCheck.init(inst, def);
-    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.length !== undefined;
     });
@@ -2136,9 +2161,9 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckLengthEquals = /* @__PURE__ */ $constructor("$ZodCheckLengthEquals", (inst, def) => {
-    var _a;
+    var _a2;
     $ZodCheck.init(inst, def);
-    (_a = inst._zod.def).when ?? (_a.when = (payload) => {
+    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
       const val = payload.value;
       return !nullish(val) && val.length !== undefined;
     });
@@ -2167,7 +2192,7 @@ var init_checks = __esm(() => {
     };
   });
   $ZodCheckStringFormat = /* @__PURE__ */ $constructor("$ZodCheckStringFormat", (inst, def) => {
-    var _a, _b;
+    var _a2, _b;
     $ZodCheck.init(inst, def);
     inst._zod.onattach.push((inst2) => {
       const bag = inst2._zod.bag;
@@ -2178,7 +2203,7 @@ var init_checks = __esm(() => {
       }
     });
     if (def.pattern)
-      (_a = inst._zod).check ?? (_a.check = (payload) => {
+      (_a2 = inst._zod).check ?? (_a2.check = (payload) => {
         def.pattern.lastIndex = 0;
         if (def.pattern.test(payload.value))
           return;
@@ -2373,8 +2398,8 @@ var version;
 var init_versions = __esm(() => {
   version = {
     major: 4,
-    minor: 3,
-    patch: 6
+    minor: 4,
+    patch: 3
   };
 });
 
@@ -2382,6 +2407,8 @@ var init_versions = __esm(() => {
 function isValidBase64(data) {
   if (data === "")
     return true;
+  if (/\s/.test(data))
+    return false;
   if (data.length % 4 !== 0)
     return false;
   try {
@@ -2424,15 +2451,27 @@ function handleArrayResult(result, final, index) {
   }
   final.value[index] = result.value;
 }
-function handlePropertyResult(result, final, key, input, isOptionalOut) {
+function handlePropertyResult(result, final, key, input, isOptionalIn, isOptionalOut) {
+  const isPresent = key in input;
   if (result.issues.length) {
-    if (isOptionalOut && !(key in input)) {
+    if (isOptionalIn && isOptionalOut && !isPresent) {
       return;
     }
     final.issues.push(...prefixIssues(key, result.issues));
   }
+  if (!isPresent && !isOptionalIn) {
+    if (!result.issues.length) {
+      final.issues.push({
+        code: "invalid_type",
+        expected: "nonoptional",
+        input: undefined,
+        path: [key]
+      });
+    }
+    return;
+  }
   if (result.value === undefined) {
-    if (key in input) {
+    if (isPresent) {
       final.value[key] = undefined;
     }
   } else {
@@ -2460,8 +2499,11 @@ function handleCatchall(proms, input, payload, ctx, def, inst) {
   const keySet = def.keySet;
   const _catchall = def.catchall._zod;
   const t = _catchall.def.type;
+  const isOptionalIn = _catchall.optin === "optional";
   const isOptionalOut = _catchall.optout === "optional";
   for (const key in input) {
+    if (key === "__proto__")
+      continue;
     if (keySet.has(key))
       continue;
     if (t === "never") {
@@ -2470,9 +2512,9 @@ function handleCatchall(proms, input, payload, ctx, def, inst) {
     }
     const r = _catchall.run({ value: input[key], issues: [] }, ctx);
     if (r instanceof Promise) {
-      proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalOut)));
+      proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalIn, isOptionalOut)));
     } else {
-      handlePropertyResult(r, payload, key, input, isOptionalOut);
+      handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
     }
   }
   if (unrecognized.length) {
@@ -2616,11 +2658,40 @@ function handleIntersectionResults(result, left, right) {
   result.value = merged.data;
   return result;
 }
+function getTupleOptStart(items, key) {
+  for (let i = items.length - 1;i >= 0; i--) {
+    if (items[i]._zod[key] !== "optional")
+      return i + 1;
+  }
+  return 0;
+}
 function handleTupleResult(result, final, index) {
   if (result.issues.length) {
     final.issues.push(...prefixIssues(index, result.issues));
   }
   final.value[index] = result.value;
+}
+function handleTupleResults(itemResults, final, items, input, optoutStart) {
+  for (let i = 0;i < items.length; i++) {
+    const r = itemResults[i];
+    const isPresent = i < input.length;
+    if (r.issues.length) {
+      if (!isPresent && i >= optoutStart) {
+        final.value.length = i;
+        break;
+      }
+      final.issues.push(...prefixIssues(i, r.issues));
+    }
+    final.value[i] = r.value;
+  }
+  for (let i = final.value.length - 1;i >= input.length; i--) {
+    if (items[i]._zod.optout === "optional" && final.value[i] === undefined) {
+      final.value.length = i;
+    } else {
+      break;
+    }
+  }
+  return final;
 }
 function handleMapResult(keyResult, valueResult, final, key, input, inst, ctx) {
   if (keyResult.issues.length) {
@@ -2659,7 +2730,7 @@ function handleSetResult(result, final) {
   final.value.add(result.value);
 }
 function handleOptionalResult(result, input) {
-  if (result.issues.length && input === undefined) {
+  if (input === undefined && (result.issues.length || result.fallback)) {
     return { issues: [], value: undefined };
   }
   return result;
@@ -2686,7 +2757,7 @@ function handlePipeResult(left, next, ctx) {
     left.aborted = true;
     return left;
   }
-  return next._zod.run({ value: left.value, issues: left.issues }, ctx);
+  return next._zod.run({ value: left.value, issues: left.issues, fallback: left.fallback }, ctx);
 }
 function handleCodecAResult(result, def, ctx) {
   if (result.issues.length) {
@@ -2733,7 +2804,7 @@ function handleRefineResult(result, payload, input, inst) {
     payload.issues.push(issue(_iss));
   }
 }
-var $ZodType, $ZodString, $ZodStringFormat, $ZodGUID, $ZodUUID, $ZodEmail, $ZodURL, $ZodEmoji, $ZodNanoID, $ZodCUID, $ZodCUID2, $ZodULID, $ZodXID, $ZodKSUID, $ZodISODateTime, $ZodISODate, $ZodISOTime, $ZodISODuration, $ZodIPv4, $ZodIPv6, $ZodMAC, $ZodCIDRv4, $ZodCIDRv6, $ZodBase64, $ZodBase64URL, $ZodE164, $ZodJWT, $ZodCustomStringFormat, $ZodNumber, $ZodNumberFormat, $ZodBoolean, $ZodBigInt, $ZodBigIntFormat, $ZodSymbol, $ZodUndefined, $ZodNull, $ZodAny, $ZodUnknown, $ZodNever, $ZodVoid, $ZodDate, $ZodArray, $ZodObject, $ZodObjectJIT, $ZodUnion, $ZodXor, $ZodDiscriminatedUnion, $ZodIntersection, $ZodTuple, $ZodRecord, $ZodMap, $ZodSet, $ZodEnum, $ZodLiteral, $ZodFile, $ZodTransform, $ZodOptional, $ZodExactOptional, $ZodNullable, $ZodDefault, $ZodPrefault, $ZodNonOptional, $ZodSuccess, $ZodCatch, $ZodNaN, $ZodPipe, $ZodCodec, $ZodReadonly, $ZodTemplateLiteral, $ZodFunction, $ZodPromise, $ZodLazy, $ZodCustom;
+var $ZodType, $ZodString, $ZodStringFormat, $ZodGUID, $ZodUUID, $ZodEmail, $ZodURL, $ZodEmoji, $ZodNanoID, $ZodCUID, $ZodCUID2, $ZodULID, $ZodXID, $ZodKSUID, $ZodISODateTime, $ZodISODate, $ZodISOTime, $ZodISODuration, $ZodIPv4, $ZodIPv6, $ZodMAC, $ZodCIDRv4, $ZodCIDRv6, $ZodBase64, $ZodBase64URL, $ZodE164, $ZodJWT, $ZodCustomStringFormat, $ZodNumber, $ZodNumberFormat, $ZodBoolean, $ZodBigInt, $ZodBigIntFormat, $ZodSymbol, $ZodUndefined, $ZodNull, $ZodAny, $ZodUnknown, $ZodNever, $ZodVoid, $ZodDate, $ZodArray, $ZodObject, $ZodObjectJIT, $ZodUnion, $ZodXor, $ZodDiscriminatedUnion, $ZodIntersection, $ZodTuple, $ZodRecord, $ZodMap, $ZodSet, $ZodEnum, $ZodLiteral, $ZodFile, $ZodTransform, $ZodOptional, $ZodExactOptional, $ZodNullable, $ZodDefault, $ZodPrefault, $ZodNonOptional, $ZodSuccess, $ZodCatch, $ZodNaN, $ZodPipe, $ZodCodec, $ZodPreprocess, $ZodReadonly, $ZodTemplateLiteral, $ZodFunction, $ZodPromise, $ZodLazy, $ZodCustom;
 var init_schemas = __esm(() => {
   init_checks();
   init_core();
@@ -2743,7 +2814,7 @@ var init_schemas = __esm(() => {
   init_versions();
   init_util();
   $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
-    var _a;
+    var _a2;
     inst ?? (inst = {});
     inst._zod.def = def;
     inst._zod.bag = inst._zod.bag || {};
@@ -2758,7 +2829,7 @@ var init_schemas = __esm(() => {
       }
     }
     if (checks.length === 0) {
-      (_a = inst._zod).deferred ?? (_a.deferred = []);
+      (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
       inst._zod.deferred?.push(() => {
         inst._zod.run = inst._zod.parse;
       });
@@ -2768,6 +2839,8 @@ var init_schemas = __esm(() => {
         let asyncResult;
         for (const ch of checks2) {
           if (ch._zod.def.when) {
+            if (explicitlyAborted(payload))
+              continue;
             const shouldRun = ch._zod.def.when(payload);
             if (!shouldRun)
               continue;
@@ -2907,6 +2980,19 @@ var init_schemas = __esm(() => {
     inst._zod.check = (payload) => {
       try {
         const trimmed = payload.value.trim();
+        if (!def.normalize && def.protocol?.source === httpProtocol.source) {
+          if (!/^https?:\/\//i.test(trimmed)) {
+            payload.issues.push({
+              code: "invalid_format",
+              format: "url",
+              note: "Invalid URL format",
+              input: payload.value,
+              inst,
+              continue: !def.abort
+            });
+            return;
+          }
+        }
         const url = new URL(trimmed);
         if (def.hostname) {
           def.hostname.lastIndex = 0;
@@ -3210,8 +3296,6 @@ var init_schemas = __esm(() => {
     $ZodType.init(inst, def);
     inst._zod.pattern = _undefined;
     inst._zod.values = new Set([undefined]);
-    inst._zod.optin = "optional";
-    inst._zod.optout = "optional";
     inst._zod.parse = (payload, _ctx) => {
       const input = payload.value;
       if (typeof input === "undefined")
@@ -3382,12 +3466,13 @@ var init_schemas = __esm(() => {
       const shape = value.shape;
       for (const key of value.keys) {
         const el = shape[key];
+        const isOptionalIn = el._zod.optin === "optional";
         const isOptionalOut = el._zod.optout === "optional";
         const r = el._zod.run({ value: input[key], issues: [] }, ctx);
         if (r instanceof Promise) {
-          proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalOut)));
+          proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalIn, isOptionalOut)));
         } else {
-          handlePropertyResult(r, payload, key, input, isOptionalOut);
+          handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
         }
       }
       if (!catchall) {
@@ -3418,9 +3503,10 @@ var init_schemas = __esm(() => {
         const id = ids[key];
         const k = esc(key);
         const schema = shape[key];
+        const isOptionalIn = schema?._zod?.optin === "optional";
         const isOptionalOut = schema?._zod?.optout === "optional";
         doc.write(`const ${id} = ${parseStr(key)};`);
-        if (isOptionalOut) {
+        if (isOptionalIn && isOptionalOut) {
           doc.write(`
         if (${id}.issues.length) {
           if (${k} in input) {
@@ -3439,6 +3525,33 @@ var init_schemas = __esm(() => {
           newResult[${k}] = ${id}.value;
         }
         
+      `);
+        } else if (!isOptionalIn) {
+          doc.write(`
+        const ${id}_present = ${k} in input;
+        if (${id}.issues.length) {
+          payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
+            ...iss,
+            path: iss.path ? [${k}, ...iss.path] : [${k}]
+          })));
+        }
+        if (!${id}_present && !${id}.issues.length) {
+          payload.issues.push({
+            code: "invalid_type",
+            expected: "nonoptional",
+            input: undefined,
+            path: [${k}]
+          });
+        }
+
+        if (${id}_present) {
+          if (${id}.value === undefined) {
+            newResult[${k}] = undefined;
+          } else {
+            newResult[${k}] = ${id}.value;
+          }
+        }
+
       `);
         } else {
           doc.write(`
@@ -3512,10 +3625,9 @@ var init_schemas = __esm(() => {
       }
       return;
     });
-    const single = def.options.length === 1;
-    const first = def.options[0]._zod.run;
+    const first = def.options.length === 1 ? def.options[0]._zod.run : null;
     inst._zod.parse = (payload, ctx) => {
-      if (single) {
+      if (first) {
         return first(payload, ctx);
       }
       let async = false;
@@ -3544,10 +3656,9 @@ var init_schemas = __esm(() => {
   $ZodXor = /* @__PURE__ */ $constructor("$ZodXor", (inst, def) => {
     $ZodUnion.init(inst, def);
     def.inclusive = false;
-    const single = def.options.length === 1;
-    const first = def.options[0]._zod.run;
+    const first = def.options.length === 1 ? def.options[0]._zod.run : null;
     inst._zod.parse = (payload, ctx) => {
-      if (single) {
+      if (first) {
         return first(payload, ctx);
       }
       let async = false;
@@ -3622,7 +3733,7 @@ var init_schemas = __esm(() => {
       if (opt) {
         return opt._zod.run(payload, ctx);
       }
-      if (def.unionFallback) {
+      if (def.unionFallback || ctx.direction === "backward") {
         return _super(payload, ctx);
       }
       payload.issues.push({
@@ -3630,6 +3741,7 @@ var init_schemas = __esm(() => {
         errors: [],
         note: "No matching discriminator",
         discriminator: def.discriminator,
+        options: Array.from(disc.value.keys()),
         input,
         path: [def.discriminator],
         inst
@@ -3668,56 +3780,59 @@ var init_schemas = __esm(() => {
       }
       payload.value = [];
       const proms = [];
-      const reversedIndex = [...items].reverse().findIndex((item) => item._zod.optin !== "optional");
-      const optStart = reversedIndex === -1 ? 0 : items.length - reversedIndex;
+      const optinStart = getTupleOptStart(items, "optin");
+      const optoutStart = getTupleOptStart(items, "optout");
       if (!def.rest) {
-        const tooBig = input.length > items.length;
-        const tooSmall = input.length < optStart - 1;
-        if (tooBig || tooSmall) {
+        if (input.length < optinStart) {
           payload.issues.push({
-            ...tooBig ? { code: "too_big", maximum: items.length, inclusive: true } : { code: "too_small", minimum: items.length },
+            code: "too_small",
+            minimum: optinStart,
+            inclusive: true,
             input,
             inst,
             origin: "array"
           });
           return payload;
         }
-      }
-      let i = -1;
-      for (const item of items) {
-        i++;
-        if (i >= input.length) {
-          if (i >= optStart)
-            continue;
+        if (input.length > items.length) {
+          payload.issues.push({
+            code: "too_big",
+            maximum: items.length,
+            inclusive: true,
+            input,
+            inst,
+            origin: "array"
+          });
         }
-        const result = item._zod.run({
-          value: input[i],
-          issues: []
-        }, ctx);
-        if (result instanceof Promise) {
-          proms.push(result.then((result2) => handleTupleResult(result2, payload, i)));
+      }
+      const itemResults = new Array(items.length);
+      for (let i = 0;i < items.length; i++) {
+        const r = items[i]._zod.run({ value: input[i], issues: [] }, ctx);
+        if (r instanceof Promise) {
+          proms.push(r.then((rr) => {
+            itemResults[i] = rr;
+          }));
         } else {
-          handleTupleResult(result, payload, i);
+          itemResults[i] = r;
         }
       }
       if (def.rest) {
+        let i = items.length - 1;
         const rest = input.slice(items.length);
         for (const el of rest) {
           i++;
-          const result = def.rest._zod.run({
-            value: el,
-            issues: []
-          }, ctx);
+          const result = def.rest._zod.run({ value: el, issues: [] }, ctx);
           if (result instanceof Promise) {
-            proms.push(result.then((result2) => handleTupleResult(result2, payload, i)));
+            proms.push(result.then((r) => handleTupleResult(r, payload, i)));
           } else {
             handleTupleResult(result, payload, i);
           }
         }
       }
-      if (proms.length)
-        return Promise.all(proms).then(() => payload);
-      return payload;
+      if (proms.length) {
+        return Promise.all(proms).then(() => handleTupleResults(itemResults, payload, items, input, optoutStart));
+      }
+      return handleTupleResults(itemResults, payload, items, input, optoutStart);
     };
   });
   $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
@@ -3741,19 +3856,35 @@ var init_schemas = __esm(() => {
         for (const key of values) {
           if (typeof key === "string" || typeof key === "number" || typeof key === "symbol") {
             recordKeys.add(typeof key === "number" ? key.toString() : key);
+            const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
+            if (keyResult instanceof Promise) {
+              throw new Error("Async schemas not supported in object keys currently");
+            }
+            if (keyResult.issues.length) {
+              payload.issues.push({
+                code: "invalid_key",
+                origin: "record",
+                issues: keyResult.issues.map((iss) => finalizeIssue(iss, ctx, config())),
+                input: key,
+                path: [key],
+                inst
+              });
+              continue;
+            }
+            const outKey = keyResult.value;
             const result = def.valueType._zod.run({ value: input[key], issues: [] }, ctx);
             if (result instanceof Promise) {
               proms.push(result.then((result2) => {
                 if (result2.issues.length) {
                   payload.issues.push(...prefixIssues(key, result2.issues));
                 }
-                payload.value[key] = result2.value;
+                payload.value[outKey] = result2.value;
               }));
             } else {
               if (result.issues.length) {
                 payload.issues.push(...prefixIssues(key, result.issues));
               }
-              payload.value[key] = result.value;
+              payload.value[outKey] = result.value;
             }
           }
         }
@@ -3776,6 +3907,8 @@ var init_schemas = __esm(() => {
         payload.value = {};
         for (const key of Reflect.ownKeys(input)) {
           if (key === "__proto__")
+            continue;
+          if (!Object.prototype.propertyIsEnumerable.call(input, key))
             continue;
           let keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
           if (keyResult instanceof Promise) {
@@ -3945,6 +4078,7 @@ var init_schemas = __esm(() => {
   });
   $ZodTransform = /* @__PURE__ */ $constructor("$ZodTransform", (inst, def) => {
     $ZodType.init(inst, def);
+    inst._zod.optin = "optional";
     inst._zod.parse = (payload, ctx) => {
       if (ctx.direction === "backward") {
         throw new $ZodEncodeError(inst.constructor.name);
@@ -3954,6 +4088,7 @@ var init_schemas = __esm(() => {
         const output = _out instanceof Promise ? _out : Promise.resolve(_out);
         return output.then((output2) => {
           payload.value = output2;
+          payload.fallback = true;
           return payload;
         });
       }
@@ -3961,6 +4096,7 @@ var init_schemas = __esm(() => {
         throw new $ZodAsyncError;
       }
       payload.value = _out;
+      payload.fallback = true;
       return payload;
     };
   });
@@ -3977,10 +4113,11 @@ var init_schemas = __esm(() => {
     });
     inst._zod.parse = (payload, ctx) => {
       if (def.innerType._zod.optin === "optional") {
+        const input = payload.value;
         const result = def.innerType._zod.run(payload, ctx);
         if (result instanceof Promise)
-          return result.then((r) => handleOptionalResult(r, payload.value));
-        return handleOptionalResult(result, payload.value);
+          return result.then((r) => handleOptionalResult(r, input));
+        return handleOptionalResult(result, input);
       }
       if (payload.value === undefined) {
         return payload;
@@ -4079,7 +4216,7 @@ var init_schemas = __esm(() => {
   });
   $ZodCatch = /* @__PURE__ */ $constructor("$ZodCatch", (inst, def) => {
     $ZodType.init(inst, def);
-    defineLazy(inst._zod, "optin", () => def.innerType._zod.optin);
+    inst._zod.optin = "optional";
     defineLazy(inst._zod, "optout", () => def.innerType._zod.optout);
     defineLazy(inst._zod, "values", () => def.innerType._zod.values);
     inst._zod.parse = (payload, ctx) => {
@@ -4099,6 +4236,7 @@ var init_schemas = __esm(() => {
               input: payload.value
             });
             payload.issues = [];
+            payload.fallback = true;
           }
           return payload;
         });
@@ -4113,6 +4251,7 @@ var init_schemas = __esm(() => {
           input: payload.value
         });
         payload.issues = [];
+        payload.fallback = true;
       }
       return payload;
     };
@@ -4175,6 +4314,9 @@ var init_schemas = __esm(() => {
         return handleCodecAResult(right, def, ctx);
       }
     };
+  });
+  $ZodPreprocess = /* @__PURE__ */ $constructor("$ZodPreprocess", (inst, def) => {
+    $ZodPipe.init(inst, def);
   });
   $ZodReadonly = /* @__PURE__ */ $constructor("$ZodReadonly", (inst, def) => {
     $ZodType.init(inst, def);
@@ -4323,7 +4465,12 @@ var init_schemas = __esm(() => {
   });
   $ZodLazy = /* @__PURE__ */ $constructor("$ZodLazy", (inst, def) => {
     $ZodType.init(inst, def);
-    defineLazy(inst._zod, "innerType", () => def.getter());
+    defineLazy(inst._zod, "innerType", () => {
+      const d = def;
+      if (!d._cachedInner)
+        d._cachedInner = def.getter();
+      return d._cachedInner;
+    });
     defineLazy(inst._zod, "pattern", () => inst._zod.innerType?._zod?.pattern);
     defineLazy(inst._zod, "propValues", () => inst._zod.innerType?._zod?.propValues);
     defineLazy(inst._zod, "optin", () => inst._zod.innerType?._zod?.optin ?? undefined);
@@ -5311,13 +5458,126 @@ var init_de = __esm(() => {
   init_util();
 });
 
-// node_modules/zod/v4/locales/en.js
-function en_default() {
+// node_modules/zod/v4/locales/el.js
+function el_default() {
   return {
     localeError: error10()
   };
 }
 var error10 = () => {
+  const Sizable = {
+    string: { unit: "\u03C7\u03B1\u03C1\u03B1\u03BA\u03C4\u03AE\u03C1\u03B5\u03C2", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
+    file: { unit: "bytes", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
+    array: { unit: "\u03C3\u03C4\u03BF\u03B9\u03C7\u03B5\u03AF\u03B1", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
+    set: { unit: "\u03C3\u03C4\u03BF\u03B9\u03C7\u03B5\u03AF\u03B1", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
+    map: { unit: "\u03BA\u03B1\u03C4\u03B1\u03C7\u03C9\u03C1\u03AE\u03C3\u03B5\u03B9\u03C2", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" }
+  };
+  function getSizing(origin) {
+    return Sizable[origin] ?? null;
+  }
+  const FormatDictionary = {
+    regex: "\u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2",
+    email: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 email",
+    url: "URL",
+    emoji: "emoji",
+    uuid: "UUID",
+    uuidv4: "UUIDv4",
+    uuidv6: "UUIDv6",
+    nanoid: "nanoid",
+    guid: "GUID",
+    cuid: "cuid",
+    cuid2: "cuid2",
+    ulid: "ULID",
+    xid: "XID",
+    ksuid: "KSUID",
+    datetime: "ISO \u03B7\u03BC\u03B5\u03C1\u03BF\u03BC\u03B7\u03BD\u03AF\u03B1 \u03BA\u03B1\u03B9 \u03CE\u03C1\u03B1",
+    date: "ISO \u03B7\u03BC\u03B5\u03C1\u03BF\u03BC\u03B7\u03BD\u03AF\u03B1",
+    time: "ISO \u03CE\u03C1\u03B1",
+    duration: "ISO \u03B4\u03B9\u03AC\u03C1\u03BA\u03B5\u03B9\u03B1",
+    ipv4: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 IPv4",
+    ipv6: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 IPv6",
+    mac: "\u03B4\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 MAC",
+    cidrv4: "\u03B5\u03CD\u03C1\u03BF\u03C2 IPv4",
+    cidrv6: "\u03B5\u03CD\u03C1\u03BF\u03C2 IPv6",
+    base64: "\u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC \u03BA\u03C9\u03B4\u03B9\u03BA\u03BF\u03C0\u03BF\u03B9\u03B7\u03BC\u03AD\u03BD\u03B7 \u03C3\u03B5 base64",
+    base64url: "\u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC \u03BA\u03C9\u03B4\u03B9\u03BA\u03BF\u03C0\u03BF\u03B9\u03B7\u03BC\u03AD\u03BD\u03B7 \u03C3\u03B5 base64url",
+    json_string: "\u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC JSON",
+    e164: "\u03B1\u03C1\u03B9\u03B8\u03BC\u03CC\u03C2 E.164",
+    jwt: "JWT",
+    template_literal: "\u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2"
+  };
+  const TypeDictionary = {
+    nan: "NaN"
+  };
+  return (issue2) => {
+    switch (issue2.code) {
+      case "invalid_type": {
+        const expected = TypeDictionary[issue2.expected] ?? issue2.expected;
+        const receivedType = parsedType(issue2.input);
+        const received = TypeDictionary[receivedType] ?? receivedType;
+        if (typeof issue2.expected === "string" && /^[A-Z]/.test(issue2.expected)) {
+          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD instanceof ${issue2.expected}, \u03BB\u03AE\u03C6\u03B8\u03B7\u03BA\u03B5 ${received}`;
+        }
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${expected}, \u03BB\u03AE\u03C6\u03B8\u03B7\u03BA\u03B5 ${received}`;
+      }
+      case "invalid_value":
+        if (issue2.values.length === 1)
+          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${stringifyPrimitive(issue2.values[0])}`;
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03C0\u03B9\u03BB\u03BF\u03B3\u03AE: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD \u03AD\u03BD\u03B1 \u03B1\u03C0\u03CC ${joinValues(issue2.values, "|")}`;
+      case "too_big": {
+        const adj = issue2.inclusive ? "<=" : "<";
+        const sizing = getSizing(issue2.origin);
+        if (sizing)
+          return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B5\u03B3\u03AC\u03BB\u03BF: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin ?? "\u03C4\u03B9\u03BC\u03AE"} \u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9 ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "\u03C3\u03C4\u03BF\u03B9\u03C7\u03B5\u03AF\u03B1"}`;
+        return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B5\u03B3\u03AC\u03BB\u03BF: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin ?? "\u03C4\u03B9\u03BC\u03AE"} \u03BD\u03B1 \u03B5\u03AF\u03BD\u03B1\u03B9 ${adj}${issue2.maximum.toString()}`;
+      }
+      case "too_small": {
+        const adj = issue2.inclusive ? ">=" : ">";
+        const sizing = getSizing(issue2.origin);
+        if (sizing) {
+          return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B9\u03BA\u03C1\u03CC: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin} \u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9 ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
+        }
+        return `\u03A0\u03BF\u03BB\u03CD \u03BC\u03B9\u03BA\u03C1\u03CC: \u03B1\u03BD\u03B1\u03BC\u03B5\u03BD\u03CC\u03C4\u03B1\u03BD ${issue2.origin} \u03BD\u03B1 \u03B5\u03AF\u03BD\u03B1\u03B9 ${adj}${issue2.minimum.toString()}`;
+      }
+      case "invalid_format": {
+        const _issue = issue2;
+        if (_issue.format === "starts_with") {
+          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03BE\u03B5\u03BA\u03B9\u03BD\u03AC \u03BC\u03B5 "${_issue.prefix}"`;
+        }
+        if (_issue.format === "ends_with")
+          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03C4\u03B5\u03BB\u03B5\u03B9\u03CE\u03BD\u03B5\u03B9 \u03BC\u03B5 "${_issue.suffix}"`;
+        if (_issue.format === "includes")
+          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03C0\u03B5\u03C1\u03B9\u03AD\u03C7\u03B5\u03B9 "${_issue.includes}"`;
+        if (_issue.format === "regex")
+          return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C3\u03C5\u03BC\u03B2\u03BF\u03BB\u03BF\u03C3\u03B5\u03B9\u03C1\u03AC: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03C4\u03B1\u03B9\u03C1\u03B9\u03AC\u03B6\u03B5\u03B9 \u03BC\u03B5 \u03C4\u03BF \u03BC\u03BF\u03C4\u03AF\u03B2\u03BF ${_issue.pattern}`;
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03BF: ${FormatDictionary[_issue.format] ?? issue2.format}`;
+      }
+      case "not_multiple_of":
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03BF\u03C2 \u03B1\u03C1\u03B9\u03B8\u03BC\u03CC\u03C2: \u03C0\u03C1\u03AD\u03C0\u03B5\u03B9 \u03BD\u03B1 \u03B5\u03AF\u03BD\u03B1\u03B9 \u03C0\u03BF\u03BB\u03BB\u03B1\u03C0\u03BB\u03AC\u03C3\u03B9\u03BF \u03C4\u03BF\u03C5 ${issue2.divisor}`;
+      case "unrecognized_keys":
+        return `\u0386\u03B3\u03BD\u03C9\u03C3\u03C4${issue2.keys.length > 1 ? "\u03B1" : "\u03BF"} \u03BA\u03BB\u03B5\u03B9\u03B4${issue2.keys.length > 1 ? "\u03B9\u03AC" : "\u03AF"}: ${joinValues(issue2.keys, ", ")}`;
+      case "invalid_key":
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03BF \u03BA\u03BB\u03B5\u03B9\u03B4\u03AF \u03C3\u03C4\u03BF ${issue2.origin}`;
+      case "invalid_union":
+        return "\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2";
+      case "invalid_element":
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03C4\u03B9\u03BC\u03AE \u03C3\u03C4\u03BF ${issue2.origin}`;
+      default:
+        return `\u039C\u03B7 \u03AD\u03B3\u03BA\u03C5\u03C1\u03B7 \u03B5\u03AF\u03C3\u03BF\u03B4\u03BF\u03C2`;
+    }
+  };
+};
+var init_el = __esm(() => {
+  init_util();
+});
+
+// node_modules/zod/v4/locales/en.js
+function en_default() {
+  return {
+    localeError: error11()
+  };
+}
+var error11 = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
     file: { unit: "bytes", verb: "to have" },
@@ -5409,6 +5669,10 @@ var error10 = () => {
       case "invalid_key":
         return `Invalid key in ${issue2.origin}`;
       case "invalid_union":
+        if (issue2.options && Array.isArray(issue2.options) && issue2.options.length > 0) {
+          const opts = issue2.options.map((o) => `'${o}'`).join(" | ");
+          return `Invalid discriminator value. Expected ${opts}`;
+        }
         return "Invalid input";
       case "invalid_element":
         return `Invalid value in ${issue2.origin}`;
@@ -5424,10 +5688,10 @@ var init_en = __esm(() => {
 // node_modules/zod/v4/locales/eo.js
 function eo_default() {
   return {
-    localeError: error11()
+    localeError: error12()
   };
 }
-var error11 = () => {
+var error12 = () => {
   const Sizable = {
     string: { unit: "karaktrojn", verb: "havi" },
     file: { unit: "bajtojn", verb: "havi" },
@@ -5537,10 +5801,10 @@ var init_eo = __esm(() => {
 // node_modules/zod/v4/locales/es.js
 function es_default() {
   return {
-    localeError: error12()
+    localeError: error13()
   };
 }
-var error12 = () => {
+var error13 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "tener" },
     file: { unit: "bytes", verb: "tener" },
@@ -5673,10 +5937,10 @@ var init_es = __esm(() => {
 // node_modules/zod/v4/locales/fa.js
 function fa_default() {
   return {
-    localeError: error13()
+    localeError: error14()
   };
 }
-var error13 = () => {
+var error14 = () => {
   const Sizable = {
     string: { unit: "\u06A9\u0627\u0631\u0627\u06A9\u062A\u0631", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
     file: { unit: "\u0628\u0627\u06CC\u062A", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
@@ -5791,10 +6055,10 @@ var init_fa = __esm(() => {
 // node_modules/zod/v4/locales/fi.js
 function fi_default() {
   return {
-    localeError: error14()
+    localeError: error15()
   };
 }
-var error14 = () => {
+var error15 = () => {
   const Sizable = {
     string: { unit: "merkki\xE4", subject: "merkkijonon" },
     file: { unit: "tavua", subject: "tiedoston" },
@@ -5907,10 +6171,10 @@ var init_fi = __esm(() => {
 // node_modules/zod/v4/locales/fr.js
 function fr_default() {
   return {
-    localeError: error15()
+    localeError: error16()
   };
 }
-var error15 = () => {
+var error16 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -5951,9 +6215,27 @@ var error15 = () => {
     template_literal: "entr\xE9e"
   };
   const TypeDictionary = {
-    nan: "NaN",
+    string: "cha\xEEne",
     number: "nombre",
-    array: "tableau"
+    int: "entier",
+    boolean: "bool\xE9en",
+    bigint: "grand entier",
+    symbol: "symbole",
+    undefined: "ind\xE9fini",
+    null: "null",
+    never: "jamais",
+    void: "vide",
+    date: "date",
+    array: "tableau",
+    object: "objet",
+    tuple: "tuple",
+    record: "enregistrement",
+    map: "carte",
+    set: "ensemble",
+    file: "fichier",
+    nonoptional: "non-optionnel",
+    nan: "NaN",
+    function: "fonction"
   };
   return (issue2) => {
     switch (issue2.code) {
@@ -5974,16 +6256,15 @@ var error15 = () => {
         const adj = issue2.inclusive ? "<=" : "<";
         const sizing = getSizing(issue2.origin);
         if (sizing)
-          return `Trop grand : ${issue2.origin ?? "valeur"} doit ${sizing.verb} ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "\xE9l\xE9ment(s)"}`;
-        return `Trop grand : ${issue2.origin ?? "valeur"} doit \xEAtre ${adj}${issue2.maximum.toString()}`;
+          return `Trop grand : ${TypeDictionary[issue2.origin] ?? "valeur"} doit ${sizing.verb} ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "\xE9l\xE9ment(s)"}`;
+        return `Trop grand : ${TypeDictionary[issue2.origin] ?? "valeur"} doit \xEAtre ${adj}${issue2.maximum.toString()}`;
       }
       case "too_small": {
         const adj = issue2.inclusive ? ">=" : ">";
         const sizing = getSizing(issue2.origin);
-        if (sizing) {
-          return `Trop petit : ${issue2.origin} doit ${sizing.verb} ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
-        }
-        return `Trop petit : ${issue2.origin} doit \xEAtre ${adj}${issue2.minimum.toString()}`;
+        if (sizing)
+          return `Trop petit : ${TypeDictionary[issue2.origin] ?? "valeur"} doit ${sizing.verb} ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
+        return `Trop petit : ${TypeDictionary[issue2.origin] ?? "valeur"} doit \xEAtre ${adj}${issue2.minimum.toString()}`;
       }
       case "invalid_format": {
         const _issue = issue2;
@@ -6019,10 +6300,10 @@ var init_fr = __esm(() => {
 // node_modules/zod/v4/locales/fr-CA.js
 function fr_CA_default() {
   return {
-    localeError: error16()
+    localeError: error17()
   };
 }
-var error16 = () => {
+var error17 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -6130,10 +6411,10 @@ var init_fr_CA = __esm(() => {
 // node_modules/zod/v4/locales/he.js
 function he_default() {
   return {
-    localeError: error17()
+    localeError: error18()
   };
 }
-var error17 = () => {
+var error18 = () => {
   const TypeNames = {
     string: { label: "\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA", gender: "f" },
     number: { label: "\u05DE\u05E1\u05E4\u05E8", gender: "m" },
@@ -6324,13 +6605,139 @@ var init_he = __esm(() => {
   init_util();
 });
 
+// node_modules/zod/v4/locales/hr.js
+function hr_default() {
+  return {
+    localeError: error19()
+  };
+}
+var error19 = () => {
+  const Sizable = {
+    string: { unit: "znakova", verb: "imati" },
+    file: { unit: "bajtova", verb: "imati" },
+    array: { unit: "stavki", verb: "imati" },
+    set: { unit: "stavki", verb: "imati" }
+  };
+  function getSizing(origin) {
+    return Sizable[origin] ?? null;
+  }
+  const FormatDictionary = {
+    regex: "unos",
+    email: "email adresa",
+    url: "URL",
+    emoji: "emoji",
+    uuid: "UUID",
+    uuidv4: "UUIDv4",
+    uuidv6: "UUIDv6",
+    nanoid: "nanoid",
+    guid: "GUID",
+    cuid: "cuid",
+    cuid2: "cuid2",
+    ulid: "ULID",
+    xid: "XID",
+    ksuid: "KSUID",
+    datetime: "ISO datum i vrijeme",
+    date: "ISO datum",
+    time: "ISO vrijeme",
+    duration: "ISO trajanje",
+    ipv4: "IPv4 adresa",
+    ipv6: "IPv6 adresa",
+    cidrv4: "IPv4 raspon",
+    cidrv6: "IPv6 raspon",
+    base64: "base64 kodirani tekst",
+    base64url: "base64url kodirani tekst",
+    json_string: "JSON tekst",
+    e164: "E.164 broj",
+    jwt: "JWT",
+    template_literal: "unos"
+  };
+  const TypeDictionary = {
+    nan: "NaN",
+    string: "tekst",
+    number: "broj",
+    boolean: "boolean",
+    array: "niz",
+    object: "objekt",
+    set: "skup",
+    file: "datoteka",
+    date: "datum",
+    bigint: "bigint",
+    symbol: "simbol",
+    undefined: "undefined",
+    null: "null",
+    function: "funkcija",
+    map: "mapa"
+  };
+  return (issue2) => {
+    switch (issue2.code) {
+      case "invalid_type": {
+        const expected = TypeDictionary[issue2.expected] ?? issue2.expected;
+        const receivedType = parsedType(issue2.input);
+        const received = TypeDictionary[receivedType] ?? receivedType;
+        if (/^[A-Z]/.test(issue2.expected)) {
+          return `Neispravan unos: o\u010Dekuje se instanceof ${issue2.expected}, a primljeno je ${received}`;
+        }
+        return `Neispravan unos: o\u010Dekuje se ${expected}, a primljeno je ${received}`;
+      }
+      case "invalid_value":
+        if (issue2.values.length === 1)
+          return `Neispravna vrijednost: o\u010Dekivano ${stringifyPrimitive(issue2.values[0])}`;
+        return `Neispravna opcija: o\u010Dekivano jedno od ${joinValues(issue2.values, "|")}`;
+      case "too_big": {
+        const adj = issue2.inclusive ? "<=" : "<";
+        const sizing = getSizing(issue2.origin);
+        const origin = TypeDictionary[issue2.origin] ?? issue2.origin;
+        if (sizing)
+          return `Preveliko: o\u010Dekivano da ${origin ?? "vrijednost"} ima ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "elemenata"}`;
+        return `Preveliko: o\u010Dekivano da ${origin ?? "vrijednost"} bude ${adj}${issue2.maximum.toString()}`;
+      }
+      case "too_small": {
+        const adj = issue2.inclusive ? ">=" : ">";
+        const sizing = getSizing(issue2.origin);
+        const origin = TypeDictionary[issue2.origin] ?? issue2.origin;
+        if (sizing) {
+          return `Premalo: o\u010Dekivano da ${origin} ima ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
+        }
+        return `Premalo: o\u010Dekivano da ${origin} bude ${adj}${issue2.minimum.toString()}`;
+      }
+      case "invalid_format": {
+        const _issue = issue2;
+        if (_issue.format === "starts_with")
+          return `Neispravan tekst: mora zapo\u010Dinjati s "${_issue.prefix}"`;
+        if (_issue.format === "ends_with")
+          return `Neispravan tekst: mora zavr\u0161avati s "${_issue.suffix}"`;
+        if (_issue.format === "includes")
+          return `Neispravan tekst: mora sadr\u017Eavati "${_issue.includes}"`;
+        if (_issue.format === "regex")
+          return `Neispravan tekst: mora odgovarati uzorku ${_issue.pattern}`;
+        return `Neispravna ${FormatDictionary[_issue.format] ?? issue2.format}`;
+      }
+      case "not_multiple_of":
+        return `Neispravan broj: mora biti vi\u0161ekratnik od ${issue2.divisor}`;
+      case "unrecognized_keys":
+        return `Neprepoznat${issue2.keys.length > 1 ? "i klju\u010Devi" : " klju\u010D"}: ${joinValues(issue2.keys, ", ")}`;
+      case "invalid_key":
+        return `Neispravan klju\u010D u ${TypeDictionary[issue2.origin] ?? issue2.origin}`;
+      case "invalid_union":
+        return "Neispravan unos";
+      case "invalid_element":
+        return `Neispravna vrijednost u ${TypeDictionary[issue2.origin] ?? issue2.origin}`;
+      default:
+        return `Neispravan unos`;
+    }
+  };
+};
+var init_hr = __esm(() => {
+  init_util();
+});
+
 // node_modules/zod/v4/locales/hu.js
 function hu_default() {
   return {
-    localeError: error18()
+    localeError: error20()
   };
 }
-var error18 = () => {
+var error20 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "legyen" },
     file: { unit: "byte", verb: "legyen" },
@@ -6449,10 +6856,10 @@ function withDefiniteArticle(word) {
 }
 function hy_default() {
   return {
-    localeError: error19()
+    localeError: error21()
   };
 }
-var error19 = () => {
+var error21 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -6590,10 +6997,10 @@ var init_hy = __esm(() => {
 // node_modules/zod/v4/locales/id.js
 function id_default() {
   return {
-    localeError: error20()
+    localeError: error22()
   };
 }
-var error20 = () => {
+var error22 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "memiliki" },
     file: { unit: "byte", verb: "memiliki" },
@@ -6700,10 +7107,10 @@ var init_id = __esm(() => {
 // node_modules/zod/v4/locales/is.js
 function is_default() {
   return {
-    localeError: error21()
+    localeError: error23()
   };
 }
-var error21 = () => {
+var error23 = () => {
   const Sizable = {
     string: { unit: "stafi", verb: "a\xF0 hafa" },
     file: { unit: "b\xE6ti", verb: "a\xF0 hafa" },
@@ -6813,10 +7220,10 @@ var init_is = __esm(() => {
 // node_modules/zod/v4/locales/it.js
 function it_default() {
   return {
-    localeError: error22()
+    localeError: error24()
   };
 }
-var error22 = () => {
+var error24 = () => {
   const Sizable = {
     string: { unit: "caratteri", verb: "avere" },
     file: { unit: "byte", verb: "avere" },
@@ -6901,7 +7308,7 @@ var error22 = () => {
           return `Stringa non valida: deve includere "${_issue.includes}"`;
         if (_issue.format === "regex")
           return `Stringa non valida: deve corrispondere al pattern ${_issue.pattern}`;
-        return `Invalid ${FormatDictionary[_issue.format] ?? issue2.format}`;
+        return `Input non valido: ${FormatDictionary[_issue.format] ?? issue2.format}`;
       }
       case "not_multiple_of":
         return `Numero non valido: deve essere un multiplo di ${issue2.divisor}`;
@@ -6925,10 +7332,10 @@ var init_it = __esm(() => {
 // node_modules/zod/v4/locales/ja.js
 function ja_default() {
   return {
-    localeError: error23()
+    localeError: error25()
   };
 }
-var error23 = () => {
+var error25 = () => {
   const Sizable = {
     string: { unit: "\u6587\u5B57", verb: "\u3067\u3042\u308B" },
     file: { unit: "\u30D0\u30A4\u30C8", verb: "\u3067\u3042\u308B" },
@@ -7036,10 +7443,10 @@ var init_ja = __esm(() => {
 // node_modules/zod/v4/locales/ka.js
 function ka_default() {
   return {
-    localeError: error24()
+    localeError: error26()
   };
 }
-var error24 = () => {
+var error26 = () => {
   const Sizable = {
     string: { unit: "\u10E1\u10D8\u10DB\u10D1\u10DD\u10DA\u10DD", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
     file: { unit: "\u10D1\u10D0\u10D8\u10E2\u10D8", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
@@ -7072,9 +7479,9 @@ var error24 = () => {
     ipv6: "IPv6 \u10DB\u10D8\u10E1\u10D0\u10DB\u10D0\u10E0\u10D7\u10D8",
     cidrv4: "IPv4 \u10D3\u10D8\u10D0\u10DE\u10D0\u10D6\u10DD\u10DC\u10D8",
     cidrv6: "IPv6 \u10D3\u10D8\u10D0\u10DE\u10D0\u10D6\u10DD\u10DC\u10D8",
-    base64: "base64-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
-    base64url: "base64url-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
-    json_string: "JSON \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
+    base64: "base64-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10D5\u10D4\u10DA\u10D8",
+    base64url: "base64url-\u10D9\u10DD\u10D3\u10D8\u10E0\u10D4\u10D1\u10E3\u10DA\u10D8 \u10D5\u10D4\u10DA\u10D8",
+    json_string: "JSON \u10D5\u10D4\u10DA\u10D8",
     e164: "E.164 \u10DC\u10DD\u10DB\u10D4\u10E0\u10D8",
     jwt: "JWT",
     template_literal: "\u10E8\u10D4\u10E7\u10D5\u10D0\u10DC\u10D0"
@@ -7082,7 +7489,7 @@ var error24 = () => {
   const TypeDictionary = {
     nan: "NaN",
     number: "\u10E0\u10D8\u10EA\u10EE\u10D5\u10D8",
-    string: "\u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8",
+    string: "\u10D5\u10D4\u10DA\u10D8",
     boolean: "\u10D1\u10E3\u10DA\u10D4\u10D0\u10DC\u10D8",
     function: "\u10E4\u10E3\u10DC\u10E5\u10EA\u10D8\u10D0",
     array: "\u10DB\u10D0\u10E1\u10D8\u10D5\u10D8"
@@ -7120,14 +7527,14 @@ var error24 = () => {
       case "invalid_format": {
         const _issue = issue2;
         if (_issue.format === "starts_with") {
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10D8\u10EC\u10E7\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.prefix}"-\u10D8\u10D7`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10D8\u10EC\u10E7\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.prefix}"-\u10D8\u10D7`;
         }
         if (_issue.format === "ends_with")
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10DB\u10D7\u10D0\u10D5\u10E0\u10D3\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.suffix}"-\u10D8\u10D7`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10DB\u10D7\u10D0\u10D5\u10E0\u10D3\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 "${_issue.suffix}"-\u10D8\u10D7`;
         if (_issue.format === "includes")
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1 "${_issue.includes}"-\u10E1`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1 "${_issue.includes}"-\u10E1`;
         if (_issue.format === "regex")
-          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10E1\u10E2\u10E0\u10D8\u10DC\u10D2\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D4\u10E1\u10D0\u10D1\u10D0\u10DB\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 \u10E8\u10D0\u10D1\u10DA\u10DD\u10DC\u10E1 ${_issue.pattern}`;
+          return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 \u10D5\u10D4\u10DA\u10D8: \u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D4\u10E1\u10D0\u10D1\u10D0\u10DB\u10D4\u10D1\u10DD\u10D3\u10D4\u10E1 \u10E8\u10D0\u10D1\u10DA\u10DD\u10DC\u10E1 ${_issue.pattern}`;
         return `\u10D0\u10E0\u10D0\u10E1\u10EC\u10DD\u10E0\u10D8 ${FormatDictionary[_issue.format] ?? issue2.format}`;
       }
       case "not_multiple_of":
@@ -7152,10 +7559,10 @@ var init_ka = __esm(() => {
 // node_modules/zod/v4/locales/km.js
 function km_default() {
   return {
-    localeError: error25()
+    localeError: error27()
   };
 }
-var error25 = () => {
+var error27 = () => {
   const Sizable = {
     string: { unit: "\u178F\u17BD\u17A2\u1780\u17D2\u179F\u179A", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
     file: { unit: "\u1794\u17C3", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
@@ -7274,10 +7681,10 @@ var init_kh = __esm(() => {
 // node_modules/zod/v4/locales/ko.js
 function ko_default() {
   return {
-    localeError: error26()
+    localeError: error28()
   };
 }
-var error26 = () => {
+var error28 = () => {
   const Sizable = {
     string: { unit: "\uBB38\uC790", verb: "to have" },
     file: { unit: "\uBC14\uC774\uD2B8", verb: "to have" },
@@ -7399,12 +7806,12 @@ function getUnitTypeFromNumber(number2) {
 }
 function lt_default() {
   return {
-    localeError: error27()
+    localeError: error29()
   };
 }
 var capitalizeFirstCharacter = (text) => {
   return text.charAt(0).toUpperCase() + text.slice(1);
-}, error27 = () => {
+}, error29 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -7595,10 +8002,10 @@ var init_lt = __esm(() => {
 // node_modules/zod/v4/locales/mk.js
 function mk_default() {
   return {
-    localeError: error28()
+    localeError: error30()
   };
 }
-var error28 = () => {
+var error30 = () => {
   const Sizable = {
     string: { unit: "\u0437\u043D\u0430\u0446\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
     file: { unit: "\u0431\u0430\u0458\u0442\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
@@ -7708,10 +8115,10 @@ var init_mk = __esm(() => {
 // node_modules/zod/v4/locales/ms.js
 function ms_default() {
   return {
-    localeError: error29()
+    localeError: error31()
   };
 }
-var error29 = () => {
+var error31 = () => {
   const Sizable = {
     string: { unit: "aksara", verb: "mempunyai" },
     file: { unit: "bait", verb: "mempunyai" },
@@ -7819,10 +8226,10 @@ var init_ms = __esm(() => {
 // node_modules/zod/v4/locales/nl.js
 function nl_default() {
   return {
-    localeError: error30()
+    localeError: error32()
   };
 }
-var error30 = () => {
+var error32 = () => {
   const Sizable = {
     string: { unit: "tekens", verb: "heeft" },
     file: { unit: "bytes", verb: "heeft" },
@@ -7933,10 +8340,10 @@ var init_nl = __esm(() => {
 // node_modules/zod/v4/locales/no.js
 function no_default() {
   return {
-    localeError: error31()
+    localeError: error33()
   };
 }
-var error31 = () => {
+var error33 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "\xE5 ha" },
     file: { unit: "bytes", verb: "\xE5 ha" },
@@ -8045,10 +8452,10 @@ var init_no = __esm(() => {
 // node_modules/zod/v4/locales/ota.js
 function ota_default() {
   return {
-    localeError: error32()
+    localeError: error34()
   };
 }
-var error32 = () => {
+var error34 = () => {
   const Sizable = {
     string: { unit: "harf", verb: "olmal\u0131d\u0131r" },
     file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
@@ -8158,10 +8565,10 @@ var init_ota = __esm(() => {
 // node_modules/zod/v4/locales/ps.js
 function ps_default() {
   return {
-    localeError: error33()
+    localeError: error35()
   };
 }
-var error33 = () => {
+var error35 = () => {
   const Sizable = {
     string: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
     file: { unit: "\u0628\u0627\u06CC\u067C\u0633", verb: "\u0648\u0644\u0631\u064A" },
@@ -8276,10 +8683,10 @@ var init_ps = __esm(() => {
 // node_modules/zod/v4/locales/pl.js
 function pl_default() {
   return {
-    localeError: error34()
+    localeError: error36()
   };
 }
-var error34 = () => {
+var error36 = () => {
   const Sizable = {
     string: { unit: "znak\xF3w", verb: "mie\u0107" },
     file: { unit: "bajt\xF3w", verb: "mie\u0107" },
@@ -8389,10 +8796,10 @@ var init_pl = __esm(() => {
 // node_modules/zod/v4/locales/pt.js
 function pt_default() {
   return {
-    localeError: error35()
+    localeError: error37()
   };
 }
-var error35 = () => {
+var error37 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "ter" },
     file: { unit: "bytes", verb: "ter" },
@@ -8498,6 +8905,129 @@ var init_pt = __esm(() => {
   init_util();
 });
 
+// node_modules/zod/v4/locales/ro.js
+function ro_default() {
+  return {
+    localeError: error38()
+  };
+}
+var error38 = () => {
+  const Sizable = {
+    string: { unit: "caractere", verb: "s\u0103 aib\u0103" },
+    file: { unit: "octe\u021Bi", verb: "s\u0103 aib\u0103" },
+    array: { unit: "elemente", verb: "s\u0103 aib\u0103" },
+    set: { unit: "elemente", verb: "s\u0103 aib\u0103" },
+    map: { unit: "intr\u0103ri", verb: "s\u0103 aib\u0103" }
+  };
+  function getSizing(origin) {
+    return Sizable[origin] ?? null;
+  }
+  const FormatDictionary = {
+    regex: "intrare",
+    email: "adres\u0103 de email",
+    url: "URL",
+    emoji: "emoji",
+    uuid: "UUID",
+    uuidv4: "UUIDv4",
+    uuidv6: "UUIDv6",
+    nanoid: "nanoid",
+    guid: "GUID",
+    cuid: "cuid",
+    cuid2: "cuid2",
+    ulid: "ULID",
+    xid: "XID",
+    ksuid: "KSUID",
+    datetime: "dat\u0103 \u0219i or\u0103 ISO",
+    date: "dat\u0103 ISO",
+    time: "or\u0103 ISO",
+    duration: "durat\u0103 ISO",
+    ipv4: "adres\u0103 IPv4",
+    ipv6: "adres\u0103 IPv6",
+    mac: "adres\u0103 MAC",
+    cidrv4: "interval IPv4",
+    cidrv6: "interval IPv6",
+    base64: "\u0219ir codat base64",
+    base64url: "\u0219ir codat base64url",
+    json_string: "\u0219ir JSON",
+    e164: "num\u0103r E.164",
+    jwt: "JWT",
+    template_literal: "intrare"
+  };
+  const TypeDictionary = {
+    nan: "NaN",
+    string: "\u0219ir",
+    number: "num\u0103r",
+    boolean: "boolean",
+    function: "func\u021Bie",
+    array: "matrice",
+    object: "obiect",
+    undefined: "nedefinit",
+    symbol: "simbol",
+    bigint: "num\u0103r mare",
+    void: "void",
+    never: "never",
+    map: "hart\u0103",
+    set: "set"
+  };
+  return (issue2) => {
+    switch (issue2.code) {
+      case "invalid_type": {
+        const expected = TypeDictionary[issue2.expected] ?? issue2.expected;
+        const receivedType = parsedType(issue2.input);
+        const received = TypeDictionary[receivedType] ?? receivedType;
+        return `Intrare invalid\u0103: a\u0219teptat ${expected}, primit ${received}`;
+      }
+      case "invalid_value":
+        if (issue2.values.length === 1)
+          return `Intrare invalid\u0103: a\u0219teptat ${stringifyPrimitive(issue2.values[0])}`;
+        return `Op\u021Biune invalid\u0103: a\u0219teptat una dintre ${joinValues(issue2.values, "|")}`;
+      case "too_big": {
+        const adj = issue2.inclusive ? "<=" : "<";
+        const sizing = getSizing(issue2.origin);
+        if (sizing)
+          return `Prea mare: a\u0219teptat ca ${issue2.origin ?? "valoarea"} ${sizing.verb} ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "elemente"}`;
+        return `Prea mare: a\u0219teptat ca ${issue2.origin ?? "valoarea"} s\u0103 fie ${adj}${issue2.maximum.toString()}`;
+      }
+      case "too_small": {
+        const adj = issue2.inclusive ? ">=" : ">";
+        const sizing = getSizing(issue2.origin);
+        if (sizing) {
+          return `Prea mic: a\u0219teptat ca ${issue2.origin} ${sizing.verb} ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
+        }
+        return `Prea mic: a\u0219teptat ca ${issue2.origin} s\u0103 fie ${adj}${issue2.minimum.toString()}`;
+      }
+      case "invalid_format": {
+        const _issue = issue2;
+        if (_issue.format === "starts_with") {
+          return `\u0218ir invalid: trebuie s\u0103 \xEEnceap\u0103 cu "${_issue.prefix}"`;
+        }
+        if (_issue.format === "ends_with")
+          return `\u0218ir invalid: trebuie s\u0103 se termine cu "${_issue.suffix}"`;
+        if (_issue.format === "includes")
+          return `\u0218ir invalid: trebuie s\u0103 includ\u0103 "${_issue.includes}"`;
+        if (_issue.format === "regex")
+          return `\u0218ir invalid: trebuie s\u0103 se potriveasc\u0103 cu modelul ${_issue.pattern}`;
+        return `Format invalid: ${FormatDictionary[_issue.format] ?? issue2.format}`;
+      }
+      case "not_multiple_of":
+        return `Num\u0103r invalid: trebuie s\u0103 fie multiplu de ${issue2.divisor}`;
+      case "unrecognized_keys":
+        return `Chei nerecunoscute: ${joinValues(issue2.keys, ", ")}`;
+      case "invalid_key":
+        return `Cheie invalid\u0103 \xEEn ${issue2.origin}`;
+      case "invalid_union":
+        return "Intrare invalid\u0103";
+      case "invalid_element":
+        return `Valoare invalid\u0103 \xEEn ${issue2.origin}`;
+      default:
+        return `Intrare invalid\u0103`;
+    }
+  };
+};
+var init_ro = __esm(() => {
+  init_util();
+});
+
 // node_modules/zod/v4/locales/ru.js
 function getRussianPlural(count, one, few, many) {
   const absCount = Math.abs(count);
@@ -8516,10 +9046,10 @@ function getRussianPlural(count, one, few, many) {
 }
 function ru_default() {
   return {
-    localeError: error36()
+    localeError: error39()
   };
 }
-var error36 = () => {
+var error39 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -8661,10 +9191,10 @@ var init_ru = __esm(() => {
 // node_modules/zod/v4/locales/sl.js
 function sl_default() {
   return {
-    localeError: error37()
+    localeError: error40()
   };
 }
-var error37 = () => {
+var error40 = () => {
   const Sizable = {
     string: { unit: "znakov", verb: "imeti" },
     file: { unit: "bajtov", verb: "imeti" },
@@ -8774,10 +9304,10 @@ var init_sl = __esm(() => {
 // node_modules/zod/v4/locales/sv.js
 function sv_default() {
   return {
-    localeError: error38()
+    localeError: error41()
   };
 }
-var error38 = () => {
+var error41 = () => {
   const Sizable = {
     string: { unit: "tecken", verb: "att ha" },
     file: { unit: "bytes", verb: "att ha" },
@@ -8888,10 +9418,10 @@ var init_sv = __esm(() => {
 // node_modules/zod/v4/locales/ta.js
 function ta_default() {
   return {
-    localeError: error39()
+    localeError: error42()
   };
 }
-var error39 = () => {
+var error42 = () => {
   const Sizable = {
     string: { unit: "\u0B8E\u0BB4\u0BC1\u0BA4\u0BCD\u0BA4\u0BC1\u0B95\u0BCD\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
     file: { unit: "\u0BAA\u0BC8\u0B9F\u0BCD\u0B9F\u0BC1\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
@@ -9002,10 +9532,10 @@ var init_ta = __esm(() => {
 // node_modules/zod/v4/locales/th.js
 function th_default() {
   return {
-    localeError: error40()
+    localeError: error43()
   };
 }
-var error40 = () => {
+var error43 = () => {
   const Sizable = {
     string: { unit: "\u0E15\u0E31\u0E27\u0E2D\u0E31\u0E01\u0E29\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
     file: { unit: "\u0E44\u0E1A\u0E15\u0E4C", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
@@ -9116,10 +9646,10 @@ var init_th = __esm(() => {
 // node_modules/zod/v4/locales/tr.js
 function tr_default() {
   return {
-    localeError: error41()
+    localeError: error44()
   };
 }
-var error41 = () => {
+var error44 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "olmal\u0131" },
     file: { unit: "bayt", verb: "olmal\u0131" },
@@ -9225,10 +9755,10 @@ var init_tr = __esm(() => {
 // node_modules/zod/v4/locales/uk.js
 function uk_default() {
   return {
-    localeError: error42()
+    localeError: error45()
   };
 }
-var error42 = () => {
+var error45 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
     file: { unit: "\u0431\u0430\u0439\u0442\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
@@ -9345,10 +9875,10 @@ var init_ua = __esm(() => {
 // node_modules/zod/v4/locales/ur.js
 function ur_default() {
   return {
-    localeError: error43()
+    localeError: error46()
   };
 }
-var error43 = () => {
+var error46 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0648\u0641", verb: "\u06C1\u0648\u0646\u0627" },
     file: { unit: "\u0628\u0627\u0626\u0679\u0633", verb: "\u06C1\u0648\u0646\u0627" },
@@ -9459,15 +9989,16 @@ var init_ur = __esm(() => {
 // node_modules/zod/v4/locales/uz.js
 function uz_default() {
   return {
-    localeError: error44()
+    localeError: error47()
   };
 }
-var error44 = () => {
+var error47 = () => {
   const Sizable = {
     string: { unit: "belgi", verb: "bo\u2018lishi kerak" },
     file: { unit: "bayt", verb: "bo\u2018lishi kerak" },
     array: { unit: "element", verb: "bo\u2018lishi kerak" },
-    set: { unit: "element", verb: "bo\u2018lishi kerak" }
+    set: { unit: "element", verb: "bo\u2018lishi kerak" },
+    map: { unit: "yozuv", verb: "bo\u2018lishi kerak" }
   };
   function getSizing(origin) {
     return Sizable[origin] ?? null;
@@ -9572,10 +10103,10 @@ var init_uz = __esm(() => {
 // node_modules/zod/v4/locales/vi.js
 function vi_default() {
   return {
-    localeError: error45()
+    localeError: error48()
   };
 }
-var error45 = () => {
+var error48 = () => {
   const Sizable = {
     string: { unit: "k\xFD t\u1EF1", verb: "c\xF3" },
     file: { unit: "byte", verb: "c\xF3" },
@@ -9684,10 +10215,10 @@ var init_vi = __esm(() => {
 // node_modules/zod/v4/locales/zh-CN.js
 function zh_CN_default() {
   return {
-    localeError: error46()
+    localeError: error49()
   };
 }
-var error46 = () => {
+var error49 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u7B26", verb: "\u5305\u542B" },
     file: { unit: "\u5B57\u8282", verb: "\u5305\u542B" },
@@ -9797,10 +10328,10 @@ var init_zh_CN = __esm(() => {
 // node_modules/zod/v4/locales/zh-TW.js
 function zh_TW_default() {
   return {
-    localeError: error47()
+    localeError: error50()
   };
 }
-var error47 = () => {
+var error50 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u5143", verb: "\u64C1\u6709" },
     file: { unit: "\u4F4D\u5143\u7D44", verb: "\u64C1\u6709" },
@@ -9908,10 +10439,10 @@ var init_zh_TW = __esm(() => {
 // node_modules/zod/v4/locales/yo.js
 function yo_default() {
   return {
-    localeError: error48()
+    localeError: error51()
   };
 }
-var error48 = () => {
+var error51 = () => {
   const Sizable = {
     string: { unit: "\xE0mi", verb: "n\xED" },
     file: { unit: "bytes", verb: "n\xED" },
@@ -10033,6 +10564,7 @@ __export(exports_locales, {
   sv: () => sv_default,
   sl: () => sl_default,
   ru: () => ru_default,
+  ro: () => ro_default,
   pt: () => pt_default,
   ps: () => ps_default,
   pl: () => pl_default,
@@ -10052,6 +10584,7 @@ __export(exports_locales, {
   id: () => id_default,
   hy: () => hy_default,
   hu: () => hu_default,
+  hr: () => hr_default,
   he: () => he_default,
   frCA: () => fr_CA_default,
   fr: () => fr_default,
@@ -10060,6 +10593,7 @@ __export(exports_locales, {
   es: () => es_default,
   eo: () => eo_default,
   en: () => en_default,
+  el: () => el_default,
   de: () => de_default,
   da: () => da_default,
   cs: () => cs_default,
@@ -10078,6 +10612,7 @@ var init_locales = __esm(() => {
   init_cs();
   init_da();
   init_de();
+  init_el();
   init_en();
   init_eo();
   init_es();
@@ -10086,6 +10621,7 @@ var init_locales = __esm(() => {
   init_fr();
   init_fr_CA();
   init_he();
+  init_hr();
   init_hu();
   init_hy();
   init_id();
@@ -10105,6 +10641,7 @@ var init_locales = __esm(() => {
   init_ps();
   init_pl();
   init_pt();
+  init_ro();
   init_ru();
   init_sl();
   init_sv();
@@ -10165,11 +10702,11 @@ class $ZodRegistry {
 function registry() {
   return new $ZodRegistry;
 }
-var _a, $output, $input, globalRegistry;
+var _a2, $output, $input, globalRegistry;
 var init_registries = __esm(() => {
   $output = Symbol("ZodOutput");
   $input = Symbol("ZodInput");
-  (_a = globalThis).__zod_globalRegistry ?? (_a.__zod_globalRegistry = registry());
+  (_a2 = globalThis).__zod_globalRegistry ?? (_a2.__zod_globalRegistry = registry());
   globalRegistry = globalThis.__zod_globalRegistry;
 });
 
@@ -10970,7 +11507,7 @@ function _refine(Class2, fn, _params) {
   });
   return schema;
 }
-function _superRefine(fn) {
+function _superRefine(fn, params) {
   const ch = _check((payload) => {
     payload.addIssue = (issue2) => {
       if (typeof issue2 === "string") {
@@ -10987,7 +11524,7 @@ function _superRefine(fn) {
       }
     };
     return fn(payload.value, payload);
-  });
+  }, params);
   return ch;
 }
 function _check(fn, params) {
@@ -11123,7 +11660,7 @@ function initializeContext(params) {
   };
 }
 function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
-  var _a2;
+  var _a3;
   const def = schema._zod.def;
   const seen = ctx.seen.get(schema);
   if (seen) {
@@ -11170,8 +11707,8 @@ function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
     delete result.schema.examples;
     delete result.schema.default;
   }
-  if (ctx.io === "input" && result.schema._prefault)
-    (_a2 = result.schema).default ?? (_a2.default = result.schema._prefault);
+  if (ctx.io === "input" && "_prefault" in result.schema)
+    (_a3 = result.schema).default ?? (_a3.default = result.schema._prefault);
   delete result.schema._prefault;
   const _result = ctx.seen.get(schema);
   return _result.schema;
@@ -11348,10 +11885,15 @@ function finalize(ctx, schema) {
     result.$id = ctx.external.uri(id);
   }
   Object.assign(result, root.def ?? root.schema);
+  const rootMetaId = ctx.metadataRegistry.get(schema)?.id;
+  if (rootMetaId !== undefined && result.id === rootMetaId)
+    delete result.id;
   const defs = ctx.external?.defs ?? {};
   for (const entry of ctx.seen.entries()) {
     const seen = entry[1];
     if (seen.def && seen.defId) {
+      if (seen.def.id === seen.defId)
+        delete seen.def.id;
       defs[seen.defId] = seen.def;
     }
   }
@@ -11406,6 +11948,8 @@ function isTransforming(_schema, _ctx) {
     return isTransforming(def.keyType, ctx) || isTransforming(def.valueType, ctx);
   }
   if (def.type === "pipe") {
+    if (_schema._zod.traits.has("$ZodCodec"))
+      return true;
     return isTransforming(def.in, ctx) || isTransforming(def.out, ctx);
   }
   if (def.type === "object") {
@@ -11522,39 +12066,28 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
     json.type = "integer";
   else
     json.type = "number";
-  if (typeof exclusiveMinimum === "number") {
-    if (ctx.target === "draft-04" || ctx.target === "openapi-3.0") {
+  const exMin = typeof exclusiveMinimum === "number" && exclusiveMinimum >= (minimum ?? Number.NEGATIVE_INFINITY);
+  const exMax = typeof exclusiveMaximum === "number" && exclusiveMaximum <= (maximum ?? Number.POSITIVE_INFINITY);
+  const legacy = ctx.target === "draft-04" || ctx.target === "openapi-3.0";
+  if (exMin) {
+    if (legacy) {
       json.minimum = exclusiveMinimum;
       json.exclusiveMinimum = true;
     } else {
       json.exclusiveMinimum = exclusiveMinimum;
     }
-  }
-  if (typeof minimum === "number") {
+  } else if (typeof minimum === "number") {
     json.minimum = minimum;
-    if (typeof exclusiveMinimum === "number" && ctx.target !== "draft-04") {
-      if (exclusiveMinimum >= minimum)
-        delete json.minimum;
-      else
-        delete json.exclusiveMinimum;
-    }
   }
-  if (typeof exclusiveMaximum === "number") {
-    if (ctx.target === "draft-04" || ctx.target === "openapi-3.0") {
+  if (exMax) {
+    if (legacy) {
       json.maximum = exclusiveMaximum;
       json.exclusiveMaximum = true;
     } else {
       json.exclusiveMaximum = exclusiveMaximum;
     }
-  }
-  if (typeof maximum === "number") {
+  } else if (typeof maximum === "number") {
     json.maximum = maximum;
-    if (typeof exclusiveMaximum === "number" && ctx.target !== "draft-04") {
-      if (exclusiveMaximum <= maximum)
-        delete json.maximum;
-      else
-        delete json.exclusiveMaximum;
-    }
   }
   if (typeof multipleOf === "number")
     json.multipleOf = multipleOf;
@@ -11700,7 +12233,10 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
   if (typeof maximum === "number")
     json.maxItems = maximum;
   json.type = "array";
-  json.items = process2(def.element, ctx, { ...params, path: [...params.path, "items"] });
+  json.items = process2(def.element, ctx, {
+    ...params,
+    path: [...params.path, "items"]
+  });
 }, objectProcessor = (schema, ctx, _json, params) => {
   const json = _json;
   const def = schema._zod.def;
@@ -11882,7 +12418,8 @@ var formatMap, stringProcessor = (schema, ctx, _json, _params) => {
   json.default = catchValue;
 }, pipeProcessor = (schema, ctx, _json, params) => {
   const def = schema._zod.def;
-  const innerType = ctx.io === "input" ? def.in._zod.def.type === "transform" ? def.out : def.in : def.out;
+  const inIsTransform = def.in._zod.traits.has("$ZodTransform");
+  const innerType = ctx.io === "input" ? inIsTransform ? def.out : def.in : def.out;
   process2(innerType, ctx, params);
   const seen = ctx.seen.get(schema);
   seen.ref = innerType;
@@ -12228,6 +12765,7 @@ __export(exports_core2, {
   $ZodRealError: () => $ZodRealError,
   $ZodReadonly: () => $ZodReadonly,
   $ZodPromise: () => $ZodPromise,
+  $ZodPreprocess: () => $ZodPreprocess,
   $ZodPrefault: () => $ZodPrefault,
   $ZodPipe: () => $ZodPipe,
   $ZodOptional: () => $ZodOptional,
@@ -12441,8 +12979,8 @@ var init_errors3 = __esm(() => {
   init_core2();
   init_core2();
   init_util();
-  ZodError = $constructor("ZodError", initializer2);
-  ZodRealError = $constructor("ZodError", initializer2, {
+  ZodError = /* @__PURE__ */ $constructor("ZodError", initializer2);
+  ZodRealError = /* @__PURE__ */ $constructor("ZodError", initializer2, {
     Parent: Error
   });
 });
@@ -12526,6 +13064,7 @@ __export(exports_schemas2, {
   json: () => json,
   ipv6: () => ipv62,
   ipv4: () => ipv42,
+  invertCodec: () => invertCodec,
   intersection: () => intersection,
   int64: () => int64,
   int32: () => int32,
@@ -12586,6 +13125,7 @@ __export(exports_schemas2, {
   ZodRecord: () => ZodRecord,
   ZodReadonly: () => ZodReadonly,
   ZodPromise: () => ZodPromise,
+  ZodPreprocess: () => ZodPreprocess,
   ZodPrefault: () => ZodPrefault,
   ZodPipe: () => ZodPipe,
   ZodOptional: () => ZodOptional,
@@ -12634,6 +13174,42 @@ __export(exports_schemas2, {
   ZodArray: () => ZodArray,
   ZodAny: () => ZodAny
 });
+function _installLazyMethods(inst, group, methods) {
+  const proto = Object.getPrototypeOf(inst);
+  let installed = _installedGroups.get(proto);
+  if (!installed) {
+    installed = new Set;
+    _installedGroups.set(proto, installed);
+  }
+  if (installed.has(group))
+    return;
+  installed.add(group);
+  for (const key in methods) {
+    const fn = methods[key];
+    Object.defineProperty(proto, key, {
+      configurable: true,
+      enumerable: false,
+      get() {
+        const bound = fn.bind(this);
+        Object.defineProperty(this, key, {
+          configurable: true,
+          writable: true,
+          enumerable: true,
+          value: bound
+        });
+        return bound;
+      },
+      set(v) {
+        Object.defineProperty(this, key, {
+          configurable: true,
+          writable: true,
+          enumerable: true,
+          value: v
+        });
+      }
+    });
+  }
+}
 function string2(params) {
   return _string(ZodString, params);
 }
@@ -12660,7 +13236,7 @@ function url(params) {
 }
 function httpUrl(params) {
   return _url(ZodURL, {
-    protocol: /^https?$/,
+    protocol: exports_regexes.httpProtocol,
     hostname: exports_regexes.domain,
     ...exports_util.normalizeParams(params)
   });
@@ -12857,6 +13433,14 @@ function tuple(items, _paramsOrRest, _params) {
   });
 }
 function record(keyType, valueType, params) {
+  if (!valueType || !valueType._zod) {
+    return new ZodRecord({
+      type: "record",
+      keyType: string2(),
+      valueType: keyType,
+      ...exports_util.normalizeParams(valueType)
+    });
+  }
   return new ZodRecord({
     type: "record",
     keyType,
@@ -13007,6 +13591,16 @@ function codec(in_, out, params) {
     reverseTransform: params.encode
   });
 }
+function invertCodec(codec2) {
+  const def = codec2._zod.def;
+  return new ZodCodec({
+    type: "pipe",
+    in: def.out,
+    out: def.in,
+    transform: def.reverseTransform,
+    reverseTransform: def.transform
+  });
+}
 function readonly(innerType) {
   return new ZodReadonly({
     type: "readonly",
@@ -13052,8 +13646,8 @@ function custom(fn, _params) {
 function refine(fn, _params = {}) {
   return _refine(ZodCustom, fn, _params);
 }
-function superRefine(fn) {
-  return _superRefine(fn);
+function superRefine(fn, params) {
+  return _superRefine(fn, params);
 }
 function _instanceof(cls, params = {}) {
   const inst = new ZodCustom({
@@ -13084,9 +13678,13 @@ function json(params) {
   return jsonSchema;
 }
 function preprocess(fn, schema) {
-  return pipe(transform(fn), schema);
+  return new ZodPreprocess({
+    type: "pipe",
+    in: transform(fn),
+    out: schema
+  });
 }
-var ZodType, _ZodString, ZodString, ZodStringFormat, ZodEmail, ZodGUID, ZodUUID, ZodURL, ZodEmoji, ZodNanoID, ZodCUID, ZodCUID2, ZodULID, ZodXID, ZodKSUID, ZodIPv4, ZodMAC, ZodIPv6, ZodCIDRv4, ZodCIDRv6, ZodBase64, ZodBase64URL, ZodE164, ZodJWT, ZodCustomStringFormat, ZodNumber, ZodNumberFormat, ZodBoolean, ZodBigInt, ZodBigIntFormat, ZodSymbol, ZodUndefined, ZodNull, ZodAny, ZodUnknown, ZodNever, ZodVoid, ZodDate, ZodArray, ZodObject, ZodUnion, ZodXor, ZodDiscriminatedUnion, ZodIntersection, ZodTuple, ZodRecord, ZodMap, ZodSet, ZodEnum, ZodLiteral, ZodFile, ZodTransform, ZodOptional, ZodExactOptional, ZodNullable, ZodDefault, ZodPrefault, ZodNonOptional, ZodSuccess, ZodCatch, ZodNaN, ZodPipe, ZodCodec, ZodReadonly, ZodTemplateLiteral, ZodLazy, ZodPromise, ZodFunction, ZodCustom, describe2, meta2, stringbool = (...args) => _stringbool({
+var _installedGroups, ZodType, _ZodString, ZodString, ZodStringFormat, ZodEmail, ZodGUID, ZodUUID, ZodURL, ZodEmoji, ZodNanoID, ZodCUID, ZodCUID2, ZodULID, ZodXID, ZodKSUID, ZodIPv4, ZodMAC, ZodIPv6, ZodCIDRv4, ZodCIDRv6, ZodBase64, ZodBase64URL, ZodE164, ZodJWT, ZodCustomStringFormat, ZodNumber, ZodNumberFormat, ZodBoolean, ZodBigInt, ZodBigIntFormat, ZodSymbol, ZodUndefined, ZodNull, ZodAny, ZodUnknown, ZodNever, ZodVoid, ZodDate, ZodArray, ZodObject, ZodUnion, ZodXor, ZodDiscriminatedUnion, ZodIntersection, ZodTuple, ZodRecord, ZodMap, ZodSet, ZodEnum, ZodLiteral, ZodFile, ZodTransform, ZodOptional, ZodExactOptional, ZodNullable, ZodDefault, ZodPrefault, ZodNonOptional, ZodSuccess, ZodCatch, ZodNaN, ZodPipe, ZodCodec, ZodPreprocess, ZodReadonly, ZodTemplateLiteral, ZodLazy, ZodPromise, ZodFunction, ZodCustom, describe2, meta2, stringbool = (...args) => _stringbool({
   Codec: ZodCodec,
   Boolean: ZodBoolean,
   String: ZodString
@@ -13099,6 +13697,7 @@ var init_schemas2 = __esm(() => {
   init_checks2();
   init_iso();
   init_parse2();
+  _installedGroups = /* @__PURE__ */ new WeakMap;
   ZodType = /* @__PURE__ */ $constructor("ZodType", (inst, def) => {
     $ZodType.init(inst, def);
     Object.assign(inst["~standard"], {
@@ -13111,23 +13710,6 @@ var init_schemas2 = __esm(() => {
     inst.def = def;
     inst.type = def.type;
     Object.defineProperty(inst, "_def", { value: def });
-    inst.check = (...checks2) => {
-      return inst.clone(exports_util.mergeDefs(def, {
-        checks: [
-          ...def.checks ?? [],
-          ...checks2.map((ch) => typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch)
-        ]
-      }), {
-        parent: true
-      });
-    };
-    inst.with = inst.check;
-    inst.clone = (def2, params) => clone(inst, def2, params);
-    inst.brand = () => inst;
-    inst.register = (reg, meta2) => {
-      reg.add(inst, meta2);
-      return inst;
-    };
     inst.parse = (data, params) => parse3(inst, data, params, { callee: inst.parse });
     inst.safeParse = (data, params) => safeParse2(inst, data, params);
     inst.parseAsync = async (data, params) => parseAsync2(inst, data, params, { callee: inst.parseAsync });
@@ -13141,45 +13723,108 @@ var init_schemas2 = __esm(() => {
     inst.safeDecode = (data, params) => safeDecode2(inst, data, params);
     inst.safeEncodeAsync = async (data, params) => safeEncodeAsync2(inst, data, params);
     inst.safeDecodeAsync = async (data, params) => safeDecodeAsync2(inst, data, params);
-    inst.refine = (check, params) => inst.check(refine(check, params));
-    inst.superRefine = (refinement) => inst.check(superRefine(refinement));
-    inst.overwrite = (fn) => inst.check(_overwrite(fn));
-    inst.optional = () => optional(inst);
-    inst.exactOptional = () => exactOptional(inst);
-    inst.nullable = () => nullable(inst);
-    inst.nullish = () => optional(nullable(inst));
-    inst.nonoptional = (params) => nonoptional(inst, params);
-    inst.array = () => array(inst);
-    inst.or = (arg) => union([inst, arg]);
-    inst.and = (arg) => intersection(inst, arg);
-    inst.transform = (tx) => pipe(inst, transform(tx));
-    inst.default = (def2) => _default2(inst, def2);
-    inst.prefault = (def2) => prefault(inst, def2);
-    inst.catch = (params) => _catch2(inst, params);
-    inst.pipe = (target) => pipe(inst, target);
-    inst.readonly = () => readonly(inst);
-    inst.describe = (description) => {
-      const cl = inst.clone();
-      globalRegistry.add(cl, { description });
-      return cl;
-    };
+    _installLazyMethods(inst, "ZodType", {
+      check(...chks) {
+        const def2 = this.def;
+        return this.clone(exports_util.mergeDefs(def2, {
+          checks: [
+            ...def2.checks ?? [],
+            ...chks.map((ch) => typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch)
+          ]
+        }), { parent: true });
+      },
+      with(...chks) {
+        return this.check(...chks);
+      },
+      clone(def2, params) {
+        return clone(this, def2, params);
+      },
+      brand() {
+        return this;
+      },
+      register(reg, meta2) {
+        reg.add(this, meta2);
+        return this;
+      },
+      refine(check, params) {
+        return this.check(refine(check, params));
+      },
+      superRefine(refinement, params) {
+        return this.check(superRefine(refinement, params));
+      },
+      overwrite(fn) {
+        return this.check(_overwrite(fn));
+      },
+      optional() {
+        return optional(this);
+      },
+      exactOptional() {
+        return exactOptional(this);
+      },
+      nullable() {
+        return nullable(this);
+      },
+      nullish() {
+        return optional(nullable(this));
+      },
+      nonoptional(params) {
+        return nonoptional(this, params);
+      },
+      array() {
+        return array(this);
+      },
+      or(arg) {
+        return union([this, arg]);
+      },
+      and(arg) {
+        return intersection(this, arg);
+      },
+      transform(tx) {
+        return pipe(this, transform(tx));
+      },
+      default(d) {
+        return _default2(this, d);
+      },
+      prefault(d) {
+        return prefault(this, d);
+      },
+      catch(params) {
+        return _catch2(this, params);
+      },
+      pipe(target) {
+        return pipe(this, target);
+      },
+      readonly() {
+        return readonly(this);
+      },
+      describe(description) {
+        const cl = this.clone();
+        globalRegistry.add(cl, { description });
+        return cl;
+      },
+      meta(...args) {
+        if (args.length === 0)
+          return globalRegistry.get(this);
+        const cl = this.clone();
+        globalRegistry.add(cl, args[0]);
+        return cl;
+      },
+      isOptional() {
+        return this.safeParse(undefined).success;
+      },
+      isNullable() {
+        return this.safeParse(null).success;
+      },
+      apply(fn) {
+        return fn(this);
+      }
+    });
     Object.defineProperty(inst, "description", {
       get() {
         return globalRegistry.get(inst)?.description;
       },
       configurable: true
     });
-    inst.meta = (...args) => {
-      if (args.length === 0) {
-        return globalRegistry.get(inst);
-      }
-      const cl = inst.clone();
-      globalRegistry.add(cl, args[0]);
-      return cl;
-    };
-    inst.isOptional = () => inst.safeParse(undefined).success;
-    inst.isNullable = () => inst.safeParse(null).success;
-    inst.apply = (fn) => fn(inst);
     return inst;
   });
   _ZodString = /* @__PURE__ */ $constructor("_ZodString", (inst, def) => {
@@ -13190,21 +13835,53 @@ var init_schemas2 = __esm(() => {
     inst.format = bag.format ?? null;
     inst.minLength = bag.minimum ?? null;
     inst.maxLength = bag.maximum ?? null;
-    inst.regex = (...args) => inst.check(_regex(...args));
-    inst.includes = (...args) => inst.check(_includes(...args));
-    inst.startsWith = (...args) => inst.check(_startsWith(...args));
-    inst.endsWith = (...args) => inst.check(_endsWith(...args));
-    inst.min = (...args) => inst.check(_minLength(...args));
-    inst.max = (...args) => inst.check(_maxLength(...args));
-    inst.length = (...args) => inst.check(_length(...args));
-    inst.nonempty = (...args) => inst.check(_minLength(1, ...args));
-    inst.lowercase = (params) => inst.check(_lowercase(params));
-    inst.uppercase = (params) => inst.check(_uppercase(params));
-    inst.trim = () => inst.check(_trim());
-    inst.normalize = (...args) => inst.check(_normalize(...args));
-    inst.toLowerCase = () => inst.check(_toLowerCase());
-    inst.toUpperCase = () => inst.check(_toUpperCase());
-    inst.slugify = () => inst.check(_slugify());
+    _installLazyMethods(inst, "_ZodString", {
+      regex(...args) {
+        return this.check(_regex(...args));
+      },
+      includes(...args) {
+        return this.check(_includes(...args));
+      },
+      startsWith(...args) {
+        return this.check(_startsWith(...args));
+      },
+      endsWith(...args) {
+        return this.check(_endsWith(...args));
+      },
+      min(...args) {
+        return this.check(_minLength(...args));
+      },
+      max(...args) {
+        return this.check(_maxLength(...args));
+      },
+      length(...args) {
+        return this.check(_length(...args));
+      },
+      nonempty(...args) {
+        return this.check(_minLength(1, ...args));
+      },
+      lowercase(params) {
+        return this.check(_lowercase(params));
+      },
+      uppercase(params) {
+        return this.check(_uppercase(params));
+      },
+      trim() {
+        return this.check(_trim());
+      },
+      normalize(...args) {
+        return this.check(_normalize(...args));
+      },
+      toLowerCase() {
+        return this.check(_toLowerCase());
+      },
+      toUpperCase() {
+        return this.check(_toUpperCase());
+      },
+      slugify() {
+        return this.check(_slugify());
+      }
+    });
   });
   ZodString = /* @__PURE__ */ $constructor("ZodString", (inst, def) => {
     $ZodString.init(inst, def);
@@ -13329,21 +14006,53 @@ var init_schemas2 = __esm(() => {
     $ZodNumber.init(inst, def);
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => numberProcessor(inst, ctx, json, params);
-    inst.gt = (value, params) => inst.check(_gt(value, params));
-    inst.gte = (value, params) => inst.check(_gte(value, params));
-    inst.min = (value, params) => inst.check(_gte(value, params));
-    inst.lt = (value, params) => inst.check(_lt(value, params));
-    inst.lte = (value, params) => inst.check(_lte(value, params));
-    inst.max = (value, params) => inst.check(_lte(value, params));
-    inst.int = (params) => inst.check(int(params));
-    inst.safe = (params) => inst.check(int(params));
-    inst.positive = (params) => inst.check(_gt(0, params));
-    inst.nonnegative = (params) => inst.check(_gte(0, params));
-    inst.negative = (params) => inst.check(_lt(0, params));
-    inst.nonpositive = (params) => inst.check(_lte(0, params));
-    inst.multipleOf = (value, params) => inst.check(_multipleOf(value, params));
-    inst.step = (value, params) => inst.check(_multipleOf(value, params));
-    inst.finite = () => inst;
+    _installLazyMethods(inst, "ZodNumber", {
+      gt(value, params) {
+        return this.check(_gt(value, params));
+      },
+      gte(value, params) {
+        return this.check(_gte(value, params));
+      },
+      min(value, params) {
+        return this.check(_gte(value, params));
+      },
+      lt(value, params) {
+        return this.check(_lt(value, params));
+      },
+      lte(value, params) {
+        return this.check(_lte(value, params));
+      },
+      max(value, params) {
+        return this.check(_lte(value, params));
+      },
+      int(params) {
+        return this.check(int(params));
+      },
+      safe(params) {
+        return this.check(int(params));
+      },
+      positive(params) {
+        return this.check(_gt(0, params));
+      },
+      nonnegative(params) {
+        return this.check(_gte(0, params));
+      },
+      negative(params) {
+        return this.check(_lt(0, params));
+      },
+      nonpositive(params) {
+        return this.check(_lte(0, params));
+      },
+      multipleOf(value, params) {
+        return this.check(_multipleOf(value, params));
+      },
+      step(value, params) {
+        return this.check(_multipleOf(value, params));
+      },
+      finite() {
+        return this;
+      }
+    });
     const bag = inst._zod.bag;
     inst.minValue = Math.max(bag.minimum ?? Number.NEGATIVE_INFINITY, bag.exclusiveMinimum ?? Number.NEGATIVE_INFINITY) ?? null;
     inst.maxValue = Math.min(bag.maximum ?? Number.POSITIVE_INFINITY, bag.exclusiveMaximum ?? Number.POSITIVE_INFINITY) ?? null;
@@ -13436,11 +14145,23 @@ var init_schemas2 = __esm(() => {
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => arrayProcessor(inst, ctx, json, params);
     inst.element = def.element;
-    inst.min = (minLength, params) => inst.check(_minLength(minLength, params));
-    inst.nonempty = (params) => inst.check(_minLength(1, params));
-    inst.max = (maxLength, params) => inst.check(_maxLength(maxLength, params));
-    inst.length = (len, params) => inst.check(_length(len, params));
-    inst.unwrap = () => inst.element;
+    _installLazyMethods(inst, "ZodArray", {
+      min(n, params) {
+        return this.check(_minLength(n, params));
+      },
+      nonempty(params) {
+        return this.check(_minLength(1, params));
+      },
+      max(n, params) {
+        return this.check(_maxLength(n, params));
+      },
+      length(n, params) {
+        return this.check(_length(n, params));
+      },
+      unwrap() {
+        return this.element;
+      }
+    });
   });
   ZodObject = /* @__PURE__ */ $constructor("ZodObject", (inst, def) => {
     $ZodObjectJIT.init(inst, def);
@@ -13449,23 +14170,47 @@ var init_schemas2 = __esm(() => {
     exports_util.defineLazy(inst, "shape", () => {
       return def.shape;
     });
-    inst.keyof = () => _enum2(Object.keys(inst._zod.def.shape));
-    inst.catchall = (catchall) => inst.clone({ ...inst._zod.def, catchall });
-    inst.passthrough = () => inst.clone({ ...inst._zod.def, catchall: unknown() });
-    inst.loose = () => inst.clone({ ...inst._zod.def, catchall: unknown() });
-    inst.strict = () => inst.clone({ ...inst._zod.def, catchall: never() });
-    inst.strip = () => inst.clone({ ...inst._zod.def, catchall: undefined });
-    inst.extend = (incoming) => {
-      return exports_util.extend(inst, incoming);
-    };
-    inst.safeExtend = (incoming) => {
-      return exports_util.safeExtend(inst, incoming);
-    };
-    inst.merge = (other) => exports_util.merge(inst, other);
-    inst.pick = (mask) => exports_util.pick(inst, mask);
-    inst.omit = (mask) => exports_util.omit(inst, mask);
-    inst.partial = (...args) => exports_util.partial(ZodOptional, inst, args[0]);
-    inst.required = (...args) => exports_util.required(ZodNonOptional, inst, args[0]);
+    _installLazyMethods(inst, "ZodObject", {
+      keyof() {
+        return _enum2(Object.keys(this._zod.def.shape));
+      },
+      catchall(catchall) {
+        return this.clone({ ...this._zod.def, catchall });
+      },
+      passthrough() {
+        return this.clone({ ...this._zod.def, catchall: unknown() });
+      },
+      loose() {
+        return this.clone({ ...this._zod.def, catchall: unknown() });
+      },
+      strict() {
+        return this.clone({ ...this._zod.def, catchall: never() });
+      },
+      strip() {
+        return this.clone({ ...this._zod.def, catchall: undefined });
+      },
+      extend(incoming) {
+        return exports_util.extend(this, incoming);
+      },
+      safeExtend(incoming) {
+        return exports_util.safeExtend(this, incoming);
+      },
+      merge(other) {
+        return exports_util.merge(this, other);
+      },
+      pick(mask) {
+        return exports_util.pick(this, mask);
+      },
+      omit(mask) {
+        return exports_util.omit(this, mask);
+      },
+      partial(...args) {
+        return exports_util.partial(ZodOptional, this, args[0]);
+      },
+      required(...args) {
+        return exports_util.required(ZodNonOptional, this, args[0]);
+      }
+    });
   });
   ZodUnion = /* @__PURE__ */ $constructor("ZodUnion", (inst, def) => {
     $ZodUnion.init(inst, def);
@@ -13609,10 +14354,12 @@ var init_schemas2 = __esm(() => {
       if (output instanceof Promise) {
         return output.then((output2) => {
           payload.value = output2;
+          payload.fallback = true;
           return payload;
         });
       }
       payload.value = output;
+      payload.fallback = true;
       return payload;
     };
   });
@@ -13681,6 +14428,10 @@ var init_schemas2 = __esm(() => {
   ZodCodec = /* @__PURE__ */ $constructor("ZodCodec", (inst, def) => {
     ZodPipe.init(inst, def);
     $ZodCodec.init(inst, def);
+  });
+  ZodPreprocess = /* @__PURE__ */ $constructor("ZodPreprocess", (inst, def) => {
+    ZodPipe.init(inst, def);
+    $ZodPreprocess.init(inst, def);
   });
   ZodReadonly = /* @__PURE__ */ $constructor("ZodReadonly", (inst, def) => {
     $ZodReadonly.init(inst, def);
@@ -14063,12 +14814,6 @@ function convertBaseSchema(schema, ctx) {
     default:
       throw new Error(`Unsupported type: ${type}`);
   }
-  if (schema.description) {
-    zodSchema = zodSchema.describe(schema.description);
-  }
-  if (schema.default !== undefined) {
-    zodSchema = zodSchema.default(schema.default);
-  }
   return zodSchema;
 }
 function convertSchema(schema, ctx) {
@@ -14105,6 +14850,9 @@ function convertSchema(schema, ctx) {
   if (schema.readOnly === true) {
     baseSchema = z.readonly(baseSchema);
   }
+  if (schema.default !== undefined) {
+    baseSchema = baseSchema.default(schema.default);
+  }
   const extraMeta = {};
   const coreMetadataKeys = ["$id", "id", "$comment", "$anchor", "$vocabulary", "$dynamicRef", "$dynamicAnchor"];
   for (const key of coreMetadataKeys) {
@@ -14126,23 +14874,32 @@ function convertSchema(schema, ctx) {
   if (Object.keys(extraMeta).length > 0) {
     ctx.registry.add(baseSchema, extraMeta);
   }
+  if (schema.description) {
+    baseSchema = baseSchema.describe(schema.description);
+  }
   return baseSchema;
 }
 function fromJSONSchema(schema, params) {
   if (typeof schema === "boolean") {
     return schema ? z.any() : z.never();
   }
-  const version2 = detectVersion(schema, params?.defaultTarget);
-  const defs = schema.$defs || schema.definitions || {};
+  let normalized;
+  try {
+    normalized = JSON.parse(JSON.stringify(schema));
+  } catch {
+    throw new Error("fromJSONSchema input is not valid JSON (possibly cyclic); use $defs/$ref for recursive schemas");
+  }
+  const version2 = detectVersion(normalized, params?.defaultTarget);
+  const defs = normalized.$defs || normalized.definitions || {};
   const ctx = {
     version: version2,
     defs,
     refs: new Map,
     processing: new Set,
-    rootSchema: schema,
+    rootSchema: normalized,
     registry: params?.registry ?? globalRegistry
   };
-  return convertSchema(schema, ctx);
+  return convertSchema(normalized, ctx);
 }
 var z, RECOGNIZED_KEYS;
 var init_from_json_schema = __esm(() => {
@@ -14155,7 +14912,7 @@ var init_from_json_schema = __esm(() => {
     ...exports_checks2,
     iso: exports_iso
   };
-  RECOGNIZED_KEYS = new Set([
+  RECOGNIZED_KEYS = /* @__PURE__ */ new Set([
     "$schema",
     "$ref",
     "$defs",
@@ -14347,6 +15104,7 @@ __export(exports_external, {
   iso: () => exports_iso,
   ipv6: () => ipv62,
   ipv4: () => ipv42,
+  invertCodec: () => invertCodec,
   intersection: () => intersection,
   int64: () => int64,
   int32: () => int32,
@@ -14425,6 +15183,7 @@ __export(exports_external, {
   ZodRealError: () => ZodRealError,
   ZodReadonly: () => ZodReadonly,
   ZodPromise: () => ZodPromise,
+  ZodPreprocess: () => ZodPreprocess,
   ZodPrefault: () => ZodPrefault,
   ZodPipe: () => ZodPipe,
   ZodOptional: () => ZodOptional,
@@ -14629,11 +15388,11 @@ var init_telemetry = __esm(() => {
     gatePassed(sessionId, gate, taskId) {
       _internals2.emit("gate_passed", { sessionId, gate, taskId });
     },
-    gateParseError(taskId, error49) {
+    gateParseError(taskId, error52) {
       _internals2.emit("gate_parse_error", {
         taskId,
-        errorName: error49.name,
-        errorMessage: error49.message.slice(0, 200)
+        errorName: error52.name,
+        errorMessage: error52.message.slice(0, 200)
       });
     },
     gateFailed(sessionId, gate, taskId, reason) {
@@ -14743,9 +15502,9 @@ async function computeSpecHash(directory) {
   try {
     const content = await readFile2(specPath, "utf-8");
     hash2 = createHash("sha256").update(content, "utf-8").digest("hex");
-  } catch (error49) {
-    if (error49.code !== "ENOENT") {
-      throw error49;
+  } catch (error52) {
+    if (error52.code !== "ENOENT") {
+      throw error52;
     }
   }
   return hash2;
@@ -15251,9 +16010,9 @@ async function retryCasWithBackoff(directory, eventInput, options) {
         expectedHash: currentExpected,
         planHashAfter: options.planHashAfter
       });
-    } catch (error49) {
-      if (!(error49 instanceof LedgerStaleWriterError) || attempt >= maxRetries) {
-        throw error49;
+    } catch (error52) {
+      if (!(error52 instanceof LedgerStaleWriterError) || attempt >= maxRetries) {
+        throw error52;
       }
       attempt++;
       const base = Math.min(CAS_BACKOFF_START_MS * 2 ** (attempt - 1), CAS_BACKOFF_CAP_MS);
@@ -15285,8 +16044,8 @@ async function loadPlanJsonOnly(directory) {
       const parsed = JSON.parse(planJsonContent);
       const validated = PlanSchema.parse(parsed);
       return validated;
-    } catch (error49) {
-      warn(`Plan validation failed for .swarm/plan.json: ${error49 instanceof Error ? error49.message : String(error49)}`);
+    } catch (error52) {
+      warn(`Plan validation failed for .swarm/plan.json: ${error52 instanceof Error ? error52.message : String(error52)}`);
     }
   }
   return null;
@@ -15487,8 +16246,8 @@ async function loadPlan(directory) {
           }
         }
         return validated;
-      } catch (error49) {
-        warn(`[loadPlan] plan.json validation failed: ${error49 instanceof Error ? error49.message : String(error49)}. Attempting rebuild from ledger. If rebuild fails, check .swarm/SWARM_PLAN.md for a checkpoint.`);
+      } catch (error52) {
+        warn(`[loadPlan] plan.json validation failed: ${error52 instanceof Error ? error52.message : String(error52)}. Attempting rebuild from ledger. If rebuild fails, check .swarm/SWARM_PLAN.md for a checkpoint.`);
         let rawPlanId = null;
         try {
           const rawParsed = JSON.parse(planJsonContent);
@@ -15816,11 +16575,11 @@ async function savePlan(directory, plan, options) {
             }
           });
         }
-      } catch (error49) {
-        if (error49 instanceof LedgerStaleWriterError) {
-          throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error49.message}. Please retry the operation.`);
+      } catch (error52) {
+        if (error52 instanceof LedgerStaleWriterError) {
+          throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error52.message}. Please retry the operation.`);
         }
-        throw error49;
+        throw error52;
       }
     }
     try {
@@ -15858,11 +16617,11 @@ async function savePlan(directory, plan, options) {
           }
         }
       }
-    } catch (error49) {
-      if (error49 instanceof LedgerStaleWriterError) {
-        throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error49.message}. Please retry the operation.`);
+    } catch (error52) {
+      if (error52 instanceof LedgerStaleWriterError) {
+        throw new PlanConcurrentModificationError(`Concurrent plan modification detected after retries: ${error52.message}. Please retry the operation.`);
       }
-      throw error49;
+      throw error52;
     }
   }
   const SNAPSHOT_INTERVAL = 50;
@@ -16376,11 +17135,11 @@ async function handleAcknowledgeSpecDriftCommand(directory, _args, acknowledgedB
   let stalenessContent;
   try {
     stalenessContent = await fsPromises3.readFile(specStalenessPath, "utf-8");
-  } catch (error49) {
-    if (error49?.code === "ENOENT") {
+  } catch (error52) {
+    if (error52?.code === "ENOENT") {
       return "No spec drift detected.";
     }
-    throw error49;
+    throw error52;
   }
   let stalenessData;
   try {
@@ -17661,6 +18420,13 @@ var init_schema = __esm(() => {
     redaction: exports_external.object({
       rejectDurableSecrets: exports_external.boolean().default(true)
     }).default({ rejectDurableSecrets: true }),
+    maintenance: exports_external.object({
+      lowUtilityMaxConfidence: exports_external.number().min(0).max(1).default(0.45),
+      lowUtilityMinAgeDays: exports_external.number().int().min(1).max(3650).default(30)
+    }).default({
+      lowUtilityMaxConfidence: 0.45,
+      lowUtilityMinAgeDays: 30
+    }),
     hardDelete: exports_external.boolean().default(false)
   });
   CuratorConfigSchema = exports_external.object({
@@ -18149,10 +18915,10 @@ function loadRawConfigFromPath(configPath) {
       fileExisted: true,
       hadError: false
     };
-  } catch (error49) {
-    const isFileNotFoundError = error49 instanceof Error && "code" in error49 && error49.code === "ENOENT";
+  } catch (error52) {
+    const isFileNotFoundError = error52 instanceof Error && "code" in error52 && error52.code === "ENOENT";
     if (!isFileNotFoundError) {
-      const errorMessage = error49 instanceof Error ? error49.message : String(error49);
+      const errorMessage = error52 instanceof Error ? error52.message : String(error52);
       console.warn(`[opencode-swarm] \u26A0\uFE0F CONFIG LOAD FAILURE \u2014 config exists at ${configPath} but could not be loaded: ${errorMessage}`);
       console.warn("[opencode-swarm] \u26A0\uFE0F SECURITY: Config load failed. Falling back to safe defaults with guardrails ENABLED.");
       return { config: null, fileExisted: true, hadError: true };
@@ -18680,7 +19446,7 @@ var require_polyfills = __commonJS((exports, module) => {
           return ret;
         };
       } else if (fs4.futimes) {
-        fs4.lutimes = function(_a2, _b, _c, cb) {
+        fs4.lutimes = function(_a3, _b, _c, cb) {
           if (cb)
             process.nextTick(cb);
         };
@@ -19376,12 +20142,12 @@ var require_retry_operation = __commonJS((exports, module) => {
     var mainError = null;
     var mainErrorCount = 0;
     for (var i = 0;i < this._errors.length; i++) {
-      var error49 = this._errors[i];
-      var message = error49.message;
+      var error52 = this._errors[i];
+      var message = error52.message;
       var count = (counts[message] || 0) + 1;
       counts[message] = count;
       if (count >= mainErrorCount) {
-        mainError = error49;
+        mainError = error52;
         mainErrorCount = count;
       }
     }
@@ -20233,8 +20999,8 @@ function validateProjectRoot(directory) {
               hasProjectIndicator = true;
               break;
             }
-          } catch (error49) {
-            if (error49 instanceof Error && "code" in error49 && error49.code === "ENOENT") {} else {
+          } catch (error52) {
+            if (error52 instanceof Error && "code" in error52 && error52.code === "ENOENT") {} else {
               hasProjectIndicator = true;
               break;
             }
@@ -20245,9 +21011,9 @@ function validateProjectRoot(directory) {
           throw new Error(`Cannot write evidence in "${resolved}" \u2014 parent directory "${parent}" already contains a .swarm/ folder. Evidence must be written to the project root.`);
         }
       }
-    } catch (error49) {
-      if (error49 instanceof Error && error49.message.startsWith("Cannot write evidence")) {
-        throw error49;
+    } catch (error52) {
+      if (error52 instanceof Error && error52.message.startsWith("Cannot write evidence")) {
+        throw error52;
       }
     }
     current = parent;
@@ -20267,8 +21033,8 @@ async function saveEvidence(directory, taskId, evidence) {
       try {
         const parsed = JSON.parse(existingContent);
         bundle = EvidenceBundleSchema.parse(parsed);
-      } catch (error49) {
-        warn(`Existing evidence bundle invalid for task ${sanitizedTaskId}, creating new: ${error49 instanceof Error ? error49.message : String(error49)}`);
+      } catch (error52) {
+        warn(`Existing evidence bundle invalid for task ${sanitizedTaskId}, creating new: ${error52 instanceof Error ? error52.message : String(error52)}`);
         const now = new Date().toISOString();
         bundle = {
           schema_version: "1.0.0",
@@ -20307,11 +21073,11 @@ async function saveEvidence(directory, taskId, evidence) {
     try {
       await bunWrite(tempPath, bundleJson);
       await fs4.rename(tempPath, evidencePath);
-    } catch (error49) {
+    } catch (error52) {
       try {
         rmSync(tempPath, { force: true });
       } catch {}
-      throw error49;
+      throw error52;
     }
     return updatedBundle;
   });
@@ -20377,18 +21143,18 @@ async function loadEvidence(directory, taskId) {
         warn(`Evidence lock failed during flat-retrospective write-back for task ${sanitizedTaskId}: ${lockErr instanceof Error ? lockErr.message : String(lockErr)}`);
       }
       return { status: "found", bundle: validated };
-    } catch (error49) {
-      warn(`Wrapped flat retrospective failed validation for task ${sanitizedTaskId}: ${error49 instanceof Error ? error49.message : String(error49)}`);
-      const errors3 = error49 instanceof ZodError ? error49.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error49 instanceof Error ? error49.message : String(error49)];
+    } catch (error52) {
+      warn(`Wrapped flat retrospective failed validation for task ${sanitizedTaskId}: ${error52 instanceof Error ? error52.message : String(error52)}`);
+      const errors3 = error52 instanceof ZodError ? error52.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error52 instanceof Error ? error52.message : String(error52)];
       return { status: "invalid_schema", errors: errors3 };
     }
   }
   try {
     const validated = EvidenceBundleSchema.parse(parsed);
     return { status: "found", bundle: validated };
-  } catch (error49) {
-    warn(`Evidence bundle validation failed for task ${sanitizedTaskId}: ${error49 instanceof Error ? error49.message : String(error49)}`);
-    const errors3 = error49 instanceof ZodError ? error49.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error49 instanceof Error ? error49.message : String(error49)];
+  } catch (error52) {
+    warn(`Evidence bundle validation failed for task ${sanitizedTaskId}: ${error52 instanceof Error ? error52.message : String(error52)}`);
+    const errors3 = error52 instanceof ZodError ? error52.issues.map((e) => `${e.path.join(".")}: ${e.message}`) : [error52 instanceof Error ? error52.message : String(error52)];
     return { status: "invalid_schema", errors: errors3 };
   }
 }
@@ -20415,9 +21181,9 @@ async function listEvidenceTaskIds(directory) {
       }
       sanitizeTaskId2(entry);
       taskIds.push(entry);
-    } catch (error49) {
-      if (error49 instanceof Error && !error49.message.startsWith("Invalid task ID")) {
-        warn(`Error reading evidence entry '${entry}': ${error49.message}`);
+    } catch (error52) {
+      if (error52 instanceof Error && !error52.message.startsWith("Invalid task ID")) {
+        warn(`Error reading evidence entry '${entry}': ${error52.message}`);
       }
     }
   }
@@ -20435,8 +21201,8 @@ async function deleteEvidence(directory, taskId) {
   try {
     rmSync(evidenceDir, { recursive: true, force: true });
     return true;
-  } catch (error49) {
-    warn(`Failed to delete evidence for task ${sanitizedTaskId}: ${error49 instanceof Error ? error49.message : String(error49)}`);
+  } catch (error52) {
+    warn(`Failed to delete evidence for task ${sanitizedTaskId}: ${error52 instanceof Error ? error52.message : String(error52)}`);
     return false;
   }
 }
@@ -22049,12 +22815,12 @@ async function handleBrainstormCommand(_directory, args) {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/core/core.js
 function $constructor2(name, initializer3, params) {
   function init(inst, def) {
-    var _a2;
+    var _a3;
     Object.defineProperty(inst, "_zod", {
       value: inst._zod ?? {},
       enumerable: false
     });
-    (_a2 = inst._zod).traits ?? (_a2.traits = new Set);
+    (_a3 = inst._zod).traits ?? (_a3.traits = new Set);
     inst._zod.traits.add(name);
     initializer3(inst, def);
     for (const k in _.prototype) {
@@ -22070,10 +22836,10 @@ function $constructor2(name, initializer3, params) {
   }
   Object.defineProperty(Definition, "name", { value: name });
   function _(def) {
-    var _a2;
+    var _a3;
     const inst = params?.Parent ? new Definition : this;
     init(inst, def);
-    (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
+    (_a3 = inst._zod).deferred ?? (_a3.deferred = []);
     for (const fn of inst._zod.deferred) {
       fn();
     }
@@ -22576,8 +23342,8 @@ function aborted2(x, startIndex = 0) {
 }
 function prefixIssues2(path9, issues) {
   return issues.map((iss) => {
-    var _a2;
-    (_a2 = iss).path ?? (_a2.path = []);
+    var _a3;
+    (_a3 = iss).path ?? (_a3.path = []);
     iss.path.unshift(path9);
     return iss;
   });
@@ -22747,10 +23513,10 @@ var init_util2 = __esm(() => {
 });
 
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/core/errors.js
-function flattenError2(error49, mapper = (issue3) => issue3.message) {
+function flattenError2(error52, mapper = (issue3) => issue3.message) {
   const fieldErrors = {};
   const formErrors = [];
-  for (const sub of error49.issues) {
+  for (const sub of error52.issues) {
     if (sub.path.length > 0) {
       fieldErrors[sub.path[0]] = fieldErrors[sub.path[0]] || [];
       fieldErrors[sub.path[0]].push(mapper(sub));
@@ -22760,13 +23526,13 @@ function flattenError2(error49, mapper = (issue3) => issue3.message) {
   }
   return { formErrors, fieldErrors };
 }
-function formatError2(error49, _mapper) {
+function formatError2(error52, _mapper) {
   const mapper = _mapper || function(issue3) {
     return issue3.message;
   };
   const fieldErrors = { _errors: [] };
-  const processError = (error50) => {
-    for (const issue3 of error50.issues) {
+  const processError = (error53) => {
+    for (const issue3 of error53.issues) {
       if (issue3.code === "invalid_union" && issue3.errors.length) {
         issue3.errors.map((issues) => processError({ issues }));
       } else if (issue3.code === "invalid_key") {
@@ -22793,17 +23559,17 @@ function formatError2(error49, _mapper) {
       }
     }
   };
-  processError(error49);
+  processError(error52);
   return fieldErrors;
 }
-function treeifyError2(error49, _mapper) {
+function treeifyError2(error52, _mapper) {
   const mapper = _mapper || function(issue3) {
     return issue3.message;
   };
   const result = { errors: [] };
-  const processError = (error50, path9 = []) => {
-    var _a2, _b;
-    for (const issue3 of error50.issues) {
+  const processError = (error53, path9 = []) => {
+    var _a3, _b;
+    for (const issue3 of error53.issues) {
       if (issue3.code === "invalid_union" && issue3.errors.length) {
         issue3.errors.map((issues) => processError({ issues }, issue3.path));
       } else if (issue3.code === "invalid_key") {
@@ -22823,7 +23589,7 @@ function treeifyError2(error49, _mapper) {
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
             curr.properties ?? (curr.properties = {});
-            (_a2 = curr.properties)[el] ?? (_a2[el] = { errors: [] });
+            (_a3 = curr.properties)[el] ?? (_a3[el] = { errors: [] });
             curr = curr.properties[el];
           } else {
             curr.items ?? (curr.items = []);
@@ -22838,7 +23604,7 @@ function treeifyError2(error49, _mapper) {
       }
     }
   };
-  processError(error49);
+  processError(error52);
   return result;
 }
 function toDotPath2(_path) {
@@ -22859,9 +23625,9 @@ function toDotPath2(_path) {
   }
   return segs.join("");
 }
-function prettifyError2(error49) {
+function prettifyError2(error52) {
   const lines = [];
-  const issues = [...error49.issues].sort((a, b) => (a.path ?? []).length - (b.path ?? []).length);
+  const issues = [...error52.issues].sort((a, b) => (a.path ?? []).length - (b.path ?? []).length);
   for (const issue3 of issues) {
     lines.push(`\u2716 ${issue3.message}`);
     if (issue3.path?.length)
@@ -23138,10 +23904,10 @@ var init_checks3 = __esm(() => {
   init_regexes2();
   init_util2();
   $ZodCheck2 = /* @__PURE__ */ $constructor2("$ZodCheck", (inst, def) => {
-    var _a2;
+    var _a3;
     inst._zod ?? (inst._zod = {});
     inst._zod.def = def;
-    (_a2 = inst._zod).onattach ?? (_a2.onattach = []);
+    (_a3 = inst._zod).onattach ?? (_a3.onattach = []);
   });
   numericOriginMap2 = {
     number: "number",
@@ -23207,8 +23973,8 @@ var init_checks3 = __esm(() => {
   $ZodCheckMultipleOf2 = /* @__PURE__ */ $constructor2("$ZodCheckMultipleOf", (inst, def) => {
     $ZodCheck2.init(inst, def);
     inst._zod.onattach.push((inst2) => {
-      var _a2;
-      (_a2 = inst2._zod.bag).multipleOf ?? (_a2.multipleOf = def.value);
+      var _a3;
+      (_a3 = inst2._zod.bag).multipleOf ?? (_a3.multipleOf = def.value);
     });
     inst._zod.check = (payload) => {
       if (typeof payload.value !== typeof def.value)
@@ -23335,9 +24101,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMaxSize2 = /* @__PURE__ */ $constructor2("$ZodCheckMaxSize", (inst, def) => {
-    var _a2;
+    var _a3;
     $ZodCheck2.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.size !== undefined;
     });
@@ -23363,9 +24129,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMinSize2 = /* @__PURE__ */ $constructor2("$ZodCheckMinSize", (inst, def) => {
-    var _a2;
+    var _a3;
     $ZodCheck2.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.size !== undefined;
     });
@@ -23391,9 +24157,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckSizeEquals2 = /* @__PURE__ */ $constructor2("$ZodCheckSizeEquals", (inst, def) => {
-    var _a2;
+    var _a3;
     $ZodCheck2.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.size !== undefined;
     });
@@ -23421,9 +24187,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMaxLength2 = /* @__PURE__ */ $constructor2("$ZodCheckMaxLength", (inst, def) => {
-    var _a2;
+    var _a3;
     $ZodCheck2.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.length !== undefined;
     });
@@ -23450,9 +24216,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckMinLength2 = /* @__PURE__ */ $constructor2("$ZodCheckMinLength", (inst, def) => {
-    var _a2;
+    var _a3;
     $ZodCheck2.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.length !== undefined;
     });
@@ -23479,9 +24245,9 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckLengthEquals2 = /* @__PURE__ */ $constructor2("$ZodCheckLengthEquals", (inst, def) => {
-    var _a2;
+    var _a3;
     $ZodCheck2.init(inst, def);
-    (_a2 = inst._zod.def).when ?? (_a2.when = (payload) => {
+    (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
       const val = payload.value;
       return !nullish3(val) && val.length !== undefined;
     });
@@ -23510,7 +24276,7 @@ var init_checks3 = __esm(() => {
     };
   });
   $ZodCheckStringFormat2 = /* @__PURE__ */ $constructor2("$ZodCheckStringFormat", (inst, def) => {
-    var _a2, _b;
+    var _a3, _b;
     $ZodCheck2.init(inst, def);
     inst._zod.onattach.push((inst2) => {
       const bag = inst2._zod.bag;
@@ -23521,7 +24287,7 @@ var init_checks3 = __esm(() => {
       }
     });
     if (def.pattern)
-      (_a2 = inst._zod).check ?? (_a2.check = (payload) => {
+      (_a3 = inst._zod).check ?? (_a3.check = (payload) => {
         def.pattern.lastIndex = 0;
         if (def.pattern.test(payload.value))
           return;
@@ -24035,7 +24801,7 @@ var init_schemas3 = __esm(() => {
   init_versions2();
   init_util2();
   $ZodType2 = /* @__PURE__ */ $constructor2("$ZodType", (inst, def) => {
-    var _a2;
+    var _a3;
     inst ?? (inst = {});
     inst._zod.def = def;
     inst._zod.bag = inst._zod.bag || {};
@@ -24050,7 +24816,7 @@ var init_schemas3 = __esm(() => {
       }
     }
     if (checks3.length === 0) {
-      (_a2 = inst._zod).deferred ?? (_a2.deferred = []);
+      (_a3 = inst._zod).deferred ?? (_a3.deferred = []);
       inst._zod.deferred?.push(() => {
         inst._zod.run = inst._zod.parse;
       });
@@ -25558,10 +26324,10 @@ var init_schemas3 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ar.js
 function ar_default2() {
   return {
-    localeError: error49()
+    localeError: error52()
   };
 }
-var error49 = () => {
+var error52 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0641", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
     file: { unit: "\u0628\u0627\u064A\u062A", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
@@ -25678,10 +26444,10 @@ var init_ar2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/az.js
 function az_default2() {
   return {
-    localeError: error50()
+    localeError: error53()
   };
 }
-var error50 = () => {
+var error53 = () => {
   const Sizable = {
     string: { unit: "simvol", verb: "olmal\u0131d\u0131r" },
     file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
@@ -25812,10 +26578,10 @@ function getBelarusianPlural2(count, one, few, many) {
 }
 function be_default2() {
   return {
-    localeError: error51()
+    localeError: error54()
   };
 }
-var error51 = () => {
+var error54 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -25965,10 +26731,10 @@ var init_be2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ca.js
 function ca_default2() {
   return {
-    localeError: error52()
+    localeError: error55()
   };
 }
-var error52 = () => {
+var error55 = () => {
   const Sizable = {
     string: { unit: "car\xE0cters", verb: "contenir" },
     file: { unit: "bytes", verb: "contenir" },
@@ -26086,10 +26852,10 @@ var init_ca2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/cs.js
 function cs_default2() {
   return {
-    localeError: error53()
+    localeError: error56()
   };
 }
-var error53 = () => {
+var error56 = () => {
   const Sizable = {
     string: { unit: "znak\u016F", verb: "m\xEDt" },
     file: { unit: "bajt\u016F", verb: "m\xEDt" },
@@ -26225,10 +26991,10 @@ var init_cs2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/da.js
 function da_default2() {
   return {
-    localeError: error54()
+    localeError: error57()
   };
 }
-var error54 = () => {
+var error57 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "havde" },
     file: { unit: "bytes", verb: "havde" },
@@ -26360,10 +27126,10 @@ var init_da2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/de.js
 function de_default2() {
   return {
-    localeError: error55()
+    localeError: error58()
   };
 }
-var error55 = () => {
+var error58 = () => {
   const Sizable = {
     string: { unit: "Zeichen", verb: "zu haben" },
     file: { unit: "Bytes", verb: "zu haben" },
@@ -26480,7 +27246,7 @@ var init_de2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/en.js
 function en_default2() {
   return {
-    localeError: error56()
+    localeError: error59()
   };
 }
 var parsedType2 = (data) => {
@@ -26502,7 +27268,7 @@ var parsedType2 = (data) => {
     }
   }
   return t;
-}, error56 = () => {
+}, error59 = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
     file: { unit: "bytes", verb: "to have" },
@@ -26600,7 +27366,7 @@ var init_en2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/eo.js
 function eo_default2() {
   return {
-    localeError: error57()
+    localeError: error60()
   };
 }
 var parsedType3 = (data) => {
@@ -26622,7 +27388,7 @@ var parsedType3 = (data) => {
     }
   }
   return t;
-}, error57 = () => {
+}, error60 = () => {
   const Sizable = {
     string: { unit: "karaktrojn", verb: "havi" },
     file: { unit: "bajtojn", verb: "havi" },
@@ -26719,10 +27485,10 @@ var init_eo2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/es.js
 function es_default2() {
   return {
-    localeError: error58()
+    localeError: error61()
   };
 }
-var error58 = () => {
+var error61 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "tener" },
     file: { unit: "bytes", verb: "tener" },
@@ -26871,10 +27637,10 @@ var init_es2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fa.js
 function fa_default2() {
   return {
-    localeError: error59()
+    localeError: error62()
   };
 }
-var error59 = () => {
+var error62 = () => {
   const Sizable = {
     string: { unit: "\u06A9\u0627\u0631\u0627\u06A9\u062A\u0631", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
     file: { unit: "\u0628\u0627\u06CC\u062A", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
@@ -26997,10 +27763,10 @@ var init_fa2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fi.js
 function fi_default2() {
   return {
-    localeError: error60()
+    localeError: error63()
   };
 }
-var error60 = () => {
+var error63 = () => {
   const Sizable = {
     string: { unit: "merkki\xE4", subject: "merkkijonon" },
     file: { unit: "tavua", subject: "tiedoston" },
@@ -27123,10 +27889,10 @@ var init_fi2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fr.js
 function fr_default2() {
   return {
-    localeError: error61()
+    localeError: error64()
   };
 }
-var error61 = () => {
+var error64 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -27243,10 +28009,10 @@ var init_fr2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/fr-CA.js
 function fr_CA_default2() {
   return {
-    localeError: error62()
+    localeError: error65()
   };
 }
-var error62 = () => {
+var error65 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
     file: { unit: "octets", verb: "avoir" },
@@ -27364,10 +28130,10 @@ var init_fr_CA2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/he.js
 function he_default2() {
   return {
-    localeError: error63()
+    localeError: error66()
   };
 }
-var error63 = () => {
+var error66 = () => {
   const Sizable = {
     string: { unit: "\u05D0\u05D5\u05EA\u05D9\u05D5\u05EA", verb: "\u05DC\u05DB\u05DC\u05D5\u05DC" },
     file: { unit: "\u05D1\u05D9\u05D9\u05D8\u05D9\u05DD", verb: "\u05DC\u05DB\u05DC\u05D5\u05DC" },
@@ -27484,10 +28250,10 @@ var init_he2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/hu.js
 function hu_default2() {
   return {
-    localeError: error64()
+    localeError: error67()
   };
 }
-var error64 = () => {
+var error67 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "legyen" },
     file: { unit: "byte", verb: "legyen" },
@@ -27604,10 +28370,10 @@ var init_hu2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/id.js
 function id_default2() {
   return {
-    localeError: error65()
+    localeError: error68()
   };
 }
-var error65 = () => {
+var error68 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "memiliki" },
     file: { unit: "byte", verb: "memiliki" },
@@ -27724,7 +28490,7 @@ var init_id2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/is.js
 function is_default2() {
   return {
-    localeError: error66()
+    localeError: error69()
   };
 }
 var parsedType4 = (data) => {
@@ -27746,7 +28512,7 @@ var parsedType4 = (data) => {
     }
   }
   return t;
-}, error66 = () => {
+}, error69 = () => {
   const Sizable = {
     string: { unit: "stafi", verb: "a\xF0 hafa" },
     file: { unit: "b\xE6ti", verb: "a\xF0 hafa" },
@@ -27844,10 +28610,10 @@ var init_is2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/it.js
 function it_default2() {
   return {
-    localeError: error67()
+    localeError: error70()
   };
 }
-var error67 = () => {
+var error70 = () => {
   const Sizable = {
     string: { unit: "caratteri", verb: "avere" },
     file: { unit: "byte", verb: "avere" },
@@ -27964,10 +28730,10 @@ var init_it2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ja.js
 function ja_default2() {
   return {
-    localeError: error68()
+    localeError: error71()
   };
 }
-var error68 = () => {
+var error71 = () => {
   const Sizable = {
     string: { unit: "\u6587\u5B57", verb: "\u3067\u3042\u308B" },
     file: { unit: "\u30D0\u30A4\u30C8", verb: "\u3067\u3042\u308B" },
@@ -28083,7 +28849,7 @@ var init_ja2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ka.js
 function ka_default2() {
   return {
-    localeError: error69()
+    localeError: error72()
   };
 }
 var parsedType5 = (data) => {
@@ -28113,7 +28879,7 @@ var parsedType5 = (data) => {
     function: "\u10E4\u10E3\u10DC\u10E5\u10EA\u10D8\u10D0"
   };
   return typeMap[t] ?? t;
-}, error69 = () => {
+}, error72 = () => {
   const Sizable = {
     string: { unit: "\u10E1\u10D8\u10DB\u10D1\u10DD\u10DA\u10DD", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
     file: { unit: "\u10D1\u10D0\u10D8\u10E2\u10D8", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
@@ -28211,10 +28977,10 @@ var init_ka2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/km.js
 function km_default2() {
   return {
-    localeError: error70()
+    localeError: error73()
   };
 }
-var error70 = () => {
+var error73 = () => {
   const Sizable = {
     string: { unit: "\u178F\u17BD\u17A2\u1780\u17D2\u179F\u179A", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
     file: { unit: "\u1794\u17C3", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
@@ -28340,10 +29106,10 @@ var init_kh2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ko.js
 function ko_default2() {
   return {
-    localeError: error71()
+    localeError: error74()
   };
 }
-var error71 = () => {
+var error74 = () => {
   const Sizable = {
     string: { unit: "\uBB38\uC790", verb: "to have" },
     file: { unit: "\uBC14\uC774\uD2B8", verb: "to have" },
@@ -28475,7 +29241,7 @@ function getUnitTypeFromNumber2(number5) {
 }
 function lt_default2() {
   return {
-    localeError: error72()
+    localeError: error75()
   };
 }
 var parsedType6 = (data) => {
@@ -28524,7 +29290,7 @@ var parsedType6 = (data) => {
   return t;
 }, capitalizeFirstCharacter2 = (text) => {
   return text.charAt(0).toUpperCase() + text.slice(1);
-}, error72 = () => {
+}, error75 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -28695,10 +29461,10 @@ var init_lt2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/mk.js
 function mk_default2() {
   return {
-    localeError: error73()
+    localeError: error76()
   };
 }
-var error73 = () => {
+var error76 = () => {
   const Sizable = {
     string: { unit: "\u0437\u043D\u0430\u0446\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
     file: { unit: "\u0431\u0430\u0458\u0442\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
@@ -28816,10 +29582,10 @@ var init_mk2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ms.js
 function ms_default2() {
   return {
-    localeError: error74()
+    localeError: error77()
   };
 }
-var error74 = () => {
+var error77 = () => {
   const Sizable = {
     string: { unit: "aksara", verb: "mempunyai" },
     file: { unit: "bait", verb: "mempunyai" },
@@ -28936,10 +29702,10 @@ var init_ms2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/nl.js
 function nl_default2() {
   return {
-    localeError: error75()
+    localeError: error78()
   };
 }
-var error75 = () => {
+var error78 = () => {
   const Sizable = {
     string: { unit: "tekens" },
     file: { unit: "bytes" },
@@ -29057,10 +29823,10 @@ var init_nl2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/no.js
 function no_default2() {
   return {
-    localeError: error76()
+    localeError: error79()
   };
 }
-var error76 = () => {
+var error79 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "\xE5 ha" },
     file: { unit: "bytes", verb: "\xE5 ha" },
@@ -29177,10 +29943,10 @@ var init_no2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ota.js
 function ota_default2() {
   return {
-    localeError: error77()
+    localeError: error80()
   };
 }
-var error77 = () => {
+var error80 = () => {
   const Sizable = {
     string: { unit: "harf", verb: "olmal\u0131d\u0131r" },
     file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
@@ -29297,10 +30063,10 @@ var init_ota2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ps.js
 function ps_default2() {
   return {
-    localeError: error78()
+    localeError: error81()
   };
 }
-var error78 = () => {
+var error81 = () => {
   const Sizable = {
     string: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
     file: { unit: "\u0628\u0627\u06CC\u067C\u0633", verb: "\u0648\u0644\u0631\u064A" },
@@ -29423,10 +30189,10 @@ var init_ps2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/pl.js
 function pl_default2() {
   return {
-    localeError: error79()
+    localeError: error82()
   };
 }
-var error79 = () => {
+var error82 = () => {
   const Sizable = {
     string: { unit: "znak\xF3w", verb: "mie\u0107" },
     file: { unit: "bajt\xF3w", verb: "mie\u0107" },
@@ -29544,10 +30310,10 @@ var init_pl2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/pt.js
 function pt_default2() {
   return {
-    localeError: error80()
+    localeError: error83()
   };
 }
-var error80 = () => {
+var error83 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "ter" },
     file: { unit: "bytes", verb: "ter" },
@@ -29679,10 +30445,10 @@ function getRussianPlural2(count, one, few, many) {
 }
 function ru_default2() {
   return {
-    localeError: error81()
+    localeError: error84()
   };
 }
-var error81 = () => {
+var error84 = () => {
   const Sizable = {
     string: {
       unit: {
@@ -29832,10 +30598,10 @@ var init_ru2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/sl.js
 function sl_default2() {
   return {
-    localeError: error82()
+    localeError: error85()
   };
 }
-var error82 = () => {
+var error85 = () => {
   const Sizable = {
     string: { unit: "znakov", verb: "imeti" },
     file: { unit: "bajtov", verb: "imeti" },
@@ -29953,10 +30719,10 @@ var init_sl2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/sv.js
 function sv_default2() {
   return {
-    localeError: error83()
+    localeError: error86()
   };
 }
-var error83 = () => {
+var error86 = () => {
   const Sizable = {
     string: { unit: "tecken", verb: "att ha" },
     file: { unit: "bytes", verb: "att ha" },
@@ -30075,10 +30841,10 @@ var init_sv2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ta.js
 function ta_default2() {
   return {
-    localeError: error84()
+    localeError: error87()
   };
 }
-var error84 = () => {
+var error87 = () => {
   const Sizable = {
     string: { unit: "\u0B8E\u0BB4\u0BC1\u0BA4\u0BCD\u0BA4\u0BC1\u0B95\u0BCD\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
     file: { unit: "\u0BAA\u0BC8\u0B9F\u0BCD\u0B9F\u0BC1\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
@@ -30196,10 +30962,10 @@ var init_ta2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/th.js
 function th_default2() {
   return {
-    localeError: error85()
+    localeError: error88()
   };
 }
-var error85 = () => {
+var error88 = () => {
   const Sizable = {
     string: { unit: "\u0E15\u0E31\u0E27\u0E2D\u0E31\u0E01\u0E29\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
     file: { unit: "\u0E44\u0E1A\u0E15\u0E4C", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
@@ -30317,7 +31083,7 @@ var init_th2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/tr.js
 function tr_default2() {
   return {
-    localeError: error86()
+    localeError: error89()
   };
 }
 var parsedType7 = (data) => {
@@ -30339,7 +31105,7 @@ var parsedType7 = (data) => {
     }
   }
   return t;
-}, error86 = () => {
+}, error89 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "olmal\u0131" },
     file: { unit: "bayt", verb: "olmal\u0131" },
@@ -30435,10 +31201,10 @@ var init_tr2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/uk.js
 function uk_default2() {
   return {
-    localeError: error87()
+    localeError: error90()
   };
 }
-var error87 = () => {
+var error90 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
     file: { unit: "\u0431\u0430\u0439\u0442\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
@@ -30563,10 +31329,10 @@ var init_ua2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/ur.js
 function ur_default2() {
   return {
-    localeError: error88()
+    localeError: error91()
   };
 }
-var error88 = () => {
+var error91 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0648\u0641", verb: "\u06C1\u0648\u0646\u0627" },
     file: { unit: "\u0628\u0627\u0626\u0679\u0633", verb: "\u06C1\u0648\u0646\u0627" },
@@ -30684,10 +31450,10 @@ var init_ur2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/vi.js
 function vi_default2() {
   return {
-    localeError: error89()
+    localeError: error92()
   };
 }
-var error89 = () => {
+var error92 = () => {
   const Sizable = {
     string: { unit: "k\xFD t\u1EF1", verb: "c\xF3" },
     file: { unit: "byte", verb: "c\xF3" },
@@ -30804,10 +31570,10 @@ var init_vi2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/zh-CN.js
 function zh_CN_default2() {
   return {
-    localeError: error90()
+    localeError: error93()
   };
 }
-var error90 = () => {
+var error93 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u7B26", verb: "\u5305\u542B" },
     file: { unit: "\u5B57\u8282", verb: "\u5305\u542B" },
@@ -30924,10 +31690,10 @@ var init_zh_CN2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/zh-TW.js
 function zh_TW_default2() {
   return {
-    localeError: error91()
+    localeError: error94()
   };
 }
-var error91 = () => {
+var error94 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u5143", verb: "\u64C1\u6709" },
     file: { unit: "\u4F4D\u5143\u7D44", verb: "\u64C1\u6709" },
@@ -31045,10 +31811,10 @@ var init_zh_TW2 = __esm(() => {
 // node_modules/@opencode-ai/plugin/node_modules/zod/v4/locales/yo.js
 function yo_default2() {
   return {
-    localeError: error92()
+    localeError: error95()
   };
 }
-var error92 = () => {
+var error95 = () => {
   const Sizable = {
     string: { unit: "\xE0mi", verb: "n\xED" },
     file: { unit: "bytes", verb: "n\xED" },
@@ -32211,7 +32977,7 @@ class JSONSchemaGenerator2 {
     this.seen = new Map;
   }
   process(schema, _params = { path: [], schemaPath: [] }) {
-    var _a2;
+    var _a3;
     const def = schema._zod.def;
     const formatMap2 = {
       guid: "uuid",
@@ -32714,7 +33480,7 @@ class JSONSchemaGenerator2 {
       delete result.schema.default;
     }
     if (this.io === "input" && result.schema._prefault)
-      (_a2 = result.schema).default ?? (_a2.default = result.schema._prefault);
+      (_a3 = result.schema).default ?? (_a3.default = result.schema._prefault);
     delete result.schema._prefault;
     const _result = this.seen.get(schema);
     return _result.schema;
@@ -34708,8 +35474,8 @@ var init_dist = __esm(() => {
 });
 
 // src/tools/create-tool.ts
-function classifyToolError(error93) {
-  const msg = (error93 instanceof Error ? error93.message ?? "" : String(error93)).toLowerCase();
+function classifyToolError(error96) {
+  const msg = (error96 instanceof Error ? error96.message ?? "" : String(error96)).toLowerCase();
   if (msg.includes("not registered") || msg.includes("unknown tool"))
     return "not_registered";
   if (msg.includes("not whitelisted") || msg.includes("not allowed"))
@@ -34727,11 +35493,11 @@ function createSwarmTool(opts) {
       try {
         const result = await opts.execute(args, directory, ctx);
         return result;
-      } catch (error93) {
-        const message = error93 instanceof Error ? error93.message : String(error93);
+      } catch (error96) {
+        const message = error96 instanceof Error ? error96.message : String(error96);
         return JSON.stringify({
           success: false,
-          failure_class: classifyToolError(error93),
+          failure_class: classifyToolError(error96),
           message: "Tool execution failed",
           errors: [message]
         }, null, 2);
@@ -35101,8 +35867,8 @@ async function handleSave2(directory, label) {
     } else {
       return `Error: ${parsed.error || "Failed to save checkpoint"}`;
     }
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     return `Error: ${msg}`;
   }
 }
@@ -35120,8 +35886,8 @@ async function handleRestore2(directory, label) {
     } else {
       return `Error: ${parsed.error || "Failed to restore checkpoint"}`;
     }
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     return `Error: ${msg}`;
   }
 }
@@ -35139,8 +35905,8 @@ async function handleDelete2(directory, label) {
     } else {
       return `Error: ${parsed.error || "Failed to delete checkpoint"}`;
     }
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     return `Error: ${msg}`;
   }
 }
@@ -35169,8 +35935,8 @@ async function handleList2(directory) {
     ];
     return lines.join(`
 `);
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     return `Error: ${msg}`;
   }
 }
@@ -35696,8 +36462,8 @@ class AutomationEventBus {
       await Promise.all(Array.from(listeners).map(async (listener) => {
         try {
           await listener(event);
-        } catch (error93) {
-          log(`[EventBus] Listener error for ${type}`, { error: error93 });
+        } catch (error96) {
+          log(`[EventBus] Listener error for ${type}`, { error: error96 });
         }
       }));
     }
@@ -38156,11 +38922,11 @@ async function executeWriteRetro(args, directory) {
       phase,
       message: `Retrospective evidence written to .swarm/evidence/${taskId}/evidence.json`
     }, null, 2);
-  } catch (error93) {
+  } catch (error96) {
     return JSON.stringify({
       success: false,
       phase,
-      message: error93 instanceof Error ? error93.message : String(error93)
+      message: error96 instanceof Error ? error96.message : String(error96)
     }, null, 2);
   }
 }
@@ -38291,9 +39057,9 @@ async function handleCloseCommand(directory, args, options = {}) {
     const content = await fs7.readFile(planPath, "utf-8");
     planData = JSON.parse(content);
     planExists = true;
-  } catch (error93) {
-    if (error93?.code !== "ENOENT") {
-      return `\u274C Failed to read plan.json: ${error93 instanceof Error ? error93.message : String(error93)}`;
+  } catch (error96) {
+    if (error96?.code !== "ENOENT") {
+      return `\u274C Failed to read plan.json: ${error96 instanceof Error ? error96.message : String(error96)}`;
     }
     const swarmDirExists = await fs7.access(swarmDir).then(() => true).catch(() => false);
     if (!swarmDirExists) {
@@ -38429,10 +39195,10 @@ async function handleCloseCommand(directory, args, options = {}) {
   try {
     curationResult = await curateAndStoreSwarm(allLessons, projectName, { phase_number: 0 }, directory, config3);
     curationSucceeded = true;
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     warnings.push(`Lessons curation failed: ${msg}`);
-    console.warn("[close-command] curateAndStoreSwarm error:", error93);
+    console.warn("[close-command] curateAndStoreSwarm error:", error96);
   }
   if (curationSucceeded && allLessons.length > 0) {
     await fs7.unlink(lessonsFilePath).catch(() => {});
@@ -38532,10 +39298,10 @@ async function handleCloseCommand(directory, args, options = {}) {
           closedTaskIds: guaranteeResult.closedTaskIds,
           originalStatuses
         });
-      } catch (error93) {
-        const msg = error93 instanceof Error ? error93.message : String(error93);
+      } catch (error96) {
+        const msg = error96 instanceof Error ? error96.message : String(error96);
         warnings.push(`Failed to persist terminal plan state: ${msg}`);
-        console.warn("[close-command] Failed to write terminal plan state:", error93);
+        console.warn("[close-command] Failed to write terminal plan state:", error96);
       }
     }
   }
@@ -38594,10 +39360,10 @@ async function handleCloseCommand(directory, args, options = {}) {
   }
   try {
     await archiveEvidence(directory, 30, 10);
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     warnings.push(`Evidence retention archive failed: ${msg}`);
-    console.warn("[close-command] archiveEvidence error:", error93);
+    console.warn("[close-command] archiveEvidence error:", error96);
   }
   let configBackupsRemoved = 0;
   const cleanedFiles = [];
@@ -38674,10 +39440,10 @@ async function handleCloseCommand(directory, args, options = {}) {
 `);
   try {
     await fs7.writeFile(contextPath, contextContent, "utf-8");
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     warnings.push(`Failed to reset context.md: ${msg}`);
-    console.warn("[close-command] Failed to write context.md:", error93);
+    console.warn("[close-command] Failed to write context.md:", error96);
   }
   const pruneBranches = args.includes("--prune-branches");
   let gitAlignResult = "";
@@ -38760,10 +39526,10 @@ async function handleCloseCommand(directory, args, options = {}) {
 `);
   try {
     await fs7.writeFile(closeSummaryPath, summaryContent, "utf-8");
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     warnings.push(`Failed to write close-summary.md: ${msg}`);
-    console.warn("[close-command] Failed to write close-summary.md:", error93);
+    console.warn("[close-command] Failed to write close-summary.md:", error96);
   }
   const preservedClient = swarmState.opencodeClient;
   const preservedFullAutoFlag = swarmState.fullAutoEnabledInConfig;
@@ -39089,11 +39855,11 @@ async function handleCurateCommand(directory, _args) {
     const swarmEntries = await readKnowledge(swarmPath) ?? [];
     const summary = await checkHivePromotions(swarmEntries, config3);
     return formatCurationSummary(summary);
-  } catch (error93) {
-    if (error93 instanceof Error) {
-      return `\u274C Curation failed: ${error93.message}`;
+  } catch (error96) {
+    if (error96 instanceof Error) {
+      return `\u274C Curation failed: ${error96.message}`;
     }
-    return `\u274C Curation failed: ${error93 instanceof Error ? error93.message : String(error93)}`;
+    return `\u274C Curation failed: ${error96 instanceof Error ? error96.message : String(error96)}`;
   }
 }
 function formatCurationSummary(summary) {
@@ -39709,11 +40475,11 @@ function readExisting(evidencePath, taskId) {
   try {
     const raw = readFileSync6(evidencePath, "utf-8");
     return TaskEvidenceSchema.parse(JSON.parse(raw));
-  } catch (error93) {
-    if (error93.code === "ENOENT")
+  } catch (error96) {
+    if (error96.code === "ENOENT")
       return null;
-    telemetry.gateParseError(taskId, error93);
-    throw error93;
+    telemetry.gateParseError(taskId, error96);
+    throw error96;
   }
 }
 async function readTaskEvidence(directory, taskId) {
@@ -39730,10 +40496,10 @@ function readTaskEvidenceRaw(directory, taskId) {
   try {
     const raw = readFileSync6(evidencePath, "utf-8");
     return TaskEvidenceSchema.parse(JSON.parse(raw));
-  } catch (error93) {
-    if (error93.code === "ENOENT")
+  } catch (error96) {
+    if (error96.code === "ENOENT")
       return null;
-    throw error93;
+    throw error96;
   }
 }
 var GateEvidenceSchema, TaskEvidenceSchema;
@@ -40805,9 +41571,9 @@ function createConfigBackup(directory) {
   if (fs8.existsSync(projectConfigPath)) {
     try {
       content = fs8.readFileSync(projectConfigPath, "utf-8");
-    } catch (error93) {
+    } catch (error96) {
       log("[ConfigDoctor] project config read failed", {
-        error: error93 instanceof Error ? error93.message : String(error93)
+        error: error96 instanceof Error ? error96.message : String(error96)
       });
     }
   }
@@ -40815,9 +41581,9 @@ function createConfigBackup(directory) {
     configPath = userConfigPath;
     try {
       content = fs8.readFileSync(userConfigPath, "utf-8");
-    } catch (error93) {
+    } catch (error96) {
       log("[ConfigDoctor] user config read failed", {
-        error: error93 instanceof Error ? error93.message : String(error93)
+        error: error96 instanceof Error ? error96.message : String(error96)
       });
     }
   }
@@ -43819,8 +44585,8 @@ function withStateLock(directory, fn) {
       retries: { retries: 5, minTimeout: 5, maxTimeout: 50 },
       stale: 5000
     });
-  } catch (error93) {
-    warn(`[full-auto/state] cross-process lock unavailable; proceeding unlocked: ${error93 instanceof Error ? error93.message : String(error93)}`);
+  } catch (error96) {
+    warn(`[full-auto/state] cross-process lock unavailable; proceeding unlocked: ${error96 instanceof Error ? error96.message : String(error96)}`);
   }
   try {
     return fn();
@@ -43871,8 +44637,8 @@ function readPersisted(directory) {
       oversightSequence: typeof parsed.oversightSequence === "number" ? parsed.oversightSequence : 0,
       sessions: parsed.sessions
     };
-  } catch (error93) {
-    const reason = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const reason = error96 instanceof Error ? error96.message : String(error96);
     error(`[full-auto/state] Failed to read ${STATE_FILE}: ${reason} \u2014 attempting .bak recovery`);
     try {
       const bakPath = validateSwarmPath(directory, `${STATE_FILE}.bak`);
@@ -43910,8 +44676,8 @@ function writePersisted(directory, persisted) {
     persisted.updatedAt = nowISO();
     payload = `${JSON.stringify(persisted, null, 2)}
 `;
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     error(`[full-auto/state] Failed to prepare ${STATE_FILE} write: ${msg}`);
     throw new Error(`Full-Auto state persistence prepare failed: ${msg}`);
   }
@@ -43936,8 +44702,8 @@ function writePersisted(directory, persisted) {
     if (parsed?.version !== 2) {
       throw new Error("Round-trip readback returned wrong version");
     }
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     error(`[full-auto/state] Failed to persist ${STATE_FILE} atomically: ${msg}`);
     throw new Error(`Full-Auto state persistence failed: ${msg}`);
   }
@@ -44053,8 +44819,8 @@ async function handleFullAutoCommand(directory, args, sessionID) {
       }
       v2Status = "paused";
     }
-  } catch (error93) {
-    durableError = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    durableError = error96 instanceof Error ? error96.message : String(error96);
     error(`[full-auto] durable run-state write failed: ${durableError}`);
   }
   if (newFullAutoMode && durableError) {
@@ -44202,9 +44968,9 @@ function parseSessionState(content) {
       }
     }
     return { activeAgent, delegationState, pendingQA };
-  } catch (error93) {
+  } catch (error96) {
     log("[HandoffService] state extraction failed", {
-      error: error93 instanceof Error ? error93.message : String(error93)
+      error: error96 instanceof Error ? error96.message : String(error96)
     });
     return null;
   }
@@ -44584,9 +45350,9 @@ async function writeSnapshot(directory, state) {
       }
     } catch {}
     renameSync6(tempPath, resolvedPath);
-  } catch (error93) {
+  } catch (error96) {
     log("[snapshot-writer] write failed", {
-      error: error93 instanceof Error ? error93.message : String(error93)
+      error: error96 instanceof Error ? error96.message : String(error96)
     });
   }
 }
@@ -45318,8 +46084,8 @@ async function handleKnowledgeQuarantineCommand(directory, args) {
     const fullId = resolved.entry.id;
     await quarantineEntry(directory, fullId, reason, "user");
     return `\u2705 Entry ${fullId} quarantined successfully.`;
-  } catch (error93) {
-    console.warn("[knowledge-command] quarantineEntry error:", error93 instanceof Error ? error93.message : String(error93));
+  } catch (error96) {
+    console.warn("[knowledge-command] quarantineEntry error:", error96 instanceof Error ? error96.message : String(error96));
     return `\u274C Failed to quarantine entry. Check the entry ID and try again.`;
   }
 }
@@ -45341,8 +46107,8 @@ async function handleKnowledgeRestoreCommand(directory, args) {
     const fullId = resolved.entry.id;
     await restoreEntry(directory, fullId);
     return `\u2705 Entry ${fullId} restored successfully.`;
-  } catch (error93) {
-    console.warn("[knowledge-command] restoreEntry error:", error93 instanceof Error ? error93.message : String(error93));
+  } catch (error96) {
+    console.warn("[knowledge-command] restoreEntry error:", error96 instanceof Error ? error96.message : String(error96));
     return `\u274C Failed to restore entry. Check the entry ID and try again.`;
   }
 }
@@ -45363,8 +46129,8 @@ async function handleKnowledgeMigrateCommand(directory, args) {
       }
     }
     return `\u2705 Migration complete: ${result.entriesMigrated} entries added, ${result.entriesDropped} dropped (validation/dedup), ${result.entriesTotal} total processed.`;
-  } catch (error93) {
-    console.warn("[knowledge-command] migrateContextToKnowledge error:", error93 instanceof Error ? error93.message : String(error93));
+  } catch (error96) {
+    console.warn("[knowledge-command] migrateContextToKnowledge error:", error96 instanceof Error ? error96.message : String(error96));
     return "\u274C Migration failed. Check .swarm/context.md is readable.";
   }
 }
@@ -45390,8 +46156,8 @@ async function handleKnowledgeListCommand(directory, _args) {
     lines.push("Use `/swarm knowledge quarantine <id-prefix>` to hide an entry. Prefix matching is supported \u2014 the 12-character prefix shown is unique in most stores.");
     return lines.join(`
 `);
-  } catch (error93) {
-    console.warn("[knowledge-command] list error:", error93 instanceof Error ? error93.message : String(error93));
+  } catch (error96) {
+    console.warn("[knowledge-command] list error:", error96 instanceof Error ? error96.message : String(error96));
     return "\u274C Failed to list knowledge entries. Ensure .swarm/knowledge.jsonl exists.";
   }
 }
@@ -45426,6 +46192,10 @@ function resolveMemoryConfig(input) {
     redaction: {
       ...DEFAULT_MEMORY_CONFIG.redaction,
       ...input?.redaction ?? {}
+    },
+    maintenance: {
+      ...DEFAULT_MEMORY_CONFIG.maintenance,
+      ...input?.maintenance ?? {}
     }
   };
 }
@@ -45456,6 +46226,10 @@ var init_config3 = __esm(() => {
     },
     redaction: {
       rejectDurableSecrets: true
+    },
+    maintenance: {
+      lowUtilityMaxConfidence: 0.45,
+      lowUtilityMinAgeDays: 30
     },
     hardDelete: false
   };
@@ -45837,6 +46611,167 @@ function normalizeTags(tags) {
 }
 var init_curator_decision_helpers = __esm(() => {
   init_errors6();
+  init_schema2();
+});
+
+// src/memory/maintenance.ts
+async function buildMemoryMaintenanceReport(provider, options = {}) {
+  const now = options.now ?? new Date;
+  const limit = Math.max(1, Math.trunc(options.limit ?? 20));
+  const memories = await provider.list({
+    includeExpired: true,
+    includeInactive: true
+  });
+  const proposals = await loadMaintenanceProposals(provider, limit);
+  const recallUsage = provider.listRecallUsage ? await provider.listRecallUsage() : [];
+  const usageByMemory = summarizeRecallByMemory(recallUsage);
+  const usageByRole = summarizeRecallByRole(recallUsage);
+  const activeMemories = memories.filter((memory) => isActiveMemory(memory, now));
+  const deletedMemories = memories.filter((memory) => memory.metadata.deleted === true);
+  const expiredScratchMemories = memories.filter((memory) => memory.kind === "scratch" && isExpired(memory, now));
+  const supersededMemories = memories.filter((memory) => Boolean(memory.supersededBy));
+  const lowUtilityMemories = activeMemories.filter((memory) => isLowUtility(memory, usageByMemory, now, {
+    maxConfidence: options.lowUtilityMaxConfidence ?? DEFAULT_LOW_UTILITY_MAX_CONFIDENCE,
+    minAgeDays: options.lowUtilityMinAgeDays ?? DEFAULT_LOW_UTILITY_MIN_AGE_DAYS
+  })).sort(memorySort);
+  const neverRecalledMemories = activeMemories.filter((memory) => !usageByMemory.has(memory.id)).sort(memorySort);
+  const rejectedProposalReasons = proposals.filter((proposal) => proposal.status === "rejected").sort(proposalSort);
+  const pendingProposals = proposals.filter((proposal) => proposal.status === "pending").sort(proposalSort);
+  return {
+    generatedAt: now.toISOString(),
+    totalMemories: memories.length,
+    activeMemories: activeMemories.length,
+    deletedMemories: deletedMemories.slice(0, limit),
+    expiredScratchMemories: expiredScratchMemories.slice(0, limit),
+    supersededMemories: supersededMemories.slice(0, limit),
+    supersededChains: buildSupersededChains(memories).slice(0, limit),
+    lowUtilityMemories: lowUtilityMemories.slice(0, limit),
+    neverRecalledMemories: neverRecalledMemories.slice(0, limit),
+    mostRecalledMemories: Array.from(usageByMemory.values()).sort((a, b) => b.count - a.count || b.lastRecalledAt.localeCompare(a.lastRecalledAt) || a.memoryId.localeCompare(b.memoryId)).slice(0, limit),
+    recallByAgentRole: Array.from(usageByRole.values()).sort((a, b) => b.count - a.count || a.agentRole.localeCompare(b.agentRole)).slice(0, limit),
+    rejectedProposalReasons: rejectedProposalReasons.slice(0, limit),
+    pendingProposals: pendingProposals.slice(0, limit),
+    recallEventCount: recallUsage.length
+  };
+}
+function shouldCompactMemory(memory, now = new Date) {
+  if (memory.metadata.deleted === true)
+    return "deleted";
+  if (memory.supersededBy)
+    return "superseded";
+  if (memory.kind === "scratch" && isExpired(memory, now)) {
+    return "expired_scratch";
+  }
+  return null;
+}
+function isActiveMemory(memory, now) {
+  return memory.metadata.deleted !== true && !memory.supersededBy && !isExpired(memory, now);
+}
+function isLowUtility(memory, usageByMemory, now, options) {
+  if (usageByMemory.has(memory.id))
+    return false;
+  const updated = Date.parse(memory.updatedAt);
+  const ageDays = Number.isFinite(updated) ? (now.getTime() - updated) / (24 * 60 * 60 * 1000) : 0;
+  return memory.confidence <= options.maxConfidence || ageDays >= options.minAgeDays;
+}
+function summarizeRecallByMemory(usageEvents) {
+  const byMemory = new Map;
+  for (const event of usageEvents) {
+    event.memoryIds.forEach((memoryId, index) => {
+      const role = event.agentRole ?? "unknown";
+      const existing = byMemory.get(memoryId) ?? {
+        memoryId,
+        count: 0,
+        lastRecalledAt: event.timestamp,
+        agentRoles: {},
+        averageScore: 0,
+        scoreTotal: 0,
+        scoreCount: 0
+      };
+      existing.count++;
+      existing.lastRecalledAt = event.timestamp > existing.lastRecalledAt ? event.timestamp : existing.lastRecalledAt;
+      existing.agentRoles[role] = (existing.agentRoles[role] ?? 0) + 1;
+      const score = event.scores[index];
+      if (typeof score === "number" && Number.isFinite(score)) {
+        existing.scoreTotal += score;
+        existing.scoreCount++;
+        existing.averageScore = existing.scoreTotal / existing.scoreCount;
+      }
+      byMemory.set(memoryId, existing);
+    });
+  }
+  return new Map(Array.from(byMemory, ([memoryId, value]) => [
+    memoryId,
+    {
+      memoryId,
+      count: value.count,
+      lastRecalledAt: value.lastRecalledAt,
+      agentRoles: value.agentRoles,
+      averageScore: value.averageScore
+    }
+  ]));
+}
+async function loadMaintenanceProposals(provider, limit) {
+  if (!provider.listProposals)
+    return [];
+  const [pending, rejected, recent] = await Promise.all([
+    provider.listProposals({ status: "pending", limit }),
+    provider.listProposals({ status: "rejected", limit }),
+    provider.listProposals({ limit: Math.max(limit * 4, 100) })
+  ]);
+  const byId = new Map;
+  for (const proposal of [...pending, ...rejected, ...recent]) {
+    byId.set(proposal.id, proposal);
+  }
+  return Array.from(byId.values());
+}
+function summarizeRecallByRole(usageEvents) {
+  const byRole = new Map;
+  for (const event of usageEvents) {
+    const role = event.agentRole ?? "unknown";
+    const existing = byRole.get(role) ?? {
+      agentRole: role,
+      count: 0,
+      memoryIds: {}
+    };
+    existing.count++;
+    for (const memoryId of event.memoryIds) {
+      existing.memoryIds[memoryId] = (existing.memoryIds[memoryId] ?? 0) + 1;
+    }
+    byRole.set(role, existing);
+  }
+  return byRole;
+}
+function buildSupersededChains(memories) {
+  const byId = new Map(memories.map((memory) => [memory.id, memory]));
+  const supersededIds = new Set(memories.filter((memory) => memory.supersededBy).map((memory) => memory.id));
+  const roots = memories.filter((memory) => memory.supersededBy && !(memory.supersedes ?? []).some((id) => supersededIds.has(id)));
+  return roots.map((root) => {
+    const chain = [root.id];
+    const seen = new Set(chain);
+    let cursor = root;
+    while (cursor?.supersededBy && !seen.has(cursor.supersededBy)) {
+      chain.push(cursor.supersededBy);
+      seen.add(cursor.supersededBy);
+      cursor = byId.get(cursor.supersededBy);
+    }
+    return {
+      rootId: root.id,
+      chain,
+      reason: typeof root.metadata.supersedeReason === "string" ? root.metadata.supersedeReason : undefined
+    };
+  });
+}
+function memorySort(a, b) {
+  return b.updatedAt.localeCompare(a.updatedAt) || a.id.localeCompare(b.id);
+}
+function proposalSort(a, b) {
+  const aTime = a.reviewedAt ?? a.createdAt;
+  const bTime = b.reviewedAt ?? b.createdAt;
+  return bTime.localeCompare(aTime) || a.id.localeCompare(b.id);
+}
+var DEFAULT_LOW_UTILITY_MAX_CONFIDENCE = 0.45, DEFAULT_LOW_UTILITY_MIN_AGE_DAYS = 30;
+var init_maintenance = __esm(() => {
   init_schema2();
 });
 
@@ -46227,16 +47162,21 @@ class LocalJsonlMemoryProvider {
   }
   async recordRecallUsage(event) {
     await this.initialize();
-    await this.audit("recall", event.bundleId, JSON.stringify({
-      query: event.query,
-      scopes: event.scopes,
-      kinds: event.kinds,
-      memoryIds: event.memoryIds,
-      scores: event.scores,
-      tokenEstimate: event.tokenEstimate,
-      agentRole: event.agentRole,
-      runId: event.runId
-    }));
+    await this.audit("recall", event.bundleId, undefined, event);
+  }
+  async listRecallUsage(filter = {}) {
+    await this.initialize();
+    const events = await readAuditEvents(this.pathFor("audit"));
+    const usage = [];
+    for (const event of events) {
+      if (event.operation !== "recall")
+        continue;
+      const parsed = parseRecallUsageEvent(event);
+      if (parsed)
+        usage.push(parsed);
+    }
+    usage.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    return usage.slice(0, filter.limit ?? usage.length);
   }
   async list(filter = {}) {
     await this.initialize();
@@ -46256,7 +47196,9 @@ class LocalJsonlMemoryProvider {
         return !Number.isFinite(expires) || expires > now;
       });
     }
-    records = records.filter((record3) => !record3.supersededBy && record3.metadata.deleted !== true);
+    if (!filter.includeInactive) {
+      records = records.filter((record3) => !record3.supersededBy && record3.metadata.deleted !== true);
+    }
     records.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
     return records.slice(0, filter.limit ?? records.length);
   }
@@ -46368,6 +47310,41 @@ class LocalJsonlMemoryProvider {
     await writeJsonlAtomic(this.pathFor("memories"), Array.from(this.memories.values()));
     await this.audit("compact", "memories");
   }
+  async compactMaintenance(options = {}) {
+    await this.initialize();
+    const now = options.now ? new Date(options.now) : new Date;
+    const kept = [];
+    const result = {
+      dryRun: options.dryRun !== false,
+      removedDeleted: 0,
+      removedSuperseded: 0,
+      removedExpiredScratch: 0,
+      remaining: 0
+    };
+    for (const memory of this.memories.values()) {
+      const compactReason = shouldCompactMemory(memory, now);
+      if (compactReason === "deleted") {
+        result.removedDeleted++;
+        continue;
+      }
+      if (compactReason === "superseded") {
+        result.removedSuperseded++;
+        continue;
+      }
+      if (compactReason === "expired_scratch") {
+        result.removedExpiredScratch++;
+        continue;
+      }
+      kept.push(memory);
+    }
+    result.remaining = kept.length;
+    if (result.dryRun)
+      return result;
+    this.memories = new Map(kept.map((memory) => [memory.id, memory]));
+    await writeJsonlAtomic(this.pathFor("memories"), kept);
+    await this.audit("compact", "memories", "removed deleted, superseded, and expired scratch memories", result);
+    return result;
+  }
   async audit(operation, targetId, reason, eventJson) {
     const event = {
       id: randomUUID3(),
@@ -46446,6 +47423,46 @@ async function readJsonl(filePath) {
   }
   return records;
 }
+async function readAuditEvents(filePath) {
+  const values = await readJsonl(filePath);
+  const events = [];
+  for (const value of values) {
+    if (!value || typeof value !== "object")
+      continue;
+    const candidate = value;
+    if (typeof candidate.id !== "string" || typeof candidate.operation !== "string" || typeof candidate.targetId !== "string" || typeof candidate.timestamp !== "string") {
+      continue;
+    }
+    events.push(candidate);
+  }
+  return events;
+}
+function parseRecallUsageEvent(event) {
+  const raw = event.eventJson ?? event.reason;
+  if (typeof raw !== "string" && (!raw || typeof raw !== "object")) {
+    return null;
+  }
+  try {
+    const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+    if (!Array.isArray(parsed.memoryIds) || typeof parsed.query !== "string") {
+      return null;
+    }
+    return {
+      bundleId: typeof parsed.bundleId === "string" ? parsed.bundleId : event.targetId,
+      query: parsed.query,
+      scopes: Array.isArray(parsed.scopes) ? parsed.scopes : [],
+      kinds: Array.isArray(parsed.kinds) ? parsed.kinds : undefined,
+      memoryIds: parsed.memoryIds.filter((memoryId) => typeof memoryId === "string"),
+      scores: Array.isArray(parsed.scores) ? parsed.scores.filter((score) => typeof score === "number" && Number.isFinite(score)) : [],
+      tokenEstimate: typeof parsed.tokenEstimate === "number" ? parsed.tokenEstimate : 0,
+      agentRole: typeof parsed.agentRole === "string" ? parsed.agentRole : undefined,
+      runId: typeof parsed.runId === "string" ? parsed.runId : undefined,
+      timestamp: typeof parsed.timestamp === "string" ? parsed.timestamp : event.timestamp
+    };
+  } catch {
+    return null;
+  }
+}
 async function appendJsonl(filePath, value) {
   await mkdir8(path29.dirname(filePath), { recursive: true });
   await appendFile4(filePath, `${JSON.stringify(value)}
@@ -46465,6 +47482,7 @@ var init_local_jsonl_provider = __esm(() => {
   init_config3();
   init_curator_decision_helpers();
   init_errors6();
+  init_maintenance();
   init_schema2();
   init_scoring();
 });
@@ -46722,6 +47740,10 @@ class SQLiteMemoryProvider {
       redaction: {
         ...DEFAULT_MEMORY_CONFIG.redaction,
         ...config3.redaction ?? {}
+      },
+      maintenance: {
+        ...DEFAULT_MEMORY_CONFIG.maintenance,
+        ...config3.maintenance ?? {}
       }
     };
   }
@@ -46827,6 +47849,26 @@ class SQLiteMemoryProvider {
 			) VALUES (?, ?, ?, ?)`, [randomUUID4(), event.bundleId, event.timestamp, JSON.stringify(event)]);
     await this.event("recall", event.bundleId, JSON.stringify(event));
   }
+  async listRecallUsage(filter = {}) {
+    await this.initialize();
+    const rows = typeof filter.limit === "number" ? this.requireDb().query(`SELECT usage_json
+				FROM memory_recall_usage
+				ORDER BY timestamp DESC
+				LIMIT ?`).all(Math.max(1, Math.trunc(filter.limit))) : this.requireDb().query(`SELECT usage_json
+				FROM memory_recall_usage
+				ORDER BY timestamp DESC
+				`).all();
+    const events = [];
+    for (const row of rows) {
+      try {
+        const parsed = JSON.parse(row.usage_json);
+        if (Array.isArray(parsed.memoryIds) && typeof parsed.query === "string") {
+          events.push(parsed);
+        }
+      } catch {}
+    }
+    return events;
+  }
   async list(filter = {}) {
     await this.initialize();
     let records = Array.from(this.memories.values());
@@ -46845,7 +47887,9 @@ class SQLiteMemoryProvider {
         return !Number.isFinite(expires) || expires > now;
       });
     }
-    records = records.filter((record3) => !record3.supersededBy && record3.metadata.deleted !== true);
+    if (!filter.includeInactive) {
+      records = records.filter((record3) => !record3.supersededBy && record3.metadata.deleted !== true);
+    }
     records.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
     return records.slice(0, filter.limit ?? records.length);
   }
@@ -46925,6 +47969,52 @@ class SQLiteMemoryProvider {
       memories: memories.length,
       proposals: proposals.length
     };
+  }
+  async compactMaintenance(options = {}) {
+    await this.initialize();
+    const now = options.now ? new Date(options.now) : new Date;
+    const kept = [];
+    const removeIds = [];
+    const result = {
+      dryRun: options.dryRun !== false,
+      removedDeleted: 0,
+      removedSuperseded: 0,
+      removedExpiredScratch: 0,
+      remaining: 0
+    };
+    for (const memory of this.memories.values()) {
+      const compactReason = shouldCompactMemory(memory, now);
+      if (compactReason === "deleted") {
+        result.removedDeleted++;
+        removeIds.push(memory.id);
+        continue;
+      }
+      if (compactReason === "superseded") {
+        result.removedSuperseded++;
+        removeIds.push(memory.id);
+        continue;
+      }
+      if (compactReason === "expired_scratch") {
+        result.removedExpiredScratch++;
+        removeIds.push(memory.id);
+        continue;
+      }
+      kept.push(memory);
+    }
+    result.remaining = kept.length;
+    if (result.dryRun)
+      return result;
+    const db = this.requireDb();
+    const compact = db.transaction(() => {
+      for (const id of removeIds) {
+        db.run("DELETE FROM memory_items WHERE id = ?", [id]);
+        this.deleteMemoryFts(id);
+      }
+      this.insertEvent("compact", "memory_items", "removed deleted, superseded, and expired scratch memories", JSON.stringify(result));
+    });
+    compact();
+    this.memories = new Map(kept.map((memory) => [memory.id, memory]));
+    return result;
   }
   hasMigration(name) {
     const row = this.requireDb().query("SELECT version, name FROM schema_migrations WHERE name = ? LIMIT 1").get(name);
@@ -47402,6 +48492,7 @@ var init_sqlite_provider = __esm(() => {
   init_curator_decision_helpers();
   init_errors6();
   init_jsonl_migration();
+  init_maintenance();
   init_schema2();
   init_scoring();
   FTS_INDEX_COLUMNS = [
@@ -47929,6 +49020,7 @@ var init_memory = __esm(() => {
   init_injector();
   init_jsonl_migration();
   init_local_jsonl_provider();
+  init_maintenance();
   init_prompt_block();
   init_recall_planner();
   init_redaction();
@@ -47947,6 +49039,10 @@ async function handleMemoryCommand(_directory, _args) {
     "## Swarm Memory",
     "",
     "- `/swarm memory status` - show provider, SQLite path, JSONL files, and last migration report",
+    "- `/swarm memory pending` - show pending proposals and recent rejection reasons",
+    "- `/swarm memory recall-log` - summarize recall usage by agent role and memory ID",
+    "- `/swarm memory stale` - list expired scratch, superseded, deleted, and low-utility memories",
+    "- `/swarm memory compact` - dry-run compaction; pass `--confirm` to remove deleted, superseded, and expired scratch records",
     "- `/swarm memory export` - export current memory and proposals to `.swarm/memory/export/*.jsonl`",
     "- `/swarm memory import` - import `.swarm/memory/{memories,proposals}.jsonl` into SQLite",
     "- `/swarm memory migrate` - run the one-time legacy JSONL to SQLite migration",
@@ -47968,6 +49064,7 @@ async function handleMemoryStatusCommand(directory, _args) {
     `- Storage: \`${storageDir}\``,
     `- SQLite path: \`${sqlitePath}\``,
     `- SQLite database exists: \`${existsSync20(sqlitePath)}\``,
+    `- Automatic destructive cleanup: \`disabled\``,
     "",
     "### Legacy JSONL"
   ];
@@ -47991,6 +49088,119 @@ async function handleMemoryStatusCommand(directory, _args) {
   }
   return lines.join(`
 `);
+}
+async function handleMemoryPendingCommand(directory, args) {
+  const parsed = parseMaintenanceArgs(args, {
+    usage: "Usage: /swarm memory pending [--limit <n>]",
+    allowConfirm: false
+  });
+  if ("error" in parsed)
+    return parsed.error;
+  const config3 = resolveCommandMemoryConfig(directory);
+  const provider = createMaintenanceProvider(directory, config3);
+  try {
+    await provider.initialize?.();
+    const report = await buildMemoryMaintenanceReport(provider, {
+      ...maintenanceReportOptions(config3, parsed.limit)
+    });
+    const lines = [
+      "## Swarm Memory Pending",
+      "",
+      `- Pending proposals shown: \`${report.pendingProposals.length}\``,
+      `- Rejected proposal reasons shown: \`${report.rejectedProposalReasons.length}\``
+    ];
+    appendProposalLines(lines, "Pending proposals", report.pendingProposals);
+    appendProposalLines(lines, "Rejected proposal reasons", report.rejectedProposalReasons);
+    return lines.join(`
+`);
+  } finally {
+    await provider.close?.();
+  }
+}
+async function handleMemoryRecallLogCommand(directory, args) {
+  const parsed = parseMaintenanceArgs(args, {
+    usage: "Usage: /swarm memory recall-log [--limit <n>]",
+    allowConfirm: false
+  });
+  if ("error" in parsed)
+    return parsed.error;
+  const config3 = resolveCommandMemoryConfig(directory);
+  const provider = createMaintenanceProvider(directory, config3);
+  try {
+    await provider.initialize?.();
+    const report = await buildMemoryMaintenanceReport(provider, {
+      ...maintenanceReportOptions(config3, parsed.limit)
+    });
+    const lines = [
+      "## Swarm Memory Recall Log",
+      "",
+      `- Recall events scanned: \`${report.recallEventCount}\``,
+      `- Most-recalled memories shown: \`${report.mostRecalledMemories.length}\``,
+      `- Never-recalled memories shown: \`${report.neverRecalledMemories.length}\``
+    ];
+    appendRecallRoleLines(lines, report.recallByAgentRole);
+    appendRecallMemoryLines(lines, report.mostRecalledMemories);
+    appendMemoryLines(lines, "Never-recalled memories", report.neverRecalledMemories);
+    return lines.join(`
+`);
+  } finally {
+    await provider.close?.();
+  }
+}
+async function handleMemoryStaleCommand(directory, args) {
+  const parsed = parseMaintenanceArgs(args, {
+    usage: "Usage: /swarm memory stale [--limit <n>]",
+    allowConfirm: false
+  });
+  if ("error" in parsed)
+    return parsed.error;
+  const config3 = resolveCommandMemoryConfig(directory);
+  const provider = createMaintenanceProvider(directory, config3);
+  try {
+    await provider.initialize?.();
+    const report = await buildMemoryMaintenanceReport(provider, {
+      ...maintenanceReportOptions(config3, parsed.limit)
+    });
+    const lines = [
+      "## Swarm Memory Stale",
+      "",
+      `- Active memories: \`${report.activeMemories}\``,
+      `- Expired scratch memories shown: \`${report.expiredScratchMemories.length}\``,
+      `- Deleted tombstones shown: \`${report.deletedMemories.length}\``,
+      `- Superseded memories shown: \`${report.supersededMemories.length}\``,
+      `- Low-utility memories shown: \`${report.lowUtilityMemories.length}\``
+    ];
+    appendMemoryLines(lines, "Expired scratch memories", report.expiredScratchMemories);
+    appendMemoryLines(lines, "Deleted tombstones", report.deletedMemories);
+    appendSupersededChains(lines, report);
+    appendMemoryLines(lines, "Low-utility memories", report.lowUtilityMemories);
+    return lines.join(`
+`);
+  } finally {
+    await provider.close?.();
+  }
+}
+async function handleMemoryCompactCommand(directory, args) {
+  const parsed = parseMaintenanceArgs(args, {
+    usage: "Usage: /swarm memory compact [--confirm]",
+    allowConfirm: true,
+    allowLimit: false
+  });
+  if ("error" in parsed)
+    return parsed.error;
+  const provider = createMaintenanceProvider(directory, resolveCommandMemoryConfig(directory));
+  try {
+    await provider.initialize?.();
+    if (!provider.compactMaintenance) {
+      return "Memory provider does not support compaction.";
+    }
+    const result = await provider.compactMaintenance({
+      dryRun: !parsed.confirm
+    });
+    return formatCompactResult(result, parsed.confirm);
+  } finally {
+    await provider.close?.();
+  }
 }
 async function handleMemoryMigrateCommand(directory, _args) {
   const config3 = {
@@ -48047,6 +49257,16 @@ async function handleMemoryExportCommand(directory, _args) {
   } finally {
     await provider.close?.();
   }
+}
+function createMaintenanceProvider(directory, config3) {
+  return createConfiguredMemoryProvider(directory, config3);
+}
+function maintenanceReportOptions(config3, limit) {
+  return {
+    limit,
+    lowUtilityMaxConfidence: config3.maintenance.lowUtilityMaxConfidence,
+    lowUtilityMinAgeDays: config3.maintenance.lowUtilityMinAgeDays
+  };
 }
 async function handleMemoryEvaluateCommand(directory, args) {
   const parsed = parseEvaluateArgs(directory, args);
@@ -48106,6 +49326,28 @@ function parseEvaluateArgs(directory, args) {
   }
   return { json: json3, fixtureDirectory };
 }
+function parseMaintenanceArgs(args, options) {
+  let limit = 20;
+  let confirm = false;
+  const allowLimit = options.allowLimit ?? true;
+  for (let i = 0;i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--confirm" && options.allowConfirm) {
+      confirm = true;
+      continue;
+    }
+    if (arg === "--limit" && allowLimit) {
+      const next = args[i + 1];
+      if (!next || !/^\d+$/.test(next))
+        return { error: options.usage };
+      limit = Math.min(100, Math.max(1, Number(next)));
+      i++;
+      continue;
+    }
+    return { error: options.usage };
+  }
+  return { limit, confirm };
+}
 function resolvePackageRootFromModule(modulePath) {
   const moduleDir = path33.dirname(modulePath);
   const leaf = path33.basename(moduleDir);
@@ -48155,6 +49397,80 @@ function appendInvalidRows(lines, invalidRows) {
   if (invalidRows.length > 20) {
     lines.push(`- ... ${invalidRows.length - 20} more`);
   }
+}
+function appendProposalLines(lines, title, proposals) {
+  lines.push("", `### ${title}`);
+  if (proposals.length === 0) {
+    lines.push("- none");
+    return;
+  }
+  for (const proposal of proposals) {
+    const reason = proposal.status === "rejected" ? ` - ${proposal.rejectionReason ?? "no reason recorded"}` : "";
+    lines.push(`- \`${proposal.id}\` ${proposal.operation} ${proposal.targetMemoryId ?? proposal.proposedRecord?.id ?? "new"} (${proposal.status})${reason}`);
+  }
+}
+function appendMemoryLines(lines, title, memories) {
+  lines.push("", `### ${title}`);
+  if (memories.length === 0) {
+    lines.push("- none");
+    return;
+  }
+  for (const memory of memories) {
+    lines.push(`- \`${memory.id}\` ${memory.kind} confidence=${memory.confidence.toFixed(2)} updated=${memory.updatedAt} - ${truncate(memory.text, 100)}`);
+  }
+}
+function appendRecallRoleLines(lines, roles) {
+  lines.push("", "### Recall by agent role");
+  if (roles.length === 0) {
+    lines.push("- none");
+    return;
+  }
+  for (const role of roles) {
+    const memoryCount = Object.keys(role.memoryIds).length;
+    lines.push(`- \`${role.agentRole}\`: ${role.count} recall event(s), ${memoryCount} memory ID(s)`);
+  }
+}
+function appendRecallMemoryLines(lines, memories) {
+  lines.push("", "### Most-recalled memories");
+  if (memories.length === 0) {
+    lines.push("- none");
+    return;
+  }
+  for (const memory of memories) {
+    lines.push(`- \`${memory.memoryId}\`: ${memory.count} hit(s), last=${memory.lastRecalledAt}, avgScore=${memory.averageScore.toFixed(3)}`);
+  }
+}
+function appendSupersededChains(lines, report) {
+  lines.push("", "### Superseded chains");
+  if (report.supersededChains.length === 0) {
+    lines.push("- none");
+    return;
+  }
+  for (const chain of report.supersededChains) {
+    const reason = chain.reason ? ` - ${chain.reason}` : "";
+    lines.push(`- ${chain.chain.map((id) => `\`${id}\``).join(" -> ")}${reason}`);
+  }
+}
+function formatCompactResult(result, confirmed) {
+  const lines = [
+    "## Swarm Memory Compact",
+    "",
+    `- Mode: \`${confirmed ? "confirmed" : "dry-run"}\``,
+    `- Deleted tombstones: \`${result.removedDeleted}\``,
+    `- Superseded records: \`${result.removedSuperseded}\``,
+    `- Expired scratch records: \`${result.removedExpiredScratch}\``,
+    `- Remaining memories: \`${result.remaining}\``
+  ];
+  if (!confirmed) {
+    lines.push("", "No records were removed. Re-run `/swarm memory compact --confirm` to apply this compaction.");
+  }
+  return lines.join(`
+`);
+}
+function truncate(value, maxLength) {
+  if (value.length <= maxLength)
+    return value;
+  return `${value.slice(0, maxLength - 3)}...`;
 }
 var PACKAGE_ROOT;
 var init_memory2 = __esm(() => {
@@ -48832,13 +50148,13 @@ async function runLint(linter, mode, directory) {
       result.message = `${linter} check found issues (exit code ${exitCode}).`;
     }
     return result;
-  } catch (error93) {
+  } catch (error96) {
     return {
       success: false,
       mode,
       linter,
       command,
-      error: error93 instanceof Error ? `Execution failed: ${error93.message}` : "Execution failed: unknown error"
+      error: error96 instanceof Error ? `Execution failed: ${error96.message}` : "Execution failed: unknown error"
     };
   }
 }
@@ -48890,13 +50206,13 @@ async function runAdditionalLint(linter, mode, cwd) {
       result.message = `${linter} check found issues (exit code ${exitCode}).`;
     }
     return result;
-  } catch (error93) {
+  } catch (error96) {
     return {
       success: false,
       mode,
       linter,
       command,
-      error: error93 instanceof Error ? `Execution failed: ${error93.message}` : "Execution failed: unknown error"
+      error: error96 instanceof Error ? `Execution failed: ${error96.message}` : "Execution failed: unknown error"
     };
   }
 }
@@ -52797,7 +54113,7 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
       }
       return result;
     }
-  } catch (error93) {
+  } catch (error96) {
     const duration_ms = Date.now() - startTime;
     return {
       success: false,
@@ -52806,7 +54122,7 @@ async function runTests(framework, scope, files, coverage, timeout_ms, cwd) {
       command,
       timeout_ms,
       duration_ms,
-      error: error93 instanceof Error ? `Execution failed: ${error93.message}` : "Execution failed: unknown error",
+      error: error96 instanceof Error ? `Execution failed: ${error96.message}` : "Execution failed: unknown error",
       outcome: "error"
     };
   }
@@ -53496,11 +54812,11 @@ async function runVersionCheck(dir, _timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error93) {
+  } catch (error96) {
     return {
       type: "version",
       status: "error",
-      message: `Version check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
+      message: `Version check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -53554,12 +54870,12 @@ async function runLintCheck(dir, linter, timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error93) {
-    if (error93 instanceof Error && error93.message.includes("timed out")) {
+  } catch (error96) {
+    if (error96 instanceof Error && error96.message.includes("timed out")) {
       return {
         type: "lint",
         status: "error",
-        message: error93.message,
+        message: error96.message,
         details: { linter },
         durationMs: Date.now() - startTime
       };
@@ -53567,7 +54883,7 @@ async function runLintCheck(dir, linter, timeoutMs) {
     return {
       type: "lint",
       status: "error",
-      message: `Lint check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
+      message: `Lint check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
       details: { linter },
       durationMs: Date.now() - startTime
     };
@@ -53623,8 +54939,8 @@ async function runTestsCheck(_dir, scope, timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error93) {
-    if (error93 instanceof Error && (error93.message.includes("timeout") || error93.message.includes("ETIMEDOUT"))) {
+  } catch (error96) {
+    if (error96 instanceof Error && (error96.message.includes("timeout") || error96.message.includes("ETIMEDOUT"))) {
       return {
         type: "tests",
         status: "error",
@@ -53635,7 +54951,7 @@ async function runTestsCheck(_dir, scope, timeoutMs) {
     return {
       type: "tests",
       status: "error",
-      message: `Tests check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
+      message: `Tests check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -53678,8 +54994,8 @@ async function runSecretsCheck(dir, timeoutMs) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error93) {
-    if (error93 instanceof Error && error93.name === "AbortError") {
+  } catch (error96) {
+    if (error96 instanceof Error && error96.name === "AbortError") {
       return {
         type: "secrets",
         status: "error",
@@ -53690,7 +55006,7 @@ async function runSecretsCheck(dir, timeoutMs) {
     return {
       type: "secrets",
       status: "error",
-      message: `Secrets check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
+      message: `Secrets check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -53766,11 +55082,11 @@ async function runEvidenceCheck(dir) {
       },
       durationMs: Date.now() - startTime
     };
-  } catch (error93) {
+  } catch (error96) {
     return {
       type: "evidence",
       status: "error",
-      message: `Evidence check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
+      message: `Evidence check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -53805,11 +55121,11 @@ async function runRequirementCoverageCheck(dir, currentPhase) {
       details: { expectedPath: coverage.path },
       durationMs: Date.now() - startTime
     };
-  } catch (error93) {
+  } catch (error96) {
     return {
       type: "req_coverage",
       status: "error",
-      message: `Requirement coverage check failed: ${error93 instanceof Error ? error93.message : String(error93)}`,
+      message: `Requirement coverage check failed: ${error96 instanceof Error ? error96.message : String(error96)}`,
       durationMs: Date.now() - startTime
     };
   }
@@ -53820,7 +55136,7 @@ async function runPreflight(dir, phase, config3) {
   let validatedDir;
   try {
     validatedDir = _internals27.validateDirectoryPath(dir);
-  } catch (error93) {
+  } catch (error96) {
     return {
       id: reportId,
       timestamp: startTime,
@@ -53830,7 +55146,7 @@ async function runPreflight(dir, phase, config3) {
         {
           type: "lint",
           status: "error",
-          message: `Invalid directory: ${error93 instanceof Error ? error93.message : String(error93)}`
+          message: `Invalid directory: ${error96 instanceof Error ? error96.message : String(error96)}`
         }
       ],
       totalDurationMs: Date.now() - startTime,
@@ -53840,7 +55156,7 @@ async function runPreflight(dir, phase, config3) {
   let validatedTimeout;
   try {
     validatedTimeout = _internals27.validateTimeout(config3?.checkTimeoutMs, DEFAULT_CONFIG.checkTimeoutMs);
-  } catch (error93) {
+  } catch (error96) {
     return {
       id: reportId,
       timestamp: startTime,
@@ -53850,7 +55166,7 @@ async function runPreflight(dir, phase, config3) {
         {
           type: "lint",
           status: "error",
-          message: `Invalid config: ${error93 instanceof Error ? error93.message : String(error93)}`
+          message: `Invalid config: ${error96 instanceof Error ? error96.message : String(error96)}`
         }
       ],
       totalDurationMs: Date.now() - startTime,
@@ -54056,20 +55372,20 @@ async function handlePromoteCommand(directory, args) {
   if (lessonId) {
     try {
       return await promoteFromSwarm(directory, lessonId);
-    } catch (error93) {
-      if (error93 instanceof Error) {
-        return error93.message;
+    } catch (error96) {
+      if (error96 instanceof Error) {
+        return error96.message;
       }
-      return `Failed to promote lesson: ${error93 instanceof Error ? error93.message : String(error93)}`;
+      return `Failed to promote lesson: ${error96 instanceof Error ? error96.message : String(error96)}`;
     }
   }
   try {
     return await promoteToHive(directory, lessonText, category);
-  } catch (error93) {
-    if (error93 instanceof Error) {
-      return error93.message;
+  } catch (error96) {
+    if (error96 instanceof Error) {
+      return error96.message;
     }
-    return `Failed to promote lesson: ${error93 instanceof Error ? error93.message : String(error93)}`;
+    return `Failed to promote lesson: ${error96 instanceof Error ? error96.message : String(error96)}`;
   }
 }
 var init_promote = __esm(() => {
@@ -54238,8 +55554,8 @@ class CircuitBreaker {
   async execute(fn) {
     const state = this.getState();
     if (state === "open") {
-      const error93 = new Error(`Circuit breaker '${this.name}' is open`);
-      throw error93;
+      const error96 = new Error(`Circuit breaker '${this.name}' is open`);
+      throw error96;
     }
     const startTime = Date.now();
     try {
@@ -54247,10 +55563,10 @@ class CircuitBreaker {
       const duration5 = Date.now() - startTime;
       this.recordSuccess(duration5);
       return result;
-    } catch (error93) {
+    } catch (error96) {
       const duration5 = Date.now() - startTime;
-      this.recordFailure(error93, duration5);
-      throw error93;
+      this.recordFailure(error96, duration5);
+      throw error96;
     }
   }
   async executeWithTimeout(fn) {
@@ -54264,9 +55580,9 @@ class CircuitBreaker {
       fn().then((result) => {
         clearTimeout(timeout);
         resolve17(result);
-      }).catch((error93) => {
+      }).catch((error96) => {
         clearTimeout(timeout);
-        reject(error93);
+        reject(error96);
       });
     });
   }
@@ -54280,7 +55596,7 @@ class CircuitBreaker {
     }
     this.onStateChange?.("callSuccess", { duration: duration5 });
   }
-  recordFailure(error93, duration5) {
+  recordFailure(error96, duration5) {
     this.failureCount++;
     this.lastFailureTime = Date.now();
     if (this.state === "half-open") {
@@ -54288,7 +55604,7 @@ class CircuitBreaker {
     } else if (this.state === "closed" && this.failureCount >= this.config.failureThreshold) {
       this.transitionTo("open");
     }
-    this.onStateChange?.("callFailure", { error: error93, duration: duration5 });
+    this.onStateChange?.("callFailure", { error: error96, duration: duration5 });
   }
   transitionTo(newState) {
     const oldState = this.state;
@@ -54626,11 +55942,11 @@ class WorkerManager {
         });
       }
     };
-    processLoop().catch((error93) => {
+    processLoop().catch((error96) => {
       this.eventBus.publish("worker.error", {
         workerName: worker.name,
         itemId: "loop",
-        error: error93
+        error: error96
       });
     });
   }
@@ -54645,15 +55961,15 @@ class WorkerManager {
         worker.lastError = result.error;
         worker.queue.retry(item.id, result.error);
       }
-    } catch (error93) {
+    } catch (error96) {
       worker.errorCount++;
-      worker.lastError = error93;
+      worker.lastError = error96;
       this.eventBus.publish("worker.error", {
         workerName: worker.name,
         itemId: item.id,
-        error: error93
+        error: error96
       });
-      worker.queue.retry(item.id, error93);
+      worker.queue.retry(item.id, error96);
     }
   }
   stop(name) {
@@ -55065,8 +56381,8 @@ async function loadFullOutput(directory, id) {
     }
     warn(`Summary entry ${sanitizedId} missing valid fullOutput field`);
     return null;
-  } catch (error93) {
-    warn(`Summary entry validation failed for ${sanitizedId}: ${error93 instanceof Error ? error93.message : String(error93)}`);
+  } catch (error96) {
+    warn(`Summary entry validation failed for ${sanitizedId}: ${error96 instanceof Error ? error96.message : String(error96)}`);
     return null;
   }
 }
@@ -55103,10 +56419,10 @@ No stored output found for ID \`${summaryId}\`.
 Use a valid summary ID (e.g., S1, S2, S3).`;
     }
     return fullOutput;
-  } catch (error93) {
+  } catch (error96) {
     return `## Retrieve Failed
 
-${error93 instanceof Error ? error93.message : String(error93)}`;
+${error96 instanceof Error ? error96.message : String(error96)}`;
   }
 }
 var init_retrieve = __esm(() => {
@@ -55185,8 +56501,8 @@ async function handleRollbackCommand(directory, args) {
     try {
       fs27.cpSync(src, dest, { recursive: true, force: true });
       successes.push(file3);
-    } catch (error93) {
-      failures.push({ file: file3, error: error93.message });
+    } catch (error96) {
+      failures.push({ file: file3, error: error96.message });
     }
   }
   if (failures.length > 0) {
@@ -55236,8 +56552,8 @@ async function handleRollbackCommand(directory, args) {
   try {
     fs27.appendFileSync(eventsPath, `${JSON.stringify(rollbackEvent)}
 `);
-  } catch (error93) {
-    console.error("Failed to write rollback event:", error93 instanceof Error ? error93.message : String(error93));
+  } catch (error96) {
+    console.error("Failed to write rollback event:", error96 instanceof Error ? error96.message : String(error96));
   }
   return `Rolled back to phase ${targetPhase}: ${checkpoint2.label || "no label"}`;
 }
@@ -55392,8 +56708,8 @@ function readPersisted2(directory) {
       updatedAt: parsed.updatedAt ?? nowISO2(),
       sessions: parsed.sessions
     };
-  } catch (error93) {
-    const reason = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const reason = error96 instanceof Error ? error96.message : String(error96);
     markStateUnreadable2(directory, reason);
     return null;
   }
@@ -55412,16 +56728,16 @@ function writePersisted2(directory, persisted) {
     persisted.updatedAt = nowISO2();
     payload = `${JSON.stringify(persisted, null, 2)}
 `;
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     error(`[turbo/lean/state] Failed to prepare ${STATE_FILE2} write: ${msg}`);
     throw new Error(`Lean Turbo state persistence prepare failed: ${msg}`);
   }
   try {
     fs28.writeFileSync(tmpPath, payload, "utf-8");
     fs28.renameSync(tmpPath, filePath);
-  } catch (error93) {
-    const msg = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    const msg = error96 instanceof Error ? error96.message : String(error96);
     error(`[turbo/lean/state] Failed to persist ${STATE_FILE2} atomically: ${msg}`);
     try {
       if (fs28.existsSync(tmpPath)) {
@@ -55832,8 +57148,8 @@ async function handleTurboCommand(directory, args, sessionID) {
     if (isLeanActive) {
       try {
         pauseLeanTurboRun(directory, sessionID, reason);
-      } catch (error93) {
-        error(`[turbo] pauseLeanTurboRun failed: ${error93 instanceof Error ? error93.message : String(error93)}`);
+      } catch (error96) {
+        error(`[turbo] pauseLeanTurboRun failed: ${error96 instanceof Error ? error96.message : String(error96)}`);
       }
     }
     session.turboMode = false;
@@ -55868,8 +57184,8 @@ async function handleTurboCommand(directory, args, sessionID) {
       if (config3.turbo?.strategy === "lean") {
         strategy = "lean";
       }
-    } catch (error93) {
-      warn(`[turbo] could not read config for strategy default: ${error93 instanceof Error ? error93.message : String(error93)}`);
+    } catch (error96) {
+      warn(`[turbo] could not read config for strategy default: ${error96 instanceof Error ? error96.message : String(error96)}`);
     }
     if (strategy === "lean") {
       return enableLeanTurbo(session, directory, sessionID);
@@ -55925,16 +57241,16 @@ function enableLeanTurbo(session, directory, sessionID) {
       maxParallelCoders = leanConfig.max_parallel_coders ?? 4;
       conflictPolicy = leanConfig.conflict_policy ?? "serialize";
     }
-  } catch (error93) {
-    warn(`[turbo] could not read lean config: ${error93 instanceof Error ? error93.message : String(error93)}`);
+  } catch (error96) {
+    warn(`[turbo] could not read lean config: ${error96 instanceof Error ? error96.message : String(error96)}`);
   }
   let durableError;
   try {
     const state = emptyRunState(sessionID, maxParallelCoders);
     state.status = "running";
     saveLeanTurboRunState(directory, state);
-  } catch (error93) {
-    durableError = error93 instanceof Error ? error93.message : String(error93);
+  } catch (error96) {
+    durableError = error96 instanceof Error ? error96.message : String(error96);
     error(`[turbo] durable run-state write failed: ${durableError}`);
   }
   if (durableError) {
@@ -56215,7 +57531,7 @@ function classifySwarmCommandToolUse(resolved) {
       return { allowed: true };
     return {
       allowed: false,
-      message: "Use `/swarm memory status`, `/swarm memory export`, or `/swarm memory evaluate --json` through swarm_command. Memory import and migrate are intentionally excluded from chat-tool execution."
+      message: "Use `/swarm memory status`, `/swarm memory pending`, `/swarm memory recall-log`, `/swarm memory stale`, `/swarm memory export`, or `/swarm memory evaluate --json` through swarm_command. Memory import, migrate, and compact are intentionally excluded from chat-tool execution."
     };
   }
   if (canonicalKey === "memory evaluate") {
@@ -56226,6 +57542,17 @@ function classifySwarmCommandToolUse(resolved) {
     return {
       allowed: false,
       message: "Usage through swarm_command: `/swarm memory evaluate --json`. Custom fixture directories are only available through direct user command execution."
+    };
+  }
+  if (canonicalKey === "memory pending" || canonicalKey === "memory recall-log" || canonicalKey === "memory stale") {
+    if (args.length === 0)
+      return { allowed: true };
+    if (args.length === 2 && args[0] === "--limit" && /^\d+$/.test(args[1])) {
+      return { allowed: true };
+    }
+    return {
+      allowed: false,
+      message: `Usage through swarm_command: \`/swarm ${canonicalKey}\` or ` + `\`/swarm ${canonicalKey} --limit <n>\`.`
     };
   }
   if (canonicalKey === "retrieve") {
@@ -56279,7 +57606,7 @@ function classifySwarmCommandChatFallbackUse(resolved) {
       message: "/swarm config doctor --fix is not available through chat fallback because it can modify configuration files. Run the CLI command directly when you intend to apply fixes."
     };
   }
-  if (canonicalKey === "knowledge migrate" || canonicalKey === "knowledge quarantine" || canonicalKey === "knowledge restore" || canonicalKey === "memory import" || canonicalKey === "memory migrate") {
+  if (canonicalKey === "knowledge migrate" || canonicalKey === "knowledge quarantine" || canonicalKey === "knowledge restore" || canonicalKey === "memory import" || canonicalKey === "memory migrate" || canonicalKey === "memory compact") {
     return {
       allowed: false,
       message: `/swarm ${canonicalKey} is not available through chat fallback because it mutates .swarm state. ` + "Run the CLI command directly after confirming the intended state change."
@@ -56312,6 +57639,10 @@ var init_tool_policy = __esm(() => {
     "knowledge",
     "memory",
     "memory status",
+    "memory pending",
+    "memory recall-log",
+    "memory compact",
+    "memory stale",
     "memory export",
     "memory evaluate",
     "memory import",
@@ -56338,6 +57669,9 @@ var init_tool_policy = __esm(() => {
     "knowledge",
     "memory",
     "memory status",
+    "memory pending",
+    "memory recall-log",
+    "memory stale",
     "memory export",
     "memory evaluate",
     "sync-plan",
@@ -56350,7 +57684,8 @@ var init_tool_policy = __esm(() => {
     "rollback",
     "checkpoint",
     "memory import",
-    "memory migrate"
+    "memory migrate",
+    "memory compact"
   ]);
   NO_ARGS = new Set([
     "agents",
@@ -57345,6 +58680,34 @@ Subcommands:
       args: "",
       category: "diagnostics"
     },
+    "memory pending": {
+      handler: (ctx) => handleMemoryPendingCommand(ctx.directory, ctx.args),
+      description: "Show pending Swarm memory proposals and rejection reasons",
+      subcommandOf: "memory",
+      args: "--limit <n>",
+      category: "diagnostics"
+    },
+    "memory recall-log": {
+      handler: (ctx) => handleMemoryRecallLogCommand(ctx.directory, ctx.args),
+      description: "Summarize Swarm memory recall usage",
+      subcommandOf: "memory",
+      args: "--limit <n>",
+      category: "diagnostics"
+    },
+    "memory compact": {
+      handler: (ctx) => handleMemoryCompactCommand(ctx.directory, ctx.args),
+      description: "Compact deleted, superseded, and expired scratch memories",
+      subcommandOf: "memory",
+      args: "--confirm",
+      category: "utility"
+    },
+    "memory stale": {
+      handler: (ctx) => handleMemoryStaleCommand(ctx.directory, ctx.args),
+      description: "List stale and low-utility Swarm memories",
+      subcommandOf: "memory",
+      args: "--limit <n>",
+      category: "diagnostics"
+    },
     "memory export": {
       handler: (ctx) => handleMemoryExportCommand(ctx.directory, ctx.args),
       description: "Export current Swarm memory to JSONL files",
@@ -57491,9 +58854,9 @@ function writeProjectConfigIfMissing(cwd) {
     ensureDir(opencodeDir);
     saveJson(projectConfigPath, { agents: {} });
     console.log("\u2713 Created project config at:", projectConfigPath);
-  } catch (error93) {
+  } catch (error96) {
     console.warn("\u26A0 Could not create project config \u2014 installation will continue:");
-    console.warn(`  ${error93 instanceof Error ? error93.message : String(error93)}`);
+    console.warn(`  ${error96 instanceof Error ? error96.message : String(error96)}`);
   }
 }
 async function install() {
@@ -57721,8 +59084,8 @@ async function uninstall() {
     console.log(`
 \u2705 Uninstall complete!`);
     return 0;
-  } catch (error93) {
-    console.log("\u2717 Uninstall failed: " + (error93 instanceof Error ? error93.message : String(error93)));
+  } catch (error96) {
+    console.log("\u2717 Uninstall failed: " + (error96 instanceof Error ? error96.message : String(error96)));
     return 1;
   }
 }

--- a/dist/commands/memory.d.ts
+++ b/dist/commands/memory.d.ts
@@ -1,5 +1,9 @@
 export declare function handleMemoryCommand(_directory: string, _args: string[]): Promise<string>;
 export declare function handleMemoryStatusCommand(directory: string, _args: string[]): Promise<string>;
+export declare function handleMemoryPendingCommand(directory: string, args: string[]): Promise<string>;
+export declare function handleMemoryRecallLogCommand(directory: string, args: string[]): Promise<string>;
+export declare function handleMemoryStaleCommand(directory: string, args: string[]): Promise<string>;
+export declare function handleMemoryCompactCommand(directory: string, args: string[]): Promise<string>;
 export declare function handleMemoryMigrateCommand(directory: string, _args: string[]): Promise<string>;
 export declare function handleMemoryImportCommand(directory: string, _args: string[]): Promise<string>;
 export declare function handleMemoryExportCommand(directory: string, _args: string[]): Promise<string>;

--- a/dist/commands/registry.d.ts
+++ b/dist/commands/registry.d.ts
@@ -441,6 +441,34 @@ export declare const COMMAND_REGISTRY: {
         readonly args: "";
         readonly category: "diagnostics";
     };
+    readonly 'memory pending': {
+        readonly handler: (ctx: CommandContext) => Promise<string>;
+        readonly description: "Show pending Swarm memory proposals and rejection reasons";
+        readonly subcommandOf: "memory";
+        readonly args: "--limit <n>";
+        readonly category: "diagnostics";
+    };
+    readonly 'memory recall-log': {
+        readonly handler: (ctx: CommandContext) => Promise<string>;
+        readonly description: "Summarize Swarm memory recall usage";
+        readonly subcommandOf: "memory";
+        readonly args: "--limit <n>";
+        readonly category: "diagnostics";
+    };
+    readonly 'memory compact': {
+        readonly handler: (ctx: CommandContext) => Promise<string>;
+        readonly description: "Compact deleted, superseded, and expired scratch memories";
+        readonly subcommandOf: "memory";
+        readonly args: "--confirm";
+        readonly category: "utility";
+    };
+    readonly 'memory stale': {
+        readonly handler: (ctx: CommandContext) => Promise<string>;
+        readonly description: "List stale and low-utility Swarm memories";
+        readonly subcommandOf: "memory";
+        readonly args: "--limit <n>";
+        readonly category: "diagnostics";
+    };
     readonly 'memory export': {
         readonly handler: (ctx: CommandContext) => Promise<string>;
         readonly description: "Export current Swarm memory to JSONL files";

--- a/dist/commands/tool-policy.d.ts
+++ b/dist/commands/tool-policy.d.ts
@@ -1,5 +1,5 @@
 import type { ResolvedSwarmCommand, SwarmCommandPolicyResult } from './command-dispatch.js';
-export declare const SWARM_COMMAND_TOOL_COMMANDS: readonly ["agents", "config", "config doctor", "config-doctor", "doctor", "doctor tools", "status", "show-plan", "plan", "help", "history", "evidence", "evidence summary", "evidence-summary", "retrieve", "diagnose", "preflight", "benchmark", "knowledge", "memory", "memory status", "memory export", "memory evaluate", "memory import", "memory migrate", "sync-plan", "export", "list-agents"];
+export declare const SWARM_COMMAND_TOOL_COMMANDS: readonly ["agents", "config", "config doctor", "config-doctor", "doctor", "doctor tools", "status", "show-plan", "plan", "help", "history", "evidence", "evidence summary", "evidence-summary", "retrieve", "diagnose", "preflight", "benchmark", "knowledge", "memory", "memory status", "memory pending", "memory recall-log", "memory compact", "memory stale", "memory export", "memory evaluate", "memory import", "memory migrate", "sync-plan", "export", "list-agents"];
 export type SwarmCommandToolInputCommand = (typeof SWARM_COMMAND_TOOL_COMMANDS)[number];
 export declare const SWARM_COMMAND_TOOL_ALLOWLIST: Set<string>;
 /**

--- a/dist/config/schema.d.ts
+++ b/dist/config/schema.d.ts
@@ -531,6 +531,10 @@ export declare const MemoryConfigSchema: z.ZodObject<{
     redaction: z.ZodDefault<z.ZodObject<{
         rejectDurableSecrets: z.ZodDefault<z.ZodBoolean>;
     }, z.core.$strip>>;
+    maintenance: z.ZodDefault<z.ZodObject<{
+        lowUtilityMaxConfidence: z.ZodDefault<z.ZodNumber>;
+        lowUtilityMinAgeDays: z.ZodDefault<z.ZodNumber>;
+    }, z.core.$strip>>;
     hardDelete: z.ZodDefault<z.ZodBoolean>;
 }, z.core.$strip>;
 export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;
@@ -1195,6 +1199,10 @@ export declare const PluginConfigSchema: z.ZodObject<{
         }, z.core.$strip>>;
         redaction: z.ZodDefault<z.ZodObject<{
             rejectDurableSecrets: z.ZodDefault<z.ZodBoolean>;
+        }, z.core.$strip>>;
+        maintenance: z.ZodDefault<z.ZodObject<{
+            lowUtilityMaxConfidence: z.ZodDefault<z.ZodNumber>;
+            lowUtilityMinAgeDays: z.ZodDefault<z.ZodNumber>;
         }, z.core.$strip>>;
         hardDelete: z.ZodDefault<z.ZodBoolean>;
     }, z.core.$strip>>;

--- a/dist/hooks/skill-usage-log.d.ts
+++ b/dist/hooks/skill-usage-log.d.ts
@@ -62,7 +62,7 @@ export declare const _internals: {
     renameSync: typeof fs.renameSync;
     mkdirSync: typeof fs.mkdirSync;
     existsSync: typeof fs.existsSync;
-    statSync: typeof fs.statSync;
+    statSync: any;
     openSync: typeof fs.openSync;
     readSync: typeof fs.readSync;
     closeSync: typeof fs.closeSync;

--- a/dist/hooks/skill-usage-log.d.ts
+++ b/dist/hooks/skill-usage-log.d.ts
@@ -62,7 +62,7 @@ export declare const _internals: {
     renameSync: typeof fs.renameSync;
     mkdirSync: typeof fs.mkdirSync;
     existsSync: typeof fs.existsSync;
-    statSync: any;
+    statSync: typeof fs.statSync;
     openSync: typeof fs.openSync;
     readSync: typeof fs.readSync;
     closeSync: typeof fs.closeSync;

--- a/dist/memory/config.d.ts
+++ b/dist/memory/config.d.ts
@@ -25,6 +25,10 @@ export interface MemoryConfig {
     redaction: {
         rejectDurableSecrets: boolean;
     };
+    maintenance: {
+        lowUtilityMaxConfidence: number;
+        lowUtilityMinAgeDays: number;
+    };
     hardDelete: boolean;
 }
 export declare const DEFAULT_MEMORY_CONFIG: MemoryConfig;

--- a/dist/memory/index.d.ts
+++ b/dist/memory/index.d.ts
@@ -7,8 +7,9 @@ export { createConfiguredMemoryProvider, createMemoryGateway, MemoryGateway, } f
 export { createMemoryLifecycleHooks, type MemoryLifecycleHookOptions, type MemoryLifecycleHooks, } from './injector';
 export { backupLegacyJsonl, getLegacyJsonlFileStatus, type JsonlBackupResult, type JsonlImportPayload, type JsonlInvalidRow, type JsonlMigrationReport, LEGACY_JSONL_MIGRATION_NAME, LEGACY_JSONL_MIGRATION_VERSION, readLegacyJsonl, readMigrationReport, resolveMemoryStorageDir, resolveSqliteDatabasePath, writeJsonlExport, writeMigrationReport, } from './jsonl-migration';
 export { LocalJsonlMemoryProvider } from './local-jsonl-provider';
+export { buildMemoryMaintenanceReport, type MemoryMaintenanceReport, type MemoryMaintenanceReportOptions, type MemoryRecallUsageByMemory, type MemoryRecallUsageByRole, type MemorySupersededChain, shouldCompactMemory, } from './maintenance';
 export { buildRecallPromptBlock } from './prompt-block';
-export type { MemoryProposalStore, MemoryProvider } from './provider';
+export type { MemoryCompactOptions, MemoryCompactResult, MemoryProposalStore, MemoryProvider, MemoryRecallUsageEvent, MemoryRecallUsageFilter, } from './provider';
 export { buildMemoryRecallPlan, type MemoryRecallPlan, type MemoryRecallPlannerInput, } from './recall-planner';
 export { findSecrets, redactSecrets } from './redaction';
 export { MEMORY_RECALL_PROFILES, type MemoryRecallProfile, normalizeMemoryAgentRole, resolveMemoryRecallProfile, } from './role-profiles';

--- a/dist/memory/local-jsonl-provider.d.ts
+++ b/dist/memory/local-jsonl-provider.d.ts
@@ -1,5 +1,5 @@
 import { type MemoryConfig } from './config';
-import type { MemoryProposalStore, MemoryProvider, MemoryRecallUsageEvent } from './provider';
+import type { MemoryCompactOptions, MemoryCompactResult, MemoryProposalStore, MemoryProvider, MemoryRecallUsageEvent, MemoryRecallUsageFilter } from './provider';
 import type { RecallScoringDiagnostics } from './scoring';
 import type { AppliedMemoryChange, MemoryListFilter, MemoryProposal, MemoryRecord, RecallRequest, RecallResultItem, ResolvedCuratorMemoryDecision } from './types';
 export declare class LocalJsonlMemoryProvider implements MemoryProvider, MemoryProposalStore {
@@ -21,6 +21,7 @@ export declare class LocalJsonlMemoryProvider implements MemoryProvider, MemoryP
         diagnostics: RecallScoringDiagnostics;
     }>;
     recordRecallUsage(event: MemoryRecallUsageEvent): Promise<void>;
+    listRecallUsage(filter?: MemoryRecallUsageFilter): Promise<MemoryRecallUsageEvent[]>;
     list(filter?: MemoryListFilter): Promise<MemoryRecord[]>;
     createProposal(proposal: MemoryProposal): Promise<MemoryProposal>;
     listProposals(filter?: {
@@ -29,6 +30,7 @@ export declare class LocalJsonlMemoryProvider implements MemoryProvider, MemoryP
     }): Promise<MemoryProposal[]>;
     applyCuratorDecision(decision: ResolvedCuratorMemoryDecision): Promise<AppliedMemoryChange>;
     compact(): Promise<void>;
+    compactMaintenance(options?: MemoryCompactOptions): Promise<MemoryCompactResult>;
     private audit;
     private activeMemory;
     private validateDecisionMemory;

--- a/dist/memory/maintenance.d.ts
+++ b/dist/memory/maintenance.d.ts
@@ -1,0 +1,47 @@
+import type { MemoryProposalStore, MemoryProvider } from './provider';
+import type { MemoryProposal, MemoryRecord } from './types';
+export interface MemoryRecallUsageByMemory {
+    memoryId: string;
+    count: number;
+    lastRecalledAt: string;
+    agentRoles: Record<string, number>;
+    averageScore: number;
+}
+export interface MemoryRecallUsageByRole {
+    agentRole: string;
+    count: number;
+    memoryIds: Record<string, number>;
+}
+export interface MemorySupersededChain {
+    rootId: string;
+    chain: string[];
+    reason?: string;
+}
+export interface MemoryMaintenanceReport {
+    generatedAt: string;
+    totalMemories: number;
+    activeMemories: number;
+    deletedMemories: MemoryRecord[];
+    expiredScratchMemories: MemoryRecord[];
+    supersededMemories: MemoryRecord[];
+    supersededChains: MemorySupersededChain[];
+    lowUtilityMemories: MemoryRecord[];
+    neverRecalledMemories: MemoryRecord[];
+    mostRecalledMemories: MemoryRecallUsageByMemory[];
+    recallByAgentRole: MemoryRecallUsageByRole[];
+    rejectedProposalReasons: MemoryProposal[];
+    pendingProposals: MemoryProposal[];
+    recallEventCount: number;
+}
+export interface MemoryMaintenanceReportOptions {
+    now?: Date;
+    limit?: number;
+    lowUtilityMaxConfidence?: number;
+    lowUtilityMinAgeDays?: number;
+}
+type ObservableProvider = MemoryProvider & Partial<MemoryProposalStore> & {
+    listRecallUsage?: MemoryProvider['listRecallUsage'];
+};
+export declare function buildMemoryMaintenanceReport(provider: ObservableProvider, options?: MemoryMaintenanceReportOptions): Promise<MemoryMaintenanceReport>;
+export declare function shouldCompactMemory(memory: MemoryRecord, now?: Date): 'deleted' | 'superseded' | 'expired_scratch' | null;
+export {};

--- a/dist/memory/provider.d.ts
+++ b/dist/memory/provider.d.ts
@@ -16,6 +16,20 @@ export interface MemoryRecallUsageEvent {
     runId?: string;
     timestamp: string;
 }
+export interface MemoryRecallUsageFilter {
+    limit?: number;
+}
+export interface MemoryCompactOptions {
+    dryRun?: boolean;
+    now?: string;
+}
+export interface MemoryCompactResult {
+    dryRun: boolean;
+    removedDeleted: number;
+    removedSuperseded: number;
+    removedExpiredScratch: number;
+    remaining: number;
+}
 export interface MemoryProvider {
     readonly name: string;
     initialize?(): Promise<void>;
@@ -26,6 +40,8 @@ export interface MemoryProvider {
     recall(request: RecallRequest): Promise<RecallResultItem[]>;
     recallWithDiagnostics?(request: RecallRequest): Promise<MemoryRecallResult>;
     recordRecallUsage?(event: MemoryRecallUsageEvent): Promise<void>;
+    listRecallUsage?(filter?: MemoryRecallUsageFilter): Promise<MemoryRecallUsageEvent[]>;
+    compactMaintenance?(options?: MemoryCompactOptions): Promise<MemoryCompactResult>;
     list(filter: MemoryListFilter): Promise<MemoryRecord[]>;
 }
 export interface MemoryProposalStore {

--- a/dist/memory/sqlite-provider.d.ts
+++ b/dist/memory/sqlite-provider.d.ts
@@ -1,6 +1,6 @@
 import { type MemoryConfig } from './config';
 import { type JsonlMigrationReport } from './jsonl-migration';
-import type { MemoryProposalStore, MemoryProvider, MemoryRecallUsageEvent } from './provider';
+import type { MemoryCompactOptions, MemoryCompactResult, MemoryProposalStore, MemoryProvider, MemoryRecallUsageEvent, MemoryRecallUsageFilter } from './provider';
 import type { RecallScoringDiagnostics } from './scoring';
 import type { AppliedMemoryChange, MemoryListFilter, MemoryProposal, MemoryRecord, RecallRequest, RecallResultItem, ResolvedCuratorMemoryDecision } from './types';
 export interface SQLiteJsonlImportResult {
@@ -31,6 +31,7 @@ export declare class SQLiteMemoryProvider implements MemoryProvider, MemoryPropo
         diagnostics: RecallScoringDiagnostics;
     }>;
     recordRecallUsage(event: MemoryRecallUsageEvent): Promise<void>;
+    listRecallUsage(filter?: MemoryRecallUsageFilter): Promise<MemoryRecallUsageEvent[]>;
     list(filter?: MemoryListFilter): Promise<MemoryRecord[]>;
     createProposal(proposal: MemoryProposal): Promise<MemoryProposal>;
     listProposals(filter?: {
@@ -47,6 +48,7 @@ export declare class SQLiteMemoryProvider implements MemoryProvider, MemoryPropo
         memories: number;
         proposals: number;
     }>;
+    compactMaintenance(options?: MemoryCompactOptions): Promise<MemoryCompactResult>;
     hasMigration(name: string): boolean;
     markMigration(version: number, name: string): void;
     private selectRecallCandidates;

--- a/dist/memory/types.d.ts
+++ b/dist/memory/types.d.ts
@@ -185,5 +185,6 @@ export interface MemoryListFilter {
     scopes?: MemoryScopeRef[];
     kinds?: MemoryKind[];
     includeExpired?: boolean;
+    includeInactive?: boolean;
     limit?: number;
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -338,6 +338,22 @@ Show memory storage commands.
 
 Show the resolved memory provider, SQLite database path, legacy JSONL file status, and the latest migration report.
 
+### `/swarm memory pending`
+
+Show pending memory proposals and recent rejected proposal reasons.
+
+### `/swarm memory recall-log`
+
+Summarize recall usage by agent role and memory ID. Also shows the most-recalled and never-recalled memories.
+
+### `/swarm memory stale`
+
+List expired scratch memories, deleted tombstones, superseded chains, and low-utility memories.
+
+### `/swarm memory compact`
+
+Dry-run compaction for deleted, superseded, and expired scratch memory records. Pass `--confirm` to apply the cleanup. There is no automatic destructive compaction.
+
 ### `/swarm memory export`
 
 Export current memory records and proposals to `.swarm/memory/export/memories.jsonl` and `.swarm/memory/export/proposals.jsonl`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -228,6 +228,8 @@ Optional scoped memory substrate for recall and proposal-only memory writes.
 | `recall.injection.tokenBudget` | number | `1000` | Token budget for automatic memory injection |
 | `writes.mode` | string | `"propose"` | Normal agents can only create proposals |
 | `redaction.rejectDurableSecrets` | boolean | `true` | Reject durable memories that contain likely secrets |
+| `maintenance.lowUtilityMaxConfidence` | number | `0.45` | Confidence threshold used by `/swarm memory stale` low-utility reporting |
+| `maintenance.lowUtilityMinAgeDays` | number | `30` | Age threshold used by `/swarm memory stale` low-utility reporting |
 
 Memory stores durable state in `.swarm/memory/memory.db` by default. Legacy JSONL files under `.swarm/memory/` are migrated once into SQLite, backed up, and remain available through `memory.provider="local-jsonl"` for legacy/debug mode. Recall is scope-filtered and labels retrieved memory as untrusted background. Proposals do not become durable memory without curator or trusted gateway review. See [Swarm Memory](memory.md).
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -184,6 +184,18 @@ Curator agents may return an optional JSON `curatorMemoryDecisions` array in Tas
 
 In SQLite, decision application is transactional: Swarm loads the pending proposal, validates the decision and resulting memory record, applies the memory change, updates proposal status, and appends a `curator_decision` event in one transaction. Superseded memories are marked with `supersededBy` and stop appearing in recall.
 
+## Maintenance and Observability
+
+Memory cleanup is explicit. Swarm does not automatically remove deleted, superseded, or expired scratch records. The command surface is safe by default:
+
+- `/swarm memory status` reports storage, migration, and cleanup mode.
+- `/swarm memory pending` lists pending proposals and recent rejected proposal reasons.
+- `/swarm memory recall-log` summarizes recall usage by agent role and memory ID, including most-recalled and never-recalled memories.
+- `/swarm memory stale` lists expired scratch memories, deleted tombstones, superseded chains, and low-utility memories.
+- `/swarm memory compact` is a dry run unless `--confirm` is passed. Confirmed compaction removes only deleted tombstones, superseded records, and expired scratch memories.
+
+Expired scratch memory is hidden from recall and normal list results by default. Superseded chains remain inspectable through `/swarm memory stale` before compaction.
+
 ## Secret Handling
 
 The detector is intentionally conservative and covers obvious cases:

--- a/docs/releases/pending/memory-maintenance-observability.md
+++ b/docs/releases/pending/memory-maintenance-observability.md
@@ -1,0 +1,5 @@
+# Memory Maintenance Observability
+
+- Adds `/swarm memory pending`, `/swarm memory recall-log`, `/swarm memory stale`, and dry-run-by-default `/swarm memory compact` commands for long-running memory stores.
+- Expired scratch memory remains hidden from default recall/list paths; compacting deleted, superseded, and expired scratch records requires explicit `--confirm`.
+- Recall usage can now be summarized by agent role and memory ID, with most-recalled, never-recalled, low-utility, and rejected-proposal diagnostics.

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -3,10 +3,15 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadPluginConfig } from '../config/loader';
 import {
+	buildMemoryMaintenanceReport,
 	createConfiguredMemoryProvider,
 	DEFAULT_MEMORY_CONFIG,
 	evaluateMemoryRecallFixtures,
 	getLegacyJsonlFileStatus,
+	type MemoryMaintenanceReport,
+	type MemoryRecallUsageByMemory,
+	type MemoryRecallUsageByRole,
+	type MemoryRecord,
 	readMigrationReport,
 	resolveMemoryConfig,
 	resolveMemoryStorageDir,
@@ -15,7 +20,11 @@ import {
 	writeJsonlExport,
 } from '../memory';
 import type { MemoryConfig } from '../memory/config';
-import type { MemoryProposalStore, MemoryProvider } from '../memory/provider';
+import type {
+	MemoryCompactResult,
+	MemoryProposalStore,
+	MemoryProvider,
+} from '../memory/provider';
 
 type ExportableProvider = MemoryProvider & Partial<MemoryProposalStore>;
 
@@ -31,6 +40,10 @@ export async function handleMemoryCommand(
 		'## Swarm Memory',
 		'',
 		'- `/swarm memory status` - show provider, SQLite path, JSONL files, and last migration report',
+		'- `/swarm memory pending` - show pending proposals and recent rejection reasons',
+		'- `/swarm memory recall-log` - summarize recall usage by agent role and memory ID',
+		'- `/swarm memory stale` - list expired scratch, superseded, deleted, and low-utility memories',
+		'- `/swarm memory compact` - dry-run compaction; pass `--confirm` to remove deleted, superseded, and expired scratch records',
 		'- `/swarm memory export` - export current memory and proposals to `.swarm/memory/export/*.jsonl`',
 		'- `/swarm memory import` - import `.swarm/memory/{memories,proposals}.jsonl` into SQLite',
 		'- `/swarm memory migrate` - run the one-time legacy JSONL to SQLite migration',
@@ -56,6 +69,7 @@ export async function handleMemoryStatusCommand(
 		`- Storage: \`${storageDir}\``,
 		`- SQLite path: \`${sqlitePath}\``,
 		`- SQLite database exists: \`${existsSync(sqlitePath)}\``,
+		`- Automatic destructive cleanup: \`disabled\``,
 		'',
 		'### Legacy JSONL',
 	];
@@ -86,6 +100,143 @@ export async function handleMemoryStatusCommand(
 		}
 	}
 	return lines.join('\n');
+}
+
+export async function handleMemoryPendingCommand(
+	directory: string,
+	args: string[],
+): Promise<string> {
+	const parsed = parseMaintenanceArgs(args, {
+		usage: 'Usage: /swarm memory pending [--limit <n>]',
+		allowConfirm: false,
+	});
+	if ('error' in parsed) return parsed.error;
+	const config = resolveCommandMemoryConfig(directory);
+	const provider = createMaintenanceProvider(directory, config);
+	try {
+		await provider.initialize?.();
+		const report = await buildMemoryMaintenanceReport(provider, {
+			...maintenanceReportOptions(config, parsed.limit),
+		});
+		const lines = [
+			'## Swarm Memory Pending',
+			'',
+			`- Pending proposals shown: \`${report.pendingProposals.length}\``,
+			`- Rejected proposal reasons shown: \`${report.rejectedProposalReasons.length}\``,
+		];
+		appendProposalLines(lines, 'Pending proposals', report.pendingProposals);
+		appendProposalLines(
+			lines,
+			'Rejected proposal reasons',
+			report.rejectedProposalReasons,
+		);
+		return lines.join('\n');
+	} finally {
+		await provider.close?.();
+	}
+}
+
+export async function handleMemoryRecallLogCommand(
+	directory: string,
+	args: string[],
+): Promise<string> {
+	const parsed = parseMaintenanceArgs(args, {
+		usage: 'Usage: /swarm memory recall-log [--limit <n>]',
+		allowConfirm: false,
+	});
+	if ('error' in parsed) return parsed.error;
+	const config = resolveCommandMemoryConfig(directory);
+	const provider = createMaintenanceProvider(directory, config);
+	try {
+		await provider.initialize?.();
+		const report = await buildMemoryMaintenanceReport(provider, {
+			...maintenanceReportOptions(config, parsed.limit),
+		});
+		const lines = [
+			'## Swarm Memory Recall Log',
+			'',
+			`- Recall events scanned: \`${report.recallEventCount}\``,
+			`- Most-recalled memories shown: \`${report.mostRecalledMemories.length}\``,
+			`- Never-recalled memories shown: \`${report.neverRecalledMemories.length}\``,
+		];
+		appendRecallRoleLines(lines, report.recallByAgentRole);
+		appendRecallMemoryLines(lines, report.mostRecalledMemories);
+		appendMemoryLines(
+			lines,
+			'Never-recalled memories',
+			report.neverRecalledMemories,
+		);
+		return lines.join('\n');
+	} finally {
+		await provider.close?.();
+	}
+}
+
+export async function handleMemoryStaleCommand(
+	directory: string,
+	args: string[],
+): Promise<string> {
+	const parsed = parseMaintenanceArgs(args, {
+		usage: 'Usage: /swarm memory stale [--limit <n>]',
+		allowConfirm: false,
+	});
+	if ('error' in parsed) return parsed.error;
+	const config = resolveCommandMemoryConfig(directory);
+	const provider = createMaintenanceProvider(directory, config);
+	try {
+		await provider.initialize?.();
+		const report = await buildMemoryMaintenanceReport(provider, {
+			...maintenanceReportOptions(config, parsed.limit),
+		});
+		const lines = [
+			'## Swarm Memory Stale',
+			'',
+			`- Active memories: \`${report.activeMemories}\``,
+			`- Expired scratch memories shown: \`${report.expiredScratchMemories.length}\``,
+			`- Deleted tombstones shown: \`${report.deletedMemories.length}\``,
+			`- Superseded memories shown: \`${report.supersededMemories.length}\``,
+			`- Low-utility memories shown: \`${report.lowUtilityMemories.length}\``,
+		];
+		appendMemoryLines(
+			lines,
+			'Expired scratch memories',
+			report.expiredScratchMemories,
+		);
+		appendMemoryLines(lines, 'Deleted tombstones', report.deletedMemories);
+		appendSupersededChains(lines, report);
+		appendMemoryLines(lines, 'Low-utility memories', report.lowUtilityMemories);
+		return lines.join('\n');
+	} finally {
+		await provider.close?.();
+	}
+}
+
+export async function handleMemoryCompactCommand(
+	directory: string,
+	args: string[],
+): Promise<string> {
+	const parsed = parseMaintenanceArgs(args, {
+		usage: 'Usage: /swarm memory compact [--confirm]',
+		allowConfirm: true,
+		allowLimit: false,
+	});
+	if ('error' in parsed) return parsed.error;
+	const provider = createMaintenanceProvider(
+		directory,
+		resolveCommandMemoryConfig(directory),
+	);
+	try {
+		await provider.initialize?.();
+		if (!provider.compactMaintenance) {
+			return 'Memory provider does not support compaction.';
+		}
+		const result = await provider.compactMaintenance({
+			dryRun: !parsed.confirm,
+		});
+		return formatCompactResult(result, parsed.confirm);
+	} finally {
+		await provider.close?.();
+	}
 }
 
 export async function handleMemoryMigrateCommand(
@@ -164,6 +315,31 @@ export async function handleMemoryExportCommand(
 	}
 }
 
+function createMaintenanceProvider(
+	directory: string,
+	config: MemoryConfig,
+): ExportableProvider {
+	return createConfiguredMemoryProvider(
+		directory,
+		config,
+	) as ExportableProvider;
+}
+
+function maintenanceReportOptions(
+	config: MemoryConfig,
+	limit: number,
+): {
+	limit: number;
+	lowUtilityMaxConfidence: number;
+	lowUtilityMinAgeDays: number;
+} {
+	return {
+		limit,
+		lowUtilityMaxConfidence: config.maintenance.lowUtilityMaxConfidence,
+		lowUtilityMinAgeDays: config.maintenance.lowUtilityMinAgeDays,
+	};
+}
+
 export async function handleMemoryEvaluateCommand(
 	directory: string,
 	args: string[],
@@ -233,6 +409,31 @@ function parseEvaluateArgs(
 	return { json, fixtureDirectory };
 }
 
+function parseMaintenanceArgs(
+	args: string[],
+	options: { usage: string; allowConfirm: boolean; allowLimit?: boolean },
+): { limit: number; confirm: boolean } | { error: string } {
+	let limit = 20;
+	let confirm = false;
+	const allowLimit = options.allowLimit ?? true;
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === '--confirm' && options.allowConfirm) {
+			confirm = true;
+			continue;
+		}
+		if (arg === '--limit' && allowLimit) {
+			const next = args[i + 1];
+			if (!next || !/^\d+$/.test(next)) return { error: options.usage };
+			limit = Math.min(100, Math.max(1, Number(next)));
+			i++;
+			continue;
+		}
+		return { error: options.usage };
+	}
+	return { limit, confirm };
+}
+
 function resolvePackageRootFromModule(modulePath: string): string {
 	const moduleDir = path.dirname(modulePath);
 	const leaf = path.basename(moduleDir);
@@ -289,4 +490,119 @@ function appendInvalidRows(
 	if (invalidRows.length > 20) {
 		lines.push(`- ... ${invalidRows.length - 20} more`);
 	}
+}
+
+function appendProposalLines(
+	lines: string[],
+	title: string,
+	proposals: MemoryMaintenanceReport['pendingProposals'],
+): void {
+	lines.push('', `### ${title}`);
+	if (proposals.length === 0) {
+		lines.push('- none');
+		return;
+	}
+	for (const proposal of proposals) {
+		const reason =
+			proposal.status === 'rejected'
+				? ` - ${proposal.rejectionReason ?? 'no reason recorded'}`
+				: '';
+		lines.push(
+			`- \`${proposal.id}\` ${proposal.operation} ${proposal.targetMemoryId ?? proposal.proposedRecord?.id ?? 'new'} (${proposal.status})${reason}`,
+		);
+	}
+}
+
+function appendMemoryLines(
+	lines: string[],
+	title: string,
+	memories: MemoryRecord[],
+): void {
+	lines.push('', `### ${title}`);
+	if (memories.length === 0) {
+		lines.push('- none');
+		return;
+	}
+	for (const memory of memories) {
+		lines.push(
+			`- \`${memory.id}\` ${memory.kind} confidence=${memory.confidence.toFixed(2)} updated=${memory.updatedAt} - ${truncate(memory.text, 100)}`,
+		);
+	}
+}
+
+function appendRecallRoleLines(
+	lines: string[],
+	roles: MemoryRecallUsageByRole[],
+): void {
+	lines.push('', '### Recall by agent role');
+	if (roles.length === 0) {
+		lines.push('- none');
+		return;
+	}
+	for (const role of roles) {
+		const memoryCount = Object.keys(role.memoryIds).length;
+		lines.push(
+			`- \`${role.agentRole}\`: ${role.count} recall event(s), ${memoryCount} memory ID(s)`,
+		);
+	}
+}
+
+function appendRecallMemoryLines(
+	lines: string[],
+	memories: MemoryRecallUsageByMemory[],
+): void {
+	lines.push('', '### Most-recalled memories');
+	if (memories.length === 0) {
+		lines.push('- none');
+		return;
+	}
+	for (const memory of memories) {
+		lines.push(
+			`- \`${memory.memoryId}\`: ${memory.count} hit(s), last=${memory.lastRecalledAt}, avgScore=${memory.averageScore.toFixed(3)}`,
+		);
+	}
+}
+
+function appendSupersededChains(
+	lines: string[],
+	report: MemoryMaintenanceReport,
+): void {
+	lines.push('', '### Superseded chains');
+	if (report.supersededChains.length === 0) {
+		lines.push('- none');
+		return;
+	}
+	for (const chain of report.supersededChains) {
+		const reason = chain.reason ? ` - ${chain.reason}` : '';
+		lines.push(
+			`- ${chain.chain.map((id) => `\`${id}\``).join(' -> ')}${reason}`,
+		);
+	}
+}
+
+function formatCompactResult(
+	result: MemoryCompactResult,
+	confirmed: boolean,
+): string {
+	const lines = [
+		'## Swarm Memory Compact',
+		'',
+		`- Mode: \`${confirmed ? 'confirmed' : 'dry-run'}\``,
+		`- Deleted tombstones: \`${result.removedDeleted}\``,
+		`- Superseded records: \`${result.removedSuperseded}\``,
+		`- Expired scratch records: \`${result.removedExpiredScratch}\``,
+		`- Remaining memories: \`${result.remaining}\``,
+	];
+	if (!confirmed) {
+		lines.push(
+			'',
+			'No records were removed. Re-run `/swarm memory compact --confirm` to apply this compaction.',
+		);
+	}
+	return lines.join('\n');
+}
+
+function truncate(value: string, maxLength: number): string {
+	if (value.length <= maxLength) return value;
+	return `${value.slice(0, maxLength - 3)}...`;
 }

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -33,10 +33,14 @@ import {
 } from './knowledge.js';
 import {
 	handleMemoryCommand,
+	handleMemoryCompactCommand,
 	handleMemoryEvaluateCommand,
 	handleMemoryExportCommand,
 	handleMemoryImportCommand,
 	handleMemoryMigrateCommand,
+	handleMemoryPendingCommand,
+	handleMemoryRecallLogCommand,
+	handleMemoryStaleCommand,
 	handleMemoryStatusCommand,
 } from './memory.js';
 import { handlePlanCommand } from './plan.js';
@@ -746,6 +750,34 @@ export const COMMAND_REGISTRY = {
 		description: 'Show Swarm memory provider, JSONL, and migration status',
 		subcommandOf: 'memory',
 		args: '',
+		category: 'diagnostics',
+	},
+	'memory pending': {
+		handler: (ctx) => handleMemoryPendingCommand(ctx.directory, ctx.args),
+		description: 'Show pending Swarm memory proposals and rejection reasons',
+		subcommandOf: 'memory',
+		args: '--limit <n>',
+		category: 'diagnostics',
+	},
+	'memory recall-log': {
+		handler: (ctx) => handleMemoryRecallLogCommand(ctx.directory, ctx.args),
+		description: 'Summarize Swarm memory recall usage',
+		subcommandOf: 'memory',
+		args: '--limit <n>',
+		category: 'diagnostics',
+	},
+	'memory compact': {
+		handler: (ctx) => handleMemoryCompactCommand(ctx.directory, ctx.args),
+		description: 'Compact deleted, superseded, and expired scratch memories',
+		subcommandOf: 'memory',
+		args: '--confirm',
+		category: 'utility',
+	},
+	'memory stale': {
+		handler: (ctx) => handleMemoryStaleCommand(ctx.directory, ctx.args),
+		description: 'List stale and low-utility Swarm memories',
+		subcommandOf: 'memory',
+		args: '--limit <n>',
 		category: 'diagnostics',
 	},
 	'memory export': {

--- a/src/commands/tool-policy.human-only.test.ts
+++ b/src/commands/tool-policy.human-only.test.ts
@@ -26,6 +26,7 @@ describe('tool-policy — human-only command refusal (issue #890)', () => {
 		expect(HUMAN_ONLY_SWARM_COMMANDS.has('checkpoint')).toBe(true);
 		expect(HUMAN_ONLY_SWARM_COMMANDS.has('memory import')).toBe(true);
 		expect(HUMAN_ONLY_SWARM_COMMANDS.has('memory migrate')).toBe(true);
+		expect(HUMAN_ONLY_SWARM_COMMANDS.has('memory compact')).toBe(true);
 	});
 
 	describe('classifySwarmCommandToolUse — chat-tool path', () => {
@@ -102,10 +103,38 @@ describe('tool-policy — human-only command refusal (issue #890)', () => {
 			expect(result.allowed).toBe(true);
 		});
 
-		test('memory status is allowed, but memory import is human-only', () => {
+		test('memory read-only diagnostics are allowed, but mutating commands are human-only', () => {
 			expect(
 				classifySwarmCommandToolUse(resolve(['memory', 'status'])).allowed,
 			).toBe(true);
+			expect(
+				classifySwarmCommandToolUse(resolve(['memory', 'pending'])).allowed,
+			).toBe(true);
+			expect(
+				classifySwarmCommandToolUse(
+					resolve(['memory', 'pending', '--limit', '5']),
+				).allowed,
+			).toBe(true);
+			expect(
+				classifySwarmCommandToolUse(resolve(['memory', 'recall-log'])).allowed,
+			).toBe(true);
+			expect(
+				classifySwarmCommandToolUse(
+					resolve(['memory', 'recall-log', '--limit', '5']),
+				).allowed,
+			).toBe(true);
+			expect(
+				classifySwarmCommandToolUse(resolve(['memory', 'stale'])).allowed,
+			).toBe(true);
+			expect(
+				classifySwarmCommandToolUse(
+					resolve(['memory', 'stale', '--limit', '5']),
+				).allowed,
+			).toBe(true);
+			expect(
+				classifySwarmCommandToolUse(resolve(['memory', 'stale', '--confirm']))
+					.allowed,
+			).toBe(false);
 			expect(
 				classifySwarmCommandToolUse(resolve(['memory', 'evaluate'])).allowed,
 			).toBe(true);
@@ -122,6 +151,13 @@ describe('tool-policy — human-only command refusal (issue #890)', () => {
 			expect(result.allowed).toBe(false);
 			if (result.allowed === false) {
 				expect(result.message).toContain('human-only');
+			}
+			const compactResult = classifySwarmCommandToolUse(
+				resolve(['memory', 'compact']),
+			);
+			expect(compactResult.allowed).toBe(false);
+			if (compactResult.allowed === false) {
+				expect(compactResult.message).toContain('human-only');
 			}
 		});
 	});
@@ -154,6 +190,13 @@ describe('tool-policy — human-only command refusal (issue #890)', () => {
 		test('memory migrate stays blocked because it mutates .swarm state', () => {
 			const result = classifySwarmCommandChatFallbackUse(
 				resolve(['memory', 'migrate']),
+			);
+			expect(result.allowed).toBe(false);
+		});
+
+		test('memory compact stays blocked because it mutates .swarm state', () => {
+			const result = classifySwarmCommandChatFallbackUse(
+				resolve(['memory', 'compact']),
 			);
 			expect(result.allowed).toBe(false);
 		});

--- a/src/commands/tool-policy.ts
+++ b/src/commands/tool-policy.ts
@@ -26,6 +26,10 @@ export const SWARM_COMMAND_TOOL_COMMANDS = [
 	'knowledge',
 	'memory',
 	'memory status',
+	'memory pending',
+	'memory recall-log',
+	'memory compact',
+	'memory stale',
 	'memory export',
 	'memory evaluate',
 	'memory import',
@@ -56,6 +60,9 @@ export const SWARM_COMMAND_TOOL_ALLOWLIST = new Set<string>([
 	'knowledge',
 	'memory',
 	'memory status',
+	'memory pending',
+	'memory recall-log',
+	'memory stale',
 	'memory export',
 	'memory evaluate',
 	'sync-plan',
@@ -78,6 +85,7 @@ export const HUMAN_ONLY_SWARM_COMMANDS = new Set<string>([
 	'checkpoint',
 	'memory import',
 	'memory migrate',
+	'memory compact',
 ]);
 
 const NO_ARGS = new Set([
@@ -160,7 +168,7 @@ export function classifySwarmCommandToolUse(
 		return {
 			allowed: false,
 			message:
-				'Use `/swarm memory status`, `/swarm memory export`, or `/swarm memory evaluate --json` through swarm_command. Memory import and migrate are intentionally excluded from chat-tool execution.',
+				'Use `/swarm memory status`, `/swarm memory pending`, `/swarm memory recall-log`, `/swarm memory stale`, `/swarm memory export`, or `/swarm memory evaluate --json` through swarm_command. Memory import, migrate, and compact are intentionally excluded from chat-tool execution.',
 		};
 	}
 
@@ -171,6 +179,23 @@ export function classifySwarmCommandToolUse(
 			allowed: false,
 			message:
 				'Usage through swarm_command: `/swarm memory evaluate --json`. Custom fixture directories are only available through direct user command execution.',
+		};
+	}
+
+	if (
+		canonicalKey === 'memory pending' ||
+		canonicalKey === 'memory recall-log' ||
+		canonicalKey === 'memory stale'
+	) {
+		if (args.length === 0) return { allowed: true };
+		if (args.length === 2 && args[0] === '--limit' && /^\d+$/.test(args[1])) {
+			return { allowed: true };
+		}
+		return {
+			allowed: false,
+			message:
+				`Usage through swarm_command: \`/swarm ${canonicalKey}\` or ` +
+				`\`/swarm ${canonicalKey} --limit <n>\`.`,
 		};
 	}
 
@@ -249,7 +274,8 @@ export function classifySwarmCommandChatFallbackUse(
 		canonicalKey === 'knowledge quarantine' ||
 		canonicalKey === 'knowledge restore' ||
 		canonicalKey === 'memory import' ||
-		canonicalKey === 'memory migrate'
+		canonicalKey === 'memory migrate' ||
+		canonicalKey === 'memory compact'
 	) {
 		return {
 			allowed: false,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1003,6 +1003,15 @@ export const MemoryConfigSchema = z.object({
 			rejectDurableSecrets: z.boolean().default(true),
 		})
 		.default({ rejectDurableSecrets: true }),
+	maintenance: z
+		.object({
+			lowUtilityMaxConfidence: z.number().min(0).max(1).default(0.45),
+			lowUtilityMinAgeDays: z.number().int().min(1).max(3650).default(30),
+		})
+		.default({
+			lowUtilityMaxConfidence: 0.45,
+			lowUtilityMinAgeDays: 30,
+		}),
 	hardDelete: z.boolean().default(false),
 });
 

--- a/src/memory/config.ts
+++ b/src/memory/config.ts
@@ -26,6 +26,10 @@ export interface MemoryConfig {
 	redaction: {
 		rejectDurableSecrets: boolean;
 	};
+	maintenance: {
+		lowUtilityMaxConfidence: number;
+		lowUtilityMinAgeDays: number;
+	};
 	hardDelete: boolean;
 }
 
@@ -54,6 +58,10 @@ export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
 	},
 	redaction: {
 		rejectDurableSecrets: true,
+	},
+	maintenance: {
+		lowUtilityMaxConfidence: 0.45,
+		lowUtilityMinAgeDays: 30,
 	},
 	hardDelete: false,
 };
@@ -100,6 +108,10 @@ export function resolveMemoryConfig(
 		redaction: {
 			...DEFAULT_MEMORY_CONFIG.redaction,
 			...(input?.redaction ?? {}),
+		},
+		maintenance: {
+			...DEFAULT_MEMORY_CONFIG.maintenance,
+			...(input?.maintenance ?? {}),
 		},
 	};
 }

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -43,8 +43,24 @@ export {
 	writeMigrationReport,
 } from './jsonl-migration';
 export { LocalJsonlMemoryProvider } from './local-jsonl-provider';
+export {
+	buildMemoryMaintenanceReport,
+	type MemoryMaintenanceReport,
+	type MemoryMaintenanceReportOptions,
+	type MemoryRecallUsageByMemory,
+	type MemoryRecallUsageByRole,
+	type MemorySupersededChain,
+	shouldCompactMemory,
+} from './maintenance';
 export { buildRecallPromptBlock } from './prompt-block';
-export type { MemoryProposalStore, MemoryProvider } from './provider';
+export type {
+	MemoryCompactOptions,
+	MemoryCompactResult,
+	MemoryProposalStore,
+	MemoryProvider,
+	MemoryRecallUsageEvent,
+	MemoryRecallUsageFilter,
+} from './provider';
 export {
 	buildMemoryRecallPlan,
 	type MemoryRecallPlan,

--- a/src/memory/local-jsonl-provider.ts
+++ b/src/memory/local-jsonl-provider.ts
@@ -18,10 +18,14 @@ import {
 	validateDecisionMatchesProposal,
 } from './curator-decision-helpers';
 import { MemoryValidationError } from './errors';
+import { shouldCompactMemory } from './maintenance';
 import type {
+	MemoryCompactOptions,
+	MemoryCompactResult,
 	MemoryProposalStore,
 	MemoryProvider,
 	MemoryRecallUsageEvent,
+	MemoryRecallUsageFilter,
 } from './provider';
 import { validateMemoryProposal, validateMemoryRecordRules } from './schema';
 import type { RecallScoringDiagnostics } from './scoring';
@@ -192,20 +196,22 @@ export class LocalJsonlMemoryProvider
 
 	async recordRecallUsage(event: MemoryRecallUsageEvent): Promise<void> {
 		await this.initialize();
-		await this.audit(
-			'recall',
-			event.bundleId,
-			JSON.stringify({
-				query: event.query,
-				scopes: event.scopes,
-				kinds: event.kinds,
-				memoryIds: event.memoryIds,
-				scores: event.scores,
-				tokenEstimate: event.tokenEstimate,
-				agentRole: event.agentRole,
-				runId: event.runId,
-			}),
-		);
+		await this.audit('recall', event.bundleId, undefined, event);
+	}
+
+	async listRecallUsage(
+		filter: MemoryRecallUsageFilter = {},
+	): Promise<MemoryRecallUsageEvent[]> {
+		await this.initialize();
+		const events = await readAuditEvents(this.pathFor('audit'));
+		const usage: MemoryRecallUsageEvent[] = [];
+		for (const event of events) {
+			if (event.operation !== 'recall') continue;
+			const parsed = parseRecallUsageEvent(event);
+			if (parsed) usage.push(parsed);
+		}
+		usage.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+		return usage.slice(0, filter.limit ?? usage.length);
 	}
 
 	async list(filter: MemoryListFilter = {}): Promise<MemoryRecord[]> {
@@ -227,9 +233,11 @@ export class LocalJsonlMemoryProvider
 				return !Number.isFinite(expires) || expires > now;
 			});
 		}
-		records = records.filter(
-			(record) => !record.supersededBy && record.metadata.deleted !== true,
-		);
+		if (!filter.includeInactive) {
+			records = records.filter(
+				(record) => !record.supersededBy && record.metadata.deleted !== true,
+			);
+		}
 		records.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 		return records.slice(0, filter.limit ?? records.length);
 	}
@@ -376,6 +384,48 @@ export class LocalJsonlMemoryProvider
 		await this.audit('compact', 'memories');
 	}
 
+	async compactMaintenance(
+		options: MemoryCompactOptions = {},
+	): Promise<MemoryCompactResult> {
+		await this.initialize();
+		const now = options.now ? new Date(options.now) : new Date();
+		const kept: MemoryRecord[] = [];
+		const result: MemoryCompactResult = {
+			dryRun: options.dryRun !== false,
+			removedDeleted: 0,
+			removedSuperseded: 0,
+			removedExpiredScratch: 0,
+			remaining: 0,
+		};
+		for (const memory of this.memories.values()) {
+			const compactReason = shouldCompactMemory(memory, now);
+			if (compactReason === 'deleted') {
+				result.removedDeleted++;
+				continue;
+			}
+			if (compactReason === 'superseded') {
+				result.removedSuperseded++;
+				continue;
+			}
+			if (compactReason === 'expired_scratch') {
+				result.removedExpiredScratch++;
+				continue;
+			}
+			kept.push(memory);
+		}
+		result.remaining = kept.length;
+		if (result.dryRun) return result;
+		this.memories = new Map(kept.map((memory) => [memory.id, memory]));
+		await writeJsonlAtomic(this.pathFor('memories'), kept);
+		await this.audit(
+			'compact',
+			'memories',
+			'removed deleted, superseded, and expired scratch memories',
+			result,
+		);
+		return result;
+	}
+
 	private async audit(
 		operation: AuditOperation,
 		targetId: string,
@@ -473,6 +523,69 @@ async function readJsonl(filePath: string): Promise<unknown[]> {
 		}
 	}
 	return records;
+}
+
+async function readAuditEvents(filePath: string): Promise<AuditEvent[]> {
+	const values = await readJsonl(filePath);
+	const events: AuditEvent[] = [];
+	for (const value of values) {
+		if (!value || typeof value !== 'object') continue;
+		const candidate = value as Partial<AuditEvent>;
+		if (
+			typeof candidate.id !== 'string' ||
+			typeof candidate.operation !== 'string' ||
+			typeof candidate.targetId !== 'string' ||
+			typeof candidate.timestamp !== 'string'
+		) {
+			continue;
+		}
+		events.push(candidate as AuditEvent);
+	}
+	return events;
+}
+
+function parseRecallUsageEvent(
+	event: AuditEvent,
+): MemoryRecallUsageEvent | null {
+	const raw = event.eventJson ?? event.reason;
+	if (typeof raw !== 'string' && (!raw || typeof raw !== 'object')) {
+		return null;
+	}
+	try {
+		const parsed = (
+			typeof raw === 'string' ? JSON.parse(raw) : raw
+		) as Partial<MemoryRecallUsageEvent>;
+		if (!Array.isArray(parsed.memoryIds) || typeof parsed.query !== 'string') {
+			return null;
+		}
+		return {
+			bundleId:
+				typeof parsed.bundleId === 'string' ? parsed.bundleId : event.targetId,
+			query: parsed.query,
+			scopes: Array.isArray(parsed.scopes) ? parsed.scopes : [],
+			kinds: Array.isArray(parsed.kinds) ? parsed.kinds : undefined,
+			memoryIds: parsed.memoryIds.filter(
+				(memoryId): memoryId is string => typeof memoryId === 'string',
+			),
+			scores: Array.isArray(parsed.scores)
+				? parsed.scores.filter(
+						(score): score is number =>
+							typeof score === 'number' && Number.isFinite(score),
+					)
+				: [],
+			tokenEstimate:
+				typeof parsed.tokenEstimate === 'number' ? parsed.tokenEstimate : 0,
+			agentRole:
+				typeof parsed.agentRole === 'string' ? parsed.agentRole : undefined,
+			runId: typeof parsed.runId === 'string' ? parsed.runId : undefined,
+			timestamp:
+				typeof parsed.timestamp === 'string'
+					? parsed.timestamp
+					: event.timestamp,
+		};
+	} catch {
+		return null;
+	}
 }
 
 async function appendJsonl(filePath: string, value: unknown): Promise<void> {

--- a/src/memory/maintenance.ts
+++ b/src/memory/maintenance.ts
@@ -1,0 +1,304 @@
+import type { MemoryProposalStore, MemoryProvider } from './provider';
+import { isExpired } from './schema';
+import type { MemoryProposal, MemoryRecord } from './types';
+
+export interface MemoryRecallUsageByMemory {
+	memoryId: string;
+	count: number;
+	lastRecalledAt: string;
+	agentRoles: Record<string, number>;
+	averageScore: number;
+}
+
+export interface MemoryRecallUsageByRole {
+	agentRole: string;
+	count: number;
+	memoryIds: Record<string, number>;
+}
+
+export interface MemorySupersededChain {
+	rootId: string;
+	chain: string[];
+	reason?: string;
+}
+
+export interface MemoryMaintenanceReport {
+	generatedAt: string;
+	totalMemories: number;
+	activeMemories: number;
+	deletedMemories: MemoryRecord[];
+	expiredScratchMemories: MemoryRecord[];
+	supersededMemories: MemoryRecord[];
+	supersededChains: MemorySupersededChain[];
+	lowUtilityMemories: MemoryRecord[];
+	neverRecalledMemories: MemoryRecord[];
+	mostRecalledMemories: MemoryRecallUsageByMemory[];
+	recallByAgentRole: MemoryRecallUsageByRole[];
+	rejectedProposalReasons: MemoryProposal[];
+	pendingProposals: MemoryProposal[];
+	recallEventCount: number;
+}
+
+export interface MemoryMaintenanceReportOptions {
+	now?: Date;
+	limit?: number;
+	lowUtilityMaxConfidence?: number;
+	lowUtilityMinAgeDays?: number;
+}
+
+type ObservableProvider = MemoryProvider &
+	Partial<MemoryProposalStore> & {
+		listRecallUsage?: MemoryProvider['listRecallUsage'];
+	};
+
+const DEFAULT_LOW_UTILITY_MAX_CONFIDENCE = 0.45;
+const DEFAULT_LOW_UTILITY_MIN_AGE_DAYS = 30;
+
+export async function buildMemoryMaintenanceReport(
+	provider: ObservableProvider,
+	options: MemoryMaintenanceReportOptions = {},
+): Promise<MemoryMaintenanceReport> {
+	const now = options.now ?? new Date();
+	const limit = Math.max(1, Math.trunc(options.limit ?? 20));
+	const memories = await provider.list({
+		includeExpired: true,
+		includeInactive: true,
+	});
+	const proposals = await loadMaintenanceProposals(provider, limit);
+	const recallUsage = provider.listRecallUsage
+		? await provider.listRecallUsage()
+		: [];
+	const usageByMemory = summarizeRecallByMemory(recallUsage);
+	const usageByRole = summarizeRecallByRole(recallUsage);
+	const activeMemories = memories.filter((memory) =>
+		isActiveMemory(memory, now),
+	);
+	const deletedMemories = memories.filter(
+		(memory) => memory.metadata.deleted === true,
+	);
+	const expiredScratchMemories = memories.filter(
+		(memory) => memory.kind === 'scratch' && isExpired(memory, now),
+	);
+	const supersededMemories = memories.filter((memory) =>
+		Boolean(memory.supersededBy),
+	);
+	const lowUtilityMemories = activeMemories
+		.filter((memory) =>
+			isLowUtility(memory, usageByMemory, now, {
+				maxConfidence:
+					options.lowUtilityMaxConfidence ?? DEFAULT_LOW_UTILITY_MAX_CONFIDENCE,
+				minAgeDays:
+					options.lowUtilityMinAgeDays ?? DEFAULT_LOW_UTILITY_MIN_AGE_DAYS,
+			}),
+		)
+		.sort(memorySort);
+	const neverRecalledMemories = activeMemories
+		.filter((memory) => !usageByMemory.has(memory.id))
+		.sort(memorySort);
+	const rejectedProposalReasons = proposals
+		.filter((proposal) => proposal.status === 'rejected')
+		.sort(proposalSort);
+	const pendingProposals = proposals
+		.filter((proposal) => proposal.status === 'pending')
+		.sort(proposalSort);
+
+	return {
+		generatedAt: now.toISOString(),
+		totalMemories: memories.length,
+		activeMemories: activeMemories.length,
+		deletedMemories: deletedMemories.slice(0, limit),
+		expiredScratchMemories: expiredScratchMemories.slice(0, limit),
+		supersededMemories: supersededMemories.slice(0, limit),
+		supersededChains: buildSupersededChains(memories).slice(0, limit),
+		lowUtilityMemories: lowUtilityMemories.slice(0, limit),
+		neverRecalledMemories: neverRecalledMemories.slice(0, limit),
+		mostRecalledMemories: Array.from(usageByMemory.values())
+			.sort(
+				(a, b) =>
+					b.count - a.count ||
+					b.lastRecalledAt.localeCompare(a.lastRecalledAt) ||
+					a.memoryId.localeCompare(b.memoryId),
+			)
+			.slice(0, limit),
+		recallByAgentRole: Array.from(usageByRole.values())
+			.sort(
+				(a, b) => b.count - a.count || a.agentRole.localeCompare(b.agentRole),
+			)
+			.slice(0, limit),
+		rejectedProposalReasons: rejectedProposalReasons.slice(0, limit),
+		pendingProposals: pendingProposals.slice(0, limit),
+		recallEventCount: recallUsage.length,
+	};
+}
+
+export function shouldCompactMemory(
+	memory: MemoryRecord,
+	now = new Date(),
+): 'deleted' | 'superseded' | 'expired_scratch' | null {
+	if (memory.metadata.deleted === true) return 'deleted';
+	if (memory.supersededBy) return 'superseded';
+	if (memory.kind === 'scratch' && isExpired(memory, now)) {
+		return 'expired_scratch';
+	}
+	return null;
+}
+
+function isActiveMemory(memory: MemoryRecord, now: Date): boolean {
+	return (
+		memory.metadata.deleted !== true &&
+		!memory.supersededBy &&
+		!isExpired(memory, now)
+	);
+}
+
+function isLowUtility(
+	memory: MemoryRecord,
+	usageByMemory: Map<string, MemoryRecallUsageByMemory>,
+	now: Date,
+	options: { maxConfidence: number; minAgeDays: number },
+): boolean {
+	if (usageByMemory.has(memory.id)) return false;
+	const updated = Date.parse(memory.updatedAt);
+	const ageDays = Number.isFinite(updated)
+		? (now.getTime() - updated) / (24 * 60 * 60 * 1000)
+		: 0;
+	return (
+		memory.confidence <= options.maxConfidence || ageDays >= options.minAgeDays
+	);
+}
+
+function summarizeRecallByMemory(
+	usageEvents: Awaited<
+		ReturnType<NonNullable<MemoryProvider['listRecallUsage']>>
+	>,
+): Map<string, MemoryRecallUsageByMemory> {
+	const byMemory = new Map<
+		string,
+		MemoryRecallUsageByMemory & { scoreTotal: number; scoreCount: number }
+	>();
+	for (const event of usageEvents) {
+		event.memoryIds.forEach((memoryId, index) => {
+			const role = event.agentRole ?? 'unknown';
+			const existing =
+				byMemory.get(memoryId) ??
+				({
+					memoryId,
+					count: 0,
+					lastRecalledAt: event.timestamp,
+					agentRoles: {},
+					averageScore: 0,
+					scoreTotal: 0,
+					scoreCount: 0,
+				} satisfies MemoryRecallUsageByMemory & {
+					scoreTotal: number;
+					scoreCount: number;
+				});
+			existing.count++;
+			existing.lastRecalledAt =
+				event.timestamp > existing.lastRecalledAt
+					? event.timestamp
+					: existing.lastRecalledAt;
+			existing.agentRoles[role] = (existing.agentRoles[role] ?? 0) + 1;
+			const score = event.scores[index];
+			if (typeof score === 'number' && Number.isFinite(score)) {
+				existing.scoreTotal += score;
+				existing.scoreCount++;
+				existing.averageScore = existing.scoreTotal / existing.scoreCount;
+			}
+			byMemory.set(memoryId, existing);
+		});
+	}
+	return new Map(
+		Array.from(byMemory, ([memoryId, value]) => [
+			memoryId,
+			{
+				memoryId,
+				count: value.count,
+				lastRecalledAt: value.lastRecalledAt,
+				agentRoles: value.agentRoles,
+				averageScore: value.averageScore,
+			},
+		]),
+	);
+}
+
+async function loadMaintenanceProposals(
+	provider: Partial<MemoryProposalStore>,
+	limit: number,
+): Promise<MemoryProposal[]> {
+	if (!provider.listProposals) return [];
+	const [pending, rejected, recent] = await Promise.all([
+		provider.listProposals({ status: 'pending', limit }),
+		provider.listProposals({ status: 'rejected', limit }),
+		provider.listProposals({ limit: Math.max(limit * 4, 100) }),
+	]);
+	const byId = new Map<string, MemoryProposal>();
+	for (const proposal of [...pending, ...rejected, ...recent]) {
+		byId.set(proposal.id, proposal);
+	}
+	return Array.from(byId.values());
+}
+
+function summarizeRecallByRole(
+	usageEvents: Awaited<
+		ReturnType<NonNullable<MemoryProvider['listRecallUsage']>>
+	>,
+): Map<string, MemoryRecallUsageByRole> {
+	const byRole = new Map<string, MemoryRecallUsageByRole>();
+	for (const event of usageEvents) {
+		const role = event.agentRole ?? 'unknown';
+		const existing = byRole.get(role) ?? {
+			agentRole: role,
+			count: 0,
+			memoryIds: {},
+		};
+		existing.count++;
+		for (const memoryId of event.memoryIds) {
+			existing.memoryIds[memoryId] = (existing.memoryIds[memoryId] ?? 0) + 1;
+		}
+		byRole.set(role, existing);
+	}
+	return byRole;
+}
+
+function buildSupersededChains(
+	memories: MemoryRecord[],
+): MemorySupersededChain[] {
+	const byId = new Map(memories.map((memory) => [memory.id, memory]));
+	const supersededIds = new Set(
+		memories.filter((memory) => memory.supersededBy).map((memory) => memory.id),
+	);
+	const roots = memories.filter(
+		(memory) =>
+			memory.supersededBy &&
+			!(memory.supersedes ?? []).some((id) => supersededIds.has(id)),
+	);
+	return roots.map((root) => {
+		const chain = [root.id];
+		const seen = new Set(chain);
+		let cursor: MemoryRecord | undefined = root;
+		while (cursor?.supersededBy && !seen.has(cursor.supersededBy)) {
+			chain.push(cursor.supersededBy);
+			seen.add(cursor.supersededBy);
+			cursor = byId.get(cursor.supersededBy);
+		}
+		return {
+			rootId: root.id,
+			chain,
+			reason:
+				typeof root.metadata.supersedeReason === 'string'
+					? root.metadata.supersedeReason
+					: undefined,
+		};
+	});
+}
+
+function memorySort(a: MemoryRecord, b: MemoryRecord): number {
+	return b.updatedAt.localeCompare(a.updatedAt) || a.id.localeCompare(b.id);
+}
+
+function proposalSort(a: MemoryProposal, b: MemoryProposal): number {
+	const aTime = a.reviewedAt ?? a.createdAt;
+	const bTime = b.reviewedAt ?? b.createdAt;
+	return bTime.localeCompare(aTime) || a.id.localeCompare(b.id);
+}

--- a/src/memory/provider.ts
+++ b/src/memory/provider.ts
@@ -27,6 +27,23 @@ export interface MemoryRecallUsageEvent {
 	timestamp: string;
 }
 
+export interface MemoryRecallUsageFilter {
+	limit?: number;
+}
+
+export interface MemoryCompactOptions {
+	dryRun?: boolean;
+	now?: string;
+}
+
+export interface MemoryCompactResult {
+	dryRun: boolean;
+	removedDeleted: number;
+	removedSuperseded: number;
+	removedExpiredScratch: number;
+	remaining: number;
+}
+
 export interface MemoryProvider {
 	readonly name: string;
 	initialize?(): Promise<void>;
@@ -37,6 +54,12 @@ export interface MemoryProvider {
 	recall(request: RecallRequest): Promise<RecallResultItem[]>;
 	recallWithDiagnostics?(request: RecallRequest): Promise<MemoryRecallResult>;
 	recordRecallUsage?(event: MemoryRecallUsageEvent): Promise<void>;
+	listRecallUsage?(
+		filter?: MemoryRecallUsageFilter,
+	): Promise<MemoryRecallUsageEvent[]>;
+	compactMaintenance?(
+		options?: MemoryCompactOptions,
+	): Promise<MemoryCompactResult>;
 	list(filter: MemoryListFilter): Promise<MemoryRecord[]>;
 }
 

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -22,10 +22,14 @@ import {
 	writeJsonlExport,
 	writeMigrationReport,
 } from './jsonl-migration';
+import { shouldCompactMemory } from './maintenance';
 import type {
+	MemoryCompactOptions,
+	MemoryCompactResult,
 	MemoryProposalStore,
 	MemoryProvider,
 	MemoryRecallUsageEvent,
+	MemoryRecallUsageFilter,
 } from './provider';
 import { validateMemoryProposal, validateMemoryRecordRules } from './schema';
 import type { RecallScoringDiagnostics } from './scoring';
@@ -57,6 +61,7 @@ type EventOperation =
 	| 'proposal'
 	| 'recall'
 	| 'migration'
+	| 'compact'
 	| 'curator_decision'
 	| 'invalid_load';
 
@@ -178,6 +183,10 @@ interface ProposalRow {
 	proposal_json: string;
 }
 
+interface RecallUsageRow {
+	usage_json: string;
+}
+
 interface DecisionTransactionResult {
 	change: AppliedMemoryChange;
 	proposal: MemoryProposal;
@@ -234,6 +243,10 @@ export class SQLiteMemoryProvider
 			redaction: {
 				...DEFAULT_MEMORY_CONFIG.redaction,
 				...(config.redaction ?? {}),
+			},
+			maintenance: {
+				...DEFAULT_MEMORY_CONFIG.maintenance,
+				...(config.maintenance ?? {}),
 			},
 		};
 	}
@@ -377,6 +390,45 @@ export class SQLiteMemoryProvider
 		await this.event('recall', event.bundleId, JSON.stringify(event));
 	}
 
+	async listRecallUsage(
+		filter: MemoryRecallUsageFilter = {},
+	): Promise<MemoryRecallUsageEvent[]> {
+		await this.initialize();
+		const rows =
+			typeof filter.limit === 'number'
+				? this.requireDb()
+						.query<RecallUsageRow, [number]>(
+							`SELECT usage_json
+				FROM memory_recall_usage
+				ORDER BY timestamp DESC
+				LIMIT ?`,
+						)
+						.all(Math.max(1, Math.trunc(filter.limit)))
+				: this.requireDb()
+						.query<RecallUsageRow, []>(
+							`SELECT usage_json
+				FROM memory_recall_usage
+				ORDER BY timestamp DESC
+				`,
+						)
+						.all();
+		const events: MemoryRecallUsageEvent[] = [];
+		for (const row of rows) {
+			try {
+				const parsed = JSON.parse(row.usage_json) as MemoryRecallUsageEvent;
+				if (
+					Array.isArray(parsed.memoryIds) &&
+					typeof parsed.query === 'string'
+				) {
+					events.push(parsed);
+				}
+			} catch {
+				// Ignore corrupt recall usage rows; maintenance reports are advisory.
+			}
+		}
+		return events;
+	}
+
 	async list(filter: MemoryListFilter = {}): Promise<MemoryRecord[]> {
 		await this.initialize();
 		let records = Array.from(this.memories.values());
@@ -396,9 +448,11 @@ export class SQLiteMemoryProvider
 				return !Number.isFinite(expires) || expires > now;
 			});
 		}
-		records = records.filter(
-			(record) => !record.supersededBy && record.metadata.deleted !== true,
-		);
+		if (!filter.includeInactive) {
+			records = records.filter(
+				(record) => !record.supersededBy && record.metadata.deleted !== true,
+			);
+		}
 		records.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 		return records.slice(0, filter.limit ?? records.length);
 	}
@@ -508,6 +562,60 @@ export class SQLiteMemoryProvider
 			memories: memories.length,
 			proposals: proposals.length,
 		};
+	}
+
+	async compactMaintenance(
+		options: MemoryCompactOptions = {},
+	): Promise<MemoryCompactResult> {
+		await this.initialize();
+		const now = options.now ? new Date(options.now) : new Date();
+		const kept: MemoryRecord[] = [];
+		const removeIds: string[] = [];
+		const result: MemoryCompactResult = {
+			dryRun: options.dryRun !== false,
+			removedDeleted: 0,
+			removedSuperseded: 0,
+			removedExpiredScratch: 0,
+			remaining: 0,
+		};
+		for (const memory of this.memories.values()) {
+			const compactReason = shouldCompactMemory(memory, now);
+			if (compactReason === 'deleted') {
+				result.removedDeleted++;
+				removeIds.push(memory.id);
+				continue;
+			}
+			if (compactReason === 'superseded') {
+				result.removedSuperseded++;
+				removeIds.push(memory.id);
+				continue;
+			}
+			if (compactReason === 'expired_scratch') {
+				result.removedExpiredScratch++;
+				removeIds.push(memory.id);
+				continue;
+			}
+			kept.push(memory);
+		}
+		result.remaining = kept.length;
+		if (result.dryRun) return result;
+
+		const db = this.requireDb();
+		const compact = db.transaction(() => {
+			for (const id of removeIds) {
+				db.run('DELETE FROM memory_items WHERE id = ?', [id]);
+				this.deleteMemoryFts(id);
+			}
+			this.insertEvent(
+				'compact',
+				'memory_items',
+				'removed deleted, superseded, and expired scratch memories',
+				JSON.stringify(result),
+			);
+		});
+		compact();
+		this.memories = new Map(kept.map((memory) => [memory.id, memory]));
+		return result;
 	}
 
 	hasMigration(name: string): boolean {

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -231,5 +231,6 @@ export interface MemoryListFilter {
 	scopes?: MemoryScopeRef[];
 	kinds?: MemoryKind[];
 	includeExpired?: boolean;
+	includeInactive?: boolean;
 	limit?: number;
 }

--- a/tests/unit/commands/memory.test.ts
+++ b/tests/unit/commands/memory.test.ts
@@ -4,9 +4,13 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+	handleMemoryCompactCommand,
 	handleMemoryEvaluateCommand,
 	handleMemoryExportCommand,
 	handleMemoryImportCommand,
+	handleMemoryPendingCommand,
+	handleMemoryRecallLogCommand,
+	handleMemoryStaleCommand,
 	handleMemoryStatusCommand,
 } from '../../../src/commands/memory';
 import {
@@ -45,6 +49,7 @@ describe('/swarm memory commands', () => {
 		expect(output).toContain('Provider: `sqlite`');
 		expect(output).toContain('memories.jsonl: `missing`');
 		expect(output).toContain('proposals.jsonl: `missing`');
+		expect(output).toContain('Automatic destructive cleanup: `disabled`');
 	});
 
 	test('export writes current SQLite memory to JSONL', async () => {
@@ -140,6 +145,250 @@ describe('/swarm memory commands', () => {
 			handleMemoryEvaluateCommand(tmpDir, ['--fixture-dir', 'fixtures']),
 		).resolves.toBe(usage);
 	});
+
+	test('pending lists pending proposals and rejected proposal reasons', async () => {
+		const provider = new SQLiteMemoryProvider(tmpDir, {
+			enabled: true,
+			provider: 'sqlite',
+		});
+		const pendingRecord = makeRecord('Pending proposal should be listed.');
+		const rejectedRecord = makeRecord(
+			'Rejected proposal reason should be shown.',
+		);
+		const pending = makeProposal(pendingRecord);
+		const rejected = makeProposal(rejectedRecord);
+		try {
+			await provider.createProposal(pending);
+			await provider.createProposal(rejected);
+			await provider.applyCuratorDecision({
+				action: 'reject',
+				proposalId: rejected.id,
+				reason: 'Too vague to keep.',
+			});
+		} finally {
+			provider.close();
+		}
+
+		const output = await handleMemoryPendingCommand(tmpDir, []);
+
+		expect(output).toContain('Pending proposals shown: `1`');
+		expect(output).toContain(pending.id);
+		expect(output).toContain('Rejected proposal reasons shown: `1`');
+		expect(output).toContain('Too vague to keep.');
+	});
+
+	test('pending keeps rejected reasons visible behind newer proposal pages', async () => {
+		const provider = new SQLiteMemoryProvider(tmpDir, {
+			enabled: true,
+			provider: 'sqlite',
+		});
+		const rejectedRecord = makeRecord(
+			'Old rejected proposal reason should still be shown.',
+		);
+		const rejected = makeProposal(rejectedRecord, {
+			createdAt: '2026-01-01T12:00:00.000Z',
+		});
+		try {
+			await provider.createProposal(rejected);
+			await provider.applyCuratorDecision({
+				action: 'reject',
+				proposalId: rejected.id,
+				reason: 'Rejected before many newer proposals.',
+			});
+			for (let index = 0; index < 105; index++) {
+				const record = makeRecord(`Newer pending proposal ${index}.`);
+				await provider.createProposal(
+					makeProposal(record, {
+						createdAt: new Date(Date.UTC(2026, 4, 25, 12, index)).toISOString(),
+					}),
+				);
+			}
+		} finally {
+			provider.close();
+		}
+
+		const output = await handleMemoryPendingCommand(tmpDir, []);
+
+		expect(output).toContain('Pending proposals shown: `20`');
+		expect(output).toContain('Rejected proposal reasons shown: `1`');
+		expect(output).toContain('Rejected before many newer proposals.');
+	});
+
+	test('recall-log summarizes usage by agent role and memory ID', async () => {
+		const provider = new SQLiteMemoryProvider(tmpDir, {
+			enabled: true,
+			provider: 'sqlite',
+		});
+		const recalled = makeRecord('Recall log should count this memory.');
+		const never = makeRecord('Never recalled memory should be visible.');
+		try {
+			await provider.upsert(recalled);
+			await provider.upsert(never);
+			await provider.recordRecallUsage({
+				bundleId: 'bundle_20260525_abcd1234',
+				query: 'memory maintenance',
+				scopes: [recalled.scope],
+				kinds: ['repo_convention'],
+				memoryIds: [recalled.id],
+				scores: [0.77],
+				tokenEstimate: 120,
+				agentRole: 'coder',
+				runId: 'session-a',
+				timestamp: '2026-05-25T13:00:00.000Z',
+			});
+			await provider.recordRecallUsage({
+				bundleId: 'bundle_20260525_abcd5678',
+				query: 'memory maintenance',
+				scopes: [recalled.scope],
+				memoryIds: [recalled.id],
+				scores: [0.88],
+				tokenEstimate: 80,
+				agentRole: 'qa',
+				runId: 'session-b',
+				timestamp: '2026-05-25T14:00:00.000Z',
+			});
+		} finally {
+			provider.close();
+		}
+
+		const output = await handleMemoryRecallLogCommand(tmpDir, []);
+
+		expect(output).toContain('Recall events scanned: `2`');
+		expect(output).toContain('`coder`: 1 recall event(s), 1 memory ID(s)');
+		expect(output).toContain('`qa`: 1 recall event(s), 1 memory ID(s)');
+		expect(output).toContain(`\`${recalled.id}\`: 2 hit(s)`);
+		expect(output).toContain(never.id);
+	});
+
+	test('recall-log does not classify memories as never recalled outside the recent window', async () => {
+		const provider = new SQLiteMemoryProvider(tmpDir, {
+			enabled: true,
+			provider: 'sqlite',
+		});
+		const oldRecalled = makeRecord('Older recall event should still count.');
+		const filler = makeRecord('Filler recall event memory.');
+		try {
+			await provider.upsert(oldRecalled);
+			await provider.upsert(filler);
+			await provider.recordRecallUsage({
+				bundleId: 'bundle_20260525_old',
+				query: 'old recall',
+				scopes: [oldRecalled.scope],
+				memoryIds: [oldRecalled.id],
+				scores: [0.7],
+				tokenEstimate: 80,
+				agentRole: 'coder',
+				runId: 'old-session',
+				timestamp: '2026-05-25T00:00:00.000Z',
+			});
+			for (let index = 0; index < 1000; index++) {
+				await provider.recordRecallUsage({
+					bundleId: `bundle_20260525_recent_${index}`,
+					query: 'recent recall',
+					scopes: [filler.scope],
+					memoryIds: [filler.id],
+					scores: [0.8],
+					tokenEstimate: 80,
+					agentRole: 'qa',
+					runId: `recent-session-${index}`,
+					timestamp: new Date(Date.UTC(2026, 4, 25, 1, 0, index)).toISOString(),
+				});
+			}
+		} finally {
+			provider.close();
+		}
+
+		const output = await handleMemoryRecallLogCommand(tmpDir, []);
+
+		expect(output).toContain('Recall events scanned: `1001`');
+		expect(output).toContain(`\`${oldRecalled.id}\`: 1 hit(s)`);
+		expect(output).not.toContain(
+			`${oldRecalled.id}\` ${oldRecalled.kind} confidence=`,
+		);
+	});
+
+	test('stale lists expired scratch memories and superseded chains', async () => {
+		const provider = new SQLiteMemoryProvider(tmpDir, {
+			enabled: true,
+			provider: 'sqlite',
+		});
+		const expiredScratch = makeScratchRecord('Expired scratch is stale.');
+		const oldMemory = makeRecord('Old superseded convention.');
+		const replacement = {
+			...makeRecord('Replacement convention.'),
+			supersedes: [oldMemory.id],
+		};
+		const superseded = {
+			...oldMemory,
+			updatedAt: '2026-05-25T14:00:00.000Z',
+			supersededBy: replacement.id,
+			metadata: { supersedeReason: 'Replacement is more precise.' },
+		};
+		try {
+			await provider.upsert(expiredScratch);
+			await provider.upsert(superseded);
+			await provider.upsert(replacement);
+		} finally {
+			provider.close();
+		}
+
+		const output = await handleMemoryStaleCommand(tmpDir, []);
+
+		expect(output).toContain('Expired scratch memories shown: `1`');
+		expect(output).toContain(expiredScratch.id);
+		expect(output).toContain('Superseded chains');
+		expect(output).toContain(`${oldMemory.id}\` -> \`${replacement.id}`);
+		expect(output).toContain('Replacement is more precise.');
+	});
+
+	test('compact is dry-run by default and requires --confirm to remove records', async () => {
+		const provider = new SQLiteMemoryProvider(tmpDir, {
+			enabled: true,
+			provider: 'sqlite',
+		});
+		const deleted = makeRecord('Deleted memory should compact.');
+		const expiredScratch = makeScratchRecord('Expired scratch should compact.');
+		try {
+			await provider.upsert(deleted);
+			await provider.upsert(expiredScratch);
+			await provider.delete(deleted.id, 'obsolete');
+		} finally {
+			provider.close();
+		}
+
+		const dryRun = await handleMemoryCompactCommand(tmpDir, []);
+		expect(dryRun).toContain('Mode: `dry-run`');
+		expect(dryRun).toContain('Deleted tombstones: `1`');
+		expect(dryRun).toContain('Expired scratch records: `1`');
+		await expect(
+			handleMemoryCompactCommand(tmpDir, ['--limit', '1']),
+		).resolves.toBe('Usage: /swarm memory compact [--confirm]');
+
+		const afterDryRun = new SQLiteMemoryProvider(tmpDir, {
+			enabled: true,
+			provider: 'sqlite',
+		});
+		try {
+			expect(await afterDryRun.get(deleted.id)).not.toBeNull();
+			expect(await afterDryRun.get(expiredScratch.id)).not.toBeNull();
+		} finally {
+			afterDryRun.close();
+		}
+
+		const confirmed = await handleMemoryCompactCommand(tmpDir, ['--confirm']);
+		expect(confirmed).toContain('Mode: `confirmed`');
+
+		const afterConfirm = new SQLiteMemoryProvider(tmpDir, {
+			enabled: true,
+			provider: 'sqlite',
+		});
+		try {
+			expect(await afterConfirm.get(deleted.id)).toBeNull();
+			expect(await afterConfirm.get(expiredScratch.id)).toBeNull();
+		} finally {
+			afterConfirm.close();
+		}
+	});
 });
 
 function makeRecord(text: string): MemoryRecord {
@@ -166,8 +415,35 @@ function makeRecord(text: string): MemoryRecord {
 	};
 }
 
-function makeProposal(record: MemoryRecord): MemoryProposal {
-	const createdAt = '2026-05-25T12:00:00.000Z';
+function makeScratchRecord(text: string): MemoryRecord {
+	const base = {
+		scope: {
+			type: 'run' as const,
+			runId: 'run-a',
+		},
+		kind: 'scratch' as const,
+		text,
+	};
+	return {
+		id: createMemoryId(base),
+		...base,
+		tags: ['scratch'],
+		confidence: 0.5,
+		stability: 'ephemeral',
+		source: { type: 'agent', createdBy: 'coder' },
+		createdAt: '2026-05-20T12:00:00.000Z',
+		updatedAt: '2026-05-20T12:00:00.000Z',
+		expiresAt: '2026-05-21T12:00:00.000Z',
+		contentHash: computeMemoryContentHash(base),
+		metadata: {},
+	};
+}
+
+function makeProposal(
+	record: MemoryRecord,
+	options: { createdAt?: string } = {},
+): MemoryProposal {
+	const createdAt = options.createdAt ?? '2026-05-25T12:00:00.000Z';
 	return {
 		id: createProposalId({
 			createdAt,

--- a/tests/unit/commands/registry.test.ts
+++ b/tests/unit/commands/registry.test.ts
@@ -258,7 +258,16 @@ describe('resolveCommand()', () => {
 		});
 
 		test('resolves memory subcommands', () => {
-			for (const subcommand of ['status', 'export', 'import', 'migrate']) {
+			for (const subcommand of [
+				'status',
+				'pending',
+				'recall-log',
+				'compact',
+				'stale',
+				'export',
+				'import',
+				'migrate',
+			]) {
 				const result = resolveCommand(['memory', subcommand]);
 				expect(result).not.toBeNull();
 				expect(result!.entry.subcommandOf).toBe('memory');

--- a/tests/unit/config/memory-config.test.ts
+++ b/tests/unit/config/memory-config.test.ts
@@ -37,6 +37,10 @@ describe('MemoryConfigSchema', () => {
 			},
 			writes: { mode: 'propose' },
 			redaction: { rejectDurableSecrets: true },
+			maintenance: {
+				lowUtilityMaxConfidence: 0.45,
+				lowUtilityMinAgeDays: 30,
+			},
 			hardDelete: false,
 		});
 	});
@@ -84,6 +88,25 @@ describe('MemoryConfigSchema', () => {
 		expect(() => MemoryConfigSchema.parse({ provider: 'qdrant' })).toThrow();
 		expect(() =>
 			MemoryConfigSchema.parse({ writes: { mode: 'direct' } }),
+		).toThrow();
+	});
+
+	test('accepts explicit maintenance thresholds for low-utility reporting', () => {
+		const parsed = MemoryConfigSchema.parse({
+			maintenance: {
+				lowUtilityMaxConfidence: 0.2,
+				lowUtilityMinAgeDays: 90,
+			},
+		});
+
+		expect(parsed.maintenance).toEqual({
+			lowUtilityMaxConfidence: 0.2,
+			lowUtilityMinAgeDays: 90,
+		});
+		expect(() =>
+			MemoryConfigSchema.parse({
+				maintenance: { lowUtilityMinAgeDays: 0 },
+			}),
 		).toThrow();
 	});
 

--- a/tests/unit/memory/local-jsonl-provider.test.ts
+++ b/tests/unit/memory/local-jsonl-provider.test.ts
@@ -105,9 +105,17 @@ describe('LocalJsonlMemoryProvider', () => {
 			path.join(tmpDir, '.swarm', 'memory', 'audit.jsonl'),
 			'utf-8',
 		);
+		const usage = await provider.listRecallUsage();
 		expect(audit).toContain('"operation":"recall"');
 		expect(audit).toContain(repoA.id);
 		expect(audit).toContain('bundle_20260524_abcd');
+		expect(usage).toEqual([
+			expect.objectContaining({
+				bundleId: 'bundle_20260524_abcd',
+				memoryIds: [repoA.id],
+				agentRole: 'coder',
+			}),
+		]);
 	});
 
 	test('recall excludes expired records by default', async () => {

--- a/tests/unit/memory/provider-contract.test.ts
+++ b/tests/unit/memory/provider-contract.test.ts
@@ -170,6 +170,14 @@ describe('MemoryProvider contract parity', () => {
 				});
 
 				expect(results.map((item) => item.record.id)).toEqual([repoA.id]);
+				expect(await provider.listRecallUsage()).toEqual([
+					expect.objectContaining({
+						bundleId: 'bundle_20260524_abcd',
+						memoryIds: [repoA.id],
+						agentRole: 'coder',
+					}),
+				]);
+				expect(await provider.listRecallUsage({ limit: 1 })).toHaveLength(1);
 			});
 
 			test('tombstones deletes and refuses to upsert over tombstones', async () => {


### PR DESCRIPTION
﻿## Summary
- add memory maintenance reporting and commands: `/swarm memory pending`, `/swarm memory recall-log`, `/swarm memory stale`, and dry-run-by-default `/swarm memory compact --confirm`
- add provider observability and maintenance plumbing across SQLite and local JSONL, including recall-usage listing and explicit compaction of deleted/superseded/expired-scratch records
- keep cleanup explicit (no automatic destructive cleanup path), preserve expired-scratch default hiding, and expose superseded-chain inspection
- fix follow-up critic gaps: remove unwired `maintenance.autoCompact` config, reject unused `--limit` on `memory compact`, and prevent recall-log windowing from misclassifying older recalled memories as never-recalled
- update docs and release fragment for memory maintenance observability

## Invariant audit
- 1 (plugin init): not touched - no init-path behavior or startup hooks changed; work is scoped to memory providers/commands/docs/tests
- 2 (runtime portability): touched - `bun run build`; `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`; `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-node-load.test.ts tests/unit/build/bundle-plugin-shape.test.ts --timeout 30000`
- 3 (subprocesses): not touched - no new spawn usage in touched source; `rg -n "process\.cwd\(|bunSpawn\(|spawn\(|spawnSync\(" src/commands/memory.ts src/memory/maintenance.ts src/memory/local-jsonl-provider.ts src/memory/sqlite-provider.ts src/commands/registry.ts src/commands/tool-policy.ts` returned no matches
- 4 (.swarm containment): touched - memory storage/maintenance remains provider-rooted under configured `.swarm/memory`; escape guard parity verified by `bun --smol test tests/unit/memory/provider-contract.test.ts tests/unit/memory/local-jsonl-provider.test.ts --timeout 30000`
- 5 (plan durability): not touched - no `.swarm/plan-*` or plan-ledger paths changed
- 6 (test_runner safety): not touched - validation used shell `bun --smol test` commands, no broad `test_runner` scope usage
- 7 (test writing): touched - added/updated bun:test coverage in `tests/unit/commands/memory.test.ts`, `tests/unit/config/memory-config.test.ts`, `tests/unit/memory/provider-contract.test.ts`, `tests/unit/memory/local-jsonl-provider.test.ts`; no cross-file `mock.module` pattern introduced
- 8 (session state): not touched - no session/global-state modules changed
- 9 (guardrails/retry): not touched - no retry/circuit-breaker logic changed
- 10 (chat/system msg): not touched - no chat/system transform logic changed
- 11 (tool registration): touched - added memory subcommands in `src/commands/registry.ts` with policy gating in `src/commands/tool-policy.ts`; verified by `bun --smol test tests/unit/commands/registry.test.ts src/commands/tool-policy.human-only.test.ts --timeout 30000`
- 12 (release/cache): touched - added release fragment `docs/releases/pending/memory-maintenance-observability.md`; rebuilt generated `dist/*` with `bun run build`

## Test plan
- [x] `bun run build`
- [x] `git diff --check`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `bun --smol test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-node-load.test.ts tests/unit/build/bundle-plugin-shape.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/config/memory-config.test.ts tests/unit/commands/memory.test.ts tests/unit/commands/registry.test.ts src/commands/tool-policy.human-only.test.ts tests/unit/memory/provider-contract.test.ts tests/unit/memory/local-jsonl-provider.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/memory --timeout 60000`


## Feedback closure ledger
- F-001 (dist/Zod reproducibility): fixed - inspected current dist-check failure on run `26485345588` / job `77991543857`; rebased branch onto `origin/main`, ran `bun install --frozen-lockfile --force` which installed `zod@4.3.6`, rebuilt with `bun run build`, committed regenerated `dist/`, and verified `git diff --exit-code -- dist` is clean after a second build.
- F-002 (low-utility OR semantics): advisory/no code change - the heuristic only lists human-review candidates and does not feed automatic cleanup; destructive compaction remains explicit and limited to deleted, superseded, and expired scratch records.
- C-003 (non-linear superseded chains): advisory/unverified follow-up - current PR keeps the existing inspectable-chain implementation and two-item coverage; no merge-blocking correctness issue was proven in pasted feedback.
- Architecture observations: advisory/no code change - all-memory/all-recall maintenance scans and O(n) SQLite compaction remain acceptable for this explicit diagnostic command surface; no automatic runtime path invokes them.
- Coverage gaps: advisory/no code change - existing targeted coverage proves the blocker and acceptance paths; listed gaps can be handled as follow-up hardening.
- CI-001 (dist-check failure): fixed locally - `bun run build`; `git diff --exit-code -- dist`; `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`; bundle and focused memory tests passed before push.
- BRANCH-001 (PR behind main): fixed - branch rebased onto `origin/main` before rebuilding and force-with-lease pushing.
