### PR TITLE
fix(skills): align compliance verdict consumers to canonical violated value

### DIFF
--- a/docs/releases/pending/1281-compliance-verdict-vocabulary.md
+++ b/docs/releases/pending/1281-compliance-verdict-vocabulary.md
@@ -1,0 +1,25 @@
+# `fix(skills)`: align compliance verdict vocabulary across producers and consumers
+
+## Summary
+
+- The sole producer of skill compliance verdicts (`skill-propagation-gate.ts`) writes the canonical spelling `'violated'` (lowercased regex capture), but six consumer comparisons in `skill-usage-log.ts` and `curator.ts` filtered on the string `'violation'`, which no producer ever writes.
+- As a result, negative skill feedback (confidence decay) and the 30% violation-rate auto-retire threshold never fired.
+- All consumer comparisons now use the canonical `'violated'` spelling. A `normalizeComplianceVerdict()` helper maps legacy on-disk entries (`'violation'`) to `'violated'` on both read paths, so pre-existing `skill-usage.jsonl` data is handled without manual migration.
+
+## User-facing changes
+
+- Skill compliance feedback now works as intended: a recorded `SKILL_COMPLIANCE: VIOLATED` verdict produces the expected negative confidence delta, and skills exceeding the violation-rate threshold are eligible for auto-retire again.
+- `getSkillUsageStats` (`stats.violation`) now counts violated entries.
+
+## Migration notes
+
+No action required. Legacy on-disk `skill-usage.jsonl` entries carrying the old `'violation'` spelling are normalized to `'violated'` automatically on read.
+
+## Breaking changes
+
+None.
+
+## Known caveats
+
+- The producer vocabulary (`'compliant' | 'partial' | 'violated'`) is unchanged; only consumer comparisons were corrected.
+- Found during the 2026-06-12 knowledge/skill system end-to-end review (issue #1281).

--- a/src/hooks/curator.ts
+++ b/src/hooks/curator.ts
@@ -156,7 +156,7 @@ async function autoRetireSkills(
 			});
 
 			const violations = skillUsage.filter(
-				(e) => e.complianceVerdict === 'violation',
+				(e) => e.complianceVerdict === 'violated',
 			).length;
 			const violationRate =
 				skillUsage.length > 0 ? violations / skillUsage.length : 0;
