### PR TITLE
fix(test-engineer): expand cross-language write authority

### DIFF
--- a/docs/releases/pending/1303-test-engineer-write-scope.md
+++ b/docs/releases/pending/1303-test-engineer-write-scope.md
@@ -17,6 +17,13 @@ retry loops. Three root causes were fixed:
 3. **Cross-language test file patterns added to write authority** - the
    `test_engineer` authority rules now recognize the test-file conventions
    advertised in the agent prompt, including Python `test_*.py` / `*_test.py`,
-   Go `*_test.go`, Ruby `*_spec.rb`, JUnit `*Test.java`, C# `*Tests.cs`, and
-   PowerShell `*.Tests.ps1`. These paths remain blocked in generated output
-   directories such as `dist/` and `build/`.
+   Go `*_test.go`, Ruby `*_spec.rb`, JUnit `*Test.java`, Kotlin `*Test.kt`,
+   C# `*Tests.cs`, and PowerShell `*.Tests.ps1`. These paths remain blocked in
+   generated output directories such as `dist/` and `build/`. Java, Kotlin, and
+   C# suffix patterns are matched case-sensitively to avoid false matches like
+   `Contest.java` or `Contests.cs` on Windows/macOS, and the glob matcher cache
+   now keys entries by case mode as well as pattern.
+
+   Custom `authority.rules.<agent>.allowedCaseSensitiveGlobs` values follow the
+   same replacement semantics as the existing authority array fields; setting an
+   empty array intentionally clears the default case-sensitive suffix allowlist.

--- a/docs/releases/pending/1303-test-engineer-write-scope.md
+++ b/docs/releases/pending/1303-test-engineer-write-scope.md
@@ -1,7 +1,7 @@
 # fix: test_engineer can now write test files (issue #1303, PR #1305)
 
 The `test_engineer` agent was unable to write test files and would fall into
-retry loops. Two root causes were fixed:
+retry loops. Three root causes were fixed:
 
 1. **`apply_patch` added to test_engineer's tool map** — `apply_patch` (the
    plugin's unified-diff write tool) was only registered for `coder`. Adding it
@@ -13,3 +13,10 @@ retry loops. Two root causes were fixed:
    with the target test file paths before any `test_engineer` delegation that
    will write new test files. This mirrors the existing coder scope discipline
    and prevents scope-guard blocks in sessions where a task ID is active.
+
+3. **Cross-language test file patterns added to write authority** - the
+   `test_engineer` authority rules now recognize the test-file conventions
+   advertised in the agent prompt, including Python `test_*.py` / `*_test.py`,
+   Go `*_test.go`, Ruby `*_spec.rb`, JUnit `*Test.java`, C# `*Tests.cs`, and
+   PowerShell `*.Tests.ps1`. These paths remain blocked in generated output
+   directories such as `dist/` and `build/`.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1368,6 +1368,7 @@ export const AgentAuthorityRuleSchema = z.object({
 		.optional(),
 	blockedGlobs: z.array(z.string()).optional(),
 	allowedGlobs: z.array(z.string()).optional(),
+	allowedCaseSensitiveGlobs: z.array(z.string()).optional(),
 });
 
 export type AgentAuthorityRule = z.infer<typeof AgentAuthorityRuleSchema>;

--- a/src/hooks/guardrails/file-authority.ts
+++ b/src/hooks/guardrails/file-authority.ts
@@ -668,6 +668,8 @@ export function checkFileAuthorityWithRules(
 		}
 	}
 
