### PR TITLE
fix(planning): offer general council before plan writing

### DIFF
--- a/.claude/skills/council/SKILL.md
+++ b/.claude/skills/council/SKILL.md
@@ -27,7 +27,8 @@ This mode is ADVISORY. It does not block any other workflow and does not modify
 code, plans, or specs. The output is for the user (general mode) or for the spec
 being drafted (spec_review mode is available via `/swarm council --spec-review`
 for manual spec review). General Council advisory input is offered as an early
-workflow option in MODE: BRAINSTORM (Phase 1b).
+workflow option in MODE: BRAINSTORM (Phase 1b) and MODE: PLAN before
+`save_plan`.
 
 #### Pre-flight (always run first)
 

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -39,6 +39,22 @@ This is a SOFT gate. When the user chooses "Skip and plan directly", proceed to 
 
 Run CODEBASE REALITY CHECK scoped to codebase elements referenced in spec.md or user constraints. Discrepancies must be reflected in the generated plan.
 
+### GENERAL COUNCIL ADVISORY OPTION (pre-save_plan)
+
+Before drafting or saving the plan, the architect MUST offer General Council advisory input when `council.general.enabled` is true in the resolved opencode-swarm config and a search API key is configured.
+
+- Ask the user: "Use General Council advisory input before I write the plan? The 3-agent council (generalist, skeptic, domain expert) will gather current external context and provide perspectives that I will fold into the plan before critic review. (default: no)"
+- If the user declines, proceed to the clarification funnel and planning normally.
+- If the user accepts:
+  1. Run the General Council Research Phase: formulate 1-3 targeted `web_search` queries grounded in the work being planned.
+  2. Dispatch `the active swarm's council_generalist agent`, `the active swarm's council_skeptic agent`, and `the active swarm's council_domain_expert agent` in PARALLEL with the RESEARCH CONTEXT.
+  3. Collect responses and call `convene_general_council` with mode `general`.
+  4. Record the council consensus, disagreements, cited sources, and any plan-impacting assumptions in `.swarm/context.md` under `## Decisions`.
+  5. Use that recorded council input as planning context before calling `save_plan`.
+- If General Council is unavailable and the user explicitly requested council input, surface the config/key requirement and stop before `save_plan` rather than writing an ungrounded plan.
+
+General Council is advisory and distinct from `council_mode`, `phase_council`, and `final_council`. It is not a QA gate. Its purpose here is to make current external context available before the architect writes any plan and before any critic pre-plan review.
+
 ### CLARIFICATION FUNNEL (pre-save_plan)
 
 Before calling `save_plan` — whether creating a new plan or finalizing an external plan ingestion — the architect MUST run this four-stage clarification funnel. The goal is to limit unnecessary user interruption, not planning completeness.

--- a/.claude/skills/specify/SKILL.md
+++ b/.claude/skills/specify/SKILL.md
@@ -30,10 +30,10 @@ Activates when: user asks to "specify", "define requirements", "write a spec", o
    - Edge cases and known failure modes
     - `[NEEDS CLARIFICATION]` markers for items where uncertainty could change scope, security, or core behavior, BUT ONLY after running the clarification funnel: (1) inventory all material uncertainties without numeric cap, (2) classify each as self_resolved/critic_resolved/research_needed/user_decision/deferred_nonblocking — **overconfidence guard:** if the default is not directly supported by user request, spec, or recorded context, classify as `user_decision` rather than `self_resolved`, (3) consult critic_sounding_board with candidate items — critic responds per SoundingBoardVerdict: UNNECESSARY→DROP, RESOLVE→RESOLVE, REPHRASE→REPHRASE, APPROVED→ASK_USER — **always-surface protection:** always-surface categories must not receive UNNECESSARY/DROP; override to APPROVED/ASK_USER, (4) record all resolved items as explicit assumptions in the spec, (5) use markers only for items that survive the funnel (ASK_USER or unresolved after critic consultation). Decision packet format: grouped by category, recommended defaults, blocking vs optional markers, impact of accepting default. Prefer informed defaults over asking
 5. Write the spec to `.swarm/spec.md`.
-5b. **QA GATE SELECTION, PARALLEL CODERS, AND COMMIT FREQUENCY (dialogue only).**
-Ask the user which QA gates to enable for this plan, how many parallel coders to use, and the commit frequency -- do not select on their behalf. Present all three items together as one unified exchange.
+5b. **QA GATE SELECTION, PARALLEL CODERS, COMMIT FREQUENCY, AND AUTO_PROCEED (dialogue only).**
+Ask the user which QA gates to enable for this plan, how many parallel coders to use, the commit frequency, and auto_proceed -- do not select on their behalf. Present all four items together as one unified exchange.
 