@@ -1276,7 +1276,7 @@ export async function runCuratorPhase(
 				if (skillUsage.length === 0) continue;
 
 				const violations = skillUsage.filter(
-					(e) => e.complianceVerdict === 'violation',
+					(e) => e.complianceVerdict === 'violated',
 				).length;
 				const violationRate = violations / skillUsage.length;
 
@@ -1290,7 +1290,7 @@ export async function runCuratorPhase(
 
 					const currentVersion = fm?.version ?? 1;
 					const violationContexts: ViolationContext[] = skillUsage
-						.filter((e) => e.complianceVerdict === 'violation')
+						.filter((e) => e.complianceVerdict === 'violated')
 						.slice(-10)
 						.map((e) => ({
 							taskId: e.taskID,

--- a/src/hooks/skill-usage-log.ts
+++ b/src/hooks/skill-usage-log.ts
@@ -27,7 +27,9 @@ export interface SkillUsageEntry {
 	taskID: string;
 	/** ISO 8601 timestamp of the event. */
 	timestamp: string;
-	/** Compliance outcome — 'compliant' | 'violation' | 'partial' | 'not_checked' | custom. */
+	/** Compliance outcome — 'compliant' | 'partial' | 'violated' | 'not_checked' | custom.
+	 *  Legacy on-disk entries may carry the pre-fix spelling 'violation'; these are
+	 *  normalized to 'violated' on the read path (see normalizeComplianceVerdict). */
 	complianceVerdict: string;
 	/** Optional free-text notes from the reviewer. */
 	reviewerNotes?: string;
@@ -68,6 +70,23 @@ export interface PruneResult {
 /** Resolve the absolute path to `.swarm/skill-usage.jsonl`, with swarm-path validation. */
 function resolveLogPath(directory: string): string {
 	return validateSwarmPath(directory, 'skill-usage.jsonl');
+}
+
+// ============================================================================
+// Verdict normalization (legacy backward-compat)
+// ============================================================================
+
+/**
+ * Normalize a compliance verdict to the canonical spelling.
+ * The sole producer (`skill-propagation-gate.ts`) lowercases the regex
+ * capture, yielding 'violated'.  Pre-fix on-disk entries may carry the
+ * legacy spelling 'violation'; this maps them to the canonical form so
+ * that every downstream comparison can use a single string.
+ *
+ * Exported for unit-testing.
+ */
+export function normalizeComplianceVerdict(verdict: string): string {
+	return verdict === 'violation' ? 'violated' : verdict;
 }
 
 // ============================================================================
@@ -213,7 +232,11 @@ export function readSkillUsageEntries(
 		const trimmed = line.trim();
 		if (!trimmed) continue;
 		try {
-			entries.push(JSON.parse(trimmed) as SkillUsageEntry);
+			const entry = JSON.parse(trimmed) as SkillUsageEntry;
+			entry.complianceVerdict = normalizeComplianceVerdict(
+				entry.complianceVerdict,
+			);
+			entries.push(entry);
 		} catch {
 			// skip malformed line — consistent with knowledge-application pattern
 		}
@@ -300,6 +323,9 @@ export function readSkillUsageEntriesTail(
 				if (!line.trim()) continue;
 				try {
 					const entry: SkillUsageEntry = JSON.parse(line);
+					entry.complianceVerdict = normalizeComplianceVerdict(
+						entry.complianceVerdict,
+					);
 					if (
 						filters.sessionID !== undefined &&
 						entry.sessionID !== filters.sessionID
@@ -358,7 +384,7 @@ export function computeComplianceByVersion(
 		}
 		stats.total += 1;
 		if (e.complianceVerdict === 'compliant') stats.compliant += 1;
-		if (e.complianceVerdict === 'violation') stats.violation += 1;
+		if (e.complianceVerdict === 'violated') stats.violation += 1;
 	}
 
 	for (const stats of map.values()) {
@@ -594,7 +620,7 @@ export async function applySkillUsageFeedback(
 		const actionable = allEntries.filter((e) => {
 			if (
 				e.complianceVerdict !== 'compliant' &&
-				e.complianceVerdict !== 'violation'
+				e.complianceVerdict !== 'violated'
 			) {
 				return false;
 			}
@@ -625,7 +651,7 @@ export async function applySkillUsageFeedback(
 
 			for (const entry of entries) {
 				if (entry.complianceVerdict === 'compliant') compliantCount++;
-				else if (entry.complianceVerdict === 'violation') violationCount++;
+				else if (entry.complianceVerdict === 'violated') violationCount++;
 			}
 
 			// Skip skills with no actionable verdicts (shouldn't happen due to filter, but defensive)

--- a/tests/unit/hooks/curator-auto-retire.test.ts
+++ b/tests/unit/hooks/curator-auto-retire.test.ts
@@ -69,17 +69,17 @@ describe('autoRetireSkills', () => {
 			{
 				skillPath:
 					'file:/fake/dir/.opencode/skills/generated/high-violation/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath:
 					'/fake/dir/.opencode/skills/generated/high-violation/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath:
 					'/fake/dir/.opencode/skills/generated/high-violation/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath:
@@ -317,11 +317,11 @@ describe('autoRetireSkills', () => {
 		const mockReadSkillUsageEntries = mock(() => [
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/no-fm-skill/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/no-fm-skill/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/no-fm-skill/SKILL.md',
@@ -372,7 +372,7 @@ describe('autoRetireSkills', () => {
 		const mockReadSkillUsageEntries = mock(() => [
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/fail-retire/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/fail-retire/SKILL.md',
@@ -437,7 +437,7 @@ describe('autoRetireSkills', () => {
 			{
 				skillPath:
 					'/fake/dir/.opencode/skills/generated/violation-skill/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath:
@@ -527,15 +527,15 @@ describe('autoRetireSkills', () => {
 		const mockReadSkillUsageEntries = mock(() => [
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/test-skill/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/test-skill/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/test-skill/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 		]);
 

--- a/tests/unit/hooks/skill-usage-feedback.test.ts
+++ b/tests/unit/hooks/skill-usage-feedback.test.ts
@@ -21,6 +21,8 @@ import {
 import {
 	appendSkillUsageEntry,
 	applySkillUsageFeedback,
+	computeComplianceByVersion,
+	normalizeComplianceVerdict,
 	readSkillUsageEntries,
 	resolveSourceKnowledgeIds,
 	type SkillUsageEntry,
@@ -523,7 +525,7 @@ describe('applySkillUsageFeedback', () => {
 			agentName: 'test-agent',
 			taskID: 'task-001',
 			timestamp: '2026-01-01T00:02:00.000Z',
-			complianceVerdict: 'violation',
+			complianceVerdict: 'violated',
 			sessionID: 'session-abc',
 		});
 
@@ -580,7 +582,7 @@ describe('applySkillUsageFeedback', () => {
 			agentName: 'test-agent',
 			taskID: 'task-004',
 			timestamp: '2026-01-01T00:04:00.000Z',
-			complianceVerdict: 'violation',
+			complianceVerdict: 'violated',
 			sessionID: 'session-abc',
 		});
 
@@ -756,7 +758,7 @@ Content
 			agentName: 'test-agent',
 			taskID: 'task-002',
 			timestamp: '2026-01-01T00:02:00.000Z',
-			complianceVerdict: 'violation',
+			complianceVerdict: 'violated',
 			sessionID: 'session-abc',
 		});
 
@@ -821,6 +823,144 @@ Content
 		const knowledge = readSwarmKnowledge(tempDir);
 		expect(knowledge).toHaveLength(1);
 		expect(knowledge[0]!.confidence).toBeCloseTo(0.55);
+	});
+});
+
+// =============================================================================
+// normalizeComplianceVerdict + computeComplianceByVersion regression tests
+//
+// Issue #1281: producer writes 'violated' but consumers filtered 'violation'.
+// These tests verify the canonical 'violated' spelling flows through every
+// code path, and that legacy 'violation' entries are normalized on read.
+// =============================================================================
+
+describe('normalizeComplianceVerdict', () => {
+	test('maps legacy "violation" to canonical "violated"', () => {
+		expect(normalizeComplianceVerdict('violation')).toBe('violated');
+	});
+
+	test('passes through canonical "violated" unchanged', () => {
+		expect(normalizeComplianceVerdict('violated')).toBe('violated');
+	});
+
+	test('passes through other verdicts unchanged', () => {
+		expect(normalizeComplianceVerdict('compliant')).toBe('compliant');
+		expect(normalizeComplianceVerdict('partial')).toBe('partial');
+		expect(normalizeComplianceVerdict('not_checked')).toBe('not_checked');
+	});
+});
+
+describe('read-path normalization (legacy backward-compat)', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = makeTempDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test('legacy "violation" entries on disk are normalized to "violated" on read', () => {
+		// Write a raw JSONL line with the legacy spelling directly to disk
+		writeRawLog(
+			tempDir,
+			JSON.stringify({
+				...makeEntry({ complianceVerdict: 'violation' }),
+				id: 'legacy-001',
+			}) + '\n',
+		);
+
+		const entries = readSkillUsageEntries(tempDir);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]!.complianceVerdict).toBe('violated');
+	});
+
+	test('canonical "violated" entries are read back unchanged', () => {
+		writeRawLog(
+			tempDir,
+			JSON.stringify({
+				...makeEntry({ complianceVerdict: 'violated' }),
+				id: 'canonical-001',
+			}) + '\n',
+		);
+
+		const entries = readSkillUsageEntries(tempDir);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]!.complianceVerdict).toBe('violated');
+	});
+
+	test('legacy "violation" verdict triggers negative confidence delta (issue #1281)', async () => {
+		// This verifies the full producer→consumer round-trip:
+		// The producer writes 'violated' (simulated here as legacy 'violation' on disk),
+		// readSkillUsageEntries normalizes it, and applySkillUsageFeedback produces -0.1.
+		writeSwarmKnowledge(tempDir, [
+			{ id: 'legacy-fb-uuid', lesson: 'legacy entry', confidence: 0.5 },
+		]);
+		writeSkillFile(tempDir, '.claude/skills/legacy-fb-skill/SKILL.md', [
+			'legacy-fb-uuid',
+		]);
+
+		// Write a legacy 'violation' entry directly to disk (bypassing appendSkillUsageEntry)
+		writeRawLog(
+			tempDir,
+			JSON.stringify({
+				...makeEntry({
+					skillPath: '.claude/skills/legacy-fb-skill/SKILL.md',
+					complianceVerdict: 'violation',
+				}),
+				id: 'legacy-fb-001',
+			}) + '\n',
+		);
+
+		const result = await applySkillUsageFeedback(tempDir);
+
+		expect(result.processed).toBe(1);
+		expect(result.bumps).toBe(1);
+
+		const knowledge = readSwarmKnowledge(tempDir);
+		expect(knowledge[0]!.confidence).toBe(0.4); // 0.5 - 0.1 = negative delta
+	});
+});
+
+describe('computeComplianceByVersion (verdict vocabulary)', () => {
+	test('counts "violated" entries in stats.violation', () => {
+		const entries = [
+			{ ...makeEntry({ complianceVerdict: 'violated' }), id: 'v1' },
+			{ ...makeEntry({ complianceVerdict: 'violated' }), id: 'v2' },
+			{ ...makeEntry({ complianceVerdict: 'compliant' }), id: 'c1' },
+			{ ...makeEntry({ complianceVerdict: 'not_checked' }), id: 'n1' },
+		] as SkillUsageEntry[];
+
+		const stats = computeComplianceByVersion(
+			entries,
+			'.claude/skills/my-skill/SKILL.md',
+		);
+		const agg = stats.get(undefined)!;
+		expect(agg.total).toBe(4);
+		expect(agg.violation).toBe(2);
+		expect(agg.compliant).toBe(1);
+		expect(agg.rate).toBeCloseTo(0.25); // 1 compliant / 4 total
+	});
+
+	test('"violation" (legacy) entries are NOT counted without read-path normalization', () => {
+		// This verifies that computeComplianceByVersion uses the canonical spelling.
+		// Raw entries with legacy 'violation' that bypass readSkillUsageEntries
+		// normalization should not be counted (they'd be caught by the read path
+		// in production).
+		const entries = [
+			{ ...makeEntry({ complianceVerdict: 'violation' }), id: 'v1' },
+			{ ...makeEntry({ complianceVerdict: 'compliant' }), id: 'c1' },
+		] as SkillUsageEntry[];
+
+		const stats = computeComplianceByVersion(
+			entries,
+			'.claude/skills/my-skill/SKILL.md',
+		);
+		const agg = stats.get(undefined)!;
+		expect(agg.total).toBe(2);
+		expect(agg.violation).toBe(0); // 'violation' ≠ 'violated'
+		expect(agg.compliant).toBe(1);
 	});
 });
 


### PR DESCRIPTION
Closes #1281

## Summary

- The sole producer of skill compliance verdicts (`skill-propagation-gate.ts`) lowercases its regex capture and writes the canonical spelling `'violated'`, but six consumer comparisons across `skill-usage-log.ts` and `curator.ts` filtered on the string `'violation'` — which no producer ever writes.
- Because `'violated' !== 'violation'`, **negative skill feedback (confidence decay `-0.1`) and the 30% violation-rate auto-retire threshold have never fired**.
- This PR corrects all consumer comparisons to the canonical `'violated'` value and adds a `normalizeComplianceVerdict()` read-path helper so legacy on-disk `skill-usage.jsonl` entries carrying the old `'violation'` spelling are mapped to `'violated'` automatically — no manual data migration required.

## Invariant audit

- 1 (plugin init): not touched — change is in task-lifecycle hooks (`curator.ts`, `skill-usage-log.ts`), not plugin registration/init paths.
- 2 (runtime portability): not touched — no top-level `bun:` imports, no `Bun.*` calls, no changes to `src/index.ts`, `package.json#main`, or plugin entry shape.
- 3 (subprocesses): not touched — no `spawn`/`spawnSync`/`bunSpawn` calls added or modified.
- 4 (.swarm containment): not touched — log reads use the existing `validateSwarmPath(directory, 'skill-usage.jsonl')` helper; no new runtime-state paths introduced.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — validation run via shell per-file loops, not `test_runner` with broad scopes.
- 7 (test writing): touched — added regression tests (`normalizeComplianceVerdict`, read-path backward-compat, `computeComplianceByVersion` counting) in `tests/unit/hooks/skill-usage-feedback.test.ts` and updated `curator-auto-retire.test.ts` mock data to canonical `'violated'`. Tests follow the repo's per-file isolation pattern; no `mock.module` leakage.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched.
- 12 (release/cache): touched — added `docs/releases/pending/1281-compliance-verdict-vocabulary.md`. `package.json` version, `CHANGELOG.md`, and `.release-please-manifest.json` are untouched.

## Test plan

- [x] `bun run typecheck` (`tsc --noEmit`) — clean, no errors.
- [x] `bunx biome check` on the 4 changed source/test files — passes (formatter applied: single-arg calls wrapped to print-width; behaviorally identical).
- [x] `bun --smol test tests/unit/hooks/curator-auto-retire.test.ts` — 9/9 pass.
- [x] `bun --smol test tests/unit/hooks/skill-usage-feedback.test.ts` — 37/37 pass (incl. new regression tests: `normalizeComplianceVerdict`, read-path legacy backward-compat, `computeComplianceByVersion` verdict counting, and "legacy 'violation' verdict triggers negative confidence delta (issue #1281)").
- [x] `bun --smol test` on `curator.test.ts` + `skill-usage-log.test.ts` — all pass (210/210 across the 4 touched files).
- [x] Acceptance criteria from the issue: a recorded `SKILL_COMPLIANCE: VIOLATED` verdict now produces a negative confidence delta; a fixture skill with >30% `violated` verdicts is auto-retired; `getSkillUsageStats` counts violated entries.

## Pre-existing failures (unrelated)

A handful of unrelated `tests/unit/hooks/*` files fail (`skill-scoring`, `write-lstat-authority`, `self-coding-detection`, `spec-drift-advisory`, several `guardrails-*`, `full-auto-intercept`, `repo-graph-*`). These reproduce on clean `origin/main` (verified via a `git worktree` of `origin/main`) and are outside this change's blast radius. No new failures are introduced.

## Notes

- Autonomous cron-driven fix (`auto-fix` workflow). Opened as a **draft** — the human reviewer decides ready/merge.
- The fix is intentionally surgical: only the vocabulary mismatch is corrected. No refactors, no scope expansion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a verdict vocabulary mismatch: producers write 'violated' but consumers checked 'violation'. Aligns consumers to 'violated' and normalizes legacy reads, restoring negative feedback, auto-retire, and correct stats (meets #1281).

- **Bug Fixes**
  - Switched consumer checks in `src/hooks/curator.ts` and `src/hooks/skill-usage-log.ts` to `'violated'`.
  - Added `normalizeComplianceVerdict()`; applied in `readSkillUsageEntries` and `readSkillUsageEntriesTail` to map legacy `'violation'` to `'violated'`.
  - Updated `computeComplianceByVersion` and `applySkillUsageFeedback` to use `'violated'`; added tests for normalization, read-path compat, and verdict counting so `getSkillUsageStats` counts violated entries.

- **Migration**
  - No action needed. Legacy `skill-usage.jsonl` entries are normalized on read.

<sup>Written for commit 034bb56bdb7688c0a59152c945f0833d885ef646. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

