### PR TITLE
perf(cache): add swarm artifact read-through cache

### DIFF
--- a/docs/releases/pending/1276-swarm-artifact-cache.md
+++ b/docs/releases/pending/1276-swarm-artifact-cache.md
@@ -1,7 +1,8 @@
 # Swarm Artifact Cache
 
-- Added a bounded mtime/size keyed read-through cache for frequently read swarm artifacts on the chat injection path.
+- Added a bounded stat-metadata keyed read-through cache for frequently read swarm artifacts on the chat injection path.
 - Reused cached parsed plan and knowledge JSONL forms when files are unchanged, while returning cloned parsed values so callers cannot mutate cached state.
+- Hardened cache invalidation for same-size rewrites and mid-read file changes, kept eviction FIFO as documented, and split text/parsed eviction counters for clearer diagnostics.
 - Preserved fail-open behavior: stat/read/parse failures continue through the existing fallback paths instead of blocking hook execution.
 - Focused regression coverage shows unchanged raw `.swarm` reads drop from two direct reads to one cached read, and repeated parsed `plan.json` / `knowledge.jsonl` loads drop to one parsed read until rewrite invalidation.
 - Fixed reviewer `SKILL_COMPLIANCE` capture so verdict lines no longer require a trailing space to be recorded.

--- a/docs/releases/pending/1276-swarm-artifact-cache.md
+++ b/docs/releases/pending/1276-swarm-artifact-cache.md
@@ -1,0 +1,9 @@
+# Swarm Artifact Cache
+
+- Added a bounded mtime/size keyed read-through cache for frequently read swarm artifacts on the chat injection path.
+- Reused cached parsed plan and knowledge JSONL forms when files are unchanged, while returning cloned parsed values so callers cannot mutate cached state.
+- Preserved fail-open behavior: stat/read/parse failures continue through the existing fallback paths instead of blocking hook execution.
+- Focused regression coverage shows unchanged raw `.swarm` reads drop from two direct reads to one cached read, and repeated parsed `plan.json` / `knowledge.jsonl` loads drop to one parsed read until rewrite invalidation.
+- Fixed reviewer `SKILL_COMPLIANCE` capture so verdict lines no longer require a trailing space to be recorded.
+- Restored the architect prompt's `6k. SPEC-STALENESS GUARD` guidance so spec-drift prompts continue to surface `removed_task_ids`, `SPEC_DRIFT_BLOCKED_TOOLS`, and `SPEC_DRIFT_BLOCK`.
+- No migration is required.

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -926,6 +926,13 @@ ACTION: Load skill file:.opencode/skills/critic-gate/SKILL.md immediately. Follo
 HARD CONSTRAINTS:
 - Do not begin implementation until the critic has reviewed and approved the plan.
 
+6k. SPEC-STALENESS GUARD:
+- If _specStale or .swarm/spec-staleness.json exists, stop and surface the drift to the user. The user must run /swarm clarify to update the spec, or /swarm acknowledge-spec-drift to acknowledge the drift and suppress warnings.
+- Do NOT run /swarm acknowledge-spec-drift yourself, including through swarm_command, chat fallback, shell, bunx, npx, node, bun, or equivalent dispatcher forms.
+- Do NOT proceed with implementation until the user resolves the staleness.
+- When re-saving a plan in response to spec drift, save_plan requires every prior task missing from the new args.phases to be listed in removed_task_ids with a removal_reason. Pending, in_progress, or blocked tasks must not be removed without explicit user confirmation.
+- While .swarm/spec-staleness.json exists, the runtime structurally blocks SPEC_DRIFT_BLOCKED_TOOLS: save_plan, update_task_status, phase_complete, lean_turbo_run_phase, and lean_turbo_acquire_locks. If a call returns SPEC_DRIFT_BLOCK, do not retry; surface the drift and wait for the user to run /swarm clarify or /swarm acknowledge-spec-drift.
+
 ### MODE: EXECUTE
 Activates when: MODE: CRITIC-GATE has approved a complete plan, or an existing approved plan is being resumed for implementation.
 

--- a/src/hooks/knowledge-store.ts
+++ b/src/hooks/knowledge-store.ts
@@ -6,12 +6,15 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import lockfile from 'proper-lockfile';
 import { atomicWriteFile } from '../evidence/task-file.js';
+import { readCachedParsedFile } from '../utils/swarm-artifact-cache.js';
 import type {
 	ActionableDirectiveFields,
 	KnowledgeEntryBase,
 	RejectedLesson,
 	RetrievalOutcome,
 } from './knowledge-types.js';
+
+const KNOWLEDGE_JSONL_CACHE_NAMESPACE = 'knowledge-jsonl:normalized:v1';
 
 // ============================================================================
 // Path Resolvers
@@ -108,25 +111,35 @@ export function resolveHiveEventsPath(): string {
 // v2: each parsed entry is passed through normalizeEntry() so v1 entries get
 // optional v2 fields filled in WITHOUT mutating on-disk JSONL.
 export async function readKnowledge<T>(filePath: string): Promise<T[]> {
-	if (!existsSync(filePath)) return [];
-	const content = await readFile(filePath, 'utf-8');
-	const results: T[] = [];
-	for (const line of content.split('\n')) {
-		const trimmed = line.trim();
-		if (!trimmed) continue;
-		try {
-			const raw = JSON.parse(trimmed) as T;
-			results.push(normalizeEntry(raw));
-		} catch {
-			console.warn(
-				`[knowledge-store] Skipping corrupted JSONL line in ${filePath}: ${trimmed.slice(
-					0,
-					80,
-				)}`,
-			);
-		}
-	}
-	return results;
+	const resolvedPath = path.resolve(filePath);
+	const entries = await readCachedParsedFile<T[]>(
+		resolvedPath,
+		KNOWLEDGE_JSONL_CACHE_NAMESPACE,
+		async () => {
+			if (!existsSync(resolvedPath)) return null;
+			return await readFile(resolvedPath, 'utf-8');
+		},
+		(content) => {
+			const results: T[] = [];
+			for (const line of content.split('\n')) {
+				const trimmed = line.trim();
+				if (!trimmed) continue;
+				try {
+					const raw = JSON.parse(trimmed) as T;
+					results.push(normalizeEntry(raw));
+				} catch {
+					console.warn(
+						`[knowledge-store] Skipping corrupted JSONL line in ${resolvedPath}: ${trimmed.slice(
+							0,
+							80,
+						)}`,
+					);
+				}
+			}
+			return results;
+		},
+	);
+	return entries ?? [];
 }
 
 // v2: Normalize a parsed entry to the current shape in memory.

--- a/src/hooks/system-enhancer.ts
+++ b/src/hooks/system-enhancer.ts
@@ -31,6 +31,12 @@ import {
 	hasActiveTurboMode,
 	swarmState,
 } from '../state';
+import {
+	readCachedParsedFileSync,
+	readCachedTextFileSync,
+} from '../utils/swarm-artifact-cache';
+
+const SPEC_STALENESS_CACHE_NAMESPACE = 'spec-staleness-json:v1';
 
 /**
  * Build the [spec-drift] advisory injected into the model's system prompt
@@ -74,19 +80,25 @@ function readSpecStalenessSnapshot(
 ): { specHash_plan: string; specHash_current: string | null } | null {
 	try {
 		const p = path.join(directory, '.swarm', 'spec-staleness.json');
-		if (!fs.existsSync(p)) return null;
-		const raw = fs.readFileSync(p, 'utf-8');
-		const parsed = JSON.parse(raw);
-		if (
-			typeof parsed?.specHash_plan === 'string' &&
-			(typeof parsed?.specHash_current === 'string' ||
-				parsed?.specHash_current === null)
-		) {
-			return {
-				specHash_plan: parsed.specHash_plan,
-				specHash_current: parsed.specHash_current,
-			};
-		}
+		return readCachedParsedFileSync(
+			p,
+			SPEC_STALENESS_CACHE_NAMESPACE,
+			() => (fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : null),
+			(raw) => {
+				const parsed = JSON.parse(raw);
+				if (
+					typeof parsed?.specHash_plan === 'string' &&
+					(typeof parsed?.specHash_current === 'string' ||
+						parsed?.specHash_current === null)
+				) {
+					return {
+						specHash_plan: parsed.specHash_plan,
+						specHash_current: parsed.specHash_current,
+					};
+				}
+				return null;
+			},
+		);
 	} catch {
 		/* malformed — fall through */
 	}
