### PR TITLE
docs(skills): close three workflow gaps found during issue #1144 run

### DIFF
--- a/.claude/skills/commit-pr/SKILL.md
+++ b/.claude/skills/commit-pr/SKILL.md
@@ -398,6 +398,12 @@ gh run cancel <stale-run-id>
 downstream jobs. When the PR checks view looks stale, missing, or inconsistent,
 use the workflow run as the authoritative detail:
 
+> **MCP environments:** When using GitHub MCP tools instead of `gh`, prefer
+> `get_check_runs` over `get_status`. The `get_status` method uses GitHub's
+> legacy commit status API: it returns `state: "pending"` even when all GitHub
+> Actions jobs are green, because Actions creates check-runs (not legacy
+> statuses). `get_check_runs` returns the actual job results.
+
 ```powershell
 gh run view <run-id> --json headSha,status,conclusion,jobs,url
 ```

--- a/.claude/skills/qa-sweep/SKILL.md
+++ b/.claude/skills/qa-sweep/SKILL.md
@@ -45,3 +45,6 @@ Do NOT stop until ≥95% confident that:
 - Delivered work matches the original plan completely
 
 If below 95%, state what remains and continue working.
+
+#### User-controlled gates
+When the user has explicitly declined or deferred an action that is theirs to take — such as choosing "Leave it for you" on a merge offer, or explicitly saying they will merge manually — that action is outside the agent's scope. The 95% confidence gate applies to technical work the agent controls. Publication by merge is a user-controlled gate: once the user has deliberately declined it, the agent's work is complete and the stop condition is satisfied. Do not loop on pending user-controlled actions.

--- a/.claude/skills/swarm-pr-feedback/SKILL.md
+++ b/.claude/skills/swarm-pr-feedback/SKILL.md
@@ -21,7 +21,18 @@ canonical workflow.
   proves it.
 - Cluster feedback by root cause before delegating fixes.
 - Use reviewer or critic agents for high-risk, ambiguous, or cross-file items.
-- Do not resolve GitHub review threads unless the user explicitly instructs it.
+- Resolve GitHub review threads only when the user has explicitly instructed it.
+  "Address any comments on the PR" and "resolve review threads" are explicit instructions.
+  A general "fix the PR" or "update the PR" is not. When resolving is authorized, verify
+  the fix is present in the current code before resolving — do not resolve a thread whose
+  underlying issue has not been corrected.
+- **Already-fixed thread closure:** When resolving is authorized and a thread's issue is
+  already addressed in the current code (fixed in a prior commit): (1) read the current
+  code at the cited file:line to confirm the fix is present, (2) reply to the thread's
+  root comment citing the fixing commit SHA and what changed, (3) resolve the thread.
+  Do not open a code-change path for already-fixed issues — only acknowledge and close.
+  If a thread's issue is NOT yet fixed in code, treat it as a normal feedback item
+  requiring a code change before resolution.
 - Do not run a fresh broad PR review while closing known feedback. Inspect nearby
   code only to verify reachability, dependency, root cause, or regression risk.
 - Use the repository commit/PR workflow before pushing or updating the PR.

--- a/docs/releases/pending/docs-skill-workflow-gaps.md
+++ b/docs/releases/pending/docs-skill-workflow-gaps.md
@@ -1,0 +1,22 @@
+# docs(skills): agent workflow gap fixes from issue #1144 session
+
+Three gaps in agent skill documentation patched based on observed failure modes
+during the issue #1144 run:
+
+- `qa-sweep`: The 95% stop-condition gate now recognises user-controlled
+  publication decisions (e.g. "leave for you" on a merge offer) as complete
+  agent work — the gate no longer loops on actions the user has deliberately
+  deferred.
+
+- `commit-pr`: Documents that `get_status` (GitHub MCP tool) uses the legacy
+  commit status API and returns `pending` even when all GitHub Actions
+  check-runs are green; agents in MCP environments must use `get_check_runs`
+  instead.
+
+- `swarm-pr-feedback`: Clarifies when resolving review threads is authorised
+  ("address any comments" counts; "fix the PR" does not) and adds the
+  already-fixed closure workflow (verify fix in code → reply with commit SHA
+  → resolve, without opening a code-change path).
+
+## Migration
+No migration required. These are internal agent workflow doc changes only.


### PR DESCRIPTION
## Summary

Three agent skill documentation gaps patched based on observed failure modes during the issue #1144 run:

- **qa-sweep stop condition**: The 95% confidence gate now recognises user-controlled publication decisions (e.g. "leave it for you" on a merge offer). Previously the stop hook looped on "PR not yet merged" even after the user explicitly declined to merge — the gate now treats user-deferred actions as outside the agent's scope.
- **commit-pr MCP API note**: Documents that `get_status` uses GitHub's legacy commit status API and returns `pending` even when all GitHub Actions check-runs are green. MCP-environment agents must use `get_check_runs`. Discovered during the CI watch cycle for PR #1147.
- **swarm-pr-feedback thread resolution**: Clarifies what counts as an explicit instruction to resolve threads ("address any comments" counts; "fix the PR" does not) and adds the already-fixed closure workflow: verify fix in code → reply with commit SHA → resolve, without opening a code-change path.

## Invariant audit
- 1 (plugin init): not touched — diff is `.claude/skills/*.md` only; no init-path code changed
- 2 (runtime portability): not touched — no bundle/dist/ESM changes
- 3 (subprocesses): not touched — no spawn/exec changes
- 4 (.swarm containment): not touched — no tool writes or directory changes
- 5 (plan durability): not touched — no ledger/plan code changed
- 6 (test_runner safety): not touched — no test_runner calls added
- 7 (test writing): not touched — no test files modified
- 8 (session state): not touched — no session state changes
- 9 (guardrails/retry): not touched — no guardrail changes
- 10 (chat/system msg): not touched — no message hook changes
- 11 (tool registration): not touched — no tool/agent/command changes
- 12 (release/cache): not touched — version files untouched; release fragment added at `docs/releases/pending/docs-skill-workflow-gaps.md`

## Test plan
- [x] `git diff --name-only origin/main..HEAD` confirms only `.claude/skills/*.md` and `docs/releases/pending/` changed — no TypeScript, no tests, no build config
- [x] No TypeScript source changed → typecheck is no-signal (explicitly justified)
- [x] No test files changed → all test tiers are no-signal (explicitly justified)
- [x] Biome does not lint markdown → quality gate is no-signal (explicitly justified)
- [x] All 12 invariants confirmed not touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYDguFVVojE9kUprE51Wuw)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch three agent skill docs to close workflow gaps seen in issue #1144: prevent QA loops on user-owned merge decisions, clarify CI status APIs for MCP, and tighten PR thread resolution rules.

- **Bug Fixes**
  - `qa-sweep`: Treat explicit user-controlled merge decisions as out of scope; stop looping on them.
  - `commit-pr`: Note MCP `get_status` uses legacy status API and can stay `pending`; use `get_check_runs` for Actions results.
  - `swarm-pr-feedback`: Define when resolving threads is allowed and add already-fixed closure flow (verify in code → reply with commit SHA → resolve).

<sup>Written for commit 7bb7c193a021efd801bc3891ad961ab7fd0b55b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

