### PR TITLE
fix(release): trigger plan execute skill release

### DIFF
--- a/docs/releases/pending/extract-plan-execute-skills.md
+++ b/docs/releases/pending/extract-plan-execute-skills.md
@@ -4,3 +4,4 @@ Details:
 - Added mirrored `.opencode` and `.claude` skill files for `plan` and `execute`.
 - Kept architect trigger/action stubs plus critical gate-selection, scope, retry, and completion constraints inline.
 - Added focused skill protocol tests for the extracted mode bodies.
+- Ships the extraction as a patch release because the refactor changes the architect's runtime prompt-loading path and should be available in the published npm package for validation.


### PR DESCRIPTION
﻿## Summary
- Marks the PLAN/EXECUTE skill extraction as a releasable patch by updating its pending release fragment.
- Keeps the actual implementation unchanged; this exists so release-please sees a user-facing `fix(...)` commit after PR #1048 merged as `refactor(...)`.
- Expected post-merge behavior: release-please should open the next release PR, and merging that release PR should publish the npm package.

## Invariant audit
- 1 (plugin init): not touched - release-note-only change.
- 2 (runtime portability): not touched - no source, package, build, or `dist/` changes.
- 3 (subprocesses): not touched - no subprocess code changes.
- 4 (.swarm containment): not touched - no runtime state or path handling changes.
- 5 (plan durability): not touched - no plan code changes.
- 6 (test_runner safety): not touched - no `test_runner` changes; validation used shell only.
- 7 (test writing): not touched - no tests changed.
- 8 (session state): not touched - no session/global state changes.
- 9 (guardrails/retry): not touched - no guardrail/retry changes.
- 10 (chat/system msg): not touched - no prompt or message-shape changes in this PR.
- 11 (tool registration): not touched - no tool or agent map changes.
- 12 (release/cache): touched - pending release fragment `docs/releases/pending/extract-plan-execute-skills.md` updated; no release-please-owned version files edited.

## Test plan
- [x] `git diff --check`
- [x] Staged-file audit: only `docs/releases/pending/extract-plan-execute-skills.md`
- [x] Confirmed latest release state before this PR: release-please skipped PR #1048 because it found no user-facing commits after `v7.41.0`
