### PR TITLE
fix(pr-review): dispatch explorer lanes deterministically

### DIFF
--- a/.agents/skills/swarm-pr-review/SKILL.md
+++ b/.agents/skills/swarm-pr-review/SKILL.md
@@ -264,9 +264,9 @@ Tool candidate rules:
 
 ## Phase 3: Parallel Base Explorer Lanes
 
-Launch all base lanes in parallel in a single message with multiple Agent tool calls when the environment supports it (`run_in_background: true`). Use `Explore` subagents for exploration.
+Launch all base lanes with the `dispatch_lanes` tool in one call. Pass the six lane specs together, set `max_concurrent` to `6`, and treat the returned `lane_results` as the join barrier before synthesis. Use read-only explorer/reviewer-style agents; do not rely on model-emitted background Agent calls or native background flags for base-lane parallelism.
 
-If the Agent tool is unavailable, simulate isolated passes. Do not let one lane's conclusions bias another lane.
+If `dispatch_lanes` is unavailable, simulate isolated passes. Do not let one lane's conclusions bias another lane, and record that deterministic dispatch was unavailable in the validation gate.
 
 Explorers optimize for recall. Over-reporting is expected. Explorers produce candidates only.
 
@@ -304,7 +304,7 @@ Explorers must not use `CONFIRMED`, `DISPROVED`, or `PRE_EXISTING` as verdict la
 
 ## Phase 4: Triggered Swarm Plugin Micro-Lanes
 
-After base lanes start, inspect the context pack risk triggers. Launch focused micro-lanes for triggered categories only. Do not launch irrelevant micro-lanes.
+After `dispatch_lanes` returns for base lanes, inspect the context pack risk triggers. Launch focused micro-lanes for triggered categories only, using `dispatch_lanes` again when more than one read-only micro-lane is needed. Do not launch irrelevant micro-lanes.
 
 Each micro-lane receives:
 
@@ -591,7 +591,7 @@ Council mode is opt-in only and adversarial.
 When triggered:
 
 1. Build the same context pack as default mode.
-2. Launch all council agents in a single message with multiple Agent tool calls when supported (`run_in_background: true`).
+2. Launch all council agents with one `dispatch_lanes` call when available; use the returned `lane_results` as the join barrier before reviewer classification.
 3. Each council agent assumes all work is wrong until code evidence proves otherwise.
 4. Each agent hunts within its lane only.
 5. Agents return evidence states only: `EVIDENCE_FOUND`, `SUSPICIOUS`, or `CLEAN`.
@@ -665,6 +665,7 @@ Before writing the final output, print this checklist with filled values. Every 
 [VALIDATION] obligation count: ___
 [VALIDATION] repo graph / impact cone source: ___
 [VALIDATION] deterministic signals ingested: ___
+[VALIDATION] deterministic lane dispatcher used: YES/NO — ___
 [VALIDATION] base explorer lanes dispatched: ___ / 6
 [VALIDATION] base explorer lanes returned: ___ / 6
 [VALIDATION] triggered micro-lanes: ___

--- a/.claude/skills/swarm-pr-review/SKILL.md
+++ b/.claude/skills/swarm-pr-review/SKILL.md
@@ -166,7 +166,7 @@ When the PR has merge conflicts:
 
 When the user asks for a "council", "independent review", "N-agent review", or uses phrases like "assume all work is wrong", run the explorer lanes as a parallel **adversarial council**:
 
-1. Launch all council agents in a **single message with multiple Agent tool calls** so they run in parallel, in the background (`run_in_background: true`), using the `Explore` subagent type.
+1. In OpenCode, launch all council agents with one `dispatch_lanes` call and treat `lane_results` as the join barrier. In Claude Code, launch the council agents as parallel Agent calls in the same response, using the `Explore` subagent type.
 2. Each agent is told to **assume all work is WRONG until code evidence proves otherwise** and to hunt for bugs in its lane only.
 3. Default lane set for a 5-agent council:
    - correctness and edge cases
@@ -221,9 +221,9 @@ Common patterns to verify:
 
 ---
 
-### Phase 2: Parallel Explorer Lanes (6 lanes, launch in single message)
+### Phase 2: Parallel Explorer Lanes (6 lanes, one dispatch batch)
 
-Launch all 6 lanes in parallel in a **single message with multiple Agent tool calls** (`run_in_background: true`). Each lane produces candidate findings with exact file:line evidence — not final verdicts.
+In OpenCode, launch all 6 lanes with one `dispatch_lanes` call, `max_concurrent: 6`, and use the returned `lane_results` as the join barrier before synthesis. In Claude Code, launch all 6 lanes as parallel Agent calls in the same response. Each lane produces candidate findings with exact file:line evidence — not final verdicts.
 
 | Lane | Focus | Lane-Specific Checklist |
 |------|-------|----------------------|
@@ -344,7 +344,7 @@ Run the **Runtime-Aware False-Positive Guard Checklist** (below) before confirmi
 
 When user requests council review or uses phrases like "independent review", "5-agent review", "assume all work is wrong":
 
-1. Launch all 6 explorer lanes as **adversarial council agents** in parallel (`run_in_background: true`)
+1. In OpenCode, launch all 6 explorer lanes as adversarial council agents with one `dispatch_lanes` call; in Claude Code, launch them as parallel Agent calls.
 2. Each agent assumes **all work is WRONG until code evidence proves otherwise**
 3. Each agent returns: `EVIDENCE_FOUND / SUSPICIOUS / CLEAN` with file:line evidence, capped at N words. Agents must not return CONFIRMED, DISPROVED, or final severity.
 4. Main thread acts as **independent reviewer** — re-reads file:line evidence directly and classifies candidates
@@ -462,6 +462,7 @@ parallel with explorer lanes to confirm candidate regressions are real.
 [TEST EXECUTION] result: ___ (N pass, N fail)
 [TEST EXECUTION] regression failures (PR-introduced): ___ (count)
 [TEST EXECUTION] pre-existing failures (base branch): ___ (count)
+[VALIDATION] deterministic lane dispatcher used: YES/NO — ___
 [VALIDATION] reviewer dispatched: ___ (agent type, task description)
 [VALIDATION] reviewer returned: ___ (APPROVED / REJECTED / CONCERNS — copy verdict text)
 [VALIDATION] critic dispatched: ___ (agent type, task description) OR "SKIPPED — no reviewer-confirmed HIGH or borderline-confidence findings"

--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -468,14 +468,11 @@ Tool candidate rules:
 
 ## Phase 3: Parallel Base Explorer Lanes
 
-Launch all base lanes in parallel in a single message with multiple Agent tool calls when the environment supports it (`run_in_background: true`). Use `Explore` subagents for exploration.
+Launch all base lanes with the `dispatch_lanes` tool in one call. Pass the six lane specs together, set `max_concurrent` to `6`, and treat the returned `lane_results` as the join barrier before synthesis. Use read-only explorer/reviewer-style agents; do not rely on model-emitted background Agent calls or native background flags for base-lane parallelism.
 
-If the Agent tool is unavailable, simulate isolated passes. Do not let one lane's conclusions bias another lane.
+If `dispatch_lanes` is unavailable, simulate isolated passes. Do not let one lane's conclusions bias another lane, and record that deterministic dispatch was unavailable in the validation gate.
 
-**task_id uniqueness for parallel dispatches:** When re-dispatching failed or re-running explorer lanes, apply these rules:
-- For Agent tools that require caller-supplied `task_id` values, every parallel explorer lane invocation and retry MUST use a unique ID across the review session, including lane and attempt suffix (e.g. `pr_review_explore_lane1_attempt2`). Never reuse a prior `task_id` unless intentionally resuming that exact lane.
-- If the runtime auto-generates `task_id` values (resume mode), omit the `task_id` parameter rather than fabricating one.
-- Do not use the same `task_id` across concurrent lane dispatches — schema validation rejects duplicate `task_id` values.
+**lane id uniqueness for parallel dispatches:** When re-dispatching failed or re-running explorer lanes, every `dispatch_lanes` lane `id` MUST be unique within that dispatch batch and should include lane and attempt suffixes (e.g. `pr_review_explore_lane1_attempt2`). Never reuse an id in the same batch unless intentionally replacing that exact lane before dispatch.
 
 Explorers optimize for recall. Over-reporting is expected. Explorers produce candidates only.
 
@@ -513,7 +510,7 @@ Explorers must not use `CONFIRMED`, `DISPROVED`, or `PRE_EXISTING`.
 
 ## Phase 4: Triggered Swarm Plugin Micro-Lanes
 
-After base lanes start, inspect the context pack risk triggers. Launch focused micro-lanes for triggered categories only. Do not launch irrelevant micro-lanes.
+After `dispatch_lanes` returns for base lanes, inspect the context pack risk triggers. Launch focused micro-lanes for triggered categories only, using `dispatch_lanes` again when more than one read-only micro-lane is needed. Do not launch irrelevant micro-lanes.
 
 Each micro-lane receives:
 
@@ -796,7 +793,7 @@ Council mode is opt-in only and adversarial.
 When triggered:
 
 1. Build the same context pack as default mode.
-2. Launch all council agents in a single message with multiple Agent tool calls when supported (`run_in_background: true`).
+2. Launch all council agents with one `dispatch_lanes` call when available; use the returned `lane_results` as the join barrier before reviewer classification.
 3. Each council agent assumes all work is wrong until code evidence proves otherwise.
 4. Each agent hunts within its lane only.
 5. Agents return evidence states only: `EVIDENCE_FOUND`, `SUSPICIOUS`, or `CLEAN`.
