### PR TITLE
fix: stop background sessions flooding the TUI with reasoning parts

### DIFF
--- a/docs/releases/pending/1346-background-session-tui-flooding.md
+++ b/docs/releases/pending/1346-background-session-tui-flooding.md
@@ -1,0 +1,58 @@
+# Stop background LLM sessions flooding the TUI with reasoning parts (PR 1346)
+
+## What
+
+Background LLM dispatches (curator, skill-improver, mutation generator, full-auto
+oversight/critic, and lean-turbo reviewer/critic/lanes) no longer flood the right-hand
+OpenCode TUI session log with internal reasoning text, and no longer risk a foreign-key
+crash when a dispatch is cancelled mid-prompt.
+
+- **Child sessions instead of roots (Fix A).** Every background `client.session.create`
+  now passes `body: { parentID, title }` when a calling session ID is available, so
+  OpenCode treats the ephemeral session as a child of the originating session rather than
+  a new top-level root. Root sessions persist all message parts — including
+  `ReasoningPart` tokens — into the TUI log; child sessions do not. Sites updated:
+  `src/hooks/curator-llm-factory.ts`, `src/hooks/skill-improver-llm-factory.ts`,
+  `src/mutation/generator.ts`, `src/full-auto/oversight.ts`,
+  `src/hooks/full-auto-intercept.ts`, `src/turbo/lean/reviewer.ts`,
+  `src/turbo/lean/integration.ts`, `src/turbo/lean/runner.ts`. When no session ID is
+  available the body is omitted and a root session is created as before (graceful
+  fallback).
+- **Extended thinking disabled for classification agents (Fix B).** `createCuratorAgent`
+  and `createCriticAutonomousOversightAgent` now set `thinking: { type: 'disabled' }`.
+  These produce verdict/classification output, for which extended thinking adds large
+  reasoning parts and no value. Users can re-enable via
+  `agents.curator_<role>.thinking` / `agents.critic_oversight.thinking` in config. Other
+  critic roles are intentionally left unchanged.
+- **Native cancellation instead of mid-prompt session deletion (Fix C).** The curator and
+  skill-improver factories forward the caller's `AbortSignal` to `session.create` and
+  `session.prompt`, and the abort→delete listener was removed. This prevents the FK
+  constraint crash that occurred when `cleanup()` deleted a session while OpenCode was
+  still writing parts. Timeout-sentinel translation (`CURATOR_LLM_TIMEOUT` /
+  `SKILL_IMPROVER_LLM_TIMEOUT`) is now narrowed to genuine cancellation
+  (`AbortError`/`TimeoutError`), so a real failure that merely coincides with an aborted
+  signal still surfaces as itself.
+
+## Why
+
+Two screenshots showed the TUI's right window filling with the LLM's internal reasoning.
+Root cause: background ephemeral sessions were created without a `parentID`, so OpenCode
+registered them as root sessions and persisted every part — reasoning included — to the
+session log. A secondary crash occurred when an abort/timeout deleted the session
+mid-prompt, violating a foreign-key constraint in OpenCode's part writer.
+
+## Migration
+
+No action required. Background dispatches behave identically except that their ephemeral
+sessions are now children of the calling session and no longer surface reasoning text in
+the TUI. To restore extended thinking for the curator or autonomous-oversight critic, set
+`thinking` in the relevant `agents.*` config block.
+
+## Scope / follow-up
+
+`AbortSignal` forwarding (Fix C) is implemented only at the curator and skill-improver
+factories, because only those two delegate paths receive an `AbortSignal` from their
+callers today. The other six background `session.create` sites correctly create child
+sessions (Fix A) but do not yet forward a signal — their callers expose no signal
+parameter in the current code. Threading abort plumbing through those call chains is
+deferred to a follow-up and is out of scope for this TUI-flooding fix.

--- a/src/agents/critic.ts
+++ b/src/agents/critic.ts
@@ -820,6 +820,10 @@ export function createCriticAutonomousOversightAgent(
 				edit: false,
 				patch: false,
 			},
+			// Oversight is a verdict/classification task; extended thinking generates
+			// large reasoning parts that flood OpenCode's session log. Disabled by
+			// default; override via agents.critic_oversight.thinking in config.
+			thinking: { type: 'disabled' },
 		},
 	};
 }

--- a/src/agents/curator-agent.ts
+++ b/src/agents/curator-agent.ts
@@ -77,6 +77,10 @@ export function createCuratorAgent(
 				edit: false,
 				patch: false,
 			},
+			// Classification tasks don't benefit from extended thinking; disabling
+			// avoids flooding OpenCode's session log with reasoning parts.
+			// Users may re-enable via agents.curator_<role>.thinking in their config.
+			thinking: { type: 'disabled' },
 		},
 	};
 }

