### PR TITLE
feat(tools): add native apply_patch tool with scope-guard array-aware path extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Most AI coding tools let one model write code and ask that same model whether th
 - 🔁 **Resumable sessions** — all state saved to `.swarm/`; pick up any project any day
 - 🌐 **20 languages** — TypeScript, Python, Go, Rust, Java, Kotlin, C/C++, C#, Ruby, Swift, Dart, PHP, JavaScript, CSS, Bash, PowerShell, INI, Regex (extending: see [docs/adding-a-language.md](docs/adding-a-language.md))
 - 🛡️ **Built-in security** — SAST, secrets scanning, dependency audit per task
+- 🔒 **Scope enforcement** — Validates write targets against declared scope with cross-process persistence, TTL expiry, and scope-aware destructive command blocking. **Handles both single-string and array-based path arguments** (`files[]`, `paths[]`, `targetFiles[]`) to prevent scope bypass via multi-file tool calls.
 - 📝 **Shell write detection** — Static analysis of POSIX/PowerShell/cmd commands to detect file writes (redirects, builtins, in-place editors, network downloads, archive extraction, git destructive ops) before execution
-- 🔒 **Scope enforcement** — Validates write targets against declared scope with cross-process persistence, TTL expiry, and scope-aware destructive command blocking
 - 🆓 **Free tier** — works with OpenCode Zen's free model roster
 - ⚙️ **Fully configurable** — override any agent's model, disable agents, tune guardrails
 

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.49.0",
+    version: "7.49.1",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",
@@ -16987,6 +16987,10 @@ var init_tool_metadata = __esm(() => {
     lean_turbo_status: {
       description: "returns Lean Turbo configuration and active status for the current session",
       agents: ["architect"]
+    },
+    apply_patch: {
+      description: "Apply a unified diff patch to workspace files with exact context matching, atomic writes, and path validation",
+      agents: ["coder"]
     }
   };
   TOOL_NAMES = Object.keys(TOOL_METADATA);

--- a/dist/hooks/scope-guard.d.ts
+++ b/dist/hooks/scope-guard.d.ts
@@ -41,3 +41,27 @@ export declare function createScopeGuardHook(config: Partial<ScopeGuardConfig>, 
  * @returns true if the file is within scope, false otherwise
  */
 export declare function isFileInScope(filePath: string, scopeEntries: string[], directory?: string): boolean;
+/**
+ * Sanitize a raw file path string to prevent log injection and null-byte attacks.
+ * Strips control characters (NUL, CR, LF, TAB, BS, FF, VT), ESC (ANSI escape prefix),
+ * and remaining ANSI CSI sequences.
+ *
+ * Null bytes are removed rather than replaced because Node.js `path.resolve()`
+ * throws `ERR_INVALID_ARG_VALUE` on `\0`, which would bypass the intended
+ * SCOPE VIOLATION error path with a raw TypeError.
+ *
+ * Extracted from the original inline sanitization in the scope guard
+ * to support reuse across single-path and multi-path code paths.
+ *
+ * @param raw - The unsanitized file path string
+ * @returns The sanitized file path string safe for logging and scope matching
+ */
+declare function sanitizePath(raw: string): string;
+/**
+ * Internal implementation details exposed for unit testing.
+ * DO NOT use these in production code.
+ */
+export declare const _internals: {
+    sanitizePath: typeof sanitizePath;
+};
+export {};

--- a/dist/hooks/scope-guard.d.ts
+++ b/dist/hooks/scope-guard.d.ts
@@ -43,8 +43,8 @@ export declare function createScopeGuardHook(config: Partial<ScopeGuardConfig>, 
 export declare function isFileInScope(filePath: string, scopeEntries: string[], directory?: string): boolean;
 /**
  * Sanitize a raw file path string to prevent log injection and null-byte attacks.
- * Strips control characters (NUL, CR, LF, TAB, BS, FF, VT), ESC (ANSI escape prefix),
- * and remaining ANSI CSI sequences.
+ * Strips C0 control characters (NUL, CR, LF, TAB, BS, FF, VT), ESC (ANSI escape prefix),
+ * C1 control characters (0x80-0x9F), and remaining ANSI CSI sequences.
  *
  * Null bytes are removed rather than replaced because Node.js `path.resolve()`
  * throws `ERR_INVALID_ARG_VALUE` on `\0`, which would bypass the intended

--- a/dist/hooks/scope-guard.d.ts
+++ b/dist/hooks/scope-guard.d.ts
@@ -43,12 +43,12 @@ export declare function createScopeGuardHook(config: Partial<ScopeGuardConfig>, 
 export declare function isFileInScope(filePath: string, scopeEntries: string[], directory?: string): boolean;
 /**
  * Sanitize a raw file path string to prevent log injection and null-byte attacks.
- * Strips C0 control characters (NUL, CR, LF, TAB, BS, FF, VT), ESC (ANSI escape prefix),
- * C1 control characters (0x80-0x9F), and remaining ANSI CSI sequences.
+ * Replaces C0 control characters (0x00-0x1F), DEL (0x7F), C1 control characters
+ * (0x80-0x9F), and strips remaining ANSI CSI sequences.
  *
- * Null bytes are removed rather than replaced because Node.js `path.resolve()`
- * throws `ERR_INVALID_ARG_VALUE` on `\0`, which would bypass the intended
- * SCOPE VIOLATION error path with a raw TypeError.
+ * All matched control characters are replaced with underscores rather than removed,
+ * so that the resulting string can still be passed to `path.resolve()` without
+ * triggering `ERR_INVALID_ARG_VALUE` on embedded null bytes.
  *
  * Extracted from the original inline sanitization in the scope guard
  * to support reuse across single-path and multi-path code paths.

--- a/dist/tools/apply-patch.d.ts
+++ b/dist/tools/apply-patch.d.ts
@@ -1,0 +1,48 @@
+/**
+ * apply-patch — Native Swarm tool for applying unified diffs in-process.
+ * Parses standard unified diff format, validates paths against workspace
+ * boundaries, matches hunk context exactly, and writes atomically.
+ *
+ * FR-001 through FR-014, SR-002 through SR-005.
+ * Pure TypeScript, no shell/git/external binaries, standard node:fs sync I/O.
+ */
+import type { ToolDefinition } from '@opencode-ai/plugin/tool';
+/** Per-file error detail in the structured output. */
+export interface ApplyPatchFileError {
+    hunkIndex: number;
+    type: 'context-mismatch' | 'file-not-found' | 'file-unchanged' | 'create-not-allowed' | 'delete-not-allowed' | 'binary-rejected' | 'rename-rejected';
+    message: string;
+    expected?: string;
+    actual?: string;
+    line?: number;
+}
+/** Per-file result in the structured output. */
+export interface ApplyPatchFileResult {
+    file: string;
+    status: 'applied' | 'no-changes' | 'created' | 'error';
+    hunks: number;
+    hunksApplied: number;
+    hunksFailed: number;
+    errors?: ApplyPatchFileError[];
+}
+/** Structured JSON result returned by the tool. */
+export interface ApplyPatchResult {
+    success: boolean;
+    dryRun?: boolean;
+    files: ApplyPatchFileResult[];
+    summary: {
+        totalFiles: number;
+        applied: number;
+        failed: number;
+        totalHunks: number;
+    };
+}
+/** Arguments accepted by the apply_patch tool. */
+export interface ApplyPatchArgs {
+    patch: string;
+    files: string[];
+    dryRun?: boolean;
+    allowCreates?: boolean;
+    allowDeletes?: boolean;
+}
+export declare const applyPatch: ToolDefinition;

--- a/dist/tools/index.d.ts
+++ b/dist/tools/index.d.ts
@@ -1,3 +1,4 @@
+export { applyPatch } from './apply-patch';
 export { batch_symbols } from './batch-symbols';
 export { build_check } from './build-check';
 export { check_gate_status } from './check-gate-status';

--- a/dist/tools/manifest.d.ts
+++ b/dist/tools/manifest.d.ts
@@ -106,4 +106,5 @@ export declare const TOOL_MANIFEST: {
     lean_turbo_review: () => ToolDefinition;
     lean_turbo_run_phase: () => ToolDefinition;
     lean_turbo_status: () => ToolDefinition;
+    apply_patch: () => ToolDefinition;
 };

--- a/dist/tools/tool-metadata.d.ts
+++ b/dist/tools/tool-metadata.d.ts
@@ -355,6 +355,10 @@ export declare const TOOL_METADATA: {
         description: string;
         agents: "architect"[];
     };
+    apply_patch: {
+        description: string;
+        agents: "coder"[];
+    };
 };
 /** Union type of all valid tool names (the metadata keys). */
 export type ToolName = keyof typeof TOOL_METADATA;

--- a/docs/releases/pending/native-apply-patch-tool.md
+++ b/docs/releases/pending/native-apply-patch-tool.md
@@ -28,5 +28,4 @@ No migration required. The tool is automatically available to `coder` agents via
 
 ## Known caveats
 
-- 3 edge-case tests are skipped: CRLF line ending handling, files without trailing newlines, and empty patch format. These represent minor implementation gaps that do not affect core functionality.
 - Line coverage is 69.87% — error recovery paths and some edge cases are untested.

--- a/docs/releases/pending/native-apply-patch-tool.md
+++ b/docs/releases/pending/native-apply-patch-tool.md
@@ -1,0 +1,32 @@
+# Native apply_patch tool
+
+## What changed
+
+- Added a native `apply_patch` Swarm tool that parses and applies unified diffs in-process under Swarm's safety model
+- Extended `scope-guard` to extract paths from array-based tool arguments (`files[]`, `paths[]`, `targetFiles[]`)
+
+The `apply_patch` tool replaces shell-based `git apply` calls for swarm agents with a pure TypeScript implementation that:
+- Parses unified diffs (`---`/`+++` headers, `@@` hunk headers, context/addition/removal lines)
+- Rejects binary, rename, and copy patches
+- Enforces workspace boundaries with canonical symlink protection (`realpathSync`)
+- Blocks access to `.git/` and `.swarm/` directories (both lexical and canonical paths)
+- Uses exact context matching with accumulated delta tracking for multi-hunk patches
+- Performs per-file atomic writes via temp+rename
+- Supports dry-run mode, `allowCreates` gate (default false), and `allowDeletes` gate (default false)
+- Returns structured JSON results with per-file status and diagnostics
+- Preserves CRLF line endings and trailing newlines
+
+The scope-guard enhancement prevents scope bypass via multi-file tool calls by extracting paths from array arguments in addition to single-string arguments.
+
+## Why
+
+Issue #1103: Swarm agents needed a safe, in-process patch application tool that works under Swarm's safety model without shell access or external binaries. The scope-guard had a first-match-wins gap where array-based path arguments (like `apply_patch`'s `files[]`) could bypass scope enforcement.
+
+## Migration
+
+No migration required. The tool is automatically available to `coder` agents via the manifest registration. Existing tools and agents are unaffected.
+
+## Known caveats
+
+- 3 edge-case tests are skipped: CRLF line ending handling, files without trailing newlines, and empty patch format. These represent minor implementation gaps that do not affect core functionality.
+- Line coverage is 69.87% — error recovery paths and some edge cases are untested.

--- a/docs/releases/pending/scope-guard-array-path-extraction.md
+++ b/docs/releases/pending/scope-guard-array-path-extraction.md
@@ -1,0 +1,17 @@
+## scope-guard: array-path extraction and security hardening
+
+Scope guard now extracts paths from both single-string and array-based tool arguments, closing a scope bypass vulnerability where tools passing `files[]`, `paths[]`, or `targetFiles[]` could write outside declared scope.
+
+### Changed
+
+- **`sanitizePath`** — now strips the full C0 control-character range (`0x00–0x1F`) and DEL (`0x7F`), ESC (`0x1B`), and ANSI CSI sequences. Null bytes are removed rather than replaced to prevent `path.resolve()` from throwing `ERR_INVALID_ARG_VALUE` and bypassing the SCOPE VIOLATION error path.
+- **`isFileInScope`** — filters empty-string scope entries before checking, preventing `path.resolve(dir, '')` from resolving to the project root and silently allowing all files.
+- **Path extraction** — collects from single-string keys (`path`, `filePath`, `file`) AND array keys (`files`, `paths`, `targetFiles`). Validates every collected path rather than stopping at the first match.
+
+### Why
+
+A tool call that passes multiple target paths via an array argument could write to files outside the declared scope if only the first path was checked. The collect-all-then-validate pattern ensures every path in the array is validated against the declared scope.
+
+### Testing
+
+78 tests across 6 test files pass, covering single-string paths, array paths, empty-string filtering, and control-character stripping.

--- a/docs/releases/pending/scope-guard-array-path-extraction.md
+++ b/docs/releases/pending/scope-guard-array-path-extraction.md
@@ -4,7 +4,7 @@ Scope guard now extracts paths from both single-string and array-based tool argu
 
 ### Changed
 
-- **`sanitizePath`** — now strips the full C0 control-character range (`0x00–0x1F`) and DEL (`0x7F`), ESC (`0x1B`), and ANSI CSI sequences. Null bytes are removed rather than replaced to prevent `path.resolve()` from throwing `ERR_INVALID_ARG_VALUE` and bypassing the SCOPE VIOLATION error path.
+- **`sanitizePath`** — now replaces the full C0 control-character range (`0x00–0x1F`), DEL (`0x7F`), ESC (`0x1B`), C1 controls (`0x80–0x9F`), and ANSI CSI sequences with underscores. This sanitization prevents `path.resolve()` from throwing `ERR_INVALID_ARG_VALUE` on embedded null bytes and bypassing the SCOPE VIOLATION error path.
 - **`isFileInScope`** — filters empty-string scope entries before checking, preventing `path.resolve(dir, '')` from resolving to the project root and silently allowing all files.
 - **Path extraction** — collects from single-string keys (`path`, `filePath`, `file`) AND array keys (`files`, `paths`, `targetFiles`). Validates every collected path rather than stopping at the first match.
 

--- a/src/hooks/scope-guard-array-paths.test.ts
+++ b/src/hooks/scope-guard-array-paths.test.ts
@@ -1,0 +1,730 @@
+/**
+ * scope-guard-array-paths.test.ts
+ *
+ * Tests for array-path parameter handling in scope-guard hook (Task 1.1 apply-patch feature):
+ * 1. Single-string path extraction still works (existing behavior)
+ * 2. Array-path extraction works for files[], paths[], targetFiles[]
+ * 3. Mixed args (both single and array) are handled correctly
+ * 4. Empty arrays are skipped (no false violations)
+ * 5. Non-string elements in arrays are skipped
+ * 6. Scope violation is reported for out-of-scope paths in arrays
+ * 7. In-scope paths in arrays pass without violation
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { ensureAgentSession, resetSwarmState, swarmState } from '../state';
+import { createScopeGuardHook } from './scope-guard';
+
+const SESSION_ID = 'test-session-array-paths';
+const WORKSPACE_DIR = '/workspace';
+
+describe('scope-guard array-path parameter handling', () => {
+	beforeEach(() => {
+		resetSwarmState();
+	});
+
+	afterEach(() => {
+		resetSwarmState();
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 1: Single-string path extraction still works
+	// ─────────────────────────────────────────────────────────────
+	describe('Scenario 1: Single-string path extraction (existing behavior)', () => {
+		it('1a. path parameter triggers scope check', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Outside scope — should throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'edit', sessionID: SESSION_ID, callID: 'call-1' },
+					{ args: { path: '/workspace/src/tools/out.ts' } },
+				);
+			}).toThrow(/SCOPE VIOLATION/);
+		});
+
+		it('1b. filePath parameter triggers scope check', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Outside scope — should throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'edit', sessionID: SESSION_ID, callID: 'call-1' },
+					{ args: { filePath: '/workspace/src/tools/out.ts' } },
+				);
+			}).toThrow(/SCOPE VIOLATION/);
+		});
+
+		it('1c. file parameter triggers scope check', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Outside scope — should throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'edit', sessionID: SESSION_ID, callID: 'call-1' },
+					{ args: { file: '/workspace/src/tools/out.ts' } },
+				);
+			}).toThrow(/SCOPE VIOLATION/);
+		});
+
+		it('1d. Single string path inside scope does NOT throw', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Inside scope — should NOT throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'edit', sessionID: SESSION_ID, callID: 'call-1' },
+					{ args: { path: '/workspace/src/hooks/scope-guard.ts' } },
+				);
+			}).not.toThrow();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 2: Array-path extraction works for files[], paths[], targetFiles[]
+	// ─────────────────────────────────────────────────────────────
+	describe('Scenario 2: Array-path extraction for files[], paths[], targetFiles[]', () => {
+		it('2a. files[] array triggers scope check for each element', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Second file is outside scope — should throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [
+								'/workspace/src/hooks/scope-guard.ts', // in scope
+								'/workspace/src/tools/out.ts', // out of scope
+							],
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION.*src\/tools\/out\.ts/);
+		});
+
+		it('2b. paths[] array triggers scope check for each element', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Second file is outside scope — should throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							paths: [
+								'/workspace/src/hooks/scope-guard.ts', // in scope
+								'/workspace/src/tools/out.ts', // out of scope
+							],
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION.*src\/tools\/out\.ts/);
+		});
+
+		it('2c. targetFiles[] array triggers scope check for each element', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Second file is outside scope — should throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							targetFiles: [
+								'/workspace/src/hooks/scope-guard.ts', // in scope
+								'/workspace/src/tools/out.ts', // out of scope
+							],
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION.*src\/tools\/out\.ts/);
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 3: Mixed args (both single and array) — single takes precedence
+	// ─────────────────────────────────────────────────────────────
+	describe('Scenario 3: Mixed args (both single string and array)', () => {
+		it('3. Single-string path takes precedence over array when both present', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// path is outside scope; array has only in-scope files
+			// Since single-string path (path=) is checked first, should throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							path: '/workspace/src/tools/out.ts', // out of scope
+							files: [
+								'/workspace/src/hooks/scope-guard.ts', // in scope
+							],
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION.*src\/tools\/out\.ts/);
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 4: Empty arrays are skipped (no false violations)
+	// ─────────────────────────────────────────────────────────────
+	describe('Scenario 4: Empty arrays are skipped (no false violations)', () => {
+		it('4a. Empty files[] array does not throw', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Empty array — should return early, NOT throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{ args: { files: [] } },
+				);
+			}).not.toThrow();
+		});
+
+		it('4b. Empty paths[] array does not throw', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Empty array — should return early, NOT throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{ args: { paths: [] } },
+				);
+			}).not.toThrow();
+		});
+
+		it('4c. Empty targetFiles[] array does not throw', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Empty array — should return early, NOT throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{ args: { targetFiles: [] } },
+				);
+			}).not.toThrow();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 5: Non-string elements in arrays are skipped
+	// ─────────────────────────────────────────────────────────────
+	describe('Scenario 5: Non-string elements in arrays are skipped', () => {
+		it('5a. null elements in array are skipped', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Only valid string path is in scope — should NOT throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [
+								null,
+								'/workspace/src/hooks/scope-guard.ts', // in scope
+								null,
+							],
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+
+		it('5b. undefined elements in array are skipped', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Only valid string path is in scope — should NOT throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [
+								undefined,
+								'/workspace/src/hooks/scope-guard.ts', // in scope
+								undefined,
+							],
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+
+		it('5c. number elements in array are skipped', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Only valid string path is in scope — should NOT throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [
+								123,
+								'/workspace/src/hooks/scope-guard.ts', // in scope
+								456,
+							],
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+
+		it('5d. object elements in array are skipped', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Only valid string path is in scope — should NOT throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [
+								{ path: '/workspace/src/hooks/scope-guard.ts' },
+								'/workspace/src/hooks/scope-guard.ts', // valid string
+							],
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+
+		it('5e. empty string elements in array are skipped', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Only valid string path is in scope — should NOT throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [
+								'',
+								'/workspace/src/hooks/scope-guard.ts', // in scope
+								'',
+							],
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 6: Scope violation reported for out-of-scope paths in arrays
+	// ─────────────────────────────────────────────────────────────
+	describe('Scenario 6: Scope violation reported for out-of-scope paths in arrays', () => {
+		it('6a. First path out-of-scope triggers violation', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [
+								'/workspace/src/tools/first-out.ts', // out of scope
+								'/workspace/src/hooks/scope-guard.ts', // in scope
+							],
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION.*src\/tools\/first-out\.ts/);
+		});
+
+		it('6b. Middle path out-of-scope triggers violation', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [
+								'/workspace/src/hooks/scope-guard.ts', // in scope
+								'/workspace/src/tools/middle-out.ts', // out of scope
+								'/workspace/src/hooks/another.ts', // in scope
+							],
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION.*src\/tools\/middle-out\.ts/);
+		});
+
+		it('6c. Last path out-of-scope triggers violation', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [
+								'/workspace/src/hooks/scope-guard.ts', // in scope
+								'/workspace/src/hooks/another.ts', // in scope
+								'/workspace/src/tools/last-out.ts', // out of scope
+							],
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION.*src\/tools\/last-out\.ts/);
+		});
+
+		it('6d. Multiple out-of-scope paths — first violation thrown', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [
+								'/workspace/src/tools/first-out.ts', // out of scope
+								'/workspace/src/tools/second-out.ts', // out of scope
+							],
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION.*src\/tools\/first-out\.ts/);
+		});
+
+		it('6e. Out-of-scope path with malicious characters still sanitized', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			let advisoryMessage = '';
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				(_sessionId, message) => {
+					advisoryMessage = message;
+				},
+			);
+
+			const maliciousPath =
+				'/workspace/src/tools/malicious.ts\r\nMalicious content';
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [maliciousPath],
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION/);
+
+			// Sanitization should have replaced \r\n with underscore
+			expect(advisoryMessage).not.toContain('\r');
+			expect(advisoryMessage).not.toContain('\n');
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 7: In-scope paths in arrays pass without violation
+	// ─────────────────────────────────────────────────────────────
+	describe('Scenario 7: In-scope paths in arrays pass without violation', () => {
+		it('7a. All in-scope files[] does not throw', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = [
+				'/workspace/src/hooks',
+				'/workspace/src/utils',
+			];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [
+								'/workspace/src/hooks/scope-guard.ts',
+								'/workspace/src/utils/helper.ts',
+							],
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+
+		it('7b. All in-scope paths[] does not throw', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = [
+				'/workspace/src/hooks',
+				'/workspace/src/utils',
+			];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							paths: [
+								'/workspace/src/hooks/scope-guard.ts',
+								'/workspace/src/utils/helper.ts',
+							],
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+
+		it('7c. All in-scope targetFiles[] does not throw', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = [
+				'/workspace/src/hooks',
+				'/workspace/src/utils',
+			];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							targetFiles: [
+								'/workspace/src/hooks/scope-guard.ts',
+								'/workspace/src/utils/helper.ts',
+							],
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+
+		it('7d. Mixed in-scope and out-of-scope — throws on out-of-scope', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Second path is out of scope — should throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [
+								'/workspace/src/hooks/scope-guard.ts', // in scope
+								'/workspace/src/utils/helper.ts', // out of scope
+							],
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION.*src\/utils\/helper\.ts/);
+		});
+
+		it('7e. Relative paths in array resolve against workspace directory', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Relative path 'src/hooks/scope-guard.ts' resolves to '/workspace/src/hooks/scope-guard.ts'
+			// which is inside scope — should NOT throw
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: ['src/hooks/scope-guard.ts'],
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+	});
+});

--- a/src/hooks/scope-guard-array-paths.test.ts
+++ b/src/hooks/scope-guard-array-paths.test.ts
@@ -297,6 +297,87 @@ describe('scope-guard array-path parameter handling', () => {
 	});
 
 	// ─────────────────────────────────────────────────────────────
+	// Scenario 8: Empty array bypass — hasArrayKeys prevents early return
+	// ─────────────────────────────────────────────────────────────
+	describe('Scenario 8: Empty array bypass protection (F-001)', () => {
+		it('8a. Empty files[] does not bypass scope check for co-present single-path arg', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// Empty files[] + out-of-scope single path — should still detect violation
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							files: [],
+							path: '/workspace/src/tools/out.ts',
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION.*src\/tools\/out\.ts/);
+		});
+
+		it('8b. Empty files[] alone does not throw but does not bypass guard', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			let advisoryCalled = false;
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {
+					advisoryCalled = true;
+				},
+			);
+
+			// Empty files[] with declared scope — should not throw (no paths to check)
+			// but should NOT silently bypass the guard (early return at line 118)
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{ args: { files: [] } },
+				);
+			}).not.toThrow();
+
+			// Verify no false violation was raised (field may exist as false from init)
+			expect(session.scopeViolationDetected).not.toBe(true);
+		});
+
+		it('8c. Empty paths[] does not bypass scope check for co-present single-path arg', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{ tool: 'apply_patch', sessionID: SESSION_ID, callID: 'call-1' },
+					{
+						args: {
+							paths: [],
+							filePath: '/workspace/src/tools/out.ts',
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION.*src\/tools\/out\.ts/);
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────
 	// Scenario 5: Non-string elements in arrays are skipped
 	// ─────────────────────────────────────────────────────────────
 	describe('Scenario 5: Non-string elements in arrays are skipped', () => {

--- a/src/hooks/scope-guard-mixed-args.test.ts
+++ b/src/hooks/scope-guard-mixed-args.test.ts
@@ -1,0 +1,432 @@
+/**
+ * scope-guard-mixed-args.test.ts
+ *
+ * Regression tests for the first-match-wins bypass fix in scope-guard hook.
+ *
+ * PRIOR BUG (F#): When both a single-string path key (path/filePath/file) AND
+ * an array key (files/paths/targetFiles) were present in args, only the single-string
+ * path was validated and the array was silently ignored. An attacker could bypass
+ * scope by putting an in-scope path in `path` and out-of-scope paths in `files[]`.
+ *
+ * FIX: Both single-string AND array paths are now collected into candidatePaths and
+ * ALL are validated. The first violation throws, blocking the tool call.
+ *
+ * These tests verify the fix covers ALL 6 bypass scenarios:
+ * 1. Mixed args: path in-scope + files[] out-of-scope → VIOLATION
+ * 2. Mixed args: filePath out-of-scope + paths[] in-scope → VIOLATION
+ * 3. Multiple arrays: files[] in-scope + targetFiles[] out-of-scope → VIOLATION
+ * 4. All paths in-scope across all keys → no violation
+ * 5. Empty arrays alongside valid single path → no false violation
+ * 6. Non-string array elements are safely skipped
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { ensureAgentSession, resetSwarmState, swarmState } from '../state';
+import { createScopeGuardHook } from './scope-guard';
+
+const SESSION_ID = 'test-session-mixed-args';
+const WORKSPACE_DIR = '/workspace';
+
+describe('scope-guard mixed-args bypass — regression: first-match-wins bypass (F#)', () => {
+	beforeEach(() => {
+		resetSwarmState();
+	});
+
+	afterEach(() => {
+		resetSwarmState();
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Verification 1: Mixed args — path IN-SCOPE + files[] OUT-OF-SCOPE
+	// This is the PRIMARY bypass: attacker uses in-scope path + out-of-scope array
+	// ─────────────────────────────────────────────────────────────
+	it('1. Mixed args: path in-scope + files[] out-of-scope → SCOPE VIOLATION is still reported', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		// Scope is limited to src/hooks
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// path is IN-scope, but files[] contains OUT-OF-scope paths
+		// This was the bypass: old code only checked `path` and ignored `files[]`
+		// Fix must check BOTH and report violation for the out-of-scope entry
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-bypass-1',
+				},
+				{
+					args: {
+						path: '/workspace/src/hooks/safe.ts', // in-scope (attacker uses this as "cover")
+						files: [
+							'/workspace/src/tools/evil.ts', // out-of-scope (bypass attempt)
+						],
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Verification 2: Mixed args — filePath OUT-OF-SCOPE + paths[] IN-SCOPE
+	// Reverse bypass: single is out-of-scope, array is in-scope
+	// ─────────────────────────────────────────────────────────────
+	it('2. Mixed args: filePath out-of-scope + paths[] in-scope → SCOPE VIOLATION is reported', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// filePath is out-of-scope, paths[] is all in-scope
+		// Old bypass: if filePath was checked first and rejected, the loop might have
+		// continued without checking paths[] (first-throw behavior used as excuse to skip rest)
+		// Fix: check ALL paths, first violation thrown
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-bypass-2',
+				},
+				{
+					args: {
+						filePath: '/workspace/src/tools/evil.ts', // out-of-scope
+						paths: ['/workspace/src/hooks/safe.ts'], // in-scope
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Verification 3: Multiple arrays — files[] IN-SCOPE + targetFiles[] OUT-OF-SCOPE
+	// Bypass via multiple array keys with different scope membership
+	// ─────────────────────────────────────────────────────────────
+	it('3. Multiple array keys: files[] in-scope + targetFiles[] out-of-scope → SCOPE VIOLATION is reported', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// Both array keys are processed, but targetFiles[] has out-of-scope entry
+		// Old code might have stopped after checking files[] successfully
+		// Fix: iterate ALL array keys and ALL elements
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-bypass-3',
+				},
+				{
+					args: {
+						files: ['/workspace/src/hooks/safe.ts'], // all in-scope
+						targetFiles: ['/workspace/src/tools/evil.ts'], // out-of-scope
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Verification 4: All paths in-scope across all keys — no violation
+	// Legitimate use case: ensure fix doesn't cause false positives
+	// ─────────────────────────────────────────────────────────────
+	it('4. All paths in-scope across all keys → no violation', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = [
+			'/workspace/src/hooks',
+			'/workspace/src/utils',
+		];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// All paths are within declared scope — should NOT throw
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-legit-1',
+				},
+				{
+					args: {
+						path: '/workspace/src/hooks/safe.ts',
+						files: ['/workspace/src/hooks/another.ts'],
+						targetFiles: ['/workspace/src/utils/helper.ts'],
+					},
+				},
+			);
+		}).not.toThrow();
+	});
+
+	it('4b. Multiple arrays all in-scope — no violation', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = [
+			'/workspace/src/hooks',
+			'/workspace/src/utils',
+		];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-legit-2',
+				},
+				{
+					args: {
+						files: ['/workspace/src/hooks/safe.ts'],
+						paths: ['/workspace/src/utils/helper.ts'],
+						targetFiles: ['/workspace/src/hooks/also-safe.ts'],
+					},
+				},
+			);
+		}).not.toThrow();
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Verification 5: Empty arrays alongside valid single path — no false violation
+	// Edge case: ensure empty array doesn't cause candidatePaths to be empty
+	// and force early return when single path is valid
+	// ─────────────────────────────────────────────────────────────
+	it('5. Empty arrays alongside valid single path → no false violation', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// path is valid, arrays are empty — should NOT throw
+		// (candidatePaths will have the single path, validated successfully)
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-empty-1',
+				},
+				{
+					args: {
+						path: '/workspace/src/hooks/safe.ts',
+						files: [],
+						targetFiles: [],
+					},
+				},
+			);
+		}).not.toThrow();
+	});
+
+	it('5b. Empty files[] with in-scope path → no false violation', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-empty-2',
+				},
+				{
+					args: {
+						files: [],
+					},
+				},
+			);
+		}).not.toThrow();
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Verification 6: Non-string array elements are safely skipped
+	// Ensure type confusion (number, object, null) doesn't cause crash or bypass
+	// ─────────────────────────────────────────────────────────────
+	it('6. Non-string elements in array are safely skipped — number', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// Number elements should be skipped; valid string should be checked
+		// All entries are in-scope → should NOT throw
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-type-1',
+				},
+				{
+					args: {
+						files: [42, '/workspace/src/hooks/safe.ts', null, { foo: 'bar' }],
+					},
+				},
+			);
+		}).not.toThrow();
+	});
+
+	it('6b. Non-string elements — out-of-scope valid string triggers violation', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// Non-string elements are skipped, but out-of-scope string should still trigger
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-type-2',
+				},
+				{
+					args: {
+						files: [null, 123, '/workspace/src/tools/evil.ts', undefined],
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Additional edge cases
+	// ─────────────────────────────────────────────────────────────
+
+	it('all three array keys present — second key has out-of-scope → violation', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// files[] and paths[] are in-scope, but targetFiles[] has out-of-scope
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-triple',
+				},
+				{
+					args: {
+						files: ['/workspace/src/hooks/a.ts'],
+						paths: ['/workspace/src/hooks/b.ts'],
+						targetFiles: ['/workspace/src/tools/evil.ts'],
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+	});
+
+	it('single path is out-of-scope, arrays are empty → violation', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-single-out',
+				},
+				{
+					args: {
+						path: '/workspace/src/tools/evil.ts',
+						files: [],
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+	});
+
+	it('both single-path key AND array key are out-of-scope → first detected violation thrown', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// Both are out-of-scope; whichever is checked first triggers the throw
+		// The important thing is BOTH are checked, not just the single path
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-both-out',
+				},
+				{
+					args: {
+						path: '/workspace/src/tools/evil1.ts',
+						files: ['/workspace/src/tools/evil2.ts'],
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION/);
+	});
+});

--- a/src/hooks/scope-guard-single-path-keys.test.ts
+++ b/src/hooks/scope-guard-single-path-keys.test.ts
@@ -1,0 +1,423 @@
+/**
+ * scope-guard-single-path-keys.test.ts
+ *
+ * Targeted regression tests for the single-path multi-key iteration fix.
+ *
+ * PRIOR BUG: `argsObj?.path ?? argsObj?.filePath ?? argsObj?.file` used first-match-wins
+ * semantics — only the first present key was validated. If `path` was in-scope but `filePath`
+ * was out-of-scope, the guard passed because it never checked `filePath`.
+ *
+ * FIX: Iterates all three single-path keys (path, filePath, file), collects ALL string values
+ * into candidatePaths[], and validates EVERY one. First out-of-scope detection throws.
+ *
+ * These tests verify all 7 scenarios:
+ * 1.  path in-scope + filePath out-of-scope → SCOPE VIOLATION reported
+ * 2.  path in-scope + file out-of-scope → SCOPE VIOLATION reported
+ * 3.  filePath in-scope + file out-of-scope → SCOPE VIOLATION reported
+ * 4.  All three single-path keys in-scope → no violation
+ * 5.  All three single-path keys out-of-scope → VIOLATION on first detected
+ * 6.  path out-of-scope + files[] in-scope → VIOLATION reported
+ * 7.  Non-string values for single-path keys (null, undefined, number, object) → safely skipped
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { ensureAgentSession, resetSwarmState, swarmState } from '../state';
+import { createScopeGuardHook } from './scope-guard';
+
+const SESSION_ID = 'test-session-single-path-keys';
+const WORKSPACE_DIR = '/workspace';
+
+describe('scope-guard single-path multi-key iteration — regression: first-match-wins bypass (F#)', () => {
+	beforeEach(() => {
+		resetSwarmState();
+	});
+
+	afterEach(() => {
+		resetSwarmState();
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 1: path in-scope + filePath out-of-scope → VIOLATION
+	// This was the core bypass: old code stopped after `path` (in-scope → allow)
+	// and never checked `filePath` (out-of-scope → should have blocked)
+	// ─────────────────────────────────────────────────────────────
+	it('1. path in-scope + filePath out-of-scope → SCOPE VIOLATION is reported', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// path is IN-scope (attacker uses this as cover), but filePath is OUT-OF-scope
+		// Old first-match-wins: checked `path` only → passed → bypass!
+		// Fix: iterates ALL three keys → filePath detected as out-of-scope → throw
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-sp-1',
+				},
+				{
+					args: {
+						path: '/workspace/src/hooks/safe.ts', // in-scope (cover)
+						filePath: '/workspace/src/tools/evil.ts', // out-of-scope (bypass attempt)
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 2: path in-scope + file out-of-scope → VIOLATION
+	// Same bypass pattern with `file` instead of `filePath`
+	// ─────────────────────────────────────────────────────────────
+	it('2. path in-scope + file out-of-scope → SCOPE VIOLATION is reported', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// path is in-scope (cover), file is out-of-scope (bypass attempt)
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-sp-2',
+				},
+				{
+					args: {
+						path: '/workspace/src/hooks/safe.ts', // in-scope (cover)
+						file: '/workspace/src/tools/evil.ts', // out-of-scope (bypass attempt)
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 3: filePath in-scope + file out-of-scope → VIOLATION
+	// ─────────────────────────────────────────────────────────────
+	it('3. filePath in-scope + file out-of-scope → SCOPE VIOLATION is reported', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-sp-3',
+				},
+				{
+					args: {
+						filePath: '/workspace/src/hooks/safe.ts', // in-scope (cover)
+						file: '/workspace/src/tools/evil.ts', // out-of-scope (bypass attempt)
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 4: All three single-path keys in-scope → no violation
+	// Legitimate multi-key usage with all paths valid
+	// ─────────────────────────────────────────────────────────────
+	it('4. All three single-path keys in-scope → no violation', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = [
+			'/workspace/src/hooks',
+			'/workspace/src/utils',
+		];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// All three keys present, all in-scope → should NOT throw
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-sp-4',
+				},
+				{
+					args: {
+						path: '/workspace/src/hooks/a.ts', // in-scope
+						filePath: '/workspace/src/hooks/b.ts', // in-scope
+						file: '/workspace/src/utils/c.ts', // in-scope
+					},
+				},
+			);
+		}).not.toThrow();
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 5: All three single-path keys out-of-scope → VIOLATION on first detected
+	// ─────────────────────────────────────────────────────────────
+	it('5. All three single-path keys out-of-scope → first detected violation thrown', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// All three are out-of-scope; whichever is checked first triggers the throw
+		// The important thing: ALL three are checked, not just the first
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-sp-5',
+				},
+				{
+					args: {
+						path: '/workspace/src/tools/evil1.ts', // out-of-scope
+						filePath: '/workspace/src/tools/evil2.ts', // out-of-scope
+						file: '/workspace/src/tools/evil3.ts', // out-of-scope
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION/);
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 6: path out-of-scope + files[] in-scope → VIOLATION reported
+	// Mixed single-path and array keys; single-path out-of-scope should throw
+	// ─────────────────────────────────────────────────────────────
+	it('6. path out-of-scope + files[] in-scope → SCOPE VIOLATION is reported', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		// Single-path key is out-of-scope (primary violation), array is in-scope
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-sp-6',
+				},
+				{
+					args: {
+						path: '/workspace/src/tools/evil.ts', // out-of-scope (primary violation)
+						files: ['/workspace/src/hooks/safe.ts'], // in-scope (secondary)
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Scenario 7: Non-string values for single-path keys → safely skipped
+	// Type confusion must not cause crash or bypass
+	// ─────────────────────────────────────────────────────────────
+	describe('Scenario 7: Non-string values for single-path keys are safely skipped', () => {
+		it('7a. null value for filePath → safely skipped, in-scope path passes', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// null should be skipped; valid in-scope path should pass
+			await expect(async () => {
+				await hook.toolBefore(
+					{
+						tool: 'apply_patch',
+						sessionID: SESSION_ID,
+						callID: 'call-ns-1',
+					},
+					{
+						args: {
+							path: '/workspace/src/hooks/safe.ts', // in-scope (valid)
+							filePath: null, // should be skipped
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+
+		it('7b. undefined value for file → safely skipped, in-scope path passes', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{
+						tool: 'apply_patch',
+						sessionID: SESSION_ID,
+						callID: 'call-ns-2',
+					},
+					{
+						args: {
+							path: '/workspace/src/hooks/safe.ts', // in-scope (valid)
+							file: undefined, // should be skipped
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+
+		it('7c. number value for filePath → safely skipped, in-scope path passes', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{
+						tool: 'apply_patch',
+						sessionID: SESSION_ID,
+						callID: 'call-ns-3',
+					},
+					{
+						args: {
+							path: '/workspace/src/hooks/safe.ts', // in-scope (valid)
+							filePath: 42, // should be skipped
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+
+		it('7d. object value for file → safely skipped, in-scope path passes', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{
+						tool: 'apply_patch',
+						sessionID: SESSION_ID,
+						callID: 'call-ns-4',
+					},
+					{
+						args: {
+							path: '/workspace/src/hooks/safe.ts', // in-scope (valid)
+							file: { path: '/workspace/src/tools/evil.ts' }, // object — should be skipped
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+
+		it('7e. null in any single-path key + out-of-scope string in another → violation triggered', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			// nulls are skipped; the out-of-scope string triggers the violation
+			await expect(async () => {
+				await hook.toolBefore(
+					{
+						tool: 'apply_patch',
+						sessionID: SESSION_ID,
+						callID: 'call-ns-5',
+					},
+					{
+						args: {
+							path: null, // should be skipped
+							filePath: '/workspace/src/tools/evil.ts', // out-of-scope — should throw
+							file: undefined, // should be skipped
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Additional edge: only two keys present (path + file), file out-of-scope
+	// ─────────────────────────────────────────────────────────────
+	it('path in-scope + file out-of-scope (no filePath key present) → SCOPE VIOLATION', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-sp-edge',
+				},
+				{
+					args: {
+						path: '/workspace/src/hooks/safe.ts', // in-scope (cover)
+						file: '/workspace/src/tools/evil.ts', // out-of-scope (bypass attempt)
+						// filePath key is absent entirely
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+	});
+});

--- a/src/hooks/scope-guard.ts
+++ b/src/hooks/scope-guard.ts
@@ -103,10 +103,12 @@ export function createScopeGuardHook(
 			}
 
 			// Collect array paths from all supported array keys
+			let hasArrayKeys = false;
 			const arrayPathKeys = ['files', 'paths', 'targetFiles'];
 			for (const key of arrayPathKeys) {
 				const val = argsObj?.[key];
 				if (Array.isArray(val)) {
+					hasArrayKeys = true;
 					for (const item of val) {
 						if (typeof item === 'string' && item) {
 							candidatePaths.push(item);
@@ -115,7 +117,7 @@ export function createScopeGuardHook(
 				}
 			}
 
-			if (candidatePaths.length === 0) return; // Can't determine path — allow
+			if (candidatePaths.length === 0 && !hasArrayKeys) return; // Can't determine path — allow
 
 			// Validate every collected path
 			for (const rawPath of candidatePaths) {
@@ -167,8 +169,8 @@ export function isFileInScope(
 
 /**
  * Sanitize a raw file path string to prevent log injection and null-byte attacks.
- * Strips control characters (NUL, CR, LF, TAB, BS, FF, VT), ESC (ANSI escape prefix),
- * and remaining ANSI CSI sequences.
+ * Strips C0 control characters (NUL, CR, LF, TAB, BS, FF, VT), ESC (ANSI escape prefix),
+ * C1 control characters (0x80-0x9F), and remaining ANSI CSI sequences.
  *
  * Null bytes are removed rather than replaced because Node.js `path.resolve()`
  * throws `ERR_INVALID_ARG_VALUE` on `\0`, which would bypass the intended
@@ -184,8 +186,8 @@ function sanitizePath(raw: string): string {
 	let result = '';
 	for (let i = 0; i < raw.length; i++) {
 		const c = raw.charCodeAt(i);
-		// Replace C0 controls (0x00-0x1F) and DEL (0x7F) with underscore
-		if (c <= 0x1f || c === 0x7f) {
+		// Replace C0 controls (0x00-0x1F), DEL (0x7F), and C1 controls (0x80-0x9F) with underscore
+		if (c <= 0x1f || c === 0x7f || (c >= 0x80 && c <= 0x9f)) {
 			result += '_';
 			continue;
 		}

--- a/src/hooks/scope-guard.ts
+++ b/src/hooks/scope-guard.ts
@@ -169,12 +169,12 @@ export function isFileInScope(
 
 /**
  * Sanitize a raw file path string to prevent log injection and null-byte attacks.
- * Strips C0 control characters (NUL, CR, LF, TAB, BS, FF, VT), ESC (ANSI escape prefix),
- * C1 control characters (0x80-0x9F), and remaining ANSI CSI sequences.
+ * Replaces C0 control characters (0x00-0x1F), DEL (0x7F), C1 control characters
+ * (0x80-0x9F), and strips remaining ANSI CSI sequences.
  *
- * Null bytes are removed rather than replaced because Node.js `path.resolve()`
- * throws `ERR_INVALID_ARG_VALUE` on `\0`, which would bypass the intended
- * SCOPE VIOLATION error path with a raw TypeError.
+ * All matched control characters are replaced with underscores rather than removed,
+ * so that the resulting string can still be passed to `path.resolve()` without
+ * triggering `ERR_INVALID_ARG_VALUE` on embedded null bytes.
  *
  * Extracted from the original inline sanitization in the scope guard
  * to support reuse across single-path and multi-path code paths.
@@ -188,11 +188,6 @@ function sanitizePath(raw: string): string {
 		const c = raw.charCodeAt(i);
 		// Replace C0 controls (0x00-0x1F), DEL (0x7F), and C1 controls (0x80-0x9F) with underscore
 		if (c <= 0x1f || c === 0x7f || (c >= 0x80 && c <= 0x9f)) {
-			result += '_';
-			continue;
-		}
-		// ESC (0x1B) requires split/join to avoid regex control-char rule
-		if (c === 0x1b) {
 			result += '_';
 			continue;
 		}

--- a/src/hooks/scope-guard.ts
+++ b/src/hooks/scope-guard.ts
@@ -13,7 +13,7 @@ import * as path from 'node:path';
 import { ORCHESTRATOR_NAME, WRITE_TOOL_NAMES } from '../config/constants';
 import { stripKnownSwarmPrefix } from '../config/schema';
 import { resolveScopeWithFallbacks } from '../scope/scope-persistence';
-import { swarmState } from '../state';
+import { type AgentSessionState, swarmState } from '../state';
 import { pendingCoderScopeByTaskId } from './delegation-gate.js';
 import { normalizeToolName } from './normalize-tool-name';
 
@@ -89,52 +89,48 @@ export function createScopeGuardHook(
 			});
 			if (!declaredScope || declaredScope.length === 0) return; // No scope declared — allow
 
-			// Get the file path from args
+			// Get the file path(s) from args — collect ALL candidate paths from ALL supported keys
 			const argsObj = output.args as Record<string, unknown> | undefined;
-			const rawFilePath = argsObj?.path ?? argsObj?.filePath ?? argsObj?.file;
-			if (typeof rawFilePath !== 'string' || !rawFilePath) return; // Can't determine path — allow
-			// Sanitize path to prevent log injection — strip control chars + ANSI escape sequences.
-			// ESC (0x1B) is handled via split/join to avoid biome noControlCharactersInRegex rule.
-			const filePath = rawFilePath
-				.replace(/[\r\n\t]/g, '_')
-				.split(String.fromCharCode(27))
-				.join('_') // strip ESC (ANSI escape prefix)
-				.replace(/\[[\d;]*m/g, ''); // strip remaining ANSI CSI sequences
+			const candidatePaths: string[] = [];
 
-			// Check if file is in scope
-			if (!isFileInScope(filePath, declaredScope, directory)) {
-				const taskId = session?.currentTaskId ?? 'unknown';
-				const violationMessage = `SCOPE VIOLATION: ${agentName} attempted to modify '${filePath}' which is not in declared scope for task ${taskId}. Declared scope: [${declaredScope.slice(0, 3).join(', ')}${declaredScope.length > 3 ? '...' : ''}]`;
-
-				// Log violation to session
-				if (session) {
-					session.lastScopeViolation = violationMessage;
-					session.scopeViolationDetected = true;
+			// Collect single-string paths from ALL supported keys
+			const singlePathKeys = ['path', 'filePath', 'file'];
+			for (const key of singlePathKeys) {
+				const val = argsObj?.[key];
+				if (typeof val === 'string' && val) {
+					candidatePaths.push(val);
 				}
+			}
 
-				// Inject advisory to architect session (if callback provided)
-				if (injectAdvisory) {
-					// Find the architect session to notify
-					for (const [archSessionId, archSession] of swarmState.agentSessions) {
-						const archAgent =
-							swarmState.activeAgent.get(archSessionId) ??
-							archSession.agentName;
-						if (stripKnownSwarmPrefix(archAgent) === ORCHESTRATOR_NAME) {
-							try {
-								injectAdvisory(
-									archSessionId,
-									`[SCOPE GUARD] ${violationMessage}`,
-								);
-							} catch {
-								/* non-blocking */
-							}
-							break;
+			// Collect array paths from all supported array keys
+			const arrayPathKeys = ['files', 'paths', 'targetFiles'];
+			for (const key of arrayPathKeys) {
+				const val = argsObj?.[key];
+				if (Array.isArray(val)) {
+					for (const item of val) {
+						if (typeof item === 'string' && item) {
+							candidatePaths.push(item);
 						}
 					}
 				}
+			}
 
-				// BLOCK the tool call by throwing
-				throw new Error(violationMessage);
+			if (candidatePaths.length === 0) return; // Can't determine path — allow
+
+			// Validate every collected path
+			for (const rawPath of candidatePaths) {
+				const filePath = sanitizePath(rawPath);
+				if (!isFileInScope(filePath, declaredScope, directory)) {
+					reportScopeViolation(
+						agentName,
+						filePath,
+						taskId,
+						session,
+						injectAdvisory,
+						swarmState,
+						declaredScope,
+					);
+				}
 			}
 		},
 	};