-Present the eleven gates with their defaults (DEFAULT_QA_GATES), parallel coder count, and commit frequency as a single user-facing section. Offer the user a one-shot choice: accept defaults, or customize. The eleven gates are:
+Present the eleven gates with their defaults (DEFAULT_QA_GATES), parallel coder count, commit frequency, and auto_proceed as a single user-facing section. Offer the user a one-shot choice: accept defaults, or customize. The eleven gates are:
 - reviewer (default: ON) -- code review of coder output
 - test_engineer (default: ON) -- test verification of coder output
 - sme_enabled (default: ON) -- SME consultation during planning/clarification
@@ -88,9 +88,9 @@ GATE SELECTION IS MANDATORY — these thoughts are WRONG and must be ignored:
 
 MANDATORY PAUSE: Do NOT write the spec summary (step 7). Do NOT suggest next steps.
 You are BLOCKED until ALL THREE of these conditions are met:
-  (1) The unified gate/coders/commit selection section has been presented to the user in a single message
-  (2) The user has responded (accept defaults OR customized list for all three items)
-  (3) The elected gates, parallel coder config, and commit policy have been written to .swarm/context.md under "## Pending QA Gate Selection" (and related sections as applicable)
+  (1) The unified gate/coders/commit/auto_proceed selection section has been presented to the user in a single message
+  (2) The user has responded (accept defaults OR customized list for all four items)
+  (3) The elected gates, parallel coder config, commit policy, and auto_proceed selection have been written to .swarm/context.md under "## Pending QA Gate Selection" (and related sections as applicable)
 <!-- BEHAVIORAL_GUIDANCE_END -->
 
 Do NOT call `set_qa_gates` yet — `plan.json` does not exist at this point. Once the user answers, write the elected gates to `.swarm/context.md` under a new section:

--- a/.claude/skills/specify/SKILL.md
+++ b/.claude/skills/specify/SKILL.md
@@ -46,11 +46,12 @@ Present the eleven gates with their defaults (DEFAULT_QA_GATES), parallel coder 
 - drift_check (default: ON) -- when enabled, mandatory per-phase drift verification via critic_drift_verifier at PHASE-WRAP; compares implemented changes against spec.md intent; hard-blocks phase_complete when spec.md exists and drift evidence is missing or REJECTED; advisory-only when no spec.md exists (recommended for all projects with a specification)
 - final_council (default: OFF) -- when enabled, after all phases complete the architect dispatches the full 5-member council (critic, reviewer, sme, test_engineer, explorer) -- NOT the General Council -- at project scope, collects `CouncilMemberVerdict` objects, and calls `write_final_council_evidence`. This does not require `council.general.enabled`.
 
-Additionally, present these two sub-items as part of the same exchange:
+Additionally, present these three sub-items as part of the same exchange:
 - Parallel coders (default: 1, range: 1-4) -- how many coders should run in parallel.
 - Commit frequency (default: phase-level only) -- optional per-task checkpoint commit after each task completion.
+- auto_proceed (boolean, default: false) -- when true, auto-advance to the next phase without asking "Ready for Phase N+1?"; runtime toggle via /swarm auto-proceed on|off.
 
-The user answers all three (gates, parallel coders, commit frequency) in one exchange. Wait for the user's response.
+The user answers all four (gates, parallel coders, commit frequency, auto_proceed) in one exchange. Wait for the user's response.
 
 If the user says parallel coders > 1, write a `## Pending Parallelization Config` section to `.swarm/context.md` alongside the gate selection:
 ```
@@ -110,7 +111,7 @@ Do NOT call `set_qa_gates` yet — `plan.json` does not exist at this point. Onc
 ```
 MODE: PLAN will read this section after `save_plan` succeeds and persist via `set_qa_gates`.
 
-General Council advisory input is offered as an early workflow option in MODE: BRAINSTORM (Phase 1b), not as a SPECIFY step. If the user wants council input during SPECIFY, they can use `/swarm council <question>` manually.
+General Council advisory input is offered as an early workflow option in MODE: BRAINSTORM (Phase 1b) and MODE: PLAN before `save_plan`, not as a SPECIFY step. If the user wants council input during SPECIFY, they can use `/swarm council <question>` manually.
 
 7. Report a summary to the user (MUST count, SHALL count, scenario count, clarification markers, elected QA gates) and suggest the next step: `CLARIFY-SPEC` (if markers exist) or `PLAN`.
 

--- a/.opencode/skills/council/SKILL.md
+++ b/.opencode/skills/council/SKILL.md
@@ -27,7 +27,8 @@ This mode is ADVISORY. It does not block any other workflow and does not modify
 code, plans, or specs. The output is for the user (general mode) or for the spec
 being drafted (spec_review mode is available via `/swarm council --spec-review`
 for manual spec review). General Council advisory input is offered as an early
-workflow option in MODE: BRAINSTORM (Phase 1b).
+workflow option in MODE: BRAINSTORM (Phase 1b) and MODE: PLAN before
+`save_plan`.
 
 #### Pre-flight (always run first)
 

