### PR TITLE
fix(sessions): abort in-flight prompt before session.delete() to prevent FK crashes

### DIFF
--- a/docs/releases/pending/fix-fk-session-delete-race.md
+++ b/docs/releases/pending/fix-fk-session-delete-race.md
@@ -1,0 +1,53 @@
+# Fix: abort in-flight prompt before session.delete() to prevent FK crashes
+
+## What changed
+
+All 8 callsites that create ephemeral sessions via `client.session.create()` and then
+prompt via `client.session.prompt()` now forward an `AbortController` signal to the
+prompt call and invoke `controller.abort()` before calling `session.delete()`.
+
+The fix covers:
+- `src/tools/dispatch-lanes.ts` — `runLane()` and `withTimeout()` helper
+- `src/hooks/auto-review.ts` — `dispatchReviewer()`
+- `src/hooks/full-auto-intercept.ts` — `dispatchCriticAndWriteEvent()`
+- `src/mutation/generator.ts` — `generateMutants()`
+- `src/full-auto/oversight.ts` — `dispatchFullAutoOversight()`
+- `src/turbo/lean/reviewer.ts` — `defaultDispatchReviewerAgent()`
+- `src/turbo/lean/integration.ts` — `defaultDispatchCriticAgent()`
+- `src/turbo/lean/runner.ts` — `LeanTurboRunner.dispatchLane()`
+
+Secondary fixes in the same PR:
+- **Timer leaks** in `reviewer.ts`, `integration.ts`, and `runner.ts`: `setTimeout`
+  handles are now stored and cleared in `finally` blocks on success paths.
+- **Session leak** in `runner.ts` `_doDispatch`: hoisted `sessionId` to outer scope so
+  `session.delete()` fires in the `catch` block when `session.prompt()` throws.
+
+## Why
+
+When a timeout fires mid-prompt, `session.delete()` removed the session row from
+SQLite while OpenCode's `SessionProcessor` was still writing `message` rows that
+reference `session.id`. The FK constraint (`message.session_id → session.id`) then
+failed with `SQLiteError: FOREIGN KEY constraint failed`, producing a visible error
+loop in the host application.
+
+The root cause is a delete-before-cancel race: `session.delete()` fired before the
+HTTP fetch backing `session.prompt()` was cancelled. Calling `controller.abort()` first
+causes the SDK to cancel the in-flight request, so the `SessionProcessor` stops writing
+before the session row disappears.
+
+The fix pattern was already deployed in `curator-llm-factory.ts` and
+`skill-improver-llm-factory.ts` with a documented comment about FK crashes; this PR
+applies it uniformly to all remaining callsites.
+
+## Migration steps
+
+No migration required. This is an internal change to session lifecycle management with
+no API or configuration surface changes.
+
+## Breaking changes
+
+None.
+
+## Known caveats
+
+None.

--- a/src/full-auto/oversight.ts
+++ b/src/full-auto/oversight.ts
@@ -361,7 +361,9 @@ export async function dispatchFullAutoOversight(
 	);
 
 	let ephemeralSessionId: string | undefined;
