### PR TITLE
docs(skills): add test isolation failure diagnosis protocol and closure capture pitfall

### DIFF
--- a/.opencode/skills/generated/mock-to-internals-migration/SKILL.md
+++ b/.opencode/skills/generated/mock-to-internals-migration/SKILL.md
@@ -189,6 +189,7 @@ Do NOT change these helpers to use the DI seam.
 | Using `type SpawnSyncFn` import from `node:child_process` | Type export doesn't exist at runtime; build fails |
 | Forgetting to restore `_internals.spawnSync` | Subsequent tests or other files get the mock |
 | Using async `fs.rm` in `afterEach` without `await` | Temp directories not cleaned up; use `rmSync` |
+| Forgetting vi.mock() captures closures at hoist-time | Reassigning mockFn.mockImplementation(newFn) in test body does NOT update the hoisted closure — mock still calls original function. Symptom: toHaveBeenCalledTimes(N) fails unexpectedly. Fix: use _internals seam instead |
 | Converting `initGitRepo`-style helpers | These need the REAL subprocess; keep them as `require()` |
 
 ## Verification checklist

--- a/.opencode/skills/writing-tests/SKILL.md
+++ b/.opencode/skills/writing-tests/SKILL.md
@@ -441,6 +441,29 @@ When CI reports a `unit (ubuntu|macos|windows)` failure:
 - **Do not test framework behavior.** "Zod schema parses valid input" tests Zod, not your schema.
 - **Do not test test utilities.** If it only exists to support other tests, it doesn't need its own test.
 - **Do not mock everything.** If every dependency is mocked, you're testing the mock setup. Prefer real dependencies for pure functions and only mock I/O boundaries (filesystem, network, timers).
+
+### Anchored Content Assertions
+
+When asserting that skill files, protocol docs, or structured markdown contain expected text, **anchor your assertions to the relevant section** rather than using bare `toContain()` on the full file content:
+
+```typescript
+// WEAK — passes even if the word appears in prose outside the intended section
+expect(content).toContain('DROP');
+
+// STRONG — fails if the structured section is removed or relocated
+const stage3Start = content.indexOf('#### Stage 3: Consult Critic Sounding Board');
+const stage4Start = content.indexOf('#### Stage 4: Surface User Decision Packet');
+const stage3Section = content.slice(stage3Start, stage4Start);
+expect(stage3Section).toContain('DROP');
+expect(stage3Section).toContain('ASK_USER');
+```
+
+**Why this matters:** A bare `toContain('DROP')` passes as long as the word appears anywhere in the file. If the structured outcomes section is deleted but a prose reference remains (e.g., "The critic may DROP irrelevant items"), the test still passes — silently hiding the removal. Section-anchored assertions fail when the content is actually removed from its intended location.
+
+Use this pattern for:
+- Critic outcome mappings in skill files (DROP, ASK_USER, RESOLVE, REPHRASE)
+- Classification category lists (self_resolved, user_decision, etc.)
+- Any structured section where word presence is necessary but position-dependent
 - **Do not hardcode version numbers.** Version bumps are automated — a test asserting `version === '6.31.3'` breaks on every release.
 - **Do not use `sleep` or `setTimeout` for synchronization.** Use explicit signals, resolved promises, or `Bun.sleep()` with tight bounds.
 - **Do not spawn `cat /dev/zero`, `yes`, or other infinite-output commands.** Use `sleep 30` for "blocking command" tests.