+	// Step 6b: allowedCaseSensitiveGlobs - explicit allow for language suffix
+	// conventions that must not use Windows/macOS nocase matching.
 	if (
 		rules.allowedCaseSensitiveGlobs &&
 		rules.allowedCaseSensitiveGlobs.length > 0

--- a/src/hooks/guardrails/file-authority.ts
+++ b/src/hooks/guardrails/file-authority.ts
@@ -138,7 +138,7 @@ const pathNormalizationCache = new QuickLRU<string, string>({
 
 /**
  * LRU cache for compiled picomatch matchers.
- * Maps glob pattern -> matcher function.
+ * Maps glob pattern + case-sensitivity mode -> matcher function.
  */
 const globMatcherCache = new QuickLRU<string, (path: string) => boolean>({
 	maxSize: 200,
@@ -204,7 +204,8 @@ export function getGlobMatcher(
 	caseInsensitive = process.platform === 'win32' ||
 		process.platform === 'darwin',
 ): (path: string) => boolean {
-	const cached = globMatcherCache.get(pattern);
+	const cacheKey = `${caseInsensitive ? 'nocase' : 'case'}\0${pattern}`;
+	const cached = globMatcherCache.get(cacheKey);
 	if (cached !== undefined) {
 		return cached;
 	}
@@ -216,7 +217,7 @@ export function getGlobMatcher(
 			nocase: caseInsensitive, // Case-insensitive on Windows/macOS
 		});
 
-		globMatcherCache.set(pattern, matcher);
+		globMatcherCache.set(cacheKey, matcher);
 
 		return matcher;
 	} catch (err) {
@@ -235,6 +236,7 @@ export type AgentRule = {
 	blockedZones?: FileZone[];
 	blockedGlobs?: string[];
 	allowedGlobs?: string[];
+	allowedCaseSensitiveGlobs?: string[];
 };
 
 export const DEFAULT_AGENT_AUTHORITY_RULES: Record<string, AgentRule> = {
@@ -286,12 +288,12 @@ export const DEFAULT_AGENT_AUTHORITY_RULES: Record<string, AgentRule> = {
 		allowedPrefix: ['tests/', 'test/', '.swarm/evidence/'],
 		// v7.x (#bug-test-engineer-write-access): allow writes to any tests/test
 		// directory at any depth (e.g. src-tauri/tests/, packages/foo/test/) and
-		// to any .test.* / .spec.* file so that projects with non-root test
-		// layouts are not blocked. allowedGlobs runs at Step 6, BEFORE blockedPrefix
+		// to common framework test-file conventions so that projects with non-root
+		// test layouts are not blocked. allowedGlobs runs at Step 6, BEFORE blockedPrefix
 		// at Step 7; this ordering is intentional — it means test files inside a
-		// blocked directory like src/ (e.g. src/__tests__/, src/auth/login.test.ts)
+		// blocked directory like src/ (e.g. src/__tests__/, src/auth/test_login.py)
 		// are explicitly re-allowed by the glob before blockedPrefix can deny them.
-		// NOTE: blockedZones runs at Step 5, BEFORE allowedGlobs, so test files
+		// NOTE: blockedZones runs at Step 5, BEFORE allowed globs, so test files
 		// inside generated output dirs (dist/, build/) are still blocked.
 		allowedGlobs: [
 			'**/tests/**',
@@ -299,6 +301,27 @@ export const DEFAULT_AGENT_AUTHORITY_RULES: Record<string, AgentRule> = {
 			'**/__tests__/**',
 			'**/*.test.*',
 			'**/*.spec.*',
+			'test_*.py',
+			'**/test_*.py',
+			'*_test.py',
+			'**/*_test.py',
+			'*_test.go',
+			'**/*_test.go',
+			'*_spec.rb',
+			'**/*_spec.rb',
+			'*.Tests.ps1',
+			'**/*.Tests.ps1',
+		],
+		// Language class suffixes must remain case-sensitive even on Windows/macOS:
+		// case-insensitive "*Test.java" matches Contest.java, and "*Tests.cs"
+		// matches Contests.cs.
+		allowedCaseSensitiveGlobs: [
+			'*Test.java',
+			'**/*Test.java',
+			'*Test.kt',
+			'**/*Test.kt',
+			'*Tests.cs',
+			'**/*Tests.cs',
 		],
 		blockedZones: ['generated'],
 	},
@@ -433,6 +456,9 @@ export function buildEffectiveRules(
 			blockedZones: userRule.blockedZones ?? existing.blockedZones,
 			blockedGlobs: userRule.blockedGlobs ?? existing.blockedGlobs,
 			allowedGlobs: userRule.allowedGlobs ?? existing.allowedGlobs,
+			allowedCaseSensitiveGlobs:
+				userRule.allowedCaseSensitiveGlobs ??
+				existing.allowedCaseSensitiveGlobs,
 		};
 	}
 	return merged;
@@ -638,6 +664,21 @@ export function checkFileAuthorityWithRules(
 			return matcher(normalizedPath);
 		});
 		if (isGlobAllowed) {
+			return { allowed: true };
+		}
+	}
+
+	if (
+		rules.allowedCaseSensitiveGlobs &&
+		rules.allowedCaseSensitiveGlobs.length > 0
+	) {
+		const isCaseSensitiveGlobAllowed = rules.allowedCaseSensitiveGlobs.some(
+			(glob) => {
+				const matcher = getGlobMatcher(glob, false);
+				return matcher(normalizedPath);
+			},
+		);
+		if (isCaseSensitiveGlobAllowed) {
 			return { allowed: true };
 		}
 	}

--- a/tests/unit/hooks/guardrails-authority.test.ts
+++ b/tests/unit/hooks/guardrails-authority.test.ts
@@ -9,8 +9,10 @@ import {
 } from '../../../src/config/schema';
 import {
 	checkFileAuthority,
+	clearGuardrailsCaches,
 	createGuardrailsHooks,
 	DEFAULT_AGENT_AUTHORITY_RULES,
+	getGlobMatcher,
 } from '../../../src/hooks/guardrails';
 import {
 	beginInvocation,
@@ -392,6 +394,78 @@ describe('guardrails-authority - File Authority Enforcement', () => {
 			expect(result.allowed).toBe(true);
 		});
 
+		it('allows test_engineer to write Python test_*.py files under src/', () => {
+			const result = checkFileAuthority(
+				'test_engineer',
+				'src/auth/test_login.py',
+				tempDir,
+			);
+			expect(result.allowed).toBe(true);
+		});
+
+		it('allows test_engineer to write Python *_test.py files under src/', () => {
+			const result = checkFileAuthority(
+				'test_engineer',
+				'src/auth/login_test.py',
+				tempDir,
+			);
+			expect(result.allowed).toBe(true);
+		});
+
+		it('allows test_engineer to write Go *_test.go files beside source', () => {
+			const result = checkFileAuthority(
+				'test_engineer',
+				'cmd/server/main_test.go',
+				tempDir,
+			);
+			expect(result.allowed).toBe(true);
+		});
+
+		it('allows test_engineer to write Ruby *_spec.rb files beside source', () => {
+			const result = checkFileAuthority(
+				'test_engineer',
+				'app/models/user_spec.rb',
+				tempDir,
+			);
+			expect(result.allowed).toBe(true);
+		});
+
+		it('allows test_engineer to write JUnit *Test.java files beside source', () => {
+			const result = checkFileAuthority(
+				'test_engineer',
+				'src/main/java/com/example/UserServiceTest.java',
+				tempDir,
+			);
+			expect(result.allowed).toBe(true);
+		});
+
+		it('allows test_engineer to write Kotlin *Test.kt files beside source', () => {
+			const result = checkFileAuthority(
+				'test_engineer',
+				'src/main/kotlin/com/example/UserServiceTest.kt',
+				tempDir,
+			);
+			expect(result.allowed).toBe(true);
+		});
+
+		it('allows test_engineer to write C# *Tests.cs files beside source', () => {
+			const result = checkFileAuthority(
+				'test_engineer',
+				'src/Services/UserServiceTests.cs',
+				tempDir,
+			);
+			expect(result.allowed).toBe(true);
+		});
+
+		it('allows test_engineer to write PowerShell *.Tests.ps1 files beside source', () => {
+			const result = checkFileAuthority(
+				'test_engineer',
+				'scripts/UserService.Tests.ps1',
+				tempDir,
+			);
+			expect(result.allowed).toBe(true);
+		});
+
 		it('blocks test_engineer from writing to src/ production files (no test marker)', () => {
 			const result = checkFileAuthority(
 				'test_engineer',
@@ -401,6 +475,59 @@ describe('guardrails-authority - File Authority Enforcement', () => {
 			expect(result.allowed).toBe(false);
 			if (isDenied(result)) {
 				expect(result.reason).toContain('Path blocked');
+			}
+		});
+
+		it('blocks test_engineer from writing non-test config-looking files with test_ prefix', () => {
+			const result = checkFileAuthority(
+				'test_engineer',
+				'src/test_config.json',
+				tempDir,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('Path blocked');
+			}
+		});
+
+		it('blocks test_engineer from writing Java production names ending with lowercase test', () => {
+			for (const filePath of [
+				'src/main/java/com/example/Contest.java',
+				'src/main/java/com/example/Latest.java',
+				'src/main/java/com/example/Protest.java',
+			]) {
+				const result = checkFileAuthority('test_engineer', filePath, tempDir);
+				expect(result.allowed).toBe(false);
+				if (isDenied(result)) {
+					expect(result.reason).toContain('Path blocked');
+				}
+			}
+		});
+
+		it('blocks test_engineer from writing Kotlin production names ending with lowercase test', () => {
+			for (const filePath of [
+				'src/main/kotlin/com/example/Contest.kt',
+				'src/main/kotlin/com/example/Latest.kt',
+				'src/main/kotlin/com/example/Protest.kt',
+			]) {
+				const result = checkFileAuthority('test_engineer', filePath, tempDir);
+				expect(result.allowed).toBe(false);
+				if (isDenied(result)) {
+					expect(result.reason).toContain('Path blocked');
+				}
+			}
+		});
+
+		it('blocks test_engineer from writing C# production names ending with lowercase tests', () => {
+			for (const filePath of [
+				'src/domain/Contests.cs',
+				'src/domain/Protests.cs',
+			]) {
+				const result = checkFileAuthority('test_engineer', filePath, tempDir);
+				expect(result.allowed).toBe(false);
+				if (isDenied(result)) {
+					expect(result.reason).toContain('Path blocked');
+				}
 			}
 		});
 
@@ -560,6 +687,18 @@ describe('guardrails-authority - File Authority Enforcement', () => {
 				tempDir,
 			);
 			expect(result.allowed).toBe(false);
+		});
+
+		it('blocks test_engineer from writing dist/main_test.go (generated zone beats *_test.* glob)', () => {
+			const result = checkFileAuthority(
+				'test_engineer',
+				'dist/main_test.go',
+				tempDir,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('generated');
+			}
 		});
 
 		it('blocks docs from writing dist/README.md (generated zone beats *.md glob)', () => {
@@ -997,6 +1136,48 @@ describe('guardrails-authority - File Authority Enforcement', () => {
 				},
 			});
 			expect(result.allowed).toBe(true);
+		});
+
+		it('user rules allow case-sensitive glob paths without matching lowercase suffixes', () => {
+			const authorityConfig = {
+				enabled: true,
+				rules: {
+					custom_agent: {
+						allowedCaseSensitiveGlobs: ['**/*Test.java'],
+						blockedPrefix: ['src/'],
+					},
+				},
+			};
+
+			const testResult = checkFileAuthority(
+				'custom_agent',
+				'src/main/java/UserServiceTest.java',
+				tempDir,
+				authorityConfig,
+			);
+			expect(testResult.allowed).toBe(true);
+
+			const productionResult = checkFileAuthority(
+				'custom_agent',
+				'src/main/java/Contest.java',
+				tempDir,
+				authorityConfig,
+			);
+			expect(productionResult.allowed).toBe(false);
+			if (isDenied(productionResult)) {
+				expect(productionResult.reason).toContain('Path blocked');
+			}
+		});
+
+		it('keeps case-sensitive glob matchers isolated from nocase cache entries', () => {
+			clearGuardrailsCaches();
+			const nocaseMatcher = getGlobMatcher('**/*Test.java', true);
+			expect(nocaseMatcher('src/main/java/Contest.java')).toBe(true);
+
+			const caseMatcher = getGlobMatcher('**/*Test.java', false);
+			expect(caseMatcher('src/main/java/UserServiceTest.java')).toBe(true);
+			expect(caseMatcher('src/main/java/Contest.java')).toBe(false);
+			clearGuardrailsCaches();
 		});
 
 		it('user rules add new agent not in defaults', () => {

--- a/tests/unit/hooks/guardrails-authority.test.ts
+++ b/tests/unit/hooks/guardrails-authority.test.ts
@@ -531,6 +531,39 @@ describe('guardrails-authority - File Authority Enforcement', () => {
 			}
 		});
 
+		it('blocks case-insensitive class-name false matches before prefix rules can mask them', () => {
+			const authorityConfig = {
+				enabled: true,
+				rules: {
+					custom_agent: {
+						allowedCaseSensitiveGlobs: [
+							'**/*Test.java',
+							'**/*Test.kt',
+							'**/*Tests.cs',
+						],
+						allowedPrefix: [],
+					},
+				},
+			};
+
+			for (const filePath of [
+				'lib/Contest.java',
+				'lib/Latest.kt',
+				'lib/Contests.cs',
+			]) {
+				const result = checkFileAuthority(
+					'custom_agent',
+					filePath,
+					tempDir,
+					authorityConfig,
+				);
+				expect(result.allowed).toBe(false);
+				if (isDenied(result)) {
+					expect(result.reason).toContain('not in allowed list');
+				}
+			}
+		});
+
 		it('allows prefixed test_engineer (e.g. local_test_engineer) to write to subdirectory tests/', () => {
 			const result = checkFileAuthority(
 				'local_test_engineer',
@@ -693,6 +726,42 @@ describe('guardrails-authority - File Authority Enforcement', () => {
 			const result = checkFileAuthority(
 				'test_engineer',
 				'dist/main_test.go',
+				tempDir,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('generated');
+			}
+		});
+
+		it('blocks test_engineer from writing dist/UserServiceTest.java (generated zone beats *Test.java)', () => {
+			const result = checkFileAuthority(
+				'test_engineer',
+				'dist/UserServiceTest.java',
+				tempDir,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('generated');
+			}
+		});
+
+		it('blocks test_engineer from writing dist/UserServiceTest.kt (generated zone beats *Test.kt)', () => {
+			const result = checkFileAuthority(
+				'test_engineer',
+				'dist/UserServiceTest.kt',
+				tempDir,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('generated');
+			}
+		});
+
+		it('blocks test_engineer from writing dist/UserServiceTests.cs (generated zone beats *Tests.cs)', () => {
+			const result = checkFileAuthority(
+				'test_engineer',
+				'dist/UserServiceTests.cs',
 				tempDir,
 			);
 			expect(result.allowed).toBe(false);
@@ -1169,6 +1238,101 @@ describe('guardrails-authority - File Authority Enforcement', () => {
 			}
 		});
 
+		it('blockedGlobs take precedence over allowedCaseSensitiveGlobs', () => {
+			const result = checkFileAuthority(
+				'custom_agent',
+				'src/main/java/UserServiceTest.java',
+				tempDir,
+				{
+					enabled: true,
+					rules: {
+						custom_agent: {
+							blockedGlobs: ['**/*Test.java'],
+							allowedCaseSensitiveGlobs: ['**/*Test.java'],
+						},
+					},
+				},
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('Path blocked (glob **/*Test.java)');
+			}
+		});
+
+		it('invalid allowedCaseSensitiveGlobs patterns fail closed without throwing', () => {
+			const result = checkFileAuthority(
+				'custom_agent',
+				'src/main/java/UserServiceTest.java',
+				tempDir,
+				{
+					enabled: true,
+					rules: {
+						custom_agent: {
+							allowedCaseSensitiveGlobs: ['['],
+							allowedPrefix: [],
+						},
+					},
+				},
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('not in allowed list');
+			}
+		});
+
+		it('user rules replace default allowedCaseSensitiveGlobs for test_engineer', () => {
+			const clearedResult = checkFileAuthority(
+				'test_engineer',
+				'src/main/java/UserServiceTest.java',
+				tempDir,
+				{
+					enabled: true,
+					rules: {
+						test_engineer: {
+							allowedCaseSensitiveGlobs: [],
+						},
+					},
+				},
+			);
+			expect(clearedResult.allowed).toBe(false);
+			if (isDenied(clearedResult)) {
+				expect(clearedResult.reason).toContain('Path blocked');
+			}
+
+			const customResult = checkFileAuthority(
+				'test_engineer',
+				'src/main/java/UserServiceSpec.java',
+				tempDir,
+				{
+					enabled: true,
+					rules: {
+						test_engineer: {
+							allowedCaseSensitiveGlobs: ['**/*Spec.java'],
+						},
+					},
+				},
+			);
+			expect(customResult.allowed).toBe(true);
+
+			const replacedDefaultResult = checkFileAuthority(
+				'test_engineer',
+				'src/main/java/UserServiceTest.java',
+				tempDir,
+				{
+					enabled: true,
+					rules: {
+						test_engineer: {
+							allowedCaseSensitiveGlobs: ['**/*Spec.java'],
+						},
+					},
+				},
+			);
+			expect(replacedDefaultResult.allowed).toBe(false);
+			if (isDenied(replacedDefaultResult)) {
+				expect(replacedDefaultResult.reason).toContain('Path blocked');
+			}
+		});
+
 		it('keeps case-sensitive glob matchers isolated from nocase cache entries', () => {
 			clearGuardrailsCaches();
 			const nocaseMatcher = getGlobMatcher('**/*Test.java', true);
@@ -1177,6 +1341,17 @@ describe('guardrails-authority - File Authority Enforcement', () => {
 			const caseMatcher = getGlobMatcher('**/*Test.java', false);
 			expect(caseMatcher('src/main/java/UserServiceTest.java')).toBe(true);
 			expect(caseMatcher('src/main/java/Contest.java')).toBe(false);
+			clearGuardrailsCaches();
+		});
+
+		it('keeps nocase glob matchers isolated from case-sensitive cache entries', () => {
+			clearGuardrailsCaches();
+			const caseMatcher = getGlobMatcher('**/*Test.java', false);
+			expect(caseMatcher('src/main/java/Contest.java')).toBe(false);
+
+			const nocaseMatcher = getGlobMatcher('**/*Test.java', true);
+			expect(nocaseMatcher('src/main/java/UserServiceTest.java')).toBe(true);
+			expect(nocaseMatcher('src/main/java/Contest.java')).toBe(true);
 			clearGuardrailsCaches();
 		});
 


### PR DESCRIPTION
Closes #1303

## Summary
- Expanded `test_engineer` authority to cover common cross-language test conventions without opening production-file write paths.
- Split Java/Kotlin/C# suffix handling into case-sensitive globs so Windows/macOS nocase matching cannot widen authority to names like `Contest.java`, `Contests.cs`, or `Latest.kt`.
- Added config-schema support and regression coverage for the new case-sensitive glob path, including review-driven coverage for generated-zone precedence, blocked-glob precedence, invalid globs, override semantics, and cache isolation in both directions.

## Invariant audit
- 1 (plugin init): not touched - no plugin bootstrap or startup path changed.
- 2 (runtime portability): not touched - `bun run build` and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` passed after the source changes.
- 3 (subprocesses): not touched - no spawn/spawnSync code changed.
- 4 (.swarm containment): not touched - runtime `.swarm` behavior unchanged; only publication evidence files were added under `.swarm/evidence/`.
- 5 (plan durability): not touched - no plan ledger or projection code changed.
- 6 (test_runner safety): not touched - validation used direct Bun commands, not broad `test_runner`.
- 7 (test writing): touched - added and updated `bun:test` coverage in `tests/unit/hooks/guardrails-authority.test.ts`; writing-tests skill was loaded before test edits.
- 8 (session state): not touched - no session-scoped state logic changed.
- 9 (guardrails/retry): touched - `src/hooks/guardrails/file-authority.ts` now distinguishes case-sensitive glob rules and caches matchers by case mode plus pattern; covered by authority regressions.
- 10 (chat/system msg): not touched - no message-shape or hook-output logic changed.
- 11 (tool registration): not touched - no tool map, agent map, or registration changes.
- 12 (release/cache): touched - updated `docs/releases/pending/1303-test-engineer-write-scope.md` and fixed glob matcher cache keying to avoid case-mode contamination.

## Test plan
- `bun --smol test tests/unit/hooks/guardrails-authority.test.ts --timeout 30000` - 173 pass
- `bun --smol test src/hooks/scope-guard.test.ts --timeout 30000` - 17 pass
- `bunx biome check src/hooks/guardrails/file-authority.ts tests/unit/hooks/guardrails-authority.test.ts docs/releases/pending/1303-test-engineer-write-scope.md` - passed
- `bun run typecheck` - passed
- `git diff --check` - passed
- `bun run build` - passed
- `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` - passed