--- a/.opencode/skills/plan/SKILL.md
+++ b/.opencode/skills/plan/SKILL.md
@@ -39,6 +39,22 @@ This is a SOFT gate. When the user chooses "Skip and plan directly", proceed to 
 
 Run CODEBASE REALITY CHECK scoped to codebase elements referenced in spec.md or user constraints. Discrepancies must be reflected in the generated plan.
 
+### GENERAL COUNCIL ADVISORY OPTION (pre-save_plan)
+
+Before drafting or saving the plan, the architect MUST offer General Council advisory input when `council.general.enabled` is true in the resolved opencode-swarm config and a search API key is configured.
+
+- Ask the user: "Use General Council advisory input before I write the plan? The 3-agent council (generalist, skeptic, domain expert) will gather current external context and provide perspectives that I will fold into the plan before critic review. (default: no)"
+- If the user declines, proceed to the clarification funnel and planning normally.
+- If the user accepts:
+  1. Run the General Council Research Phase: formulate 1-3 targeted `web_search` queries grounded in the work being planned.
+  2. Dispatch `the active swarm's council_generalist agent`, `the active swarm's council_skeptic agent`, and `the active swarm's council_domain_expert agent` in PARALLEL with the RESEARCH CONTEXT.
+  3. Collect responses and call `convene_general_council` with mode `general`.
+  4. Record the council consensus, disagreements, cited sources, and any plan-impacting assumptions in `.swarm/context.md` under `## Decisions`.
+  5. Use that recorded council input as planning context before calling `save_plan`.
+- If General Council is unavailable and the user explicitly requested council input, surface the config/key requirement and stop before `save_plan` rather than writing an ungrounded plan.
+
+General Council is advisory and distinct from `council_mode`, `phase_council`, and `final_council`. It is not a QA gate. Its purpose here is to make current external context available before the architect writes any plan and before any critic pre-plan review.
+
 ### CLARIFICATION FUNNEL (pre-save_plan)
 
 Before calling `save_plan` — whether creating a new plan or finalizing an external plan ingestion — the architect MUST run this four-stage clarification funnel. The goal is to limit unnecessary user interruption, not planning completeness.

--- a/.opencode/skills/specify/SKILL.md
+++ b/.opencode/skills/specify/SKILL.md
@@ -30,10 +30,10 @@ Activates when: user asks to "specify", "define requirements", "write a spec", o
    - Edge cases and known failure modes
     - `[NEEDS CLARIFICATION]` markers for items where uncertainty could change scope, security, or core behavior, BUT ONLY after running the clarification funnel: (1) inventory all material uncertainties without numeric cap, (2) classify each as self_resolved/critic_resolved/research_needed/user_decision/deferred_nonblocking — **overconfidence guard:** if the default is not directly supported by user request, spec, or recorded context, classify as `user_decision` rather than `self_resolved`, (3) consult critic_sounding_board with candidate items — critic responds per SoundingBoardVerdict: UNNECESSARY→DROP, RESOLVE→RESOLVE, REPHRASE→REPHRASE, APPROVED→ASK_USER — **always-surface protection:** always-surface categories must not receive UNNECESSARY/DROP; override to APPROVED/ASK_USER, (4) record all resolved items as explicit assumptions in the spec, (5) use markers only for items that survive the funnel (ASK_USER or unresolved after critic consultation). Decision packet format: grouped by category, recommended defaults, blocking vs optional markers, impact of accepting default. Prefer informed defaults over asking
 5. Write the spec to `.swarm/spec.md`.
-5b. **QA GATE SELECTION, PARALLEL CODERS, AND COMMIT FREQUENCY (dialogue only).**
-Ask the user which QA gates to enable for this plan, how many parallel coders to use, and the commit frequency -- do not select on their behalf. Present all three items together as one unified exchange.
+5b. **QA GATE SELECTION, PARALLEL CODERS, COMMIT FREQUENCY, AND AUTO_PROCEED (dialogue only).**
+Ask the user which QA gates to enable for this plan, how many parallel coders to use, the commit frequency, and auto_proceed -- do not select on their behalf. Present all four items together as one unified exchange.
 
-Present the eleven gates with their defaults (DEFAULT_QA_GATES), parallel coder count, and commit frequency as a single user-facing section. Offer the user a one-shot choice: accept defaults, or customize. The eleven gates are:
+Present the eleven gates with their defaults (DEFAULT_QA_GATES), parallel coder count, commit frequency, and auto_proceed as a single user-facing section. Offer the user a one-shot choice: accept defaults, or customize. The eleven gates are:
 - reviewer (default: ON) -- code review of coder output
 - test_engineer (default: ON) -- test verification of coder output
 - sme_enabled (default: ON) -- SME consultation during planning/clarification
@@ -88,9 +88,9 @@ GATE SELECTION IS MANDATORY — these thoughts are WRONG and must be ignored:
 
 MANDATORY PAUSE: Do NOT write the spec summary (step 7). Do NOT suggest next steps.
 You are BLOCKED until ALL THREE of these conditions are met:
-  (1) The unified gate/coders/commit selection section has been presented to the user in a single message
-  (2) The user has responded (accept defaults OR customized list for all three items)
-  (3) The elected gates, parallel coder config, and commit policy have been written to .swarm/context.md under "## Pending QA Gate Selection" (and related sections as applicable)
+  (1) The unified gate/coders/commit/auto_proceed selection section has been presented to the user in a single message
+  (2) The user has responded (accept defaults OR customized list for all four items)
+  (3) The elected gates, parallel coder config, commit policy, and auto_proceed selection have been written to .swarm/context.md under "## Pending QA Gate Selection" (and related sections as applicable)
 <!-- BEHAVIORAL_GUIDANCE_END -->
 
 Do NOT call `set_qa_gates` yet — `plan.json` does not exist at this point. Once the user answers, write the elected gates to `.swarm/context.md` under a new section:

--- a/.opencode/skills/specify/SKILL.md
+++ b/.opencode/skills/specify/SKILL.md
@@ -46,12 +46,12 @@ Present the eleven gates with their defaults (DEFAULT_QA_GATES), parallel coder 
 - drift_check (default: ON) -- when enabled, mandatory per-phase drift verification via critic_drift_verifier at PHASE-WRAP; compares implemented changes against spec.md intent; hard-blocks phase_complete when spec.md exists and drift evidence is missing or REJECTED; advisory-only when no spec.md exists (recommended for all projects with a specification)
 - final_council (default: OFF) -- when enabled, after all phases complete the architect dispatches the full 5-member council (critic, reviewer, sme, test_engineer, explorer) -- NOT the General Council -- at project scope, collects `CouncilMemberVerdict` objects, and calls `write_final_council_evidence`. This does not require `council.general.enabled`.
 
-Additionally, present these two sub-items as part of the same exchange:
+Additionally, present these three sub-items as part of the same exchange:
 - Parallel coders (default: 1, range: 1-4) -- how many coders should run in parallel.
 - Commit frequency (default: phase-level only) -- optional per-task checkpoint commit after each task completion.
 - auto_proceed (boolean, default: false) -- when true, auto-advance to the next phase without asking "Ready for Phase N+1?"; runtime toggle via /swarm auto-proceed on|off.
 
-The user answers all three (gates, parallel coders, commit frequency) in one exchange. Wait for the user's response.
+The user answers all four (gates, parallel coders, commit frequency, auto_proceed) in one exchange. Wait for the user's response.
 
 If the user says parallel coders > 1, write a `## Pending Parallelization Config` section to `.swarm/context.md` alongside the gate selection:
 ```
@@ -111,7 +111,7 @@ Do NOT call `set_qa_gates` yet — `plan.json` does not exist at this point. Onc
 ```
 MODE: PLAN will read this section after `save_plan` succeeds and persist via `set_qa_gates`.
 
-General Council advisory input is offered as an early workflow option in MODE: BRAINSTORM (Phase 1b), not as a SPECIFY step. If the user wants council input during SPECIFY, they can use `/swarm council <question>` manually.
+General Council advisory input is offered as an early workflow option in MODE: BRAINSTORM (Phase 1b) and MODE: PLAN before `save_plan`, not as a SPECIFY step. If the user wants council input during SPECIFY, they can use `/swarm council <question>` manually.
 
 7. Report a summary to the user (MUST count, SHALL count, scenario count, clarification markers, elected QA gates) and suggest the next step: `CLARIFY-SPEC` (if markers exist) or `PLAN`.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -132,6 +132,8 @@ Enter architect BRAINSTORM mode: seven-phase planning workflow for new features 
 
 Enter architect MODE: COUNCIL — convene a fixed three-agent General Council (`council_generalist`, `council_skeptic`, `council_domain_expert`) for an advisory deliberation. The architect runs a web-search pre-pass and supplies all agents with a RESEARCH CONTEXT block; agents answer in parallel without individual web access. The architect routes any disagreements back for one targeted Round 2 reconciliation, then synthesizes the final answer directly using inline output rules (no separate moderator pass).
 
+When enabled in config, the same General Council advisory flow is also offered by BRAINSTORM before spec writing and by PLAN before `save_plan`, so current council input can inform plan writing before critic review.
+
 | Flag | Effect |
 |------|--------|
 | `--spec-review` | Switch to single-pass advisory mode. Can be invoked manually to fold council input into a draft spec — no Round 2 deliberation. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -610,7 +610,7 @@ Distinct from the Work Complete Council above. Where the Work Complete Council i
 
 The three council agents derive their models from the `reviewer`, `critic`, and `sme` swarm config entries respectively (generalist→reviewer, skeptic→critic, domain_expert→SME). They have no tools — for General Council dispatch, the architect runs `web_search` 1–3 times before dispatch and passes the results in. Separately, SME agents may call `web_search` directly for external skill/source research when `council.general.enabled=true` and a Tavily or Brave API key is configured.
 
