### PR TITLE
feat(learning): WP6 + WP7 — near-dup escalation, verdict feedback, justification, post-mortem (#1234)

### DIFF
--- a/docs/releases/pending/1234-wp6-smaller-validated-items.md
+++ b/docs/releases/pending/1234-wp6-smaller-validated-items.md
@@ -1,0 +1,13 @@
+# Issue #1234 WP6: Smaller validated items (A–C)
+
+## Near-duplicate co-escalation (WP6-A)
+
+`maybeEscalateOnViolation()` now co-counts violations on semantically near-duplicate entries (Jaccard bigram similarity >= 0.6) so equivalent lessons under different IDs accumulate toward the 2-in-30-days escalation threshold. The near-duplicate lookup is fail-open — if the knowledge store is unreadable, escalation falls back to exact-entry counting only.
+
+## Knowledge verdict feedback → confidence (WP6-B)
+
+New `applyKnowledgeVerdictFeedback()` bridges knowledge receipt events (applied/violated/ignored) to `entry.confidence` via the existing `bumpKnowledgeConfidenceBatch` mechanism. Runs at phase_complete alongside the skill-usage feedback bridge. Net-positive entries get +0.03 boost; net-negative entries get -0.05 decay, clamped to [0.1, 1.0].
+
+## Override justification minimum substance (WP6-C)
+
+`accept_violations_justification` now requires at least 10 characters of substantive reasoning (previously accepted any non-empty string after trim). Single-character or trivially short overrides are rejected.

--- a/docs/releases/pending/1234-wp7-curator-postmortem.md
+++ b/docs/releases/pending/1234-wp7-curator-postmortem.md
@@ -1,0 +1,36 @@
+# Issue #1234 WP7: Post-mortem agent (`curator_postmortem`)
+
+## Overview
+
+New `curator_postmortem` agent completes the curator cadence: `curator_init` (session start) -> `curator_phase` (phase end) -> `curator_postmortem` (project end). Read-only, optional, model-overridable — same roster pattern as the other curators.
+
+## Agent registration
+
+- `CuratorRole` type extended: `'curator_init' | 'curator_phase' | 'curator_postmortem'`
+- `ROLE_CONFIG` entry with baked-in `CURATOR_POSTMORTEM_PROMPT`
+- Registered in `ALL_SUBAGENT_NAMES`, tool map (`swarm_memory_recall`), default model (`gpt-5-nano`), fallback model, and agent factory
+- Gated by `curator.postmortem_enabled` (default: true)
+
+## Core logic (`src/hooks/curator-postmortem.ts`)
+
+`runCuratorPostMortem(directory, options)` reads structured `.swarm/` evidence and produces `.swarm/post-mortem-{planId}.md`:
+
+- **Knowledge metrics**: total entries, application/violation/ignored counts, never-applied entries, high-violation entries
+- **Queue status**: pending proposals (insight-candidates, skill proposals) and unactionable quarantine counts
+- **Retrospectives**: phase retrospective evidence summaries
+- **Drift reports**: alignment status per phase
+- **Curator digest**: running digest from curator_phase
+- **LLM delegate**: optional — when available, sends assembled context to the `CURATOR_POSTMORTEM_PROMPT` for richer synthesis; falls back to data-only report on failure
+
+## Triggers
+
+1. **Automatic at project end**: `phase_complete` detects all phases complete and auto-fires
+2. **`/swarm finalize` step**: runs during finalize after curation, before archive
+3. **On demand**: `/swarm post-mortem [--scope session|project] [--force]`
+
+## Idempotency and safety
+
+- Dedup-protected: if report exists for the same plan ID, skips (unless `--force`)
+- Fail-open: errors never block `phase_complete` or `finalize`
+- Outputs route through existing gated paths only (no new ungated injection)
+- Config-gated: `curator.postmortem_enabled: false` disables all behavior

--- a/docs/releases/pending/1234-wp7-curator-postmortem.md
+++ b/docs/releases/pending/1234-wp7-curator-postmortem.md
@@ -26,7 +26,7 @@ New `curator_postmortem` agent completes the curator cadence: `curator_init` (se
 
 1. **Automatic at project end**: `phase_complete` detects all phases complete and auto-fires
 2. **`/swarm finalize` step**: runs during finalize after curation, before archive
-3. **On demand**: `/swarm post-mortem [--scope session|project] [--force]`
+3. **On demand**: `/swarm post-mortem [--force]`
 
 ## Idempotency and safety
 

--- a/src/agents/curator-agent.ts
+++ b/src/agents/curator-agent.ts
@@ -1,7 +1,14 @@
 import type { AgentDefinition } from './architect';
-import { CURATOR_INIT_PROMPT, CURATOR_PHASE_PROMPT } from './explorer.js';
+import {
+	CURATOR_INIT_PROMPT,
+	CURATOR_PHASE_PROMPT,
+	CURATOR_POSTMORTEM_PROMPT,
+} from './explorer.js';
 
-export type CuratorRole = 'curator_init' | 'curator_phase';
+export type CuratorRole =
+	| 'curator_init'
+	| 'curator_phase'
+	| 'curator_postmortem';
 
 const ROLE_CONFIG: Record<
 	CuratorRole,
@@ -18,6 +25,12 @@ const ROLE_CONFIG: Record<
 		description:
 			'Curator (Phase). Consolidates completed phase outcomes, detects workflow deviations, and recommends knowledge updates at phase boundaries. Read-only.',
 		prompt: CURATOR_PHASE_PROMPT,
+	},
+	curator_postmortem: {
+		name: 'curator_postmortem',
+		description:
+			'Curator (Post-mortem). Synthesizes project-end evidence into an improvement agenda, consolidates knowledge, and triages pending proposals. Read-only.',
+		prompt: CURATOR_POSTMORTEM_PROMPT,
 	},
 };
 

--- a/src/agents/explorer.ts
+++ b/src/agents/explorer.ts
@@ -260,6 +260,61 @@ Example output:
 {"applies_to_agents":["coder"],"forbidden_actions":["use async iterators in hot paths"],"required_actions":["use a plain for loop in hot paths"],"triggers":["hot path","async iterator"],"directive_priority":"high"}
 `;
 
+export const CURATOR_POSTMORTEM_PROMPT = `## IDENTITY
+You are Explorer in CURATOR_POSTMORTEM mode. You synthesize a project-end post-mortem from structured .swarm/ evidence.
+DO NOT use the Task tool to delegate. You ARE the agent that does the work.
+DO NOT scan raw source code — work only from the recorded evidence provided below.
+
+INPUT FORMAT:
+TASK: CURATOR_POSTMORTEM [plan_id]
+PLAN_SUMMARY: [plan phases, task counts, completion status]
+CURATOR_DIGESTS: [running digest from curator_phase across all phases]
+KNOWLEDGE_ENTRIES: [JSON array of existing entries with UUIDs]
+KNOWLEDGE_EVENTS_SUMMARY: [aggregated violation/applied/ignored counts per entry]
+PENDING_PROPOSALS: [skill/motif proposals awaiting triage]
+UNACTIONABLE_QUARANTINE: [entries flagged unactionable with retry status]
+EVIDENCE_SUMMARY: [key evidence bundle filenames and their phase associations]
+RETROSPECTIVES: [any session retrospectives found]
+
+ACTIONS:
+1. IMPROVEMENT AGENDA: Rank process + code improvement opportunities, each citing recorded evidence (task IDs, event records, evidence bundles). Focus on what would most reduce mistakes or increase reuse in the next project.
+2. FINAL CURATION PASS: Consolidate knowledge across phases — identify near-duplicate lessons that accumulated under different IDs, recommend hive promotion for project-proven entries (high confidence, multiple phases confirmed), flag never-applied entries past 3+ phases for review.
+3. QUEUE TRIAGE: For each pending proposal, recommend apply/reject with one-line reasoning. Surface unactionable-quarantine counts and retry candidates.
+4. LEARNING METRICS SUMMARY: Embed violation-rate trend, application rates, escalation frequency if metrics data is provided.
+
+RULES:
+- Output under 4000 chars
+- No code modifications — read-only synthesis
+- Every improvement item must cite a specific evidence artifact or event record
+- Do not invent evidence — if an artifact is missing, note the gap
+- Proposals route through existing gated paths (knowledge_add, skill proposals, hive promotion) — recommend the path, do not bypass it
+- HIGH-severity items that should become critical directives must be flagged for critic gate validation
+
+OUTPUT FORMAT:
+POST_MORTEM_REPORT:
+plan_id: [plan identifier]
+generated_at: [ISO timestamp]
+
+IMPROVEMENT_AGENDA:
+1. [priority] [description] — evidence: [artifact/event ref]
+2. ...
+
+CURATION_RECOMMENDATIONS:
+- merge: [entry_a UUID] + [entry_b UUID] — [reason]
+- promote_to_hive: [entry UUID] — [evidence of cross-phase confirmation]
+- flag_stale: [entry UUID] — [never applied in N phases]
+- rewrite: [entry UUID] — [what's verbose/outdated]
+
+QUEUE_TRIAGE:
+- [proposal_id]: APPLY|REJECT — [one-line reasoning]
+
+LEARNING_METRICS:
+[3-line summary of trends if data available, or "metrics data not provided"]
+
+SUMMARY:
+[3-line executive summary for architect briefing]
+`;
+
 export function createExplorerAgent(
 	model: string,
 	customPrompt?: string,

--- a/src/agents/explorer.ts
+++ b/src/agents/explorer.ts
@@ -273,7 +273,7 @@ KNOWLEDGE_ENTRIES: [JSON array of existing entries with UUIDs]
 KNOWLEDGE_EVENTS_SUMMARY: [aggregated violation/applied/ignored counts per entry]
 PENDING_PROPOSALS: [skill/motif proposals awaiting triage]
 UNACTIONABLE_QUARANTINE: [entries flagged unactionable with retry status]
-EVIDENCE_SUMMARY: [key evidence bundle filenames and their phase associations]
+DRIFT_REPORTS: [per-phase alignment/drift scores if available]
 RETROSPECTIVES: [any session retrospectives found]
 
 ACTIONS:

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -173,7 +173,9 @@ export function resolveFallbackModel(
 	// Only inherit if the curator agent does NOT have fallback_models key at all
 	if (
 		fallbackModels === undefined &&
-		(agentBaseName === 'curator_init' || agentBaseName === 'curator_phase')
+		(agentBaseName === 'curator_init' ||
+			agentBaseName === 'curator_phase' ||
+			agentBaseName === 'curator_postmortem')
 	) {
 		fallbackModels = swarmAgents?.explorer?.fallback_models;
 	}
@@ -605,6 +607,21 @@ If you call @coder instead of @${swarmId}_coder, the call will FAIL or go to the
 		);
 		curatorPhase.name = prefixName('curator_phase');
 		agents.push(applyOverrides(curatorPhase, swarmAgents, swarmPrefix, quiet));
+	}
+
+	// 5e. Create Curator Post-mortem agent
+	if (!isAgentDisabled('curator_postmortem', swarmAgents, swarmPrefix)) {
+		const curatorPostmortemPrompts = getPrompts('curator_postmortem');
+		const curatorPostmortem = createCuratorAgent(
+			swarmAgents?.curator_postmortem?.model ?? getModel('explorer'),
+			curatorPostmortemPrompts.prompt,
+			curatorPostmortemPrompts.appendPrompt,
+			'curator_postmortem' as CuratorRole,
+		);
+		curatorPostmortem.name = prefixName('curator_postmortem');
+		agents.push(
+			applyOverrides(curatorPostmortem, swarmAgents, swarmPrefix, quiet),
+		);
 	}
 
 	// 5f. v2: skill_improver — issue #629. Registered when enabled in config.

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -728,7 +728,7 @@ export async function handleCloseCommand(
 			const pmResult = await runCuratorPostMortem(directory, {
 				llmDelegate: createCuratorLLMDelegate(
 					directory,
-					'phase',
+					'postmortem',
 					options.sessionID,
 				),
 			});

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -713,6 +713,36 @@ export async function handleCloseCommand(
 		}
 	}
 
+	// ─── POST-MORTEM (WP7, #1234) ──────────────────────────────────
+	// Run the post-mortem agent as part of finalize. Idempotent: if
+	// phase_complete already produced a report, this is a no-op.
+	let postMortemSummary = '';
+	try {
+		const { CuratorConfigSchema: CCS } = await import('../config/schema.js');
+		const { config: pmLoadedConfig } = loadPluginConfigWithMeta(directory);
+		const curatorCfg = CCS.parse(pmLoadedConfig.curator ?? {});
+		if (curatorCfg.enabled && curatorCfg.postmortem_enabled) {
+			const { runCuratorPostMortem } = await import(
+				'../hooks/curator-postmortem.js'
+			);
+			const pmResult = await runCuratorPostMortem(directory, {
+				llmDelegate: createCuratorLLMDelegate(
+					directory,
+					'phase',
+					options.sessionID,
+				),
+			});
+			if (pmResult.success && pmResult.summary) {
+				postMortemSummary = pmResult.summary;
+			}
+			for (const w of pmResult.warnings) {
+				warnings.push(`[POST-MORTEM] ${w}`);
+			}
+		}
+	} catch {
+		// fail-open: post-mortem never blocks finalize
+	}
+
 	// ─── STAGE 2: ARCHIVE ────────────────────────────────────────────
 	const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 	const suffix = Math.random().toString(36).slice(2, 8);
@@ -1103,11 +1133,14 @@ export async function handleCloseCommand(
 	const skillReviewOutput = skillReviewSummary
 		? `\n\n**Skill Review:** ${skillReviewSummary}`
 		: '';
+	const postMortemOutput = postMortemSummary
+		? `\n\n**Post-Mortem:** ${postMortemSummary}`
+		: '';
 
 	if (planAlreadyDone) {
-		return `✅ Session finalized. Plan was already in a terminal state — cleanup and archive applied.\n\n**Archive:** ${archiveResult}\n**Git:** ${gitAlignResult}${lessonSummary}${knowledgeHintSummary}${skillReviewOutput}${warningMsg}`;
+		return `✅ Session finalized. Plan was already in a terminal state — cleanup and archive applied.\n\n**Archive:** ${archiveResult}\n**Git:** ${gitAlignResult}${lessonSummary}${knowledgeHintSummary}${skillReviewOutput}${postMortemOutput}${warningMsg}`;
 	}
-	return `✅ Swarm finalized. ${closedPhases.length} phase(s) closed, ${closedTasks.length} incomplete task(s) marked closed.\n\n**Archive:** ${archiveResult}\n**Git:** ${gitAlignResult}${lessonSummary}${knowledgeHintSummary}${skillReviewOutput}${warningMsg}`;
+	return `✅ Swarm finalized. ${closedPhases.length} phase(s) closed, ${closedTasks.length} incomplete task(s) marked closed.\n\n**Archive:** ${archiveResult}\n**Git:** ${gitAlignResult}${lessonSummary}${knowledgeHintSummary}${skillReviewOutput}${postMortemOutput}${warningMsg}`;
 }
 
 export const _internals = {

--- a/src/commands/post-mortem.ts
+++ b/src/commands/post-mortem.ts
@@ -20,7 +20,7 @@ export async function handlePostMortemCommand(
 			try {
 				pmOptions.llmDelegate = createCuratorLLMDelegate(
 					directory,
-					'phase',
+					'postmortem',
 					options.sessionID,
 				);
 			} catch {

--- a/src/commands/post-mortem.ts
+++ b/src/commands/post-mortem.ts
@@ -1,0 +1,64 @@
+import { createCuratorLLMDelegate } from '../hooks/curator-llm-factory.js';
+import {
+	type PostMortemOptions,
+	runCuratorPostMortem,
+} from '../hooks/curator-postmortem.js';
+
+export async function handlePostMortemCommand(
+	directory: string,
+	args: string[],
+	options?: { sessionID?: string },
+): Promise<string> {
+	try {
+		const force = args.includes('--force');
+
+		const pmOptions: PostMortemOptions = {
+			force,
+		};
+
+		if (options?.sessionID) {
+			try {
+				pmOptions.llmDelegate = createCuratorLLMDelegate(
+					directory,
+					'phase',
+					options.sessionID,
+				);
+			} catch {
+				// LLM delegate unavailable — data-only report
+			}
+		}
+
+		const result = await runCuratorPostMortem(directory, pmOptions);
+
+		const lines: string[] = [];
+
+		if (result.success) {
+			lines.push('## Post-Mortem Report Generated');
+			lines.push('');
+			if (result.reportPath) {
+				lines.push(`Report: \`${result.reportPath}\``);
+			}
+			if (result.summary) {
+				lines.push('');
+				lines.push(result.summary);
+			}
+		} else {
+			lines.push('## Post-Mortem Failed');
+			lines.push('');
+			lines.push('The post-mortem report could not be generated.');
+		}
+
+		if (result.warnings.length > 0) {
+			lines.push('');
+			lines.push('### Warnings');
+			for (const w of result.warnings) {
+				lines.push(`- ${w}`);
+			}
+		}
+
+		return lines.join('\n');
+	} catch (err: unknown) {
+		const message = err instanceof Error ? err.message : String(err);
+		return `Error running post-mortem: ${message}. Run /swarm diagnose to check .swarm/ health.`;
+	}
+}

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -51,6 +51,7 @@ import {
 	handleMemoryStatusCommand,
 } from './memory.js';
 import { handlePlanCommand } from './plan.js';
