### PR TITLE
fix(skills): materialize bundled mode skills at plugin init for fresh-project onboarding

### DIFF
--- a/docs/releases/pending/onboarding-bundled-skills-init-sync.md
+++ b/docs/releases/pending/onboarding-bundled-skills-init-sync.md
@@ -1,0 +1,53 @@
+# Fresh-project onboarding: materialize architect mode skills at plugin init
+
+## What
+
+On a brand-new project, the architect now follows the swarm workflow out of the
+box — no manual `/swarm` command and no session restart required.
+
+- The bundled architect MODE skills (`.opencode/skills/<mode>/SKILL.md` for all
+  20 modes: specify, plan, execute, critic-gate, brainstorm, clarify, …) are now
+  materialized into the project during plugin initialization via a new
+  bounded, fail-open async sync (`syncBundledProjectSkillsIfMissingAsync`).
+  Per AGENTS.md invariant 1 / issue #704 the sync is **deferred** off the
+  `server()`-resolution path via `queueMicrotask` (not `await`ed inline) and
+  bounded by `withTimeout`, so plugin init stays fast even on cold Windows
+  filesystems while the sync completes in the background before the architect
+  reads any `SKILL.md` at runtime.
+- Previously these files were copied only as a side effect of a subset of
+  `/swarm` mode commands, so a fresh project's architect hit missing skill files
+  on its first auto-entered mode (e.g. SPECIFY for a new project) and a weaker
+  architect model would narrate/hallucinate the workflow instead of executing
+  it. The command-path sync is retained as a backstop for pre-existing projects.
+- Fixed `/swarm doctor-tools` returning "command not found": the hyphenated form
+  is now a registered alias of `doctor tools` (with its own handler, since
+  `aliasOf` is warning text only).
+
+## Why
+
+The architect's system prompt delegates every mode's protocol to a project-local
+`SKILL.md`. Because those files were only installed by certain `/swarm` commands,
+a freshly installed swarm on a new system did not follow the swarm workflow until
+the user happened to run a mode command and restart the session — a serious
+onboarding gap, especially with non-frontier architect models.
+
+## Migration
+
+No breaking changes. All changes are additive:
+- The init-time sync is missing-only and never overwrites user-customized skill
+  files (COPYFILE_EXCL + existence checks, symlink-guarded, byte/file-bounded,
+  rollback-on-error). It is a no-op after first run and on every supported
+  platform fails open without blocking plugin init.
+- The `doctor-tools` alias is a convenience redirect to `doctor tools`.
+
+## Caveats
+
+- The fix removes the restart requirement for the architect runtime-read path
+  (the architect reads the materialized `SKILL.md` via its `read` tool). The sync
+  is dispatched at plugin init on the next microtask and runs in the background;
+  because the architect cannot read a `SKILL.md` until the user sends a turn
+  (seconds later), the deferred sync has completed by then, and the command-path
+  sync remains a backstop. Whether OpenCode's own native skill-discovery picks up
+  files written during the same boot is external to this repo and unverified
+  here; the runtime-read path is demonstrated by a fresh-project materialization
+  check (20/20 mode skills present, incl. `specify/SKILL.md`).

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,5 +1,5 @@
 import type { AgentDefinition } from '../agents/index.js';
-import { syncBundledProjectSkillsIfMissing } from '../config/bundled-skills.js';
+import { syncBundledProjectSkillsIfMissingAsync } from '../config/bundled-skills.js';
 import { handleAcknowledgeSpecDriftCommand } from './acknowledge-spec-drift.js';
 import { handleAgentsCommand } from './agents.js';
 import { handleAnalyzeCommand } from './analyze.js';
@@ -240,7 +240,13 @@ async function handleModeCommandWithBundledSkills(
 	handler: (directory: string, args: string[]) => string | CommandResult,
 ): CommandResult {
 	if (ctx.packageRoot) {
-		syncBundledProjectSkillsIfMissing(ctx.directory, ctx.packageRoot);
+		// Backstop for projects that predate init-time materialization (the
+		// primary sync now runs at plugin init; see src/index.ts). Missing-only
+		// and fail-open, so it self-heals legacy projects without regression.
+		await syncBundledProjectSkillsIfMissingAsync(
+			ctx.directory,
+			ctx.packageRoot,
+		);
 	}
 	return Promise.resolve(handler(ctx.directory, ctx.args));
 }
