### PR TITLE
fix(final-council): treat advisory CONCERNS as non-blocking (#972)

### DIFF
--- a/docs/releases/pending/972-final-council-concerns-advisory.md
+++ b/docs/releases/pending/972-final-council-concerns-advisory.md
@@ -1,0 +1,41 @@
+# Final Council: CONCERNS is advisory when there are no required fixes
+
+## Overview
+
+`write_final_council_evidence` previously normalized every non-`APPROVE` verdict to `rejected` in the evidence file. That collapsed two semantically distinct council outcomes — `CONCERNS` (advisory, 0 required fixes) and `REJECT` (blocking, ≥1 required fix) — into a single value. The `final_council` gate in `phase_complete` then treated `CONCERNS` as a hard block, which prevented the last phase from completing even when 4 of 5 council members voted `APPROVE` and the dissenting member had only advisory findings.
+
+The symptom: `phase_complete` returned `FINAL_COUNCIL_REJECTED` (or, depending on the evidence layout, `FINAL_COUNCIL_INVALID_VERDICT`) on advisory-only council outcomes, forcing manual `/swarm finalize` workarounds.
+
+This aligns the final-council gate with the existing phase-council gate, which already treats `CONCERNS` as non-blocking when `phaseConcernsAllowComplete` is enabled (default `true`).
+
+## What changed
+
+- `src/tools/write-final-council-evidence.ts:normalizeFinalVerdict` now returns one of three values instead of two:
+  - `APPROVE` → `approved`
+  - `CONCERNS` → `concerns` (new — was collapsed into `rejected` before)
+  - `REJECT` → `rejected`
+- `src/tools/phase-complete/gates/final-council-gate.ts` now recognizes `entry.verdict === 'concerns'` (and the uppercase `'CONCERNS'` for forward compatibility) as a non-blocking path. When the new `council.finalConcernsAllowComplete` config flag (default `true`) is enabled, the gate logs the advisory notes via `safeWarn` and lets `phase_complete` proceed. When set to `false`, `CONCERNS` blocks with the new `FINAL_COUNCIL_CONCERNS` reason.
+- `src/config/schema.ts` and `src/council/types.ts` declare the new `council.finalConcernsAllowComplete: boolean` field (default `true`).
+- Updated tests that encoded the buggy normalization:
+  - `tests/unit/tools/phase-complete-final-council.test.ts` — replaced the test that expected `FINAL_COUNCIL_INVALID_VERDICT` for `CONCERNS` evidence with three new tests covering: `concerns` (lowercase, passes), `CONCERNS` (uppercase, passes), and `concerns` with `finalConcernsAllowComplete: false` (blocks as `FINAL_COUNCIL_CONCERNS`).
+  - `tests/unit/tools/write-final-council-evidence.test.ts` — split the single "REJECT or CONCERNS → rejected" test into three tests: REJECT → `rejected`, advisory CONCERNS → `concerns`, and mixed REJECT+CONCERNS → `rejected` (REJECT wins).
+
+## How to use
+
+No action required. The fix is on by default (`finalConcernsAllowComplete: true`). To opt into blocking CONCERNS at the final council (matching phase-council's `phaseConcernsAllowComplete: false` behavior), set:
+
+```json
+{
+  "council": {
+    "finalConcernsAllowComplete": false
+  }
+}
+```
+
+in your `.opencode/opencode-swarm.json`.
+
+## Migration
+
+None. The evidence JSON shape gains a third value (`'concerns'`) but keeps the previous `'approved' | 'rejected'` values unchanged, so existing evidence readers continue to work.
+
+Closes: #972

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1415,6 +1415,12 @@ export const CouncilConfigSchema = z
 			.describe(
 				'When true, a phase-level council CONCERNS verdict does NOT block phase completion — the advisory notes are logged as warnings and the phase proceeds. When false, CONCERNS blocks like REJECT. Default: true (CONCERNS is advisory).',
 			),
+		finalConcernsAllowComplete: z
+			.boolean()
+			.default(true)
+			.describe(
+				'When true, a project-scoped final council CONCERNS verdict does NOT block project close — the advisory notes are logged as warnings and the final phase proceeds. When false, CONCERNS at the final council blocks like REJECT. Default: true (CONCERNS is advisory). See issue #972.',
+			),
 		// General Council Mode (advisory). Optional — undefined means feature is
 		// not configured. When present and enabled: true, the architect can run
 		// `/swarm council` and the SPECIFY-COUNCIL-REVIEW gate.

--- a/src/council/types.ts
+++ b/src/council/types.ts
@@ -191,6 +191,8 @@ export interface CouncilConfig {
 	escalateOnMaxRounds?: string;
 	/** Default true — CONCERNS verdict at phase-level council does NOT block completion (advisory). Set false to make CONCERNS block like REJECT. */
 	phaseConcernsAllowComplete: boolean;
+	/** Default true — CONCERNS verdict at the project-scoped final council does NOT block project close (advisory). Set false to make final CONCERNS block like REJECT. */
+	finalConcernsAllowComplete: boolean;
 }
 
 export const COUNCIL_DEFAULTS: CouncilConfig = {
@@ -202,4 +204,5 @@ export const COUNCIL_DEFAULTS: CouncilConfig = {
 	requireAllMembers: false,
 	minimumMembers: 3,
 	phaseConcernsAllowComplete: true,
+	finalConcernsAllowComplete: true,
 };

--- a/src/tools/phase-complete/gates/final-council-gate.ts
+++ b/src/tools/phase-complete/gates/final-council-gate.ts
@@ -15,7 +15,7 @@ import type { GateContext, GateResult } from './types';
 export async function runFinalCouncilGate(
 	ctx: GateContext,
 ): Promise<GateResult> {
-	const { phase, dir, sessionID, agentsDispatched, safeWarn } = ctx;
+	const { phase, dir, sessionID, pluginConfig, agentsDispatched, safeWarn } = ctx;
 
 	let finalCouncilEnabled = false;
 
@@ -148,9 +148,61 @@ export async function runFinalCouncilGate(
 										};
 									}
 
+									// CONCERNS at the final-council level is advisory-only
+									// when no required fixes exist. The write tool maps the
+									// raw CONCERNS verdict to the lowercased 'concerns' value
+									// (uppercase preserved for forward compat). Treat as
+									// non-blocking by default; finalConcernsAllowComplete
+									// (default true) gates whether CONCERNS is allowed to
+									// complete. See issue #972.
+									if (
+										entry.verdict === 'concerns' ||
+										entry.verdict === 'CONCERNS'
+									) {
+										const finalConcernsAllow =
+											pluginConfig.council?.finalConcernsAllowComplete ?? true;
+
+										const advisoryNotes =
+											Array.isArray(entry.advisoryNotes)
+												? entry.advisoryNotes.filter(
+														(note: unknown): note is string =>
+															typeof note === 'string',
+													)
+												: [];
+										const notesDetail =
+											advisoryNotes.length > 0
+												? `\nAdvisory notes: ${advisoryNotes.join('; ')}`
+												: '';
+										const advisoryFindingsCount = Array.isArray(
+											entry.advisoryFindings,
+										)
+											? entry.advisoryFindings.length
+											: 0;
+
+										if (!finalConcernsAllow) {
+											return {
+												blocked: true,
+												reason: 'FINAL_COUNCIL_CONCERNS',
+												message: `Phase ${phase} (last phase) cannot be completed: final council returned verdict 'CONCERNS' with ${advisoryFindingsCount} advisory finding(s).${notesDetail}`,
+												agentsDispatched,
+												agentsMissing: [],
+												warnings: [],
+											};
+										}
+
+										// Non-blocking concerns: surface as warnings, continue.
+										safeWarn(
+											`[phase_complete] Final council returned CONCERNS for phase ${phase} — proceeding (finalConcernsAllowComplete is enabled, ${advisoryFindingsCount} advisory finding(s))${notesDetail ? ': ' + notesDetail : ''}`,
+											undefined,
+										);
+										// fall through to the final "approved/approved-like" path
+									}
+
 									if (
 										entry.verdict !== 'approved' &&
-										entry.verdict !== 'APPROVED'
+										entry.verdict !== 'APPROVED' &&
+										entry.verdict !== 'concerns' &&
+										entry.verdict !== 'CONCERNS'
 									) {
 										return {
 											blocked: true,

--- a/src/tools/write-final-council-evidence.ts
+++ b/src/tools/write-final-council-evidence.ts
@@ -65,8 +65,23 @@ export interface WriteFinalCouncilEvidenceArgs {
 	verdicts: CouncilMemberVerdict[];
 }
 
-function normalizeFinalVerdict(verdict: 'APPROVE' | 'CONCERNS' | 'REJECT') {
-	return verdict === 'APPROVE' ? 'approved' : 'rejected';
+function normalizeFinalVerdict(
+	verdict: 'APPROVE' | 'CONCERNS' | 'REJECT',
+): 'approved' | 'concerns' | 'rejected' {
+	switch (verdict) {
+		case 'APPROVE':
+			return 'approved';
+		case 'CONCERNS':
+			// CONCERNS is advisory-only when the overall synthesis lands here:
+			// synthesizeFinalCouncilAdvisory only emits 'CONCERNS' when no member
+			// returned a REJECT verdict, so requiredFixes is always empty.
+			// Map it to a non-blocking 'concerns' verdict so the final-council
+			// gate can surface advisory notes without blocking phase completion.
+			// See issue #972.
+			return 'concerns';
+		case 'REJECT':
+			return 'rejected';
+	}
 }
 
 /**

--- a/tests/unit/tools/phase-complete-final-council.test.ts
+++ b/tests/unit/tools/phase-complete-final-council.test.ts
@@ -404,11 +404,57 @@ describe('final_council gate (Gate 6)', () => {
 			expect(parsed.message).toContain('all five required members voted');
 		});
 
-		test('blocks with FINAL_COUNCIL_INVALID_VERDICT when evidence has unrecognized verdict', async () => {
+		test('allows completion when evidence has concerns verdict (issue #972: advisory-only CONCERNS is non-blocking)', async () => {
+			setupLastPhaseOnly(true);
+			writeFinalCouncilEvidence({
+				verdict: 'concerns',
+				summary: 'Minor concerns, all advisory',
+			});
+			const result = await executePhaseComplete(
+				{ phase: 3, summary: 'test', sessionID: SESSION_ID },
+				tempDir,
+				tempDir,
+			);
+			const parsed = JSON.parse(result);
+			expect(parsed.success).toBe(true);
+			expect(parsed.status).toBe('success');
+		});
+
+		test('allows completion when evidence has CONCERNS (uppercase) verdict (issue #972: forward-compat)', async () => {
 			setupLastPhaseOnly(true);
 			writeFinalCouncilEvidence({
 				verdict: 'CONCERNS',
-				summary: 'Some concerns',
+				summary: 'Minor concerns, all advisory (uppercase)',
+			});
+			const result = await executePhaseComplete(
+				{ phase: 3, summary: 'test', sessionID: SESSION_ID },
+				tempDir,
+				tempDir,
+			);
+			const parsed = JSON.parse(result);
+			expect(parsed.success).toBe(true);
+			expect(parsed.status).toBe('success');
+		});
+
+		test('blocks with FINAL_COUNCIL_CONCERNS when evidence has concerns verdict and finalConcernsAllowComplete is disabled', async () => {
+			setupLastPhaseOnly(true);
+			// Disable the concerns-pass-through at the plugin-config level.
+			mkdirSync(join(tempDir, '.opencode'), { recursive: true });
+			writeFileSync(
+				join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({
+					phase_complete: {
+						enabled: true,
+						required_agents: [],
+						require_docs: false,
+						policy: 'warn',
+					},
+					council: { finalConcernsAllowComplete: false },
+				}),
+			);
+			writeFinalCouncilEvidence({
+				verdict: 'concerns',
+				summary: 'Concerns that must block when finalConcernsAllowComplete=false',
 			});
 			const result = await executePhaseComplete(
 				{ phase: 3, summary: 'test', sessionID: SESSION_ID },
@@ -418,9 +464,8 @@ describe('final_council gate (Gate 6)', () => {
 			const parsed = JSON.parse(result);
 			expect(parsed.success).toBe(false);
 			expect(parsed.status).toBe('blocked');
-			expect(parsed.reason).toBe('FINAL_COUNCIL_INVALID_VERDICT');
-			expect(parsed.message).toContain('CONCERNS');
-			expect(parsed.message).toContain('unrecognized verdict');
+			expect(parsed.reason).toBe('FINAL_COUNCIL_CONCERNS');
+			expect(parsed.message).toContain("CONCERNS");
 		});
 
 		test('blocks with FINAL_COUNCIL_INVALID_VERDICT when evidence has invalid verdict string', async () => {

--- a/tests/unit/tools/write-final-council-evidence.test.ts
+++ b/tests/unit/tools/write-final-council-evidence.test.ts
@@ -121,7 +121,7 @@ describe('executeWriteFinalCouncilEvidence', () => {
 		expect(new Date(entry.timestamp).toISOString()).toBe(entry.timestamp);
 	});
 
-	test('normalizes rejecting or concern final council verdicts to rejected evidence verdict', async () => {
+	test('normalizes REJECT verdicts to rejected evidence verdict', async () => {
 		const result = await executeWriteFinalCouncilEvidence(
 			{
 				phase: 2,
@@ -145,6 +145,127 @@ describe('executeWriteFinalCouncilEvidence', () => {
 		expect(entry.verdict).toBe('rejected');
 		expect(entry.requiredFixes).toHaveLength(1);
 		expect(entry.allCriteriaMet).toBe(false);
+	});
+
+	test('normalizes advisory CONCERNS verdict to concerns (issue #972)', async () => {
+		// 4 APPROVE + 1 CONCERNS (advisory only, 0 required fixes)
+		const members = [
+			'critic',
+			'reviewer',
+			'sme',
+			'test_engineer',
+			'explorer',
+		] as const;
+		const concernsVerdicts = members.map((agent) =>
+			verdict(agent, {
+				verdict: 'APPROVE',
+				findings: [],
+				criteriaUnmet: [],
+			}),
+		);
+		// Override test_engineer to vote CONCERNS with 2 MEDIUM advisory findings
+		concernsVerdicts[3] = verdict('test_engineer', {
+			verdict: 'CONCERNS',
+			findings: [
+				{
+					severity: 'MEDIUM',
+					category: 'test_gap',
+					location: 'src/example.ts:10',
+					detail: 'Missing edge case coverage.',
+					evidence: 'test_engineer found uncovered path',
+				},
+				{
+					severity: 'MEDIUM',
+					category: 'test_quality',
+					location: 'src/example.ts:20',
+					detail: 'Brittle assertion.',
+					evidence: 'test_engineer found flaky pattern',
+				},
+			],
+			criteriaUnmet: [],
+		});
+
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 2,
+				projectSummary: 'Project complete with advisory test concerns.',
+				verdicts: concernsVerdicts,
+			},
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.overallVerdict).toBe('CONCERNS');
+		expect(parsed.verdict).toBe('concerns');
+		expect(parsed.requiredFixesCount).toBe(0);
+		expect(parsed.advisoryFindingsCount).toBe(2);
+
+		const content = await fs.promises.readFile(
+			path.join(tempDir, '.swarm', 'evidence', 'final-council.json'),
+			'utf-8',
+		);
+		const entry = JSON.parse(content).entries[0];
+		expect(entry.verdict).toBe('concerns');
+		expect(entry.rawCouncilVerdict).toBe('CONCERNS');
+		expect(entry.requiredFixes).toHaveLength(0);
+		expect(entry.advisoryFindings).toHaveLength(2);
+		expect(entry.allCriteriaMet).toBe(true);
+	});
+
+	test('normalizes mixed REJECT+CONCERNS verdicts to rejected (REJECT wins)', async () => {
+		// One REJECT member with HIGH finding should keep verdict as rejected
+		// even if other members vote CONCERNS.
+		const members = [
+			'critic',
+			'reviewer',
+			'sme',
+			'test_engineer',
+			'explorer',
+		] as const;
+		const mixedVerdicts = members.map((agent) =>
+			verdict(agent, {
+				verdict: 'CONCERNS',
+				findings: [
+					{
+						severity: 'LOW',
+						category: 'naming',
+						location: 'src/example.ts:1',
+						detail: 'Naming style nit.',
+						evidence: 'cosmetic',
+					},
+				],
+			}),
+		);
+		// One member votes REJECT with a HIGH finding
+		mixedVerdicts[0] = verdict('critic', {
+			verdict: 'REJECT',
+			findings: [
+				{
+					severity: 'HIGH',
+					category: 'logic',
+					location: 'src/example.ts:42',
+					detail: 'Project close would ship a runtime bug.',
+					evidence: 'critic found broken path',
+				},
+			],
+			criteriaUnmet: ['project-scope'],
+		});
+
+		const result = await executeWriteFinalCouncilEvidence(
+			{
+				phase: 2,
+				projectSummary: 'Project blocked by critic REJECT.',
+				verdicts: mixedVerdicts,
+			},
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.overallVerdict).toBe('REJECT');
+		expect(parsed.verdict).toBe('rejected');
+		expect(parsed.requiredFixesCount).toBe(1);
 	});
 
 	test('rejects invalid phase and missing project summary', async () => {


### PR DESCRIPTION
Closes #972

## Summary

`write_final_council_evidence` previously normalized every non-`APPROVE` verdict to `rejected` in the evidence file, collapsing `CONCERNS` (advisory, 0 required fixes) and `REJECT` (blocking, ≥1 required fix) into a single value. The `final_council` gate in `phase_complete` then treated `CONCERNS` as a hard block, preventing the last phase from completing even when 4 of 5 council members voted `APPROVE` and the dissenting member had only advisory findings.

- `normalizeFinalVerdict` now returns one of three values: `APPROVE` → `approved`, `CONCERNS` → `concerns`, `REJECT` → `rejected`.
- The `final_council` gate accepts `concerns` (and uppercase `CONCERNS` for forward compat) as a non-blocking path, governed by the new `council.finalConcernsAllowComplete` config flag (default `true`), mirroring the existing phase-council `phaseConcernsAllowComplete` pattern. When allowed, advisory notes surface via `safeWarn` and `phase_complete` proceeds. When disabled, `CONCERNS` blocks with the new `FINAL_COUNCIL_CONCERNS` reason.
- Added `council.finalConcernsAllowComplete: boolean` (default `true`) to `src/config/schema.ts` and `src/council/types.ts`.
- Tests that encoded the buggy normalization in `phase-complete-final-council.test.ts` and `write-final-council-evidence.test.ts` updated; new coverage added for the new behaviors.
- Release note fragment: `docs/releases/pending/972-final-council-concerns-advisory.md`.

## Invariant audit

- 1 (plugin init):       not touched — no init-path code changed; build and dist import verified.
- 2 (runtime portability): touched — `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"` both succeed (see validation log). No new top-level `bun:` imports or direct `Bun.*` calls were introduced.
- 3 (subprocesses):      not touched — diff against origin/main shows no new `spawn(`, `bunSpawn(`, or `spawnSync(` calls; no subprocess patterns added or modified.
- 4 (.swarm containment): not touched — no new `.swarm/` writers; evidence files written under `.swarm/evidence/` are runtime state, not committed.
- 5 (plan durability):   not touched — no ledger, projection, or plan-schema changes.
- 6 (test_runner safety): not touched — no `test_runner` calls; validation ran via direct `bun --smol test` invocations against the two touched test files plus a config-suite sanity check.
- 7 (test writing):      touched — added 4 new test cases and updated 2 in `tests/unit/tools/phase-complete-final-council.test.ts` and `tests/unit/tools/write-final-council-evidence.test.ts`; no new `mock.module` use, no `mock.*` cross-file leaks, no hardcoded `/tmp` paths introduced.
- 8 (session state):     not touched — no new session-keyed or module-level state.
- 9 (guardrails/retry):  not touched — no retry/circuit-breaker changes.
- 10 (chat/system msg):  not touched — no message-shape changes.
- 11 (tool registration): not touched — no new tools, agents, or map entries; the new `council.finalConcernsAllowComplete` schema field follows the existing `phaseConcernsAllowComplete` pattern. Config tests run; the 7 pre-existing failures (subagent counts, tool map sizes, model lists) reproduce on clean `origin/main` and are unrelated — see "Pre-existing failures".
- 12 (release/cache):    touched — release note fragment added at `docs/releases/pending/972-final-council-concerns-advisory.md`; `package.json`, `CHANGELOG.md`, `.release-please-manifest.json` are untouched.

## Test plan

- [x] `bun --smol test tests/unit/tools/phase-complete-final-council.test.ts tests/unit/tools/write-final-council-evidence.test.ts --timeout 60000` — 26 pass, 0 fail (112 expect() calls) in 830ms
- [x] `bun run typecheck` — `tsc --noEmit` exit 0
- [x] `bun run build` — bundle built (4.73 MB index.js, 2.13 MB CLI)
- [x] `node --input-type=module -e "await import('./dist/index.js')"` — `dist import OK`
- [x] `bun --smol test tests/unit/config --timeout 60000` — 1270 pass, 7 fail (pre-existing on `origin/main`); see "Pre-existing failures"

## Pre-existing failures

The 7 failing tests in `tests/unit/config` (subagent count of 17 vs expected, AGENT_TOOL_MAP subagent count, critic agent registration, ALL_SUBAGENT_NAMES, ALL_AGENT_NAMES, DEFAULT_MODELS count, quiet:false deprecation warning) are not introduced by this change. They reproduce on a clean `origin/main` worktree (157 tests, 41 fail, 36 errors) and exist independently of issue #972.

## Migration

No migration required. The evidence JSON shape gains a third value (`'concerns'`) but keeps the previous `'approved' | 'rejected'` values unchanged, so existing evidence readers continue to work. To opt into blocking CONCERNS at the final council, set `council.finalConcernsAllowComplete: false` in `.opencode/opencode-swarm.json`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat final council CONCERNS as advisory (non-blocking) and correctly distinguish APPROVE, CONCERNS, and REJECT in final-council evidence. This fixes last-phase blocks when the only dissent is advisory and aligns with #972.

- **Bug Fixes**
  - Evidence now writes verdicts as 'approved' | 'concerns' | 'rejected' instead of collapsing CONCERNS into 'rejected'.
  - Final-council gate accepts 'concerns' (and 'CONCERNS') as non-blocking, controlled by `council.finalConcernsAllowComplete` (default true); when disabled, it blocks with `FINAL_COUNCIL_CONCERNS` and otherwise logs a warning and proceeds.
  - Added `finalConcernsAllowComplete` to `src/config/schema.ts` and `src/council/types.ts`; updated tests and added a release note.

- **Migration**
  - No migration needed; evidence may now include 'concerns'.
  - To make CONCERNS block at final council, set `council.finalConcernsAllowComplete: false` in `.opencode/opencode-swarm.json`.

<sup>Written for commit 0cce34158fa348b9696aa51f1f1e02bb7d79ae41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

