### PR TITLE
perf(ci): two-tier CI with automatic test sharding for faster PR feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,10 @@ jobs:
           find tests/unit -name '*.test.ts' -type f | sort > "$tmpdir/all-tests.txt"
           num_shards=4
           awk -v s="$SHARD" -v n="$num_shards" '(NR - 1) % n == (s - 1)' "$tmpdir/all-tests.txt" > "$tmpdir/shard-tests.txt"
+          if [ ! -s "$tmpdir/shard-tests.txt" ]; then
+            echo "::error::No test files found for shard ${SHARD}"
+            exit 1
+          fi
           echo "Shard ${SHARD}/${num_shards}"
       - name: Run unit tests
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,22 +51,22 @@ jobs:
         shell: bash
         run: chmod +x scripts/check-cross-contamination.sh && bash scripts/check-cross-contamination.sh
 
+  # Two-tier CI: on pull_request, run ubuntu-only with 4 shards for fast feedback.
+  # On merge_group (merge queue), run the full 3-OS matrix for merge safety.
+  # Test files are discovered automatically via find and distributed round-robin
+  # across shards — no hardcoded file lists, no duplication.
   unit:
     needs: quality
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: ${{ github.event_name == 'merge_group' && fromJSON('["ubuntu-latest","macos-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        shard: [1, 2, 3, 4]
     runs-on: ${{ matrix.os }}
-    # 90m (was 35m → 50m → 60m): the `tests/unit/tools/` step runs 234 files
-    # sequentially. Cumulative runtime on GitHub's Windows runner is
-    # 4-7x slower than local Windows (4 min locally → 30-60+ min on the
-    # runner). The Windows runner is unreliable in this repo — earlier
-    # attempts at 35m, 50m, and 60m were all insufficient or the runner
-    # got stuck. Local precedent: e9677cb4 raised the ubuntu unit
-    # timeout. macOS/ubuntu complete the same step in 12-14 min, so
-    # 90m is well within their budget. Refs: PR #1245.
-    timeout-minutes: 90
+    # 40m: was 90m before sharding (PR #1245). With 4 shards (~263 files each),
+    # per-shard runtime is ~7-15 min on ubuntu/macOS and ~20-25 min on Windows
+    # (4-7× slower GitHub runners, see PR #1245). 40m gives Windows headroom.
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -87,467 +87,26 @@ jobs:
       # tests under tests/unit/build/ that load the bundle have a dist/ to read.
       - name: Build
         run: bun run build
-      - name: Unit tests (hooks - guardrails)
+      - name: Collect and partition test files
         shell: bash
         run: |
-          set -o pipefail
-          IFS=$'\n'
+          tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
+          find tests/unit -name '*.test.ts' -type f | sort > "$tmpdir/all-tests.txt"
+          total=$(wc -l < "$tmpdir/all-tests.txt")
+          shard=${{ matrix.shard }}
+          num_shards=4
+          awk -v s="$shard" -v n="$num_shards" '(NR - 1) % n == (s - 1)' "$tmpdir/all-tests.txt" > "$tmpdir/shard-tests.txt"
+          shard_count=$(wc -l < "$tmpdir/shard-tests.txt")
+          echo "Shard ${shard}/${num_shards}: ${shard_count} of ${total} files"
+      - name: Run unit tests
+        shell: bash
+        run: |
           failed=0
           tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
           trap 'rm -f "$tmpdir"/bun-out-$$-*' EXIT
-          for f in tests/unit/hooks/guardrails*.test.ts; do
+          while IFS= read -r f; do
             [ -f "$f" ] || continue
-            tmp="$tmpdir/bun-out-$$-${f##*/}"
-            exit_code=0
-            bun --smol test "$f" --timeout 120000 > "$tmp" 2>&1 || exit_code=$?
-            if [ $exit_code -ne 0 ]; then
-              if grep -qE "^[[:space:]]*(FAIL|✗|AssertionError)" "$tmp"; then
-                echo "::error file=$f::FAILED: $f"
-                failed=1
-              fi
-            fi
-          done
-          exit $failed
-      - name: Unit tests (destructive command guard - all platforms)
-        shell: bash
-        run: |
-          set -o pipefail
-          IFS=$'\n'
-          failed=0
-          tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
-          trap 'rm -f "$tmpdir"/bun-out-$$-*' EXIT
-          for f in tests/unit/hooks/destructive-command*.test.ts tests/unit/hooks/incident-replay*.test.ts; do
-            [ -f "$f" ] || continue
-            tmp="$tmpdir/bun-out-$$-${f##*/}"
-            exit_code=0
-            bun --smol test "$f" --timeout 120000 > "$tmp" 2>&1 || exit_code=$?
-            if [ $exit_code -ne 0 ]; then
-              # bun exited non-zero — check if it was a real failure or crash
-              if grep -qE "^[[:space:]]*(FAIL|✗|AssertionError)" "$tmp"; then
-                echo "::error file=$f::FAILED: $f"
-                failed=1
-              fi
-            fi
-          done
-          exit $failed
-      - name: Unit tests (hooks - knowledge types/validator/store)
-        shell: bash
-        run: |
-          failed=0
-          for f in tests/unit/hooks/knowledge-types*.test.ts tests/unit/hooks/knowledge-validator*.test.ts tests/unit/hooks/knowledge-registration*.test.ts tests/unit/hooks/knowledge-store*.test.ts tests/unit/hooks/knowledge-quarantine*.test.ts; do
-            [ -f "$f" ] || continue
-            if ! bun --smol test "$f" --timeout 120000; then
-              failed=1
-            fi
-          done
-          exit $failed
-      - name: Unit tests (hooks - knowledge reader/migrator)
-        shell: bash
-        run: |
-          failed=0
-          for f in tests/unit/hooks/knowledge-reader-key-normalization.test.ts tests/unit/hooks/knowledge-migrator*.test.ts tests/unit/hooks/knowledge-application*.test.ts tests/unit/hooks/knowledge-schema-v2*.test.ts tests/unit/hooks/knowledge-contextual-retrieval*.test.ts; do
-            [ -f "$f" ] || continue
-            if ! bun --smol test "$f" --timeout 120000; then
-              failed=1
-            fi
-          done
-          exit $failed
-      - name: Unit tests (hooks - knowledge injector)
-        shell: bash
-        run: |
-          failed=0
-          for f in tests/unit/hooks/knowledge-injector.test.ts tests/unit/hooks/knowledge-injector-allowlist.test.ts tests/unit/hooks/knowledge-injector-drift.test.ts; do
-            [ -f "$f" ] || continue
-            if ! bun --smol test "$f" --timeout 120000; then
-              failed=1
-            fi
-          done
-          exit $failed
-      - name: Unit tests (hooks - knowledge-curator)
-        shell: bash
-        run: |
-          failed=0
-          for f in tests/unit/hooks/knowledge-curator.test.ts tests/unit/hooks/knowledge-curator-evidence-curation.test.ts tests/unit/hooks/knowledge-curator-evidence-predicate.test.ts tests/unit/hooks/knowledge-curator-outcome-promotion.test.ts tests/unit/hooks/knowledge-curator-output.test.ts tests/unit/hooks/knowledge-curator-ttl.test.ts; do
-            [ -f "$f" ] || continue
-            if ! bun --smol test "$f" --timeout 120000; then
-              failed=1
-            fi
-          done
-          exit $failed
-      - name: Unit tests (hooks - mock.module isolation)
-        shell: bash
-        run: |
-          set -o pipefail
-          IFS=$'\n'
-          failed=0
-          tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
-          trap 'rm -f "$tmpdir"/bun-out-$$-*' EXIT
-          for f in \
-            tests/unit/hooks/knowledge-injector.adversarial.test.ts \
-            tests/unit/hooks/knowledge-curator.test.ts \
-            tests/unit/hooks/knowledge-curator-evidence-curation.test.ts \
-            tests/unit/hooks/knowledge-curator-ttl.test.ts \
-            tests/unit/hooks/knowledge-curator.adversarial.test.ts \
-            tests/unit/hooks/knowledge-curator-output.test.ts \
-            tests/unit/hooks/full-auto-intercept.test.ts \
-            tests/unit/hooks/full-auto-intercept.adversarial.test.ts \
-            tests/unit/hooks/full-auto-intercept.dispatch.test.ts \
-            tests/unit/hooks/utils.test.ts \
-            tests/unit/hooks/system-enhancer-coder-context.test.ts \
-            tests/unit/hooks/model-limits-log-reclassification.test.ts \
-            tests/unit/hooks/model-limits-adversarial.test.ts \
-            tests/unit/hooks/log-level-reclassification.test.ts \
-            tests/unit/hooks/context-budget-log-reclassification.test.ts \
-            tests/unit/hooks/knowledge-reader.test.ts; do
-            [ -f "$f" ] || continue
-            tmp="$tmpdir/bun-out-$$-${f##*/}"
-            exit_code=0
-            bun --smol test "$f" --timeout 120000 > "$tmp" 2>&1 || exit_code=$?
-            if [ $exit_code -ne 0 ]; then
-              if grep -qE "^[[:space:]]*(FAIL|✗|AssertionError)" "$tmp"; then
-                echo "::error file=$f::FAILED: $f"
-                failed=1
-              fi
-            fi
-          done
-          exit $failed
-      - name: Unit tests (hooks - curator)
-        shell: bash
-        run: |
-          failed=0
-          for f in tests/unit/hooks/curator*.test.ts; do
-            [ -f "$f" ] || continue
-            if ! bun --smol test "$f" --timeout 120000; then
-              failed=1
-            fi
-          done
-          exit $failed
-      - name: Unit tests (hooks - hive)
-        shell: bash
-        run: |
-          failed=0
-          for f in tests/unit/hooks/hive*.test.ts; do
-            [ -f "$f" ] || continue
-            if ! bun --smol test "$f" --timeout 120000; then
-              failed=1
-            fi
-          done
-          exit $failed
-      - name: Unit tests (hooks - system-enhancer load-evidence)
-        shell: bash
-        run: |
-          failed=0
-          for f in tests/unit/hooks/system-enhancer-load-evidence*.test.ts; do
-            [ -f "$f" ] || continue
-            if ! bun --smol test "$f" --timeout 120000; then
-              failed=1
-            fi
-          done
-          exit $failed
-      - name: Unit tests (hooks - system-enhancer)
-        shell: bash
-        run: |
-          failed=0
-          for f in tests/unit/hooks/system-enhancer-adversarial.attack.test.ts tests/unit/hooks/system-enhancer-adversarial.test.ts tests/unit/hooks/system-enhancer-compaction.test.ts tests/unit/hooks/system-enhancer-context-budget-wiring.test.ts tests/unit/hooks/system-enhancer-drift.test.ts tests/unit/hooks/system-enhancer-evidence.adversarial.test.ts tests/unit/hooks/system-enhancer-evidence.test.ts tests/unit/hooks/system-enhancer-handoff.test.ts tests/unit/hooks/system-enhancer-hf1b-adversarial.test.ts tests/unit/hooks/system-enhancer-hf1b.test.ts tests/unit/hooks/system-enhancer-lang-constraints-adversarial.test.ts tests/unit/hooks/system-enhancer-lang-constraints.test.ts tests/unit/hooks/system-enhancer-retro.test.ts tests/unit/hooks/system-enhancer-reviewer-checklist-adversarial.test.ts tests/unit/hooks/system-enhancer-reviewer-checklist.test.ts tests/unit/hooks/system-enhancer-test-constraints.test.ts tests/unit/hooks/system-enhancer-v6.test.ts tests/unit/hooks/system-enhancer-v61.test.ts tests/unit/hooks/system-enhancer-v62-adversarial.test.ts tests/unit/hooks/system-enhancer-v62.test.ts tests/unit/hooks/system-enhancer.test.ts; do
-            [ -f "$f" ] || continue
-            if ! bun --smol test "$f" --timeout 120000; then
-              failed=1
-            fi
-          done
-          exit $failed
-      - name: Unit tests (hooks - delegation)
-        shell: bash
-        run: |
-          failed=0
-          for f in tests/unit/hooks/delegation*.test.ts; do
-            [ -f "$f" ] || continue
-            if ! bun --smol test "$f" --timeout 120000; then
-              failed=1
-            fi
-          done
-          exit $failed
-      - name: Unit tests (hooks - adversarial-detector)
-        shell: bash
-        run: |
-          failed=0
-          for f in tests/unit/hooks/adversarial-detect*.test.ts; do
-            [ -f "$f" ] || continue
-            if ! bun --smol test "$f" --timeout 120000; then
-              failed=1
-            fi
-          done
-          exit $failed
-      - name: Unit tests (hooks - remaining)
-        shell: bash
-        run: |
-          set -o pipefail
-          IFS=$'\n'
-          failed=0
-          tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
-          trap 'rm -f "$tmpdir"/bun-out-$$-*' EXIT
-          for f in \
-            tests/unit/hooks/adversarial-detection-schema.adversarial.test.ts \
-            tests/unit/hooks/adversarial-detector-adversarial.test.ts \
-            tests/unit/hooks/adversarial-detector-pattern-attack.test.ts \
-            tests/unit/hooks/adversarial-detector-patterns.test.ts \
-            tests/unit/hooks/adversarial-detector-spiral-handler.test.ts \
-            tests/unit/hooks/adversarial-detector-task1-2.test.ts \
-            tests/unit/hooks/adversarial-detector-wiring.test.ts \
-            tests/unit/hooks/adversarial-detector.test.ts \
-            tests/unit/hooks/advisory-injection.test.ts \
-            tests/unit/hooks/agent-activity-adversarial.test.ts \
-            tests/unit/hooks/agent-activity-atomic-write.test.ts \
-            tests/unit/hooks/agent-activity.test.ts \
-            tests/unit/hooks/co-change-suggester-adversarial.test.ts \
-            tests/unit/hooks/co-change-suggester.test.ts \
-            tests/unit/hooks/compaction-customizer.test.ts \
-            tests/unit/hooks/context-budget.test.ts \
-            tests/unit/hooks/context-scoring.test.ts \
-            tests/unit/hooks/curator-atomic-write.test.ts \
-            tests/unit/hooks/curator-auto-retire.test.ts \
-            tests/unit/hooks/curator-coverage.test.ts \
-            tests/unit/hooks/curator-drift.test.ts \
-            tests/unit/hooks/curator-llm-factory.test.ts \
-            tests/unit/hooks/curator-role-normalization.test.ts \
-            tests/unit/hooks/curator-structured-blocks.test.ts \
-            tests/unit/hooks/curator.adversarial.test.ts \
-            tests/unit/hooks/curator.test.ts \
-            tests/unit/hooks/dark-matter-detector-adversarial.test.ts \
-            tests/unit/hooks/dark-matter-detector.test.ts \
-            tests/unit/hooks/delegation-gate-completion-gate.test.ts \
-            tests/unit/hooks/delegation-gate-council-fallback.test.ts \
-            tests/unit/hooks/delegation-gate-council-phase.test.ts \
-            tests/unit/hooks/delegation-gate-council.test.ts \
-            tests/unit/hooks/delegation-gate-envelope.test.ts \
-            tests/unit/hooks/delegation-gate-evidence-taskid.test.ts \
-            tests/unit/hooks/delegation-gate-plan-aware-filtering.test.ts \
-            tests/unit/hooks/delegation-gate-prior-coder.test.ts \
-            tests/unit/hooks/delegation-gate-reviewer-run.test.ts \
-            tests/unit/hooks/delegation-gate-scope.test.ts \
-            tests/unit/hooks/delegation-gate-stale-state.test.ts \
-            tests/unit/hooks/delegation-gate-state-machine.adversarial.test.ts \
-            tests/unit/hooks/delegation-gate-task-1-5.test.ts \
-            tests/unit/hooks/delegation-gate-tests-run.test.ts \
-            tests/unit/hooks/delegation-gate.adversarial.test.ts \
-            tests/unit/hooks/delegation-gate.directory-security.test.ts \
-            tests/unit/hooks/delegation-gate.evidence-task-id.test.ts \
-            tests/unit/hooks/delegation-gate.stage-b-parallel.adversarial.test.ts \
-            tests/unit/hooks/delegation-gate.test.ts \
-            tests/unit/hooks/delegation-sanitizer.test.ts \
-            tests/unit/hooks/delegation-tracker.adversarial.test.ts \
-            tests/unit/hooks/delegation-tracker.test.ts \
-            tests/unit/hooks/destructive-command-guard.test.ts \
-            tests/unit/hooks/destructive-command-lstat.test.ts \
-            tests/unit/hooks/destructive-command-swarm-cli-bypass.test.ts \
-            tests/unit/hooks/destructive-command-windows.test.ts \
-            tests/unit/hooks/destructive-command-wrapper-unwrap.test.ts \
-            tests/unit/hooks/extractors.test.ts \
-            tests/unit/hooks/full-auto-delegation.test.ts \
-            tests/unit/hooks/full-auto-input-probe.test.ts \
-            tests/unit/hooks/full-auto-permission-integration.test.ts \
-            tests/unit/hooks/full-auto-permission.test.ts \
-            tests/unit/hooks/gate-tracking.test.ts \
-            tests/unit/hooks/guardrails-architect-config-zone.adversarial.test.ts \
-            tests/unit/hooks/guardrails-attestation.test.ts \
-            tests/unit/hooks/guardrails-authority-enhanced.test.ts \
-            tests/unit/hooks/guardrails-authority.test.ts \
-            tests/unit/hooks/guardrails-catastrophic-warning.test.ts \
-            tests/unit/hooks/guardrails-coder-revisions.test.ts \
-            tests/unit/hooks/guardrails-codex-p1-fixes.test.ts \
-            tests/unit/hooks/guardrails-config-file-logging.test.ts \
-            tests/unit/hooks/guardrails-directory.adversarial.test.ts \
-            tests/unit/hooks/guardrails-directory.test.ts \
-            tests/unit/hooks/guardrails-disabled.test.ts \
-            tests/unit/hooks/guardrails-enforcement.test.ts \
-            tests/unit/hooks/guardrails-error-classification.test.ts \
-            tests/unit/hooks/guardrails-fallback.test.ts \
-            tests/unit/hooks/guardrails-loop-detection.test.ts \
-            tests/unit/hooks/guardrails-model-fallback.adversarial.test.ts \
-            tests/unit/hooks/guardrails-model-fallback.test.ts \
-            tests/unit/hooks/guardrails-modified-files.adversarial.test.ts \
-            tests/unit/hooks/guardrails-modified-files.test.ts \
-            tests/unit/hooks/guardrails-native-agents.test.ts \
-            tests/unit/hooks/guardrails-pathtraversal-adversarial.test.ts \
-            tests/unit/hooks/guardrails-plan-md-guard.test.ts \
-            tests/unit/hooks/guardrails-plan-md-protection.test.ts \
-            tests/unit/hooks/guardrails-pre-check-batch.test.ts \
-            tests/unit/hooks/guardrails-prompt-trimming.adversarial.test.ts \
-            tests/unit/hooks/guardrails-prompt-trimming.test.ts \
-            tests/unit/hooks/guardrails-runaway.test.ts \
-            tests/unit/hooks/guardrails-scope-check.adversarial.test.ts \
-            tests/unit/hooks/guardrails-scope-check.test.ts \
-            tests/unit/hooks/guardrails-self-coding-gate.test.ts \
-            tests/unit/hooks/guardrails-shell-write.test.ts \
-            tests/unit/hooks/guardrails-source-path.test.ts \
-            tests/unit/hooks/guardrails-subagent-advisory.test.ts \
-            tests/unit/hooks/guardrails-swarm-path-evasion.adversarial.test.ts \
-            tests/unit/hooks/guardrails-swarm-path-guard.test.ts \
-            tests/unit/hooks/guardrails-task-1-7-edge-case.test.ts \
-            tests/unit/hooks/guardrails-task23.adversarial.test.ts \
-            tests/unit/hooks/guardrails-test-suite-guard.adversarial.test.ts \
-            tests/unit/hooks/guardrails-test-suite-guard.test.ts \
-            tests/unit/hooks/guardrails-v612-adversarial.test.ts \
-            tests/unit/hooks/guardrails-v612-verification.test.ts \
-            tests/unit/hooks/guardrails-v622-adversarial.test.ts \
-            tests/unit/hooks/guardrails-zone-authority.test.ts \
-            tests/unit/hooks/guardrails.adversarial.test.ts \
-            tests/unit/hooks/guardrails.test.ts \
-            tests/unit/hooks/hive-promoter-task3-4.adversarial.test.ts \
-            tests/unit/hooks/hive-promoter.adversarial.test.ts \
-            tests/unit/hooks/hive-promoter.test.ts \
-            tests/unit/hooks/hook-composition.test.ts \
-            tests/unit/hooks/interpreter-gating.test.ts \
-            tests/unit/hooks/knowledge-application-gate.test.ts \
-            tests/unit/hooks/knowledge-application.test.ts \
-            tests/unit/hooks/knowledge-contextual-retrieval.test.ts \
-            tests/unit/hooks/knowledge-curator-evidence-predicate.test.ts \
-            tests/unit/hooks/knowledge-curator-outcome-promotion.test.ts \
-            tests/unit/hooks/knowledge-curator-skip-promotion.test.ts \
-            tests/unit/hooks/knowledge-events.test.ts \
-            tests/unit/hooks/knowledge-injector-allowlist.test.ts \
-            tests/unit/hooks/knowledge-injector-drift-adversarial.test.ts \
-            tests/unit/hooks/knowledge-injector-drift.test.ts \
-            tests/unit/hooks/knowledge-injector.test.ts \
-            tests/unit/hooks/knowledge-migrator.adversarial.test.ts \
-            tests/unit/hooks/knowledge-migrator.external.test.ts \
-            tests/unit/hooks/knowledge-migrator.test.ts \
-            tests/unit/hooks/knowledge-quarantine.adversarial.test.ts \
-            tests/unit/hooks/knowledge-quarantine.test.ts \
-            tests/unit/hooks/knowledge-reader-key-normalization.test.ts \
-            tests/unit/hooks/knowledge-reader.test.ts \
-            tests/unit/hooks/knowledge-registration.test.ts \
-            tests/unit/hooks/knowledge-schema-v2.test.ts \
-            tests/unit/hooks/knowledge-store-caps.test.ts \
-            tests/unit/hooks/knowledge-store-normalize-entry.adversarial.test.ts \
-            tests/unit/hooks/knowledge-store-normalize-entry.test.ts \
-            tests/unit/hooks/knowledge-store-sweep.test.ts \
-            tests/unit/hooks/knowledge-store.test.ts \
-            tests/unit/hooks/knowledge-types.adversarial.test.ts \
-            tests/unit/hooks/knowledge-types.test.ts \
-            tests/unit/hooks/knowledge-validator.adversarial.test.ts \
-            tests/unit/hooks/knowledge-validator.test.ts \
-            tests/unit/hooks/system-enhancer-v62.test.ts \
-            tests/unit/hooks/system-enhancer.test.ts \
-            tests/unit/hooks/system-message-consolidation.test.ts \
-            tests/unit/hooks/telemetry-guardrails-wiring.test.ts \
-            tests/unit/hooks/tool-summarizer-exempt.adversarial.test.ts \
-            tests/unit/hooks/tool-summarizer-exempt.test.ts \
-            tests/unit/hooks/tool-summarizer.test.ts \
-            tests/unit/hooks/trajectory-logger.test.ts \
-            tests/unit/hooks/write-lstat-authority.test.ts; do
-            [ -f "$f" ] || continue
-            tmp="$tmpdir/bun-out-$$-${f##*/}"
-            exit_code=0
-            bun --smol test "$f" --timeout 120000 > "$tmp" 2>&1 || exit_code=$?
-            if [ $exit_code -ne 0 ]; then
-              # bun exited non-zero — check if it was a real failure or crash
-              if grep -qE "^[[:space:]]*(FAIL|✗|AssertionError)" "$tmp"; then
-                echo "::error file=$f::FAILED: $f"
-                failed=1
-              fi
-            fi
-          done
-          exit $failed
-      - name: Unit tests (commands, config)
-        shell: bash
-        run: |
-          set -o pipefail
-          IFS=$'\n'
-          # Per-file isolation to prevent --smol cache poisoning (#330).
-          failed=0
-          tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
-          trap 'rm -f "$tmpdir"/bun-out-$$-*' EXIT
-          for dir in tests/unit/commands tests/unit/config; do
-            for f in "$dir"/*.test.ts; do
-              [ -f "$f" ] || continue
-              tmp="$tmpdir/bun-out-$$-${f##*/}"
-              exit_code=0
-              bun --smol test "$f" --timeout 120000 > "$tmp" 2>&1 || exit_code=$?
-              if [ $exit_code -ne 0 ]; then
-                # bun exited non-zero — check if it was a real failure or crash
-                if grep -qE "^[[:space:]]*(FAIL|✗|AssertionError)" "$tmp"; then
-                  echo "::error file=$f::FAILED: $f"
-                  failed=1
-                fi
-              fi
-            done
-          done
-          exit $failed
-      - name: Unit tests (cli)
-        shell: bash
-        run: |
-          set -o pipefail
-          IFS=$'\n'
-          tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
-          tmp="$tmpdir/bun-out-cli-$$"
-          exit_code=0
-          bun --smol test tests/unit/cli --timeout 120000 > "$tmp" 2>&1 || exit_code=$?
-          if [ $exit_code -ne 0 ]; then
-            # bun exited non-zero — check if it was a real failure or crash
-            if grep -qE "^[[:space:]]*(FAIL|✗|AssertionError)" "$tmp"; then
-              exit 1
-            fi
-          fi
-      - name: Unit tests (tools)
-        shell: bash
-        run: |
-          set -o pipefail
-          IFS=$'\n'
-          # Run each tools test file in its own process to prevent
-          # --smol module cache poisoning across files (#330).
-          failed=0
-          tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
-          trap 'rm -f "$tmpdir"/bun-out-$$-*' EXIT
-          for f in tests/unit/tools/*.test.ts; do
-            tmp="$tmpdir/bun-out-$$-${f##*/}"
-            exit_code=0
-            bun --smol test "$f" --timeout 120000 > "$tmp" 2>&1 || exit_code=$?
-            if [ $exit_code -ne 0 ]; then
-              # bun exited non-zero — check if it was a real failure or crash
-              if grep -qE "^[[:space:]]*(FAIL|✗|AssertionError)" "$tmp"; then
-                echo "::error file=$f::FAILED: $f"
-                failed=1
-              fi
-            fi
-          done
-          exit $failed
-      - name: Unit tests (services, build, quality, sast, sbom, scripts)
-        shell: bash
-        run: |
-          set -o pipefail
-          IFS=$'\n'
-          # Per-file isolation to prevent --smol cache poisoning (#330).
-          failed=0
-          tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
-          trap 'rm -f "$tmpdir"/bun-out-$$-*' EXIT
-          for dir in tests/unit/services tests/unit/build tests/unit/quality tests/unit/sast tests/unit/sbom tests/unit/scripts; do
-            for f in "$dir"/*.test.ts; do
-              [ -f "$f" ] || continue
-              tmp="$tmpdir/bun-out-$$-${f##*/}"
-              exit_code=0
-              bun --smol test "$f" --timeout 120000 > "$tmp" 2>&1 || exit_code=$?
-              if [ $exit_code -ne 0 ]; then
-                # bun exited non-zero — check if it was a real failure or crash
-                if grep -qE "^[[:space:]]*(FAIL|✗|AssertionError)" "$tmp"; then
-                  echo "::error file=$f::FAILED: $f"
-                  failed=1
-                fi
-              fi
-            done
-          done
-          exit $failed
-      - name: Unit tests (sandbox)
-        shell: bash
-        run: |
-          set -o pipefail
-          IFS=$'\n'
-          # Per-file isolation to prevent --smol cache poisoning (#330).
-          failed=0
-          tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
-          trap 'rm -f "$tmpdir"/bun-out-$$-*' EXIT
-          while IFS= read -r -d '' f; do
-            [ -f "$f" ] || continue
-            tmp="$tmpdir/bun-out-$$-${f##*/}"
+            tmp="$tmpdir/bun-out-$$-$(basename "$f")"
             exit_code=0
             bun --smol test "$f" --timeout 120000 > "$tmp" 2>&1 || exit_code=$?
             if [ $exit_code -ne 0 ]; then
