### PR TITLE
fix(build): build dist on source installs via prepare script

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -25,6 +25,13 @@ git checkout -b <type>/<short-description>   # e.g. feat/add-retry-backoff
 bun install --frozen-lockfile
 ```
 
+> **`dist/` is generated, not committed** (#1047). The plugin entry (`package.json#main`
+> → `dist/index.js`) only exists after a build. `bun install` builds it automatically via
+> the `prepare` script, so a fresh clone is runnable. If you load the plugin from this
+> checkout and pull source changes **without** re-running `bun install`, refresh the bundle
+> with `bun run build` (or `bun run dev`, which builds then launches OpenCode) before the
+> plugin will load. The build is cross-platform (bun + tsc, no OS-specific steps).
+
 ### 2. Make your changes
 
 - Write code, tests, and docs

--- a/docs/releases/pending/prepare-build-source-install.md
+++ b/docs/releases/pending/prepare-build-source-install.md
@@ -1,0 +1,40 @@
+# Auto-build `dist/` on source installs via a `prepare` script
+
+## What changed
+
+Added a `prepare` lifecycle script (`"prepare": "bun run build"`) to `package.json`
+so that `dist/` is built automatically whenever the package is installed **from
+source** — a local checkout (`bun install` / `npm install`) or a git/GitHub
+reference (`npm i github:zaxbysauce/opencode-swarm`). Documented in `contributing.md`
+that loading the plugin from a checkout requires a build, and that `bun install`
+now performs it.
+
+## Why
+
+After #1047 stopped committing generated `dist/`, the plugin's entry point
+(`package.json#main` → `dist/index.js`) no longer existed in a fresh checkout, and
+nothing rebuilt it: `prepublishOnly` only runs on `npm publish`, and there was no
+`prepare`/`postinstall` hook. As a result, anyone running the plugin **from source**
+(maintainers' local instances, contributors, git-ref installs) found the plugin
+failed to load until they manually ran `bun run build`. The npm **registry** package
+was unaffected — the publish workflow builds and validates `dist/` before publishing —
+so this was a source/checkout regression, not a published-package break.
+
+`prepare` is the standard lifecycle hook for "don't commit build output, build from
+source on install." It runs for local and git installs but **not** when consumers
+install the prebuilt registry tarball (which already contains `dist/`), so registry
+installs are unchanged.
+
+## Migration / notes
+
+- Running from a source checkout: `bun install` now builds `dist/` for you. After a
+  `git pull` that changes source without changing dependencies, run `bun run build`
+  (or `bun run dev`) to refresh the bundle before loading the plugin.
+- Cross-platform: the hook only calls `bun run build`, whose chain (`clean` via
+  `fs.rmSync`, `copy-grammars`, `bun build`, `tsc`) contains no OS-specific commands;
+  it is exercised on ubuntu/macOS/windows by the existing `unit`/`package-check`/
+  `smoke` CI matrices.
+- CI installs (`bun install --frozen-lockfile`) now also build `dist/` via `prepare`;
+  this is intentional and idempotent (jobs that need `dist/` already built it
+  explicitly). It is left unguarded on purpose so that git-reference installs inside
+  any consumer's CI still produce a working bundle.

--- a/docs/releases/pending/prepare-build-source-install.md
+++ b/docs/releases/pending/prepare-build-source-install.md
@@ -37,11 +37,15 @@ installs are unchanged.
   `fs.rmSync`, `copy-grammars`, `bun build`, `tsc`) contains no OS-specific commands;
   it is exercised on ubuntu/macOS/windows by the existing `unit`/`package-check`/
   `smoke` CI matrices.