+	const promptController = new AbortController();
 	const cleanup = () => {
+		promptController.abort();
 		if (ephemeralSessionId) {
 			const id = ephemeralSessionId;
 			ephemeralSessionId = undefined;
@@ -399,6 +401,7 @@ export async function dispatchFullAutoOversight(
 				tools: { write: false, edit: false, patch: false },
 				parts: [{ type: 'text', text: buildOversightPrompt(input) }],
 			},
+			signal: promptController.signal,
 		});
 
 		if (!promptResult.data) {

--- a/src/hooks/auto-review.ts
+++ b/src/hooks/auto-review.ts
@@ -200,6 +200,7 @@ async function dispatchReviewer(
 		throw new Error('Failed to create auto-review session');
 	}
 	const sessionId = createResult.data.id;
+	const promptController = new AbortController();
 	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 	try {
 		const promptCall = client.session.prompt({
@@ -210,14 +211,15 @@ async function dispatchReviewer(
 				tools: { write: false, edit: false, patch: false },
 				parts: [{ type: 'text', text: prompt }],
 			},
+			signal: promptController.signal,
 		});
 		const response = await Promise.race([
 			promptCall,
 			new Promise<never>((_, reject) => {
-				timeoutHandle = setTimeout(
-					() => reject(new Error(`auto-review timed out after ${timeoutMs}ms`)),
-					timeoutMs,
-				);
+				timeoutHandle = setTimeout(() => {
+					promptController.abort();
+					reject(new Error(`auto-review timed out after ${timeoutMs}ms`));
+				}, timeoutMs);
 			}),
 		]);
 		if (!response.data) {
@@ -228,9 +230,8 @@ async function dispatchReviewer(
 			.map((p) => p.text)
 			.join('\n');
 	} finally {
-		// Clear the race timer so successful dispatches do not leave a pending
-		// timeout (up to 30min) keeping the event loop alive.
 		if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+		promptController.abort();
 		client.session.delete({ path: { id: sessionId } }).catch(() => {});
 	}
 }

--- a/src/hooks/full-auto-intercept.ts
+++ b/src/hooks/full-auto-intercept.ts
@@ -499,9 +499,14 @@ export async function dispatchCriticAndWriteEvent(
 	);
 
 	let ephemeralSessionId: string | undefined;
+	const promptController = new AbortController();
 
-	// Best-effort cleanup — never throws
+	// Best-effort cleanup — never throws.
+	// Aborts any in-flight prompt before deleting the session so OpenCode
+	// stops writing message rows before the session row is removed (prevents
+	// FK constraint crashes).
 	const cleanup = () => {
+		promptController.abort();
 		if (ephemeralSessionId) {
 			const id = ephemeralSessionId;
 			ephemeralSessionId = undefined;
@@ -540,6 +545,7 @@ export async function dispatchCriticAndWriteEvent(
 				tools: { write: false, edit: false, patch: false },
 				parts: [{ type: 'text', text: criticContext }],
 			},
+			signal: promptController.signal,
 		});
 
 		if (!promptResult.data) {

--- a/src/mutation/generator.ts
+++ b/src/mutation/generator.ts
@@ -78,9 +78,13 @@ export async function generateMutants(
 
 	const directory = ctx.directory ?? process.cwd();
 	let ephemeralSessionId: string | undefined;
+	const promptController = new AbortController();
 
-	/** Best-effort session cleanup — never throws. */
+	/** Best-effort session cleanup — never throws.
+	 *  Aborts any in-flight prompt before deleting the session so OpenCode
+	 *  stops writing message rows before the session row is removed. */
 	const cleanup = () => {
+		promptController.abort();
 		if (ephemeralSessionId) {
 			const id = ephemeralSessionId;
 			ephemeralSessionId = undefined;
@@ -141,6 +145,7 @@ Return ONLY a valid JSON array. No markdown, no code fences, no explanation. Sta
 				tools: { write: false, edit: false, patch: false },
 				parts: [{ type: 'text', text: promptText }],
 			},
+			signal: promptController.signal,
 		});
 
 		if (!promptResult.data) {

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -151,6 +151,7 @@ export interface SessionOps {
 			tools: ReadOnlyToolPermissions;
 			parts: Array<{ type: 'text'; text: string }>;
 		};
+		signal?: AbortSignal;
 	}): Promise<{
 		data?: { parts?: Array<{ type: string; text?: string }> } | null;
 		error?: unknown;
@@ -281,6 +282,7 @@ async function runLane(
 		};
 	}
 
+	const promptController = new AbortController();
 	let sessionId: string | undefined;
 	try {
 		const createTimeoutMessage = `Lane "${lane.id}" session.create timed out after ${timeoutMs}ms`;
@@ -323,9 +325,11 @@ async function runLane(
 					tools: buildReadOnlyTools(),
 					parts: [{ type: 'text', text: lane.prompt }],
 				},
+				signal: promptController.signal,
 			}),
 			timeoutMs,
 			`Lane "${lane.id}" session.prompt timed out after ${timeoutMs}ms`,
+			promptController,
 		);
 		if (!promptResult.data) {
 			return failedLane(
@@ -364,6 +368,7 @@ async function runLane(
 		);
 	} finally {
 		dispatcher.releaseSlot(decision.slot.slotId);
+		promptController.abort();
 		if (sessionId) {
 			scheduleSessionCleanup(session, sessionId);
 		}
@@ -539,13 +544,20 @@ async function withTimeout<T>(
 	promise: Promise<T>,
 	timeoutMs: number,
 	message: string,
+	controller?: AbortController,
 ): Promise<T> {
 	let timeout: ReturnType<typeof setTimeout> | undefined;
 	try {
 		return await Promise.race([
 			promise,
 			new Promise<never>((_, reject) => {
-				timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+				timeout = setTimeout(() => {
+					controller?.abort();
+					reject(new Error(message));
+				}, timeoutMs);
+				if (typeof (timeout as { unref?: () => void }).unref === 'function') {
+					(timeout as { unref: () => void }).unref();
+				}
 			}),
 		]);
 	} finally {

--- a/src/turbo/lean/integration.ts
+++ b/src/turbo/lean/integration.ts
@@ -405,6 +405,8 @@ async function defaultDispatchCriticAgent(
 	}
 
 	const sessionId = sessionResult.data.id;
+	const promptController = new AbortController();
+	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
 	try {
 		const promptText = `You are a read-only phase critic performing boundary review for Lean Turbo execution.
@@ -461,16 +463,16 @@ Be specific and evidence-based. When safety concerns are present, err on the sid
 								tools: { write: false, edit: false, patch: false },
 								parts: [{ type: 'text', text: promptText }],
 							},
+							signal: promptController.signal,
 						}),
-						new Promise<never>((_, reject) =>
-							setTimeout(
-								() =>
-									reject(
-										new Error(`Critic dispatch timed out after ${timeoutMs}ms`),
-									),
-								timeoutMs,
-							),
-						),
+						new Promise<never>((_, reject) => {
+							timeoutHandle = setTimeout(() => {
+								promptController.abort();
+								reject(
+									new Error(`Critic dispatch timed out after ${timeoutMs}ms`),
+								);
+							}, timeoutMs);
+						}),
 					])
 				: await client.session.prompt({
 						path: { id: sessionId },
@@ -479,6 +481,7 @@ Be specific and evidence-based. When safety concerns are present, err on the sid
 							tools: { write: false, edit: false, patch: false },
 							parts: [{ type: 'text', text: promptText }],
 						},
+						signal: promptController.signal,
 					});
 
 		if (!response.data) {
@@ -493,7 +496,8 @@ Be specific and evidence-based. When safety concerns are present, err on the sid
 
 		return textParts;
 	} finally {
-		// Clean up the ephemeral session
+		if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+		promptController.abort();
 		client.session.delete({ path: { id: sessionId } }).catch(() => {});
 	}
 }

--- a/src/turbo/lean/reviewer.ts
+++ b/src/turbo/lean/reviewer.ts
@@ -384,6 +384,8 @@ async function defaultDispatchReviewerAgent(
 	}
 
 	const sessionId = sessionResult.data.id;
+	const promptController = new AbortController();
+	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
 	try {
 		const promptText = `You are a read-only phase reviewer for Lean Turbo execution.
@@ -435,18 +437,16 @@ Be specific and evidence-based. Do not approve a phase with unresolved degraded 
 								tools: { write: false, edit: false, patch: false },
 								parts: [{ type: 'text', text: promptText }],
 							},
+							signal: promptController.signal,
 						}),
-						new Promise<never>((_, reject) =>
-							setTimeout(
-								() =>
-									reject(
-										new Error(
-											`Reviewer dispatch timed out after ${timeoutMs}ms`,
-										),
-									),
-								timeoutMs,
-							),
-						),
+						new Promise<never>((_, reject) => {
+							timeoutHandle = setTimeout(() => {
+								promptController.abort();
+								reject(
+									new Error(`Reviewer dispatch timed out after ${timeoutMs}ms`),
+								);
+							}, timeoutMs);
+						}),
 					])
 				: await client.session.prompt({
 						path: { id: sessionId },
@@ -455,6 +455,7 @@ Be specific and evidence-based. Do not approve a phase with unresolved degraded 
 							tools: { write: false, edit: false, patch: false },
 							parts: [{ type: 'text', text: promptText }],
 						},
+						signal: promptController.signal,
 					});
 
 		if (!response.data) {
@@ -469,7 +470,8 @@ Be specific and evidence-based. Do not approve a phase with unresolved degraded 
 
 		return textParts;
 	} finally {
-		// Clean up the ephemeral session
+		if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+		promptController.abort();
 		client.session.delete({ path: { id: sessionId } }).catch(() => {});
 	}
 }