--- a/src/full-auto/oversight.ts
+++ b/src/full-auto/oversight.ts
@@ -376,7 +376,12 @@ export async function dispatchFullAutoOversight(
 		// a child session and does not persist it as a new root in the TUI.
 		const createResult = await client.session.create({
 			...(input.sessionID
-				? { body: { parentID: input.sessionID, title: 'full_auto_oversight background' } }
+				? {
+						body: {
+							parentID: input.sessionID,
+							title: 'full_auto_oversight background',
+						},
+					}
 				: {}),
 			query: { directory: input.directory },
 		});

--- a/src/full-auto/oversight.ts
+++ b/src/full-auto/oversight.ts
@@ -372,7 +372,12 @@ export async function dispatchFullAutoOversight(
 	let criticResponse = '';
 	let dispatchError: unknown;
 	try {
+		// Bind to the calling session as parent so OpenCode treats this as
+		// a child session and does not persist it as a new root in the TUI.
 		const createResult = await client.session.create({
+			...(input.sessionID
+				? { body: { parentID: input.sessionID, title: 'full_auto_oversight background' } }
+				: {}),
 			query: { directory: input.directory },
 		});
 		if (!createResult.data) {

--- a/src/hooks/abort-utils.ts
+++ b/src/hooks/abort-utils.ts
@@ -1,0 +1,12 @@
+/**
+ * True only for genuine cancellation errors (a native `AbortError` /
+ * `TimeoutError` raised when a forwarded `AbortSignal` fires). Used to map
+ * cancellation — and only cancellation — onto timeout sentinels, so a real
+ * failure that merely coincides with an aborted signal still surfaces as
+ * itself rather than being misclassified as a timeout.
+ */
+export function isAbortError(err: unknown): boolean {
+	if (typeof err !== 'object' || err === null) return false;
+	const name = (err as { name?: unknown }).name;
+	return name === 'AbortError' || name === 'TimeoutError';
+}

--- a/src/hooks/curator-llm-factory.ts
+++ b/src/hooks/curator-llm-factory.ts
@@ -139,20 +139,26 @@ export function createCuratorLLMDelegate(
 			}
 		};
 
-		// If the caller already aborted, clean up immediately and bail.
+		// If the caller already aborted, bail.
 		if (signal?.aborted) {
-			cleanup();
 			throw new Error('CURATOR_LLM_TIMEOUT');
 		}
 
-		// Wire up abort listener so the ephemeral session is deleted as soon
-		// as the timeout fires, rather than waiting for the SDK call to settle.
-		signal?.addEventListener('abort', cleanup, { once: true });
+		// Forward the abort signal to SDK fetch calls so native cancellation
+		// is used instead of deleting the session mid-prompt (which caused
+		// FK constraint crashes when OpenCode was still writing parts).
+		const sdkOpts = signal ? { signal } : {};
 
 		try {
-			// 1. Create ephemeral session scoped to project directory
+			// 1. Create ephemeral session scoped to project directory.
+			// Bind to the calling session as parent so OpenCode treats this as
+			// a child session and does not persist it as a new root in the TUI.
 			const createResult = await client.session.create({
+				...(sessionId
+					? { body: { parentID: sessionId, title: `curator_${mode} background` } }
+					: {}),
 				query: { directory },
+				...sdkOpts,
 			});
 			if (!createResult.data) {
 				throw new Error(
@@ -170,27 +176,15 @@ export function createCuratorLLMDelegate(
 			const agentName = resolveCuratorAgentName(mode, sessionId);
 
 			// 3. Prompt using the registered curator agent.
-			let promptResult: Awaited<ReturnType<typeof client.session.prompt>>;
-			try {
-				promptResult = await client.session.prompt({
-					path: { id: ephemeralSessionId },
-					body: {
-						agent: agentName,
-						tools: { write: false, edit: false, patch: false },
-						parts: [{ type: 'text', text: userInput }],
-					},
-				});
-			} catch (promptErr) {
-				// When the abort signal has fired, the abort handler already
-				// deleted the ephemeral session. The SDK will throw a
-				// NotFoundError ("Session not found") for the now-deleted
-				// session. Translate that into CURATOR_LLM_TIMEOUT so the
-				// caller sees a clean timeout rather than an unexpected error.
-				if (signal?.aborted) {
-					throw new Error('CURATOR_LLM_TIMEOUT');
-				}
-				throw promptErr;
-			}
+			const promptResult = await client.session.prompt({
+				path: { id: ephemeralSessionId },
+				body: {
+					agent: agentName,
+					tools: { write: false, edit: false, patch: false },
+					parts: [{ type: 'text', text: userInput }],
+				},
+				...sdkOpts,
+			});
 
 			if (!promptResult.data) {
 				throw new Error(
@@ -203,8 +197,14 @@ export function createCuratorLLMDelegate(
 				(p): p is typeof p & { text: string } => p.type === 'text',
 			);
 			return textParts.map((p) => p.text).join('\n');
+		} catch (err) {
+			// Translate a native AbortError (from signal cancellation) into the
+			// CURATOR_LLM_TIMEOUT sentinel that callers expect.
+			if (signal?.aborted) {
+				throw new Error('CURATOR_LLM_TIMEOUT');
+			}
+			throw err;
 		} finally {
-			signal?.removeEventListener('abort', cleanup);
 			cleanup();
 		}
 	};

--- a/src/hooks/curator-llm-factory.ts
+++ b/src/hooks/curator-llm-factory.ts
@@ -2,6 +2,19 @@ import { swarmState } from '../state.js';
 import type { CuratorLLMDelegate } from './curator.js';
 
 /**
+ * True only for genuine cancellation errors (a native `AbortError` /
+ * `TimeoutError` raised when a forwarded `AbortSignal` fires). Used to map
+ * cancellation — and only cancellation — onto the `CURATOR_LLM_TIMEOUT`
+ * sentinel, so a real failure that merely coincides with an aborted signal
+ * still surfaces as itself rather than being misclassified as a timeout.
+ */
+function isAbortError(err: unknown): boolean {
+	if (typeof err !== 'object' || err === null) return false;
+	const name = (err as { name?: unknown }).name;
+	return name === 'AbortError' || name === 'TimeoutError';
+}
+
+/**
  * Resolve the registered curator agent name for a given swarm session.
  *
  * Resolution priority:
@@ -155,7 +168,12 @@ export function createCuratorLLMDelegate(
 			// a child session and does not persist it as a new root in the TUI.
 			const createResult = await client.session.create({
 				...(sessionId
-					? { body: { parentID: sessionId, title: `curator_${mode} background` } }
+					? {
+							body: {
+								parentID: sessionId,
+								title: `curator_${mode} background`,
+							},
+						}
 					: {}),
 				query: { directory },
 				...sdkOpts,
@@ -187,6 +205,11 @@ export function createCuratorLLMDelegate(
 			});
 
 			if (!promptResult.data) {
+				// A null result while the signal is aborted is the cancellation
+				// path, not a real prompt failure.
+				if (signal?.aborted) {
+					throw new Error('CURATOR_LLM_TIMEOUT');
+				}
 				throw new Error(
 					`Curator LLM prompt failed: ${JSON.stringify(promptResult.error)}`,
 				);
@@ -198,9 +221,11 @@ export function createCuratorLLMDelegate(
 			);
 			return textParts.map((p) => p.text).join('\n');
 		} catch (err) {
-			// Translate a native AbortError (from signal cancellation) into the
-			// CURATOR_LLM_TIMEOUT sentinel that callers expect.
-			if (signal?.aborted) {
+			// Translate only a genuine cancellation (native AbortError from the
+			// forwarded signal) into the CURATOR_LLM_TIMEOUT sentinel. A real
+			// failure that happens to coincide with an aborted signal must
+			// surface as itself rather than being misreported as a timeout.
+			if (isAbortError(err)) {
 				throw new Error('CURATOR_LLM_TIMEOUT');
 			}
 			throw err;

--- a/src/hooks/curator-llm-factory.ts
+++ b/src/hooks/curator-llm-factory.ts
@@ -1,18 +1,6 @@
 import { swarmState } from '../state.js';
+import { isAbortError } from './abort-utils.js';
 import type { CuratorLLMDelegate } from './curator.js';
-
-/**
- * True only for genuine cancellation errors (a native `AbortError` /
- * `TimeoutError` raised when a forwarded `AbortSignal` fires). Used to map
- * cancellation — and only cancellation — onto the `CURATOR_LLM_TIMEOUT`
- * sentinel, so a real failure that merely coincides with an aborted signal
- * still surfaces as itself rather than being misclassified as a timeout.
- */
-function isAbortError(err: unknown): boolean {
-	if (typeof err !== 'object' || err === null) return false;
-	const name = (err as { name?: unknown }).name;
-	return name === 'AbortError' || name === 'TimeoutError';
-}
 
 /**
  * Resolve the registered curator agent name for a given swarm session.
@@ -205,11 +193,6 @@ export function createCuratorLLMDelegate(
 			});
 
 			if (!promptResult.data) {
-				// A null result while the signal is aborted is the cancellation
-				// path, not a real prompt failure.
-				if (signal?.aborted) {
-					throw new Error('CURATOR_LLM_TIMEOUT');
-				}
 				throw new Error(
 					`Curator LLM prompt failed: ${JSON.stringify(promptResult.error)}`,
 				);

--- a/src/hooks/full-auto-intercept.ts
+++ b/src/hooks/full-auto-intercept.ts
@@ -516,7 +516,9 @@ export async function dispatchCriticAndWriteEvent(
 		// a child session and does not persist it as a new root in the TUI.
 		const createResult = await client.session.create({
 			...(sessionID
-				? { body: { parentID: sessionID, title: 'full_auto_critic background' } }
+				? {
+						body: { parentID: sessionID, title: 'full_auto_critic background' },
+					}
 				: {}),
 			query: { directory },
 		});

--- a/src/hooks/full-auto-intercept.ts
+++ b/src/hooks/full-auto-intercept.ts
@@ -511,8 +511,13 @@ export async function dispatchCriticAndWriteEvent(
 
 	let criticResponse = '';
 	try {
-		// 1. Create ephemeral session scoped to project directory
+		// 1. Create ephemeral session scoped to project directory.
+		// Bind to the calling session as parent so OpenCode treats this as
+		// a child session and does not persist it as a new root in the TUI.
 		const createResult = await client.session.create({
+			...(sessionID
+				? { body: { parentID: sessionID, title: 'full_auto_critic background' } }
+				: {}),
 			query: { directory },
 		});
 		if (!createResult.data) {

--- a/src/hooks/skill-improver-llm-factory.ts
+++ b/src/hooks/skill-improver-llm-factory.ts
@@ -15,6 +15,19 @@
 
 import { swarmState } from '../state.js';
 
+/**
+ * True only for genuine cancellation errors (a native `AbortError` /
+ * `TimeoutError` raised when a forwarded `AbortSignal` fires). Used to map
+ * cancellation — and only cancellation — onto the `SKILL_IMPROVER_LLM_TIMEOUT`
+ * sentinel, so a real failure that merely coincides with an aborted signal
+ * still surfaces as itself rather than being misclassified as a timeout.
+ */
+function isAbortError(err: unknown): boolean {
+	if (typeof err !== 'object' || err === null) return false;
+	const name = (err as { name?: unknown }).name;
+	return name === 'AbortError' || name === 'TimeoutError';
+}
+
 export type SkillImproverLLMDelegate = (
 	systemPrompt: string,
 	userInput: string,
@@ -112,7 +125,9 @@ export function createSkillImproverLLMDelegate(
 			// a child session and does not persist it as a new root in the TUI.
 			const createResult = await client.session.create({
 				...(sessionId
-					? { body: { parentID: sessionId, title: 'skill_improver background' } }
+					? {
+							body: { parentID: sessionId, title: 'skill_improver background' },
+						}
 					: {}),
 				query: { directory },
 				...sdkOpts,
@@ -141,6 +156,9 @@ export function createSkillImproverLLMDelegate(
 			});
 
 			if (!promptResult.data) {
+				// A null result while the signal is aborted is the cancellation
+				// path, not a real prompt failure.
+				if (signal?.aborted) throw new Error('SKILL_IMPROVER_LLM_TIMEOUT');
 				throw new Error(
 					`skill_improver LLM prompt failed: ${JSON.stringify(promptResult.error)}`,
 				);
@@ -151,9 +169,11 @@ export function createSkillImproverLLMDelegate(
 			);
 			return textParts.map((p) => p.text).join('\n');
 		} catch (err) {
-			// Translate a native AbortError (from signal cancellation) into the
-			// SKILL_IMPROVER_LLM_TIMEOUT sentinel that callers expect.
-			if (signal?.aborted) throw new Error('SKILL_IMPROVER_LLM_TIMEOUT');
+			// Translate only a genuine cancellation (native AbortError from the
+			// forwarded signal) into the SKILL_IMPROVER_LLM_TIMEOUT sentinel. A
+			// real failure that happens to coincide with an aborted signal must
+			// surface as itself rather than being misreported as a timeout.
+			if (isAbortError(err)) throw new Error('SKILL_IMPROVER_LLM_TIMEOUT');
 			throw err;
 		} finally {
 			cleanup();

--- a/src/hooks/skill-improver-llm-factory.ts
+++ b/src/hooks/skill-improver-llm-factory.ts
@@ -97,15 +97,25 @@ export function createSkillImproverLLMDelegate(
 			}
 		};
 
+		// If the caller already aborted, bail.
 		if (signal?.aborted) {
-			cleanup();
 			throw new Error('SKILL_IMPROVER_LLM_TIMEOUT');
 		}
-		signal?.addEventListener('abort', cleanup, { once: true });
+
+		// Forward the abort signal to SDK fetch calls so native cancellation
+		// is used instead of deleting the session mid-prompt (which caused
+		// FK constraint crashes when OpenCode was still writing parts).
+		const sdkOpts = signal ? { signal } : {};
 
 		try {
+			// Bind to the calling session as parent so OpenCode treats this as
+			// a child session and does not persist it as a new root in the TUI.
 			const createResult = await client.session.create({
+				...(sessionId
+					? { body: { parentID: sessionId, title: 'skill_improver background' } }
+					: {}),
 				query: { directory },
+				...sdkOpts,
 			});
 			if (!createResult.data) {
 				throw new Error(
@@ -117,23 +127,18 @@ export function createSkillImproverLLMDelegate(
 
 			const agentName = resolveSkillImproverAgentName(sessionId);
 
-			let promptResult: Awaited<ReturnType<typeof client.session.prompt>>;
-			try {
-				const prelude = systemPrompt
-					? `${systemPrompt}\n\n---\n\n${userInput}`
-					: userInput;
-				promptResult = await client.session.prompt({
-					path: { id: ephemeralSessionId },
-					body: {
-						agent: agentName,
-						tools: { write: false, edit: false, patch: false },
-						parts: [{ type: 'text', text: prelude }],
-					},
-				});
-			} catch (err) {
-				if (signal?.aborted) throw new Error('SKILL_IMPROVER_LLM_TIMEOUT');
-				throw err;
-			}
+			const prelude = systemPrompt
+				? `${systemPrompt}\n\n---\n\n${userInput}`
+				: userInput;
+			const promptResult = await client.session.prompt({
+				path: { id: ephemeralSessionId },
+				body: {
+					agent: agentName,
+					tools: { write: false, edit: false, patch: false },
+					parts: [{ type: 'text', text: prelude }],
+				},
+				...sdkOpts,
+			});
 
 			if (!promptResult.data) {
 				throw new Error(
@@ -145,8 +150,12 @@ export function createSkillImproverLLMDelegate(
 				(p): p is typeof p & { text: string } => p.type === 'text',
 			);
 			return textParts.map((p) => p.text).join('\n');
+		} catch (err) {
+			// Translate a native AbortError (from signal cancellation) into the
+			// SKILL_IMPROVER_LLM_TIMEOUT sentinel that callers expect.
+			if (signal?.aborted) throw new Error('SKILL_IMPROVER_LLM_TIMEOUT');
+			throw err;
 		} finally {
-			signal?.removeEventListener('abort', cleanup);
 			cleanup();
 		}
 	};

--- a/src/hooks/skill-improver-llm-factory.ts
+++ b/src/hooks/skill-improver-llm-factory.ts
@@ -14,19 +14,7 @@
  */
 
 import { swarmState } from '../state.js';
-
-/**
- * True only for genuine cancellation errors (a native `AbortError` /
- * `TimeoutError` raised when a forwarded `AbortSignal` fires). Used to map
- * cancellation — and only cancellation — onto the `SKILL_IMPROVER_LLM_TIMEOUT`
- * sentinel, so a real failure that merely coincides with an aborted signal
- * still surfaces as itself rather than being misclassified as a timeout.
- */
-function isAbortError(err: unknown): boolean {
-	if (typeof err !== 'object' || err === null) return false;
-	const name = (err as { name?: unknown }).name;
-	return name === 'AbortError' || name === 'TimeoutError';
-}
+import { isAbortError } from './abort-utils.js';
 
 export type SkillImproverLLMDelegate = (
 	systemPrompt: string,
@@ -156,9 +144,6 @@ export function createSkillImproverLLMDelegate(
 			});
 
 			if (!promptResult.data) {
-				// A null result while the signal is aborted is the cancellation
-				// path, not a real prompt failure.
-				if (signal?.aborted) throw new Error('SKILL_IMPROVER_LLM_TIMEOUT');
 				throw new Error(
 					`skill_improver LLM prompt failed: ${JSON.stringify(promptResult.error)}`,
 				);

--- a/src/mutation/generator.ts
+++ b/src/mutation/generator.ts
@@ -89,8 +89,13 @@ export async function generateMutants(
 	};
 
 	try {
-		// 1. Create ephemeral session scoped to project directory
+		// 1. Create ephemeral session scoped to project directory.
+		// Bind to the calling session as parent so OpenCode treats this as
+		// a child session and does not persist it as a new root in the TUI.
 		const createResult = await client.session.create({
+			...(ctx?.sessionID
+				? { body: { parentID: ctx.sessionID, title: 'mutation_generator background' } }
+				: {}),
 			query: { directory },
 		});
 		if (!createResult.data) {

--- a/src/mutation/generator.ts
+++ b/src/mutation/generator.ts
@@ -94,7 +94,12 @@ export async function generateMutants(
 		// a child session and does not persist it as a new root in the TUI.
 		const createResult = await client.session.create({
 			...(ctx?.sessionID
-				? { body: { parentID: ctx.sessionID, title: 'mutation_generator background' } }
+				? {
+						body: {
+							parentID: ctx.sessionID,
+							title: 'mutation_generator background',
+						},
+					}
 				: {}),
 			query: { directory },
 		});

--- a/src/turbo/lean/integration.ts
+++ b/src/turbo/lean/integration.ts
@@ -59,7 +59,7 @@ export interface PhaseCriticResult {
 	evidencePath: string;
 }
 
-// ─── Internal Types ────────────────────────────────────────────────────────────
+// ─── Internal Types ───────────────────────────────────────────────────────────
 
 /**
  * Reviewer evidence record (lean-turbo-reviewer.json).

--- a/src/turbo/lean/integration.ts
+++ b/src/turbo/lean/integration.ts
@@ -59,7 +59,7 @@ export interface PhaseCriticResult {
 	evidencePath: string;
 }
 
-// ─── Internal Types ────────────────────────────────────────────────────────────
+// ─── Internal Types ───────────────────────────────────────────────────────────
 
 /**
  * Reviewer evidence record (lean-turbo-reviewer.json).
@@ -373,12 +373,14 @@ async function writeCriticEvidence(
  * @param criticPackage - Compiled boundary review package
  * @param agentName - Name of the critic agent to dispatch
  * @param timeoutMs - Timeout in milliseconds (0 for no timeout)
+ * @param parentSessionId - Parent session ID to attach as child session
  */
 async function defaultDispatchCriticAgent(
 	directory: string,
 	criticPackage: CriticPackage,
 	agentName: string,
 	timeoutMs: number,
+	parentSessionId?: string,
 ): Promise<string> {
 	const client = swarmState.opencodeClient;
 	if (!client) {
@@ -387,6 +389,9 @@ async function defaultDispatchCriticAgent(
 
 	// Create an ephemeral session for the critic, scoped to the project directory
 	const sessionResult = await client.session.create({
+		...(parentSessionId
+			? { body: { parentID: parentSessionId, title: 'lean_turbo_critic background' } }
+			: {}),
 		query: { directory },
 	});
 
@@ -503,6 +508,7 @@ export const _internals: {
 		pkg: CriticPackage,
 		agentName: string,
 		timeoutMs: number,
+		parentSessionId?: string,
 	) => Promise<string>;
 	resolveDefaultCriticAgent: typeof resolveDefaultCriticAgent;
 	readReviewerEvidence: typeof readReviewerEvidence;
@@ -571,6 +577,7 @@ export async function dispatchPhaseCritic(
 			pkg,
 			agentName,
 			mergedConfig.timeoutMs,
+			sessionID,
 		);
 	} catch (error) {
 		// Fail-closed: dispatch failure → write REJECTED verdict

--- a/src/turbo/lean/integration.ts
+++ b/src/turbo/lean/integration.ts
@@ -59,7 +59,7 @@ export interface PhaseCriticResult {
 	evidencePath: string;
 }
 
-// ─── Internal Types ───────────────────────────────────────────────────────────
+// ─── Internal Types ────────────────────────────────────────────────────────────
 
 /**
  * Reviewer evidence record (lean-turbo-reviewer.json).
@@ -390,7 +390,12 @@ async function defaultDispatchCriticAgent(
 	// Create an ephemeral session for the critic, scoped to the project directory
 	const sessionResult = await client.session.create({
 		...(parentSessionId
-			? { body: { parentID: parentSessionId, title: 'lean_turbo_critic background' } }
+			? {
+					body: {
+						parentID: parentSessionId,
+						title: 'lean_turbo_critic background',
+					},
+				}
 			: {}),
 		query: { directory },
 	});

--- a/src/turbo/lean/reviewer.ts
+++ b/src/turbo/lean/reviewer.ts
@@ -359,6 +359,7 @@ async function defaultDispatchReviewerAgent(
 	reviewPackage: ReviewPackage,
 	agentName: string,
 	timeoutMs: number,
+	parentSessionId?: string,
 ): Promise<string> {
 	const client = swarmState.opencodeClient;
 	if (!client) {
@@ -367,6 +368,9 @@ async function defaultDispatchReviewerAgent(
 
 	// Create an ephemeral session for the reviewer
 	const sessionResult = await client.session.create({
+		...(parentSessionId
+			? { body: { parentID: parentSessionId, title: 'lean_turbo_reviewer background' } }
+			: {}),
 		query: { directory },
 	});
 
@@ -480,6 +484,7 @@ export const _internals: {
 		pkg: ReviewPackage,
 		agentName: string,
 		timeoutMs: number,
+		parentSessionId?: string,
 	) => Promise<string>;
 	resolveDefaultReviewerAgent: typeof resolveDefaultReviewerAgent;
 	listLaneEvidence: typeof listLaneEvidence;
@@ -550,6 +555,7 @@ export async function dispatchPhaseReviewer(
 			pkg,
 			agentName,
 			mergedConfig.timeoutMs,
+			sessionID,
 		);
 	} catch (error) {
 		// Fail-closed: dispatch failure → write REJECTED verdict

--- a/src/turbo/lean/reviewer.ts
+++ b/src/turbo/lean/reviewer.ts
@@ -22,7 +22,7 @@ import {
 import type { LeanTurboRunState } from './state';
 import { readPersisted } from './state';
 
-// ─── Config ───────────────────────────────────────────────────────────────────
+// ─── Config ──────────────────────────────────────────────────────
 
 /**
  * Configuration options for phase reviewer dispatch.
@@ -55,7 +55,7 @@ const DEFAULT_CONFIG: Required<LeanTurboPhaseReviewerConfig> = {
 	requireDiffSummary: false,
 };
 
-// ─── Result Types ─────────────────────────────────────────────────────────────
+// ─── Result Types ────────────────────────────────────────────────
 
 /**
  * Result of a phase reviewer dispatch.
@@ -69,7 +69,7 @@ export interface PhaseReviewerResult {
 	evidencePath: string;
 }
 
-// ─── Internal Functions ────────────────────────────────────────────────────────
+// ─── Internal Functions ─────────────────────────────────────────────
 
 /**
  * Resolves the default reviewer agent name from the generated agent names.
@@ -369,7 +369,12 @@ async function defaultDispatchReviewerAgent(
 	// Create an ephemeral session for the reviewer
 	const sessionResult = await client.session.create({
 		...(parentSessionId
-			? { body: { parentID: parentSessionId, title: 'lean_turbo_reviewer background' } }
+			? {
+					body: {
+						parentID: parentSessionId,
+						title: 'lean_turbo_reviewer background',
+					},
+				}
 			: {}),
 		query: { directory },
 	});
@@ -469,7 +474,7 @@ Be specific and evidence-based. Do not approve a phase with unresolved degraded 
 	}
 }
 
-// ─── _internals Seam ───────────────────────────────────────────────────────────
+// ─── _internals Seam ────────────────────────────────────────────────
 
 /**
  * Test-only dependency-injection seam.
@@ -501,7 +506,7 @@ export const _internals: {
 	readPersisted,
 };
 
-// ─── Public API ───────────────────────────────────────────────────────────────
+// ─── Public API ──────────────────────────────────────────────────
 
 /**
  * Dispatch a read-only reviewer agent to evaluate a completed Lean Turbo phase.

--- a/src/turbo/lean/reviewer.ts
+++ b/src/turbo/lean/reviewer.ts
@@ -22,7 +22,7 @@ import {
 import type { LeanTurboRunState } from './state';
 import { readPersisted } from './state';
 
-// ─── Config ──────────────────────────────────────────────────────
+// ─── Config ───────────────────────────────────────────────────────────────────
 
 /**
  * Configuration options for phase reviewer dispatch.
@@ -55,7 +55,7 @@ const DEFAULT_CONFIG: Required<LeanTurboPhaseReviewerConfig> = {
 	requireDiffSummary: false,
 };
 
-// ─── Result Types ────────────────────────────────────────────────
+// ─── Result Types ─────────────────────────────────────────────────────────────
 
 /**
  * Result of a phase reviewer dispatch.
@@ -69,7 +69,7 @@ export interface PhaseReviewerResult {
 	evidencePath: string;
 }
 
-// ─── Internal Functions ─────────────────────────────────────────────
+// ─── Internal Functions ────────────────────────────────────────────────────────
 
 /**
  * Resolves the default reviewer agent name from the generated agent names.
@@ -474,7 +474,7 @@ Be specific and evidence-based. Do not approve a phase with unresolved degraded 
 	}
 }
 
-// ─── _internals Seam ────────────────────────────────────────────────
+// ─── _internals Seam ───────────────────────────────────────────────────────────
 
 /**
  * Test-only dependency-injection seam.
@@ -506,7 +506,7 @@ export const _internals: {
 	readPersisted,
 };
 
-// ─── Public API ──────────────────────────────────────────────────
+// ─── Public API ───────────────────────────────────────────────────────────────
 
 /**
  * Dispatch a read-only reviewer agent to evaluate a completed Lean Turbo phase.

--- a/src/turbo/lean/runner.ts
+++ b/src/turbo/lean/runner.ts
@@ -68,7 +68,7 @@ interface SessionClient {
 	delete(options: { path: { id: string } }): Promise<void>;
 }
 
-// ─── Result Types ─────────────────────────────────────────────────────────────
+// ─── Result Types ───────────────────────────────────────────────────────────────────
 
 /**
  * Result of a single lane dispatch (session creation + prompt).
@@ -195,7 +195,7 @@ function isTransientProvisionError(errorMsg: string): boolean {
 	return false;
 }
 
-// ─── Runner Class ─────────────────────────────────────────────────────────────
+// ─── Runner Class ───────────────────────────────────────────────────────────────
 
 /**
  * Orchestrates Lean Turbo lane execution.
@@ -340,7 +340,7 @@ export class LeanTurboRunner {
 		this._availableAgents = this._resolveCoderAgents(names);
 	}
 
-	// ─── Public Methods ──────────────────────────────────────────────────────────
+	// ─── Public Methods ─────────────────────────────────────────────────────────────
 
 	/**
 	 * Run a single phase: plan lanes, acquire locks, dispatch coders.
@@ -601,7 +601,12 @@ export class LeanTurboRunner {
 			// Create ephemeral session
 			const createResult = await session.create({
 				...(this._sessionID
-					? { body: { parentID: this._sessionID, title: `lean_turbo_lane_${lane.laneId} background` } }
+					? {
+							body: {
+								parentID: this._sessionID,
+								title: `lean_turbo_lane_${lane.laneId} background`,
+							},
+						}
 					: {}),
 				query: { directory: effectiveDirectory },
 			});
@@ -1467,7 +1472,7 @@ export class LeanTurboRunner {
 	}
 }
 
-// ─── Exported Types ──────────────────────────────────────────────────────────────
+// ─── Exported Types ───────────────────────────────────────────────────────────────
 
 /**
  * Current status of a lane (returned by waitForLanes).

--- a/src/turbo/lean/runner.ts
+++ b/src/turbo/lean/runner.ts
@@ -47,7 +47,10 @@ import {
  * requiring the full SDK type.
  */
 interface SessionClient {
-	create(options: { query: { directory: string } }): Promise<{
+	create(options: {
+		body?: { parentID?: string; title?: string };
+		query: { directory: string };
+	}): Promise<{
 		data: { id: string } | null;
 		error: unknown;
 	}>;
@@ -137,7 +140,7 @@ export interface LeanTurboPhaseResult {
  */
 type LaneLockMap = Record<string, string[]>;
 
-// ─── Transient Error Detection ─────────────────────────────────────────────
+// ─── Transient Error Detection ───────────────────────────────────────────────
 
 /**
  * Determines whether a worktree provisioning error is transient and worth retrying.
@@ -192,7 +195,7 @@ function isTransientProvisionError(errorMsg: string): boolean {
 	return false;
 }
 
-// ─── Runner Class ────────────────────────────────────────────────────────────
+// ─── Runner Class ─────────────────────────────────────────────────────────────
 
 /**
  * Orchestrates Lean Turbo lane execution.
@@ -337,7 +340,7 @@ export class LeanTurboRunner {
 		this._availableAgents = this._resolveCoderAgents(names);
 	}
 
-	// ─── Public Methods ─────────────────────────────────────────────────────────
+	// ─── Public Methods ──────────────────────────────────────────────────────────
 
 	/**
 	 * Run a single phase: plan lanes, acquire locks, dispatch coders.
@@ -597,6 +600,9 @@ export class LeanTurboRunner {
 			const effectiveDirectory = worktreeDirectory ?? this._directory;
 			// Create ephemeral session
 			const createResult = await session.create({
+				...(this._sessionID
+					? { body: { parentID: this._sessionID, title: `lean_turbo_lane_${lane.laneId} background` } }
+					: {}),
 				query: { directory: effectiveDirectory },
 			});
 
@@ -1461,7 +1467,7 @@ export class LeanTurboRunner {
 	}
 }
 
-// ─── Exported Types ────────────────────────────────────────────────────────────
+// ─── Exported Types ──────────────────────────────────────────────────────────────
 
 /**
  * Current status of a lane (returned by waitForLanes).

--- a/tests/unit/agents/agent-thinking-disabled.test.ts
+++ b/tests/unit/agents/agent-thinking-disabled.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	createCriticAgent,
+	createCriticAutonomousOversightAgent,
+	createCriticDriftVerifierAgent,
+} from '../../../src/agents/critic';
+import {
+	type CuratorRole,
+	createCuratorAgent,
+} from '../../../src/agents/curator-agent';
+
+// Fix B (F-005): extended thinking is disabled by default for the
+// classification/verdict agents (curator roles + autonomous-oversight critic),
+// and intentionally left enabled for other critic roles. A regression that
+// re-enabled thinking would re-flood the OpenCode session log.
+
+const TEST_MODEL = 'test-model';
+
+describe('curator agents disable extended thinking', () => {
+	const roles: CuratorRole[] = [
+		'curator_init',
+		'curator_phase',
+		'curator_postmortem',
+	];
+	for (const role of roles) {
+		test(`createCuratorAgent(role=${role}).config.thinking is { type: 'disabled' }`, () => {
+			const agent = createCuratorAgent(TEST_MODEL, undefined, undefined, role);
+			expect(agent.config.thinking).toEqual({ type: 'disabled' });
+		});
+	}
+});
+
+describe('critic thinking configuration (oversight-only scope)', () => {
+	test('createCriticAutonomousOversightAgent disables thinking by default', () => {
+		const agent = createCriticAutonomousOversightAgent(TEST_MODEL);
+		expect(agent.config.thinking).toEqual({ type: 'disabled' });
+	});
+
+	test('createCriticAgent does NOT disable thinking', () => {
+		const agent = createCriticAgent(TEST_MODEL);
+		expect(agent.config.thinking).toBeUndefined();
+	});
+
+	test('createCriticDriftVerifierAgent does NOT disable thinking', () => {
+		const agent = createCriticDriftVerifierAgent(TEST_MODEL);
+		expect(agent.config.thinking).toBeUndefined();
+	});
+});

--- a/tests/unit/full-auto/oversight-parenting.test.ts
+++ b/tests/unit/full-auto/oversight-parenting.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { dispatchFullAutoOversight } from '../../../src/full-auto/oversight';
+import { _internals as stateInternals } from '../../../src/state';
+
+// Fix A: the ephemeral oversight session must be created as a child of the
+// calling session (parentID) so OpenCode does not persist it as a new TUI root.
+
+let tmpDir: string;
+let origClient: typeof stateInternals.swarmState.opencodeClient;
+
+beforeEach(() => {
+	tmpDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'full-auto-oversight-parent-')),
+	);
+	fs.mkdirSync(path.join(tmpDir, '.swarm'), { recursive: true });
+	origClient = stateInternals.swarmState.opencodeClient;
+});
+
+afterEach(() => {
+	stateInternals.swarmState.opencodeClient = origClient;
+	try {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	} catch {
+		// best-effort
+	}
+});
+
+describe('dispatchFullAutoOversight background session parenting', () => {
+	test('binds the critic session to the calling session (parentID + background title)', async () => {
+		let capturedBody: { parentID?: string; title?: string } | undefined;
+		stateInternals.swarmState.opencodeClient = {
+			session: {
+				create: async (params: {
+					body?: { parentID?: string; title?: string };
+				}) => {
+					capturedBody = params.body;
+					return { data: { id: 'oversight-sess' } };
+				},
+				prompt: async () => ({
+					data: {
+						parts: [
+							{
+								type: 'text',
+								text: 'VERDICT: APPROVED\nREASONING: ok\nEVIDENCE_CHECKED: diff\nANTI_PATTERNS_DETECTED: none\nESCALATION_NEEDED: NO',
+							},
+						],
+					},
+				}),
+				delete: async () => ({}),
+			},
+		} as typeof stateInternals.swarmState.opencodeClient;
+
+		await dispatchFullAutoOversight({
+			directory: tmpDir,
+			sessionID: 'sess-parent',
+			trigger: 'test',
+			triggerSource: 'tool_action',
+			criticModel: 'm',
+			oversightAgentName: 'critic_oversight',
+		});
+
+		expect(capturedBody?.parentID).toBe('sess-parent');
+		expect(capturedBody?.title).toContain('background');
+	});
+});

--- a/tests/unit/hooks/abort-utils.test.ts
+++ b/tests/unit/hooks/abort-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { isAbortError } from '../../../src/hooks/abort-utils';
+
+describe('isAbortError', () => {
+	test('returns true for AbortError', () => {
+		const err = new Error('aborted');
+		err.name = 'AbortError';
+		expect(isAbortError(err)).toBe(true);
+	});
+
+	test('returns true for TimeoutError', () => {
+		const err = new Error('timeout');
+		err.name = 'TimeoutError';
+		expect(isAbortError(err)).toBe(true);
+	});
+
+	test('returns false for a plain Error', () => {
+		expect(isAbortError(new Error('UPSTREAM_500'))).toBe(false);
+	});
+
+	test('returns false for non-object values', () => {
+		expect(isAbortError('string error')).toBe(false);
+		expect(isAbortError(null)).toBe(false);
+		expect(isAbortError(undefined)).toBe(false);
+		expect(isAbortError(42)).toBe(false);
+	});
+
+	test('returns false for objects without a matching name', () => {
+		expect(isAbortError({})).toBe(false);
+		expect(isAbortError({ message: 'fail' })).toBe(false);
+	});
+});

--- a/tests/unit/hooks/curator-llm-factory.test.ts
+++ b/tests/unit/hooks/curator-llm-factory.test.ts
@@ -1,17 +1,12 @@
-import { beforeEach, describe, expect, test, vi } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
 import { createCuratorLLMDelegate } from '../../../src/hooks/curator-llm-factory';
 import { swarmState } from '../../../src/state';
 
-// Mock swarmState so we can control opencodeClient and curator agent names
-vi.mock('../../../src/state', () => ({
-	swarmState: {
-		opencodeClient: null,
-		curatorInitAgentNames: [] as string[],
-		curatorPhaseAgentNames: [] as string[],
-		curatorPostmortemAgentNames: [] as string[],
-		activeAgent: new Map<string, string>(),
-	},
-}));
+// NOTE: We deliberately do NOT vi.mock('../../../src/state'). Replacing the
+// shared state module leaks a stripped-down swarmState (missing fields such as
+// agentSessions) into every other test file in Bun's shared test-runner
+// process (AGENTS.md #7 — DI over mock.module). Instead we mutate the real
+// swarmState singleton and restore the touched fields in afterEach.
 
 const mockDelete = vi.fn().mockResolvedValue({ data: undefined });
 const mockPrompt = vi.fn();
@@ -25,17 +20,41 @@ const mockClient = {
 	},
 } as never;
 
+type CuratorStateFields = {
+	opencodeClient: unknown;
+	curatorInitAgentNames: string[];
+	curatorPhaseAgentNames: string[];
+	curatorPostmortemAgentNames: string[];
+	activeAgent: Map<string, string>;
+};
+
+let savedState: CuratorStateFields;
+
 beforeEach(() => {
 	vi.clearAllMocks();
-	(swarmState as { opencodeClient: unknown }).opencodeClient = null;
-	(swarmState as { curatorInitAgentNames: string[] }).curatorInitAgentNames =
-		[];
-	(swarmState as { curatorPhaseAgentNames: string[] }).curatorPhaseAgentNames =
-		[];
-	(
-		swarmState as { curatorPostmortemAgentNames: string[] }
-	).curatorPostmortemAgentNames = [];
-	(swarmState as { activeAgent: Map<string, string> }).activeAgent = new Map();
+	const s = swarmState as unknown as CuratorStateFields;
+	// Snapshot the real fields this suite mutates so afterEach can restore them.
+	savedState = {
+		opencodeClient: s.opencodeClient,
+		curatorInitAgentNames: s.curatorInitAgentNames,
+		curatorPhaseAgentNames: s.curatorPhaseAgentNames,
+		curatorPostmortemAgentNames: s.curatorPostmortemAgentNames,
+		activeAgent: s.activeAgent,
+	};
+	s.opencodeClient = null;
+	s.curatorInitAgentNames = [];
+	s.curatorPhaseAgentNames = [];
+	s.curatorPostmortemAgentNames = [];
+	s.activeAgent = new Map();
+});
+
+afterEach(() => {
+	const s = swarmState as unknown as CuratorStateFields;
+	s.opencodeClient = savedState.opencodeClient;
+	s.curatorInitAgentNames = savedState.curatorInitAgentNames;
+	s.curatorPhaseAgentNames = savedState.curatorPhaseAgentNames;
+	s.curatorPostmortemAgentNames = savedState.curatorPostmortemAgentNames;
+	s.activeAgent = savedState.activeAgent;
 });
 
 describe('createCuratorLLMDelegate', () => {
@@ -51,7 +70,7 @@ describe('createCuratorLLMDelegate', () => {
 		expect(typeof delegate).toBe('function');
 	});
 
-	// ─── Single-swarm resolution ─────────────────────────────────────────────
+	// ─── Single-swarm resolution ────────────────────────────────────
 
 	test('single default swarm: uses curator_init', async () => {
 		(swarmState as { opencodeClient: unknown }).opencodeClient = mockClient;
@@ -89,7 +108,7 @@ describe('createCuratorLLMDelegate', () => {
 		});
 	});
 
-	// ─── Multi-swarm active-agent resolution ─────────────────────────────────
+	// ─── Multi-swarm active-agent resolution ─────────────────────────
 
 	test('multi-swarm: picks curator for active swarm via prefix matching', async () => {
 		(swarmState as { opencodeClient: unknown }).opencodeClient = mockClient;
@@ -234,7 +253,7 @@ describe('createCuratorLLMDelegate', () => {
 		});
 	});
 
-	// ─── Direct sessionId lookup ─────────────────────────────────────────────
+	// ─── Direct sessionId lookup ────────────────────────────────────
 
 	test('sessionId direct lookup: ignores other active sessions, picks calling swarm', async () => {
 		(swarmState as { opencodeClient: unknown }).opencodeClient = mockClient;
@@ -291,7 +310,7 @@ describe('createCuratorLLMDelegate', () => {
 		});
 	});
 
-	// ─── Finding 1 fix: default-swarm sessionId hole ─────────────────────────
+	// ─── Finding 1 fix: default-swarm sessionId hole ──────────────────────
 
 	test('default-swarm session uses curator_init even when named swarms also registered', async () => {
 		// Finding 1 fix: direct lookup must return default-swarm curator (empty prefix)
@@ -328,7 +347,7 @@ describe('createCuratorLLMDelegate', () => {
 		});
 	});
 
-	// ─── Prefix collision (longest-match) ────────────────────────────────────
+	// ─── Prefix collision (longest-match) ────────────────────────────
 
 	test('prefix collision: alpha_extended_ beats alpha_ for alpha_extended_architect', async () => {
 		(swarmState as { opencodeClient: unknown }).opencodeClient = mockClient;
@@ -378,7 +397,7 @@ describe('createCuratorLLMDelegate', () => {
 		});
 	});
 
-	// ─── Session lifecycle ────────────────────────────────────────────────────
+	// ─── Session lifecycle ───────────────────────────────────────
 
 	test('system prompt parameter is NOT forwarded — registered agent uses its own baked-in prompt', async () => {
 		// Finding 3 fix: removing system: override allows registered custom prompts to take effect.
@@ -486,37 +505,118 @@ describe('createCuratorLLMDelegate', () => {
 		expect(result).toBe('final answer');
 	});
 
-	test('NotFoundError from prompt is converted to CURATOR_LLM_TIMEOUT when signal aborts during prompt', async () => {
-		// Regression test: when an AbortController fires (timeout) while
-		// session.prompt() is in flight, the abort handler deletes the
-		// ephemeral session and session.prompt() throws NotFoundError.
-		// Without the fix this becomes an unhandled rejection rather than a
-		// clean CURATOR_LLM_TIMEOUT. This test exercises the NEW catch block
-		// added around session.prompt(), not the existing pre-abort early check.
+	test('aborted signal during prompt is forwarded to the SDK and mapped to CURATOR_LLM_TIMEOUT', async () => {
+		// Fix C: the AbortSignal is forwarded to session.create AND
+		// session.prompt so the SDK cancels natively (instead of the old
+		// abort-handler-deletes-session path). A native AbortError surfaced by
+		// the SDK is then translated into the CURATOR_LLM_TIMEOUT sentinel.
 		(swarmState as { opencodeClient: unknown }).opencodeClient = mockClient;
 		(swarmState as { curatorInitAgentNames: string[] }).curatorInitAgentNames =
 			['curator_init'];
 		mockCreate.mockResolvedValue({ data: { id: 'sess-abort' } });
 
 		const ac = new AbortController();
-		// Simulate: the abort fires DURING prompt execution, then the SDK
-		// throws NotFoundError because the session was deleted by cleanup.
+		// The forwarded signal fires mid-flight; the SDK surfaces an AbortError.
 		mockPrompt.mockImplementation(async () => {
-			// Abort happens mid-flight (abort handler fires, deletes session)
 			ac.abort();
-			const err = new Error('Session not found: sess-abort');
-			err.name = 'NotFoundError';
+			const err = new Error('The operation was aborted');
+			err.name = 'AbortError';
 			throw err;
 		});
 
-		// Signal is NOT pre-aborted; it aborts inside mockPrompt above.
 		const delegate = createCuratorLLMDelegate('/tmp/test')!;
 		await expect(delegate('SYS', 'input', ac.signal)).rejects.toThrow(
 			'CURATOR_LLM_TIMEOUT',
 		);
-		// session.create() and session.prompt() must both have been called
-		expect(mockCreate).toHaveBeenCalledTimes(1);
-		expect(mockPrompt).toHaveBeenCalledTimes(1);
+
+		// Fix C: signal must be forwarded to BOTH SDK calls (native cancellation).
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({ signal: ac.signal }),
+		);
+		expect(mockPrompt).toHaveBeenCalledWith(
+			expect.objectContaining({ signal: ac.signal }),
+		);
+	});
+
+	test('pre-aborted signal bails before any SDK call (CURATOR_LLM_TIMEOUT)', async () => {
+		// F-003: the early `if (signal?.aborted)` guard must short-circuit
+		// before session.create is invoked.
+		(swarmState as { opencodeClient: unknown }).opencodeClient = mockClient;
+		(swarmState as { curatorInitAgentNames: string[] }).curatorInitAgentNames =
+			['curator_init'];
+
+		const ac = new AbortController();
+		ac.abort();
+
+		const delegate = createCuratorLLMDelegate('/tmp/test')!;
+		await expect(delegate('SYS', 'input', ac.signal)).rejects.toThrow(
+			'CURATOR_LLM_TIMEOUT',
+		);
+		expect(mockCreate).not.toHaveBeenCalled();
+	});
+
+	test('real prompt failure that coincides with an aborted signal is NOT mislabeled as timeout', async () => {
+		// cubic P2: only a genuine AbortError maps to the sentinel. A real
+		// failure must surface as itself even if the signal happens to be aborted.
+		(swarmState as { opencodeClient: unknown }).opencodeClient = mockClient;
+		(swarmState as { curatorInitAgentNames: string[] }).curatorInitAgentNames =
+			['curator_init'];
+		mockCreate.mockResolvedValue({ data: { id: 'sess-realfail' } });
+
+		const ac = new AbortController();
+		mockPrompt.mockImplementation(async () => {
+			ac.abort(); // signal becomes aborted, but the error below is the real cause
+			throw new Error('UPSTREAM_500');
+		});
+
+		const delegate = createCuratorLLMDelegate('/tmp/test')!;
+		await expect(delegate('SYS', 'input', ac.signal)).rejects.toThrow(
+			'UPSTREAM_500',
+		);
+	});
+
+	// ─── Background session parenting (Fix A) ────────────────────────
+
+	test('forwards parentID + descriptive title when sessionId is provided', async () => {
+		(swarmState as { opencodeClient: unknown }).opencodeClient = mockClient;
+		(swarmState as { curatorInitAgentNames: string[] }).curatorInitAgentNames =
+			['curator_init'];
+		mockCreate.mockResolvedValue({ data: { id: 'sess-parent' } });
+		mockPrompt.mockResolvedValue({
+			data: { info: {}, parts: [{ type: 'text', text: 'ok' }] },
+		});
+
+		const delegate = createCuratorLLMDelegate(
+			'/tmp/test',
+			'phase',
+			'parent-sess',
+		)!;
+		await delegate('SYS', 'input');
+
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				body: {
+					parentID: 'parent-sess',
+					title: expect.stringContaining('background'),
+				},
+			}),
+		);
+	});
+
+	test('omits body (root session fallback) when no sessionId is provided', async () => {
+		(swarmState as { opencodeClient: unknown }).opencodeClient = mockClient;
+		(swarmState as { curatorInitAgentNames: string[] }).curatorInitAgentNames =
+			['curator_init'];
+		mockCreate.mockResolvedValue({ data: { id: 'sess-root' } });
+		mockPrompt.mockResolvedValue({
+			data: { info: {}, parts: [{ type: 'text', text: 'ok' }] },
+		});
+
+		const delegate = createCuratorLLMDelegate('/tmp/test', 'init')!;
+		await delegate('SYS', 'input');
+
+		const createArg = mockCreate.mock.calls[0][0] as { body?: unknown };
+		expect(createArg.body).toBeUndefined();
 	});
 
 	test('non-abort NotFoundError from prompt is re-thrown unchanged', async () => {

--- a/tests/unit/hooks/full-auto-intercept-parenting.test.ts
+++ b/tests/unit/hooks/full-auto-intercept-parenting.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { dispatchCriticAndWriteEvent } from '../../../src/hooks/full-auto-intercept';
+import { _internals as stateInternals } from '../../../src/state';
+
+// Fix A: dispatchCriticAndWriteEvent must create its ephemeral critic session
+// as a child of the calling architect session (parentID) so OpenCode does not
+// persist it as a new TUI root.
+
+let tmpDir: string;
+let origClient: typeof stateInternals.swarmState.opencodeClient;
+
+beforeEach(() => {
+	tmpDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'fa-intercept-parent-')),
+	);
+	fs.mkdirSync(path.join(tmpDir, '.swarm'), { recursive: true });
+	origClient = stateInternals.swarmState.opencodeClient;
+});
+
+afterEach(() => {
+	stateInternals.swarmState.opencodeClient = origClient;
+	try {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	} catch {
+		// best-effort
+	}
+});
+
+describe('dispatchCriticAndWriteEvent background session parenting', () => {
+	test('attaches parentID + background title when a sessionID is provided', async () => {
+		let capturedBody: { parentID?: string; title?: string } | undefined;
+		stateInternals.swarmState.opencodeClient = {
+			session: {
+				create: async (params: {
+					body?: { parentID?: string; title?: string };
+				}) => {
+					capturedBody = params.body;
+					return { data: { id: 'critic-sess' } };
+				},
+				prompt: async () => ({
+					data: {
+						parts: [
+							{
+								type: 'text',
+								text: 'VERDICT: APPROVED\nREASONING: ok\nEVIDENCE_CHECKED: diff\nANTI_PATTERNS_DETECTED: none\nESCALATION_NEEDED: NO',
+							},
+						],
+					},
+				}),
+				delete: async () => ({}),
+			},
+		} as typeof stateInternals.swarmState.opencodeClient;
+
+		await dispatchCriticAndWriteEvent(
+			tmpDir,
+			'architect output',
+			'critic context',
+			'm',
+			'phase_completion',
+			1,
+			0,
+			'critic_oversight',
+			'architect-sess',
+		);
+
+		expect(capturedBody?.parentID).toBe('architect-sess');
+		expect(capturedBody?.title).toContain('background');
+	});
+
+	test('omits body (root session) when no sessionID is provided', async () => {
+		let capturedBody: unknown;
+		stateInternals.swarmState.opencodeClient = {
+			session: {
+				create: async (params: { body?: unknown }) => {
+					capturedBody = params.body;
+					return { data: { id: 'critic-sess' } };
+				},
+				prompt: async () => ({
+					data: {
+						parts: [
+							{
+								type: 'text',
+								text: 'VERDICT: APPROVED\nREASONING: ok\nEVIDENCE_CHECKED: diff\nANTI_PATTERNS_DETECTED: none\nESCALATION_NEEDED: NO',
+							},
+						],
+					},
+				}),
+				delete: async () => ({}),
+			},
+		} as typeof stateInternals.swarmState.opencodeClient;
+
+		await dispatchCriticAndWriteEvent(
+			tmpDir,
+			'architect output',
+			'critic context',
+			'm',
+			'phase_completion',
+			1,
+			0,
+			'critic_oversight',
+		);
+
+		expect(capturedBody).toBeUndefined();
+	});
+});

--- a/tests/unit/hooks/skill-improver-llm-factory.test.ts
+++ b/tests/unit/hooks/skill-improver-llm-factory.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
+import { createSkillImproverLLMDelegate } from '../../../src/hooks/skill-improver-llm-factory';
+import { swarmState } from '../../../src/state';
+
+// As with curator-llm-factory.test.ts we mutate the real swarmState singleton
+// and restore the touched fields in afterEach, rather than vi.mock-ing the
+// shared state module (which leaks across Bun's shared test-runner process —
+// AGENTS.md #7).
+
+const mockDelete = vi.fn().mockResolvedValue({ data: undefined });
+const mockPrompt = vi.fn();
+const mockCreate = vi.fn();
+
+const mockClient = {
+	session: {
+		create: mockCreate,
+		prompt: mockPrompt,
+		delete: mockDelete,
+	},
+} as never;
+
+type SkillImproverStateFields = {
+	opencodeClient: unknown;
+	skillImproverAgentNames: string[];
+	activeAgent: Map<string, string>;
+};
+
+let savedState: SkillImproverStateFields;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	const s = swarmState as unknown as SkillImproverStateFields;
+	savedState = {
+		opencodeClient: s.opencodeClient,
+		skillImproverAgentNames: s.skillImproverAgentNames,
+		activeAgent: s.activeAgent,
+	};
+	s.opencodeClient = mockClient;
+	s.skillImproverAgentNames = ['skill_improver'];
+	s.activeAgent = new Map();
+});
+
+afterEach(() => {
+	const s = swarmState as unknown as SkillImproverStateFields;
+	s.opencodeClient = savedState.opencodeClient;
+	s.skillImproverAgentNames = savedState.skillImproverAgentNames;
+	s.activeAgent = savedState.activeAgent;
+});
+
+describe('createSkillImproverLLMDelegate', () => {
+	test('returns undefined when opencodeClient is null', () => {
+		(swarmState as { opencodeClient: unknown }).opencodeClient = null;
+		expect(createSkillImproverLLMDelegate('/tmp/test')).toBeUndefined();
+	});
+
+	// ─── Background session parenting (Fix A) ────────────────────────
+
+	test('forwards parentID + descriptive title when sessionId is provided', async () => {
+		mockCreate.mockResolvedValue({ data: { id: 'sess-parent' } });
+		mockPrompt.mockResolvedValue({
+			data: { parts: [{ type: 'text', text: 'ok' }] },
+		});
+
+		const delegate = createSkillImproverLLMDelegate(
+			'/tmp/test',
+			'parent-sess',
+		)!;
+		await delegate('SYS', 'input');
+
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				body: {
+					parentID: 'parent-sess',
+					title: expect.stringContaining('background'),
+				},
+			}),
+		);
+	});
+
+	test('omits body (root session fallback) when no sessionId is provided', async () => {
+		mockCreate.mockResolvedValue({ data: { id: 'sess-root' } });
+		mockPrompt.mockResolvedValue({
+			data: { parts: [{ type: 'text', text: 'ok' }] },
+		});
+
+		const delegate = createSkillImproverLLMDelegate('/tmp/test')!;
+		await delegate('SYS', 'input');
+
+		const createArg = mockCreate.mock.calls[0][0] as { body?: unknown };
+		expect(createArg.body).toBeUndefined();
+	});
+
+	// ─── Abort handling (Fix C + cubic P2) ───────────────────────────
+
+	test('pre-aborted signal bails before any SDK call (SKILL_IMPROVER_LLM_TIMEOUT)', async () => {
+		const ac = new AbortController();
+		ac.abort();
+
+		const delegate = createSkillImproverLLMDelegate('/tmp/test')!;
+		await expect(delegate('SYS', 'input', ac.signal)).rejects.toThrow(
+			'SKILL_IMPROVER_LLM_TIMEOUT',
+		);
+		expect(mockCreate).not.toHaveBeenCalled();
+	});
+
+	test('aborted signal during prompt is forwarded to the SDK and mapped to SKILL_IMPROVER_LLM_TIMEOUT', async () => {
+		mockCreate.mockResolvedValue({ data: { id: 'sess-abort' } });
+
+		const ac = new AbortController();
+		mockPrompt.mockImplementation(async () => {
+			ac.abort();
+			const err = new Error('The operation was aborted');
+			err.name = 'AbortError';
+			throw err;
+		});
+
+		const delegate = createSkillImproverLLMDelegate('/tmp/test')!;
+		await expect(delegate('SYS', 'input', ac.signal)).rejects.toThrow(
+			'SKILL_IMPROVER_LLM_TIMEOUT',
+		);
+
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({ signal: ac.signal }),
+		);
+		expect(mockPrompt).toHaveBeenCalledWith(
+			expect.objectContaining({ signal: ac.signal }),
+		);
+	});
+
+	test('real prompt failure that coincides with an aborted signal is NOT mislabeled as timeout', async () => {
+		mockCreate.mockResolvedValue({ data: { id: 'sess-realfail' } });
+
+		const ac = new AbortController();
+		mockPrompt.mockImplementation(async () => {
+			ac.abort();
+			throw new Error('UPSTREAM_500');
+		});
+
+		const delegate = createSkillImproverLLMDelegate('/tmp/test')!;
+		await expect(delegate('SYS', 'input', ac.signal)).rejects.toThrow(
+			'UPSTREAM_500',
+		);
+	});
+});

--- a/tests/unit/mutation/generator-parenting.test.ts
+++ b/tests/unit/mutation/generator-parenting.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { generateMutants } from '../../../src/mutation/generator';
+import { swarmState } from '../../../src/state';
+
+// Fix A: the ephemeral mutation-generator session must bind to the calling
+// session (parentID) so OpenCode treats it as a child rather than a new TUI
+// root. We mutate the real swarmState singleton and restore it afterwards.
+
+type GeneratorCtx = Parameters<typeof generateMutants>[1];
+
+let savedClient: unknown;
+
+beforeEach(() => {
+	savedClient = (swarmState as { opencodeClient: unknown }).opencodeClient;
+});
+
+afterEach(() => {
+	(swarmState as { opencodeClient: unknown }).opencodeClient = savedClient;
+});
+
+describe('generateMutants background session parenting', () => {
+	test('attaches parentID + background title when ctx.sessionID is present', async () => {
+		let capturedBody: { parentID?: string; title?: string } | undefined;
+		(swarmState as { opencodeClient: unknown }).opencodeClient = {
+			session: {
+				create: async (params: {
+					body?: { parentID?: string; title?: string };
+				}) => {
+					capturedBody = params.body;
+					return { data: { id: 'mut-sess' } };
+				},
+				// Returning a non-JSON body makes generateMutants return [],
+				// but session.create has already been captured by then.
+				prompt: async () => ({
+					data: { parts: [{ type: 'text', text: '[]' }] },
+				}),
+				delete: async () => ({}),
+			},
+		};
+
+		await generateMutants(['src/a.ts'], {
+			sessionID: 'mut-parent',
+			directory: '/tmp/mut',
+		} as unknown as GeneratorCtx);
+
+		expect(capturedBody?.parentID).toBe('mut-parent');
+		expect(capturedBody?.title).toContain('background');
+	});
+
+	test('omits body (root session) when ctx has no sessionID', async () => {
+		let capturedBody: unknown;
+		(swarmState as { opencodeClient: unknown }).opencodeClient = {
+			session: {
+				create: async (params: { body?: unknown }) => {
+					capturedBody = params.body;
+					return { data: { id: 'mut-sess' } };
+				},
+				prompt: async () => ({
+					data: { parts: [{ type: 'text', text: '[]' }] },
+				}),
+				delete: async () => ({}),
+			},
+		};
+
+		await generateMutants(['src/a.ts'], {
+			directory: '/tmp/mut',
+		} as unknown as GeneratorCtx);
+
+		expect(capturedBody).toBeUndefined();
+	});
+});

--- a/tests/unit/turbo/lean/integration-parenting.test.ts
+++ b/tests/unit/turbo/lean/integration-parenting.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { swarmState } from '../../../../src/state';
+import { _internals } from '../../../../src/turbo/lean/integration';
+
+// Fix A: defaultDispatchCriticAgent must create its ephemeral session as a
+// child of the calling session (parentID) when one is provided, so OpenCode
+// does not persist it as a new TUI root.
+
+function makeCriticPackage() {
+	return {
+		phase: 1,
+		sessionID: 'test-session',
+		reviewerVerdict: 'APPROVED' as const,
+		reviewerMissing: false,
+		safetyConcerns: [],
+		laneSummaries: [],
+		filesChanged: [],
+		testResults: { totalLanes: 0, completedLanes: 0, failedLanes: 0 },
+		degradationSummary: {
+			totalDegraded: 0,
+			resolvedDegraded: 0,
+			pendingDegraded: 0,
+		},
+	};
+}
+
+describe('defaultDispatchCriticAgent background session parenting', () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lean-critic-parent-'));
+	});
+
+	afterEach(() => {
+		try {
+			fs.rmSync(dir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('attaches parentID + background title when a parent session is provided', async () => {
+		let capturedBody: { parentID?: string; title?: string } | undefined;
+		const mockClient = {
+			session: {
+				create: mock(
+					async (params: {
+						body?: { parentID?: string; title?: string };
+						query: { directory: string };
+					}) => {
+						capturedBody = params.body;
+						return { data: { id: 'mock-session-id' } };
+					},
+				),
+				prompt: mock(async () => ({
+					data: {
+						parts: [{ type: 'text', text: 'VERDICT: APPROVED\nREASON: ok' }],
+					},
+				})),
+				delete: mock(async () => ({})),
+			},
+		};
+
+		const originalClient = swarmState.opencodeClient;
+		swarmState.opencodeClient = mockClient as typeof mockClient;
+		try {
+			await _internals.dispatchCriticAgent(
+				dir,
+				makeCriticPackage(),
+				'test_critic',
+				0,
+				'parent-sess',
+			);
+			expect(capturedBody?.parentID).toBe('parent-sess');
+			expect(capturedBody?.title).toContain('background');
+		} finally {
+			swarmState.opencodeClient = originalClient;
+		}
+	});
+
+	test('omits body (root session) when no parent session is provided', async () => {
+		let capturedBody: unknown;
+		const mockClient = {
+			session: {
+				create: mock(async (params: { body?: unknown }) => {
+					capturedBody = params.body;
+					return { data: { id: 'mock-session-id' } };
+				}),
+				prompt: mock(async () => ({
+					data: {
+						parts: [{ type: 'text', text: 'VERDICT: APPROVED\nREASON: ok' }],
+					},
+				})),
+				delete: mock(async () => ({})),
+			},
+		};
+
+		const originalClient = swarmState.opencodeClient;
+		swarmState.opencodeClient = mockClient as typeof mockClient;
+		try {
+			await _internals.dispatchCriticAgent(
+				dir,
+				makeCriticPackage(),
+				'test_critic',
+				0,
+			);
+			expect(capturedBody).toBeUndefined();
+		} finally {
+			swarmState.opencodeClient = originalClient;
+		}
+	});
+});

--- a/tests/unit/turbo/lean/reviewer-parenting.test.ts
+++ b/tests/unit/turbo/lean/reviewer-parenting.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { swarmState } from '../../../../src/state';
+import { _internals } from '../../../../src/turbo/lean/reviewer';
+
+// Fix A: defaultDispatchReviewerAgent must create its ephemeral session as a
+// child of the calling session (parentID) when one is provided, so OpenCode
+// does not persist it as a new TUI root.
+
+function makeReviewPackage() {
+	return {
+		phase: 1,
+		sessionID: 'test-session',
+		laneSummaries: [],
+		filesChanged: [],
+		testResults: { totalLanes: 0, completedLanes: 0, failedLanes: 0 },
+		buildStatus: 'unknown' as const,
+		degradationSummary: {
+			totalDegraded: 0,
+			resolvedDegraded: 0,
+			pendingDegraded: 0,
+		},
+	};
+}
+
+describe('defaultDispatchReviewerAgent background session parenting', () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lean-reviewer-parent-'));
+	});
+
+	afterEach(() => {
+		try {
+			fs.rmSync(dir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('attaches parentID + background title when a parent session is provided', async () => {
+		let capturedBody: { parentID?: string; title?: string } | undefined;
+		const mockClient = {
+			session: {
+				create: mock(
+					async (params: {
+						body?: { parentID?: string; title?: string };
+						query: { directory: string };
+					}) => {
+						capturedBody = params.body;
+						return { data: { id: 'mock-session-id' } };
+					},
+				),
+				prompt: mock(async () => ({
+					data: {
+						parts: [{ type: 'text', text: 'VERDICT: APPROVED\nREASON: ok' }],
+					},
+				})),
+				delete: mock(async () => ({})),
+			},
+		};
+
+		const originalClient = swarmState.opencodeClient;
+		swarmState.opencodeClient = mockClient as typeof mockClient;
+		try {
+			await _internals.dispatchReviewerAgent(
+				dir,
+				makeReviewPackage(),
+				'test_reviewer',
+				0,
+				'parent-sess',
+			);
+			expect(capturedBody?.parentID).toBe('parent-sess');
+			expect(capturedBody?.title).toContain('background');
+		} finally {
+			swarmState.opencodeClient = originalClient;
+		}
+	});
+
+	test('omits body (root session) when no parent session is provided', async () => {
+		let capturedBody: unknown;
+		const mockClient = {
+			session: {
+				create: mock(async (params: { body?: unknown }) => {
+					capturedBody = params.body;
+					return { data: { id: 'mock-session-id' } };
+				}),
+				prompt: mock(async () => ({
+					data: {
+						parts: [{ type: 'text', text: 'VERDICT: APPROVED\nREASON: ok' }],
+					},
+				})),
+				delete: mock(async () => ({})),
+			},
+		};
+
+		const originalClient = swarmState.opencodeClient;
+		swarmState.opencodeClient = mockClient as typeof mockClient;
+		try {
+			await _internals.dispatchReviewerAgent(
+				dir,
+				makeReviewPackage(),
+				'test_reviewer',
+				0,
+			);
+			expect(capturedBody).toBeUndefined();
+		} finally {
+			swarmState.opencodeClient = originalClient;
+		}
+	});
+});

--- a/tests/unit/turbo/lean/runner-parenting.test.ts
+++ b/tests/unit/turbo/lean/runner-parenting.test.ts
@@ -7,12 +7,12 @@ import type { LeanTurboLane } from '../../../../src/turbo/lean/state';
 // We drive dispatchLane directly with an injected _sessionOps mock, avoiding
 // the full plan/lock machinery.
 //
-// Injection seam: LeanTurboRunner stores its SDK session operations in the
-// `_sessionOps` field (prefixed by convention as a test seam). The cast below
-// replaces it before the first `dispatchLane` call, skipping network I/O
-// while keeping the full business logic path under test. If the runner is
-// refactored to expose _internals (like integration.ts / reviewer.ts), update
-// to use that instead.
+// `_sessionOps` is a documented public test-seam field declared at
+// runner.ts:265-283. It is part of the class's intentional DI contract — the
+// class JSDoc shows this exact injection pattern. The `as unknown as` cast on
+// the assigned value is only needed because `SessionClient` is not exported
+// and the bun `mock()` wrapper differs in exact type signature while remaining
+// structurally compatible.
 
 const LANE: LeanTurboLane = {
 	laneId: 'lane-1',
@@ -42,13 +42,9 @@ describe('LeanTurboRunner lane session parenting', () => {
 			directory: '/tmp/runner-parent',
 			sessionID: 'sess-parent',
 		});
-		(
-			runner as unknown as {
-				_sessionOps: ReturnType<typeof makeMockSessionOps>;
-			}
-		)._sessionOps = makeMockSessionOps((b) => {
+		runner._sessionOps = makeMockSessionOps((b) => {
 			capturedBody = b as { parentID?: string; title?: string };
-		});
+		}) as unknown as typeof runner._sessionOps;
 
 		const result = await runner.dispatchLane(LANE, 'coder');
 

--- a/tests/unit/turbo/lean/runner-parenting.test.ts
+++ b/tests/unit/turbo/lean/runner-parenting.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { LeanTurboRunner } from '../../../../src/turbo/lean/runner';
+import type { LeanTurboLane } from '../../../../src/turbo/lean/state';
+
+// Fix A: a lane's ephemeral session must be created as a child of the runner's
+// owning session (parentID) so OpenCode does not persist it as a new TUI root.
+// We drive dispatchLane directly with an injected _sessionOps mock, avoiding
+// the full plan/lock machinery.
+
+const LANE: LeanTurboLane = {
+	laneId: 'lane-1',
+	taskIds: ['1.1'],
+	files: ['src/a.ts'],
+	status: 'pending',
+};
+
+function makeMockSessionOps(capture: (body: unknown) => void) {
+	return {
+		create: mock(async (params: { body?: unknown }) => {
+			capture(params.body);
+			return { data: { id: 'lane-sess' }, error: null };
+		}),
+		prompt: mock(async () => ({
+			data: { parts: [{ type: 'text', text: 'Done' }] },
+			error: null,
+		})),
+		delete: mock(async () => {}),
+	};
+}
+
+describe('LeanTurboRunner lane session parenting', () => {
+	test('attaches parentID + background title to the lane session', async () => {
+		let capturedBody: { parentID?: string; title?: string } | undefined;
+		const runner = new LeanTurboRunner({
+			directory: '/tmp/runner-parent',
+			sessionID: 'sess-parent',
+		});
+		(
+			runner as unknown as {
+				_sessionOps: ReturnType<typeof makeMockSessionOps>;
+			}
+		)._sessionOps = makeMockSessionOps((b) => {
+			capturedBody = b as { parentID?: string; title?: string };
+		});
+
+		const result = await runner.dispatchLane(LANE, 'coder');
+
+		expect(result.ok).toBe(true);
+		expect(capturedBody?.parentID).toBe('sess-parent');
+		expect(capturedBody?.title).toContain('background');
+	});
+});

--- a/tests/unit/turbo/lean/runner-parenting.test.ts
+++ b/tests/unit/turbo/lean/runner-parenting.test.ts
@@ -6,6 +6,13 @@ import type { LeanTurboLane } from '../../../../src/turbo/lean/state';
 // owning session (parentID) so OpenCode does not persist it as a new TUI root.
 // We drive dispatchLane directly with an injected _sessionOps mock, avoiding
 // the full plan/lock machinery.
+//
+// Injection seam: LeanTurboRunner stores its SDK session operations in the
+// `_sessionOps` field (prefixed by convention as a test seam). The cast below
+// replaces it before the first `dispatchLane` call, skipping network I/O
+// while keeping the full business logic path under test. If the runner is
+// refactored to expose _internals (like integration.ts / reviewer.ts), update
+// to use that instead.
 
 const LANE: LeanTurboLane = {
 	laneId: 'lane-1',


### PR DESCRIPTION
## Summary

Background LLM dispatches were created without a `parentID`, so OpenCode treated each ephemeral session as a top-level **root** session and persisted *every* message part — including `ReasoningPart` thinking tokens — into the right-hand TUI session log, flooding it. A secondary crash occurred when an abort/timeout deleted a session mid-prompt (FK constraint violation in OpenCode's part writer).

- **Fix A — child sessions (8 `session.create` sites).** Each background `session.create` now passes `body: { parentID, title }` when a calling session ID is available, so OpenCode registers it as a child (not shown in the root TUI log). Sites: `curator-llm-factory`, `skill-improver-llm-factory`, `mutation/generator`, `full-auto/oversight`, `full-auto-intercept`, `turbo/lean/{reviewer,integration,runner}`. Missing session ID → body omitted → root session as before (graceful fallback).
- **Fix B — disable extended thinking for classification agents.** `createCuratorAgent` and `createCriticAutonomousOversightAgent` set `thinking: { type: 'disabled' }` (verdict/classification tasks; configurable via `agents.*.thinking`). Other critic roles unchanged.
- **Fix C — native cancellation.** Curator/skill-improver factories forward the caller's `AbortSignal` to `session.create` and `session.prompt` and drop the abort→delete listener, preventing the FK crash. Timeout-sentinel translation is narrowed to genuine cancellation (`AbortError`/`TimeoutError`) so a real failure coinciding with an aborted signal still surfaces as itself.

Review follow-up (this revision) addresses findings F-001…F-007 and the cubic-dev-ai P2 thread: added parentID/title + abort coverage across all sites, migrated `curator-llm-factory.test.ts` off `vi.mock('src/state')` (cross-file mock leak), narrowed the timeout translation, and added the release-note fragment.

## Invariant audit
- 1 (plugin init): not touched — no plugin entry/registration changes.
- 2 (runtime portability): not touched — no Node/Bun-specific APIs added.
- 3 (subprocesses): not touched — `git diff` shows no `spawn`/`bunSpawn` changes.
- 4 (.swarm containment): not touched — oversight evidence paths unchanged; still via `validateSwarmPath`.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — no `test_runner` repo-validation scopes used.
- 7 (test writing): **touched** — migrated `curator-llm-factory.test.ts` off `vi.mock('../../../src/state')` to snapshot-and-restore the real `swarmState` singleton (the mock was leaking a stripped state object into other suites). New tests use the same real-singleton-restore / exported `_internals` seams and restore in `afterEach`. Evidence: `bun test tests/unit/hooks/curator-llm-factory.test.ts tests/unit/turbo/lean/runner.test.ts` → 94 pass (previously 58 failed from leakage).
- 8 (session state): **touched** — background `session.create` calls now pass `parentID`/`title`; no new global mutable state introduced. Factory delegates still read `swarmState`; tests snapshot/restore the touched fields.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched — no chat/system message hook changes (Fix B is agent-definition config, not a hook).
- 11 (tool registration): not touched.
- 12 (release/cache): **touched** — added `docs/releases/pending/1346-background-session-tui-flooding.md`; no edits to `package.json` version, `CHANGELOG.md`, or `.release-please-manifest.json`.

## Test plan
- [x] `bun run typecheck` — clean.
- [x] `bunx biome ci .` — clean (1927 files, no errors).
- [x] Targeted suites pass together (no cross-file leakage): `bun test` over the curator/skill-improver/full-auto-intercept/mutation/lean reviewer+integration+runner/oversight/agents test files → 284 pass / 0 fail.
- [x] Co-run leakage regression: `curator-llm-factory.test.ts` + `runner.test.ts` → 94 pass.
- [ ] Manual: trigger a curator/oversight/lean background dispatch and confirm no reasoning text appears in the TUI; confirm lane/critic sessions appear as children, not roots.
- [ ] Manual: abort a background dispatch and confirm no FK crash and the session is cleaned up.

_Note: this PR traces a screenshot-reported TUI-flooding bug and does not close a tracked GitHub issue._