@@ -557,74 +116,36 @@ jobs:
               fi
             fi
             rm -f "$tmp"
-          done < <(find tests/unit/sandbox -name '*.test.ts' -type f -print0)
-          exit $failed
-      - name: Unit tests (state, agents, knowledge, evidence, plan, misc)
-        shell: bash
-        run: |
-          set -o pipefail
-          IFS=$'\n'
-          # Per-file isolation to prevent --smol cache poisoning (#330).
-          failed=0
-          tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
-          trap 'rm -f "$tmpdir"/bun-out-$$-*' EXIT
-          for dir in tests/unit/adversarial tests/unit/agents tests/unit/background tests/unit/context tests/unit/council tests/unit/diff tests/unit/evidence tests/unit/git tests/unit/helpers tests/unit/knowledge tests/unit/lang tests/unit/output tests/unit/parallel tests/unit/plan tests/unit/session tests/unit/skills tests/unit/types tests/unit/utils; do
-            for f in "$dir"/*.test.ts; do
-              [ -f "$f" ] || continue
-              tmp="$tmpdir/bun-out-$$-${f##*/}"
-              exit_code=0
-              bun --smol test "$f" --timeout 120000 > "$tmp" 2>&1 || exit_code=$?
-              if [ $exit_code -ne 0 ]; then
-                # bun exited non-zero — check if it was a real failure or crash
-                if grep -qE "^[[:space:]]*(FAIL|✗|AssertionError)" "$tmp"; then
-                  echo "::error file=$f::FAILED: $f"
-                  failed=1
-                fi
-              fi
-              rm -f "$tmp"
-            done
-          done
-          # Standalone test files
-          for f in tests/unit/cli-dispatch.test.ts tests/unit/index-commands.test.ts tests/unit/stale-delegation-guard.test.ts tests/unit/state-invocation-windows.test.ts tests/unit/state-rehydrate.test.ts tests/unit/state-turbo-mode.test.ts tests/unit/state-workflow-guard.adversarial.test.ts tests/unit/state-workflow-guard.test.ts tests/unit/state.adversarial-scope.test.ts tests/unit/state.adversarial.test.ts tests/unit/state.rehydrate.adversarial.test.ts tests/unit/state.test.ts tests/unit/version-bump.test.ts; do
-            [ -f "$f" ] || continue
-            tmp="$tmpdir/bun-out-$$-${f##*/}"
-            exit_code=0
-            bun --smol test "$f" --timeout 120000 > "$tmp" 2>&1 || exit_code=$?
-            if [ $exit_code -ne 0 ]; then
-              # bun exited non-zero — check if it was a real failure or crash
-              if grep -qE "^[[:space:]]*(FAIL|✗|AssertionError)" "$tmp"; then
-                echo "::error file=$f::FAILED: $f"
-                failed=1
-              fi
-            fi
-            rm -f "$tmp"
-          done
+          done < "$tmpdir/shard-tests.txt"
           exit $failed
 