@@ -872,6 +869,7 @@ Before writing the final output, print this checklist with filled values. Every 
 [VALIDATION] obligation count: ___
 [VALIDATION] repo graph / impact cone source: ___
 [VALIDATION] deterministic signals ingested: ___
+[VALIDATION] deterministic lane dispatcher used: YES/NO — ___
 [VALIDATION] base explorer lanes dispatched: ___ / 6
 [VALIDATION] base explorer lanes returned: ___ / 6
 [VALIDATION] triggered micro-lanes: ___

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,7 +100,7 @@ Discovery is deliberate and robust:
 Current signal-triggered modes: `DEEP_DIVE`, `PR_REVIEW`, `PR_FEEDBACK`, `DESIGN_DOCS`, `COUNCIL`, `ISSUE_INGEST` (and the spec-workflow modes `SPECIFY`, `BRAINSTORM`, `CLARIFY-SPEC`).
 
 #### PR_REVIEW Protocol
-Triggered by `/swarm pr-review`. A read-only, structured review: intent reconstruction → 6 parallel explorer lanes → independent reviewer confirmation → critic challenge on HIGH/CRITICAL → synthesis. The architect checks out the PR branch locally before exploring (explorers read the working tree, not git history) and launches the skill's triggered micro-lanes for risk categories present in the diff. Does NOT mutate source or delegate to the coder.
+Triggered by `/swarm pr-review`. A read-only, structured review: intent reconstruction → 6 parallel explorer lanes via the `dispatch_lanes` join barrier → independent reviewer confirmation → critic challenge on HIGH/CRITICAL → synthesis. The architect checks out the PR branch locally before exploring (explorers read the working tree, not git history) and launches the skill's triggered micro-lanes for risk categories present in the diff. Does NOT mutate source or delegate to the coder.
 
 #### PR_FEEDBACK Protocol
 Triggered by `/swarm pr-feedback`. Ingests and closes **known** feedback (review threads, requested changes, CI failures, conflicts, pasted notes) rather than discovering new findings. The architect checks out the PR branch, builds a complete feedback ledger, verifies every item against source (CONFIRMED / DISPROVED / PRE_EXISTING / NEEDS_USER_DECISION), fixes confirmed items plus their tests/docs, and reports a closure ledger for every item. GitHub review threads are resolved only on explicit user instruction.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -156,12 +156,12 @@ Launch a structured deep PR review using multi-lane parallel analysis with indep
 
 **Workflow:**
 1. **Intent Reconstruction** — Extract obligations from PR body checkboxes, linked issues, commit scopes, test names, and interface changes
-2. **Parallel Explorer Lanes** — 6 lanes: correctness, security, dependencies, docs-vs-intent, tests, performance/architecture
+2. **Parallel Explorer Lanes** — 6 lanes dispatched through the deterministic `dispatch_lanes` join barrier: correctness, security, dependencies, docs-vs-intent, tests, performance/architecture
 3. **Independent Reviewer Confirmation** — Validate each finding with file:line evidence
 4. **Critic Challenge** — Adversarial review of HIGH/CRITICAL findings only
 5. **Synthesis** — Obligation assessment, findings table, merge recommendation
 
-The architect checks out the PR branch locally before launching explorers and runs the skill's triggered micro-lanes automatically — you no longer need to ask for these by hand.
+The architect checks out the PR branch locally before launching explorers and runs the skill's triggered micro-lanes automatically. OpenCode uses `dispatch_lanes` for read-only lane fan-out so local models do not need to emit background Agent calls by hand.
 
 **Council variant** (`--council`): After standard review, convene a General Council to evaluate review quality and hunt for blind spots. Council findings are supplementary.
 

--- a/docs/releases/pending/1352-parallel-lane-dispatch.md
+++ b/docs/releases/pending/1352-parallel-lane-dispatch.md
@@ -1,0 +1,1 @@
+Fixes PR-review lane dispatch so OpenCode uses a deterministic `dispatch_lanes` tool to fan out read-only explorer/reviewer lanes concurrently and join their results, instead of depending on local models to emit background Agent calls.

