### PR TITLE
fix(knowledge): add tier arg to knowledge_archive for hive entry archival

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -98,6 +98,17 @@ Quarantined entries are hidden from queries but preserved:
 /swarm knowledge restore lesson-abc123
 ```
 
+### Archival / Purge (knowledge_archive tool)
+
+Use the `knowledge_archive` tool to archive, quarantine, or purge knowledge entries with an immutable audit tombstone:
+
+- `knowledge_archive { id, reason }` — archive a swarm entry (default tier).
+- `knowledge_archive { id, reason, tier: 'hive' }` — archive a hive entry.
+- `mode: 'quarantine'` — set status to quarantined instead of archived.
+- `mode: 'purge', allow_purge: true` — hard-delete (requires admin flag).
+
+Archived and quarantined entries are automatically hidden from `searchKnowledge` results.
+
 ### Expiration (N-phase TTL decay)
 
 At every successful phase completion, `sweepAgedEntries()` runs:

--- a/src/hooks/knowledge-events.ts
+++ b/src/hooks/knowledge-events.ts
@@ -149,6 +149,8 @@ export interface ArchivedEvent {
 	mode: 'archive' | 'quarantine' | 'purge';
 	evidence?: string;
 	previous_status?: string;
+	/** Knowledge tier that was targeted ('swarm' or 'hive'). Defaults to 'swarm'. */
+	tier?: 'swarm' | 'hive';
 }
 
 /** An escalation: a directive was auto-promoted by the repeat-mistake escalator. */

--- a/src/tools/knowledge-archive.ts
+++ b/src/tools/knowledge-archive.ts
@@ -16,10 +16,11 @@ import { z } from 'zod';
 import { recordKnowledgeEvent } from '../hooks/knowledge-events.js';
 import {
 	readKnowledge,
+	resolveHiveKnowledgePath,
 	resolveSwarmKnowledgePath,
 	rewriteKnowledge,
 } from '../hooks/knowledge-store.js';
-import type { SwarmKnowledgeEntry } from '../hooks/knowledge-types.js';
+import type { KnowledgeEntryBase } from '../hooks/knowledge-types.js';
 import { warn } from '../utils/logger.js';
 import { createSwarmTool } from './create-tool.js';
 
@@ -29,7 +30,7 @@ type ArchiveMode = (typeof MODES)[number];
 export const knowledge_archive: ReturnType<typeof createSwarmTool> =
 	createSwarmTool({
 		description:
-			"Archive (default), quarantine, or purge a swarm knowledge entry by ID, appending an immutable audit tombstone. 'archive'/'quarantine' set the entry status reversibly and hide it from recall; 'purge' hard-deletes and requires allow_purge:true.",
+			"Archive (default), quarantine, or purge a swarm or hive knowledge entry by ID, appending an immutable audit tombstone. 'archive'/'quarantine' set the entry status reversibly and hide it from recall; 'purge' hard-deletes and requires allow_purge:true. Use tier:'hive' to target a cross-project hive entry (default tier is 'swarm').",
 		args: {
 			id: z.string().min(1).describe('UUID of the knowledge entry'),
 			reason: z
@@ -49,6 +50,10 @@ export const knowledge_archive: ReturnType<typeof createSwarmTool> =
 				.boolean()
 				.optional()
 				.describe("Admin flag required when mode='purge'"),
+			tier: z
+				.enum(['swarm', 'hive'] as const)
+				.optional()
+				.describe("Target knowledge tier: 'swarm' (default, project-local) or 'hive' (cross-project)"),
 		},
 		execute: async (args: unknown, directory, ctx): Promise<string> => {
 			const a = (args ?? {}) as {
@@ -57,6 +62,7 @@ export const knowledge_archive: ReturnType<typeof createSwarmTool> =
 				evidence?: unknown;
 				mode?: unknown;
 				allow_purge?: unknown;
+				tier?: unknown;
 			};
 
 			const id = typeof a.id === 'string' ? a.id : '';
@@ -76,6 +82,8 @@ export const knowledge_archive: ReturnType<typeof createSwarmTool> =
 			const evidence = typeof a.evidence === 'string' ? a.evidence : undefined;
 			const mode: ArchiveMode =
 				a.mode === 'quarantine' || a.mode === 'purge' ? a.mode : 'archive';
+			const tier: 'swarm' | 'hive' =
+				a.tier === 'hive' ? 'hive' : 'swarm';
 
 			if (mode === 'purge' && a.allow_purge !== true) {
 				return JSON.stringify({
@@ -84,10 +92,13 @@ export const knowledge_archive: ReturnType<typeof createSwarmTool> =
 				});
 			}
 
-			const swarmPath = resolveSwarmKnowledgePath(directory);
-			let entries: SwarmKnowledgeEntry[];
+			const targetPath =
+				tier === 'hive'
+					? resolveHiveKnowledgePath()
+					: resolveSwarmKnowledgePath(directory);
+			let entries: KnowledgeEntryBase[];
 			try {
-				entries = await readKnowledge<SwarmKnowledgeEntry>(swarmPath);
+				entries = await readKnowledge<KnowledgeEntryBase>(targetPath);
 			} catch (err) {
 				return JSON.stringify({
 					success: false,
@@ -102,14 +113,14 @@ export const knowledge_archive: ReturnType<typeof createSwarmTool> =
 			const previousStatus = target.status;
 			const now = new Date().toISOString();
 
-			let nextEntries: SwarmKnowledgeEntry[];
+			let nextEntries: KnowledgeEntryBase[];
 			let resultStatus: string;
 			if (mode === 'purge') {
 				// Defense-in-depth: hard-delete is irreversible. Emit a prominent
 				// warning even though allow_purge:true was already required. The
 				// archived event below is the audit trail.
 				warn(
-					`[knowledge_archive] PURGE: hard-deleting entry id=${id} actor=${
+					`[knowledge_archive] PURGE: hard-deleting entry id=${id} tier=${tier} actor=${
 						ctx?.agent ?? 'unknown'
 					} reason=${reason}`,
 				);
