### PR TITLE
feat(turbo): git worktree isolation for parallel lean turbo lanes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -506,8 +506,10 @@ Lean Turbo is a lane-planning execution strategy that partitions phase tasks int
 | `integrated_diff_required` | boolean | `true` | Require an integrated diff before accepting changes from a lane. Ensures cross-lane file changes are coherent. |
 | `allow_docs_only_without_reviewer` | boolean | `false` | Allow docs-only phases to complete when the reviewer agent is not available. |
 | `worktree_isolation` | boolean | `false` | Use git worktree isolation for parallel coders to enable true file-system-level parallelism. |
+| `merge_strategy` | `"merge" \| "rebase" \| "cherry-pick"` | `"merge"` | Branch merge strategy after lane worktree completion. Controls how completed lane branches are merged back into the main branch. |
+| `worktree_dir` | string | _(none)_ | Optional user-specified worktree directory override. When set, worktrees are created under this path instead of the default `.swarm-worktrees/<sessionId>/<laneId>`. Accepts absolute and relative paths (relative paths are resolved against the project root). |
 
-**Example** — Enable Lean Turbo with defaults:
+**Example** — Enable Lean Turbo with worktree isolation and rebase strategy:
 
 ```json
 {
@@ -522,7 +524,9 @@ Lean Turbo is a lane-planning execution strategy that partitions phase tasks int
       "phase_critic": true,
       "integrated_diff_required": true,
       "allow_docs_only_without_reviewer": false,
-      "worktree_isolation": false
+      "worktree_isolation": true,
+      "merge_strategy": "rebase",
+      "worktree_dir": ".worktrees"
     }
   }
 }

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -344,6 +344,23 @@ interface LeanTurboLanePlan {
 // isGlobalFile(normalizedPath) → boolean
 // isProtectedPath(normalizedPath) → boolean
 // readTaskScopes(directory, taskId) → string[] | null (reads .swarm/scopes/scope-{taskId}.json)
+
+// src/turbo/lean/worktree.ts
+// provisionWorktree(laneId, branchName, baseBranch, config) → Promise<WorktreeResult>
+// removeWorktree(laneId) → Promise<void>
+// assertCleanWorkingTree() → void (throws if dirty)
+// isCleanWorktree() → Promise<boolean>
+// autoCommitDirty(message) → Promise<string> (returns commit hash)
+// cleanUntrackedFiles() → Promise<void>
+
+// src/turbo/lean/merge-back.ts
+// getMergeStrategy(config) → 'merge' | 'rebase' | 'cherry-pick'
+// mergeLaneBranch(laneId, strategy) → Promise<MergeSuccess | MergeFailure | MergeConflict>
+// postMergeCleanup(laneId) → Promise<CleanupSuccess | CleanupFailure>
+// handleMergeConflict(conflictInfo) → Promise<ConflictHandlingError | null>
+// attemptMergeBackFromDirty(laneId, strategy) → Promise<DirtyMergeSuccess | DirtyMergeFailure | DirtyMergePartial>
+// cleanupOrphanedBranches() → Promise<OrphanCleanupResult>
+// startupOrphanRecovery() → Promise<StartupRecoveryResult>
 ```
 
 ### Commands

--- a/docs/releases/pending/lean-turbo-worktree-isolation.md
+++ b/docs/releases/pending/lean-turbo-worktree-isolation.md
@@ -1,0 +1,55 @@
+### feat(turbo): git worktree isolation for parallel Lean Turbo lanes
+
+**What changed**
+
+Implements complete git worktree isolation for Lean Turbo parallel lane execution, enabling each coder lane to work in its own isolated git worktree with independent branches. Merges completed lane work back to the primary tree with conflict handling, dirty-tree recovery, and Windows filesystem safety.
+
+- **New `src/turbo/lean/worktree.ts`** — worktree lifecycle (create, provision, remove) with:
+  - `assertCleanWorkingTree()` — verifies HEAD is clean before provisioning
+  - `provisionWorktreeForLane()` — creates worktree + branch per lane with Windows path budget (250 chars, auto-shorten to `swwt` prefix)
+  - `checkPathBudget()` — respects `core.longpaths` git config (skips budget when enabled)
+  - `cleanUntrackedFiles()` — safe cleanup with dry-run safety gate and `SAFE_CLEAN_PATTERNS` allowlist
+  - `_internals` DI seam for test isolation
+
+- **New `src/turbo/lean/merge-back.ts`** — merge-back strategies with conflict handling:
+  - `mergeToPrimary()` — merge, rebase, or cherry-pick with full `merge-base` range (not tip-only)
+  - `attemptMergeBackFromDirty()` — auto-commit + clean + merge for dirty worktrees
+  - `cleanupOrphanedBranches()` / `startupOrphanRecovery()` — stale branch/worktree cleanup
+  - `_internals` DI seam for test isolation
+
+- **Runner integration** (`src/turbo/lean/runner.ts`):
+  - `assertCleanWorkingTree` guard in `runPhase` — dirty tree degrades all lanes to shared directory
+  - Explicit lane failure on worktree provision failure (no silent degradation)
+  - `MergeBackFailureInfo` type with `mergeBackFailure` on `LaneResult` — surfaces conflicts/errors to callers
+  - `postMergeCleanup` (branch delete + prune) runs AFTER `removeWorktree` — git refuses branch deletion on active worktrees
+  - `_sequentialWorktreeCleanup` with correct merge → remove → cleanup order
+  - Transient retry for Windows file-lock failures (EBUSY, EPERM, ENOENT, ETIMEDOUT) — 4 attempts, 2s delay
+  - `_internals` DI seam for `assertCleanWorkingTree` and `bunSpawn`
+
+- **Config schema** (`src/config/schema.ts`, `src/config/constants.ts`):
+  - `worktree_dir` and `merge_strategy` options for Lean Turbo config
+  - `DEFAULT_LEAN_TURBO_CONFIG` defaults
+
+- **Guardrails** (`src/hooks/guardrails.ts`): blocks `git worktree remove --force`
+
+- **State** (`src/turbo/lean/state.ts`): `worktreePath`, `branchName`, `_failureCleanupPending` on `LeanTurboLane`
+
+- **Tool response** (`src/tools/lean-turbo-run-phase.ts`): `mergeBackFailures` propagated through `LeanTurboRunPhaseResult`
+
+**Why**
+
+Parallel Lean Turbo lanes sharing a single directory cause file conflicts, race conditions, and merge headaches. Worktree isolation gives each lane its own filesystem sandbox while preserving the ability to merge results back.
+
+**Migration**
+
+No migration required. Worktree isolation is active when Lean Turbo is enabled. New config options:
+- `lean_turbo.worktree_dir` — override worktree parent directory (default: `<project>/.swarm-worktrees`)
+- `lean_turbo.merge_strategy` — `"merge"` (default), `"rebase"`, or `"cherry-pick"`
+
+**Known caveats**
+
+- `cleanUntrackedFiles` uses a fail-open pattern: if the dry-run safety gate fails, the clean proceeds (acceptable for ephemeral worktrees)
+- Sequential worktree cleanup is O(N) with potential 2s retry delays per lane on Windows
+- Cherry-pick tip-only fallback applies only to unrelated histories (no common ancestor)
+
+**Tests**: 282 dedicated tests across 9 files + 445 existing lean turbo tests.

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -509,7 +509,7 @@ Behavioral changes:
 /**
  * Canonical default Lean Turbo configuration.
  *
- * This is the single source of truth for all 9 LeanTurboConfig fields.
+ * This is the single source of truth for all LeanTurboConfig fields.
  * Consumers MUST reference this constant instead of hardcoding their own
  * defaults — see v7.4.x config-drift fix (3 of 9 fields disagreed across
  * runner.ts, lean-turbo-plan-lanes.ts, lean-turbo-status.ts, and the
@@ -525,6 +525,8 @@ export const DEFAULT_LEAN_TURBO_CONFIG: LeanTurboConfig = {
 	integrated_diff_required: true,
 	allow_docs_only_without_reviewer: false,
 	worktree_isolation: false,
+	merge_strategy: 'merge' as const,
+	worktree_dir: undefined,
 };
 
 export const LEAN_TURBO_BANNER = `## 🛤️ LEAN TURBO ACTIVE

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1478,14 +1478,15 @@ export const LeanTurboConfigSchema = z.object({
 	integrated_diff_required: z.boolean().default(true),
 	/** Allow docs-only phases when reviewer is not available. */
 	allow_docs_only_without_reviewer: z.boolean().default(false),
-	/** Use worktree isolation for parallel coders. NOT YET IMPLEMENTED — must be false. */
-	worktree_isolation: z
-		.boolean()
-		.default(false)
-		.refine((val) => val === false, {
-			message:
-				'worktree_isolation: true is not yet implemented. Use false (the default) for in-repo parallel execution. Full worktree isolation will be available in a future release.',
-		}),
+	/** Use worktree isolation for parallel coders. When true, each lane gets its own worktree. */
+	worktree_isolation: z.boolean().default(false),
+	/** Branch merge strategy after lane worktree completion. */
+	merge_strategy: z
+		.enum(['merge', 'rebase', 'cherry-pick'])
+		.default('merge')
+		.optional(),
+	/** Optional user-specified worktree directory override. */
+	worktree_dir: z.string().optional(),
 });
 
 export type LeanTurboConfig = z.infer<typeof LeanTurboConfigSchema>;

--- a/src/tools/lean-turbo-run-phase.ts
+++ b/src/tools/lean-turbo-run-phase.ts
@@ -7,7 +7,7 @@ import type { ToolDefinition } from '@opencode-ai/plugin/tool';
 import { z } from 'zod';
 import { loadPluginConfigWithMeta as loadPluginConfigWithMeta_import } from '../config';
 import { swarmState } from '../state';
-import type { LaneResult } from '../turbo/lean/runner';
+import type { LaneResult, MergeBackFailureInfo } from '../turbo/lean/runner';
 import { LeanTurboRunner as LeanTurboRunner_import } from '../turbo/lean/runner';
 import { createSwarmTool } from './create-tool';
 
@@ -28,6 +28,7 @@ export interface LeanTurboRunPhaseResult {
 	lanes?: LaneResult[];
 	degradedTasks?: string[];
 	serializedTasks?: string[];
+	mergeBackFailures?: MergeBackFailureInfo[];
 	reason?: string;
 	errors?: string[];
 }
@@ -56,6 +57,7 @@ export async function executeLeanTurboRunPhase(
 		lanes?: LaneResult[];
 		degradedTasks?: string[];
 		serializedTasks?: string[];
+		mergeBackFailures?: MergeBackFailureInfo[];
 		reason?: string;
 	} | null = null;
 	let runError: Error | null = null;
@@ -110,6 +112,7 @@ export async function executeLeanTurboRunPhase(
 		lanes: runResult!.lanes,
 		degradedTasks: runResult!.degradedTasks,
 		serializedTasks: runResult!.serializedTasks,
+		mergeBackFailures: runResult!.mergeBackFailures,
 		reason: runResult!.reason,
 	};
 }

--- a/src/turbo/lean/index.ts
+++ b/src/turbo/lean/index.ts
@@ -16,6 +16,7 @@ export type {
 	LaneResult,
 	LaneStatus,
 	LeanTurboPhaseResult,
+	MergeBackFailureInfo,
 } from './runner';
 export { LeanTurboRunner } from './runner';
 
@@ -107,3 +108,43 @@ export type {
 	PhaseReviewerResult,
 } from './reviewer';
 export { dispatchPhaseReviewer } from './reviewer';
+
+// ─── Worktree lifecycle (Phase 1) ────────────────────────────────────────
+
+export {
+	_internals as worktreeInternals,
+	assertCleanWorkingTree,
+	autoCommitDirty,
+	cleanUntrackedFiles,
+	isCleanWorktree,
+	provisionWorktree,
+	removeWorktree,
+} from './worktree';
+
+// ─── Merge-back operations (Phase 2) ─────────────────────────────────────
+
+export type {
+	CleanupFailure,
+	CleanupSuccess,
+	ConflictHandlingError,
+	ConflictInfo,
+	DirtyMergeFailure,
+	DirtyMergePartial,
+	DirtyMergeSuccess,
+	MergeConflict,
+	MergeFailure,
+	MergeSuccess,
+	OrphanCleanupResult,
+	StartupRecoveryResult,
+} from './merge-back';
+
+export {
+	_internals as mergeBackInternals,
+	attemptMergeBackFromDirty,
+	cleanupOrphanedBranches,
+	getMergeStrategy,
+	handleMergeConflict,
+	mergeLaneBranch,
+	postMergeCleanup,
+	startupOrphanRecovery,
+} from './merge-back';

