### PR TITLE
feat(delegation-gate): opt-in durable tracking + observer for background subagents (#1151 PR 2 Stage A)

### DIFF
--- a/docs/releases/pending/1151-background-subagents-stage-a.md
+++ b/docs/releases/pending/1151-background-subagents-stage-a.md
@@ -1,0 +1,65 @@
+# Background subagents — durable dispatch tracking + completion observer (issue #1151, PR 2 Stage A)
+
+## What
+
+Adds opt-in, gate-safe groundwork for OpenCode v1.16.2 background subagents, building on the
+PR 1 fail-closed guard.
+
+New config (under `hooks`):
+- `background_subagents` (default **false**) — when false, PR 1 behavior is unchanged
+  (background swarm `Task` dispatches are fail-closed-blocked). When true, background swarm
+  dispatches are **allowed and tracked**.
+- `background_pending_timeout_minutes` (default 30) — bounded lifetime after which a tracked
+  pending delegation is swept to `stale`.
+
+When `background_subagents` is enabled:
+- `src/hooks/delegation-gate.ts` no longer blocks background swarm dispatch; instead
+  `tool.execute.after` records a **durable pending delegation** (parent session id, jobId,
+  subagent session id, callID, normalized + prefixed agent, plan/evidence task id, status,
+  timestamps) in an append-only `.swarm/background-delegations.jsonl` store
+  (`src/background/pending-delegations.ts`). All writes run under the evidence lock; reads are
+  lock-free with malformed-line tolerance; the path is `validateSwarmPath`-contained.
+- A new read-only `event` hook observer (`src/background/completion-observer.ts`) watches for
+  the trusted completion signal — a message part with `synthetic === true` whose text is a
+  task envelope (`<task id="…" state="completed|error">`, parsed by
+  `src/background/task-envelope.ts`) — and logs (under `OPENCODE_SWARM_DEBUG=1`) whether it
+  correlates to a pending record.
+- A lazy stale sweep (on dispatch — no plugin-init cost) transitions unresolved pendings to
+  `stale`, bounding the folded in-memory view. The on-disk JSONL is append-only and not
+  compacted in Stage A (each dispatch leaves a small fixed number of lines); on-disk
+  compaction is a future stage.
+
+## Why
+
+PR 2's gate-affecting completion ingestion must only be built on a **runtime-confirmed**
+trusted completion signal. The upstream signal is confirmed in source (synthetic-flagged
+parent injection of a stable XML envelope, with `jobId`/subagent-session correlation), but
+not yet verifiable at runtime in the pinned SDK. Stage A lands the safe, reversible
+foundation — durable dispatch tracking + the empirical observation instrument — **without any
+gate effect**, so the signal can be confirmed before Stage B enables advancement.
+
+## Stage A is observe-only
+
+A background completion does **not** advance workflow gates or record gate evidence in this
+stage. Reviewer/test_engineer gates are satisfied only by foreground delegations. The
+gate-affecting completion ingestion (correlate → reuse foreground transitions → exact-once,
+with parent-session-gone and multi-swarm isolation handling) is **Stage B**, a separate PR
+gated on runtime confirmation produced by this observer.
+
+## Migration
+
+No action and no behavior change for existing users — the feature is **off by default** and
+preserves the PR 1 fail-closed block. Enabling requires both `hooks.background_subagents: true`
+and the upstream `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true`.
+
+## Invariant audit
+
+- **4. `.swarm/` containment** — new durable store is `validateSwarmPath`-contained under
+  project-root `.swarm/`; verified by tests.
+- **7. Test writing** — new `bun:test` suites; no `mock.module`; positive/negative/adversarial
+  (spoof/trust-gate, malformed-line, concurrent-append) cases.
+- **8. Session/global state** — pending correlation is durable + session-scoped; flag-off path
+  unchanged.
+- **10. Chat/system message** — the observer is read-only and logs only under
+  `OPENCODE_SWARM_DEBUG`; the new `event` hook is `safeHook`-wrapped (never blocks delivery).
+- **1. Plugin init** — no init-time disk work added; the stale sweep is lazy on dispatch.

--- a/docs/troubleshooting/recovery-guide.md
+++ b/docs/troubleshooting/recovery-guide.md
@@ -95,12 +95,27 @@ background delegations for any swarm role (reviewer, test_engineer, coder, explo
 Swarm never silently rewrites `background` to `false` — the unsupported capability is
 surfaced explicitly.
 
-**Action needed:** Re-issue the delegation **without** `background` (or with
+**Action needed (default):** Re-issue the delegation **without** `background` (or with
 `background: false`). Foreground swarm delegations are unaffected. Non-swarm OpenCode
 `Task` usage (e.g. the native `general` agent) is not blocked. The pre-dispatch block runs
 in `tool.execute.before`, so OpenCode rejects the call before the background task launches;
 a belt-and-suspenders check in `tool.execute.after` ensures a running placeholder never
 advances workflow state even if it slips through.
+
+### Opt-in tracking (PR 2 Stage A)
+
+Setting `hooks.background_subagents: true` lifts the block: background swarm dispatches are
+**allowed and tracked** as durable pending records in `.swarm/background-delegations.jsonl`,
+and a read-only observer logs the upstream completion signal (the trusted `synthetic` task
+envelope) when `OPENCODE_SWARM_DEBUG=1`. Unresolved pendings are transitioned to `stale`
+after `hooks.background_pending_timeout_minutes` (default 30); the on-disk log is append-only
+and not compacted in Stage A.
+
+> **Stage A is observe-only:** a background completion does **not** advance workflow gates or
+> record gate evidence yet. This stage exists to confirm the runtime completion signal before
+> gate-affecting ingestion (Stage B) is enabled. Until then, background swarm delegations are
+> tracked but do not satisfy reviewer/test_engineer gates — use foreground delegations when you
+> need a gate to advance. Requires upstream `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true`.
 
 ---
 

--- a/src/background/completion-observer.ts
+++ b/src/background/completion-observer.ts
@@ -1,0 +1,96 @@
+/**
+ * Background subagent completion OBSERVER (issue #1151, PR 2 Stage A).
+ *
+ * Registers as a swarm `event` hook to watch for the upstream background-completion signal:
+ * a message part with `synthetic === true` whose text is a task envelope with
+ * `state="completed"` or `state="error"`. When such a part correlates to a durable pending
+ * background-delegation record, it is logged (debug-gated) as the empirical confirmation
+ * instrument operators use to verify the runtime signal in a real environment.
+ *
+ * Stage A is strictly READ-ONLY: this observer NEVER advances workflow gates, records gate
+ * evidence, or mutates the durable store. Gate-affecting completion ingestion is Stage B,
+ * gated on runtime confirmation produced by exactly this observer.
+ *
+ * The `synthetic` flag is the trust gate (set by OpenCode, not the model/user). Non-synthetic
+ * text that merely looks like an envelope is ignored. The observer is fail-open: any error is
+ * swallowed so it can never block event delivery or plugin load (Invariant 1/10).
+ */
+
+import * as logger from '../utils/logger.js';
+import { findByCorrelationId } from './pending-delegations.js';
+import { parseTaskEnvelope } from './task-envelope.js';
+
+interface ObserverConfig {
+	enabled: boolean;
+}
+
+interface MaybeTextPart {
+	type?: unknown;
+	text?: unknown;
+	synthetic?: unknown;
+	sessionID?: unknown;
+}
+
+interface MaybeEvent {
+	type?: unknown;
+	properties?: { part?: unknown } & Record<string, unknown>;
+}
+
+/**
+ * Build the Stage A completion observer. Returns an `event` handler suitable for the
+ * OpenCode plugin `event` hook. No-op (cheap early return) when the feature is disabled.
+ */
+export function createBackgroundCompletionObserver(opts: {
+	config: ObserverConfig;
+	directory: string;
+}): {
+	event: (input: { event: unknown }) => Promise<void>;
+} {
+	const { config, directory } = opts;
+
+	const event = async (input: { event: unknown }): Promise<void> => {
+		if (!config.enabled) return;
+		try {
+			const evt = input?.event as MaybeEvent | undefined;
+			if (!evt || evt.type !== 'message.part.updated') return;
+			const part = evt.properties?.part as MaybeTextPart | undefined;
+			if (!part || part.type !== 'text') return;
+
+			// Trust gate: only OpenCode-set synthetic parts are considered.
+			if (part.synthetic !== true) return;
+			if (typeof part.text !== 'string') return;
+
+			const envelope = parseTaskEnvelope(part.text);
+			if (!envelope) return;
+			// Only terminal states are completion signals; running placeholders are dispatch.
+			if (envelope.state !== 'completed' && envelope.state !== 'error') return;
+
+			const pending = findByCorrelationId(directory, envelope.sessionId);
+			const parentSessionId =
+				typeof part.sessionID === 'string' ? part.sessionID : 'unknown';
+
+			if (!pending) {
+				// Synthetic completion with no matching durable record — log for visibility
+				// but take no action (could be a non-swarm background task or a spoof).
+				logger.log(
+					`[background] observed synthetic completion (state=${envelope.state}) for subagent ${envelope.sessionId} in parent ${parentSessionId} with NO matching pending record — ignored (Stage A observe-only)`,
+				);
+				return;
+			}
+
+			logger.log(
+				`[background] observed trusted completion (state=${envelope.state}) correlated to pending delegation: ` +
+					`agent=${pending.normalizedAgent} task=${pending.evidenceTaskId ?? pending.planTaskId ?? 'unknown'} ` +
+					`parent=${pending.parentSessionId} observedParent=${parentSessionId} pendingStatus=${pending.status} ` +
+					'(Stage A observe-only — no gate effect; Stage B will ingest completion)',
+			);
+		} catch (err) {
+			// Fail-open: never block event delivery.
+			logger.warn(
+				`[background] completion observer error: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	};
+
+	return { event };
+}

--- a/src/background/pending-delegations.ts
+++ b/src/background/pending-delegations.ts
@@ -1,0 +1,264 @@
+/**
+ * Durable pending background-delegation store (issue #1151, PR 2 Stage A).
+ *
+ * Append-only JSONL event log under project-root `.swarm/background-delegations.jsonl`.
+ * Each line is a full record snapshot; readers fold to the latest snapshot per
+ * `correlationId`. This tracks background swarm `Task` dispatches so a later (Stage B)
+ * trusted completion can be correlated to a real dispatch. The stale sweep bounds the
+ * number of permanently-running (unresolved) entries by transitioning them to `stale`, so
+ * the folded in-memory view stays bounded by distinct correlationIds. Note: the on-disk
+ * log itself is append-only and is NOT compacted in Stage A — each dispatch leaves a small,
+ * fixed number of lines; on-disk compaction of dropped/stale records is a future stage.
+ *
+ * Stage A scope: dispatch records a `pending` snapshot and the stale sweep records
+ * `stale` snapshots. There is NO gate advancement and NO completion mutation here — the
+ * completion observer (Stage A) is read-only. Gate-affecting completion ingestion is
+ * Stage B, gated on runtime confirmation of the upstream completion signal.
+ *
+ * Concurrency: all writes (append, sweep) run under a single project-scoped lock via
+ * `withEvidenceLock`, so concurrent dispatches/sweeps cannot interleave appends. Reads are
+ * lock-free (line-oriented; partial trailing lines are skipped defensively).
+ *
+ * Containment: the path is validated with `validateSwarmPath`, so it can never escape
+ * `.swarm/` (Invariant 4).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { z } from 'zod';
+import { withEvidenceLock } from '../evidence/lock.js';
+import { validateSwarmPath } from '../hooks/utils.js';
+import * as logger from '../utils/logger.js';
+
+export const BACKGROUND_DELEGATIONS_FILE = 'background-delegations.jsonl';
+
+/** Lock + diagnostics identity for the project-scoped store lock. */
+const STORE_LOCK_AGENT = 'background';
+const STORE_LOCK_TASK = 'background-delegations';
+
+export type BackgroundDelegationStatus =
+	| 'pending'
+	| 'completed'
+	| 'error'
+	| 'stale';
+
+export interface BackgroundDelegationRecord {
+	schemaVersion: 1;
+	/** Subagent session id from the dispatch envelope — the correlation key. */
+	correlationId: string;
+	/** Structured jobId from dispatch metadata when available, else null. */
+	jobId: string | null;
+	/** Subagent session id (== correlationId; kept explicit for clarity/forward-compat). */
+	subagentSessionId: string;
+	/** Parent (dispatching) session id. */
+	parentSessionId: string;
+	/** Tool callID of the dispatching Task call. */
+	callID: string;
+	/** Canonical swarm role (e.g. "reviewer", "test_engineer"). */
+	normalizedAgent: string;
+	/** Raw, possibly swarm-prefixed agent name (e.g. "mega_reviewer"). */
+	swarmPrefixedAgent: string;
+	/** Plan/evidence task id resolved at dispatch, or null. */
+	planTaskId: string | null;
+	evidenceTaskId: string | null;
+	status: BackgroundDelegationStatus;
+	createdAt: number;
+	updatedAt: number;
+}
+
+const RecordSchema = z
+	.object({
+		schemaVersion: z.literal(1),
+		correlationId: z.string().min(1),
+		jobId: z.string().nullable(),
+		subagentSessionId: z.string().min(1),
+		parentSessionId: z.string().min(1),
+		callID: z.string(),
+		normalizedAgent: z.string(),
+		swarmPrefixedAgent: z.string(),
+		planTaskId: z.string().nullable(),
+		evidenceTaskId: z.string().nullable(),
+		status: z.enum(['pending', 'completed', 'error', 'stale']),
+		createdAt: z.number(),
+		updatedAt: z.number(),
+	})
+	.strict();
+
+function storePath(directory: string): string {
+	return validateSwarmPath(directory, BACKGROUND_DELEGATIONS_FILE);
+}
+
+function ensureSwarmDir(directory: string): void {
+	fs.mkdirSync(path.resolve(directory, '.swarm'), { recursive: true });
+}
+
+/**
+ * Read and fold the store to the latest snapshot per correlationId. Lock-free and
+ * defensive: a missing file yields an empty list, and malformed/partial lines are skipped
+ * (never throws). Records are returned in first-seen correlationId order.
+ */
+export function readDelegations(
+	directory: string,
+): BackgroundDelegationRecord[] {
+	let raw: string;
+	try {
+		raw = fs.readFileSync(storePath(directory), 'utf-8');
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+		// Unexpected read error — treat as empty but record under debug.
+		logger.warn(
+			`[background] readDelegations failed: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return [];
+	}
+
+	const folded = new Map<string, BackgroundDelegationRecord>();
+	for (const line of raw.split('\n')) {
+		const trimmed = line.trim();
+		if (trimmed.length === 0) continue;
+		let parsedJson: unknown;
+		try {
+			parsedJson = JSON.parse(trimmed);
+		} catch {
+			continue; // skip malformed/partial line
+		}
+		const result = RecordSchema.safeParse(parsedJson);
+		if (!result.success) continue;
+		folded.set(result.data.correlationId, result.data);
+	}
+	return [...folded.values()];
+}
+
+/** Returns the folded record for a correlationId, or null. Lock-free read. */
+export function findByCorrelationId(
+	directory: string,
+	correlationId: string,
+): BackgroundDelegationRecord | null {
+	if (!correlationId) return null;
+	for (const record of readDelegations(directory)) {
+		if (record.correlationId === correlationId) return record;
+	}
+	return null;
+}
+
+function appendRecord(
+	directory: string,
+	record: BackgroundDelegationRecord,
+): void {
+	ensureSwarmDir(directory);
+	fs.appendFileSync(
+		storePath(directory),
+		`${JSON.stringify(record)}\n`,
+		'utf-8',
+	);
+}
+
+export interface RecordPendingInput {
+	correlationId: string;
+	jobId: string | null;
+	subagentSessionId: string;
+	parentSessionId: string;
+	callID: string;
+	normalizedAgent: string;
+	swarmPrefixedAgent: string;
+	planTaskId: string | null;
+	evidenceTaskId: string | null;
+}
+
+/**
+ * Record a `pending` background delegation. Runs the stale sweep first (lazy maintenance,
+ * no plugin-init cost), then appends the pending snapshot — all under one lock acquisition
+ * so concurrent dispatches cannot interleave. Best-effort: returns null on lock timeout or
+ * write failure (Stage A has no gate effects, so a missed record is non-fatal).
+ */
+export async function recordPendingDelegation(
+	directory: string,
+	input: RecordPendingInput,
+	options: { staleTimeoutMs?: number } = {},
+): Promise<BackgroundDelegationRecord | null> {
+	const now = Date.now();
+	const record: BackgroundDelegationRecord = {
+		schemaVersion: 1,
+		correlationId: input.correlationId,
+		jobId: input.jobId,
+		subagentSessionId: input.subagentSessionId,
+		parentSessionId: input.parentSessionId,
+		callID: input.callID,
+		normalizedAgent: input.normalizedAgent,
+		swarmPrefixedAgent: input.swarmPrefixedAgent,
+		planTaskId: input.planTaskId,
+		evidenceTaskId: input.evidenceTaskId,
+		status: 'pending',
+		createdAt: now,
+		updatedAt: now,
+	};
+
+	try {
+		await withEvidenceLock(
+			directory,
+			BACKGROUND_DELEGATIONS_FILE,
+			STORE_LOCK_AGENT,
+			STORE_LOCK_TASK,
+			async () => {
+				if (options.staleTimeoutMs && options.staleTimeoutMs > 0) {
+					sweepStaleLocked(directory, options.staleTimeoutMs, now);
+				}
+				appendRecord(directory, record);
+			},
+		);
+		return record;
+	} catch (err) {
+		logger.warn(
+			`[background] recordPendingDelegation failed: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return null;
+	}
+}
+
+/**
+ * Mark all `pending` records older than `timeoutMs` as `stale` (status-only; no gate
+ * effect). Called within an already-held store lock.
+ */
+function sweepStaleLocked(
+	directory: string,
+	timeoutMs: number,
+	now: number,
+): number {
+	let swept = 0;
+	for (const record of readDelegations(directory)) {
+		if (record.status !== 'pending') continue;
+		if (now - record.updatedAt <= timeoutMs) continue;
+		appendRecord(directory, {
+			...record,
+			status: 'stale',
+			updatedAt: now,
+		});
+		swept += 1;
+	}
+	return swept;
+}
+
+/**
+ * Public stale sweep: acquires the store lock and marks overdue pendings as `stale`.
+ * Best-effort; returns the number swept (0 on lock timeout / error).
+ */
+export async function sweepStaleDelegations(
+	directory: string,
+	timeoutMs: number,
+): Promise<number> {
+	if (!timeoutMs || timeoutMs <= 0) return 0;
+	try {
+		return await withEvidenceLock(
+			directory,
+			BACKGROUND_DELEGATIONS_FILE,
+			STORE_LOCK_AGENT,
+			STORE_LOCK_TASK,
+			async () => sweepStaleLocked(directory, timeoutMs, Date.now()),
+		);
+	} catch (err) {
+		logger.warn(
+			`[background] sweepStaleDelegations failed: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return 0;
+	}
+}

--- a/src/background/pending-delegations.ts
+++ b/src/background/pending-delegations.ts
@@ -96,6 +96,12 @@ function ensureSwarmDir(directory: string): void {
  * Read and fold the store to the latest snapshot per correlationId. Lock-free and
  * defensive: a missing file yields an empty list, and malformed/partial lines are skipped
  * (never throws). Records are returned in first-seen correlationId order.
+ *
+ * Cost: O(lines on disk) per call — a full read + parse + fold with no in-memory cache.
+ * This is intentionally simple and acceptable at Stage A volumes (a swarm has few concurrent
+ * background delegations, and the on-disk log is small). If sustained high-throughput
+ * background load ever makes this hot, a future stage should add a stat-invalidated in-memory
+ * cache and/or JSONL compaction (the same future-compaction work noted in the module header).
  */
 export function readDelegations(
 	directory: string,

--- a/src/background/task-envelope.ts
+++ b/src/background/task-envelope.ts
@@ -1,0 +1,100 @@
+/**
+ * Background subagent task-envelope parsing (issue #1151, PR 2 Stage A).
+ *
+ * OpenCode background subagents (v1.16.2) render task dispatch/completion as a stable
+ * XML-ish envelope via the upstream `renderOutput`:
+ *
+ *   <task id="<subagentSessionID>" state="running|completed|error">
+ *   <summary>...</summary>
+ *   <task_result>...</task_result>   (or <task_error> for state="error")
+ *   </task>
+ *
+ * - The dispatch tool result carries `state="running"` and the subagent session id.
+ * - The deferred completion arrives as a synthetic parent message part whose text is the
+ *   same envelope with `state="completed"` or `state="error"`.
+ *
+ * These parsers are intentionally pure and defensive — they never throw — so they can be
+ * used both at dispatch (tool.execute.after output) and at completion observation time.
+ */
+
+export type TaskEnvelopeState = 'running' | 'completed' | 'error';
+
+export interface TaskEnvelope {
+	/** The subagent session id from `<task id="...">` — the cross-event correlation key. */
+	sessionId: string;
+	state: TaskEnvelopeState;
+}
+
+// Anchored to the opening tag only; tolerant of arbitrary body/whitespace after it.
+// `id` is captured non-greedily and must be non-empty; `state` is constrained to the
+// known set so unrelated `<task ...>` text cannot masquerade as an envelope.
+const TASK_ENVELOPE_RE =
+	/<task\s+id="([^"]+)"\s+state="(running|completed|error)"\s*>/;
+
+/**
+ * Parse a task envelope from arbitrary text. Returns null when the text does not contain
+ * a well-formed opening `<task id="..." state="...">` tag. Never throws.
+ */
+export function parseTaskEnvelope(text: unknown): TaskEnvelope | null {
+	if (typeof text !== 'string' || text.length === 0) return null;
+	const match = text.match(TASK_ENVELOPE_RE);
+	if (!match) return null;
+	const sessionId = match[1];
+	const state = match[2] as TaskEnvelopeState;
+	if (!sessionId) return null;
+	return { sessionId, state };
+}
+
+/**
+ * Extract the subagent session id and (optional) jobId from a background `Task` dispatch
+ * result (the `tool.execute.after` output object `{ title, output, metadata }`).
+ *
+ * - `subagentSessionId` is parsed from the rendered `output` envelope `<task id="...">`.
+ * - `jobId` is read defensively from `metadata.jobId` (the installed plugin SDK types this
+ *   field as `any`; upstream sets `{ background: true, jobId }`). Absent → null.
+ *
+ * Both are best-effort; either may be null.
+ */
+export function extractDispatchIds(output: unknown): {
+	subagentSessionId: string | null;
+	jobId: string | null;
+} {
+	let subagentSessionId: string | null = null;
+	let jobId: string | null = null;
+
+	if (typeof output === 'object' && output !== null) {
+		const o = output as Record<string, unknown>;
+
+		// jobId from structured metadata (trusted, not free text).
+		const metadata = o.metadata;
+		if (typeof metadata === 'object' && metadata !== null) {
+			const rawJobId = (metadata as Record<string, unknown>).jobId;
+			if (typeof rawJobId === 'string' && rawJobId.length > 0) {
+				jobId = rawJobId;
+			}
+		}
+
+		// subagent session id from the rendered dispatch envelope.
+		const rendered = o.output;
+		const envelope = parseTaskEnvelope(
+			typeof rendered === 'string' ? rendered : undefined,
+		);
+		if (envelope && envelope.state === 'running') {
+			subagentSessionId = envelope.sessionId;
+		}
+	} else if (typeof output === 'string') {
+		// Some runtimes may surface the rendered string directly.
+		const envelope = parseTaskEnvelope(output);
+		if (envelope && envelope.state === 'running') {
+			subagentSessionId = envelope.sessionId;
+		}
+	}
+
+	// Fall back to jobId as the correlation id when the envelope is unavailable but the
+	// structured jobId is present (upstream treats them as equivalent identifiers).
+	if (!subagentSessionId && jobId) {
+		subagentSessionId = jobId;
+	}
+
+	return { subagentSessionId, jobId };
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -181,6 +181,24 @@ export const HooksConfigSchema = z.object({
 	agent_awareness_max_chars: z.number().min(50).max(2000).default(300),
 	delegation_gate: z.boolean().default(true),
 	delegation_max_chars: z.number().min(500).max(20000).default(4000),
+	/**
+	 * Issue #1151 PR 2 (Stage A): opt-in support for OpenCode background subagents.
+	 * When false (default) swarm fail-closed-blocks background swarm `Task` dispatches
+	 * (PR 1 behavior). When true, background swarm dispatches are allowed and tracked as
+	 * durable pending records under `.swarm/background-delegations.jsonl`, and a read-only
+	 * completion observer logs the upstream completion signal — but NO workflow gate is
+	 * advanced from a background completion in Stage A (gate-affecting ingestion is Stage B).
+	 * Requires upstream `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true` to have any effect.
+	 */
+	background_subagents: z.boolean().default(false),
+	/** Bounded lifetime (minutes) after which a tracked pending background delegation is
+	 *  swept to `stale` so `.swarm/` does not accumulate permanently-running entries. */
+	background_pending_timeout_minutes: z
+		.number()
+		.int()
+		.min(1)
+		.max(1440)
+		.default(30),
 });
 
 export type HooksConfig = z.infer<typeof HooksConfigSchema>;

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -812,6 +812,17 @@ export function createDelegationGateHook(
 		((config.hooks as Record<string, unknown> | undefined)
 			?.delegation_max_chars as number | undefined) ?? 4000;
 
+	// Issue #1151 PR 2 (Stage A): opt-in background-subagent support. When false (default)
+	// background swarm Task dispatches are fail-closed-blocked (PR 1). When true, they are
+	// allowed and tracked as durable pending records (no gate advancement in Stage A).
+	const backgroundSubagentsEnabled =
+		(config.hooks as Record<string, unknown> | undefined)
+			?.background_subagents === true;
+	const backgroundPendingTimeoutMs =
+		(((config.hooks as Record<string, unknown> | undefined)
+			?.background_pending_timeout_minutes as number | undefined) ?? 30) *
+		60_000;
+
 	if (!enabled) {
 		return {
 			messagesTransform: async (
@@ -909,7 +920,12 @@ export function createDelegationGateHook(
 		// agent) is never blocked. This throw propagates through the fail-closed
 		// tool.execute.before chain in src/index.ts (no safeHook wrapper), so OpenCode
 		// rejects the tool before launching the background task.
+		//
+		// PR 2 Stage A: when background_subagents is opted in, the block is lifted — the
+		// dispatch is allowed and tracked as a durable pending record in toolAfter (still
+		// no gate advancement in Stage A). When disabled (default), PR 1 behavior stands.
 		if (
+			!backgroundSubagentsEnabled &&
 			isBackgroundTrue(args.background) &&
 			isKnownCanonicalRole(targetAgent)
 		) {
@@ -1145,12 +1161,14 @@ export function createDelegationGateHook(
 			const subagentType =
 				directArgs?.subagent_type ?? storedArgs?.subagent_type;
 
-			// Issue #1151: defensive belt-and-suspenders for background swarm Task.
-			// Pre-dispatch toolBefore is the primary guard; if a background swarm Task
-			// still reaches here (a "running" placeholder), it must NOT advance Stage B
-			// or record completed gate evidence. Detect background from args (direct or
-			// stored) or from the result shape, scoped to swarm roles. Clean up stored
-			// args so the callID entry does not leak, then bail before any advancement.
+			// Issue #1151: background swarm Task handling.
+			// A background swarm Task returns a "running" placeholder; it must NEVER advance
+			// Stage B or record completed gate evidence here. Detect background from args
+			// (direct or stored) or from the result shape, scoped to swarm roles.
+			//   - PR 1 (flag OFF): defensive belt-and-suspenders — bail before any advancement.
+			//   - PR 2 Stage A (flag ON): additionally record a DURABLE pending delegation so a
+			//     later (Stage B) trusted completion can be correlated. Still no gate effect.
+			// Either way: clean up stored args so the callID entry does not leak, then bail.
 			if (
 				typeof subagentType === 'string' &&
 				isKnownCanonicalRole(stripKnownSwarmPrefix(subagentType)) &&
@@ -1158,6 +1176,52 @@ export function createDelegationGateHook(
 					isBackgroundTrue(storedArgs?.background) ||
 					outputLooksLikeBackgroundRunning(_output))
 			) {
+				if (backgroundSubagentsEnabled) {
+					try {
+						const { extractDispatchIds } = await import(
+							'../background/task-envelope.js'
+						);
+						const { recordPendingDelegation } = await import(
+							'../background/pending-delegations.js'
+						);
+						const { subagentSessionId, jobId } = extractDispatchIds(_output);
+						if (subagentSessionId) {
+							const mergedArgs = { ...(storedArgs ?? {}), ...directArgs };
+							const evidenceTaskId = await resolveEvidenceTaskId(
+								mergedArgs,
+								session,
+								directory,
+							);
+							await recordPendingDelegation(
+								directory,
+								{
+									correlationId: subagentSessionId,
+									jobId,
+									subagentSessionId,
+									parentSessionId: input.sessionID,
+									callID: input.callID,
+									normalizedAgent: stripKnownSwarmPrefix(subagentType),
+									swarmPrefixedAgent: subagentType,
+									planTaskId: evidenceTaskId,
+									evidenceTaskId,
+								},
+								{ staleTimeoutMs: backgroundPendingTimeoutMs },
+							);
+						} else {
+							// No usable correlation id (no jobId and no parseable dispatch
+							// envelope). Do NOT write an unkeyable/orphan record; the dispatch
+							// already launched upstream, but Stage A has no gate effect so an
+							// untracked background dispatch is safe (it is simply unobservable).
+							logger.warn(
+								'[delegation-gate] background dispatch had no correlation id (no jobId / no envelope) — not tracked',
+							);
+						}
+					} catch (err) {
+						logger.warn(
+							`[delegation-gate] background pending recording failed: ${err instanceof Error ? err.message : String(err)}`,
+						);
+					}
+				}
 				if (storedArgs !== undefined) deleteStoredInputArgs(input.callID);
 				return;
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
 	PlanSyncWorker,
 	type PreflightTriggerManager,
 } from './background';
+import { createBackgroundCompletionObserver } from './background/completion-observer.js';
 import {
 	agentHasSwarmCommandTool,
 	createSwarmCommandHandler,
@@ -454,6 +455,16 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 		ctx.directory,
 	);
 	const delegationGateHooks = createDelegationGateHook(config, ctx.directory);
+	// Issue #1151 PR 2 (Stage A): read-only observer for the background-subagent
+	// completion signal. No-op unless hooks.background_subagents is opted in.
+	const backgroundCompletionObserver = createBackgroundCompletionObserver({
+		config: {
+			enabled:
+				(config.hooks as Record<string, unknown> | undefined)
+					?.background_subagents === true,
+		},
+		directory: ctx.directory,
+	});
 	const delegationSanitizerHook = createDelegationSanitizerHook(ctx.directory);
 	const memoryLifecycleHooks = createMemoryLifecycleHooks({
 		directory: ctx.directory,
@@ -843,6 +854,12 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 
 		// Register tools
 		tool: buildPluginToolObject(agentDefinitionMap),
+
+		// Issue #1151 PR 2 (Stage A): observe the background-subagent completion signal.
+		// ADVISORY/observer-only — safeHook-wrapped so it can never block event delivery or
+		// plugin load. No-op unless hooks.background_subagents is opted in.
+		// biome-ignore lint/suspicious/noExplicitAny: Plugin API requires generic hook wrappers
+		event: safeHook(backgroundCompletionObserver.event) as any,
 
 		// Configure OpenCode - merge agents into config
 		config: async (opencodeConfig: Record<string, unknown>) => {

--- a/tests/unit/background/completion-observer.test.ts
+++ b/tests/unit/background/completion-observer.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Issue #1151 PR 2 (Stage A) — completion observer tests.
+ *
+ * Stage A is observe-only: the observer NEVER mutates the durable store or advances gates.
+ * These tests assert no-throw, disabled-no-op, the synthetic trust gate, and that a
+ * correlated completion does NOT change the pending record's status (Stage B will).
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createBackgroundCompletionObserver } from '../../../src/background/completion-observer';
+import {
+	findByCorrelationId,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations';
+
+function makeTempProject(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-bgobs-'));
+	const real = fs.realpathSync(dir);
+	fs.mkdirSync(path.join(real, '.swarm'), { recursive: true });
+	return real;
+}
+
+function syntheticPartEvent(opts: {
+	text: string;
+	synthetic?: boolean;
+	sessionID?: string;
+}) {
+	return {
+		event: {
+			type: 'message.part.updated',
+			properties: {
+				part: {
+					type: 'text',
+					text: opts.text,
+					synthetic: opts.synthetic,
+					sessionID: opts.sessionID ?? 'parent_session',
+				},
+			},
+		},
+	};
+}
+
+const completedEnvelope = (id: string) =>
+	`<task id="${id}" state="completed">\n<task_result>done</task_result>\n</task>`;
+
+describe('background completion observer (Stage A)', () => {
+	let dir: string;
+	beforeEach(() => {
+		dir = makeTempProject();
+	});
+	afterEach(() => {
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('is a no-op when disabled', async () => {
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: false },
+			directory: dir,
+		});
+		await expect(
+			obs.event(
+				syntheticPartEvent({
+					text: completedEnvelope('ses_1'),
+					synthetic: true,
+				}),
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it('does not mutate the durable record on a correlated completion (observe-only)', async () => {
+		await recordPendingDelegation(dir, {
+			correlationId: 'ses_obs',
+			jobId: 'job_obs',
+			subagentSessionId: 'ses_obs',
+			parentSessionId: 'parent_session',
+			callID: 'c1',
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: '1.1',
+			evidenceTaskId: '1.1',
+		});
+
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await obs.event(
+			syntheticPartEvent({
+				text: completedEnvelope('ses_obs'),
+				synthetic: true,
+			}),
+		);
+
+		// Stage A: status is unchanged (still pending) — no gate/store mutation.
+		expect(findByCorrelationId(dir, 'ses_obs')?.status).toBe('pending');
+	});
+
+	it('ignores non-synthetic envelope-shaped text (trust gate)', async () => {
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await expect(
+			obs.event(
+				syntheticPartEvent({
+					text: completedEnvelope('ses_spoof'),
+					synthetic: false,
+				}),
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it('ignores non-text / non-part / unrelated events without throwing', async () => {
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await expect(
+			obs.event({ event: { type: 'session.idle', properties: {} } }),
+		).resolves.toBeUndefined();
+		await expect(obs.event({ event: undefined })).resolves.toBeUndefined();
+		await expect(
+			obs.event({
+				event: {
+					type: 'message.part.updated',
+					properties: { part: { type: 'file' } },
+				},
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it('handles a synthetic completion with no matching pending record (no throw)', async () => {
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await expect(
+			obs.event(
+				syntheticPartEvent({
+					text: completedEnvelope('ses_unknown'),
+					synthetic: true,
+				}),
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it('ignores a running (non-terminal) synthetic envelope', async () => {
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await expect(
+			obs.event(
+				syntheticPartEvent({
+					text: '<task id="ses_run" state="running"></task>',
+					synthetic: true,
+				}),
+			),
+		).resolves.toBeUndefined();
+	});
+});

--- a/tests/unit/background/pending-delegations.test.ts
+++ b/tests/unit/background/pending-delegations.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Issue #1151 PR 2 (Stage A) — durable pending-delegation store tests.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	BACKGROUND_DELEGATIONS_FILE,
+	findByCorrelationId,
+	type RecordPendingInput,
+	readDelegations,
+	recordPendingDelegation,
+	sweepStaleDelegations,
+} from '../../../src/background/pending-delegations';
+
+function makeTempProject(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-bg-'));
+	const real = fs.realpathSync(dir);
+	fs.mkdirSync(path.join(real, '.swarm'), { recursive: true });
+	return real;
+}
+
+function input(over: Partial<RecordPendingInput> = {}): RecordPendingInput {
+	return {
+		correlationId: 'ses_1',
+		jobId: 'job_1',
+		subagentSessionId: 'ses_1',
+		parentSessionId: 'parent_1',
+		callID: 'call_1',
+		normalizedAgent: 'reviewer',
+		swarmPrefixedAgent: 'reviewer',
+		planTaskId: '1.1',
+		evidenceTaskId: '1.1',
+		...over,
+	};
+}
+
+describe('pending-delegations store', () => {
+	let dir: string;
+	beforeEach(() => {
+		dir = makeTempProject();
+	});
+	afterEach(() => {
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('records a pending delegation and reads it back', async () => {
+		const rec = await recordPendingDelegation(dir, input());
+		expect(rec).not.toBeNull();
+		expect(rec?.status).toBe('pending');
+
+		const all = readDelegations(dir);
+		expect(all).toHaveLength(1);
+		expect(all[0].correlationId).toBe('ses_1');
+		expect(all[0].normalizedAgent).toBe('reviewer');
+
+		// File is under .swarm/ with the expected name.
+		expect(
+			fs.existsSync(path.join(dir, '.swarm', BACKGROUND_DELEGATIONS_FILE)),
+		).toBe(true);
+	});
+
+	it('returns empty for a missing store (no throw)', () => {
+		expect(readDelegations(dir)).toEqual([]);
+		expect(findByCorrelationId(dir, 'nope')).toBeNull();
+	});
+
+	it('folds to the latest snapshot per correlationId', async () => {
+		await recordPendingDelegation(
+			dir,
+			input({
+				correlationId: 'ses_a',
+				evidenceTaskId: '1.1',
+				planTaskId: '1.1',
+			}),
+		);
+		// Second snapshot for the same correlationId with a different task id.
+		await recordPendingDelegation(
+			dir,
+			input({
+				correlationId: 'ses_a',
+				evidenceTaskId: '9.9',
+				planTaskId: '9.9',
+			}),
+		);
+		await recordPendingDelegation(dir, input({ correlationId: 'ses_b' }));
+
+		const folded = readDelegations(dir);
+		// Two distinct correlationIds; ses_a folded to the LATEST snapshot.
+		expect(folded).toHaveLength(2);
+		expect(findByCorrelationId(dir, 'ses_a')?.evidenceTaskId).toBe('9.9');
+	});
+
+	it('sweeps overdue pendings to stale (deterministic via elapsed time)', async () => {
+		await recordPendingDelegation(dir, input({ correlationId: 'ses_stale' }));
+		// Wait so the record is reliably older than the sweep timeout.
+		await new Promise((r) => setTimeout(r, 30));
+		const swept = await sweepStaleDelegations(dir, 1);
+		expect(swept).toBe(1);
+		expect(findByCorrelationId(dir, 'ses_stale')?.status).toBe('stale');
+	});
+
+	it('findByCorrelationId returns the folded record', async () => {
+		await recordPendingDelegation(dir, input({ correlationId: 'ses_find' }));
+		const found = findByCorrelationId(dir, 'ses_find');
+		expect(found?.correlationId).toBe('ses_find');
+		expect(found?.status).toBe('pending');
+	});
+
+	it('skips malformed/partial lines without throwing', async () => {
+		await recordPendingDelegation(dir, input({ correlationId: 'ses_ok' }));
+		const file = path.join(dir, '.swarm', BACKGROUND_DELEGATIONS_FILE);
+		fs.appendFileSync(file, 'not json\n');
+		fs.appendFileSync(file, '{"partial": \n');
+		fs.appendFileSync(file, `${JSON.stringify({ bogus: true })}\n`);
+		const all = readDelegations(dir);
+		expect(all).toHaveLength(1);
+		expect(all[0].correlationId).toBe('ses_ok');
+	});
+
+	it('sweep marks only overdue pendings stale (fresh ones survive)', async () => {
+		await recordPendingDelegation(dir, input({ correlationId: 'ses_old' }));
+		// Large timeout → nothing overdue.
+		const swept = await sweepStaleDelegations(dir, 10 * 60_000);
+		expect(swept).toBe(0);
+		expect(findByCorrelationId(dir, 'ses_old')?.status).toBe('pending');
+	});
+
+	it('handles concurrent pending appends under lock', async () => {
+		await Promise.all(
+			Array.from({ length: 8 }, (_, i) =>
+				recordPendingDelegation(dir, input({ correlationId: `ses_${i}` })),
+			),
+		);
+		const all = readDelegations(dir);
+		expect(all).toHaveLength(8);
+		const ids = new Set(all.map((r) => r.correlationId));
+		expect(ids.size).toBe(8);
+	});
+});

--- a/tests/unit/background/pending-delegations.test.ts
+++ b/tests/unit/background/pending-delegations.test.ts
@@ -92,11 +92,32 @@ describe('pending-delegations store', () => {
 		expect(findByCorrelationId(dir, 'ses_a')?.evidenceTaskId).toBe('9.9');
 	});
 
-	it('sweeps overdue pendings to stale (deterministic via elapsed time)', async () => {
-		await recordPendingDelegation(dir, input({ correlationId: 'ses_stale' }));
-		// Wait so the record is reliably older than the sweep timeout.
-		await new Promise((r) => setTimeout(r, 30));
-		const swept = await sweepStaleDelegations(dir, 1);
+	it('sweeps overdue pendings to stale (deterministic via backdated record)', async () => {
+		// Seed a backdated pending record directly so staleness does not depend on real
+		// elapsed time (avoids flakiness on slow/loaded CI runners). updatedAt is 10 min
+		// in the past; sweeping with a 1 min timeout makes it reliably overdue.
+		const tenMinAgo = Date.now() - 10 * 60_000;
+		const backdated = {
+			schemaVersion: 1,
+			correlationId: 'ses_stale',
+			jobId: 'job_stale',
+			subagentSessionId: 'ses_stale',
+			parentSessionId: 'parent_1',
+			callID: 'call_1',
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: '1.1',
+			evidenceTaskId: '1.1',
+			status: 'pending',
+			createdAt: tenMinAgo,
+			updatedAt: tenMinAgo,
+		};
+		fs.writeFileSync(
+			path.join(dir, '.swarm', BACKGROUND_DELEGATIONS_FILE),
+			`${JSON.stringify(backdated)}\n`,
+		);
+
+		const swept = await sweepStaleDelegations(dir, 60_000);
 		expect(swept).toBe(1);
 		expect(findByCorrelationId(dir, 'ses_stale')?.status).toBe('stale');
 	});

--- a/tests/unit/background/task-envelope.test.ts
+++ b/tests/unit/background/task-envelope.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Issue #1151 PR 2 (Stage A) — task envelope parser tests.
+ */
+import { describe, expect, it } from 'bun:test';
+import {
+	extractDispatchIds,
+	parseTaskEnvelope,
+} from '../../../src/background/task-envelope';
+
+const runningEnvelope =
+	'<task id="ses_abc123" state="running">\n<summary>Background task started</summary>\n<task_result>...</task_result>\n</task>';
+const completedEnvelope =
+	'<task id="ses_abc123" state="completed">\n<summary>Background task completed: review</summary>\n<task_result>looks good</task_result>\n</task>';
+const errorEnvelope =
+	'<task id="ses_xyz" state="error">\n<task_error>boom</task_error>\n</task>';
+
+describe('parseTaskEnvelope', () => {
+	it('parses a running envelope', () => {
+		expect(parseTaskEnvelope(runningEnvelope)).toEqual({
+			sessionId: 'ses_abc123',
+			state: 'running',
+		});
+	});
+
+	it('parses completed and error envelopes', () => {
+		expect(parseTaskEnvelope(completedEnvelope)?.state).toBe('completed');
+		expect(parseTaskEnvelope(errorEnvelope)).toEqual({
+			sessionId: 'ses_xyz',
+			state: 'error',
+		});
+	});
+
+	it('returns null for non-envelope text', () => {
+		expect(parseTaskEnvelope('just some text')).toBeNull();
+		expect(parseTaskEnvelope('')).toBeNull();
+		expect(parseTaskEnvelope(undefined)).toBeNull();
+		expect(parseTaskEnvelope(null)).toBeNull();
+		expect(parseTaskEnvelope(42)).toBeNull();
+	});
+
+	it('rejects unknown state values (cannot masquerade as envelope)', () => {
+		expect(parseTaskEnvelope('<task id="x" state="bogus">')).toBeNull();
+	});
+
+	it('rejects empty id', () => {
+		expect(parseTaskEnvelope('<task id="" state="completed">')).toBeNull();
+	});
+});
+
+describe('extractDispatchIds', () => {
+	it('extracts jobId from metadata and sessionId from the dispatch envelope', () => {
+		const output = {
+			title: 'review',
+			output: runningEnvelope,
+			metadata: { background: true, jobId: 'job_999' },
+		};
+		expect(extractDispatchIds(output)).toEqual({
+			subagentSessionId: 'ses_abc123',
+			jobId: 'job_999',
+		});
+	});
+
+	it('falls back to jobId as correlation id when envelope is absent', () => {
+		const output = {
+			title: 'review',
+			output: 'no envelope here',
+			metadata: { background: true, jobId: 'job_only' },
+		};
+		expect(extractDispatchIds(output)).toEqual({
+			subagentSessionId: 'job_only',
+			jobId: 'job_only',
+		});
+	});
+
+	it('returns nulls when neither metadata.jobId nor envelope is present', () => {
+		expect(
+			extractDispatchIds({ title: 't', output: 'nothing', metadata: {} }),
+		).toEqual({ subagentSessionId: null, jobId: null });
+	});
+
+	it('parses a raw rendered string output', () => {
+		expect(extractDispatchIds(runningEnvelope)).toEqual({
+			subagentSessionId: 'ses_abc123',
+			jobId: null,
+		});
+	});
+
+	it('ignores a completed envelope at dispatch (only running is a dispatch)', () => {
+		const out = { output: completedEnvelope, metadata: {} };
+		expect(extractDispatchIds(out)).toEqual({
+			subagentSessionId: null,
+			jobId: null,
+		});
+	});
+
+	it('is defensive against non-object / null output', () => {
+		expect(extractDispatchIds(null)).toEqual({
+			subagentSessionId: null,
+			jobId: null,
+		});
+		expect(extractDispatchIds(123)).toEqual({
+			subagentSessionId: null,
+			jobId: null,
+		});
+	});
+});

--- a/tests/unit/hooks/delegation-gate-background-stage-a.test.ts
+++ b/tests/unit/hooks/delegation-gate-background-stage-a.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Issue #1151 PR 2 (Stage A) — delegation-gate background flag behavior.
+ *
+ * Flag OFF (default): PR 1 behavior preserved (toolBefore blocks; toolAfter bails, no record).
+ * Flag ON: background swarm dispatch is allowed; toolAfter records a durable pending
+ * delegation but NEVER advances workflow gates.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	findByCorrelationId,
+	readDelegations,
+} from '../../../src/background/pending-delegations';
+import type { PluginConfig } from '../../../src/config';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import {
+	ensureAgentSession,
+	getTaskState,
+	resetSwarmState,
+} from '../../../src/state';
+
+function makeConfig(backgroundEnabled: boolean): PluginConfig {
+	return {
+		max_iterations: 5,
+		qa_retry_limit: 3,
+		inject_phase_reminders: true,
+		hooks: {
+			system_enhancer: true,
+			compaction: true,
+			agent_activity: true,
+			delegation_tracker: false,
+			agent_awareness_max_chars: 300,
+			delegation_gate: true,
+			delegation_max_chars: 4000,
+			background_subagents: backgroundEnabled,
+			background_pending_timeout_minutes: 30,
+		},
+	} as PluginConfig;
+}
+
+function makeTempProject(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-bgsa-'));
+	const real = fs.realpathSync(dir);
+	fs.mkdirSync(path.join(real, '.swarm'), { recursive: true });
+	return real;
+}
+
+const runningDispatch = (id: string) => ({
+	title: 'review',
+	output: `<task id="${id}" state="running">\n<summary>Background task started</summary>\n</task>`,
+	metadata: { background: true, jobId: `job_${id}` },
+});
+
+describe('delegation-gate background flag (Stage A)', () => {
+	let dir: string;
+	beforeEach(() => {
+		resetSwarmState();
+		dir = makeTempProject();
+	});
+	afterEach(() => {
+		resetSwarmState();
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	// ── toolBefore: flag gates the PR 1 block ────────────────────────────────
+	it('flag OFF: toolBefore blocks background reviewer (PR 1 preserved)', async () => {
+		const hook = createDelegationGateHook(makeConfig(false), dir);
+		let threw = false;
+		try {
+			await hook.toolBefore(
+				{ tool: 'Task', sessionID: 's1', callID: 'c1' },
+				{ args: { subagent_type: 'reviewer', background: true } },
+			);
+		} catch {
+			threw = true;
+		}
+		expect(threw).toBe(true);
+	});
+
+	it('flag ON: toolBefore allows background reviewer dispatch', async () => {
+		const hook = createDelegationGateHook(makeConfig(true), dir);
+		let threw = false;
+		try {
+			await hook.toolBefore(
+				{ tool: 'Task', sessionID: 's1', callID: 'c1' },
+				{ args: { subagent_type: 'reviewer', background: true } },
+			);
+		} catch {
+			threw = true;
+		}
+		expect(threw).toBe(false);
+	});
+
+	// ── toolAfter: flag ON records pending, never advances gates ──────────────
+	it('flag ON: toolAfter records a pending delegation and does NOT advance Stage B', async () => {
+		const hook = createDelegationGateHook(makeConfig(true), dir);
+		const session = ensureAgentSession('s2');
+		session.taskWorkflowStates.set('1.1', 'coder_delegated');
+		session.currentTaskId = '1.1';
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 's2',
+				callID: 'c2',
+				args: { subagent_type: 'reviewer', background: true },
+			},
+			runningDispatch('ses_corr'),
+		);
+
+		// No gate advancement.
+		expect(getTaskState(session, '1.1')).toBe('coder_delegated');
+		// Durable pending record written.
+		const rec = findByCorrelationId(dir, 'ses_corr');
+		expect(rec?.status).toBe('pending');
+		expect(rec?.normalizedAgent).toBe('reviewer');
+		expect(rec?.parentSessionId).toBe('s2');
+		expect(rec?.jobId).toBe('job_ses_corr');
+	});
+
+	it('flag ON: prefixed swarm agent records normalized role', async () => {
+		const hook = createDelegationGateHook(makeConfig(true), dir);
+		const session = ensureAgentSession('s3');
+		session.taskWorkflowStates.set('2.1', 'coder_delegated');
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 's3',
+				callID: 'c3',
+				args: { subagent_type: 'mega_reviewer', background: true },
+			},
+			runningDispatch('ses_pref'),
+		);
+
+		const rec = findByCorrelationId(dir, 'ses_pref');
+		expect(rec?.normalizedAgent).toBe('reviewer');
+		expect(rec?.swarmPrefixedAgent).toBe('mega_reviewer');
+	});
+
+	it('flag ON: no correlation id → no orphan record, no throw, no advancement', async () => {
+		const hook = createDelegationGateHook(makeConfig(true), dir);
+		const session = ensureAgentSession('s4');
+		session.taskWorkflowStates.set('3.1', 'coder_delegated');
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 's4',
+				callID: 'c4',
+				args: { subagent_type: 'reviewer', background: true },
+			},
+			// background detectable via args, but no envelope and no jobId → unkeyable
+			{ title: 't', output: 'no envelope', metadata: { background: true } },
+		);
+
+		expect(getTaskState(session, '3.1')).toBe('coder_delegated');
+		expect(readDelegations(dir)).toHaveLength(0);
+	});
+
+	// ── toolAfter: flag OFF preserves PR 1 (defensive bail, no record) ────────
+	it('flag OFF: toolAfter background bails with no record (PR 1 behavior)', async () => {
+		const hook = createDelegationGateHook(makeConfig(false), dir);
+		const session = ensureAgentSession('s5');
+		session.taskWorkflowStates.set('4.1', 'coder_delegated');
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 's5',
+				callID: 'c5',
+				args: { subagent_type: 'reviewer', background: true },
+			},
+			runningDispatch('ses_off'),
+		);
+
+		expect(getTaskState(session, '4.1')).toBe('coder_delegated');
+		expect(readDelegations(dir)).toHaveLength(0);
+	});
+
+	// ── Regression: foreground still advances under both flag states ─────────
+	it('flag ON: foreground reviewer still advances coder_delegated -> reviewer_run', async () => {
+		const hook = createDelegationGateHook(makeConfig(true), dir);
+		const session = ensureAgentSession('s6');
+		session.taskWorkflowStates.set('5.1', 'coder_delegated');
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 's6',
+				callID: 'c6',
+				args: { subagent_type: 'reviewer' },
+			},
+			{ state: 'completed', text: 'done' },
+		);
+
+		expect(getTaskState(session, '5.1')).toBe('reviewer_run');
+		expect(readDelegations(dir)).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
Part of #1151 (PR 2, Stage A). Follow-up to the merged PR 1 fail-closed guard (#1160).

## Summary

OpenCode v1.16.2 background subagents (`Task` with `background=true`) return a running placeholder and complete later via a synthetic parent message. PR 1 fail-closed-blocked them. This PR adds the **safe, reversible, opt-in foundation** for supporting them — durable dispatch tracking + a runtime completion observer — **with no gate effects**.

The trusted completion signal is confirmed in upstream source (a `synthetic:true` part carrying a stable `<task id="…" state="completed|error">` envelope, with `jobId`/subagent-session correlation), but **not yet verifiable at runtime** in the pinned SDK, and the "parent-session-gone at completion" case is unresolved. Per the issue's guardrail and an independent plan critic, gate-affecting completion ingestion is deferred to **Stage B** (a separate PR), gated on runtime confirmation produced by the observer this PR adds.

New opt-in config (under `hooks`, **default off** → PR 1 behavior unchanged):
- `background_subagents` — when true, background swarm `Task` dispatch is allowed and tracked.
- `background_pending_timeout_minutes` (default 30) — bounded lifetime for unresolved pendings.

When enabled:
- `delegation-gate.ts` no longer blocks background swarm dispatch; `tool.execute.after` records a **durable pending delegation** in an append-only `.swarm/background-delegations.jsonl` store (`src/background/pending-delegations.ts`: `validateSwarmPath`-contained, evidence-lock serialized, malformed-line tolerant) and returns **before any Stage B / gate-evidence code** — no workflow gate advances.
- A new read-only `event`-hook observer (`src/background/completion-observer.ts`) watches for the trusted `synthetic` task envelope (`src/background/task-envelope.ts`) and logs correlation under `OPENCODE_SWARM_DEBUG` only.
- A lazy stale sweep (on dispatch — no plugin-init cost) transitions unresolved pendings to `stale`.

If a dispatch yields no usable correlation id (no `jobId` and no parseable envelope), no orphan record is written.

## Invariant audit

- **1. Plugin init fast/bounded** — touched. No init-time disk I/O; the stale sweep is lazy on dispatch; observer construction is a pure closure. Evidence: `index.ts` instantiation is a closure; sweep runs inside `recordPendingDelegation`.
- **4. `.swarm/` containment** — touched. New durable store path goes through `validateSwarmPath`; covered by `tests/unit/background/pending-delegations.test.ts` (containment + missing-file + malformed-line).
- **7. Test writing** — touched. New `bun:test` suites; no `mock.module`; positive/negative/adversarial (synthetic trust gate, malformed lines, completed-at-dispatch rejection, concurrent appends, no-orphan).
- **8. Session/global state** — touched. Pending correlation is durable + session-scoped (parentSessionId/subagentSessionId); flag-off path unchanged.
- **10. Chat/system message** — touched. Observer is read-only and logs only under `OPENCODE_SWARM_DEBUG`; the new `event` hook is `safeHook`-wrapped (never blocks delivery/load).
- **11. Tool/agent registration** — not touched (no map/registration changes).

Gate-safety (the load-bearing property): an independent adversarial reviewer confirmed no background path (dispatch or completion) reaches `recordStageBCompletion`/`advanceTaskState`/`recordGateEvidence`; the toolAfter background branch ends in an unconditional `return` before the Stage B code for both flag states, and `src/background/` has zero references to gate/evidence mutators.

## Test plan

All run with `bun --smol test … --timeout 30000` (Invariant 6), files run individually (combined directory runs can hang due to pre-existing bun:test cross-file behavior):
- `tests/unit/background/task-envelope.test.ts` → 11 pass / 0 fail
- `tests/unit/background/pending-delegations.test.ts` → 8 pass / 0 fail (incl. concurrency, malformed-line, stale sweep, folding)
- `tests/unit/background/completion-observer.test.ts` → 6 pass / 0 fail (trust gate, observe-only, malformed events)
- `tests/unit/hooks/delegation-gate-background-stage-a.test.ts` → 7 pass / 0 fail (flag-off==PR1, flag-on records-but-no-advance, no-orphan, foreground regression)
- `tests/unit/hooks/delegation-gate-background-task.test.ts` (PR 1, flag-off default) → 13 pass / 0 fail
- Regression: `tests/unit/hooks/delegation-gate.test.ts` → 100 pass / 0 fail; `src/hooks/delegation-gate.evidence.test.ts` → 18 pass / 0 fail
- `bun run typecheck` → EXIT 0; `biome check` (changed files) → clean; `git diff --check` → clean

Independent adversarial implementation review: APPROVE (no required changes). Not validated at runtime: the live OpenCode background-subagent completion signal — Stage A intentionally exists to capture it observationally before Stage B builds on it.

https://claude.ai/code/session_01Q1o4W7kBqRaxghSnBeFZme

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1o4W7kBqRaxghSnBeFZme)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in durable tracking for background subagent dispatches and a read-only completion observer; Stage A for #1151 with no workflow gate effects. Off by default; enable with `hooks.background_subagents: true` and `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true`.

- **New Features**
  - `hooks.background_subagents` (default false): allow and track background swarm `Task` dispatches; no gate advancement.
  - Durable store `.swarm/background-delegations.jsonl`: append-only, evidence-locked, path-contained; fold reads are O(lines); stale sweep via `hooks.background_pending_timeout_minutes` (default 30) marks overdue `pending` as `stale`.
  - Read-only `event` observer: trusts only `synthetic` `<task id="…" state="completed|error">` parts; logs under `OPENCODE_SWARM_DEBUG`; never mutates state.
  - Gate safety: `tool.execute.after` records and returns before Stage B; if no `jobId`/envelope, nothing is written.

- **Bug Fixes**
  - Made the stale-sweep test deterministic (backdated record) and documented read-fold cost; no behavior changes.

<sup>Written for commit 11a4d9489d213dd28c3aa0e96b2207caf0c66536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

