### PR TITLE
docs(skills): add cross-platform env var redirection guidance to writing-tests

### DIFF
--- a/.opencode/skills/writing-tests/SKILL.md
+++ b/.opencode/skills/writing-tests/SKILL.md
@@ -389,6 +389,78 @@ mockRealpathSync.mockImplementation((inputPath: string) => {
   Do not call recursive `rm` on a computed path unless the helper has rejected
   empty strings, `os.tmpdir()` itself, and paths outside the temp root.
 
+### Platform-specific environment variable redirection
+
+When tests redirect `process.env.HOME` to isolate path-resolver-dependent code
+(functions like `resolveHiveKnowledgePath`, `resolveSwarmKnowledgePath`, or any
+function that reads `os.homedir()` / platform env vars), they MUST redirect ALL
+platform-specific env vars, not just `HOME`. A partial redirect silently falls
+back to the real user profile on some platforms, causing tests to read/write
+actual user data instead of the isolated temp directory.
+
+Per-platform requirements:
+
+- **Linux**: redirect `HOME`, `XDG_CONFIG_HOME`, and `XDG_DATA_HOME`.
+- **macOS**: redirect `HOME` (macOS resolves `~/Library/Application Support` from
+  the home directory).
+- **Windows**: redirect `HOME`, `LOCALAPPDATA`, AND `APPDATA`. Windows path
+  resolvers read `LOCALAPPDATA` and `APPDATA`, neither of which is derived from
+  `HOME`. Redirecting only `HOME` silently fails on Windows, causing tests to
+  touch the real `%LOCALAPPDATA%` and `%APPDATA%` trees.
+
+> **⚠️ Bun caches `os.homedir()` on first call.** If a module calls `os.homedir()`
+> before the test sets `process.env.HOME`, the cached value persists for the
+> lifetime of the process and later env changes are silently ignored. Set
+> `process.env.HOME` (and other redirected vars) **before** importing any module
+> that calls `os.homedir()`. The source code documents this at
+> `src/hooks/knowledge-store.ts`: "Bun caches os.homedir(), so changing $HOME
+> after first call is ignored."
+
+Use per-variable save/restore rather than saving and replacing the entire
+`process.env` object — the latter discards process-level env state and can
+interfere with other test infrastructure:
+
+```typescript
+import { beforeEach, afterEach } from 'bun:test';
+import os from 'node:os';
+import path from 'node:path';
+
+const saved = {
+  HOME: process.env.HOME,
+  LOCALAPPDATA: process.env.LOCALAPPDATA,
+  APPDATA: process.env.APPDATA,
+  XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+  XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+};
+
+beforeEach(() => {
+  const isolatedDir = path.join(os.tmpdir(), 'test-home');
+  process.env.HOME = isolatedDir;
+  process.env.LOCALAPPDATA = isolatedDir;
+  process.env.APPDATA = isolatedDir;
+  process.env.XDG_CONFIG_HOME = isolatedDir;
+  process.env.XDG_DATA_HOME = isolatedDir;
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+```
+
+For cross-file isolation (tests that must survive across multiple files in the
+same process, e.g. batch steps), use `beforeAll` / `afterAll` with the same
+per-var save/restore pattern. Never mutate `process.env` without restoring it in
+a matching teardown hook.
+
+**Preferred approach:** Use `createIsolatedTestEnv()` from
+`tests/helpers/isolated-test-env.ts`. It handles `XDG_CONFIG_HOME`, `APPDATA`,
+`LOCALAPPDATA`, and `HOME` with correct per-variable save/restore and returns a
+cleanup function that removes the temp directory. Use this helper unless your
+test has specific requirements it doesn't cover.
+
 ### Line ending normalization
 
 Git on Windows converts LF to CRLF by default. Tests that compare file contents

--- a/docs/releases/pending/skill-cross-platform-env-redirection.md
+++ b/docs/releases/pending/skill-cross-platform-env-redirection.md
@@ -1,0 +1,18 @@
+# Cross-platform env var redirection guidance for writing-tests skill
+
+## What changed
+
+Added a new "Platform-specific environment variable redirection" subsection to the `writing-tests` skill's Cross-Platform Test Patterns section. The subsection documents:
+
+- Which platform-specific env vars must be redirected when tests isolate path-resolver-dependent code (`HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME` on Linux; `HOME` on macOS; `HOME`, `LOCALAPPDATA`, `APPDATA` on Windows)
+- A warning about Bun's `os.homedir()` caching behavior (must set `HOME` before importing modules that call it)
+- A per-variable save/restore code pattern matching the canonical `tests/helpers/isolated-test-env.ts` helper
+- A recommendation to use `createIsolatedTestEnv()` as the preferred approach
+
+## Why
+
+During PR #1312 review, 3 hive-tier tests failed on Windows because `resolveHiveKnowledgePath()` reads `LOCALAPPDATA` (not redirected by the test's `HOME`/`XDG_DATA_HOME` override). Tests silently read/wrote the real user data file instead of an isolated temp directory. This guidance prevents future occurrences.
+
+## Migration
+
+No code changes required. Test authors should follow the new guidance when writing tests that redirect `HOME` for path-resolver isolation. Existing tests that use `createIsolatedTestEnv()` are already compliant.


### PR DESCRIPTION
## Summary

- Adds a new "Platform-specific environment variable redirection" subsection to the `writing-tests` skill's Cross-Platform Test Patterns section.
- Documents which platform-specific env vars must be redirected when tests isolate path-resolver-dependent code: `HOME` + `XDG_CONFIG_HOME` + `XDG_DATA_HOME` (Linux), `HOME` (macOS), `HOME` + `LOCALAPPDATA` + `APPDATA` (Windows).
- Includes a Bun `os.homedir()` caching warning, a per-variable save/restore code pattern matching the canonical `tests/helpers/isolated-test-env.ts`, and a recommendation to use `createIsolatedTestEnv()`.
- Discovered during PR #1312 review where 3 hive-tier tests failed on Windows because `resolveHiveKnowledgePath()` reads `LOCALAPPDATA` (not redirected by the test's `HOME` override).

## Invariant audit

- 1 (plugin init): not touched — no plugin registration or startup paths changed
- 2 (runtime portability): not touched — no source code or bundle shape changes
- 3 (subprocesses): not touched — no spawn calls modified
- 4 (.swarm containment): not touched — skill file is under `.opencode/skills/`, not `.swarm/`
- 5 (plan durability): not touched — no plan/ledger changes
- 6 (test_runner safety): not touched — no test_runner tool changes
- 7 (test writing): touched — the `writing-tests` skill documentation is updated with new cross-platform guidance. No test code itself changed. The guidance was reviewed by a critic (2 rounds: initial NEEDS_REVISION with 6 findings → revised → APPROVED with zero remaining issues).
- 8 (session state): not touched — no session state changes
- 9 (guardrails/retry): not touched — no guardrail logic changed
- 10 (chat/system msg): not touched — no prompt or message changes
- 11 (tool registration): not touched — no tool registration changes
- 12 (release/cache): touched — release fragment added at `docs/releases/pending/skill-cross-platform-env-redirection.md`. No version/changelog/manifest files edited.

## Test plan

- [x] `bun run typecheck` — exit 0
- [x] `bunx biome ci .` — 1959 files checked, no issues
- [x] Critic review: 2 rounds (NEEDS_REVISION → APPROVED, zero remaining issues)
- [ ] CI validation: typecheck, biome, unit/integration/smoke suites will run on PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross-platform env var redirection guidance to the `writing-tests` skill to keep path-resolver tests fully isolated and prevent writes to real user directories.

- **New Features**
  - New subsection: “Platform-specific environment variable redirection” under Cross-Platform Test Patterns.
  - Per-OS vars to redirect: Linux `HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`; macOS `HOME`; Windows `HOME`, `LOCALAPPDATA`, `APPDATA`.
  - Note: set `HOME` before importing modules that call `os.homedir()` due to Bun caching.
  - Shows per-variable save/restore (incl. `beforeAll`/`afterAll` for cross-file) and recommends `createIsolatedTestEnv()`.

- **Migration**
  - No code changes. When tests override `HOME`, also redirect the listed vars or use `createIsolatedTestEnv()`.

<sup>Written for commit 8451d51507d70a4ba83a826dc5a4d44b67c42c4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

