### PR TITLE
fix(cli): address PR #1154 review follow-ups (docs + test coverage)

### DIFF
--- a/docs/releases/pending/700-follow-up-lockfile-validation.md
+++ b/docs/releases/pending/700-follow-up-lockfile-validation.md
@@ -5,7 +5,7 @@
 Enhanced defense-in-depth validation for lock file deletion safety:
 
 - Added grandparent directory check to `isSafeLockFilePath()` to reject misconfigured nested paths like `opencode/opencode/filename`
-- Improved error messages in `close.ts` to show full paths instead of just basenames, enabling better debugging of path-related issues
+- Improved the `SWARM_PLAN` path-removal warning in `src/commands/close.ts:843-847` to show the full candidate path instead of just the basename, enabling better debugging of path-related issues
 - Clarified documentation explaining why `isSafeLockFilePath()` and `isSafeCachePath()` are kept separate (different validation rules)
 
 ## Why

--- a/tests/unit/cli/update-command.test.ts
+++ b/tests/unit/cli/update-command.test.ts
@@ -386,6 +386,45 @@ describe('evictLockFiles', () => {
 		expect(stdout).toMatch(/cache[\\/]opencode[\\/]bun\.lockb/);
 		expect(stdout).toMatch(/config[\\/]opencode[\\/]package-lock\.json/);
 	});
+
+	test('full CLI path refuses misconfigured nested opencode/opencode/bun.lock (integration)', async () => {
+		// End-to-end coverage of the PR #1154 grandparent guard through the
+		// full CLI path: getPluginLockFilePaths() → isSafeLockFilePath() →
+		// evictLockFiles() → console.error with full path → exit code 1 →
+		// file is NOT deleted.
+		//
+		// To produce a resolved lock path whose grandparent segment is
+		// literally 'opencode', the XDG_CACHE_HOME itself must end in
+		// 'opencode' (so the constructed path <XDG>/opencode/bun.lock becomes
+		// <X>/opencode/opencode/bun.lock). The child process must own
+		// the file, so we create a temp dir and pass its absolute path.
+		const nestedCacheBase = join(tempDir, 'opencode');
+		const nestedLockPath = join(nestedCacheBase, 'opencode', 'bun.lock');
+		await mkdir(join(nestedCacheBase, 'opencode'), { recursive: true });
+		await writeFile(nestedLockPath, '{}');
+
+		const proc = Bun.spawn([process.execPath, 'run', CLI_PATH, 'update'], {
+			env: {
+				...process.env,
+				XDG_CACHE_HOME: nestedCacheBase,
+				XDG_CONFIG_HOME: xdgConfigHome,
+			},
+			stdout: 'pipe',
+			stderr: 'pipe',
+		});
+		const exitCode = await proc.exited;
+		const stderr = await new Response(proc.stderr).text();
+
+		// 1. Non-zero exit code signals the safety check tripped.
+		expect(exitCode).toBe(1);
+		// 2. The full path (not just the basename) appears in stderr — this
+		// is the diagnostic improvement PR #1154 also standardized on.
+		expect(stderr).toContain(nestedLockPath);
+		expect(stderr).toContain('refused: failed safety check');
+		// 3. The lock file MUST still exist — the guard must have refused
+		// before the unlink attempt.
+		expect(existsSync(nestedLockPath)).toBe(true);
+	});
 });
 
 describe('isSafeLockFilePath', () => {
@@ -434,6 +473,43 @@ describe('isSafeLockFilePath', () => {
 		// This prevents misconfigured nested paths like /tmp/opencode/opencode/bun.lock.
 		expect(isSafeLockFilePath('/tmp/opencode/opencode/bun.lock')).toBe(false);
 		expect(isSafeLockFilePath('/var/opencode/opencode/bun.lockb')).toBe(false);
+	});
+
+	test('rejects nested opencode path on Windows-style absolute path (grandparent check)', () => {
+		// path.resolve() normalizes the separators, so on Linux CI we use a
+		// forward-slash Windows-style path. The check is platform-safe: it
+		// splits on path.sep after resolution, so a Windows-style
+		// C:\\opencode\\opencode\\bun.lock would produce the same 4-segment
+		// /c/opencode/opencode/bun.lock shape on this runner and trip the
+		// grandparent guard.
+		const winNested = '/c/opencode/opencode/bun.lock';
+		expect(isSafeLockFilePath(winNested)).toBe(false);
+		const winNestedLockb = '/c/Users/testuser/opencode/opencode/bun.lockb';
+		expect(isSafeLockFilePath(winNestedLockb)).toBe(false);
+	});
+
+	test('grandparent check is case-sensitive: documents current strict-equality behavior', () => {
+		// Documents the strict case-sensitive behavior of the grandparent
+		// check. The check is `grandparent === 'opencode'` (byte-exact), so
+		// a grandparent segment like 'OpenCode' would NOT trip the guard.
+		// The mitigations are: (a) the parent check (`parent === 'opencode'`)
+		// also fails case-sensitively, so `/tmp/OPENCODE/OPENCODE/bun.lock`
+		// is still rejected because its parent 'OPENCODE' ≠ 'opencode';
+		// (b) on case-insensitive filesystems (macOS HFS+ default, Windows
+		// NTFS) the OS normalizes case at the FS layer before any path
+		// comparison, so the case-mismatch path simply does not exist
+		// on disk. This test pins the current behavior so any future
+		// case-insensitive change is intentional.
+		//
+		// Case A: ALL-uppercase — rejected by the parent check (parent is
+		// 'OPENCODE', not 'opencode'), NOT by the grandparent check.
+		expect(isSafeLockFilePath('/tmp/OPENCODE/OPENCODE/bun.lock')).toBe(false);
+		// Case B: mixed-case grandparent — actually ACCEPTED, because the
+		// parent segment is the legitimate lowercase 'opencode' and the
+		// byte-exact grandparent guard does not match 'OpenCode'. The
+		// path is "safe-looking" from the validator's perspective even
+		// though it is unlikely to arise in practice.
+		expect(isSafeLockFilePath('/var/OpenCode/opencode/bun.lock')).toBe(true);
 	});
 });
 