@@ -1048,11 +1060,14 @@ ${handoffContent}`;
 										'evidence',
 										`${taskId_ccp}.json`,
 									);
-									if (fs.existsSync(evidencePath)) {
-										const evidenceContent = fs.readFileSync(
-											evidencePath,
-											'utf-8',
-										);
+									const evidenceContent = readCachedTextFileSync(
+										evidencePath,
+										() =>
+											fs.existsSync(evidencePath)
+												? fs.readFileSync(evidencePath, 'utf-8')
+												: null,
+									);
+									if (evidenceContent !== null) {
 										const evidenceData = JSON.parse(evidenceContent) as {
 											bundle?: {
 												entries?: Array<{

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -9,6 +9,7 @@
 import * as path from 'node:path';
 import { SwarmError, warn } from '../utils';
 import { bunFile } from '../utils/bun-compat';
+import { readCachedTextFile } from '../utils/swarm-artifact-cache';
 
 /**
  * Test-only dependency-injection seam. Production code calls
@@ -179,9 +180,10 @@ export async function readSwarmFileAsync(
 	for (let attempt = 0; attempt < maxAttempts; attempt++) {
 		try {
 			const resolvedPath = _internals.validateSwarmPath(directory, filename);
-			const file = bunFile(resolvedPath);
-			const content = await file.text();
-			return content;
+			return await readCachedTextFile(resolvedPath, async () => {
+				const file = bunFile(resolvedPath);
+				return await file.text();
+			});
 		} catch (err) {
 			// Only retry on ENOENT (file not found) — other errors should fail fast
 			const isNotFound = (err as NodeJS.ErrnoException)?.code === 'ENOENT';

--- a/src/plan/manager.ts
+++ b/src/plan/manager.ts
@@ -73,6 +73,7 @@ import type { SpecStaleDetectedEvent } from '../types/events';
 import { warn } from '../utils';
 import { bunHash, bunWrite } from '../utils/bun-compat';
 import { isSpecStale } from '../utils/spec-hash';
+import { readCachedParsedFile } from '../utils/swarm-artifact-cache';
 import {
 	appendLedgerEvent,
 	computeCurrentPlanHash,
@@ -100,6 +101,8 @@ const startupLedgerCheckedWorkspaces = new Set<string>();
 // Prevents two concurrent loadPlan calls from racing through the
 // approved-snapshot recovery and both calling savePlan (#444 item 6).
 const recoveryMutexes = new Map<string, Promise<void>>();
+
+const PLAN_JSON_CACHE_NAMESPACE = 'plan-json:validated:v1';
 
 /** Reset the startup ledger check flag. For testing only. */
 export function resetStartupLedgerCheck(): void {
@@ -212,8 +215,7 @@ export async function loadPlanJsonOnly(
 			return null;
 		}
 		try {
-			const parsed = JSON.parse(planJsonContent);
-			const validated = PlanSchema.parse(parsed);
+			const validated = await parsePlanJsonCached(directory, planJsonContent);
 			return validated;
 		} catch (error) {
 			warn(
@@ -256,6 +258,26 @@ async function getLatestLedgerHash(directory: string): Promise<string> {
 	} catch {
 		return '';
 	}
+}
+
+async function parsePlanJsonCached(
+	directory: string,
+	content: string,
+): Promise<Plan> {
+	const planJsonPath = path.resolve(directory, '.swarm', 'plan.json');
+	const validated = await readCachedParsedFile<Plan>(
+		planJsonPath,
+		PLAN_JSON_CACHE_NAMESPACE,
+		async () => content,
+		(planJsonContent) => {
+			const parsed = JSON.parse(planJsonContent);
+			return PlanSchema.parse(parsed);
+		},
+	);
+	if (validated === null) {
+		throw new Error('plan.json disappeared during cached parse');
+	}
+	return validated;
 }
 
 /**
@@ -402,8 +424,7 @@ export async function loadPlan(directory: string): Promise<RuntimePlan | null> {
 			// Skip to plan.md migration path - don't parse tainted content
 		} else {
 			try {
-				const parsed = JSON.parse(planJsonContent);
-				const validated = PlanSchema.parse(parsed);
+				const validated = await parsePlanJsonCached(directory, planJsonContent);
 
 				// Auto-heal case 1: Valid plan.json exists, check if plan.md needs regeneration
 				const inSync = await isPlanMdInSync(directory, validated);

--- a/src/plan/manager.ts
+++ b/src/plan/manager.ts
@@ -205,23 +205,12 @@ export async function retryCasWithBackoff(
 export async function loadPlanJsonOnly(
 	directory: string,
 ): Promise<Plan | null> {
-	const planJsonContent = await readSwarmFileAsync(directory, 'plan.json');
-	if (planJsonContent !== null) {
-		// SECURITY: Reject content with null bytes (injection) or invalid UTF-8 (corruption markers)
-		if (planJsonContent.includes('\0') || planJsonContent.includes('�')) {
-			warn(
-				'Plan rejected: .swarm/plan.json contains null bytes or invalid encoding',
-			);
-			return null;
-		}
-		try {
-			const validated = await parsePlanJsonCached(directory, planJsonContent);
-			return validated;
-		} catch (error) {
-			warn(
-				`Plan validation failed for .swarm/plan.json: ${error instanceof Error ? error.message : String(error)}`,
-			);
-		}
+	try {
+		return await parsePlanJsonCached(directory);
+	} catch (error) {
+		warn(
+			`Plan validation failed for .swarm/plan.json: ${error instanceof Error ? error.message : String(error)}`,
+		);
 	}
 	return null;
 }
@@ -260,24 +249,25 @@ async function getLatestLedgerHash(directory: string): Promise<string> {
 	}
 }
 
-async function parsePlanJsonCached(
-	directory: string,
-	content: string,
-): Promise<Plan> {
+async function parsePlanJsonCached(directory: string): Promise<Plan | null> {
 	const planJsonPath = path.resolve(directory, '.swarm', 'plan.json');
-	const validated = await readCachedParsedFile<Plan>(
+	return readCachedParsedFile<Plan>(
 		planJsonPath,
 		PLAN_JSON_CACHE_NAMESPACE,
-		async () => content,
+		() => readSwarmFileAsync(directory, 'plan.json'),
 		(planJsonContent) => {
+			if (
+				planJsonContent.includes('\0') ||
+				planJsonContent.includes('\uFFFD')
+			) {
+				throw new Error(
+					'Plan rejected: .swarm/plan.json contains null bytes or invalid encoding',
+				);
+			}
 			const parsed = JSON.parse(planJsonContent);
 			return PlanSchema.parse(parsed);
 		},
 	);
-	if (validated === null) {
-		throw new Error('plan.json disappeared during cached parse');
-	}
-	return validated;
 }
 
 /**
@@ -417,191 +407,200 @@ export async function loadPlan(directory: string): Promise<RuntimePlan | null> {
 	const planJsonContent = await readSwarmFileAsync(directory, 'plan.json');
 	if (planJsonContent !== null) {
 		// SECURITY: Reject content with null bytes or invalid UTF-8
-		if (planJsonContent.includes('\0') || planJsonContent.includes('�')) {
+		if (planJsonContent.includes('\0') || planJsonContent.includes('\uFFFD')) {
 			warn(
 				'Plan rejected: .swarm/plan.json contains null bytes or invalid encoding',
 			);
 			// Skip to plan.md migration path - don't parse tainted content
 		} else {
 			try {
-				const validated = await parsePlanJsonCached(directory, planJsonContent);
-
-				// Auto-heal case 1: Valid plan.json exists, check if plan.md needs regeneration
-				const inSync = await isPlanMdInSync(directory, validated);
-				if (!inSync) {
-					try {
-						await _internals.regeneratePlanMarkdown(directory, validated);
-					} catch (regenError) {
-						// Log warning but don't fail - plan.json is valid
-						warn(
-							`Failed to regenerate plan.md: ${regenError instanceof Error ? regenError.message : String(regenError)}. Proceeding with plan.json only.`,
-						);
+				const validated = await parsePlanJsonCached(directory);
+				if (validated === null) {
+					warn(
+						'[loadPlan] plan.json disappeared during cached parse. Falling back to plan.md migration or ledger recovery.',
+					);
+				} else {
+					// Auto-heal case 1: Valid plan.json exists, check if plan.md needs regeneration
+					const inSync = await isPlanMdInSync(directory, validated);
+					if (!inSync) {
+						try {
+							await _internals.regeneratePlanMarkdown(directory, validated);
+						} catch (regenError) {
+							// Log warning but don't fail - plan.json is valid
+							warn(
+								`Failed to regenerate plan.md: ${regenError instanceof Error ? regenError.message : String(regenError)}. Proceeding with plan.json only.`,
+							);
+						}
 					}
-				}
 
-				// Task 3.1: Ledger-aware rehydration guard
-				// If ledger exists and plan.json hash doesn't match latest ledger hash,
-				// the projection is stale — rebuild from ledger before returning.
-				// SCOPED TO STARTUP ONLY: Hash mismatches during active sessions are expected
-				// due to concurrent writes (save_plan + update_task_status). Only rebuild on
-				// first loadPlan() call per workspace per process lifetime.
-				if (await ledgerExists(directory)) {
-					const planHash = computePlanHash(validated);
-					const ledgerHash = await getLatestLedgerHash(directory);
-					const resolvedWorkspace = path.resolve(directory);
-					if (!startupLedgerCheckedWorkspaces.has(resolvedWorkspace)) {
-						startupLedgerCheckedWorkspaces.add(resolvedWorkspace);
-						if (ledgerHash !== '' && planHash !== ledgerHash) {
-							const currentPlanId = derivePlanId(validated);
-							const ledgerEvents = await readLedgerEvents(directory);
-							const firstEvent =
-								ledgerEvents.length > 0 ? ledgerEvents[0] : null;
-							if (firstEvent && firstEvent.plan_id !== currentPlanId) {
-								// Ledger is from a different plan identity — migration detected.
-								// Use the first event (plan_created anchor) as the authoritative identity,
-								// consistent with savePlan's archive guard which also uses events[0].
-								// Do not rebuild; plan.json is the authoritative post-migration state.
-								warn(
-									`[loadPlan] Ledger identity mismatch (ledger: ${firstEvent.plan_id}, plan: ${currentPlanId}) — skipping ledger rebuild (migration detected). Use /swarm reset-session to reinitialize the ledger.`,
-								);
-							} else {
-								warn(
-									'[loadPlan] plan.json is stale (hash mismatch with ledger) — rebuilding from ledger. If this recurs, run /swarm reset-session to clear stale session state.',
-								);
-								try {
-									const rebuilt = await replayFromLedger(directory);
-									if (rebuilt) {
-										await rebuildPlan(directory, rebuilt, {
-											reason: 'ledger_hash_mismatch_recovery',
-										});
-										warn(
-											'[loadPlan] Rebuilt plan from ledger. Checkpoint available at .swarm/SWARM_PLAN.md if it exists.',
-										);
-										return rebuilt;
-									}
-								} catch (replayError) {
-									// Ledger replay failed — try the critic-approved immutable
-									// snapshot as a last-resort fallback before returning stale state.
-									//
-									// Identity guard: pass the current workspace's plan identity
-									// (derived from the still-loaded plan.json above) to prevent
-									// resurrecting a foreign approved snapshot from a reused directory.
-									try {
-										const approved = await loadLastApprovedPlan(
-											directory,
-											currentPlanId,
-										);
-										if (approved) {
-											await rebuildPlan(directory, approved.plan, {
-												reason: 'approved_snapshot_fallback',
-											});
-											// Heal the ledger tail so subsequent loadPlan calls don't
-											// loop back into this recovery path. The recovered plan is
-											// now the authoritative state; tag it as a fresh snapshot
-											// so replayFromLedger's walk-backward picks it up before
-											// hitting whatever event (plan_reset, corruption, ...)
-											// caused the original replay to fail.
-											try {
-												await takeSnapshotEvent(directory, approved.plan, {
-													source: 'recovery_from_approved_snapshot',
-													approvalMetadata: approved.approval,
-												});
-											} catch (healError) {
-												warn(
-													`[loadPlan] Recovery-heal snapshot append failed: ${healError instanceof Error ? healError.message : String(healError)}. Next loadPlan may re-enter recovery path.`,
-												);
-											}
-											const approvedPhase =
-												approved.approval &&
-												typeof approved.approval === 'object' &&
-												'phase' in approved.approval
-													? (approved.approval as { phase?: unknown }).phase
-													: undefined;
-											warn(
-												`[loadPlan] Ledger replay failed (${replayError instanceof Error ? replayError.message : String(replayError)}) — recovered from critic-approved snapshot seq=${approved.seq} (approval phase=${approvedPhase ?? 'unknown'}, timestamp=${approved.timestamp}). This may roll the plan back to an earlier phase — verify before continuing.`,
-											);
-											return approved.plan;
-										}
-									} catch {
-										// Fall through to the stale-plan warning below
-									}
+					// Task 3.1: Ledger-aware rehydration guard
+					// If ledger exists and plan.json hash doesn't match latest ledger hash,
+					// the projection is stale — rebuild from ledger before returning.
+					// SCOPED TO STARTUP ONLY: Hash mismatches during active sessions are expected
+					// due to concurrent writes (save_plan + update_task_status). Only rebuild on
+					// first loadPlan() call per workspace per process lifetime.
+					if (await ledgerExists(directory)) {
+						const planHash = computePlanHash(validated);
+						const ledgerHash = await getLatestLedgerHash(directory);
+						const resolvedWorkspace = path.resolve(directory);
+						if (!startupLedgerCheckedWorkspaces.has(resolvedWorkspace)) {
+							startupLedgerCheckedWorkspaces.add(resolvedWorkspace);
+							if (ledgerHash !== '' && planHash !== ledgerHash) {
+								const currentPlanId = derivePlanId(validated);
+								const ledgerEvents = await readLedgerEvents(directory);
+								const firstEvent =
+									ledgerEvents.length > 0 ? ledgerEvents[0] : null;
+								if (firstEvent && firstEvent.plan_id !== currentPlanId) {
+									// Ledger is from a different plan identity — migration detected.
+									// Use the first event (plan_created anchor) as the authoritative identity,
+									// consistent with savePlan's archive guard which also uses events[0].
+									// Do not rebuild; plan.json is the authoritative post-migration state.
 									warn(
-										`[loadPlan] Ledger replay failed during hash-mismatch rebuild: ${replayError instanceof Error ? replayError.message : String(replayError)}. Returning stale plan.json. To recover: check .swarm/SWARM_PLAN.md for a checkpoint, or run /swarm reset-session.`,
+										`[loadPlan] Ledger identity mismatch (ledger: ${firstEvent.plan_id}, plan: ${currentPlanId}) — skipping ledger rebuild (migration detected). Use /swarm reset-session to reinitialize the ledger.`,
 									);
+								} else {
+									warn(
+										'[loadPlan] plan.json is stale (hash mismatch with ledger) — rebuilding from ledger. If this recurs, run /swarm reset-session to clear stale session state.',
+									);
+									try {
+										const rebuilt = await replayFromLedger(directory);
+										if (rebuilt) {
+											await rebuildPlan(directory, rebuilt, {
+												reason: 'ledger_hash_mismatch_recovery',
+											});
+											warn(
+												'[loadPlan] Rebuilt plan from ledger. Checkpoint available at .swarm/SWARM_PLAN.md if it exists.',
+											);
+											return rebuilt;
+										}
+									} catch (replayError) {
+										// Ledger replay failed — try the critic-approved immutable
+										// snapshot as a last-resort fallback before returning stale state.
+										//
+										// Identity guard: pass the current workspace's plan identity
+										// (derived from the still-loaded plan.json above) to prevent
+										// resurrecting a foreign approved snapshot from a reused directory.
+										try {
+											const approved = await loadLastApprovedPlan(
+												directory,
+												currentPlanId,
+											);
+											if (approved) {
+												await rebuildPlan(directory, approved.plan, {
+													reason: 'approved_snapshot_fallback',
+												});
+												// Heal the ledger tail so subsequent loadPlan calls don't
+												// loop back into this recovery path. The recovered plan is
+												// now the authoritative state; tag it as a fresh snapshot
+												// so replayFromLedger's walk-backward picks it up before
+												// hitting whatever event (plan_reset, corruption, ...)
+												// caused the original replay to fail.
+												try {
+													await takeSnapshotEvent(directory, approved.plan, {
+														source: 'recovery_from_approved_snapshot',
+														approvalMetadata: approved.approval,
+													});
+												} catch (healError) {
+													warn(
+														`[loadPlan] Recovery-heal snapshot append failed: ${healError instanceof Error ? healError.message : String(healError)}. Next loadPlan may re-enter recovery path.`,
+													);
+												}
+												const approvedPhase =
+													approved.approval &&
+													typeof approved.approval === 'object' &&
+													'phase' in approved.approval
+														? (approved.approval as { phase?: unknown }).phase
+														: undefined;
+												warn(
+													`[loadPlan] Ledger replay failed (${replayError instanceof Error ? replayError.message : String(replayError)}) — recovered from critic-approved snapshot seq=${approved.seq} (approval phase=${approvedPhase ?? 'unknown'}, timestamp=${approved.timestamp}). This may roll the plan back to an earlier phase — verify before continuing.`,
+												);
+												return approved.plan;
+											}
+										} catch {
+											// Fall through to the stale-plan warning below
+										}
+										warn(
+											`[loadPlan] Ledger replay failed during hash-mismatch rebuild: ${replayError instanceof Error ? replayError.message : String(replayError)}. Returning stale plan.json. To recover: check .swarm/SWARM_PLAN.md for a checkpoint, or run /swarm reset-session.`,
+										);
+									}
+									// Fall through and return the validated plan.json
 								}
-								// Fall through and return the validated plan.json
+							}
+						} else if (ledgerHash !== '' && planHash !== ledgerHash) {
+							// During active session: hash mismatch is expected due to concurrent writes.
+							if (process.env.DEBUG_SWARM) {
+								console.warn(
+									`[loadPlan] Ledger hash mismatch during active session for ${resolvedWorkspace} — skipping rebuild (startup check already performed).`,
+								);
 							}
 						}
-					} else if (ledgerHash !== '' && planHash !== ledgerHash) {
-						// During active session: hash mismatch is expected due to concurrent writes.
-						if (process.env.DEBUG_SWARM) {
-							console.warn(
-								`[loadPlan] Ledger hash mismatch during active session for ${resolvedWorkspace} — skipping rebuild (startup check already performed).`,
-							);
+					}
+					// Step 3: SPEC STALENESS CHECK
+					// Only check staleness if plan has a specHash (pre-feature plans are exempt)
+					if (validated.specHash) {
+						const staleResult = await isSpecStale(directory, validated);
+						if (staleResult.stale) {
+							// Cast to RuntimePlan to attach runtime staleness flags
+							const runtimePlan = validated as RuntimePlan;
+							runtimePlan._specStale = true;
+							runtimePlan._specStaleReason = staleResult.reason;
+
+							// Write spec-staleness.json
+							try {
+								const specStalenessPath = path.join(
+									directory,
+									'.swarm',
+									'spec-staleness.json',
+								);
+								await fsPromises.writeFile(
+									specStalenessPath,
+									JSON.stringify(
+										{
+											type: 'spec_stale_detected',
+											timestamp: new Date().toISOString(),
+											phase: validated.current_phase ?? 1,
+											specHash_plan: validated.specHash,
+											specHash_current: staleResult.currentHash ?? null,
+											reason: staleResult.reason,
+											planTitle: validated.title,
+										},
+										null,
+										2,
+									),
+									'utf-8',
+								);
+							} catch {
+								// Non-fatal: spec-staleness.json write failure does not block plan loading
+							}
+
+							// Emit spec_stale_detected to events.jsonl
+							try {
+								const eventsPath = path.join(
+									directory,
+									'.swarm',
+									'events.jsonl',
+								);
+								const event: SpecStaleDetectedEvent = {
+									type: 'spec_stale_detected',
+									timestamp: new Date().toISOString(),
+									phase: validated.current_phase ?? 1,
+									specHash_plan: validated.specHash,
+									specHash_current: staleResult.currentHash ?? null,
+									reason: staleResult.reason ?? 'unknown',
+									planTitle: validated.title,
+								};
+								await fsPromises.appendFile(
+									eventsPath,
+									`${JSON.stringify(event)}\n`,
+									'utf-8',
+								);
+							} catch {
+								// Non-fatal: event write failure does not block plan loading
+							}
 						}
 					}
+					return validated;
 				}
-				// Step 3: SPEC STALENESS CHECK
-				// Only check staleness if plan has a specHash (pre-feature plans are exempt)
-				if (validated.specHash) {
-					const staleResult = await isSpecStale(directory, validated);
-					if (staleResult.stale) {
-						// Cast to RuntimePlan to attach runtime staleness flags
-						const runtimePlan = validated as RuntimePlan;
-						runtimePlan._specStale = true;
-						runtimePlan._specStaleReason = staleResult.reason;
-
-						// Write spec-staleness.json
-						try {
-							const specStalenessPath = path.join(
-								directory,
-								'.swarm',
-								'spec-staleness.json',
-							);
-							await fsPromises.writeFile(
-								specStalenessPath,
-								JSON.stringify(
-									{
-										type: 'spec_stale_detected',
-										timestamp: new Date().toISOString(),
-										phase: validated.current_phase ?? 1,
-										specHash_plan: validated.specHash,
-										specHash_current: staleResult.currentHash ?? null,
-										reason: staleResult.reason,
-										planTitle: validated.title,
-									},
-									null,
-									2,
-								),
-								'utf-8',
-							);
-						} catch {
-							// Non-fatal: spec-staleness.json write failure does not block plan loading
-						}
-
-						// Emit spec_stale_detected to events.jsonl
-						try {
-							const eventsPath = path.join(directory, '.swarm', 'events.jsonl');
-							const event: SpecStaleDetectedEvent = {
-								type: 'spec_stale_detected',
-								timestamp: new Date().toISOString(),
-								phase: validated.current_phase ?? 1,
-								specHash_plan: validated.specHash,
-								specHash_current: staleResult.currentHash ?? null,
-								reason: staleResult.reason ?? 'unknown',
-								planTitle: validated.title,
-							};
-							await fsPromises.appendFile(
-								eventsPath,
-								`${JSON.stringify(event)}\n`,
-								'utf-8',
-							);
-						} catch {
-							// Non-fatal: event write failure does not block plan loading
-						}
-					}
-				}
-				return validated;
 			} catch (error) {
 				// Step 2: Validation failed, log warning and fall through to legacy
 				warn(

--- a/src/utils/swarm-artifact-cache.ts
+++ b/src/utils/swarm-artifact-cache.ts
@@ -1,0 +1,248 @@
+import * as fsSync from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+const MAX_CACHE_ENTRIES = 128;
+
+interface ArtifactStamp {
+	mtimeMs: number;
+	size: number;
+}
+
+interface TextCacheEntry extends ArtifactStamp {
+	value: string;
+}
+
+interface ParsedCacheEntry<T> extends ArtifactStamp {
+	value: T;
+}
+
+export interface SwarmArtifactCacheStats {
+	textReadCount: number;
+	textCacheHitCount: number;
+	textCacheMissCount: number;
+	parsedReadCount: number;
+	parseCount: number;
+	parsedCacheHitCount: number;
+	parsedCacheMissCount: number;
+	statFailureCount: number;
+	evictionCount: number;
+	textEntryCount: number;
+	parsedEntryCount: number;
+}
+
+const textCache = new Map<string, TextCacheEntry>();
+const parsedCache = new Map<string, ParsedCacheEntry<unknown>>();
+
+const stats: SwarmArtifactCacheStats = {
+	textReadCount: 0,
+	textCacheHitCount: 0,
+	textCacheMissCount: 0,
+	parsedReadCount: 0,
+	parseCount: 0,
+	parsedCacheHitCount: 0,
+	parsedCacheMissCount: 0,
+	statFailureCount: 0,
+	evictionCount: 0,
+	textEntryCount: 0,
+	parsedEntryCount: 0,
+};
+
+function sameStamp(a: ArtifactStamp, b: ArtifactStamp): boolean {
+	return a.mtimeMs === b.mtimeMs && a.size === b.size;
+}
+
+async function getStamp(filePath: string): Promise<ArtifactStamp | null> {
+	try {
+		const stat = await fs.stat(filePath);
+		if (!stat.isFile()) return null;
+		return { mtimeMs: stat.mtimeMs, size: stat.size };
+	} catch {
+		stats.statFailureCount++;
+		return null;
+	}
+}
+
+function getStampSync(filePath: string): ArtifactStamp | null {
+	try {
+		const stat = fsSync.statSync(filePath);
+		if (!stat.isFile()) return null;
+		return { mtimeMs: stat.mtimeMs, size: stat.size };
+	} catch {
+		stats.statFailureCount++;
+		return null;
+	}
+}
+
+// Freshness is intentionally keyed by stat metadata so hot hook paths can reuse
+// unchanged .swarm artifacts without holding file handles or blocking fail-open paths.
+function touchEntry<K, V>(cache: Map<K, V>, key: K, value: V): void {
+	cache.delete(key);
+	cache.set(key, value);
+}
+
+function setBounded<K, V>(cache: Map<K, V>, key: K, value: V): void {
+	touchEntry(cache, key, value);
+	while (cache.size > MAX_CACHE_ENTRIES) {
+		const oldest = cache.keys().next().value;
+		if (oldest === undefined) break;
+		cache.delete(oldest);
+		stats.evictionCount++;
+	}
+	stats.textEntryCount = textCache.size;
+	stats.parsedEntryCount = parsedCache.size;
+}
+
+export function cloneCachedValue<T>(value: T): T {
+	if (value === null || typeof value !== 'object') return value;
+	if (typeof structuredClone === 'function') {
+		return structuredClone(value);
+	}
+	return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function readCachedTextFileSync(
+	filePath: string,
+	directRead: () => string | null,
+): string | null {
+	const cacheKey = path.resolve(filePath);
+	const stamp = getStampSync(cacheKey);
+	if (!stamp) {
+		stats.textReadCount++;
+		return directRead();
+	}
+
+	const cached = textCache.get(cacheKey);
+	if (cached && sameStamp(cached, stamp)) {
+		stats.textCacheHitCount++;
+		touchEntry(textCache, cacheKey, cached);
+		return cached.value;
+	}
+
+	stats.textCacheMissCount++;
+	stats.textReadCount++;
+	const value = directRead();
+	if (value !== null) {
+		setBounded(textCache, cacheKey, { ...stamp, value });
+	}
+	return value;
+}
+
+export async function readCachedTextFile(
+	filePath: string,
+	directRead: () => Promise<string | null>,
+): Promise<string | null> {
+	const cacheKey = path.resolve(filePath);
+	const stamp = await getStamp(cacheKey);
+	if (!stamp) {
+		stats.textReadCount++;
+		return directRead();
+	}
+
+	const cached = textCache.get(cacheKey);
+	if (cached && sameStamp(cached, stamp)) {
+		stats.textCacheHitCount++;
+		touchEntry(textCache, cacheKey, cached);
+		return cached.value;
+	}
+
+	stats.textCacheMissCount++;
+	stats.textReadCount++;
+	const value = await directRead();
+	if (value !== null) {
+		setBounded(textCache, cacheKey, { ...stamp, value });
+	}
+	return value;
+}
+
+export function readCachedParsedFileSync<T>(
+	filePath: string,
+	namespace: string,
+	readText: () => string | null,
+	parse: (content: string) => T,
+): T | null {
+	const resolvedPath = path.resolve(filePath);
+	const cacheKey = `${resolvedPath}\0${namespace}`;
+	const stamp = getStampSync(resolvedPath);
+	if (!stamp) {
+		stats.parsedReadCount++;
+		const content = readText();
+		if (content === null) return null;
+		stats.parseCount++;
+		return parse(content);
+	}
+
+	const cached = parsedCache.get(cacheKey) as ParsedCacheEntry<T> | undefined;
+	if (cached && sameStamp(cached, stamp)) {
+		stats.parsedCacheHitCount++;
+		touchEntry(parsedCache, cacheKey, cached);
+		return cloneCachedValue(cached.value);
+	}
+
+	stats.parsedCacheMissCount++;
+	stats.parsedReadCount++;
+	const content = readText();
+	if (content === null) return null;
+	stats.parseCount++;
+	const value = parse(content);
+	setBounded(parsedCache, cacheKey, { ...stamp, value });
+	return cloneCachedValue(value);
+}
+
+export async function readCachedParsedFile<T>(
+	filePath: string,
+	namespace: string,
+	readText: () => Promise<string | null>,
+	parse: (content: string) => T,
+): Promise<T | null> {
+	const resolvedPath = path.resolve(filePath);
+	const cacheKey = `${resolvedPath}\0${namespace}`;
+	const stamp = await getStamp(resolvedPath);
+	if (!stamp) {
+		stats.parsedReadCount++;
+		const content = await readText();
+		if (content === null) return null;
+		stats.parseCount++;
+		return parse(content);
+	}
+
+	const cached = parsedCache.get(cacheKey) as ParsedCacheEntry<T> | undefined;
+	if (cached && sameStamp(cached, stamp)) {
+		stats.parsedCacheHitCount++;
+		touchEntry(parsedCache, cacheKey, cached);
+		return cloneCachedValue(cached.value);
+	}
+
+	stats.parsedCacheMissCount++;
+	stats.parsedReadCount++;
+	const content = await readText();
+	if (content === null) return null;
+	stats.parseCount++;
+	const value = parse(content);
+	setBounded(parsedCache, cacheKey, { ...stamp, value });
+	return cloneCachedValue(value);
+}
+
+export function resetSwarmArtifactCache(): void {
+	textCache.clear();
+	parsedCache.clear();
+	stats.textReadCount = 0;
+	stats.textCacheHitCount = 0;
+	stats.textCacheMissCount = 0;
+	stats.parsedReadCount = 0;
+	stats.parseCount = 0;
+	stats.parsedCacheHitCount = 0;
+	stats.parsedCacheMissCount = 0;
+	stats.statFailureCount = 0;
+	stats.evictionCount = 0;
+	stats.textEntryCount = 0;
+	stats.parsedEntryCount = 0;
+}
+
+export function getSwarmArtifactCacheStats(): SwarmArtifactCacheStats {
+	return {
+		...stats,
+		textEntryCount: textCache.size,
+		parsedEntryCount: parsedCache.size,
+	};
+}

--- a/src/utils/swarm-artifact-cache.ts
+++ b/src/utils/swarm-artifact-cache.ts
@@ -6,6 +6,7 @@ const MAX_CACHE_ENTRIES = 128;
 
 interface ArtifactStamp {
 	mtimeMs: number;
+	ctimeMs: number;
 	size: number;
 }
 
@@ -27,6 +28,9 @@ export interface SwarmArtifactCacheStats {
 	parsedCacheMissCount: number;
 	statFailureCount: number;
 	evictionCount: number;
+	textEvictionCount: number;
+	parsedEvictionCount: number;
+	cloneFallbackCount: number;
 	textEntryCount: number;
 	parsedEntryCount: number;
 }
@@ -44,19 +48,24 @@ const stats: SwarmArtifactCacheStats = {
 	parsedCacheMissCount: 0,
 	statFailureCount: 0,
 	evictionCount: 0,
+	textEvictionCount: 0,
+	parsedEvictionCount: 0,
+	cloneFallbackCount: 0,
 	textEntryCount: 0,
 	parsedEntryCount: 0,
 };
 
 function sameStamp(a: ArtifactStamp, b: ArtifactStamp): boolean {
-	return a.mtimeMs === b.mtimeMs && a.size === b.size;
+	return (
+		a.mtimeMs === b.mtimeMs && a.ctimeMs === b.ctimeMs && a.size === b.size
+	);
 }
 
 async function getStamp(filePath: string): Promise<ArtifactStamp | null> {
 	try {
 		const stat = await fs.stat(filePath);
 		if (!stat.isFile()) return null;
-		return { mtimeMs: stat.mtimeMs, size: stat.size };
+		return { mtimeMs: stat.mtimeMs, ctimeMs: stat.ctimeMs, size: stat.size };
 	} catch {
 		stats.statFailureCount++;
 		return null;
@@ -67,27 +76,41 @@ function getStampSync(filePath: string): ArtifactStamp | null {
 	try {
 		const stat = fsSync.statSync(filePath);
 		if (!stat.isFile()) return null;
-		return { mtimeMs: stat.mtimeMs, size: stat.size };
+		return { mtimeMs: stat.mtimeMs, ctimeMs: stat.ctimeMs, size: stat.size };
 	} catch {
 		stats.statFailureCount++;
 		return null;
 	}
 }
 
-// Freshness is intentionally keyed by stat metadata so hot hook paths can reuse
-// unchanged .swarm artifacts without holding file handles or blocking fail-open paths.
-function touchEntry<K, V>(cache: Map<K, V>, key: K, value: V): void {
-	cache.delete(key);
-	cache.set(key, value);
+// Freshness is keyed by stat metadata so hot hook paths can reuse unchanged
+// .swarm artifacts without holding file handles or blocking fail-open paths.
+// ctime is included with mtime+size to catch same-size rewrites on filesystems
+// whose mtime granularity can otherwise collapse rapid updates.
+function canStoreRead(
+	before: ArtifactStamp,
+	after: ArtifactStamp | null,
+): after is ArtifactStamp {
+	return after !== null && sameStamp(before, after);
 }
 
-function setBounded<K, V>(cache: Map<K, V>, key: K, value: V): void {
-	touchEntry(cache, key, value);
+function setBounded<K, V>(
+	cache: Map<K, V>,
+	key: K,
+	value: V,
+	cacheKind: 'text' | 'parsed',
+): void {
+	cache.set(key, value);
 	while (cache.size > MAX_CACHE_ENTRIES) {
 		const oldest = cache.keys().next().value;
 		if (oldest === undefined) break;
 		cache.delete(oldest);
 		stats.evictionCount++;
+		if (cacheKind === 'text') {
+			stats.textEvictionCount++;
+		} else {
+			stats.parsedEvictionCount++;
+		}
 	}
 	stats.textEntryCount = textCache.size;
 	stats.parsedEntryCount = parsedCache.size;
@@ -98,6 +121,9 @@ export function cloneCachedValue<T>(value: T): T {
 	if (typeof structuredClone === 'function') {
 		return structuredClone(value);
 	}
+	// Fallback is intentionally limited to JSON-compatible parsed artifacts.
+	// Current callers cache Plan JSON, knowledge JSONL, and spec/evidence JSON.
+	stats.cloneFallbackCount++;
 	return JSON.parse(JSON.stringify(value)) as T;
 }
 
@@ -115,15 +141,15 @@ export function readCachedTextFileSync(
 	const cached = textCache.get(cacheKey);
 	if (cached && sameStamp(cached, stamp)) {
 		stats.textCacheHitCount++;
-		touchEntry(textCache, cacheKey, cached);
 		return cached.value;
 	}
 
 	stats.textCacheMissCount++;
 	stats.textReadCount++;
 	const value = directRead();
-	if (value !== null) {
-		setBounded(textCache, cacheKey, { ...stamp, value });
+	const afterReadStamp = getStampSync(cacheKey);
+	if (value !== null && canStoreRead(stamp, afterReadStamp)) {
+		setBounded(textCache, cacheKey, { ...afterReadStamp, value }, 'text');
 	}
 	return value;
 }
@@ -142,15 +168,15 @@ export async function readCachedTextFile(
 	const cached = textCache.get(cacheKey);
 	if (cached && sameStamp(cached, stamp)) {
 		stats.textCacheHitCount++;
-		touchEntry(textCache, cacheKey, cached);
 		return cached.value;
 	}
 
 	stats.textCacheMissCount++;
 	stats.textReadCount++;
 	const value = await directRead();
-	if (value !== null) {
-		setBounded(textCache, cacheKey, { ...stamp, value });
+	const afterReadStamp = await getStamp(cacheKey);
+	if (value !== null && canStoreRead(stamp, afterReadStamp)) {
+		setBounded(textCache, cacheKey, { ...afterReadStamp, value }, 'text');
 	}
 	return value;
 }
@@ -175,7 +201,6 @@ export function readCachedParsedFileSync<T>(
 	const cached = parsedCache.get(cacheKey) as ParsedCacheEntry<T> | undefined;
 	if (cached && sameStamp(cached, stamp)) {
 		stats.parsedCacheHitCount++;
-		touchEntry(parsedCache, cacheKey, cached);
 		return cloneCachedValue(cached.value);
 	}
 
@@ -185,7 +210,10 @@ export function readCachedParsedFileSync<T>(
 	if (content === null) return null;
 	stats.parseCount++;
 	const value = parse(content);
-	setBounded(parsedCache, cacheKey, { ...stamp, value });
+	const afterReadStamp = getStampSync(resolvedPath);
+	if (canStoreRead(stamp, afterReadStamp)) {
+		setBounded(parsedCache, cacheKey, { ...afterReadStamp, value }, 'parsed');
+	}
 	return cloneCachedValue(value);
 }
 
@@ -209,7 +237,6 @@ export async function readCachedParsedFile<T>(
 	const cached = parsedCache.get(cacheKey) as ParsedCacheEntry<T> | undefined;
 	if (cached && sameStamp(cached, stamp)) {
 		stats.parsedCacheHitCount++;
-		touchEntry(parsedCache, cacheKey, cached);
 		return cloneCachedValue(cached.value);
 	}
 
@@ -219,7 +246,10 @@ export async function readCachedParsedFile<T>(
 	if (content === null) return null;
 	stats.parseCount++;
 	const value = parse(content);
-	setBounded(parsedCache, cacheKey, { ...stamp, value });
+	const afterReadStamp = await getStamp(resolvedPath);
+	if (canStoreRead(stamp, afterReadStamp)) {
+		setBounded(parsedCache, cacheKey, { ...afterReadStamp, value }, 'parsed');
+	}
 	return cloneCachedValue(value);
 }
 
@@ -235,6 +265,9 @@ export function resetSwarmArtifactCache(): void {
 	stats.parsedCacheMissCount = 0;
 	stats.statFailureCount = 0;
 	stats.evictionCount = 0;
+	stats.textEvictionCount = 0;
+	stats.parsedEvictionCount = 0;
+	stats.cloneFallbackCount = 0;
 	stats.textEntryCount = 0;
 	stats.parsedEntryCount = 0;
 }

--- a/tests/unit/hooks/utils.test.ts
+++ b/tests/unit/hooks/utils.test.ts
@@ -25,6 +25,10 @@ import {
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import {
+	getSwarmArtifactCacheStats,
+	resetSwarmArtifactCache,
+} from '../../../src/utils/swarm-artifact-cache';
 
 describe('Hook Utilities', () => {
 	afterEach(() => {
@@ -261,10 +265,12 @@ describe('Hook Utilities', () => {
 		let tempDir: string;
 
 		beforeEach(async () => {
+			resetSwarmArtifactCache();
 			tempDir = await mkdtemp(join(tmpdir(), 'swarm-test-'));
 		});
 
 		afterEach(async () => {
+			resetSwarmArtifactCache();
 			try {
 				await rm(tempDir, { recursive: true, force: true });
 			} catch (error) {
@@ -338,6 +344,32 @@ describe('Hook Utilities', () => {
 		it('returns null when filename contains null bytes', async () => {
 			const result = await readSwarmFileAsync(tempDir, 'test\0file.txt');
 			expect(result).toBeNull();
+		});
+
+		it('reuses unchanged file content and invalidates after rewrite', async () => {
+			const swarmDir = join(tempDir, '.swarm');
+			await mkdir(swarmDir, { recursive: true });
+			const testFile = join(swarmDir, 'cached.txt');
+
+			await writeFile(testFile, 'cached-content');
+			expect(await readSwarmFileAsync(tempDir, 'cached.txt')).toBe(
+				'cached-content',
+			);
+			expect(await readSwarmFileAsync(tempDir, 'cached.txt')).toBe(
+				'cached-content',
+			);
+
+			let stats = getSwarmArtifactCacheStats();
+			expect(stats.textReadCount).toBe(1);
+			expect(stats.textCacheHitCount).toBe(1);
+
+			await writeFile(testFile, 'rewritten-content-is-longer');
+			expect(await readSwarmFileAsync(tempDir, 'cached.txt')).toBe(
+				'rewritten-content-is-longer',
+			);
+
+			stats = getSwarmArtifactCacheStats();
+			expect(stats.textReadCount).toBe(2);
 		});
 	});
 

--- a/tests/unit/plan/manager.test.ts
+++ b/tests/unit/plan/manager.test.ts
@@ -13,6 +13,10 @@ import {
 	savePlan,
 	updateTaskStatus,
 } from '../../../src/plan/manager';
+import {
+	getSwarmArtifactCacheStats,
+	resetSwarmArtifactCache,
+} from '../../../src/utils/swarm-artifact-cache';
 
 function createTestPlan(overrides?: Partial<Plan>): Plan {
 	return {
@@ -58,10 +62,12 @@ describe('loadPlanJsonOnly', () => {
 	let tempDir: string;
 
 	beforeEach(async () => {
+		resetSwarmArtifactCache();
 		tempDir = await mkdtemp(join(tmpdir(), 'opencode-swarm-test-'));
 	});
 
 	afterEach(async () => {
+		resetSwarmArtifactCache();
 		if (existsSync(tempDir)) {
 			await rm(tempDir, { recursive: true, force: true });
 		}
@@ -108,16 +114,43 @@ describe('loadPlanJsonOnly', () => {
 		const result = await loadPlanJsonOnly(tempDir);
 		expect(result).toBeNull();
 	});
+
+	test('reuses parsed plan.json until mtime or size changes', async () => {
+		const testPlan = createTestPlan();
+		await writePlanJson(tempDir, testPlan);
+
+		const first = await loadPlanJsonOnly(tempDir);
+		const second = await loadPlanJsonOnly(tempDir);
+
+		expect(first).toEqual(testPlan);
+		expect(second).toEqual(testPlan);
+		let stats = getSwarmArtifactCacheStats();
+		expect(stats.parsedReadCount).toBe(1);
+		expect(stats.parseCount).toBe(1);
+		expect(stats.parsedCacheHitCount).toBe(1);
+
+		const rewrittenPlan = createTestPlan({ title: 'Rewritten Test Plan' });
+		await writePlanJson(tempDir, rewrittenPlan);
+
+		const third = await loadPlanJsonOnly(tempDir);
+
+		expect(third).toEqual(rewrittenPlan);
+		stats = getSwarmArtifactCacheStats();
+		expect(stats.parsedReadCount).toBe(2);
+		expect(stats.parseCount).toBe(2);
+	});
 });
 
 describe('loadPlan (auto-heal behavior)', () => {
 	let tempDir: string;
 
 	beforeEach(async () => {
+		resetSwarmArtifactCache();
 		tempDir = await mkdtemp(join(tmpdir(), 'opencode-swarm-test-'));
 	});
 
 	afterEach(async () => {
+		resetSwarmArtifactCache();
 		if (existsSync(tempDir)) {
 			await rm(tempDir, { recursive: true, force: true });
 		}
@@ -134,6 +167,22 @@ describe('loadPlan (auto-heal behavior)', () => {
 		const result = await loadPlan(tempDir);
 		expect(result).not.toBeNull();
 		expect(result).toEqual(testPlan);
+	});
+
+	test('shares parsed plan.json between loadPlanJsonOnly and loadPlan', async () => {
+		const testPlan = createTestPlan();
+		await writePlanJson(tempDir, testPlan);
+		await writePlanMd(tempDir, derivePlanMarkdown(testPlan));
+
+		const lightweight = await loadPlanJsonOnly(tempDir);
+		const full = await loadPlan(tempDir);
+
+		expect(lightweight).toEqual(testPlan);
+		expect(full).toEqual(testPlan);
+		const stats = getSwarmArtifactCacheStats();
+		expect(stats.parsedReadCount).toBe(1);
+		expect(stats.parseCount).toBe(1);
+		expect(stats.parsedCacheHitCount).toBeGreaterThanOrEqual(1);
 	});
 
 	// ====== Auto-heal tests (Task 5.1) ======

--- a/tests/unit/utils/swarm-artifact-cache.test.ts
+++ b/tests/unit/utils/swarm-artifact-cache.test.ts
@@ -1,9 +1,17 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+	mkdtemp,
+	readFile,
+	rm,
+	stat,
+	utimes,
+	writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+	cloneCachedValue,
 	getSwarmArtifactCacheStats,
 	readCachedParsedFile,
 	readCachedParsedFileSync,
@@ -41,6 +49,23 @@ describe('swarm-artifact-cache', () => {
 		expect(await readCachedTextFile(filePath, read)).toBe('two-two');
 
 		stats = getSwarmArtifactCacheStats();
+		expect(stats.textReadCount).toBe(2);
+		expect(stats.textCacheMissCount).toBe(2);
+	});
+
+	test('invalidates same-size rewrites even when mtime is restored', async () => {
+		const filePath = join(tempDir, 'knowledge.jsonl');
+		await writeFile(filePath, 'one', 'utf-8');
+		const originalStat = await stat(filePath);
+
+		const read = () => readFile(filePath, 'utf-8');
+		expect(await readCachedTextFile(filePath, read)).toBe('one');
+
+		await writeFile(filePath, 'two', 'utf-8');
+		await utimes(filePath, originalStat.atime, originalStat.mtime);
+
+		expect(await readCachedTextFile(filePath, read)).toBe('two');
+		const stats = getSwarmArtifactCacheStats();
 		expect(stats.textReadCount).toBe(2);
 		expect(stats.textCacheMissCount).toBe(2);
 	});
@@ -130,5 +155,86 @@ describe('swarm-artifact-cache', () => {
 		expect(stats.parsedReadCount).toBe(1);
 		expect(stats.parseCount).toBe(1);
 		expect(stats.parsedCacheHitCount).toBe(1);
+	});
+
+	test('does not cache a parsed read when the file changes during the read', async () => {
+		const filePath = join(tempDir, 'racy-plan.json');
+		await writeFile(filePath, '{"value":"old"}', 'utf-8');
+
+		const first = await readCachedParsedFile(
+			filePath,
+			'race-test',
+			async () => {
+				const content = await readFile(filePath, 'utf-8');
+				await writeFile(filePath, '{"value":"new"}', 'utf-8');
+				return content;
+			},
+			(content) => JSON.parse(content) as { value: string },
+		);
+
+		expect(first?.value).toBe('old');
+		let stats = getSwarmArtifactCacheStats();
+		expect(stats.parsedEntryCount).toBe(0);
+		expect(stats.parseCount).toBe(1);
+
+		const second = await readCachedParsedFile(
+			filePath,
+			'race-test',
+			() => readFile(filePath, 'utf-8'),
+			(content) => JSON.parse(content) as { value: string },
+		);
+
+		expect(second?.value).toBe('new');
+		stats = getSwarmArtifactCacheStats();
+		expect(stats.parsedEntryCount).toBe(1);
+		expect(stats.parseCount).toBe(2);
+	});
+
+	test('keeps FIFO eviction stable after cache hits', async () => {
+		const paths = Array.from({ length: 129 }, (_, index) =>
+			join(tempDir, `artifact-${index}.md`),
+		);
+		for (const [index, filePath] of paths.entries()) {
+			await writeFile(filePath, `value-${index}`, 'utf-8');
+		}
+
+		for (let index = 0; index < 128; index++) {
+			const filePath = paths[index]!;
+			await readCachedTextFile(filePath, () => readFile(filePath, 'utf-8'));
+		}
+		expect(
+			await readCachedTextFile(paths[0]!, () => readFile(paths[0]!, 'utf-8')),
+		).toBe('value-0');
+
+		await readCachedTextFile(paths[128]!, () => readFile(paths[128]!, 'utf-8'));
+		let stats = getSwarmArtifactCacheStats();
+		expect(stats.evictionCount).toBe(1);
+		expect(stats.textEvictionCount).toBe(1);
+		expect(stats.parsedEvictionCount).toBe(0);
+
+		expect(
+			await readCachedTextFile(paths[0]!, () => readFile(paths[0]!, 'utf-8')),
+		).toBe('value-0');
+		stats = getSwarmArtifactCacheStats();
+		expect(stats.textReadCount).toBe(130);
+		expect(stats.textCacheMissCount).toBe(130);
+	});
+
+	test('counts JSON-compatible clone fallback when structuredClone is unavailable', () => {
+		const mutableGlobal = globalThis as typeof globalThis & {
+			structuredClone?: typeof structuredClone;
+		};
+		const originalStructuredClone = mutableGlobal.structuredClone;
+		try {
+			mutableGlobal.structuredClone = undefined;
+			const cloned = cloneCachedValue({ nested: { value: 'kept' } });
+			cloned.nested.value = 'mutated';
+
+			expect(cloned.nested.value).toBe('mutated');
+			const stats = getSwarmArtifactCacheStats();
+			expect(stats.cloneFallbackCount).toBe(1);
+		} finally {
+			mutableGlobal.structuredClone = originalStructuredClone;
+		}
 	});
 });

--- a/tests/unit/utils/swarm-artifact-cache.test.ts
+++ b/tests/unit/utils/swarm-artifact-cache.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	getSwarmArtifactCacheStats,
+	readCachedParsedFile,
+	readCachedParsedFileSync,
+	readCachedTextFile,
+	readCachedTextFileSync,
+	resetSwarmArtifactCache,
+} from '../../../src/utils/swarm-artifact-cache';
+
+describe('swarm-artifact-cache', () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		resetSwarmArtifactCache();
+		tempDir = await mkdtemp(join(tmpdir(), 'swarm-artifact-cache-'));
+	});
+
+	afterEach(async () => {
+		resetSwarmArtifactCache();
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	test('reuses unchanged text reads and invalidates when size changes', async () => {
+		const filePath = join(tempDir, 'plan.md');
+		await writeFile(filePath, 'one', 'utf-8');
+
+		const read = () => readFile(filePath, 'utf-8');
+		expect(await readCachedTextFile(filePath, read)).toBe('one');
+		expect(await readCachedTextFile(filePath, read)).toBe('one');
+
+		let stats = getSwarmArtifactCacheStats();
+		expect(stats.textReadCount).toBe(1);
+		expect(stats.textCacheHitCount).toBe(1);
+
+		await writeFile(filePath, 'two-two', 'utf-8');
+		expect(await readCachedTextFile(filePath, read)).toBe('two-two');
+
+		stats = getSwarmArtifactCacheStats();
+		expect(stats.textReadCount).toBe(2);
+		expect(stats.textCacheMissCount).toBe(2);
+	});
+
+	test('falls back to the direct reader when stat fails', async () => {
+		const missingPath = join(tempDir, 'missing.md');
+
+		const result = await readCachedTextFile(
+			missingPath,
+			async () => 'fallback',
+		);
+
+		expect(result).toBe('fallback');
+		const stats = getSwarmArtifactCacheStats();
+		expect(stats.statFailureCount).toBe(1);
+		expect(stats.textReadCount).toBe(1);
+	});
+
+	test('shares cache behavior for synchronous text and parsed reads', async () => {
+		const textPath = join(tempDir, 'context.md');
+		const jsonPath = join(tempDir, 'spec-staleness.json');
+		await writeFile(textPath, 'context-one', 'utf-8');
+		await writeFile(
+			jsonPath,
+			'{"specHash_plan":"a","specHash_current":null}',
+			'utf-8',
+		);
+
+		expect(
+			readCachedTextFileSync(textPath, () => readFileSync(textPath, 'utf-8')),
+		).toBe('context-one');
+		expect(
+			readCachedTextFileSync(textPath, () => readFileSync(textPath, 'utf-8')),
+		).toBe('context-one');
+
+		const first = readCachedParsedFileSync(
+			jsonPath,
+			'sync-json',
+			() => readFileSync(jsonPath, 'utf-8'),
+			(content) => JSON.parse(content) as { specHash_plan: string },
+		);
+		const second = readCachedParsedFileSync(
+			jsonPath,
+			'sync-json',
+			() => readFileSync(jsonPath, 'utf-8'),
+			(content) => JSON.parse(content) as { specHash_plan: string },
+		);
+
+		expect(first?.specHash_plan).toBe('a');
+		expect(second?.specHash_plan).toBe('a');
+		const stats = getSwarmArtifactCacheStats();
+		expect(stats.textReadCount).toBe(1);
+		expect(stats.textCacheHitCount).toBe(1);
+		expect(stats.parsedReadCount).toBe(1);
+		expect(stats.parsedCacheHitCount).toBe(1);
+	});
+
+	test('caches parsed values and returns clones to prevent cache poisoning', async () => {
+		const filePath = join(tempDir, 'knowledge.json');
+		await writeFile(filePath, '{"items":[{"id":"a"}]}', 'utf-8');
+		let parseCount = 0;
+
+		const parse = (content: string) => {
+			parseCount++;
+			return JSON.parse(content) as { items: Array<{ id: string }> };
+		};
+
+		const first = await readCachedParsedFile(
+			filePath,
+			'json-test',
+			() => readFile(filePath, 'utf-8'),
+			parse,
+		);
+		expect(first?.items[0]?.id).toBe('a');
+		first!.items[0]!.id = 'mutated';
+
+		const second = await readCachedParsedFile(
+			filePath,
+			'json-test',
+			() => readFile(filePath, 'utf-8'),
+			parse,
+		);
+
+		expect(second?.items[0]?.id).toBe('a');
+		expect(parseCount).toBe(1);
+		const stats = getSwarmArtifactCacheStats();
+		expect(stats.parsedReadCount).toBe(1);
+		expect(stats.parseCount).toBe(1);
+		expect(stats.parsedCacheHitCount).toBe(1);
+	});
+});


### PR DESCRIPTION
Closes #1276.

## Summary

- Added a bounded stat-metadata keyed read-through cache for hot `.swarm` artifact reads in chat/system injection paths.
- Wired the cache through raw `.swarm` reads, parsed `plan.json`, knowledge JSONL, spec-staleness JSON, coder evidence reads, and the skill index `context.md` read.
- Preserved fail-open behavior on stat/read/parse failures, clone parsed cache returns to prevent caller mutation from poisoning cached values, and avoid caching reads when the file changes during the read.
- Addressed PR feedback by catching same-size rewrites with `ctime`, preserving documented FIFO eviction, splitting text/parsed eviction stats, documenting/counting the JSON clone fallback, and removing the `plan.json disappeared during cached parse` throw path.
- Fixed two validation-blocking regressions in the touched surfaces: reviewer `SKILL_COMPLIANCE` verdict capture no longer requires a trailing space, and the architect prompt again contains the `6k. SPEC-STALENESS GUARD` contract.

## Read-count evidence

- Raw `.swarm` reads: focused tests verify two unchanged `readSwarmFileAsync` calls now produce `textReadCount = 1` and `textCacheHitCount = 1`; after rewrite, `textReadCount = 2`.
- Parsed plan reads: focused tests verify repeated `loadPlanJsonOnly` calls produce `parsedReadCount = 1`, `parseCount = 1`, and `parsedCacheHitCount = 1`; after rewrite, counts become `2`.
- Pipeline plan sharing: `loadPlanJsonOnly` followed by `loadPlan` shares the same parsed plan with `parsedReadCount = 1`, `parseCount = 1`, and a parsed cache hit.
- Knowledge JSONL reads: focused tests verify repeated `readKnowledge` calls parse once, return cloned entries, and invalidate after rewrite.

## PR feedback closeout

- Cubic P2 stale same-size reads: fixed by extending cache stamps from `mtimeMs + size` to `mtimeMs + ctimeMs + size`; `invalidates same-size rewrites even when mtime is restored` proves the rewrite is observed.
- Cubic P2 FIFO/LRU drift: fixed by removing cache-hit reordering and keeping eviction insertion-order FIFO; `keeps FIFO eviction stable after cache hits` proves a hit on the oldest entry does not spare it from eviction.
- Cubic P2 plan parse TOCTOU: fixed by moving `parsePlanJsonCached` to a cache-owned direct read and by re-statting after direct reads before storing entries; `does not cache a parsed read when the file changes during the read` proves stale pre-change content is not cached.
- Hermes medium disappearance path: fixed by changing `parsePlanJsonCached` to return `Plan | null` from the shared cache reader instead of throwing `plan.json disappeared during cached parse`.
- Hermes medium stats ambiguity: fixed by adding `textEvictionCount` and `parsedEvictionCount` while preserving aggregate `evictionCount`.
- Hermes low clone fallback concern: fixed by documenting the fallback as JSON-compatible only and adding `cloneFallbackCount`; `counts JSON-compatible clone fallback when structuredClone is unavailable` covers the fallback.
- Hermes Bun/Node compatibility risk: re-verified with `bun run build` and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`.

