### PR TITLE
docs(skills): add safe-extraction skill and update mock-to-internals-migration

### DIFF
--- a/.opencode/skills/generated/mock-to-internals-migration/SKILL.md
+++ b/.opencode/skills/generated/mock-to-internals-migration/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: mock-to-internals-migration
 description: >
-  Apply when converting test files from mock.module('node:child_process') to _internals DI seam pattern.
-  Guides the complete migration: adding spawnSync/_internals to source files, converting test files,
-  adding proper beforeEach/afterEach save/restore lifecycle, mockReset() cleanup, and temp directory cleanup.
-  Prevents mock.module leaks across Bun's shared test-runner process.
+  Apply when converting test files from mock.module or vi.spyOn to _internals DI seam pattern. While examples
+  use spawnSync from node:child_process, the pattern applies to ANY function needing test injection
+  (readFileSync, fetch, execGit, etc.). Guides the complete migration: adding functions to _internals in source
+  files, converting test files, adding proper beforeEach/afterEach save/restore lifecycle, mockReset() cleanup,
+  and temp directory cleanup. Prevents mock.module and vi.spyOn leaks across Bun's shared test-runner process.
 effort: medium
 ---
 
-# mock.module → _internals DI Seam Migration Protocol
+# mock.module / vi.spyOn → _internals DI Seam Migration Protocol
 
 Follow every step in order. Do not skip steps.
 
 ## When to use this skill
 
 - A test file uses `mock.module('node:child_process')` or `mock.module('node:fs')` or similar
+- A test file uses `vi.spyOn(module, 'functionName')` on a module's exported functions (same anti-pattern as `mock.module` — unreliable across Bun's shared test runner when the module is split or functions move)
 - The production code already has an `_internals` export (or needs one added)
 - The goal is to eliminate `mock.module` usage per AGENTS.md invariant 7 and the writing-tests skill
 
@@ -29,13 +31,36 @@ Follow every step in order. Do not skip steps.
 2. Read the source module (e.g., `src/mutation/engine.ts`)
 3. Check if `_internals` already exists:
    ```typescript
-   export const _internals = { ... };
+    export const _internals = {
+      existingHelper,
+      // other entries...
+    };
    ```
 4. Identify which function/method the mock.module was intercepting (usually `spawnSync`, `execFileSync`, `readFileSync`, etc.)
 
+## Step 0b — Check ALL test files consuming the target module
+
+**CRITICAL:** Before converting any test file, identify EVERY test file that imports or spies on the target module. Cross-file mock leakage in Bun's shared test runner means a migration in one file can silently break tests in another file.
+
+```bash
+# Find all test files that import the module
+grep -rln "from.*<source-module>" src/ tests/ --include="*.test.ts"
+
+# Find all test files that spy on the module
+grep -rln "vi.spyOn.*<source-module>" src/ tests/ --include="*.test.ts"
+grep -rln "spyOn.*<source-module>" src/ tests/ --include="*.test.ts"
+
+# Find all test files that mock the module
+grep -rln "mock.module.*<source-module>" src/ tests/ --include="*.test.ts"
+```
+
+Prefer the `imports` tool for comprehensive discovery — grep misses dynamic imports and re-exports.
+
+Record every file found. ALL of them must pass after migration — not just the one being explicitly converted.
+
 ## Step 1 — Add the function to _internals in the source file
 
-**CRITICAL:** Do NOT import type aliases from Node.js built-ins (e.g., `type SpawnSyncFn` from `node:child_process`). Use `typeof` instead.
+**CRITICAL:** Do NOT import type aliases from Node.js built-ins (e.g., `type SpawnSyncFn` from `node:child_process`). Use `typeof` instead. This applies to ALL Node built-in functions, not just spawnSync.
 
 ```typescript
 // BAD — fails build
@@ -84,7 +109,7 @@ Delete the entire `mock.module(...)` block and any related mock setup.
 
 ```typescript
 // Module-level reference to the original function (saved/restored in beforeEach/afterEach)
