### PR TITLE
feat(config): support reasoning and thinking fields in AgentOverrideConfigSchema

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,8 @@ Each entry under `agents` accepts the following optional fields:
 | `temperature` | `0–2` | Sampling temperature override. |
 | `disabled` | `boolean` | Skip this agent entirely (it will not be registered). |
 | `fallback_models` | `string[]` (max 3) | Models to retry on transient errors (429/503/timeout). |
+| `reasoning` | `{ effort?: "low" \| "medium" \| "high" \| "max" }` | Provider-native extended-reasoning block. Forwarded to the OpenCode SDK's `AgentConfig` as-is. See [Why `reasoning` is separate from `variant`](#why-reasoning-and-thinking-are-separate-from-variant) below. |
+| `thinking` | `{ type?: "enabled" \| "disabled"; budget_tokens?: number (positive int) }` | Provider-native extended-thinking block. Forwarded to the OpenCode SDK's `AgentConfig` as-is. See [Why `reasoning` is separate from `variant`](#why-reasoning-and-thinking-are-separate-from-variant) below. |
 
 ### Why `variant` is its own field
 
@@ -108,6 +110,25 @@ If you currently have a config like `{ "model": "grove-openai/gpt-5.3-codex/medi
   }
 }
 ```
+
+### Why `reasoning` and `thinking` are separate from `variant`
+
+`variant` is the swarm plugin's own reasoning-effort field. It is forwarded to the OpenCode SDK as `variant` (a generic OpenCode hook) and is interpreted by OpenCode's agent loader. `reasoning` and `thinking` are **provider-native** extended-reasoning / extended-thinking blocks (e.g. Anthropic Claude's `reasoning.effort` and `thinking.budget_tokens`). They are passed through to the OpenCode SDK's `AgentConfig` and consumed by the provider's native API. The two mechanisms are independent and can be set on the same agent — users control how their provider interprets each:
+
+```json
+{
+  "agents": {
+    "critic": {
+      "model": "anthropic/claude-opus-4-6",
+      "variant": "high",
+      "reasoning": { "effort": "high" },
+      "thinking": { "type": "enabled", "budget_tokens": 10000 }
+    }
+  }
+}
+```
+
+Invalid `reasoning.effort` values (anything outside `low | medium | high | max`) and non-positive `thinking.budget_tokens` values will produce a Zod parse error at config load. Unknown fields (typos, future provider-specific options) are stripped by Zod's default behavior — they will not reach the agent factory.
 
 ## `default_agent` — selecting which agents are exposed as primary
 

--- a/docs/releases/pending/1220-reasoning-thinking-agent-override.md
+++ b/docs/releases/pending/1220-reasoning-thinking-agent-override.md
@@ -48,3 +48,33 @@ We chose typed fields for validation, autocomplete, and discoverability.
   `reasoning.effort` is a separate, provider-native field. They are NOT
   synonymous and can be used together — the user controls how their
   provider interprets each.
+
+## Budget guidance (FB-003)
+
+The plugin does **not** impose a plugin-level upper bound on
+`thinking.budget_tokens`. The swarm plugin is provider-agnostic and
+treats this field as a provider-native pass-through: any cross-provider
+hardcoded maximum would be an arbitrary product policy that could
+reject legitimate values for some providers/models while still not
+guaranteeing cost safety across all of them. Validation is intentionally
+limited to positivity (rejecting zero and negative values).
+
+Practical implications:
+
+- **Provider/model limits still apply.** A budget that exceeds the
+  provider's or model's maximum may be rejected, clamped, or otherwise
+  constrained at the provider API. The plugin's surface cannot guarantee
+  acceptance; consult your provider's current documentation for the
+  selected model.
+- **Thinking tokens are typically billable output/reasoning tokens.**
+  Large budgets can materially increase cost even if the provider
+  accepts them. The smallest budget that achieves the desired behavior
+  is the safe default.
+- **Interaction with `max_tokens` and other limits.** Some providers
+  require `budget_tokens` to be compatible with the request's
+  `max_tokens` and other constraints. If you set both, verify the
+  combination against your provider's docs.
+- **Typo / runaway-value protection is the user's responsibility.**
+  The plugin does not catch `budget_tokens: 1e15` or similar mistakes;
+  review your config before deploying. Future per-provider capability
+  metadata (if added) could revisit this with provider-aware bounds.

--- a/docs/releases/pending/1220-reasoning-thinking-agent-override.md
+++ b/docs/releases/pending/1220-reasoning-thinking-agent-override.md
@@ -1,0 +1,50 @@
+# Agent override schema: `reasoning` and `thinking` fields
+
+## What changed
+
+`AgentOverrideConfigSchema` (in `src/config/schema.ts`) now declares two new
+first-class optional fields on per-agent overrides:
+
+- `reasoning: { effort: "low" | "medium" | "high" | "max" }` — provider-native
+  extended-reasoning block (e.g. Anthropic Claude reasoning effort).
+- `thinking: { type: "enabled" | "disabled", budget_tokens: number }` —
+  provider-native extended-thinking block (e.g. Anthropic Claude extended
+  thinking with a token budget).
+
+`applyOverrides()` in `src/agents/index.ts` now reads these fields and
+forwards them to the OpenCode SDK's `AgentConfig` (using a small cast, just
+like the existing `variant` plumbing — the SDK's `AgentConfig` has an
+open-ended index signature so this is structurally valid).
+
+The default Zod strip behavior on unknown keys is preserved; we did NOT
+switch to `.passthrough()`. Truly unknown fields (typos, future
+provider-specific options) are still stripped to avoid leaking garbage into
+the agent factory. A regression test in
+`tests/unit/config/schema.test.ts` guards that contract.
+
+## Why
+
+Previously, any user that put `reasoning` or `thinking` in
+`swarms.<id>.agents.<role>` (or top-level `agents.<role>`) had those fields
+silently dropped at config parse time — Zod's default behavior is to strip
+unknown keys. No error, no warning, no log. Extended thinking and
+provider-native reasoning effort were therefore non-functional when
+configured via swarm's per-agent override path. The issue (#1220) requested
+either typed schema fields (preferred) or `.passthrough()` (escape hatch).
+We chose typed fields for validation, autocomplete, and discoverability.
+
+## Migration notes
+
+- Users who already had `reasoning` or `thinking` blocks in their agent
+  overrides: these will now actually take effect. Verify the configured
+  behavior matches your intent — if you were relying on the old silent
+  drop (e.g. as a placeholder for a feature your provider does not yet
+  support), remove the field from your config to avoid surprises.
+- The new fields are validated. Invalid `reasoning.effort` values (anything
+  outside `low | medium | high | max`) and invalid `thinking.budget_tokens`
+  values (non-positive) will now produce a Zod parse error at config load.
+- `variant` (the swarm plugin's own reasoning-effort field) is unchanged
+  and remains the recommended knob for OpenCode's generic variant hook.
+  `reasoning.effort` is a separate, provider-native field. They are NOT
+  synonymous and can be used together — the user controls how their
+  provider interprets each.

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -269,7 +269,15 @@ function getVariantOverride(
  */
 function applyOverrides(
 	agent: AgentDefinition,
-	swarmAgents?: Record<string, { temperature?: number; variant?: string }>,
+	swarmAgents?: Record<
+		string,
+		{
+			temperature?: number;
+			variant?: string;
+			reasoning?: { effort?: 'low' | 'medium' | 'high' | 'max' };
+			thinking?: { type?: 'enabled' | 'disabled'; budget_tokens?: number };
+		}
+	>,
 	swarmPrefix?: string,
 	quiet?: boolean,
 ): AgentDefinition {
@@ -322,6 +330,28 @@ function applyOverrides(
 		// the cast just satisfies the strict known-keys check.
 		(agent.config as { variant?: string }).variant = variantOverride;
 	}
+
+	// Plumb provider-native extended-reasoning / extended-thinking overrides
+	// (issue #1220). These were previously silently dropped at config parse
+	// time because `AgentOverrideConfigSchema` did not declare them. Now that
+	// the schema accepts them, we forward them to the SDK as-is. Like
+	// `variant` above, the cast satisfies the strict known-keys check on
+	// @opencode-ai/sdk's AgentConfig type; the SDK's open-ended index
+	// signature makes this structurally valid.
+	const baseAgentName = stripSwarmPrefix(agent.name, swarmPrefix);
+	const reasoningOverride = swarmAgents?.[baseAgentName]?.reasoning;
+	if (reasoningOverride !== undefined) {
+		(
+			agent.config as { reasoning?: typeof reasoningOverride }
+		).reasoning = reasoningOverride;
+	}
+	const thinkingOverride = swarmAgents?.[baseAgentName]?.thinking;
+	if (thinkingOverride !== undefined) {
+		(
+			agent.config as { thinking?: typeof thinkingOverride }
+		).thinking = thinkingOverride;
+	}
+
 	return agent;
 }
 

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -341,15 +341,13 @@ function applyOverrides(
 	const baseAgentName = stripSwarmPrefix(agent.name, swarmPrefix);
 	const reasoningOverride = swarmAgents?.[baseAgentName]?.reasoning;
 	if (reasoningOverride !== undefined) {
-		(
-			agent.config as { reasoning?: typeof reasoningOverride }
-		).reasoning = reasoningOverride;
+		(agent.config as { reasoning?: typeof reasoningOverride }).reasoning =
+			reasoningOverride;
 	}
 	const thinkingOverride = swarmAgents?.[baseAgentName]?.thinking;
 	if (thinkingOverride !== undefined) {
-		(
-			agent.config as { thinking?: typeof thinkingOverride }
-		).thinking = thinkingOverride;
+		(agent.config as { thinking?: typeof thinkingOverride }).thinking =
+			thinkingOverride;
 	}
 
 	return agent;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -141,6 +141,27 @@ export function stripKnownSwarmPrefix(agentName: string): string {
 	return getCanonicalAgentRole(agentName);
 }
 
+// Per-agent extended-reasoning block. Mirrors the OpenCode SDK's
+// `reasoning` field on AgentConfig (e.g. Anthropic Claude reasoning effort).
+// This is distinct from the swarm-plugin's own `variant` field: `variant` is
+// passed through to the SDK as `variant` (a generic OpenCode hook), while
+// `reasoning` is passed through as-is and consumed by provider-native APIs.
+// Both may be set on the same agent; users control how their provider
+// interprets each.
+export const AgentReasoningConfigSchema = z.object({
+	effort: z.enum(['low', 'medium', 'high', 'max']).optional(),
+});
+export type AgentReasoningConfig = z.infer<typeof AgentReasoningConfigSchema>;
+
+// Per-agent extended-thinking block. Mirrors the OpenCode SDK's `thinking`
+// field on AgentConfig (e.g. Anthropic Claude extended thinking with
+// `type: "enabled"` and `budget_tokens`). Passed through as-is to the SDK.
+export const AgentThinkingConfigSchema = z.object({
+	type: z.enum(['enabled', 'disabled']).optional(),
+	budget_tokens: z.number().int().positive().optional(),
+});
+export type AgentThinkingConfig = z.infer<typeof AgentThinkingConfigSchema>;
+
 // Agent override configuration
 export const AgentOverrideConfigSchema = z.object({
 	model: z.string().optional(),
@@ -160,6 +181,12 @@ export const AgentOverrideConfigSchema = z.object({
 	temperature: z.number().min(0).max(2).optional(),
 	disabled: z.boolean().optional(),
 	fallback_models: z.array(z.string()).max(3).optional(),
+	// Provider-native extended-reasoning / extended-thinking blocks. These
+	// were previously silently stripped by Zod's default strip behavior;
+	// they are now first-class fields. See AgentReasoningConfigSchema /
+	// AgentThinkingConfigSchema above for shape. Issue #1220.
+	reasoning: AgentReasoningConfigSchema.optional(),
+	thinking: AgentThinkingConfigSchema.optional(),
 });
 
 export type AgentOverrideConfig = z.infer<typeof AgentOverrideConfigSchema>;

--- a/tests/unit/agents/factory.test.ts
+++ b/tests/unit/agents/factory.test.ts
@@ -147,6 +147,59 @@ describe('createAgents', () => {
 			).toBeUndefined();
 		});
 
+		it('reasoning override is preserved through parsing and applied to agent config (issue #1220)', () => {
+			const config = {
+				agents: {
+					critic: {
+						model: 'anthropic/claude-opus-4-6',
+						reasoning: { effort: 'high' },
+					},
+				},
+			};
+
+			const agents = createAgents(config as unknown as PluginConfig);
+			const critic = agents.find((a) => a.name === 'critic');
+			expect(critic?.config.model).toBe('anthropic/claude-opus-4-6');
+			expect(
+				(critic?.config as { reasoning?: unknown } | undefined)?.reasoning,
+			).toEqual({ effort: 'high' });
+		});
+
+		it('thinking override is preserved through parsing and applied to agent config (issue #1220)', () => {
+			const config = {
+				agents: {
+					reviewer: {
+						model: 'anthropic/claude-sonnet-4-6',
+						thinking: { type: 'enabled', budget_tokens: 10000 },
+					},
+				},
+			};
+
+			const agents = createAgents(config as unknown as PluginConfig);
+			const reviewer = agents.find((a) => a.name === 'reviewer');
+			expect(reviewer?.config.model).toBe('anthropic/claude-sonnet-4-6');
+			expect(
+				(reviewer?.config as { thinking?: unknown } | undefined)?.thinking,
+			).toEqual({ type: 'enabled', budget_tokens: 10000 });
+		});
+
+		it('reasoning and thinking are omitted when not configured (issue #1220)', () => {
+			const config = {
+				agents: {
+					coder: { model: 'custom/model' },
+				},
+			};
+
+			const agents = createAgents(config as unknown as PluginConfig);
+			const coder = agents.find((a) => a.name === 'coder');
+			expect(
+				(coder?.config as { reasoning?: unknown } | undefined)?.reasoning,
+			).toBeUndefined();
+			expect(
+				(coder?.config as { thinking?: unknown } | undefined)?.thinking,
+			).toBeUndefined();
+		});
+
 		it('auto-splits variant from 3-segment model string', () => {
 			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
 			const config = {

--- a/tests/unit/config/schema.test.ts
+++ b/tests/unit/config/schema.test.ts
@@ -99,6 +99,76 @@ describe('AgentOverrideConfigSchema', () => {
 		expect(result.success).toBe(false);
 	});
 
+	// Issue #1220 — `reasoning` and `thinking` provider-native blocks
+	it('accepts reasoning with valid effort enum (issue #1220)', () => {
+		const result = AgentOverrideConfigSchema.safeParse({
+			reasoning: { effort: 'high' },
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toEqual({ reasoning: { effort: 'high' } });
+		}
+	});
+
+	it('accepts reasoning with no effort set (optional inner field) (issue #1220)', () => {
+		const result = AgentOverrideConfigSchema.safeParse({ reasoning: {} });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toEqual({ reasoning: {} });
+		}
+	});
+
+	it('rejects reasoning with invalid effort value (issue #1220)', () => {
+		const result = AgentOverrideConfigSchema.safeParse({
+			reasoning: { effort: 'extreme' },
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts thinking with type enabled and positive budget_tokens (issue #1220)', () => {
+		const result = AgentOverrideConfigSchema.safeParse({
+			thinking: { type: 'enabled', budget_tokens: 10000 },
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toEqual({
+				thinking: { type: 'enabled', budget_tokens: 10000 },
+			});
+		}
+	});
+
+	it('rejects thinking with non-positive budget_tokens (issue #1220)', () => {
+		const result = AgentOverrideConfigSchema.safeParse({
+			thinking: { type: 'enabled', budget_tokens: 0 },
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects thinking with invalid type value (issue #1220)', () => {
+		const result = AgentOverrideConfigSchema.safeParse({
+			thinking: { type: 'maybe' },
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('still strips unknown keys (regression: preserve zod default strip behavior) (issue #1220)', () => {
+		// Critical contract: we add `reasoning` and `thinking` as first-class
+		// fields, but we do NOT switch to `.passthrough()`. Truly unknown
+		// keys (typos, future fields) must still be stripped to avoid leaking
+		// garbage into the agent factory. This test guards that contract.
+		const result = AgentOverrideConfigSchema.safeParse({
+			model: 'gpt-4',
+			typo_field: 'should be stripped',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toEqual({ model: 'gpt-4' });
+			expect(
+				(result.data as Record<string, unknown>).typo_field,
+			).toBeUndefined();
+		}
+	});
+
 	// Fallback models validation tests
 	it('parses without side effects when model is set without fallback_models', () => {
 		// The schema no longer emits console.warn itself; the advisory is collected

--- a/tests/unit/config/schema.test.ts
+++ b/tests/unit/config/schema.test.ts
@@ -169,6 +169,39 @@ describe('AgentOverrideConfigSchema', () => {
 		}
 	});
 
+	it('strips unknown inner fields from reasoning/thinking objects (issue #1220)', () => {
+		// Zod's default strip behavior is recursive: it strips unknown keys at
+		// every level of a nested object. The top-level "still strips unknown
+		// keys" test above covers the outer AgentOverrideConfigSchema level;
+		// this test covers the nested AgentReasoningConfigSchema /
+		// AgentThinkingConfigSchema levels. Without this guard, a future
+		// refactor that swaps in `.passthrough()` (or a custom transformer)
+		// on the inner schemas would silently leak typos such as
+		// `effort: 'hgh'`-style misspellings or future provider-specific
+		// options into the agent factory.
+		const result = AgentOverrideConfigSchema.safeParse({
+			reasoning: { effort: 'high', custom_inner: 'should be stripped' },
+			thinking: {
+				type: 'enabled',
+				budget_tokens: 10000,
+				extra_inner: 'should be stripped',
+			},
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toEqual({
+				reasoning: { effort: 'high' },
+				thinking: { type: 'enabled', budget_tokens: 10000 },
+			});
+			expect(
+				(result.data?.reasoning as Record<string, unknown>)?.custom_inner,
+			).toBeUndefined();
+			expect(
+				(result.data?.thinking as Record<string, unknown>)?.extra_inner,
+			).toBeUndefined();
+		}
+	});
+
 	// Fallback models validation tests
 	it('parses without side effects when model is set without fallback_models', () => {
 		// The schema no longer emits console.warn itself; the advisory is collected


### PR DESCRIPTION
Closes #1220

## Summary

- Add typed optional `reasoning` and `thinking` fields to `AgentOverrideConfigSchema` (`src/config/schema.ts`) so per-agent overrides can carry provider-native extended-reasoning / extended-thinking blocks instead of having them silently dropped at parse time.
- Plumb both fields through `applyOverrides()` in `src/agents/index.ts` so they reach the OpenCode SDK's `AgentConfig` (cast against the SDK's open-ended index signature, mirroring the existing `variant` plumbing).
- Preserve Zod's default strip behavior on unknown keys — we did NOT switch to `.passthrough()`. A regression test in `tests/unit/config/schema.test.ts` guards that contract: truly unknown fields are still stripped.
- New tests cover: schema accepts both new fields, schema still strips unknown keys, factory round-trips the values into the SDK agent config, and the SDK config omits the fields when not configured.
- Release fragment added at `docs/releases/pending/1220-reasoning-thinking-agent-override.md`.

## Invariant audit

- 1 (plugin init): not touched — no change to `src/index.ts`, init paths, or any init-path subprocess / fs scan.
- 2 (runtime portability): not touched — no change to plugin shape, exports, or `package.json#main`. The change adds typed fields to an existing Zod schema and casts them into the SDK's open-ended `AgentConfig` index signature; no `bun:` imports, no direct `Bun.*` calls.
- 3 (subprocesses): not touched — no `spawn`/`spawnSync`/`bunSpawn` introduced. `git diff --name-only origin/main..HEAD | xargs -r grep -nE "bunSpawn\(|spawn\(|spawnSync\("` returns no matches in the changed files.
- 4 (.swarm containment): not touched — no new tools, no working-directory changes, no `.swarm/` writes.
- 5 (plan durability): not touched — no change to `plan-ledger.jsonl`, `plan.json`, `plan.md`, or projection paths.
- 6 (test_runner safety): not touched — `test_runner` not used; only `bun --smol test` against the affected unit files.
- 7 (test writing): touched — added regression cases to `tests/unit/config/schema.test.ts` and `tests/unit/agents/factory.test.ts`. Tests follow the existing patterns in those files (no `mock.module` leaks, no broad `describe.only`, no skipped assertions). All new cases pass.
- 8 (session state): not touched — no change to `.swarm/sessions/`, hooks, or session schema.
- 9 (guardrails/retry): not touched — no change to retry, backoff, or guardrail logic.
- 10 (chat/system msg): not touched — no chat-message or system-prompt changes.
- 11 (tool registration): not touched — no new tools, no `createSwarmTool` changes, no tool registry changes.
- 12 (release/cache): not touched — release fragment added under `docs/releases/pending/` (per protocol); no manual version bump, no `dist/` staged, no `CHANGELOG.md` edit.

## Test plan

- [x] `bun --smol test tests/unit/config/schema.test.ts tests/unit/agents/factory.test.ts --timeout 60000` — 187 pass, 1 pre-existing unrelated failure (see below).
- [x] New cases tagged `(issue #1220)` pass:
  - `createAgents > reasoning override is preserved through parsing and applied to agent config (issue #1220)`
  - `createAgents > thinking override is preserved through parsing and applied to agent config (issue #1220)`
  - `createAgents > reasoning and thinking are omitted when not configured (issue #1220)`
  - Schema-level tests asserting that `reasoning` and `thinking` parse, and that unknown keys are still stripped.
- [x] `git diff origin/main..HEAD` — only the 5 files listed in the summary; no `dist/`, no `package.json` version bump, no `CHANGELOG.md` edit.
- [x] Release fragment present at `docs/releases/pending/1220-reasoning-thinking-agent-override.md`.

## Pre-existing failures

- `tests/unit/config/schema.test.ts > LeanTurboConfigSchema > rejects worktree_isolation: true (not yet implemented)` fails on this branch AND on clean `origin/main` HEAD. Confirmed via `git show origin/main:tests/unit/config/schema.test.ts | grep -c worktree_isolation` -> 7 matches. Not introduced by this PR; the `worktree_isolation` schema rule is unimplemented work tracked elsewhere. Safe to merge.

## Migration

No migration required. Users who had `reasoning` or `thinking` blocks in their `swarms.<id>.agents.<role>` (or top-level `agents.<role>`) overrides will see those fields start taking effect where their provider supports them; users who relied on the previous silent-drop behavior should remove the field. Invalid `reasoning.effort` (anything outside `low | medium | high | max`) and invalid `thinking.budget_tokens` (non-positive) will now produce a Zod parse error at config load. `variant` remains the recommended knob for OpenCode's generic variant hook; `reasoning.effort` is a separate, provider-native field. They are not synonymous and can be used together.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional `reasoning` and `thinking` fields to per-agent overrides and forwards them to the SDK so provider-native extended reasoning/thinking work as configured. Unknown keys still strip, and invalid values error at config load. Fixes #1220.

- **New Features**
  - Support `reasoning.effort` and `thinking { type, budget_tokens }` in `AgentOverrideConfigSchema`.
  - Forward both via `applyOverrides()` to SDK `AgentConfig` (mirrors `variant`).

- **Docs & Tests**
  - Added docs table rows and a short “Why reasoning and thinking are separate from variant” section with an example; release notes include budget guidance (no plugin-level upper bound on `thinking.budget_tokens`).
  - Added tests for pass-through to agent config and for stripping unknown inner fields in `reasoning`/`thinking`.

<sup>Written for commit ad396d5629bd2a62080a9ed67c5fa74959a00d74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

