### PR TITLE
docs(swarm-pr-review): add base-branch verification and task_id uniqueness rules

### DIFF
--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -276,6 +276,11 @@ Launch all base lanes in parallel in a single message with multiple Agent tool c
 
 If the Agent tool is unavailable, simulate isolated passes. Do not let one lane's conclusions bias another lane.
 
+**task_id uniqueness for parallel dispatches:** When re-dispatching failed or re-running explorer lanes, apply these rules:
+- For Agent tools that require caller-supplied `task_id` values, every parallel explorer lane invocation and retry MUST use a unique ID across the review session, including lane and attempt suffix (e.g. `pr_review_explore_lane1_attempt2`). Never reuse a prior `task_id` unless intentionally resuming that exact lane.
+- If the runtime auto-generates `task_id` values (resume mode), omit the `task_id` parameter rather than fabricating one.
+- Do not use the same `task_id` across concurrent lane dispatches — schema validation rejects duplicate `task_id` values.
+
 Explorers optimize for recall. Over-reporting is expected. Explorers produce candidates only.
 
 | Lane | Focus | Required checks |
@@ -803,6 +808,8 @@ Context pack summary:
 - impact cone: ...
 - deterministic signals: ...
 - relevant Swarm artifacts / knowledge: ...
+- base_ref: <commit SHA of base branch>
+- head_ref: <commit SHA of PR head branch>
 
 Candidates:
 - ...
@@ -811,6 +818,8 @@ For each candidate, return:
 [REVIEWED] | candidate_id | CONFIRMED/DISPROVED/UNVERIFIED/PRE_EXISTING | evidence_type | final_severity | introduced_by_pr | file:line | rationale | falsification_probe | reviewer_id
 
 You must check caller context, reachability, schema/middleware/framework mitigations, state-machine constraints, test coverage, PR-introducedness, and severity.
+
+IMPORTANT: If a finding claims behavior is "new" or "introduced by the PR", you MUST read the equivalent code on the base branch (git show <base_ref>:<file>) to verify it was not present before. A reviewer claim of "this is new" is invalid without base-branch evidence. Do not compare the new code to an idealized baseline — compare it to what actually existed on the base branch at the time of the PR.
 ```
 
 ---

--- a/docs/releases/pending/swarm-pr-review-prior-code-task-id-docs.md
+++ b/docs/releases/pending/swarm-pr-review-prior-code-task-id-docs.md
@@ -1,0 +1,13 @@
+## What changed
+- Added explicit `base_ref`/`head_ref` fields to the reviewer context pack so base-branch verification is possible
+- Added IMPORTANT note requiring reviewers to verify "new behavior" claims against actual base branch code, not an idealized baseline
+- Added task_id uniqueness rules for parallel explorer lane re-dispatch to avoid schema validation errors on retry
+
+## Why
+Reviewer findings of "this is new" or "this was introduced by the PR" were being accepted without base-branch evidence. F-1081-01 (cachedShownIds budget gap) was misclassified as MEDIUM before critic correction — both indicate the base-branch verification step was missing from the review template. Additionally, parallel lane re-dispatch during PR #1081 review triggered schema errors due to reused task_id values.
+
+## Migration
+No migration required. Advisory-only skill changes.
+
+## Caveats
+None.


### PR DESCRIPTION
﻿## Summary
- swarm-pr-review/SKILL.md: Added ase_ref/head_ref to the reviewer context pack so base-branch code can be read during verification
- Added IMPORTANT note requiring reviewers to verify "new behavior" claims against actual base branch code, not an idealized baseline
- Added task_id uniqueness rules for parallel explorer lane re-dispatch to prevent schema validation errors on retry

These changes address two findings from PR #1081 review: (1) F-1081-01 severity inflation where the reviewer accepted "new behavior" claims without base-branch evidence, and (2) Lane 6 schema errors from reused task_id values during parallel lane re-dispatch.

## Invariant audit
- 1 (plugin init): not touched
- 2 (runtime portability): not touched
- 3 (subprocesses): not touched
- 4 (.swarm containment): not touched
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched
- 7 (test writing): not touched
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched — skill guidance only, no agent/config changes
- 12 (release/cache): not touched

## Test plan
- [ ] Reviewer confirmed all 3 additions match approved specification (done inline prior to commit)
- [ ] No source files changed — advisory-only skill guidance