--- a/docs/releases/pending/1358-dispatch-lanes-review-feedback.md
+++ b/docs/releases/pending/1358-dispatch-lanes-review-feedback.md
@@ -1,0 +1,37 @@
+# Dispatch-lanes review feedback fixes
+
+Addresses review findings on the `dispatch_lanes` tool introduced in PR #1358.
+
+## What changed
+
+- Hardened the read-only lane tool denylist to also block `summarize_work` and
+  `doc_scan`, preventing read-only lanes from mutating `.swarm/` evidence or the
+  documentation manifest cache.
+- Fixed `boundLaneOutput` so the returned string never exceeds
+  `MAX_LANE_OUTPUT_CHARS` (20,000), including the truncation suffix.
+- Replaced the `formatError` `JSON.stringify` fallback with a safe, bounded
+  `String()` representation that handles circular objects and non-Error thrown
+  values without leaking large payloads.
+- Removed a no-op identity catch in the `runLane` session-create timeout path.
+- Added regression tests for duplicate lane ID rejection, schema boundary
+  validation (empty/missing fields, `max_concurrent`, `timeout_ms`), and
+  `max_concurrent` clamping behavior.
+
+## Why
+
+The original `dispatch_lanes` implementation passed CI but left several review
+findings unaddressed: write-adjacent tools were still exposed to read-only
+lanes, output truncation could exceed the documented limit, error formatting
+could throw on circular structures, and key schema/validation paths lacked unit
+ test coverage.
+
+## Migration
+
+No migration required. The tool's public shape and arguments are unchanged;
+only internal correctness and test coverage improved.
+
+## Caveats
+
+- `Error.message` strings are still returned verbatim without truncation. This
+  is intentional for `Error` instances; only non-Error thrown values are
+  bounded to `MAX_ERROR_CHARS`.

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -696,7 +696,7 @@ export const COMMAND_REGISTRY = {
 			'Launch deep PR review with multi-lane analysis [url] [--council]',
 		args: '<pr-url|owner/repo#N|N> [--council]',
 		details:
-			'Launches a structured PR review: reconstructs PR intent via obligation extraction cascade, runs 6 parallel explorer lanes (correctness, security, dependencies, docs-intent-vs-actual, tests, performance-architecture), validates findings through independent reviewer confirmation, applies critic challenge to HIGH/CRITICAL findings, synthesizes structured report. --council variant fires adversarial multi-model review. Supports full GitHub URL, owner/repo#N shorthand, or bare PR number (resolves against origin remote).',
+			'Launches a structured PR review: reconstructs PR intent via obligation extraction cascade, runs 6 parallel explorer lanes through the deterministic dispatch_lanes join barrier (correctness, security, dependencies, docs-intent-vs-actual, tests, performance-architecture), validates findings through independent reviewer confirmation, applies critic challenge to HIGH/CRITICAL findings, synthesizes structured report. --council variant fires adversarial multi-model review. Supports full GitHub URL, owner/repo#N shorthand, or bare PR number (resolves against origin remote).',
 		category: 'agent',
 	},
 	'pr-feedback': {

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -1,0 +1,595 @@
+import pLimit from 'p-limit';
+import { z } from 'zod';
+import { WRITE_TOOL_NAMES } from '../config/constants.js';
+import {
+	isKnownCanonicalRole,
+	resolveGeneratedAgentRole,
+} from '../config/schema.js';
+import type { ParallelDispatcher } from '../parallel/dispatcher/parallel-dispatcher.js';
+import { createParallelDispatcher } from '../parallel/dispatcher/parallel-dispatcher.js';
+import { swarmState } from '../state.js';
+import { createSwarmTool } from './create-tool.js';
+
+const MAX_LANES = 8;
+const MAX_PROMPT_CHARS = 80_000;
+const DEFAULT_TIMEOUT_MS = 300_000;
+const MAX_TIMEOUT_MS = 1_800_000;
+const MAX_LANE_OUTPUT_CHARS = 20_000;
+
+const AGENT_NAME_SEPARATORS = ['_', '-', ' '] as const;
+
+const READ_ONLY_LANE_ROLES: ReadonlySet<string> = new Set([
+	'explorer',
+	'reviewer',
+	'critic',
+	'critic_oversight',
+	'critic_sounding_board',
+	'critic_drift_verifier',
+	'critic_hallucination_verifier',
+	'critic_architecture_supervisor',
+	'sme',
+	'researcher',
+	'council_generalist',
+	'council_skeptic',
+	'council_domain_expert',
+]);
+
+const READ_ONLY_TOOL_DENYLIST = [
+	...new Set([
+		...WRITE_TOOL_NAMES,
+		'extract_code_blocks',
+		'multiedit',
+		'multi_edit',
+		'todo_write',
+		'save_plan',
+		'update_task_status',
+		'phase_complete',
+		'declare_scope',
+		'declare_council_criteria',
+		'submit_council_verdicts',
+		'submit_phase_council_verdicts',
+		'set_qa_gates',
+		'write_retro',
+		'write_drift_evidence',
+		'write_hallucination_evidence',
+		'write_mutation_evidence',
+		'knowledge_add',
+		'knowledge_remove',
+	]),
+] as const;
+
+const LaneSchema = z.object({
+	id: z
+		.string()
+		.min(1)
+		.max(80)
+		.regex(/^[A-Za-z0-9][A-Za-z0-9_.-]*$/)
+		.describe('Stable lane identifier, unique within this dispatch batch'),
+	agent: z
+		.string()
+		.min(1)
+		.max(120)
+		.describe(
+			'Read-only swarm agent name, including any generated swarm prefix',
+		),
+	prompt: z
+		.string()
+		.min(1)
+		.max(MAX_PROMPT_CHARS)
+		.describe('Full lane prompt to send to the requested agent'),
+});
+
+const DispatchLanesArgsSchema = z.object({
+	lanes: z
+		.array(LaneSchema)
+		.min(1)
+		.max(MAX_LANES)
+		.describe('Read-only lane specs to dispatch concurrently'),
+	max_concurrent: z
+		.number()
+		.int()
+		.min(1)
+		.max(MAX_LANES)
+		.optional()
+		.describe('Maximum lanes in flight at once; defaults to lane count'),
+	timeout_ms: z
+		.number()
+		.int()
+		.min(10)
+		.max(MAX_TIMEOUT_MS)
+		.optional()
+		.describe('Per-lane session create/prompt timeout in milliseconds'),
+});
+
+export type DispatchLaneSpec = z.infer<typeof LaneSchema>;
+export type DispatchLanesArgs = z.infer<typeof DispatchLanesArgsSchema>;
+
+export type DispatchLaneStatus = 'completed' | 'failed' | 'rejected';
+
+export interface DispatchLaneResult {
+	id: string;
+	agent: string;
+	role: string;
+	status: DispatchLaneStatus;
+	session_id?: string;
+	slot_id?: string;
+	run_id?: string;
+	started_at: string;
+	completed_at: string;
+	output?: string;
+	output_chars?: number;
+	output_truncated?: boolean;
+	error?: string;
+}
+
+export interface DispatchLanesResult {
+	success: boolean;
+	failure_class?: 'invalid_args' | 'no_client';
+	message?: string;
+	dispatched: number;
+	completed: number;
+	failed: number;
+	rejected: number;
+	max_concurrent: number;
+	timeout_ms: number;
+	lane_results: DispatchLaneResult[];
+	errors?: string[];
+}
+
+export interface SessionOps {
+	create(args: {
+		query: { directory: string };
+	}): Promise<{ data?: { id?: string } | null; error?: unknown }>;
+	prompt(args: {
+		path: { id: string };
+		body: {
+			agent: string;
+			tools: ReadOnlyToolPermissions;
+			parts: Array<{ type: 'text'; text: string }>;
+		};
+	}): Promise<{
+		data?: { parts?: Array<{ type: string; text?: string }> } | null;
+		error?: unknown;
+	}>;
+	delete(args: { path: { id: string } }): Promise<unknown>;
+}
+
+export const _internals: {
+	getSessionOps: () => SessionOps | null;
+	getGeneratedAgentNames: () => readonly string[];
+	createParallelDispatcher: typeof createParallelDispatcher;
+	now: () => number;
+} = {
+	getSessionOps: () =>
+		(swarmState.opencodeClient?.session as unknown as SessionOps | undefined) ??
+		null,
+	getGeneratedAgentNames: () => swarmState.generatedAgentNames,
+	createParallelDispatcher,
+	now: () => Date.now(),
+};
+
+type ReadOnlyToolPermissions = Record<string, false> & {
+	write: false;
+	edit: false;
+	patch: false;
+};
+
+interface DispatchLanesExecutionContext {
+	callerAgent?: string;
+}
+
+export async function executeDispatchLanes(
+	args: unknown,
+	directory: string,
+	context: DispatchLanesExecutionContext = {},
+): Promise<DispatchLanesResult> {
+	const parsed = DispatchLanesArgsSchema.safeParse(args);
+	if (!parsed.success) {
+		return failureResult({
+			failure_class: 'invalid_args',
+			message: 'Invalid dispatch_lanes arguments',
+			errors: parsed.error.issues.map(
+				(issue) => `${issue.path.join('.')}: ${issue.message}`,
+			),
+		});
+	}
+
+	const duplicateLaneIds = findDuplicateLaneIds(parsed.data.lanes);
+	if (duplicateLaneIds.length > 0) {
+		return failureResult({
+			failure_class: 'invalid_args',
+			message: 'Lane IDs must be unique within one dispatch_lanes batch',
+			errors: duplicateLaneIds.map((id) => `Duplicate lane id: ${id}`),
+		});
+	}
+
+	const session = _internals.getSessionOps();
+	if (!session) {
+		return failureResult({
+			failure_class: 'no_client',
+			message: 'OpenCode session client is not available',
+		});
+	}
+
+	const lanes = parsed.data.lanes;
+	const maxConcurrent = Math.min(
+		parsed.data.max_concurrent ?? lanes.length,
+		lanes.length,
+		MAX_LANES,
+	);
+	const timeoutMs = parsed.data.timeout_ms ?? DEFAULT_TIMEOUT_MS;
+	const dispatcher = _internals.createParallelDispatcher({
+		enabled: true,
+		maxConcurrentTasks: maxConcurrent,
+		evidenceLockTimeoutMs: 0,
+	});
+	const limit = pLimit(maxConcurrent);
+
+	try {
+		const laneResults = await Promise.all(
+			lanes.map((lane) =>
+				limit(() =>
+					runLane(session, dispatcher, lane, directory, timeoutMs, context),
+				),
+			),
+		);
+		return buildResult(laneResults, maxConcurrent, timeoutMs);
+	} finally {
+		dispatcher.shutdown();
+	}
+}
+
+async function runLane(
+	session: SessionOps,
+	dispatcher: ParallelDispatcher,
+	lane: DispatchLaneSpec,
+	directory: string,
+	timeoutMs: number,
+	context: DispatchLanesExecutionContext,
+): Promise<DispatchLaneResult> {
+	const validation = validateLaneAgent(lane.agent, context);
+	const role = validation.role;
+	const startedAt = isoNow();
+	if (!validation.ok) {
+		return {
+			id: lane.id,
+			agent: lane.agent,
+			role,
+			status: 'rejected',
+			started_at: startedAt,
+			completed_at: isoNow(),
+			error: validation.error,
+		};
+	}
+
+	const decision = dispatcher.dispatch(lane.id);
+	if (decision.action !== 'dispatch') {
+		return {
+			id: lane.id,
+			agent: lane.agent,
+			role,
+			status: 'failed',
+			started_at: startedAt,
+			completed_at: isoNow(),
+			error: `dispatcher ${decision.action}: ${decision.reason}`,
+		};
+	}
+
+	let sessionId: string | undefined;
+	try {
+		const createTimeoutMessage = `Lane "${lane.id}" session.create timed out after ${timeoutMs}ms`;
+		const createPromise = session.create({ query: { directory } });
+		let createTimedOut = false;
+		createPromise
+			.then((createResult) => {
+				if (createTimedOut && createResult.data?.id) {
+					scheduleSessionCleanup(session, createResult.data.id);
+				}
+			})
+			.catch(() => undefined);
+		const createResult = await withTimeout(
+			createPromise.catch((error) => {
+				throw error;
+			}),
+			timeoutMs,
+			createTimeoutMessage,
+		).catch((error) => {
+			if (formatError(error) === createTimeoutMessage) {
+				createTimedOut = true;
+			}
+			throw error;
+		});
+		if (!createResult.data?.id) {
+			return failedLane(
+				lane,
+				role,
+				startedAt,
+				`session.create failed: ${formatError(createResult.error)}`,
+				decision.slot.slotId,
+				decision.slot.runId,
+			);
+		}
+		sessionId = createResult.data.id;
+
+		const promptResult = await withTimeout(
+			session.prompt({
+				path: { id: sessionId },
+				body: {
+					agent: lane.agent,
+					tools: buildReadOnlyTools(),
+					parts: [{ type: 'text', text: lane.prompt }],
+				},
+			}),
+			timeoutMs,
+			`Lane "${lane.id}" session.prompt timed out after ${timeoutMs}ms`,
+		);
+		if (!promptResult.data) {
+			return failedLane(
+				lane,
+				role,
+				startedAt,
+				`session.prompt failed: ${formatError(promptResult.error)}`,
+				decision.slot.slotId,
+				decision.slot.runId,
+				sessionId,
+			);
+		}
+
+		const boundedOutput = boundLaneOutput(extractText(promptResult.data.parts));
+		return {
+			id: lane.id,
+			agent: lane.agent,
+			role,
+			status: 'completed',
+			session_id: sessionId,
+			slot_id: decision.slot.slotId,
+			run_id: decision.slot.runId,
+			started_at: startedAt,
+			completed_at: isoNow(),
+			...boundedOutput,
+		};
+	} catch (error) {
+		return failedLane(
+			lane,
+			role,
+			startedAt,
+			formatError(error),
+			decision.slot.slotId,
+			decision.slot.runId,
+			sessionId,
+		);
+	} finally {
+		dispatcher.releaseSlot(decision.slot.slotId);
+		if (sessionId) {
+			scheduleSessionCleanup(session, sessionId);
+		}
+	}
+}
+
+function buildResult(
+	laneResults: DispatchLaneResult[],
+	maxConcurrent: number,
+	timeoutMs: number,
+): DispatchLanesResult {
+	const completed = laneResults.filter((lane) => lane.status === 'completed');
+	const failed = laneResults.filter((lane) => lane.status === 'failed');
+	const rejected = laneResults.filter((lane) => lane.status === 'rejected');
+	return {
+		success: failed.length === 0 && rejected.length === 0,
+		dispatched: laneResults.length,
+		completed: completed.length,
+		failed: failed.length,
+		rejected: rejected.length,
+		max_concurrent: maxConcurrent,
+		timeout_ms: timeoutMs,
+		lane_results: laneResults,
+	};
+}
+
+function failedLane(
+	lane: DispatchLaneSpec,
+	role: string,
+	startedAt: string,
+	error: string,
+	slotId?: string,
+	runId?: string,
+	sessionId?: string,
+): DispatchLaneResult {
+	return {
+		id: lane.id,
+		agent: lane.agent,
+		role,
+		status: 'failed',
+		session_id: sessionId,
+		slot_id: slotId,
+		run_id: runId,
+		started_at: startedAt,
+		completed_at: isoNow(),
+		error,
+	};
+}
+
+function validateLaneAgent(
+	agent: string,
+	context: DispatchLanesExecutionContext,
+): { ok: true; role: string } | { ok: false; role: string; error: string } {
+	const generatedAgentNames = _internals.getGeneratedAgentNames();
+	const role = resolveGeneratedAgentRole(agent, generatedAgentNames);
+	if (!isKnownCanonicalRole(role)) {
+		return {
+			ok: false,
+			role,
+			error: `Agent "${agent}" is not registered as a generated swarm agent or canonical role`,
+		};
+	}
+	if (!READ_ONLY_LANE_ROLES.has(role)) {
+		return {
+			ok: false,
+			role,
+			error: `Agent role "${role}" is not allowed for read-only lane dispatch`,
+		};
+	}
+
+	const callerPrefix = context.callerAgent
+		? getGeneratedAgentPrefix(context.callerAgent, generatedAgentNames)
+		: null;
+	if (callerPrefix) {
+		const lanePrefix = getGeneratedAgentPrefix(agent, generatedAgentNames);
+		if (lanePrefix !== callerPrefix) {
+			return {
+				ok: false,
+				role,
+				error: `Agent "${agent}" does not match caller swarm prefix "${callerPrefix}"`,
+			};
+		}
+	}
+
+	return { ok: true, role };
+}
+
+function getGeneratedAgentPrefix(
+	agent: string,
+	generatedAgentNames: readonly string[],
+): string | null {
+	const role = resolveGeneratedAgentRole(agent, generatedAgentNames);
+	if (!isKnownCanonicalRole(role)) return null;
+	const normalized = agent.toLowerCase();
+	if (normalized === role) return null;
+	for (const separator of AGENT_NAME_SEPARATORS) {
+		const suffix = `${separator}${role}`;
+		if (normalized.endsWith(suffix)) {
+			return normalized.slice(0, -suffix.length);
+		}
+	}
+	return null;
+}
+
+function buildReadOnlyTools(): ReadOnlyToolPermissions {
+	const tools: Record<string, false> = {};
+	for (const toolName of READ_ONLY_TOOL_DENYLIST) {
+		tools[toolName] = false;
+	}
+	tools.write = false;
+	tools.edit = false;
+	tools.patch = false;
+	return tools as ReadOnlyToolPermissions;
+}
+
+function boundLaneOutput(output: string): {
+	output: string;
+	output_chars: number;
+	output_truncated: boolean;
+} {
+	if (output.length <= MAX_LANE_OUTPUT_CHARS) {
+		return {
+			output,
+			output_chars: output.length,
+			output_truncated: false,
+		};
+	}
+	const omitted = output.length - MAX_LANE_OUTPUT_CHARS;
+	return {
+		output: `${output.slice(0, MAX_LANE_OUTPUT_CHARS)}\n[... ${omitted} chars truncated by dispatch_lanes ...]`,
+		output_chars: output.length,
+		output_truncated: true,
+	};
+}
+
+function failureResult(args: {
+	failure_class: 'invalid_args' | 'no_client';
+	message: string;
+	errors?: string[];
+}): DispatchLanesResult {
+	return {
+		success: false,
+		failure_class: args.failure_class,
+		message: args.message,
+		dispatched: 0,
+		completed: 0,
+		failed: 0,
+		rejected: 0,
+		max_concurrent: 0,
+		timeout_ms: 0,
+		lane_results: [],
+		errors: args.errors,
+	};
+}
+
+function findDuplicateLaneIds(lanes: DispatchLaneSpec[]): string[] {
+	const seen = new Set<string>();
+	const duplicates = new Set<string>();
+	for (const lane of lanes) {
+		if (seen.has(lane.id)) duplicates.add(lane.id);
+		seen.add(lane.id);
+	}
+	return [...duplicates];
+}
+
+function scheduleSessionCleanup(session: SessionOps, sessionId: string): void {
+	void session.delete({ path: { id: sessionId } }).catch(() => undefined);
+}
+
+async function withTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	message: string,
+): Promise<T> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}
+
+function extractText(
+	parts: Array<{ type: string; text?: string }> | undefined,
+): string {
+	if (!Array.isArray(parts)) return '';
+	return parts
+		.filter((part) => part.type === 'text')
+		.map((part) => part.text ?? '')
+		.join('\n');
+}
+
+function formatError(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === 'string') return error;
+	try {
+		return JSON.stringify(error);
+	} catch {
+		return String(error);
+	}
+}
+
+function isoNow(): string {
+	return new Date(_internals.now()).toISOString();
+}
+
+export const dispatch_lanes: ReturnType<typeof createSwarmTool> =
+	createSwarmTool({
+		description:
+			'Dispatch multiple read-only exploration/review lanes concurrently through OpenCode sessions and return a structured join result.',
+		args: {
+			lanes: DispatchLanesArgsSchema.shape.lanes,
+			max_concurrent: DispatchLanesArgsSchema.shape.max_concurrent,
+			timeout_ms: DispatchLanesArgsSchema.shape.timeout_ms,
+		},
+		execute: async (args: unknown, directory: string, ctx): Promise<string> => {
+			const result = await executeDispatchLanes(args, directory, {
+				callerAgent: getContextAgent(ctx),
+			});
+			return JSON.stringify(result, null, 2);
+		},
+	});
+
+function getContextAgent(ctx: unknown): string | undefined {
+	if (!ctx || typeof ctx !== 'object') return undefined;
+	const value = (ctx as Record<string, unknown>).agent;
+	return typeof value === 'string' ? value : undefined;
+}

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -15,6 +15,8 @@ const MAX_PROMPT_CHARS = 80_000;
 const DEFAULT_TIMEOUT_MS = 300_000;
 const MAX_TIMEOUT_MS = 1_800_000;
 const MAX_LANE_OUTPUT_CHARS = 20_000;