## Invariant audit

- 1 (plugin init): not touched - no plugin init/startup path changes; `bun run build` and Node ESM import passed.
- 2 (runtime portability): touched - new cache utility is in the plugin bundle and uses Node APIs only; `bun run build` and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` passed after the PR-feedback hardening.
- 3 (subprocesses): not touched - no subprocess calls added or changed.
- 4 (.swarm containment): touched - cache wraps existing `.swarm` artifact reads; `readSwarmFileAsync` still validates paths and focused tests cover traversal rejection.
- 5 (plan durability): touched - plan cache wraps `plan.json` parse/validation only and now avoids caching content if the file changes during a read; `tests/unit/plan/manager.test.ts` and `tests/unit/utils/swarm-artifact-cache.test.ts` passed.
- 6 (test_runner safety): not touched - validation used shell/Bun commands, not broad OpenCode `test_runner`.
- 7 (test writing): touched - loaded writing-tests workflow; new and changed tests use `bun:test`, temp dirs, and DI/stat seams without `mock.module`.
- 8 (session state): touched - added bounded module-level cache with `MAX_CACHE_ENTRIES = 128`, FIFO eviction, per-cache eviction stats, reset/stats helpers, and tests covering reuse/invalidation/FIFO eviction.
- 9 (guardrails/retry): not touched - no retry/guardrail behavior changed.
- 10 (chat/system msg): touched - injection hook reads now use the cache and architect prompt spec-staleness guidance was restored; `system-enhancer`, `spec-drift-advisory`, and architect prompt tests passed.
- 11 (tool registration): not touched - no tool additions, removals, or agent tool-map changes.
- 12 (release/cache): touched - added `docs/releases/pending/1276-swarm-artifact-cache.md`; no OpenCode plugin cache layout behavior changed.

## Test plan

- `bun --smol test tests\unit\utils\swarm-artifact-cache.test.ts --timeout 30000`
- `bun --smol test tests\unit\hooks\utils.test.ts --timeout 30000`
- `bun --smol test tests\unit\plan\manager.test.ts --timeout 30000`
- `bun --smol test tests\unit\hooks\knowledge-store.test.ts --timeout 30000`
- `bun --smol test tests\unit\hooks\skill-propagation-gate.test.ts --timeout 30000`
- `bun --smol test tests\unit\hooks\system-enhancer-coder-context.test.ts --timeout 30000`
- `bun --smol test tests\unit\hooks\system-enhancer-retro.test.ts --timeout 30000`
- `bun --smol test tests\unit\services\context-budget-service.test.ts --timeout 30000`
- `bun --smol test tests\unit\hooks\spec-drift-advisory.test.ts --timeout 30000`
- `bun --smol test .\tests\unit\skills\architect-mode-protocols.test.ts --timeout 30000`
- `bun --smol test .\tests\unit\skills\architect-pipeline-integration.test.ts --timeout 30000`
- `bun --smol test .\tests\unit\agents\architect-spec-gate-adversarial.test.ts --timeout 30000`
- `bun --smol test .\tests\unit\agents\architect-workflow-security.test.ts --timeout 30000`
- `bun --smol test tests\unit\agents\architect-prompt-regression.test.ts --timeout 30000`
- `bun --smol test tests\unit\agents\architect-prompt-markers.test.ts --timeout 30000`
- `bun --smol test tests\unit\agents\architect.test.ts --timeout 30000`
- `bun run typecheck`
- `bunx biome ci .`
- `git diff --check HEAD~1..HEAD`
- `bun run build`
- `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
