### PR TITLE
fix(issue): use shared parseGitRemoteUrl so /swarm issue resolves proxy and GitHub Enterprise remotes

### DIFF
--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -12,6 +12,7 @@
  */
 
 import { execSync } from 'node:child_process';
+import { parseGitRemoteUrl } from './pr-ref';
 
 const MAX_URL_LEN = 2048;
 
@@ -268,38 +269,6 @@ function detectGitRemote(): string | null {
 	} catch {
 		return null;
 	}
-}
-
-/**
- * Parse owner/repo from a git remote URL.
- * Supports HTTPS (https://github.com/owner/repo.git) and SSH (git@github.com:owner/repo.git).
- */
-function parseGitRemoteUrl(
-	remoteUrl: string,
-): { owner: string; repo: string } | null {
-	// HTTPS format: https://github.com/owner/repo.git
-	const httpsMatch = remoteUrl.match(
-		/^https:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/i,
-	);
-	if (httpsMatch) {
-		return {
-			owner: httpsMatch[1],
-			repo: httpsMatch[2].replace(/\.git$/, ''),
-		};
-	}
-
-	// SSH format: git@github.com:owner/repo.git
-	const sshMatch = remoteUrl.match(
-		/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/i,
-	);
-	if (sshMatch) {
-		return {
-			owner: sshMatch[1],
-			repo: sshMatch[2].replace(/\.git$/, ''),
-		};
-	}
-
-	return null;
 }
 
 export function handleIssueCommand(_directory: string, args: string[]): string {

--- a/tests/unit/commands/issue.test.ts
+++ b/tests/unit/commands/issue.test.ts
@@ -302,6 +302,31 @@ describe('handleIssueCommand', () => {
 			expect(result).toContain('test-repo');
 			expect(result).toContain('100');
 		});
+
+		// Regression for DD-C014 (deep-dive audit, issue #1235):
+		// `parseGitRemoteUrl` previously returned null for proxy remotes and
+		// GitHub Enterprise hostnames, causing bare-number issue resolution to
+		// silently fail with a misleading "Could not parse issue reference" error
+		// for users on those remote shapes.
+		test('Bare number with proxy remote (path-style) resolves owner/repo', () => {
+			execSyncMock.mockImplementation(
+				() => 'http://proxy.example.com/git/owner/repo.git',
+			);
+			const result = handleIssueCommand('/test', ['77']);
+			expect(result).toContain(
+				'issue="https://github.com/owner/repo/issues/77"',
+			);
+		});
+
+		test('Bare number with GitHub Enterprise host (path-style) resolves owner/repo', () => {
+			execSyncMock.mockImplementation(
+				() => 'https://github.acme.com/owner/repo.git',
+			);
+			const result = handleIssueCommand('/test', ['88']);
+			expect(result).toContain(
+				'issue="https://github.com/owner/repo/issues/88"',
+			);
+		});
 	});
 
 	// =============================================================================


### PR DESCRIPTION
Closes #1235

## Summary
- DD-C014 fix: replaced the duplicate `parseGitRemoteUrl` copy in `src/commands/issue.ts` with the shared 3-format version exported from `src/commands/pr-ref.ts`
- The issue command silently returned `null` for GitHub Enterprise and proxy remotes that pr-ref.ts already handles (HTTPS, SSH, and path-style shapes)
- Added regression tests covering both proxy and GitHub Enterprise remote shapes
- This was the top-priority item from the deep-dive maintainability audit (issue #1235) as it was the only confirmed correctness bug among the downgraded findings

## Invariant audit
- 1 (plugin init): not touched - no changes to plugin loading or registration
- 2 (runtime portability): not touched - no Node/Bun compatibility changes
- 3 (subprocesses): not touched - no spawn or subprocess changes
- 4 (.swarm containment): not touched - no .swarm/ directory changes
- 5 (plan durability): not touched - no plan ledger changes
- 6 (test_runner safety): not touched - no test_runner changes
- 7 (test writing): touched - added regression tests in tests/unit/commands/issue.test.ts covering proxy and GitHub Enterprise remote shapes
- 8 (session state): not touched - no state.ts changes
- 9 (guardrails/retry): not touched - no guardrail changes
- 10 (chat/system msg): not touched - no message changes
- 11 (tool registration): not touched - no tool registration changes
- 12 (release/cache): not touched - no version or cache changes

## Test plan
- [x] `bun run build` — build succeeds
- [x] `bun --smol test tests/unit/commands/issue.test.ts --timeout 30000` — all tests pass, including 2 new regression tests
- [x] `bunx biome ci .` — lint and formatting pass
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` — dist loads correctly


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `issue` command to use the shared `parseGitRemoteUrl`, fixing bare-number issue resolution for proxy and GitHub Enterprise remotes. Closes #1235.

- **Bug Fixes**
  - Import shared parser from `src/commands/pr-ref.ts` and remove the duplicate in `src/commands/issue.ts`.
  - Support HTTPS, SSH, and path-style remote URLs.
  - Add regression tests for proxy and GitHub Enterprise remotes.

<sup>Written for commit 35a0f08d0e1d6df372ef289c0fb5f71275def6f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