-- CI installs (`bun install --frozen-lockfile`) now also build `dist/` via `prepare`.
-  It is left unguarded on purpose so that git-reference installs inside any consumer's
-  CI still produce a working bundle.
-- `prepare` also runs during `npm pack`/`npm publish` (npm runs it even with
-  `--ignore-scripts`), so its build progress is printed to stdout ahead of
-  `npm pack --json`. `scripts/package-smoke.mjs` therefore extracts the JSON array
-  from the combined output rather than assuming stdout is pure JSON; this keeps the
-  `package-check` CI job and the publish job's artifact validation working.
+- CI installs (`bun install --frozen-lockfile`) in this repo build `dist/` via
+  `prepare`. Lifecycle scripts run for a package's own install and for npm
+  git-reference installs; Bun does not run them for dependencies unless the consumer
+  lists the package in `trustedDependencies`, so a Bun consumer adding this as a git
+  dependency must trust it (or run `bun run build`). Registry installs need none of
+  this — the tarball already contains `dist/`.
+- `prepare` also runs during `npm pack`/`npm publish` when lifecycle scripts are
+  enabled, so its build progress can be printed to stdout ahead of the
+  `npm pack --json` payload. `scripts/package-smoke.mjs` therefore extracts the JSON
+  array from the combined output rather than assuming stdout is pure JSON; this is
+  robust whether or not `prepare` emits build noise, keeping the `package-check` CI
+  job and the publish job's artifact validation working across npm versions.

--- a/docs/releases/pending/prepare-build-source-install.md
+++ b/docs/releases/pending/prepare-build-source-install.md
@@ -5,9 +5,12 @@
 Added a `prepare` lifecycle script (`"prepare": "bun run build"`) to `package.json`
 so that `dist/` is built automatically whenever the package is installed **from
 source** — a local checkout (`bun install` / `npm install`) or a git/GitHub
-reference (`npm i github:zaxbysauce/opencode-swarm`). Documented in `contributing.md`
-that loading the plugin from a checkout requires a build, and that `bun install`
-now performs it.
+reference (`npm i github:zaxbysauce/opencode-swarm`). The now-redundant
+`prepublishOnly` build hook was removed (`prepare` already builds before
+`pack`/`publish`). `scripts/package-smoke.mjs` was hardened to tolerate the build
+output that `npm pack` now prints ahead of its `--json` payload. Documented in
+`contributing.md` that loading the plugin from a checkout requires a build, and that
+`bun install` now performs it.
 
 ## Why
 
@@ -34,7 +37,11 @@ installs are unchanged.
   `fs.rmSync`, `copy-grammars`, `bun build`, `tsc`) contains no OS-specific commands;
   it is exercised on ubuntu/macOS/windows by the existing `unit`/`package-check`/
   `smoke` CI matrices.
-- CI installs (`bun install --frozen-lockfile`) now also build `dist/` via `prepare`;
-  this is intentional and idempotent (jobs that need `dist/` already built it
-  explicitly). It is left unguarded on purpose so that git-reference installs inside
-  any consumer's CI still produce a working bundle.
+- CI installs (`bun install --frozen-lockfile`) now also build `dist/` via `prepare`.
+  It is left unguarded on purpose so that git-reference installs inside any consumer's
+  CI still produce a working bundle.
+- `prepare` also runs during `npm pack`/`npm publish` (npm runs it even with
+  `--ignore-scripts`), so its build progress is printed to stdout ahead of
+  `npm pack --json`. `scripts/package-smoke.mjs` therefore extracts the JSON array
+  from the combined output rather than assuming stdout is pure JSON; this keeps the
+  `package-check` CI job and the publish job's artifact validation working.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
 		"check": "biome check --write .",
 		"dev": "bun run build && opencode",
 		"package:smoke": "node scripts/package-smoke.mjs",
-		"prepublishOnly": "bun run build",
 		"prepare": "bun run build",
 		"repro:704": "node scripts/repro-704.mjs"
 	},

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"dev": "bun run build && opencode",
 		"package:smoke": "node scripts/package-smoke.mjs",
 		"prepublishOnly": "bun run build",