-let originalSpawnSync: typeof import('node:child_process').spawnSync | undefined;
+let originalSpawnSync: typeof import('node:child_process').spawnSync;
 
 // Module-level mock that logs calls and delegates to original
 const mockSpawnSync = mock(
@@ -148,7 +173,7 @@ afterEach(() => {
 Replace assertions that checked `mockSpawnSync.mock.calls` with assertions that check `spawnCallLog`:
 ```typescript
 // BEFORE (with mock.module)
-expect(mockSpawnSync).toHaveBeenCalledWith('git', ['apply', ...]);
+expect(mockSpawnSync).toHaveBeenCalledWith('git', ['apply', '<patch-file>']);
 
 // AFTER (with _internals seam)
 const gitCalls = spawnCallLog.filter(c => c.cmd === 'git');
@@ -175,11 +200,27 @@ Some test helpers (like `initGitRepo`) may use `require('node:child_process')` d
 ```typescript
 function initGitRepo(dir: string): void {
   const { spawnSync: s } = require('node:child_process');
-  s('git', ['init'], { cwd: dir });
+  s('git', ['init'], {
+    cwd: dir,
+    stdin: 'ignore',          // AGENTS.md invariant 3: non-interactive
+    timeout: 5000,            // AGENTS.md invariant 3: bounded
+    stdio: ['ignore', 'ignore', 'ignore'],  // bounded output
+  });
 }
 ```
 
 Do NOT change these helpers to use the DI seam.
+
+### Distinguishing safe local spies from module spies that need migration
+
+Not every `vi.spyOn` needs migration. Use this table to decide:
+
+| Spy target | Needs migration? | Why |
+|-----------|-----------------|-----|
+| `vi.spyOn(console, 'warn')` | NO | `console` is a global singleton, not a module export |
+| `vi.spyOn(process.stdout, 'write')` | NO | Global process object, not module-scoped |
+| `vi.spyOn(importedModule, 'functionName')` | YES | Module export — unreliable across shared test runner |
+| `vi.spyOn(someObject.method)` where object is from import | YES | Same as above |
 
 ## Common mistakes
 
@@ -192,6 +233,19 @@ Do NOT change these helpers to use the DI seam.
 | Forgetting vi.mock() captures closures at hoist-time | Reassigning mockFn.mockImplementation(newFn) in test body does NOT update the hoisted closure — mock still calls original function. Symptom: toHaveBeenCalledTimes(N) fails unexpectedly. Fix: use _internals seam instead |
 | Converting `initGitRepo`-style helpers | These need the REAL subprocess; keep them as `require()` |
 
+## When NOT to add a function to _internals
+
+Not every function belongs in `_internals`. Adding unnecessary functions creates mockable surface area that tests might accidentally override:
+
+- **Pure functions** (no side effects, no I/O) — test them directly with real inputs/outputs
+- **Constants and type guards** — these have no behavior to mock
+- **Functions only called from within the module itself** that don't touch external state
+
+Only add a function to `_internals` when:
+1. It has side effects or external dependencies (filesystem, network, subprocess)
+2. Tests need to control or observe those side effects
+3. The function is called from production code that you need to test in isolation
+
 ## Verification checklist
 
 - [ ] Source file `_internals` includes the function
@@ -200,4 +254,5 @@ Do NOT change these helpers to use the DI seam.
 - [ ] `beforeEach` saves original and assigns mock
 - [ ] `afterEach` restores original, calls `mockReset()`, cleans temp dir
 - [ ] All tests pass
+- [ ] ALL test files from Step 0b pass (not just the explicitly converted file)
 - [ ] `bun run build` passes

--- a/.opencode/skills/generated/safe-extraction/SKILL.md
+++ b/.opencode/skills/generated/safe-extraction/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: safe-extraction
+description: >
+  Apply when extracting code from a large monolith file into submodules. Covers barrel re-exports,
+  _internals DI seam proxy patterns, CI invariant allowlist updates, and cross-file test verification.
+  Prevents CI failures, broken imports, and test regressions from code extraction.
+effort: medium
+---
+
+# Safe Extraction Protocol
+
+Follow every step in order. Do not skip steps.
+
+## When to use this skill
+
+- A source file exceeds team-agreed size thresholds (this repo uses <2000 lines per file per FR-005) and needs splitting
+- A subsystem (destructive-command, worktree-isolation, etc.) is being extracted to its own file
+- Code is being moved from one module to another without changing behavior
+
+**Benefit:** Prevents the three most common extraction failure modes:
+1. CI invariant check failures (new file paths not in allowlists)
+2. Broken _internals DI seams (test mocks stop working)
+3. Cross-file test regressions (other test files that consume the module)
+
+## Step 0 — Pre-extraction audit
+
+Before moving ANY code, inventory every path-scoped artifact that references the source file:
+
+### 0a. CI invariant scripts
+```bash
+grep -rn "<source-file-path>" scripts/ .github/workflows/
+```
+Check:
+- `LEGACY_EXEMPTS` arrays (e.g., `check-invariants.sh`)
+- Path-scoped lint/scan configurations
+- GitHub Actions path filters
+
+### 0b. Mock allowlists
+```bash
+grep -rn "<source-file-path>" scripts/mock-allowlist.txt
+```
+
+### 0c. Test file inventory
+```bash
+grep -rln "from.*<source-module>" src/ tests/ --include="*.test.ts"
+grep -rln "vi.spyOn.*<source-module>" src/ tests/ --include="*.test.ts"
+grep -rln "_internals.*<source-module>" src/ tests/ --include="*.test.ts"
+```
+Record EVERY test file that imports or spies on the source module. These must all pass after extraction.
+
+Prefer the `imports` tool or `repo_map` action for comprehensive consumer discovery. Grep catches direct string matches but misses `require()` imports, dynamic `import()`, and re-exports through intermediate modules. Use grep as a secondary cross-check.
+
+### 0d. Import graph
+```
+Use the imports tool or repo_map to find all consumers of exports from the source file.
+```
+
+## Step 1 — Create the extracted module
+
+1. Move the code block(s) to the new file(s)
+2. Move all supporting types, constants, and helper functions used exclusively by the extracted code
+3. Add necessary imports to the new file (from external dependencies)
+
+## Step 2 — Create barrel re-export (if preserving public API)
+
+If consumers import from the original path, keep the original file as a barrel:
+
+```typescript
+// src/hooks/guardrails.ts (barrel — preserves import path)
+// Use EXPLICIT named exports, not `export *`, to avoid naming conflicts
+// when multiple submodules export symbols with the same name.
+export {
+  _internals,
+  createGuardrailsHooks,
+  enforceSpecDriftGate,
+} from './guardrails/index';
+export {
+  buildEffectiveRules,
+  checkFileAuthority,
+  getGlobMatcher,
+} from './guardrails/file-authority';
+export {
+  createToolBeforeHandler,
+  normalizeToolInput,
+} from './guardrails/tool-before';
+// etc.
+```
+
+**Verify:** `bun run build` succeeds. All existing imports still resolve.
+
+## Step 3 — Handle _internals DI seams
+
+If the source module exports `_internals` for test injection:
+
+### 3a. Direct functions stay in source _internals
+Functions that remain in the source file stay as direct entries:
+```typescript
+export const _internals = {
+  resolveEvidenceTaskId,      // still in this file
+  loadPlanJsonOnly,           // still in this file
+  // ...
+};
+```
+
+### 3b. Extracted functions need getter/setter proxies
+Functions moved to the extracted module need proxy entries so test mocks propagate:
+```typescript
+import { _internals as _extractedInternals } from './extracted-module';
+
+export const _internals = {
+  resolveEvidenceTaskId,      // direct
+  get extractedFn() {
+    return _extractedInternals.extractedFn;    // proxy to extracted module
+  },
+  set extractedFn(v) {
+    _extractedInternals.extractedFn = v;       // allow test injection
+  },
+};
+```
+
+The extracted module must ALSO export its own `_internals`:
+```typescript
+// extracted-module.ts
+export const _internals = {
+  extractedFn,
+  otherExtractedFn,
+};
+```
+
+**Type annotation:** Always include an explicit type annotation on `_internals` objects to override `as const` readonly inference. Without it, `as const` makes properties `readonly` and test injection (`_internals.fn = mockFn`) fails at compile time:
+```typescript
+// GOOD — explicit type annotation allows mutation
+export const _internals: {
+  extractedFn: typeof extractedFn;
+  otherFn: typeof otherFn;
+} = {
+  extractedFn,
+  otherFn,
+};
+```
+
+**CRITICAL:** The extracted module's own production code must call mockable functions through `_internals.fn(...)`, NOT through the direct function reference. If `extractedFn` internally calls `otherExtractedFn`, it must use `_internals.otherExtractedFn()` — otherwise test mocks set on `_internals` won't intercept the internal call. This is the same pattern the parent module follows.
+
+**Verify:** Run ALL test files from Step 0c — not just the one explicitly in scope.
+
+### 3c. Alternative: Factory parameter pattern (no _internals proxy needed)
+
+When splitting a factory function into handler files (NOT extracting a subsystem with its own _internals), the getter/setter proxy is unnecessary. Instead:
+
+1. Handler files export factory functions that receive dependencies as parameters
+2. The orchestrator file calls these factories, passing closure-scoped config
+3. The barrel re-exports only the top-level orchestrator API
+
+```typescript
+// guardrails/tool-before.ts — handler file
+export function createToolBeforeHandler(cfg: Config, deps: Deps) {
+  // Receives all dependencies as parameters — no _internals needed
+  return function toolBefore(input: ToolInput) {
+    /* handler logic using cfg and deps */
+  };
+}
+
+// guardrails/index.ts — orchestrator
+export function createGuardrailsHooks(config: PluginConfig) {
+  const cfg = resolveConfig(config);
+  return {
+    toolBefore: createToolBeforeHandler(cfg, deps),
+    // ...
+  };
+}
+```
+
+Use this pattern when:
+- Splitting a large factory function into handler files
+- The submodules don't have their own mockable functions
+- All dependencies can be passed as closure parameters
+
+Use the _internals proxy pattern (3b) when:
+- Extracting a subsystem that tests mock independently
+- The source module exports `_internals` for test injection
+- Mockable functions are moving to the extracted module
+
+## Step 4 — Update CI invariant scripts
+
+For EVERY path-scoped artifact found in Step 0a, add the new file paths:
+
+```bash
+# Example: check-invariants.sh
+LEGACY_EXEMPTS=(
+  "src/hooks/guardrails.ts"                    # original (still exists as barrel)
+  "src/hooks/guardrails/file-authority.ts"     # NEW
+  "src/hooks/guardrails/helpers.ts"            # NEW
+  "src/hooks/guardrails/index.ts"              # NEW
+)
+```
+
+**Verify:** Run the invariant check script locally if possible (bash on Windows may require WSL).
+
+## Step 4.5 — Re-capture SAST baseline
+
+File-path moves alter SAST finding fingerprints, making pre-existing findings appear new. After extraction:
+
+1. Run `sast_scan` with `capture_baseline: true` and the current phase number
+2. Compare against the previous baseline to identify findings that moved (same rule, different file path)
+3. Merge the updated baseline so pre-existing findings don't fail the gate
+
+**Verify:** SAST scan on the new file paths shows only genuinely new findings, not relocated pre-existing ones.
+
+## Step 5 — Update documentation
+
+Update any doc references that point to the old monolith for functions that moved:
+
+```bash
+grep -rn "<source-file-path>" docs/ *.md
+```
+
+Fix references to point to the new submodule location.
+
+## Step 6 — Verification checklist
+
+- [ ] `bun run build` succeeds
+- [ ] `bun run typecheck` succeeds (zero new type errors)
+- [ ] `biome ci .` passes
+- [ ] ALL test files from Step 0c pass (not just the one in scope)
+- [ ] CI invariant scripts updated for new paths
+- [ ] Documentation references updated
+- [ ] No runtime behavior changes (pure extraction)
+
+## Common mistakes
+
+| Mistake | Why it fails |
+|---------|-------------|
+| Forgetting to update LEGACY_EXEMPTS | CI `quality` job fails on `process.cwd()` check for new file paths |
+| Only testing the explicit test file | Cross-file regressions in OTHER consuming test files go undetected |
+| Not creating getter/setter proxies for _internals | Test mocks on the parent module don't propagate to extracted functions |
+| Moving helper functions without updating/re-exporting all consumers | Import errors in unrelated files that depended on the helper |
+| Updating docs to reference new paths but missing some | Stale doc references confuse future readers |
+
+## Relationship to other skills
+
+- **safe-rename**: Use when renaming symbols across the codebase. Use **safe-extraction** when moving code to new files.
+- **mock-to-internals-migration**: Use when converting test files from mock.module/vi.spyOn to _internals DI seam. May be needed as part of extraction if the source module's _internals changes.
+- **subprocess-safety**: Relevant if the extracted code calls spawn/spawnSync — ensure the _internals proxy preserves timeout/kill semantics.

--- a/docs/releases/pending/skill-improvements-safe-extraction.md
+++ b/docs/releases/pending/skill-improvements-safe-extraction.md
@@ -1,0 +1,26 @@
+# Skill improvements: safe-extraction + mock-to-internals-migration
+
+## What changed
+
+### New skill: `safe-extraction`
+Created a new generated skill covering the pattern of extracting code from a large monolith into submodules. Includes:
+- Pre-extraction audit (CI invariant scripts, mock allowlists, test file inventory, import graph)
+- Barrel re-export with explicit named exports
+- Two extraction patterns: `_internals` proxy (for mockable subsystems) and factory parameter (for handler splits)
+- SAST baseline recapture guidance
+- CI allowlist update step
+
+### Updated skill: `mock-to-internals-migration`
+Added 6 improvements based on PR #1318 learnings:
+- Step 0b: Check ALL test files consuming the target module (prevents cross-file regressions)
+- `vi.spyOn` trigger condition (previously only covered `mock.module`)
+- Safe-local-spy distinction table
+- Generalized beyond `spawnSync` (applies to any injectable function)
+- Verification checklist references Step 0b
+- "When NOT to add a function to _internals" guidance
+
+## Why
+Both skill improvements were motivated by real issues encountered during PR #1318 (guardrails maintainability refactoring). The safe-extraction skill captures the complete extraction workflow that was learned through trial and error. The mock-to-internals-migration update closes a gap that caused an integration test regression.
+
+## Migration
+No migration required. Skills are consumed automatically by the swarm plugin's skill injection system.


### PR DESCRIPTION
## Summary
- **New skill: `safe-extraction`** — Covers the complete pattern of extracting code from a monolith into submodules: pre-extraction audit (CI scripts, mock allowlists, test inventory, import graph), barrel re-exports with explicit named exports, two extraction patterns (_internals proxy for mockable subsystems, factory parameter for handler splits), SAST baseline recapture, and CI allowlist updates
- **Updated skill: `mock-to-internals-migration`** — 6 improvements: Step 0b (check ALL test files consuming the target module), vi.spyOn trigger condition, safe-local-spy distinction table, generalized beyond spawnSync, verification checklist references Step 0b, "When NOT to add a function to _internals" guidance

Both skill improvements were motivated by real issues encountered during PR #1318 (guardrails maintainability refactoring). The safe-extraction skill captures the complete extraction workflow learned through trial and error. The mock-to-internals-migration update closes a gap that caused an integration test regression.

## Invariant audit
- 1 (plugin init): not touched — no changes to src/index.ts or init path
- 2 (runtime portability): not touched — no bundle or source changes
- 3 (subprocesses): not touched — no spawn/spawnSync calls
- 4 (.swarm containment): not touched — skill files are in .opencode/skills/generated/, not .swarm/
- 5 (plan durability): not touched — no plan-schema changes
- 6 (test_runner safety): not touched — no test_runner usage
- 7 (test writing): not touched — skill files are documentation, not test code. The mock-to-internals-migration skill DESCRIBES test patterns but does not modify any tests.
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched — no new tools, agents, or tool maps. Skill files are consumed by the skill injection system, not the tool registry.
- 12 (release/cache): not touched — release fragment created, no version files edited

## Test plan
- [x] `bun run build` succeeds
- [x] `biome ci .` passes (0 errors)
- [x] safe-extraction skill reviewed by mega_reviewer: APPROVED (4 review rounds)
- [x] mock-to-internals-migration skill reviewed by mega_reviewer: APPROVED (4 review rounds)
- [x] safe-extraction skill verified by mega_test_engineer: PASS (step numbering, TS syntax, cross-references, pattern consistency)
- [x] All TypeScript code examples in both skills are syntactically valid


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `safe-extraction` skill and updates `mock-to-internals-migration` to prevent CI breaks and test flakiness when splitting modules and migrating off mocks.

- **New Features**
  - New `safe-extraction`: pre-extraction audit (CI scripts, mock allowlists, test inventory, import graph), barrel re-exports with explicit named exports, two patterns (`_internals` proxy for mockable subsystems; factory parameter for handler splits), SAST baseline recapture, and CI allowlist updates.
  - Updated `mock-to-internals-migration`: adds Step 0b to find all consuming tests, treats `vi.spyOn` as a trigger, clarifies safe local spies vs module spies, generalizes beyond `spawnSync`, ties verification to Step 0b, and adds guidance on when not to add functions to `_internals`.

<sup>Written for commit 7009eff9a693e3f3c53345dfe6e81c2ecc4fa0e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