### PR DESCRIPTION
Closes #1177

## Summary

Follow-up to PR #1154 (lock file path validation hardening). Resolves the four non-blocking review items tracked in issue #1177 that remained open after the grandparent-check merge.

- [DOCS] Release note plural inaccuracy: tightened the `What changed` bullet to name the single warning that was updated (the `SWARM_PLAN` path-removal warning at `src/commands/close.ts:843-847`) and the specific change (full path instead of basename), so the bullet no longer overstates the diff.
- [TEST] Full-CLI integration test for the grandparent guard: spawns a real child process with a misconfigured nested lock file at `<XDG>/opencode/opencode/bun.lock` (required because `OPENCODE_PLUGIN_LOCK_FILE_PATHS` is captured at module load time) and asserts the full safety contract -- non-zero exit code, full path in stderr, and the file is NOT deleted.
- [TEST] Windows-style path coverage: pins platform-safety of the `path.sep`-based comparison by exercising a `/c/opencode/opencode/bun.lock` shape on Linux CI, matching the same segment shape Windows would produce.
- [TEST] Case-variant test for the strict-equality grandparent check: documents the byte-exact behavior of the grandparent guard (mixed-case grandparent is NOT rejected; all-uppercase is rejected by the parent check, not the grandparent check) so any future case-insensitive change is intentional.

Item 5 from issue #1177 (pre-existing Windows `EISDIR` vs `EPERM`) is intentionally deferred -- it predates PR #1154 and is unrelated to the grandparent guard. It needs Windows CI to validate the right fix.

Diff scope: 2 files, +77/-1.
- `docs/releases/pending/700-follow-up-lockfile-validation.md` (+1/-1)
- `tests/unit/cli/update-command.test.ts` (+76/-0)

## Invariant audit

- 1 (plugin init): not touched - no `src/index.ts` / plugin entry changes.
- 2 (runtime portability): not touched - no `package.json#main` / `bun build` / plugin-shape changes; `dist/` not staged.
- 3 (subprocesses): not touched - no `spawn` / `bunSpawn` / `spawnSync` changes in source; the new test uses `Bun.spawn` only inside a test file, with `stdout/stderr: 'pipe'` consumed, child awaited, and the spawned binary is the package's own CLI under test.
- 4 (.swarm containment): not touched - no tool/hook/working-directory changes.
- 5 (plan durability): not touched - no plan-ledger / projection / checkpoint changes.
- 6 (test_runner safety): not touched - no `test_runner` tool usage; validation done via shell `bun --smol test` per-file loops.
- 7 (test writing): touched - new tests follow the writing-tests skill (`tests/unit/cli/update-command.test.ts`). The new tests use real fs fixtures in `tmp` and a child process for the integration case; no `mock.module` is introduced; case-variant test pins existing byte-exact behavior with an explanatory comment so any future change is intentional.
- 8 (session state): not touched - no session/swarm-mode changes.
- 9 (guardrails/retry): not touched - no retry/guardrail changes.
- 10 (chat/system msg): not touched - no agent-prompt / system-message changes.
- 11 (tool registration): not touched - no `createSwarmTool` / tool-registration changes.
- 12 (release/cache): touched - `docs/releases/pending/700-follow-up-lockfile-validation.md` was edited to accurately describe the single-line warning change. `package.json` version, `CHANGELOG.md`, and `.release-please-manifest.json` are untouched (release-please will produce the next version).

## Test plan

- [x] `bun --smol test tests/unit/cli/update-command.test.ts` -- 26 pass (3 new + 23 pre-existing); 0 new failures introduced.
- [x] `bun --smol test tests/unit/cli` -- 290 pass (was 287), 4 pre-existing failures unchanged on `origin/main`.
- [x] `bun run typecheck` -- clean.
- [x] `bun run build` -- clean.
- [x] `bun run lint` -- no warnings on touched files.
- [ ] CI `pr-standards` and `action-semantic-pull-request` `check-title` jobs on the open PR.

## Pre-existing failures

- 4 failures in `tests/unit/cli` reproduce on `origin/main`; not introduced by this PR.

## Out of scope

- Item 5 from issue #1177 (pre-existing Windows `EISDIR` vs `EPERM`) is deferred -- predates PR #1154 and needs Windows CI to validate the right fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end and cross-platform tests for the grandparent lockfile safety check, and updates the release note to name the exact warning that changed. Completes the remaining review follow-ups in #1177 for PR #1154.

- **Test Coverage**
  - Adds an integration test that spawns the CLI with a nested `opencode/opencode/bun.lock`; expects exit code 1, full path in stderr, and no deletion.
  - Covers Windows-style paths and case sensitivity to pin `path.sep` behavior and the current byte-exact checks.

- **Documentation**
  - Tightens the pending release note to specify the `SWARM_PLAN` path-removal warning now prints the full candidate path (`src/commands/close.ts:843-847`).

<sup>Written for commit b3d1424f845f3333d3a63d269403e4929700cb84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

