### PR TITLE
fix(commit-pr): replace BOM-generating Out-File with BOM-free WriteAllText

### DIFF
--- a/.claude/skills/commit-pr/SKILL.md
+++ b/.claude/skills/commit-pr/SKILL.md
@@ -291,8 +291,10 @@ Closes #<issue-number>
 ## Test plan
 - [ ] <validation item>
 "@
-$body | Out-File "$env:TEMP\pr_body.txt" -Encoding UTF8
-gh pr create --title "<type>(<scope>): <description>" --body-file "$env:TEMP\pr_body.txt" --base main
+$utf8NoBom = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
+$prBodyPath = Join-Path ([System.IO.Path]::GetTempPath()) "pr_body.txt"
+[System.IO.File]::WriteAllText($prBodyPath, $body, $utf8NoBom)
+gh pr create --title "<type>(<scope>): <description>" --body-file $prBodyPath --base main
 ```
 
 ## Step 6.5 - Issue comment
@@ -324,8 +326,10 @@ Fixed in PR #<pr-number>.
 ## Migration
 No migration required.
 "@
-$comment | Out-File "$env:TEMP\issue-comment.txt" -Encoding UTF8
-gh issue comment <issue-number> --body-file "$env:TEMP\issue-comment.txt"
+$utf8NoBom = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
+$issueCommentPath = Join-Path ([System.IO.Path]::GetTempPath()) "issue-comment.txt"
+[System.IO.File]::WriteAllText($issueCommentPath, $comment, $utf8NoBom)
+gh issue comment <issue-number> --body-file $issueCommentPath
 ````
 
 If the PR merged before this was done, post the missing issue comment immediately.


### PR DESCRIPTION
## Summary

Fix BOM-generating PowerShell pattern in commit-pr SKILL.md that caused the pr-standards CI check to fail on PR #1123. Two instances of Out-File -Encoding UTF8 (which adds UTF-8 BOM in PowerShell 5.1) replaced with BOM-free UTF8Encoding(False) + [System.IO.Path]::GetTempPath() for cross-platform portability.

## Invariant audit
- 1 (plugin init):       not touched
- 2 (runtime portability): not touched
- 3 (subprocesses):      not touched
- 4 (.swarm containment): not touched
- 5 (plan durability):   not touched
- 6 (test_runner safety): not touched
- 7 (test writing):      not touched
- 8 (session state):     not touched
- 9 (guardrails/retry):  not touched
- 10 (chat/system msg):  not touched
- 11 (tool registration): not touched
- 12 (release/cache):    not touched

## Test plan
- [x] Verified both PowerShell patterns produce BOM-free output
- [x] Code fences preserved correctly (triple for PR body, quadruple for issue comment)
- [x] No unintended changes outside the two patterns
- [x] Reviewer APPROVED with LOW risk

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates UTF‑8 BOM in files generated by the commit-pr skill to stop pr-standards CI grep failures and improve portability. Replaces PowerShell `Out-File -Encoding UTF8` with BOM-free `WriteAllText` and uses a cross-platform temp path.

- **Bug Fixes**
  - Write PR body and issue comment with `System.Text.UTF8Encoding(false)` via `System.IO.File]::WriteAllText` to avoid BOM in PowerShell 5.1.
  - Use `[System.IO.Path]::GetTempPath()` + `Join-Path` instead of a hard-coded `%TEMP%` path for cross-platform support.

<sup>Written for commit 62539519449f7a023bcdc724cbd9be82e9c57ead. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

