### PR TITLE
ci(workflows): repin actions to node.js 24 release commits

### DIFF
--- a/.github/workflows/check-duplicates.yml
+++ b/.github/workflows/check-duplicates.yml
@@ -11,7 +11,7 @@ jobs:
   check-duplicates:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const pulls = await github.rest.pulls.list({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -54,13 +54,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
         id: cache-bun
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -587,12 +587,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -627,12 +627,12 @@ jobs:
     needs: quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -689,15 +689,15 @@ jobs:
     needs: quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.13"
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "22"
       - name: Cache bun dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -713,12 +713,12 @@ jobs:
     needs: quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -733,17 +733,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: "8.2"
           tools: composer
           coverage: none
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -767,12 +767,12 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
       - name: Cache cargo
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry
@@ -805,12 +805,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -14,7 +14,7 @@ jobs:
       releases_created: ${{ steps.rp.outputs.releases_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: rp
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -29,21 +29,21 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.13"
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Cache bun dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
@@ -106,7 +106,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
 

--- a/.opencode/contributing/SKILL.md
+++ b/.opencode/contributing/SKILL.md
@@ -138,7 +138,7 @@ Never replace the release PR body, create tags/releases manually, or edit these 
 
 All `uses:` in `.github/workflows/` must be pinned to full 40-char SHA with version comment:
 ```yaml
-- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+- uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 ```
 
 Find SHA: `gh api repos/{owner}/{repo}/git/ref/tags/{tag} --jq '.object.sha'`

--- a/contributing.md
+++ b/contributing.md
@@ -291,7 +291,7 @@ If you add or modify a workflow file in `.github/workflows/`, every `uses:` refe
 
 ```yaml
 # Correct
-- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+- uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
 # Wrong — will fail security tests
 - uses: actions/checkout@v4

--- a/docs/releases/pending/issue-1074-node24-actions.md
+++ b/docs/releases/pending/issue-1074-node24-actions.md
@@ -1,0 +1,41 @@
+# CI: Migrate pinned GitHub Actions to Node.js 24 (Issue #1074)
+
+## What changed
+
+- **Repinned all Node.js 20 GitHub Actions to Node.js 24 release commits**, ahead of the
+  GitHub runner cutoff (Node.js 24 forced from 2026-06-02; Node.js 20 support ends
+  2026-09-16). Each new pin was verified against the GitHub API to resolve to the stated
+  tag and a `runs.using: node24` runtime.
+  - `actions/checkout` → `v5.0.1` (`93cb6efe…`)
+  - `oven-sh/setup-bun` → `v2.2.0` (`0c5077e5…`)
+  - `actions/cache` → `v5.0.5` (`27d5ce7f…`)
+  - `actions/setup-node` → `v5.0.0` (`a0853c24…`)
+  - `googleapis/release-please-action` → `v5.0.0` (`45996ed1…`)
+  - `actions/github-script` → `v8` (`ed597411…`)
+- Updated the `actions/checkout` SHA-pinning examples in `contributing.md` and
+  `.opencode/contributing/SKILL.md` to match.
+
+## Why
+
+Steps pinned to Node.js 20 action builds emit deprecation annotations now and will fail
+after the cutoff. `checkout`, `cache`, and `setup-node` have no Node.js 24 build in their
+prior major, so a major version bump was required; the lowest Node.js 24 major was chosen
+to minimize behavioral change. All runners are GitHub-hosted `*-latest`, satisfying the
+runner ≥ v2.327.1 minimum that `checkout@v5`/`cache@v5` require.
+
+## Migration
+
+No migration required. `setup-node@v5`'s opt-in package-manager auto-cache does not engage
+(no `packageManager` field in `package.json`; only `bun.lock` present; no `cache:` inputs).
+
+## Breaking changes
+
+None for this repository. The upstream major bumps (`checkout`, `cache`, `setup-node`,
+`release-please-action`, `github-script`) carry no input/output changes that this repo's
+workflows depend on.
+
+## Known caveats
+
+- `shivammathur/setup-php` was already on Node.js 24 (pinned to `2.37.0`), so it was left
+  unchanged despite being listed in the issue.
+- `concurrency.cancel-in-progress: false` in `ci.yml` is preserved.


### PR DESCRIPTION
Closes #1074

## Summary
Migrate every Node.js 20 pinned GitHub Action to a verified Node.js 24 release commit, ahead of the runner cutoff (Node 24 forced 2026-06-02; Node 20 EOL 2026-09-16). Each new SHA was resolved via the GitHub API to confirm it maps to the stated tag **and** an `action.yml` `runs.using: node24` runtime — independently re-verified by a second reviewer pass.

| Action | Was (Node 20) | Now (Node 24) | Occurrences |
|---|---|---|---|
| actions/checkout | `34e1148…` v4.3.1 | `93cb6efe…` **v5.0.1** | 12 |
| oven-sh/setup-bun | `3d26778…` v2.0.x | `0c5077e5…` **v2.2.0** | 9 |
| actions/cache | `0057852…` v4.3.0 | `27d5ce7f…` **v5.0.5** | 10 |
| actions/setup-node | `49933ea…` v4.4.0 | `a0853c24…` **v5.0.0** | 2 |
| googleapis/release-please-action | `16a9c90…` v4.4.0 | `45996ed1…` **v5.0.0** | 1 |
| actions/github-script | `f28e40c…` v7.1.0 | `ed597411…` **v8** | 1 |

- **`shivammathur/setup-php` was already Node 24** (pinned to `2.37.0` / `accd6127…`) — the issue's claim that it was Node 20 was stale, so it is left unchanged.
- Version policy: lowest Node 24 major (minimizes behavioral change). All runners are GitHub-hosted `*-latest`, satisfying the runner ≥ v2.327.1 minimum `checkout@v5`/`cache@v5` require.
- Breaking-change review: `setup-node@v5` auto-cache does **not** engage (no `packageManager` field; only `bun.lock`; no `cache:` inputs). `release-please@v5` and `github-script@v8` release notes list **only** the node24 bump — no input/output/API changes this repo depends on.
- Synced the `actions/checkout` SHA-pinning example in `contributing.md` and `.opencode/contributing/SKILL.md`.
- `concurrency.cancel-in-progress: false` in `ci.yml` is preserved.

## Invariant audit
- 1 (plugin init): not touched — no `src/index.ts` / init-path change.
- 2 (runtime portability): not touched — no bundle/`dist/`/package-export change (0 `src`/`dist` files in diff).
- 3 (subprocesses): not touched — no source spawn code changed.
- 4 (.swarm containment): not touched — no tool/cwd code.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — no `test_runner` used; validation via shell + focused bun test.
- 7 (test writing): not touched — no test files changed.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched.
- 12 (release/cache): **touched (release hygiene + workflow pinning)** — added `docs/releases/pending/issue-1074-node24-actions.md`; `package.json`/`CHANGELOG.md`/`.release-please-manifest.json` untouched. All workflow `uses:` remain pinned to a full 40-char SHA + version comment (verified by `tests/security/ci-workflow-security.test.ts` and grep counts).

## Test plan
- [x] All 6 new SHAs resolve to claimed tag + `runs.using: node24` (GitHub API, main + independent critic).
- [x] `tests/security/ci-workflow-security.test.ts` — 7 pass / 0 fail (SHA-pinning + permissions).
- [x] All 5 workflow files parse as valid YAML (js-yaml).
- [x] `bun run typecheck` — clean (exit 0). `bunx biome ci .` — exit 0 (2 pre-existing `any` warnings, unrelated).
- [x] Occurrence counts post-edit match plan; no stale Node 20 SHAs remain; `cancel-in-progress: false` intact.
- [x] Scoped narrowing justified: 0 `src/`/`dist/`/`tests/`/lockfile/version files changed → unit/integration/smoke/dist-check structurally unaffected by this CI-YAML+docs change.
- [ ] **Definitive (this PR's CI run):** quality, unit ×3 OS, integration, dist-check, package-check, security, php-validation, rust-sandbox-runner, smoke ×3 OS all green and Node 20 deprecation annotations gone.

## Pre-existing (not introduced here)
`scripts/check-invariants.sh` reports 295 mock-allowlist violations in unrelated test files — **identical count with and without this change** (stash-verified), none referencing changed files. Appears to be a local Windows path-normalization artifact (`main` releases cleanly on Linux CI). Out of scope for #1074.