@@ -155,10 +151,109 @@ export function isFileInScope(
 ): boolean {
 	const dir = directory ?? process.cwd();
 	const resolvedFile = path.resolve(dir, filePath);
-	return scopeEntries.some((scope) => {
-		const resolvedScope = path.resolve(dir, scope);
-		if (resolvedFile === resolvedScope) return true;
-		const rel = path.relative(resolvedScope, resolvedFile);
-		return rel.length > 0 && !rel.startsWith('..') && !path.isAbsolute(rel);
-	});
+	// Filter empty strings: path.resolve(dir, '') resolves to dir itself,
+	// making path.relative return non-dotdot for ANY file — silently neutering scope.
+	return scopeEntries
+		.filter((scope) => scope.length > 0)
+		.some((scope) => {
+			const resolvedScope = path.resolve(dir, scope);
+			if (resolvedFile === resolvedScope) return true;
+			const rel = path.relative(resolvedScope, resolvedFile);
+			return rel.length > 0 && !rel.startsWith('..') && !path.isAbsolute(rel);
+		});
+}
+
+// --- Helpers for array-path scope checking ---
+
+/**
+ * Sanitize a raw file path string to prevent log injection and null-byte attacks.
+ * Strips control characters (NUL, CR, LF, TAB, BS, FF, VT), ESC (ANSI escape prefix),
+ * and remaining ANSI CSI sequences.
+ *
+ * Null bytes are removed rather than replaced because Node.js `path.resolve()`
+ * throws `ERR_INVALID_ARG_VALUE` on `\0`, which would bypass the intended
+ * SCOPE VIOLATION error path with a raw TypeError.
+ *
+ * Extracted from the original inline sanitization in the scope guard
+ * to support reuse across single-path and multi-path code paths.
+ *
+ * @param raw - The unsanitized file path string
+ * @returns The sanitized file path string safe for logging and scope matching
+ */
+function sanitizePath(raw: string): string {
+	let result = '';
+	for (let i = 0; i < raw.length; i++) {
+		const c = raw.charCodeAt(i);
+		// Replace C0 controls (0x00-0x1F) and DEL (0x7F) with underscore
+		if (c <= 0x1f || c === 0x7f) {
+			result += '_';
+			continue;
+		}
+		// ESC (0x1B) requires split/join to avoid regex control-char rule
+		if (c === 0x1b) {
+			result += '_';
+			continue;
+		}
+		result += raw[i];
+	}
+	// Strip remaining ANSI CSI sequences
+	return result.replace(/\[[\d;]*m/g, '');
+}
+
+/**
+ * Internal implementation details exposed for unit testing.
+ * DO NOT use these in production code.
+ */
+export const _internals = { sanitizePath };
+
+/**
+ * Report a scope violation for an out-of-scope file path.
+ * Logs the violation to the session state, injects an advisory to the
+ * architect session, and throws an Error to block the tool call.
+ *
+ * @param agentName - Name of the agent that caused the violation
+ * @param filePath - The sanitized file path that is out of scope
+ * @param taskId - The current task ID (or null if unknown)
+ * @param session - The agent session state (or undefined)
+ * @param injectAdvisory - Optional callback to push advisory to architect session
+ * @param state - The swarm state singleton for finding architect sessions
+ * @param scopeEntries - The declared scope entries for scope mismatch display
+ * @throws Error - Always throws to block the violating tool call
+ */
+function reportScopeViolation(
+	agentName: string,
+	filePath: string,
+	taskId: string | null,
+	session: AgentSessionState | undefined,
+	injectAdvisory: ((sessionId: string, message: string) => void) | undefined,
+	state: typeof swarmState,
+	scopeEntries: string[],
+): void {
+	const taskLabel = taskId ?? 'unknown';
+	const violationMessage = `SCOPE VIOLATION: ${agentName} attempted to modify '${filePath}' which is not in declared scope for task ${taskLabel}. Declared scope: [${scopeEntries.slice(0, 3).join(', ')}${scopeEntries.length > 3 ? '...' : ''}]`;
+
+	// Log violation to session
+	if (session) {
+		session.lastScopeViolation = violationMessage;
+		session.scopeViolationDetected = true;
+	}
+
+	// Inject advisory to architect session (if callback provided)
+	if (injectAdvisory) {
+		for (const [archSessionId, archSession] of state.agentSessions) {
+			const archAgent =
+				state.activeAgent.get(archSessionId) ?? archSession.agentName;
+			if (stripKnownSwarmPrefix(archAgent) === ORCHESTRATOR_NAME) {
+				try {
+					injectAdvisory(archSessionId, `[SCOPE GUARD] ${violationMessage}`);
+				} catch {
+					/* non-blocking */
+				}
+				break;
+			}
+		}
+	}
+
+	// BLOCK the tool call by throwing
+	throw new Error(violationMessage);
 }

--- a/src/tools/apply-patch.test.ts
+++ b/src/tools/apply-patch.test.ts
@@ -1,0 +1,818 @@
+﻿import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	existsSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import type { ApplyPatchResult } from './apply-patch';
+import { applyPatch } from './apply-patch';
+
+// Helper: create a temp directory
+function createTempDir(): string {
+	return mkdtempSync(path.join(tmpdir(), 'apply-patch-test-'));
+}
+
+// Helper: create a test file with given content
+function createFile(dir: string, relativePath: string, content: string): void {
+	const fullPath = path.join(dir, relativePath);
+	const parent = path.dirname(fullPath);
+	if (!existsSync(parent)) {
+		// mkdirSync recursively creates parent dirs
+	}
+	writeFileSync(fullPath, content, 'utf-8');
+}
+
+// Helper: read file content
+function readFileContent(dir: string, relativePath: string): string {
+	return readFileSync(path.join(dir, relativePath), 'utf-8');
+}
+
+// Helper: parse JSON result
+function parseResult(result: string): ApplyPatchResult {
+	return JSON.parse(result) as ApplyPatchResult;
+}
+
+// Helper: build a simple unified diff for a single file
+function buildDiff(
+	oldPath: string,
+	newPath: string,
+	oldContent: string,
+	newContent: string,
+): string {
+	const oldLines = oldContent.split('\n');
+	const newLines = newContent.split('\n');
+
+	// Find the common prefix and suffix
+	let prefixLen = 0;
+	while (
+		prefixLen < oldLines.length &&
+		prefixLen < newLines.length &&
+		oldLines[prefixLen] === newLines[prefixLen]
+	) {
+		prefixLen++;
+	}
+
+	let suffixLen = 0;
+	while (
+		suffixLen < oldLines.length - prefixLen &&
+		suffixLen < newLines.length - prefixLen &&
+		oldLines[oldLines.length - 1 - suffixLen] ===
+			newLines[newLines.length - 1 - suffixLen]
+	) {
+		suffixLen++;
+	}
+
+	const oldBody = oldLines.slice(prefixLen, oldLines.length - suffixLen);
+	const newBody = newLines.slice(prefixLen, newLines.length - suffixLen);
+
+	// Compute adjusted suffix length excluding trailing empty element (newline artifact)
+	// When content ends with '\n', split('\n') produces a trailing empty element.
+	// This trailing empty should NOT be counted as a suffix line.
+	const trailingEmptyOld =
+		oldLines.length > 0 && oldLines[oldLines.length - 1] === '' ? 1 : 0;
+	const trailingEmptyNew =
+		newLines.length > 0 && newLines[newLines.length - 1] === '' ? 1 : 0;
+	const adjustedSuffixLen = Math.max(0, suffixLen - trailingEmptyOld);
+	const adjustedSuffixLenNew = Math.max(0, suffixLen - trailingEmptyNew);
+
+	// oldStart is the position of the first line in the hunk (0-indexed prefix)
+	const oldStart = prefixLen;
+	const oldCount = oldBody.length + prefixLen + adjustedSuffixLen;
+	const newStart = prefixLen;
+	const newCount = newBody.length + prefixLen + adjustedSuffixLenNew;
+
+	const hunkLines: string[] = [];
+	// Add prefix context lines
+	for (let i = 0; i < prefixLen; i++) {
+		hunkLines.push(` ${oldLines[i]}`);
+	}
+	// Add removal and addition lines
+	for (const line of oldBody) {
+		hunkLines.push(`-${line}`);
+	}
+	for (const line of newBody) {
+		hunkLines.push(`+${line}`);
+	}
+	// Add suffix context lines (only non-empty ones)
+	for (let i = 0; i < adjustedSuffixLen; i++) {
+		const contextLine = oldLines[prefixLen + oldBody.length + i] ?? '';
+		hunkLines.push(` ${contextLine}`);
+	}
+
+	return `--- ${oldPath}\n+++ ${newPath}\n@@ -${oldStart},${oldCount} +${newStart},${newCount} @@\n${hunkLines.join('\n')}\n`;
+}
+
+// Helper: build a new file creation diff
+function buildCreateDiff(newPath: string, content: string): string {
+	// Split and filter out empty trailing element from trailing newline
+	const lines = content
+		.split('\n')
+		.filter((l, i, arr) => i < arr.length - 1 || l !== '');
+	const hunkLines: string[] = [];
+	for (const line of lines) {
+		hunkLines.push(`+${line}`);
+	}
+	return `--- /dev/null\n+++ ${newPath}\n@@ -0,0 +1,${lines.length} @@\n${hunkLines.join('\n')}\n`;
+}
+
+// Helper: build a delete diff
+function buildDeleteDiff(delPath: string, content: string): string {
+	const lines = content.split('\n');
+	const hunkLines: string[] = [];
+	for (const line of lines) {
+		hunkLines.push(`-${line}`);
+	}
+	return `--- ${delPath}\n+++ /dev/null\n@@ -1,${lines.length} +0,0 @@\n${hunkLines.join('\n')}\n`;
+}
+
+// Helper: call applyPatch.execute with correct ctx argument
+async function applyPatchExec(args: {
+	patch: string;
+	files: string[];
+	dryRun?: boolean;
+	allowCreates?: boolean;
+	allowDeletes?: boolean;
+	directory: string;
+}): Promise<string> {
+	// The createSwarmTool wrapper expects ctx as second arg, not directory
+	// It extracts directory from ctx.directory
+	return applyPatch.execute(args, { directory: args.directory } as any);
+}
+
+// Helper: workspace for execute call
+function workspaceOf(dir: string) {
+	return { directory: dir };
+}
+
+describe('apply-patch tool', () => {
+	let workspace: string;
+
+	beforeEach(() => {
+		workspace = createTempDir();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(workspace, { recursive: true, force: true });
+		} catch {
+			// Ignore cleanup errors
+		}
+	});
+
+	// ===== Test 1: Applies a simple single-file replacement patch =====
+	test('applies a simple single-file replacement patch', async () => {
+		const targetFile = 'example.txt';
+		createFile(workspace, targetFile, 'line1\nline2\nline3\n');
+
+		const patch = buildDiff(
+			targetFile,
+			targetFile,
+			'line1\nline2\nline3\n',
+			'line1\nline2-modified\nline3\n',
+		);
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(true);
+		expect(result.summary.totalFiles).toBe(1);
+		expect(result.summary.applied).toBe(1);
+		expect(result.files[0]?.status).toBe('applied');
+		expect(readFileContent(workspace, targetFile)).toBe(
+			'line1\nline2-modified\nline3\n',
+		);
+	});
+
+	// ===== Test 2: Applies a multi-hunk patch to one file =====
+	test('applies a multi-hunk patch to one file', async () => {
+		const targetFile = 'multihunk.js';
+
+		const patch1 = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,4 +1,4 @@\n const x = 1;\n-const y = 2;\n+const y = 99;\n const z = 3;\n const w = 4;\n`;
+		const patch2 = `--- ${targetFile}\n+++ ${targetFile}\n@@ -3,4 +3,4 @@\n const z = 3;\n const w = 4;\n+console.log('added');\n const final = true;\n`;
+
+		// Write initial file
+		createFile(
+			workspace,
+			targetFile,
+			'const x = 1;\nconst y = 2;\nconst z = 3;\nconst w = 4;\nconst final = true;\n',
+		);
+
+		const combinedPatch = patch1 + patch2;
+		const resultStr = await applyPatch.execute(
+			{ patch: combinedPatch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(true);
+		expect(result.files[0]?.status).toBe('applied');
+		const content = readFileContent(workspace, targetFile);
+		expect(content).toContain('const y = 99;');
+		expect(content).toContain("console.log('added');");
+	});
+
+	// ===== Test 3: Applies a multi-file patch when all files are declared =====
+	test('applies a multi-file patch when all files are declared', async () => {
+		const fileA = 'a.txt';
+		const fileB = 'b.txt';
+		createFile(workspace, fileA, 'hello\nworld\n');
+		createFile(workspace, fileB, 'foo\nbar\n');
+
+		const patchA = buildDiff(fileA, fileA, 'hello\nworld\n', 'hello\nswarm\n');
+		const patchB = buildDiff(fileB, fileB, 'foo\nbar\n', 'foo\nbaz\n');
+
+		const resultStr = await applyPatch.execute(
+			{ patch: patchA + patchB, files: [fileA, fileB] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(true);
+		expect(result.summary.totalFiles).toBe(2);
+		expect(result.summary.applied).toBe(2);
+		expect(readFileContent(workspace, fileA)).toBe('hello\nswarm\n');
+		expect(readFileContent(workspace, fileB)).toBe('foo\nbaz\n');
+	});
+
+	// ===== Test 4: dryRun reports success without changing files =====
+	test('dryRun: true reports success without changing files', async () => {
+		const targetFile = 'dryrun.txt';
+		createFile(workspace, targetFile, 'original\n');
+
+		const patch = buildDiff(targetFile, targetFile, 'original\n', 'modified\n');
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [targetFile], dryRun: true },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(true);
+		expect(result.dryRun).toBe(true);
+		expect(readFileContent(workspace, targetFile)).toBe('original\n');
+		expect(result.files[0]?.status).toBe('applied');
+	});
+
+	// ===== Test 5: Rejects when parsed patch target is not in files[] =====
+	test('rejects when parsed patch target is not in files[]', async () => {
+		const targetFile = 'only-in-patch.txt';
+		createFile(workspace, 'other.txt', 'content\n');
+
+		const patch = buildDiff(targetFile, targetFile, 'old\n', 'new\n');
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: ['other.txt'] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.errors?.[0]?.type).toBe('context-mismatch');
+		expect(result.files[0]?.errors?.[0]?.message).toContain(
+			'not in the declared files array',
+		);
+	});
+
+	// ===== Test 6: Warns when files[] has extra entries not in patch =====
+	test('warns when files[] has extra entries not in patch', async () => {
+		const targetFile = 'patched.txt';
+		const extraFile = 'extra.txt';
+		createFile(workspace, targetFile, 'line1\nline2\nline3\n');
+		createFile(workspace, extraFile, 'extra content\n');
+
+		const patch = buildDiff(
+			targetFile,
+			targetFile,
+			'line1\nline2\nline3\n',
+			'line1\nline2-modified\nline3\n',
+		);
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [targetFile, extraFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		// Should still succeed with warning
+		expect(result.success).toBe(true);
+		expect(result.warnings).toBeDefined();
+		expect(result.warnings?.[0]).toContain('extra.txt');
+	});
+
+	// ===== Test 7: Rejects context mismatch with diagnostics =====
+	test('rejects context mismatch with diagnostics', async () => {
+		const targetFile = 'mismatch.txt';
+		// File has different content than what patch expects
+		createFile(workspace, targetFile, 'line1\nDIFFERENT\nline3\n');
+
+		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,3 +1,3 @@\n line1\n-old\n+new\n line3\n`;
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.status).toBe('error');
+		expect(result.files[0]?.errors?.[0]?.type).toBe('context-mismatch');
+		expect(result.files[0]?.errors?.[0]?.expected).toBeDefined();
+		expect(result.files[0]?.errors?.[0]?.actual).toBeDefined();
+	});
+
+	// ===== Test 8: Rejects absolute paths =====
+	test('rejects absolute paths', async () => {
+		const patch = '--- /etc/passwd\n+++ /etc/passwd\n@@ -1 +1 @@\n-old\n+new\n';
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: ['/etc/passwd'] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.errors?.[0]?.message).toContain('Absolute path');
+	});
+
+	// ===== Test 9: Rejects ../ traversal =====
+	test('rejects ../ traversal', async () => {
+		const patch = `--- ../secret.txt\n+++ ../secret.txt\n@@ -1 +1 @@\n-old\n+new\n`;
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: ['../secret.txt'] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.errors?.[0]?.message).toContain('traversal');
+	});
+
+	// ===== Test 10: Rejects .git/ and .swarm/ targets =====
+	test('rejects .git/ and .swarm/ protected directory targets', async () => {
+		const gitPatch = `--- .git/config\n+++ .git/config\n@@ -1 +1 @@\n-old\n+new\n`;
+		const resultStr = await applyPatch.execute(
+			{ patch: gitPatch, files: ['.git/config'] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.errors?.[0]?.message).toContain(
+			'Protected directory',
+		);
+
+		const swarmPatch = `--- .swarm/secret.txt\n+++ .swarm/secret.txt\n@@ -1 +1 @@\n-old\n+new\n`;
+		const resultStr2 = await applyPatch.execute(
+			{ patch: swarmPatch, files: ['.swarm/secret.txt'] },
+			workspaceOf(workspace) as any,
+		);
+		const result2 = parseResult(resultStr2);
+		expect(result2.success).toBe(false);
+		expect(result2.files[0]?.errors?.[0]?.message).toContain(
+			'Protected directory',
+		);
+	});
+
+	// ===== Test 10b: Rejects NESTED .git/ and .swarm/ targets (regression: Fix-apply-patch-nested-protected) =====
+	// Prior code checked ONLY the first path segment, so `src/.git/config` would pass
+	// isProtectedPath because segment[0] === 'src' !== '.git'. The fix uses
+	// segments.some() to check ALL segments, correctly rejecting nested protected dirs.
+	test('rejects .git/ hidden inside a subdirectory path (src/.git/config)', async () => {
+		const nestedGitPatch = `--- src/.git/config\n+++ src/.git/config\n@@ -1 +1 @@\n-old\n+new\n`;
+		const resultStr = await applyPatch.execute(
+			{ patch: nestedGitPatch, files: ['src/.git/config'] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.errors?.[0]?.message).toContain(
+			'Protected directory',
+		);
+	});
+
+	test('rejects .swarm/ hidden inside a subdirectory path (src/.swarm/state)', async () => {
+		const nestedSwarmPatch = `--- src/.swarm/state\n+++ src/.swarm/state\n@@ -1 +1 @@\n-old\n+new\n`;
+		const resultStr = await applyPatch.execute(
+			{ patch: nestedSwarmPatch, files: ['src/.swarm/state'] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.errors?.[0]?.message).toContain(
+			'Protected directory',
+		);
+	});
+
+	test('rejects .git/ at arbitrary depth (a/b/.git/c)', async () => {
+		const deepGitPatch = `--- a/b/.git/c\n+++ a/b/.git/c\n@@ -1 +1 @@\n-old\n+new\n`;
+		const resultStr = await applyPatch.execute(
+			{ patch: deepGitPatch, files: ['a/b/.git/c'] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.errors?.[0]?.message).toContain(
+			'Protected directory',
+		);
+	});
+
+	// ===== Test 11: Creates new file when allowCreates=true =====
+	test('creates new file when allowCreates=true', async () => {
+		const newFile = 'brand-new.txt';
+		const content = 'brand new content\n';
+		const patch = buildCreateDiff(newFile, content);
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [newFile], allowCreates: true },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(true);
+		expect(result.files[0]?.status).toBe('created');
+		expect(existsSync(path.join(workspace, newFile))).toBe(true);
+		expect(readFileContent(workspace, newFile)).toBe(content);
+	});
+
+	// ===== Test 12: Rejects create when allowCreates=false (default) =====
+	test('rejects create when allowCreates=false (default)', async () => {
+		const newFile = 'not-created.txt';
+		const patch = buildCreateDiff(newFile, 'some content\n');
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [newFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.status).toBe('error');
+		expect(result.files[0]?.errors?.[0]?.type).toBe('create-not-allowed');
+		expect(existsSync(path.join(workspace, newFile))).toBe(false);
+	});
+
+	// ===== Test 13: Rejects delete by default =====
+	test('rejects delete by default (allowDeletes=false)', async () => {
+		const targetFile = 'to-delete.txt';
+		createFile(workspace, targetFile, 'content to delete\n');
+		const patch = buildDeleteDiff(targetFile, 'content to delete\n');
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.status).toBe('error');
+		expect(result.files[0]?.errors?.[0]?.type).toBe('delete-not-allowed');
+		expect(existsSync(path.join(workspace, targetFile))).toBe(true);
+	});
+
+	// ===== Test 14: Allows delete when allowDeletes=true =====
+	test('allows delete when allowDeletes=true', async () => {
+		const targetFile = 'to-delete.txt';
+		createFile(workspace, targetFile, 'content to delete\n');
+		const patch = buildDeleteDiff(targetFile, 'content to delete\n');
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [targetFile], allowDeletes: true },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(true);
+		expect(result.files[0]?.status).toBe('applied');
+		expect(existsSync(path.join(workspace, targetFile))).toBe(false);
+	});
+
+	// ===== Test 15: Rejects binary patches =====
+	test('rejects binary patches', async () => {
+		const targetFile = 'binary.txt';
+		createFile(workspace, targetFile, 'original\n');
+
+		const binaryPatch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1 +1 @@\n-old\n\\ No newline at end of file\n+new\n\\ No newline at end of file\nGIT binary patch\nliteral 1\nH Pf\n`;
+
+		const resultStr = await applyPatch.execute(
+			{ patch: binaryPatch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		// Binary detection happens at parse time — whole patch fails
+		expect(result.files[0]?.errors?.[0]?.message).toContain('Binary');
+	});
+
+	// ===== Test 16: Rejects rename/copy patches =====
+	test('rejects rename/copy patches', async () => {
+		const oldFile = 'old-name.txt';
+		const newFile = 'new-name.txt';
+		createFile(workspace, oldFile, 'content\n');
+
+		const renamePatch = `--- ${oldFile}\n+++ ${newFile}\nrename from ${oldFile}\nrename to ${newFile}\n`;
+
+		const resultStr = await applyPatch.execute(
+			{ patch: renamePatch, files: [oldFile, newFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.errors?.[0]?.message).toContain('Rename/copy');
+	});
+
+	// ===== Test 17: Preserves unrelated content =====
+	test('preserves unrelated content when only one file is patched', async () => {
+		const patchedFile = 'patched.txt';
+		const unrelatedFile = 'unrelated.txt';
+		createFile(workspace, patchedFile, 'line1\nline2\nline3\n');
+		createFile(workspace, unrelatedFile, 'unchanged content\n');
+
+		const patch = buildDiff(
+			patchedFile,
+			patchedFile,
+			'line1\nline2\nline3\n',
+			'line1\nmodified\nline3\n',
+		);
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [patchedFile, unrelatedFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(true);
+		expect(readFileContent(workspace, unrelatedFile)).toBe(
+			'unchanged content\n',
+		);
+	});
+
+	// ===== Test 18: Atomic writes — no temp files left =====
+	test('atomic writes leave no temp files behind', async () => {
+		const targetFile = 'atomic.txt';
+		createFile(workspace, targetFile, 'original\n');
+
+		const patch = buildDiff(targetFile, targetFile, 'original\n', 'modified\n');
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(true);
+		expect(readFileContent(workspace, targetFile)).toBe('modified\n');
+
+		// Verify no temp files are left in the workspace
+		const entries = readdirSync(workspace).filter((n) =>
+			n.includes('.apply-patch-'),
+		);
+		expect(entries).toHaveLength(0);
+	});
+
+	// ===== Test 19: Handles \\r\\n line endings =====
+	// SKIPPED: Implementation bug - apply-patch.ts normalizes patch to LF but reads
+	// file content as-is with CRLF. The comparison fails because '\r' is in the file
+	// but not in the normalized patch. To fix: normalize file content in applyHunks.
+	test.skip('handles \\r\\n line endings correctly', async () => {
+		const targetFile = 'crlf.txt';
+		// File with CRLF line endings
+		createFile(workspace, targetFile, 'line1\r\nline2\r\nline3\r\n');
+
+		const patch = buildDiff(
+			targetFile,
+			targetFile,
+			'line1\r\nline2\r\nline3\r\n',
+			'line1\r\nline2-modified\r\nline3\r\n',
+		);
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(true);
+		expect(result.files[0]?.status).toBe('applied');
+		const content = readFileSync(
+			path.join(workspace, targetFile),
+			'utf-8',
+		).replace(/\r\n/g, '\n');
+		expect(content).toContain('line2-modified');
+	});
+
+	// SKIPPED: Implementation bug - applyHunks uses expectedOldLines.join('\\n') which
+	// always produces a trailing \\n, but file content without trailing newline doesn't have one.
+	// The comparison fails. To fix: handle trailing newline difference in applyHunks.
+	test.skip('handles file with no trailing newline', async () => {
+		const targetFile = 'nonl.txt';
+		// File WITHOUT trailing newline
+		writeFileSync(
+			path.join(workspace, targetFile),
+			'line1\nline2\nline3',
+			'utf-8',
+		);
+
+		const patch = buildDiff(
+			targetFile,
+			targetFile,
+			'line1\nline2\nline3',
+			'line1\nline2-modified\nline3',
+		);
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(true);
+		const content = readFileSync(path.join(workspace, targetFile), 'utf-8');
+		// Should preserve no-trailing-newline
+		expect(content).not.toEndWith('\n');
+		expect(content).toContain('line2-modified');
+	});
+
+	// SKIPPED: Implementation bug - empty patch format (no hunk) is not recognized as "no-changes".
+	// The parser returns no files rather than a file with no-changes status.
+	test.skip('empty patch returns success with no-changes status', async () => {
+		const targetFile = 'empty-patch.txt';
+		createFile(workspace, targetFile, 'content\n');
+
+		// Patch with no hunks (just headers)
+		const emptyPatch = `--- ${targetFile}\n+++ ${targetFile}\n`;
+
+		const resultStr = await applyPatch.execute(
+			{ patch: emptyPatch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(true);
+		expect(result.files[0]?.status).toBe('no-changes');
+		expect(result.summary.applied).toBe(0);
+	});
+
+	// ===== Test 22: Partial application (one file succeeds, another fails) =====
+	test('partial application: one file succeeds, another fails', async () => {
+		const goodFile = 'good.txt';
+		const badFile = 'bad.txt';
+		createFile(workspace, goodFile, 'line1\nline2\nline3\n');
+		createFile(workspace, badFile, 'different content\n');
+
+		const goodPatch = buildDiff(
+			goodFile,
+			goodFile,
+			'line1\nline2\nline3\n',
+			'line1\nmodified\nline3\n',
+		);
+		const badPatch = `--- ${badFile}\n+++ ${badFile}\n@@ -1 +1 @@\n-old\n+new\n`;
+
+		const combinedPatch = goodPatch + badPatch;
+		const resultStr = await applyPatch.execute(
+			{ patch: combinedPatch, files: [goodFile, badFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		expect(result.summary.failed).toBeGreaterThan(0);
+		// Good file should have been applied despite bad file failure
+		expect(readFileContent(workspace, goodFile)).toBe(
+			'line1\nmodified\nline3\n',
+		);
+	});
+
+	// ===== Test 23: Rejects Windows reserved names =====
+	test('rejects Windows reserved names', async () => {
+		const reservedNames = ['nul', 'NUL', 'aux', 'prn', 'com1', 'lpt9'];
+		for (const name of reservedNames) {
+			const patch = `--- ${name}.txt\n+++ ${name}.txt\n@@ -1 +1 @@\n-old\n+new\n`;
+
+			const resultStr = await applyPatch.execute(
+				{ patch, files: [`${name}.txt`] },
+				workspaceOf(workspace) as any,
+			);
+			const result = parseResult(resultStr);
+
+			expect(result.success).toBe(false);
+			expect(result.files[0]?.errors?.[0]?.message).toContain(
+				'Windows reserved name',
+			);
+		}
+	});
+
+	// ===== Test 24: Rejects control characters in paths =====
+	test('rejects control characters in file paths', async () => {
+		const badPath = 'file\x00with\x01control.txt';
+		const patch = `--- ${badPath}\n+++ ${badPath}\n@@ -1 +1 @@\n-old\n+new\n`;
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [badPath] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.errors?.[0]?.message).toContain(
+			'Control characters',
+		);
+	});
+
+	// ===== Test 25: Whitespace-only result is written as empty file, not deleted =====
+	test('whitespace-only result is written as empty file, not deleted', async () => {
+		const targetFile = 'whitespace.txt';
+		createFile(workspace, targetFile, 'some content\n');
+
+		// Replace all content with spaces/tabs/newlines
+		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1 +1 @@\n-some content\n+   \t  \n`;
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(true);
+		expect(result.files[0]?.status).toBe('applied');
+		// File must still exist (NOT deleted)
+		expect(existsSync(path.join(workspace, targetFile))).toBe(true);
+	});
+
+	// ===== Test 26: Patch removing all content requires allowDeletes =====
+	test('patch removing all lines is rejected by default (allowDeletes=false)', async () => {
+		const targetFile = 'empty-result.txt';
+		createFile(workspace, targetFile, 'line1\nline2\nline3\n');
+
+		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,3 +0,0 @@\n-line1\n-line2\n-line3\n`;
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.status).toBe('error');
+		expect(result.files[0]?.errors?.[0]?.type).toBe('delete-not-allowed');
+		// File must still exist with original content
+		expect(existsSync(path.join(workspace, targetFile))).toBe(true);
+		expect(readFileContent(workspace, targetFile)).toBe(
+			'line1\nline2\nline3\n',
+		);
+	});
+
+	test('patch removing all lines writes empty file with allowDeletes=true', async () => {
+		const targetFile = 'empty-result.txt';
+		createFile(workspace, targetFile, 'line1\nline2\nline3\n');
+
+		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,3 +0,0 @@\n-line1\n-line2\n-line3\n`;
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [targetFile], allowDeletes: true },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(true);
+		expect(result.files[0]?.status).toBe('applied');
+		// File should exist as an empty file
+		expect(existsSync(path.join(workspace, targetFile))).toBe(true);
+		expect(readFileContent(workspace, targetFile)).toBe('');
+	});
+
+	// ===== Test 27: Stale patch (shifted context) is rejected, not silently applied =====
+	test('stale patch with shifted context reports mismatch', async () => {
+		const targetFile = 'stale.txt';
+		// Create a file with duplicate blocks separated by an insertion point
+		createFile(
+			workspace,
+			targetFile,
+			'block-a\nblock-a\nINSERTED\nblock-b\nblock-b\n',
+		);
+
+		// Hunk declares @@ -1,2 +1,2 @@ targeting the first block-a lines.
+		// If forward-search existed, it would silently match a later block.
+		// With exact-match-only, it should fail if the context at line 1 differs.
+		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,2 +1,2 @@\n block-x\n block-x\n+added\n`;
+
+		const resultStr = await applyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.status).toBe('error');
+		expect(result.files[0]?.errors?.[0]?.type).toBe('context-mismatch');
+	});
+});

--- a/src/tools/apply-patch.test.ts
+++ b/src/tools/apply-patch.test.ts
@@ -576,10 +576,7 @@ describe('apply-patch tool', () => {
 	});
 
 	// ===== Test 19: Handles \\r\\n line endings =====
-	// SKIPPED: Implementation bug - apply-patch.ts normalizes patch to LF but reads
-	// file content as-is with CRLF. The comparison fails because '\r' is in the file
-	// but not in the normalized patch. To fix: normalize file content in applyHunks.
-	test.skip('handles \\r\\n line endings correctly', async () => {
+	test('handles \\r\\n line endings correctly', async () => {
 		const targetFile = 'crlf.txt';
 		// File with CRLF line endings
 		createFile(workspace, targetFile, 'line1\r\nline2\r\nline3\r\n');
@@ -606,10 +603,7 @@ describe('apply-patch tool', () => {
 		expect(content).toContain('line2-modified');
 	});
 
-	// SKIPPED: Implementation bug - applyHunks uses expectedOldLines.join('\\n') which
-	// always produces a trailing \\n, but file content without trailing newline doesn't have one.
-	// The comparison fails. To fix: handle trailing newline difference in applyHunks.
-	test.skip('handles file with no trailing newline', async () => {
+	test('handles file with no trailing newline', async () => {
 		const targetFile = 'nonl.txt';
 		// File WITHOUT trailing newline
 		writeFileSync(
@@ -638,9 +632,7 @@ describe('apply-patch tool', () => {
 		expect(content).toContain('line2-modified');
 	});
 
-	// SKIPPED: Implementation bug - empty patch format (no hunk) is not recognized as "no-changes".
-	// The parser returns no files rather than a file with no-changes status.
-	test.skip('empty patch returns success with no-changes status', async () => {
+	test('empty patch returns success with no-changes status', async () => {
 		const targetFile = 'empty-patch.txt';
 		createFile(workspace, targetFile, 'content\n');
 

--- a/src/tools/apply-patch.test.ts
+++ b/src/tools/apply-patch.test.ts
@@ -1,4 +1,4 @@
-﻿import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
 	existsSync,
 	mkdtempSync,
@@ -20,10 +20,6 @@ function createTempDir(): string {
 // Helper: create a test file with given content
 function createFile(dir: string, relativePath: string, content: string): void {
 	const fullPath = path.join(dir, relativePath);
-	const parent = path.dirname(fullPath);
-	if (!existsSync(parent)) {
-		// mkdirSync recursively creates parent dirs
-	}
 	writeFileSync(fullPath, content, 'utf-8');
 }
 

--- a/src/tools/apply-patch.ts
+++ b/src/tools/apply-patch.ts
@@ -1,0 +1,1304 @@
+/**
+ * apply-patch — Native Swarm tool for applying unified diffs in-process.
+ * Parses standard unified diff format, validates paths against workspace
+ * boundaries, matches hunk context exactly, and writes atomically.
+ *
+ * FR-001 through FR-014, SR-002 through SR-005.
+ * Pure TypeScript, no shell/git/external binaries, standard node:fs sync I/O.
+ */
+
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	renameSync,
+	rmdirSync,
+	unlinkSync,
+	writeFileSync,
+} from 'node:fs';
+import * as path from 'node:path';
+import type { ToolDefinition } from '@opencode-ai/plugin/tool';
+import { z } from 'zod';
+import {
+	containsControlChars,
+	containsPathTraversal,
+} from '../utils/path-security';
+import { createSwarmTool } from './create-tool';
+
+// ============ Types ============
+
+/** A single line within a parsed hunk. */
+interface HunkLine {
+	type: 'context' | 'addition' | 'removal';
+	content: string;
+}
+
+/** A single parsed hunk from a unified diff. */
+interface ParsedHunk {
+	oldStart: number;
+	oldCount: number;
+	newStart: number;
+	newCount: number;
+	lines: HunkLine[];
+}
+
+/** A parsed file diff containing one or more hunks. */
+interface ParsedFileDiff {
+	oldPath: string | null;
+	newPath: string | null;
+	isNewFile: boolean;
+	isDelete: boolean;
+	hunks: ParsedHunk[];
+}
+
+/** Per-file error detail in the structured output. */
+export interface ApplyPatchFileError {
+	hunkIndex: number;
+	type:
+		| 'context-mismatch'
+		| 'file-not-found'
+		| 'file-unchanged'
+		| 'create-not-allowed'
+		| 'delete-not-allowed'
+		| 'binary-rejected'
+		| 'rename-rejected';
+	message: string;
+	expected?: string;
+	actual?: string;
+	line?: number;
+}
+
+/** Per-file result in the structured output. */
+export interface ApplyPatchFileResult {
+	file: string;
+	status: 'applied' | 'no-changes' | 'created' | 'error';
+	hunks: number;
+	hunksApplied: number;
+	hunksFailed: number;
+	errors?: ApplyPatchFileError[];
+}
+
+/** Structured JSON result returned by the tool. */
+export interface ApplyPatchResult {
+	success: boolean;
+	dryRun?: boolean;
+	files: ApplyPatchFileResult[];
+	summary: {
+		totalFiles: number;
+		applied: number;
+		failed: number;
+		totalHunks: number;
+	};
+}
+
+/** Arguments accepted by the apply_patch tool. */
+export interface ApplyPatchArgs {
+	patch: string;
+	files: string[];
+	dryRun?: boolean;
+	allowCreates?: boolean;
+	allowDeletes?: boolean;
+}
+
+// ============ Constants ============
+
+const WINDOWS_RESERVED_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|:|$)/i;
+const MAX_PATCH_SIZE = 500_000; // ~500KB to prevent pathological inputs
+
+// ============ Path Validation ============
+
+/**
+ * Check for Windows-specific path attacks (reserved device names, colon injection).
+ * Matches the pattern from suggest-patch.ts.
+ */
+function containsWindowsAttacks(filePath: string): boolean {
+	if (/:[^\\/]/.test(filePath)) return true;
+	const parts = filePath.split(/[/\\]/);
+	for (const part of parts) {
+		if (WINDOWS_RESERVED_NAMES.test(part)) return true;
+	}
+	return false;
+}
+
+/**
+ * Check whether a path targets a protected directory (.git/, .swarm/).
+ * Rejects ANY occurrence of .git or .swarm in the path (not just first segment).
+ */
+function isProtectedPath(filePath: string): boolean {
+	const normalized = filePath.replace(/\\/g, '/');
+	const segments = normalized.split('/');
+	return segments.some((seg) => seg === '.git' || seg === '.swarm');
+}
+
+/**
+ * Check for strict control characters (\x00-\x1F excluding \x09 tab).
+ */
+function containsStrictControlChars(str: string): boolean {
+	for (let i = 0; i < str.length; i++) {
+		const c = str.charCodeAt(i);
+		if (c <= 0x1f && c !== 0x09 && c !== 0x0a && c !== 0x0d) return true;
+	}
+	return false;
+}
+
+/**
+ * Check whether a canonical path contains a protected directory (.git/, .swarm/).
+ * Prevents symlink-based bypass: a symlink like `link/config` pointing to
+ * `.git/` would pass lexical isProtectedPath but must be caught here.
+ */
+function isCanonicalProtectedPath(
+	targetPath: string,
+	workspace: string,
+): boolean {
+	try {
+		const canonicalTarget = realpathSync(targetPath);
+		const canonicalWorkspace = realpathSync(workspace);
+		const relative = path
+			.relative(canonicalWorkspace, canonicalTarget)
+			.replace(/\\/g, '/');
+		const segments = relative.split('/').filter(Boolean);
+		return segments.some((seg) => seg === '.git' || seg === '.swarm');
+	} catch {
+		// Path doesn't exist — check parent directory's canonical segments
+		const parentDir = path.dirname(targetPath);
+		if (parentDir === targetPath) return false;
+		try {
+			const canonicalParent = realpathSync(parentDir);
+			const canonicalWorkspace = realpathSync(workspace);
+			const relative = path
+				.relative(canonicalWorkspace, canonicalParent)
+				.replace(/\\/g, '/');
+			const segments = relative.split('/').filter(Boolean);
+			return segments.some((seg) => seg === '.git' || seg === '.swarm');
+		} catch {
+			return false;
+		}
+	}
+}
+
+/**
+ * Check whether a canonical (symlink-resolved) path is within the workspace.
+ *
+ * For existing files/dirs, resolves the path itself via realpathSync.
+ * For paths that don't exist yet (e.g. new file creates), resolves the parent
+ * directory instead to prevent symlink escapes through intermediate components.
+ * Also re-checks protected-directory ban (.git, .swarm) on the canonical path.
+ *
+ * @returns true if the canonical path is safely contained within workspaceRoot.
+ */
+function isCanonicalPathWithinWorkspace(
+	targetPath: string,
+	workspaceRoot: string,
+): boolean {
+	try {
+		const canonicalTarget = realpathSync(targetPath);
+		const canonicalWorkspace = realpathSync(workspaceRoot);
+		const relative = path.relative(canonicalWorkspace, canonicalTarget);
+		if (relative.startsWith('..') || path.isAbsolute(relative)) return false;
+		// Re-apply protected-directory ban on the canonical target (all segments)
+		const segments = relative.replace(/\\/g, '/').split('/').filter(Boolean);
+		if (segments.some((seg) => seg === '.git' || seg === '.swarm'))
+			return false;
+		return true;
+	} catch {
+		// realpathSync failed (path doesn't exist) — validate parent directory instead
+		const parentDir = path.dirname(targetPath);
+		if (parentDir === targetPath) {
+			// Can't go higher (e.g. root) — reject
+			return false;
+		}
+		try {
+			const canonicalParent = realpathSync(parentDir);
+			const canonicalWorkspace = realpathSync(workspaceRoot);
+			const relative = path.relative(canonicalWorkspace, canonicalParent);
+			if (relative.startsWith('..') || path.isAbsolute(relative)) return false;
+			// Re-apply protected-directory ban on the canonical parent (all segments)
+			const segments = relative.replace(/\\/g, '/').split('/').filter(Boolean);
+			if (segments.some((seg) => seg === '.git' || seg === '.swarm'))
+				return false;
+			return true;
+		} catch {
+			// Parent also doesn't resolve — fall back to lexical check
+			// (caller should handle missing-parent errors separately)
+			return false;
+		}
+	}
+}
+
+/**
+ * Validate that a patch target path is safe and within the workspace boundary.
+ * Rejects: absolute paths, traversal, control chars, Windows attacks, protected dirs.
+ * Uses containsPathTraversal and containsControlChars from ../utils/path-security.
+ */
+function validatePatchTargetPath(
+	filePath: string,
+	workspace: string,
+): string | null {
+	if (!filePath || filePath.trim() === '') {
+		return 'Empty file path';
+	}
+	if (path.isAbsolute(filePath) || /^[A-Za-z]:[/\\]/.test(filePath)) {
+		return `Absolute path rejected: ${filePath}`;
+	}
+	if (containsPathTraversal(filePath)) {
+		return `Path traversal detected: ${filePath}`;
+	}
+	if (containsStrictControlChars(filePath)) {
+		return `Control characters detected in path: ${filePath}`;
+	}
+	// Also leverage the shared utility for additional patterns
+	if (containsControlChars(filePath)) {
+		return `Control characters detected in path: ${filePath}`;
+	}
+	if (containsWindowsAttacks(filePath)) {
+		return `Windows reserved name or invalid path: ${filePath}`;
+	}
+	if (isProtectedPath(filePath)) {
+		return `Protected directory target rejected: ${filePath}`;
+	}
+
+	// Verify the resolved path stays within the workspace (lexical check)
+	const resolved = path.resolve(workspace, filePath);
+	const relative = path.relative(workspace, resolved);
+	if (relative.startsWith('..') || path.isAbsolute(relative)) {
+		return `Path escapes workspace: ${filePath}`;
+	}
+
+	// Symlink/junction escape check: verify canonical path stays within workspace
+	if (!isCanonicalPathWithinWorkspace(resolved, workspace)) {
+		return `Path escapes workspace via symlink/junction: ${filePath}`;
+	}
+
+	return null; // valid
+}
+
+// ============ Unified Diff Parser ============
+
+/**
+ * Extract the file path from a --- or +++ header line.
+ * Handles a/, b/ prefixes and /dev/null.
+ */
+function extractHeaderPath(header: string, prefix: string): string | null {
+	const trimmed = header.trim();
+	if (!trimmed.startsWith(prefix)) return null;
+
+	const rest = trimmed.slice(prefix.length).trim();
+	if (rest === '/dev/null') return '/dev/null';
+
+	// Strip a/ or b/ prefix (standard git diff format)
+	if (rest.startsWith('a/') || rest.startsWith('b/')) {
+		const stripped = rest.slice(2);
+		if (stripped.length === 0) return null;
+		return stripped;
+	}
+
+	return rest.length > 0 ? rest : null;
+}
+
+/**
+ * Parse a @@ hunk header line.
+ */
+function parseHunkHeader(line: string): {
+	oldStart: number;
+	oldCount: number;
+	newStart: number;
+	newCount: number;
+} | null {
+	const match = line.match(/^@@\s*-(\d+)(?:,(\d+))?\s*\+(\d+)(?:,(\d+))?\s*@@/);
+	if (!match) return null;
+
+	return {
+		oldStart: parseInt(match[1], 10),
+		oldCount: match[2] !== undefined ? parseInt(match[2], 10) : 1,
+		newStart: parseInt(match[3], 10),
+		newCount: match[4] !== undefined ? parseInt(match[4], 10) : 1,
+	};
+}
+
+/**
+ * Parse a complete unified diff string into structured ParsedFileDiff objects.
+ * Rejects binary patches, rename/copy patches, and null bytes.
+ *
+ * Supports:
+ * 1. Extended git format: `diff --git a/foo b/foo` followed by ---/+++ headers
+ * 2. Standalone unified format: --- / +++ headers without git prefix
+ */
+function parseUnifiedDiff(patchText: string): {
+	files: ParsedFileDiff[];
+	error: string | null;
+} {
+	if (patchText.length > MAX_PATCH_SIZE) {
+		return {
+			files: [],
+			error: `Patch exceeds maximum size of ${MAX_PATCH_SIZE} characters`,
+		};
+	}
+
+	// Reject null bytes (binary content detection)
+	if (patchText.includes('\0')) {
+		return {
+			files: [],
+			error:
+				'Binary content detected (null byte) — binary patches are not supported (FR-013)',
+		};
+	}
+
+	// Normalize line endings to \n for consistent parsing
+	const normalized = patchText.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+	let lines = normalized.split('\n');
+	// Strip trailing empty element produced by split when patch ends with \n
+	if (lines.length > 0 && lines[lines.length - 1] === '') {
+		lines = lines.slice(0, -1);
+	}
+
+	// Reject binary patches
+	for (const line of lines) {
+		if (line === 'GIT binary patch' || line.startsWith('Binary files ')) {
+			return { files: [], error: 'Binary patches are not supported (FR-013)' };
+		}
+		// Reject rename/copy patches
+		if (
+			line.startsWith('rename from') ||
+			line.startsWith('rename to') ||
+			line.startsWith('copy from') ||
+			line.startsWith('copy to')
+		) {
+			return {
+				files: [],
+				error: 'Rename/copy patches are not supported (FR-013)',
+			};
+		}
+	}
+
+	const fileDiffs: ParsedFileDiff[] = [];
+	let i = 0;
+
+	while (i < lines.length) {
+		let oldHeaderPath: string | null = null;
+		let newHeaderPath: string | null = null;
+
+		if (lines[i].startsWith('diff --git ')) {
+			// Extended git format — skip to ---/+++
+			i++;
+
+			// Skip optional mode/index/similarity lines
+			while (
+				i < lines.length &&
+				(lines[i].startsWith('index ') ||
+					lines[i].startsWith('old mode ') ||
+					lines[i].startsWith('new mode ') ||
+					lines[i].startsWith('deleted file ') ||
+					lines[i].startsWith('new file ') ||
+					lines[i].startsWith('similarity index ') ||
+					lines[i].startsWith('dissimilarity index '))
+			) {
+				i++;
+			}
+		}
+
+		// Parse --- header
+		if (i < lines.length && lines[i].startsWith('--- ')) {
+			oldHeaderPath = extractHeaderPath(lines[i], '--- ');
+			i++;
+		} else if (oldHeaderPath === null) {
+			// No diff header and no --- line — skip
+			i++;
+			continue;
+		}
+
+		// Parse +++ header
+		if (i < lines.length && lines[i].startsWith('+++ ')) {
+			newHeaderPath = extractHeaderPath(lines[i], '+++ ');
+			i++;
+		} else {
+			continue; // Missing +++ — skip
+		}
+
+		if (oldHeaderPath === null || newHeaderPath === null) {
+			continue;
+		}
+
+		const isNewFile = oldHeaderPath === '/dev/null';
+		const isDelete = newHeaderPath === '/dev/null';
+		const targetPath = isDelete ? oldHeaderPath : newHeaderPath;
+
+		if (targetPath === '/dev/null') {
+			continue; // Both sides /dev/null — nothing to apply
+		}
+
+		// Parse hunks
+		const hunks: ParsedHunk[] = [];
+		while (i < lines.length && lines[i].startsWith('@@')) {
+			const header = parseHunkHeader(lines[i]);
+			if (!header) {
+				i++;
+				continue;
+			}
+			i++;
+
+			const hunkLines: HunkLine[] = [];
+			while (i < lines.length) {
+				const line = lines[i];
+				if (
+					line.startsWith('@@') ||
+					line.startsWith('diff --git ') ||
+					line.startsWith('--- ') ||
+					line.startsWith('+++ ')
+				) {
+					break; // Next hunk or next file
+				}
+
+				if (line.startsWith('\\')) {
+					// "\ No newline at end of file" marker — skip
+					i++;
+					continue;
+				}
+
+				// Defense-in-depth: only process lines with valid diff prefixes
+				if (line.length === 0) {
+					break; // Empty line signals end of hunk body
+				}
+
+				const firstChar = line[0];
+				if (firstChar !== ' ' && firstChar !== '+' && firstChar !== '-') {
+					break; // Unknown prefix — end of hunk body
+				}
+
+				if (firstChar === '+') {
+					hunkLines.push({ type: 'addition', content: line.slice(1) });
+				} else if (firstChar === '-') {
+					hunkLines.push({ type: 'removal', content: line.slice(1) });
+				} else {
+					// Space-prefixed = context
+					hunkLines.push({ type: 'context', content: line.slice(1) });
+				}
+				i++;
+			}
+
+			hunks.push({
+				oldStart: header.oldStart,
+				oldCount: header.oldCount,
+				newStart: header.newStart,
+				newCount: header.newCount,
+				lines: hunkLines,
+			});
+		}
+
+		if (hunks.length > 0) {
+			fileDiffs.push({
+				oldPath: oldHeaderPath,
+				newPath: newHeaderPath,
+				isNewFile,
+				isDelete,
+				hunks,
+			});
+		} else {
+			// Zero hunks but valid headers — produce a no-changes file entry
+			fileDiffs.push({
+				oldPath: oldHeaderPath,
+				newPath: newHeaderPath,
+				isNewFile,
+				isDelete,
+				hunks: [],
+			});
+		}
+	}
+
+	return { files: fileDiffs, error: null };
+}
+
+// ============ Hunk Application ============
+
+/**
+ * Result of applying hunks to file content.
+ */
+interface HunkApplyResult {
+	success: boolean;
+	appliedLines?: string[];
+	failedHunkIndex?: number;
+	error?: ApplyPatchFileError;
+}
+
+/**
+ * Check if two string arrays have identical content.
+ */
+function arraysEqual(a: string[], b: string[]): boolean {
+	if (a.length !== b.length) return false;
+	for (let idx = 0; idx < a.length; idx++) {
+		if (a[idx] !== b[idx]) return false;
+	}
+	return true;
+}
+
+/**
+ * Attempt to apply all hunks from a ParsedFileDiff to the given file content.
+ * Hunks are applied sequentially; on first failure, stops and returns diagnostics.
+ * Uses exact context matching — no fuzzy or offset matching (B3 decision).
+ *
+ * @returns HunkApplyResult with success/appliedLines or the first failing hunk's diagnostics.
+ */
+function applyHunks(
+	content: string,
+	fileDiff: ParsedFileDiff,
+): HunkApplyResult {
+	// Normalize CRLF to LF so context matching works regardless of file line endings
+	const normalizedContent = content.replace(/\r\n/g, '\n');
+	const fileLines = normalizedContent.split('\n');
+
+	// Handle new file creation (no existing content to match against)
+	if (fileDiff.isNewFile) {
+		const newLines: string[] = [];
+		for (const hunk of fileDiff.hunks) {
+			for (const line of hunk.lines) {
+				if (line.type === 'addition' || line.type === 'context') {
+					newLines.push(line.content);
+				}
+				// Removal lines in new file patch are unexpected but skip them
+			}
+		}
+		return { success: true, appliedLines: newLines };
+	}
+
+	// Handle delete patches — result is empty
+	if (fileDiff.isDelete) {
+		return { success: true, appliedLines: [] };
+	}
+
+	// Track accumulated delta so subsequent hunks match at the correct
+	// adjusted position after prior hunks changed line counts.
+	let accumulatedDelta = 0;
+
+	for (let hunkIdx = 0; hunkIdx < fileDiff.hunks.length; hunkIdx++) {
+		const hunk = fileDiff.hunks[hunkIdx];
+
+		// Compute match position: declared position adjusted by accumulated delta from prior hunks
+		const searchStart = Math.max(0, hunk.oldStart - 1 + accumulatedDelta);
+
+		// Extract expected context and removal lines from the hunk
+		const expectedOldLines: string[] = [];
+		const newLinesForHunk: string[] = [];
+
+		for (const line of hunk.lines) {
+			if (line.type === 'context') {
+				expectedOldLines.push(line.content);
+				newLinesForHunk.push(line.content);
+			} else if (line.type === 'removal') {
+				expectedOldLines.push(line.content);
+			} else if (line.type === 'addition') {
+				newLinesForHunk.push(line.content);
+			}
+		}
+
+		// Match ONLY at the exact position specified by the hunk header.
+		// No forward/backward search — if context shifted, report mismatch.
+		const exactOffset = searchStart;
+		const matchFound =
+			exactOffset <= fileLines.length - expectedOldLines.length &&
+			arraysEqual(
+				fileLines.slice(exactOffset, exactOffset + expectedOldLines.length),
+				expectedOldLines,
+			);
+
+		if (matchFound) {
+			fileLines.splice(
+				exactOffset,
+				expectedOldLines.length,
+				...newLinesForHunk,
+			);
+			const delta = newLinesForHunk.length - expectedOldLines.length;
+			accumulatedDelta += delta;
+		}
+
+		if (!matchFound) {
+			// Build diagnostic: show expected vs actual at the expected location
+			const diagStart = Math.min(searchStart, fileLines.length);
+			const diagEnd = Math.min(
+				diagStart + expectedOldLines.length,
+				fileLines.length,
+			);
+			const actualContent = fileLines.slice(diagStart, diagEnd).join('\n');
+			const expectedContent = expectedOldLines.join('\n');
+
+			return {
+				success: false,
+				failedHunkIndex: hunkIdx,
+				error: {
+					hunkIndex: hunkIdx,
+					type: 'context-mismatch',
+					message: `Context mismatch in hunk ${hunkIdx + 1} at line ${searchStart + 1}: expected context does not match file content`,
+					expected:
+						expectedContent.length > 200
+							? `${expectedContent.slice(0, 200)}... (truncated)`
+							: expectedContent,
+					actual:
+						actualContent.length > 200
+							? `${actualContent.slice(0, 200)}... (truncated)`
+							: actualContent,
+					line: searchStart + 1,
+				},
+			};
+		}
+	}
+
+	return { success: true, appliedLines: fileLines };
+}
+
+// ============ Atomic Write ============
+
+/**
+ * Atomically write content to a file using temp-file + rename.
+ * The temp file is created in the same directory as the target to ensure
+ * the rename stays on the same filesystem.
+ * Uses node:fs sync I/O (SR-003). On failure, cleans up the temp file.
+ */
+function atomicWriteFileSync(targetPath: string, content: string): void {
+	const dir = path.dirname(targetPath);
+	mkdirSync(dir, { recursive: true });
+
+	// Create a temporary file in the same directory for same-filesystem rename
+	const tempPrefix = `.apply-patch-${Date.now()}-${process.pid}`;
+	let tempPath: string;
+	try {
+		const tempDir = realpathSync(mkdtempSync(path.join(dir, tempPrefix)));
+		tempPath = path.join(tempDir, 'content');
+	} catch {
+		// Fallback: create a temp file directly in the target directory
+		tempPath = path.join(dir, `${tempPrefix}.tmp`);
+	}
+
+	try {
+		writeFileSync(tempPath, content, 'utf-8');
+		renameSync(tempPath, targetPath);
+	} finally {
+		// Best-effort cleanup of temp file if rename failed
+		if (existsSync(tempPath)) {
+			try {
+				unlinkSync(tempPath);
+			} catch {
+				// Temp file may have already been renamed — ignore
+			}
+		}
+		// Best-effort cleanup of temp directory if it was created
+		const tempDir = path.dirname(tempPath);
+		if (tempDir !== dir && existsSync(tempDir)) {
+			try {
+				rmdirSync(tempDir);
+			} catch {
+				// Directory not empty or already removed — ignore
+			}
+		}
+	}
+}
+
+// ============ Final Newline Preservation ============
+
+/**
+ * Detect the dominant line ending in a string.
+ * Returns '\r\n' if CRLF is present, '\n' otherwise.
+ */
+function detectLineEnding(content: string): '\r\n' | '\n' {
+	return content.includes('\r\n') ? '\r\n' : '\n';
+}
+
+/**
+ * Ensure content ends with a newline consistent with the original file (FR-014).
+ * If original ended with \n, result must end with \n.
+ * If original had no trailing newline, don't add one unless the patch explicitly adds it.
+ */
+function ensureFinalNewline(
+	content: string,
+	originalEndsWithNewline: boolean,
+): string {
+	if (originalEndsWithNewline && !content.endsWith('\n')) {
+		return `${content}\n`;
+	}
+	if (!originalEndsWithNewline && content.endsWith('\n')) {
+		return content.slice(0, -1);
+	}
+	return content;
+}
+
+// ============ Per-File Processing ============
+
+/**
+ * Process a single file diff: validate, apply hunks, write atomically.
+ * Returns a per-file result with hunk-level diagnostics.
+ */
+function processFileDiff(
+	fileDiff: ParsedFileDiff,
+	targetPath: string,
+	fullPath: string,
+	workspace: string,
+	dryRun: boolean,
+	allowCreates: boolean,
+	allowDeletes: boolean,
+): ApplyPatchFileResult {
+	const hunksTotal = fileDiff.hunks.length;
+
+	// Canonical path boundary check — prevent symlink/junction escape
+	// This validates the actual on-disk location before any I/O operations
+	if (!isCanonicalPathWithinWorkspace(fullPath, workspace)) {
+		return {
+			file: targetPath,
+			status: 'error',
+			hunks: hunksTotal,
+			hunksApplied: 0,
+			hunksFailed: hunksTotal,
+			errors: [
+				{
+					hunkIndex: 0,
+					type: 'context-mismatch',
+					message: `Path escapes workspace via symlink/junction: ${targetPath}`,
+				},
+			],
+		};
+	}
+
+	// Canonical protected-directory check — prevent symlink to .git/.swarm
+	if (isCanonicalProtectedPath(fullPath, workspace)) {
+		return {
+			file: targetPath,
+			status: 'error',
+			hunks: hunksTotal,
+			hunksApplied: 0,
+			hunksFailed: hunksTotal,
+			errors: [
+				{
+					hunkIndex: 0,
+					type: 'context-mismatch',
+					message: `Protected directory target rejected via symlink: ${targetPath}`,
+				},
+			],
+		};
+	}
+
+	// Handle new file creation (FR-011)
+	if (fileDiff.isNewFile) {
+		if (!allowCreates) {
+			return {
+				file: targetPath,
+				status: 'error',
+				hunks: hunksTotal,
+				hunksApplied: 0,
+				hunksFailed: hunksTotal,
+				errors: [
+					{
+						hunkIndex: 0,
+						type: 'create-not-allowed',
+						message: `New file creation not allowed: ${targetPath} (set allowCreates to true)`,
+					},
+				],
+			};
+		}
+
+		// Verify parent directory exists
+		const parentDir = path.dirname(fullPath);
+		if (!existsSync(parentDir)) {
+			return {
+				file: targetPath,
+				status: 'error',
+				hunks: hunksTotal,
+				hunksApplied: 0,
+				hunksFailed: hunksTotal,
+				errors: [
+					{
+						hunkIndex: 0,
+						type: 'file-not-found',
+						message: `Parent directory does not exist: ${parentDir}`,
+					},
+				],
+			};
+		}
+
+		// Verify file doesn't already exist (stale patch detection)
+		if (existsSync(fullPath)) {
+			return {
+				file: targetPath,
+				status: 'error',
+				hunks: hunksTotal,
+				hunksApplied: 0,
+				hunksFailed: hunksTotal,
+				errors: [
+					{
+						hunkIndex: 0,
+						type: 'file-not-found',
+						message: `File already exists: ${targetPath} (cannot create — patch may be stale)`,
+					},
+				],
+			};
+		}
+
+		if (hunksTotal === 0) {
+			return {
+				file: targetPath,
+				status: 'no-changes',
+				hunks: 0,
+				hunksApplied: 0,
+				hunksFailed: 0,
+			};
+		}
+
+		// Apply hunks for new file (extract addition lines)
+		const hunkResult = applyHunks('', fileDiff);
+		if (!hunkResult.success || !hunkResult.appliedLines) {
+			return {
+				file: targetPath,
+				status: 'error',
+				hunks: hunksTotal,
+				hunksApplied: 0,
+				hunksFailed: hunksTotal,
+				errors: hunkResult.error ? [hunkResult.error] : [],
+			};
+		}
+
+		if (!dryRun) {
+			const content = ensureFinalNewline(
+				hunkResult.appliedLines.join('\n'),
+				true,
+			);
+			atomicWriteFileSync(fullPath, content);
+		}
+
+		return {
+			file: targetPath,
+			status: 'created',
+			hunks: hunksTotal,
+			hunksApplied: hunksTotal,
+			hunksFailed: 0,
+		};
+	}
+
+	// Handle file deletion (FR-012)
+	if (fileDiff.isDelete) {
+		if (hunksTotal === 0) {
+			return {
+				file: targetPath,
+				status: 'no-changes',
+				hunks: 0,
+				hunksApplied: 0,
+				hunksFailed: 0,
+			};
+		}
+
+		if (!allowDeletes) {
+			return {
+				file: targetPath,
+				status: 'error',
+				hunks: hunksTotal,
+				hunksApplied: 0,
+				hunksFailed: hunksTotal,
+				errors: [
+					{
+						hunkIndex: 0,
+						type: 'delete-not-allowed',
+						message: `File deletion not allowed: ${targetPath} (set allowDeletes to true)`,
+					},
+				],
+			};
+		}
+
+		if (!existsSync(fullPath)) {
+			return {
+				file: targetPath,
+				status: 'error',
+				hunks: hunksTotal,
+				hunksApplied: 0,
+				hunksFailed: hunksTotal,
+				errors: [
+					{
+						hunkIndex: 0,
+						type: 'file-not-found',
+						message: `File not found for deletion: ${targetPath}`,
+					},
+				],
+			};
+		}
+
+		if (!dryRun) {
+			try {
+				unlinkSync(fullPath);
+			} catch (err) {
+				return {
+					file: targetPath,
+					status: 'error',
+					hunks: hunksTotal,
+					hunksApplied: 0,
+					hunksFailed: hunksTotal,
+					errors: [
+						{
+							hunkIndex: 0,
+							type: 'file-not-found',
+							message: `Failed to delete file: ${err instanceof Error ? err.message : String(err)}`,
+						},
+					],
+				};
+			}
+		}
+
+		return {
+			file: targetPath,
+			status: 'applied',
+			hunks: hunksTotal,
+			hunksApplied: hunksTotal,
+			hunksFailed: 0,
+		};
+	}
+
+	// --- Standard file modification path ---
+
+	if (!existsSync(fullPath)) {
+		return {
+			file: targetPath,
+			status: 'error',
+			hunks: hunksTotal,
+			hunksApplied: 0,
+			hunksFailed: hunksTotal,
+			errors: [
+				{
+					hunkIndex: 0,
+					type: 'file-not-found',
+					message: `File not found: ${targetPath}`,
+				},
+			],
+		};
+	}
+
+	let content: string;
+	try {
+		content = readFileSync(fullPath, 'utf-8');
+	} catch (err) {
+		return {
+			file: targetPath,
+			status: 'error',
+			hunks: hunksTotal,
+			hunksApplied: 0,
+			hunksFailed: hunksTotal,
+			errors: [
+				{
+					hunkIndex: 0,
+					type: 'file-not-found',
+					message: `Could not read file: ${err instanceof Error ? err.message : String(err)}`,
+				},
+			],
+		};
+	}
+
+	if (hunksTotal === 0) {
+		return {
+			file: targetPath,
+			status: 'no-changes',
+			hunks: 0,
+			hunksApplied: 0,
+			hunksFailed: 0,
+		};
+	}
+
+	// Detect whether original file ends with a newline (FR-014)
+	const originalEndsWithNewline = content.endsWith('\n');
+
+	// Detect dominant line ending to preserve CRLF on write (Problem 2)
+	const originalLineEnding = detectLineEnding(content);
+
+	// Apply hunks with exact context matching (FR-010)
+	const hunkResult = applyHunks(content, fileDiff);
+	if (!hunkResult.success) {
+		return {
+			file: targetPath,
+			status: 'error',
+			hunks: hunksTotal,
+			hunksApplied: 0,
+			hunksFailed: hunksTotal,
+			errors: hunkResult.error ? [hunkResult.error] : [],
+		};
+	}
+
+	// Build the result content (empty content requires allowDeletes — FR-012)
+	const resultContent = hunkResult.appliedLines!.join('\n');
+
+	// FR-012: Writing an empty file is a deletion — require allowDeletes
+	if (resultContent === '' && !dryRun && !allowDeletes && content.length > 0) {
+		return {
+			file: targetPath,
+			status: 'error',
+			hunks: hunksTotal,
+			hunksApplied: hunksTotal,
+			hunksFailed: 0,
+			errors: [
+				{
+					hunkIndex: 0,
+					type: 'delete-not-allowed',
+					message: `Patch would delete all content from ${targetPath}. Set allowDeletes to true to permit file deletion.`,
+				},
+			],
+		};
+	}
+
+	// Empty files have no line endings to preserve — write "" directly
+	// without line ending restoration (prevents extra newlines on empty content)
+	let finalContent: string;
+	if (resultContent === '') {
+		finalContent = '';
+	} else {
+		// Re-apply the original line ending before comparison and write
+		const withLineEnding =
+			originalLineEnding === '\r\n'
+				? resultContent.replace(/\n/g, '\r\n')
+				: resultContent;
+		finalContent = ensureFinalNewline(withLineEnding, originalEndsWithNewline);
+	}
+	if (finalContent === content) {
+		return {
+			file: targetPath,
+			status: 'no-changes',
+			hunks: hunksTotal,
+			hunksApplied: hunksTotal,
+			hunksFailed: 0,
+		};
+	}
+
+	if (!dryRun) {
+		atomicWriteFileSync(fullPath, finalContent);
+	}
+
+	return {
+		file: targetPath,
+		status: 'applied',
+		hunks: hunksTotal,
+		hunksApplied: hunksTotal,
+		hunksFailed: 0,
+	};
+}
+
+// ============ Error Result Builder ============
+
+/**
+ * Build an error result in the ApplyPatchResult shape.
+ */
+function buildErrorResult(message: string): ApplyPatchResult {
+	return {
+		success: false,
+		files: [
+			{
+				file: '',
+				status: 'error',
+				hunks: 0,
+				hunksApplied: 0,
+				hunksFailed: 0,
+				errors: [
+					{
+						hunkIndex: 0,
+						type: 'context-mismatch',
+						message,
+					},
+				],
+			},
+		],
+		summary: {
+			totalFiles: 0,
+			applied: 0,
+			failed: 1,
+			totalHunks: 0,
+		},
+	};
+}
+
+// ============ Tool Definition ============
+
+export const applyPatch: ToolDefinition = createSwarmTool({
+	description:
+		'Apply a unified diff patch to workspace files. Validates paths, matches context exactly, and writes atomically. Coder-scoped write tool.',
+	args: {
+		patch: z.string().min(1).describe('Unified diff text to parse and apply'),
+		files: z
+			.array(z.string())
+			.min(1)
+			.describe(
+				'Array of target file paths the patch is expected to touch. Every parsed target must appear in this list.',
+			),
+		dryRun: z
+			.boolean()
+			.optional()
+			.default(false)
+			.describe('Validate without writing files (default: false)'),
+		allowCreates: z
+			.boolean()
+			.optional()
+			.default(false)
+			.describe(
+				'Allow creating new files from patches with --- /dev/null (default: false)',
+			),
+		allowDeletes: z
+			.boolean()
+			.optional()
+			.default(false)
+			.describe(
+				'Allow deleting files from patches with +++ /dev/null (default: false)',
+			),
+	},
+	execute: async (args: unknown, directory: string): Promise<string> => {
+		// Safe args extraction
+		if (!args || typeof args !== 'object') {
+			return JSON.stringify(
+				buildErrorResult('Could not parse apply_patch arguments'),
+				null,
+				2,
+			);
+		}
+
+		const obj = args as Record<string, unknown>;
+		const patchText = (obj.patch as string) ?? '';
+		const files = (obj.files as string[]) ?? [];
+		const dryRun = (obj.dryRun as boolean) ?? false;
+		const allowCreates = (obj.allowCreates as boolean) ?? false;
+		const allowDeletes = (obj.allowDeletes as boolean) ?? false;
+
+		// Validate workspace directory
+		if (!existsSync(directory)) {
+			return JSON.stringify(
+				buildErrorResult('Workspace directory does not exist'),
+				null,
+				2,
+			);
+		}
+
+		// Validate files array
+		if (files.length === 0) {
+			return JSON.stringify(
+				buildErrorResult('files array cannot be empty'),
+				null,
+				2,
+			);
+		}
+
+		// Validate patch text
+		if (!patchText || patchText.trim() === '') {
+			return JSON.stringify(
+				buildErrorResult('patch text cannot be empty'),
+				null,
+				2,
+			);
+		}
+
+		// Validate all declared file paths up front (FR-003, SR-005)
+		for (const filePath of files) {
+			const validationError = validatePatchTargetPath(filePath, directory);
+			if (validationError) {
+				return JSON.stringify(buildErrorResult(validationError), null, 2);
+			}
+		}
+
+		// Parse the unified diff (FR-001, FR-013)
+		const { files: parsedFiles, error: parseError } =
+			parseUnifiedDiff(patchText);
+		if (parseError) {
+			return JSON.stringify(buildErrorResult(parseError), null, 2);
+		}
+
+		if (parsedFiles.length === 0) {
+			return JSON.stringify(
+				{
+					success: true,
+					dryRun,
+					files: [],
+					summary: { totalFiles: 0, applied: 0, failed: 0, totalHunks: 0 },
+				} satisfies ApplyPatchResult,
+				null,
+				2,
+			);
+		}
+
+		// FR-002: Every parsed target must appear in files[]
+		const declaredFileSet = new Set(files);
+		const undeclaredTargets: string[] = [];
+		for (const fileDiff of parsedFiles) {
+			const targetPath = fileDiff.isDelete
+				? fileDiff.oldPath
+				: fileDiff.newPath;
+			if (
+				targetPath &&
+				targetPath !== '/dev/null' &&
+				!declaredFileSet.has(targetPath)
+			) {
+				undeclaredTargets.push(targetPath);
+			}
+		}
+		if (undeclaredTargets.length > 0) {
+			return JSON.stringify(
+				buildErrorResult(
+					`Patch targets files not in the declared files array: ${undeclaredTargets.join(', ')}`,
+				),
+				null,
+				2,
+			);
+		}
+
+		// Warn for extra entries in files[] not targeted by the patch
+		const parsedTargetSet = new Set(
+			parsedFiles
+				.map((fd) => (fd.isDelete ? fd.oldPath : fd.newPath))
+				.filter(Boolean),
+		);
+		const extraFiles = files.filter((f) => !parsedTargetSet.has(f));
+
+		// Process each file independently (D1 decision: partial across files)
+		const fileResults: ApplyPatchFileResult[] = [];
+		let totalApplied = 0;
+		let totalFailed = 0;
+		let totalHunks = 0;
+
+		for (const fileDiff of parsedFiles) {
+			const targetPath = fileDiff.isDelete
+				? fileDiff.oldPath!
+				: fileDiff.newPath!;
+			const fullPath = path.resolve(directory, targetPath);
+			totalHunks += fileDiff.hunks.length;
+
+			const result = processFileDiff(
+				fileDiff,
+				targetPath,
+				fullPath,
+				directory,
+				dryRun,
+				allowCreates,
+				allowDeletes,
+			);
+
+			fileResults.push(result);
+			if (result.status === 'applied' || result.status === 'created') {
+				totalApplied++;
+			} else if (result.status === 'error') {
+				totalFailed++;
+			}
+		}
+
+		const output: ApplyPatchResult = {
+			success: totalFailed === 0,
+			dryRun,
+			files: fileResults,
+			summary: {
+				totalFiles: fileResults.length,
+				applied: totalApplied,
+				failed: totalFailed,
+				totalHunks,
+			},
+		};
+
+		// Include warnings for extra files if any
+		if (extraFiles.length > 0) {
+			return JSON.stringify(
+				{
+					...output,
+					warnings: [
+						`files[] contains entries not targeted by the patch: ${extraFiles.join(', ')}`,
+					],
+				},
+				null,
+				2,
+			);
+		}
+
+		return JSON.stringify(output, null, 2);
+	},
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,3 +1,4 @@
+export { applyPatch } from './apply-patch';
 export { batch_symbols } from './batch-symbols';
 export { build_check } from './build-check';
 export { check_gate_status } from './check-gate-status';

--- a/src/tools/manifest.ts
+++ b/src/tools/manifest.ts
@@ -23,6 +23,7 @@
  * Neither is implemented (no current tool needs them). Not tree-shakeable.
  */
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
+import { applyPatch } from './apply-patch';
 import { batch_symbols } from './batch-symbols';
 import { build_check } from './build-check';
 import { check_gate_status } from './check-gate-status';
@@ -204,4 +205,5 @@ export const TOOL_MANIFEST = defineHandlers({
 	lean_turbo_review: () => lean_turbo_review,
 	lean_turbo_run_phase: () => lean_turbo_run_phase,
 	lean_turbo_status: () => lean_turbo_status,
+	apply_patch: () => applyPatch,
 });

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -571,6 +571,11 @@ export const TOOL_METADATA = {
 			'returns Lean Turbo configuration and active status for the current session',
 		agents: ['architect'],
 	},
+	apply_patch: {
+		description:
+			'Apply a unified diff patch to workspace files with exact context matching, atomic writes, and path validation',
+		agents: ['coder'],
+	},
 } satisfies Record<string, ToolMeta>;
 
 /** Union type of all valid tool names (the metadata keys). */

--- a/tests/unit/hooks/scope-guard-sanitize.test.ts
+++ b/tests/unit/hooks/scope-guard-sanitize.test.ts
@@ -156,4 +156,50 @@ describe('sanitizePath — C0 control character hardening', () => {
 		// 32 C0 + 1 DEL = 33 underscores
 		expect(result).toBe('_'.repeat(33));
 	});
+
+	describe('C1 control characters (0x80-0x9F)', () => {
+		const C1_BOUNDARIES: Array<{ name: string; code: number }> = [
+			{ name: 'PAD', code: 0x80 },
+			{ name: 'BPH', code: 0x83 },
+			{ name: 'NEL', code: 0x85 },
+			{ name: 'SSA', code: 0x88 },
+			{ name: 'ESA', code: 0x89 },
+			{ name: 'HTS', code: 0x88 },
+			{ name: 'DCS', code: 0x90 },
+			{ name: 'ST', code: 0x9c },
+			{ name: 'OSC', code: 0x9d },
+			{ name: 'PM', code: 0x9e },
+			{ name: 'APC', code: 0x9f },
+		];
+
+		test.each(
+			C1_BOUNDARIES,
+		)('C1 control $name (0x${code.toString(16).padStart(2, "0")}) → replaced with _', ({
+			code,
+		}) => {
+			const input = `prefix${charStr(code)}suffix`;
+			expect(sanitizePath(input)).toBe('prefix_suffix');
+		});
+
+		test('All C1 controls (0x80-0x9F) replaced with _ in bulk', () => {
+			let input = 'prefix';
+			for (let code = 0x80; code <= 0x9f; code++) {
+				input += charStr(code);
+			}
+			input += 'suffix';
+			// 32 C1 chars replaced with 32 underscores
+			expect(sanitizePath(input)).toBe(`prefix${'_'.repeat(32)}suffix`);
+		});
+
+		test('Regular characters above 0x9F are preserved', () => {
+			// 0xA0 (NBSP), 0xFF (ÿ), and multi-byte Unicode should all pass through
+			const input = `prefix${charStr(0xa0)}mid${charStr(0xff)}end`;
+			expect(sanitizePath(input)).toBe(input);
+		});
+
+		test('CJK characters (above 0x9F) are preserved', () => {
+			const input = '/home/用户/项目/文件.ts';
+			expect(sanitizePath(input)).toBe('/home/用户/项目/文件.ts');
+		});
+	});
 });

--- a/tests/unit/hooks/scope-guard-sanitize.test.ts
+++ b/tests/unit/hooks/scope-guard-sanitize.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'bun:test';
+import { _internals } from '../../../src/hooks/scope-guard';
+
+const { sanitizePath } = _internals;
+
+// Helper to create a string with a given char code
+function charStr(code: number): string {
+	return String.fromCharCode(code);
+}
+
+describe('sanitizePath — C0 control character hardening', () => {
+	// All 32 C0 controls (0x00–0x1F) plus DEL (0x7F)
+	const C0_CONTROLS: Array<{ name: string; code: number }> = [
+		{ name: 'NUL', code: 0x00 },
+		{ name: 'SOH', code: 0x01 },
+		{ name: 'STX', code: 0x02 },
+		{ name: 'ETX', code: 0x03 },
+		{ name: 'EOT', code: 0x04 },
+		{ name: 'ENQ', code: 0x05 },
+		{ name: 'ACK', code: 0x06 },
+		{ name: 'BEL', code: 0x07 },
+		{ name: 'BS', code: 0x08 },
+		{ name: 'TAB', code: 0x09 },
+		{ name: 'LF', code: 0x0a },
+		{ name: 'VT', code: 0x0b },
+		{ name: 'FF', code: 0x0c },
+		{ name: 'CR', code: 0x0d },
+		{ name: 'SO', code: 0x0e },
+		{ name: 'SI', code: 0x0f },
+		{ name: 'DLE', code: 0x10 },
+		{ name: 'DC1', code: 0x11 },
+		{ name: 'DC2', code: 0x12 },
+		{ name: 'DC3', code: 0x13 },
+		{ name: 'DC4', code: 0x14 },
+		{ name: 'NAK', code: 0x15 },
+		{ name: 'SYN', code: 0x16 },
+		{ name: 'ETB', code: 0x17 },
+		{ name: 'CAN', code: 0x18 },
+		{ name: 'EM', code: 0x19 },
+		{ name: 'SUB', code: 0x1a },
+		{ name: 'ESC', code: 0x1b },
+		{ name: 'FS', code: 0x1c },
+		{ name: 'GS', code: 0x1d },
+		{ name: 'RS', code: 0x1e },
+		{ name: 'US', code: 0x1f },
+	];
+
+	test.each(
+		C0_CONTROLS,
+	)('C0 control $name (0x${code.toString(16).padStart(2, "0")}) → replaced with _', ({
+		code,
+	}) => {
+		const input = `prefix${charStr(code)}suffix`;
+		const expected = 'prefix_suffix';
+		expect(sanitizePath(input)).toBe(expected);
+	});
+
+	test('DEL (0x7F) → replaced with _', () => {
+		const input = `prefix${charStr(0x7f)}suffix`;
+		expect(sanitizePath(input)).toBe('prefix_suffix');
+	});
+
+	test('Null byte (0x00) embedded in path → replaced with _', () => {
+		// NUL specifically called out in the original hardening spec
+		const input = `/home/user/file${charStr(0x00)}.txt`;
+		expect(sanitizePath(input)).toBe('/home/user/file_.txt');
+	});
+
+	test('LF (0x0A) → replaced with _', () => {
+		const input = `/home/user/${charStr(0x0a)}file.txt`;
+		expect(sanitizePath(input)).toBe('/home/user/_file.txt');
+	});
+
+	test('CR (0x0D) → replaced with _', () => {
+		const input = `/home/user/${charStr(0x0d)}file.txt`;
+		expect(sanitizePath(input)).toBe('/home/user/_file.txt');
+	});
+
+	test('BS (0x08) backspace → replaced with _', () => {
+		const input = `/home/${charStr(0x08)}user/file.txt`;
+		expect(sanitizePath(input)).toBe('/home/_user/file.txt');
+	});
+
+	test('TAB (0x09) → replaced with _', () => {
+		const input = `/home\tuser/file.txt`;
+		expect(sanitizePath(input)).toBe('/home_user/file.txt');
+	});
+
+	test('VT (0x0B) vertical tab → replaced with _', () => {
+		const input = `/home/${charStr(0x0b)}user/file.txt`;
+		expect(sanitizePath(input)).toBe('/home/_user/file.txt');
+	});
+
+	test('FF (0x0C) form feed → replaced with _', () => {
+		const input = `/home/${charStr(0x0c)}user/file.txt`;
+		expect(sanitizePath(input)).toBe('/home/_user/file.txt');
+	});
+
+	test('ESC (0x1B) → replaced with _', () => {
+		// ESC is within C0 range but explicitly checked per spec
+		const input = `/home/${charStr(0x1b)}user/file.txt`;
+		expect(sanitizePath(input)).toBe('/home/_user/file.txt');
+	});
+
+	test('Mixed control chars in one path — all replaced', () => {
+		// Mix of NUL, LF, CR, DEL
+		const input = `${charStr(0x00)}${charStr(0x0a)}${charStr(0x0d)}${charStr(0x7f)}`;
+		expect(sanitizePath(input)).toBe('____');
+	});
+
+	test('Normal path with no control chars → unchanged', () => {
+		const input = '/home/user/project/src/index.ts';
+		expect(sanitizePath(input)).toBe('/home/user/project/src/index.ts');
+	});
+
+	test('Path with only safe ASCII printable chars → unchanged', () => {
+		const input = 'src/hooks/scope-guard.ts';
+		expect(sanitizePath(input)).toBe('src/hooks/scope-guard.ts');
+	});
+
+	test('Unicode characters outside control range → preserved', () => {
+		const input = '/home/用户/项目/文件.ts';
+		expect(sanitizePath(input)).toBe('/home/用户/项目/文件.ts');
+	});
+
+	test('ANSI CSI sequence stripped after control char removal', () => {
+		// ESC [ 31 m  (red color code)
+		const input = `/home/${charStr(0x1b)}[31muser/file.txt`;
+		// ESC → _, then ANSI CSI stripped
+		expect(sanitizePath(input)).toBe('/home/_user/file.txt');
+	});
+
+	test('Multiple ANSI CSI sequences stripped', () => {
+		// ESC is replaced with _; CSI sequences ([1;2;3m, [4;5m) are stripped from result
+		const input = `/home/${charStr(0x1b)}[1;2;3muser${charStr(0x1b)}[4;5mfile.txt`;
+		// ESC→_, then CSI codes stripped: /home/ _ [1;2;3m user _ [4;5m file.txt → /home/_user_file.txt
+		expect(sanitizePath(input)).toBe('/home/_user_file.txt');
+	});
+
+	test('Leading control characters stripped', () => {
+		const input = `${charStr(0x00)}/home/user/file.txt`;
+		expect(sanitizePath(input)).toBe('_/home/user/file.txt');
+	});
+
+	test('Trailing control characters stripped', () => {
+		const input = `/home/user/file.txt${charStr(0x1f)}`;
+		expect(sanitizePath(input)).toBe('/home/user/file.txt_');
+	});
+
+	test('All control characters replaced in sequence — no survivors', () => {
+		// Every character in the input is a control char
+		const allControls = C0_CONTROLS.map((c) => charStr(c.code)).join('');
+		const delOnly = charStr(0x7f);
+		const input = allControls + delOnly;
+		const result = sanitizePath(input);
+		// 32 C0 + 1 DEL = 33 underscores
+		expect(result).toBe('_'.repeat(33));
+	});
+});

--- a/tests/unit/hooks/scope-guard-security.test.ts
+++ b/tests/unit/hooks/scope-guard-security.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Security hardening verification tests for scope-guard.ts
+ * Tests the three security hardening fixes:
+ * 1. sanitizePath strips null bytes (\0) before path.resolve
+ * 2. isFileInScope filters empty strings from scopeEntries
+ * 3. sanitizePath regex expanded to cover \b, \f, \v
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { _internals, isFileInScope } from '../../../src/hooks/scope-guard';
+
+const { sanitizePath } = _internals;
+
+describe('scope-guard security hardening', () => {
+	describe('1. sanitizePath strips null bytes (\\0)', () => {
+		test('null byte in filename is replaced with underscore', () => {
+			const result = sanitizePath('file\x00.txt');
+			expect(result).toBe('file_.txt');
+		});
+
+		test('null byte at start of path is replaced', () => {
+			const result = sanitizePath('\x00file.txt');
+			expect(result).toBe('_file.txt');
+		});
+
+		test('null byte in directory component is replaced', () => {
+			const result = sanitizePath('dir\x00/file.txt');
+			expect(result).toBe('dir_/file.txt');
+		});
+
+		test('multiple null bytes are all replaced', () => {
+			const result = sanitizePath('fi\x00le\x00.txt');
+			expect(result).toBe('fi_le_.txt');
+		});
+	});
+
+	describe('2. isFileInScope filters empty strings from scopeEntries', () => {
+		test('empty string in scopeEntries does NOT neutralize scope restrictions', () => {
+			// Bug: path.resolve(dir, '') returns dir itself
+			// Without the filter, '' scope entry would match ANY file under dir!
+			// With the filter, only '/workspace/src' scope entry is checked
+			const result = isFileInScope(
+				'/workspace/src/foo.ts',
+				['', '/workspace/src'],
+				'/workspace',
+			);
+			// foo.ts IS under /workspace/src, so it should be in scope
+			expect(result).toBe(true);
+		});
+
+		test('empty string alone in scopeEntries allows nothing (no false positives)', () => {
+			// If only empty string in scope, nothing should be in scope
+			const result = isFileInScope('/workspace/src/foo.ts', [''], '/workspace');
+			expect(result).toBe(false);
+		});
+
+		test('multiple empty strings filtered out, real scopes still work', () => {
+			const result = isFileInScope(
+				'/other/src/foo.ts',
+				['', '', '/other/src', ''],
+				'/workspace',
+			);
+			expect(result).toBe(true);
+		});
+
+		test('path exactly matching non-empty scope entry', () => {
+			// File exactly matching a scope entry should be in scope
+			const result = isFileInScope(
+				'/workspace/src/foo.ts',
+				['', '/workspace/src/foo.ts'],
+				'/workspace',
+			);
+			expect(result).toBe(true);
+		});
+
+		test('file in subdirectory of non-empty scope entry', () => {
+			const result = isFileInScope(
+				'/workspace/src/sub/foo.ts',
+				['', '/workspace/src'],
+				'/workspace',
+			);
+			expect(result).toBe(true);
+		});
+
+		test('file outside scope with empty string present', () => {
+			const result = isFileInScope(
+				'/outside/foo.ts',
+				['', '/workspace/src'],
+				'/workspace',
+			);
+			expect(result).toBe(false);
+		});
+
+		test('empty string filter - file at root of workspace is IN scope', () => {
+			// path.resolve('/workspace', '/workspace') = '/workspace'
+			// path.relative('/workspace', '/workspace') = '' (length 0)
+			// exact match: '/workspace' === '/workspace' -> true
+			const result = isFileInScope(
+				'/workspace',
+				['', '/workspace'],
+				'/workspace',
+			);
+			expect(result).toBe(true);
+		});
+	});
+
+	describe('3. sanitizePath strips control characters \\b, \\f, \\v', () => {
+		test('backspace (\\x08) is stripped', () => {
+			const result = sanitizePath('file\x08.txt');
+			expect(result).toBe('file_.txt');
+		});
+
+		test('form feed (\\x0c) is stripped', () => {
+			const result = sanitizePath('file\x0c.txt');
+			expect(result).toBe('file_.txt');
+		});
+
+		test('vertical tab (\\x0b) is stripped', () => {
+			const result = sanitizePath('file\x0b.txt');
+			expect(result).toBe('file_.txt');
+		});
+
+		test('multiple control chars in sequence are all stripped', () => {
+			const result = sanitizePath('file\x08\x0c\x0b.txt');
+			expect(result).toBe('file___.txt');
+		});
+
+		test('mixed control chars all stripped', () => {
+			const result = sanitizePath('file\x00\x08\x0c\x0b.txt');
+			expect(result).toBe('file____.txt');
+		});
+	});
+
+	describe('6. existing behavior preserved: CR, LF, TAB, ESC still stripped', () => {
+		test('carriage return (\\r) is stripped', () => {
+			const result = sanitizePath('file\r.txt');
+			expect(result).toBe('file_.txt');
+		});
+
+		test('line feed (\\n) is stripped', () => {
+			const result = sanitizePath('file\n.txt');
+			expect(result).toBe('file_.txt');
+		});
+
+		test('tab (\\t) is stripped', () => {
+			const result = sanitizePath('file\t.txt');
+			expect(result).toBe('file_.txt');
+		});
+
+		test('ESC (\\x1b) alone is stripped', () => {
+			// ESC is replaced with underscore
+			const result = sanitizePath('file\x1b.txt');
+			expect(result).toBe('file_.txt');
+		});
+
+		test('ESC followed by ANSI CSI sequence is stripped', () => {
+			// ESC + '[31m' -> split on ESC gives ['', '31m'] -> join with '_' gives '_31m'
+			// Then ANSI CSI regex strips the '31m' part
+			const result = sanitizePath('file\x1b[31m.txt');
+			expect(result).toBe('file_.txt');
+		});
+
+		test('complex ANSI sequence stripped', () => {
+			const result = sanitizePath('file\x1b[38;5;255m.txt');
+			expect(result).toBe('file_.txt');
+		});
+
+		test('multiple ANSI sequences - each ESC becomes underscore then CSI stripped', () => {
+			// file<ESC>[31m<ESC>[0m.txt -> file_[31m_[0m.txt -> file__.txt
+			const result = sanitizePath('file\x1b[31m\x1b[0m.txt');
+			expect(result).toBe('file__.txt');
+		});
+	});
+
+	describe('7. no regression: normal paths pass through unchanged', () => {
+		test('simple filename unchanged', () => {
+			const result = sanitizePath('foo.ts');
+			expect(result).toBe('foo.ts');
+		});
+
+		test('relative path unchanged', () => {
+			const result = sanitizePath('./src/foo.ts');
+			expect(result).toBe('./src/foo.ts');
+		});
+
+		test('absolute path unchanged', () => {
+			const result = sanitizePath('/workspace/src/foo.ts');
+			expect(result).toBe('/workspace/src/foo.ts');
+		});
+
+		test('nested path unchanged', () => {
+			const result = sanitizePath('/workspace/src/sub/deep/foo.ts');
+			expect(result).toBe('/workspace/src/sub/deep/foo.ts');
+		});
+
+		test('paths with spaces unchanged', () => {
+			const result = sanitizePath('/workspace/src/my file.ts');
+			expect(result).toBe('/workspace/src/my file.ts');
+		});
+
+		test('paths with Unicode unchanged', () => {
+			const result = sanitizePath('/workspace/src/café.ts');
+			expect(result).toBe('/workspace/src/café.ts');
+		});
+
+		test('paths with emoji unchanged', () => {
+			const result = sanitizePath('/workspace/src/file🚀.ts');
+			expect(result).toBe('/workspace/src/file🚀.ts');
+		});
+
+		test('paths with dashes and underscores unchanged', () => {
+			const result = sanitizePath('/workspace/src/my-file_123.ts');
+			expect(result).toBe('/workspace/src/my-file_123.ts');
+		});
+
+		test('paths with dots unchanged', () => {
+			const result = sanitizePath('/workspace/src/.hidden.ts');
+			expect(result).toBe('/workspace/src/.hidden.ts');
+		});
+	});
+
+	describe('integration: sanitized paths work correctly with isFileInScope', () => {
+		test('sanitized null-byte path is still checked against scope', () => {
+			// After sanitization, 'file_.txt' is treated as a literal filename
+			// 'file_.txt' under /workspace is in scope (it's a child of /workspace)
+			const sanitized = sanitizePath('file\x00.txt');
+			expect(sanitized).toBe('file_.txt');
+			// The sanitized name doesn't match the scope path, but scope is '/workspace'
+			// so any file under /workspace is in scope - the test logic is correct
+		});
+
+		test('sanitized control-char path is still checked against scope', () => {
+			// After sanitization, 'file_.txt' is treated as a literal filename
+			const sanitized = sanitizePath('file\x08.txt');
+			expect(sanitized).toBe('file_.txt');
+		});
+
+		test('sanitized null-byte path not in scope when parent dir differs', () => {
+			// 'file\x00.txt' sanitizes to 'file_.txt'
+			// 'file_.txt' is NOT under '/other' scope
+			const sanitized = sanitizePath('file\x00.txt');
+			const result = isFileInScope(sanitized, ['/other'], '/workspace');
+			expect(result).toBe(false);
+		});
+
+		test('sanitized control-char path not in scope when parent dir differs', () => {
+			const sanitized = sanitizePath('file\x08.txt');
+			const result = isFileInScope(sanitized, ['/other'], '/workspace');
+			expect(result).toBe(false);
+		});
+
+		test('normal path IS in scope after sanitization (no-op)', () => {
+			const sanitized = sanitizePath('/workspace/src/foo.ts');
+			const result = isFileInScope(sanitized, ['/workspace/src'], '/workspace');
+			expect(result).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
﻿Closes #1103

## Summary
- **New `apply_patch` tool** (`src/tools/apply-patch.ts`, ~1300 lines): A native Swarm tool that parses and applies unified diffs in-process under Swarm's safety model. Pure TypeScript, no shell/git/external binaries. Uses `createSwarmTool` pattern with canonical symlink protection, workspace boundary enforcement, `.git`/`.swarm` protected directory checks, exact context matching with accumulated delta tracking, per-file atomic writes, dry-run mode, `allowCreates`/`allowDeletes` gates, and structured JSON results.
- **Tool registration** (`tool-metadata.ts`, `manifest.ts`, `index.ts`): Registered as tool #83 with `agents: ['coder']`. Coherent across metadata, handlers, plugin object, `TOOL_NAMES`, and `AGENT_TOOL_MAP` (verified by `check-tool-registration.ts`).
- **Scope-guard array-aware path extraction** (`scope-guard.ts`): Extended to extract paths from `files[]`, `paths[]`, `targetFiles[]` array arguments, preventing scope bypass via multi-file tool calls. 187 lines changed with 50+ new test scenarios across 3 test files.
- **28 tests pass**, 3 skipped (CRLF/no-trailing-NL/empty-patch edge cases), 0 failures. 87 scope-guard unit tests pass.

## Invariant audit
- 1 (plugin init): not touched — no init-path changes
- 2 (runtime portability): not touched — pure TypeScript, no `bun:` imports, `createSwarmTool` pattern
- 3 (subprocesses): not touched — no spawn calls, pure `node:fs` sync I/O only
- 4 (.swarm containment): not touched — tool operates on workspace files only
- 5 (plan durability): not touched — no plan state changes
- 6 (test_runner safety): not touched — tests run via `bun test` directly
- 7 (test writing): touched — new test files use `bun:test`, `os.tmpdir()` + `mkdtempSync` + `realpathSync`, no `mock.module`
- 8 (session state): not touched — no session state changes
- 9 (guardrails/retry): not touched — `apply_patch` is already in `WRITE_TOOL_NAMES` (constants.ts:240)
- 10 (chat/system msg): not touched
- 11 (tool registration): touched — added `apply_patch` to `tool-metadata.ts`, `manifest.ts`, `index.ts`. Verified: `check-tool-registration.ts` reports 83 tools coherent across all layers. Config unit tests pass (17/20; 3 pre-existing failures on main).
- 12 (release/cache): not touched

## Test plan
- [x] `bun test src/tools/apply-patch.test.ts` — 28 pass, 3 skip, 0 fail
- [x] `bun test src/hooks/scope-guard-*.test.ts` — 50 pass across 3 files
- [x] `bun test tests/unit/hooks/scope-guard-*.test.ts` — 87 pass across 2 files
- [x] `bun run build` — clean build
- [x] `bun run typecheck` — clean
- [x] `bun run scripts/check-tool-registration.ts` — 83 tools, coherent
- [x] SAST scan — 0 findings (baseline diffed)
- [x] Secret scan — 0 findings
- [x] Final council review — Round 2: CONCERNS (non-blocking), all required fixes resolved

## Pre-existing failures
The following test failures reproduce on clean `origin/main` and are not introduced by this PR:
- `tests/unit/config/constants.test.ts`: 3 failures (ALL_SUBAGENT_NAMES length, ALL_AGENT_NAMES length, DEFAULT_MODELS length) — config schema changes not yet reflected in test expectations
- `tests/unit/config/critic-registration.test.ts`: 1 failure (critic_sounding_board model mismatch)
- `tests/unit/config/loader.test.ts`: 1 failure (adversarial_testing defaults shape)
- `tests/unit/config/quiet-config.test.ts`: 1 failure (deprecation warning count)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native `apply_patch` tool to apply unified diffs in-process with exact context matching and atomic writes, and hardens scope enforcement to validate array-based path args and block empty-array/empty-scope bypasses.

- **New Features**
  - New `apply_patch`: parses unified diffs with exact context matching; atomic per-file writes; dry-run; `allowCreates`/`allowDeletes`; structured JSON results; pure TypeScript (no git/shell); enforces workspace boundaries and blocks `.git/`/`.swarm/`.
  - Tool registered in manifest/metadata and enabled for `coder`.

- **Bug Fixes**
  - Scope guard validates paths from array args (`files[]`, `paths[]`, `targetFiles[]`) and all single-path keys; closes empty-array and empty-scope bypasses; `sanitizePath` strips C0/C1 control chars and ANSI sequences.
  - Enabled CRLF, no-trailing-newline, and empty-patch tests (31/31 pass, 0 skip); removed obsolete doc caveat; corrected docs, removed dead code, and dropped a BOM.

<sup>Written for commit 8f30c42528025f27640485c66e2de5cfec3b8ac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

