### PR TITLE
docs(skills): add mandatory pr comment integration and ci cascade diagnostics to swarm-pr-feedback

### DIFF
--- a/.opencode/skills/swarm-pr-feedback/SKILL.md
+++ b/.opencode/skills/swarm-pr-feedback/SKILL.md
@@ -142,6 +142,42 @@ Build a complete feedback ledger before editing. Include every available source:
 If a source is unavailable, record that limitation. Do not treat missing access as
 evidence that no feedback exists.
 
+### CI matrix cascade check (do this before fixing)
+
+When the PR's `unit` job is a matrix across multiple OSes and downstream jobs
+(`integration`, `smoke`) have `needs: unit`, an OS leg failure blocks the
+entire pipeline. Before triaging, check:
+
+1. Are `integration` or `smoke` jobs in `skipped` or `cancelled` state rather
+   than `failed`? That signals a unit matrix cascade — the unit job failed
+   on one OS leg, blocking the downstream jobs from running on the current
+   HEAD.
+2. If a unit OS leg is the blocker, classify the failure:
+   - **Code issue** — the test itself fails. Reproduce locally; if the
+     test passes locally, the runner is the problem.
+   - **Runner performance** — the test step exceeds the configured timeout.
+     Run all files in the step locally with per-file timing; if cumulative
+     local runtime is <10 min and the runner can't complete in 60+ min, the
+     issue is runner performance. Bump the CI timeout as a stopgap and file
+     a follow-up issue for parallelization. Do not loop bumping the timeout
+     past 90 min without filing the follow-up.
+3. Surface cascade failures to the user explicitly. The downstream jobs'
+   results don't exist; the code's coverage of the current HEAD cannot be
+   confirmed by CI alone.
+
+### PR body claim verification
+
+PR body text like "PHASE 2 council APPROVED (5/5, round 2)" or "Final council
+APPROVED" must be backed by an evidence file in `.swarm/evidence/`
+(typically `phase-council.json` or `final-council.json`). Bot-generated PR
+bodies commonly auto-fill these claims without real review. Before accepting
+such a claim as part of triage:
+
+1. Check whether the corresponding evidence file exists with `verdict:APPROVED`.
+2. If the claim is unsupported, mark the closure ledger item as
+   `NEEDS_MORE_EVIDENCE` rather than `CONFIRMED`. Do not silently drop the
+   claim — it indicates the PR body was generated without a real review.
+
 ## Feedback Ledger
 
 Normalize each item before triage:
@@ -163,6 +199,59 @@ Rules:
   `CONFLICT-001` for merge/base drift and `CI-001` for check failures, so PR
   bodies can show exactly how operational blockers were closed.
 