@@ -124,7 +135,7 @@ export const knowledge_archive: ReturnType<typeof createSwarmTool> =
 			}
 
 			try {
-				await rewriteKnowledge(swarmPath, nextEntries);
+				await rewriteKnowledge(targetPath, nextEntries);
 			} catch (err) {
 				return JSON.stringify({
 					success: false,
@@ -142,12 +153,14 @@ export const knowledge_archive: ReturnType<typeof createSwarmTool> =
 				mode,
 				evidence,
 				previous_status: previousStatus,
+				tier,
 			});
 
 			return JSON.stringify({
 				success: true,
 				id,
 				mode,
+				tier,
 				previous_status: previousStatus,
 				status: resultStatus,
 			});

--- a/tests/unit/tools/knowledge-archive.test.ts
+++ b/tests/unit/tools/knowledge-archive.test.ts
@@ -9,9 +9,13 @@ import {
 import {
 	appendKnowledge,
 	readKnowledge,
+	resolveHiveKnowledgePath,
 	resolveSwarmKnowledgePath,
 } from '../../../src/hooks/knowledge-store';
-import type { SwarmKnowledgeEntry } from '../../../src/hooks/knowledge-types';
+import type {
+	HiveKnowledgeEntry,
+	SwarmKnowledgeEntry,
+} from '../../../src/hooks/knowledge-types';
 import { knowledge_archive } from '../../../src/tools/knowledge-archive';
 
 function makeEntry(id: string): SwarmKnowledgeEntry {
@@ -151,5 +155,176 @@ describe('knowledge_archive', () => {
 			await knowledge_archive.execute({ id: 'k1' } as never, ctx(dir)),
 		);
 		expect(noReason.success).toBe(false);
+	});
+
+	it('returns tier:swarm by default', async () => {
+		const raw = await knowledge_archive.execute(
+			{ id: 'k1', reason: 'stale' },
+			ctx(dir),
+		);
+		const parsed = JSON.parse(raw);
+		expect(parsed.tier).toBe('swarm');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Hive-tier tests
+// ---------------------------------------------------------------------------
+
+function makeHiveEntry(id: string): HiveKnowledgeEntry {
+	return {
+		id,
+		tier: 'hive',
+		lesson: `Hive lesson ${id} with enough characters to be valid`,
+		category: 'process',
+		tags: [],
+		scope: 'global',
+		confidence: 0.5,
+		status: 'established',
+		confirmed_by: [],
+		source_project: 'test-project',
+		encounter_score: 1.0,
+		retrieval_outcomes: {
+			applied_count: 0,
+			succeeded_after_count: 0,
+			failed_after_count: 0,
+		},
+		schema_version: 2,
+		created_at: new Date().toISOString(),
+		updated_at: new Date().toISOString(),
+	};
+}
+
+describe('knowledge_archive (hive tier)', () => {
+	let dir: string;
+	let hiveDir: string;
+	let hivePath: string;
+	let origHome: string | undefined;
+
+	beforeEach(async () => {
+		dir = join(
+			tmpdir(),
+			`swarm-archive-hive-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		mkdirSync(dir, { recursive: true });
+
+		// Redirect HOME so resolveHiveKnowledgePath() writes into our temp dir.
+		origHome = process.env.HOME;
+		hiveDir = join(dir, 'xdg-data');
+		mkdirSync(hiveDir, { recursive: true });
+		process.env.HOME = dir;
+		process.env.XDG_DATA_HOME = hiveDir;
+
+		hivePath = resolveHiveKnowledgePath();
+		await appendKnowledge(hivePath, makeHiveEntry('h1'));
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+		if (origHome !== undefined) {
+			process.env.HOME = origHome;
+		} else {
+			delete process.env.HOME;
+		}
+		delete process.env.XDG_DATA_HOME;
+	});
+
+	it('archives a hive entry when tier=hive', async () => {
+		const raw = await knowledge_archive.execute(
+			{ id: 'h1', reason: 'bad cross-project lesson', tier: 'hive' },
+			ctx(dir),
+		);
+		const parsed = JSON.parse(raw);
+		expect(parsed.success).toBe(true);
+		expect(parsed.mode).toBe('archive');
+		expect(parsed.tier).toBe('hive');
+		expect(parsed.previous_status).toBe('established');
+		expect(parsed.status).toBe('archived');
+
+		const entries = await readKnowledge<HiveKnowledgeEntry>(hivePath);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].status).toBe('archived');
+
+		const tomb = (await readKnowledgeEvents(dir)).filter(
+			(e): e is ArchivedEvent => e.type === 'archived',
+		);
+		expect(tomb).toHaveLength(1);
+		expect(tomb[0].tier).toBe('hive');
+		expect(tomb[0].entry_id).toBe('h1');
+	});
+
+	it('quarantines a hive entry when mode=quarantine, tier=hive', async () => {
+		const raw = await knowledge_archive.execute(
+			{ id: 'h1', reason: 'suspect', mode: 'quarantine', tier: 'hive', evidence: 'flaky' },
+			ctx(dir),
+		);
+		const parsed = JSON.parse(raw);
+		expect(parsed.success).toBe(true);
+		expect(parsed.status).toBe('quarantined');
+		expect(parsed.tier).toBe('hive');
+
+		const entries = await readKnowledge<HiveKnowledgeEntry>(hivePath);
+		expect(entries[0].status).toBe('quarantined');
+
+		const tomb = (await readKnowledgeEvents(dir)).filter(
+			(e): e is ArchivedEvent => e.type === 'archived',
+		);
+		expect(tomb[0].evidence).toBe('flaky');
+		expect(tomb[0].tier).toBe('hive');
+	});
+
+	it('purges a hive entry with allow_purge:true, tier=hive', async () => {
+		const raw = await knowledge_archive.execute(
+			{ id: 'h1', reason: 'gone', mode: 'purge', allow_purge: true, tier: 'hive' },
+			ctx(dir),
+		);
+		const parsed = JSON.parse(raw);
+		expect(parsed.success).toBe(true);
+		expect(parsed.status).toBe('purged');
+		expect(parsed.tier).toBe('hive');
+
+		const entries = await readKnowledge<HiveKnowledgeEntry>(hivePath);
+		expect(entries).toHaveLength(0);
+
+		const tomb = (await readKnowledgeEvents(dir)).filter(
+			(e): e is ArchivedEvent => e.type === 'archived',
+		);
+		expect(tomb).toHaveLength(1);
+		expect(tomb[0].mode).toBe('purge');
+		expect(tomb[0].tier).toBe('hive');
+	});
+
+	it('returns not found when tier=hive but id only exists in swarm', async () => {
+		// Put an entry in swarm only.
+		const swarmPath = resolveSwarmKnowledgePath(dir);
+		await appendKnowledge(swarmPath, makeEntry('s1'));
+
+		const raw = await knowledge_archive.execute(
+			{ id: 's1', reason: 'x', tier: 'hive' },
+			ctx(dir),
+		);
+		const parsed = JSON.parse(raw);
+		expect(parsed.success).toBe(false);
+		expect(parsed.message).toBe('entry not found');
+
+		// Swarm entry untouched.
+		const swarmEntries = await readKnowledge<SwarmKnowledgeEntry>(swarmPath);
+		expect(swarmEntries).toHaveLength(1);
+		expect(swarmEntries[0].status).toBe('candidate');
+	});
+
+	it('does not affect swarm store when archiving from hive', async () => {
+		// Also put an entry in swarm with a different id.
+		const swarmPath = resolveSwarmKnowledgePath(dir);
+		await appendKnowledge(swarmPath, makeEntry('s1'));
+
+		await knowledge_archive.execute(
+			{ id: 'h1', reason: 'hive only', tier: 'hive' },
+			ctx(dir),
+		);
+
+		const swarmEntries = await readKnowledge<SwarmKnowledgeEntry>(swarmPath);
+		expect(swarmEntries).toHaveLength(1);
+		expect(swarmEntries[0].status).toBe('candidate');
 	});
 });


### PR DESCRIPTION
Closes #1296

## Summary
- Add optional `tier: "swarm" | "hive"` parameter (default `"swarm"`) to the `knowledge_archive` tool. When `tier="hive"`, the tool resolves `resolveHiveKnowledgePath()` instead of `resolveSwarmKnowledgePath()`, performing the same archive/quarantine/purge status transition with an audit tombstone that records the tier.
- This allows agents to archive bad cross-project lessons without manual JSONL file edits, which was the only workaround described in the issue.
- Changes: `src/hooks/knowledge-events.ts` (tier field on ArchivedEvent), `src/tools/knowledge-archive.ts` (tier branching + response), `docs/knowledge.md` (archival tool docs).
- 6 new unit tests covering hive archive/quarantine/purge/isolation scenarios.

## Invariant audit
- 1 (plugin init): not touched - no plugin registration or startup paths changed
- 2 (runtime portability): not touched - no top-level imports or bundle shape changes
- 3 (subprocesses): not touched - no spawn calls modified
- 4 (.swarm containment): not touched - tool already resolves paths via ctx.directory
- 5 (plan durability): not touched - no plan/ledger changes
- 6 (test_runner safety): not touched - no test_runner tool changes
- 7 (test writing): touched - new unit tests follow existing test patterns in `tests/unit/tools/knowledge-archive.test.ts`
- 8 (session state): not touched - no session state changes
- 9 (guardrails/retry): not touched - no retry/guardrail logic changed
- 10 (chat/system msg): not touched - no prompt or message changes
- 11 (tool registration): touched - `knowledge_archive` tool schema extended with optional `tier` param, backward-compatible (default "swarm")
- 12 (release/cache): not touched - no cache or release changes

## Test plan
- [x] New unit tests: `bun --smol test tests/unit/tools/knowledge-archive.test.ts --timeout 30000` — 6 new tests covering hive-tier archive, quarantine, purge, and isolation
- [ ] CI validation: typecheck, biome, unit/integration/smoke suites will run on PR
- [ ] Manual verification: invoke `knowledge_archive` with `tier: "hive"` and confirm hive knowledge path is resolved and archived


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional tier to the `knowledge_archive` tool so agents can archive, quarantine, or purge hive (cross-project) knowledge entries without manual file edits. The tool records and returns the targeted tier for better auditing.

- **New Features**
  - Add `tier: 'swarm' | 'hive'` (default `'swarm'`) to `knowledge_archive`.
  - Use `resolveHiveKnowledgePath()` when `tier: 'hive'`; otherwise use `resolveSwarmKnowledgePath()`.
  - Extend `ArchivedEvent` with `tier`; include `tier` in the tool’s JSON response.
  - Support `archive`, `quarantine`, and `purge` (requires `allow_purge: true`).
  - Update docs (`docs/knowledge.md`) and add 6 unit tests for hive scenarios.

<sup>Written for commit af19956065fd7a2bd0047eecdaa4c3bdb70c6af6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