--- a/.opencode/skills/writing-tests/SKILL.md
+++ b/.opencode/skills/writing-tests/SKILL.md
@@ -125,6 +125,25 @@ mock.module('../../../src/utils/path-security', () => ({
 }));
 ```
 
+## Diagnosing Test Isolation Failures
+
+When test files pass individually but fail when run together, follow this protocol:
+
+1. **Isolate**: Run the failing file alone: `bun test <file>.test.ts --timeout 30000`
+2. **Pair**: Run it WITH its suspected polluting neighbor: `bun test <fileA>.test.ts <fileB>.test.ts`
+3. **Classify**:
+   - Both pass alone → fail together → **mock pollution** from neighbor
+   - Fails alone → **test logic bug** (not isolation issue)
+   - Passes alone + passes together but fails in full suite → **third-file pollution** (use binary search across directory)
+4. **For mock pollution**, check the neighbor for these patterns:
+   - `vi.mock()` or `mock.module()` inside `beforeEach()` (not at top level)
+   - `delete require.cache[...]` combined with re-import pattern
+   - These indicate hoist-time closure capture — see below
+5. **Specific symptom — closure capture failure**: `vi.mock()` captures closures at **hoist time** (before `beforeEach` runs). Reassigning `mockFn.mockImplementation(newFn)` in the test body does **NOT** update the hoisted closure — the mock still calls the original function.
+   - Symptom: `expect(mockFn).toHaveBeenCalledTimes(N)` fails with an unexpected count
+   - Symptom: `expect(mockFn).not.toHaveBeenCalled()` fails because the real function was called
+6. **Fix path**: Migrate the affected test file to `_internals` DI seam pattern per the `mock-to-internals-migration` skill. This eliminates both the `vi.mock()` call and the closure capture surface area.
+
 ## Two-Tier Mock Convention
 
 The codebase uses a two-tier strategy for mock isolation, plus a zero-mock testing pattern:

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.46.0",
+    version: "7.46.1",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",

--- a/docs/releases/pending/1065-skill-test-isolation-diagnosis.md
+++ b/docs/releases/pending/1065-skill-test-isolation-diagnosis.md
@@ -3,6 +3,7 @@
 ## Summary
 
 - Added **"Diagnosing Test Isolation Failures"** section to `.opencode/skills/writing-tests/SKILL.md` — a 6-step protocol for identifying mock pollution vs test logic bugs when tests pass individually but fail together
+- Added **"Anchored Content Assertions"** subsection to `.opencode/skills/writing-tests/SKILL.md` — guidance on position-aware `toContain()` checks that fail when structured sections (critic outcome mappings, classification lists) are removed, not just when words disappear from prose
 - Added **vi.mock() closure capture pitfall** to `.opencode/skills/generated/mock-to-internals-migration/SKILL.md` Common mistakes table — documents that reassigning `mockFn.mockImplementation(newFn)` in test body does NOT update hoisted closures
 
 ## User-facing changes

--- a/docs/releases/pending/1065-skill-test-isolation-diagnosis.md
+++ b/docs/releases/pending/1065-skill-test-isolation-diagnosis.md
@@ -1,0 +1,18 @@
+# `docs(skills)`: test isolation failure diagnosis protocol
+
+## Summary
+
+- Added **"Diagnosing Test Isolation Failures"** section to `.opencode/skills/writing-tests/SKILL.md` — a 6-step protocol for identifying mock pollution vs test logic bugs when tests pass individually but fail together
+- Added **vi.mock() closure capture pitfall** to `.opencode/skills/generated/mock-to-internals-migration/SKILL.md` Common mistakes table — documents that reassigning `mockFn.mockImplementation(newFn)` in test body does NOT update hoisted closures
+
+## User-facing changes
+
+None — documentation-only change to skill files. No runtime behavior changed.
+
+## Migration notes
+
+None required.
+
+## Discovery context
+
+These patterns were discovered during swarm PR review of #1064, where `semantic-diff-injection.test.ts` used `vi.mock()` + `delete require.cache` in `beforeEach`, causing 26 test regressions in `ast-diff.test.ts` when run together via Bun's shared-process hoist-time closure capture behavior.


### PR DESCRIPTION
## Summary

Additive documentation improvements to skill files based on patterns discovered during PR #1064 and #1071 review:

- **`writing-tests/SKILL.md`**: New **"Diagnosing Test Isolation Failures"** section (6-step protocol) — guides developers through isolating, pairing, classifying, and fixing mock pollution failures when tests pass individually but fail together. Includes specific symptom recognition for Bun's vi.mock() hoist-time closure capture behavior.
- **`writing-tests/SKILL.md`**: New **"Anchored Content Assertions"** subsection — guidance on position-aware `toContain()` checks that fail when structured sections (critic outcome mappings, classification lists) are removed, not just when words disappear from prose.
- **`mock-to-internals-migration/SKILL.md`**: New row in Common mistakes table — documents that `vi.mock()` captures closures at hoist time, so reassigning `mockFn.mockImplementation(newFn)` in test body does NOT update the hoisted closure.

## Changes

| File | Type | Lines |
|------|------|-------|
| `.opencode/skills/writing-tests/SKILL.md` | Additive (new sections) | +42 |
| `.opencode/skills/generated/mock-to-internals-migration/SKILL.md` | Additive (table row) | +1 |
| `docs/releases/pending/1065-skill-test-isolation-diagnosis.md` | New file | +19 |

## Invariant audit

- 1 (plugin init): not touched
- 2 (runtime portability): not touched — markdown only
- 3 (subprocesses): not touched
- 4 (.swarm containment): not touched
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched
- 7 (test writing): **touched** — this IS the test-writing skill; changes are additive documentation
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched
- 12 (release/cache): **touched** — release note fragment included

## Test plan

- [x] bunx biome check passes on all changed files
- [x] No runtime code changed — no functional tests needed
- [ ] CI quality job: pending (watch after push)