--- a/src/turbo/lean/runner.ts
+++ b/src/turbo/lean/runner.ts
@@ -61,6 +61,7 @@ interface SessionClient {
 			tools: { write: boolean; edit: boolean; patch: boolean };
 			parts: Array<{ type: 'text'; text: string }>;
 		};
+		signal?: AbortSignal;
 	}): Promise<{
 		data: { parts: Array<{ type: string; text?: string }> } | null;
 		error: unknown;
@@ -528,25 +529,29 @@ export class LeanTurboRunner {
 		}
 
 		// Build a promise that does the full dispatch
+		const promptController = new AbortController();
 		const dispatchPromise = this._doDispatch(
 			session,
 			lane,
 			agentName,
 			worktreeDirectory,
+			promptController.signal,
 		);
 
 		// Apply timeout if configured via _internals
 		const timeoutMs = LeanTurboRunner._internals.laneDispatchTimeoutMs;
 		if (timeoutMs !== undefined && timeoutMs > 0) {
-			const timeoutPromise = new Promise<never>((_, reject) =>
-				setTimeout(
-					() =>
-						reject(new Error(`Lane dispatch timed out after ${timeoutMs}ms`)),
-					timeoutMs,
-				),
-			);
+			let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+			const timeoutPromise = new Promise<never>((_, reject) => {
+				timeoutHandle = setTimeout(() => {
+					promptController.abort();
+					reject(new Error(`Lane dispatch timed out after ${timeoutMs}ms`));
+				}, timeoutMs);
+			});
 			try {
-				return await Promise.race([dispatchPromise, timeoutPromise]);
+				const result = await Promise.race([dispatchPromise, timeoutPromise]);
+				if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+				return result;
 			} catch (err) {
 				if (err instanceof Error && err.message.includes('timed out')) {
 					// Timeout won the race. Track this lane so that when _doDispatch
@@ -594,7 +599,9 @@ export class LeanTurboRunner {
 		lane: LeanTurboLane,
 		agentName: string,
 		worktreeDirectory?: string,
+		abortSignal?: AbortSignal,
 	): Promise<LaneDispatchResult> {
+		let sessionId: string | undefined;
 		try {
 			// Use worktree directory when provided, otherwise use primary directory
 			const effectiveDirectory = worktreeDirectory ?? this._directory;
@@ -618,7 +625,7 @@ export class LeanTurboRunner {
 				};
 			}
 
-			const sessionId = createResult.data.id;
+			sessionId = createResult.data.id;
 
 			// Build task prompt for this lane
 			const promptText = this._buildLanePrompt(lane);
@@ -631,10 +638,10 @@ export class LeanTurboRunner {
 					tools: { write: true, edit: true, patch: true },
 					parts: [{ type: 'text' as const, text: promptText }],
 				},
+				signal: abortSignal,
 			});
 
 			if (!promptResult.data) {
-				// Clean up the orphaned session
 				session.delete({ path: { id: sessionId } }).catch(() => {});
 				return {
 					ok: false,
@@ -644,6 +651,9 @@ export class LeanTurboRunner {
 
 			return { ok: true, sessionId };
 		} catch (err) {
+			if (sessionId) {
+				session.delete({ path: { id: sessionId } }).catch(() => {});
+			}
 			const msg = err instanceof Error ? err.message : String(err);
 			return { ok: false, error: msg };
 		}

--- a/src/turbo/lean/runner.ts
+++ b/src/turbo/lean/runner.ts
@@ -535,7 +535,7 @@ export class LeanTurboRunner {
 			lane,
 			agentName,
 			worktreeDirectory,
-			promptController.signal,
+			promptController,
 		);
 
 		// Apply timeout if configured via _internals
@@ -549,9 +549,7 @@ export class LeanTurboRunner {
 				}, timeoutMs);
 			});
 			try {
-				const result = await Promise.race([dispatchPromise, timeoutPromise]);
-				if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
-				return result;
+				return await Promise.race([dispatchPromise, timeoutPromise]);
 			} catch (err) {
 				if (err instanceof Error && err.message.includes('timed out')) {
 					// Timeout won the race. Track this lane so that when _doDispatch
@@ -585,6 +583,8 @@ export class LeanTurboRunner {
 					return { ok: false, error: err.message };
 				}
 				throw err;
+			} finally {
+				if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
 			}
 		}
 
@@ -599,7 +599,7 @@ export class LeanTurboRunner {
 		lane: LeanTurboLane,
 		agentName: string,
 		worktreeDirectory?: string,
-		abortSignal?: AbortSignal,
+		abortController?: AbortController,
 	): Promise<LaneDispatchResult> {
 		let sessionId: string | undefined;
 		try {
@@ -638,10 +638,11 @@ export class LeanTurboRunner {
 					tools: { write: true, edit: true, patch: true },
 					parts: [{ type: 'text' as const, text: promptText }],
 				},
-				signal: abortSignal,
+				signal: abortController?.signal,
 			});
 
 			if (!promptResult.data) {
+				abortController?.abort();
 				session.delete({ path: { id: sessionId } }).catch(() => {});
 				return {
 					ok: false,
@@ -652,6 +653,7 @@ export class LeanTurboRunner {
 			return { ok: true, sessionId };
 		} catch (err) {
 			if (sessionId) {
+				abortController?.abort();
 				session.delete({ path: { id: sessionId } }).catch(() => {});
 			}
 			const msg = err instanceof Error ? err.message : String(err);

--- a/tests/unit/turbo/lean/runner.timeout-adversarial.test.ts
+++ b/tests/unit/turbo/lean/runner.timeout-adversarial.test.ts
@@ -908,3 +908,125 @@ describe('ATTACK VECTOR T8 — very large session ID handling', () => {
 		expect(result.sessionId).toBe(longSessionId);
 	});
 });
+
+// ════════════════════════════════════════════════════════════════════════════════
+// ATTACK VECTOR T9: Abort-before-delete ordering invariant
+// Verifies that promptController.abort() fires before session.delete() on every
+// exit path to prevent SQLiteError: FOREIGN KEY constraint failed.
+// ════════════════════════════════════════════════════════════════════════════════
+
+describe('ATTACK VECTOR T9 — abort-before-delete ordering invariant', () => {
+	test('signal is aborted before delete when prompt returns null data (no-timeout production path)', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		let capturedSignal: AbortSignal | undefined;
+		let signalAbortedAtDelete = false;
+
+		const runner = makeRunner({ generatedAgentNames: ['mega_coder'] });
+		injectMockSessionOps(runner, {
+			create: mock(() =>
+				Promise.resolve({ data: { id: 'session-ord-1' }, error: null }),
+			),
+			prompt: mock((args: { signal?: AbortSignal }) => {
+				capturedSignal = args.signal;
+				return Promise.resolve({ data: null, error: 'prompt failed' });
+			}),
+			delete: mock(() => {
+				signalAbortedAtDelete = capturedSignal?.aborted ?? false;
+				return Promise.resolve();
+			}),
+		} as unknown as MockSessionOps);
+
+		const lane: LeanTurboLane = {
+			laneId: 'lane-1',
+			taskIds: ['1.1'],
+			files: [],
+			status: 'pending',
+		};
+
+		const result = await runner.dispatchLane(lane, 'mega_coder');
+
+		expect(result.ok).toBe(false);
+		expect(signalAbortedAtDelete).toBe(true);
+	});
+
+	test('signal is aborted before delete when prompt throws (no-timeout production path)', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		let capturedSignal: AbortSignal | undefined;
+		let signalAbortedAtDelete = false;
+
+		const runner = makeRunner({ generatedAgentNames: ['mega_coder'] });
+		injectMockSessionOps(runner, {
+			create: mock(() =>
+				Promise.resolve({ data: { id: 'session-ord-2' }, error: null }),
+			),
+			prompt: mock((args: { signal?: AbortSignal }) => {
+				capturedSignal = args.signal;
+				return Promise.reject(new Error('mid-stream network failure'));
+			}),
+			delete: mock(() => {
+				signalAbortedAtDelete = capturedSignal?.aborted ?? false;
+				return Promise.resolve();
+			}),
+		} as unknown as MockSessionOps);
+
+		const lane: LeanTurboLane = {
+			laneId: 'lane-1',
+			taskIds: ['1.1'],
+			files: [],
+			status: 'pending',
+		};
+
+		const result = await runner.dispatchLane(lane, 'mega_coder');
+
+		expect(result.ok).toBe(false);
+		expect(signalAbortedAtDelete).toBe(true);
+	});
+
+	test('signal is aborted before delete when timeout fires mid-prompt', async () => {
+		writeMinimalPlan(1);
+		writeScopeFiles({ '1.1': ['src/a.ts'] });
+
+		let capturedSignal: AbortSignal | undefined;
+		let signalAbortedAtDelete = false;
+
+		const runner = makeRunner({ generatedAgentNames: ['mega_coder'] });
+		injectMockSessionOps(runner, {
+			create: mock(() =>
+				Promise.resolve({ data: { id: 'session-ord-3' }, error: null }),
+			),
+			prompt: mock((args: { signal?: AbortSignal }) => {
+				capturedSignal = args.signal;
+				return Bun.sleep(200).then(() =>
+					Promise.resolve({
+						data: { parts: [{ type: 'text', text: 'Done' }] },
+						error: null,
+					}),
+				);
+			}),
+			delete: mock(() => {
+				signalAbortedAtDelete = capturedSignal?.aborted ?? false;
+				return Promise.resolve();
+			}),
+		} as unknown as MockSessionOps);
+
+		LeanTurboRunner._internals.laneDispatchTimeoutMs = 30;
+
+		const lane: LeanTurboLane = {
+			laneId: 'lane-1',
+			taskIds: ['1.1'],
+			files: [],
+			status: 'pending',
+		};
+
+		const result = await runner.dispatchLane(lane, 'mega_coder');
+		await Bun.sleep(300);
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain('timed out');
+		expect(signalAbortedAtDelete).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- **Bug**: `session.delete()` raced with OpenCode&#39;s `SessionProcessor` write loop when a timeout fired mid-prompt, producing `SQLiteError: FOREIGN KEY constraint failed` on the `message` table (`message.session_id → session.id`)
- **Fix**: All 8 ephemeral-session callsites now call `controller.abort()` before `session.delete()` — both on timeout paths and in `finally`/cleanup blocks — so the in-flight HTTP fetch is cancelled before the session row is removed
- **Also fixed (commit 1)**: Timer leaks (`setTimeout` handles not cleared on success) in `reviewer.ts`, `integration.ts`, and `runner.ts`; `withTimeout` in `dispatch-lanes.ts` now calls `.unref()` so long-running timers don&#39;t hold the event loop open on shutdown; pre-existing session leak in `runner.ts` `_doDispatch` where `session.prompt()` throw skipped cleanup
- **Also fixed (commit 2, from bot+adversarial review)**: `_doDispatch()` now receives `AbortController` (not just `AbortSignal`) so it can call `abort()` before `delete()` in the `!promptResult.data` and `catch` error paths; `clearTimeout(timeoutHandle)` moved to `finally` block in `dispatchLane()`
- **Tests added (commit 3)**: `ATTACK VECTOR T9` in `runner.timeout-adversarial.test.ts` — 3 tests that capture the `AbortSignal` at `session.prompt()` and assert it is already `aborted === true` when `session.delete()` is called, covering all three exit paths (null data, throw, timeout)

## Invariant audit

- 1 (plugin init): not touched — no changes to `src/index.ts`, plugin registration, or startup path
- 2 (runtime portability): not touched — no `bun:` imports, no `Bun.*` calls, no bundle config changes; `node --input-type=module -e &#34;await import(&#39;./dist/index.js&#39;)&#34;` passes
- 3 (subprocesses): not touched — no subprocess calls in changed files
- 4 (.swarm containment): not touched — no `.swarm/` path logic changed
- 5 (plan durability): not touched — no plan ledger or plan schema changes
- 6 (test_runner safety): not touched — no test_runner tool changes
- 7 (test writing): touched — new tests in `runner.timeout-adversarial.test.ts` use the `_sessionOps` `_internals` seam; no `mock.module` used; all mocking via instance injection per AGENTS.md §7
- 8 (session state): touched — `AbortController` and timeout handles are local to each dispatch call; no module-level state added
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched
- 12 (release/cache): not touched — release fragment at `docs/releases/pending/fix-fk-session-delete-race.md`

## Test plan

- [x] `bun run build` — passes (2.45 MB bundle)
- [x] `node --input-type=module -e &#34;await import(&#39;./dist/index.js&#39;)&#34;` — &#34;dist import OK&#34;
- [x] `bun run typecheck` — passes
- [x] `bunx biome ci .` — passes (1949 files, no errors)
- [x] `tests/unit/tools`, `tests/unit/services`, `tests/unit/agents`, `tests/unit/hooks` — all pass
- [x] `tests/unit/cli|commands|config` — 2676 pass / 580 fail (580 pre-existing, identical to `origin/main`)
- [x] `tests/unit/turbo/lean/runner.timeout-adversarial.test.ts` — 19p/0f (16 existing + 3 new T9 ordering tests)
- [x] `tests/unit/turbo/lean/` (all 25 files) — 706p/1f (AC-8 pre-existing)
- [x] `tests/integration` — 606 pass / 137 fail (137 pre-existing)
- [x] `tests/security` — 167 pass / 0 fail
- [x] `tests/adversarial` — 719 pass / 11 fail (11 pre-existing)
- [x] `tests/smoke` — 10 pass / 0 fail
- [x] Pre-existing failures verified on `origin/main` worktree — counts match exactly
- [x] Independent adversarial sub-agent reviewed all 8 callsites — 7 CORRECT, 2 bugs confirmed and fixed
- [x] CI run `27614769397` on head `50721f9` — all 17 check runs verified:
  - quality ✅, rust-sandbox-runner ✅, package-check ✅, security ✅, php-validation ✅
  - unit (ubuntu-latest) ✅, unit (macos-latest) ✅
  - unit (windows-latest) ❌ cancelled — 35-min `timeout-minutes` ceiling at step 23 (pre-existing, see below)
  - integration skipped, smoke skipped (cascade from Windows cancellation — skipped is treated as passing for optional checks)
  - pr-standards ✅ (×3), check-title ✅ (×3), cubic AI reviewer ✅
- [x] Windows unit is **not a required check**: despite `unit (windows-latest): cancelled`, GitHub reports `mergeable_state: "behind"` (not `"blocked"`). GitHub&#39;s merge-readiness computation has full visibility of all 17 check runs and still classifies the PR as only `"behind"` (branch needs rebase), not `"blocked"` (required check failing). This is the authoritative signal. `search_code` for `required_status_checks` in the repo returns 0 results — branch protection is configured via GitHub UI settings, and the API itself is the ground truth.

## Pre-existing failures

- **580 unit failures** — pre-existing across `tests/unit/cli|commands|config`
- **137 integration failures** — pre-existing in `tests/integration`
- **11 adversarial failures** — pre-existing; identical test names on both branches
- **1 lean-turbo unit failure** — AC-8 in `integration-worktree.test.ts` checks `worktree.ts` for a pattern refactored to `core.ts`; neither file touched by this PR
- **Windows unit timeout** — `unit (windows-latest)` consistently hits the 35-minute `timeout-minutes` job ceiling at step 23 &#34;Unit tests (tools)&#34;; Windows runner is ~5-6× slower than Linux/macOS for this suite; pre-existing on `origin/main`; confirmed non-blocking: `mergeable_state: "behind"` not `"blocked"` on every run where Windows cancelled

---
_Generated by [Claude Code](https://claude.ai/code/session_011vycFaDAmTZw77CxRmTwD2)_