### PR TITLE
fix(sast,lang,repo-graph): deep-dive audit hardening — semgrep subprocess, SAST rules, lang/runtime, syntax-check, PHP backend

### DIFF
--- a/docs/releases/pending/1002-deep-dive-audit-repo-graph-sast-syntax.md
+++ b/docs/releases/pending/1002-deep-dive-audit-repo-graph-sast-syntax.md
@@ -1,0 +1,76 @@
+# Deep-Dive Audit Fixes: repo-graph, tree-sitter/WASM, SAST, syntax-check
+
+## What
+
+Resolves the 23 verified findings from the deep-dive audit (#1002) across the
+SAST, language-dispatch, tree-sitter runtime, syntax-check, and repo-graph
+subsystems.
+
+Security / subprocess hardening:
+- The Semgrep subprocess now sets `stdin: 'ignore'`, guarantees a
+  SIGTERM→SIGKILL terminate on every settle path, and bounds stdout/stderr
+  accumulation (10 MB/stream) — AGENTS.md invariant 3.
+
+SAST rule quality:
+- Removed a duplicate `sast/go-hardcoded-secret` rule id.
+- Aligned the Java hardcoded-secret length threshold (`{5,}` → `{10,}`) with the
+  other C-family languages, cutting false positives.
+- Added a context-aware `validate` to the C# `Process.Start` rule so the safe
+  `ProcessStartInfo` + `UseShellExecute = false` pattern is no longer flagged as
+  a critical command-injection in the hard gate.
+
+Language dispatch + tree-sitter runtime:
+- Grammar loading is now wrapped in `withTimeout` and coalesces concurrent loads
+  of the same grammar; `node:fs` is statically imported.
+- Project language detection now honors glob detect files (`*.csproj`, `*.sln`,
+  `*.xcodeproj`, …) so C#/Swift solution-only projects are detected.
+- Kotlin ktlint detection uses `build.gradle.kts` instead of the generic
+  `.editorconfig`.
+- Test-framework names are unified between profiles and the dispatch map, locked
+  by a parity test.
+- Laravel detection (previously dead code) is wired into a real PHP backend and
+  the architect project-context, so Laravel apps surface `php artisan test` and
+  `PROJECT_FRAMEWORK = laravel`.
+
+syntax-check:
+- Stat-before-read large-file guard, an iterative (stack-safe) parse-tree walk,
+  and bounded-concurrency file processing.
+
+repo-graph:
+- Comment-aware import scanning to reduce false graph edges.
+- The incremental-update failure counter is now per-session, bounded, decaying,
+  and cooldown-gated (AGENTS.md invariant 8).
+
+Tests:
+- The SAST gate integration tests now run on Windows (git config pinned to
+  `core.autocrlf=false`; unrelated gates already mocked).
+
+## Why
+
+The audit surfaced two HIGH-severity subprocess-safety gaps (Semgrep stdin /
+kill / unbounded output), several SAST rules producing avoidable false positives
+or duplicate findings, an init-path invariant gap (unbounded grammar load), a
+session-state invariant violation (shared failure counter), dead Laravel code,
+and Windows test-coverage gaps. Each is a latent reliability, security, or
+correctness risk on at least one supported platform.
+
+## Migration
+
+No breaking changes. All changes are internal hardening, rule-quality, and
+test-coverage improvements:
+- Public tool/agent surfaces are unchanged.
+- The new PHP backend and Laravel project-context overlay are additive and
+  filesystem-only (no new subprocess on the init path).
+- Framework-name unification is internal; the dispatch map preserves all
+  existing detection behavior (verified by an expanded parity test).
+
+## Caveats
+
+- The Windows SAST integration tests were validated on Linux only (no Windows
+  runner is available in CI from this change's authoring environment). The fix
+  targets the documented root cause (`core.autocrlf` diff divergence) and relies
+  on the already-mocked lint/secretscan/quality gates to keep the test free of
+  Windows-fragile subprocess spawning.
+- repo-graph import scanning remains regex-based (now comment-aware): AST-based
+  extraction was intentionally rejected because the builder runs on the bounded
+  plugin-init path (AGENTS.md invariant 1).

--- a/src/agents/project-context.ts
+++ b/src/agents/project-context.ts
@@ -31,6 +31,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { LanguageBackend } from '../lang/backend';
 import { pickBackend, pickedProfiles } from '../lang/dispatch';
+import { getLaravelCommandOverlay } from '../lang/framework-detector';
 import {
 	bulletList,
 	emptyProjectContext,
@@ -216,6 +217,19 @@ export async function buildProjectContext(
 
 	const lintCmd = selectLintCommand(backend, directory);
 	if (lintCmd) ctx.LINT_CMD = lintCmd;
+
+	// Laravel command overlay (DD-C009): for a PHP project that is a Laravel
+	// app, prefer the artisan-driven commands over the generic Composer/PHPUnit
+	// defaults — `php artisan test` runs both Pest and PHPUnit, and Pint /
+	// PHP-CS-Fixer is the canonical formatter. Filesystem-only (no spawn), so it
+	// stays within the Invariant-1 session-init budget.
+	if (backend.id === 'php') {
+		const overlay = getLaravelCommandOverlay(directory);
+		if (overlay) {
+			ctx.TEST_CMD = overlay.testCommand;
+			if (overlay.lintCommand) ctx.LINT_CMD = overlay.lintCommand;
+		}
+	}
 
 	// selectFramework / selectEntryPoints — these are filesystem-only
 	// (read package.json / pyproject / go.mod) and run in parallel to

--- a/src/hooks/repo-graph-builder.ts
+++ b/src/hooks/repo-graph-builder.ts
@@ -112,8 +112,61 @@ export function createRepoGraphBuilderHook(
 
 	let initStarted = false;
 	let initPromise: Promise<void> = Promise.resolve();
-	let consecutiveFailures = 0;
+
+	// Per-session incremental-update failure tracking (AGENTS.md invariant 8:
+	// session state must be keyed by sessionID, bounded, and decay). A single
+	// shared counter (the previous implementation) mixed failures across
+	// sessions and, once it crossed the threshold, fired the advisory on every
+	// subsequent call forever — even after transient causes (disk full, a brief
+	// permission glitch) cleared. This map is keyed by sessionID, FIFO-bounded,
+	// time-decayed so an old failure streak resets, and cooldown-gated so the
+	// advisory is not spammed.
 	const FAILURE_ADVISORY_THRESHOLD = 3;
+	const FAILURE_DECAY_MS = 5 * 60 * 1000; // streak resets after 5 min idle
+	const ADVISORY_COOLDOWN_MS = 60 * 1000; // at most one advisory per minute/session
+	const MAX_TRACKED_SESSIONS = 100;
+	interface FailureState {
+		failures: number;
+		lastFailureAt: number;
+		lastAdvisoryAt: number;
+	}
+	const failuresBySession = new Map<string, FailureState>();
+
+	function recordSuccess(sessionID: string): void {
+		failuresBySession.delete(sessionID);
+	}
+
+	function recordFailure(
+		sessionID: string,
+		now: number,
+	): { count: number; advise: boolean } {
+		let state = failuresBySession.get(sessionID);
+		// Decay: a failure long after the previous one starts a fresh streak.
+		if (state && now - state.lastFailureAt > FAILURE_DECAY_MS) {
+			failuresBySession.delete(sessionID);
+			state = undefined;
+		}
+		if (!state) {
+			// FIFO eviction keeps the map bounded across many sessions.
+			if (failuresBySession.size >= MAX_TRACKED_SESSIONS) {
+				const oldest = failuresBySession.keys().next().value;
+				if (oldest !== undefined) failuresBySession.delete(oldest);
+			}
+			state = { failures: 0, lastFailureAt: 0, lastAdvisoryAt: 0 };
+			failuresBySession.set(sessionID, state);
+		}
+		state.failures += 1;
+		state.lastFailureAt = now;
+		let advise = false;
+		if (
+			state.failures >= FAILURE_ADVISORY_THRESHOLD &&
+			now - state.lastAdvisoryAt >= ADVISORY_COOLDOWN_MS
+		) {
+			advise = true;
+			state.lastAdvisoryAt = now;
+		}
+		return { count: state.failures, advise };
+	}
 
 	async function doInit(): Promise<void> {
 		// Yield once before any scan work so the caller's promise chain has
@@ -206,17 +259,17 @@ export function createRepoGraphBuilderHook(
 
 			try {
 				await _updateGraphForFiles(workspaceRoot, [absoluteFilePath]);
-				consecutiveFailures = 0;
+				recordSuccess(input.sessionID);
 				logger.log(
 					`[repo-graph] Incremental update for ${path.basename(filePath)}`,
 				);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
-				consecutiveFailures++;
+				const { count, advise } = recordFailure(input.sessionID, Date.now());
 				logger.error(`[repo-graph] Incremental update failed: ${message}`);
-				if (consecutiveFailures >= FAILURE_ADVISORY_THRESHOLD) {
+				if (advise) {
 					logger.warn(
-						`[repo-graph] ${consecutiveFailures} consecutive incremental update failures. ` +
+						`[repo-graph] ${count} consecutive incremental update failures. ` +
 							`The dependency graph may be stale. Consider reloading the workspace.`,
 					);
 				}

--- a/src/lang/backends/index.ts
+++ b/src/lang/backends/index.ts
@@ -11,6 +11,7 @@
 
 import { LANGUAGE_BACKEND_REGISTRY } from '../registry-backend';
 import { buildGoBackend } from './go';
+import { buildPhpBackend } from './php';
 import { buildPythonBackend } from './python';
 import { buildTypescriptBackend } from './typescript';
 
@@ -31,6 +32,7 @@ export function registerAllBackends(): void {
 	LANGUAGE_BACKEND_REGISTRY.register(buildTypescriptBackend());
 	LANGUAGE_BACKEND_REGISTRY.register(buildPythonBackend());
 	LANGUAGE_BACKEND_REGISTRY.register(buildGoBackend());
+	LANGUAGE_BACKEND_REGISTRY.register(buildPhpBackend());
 	registered = true;
 }
 
@@ -47,4 +49,5 @@ export function _resetForTesting(): void {
 	LANGUAGE_BACKEND_REGISTRY.unregister('typescript');
 	LANGUAGE_BACKEND_REGISTRY.unregister('python');
 	LANGUAGE_BACKEND_REGISTRY.unregister('go');
+	LANGUAGE_BACKEND_REGISTRY.unregister('php');
 }

--- a/src/lang/backends/php.ts
+++ b/src/lang/backends/php.ts
@@ -1,0 +1,59 @@
+/**
+ * PHP backend.
+ *
+ * Wires the previously-unused Laravel framework detection (DD-C009) into the
+ * dispatch layer. Overrides `selectFramework` so a Laravel project surfaces
+ * `PROJECT_FRAMEWORK = laravel` in the architect prompt (consumed by
+ * `src/agents/project-context.ts`), and exposes the command overlay so the
+ * project-context builder can prefer `php artisan test` over the generic
+ * PHPUnit/Pest default for Laravel apps.
+ *
+ * Invariants identical to the other backends — see `go.ts` / `python.ts` for
+ * the rationale. `detectLaravelProject` / `getLaravelCommandOverlay` are
+ * filesystem-only (no subprocess), so they are safe on the session-init path.
+ */
+
+import type { FrameworkSelection, LanguageBackend } from '../backend';
+import { defaultBackendFor } from '../default-backend';
+import { detectLaravelProject } from '../framework-detector';
+import { LANGUAGE_REGISTRY } from '../profiles';
+
+const PROFILE_ID = 'php';
+
+/**
+ * Detect Laravel via the multi-signal heuristic (artisan + composer.json
+ * require + config/app.php; ≥2 of 3). Returns null for generic Composer PHP
+ * projects so the architect's PROJECT_FRAMEWORK stays unresolved.
+ */
+async function selectFramework(
+	dir: string,
+): Promise<FrameworkSelection | null> {
+	if (detectLaravelProject(dir)) {
+		return {
+			name: 'laravel',
+			detectedVia: 'Laravel signals (artisan / composer.json / config/app.php)',
+		};
+	}
+	return null;
+}
+
+/**
+ * Build the PHP backend from the registered profile.
+ */
+export function buildPhpBackend(): LanguageBackend {
+	const profile = LANGUAGE_REGISTRY.get(PROFILE_ID);
+	if (!profile) {
+		throw new Error(
+			'buildPhpBackend: php profile not in LANGUAGE_REGISTRY. ' +
+				'profiles.ts must be imported before this backend.',
+		);
+	}
+	return {
+		...defaultBackendFor(profile),
+		selectFramework,
+	};
+}
+
+export const _internals: {
+	selectFramework: typeof selectFramework;
+} = { selectFramework };

--- a/src/lang/detector.ts
+++ b/src/lang/detector.ts
@@ -53,8 +53,25 @@ export async function detectProjectLanguages(
 		// Check build indicator files for each profile
 		for (const profile of LANGUAGE_REGISTRY.getAll()) {
 			for (const detectFile of profile.build.detectFiles) {
-				// Skip glob patterns (contain * or ?)
-				if (detectFile.includes('*') || detectFile.includes('?')) continue;
+				if (detectFile.includes('*') || detectFile.includes('?')) {
+					// Glob pattern (e.g. *.csproj, *.sln, *.xcodeproj). Match it
+					// against the directory listing instead of silently skipping
+					// (DD-C025) — otherwise C#/Swift projects identified only by a
+					// solution/workspace file would never be detected here. Uses
+					// the same simple glob→regex shape as default-backend's
+					// detectFileExists; detectFiles are controlled profile data.
+					const regex = new RegExp(
+						`^${detectFile
+							.replace(/\./g, '\\.')
+							.replace(/\*/g, '.*')
+							.replace(/\?/g, '.')}$`,
+					);
+					if (entries.some((name) => regex.test(name))) {
+						detected.add(profile.id);
+						break;
+					}
+					continue;
+				}
 				try {
 					await access(join(dir, detectFile));
 					detected.add(profile.id);

--- a/src/lang/index.ts
+++ b/src/lang/index.ts
@@ -17,5 +17,16 @@ export {
 	listSupportedLanguages,
 } from './registry';
 
-// runtime has no _internals — safe to re-export
-export * from './runtime';
+// Tree-sitter runtime — explicit exports so the `_internals` DI seam is
+// re-exported under a namespaced name (matching detector/registry) instead of
+// leaking as a bare `_internals` via `export *`.
+export {
+	_internals as runtimeInternals,
+	clearParserCache,
+	getInitializedLanguages,
+	getSupportedLanguages,
+	isGrammarAvailable,
+	loadGrammar,
+	type Parser,
+	parserCache,
+} from './runtime';

--- a/src/lang/profiles.ts
+++ b/src/lang/profiles.ts
@@ -388,7 +388,9 @@ LANGUAGE_REGISTRY.register({
 		detectFiles: ['Cargo.toml'],
 		frameworks: [
 			{
-				name: 'cargo test',
+				// DD-C026: framework name unified with the dispatch union name
+				// (`cargo`) so profiles and default-backend share one vocabulary.
+				name: 'cargo',
 				detect: 'Cargo.toml',
 				cmd: 'cargo test',
 				priority: 10,
@@ -461,7 +463,8 @@ LANGUAGE_REGISTRY.register({
 	test: {
 		detectFiles: ['go.mod'],
 		frameworks: [
-			{ name: 'go test', detect: 'go.mod', cmd: 'go test ./...', priority: 10 },
+			// DD-C026: name unified with the dispatch union name (`go-test`).
+			{ name: 'go-test', detect: 'go.mod', cmd: 'go test ./...', priority: 10 },
 		],
 	},
 	lint: {
@@ -537,14 +540,16 @@ LANGUAGE_REGISTRY.register({
 	test: {
 		detectFiles: ['pom.xml', 'build.gradle', 'build.gradle.kts'],
 		frameworks: [
+			// DD-C026: names unified with the dispatch union names
+			// (`maven`, `gradle`) so profiles and default-backend agree.
 			{
-				name: 'maven-test',
+				name: 'maven',
 				detect: 'pom.xml',
 				cmd: 'mvn test -q',
 				priority: 10,
 			},
 			{
-				name: 'gradle-test',
+				name: 'gradle',
 				detect: 'build.gradle',
 				cmd: 'gradle test -q',
 				priority: 9,
@@ -623,14 +628,16 @@ LANGUAGE_REGISTRY.register({
 	test: {
 		detectFiles: ['build.gradle.kts', 'build.gradle'],
 		frameworks: [
+			// DD-C026: both gradle variants use the unified union name `gradle`;
+			// they remain distinct entries via their detect file + priority.
 			{
-				name: 'gradle-test',
+				name: 'gradle',
 				detect: 'build.gradle.kts',
 				cmd: 'gradle test -q',
 				priority: 10,
 			},
 			{
-				name: 'gradle-test-groovy',
+				name: 'gradle',
 				detect: 'build.gradle',
 				cmd: 'gradle test -q',
 				priority: 9,
@@ -638,11 +645,14 @@ LANGUAGE_REGISTRY.register({
 		],
 	},
 	lint: {
-		detectFiles: ['.editorconfig', 'build.gradle.kts'],
+		// DD-C027: `.editorconfig` is a generic, cross-ecosystem file and a poor
+		// ktlint signal — any project with one would trigger detection. Use the
+		// Kotlin-specific Gradle build scripts instead.
+		detectFiles: ['build.gradle.kts', 'build.gradle'],
 		linters: [
 			{
 				name: 'ktlint',
-				detect: '.editorconfig',
+				detect: 'build.gradle.kts',
 				cmd: 'ktlint --format',
 				priority: 10,
 			},
@@ -704,7 +714,8 @@ LANGUAGE_REGISTRY.register({
 		detectFiles: ['*.csproj', '*.sln'],
 		frameworks: [
 			{
-				name: 'dotnet test',
+				// DD-C026: name unified with the dispatch union name (`dotnet-test`).
+				name: 'dotnet-test',
 				detect: '*.csproj',
 				cmd: 'dotnet test',
 				priority: 10,
@@ -859,7 +870,8 @@ LANGUAGE_REGISTRY.register({
 		detectFiles: ['Package.swift', '*.xcodeproj'],
 		frameworks: [
 			{
-				name: 'swift test',
+				// DD-C026: name unified with the dispatch union name (`swift-test`).
+				name: 'swift-test',
 				detect: 'Package.swift',
 				cmd: 'swift test',
 				priority: 10,

--- a/src/lang/runtime.ts
+++ b/src/lang/runtime.ts
@@ -1,3 +1,4 @@
+import { existsSync, statSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Parser as ParserType } from 'web-tree-sitter';
@@ -5,14 +6,38 @@ import type { Parser as ParserType } from 'web-tree-sitter';
 // TreeSitterParser is imported to use Language.load()
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Language, Parser as TreeSitterParser } from 'web-tree-sitter';
+import { withTimeout } from '../utils/timeout';
 
 // Re-export Parser type for consumers
 export type Parser = ParserType;
 
 /**
- * Parser cache to avoid reloading grammars multiple times per session
+ * Parser cache to avoid reloading grammars multiple times per session.
+ *
+ * Callers share a single `Parser` instance per language. This is safe in the
+ * single-threaded JS runtime: the only mutation of a cached parser is the
+ * one-time `setLanguage` during load (serialized by `inflightLoads` below),
+ * and `Parser.parse()` plus the subsequent tree walk run synchronously to
+ * completion with no intervening `await`, so two callers cannot interleave on
+ * the same instance even under `Promise.all`. (Same single-thread reasoning
+ * that makes a separate-parser-per-call rewrite unnecessary here.)
  */
 export const parserCache = new Map<string, ParserType>();
+
+/**
+ * In-flight grammar loads keyed by normalized language id. Concurrent callers
+ * (e.g. the parallel syntax-check loop) share the single load promise instead
+ * of each spawning a redundant `Language.load` for the same WASM file. Entries
+ * are removed once the load settles; the resolved parser lives in `parserCache`.
+ */
+const inflightLoads = new Map<string, Promise<ParserType>>();
+
+/**
+ * Upper bound on a single WASM grammar load (AGENTS.md invariant 1 — bounded
+ * init-path work). A corrupted grammar file must not be able to hang the
+ * awaiter indefinitely.
+ */
+const GRAMMAR_LOAD_TIMEOUT_MS = 10_000;
 
 /**
  * Track which languages have been initialized to avoid re-init
@@ -173,40 +198,59 @@ export async function loadGrammar(languageId: string): Promise<ParserType> {
 		return parserCache.get(normalizedId)!;
 	}
 
-	// Initialize tree-sitter WASM runtime
-	await initTreeSitter();
+	// Coalesce concurrent loads of the same grammar onto one promise.
+	const existing = inflightLoads.get(normalizedId);
+	if (existing) return existing;
 
-	// Initialize parser
-	const parser = new TreeSitterParser();
+	const loadPromise = (async (): Promise<ParserType> => {
+		// Initialize tree-sitter WASM runtime
+		await initTreeSitter();
 
-	// Get WASM file name and construct path
-	const wasmFileName = getWasmFileName(normalizedId);
-	const wasmPath = path.join(getGrammarsDirAbsolute(), wasmFileName);
+		// Initialize parser
+		const parser = new TreeSitterParser();
 
-	// Check if file exists before attempting to load
-	const { existsSync } = await import('node:fs');
-	if (!existsSync(wasmPath)) {
-		throw new Error(
-			`Grammar file not found for ${languageId}: ${wasmPath}\n` +
-				`Make sure to run 'bun run build' to copy grammar files to dist/lang/grammars/`,
-		);
-	}
+		// Get WASM file name and construct path
+		const wasmFileName = getWasmFileName(normalizedId);
+		const wasmPath = path.join(getGrammarsDirAbsolute(), wasmFileName);
 
+		// Check if file exists before attempting to load
+		if (!existsSync(wasmPath)) {
+			throw new Error(
+				`Grammar file not found for ${languageId}: ${wasmPath}\n` +
+					`Make sure to run 'bun run build' to copy grammar files to dist/lang/grammars/`,
+			);
+		}
+
+		try {
+			// Bound the load so a corrupted WASM file cannot hang indefinitely.
+			const language = await withTimeout(
+				Language.load(wasmPath),
+				GRAMMAR_LOAD_TIMEOUT_MS,
+				new Error(
+					`Timed out after ${GRAMMAR_LOAD_TIMEOUT_MS}ms loading grammar`,
+				),
+			);
+			parser.setLanguage(language);
+		} catch (error) {
+			throw new Error(
+				`Failed to load grammar for ${languageId}: ${error instanceof Error ? error.message : String(error)}\n` +
+					`WASM path: ${wasmPath}`,
+			);
+		}
+
+		// Cache and return
+		parserCache.set(normalizedId, parser);
+		initializedLanguages.add(normalizedId);
+
+		return parser;
+	})();
+
+	inflightLoads.set(normalizedId, loadPromise);
 	try {
-		const language = await Language.load(wasmPath);
-		parser.setLanguage(language);
-	} catch (error) {
-		throw new Error(
-			`Failed to load grammar for ${languageId}: ${error instanceof Error ? error.message : String(error)}\n` +
-				`WASM path: ${wasmPath}`,
-		);
+		return await loadPromise;
+	} finally {
+		inflightLoads.delete(normalizedId);
 	}
-
-	// Cache and return
-	parserCache.set(normalizedId, parser);
-	initializedLanguages.add(normalizedId);
-
-	return parser;
 }
 
 /**
@@ -240,7 +284,6 @@ export async function isGrammarAvailable(languageId: string): Promise<boolean> {
 		const wasmFileName = getWasmFileName(normalizedId);
 		const wasmPath = path.join(getGrammarsDirAbsolute(), wasmFileName);
 
-		const { statSync } = await import('node:fs');
 		statSync(wasmPath);
 		return true;
 	} catch {
@@ -253,6 +296,7 @@ export async function isGrammarAvailable(languageId: string): Promise<boolean> {
  */
 export function clearParserCache(): void {
 	parserCache.clear();
+	inflightLoads.clear();
 	initializedLanguages.clear();
 	treeSitterInitPromise = null;
 }

--- a/src/sast/rules/csharp.ts
+++ b/src/sast/rules/csharp.ts
@@ -18,6 +18,14 @@ export const csharpRules: SastRule[] = [
 		remediation:
 			'Use ProcessStartInfo with Arguments property, or sanitize input thoroughly.',
 		pattern: /Process\.Start/,
+		// Context-aware filtering (DD-C016). `Process.Start` alone is not a
+		// vulnerability — the canonical .NET mitigation is a ProcessStartInfo
+		// with UseShellExecute disabled (no shell interpretation). When the
+		// file demonstrates that safe pattern, suppress the critical finding to
+		// avoid blocking the coder workflow on legitimate process invocation.
+		validate: (_match, context) => {
+			return !/UseShellExecute\s*=\s*false/i.test(context.content);
+		},
 	},
 	{
 		id: 'sast/cs-sqli',

--- a/src/sast/rules/go.ts
+++ b/src/sast/rules/go.ts
@@ -31,17 +31,6 @@ export const goRules: SastRule[] = [
 		pattern: /InsecureSkipVerify\s*:\s*true/,
 	},
 	{
-		id: 'sast/go-hardcoded-secret',
-		name: 'Hardcoded secret detected',
-		severity: 'critical',
-		languages: ['go'],
-		description: 'Potential hardcoded API key, password, or token detected',
-		remediation:
-			'Move secrets to environment variables using os.Getenv() or a secrets manager.',
-		pattern:
-			/(?:api_key|password|secret|token|auth)[_-]?\w*\s*[:=]\s*["'][a-zA-Z0-9_-]{20,}["']/i,
-	},
-	{
 		id: 'sast/go-shell-injection',
 		name: 'Shell injection via os/exec',
 		severity: 'critical',

--- a/src/sast/rules/java.ts
+++ b/src/sast/rules/java.ts
@@ -49,8 +49,12 @@ export const javaRules: SastRule[] = [
 		description: 'Potential hardcoded API key, password, or token detected',
 		remediation:
 			'Move secrets to environment variables or a secure configuration manager.',
+		// Minimum length aligned with the other C-family static languages (Go,
+		// C# both use {10,}). The previous {5,} flagged 5-char strings like
+		// token: "abcde" as critical, producing far more false positives in
+		// Java codebases than in any other supported language (DD-C015).
 		pattern:
-			/(?:api_key|password|secret|token|auth)[_-]?\w*\s*=\s*["'][a-zA-Z0-9_-]{5,}["']/i,
+			/(?:api_key|password|secret|token|auth)[_-]?\w*\s*=\s*["'][a-zA-Z0-9_-]{10,}["']/i,
 	},
 	{
 		id: 'sast/java-xxe',

--- a/src/sast/semgrep.ts
+++ b/src/sast/semgrep.ts
@@ -55,6 +55,21 @@ const DEFAULT_RULES_DIR = '.swarm/semgrep-rules';
  */
 const DEFAULT_TIMEOUT_MS = 30000;
 
+/**
+ * Per-stream cap on accumulated stdout/stderr from the Semgrep subprocess.
+ * AGENTS.md invariant 3 requires bounded stdio: a misbehaving binary must
+ * not be able to exhaust memory by streaming unbounded output. Once a
+ * stream exceeds this cap we stop accumulating and terminate the child.
+ */
+const MAX_OUTPUT_BYTES = 10 * 1024 * 1024; // 10MB per stream
+
+/**
+ * Grace window between SIGTERM and SIGKILL when force-terminating the child.
+ * On Windows SIGTERM is best-effort; the SIGKILL escalation guarantees the
+ * orphaned process is reaped (AGENTS.md invariant 3 — killable subprocesses).
+ */
+const KILL_GRACE_MS = 2000;
+
 export const _internals: {
 	isSemgrepAvailable: typeof isSemgrepAvailable;
 	checkSemgrepAvailable: typeof checkSemgrepAvailable;
@@ -62,6 +77,7 @@ export const _internals: {
 	runSemgrep: typeof runSemgrep;
 	getRulesDirectory: typeof getRulesDirectory;
 	hasBundledRules: typeof hasBundledRules;
+	executeWithTimeout: typeof executeWithTimeout;
 } = {
 	isSemgrepAvailable,
 	checkSemgrepAvailable,
@@ -69,6 +85,7 @@ export const _internals: {
 	runSemgrep,
 	getRulesDirectory,
 	hasBundledRules,
+	executeWithTimeout,
 } as const;
 
 /**
@@ -194,38 +211,111 @@ function mapSemgrepSeverity(
 async function executeWithTimeout(
 	command: string,
 	args: string[],
-	options: { cwd?: string; timeoutMs: number },
-): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	options: { cwd?: string; timeoutMs: number; maxOutputBytes?: number },
+): Promise<{
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+	truncated: boolean;
+}> {
+	const maxOutputBytes = options.maxOutputBytes ?? MAX_OUTPUT_BYTES;
 	return new Promise((resolve) => {
-		// Use spawn with args array and NO shell to prevent command injection
+		// Use spawn with args array and NO shell to prevent command injection.
+		// stdin: 'ignore' (AGENTS.md invariant 3) — a never-closed stdin pipe
+		// under Bun on Windows can block the child from exiting.
 		const child = child_process.spawn(command, args, {
 			shell: false, // SECURITY FIX: prevent shell injection
 			cwd: options.cwd,
+			stdio: ['ignore', 'pipe', 'pipe'],
 		});
 
 		let stdout = '';
 		let stderr = '';
+		let stdoutTruncated = false;
+		let stderrTruncated = false;
+		let settled = false;
+		let timeout: ReturnType<typeof setTimeout> | undefined;
 
-		const timeout = setTimeout(() => {
-			child.kill('SIGTERM');
-			resolve({
+		/**
+		 * Resolve exactly once, always clearing the timeout and guaranteeing a
+		 * best-effort terminate of the child regardless of which event settled
+		 * the promise (AGENTS.md invariant 3: an outer timeout alone lets the
+		 * awaiter proceed but does not abort the child). If the child already
+		 * exited (close event) the kill calls are harmless no-ops.
+		 */
+		const settle = (result: {
+			stdout: string;
+			stderr: string;
+			exitCode: number;
+		}): void => {
+			if (settled) return;
+			settled = true;
+			if (timeout) clearTimeout(timeout);
+			const truncated = stdoutTruncated || stderrTruncated;
+			if (child.exitCode === null && child.signalCode === null) {
+				try {
+					child.kill('SIGTERM');
+				} catch {
+					// process may already be gone
+				}
+				const escalation = setTimeout(() => {
+					try {
+						child.kill('SIGKILL');
+					} catch {
+						// process may already be gone
+					}
+				}, KILL_GRACE_MS);
+				if (
+					typeof (escalation as { unref?: () => void }).unref === 'function'
+				) {
+					(escalation as { unref: () => void }).unref();
+				}
+			}
+			resolve({ ...result, truncated });
+		};
+
+		timeout = setTimeout(() => {
+			settle({
 				stdout,
 				stderr: 'Process timed out',
 				exitCode: 124, // Common timeout exit code
 			});
 		}, options.timeoutMs);
+		if (typeof (timeout as { unref?: () => void }).unref === 'function') {
+			(timeout as { unref: () => void }).unref();
+		}
 
 		child.stdout?.on('data', (data) => {
-			stdout += data.toString();
+			if (stdoutTruncated) return;
+			const chunk = data.toString();
+			if (stdout.length + chunk.length > maxOutputBytes) {
+				stdout += chunk.slice(0, Math.max(0, maxOutputBytes - stdout.length));
+				stdoutTruncated = true;
+				// Runaway output — terminate so we stop accumulating. The close
+				// event then settles with the truncated buffer.
+				try {
+					child.kill('SIGTERM');
+				} catch {
+					// already gone
+				}
+			} else {
+				stdout += chunk;
+			}
 		});
 
 		child.stderr?.on('data', (data) => {
-			stderr += data.toString();
+			if (stderrTruncated) return;
+			const chunk = data.toString();
+			if (stderr.length + chunk.length > maxOutputBytes) {
+				stderr += chunk.slice(0, Math.max(0, maxOutputBytes - stderr.length));
+				stderrTruncated = true;
+			} else {
+				stderr += chunk;
+			}
 		});
 
 		child.on('close', (code) => {
-			clearTimeout(timeout);
-			resolve({
+			settle({
 				stdout,
 				stderr,
 				exitCode: code ?? 0,
@@ -233,8 +323,7 @@ async function executeWithTimeout(
 		});
 
 		child.on('error', (err) => {
-			clearTimeout(timeout);
-			resolve({
+			settle({
 				stdout,
 				stderr: err.message,
 				exitCode: 1,
@@ -290,6 +379,19 @@ export async function runSemgrep(
 			timeoutMs,
 			cwd: options.cwd,
 		});
+
+		// Output was capped mid-stream: the JSON is incomplete and would parse to
+		// zero findings. Surface that as an error (engine: tier_a) rather than
+		// silently reporting a clean scan — a SAST gate must never fail open
+		// because the scanner produced too much output.
+		if (result.truncated) {
+			return {
+				available: true,
+				findings: [],
+				error: `Semgrep output exceeded ${MAX_OUTPUT_BYTES} bytes and was truncated; results incomplete`,
+				engine: 'tier_a',
+			};
+		}
 
 		if (result.exitCode !== 0) {
 			// Semgrep returned non-zero exit code

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -396,8 +396,144 @@ interface ParsedImport {
  * @param content - File content to parse
  * @returns Array of parsed imports with specifier and type
  */
-function parseFileImports(content: string): ParsedImport[] {
+/**
+ * Characters after which a `/` begins a regex literal rather than a division
+ * operator. At these expression-start positions `/` cannot be division, so a
+ * following `/regex/` is a regex literal whose body must be treated opaquely
+ * (it may legally contain `/*`, `//`, quotes, etc.).
+ */
+const REGEX_ALLOWED_AFTER = new Set('(,=:[!&|?{};*+-~^<>%'.split(''));
+
+/**
+ * Strip line (`//…`) and block (`/* … *\/`) comments from JS/TS source while
+ * preserving string, template-literal, and regex-literal contents (DD-C010).
+ * Import specifiers live inside string literals, so strings must be kept
+ * intact; only comment spans are removed. This is a bounded single-pass scanner
+ * — not a full parser (AST parsing in the repo-graph init path would violate
+ * AGENTS.md invariant 1) — and it eliminates the most common source of false
+ * import edges: import-like text inside comments (`// import x from "y"`).
+ *
+ * It is string-aware (a `//` inside `"http://…"` is not a comment) and
+ * regex-aware (a regex literal such as `/[/*]/` must not be mistaken for the
+ * start of a block comment, which would otherwise run to EOF and delete real
+ * imports). Regex-vs-division is disambiguated by the previous significant
+ * character (REGEX_ALLOWED_AFTER).
+ */
+function stripComments(content: string): string {
+	let out = '';
+	let i = 0;
+	const n = content.length;
+	type State =
+		| 'code'
+		| 'single'
+		| 'double'
+		| 'template'
+		| 'line'
+		| 'block'
+		| 'regex';
+	let state: State = 'code';
+	// Last non-whitespace char emitted while in `code` — disambiguates a `/`
+	// that starts a regex literal from a division operator. Empty = start of
+	// input (regex allowed).
+	let prevSignificant = '';
+	// Whether the regex scanner is inside a `[...]` character class, where `/`
+	// is literal and does not close the regex.
+	let regexInClass = false;
+	while (i < n) {
+		const ch = content[i];
+		const next = i + 1 < n ? content[i + 1] : '';
+		switch (state) {
+			case 'code':
+				// `//` and `/*` always start comments — a regex literal can begin
+				// with neither (`//` is an empty regex = comment per the JS grammar;
+				// `/*` cannot start a regex since `*` is an invalid leading quantifier).
+				if (ch === '/' && next === '/') {
+					state = 'line';
+					i += 2;
+				} else if (ch === '/' && next === '*') {
+					state = 'block';
+					i += 2;
+				} else if (ch === '/' && REGEX_ALLOWED_AFTER.has(prevSignificant)) {
+					// Regex literal — consume its body opaquely.
+					state = 'regex';
+					regexInClass = false;
+					out += ch;
+					i += 1;
+				} else {
+					if (ch === "'") state = 'single';
+					else if (ch === '"') state = 'double';
+					else if (ch === '`') state = 'template';
+					out += ch;
+					if (ch.trim() !== '') prevSignificant = ch;
+					i += 1;
+				}
+				break;
+			case 'single':
+			case 'double':
+			case 'template': {
+				const quote = state === 'single' ? "'" : state === 'double' ? '"' : '`';
+				if (ch === '\\') {
+					// Preserve escape sequences verbatim.
+					out += ch + next;
+					i += 2;
+				} else {
+					if (ch === quote) {
+						state = 'code';
+						// A literal is a value: a following `/` is division.
+						prevSignificant = quote;
+					}
+					out += ch;
+					i += 1;
+				}
+				break;
+			}
+			case 'regex':
+				if (ch === '\\') {
+					out += ch + next;
+					i += 2;
+				} else if (ch === '\n') {
+					// Regex literals cannot span lines — bail defensively to code.
+					state = 'code';
+					out += ch;
+					i += 1;
+				} else {
+					if (ch === '[') regexInClass = true;
+					else if (ch === ']') regexInClass = false;
+					else if (ch === '/' && !regexInClass) {
+						state = 'code';
+						prevSignificant = '/'; // after a regex, `/` is division
+					}
+					out += ch;
+					i += 1;
+				}
+				break;
+			case 'line':
+				// Drop comment chars; preserve the newline so line structure (and
+				// downstream regex anchors) are unaffected.
+				if (ch === '\n') {
+					state = 'code';
+					out += ch;
+				}
+				i += 1;
+				break;
+			case 'block':
+				if (ch === '*' && next === '/') {
+					state = 'code';
+					i += 2;
+				} else {
+					// Preserve newlines inside block comments.
+					if (ch === '\n') out += ch;
+					i += 1;
+				}
+				break;
+		}
+	}
+	return out;
+}
+
+function parseFileImports(rawContent: string): ParsedImport[] {
 	const imports: ParsedImport[] = [];
+	const content = stripComments(rawContent);
 
 	// Combined regex matching:
 	// - import { x } from '...' or import { x as y } from '...'

--- a/src/tools/syntax-check.ts
+++ b/src/tools/syntax-check.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { tool } from '@opencode-ai/plugin';
+import pLimit from 'p-limit';
 import { z } from 'zod';
 import type { PluginConfig } from '../config';
 import type { EvidenceVerdict } from '../config/evidence-schema';
@@ -40,6 +41,10 @@ export interface SyntaxCheckResult {
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB — WASM tree-sitter aborts on larger files
 const BINARY_CHECK_BYTES = 8192; // 8KB
 const BINARY_NULL_THRESHOLD = 0.1; // 10% null bytes
+// Bounded concurrency for per-file processing. Each file does a sync read +
+// sync parse; the cap keeps file-descriptor and memory pressure predictable
+// for large diffs while overlapping the async grammar-load awaits.
+const SYNTAX_CHECK_CONCURRENCY = 8;
 
 /**
  * Check if file content appears to be binary
@@ -71,9 +76,16 @@ function extractSyntaxErrors(
 
 	const errors: Array<{ line: number; column: number; message: string }> = [];
 
-	// Walk the tree to find ERROR and MISSING nodes
+	// Walk the tree to find ERROR and MISSING nodes using an explicit stack
+	// rather than recursion. A deeply nested parse tree (heavily nested JSON,
+	// minified code) could otherwise overflow the JS call stack (DD-C018);
+	// the explicit stack moves the traversal onto the heap. Children are
+	// pushed in reverse so they are visited left-to-right (pre-order),
+	// matching the previous recursive order.
 	// biome-ignore lint/suspicious/noExplicitAny: tree-sitter node type not exported
-	function walkNode(node: any) {
+	const stack: any[] = [tree.rootNode];
+	while (stack.length > 0) {
+		const node = stack.pop();
 		if (node.type === 'ERROR') {
 			errors.push({
 				line: node.startPosition.row + 1, // 1-indexed
@@ -87,12 +99,11 @@ function extractSyntaxErrors(
 				message: `Missing '${node.type}'`,
 			});
 		}
-		for (const child of node.children) {
-			walkNode(child);
+		const children = node.children;
+		for (let i = children.length - 1; i >= 0; i--) {
+			stack.push(children[i]);
 		}
 	}
-
-	walkNode(tree.rootNode);
 
 	// Fallback: if tree-walking found no explicit ERROR/MISSING nodes but the
 	// root reports hasError, flag the file so errors aren't silently swallowed
@@ -151,12 +162,29 @@ export async function syntaxCheck(
 		});
 	}
 
-	const results: SyntaxCheckFileResult[] = [];
-	let filesChecked = 0;
-	let filesFailed = 0;
-	let skippedCount = 0;
+	// Hoist the runtime module import out of the per-file loop (DD-C020). ESM
+	// caches the module, but loading it once before the fan-out keeps the hot
+	// path free of a redundant dynamic-import expression per file.
+	const { loadGrammar } = await import('../lang/runtime');
 
-	for (const fileInfo of filesToCheck) {
+	/**
+	 * Per-file processing outcome. `counted`/`failed`/`skipped` reproduce the
+	 * exact counter semantics of the original sequential loop so the summary
+	 * numbers are unchanged: early skips (unsupported/read-error/too-large/
+	 * binary) are counted as skipped only; parse outcomes are counted; a thrown
+	 * error during processing counts as both skipped and checked.
+	 */
+	interface FileOutcome {
+		result: SyntaxCheckFileResult;
+		counted: boolean;
+		failed: boolean;
+		skipped: boolean;
+	}
+
+	async function checkOneFile(fileInfo: {
+		path: string;
+		additions: number;
+	}): Promise<FileOutcome> {
 		const { path: filePath } = fileInfo;
 		const fullPath = path.isAbsolute(filePath)
 			? filePath
@@ -175,7 +203,6 @@ export async function syntaxCheck(
 			const grammarId = profile?.treeSitter?.grammarId;
 			let parser: Parser | null = null;
 			if (grammarId) {
-				const { loadGrammar } = await import('../lang/runtime');
 				try {
 					parser = await loadGrammar(grammarId);
 				} catch {
@@ -188,9 +215,21 @@ export async function syntaxCheck(
 			}
 			if (!parser) {
 				result.skipped_reason = 'unsupported_language';
-				skippedCount++;
-				results.push(result);
-				continue;
+				return { result, counted: false, failed: false, skipped: true };
+			}
+
+			// Size pre-check via stat to avoid reading large files into memory
+			// just to reject them (DD-C017). stat is a best-effort optimization:
+			// if it is unavailable or throws, fall through to the read, whose own
+			// error handling and the post-read size guard still apply.
+			try {
+				const stat = fs.statSync(fullPath);
+				if (stat.size >= MAX_FILE_SIZE) {
+					result.skipped_reason = 'file_too_large';
+					return { result, counted: false, failed: false, skipped: true };
+				}
+			} catch {
+				// stat unavailable/failed — proceed to read below
 			}
 
 			// Read file content
@@ -199,25 +238,19 @@ export async function syntaxCheck(
 				content = fs.readFileSync(fullPath, 'utf8');
 			} catch {
 				result.skipped_reason = 'file_read_error';
-				skippedCount++;
-				results.push(result);
-				continue;
+				return { result, counted: false, failed: false, skipped: true };
 			}
 
-			// Check file size
+			// Check file size (defensive: character length, post-read)
 			if (content.length >= MAX_FILE_SIZE) {
 				result.skipped_reason = 'file_too_large';
-				skippedCount++;
-				results.push(result);
-				continue;
+				return { result, counted: false, failed: false, skipped: true };
 			}
 
 			// Check for binary content
 			if (isBinaryContent(content)) {
 				result.skipped_reason = 'binary_file';
-				skippedCount++;
-				results.push(result);
-				continue;
+				return { result, counted: false, failed: false, skipped: true };
 			}
 
 			// Resolve language ID: prefer profile, fall back to registry
@@ -231,18 +264,34 @@ export async function syntaxCheck(
 			if (errors.length > 0) {
 				result.ok = false;
 				result.errors = errors;
-				filesFailed++;
-			} else {
-				result.ok = true;
+				return { result, counted: true, failed: true, skipped: false };
 			}
+			result.ok = true;
+			return { result, counted: true, failed: false, skipped: false };
 		} catch (error) {
 			result.skipped_reason =
 				error instanceof Error ? error.message : 'unknown_error';
-			skippedCount++;
+			return { result, counted: true, failed: false, skipped: true };
 		}
+	}
 
-		results.push(result);
-		filesChecked++;
+	// Process files with bounded concurrency (DD-C019). Order is preserved by
+	// mapping over the input array; counters are aggregated deterministically
+	// from the resolved outcomes afterward.
+	const limit = pLimit(SYNTAX_CHECK_CONCURRENCY);
+	const outcomes = await Promise.all(
+		filesToCheck.map((fileInfo) => limit(() => checkOneFile(fileInfo))),
+	);
+
+	const results: SyntaxCheckFileResult[] = [];
+	let filesChecked = 0;
+	let filesFailed = 0;
+	let skippedCount = 0;
+	for (const outcome of outcomes) {
+		results.push(outcome.result);
+		if (outcome.counted) filesChecked++;
+		if (outcome.failed) filesFailed++;
+		if (outcome.skipped) skippedCount++;
 	}
 
 	const verdict: EvidenceVerdict = filesFailed > 0 ? 'fail' : 'pass';

--- a/src/tools/test-runner.ts
+++ b/src/tools/test-runner.ts
@@ -359,29 +359,31 @@ function detectMinitest(cwd: string): boolean {
  * pre-Phase-3 behavior for languages whose tests the legacy path
  * couldn't detect either.
  */
-const DISPATCH_FRAMEWORK_MAP: Record<string, TestFramework> = {
-	'bun:test': 'bun',
+export const DISPATCH_FRAMEWORK_MAP: Record<string, TestFramework> = {
+	// Identity mappings — profile framework names unified with the union
+	// (DD-C026). The remaining non-identity entries are genuine aliases where
+	// several profile names collapse to one union framework.
 	bun: 'bun',
 	vitest: 'vitest',
 	jest: 'jest',
 	mocha: 'mocha',
 	pytest: 'pytest',
-	'cargo test': 'cargo',
 	cargo: 'cargo',
 	pester: 'pester',
-	'go test': 'go-test',
-	'maven-test': 'maven',
-	'gradle-test': 'gradle',
-	'gradle-test-groovy': 'gradle',
-	'gradle-kts': 'gradle',
-	'dotnet test': 'dotnet-test',
+	'go-test': 'go-test',
+	maven: 'maven',
+	gradle: 'gradle',
+	'dotnet-test': 'dotnet-test',
 	ctest: 'ctest',
-	'swift test': 'swift-test',
+	'swift-test': 'swift-test',
+	'dart-test': 'dart-test',
+	rspec: 'rspec',
+	minitest: 'minitest',
+	// Genuine aliases (many profile names → one union framework).
+	'bun:test': 'bun',
 	'xcodebuild-test': 'swift-test',
 	'flutter test': 'dart-test',
 	'dart test': 'dart-test',
-	rspec: 'rspec',
-	minitest: 'minitest',
 };
 
 export async function detectTestFrameworkViaDispatch(

--- a/tests/unit/agents/project-context-laravel.test.ts
+++ b/tests/unit/agents/project-context-laravel.test.ts
@@ -1,0 +1,66 @@
+/**
+ * DD-C009: buildProjectContext applies the Laravel command overlay for PHP
+ * projects, and the PHP backend surfaces PROJECT_FRAMEWORK = laravel. This is
+ * the production wiring that makes the previously-dead framework-detector live.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+// Importing the backends barrel registers the PHP backend in the registry.
+import '../../../src/lang/backends';
+import { buildProjectContext } from '../../../src/agents/project-context';
+import { clearDispatchCache } from '../../../src/lang/dispatch';
+
+let tempDir: string;
+
+beforeEach(() => {
+	clearDispatchCache();
+	tempDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'project-context-laravel-')),
+	);
+});
+
+afterEach(() => {
+	clearDispatchCache();
+	try {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	} catch {
+		// best-effort
+	}
+});
+
+function writeLaravelProject(dir: string): void {
+	// 2 of 3 Laravel signals: artisan file + laravel/framework in require.
+	fs.writeFileSync(path.join(dir, 'artisan'), '#!/usr/bin/env php\n');
+	fs.writeFileSync(
+		path.join(dir, 'composer.json'),
+		JSON.stringify({ require: { 'laravel/framework': '^11.0' } }),
+	);
+}
+
+describe('buildProjectContext — Laravel overlay (DD-C009)', () => {
+	test('Laravel project: TEST_CMD becomes "php artisan test"', async () => {
+		writeLaravelProject(tempDir);
+		const ctx = await buildProjectContext(tempDir);
+		expect(ctx).not.toBeNull();
+		expect(ctx!.PROJECT_LANGUAGE).toBe('PHP');
+		expect(ctx!.TEST_CMD).toBe('php artisan test');
+		expect(ctx!.PROJECT_FRAMEWORK).toBe('laravel');
+	});
+
+	test('generic Composer (non-Laravel) project keeps the profile default test command', async () => {
+		// composer.json without laravel/framework + no artisan → not Laravel.
+		fs.writeFileSync(
+			path.join(tempDir, 'composer.json'),
+			JSON.stringify({ require: { 'monolog/monolog': '^3.0' } }),
+		);
+		fs.writeFileSync(path.join(tempDir, 'phpunit.xml'), '<phpunit></phpunit>');
+		const ctx = await buildProjectContext(tempDir);
+		expect(ctx).not.toBeNull();
+		expect(ctx!.PROJECT_LANGUAGE).toBe('PHP');
+		// PHPUnit default, NOT the artisan overlay.
+		expect(ctx!.TEST_CMD).not.toBe('php artisan test');
+	});
+});

--- a/tests/unit/hooks/repo-graph-builder.boundary.test.ts
+++ b/tests/unit/hooks/repo-graph-builder.boundary.test.ts
@@ -264,4 +264,92 @@ describe('repo-graph-builder workspace boundary validation', () => {
 
 		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
 	});
+
+	// ─────────────────────────────────────────────────────────────────
+	// SYMLINK / REALPATH / URL-DECODE EDGE CASES
+	// (consolidated here from the former duplicate block in
+	// repo-graph-builder.test.ts — DD-C013)
+	// ─────────────────────────────────────────────────────────────────
+
+	test('toolAfter skips update when safeRealpathSync returns null', async () => {
+		const hook = createRepoGraphBuilderHook(workspaceRoot, {
+			updateGraphForFiles: mockUpdateGraphForFiles,
+			buildWorkspaceGraph: mockBuildWorkspaceGraph,
+			saveGraph: mockSaveGraph,
+			safeRealpathSync: () => null, // mock returns null
+		});
+
+		const filePath = path.join(workspaceRoot, 'src', 'index.ts');
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, 'export const x = 1;');
+
+		await hook.toolAfter(makeToolInput(filePath), { output: undefined });
+
+		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
+	});
+
+	test('symlink pointing outside workspace is rejected via realpathSync', async () => {
+		// Skip on platforms where symlinks are not reliably supported in tmpdir
+		if (process.platform === 'win32') return;
+
+		const hook = makeHook();
+
+		// Create a real file OUTSIDE the workspace
+		const outsideDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), 'outside-workspace-'),
+		);
+		const outsideFile = path.join(outsideDir, 'secret.ts');
+		fs.writeFileSync(outsideFile, 'export const secret = 42;');
+
+		// Create a symlink INSIDE the workspace that points outside
+		const symlinkInWorkspace = path.join(workspaceRoot, 'src', 'escape.ts');
+		fs.mkdirSync(path.dirname(symlinkInWorkspace), { recursive: true });
+		try {
+			fs.symlinkSync(outsideFile, symlinkInWorkspace);
+		} catch {
+			// If symlink creation fails (e.g., insufficient perms), skip test
+			fs.rmSync(outsideDir, { recursive: true, force: true });
+			return;
+		}
+
+		try {
+			// The symlink path is inside workspace, but realpathSync should
+			// resolve it to the real (outside) path and reject it
+			await hook.toolAfter(makeToolInput(symlinkInWorkspace), {
+				output: undefined,
+			});
+
+			expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
+		} finally {
+			fs.rmSync(outsideDir, { recursive: true, force: true });
+		}
+	});
+
+	test('URL-encoded path is decoded before boundary check', async () => {
+		const hook = makeHook();
+
+		const filePath = path.join(workspaceRoot, 'src', 'index.ts');
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, 'export const x = 1;');
+
+		// %2E = '.' so index%2Ets decodes to index.ts
+		const encodedPath = filePath.replace('index.ts', 'index%2Ets');
+
+		// Verifies that URL-encoded paths don't crash the hook and either work
+		// (if the decoded path is valid inside workspace) or are filtered.
+		await hook.toolAfter(makeToolInput(encodedPath), { output: undefined });
+
+		expect(true).toBe(true);
+	});
+
+	test('URL-encoded null byte in path is rejected', async () => {
+		const hook = makeHook();
+
+		// %00 decodes to null byte \0 which should be rejected
+		const nullBytePath = path.join(workspaceRoot, 'src%00', 'index.ts');
+
+		await hook.toolAfter(makeToolInput(nullBytePath), { output: undefined });
+
+		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
+	});
 });

--- a/tests/unit/hooks/repo-graph-builder.test.ts
+++ b/tests/unit/hooks/repo-graph-builder.test.ts
@@ -20,9 +20,11 @@ import * as path from 'node:path';
 import { createRepoGraphBuilderHook } from '../../../src/hooks/repo-graph-builder';
 import * as logger from '../../../src/utils/logger';
 
-// Create a real temp workspace directory for cross-platform compatibility
+// Create a real temp workspace directory for cross-platform compatibility.
+// Use os.tmpdir() (AGENTS.md invariant 7) so a cleanup failure cannot leave
+// artifacts inside the project tree.
 const tempWorkspace = fs.mkdtempSync(
-	path.join(process.cwd(), 'repo-graph-hook-test-'),
+	path.join(os.tmpdir(), 'repo-graph-hook-test-'),
 );
 
 // Cleanup temp workspace at end of all tests
@@ -395,402 +397,6 @@ describe('toolAfter hook', () => {
 	});
 });
 
-describe('workspace boundary validation', () => {
-	let tempDir: string;
-	let workspaceRoot: string;
-
-	beforeEach(() => {
-		mockUpdateGraphForFiles.mockClear();
-		mockBuildWorkspaceGraph.mockClear();
-		mockSaveGraph.mockClear();
-		// Create a real temp workspace directory
-		tempDir = fs.mkdtempSync(
-			path.join(os.tmpdir(), 'repo-graph-boundary-test-'),
-		);
-		workspaceRoot = tempDir;
-	});
-
-	afterEach(() => {
-		// Clean up temp directory
-		try {
-			fs.rmSync(tempDir, { recursive: true, force: true });
-		} catch {
-			// Ignore cleanup errors
-		}
-	});
-
-	test('file inside workspace triggers updateGraphForFiles', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		// Create a file inside workspace
-		const filePath = path.join(workspaceRoot, 'src', 'index.ts');
-		fs.mkdirSync(path.dirname(filePath), { recursive: true });
-		fs.writeFileSync(filePath, 'export const x = 1;');
-
-		await hook.toolAfter(
-			{ tool: 'write', sessionID: 'test', args: { file_path: filePath } },
-			{ output: undefined },
-		);
-
-		expect(mockUpdateGraphForFiles).toHaveBeenCalledTimes(1);
-		expect(mockUpdateGraphForFiles).toHaveBeenCalledWith(workspaceRoot, [
-			filePath,
-		]);
-	});
-
-	test('relative file path inside workspace triggers updateGraphForFiles', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		// Create a file inside workspace
-		const filePath = path.join(workspaceRoot, 'src', 'index.ts');
-		fs.mkdirSync(path.dirname(filePath), { recursive: true });
-		fs.writeFileSync(filePath, 'export const x = 1;');
-
-		// Pass relative path
-		await hook.toolAfter(
-			{ tool: 'write', sessionID: 'test', args: { file_path: 'src/index.ts' } },
-			{ output: undefined },
-		);
-
-		expect(mockUpdateGraphForFiles).toHaveBeenCalledTimes(1);
-		expect(mockUpdateGraphForFiles).toHaveBeenCalledWith(workspaceRoot, [
-			filePath,
-		]);
-	});
-
-	test('absolute file outside workspace is rejected', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		// Create a file OUTSIDE workspace
-		const outsideFile = path.join(os.tmpdir(), 'outside-workspace.txt');
-		fs.writeFileSync(outsideFile, 'secret');
-
-		await hook.toolAfter(
-			{ tool: 'write', sessionID: 'test', args: { file_path: outsideFile } },
-			{ output: undefined },
-		);
-
-		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
-	});
-
-	test('relative path resolving outside workspace is rejected', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		// Create a sibling directory
-		const siblingDir = path.join(workspaceRoot, '..', 'sibling-workspace');
-		fs.mkdirSync(siblingDir, { recursive: true });
-
-		// Pass a relative path that resolves outside workspace
-		await hook.toolAfter(
-			{
-				tool: 'write',
-				sessionID: 'test',
-				args: { file_path: '../sibling-workspace/file.txt' },
-			},
-			{ output: undefined },
-		);
-
-		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
-	});
-
-	test('path traversal attempt ../../../etc/passwd is rejected after resolution', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		// Attempt path traversal to escape workspace
-		await hook.toolAfter(
-			{
-				tool: 'write',
-				sessionID: 'test',
-				args: { file_path: '../../../etc/passwd' },
-			},
-			{ output: undefined },
-		);
-
-		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
-	});
-
-	test('absolute path traversal attempt is rejected', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		// Create a sibling directory for the traversal target
-		const siblingDir = path.join(workspaceRoot, '..', 'target');
-		fs.mkdirSync(siblingDir, { recursive: true });
-
-		// Path that resolves to workspace root's parent or beyond
-		const traversalPath = path.join(
-			workspaceRoot,
-			'..',
-			'..',
-			'..',
-			'target',
-			'file.ts',
-		);
-		await hook.toolAfter(
-			{ tool: 'write', sessionID: 'test', args: { file_path: traversalPath } },
-			{ output: undefined },
-		);
-
-		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
-	});
-
-	test('workspace root itself is allowed (edge case)', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		// The boundary check allows: startsWith(workspaceRoot + path.sep) OR equals workspaceRoot
-		// A file at workspace root level should be allowed
-		const rootLevelFile = path.join(workspaceRoot, 'root.ts');
-		fs.writeFileSync(rootLevelFile, '// marker');
-
-		await hook.toolAfter(
-			{ tool: 'write', sessionID: 'test', args: { file_path: 'root.ts' } },
-			{ output: undefined },
-		);
-
-		expect(mockUpdateGraphForFiles).toHaveBeenCalledTimes(1);
-	});
-
-	test('similar-name directory outside workspace is rejected', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		// Create a "similar" directory name that shares prefix but is NOT the workspace
-		const similarRoot = path.join(
-			os.tmpdir(),
-			'repo-graph-boundary-test-similar',
-		);
-		fs.mkdirSync(similarRoot, { recursive: true });
-		const similarFile = path.join(similarRoot, 'file.ts');
-		fs.writeFileSync(similarFile, 'similar');
-
-		await hook.toolAfter(
-			{ tool: 'write', sessionID: 'test', args: { file_path: similarFile } },
-			{ output: undefined },
-		);
-
-		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
-	});
-
-	test('file in parent directory of workspace is rejected', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		// Create a file in the parent of workspace
-		const parentFile = path.join(workspaceRoot, '..', 'parent-file.ts');
-		fs.writeFileSync(parentFile, 'parent');
-
-		await hook.toolAfter(
-			{ tool: 'write', sessionID: 'test', args: { file_path: parentFile } },
-			{ output: undefined },
-		);
-
-		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
-	});
-
-	test('unsupported extension is filtered before boundary check', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		// Even a file inside workspace with unsupported extension should not trigger update
-		const filePath = path.join(workspaceRoot, 'data.json');
-		fs.writeFileSync(filePath, '{}');
-
-		await hook.toolAfter(
-			{ tool: 'write', sessionID: 'test', args: { file_path: filePath } },
-			{ output: undefined },
-		);
-
-		// Should be filtered by isSupportedSourceFile before boundary check
-		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
-	});
-
-	test('non-write tool is filtered before boundary check', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		const filePath = path.join(workspaceRoot, 'file.ts');
-		fs.writeFileSync(filePath, 'content');
-
-		// Send a read tool
-		await hook.toolAfter(
-			{ tool: 'Read', sessionID: 'test', args: { file_path: filePath } },
-			{ output: undefined },
-		);
-
-		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
-	});
-
-	test('missing file_path arg is filtered before boundary check', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		await hook.toolAfter(
-			{ tool: 'write', sessionID: 'test', args: {} },
-			{ output: undefined },
-		);
-
-		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
-	});
-
-	test('toolAfter skips update when safeRealpathSync returns null', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-			safeRealpathSync: () => null, // mock returns null
-		});
-
-		// Create a file inside workspace
-		const filePath = path.join(workspaceRoot, 'src', 'index.ts');
-		fs.mkdirSync(path.dirname(filePath), { recursive: true });
-		fs.writeFileSync(filePath, 'export const x = 1;');
-
-		await hook.toolAfter(
-			{ tool: 'write', sessionID: 'test', args: { file_path: filePath } },
-			{ output: undefined },
-		);
-
-		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
-	});
-
-	test('symlink pointing outside workspace is rejected via realpathSync', async () => {
-		// Skip on platforms where symlinks are not reliably supported in tmpdir
-		if (process.platform === 'win32') return;
-
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		// Create a real file OUTSIDE the workspace
-		const outsideDir = fs.mkdtempSync(
-			path.join(os.tmpdir(), 'outside-workspace-'),
-		);
-		const outsideFile = path.join(outsideDir, 'secret.ts');
-		fs.writeFileSync(outsideFile, 'export const secret = 42;');
-
-		// Create a symlink INSIDE the workspace that points outside
-		const symlinkInWorkspace = path.join(workspaceRoot, 'src', 'escape.ts');
-		fs.mkdirSync(path.dirname(symlinkInWorkspace), { recursive: true });
-		try {
-			fs.symlinkSync(outsideFile, symlinkInWorkspace);
-		} catch {
-			// If symlink creation fails (e.g., insufficient perms), skip test
-			fs.rmSync(outsideDir, { recursive: true, force: true });
-			return;
-		}
-
-		try {
-			// The symlink path is inside workspace, but realpathSync should
-			// resolve it to the real (outside) path and reject it
-			await hook.toolAfter(
-				{
-					tool: 'write',
-					sessionID: 'test',
-					args: { file_path: symlinkInWorkspace },
-				},
-				{ output: undefined },
-			);
-
-			expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
-		} finally {
-			fs.rmSync(outsideDir, { recursive: true, force: true });
-		}
-	});
-
-	test('URL-encoded path is decoded before boundary check', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		// Create a file inside workspace with a name that would be URL-encoded
-		const filePath = path.join(workspaceRoot, 'src', 'index.ts');
-		fs.mkdirSync(path.dirname(filePath), { recursive: true });
-		fs.writeFileSync(filePath, 'export const x = 1;');
-
-		// URL-encode the path (e.g., spaces encoded as %20, etc.)
-		// The most practical case: encode the path separator or other chars
-		const encodedPath = filePath.replace('index.ts', 'index%2Ets');
-		// Note: %2E = '.' so index%2Ets decodes to index.ts
-
-		await hook.toolAfter(
-			{ tool: 'write', sessionID: 'test', args: { file_path: encodedPath } },
-			{ output: undefined },
-		);
-
-		// After URL-decode, the path should resolve to index.ts which is inside workspace
-		// The decoded path would be 'index.ts' — but the encoded form depends on whether
-		// it decodes to a valid path. Let's use a simpler approach.
-		// This test verifies that URL-encoded paths don't crash the hook
-		// and either work (if decoded path is valid inside workspace) or are filtered.
-		// We verify no exception was thrown by reaching this assertion.
-		expect(true).toBe(true);
-	});
-
-	test('URL-encoded null byte in path is rejected', async () => {
-		const hook = createRepoGraphBuilderHook(workspaceRoot, {
-			buildWorkspaceGraph: mockBuildWorkspaceGraph,
-			saveGraph: mockSaveGraph,
-			updateGraphForFiles: mockUpdateGraphForFiles,
-		});
-
-		// %00 decodes to null byte \0 which should be rejected
-		const nullBytePath = path.join(workspaceRoot, 'src%00', 'index.ts');
-
-		await hook.toolAfter(
-			{ tool: 'write', sessionID: 'test', args: { file_path: nullBytePath } },
-			{ output: undefined },
-		);
-
-		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
-	});
-});
-
 describe('error escalation advisory', () => {
 	let tempDir: string;
 	let workspaceRoot: string;
@@ -910,6 +516,49 @@ describe('error escalation advisory', () => {
 				);
 			}
 			expect(warnSpy).not.toHaveBeenCalledWith(
+				expect.stringContaining('consecutive'),
+			);
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	test('failures are tracked per session, not pooled across sessions (DD-C011)', async () => {
+		mockUpdateGraphForFiles.mockImplementation(() => {
+			throw new Error('simulated failure');
+		});
+
+		const hook = createRepoGraphBuilderHook(workspaceRoot, {
+			buildWorkspaceGraph: mockBuildWorkspaceGraph,
+			saveGraph: mockSaveGraph,
+			updateGraphForFiles: mockUpdateGraphForFiles,
+		});
+
+		const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+
+		const tsFile = path.join(workspaceRoot, 'test.ts');
+		fs.writeFileSync(tsFile, 'export const x = 1;');
+
+		try {
+			// 2 failures in session 'a' and 2 in session 'b'. A pooled counter
+			// would reach 4 and fire the advisory; per-session counting keeps each
+			// at 2 (< threshold 3), so no advisory.
+			for (const sessionID of ['a', 'a', 'b', 'b']) {
+				await hook.toolAfter(
+					{ tool: 'write', sessionID, args: { file_path: tsFile } },
+					{ output: undefined },
+				);
+			}
+			expect(warnSpy).not.toHaveBeenCalledWith(
+				expect.stringContaining('consecutive'),
+			);
+
+			// A 3rd failure in session 'a' alone crosses the threshold.
+			await hook.toolAfter(
+				{ tool: 'write', sessionID: 'a', args: { file_path: tsFile } },
+				{ output: undefined },
+			);
+			expect(warnSpy).toHaveBeenCalledWith(
 				expect.stringContaining('consecutive'),
 			);
 		} finally {

--- a/tests/unit/lang/detector.test.ts
+++ b/tests/unit/lang/detector.test.ts
@@ -150,6 +150,26 @@ describe('detectProjectLanguages', () => {
 		expect(ids).toContain('kotlin');
 	});
 
+	it('Dir with only a *.csproj file → detects csharp via glob (DD-C025)', async () => {
+		await writeFile(
+			join(tempDir, 'MyApp.csproj'),
+			'<Project Sdk="Microsoft.NET.Sdk"></Project>',
+		);
+		const profiles = await detectProjectLanguages(tempDir);
+		const ids = profiles.map((p) => p.id);
+		expect(ids).toContain('csharp');
+	});
+
+	it('Dir with only a *.sln file → detects csharp via glob (DD-C025)', async () => {
+		await writeFile(
+			join(tempDir, 'MyApp.sln'),
+			'Microsoft Visual Studio Solution File',
+		);
+		const profiles = await detectProjectLanguages(tempDir);
+		const ids = profiles.map((p) => p.id);
+		expect(ids).toContain('csharp');
+	});
+
 	it('Empty directory → returns empty array []', async () => {
 		const profiles = await detectProjectLanguages(tempDir);
 		expect(profiles).toEqual([]);

--- a/tests/unit/lang/php-backend.test.ts
+++ b/tests/unit/lang/php-backend.test.ts
@@ -1,0 +1,37 @@
+/**
+ * PHP backend tests (DD-C009). Verifies the Laravel framework detection
+ * (previously dead code) is wired into the dispatch layer via the PHP
+ * backend's `selectFramework` hook, using the real fixture projects.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
+import { buildPhpBackend } from '../../../src/lang/backends/php';
+
+const FIXTURES = path.join(process.cwd(), 'tests', 'fixtures');
+
+describe('PHP backend selectFramework (DD-C009)', () => {
+	test('detects Laravel for the laravel-baseline fixture', async () => {
+		const backend = buildPhpBackend();
+		expect(backend.selectFramework).toBeDefined();
+		const sel = await backend.selectFramework?.(
+			path.join(FIXTURES, 'laravel-baseline'),
+		);
+		expect(sel).not.toBeNull();
+		expect(sel?.name).toBe('laravel');
+	});
+
+	test('returns null for a generic (non-Laravel) Composer project', async () => {
+		const backend = buildPhpBackend();
+		const sel = await backend.selectFramework?.(
+			path.join(FIXTURES, 'generic-composer'),
+		);
+		expect(sel ?? null).toBeNull();
+	});
+
+	test('backend is built from the php profile (id + displayName)', () => {
+		const backend = buildPhpBackend();
+		expect(backend.id).toBe('php');
+		expect(backend.displayName).toBe('PHP');
+	});
+});

--- a/tests/unit/lang/python-go-backends.test.ts
+++ b/tests/unit/lang/python-go-backends.test.ts
@@ -196,8 +196,8 @@ import (
 	});
 });
 
-describe('backend registration: typescript + python + go', () => {
-	test('all three backends register through LANGUAGE_BACKEND_REGISTRY', async () => {
+describe('backend registration: typescript + python + go + php', () => {
+	test('all registered backends resolve through LANGUAGE_BACKEND_REGISTRY', async () => {
 		await import('../../../src/lang/backends');
 		const { LANGUAGE_BACKEND_REGISTRY } = await import(
 			'../../../src/lang/registry-backend'
@@ -205,5 +205,6 @@ describe('backend registration: typescript + python + go', () => {
 		expect(LANGUAGE_BACKEND_REGISTRY.get('typescript')).toBeDefined();
 		expect(LANGUAGE_BACKEND_REGISTRY.get('python')).toBeDefined();
 		expect(LANGUAGE_BACKEND_REGISTRY.get('go')).toBeDefined();
+		expect(LANGUAGE_BACKEND_REGISTRY.get('php')).toBeDefined();
 	});
 });

--- a/tests/unit/sast/rules.test.ts
+++ b/tests/unit/sast/rules.test.ts
@@ -104,6 +104,18 @@ describe('SAST Rule Engine', () => {
 		});
 	});
 
+	describe('rule registration integrity', () => {
+		it('should not register duplicate rule IDs (DD-C003)', () => {
+			const rules = getAllRules();
+			const seen = new Map<string, number>();
+			for (const rule of rules) {
+				seen.set(rule.id, (seen.get(rule.id) ?? 0) + 1);
+			}
+			const duplicates = [...seen.entries()].filter(([, count]) => count > 1);
+			expect(duplicates).toEqual([]);
+		});
+	});
+
 	describe('JavaScript/TypeScript Rule Detection', () => {
 		it('should detect eval() usage', () => {
 			const findings = executeRulesSync(
@@ -322,6 +334,20 @@ describe('SAST Rule Engine', () => {
 			);
 			expect(finding).toBeDefined();
 		});
+
+		it('should not flag short strings as Java secrets (DD-C015)', () => {
+			// A 5-char string was flagged as critical under the old {5,} threshold.
+			// The aligned {10,} threshold must not flag it.
+			const findings = executeRulesSync(
+				'test.java',
+				'String token = "abcde";',
+				'java',
+			);
+			const finding = findings.find(
+				(f) => f.rule_id === 'sast/java-hardcoded-secret',
+			);
+			expect(finding).toBeUndefined();
+		});
 	});
 
 	describe('PHP Rule Detection', () => {
@@ -429,6 +455,25 @@ describe('SAST Rule Engine', () => {
 			);
 			expect(finding).toBeDefined();
 			expect(finding?.severity).toBe('critical');
+		});
+
+		it('should NOT flag Process.Start when UseShellExecute=false (DD-C016)', () => {
+			const findings = executeRulesSync(
+				'test.cs',
+				[
+					'var psi = new ProcessStartInfo {',
+					'  FileName = "git",',
+					'  Arguments = "status",',
+					'  UseShellExecute = false,',
+					'};',
+					'Process.Start(psi);',
+				].join('\n'),
+				'csharp',
+			);
+			const finding = findings.find(
+				(f) => f.rule_id === 'sast/cs-command-injection',
+			);
+			expect(finding).toBeUndefined();
 		});
 
 		it('should detect BinaryFormatter', () => {

--- a/tests/unit/sast/semgrep.test.ts
+++ b/tests/unit/sast/semgrep.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { _internals } from '../../../src/sast/semgrep';
+
+/**
+ * Tests for the hardened `executeWithTimeout` subprocess helper
+ * (DD-C001/DD-C002/DD-C004). These exercise the AGENTS.md invariant-3
+ * properties: bounded stdio, a guaranteed timeout, and best-effort kill.
+ *
+ * The child is the bun runtime itself (`process.execPath`) running a tiny
+ * inline script, so the test is cross-platform and needs no external binary.
+ */
+describe('executeWithTimeout subprocess hardening', () => {
+	let tmpDir: string;
+
+	const writeScript = (name: string, body: string): string => {
+		const p = path.join(tmpDir, name);
+		fs.writeFileSync(p, body, 'utf8');
+		return p;
+	};
+
+	beforeAll(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'semgrep-exec-test-'));
+	});
+
+	afterAll(() => {
+		try {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it('returns stdout and exit code for a normal run', async () => {
+		const script = writeScript(
+			'ok.js',
+			'process.stdout.write("hello-world"); process.exit(0);',
+		);
+		const result = await _internals.executeWithTimeout(
+			process.execPath,
+			[script],
+			{ timeoutMs: 10_000 },
+		);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('hello-world');
+	});
+
+	it('terminates a long-running child at the timeout (DD-C002)', async () => {
+		// Child stays alive 60s; with a 300ms budget the helper must kill it and
+		// settle promptly rather than waiting for the child to exit on its own.
+		const script = writeScript('hang.js', 'setTimeout(() => {}, 60_000);');
+		const start = Date.now();
+		const result = await _internals.executeWithTimeout(
+			process.execPath,
+			[script],
+			{ timeoutMs: 300 },
+		);
+		const elapsed = Date.now() - start;
+		expect(result.exitCode).toBe(124);
+		expect(result.stderr).toBe('Process timed out');
+		// Settled near the deadline, nowhere near the child's 60s lifetime.
+		expect(elapsed).toBeLessThan(10_000);
+	});
+
+	it('does not hang when stdin is never closed (DD-C001)', async () => {
+		// With stdio stdin: 'ignore', a child that reads stdin sees immediate EOF
+		// instead of an open pipe that could block exit under Bun on Windows.
+		const script = writeScript(
+			'stdin.js',
+			[
+				'const chunks = [];',
+				'process.stdin.on("data", (d) => chunks.push(d));',
+				'process.stdin.on("end", () => { process.stdout.write("eof"); process.exit(0); });',
+				'process.stdin.resume();',
+			].join('\n'),
+		);
+		const result = await _internals.executeWithTimeout(
+			process.execPath,
+			[script],
+			{ timeoutMs: 10_000 },
+		);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('eof');
+	});
+
+	it('bounds runaway stdout accumulation (DD-C004)', async () => {
+		// Emit far more than the cap; accumulated stdout must stay bounded.
+		const script = writeScript(
+			'flood.js',
+			'process.stdout.write("x".repeat(500_000)); process.exit(0);',
+		);
+		const result = await _internals.executeWithTimeout(
+			process.execPath,
+			[script],
+			{ timeoutMs: 10_000, maxOutputBytes: 1024 },
+		);
+		expect(result.stdout.length).toBeLessThanOrEqual(1024);
+		// Truncation must be signaled so runSemgrep does not fail open.
+		expect(result.truncated).toBe(true);
+	});
+
+	it('does not flag truncation for output within the cap', async () => {
+		const script = writeScript(
+			'small.js',
+			'process.stdout.write("ok"); process.exit(0);',
+		);
+		const result = await _internals.executeWithTimeout(
+			process.execPath,
+			[script],
+			{ timeoutMs: 10_000, maxOutputBytes: 1024 },
+		);
+		expect(result.truncated).toBe(false);
+	});
+});

--- a/tests/unit/tools/pre-check-batch-sast-preexisting.test.ts
+++ b/tests/unit/tools/pre-check-batch-sast-preexisting.test.ts
@@ -314,88 +314,294 @@ mock.module('../../../src/utils', () => ({
 // Re-import after mocks are set up
 const { runPreCheckBatch } = await import('../../../src/tools/pre-check-batch');
 
-// Windows: git diff output and Bun.spawn cwd handling differ, causing multiple test failures
-describe.skipIf(process.platform === 'win32')(
-	'runPreCheckBatch SAST gate integration',
-	() => {
-		let tempDir: string;
-		let originalCwd: string;
+// DD-C008: previously skipped on Windows. The lint/secretscan/sast/quality
+// gates are all mocked (above), so the only real subprocess is git — which
+// emits forward-slash diff paths on every OS, and is stabilized here with
+// core.autocrlf=false so committed content (and therefore diff line ranges)
+// is identical across platforms. classifySastFindings already normalizes
+// `\`→`/` (pre-check-batch.ts), so the gate logic is platform-agnostic.
+describe('runPreCheckBatch SAST gate integration', () => {
+	let tempDir: string;
+	let originalCwd: string;
 
-		beforeEach(() => {
-			originalCwd = process.cwd();
-			tempDir = fs.realpathSync(
-				fs.mkdtempSync(path.join(os.tmpdir(), 'sast-gate-test-')),
-			);
-			process.chdir(tempDir);
-
-			// Create test file
-			fs.writeFileSync(path.join(tempDir, 'test.ts'), 'export const x = 1;\n');
-
-			// Symlink node_modules
-			try {
-				fs.symlinkSync(
-					path.join(originalCwd, 'node_modules'),
-					path.join(tempDir, 'node_modules'),
-					'junction',
-				);
-			} catch {
-				// May fail on some platforms
-			}
-
-			mockSastScan.mockClear();
-		});
-
-		afterEach(() => {
-			process.chdir(originalCwd);
-			try {
-				fs.rmSync(tempDir, { recursive: true, force: true });
-			} catch {
-				// Windows EBUSY: git processes may still hold locks; non-fatal in tests
-			}
-		});
-
-		test(
-			'SAST with new HIGH finding on changed line → gates_passed false',
-			{ timeout: 30_000 },
-			async () => {
-				// SAST returns a HIGH finding — and git diff is unavailable (non-git dir)
-				// so fail-closed treats it as new
-				mockSastScan.mockImplementationOnce(async () => ({
-					verdict: 'fail' as const,
-					findings: [
-						{
-							rule_id: 'sql-injection',
-							severity: 'high' as const,
-							message: 'SQL injection detected',
-							location: { file: path.join(tempDir, 'test.ts'), line: 1 },
-						},
-					],
-					summary: {
-						engine: 'tier_a' as const,
-						files_scanned: 1,
-						findings_count: 1,
-						findings_by_severity: { critical: 0, high: 1, medium: 0, low: 0 },
-					},
-				}));
-
-				const result = await runPreCheckBatch({
-					files: ['test.ts'],
-					directory: tempDir,
-				});
-
-				expect(result.gates_passed).toBe(false);
-				expect(result.sast_preexisting_findings).toBeUndefined();
-			},
+	beforeEach(() => {
+		originalCwd = process.cwd();
+		tempDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'sast-gate-test-')),
 		);
+		process.chdir(tempDir);
 
-		test(
-			'SAST with only pre-existing HIGH finding (no changed lines) → gates_passed true + sast_preexisting_findings',
-			{ timeout: 30_000 },
-			async () => {
-				// Initialize a git repo with two commits so HEAD~1 strategy works
+		// Create test file
+		fs.writeFileSync(path.join(tempDir, 'test.ts'), 'export const x = 1;\n');
+
+		// Symlink node_modules
+		try {
+			fs.symlinkSync(
+				path.join(originalCwd, 'node_modules'),
+				path.join(tempDir, 'node_modules'),
+				'junction',
+			);
+		} catch {
+			// May fail on some platforms
+		}
+
+		mockSastScan.mockClear();
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			// Windows EBUSY: git processes may still hold locks; non-fatal in tests
+		}
+	});
+
+	test(
+		'SAST with new HIGH finding on changed line → gates_passed false',
+		{ timeout: 30_000 },
+		async () => {
+			// SAST returns a HIGH finding — and git diff is unavailable (non-git dir)
+			// so fail-closed treats it as new
+			mockSastScan.mockImplementationOnce(async () => ({
+				verdict: 'fail' as const,
+				findings: [
+					{
+						rule_id: 'sql-injection',
+						severity: 'high' as const,
+						message: 'SQL injection detected',
+						location: { file: path.join(tempDir, 'test.ts'), line: 1 },
+					},
+				],
+				summary: {
+					engine: 'tier_a' as const,
+					files_scanned: 1,
+					findings_count: 1,
+					findings_by_severity: { critical: 0, high: 1, medium: 0, low: 0 },
+				},
+			}));
+
+			const result = await runPreCheckBatch({
+				files: ['test.ts'],
+				directory: tempDir,
+			});
+
+			expect(result.gates_passed).toBe(false);
+			expect(result.sast_preexisting_findings).toBeUndefined();
+		},
+	);
+
+	test(
+		'SAST with only pre-existing HIGH finding (no changed lines) → gates_passed true + sast_preexisting_findings',
+		{ timeout: 30_000 },
+		async () => {
+			// Initialize a git repo with two commits so HEAD~1 strategy works
+			const { execSync } = await import('node:child_process');
+			try {
+				execSync('git init', { cwd: tempDir, stdio: 'pipe' });
+				execSync('git config core.autocrlf false', {
+					cwd: tempDir,
+					stdio: 'pipe',
+				});
+				execSync('git config user.email "test@test.com"', {
+					cwd: tempDir,
+					stdio: 'pipe',
+				});
+				execSync('git config user.name "Test"', {
+					cwd: tempDir,
+					stdio: 'pipe',
+				});
+				// First commit with the file
+				execSync('git add -A && git commit -m "init"', {
+					cwd: tempDir,
+					stdio: 'pipe',
+				});
+				// Second commit (empty) so HEAD~1 diff shows no changes to test.ts
+				fs.writeFileSync(path.join(tempDir, 'other.txt'), 'unrelated\n');
+				execSync('git add -A && git commit -m "other"', {
+					cwd: tempDir,
+					stdio: 'pipe',
+				});
+			} catch {
+				// Git may not be available; skip this test gracefully
+				return;
+			}
+
+			const findingFile = path.join(tempDir, 'test.ts');
+			mockSastScan.mockImplementationOnce(async () => ({
+				verdict: 'fail' as const,
+				findings: [
+					{
+						rule_id: 'sql-injection',
+						severity: 'high' as const,
+						message: 'Pre-existing SQL injection',
+						location: { file: findingFile, line: 1 },
+					},
+				],
+				summary: {
+					engine: 'tier_a' as const,
+					files_scanned: 1,
+					findings_count: 1,
+					findings_by_severity: { critical: 0, high: 1, medium: 0, low: 0 },
+				},
+			}));
+
+			const result = await runPreCheckBatch({
+				files: ['test.ts'],
+				directory: tempDir,
+			});
+
+			// test.ts was not modified in the last commit — finding is pre-existing
+			expect(result.gates_passed).toBe(true);
+			expect(result.sast_preexisting_findings).toBeDefined();
+			expect(result.sast_preexisting_findings).toHaveLength(1);
+			expect(result.sast_preexisting_findings![0].rule_id).toBe(
+				'sql-injection',
+			);
+		},
+	);
+
+	test(
+		'SAST with mixed findings (one new + one pre-existing) → gates_passed false',
+		{ timeout: 30_000 },
+		async () => {
+			// In a non-git directory, fail-closed means ALL are treated as new → blocks
+			mockSastScan.mockImplementationOnce(async () => ({
+				verdict: 'fail' as const,
+				findings: [
+					{
+						rule_id: 'xss-new',
+						severity: 'critical' as const,
+						message: 'XSS on changed line',
+						location: { file: path.join(tempDir, 'test.ts'), line: 1 },
+					},
+					{
+						rule_id: 'sql-old',
+						severity: 'high' as const,
+						message: 'Pre-existing SQL injection',
+						location: { file: path.join(tempDir, 'test.ts'), line: 50 },
+					},
+				],
+				summary: {
+					engine: 'tier_a' as const,
+					files_scanned: 1,
+					findings_count: 2,
+					findings_by_severity: { critical: 1, high: 1, medium: 0, low: 0 },
+				},
+			}));
+
+			const result = await runPreCheckBatch({
+				files: ['test.ts'],
+				directory: tempDir,
+			});
+
+			// Non-git dir → fail-closed → all findings are new → blocks
+			expect(result.gates_passed).toBe(false);
+			expect(result.sast_preexisting_findings).toBeUndefined();
+		},
+	);
+
+	// DD-C008: enabled on Windows — git config below pins autocrlf off so the
+	// committed content and diff line ranges match across platforms.
+	test(
+		'reviewer receives structured sast_preexisting_findings field',
+		{ timeout: 30_000 },
+		async () => {
+			// Use git repo where file is committed (no changed lines)
+			const { execSync } = await import('node:child_process');
+			try {
+				execSync('git init', { cwd: tempDir, stdio: 'pipe' });
+				execSync('git config core.autocrlf false', {
+					cwd: tempDir,
+					stdio: 'pipe',
+				});
+				execSync('git config user.email "test@test.com"', {
+					cwd: tempDir,
+					stdio: 'pipe',
+				});
+				execSync('git config user.name "Test"', {
+					cwd: tempDir,
+					stdio: 'pipe',
+				});
+				execSync('git add -A && git commit -m "init"', {
+					cwd: tempDir,
+					stdio: 'pipe',
+				});
+				// Second commit so HEAD~1 works
+				fs.writeFileSync(path.join(tempDir, 'other.txt'), 'unrelated\n');
+				execSync('git add -A && git commit -m "other"', {
+					cwd: tempDir,
+					stdio: 'pipe',
+				});
+			} catch {
+				return; // Skip if git unavailable
+			}
+
+			const findingFile = path.join(tempDir, 'test.ts');
+			mockSastScan.mockImplementationOnce(async () => ({
+				verdict: 'fail' as const,
+				findings: [
+					{
+						rule_id: 'hardcoded-secret',
+						severity: 'critical' as const,
+						message: 'Hardcoded secret on unchanged line',
+						location: { file: findingFile, line: 1 },
+						remediation: 'Use environment variables',
+					},
+				],
+				summary: {
+					engine: 'tier_a' as const,
+					files_scanned: 1,
+					findings_count: 1,
+					findings_by_severity: { critical: 1, high: 0, medium: 0, low: 0 },
+				},
+			}));
+
+			const result = await runPreCheckBatch({
+				files: ['test.ts'],
+				directory: tempDir,
+			});
+
+			expect(result.gates_passed).toBe(true);
+			expect(result.sast_preexisting_findings).toBeDefined();
+
+			const finding = result.sast_preexisting_findings![0];
+			expect(finding.rule_id).toBe('hardcoded-secret');
+			expect(finding.severity).toBe('critical');
+			expect(finding.message).toBe('Hardcoded secret on unchanged line');
+			expect(finding.location.file).toBe(findingFile);
+			expect(finding.location.line).toBe(1);
+			expect(finding.remediation).toBe('Use environment variables');
+		},
+	);
+
+	test(
+		'no false deadlock: changed file is clean, unchanged file has HIGH SAST finding → gates_passed true, finding surfaced to reviewer',
+		{ timeout: 30_000 },
+		async () => {
+			// Scenario: coder touched clean.ts (no findings), but legacy.ts (not touched) has a HIGH finding.
+			// System must NOT block the coder for legacy.ts's pre-existing issue.
+			// The finding must be surfaced to reviewer via sast_preexisting_findings.
+
+			const tempDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'pcb-nodeadlock-')),
+			);
+			try {
+				// Create two files: clean.ts (changed) and legacy.ts (unchanged with finding)
+				fs.writeFileSync(
+					path.join(tempDir, 'clean.ts'),
+					'export const x = 1;\n',
+				);
+				fs.writeFileSync(path.join(tempDir, 'legacy.ts'), 'eval(userInput);\n');
+
+				// Set up git repo: legacy.ts committed first, then clean.ts added in second commit
 				const { execSync } = await import('node:child_process');
 				try {
 					execSync('git init', { cwd: tempDir, stdio: 'pipe' });
+					execSync('git config core.autocrlf false', {
+						cwd: tempDir,
+						stdio: 'pipe',
+					});
 					execSync('git config user.email "test@test.com"', {
 						cwd: tempDir,
 						stdio: 'pipe',
@@ -404,253 +610,59 @@ describe.skipIf(process.platform === 'win32')(
 						cwd: tempDir,
 						stdio: 'pipe',
 					});
-					// First commit with the file
-					execSync('git add -A && git commit -m "init"', {
+					// First commit: legacy.ts only
+					execSync('git add legacy.ts && git commit -m "add legacy"', {
 						cwd: tempDir,
 						stdio: 'pipe',
 					});
-					// Second commit (empty) so HEAD~1 diff shows no changes to test.ts
-					fs.writeFileSync(path.join(tempDir, 'other.txt'), 'unrelated\n');
-					execSync('git add -A && git commit -m "other"', {
+					// Second commit: add clean.ts (this is the "changed" file)
+					execSync('git add clean.ts && git commit -m "add clean"', {
 						cwd: tempDir,
 						stdio: 'pipe',
 					});
 				} catch {
-					// Git may not be available; skip this test gracefully
+					// Git not available — skip gracefully
 					return;
 				}
 
-				const findingFile = path.join(tempDir, 'test.ts');
+				const legacyFile = path.join(tempDir, 'legacy.ts');
+				// SAST returns a HIGH finding on legacy.ts line 1 (unchanged file)
 				mockSastScan.mockImplementationOnce(async () => ({
 					verdict: 'fail' as const,
 					findings: [
 						{
-							rule_id: 'sql-injection',
+							rule_id: 'eval-injection',
 							severity: 'high' as const,
-							message: 'Pre-existing SQL injection',
-							location: { file: findingFile, line: 1 },
+							message: 'eval() with user input is dangerous',
+							location: { file: legacyFile, line: 1 },
 						},
 					],
 					summary: {
 						engine: 'tier_a' as const,
-						files_scanned: 1,
+						files_scanned: 2,
 						findings_count: 1,
 						findings_by_severity: { critical: 0, high: 1, medium: 0, low: 0 },
 					},
 				}));
 
+				// Coder only touched clean.ts — pass only that file
 				const result = await runPreCheckBatch({
-					files: ['test.ts'],
+					files: ['clean.ts'],
 					directory: tempDir,
 				});
 
-				// test.ts was not modified in the last commit — finding is pre-existing
+				// Must NOT block: changed file (clean.ts) has no findings
 				expect(result.gates_passed).toBe(true);
+
+				// Must surface the pre-existing finding to reviewer
 				expect(result.sast_preexisting_findings).toBeDefined();
 				expect(result.sast_preexisting_findings).toHaveLength(1);
 				expect(result.sast_preexisting_findings![0].rule_id).toBe(
-					'sql-injection',
+					'eval-injection',
 				);
-			},
-		);
-
-		test(
-			'SAST with mixed findings (one new + one pre-existing) → gates_passed false',
-			{ timeout: 30_000 },
-			async () => {
-				// In a non-git directory, fail-closed means ALL are treated as new → blocks
-				mockSastScan.mockImplementationOnce(async () => ({
-					verdict: 'fail' as const,
-					findings: [
-						{
-							rule_id: 'xss-new',
-							severity: 'critical' as const,
-							message: 'XSS on changed line',
-							location: { file: path.join(tempDir, 'test.ts'), line: 1 },
-						},
-						{
-							rule_id: 'sql-old',
-							severity: 'high' as const,
-							message: 'Pre-existing SQL injection',
-							location: { file: path.join(tempDir, 'test.ts'), line: 50 },
-						},
-					],
-					summary: {
-						engine: 'tier_a' as const,
-						files_scanned: 1,
-						findings_count: 2,
-						findings_by_severity: { critical: 1, high: 1, medium: 0, low: 0 },
-					},
-				}));
-
-				const result = await runPreCheckBatch({
-					files: ['test.ts'],
-					directory: tempDir,
-				});
-
-				// Non-git dir → fail-closed → all findings are new → blocks
-				expect(result.gates_passed).toBe(false);
-				expect(result.sast_preexisting_findings).toBeUndefined();
-			},
-		);
-
-		// Windows: git diff and SAST scanner produce different output, causing gates_passed mismatch
-		test.skipIf(process.platform === 'win32')(
-			'reviewer receives structured sast_preexisting_findings field',
-			{ timeout: 30_000 },
-			async () => {
-				// Use git repo where file is committed (no changed lines)
-				const { execSync } = await import('node:child_process');
-				try {
-					execSync('git init', { cwd: tempDir, stdio: 'pipe' });
-					execSync('git config user.email "test@test.com"', {
-						cwd: tempDir,
-						stdio: 'pipe',
-					});
-					execSync('git config user.name "Test"', {
-						cwd: tempDir,
-						stdio: 'pipe',
-					});
-					execSync('git add -A && git commit -m "init"', {
-						cwd: tempDir,
-						stdio: 'pipe',
-					});
-					// Second commit so HEAD~1 works
-					fs.writeFileSync(path.join(tempDir, 'other.txt'), 'unrelated\n');
-					execSync('git add -A && git commit -m "other"', {
-						cwd: tempDir,
-						stdio: 'pipe',
-					});
-				} catch {
-					return; // Skip if git unavailable
-				}
-
-				const findingFile = path.join(tempDir, 'test.ts');
-				mockSastScan.mockImplementationOnce(async () => ({
-					verdict: 'fail' as const,
-					findings: [
-						{
-							rule_id: 'hardcoded-secret',
-							severity: 'critical' as const,
-							message: 'Hardcoded secret on unchanged line',
-							location: { file: findingFile, line: 1 },
-							remediation: 'Use environment variables',
-						},
-					],
-					summary: {
-						engine: 'tier_a' as const,
-						files_scanned: 1,
-						findings_count: 1,
-						findings_by_severity: { critical: 1, high: 0, medium: 0, low: 0 },
-					},
-				}));
-
-				const result = await runPreCheckBatch({
-					files: ['test.ts'],
-					directory: tempDir,
-				});
-
-				expect(result.gates_passed).toBe(true);
-				expect(result.sast_preexisting_findings).toBeDefined();
-
-				const finding = result.sast_preexisting_findings![0];
-				expect(finding.rule_id).toBe('hardcoded-secret');
-				expect(finding.severity).toBe('critical');
-				expect(finding.message).toBe('Hardcoded secret on unchanged line');
-				expect(finding.location.file).toBe(findingFile);
-				expect(finding.location.line).toBe(1);
-				expect(finding.remediation).toBe('Use environment variables');
-			},
-		);
-
-		test(
-			'no false deadlock: changed file is clean, unchanged file has HIGH SAST finding → gates_passed true, finding surfaced to reviewer',
-			{ timeout: 30_000 },
-			async () => {
-				// Scenario: coder touched clean.ts (no findings), but legacy.ts (not touched) has a HIGH finding.
-				// System must NOT block the coder for legacy.ts's pre-existing issue.
-				// The finding must be surfaced to reviewer via sast_preexisting_findings.
-
-				const tempDir = fs.realpathSync(
-					fs.mkdtempSync(path.join(os.tmpdir(), 'pcb-nodeadlock-')),
-				);
-				try {
-					// Create two files: clean.ts (changed) and legacy.ts (unchanged with finding)
-					fs.writeFileSync(
-						path.join(tempDir, 'clean.ts'),
-						'export const x = 1;\n',
-					);
-					fs.writeFileSync(
-						path.join(tempDir, 'legacy.ts'),
-						'eval(userInput);\n',
-					);
-
-					// Set up git repo: legacy.ts committed first, then clean.ts added in second commit
-					const { execSync } = await import('node:child_process');
-					try {
-						execSync('git init', { cwd: tempDir, stdio: 'pipe' });
-						execSync('git config user.email "test@test.com"', {
-							cwd: tempDir,
-							stdio: 'pipe',
-						});
-						execSync('git config user.name "Test"', {
-							cwd: tempDir,
-							stdio: 'pipe',
-						});
-						// First commit: legacy.ts only
-						execSync('git add legacy.ts && git commit -m "add legacy"', {
-							cwd: tempDir,
-							stdio: 'pipe',
-						});
-						// Second commit: add clean.ts (this is the "changed" file)
-						execSync('git add clean.ts && git commit -m "add clean"', {
-							cwd: tempDir,
-							stdio: 'pipe',
-						});
-					} catch {
-						// Git not available — skip gracefully
-						return;
-					}
-
-					const legacyFile = path.join(tempDir, 'legacy.ts');
-					// SAST returns a HIGH finding on legacy.ts line 1 (unchanged file)
-					mockSastScan.mockImplementationOnce(async () => ({
-						verdict: 'fail' as const,
-						findings: [
-							{
-								rule_id: 'eval-injection',
-								severity: 'high' as const,
-								message: 'eval() with user input is dangerous',
-								location: { file: legacyFile, line: 1 },
-							},
-						],
-						summary: {
-							engine: 'tier_a' as const,
-							files_scanned: 2,
-							findings_count: 1,
-							findings_by_severity: { critical: 0, high: 1, medium: 0, low: 0 },
-						},
-					}));
-
-					// Coder only touched clean.ts — pass only that file
-					const result = await runPreCheckBatch({
-						files: ['clean.ts'],
-						directory: tempDir,
-					});
-
-					// Must NOT block: changed file (clean.ts) has no findings
-					expect(result.gates_passed).toBe(true);
-
-					// Must surface the pre-existing finding to reviewer
-					expect(result.sast_preexisting_findings).toBeDefined();
-					expect(result.sast_preexisting_findings).toHaveLength(1);
-					expect(result.sast_preexisting_findings![0].rule_id).toBe(
-						'eval-injection',
-					);
-				} finally {
-					fs.rmSync(tempDir, { recursive: true, force: true });
-				}
-			},
-		);
-	},
-);
+			} finally {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			}
+		},
+	);
+});

--- a/tests/unit/tools/repo-graph-comment-stripping.test.ts
+++ b/tests/unit/tools/repo-graph-comment-stripping.test.ts
@@ -1,0 +1,87 @@
+/**
+ * DD-C010: parseFileImports strips comments before scanning for imports, so
+ * import-like text inside comments does not produce false graph edges. Strings
+ * (which contain the real import specifiers) must stay intact, including `//`
+ * sequences inside string literals (e.g. URLs).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { _internals as builderInternals } from '../../../src/tools/repo-graph/builder';
+
+const specifiers = (src: string): string[] =>
+	builderInternals.parseFileImports(src).map((i) => i.specifier);
+
+describe('parseFileImports comment stripping (DD-C010)', () => {
+	test('ignores import statements inside a line comment', () => {
+		const src = [
+			"import { real } from './real';",
+			"// import { fake } from './fake';",
+			"const x = 1; // require('./also-fake')",
+		].join('\n');
+		const found = specifiers(src);
+		expect(found).toContain('./real');
+		expect(found).not.toContain('./fake');
+		expect(found).not.toContain('./also-fake');
+	});
+
+	test('ignores import statements inside a block comment', () => {
+		const src = [
+			'/*',
+			" import Foo from './blocked';",
+			" export * from './blocked-reexport';",
+			'*/',
+			"import Bar from './kept';",
+		].join('\n');
+		const found = specifiers(src);
+		expect(found).toContain('./kept');
+		expect(found).not.toContain('./blocked');
+		expect(found).not.toContain('./blocked-reexport');
+	});
+
+	test('does not treat // inside a string literal as a comment', () => {
+		const src = [
+			'const url = "http://example.com/import-from-here";',
+			"import { keep } from './keep';",
+		].join('\n');
+		const found = specifiers(src);
+		expect(found).toContain('./keep');
+	});
+
+	test('real imports on the same line before a trailing comment are kept', () => {
+		const src = "import { keep } from './keep'; // import './fake'";
+		const found = specifiers(src);
+		expect(found).toContain('./keep');
+		expect(found).not.toContain('./fake');
+	});
+
+	test('a regex literal containing /* does not eat the following import', () => {
+		// Regression: without regex-literal tracking, the `/*` inside the char
+		// class starts a (never-closed) block comment and deletes the import.
+		const src = [
+			'const re = /[/*]/;',
+			"import { foo } from './real-module';",
+		].join('\n');
+		const found = specifiers(src);
+		expect(found).toContain('./real-module');
+	});
+
+	test('a regex literal containing // does not eat the following import', () => {
+		const src = ['const re = /a\\/\\//g;', "import { bar } from './bar';"].join(
+			'\n',
+		);
+		const found = specifiers(src);
+		expect(found).toContain('./bar');
+	});
+
+	test('division operators are not mistaken for a regex literal', () => {
+		// `a / b / c` is division; a real block comment after it must still strip.
+		const src = [
+			'const x = a / b / c;',
+			'/* import { gone } from "./gone"; */',
+			"import { kept } from './kept';",
+		].join('\n');
+		const found = specifiers(src);
+		expect(found).toContain('./kept');
+		expect(found).not.toContain('./gone');
+	});
+});

--- a/tests/unit/tools/test-runner-dispatch-parity.test.ts
+++ b/tests/unit/tools/test-runner-dispatch-parity.test.ts
@@ -3,8 +3,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { clearDispatchCache } from '../../../src/lang/dispatch';
+import { LANGUAGE_REGISTRY } from '../../../src/lang/profiles';
 import {
 	buildTestCommandViaDispatch,
+	DISPATCH_FRAMEWORK_MAP,
 	detectTestFramework,
 	detectTestFrameworkViaDispatch,
 	parseTestOutputViaDispatch,
@@ -167,6 +169,42 @@ describe('detectTestFramework legacy ↔ dispatch parity', () => {
 		// names to 'none' to preserve parity.
 		expect(legacy).toBe('none');
 		expect(viaDispatch).toBe('none');
+	});
+});
+
+describe('DD-C026: profile framework name ↔ dispatch map coverage', () => {
+	// Names whose test frameworks the legacy TestFramework union intentionally
+	// does not represent — `detectTestFrameworkViaDispatch` collapses them to
+	// 'none' on purpose (legacy could not detect them either).
+	const INTENTIONALLY_UNMAPPED = new Set(['unittest', 'Pest', 'PHPUnit']);
+
+	test('every profile test-framework name is either mapped or explicitly unmapped', () => {
+		const unmapped: string[] = [];
+		for (const profile of LANGUAGE_REGISTRY.getAll()) {
+			for (const fw of profile.test.frameworks) {
+				if (INTENTIONALLY_UNMAPPED.has(fw.name)) continue;
+				if (!(fw.name in DISPATCH_FRAMEWORK_MAP)) {
+					unmapped.push(`${profile.id}:${fw.name}`);
+				}
+			}
+		}
+		// A profile framework name absent from the map silently dispatches to
+		// 'none' — the exact latent footgun DD-C026 calls out. Lock it shut.
+		expect(unmapped).toEqual([]);
+	});
+
+	test('after unification, profile names map to themselves where a union member exists', () => {
+		// The 6 previously-divergent names now equal their union target.
+		for (const name of [
+			'cargo',
+			'go-test',
+			'maven',
+			'gradle',
+			'dotnet-test',
+			'swift-test',
+		]) {
+			expect(DISPATCH_FRAMEWORK_MAP[name]).toBe(name);
+		}
 	});
 });
 


### PR DESCRIPTION
Closes #1002

## Summary

- **Semgrep subprocess hardening (DD-C001/C002/C004):** `spawn` with `stdio: ['ignore', 'pipe', 'pipe']`, single `settle()` with SIGTERM→SIGKILL escalation, 10MB per-stream stdout/stderr cap; `truncated` flag causes `runSemgrep` to return an error rather than a clean-scan lie
- **SAST rule fixes (DD-C003/C015/C016):** Remove duplicate `sast/go-hardcoded-secret` rule (`{20,}` subset of `{10,}`); align Java hardcoded-secret threshold `{5,}` → `{10,}` matching Go/C# siblings; add `validate()` to C# `sast/cs-command-injection` rule gating on `UseShellExecute=false`
- **lang/runtime (DD-C021/C022):** `withTimeout` wrapping `Language.load`, in-flight load coalescing via `inflightLoads` Map, static `node:fs` imports, explicit named re-exports from `lang/index.ts` replacing `export *`
- **lang/detector (DD-C025):** Glob patterns (C# `.csproj` / Swift `.xcodeproj`) now converted to regex and matched — previously skipped, causing missed language detection
- **lang/profiles (DD-C015/C027):** Kotlin lint detection changed from `.editorconfig` to `build.gradle.kts`; 6 framework names unified across test-runner dispatch map for parity
- **PHP Laravel backend (DD-C009):** New `src/lang/backends/php.ts` with `detectLaravelProject` (≥2 of 3 signals: `artisan`, `composer.json`, `config/app.php`); `buildPhpBackend()` registered in backend registry; `getLaravelCommandOverlay` wired into `buildProjectContext`
- **syntax-check (DD-C017/C018/C020):** `statSync` pre-check before read, iterative tree walk replacing recursive `walkNode`, `pLimit` parallelization (`SYNTAX_CHECK_CONCURRENCY=8`), dynamic import hoisted out of per-file loop
- **repo-graph comment stripping (DD-C010):** `stripComments` pre-pass with full state machine including `regex` state; `REGEX_ALLOWED_AFTER` set for context-driven `/`-start disambiguation (prevents `/*` inside regex char classes from eating following imports)
- **repo-graph session state (DD-C011):** `failuresBySession` Map keyed by `sessionID`; FIFO bounded at `MAX_TRACKED_SESSIONS=100`; 5-min decay; 60-s cooldown
- **Windows SAST integration tests (DD-C008):** Removed `skipIf(win32)` guards; added `git config core.autocrlf false` to each git-init sequence
- **Test hygiene (DD-C013/C014):** Boundary tests extracted to dedicated file; `process.cwd()` temp paths → `os.tmpdir()`
- **Phase 4.5 adversarial review fixes:** Regex-literal stripping regression and semgrep truncation fail-open both identified and fixed

## Invariant audit

- **1 (plugin init): touched** — grammar load wrapped in `withTimeout(Language.load, GRAMMAR_LOAD_TIMEOUT_MS)`; syntax-check parallelized with `pLimit`; PHP backend detection is pure filesystem reads; `repro-704` smoke all 3 pass (88.7ms, 11.5ms, 15.6ms)
- **2 (runtime portability): touched** — `bun run build` clean (4.69 MB); `node --input-type=module -e "await import('./dist/index.js')"` → `dist import OK`; no `bun:` imports in changed files
- **3 (subprocesses): touched** — single changed subprocess in `semgrep.ts:226` uses `shell:false`, `stdin:'ignore'`, SIGTERM→SIGKILL, 10MB cap. Grep of changed files confirms no other spawn calls
- **4 (.swarm containment): not touched** — no new `process.cwd()` callers; `.swarm/` paths unchanged
- **5 (plan durability): not touched**
- **6 (test_runner safety): not touched**
- **7 (test writing): touched** — all new tests use `bun:test` only; `os.tmpdir()` + `mkdtempSync` for temp dirs; `_internals` DI seams for mock isolation; `afterAll` cleanup
- **8 (session state): touched** — `failuresBySession` keyed by `sessionID`; `MAX_TRACKED_SESSIONS=100` FIFO; 5-min decay; per-session isolation test in `repo-graph-builder.test.ts`
- **9 (guardrails/retry): not touched**
- **10 (chat/system msg): not touched**
- **11 (tool registration): not touched** — PHP backend is a language backend, not a tool
- **12 (release/cache): touched** — `docs/releases/pending/1002-deep-dive-audit-repo-graph-sast-syntax.md` created; `package.json` version untouched

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx biome ci .` — 2 pre-existing warnings only, no errors
- [x] `bun run build` — clean, 4.69 MB bundle
- [x] `node --input-type=module -e "await import('./dist/index.js')"` → `dist import OK`
- [x] `node scripts/repro-704.mjs` — all 3 timing checks pass
- [x] `tests/unit/sast/rules.test.ts` — 68 pass / 0 fail
- [x] `tests/unit/sast/semgrep.test.ts` — 5 pass / 0 fail (subprocess hardening: timeout kill, stdin no-hang, output cap, truncated flag)
- [x] `tests/unit/lang/detector.test.ts` — 26 pass / 0 fail (*.csproj / *.sln glob cases)
- [x] `tests/unit/lang/php-backend.test.ts` — 3 pass / 0 fail
- [x] `tests/unit/lang/*.test.ts` (all 27 files) — pass / 0 fail
- [x] `tests/unit/tools/repo-graph-comment-stripping.test.ts` — 7 pass / 0 fail (regex-literal cases)
- [x] `tests/unit/hooks/repo-graph-builder.test.ts` and `.boundary.test.ts` — 0 fail
- [x] `tests/unit/agents/project-context-laravel.test.ts` — 2 pass / 0 fail
- [x] `tests/unit/tools/test-runner-dispatch-parity.test.ts` — 21 pass / 0 fail
- [x] `tests/smoke` — 10 pass / 0 fail
- [x] `tests/security` — 139 pass / 0 fail
- [x] Phase 4.5 independent adversarial review completed; 2 confirmed findings addressed

## Pre-existing failures (verified on clean `origin/main`)

All failures below reproduce identically on `origin/main` (verified with `git worktree add /tmp/main-check origin/main && bun install`):

| File | Fail count | Notes |
|------|-----------|-------|
| `tests/unit/tools/test-runner.test.ts` | 2 | Scope-guard behavior; pre-documented |
| `tests/unit/tools/sast-and-cochanger-tools.test.ts` | 18 | `mock.module` DI leakage |
| `tests/unit/tools/tool-registration-conformance.test.ts` | 1 | Missing export pre-existing |
| `tests/unit/tools/update-task-status.adversarial.test.ts` | 10 | Pre-existing |
| `tests/unit/tools/phase-complete-lean-turbo-critic.test.ts` | 9 | Pre-existing |
| `tests/unit/hooks/full-auto-intercept.test.ts` | 21 | Pre-existing |
| `tests/unit/hooks/guardrails-shell-write.test.ts` | 15 | Pre-existing |
| `tests/unit/hooks/repo-graph-builder.adversarial.test.ts` | 2 | Oversized-path test pre-existing |
| `tests/unit/hooks/repo-graph-wiring.test.ts` | 1 | Line-number gate stale; pre-existing |
| `tests/unit/cli` + `tests/unit/commands` + `tests/unit/config` (combined) | 547 | Pre-existing bulk |
| `tests/integration` | 111 | Pre-existing |
| `tests/adversarial` | 19 | Pre-existing |

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeLVYfJbwoxpn2rGCZXrW6)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened SAST, repo-graph, and language/runtime paths, and added a PHP Laravel backend with real framework/command detection. Resolves 23 audit findings, cutting false positives and flakiness.

- **New Features**
  - PHP backend with Laravel detection and command overlay wired into project context (e.g., TEST_CMD = `php artisan test`; LINT overlay when present).
  - Language detection now matches glob indicators (e.g., `*.csproj`, `*.sln`, `*.xcodeproj`) for proper C#/Swift coverage.
  - Faster, safer syntax checks: bounded parallelism via `p-limit`, iterative tree walk, and pre-stat large-file guard; runtime module import hoisted.
  - Unified test-framework names across profiles and dispatch, with parity coverage.

- **Bug Fixes**
  - Semgrep subprocess hardening: no shell, `stdin: 'ignore'`, SIGTERM→SIGKILL on timeout, and 10MB per‑stream stdout/stderr cap; truncated output yields an error (no fail‑open).
  - Tree‑sitter runtime: bounded grammar loads via `withTimeout`, coalesced in‑flight loads, static `node:fs` import, and explicit `lang/index` re‑exports.
  - SAST rules: removed duplicate Go hardcoded‑secret rule; raised Java hardcoded‑secret threshold to `{10,}`; C# `Process.Start` rule suppresses findings when `UseShellExecute=false`.
  - Repo‑graph: comment‑aware import scan (regex‑literal safe) to avoid false edges; incremental update failures tracked per‑session with bounds, decay, and cooldown.
  - Re‑enabled Windows SAST integration tests by pinning `git config core.autocrlf false`.

<sup>Written for commit d483aaaf93ab887b22240e6d112874732d6a9ecf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

