### PR TITLE
docs(swarm-pr-review): add branch checkout requirement to pre-flight section

### DIFF
--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -109,9 +109,10 @@ If scope cannot be determined, review the narrowest safe scope available and sta
 
 Before launching explorers (Phase 3), confirm the PR branch refs are available:
 - If `head_ref` is a remote branch that is not checked out locally, fetch it via `git fetch origin <head_ref>`
-- Explicitly pass the commit range (`base_ref..head_ref`) in every explorer delegation so explorers read from the correct revision
+- **Check out the head branch locally.** Explorer agents read files from the working tree, not from git history — passing the commit range in the delegation prompt is not sufficient because `Read` / `Glob` / `Grep` tools operate on the filesystem. Without a checkout, explorers silently read the base branch's version of changed files and produce invalid candidates. **Before checking out, verify the working tree is clean (`git status --porcelain`). If uncommitted changes exist, stash them or abort the checkout to prevent data loss.**
+- Explicitly pass the commit range (`base_ref..head_ref`) in every explorer delegation so explorers have the revision context for `git show` commands if they need to inspect specific versions.
 
-If refs cannot be fetched, state the limitation in the context pack.
+If refs cannot be fetched or checked out, state the limitation in the context pack.
 
 ---
 

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -52,7 +52,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "opencode-swarm",
-    version: "7.49.1",
+    version: "7.50.0",
     description: "Architect-centric agentic swarm plugin for OpenCode - hub-and-spoke orchestration with SME consultation, code generation, and QA review",
     main: "dist/index.js",
     types: "dist/index.d.ts",


### PR DESCRIPTION
## Summary

The swarm-pr-review skill's pre-flight section told architects to fetch the PR branch and pass the commit range to explorers, but never required checking it out. Explorer agent tools (Read, Glob, Grep) operate on the filesystem working tree, not on git history - passing a commit range in a delegation prompt is insufficient. Without a checkout, explorers silently read the base branch's files and produce candidates based on wrong code, wasting the entire review pipeline.

## Changes

.opencode/skills/swarm-pr-review/SKILL.md - Pre-flight git ref availability section:

1. Explicit git checkout instruction: Added bold "Check out the head branch locally" with rationale
2. Safety guardrail: Added warning to verify clean working tree (git status --porcelain) before checkout
3. Clarified commit range purpose: Updated to say ranges are for git show context, not for tool-level file reads

## Invariant audit
- 1 (plugin init): not touched
- 2 (runtime portability): not touched
- 3 (subprocesses): not touched
- 4 (.swarm containment): not touched
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched
- 7 (test writing): not touched
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched
- 12 (release/cache): not touched

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require checking out the PR head branch in the swarm-pr-review pre-flight and add a clean-working-tree guardrail. Clarifies that explorers read from the working tree (commit ranges are only for `git show`, not `Read`/`Glob`/`Grep`), notes when refs cannot be fetched or checked out, and rebuilds dist with `opencode-swarm` bumped to 7.50.0.

<sup>Written for commit 2fcc7f1fc3797ffbd91f50db4eff90c8a8ee0d46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