+const MAX_ERROR_CHARS = 200;
+const ERROR_TRUNCATION_SUFFIX = '...';
 
 const AGENT_NAME_SEPARATORS = ['_', '-', ' '] as const;
 
@@ -55,6 +57,8 @@ const READ_ONLY_TOOL_DENYLIST = [
 		'write_mutation_evidence',
 		'knowledge_add',
 		'knowledge_remove',
+		'summarize_work',
+		'doc_scan',
 	]),
 ] as const;
 
@@ -167,6 +171,8 @@ export const _internals: {
 	createParallelDispatcher,
 	now: () => Date.now(),
 };
+
+export const _test_exports = { formatError };
 
 type ReadOnlyToolPermissions = Record<string, false> & {
 	write: false;
@@ -288,9 +294,7 @@ async function runLane(
 			})
 			.catch(() => undefined);
 		const createResult = await withTimeout(
-			createPromise.catch((error) => {
-				throw error;
-			}),
+			createPromise,
 			timeoutMs,
 			createTimeoutMessage,
 		).catch((error) => {
@@ -488,8 +492,10 @@ function boundLaneOutput(output: string): {
 		};
 	}
 	const omitted = output.length - MAX_LANE_OUTPUT_CHARS;
+	const suffix = `\n[... ${omitted} chars truncated by dispatch_lanes ...]`;
+	const maxContent = Math.max(0, MAX_LANE_OUTPUT_CHARS - suffix.length);
 	return {
-		output: `${output.slice(0, MAX_LANE_OUTPUT_CHARS)}\n[... ${omitted} chars truncated by dispatch_lanes ...]`,
+		output: `${output.slice(0, maxContent)}${suffix}`,
 		output_chars: output.length,
 		output_truncated: true,
 	};
@@ -559,12 +565,13 @@ function extractText(
 
 function formatError(error: unknown): string {
 	if (error instanceof Error) return error.message;
-	if (typeof error === 'string') return error;
-	try {
-		return JSON.stringify(error);
-	} catch {
-		return String(error);
-	}
+	const text = typeof error === 'string' ? error : String(error);
+	return boundErrorString(text);
+}
+
+function boundErrorString(text: string): string {
+	if (text.length <= MAX_ERROR_CHARS) return text;
+	return `${text.slice(0, MAX_ERROR_CHARS)}${ERROR_TRUNCATION_SUFFIX}`;
 }
 
 function isoNow(): string {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,7 @@ export { declare_council_criteria } from './declare-council-criteria';
 export { declare_scope } from './declare-scope';
 export { type DiffErrorResult, type DiffResult, diff } from './diff';
 export { diff_summary } from './diff-summary';
+export { dispatch_lanes } from './dispatch-lanes';
 export { doc_extract, doc_scan } from './doc-scan';
 export { detect_domains } from './domain-detector';
 export { evidence_check } from './evidence-check';

--- a/src/tools/manifest.ts
+++ b/src/tools/manifest.ts
@@ -38,6 +38,7 @@ import { declare_council_criteria } from './declare-council-criteria';
 import { declare_scope } from './declare-scope';
 import { diff } from './diff';
 import { diff_summary } from './diff-summary';
+import { dispatch_lanes } from './dispatch-lanes';
 import { doc_extract, doc_scan } from './doc-scan';
 import { detect_domains } from './domain-detector';
 import { evidence_check } from './evidence-check';
@@ -207,6 +208,7 @@ export const TOOL_MANIFEST = defineHandlers({
 	swarm_memory_recall: () => swarm_memory_recall,
 	swarm_memory_propose: () => swarm_memory_propose,
 	swarm_command: () => swarm_command,
+	dispatch_lanes: () => dispatch_lanes,
 	summarize_work: () => summarize_work,
 	write_architecture_supervisor_evidence: () =>
 		write_architecture_supervisor_evidence,

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -545,6 +545,11 @@ export const TOOL_METADATA = {
 			'test_engineer',
 		],
 	},
+	dispatch_lanes: {
+		description:
+			'dispatch multiple read-only exploration/review lanes concurrently and return a structured join result',
+		agents: ['architect'],
+	},
 	summarize_work: {
 		description:
 			'emit a short structured summary of completed work (key decisions, assumptions, risks, constraints) at task completion; rolls up per phase for architecture-supervisor review. Advisory, never blocks.',

--- a/tests/unit/agents/architect-tool-lists.test.ts
+++ b/tests/unit/agents/architect-tool-lists.test.ts
@@ -6,9 +6,9 @@
  * replacing the previously hand-maintained lists.
  *
  * Covers:
- * 1. YOUR TOOLS contains all 39 AGENT_TOOL_MAP.architect tools
+ * 1. YOUR TOOLS contains all AGENT_TOOL_MAP.architect tools
  * 2. YOUR TOOLS starts with "Task (delegation),"
- * 3. Available Tools contains all 39 AGENT_TOOL_MAP.architect tools
+ * 3. Available Tools contains all AGENT_TOOL_MAP.architect tools
  * 4. Available Tools has descriptions (e.g. "build_check (build verification)")
  * 5. Both lists are sorted alphabetically (after "Task (delegation)" prefix for YOUR TOOLS)
  * 6. Tool count matches AGENT_TOOL_MAP.architect.length
@@ -16,7 +16,10 @@
 
 import { beforeAll, describe, expect, it } from 'bun:test';
 import { createArchitectAgent } from '../../../src/agents/architect.js';
-import { AGENT_TOOL_MAP } from '../../../src/config/constants.js';
+import {
+	AGENT_TOOL_MAP,
+	TOOL_DESCRIPTIONS,
+} from '../../../src/config/constants.js';
 
 const ARCHITECT_TOOL_COUNT = AGENT_TOOL_MAP['architect'].length;
 
@@ -72,7 +75,7 @@ beforeAll(() => {
 });
 
 describe('YOUR TOOLS generation from AGENT_TOOL_MAP', () => {
-	it('contains all 39 AGENT_TOOL_MAP.architect tools', () => {
+	it('contains all AGENT_TOOL_MAP.architect tools', () => {
 		for (const tool of AGENT_TOOL_MAP['architect']) {
 			expect(resolvedPrompt).toContain(tool);
 		}
@@ -125,19 +128,19 @@ describe('YOUR TOOLS generation from AGENT_TOOL_MAP', () => {
 });
 
 describe('Available Tools generation from AGENT_TOOL_MAP', () => {
-	it('contains all 39 AGENT_TOOL_MAP.architect tools', () => {
+	it('contains all AGENT_TOOL_MAP.architect tools', () => {
 		for (const tool of AGENT_TOOL_MAP['architect']) {
 			expect(resolvedPrompt).toContain(tool);
 		}
 	});
 
 	it('has descriptions for tools that have TOOL_DESCRIPTIONS entries', () => {
-		// build_check has description "build verification"
-		expect(resolvedPrompt).toContain('build_check (build verification)');
-		// checkpoint has description "state snapshots"
-		expect(resolvedPrompt).toContain('checkpoint (state snapshots)');
-		// secretscan has description "secret detection"
-		expect(resolvedPrompt).toContain('secretscan (secret detection)');
+		for (const tool of ['build_check', 'checkpoint', 'dispatch_lanes']) {
+			const description =
+				TOOL_DESCRIPTIONS[tool as keyof typeof TOOL_DESCRIPTIONS];
+			expect(description).toBeTruthy();
+			expect(resolvedPrompt).toContain(`${tool} (${description})`);
+		}
 	});
 
 	it('tool count matches AGENT_TOOL_MAP.architect.length', () => {

--- a/tests/unit/skills/swarm-pr-review-dispatch-guidance.test.ts
+++ b/tests/unit/skills/swarm-pr-review-dispatch-guidance.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SWARM_PR_REVIEW_SKILLS = [
+	'.opencode/skills/swarm-pr-review/SKILL.md',
+	'.agents/skills/swarm-pr-review/SKILL.md',
+	'.claude/skills/swarm-pr-review/SKILL.md',
+] as const;
+
+describe('swarm-pr-review deterministic lane dispatch guidance', () => {
+	for (const skillPath of SWARM_PR_REVIEW_SKILLS) {
+		test(`${skillPath} uses dispatch_lanes instead of native background Task batching`, () => {
+			const source = readFileSync(join(process.cwd(), skillPath), 'utf-8');
+
+			expect(source).toContain('dispatch_lanes');
+			expect(source).toContain('lane_results');
+			expect(source).not.toContain('run_in_background');
+			expect(source).not.toContain(
+				'single message with multiple Agent tool calls',
+			);
+		});
+	}
+});

--- a/tests/unit/tools/dispatch-lanes.test.ts
+++ b/tests/unit/tools/dispatch-lanes.test.ts
@@ -1,0 +1,516 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+	_internals,
+	type DispatchLaneResult,
+	executeDispatchLanes,
+	type SessionOps,
+} from '../../../src/tools/dispatch-lanes';
+
+const originalInternals = { ..._internals };
+
+function makeTempDir(): string {
+	return fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'dispatch-lanes-')),
+	);
+}
+
+function deferred<T = void>(): {
+	promise: Promise<T>;
+	resolve: (value: T | PromiseLike<T>) => void;
+	reject: (reason?: unknown) => void;
+} {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+afterEach(() => {
+	Object.assign(_internals, originalInternals);
+});
+
+describe('executeDispatchLanes', () => {
+	test('starts permitted lanes concurrently and waits for all results', async () => {
+		const directory = makeTempDir();
+		const allStarted = deferred();
+		const releases: Array<() => void> = [];
+		let nextSession = 0;
+		let activePrompts = 0;
+		let maxActivePrompts = 0;
+		let promptStarts = 0;
+
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: `session-${++nextSession}` },
+				error: undefined,
+			})),
+			prompt: mock(async (input) => {
+				promptStarts++;
+				activePrompts++;
+				maxActivePrompts = Math.max(maxActivePrompts, activePrompts);
+				if (promptStarts === 3) allStarted.resolve();
+				await new Promise<void>((resolve) => releases.push(resolve));
+				activePrompts--;
+				return {
+					data: {
+						parts: [
+							{ type: 'text' as const, text: `done ${input.body.agent}` },
+						],
+					},
+					error: undefined,
+				};
+			}),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+
+		const execution = executeDispatchLanes(
+			{
+				max_concurrent: 3,
+				timeout_ms: 10_000,
+				lanes: [
+					{ id: 'runtime', agent: 'explorer', prompt: 'inspect runtime' },
+					{ id: 'tests', agent: 'reviewer', prompt: 'inspect tests' },
+					{ id: 'docs', agent: 'critic', prompt: 'inspect docs' },
+				],
+			},
+			directory,
+		);
+
+		await allStarted.promise;
+		expect(maxActivePrompts).toBe(3);
+		for (const release of releases) release();
+
+		const result = await execution;
+		expect(result.success).toBe(true);
+		expect(result.lane_results.map((lane) => lane.status)).toEqual([
+			'completed',
+			'completed',
+			'completed',
+		]);
+		expect(ops.create).toHaveBeenCalledTimes(3);
+		expect(ops.prompt).toHaveBeenCalledTimes(3);
+		expect(ops.delete).toHaveBeenCalledTimes(3);
+		for (const call of (ops.prompt as ReturnType<typeof mock>).mock.calls) {
+			expect(call[0].body.tools).toMatchObject({
+				write: false,
+				edit: false,
+				patch: false,
+				apply_patch: false,
+				create_file: false,
+				extract_code_blocks: false,
+				save_plan: false,
+				update_task_status: false,
+			});
+		}
+	});
+
+	test('honors max_concurrent while preserving a join barrier', async () => {
+		const directory = makeTempDir();
+		const firstTwoStarted = deferred();
+		const thirdStarted = deferred();
+		const releases: Array<() => void> = [];
+		let nextSession = 0;
+		let activePrompts = 0;
+		let maxActivePrompts = 0;
+		let promptStarts = 0;
+
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: `session-${++nextSession}` },
+				error: undefined,
+			})),
+			prompt: mock(async () => {
+				promptStarts++;
+				activePrompts++;
+				maxActivePrompts = Math.max(maxActivePrompts, activePrompts);
+				if (promptStarts === 2) firstTwoStarted.resolve();
+				if (promptStarts === 3) thirdStarted.resolve();
+				await new Promise<void>((resolve) => releases.push(resolve));
+				activePrompts--;
+				return {
+					data: { parts: [{ type: 'text' as const, text: 'done' }] },
+					error: undefined,
+				};
+			}),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+
+		const execution = executeDispatchLanes(
+			{
+				max_concurrent: 2,
+				timeout_ms: 10_000,
+				lanes: [
+					{ id: 'a', agent: 'explorer', prompt: 'a' },
+					{ id: 'b', agent: 'reviewer', prompt: 'b' },
+					{ id: 'c', agent: 'critic', prompt: 'c' },
+				],
+			},
+			directory,
+		);
+
+		await firstTwoStarted.promise;
+		expect(maxActivePrompts).toBe(2);
+		expect(promptStarts).toBe(2);
+		releases.shift()?.();
+		await thirdStarted.promise;
+		for (const release of releases) release();
+
+		const result = await execution;
+		expect(result.success).toBe(true);
+		expect(maxActivePrompts).toBe(2);
+		expect(result.lane_results).toHaveLength(3);
+	});
+
+	test('rejects writable roles before creating sessions', async () => {
+		const directory = makeTempDir();
+		const ops: SessionOps = {
+			create: mock(async () => ({ data: { id: 'unused' }, error: undefined })),
+			prompt: mock(async () => ({
+				data: { parts: [{ type: 'text' as const, text: 'unused' }] },
+				error: undefined,
+			})),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{
+				lanes: [{ id: 'write', agent: 'coder', prompt: 'please edit files' }],
+			},
+			directory,
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.lane_results).toEqual([
+			expect.objectContaining({
+				id: 'write',
+				agent: 'coder',
+				role: 'coder',
+				status: 'rejected',
+			}),
+		]);
+		expect(ops.create).not.toHaveBeenCalled();
+		expect(ops.prompt).not.toHaveBeenCalled();
+	});
+
+	test('preserves prefixed dispatch identity while validating canonical role', async () => {
+		const directory = makeTempDir();
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: 'session-1' },
+				error: undefined,
+			})),
+			prompt: mock(async () => ({
+				data: { parts: [{ type: 'text' as const, text: 'prefixed ok' }] },
+				error: undefined,
+			})),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+		_internals.getGeneratedAgentNames = () => [
+			'mega_architect',
+			'mega_reviewer',
+		];
+
+		const result = await executeDispatchLanes(
+			{
+				lanes: [
+					{ id: 'prefixed', agent: 'mega_reviewer', prompt: 'review only' },
+				],
+			},
+			directory,
+			{ callerAgent: 'mega_architect' },
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.lane_results[0]).toEqual(
+			expect.objectContaining({
+				id: 'prefixed',
+				agent: 'mega_reviewer',
+				role: 'reviewer',
+				status: 'completed',
+			} satisfies Partial<DispatchLaneResult>),
+		);
+		expect(ops.prompt).toHaveBeenCalledWith(
+			expect.objectContaining({
+				body: expect.objectContaining({ agent: 'mega_reviewer' }),
+			}),
+		);
+	});
+
+	test('rejects suffix spoofing and cross-swarm generated agents', async () => {
+		const directory = makeTempDir();
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: 'session-1' },
+				error: undefined,
+			})),
+			prompt: mock(async (input) => ({
+				data: {
+					parts: [
+						{
+							type: 'text' as const,
+							text: `ok ${input.body.agent}`,
+						},
+					],
+				},
+				error: undefined,
+			})),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+		_internals.getGeneratedAgentNames = () => [
+			'this_architect',
+			'this_reviewer',
+			'other_reviewer',
+		];
+
+		const result = await executeDispatchLanes(
+			{
+				lanes: [
+					{ id: 'spoof', agent: 'not_an_reviewer', prompt: 'spoof' },
+					{ id: 'other', agent: 'other_reviewer', prompt: 'other swarm' },
+					{ id: 'valid', agent: 'this_reviewer', prompt: 'same swarm' },
+				],
+			},
+			directory,
+			{ callerAgent: 'this_architect' },
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.lane_results).toEqual([
+			expect.objectContaining({
+				id: 'spoof',
+				role: 'not_an_reviewer',
+				status: 'rejected',
+			}),
+			expect.objectContaining({
+				id: 'other',
+				role: 'reviewer',
+				status: 'rejected',
+			}),
+			expect.objectContaining({
+				id: 'valid',
+				role: 'reviewer',
+				status: 'completed',
+				output: 'ok this_reviewer',
+			}),
+		]);
+		expect(ops.create).toHaveBeenCalledTimes(1);
+		expect(ops.prompt).toHaveBeenCalledTimes(1);
+	});
+
+	test('returns per-lane failures without dropping sibling results', async () => {
+		const directory = makeTempDir();
+		let nextSession = 0;
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: `session-${++nextSession}` },
+				error: undefined,
+			})),
+			prompt: mock(async (input) => {
+				if (input.body.agent === 'critic') {
+					return { data: undefined, error: 'critic unavailable' };
+				}
+				return {
+					data: { parts: [{ type: 'text' as const, text: 'ok' }] },
+					error: undefined,
+				};
+			}),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{
+				max_concurrent: 2,
+				lanes: [
+					{ id: 'ok', agent: 'reviewer', prompt: 'ok' },
+					{ id: 'bad', agent: 'critic', prompt: 'bad' },
+				],
+			},
+			directory,
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.lane_results).toEqual([
+			expect.objectContaining({ id: 'ok', status: 'completed', output: 'ok' }),
+			expect.objectContaining({
+				id: 'bad',
+				status: 'failed',
+				error: 'session.prompt failed: critic unavailable',
+			}),
+		]);
+		expect(ops.delete).toHaveBeenCalledTimes(2);
+	});
+
+	test('times out a hung lane and cleans up the created session', async () => {
+		const directory = makeTempDir();
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: 'session-1' },
+				error: undefined,
+			})),
+			prompt: mock(async () => await new Promise<never>(() => undefined)),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{
+				timeout_ms: 10,
+				lanes: [{ id: 'hung', agent: 'reviewer', prompt: 'hang' }],
+			},
+			directory,
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.lane_results).toEqual([
+			expect.objectContaining({
+				id: 'hung',
+				status: 'failed',
+				error: 'Lane "hung" session.prompt timed out after 10ms',
+			}),
+		]);
+		expect(ops.delete).toHaveBeenCalledWith({ path: { id: 'session-1' } });
+	});
+
+	test('does not let hung session cleanup block the join result', async () => {
+		const directory = makeTempDir();
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: 'session-1' },
+				error: undefined,
+			})),
+			prompt: mock(async () => ({
+				data: { parts: [{ type: 'text' as const, text: 'done' }] },
+				error: undefined,
+			})),
+			delete: mock(async () => await new Promise<never>(() => undefined)),
+		};
+		_internals.getSessionOps = () => ops;
+
+		const execution = executeDispatchLanes(
+			{
+				timeout_ms: 10,
+				lanes: [{ id: 'cleanup', agent: 'reviewer', prompt: 'cleanup' }],
+			},
+			directory,
+		);
+
+		const result = await Promise.race([
+			execution,
+			new Promise<'blocked'>((resolve) =>
+				setTimeout(() => resolve('blocked'), 200),
+			),
+		]);
+
+		expect(result).not.toBe('blocked');
+		expect(result).toEqual(
+			expect.objectContaining({
+				success: true,
+				completed: 1,
+			}),
+		);
+		expect(ops.delete).toHaveBeenCalledWith({ path: { id: 'session-1' } });
+	});
+
+	test('cleans up a session that is created after create timeout', async () => {
+		const directory = makeTempDir();
+		const createGate = deferred<{ data: { id: string }; error: undefined }>();
+		const deleteCalled = deferred<{ path: { id: string } }>();
+		const ops: SessionOps = {
+			create: mock(async () => await createGate.promise),
+			prompt: mock(async () => ({
+				data: { parts: [{ type: 'text' as const, text: 'unused' }] },
+				error: undefined,
+			})),
+			delete: mock(async (args) => {
+				deleteCalled.resolve(args);
+				return undefined;
+			}),
+		};
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{
+				timeout_ms: 10,
+				lanes: [{ id: 'late-create', agent: 'reviewer', prompt: 'late' }],
+			},
+			directory,
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.lane_results).toEqual([
+			expect.objectContaining({
+				id: 'late-create',
+				status: 'failed',
+				error: 'Lane "late-create" session.create timed out after 10ms',
+			}),
+		]);
+		expect(ops.prompt).not.toHaveBeenCalled();
+		expect(ops.delete).not.toHaveBeenCalled();
+
+		createGate.resolve({ data: { id: 'late-session' }, error: undefined });
+		await expect(deleteCalled.promise).resolves.toEqual({
+			path: { id: 'late-session' },
+		});
+	});
+
+	test('truncates oversized lane output with metadata', async () => {
+		const directory = makeTempDir();
+		const hugeOutput = 'x'.repeat(25_000);
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: 'session-1' },
+				error: undefined,
+			})),
+			prompt: mock(async () => ({
+				data: { parts: [{ type: 'text' as const, text: hugeOutput }] },
+				error: undefined,
+			})),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{
+				lanes: [{ id: 'huge', agent: 'reviewer', prompt: 'large output' }],
+			},
+			directory,
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.lane_results[0].output_chars).toBe(25_000);
+		expect(result.lane_results[0].output_truncated).toBe(true);
+		expect(result.lane_results[0].output?.length).toBeLessThan(
+			hugeOutput.length,
+		);
+		expect(result.lane_results[0].output).toContain(
+			'chars truncated by dispatch_lanes',
+		);
+	});
+
+	test('fails closed when the OpenCode session client is unavailable', async () => {
+		_internals.getSessionOps = () => null;
+
+		const result = await executeDispatchLanes(
+			{
+				lanes: [{ id: 'runtime', agent: 'explorer', prompt: 'inspect' }],
+			},
+			makeTempDir(),
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.failure_class).toBe('no_client');
+		expect(result.lane_results).toEqual([]);
+	});
+});

