### PR TITLE
fix(delegation-gate): fail-closed guard for OpenCode background subagents (#1151)

### DIFF
--- a/docs/releases/pending/1151-background-subagent-fail-closed-guard.md
+++ b/docs/releases/pending/1151-background-subagent-fail-closed-guard.md
@@ -1,0 +1,44 @@
+# Fail-closed guard for OpenCode background subagents (issue #1151, PR 1)
+
+## What
+
+Swarm now **fail-closed-blocks** background subagent delegations. OpenCode v1.16.2 added
+background subagents — the `Task` tool accepts `background=true` (gated upstream by
+`OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true`), which returns a "running" placeholder
+immediately and delivers the real result later via a synthetic parent message.
+
+- `src/hooks/delegation-gate.ts` `toolBefore`: throws `SWARM_BACKGROUND_TASK_BLOCKED`
+  before dispatch when a `Task` call targets a swarm role (resolved via the existing
+  `isKnownCanonicalRole(stripKnownSwarmPrefix(...))` normalization) **and** `background`
+  is `true` (the boolean `true` or the stringified `'true'`). The throw propagates through
+  the fail-closed `tool.execute.before` chain, so OpenCode rejects the call before
+  launching the background task.
+- `toolAfter`: belt-and-suspenders early-return — if a background swarm `Task` still
+  reaches it (a running placeholder, detected from args or the result shape
+  `state:"running"` / `metadata.background===true`), it does **not** advance Stage B or
+  record gate evidence, and cleans up any stored args.
+- Docs: new "Background Subagent Task Rejected" section in
+  `docs/troubleshooting/recovery-guide.md`.
+
+## Why
+
+The delegation gate equates a `Task` result with delegation completion. For
+`background=true`, the immediate running placeholder would be interpreted as a finished
+reviewer/test_engineer delegation, prematurely advancing the task state machine and
+recording gate evidence before any output exists. Blocking the capability — explicitly,
+not silently — keeps swarm gate state and evidence correct until durable background
+completion ingestion lands.
+
+## Migration
+
+No action for existing users. Foreground swarm delegations are unchanged. Non-swarm
+OpenCode `Task` usage (e.g. the native `general` agent) is not affected. To use a swarm
+delegation, omit `background` (or set `background=false`).
+
+## Scope / follow-up
+
+This is PR 1 of the two-PR path in issue #1151. PR 2 (durable background completion
+ingestion — separate dispatch/completion events, exact-once correlation, timeout/recovery,
+concurrency, spoofing resistance) is intentionally deferred and gated on an upstream
+metadata/trust spike confirming a trusted completion signal (the synthetic-prompt
+`synthetic:true` marker plus `jobId`/session correlation). It is not part of this change.

--- a/docs/troubleshooting/recovery-guide.md
+++ b/docs/troubleshooting/recovery-guide.md
@@ -80,4 +80,28 @@ await importCheckpoint()
 
 ---
 
+## 7. Background Subagent Task Rejected
+
+**Symptom:** A delegation throws `SWARM_BACKGROUND_TASK_BLOCKED: OpenCode background subagents ...`.
+
+**Why:** OpenCode v1.16.2 added background subagents — calling the `Task` tool with
+`background=true` (enabled upstream by `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true`).
+A background `Task` returns a **running placeholder immediately** and delivers the real
+result **later** via a synthetic parent message. Swarm's delegation gate treats a `Task`
+result as completion, so consuming the placeholder would advance Stage B and record gate
+evidence **before any review/test output exists**. Until swarm can correlate the deferred
+completion safely (tracked as a separate, spike-gated change), swarm **fail-closed-blocks**
+background delegations for any swarm role (reviewer, test_engineer, coder, explorer, etc.).
+Swarm never silently rewrites `background` to `false` — the unsupported capability is
+surfaced explicitly.
+
+**Action needed:** Re-issue the delegation **without** `background` (or with
+`background: false`). Foreground swarm delegations are unaffected. Non-swarm OpenCode
+`Task` usage (e.g. the native `general` agent) is not blocked. The pre-dispatch block runs
+in `tool.execute.before`, so OpenCode rejects the call before the background task launches;
+a belt-and-suspenders check in `tool.execute.after` ensures a running placeholder never
+advances workflow state even if it slips through.
+
+---
+
 For architecture details, see `docs/plan-durability.md`.

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -11,7 +11,7 @@ import { ZodError, z } from 'zod';
 
 import type { PluginConfig } from '../config';
 import type { Phase, Plan, Task } from '../config/plan-schema';
