### PR TITLE
fix(skills): align curator consumer filters to canonical violated value

### DIFF
--- a/src/hooks/curator.ts
+++ b/src/hooks/curator.ts
@@ -156,10 +156,10 @@ async function autoRetireSkills(
 			});
 
 			const violations = skillUsage.filter(
-				(e) => e.complianceVerdict === 'violation',
-			).length;
-			const violationRate =
-				skillUsage.length > 0 ? violations / skillUsage.length : 0;
+					(e) => e.complianceVerdict === 'violated',
+				).length;
+				const violationRate =
+					skillUsage.length > 0 ? violations / skillUsage.length : 0;
 
 			// Check if all source knowledge is archived
 			let allArchived = false;
@@ -1268,7 +1268,7 @@ export async function runCuratorPhase(
 				if (skillUsage.length === 0) continue;
 
 				const violations = skillUsage.filter(
-					(e) => e.complianceVerdict === 'violation',
+					(e) => e.complianceVerdict === 'violated',
 				).length;
 				const violationRate = violations / skillUsage.length;
 
@@ -1282,7 +1282,7 @@ export async function runCuratorPhase(
 
 					const currentVersion = fm?.version ?? 1;
 					const violationContexts: ViolationContext[] = skillUsage
-						.filter((e) => e.complianceVerdict === 'violation')
+						.filter((e) => e.complianceVerdict === 'violated')
 						.slice(-10)
 						.map((e) => ({
 							taskId: e.taskID,

--- a/tests/unit/hooks/curator-auto-retire.test.ts
+++ b/tests/unit/hooks/curator-auto-retire.test.ts
@@ -83,17 +83,17 @@ describe('autoRetireSkills', () => {
 			{
 				skillPath:
 					'file:/fake/dir/.opencode/skills/generated/high-violation/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath:
 					'/fake/dir/.opencode/skills/generated/high-violation/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath:
 					'/fake/dir/.opencode/skills/generated/high-violation/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath:
@@ -337,11 +337,11 @@ describe('autoRetireSkills', () => {
 		const mockReadSkillUsageEntries = makeMockFn(() => [
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/no-fm-skill/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/no-fm-skill/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/no-fm-skill/SKILL.md',
@@ -392,7 +392,7 @@ describe('autoRetireSkills', () => {
 		const mockReadSkillUsageEntries = makeMockFn(() => [
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/fail-retire/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/fail-retire/SKILL.md',
@@ -459,7 +459,7 @@ describe('autoRetireSkills', () => {
 			{
 				skillPath:
 					'/fake/dir/.opencode/skills/generated/violation-skill/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath:
@@ -549,15 +549,15 @@ describe('autoRetireSkills', () => {
 		const mockReadSkillUsageEntries = makeMockFn(() => [
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/test-skill/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/test-skill/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/test-skill/SKILL.md',
-				complianceVerdict: 'violation' as const,
+				complianceVerdict: 'violated' as const,
 			},
 		]);
 


### PR DESCRIPTION
Closes #1281

## Summary

- The sole producer of skill compliance verdicts (`skill-propagation-gate.ts`) lowercases its regex capture and writes the canonical spelling `'violated'`, but the `curator.ts` consumers filtered on the string `'violation'` — which no producer ever writes.
- Because `'violated' !== 'violation'`, the **30% violation-rate auto-retire threshold** never fired for non-compliant skills.
- This PR corrects the three `curator.ts` consumer comparisons to the canonical `'violated'` value and updates the `curator-auto-retire` test fixtures to match.

### Regression context

The original #1281 fix landed in #1342 (both `curator.ts` and `skill-usage-log.ts`). Commit `071d1bbe` (PR #1363, "port PR #1244 hardening onto latest main") subsequently re-introduced `'violation'` in `curator.ts` while `skill-usage-log.ts` retained the `'violated'` fix + `normalizeComplianceVerdict` read-path helper. This PR restores only the regressed `curator.ts` comparisons; `skill-usage-log.ts` is already correct on `main` and is intentionally left untouched.

## Invariant audit

- 1 (plugin init): not touched — change is in the task-lifecycle curator hook (`src/hooks/curator.ts`), not plugin registration/init paths.
- 2 (runtime portability): not touched — no top-level `bun:` imports, no `Bun.*` calls, no changes to `src/index.ts`, `package.json#main`, or plugin entry shape.
- 3 (subprocesses): not touched — no `spawn`/`spawnSync`/`bunSpawn` calls added or modified.
- 4 (.swarm containment): not touched — no new runtime-state paths introduced.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — validation run via direct `bun test` on a single file, not `test_runner` with broad scopes.
- 7 (test writing): touched — updated mock `complianceVerdict` fixtures in `tests/unit/hooks/curator-auto-retire.test.ts` to the canonical `'violated'` value so the auto-retire assertions exercise the real producer spelling. No `mock.module` leakage introduced.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched.
- 12 (release/cache): not touched — version files and CHANGELOG untouched.

## Test plan

- [x] `bun --smol test tests/unit/hooks/curator-auto-retire.test.ts` — 9/9 pass (0 fail), 25 expect() calls. The fixture data uses canonical `'violated'` verdicts and the >30% threshold cases correctly trigger auto-retire with a `violation` reason.
- [ ] `bun run typecheck` — pending CI (string-literal change; no type-surface change).
- [ ] Full `tests/unit/hooks` suite — pending CI.

## Notes

- Autonomous cron-driven fix (`auto-fix` workflow). Opened as a **draft** — the human reviewer decides ready/merge.
- The change is intentionally surgical: only the vocabulary mismatch in `curator.ts` is corrected. No refactors, no scope expansion.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a verdict string mismatch that blocked auto-retire: curator filters now check for 'violated' (canonical) instead of 'violation', so the 30% non-compliance threshold triggers again. Addresses #1281.

- **Bug Fixes**
  - Switched three comparisons in src/hooks/curator.ts to 'violated'.
  - Updated tests/unit/hooks/curator-auto-retire.test.ts fixtures to use 'violated'.

<sup>Written for commit 259c54cc45caeccbc79654cf9c5e236ef851d449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