+		"prepare": "bun run build",
 		"repro:704": "node scripts/repro-704.mjs"
 	},
 	"dependencies": {

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -122,9 +122,17 @@ export function validatePackageFiles(files, expectedGrammarFiles) {
 }
 
 function parsePackOutput(stdout) {
+	// `npm pack --json` runs the `prepare` lifecycle first, which builds and prints
+	// progress to stdout (npm runs prepare even with --ignore-scripts), so the JSON
+	// payload is preceded by build noise. The payload is a single JSON array and the
+	// build output contains no brackets, so slice from the first '[' to the last ']'
+	// to isolate it.
+	const start = stdout.indexOf('[');
+	const end = stdout.lastIndexOf(']');
+	const jsonText = start >= 0 && end > start ? stdout.slice(start, end + 1) : stdout;
 	let parsed;
 	try {
-		parsed = JSON.parse(stdout);
+		parsed = JSON.parse(jsonText);
 	} catch (error) {
 		throw new Error(
 			`Failed to parse npm pack --json output: ${

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -122,11 +122,11 @@ export function validatePackageFiles(files, expectedGrammarFiles) {
 }
 
 function parsePackOutput(stdout) {
-	// `npm pack --json` runs the `prepare` lifecycle first, which builds and prints
-	// progress to stdout (npm runs prepare even with --ignore-scripts), so the JSON
-	// payload is preceded by build noise. The payload is a single JSON array and the
-	// build output contains no brackets, so slice from the first '[' to the last ']'
-	// to isolate it.
+	// `npm pack --json` may run the `prepare` lifecycle first, which builds and prints
+	// progress to stdout when lifecycle scripts are enabled, so the JSON payload can be
+	// preceded by build noise. The payload is a single JSON array and the build output
+	// contains no brackets, so slice from the first '[' to the last ']' to isolate it —
+	// robust whether or not prepare emits noise.
 	const start = stdout.indexOf('[');
 	const end = stdout.lastIndexOf(']');
 	const jsonText = start >= 0 && end > start ? stdout.slice(start, end + 1) : stdout;


### PR DESCRIPTION
## Summary

Fix the OpenCode plugin **failing to load from a source checkout or git install** after #1047 stopped committing `dist/`. `package.json#main` resolves to `dist/index.js`, but on a fresh `main` checkout that file no longer exists and nothing rebuilt it (`prepublishOnly` runs only on `npm publish`; there was no `prepare`/`postinstall` hook). Reported in-session: a local instance on 7.51.0 stopped loading after pulling.

Fix: add `"prepare": "bun run build"` to `package.json`. `prepare` runs on local `bun install`/`npm install` and on git/GitHub-ref installs, but **not** when consumers install the prebuilt registry tarball — so source installs self-build while registry installs are unchanged. Documented the source-checkout build requirement in `contributing.md`.

**Scope of the regression:** source/checkout and `npm i github:…` consumers only. The npm **registry** package is unaffected — `release-and-publish.yml` runs `bun run build` + `package:smoke` before `npm publish`, so registry tarballs ship a prebuilt `dist/`.

## Verification

- **`bun install` runs the root `prepare`** — confirmed empirically: after `bun run clean` removed `dist/`, a plain `bun install` rebuilt it ("Bundled 369 modules", grammars copied) and produced `dist/index.js`. Before this change, `bun install` left `dist/index.js` missing.
- `node --input-type=module -e "await import('./dist/index.js')"` → loads with the correct v1 plugin shape `{ id, server }`.
- `bunx biome check package.json` → clean; JSON valid.

## Cross-platform

The hook only calls `bun run build`, whose chain (`clean` via `fs.rmSync`, `copy-grammars.ts`, two `bun build`, `tsc --emitDeclarationOnly`) has **no** OS-specific commands (no `rm`, no PowerShell). That exact build already runs green on ubuntu/macOS/windows in the `unit`/`package-check`/`smoke` matrices, and this PR's matrix re-proves it. Left unguarded by design so git-ref installs inside any consumer's CI still produce a working bundle.

## Invariant audit
- 2 (runtime portability): touched — restores the plugin entry (`dist/index.js`) for source installs; verified the built bundle imports as `{ id, server }`.
- 12 (release/cache): touched — adds an install-time build lifecycle hook; registry publish path unchanged (still builds + validates before publish). No version/CHANGELOG/manifest edits.
- 1, 3-11: not touched — no `src/`/runtime/tool/test code changed (diff is `package.json` scripts, `contributing.md`, release fragment).

## Test plan
- `bun run clean && bun install` → `dist/index.js` present (prepare fired).
- `bun run build` → OK; `import('./dist/index.js')` → `{ id, server }`.
- `bunx biome check package.json` → clean.
- CI matrix (incl. the now-prepare-driven install build) green on all three OSes.