+  # Merge-queue-only: on pull_request all steps are skipped, job reports success
+  # to satisfy required checks without doing work.
   integration:
     needs: unit
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: github.event_name == 'merge_group'
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        if: github.event_name == 'merge_group'
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
+        if: github.event_name == 'merge_group'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - name: Install dependencies
+        if: github.event_name == 'merge_group'
         run: bun install --frozen-lockfile
       - name: Integration tests
+        if: github.event_name == 'merge_group'
         shell: bash
         run: |
-          # Per-file isolation to prevent module cache poisoning and process.chdir
-          # contamination across integration test files (#330 pattern).
-          set -o pipefail
-          IFS=$'\n'
           failed=0
           tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
           trap 'rm -f "$tmpdir"/bun-out-int-*' EXIT
@@ -685,50 +206,66 @@ jobs:
       - name: Security tests
         run: bun test tests/security --timeout 120000
 
+  # Merge-queue-only: on pull_request all steps are skipped, job reports success.
   php-validation:
     needs: quality
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: github.event_name == 'merge_group'
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        if: github.event_name == 'merge_group'
         with:
           php-version: "8.2"
           tools: composer
           coverage: none
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        if: github.event_name == 'merge_group'
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
+        if: github.event_name == 'merge_group'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - name: Install dependencies
+        if: github.event_name == 'merge_group'
         run: bun install --frozen-lockfile
       - name: PHP profile command surface tests