+### Mandatory: integrate all PR comments with feedback or findings before validation
+
+**Before the Verification step begins, every PR comment that contains feedback
+or findings MUST be integrated into the total feedback ledger as a
+`FB-###` item.** This is a hard requirement, not a best-effort step.
+
+What counts as "feedback or findings":
+- A reviewer request for a code change ("please rename this", "add a test for
+  X", "this should call `_internals.foo`")
+- A reviewer claim about correctness, security, or style ("this is
+  incorrect", "X will leak")
+- A bot reviewer's findings table entries
+- A CI failure with a specific file:line root cause
+- A reviewer question that implies a code change is needed ("why is this
+  static?")
+- PR review summaries or aggregate comments
+
+What does NOT count (and is therefore not required to be a ledger item):
+- Pure acknowledgements ("LGTM", "looks good")
+- PR-level metadata changes (title, label, milestone)
+- Force-push acknowledgements
+
+Rules:
+- **No finding may be addressed outside the ledger.** If you fix something a
+  reviewer mentioned, the corresponding `FB-###` item MUST be in the ledger
+  before the fix. If you skip the fix, the `FB-###` item MUST be in the
+  ledger with a `DISPROVED`, `PRE_EXISTING`, `NEEDS_MORE_EVIDENCE`, or
+  `NEEDS_USER_DECISION` status before validation can begin.
+- **Status semantics for unaddressed items:**
+  - `CONFIRMED` and `PARTIAL` items must be addressed (fixed or
+    disproved) before validation can begin. A `CONFIRMED` item that is
+    left unaddressed is a regression against the review.
+  - `DISPROVED`, `PRE_EXISTING`, `NEEDS_MORE_EVIDENCE`, and
+    `NEEDS_USER_DECISION` items may remain open at validation time, but
+    each must be explicitly justified in the closure ledger.
+- **The closure ledger at the end of the run must account for every `FB-###`
+  item** with a final status (fixed / disproved / pre-existing / needs user
+  decision / needs more evidence).
+- **Comments from the latest bot round take precedence over earlier rounds**
+  for the same finding; the earlier-round `FB-###` item is updated with the
+  new evidence rather than a new item being created.
+- **Multi-round pattern continues to apply** (see "Multi-Round Bot Reviews"
+  section). A new bot round adds new `FB-###` items for findings that
+  weren't in the prior round; the prior round's items are carried forward
+  and updated with the new evidence.
+
+Rationale: silently addressing a review comment without a corresponding
+ledger item means the closure summary at the end of the run cannot
+demonstrate that every review comment was considered. The closure summary
+is the only artifact the user/maintainer reads to confirm the PR is ready
+to merge. Missing items in the ledger = missing items in the closure = a
+PR that ships with unreviewed feedback.
+
 ## Verification
 
 Classify every ledger item before fixing:
@@ -173,6 +262,7 @@ Classify every ledger item before fixing:
 | `PARTIAL` | The comment points at a real concern, but the framing, severity, or requested fix is incomplete. |
 | `DISPROVED` | Source, tests, or execution context prove the claim is false, unreachable, or already mitigated. |
 | `PRE_EXISTING` | The issue exists on the base branch and is not materially worsened by the PR. |
+| `NEEDS_MORE_EVIDENCE` | The claim (e.g., "council APPROVED") is unsupported by stored evidence (e.g., a missing or failed `.swarm/evidence/` artifact); more information is required before triage. |
 | `NEEDS_USER_DECISION` | The item requires a product, UX, compatibility, or scope choice that cannot be inferred. |
 
 Verification checklist:
@@ -183,6 +273,26 @@ Verification checklist:
 - Determine whether the issue is PR-introduced, pre-existing, or unresolved.
 - Check related tests and whether a failing/proposed test would prove the item.
 - Check whether multiple feedback items share one root cause.
+
+### DI seam migration validation
+
+When a test file mutates a DI seam object (e.g., `_internals.foo = mock`),
+verify that the production source reads from the seam at call time. A common
+anti-pattern: the test mutates the seam object, but the production code
+imports the named function (`import { foo } from './module'`) which is bound
+at module load. The seam mutation has no effect on the named reference,
+so the test fails even though the seam object's `foo === mock`.
+
+Verification: open the source file and grep for call sites. If you see
+`import { foo } from '...'` followed by `foo(...)` in the production code,
+and the test does `_internals.foo = mock`, the test will fail. The fix is
+to change the production code to call `_internals.foo(...)` (or equivalent
+active-seam pattern) so the seam mutation is read at call time.
+
+If only a few call sites exist, fix them in the source. If many call sites
+exist, consider whether the migration should use `mock.module()` instead,
+which replaces the entire module object (including the named export
+reference).
 
 ## Fix Planning
 
@@ -251,6 +361,7 @@ FB-001 | fixed | commit/test evidence
 FB-002 | disproved | code evidence
 FB-003 | pre-existing | base-branch evidence
 FB-004 | needs user decision | decision required
+FB-005 | needs more evidence | .swarm/evidence/phase-council.json missing
 CONFLICT-001 | fixed | remote mergeability is MERGEABLE/CLEAN
 CI-001 | fixed | current-head check/run evidence
 ```

--- a/docs/releases/pending/skill-enhancement-swarm-pr-feedback-mandatory-integration.md
+++ b/docs/releases/pending/skill-enhancement-swarm-pr-feedback-mandatory-integration.md
@@ -1,0 +1,58 @@
+# Skill enhancement: swarm-pr-feedback mandatory PR comment integration
+
+## What changed
+
+Enhanced the canonical `swarm-pr-feedback` skill at `.opencode/skills/swarm-pr-feedback/SKILL.md` with four additions addressing real failure modes discovered during PR #1245 follow-up:
+
+1. **CI matrix cascade check** (in Intake Surfaces) — diagnostic when downstream `integration`/`smoke` jobs are blocked by a unit matrix leg failure. Explains how to distinguish code issues from runner performance, and how to surface cascade failures to the user.
+
+2. **PR body claim verification** (in Intake Surfaces) — verifies "council APPROVED" and similar claims against `.swarm/evidence/` files. Bot-generated PR bodies commonly auto-fill these claims without real review.
+
+3. **Mandatory: integrate all PR comments with feedback or findings before validation** (in Feedback Ledger) — hard requirement that every PR comment with feedback or findings becomes a `FB-###` ledger item before verification begins. Defines what counts (reviewer requests, claims, bot findings, CI failures, review summaries) and what does not (acknowledgements, PR metadata). Includes status hierarchy: `CONFIRMED`/`PARTIAL` must be addressed; `DISPROVED`/`PRE_EXISTING`/`NEEDS_MORE_EVIDENCE`/`NEEDS_USER_DECISION` may remain open but must be explicitly justified.
+
+4. **DI seam migration validation** (in Verification) — confirms consumer code reads from the seam at call time. A common anti-pattern: tests mutate `_internals.foo = mock`, but production code imports the named function which is bound at module load.
+
+Plus a new canonical status: `NEEDS_MORE_EVIDENCE` (added to the Verification status table) for claims unsupported by stored evidence.
+
+## Why
+
+These four failure modes were all encountered in a single PR feedback session (PR #1245 follow-up):
+
+- **CI matrix cascade** cost 4+ CI cycles of re-running and waiting (Windows runner hung on `tests/unit/tools/` step). The user could have been informed earlier.
+- **PR body claim** — the original PR's "PHASE 2 council APPROVED" claim was unsupportable: `.swarm/evidence/` had only `agent-tools-init-*.json` files, no council verdict artifacts.
+- **Mandatory integration** — silently addressing review comments without ledger items means the closure summary cannot demonstrate every comment was considered. This is the single most important change: it prevents "addressed but not recorded" findings.
+- **DI seam migration** — PR #1245's `_internals` migration was incomplete because production code used static named imports. 10 of 14 dark-matter-wiring tests failed.
+
+The mandatory integration rule prevents the recurring pattern of "I fixed it but the closure summary doesn't show I addressed every comment."
+
+## Migration
+
+No migration needed. The skill is invoked on-demand; agents reading the updated skill will see the new mandates automatically. Existing in-progress feedback closures do not need to be retroactively re-templated.
+
+## Invariant audit
+
+- 1 (plugin init): not touched — no init-path code modified
+- 2 (runtime portability): not touched — no code modified
+- 3 (subprocesses): not touched
+- 4 (.swarm containment): not touched
+- 5 (plan durability): not touched
+- 6 (test_runner safety): not touched
+- 7 (test writing): not touched — but the new "DI seam migration validation" sub-section improves test-writing practice by catching the seam-bound-at-import anti-pattern at PR feedback time
+- 8 (session state): not touched
+- 9 (guardrails/retry): not touched
+- 10 (chat/system msg): not touched
+- 11 (tool registration): not touched
+- 12 (release/cache): touched — this fragment created; `dist/` not committed; no version files hand-edited
+
+## Test plan
+
+- [x] Markdown format: `bunx biome ci .opencode/skills/swarm-pr-feedback/SKILL.md` exits 0
+- [x] Three mirror files unchanged: `.claude/skills/swarm-pr-feedback/SKILL.md` and `.agents/skills/swarm-pr-feedback/SKILL.md` delegate to the canonical file (no update needed — they contain adapter-specific notes, not full content)
+- [x] `swarm-pr-feedback` reviewer (lowtier_reviewer) APPROVED the changes after two review rounds:
+  - Round 1: CHANGES_REQUESTED (duplicate line, missing status)
+  - Round 2: APPROVED with minor gap
+  - Round 3: APPROVED (gap addressed)
+- [x] No code paths affected: skill is documentation only, no `.ts`/`.js` source files modified
+- [x] `bun run typecheck`: not run (no type-checkable code changed)
+- [x] `bun run build`: not run (no source files changed)
+- [x] Plugin loads: not run (entry point unchanged)


### PR DESCRIPTION
## Summary

- `.opencode/skills/swarm-pr-feedback/SKILL.md`: Added 4 sub-sections (CI matrix cascade check, PR body claim verification, Mandatory PR comment integration, DI seam migration validation), added `NEEDS_MORE_EVIDENCE` to canonical status table, and added an example closure ledger entry for the new status. Total: 111 insertions.
- `docs/releases/pending/skill-enhancement-swarm-pr-feedback-mandatory-integration.md` (NEW): Release fragment for the skill enhancement.

This adds hard mandates and validation patterns to the `swarm-pr-feedback` skill, addressing four real failure modes discovered during PR #1245 follow-up:
1. CI matrix cascade (Windows runner blocking downstream jobs â€” wasted 4+ CI cycles)
2. PR body claims unsupported by stored evidence (e.g., "PHASE 2 council APPROVED")
3. Silently addressing review comments without ledger items (no closure summary traceability)
4. DI seam migration with static named imports (seam mutation has no effect on production code)

The skill's adapter files (`.claude/skills/...` and `.agents/skills/...`) explicitly delegate to the canonical `.opencode/...` file and add their own adapter-specific notes. They do not need updating because the canonical skill change is automatically visible to the adapters via the delegation.

## Invariant audit

- 1 (plugin init): not touched â€” no init-path code modified
- 2 (runtime portability): not touched â€” no code modified
- 3 (subprocesses): not touched
- 4 (.swarm containment): not touched
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched
- 7 (test writing): not directly touched â€” but the new "DI seam migration validation" sub-section improves test-writing practice by catching the seam-bound-at-import anti-pattern at PR feedback time
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched
- 12 (release/cache): touched â€” release fragment created; `dist/` not committed; no version files hand-edited

## Test plan

- [x] Markdown format: `bunx biome ci .opencode/skills/swarm-pr-feedback/SKILL.md` exits 0
- [x] Three mirror files unchanged: `.claude/skills/swarm-pr-feedback/SKILL.md` and `.agents/skills/swarm-pr-feedback/SKILL.md` delegate to the canonical file (no update needed)
- [x] `swarm-pr-feedback` reviewer (lowtier_reviewer) APPROVED the changes after two review rounds
- [x] No code paths affected: skill is documentation only, no `.ts`/`.js` source files modified
- [x] `bun run typecheck`: not run (no type-checkable code changed)
- [x] `bun run build`: not run (no source files changed)
- [x] Plugin loads: not run (entry point unchanged)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the `swarm-pr-feedback` skill with mandatory PR comment integration and new diagnostics to prevent missed feedback and CI blind spots. Adds four guidance sections and the `NEEDS_MORE_EVIDENCE` status, plus a release note.

- **New Features**
  - CI matrix cascade check to diagnose OS-leg failures that block downstream jobs and distinguish code vs. runner issues.
  - PR body claim verification against `.swarm/evidence/` artifacts; unsupported claims use `NEEDS_MORE_EVIDENCE`.
  - Mandatory mapping of all feedback/findings comments into `FB-###` items before validation, with clear status rules and full closure accounting.
  - DI seam migration validation to catch named-import binding issues; ensure production reads from the seam at call time.
  - Added `NEEDS_MORE_EVIDENCE` to the status table and an example closure entry; release fragment added.

<sup>Written for commit e007bf9af74d13afdf3208836d8f2bd40adf59e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zaxbysauce/opencode-swarm/pull/1404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