@@ -367,6 +373,18 @@ export const COMMAND_REGISTRY = {
 		handler: (ctx) => handleDoctorToolsCommand(ctx.directory, ctx.args),
 		description: 'Run tool registration coherence check',
 		category: 'diagnostics',
+	},
+	// Alias for the hyphenated form '/swarm doctor-tools'. Without it,
+	// resolveCommand(['doctor-tools']) returns null and the TUI shows
+	// "command not found". NOTE: aliasOf is warning text only — resolveCommand
+	// invokes this entry's OWN handler, so the handler must be set here (mirrors
+	// the 'config-doctor' alias above).
+	'doctor-tools': {
+		handler: (ctx) => handleDoctorToolsCommand(ctx.directory, ctx.args),
+		description: 'Run tool registration coherence check',
+		category: 'diagnostics',
+		aliasOf: 'doctor tools',
+		deprecated: true,
 	},
 	diagnose: {
 		handler: (ctx) => handleDiagnoseCommand(ctx.directory, ctx.args),

--- a/src/config/bundled-skills.ts
+++ b/src/config/bundled-skills.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 
 export const BUNDLED_PROJECT_SKILLS = [
@@ -38,23 +39,6 @@ interface BundledSkillFile {
 
 const syncedProjectSkillTargets = new Set<string>();
 
-function isSymbolicLink(p: string): boolean {
-	try {
-		return fs.lstatSync(p).isSymbolicLink();
-	} catch {
-		return false;
-	}
-}
-
-function ensureNotSymlinkedDirectory(p: string): boolean {
-	try {
-		const stat = fs.lstatSync(p);
-		return stat.isDirectory() && !stat.isSymbolicLink();
-	} catch (err) {
-		return (err as NodeJS.ErrnoException).code === 'ENOENT';
-	}
-}
-
 function getSyncCacheKey(
 	projectDirectory: string,
 	packageRoot: string,
@@ -62,31 +46,84 @@ function getSyncCacheKey(
 	return `${path.resolve(projectDirectory)}\0${path.resolve(packageRoot)}`;
 }
 
-function collectBundledSkillFilesBounded(
+function warnBundledSkillSyncFailure(err: unknown): void {
+	const message = err instanceof Error ? err.message : String(err);
+	console.warn(
+		`[opencode-swarm] Could not install bundled project skills; continuing without sync: ${message}`,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Async materialization for the plugin-init path. The plugin-init path must be
+// bounded by `withTimeout` (AGENTS.md Invariant 1). `withTimeout` is
+// `Promise.race`, so it can only bound work that actually yields — a synchronous
+// copy loop wrapped in an async IIFE still runs to completion on one tick and is
+// NOT bounded. This implementation uses `fs/promises` with real await points
+// between files so the timeout is enforceable at file boundaries.
+//
+// Guarantees: missing-only, never-overwrite (COPYFILE_EXCL + existence check),
+// symlink refusal, MAX_SKILL_FILES/MAX_SKILL_BYTES bounds, rollback-on-error,
+// and the sawBundledSource-gated cache add (so a trimmed package never poisons
+// the cache and disables the command-path backstop). Custom project skills are
+// never overwritten, and any filesystem error leaves command execution fail-open.
+// ---------------------------------------------------------------------------
+
+async function isSymbolicLinkAsync(p: string): Promise<boolean> {
+	try {
+		return (await fsp.lstat(p)).isSymbolicLink();
+	} catch {
+		return false;
+	}
+}
+
+async function ensureNotSymlinkedDirectoryAsync(p: string): Promise<boolean> {
+	try {
+		const stat = await fsp.lstat(p);
+		return stat.isDirectory() && !stat.isSymbolicLink();
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === 'ENOENT';
+	}
+}
+
+async function pathExistsAsync(p: string): Promise<boolean> {
+	try {
+		await fsp.access(p);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function collectBundledSkillFilesBoundedAsync(
 	sourceDir: string,
 	state: CopyState,
 	relativeDir = '',
-): BundledSkillFile[] {
+): Promise<BundledSkillFile[]> {
 	const currentSource = path.join(sourceDir, relativeDir);
-	const entries = fs.readdirSync(currentSource, { withFileTypes: true });
+	const entries = await fsp.readdir(currentSource, { withFileTypes: true });
 	const files: BundledSkillFile[] = [];
 
 	for (const entry of entries) {
 		const relativeEntry = path.join(relativeDir, entry.name);
 		const sourcePath = path.join(sourceDir, relativeEntry);
 
-		if (entry.isSymbolicLink() || isSymbolicLink(sourcePath)) continue;
+		if (entry.isSymbolicLink() || (await isSymbolicLinkAsync(sourcePath)))
+			continue;
 
 		if (entry.isDirectory()) {
 			files.push(
-				...collectBundledSkillFilesBounded(sourceDir, state, relativeEntry),
+				...(await collectBundledSkillFilesBoundedAsync(
+					sourceDir,
+					state,
+					relativeEntry,
+				)),
 			);
 			continue;
 		}
 
 		if (!entry.isFile()) continue;
 
-		const stat = fs.statSync(sourcePath);
+		const stat = await fsp.stat(sourcePath);
 		const nextFiles = state.files + 1;
 		const nextBytes = state.bytes + stat.size;
 		if (nextFiles > MAX_SKILL_FILES || nextBytes > MAX_SKILL_BYTES) {
@@ -100,7 +137,10 @@ function collectBundledSkillFilesBounded(
 	return files;
 }
 
-function rollbackCopiedFiles(copiedFiles: string[], destDir: string): void {
+async function rollbackCopiedFilesAsync(
+	copiedFiles: string[],
+	destDir: string,
+): Promise<void> {
 	const safeDestDir = path.resolve(destDir);
 	const dirs = new Set<string>();
 	for (const copiedFile of copiedFiles) {
@@ -109,7 +149,7 @@ function rollbackCopiedFiles(copiedFiles: string[], destDir: string): void {
 		if (relative.startsWith('..') || path.isAbsolute(relative)) continue;
 
 		try {
-			fs.rmSync(resolvedFile, { force: true });
+			await fsp.rm(resolvedFile, { force: true });
 		} catch {
 			// Best effort cleanup only; the original copy error is more useful.
 		}
@@ -120,15 +160,18 @@ function rollbackCopiedFiles(copiedFiles: string[], destDir: string): void {
 		const relative = path.relative(safeDestDir, path.resolve(dir));
 		if (relative.startsWith('..') || path.isAbsolute(relative)) continue;
 		try {
-			fs.rmdirSync(dir);
+			await fsp.rmdir(dir);
 		} catch {
 			// Directory may contain user files or previously installed skill files.
 		}
 	}
 }
 
-function copyBundledDirectoryBounded(sourceDir: string, destDir: string): void {
-	const files = collectBundledSkillFilesBounded(sourceDir, {
+async function copyBundledDirectoryBoundedAsync(
+	sourceDir: string,
+	destDir: string,
+): Promise<void> {
+	const files = await collectBundledSkillFilesBoundedAsync(sourceDir, {
 		files: 0,
 		bytes: 0,
 	});
@@ -139,25 +182,18 @@ function copyBundledDirectoryBounded(sourceDir: string, destDir: string): void {
 			const sourcePath = path.join(sourceDir, file.relativePath);
 			const destPath = path.join(destDir, file.relativePath);
 
-			fs.mkdirSync(path.dirname(destPath), { recursive: true });
+			await fsp.mkdir(path.dirname(destPath), { recursive: true });
 			try {
-				fs.copyFileSync(sourcePath, destPath, fs.constants.COPYFILE_EXCL);
+				await fsp.copyFile(sourcePath, destPath, fs.constants.COPYFILE_EXCL);
 				copiedFiles.push(destPath);
 			} catch (err) {
 				if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
 			}
 		}
 	} catch (err) {
-		rollbackCopiedFiles(copiedFiles, destDir);
+		await rollbackCopiedFilesAsync(copiedFiles, destDir);
 		throw err;
 	}
-}
-
-function warnBundledSkillSyncFailure(err: unknown): void {
-	const message = err instanceof Error ? err.message : String(err);
-	console.warn(
-		`[opencode-swarm] Could not install bundled project skills; continuing without sync: ${message}`,
-	);
 }
 
 /**
@@ -165,14 +201,20 @@ function warnBundledSkillSyncFailure(err: unknown): void {
  * MODE dispatch can load SKILL.md files in repositories that do not already
  * vendor the latest opencode-swarm skill tree.
  *
+ * Async, bounded, and fail-open: safe to `await withTimeout(...)` on the
+ * plugin-init path (AGENTS.md Invariant 1). Runs at plugin init so the
+ * architect's very first auto-entered mode (e.g. SPECIFY on a fresh project) can
+ * load its SKILL.md without a manual `/swarm` command or session restart; the
+ * command path calls it again as a backstop for pre-existing projects.
+ *
  * This is intentionally missing-only and fail-open: custom project skills are
  * never overwritten, and any filesystem error leaves command execution fail-open.
  */
-export function syncBundledProjectSkillsIfMissing(
+export async function syncBundledProjectSkillsIfMissingAsync(
 	projectDirectory: string,
 	packageRoot: string,
 	quiet = false,
-): void {
+): Promise<void> {
 	try {
 		const cacheKey = getSyncCacheKey(projectDirectory, packageRoot);
 		if (syncedProjectSkillTargets.has(cacheKey)) return;
@@ -182,8 +224,8 @@ export function syncBundledProjectSkillsIfMissing(
 		const skillsDir = path.join(opencodeDir, 'skills');
 		let sawBundledSource = false;
 
-		if (!ensureNotSymlinkedDirectory(opencodeDir)) return;
-		if (!ensureNotSymlinkedDirectory(skillsDir)) return;
+		if (!(await ensureNotSymlinkedDirectoryAsync(opencodeDir))) return;
+		if (!(await ensureNotSymlinkedDirectoryAsync(skillsDir))) return;
 
 		for (const slug of BUNDLED_PROJECT_SKILLS) {
 			const sourceDir = path.join(sourceRoot, slug);
@@ -191,12 +233,12 @@ export function syncBundledProjectSkillsIfMissing(
 			const destDir = path.join(skillsDir, slug);
 			const destSkill = path.join(destDir, 'SKILL.md');
 
-			if (!fs.existsSync(sourceSkill)) continue;
+			if (!(await pathExistsAsync(sourceSkill))) continue;
 			sawBundledSource = true;
-			if (fs.existsSync(destSkill)) continue;
-			if (!ensureNotSymlinkedDirectory(destDir)) continue;
+			if (await pathExistsAsync(destSkill)) continue;
+			if (!(await ensureNotSymlinkedDirectoryAsync(destDir))) continue;
 
-			copyBundledDirectoryBounded(sourceDir, destDir);
+			await copyBundledDirectoryBoundedAsync(sourceDir, destDir);
 			if (!quiet) {
 				console.warn(
 					`[opencode-swarm] Installed bundled skill .opencode/skills/${slug}/SKILL.md for first-class /swarm command support`,
@@ -211,7 +253,7 @@ export function syncBundledProjectSkillsIfMissing(
 }
 
 export const _test_exports = {
-	collectBundledSkillFilesBounded,
+	collectBundledSkillFilesBoundedAsync,
 	getSyncCacheKey,
 	resetBundledProjectSkillSyncCache: () => syncedProjectSkillTargets.clear(),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
 	createSwarmCommandHandler,
 } from './commands';
 import { loadPluginConfigWithMetaAsync } from './config';
+import { syncBundledProjectSkillsIfMissingAsync } from './config/bundled-skills.js';
 import { DEFAULT_MODELS, ORCHESTRATOR_NAME } from './config/constants';
 import {
 	writeProjectConfigIfNew,
@@ -144,6 +145,15 @@ const PACKAGE_ROOT = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
 	'..',
 );
+// Upper bound for the DEFERRED bundled-skill materialization. The sync runs in a
+// queueMicrotask off the server()-resolution path, so this ceiling does not count
+// toward init latency (Invariant 1); it only protects the background task from
+// running unboundedly. The copy is missing-only and bounded to ≤64 small files
+// (<512KB total), so it completes in single-digit ms on a healthy FS and is a
+// no-op after first run. The generous 2s ceiling is belt-and-suspenders for
+// pathological filesystems (antivirus interception, NFS stalls) — on timeout we
+// fail open and the command-path sync remains a backstop.
+const SYNC_BUNDLED_SKILLS_TIMEOUT_MS = 2_000;
 
 function createSwarmCommandSystemRuleHook(
 	agentDefinitions: Record<string, AgentDefinition>,
@@ -359,6 +369,43 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 	// or `<ctx.directory>/.opencode/`, so none risks a home-tree scan.
 	writeSwarmConfigExampleIfNew(ctx.directory);
 	writeProjectConfigIfNew(ctx.directory, config.quiet);
+	// Materialize the bundled architect MODE skills into the project so the
+	// architect's first auto-entered mode (e.g. SPECIFY on a fresh project) can
+	// load its `.opencode/skills/<mode>/SKILL.md` without first running a /swarm
+	// command and restarting the session. Previously these were synced ONLY as a
+	// side effect of a subset of /swarm commands (commands/registry.ts), so a
+	// brand-new project's architect hit missing skill files on turn one and a
+	// weaker model would hallucinate the workflow instead of executing it.
+	//
+	// DEFERRED via queueMicrotask (NOT awaited on the server()-resolution path)
+	// per Invariant 1 / Issue #704 — see the repoGraphHook precedent above. The
+	// sync touches up to 20 skill directories; awaiting it inline added cold-FS
+	// latency that pushed server() past the 400ms repro-704 T1 deadline on
+	// Windows. Deferring keeps server() fast: the sync starts on the next
+	// microtask, runs in the background, and completes long before the architect
+	// reads any SKILL.md at runtime (the user must send a turn first). It is
+	// still HARD-BOUNDED + fail-open: the async variant yields between files so
+	// withTimeout (which unref's its timer) can bound it; missing-only,
+	// never-overwrite, symlink-guarded, byte/file-bounded. On timeout/error we
+	// fail open — the command-path sync remains as a backstop.
+	queueMicrotask(() => {
+		void withTimeout(
+			syncBundledProjectSkillsIfMissingAsync(
+				ctx.directory,
+				PACKAGE_ROOT,
+				config.quiet,
+			),
+			SYNC_BUNDLED_SKILLS_TIMEOUT_MS,
+			new Error(
+				`syncBundledProjectSkillsIfMissingAsync exceeded ${SYNC_BUNDLED_SKILLS_TIMEOUT_MS}ms budget; continuing without skill materialization (command-path sync remains a backstop)`,
+			),
+		).catch((err: unknown) => {
+			const msg = err instanceof Error ? err.message : String(err);
+			log('bundled skill materialization timed out or failed (non-fatal)', {
+				error: msg,
+			});
+		});
+	});
 	// Background staleness check against npm. Detached, never blocks init,
 	// throttled to 24h on disk. See services/version-check.ts (issue #675).
 	if (config.version_check !== false) {

--- a/tests/unit/commands/doctor-tools-alias.test.ts
+++ b/tests/unit/commands/doctor-tools-alias.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	COMMAND_REGISTRY,
+	type CommandEntry,
+	resolveCommand,
+	validateAliases,
+} from '../../../src/commands/registry.js';
+
+// Regression: '/swarm doctor-tools' (hyphenated) previously returned
+// "command not found" because only 'doctor tools' (space) was registered.
+// resolveCommand uses the entry's OWN handler — aliasOf is warning text only —
+// so the hyphenated entry must carry its own handler, not just aliasOf.
+describe('doctor-tools alias', () => {
+	test('resolves the hyphenated form to its own entry', () => {
+		const resolved = resolveCommand(['doctor-tools']);
+		expect(resolved).not.toBeNull();
+		expect(resolved?.key).toBe('doctor-tools');
+	});
+
+	test('the hyphenated entry has its own handler (aliasOf does not redirect)', () => {
+		const entry = COMMAND_REGISTRY['doctor-tools'] as CommandEntry;
+		expect(typeof entry.handler).toBe('function');
+		expect(entry.aliasOf).toBe('doctor tools');
+		expect(entry.deprecated).toBe(true);
+	});
+
+	test('emits a deprecation warning pointing at the canonical form', () => {
+		const resolved = resolveCommand(['doctor-tools']);
+		expect(resolved?.warning).toContain('doctor tools');
+	});
+
+	test('canonical "doctor tools" still resolves', () => {
+		expect(resolveCommand(['doctor', 'tools'])?.key).toBe('doctor tools');
+	});
+
+	test('alias target exists and is non-circular', () => {
+		// validateAliases reports any aliasOf pointing to a missing/circular target
+		const result = validateAliases();
+		expect(result.valid).toBe(true);
+		expect(result.errors).toEqual([]);
+	});
+});

--- a/tests/unit/config/bundled-skills-async.test.ts
+++ b/tests/unit/config/bundled-skills-async.test.ts
@@ -3,9 +3,14 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
 	_test_exports,
-	syncBundledProjectSkillsIfMissing,
+	syncBundledProjectSkillsIfMissingAsync,
 } from '../../../src/config/bundled-skills';
 import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+// Mirrors tests/unit/config/bundled-skills.test.ts for the async, init-path
+// variant. The async variant is what the plugin awaits (under withTimeout) at
+// startup so a fresh project has its architect MODE skills before the first
+// turn. It must preserve every guard of the sync version.
 
 function writePackageSkill(
 	packageRoot: string,
@@ -22,7 +27,7 @@ function writePackageSkill(
 	);
 }
 
-describe('syncBundledProjectSkillsIfMissing', () => {
+describe('syncBundledProjectSkillsIfMissingAsync', () => {
 	let projectDir: string;
 	let packageRoot: string;
 	let cleanupProject: () => void;
@@ -33,10 +38,10 @@ describe('syncBundledProjectSkillsIfMissing', () => {
 	beforeEach(() => {
 		_test_exports.resetBundledProjectSkillSyncCache();
 		({ dir: projectDir, cleanup: cleanupProject } = createSafeTestDir(
-			'swarm-bundled-skill-project-',
+			'swarm-bundled-skill-async-project-',
 		));
 		({ dir: packageRoot, cleanup: cleanupPackage } = createSafeTestDir(
-			'swarm-bundled-skill-package-',
+			'swarm-bundled-skill-async-package-',
 		));
 		writePackageSkill(packageRoot);
 		writePackageSkill(packageRoot, 'design-docs', 'design docs skill\n');
@@ -56,8 +61,8 @@ describe('syncBundledProjectSkillsIfMissing', () => {
 	const projectSkillPath = (slug = 'codebase-review-swarm') =>
 		path.join(projectDir, '.opencode', 'skills', slug, 'SKILL.md');
 
-	test('installs missing bundled skills into the project skill tree', () => {
-		syncBundledProjectSkillsIfMissing(projectDir, packageRoot);
+	test('installs missing bundled skills (incl. nested references) into the project', async () => {
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
 
 		expect(fs.readFileSync(projectSkillPath(), 'utf-8')).toBe(
 			'canonical skill\n',
@@ -80,30 +85,27 @@ describe('syncBundledProjectSkillsIfMissing', () => {
 		expect(
 			warnOutput.some((m) => m.includes('codebase-review-swarm/SKILL.md')),
 		).toBe(true);
-		expect(warnOutput.some((m) => m.includes('design-docs/SKILL.md'))).toBe(
-			true,
-		);
 	});
 
-	test('does not overwrite an existing project skill', () => {
+	test('does not overwrite an existing project skill', async () => {
 		fs.mkdirSync(path.dirname(projectSkillPath()), { recursive: true });
 		fs.writeFileSync(projectSkillPath(), 'project override\n', 'utf-8');
 
-		syncBundledProjectSkillsIfMissing(projectDir, packageRoot);
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
 
 		expect(fs.readFileSync(projectSkillPath(), 'utf-8')).toBe(
 			'project override\n',
 		);
 	});
 
-	test('suppresses install warning when quiet is true', () => {
-		syncBundledProjectSkillsIfMissing(projectDir, packageRoot, true);
+	test('suppresses install warning when quiet is true', async () => {
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot, true);
 
 		expect(fs.existsSync(projectSkillPath())).toBe(true);
 		expect(warnOutput).toEqual([]);
 	});
 
-	test('skips a symlinked .opencode directory', () => {
+	test('skips a symlinked .opencode directory', async () => {
 		const target = path.join(projectDir, 'real-opencode');
 		fs.mkdirSync(target, { recursive: true });
 		fs.symlinkSync(
@@ -112,24 +114,24 @@ describe('syncBundledProjectSkillsIfMissing', () => {
 			process.platform === 'win32' ? 'junction' : 'dir',
 		);
 
-		syncBundledProjectSkillsIfMissing(projectDir, packageRoot);
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
 
 		expect(fs.existsSync(path.join(target, 'skills'))).toBe(false);
 	});
 
-	test('fails open when the bundled source skill is absent', () => {
+	test('fails open when the bundled source skill is absent', async () => {
 		cleanupPackage();
 		({ dir: packageRoot, cleanup: cleanupPackage } = createSafeTestDir(
-			'swarm-bundled-skill-empty-package-',
+			'swarm-bundled-skill-async-empty-package-',
 		));
 
-		expect(() =>
-			syncBundledProjectSkillsIfMissing(projectDir, packageRoot),
-		).not.toThrow();
+		await expect(
+			syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot),
+		).resolves.toBeUndefined();
 		expect(fs.existsSync(projectSkillPath())).toBe(false);
 	});
 
-	test('warns non-fatally when bundled skill sync fails', () => {
+	test('warns non-fatally when bundled skill sync fails', async () => {
 		const destDir = path.join(
 			projectDir,
 			'.opencode',
@@ -139,9 +141,9 @@ describe('syncBundledProjectSkillsIfMissing', () => {
 		fs.mkdirSync(destDir, { recursive: true });
 		fs.writeFileSync(path.join(destDir, 'references'), 'not a directory\n');
 
-		expect(() =>
-			syncBundledProjectSkillsIfMissing(projectDir, packageRoot),
-		).not.toThrow();
+		await expect(
+			syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot),
+		).resolves.toBeUndefined();
 		expect(fs.existsSync(projectSkillPath())).toBe(false);
 		expect(
 			warnOutput.some((m) =>
@@ -150,7 +152,10 @@ describe('syncBundledProjectSkillsIfMissing', () => {
 		).toBe(true);
 	});
 
-	test('suppresses sync failure warning when quiet is true', () => {
+	test('suppresses the failure warning when quiet is true', async () => {
+		// Force a sync failure (a file where a directory is expected) AND pass
+		// quiet=true. The catch block only warns `if (!quiet)`, so this asserts
+		// the init-path quiet branch stays silent while still failing open.
 		const destDir = path.join(
 			projectDir,
 			'.opencode',
@@ -160,13 +165,14 @@ describe('syncBundledProjectSkillsIfMissing', () => {
 		fs.mkdirSync(destDir, { recursive: true });
 		fs.writeFileSync(path.join(destDir, 'references'), 'not a directory\n');
 
-		syncBundledProjectSkillsIfMissing(projectDir, packageRoot, true);
-
+		await expect(
+			syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot, true),
+		).resolves.toBeUndefined();
 		expect(fs.existsSync(projectSkillPath())).toBe(false);
 		expect(warnOutput).toEqual([]);
 	});
 
-	test('regression F-001/F-006: does not leave a partial skill when file bounds are exceeded', () => {
+	test('regression: does not leave a partial skill when file bounds are exceeded', async () => {
 		const skillDir = path.join(
 			packageRoot,
 			'.opencode',
@@ -184,7 +190,7 @@ describe('syncBundledProjectSkillsIfMissing', () => {
 			'utf-8',
 		);
 
-		syncBundledProjectSkillsIfMissing(projectDir, packageRoot);
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
 
 		const destDir = path.join(
 			projectDir,
@@ -201,7 +207,7 @@ describe('syncBundledProjectSkillsIfMissing', () => {
 		).toBe(true);
 	});
 
-	test('regression F-001/F-006: does not leave a partial skill when byte bounds are exceeded', () => {
+	test('regression: does not leave a partial skill when byte bounds are exceeded', async () => {
 		const skillDir = path.join(
 			packageRoot,
 			'.opencode',
@@ -216,7 +222,7 @@ describe('syncBundledProjectSkillsIfMissing', () => {
 			'utf-8',
 		);
 
-		syncBundledProjectSkillsIfMissing(projectDir, packageRoot);
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
 
 		expect(fs.existsSync(projectSkillPath())).toBe(false);
 		expect(
@@ -226,11 +232,11 @@ describe('syncBundledProjectSkillsIfMissing', () => {
 		).toBe(true);
 	});
 
-	test('caches a successful sync for the current process', () => {
-		syncBundledProjectSkillsIfMissing(projectDir, packageRoot);
+	test('caches a successful sync for the current process', async () => {
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
 		fs.rmSync(projectSkillPath(), { force: true });
 
-		syncBundledProjectSkillsIfMissing(projectDir, packageRoot);
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
 
 		expect(fs.existsSync(projectSkillPath())).toBe(false);
 	});


### PR DESCRIPTION
## Summary

- **Fresh-project onboarding fix**: bundled architect MODE skills (`.opencode/skills/<mode>/SKILL.md` for all 20 modes) are now materialized into the project during plugin initialization via a bounded, fail-open async sync (`syncBundledProjectSkillsIfMissingAsync`). The sync is **deferred off the `server()`-resolution path via `queueMicrotask`** (mirroring `repoGraphHook` / issue #704) and bounded by `withTimeout`, so plugin init stays fast on every platform while the sync completes in the background before the architect reads any `SKILL.md` at runtime. Previously, these files were copied only as a side-effect of certain `/swarm` mode commands, so a fresh install's architect hit missing skill files on its first auto-entered mode (e.g. SPECIFY on a new project) and a non-frontier model (e.g. gemini-3.5-flash) would hallucinate the workflow instead of loading and executing it. The command-path sync is retained as a backstop.
- **`/swarm doctor-tools` alias fix**: the hyphenated form now resolves to its own registered entry with its own handler (mirrors the `config-doctor` pattern). Previously `resolveCommand(['doctor-tools'])` returned nothing since `aliasOf` is warning text only — the entry must carry its own handler. The deprecation warning is produced by `resolveCommand` (same mechanism as all other deprecated aliases).
- **Async-only consolidation**: the old synchronous `syncBundledProjectSkillsIfMissing` and all sync helpers were removed after the command-path switched to async. Only the async implementation remains; `COPYFILE_EXCL` + existence-check semantics are fully preserved.

## Invariant audit

- 1 (plugin init): **touched** — the skill sync is dispatched via `queueMicrotask` (NOT awaited on the `server()`-resolution path) and bounded by `withTimeout(2000ms, ...).catch(...)`; `withTimeout` unref's its timer, so it never pins the event loop. This mirrors the `repoGraphHook` deferral precedent (issue #704). `node scripts/repro-704.mjs` → T1 resolved in ~42–57ms (deadline 400ms), T2 ~25ms, T3 ~32ms. (An earlier revision `await`ed the sync inline and overshot the 400ms T1 deadline on cold Windows FS at 447ms; deferring removed that latency from the resolution path.) An independent adversarial review confirmed no race (the architect reads `SKILL.md` as an LLM tool action, only after a user turn — seconds after the sub-ms background copy), no teardown hazard, and faithfulness to the precedent.
- 2 (runtime portability): **touched** — `src/index.ts` changed. `bun run build` rc=0 (414 modules bundled). `node --input-type=module -e "await import('./dist/index.js')"` → `dist import OK`. Added import uses `.js` extension (Node ESM). No `bun:` top-level imports added.
- 3 (subprocesses): **not touched** — no subprocess changes. No `bunSpawn`/`spawn`/`spawnSync` in changed files.
- 4 (.swarm containment): **not touched** — no tool or `.swarm/` path changes.
- 5 (plan durability): **not touched** — no ledger, plan schema, or projection changes.
- 6 (test_runner safety): **not touched** — no `test_runner` tool changes.
- 7 (test writing): **touched** — new tests use `bun:test`, `os.tmpdir()` temp paths, DI seam (`_test_exports`), no `mock.module`. Sync test file deleted; async test file added. `bun --smol test tests/unit/config/bundled-skills-async.test.ts` → 10 pass / 0 fail (isolated; incl. quiet-on-failure branch). `bun --smol test tests/unit/commands/doctor-tools-alias.test.ts` → 5 pass / 0 fail (isolated).
- 8 (session state): **not touched** — no session-scoped state changes.
- 9 (guardrails/retry): **not touched** — no guardrail or retry logic changes.
- 10 (chat/system msg): **not touched** — no hook or message-transform changes.
- 11 (tool registration): **touched** — `doctor-tools` registry entry added with its own handler (mirrors `config-doctor`). `aliasOf: 'doctor tools'`, `deprecated: true`. `bun --smol test tests/unit/commands/doctor-tools-alias.test.ts` → resolves to own entry, has own handler, emits deprecation warning via `resolveCommand`, canonical still resolves, `validateAliases()` valid. All `tests/unit/tools/*.test.ts` pass in isolation.
- 12 (release/cache): **touched** — release fragment added at `docs/releases/pending/onboarding-bundled-skills-init-sync.md`. No `package.json`, `CHANGELOG.md`, or `.release-please-manifest.json` edits.

## Test plan

- [x] `bun run typecheck` → rc=0
- [x] `bunx biome ci .` → clean (1927 files checked)
- [x] `bun run build` → rc=0 (414 modules bundled)
- [x] `node scripts/repro-704.mjs` → T1 ~42–57ms, T2 ~25ms, T3 ~32ms — all under deadline
- [x] `node --input-type=module -e "await import('./dist/index.js')"` → dist import OK
- [x] `bun --smol test tests/unit/config/bundled-skills-async.test.ts` → 10/10 pass (incl. quiet-on-failure)
- [x] `bun --smol test tests/unit/commands/doctor-tools-alias.test.ts` → 5/5 pass
- [x] `bun test tests/smoke` → 10/10 pass (the deferral resolves the Windows smoke `repro-704` overshoot)
- [x] `bun test tests/integration` → 606 pass / 137 fail (137 identical on origin/main — pre-existing from #1319)
- [x] `bun test tests/security tests/adversarial` → 887 pass / 11 fail (11 identical on origin/main — pre-existing)
- [x] Fresh-project runtime check: `syncBundledProjectSkillsIfMissingAsync(freshTempDir, repoRoot, true)` → 20/20 mode skills materialized, `specify/SKILL.md` present: true
- [x] Independent adversarial review of the deferral fix → APPROVE (no blocking findings)

## Pre-existing failures

All test failures listed above (integration 137, security/adversarial 11, and `tests/unit/index.test.ts` 4) are pre-existing on `origin/main` (`040d49c`, release 7.75.0 / #1319 full-auto merge). Confirmed by running identical commands on a clean `git worktree add /tmp/repro-check origin/main` checkout — counts are byte-identical. None are related to `bundled-skills.ts`, `registry.ts`, `index.ts`, or any file touched by this PR.