-import { stripKnownSwarmPrefix } from '../config/schema';
+import { isKnownCanonicalRole, stripKnownSwarmPrefix } from '../config/schema';
 import {
 	routeReviewForChanges,
 	shouldParallelizeReview,
@@ -84,6 +84,51 @@ export const pendingCoderScopeByTaskId = new Map<string, string[]>();
  */
 export function clearPendingCoderScope(): void {
 	pendingCoderScopeByTaskId.clear();
+}
+
+/**
+ * Issue #1151: OpenCode v1.16.2 background subagents.
+ *
+ * `Task` with `background=true` (gated upstream by
+ * `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true`) returns a "running" placeholder
+ * immediately and completes later via synthetic parent injection. The delegation gate
+ * treats a `Task` result as completion, so a background swarm delegation would advance
+ * Stage B / record gate evidence before any review/test output exists. Until swarm can
+ * correlate the deferred completion safely (a separate, spike-gated PR), background
+ * swarm delegations are fail-closed-blocked. We do NOT silently coerce `background` to
+ * false — the unsupported capability is surfaced explicitly.
+ */
+export const SWARM_BACKGROUND_TASK_BLOCKED_MESSAGE =
+	'SWARM_BACKGROUND_TASK_BLOCKED: OpenCode background subagents (Task with background=true, ' +
+	'requires OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true) are recognized upstream, but swarm ' +
+	'cannot yet safely consume their deferred completion events — the Task returns a running ' +
+	'placeholder now and completes later via synthetic injection, which would advance swarm gates ' +
+	'before any review/test output exists. Omit `background` (or set background=false) for swarm ' +
+	'delegations until the completion-ingestion PR lands.';
+
+/**
+ * Fail-closed background-flag detector. Treats both the boolean `true` and the
+ * stringified `'true'` as background so a stringified flag cannot bypass the guard.
+ */
+export function isBackgroundTrue(value: unknown): boolean {
+	return value === true || value === 'true';
+}
+
+/**
+ * True when a `Task` tool RESULT looks like an OpenCode background "running"
+ * placeholder (`state: "running"` or `metadata.background === true`). Belt-and-
+ * suspenders for `toolAfter`; never throws.
+ */
+export function outputLooksLikeBackgroundRunning(output: unknown): boolean {
+	if (typeof output !== 'object' || output === null) return false;
+	const o = output as Record<string, unknown>;
+	if (o.state === 'running') return true;
+	const metadata = o.metadata;
+	return (
+		typeof metadata === 'object' &&
+		metadata !== null &&
+		(metadata as Record<string, unknown>).background === true
+	);
 }
 
 /**
@@ -857,6 +902,20 @@ export function createDelegationGateHook(
 
 		const targetAgent = stripKnownSwarmPrefix(subagentType);
 
+		// Issue #1151: fail-closed block for swarm background Task dispatch.
+		// Placed BEFORE the coder-only early return below so reviewer/test_engineer and
+		// every other swarm role are caught — not just coder. Scoped to swarm roles via
+		// isKnownCanonicalRole so unrelated OpenCode Task usage (e.g. the native `general`
+		// agent) is never blocked. This throw propagates through the fail-closed
+		// tool.execute.before chain in src/index.ts (no safeHook wrapper), so OpenCode
+		// rejects the tool before launching the background task.
+		if (
+			isBackgroundTrue(args.background) &&
+			isKnownCanonicalRole(targetAgent)
+		) {
+			throw new Error(SWARM_BACKGROUND_TASK_BLOCKED_MESSAGE);
+		}
+
 		// Review routing: when delegating to reviewer, check if review should be parallelized
 		if (targetAgent === 'reviewer') {
 			try {
@@ -1085,6 +1144,23 @@ export function createDelegationGateHook(
 				| undefined;
 			const subagentType =
 				directArgs?.subagent_type ?? storedArgs?.subagent_type;
+
+			// Issue #1151: defensive belt-and-suspenders for background swarm Task.
+			// Pre-dispatch toolBefore is the primary guard; if a background swarm Task
+			// still reaches here (a "running" placeholder), it must NOT advance Stage B
+			// or record completed gate evidence. Detect background from args (direct or
+			// stored) or from the result shape, scoped to swarm roles. Clean up stored
+			// args so the callID entry does not leak, then bail before any advancement.
+			if (
+				typeof subagentType === 'string' &&
+				isKnownCanonicalRole(stripKnownSwarmPrefix(subagentType)) &&
+				(isBackgroundTrue(directArgs?.background) ||
+					isBackgroundTrue(storedArgs?.background) ||
+					outputLooksLikeBackgroundRunning(_output))
+			) {
+				if (storedArgs !== undefined) deleteStoredInputArgs(input.callID);
+				return;
+			}
 
 			// Track if we detected reviewer and/or test_engineer via stored args
 			let hasReviewer = false;

--- a/tests/unit/hooks/delegation-gate-background-task.test.ts
+++ b/tests/unit/hooks/delegation-gate-background-task.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Issue #1151 — Support OpenCode background subagents safely in swarm (PR 1).
+ *
+ * OpenCode v1.16.2 background subagents (`Task` with `background=true`) return a
+ * "running" placeholder immediately and complete later via synthetic injection.
+ * Swarm cannot yet correlate that deferred completion, so PR 1 fail-closed-blocks
+ * background swarm delegations:
+ *   - toolBefore throws (pre-dispatch, fail-closed chain) for swarm roles.
+ *   - toolAfter defensively early-returns so a running placeholder never advances
+ *     Stage B or records gate evidence.
+ *
+ * Foreground delegation behavior is unchanged.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import type { PluginConfig } from '../../../src/config';
+import {
+	createDelegationGateHook,
+	SWARM_BACKGROUND_TASK_BLOCKED_MESSAGE,
+} from '../../../src/hooks/delegation-gate';
+import {
+	deleteStoredInputArgs,
+	getStoredInputArgs,
+	setStoredInputArgs,
+} from '../../../src/hooks/guardrails';
+import {
+	ensureAgentSession,
+	getTaskState,
+	resetSwarmState,
+} from '../../../src/state';
+
+function makeConfig(): PluginConfig {
+	return {
+		max_iterations: 5,
+		qa_retry_limit: 3,
+		inject_phase_reminders: true,
+		hooks: {
+			system_enhancer: true,
+			compaction: true,
+			agent_activity: true,
+			delegation_tracker: false,
+			agent_awareness_max_chars: 300,
+			delegation_gate: true,
+			delegation_max_chars: 4000,
+		},
+	} as PluginConfig;
+}
+
+async function callToolBefore(
+	hook: ReturnType<typeof createDelegationGateHook>,
+	args: Record<string, unknown>,
+	sessionID = 'bg-session',
+): Promise<{ threw: boolean; message: string | null }> {
+	try {
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID, callID: `call-${Math.random()}` },
+			{ args },
+		);
+		return { threw: false, message: null };
+	} catch (err) {
+		return {
+			threw: true,
+			message: err instanceof Error ? err.message : String(err),
+		};
+	}
+}
+
+describe('issue #1151 — background Task fail-closed guard', () => {
+	beforeEach(() => resetSwarmState());
+	afterEach(() => resetSwarmState());
+
+	// ── toolBefore: pre-dispatch block ───────────────────────────────────────
+	it('blocks background:true for reviewer (gate agent)', async () => {
+		const hook = createDelegationGateHook(makeConfig(), process.cwd());
+		const { threw, message } = await callToolBefore(hook, {
+			subagent_type: 'reviewer',
+			background: true,
+			description: 'review',
+		});
+		expect(threw).toBe(true);
+		expect(message).toBe(SWARM_BACKGROUND_TASK_BLOCKED_MESSAGE);
+	});
+
+	it('blocks background:true for test_engineer (gate agent)', async () => {
+		const hook = createDelegationGateHook(makeConfig(), process.cwd());
+		const { threw } = await callToolBefore(hook, {
+			subagent_type: 'test_engineer',
+			background: true,
+		});
+		expect(threw).toBe(true);
+	});
+
+	it('blocks background:true for a prefixed swarm name (mega_reviewer)', async () => {
+		const hook = createDelegationGateHook(makeConfig(), process.cwd());
+		const { threw } = await callToolBefore(hook, {
+			subagent_type: 'mega_reviewer',
+			background: true,
+		});
+		expect(threw).toBe(true);
+	});
+
+	// F1: block covers ALL canonical swarm roles, not just gate agents.
+	it('blocks background:true for a non-gate swarm role (explorer)', async () => {
+		const hook = createDelegationGateHook(makeConfig(), process.cwd());
+		const { threw } = await callToolBefore(hook, {
+			subagent_type: 'explorer',
+			background: true,
+		});
+		expect(threw).toBe(true);
+	});
+
+	it('blocks background:true for coder', async () => {
+		const hook = createDelegationGateHook(makeConfig(), process.cwd());
+		const { threw } = await callToolBefore(hook, {
+			subagent_type: 'coder',
+			background: true,
+		});
+		expect(threw).toBe(true);
+	});
+
+	// Fail-closed: stringified flag cannot bypass the guard.
+	it('blocks background:"true" (string form) for reviewer', async () => {
+		const hook = createDelegationGateHook(makeConfig(), process.cwd());
+		const { threw } = await callToolBefore(hook, {
+			subagent_type: 'reviewer',
+			background: 'true',
+		});
+		expect(threw).toBe(true);
+	});
+
+	// ── toolBefore: must NOT over-block ──────────────────────────────────────
+	it('does NOT block foreground reviewer (background absent)', async () => {
+		const hook = createDelegationGateHook(makeConfig(), process.cwd());
+		const { threw } = await callToolBefore(hook, {
+			subagent_type: 'reviewer',
+			description: 'review',
+		});
+		expect(threw).toBe(false);
+	});
+
+	it('does NOT block background:false reviewer', async () => {
+		const hook = createDelegationGateHook(makeConfig(), process.cwd());
+		const { threw } = await callToolBefore(hook, {
+			subagent_type: 'reviewer',
+			background: false,
+		});
+		expect(threw).toBe(false);
+	});
+
+	it('does NOT block background:true for non-swarm subagent_type (general)', async () => {
+		const hook = createDelegationGateHook(makeConfig(), process.cwd());
+		const { threw } = await callToolBefore(hook, {
+			subagent_type: 'general',
+			background: true,
+		});
+		expect(threw).toBe(false);
+	});
+
+	// F2: pin suffix-separator semantics — 'reviewerx' (no separator) is not a swarm role.
+	it('does NOT block background:true for reviewerx (no separator, not a swarm role)', async () => {
+		const hook = createDelegationGateHook(makeConfig(), process.cwd());
+		const { threw } = await callToolBefore(hook, {
+			subagent_type: 'reviewerx',
+			background: true,
+		});
+		expect(threw).toBe(false);
+	});
+
+	// ── toolAfter: defensive early-return ────────────────────────────────────
+	it('defensive: background reviewer (args) does NOT advance Stage B and cleans storedArgs', async () => {
+		const hook = createDelegationGateHook(makeConfig(), process.cwd());
+		const sessionID = 'bg-after-args';
+		const session = ensureAgentSession(sessionID);
+		session.taskWorkflowStates.set('1.1', 'coder_delegated');
+		const callID = 'bg-call-args';
+		setStoredInputArgs(callID, { subagent_type: 'reviewer', background: true });
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID,
+				callID,
+				args: { subagent_type: 'reviewer', background: true },
+			},
+			{ state: 'running', metadata: { background: true } },
+		);
+
+		// Early-return fired before Stage B advancement and before gate evidence.
+		expect(getTaskState(session, '1.1')).toBe('coder_delegated');
+		expect(getStoredInputArgs(callID)).toBeUndefined();
+	});
+
+	// F3: output-shape path — background flag ABSENT from args, present only in the result.
+	it('defensive: background detected from output shape (state:running) does NOT advance Stage B', async () => {
+		const hook = createDelegationGateHook(makeConfig(), process.cwd());
+		const sessionID = 'bg-after-output';
+		const session = ensureAgentSession(sessionID);
+		session.taskWorkflowStates.set('2.1', 'coder_delegated');
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID,
+				callID: 'bg-call-output',
+				// background NOT in args — only observable via the result shape
+				args: { subagent_type: 'reviewer' },
+			},
+			{ state: 'running', metadata: { background: true } },
+		);
+
+		expect(getTaskState(session, '2.1')).toBe('coder_delegated');
+	});
+
+	// Regression guard: foreground reviewer STILL advances (unchanged path).
+	it('regression: foreground reviewer advances coder_delegated -> reviewer_run', async () => {
+		const hook = createDelegationGateHook(makeConfig(), process.cwd());
+		const sessionID = 'fg-after';
+		const session = ensureAgentSession(sessionID);
+		session.taskWorkflowStates.set('3.1', 'coder_delegated');
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID,
+				callID: 'fg-call',
+				args: { subagent_type: 'reviewer' },
+			},
+			{ state: 'completed', text: 'review done' },
+		);
+
+		expect(getTaskState(session, '3.1')).toBe('reviewer_run');
+		// cleanup any stored args defensively
+		deleteStoredInputArgs('fg-call');
+	});
+});

--- a/tests/unit/hooks/delegation-gate-background-task.test.ts
+++ b/tests/unit/hooks/delegation-gate-background-task.test.ts
@@ -52,7 +52,7 @@ async function callToolBefore(
 ): Promise<{ threw: boolean; message: string | null }> {
 	try {
 		await hook.toolBefore(
-			{ tool: 'Task', sessionID, callID: `call-${Math.random()}` },
+			{ tool: 'Task', sessionID, callID: `call-${sessionID}` },
 			{ args },
 		);
 		return { threw: false, message: null };


### PR DESCRIPTION
Closes #1151

## Summary

PR 1 of the two-PR path in #1151: a fail-closed guard against OpenCode v1.16.2 background subagents in swarm delegations.

OpenCode's `Task` tool now accepts `background=true` (gated upstream by `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true`), which returns a "running" placeholder immediately and delivers the real result later via a synthetic parent message. Swarm's delegation gate treats a `Task` result as completion, so a background swarm delegation would prematurely advance Stage B and record gate evidence before any output exists (reproduced: `toolBefore` did not block; `toolAfter` advanced `coder_delegated → reviewer_run` on a running placeholder).

Changes (`src/hooks/delegation-gate.ts`):
- `toolBefore`: throws `SWARM_BACKGROUND_TASK_BLOCKED` before dispatch when `background` is true (boolean `true` or string `'true'`) and `subagent_type` resolves to a swarm role via the existing `isKnownCanonicalRole(stripKnownSwarmPrefix(...))` normalization. Placed before the coder-only early return so all swarm roles are covered. Propagates through the no-`safeHook` fail-closed `tool.execute.before` chain → OpenCode rejects the call before launching the background task. No silent `background` mutation.
- `toolAfter`: belt-and-suspenders early-return (with stored-args cleanup) so a running placeholder never advances Stage B or records gate evidence — detected from args or the result shape (`state:"running"` / `metadata.background===true`).
- Docs: new "Background Subagent Task Rejected" section in `docs/troubleshooting/recovery-guide.md`; pending release fragment.

PR 2 (durable background completion ingestion) is intentionally deferred per the issue — gated on an upstream metadata/trust spike confirming a trusted completion signal.

## Invariant audit

- **6. Test execution** — touched (validation choice). Used `bun --smol test ... --timeout 30000`, not broad `test_runner`. Evidence: new suite 13/13; relevant files green individually; the ~41 combined-run failures proven pre-existing via baseline-stash run (documented `mock.module` cross-file leakage).
- **7. Test writing** — touched. New `bun:test` file, no `mock.module` (uses real state + guardrails helpers); positive, negative, and adversarial (coercion/suffix) cases.
- **10. Chat / system-message** — touched (verification). The guard is a thrown tool rejection (intended), not chat noise; no diagnostics added to chat-visible streams.
- **11. Tool / agent registration** — not touched (no map/registration changes; `src/index.ts` unchanged).

## Test plan

- `bun --smol test tests/unit/hooks/delegation-gate-background-task.test.ts` → 13 pass / 0 fail.
- `bun --smol test tests/unit/hooks/delegation-gate.test.ts` → 100 pass / 0 fail.
- `bun run typecheck` → EXIT 0. `biome check` (changed files) → EXIT 0. `git diff --check` clean.
- Pre-existing combined-run failures confirmed unrelated (baseline with edit stashed: 41 fail).

https://claude.ai/code/session_01Q1o4W7kBqRaxghSnBeFZme

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1o4W7kBqRaxghSnBeFZme)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks OpenCode background `Task` calls for swarm roles and prevents “running” placeholders from advancing the delegation workflow. Closes #1151 by keeping gate state and evidence correct until background completion ingestion is added.

- **Bug Fixes**
  - `toolBefore`: reject with `SWARM_BACKGROUND_TASK_BLOCKED` when `background` is true (boolean or `'true'`) and `subagent_type` resolves to a swarm role; runs pre-dispatch so OpenCode rejects the call before launch.
  - `toolAfter`: early-return if a running placeholder is detected (from args or output: `state: "running"` / `metadata.background === true`); clean stored args; no Stage B advance or gate evidence.
  - Scope: only swarm roles via `isKnownCanonicalRole(stripKnownSwarmPrefix(...))`; non-swarm agents (e.g. `general`) unaffected; no silent `background` coercion.
  - Docs/tests: added troubleshooting entry and pending release note; unit tests cover positive/negative/adversarial cases and use deterministic callIDs.

<sup>Written for commit c5e03da2f168511c4ee4b087c36bbfde3f3ca486. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