-Triggered by `/swarm council <question>` (see [Commands](commands.md#swarm-council-question---spec-review)) or offered as an early workflow option in MODE: BRAINSTORM (Phase 1b) when enabled.
+Triggered by `/swarm council <question>` (see [Commands](commands.md#swarm-council-question---spec-review)) or offered as an early workflow option in MODE: BRAINSTORM (Phase 1b) and MODE: PLAN before `save_plan` when enabled.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|

--- a/docs/council/README.md
+++ b/docs/council/README.md
@@ -312,11 +312,14 @@ feeds the council's consensus and disagreements back into the draft spec.
 ### General Council as an early workflow option
 
 General Council advisory input is available as an early workflow option in
-MODE: BRAINSTORM (Phase 1b) when `council.general.enabled` is true and a
-search API key is configured. The architect offers to convene the General
-Council for advisory deliberation on the topic before approach selection.
-This is a manual option, not a QA gate — it does not appear in the gate
-selection list and does not block any workflow step.
+MODE: BRAINSTORM (Phase 1b) and MODE: PLAN before `save_plan` when
+`council.general.enabled` is true and a search API key is configured. The
+architect offers to convene the General Council for advisory deliberation
+before approach selection in BRAINSTORM, or before drafting/saving the
+implementation plan in PLAN so current input can inform plan writing before the
+critic gate. This is a manual option, not a QA gate — it does not appear in the
+gate selection list and does not block any workflow step unless the user
+explicitly requests council input and the required config/key is unavailable.
 
 ### Workflow stages (in plain language)
 

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -219,7 +219,7 @@ If you prefer to plan inside OpenCode rather than in a separate tool, the swarm 
 **Starting from scratch:**
 1. `/swarm specify <feature description>` → architect generates spec.md
 2. If spec has `[NEEDS CLARIFICATION]` markers → `/swarm clarify` to resolve them
-3. Tell the architect to start planning → PLAN mode reads spec.md and cross-references FR-### automatically
+3. Tell the architect to start planning → PLAN mode reads spec.md, optionally offers General Council advisory input when `council.general.enabled` is configured, and cross-references FR-### automatically
 4. Optionally `/swarm analyze` after planning to verify coverage
 
 **Importing an existing plan:**
@@ -230,6 +230,9 @@ Keep current requirements in `openspec/specs/**/spec.md` and pending deltas in `
 
 **Without a spec:**
 Planning works fine without a spec. When you enter PLAN mode without a spec.md, the architect offers to create one first or skip straight to planning. If you skip, planning behavior is identical to prior versions — no behavioral change.
+
+**Using General Council before planning:**
+When `council.general.enabled` is true and a Tavily or Brave search API key is configured, MODE: PLAN asks whether to use the three-agent General Council before `save_plan`. If accepted, the architect gathers current external context, records the council consensus/disagreements in `.swarm/context.md`, and uses that input before writing the plan and before critic pre-plan review.
 
 ### Spec Format
 

--- a/docs/releases/pending/council-gate-overhaul.md
+++ b/docs/releases/pending/council-gate-overhaul.md
@@ -7,7 +7,7 @@
 ## New Features
 - `phase_council` QA gate: full 5-member council reviews all work in a phase holistically at phase_complete time.
 - General Council advisory input offered as Phase 1b in MODE: BRAINSTORM and before `save_plan` in MODE: PLAN when council.general.enabled is true.
-- QA gate selection section unified: gates, parallel coders, and commit frequency presented together.
+- QA gate selection section unified: gates, parallel coders, commit frequency, and auto_proceed presented together.
 
 ## Clarifications
 - `final_council` explicitly documented as using the full 5-member council, not the General Council.

--- a/docs/releases/pending/council-gate-overhaul.md
+++ b/docs/releases/pending/council-gate-overhaul.md
@@ -1,12 +1,12 @@
 # Council Gate Overhaul
 
 ## Breaking Changes
-- `council_general_review` QA gate removed. General Council is now an early workflow option in MODE: BRAINSTORM, not a QA gate.
+- `council_general_review` QA gate removed. General Council is now an early workflow option in MODE: BRAINSTORM and MODE: PLAN before `save_plan`, not a QA gate.
 - `council_mode` behavior changed: now replaces per-task Stage B (reviewer + test_engineer) with the full 5-member council. Previously was additive at the phase level.
 
 ## New Features
 - `phase_council` QA gate: full 5-member council reviews all work in a phase holistically at phase_complete time.
-- General Council advisory input offered as Phase 1b in MODE: BRAINSTORM when council.general.enabled is true.
+- General Council advisory input offered as Phase 1b in MODE: BRAINSTORM and before `save_plan` in MODE: PLAN when council.general.enabled is true.
 - QA gate selection section unified: gates, parallel coders, and commit frequency presented together.
 
 ## Clarifications

--- a/docs/releases/pending/pre-plan-general-council.md
+++ b/docs/releases/pending/pre-plan-general-council.md
@@ -1,0 +1,4 @@
+# Pre-plan General Council
+
+- MODE: PLAN now offers General Council advisory input before `save_plan` when `council.general.enabled` and a search API key are configured, so current council findings can inform plan writing before the critic gate.
+- Updated architect prompt stubs, mirrored plan/council/specify skills, planning docs, and regression tests to keep the pre-plan council option discoverable and locked down.

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -679,7 +679,7 @@ HARD CONSTRAINTS:
 
 <!-- BEHAVIORAL_GUIDANCE_START -->
 - Treat brainstorm output as discovery material until the loaded skill transitions to SPECIFY or PLAN.
-- When council.general.enabled is true, the brainstorm skill offers the user a General Council advisory input option before spec writing. This is NOT a QA gate — it's an early workflow option. The convene_general_council tool must be available when council.general.enabled is true.
+- When council.general.enabled is true, the brainstorm skill offers the user a General Council advisory input option before spec writing, and the plan skill offers it before save_plan. This is NOT a QA gate — it's an early workflow option. The convene_general_council tool must be available when council.general.enabled is true.
 <!-- BEHAVIORAL_GUIDANCE_END -->
 
 ### MODE: SPECIFY
@@ -696,7 +696,7 @@ HARD CONSTRAINTS:
 
 <!-- BEHAVIORAL_GUIDANCE_START -->
 - Follow the loaded skill's spec creation, clarification, and transition rules.
-- General Council advisory input is available via the /swarm council command at any time. It is NOT offered as a SPECIFY workflow step — it moved to BRAINSTORM Phase 1b as an early option before spec writing.
+- General Council advisory input is available via the /swarm council command at any time. It is NOT offered as a SPECIFY workflow step — it is offered in BRAINSTORM Phase 1b before spec writing and in MODE: PLAN before save_plan.
 <!-- BEHAVIORAL_GUIDANCE_END -->
 
 <!-- BEHAVIORAL_GUIDANCE_START -->
@@ -895,6 +895,7 @@ Purpose: Create or ingest the implementation plan, apply QA gate selections afte
 ACTION: Load skill file:.opencode/skills/plan/SKILL.md immediately. Follow the protocol defined there.
 
 HARD CONSTRAINTS (apply regardless of skill load success):
+- Before drafting or saving a plan, offer the loaded skill's General Council advisory option when \`council.general.enabled\` is true and a search API key is configured. If the user accepts, use the council output as context before calling \`save_plan\` and before any critic pre-plan review.
 - Use the \`save_plan\` tool as the primary plan writer. Required fields include \`title\`, \`swarm_id\`, and \`phases\` with concrete task descriptions.
 - Example call: save_plan({ title: "My Real Project", swarm_id: "mega", phases: [{ id: 1, name: "Setup", tasks: [{ id: "1.1", description: "Install dependencies and configure TypeScript", size: "small" }] }] })
 
@@ -1027,7 +1028,8 @@ export interface CouncilWorkflowConfig {
 	/**
 	 * General Council Mode (advisory). When `general?.enabled === true`, the
 	 * architect's tool list includes `convene_general_council` and the prompt
-	 * emits `MODE: COUNCIL` and `SPECIFY-COUNCIL-REVIEW` instructions.
+	 * emits `MODE: COUNCIL` plus pre-plan advisory instructions in the loaded
+	 * PLAN protocol.
 	 */
 	general?: {
 		enabled?: boolean;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1428,12 +1428,13 @@ export type AuthorityConfig = z.infer<typeof AuthorityConfigSchema>;
 
 // General Council Mode configuration (advisory deliberation — distinct from the
 // verdict-based Work Complete Council below). Off by default. When enabled,
-// `/swarm council <question>` and the SPECIFY-COUNCIL-REVIEW gate convene a
-// fixed three-agent council (council_generalist / council_skeptic /
-// council_domain_expert). The architect runs a curated pre-search pass via
-// `web_search`, dispatches the three agents in parallel with the gathered
-// RESEARCH CONTEXT, routes disagreements back for one reconciliation round,
-// and synthesizes the final answer directly via inline output rules.
+// `/swarm council <question>`, `/swarm council --spec-review`, and the
+// MODE: PLAN pre-save advisory option convene a fixed three-agent council
+// (council_generalist / council_skeptic / council_domain_expert). The architect
+// runs a curated pre-search pass via `web_search`, dispatches the three agents
+// in parallel with the gathered RESEARCH CONTEXT, routes disagreements back for
+// one reconciliation round, and synthesizes the final answer directly via
+// inline output rules.
 //
 // Backward compatibility: `members`, `presets`, `moderator`, and
 // `moderatorModel` are retained on the schema but are no longer used at
@@ -1519,7 +1520,8 @@ export const CouncilConfigSchema = z
 			),
 		// General Council Mode (advisory). Optional — undefined means feature is
 		// not configured. When present and enabled: true, the architect can run
-		// `/swarm council` and the SPECIFY-COUNCIL-REVIEW gate.
+		// `/swarm council`, manual spec review, and the MODE: PLAN pre-save
+		// advisory option.
 		general: GeneralCouncilConfigSchema.optional(),
 	})
 	.strict();

--- a/src/tools/convene-general-council.ts
+++ b/src/tools/convene-general-council.ts
@@ -116,7 +116,7 @@ export const convene_general_council: ReturnType<typeof tool> = createSwarmTool(
 				.enum(['general', 'spec_review'])
 				.optional()
 				.describe(
-					'"general" for /swarm council; "spec_review" for SPECIFY-COUNCIL-REVIEW gate.',
+					'"general" for /swarm council or pre-save PLAN advisory; "spec_review" for manual /swarm council --spec-review.',
 				),
 			members: z
 				.array(z.string())

--- a/tests/unit/agents/architect-prompt-template.test.ts
+++ b/tests/unit/agents/architect-prompt-template.test.ts
@@ -170,7 +170,7 @@ describe('architect-prompt-template: task 11.1 verification tests', () => {
 	it('27. MODE:PLAN section includes fallback delegation pattern', () => {
 		expect(prompt).toContain('If `save_plan` is unavailable');
 		expect(planSkill).toContain(
-			'delegate plan writing to {{AGENT_PREFIX}}coder',
+			"delegate plan writing to the active swarm's coder agent",
 		);
 	});
 

--- a/tests/unit/skills/architect-mode-protocols.test.ts
+++ b/tests/unit/skills/architect-mode-protocols.test.ts
@@ -34,7 +34,15 @@ const MODE_SKILLS = [
 		['Step 0 — Parse Header', 'Step 7 — Final Report'],
 	],
 	['ISSUE_INGEST', 'issue-ingest', ['Phase 1: INTAKE', 'Phase 4: TRANSITION']],
-	['PLAN', 'plan', ['SPEC GATE', 'POST-SAVE_PLAN']],
+	[
+		'PLAN',
+		'plan',
+		[
+			'SPEC GATE',
+			'GENERAL COUNCIL ADVISORY OPTION (pre-save_plan)',
+			'POST-SAVE_PLAN',
+		],
+	],
 	[
 		'CRITIC-GATE',
 		'critic-gate',

--- a/tests/unit/skills/plan-funnel-verify.test.ts
+++ b/tests/unit/skills/plan-funnel-verify.test.ts
@@ -97,6 +97,23 @@ describe('plan SKILL.md Clarification Funnel verification', () => {
 		expect(funnelIdx).toBeLessThan(saveIdx);
 	});
 
+	test('7b — General Council option appears before funnel and save_plan in both mirrors', () => {
+		const section = '### GENERAL COUNCIL ADVISORY OPTION (pre-save_plan)';
+		const opencodeCouncilIdx = opencodeContent.indexOf(section);
+		const claudeCouncilIdx = claudeContent.indexOf(section);
+		const opencodeFunnelIdx = opencodeContent.indexOf(
+			'### CLARIFICATION FUNNEL (pre-save_plan)',
+		);
+		const opencodeSaveIdx = opencodeContent.indexOf('Use the `save_plan` tool');
+
+		expect(opencodeCouncilIdx).toBeGreaterThan(0);
+		expect(claudeCouncilIdx).toBeGreaterThan(0);
+		expect(opencodeCouncilIdx).toBeLessThan(opencodeFunnelIdx);
+		expect(opencodeCouncilIdx).toBeLessThan(opencodeSaveIdx);
+		expect(opencodeContent).toContain('before any critic pre-plan review');
+		expect(claudeContent).toContain('before any critic pre-plan review');
+	});
+
 	test('8 — mirror parity: .claude version is byte-identical to .opencode version', () => {
 		expect(claudeContent).toBe(opencodeContent);
 	});

--- a/tests/unit/skills/plan-protocol.test.ts
+++ b/tests/unit/skills/plan-protocol.test.ts
@@ -24,6 +24,20 @@ describe('.opencode/skills/plan/SKILL.md protocol content', () => {
 			expect(skillContent).toContain('EXTERNAL PLAN IMPORT PATH');
 		});
 
+		it('requires offering General Council advisory input before save_plan when enabled', () => {
+			const generalCouncilIdx = skillContent.indexOf(
+				'GENERAL COUNCIL ADVISORY OPTION (pre-save_plan)',
+			);
+			const savePlanIdx = skillContent.indexOf('Use the `save_plan` tool');
+
+			expect(generalCouncilIdx).toBeGreaterThan(0);
+			expect(savePlanIdx).toBeGreaterThan(generalCouncilIdx);
+			expect(skillContent).toContain('council.general.enabled');
+			expect(skillContent).toContain('convene_general_council');
+			expect(skillContent).toMatch(/before drafting or saving the plan/i);
+			expect(skillContent).toContain('before any critic pre-plan review');
+		});
+
 		it('keeps save_plan requirements and example', () => {
 			expect(skillContent).toContain('Use the `save_plan` tool');
 			expect(skillContent).toContain('Required parameters:');
@@ -36,8 +50,8 @@ describe('.opencode/skills/plan/SKILL.md protocol content', () => {
 			expect(skillContent).not.toContain('{{QA_GATE_DIALOGUE_PLAN}}');
 			expect(skillContent).toContain('Present the eleven gates');
 			expect(skillContent).toContain('final_council (default: OFF)');
-			expect(skillContent).toContain('How many coders should run in parallel?');
-			expect(skillContent).toContain('Commit frequency for completed tasks?');
+			expect(skillContent).toMatch(/how many coders should run in parallel/i);
+			expect(skillContent).toMatch(/commit frequency/i);
 			expect(skillContent).toContain('INLINE GATE SELECTION');
 		});
 


### PR DESCRIPTION
## Summary
- Offer General Council advisory input in MODE: PLAN before `save_plan`, so current council findings can inform plan writing before critic review.
- Mirror the protocol across OpenCode/Claude plan, council, and specify skills and reconcile planning/council docs.
- Add regression coverage for the pre-plan council option ordering and architect prompt/skill extraction.

## Invariant audit
- 1 (plugin init): not touched - no init-path code changed; `bun run build` passed.
- 2 (runtime portability): not touched - no package entry/export or Bun-only import changes; `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` passed.
- 3 (subprocesses): not touched - no subprocess code changed.
- 4 (.swarm containment): not touched - no runtime state writer changed; council protocol records accepted advisory output under existing `.swarm/context.md`.
- 5 (plan durability): not touched - no plan ledger/schema/projection/import/export code changed.
- 6 (test_runner safety): not touched - validation used shell `bun` commands, not broad `test_runner` scopes.
- 7 (test writing): touched - writing-tests guidance was loaded; regression tests added/updated in plan protocol, plan funnel, and architect mode protocol coverage; focused `bun --smol test ...` passed with 163 tests and 516 expectations, and feedback follow-up validation passed with 65 tests and 305 expectations.
- 8 (session state): not touched - no session/global state code changed.
- 9 (guardrails/retry): not touched - no retry/guardrail logic changed.
- 10 (chat/system msg): not touched - no chat hook or system-message materialization code changed.
- 11 (tool registration): not touched - no tool exports, tool-name map, plugin registration, or agent tool maps changed.
- 12 (release/cache): touched - added `docs/releases/pending/pre-plan-general-council.md`; `git diff --cached -- package.json CHANGELOG.md .release-please-manifest.json` produced no output before the original push.

## Test plan
- [x] `bun run build`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `bun run typecheck`
- [x] `bunx biome ci .`
- [x] `bun --smol test tests\unit\skills\plan-protocol.test.ts tests\unit\skills\plan-funnel-verify.test.ts tests\unit\skills\architect-mode-protocols.test.ts tests\unit\agents\architect-prompt-markers.test.ts tests\unit\agents\architect-prompt-template.test.ts tests\unit\agents\architect-council-prompt.test.ts src\__tests__\convene-general-council.test.ts --timeout 60000`
- [x] `bun --smol test tests\unit\skills\plan-protocol.test.ts tests\unit\skills\plan-funnel-verify.test.ts tests\unit\skills\architect-mode-protocols.test.ts --timeout 60000`
- [x] `git diff --cached --check`
- [x] `git diff --check`
- [x] `rg --pcre2 "SPECIFY-COUNCIL-REVIEW|BRAINSTORM-only|moved to BRAINSTORM only|not in MODE: PLAN|only.*BRAINSTORM" src .opencode .claude docs tests` only found an unrelated BRAINSTORM prompt-stub comment in `tests/unit/agents/architect-brainstorm-gates.test.ts`.

## Feedback closure
- F-001: fixed - updated both specify skill mirrors so the unified exchange, behavioral guidance, and `.swarm/context.md` write condition consistently include auto_proceed as the fourth item.
- F-002: fixed - updated `docs/releases/pending/council-gate-overhaul.md` so the unified QA gate selection release note includes auto_proceed.
- F-003: pre-existing - brainstorm skill mirror/count drift exists outside PR #1419 and was not touched by this PR.
- F-004: pre-existing - PLAN fallback wording drift exists outside PR #1419 and was not touched by this PR.
- F-005: pre-existing/outside this patch - auto_proceed persistence concerns are in `src/state.ts`, which PR #1419 does not touch.
- F-006: pre-existing - `.swarm/context.md` trust-boundary pattern predates this PR.
- F-007: disproved as blocking - SC-001 remains in architect hard constraints and already covers human-input stops; no blocking defect found.
- PR-BODY-001: fixed - restored this PR body to the planning/General Council scope; the PRM/curator/learning issue closure body belongs to PR #1421.

## Notes
- This PR intentionally does not close #1410-#1415. Those are PRM/curator/learning issues and are represented by PR #1421.
- `src/__tests__/convene-general-council.test.ts` emitted sandboxed config-read warnings for `C:\Users\Brett\.config\opencode\opencode-swarm.json`; the tests passed.