--- a/tests/unit/tools/dispatch-lanes.test.ts
+++ b/tests/unit/tools/dispatch-lanes.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {
 	_internals,
+	_test_exports,
 	type DispatchLaneResult,
 	executeDispatchLanes,
 	type SessionOps,
@@ -107,8 +108,40 @@ describe('executeDispatchLanes', () => {
 				extract_code_blocks: false,
 				save_plan: false,
 				update_task_status: false,
+				summarize_work: false,
+				doc_scan: false,
 			});
 		}
+	});
+
+	test('denies summarize_work and doc_scan to read-only lanes — regression: PR #1358 review (R1.1)', async () => {
+		const directory = makeTempDir();
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: 'session-1' },
+				error: undefined,
+			})),
+			prompt: mock(async (input) => ({
+				data: { parts: [{ type: 'text' as const, text: 'denied' }] },
+				error: undefined,
+			})),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{
+				lanes: [{ id: 'scan', agent: 'explorer', prompt: 'scan docs' }],
+			},
+			directory,
+		);
+
+		expect(result.success).toBe(true);
+		expect(ops.prompt).toHaveBeenCalledTimes(1);
+		expect(ops.prompt.mock.calls[0][0].body.tools).toMatchObject({
+			summarize_work: false,
+			doc_scan: false,
+		});
 	});
 
 	test('honors max_concurrent while preserving a join barrier', async () => {
@@ -494,6 +527,7 @@ describe('executeDispatchLanes', () => {
 		expect(result.lane_results[0].output?.length).toBeLessThan(
 			hugeOutput.length,
 		);
+		expect(result.lane_results[0].output?.length).toBe(20_000);
 		expect(result.lane_results[0].output).toContain(
 			'chars truncated by dispatch_lanes',
 		);
@@ -512,5 +546,383 @@ describe('executeDispatchLanes', () => {
 		expect(result.success).toBe(false);
 		expect(result.failure_class).toBe('no_client');
 		expect(result.lane_results).toEqual([]);
+	});
+
+	test('rejects empty lanes array — schema min(1) — regression: PR #1358 review (R1.6)', async () => {
+		_internals.getSessionOps = mock(() => null);
+
+		const result = await executeDispatchLanes({ lanes: [] }, makeTempDir());
+
+		expect(result.success).toBe(false);
+		expect(result.failure_class).toBe('invalid_args');
+		expect(result.errors).toBeDefined();
+		expect(result.errors!.some((e) => e.includes('lanes'))).toBe(true);
+		expect(result.lane_results).toEqual([]);
+	});
+
+	test('rejects lane with empty string id — schema min(1) — regression: PR #1358 review (R1.6)', async () => {
+		_internals.getSessionOps = mock(() => null);
+
+		const result = await executeDispatchLanes(
+			{
+				lanes: [{ id: '', agent: 'explorer', prompt: 'inspect' }],
+			},
+			makeTempDir(),
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.failure_class).toBe('invalid_args');
+		expect(result.errors).toBeDefined();
+		expect(result.errors!.some((e) => e.includes('id'))).toBe(true);
+		expect(result.lane_results).toEqual([]);
+	});
+
+	test('rejects lane with missing agent field — schema min(1) — regression: PR #1358 review (R1.6)', async () => {
+		_internals.getSessionOps = mock(() => null);
+
+		const result = await executeDispatchLanes(
+			{
+				lanes: [{ id: 'lane1', prompt: 'inspect' }] as Array<{
+					id: string;
+					agent: string;
+					prompt: string;
+				}>,
+			},
+			makeTempDir(),
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.failure_class).toBe('invalid_args');
+		expect(result.errors).toBeDefined();
+		expect(result.errors!.some((e) => e.includes('agent'))).toBe(true);
+		expect(result.lane_results).toEqual([]);
+	});
+
+	test('rejects lane with missing id field — schema min(1) — regression: PR #1358 review (R1.6)', async () => {
+		_internals.getSessionOps = mock(() => null);
+
+		const result = await executeDispatchLanes(
+			{
+				lanes: [{ agent: 'explorer', prompt: 'inspect' }] as Array<{
+					id: string;
+					agent: string;
+					prompt: string;
+				}>,
+			},
+			makeTempDir(),
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.failure_class).toBe('invalid_args');
+		expect(result.errors).toBeDefined();
+		expect(result.errors!.some((e) => e.includes('id'))).toBe(true);
+		expect(result.lane_results).toEqual([]);
+	});
+
+	test('rejects lane with missing prompt field — schema min(1) — regression: PR #1358 review (R1.6)', async () => {
+		_internals.getSessionOps = mock(() => null);
+
+		const result = await executeDispatchLanes(
+			{
+				lanes: [{ id: 'lane1', agent: 'explorer' }] as Array<{
+					id: string;
+					agent: string;
+					prompt: string;
+				}>,
+			},
+			makeTempDir(),
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.failure_class).toBe('invalid_args');
+		expect(result.errors).toBeDefined();
+		expect(result.errors!.some((e) => e.includes('prompt'))).toBe(true);
+		expect(result.lane_results).toEqual([]);
+	});
+
+	test('rejects lane with empty string agent — schema min(1) — regression: PR #1358 review (R1.6)', async () => {
+		_internals.getSessionOps = mock(() => null);
+
+		const result = await executeDispatchLanes(
+			{
+				lanes: [{ id: 'lane1', agent: '', prompt: 'inspect' }],
+			},
+			makeTempDir(),
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.failure_class).toBe('invalid_args');
+		expect(result.errors).toBeDefined();
+		expect(result.errors!.some((e) => e.includes('agent'))).toBe(true);
+		expect(result.lane_results).toEqual([]);
+	});
+
+	test('rejects lane with empty string prompt — schema min(1) — regression: PR #1358 review (R1.6)', async () => {
+		_internals.getSessionOps = mock(() => null);
+
+		const result = await executeDispatchLanes(
+			{
+				lanes: [{ id: 'lane1', agent: 'explorer', prompt: '' }],
+			},
+			makeTempDir(),
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.failure_class).toBe('invalid_args');
+		expect(result.errors).toBeDefined();
+		expect(result.errors!.some((e) => e.includes('prompt'))).toBe(true);
+		expect(result.lane_results).toEqual([]);
+	});
+
+	test('rejects max_concurrent of 0 — schema min(1) — regression: PR #1358 review (R1.6)', async () => {
+		_internals.getSessionOps = mock(() => null);
+
+		const result = await executeDispatchLanes(
+			{
+				max_concurrent: 0,
+				lanes: [{ id: 'lane1', agent: 'explorer', prompt: 'inspect' }],
+			},
+			makeTempDir(),
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.failure_class).toBe('invalid_args');
+		expect(result.errors).toBeDefined();
+		expect(result.errors!.some((e) => e.includes('max_concurrent'))).toBe(true);
+		expect(result.lane_results).toEqual([]);
+	});
+
+	test('rejects timeout_ms of 0 — schema min(10) — regression: PR #1358 review (R1.6)', async () => {
+		_internals.getSessionOps = mock(() => null);
+
+		const result = await executeDispatchLanes(
+			{
+				timeout_ms: 0,
+				lanes: [{ id: 'lane1', agent: 'explorer', prompt: 'inspect' }],
+			},
+			makeTempDir(),
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.failure_class).toBe('invalid_args');
+		expect(result.errors).toBeDefined();
+		expect(result.errors!.some((e) => e.includes('timeout_ms'))).toBe(true);
+		expect(result.lane_results).toEqual([]);
+	});
+
+	test('rejects timeout_ms of 5 — below schema min(10) — regression: PR #1358 review (R1.6)', async () => {
+		_internals.getSessionOps = mock(() => null);
+
+		const result = await executeDispatchLanes(
+			{
+				timeout_ms: 5,
+				lanes: [{ id: 'lane1', agent: 'explorer', prompt: 'inspect' }],
+			},
+			makeTempDir(),
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.failure_class).toBe('invalid_args');
+		expect(result.errors).toBeDefined();
+		expect(result.errors!.some((e) => e.includes('timeout_ms'))).toBe(true);
+		expect(result.lane_results).toEqual([]);
+	});
+
+	test('explicit max_concurrent above lane count is accepted but clamped to lanes.length — regression: PR #1358 review (R1.7)', async () => {
+		// max_concurrent: 5 passes schema (max 8) but Math.min(5, 3, 8) = 3
+		// The key distinction from "omitted" is that the explicit value is accepted
+		// (schema passes) and the result.max_concurrent reflects the clamped value.
+		// This verifies the clamping formula: Math.min(max_concurrent, lanes.length, MAX_LANES)
+		const directory = makeTempDir();
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: 'session-1' },
+				error: undefined,
+			})),
+			prompt: mock(async () => ({
+				data: { parts: [{ type: 'text' as const, text: 'done' }] },
+				error: undefined,
+			})),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{
+				max_concurrent: 5, // passes schema (5 <= 8), clamped to 3 by lanes.length
+				timeout_ms: 10_000,
+				lanes: [
+					{ id: 'a', agent: 'explorer', prompt: 'a' },
+					{ id: 'b', agent: 'reviewer', prompt: 'b' },
+					{ id: 'c', agent: 'critic', prompt: 'c' },
+				],
+			},
+			directory,
+		);
+
+		expect(result.success).toBe(true);
+		// Clamped by lanes.length: Math.min(5, 3, 8) = 3
+		expect(result.max_concurrent).toBe(3);
+		// All 3 lanes completed since effective concurrency (3) >= lanes.length (3)
+		expect(result.completed).toBe(3);
+	});
+
+	test('omitted max_concurrent defaults to lanes.length — regression: PR #1358 review (R1.7)', async () => {
+		const directory = makeTempDir();
+		const allStarted = deferred();
+		let activePrompts = 0;
+		let maxActivePrompts = 0;
+		let promptStarts = 0;
+
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: `session-${Math.random()}` },
+				error: undefined,
+			})),
+			prompt: mock(async () => {
+				promptStarts++;
+				activePrompts++;
+				maxActivePrompts = Math.max(maxActivePrompts, activePrompts);
+				if (promptStarts === 3) allStarted.resolve();
+				await new Promise<void>((resolve) => setTimeout(resolve, 50));
+				activePrompts--;
+				return {
+					data: { parts: [{ type: 'text' as const, text: 'done' }] },
+					error: undefined,
+				};
+			}),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{
+				// max_concurrent omitted → defaults to lanes.length (3)
+				timeout_ms: 10_000,
+				lanes: [
+					{ id: 'a', agent: 'explorer', prompt: 'a' },
+					{ id: 'b', agent: 'reviewer', prompt: 'b' },
+					{ id: 'c', agent: 'critic', prompt: 'c' },
+				],
+			},
+			directory,
+		);
+
+		await allStarted.promise;
+		// Default is lanes.length (3), which is also within MAX_LANES (8)
+		expect(result.max_concurrent).toBe(3);
+		expect(maxActivePrompts).toBe(3);
+	});
+
+	test('effective max_concurrent honors the MIN-of-three formula — regression: PR #1358 review (R1.7)', async () => {
+		// With 5 lanes and max_concurrent: 8, the clamping formula gives:
+		// Math.min(8, 5, 8) = 5 — clamped by lanes.length (5)
+		// This verifies that result.max_concurrent reflects the effective clamped value.
+		const directory = makeTempDir();
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: 'session-1' },
+				error: undefined,
+			})),
+			prompt: mock(async () => ({
+				data: { parts: [{ type: 'text' as const, text: 'done' }] },
+				error: undefined,
+			})),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{
+				max_concurrent: 8, // at MAX_LANES ceiling
+				timeout_ms: 10_000,
+				lanes: [
+					{ id: 'l1', agent: 'explorer', prompt: 'p1' },
+					{ id: 'l2', agent: 'reviewer', prompt: 'p2' },
+					{ id: 'l3', agent: 'critic', prompt: 'p3' },
+					{ id: 'l4', agent: 'explorer', prompt: 'p4' },
+					{ id: 'l5', agent: 'reviewer', prompt: 'p5' },
+				],
+			},
+			directory,
+		);
+
+		expect(result.success).toBe(true);
+		// Clamped by lanes.length: Math.min(8, 5, 8) = 5
+		expect(result.max_concurrent).toBe(5);
+		expect(result.completed).toBe(5);
+	});
+
+	test('rejects duplicate lane IDs before creating any sessions — regression: PR #1358 review (R1.2)', async () => {
+		const directory = makeTempDir();
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: 'session-1' },
+				error: undefined,
+			})),
+			prompt: mock(async () => ({
+				data: { parts: [{ type: 'text' as const, text: 'unused' }] },
+				error: undefined,
+			})),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{
+				lanes: [
+					{ id: 'dup', agent: 'explorer', prompt: 'first' },
+					{ id: 'dup', agent: 'reviewer', prompt: 'second' },
+				],
+			},
+			directory,
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.failure_class).toBe('invalid_args');
+		expect(result.message).toBe(
+			'Lane IDs must be unique within one dispatch_lanes batch',
+		);
+		expect(result.errors).toEqual(['Duplicate lane id: dup']);
+		expect(result.lane_results).toEqual([]);
+		// Verify no session ops were attempted — rejection is before session creation
+		expect(ops.create).not.toHaveBeenCalled();
+		expect(ops.prompt).not.toHaveBeenCalled();
+	});
+});
+
+describe('formatError — regression: PR #1358 review (R1.3)', () => {
+	const { formatError } = _test_exports;
+
+	test('returns Error message for Error instances', () => {
+		expect(formatError(new Error('boom'))).toBe('boom');
+	});
+
+	test('returns string values unchanged', () => {
+		expect(formatError('plain string')).toBe('plain string');
+	});
+
+	test('returns conservative String representation for non-Error values', () => {
+		expect(formatError(42)).toBe('42');
+		expect(formatError(undefined)).toBe('undefined');
+		expect(formatError(null)).toBe('null');
+		expect(formatError(true)).toBe('true');
+	});
+
+	test('avoids JSON.stringify and handles non-serializable objects safely', () => {
+		const circular: Record<string, unknown> = { a: 1 };
+		circular.self = circular;
+
+		const result = formatError(circular);
+		expect(typeof result).toBe('string');
+		expect(result).not.toContain('JSON');
+		expect(result).toContain('[object Object]');
+	});
+
+	test('caps oversized non-Error representations', () => {
+		const longText = 'x'.repeat(500);
+		const result = formatError(longText);
+		expect(result).toBe(`${longText.slice(0, 200)}...`);
+		expect(result.length).toBe(203);
 	});
 });