+import { handlePostMortemCommand } from './post-mortem.js';
 import { handlePrFeedbackCommand } from './pr-feedback.js';
 import { handlePrMonitorStatusCommand } from './pr-monitor-status.js';
 import { handlePrReviewCommand } from './pr-review.js';
@@ -534,6 +535,18 @@ export const COMMAND_REGISTRY = {
 		category: 'core',
 		aliasOf: 'finalize',
 		deprecated: true,
+	},
+	'post-mortem': {
+		handler: (ctx) =>
+			handlePostMortemCommand(ctx.directory, ctx.args, {
+				sessionID: ctx.sessionID,
+			}),
+		description:
+			'Run the post-mortem agent: project-end synthesis, queue triage, and final curation pass',
+		details:
+			'Reads .swarm/ evidence (knowledge entries, events, curator digests, proposals, retrospectives, drift reports) and produces a post-mortem report at .swarm/post-mortem-{planId}.md. Idempotent: re-runs skip if report exists unless --force is passed.',
+		args: '--force',
+		category: 'core',
 	},
 	concurrency: {
 		handler: (ctx) =>

--- a/src/config/agent-names.ts
+++ b/src/config/agent-names.ts
@@ -27,6 +27,7 @@ export const ALL_SUBAGENT_NAMES = [
 	'critic_architecture_supervisor',
 	'curator_init',
 	'curator_phase',
+	'curator_postmortem',
 	'council_generalist',
 	'council_skeptic',
 	'council_domain_expert',

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -219,6 +219,7 @@ export const MEMORY_AGENT_TOOL_MAP: Partial<Record<AgentName, ToolName[]>> = {
 	designer: ['swarm_memory_recall', 'swarm_memory_propose'],
 	curator_init: ['swarm_memory_recall'],
 	curator_phase: ['swarm_memory_recall'],
+	curator_postmortem: ['swarm_memory_recall'],
 	skill_improver: ['swarm_memory_recall', 'swarm_memory_propose'],
 	spec_writer: ['swarm_memory_recall', 'swarm_memory_propose'],
 };
@@ -296,6 +297,7 @@ export const DEFAULT_MODELS: Record<string, string> = {
 	// Curator agents — lightweight read-only analysis (same model family as explorer)
 	curator_init: 'opencode/gpt-5-nano',
 	curator_phase: 'opencode/gpt-5-nano',
+	curator_postmortem: 'opencode/gpt-5-nano',
 
 	// v2: Skill improver — defaults to a strong reasoning model, but is gated
 	// behind skill_improver.enabled and a daily quota (issue #629).
@@ -378,6 +380,10 @@ export const DEFAULT_AGENT_CONFIGS: Record<
 		fallback_models: ['opencode/big-pickle'],
 	},
 	curator_phase: {
+		model: 'opencode/gpt-5-nano',
+		fallback_models: ['opencode/big-pickle'],
+	},
+	curator_postmortem: {
 		model: 'opencode/gpt-5-nano',
 		fallback_models: ['opencode/big-pickle'],
 	},

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1139,6 +1139,8 @@ export const CuratorConfigSchema = z.object({
 	init_enabled: z.boolean().default(true),
 	/** Run CURATOR_PHASE at phase boundaries. Default: true (when curator enabled) */
 	phase_enabled: z.boolean().default(true),
+	/** Run CURATOR_POSTMORTEM at project end / finalize. Default: true (when curator enabled) */
+	postmortem_enabled: z.boolean().default(true),
 	/** Maximum tokens for curator summary. Default: 2000 */
 	max_summary_tokens: z.number().min(500).max(8000).default(2000),
 	/** Minimum confidence for knowledge entries to include in curator context. Default: 0.7 */

--- a/src/hooks/curator-llm-factory.ts
+++ b/src/hooks/curator-llm-factory.ts
@@ -21,14 +21,21 @@ import type { CuratorLLMDelegate } from './curator.js';
  * when both are registered (prefix-collision avoidance).
  */
 function resolveCuratorAgentName(
-	mode: 'init' | 'phase',
+	mode: 'init' | 'phase' | 'postmortem',
 	sessionId?: string,
 ): string {
-	const suffix = mode === 'init' ? 'curator_init' : 'curator_phase';
-	const registeredNames =
-		mode === 'init'
-			? swarmState.curatorInitAgentNames
-			: swarmState.curatorPhaseAgentNames;
+	const suffixMap = {
+		init: 'curator_init',
+		phase: 'curator_phase',
+		postmortem: 'curator_postmortem',
+	} as const;
+	const suffix = suffixMap[mode];
+	const registeredNamesMap = {
+		init: swarmState.curatorInitAgentNames,
+		phase: swarmState.curatorPhaseAgentNames,
+		postmortem: swarmState.curatorPostmortemAgentNames,
+	} as const;
+	const registeredNames = registeredNamesMap[mode];
 
 	// Fast path: only one registered (single-swarm or default-only)
 	if (registeredNames.length === 1) return registeredNames[0];
@@ -97,8 +104,9 @@ function resolveCuratorAgentName(
  * re-entrancy with the current session's message flow.
  *
  * The `mode` parameter determines which registered named agent is used:
- *   - 'init'  → curator_init  (e.g. 'curator_init' or 'swarm1_curator_init')
- *   - 'phase' → curator_phase (e.g. 'curator_phase' or 'swarm1_curator_phase')
+ *   - 'init'       → curator_init       (e.g. 'curator_init' or 'swarm1_curator_init')
+ *   - 'phase'      → curator_phase      (e.g. 'curator_phase' or 'swarm1_curator_phase')
+ *   - 'postmortem' → curator_postmortem  (e.g. 'curator_postmortem' or 'swarm1_curator_postmortem')
  *
  * The optional `sessionId` parameter enables deterministic swarm resolution:
  * when provided, the factory uses the calling session's registered agent to
@@ -109,7 +117,7 @@ function resolveCuratorAgentName(
  */
 export function createCuratorLLMDelegate(
 	directory: string,
-	mode: 'init' | 'phase' = 'init',
+	mode: 'init' | 'phase' | 'postmortem' = 'init',
 	sessionId?: string,
 ): CuratorLLMDelegate | undefined {
 	const client = swarmState.opencodeClient;

--- a/src/hooks/curator-postmortem.ts
+++ b/src/hooks/curator-postmortem.ts
@@ -101,10 +101,16 @@ function readJsonlFile(filePath: string): unknown[] {
 	try {
 		if (!existsSync(filePath)) return [];
 		const content = readFileSync(filePath, 'utf-8');
-		return content
-			.split('\n')
-			.filter((l) => l.trim())
-			.map((l) => JSON.parse(l));
+		const results: unknown[] = [];
+		for (const line of content.split('\n')) {
+			if (!line.trim()) continue;
+			try {
+				results.push(JSON.parse(line));
+			} catch {
+				// skip corrupted line, continue with remaining lines
+			}
+		}
+		return results;
 	} catch {
 		return [];
 	}

--- a/src/hooks/curator-postmortem.ts
+++ b/src/hooks/curator-postmortem.ts
@@ -1,0 +1,563 @@
+/**
+ * Curator post-mortem — project-end synthesis agent (WP7, issue #1234).
+ *
+ * Reads structured .swarm/ evidence (knowledge entries, events, curator digests,
+ * pending proposals, retrospectives, drift reports) and produces a post-mortem
+ * report with: improvement agenda, final curation pass, queue triage, and
+ * learning metrics summary.
+ *
+ * Triggers: phase_complete plan completion, /swarm finalize, /swarm post-mortem.
+ * Fail-open: errors never block finalize or phase completion.
+ * Outputs route through existing gated paths (knowledge_add, skill proposals,
+ * hive promotion) — no new ungated injection source.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { loadPlanJsonOnly } from '../plan/manager.js';
+import { derivePlanId } from '../plan/utils.js';
+import type { CuratorLLMDelegate } from './curator.js';
+import { readKnowledgeEvents } from './knowledge-events.js';
+import { readKnowledge, resolveSwarmKnowledgePath } from './knowledge-store.js';
+import type { KnowledgeEntryBase } from './knowledge-types.js';
+import { readSwarmFileAsync, validateSwarmPath } from './utils.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface PostMortemResult {
+	success: boolean;
+	planId: string | null;
+	reportPath: string | null;
+	summary: string | null;
+	warnings: string[];
+}
+
+export interface PostMortemOptions {
+	llmDelegate?: CuratorLLMDelegate;
+	force?: boolean;
+}
+
+interface KnowledgeEventSummary {
+	id: string;
+	lesson: string;
+	applied: number;
+	violated: number;
+	ignored: number;
+	confidence: number;
+	status: string;
+}
+
+// ============================================================================
+// Data collection helpers
+// ============================================================================
+
+async function collectKnowledgeSummary(
+	directory: string,
+): Promise<KnowledgeEventSummary[]> {
+	const entries = await readKnowledge<KnowledgeEntryBase>(
+		resolveSwarmKnowledgePath(directory),
+	);
+	const events = await readKnowledgeEvents(directory);
+
+	const countsMap = new Map<
+		string,
+		{ applied: number; violated: number; ignored: number }
+	>();
+	for (const e of events) {
+		if (e.type !== 'applied' && e.type !== 'violated' && e.type !== 'ignored')
+			continue;
+		const kid =
+			(e as { knowledge_id?: string }).knowledge_id ??
+			(e as { entry_id?: string }).entry_id;
+		if (!kid) continue;
+		const c = countsMap.get(kid) ?? { applied: 0, violated: 0, ignored: 0 };
+		if (e.type === 'applied') c.applied++;
+		else if (e.type === 'violated') c.violated++;
+		else if (e.type === 'ignored') c.ignored++;
+		countsMap.set(kid, c);
+	}
+
+	return entries.map((entry) => {
+		const c = countsMap.get(entry.id) ?? {
+			applied: 0,
+			violated: 0,
+			ignored: 0,
+		};
+		return {
+			id: entry.id,
+			lesson: entry.lesson,
+			applied: c.applied,
+			violated: c.violated,
+			ignored: c.ignored,
+			confidence: entry.confidence ?? 0.5,
+			status: entry.status ?? 'active',
+		};
+	});
+}
+
+function readJsonlFile(filePath: string): unknown[] {
+	try {
+		if (!existsSync(filePath)) return [];
+		const content = readFileSync(filePath, 'utf-8');
+		return content
+			.split('\n')
+			.filter((l) => l.trim())
+			.map((l) => JSON.parse(l));
+	} catch {
+		return [];
+	}
+}
+
+function collectRetrospectives(directory: string): string[] {
+	const results: string[] = [];
+	const evidenceDir = path.join(directory, '.swarm', 'evidence');
+	try {
+		if (!existsSync(evidenceDir)) return results;
+		for (const entry of readdirSync(evidenceDir, { withFileTypes: true })) {
+			if (entry.isDirectory() && entry.name.startsWith('retro-')) {
+				const retroPath = path.join(evidenceDir, entry.name, 'evidence.json');
+				if (existsSync(retroPath)) {
+					try {
+						results.push(readFileSync(retroPath, 'utf-8'));
+					} catch {
+						// skip unreadable
+					}
+				}
+			}
+		}
+	} catch {
+		// fail-open
+	}
+	return results;
+}
+
+function collectDriftReports(directory: string): string[] {
+	const results: string[] = [];
+	const swarmDir = path.join(directory, '.swarm');
+	try {
+		if (!existsSync(swarmDir)) return results;
+		for (const entry of readdirSync(swarmDir)) {
+			if (entry.startsWith('drift-report-phase-') && entry.endsWith('.json')) {
+				try {
+					results.push(readFileSync(path.join(swarmDir, entry), 'utf-8'));
+				} catch {
+					// skip
+				}
+			}
+		}
+	} catch {
+		// fail-open
+	}
+	return results;
+}
+
+function collectPendingProposals(
+	directory: string,
+): Array<{ source: string; content: string }> {
+	const results: Array<{ source: string; content: string }> = [];
+
+	const insightPath = path.join(
+		directory,
+		'.swarm',
+		'insight-candidates.jsonl',
+	);
+	if (existsSync(insightPath)) {
+		try {
+			results.push({
+				source: 'insight-candidates',
+				content: readFileSync(insightPath, 'utf-8'),
+			});
+		} catch {
+			// skip
+		}
+	}
+
+	const proposalsDir = path.join(directory, '.swarm', 'skills', 'proposals');
+	try {
+		if (existsSync(proposalsDir)) {
+			for (const entry of readdirSync(proposalsDir)) {
+				if (entry.endsWith('.md') || entry.endsWith('.json')) {
+					try {
+						results.push({
+							source: `proposals/${entry}`,
+							content: readFileSync(path.join(proposalsDir, entry), 'utf-8'),
+						});
+					} catch {
+						// skip
+					}
+				}
+			}
+		}
+	} catch {
+		// fail-open
+	}
+	return results;
+}
+
+// ============================================================================
+// Report generation
+// ============================================================================
+
+function buildDataOnlyReport(
+	planId: string,
+	planSummary: string,
+	knowledgeSummary: KnowledgeEventSummary[],
+	curatorDigest: string | null,
+	proposals: Array<{ source: string; content: string }>,
+	unactionable: unknown[],
+	retrospectives: string[],
+	driftReports: string[],
+): string {
+	const now = new Date().toISOString();
+	const lines: string[] = [];
+
+	lines.push(`# Post-Mortem Report: ${planId}`);
+	lines.push(`Generated: ${now}`);
+	lines.push('');
+
+	// Plan summary
+	lines.push('## Project Summary');
+	lines.push(planSummary);
+	lines.push('');
+
+	// Knowledge metrics
+	lines.push('## Knowledge Metrics');
+	const totalEntries = knowledgeSummary.length;
+	const totalApplied = knowledgeSummary.reduce((s, e) => s + e.applied, 0);
+	const totalViolated = knowledgeSummary.reduce((s, e) => s + e.violated, 0);
+	const totalIgnored = knowledgeSummary.reduce((s, e) => s + e.ignored, 0);
+	const neverApplied = knowledgeSummary.filter(
+		(e) => e.applied === 0 && e.violated === 0 && e.ignored === 0,
+	);
+
+	lines.push(`- Total entries: ${totalEntries}`);
+	lines.push(
+		`- Application events: ${totalApplied} applied, ${totalViolated} violated, ${totalIgnored} ignored`,
+	);
+	lines.push(`- Never-applied entries: ${neverApplied.length}`);
+	if (totalApplied + totalViolated > 0) {
+		const appRate = (
+			(totalApplied / (totalApplied + totalViolated)) *
+			100
+		).toFixed(1);
+		lines.push(`- Application rate: ${appRate}%`);
+	}
+	lines.push('');
+
+	// Stale entries
+	if (neverApplied.length > 0) {
+		lines.push('### Never-Applied Entries (review for retirement)');
+		for (const e of neverApplied.slice(0, 10)) {
+			lines.push(
+				`- \`${e.id}\` (confidence: ${e.confidence.toFixed(2)}): ${e.lesson.slice(0, 80)}`,
+			);
+		}
+		if (neverApplied.length > 10) {
+			lines.push(`- ... and ${neverApplied.length - 10} more`);
+		}
+		lines.push('');
+	}
+
+	// High-violation entries
+	const highViolation = knowledgeSummary
+		.filter((e) => e.violated > 0)
+		.sort((a, b) => b.violated - a.violated)
+		.slice(0, 5);
+	if (highViolation.length > 0) {
+		lines.push('### High-Violation Entries');
+		for (const e of highViolation) {
+			lines.push(
+				`- \`${e.id}\` — ${e.violated} violations, ${e.applied} applied: ${e.lesson.slice(0, 80)}`,
+			);
+		}
+		lines.push('');
+	}
+
+	// Queue status
+	lines.push('## Queue Status');
+	lines.push(`- Pending proposals: ${proposals.length}`);
+	lines.push(`- Unactionable quarantine: ${unactionable.length}`);
+	for (const p of proposals) {
+		lines.push(`  - ${p.source}`);
+	}
+	lines.push('');
+
+	// Retrospectives summary
+	if (retrospectives.length > 0) {
+		lines.push('## Retrospectives');
+		lines.push(`${retrospectives.length} phase retrospective(s) recorded.`);
+		lines.push('');
+	}
+
+	// Drift summary
+	if (driftReports.length > 0) {
+		lines.push('## Drift Reports');
+		for (const dr of driftReports) {
+			try {
+				const parsed = JSON.parse(dr);
+				lines.push(
+					`- Phase ${parsed.phase}: ${parsed.alignment} (score: ${parsed.drift_score})`,
+				);
+			} catch {
+				lines.push('- (unparseable drift report)');
+			}
+		}
+		lines.push('');
+	}
+
+	// Curator digest
+	if (curatorDigest) {
+		lines.push('## Curator Digest Summary');
+		const trimmed =
+			curatorDigest.length > 1000
+				? `${curatorDigest.slice(0, 1000)}...`
+				: curatorDigest;
+		lines.push(trimmed);
+		lines.push('');
+	}
+
+	return lines.join('\n');
+}
+
+function assembleLLMInput(
+	planId: string,
+	planSummary: string,
+	knowledgeSummary: KnowledgeEventSummary[],
+	curatorDigest: string | null,
+	proposals: Array<{ source: string; content: string }>,
+	unactionable: unknown[],
+	retrospectives: string[],
+	driftReports: string[],
+): string {
+	const sections: string[] = [];
+
+	sections.push(`TASK: CURATOR_POSTMORTEM ${planId}`);
+	sections.push(`PLAN_SUMMARY: ${planSummary}`);
+
+	sections.push(`CURATOR_DIGESTS: ${curatorDigest ?? 'none'}`);
+
+	const eventsSummary = knowledgeSummary
+		.map(
+			(e) =>
+				`${e.id}: applied=${e.applied} violated=${e.violated} ignored=${e.ignored} confidence=${e.confidence.toFixed(2)} status=${e.status}`,
+		)
+		.join('\n');
+	sections.push(`KNOWLEDGE_EVENTS_SUMMARY:\n${eventsSummary || 'none'}`);
+
+	const knEntries = knowledgeSummary
+		.map((e) => JSON.stringify({ id: e.id, lesson: e.lesson }))
+		.join('\n');
+	sections.push(`KNOWLEDGE_ENTRIES:\n${knEntries || '[]'}`);
+
+	const proposalText =
+		proposals.length > 0
+			? proposals
+					.map((p) => `[${p.source}]\n${p.content.slice(0, 500)}`)
+					.join('\n---\n')
+			: 'none';
+	sections.push(`PENDING_PROPOSALS:\n${proposalText}`);
+
+	sections.push(`UNACTIONABLE_QUARANTINE: ${unactionable.length} entries`);
+
+	const retroText =
+		retrospectives.length > 0
+			? retrospectives.map((r) => r.slice(0, 500)).join('\n---\n')
+			: 'none';
+	sections.push(`RETROSPECTIVES:\n${retroText}`);
+
+	if (driftReports.length > 0) {
+		const driftText = driftReports.map((r) => r.slice(0, 500)).join('\n---\n');
+		sections.push(`DRIFT_REPORTS:\n${driftText}`);
+	}
+
+	return sections.join('\n\n');
+}
+
+// ============================================================================
+// Main entry point
+// ============================================================================
+
+export async function runCuratorPostMortem(
+	directory: string,
+	options: PostMortemOptions = {},
+): Promise<PostMortemResult> {
+	const warnings: string[] = [];
+
+	// Load plan to derive the plan ID
+	let planId = 'unknown';
+	let planSummary = 'Plan data unavailable.';
+	try {
+		const plan = await loadPlanJsonOnly(directory);
+		if (plan) {
+			planId = derivePlanId(plan);
+			const phaseCount = plan.phases?.length ?? 0;
+			const completedPhases =
+				plan.phases?.filter(
+					(p: { status?: string }) => p.status === 'completed',
+				).length ?? 0;
+			planSummary = `Plan "${plan.title}" (${plan.swarm}): ${completedPhases}/${phaseCount} phases completed.`;
+		} else {
+			warnings.push('Plan not found — using fallback plan ID.');
+		}
+	} catch {
+		warnings.push('Failed to load plan data.');
+	}
+
+	// Check for existing report (dedup protection)
+	const reportFilename = `post-mortem-${planId}.md`;
+	let reportPath: string;
+	try {
+		reportPath = validateSwarmPath(directory, reportFilename);
+	} catch {
+		return {
+			success: false,
+			planId,
+			reportPath: null,
+			summary: null,
+			warnings: [...warnings, 'Invalid report path.'],
+		};
+	}
+
+	if (!options.force && existsSync(reportPath)) {
+		return {
+			success: true,
+			planId,
+			reportPath,
+			summary: 'Post-mortem report already exists (idempotent skip).',
+			warnings,
+		};
+	}
+
+	// Collect evidence
+	let knowledgeSummary: KnowledgeEventSummary[] = [];
+	try {
+		knowledgeSummary = await collectKnowledgeSummary(directory);
+	} catch {
+		warnings.push('Failed to collect knowledge summary.');
+	}
+
+	let curatorDigest: string | null = null;
+	try {
+		const raw = await readSwarmFileAsync(directory, 'curator-summary.json');
+		if (raw) {
+			const parsed = JSON.parse(raw);
+			curatorDigest = parsed.digest ?? null;
+		}
+	} catch {
+		warnings.push('Failed to read curator digest.');
+	}
+
+	const proposals = collectPendingProposals(directory);
+	const unactionablePath = path.join(
+		directory,
+		'.swarm',
+		'knowledge-unactionable.jsonl',
+	);
+	const unactionable = readJsonlFile(unactionablePath);
+	const retrospectives = collectRetrospectives(directory);
+	const driftReports = collectDriftReports(directory);
+
+	// Generate report
+	let reportContent: string;
+
+	if (options.llmDelegate) {
+		try {
+			const { CURATOR_POSTMORTEM_PROMPT } = await import(
+				'../agents/explorer.js'
+			);
+			const userInput = assembleLLMInput(
+				planId,
+				planSummary,
+				knowledgeSummary,
+				curatorDigest,
+				proposals,
+				unactionable,
+				retrospectives,
+				driftReports,
+			);
+			const llmOutput = await options.llmDelegate(
+				CURATOR_POSTMORTEM_PROMPT,
+				userInput,
+			);
+			reportContent = `# Post-Mortem Report: ${planId}\nGenerated: ${new Date().toISOString()}\n\n${llmOutput}`;
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			warnings.push(
+				`LLM delegate failed, falling back to data-only report: ${msg}`,
+			);
+			reportContent = buildDataOnlyReport(
+				planId,
+				planSummary,
+				knowledgeSummary,
+				curatorDigest,
+				proposals,
+				unactionable,
+				retrospectives,
+				driftReports,
+			);
+		}
+	} else {
+		reportContent = buildDataOnlyReport(
+			planId,
+			planSummary,
+			knowledgeSummary,
+			curatorDigest,
+			proposals,
+			unactionable,
+			retrospectives,
+			driftReports,
+		);
+	}
+
+	// Write report
+	try {
+		const { mkdirSync, writeFileSync } = await import('node:fs');
+		mkdirSync(path.dirname(reportPath), { recursive: true });
+		writeFileSync(reportPath, reportContent, 'utf-8');
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		return {
+			success: false,
+			planId,
+			reportPath: null,
+			summary: null,
+			warnings: [...warnings, `Failed to write report: ${msg}`],
+		};
+	}
+
+	// Build 3-line summary for briefing
+	const totalEntries = knowledgeSummary.length;
+	const neverAppliedCount = knowledgeSummary.filter(
+		(e) => e.applied === 0 && e.violated === 0 && e.ignored === 0,
+	).length;
+	const totalViolations = knowledgeSummary.reduce((s, e) => s + e.violated, 0);
+	const summary = [
+		`Post-mortem for plan "${planId}": ${totalEntries} knowledge entries reviewed.`,
+		`${neverAppliedCount} never-applied entries flagged; ${totalViolations} total violations recorded.`,
+		`${proposals.length} pending proposals, ${unactionable.length} quarantined entries.`,
+	].join(' ');
+
+	return {
+		success: true,
+		planId,
+		reportPath,
+		summary,
+		warnings,
+	};
+}
+
+// ============================================================================
+// DI Seam
+// ============================================================================
+
+export const _internals = {
+	collectKnowledgeSummary,
+	collectRetrospectives,
+	collectDriftReports,
+	collectPendingProposals,
+	readJsonlFile,
+	buildDataOnlyReport,
+	assembleLLMInput,
+};

--- a/src/hooks/curator-postmortem.ts
+++ b/src/hooks/curator-postmortem.ts
@@ -482,10 +482,29 @@ export async function runCuratorPostMortem(
 				retrospectives,
 				driftReports,
 			);
-			const llmOutput = await options.llmDelegate(
-				CURATOR_POSTMORTEM_PROMPT,
-				userInput,
-			);
+			const ac = new AbortController();
+			const timer = setTimeout(() => ac.abort(), 300_000);
+			let llmOutput: string;
+			try {
+				// Hoist to attach no-op catch before race — prevents unhandled
+				// rejection when timeout fires and the delegate later rejects.
+				const delegatePromise = options.llmDelegate(
+					CURATOR_POSTMORTEM_PROMPT,
+					userInput,
+					ac.signal,
+				);
+				void delegatePromise.catch(() => {});
+				llmOutput = await Promise.race([
+					delegatePromise,
+					new Promise<never>((_, reject) => {
+						ac.signal.addEventListener('abort', () =>
+							reject(new Error('CURATOR_LLM_TIMEOUT')),
+						);
+					}),
+				]);
+			} finally {
+				clearTimeout(timer);
+			}
 			reportContent = `# Post-Mortem Report: ${planId}\nGenerated: ${new Date().toISOString()}\n\n${llmOutput}`;
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);

--- a/src/hooks/curator-postmortem.ts
+++ b/src/hooks/curator-postmortem.ts
@@ -394,10 +394,9 @@ export async function runCuratorPostMortem(
 			planId = derivePlanId(plan);
 			const phaseCount = plan.phases?.length ?? 0;
 			const completedPhases =
-				plan.phases?.filter(
-					(p: { status?: string }) => p.status === 'completed',
-				).length ?? 0;
-			planSummary = `Plan "${plan.title}" (${plan.swarm}): ${completedPhases}/${phaseCount} phases completed.`;
+				plan.phases?.filter((p: { status?: string }) => p.status === 'complete')
+					.length ?? 0;
+			planSummary = `Plan "${plan.title}" (${plan.swarm}): ${completedPhases}/${phaseCount} phases complete.`;
 		} else {
 			warnings.push('Plan not found — using fallback plan ID.');
 		}

--- a/src/hooks/knowledge-escalator.ts
+++ b/src/hooks/knowledge-escalator.ts
@@ -19,15 +19,20 @@ import {
 	recordKnowledgeEvent,
 } from './knowledge-events.js';
 import {
+	jaccardBigram,
+	readKnowledge,
 	resolveHiveKnowledgePath,
 	resolveSwarmKnowledgePath,
 	transactKnowledge,
+	wordBigrams,
 } from './knowledge-store.js';
 import type {
 	DirectiveEscalationRecord,
 	DirectivePriority,
 	KnowledgeEntryBase,
 } from './knowledge-types.js';
+
+const NEAR_DUPLICATE_THRESHOLD = 0.6;
 
 export const ESCALATION_WINDOW_DAYS = 30;
 export const ESCALATION_THRESHOLD = 2;
@@ -63,12 +68,55 @@ export async function maybeEscalateOnViolation(
 	now: Date = new Date(),
 ): Promise<EscalationResult> {
 	try {
-		const count = await countEntryViolationsInWindow(
+		let count = await countEntryViolationsInWindow(
 			directory,
 			entryId,
 			ESCALATION_WINDOW_DAYS,
 			now,
 		);
+
+		// Co-count violations on semantically near-duplicate entries so
+		// equivalent lessons under different IDs accumulate toward escalation.
+		if (count < ESCALATION_THRESHOLD) {
+			try {
+				const allEntries: KnowledgeEntryBase[] = [];
+				allEntries.push(
+					...(await readKnowledge<KnowledgeEntryBase>(
+						resolveSwarmKnowledgePath(directory),
+					)),
+				);
+				const hivePath = resolveHiveKnowledgePath();
+				if (existsSync(hivePath)) {
+					allEntries.push(
+						...(await readKnowledge<KnowledgeEntryBase>(hivePath)),
+					);
+				}
+				const target = allEntries.find((e) => e.id === entryId);
+				if (target) {
+					const seen = new Set<string>([entryId]);
+					const targetBigrams = wordBigrams(target.lesson);
+					for (const e of allEntries) {
+						if (seen.has(e.id)) continue;
+						seen.add(e.id);
+						if (
+							jaccardBigram(targetBigrams, wordBigrams(e.lesson)) >=
+							NEAR_DUPLICATE_THRESHOLD
+						) {
+							count += await countEntryViolationsInWindow(
+								directory,
+								e.id,
+								ESCALATION_WINDOW_DAYS,
+								now,
+							);
+							if (count >= ESCALATION_THRESHOLD) break;
+						}
+					}
+				}
+			} catch {
+				// fail-open: near-dup co-counting is best-effort
+			}
+		}
+
 		if (count < ESCALATION_THRESHOLD) {
 			return { escalated: false, entryId, violationsInWindow: count };
 		}

--- a/src/hooks/knowledge-events.ts
+++ b/src/hooks/knowledge-events.ts
@@ -661,6 +661,96 @@ export function effectiveRetrievalOutcomes(
 }
 
 // ============================================================================
+// Feedback bridge — Knowledge verdict → confidence bumps
+// ============================================================================
+
+const VERDICT_CONFIDENCE_BOOST = 0.03;
+const VERDICT_CONFIDENCE_DECAY = 0.05;
+
+/**
+ * Read receipt events (applied/violated/ignored), aggregate per knowledge entry,
+ * and apply bounded confidence deltas via `bumpKnowledgeConfidenceBatch`.
+ *
+ * Complements `applySkillUsageFeedback` (skill-usage-log.ts) which bridges
+ * skill compliance → confidence. This function bridges raw knowledge verdict
+ * events → confidence, closing the loop where `entry.confidence` was static
+ * after creation regardless of how often the entry was applied or violated.
+ *
+ * Fail-open: errors are logged but never thrown.
+ */
+export async function applyKnowledgeVerdictFeedback(
+	directory: string,
+	options?: { sinceTimestamp?: string },
+): Promise<{ processed: number; bumps: number }> {
+	try {
+		const events = await readKnowledgeEvents(directory);
+
+		const actionable = events.filter((e): e is ReceiptEvent => {
+			if (
+				e.type !== 'applied' &&
+				e.type !== 'violated' &&
+				e.type !== 'ignored'
+			) {
+				return false;
+			}
+			if (
+				options?.sinceTimestamp &&
+				(e as ReceiptEvent).timestamp <= options.sinceTimestamp
+			) {
+				return false;
+			}
+			return true;
+		});
+
+		if (actionable.length === 0) {
+			return { processed: 0, bumps: 0 };
+		}
+
+		const groups = new Map<
+			string,
+			{ applied: number; violated: number; ignored: number }
+		>();
+		for (const event of actionable) {
+			const kid = event.knowledge_id;
+			if (!kid) continue;
+			const g = groups.get(kid) ?? { applied: 0, violated: 0, ignored: 0 };
+			if (event.type === 'applied') g.applied++;
+			else if (event.type === 'violated') g.violated++;
+			else if (event.type === 'ignored') g.ignored++;
+			groups.set(kid, g);
+		}
+
+		const deltas: Array<{ id: string; delta: number }> = [];
+		for (const [id, counts] of groups) {
+			const positives = counts.applied;
+			const negatives = counts.violated + counts.ignored;
+			if (positives === 0 && negatives === 0) continue;
+			const delta =
+				positives > negatives
+					? VERDICT_CONFIDENCE_BOOST
+					: -VERDICT_CONFIDENCE_DECAY;
+			deltas.push({ id, delta });
+		}
+
+		if (deltas.length > 0) {
+			const { bumpKnowledgeConfidenceBatch } = await import(
+				'./knowledge-store.js'
+			);
+			await bumpKnowledgeConfidenceBatch(directory, deltas);
+		}
+
+		return { processed: groups.size, bumps: deltas.length };
+	} catch (err) {
+		warn(
+			`[knowledge-events] applyKnowledgeVerdictFeedback failed (fail-open): ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		);
+		return { processed: 0, bumps: 0 };
+	}
+}
+
+// ============================================================================
 // DI seam
 // ============================================================================
 
@@ -673,6 +763,7 @@ export const _internals: {
 	readKnowledgeCounterRollups: typeof readKnowledgeCounterRollups;
 	effectiveRetrievalOutcomes: typeof effectiveRetrievalOutcomes;
 	recomputeCounters: typeof recomputeCounters;
+	applyKnowledgeVerdictFeedback: typeof applyKnowledgeVerdictFeedback;
 	newTraceId: typeof newTraceId;
 	newEventId: typeof newEventId;
 } = {
@@ -684,6 +775,7 @@ export const _internals: {
 	readKnowledgeCounterRollups,
 	effectiveRetrievalOutcomes,
 	recomputeCounters,
+	applyKnowledgeVerdictFeedback,
 	newTraceId,
 	newEventId,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -420,6 +420,9 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 	swarmState.curatorPhaseAgentNames = Object.keys(agents).filter(
 		(k) => k === 'curator_phase' || k.endsWith('_curator_phase'),
 	);
+	swarmState.curatorPostmortemAgentNames = Object.keys(agents).filter(
+		(k) => k === 'curator_postmortem' || k.endsWith('_curator_postmortem'),
+	);
 	// v2: skill_improver and spec_writer agent registries — same multi-swarm
 	// resolution pattern as curator. Used by skill-improver-llm-factory to
 	// pick the right prefixed agent under named swarms.

--- a/src/state.ts
+++ b/src/state.ts
@@ -431,6 +431,7 @@ export const swarmState = {
 	 * name at call time by matching the active session's agent prefix. */
 	curatorInitAgentNames: [] as string[],
 	curatorPhaseAgentNames: [] as string[],
+	curatorPostmortemAgentNames: [] as string[],
 
 	/** All registered skill_improver / spec_writer agent names across swarms,
 	 * mirroring curatorInitAgentNames so the LLM delegate factory can resolve
@@ -496,6 +497,7 @@ export function resetSwarmState(): void {
 	swarmState.opencodeClient = null;
 	swarmState.curatorInitAgentNames = [];
 	swarmState.curatorPhaseAgentNames = [];
+	swarmState.curatorPostmortemAgentNames = [];
 	swarmState.skillImproverAgentNames = [];
 	swarmState.specWriterAgentNames = [];
 	swarmState.currentCriticalShownIds.clear();
@@ -525,11 +527,11 @@ export function resetSwarmState(): void {
  * The preserved fields are:
  * - opencodeClient (SDK client for curator/full-auto delegation)
  * - fullAutoEnabledInConfig (config flag read at init)
- * - curatorInitAgentNames, curatorPhaseAgentNames (curator registry)
+ * - curatorInitAgentNames, curatorPhaseAgentNames, curatorPostmortemAgentNames (curator registry)
  * - skillImproverAgentNames, specWriterAgentNames (skill/spec registry)
  * - generatedAgentNames (full-auto delegation guard registry)
  *
- * Implementation: save all 7 to locals, call resetSwarmState(), restore all 7.
+ * Implementation: save all 8 to locals, call resetSwarmState(), restore all 8.
  * Synchronous (matches resetSwarmState contract). Errors from resetSwarmState
  * propagate to caller (no try/catch wrapper).
  */
@@ -538,6 +540,8 @@ export function resetSwarmStatePreservingSingletons(): void {
 	const preservedFullAutoEnabledInConfig = swarmState.fullAutoEnabledInConfig;
 	const preservedCuratorInitAgentNames = swarmState.curatorInitAgentNames;
 	const preservedCuratorPhaseAgentNames = swarmState.curatorPhaseAgentNames;
+	const preservedCuratorPostmortemAgentNames =
+		swarmState.curatorPostmortemAgentNames;
 	const preservedSkillImproverAgentNames = swarmState.skillImproverAgentNames;
 	const preservedSpecWriterAgentNames = swarmState.specWriterAgentNames;
 	const preservedGeneratedAgentNames = swarmState.generatedAgentNames;
@@ -548,6 +552,7 @@ export function resetSwarmStatePreservingSingletons(): void {
 	swarmState.fullAutoEnabledInConfig = preservedFullAutoEnabledInConfig;
 	swarmState.curatorInitAgentNames = preservedCuratorInitAgentNames;
 	swarmState.curatorPhaseAgentNames = preservedCuratorPhaseAgentNames;
+	swarmState.curatorPostmortemAgentNames = preservedCuratorPostmortemAgentNames;
 	swarmState.skillImproverAgentNames = preservedSkillImproverAgentNames;
 	swarmState.specWriterAgentNames = preservedSpecWriterAgentNames;
 	swarmState.generatedAgentNames = preservedGeneratedAgentNames;

--- a/src/state.ts
+++ b/src/state.ts
@@ -520,7 +520,7 @@ export function resetSwarmState(): void {
 }
 
 /**
- * Reset swarm state while preserving the 7 module-scoped singletons that are
+ * Reset swarm state while preserving the 8 module-scoped singletons that are
  * populated once at plugin init and must survive a /swarm close + re-init
  * within the same process lifetime.
  *

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -533,18 +533,18 @@ export async function executePhaseComplete(
 				warnings,
 			});
 		}
-		if (requestedAccept.length > 0 && justification.length === 0) {
+		if (requestedAccept.length > 0 && justification.length < 10) {
 			return blockedResult(phase, {
 				reason: 'override_requires_justification',
 				message:
-					'accept_violations requires accept_violations_justification (a written reason).',
+					'accept_violations requires accept_violations_justification (minimum 10 characters of substantive reasoning).',
 				agentsDispatched,
 				agentsMissing: [],
 				warnings,
 			});
 		}
 		const effectiveAccept =
-			requestedAccept.length > 0 && isArchitect && justification.length > 0
+			requestedAccept.length > 0 && isArchitect && justification.length >= 10
 				? requestedAccept
 				: [];
 		const directiveGate = await evaluatePhaseCriticalDirectives({
@@ -1117,6 +1117,58 @@ export async function executePhaseComplete(
 		);
 	}
 
+	// Knowledge verdict feedback: bridge applied/violated/ignored events → confidence.
+	try {
+		const verdictMarkerPath = validateSwarmPath(
+			dir,
+			'verdict-feedback-last-processed.json',
+		);
+		let verdictSinceTimestamp: string | undefined;
+		try {
+			const markerData = JSON.parse(
+				fs.readFileSync(verdictMarkerPath, 'utf-8'),
+			);
+			verdictSinceTimestamp = markerData.lastProcessedTimestamp;
+		} catch {
+			// marker doesn't exist yet — process all entries
+		}
+
+		const verdictMarkerTimestamp = new Date().toISOString();
+		const { applyKnowledgeVerdictFeedback } = await import(
+			'../hooks/knowledge-events.js'
+		);
+		const verdictResult = await applyKnowledgeVerdictFeedback(dir, {
+			sinceTimestamp: verdictSinceTimestamp,
+		});
+
+		try {
+			fs.writeFileSync(
+				verdictMarkerPath,
+				JSON.stringify({
+					lastProcessedTimestamp: verdictMarkerTimestamp,
+				}),
+				'utf-8',
+			);
+		} catch {
+			// best-effort marker write
+		}
+
+		if (verdictResult.bumps > 0) {
+			const sessionState = swarmState.agentSessions.get(sessionID);
+			if (sessionState) {
+				sessionState.pendingAdvisoryMessages ??= [];
+				sessionState.pendingAdvisoryMessages.push(
+					`[FEEDBACK] Knowledge verdict feedback: ${verdictResult.processed} entries processed, ${verdictResult.bumps} confidence updates applied.`,
+				);
+			}
+		}
+	} catch (verdictError) {
+		safeWarn(
+			'[phase_complete] Knowledge verdict feedback error (non-blocking):',
+			verdictError,
+		);
+	}
+
 	// Build the effective required-agents list.
 	// If the phase defines its own required_agents, use those instead of the global config.
 	// This allows non-code phases (acceptance, docs) to skip coder/reviewer/test_engineer requirements.
@@ -1537,6 +1589,38 @@ export async function executePhaseComplete(
 
 	// Write root-level checkpoint artifact (non-blocking)
 	await writeCheckpoint(dir).catch(() => {});
+
+	// Auto-fire post-mortem when all plan phases are now complete (WP7, #1234).
+	// Fail-open: post-mortem failures never affect phase_complete result.
+	try {
+		const curatorCfg = CuratorConfigSchema.parse(config.curator ?? {});
+		if (curatorCfg.enabled && curatorCfg.postmortem_enabled) {
+			const finalPlan = await loadPlan(dir);
+			if (finalPlan?.phases?.length) {
+				const allComplete = finalPlan.phases.every(
+					(p: { status?: string }) => p.status === 'complete',
+				);
+				if (allComplete) {
+					const { runCuratorPostMortem } = await import(
+						'../hooks/curator-postmortem.js'
+					);
+					const pmResult = await runCuratorPostMortem(dir, {
+						llmDelegate: createCuratorLLMDelegate(dir, 'phase', sessionID),
+					});
+					if (pmResult.success && pmResult.summary) {
+						warnings.push(`[POST-MORTEM] ${pmResult.summary}`);
+					}
+					if (pmResult.warnings.length > 0) {
+						for (const w of pmResult.warnings) {
+							warnings.push(`[POST-MORTEM] ${w}`);
+						}
+					}
+				}
+			}
+		}
+	} catch {
+		// fail-open: post-mortem never blocks phase completion
+	}
 
 	const outputData = {
 		...result,

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -1605,7 +1605,7 @@ export async function executePhaseComplete(
 						'../hooks/curator-postmortem.js'
 					);
 					const pmResult = await runCuratorPostMortem(dir, {
-						llmDelegate: createCuratorLLMDelegate(dir, 'phase', sessionID),
+						llmDelegate: createCuratorLLMDelegate(dir, 'postmortem', sessionID),
 					});
 					if (pmResult.success && pmResult.summary) {
 						warnings.push(`[POST-MORTEM] ${pmResult.summary}`);

--- a/tests/unit/hooks/curator-llm-factory.test.ts
+++ b/tests/unit/hooks/curator-llm-factory.test.ts
@@ -142,6 +142,31 @@ describe('createCuratorLLMDelegate', () => {
 		});
 	});
 
+	test('multi-swarm: postmortem mode picks correct swarm curator_postmortem', async () => {
+		(swarmState as { opencodeClient: unknown }).opencodeClient = mockClient;
+		(
+			swarmState as { curatorPostmortemAgentNames: string[] }
+		).curatorPostmortemAgentNames = [
+			'alpha_curator_postmortem',
+			'beta_curator_postmortem',
+		];
+		(swarmState as { activeAgent: Map<string, string> }).activeAgent = new Map([
+			['sess-a', 'alpha_reviewer'],
+		]);
+		mockCreate.mockResolvedValue({ data: { id: 'sess-pm' } });
+		mockPrompt.mockResolvedValue({
+			data: { info: {}, parts: [{ type: 'text', text: 'ok' }] },
+		});
+
+		const delegate = createCuratorLLMDelegate('/tmp/test', 'postmortem')!;
+		await delegate('SYS', 'input');
+
+		expect(mockPrompt).toHaveBeenCalledWith({
+			path: { id: 'sess-pm' },
+			body: expect.objectContaining({ agent: 'alpha_curator_postmortem' }),
+		});
+	});
+
 	test('multi-swarm: falls back to default swarm when no active session matches named swarm', async () => {
 		(swarmState as { opencodeClient: unknown }).opencodeClient = mockClient;
 		// Mix of default and named swarms

--- a/tests/unit/hooks/curator-llm-factory.test.ts
+++ b/tests/unit/hooks/curator-llm-factory.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../../src/state', () => ({
 		opencodeClient: null,
 		curatorInitAgentNames: [] as string[],
 		curatorPhaseAgentNames: [] as string[],
+		curatorPostmortemAgentNames: [] as string[],
 		activeAgent: new Map<string, string>(),
 	},
 }));
@@ -31,6 +32,9 @@ beforeEach(() => {
 		[];
 	(swarmState as { curatorPhaseAgentNames: string[] }).curatorPhaseAgentNames =
 		[];
+	(
+		swarmState as { curatorPostmortemAgentNames: string[] }
+	).curatorPostmortemAgentNames = [];
 	(swarmState as { activeAgent: Map<string, string> }).activeAgent = new Map();
 });
 

--- a/tests/unit/hooks/curator-postmortem.test.ts
+++ b/tests/unit/hooks/curator-postmortem.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Unit tests for the curator post-mortem agent (WP7, issue #1234).
+ *
+ * Validates: data collection, report generation, idempotency (dedup),
+ * LLM fallback, and fail-open behavior.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+	_internals,
+	runCuratorPostMortem,
+} from '../../../src/hooks/curator-postmortem.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeTempDir(): string {
+	return mkdtempSync(join(tmpdir(), 'postmortem-test-'));
+}
+
+function ensureSwarmDir(dir: string): string {
+	const swarmDir = join(dir, '.swarm');
+	mkdirSync(swarmDir, { recursive: true });
+	return swarmDir;
+}
+
+function writePlan(
+	dir: string,
+	plan: {
+		title: string;
+		swarm: string;
+		phases: Array<{
+			id: number;
+			name: string;
+			status: string;
+			tasks: unknown[];
+		}>;
+	},
+): void {
+	const swarmDir = ensureSwarmDir(dir);
+	writeFileSync(
+		join(swarmDir, 'plan.json'),
+		JSON.stringify({
+			schema_version: '1.0.0',
+			...plan,
+		}),
+	);
+}
+
+function writeKnowledge(
+	dir: string,
+	entries: Array<{
+		id: string;
+		lesson: string;
+		confidence?: number;
+		status?: string;
+	}>,
+): void {
+	const swarmDir = ensureSwarmDir(dir);
+	const lines = entries.map((e) =>
+		JSON.stringify({
+			id: e.id,
+			lesson: e.lesson,
+			category: 'lesson',
+			status: e.status ?? 'active',
+			confidence: e.confidence ?? 0.7,
+			tags: [],
+			scope: 'global',
+			confirmed_by: [],
+			project_name: 'test',
+		}),
+	);
+	writeFileSync(join(swarmDir, 'knowledge.jsonl'), `${lines.join('\n')}\n`);
+}
+
+function writeEvents(
+	dir: string,
+	events: Array<{
+		type: string;
+		knowledge_id?: string;
+		entry_id?: string;
+		timestamp?: string;
+	}>,
+): void {
+	const swarmDir = ensureSwarmDir(dir);
+	const lines = events.map((e) =>
+		JSON.stringify({
+			type: e.type,
+			event_id: randomUUID(),
+			trace_id: randomUUID(),
+			knowledge_id: e.knowledge_id,
+			entry_id: e.entry_id,
+			timestamp: e.timestamp ?? new Date().toISOString(),
+			session_id: 'test-session',
+			agent: 'test-agent',
+		}),
+	);
+	writeFileSync(
+		join(swarmDir, 'knowledge-events.jsonl'),
+		`${lines.join('\n')}\n`,
+	);
+}
+
+function writeCuratorSummary(dir: string, digest: string): void {
+	const swarmDir = ensureSwarmDir(dir);
+	writeFileSync(
+		join(swarmDir, 'curator-summary.json'),
+		JSON.stringify({
+			schema_version: 1,
+			session_id: 'test',
+			last_updated: new Date().toISOString(),
+			last_phase_covered: 2,
+			digest,
+			phase_digests: [],
+			compliance_observations: [],
+			knowledge_recommendations: [],
+		}),
+	);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('runCuratorPostMortem', () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = makeTempDir();
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	test('generates a data-only report from .swarm/ evidence', async () => {
+		const kid = randomUUID();
+		writePlan(dir, {
+			title: 'Test Project',
+			swarm: 'test',
+			phases: [
+				{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] },
+				{ id: 2, name: 'Phase 2', status: 'completed', tasks: [] },
+			],
+		});
+		writeKnowledge(dir, [
+			{ id: kid, lesson: 'Always validate inputs before processing' },
+		]);
+		writeEvents(dir, [
+			{ type: 'applied', knowledge_id: kid },
+			{ type: 'applied', knowledge_id: kid },
+			{ type: 'violated', knowledge_id: kid },
+		]);
+		writeCuratorSummary(dir, 'Phase 1 and 2 completed successfully.');
+
+		const result = await runCuratorPostMortem(dir);
+
+		expect(result.success).toBe(true);
+		expect(result.planId).toBe('test-Test_Project');
+		expect(result.reportPath).toBeTruthy();
+		expect(existsSync(result.reportPath!)).toBe(true);
+		expect(result.summary).toContain('1 knowledge entries');
+
+		const content = readFileSync(result.reportPath!, 'utf-8');
+		expect(content).toContain('Post-Mortem Report');
+		expect(content).toContain('2 applied');
+		expect(content).toContain('1 violated');
+	});
+
+	test('idempotent: skips if report already exists', async () => {
+		writePlan(dir, {
+			title: 'Test Project',
+			swarm: 'test',
+			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+		});
+
+		// First run creates the report
+		const result1 = await runCuratorPostMortem(dir);
+		expect(result1.success).toBe(true);
+
+		// Second run skips (idempotent)
+		const result2 = await runCuratorPostMortem(dir);
+		expect(result2.success).toBe(true);
+		expect(result2.summary).toContain('already exists');
+	});
+
+	test('--force overwrites existing report', async () => {
+		writePlan(dir, {
+			title: 'Test Project',
+			swarm: 'test',
+			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+		});
+
+		const result1 = await runCuratorPostMortem(dir);
+		expect(result1.success).toBe(true);
+
+		const result2 = await runCuratorPostMortem(dir, { force: true });
+		expect(result2.success).toBe(true);
+		expect(result2.summary).not.toContain('already exists');
+	});
+
+	test('falls back to data-only when LLM delegate fails', async () => {
+		writePlan(dir, {
+			title: 'Test Project',
+			swarm: 'test',
+			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+		});
+
+		const failingDelegate = async () => {
+			throw new Error('LLM unavailable');
+		};
+
+		const result = await runCuratorPostMortem(dir, {
+			llmDelegate: failingDelegate,
+			force: true,
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.warnings).toContainEqual(
+			expect.stringContaining('LLM delegate failed'),
+		);
+	});
+
+	test('succeeds with no .swarm/ data (minimal report)', async () => {
+		ensureSwarmDir(dir);
+
+		const result = await runCuratorPostMortem(dir);
+
+		expect(result.success).toBe(true);
+		expect(result.planId).toBe('unknown');
+		expect(result.warnings).toContainEqual(
+			expect.stringContaining('Plan not found'),
+		);
+	});
+
+	test('flags never-applied entries in the report', async () => {
+		const applied = randomUUID();
+		const stale = randomUUID();
+		writePlan(dir, {
+			title: 'Stale Test',
+			swarm: 'test',
+			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+		});
+		writeKnowledge(dir, [
+			{ id: applied, lesson: 'This entry was applied' },
+			{ id: stale, lesson: 'This entry was never applied' },
+		]);
+		writeEvents(dir, [{ type: 'applied', knowledge_id: applied }]);
+
+		const result = await runCuratorPostMortem(dir, { force: true });
+		expect(result.success).toBe(true);
+
+		const content = readFileSync(result.reportPath!, 'utf-8');
+		expect(content).toContain('Never-Applied Entries');
+		expect(content).toContain(stale);
+	});
+
+	test('includes pending proposals and quarantine counts in report', async () => {
+		writePlan(dir, {
+			title: 'Queue Test',
+			swarm: 'test',
+			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+		});
+
+		const swarmDir = ensureSwarmDir(dir);
+		writeFileSync(
+			join(swarmDir, 'insight-candidates.jsonl'),
+			`${JSON.stringify({ type: 'motif', description: 'test motif' })}\n`,
+		);
+		writeFileSync(
+			join(swarmDir, 'knowledge-unactionable.jsonl'),
+			`${JSON.stringify({ id: 'q1', lesson: 'quarantined', status: 'quarantined' })}\n${JSON.stringify({ id: 'q2', lesson: 'quarantined too', status: 'quarantined' })}\n`,
+		);
+
+		const result = await runCuratorPostMortem(dir, { force: true });
+		expect(result.success).toBe(true);
+
+		const content = readFileSync(result.reportPath!, 'utf-8');
+		expect(content).toContain('Pending proposals: 1');
+		expect(content).toContain('Unactionable quarantine: 2');
+	});
+
+	test('includes drift reports in the output', async () => {
+		writePlan(dir, {
+			title: 'Drift Test',
+			swarm: 'test',
+			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+		});
+
+		const swarmDir = ensureSwarmDir(dir);
+		writeFileSync(
+			join(swarmDir, 'drift-report-phase-1.json'),
+			JSON.stringify({
+				phase: 1,
+				alignment: 'ALIGNED',
+				drift_score: 0.0,
+			}),
+		);
+
+		const result = await runCuratorPostMortem(dir, { force: true });
+		expect(result.success).toBe(true);
+
+		const content = readFileSync(result.reportPath!, 'utf-8');
+		expect(content).toContain('Phase 1: ALIGNED');
+	});
+
+	test('includes retrospectives when present', async () => {
+		writePlan(dir, {
+			title: 'Retro Test',
+			swarm: 'test',
+			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+		});
+
+		const retroDir = join(dir, '.swarm', 'evidence', 'retro-1');
+		mkdirSync(retroDir, { recursive: true });
+		writeFileSync(
+			join(retroDir, 'evidence.json'),
+			JSON.stringify({
+				schema_version: '1.0.0',
+				task_id: 'retro-1',
+				entries: [
+					{
+						type: 'retrospective',
+						task_id: 'retro-1',
+						timestamp: new Date().toISOString(),
+						agent: 'architect',
+						verdict: 'pass',
+						summary: 'Phase went well',
+					},
+				],
+			}),
+		);
+
+		const result = await runCuratorPostMortem(dir, { force: true });
+		expect(result.success).toBe(true);
+
+		const content = readFileSync(result.reportPath!, 'utf-8');
+		expect(content).toContain('Retrospectives');
+		expect(content).toContain('1 phase retrospective(s)');
+	});
+});
+
+describe('_internals.collectKnowledgeSummary', () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = makeTempDir();
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	test('aggregates event counts per knowledge entry', async () => {
+		const kid = randomUUID();
+		writeKnowledge(dir, [{ id: kid, lesson: 'test lesson', confidence: 0.8 }]);
+		writeEvents(dir, [
+			{ type: 'applied', knowledge_id: kid },
+			{ type: 'applied', knowledge_id: kid },
+			{ type: 'violated', knowledge_id: kid },
+			{ type: 'ignored', knowledge_id: kid },
+		]);
+
+		const summary = await _internals.collectKnowledgeSummary(dir);
+
+		expect(summary).toHaveLength(1);
+		expect(summary[0].id).toBe(kid);
+		expect(summary[0].applied).toBe(2);
+		expect(summary[0].violated).toBe(1);
+		expect(summary[0].ignored).toBe(1);
+		expect(summary[0].confidence).toBe(0.8);
+	});
+});

--- a/tests/unit/hooks/curator-postmortem.test.ts
+++ b/tests/unit/hooks/curator-postmortem.test.ts
@@ -152,8 +152,8 @@ describe('runCuratorPostMortem', () => {
 			title: 'Test Project',
 			swarm: 'test',
 			phases: [
-				{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] },
-				{ id: 2, name: 'Phase 2', status: 'completed', tasks: [] },
+				{ id: 1, name: 'Phase 1', status: 'complete', tasks: [] },
+				{ id: 2, name: 'Phase 2', status: 'complete', tasks: [] },
 			],
 		});
 		writeKnowledge(dir, [
@@ -178,13 +178,15 @@ describe('runCuratorPostMortem', () => {
 		expect(content).toContain('Post-Mortem Report');
 		expect(content).toContain('2 applied');
 		expect(content).toContain('1 violated');
+		// Verify phase count uses correct 'complete' status (not 'completed')
+		expect(content).toContain('2/2 phases complete');
 	});
 
 	test('idempotent: skips if report already exists', async () => {
 		writePlan(dir, {
 			title: 'Test Project',
 			swarm: 'test',
-			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+			phases: [{ id: 1, name: 'Phase 1', status: 'complete', tasks: [] }],
 		});
 
 		// First run creates the report
@@ -201,7 +203,7 @@ describe('runCuratorPostMortem', () => {
 		writePlan(dir, {
 			title: 'Test Project',
 			swarm: 'test',
-			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+			phases: [{ id: 1, name: 'Phase 1', status: 'complete', tasks: [] }],
 		});
 
 		const result1 = await runCuratorPostMortem(dir);
@@ -216,7 +218,7 @@ describe('runCuratorPostMortem', () => {
 		writePlan(dir, {
 			title: 'Test Project',
 			swarm: 'test',
-			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+			phases: [{ id: 1, name: 'Phase 1', status: 'complete', tasks: [] }],
 		});
 
 		const failingDelegate = async () => {
@@ -252,7 +254,7 @@ describe('runCuratorPostMortem', () => {
 		writePlan(dir, {
 			title: 'Stale Test',
 			swarm: 'test',
-			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+			phases: [{ id: 1, name: 'Phase 1', status: 'complete', tasks: [] }],
 		});
 		writeKnowledge(dir, [
 			{ id: applied, lesson: 'This entry was applied' },
@@ -272,7 +274,7 @@ describe('runCuratorPostMortem', () => {
 		writePlan(dir, {
 			title: 'Queue Test',
 			swarm: 'test',
-			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+			phases: [{ id: 1, name: 'Phase 1', status: 'complete', tasks: [] }],
 		});
 
 		const swarmDir = ensureSwarmDir(dir);
@@ -297,7 +299,7 @@ describe('runCuratorPostMortem', () => {
 		writePlan(dir, {
 			title: 'Drift Test',
 			swarm: 'test',
-			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+			phases: [{ id: 1, name: 'Phase 1', status: 'complete', tasks: [] }],
 		});
 
 		const swarmDir = ensureSwarmDir(dir);
@@ -321,7 +323,7 @@ describe('runCuratorPostMortem', () => {
 		writePlan(dir, {
 			title: 'Retro Test',
 			swarm: 'test',
-			phases: [{ id: 1, name: 'Phase 1', status: 'completed', tasks: [] }],
+			phases: [{ id: 1, name: 'Phase 1', status: 'complete', tasks: [] }],
 		});
 
 		const retroDir = join(dir, '.swarm', 'evidence', 'retro-1');

--- a/tests/unit/hooks/knowledge-escalator-near-dup.test.ts
+++ b/tests/unit/hooks/knowledge-escalator-near-dup.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Unit tests for near-duplicate co-escalation in the knowledge escalator
+ * (WP6-A, issue #1234).
+ *
+ * When the exact entry alone does not reach the escalation threshold of 2
+ * violations in 30 days, the escalator co-counts violations on semantically
+ * near-duplicate entries (Jaccard bigram similarity >= 0.6). The near-dup
+ * lookup is wrapped in try-catch (fail-open).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	ESCALATION_THRESHOLD,
+	ESCALATION_WINDOW_DAYS,
+	maybeEscalateOnViolation,
+} from '../../../src/hooks/knowledge-escalator.js';
+import { readKnowledgeEvents } from '../../../src/hooks/knowledge-events.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-04-15T00:00:00.000Z');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a JSONL line for a knowledge entry. */
+function knowledgeLine(
+	id: string,
+	lesson: string,
+	overrides: Record<string, unknown> = {},
+): string {
+	return JSON.stringify({
+		id,
+		lesson,
+		category: 'process',
+		status: 'established',
+		confidence: 0.7,
+		tags: [],
+		scope: 'global',
+		confirmed_by: [],
+		project_name: 'test',
+		directive_priority: 'medium',
+		retrieval_outcomes: {
+			applied_count: 0,
+			succeeded_after_count: 0,
+			failed_after_count: 0,
+		},
+		schema_version: 2,
+		created_at: '2026-01-01T00:00:00.000Z',
+		updated_at: '2026-01-01T00:00:00.000Z',
+		...overrides,
+	});
+}
+
+/** Build a JSONL line for a violated event. */
+function violatedLine(knowledgeId: string, timestampMs: number): string {
+	return JSON.stringify({
+		type: 'violated',
+		event_id: randomUUID(),
+		trace_id: randomUUID(),
+		knowledge_id: knowledgeId,
+		timestamp: new Date(timestampMs).toISOString(),
+		session_id: randomUUID(),
+		agent: 'coder',
+	});
+}
+
+/** Write multiple JSONL lines to a file. */
+function writeJsonl(filePath: string, lines: string[]): void {
+	fs.writeFileSync(filePath, `${lines.join('\n')}\n`);
+}
+
+// Lesson text constants. The near-duplicate pair has Jaccard bigram >= 0.6;
+// the dissimilar lesson has 0.0 similarity to either.
+// Verified: "Always run tests before committing code" vs
+//           "Always run tests before committing changes" = 0.667
+const LESSON_A = 'Always run tests before committing code';
+const LESSON_B_NEAR_DUP = 'Always run tests before committing changes';
+const LESSON_C_DIFFERENT = 'Use snake_case for all database column names';
+
+describe('maybeEscalateOnViolation — near-duplicate co-escalation', () => {
+	let dir: string;
+	let swarmDir: string;
+	let knowledgePath: string;
+	let eventsPath: string;
+
+	beforeEach(() => {
+		dir = fs.mkdtempSync(path.join(os.tmpdir(), 'escalator-near-dup-'));
+		swarmDir = path.join(dir, '.swarm');
+		fs.mkdirSync(swarmDir, { recursive: true });
+		knowledgePath = path.join(swarmDir, 'knowledge.jsonl');
+		eventsPath = path.join(swarmDir, 'knowledge-events.jsonl');
+	});
+
+	afterEach(() => {
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('does not escalate when only the exact entry has 1 violation (no near-duplicates)', async () => {
+		const idA = randomUUID();
+		writeJsonl(knowledgePath, [knowledgeLine(idA, LESSON_A)]);
+		writeJsonl(eventsPath, [violatedLine(idA, NOW.getTime() - 3 * DAY)]);
+
+		const result = await maybeEscalateOnViolation(dir, idA, NOW);
+
+		expect(result.escalated).toBe(false);
+		expect(result.violationsInWindow).toBe(1);
+	});
+
+	it('escalates when the exact entry alone reaches the threshold (near-dup path not needed)', async () => {
+		const idA = randomUUID();
+		writeJsonl(knowledgePath, [knowledgeLine(idA, LESSON_A)]);
+		writeJsonl(eventsPath, [
+			violatedLine(idA, NOW.getTime() - 10 * DAY),
+			violatedLine(idA, NOW.getTime() - 1 * DAY),
+		]);
+
+		const result = await maybeEscalateOnViolation(dir, idA, NOW);
+
+		expect(result.escalated).toBe(true);
+		expect(result.from).toBe('medium');
+		expect(result.to).toBe('critical');
+		expect(result.violationsInWindow).toBeGreaterThanOrEqual(
+			ESCALATION_THRESHOLD,
+		);
+
+		// Verify the entry was updated on disk.
+		const content = fs.readFileSync(knowledgePath, 'utf-8');
+		const entry = content
+			.split('\n')
+			.filter((l) => l.trim())
+			.map((l) => JSON.parse(l))
+			.find((e: { id: string }) => e.id === idA);
+		expect(entry.directive_priority).toBe('critical');
+		expect(entry.enforcement_mode).toBe('enforce');
+
+		// An escalation event was emitted.
+		const events = await readKnowledgeEvents(dir);
+		const escalations = events.filter((e) => e.type === 'escalation');
+		expect(escalations.length).toBe(1);
+	});
+
+	it('co-counts near-duplicate violations to reach escalation threshold', async () => {
+		const idA = randomUUID();
+		const idB = randomUUID();
+
+		// Two entries with near-duplicate lessons (Jaccard >= 0.6).
+		writeJsonl(knowledgePath, [
+			knowledgeLine(idA, LESSON_A),
+			knowledgeLine(idB, LESSON_B_NEAR_DUP),
+		]);
+
+		// Each entry has 1 violation — alone not enough, but combined = 2.
+		writeJsonl(eventsPath, [
+			violatedLine(idA, NOW.getTime() - 5 * DAY),
+			violatedLine(idB, NOW.getTime() - 2 * DAY),
+		]);
+
+		const result = await maybeEscalateOnViolation(dir, idA, NOW);
+
+		expect(result.escalated).toBe(true);
+		expect(result.from).toBe('medium');
+		expect(result.to).toBe('critical');
+		expect(result.violationsInWindow).toBeGreaterThanOrEqual(
+			ESCALATION_THRESHOLD,
+		);
+
+		// Verify on-disk escalation for entry A (the target).
+		const content = fs.readFileSync(knowledgePath, 'utf-8');
+		const entryA = content
+			.split('\n')
+			.filter((l) => l.trim())
+			.map((l) => JSON.parse(l))
+			.find((e: { id: string }) => e.id === idA);
+		expect(entryA.directive_priority).toBe('critical');
+		expect(entryA.enforcement_mode).toBe('enforce');
+		expect(entryA.escalation_history).toHaveLength(1);
+		expect(entryA.escalation_history[0].reason).toBe('repeat_violation');
+
+		// Entry B is NOT escalated (only the target entry is promoted).
+		const entryB = content
+			.split('\n')
+			.filter((l) => l.trim())
+			.map((l) => JSON.parse(l))
+			.find((e: { id: string }) => e.id === idB);
+		expect(entryB.directive_priority).toBe('medium');
+	});
+
+	it('does NOT co-count entries below the similarity threshold', async () => {
+		const idA = randomUUID();
+		const idC = randomUUID();
+
+		// Entry A and entry C have completely different lessons (similarity = 0.0).
+		writeJsonl(knowledgePath, [
+			knowledgeLine(idA, LESSON_A),
+			knowledgeLine(idC, LESSON_C_DIFFERENT),
+		]);
+
+		// Each has 1 violation — but they are not similar, so no co-counting.
+		writeJsonl(eventsPath, [
+			violatedLine(idA, NOW.getTime() - 5 * DAY),
+			violatedLine(idC, NOW.getTime() - 2 * DAY),
+		]);
+
+		const result = await maybeEscalateOnViolation(dir, idA, NOW);
+
+		expect(result.escalated).toBe(false);
+		expect(result.violationsInWindow).toBe(1);
+
+		// Entry A remains at medium priority.
+		const content = fs.readFileSync(knowledgePath, 'utf-8');
+		const entryA = content
+			.split('\n')
+			.filter((l) => l.trim())
+			.map((l) => JSON.parse(l))
+			.find((e: { id: string }) => e.id === idA);
+		expect(entryA.directive_priority).toBe('medium');
+	});
+
+	it('fail-open: falls back to exact-count when knowledge store is missing', async () => {
+		const idA = randomUUID();
+
+		// Write events but do NOT create knowledge.jsonl — the near-dup
+		// lookup should fail silently and fall back to exact-only counting.
+		writeJsonl(eventsPath, [violatedLine(idA, NOW.getTime() - 3 * DAY)]);
+
+		// No knowledge.jsonl exists — readKnowledge returns [].
+		// The target entry will not be found, so near-dup loop is skipped.
+		const result = await maybeEscalateOnViolation(dir, idA, NOW);
+
+		// Only 1 exact violation, threshold not met, no crash.
+		expect(result.escalated).toBe(false);
+		expect(result.violationsInWindow).toBe(1);
+	});
+
+	it('co-counts near-duplicate violations from the hive knowledge store', async () => {
+		const idA = randomUUID();
+		const idHive = randomUUID();
+
+		// Entry A is in the swarm store with 1 violation.
+		writeJsonl(knowledgePath, [knowledgeLine(idA, LESSON_A)]);
+
+		// Near-duplicate entry lives only in the hive store.
+		const origHome = process.env.HOME;
+		const hiveHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hive-home-'));
+		process.env.HOME = hiveHome;
+		try {
+			const { resolveHiveKnowledgePath } = await import(
+				'../../../src/hooks/knowledge-store.js'
+			);
+			const hivePath = resolveHiveKnowledgePath();
+			fs.mkdirSync(path.dirname(hivePath), { recursive: true });
+			writeJsonl(hivePath, [knowledgeLine(idHive, LESSON_B_NEAR_DUP)]);
+
+			// Each entry has 1 violation — combined = 2 via near-dup co-counting.
+			writeJsonl(eventsPath, [
+				violatedLine(idA, NOW.getTime() - 5 * DAY),
+				violatedLine(idHive, NOW.getTime() - 2 * DAY),
+			]);
+
+			const result = await maybeEscalateOnViolation(dir, idA, NOW);
+
+			expect(result.escalated).toBe(true);
+			expect(result.from).toBe('medium');
+			expect(result.to).toBe('critical');
+		} finally {
+			process.env.HOME = origHome;
+			fs.rmSync(hiveHome, { recursive: true, force: true });
+		}
+	});
+
+	it('does not co-count near-duplicate violations outside the window', async () => {
+		const idA = randomUUID();
+		const idB = randomUUID();
+
+		writeJsonl(knowledgePath, [
+			knowledgeLine(idA, LESSON_A),
+			knowledgeLine(idB, LESSON_B_NEAR_DUP),
+		]);
+
+		// Entry A has 1 violation within the window.
+		// Entry B's violation is outside the 30-day window — should not count.
+		writeJsonl(eventsPath, [
+			violatedLine(idA, NOW.getTime() - 5 * DAY),
+			violatedLine(idB, NOW.getTime() - (ESCALATION_WINDOW_DAYS + 5) * DAY),
+		]);
+
+		const result = await maybeEscalateOnViolation(dir, idA, NOW);
+
+		expect(result.escalated).toBe(false);
+		expect(result.violationsInWindow).toBe(1);
+	});
+});

--- a/tests/unit/hooks/knowledge-verdict-feedback.test.ts
+++ b/tests/unit/hooks/knowledge-verdict-feedback.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Unit tests for applyKnowledgeVerdictFeedback (knowledge-events.ts).
+ *
+ * Verifies that receipt events (applied/violated/ignored) are aggregated
+ * per knowledge entry and translated into bounded confidence deltas via
+ * bumpKnowledgeConfidenceBatch.
+ *
+ * Covers: WP6-B (issue #1234).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { applyKnowledgeVerdictFeedback } from '../../../src/hooks/knowledge-events.js';
+import {
+	readKnowledge,
+	resolveSwarmKnowledgePath,
+} from '../../../src/hooks/knowledge-store.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeTempDir(): string {
+	return mkdtempSync(join(tmpdir(), 'verdict-feedback-test-'));
+}
+
+/** Resolve the knowledge-events JSONL path for a project directory. */
+function eventsPath(dir: string): string {
+	return join(dir, '.swarm', 'knowledge-events.jsonl');
+}
+
+/** Ensure .swarm/ exists and return the events file path. */
+function ensureSwarmDir(dir: string): string {
+	const p = eventsPath(dir);
+	mkdirSync(join(dir, '.swarm'), { recursive: true });
+	return p;
+}
+
+/** Build a single receipt event line (JSON string). */
+function makeReceiptEvent(overrides: {
+	type: string;
+	knowledge_id: string;
+	timestamp?: string;
+}): string {
+	return JSON.stringify({
+		type: overrides.type,
+		event_id: randomUUID(),
+		trace_id: randomUUID(),
+		knowledge_id: overrides.knowledge_id,
+		timestamp: overrides.timestamp ?? new Date().toISOString(),
+		session_id: 'test-session',
+		agent: 'test-agent',
+	});
+}
+
+/** Write receipt events as JSONL lines to the knowledge-events file. */
+function writeEvents(
+	dir: string,
+	events: Array<{
+		type: string;
+		knowledge_id: string;
+		timestamp?: string;
+	}>,
+): void {
+	const fp = ensureSwarmDir(dir);
+	const content = events.map((e) => makeReceiptEvent(e)).join('\n') + '\n';
+	writeFileSync(fp, content, 'utf-8');
+}
+
+/** Write knowledge entries to .swarm/knowledge.jsonl. */
+function writeKnowledgeEntries(
+	dir: string,
+	entries: Array<{
+		id: string;
+		lesson: string;
+		confidence: number;
+		category?: string;
+		status?: string;
+	}>,
+): void {
+	const fp = resolveSwarmKnowledgePath(dir);
+	mkdirSync(join(dir, '.swarm'), { recursive: true });
+	const content =
+		entries
+			.map((e) =>
+				JSON.stringify({
+					id: e.id,
+					lesson: e.lesson,
+					category: e.category ?? 'lesson',
+					status: e.status ?? 'active',
+					confidence: e.confidence,
+					tags: [],
+					scope: 'global',
+					confirmed_by: [],
+					project_name: 'test',
+				}),
+			)
+			.join('\n') + '\n';
+	writeFileSync(fp, content, 'utf-8');
+}
+
+/** Read knowledge entries back and return them indexed by id. */
+async function readKnowledgeById(
+	dir: string,
+): Promise<
+	Map<string, { id: string; confidence: number; [k: string]: unknown }>
+> {
+	const fp = resolveSwarmKnowledgePath(dir);
+	const entries = await readKnowledge<{
+		id: string;
+		confidence: number;
+		[k: string]: unknown;
+	}>(fp);
+	return new Map(entries.map((e) => [e.id, e]));
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('applyKnowledgeVerdictFeedback', () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = makeTempDir();
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	// --------------------------------------------------------------------------
+	// 1. Returns empty when no events exist
+	// --------------------------------------------------------------------------
+	test('returns { processed: 0, bumps: 0 } when no events file exists', async () => {
+		// Empty directory — no .swarm/ at all
+		const result = await applyKnowledgeVerdictFeedback(dir);
+
+		expect(result.processed).toBe(0);
+		expect(result.bumps).toBe(0);
+	});
+
+	// --------------------------------------------------------------------------
+	// 2. Boosts confidence when applied > violated+ignored
+	// --------------------------------------------------------------------------
+	test('boosts confidence (+0.03) when applied count exceeds violated+ignored', async () => {
+		const kid = randomUUID();
+
+		writeKnowledgeEntries(dir, [
+			{ id: kid, lesson: 'always run tests before commit', confidence: 0.5 },
+		]);
+
+		// 3 applied, 1 violated → applied (3) > violated+ignored (1) → boost
+		writeEvents(dir, [
+			{ type: 'applied', knowledge_id: kid },
+			{ type: 'applied', knowledge_id: kid },
+			{ type: 'applied', knowledge_id: kid },
+			{ type: 'violated', knowledge_id: kid },
+		]);
+
+		const result = await applyKnowledgeVerdictFeedback(dir);
+
+		expect(result.processed).toBe(1);
+		expect(result.bumps).toBe(1);
+
+		const entries = await readKnowledgeById(dir);
+		expect(entries.get(kid)!.confidence).toBeCloseTo(0.53); // 0.5 + 0.03
+	});
+
+	// --------------------------------------------------------------------------
+	// 3. Decays confidence when violated+ignored >= applied
+	// --------------------------------------------------------------------------
+	test('decays confidence (-0.05) when violated+ignored exceeds applied', async () => {
+		const kid = randomUUID();
+
+		writeKnowledgeEntries(dir, [
+			{ id: kid, lesson: 'use strict mode everywhere', confidence: 0.5 },
+		]);
+
+		// 2 violated, 1 applied → violated+ignored (2) >= applied (1) → decay
+		writeEvents(dir, [
+			{ type: 'violated', knowledge_id: kid },
+			{ type: 'violated', knowledge_id: kid },
+			{ type: 'applied', knowledge_id: kid },
+		]);
+
+		const result = await applyKnowledgeVerdictFeedback(dir);
+
+		expect(result.processed).toBe(1);
+		expect(result.bumps).toBe(1);
+
+		const entries = await readKnowledgeById(dir);
+		expect(entries.get(kid)!.confidence).toBeCloseTo(0.45); // 0.5 - 0.05
+	});
+
+	// --------------------------------------------------------------------------
+	// 4. Respects sinceTimestamp filter
+	// --------------------------------------------------------------------------
+	test('sinceTimestamp filters out old events', async () => {
+		const kid = randomUUID();
+
+		writeKnowledgeEntries(dir, [
+			{ id: kid, lesson: 'handle errors gracefully', confidence: 0.5 },
+		]);
+
+		const oldTimestamp = '2025-01-01T00:00:00.000Z';
+		const newTimestamp = '2026-06-01T00:00:00.000Z';
+		const cutoff = '2026-01-01T00:00:00.000Z';
+
+		// Old events: 3 violated (would cause decay if counted)
+		// New events: 2 applied (should cause boost since only these are counted)
+		writeEvents(dir, [
+			{ type: 'violated', knowledge_id: kid, timestamp: oldTimestamp },
+			{ type: 'violated', knowledge_id: kid, timestamp: oldTimestamp },
+			{ type: 'violated', knowledge_id: kid, timestamp: oldTimestamp },
+			{ type: 'applied', knowledge_id: kid, timestamp: newTimestamp },
+			{ type: 'applied', knowledge_id: kid, timestamp: newTimestamp },
+		]);
+
+		const result = await applyKnowledgeVerdictFeedback(dir, {
+			sinceTimestamp: cutoff,
+		});
+
+		expect(result.processed).toBe(1);
+		expect(result.bumps).toBe(1);
+
+		// Only the 2 new applied events count → applied (2) > violated+ignored (0) → boost
+		const entries = await readKnowledgeById(dir);
+		expect(entries.get(kid)!.confidence).toBeCloseTo(0.53); // 0.5 + 0.03
+	});
+
+	// --------------------------------------------------------------------------
+	// 5. Handles multiple entries independently
+	// --------------------------------------------------------------------------
+	test('handles multiple knowledge entries with independent verdicts', async () => {
+		const kidA = randomUUID();
+		const kidB = randomUUID();
+
+		writeKnowledgeEntries(dir, [
+			{ id: kidA, lesson: 'entry A - net positive', confidence: 0.5 },
+			{ id: kidB, lesson: 'entry B - net negative', confidence: 0.5 },
+		]);
+
+		// Entry A: 2 applied, 0 violated → boost
+		// Entry B: 1 applied, 3 ignored → decay
+		writeEvents(dir, [
+			{ type: 'applied', knowledge_id: kidA },
+			{ type: 'applied', knowledge_id: kidA },
+			{ type: 'applied', knowledge_id: kidB },
+			{ type: 'ignored', knowledge_id: kidB },
+			{ type: 'ignored', knowledge_id: kidB },
+			{ type: 'ignored', knowledge_id: kidB },
+		]);
+
+		const result = await applyKnowledgeVerdictFeedback(dir);
+
+		expect(result.processed).toBe(2);
+		expect(result.bumps).toBe(2);
+
+		const entries = await readKnowledgeById(dir);
+		expect(entries.get(kidA)!.confidence).toBeCloseTo(0.53); // 0.5 + 0.03 (boosted)
+		expect(entries.get(kidB)!.confidence).toBeCloseTo(0.45); // 0.5 - 0.05 (decayed)
+	});
+
+	// --------------------------------------------------------------------------
+	// 6. Decays on exact tie (applied === violated+ignored)
+	// --------------------------------------------------------------------------
+	test('decays confidence on exact tie (applied === violated+ignored)', async () => {
+		const kid = randomUUID();
+
+		writeKnowledgeEntries(dir, [
+			{ id: kid, lesson: 'tie case entry', confidence: 0.5 },
+		]);
+
+		// 1 applied, 1 violated → exact tie → decay
+		writeEvents(dir, [
+			{ type: 'applied', knowledge_id: kid },
+			{ type: 'violated', knowledge_id: kid },
+		]);
+
+		const result = await applyKnowledgeVerdictFeedback(dir);
+
+		expect(result.processed).toBe(1);
+		expect(result.bumps).toBe(1);
+
+		const entries = await readKnowledgeById(dir);
+		expect(entries.get(kid)!.confidence).toBeCloseTo(0.45); // 0.5 - 0.05
+	});
+
+	// --------------------------------------------------------------------------
+	// 7. sinceTimestamp boundary — event at exact cutoff is excluded
+	// --------------------------------------------------------------------------
+	test('excludes events with timestamp exactly equal to sinceTimestamp', async () => {
+		const kid = randomUUID();
+
+		writeKnowledgeEntries(dir, [
+			{ id: kid, lesson: 'boundary test entry', confidence: 0.5 },
+		]);
+
+		const cutoff = '2026-06-01T12:00:00.000Z';
+		const afterCutoff = '2026-06-01T12:00:00.001Z';
+
+		// 2 violated AT cutoff (should be excluded), 1 applied AFTER (included)
+		writeEvents(dir, [
+			{ type: 'violated', knowledge_id: kid, timestamp: cutoff },
+			{ type: 'violated', knowledge_id: kid, timestamp: cutoff },
+			{ type: 'applied', knowledge_id: kid, timestamp: afterCutoff },
+		]);
+
+		const result = await applyKnowledgeVerdictFeedback(dir, {
+			sinceTimestamp: cutoff,
+		});
+
+		expect(result.processed).toBe(1);
+		expect(result.bumps).toBe(1);
+
+		// Only the 1 applied event after cutoff counts → boost
+		const entries = await readKnowledgeById(dir);
+		expect(entries.get(kid)!.confidence).toBeCloseTo(0.53); // 0.5 + 0.03
+	});
+
+	// --------------------------------------------------------------------------
+	// 8. Ignores non-verdict event types
+	// --------------------------------------------------------------------------
+	test('ignores non-verdict event types (acknowledged, n_a)', async () => {
+		const kid = randomUUID();
+
+		writeKnowledgeEntries(dir, [
+			{ id: kid, lesson: 'non-verdict events only', confidence: 0.5 },
+		]);
+
+		// Only acknowledged and n_a events — neither is a verdict type
+		writeEvents(dir, [
+			{ type: 'acknowledged', knowledge_id: kid },
+			{ type: 'acknowledged', knowledge_id: kid },
+			{ type: 'n_a', knowledge_id: kid },
+		]);
+
+		const result = await applyKnowledgeVerdictFeedback(dir);
+
+		expect(result.processed).toBe(0);
+		expect(result.bumps).toBe(0);
+
+		// Confidence should be unchanged
+		const entries = await readKnowledgeById(dir);
+		expect(entries.get(kid)!.confidence).toBe(0.5);
+	});
+});

--- a/tests/unit/tools/phase-complete-justification.test.ts
+++ b/tests/unit/tools/phase-complete-justification.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Tests for the override justification minimum-length requirement in
+ * phase-complete.ts (issue #1234 WP6-C).
+ *
+ * The validation in phase-complete.ts:
+ *   1. Trims the incoming justification string.
+ *   2. Rejects it if the trimmed length is < 10.
+ *   3. Only applies the override when the trimmed length is >= 10.
+ *
+ * Rather than invoking the full phase_complete tool (which requires extensive
+ * mocking of state, curator, knowledge, plan, and directive subsystems), we
+ * replicate the exact validation logic as a focused helper and verify its
+ * boundary behavior exhaustively. A source-code verification test confirms the
+ * threshold constant has not silently regressed.
+ */
+
+// ---------------------------------------------------------------------------
+// Helper — mirrors the validation extracted from phase-complete.ts lines ~514-548
+// ---------------------------------------------------------------------------
+
+/**
+ * Replicates the justification validation performed inside phase_complete:
+ *
+ *   const justification =
+ *     typeof args.acceptViolationsJustification === 'string'
+ *       ? args.acceptViolationsJustification.trim()
+ *       : '';
+ *   ...
+ *   if (requestedAccept.length > 0 && justification.length < 10) { ... block ... }
+ *
+ * Returns `true` when the justification is long enough to pass the gate.
+ */
+function validateJustification(justification: string): boolean {
+	const trimmed = justification.trim();
+	return trimmed.length >= 10;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('phase-complete override justification minimum length', () => {
+	test('rejects empty string', () => {
+		expect(validateJustification('')).toBe(false);
+	});
+
+	test('rejects whitespace-only string', () => {
+		expect(validateJustification('   ')).toBe(false);
+		expect(validateJustification('\t\n')).toBe(false);
+	});
+
+	test('rejects single character', () => {
+		expect(validateJustification('a')).toBe(false);
+	});
+
+	test('rejects 9-character string (boundary - 1)', () => {
+		// "too short" is exactly 9 characters
+		const nineChars = 'too short';
+		expect(nineChars.length).toBe(9);
+		expect(validateJustification(nineChars)).toBe(false);
+	});
+
+	test('accepts exactly 10-character string (boundary)', () => {
+		// "good reaso" is exactly 10 characters
+		const tenChars = 'good reaso';
+		expect(tenChars.length).toBe(10);
+		expect(validateJustification(tenChars)).toBe(true);
+	});
+
+	test('accepts 11-character string (boundary + 1)', () => {
+		const elevenChars = 'good reason';
+		expect(elevenChars.length).toBe(11);
+		expect(validateJustification(elevenChars)).toBe(true);
+	});
+
+	test('accepts substantive justification', () => {
+		expect(
+			validateJustification(
+				"This directive conflicts with the project's testing strategy",
+			),
+		).toBe(true);
+	});
+
+	test('rejects padded short string (trims first, then checks length)', () => {
+		// "  abc  " trims to "abc" (3 chars) — must be rejected
+		expect(validateJustification('  abc  ')).toBe(false);
+	});
+
+	test('accepts padded long string (trims first, still >= 10)', () => {
+		// "  good reason  " trims to "good reason" (11 chars) — must pass
+		expect(validateJustification('  good reason  ')).toBe(true);
+	});
+
+	test('rejects string that is exactly 10 chars only because of padding', () => {
+		// "   abcde  " is 10 chars total, but trims to "abcde" (5 chars)
+		const padded = '   abcde  ';
+		expect(padded.length).toBe(10);
+		expect(validateJustification(padded)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Source-code verification — confirm the threshold constant in the actual file
+	// ---------------------------------------------------------------------------
+
+	test('source code uses threshold of 10 for justification length', () => {
+		const sourceFile = path.resolve(
+			__dirname,
+			'../../../src/tools/phase-complete.ts',
+		);
+		const source = fs.readFileSync(sourceFile, 'utf-8');
+
+		// The blocking check: justification.length < 10
+		expect(source).toContain('justification.length < 10');
+
+		// The effective-accept gate: justification.length >= 10
+		expect(source).toContain('justification.length >= 10');
+
+		// The user-facing message mentions the minimum
+		expect(source).toContain('minimum 10 characters');
+	});
+});


### PR DESCRIPTION
Closes #1234

## Summary
- **WP6-A**: Extend near-duplicate knowledge escalation lookup to include the hive store; add seen-set deduplication to prevent double-counting when the same entry appears in both swarm and hive stores.
- **WP6-B**: Add `applyKnowledgeVerdictFeedback()` that reads receipt events since a recorded marker timestamp and bumps knowledge confidence via `bumpKnowledgeConfidenceBatch`. Fixes timestamp-gap bug: marker is captured *before* processing and written *after*, so no events fall into a missed window.
- **WP6-C**: Tighten justification gate from `=== 0` to `< 10` so whitespace-only and trivially short justifications are rejected instead of accepted.
- **WP7**: Add `curator_postmortem` agent role with `CURATOR_POSTMORTEM_PROMPT`, `runCuratorPostMortem()` that produces a project-end synthesis report, auto-trigger from `phase_complete` (all-phases-done path) and `/swarm close`, and a new `/post-mortem` command. Fixes: drift reports missing from LLM input, fallback model not covering `curator_postmortem`, dead `scope` option removed.
- **Post-adversarial-review fix**: Phase summary in `curator-postmortem.ts` used `p.status === 'completed'` — plans use `'complete'` for phases (tasks use `'completed'`). Fixed filter and updated test fixtures to use the canonical value; added assertion verifying the count appears correctly in the report.

## Invariant audit
- 1 (plugin init): touched — `curator_postmortem` agent registered via standard `createCuratorAgent()` factory in `src/agents/index.ts`; `isAgentDisabled()` gate respected. Build succeeds.
- 2 (runtime portability): touched — no `bun:` imports in new files; `node --input-type=module -e "await import('./dist/index.js')"` passes.
- 3 (subprocesses): not touched — grep for `bunSpawn|spawn|spawnSync` in changed files returns no matches.
- 4 (.swarm containment): touched — `runCuratorPostMortem` calls `validateSwarmPath(directory, reportFilename)` before writing the report file (`src/hooks/curator-postmortem.ts`).
- 5 (plan durability): not touched — no changes to plan read/write logic.
- 6 (test_runner safety): not touched — test runner tool not changed.
- 7 (test writing): touched — all new tests use `bun:test` only; `_internals` DI seam exported from `curator-postmortem.ts`; no `mock.module` leakage (verified by independent adversarial reviewer).
- 8 (session state): not touched — session state management unchanged.
- 9 (guardrails/retry): not touched — guardrails hooks unchanged.
- 10 (chat/system msg): not touched — no chat/system message changes.
- 11 (tool registration): touched — `curator_postmortem` added to `ALL_SUBAGENT_NAMES` in `agent-names.ts`, tool map and model defaults in `constants.ts`. Config unit tests pass.
- 12 (release/cache): touched — two release fragments created under `docs/releases/pending/`; `package.json` version and `CHANGELOG.md` not modified.

## Test plan
- [x] `bun run build` — clean, no errors
- [x] `node --input-type=module -e "await import('./dist/index.js')"` — dist import OK
- [x] `bun run typecheck` — clean, no errors
- [x] `bunx biome ci .` — 1902 files checked, no fixes needed
- [x] `tests/unit/hooks/curator-postmortem.test.ts` — 10 tests, all pass (idempotency, LLM fallback, data-only report, flagging never-applied entries, proposals/quarantine counts, drift reports, retrospectives, phase count assertion)
- [x] `tests/unit/hooks/knowledge-escalator-near-dup.test.ts` + `knowledge-verdict-feedback.test.ts` — 15 tests, all pass
- [x] `tests/unit/tools/phase-complete-justification.test.ts` — 11 tests, all pass
- [x] `bun test tests/smoke` — 10 pass / 0 fail
- [x] `bun test tests/security` — 167 pass / 0 fail
- [x] Pre-existing failures confirmed on origin/main — our commits do not touch any of those test files

## Independent adversarial review
A fresh subagent reviewer was launched against the final diff. Full findings:

**CONFIRMED and fixed:** Phase status `'completed'` → `'complete'` in `curator-postmortem.ts` plan summary (plans use `'complete'`, tasks use `'completed'`). Test fixtures updated and a new assertion added.

**DISPROVED:**
- `plan.swarm` undefined risk: `loadPlanJsonOnly` validates through Zod `PlanSchema` (`swarm: z.string().min(1)` required); non-null return guarantees `plan.swarm` is always a valid string.
- `countEntryViolationsInWindow` hive-store scope: `recordKnowledgeEvent` always writes to project-local events with the entry's ID regardless of hive/swarm origin — hive violations are correctly found by local event log lookup.
- `sinceTimestamp` boundary: `<=` exclusion is intentional, verified by test 7 in `knowledge-verdict-feedback.test.ts`.
- `ignored` as negative: deliberate design choice, encoded in tests.
- `mock.module` leakage: confirmed absent from all 4 new test files.
- No subprocess usage in any changed file.

**MINOR (no fix required for this PR):** `phase-complete-justification.test.ts` boundary tests use a local helper that replicates production logic rather than calling production code directly; source-scan test at lines 109–124 ties the threshold constant to the production source as a backstop, and full integration coverage of the gate exists in `phase-complete.test.ts`.