+        if: github.event_name == 'merge_group'
         run: bun --smol test tests/unit/lang/profiles-php.test.ts --timeout 60000
       - name: PHP framework detection and command overlay tests
+        if: github.event_name == 'merge_group'
         run: bun --smol test tests/unit/lang/framework-detector.test.ts --timeout 60000
       - name: PHP Composer ecosystem discovery tests
+        if: github.event_name == 'merge_group'
         run: bun --smol test tests/unit/build/discovery-php.test.ts --timeout 60000
       - name: Composer audit handler tests
+        if: github.event_name == 'merge_group'
         run: bun --smol test tests/unit/tools/pkg-audit-composer.test.ts --timeout 60000
       - name: Laravel SAST rule tests
+        if: github.event_name == 'merge_group'
         run: bun --smol test tests/unit/tools/sast-scan-laravel.test.ts --timeout 60000
       - name: Laravel fixture detection and SAST coverage tests
+        if: github.event_name == 'merge_group'
         run: bun --smol test tests/unit/lang/laravel-fixture.test.ts --timeout 60000
 
+  # Merge-queue-only: on pull_request all steps are skipped, job reports success.
   rust-sandbox-runner:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: github.event_name == 'merge_group'
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        if: github.event_name == 'merge_group'
         with:
           components: rustfmt, clippy
       - name: Cache cargo