### PR DESCRIPTION
Closes #1352

## Summary
- Add dispatch_lanes, an architect-facing read-only lane dispatcher that fans out OpenCode sessions concurrently with bounded concurrency and returns structured join results.
- Rewire swarm-pr-review skill/docs to use dispatch_lanes instead of model-emitted background Agent calls.
- Cover registration, prompt visibility, skill guidance, cleanup/timeout, read-only enforcement, and generated-agent validation.
- **Follow-up:** Addressed PR review feedback — hardened read-only denylist (summarize_work, doc_scan), fixed output truncation bound, replaced JSON.stringify error fallback with safe String() representation, removed dead identity catch, and added regression tests for duplicate IDs, schema boundaries, and concurrency clamping.

## Invariant audit
- 1 (plugin init): not touched - no startup/init path changed; dispatch_lanes is a lazy handler in the existing manifest path.
- 2 (runtime portability): touched - un run build passed; 
ode --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')" printed dist import OK.
- 3 (subprocesses): not touched - no spawn/subprocess code added in the production diff.
- 4 (.swarm containment): touched - dispatch_lanes creates no runtime files; read-only lanes are denied tools (including summarize_work and doc_scan) that write .swarm/ state.
- 5 (plan durability): not touched - no plan ledger/projection/checkpoint paths changed.
- 6 (test_runner safety): touched - validation used shell/Bun commands only; no broad OpenCode 	est_runner scope was used.
- 7 (test writing): touched - writing-tests guidance was loaded; new tests use un:test, _internals seams, temp dirs via os.tmpdir()/path.join()/ealpathSync, and no mock.module.
- 8 (session state): touched - dispatch_lanes creates ephemeral sessions and cleans them up; tests cover prompt timeout cleanup, hung cleanup non-blocking, late-create cleanup, and no module-level session maps were added.
- 9 (guardrails/retry): not touched - no retry/circuit-breaker/guardrail semantics changed.
- 10 (chat/system msg): not touched - no chat/system-message hook changed.
- 11 (tool registration): touched - un run scripts/check-tool-registration.ts passed; focused manifest/config/architect prompt tests passed.
- 12 (release/cache): touched - added docs/releases/pending/1358-dispatch-lanes-review-feedback.md; version files untouched.

## Test plan
- un --smol test tests/unit/tools/dispatch-lanes.test.ts --timeout 30000 — 31/31 pass
- un --smol test tests/unit/tools/manifest-parity.test.ts tests/unit/config/constants.test.ts tests/unit/agents/architect-tool-lists.test.ts tests/unit/skills/swarm-pr-review-dispatch-guidance.test.ts --timeout 30000 — 42/42 pass
- un run typecheck — passed
- unx biome ci . — passed
- un run scripts/check-tool-registration.ts — passed
- git diff --check — passed
- un run build — passed
- 
ode --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')" — dist import OK

## Feedback closure
- FB-001 (cubic): fixed - extract_code_blocks is explicitly denied in read-only lane tool permissions, and tests assert that denial.
- R1.1 (reviewer): fixed - summarize_work and doc_scan added to READ_ONLY_TOOL_DENYLIST; tests assert denial.
- R1.2 (reviewer): fixed - duplicate lane ID rejection test added.
- R1.3 (reviewer): fixed - ormatError no longer uses JSON.stringify; regression tests added.
- R1.4 (reviewer): fixed - dead identity catch removed.
- R1.6 (reviewer): fixed - schema boundary validation tests added.
- R1.7 (reviewer): fixed - max_concurrent boundary tests added.