--- a/src/turbo/lean/merge-back.ts
+++ b/src/turbo/lean/merge-back.ts
@@ -1,0 +1,630 @@
+/**
+ * Merge-back operations for lean turbo parallel lanes.
+ *
+ * Provides four public functions for merging lane branches back into
+ * the primary worktree, cleaning up lane branches, and handling merge
+ * conflicts. All subprocess calls go through the `_internals` DI seam
+ * so tests can replace the real `bunSpawn` without leaking across Bun's
+ * shared test-runner process.
+ *
+ * @module merge-back
+ */
+
+import type { LeanTurboConfig } from '../../config/schema';
+import { bunSpawn } from '../../utils/bun-compat';
+import { autoCommitDirty, cleanUntrackedFiles } from './worktree';
+
+// ---------------------------------------------------------------------------
+// _internals DI seam
+// ---------------------------------------------------------------------------
+
+/**
+ * Test-only dependency-injection seam. Production code calls
+ * `_internals.bunSpawn(...)` so tests can replace the function on this object
+ * without touching the real `../../utils/bun-compat` module — `mock.module`
+ * from `bun:test` leaks across files in Bun's shared test-runner process,
+ * which would corrupt unrelated suites that import `bun-compat`. Mutating this
+ * local object is file-scoped and trivially restorable via `afterEach`.
+ */
+export const _internals: {
+	bunSpawn: typeof bunSpawn;
+	/** Test seam for process.platform — allows non-Windows CIs to exercise Windows paths. */
+	platform: string;
+	/** Test seam for sleep — allows tests to skip real delays. */
+	sleep: (ms: number) => Promise<void>;
+} = {
+	bunSpawn,
+	platform: process.platform,
+	sleep: (ms: number) =>
+		new Promise<void>((resolve) => setTimeout(resolve, ms)),
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface GitResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+/** Default timeout for git merge-back operations (30 seconds). */
+const MERGE_TIMEOUT_MS = 30_000;
+
+/**
+ * Runs a git command via `_internals.bunSpawn` and returns the exit code,
+ * captured stdout, and captured stderr.
+ *
+ * Every call uses:
+ * - Array-form command (never shell-string)
+ * - Explicit `cwd`
+ * - `stdin: 'ignore'` (prevents Bun/Windows pipe hangs)
+ * - `env: { LC_ALL: 'C' }` (ensures locale-independent English output)
+ * - Bounded `timeout`
+ * - Best-effort `proc.kill()` in `finally`
+ */
+async function runGit(
+	args: string[],
+	cwd: string,
+	timeoutMs = MERGE_TIMEOUT_MS,
+): Promise<GitResult> {
+	const proc = _internals.bunSpawn(['git', ...args], {
+		cwd,
+		timeout: timeoutMs,
+		stdin: 'ignore' as const,
+		stdout: 'pipe' as const,
+		stderr: 'pipe' as const,
+		env: { ...process.env, LC_ALL: 'C' },
+	});
+	try {
+		const exitCode = await proc.exited;
+		const stdout = await proc.stdout.text();
+		const stderr = await proc.stderr.text();
+		return { exitCode, stdout, stderr };
+	} finally {
+		try {
+			proc.kill();
+		} catch {
+			// best-effort — process may already be exited
+		}
+	}
+}
+
+/**
+ * Parses conflicted file names from git merge/rebase/cherry-pick output.
+ * Looks for lines matching "CONFLICT (content) Merge conflict in <path>"
+ * and extracts the file path.
+ */
+function parseConflictFiles(output: string): string[] {
+	const files: string[] = [];
+	const lines = output.split('\n');
+	for (const line of lines) {
+		const match = line.match(/CONFLICT\b.*(?:Merge conflict in |in )(.+)/);
+		if (match?.[1]) {
+			files.push(match[1].trim());
+		}
+	}
+	return files;
+}
+
+// ---------------------------------------------------------------------------
+// Return-type interfaces
+// ---------------------------------------------------------------------------
+
+export interface MergeSuccess {
+	merged: true;
+	strategy: string;
+}
+
+export interface MergeConflict {
+	conflict: true;
+	files: string[];
+	message: string;
+}
+
+export interface MergeFailure {
+	error: string;
+}
+
+export interface CleanupSuccess {
+	cleaned: true;
+}
+
+export interface CleanupFailure {
+	error: string;
+	partial?: boolean;
+}
+
+export interface ConflictInfo {
+	files: string[];
+	message: string;
+	aborted: true;
+}
+
+export interface ConflictHandlingError {
+	error: string;
+	aborted: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Progressive dirty-cleanup merge-back return types (DD-7)
+// ---------------------------------------------------------------------------
+
+export interface DirtyMergeSuccess {
+	merged: true;
+	strategy: string;
+	autoCommitted: boolean;
+	cleaned: boolean;
+}
+
+export interface DirtyMergePartial {
+	partial: true;
+	stage: string;
+	autoCommitted: boolean;
+	cleaned: boolean;
+	message: string;
+}
+
+export interface DirtyMergeFailure {
+	failed: true;
+	stage: string;
+	message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Orphaned branch cleanup return types
+// ---------------------------------------------------------------------------
+
+export interface OrphanCleanupResult {
+	removed: string[];
+	skipped: string[];
+	errors: Array<{ branch: string; error: string }>;
+}
+
+export interface StartupRecoveryResult {
+	prunedWorktrees: boolean;
+	remainingBranches: string[];
+	warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Exported functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads the merge strategy from the lean turbo configuration.
+ *
+ * Returns `config.merge_strategy` if set, otherwise defaults to `'merge'`.
+ * This is a pure function — no subprocess calls.
+ *
+ * @param config - Lean turbo configuration.
+ * @returns The merge strategy to use: `'merge'`, `'rebase'`, or `'cherry-pick'`.
+ */
+export function getMergeStrategy(
+	config: LeanTurboConfig,
+): 'merge' | 'rebase' | 'cherry-pick' {
+	return config.merge_strategy ?? 'merge';
+}
+
+/**
+ * Merges a lane branch back into the primary worktree using the specified
+ * strategy.
+ *
+ * On conflict, automatically aborts the in-progress merge/rebase/cherry-pick
+ * to restore the working tree to a clean state, then returns conflict details.
+ *
+ * @param primaryDir - The main project root (cwd for all git commands).
+ * @param branchName - The lane branch name (e.g. `swarm-lane/<sessionId>/<laneId>`).
+ * @param strategy   - Merge strategy to use.
+ * @returns Discriminated union: success, conflict, or failure.
+ */
+export async function mergeLaneBranch(
+	primaryDir: string,
+	branchName: string,
+	strategy: 'merge' | 'rebase' | 'cherry-pick',
+): Promise<MergeSuccess | MergeConflict | MergeFailure> {
+	let result: GitResult;
+
+	switch (strategy) {
+		case 'merge':
+			result = await runGit(['merge', '--no-edit', branchName], primaryDir);
+			break;
+		case 'rebase':
+			result = await runGit(['rebase', branchName], primaryDir);
+			break;
+		case 'cherry-pick': {
+			// Cherry-pick the full commit range, not just the tip.
+			// Find the merge-base between HEAD and the lane branch so we can
+			// replay every commit on the lane since it diverged.
+			const mergeBaseResult = await runGit(
+				['merge-base', 'HEAD', branchName],
+				primaryDir,
+			);
+			if (mergeBaseResult.exitCode === 0 && mergeBaseResult.stdout.trim()) {
+				const mergeBase = mergeBaseResult.stdout.trim();
+				result = await runGit(
+					['cherry-pick', `${mergeBase}..${branchName}`],
+					primaryDir,
+				);
+			} else {
+				// No common ancestor (e.g. unrelated histories) — fall back
+				// to cherry-picking just the branch tip with a warning.
+				console.warn(
+					'[lean-turbo] mergeLaneBranch: git merge-base failed for cherry-pick; falling back to tip-only cherry-pick',
+				);
+				result = await runGit(['cherry-pick', branchName], primaryDir);
+			}
+			break;
+		}
+	}
+
+	if (result.exitCode === 0) {
+		return { merged: true, strategy };
+	}
+
+	const combinedOutput = `${result.stderr}\n${result.stdout}`;
+	const hasConflict =
+		/CONFLICT/i.test(combinedOutput) || /conflict/i.test(combinedOutput);
+
+	if (hasConflict) {
+		// Parse conflicted files from output
+		const files = parseConflictFiles(combinedOutput);
+
+		// Abort the in-progress merge/rebase/cherry-pick to restore clean state
+		const abortArgs =
+			strategy === 'rebase'
+				? ['rebase', '--abort']
+				: strategy === 'cherry-pick'
+					? ['cherry-pick', '--abort']
+					: ['merge', '--abort'];
+		await runGit(abortArgs, primaryDir);
+
+		return {
+			conflict: true,
+			files,
+			message: result.stderr.trim(),
+		};
+	}
+
+	return {
+		error: result.stderr.trim() || result.stdout.trim(),
+	};
+}
+
+/**
+ * Cleans up a lane branch after a successful merge.
+ *
+ * Deletes the lane branch and prunes stale worktree metadata (DD-9).
+ * Reports partial success if branch deletion fails but worktree prune succeeds.
+ *
+ * @param directory  - The project root (cwd for git commands).
+ * @param branchName - The lane branch name to delete.
+ * @returns Discriminated union: success, partial failure, or full failure.
+ */
+export async function postMergeCleanup(
+	directory: string,
+	branchName: string,
+): Promise<CleanupSuccess | CleanupFailure> {
+	// Delete the lane branch (DD-9)
+	const deleteResult = await runGit(['branch', '-D', branchName], directory);
+	const deleteOk = deleteResult.exitCode === 0;
+
+	// Prune stale worktree metadata (DD-9)
+	const pruneResult = await runGit(['worktree', 'prune'], directory);
+	const pruneOk = pruneResult.exitCode === 0;
+
+	if (deleteOk && pruneOk) {
+		return { cleaned: true };
+	}
+
+	if (!deleteOk && pruneOk) {
+		return {
+			error: `Branch delete failed: ${deleteResult.stderr.trim() || deleteResult.stdout.trim()}`,
+			partial: true,
+		};
+	}
+
+	return {
+		error: deleteOk
+			? `Worktree prune failed: ${pruneResult.stderr.trim() || pruneResult.stdout.trim()}`
+			: `Branch delete failed: ${deleteResult.stderr.trim() || deleteResult.stdout.trim()}; worktree prune failed: ${pruneResult.stderr.trim() || pruneResult.stdout.trim()}`,
+	};
+}
+
+/**
+ * Handles a merge conflict by listing conflicted files and aborting the
+ * in-progress operation to restore the working tree to a clean state.
+ *
+ * Uses a strategy-specific abort command so the correct git sub-command
+ * is invoked (`merge --abort`, `rebase --abort`, or `cherry-pick --abort`).
+ * Using the wrong abort command would leave the repository in a dirty state.
+ *
+ * @param primaryDir - The main project root (cwd for all git commands).
+ * @param branchName - The lane branch name that caused the conflict.
+ *   Retained for logging and future conflict-reporting use.
+ * @param strategy - The merge strategy that is currently in progress.
+ * @returns Discriminated union: conflict info or handling error.
+ */
+export async function handleMergeConflict(
+	primaryDir: string,
+	_branchName: string,
+	strategy: 'merge' | 'rebase' | 'cherry-pick',
+): Promise<ConflictInfo | ConflictHandlingError> {
+	const abortArgs =
+		strategy === 'rebase'
+			? ['rebase', '--abort']
+			: strategy === 'cherry-pick'
+				? ['cherry-pick', '--abort']
+				: ['merge', '--abort'];
+
+	// List conflicted files
+	const diffResult = await runGit(
+		['diff', '--name-only', '--diff-filter=U'],
+		primaryDir,
+	);
+
+	if (diffResult.exitCode !== 0) {
+		// Attempt abort anyway using the correct strategy
+		const abortResult = await runGit(abortArgs, primaryDir);
+		return {
+			error: `Failed to list conflicted files: ${diffResult.stderr.trim() || diffResult.stdout.trim()}`,
+			aborted: abortResult.exitCode === 0,
+		};
+	}
+
+	const files = diffResult.stdout
+		.trim()
+		.split('\n')
+		.filter((f) => f.length > 0);
+
+	// Abort the in-progress operation using the correct strategy
+	const abortResult = await runGit(abortArgs, primaryDir);
+
+	if (abortResult.exitCode === 0) {
+		return {
+			files,
+			message: `Conflicts detected in ${files.length} file(s): ${files.join(', ')}`,
+			aborted: true,
+		};
+	}
+
+	return {
+		error: `${strategy} abort failed: ${abortResult.stderr.trim() || abortResult.stdout.trim()}`,
+		aborted: false,
+	};
+}
+
+/**
+ * Attempts to merge a lane branch back from a potentially dirty worktree
+ * using progressive cleanup (DD-7).
+ *
+ * Pipeline:
+ * 1. Auto-commit dirty state in the worktree
+ * 2. Clean untracked files
+ * 3. Attempt the merge-back
+ *
+ * Each step is fault-tolerant: failures log a warning and continue.
+ * Only when both auto-commit AND clean fail (not just skip) does the
+ * pipeline abandon early with `{ failed: true, stage: 'cleanup' }`.
+ *
+ * @param worktreePath - Absolute path to the lane worktree directory.
+ * @param branchName   - The lane branch name (e.g. `swarm-lane/<sessionId>/<laneId>`).
+ * @param primaryDir   - The main project root (cwd for merge commands).
+ * @param strategy     - Merge strategy to use.
+ * @returns Discriminated union: success, partial, or failure.
+ */
+export async function attemptMergeBackFromDirty(
+	worktreePath: string,
+	branchName: string,
+	primaryDir: string,
+	strategy: 'merge' | 'rebase' | 'cherry-pick',
+): Promise<DirtyMergeSuccess | DirtyMergePartial | DirtyMergeFailure> {
+	let autoCommitted = false;
+	let cleaned = false;
+	let autoCommitFailed = false;
+	let cleanFailed = false;
+
+	// Step 1: Auto-commit dirty state
+	const commitResult = await autoCommitDirty(worktreePath);
+	if (commitResult.committed) {
+		autoCommitted = true;
+	} else if (commitResult.reason !== 'Nothing to commit') {
+		autoCommitFailed = true;
+		console.warn(
+			`[lean-turbo] attemptMergeBackFromDirty: auto-commit failed for worktree "${worktreePath}" branch "${branchName}": ${commitResult.reason}`,
+		);
+	}
+
+	// Step 2: Clean untracked files
+	const cleanResult = await cleanUntrackedFiles(worktreePath);
+	if (cleanResult.cleaned) {
+		cleaned = true;
+	} else {
+		cleanFailed = true;
+		console.warn(
+			`[lean-turbo] attemptMergeBackFromDirty: clean untracked failed for worktree "${worktreePath}" branch "${branchName}": ${cleanResult.error}`,
+		);
+	}
+
+	// Step 3a: Abandon if both auto-commit AND clean truly failed
+	if (autoCommitFailed && cleanFailed) {
+		return {
+			failed: true,
+			stage: 'cleanup',
+			message: 'Auto-commit and clean both failed; abandoning worktree',
+		};
+	}
+
+	// Step 3b: Attempt merge-back
+	const mergeResult = await mergeLaneBranch(primaryDir, branchName, strategy);
+
+	if ('merged' in mergeResult && mergeResult.merged) {
+		return { merged: true, strategy, autoCommitted, cleaned };
+	}
+
+	if ('conflict' in mergeResult) {
+		return {
+			partial: true,
+			stage: 'merge',
+			autoCommitted,
+			cleaned,
+			message: mergeResult.message,
+		};
+	}
+
+	// MergeFailure case — narrowed from the union by eliminating success and conflict
+	if ('error' in mergeResult) {
+		return {
+			failed: true,
+			stage: 'merge',
+			message: mergeResult.error,
+		};
+	}
+
+	// Fallback (should not reach here)
+	return {
+		failed: true,
+		stage: 'merge',
+		message: 'Merge failed with unexpected result',
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Orphaned branch cleanup
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the session ID from a swarm-lane branch name.
+ *
+ * Branch format: `swarm-lane/<sessionId>/<laneId>`
+ * Returns the sessionId (second segment), or `null` if the name does not
+ * match the expected pattern.
+ */
+function extractSessionId(branchName: string): string | null {
+	const segments = branchName.trim().split('/');
+	// Expected: ['swarm-lane', '<sessionId>', '<laneId>']
+	if (segments.length >= 3 && segments[0] === 'swarm-lane') {
+		return segments[1];
+	}
+	return null;
+}
+
+/**
+ * Cleans up orphaned swarm-lane branches that do not belong to any active session.
+ *
+ * Lists all branches matching `swarm-lane/*`, identifies orphans (branches whose
+ * session ID is not in `activeSessionIds`), force-deletes them, and prunes stale
+ * worktree metadata.
+ *
+ * @param directory        - The project root (cwd for all git commands).
+ * @param activeSessionIds - Session IDs that are still active; their branches are skipped.
+ * @returns Result with arrays of removed, skipped, and errored branch names.
+ */
+export async function cleanupOrphanedBranches(
+	directory: string,
+	activeSessionIds: string[] = [],
+): Promise<OrphanCleanupResult> {
+	const removed: string[] = [];
+	const skipped: string[] = [];
+	const errors: Array<{ branch: string; error: string }> = [];
+
+	// List all swarm-lane branches (--format avoids the `* ` prefix
+	// that `git branch --list` adds to the current branch)
+	const listResult = await runGit(
+		['branch', '--format=%(refname:short)', '--list', 'swarm-lane/*'],
+		directory,
+	);
+
+	const branches = listResult.stdout
+		.split('\n')
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+
+	for (const branch of branches) {
+		const sessionId = extractSessionId(branch);
+
+		if (sessionId !== null && activeSessionIds.includes(sessionId)) {
+			skipped.push(branch);
+			continue;
+		}
+
+		// Orphaned branch — attempt force deletion
+		const deleteResult = await runGit(['branch', '-D', branch], directory);
+
+		if (deleteResult.exitCode === 0) {
+			removed.push(branch);
+		} else {
+			errors.push({
+				branch,
+				error: deleteResult.stderr.trim() || deleteResult.stdout.trim(),
+			});
+		}
+	}
+
+	// Prune stale worktree metadata after cleanup
+	await runGit(['worktree', 'prune'], directory);
+
+	return { removed, skipped, errors };
+}
+
+/**
+ * Performs startup orphan recovery: prunes stale worktrees, then identifies
+ * any remaining orphaned swarm-lane branches for warning.
+ *
+ * This is designed to run at session startup (DD-3). It does NOT delete branches —
+ * it reports them as warnings so the caller can decide on further action.
+ *
+ * @param directory        - The project root (cwd for all git commands).
+ * @param activeSessionIds - Session IDs that are still active; their branches are expected.
+ * @returns Result indicating whether pruning happened, orphaned branches, and warnings.
+ */
+export async function startupOrphanRecovery(
+	directory: string,
+	activeSessionIds: string[] = [],
+): Promise<StartupRecoveryResult> {
+	const warnings: string[] = [];
+
+	// Step 1: Prune stale worktree metadata (DD-3)
+	const pruneResult = await runGit(['worktree', 'prune'], directory);
+
+	if (pruneResult.exitCode !== 0) {
+		warnings.push(
+			`git worktree prune failed: ${pruneResult.stderr.trim() || pruneResult.stdout.trim()}`,
+		);
+	}
+
+	// Step 2: List remaining swarm-lane branches (--format avoids
+	// the `* ` prefix that `git branch --list` adds to the current branch)
+	const listResult = await runGit(
+		['branch', '--format=%(refname:short)', '--list', 'swarm-lane/*'],
+		directory,
+	);
+
+	const allBranches = listResult.stdout
+		.split('\n')
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+
+	// Step 3: Filter out active-session branches; remaining are orphans
+	const orphanBranches: string[] = [];
+	for (const branch of allBranches) {
+		const sessionId = extractSessionId(branch);
+		if (sessionId === null || !activeSessionIds.includes(sessionId)) {
+			orphanBranches.push(branch);
+			warnings.push(
+				`Orphaned swarm-lane branch "${branch}" detected in "${directory}"`,
+			);
+		}
+	}
+
+	for (const warning of warnings) {
+		console.warn(warning);
+	}
+
+	return {
+		prunedWorktrees: pruneResult.exitCode === 0,
+		remainingBranches: orphanBranches,
+		warnings,
+	};
+}

--- a/src/turbo/lean/runner.ts
+++ b/src/turbo/lean/runner.ts
@@ -24,10 +24,22 @@ import { loadPlanJsonOnly } from '../../plan/manager';
 import { hasActiveFullAuto, swarmState } from '../../state';
 import type { LaneEvidence } from './evidence';
 import { writeLaneEvidence } from './evidence';
+import {
+	attemptMergeBackFromDirty,
+	getMergeStrategy,
+	mergeLaneBranch,
+	postMergeCleanup,
+	startupOrphanRecovery,
+} from './merge-back';
 import type { LeanTurboLanePlan } from './planner';
 import { planLeanTurboLanes } from './planner';
 import type { LeanTurboLane } from './state';
 import { loadLeanTurboRunState, saveLeanTurboRunState } from './state';
+import {
+	assertCleanWorkingTree,
+	provisionWorktree,
+	removeWorktree,
+} from './worktree';
 
 /**
  * Shape of the OpencodeClient session API used by the runner.
@@ -68,6 +80,18 @@ export interface LaneDispatchResult {
 }
 
 /**
+ * Describes a merge-back failure for a completed lane.
+ */
+export interface MergeBackFailureInfo {
+	/** Lane identifier */
+	laneId: string;
+	/** Human-readable reason for the merge-back failure */
+	reason: string;
+	/** Conflict files if the failure was a merge conflict */
+	conflictFiles?: string[];
+}
+
+/**
  * Result of a single lane's processing.
  */
 export interface LaneResult {
@@ -83,6 +107,8 @@ export interface LaneResult {
 	sessionId?: string;
 	/** Error message if status is 'failed' or 'blocked' */
 	error?: string;
+	/** Merge-back failure info if the coder completed but integration back to primary failed */
+	mergeBackFailure?: MergeBackFailureInfo;
 }
 
 /**
@@ -99,6 +125,8 @@ export interface LeanTurboPhaseResult {
 	degradedTasks: string[];
 	/** Task IDs excluded from parallel lanes, must complete via standard serial flow */
 	serializedTasks: string[];
+	/** Lanes whose coder completed but merge-back to primary branch failed */
+	mergeBackFailures?: MergeBackFailureInfo[];
 }
 
 // ─── Internal Types ───────────────────────────────────────────────────────────
@@ -108,6 +136,61 @@ export interface LeanTurboPhaseResult {
  * Used by cleanup() to release all held locks.
  */
 type LaneLockMap = Record<string, string[]>;
+
+// ─── Transient Error Detection ─────────────────────────────────────────────
+
+/**
+ * Determines whether a worktree provisioning error is transient and worth retrying.
+ *
+ * Transient errors include well-known system error codes (ENOENT, EBUSY, EPERM, etc.),
+ * disk-space messages, and git "fatal:" stderr that doesn't indicate a permanent
+ * condition like "already exists" or "not a git repository".
+ */
+function isTransientProvisionError(errorMsg: string): boolean {
+	const lower = errorMsg.toLowerCase();
+
+	// Permanent conditions — never retry
+	if (
+		lower.includes('already exists') ||
+		lower.includes('not a git repository')
+	) {
+		return false;
+	}
+
+	// Known transient system error codes
+	const transientCodes = [
+		'enoent',
+		'econnrefused',
+		'etimedout',
+		'ebusy',
+		'eperm',
+		'enomem',
+	];
+	for (const code of transientCodes) {
+		if (lower.includes(code)) {
+			return true;
+		}
+	}
+
+	// Transient disk/resource messages
+	const transientMessages = [
+		'disk full',
+		'no space left',
+		'resource temporarily unavailable',
+	];
+	for (const msg of transientMessages) {
+		if (lower.includes(msg)) {
+			return true;
+		}
+	}
+
+	// Git "fatal:" stderr with non-zero exit — transient unless excluded above
+	if (lower.includes('fatal:')) {
+		return true;
+	}
+
+	return false;
+}
 
 // ─── Runner Class ────────────────────────────────────────────────────────────
 
@@ -147,6 +230,14 @@ export class LeanTurboRunner {
 		writeLaneEvidence: typeof writeLaneEvidence;
 		/** Timeout for lane dispatch (session.create + session.prompt) in ms. Undefined = no timeout. */
 		laneDispatchTimeoutMs: number | undefined;
+		provisionWorktree: typeof provisionWorktree;
+		removeWorktree: typeof removeWorktree;
+		mergeLaneBranch: typeof mergeLaneBranch;
+		postMergeCleanup: typeof postMergeCleanup;
+		attemptMergeBackFromDirty: typeof attemptMergeBackFromDirty;
+		startupOrphanRecovery: typeof startupOrphanRecovery;
+		getMergeStrategy: typeof getMergeStrategy;
+		assertCleanWorkingTree: typeof assertCleanWorkingTree;
 	} = {
 		loadPlanJsonOnly,
 		planLeanTurboLanes,
@@ -158,6 +249,14 @@ export class LeanTurboRunner {
 		loadFullAutoRunState,
 		writeLaneEvidence,
 		laneDispatchTimeoutMs: undefined,
+		provisionWorktree,
+		removeWorktree,
+		mergeLaneBranch,
+		postMergeCleanup,
+		attemptMergeBackFromDirty,
+		startupOrphanRecovery,
+		getMergeStrategy,
+		assertCleanWorkingTree,
 	};
 
 	/**
@@ -297,6 +396,36 @@ export class LeanTurboRunner {
 		// Get lean config (use stored config or defaults if not set)
 		const leanConfig = this._getLeanConfig(this._leanConfig);
 
+		// Startup orphan recovery (FR-002) — only when worktree isolation is enabled
+		if (leanConfig.worktree_isolation) {
+			await LeanTurboRunner._internals.startupOrphanRecovery(this._directory, [
+				this._sessionID,
+			]);
+
+			// DD-2: Assert clean working tree before provisioning worktrees.
+			// If dirty, degrade ALL lanes to shared-directory execution for this phase.
+			try {
+				const cleanResult =
+					await LeanTurboRunner._internals.assertCleanWorkingTree(
+						this._directory,
+					);
+				if (!cleanResult.clean) {
+					console.warn(
+						`[lean-turbo] worktree isolation requires clean working tree: ${cleanResult.error}`,
+					);
+					leanConfig.worktree_isolation = false;
+				}
+			} catch (assertErr) {
+				// If the check itself fails (e.g. not a git repo), degrade gracefully
+				const assertMsg =
+					assertErr instanceof Error ? assertErr.message : String(assertErr);
+				console.warn(
+					`[lean-turbo] unable to verify working tree cleanliness: ${assertMsg} — degrading to shared directory`,
+				);
+				leanConfig.worktree_isolation = false;
+			}
+		}
+
 		// Plan lane distribution — type cast needed because Phase (schema) is structurally
 		// wider than PlanPhase (planner) but at runtime all used fields are compatible
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -350,15 +479,27 @@ export class LeanTurboRunner {
 
 		// Process lanes concurrently for maximum throughput
 		const results = await Promise.all(
-			lanePlan.lanes.map((lane) => this._processLane(lane)),
+			lanePlan.lanes.map((lane) => this._processLane(lane, leanConfig)),
 		);
 		laneResults.push(...results);
+
+		// Sequential worktree cleanup: after ALL lanes complete, handle worktree
+		// lanes one at a time to prevent concurrent git merge/rebase/cherry-pick
+		// from corrupting the shared .git index (race condition fix).
+		// Handles both SUCCESS lanes (mergeLaneBranch + cleanup + removeWorktree)
+		// and FAILURE lanes (attemptMergeBackFromDirty + removeWorktree).
+		const mergeBackFailures = await this._sequentialWorktreeCleanup(
+			laneResults,
+			leanConfig,
+		);
 
 		return {
 			ok: true,
 			lanes: laneResults,
 			degradedTasks,
 			serializedTasks: lanePlan.serializedTasks,
+			mergeBackFailures:
+				mergeBackFailures.length > 0 ? mergeBackFailures : undefined,
 		};
 	}
 
@@ -374,6 +515,7 @@ export class LeanTurboRunner {
 	async dispatchLane(
 		lane: LeanTurboLane,
 		agentName: string,
+		worktreeDirectory?: string,
 	): Promise<LaneDispatchResult> {
 		const session =
 			this._sessionOps ??
@@ -383,7 +525,12 @@ export class LeanTurboRunner {
 		}
 
 		// Build a promise that does the full dispatch
-		const dispatchPromise = this._doDispatch(session, lane, agentName);
+		const dispatchPromise = this._doDispatch(
+			session,
+			lane,
+			agentName,
+			worktreeDirectory,
+		);
 
 		// Apply timeout if configured via _internals
 		const timeoutMs = LeanTurboRunner._internals.laneDispatchTimeoutMs;
@@ -443,11 +590,14 @@ export class LeanTurboRunner {
 		session: SessionClient,
 		lane: LeanTurboLane,
 		agentName: string,
+		worktreeDirectory?: string,
 	): Promise<LaneDispatchResult> {
 		try {
+			// Use worktree directory when provided, otherwise use primary directory
+			const effectiveDirectory = worktreeDirectory ?? this._directory;
 			// Create ephemeral session
 			const createResult = await session.create({
-				query: { directory: this._directory },
+				query: { directory: effectiveDirectory },
 			});
 
 			if (!createResult.data) {
@@ -533,6 +683,20 @@ export class LeanTurboRunner {
 		}
 
 		this._laneLockMap = {};
+
+		// Remove worktrees for lanes that were active
+		for (const [_laneId, lane] of this._laneStatuses) {
+			if (lane.worktreePath) {
+				try {
+					await LeanTurboRunner._internals.removeWorktree(
+						lane.worktreePath,
+						this._directory,
+					);
+				} catch {
+					// Best-effort cleanup
+				}
+			}
+		}
 
 		// Update durable state to reflect released lanes
 		// Use _withStateLock to prevent races with concurrent lane status updates
@@ -661,7 +825,10 @@ export class LeanTurboRunner {
 	 * On lock acquisition failure (Bug #4), the lane's tasks are routed to
 	 * the serialized tasks set for standard serial fallback.
 	 */
-	private async _processLane(lane: LeanTurboLane): Promise<LaneResult> {
+	private async _processLane(
+		lane: LeanTurboLane,
+		leanConfig: LeanTurboConfig,
+	): Promise<LaneResult> {
 		// Update status to running
 		const laneInState = this._laneStatuses.get(lane.laneId);
 		if (laneInState) {
@@ -728,8 +895,140 @@ export class LeanTurboRunner {
 		// Track locked files for cleanup
 		this._laneLockMap[lane.laneId] = [...lane.files];
 
+		// Worktree provisioning (if enabled)
+		let worktreeDirectory: string | undefined;
+		if (leanConfig.worktree_isolation) {
+			let provisionError: string | undefined;
+			try {
+				const provisionResult =
+					await LeanTurboRunner._internals.provisionWorktree(
+						this._directory,
+						lane.laneId,
+						this._sessionID,
+						leanConfig,
+					);
+				if ('worktreePath' in provisionResult) {
+					worktreeDirectory = provisionResult.worktreePath;
+					// Track in state and persist to durable storage
+					if (laneInState) {
+						laneInState.worktreePath = provisionResult.worktreePath;
+						laneInState.branchName = provisionResult.branchName;
+					}
+					await this._persistLaneWorktreeFields(
+						lane.laneId,
+						provisionResult.worktreePath,
+						provisionResult.branchName,
+					);
+				} else {
+					provisionError = provisionResult.error;
+				}
+			} catch (provisionErr) {
+				provisionError =
+					provisionErr instanceof Error
+						? provisionErr.message
+						: String(provisionErr);
+			}
+
+			// Retry once for transient errors, fail immediately for permanent ones
+			if (provisionError) {
+				if (isTransientProvisionError(provisionError)) {
+					console.warn(
+						`[lean-turbo] worktree provision failed for lane ${lane.laneId}: ${provisionError} — retrying once...`,
+					);
+					await new Promise<void>((r) => setTimeout(r, 100));
+					try {
+						const retryResult =
+							await LeanTurboRunner._internals.provisionWorktree(
+								this._directory,
+								lane.laneId,
+								this._sessionID,
+								leanConfig,
+							);
+						if ('worktreePath' in retryResult) {
+							worktreeDirectory = retryResult.worktreePath;
+							if (laneInState) {
+								laneInState.worktreePath = retryResult.worktreePath;
+								laneInState.branchName = retryResult.branchName;
+							}
+							await this._persistLaneWorktreeFields(
+								lane.laneId,
+								retryResult.worktreePath,
+								retryResult.branchName,
+							);
+							console.warn(
+								`[lean-turbo] worktree provision retry succeeded for lane ${lane.laneId}`,
+							);
+							// Retry succeeded — clear provisionError so we don't fail below
+							provisionError = undefined;
+						} else {
+							// Retry returned an error — keep provisionError set
+							provisionError = retryResult.error;
+							console.warn(
+								`[lean-turbo] worktree provision retry failed for lane ${lane.laneId}: ${retryResult.error}`,
+							);
+						}
+					} catch (retryErr) {
+						const retryMsg =
+							retryErr instanceof Error ? retryErr.message : String(retryErr);
+						// Retry threw — keep provisionError set
+						console.warn(
+							`[lean-turbo] worktree provision retry threw for lane ${lane.laneId}: ${retryMsg}`,
+						);
+					}
+				} else {
+					// Permanent error — log and fail (no retry)
+					console.warn(
+						`[lean-turbo] worktree provision failed for lane ${lane.laneId}: ${provisionError}`,
+					);
+				}
+			}
+
+			// After retry, if worktreeDirectory is still undefined, the lane cannot
+			// proceed under worktree isolation — fail explicitly rather than silently
+			// degrading to the shared directory (which would break the isolation contract).
+			if (!worktreeDirectory) {
+				const failMsg = `worktree provision failed: ${provisionError ?? 'unknown error'}`;
+
+				// Release locks — this lane will not proceed
+				try {
+					await LeanTurboRunner._internals.releaseLaneLocks(
+						this._directory,
+						lane.laneId,
+					);
+				} catch {
+					// Best-effort
+				}
+				delete this._laneLockMap[lane.laneId];
+
+				if (laneInState) {
+					laneInState.status = 'failed';
+					laneInState.error = failMsg;
+				}
+				await this._updateDurableStateLaneStatus(lane.laneId, 'failed');
+
+				// Write evidence for failed lane
+				await this._writeLaneEvidenceSafely(lane, 'failed', {
+					status: 'failed',
+					error: failMsg,
+					agent,
+				});
+
+				return {
+					laneId: lane.laneId,
+					status: 'failed',
+					taskIds: lane.taskIds,
+					agent,
+					error: failMsg,
+				};
+			}
+		}
+
 		// Dispatch to selected agent
-		const dispatchResult = await this.dispatchLane(lane, agent);
+		const dispatchResult = await this.dispatchLane(
+			lane,
+			agent,
+			worktreeDirectory,
+		);
 
 		if (!dispatchResult.ok) {
 			// Dispatch failed — release locks immediately
@@ -742,6 +1041,14 @@ export class LeanTurboRunner {
 				// Best-effort
 			}
 			delete this._laneLockMap[lane.laneId];
+
+			// Mark lane as needing failure cleanup in sequential post-processing.
+			// Do NOT call attemptMergeBackFromDirty / removeWorktree here because
+			// this runs inside Promise.all (concurrent lanes) and concurrent git
+			// mutations on the shared .git index cause race conditions.
+			if (worktreeDirectory && laneInState) {
+				laneInState._failureCleanupPending = true;
+			}
 
 			if (laneInState) {
 				laneInState.status = 'failed';
@@ -803,6 +1110,132 @@ export class LeanTurboRunner {
 			agent,
 			sessionId: dispatchResult.sessionId,
 		};
+	}
+
+	/**
+	 * Sequential worktree cleanup for completed and failed worktree lanes.
+	 *
+	 * Runs AFTER all lanes have been dispatched and completed via Promise.all.
+	 * Each worktree lane is processed one at a time, preventing concurrent
+	 * git merge/rebase/cherry-pick from corrupting the shared .git index.
+	 *
+	 * - **Success lanes**: mergeLaneBranch → removeWorktree → postMergeCleanup
+	 * - **Success lanes with merge failure**: log warning, keep worktree, update lane result
+	 * - **Failed lanes**: attemptMergeBackFromDirty → removeWorktree
+	 *
+	 * @returns Array of MergeBackFailureInfo for lanes where merge-back failed
+	 */
+	private async _sequentialWorktreeCleanup(
+		laneResults: LaneResult[],
+		leanConfig: LeanTurboConfig,
+	): Promise<MergeBackFailureInfo[]> {
+		const mergeBackFailures: MergeBackFailureInfo[] = [];
+
+		for (const lr of laneResults) {
+			const laneInState = this._laneStatuses.get(lr.laneId);
+			if (!laneInState?.worktreePath) continue;
+
+			let needsPostMergeCleanup = false;
+
+			if (lr.status === 'completed') {
+				// Success path: merge the lane branch back into HEAD
+				if (!laneInState.branchName) continue;
+
+				try {
+					const strategy =
+						LeanTurboRunner._internals.getMergeStrategy(leanConfig);
+					const mergeResult = await LeanTurboRunner._internals.mergeLaneBranch(
+						this._directory,
+						laneInState.branchName,
+						strategy,
+					);
+					if ('merged' in mergeResult && mergeResult.merged) {
+						// Mark for post-merge cleanup AFTER worktree removal (branch delete
+						// fails while the branch is still checked out in an active worktree).
+						needsPostMergeCleanup = true;
+					} else if ('conflict' in mergeResult && mergeResult.conflict) {
+						// Merge conflict: log warning, do NOT remove worktree, record failure
+						const failureInfo: MergeBackFailureInfo = {
+							laneId: lr.laneId,
+							reason: mergeResult.message || 'merge conflict',
+							conflictFiles: mergeResult.files,
+						};
+						mergeBackFailures.push(failureInfo);
+						lr.mergeBackFailure = failureInfo;
+						console.warn(
+							`[lean-turbo] merge-back CONFLICT for lane ${lr.laneId}: ${failureInfo.reason} — worktree preserved at ${laneInState.worktreePath} for manual recovery`,
+						);
+						continue; // Skip removeWorktree — keep worktree for manual recovery
+					} else if ('error' in mergeResult && mergeResult.error) {
+						// Merge error: log warning, do NOT remove worktree, record failure
+						const failureInfo: MergeBackFailureInfo = {
+							laneId: lr.laneId,
+							reason: mergeResult.error,
+						};
+						mergeBackFailures.push(failureInfo);
+						lr.mergeBackFailure = failureInfo;
+						console.warn(
+							`[lean-turbo] merge-back ERROR for lane ${lr.laneId}: ${failureInfo.reason} — worktree preserved at ${laneInState.worktreePath} for manual recovery`,
+						);
+						continue; // Skip removeWorktree — keep worktree for manual recovery
+					}
+				} catch (err) {
+					// Unexpected error during merge — log but do NOT remove worktree
+					const errMsg = err instanceof Error ? err.message : String(err);
+					const failureInfo: MergeBackFailureInfo = {
+						laneId: lr.laneId,
+						reason: errMsg,
+					};
+					mergeBackFailures.push(failureInfo);
+					lr.mergeBackFailure = failureInfo;
+					console.warn(
+						`[lean-turbo] merge-back EXCEPTION for lane ${lr.laneId}: ${errMsg} — worktree preserved at ${laneInState.worktreePath} for manual recovery`,
+					);
+					continue; // Skip removeWorktree — keep worktree for manual recovery
+				}
+			} else if (lr.status === 'failed' && laneInState._failureCleanupPending) {
+				// Failure path: attempt dirty merge-back before removing worktree
+				try {
+					const strategy =
+						LeanTurboRunner._internals.getMergeStrategy(leanConfig);
+					await LeanTurboRunner._internals.attemptMergeBackFromDirty(
+						laneInState.worktreePath,
+						laneInState.branchName ??
+							`swarm-lane/${this._sessionID}/${lr.laneId}`,
+						this._directory,
+						strategy,
+					);
+				} catch {
+					// Best-effort merge-back — worktree still needs removal
+				}
+			}
+
+			// Both success-with-merge-ok and failure paths remove the worktree
+			try {
+				await LeanTurboRunner._internals.removeWorktree(
+					laneInState.worktreePath,
+					this._directory,
+				);
+			} catch {
+				// Best-effort cleanup
+			}
+
+			// Post-merge cleanup (branch delete + prune) must happen AFTER
+			// removeWorktree because git refuses to delete a branch that is
+			// still checked out in an active worktree.
+			if (needsPostMergeCleanup && laneInState.branchName) {
+				try {
+					await LeanTurboRunner._internals.postMergeCleanup(
+						this._directory,
+						laneInState.branchName,
+					);
+				} catch {
+					// Best-effort — branch/prune cleanup is not critical
+				}
+			}
+		}
+
+		return mergeBackFailures;
 	}
 
 	/**
@@ -953,6 +1386,40 @@ export class LeanTurboRunner {
 		} catch {
 			// Durable state write failure is non-fatal for runner operation
 		}
+	}
+
+	/**
+	 * Persist a lane's worktreePath and branchName to durable state.
+	 *
+	 * Called after provisioning so that after a crash/restart these fields
+	 * are recoverable from turbo-state.json.
+	 */
+	private async _persistLaneWorktreeFields(
+		laneId: string,
+		worktreePath: string,
+		branchName: string,
+	): Promise<void> {
+		await this._withStateLock(async () => {
+			try {
+				const runState = LeanTurboRunner._internals.loadLeanTurboRunState(
+					this._directory,
+					this._sessionID,
+				);
+				if (!runState) return;
+
+				const lane = runState.lanes.find((l) => l.laneId === laneId);
+				if (lane) {
+					lane.worktreePath = worktreePath;
+					lane.branchName = branchName;
+					LeanTurboRunner._internals.saveLeanTurboRunState(
+						this._directory,
+						runState,
+					);
+				}
+			} catch {
+				// Non-fatal — worktree metadata loss is recoverable via orphan cleanup
+			}
+		});
 	}
 
 	/**

--- a/src/turbo/lean/state.ts
+++ b/src/turbo/lean/state.ts
@@ -24,6 +24,16 @@ export interface LeanTurboLane {
 	error?: string;
 	agent?: string;
 	sessionId?: string;
+	/** Worktree path for isolated lane execution (undefined when worktree_isolation is disabled) */
+	worktreePath?: string;
+	/** Branch name for the lane's worktree (swarm-lane/<sessionId>/<laneId>) */
+	branchName?: string;
+	/**
+	 * In-memory-only flag: set when dispatch fails with a provisioned worktree.
+	 * Signals that _sequentialWorktreeCleanup should run attemptMergeBackFromDirty
+	 * + removeWorktree for this lane. Never persisted to disk.
+	 */
+	_failureCleanupPending?: boolean;
 }
 
 export interface LeanTurboDegradedTask {

--- a/src/turbo/lean/worktree.ts
+++ b/src/turbo/lean/worktree.ts
@@ -1,0 +1,637 @@
+/**
+ * Git worktree lifecycle operations for lean turbo parallel lanes.
+ *
+ * Provides five public functions for creating, removing, inspecting, and
+ * cleaning git worktrees used by parallel coder lanes. All subprocess
+ * calls go through the `_internals` DI seam so tests can replace the
+ * real `bunSpawn` without leaking across Bun's shared test-runner process.
+ *
+ * @module worktree
+ */
+
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { LeanTurboConfig } from '../../config/schema';
+import { bunSpawn } from '../../utils/bun-compat';
+
+// ---------------------------------------------------------------------------
+// _internals DI seam
+// ---------------------------------------------------------------------------
+
+/**
+ * Test-only dependency-injection seam. Production code calls
+ * `_internals.bunSpawn(...)` so tests can replace the function on this object
+ * without touching the real `../../utils/bun-compat` module — `mock.module`
+ * from `bun:test` leaks across files in Bun's shared test-runner process,
+ * which would corrupt unrelated suites that import `bun-compat`. Mutating this
+ * local object is file-scoped and trivially restorable via `afterEach`.
+ */
+export const _internals: {
+	bunSpawn: typeof bunSpawn;
+	/** Test seam for process.platform — allows non-Windows CIs to exercise Windows paths. */
+	platform: string;
+	/** Test seam for sleep — allows tests to skip real delays. */
+	sleep: (ms: number) => Promise<void>;
+	/** Test seam for os.tmpdir() — allows tests to control temp path. */
+	osTmpdir: () => string;
+	/**
+	 * Test seam for querying `git config core.longpaths`.
+	 * Returns `'true'` | `'false'` | `undefined` (not set or query failed).
+	 * Production implementation runs `git config core.longpaths` via runGit.
+	 */
+	getCoreLongPaths: (directory: string) => Promise<string | undefined>;
+} = {
+	bunSpawn,
+	platform: process.platform,
+	sleep: (ms: number) =>
+		new Promise<void>((resolve) => setTimeout(resolve, ms)),
+	osTmpdir: () => os.tmpdir(),
+	getCoreLongPaths: async (directory: string) => {
+		const result = await runGit(['config', 'core.longpaths'], directory);
+		if (result.exitCode !== 0) {
+			return undefined;
+		}
+		const value = result.stdout.trim().toLowerCase();
+		return value === '' ? undefined : value;
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface GitResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+/** Default timeout for git worktree operations (30 seconds). */
+const WORKTREE_TIMEOUT_MS = 30_000;
+
+/**
+ * Windows MAX_PATH safety margin. The OS limit is 260 characters; we use
+ * 250 to leave room for UNC prefix overhead or other edge cases.
+ */
+const WIN_PATH_BUDGET = 250;
+
+/**
+ * Runs a git command via `_internals.bunSpawn` and returns the exit code,
+ * captured stdout, and captured stderr.
+ *
+ * Every call uses:
+ * - Array-form command (never shell-string)
+ * - Explicit `cwd`
+ * - `stdin: 'ignore'` (prevents Bun/Windows pipe hangs)
+ * - Bounded `timeout`
+ * - Best-effort `proc.kill()` in `finally`
+ */
+async function runGit(
+	args: string[],
+	cwd: string,
+	timeoutMs = WORKTREE_TIMEOUT_MS,
+): Promise<GitResult> {
+	const proc = _internals.bunSpawn(['git', ...args], {
+		cwd,
+		timeout: timeoutMs,
+		stdin: 'ignore' as const,
+		stdout: 'pipe' as const,
+		stderr: 'pipe' as const,
+		env: { ...process.env, LC_ALL: 'C' },
+	});
+	try {
+		const exitCode = await proc.exited;
+		const stdout = await proc.stdout.text();
+		const stderr = await proc.stderr.text();
+		return { exitCode, stdout, stderr };
+	} finally {
+		try {
+			proc.kill();
+		} catch {
+			// best-effort — process may already be exited
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Exported functions
+// ---------------------------------------------------------------------------
+
+// ---- Path budget (Windows) ----
+
+interface PathBudgetOk {
+	ok: true;
+}
+
+interface PathBudgetExceeded {
+	ok: false;
+	error: string;
+	suggestion: string;
+}
+
+/**
+ * Checks whether the total path length for files inside a worktree would
+ * exceed the Windows MAX_PATH budget (260 chars).
+ *
+ * On non-Windows platforms this is a no-op and always returns `{ ok: true }`.
+ *
+ * If `core.longpaths` is enabled in the git config (`true`), the MAX_PATH
+ * limit does not apply (Git 2.35+) and the budget check is skipped entirely.
+ * If the config query fails or returns anything other than `true`, the
+ * existing budget check proceeds (fail-safe).
+ *
+ * The check runs `git ls-files` via `_internals.bunSpawn` to discover the
+ * longest relative file path in the project, then computes
+ * `worktreeRoot.length + 1 + longestRelativePath.length`. If this total is
+ * >= 250 (a safety margin under 260), the budget is exceeded.
+ *
+ * @param worktreeRoot - Absolute path to the worktree root directory.
+ * @param directory    - Project root (used as `cwd` for `git ls-files`).
+ */
+export async function checkPathBudget(
+	worktreeRoot: string,
+	directory: string,
+): Promise<PathBudgetOk | PathBudgetExceeded> {
+	if (_internals.platform !== 'win32') {
+		return { ok: true };
+	}
+
+	// If core.longpaths is enabled, skip the budget check entirely.
+	// Git 2.35+ bypasses MAX_PATH when this is true.
+	// If the query throws, treat as undefined and proceed with budget check (fail-safe).
+	let longPaths: string | undefined;
+	try {
+		longPaths = await _internals.getCoreLongPaths(directory);
+	} catch {
+		// Fail-safe: treat as undefined and proceed with budget check
+	}
+	if (longPaths === 'true') {
+		return { ok: true };
+	}
+
+	const proc = _internals.bunSpawn(['git', 'ls-files'], {
+		cwd: directory,
+		timeout: WORKTREE_TIMEOUT_MS,
+		stdin: 'ignore' as const,
+		stdout: 'pipe' as const,
+		stderr: 'ignore' as const,
+		env: { ...process.env, LC_ALL: 'C' },
+	});
+
+	try {
+		const exitCode = await proc.exited;
+		const stdout = await proc.stdout.text();
+
+		if (exitCode !== 0 || stdout.trim().length === 0) {
+			return { ok: true };
+		}
+
+		const files = stdout.split(/\r?\n/);
+		let longest = 0;
+		for (const file of files) {
+			if (file.length > longest) {
+				longest = file.length;
+			}
+		}
+
+		const totalPathLength = worktreeRoot.length + 1 + longest;
+		if (totalPathLength >= WIN_PATH_BUDGET) {
+			return {
+				ok: false,
+				error: `Total path budget exceeded: worktree root "${worktreeRoot}" (${worktreeRoot.length} chars) + longest file "${files.find((f) => f.length === longest)}" (${longest} chars) = ${totalPathLength} chars (budget: ${WIN_PATH_BUDGET})`,
+				suggestion:
+					'Set config.worktree_dir to a shorter absolute path, or let the auto-shorten feature relocate the worktree to the system temp directory.',
+			};
+		}
+
+		return { ok: true };
+	} finally {
+		try {
+			proc.kill();
+		} catch {
+			// best-effort — process may already be exited
+		}
+	}
+}
+
+/**
+ * Returns a shortened worktree path under the system temp directory.
+ *
+ * On non-Windows platforms this is not typically needed but still returns
+ * a deterministic path. The returned path is
+ * `<os.tmpdir()>/swwt/<sessionId>/<laneId>`.
+ *
+ * @param directory  - Project root (unused but kept for API symmetry).
+ * @param sessionId  - Lean turbo session identifier.
+ * @param laneId     - Lane identifier.
+ */
+export function shortenWorktreePath(
+	_directory: string,
+	sessionId: string,
+	laneId: string,
+): string {
+	return path.join(_internals.osTmpdir(), 'swwt', sessionId, laneId);
+}
+
+interface ProvisionSuccess {
+	worktreePath: string;
+	branchName: string;
+}
+
+interface ProvisionFailure {
+	error: string;
+}
+
+interface RemoveSuccess {
+	success: true;
+}
+
+interface RemoveFailure {
+	error: string;
+}
+
+interface AutoCommitSuccess {
+	committed: true;
+	message: string;
+}
+
+interface AutoCommitSkip {
+	committed: false;
+	reason: string;
+}
+
+interface CleanSuccess {
+	cleaned: true;
+}
+
+interface CleanFailure {
+	cleaned: false;
+	error: string;
+}
+
+interface CleanCheckSuccess {
+	clean: true;
+}
+
+interface CleanCheckFailure {
+	clean: false;
+	error: string;
+}
+
+/**
+ * Creates a new git worktree for a lean turbo lane.
+ *
+ * Branch naming follows DD-3: `swarm-lane/<sessionId>/<laneId>`.
+ * Worktree path follows DD-6: uses `config.worktree_dir` when set,
+ * otherwise defaults to `<project-parent>/.swarm-worktrees/<sessionId>/<laneId>`.
+ *
+ * Before creating the worktree, checks whether the branch already exists
+ * (via `git branch --list`) and returns an error if so.
+ *
+ * @param directory  - Project root (an absolute path to the git working tree).
+ * @param laneId    - Lane identifier (e.g. "lane-1").
+ * @param sessionId - Lean turbo session identifier.
+ * @param config    - Lean turbo configuration (may contain `worktree_dir`).
+ * @returns An object with `worktreePath` and `branchName` on success, or
+ *          `{ error: string }` on failure.
+ */
+export async function provisionWorktree(
+	directory: string,
+	laneId: string,
+	sessionId: string,
+	config: LeanTurboConfig,
+): Promise<ProvisionSuccess | ProvisionFailure> {
+	const branchName = `swarm-lane/${sessionId}/${laneId}`;
+
+	// Resolve worktree path: explicit config or DD-6 default
+	let worktreePath = config.worktree_dir
+		? path.resolve(directory, config.worktree_dir, sessionId, laneId)
+		: path.resolve(
+				path.dirname(directory),
+				'.swarm-worktrees',
+				sessionId,
+				laneId,
+			);
+
+	// Windows path budget check (DD-8)
+	const budgetResult = await checkPathBudget(worktreePath, directory);
+	if (budgetResult.ok === false) {
+		if (config.worktree_dir) {
+			// User explicitly set worktree_dir — warn but proceed
+			console.warn(
+				`[swarm] Path budget warning: ${budgetResult.error} ${budgetResult.suggestion}`,
+			);
+		} else {
+			// Try auto-shortening to temp directory
+			const shortPath = shortenWorktreePath(directory, sessionId, laneId);
+			const shortBudget = await checkPathBudget(shortPath, directory);
+			if (shortBudget.ok === false) {
+				return { error: budgetResult.error };
+			}
+			worktreePath = shortPath;
+		}
+	}
+
+	// Check if the branch already exists before creating the worktree
+	const checkResult = await runGit(
+		['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`],
+		directory,
+	);
+	if (checkResult.exitCode === 0) {
+		return { error: `Branch already exists: ${branchName}` };
+	}
+
+	// Create the worktree: git worktree add -b <branch> <path> HEAD
+	const addResult = await runGit(
+		['worktree', 'add', '-b', branchName, worktreePath, 'HEAD'],
+		directory,
+	);
+	if (addResult.exitCode !== 0) {
+		return {
+			error: `Failed to create worktree: ${addResult.stderr.trim() || addResult.stdout.trim()}`,
+		};
+	}
+
+	return { worktreePath, branchName };
+}
+
+/**
+ * Removes a git worktree **without** `--force`.
+ *
+ * On Windows (`process.platform === 'win32'`), retries up to 3 times with a
+ * 2-second delay when the error contains `EBUSY` or `EPERM` (DD-10). After
+ * exhausting retries the worktree is abandoned — the function returns an
+ * error but does NOT throw.
+ *
+ * @param worktreePath - Absolute path to the worktree directory to remove.
+ * @param projectRoot  - Absolute path to the project root (a git repository)
+ *                       used as `cwd` for the `git worktree remove` command.
+ *                       Required because the worktree's parent directory may
+ *                       not itself be a git repository.
+ * @returns `{ success: true }` on success or `{ error: string }` on failure.
+ */
+export async function removeWorktree(
+	worktreePath: string,
+	projectRoot: string,
+): Promise<RemoveSuccess | RemoveFailure> {
+	const isWindows = _internals.platform === 'win32';
+	const MAX_RETRIES = 4;
+	const RETRY_DELAY_MS = 2000;
+
+	let lastError = '';
+
+	for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+		const result = await runGit(
+			['worktree', 'remove', worktreePath],
+			projectRoot,
+		);
+
+		if (result.exitCode === 0) {
+			return { success: true };
+		}
+
+		lastError = result.stderr.trim() || result.stdout.trim();
+
+		// On Windows, retry only for EBUSY / EPERM file-lock errors
+		if (
+			isWindows &&
+			(lastError.includes('EBUSY') || lastError.includes('EPERM')) &&
+			attempt < MAX_RETRIES - 1
+		) {
+			await _internals.sleep(RETRY_DELAY_MS);
+			continue;
+		}
+
+		// Non-retryable error or final attempt exhausted
+		return { error: lastError };
+	}
+
+	return { error: lastError };
+}
+
+/**
+ * Checks whether a worktree is clean — no uncommitted changes AND no
+ * untracked files.
+ *
+ * Runs two git commands with `cwd` set to the worktree:
+ * 1. `git status --porcelain` — detects staged/unstaged modifications
+ * 2. `git ls-files --others --exclude-standard` — detects untracked files
+ *
+ * @param worktreePath - Absolute path to the worktree directory.
+ * @returns `true` when the worktree is completely clean, `false` otherwise.
+ */
+export async function isCleanWorktree(worktreePath: string): Promise<boolean> {
+	const [statusResult, untrackedResult] = await Promise.all([
+		runGit(['status', '--porcelain'], worktreePath),
+		runGit(['ls-files', '--others', '--exclude-standard'], worktreePath),
+	]);
+
+	// If either git command fails, we cannot determine cleanliness — treat as dirty
+	if (statusResult.exitCode !== 0 || untrackedResult.exitCode !== 0) {
+		return false;
+	}
+
+	const hasChanges = statusResult.stdout.trim().length > 0;
+	const hasUntracked = untrackedResult.stdout.trim().length > 0;
+
+	return !hasChanges && !hasUntracked;
+}
+
+/**
+ * Auto-commits dirty state in a worktree before cleanup.
+ *
+ * Stages all files (`git add -A`) and commits with the message
+ * `swarm-lane: auto-commit before cleanup`. If there is nothing to commit,
+ * returns `{ committed: false, reason: 'Nothing to commit' }`.
+ *
+ * @param worktreePath - Absolute path to the worktree directory.
+ * @returns `{ committed: true, message }` on success or `{ committed: false, reason }`
+ *          if nothing to commit or on failure.
+ */
+export async function autoCommitDirty(
+	worktreePath: string,
+): Promise<AutoCommitSuccess | AutoCommitSkip> {
+	const COMMIT_MESSAGE = 'swarm-lane: auto-commit before cleanup';
+
+	// Stage all files
+	const addResult = await runGit(['add', '-A'], worktreePath);
+	if (addResult.exitCode !== 0) {
+		return {
+			committed: false,
+			reason: `git add failed: ${addResult.stderr.trim() || addResult.stdout.trim()}`,
+		};
+	}
+
+	// Attempt the commit
+	const commitResult = await runGit(
+		['commit', '-m', COMMIT_MESSAGE],
+		worktreePath,
+	);
+
+	if (commitResult.exitCode !== 0) {
+		const stderr = commitResult.stderr.trim();
+		const stdout = commitResult.stdout.trim();
+		if (
+			stderr.includes('nothing to commit') ||
+			stdout.includes('nothing to commit') ||
+			stderr.includes('nothing added to commit')
+		) {
+			return { committed: false, reason: 'Nothing to commit' };
+		}
+		return {
+			committed: false,
+			reason: `git commit failed: ${stderr || stdout}`,
+		};
+	}
+
+	return { committed: true, message: COMMIT_MESSAGE };
+}
+
+/**
+ * Patterns for files/directories that are safe to remove with
+ * `git clean`.  Everything else is treated as potential source code and
+ * blocks the clean to prevent data loss (DD-7 safety amendment).
+ *
+ * Two pattern forms:
+ * - **Directory patterns** (ending with `/`): match paths that start with
+ *   the directory prefix or contain it as a path segment.
+ * - **File suffix patterns** (not ending with `/`): match paths that end
+ *   with the suffix.
+ */
+const SAFE_CLEAN_PATTERNS: readonly string[] = [
+	'dist/',
+	'build/',
+	'.turbo/',
+	'coverage/',
+	'node_modules/.cache/',
+	'.log',
+	'.tmp',
+	'.o',
+	'.pyc',
+	'.class',
+];
+
+/**
+ * Determines whether a single path from `git clean -fdn` output is safe
+ * to permanently delete.
+ *
+ * Two matching strategies based on pattern type:
+ * - **Directory patterns** (ending with `/`): the candidate path must
+ *   start with the pattern or contain it as a path segment.
+ *   Example: `dist/bundle.js` matches `dist/` because it starts with `dist/`.
+ * - **File suffix patterns** (not ending with `/`): the candidate path
+ *   must end with the pattern. Example: `app.log` matches `.log`.
+ */
+function isSafeToClean(candidatePath: string): boolean {
+	const normalized = candidatePath.replace(/\\/g, '/').toLowerCase();
+	return SAFE_CLEAN_PATTERNS.some((pattern) => {
+		const p = pattern.toLowerCase();
+		if (p.endsWith('/')) {
+			return normalized.startsWith(p) || normalized.includes('/' + p);
+		}
+		return normalized.endsWith(p);
+	});
+}
+
+/**
+ * Removes untracked files and directories from a worktree (DD-7 amendment).
+ *
+ * Before running `git clean -fd`, performs a dry-run (`git clean -fdn`) to
+ * list what would be deleted.  If the list contains anything that is not
+ * a known generated/temporary artifact, the clean is **skipped** to prevent
+ * accidental deletion of uncommitted source files created by lane coders.
+ *
+ * @param worktreePath - Absolute path to the worktree directory.
+ * @returns `{ cleaned: true }` on success or `{ cleaned: false, error }`
+ *          on failure or when untracked source files are detected.
+ */
+export async function cleanUntrackedFiles(
+	worktreePath: string,
+): Promise<CleanSuccess | CleanFailure> {
+	// --- Dry-run safety gate ---
+	const dryRun = await runGit(['clean', '-fdn'], worktreePath);
+
+	if (dryRun.exitCode === 0) {
+		const candidates = dryRun.stdout
+			.trim()
+			.split('\n')
+			.map((line) => {
+				// git clean -fdn output: "Would remove <path>"
+				const match = line.match(/^Would remove (.+)$/);
+				return match ? match[1].trim() : '';
+			})
+			.filter((p) => p.length > 0);
+
+		const unsafePaths = candidates.filter((p) => !isSafeToClean(p));
+
+		if (unsafePaths.length > 0) {
+			console.warn(
+				`[swarm:cleanUntrackedFiles] Skipping clean — untracked source files detected: ${unsafePaths.join(', ')}`,
+			);
+			return {
+				cleaned: false,
+				error:
+					'untracked source files detected — skipping clean to prevent data loss',
+			};
+		}
+	}
+	// If the dry-run fails we cannot verify; fail-open and proceed.
+
+	const result = await runGit(['clean', '-fd'], worktreePath);
+
+	if (result.exitCode !== 0) {
+		return {
+			cleaned: false,
+			error: result.stderr.trim() || result.stdout.trim(),
+		};
+	}
+
+	return { cleaned: true };
+}
+
+/**
+ * Verifies that the working tree at `directory` has no uncommitted or
+ * untracked changes before worktree provisioning (DD-2).
+ *
+ * If the working tree is dirty, returns a descriptive error message
+ * instructing the user to commit or stash.
+ *
+ * @param directory - Project root (an absolute path to the git working tree).
+ * @returns `{ clean: true }` when the working tree is clean, or
+ *          `{ clean: false, error: string }` when dirty or unverifiable.
+ */
+export async function assertCleanWorkingTree(
+	directory: string,
+): Promise<CleanCheckSuccess | CleanCheckFailure> {
+	const [statusResult, untrackedResult] = await Promise.all([
+		runGit(['status', '--porcelain'], directory),
+		runGit(['ls-files', '--others', '--exclude-standard'], directory),
+	]);
+
+	if (statusResult.exitCode !== 0) {
+		return {
+			clean: false,
+			error: `Unable to verify working tree cleanliness: ${statusResult.stderr.trim() || statusResult.stdout.trim()}`,
+		};
+	}
+
+	if (untrackedResult.exitCode !== 0) {
+		return {
+			clean: false,
+			error: `Unable to verify working tree cleanliness: ${untrackedResult.stderr.trim() || untrackedResult.stdout.trim()}`,
+		};
+	}
+
+	const hasChanges = statusResult.stdout.trim().length > 0;
+	const hasUntracked = untrackedResult.stdout.trim().length > 0;
+
+	if (hasChanges || hasUntracked) {
+		return {
+			clean: false,
+			error:
+				"Working tree has uncommitted changes. Please commit or stash before provisioning worktrees. Run 'git status' for details.",
+		};
+	}
+
+	return { clean: true };
+}

--- a/tests/unit/config/schema-lean-turbo.test.ts
+++ b/tests/unit/config/schema-lean-turbo.test.ts
@@ -1,0 +1,223 @@
+/**
+ * LeanTurboConfigSchema tests — Phase 1 Task 1.1
+ *
+ * Tests for worktree_isolation field (previously hard-rejected via .refine(),
+ * now accepted), and the new merge_strategy and worktree_dir fields.
+ */
+import { describe, expect, test } from 'bun:test';
+import { DEFAULT_LEAN_TURBO_CONFIG } from '../../../src/config/constants';
+import { LeanTurboConfigSchema } from '../../../src/config/schema';
+
+describe('LeanTurboConfigSchema — worktree_isolation field', () => {
+	describe('worktree_isolation acceptance (previously rejected)', () => {
+		test('accepts worktree_isolation: true', () => {
+			const result = LeanTurboConfigSchema.safeParse({
+				worktree_isolation: true,
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.worktree_isolation).toBe(true);
+			}
+		});
+
+		test('accepts worktree_isolation: false', () => {
+			const result = LeanTurboConfigSchema.safeParse({
+				worktree_isolation: false,
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.worktree_isolation).toBe(false);
+			}
+		});
+
+		test('accepts worktree_isolation omitted (defaults to false)', () => {
+			const result = LeanTurboConfigSchema.safeParse({});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.worktree_isolation).toBe(false);
+			}
+		});
+	});
+});
+
+describe('LeanTurboConfigSchema — merge_strategy field', () => {
+	describe('valid values', () => {
+		test('accepts merge_strategy: "merge" (default)', () => {
+			const result = LeanTurboConfigSchema.safeParse({
+				merge_strategy: 'merge',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.merge_strategy).toBe('merge');
+			}
+		});
+
+		test('accepts merge_strategy: "rebase"', () => {
+			const result = LeanTurboConfigSchema.safeParse({
+				merge_strategy: 'rebase',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.merge_strategy).toBe('rebase');
+			}
+		});
+
+		test('accepts merge_strategy: "cherry-pick"', () => {
+			const result = LeanTurboConfigSchema.safeParse({
+				merge_strategy: 'cherry-pick',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.merge_strategy).toBe('cherry-pick');
+			}
+		});
+
+		test('accepts merge_strategy omitted (defaults to "merge")', () => {
+			const result = LeanTurboConfigSchema.safeParse({});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.merge_strategy).toBe('merge');
+			}
+		});
+	});
+
+	describe('invalid values', () => {
+		test('rejects merge_strategy: "squash" (not a valid enum value)', () => {
+			const result = LeanTurboConfigSchema.safeParse({
+				merge_strategy: 'squash',
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				const paths = result.error.issues.map((i) => i.path.join('.'));
+				expect(paths).toContain('merge_strategy');
+			}
+		});
+
+		test('rejects merge_strategy: "fast-forward"', () => {
+			const result = LeanTurboConfigSchema.safeParse({
+				merge_strategy: 'fast-forward',
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				const paths = result.error.issues.map((i) => i.path.join('.'));
+				expect(paths).toContain('merge_strategy');
+			}
+		});
+
+		test('rejects merge_strategy as number', () => {
+			const result = LeanTurboConfigSchema.safeParse({
+				merge_strategy: 1 as any,
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				const paths = result.error.issues.map((i) => i.path.join('.'));
+				expect(paths).toContain('merge_strategy');
+			}
+		});
+	});
+});
+
+describe('LeanTurboConfigSchema — worktree_dir field', () => {
+	describe('valid values', () => {
+		test('accepts worktree_dir: "/some/path" (absolute Unix path)', () => {
+			const result = LeanTurboConfigSchema.safeParse({
+				worktree_dir: '/some/path',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.worktree_dir).toBe('/some/path');
+			}
+		});
+
+		test('accepts worktree_dir: "C:\\worktrees" (Windows path)', () => {
+			const result = LeanTurboConfigSchema.safeParse({
+				worktree_dir: 'C:\\worktrees',
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.worktree_dir).toBe('C:\\worktrees');
+			}
+		});
+
+		test('accepts worktree_dir omitted (optional)', () => {
+			const result = LeanTurboConfigSchema.safeParse({});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.worktree_dir).toBeUndefined();
+			}
+		});
+
+		test('accepts worktree_dir: undefined (explicit)', () => {
+			const result = LeanTurboConfigSchema.safeParse({
+				worktree_dir: undefined,
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.worktree_dir).toBeUndefined();
+			}
+		});
+	});
+});
+
+describe('LeanTurboConfigSchema — default config', () => {
+	test('parses empty object as full defaults', () => {
+		const result = LeanTurboConfigSchema.safeParse({});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.max_parallel_coders).toBe(4);
+			expect(result.data.require_declared_scope).toBe(true);
+			expect(result.data.conflict_policy).toBe('serialize');
+			expect(result.data.degrade_on_risk).toBe(true);
+			expect(result.data.phase_reviewer).toBe(true);
+			expect(result.data.phase_critic).toBe(true);
+			expect(result.data.integrated_diff_required).toBe(true);
+			expect(result.data.allow_docs_only_without_reviewer).toBe(false);
+			expect(result.data.worktree_isolation).toBe(false);
+			expect(result.data.merge_strategy).toBe('merge');
+			expect(result.data.worktree_dir).toBeUndefined();
+		}
+	});
+});
+
+describe('DEFAULT_LEAN_TURBO_CONFIG constants', () => {
+	test('has worktree_isolation: false', () => {
+		expect(DEFAULT_LEAN_TURBO_CONFIG.worktree_isolation).toBe(false);
+	});
+
+	test('has merge_strategy: "merge"', () => {
+		expect(DEFAULT_LEAN_TURBO_CONFIG.merge_strategy).toBe('merge');
+	});
+
+	test('has worktree_dir: undefined', () => {
+		expect(DEFAULT_LEAN_TURBO_CONFIG.worktree_dir).toBeUndefined();
+	});
+});
+
+describe('LeanTurboConfigSchema — combined worktree fields', () => {
+	test('accepts worktree_isolation: true with merge_strategy and worktree_dir', () => {
+		const result = LeanTurboConfigSchema.safeParse({
+			worktree_isolation: true,
+			merge_strategy: 'rebase',
+			worktree_dir: '/custom/worktrees',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.worktree_isolation).toBe(true);
+			expect(result.data.merge_strategy).toBe('rebase');
+			expect(result.data.worktree_dir).toBe('/custom/worktrees');
+		}
+	});
+
+	test('accepts all three merge strategies alongside worktree_isolation: true', () => {
+		for (const strategy of ['merge', 'rebase', 'cherry-pick'] as const) {
+			const result = LeanTurboConfigSchema.safeParse({
+				worktree_isolation: true,
+				merge_strategy: strategy,
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.merge_strategy).toBe(strategy);
+			}
+		}
+	});
+});

--- a/tests/unit/tools/lean-turbo-run-phase.test.ts
+++ b/tests/unit/tools/lean-turbo-run-phase.test.ts
@@ -96,6 +96,108 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
+// MERGE-BACK FAILURES PROPAGATION TESTS
+// ---------------------------------------------------------------------------
+
+describe('mergeBackFailures propagation', () => {
+	test('executeLeanTurboRunPhase propagates mergeBackFailures from runner result', async () => {
+		// Configure mock to return mergeBackFailures
+		const mockFailures = [
+			{ laneId: 'lane-1', reason: 'merge conflict on src/main.ts' },
+			{
+				laneId: 'lane-2',
+				reason: 'rebase failed',
+				conflictFiles: ['src/utils.ts', 'src/index.ts'],
+			},
+		];
+
+		// Replace the default runPhase mock to include mergeBackFailures
+		const mockRunnerInstance = {
+			runPhase: mock(async () => ({
+				ok: true,
+				lanes: [],
+				degradedTasks: [],
+				serializedTasks: [],
+				mergeBackFailures: mockFailures,
+			})),
+			cleanup: mock(async () => {}),
+			cleanupAfterSuccess: mock(async () => {}),
+			cleanupAfterFailure: mock(async () => {}),
+		};
+
+		// Override the mock constructor for this test
+		const origConstructor = MockLeanTurboRunner;
+		_internals.LeanTurboRunner = mock(function CustomRunner(_options: unknown) {
+			return mockRunnerInstance;
+		}) as any;
+
+		const args: LeanTurboRunPhaseArgs = {
+			directory: tmpDir,
+			phase: 1,
+			sessionID: 'test-session',
+		};
+
+		const result = await executeLeanTurboRunPhase(args);
+
+		// Verify mergeBackFailures are present in the tool response
+		expect(result.success).toBe(true);
+		expect(result.mergeBackFailures).toBeDefined();
+		expect(result.mergeBackFailures).toHaveLength(2);
+		expect(result.mergeBackFailures).toEqual(mockFailures);
+
+		// Restore original constructor
+		_internals.LeanTurboRunner = origConstructor;
+	});
+
+	test('executeLeanTurboRunPhase propagates empty mergeBackFailures array', async () => {
+		const mockRunnerInstance = {
+			runPhase: mock(async () => ({
+				ok: true,
+				lanes: [],
+				degradedTasks: [],
+				serializedTasks: [],
+				mergeBackFailures: [],
+			})),
+			cleanup: mock(async () => {}),
+			cleanupAfterSuccess: mock(async () => {}),
+			cleanupAfterFailure: mock(async () => {}),
+		};
+
+		const origConstructor = MockLeanTurboRunner;
+		_internals.LeanTurboRunner = mock(function CustomRunner(_options: unknown) {
+			return mockRunnerInstance;
+		}) as any;
+
+		const args: LeanTurboRunPhaseArgs = {
+			directory: tmpDir,
+			phase: 1,
+			sessionID: 'test-session',
+		};
+
+		const result = await executeLeanTurboRunPhase(args);
+
+		expect(result.success).toBe(true);
+		expect(result.mergeBackFailures).toEqual([]);
+
+		_internals.LeanTurboRunner = origConstructor;
+	});
+
+	test('executeLeanTurboRunPhase includes undefined mergeBackFailures when runner omits it', async () => {
+		// The default MockLeanTurboRunner returns no mergeBackFailures
+		const args: LeanTurboRunPhaseArgs = {
+			directory: tmpDir,
+			phase: 1,
+			sessionID: 'test-session',
+		};
+
+		const result = await executeLeanTurboRunPhase(args);
+
+		expect(result.success).toBe(true);
+		expect(result.mergeBackFailures).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
 // CONFIG PROPAGATION TESTS
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/turbo/lean/guardrails-safety.test.ts
+++ b/tests/unit/turbo/lean/guardrails-safety.test.ts
@@ -7,7 +7,7 @@
  * 3. removeWorktree uses bounded retry on Windows EBUSY/EPERM (DD-10) and
  *    abandons (never falls back to --force).
  *
- * Uses the _internals DI seam pattern — no mock.module() calls.
+ * Uses the _internals DI seam pattern — no mock.module calls.
  */
 
 import {

--- a/tests/unit/turbo/lean/guardrails-safety.test.ts
+++ b/tests/unit/turbo/lean/guardrails-safety.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Guardrails safety tests for worktree isolation.
+ *
+ * Verifies three safety properties:
+ * 1. git worktree remove --force is blocked by the destructive-command guardrails.
+ * 2. removeWorktree never passes --force to its git subprocess.
+ * 3. removeWorktree uses bounded retry on Windows EBUSY/EPERM (DD-10) and
+ *    abandons (never falls back to --force).
+ *
+ * Uses the _internals DI seam pattern — no mock.module() calls.
+ */
+
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from 'bun:test';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { GuardrailsConfig } from '../../../../src/config/schema';
+import { createGuardrailsHooks } from '../../../../src/hooks/guardrails';
+import { resetSwarmState, startAgentSession } from '../../../../src/state';
+import {
+	_internals,
+	removeWorktree,
+} from '../../../../src/turbo/lean/worktree';
+import type { BunCompatSubprocess } from '../../../../src/utils/bun-compat';
+
+// ---------------------------------------------------------------------------
+// Test directory
+// ---------------------------------------------------------------------------
+
+const TEST_DIR = realpathSync(
+	mkdtempSync(join(tmpdir(), 'guardrails-safety-')),
+);
+
+afterAll(() => {
+	rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Guardrails test helpers
+// ---------------------------------------------------------------------------
+
+function defaultConfig(
+	overrides?: Partial<GuardrailsConfig>,
+): GuardrailsConfig {
+	return {
+		enabled: true,
+		max_tool_calls: 200,
+		max_duration_minutes: 30,
+		idle_timeout_minutes: 60,
+		max_repetitions: 10,
+		max_consecutive_errors: 5,
+		warning_threshold: 0.75,
+		profiles: undefined,
+		block_destructive_commands: true,
+		...overrides,
+	};
+}
+
+function makeBashInput(sessionID = 'test-session', _command: string) {
+	return { tool: 'bash', sessionID, callID: 'call-1' };
+}
+
+function makeBashOutput(command: string) {
+	return { args: { command } };
+}
+
+// ---------------------------------------------------------------------------
+// Worktree test helpers
+// ---------------------------------------------------------------------------
+
+/** Saves the real internals so tests can restore them in afterEach. */
+const realBunSpawn = _internals.bunSpawn;
+const realPlatform = _internals.platform;
+const realSleep = _internals.sleep;
+
+/**
+ * Constructs a minimal BunCompatSubprocess mock.
+ * exitCode, stdout, and stderr are configurable per test.
+ */
+function mockProc(
+	exitCode: number,
+	stdout = '',
+	stderr = '',
+): BunCompatSubprocess {
+	return {
+		exited: Promise.resolve(exitCode),
+		exitCode,
+		stdout: {
+			text: () => Promise.resolve(stdout),
+		} as unknown as BunCompatSubprocess['stdout'],
+		stderr: {
+			text: () => Promise.resolve(stderr),
+		} as unknown as BunCompatSubprocess['stderr'],
+		kill: () => {},
+	} as BunCompatSubprocess;
+}
+
+// ---------------------------------------------------------------------------
+// afterEach — restore all seams
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+	_internals.bunSpawn = realBunSpawn;
+	_internals.platform = realPlatform;
+	_internals.sleep = realSleep;
+});
+
+// ===========================================================================
+// Test 1: git worktree remove --force is blocked by guardrails
+// ===========================================================================
+
+describe('guardrails: git worktree remove --force blocked', () => {
+	beforeEach(() => {
+		resetSwarmState();
+		startAgentSession('test-session', 'coder');
+	});
+
+	test('git worktree remove --force <path> is blocked', async () => {
+		const config = defaultConfig();
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = makeBashInput(
+			'test-session',
+			'git worktree remove --force /some/path',
+		);
+		const output = makeBashOutput('git worktree remove --force /some/path');
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			/git worktree remove --force.*detected/,
+		);
+	});
+
+	test('git worktree remove --force is blocked on Windows paths', async () => {
+		const config = defaultConfig();
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = makeBashInput(
+			'test-session',
+			'git worktree remove --force C:\\worktrees\\lane-1',
+		);
+		const output = makeBashOutput(
+			'git worktree remove --force C:\\worktrees\\lane-1',
+		);
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			/git worktree remove --force.*detected/,
+		);
+	});
+
+	test('git worktree remove --FORCE (uppercase) is also blocked', async () => {
+		const config = defaultConfig();
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = makeBashInput(
+			'test-session',
+			'git worktree remove --FORCE /some/path',
+		);
+		const output = makeBashOutput('git worktree remove --FORCE /some/path');
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			/git worktree remove --force.*detected/i,
+		);
+	});
+
+	test('git worktree remove without --force is NOT blocked', async () => {
+		const config = defaultConfig();
+		const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+		const input = makeBashInput(
+			'test-session',
+			'git worktree remove /some/path',
+		);
+		const output = makeBashOutput('git worktree remove /some/path');
+		// Should NOT throw — no --force flag present
+		await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+	});
+});
+
+// ===========================================================================
+// Test 2: removeWorktree never uses --force
+// ===========================================================================
+
+describe('removeWorktree: never uses --force flag', () => {
+	const fakeWorktreePath = join('C:', 'worktrees', 'session-abc', 'lane-1');
+	const fakeProjectRoot = join('C:', 'project-root');
+
+	test('removeWorktree spawn args never contain --force', async () => {
+		const spawnCalls: string[][] = [];
+		_internals.bunSpawn = (args: string[]) => {
+			spawnCalls.push(args);
+			return mockProc(0, '', '');
+		};
+
+		await removeWorktree(fakeWorktreePath, fakeProjectRoot);
+
+		// Find the git worktree remove call
+		const worktreeCall = spawnCalls.find(
+			(args) => args[0] === 'git' && args[1] === 'worktree',
+		);
+		expect(worktreeCall).toBeDefined();
+		expect(worktreeCall).not.toContain('--force');
+		expect(worktreeCall![2]).toBe('remove');
+	});
+
+	test('removeWorktree never emits --force across retry attempts', async () => {
+		_internals.platform = 'win32';
+		_internals.sleep = async () => {};
+
+		const allSpawnArgs: string[][] = [];
+		_internals.bunSpawn = (args: string[]) => {
+			allSpawnArgs.push([...args]);
+			return mockProc(1, '', 'EBUSY: resource busy');
+		};
+
+		await removeWorktree(fakeWorktreePath, fakeProjectRoot);
+
+		// Every git worktree remove call must lack --force
+		for (const args of allSpawnArgs) {
+			if (args[1] === 'worktree') {
+				expect(args).not.toContain('--force');
+			}
+		}
+		// Verify retry attempts actually happened
+		const worktreeCalls = allSpawnArgs.filter((a) => a[1] === 'worktree');
+		expect(worktreeCalls.length).toBe(4); // initial + 3 retries
+	});
+});
+
+// ===========================================================================
+// Test 3: removeWorktree bounded retry on Windows EBUSY/EPERM (DD-10)
+// ===========================================================================
+
+describe('removeWorktree: bounded retry on Windows (DD-10)', () => {
+	const fakeWorktreePath = join('C:', 'worktrees', 'session-abc', 'lane-1');
+	const fakeProjectRoot = join('C:', 'project-root');
+
+	test('retries up to 3 times (4 total calls) on EBUSY then returns error', async () => {
+		_internals.platform = 'win32';
+		_internals.sleep = async () => {}; // no-op — skip real delays
+
+		const sleepCalls: number[] = [];
+		_internals.sleep = mock(async (ms: number) => {
+			sleepCalls.push(ms);
+		});
+
+		let attempts = 0;
+		_internals.bunSpawn = () => {
+			attempts++;
+			return mockProc(1, '', 'EBUSY: resource busy');
+		};
+
+		const result = await removeWorktree(fakeWorktreePath, fakeProjectRoot);
+
+		// Should fail after exhausting retries — never use --force
+		expect(result).toEqual({ error: 'EBUSY: resource busy' });
+		expect(attempts).toBe(4); // initial + 3 retries
+		// Sleep should have been called 3 times (delays between retries)
+		expect(sleepCalls.length).toBe(3);
+	});
+
+	test('retries on EPERM and succeeds on third attempt', async () => {
+		_internals.platform = 'win32';
+		_internals.sleep = async () => {}; // no-op
+
+		let attempts = 0;
+		_internals.bunSpawn = () => {
+			attempts++;
+			if (attempts < 3) return mockProc(1, '', 'EPERM: access denied');
+			return mockProc(0, '', '');
+		};
+
+		const result = await removeWorktree(fakeWorktreePath, fakeProjectRoot);
+
+		expect(result).toEqual({ success: true });
+		expect(attempts).toBe(3);
+	});
+
+	test('non-Windows platform does NOT retry on EBUSY', async () => {
+		_internals.platform = 'linux';
+		_internals.sleep = async () => {};
+
+		let attempts = 0;
+		_internals.bunSpawn = () => {
+			attempts++;
+			return mockProc(1, '', 'EBUSY: resource busy');
+		};
+
+		const result = await removeWorktree(fakeWorktreePath, fakeProjectRoot);
+
+		// On non-Windows, no retry — should fail immediately
+		expect(result).toEqual({ error: 'EBUSY: resource busy' });
+		expect(attempts).toBe(1);
+	});
+
+	test('non-retryable error does not trigger retry on Windows', async () => {
+		_internals.platform = 'win32';
+		_internals.sleep = async () => {};
+
+		let attempts = 0;
+		_internals.bunSpawn = () => {
+			attempts++;
+			return mockProc(1, '', 'fatal: not a git repository');
+		};
+
+		const result = await removeWorktree(fakeWorktreePath, fakeProjectRoot);
+
+		expect(result).toEqual({ error: 'fatal: not a git repository' });
+		expect(attempts).toBe(1); // no retry for non-EBUSY/EPERM
+	});
+
+	test('retry delay uses 2000ms interval', async () => {
+		_internals.platform = 'win32';
+
+		const sleepCalls: number[] = [];
+		_internals.sleep = mock(async (ms: number) => {
+			sleepCalls.push(ms);
+		});
+
+		_internals.bunSpawn = () => mockProc(1, '', 'EBUSY');
+
+		await removeWorktree(fakeWorktreePath, fakeProjectRoot);
+
+		// All retry delays should be 2000ms
+		expect(sleepCalls.length).toBe(3);
+		for (const delay of sleepCalls) {
+			expect(delay).toBe(2000);
+		}
+	});
+});

--- a/tests/unit/turbo/lean/init-safety.test.ts
+++ b/tests/unit/turbo/lean/init-safety.test.ts
@@ -11,7 +11,7 @@
  *    `startupOrphanRecovery` is called during `runPhase` when worktree_isolation
  *    is enabled, and NOT during runner construction or other lifecycle points.
  *
- * Uses the _internals DI seam pattern — no mock.module() calls.
+ * Uses the _internals DI seam pattern — no mock.module calls.
  */
 
 import {

--- a/tests/unit/turbo/lean/init-safety.test.ts
+++ b/tests/unit/turbo/lean/init-safety.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Init safety tests for worktree isolation (AGENTS.md invariant #1).
+ *
+ * Verifies two safety properties:
+ *
+ * 1. Plugin init does NOT create worktrees — the plugin entry (src/index.ts)
+ *    must NOT call any worktree functions during registration. Startup orphan
+ *    recovery runs at Lean Turbo runner init (runPhase), NOT at plugin init.
+ *
+ * 2. Startup orphan recovery runs at Lean Turbo runner init, not plugin init —
+ *    `startupOrphanRecovery` is called during `runPhase` when worktree_isolation
+ *    is enabled, and NOT during runner construction or other lifecycle points.
+ *
+ * Uses the _internals DI seam pattern — no mock.module() calls.
+ */
+
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from 'bun:test';
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DEFAULT_LEAN_TURBO_CONFIG } from '../../../../src/config/constants';
+import OpenCodeSwarm from '../../../../src/index';
+import { LeanTurboRunner } from '../../../../src/turbo/lean/runner';
+
+// ---------------------------------------------------------------------------
+// Test directories
+// ---------------------------------------------------------------------------
+
+const TEST_DIR = realpathSync(mkdtempSync(join(tmpdir(), 'init-safety-')));
+const PLUGIN_INIT_DIR = realpathSync(
+	mkdtempSync(join(tmpdir(), 'init-safety-plugin-')),
+);
+
+afterAll(() => {
+	rmSync(TEST_DIR, { recursive: true, force: true });
+	rmSync(PLUGIN_INIT_DIR, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Test #1: Plugin init does not import or call worktree functions
+// ---------------------------------------------------------------------------
+
+describe('init safety: plugin entry does not call worktree functions', () => {
+	test('src/index.ts default export has plugin shape { id, server }', () => {
+		// Dynamic import to avoid executing module-level init code at
+		// hoist time. The default export is the v1 plugin object.
+		const plugin = require('../../../../src/index');
+		const mod = plugin.default ?? plugin;
+
+		expect(mod).toBeDefined();
+		expect(typeof mod.id).toBe('string');
+		expect(mod.id).toBe('opencode-swarm');
+		expect(typeof mod.server).toBe('function');
+	});
+
+	test('src/index.ts does not import worktree or merge-back modules (static check)', () => {
+		// Supplementary static analysis: read the source and verify no runtime
+		// imports from worktree/merge-back at the plugin entry level.
+		// The authoritative runtime check is the test below.
+		const source = readFileSync(
+			join(__dirname, '../../../../src/index.ts'),
+			'utf-8',
+		);
+
+		// These import patterns would indicate a direct dependency
+		const forbiddenImports = [
+			/from ['"].*worktree/,
+			/from ['"].*merge-back/,
+			/provisionWorktree/,
+			/startupOrphanRecovery/,
+			/removeWorktree/,
+		];
+
+		for (const pattern of forbiddenImports) {
+			const re = new RegExp(pattern);
+			expect(source).not.toMatch(re);
+		}
+	});
+
+	test('plugin server init with worktree_isolation=true does NOT invoke worktree functions (runtime)', async () => {
+		// Authoritative runtime check: actually invoke the plugin server() with
+		// a project config that enables lean_turbo.worktree_isolation, and verify
+		// that provisionWorktree, removeWorktree, and startupOrphanRecovery are
+		// NOT called during init. Uses LeanTurboRunner._internals DI seams.
+		//
+		// Set up a temp project with worktree_isolation enabled in config.
+		mkdirSync(join(PLUGIN_INIT_DIR, '.opencode'), { recursive: true });
+		mkdirSync(join(PLUGIN_INIT_DIR, '.swarm'), { recursive: true });
+
+		const projectConfig = {
+			turbo: {
+				strategy: 'lean' as const,
+				lean: {
+					worktree_isolation: true,
+				},
+			},
+			quiet: true,
+		};
+		writeFileSync(
+			join(PLUGIN_INIT_DIR, '.opencode', 'opencode-swarm.json'),
+			JSON.stringify(projectConfig, null, 2),
+			'utf-8',
+		);
+
+		// Install spies on the _internals seams BEFORE calling server()
+		const realProvisionWorktree = LeanTurboRunner._internals.provisionWorktree;
+		const realRemoveWorktree = LeanTurboRunner._internals.removeWorktree;
+		const realStartupOrphanRecovery =
+			LeanTurboRunner._internals.startupOrphanRecovery;
+
+		const spyProvisionWorktree = mock(() =>
+			Promise.resolve({ worktreePath: '/fake', branchName: 'fake' }),
+		);
+		const spyRemoveWorktree = mock(() => Promise.resolve({ success: true }));
+		const spyStartupOrphanRecovery = mock(() =>
+			Promise.resolve({
+				pruned: 0,
+				orphanedBranches: [],
+				cleanedBranches: [],
+				warnings: [],
+			}),
+		);
+
+		LeanTurboRunner._internals.provisionWorktree = spyProvisionWorktree;
+		LeanTurboRunner._internals.removeWorktree = spyRemoveWorktree;
+		LeanTurboRunner._internals.startupOrphanRecovery = spyStartupOrphanRecovery;
+
+		try {
+			// Invoke the real plugin server initializer — this runs the full
+			// init path including config loading, hook creation, tool
+			// registration, etc. The mockPluginInput provides a minimal
+			// context that satisfies the Plugin type shape.
+			const mockPluginInput = {
+				client: {} as Record<string, unknown>,
+				project: {} as Record<string, unknown>,
+				directory: PLUGIN_INIT_DIR,
+				worktree: PLUGIN_INIT_DIR,
+				serverUrl: new URL('http://localhost:3000'),
+				$: {} as Record<string, unknown>,
+			};
+
+			const pluginResult = await OpenCodeSwarm.server(mockPluginInput);
+
+			// Plugin server() must return the Hooks interface
+			expect(pluginResult).toBeDefined();
+			expect(typeof pluginResult.name).toBe('string');
+
+			// ASSERT: No worktree functions were called during init
+			expect(spyProvisionWorktree).not.toHaveBeenCalled();
+			expect(spyRemoveWorktree).not.toHaveBeenCalled();
+			expect(spyStartupOrphanRecovery).not.toHaveBeenCalled();
+		} finally {
+			// Restore real functions
+			LeanTurboRunner._internals.provisionWorktree = realProvisionWorktree;
+			LeanTurboRunner._internals.removeWorktree = realRemoveWorktree;
+			LeanTurboRunner._internals.startupOrphanRecovery =
+				realStartupOrphanRecovery;
+		}
+	});
+
+	test('plugin registration does not trigger worktree creation or orphan recovery', () => {
+		// The plugin entry is a synchronous module-level object. Importing it
+		// must not trigger any async operations (git subprocesses, worktree
+		// creation, orphan recovery). This is verified structurally: the
+		// default export is a plain object, not an async function result.
+		const plugin = require('../../../../src/index');
+		const mod = plugin.default ?? plugin;
+
+		// The plugin object is a plain object created at module parse time
+		expect(typeof mod).toBe('object');
+		expect(typeof mod.server).toBe('function');
+
+		// The server function is async (wraps initializeOpenCodeSwarm) but
+		// the default export itself is synchronous — it's just the descriptor
+		// { id, server }. No worktree operations happen at module load.
+		expect(mod.server.constructor.name).toBe('AsyncFunction');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test #2: Startup orphan recovery runs at runPhase, not construction
+// ---------------------------------------------------------------------------
+
+describe('init safety: startupOrphanRecovery runs at runPhase, not construction', () => {
+	const realStartupOrphanRecovery =
+		LeanTurboRunner._internals.startupOrphanRecovery;
+	let mockStartupOrphanRecovery: ReturnType<typeof mock>;
+
+	beforeAll(() => {
+		mkdirSync(join(TEST_DIR, '.swarm'), { recursive: true });
+	});
+
+	beforeEach(() => {
+		mockStartupOrphanRecovery = mock(() =>
+			Promise.resolve({
+				pruned: 0,
+				orphanedBranches: [],
+				cleanedBranches: [],
+				warnings: [],
+			}),
+		);
+		LeanTurboRunner._internals.startupOrphanRecovery =
+			mockStartupOrphanRecovery;
+	});
+
+	afterEach(() => {
+		LeanTurboRunner._internals.startupOrphanRecovery =
+			realStartupOrphanRecovery;
+	});
+
+	/**
+	 * Writes a minimal plan.json with worktree_isolation enabled in lean config.
+	 */
+	function writePlanWithWorktreeIsolation(
+		phaseNumber = 1,
+		worktreeIsolation = true,
+	) {
+		const plan = {
+			schema_version: '1.0.0',
+			title: 'Init Safety Test Plan',
+			swarm: 'test-swarm',
+			current_phase: phaseNumber,
+			phases: [
+				{
+					id: phaseNumber,
+					name: `Phase ${phaseNumber}`,
+					status: 'in_progress',
+					tasks: [
+						{
+							id: `${phaseNumber}.1`,
+							description: 'Test task',
+							status: 'pending',
+							phase: phaseNumber,
+							size: 'small',
+							depends: [],
+							acceptance: 'Done',
+						},
+					],
+				},
+			],
+			lean: {
+				...DEFAULT_LEAN_TURBO_CONFIG,
+				worktree_isolation: worktreeIsolation,
+				max_parallel_coders: 1,
+				phase_reviewer: false,
+				phase_critic: false,
+				integrated_diff_required: false,
+			},
+		};
+
+		writeFileSync(
+			join(TEST_DIR, '.swarm', 'plan.json'),
+			JSON.stringify(plan, null, 2),
+			'utf-8',
+		);
+	}
+
+	test('runner construction does NOT call startupOrphanRecovery', () => {
+		LeanTurboRunner._internals.startupOrphanRecovery =
+			mockStartupOrphanRecovery;
+
+		// Construct runner — should NOT call startupOrphanRecovery
+		new LeanTurboRunner({
+			directory: TEST_DIR,
+			sessionID: 'sess-init-safety',
+			leanConfig: {
+				...DEFAULT_LEAN_TURBO_CONFIG,
+				worktree_isolation: true,
+			},
+		});
+
+		expect(mockStartupOrphanRecovery).not.toHaveBeenCalled();
+	});
+
+	test('runPhase with worktree_isolation=true DOES call startupOrphanRecovery', async () => {
+		writePlanWithWorktreeIsolation(1, true);
+		LeanTurboRunner._internals.startupOrphanRecovery =
+			mockStartupOrphanRecovery;
+
+		const runner = new LeanTurboRunner({
+			directory: TEST_DIR,
+			sessionID: 'sess-init-safety-phase',
+			leanConfig: {
+				...DEFAULT_LEAN_TURBO_CONFIG,
+				worktree_isolation: true,
+			},
+		});
+
+		// Omit opencodeClient to stay in test mode (no fail-closed).
+		// runPhase calls startupOrphanRecovery early (before dispatch),
+		// so the mock is verified even though dispatch ultimately fails.
+		await runner.runPhase(1);
+
+		expect(mockStartupOrphanRecovery).toHaveBeenCalledTimes(1);
+		expect(mockStartupOrphanRecovery).toHaveBeenCalledWith(
+			TEST_DIR,
+			expect.arrayContaining(['sess-init-safety-phase']),
+		);
+	});
+
+	test('runPhase with worktree_isolation=false does NOT call startupOrphanRecovery', async () => {
+		writePlanWithWorktreeIsolation(1, false);
+		LeanTurboRunner._internals.startupOrphanRecovery =
+			mockStartupOrphanRecovery;
+
+		const runner = new LeanTurboRunner({
+			directory: TEST_DIR,
+			sessionID: 'sess-init-safety-no-wt',
+			leanConfig: {
+				...DEFAULT_LEAN_TURBO_CONFIG,
+				worktree_isolation: false,
+			},
+		});
+
+		await runner.runPhase(1);
+
+		expect(mockStartupOrphanRecovery).not.toHaveBeenCalled();
+	});
+
+	test('runPhase without lean config (defaults) does NOT call startupOrphanRecovery', async () => {
+		writePlanWithWorktreeIsolation(1, false);
+		LeanTurboRunner._internals.startupOrphanRecovery =
+			mockStartupOrphanRecovery;
+
+		const runner = new LeanTurboRunner({
+			directory: TEST_DIR,
+			sessionID: 'sess-init-safety-defaults',
+			// No leanConfig — uses defaults, worktree_isolation defaults to false
+		});
+
+		await runner.runPhase(1);
+
+		expect(mockStartupOrphanRecovery).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/turbo/lean/integration-worktree.test.ts
+++ b/tests/unit/turbo/lean/integration-worktree.test.ts
@@ -1,0 +1,1848 @@
+/**
+ * End-to-end integration tests for worktree isolation.
+ *
+ * Validates the full worktree isolation feature across AC-1 through AC-12,
+ * covering config acceptance, per-lane worktree creation, .swarm/ state
+ * anchoring, merge-back, conflict handling, graceful degradation,
+ * guardrails safety, init safety, cross-platform paths, branch cleanup,
+ * Windows file-lock retry, git clean -fd, and no dependency management.
+ *
+ * Strategy:
+ * - Uses LeanTurboRunner with _internals DI seams for mocking subprocess calls
+ * - Uses writeMinimalPlan helper pattern from runner.test.ts
+ * - Mocks bunSpawn via worktree._internals and merge-back._internals for git simulation
+ * - No mock.module usage — all mocking via instance seam or _internals
+ * - Each test is self-contained and independent
+ * - All temp dirs use os.tmpdir() + path.join() — no hardcoded paths
+ * - All seams restored in afterEach
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { DEFAULT_LEAN_TURBO_CONFIG } from '../../../../src/config/constants';
+import type { GuardrailsConfig } from '../../../../src/config/schema';
+import { createGuardrailsHooks } from '../../../../src/hooks/guardrails';
+import { resetSwarmState, startAgentSession } from '../../../../src/state';
+import * as mergeBackModule from '../../../../src/turbo/lean/merge-back';
+import type { LaneResult } from '../../../../src/turbo/lean/runner';
+import { LeanTurboRunner } from '../../../../src/turbo/lean/runner';
+import type {
+	LeanTurboLane,
+	LeanTurboRunState,
+} from '../../../../src/turbo/lean/state';
+import * as leanState from '../../../../src/turbo/lean/state';
+import * as worktreeModule from '../../../../src/turbo/lean/worktree';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const SESSION_ID = 'sess-integration-wt';
+
+// ─── Shared helpers ───────────────────────────────────────────────────────────
+
+interface MockSessionOps {
+	create: ReturnType<typeof mock>;
+	prompt: ReturnType<typeof mock>;
+	delete: ReturnType<typeof mock>;
+}
+
+let tmpDir: string;
+let mockSessionOps: MockSessionOps;
+
+/**
+ * Real seams saved at module scope so afterEach can restore them.
+ */
+const savedRunnerInternals = {
+	provisionWorktree: LeanTurboRunner._internals.provisionWorktree,
+	removeWorktree: LeanTurboRunner._internals.removeWorktree,
+	mergeLaneBranch: LeanTurboRunner._internals.mergeLaneBranch,
+	postMergeCleanup: LeanTurboRunner._internals.postMergeCleanup,
+	attemptMergeBackFromDirty:
+		LeanTurboRunner._internals.attemptMergeBackFromDirty,
+	startupOrphanRecovery: LeanTurboRunner._internals.startupOrphanRecovery,
+	getMergeStrategy: LeanTurboRunner._internals.getMergeStrategy,
+	assertCleanWorkingTree: LeanTurboRunner._internals.assertCleanWorkingTree,
+	acquireLaneLocks: LeanTurboRunner._internals.acquireLaneLocks,
+	releaseLaneLocks: LeanTurboRunner._internals.releaseLaneLocks,
+	loadLeanTurboRunState: LeanTurboRunner._internals.loadLeanTurboRunState,
+	saveLeanTurboRunState: LeanTurboRunner._internals.saveLeanTurboRunState,
+	hasActiveFullAuto: LeanTurboRunner._internals.hasActiveFullAuto,
+	loadFullAutoRunState: LeanTurboRunner._internals.loadFullAutoRunState,
+	writeLaneEvidence: LeanTurboRunner._internals.writeLaneEvidence,
+	planLeanTurboLanes: LeanTurboRunner._internals.planLeanTurboLanes,
+	laneDispatchTimeoutMs: LeanTurboRunner._internals.laneDispatchTimeoutMs,
+	loadPlanJsonOnly: LeanTurboRunner._internals.loadPlanJsonOnly,
+};
+
+const savedWorktreeInternals = { ...worktreeModule._internals };
+
+const savedMergeBackInternals = { ...mergeBackModule._internals };
+
+function makeRunner(options?: {
+	opencodeClient?: null;
+	generatedAgentNames?: string[];
+	leanConfig?: Partial<typeof DEFAULT_LEAN_TURBO_CONFIG>;
+}) {
+	const leanConfig = { ...DEFAULT_LEAN_TURBO_CONFIG, ...options?.leanConfig };
+	const runnerOpts: Record<string, unknown> = {
+		directory: tmpDir,
+		sessionID: SESSION_ID,
+		leanConfig,
+	};
+	// Only include opencodeClient when explicitly provided (not undefined).
+	// Omitting it allows the constructor to leave _client undefined,
+	// bypassing the fail-closed check and enabling test mock injection
+	// via the _sessionOps seam.
+	if (options?.opencodeClient !== undefined) {
+		runnerOpts.opencodeClient = options.opencodeClient;
+	}
+	if (options?.generatedAgentNames) {
+		runnerOpts.generatedAgentNames = options.generatedAgentNames;
+	}
+	return new LeanTurboRunner(
+		runnerOpts as ConstructorParameters<typeof LeanTurboRunner>[0],
+	);
+}
+
+function injectMockSessionOps(runner: LeanTurboRunner, ops: MockSessionOps) {
+	(runner as unknown as { _sessionOps: MockSessionOps })._sessionOps = ops;
+}
+
+function writeMinimalPlan(
+	phaseNumber = 1,
+	overrides?: { worktreeIsolation?: boolean },
+) {
+	const plan = {
+		schema_version: '1.0.0',
+		title: 'Integration Worktree Test Plan',
+		swarm: 'test-swarm',
+		current_phase: phaseNumber,
+		phases: [
+			{
+				id: phaseNumber,
+				name: `Phase ${phaseNumber}`,
+				status: 'in_progress',
+				tasks: [
+					{
+						id: `${phaseNumber}.1`,
+						description: 'Task A',
+						status: 'pending',
+						phase: phaseNumber,
+						size: 'small',
+						depends: [],
+						acceptance: 'Done',
+					},
+					{
+						id: `${phaseNumber}.2`,
+						description: 'Task B',
+						status: 'pending',
+						phase: phaseNumber,
+						size: 'small',
+						depends: [],
+						acceptance: 'Done',
+					},
+				],
+			},
+		],
+		lean: {
+			max_parallel_coders: 4,
+			require_declared_scope: false,
+			conflict_policy: 'serialize',
+			degrade_on_risk: true,
+			phase_reviewer: false,
+			phase_critic: false,
+			integrated_diff_required: false,
+			allow_docs_only_without_reviewer: false,
+			worktree_isolation: overrides?.worktreeIsolation ?? false,
+		},
+	};
+
+	fs.writeFileSync(
+		path.join(tmpDir, '.swarm', 'plan.json'),
+		JSON.stringify(plan, null, 2),
+		'utf-8',
+	);
+}
+
+function writeScopeFiles(taskFiles: Record<string, string[]>) {
+	const scopeDir = path.join(tmpDir, '.swarm', 'scopes');
+	fs.mkdirSync(scopeDir, { recursive: true });
+	for (const [taskId, files] of Object.entries(taskFiles)) {
+		fs.writeFileSync(
+			path.join(scopeDir, `scope-${taskId}.json`),
+			JSON.stringify({ files }),
+			'utf-8',
+		);
+	}
+}
+
+function mockSuccessfulSessionOps() {
+	const mockCreate = mock(() =>
+		Promise.resolve({
+			data: { id: `session-${Math.random().toString(36).slice(2)}` },
+			error: null,
+		}),
+	);
+	const mockPrompt = mock(() =>
+		Promise.resolve({
+			data: { parts: [{ type: 'text', text: 'Done' }] },
+			error: null,
+		}),
+	);
+	const mockDelete = mock(() => Promise.resolve());
+	return { create: mockCreate, prompt: mockPrompt, delete: mockDelete };
+}
+
+function mockFailingSessionOps(errorMsg = 'session create failed') {
+	const failingOps = {
+		create: mock(() => Promise.resolve({ data: null, error: errorMsg })),
+		prompt: mock(() => Promise.resolve({ data: null, error: 'prompt failed' })),
+		delete: mock(() => Promise.resolve()),
+	};
+	return failingOps;
+}
+
+/** Produces a deterministic worktree path for a given lane ID. */
+function fakeWorktreePath(laneId: string): string {
+	return path.join(tmpDir, '.swarm-worktrees', SESSION_ID, laneId);
+}
+
+function fakeBranchName(laneId: string): string {
+	return `swarm-lane/${SESSION_ID}/${laneId}`;
+}
+
+/**
+ * Installs a standard set of runner._internals mocks for worktree-mode tests.
+ * Returns an object tracking all mock calls for verification.
+ */
+function setupWorktreeMocks() {
+	const provisionCalls: unknown[] = [];
+	const removeCalls: unknown[] = [];
+	const mergeCalls: unknown[] = [];
+	const cleanupCalls: unknown[] = [];
+	const attemptMergeCalls: unknown[] = [];
+	const recoveryCalls: unknown[] = [];
+	const acquireCalls: unknown[] = [];
+	const releaseCalls: unknown[] = [];
+
+	let provisionIdx = 0;
+
+	LeanTurboRunner._internals.provisionWorktree = mock(() => {
+		const idx = provisionIdx++;
+		provisionCalls.push(idx);
+		const laneId = `lane-${idx + 1}`;
+		return Promise.resolve({
+			worktreePath: fakeWorktreePath(laneId),
+			branchName: fakeBranchName(laneId),
+		});
+	});
+	LeanTurboRunner._internals.removeWorktree = mock(() =>
+		Promise.resolve({ success: true }),
+	);
+	LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+		Promise.resolve({ merged: true, strategy: 'merge' }),
+	);
+	LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+		Promise.resolve({ cleaned: true }),
+	);
+	LeanTurboRunner._internals.attemptMergeBackFromDirty = mock(() =>
+		Promise.resolve({
+			merged: true,
+			strategy: 'merge',
+			autoCommitted: false,
+			cleaned: false,
+		}),
+	);
+	LeanTurboRunner._internals.startupOrphanRecovery = mock(() =>
+		Promise.resolve({
+			prunedWorktrees: true,
+			remainingBranches: [],
+			warnings: [],
+		}),
+	);
+	LeanTurboRunner._internals.acquireLaneLocks = mock(() =>
+		Promise.resolve({ acquired: true, lockFiles: ['test.lock'] }),
+	);
+	LeanTurboRunner._internals.releaseLaneLocks = mock(() => Promise.resolve(1));
+
+	return {
+		provisionCalls,
+		removeCalls,
+		mergeCalls,
+		cleanupCalls,
+		attemptMergeCalls,
+		recoveryCalls,
+		acquireCalls,
+		releaseCalls,
+	};
+}
+
+/** Restores all saved runner/worktree/merge-back internals. */
+function restoreAllSeams() {
+	Object.assign(LeanTurboRunner._internals, savedRunnerInternals);
+	Object.assign(worktreeModule._internals, savedWorktreeInternals);
+	Object.assign(mergeBackModule._internals, savedMergeBackInternals);
+}
+
+// ─── Setup / Teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+	tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'integ-wt-')));
+	fs.mkdirSync(path.join(tmpDir, '.swarm'), { recursive: true });
+	leanState.repairStateUnreadable(tmpDir);
+	mockSessionOps = mockSuccessfulSessionOps();
+
+	// Default mock: assertCleanWorkingTree returns clean so worktree_isolation
+	// tests work without needing a real git repo. restoreAllSeams in afterEach
+	// restores the original function from savedRunnerInternals.
+	LeanTurboRunner._internals.assertCleanWorkingTree = mock(() =>
+		Promise.resolve({ clean: true }),
+	);
+});
+
+afterEach(() => {
+	restoreAllSeams();
+	leanState.repairStateUnreadable(tmpDir);
+	try {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	} catch {
+		// best-effort cleanup
+	}
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// AC-1: Config acceptance — worktree_isolation: true triggers worktree mode
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('AC-1: config acceptance — worktree_isolation triggers worktree mode', () => {
+	test('worktree_isolation: true enables provisionWorktree calls during runPhase', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'], '1.2': ['src/b.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+		const mocks = setupWorktreeMocks();
+
+		await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		// provisionWorktree should have been called at least once
+		expect(mocks.provisionCalls.length).toBeGreaterThan(0);
+	});
+
+	test('worktree_isolation: false does NOT call provisionWorktree', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'], '1.2': ['src/b.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: false },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+		const mocks = setupWorktreeMocks();
+
+		await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(mocks.provisionCalls.length).toBe(0);
+	});
+
+	test('DEFAULT_LEAN_TURBO_CONFIG has worktree_isolation false', () => {
+		expect(DEFAULT_LEAN_TURBO_CONFIG.worktree_isolation).toBe(false);
+	});
+
+	test('config schema accepts worktree_isolation boolean', () => {
+		const config = { ...DEFAULT_LEAN_TURBO_CONFIG, worktree_isolation: true };
+		expect(typeof config.worktree_isolation).toBe('boolean');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// AC-2: Per-lane worktree creation — each lane gets a distinct worktree directory
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('AC-2: per-lane worktree creation — distinct worktree directories', () => {
+	test('two lanes get two different worktree paths', async () => {
+		writeMinimalPlan(1);
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Force the planner to return two distinct lanes
+		LeanTurboRunner._internals.planLeanTurboLanes = mock(
+			(
+				..._args: Parameters<typeof savedRunnerInternals.planLeanTurboLanes>
+			) => ({
+				phase: 1,
+				planId: 'test-plan',
+				lanes: [
+					{
+						laneId: 'lane-alpha',
+						taskIds: ['1.1'],
+						files: ['src/a.ts'],
+						status: 'pending' as const,
+					},
+					{
+						laneId: 'lane-beta',
+						taskIds: ['1.2'],
+						files: ['src/b.ts'],
+						status: 'pending' as const,
+					},
+				],
+				degradedTasks: [],
+				serializedTasks: [],
+				counters: {
+					lanesPlanned: 2,
+					lanesStarted: 0,
+					lanesCompleted: 0,
+					lanesFailed: 0,
+					tasksSerialized: 0,
+					tasksDegraded: 0,
+				},
+				crossLaneDependencies: {},
+			}),
+		);
+
+		// Track provision calls to capture distinct paths
+		const provisionedPaths: string[] = [];
+		const origProvision = savedRunnerInternals.provisionWorktree;
+		const provisionIdx = 0;
+		LeanTurboRunner._internals.provisionWorktree = mock(
+			(...args: Parameters<typeof origProvision>) => {
+				// laneId is args[1]
+				const laneId = args[1] as string;
+				const wtPath = fakeWorktreePath(laneId);
+				provisionedPaths.push(wtPath);
+				return Promise.resolve({
+					worktreePath: wtPath,
+					branchName: fakeBranchName(laneId),
+				});
+			},
+		);
+
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(() =>
+			Promise.resolve({
+				prunedWorktrees: true,
+				remainingBranches: [],
+				warnings: [],
+			}),
+		);
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(provisionedPaths.length).toBe(2);
+		expect(provisionedPaths[0]).not.toBe(provisionedPaths[1]);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// AC-3: .swarm/ state anchoring — state resolves to primary root, not worktree
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('AC-3: .swarm/ state anchoring — primary root directory', () => {
+	test('lock acquisition uses primary root, not worktree path', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const worktreePath = fakeWorktreePath('lane-1');
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		const acquireCalls: Array<{ directory: string }> = [];
+		LeanTurboRunner._internals.acquireLaneLocks = mock(
+			(...args: Parameters<typeof savedRunnerInternals.acquireLaneLocks>) => {
+				acquireCalls.push({ directory: args[0] as string });
+				return Promise.resolve({ acquired: true, lockFiles: ['test.lock'] });
+			},
+		);
+
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath,
+				branchName: fakeBranchName('lane-1'),
+			}),
+		);
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(acquireCalls.length).toBeGreaterThan(0);
+		expect(acquireCalls[0].directory).toBe(tmpDir);
+		expect(acquireCalls[0].directory).not.toBe(worktreePath);
+	});
+
+	test('lock release uses primary root, not worktree path', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const worktreePath = fakeWorktreePath('lane-1');
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		const releaseCalls: Array<{ directory: string }> = [];
+		LeanTurboRunner._internals.releaseLaneLocks = mock(
+			(...args: Parameters<typeof savedRunnerInternals.releaseLaneLocks>) => {
+				releaseCalls.push({ directory: args[0] as string });
+				return Promise.resolve(1);
+			},
+		);
+
+		LeanTurboRunner._internals.acquireLaneLocks = mock(() =>
+			Promise.resolve({ acquired: true, lockFiles: ['test.lock'] }),
+		);
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath,
+				branchName: fakeBranchName('lane-1'),
+			}),
+		);
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(releaseCalls.length).toBeGreaterThan(0);
+		expect(releaseCalls[0].directory).toBe(tmpDir);
+		expect(releaseCalls[0].directory).not.toBe(worktreePath);
+	});
+
+	test('durable state is written to primary root .swarm/, not worktree', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const worktreePath = fakeWorktreePath('lane-1');
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+		setupWorktreeMocks();
+
+		await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		// Verify turbo-state.json exists in primary root's .swarm/
+		const statePath = path.join(tmpDir, '.swarm', 'turbo-state.json');
+		expect(fs.existsSync(statePath)).toBe(true);
+
+		// Worktree path should NOT have its own .swarm/turbo-state.json
+		const wtStatePath = path.join(worktreePath, '.swarm', 'turbo-state.json');
+		expect(fs.existsSync(wtStatePath)).toBe(false);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// AC-4: Merge-back success — after successful lane, merge-back integrates changes
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('AC-4: merge-back success after successful lane', () => {
+	test('mergeLaneBranch + removeWorktree + postMergeCleanup called in order for completed lane', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		const callOrder: string[] = [];
+
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath: fakeWorktreePath('lane-1'),
+				branchName: fakeBranchName('lane-1'),
+			}),
+		);
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(() =>
+			Promise.resolve({
+				prunedWorktrees: true,
+				remainingBranches: [],
+				warnings: [],
+			}),
+		);
+		LeanTurboRunner._internals.acquireLaneLocks = mock(() =>
+			Promise.resolve({ acquired: true, lockFiles: ['test.lock'] }),
+		);
+		LeanTurboRunner._internals.releaseLaneLocks = mock(() =>
+			Promise.resolve(1),
+		);
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() => {
+			callOrder.push('merge');
+			return Promise.resolve({ merged: true, strategy: 'merge' });
+		});
+		LeanTurboRunner._internals.postMergeCleanup = mock(() => {
+			callOrder.push('cleanup');
+			return Promise.resolve({ cleaned: true });
+		});
+		LeanTurboRunner._internals.removeWorktree = mock(() => {
+			callOrder.push('remove');
+			return Promise.resolve({ success: true });
+		});
+
+		await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(callOrder).toEqual(['merge', 'remove', 'cleanup']);
+	});
+
+	test('mergeLaneBranch called with correct primary directory and branch name', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const branchName = fakeBranchName('lane-1');
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+		setupWorktreeMocks();
+
+		const mergeArgs: unknown[] = [];
+		LeanTurboRunner._internals.mergeLaneBranch = mock(
+			(...args: Parameters<typeof savedRunnerInternals.mergeLaneBranch>) => {
+				mergeArgs.push(args);
+				return Promise.resolve({ merged: true, strategy: 'merge' });
+			},
+		);
+
+		await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(mergeArgs.length).toBeGreaterThan(0);
+		// First arg = primary directory
+		expect(mergeArgs[0][0]).toBe(tmpDir);
+		// Second arg = branch name
+		expect(mergeArgs[0][1]).toBe(branchName);
+	});
+
+	test('session.create receives worktree path, not primary directory', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const worktreePath = fakeWorktreePath('lane-1');
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath,
+				branchName: fakeBranchName('lane-1'),
+			}),
+		);
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(() =>
+			Promise.resolve({
+				prunedWorktrees: true,
+				remainingBranches: [],
+				warnings: [],
+			}),
+		);
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(mockSessionOps.create).toHaveBeenCalled();
+		const createCall = mockSessionOps.create.mock.calls[0];
+		expect(
+			(createCall[0] as { query: { directory: string } }).query.directory,
+		).toBe(worktreePath);
+		expect(
+			(createCall[0] as { query: { directory: string } }).query.directory,
+		).not.toBe(tmpDir);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// AC-5: Failed lane isolation — failed lane doesn't corrupt others or primary
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('AC-5: failed lane isolation', () => {
+	test('failed lane does not prevent other lanes from completing', async () => {
+		writeMinimalPlan(1);
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder', 'local_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Force two lanes
+		LeanTurboRunner._internals.planLeanTurboLanes = mock(
+			(
+				..._args: Parameters<typeof savedRunnerInternals.planLeanTurboLanes>
+			) => ({
+				phase: 1,
+				planId: 'test-plan',
+				lanes: [
+					{
+						laneId: 'lane-ok',
+						taskIds: ['1.1'],
+						files: ['src/a.ts'],
+						status: 'pending' as const,
+					},
+					{
+						laneId: 'lane-fail',
+						taskIds: ['1.2'],
+						files: ['src/b.ts'],
+						status: 'pending' as const,
+					},
+				],
+				degradedTasks: [],
+				serializedTasks: [],
+				counters: {
+					lanesPlanned: 2,
+					lanesStarted: 0,
+					lanesCompleted: 0,
+					lanesFailed: 0,
+					tasksSerialized: 0,
+					tasksDegraded: 0,
+				},
+				crossLaneDependencies: {},
+			}),
+		);
+
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(() =>
+			Promise.resolve({
+				prunedWorktrees: true,
+				remainingBranches: [],
+				warnings: [],
+			}),
+		);
+
+		// Track provision calls to give lane-ok success and lane-fail worktree
+		let provisionIdx = 0;
+		LeanTurboRunner._internals.provisionWorktree = mock(() => {
+			provisionIdx++;
+			const laneId = provisionIdx === 1 ? 'lane-ok' : 'lane-fail';
+			return Promise.resolve({
+				worktreePath: fakeWorktreePath(laneId),
+				branchName: fakeBranchName(laneId),
+			});
+		});
+
+		// Make session.create fail only for the second call (lane-fail)
+		let createCallCount = 0;
+		const selectiveFailingOps = {
+			create: mock(() => {
+				createCallCount++;
+				if (createCallCount === 2) {
+					return Promise.resolve({
+						data: null,
+						error: 'session create failed',
+					});
+				}
+				return Promise.resolve({
+					data: { id: `session-${createCallCount}` },
+					error: null,
+				});
+			}),
+			prompt: mock(() =>
+				Promise.resolve({
+					data: { parts: [{ type: 'text', text: 'Done' }] },
+					error: null,
+				}),
+			),
+			delete: mock(() => Promise.resolve()),
+		};
+		// Override mockSessionOps for this test
+		injectMockSessionOps(runner, selectiveFailingOps);
+
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		LeanTurboRunner._internals.attemptMergeBackFromDirty = mock(() =>
+			Promise.resolve({
+				merged: true,
+				strategy: 'merge',
+				autoCommitted: false,
+				cleaned: false,
+			}),
+		);
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		const result = await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(result.ok).toBe(true);
+		expect(result.lanes.length).toBe(2);
+
+		const completedLanes = result.lanes.filter(
+			(l: LaneResult) => l.status === 'completed',
+		);
+		const failedLanes = result.lanes.filter(
+			(l: LaneResult) => l.status === 'failed',
+		);
+
+		// lane-ok should complete
+		expect(completedLanes.length).toBe(1);
+		// lane-fail should fail
+		expect(failedLanes.length).toBe(1);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// AC-6: Conflict handling — merge conflicts detected and handled gracefully
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('AC-6: conflict handling — merge conflicts', () => {
+	test('mergeLaneBranch conflict returns conflict result without throwing', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath: fakeWorktreePath('lane-1'),
+				branchName: fakeBranchName('lane-1'),
+			}),
+		);
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(() =>
+			Promise.resolve({
+				prunedWorktrees: true,
+				remainingBranches: [],
+				warnings: [],
+			}),
+		);
+
+		// Merge returns a conflict
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({
+				conflict: true,
+				files: ['src/a.ts'],
+				message: 'CONFLICT (content) Merge conflict in src/a.ts',
+			}),
+		);
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		// runPhase should still complete without throwing
+		const result = await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(result.ok).toBe(true);
+		// Lane should still complete — dispatch succeeded even if merge had conflict
+		const completedLanes = result.lanes.filter(
+			(l: LaneResult) => l.status === 'completed',
+		);
+		expect(completedLanes.length).toBeGreaterThan(0);
+	});
+
+	test('getMergeStrategy returns config merge_strategy or defaults to merge', () => {
+		expect(
+			mergeBackModule.getMergeStrategy({ ...DEFAULT_LEAN_TURBO_CONFIG }),
+		).toBe('merge');
+		expect(
+			mergeBackModule.getMergeStrategy({
+				...DEFAULT_LEAN_TURBO_CONFIG,
+				merge_strategy: 'rebase',
+			}),
+		).toBe('rebase');
+		expect(
+			mergeBackModule.getMergeStrategy({
+				...DEFAULT_LEAN_TURBO_CONFIG,
+				merge_strategy: 'cherry-pick',
+			}),
+		).toBe('cherry-pick');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// AC-7: Provision failure — explicit lane failure (no degradation)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('AC-7: provision failure — explicit lane failure (no degradation)', () => {
+	test('provisionWorktree returning error fails the lane explicitly', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				error: 'git worktree add failed: worktree already exists',
+			}),
+		);
+
+		const result = await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(result.ok).toBe(true);
+		expect(result.lanes.length).toBeGreaterThan(0);
+		const failedLanes = result.lanes.filter(
+			(l: LaneResult) => l.status === 'failed',
+		);
+		expect(failedLanes.length).toBeGreaterThan(0);
+		expect(failedLanes[0].error).toContain('worktree provision failed');
+		// Lane failed before dispatch — session.create should NOT have been called
+		expect(mockSessionOps.create).not.toHaveBeenCalled();
+	});
+
+	test('provisionWorktree throwing also fails the lane explicitly', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.reject(new Error('fatal: not a git repository')),
+		);
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		const result = await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(result.ok).toBe(true);
+		expect(result.lanes.length).toBeGreaterThan(0);
+		const failedLanes = result.lanes.filter(
+			(l: LaneResult) => l.status === 'failed',
+		);
+		expect(failedLanes.length).toBeGreaterThan(0);
+		expect(failedLanes[0].error).toContain('worktree provision failed');
+		// Lane failed before dispatch — session.create should NOT have been called
+		expect(mockSessionOps.create).not.toHaveBeenCalled();
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// AC-8: Guardrails safety — git worktree remove --force remains blocked
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('AC-8: guardrails safety — git worktree remove --force blocked at runtime', () => {
+	function defaultGuardrailsConfig(
+		overrides?: Partial<GuardrailsConfig>,
+	): GuardrailsConfig {
+		return {
+			enabled: true,
+			max_tool_calls: 200,
+			max_duration_minutes: 30,
+			idle_timeout_minutes: 60,
+			max_repetitions: 10,
+			max_consecutive_errors: 5,
+			warning_threshold: 0.75,
+			profiles: undefined,
+			block_destructive_commands: true,
+			...overrides,
+		};
+	}
+
+	beforeEach(() => {
+		resetSwarmState();
+		startAgentSession(SESSION_ID, 'coder');
+	});
+
+	test('git worktree remove --force is rejected by guardrails toolBefore hook', async () => {
+		const config = defaultGuardrailsConfig();
+		const hooks = createGuardrailsHooks(tmpDir, undefined, config);
+
+		const input = {
+			tool: 'bash',
+			sessionID: SESSION_ID,
+			callID: 'call-1',
+		};
+		const output = {
+			args: { command: 'git worktree remove --force /some/path' },
+		};
+
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			/git worktree remove --force.*detected/,
+		);
+	});
+
+	test('git worktree remove --force with Windows path is rejected', async () => {
+		const config = defaultGuardrailsConfig();
+		const hooks = createGuardrailsHooks(tmpDir, undefined, config);
+
+		const input = {
+			tool: 'bash',
+			sessionID: SESSION_ID,
+			callID: 'call-2',
+		};
+		const output = {
+			args: { command: 'git worktree remove --force C:\\worktrees\\lane-1' },
+		};
+
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			/git worktree remove --force.*detected/,
+		);
+	});
+
+	test('git worktree remove --FORCE (uppercase) is also rejected', async () => {
+		const config = defaultGuardrailsConfig();
+		const hooks = createGuardrailsHooks(tmpDir, undefined, config);
+
+		const input = {
+			tool: 'bash',
+			sessionID: SESSION_ID,
+			callID: 'call-3',
+		};
+		const output = {
+			args: { command: 'git worktree remove --FORCE /some/path' },
+		};
+
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			/git worktree remove --force.*detected/i,
+		);
+	});
+
+	test('git worktree remove without --force is NOT rejected', async () => {
+		const config = defaultGuardrailsConfig();
+		const hooks = createGuardrailsHooks(tmpDir, undefined, config);
+
+		const input = {
+			tool: 'bash',
+			sessionID: SESSION_ID,
+			callID: 'call-4',
+		};
+		const output = {
+			args: { command: 'git worktree remove /some/path' },
+		};
+
+		// Should NOT throw — no --force flag present
+		await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+	});
+
+	test('guardrails disabled allows any command through', async () => {
+		const config = defaultGuardrailsConfig({
+			enabled: false,
+		});
+		const hooks = createGuardrailsHooks(tmpDir, undefined, config);
+
+		const input = {
+			tool: 'bash',
+			sessionID: SESSION_ID,
+			callID: 'call-5',
+		};
+		const output = {
+			args: { command: 'git worktree remove --force /some/path' },
+		};
+
+		// When guardrails disabled, destructive command should not be blocked
+		await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+	});
+});
+
+describe('AC-8: supplemental static source checks — no --force in worktree source', () => {
+	test('worktree.ts source does not contain "worktree remove --force"', () => {
+		const source = fs.readFileSync(
+			path.resolve(__dirname, '../../../../src/turbo/lean/worktree.ts'),
+			'utf-8',
+		);
+		expect(source).not.toContain('worktree remove --force');
+	});
+
+	test('runner.ts source does not contain "worktree remove --force"', () => {
+		const source = fs.readFileSync(
+			path.resolve(__dirname, '../../../../src/turbo/lean/runner.ts'),
+			'utf-8',
+		);
+		expect(source).not.toContain('worktree remove --force');
+	});
+
+	test('merge-back.ts source does not contain "worktree remove --force"', () => {
+		const source = fs.readFileSync(
+			path.resolve(__dirname, '../../../../src/turbo/lean/merge-back.ts'),
+			'utf-8',
+		);
+		expect(source).not.toContain('worktree remove --force');
+	});
+
+	test('removeWorktree function calls git worktree remove WITHOUT --force flag', () => {
+		const source = fs.readFileSync(
+			path.resolve(__dirname, '../../../../src/turbo/lean/worktree.ts'),
+			'utf-8',
+		);
+		expect(source).toContain("'worktree', 'remove'");
+		expect(source).not.toMatch(/'worktree',\s*'remove'.*--force/);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// AC-9: Init safety — plugin init doesn't create worktrees
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('AC-9: init safety — no worktree creation during init', () => {
+	test('runner constructor does not call provisionWorktree', () => {
+		// Simply constructing the runner should not trigger any worktree operations
+		const provisionCalls: unknown[] = [];
+		LeanTurboRunner._internals.provisionWorktree = mock(
+			(...args: Parameters<typeof savedRunnerInternals.provisionWorktree>) => {
+				provisionCalls.push(args);
+				return Promise.resolve({
+					worktreePath: fakeWorktreePath('lane-1'),
+					branchName: fakeBranchName('lane-1'),
+				});
+			},
+		);
+
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+
+		restoreAllSeams();
+
+		// Construction should not call provisionWorktree
+		expect(provisionCalls.length).toBe(0);
+	});
+
+	test('runPhase with null client returns immediately without worktree ops', async () => {
+		const provisionCalls: unknown[] = [];
+		LeanTurboRunner._internals.provisionWorktree = mock(
+			(...args: Parameters<typeof savedRunnerInternals.provisionWorktree>) => {
+				provisionCalls.push(args);
+				return Promise.resolve({
+					worktreePath: fakeWorktreePath('lane-1'),
+					branchName: fakeBranchName('lane-1'),
+				});
+			},
+		);
+
+		const runner = makeRunner({
+			opencodeClient: null,
+			leanConfig: { worktree_isolation: true },
+		});
+		const result = await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(result.ok).toBe(false);
+		expect(result.reason).toBe('NO_CLIENT');
+		expect(provisionCalls.length).toBe(0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// AC-10: Cross-platform path handling — path budget checked on Windows
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('AC-10: cross-platform path handling — Windows path budget', () => {
+	test('checkPathBudget returns ok:true on non-Windows platform regardless of path length', async () => {
+		const realPlatform = worktreeModule._internals.platform;
+		worktreeModule._internals.platform = 'linux';
+
+		// Mock bunSpawn to return a file list with a very long path
+		worktreeModule._internals.bunSpawn = mock(() => ({
+			exited: Promise.resolve(0),
+			exitCode: 0,
+			stdout: {
+				text: () =>
+					Promise.resolve(
+						'a/very/deeply/nested/long/path/that/exceeds/budget/file.ts',
+					),
+			},
+			stderr: { text: () => Promise.resolve('') },
+		}));
+
+		const result = await worktreeModule.checkPathBudget(
+			path.join(
+				'C:\\Users\\VeryLongUserName\\Projects\\MyProject\\.swarm-worktrees\\session\\lane',
+			),
+			tmpDir,
+		);
+
+		worktreeModule._internals.platform = realPlatform;
+		restoreAllSeams();
+
+		// Non-Windows should always pass
+		expect(result.ok).toBe(true);
+	});
+
+	test('checkPathBudget returns ok:false on win32 when path exceeds budget', async () => {
+		const realPlatform = worktreeModule._internals.platform;
+		worktreeModule._internals.platform = 'win32';
+
+		// Create a very long worktree root and a long file path that together
+		// exceed the WIN_PATH_BUDGET of 250 characters.
+		const longWorktreeRoot =
+			'C:\\Users\\VeryLongUserName\\Projects\\MyVeryLongProjectName\\.swarm-worktrees\\session-id\\lane-1';
+		// Generate a file path long enough to push the total over 250.
+		// The prefix and suffix use single backslashes (TypeScript escape sequences).
+		const prefix = 'src\\very\\deeply\\nested\\';
+		const suffix = '\\file.ts';
+		const padding = 'a'.repeat(
+			251 - longWorktreeRoot.length - prefix.length - suffix.length,
+		);
+		const longFileName = prefix + padding + suffix;
+
+		worktreeModule._internals.bunSpawn = mock(() => ({
+			exited: Promise.resolve(0),
+			exitCode: 0,
+			stdout: { text: () => Promise.resolve(longFileName) },
+			stderr: { text: () => Promise.resolve('') },
+		}));
+
+		const result = await worktreeModule.checkPathBudget(
+			longWorktreeRoot,
+			tmpDir,
+		);
+
+		worktreeModule._internals.platform = realPlatform;
+		restoreAllSeams();
+
+		// Windows: total path = longWorktreeRoot + 1 + longFileName > 250
+		expect(result.ok).toBe(false);
+		if (result.ok === false) {
+			expect(result.error).toContain('Total path budget exceeded');
+			expect(result.suggestion).toBeDefined();
+		}
+	});
+
+	test('shortenWorktreePath returns os.tmpdir-based path', () => {
+		const customTmp = 'C:\\Temp\\CustomPath';
+		worktreeModule._internals.osTmpdir = () => customTmp;
+
+		const result = worktreeModule.shortenWorktreePath(
+			tmpDir,
+			'sess-123',
+			'lane-1',
+		);
+
+		worktreeModule._internals.osTmpdir = savedWorktreeInternals.osTmpdir;
+
+		expect(result).toBe(path.join(customTmp, 'swwt', 'sess-123', 'lane-1'));
+	});
+
+	test('shortenWorktreePath uses path.join for cross-platform correctness', () => {
+		// Verify no hardcoded separators
+		const result = worktreeModule.shortenWorktreePath(
+			'/project',
+			'sess',
+			'lane',
+		);
+		expect(result).not.toContain('//');
+		// On Windows, should use backslash
+		if (process.platform === 'win32') {
+			expect(result).toContain(path.sep);
+		}
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// AC-11/AC-12: Post-merge branch cleanup — branch deleted, worktree pruned (DD-9)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('AC-11/AC-12: post-merge branch cleanup (DD-9)', () => {
+	test('postMergeCleanup calls git branch -D and git worktree prune', async () => {
+		// Test the merge-back module's postMergeCleanup directly via _internals seam
+		const gitCalls: string[][] = [];
+		mergeBackModule._internals.bunSpawn = mock((args: string[]) => {
+			gitCalls.push(args);
+			return {
+				exited: Promise.resolve(0),
+				exitCode: 0,
+				stdout: { text: () => Promise.resolve('') },
+				stderr: { text: () => Promise.resolve('') },
+			};
+		});
+
+		const branchName = 'swarm-lane/session-1/lane-1';
+		const result = await mergeBackModule.postMergeCleanup(tmpDir, branchName);
+
+		restoreAllSeams();
+
+		expect(result.cleaned).toBe(true);
+		// Verify git branch -D was called with the branch name
+		const branchDeleteCall = gitCalls.find(
+			(c) =>
+				c[0] === 'git' &&
+				c[1] === 'branch' &&
+				c[2] === '-D' &&
+				c[3] === branchName,
+		);
+		expect(branchDeleteCall).toBeDefined();
+		// Verify git worktree prune was called
+		const pruneCall = gitCalls.find(
+			(c) => c[0] === 'git' && c[1] === 'worktree' && c[2] === 'prune',
+		);
+		expect(pruneCall).toBeDefined();
+	});
+
+	test('postMergeCleanup returns partial success when branch delete fails but prune succeeds', async () => {
+		let callCount = 0;
+		mergeBackModule._internals.bunSpawn = mock((args: string[]) => {
+			callCount++;
+			// branch -D fails, worktree prune succeeds
+			if (args[1] === 'branch') {
+				return {
+					exited: Promise.resolve(1),
+					exitCode: 1,
+					stdout: { text: () => Promise.resolve('') },
+					stderr: {
+						text: () => Promise.resolve("error: branch 'x' not found"),
+					},
+				};
+			}
+			return {
+				exited: Promise.resolve(0),
+				exitCode: 0,
+				stdout: { text: () => Promise.resolve('') },
+				stderr: { text: () => Promise.resolve('') },
+			};
+		});
+
+		const result = await mergeBackModule.postMergeCleanup(
+			tmpDir,
+			'swarm-lane/sess/1',
+		);
+
+		restoreAllSeams();
+
+		expect(result.partial).toBe(true);
+		expect(result.error).toContain('Branch delete failed');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// DD-10: Windows file-lock retry — removeWorktree retries on EBUSY/EPERM
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('DD-10: Windows file-lock retry — EBUSY/EPERM', () => {
+	test('removeWorktree retries on EBUSY on Windows platform', async () => {
+		worktreeModule._internals.platform = 'win32';
+
+		let attempts = 0;
+		const sleepCalls: number[] = [];
+		worktreeModule._internals.sleep = mock(async (ms: number) => {
+			sleepCalls.push(ms);
+		});
+
+		worktreeModule._internals.bunSpawn = mock(() => {
+			attempts++;
+			if (attempts <= 2) {
+				// First two attempts fail with EBUSY
+				return {
+					exited: Promise.resolve(128),
+					exitCode: 128,
+					stdout: { text: () => Promise.resolve('') },
+					stderr: {
+						text: () =>
+							Promise.resolve("fatal: unable to delete 'path': EBUSY"),
+					},
+				};
+			}
+			// Third attempt succeeds
+			return {
+				exited: Promise.resolve(0),
+				exitCode: 0,
+				stdout: { text: () => Promise.resolve('') },
+				stderr: { text: () => Promise.resolve('') },
+			};
+		});
+
+		const result = await worktreeModule.removeWorktree(
+			path.join(tmpDir, '.swarm-worktrees', 'lane-1'),
+			tmpDir,
+		);
+
+		restoreAllSeams();
+
+		expect(result.success).toBe(true);
+		expect(attempts).toBe(3);
+		expect(sleepCalls.length).toBe(2);
+		expect(sleepCalls[0]).toBe(2000); // RETRY_DELAY_MS
+	});
+
+	test('removeWorktree retries on EPERM on Windows platform', async () => {
+		worktreeModule._internals.platform = 'win32';
+
+		let attempts = 0;
+		worktreeModule._internals.sleep = mock(async () => {});
+
+		worktreeModule._internals.bunSpawn = mock(() => {
+			attempts++;
+			if (attempts <= 1) {
+				return {
+					exited: Promise.resolve(128),
+					exitCode: 128,
+					stdout: { text: () => Promise.resolve('') },
+					stderr: {
+						text: () => Promise.resolve('fatal: EPERM: resource locked'),
+					},
+				};
+			}
+			return {
+				exited: Promise.resolve(0),
+				exitCode: 0,
+				stdout: { text: () => Promise.resolve('') },
+				stderr: { text: () => Promise.resolve('') },
+			};
+		});
+
+		const result = await worktreeModule.removeWorktree(
+			path.join(tmpDir, '.swarm-worktrees', 'lane-1'),
+			tmpDir,
+		);
+
+		restoreAllSeams();
+
+		expect(result.success).toBe(true);
+		expect(attempts).toBe(2);
+	});
+
+	test('removeWorktree does NOT retry non-EBUSY/EPERM errors', async () => {
+		worktreeModule._internals.platform = 'win32';
+
+		let attempts = 0;
+		worktreeModule._internals.sleep = mock(async () => {});
+
+		worktreeModule._internals.bunSpawn = mock(() => {
+			attempts++;
+			return {
+				exited: Promise.resolve(1),
+				exitCode: 1,
+				stdout: { text: () => Promise.resolve('') },
+				stderr: { text: () => Promise.resolve('fatal: not a git repository') },
+			};
+		});
+
+		const result = await worktreeModule.removeWorktree(
+			path.join(tmpDir, '.swarm-worktrees', 'lane-1'),
+			tmpDir,
+		);
+
+		restoreAllSeams();
+
+		expect('error' in result).toBe(true);
+		// Should NOT retry — only 1 attempt
+		expect(attempts).toBe(1);
+	});
+
+	test('removeWorktree on non-Windows does not retry', async () => {
+		worktreeModule._internals.platform = 'linux';
+
+		let attempts = 0;
+		worktreeModule._internals.sleep = mock(async () => {});
+
+		worktreeModule._internals.bunSpawn = mock(() => {
+			attempts++;
+			return {
+				exited: Promise.resolve(1),
+				exitCode: 1,
+				stdout: { text: () => Promise.resolve('') },
+				stderr: { text: () => Promise.resolve('EBUSY: device busy') },
+			};
+		});
+
+		const result = await worktreeModule.removeWorktree(
+			path.join(tmpDir, '.swarm-worktrees', 'lane-1'),
+			tmpDir,
+		);
+
+		restoreAllSeams();
+
+		expect('error' in result).toBe(true);
+		// Non-Windows should not retry
+		expect(attempts).toBe(1);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// DD-7: git clean -fd in cleanup — untracked files cleaned before merge-back
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('DD-7: git clean -fd in cleanup — untracked files cleaned', () => {
+	test('attemptMergeBackFromDirty calls autoCommitDirty then cleanUntrackedFiles then merge', async () => {
+		const callOrder: string[] = [];
+
+		// autoCommitDirty and cleanUntrackedFiles are imported from worktree.ts
+		// and use worktree._internals.bunSpawn, while attemptMergeBackFromDirty's
+		// own runGit uses merge-back._internals.bunSpawn. Mock both seams.
+		worktreeModule._internals.bunSpawn = mock((args: string[]) => {
+			if (args[1] === 'add' && args[2] === '-A') {
+				callOrder.push('autoCommit:git-add');
+			} else if (args[1] === 'commit') {
+				callOrder.push('autoCommit:git-commit');
+			} else if (args[1] === 'clean' && args[2] === '-fd') {
+				callOrder.push('cleanUntracked:git-clean');
+			}
+			return {
+				exited: Promise.resolve(0),
+				exitCode: 0,
+				stdout: { text: () => Promise.resolve('') },
+				stderr: { text: () => Promise.resolve('') },
+			};
+		});
+		mergeBackModule._internals.bunSpawn = mock((args: string[]) => {
+			if (args[1] === 'merge') {
+				callOrder.push('merge:git-merge');
+			}
+			return {
+				exited: Promise.resolve(0),
+				exitCode: 0,
+				stdout: { text: () => Promise.resolve('') },
+				stderr: { text: () => Promise.resolve('') },
+			};
+		});
+
+		const result = await mergeBackModule.attemptMergeBackFromDirty(
+			path.join(tmpDir, '.swarm-worktrees', 'lane-1'),
+			'swarm-lane/session-1/lane-1',
+			tmpDir,
+			'merge',
+		);
+
+		restoreAllSeams();
+
+		expect('merged' in result && result.merged).toBe(true);
+		// Pipeline order: add → commit → clean → merge
+		expect(callOrder).toContain('autoCommit:git-add');
+		expect(callOrder.indexOf('autoCommit:git-add')).toBeLessThan(
+			callOrder.indexOf('autoCommit:git-commit'),
+		);
+		expect(callOrder.indexOf('autoCommit:git-commit')).toBeLessThan(
+			callOrder.indexOf('cleanUntracked:git-clean'),
+		);
+		expect(callOrder.indexOf('cleanUntracked:git-clean')).toBeLessThan(
+			callOrder.indexOf('merge:git-merge'),
+		);
+	});
+
+	test('cleanUntrackedFiles calls git clean -fd via bunSpawn', async () => {
+		const gitArgs: string[][] = [];
+		worktreeModule._internals.bunSpawn = mock((args: string[]) => {
+			gitArgs.push(args);
+			return {
+				exited: Promise.resolve(0),
+				exitCode: 0,
+				stdout: { text: () => Promise.resolve('') },
+				stderr: { text: () => Promise.resolve('') },
+			};
+		});
+
+		const result = await worktreeModule.cleanUntrackedFiles(
+			path.join(tmpDir, '.swarm-worktrees', 'lane-1'),
+		);
+
+		restoreAllSeams();
+
+		expect(result.cleaned).toBe(true);
+		// Verify the exact command
+		const cleanCall = gitArgs.find((a) => a[1] === 'clean' && a[2] === '-fd');
+		expect(cleanCall).toBeDefined();
+		// Should have cwd set to the worktree path
+		expect(cleanCall).toBeDefined();
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// FR-011: No dependency management in worktrees — no npm/bun install in worktree paths
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('FR-011: no dependency management in worktrees', () => {
+	test('runner.ts source contains no npm/yarn/pnpm/pip/bun install commands', () => {
+		const runnerSource = fs.readFileSync(
+			path.resolve(__dirname, '../../../../src/turbo/lean/runner.ts'),
+			'utf-8',
+		);
+
+		const forbiddenPatterns: RegExp[] = [
+			/npm\s+install/,
+			/npm\s+ci/,
+			/yarn\s+install/,
+			/pnpm\s+install/,
+			/bun\s+install/,
+			/bun\s+add/,
+			/bun\s+remove/,
+			/pip\s+install/,
+			/pip3\s+install/,
+			/\[\s*['"]npm['"]\s*,/,
+			/\[\s*['"]yarn['"]\s*,/,
+			/\[\s*['"]pnpm['"]\s*,/,
+			/\[\s*['"]pip['"]\s*,/,
+			/\[\s*['"]bun['"]\s*,.*['"](?:install|add|remove)['"]/,
+		];
+
+		for (const pattern of forbiddenPatterns) {
+			expect(runnerSource).not.toMatch(pattern);
+		}
+
+		expect(runnerSource).not.toContain('child_process');
+	});
+
+	test('worktree.ts source contains no dependency management commands', () => {
+		const source = fs.readFileSync(
+			path.resolve(__dirname, '../../../../src/turbo/lean/worktree.ts'),
+			'utf-8',
+		);
+
+		const forbiddenPatterns: RegExp[] = [
+			/npm\s+install/,
+			/yarn\s+install/,
+			/bun\s+install/,
+			/bun\s+add/,
+			/pip\s+install/,
+		];
+
+		for (const pattern of forbiddenPatterns) {
+			expect(source).not.toMatch(pattern);
+		}
+	});
+
+	test('merge-back.ts source contains no dependency management commands', () => {
+		const source = fs.readFileSync(
+			path.resolve(__dirname, '../../../../src/turbo/lean/merge-back.ts'),
+			'utf-8',
+		);
+
+		const forbiddenPatterns: RegExp[] = [
+			/npm\s+install/,
+			/yarn\s+install/,
+			/bun\s+install/,
+			/bun\s+add/,
+			/pip\s+install/,
+		];
+
+		for (const pattern of forbiddenPatterns) {
+			expect(source).not.toMatch(pattern);
+		}
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// End-to-end: Full lane lifecycle with worktree isolation
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('end-to-end: full lane lifecycle with worktree isolation', () => {
+	test('startupOrphanRecovery → provision → dispatch → merge → remove → cleanup — complete pipeline', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const worktreePath = fakeWorktreePath('lane-1');
+		const branchName = fakeBranchName('lane-1');
+		const pipelineOrder: string[] = [];
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(() => {
+			pipelineOrder.push('orphanRecovery');
+			return Promise.resolve({
+				prunedWorktrees: true,
+				remainingBranches: [],
+				warnings: [],
+			});
+		});
+
+		LeanTurboRunner._internals.acquireLaneLocks = mock(() => {
+			pipelineOrder.push('acquireLocks');
+			return Promise.resolve({ acquired: true, lockFiles: ['test.lock'] });
+		});
+
+		LeanTurboRunner._internals.provisionWorktree = mock(() => {
+			pipelineOrder.push('provisionWorktree');
+			return Promise.resolve({ worktreePath, branchName });
+		});
+
+		LeanTurboRunner._internals.releaseLaneLocks = mock(() => {
+			pipelineOrder.push('releaseLocks');
+			return Promise.resolve(1);
+		});
+
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() => {
+			pipelineOrder.push('mergeLaneBranch');
+			return Promise.resolve({ merged: true, strategy: 'merge' });
+		});
+
+		LeanTurboRunner._internals.postMergeCleanup = mock(() => {
+			pipelineOrder.push('postMergeCleanup');
+			return Promise.resolve({ cleaned: true });
+		});
+
+		LeanTurboRunner._internals.removeWorktree = mock(() => {
+			pipelineOrder.push('removeWorktree');
+			return Promise.resolve({ success: true });
+		});
+
+		const result = await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(result.ok).toBe(true);
+
+		// Verify complete pipeline order
+		expect(pipelineOrder[0]).toBe('orphanRecovery');
+		expect(pipelineOrder).toContain('acquireLocks');
+		expect(pipelineOrder).toContain('provisionWorktree');
+		expect(pipelineOrder).toContain('releaseLocks');
+		expect(pipelineOrder).toContain('mergeLaneBranch');
+		expect(pipelineOrder).toContain('postMergeCleanup');
+		expect(pipelineOrder).toContain('removeWorktree');
+
+		// Locks should be acquired before provision
+		expect(pipelineOrder.indexOf('acquireLocks')).toBeLessThan(
+			pipelineOrder.indexOf('provisionWorktree'),
+		);
+		// Merge should come after locks are released
+		expect(pipelineOrder.indexOf('releaseLocks')).toBeLessThan(
+			pipelineOrder.indexOf('mergeLaneBranch'),
+		);
+		// Remove should come before cleanup
+		expect(pipelineOrder.indexOf('removeWorktree')).toBeLessThan(
+			pipelineOrder.indexOf('postMergeCleanup'),
+		);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// End-to-end: Failed lane with dirty merge-back pipeline
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('end-to-end: failed lane dirty merge-back pipeline', () => {
+	test('failed lane calls attemptMergeBackFromDirty then removeWorktree', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const worktreePath = fakeWorktreePath('lane-1');
+		const branchName = fakeBranchName('lane-1');
+		const pipelineOrder: string[] = [];
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockFailingSessionOps());
+
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(() => {
+			pipelineOrder.push('orphanRecovery');
+			return Promise.resolve({
+				prunedWorktrees: true,
+				remainingBranches: [],
+				warnings: [],
+			});
+		});
+
+		LeanTurboRunner._internals.provisionWorktree = mock(() => {
+			pipelineOrder.push('provisionWorktree');
+			return Promise.resolve({ worktreePath, branchName });
+		});
+
+		LeanTurboRunner._internals.attemptMergeBackFromDirty = mock(() => {
+			pipelineOrder.push('attemptMergeBackFromDirty');
+			return Promise.resolve({
+				merged: true,
+				strategy: 'merge',
+				autoCommitted: true,
+				cleaned: true,
+			});
+		});
+
+		LeanTurboRunner._internals.removeWorktree = mock(() => {
+			pipelineOrder.push('removeWorktree');
+			return Promise.resolve({ success: true });
+		});
+
+		const result = await runner.runPhase(1);
+
+		restoreAllSeams();
+
+		expect(result.ok).toBe(true);
+		const failedLanes = result.lanes.filter(
+			(l: LaneResult) => l.status === 'failed',
+		);
+		expect(failedLanes.length).toBeGreaterThan(0);
+
+		// Failed lane should trigger dirty merge-back then remove
+		expect(pipelineOrder).toContain('attemptMergeBackFromDirty');
+		expect(pipelineOrder).toContain('removeWorktree');
+		expect(pipelineOrder.indexOf('attemptMergeBackFromDirty')).toBeLessThan(
+			pipelineOrder.indexOf('removeWorktree'),
+		);
+	});
+});

--- a/tests/unit/turbo/lean/merge-back.test.ts
+++ b/tests/unit/turbo/lean/merge-back.test.ts
@@ -1,0 +1,1214 @@
+/**
+ * Tests for src/turbo/lean/merge-back.ts
+ *
+ * All tests mock _internals.bunSpawn (the DI seam) to avoid needing a real git repo.
+ * The mock replaces the BunCompatSubprocess return value so each test can exercise
+ * specific exit codes and stdout/stderr strings.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
+import type { LeanTurboConfig } from '../../../../src/config/schema';
+import {
+	_internals,
+	attemptMergeBackFromDirty,
+	cleanupOrphanedBranches,
+	getMergeStrategy,
+	handleMergeConflict,
+	mergeLaneBranch,
+	postMergeCleanup,
+	startupOrphanRecovery,
+} from '../../../../src/turbo/lean/merge-back';
+import { _internals as worktreeInternals } from '../../../../src/turbo/lean/worktree';
+import type { BunCompatSubprocess } from '../../../../src/utils/bun-compat';
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+/** Saves the real bunSpawn so tests can restore it in afterEach. */
+const realBunSpawn = _internals.bunSpawn;
+
+/**
+ * Constructs a minimal BunCompatSubprocess mock.
+ * exitCode, stdout, and stderr are configurable per test.
+ */
+function mockProc(
+	exitCode: number,
+	stdout = '',
+	stderr = '',
+): BunCompatSubprocess {
+	return {
+		exited: Promise.resolve(exitCode),
+		exitCode,
+		stdout: {
+			text: () => Promise.resolve(stdout),
+		} as unknown as BunCompatSubprocess['stdout'],
+		stderr: {
+			text: () => Promise.resolve(stderr),
+		} as unknown as BunCompatSubprocess['stderr'],
+		kill: () => {},
+	} as BunCompatSubprocess;
+}
+
+/**
+ * Installs a fake bunSpawn that returns a pre-configured mockProc.
+ * Subsequent calls to _internals.bunSpawn return the same mock unless
+ * the test reassigns _internals.bunSpawn directly.
+ */
+function stubSpawn(exitCode: number, stdout = '', stderr = '') {
+	_internals.bunSpawn = () => mockProc(exitCode, stdout, stderr);
+}
+
+/** Restores the real bunSpawn after every test. */
+afterEach(() => {
+	_internals.bunSpawn = realBunSpawn;
+});
+
+// ---------------------------------------------------------------------------
+// getMergeStrategy
+// ---------------------------------------------------------------------------
+
+describe('getMergeStrategy', () => {
+	test('returns config.merge_strategy when set to merge', () => {
+		const config: LeanTurboConfig = { merge_strategy: 'merge' };
+		expect(getMergeStrategy(config)).toBe('merge');
+	});
+
+	test('returns config.merge_strategy when set to rebase', () => {
+		const config: LeanTurboConfig = { merge_strategy: 'rebase' };
+		expect(getMergeStrategy(config)).toBe('rebase');
+	});
+
+	test('returns config.merge_strategy when set to cherry-pick', () => {
+		const config: LeanTurboConfig = { merge_strategy: 'cherry-pick' };
+		expect(getMergeStrategy(config)).toBe('cherry-pick');
+	});
+
+	test('returns merge when config.merge_strategy is undefined', () => {
+		const config: LeanTurboConfig = {};
+		expect(getMergeStrategy(config)).toBe('merge');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// mergeLaneBranch
+// ---------------------------------------------------------------------------
+
+describe('mergeLaneBranch', () => {
+	const fakeDir = 'C:\\project-root';
+	const fakeBranch = 'swarm-lane/session-abc/lane-1';
+
+	test('success with merge strategy — returns { merged: true, strategy: "merge" }', async () => {
+		stubSpawn(0, '', '');
+
+		const result = await mergeLaneBranch(fakeDir, fakeBranch, 'merge');
+
+		expect(result).toEqual({ merged: true, strategy: 'merge' });
+	});
+
+	test('success with rebase strategy — returns { merged: true, strategy: "rebase" }', async () => {
+		stubSpawn(0, '', '');
+
+		const result = await mergeLaneBranch(fakeDir, fakeBranch, 'rebase');
+
+		expect(result).toEqual({ merged: true, strategy: 'rebase' });
+	});
+
+	test('success with cherry-pick strategy — returns { merged: true, strategy: "cherry-pick" }', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = (_args: string[]) => {
+			callCount++;
+			// Call 1: git merge-base HEAD <branchName>
+			if (callCount === 1) return mockProc(0, 'abc1234\n', '');
+			// Call 2: git cherry-pick <range>
+			return mockProc(0, '', '');
+		};
+
+		const result = await mergeLaneBranch(fakeDir, fakeBranch, 'cherry-pick');
+
+		expect(result).toEqual({ merged: true, strategy: 'cherry-pick' });
+		expect(callCount).toBe(2);
+	});
+
+	test('conflict detection: stderr contains CONFLICT → returns { conflict: true, files, message }', async () => {
+		// First call: merge returns conflict
+		// Second call: merge --abort returns success
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) {
+				return mockProc(
+					1,
+					'',
+					'CONFLICT (content): Merge conflict in src/file1.ts\nCONFLICT (content): Merge conflict in src/file2.ts',
+				);
+			}
+			return mockProc(0, '', '');
+		};
+
+		const result = await mergeLaneBranch(fakeDir, fakeBranch, 'merge');
+
+		expect(result).toEqual({
+			conflict: true,
+			files: ['src/file1.ts', 'src/file2.ts'],
+			message: expect.stringContaining('CONFLICT'),
+		});
+	});
+
+	test('conflict auto-abort: uses merge --abort for merge strategy', async () => {
+		const spawnCalls: string[][] = [];
+		let callCount = 0;
+		_internals.bunSpawn = (args: string[]) => {
+			callCount++;
+			spawnCalls.push(args);
+			if (callCount === 1) {
+				return mockProc(
+					1,
+					'',
+					'CONFLICT (content): Merge conflict in src/file.ts',
+				);
+			}
+			return mockProc(0, '', '');
+		};
+
+		await mergeLaneBranch(fakeDir, fakeBranch, 'merge');
+
+		const abortCall = spawnCalls.find(
+			(args) =>
+				args[0] === 'git' && args[1] === 'merge' && args[2] === '--abort',
+		);
+		expect(abortCall).toBeDefined();
+	});
+
+	test('conflict auto-abort: uses rebase --abort for rebase strategy', async () => {
+		const spawnCalls: string[][] = [];
+		let callCount = 0;
+		_internals.bunSpawn = (args: string[]) => {
+			callCount++;
+			spawnCalls.push(args);
+			if (callCount === 1) {
+				return mockProc(
+					1,
+					'',
+					'CONFLICT (content): Merge conflict in src/file.ts',
+				);
+			}
+			return mockProc(0, '', '');
+		};
+
+		await mergeLaneBranch(fakeDir, fakeBranch, 'rebase');
+
+		const abortCall = spawnCalls.find(
+			(args) =>
+				args[0] === 'git' && args[1] === 'rebase' && args[2] === '--abort',
+		);
+		expect(abortCall).toBeDefined();
+	});
+
+	test('conflict auto-abort: uses cherry-pick --abort for cherry-pick strategy', async () => {
+		const spawnCalls: string[][] = [];
+		let callCount = 0;
+		_internals.bunSpawn = (args: string[]) => {
+			callCount++;
+			spawnCalls.push(args);
+			if (callCount === 1) {
+				// Call 1: git merge-base HEAD <branchName>
+				return mockProc(0, 'abc1234\n', '');
+			}
+			if (callCount === 2) {
+				// Call 2: git cherry-pick <range> — conflict
+				return mockProc(
+					1,
+					'',
+					'CONFLICT (content): Merge conflict in src/file.ts',
+				);
+			}
+			// Call 3: git cherry-pick --abort
+			return mockProc(0, '', '');
+		};
+
+		await mergeLaneBranch(fakeDir, fakeBranch, 'cherry-pick');
+
+		const abortCall = spawnCalls.find(
+			(args) =>
+				args[0] === 'git' && args[1] === 'cherry-pick' && args[2] === '--abort',
+		);
+		expect(abortCall).toBeDefined();
+	});
+
+	test('non-conflict failure: returns { error }', async () => {
+		stubSpawn(128, '', 'fatal: not a git repository');
+
+		const result = await mergeLaneBranch(fakeDir, fakeBranch, 'merge');
+
+		expect(result).toEqual({ error: 'fatal: not a git repository' });
+	});
+
+	test('non-conflict failure with stdout error: returns { error } from stdout', async () => {
+		stubSpawn(1, 'some error output', '');
+
+		const result = await mergeLaneBranch(fakeDir, fakeBranch, 'merge');
+
+		expect(result).toEqual({ error: 'some error output' });
+	});
+
+	test('verify correct git command args for merge strategy', async () => {
+		const spawnCalls: string[][] = [];
+		_internals.bunSpawn = (args: string[]) => {
+			spawnCalls.push(args);
+			return mockProc(0, '', '');
+		};
+
+		await mergeLaneBranch(fakeDir, fakeBranch, 'merge');
+
+		const mergeCall = spawnCalls.find(
+			(args) => args[0] === 'git' && args[1] === 'merge',
+		);
+		expect(mergeCall).toBeDefined();
+		expect(mergeCall![2]).toBe('--no-edit');
+		expect(mergeCall![3]).toBe(fakeBranch);
+	});
+
+	test('verify correct git command args for rebase strategy', async () => {
+		const spawnCalls: string[][] = [];
+		_internals.bunSpawn = (args: string[]) => {
+			spawnCalls.push(args);
+			return mockProc(0, '', '');
+		};
+
+		await mergeLaneBranch(fakeDir, fakeBranch, 'rebase');
+
+		const rebaseCall = spawnCalls.find(
+			(args) => args[0] === 'git' && args[1] === 'rebase',
+		);
+		expect(rebaseCall).toBeDefined();
+		expect(rebaseCall![2]).toBe(fakeBranch);
+	});
+
+	test('verify correct git command args for cherry-pick strategy', async () => {
+		const fakeMergeBase = 'abc1234';
+		const spawnCalls: string[][] = [];
+		let callCount = 0;
+		_internals.bunSpawn = (args: string[]) => {
+			callCount++;
+			spawnCalls.push(args);
+			if (callCount === 1) {
+				// merge-base call
+				return mockProc(0, `${fakeMergeBase}\n`, '');
+			}
+			return mockProc(0, '', '');
+		};
+
+		await mergeLaneBranch(fakeDir, fakeBranch, 'cherry-pick');
+
+		// First call: git merge-base HEAD <branchName>
+		const mergeBaseCall = spawnCalls.find(
+			(args) => args[0] === 'git' && args[1] === 'merge-base',
+		);
+		expect(mergeBaseCall).toBeDefined();
+		expect(mergeBaseCall![2]).toBe('HEAD');
+		expect(mergeBaseCall![3]).toBe(fakeBranch);
+
+		// Second call: git cherry-pick <mergeBase>..<branchName>
+		const cherryPickCall = spawnCalls.find(
+			(args) => args[0] === 'git' && args[1] === 'cherry-pick',
+		);
+		expect(cherryPickCall).toBeDefined();
+		expect(cherryPickCall![2]).toBe(`${fakeMergeBase}..${fakeBranch}`);
+	});
+
+	test('cherry-pick merge-base failure falls back to tip-only with warning', async () => {
+		const spawnCalls: string[][] = [];
+		let callCount = 0;
+		_internals.bunSpawn = (args: string[]) => {
+			callCount++;
+			spawnCalls.push(args);
+			if (callCount === 1) {
+				// merge-base fails (no common ancestor)
+				return mockProc(1, '', 'fatal: no common ancestor');
+			}
+			// Fallback: cherry-pick <branchName> (tip only)
+			return mockProc(0, '', '');
+		};
+
+		// Suppress console.warn output from the fallback path
+		const warnSpy = (console.warn = vi.fn() as unknown as typeof console.warn);
+
+		const result = await mergeLaneBranch(fakeDir, fakeBranch, 'cherry-pick');
+
+		expect(result).toEqual({ merged: true, strategy: 'cherry-pick' });
+		expect(callCount).toBe(2);
+
+		// Verify merge-base was attempted
+		const mergeBaseCall = spawnCalls.find(
+			(args) => args[0] === 'git' && args[1] === 'merge-base',
+		);
+		expect(mergeBaseCall).toBeDefined();
+
+		// Verify fallback used tip-only cherry-pick (not a range)
+		const cherryPickCall = spawnCalls.find(
+			(args) => args[0] === 'git' && args[1] === 'cherry-pick',
+		);
+		expect(cherryPickCall).toBeDefined();
+		expect(cherryPickCall![2]).toBe(fakeBranch);
+		expect(cherryPickCall![2]).not.toContain('..');
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining('merge-base failed'),
+		);
+		warnSpy.mockRestore?.();
+	});
+
+	test('cherry-pick merge-base returns empty stdout falls back to tip-only', async () => {
+		const spawnCalls: string[][] = [];
+		let callCount = 0;
+		_internals.bunSpawn = (args: string[]) => {
+			callCount++;
+			spawnCalls.push(args);
+			if (callCount === 1) {
+				// merge-base succeeds but returns empty stdout
+				return mockProc(0, '', '');
+			}
+			// Fallback: cherry-pick <branchName> (tip only)
+			return mockProc(0, '', '');
+		};
+
+		const warnSpy = (console.warn = vi.fn() as unknown as typeof console.warn);
+
+		const result = await mergeLaneBranch(fakeDir, fakeBranch, 'cherry-pick');
+
+		expect(result).toEqual({ merged: true, strategy: 'cherry-pick' });
+
+		const cherryPickCall = spawnCalls.find(
+			(args) => args[0] === 'git' && args[1] === 'cherry-pick',
+		);
+		expect(cherryPickCall).toBeDefined();
+		expect(cherryPickCall![2]).toBe(fakeBranch);
+
+		warnSpy.mockRestore?.();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// postMergeCleanup
+// ---------------------------------------------------------------------------
+
+describe('postMergeCleanup', () => {
+	const fakeDir = 'C:\\project-root';
+	const fakeBranch = 'swarm-lane/session-abc/lane-1';
+
+	test('both branch delete and prune succeed → { cleaned: true }', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			return mockProc(0, '', '');
+		};
+
+		const result = await postMergeCleanup(fakeDir, fakeBranch);
+
+		expect(result).toEqual({ cleaned: true });
+		expect(callCount).toBe(2);
+	});
+
+	test('branch delete fails but prune succeeds → { error, partial: true }', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) return mockProc(1, '', 'fatal: branch not found');
+			return mockProc(0, '', '');
+		};
+
+		const result = await postMergeCleanup(fakeDir, fakeBranch);
+
+		expect(result).toMatchObject({
+			error: expect.stringContaining('Branch delete failed'),
+			partial: true,
+		});
+	});
+
+	test('both fail → { error } (no partial)', async () => {
+		stubSpawn(1, '', 'fatal: something went wrong');
+
+		const result = await postMergeCleanup(fakeDir, fakeBranch);
+
+		expect(result).toMatchObject({
+			error: expect.stringContaining('Branch delete failed'),
+		});
+		expect(result).not.toMatchObject({ partial: true });
+	});
+
+	test('prune fails but branch delete succeeds → { error } (no partial)', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) return mockProc(0, '', ''); // branch delete succeeds
+			return mockProc(1, '', 'fatal: prune failed'); // prune fails
+		};
+
+		const result = await postMergeCleanup(fakeDir, fakeBranch);
+
+		expect(result).toMatchObject({
+			error: expect.stringContaining('Worktree prune failed'),
+		});
+		expect(result).not.toMatchObject({ partial: true });
+	});
+
+	test('verify correct git command args for branch -D', async () => {
+		const spawnCalls: string[][] = [];
+		_internals.bunSpawn = (args: string[]) => {
+			spawnCalls.push(args);
+			return mockProc(0, '', '');
+		};
+
+		await postMergeCleanup(fakeDir, fakeBranch);
+
+		const branchCall = spawnCalls.find(
+			(args) => args[0] === 'git' && args[1] === 'branch',
+		);
+		expect(branchCall).toBeDefined();
+		expect(branchCall![2]).toBe('-D');
+		expect(branchCall![3]).toBe(fakeBranch);
+	});
+
+	test('verify correct git command args for worktree prune', async () => {
+		const spawnCalls: string[][] = [];
+		_internals.bunSpawn = (args: string[]) => {
+			spawnCalls.push(args);
+			return mockProc(0, '', '');
+		};
+
+		await postMergeCleanup(fakeDir, fakeBranch);
+
+		const pruneCall = spawnCalls.find(
+			(args) =>
+				args[0] === 'git' && args[1] === 'worktree' && args[2] === 'prune',
+		);
+		expect(pruneCall).toBeDefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// handleMergeConflict
+// ---------------------------------------------------------------------------
+
+describe('handleMergeConflict', () => {
+	const fakeDir = 'C:\\project-root';
+	const fakeBranch = 'swarm-lane/session-abc/lane-1';
+
+	test('lists conflicted files and aborts successfully → { files, message, aborted: true }', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) {
+				return mockProc(0, 'src/file1.ts\nsrc/file2.ts', '');
+			}
+			return mockProc(0, '', '');
+		};
+
+		const result = await handleMergeConflict(fakeDir, fakeBranch, 'merge');
+
+		expect(result).toEqual({
+			files: ['src/file1.ts', 'src/file2.ts'],
+			message: 'Conflicts detected in 2 file(s): src/file1.ts, src/file2.ts',
+			aborted: true,
+		});
+	});
+
+	test('diff fails but abort succeeds → { error, aborted: true }', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) {
+				return mockProc(128, '', 'fatal: not a git repository');
+			}
+			return mockProc(0, '', '');
+		};
+
+		const result = await handleMergeConflict(fakeDir, fakeBranch, 'merge');
+
+		expect(result).toEqual({
+			error: 'Failed to list conflicted files: fatal: not a git repository',
+			aborted: true,
+		});
+	});
+
+	test('diff succeeds but abort fails → { error, aborted: false }', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) {
+				return mockProc(0, 'src/file1.ts', '');
+			}
+			return mockProc(1, '', 'fatal: could not abort');
+		};
+
+		const result = await handleMergeConflict(fakeDir, fakeBranch, 'merge');
+
+		expect(result).toEqual({
+			error: 'merge abort failed: fatal: could not abort',
+			aborted: false,
+		});
+	});
+
+	test('diff succeeds but returns empty file list', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) {
+				return mockProc(0, '', '');
+			}
+			return mockProc(0, '', '');
+		};
+
+		const result = await handleMergeConflict(fakeDir, fakeBranch, 'merge');
+
+		expect(result).toEqual({
+			files: [],
+			message: 'Conflicts detected in 0 file(s): ',
+			aborted: true,
+		});
+	});
+
+	test('strategy-aware abort: rebase uses rebase --abort', async () => {
+		const spawnCalls: string[][] = [];
+		let callCount = 0;
+		_internals.bunSpawn = (args: string[]) => {
+			callCount++;
+			spawnCalls.push(args);
+			if (callCount === 1) return mockProc(0, 'src/file.ts', '');
+			return mockProc(0, '', '');
+		};
+
+		await handleMergeConflict(fakeDir, fakeBranch, 'rebase');
+
+		const abortCall = spawnCalls.find(
+			(args) =>
+				args[0] === 'git' && args[1] === 'rebase' && args[2] === '--abort',
+		);
+		expect(abortCall).toBeDefined();
+	});
+
+	test('strategy-aware abort: cherry-pick uses cherry-pick --abort', async () => {
+		const spawnCalls: string[][] = [];
+		let callCount = 0;
+		_internals.bunSpawn = (args: string[]) => {
+			callCount++;
+			spawnCalls.push(args);
+			if (callCount === 1) return mockProc(0, 'src/file.ts', '');
+			return mockProc(0, '', '');
+		};
+
+		await handleMergeConflict(fakeDir, fakeBranch, 'cherry-pick');
+
+		const abortCall = spawnCalls.find(
+			(args) =>
+				args[0] === 'git' && args[1] === 'cherry-pick' && args[2] === '--abort',
+		);
+		expect(abortCall).toBeDefined();
+	});
+
+	test('strategy-aware abort: merge uses merge --abort', async () => {
+		const spawnCalls: string[][] = [];
+		let callCount = 0;
+		_internals.bunSpawn = (args: string[]) => {
+			callCount++;
+			spawnCalls.push(args);
+			if (callCount === 1) return mockProc(0, 'src/file.ts', '');
+			return mockProc(0, '', '');
+		};
+
+		await handleMergeConflict(fakeDir, fakeBranch, 'merge');
+
+		const abortCall = spawnCalls.find(
+			(args) =>
+				args[0] === 'git' && args[1] === 'merge' && args[2] === '--abort',
+		);
+		expect(abortCall).toBeDefined();
+	});
+
+	test('verify git diff --name-only --diff-filter=U is called', async () => {
+		const spawnCalls: string[][] = [];
+		_internals.bunSpawn = (args: string[]) => {
+			spawnCalls.push(args);
+			return mockProc(0, 'src/file.ts', '');
+		};
+
+		await handleMergeConflict(fakeDir, fakeBranch, 'merge');
+
+		const diffCall = spawnCalls.find(
+			(args) =>
+				args[0] === 'git' &&
+				args[1] === 'diff' &&
+				args[2] === '--name-only' &&
+				args[3] === '--diff-filter=U',
+		);
+		expect(diffCall).toBeDefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// attemptMergeBackFromDirty (DD-7 progressive dirty cleanup)
+// ---------------------------------------------------------------------------
+
+describe('attemptMergeBackFromDirty', () => {
+	const fakeWorktree = 'C:\\project-root\\.swarm-worktrees\\session-1\\lane-1';
+	const fakeBranch = 'swarm-lane/session-1/lane-1';
+	const fakePrimary = 'C:\\project-root';
+
+	let savedWorktreeSpawn: typeof worktreeInternals.bunSpawn;
+
+	beforeEach(() => {
+		savedWorktreeSpawn = worktreeInternals.bunSpawn;
+	});
+
+	afterEach(() => {
+		// Restore both DI seams
+		_internals.bunSpawn = realBunSpawn;
+		worktreeInternals.bunSpawn = savedWorktreeSpawn;
+	});
+
+	/**
+	 * Helper: configure mock bunSpawn for worktree operations AND merge operations.
+	 *
+	 * The worktree functions (autoCommitDirty, cleanUntrackedFiles) use worktree's _internals.bunSpawn.
+	 * The merge function (mergeLaneBranch) uses merge-back's _internals.bunSpawn.
+	 * Both must be set independently.
+	 */
+	function setupMocks(opts: {
+		/** git add exit code (autoCommitDirty step 1) */
+		commitAddExit?: number;
+		/** git commit exit code (autoCommitDirty step 2) */
+		commitCommitExit?: number;
+		/** git commit stderr (for "nothing to commit" detection) */
+		commitStderr?: string;
+		/** git commit stdout (for "nothing to commit" detection) */
+		commitStdout?: string;
+		/** git clean exit code (cleanUntrackedFiles) */
+		cleanExit?: number;
+		/** git clean stderr */
+		cleanStderr?: string;
+		/** merge exit code */
+		mergeExit?: number;
+		/** merge stderr */
+		mergeStderr?: string;
+	}) {
+		const {
+			commitAddExit = 0,
+			commitCommitExit = 0,
+			commitStderr = '',
+			commitStdout = '',
+			cleanExit = 0,
+			cleanStderr = '',
+			mergeExit = 0,
+			mergeStderr = '',
+		} = opts;
+
+		// Configure worktree's bunSpawn (for autoCommitDirty and cleanUntrackedFiles)
+		// Args-aware (not call-count) so early exits in autoCommitDirty don't
+		// shift which mock response cleanUntrackedFiles receives.
+		worktreeInternals.bunSpawn = (args: string[]) => {
+			if (args.includes('add')) {
+				// git add -A (autoCommitDirty step 1)
+				return mockProc(commitAddExit, '', commitStderr);
+			}
+			if (args.includes('commit')) {
+				// git commit -m ... (autoCommitDirty step 2)
+				return mockProc(commitCommitExit, commitStdout, commitStderr);
+			}
+			if (args.includes('clean')) {
+				// git clean -fd (cleanUntrackedFiles)
+				return mockProc(cleanExit, '', cleanStderr);
+			}
+			return mockProc(0, '', '');
+		};
+
+		// Configure merge-back's bunSpawn (for mergeLaneBranch)
+		_internals.bunSpawn = (_args: string[]) => {
+			return mockProc(mergeExit, '', mergeStderr);
+		};
+	}
+
+	test('dirty worktree auto-committed + cleaned + merged → { merged: true, autoCommitted: true, cleaned: true }', async () => {
+		setupMocks({
+			commitAddExit: 0,
+			commitCommitExit: 0,
+			cleanExit: 0,
+			mergeExit: 0,
+		});
+
+		const result = await attemptMergeBackFromDirty(
+			fakeWorktree,
+			fakeBranch,
+			fakePrimary,
+			'merge',
+		);
+
+		expect(result).toEqual({
+			merged: true,
+			strategy: 'merge',
+			autoCommitted: true,
+			cleaned: true,
+		});
+	});
+
+	test('clean worktree (nothing to commit) + cleaned + merged → { merged: true, autoCommitted: false, cleaned: true }', async () => {
+		setupMocks({
+			commitAddExit: 0,
+			commitCommitExit: 1,
+			commitStderr: 'nothing to commit, working tree clean',
+			cleanExit: 0,
+			mergeExit: 0,
+		});
+
+		const result = await attemptMergeBackFromDirty(
+			fakeWorktree,
+			fakeBranch,
+			fakePrimary,
+			'merge',
+		);
+
+		expect(result).toEqual({
+			merged: true,
+			strategy: 'merge',
+			autoCommitted: false,
+			cleaned: true,
+		});
+	});
+
+	test('auto-commit fails but clean succeeds and merge succeeds → { merged: true, autoCommitted: false, cleaned: true }', async () => {
+		setupMocks({
+			commitAddExit: 1,
+			commitStderr: 'fatal: git add failed',
+			cleanExit: 0,
+			mergeExit: 0,
+		});
+
+		const result = await attemptMergeBackFromDirty(
+			fakeWorktree,
+			fakeBranch,
+			fakePrimary,
+			'merge',
+		);
+
+		expect(result).toEqual({
+			merged: true,
+			strategy: 'merge',
+			autoCommitted: false,
+			cleaned: true,
+		});
+	});
+
+	test('clean fails but auto-commit succeeds and merge succeeds → { merged: true, autoCommitted: true, cleaned: false }', async () => {
+		setupMocks({
+			commitAddExit: 0,
+			commitCommitExit: 0,
+			cleanExit: 1,
+			cleanStderr: 'fatal: git clean failed',
+			mergeExit: 0,
+		});
+
+		const result = await attemptMergeBackFromDirty(
+			fakeWorktree,
+			fakeBranch,
+			fakePrimary,
+			'merge',
+		);
+
+		expect(result).toEqual({
+			merged: true,
+			strategy: 'merge',
+			autoCommitted: true,
+			cleaned: false,
+		});
+	});
+
+	test('merge has conflicts → { partial: true, stage: "merge" }', async () => {
+		// mergeLaneBranch runs merge, detects conflict, then runs --abort
+		// So we need two merge-back bunSpawn calls: merge (fail with conflict) and --abort (success)
+		let mergeCallCount = 0;
+		_internals.bunSpawn = (_args: string[]) => {
+			mergeCallCount++;
+			if (mergeCallCount === 1) {
+				return mockProc(
+					1,
+					'',
+					'CONFLICT (content): Merge conflict in src/file.ts',
+				);
+			}
+			return mockProc(0, '', '');
+		};
+
+		// Configure worktree's bunSpawn for successful auto-commit and clean
+		let worktreeCallCount = 0;
+		worktreeInternals.bunSpawn = (_args: string[]) => {
+			worktreeCallCount++;
+			if (worktreeCallCount === 1) return mockProc(0, '', '');
+			if (worktreeCallCount === 2) return mockProc(0, '', '');
+			if (worktreeCallCount === 3) return mockProc(0, '', '');
+			return mockProc(0, '', '');
+		};
+
+		const result = await attemptMergeBackFromDirty(
+			fakeWorktree,
+			fakeBranch,
+			fakePrimary,
+			'merge',
+		);
+
+		expect(result).toMatchObject({
+			partial: true,
+			stage: 'merge',
+			autoCommitted: true,
+			cleaned: true,
+			message: expect.stringContaining('CONFLICT'),
+		});
+	});
+
+	test('merge fails (non-conflict error) → { failed: true, stage: "merge" }', async () => {
+		setupMocks({
+			commitAddExit: 0,
+			commitCommitExit: 0,
+			cleanExit: 0,
+			mergeExit: 128,
+			mergeStderr: 'fatal: not a git repository',
+		});
+
+		const result = await attemptMergeBackFromDirty(
+			fakeWorktree,
+			fakeBranch,
+			fakePrimary,
+			'merge',
+		);
+
+		expect(result).toEqual({
+			failed: true,
+			stage: 'merge',
+			message: 'fatal: not a git repository',
+		});
+	});
+
+	test('both auto-commit and clean fail → { failed: true, stage: "cleanup" }', async () => {
+		setupMocks({
+			commitAddExit: 1,
+			commitStderr: 'fatal: git add failed',
+			cleanExit: 1,
+			cleanStderr: 'fatal: git clean failed',
+		});
+
+		const result = await attemptMergeBackFromDirty(
+			fakeWorktree,
+			fakeBranch,
+			fakePrimary,
+			'merge',
+		);
+
+		expect(result).toEqual({
+			failed: true,
+			stage: 'cleanup',
+			message: 'Auto-commit and clean both failed; abandoning worktree',
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// _internals DI seam
+// ---------------------------------------------------------------------------
+
+describe('_internals.bunSpawn', () => {
+	test('_internals.bunSpawn can be replaced for testing', () => {
+		// Confirm the seam exists and is initially the real function
+		expect(typeof _internals.bunSpawn).toBe('function');
+
+		// Replace with a no-op mock
+		_internals.bunSpawn = () => mockProc(0, 'replaced', '');
+		const result = _internals.bunSpawn();
+		expect(result.exitCode).toBe(0);
+		expect(result).toHaveProperty('exited');
+		expect(result).toHaveProperty('kill');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// cleanupOrphanedBranches
+// ---------------------------------------------------------------------------
+
+describe('cleanupOrphanedBranches', () => {
+	const fakeDir = 'C:\\project-root';
+
+	test('removes branches not in activeSessionIds', async () => {
+		// Branch list returns 2 branches: one active, one orphan
+		_internals.bunSpawn = (args: string[]) => {
+			// git branch --list 'swarm-lane/*'
+			if (args.includes('branch') && args.includes('--list')) {
+				return mockProc(
+					0,
+					'swarm-lane/session-active/lane-1\nswarm-lane/session-orphan/lane-2',
+					'',
+				);
+			}
+			// git branch -D — only called for orphan branches
+			if (args.includes('branch') && args.includes('-D')) {
+				// Verify we're only deleting the orphan, not the active branch
+				const branchArg = args[args.length - 1];
+				if (branchArg === 'swarm-lane/session-active/lane-1') {
+					throw new Error('Unexpected branch delete for active branch');
+				}
+				return mockProc(0, '', '');
+			}
+			// git worktree prune
+			return mockProc(0, '', '');
+		};
+
+		const result = await cleanupOrphanedBranches(fakeDir, ['session-active']);
+
+		expect(result.removed).toEqual(['swarm-lane/session-orphan/lane-2']);
+		expect(result.skipped).toEqual(['swarm-lane/session-active/lane-1']);
+		expect(result.errors).toEqual([]);
+	});
+
+	test('skips branches with active sessionIds', async () => {
+		// All branches belong to active sessions
+		_internals.bunSpawn = (_args: string[]) => {
+			return mockProc(
+				0,
+				'swarm-lane/session-1/lane-a\nswarm-lane/session-2/lane-b',
+				'',
+			);
+		};
+
+		const result = await cleanupOrphanedBranches(fakeDir, [
+			'session-1',
+			'session-2',
+		]);
+
+		expect(result.removed).toEqual([]);
+		expect(result.skipped).toEqual([
+			'swarm-lane/session-1/lane-a',
+			'swarm-lane/session-2/lane-b',
+		]);
+		expect(result.errors).toEqual([]);
+	});
+
+	test('records errors when branch -D fails', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = (args: string[]) => {
+			callCount++;
+			if (callCount === 1) {
+				// git branch --list
+				return mockProc(0, 'swarm-lane/session-orphan/lane-fail', '');
+			}
+			if (callCount === 2) {
+				// git branch -D fails
+				return mockProc(1, '', 'error: branch not found');
+			}
+			// git worktree prune
+			return mockProc(0, '', '');
+		};
+
+		const result = await cleanupOrphanedBranches(fakeDir, []);
+
+		expect(result.removed).toEqual([]);
+		expect(result.errors).toEqual([
+			{
+				branch: 'swarm-lane/session-orphan/lane-fail',
+				error: 'error: branch not found',
+			},
+		]);
+	});
+
+	test('returns empty arrays when no swarm-lane branches exist', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			return mockProc(0, '', '');
+		};
+
+		const result = await cleanupOrphanedBranches(fakeDir, []);
+
+		expect(result.removed).toEqual([]);
+		expect(result.skipped).toEqual([]);
+		expect(result.errors).toEqual([]);
+		// Should have called list + worktree prune
+		expect(callCount).toBe(2);
+	});
+
+	test('handles `* ` prefix when current branch is a swarm-lane branch (simulated git branch --list output)', async () => {
+		// git branch --list prefixes the current branch with `* `, but our
+		// command now uses --format=%(refname:short) which strips it.
+		// This test simulates the OLD format to ensure that even if the
+		// format option weren't used, the branch names would still be
+		// parsed correctly because they arrive clean from --format.
+		// Here we verify the --format-based output works with `* ` in
+		// a mixed scenario: one branch prefixed (old format), one not.
+		_internals.bunSpawn = (args: string[]) => {
+			if (args.includes('branch') && args.includes('--list')) {
+				// Simulate --format output: clean names, no `* ` prefix
+				return mockProc(
+					0,
+					'swarm-lane/session-active/lane-1\nswarm-lane/session-orphan/lane-2',
+					'',
+				);
+			}
+			if (args.includes('branch') && args.includes('-D')) {
+				return mockProc(0, '', '');
+			}
+			return mockProc(0, '', '');
+		};
+
+		const result = await cleanupOrphanedBranches(fakeDir, ['session-active']);
+
+		// Active branch correctly identified and skipped (no false orphan)
+		expect(result.skipped).toEqual(['swarm-lane/session-active/lane-1']);
+		expect(result.removed).toEqual(['swarm-lane/session-orphan/lane-2']);
+		expect(result.errors).toEqual([]);
+	});
+
+	test('runs git worktree prune after cleanup', async () => {
+		const spawnCalls: string[][] = [];
+		_internals.bunSpawn = (args: string[]) => {
+			spawnCalls.push(args);
+			return mockProc(0, '', '');
+		};
+
+		await cleanupOrphanedBranches(fakeDir, []);
+
+		// First call: git branch --list 'swarm-lane/*'
+		expect(spawnCalls[0]).toContain('branch');
+		expect(spawnCalls[0]).toContain('--list');
+
+		// Last call: git worktree prune
+		const pruneCall = spawnCalls.find(
+			(args) =>
+				args[0] === 'git' && args[1] === 'worktree' && args[2] === 'prune',
+		);
+		expect(pruneCall).toBeDefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// startupOrphanRecovery
+// ---------------------------------------------------------------------------
+
+describe('startupOrphanRecovery', () => {
+	const fakeDir = 'C:\\project-root';
+
+	test('prunes worktrees and returns empty when no branches remain', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			return mockProc(0, '', '');
+		};
+
+		const result = await startupOrphanRecovery(fakeDir, []);
+
+		expect(result).toEqual({
+			prunedWorktrees: true,
+			remainingBranches: [],
+			warnings: [],
+		});
+	});
+
+	test('lists orphaned branches and generates warnings', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) {
+				// git worktree prune — success
+				return mockProc(0, '', '');
+			}
+			// git branch --list
+			return mockProc(
+				0,
+				'swarm-lane/session-dead/lane-1\nswarm-lane/session-dead/lane-2',
+				'',
+			);
+		};
+
+		const result = await startupOrphanRecovery(fakeDir, []);
+
+		expect(result.prunedWorktrees).toBe(true);
+		expect(result.remainingBranches).toEqual([
+			'swarm-lane/session-dead/lane-1',
+			'swarm-lane/session-dead/lane-2',
+		]);
+		expect(result.warnings).toHaveLength(2);
+		expect(result.warnings[0]).toContain('swarm-lane/session-dead/lane-1');
+		expect(result.warnings[1]).toContain('swarm-lane/session-dead/lane-2');
+	});
+
+	test('skips branches with active sessionIds', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) {
+				return mockProc(0, '', '');
+			}
+			// Mix of active and orphan
+			return mockProc(
+				0,
+				'swarm-lane/session-active/lane-1\nswarm-lane/session-orphan/lane-2',
+				'',
+			);
+		};
+
+		const result = await startupOrphanRecovery(fakeDir, ['session-active']);
+
+		expect(result.remainingBranches).toEqual([
+			'swarm-lane/session-orphan/lane-2',
+		]);
+		// Only 1 warning for the orphan
+		expect(result.warnings).toHaveLength(1);
+		expect(result.warnings[0]).toContain('session-orphan');
+	});
+
+	test('handles `* ` prefix when current branch is a swarm-lane branch (simulated git branch --list output)', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) {
+				// git worktree prune — success
+				return mockProc(0, '', '');
+			}
+			// git branch --format output: clean names, no `* ` prefix.
+			// The active branch must NOT be reported as orphaned.
+			return mockProc(
+				0,
+				'swarm-lane/session-active/lane-1\nswarm-lane/session-orphan/lane-2',
+				'',
+			);
+		};
+
+		const result = await startupOrphanRecovery(fakeDir, ['session-active']);
+
+		// Active branch correctly identified; only orphan reported
+		expect(result.remainingBranches).toEqual([
+			'swarm-lane/session-orphan/lane-2',
+		]);
+		expect(result.warnings).toHaveLength(1);
+		expect(result.warnings[0]).toContain('session-orphan');
+	});
+
+	test('continues with branch listing even if worktree prune fails', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) {
+				// git worktree prune — FAILS
+				return mockProc(1, '', 'fatal: prune failed');
+			}
+			// git branch --list — succeeds
+			return mockProc(0, 'swarm-lane/session-orphan/lane-1', '');
+		};
+
+		const result = await startupOrphanRecovery(fakeDir, []);
+
+		expect(result.prunedWorktrees).toBe(false);
+		expect(result.remainingBranches).toEqual([
+			'swarm-lane/session-orphan/lane-1',
+		]);
+		// First warning is about prune failure, second about orphan
+		expect(result.warnings).toHaveLength(2);
+		expect(result.warnings[0]).toContain('git worktree prune failed');
+		expect(result.warnings[1]).toContain('session-orphan');
+	});
+});

--- a/tests/unit/turbo/lean/retroactive-adversarial.test.ts
+++ b/tests/unit/turbo/lean/retroactive-adversarial.test.ts
@@ -645,10 +645,10 @@ describe('ATTACK VECTOR 3 — integrated_diff_required=false skips diff summary'
 });
 
 // ════════════════════════════════════════════════════════════════════════════════
-// ATTACK VECTOR 4: worktree_isolation=true via type coercion bypass
+// ATTACK VECTOR 4: worktree_isolation — non-boolean coercion still rejected, boolean true now accepted
 // ════════════════════════════════════════════════════════════════════════════════
 
-describe('ATTACK VECTOR 4 — worktree_isolation=true via type coercion bypass', () => {
+describe('ATTACK VECTOR 4 — worktree_isolation coercion from non-boolean values', () => {
 	test('schema: string "true" is rejected by z.boolean() (no coerce)', () => {
 		// The schema uses z.boolean() without coerce — string "true" should NOT pass
 		const result = LeanTurboConfigSchema.safeParse({
@@ -659,23 +659,20 @@ describe('ATTACK VECTOR 4 — worktree_isolation=true via type coercion bypass',
 		expect(result.success).toBe(false);
 	});
 
-	test('schema: boolean true fails the .refine() that val === false', () => {
-		// Even if coercion somehow produces boolean true, the refine rejects it
+	test('schema: boolean true is now accepted (refine gate removed)', () => {
+		// The .refine() gate was removed in v1 — worktree_isolation: true is now accepted
 		const result = LeanTurboConfigSchema.safeParse({
 			max_parallel_coders: 4,
-			worktree_isolation: true, // explicitly true — rejected by refine
+			worktree_isolation: true,
 		});
 
-		expect(result.success).toBe(false);
-		if (!result.success) {
-			const issue = result.error.issues.find((i) =>
-				i.path.includes('worktree_isolation'),
-			);
-			expect(issue).toBeDefined();
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.worktree_isolation).toBe(true);
 		}
 	});
 
-	test('schema: worktree_isolation=false (the only valid value) passes', () => {
+	test('schema: worktree_isolation=false passes', () => {
 		const result = LeanTurboConfigSchema.safeParse({
 			max_parallel_coders: 4,
 			worktree_isolation: false,

--- a/tests/unit/turbo/lean/runner.test.ts
+++ b/tests/unit/turbo/lean/runner.test.ts
@@ -32,6 +32,7 @@ interface MockSessionOps {
 
 let tmpDir: string;
 let mockSessionOps: MockSessionOps;
+let origAssertCleanWorkingTree: typeof LeanTurboRunner._internals.assertCleanWorkingTree;
 
 function makeRunner(options?: {
 	opencodeClient?: null;
@@ -138,9 +139,22 @@ beforeEach(() => {
 	fs.mkdirSync(path.join(tmpDir, '.swarm'), { recursive: true });
 	leanState.repairStateUnreadable(tmpDir);
 	mockSessionOps = mockSuccessfulSessionOps();
+
+	// Default mock: assertCleanWorkingTree returns clean so worktree_isolation
+	// tests work without needing a real git repo. Individual tests that test
+	// dirty/throw scenarios override this mock within their own scope.
+	origAssertCleanWorkingTree =
+		LeanTurboRunner._internals.assertCleanWorkingTree;
+	LeanTurboRunner._internals.assertCleanWorkingTree = mock(() =>
+		Promise.resolve({ clean: true }),
+	);
 });
 
 afterEach(() => {
+	// Restore assertCleanWorkingTree before cleaning up tmpDir
+	LeanTurboRunner._internals.assertCleanWorkingTree =
+		origAssertCleanWorkingTree;
+
 	leanState.repairStateUnreadable(tmpDir);
 	try {
 		fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -1424,5 +1438,2153 @@ describe('leanConfig propagation', () => {
 		expect(
 			(capturedConfig as { max_parallel_coders: number }).max_parallel_coders,
 		).toBe(4);
+	});
+});
+
+// ─── Test 17: Worktree isolation integration ──────────────────────────────────
+
+describe('worktree isolation integration', () => {
+	test('calls provisionWorktree when worktree_isolation is true', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Mock provisionWorktree
+		const provisionCalls: unknown[] = [];
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() => ({
+			worktreePath: path.join(
+				tmpDir,
+				'.swarm-worktrees',
+				'sess-runner-test',
+				'lane-1',
+			),
+			branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+		}));
+		// Wrap to capture calls
+		LeanTurboRunner._internals.provisionWorktree = mock(
+			(...args: Parameters<typeof origProvision>) => {
+				provisionCalls.push(args);
+				return Promise.resolve({
+					worktreePath: path.join(
+						tmpDir,
+						'.swarm-worktrees',
+						SESSION_ID,
+						'lane-1',
+					),
+					branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+				});
+			},
+		);
+
+		// Mock merge-back and cleanup so they don't fail
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		expect(result.ok).toBe(true);
+		expect(provisionCalls.length).toBeGreaterThan(0);
+	});
+
+	test('does NOT call provisionWorktree when worktree_isolation is false', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: false },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Mock provisionWorktree to track calls
+		const provisionCalls: unknown[] = [];
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(
+			(...args: Parameters<typeof origProvision>) => {
+				provisionCalls.push(args);
+				return Promise.resolve({
+					worktreePath: path.join(
+						tmpDir,
+						'.swarm-worktrees',
+						SESSION_ID,
+						'lane-1',
+					),
+					branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+				});
+			},
+		);
+
+		await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+
+		expect(provisionCalls.length).toBe(0);
+	});
+
+	test('passes worktree path to session.create (not this._directory)', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+
+		// Mock provisionWorktree to return a known path
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath,
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			}),
+		);
+
+		// Mock merge-back and cleanup
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		// Verify session.create was called with the worktree path, NOT tmpDir
+		expect(mockSessionOps.create).toHaveBeenCalled();
+		const createCall = mockSessionOps.create.mock.calls[0];
+		expect(
+			(createCall[0] as { query: { directory: string } }).query.directory,
+		).toBe(worktreePath);
+		expect(
+			(createCall[0] as { query: { directory: string } }).query.directory,
+		).not.toBe(tmpDir);
+	});
+
+	test('calls merge-back + cleanup on lane success', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Mock provisionWorktree
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath,
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			}),
+		);
+
+		// Track merge and cleanup calls
+		const mergeCalls: unknown[] = [];
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(
+			(...args: Parameters<typeof origMerge>) => {
+				mergeCalls.push(args);
+				return Promise.resolve({ merged: true, strategy: 'merge' });
+			},
+		);
+
+		const cleanupCalls: unknown[] = [];
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(
+			(...args: Parameters<typeof origCleanup>) => {
+				cleanupCalls.push(args);
+				return Promise.resolve({ cleaned: true });
+			},
+		);
+
+		const removeCalls: unknown[] = [];
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(
+			(...args: Parameters<typeof origRemove>) => {
+				removeCalls.push(args);
+				return Promise.resolve({ success: true });
+			},
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		expect(result.ok).toBe(true);
+		expect(mergeCalls.length).toBeGreaterThan(0);
+		expect(cleanupCalls.length).toBeGreaterThan(0);
+		expect(removeCalls.length).toBeGreaterThan(0);
+	});
+
+	test('calls attemptMergeBackFromDirty + removeWorktree sequentially for failed lane', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		// Make session fail
+		const failingOps = {
+			create: mock(() =>
+				Promise.resolve({ data: null, error: 'session create failed' }),
+			),
+			prompt: mock(() =>
+				Promise.resolve({ data: null, error: 'prompt failed' }),
+			),
+			delete: mock(() => Promise.resolve()),
+		};
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, failingOps);
+
+		// Mock provisionWorktree
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath,
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			}),
+		);
+
+		// Track failure-path calls
+		const attemptMergeCalls: unknown[] = [];
+		const origAttemptMerge =
+			LeanTurboRunner._internals.attemptMergeBackFromDirty;
+		LeanTurboRunner._internals.attemptMergeBackFromDirty = mock(
+			(...args: Parameters<typeof origAttemptMerge>) => {
+				attemptMergeCalls.push(args);
+				return Promise.resolve({
+					merged: true,
+					strategy: 'merge',
+					autoCommitted: false,
+					cleaned: false,
+				});
+			},
+		);
+
+		const removeCalls: unknown[] = [];
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(
+			(...args: Parameters<typeof origRemove>) => {
+				removeCalls.push(args);
+				return Promise.resolve({ success: true });
+			},
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.attemptMergeBackFromDirty = origAttemptMerge;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		expect(result.ok).toBe(true);
+		// Lane should have failed
+		const failedLanes = result.lanes.filter((l) => l.status === 'failed');
+		expect(failedLanes.length).toBeGreaterThan(0);
+		// attemptMergeBackFromDirty should have been called
+		expect(attemptMergeCalls.length).toBeGreaterThan(0);
+		// removeWorktree should have been called
+		expect(removeCalls.length).toBeGreaterThan(0);
+	});
+
+	test('calls startupOrphanRecovery at runPhase start when worktree_isolation is enabled', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Track startupOrphanRecovery calls
+		const recoveryCalls: unknown[] = [];
+		const origRecovery = LeanTurboRunner._internals.startupOrphanRecovery;
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(
+			(...args: Parameters<typeof origRecovery>) => {
+				recoveryCalls.push(args);
+				return Promise.resolve({
+					prunedWorktrees: true,
+					remainingBranches: [],
+					warnings: [],
+				});
+			},
+		);
+
+		// Mock provision + merge + cleanup
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath: path.join(
+					tmpDir,
+					'.swarm-worktrees',
+					SESSION_ID,
+					'lane-1',
+				),
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			}),
+		);
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.startupOrphanRecovery = origRecovery;
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		expect(recoveryCalls.length).toBe(1);
+		// Verify it was called with the directory and session ID
+		expect(recoveryCalls[0][0]).toBe(tmpDir);
+		expect(recoveryCalls[0][1]).toEqual([SESSION_ID]);
+	});
+
+	test('does NOT call startupOrphanRecovery when worktree_isolation is disabled', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: false },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Track startupOrphanRecovery calls
+		const recoveryCalls: unknown[] = [];
+		const origRecovery = LeanTurboRunner._internals.startupOrphanRecovery;
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(
+			(...args: Parameters<typeof origRecovery>) => {
+				recoveryCalls.push(args);
+				return Promise.resolve({
+					prunedWorktrees: true,
+					remainingBranches: [],
+					warnings: [],
+				});
+			},
+		);
+
+		await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.startupOrphanRecovery = origRecovery;
+
+		expect(recoveryCalls.length).toBe(0);
+	});
+
+	test('worktree provision failure fails lane explicitly, does NOT degrade to shared directory', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Mock provisionWorktree to FAIL with a permanent error
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				error: 'git worktree add failed: worktree already exists',
+			}),
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+
+		// Phase returns ok:true (runPhase always returns ok when there are lanes),
+		// but the lane itself should have failed
+		expect(result.ok).toBe(true);
+		expect(result.lanes.length).toBe(1);
+		expect(result.lanes[0].status).toBe('failed');
+		expect(result.lanes[0].error).toContain('worktree provision failed');
+		// session.create should NOT have been called — lane failed before dispatch
+		expect(mockSessionOps.create).not.toHaveBeenCalled();
+	});
+
+	test('cleanup removes worktrees for active lanes', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+
+		// Mock provisionWorktree
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath,
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			}),
+		);
+
+		// Mock merge + cleanup so lanes complete with worktree state
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		await runner.runPhase(1);
+
+		// Reset remove mock to track cleanup-specific calls
+		const cleanupRemoveCalls: unknown[] = [];
+		LeanTurboRunner._internals.removeWorktree = mock(
+			(...args: Parameters<typeof origRemove>) => {
+				cleanupRemoveCalls.push(args);
+				return Promise.resolve({ success: true });
+			},
+		);
+
+		await runner.cleanup();
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		// removeWorktree should have been called during cleanup for worktree lanes
+		expect(cleanupRemoveCalls.length).toBeGreaterThan(0);
+	});
+});
+
+// ─── Test 18: Sequential merge-back after all lanes complete (Finding 1 fix) ─────
+
+describe('sequential merge-back after concurrent lanes (race condition fix)', () => {
+	test('merge-back runs sequentially AFTER all lanes complete, not inside _processLane', async () => {
+		writeMinimalPlan(1);
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Mock the planner to return TWO separate lanes.
+		// The real planner greedily packs non-conflicting tasks into one lane,
+		// so we inject a custom plan to force 2 lanes for this test.
+		const origPlan = LeanTurboRunner._internals.planLeanTurboLanes;
+		LeanTurboRunner._internals.planLeanTurboLanes = mock(
+			(..._args: Parameters<typeof origPlan>) => ({
+				phase: 1,
+				planId: 'test-plan',
+				lanes: [
+					{
+						laneId: 'lane-1',
+						taskIds: ['1.1'],
+						files: ['src/a.ts'],
+						status: 'pending' as const,
+					},
+					{
+						laneId: 'lane-2',
+						taskIds: ['1.2'],
+						files: ['src/b.ts'],
+						status: 'pending' as const,
+					},
+				],
+				degradedTasks: [],
+				serializedTasks: [],
+				counters: {
+					lanesPlanned: 2,
+					lanesStarted: 0,
+					lanesCompleted: 0,
+					lanesFailed: 0,
+					tasksSerialized: 0,
+					tasksDegraded: 0,
+				},
+				crossLaneDependencies: {},
+			}),
+		);
+
+		// Mock startupOrphanRecovery to avoid git commands in non-git tmpDir
+		const origOrphanRecovery = LeanTurboRunner._internals.startupOrphanRecovery;
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(() =>
+			Promise.resolve({
+				prunedWorktrees: true,
+				remainingBranches: [],
+				warnings: [],
+			}),
+		);
+
+		// Mock provisionWorktree to return distinct paths per lane
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		let provisionCallIndex = 0;
+		const worktreePaths = [
+			path.join(tmpDir, '.swarm-worktrees', SESSION_ID, 'lane-1'),
+			path.join(tmpDir, '.swarm-worktrees', SESSION_ID, 'lane-2'),
+		];
+		LeanTurboRunner._internals.provisionWorktree = mock(() => {
+			const idx = provisionCallIndex++;
+			return Promise.resolve({
+				worktreePath: worktreePaths[idx] ?? worktreePaths[0],
+				branchName: `swarm-lane/${SESSION_ID}/lane-${idx + 1}`,
+			});
+		});
+
+		// Track the order of mergeLaneBranch calls to verify sequential execution
+		const mergeCallOrder: number[] = [];
+		let mergeRunning = false;
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(
+			async (...args: Parameters<typeof origMerge>) => {
+				const callNum = mergeCallOrder.length;
+				mergeCallOrder.push(callNum);
+				// Simulate non-zero duration to expose concurrent execution
+				if (mergeRunning) {
+					// If another merge is already running, this proves they are concurrent
+					mergeCallOrder.push(-1); // sentinel for concurrent execution
+				}
+				mergeRunning = true;
+				await Bun.sleep(10);
+				mergeRunning = false;
+				return { merged: true, strategy: 'merge' as const };
+			},
+		);
+
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		let result;
+		try {
+			result = await runner.runPhase(1);
+
+			expect(result.ok).toBe(true);
+			expect(result.lanes.length).toBe(2);
+			// Both lanes should complete
+			const completedLanes = result.lanes.filter(
+				(l) => l.status === 'completed',
+			);
+			expect(completedLanes.length).toBe(2);
+			// mergeLaneBranch should have been called twice (once per completed worktree lane)
+			expect(mergeCallOrder.filter((n) => n >= 0).length).toBe(2);
+			// No concurrent sentinel (-1) should appear — merges ran sequentially
+			expect(mergeCallOrder).not.toContain(-1);
+		} finally {
+			LeanTurboRunner._internals.planLeanTurboLanes = origPlan;
+			LeanTurboRunner._internals.startupOrphanRecovery = origOrphanRecovery;
+			LeanTurboRunner._internals.provisionWorktree = origProvision;
+			LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+			LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+			LeanTurboRunner._internals.removeWorktree = origRemove;
+		}
+	});
+
+	test('failed worktree lanes are cleaned up sequentially in post-processing', async () => {
+		writeMinimalPlan(1);
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+
+		// Make session fail for BOTH lanes
+		const failingOps = {
+			create: mock(() =>
+				Promise.resolve({ data: null, error: 'session create failed' }),
+			),
+			prompt: mock(() =>
+				Promise.resolve({ data: null, error: 'prompt failed' }),
+			),
+			delete: mock(() => Promise.resolve()),
+		};
+		injectMockSessionOps(runner, failingOps);
+
+		// Mock the planner to return TWO separate lanes
+		const origPlan = LeanTurboRunner._internals.planLeanTurboLanes;
+		LeanTurboRunner._internals.planLeanTurboLanes = mock(
+			(..._args: Parameters<typeof origPlan>) => ({
+				phase: 1,
+				planId: 'test-plan',
+				lanes: [
+					{
+						laneId: 'lane-1',
+						taskIds: ['1.1'],
+						files: ['src/a.ts'],
+						status: 'pending' as const,
+					},
+					{
+						laneId: 'lane-2',
+						taskIds: ['1.2'],
+						files: ['src/b.ts'],
+						status: 'pending' as const,
+					},
+				],
+				degradedTasks: [],
+				serializedTasks: [],
+				counters: {
+					lanesPlanned: 2,
+					lanesStarted: 0,
+					lanesCompleted: 0,
+					lanesFailed: 0,
+					tasksSerialized: 0,
+					tasksDegraded: 0,
+				},
+				crossLaneDependencies: {},
+			}),
+		);
+
+		// Mock startupOrphanRecovery to avoid git commands in non-git tmpDir
+		const origOrphanRecovery = LeanTurboRunner._internals.startupOrphanRecovery;
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(() =>
+			Promise.resolve({
+				prunedWorktrees: true,
+				remainingBranches: [],
+				warnings: [],
+			}),
+		);
+
+		// Mock provisionWorktree to return distinct paths per lane
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		let provisionCallIndex = 0;
+		const worktreePaths = [
+			path.join(tmpDir, '.swarm-worktrees', SESSION_ID, 'lane-1'),
+			path.join(tmpDir, '.swarm-worktrees', SESSION_ID, 'lane-2'),
+		];
+		LeanTurboRunner._internals.provisionWorktree = mock(() => {
+			const idx = provisionCallIndex++;
+			return Promise.resolve({
+				worktreePath: worktreePaths[idx] ?? worktreePaths[0],
+				branchName: `swarm-lane/${SESSION_ID}/lane-${idx + 1}`,
+			});
+		});
+
+		// Track the order of attemptMergeBackFromDirty calls to verify sequential execution
+		const attemptMergeCallOrder: number[] = [];
+		let attemptMergeRunning = false;
+		const origAttemptMerge =
+			LeanTurboRunner._internals.attemptMergeBackFromDirty;
+		LeanTurboRunner._internals.attemptMergeBackFromDirty = mock(
+			async (...args: Parameters<typeof origAttemptMerge>) => {
+				const callNum = attemptMergeCallOrder.length;
+				attemptMergeCallOrder.push(callNum);
+				// Simulate non-zero duration to expose concurrent execution
+				if (attemptMergeRunning) {
+					// If another merge is already running, this proves they are concurrent
+					attemptMergeCallOrder.push(-1); // sentinel for concurrent execution
+				}
+				attemptMergeRunning = true;
+				await Bun.sleep(10);
+				attemptMergeRunning = false;
+				return {
+					merged: true,
+					strategy: 'merge',
+					autoCommitted: false,
+					cleaned: false,
+				};
+			},
+		);
+
+		const removeCalls: unknown[] = [];
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(
+			(...args: Parameters<typeof origRemove>) => {
+				removeCalls.push(args);
+				return Promise.resolve({ success: true });
+			},
+		);
+
+		let result;
+		try {
+			result = await runner.runPhase(1);
+
+			expect(result.ok).toBe(true);
+			expect(result.lanes.length).toBe(2);
+			// Both lanes should have failed
+			const failedLanes = result.lanes.filter((l) => l.status === 'failed');
+			expect(failedLanes.length).toBe(2);
+			// attemptMergeBackFromDirty should have been called twice (once per failed worktree lane)
+			expect(attemptMergeCallOrder.filter((n) => n >= 0).length).toBe(2);
+			// No concurrent sentinel (-1) should appear — cleanup ran sequentially
+			expect(attemptMergeCallOrder).not.toContain(-1);
+			// removeWorktree should have been called for both failed worktree lanes
+			expect(removeCalls.length).toBe(2);
+		} finally {
+			LeanTurboRunner._internals.planLeanTurboLanes = origPlan;
+			LeanTurboRunner._internals.startupOrphanRecovery = origOrphanRecovery;
+			LeanTurboRunner._internals.provisionWorktree = origProvision;
+			LeanTurboRunner._internals.attemptMergeBackFromDirty = origAttemptMerge;
+			LeanTurboRunner._internals.removeWorktree = origRemove;
+		}
+	});
+});
+
+// ─── Test 19: provisionWorktree throw caught gracefully (Finding 2 fix) ─────────
+
+describe('provisionWorktree throw handling', () => {
+	test('catches provisionWorktree rejection and fails lane explicitly', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Mock provisionWorktree to THROW (not return an error object)
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.reject(
+				new Error('git worktree add: fatal: not a git repository'),
+			),
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+
+		// The lane should have failed — not degraded to shared directory
+		expect(result.ok).toBe(true);
+		expect(result.lanes.length).toBe(1);
+		expect(result.lanes[0].status).toBe('failed');
+		expect(result.lanes[0].error).toContain('worktree provision failed');
+		// session.create should NOT have been called — lane failed before dispatch
+		expect(mockSessionOps.create).not.toHaveBeenCalled();
+	});
+});
+
+// ─── Test 20: worktreePath persisted to durable state (Finding 3 fix) ────────────
+
+describe('worktreePath persisted to durable state', () => {
+	test('persists worktreePath and branchName to turbo-state.json after provisioning', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+		const branchName = `swarm-lane/${SESSION_ID}/lane-1`;
+
+		// Mock provisionWorktree
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({ worktreePath, branchName }),
+		);
+
+		// Mock merge + cleanup
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		expect(result.ok).toBe(true);
+
+		// Load durable state from disk and verify worktreePath/branchName are persisted
+		const durableState = leanState.loadLeanTurboRunState(tmpDir, SESSION_ID);
+		expect(durableState).not.toBeNull();
+		const persistedLane = durableState!.lanes.find(
+			(l) => l.laneId && l.laneId.startsWith('lane-'),
+		);
+		expect(persistedLane).toBeDefined();
+		expect(persistedLane!.worktreePath).toBe(worktreePath);
+		expect(persistedLane!.branchName).toBe(branchName);
+	});
+});
+
+// ─── Test 21: Transient failure retry for worktree provisioning ──────────────
+
+describe('transient worktree provision retry', () => {
+	test('transient provision error (EBUSY) retries once and succeeds on retry → lane uses worktree', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+
+		// Mock provisionWorktree: first call fails with EBUSY, second succeeds
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		let provisionCallCount = 0;
+		LeanTurboRunner._internals.provisionWorktree = mock(() => {
+			provisionCallCount++;
+			if (provisionCallCount === 1) {
+				return Promise.resolve({ error: 'EBUSY: worktree add failed' });
+			}
+			return Promise.resolve({
+				worktreePath,
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			});
+		});
+
+		// Mock merge + cleanup so lane completes fully
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		expect(result.ok).toBe(true);
+		expect(provisionCallCount).toBe(2); // initial + 1 retry
+		// session.create should have been called with the worktree path (retry succeeded)
+		expect(mockSessionOps.create).toHaveBeenCalled();
+		const createCall = mockSessionOps.create.mock.calls[0];
+		expect(
+			(createCall[0] as { query: { directory: string } }).query.directory,
+		).toBe(worktreePath);
+	});
+
+	test('transient provision error retries once and fails again → lane fails explicitly', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		let provisionCallCount = 0;
+		LeanTurboRunner._internals.provisionWorktree = mock(() => {
+			provisionCallCount++;
+			// Both calls fail with transient ETIMEDOUT
+			return Promise.resolve({
+				error: `ETIMEDOUT: git worktree add timed out (attempt ${provisionCallCount})`,
+			});
+		});
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+
+		expect(result.ok).toBe(true);
+		expect(provisionCallCount).toBe(2); // initial + 1 retry
+		// Lane should have failed — NOT degraded
+		expect(result.lanes.length).toBe(1);
+		expect(result.lanes[0].status).toBe('failed');
+		expect(result.lanes[0].error).toContain('worktree provision failed');
+		// session.create should NOT have been called — lane failed before dispatch
+		expect(mockSessionOps.create).not.toHaveBeenCalled();
+	});
+
+	test('permanent provision error (already exists) does NOT retry → lane fails immediately', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		let provisionCallCount = 0;
+		LeanTurboRunner._internals.provisionWorktree = mock(() => {
+			provisionCallCount++;
+			return Promise.resolve({ error: 'worktree already exists' });
+		});
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+
+		expect(result.ok).toBe(true);
+		expect(provisionCallCount).toBe(1); // NO retry — permanent error
+		// Lane should have failed — NOT degraded
+		expect(result.lanes.length).toBe(1);
+		expect(result.lanes[0].status).toBe('failed');
+		expect(result.lanes[0].error).toContain('worktree provision failed');
+		// session.create should NOT have been called — lane failed before dispatch
+		expect(mockSessionOps.create).not.toHaveBeenCalled();
+	});
+
+	test('provisionWorktree throws with transient error message → retries once', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+
+		// Mock provisionWorktree: first call throws with EPERM, second succeeds
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		let provisionCallCount = 0;
+		LeanTurboRunner._internals.provisionWorktree = mock(() => {
+			provisionCallCount++;
+			if (provisionCallCount === 1) {
+				return Promise.reject(
+					new Error('EPERM: resource locked by another process'),
+				);
+			}
+			return Promise.resolve({
+				worktreePath,
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			});
+		});
+
+		// Mock merge + cleanup so lane completes fully
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		expect(result.ok).toBe(true);
+		expect(provisionCallCount).toBe(2); // initial throw + 1 retry
+		// session.create should have been called with the worktree path (retry succeeded)
+		expect(mockSessionOps.create).toHaveBeenCalled();
+		const createCall = mockSessionOps.create.mock.calls[0];
+		expect(
+			(createCall[0] as { query: { directory: string } }).query.directory,
+		).toBe(worktreePath);
+	});
+
+	// ─── FR-006 / FR-011 defense-in-depth tests ──────────────────────────────────
+
+	test('file locks are still acquired when worktree_isolation is enabled (FR-006)', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Track acquireLaneLocks calls to verify locks are still acquired
+		const acquireCalls: unknown[] = [];
+		const origAcquire = LeanTurboRunner._internals.acquireLaneLocks;
+		LeanTurboRunner._internals.acquireLaneLocks = mock(
+			(...args: Parameters<typeof origAcquire>) => {
+				acquireCalls.push(args);
+				return Promise.resolve({
+					acquired: true,
+					locks: [
+						{
+							filePath: 'src/a.ts',
+							laneId: 'lane-1',
+							_release: async () => {},
+						},
+					],
+				});
+			},
+		);
+
+		// Mock worktree provision + merge + cleanup
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath: path.join(
+					tmpDir,
+					'.swarm-worktrees',
+					SESSION_ID,
+					'lane-1',
+				),
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			}),
+		);
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.acquireLaneLocks = origAcquire;
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		expect(result.ok).toBe(true);
+		// Lock acquisition MUST still happen even in worktree mode (FR-006)
+		expect(acquireCalls.length).toBeGreaterThan(0);
+	});
+
+	test('file locks use primary root directory, not worktree path (FR-006)', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+
+		// Capture the exact arguments passed to acquireLaneLocks
+		const acquireCalls: unknown[] = [];
+		const origAcquire = LeanTurboRunner._internals.acquireLaneLocks;
+		LeanTurboRunner._internals.acquireLaneLocks = mock(
+			(...args: Parameters<typeof origAcquire>) => {
+				acquireCalls.push(args);
+				return Promise.resolve({
+					acquired: true,
+					locks: [
+						{
+							filePath: 'src/a.ts',
+							laneId: 'lane-1',
+							_release: async () => {},
+						},
+					],
+				});
+			},
+		);
+
+		// Mock worktree provision + merge + cleanup
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath,
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			}),
+		);
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.acquireLaneLocks = origAcquire;
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		expect(acquireCalls.length).toBeGreaterThan(0);
+		// First argument to acquireLaneLocks must be the PRIMARY root directory,
+		// NOT the worktree path — locks live under primary root's .swarm/locks/
+		const firstCall = acquireCalls[0] as [string, ...unknown[]];
+		expect(firstCall[0]).toBe(tmpDir);
+		expect(firstCall[0]).not.toBe(worktreePath);
+	});
+
+	test('no package manager commands are spawned in worktree path (FR-011)', () => {
+		// Static analysis: verify runner.ts source contains no package-manager
+		// spawn calls.  The runner only delegates to _internals for worktree
+		// lifecycle (provision, merge, cleanup) which use git commands via
+		// bunSpawn.  No npm/yarn/pnpm/pip/bun install should ever appear.
+		const runnerSource = fs.readFileSync(
+			path.resolve(__dirname, '../../../../src/turbo/lean/runner.ts'),
+			'utf-8',
+		);
+
+		// Package manager patterns that must NOT appear in runner source
+		// Covers both shell-string (npm install) and array-form (['npm', 'install']) patterns
+		const forbiddenPatterns: RegExp[] = [
+			// Shell-string forms: "npm install", "bun add", etc.
+			/npm\s+install/,
+			/npm\s+ci/,
+			/yarn\s+install/,
+			/pnpm\s+install/,
+			/bun\s+install/,
+			/bun\s+add/,
+			/bun\s+remove/,
+			/pip\s+install/,
+			/pip3\s+install/,
+			// Array-form patterns: ['npm', 'install'], ("npm", "install"), etc.
+			/\[\s*['"]npm['"]\s*,/,
+			/\[\s*['"]yarn['"]\s*,/,
+			/\[\s*['"]pnpm['"]\s*,/,
+			/\[\s*['"]pip['"]\s*,/,
+			/\[\s*['"]pip3['"]\s*,/,
+			/\(\s*['"]npm['"]\s*,/,
+			/\(\s*['"]yarn['"]\s*,/,
+			/\(\s*['"]pnpm['"]\s*,/,
+			/\(\s*['"]pip['"]\s*,/,
+			/\(\s*['"]pip3['"]\s*,/,
+			// bun add/remove via array form
+			/\[\s*['"]bun['"]\s*,.*['"](?:install|add|remove)['"]/,
+			/\(\s*['"]bun['"]\s*,.*['"](?:install|add|remove)['"]/,
+		];
+
+		for (const pattern of forbiddenPatterns) {
+			expect(runnerSource).not.toMatch(pattern);
+		}
+
+		// The runner must not import child_process directly — subprocesses are
+		// delegated through the worktree / merge-back modules' _internals seam.
+		expect(runnerSource).not.toContain('child_process');
+	});
+
+	test('assertCleanWorkingTree dirty → worktree provisioning skipped, lanes run in shared directory', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Mock assertCleanWorkingTree to return dirty
+		const origAssertClean = LeanTurboRunner._internals.assertCleanWorkingTree;
+		LeanTurboRunner._internals.assertCleanWorkingTree = mock(() =>
+			Promise.resolve({
+				clean: false,
+				error:
+					'Working tree has uncommitted changes. Please commit or stash before provisioning worktrees.',
+			}),
+		);
+
+		// Track provisionWorktree calls — should be ZERO since we degraded
+		const provisionCalls: unknown[] = [];
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(
+			(...args: Parameters<typeof origProvision>) => {
+				provisionCalls.push(args);
+				return Promise.resolve({
+					worktreePath: path.join(
+						tmpDir,
+						'.swarm-worktrees',
+						SESSION_ID,
+						'lane-1',
+					),
+					branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+				});
+			},
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.assertCleanWorkingTree = origAssertClean;
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+
+		// Phase should still succeed (degraded, not failed)
+		expect(result.ok).toBe(true);
+		expect(result.lanes.length).toBeGreaterThan(0);
+		// provisionWorktree must NOT have been called — degraded to shared directory
+		expect(provisionCalls.length).toBe(0);
+		// session.create should have been called with the PRIMARY directory (shared mode)
+		expect(mockSessionOps.create).toHaveBeenCalled();
+		const createCall = mockSessionOps.create.mock.calls[0];
+		expect(
+			(createCall[0] as { query: { directory: string } }).query.directory,
+		).toBe(tmpDir);
+	});
+
+	test('assertCleanWorkingTree clean → worktree provisioning proceeds normally', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Mock assertCleanWorkingTree to return clean
+		const origAssertClean = LeanTurboRunner._internals.assertCleanWorkingTree;
+		LeanTurboRunner._internals.assertCleanWorkingTree = mock(() =>
+			Promise.resolve({ clean: true }),
+		);
+
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+
+		// Mock provisionWorktree to succeed
+		const provisionCalls: unknown[] = [];
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(
+			(...args: Parameters<typeof origProvision>) => {
+				provisionCalls.push(args);
+				return Promise.resolve({
+					worktreePath,
+					branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+				});
+			},
+		);
+
+		// Mock merge + cleanup so lane completes fully
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.assertCleanWorkingTree = origAssertClean;
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		// Phase should succeed with worktree isolation
+		expect(result.ok).toBe(true);
+		expect(result.lanes.length).toBeGreaterThan(0);
+		// provisionWorktree MUST have been called — clean tree means worktrees are allowed
+		expect(provisionCalls.length).toBeGreaterThan(0);
+		// session.create should have been called with the WORKTREE path
+		expect(mockSessionOps.create).toHaveBeenCalled();
+		const createCall = mockSessionOps.create.mock.calls[0];
+		expect(
+			(createCall[0] as { query: { directory: string } }).query.directory,
+		).toBe(worktreePath);
+	});
+
+	test('assertCleanWorkingTree NOT called when worktree_isolation is false', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: false },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Track assertCleanWorkingTree calls
+		const assertCleanCalls: unknown[] = [];
+		const origAssertClean = LeanTurboRunner._internals.assertCleanWorkingTree;
+		LeanTurboRunner._internals.assertCleanWorkingTree = mock(
+			(...args: Parameters<typeof origAssertClean>) => {
+				assertCleanCalls.push(args);
+				return Promise.resolve({ clean: true });
+			},
+		);
+
+		await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.assertCleanWorkingTree = origAssertClean;
+
+		// assertCleanWorkingTree must NOT have been called when worktree_isolation is off
+		expect(assertCleanCalls.length).toBe(0);
+	});
+
+	test('assertCleanWorkingTree throw → degrades to shared directory gracefully', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Mock assertCleanWorkingTree to throw
+		const origAssertClean = LeanTurboRunner._internals.assertCleanWorkingTree;
+		LeanTurboRunner._internals.assertCleanWorkingTree = mock(() =>
+			Promise.reject(new Error('not a git repository')),
+		);
+
+		// Track provisionWorktree calls — should be ZERO since we degraded
+		const provisionCalls: unknown[] = [];
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(
+			(...args: Parameters<typeof origProvision>) => {
+				provisionCalls.push(args);
+				return Promise.resolve({
+					worktreePath: path.join(
+						tmpDir,
+						'.swarm-worktrees',
+						SESSION_ID,
+						'lane-1',
+					),
+					branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+				});
+			},
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.assertCleanWorkingTree = origAssertClean;
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+
+		// Phase should still succeed (degraded, not failed)
+		expect(result.ok).toBe(true);
+		expect(result.lanes.length).toBeGreaterThan(0);
+		// provisionWorktree must NOT have been called — degraded to shared directory
+		expect(provisionCalls.length).toBe(0);
+	});
+
+	test('lock release after lane completion uses primary root, not worktree path (FR-006)', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+
+		// Capture releaseLaneLocks arguments
+		const releaseCalls: unknown[] = [];
+		const origRelease = LeanTurboRunner._internals.releaseLaneLocks;
+		LeanTurboRunner._internals.releaseLaneLocks = mock(
+			(...args: Parameters<typeof origRelease>) => {
+				releaseCalls.push(args);
+				return Promise.resolve(1);
+			},
+		);
+
+		// Mock acquireLaneLocks to succeed
+		const origAcquire = LeanTurboRunner._internals.acquireLaneLocks;
+		LeanTurboRunner._internals.acquireLaneLocks = mock(() =>
+			Promise.resolve({
+				acquired: true,
+				locks: [
+					{ filePath: 'src/a.ts', laneId: 'lane-1', _release: async () => {} },
+				],
+			}),
+		);
+
+		// Mock worktree provision + merge + cleanup
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath,
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			}),
+		);
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.releaseLaneLocks = origRelease;
+		LeanTurboRunner._internals.acquireLaneLocks = origAcquire;
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		expect(result.ok).toBe(true);
+		// releaseLaneLocks should have been called after lane completion
+		expect(releaseCalls.length).toBeGreaterThan(0);
+		// First argument must be the PRIMARY root directory, NOT the worktree path
+		const firstReleaseCall = releaseCalls[0] as [string, ...unknown[]];
+		expect(firstReleaseCall[0]).toBe(tmpDir);
+		expect(firstReleaseCall[0]).not.toBe(worktreePath);
+	});
+
+	// ─── New: worktree provision permanent failure → lane fails ─────────────
+
+	test('worktree provision permanent failure → lane fails explicitly, does NOT degrade to shared directory', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		// Mock provisionWorktree to always fail with a permanent error
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				error: 'ENOTDIR: not a directory',
+			}),
+		);
+
+		// Mock releaseLaneLocks to verify it was called on failure
+		const origRelease = LeanTurboRunner._internals.releaseLaneLocks;
+		const releaseCalls: unknown[] = [];
+		LeanTurboRunner._internals.releaseLaneLocks = mock(
+			(...args: Parameters<typeof origRelease>) => {
+				releaseCalls.push(args);
+				return Promise.resolve();
+			},
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.releaseLaneLocks = origRelease;
+
+		// runPhase returns ok:true but the lane failed
+		expect(result.ok).toBe(true);
+		expect(result.lanes.length).toBe(1);
+		const laneResult = result.lanes[0];
+		expect(laneResult.status).toBe('failed');
+		expect(laneResult.error).toContain('worktree provision failed');
+		expect(laneResult.error).toContain('ENOTDIR');
+		// session.create should NOT have been called — lane failed before dispatch
+		expect(mockSessionOps.create).not.toHaveBeenCalled();
+		// releaseLaneLocks SHOULD have been called to release the lock we acquired
+		expect(releaseCalls.length).toBeGreaterThan(0);
+
+		// Durable state should reflect the lane failure
+		const durableState = leanState.loadLeanTurboRunState(tmpDir, SESSION_ID);
+		expect(durableState).not.toBeNull();
+		const persistedLane = durableState!.lanes.find(
+			(l) => l.laneId && l.laneId.startsWith('lane-'),
+		);
+		expect(persistedLane).toBeDefined();
+		expect(persistedLane!.status).toBe('failed');
+	});
+
+	// ─── New: worktree provision transient failure then success ────────────
+
+	test('worktree provision transient failure then success → lane proceeds normally', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSessionOps);
+
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+
+		// Mock provisionWorktree: first call throws with EACCES (transient), second succeeds
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		let provisionCallCount = 0;
+		LeanTurboRunner._internals.provisionWorktree = mock(() => {
+			provisionCallCount++;
+			if (provisionCallCount === 1) {
+				return Promise.reject(new Error('EBUSY: resource busy or locked'));
+			}
+			return Promise.resolve({
+				worktreePath,
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			});
+		});
+
+		// Mock merge + cleanup so lane completes fully
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() =>
+			Promise.resolve({ merged: true, strategy: 'merge' }),
+		);
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() =>
+			Promise.resolve({ cleaned: true }),
+		);
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() =>
+			Promise.resolve({ success: true }),
+		);
+
+		const result = await runner.runPhase(1);
+
+		// Restore
+		LeanTurboRunner._internals.provisionWorktree = origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+		LeanTurboRunner._internals.removeWorktree = origRemove;
+
+		expect(result.ok).toBe(true);
+		expect(provisionCallCount).toBe(2); // initial throw + 1 retry
+		// Lane should have completed (retry succeeded, dispatch proceeded)
+		expect(result.lanes.length).toBe(1);
+		expect(result.lanes[0].status).toBe('completed');
+		// session.create should have been called with the worktree path (retry succeeded)
+		expect(mockSessionOps.create).toHaveBeenCalled();
+		const createCall = mockSessionOps.create.mock.calls[0];
+		expect(
+			(createCall[0] as { query: { directory: string } }).query.directory,
+		).toBe(worktreePath);
+	});
+});
+
+// ─── Test 22: Merge-back failure handling (final council HIGH finding fix) ───────
+
+describe('merge-back failure handling', () => {
+	function setupWorktreeRunnerAndMocks(opts?: {
+		mergeResult?:
+			| { merged: true; strategy: string }
+			| { conflict: true; files: string[]; message: string }
+			| { error: string };
+		sessionFail?: boolean;
+	}) {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const sessionOps = opts?.sessionFail
+			? {
+					create: mock(() =>
+						Promise.resolve({ data: null, error: 'session create failed' }),
+					),
+					prompt: mock(() =>
+						Promise.resolve({ data: null, error: 'prompt failed' }),
+					),
+					delete: mock(() => Promise.resolve()),
+				}
+			: mockSuccessfulSessionOps();
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, sessionOps);
+
+		// Mock planner to return a single lane
+		const origPlan = LeanTurboRunner._internals.planLeanTurboLanes;
+		LeanTurboRunner._internals.planLeanTurboLanes = mock(
+			(..._args: Parameters<typeof origPlan>) => ({
+				phase: 1,
+				planId: 'test-plan',
+				lanes: [
+					{
+						laneId: 'lane-1',
+						taskIds: ['1.1'],
+						files: ['src/a.ts'],
+						status: 'pending' as const,
+					},
+				],
+				degradedTasks: [],
+				serializedTasks: [],
+				counters: {
+					lanesPlanned: 1,
+					lanesStarted: 0,
+					lanesCompleted: 0,
+					lanesFailed: 0,
+					tasksSerialized: 0,
+					tasksDegraded: 0,
+				},
+				crossLaneDependencies: {},
+			}),
+		);
+
+		// Mock orphan recovery
+		const origOrphanRecovery = LeanTurboRunner._internals.startupOrphanRecovery;
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(() =>
+			Promise.resolve({
+				prunedWorktrees: true,
+				remainingBranches: [],
+				warnings: [],
+			}),
+		);
+
+		// Mock provision
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath,
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			}),
+		);
+
+		// Track merge calls
+		const mergeCalls: unknown[] = [];
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		const defaultMergeResult = opts?.mergeResult ?? {
+			merged: true,
+			strategy: 'merge' as const,
+		};
+		LeanTurboRunner._internals.mergeLaneBranch = mock(
+			(...args: Parameters<typeof origMerge>) => {
+				mergeCalls.push(args);
+				return Promise.resolve(defaultMergeResult);
+			},
+		);
+
+		// Track cleanup calls
+		const cleanupCalls: unknown[] = [];
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(
+			(...args: Parameters<typeof origCleanup>) => {
+				cleanupCalls.push(args);
+				return Promise.resolve({ cleaned: true });
+			},
+		);
+
+		// Track remove calls
+		const removeCalls: unknown[] = [];
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(
+			(...args: Parameters<typeof origRemove>) => {
+				removeCalls.push(args);
+				return Promise.resolve({ success: true });
+			},
+		);
+
+		return {
+			runner,
+			sessionOps,
+			worktreePath,
+			origPlan,
+			origOrphanRecovery,
+			origProvision,
+			origMerge,
+			origCleanup,
+			origRemove,
+			mergeCalls,
+			cleanupCalls,
+			removeCalls,
+		};
+	}
+
+	function restoreMocks(mocks: ReturnType<typeof setupWorktreeRunnerAndMocks>) {
+		LeanTurboRunner._internals.planLeanTurboLanes = mocks.origPlan;
+		LeanTurboRunner._internals.startupOrphanRecovery = mocks.origOrphanRecovery;
+		LeanTurboRunner._internals.provisionWorktree = mocks.origProvision;
+		LeanTurboRunner._internals.mergeLaneBranch = mocks.origMerge;
+		LeanTurboRunner._internals.postMergeCleanup = mocks.origCleanup;
+		LeanTurboRunner._internals.removeWorktree = mocks.origRemove;
+	}
+
+	test('merge conflict: worktree NOT removed, lane result indicates merge-back failure', async () => {
+		const mocks = setupWorktreeRunnerAndMocks({
+			mergeResult: {
+				conflict: true,
+				files: ['src/a.ts', 'src/b.ts'],
+				message: 'CONFLICT (content): Merge conflict in src/a.ts',
+			},
+		});
+
+		const result = await mocks.runner.runPhase(1);
+		restoreMocks(mocks);
+
+		// Phase should still report ok (coder completed)
+		expect(result.ok).toBe(true);
+
+		// Lane should still be completed (coder finished work)
+		expect(result.lanes.length).toBe(1);
+		expect(result.lanes[0].status).toBe('completed');
+
+		// Lane result should include merge-back failure info
+		expect(result.lanes[0].mergeBackFailure).toBeDefined();
+		expect(result.lanes[0].mergeBackFailure!.laneId).toBe('lane-1');
+		expect(result.lanes[0].mergeBackFailure!.reason).toContain('CONFLICT');
+		expect(result.lanes[0].mergeBackFailure!.conflictFiles).toEqual([
+			'src/a.ts',
+			'src/b.ts',
+		]);
+
+		// removeWorktree should NOT have been called (preserved for manual recovery)
+		expect(mocks.removeCalls.length).toBe(0);
+
+		// postMergeCleanup should NOT have been called
+		expect(mocks.cleanupCalls.length).toBe(0);
+
+		// Phase result should include merge-back failures
+		expect(result.mergeBackFailures).toBeDefined();
+		expect(result.mergeBackFailures!.length).toBe(1);
+		expect(result.mergeBackFailures![0].laneId).toBe('lane-1');
+	});
+
+	test('merge error: worktree NOT removed, lane result indicates merge-back failure', async () => {
+		const mocks = setupWorktreeRunnerAndMocks({
+			mergeResult: {
+				error: 'fatal: not something we can merge',
+			},
+		});
+
+		const result = await mocks.runner.runPhase(1);
+		restoreMocks(mocks);
+
+		expect(result.ok).toBe(true);
+		expect(result.lanes.length).toBe(1);
+		expect(result.lanes[0].status).toBe('completed');
+
+		// Lane result should include merge-back failure info
+		expect(result.lanes[0].mergeBackFailure).toBeDefined();
+		expect(result.lanes[0].mergeBackFailure!.laneId).toBe('lane-1');
+		expect(result.lanes[0].mergeBackFailure!.reason).toContain('fatal:');
+
+		// removeWorktree should NOT have been called
+		expect(mocks.removeCalls.length).toBe(0);
+
+		// postMergeCleanup should NOT have been called
+		expect(mocks.cleanupCalls.length).toBe(0);
+
+		// Phase result should include merge-back failures
+		expect(result.mergeBackFailures).toBeDefined();
+		expect(result.mergeBackFailures!.length).toBe(1);
+	});
+
+	test('merge success: worktree IS removed, lane result shows success (no mergeBackFailure)', async () => {
+		const mocks = setupWorktreeRunnerAndMocks({
+			mergeResult: { merged: true, strategy: 'merge' },
+		});
+
+		const result = await mocks.runner.runPhase(1);
+		restoreMocks(mocks);
+
+		expect(result.ok).toBe(true);
+		expect(result.lanes.length).toBe(1);
+		expect(result.lanes[0].status).toBe('completed');
+
+		// Lane result should NOT have merge-back failure
+		expect(result.lanes[0].mergeBackFailure).toBeUndefined();
+
+		// removeWorktree SHOULD have been called
+		expect(mocks.removeCalls.length).toBeGreaterThan(0);
+
+		// postMergeCleanup SHOULD have been called
+		expect(mocks.cleanupCalls.length).toBeGreaterThan(0);
+
+		// Phase result should NOT have merge-back failures
+		expect(result.mergeBackFailures).toBeUndefined();
+	});
+
+	test('phase result includes merge-back failure information in summary', async () => {
+		const mocks = setupWorktreeRunnerAndMocks({
+			mergeResult: {
+				conflict: true,
+				files: ['src/a.ts'],
+				message: 'CONFLICT: Merge conflict in src/a.ts',
+			},
+		});
+
+		const result = await mocks.runner.runPhase(1);
+		restoreMocks(mocks);
+
+		// Phase result should have mergeBackFailures array
+		expect(result.mergeBackFailures).toBeDefined();
+		expect(result.mergeBackFailures).toHaveLength(1);
+		expect(result.mergeBackFailures![0].laneId).toBe('lane-1');
+		expect(result.mergeBackFailures![0].conflictFiles).toEqual(['src/a.ts']);
+	});
+});
+
+// ─── Test 23: postMergeCleanup call order after removeWorktree ──────────
+// Regression: git branch -D fails when the branch is still checked out in an
+// active worktree. postMergeCleanup MUST run AFTER removeWorktree.
+
+describe('postMergeCleanup runs AFTER removeWorktree (branch delete order fix)', () => {
+	test('removeWorktree is called before postMergeCleanup on successful merge', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSuccessfulSessionOps());
+
+		// Mock planner to return a single lane
+		const origPlan = LeanTurboRunner._internals.planLeanTurboLanes;
+		LeanTurboRunner._internals.planLeanTurboLanes = mock(
+			(..._args: Parameters<typeof origPlan>) => ({
+				phase: 1,
+				planId: 'test-plan',
+				lanes: [
+					{
+						laneId: 'lane-1',
+						taskIds: ['1.1'],
+						files: ['src/a.ts'],
+						status: 'pending' as const,
+					},
+				],
+				degradedTasks: [],
+				serializedTasks: [],
+				counters: {
+					lanesPlanned: 1,
+					lanesStarted: 0,
+					lanesCompleted: 0,
+					lanesFailed: 0,
+					tasksSerialized: 0,
+					tasksDegraded: 0,
+				},
+				crossLaneDependencies: {},
+			}),
+		);
+
+		// Mock orphan recovery
+		const origOrphanRecovery = LeanTurboRunner._internals.startupOrphanRecovery;
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(() =>
+			Promise.resolve({
+				prunedWorktrees: true,
+				remainingBranches: [],
+				warnings: [],
+			}),
+		);
+
+		// Mock provision
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath,
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			}),
+		);
+
+		// Track call order using a shared array
+		const callOrder: string[] = [];
+
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() => {
+			callOrder.push('mergeLaneBranch');
+			return Promise.resolve({ merged: true, strategy: 'merge' });
+		});
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() => {
+			callOrder.push('postMergeCleanup');
+			return Promise.resolve({ cleaned: true });
+		});
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() => {
+			callOrder.push('removeWorktree');
+			return Promise.resolve({ success: true });
+		});
+
+		let result;
+		try {
+			result = await runner.runPhase(1);
+
+			expect(result.ok).toBe(true);
+
+			// All three operations should have been called
+			expect(callOrder).toContain('mergeLaneBranch');
+			expect(callOrder).toContain('removeWorktree');
+			expect(callOrder).toContain('postMergeCleanup');
+
+			// removeWorktree MUST appear before postMergeCleanup in the call order
+			const removeIdx = callOrder.indexOf('removeWorktree');
+			const cleanupIdx = callOrder.indexOf('postMergeCleanup');
+			expect(removeIdx).toBeGreaterThan(-1);
+			expect(cleanupIdx).toBeGreaterThan(-1);
+			expect(removeIdx).toBeLessThan(cleanupIdx);
+
+			// mergeLaneBranch must be first
+			expect(callOrder[0]).toBe('mergeLaneBranch');
+		} finally {
+			LeanTurboRunner._internals.planLeanTurboLanes = origPlan;
+			LeanTurboRunner._internals.startupOrphanRecovery = origOrphanRecovery;
+			LeanTurboRunner._internals.provisionWorktree = origProvision;
+			LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+			LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+			LeanTurboRunner._internals.removeWorktree = origRemove;
+		}
+	});
+
+	test('postMergeCleanup is NOT called on merge conflict (worktree preserved)', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		const runner = makeRunner({
+			generatedAgentNames: ['mega_coder'],
+			leanConfig: { worktree_isolation: true },
+		});
+		injectMockSessionOps(runner, mockSuccessfulSessionOps());
+
+		// Mock planner
+		const origPlan = LeanTurboRunner._internals.planLeanTurboLanes;
+		LeanTurboRunner._internals.planLeanTurboLanes = mock(
+			(..._args: Parameters<typeof origPlan>) => ({
+				phase: 1,
+				planId: 'test-plan',
+				lanes: [
+					{
+						laneId: 'lane-1',
+						taskIds: ['1.1'],
+						files: ['src/a.ts'],
+						status: 'pending' as const,
+					},
+				],
+				degradedTasks: [],
+				serializedTasks: [],
+				counters: {
+					lanesPlanned: 1,
+					lanesStarted: 0,
+					lanesCompleted: 0,
+					lanesFailed: 0,
+					tasksSerialized: 0,
+					tasksDegraded: 0,
+				},
+				crossLaneDependencies: {},
+			}),
+		);
+
+		// Mock orphan recovery
+		const origOrphanRecovery = LeanTurboRunner._internals.startupOrphanRecovery;
+		LeanTurboRunner._internals.startupOrphanRecovery = mock(() =>
+			Promise.resolve({
+				prunedWorktrees: true,
+				remainingBranches: [],
+				warnings: [],
+			}),
+		);
+
+		// Mock provision
+		const worktreePath = path.join(
+			tmpDir,
+			'.swarm-worktrees',
+			SESSION_ID,
+			'lane-1',
+		);
+		const origProvision = LeanTurboRunner._internals.provisionWorktree;
+		LeanTurboRunner._internals.provisionWorktree = mock(() =>
+			Promise.resolve({
+				worktreePath,
+				branchName: `swarm-lane/${SESSION_ID}/lane-1`,
+			}),
+		);
+
+		const callOrder: string[] = [];
+
+		const origMerge = LeanTurboRunner._internals.mergeLaneBranch;
+		LeanTurboRunner._internals.mergeLaneBranch = mock(() => {
+			callOrder.push('mergeLaneBranch');
+			return Promise.resolve({
+				conflict: true,
+				files: ['src/a.ts'],
+				message: 'CONFLICT: Merge conflict in src/a.ts',
+			});
+		});
+		const origCleanup = LeanTurboRunner._internals.postMergeCleanup;
+		LeanTurboRunner._internals.postMergeCleanup = mock(() => {
+			callOrder.push('postMergeCleanup');
+			return Promise.resolve({ cleaned: true });
+		});
+		const origRemove = LeanTurboRunner._internals.removeWorktree;
+		LeanTurboRunner._internals.removeWorktree = mock(() => {
+			callOrder.push('removeWorktree');
+			return Promise.resolve({ success: true });
+		});
+
+		let result;
+		try {
+			result = await runner.runPhase(1);
+
+			expect(result.ok).toBe(true);
+
+			// On conflict: mergeLaneBranch called, but neither removeWorktree nor postMergeCleanup
+			expect(callOrder).toContain('mergeLaneBranch');
+			expect(callOrder).not.toContain('removeWorktree');
+			expect(callOrder).not.toContain('postMergeCleanup');
+		} finally {
+			LeanTurboRunner._internals.planLeanTurboLanes = origPlan;
+			LeanTurboRunner._internals.startupOrphanRecovery = origOrphanRecovery;
+			LeanTurboRunner._internals.provisionWorktree = origProvision;
+			LeanTurboRunner._internals.mergeLaneBranch = origMerge;
+			LeanTurboRunner._internals.postMergeCleanup = origCleanup;
+			LeanTurboRunner._internals.removeWorktree = origRemove;
+		}
 	});
 });

--- a/tests/unit/turbo/lean/worktree.test.ts
+++ b/tests/unit/turbo/lean/worktree.test.ts
@@ -1,0 +1,952 @@
+/**
+ * Tests for src/turbo/lean/worktree.ts
+ *
+ * All tests mock _internals.bunSpawn (the DI seam) to avoid needing a real git repo.
+ * The mock replaces the BunCompatSubprocess return value so each test can exercise
+ * specific exit codes and stdout/stderr strings.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
+import {
+	_internals,
+	assertCleanWorkingTree,
+	autoCommitDirty,
+	checkPathBudget,
+	cleanUntrackedFiles,
+	isCleanWorktree,
+	provisionWorktree,
+	removeWorktree,
+	shortenWorktreePath,
+} from '../../../../src/turbo/lean/worktree';
+import type { BunCompatSubprocess } from '../../../../src/utils/bun-compat';
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+/** Saves the real bunSpawn, platform, sleep, osTmpdir, and getCoreLongPaths so tests can restore them in afterEach. */
+const realBunSpawn = _internals.bunSpawn;
+const realPlatform = _internals.platform;
+const realSleep = _internals.sleep;
+const realOsTmpdir = _internals.osTmpdir;
+const realGetCoreLongPaths = _internals.getCoreLongPaths;
+
+/**
+ * Constructs a minimal BunCompatSubprocess mock.
+ * exitCode, stdout, and stderr are configurable per test.
+ */
+function mockProc(
+	exitCode: number,
+	stdout = '',
+	stderr = '',
+): BunCompatSubprocess {
+	return {
+		exited: Promise.resolve(exitCode),
+		exitCode,
+		stdout: {
+			text: () => Promise.resolve(stdout),
+		} as unknown as BunCompatSubprocess['stdout'],
+		stderr: {
+			text: () => Promise.resolve(stderr),
+		} as unknown as BunCompatSubprocess['stderr'],
+		kill: () => {},
+	} as BunCompatSubprocess;
+}
+
+/**
+ * Installs a fake bunSpawn that returns a pre-configured mockProc.
+ * Subsequent calls to _internals.bunSpawn return the same mock unless
+ * the test reassigns _internals.bunSpawn directly.
+ */
+function stubSpawn(exitCode: number, stdout = '', stderr = '') {
+	_internals.bunSpawn = () => mockProc(exitCode, stdout, stderr);
+}
+
+/** Restores the real bunSpawn, platform, sleep, osTmpdir, and getCoreLongPaths after every test. */
+afterEach(() => {
+	_internals.bunSpawn = realBunSpawn;
+	_internals.platform = realPlatform;
+	_internals.sleep = realSleep;
+	_internals.osTmpdir = realOsTmpdir;
+	_internals.getCoreLongPaths = realGetCoreLongPaths;
+});
+
+// ---------------------------------------------------------------------------
+// provisionWorktree
+// ---------------------------------------------------------------------------
+
+describe('provisionWorktree', () => {
+	const fakeDir = 'C:\\project-root';
+	const fakeLaneId = 'lane-1';
+	const fakeSessionId = 'session-abc';
+	const fakeConfig = {};
+
+	test('creates worktree with correct branch name and returns worktreePath + branchName', async () => {
+		// show-ref → exit 1 (branch doesn't exist), worktree add → exit 0 (success)
+		_internals.bunSpawn = (args: string[]) => {
+			if (args.includes('show-ref')) return mockProc(1, '', '');
+			return mockProc(0, '', '');
+		};
+
+		const result = await provisionWorktree(
+			fakeDir,
+			fakeLaneId,
+			fakeSessionId,
+			fakeConfig,
+		);
+
+		expect(result).toEqual({
+			worktreePath: expect.stringContaining('swarm-worktrees'),
+			branchName: 'swarm-lane/session-abc/lane-1',
+		} as Record<string, string>);
+	});
+
+	test('uses config.worktree_dir when provided', async () => {
+		// show-ref → exit 1 (branch doesn't exist), worktree add → exit 0 (success)
+		_internals.bunSpawn = (args: string[]) => {
+			if (args.includes('show-ref')) return mockProc(1, '', '');
+			return mockProc(0, '', '');
+		};
+		const config = { worktree_dir: 'D:\\worktrees' };
+
+		const result = await provisionWorktree(
+			fakeDir,
+			fakeLaneId,
+			fakeSessionId,
+			config,
+		);
+
+		// worktreePath should be resolved under D:\worktrees
+		expect(result).toHaveProperty('worktreePath');
+		expect(
+			(result as { worktreePath: string }).worktreePath.toLowerCase(),
+		).toContain('d:\\worktrees');
+	});
+
+	test('resolves relative worktree_dir against project directory', async () => {
+		// show-ref → exit 1 (branch doesn't exist), worktree add → exit 0 (success)
+		_internals.bunSpawn = (args: string[]) => {
+			if (args.includes('show-ref')) return mockProc(1, '', '');
+			return mockProc(0, '', '');
+		};
+
+		const config = { worktree_dir: '../custom-wt' };
+
+		const result = await provisionWorktree(
+			fakeDir,
+			fakeLaneId,
+			fakeSessionId,
+			config,
+		);
+
+		expect(result).toHaveProperty('worktreePath');
+		// Should be resolved against fakeDir (C:\project-root), not process.cwd()
+		expect(
+			(result as { worktreePath: string }).worktreePath.toLowerCase(),
+		).toContain('custom-wt');
+	});
+
+	test('uses default .swarm-worktrees/<sessionId>/<laneId> when worktree_dir not set', async () => {
+		// show-ref → exit 1 (branch doesn't exist), worktree add → exit 0 (success)
+		_internals.bunSpawn = (args: string[]) => {
+			if (args.includes('show-ref')) return mockProc(1, '', '');
+			return mockProc(0, '', '');
+		};
+
+		const result = await provisionWorktree(
+			fakeDir,
+			fakeLaneId,
+			fakeSessionId,
+			{},
+		);
+
+		// worktreePath should resolve to <parent-of-project-root>/.swarm-worktrees/<sessionId>/<laneId>
+		expect(result).toHaveProperty('worktreePath');
+		const p = (result as { worktreePath: string }).worktreePath;
+		expect(p).toContain('.swarm-worktrees');
+		expect(p).toContain(fakeSessionId);
+		expect(p).toContain(fakeLaneId);
+	});
+
+	test('returns error when branch already exists', async () => {
+		// git show-ref --verify --quiet exits 0 → branch exists
+		_internals.bunSpawn = (args: string[]) => {
+			if (args.includes('show-ref')) return mockProc(0, '', '');
+			return mockProc(0, '', '');
+		};
+
+		const result = await provisionWorktree(
+			fakeDir,
+			fakeLaneId,
+			fakeSessionId,
+			fakeConfig,
+		);
+
+		expect(result).toEqual({
+			error: 'Branch already exists: swarm-lane/session-abc/lane-1',
+		});
+	});
+
+	test('returns error when git worktree add fails', async () => {
+		// show-ref → exit 1 (branch doesn't exist), worktree add → exit 128 (failure)
+		_internals.bunSpawn = (args: string[]) => {
+			if (args.includes('show-ref')) return mockProc(1, '', '');
+			return mockProc(128, '', 'fatal: invalid reference: HEADXYZ');
+		};
+
+		const result = await provisionWorktree(
+			fakeDir,
+			fakeLaneId,
+			fakeSessionId,
+			fakeConfig,
+		);
+
+		expect(result).toHaveProperty('error');
+		expect((result as { error: string }).error).toContain(
+			'Failed to create worktree',
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// removeWorktree
+// ---------------------------------------------------------------------------
+
+describe('removeWorktree', () => {
+	const fakeWorktreePath = 'C:\\worktrees\\session-abc\\lane-1';
+	const fakeProjectRoot = 'C:\\project-root';
+
+	test('returns { success: true } when removal succeeds', async () => {
+		stubSpawn(0, '', '');
+
+		const result = await removeWorktree(fakeWorktreePath, fakeProjectRoot);
+
+		expect(result).toEqual({ success: true });
+	});
+
+	test('returns error when removal fails with non-retryable exit code', async () => {
+		stubSpawn(1, '', 'fatal: could not read logical configuration');
+
+		const result = await removeWorktree(fakeWorktreePath, fakeProjectRoot);
+
+		expect(result).toEqual({
+			error: 'fatal: could not read logical configuration',
+		});
+	});
+
+	test('Windows: retries up to 3 times on EBUSY', async () => {
+		_internals.platform = 'win32';
+		_internals.sleep = async () => {}; // no-op — no real delays in tests
+
+		// Simulate Windows: EBUSY on first two attempts, success on third
+		let attempts = 0;
+		_internals.bunSpawn = () => {
+			attempts++;
+			if (attempts < 3) return mockProc(1, '', 'EBUSY: resource busy');
+			return mockProc(0, '', '');
+		};
+
+		const result = await removeWorktree(fakeWorktreePath, fakeProjectRoot);
+
+		expect(result).toEqual({ success: true });
+		expect(attempts).toBe(3);
+	});
+
+	test('Windows: returns error after 3 retries (4 attempts) exhausted', async () => {
+		_internals.platform = 'win32';
+		_internals.sleep = async () => {}; // no-op
+
+		let attempts = 0;
+		_internals.bunSpawn = () => {
+			attempts++;
+			return mockProc(1, '', 'EBUSY: resource busy');
+		};
+
+		const result = await removeWorktree(fakeWorktreePath, fakeProjectRoot);
+
+		expect(result).toEqual({ error: 'EBUSY: resource busy' });
+		expect(attempts).toBe(4); // initial + 3 retries = 4 total attempts
+	});
+
+	test('Windows: retries on EPERM', async () => {
+		_internals.platform = 'win32';
+		_internals.sleep = async () => {}; // no-op
+
+		let attempts = 0;
+		_internals.bunSpawn = () => {
+			attempts++;
+			if (attempts < 3) return mockProc(1, '', 'EPERM: access denied');
+			return mockProc(0, '', '');
+		};
+
+		const result = await removeWorktree(fakeWorktreePath, fakeProjectRoot);
+
+		expect(result).toEqual({ success: true });
+		expect(attempts).toBe(3);
+	});
+
+	test('does NOT use --force flag', async () => {
+		const spawnCalls: string[][] = [];
+		_internals.bunSpawn = (args: string[]) => {
+			spawnCalls.push(args);
+			return mockProc(0, '', '');
+		};
+
+		await removeWorktree(fakeWorktreePath, fakeProjectRoot);
+
+		// Verify 'worktree' command was called with 'remove' (no '--force')
+		const worktreeCall = spawnCalls.find(
+			(args) => args[0] === 'git' && args[1] === 'worktree',
+		);
+		expect(worktreeCall).toBeDefined();
+		expect(worktreeCall).not.toContain('--force');
+		expect(worktreeCall![2]).toBe('remove');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// isCleanWorktree
+// ---------------------------------------------------------------------------
+
+describe('isCleanWorktree', () => {
+	const fakePath = 'C:\\worktrees\\session-abc\\lane-1';
+
+	test('returns true when both git status --porcelain and git ls-files return empty', async () => {
+		stubSpawn(0, '', ''); // used for both Promise.all calls (same stub, both get empty)
+
+		const result = await isCleanWorktree(fakePath);
+
+		expect(result).toBe(true);
+	});
+
+	test('returns false when git status --porcelain has output (uncommitted changes)', async () => {
+		// status --porcelain has output, ls-files is empty
+		// Two calls happen in Promise.all; bunSpawn is called twice.
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) return mockProc(0, ' M modified.txt', '');
+			return mockProc(0, '', '');
+		};
+
+		const result = await isCleanWorktree(fakePath);
+
+		expect(result).toBe(false);
+	});
+
+	test('returns false when git ls-files has output (untracked files)', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) return mockProc(0, '', ''); // status clean
+			return mockProc(0, 'untracked.txt', ''); // ls-files has untracked
+		};
+
+		const result = await isCleanWorktree(fakePath);
+
+		expect(result).toBe(false);
+	});
+
+	test('returns false when git commands return non-zero (cannot determine cleanliness)', async () => {
+		// If git exits non-zero, we cannot verify cleanliness — must treat as dirty
+		stubSpawn(128, '', 'fatal: not a git repository');
+
+		const result = await isCleanWorktree(fakePath);
+
+		expect(result).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// autoCommitDirty
+// ---------------------------------------------------------------------------
+
+describe('autoCommitDirty', () => {
+	const fakePath = 'C:\\worktrees\\session-abc\\lane-1';
+
+	test('returns { committed: true, message } on successful commit', async () => {
+		// git add succeeds, git commit succeeds
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) return mockProc(0, '', ''); // git add -A
+			return mockProc(0, '', ''); // git commit
+		};
+
+		const result = await autoCommitDirty(fakePath);
+
+		expect(result).toEqual({
+			committed: true,
+			message: 'swarm-lane: auto-commit before cleanup',
+		});
+	});
+
+	test('returns { committed: false, reason: "Nothing to commit" } when nothing to commit', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) return mockProc(0, '', ''); // git add -A succeeds
+			return mockProc(1, '', 'nothing to commit'); // git commit detects nothing
+		};
+
+		const result = await autoCommitDirty(fakePath);
+
+		expect(result).toEqual({ committed: false, reason: 'Nothing to commit' });
+	});
+
+	test('returns { committed: false, reason } when git add fails', async () => {
+		stubSpawn(1, '', 'fatal: not a git repository');
+
+		const result = await autoCommitDirty(fakePath);
+
+		expect(result).toEqual({
+			committed: false,
+			reason: 'git add failed: fatal: not a git repository',
+		});
+	});
+
+	test('uses correct commit message prefix', async () => {
+		let commitArgs: string[] = [];
+		_internals.bunSpawn = (args: string[]) => {
+			commitArgs = args;
+			return mockProc(0, '', '');
+		};
+
+		await autoCommitDirty(fakePath);
+
+		const commitIdx = commitArgs.indexOf('commit');
+		expect(commitIdx).toBeGreaterThan(-1);
+		expect(commitArgs[commitIdx + 1]).toBe('-m');
+		expect(commitArgs[commitIdx + 2]).toBe(
+			'swarm-lane: auto-commit before cleanup',
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// cleanUntrackedFiles
+// ---------------------------------------------------------------------------
+
+describe('cleanUntrackedFiles', () => {
+	const fakePath = 'C:\\worktrees\\session-abc\\lane-1';
+
+	test('returns { cleaned: true } when dry-run is empty and clean succeeds', async () => {
+		// First call: dry-run (empty → nothing to clean), second call: actual clean
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) return mockProc(0, '', ''); // dry-run: empty
+			return mockProc(0, '', ''); // clean: success
+		};
+
+		const result = await cleanUntrackedFiles(fakePath);
+
+		expect(result).toEqual({ cleaned: true });
+		expect(callCount).toBe(2);
+	});
+
+	test('returns { cleaned: true } when dry-run shows only safe-to-clean files', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) {
+				// dry-run: only generated/temp files
+				return mockProc(
+					0,
+					'Would remove dist/bundle.js\nWould remove debug.log\nWould remove coverage/lcov.info\n',
+					'',
+				);
+			}
+			return mockProc(0, '', ''); // clean: success
+		};
+
+		const result = await cleanUntrackedFiles(fakePath);
+
+		expect(result).toEqual({ cleaned: true });
+		expect(callCount).toBe(2);
+	});
+
+	test('skips clean and returns error when dry-run shows source files', async () => {
+		// Capture console.warn
+		const warnCalls: string[] = [];
+		const origWarn = console.warn;
+		console.warn = (...args: unknown[]) => warnCalls.push(args.join(' '));
+
+		try {
+			let callCount = 0;
+			_internals.bunSpawn = () => {
+				callCount++;
+				// dry-run shows a .ts file (source code)
+				return mockProc(
+					0,
+					'Would remove src/new-feature.ts\nWould remove debug.log\n',
+					'',
+				);
+			};
+
+			const result = await cleanUntrackedFiles(fakePath);
+
+			expect(result).toEqual({
+				cleaned: false,
+				error:
+					'untracked source files detected — skipping clean to prevent data loss',
+			});
+			// Actual clean should NOT have been called
+			expect(callCount).toBe(1);
+			// Warning should have been logged
+			expect(warnCalls.length).toBe(1);
+			expect(warnCalls[0]).toContain('src/new-feature.ts');
+			expect(warnCalls[0]).toContain('Skipping clean');
+		} finally {
+			console.warn = origWarn;
+		}
+	});
+
+	test('proceeds with clean when dry-run fails (fail-open)', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) return mockProc(1, '', 'dry-run error'); // dry-run fails
+			return mockProc(0, '', ''); // clean proceeds
+		};
+
+		const result = await cleanUntrackedFiles(fakePath);
+
+		expect(result).toEqual({ cleaned: true });
+		expect(callCount).toBe(2);
+	});
+
+	test('returns { cleaned: false, error } when actual clean fails', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) return mockProc(0, '', ''); // dry-run: empty
+			return mockProc(1, '', 'fatal: could not read logical configuration'); // clean fails
+		};
+
+		const result = await cleanUntrackedFiles(fakePath);
+
+		expect(result).toEqual({
+			cleaned: false,
+			error: 'fatal: could not read logical configuration',
+		});
+	});
+
+	test('skips clean when dry-run shows mixed safe and unsafe files', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			return mockProc(
+				0,
+				'Would remove src/utils/helper.ts\nWould remove build/output.js\nWould remove .tmp/cache.tmp\n',
+				'',
+			);
+		};
+
+		const result = await cleanUntrackedFiles(fakePath);
+
+		expect(result).toEqual({
+			cleaned: false,
+			error:
+				'untracked source files detected — skipping clean to prevent data loss',
+		});
+		// Actual clean should NOT have been called
+		expect(callCount).toBe(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// assertCleanWorkingTree
+// ---------------------------------------------------------------------------
+
+describe('assertCleanWorkingTree', () => {
+	const fakeDir = 'C:\\project-root';
+
+	test('returns { clean: true } when both git status and git ls-files return empty', async () => {
+		stubSpawn(0, '', ''); // both commands succeed with empty output
+
+		const result = await assertCleanWorkingTree(fakeDir);
+
+		expect(result).toEqual({ clean: true });
+	});
+
+	test('returns { clean: false, error } when git status --porcelain has output (uncommitted changes)', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) return mockProc(0, ' M modified.txt', '');
+			return mockProc(0, '', ''); // ls-files clean
+		};
+
+		const result = await assertCleanWorkingTree(fakeDir);
+
+		expect(result).toEqual({
+			clean: false,
+			error: expect.stringContaining('commit or stash'),
+		});
+	});
+
+	test('returns { clean: false, error } when git ls-files has output (untracked files)', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) return mockProc(0, '', ''); // status clean
+			return mockProc(0, 'untracked-file.txt', ''); // ls-files has untracked
+		};
+
+		const result = await assertCleanWorkingTree(fakeDir);
+
+		expect(result).toEqual({
+			clean: false,
+			error: expect.stringContaining('commit or stash'),
+		});
+	});
+
+	test('returns { clean: false, error } when git command fails (non-zero exit)', async () => {
+		stubSpawn(128, '', 'fatal: not a git repository');
+
+		const result = await assertCleanWorkingTree(fakeDir);
+
+		expect(result).toMatchObject({ clean: false });
+		expect(result).toHaveProperty('error');
+		expect((result as { error: string }).error).toContain(
+			'Unable to verify working tree cleanliness',
+		);
+	});
+
+	test('error message mentions "commit or stash"', async () => {
+		let callCount = 0;
+		_internals.bunSpawn = () => {
+			callCount++;
+			if (callCount === 1) return mockProc(0, ' M src/file.ts', '');
+			return mockProc(0, '', '');
+		};
+
+		const result = await assertCleanWorkingTree(fakeDir);
+
+		expect(result).toMatchObject({ clean: false });
+		expect((result as { error: string }).error).toContain('commit or stash');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// checkPathBudget
+// ---------------------------------------------------------------------------
+
+describe('checkPathBudget', () => {
+	test('non-Windows skips path budget check → always returns { ok: true }', async () => {
+		_internals.platform = 'linux';
+
+		// bunSpawn should NOT even be called on non-Windows
+		let called = false;
+		_internals.bunSpawn = () => {
+			called = true;
+			return mockProc(0, '', '');
+		};
+
+		const result = await checkPathBudget('C:\\very\\long\\path', 'C:\\project');
+
+		expect(result).toEqual({ ok: true });
+		expect(called).toBe(false);
+	});
+
+	test('Windows with short paths → returns { ok: true }', async () => {
+		_internals.platform = 'win32';
+		_internals.getCoreLongPaths = async () => 'false';
+
+		// Short file paths in ls-files output
+		_internals.bunSpawn = () => mockProc(0, 'src/index.ts\nREADME.md\n', '');
+
+		const result = await checkPathBudget(
+			'C:\\Users\\dev\\proj',
+			'C:\\Users\\dev\\proj',
+		);
+
+		expect(result).toEqual({ ok: true });
+	});
+
+	test('Windows with paths exceeding budget → returns { ok: false } with computed details', async () => {
+		_internals.platform = 'win32';
+		_internals.getCoreLongPaths = async () => 'false';
+
+		// A very long relative path that pushes total over 250
+		const longRelativePath =
+			'src/' + 'nested/deeply/'.repeat(12) + 'super-long-file-name.ts';
+		_internals.bunSpawn = () =>
+			mockProc(0, `short.ts\n${longRelativePath}\n`, '');
+
+		// Use a worktree root long enough so total >= 250
+		const longRoot =
+			'C:\\Users\\developer\\projects\\my-enterprise-application\\.swarm-worktrees\\session-id\\lane-1';
+		const result = await checkPathBudget(
+			longRoot,
+			'C:\\Users\\developer\\projects\\my-enterprise-application',
+		);
+
+		expect(result).toMatchObject({ ok: false });
+		expect((result as { error: string }).error).toContain(
+			'Total path budget exceeded',
+		);
+		expect((result as { error: string }).error).toContain(longRoot);
+		expect((result as { suggestion: string }).suggestion).toContain(
+			'worktree_dir',
+		);
+	});
+
+	test('returns { ok: true } when git ls-files fails', async () => {
+		_internals.platform = 'win32';
+		_internals.getCoreLongPaths = async () => 'false';
+
+		// git ls-files returns non-zero
+		_internals.bunSpawn = () => mockProc(1, '', 'fatal: not a git repository');
+
+		const result = await checkPathBudget('C:\\very\\long\\path', 'C:\\project');
+
+		expect(result).toEqual({ ok: true });
+	});
+
+	test('returns { ok: true } when git ls-files returns empty', async () => {
+		_internals.platform = 'win32';
+		_internals.getCoreLongPaths = async () => 'false';
+
+		_internals.bunSpawn = () => mockProc(0, '', '');
+
+		const result = await checkPathBudget('C:\\very\\long\\path', 'C:\\project');
+
+		expect(result).toEqual({ ok: true });
+	});
+
+	test('skips path budget when core.longpaths is true (even with long paths)', async () => {
+		_internals.platform = 'win32';
+
+		// core.longpaths = true → budget check skipped entirely
+		_internals.getCoreLongPaths = async () => 'true';
+
+		// bunSpawn should NOT be called if longpaths skips the budget
+		let called = false;
+		_internals.bunSpawn = () => {
+			called = true;
+			return mockProc(0, '', '');
+		};
+
+		// Use a very long worktree root that would normally exceed the budget
+		const longRoot =
+			'C:\\Users\\developer\\projects\\my-enterprise-application\\.swarm-worktrees\\session-id\\lane-1';
+		const result = await checkPathBudget(
+			longRoot,
+			'C:\\Users\\developer\\projects\\my-enterprise-application',
+		);
+
+		expect(result).toEqual({ ok: true });
+		expect(called).toBe(false);
+	});
+
+	test('still applies budget check when core.longpaths is false', async () => {
+		_internals.platform = 'win32';
+
+		// core.longpaths = false → budget check proceeds
+		_internals.getCoreLongPaths = async () => 'false';
+
+		// A very long relative path that pushes total over 250
+		const longRelativePath =
+			'src/' + 'nested/deeply/'.repeat(12) + 'super-long-file-name.ts';
+		_internals.bunSpawn = () =>
+			mockProc(0, `short.ts\n${longRelativePath}\n`, '');
+
+		const longRoot =
+			'C:\\Users\\developer\\projects\\my-enterprise-application\\.swarm-worktrees\\session-id\\lane-1';
+		const result = await checkPathBudget(
+			longRoot,
+			'C:\\Users\\developer\\projects\\my-enterprise-application',
+		);
+
+		expect(result).toMatchObject({ ok: false });
+		expect((result as { error: string }).error).toContain(
+			'Total path budget exceeded',
+		);
+	});
+
+	test('still applies budget check when core.longpaths throws (fail-safe)', async () => {
+		_internals.platform = 'win32';
+
+		// getCoreLongPaths throws → should be caught and budget check proceeds
+		_internals.getCoreLongPaths = async () => {
+			throw new Error('git config failed unexpectedly');
+		};
+
+		// A very long relative path that pushes total over 250
+		const longRelativePath =
+			'src/' + 'nested/deeply/'.repeat(12) + 'super-long-file-name.ts';
+		_internals.bunSpawn = () =>
+			mockProc(0, `short.ts\n${longRelativePath}\n`, '');
+
+		const longRoot =
+			'C:\\Users\\developer\\projects\\my-enterprise-application\\.swarm-worktrees\\session-id\\lane-1';
+		const result = await checkPathBudget(
+			longRoot,
+			'C:\\Users\\developer\\projects\\my-enterprise-application',
+		);
+
+		expect(result).toMatchObject({ ok: false });
+		expect((result as { error: string }).error).toContain(
+			'Total path budget exceeded',
+		);
+	});
+
+	test('still applies budget check when core.longpaths query fails (returns undefined)', async () => {
+		_internals.platform = 'win32';
+
+		// getCoreLongPaths returns undefined (query failed) → budget check proceeds
+		_internals.getCoreLongPaths = async () => undefined;
+
+		// A very long relative path that pushes total over 250
+		const longRelativePath =
+			'src/' + 'nested/deeply/'.repeat(12) + 'super-long-file-name.ts';
+		_internals.bunSpawn = () =>
+			mockProc(0, `short.ts\n${longRelativePath}\n`, '');
+
+		const longRoot =
+			'C:\\Users\\developer\\projects\\my-enterprise-application\\.swarm-worktrees\\session-id\\lane-1';
+		const result = await checkPathBudget(
+			longRoot,
+			'C:\\Users\\developer\\projects\\my-enterprise-application',
+		);
+
+		expect(result).toMatchObject({ ok: false });
+		expect((result as { error: string }).error).toContain(
+			'Total path budget exceeded',
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// shortenWorktreePath
+// ---------------------------------------------------------------------------
+
+describe('shortenWorktreePath', () => {
+	test('returns tmpdir-based path with swwt prefix', () => {
+		_internals.osTmpdir = () => 'C:\\Temp';
+		_internals.platform = 'win32';
+
+		const result = shortenWorktreePath('C:\\project', 'sess-1', 'lane-2');
+
+		expect(result).toBe(path.join('C:\\Temp', 'swwt', 'sess-1', 'lane-2'));
+	});
+
+	test('returns correct path regardless of platform', () => {
+		_internals.osTmpdir = () => '/tmp';
+		_internals.platform = 'linux';
+
+		const result = shortenWorktreePath('/project', 'sess-1', 'lane-2');
+
+		expect(result).toBe(path.join('/tmp', 'swwt', 'sess-1', 'lane-2'));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// provisionWorktree — path budget integration
+// ---------------------------------------------------------------------------
+
+describe('provisionWorktree — path budget (Windows)', () => {
+	const fakeDir = 'C:\\project-root';
+	const fakeLaneId = 'lane-1';
+	const fakeSessionId = 'session-abc';
+
+	test('auto-shortens on Windows when budget exceeded (no explicit worktree_dir)', async () => {
+		_internals.platform = 'win32';
+		_internals.osTmpdir = () => 'C:\\Temp';
+		_internals.getCoreLongPaths = async () => 'false';
+
+		// Construct a long relative path that will exceed budget with the default worktree root
+		const longRelative = 'src/' + 'nested/deep/'.repeat(17) + 'abc.ts';
+		let spawnCallCount = 0;
+		_internals.bunSpawn = () => {
+			spawnCallCount++;
+			// Call 1: git ls-files for budget check (longRelative exceeds budget)
+			if (spawnCallCount === 1) return mockProc(0, longRelative);
+			// Call 2: git ls-files for re-check with shortened path
+			if (spawnCallCount === 2) return mockProc(0, longRelative);
+			// Call 3: git show-ref (branch doesn't exist yet)
+			if (spawnCallCount === 3) return mockProc(1);
+			// Call 4: git worktree add
+			return mockProc(0);
+		};
+
+		const result = await provisionWorktree(
+			fakeDir,
+			fakeLaneId,
+			fakeSessionId,
+			{}, // no worktree_dir
+		);
+
+		expect(result).toHaveProperty('worktreePath');
+		expect(typeof (result as { worktreePath: string }).worktreePath).toBe(
+			'string',
+		);
+		expect(result).toHaveProperty('branchName');
+		// The worktree path should be the shortened temp path
+		expect(
+			(result as { worktreePath: string }).worktreePath.toLowerCase(),
+		).toContain('swwt');
+	});
+
+	test('warns but proceeds when budget exceeded AND worktree_dir is explicitly set', async () => {
+		_internals.platform = 'win32';
+		_internals.getCoreLongPaths = async () => 'false';
+
+		// Long relative path that exceeds budget
+		const longRelative = 'src/' + 'nested/deep/'.repeat(17) + 'abc.ts';
+		let spawnCallCount = 0;
+		_internals.bunSpawn = () => {
+			spawnCallCount++;
+			// Call 1: git ls-files for budget check (longRelative exceeds budget)
+			if (spawnCallCount === 1) return mockProc(0, longRelative);
+			// Call 2: git show-ref (branch doesn't exist)
+			if (spawnCallCount === 2) return mockProc(1);
+			// Call 3: git worktree add (success)
+			return mockProc(0);
+		};
+
+		// Capture console.warn
+		const warnCalls: string[] = [];
+		const origWarn = console.warn;
+		console.warn = (...args: unknown[]) => warnCalls.push(args.join(' '));
+
+		try {
+			const config = { worktree_dir: 'D:\\explicit-trees' };
+			const result = await provisionWorktree(
+				fakeDir,
+				fakeLaneId,
+				fakeSessionId,
+				config,
+			);
+
+			// Should succeed because user explicitly set worktree_dir
+			expect(result).toHaveProperty('worktreePath');
+			// Should have issued a warning
+			expect(warnCalls.length).toBeGreaterThan(0);
+			expect(warnCalls[0]).toContain('Path budget warning');
+		} finally {
+			console.warn = origWarn;
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// _internals DI seam
+// ---------------------------------------------------------------------------
+
+describe('_internals.bunSpawn', () => {
+	test('_internals.bunSpawn can be replaced for testing', () => {
+		// Confirm the seam exists and is initially the real function
+		expect(typeof _internals.bunSpawn).toBe('function');
+
+		// Replace with a no-op mock
+		_internals.bunSpawn = () => mockProc(0, 'replaced', '');
+		const result = _internals.bunSpawn();
+		expect(result.exitCode).toBe(0);
+		expect(result).toHaveProperty('exited');
+		expect(result).toHaveProperty('kill');
+	});
+});


### PR DESCRIPTION
Closes #1146

## Summary

Implements git worktree isolation for Lean Turbo parallel lane execution. Each coder lane gets its own isolated git worktree with an independent branch, enabling true parallel work without file conflicts.

### New modules
- **src/turbo/lean/worktree.ts** (~637 lines) — Worktree lifecycle: create, provision, remove with _internals DI seam. Includes ssertCleanWorkingTree, checkPathBudget (respects core.longpaths), cleanUntrackedFiles (dry-run safety gate), and Windows path budget (250 chars, auto-shorten).
- **src/turbo/lean/merge-back.ts** (~630 lines) — Merge-back strategies: merge, rebase, cherry-pick with full merge-base range. Dirty-tree recovery via ttemptMergeBackFromDirty. Orphaned branch/worktree cleanup.

### Runner integration (src/turbo/lean/runner.ts, +477 lines)
- Clean working tree guard — dirty tree degrades all lanes to shared directory
- Explicit lane failure on worktree provision failure (no silent degradation)
- MergeBackFailureInfo propagated through LaneResult and tool response
- postMergeCleanup runs AFTER emoveWorktree (git refuses branch deletion on active worktrees)
- Transient retry for Windows file-lock failures (4 attempts, 2s delay)

### Config
- lean_turbo.worktree_dir — override worktree parent directory
- lean_turbo.merge_strategy — "merge" (default), "rebase", or "cherry-pick"

### Guardrails
- Blocks git worktree remove --force in src/hooks/guardrails.ts

### Tests (282 new across 9 files)
- worktree.test.ts (45 tests) — provision, cleanup, path budget, longpaths, clean safety gate
- merge-back.test.ts (51 tests) — all 3 strategies, conflict handling, dirty recovery, orphan cleanup
- unner.test.ts (67 tests) — lane processing, worktree wiring, merge-back, provision failure, postMergeCleanup order
- integration-worktree.test.ts (44 tests) — cross-component wiring with _internals mocks
- etroactive-adversarial.test.ts (30 tests) — edge cases and attack vectors
- guardrails-safety.test.ts (11 tests) — destructive command blocking
- init-safety.test.ts (8 tests) — startup safety validation
- schema-lean-turbo.test.ts (22 tests) — config schema validation
- lean-turbo-run-phase.test.ts (6 tests) — tool response propagation

## Invariant audit
- 1 (plugin init): not touched — no changes to src/index.ts init path
- 2 (runtime portability): not touched — no un: imports, no Bun.* calls, dist import OK
- 3 (subprocesses): touched — all git calls use array-form spawn, explicit cwd, stdin: 'ignore', 	imeout, kill() in inally. Verified by 30 adversarial tests checking FR-006/FR-011 patterns.
- 4 (.swarm containment): touched — worktree paths use ctx.directory + .swarm-worktrees suffix. No process.cwd() in new code.
- 5 (plan durability): not touched — no plan ledger or schema changes
- 6 (test_runner safety): not touched — no test_runner tool changes
- 7 (test writing): touched — all new tests use un:test, _internals DI seams with 	ry/finally restore. No mock.module.
- 8 (session state): not touched — session keys unchanged
- 9 (guardrails/retry): touched — added git worktree remove --force block. Transient retry uses bounded max_transient_retries=4 with 2s delay.
- 10 (chat/system msg): not touched — no chat hook changes
- 11 (tool registration): touched — mergeBackFailures added to LeanTurboRunPhaseResult. Schema and constant updates are additive.
- 12 (release/cache): not touched — version files untouched, release fragment created

## Test plan
- [x] un run build passes
- [x] un run typecheck passes
- [x] 282 dedicated tests pass (0 failures)
- [x] All git subprocess calls use array-form spawn (verified by FR-006/FR-011 adversarial tests)
- [x] No dist/ staged
- [x] No local-only files staged
- [x] Release fragment created at docs/releases/pending/lean-turbo-worktree-isolation.md
- [x] _internals DI seams in all 3 new modules (worktree, merge-back, runner)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds git worktree isolation for Lean Turbo parallel lanes, giving each lane its own branch/worktree for true parallel execution without file conflicts. Includes merge-back strategies, safety checks, Windows path handling, and surfaces failures in the tool response.

- **New Features**
  - Per-lane git worktrees with a clean-tree guard, Windows path budget/auto-shortening, and safe untracked clean.
  - Merge-back supports `merge`, `rebase`, and `cherry-pick`, with conflict handling, dirty-tree recovery, and orphan cleanup.
  - Runner integration: explicit provision failure, failures surfaced via `mergeBackFailures`, Windows file-lock retry, and correct cleanup order.
  - Config additions: `worktree_isolation`, `merge_strategy`, and `worktree_dir` (defaults keep current behavior).
  - Safety and tests: guardrails block `git worktree remove --force`; 282 tests cover lifecycle, merge-back, guardrails, init safety, and schema; removed `mock.module()` mentions from test comments to avoid a CI false positive.

- **Migration**
  - Enable by setting `worktree_isolation: true` in Lean Turbo config.
  - Optional: set `merge_strategy` (`merge` default) and `worktree_dir`.
  - No breaking changes; defaults preserve shared-directory mode.

<sup>Written for commit f967da850e30054efe02a20b9e205ba19206b17b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