+        if: github.event_name == 'merge_group'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -738,21 +275,27 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('runners/swarm-sandbox-runner/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
       - name: Check formatting
+        if: github.event_name == 'merge_group'
         working-directory: runners/swarm-sandbox-runner
         run: cargo fmt --check
       - name: Clippy lint
+        if: github.event_name == 'merge_group'
         working-directory: runners/swarm-sandbox-runner
         run: cargo clippy --all-targets -- -D warnings
       - name: Run tests
+        if: github.event_name == 'merge_group'
         working-directory: runners/swarm-sandbox-runner
         run: cargo test --all-targets
       - name: Build release binary
+        if: github.event_name == 'merge_group'
         working-directory: runners/swarm-sandbox-runner
         run: cargo build --release
       - name: Probe smoke test
+        if: github.event_name == 'merge_group'
         working-directory: runners/swarm-sandbox-runner
         run: ./target/release/swarm-sandbox-runner.exe --probe
 
+  # Merge-queue-only: on pull_request all steps are skipped, job reports success.
   smoke:
     needs: [unit, integration, package-check, php-validation, rust-sandbox-runner]
     strategy:
@@ -763,25 +306,32 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: github.event_name == 'merge_group'
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        if: github.event_name == 'merge_group'
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
+        if: github.event_name == 'merge_group'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - name: Install dependencies
+        if: github.event_name == 'merge_group'
         run: bun install --frozen-lockfile
       - name: Build package
+        if: github.event_name == 'merge_group'
         run: bun run build
       - name: Smoke tests
+        if: github.event_name == 'merge_group'
         run: bun test tests/smoke --timeout 120000
       - name: Issue #704 repro — Desktop init under Node
         # Loads the compiled dist/ under Node (the runtime OpenCode Desktop's
         # sidecar uses on macOS) and asserts the plugin's `server()` resolves
         # within 10s. Pre-fix this would hang. Runs on Linux, macOS, Windows
         # so the cycle/cap/budget guards are exercised on each OS.
+        if: github.event_name == 'merge_group'
         shell: bash
         run: node scripts/repro-704.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,15 +89,14 @@ jobs:
         run: bun run build
       - name: Collect and partition test files
         shell: bash
+        env:
+          SHARD: ${{ matrix.shard }}
         run: |
           tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
           find tests/unit -name '*.test.ts' -type f | sort > "$tmpdir/all-tests.txt"
-          total=$(wc -l < "$tmpdir/all-tests.txt")
-          shard=${{ matrix.shard }}
           num_shards=4
-          awk -v s="$shard" -v n="$num_shards" '(NR - 1) % n == (s - 1)' "$tmpdir/all-tests.txt" > "$tmpdir/shard-tests.txt"
-          shard_count=$(wc -l < "$tmpdir/shard-tests.txt")
-          echo "Shard ${shard}/${num_shards}: ${shard_count} of ${total} files"
+          awk -v s="$SHARD" -v n="$num_shards" '(NR - 1) % n == (s - 1)' "$tmpdir/all-tests.txt" > "$tmpdir/shard-tests.txt"
+          echo "Shard ${SHARD}/${num_shards}"
       - name: Run unit tests
         shell: bash
         run: |
@@ -106,7 +105,7 @@ jobs:
           trap 'rm -f "$tmpdir"/bun-out-$$-*' EXIT
           while IFS= read -r f; do
             [ -f "$f" ] || continue
-            tmp="$tmpdir/bun-out-$$-$(basename "$f")"
+            tmp="$tmpdir/bun-out-$$-${f##*/}"
             exit_code=0
             bun --smol test "$f" --timeout 120000 > "$tmp" 2>&1 || exit_code=$?
             if [ $exit_code -ne 0 ]; then

--- a/docs/releases/pending/ci-two-tier-sharding.md
+++ b/docs/releases/pending/ci-two-tier-sharding.md
@@ -6,7 +6,7 @@ The CI pipeline (`ci.yml`) was restructured to reduce PR feedback time from ~40 
 
 **Two-tier CI:** Merge-queue-only jobs (`integration`, `smoke`, `php-validation`, `rust-sandbox-runner`) now gate all their steps with `if: github.event_name == 'merge_group'`. On `pull_request`, those jobs run but all steps are skipped, so the job completes in ~10 seconds while still satisfying required status checks. On `merge_group`, the full validation runs. Jobs that were always fast (`quality`, `package-check`, `security`) continue running on both events unchanged.
 
-**Automatic round-robin test sharding:** The 20 hand-maintained test steps (which ran 118 files twice and silently skipped ~154 files) have been replaced with automatic file discovery via `find tests/unit -name '*.test.ts' -type f | sort` distributed across 4 parallel shards using modulo assignment. All 1049 test files are covered with zero duplication.
+**Automatic round-robin test sharding:** The 20 hand-maintained test steps (which duplicated ~111 files and silently skipped ~177 files) have been replaced with automatic file discovery via `find tests/unit -name '*.test.ts' -type f | sort` distributed across 4 parallel shards using modulo assignment. All test files are covered with zero duplication.
 
 **Dynamic OS matrix:** Unit tests run on ubuntu-only for PRs and the full 3-OS matrix for merge queue runs.
 
@@ -22,10 +22,10 @@ The `unit` job matrix gains a `shard` dimension, changing required check names:
 - **Old:** `unit (ubuntu-latest)`, `unit (macos-latest)`, `unit (windows-latest)`
 - **New:** `unit (ubuntu-latest, 1)` through `unit (ubuntu-latest, 4)` (PR tier); `unit (ubuntu-latest, 1)` through `unit (windows-latest, 4)` (merge queue tier)
 
-**Branch protection migration:**
-1. Temporarily remove old `unit (...)` required checks
+**Branch protection migration** (atomic path preferred — add new checks before removing old to avoid a protection gap):
+1. Add new required checks: `unit (ubuntu-latest, 1)` through `unit (ubuntu-latest, 4)`, plus `quality`, `package-check`, `security`
 2. Merge this PR
-3. Add new required checks: `unit (ubuntu-latest, 1)` through `unit (ubuntu-latest, 4)`, plus `quality`, `package-check`, `security`
+3. Remove old `unit (...)` required checks
 4. The merge-queue-only jobs keep their existing names
 
 **To eliminate cascading CI restarts (Problem #1), also:**
@@ -36,3 +36,5 @@ The `unit` job matrix gains a `shard` dimension, changing required check names:
 
 - PR runs no longer run integration, smoke, php-validation, or rust-sandbox-runner. Cross-platform and integration bugs are caught at merge queue time instead of during development.
 - macOS and Windows unit test failures are only surfaced in the merge queue, not on individual PRs.
+- `repro-704` (plugin init deadline verification, AGENTS.md invariant 1) runs in the `smoke` job and is deferred to merge queue only.
+- Unit job timeout reduced from 90m (pre-sharding, PR #1245) to 40m per shard. Windows merge-queue shards are estimated at 20-25 min; monitor first runs and adjust if needed.

--- a/docs/releases/pending/ci-two-tier-sharding.md
+++ b/docs/releases/pending/ci-two-tier-sharding.md
@@ -1,0 +1,38 @@
+# CI: Two-tier CI with automatic test sharding
+
+## What changed
+
+The CI pipeline (`ci.yml`) was restructured to reduce PR feedback time from ~40 minutes to ~12 minutes and to prepare for merge queue adoption.
+
+**Two-tier CI:** Merge-queue-only jobs (`integration`, `smoke`, `php-validation`, `rust-sandbox-runner`) now gate all their steps with `if: github.event_name == 'merge_group'`. On `pull_request`, those jobs run but all steps are skipped, so the job completes in ~10 seconds while still satisfying required status checks. On `merge_group`, the full validation runs. Jobs that were always fast (`quality`, `package-check`, `security`) continue running on both events unchanged.
+
+**Automatic round-robin test sharding:** The 20 hand-maintained test steps (which ran 118 files twice and silently skipped ~154 files) have been replaced with automatic file discovery via `find tests/unit -name '*.test.ts' -type f | sort` distributed across 4 parallel shards using modulo assignment. All 1049 test files are covered with zero duplication.
+
+**Dynamic OS matrix:** Unit tests run on ubuntu-only for PRs and the full 3-OS matrix for merge queue runs.
+
+## Why
+
+1. **Cascading CI restarts:** When one PR merges, branch updates cascade to all open PRs, each restarting a 40+ min CI run. Enabling the merge queue (see below) stops the cascades entirely.
+2. **CI duration:** The critical path through quality → unit (3-OS matrix, 140+ sequential files) → integration → smoke was 40+ minutes. Sharding and the two-tier split bring PR feedback to ~12 minutes.
+
+## Migration steps (admin required)
+
+The `unit` job matrix gains a `shard` dimension, changing required check names:
+
+- **Old:** `unit (ubuntu-latest)`, `unit (macos-latest)`, `unit (windows-latest)`
+- **New:** `unit (ubuntu-latest, 1)` through `unit (ubuntu-latest, 4)` (PR tier); `unit (ubuntu-latest, 1)` through `unit (windows-latest, 4)` (merge queue tier)
+
+**Branch protection migration:**
+1. Temporarily remove old `unit (...)` required checks
+2. Merge this PR
+3. Add new required checks: `unit (ubuntu-latest, 1)` through `unit (ubuntu-latest, 4)`, plus `quality`, `package-check`, `security`
+4. The merge-queue-only jobs keep their existing names
+
+**To eliminate cascading CI restarts (Problem #1), also:**
+- Enable the GitHub merge queue on `main` in branch protection settings
+- Disable "Require branches to be up to date before merging" (the merge queue handles freshness validation)
+
+## Known caveats
+
+- PR runs no longer run integration, smoke, php-validation, or rust-sandbox-runner. Cross-platform and integration bugs are caught at merge queue time instead of during development.
+- macOS and Windows unit test failures are only surfaced in the merge queue, not on individual PRs.


### PR DESCRIPTION
## Summary

- **Two-tier CI**: Merge-queue-only jobs (`integration`, `smoke`, `php-validation`, `rust-sandbox-runner`) now have all steps gated with `if: github.event_name == 'merge_group'`. On `pull_request`, jobs run but complete in ~10 seconds with all steps skipped — required status checks are still satisfied. On `merge_group`, full validation runs.
- **Automatic round-robin sharding**: 20 hand-maintained test steps (~111 file duplications, ~177 silently skipped files) replaced with `find tests/unit -name '*.test.ts' | sort | awk` distributing all test files across 4 parallel shards.
- **Dynamic OS matrix**: unit tests run ubuntu-only on PRs, full 3-OS on merge queue.
- **Timeout**: reduced from 90m (pre-sharding, PR #1245) to 40m per shard. With ~263 files per shard, estimated runtime is ~7-15 min on ubuntu/macOS and ~20-25 min on Windows (4-7× slower GitHub runners). 40m gives Windows headroom.
- **PR feedback time**: ~40 min → ~12 min.

## Invariant audit
- 1 (plugin init): not touched — no changes to `src/index.ts` or any plugin init path
- 2 (runtime portability): not touched — no bundle, dist, or export shape changes
- 3 (subprocesses): not touched — no changes to subprocess-spawning source code
- 4 (.swarm containment): not touched — no tool or working-directory logic changes
- 5 (plan durability): not touched — no plan ledger changes
- 6 (test_runner safety): not touched — the `test_runner` tool is unchanged; CI shell loops use `bun --smol test "$f"` per-file isolation (same pattern as before, now auto-discovered)
- 7 (test writing): not touched — no test files added or modified
- 8 (session state): not touched — no session-scoped code changes
- 9 (guardrails/retry): not touched — no guardrail logic changes
- 10 (chat/system msg): not touched — no hook or message-shape changes
- 11 (tool registration): not touched — no tool exports, TOOL_NAMES, or agent map changes
- 12 (release/cache): not touched — `package.json`, `CHANGELOG.md`, `.release-please-manifest.json` unchanged; release fragment added at `docs/releases/pending/ci-two-tier-sharding.md`

## Test plan
- [x] YAML syntax validated: `python3 -c "import yaml; yaml.safe_load(...)"` → valid
- [x] Shard distribution verified: 263/262/262/262 files across 4 shards; reassembled list diff vs `find` output → identical (no missing files, no duplicates)
- [x] All `uses:` lines have SHA pins (grep for unpinned `uses:` returned no output)
- [x] `bun run build` → success (`index.js 2.45 MB`)
- [x] `bun run typecheck` → `No fixes applied.` (1953 files)
- [x] `bunx biome ci .` → exit 0, `No fixes applied.`
- [x] Security tests pass: 7/7 (`bun test tests/security/ci-workflow-security.test.ts`)
- [x] Independent critic agent reviewed plan: round 1 NEEDS_REVISION → revised → round 2 APPROVED
- [x] Independent verification agent confirmed all 10 implementation checks PASS
- [x] Branch diff is exactly 2 files: `ci.yml` + release fragment

## Admin migration required

**Required status check names change** when this merges. Atomic path preferred — add new checks before removing old to avoid a protection gap:
1. Add new required checks: `unit (ubuntu-latest, 1)` through `unit (ubuntu-latest, 4)`, plus `quality`, `package-check`, `security`
2. Merge this PR
3. Remove old `unit (...)` required checks

**To eliminate cascading CI restarts** (the cascade-on-merge problem):
- Enable the GitHub merge queue on `main` in branch protection settings
- Disable "Require branches to be up to date before merging" (merge queue handles freshness validation)

The two-tier CI reduces the cost of each merge-queue run but the merge queue itself is what stops cascades.

---
_Generated by [Claude Code](https://claude.ai/code/session_0187xL8DepuSE3AJAi7FvEfZ)_