### PR TITLE
fix(prm): harden trajectory, curator, and learning flows

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -48,7 +48,7 @@ Tasks: 3/5 complete
 Agents: 11 registered
 ```
 
-### `/swarm learning [--json] [--phase N]`
+### `/swarm learning [--json] [--phase N] [--timeout-ms N]`
 
 Show aggregate learning metrics computed from `.swarm/knowledge-events.jsonl` and the knowledge store:
 
@@ -65,6 +65,7 @@ A 3-line learning summary is automatically injected into the curator phase diges
 |------|--------|
 | `--json` | Output metrics as structured JSON in a `[LEARNING_JSON]...[/LEARNING_JSON]` envelope |
 | `--phase N` | Set the current phase number for never-applied threshold calculations |
+| `--timeout-ms N` | Bound metrics computation time; defaults to 30000 ms |
 
 ### `/swarm diagnose`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -305,16 +305,22 @@ Optional knowledge-base curator that validates agent output against project know
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enabled` | boolean | `false` | Master switch for Curator |
+| `enabled` | boolean | `true` | Master switch for Curator |
 | `init_enabled` | boolean | `true` | Run Curator at session start |
 | `phase_enabled` | boolean | `true` | Run Curator at phase boundaries |
+| `postmortem_enabled` | boolean | `true` | Run postmortem curator analysis during closeout |
 | `max_summary_tokens` | number | `2000` | Max tokens for Curator summary output |
 | `min_knowledge_confidence` | number | `0.7` | Minimum confidence threshold for knowledge entries |
 | `compliance_report` | boolean | `true` | Include compliance report in phase digest |
 | `suppress_warnings` | boolean | `true` | Suppress TUI warnings; emit events only |
 | `drift_inject_max_chars` | number | `500` | Max chars for drift report summary injected into architect context |
+| `llm_timeout_ms` | number | `300000` | Timeout for Curator init and phase LLM calls |
+| `skill_generation_enabled` | boolean | `true` | Enable curator-generated skill candidate output |
+| `skill_generation_mode` | `draft` \| `active` | `draft` | Controls whether skill candidates are drafted or promoted as active skills |
+| `min_skill_confidence` | number | `0.7` | Minimum confidence for generated skill candidates |
+| `min_skill_confirmations` | number | `2` | Minimum confirmations before skill promotion |
 
-Curator is optional and disabled by default. When enabled, it writes `.swarm/curator-summary.json` and `.swarm/drift-report-phase-N.json` to track knowledge alignment and drift detection.
+Curator is enabled by default. Set `curator.enabled = false` to disable it. When enabled, it writes `.swarm/curator-summary.json` and `.swarm/drift-report-phase-N.json` to track knowledge alignment and drift detection. Curator uses directory-level knowledge locking for cross-file updates; this favors simple atomic consistency over per-file parallelism.
 
 ### Architectural supervision
 

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -449,7 +449,8 @@ skill revision writes anything. Rejected candidates are recorded in the bounded
 
 When `curator.skill_generation_enabled` is true (default), the curator's
 phase analysis can emit `skill_candidates` and `knowledge_application_findings`
-JSON blocks that are parsed strictly. Malformed JSON is silently dropped.
+JSON blocks that are parsed strictly. Malformed JSON is skipped without writes
+and reported through debug-gated curator diagnostics.
 High-confidence candidates (>= `curator.min_skill_confidence`) trigger
 `skill_generate` in **draft** mode; activation always requires a human or
 architect to call `skill_apply`.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -290,7 +290,7 @@ The coder and reviewer agents automatically receive language-specific constraint
 
 ## Curator Integration
 
-The Curator is an optional background analysis system that provides phase-level intelligence across the project lifecycle. It is **disabled by default** — set `curator.enabled = true` in `.opencode/opencode-swarm.json` to activate it.
+The Curator is a background analysis system that provides phase-level intelligence across the project lifecycle. It is **enabled by default**; set `curator.enabled = false` in `.opencode/opencode-swarm.json` to disable it.
 
 ### How the Curator Hooks into Execution
 
@@ -367,7 +367,7 @@ interface DriftReport {
 
 | Field | Default | Effect |
 |-------|---------|--------|
-| `enabled` | `false` | Master switch — must be `true` for any Curator activity |
+| `enabled` | `true` | Master switch; set to `false` to disable Curator activity |
 | `init_enabled` | `true` | Run curator init on first phase |
 | `phase_enabled` | `true` | Run phase analysis + drift check after each phase |
 | `max_summary_tokens` | `2000` | Cap on curator summary size |

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -370,8 +370,14 @@ interface DriftReport {
 | `enabled` | `true` | Master switch; set to `false` to disable Curator activity |
 | `init_enabled` | `true` | Run curator init on first phase |
 | `phase_enabled` | `true` | Run phase analysis + drift check after each phase |
+| `postmortem_enabled` | `true` | Run curator postmortem analysis during closeout |
 | `max_summary_tokens` | `2000` | Cap on curator summary size |
 | `min_knowledge_confidence` | `0.7` | Minimum confidence for knowledge entry inclusion |
 | `drift_inject_max_chars` | `500` | Max chars of drift text injected into architect context |
+| `llm_timeout_ms` | `300000` | Timeout for curator init and phase LLM calls |
+| `skill_generation_enabled` | `true` | Enable curator-generated skill candidate output |
+| `skill_generation_mode` | `draft` | Write generated skill candidates as drafts by default |
+| `min_skill_confidence` | `0.7` | Minimum confidence for generated skill candidates |
+| `min_skill_confirmations` | `2` | Minimum confirmations before skill promotion |
 
 See the [Curator section in README.md](../README.md#curator) for full configuration details.

--- a/docs/releases/pending/1410-1415-prm-curator-learning-hardening.md
+++ b/docs/releases/pending/1410-1415-prm-curator-learning-hardening.md
@@ -1,0 +1,5 @@
+Fixes PRM trajectory durability, Curator recommendation retention, and `/swarm learning` timeout handling.
+
+- PRM session trajectories now update cache only after durable disk writes, refill cache from disk on cold reads, bound cached sessions, expose path helper coverage, and reset PRM/trajectory in-memory state during `/swarm reset-session` and close/reset flows.
+- Curator phase summaries now accumulate recommendations, cap retained phase digests, report malformed recommendation lines and structured JSON blocks through debug-gated logs, filter unknown knowledge IDs, and document current defaults/configuration.
+- `/swarm learning` now defaults to a 30 second timeout, supports `--timeout-ms`, passes cancellation into metrics computation, and returns structured timeout output for markdown and JSON modes.

--- a/docs/releases/pending/1410-1415-prm-curator-learning-hardening.md
+++ b/docs/releases/pending/1410-1415-prm-curator-learning-hardening.md
@@ -1,5 +1,7 @@
 Fixes PRM trajectory durability, Curator recommendation retention, and `/swarm learning` timeout handling.
 
 - PRM session trajectories now update cache only after durable disk writes, refill cache from disk on cold reads, bound cached sessions, expose path helper coverage, and reset PRM/trajectory in-memory state during `/swarm reset-session` and close/reset flows.
-- Curator phase summaries now accumulate recommendations, cap retained phase digests, report malformed recommendation lines and structured JSON blocks through debug-gated logs, filter unknown knowledge IDs, and document current defaults/configuration.
+- Curator phase summaries now accumulate recommendations, cap retained phase digests, compliance observations, and knowledge recommendations, report malformed recommendation lines and structured JSON blocks through debug-gated logs, filter unknown knowledge IDs, and document current defaults/configuration.
+- Existing projects with more than 50 stored phase digests will retain the most recent 50 the next time the curator writes `curator-summary.json`; older phase digests are intentionally dropped to bound summary size.
+- Curator gains config fields for `postmortem_enabled`, `min_skill_confidence`, and `min_skill_confirmations`.
 - `/swarm learning` now defaults to a 30 second timeout, supports `--timeout-ms`, passes cancellation into metrics computation, and returns structured timeout output for markdown and JSON modes.

--- a/src/commands/learning.ts
+++ b/src/commands/learning.ts
@@ -4,12 +4,71 @@ import {
 	formatLearningMarkdown,
 } from '../services/learning-metrics.js';
 
+const DEFAULT_LEARNING_TIMEOUT_MS = 30_000;
+const MAX_LEARNING_TIMEOUT_MS = 300_000;
+
+class LearningMetricsTimeoutError extends Error {
+	constructor(readonly timeoutMs: number) {
+		super(`Learning metrics timed out after ${timeoutMs}ms`);
+		this.name = 'LearningMetricsTimeoutError';
+	}
+}
+
+function parseTimeoutMs(args: string[]): number {
+	const timeoutIdx = args.indexOf('--timeout-ms');
+	if (timeoutIdx === -1 || timeoutIdx + 1 >= args.length) {
+		return DEFAULT_LEARNING_TIMEOUT_MS;
+	}
+	const parsed = Number(args[timeoutIdx + 1]);
+	if (
+		!Number.isInteger(parsed) ||
+		parsed < 1 ||
+		parsed > MAX_LEARNING_TIMEOUT_MS
+	) {
+		return DEFAULT_LEARNING_TIMEOUT_MS;
+	}
+	return parsed;
+}
+
+function timeoutMessage(timeoutMs: number): string {
+	return `LEARNING_METRICS_TIMEOUT: exceeded ${timeoutMs}ms while computing learning metrics. Run /swarm diagnose to check .swarm/ health.`;
+}
+
+async function computeWithTimeout(
+	directory: string,
+	currentPhase: number | undefined,
+	timeoutMs: number,
+) {
+	const controller = new AbortController();
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const metricsPromise = _internals.computeLearningMetrics(directory, {
+		currentPhase,
+		signal: controller.signal,
+	});
+	void metricsPromise.catch(() => {
+		/* handled by Promise.race or intentional timeout cancellation */
+	});
+	const timeoutPromise = new Promise<never>((_, reject) => {
+		timeout = setTimeout(() => {
+			reject(new LearningMetricsTimeoutError(timeoutMs));
+			controller.abort();
+		}, timeoutMs);
+	});
+
+	try {
+		return await Promise.race([metricsPromise, timeoutPromise]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}
+
 export async function handleLearningCommand(
 	directory: string,
 	args: string[],
 ): Promise<string> {
 	try {
 		const jsonMode = args.includes('--json');
+		const timeoutMs = parseTimeoutMs(args);
 
 		let currentPhase: number | undefined;
 		const phaseIdx = args.indexOf('--phase');
@@ -20,7 +79,11 @@ export async function handleLearningCommand(
 			}
 		}
 
-		const metrics = await computeLearningMetrics(directory, { currentPhase });
+		const metrics = await computeWithTimeout(
+			directory,
+			currentPhase,
+			timeoutMs,
+		);
 
 		if (jsonMode) {
 			return `[LEARNING_JSON]\n${JSON.stringify(formatLearningJSON(metrics), null, 2)}\n[/LEARNING_JSON]`;
@@ -28,7 +91,28 @@ export async function handleLearningCommand(
 
 		return formatLearningMarkdown(metrics);
 	} catch (err: unknown) {
+		if (err instanceof LearningMetricsTimeoutError) {
+			if (args.includes('--json')) {
+				return `[LEARNING_JSON]\n${JSON.stringify(
+					{
+						ok: false,
+						error: {
+							code: 'LEARNING_METRICS_TIMEOUT',
+							timeout_ms: err.timeoutMs,
+							message: timeoutMessage(err.timeoutMs),
+						},
+					},
+					null,
+					2,
+				)}\n[/LEARNING_JSON]`;
+			}
+			return timeoutMessage(err.timeoutMs);
+		}
 		const message = err instanceof Error ? err.message : String(err);
 		return `Error computing learning metrics: ${message}. Run /swarm diagnose to check .swarm/ health.`;
 	}
 }
+
+export const _internals = {
+	computeLearningMetrics,
+};

--- a/src/commands/reset-session.ts
+++ b/src/commands/reset-session.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { clearTrajectoryStep } from '../hooks/trajectory-logger';
 import { validateSwarmPath } from '../hooks/utils';
+import { resetPrmSessionState } from '../prm';
 import { swarmState } from '../state';
 
 /**
@@ -52,6 +54,10 @@ export async function handleResetSessionCommand(
 
 	// Clear in-memory agent sessions
 	const sessionCount = swarmState.agentSessions.size;
+	for (const [sessionId, session] of swarmState.agentSessions) {
+		resetPrmSessionState(session, sessionId);
+		clearTrajectoryStep(sessionId);
+	}
 	swarmState.agentSessions.clear();
 	results.push(`✅ Cleared ${sessionCount} in-memory agent session(s)`);
 

--- a/src/hooks/curator-types.ts
+++ b/src/hooks/curator-types.ts
@@ -11,13 +11,13 @@ export interface CuratorSummary {
 	session_id: string;
 	last_updated: string; // ISO 8601
 	last_phase_covered: number;
-	/** Running digest — extended each phase, never regenerated */
+	/** Running digest rebuilt from the capped phase_digests projection */
 	digest: string;
-	/** Phase-level digests for lookup */
+	/** Phase-level digests for lookup, capped to the most recent phases */
 	phase_digests: PhaseDigestEntry[];
 	/** Accumulated compliance observations */
 	compliance_observations: ComplianceObservation[];
-	/** Knowledge update recommendations from the last curator run */
+	/** Accumulated knowledge update recommendations from curator runs */
 	knowledge_recommendations: KnowledgeRecommendation[];
 }
 
@@ -113,12 +113,17 @@ export interface CuratorConfig {
 	enabled: boolean;
 	init_enabled: boolean;
 	phase_enabled: boolean;
+	postmortem_enabled?: boolean;
 	max_summary_tokens: number;
 	min_knowledge_confidence: number;
 	compliance_report: boolean;
 	suppress_warnings: boolean;
 	drift_inject_max_chars: number;
 	llm_timeout_ms?: number;
+	skill_generation_enabled?: boolean;
+	skill_generation_mode?: 'draft' | 'active';
+	min_skill_confidence?: number;
+	min_skill_confirmations?: number;
 }
 
 export interface CuratorInitResult {

--- a/src/hooks/curator.ts
+++ b/src/hooks/curator.ts
@@ -97,6 +97,7 @@ export type CuratorLLMDelegate = (
 /** Default timeout for curator LLM delegation calls (ms).
  * Used as fallback when config.llm_timeout_ms is not set. */
 const DEFAULT_CURATOR_LLM_TIMEOUT_MS = 300_000;
+const MAX_CURATOR_PHASE_DIGESTS = 50;
 
 // ============================================================================
 // DI Seam — _internals (declared before functions that use it to avoid TDZ)
@@ -104,6 +105,7 @@ const DEFAULT_CURATOR_LLM_TIMEOUT_MS = 300_000;
 
 export const _internals = {
 	parseKnowledgeRecommendations,
+	parseKnowledgeRecommendationsWithDiagnostics,
 	readCuratorSummary,
 	writeCuratorSummary,
 	filterPhaseEvents,
@@ -122,6 +124,22 @@ export const _internals = {
 	reviseSkill,
 	getSkillVersion,
 };
+
+export interface RecommendationParseDiagnostic {
+	section: 'OBSERVATIONS' | 'KNOWLEDGE_UPDATES';
+	line: string;
+	reason: string;
+}
+
+function capPhaseDigests(digests: PhaseDigestEntry[]): PhaseDigestEntry[] {
+	return digests.slice(-MAX_CURATOR_PHASE_DIGESTS);
+}
+
+function buildDigestFromPhaseDigests(digests: PhaseDigestEntry[]): string {
+	return digests
+		.map((digest) => `### Phase ${digest.phase}\n${digest.summary}`)
+		.join('\n\n');
+}
 
 /**
  * Auto-retire generated skills whose violation rate exceeds 30% or
@@ -221,7 +239,18 @@ async function autoRetireSkills(
 export function parseKnowledgeRecommendations(
 	llmOutput: string,
 ): KnowledgeRecommendation[] {
+	return parseKnowledgeRecommendationsWithDiagnostics(llmOutput)
+		.recommendations;
+}
+
+export function parseKnowledgeRecommendationsWithDiagnostics(
+	llmOutput: string,
+): {
+	recommendations: KnowledgeRecommendation[];
+	diagnostics: RecommendationParseDiagnostic[];
+} {
 	const recommendations: KnowledgeRecommendation[] = [];
+	const diagnostics: RecommendationParseDiagnostic[] = [];
 	const UUID_V4 =
 		/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -237,7 +266,14 @@ export function parseKnowledgeRecommendations(
 
 			// Match "- entry <uuid> (observable): text" or "- entry <uuid> (observable, directive hint): text"
 			const match = trimmed.match(/^-\s+entry\s+(\S+)\s+\(([^)]+)\):\s+(.+)$/i);
-			if (!match) continue;
+			if (!match) {
+				diagnostics.push({
+					section: 'OBSERVATIONS',
+					line: trimmed,
+					reason: 'expected "- entry <uuid|new> (<observable>): <text>"',
+				});
+				continue;
+			}
 
 			const uuid = match[1];
 			const parenthetical = match[2];
@@ -299,10 +335,24 @@ export function parseKnowledgeRecommendations(
 
 			// Match "- <action> <id>: <text>"
 			const match = trimmed.match(/^-\s+(\S+)\s+(\S+):\s+(.+)$/);
-			if (!match) continue;
+			if (!match) {
+				diagnostics.push({
+					section: 'KNOWLEDGE_UPDATES',
+					line: trimmed,
+					reason: 'expected "- <action> <id>: <text>"',
+				});
+				continue;
+			}
 
 			const action = match[1].toLowerCase();
-			if (!validActions.has(action)) continue;
+			if (!validActions.has(action)) {
+				diagnostics.push({
+					section: 'KNOWLEDGE_UPDATES',
+					line: trimmed,
+					reason: `unknown action "${action}"`,
+				});
+				continue;
+			}
 
 			const id = match[2];
 			const text = match[3].trim();
@@ -317,7 +367,7 @@ export function parseKnowledgeRecommendations(
 		}
 	}
 
-	return recommendations;
+	return { recommendations, diagnostics };
 }
 
 /**
@@ -333,30 +383,56 @@ export function parseKnowledgeRecommendations(
  * [{ "slug": "...", "title": "...", ... }]
  * ```
  *
- * Malformed JSON or unexpected types are silently dropped: no knowledge or
- * skill writes happen when curator output is malformed.
+ * Malformed JSON or unexpected types are skipped with diagnostics: no knowledge
+ * or skill writes happen when curator output is malformed.
  */
+export interface StructuredCuratorDiagnostic {
+	block: 'knowledge_application_findings' | 'skill_candidates';
+	reason:
+		| 'malformed_json'
+		| 'expected_array'
+		| 'invalid_finding'
+		| 'invalid_skill_candidate';
+	index?: number;
+	detail?: string;
+}
+
 export function parseStructuredCuratorBlocks(llmOutput: string): {
 	findings: import('./curator-types.js').KnowledgeApplicationFinding[];
 	candidates: import('./curator-types.js').SkillCandidate[];
+	diagnostics: StructuredCuratorDiagnostic[];
 } {
 	const out: {
 		findings: import('./curator-types.js').KnowledgeApplicationFinding[];
 		candidates: import('./curator-types.js').SkillCandidate[];
-	} = { findings: [], candidates: [] };
+		diagnostics: StructuredCuratorDiagnostic[];
+	} = { findings: [], candidates: [], diagnostics: [] };
 	if (!llmOutput || typeof llmOutput !== 'string') return out;
 
 	const fences =
 		/```(?:json|jsonc)?\s+(knowledge_application_findings|skill_candidates)\s*\n([\s\S]*?)\n```/g;
 	for (const m of llmOutput.matchAll(fences)) {
-		const kind = m[1];
+		const kind = m[1] as StructuredCuratorDiagnostic['block'];
 		const body = m[2];
 		try {
 			const parsed = JSON.parse(body);
-			if (!Array.isArray(parsed)) continue;
+			if (!Array.isArray(parsed)) {
+				out.diagnostics.push({
+					block: kind,
+					reason: 'expected_array',
+				});
+				continue;
+			}
 			if (kind === 'knowledge_application_findings') {
-				for (const item of parsed) {
-					if (!item || typeof item !== 'object') continue;
+				for (const [index, item] of parsed.entries()) {
+					if (!item || typeof item !== 'object') {
+						out.diagnostics.push({
+							block: kind,
+							reason: 'invalid_finding',
+							index,
+						});
+						continue;
+					}
 					const knowledge_id = (item as { knowledge_id?: unknown })
 						.knowledge_id;
 					const verdict = (item as { verdict?: unknown }).verdict;
@@ -367,6 +443,11 @@ export function parseStructuredCuratorBlocks(llmOutput: string): {
 							verdict,
 						)
 					) {
+						out.diagnostics.push({
+							block: kind,
+							reason: 'invalid_finding',
+							index,
+						});
 						continue;
 					}
 					const expected = String(
@@ -397,11 +478,25 @@ export function parseStructuredCuratorBlocks(llmOutput: string): {
 					});
 				}
 			} else if (kind === 'skill_candidates') {
-				for (const item of parsed) {
-					if (!item || typeof item !== 'object') continue;
+				for (const [index, item] of parsed.entries()) {
+					if (!item || typeof item !== 'object') {
+						out.diagnostics.push({
+							block: kind,
+							reason: 'invalid_skill_candidate',
+							index,
+						});
+						continue;
+					}
 					const slug = (item as { slug?: unknown }).slug;
 					const title = (item as { title?: unknown }).title;
-					if (typeof slug !== 'string' || typeof title !== 'string') continue;
+					if (typeof slug !== 'string' || typeof title !== 'string') {
+						out.diagnostics.push({
+							block: kind,
+							reason: 'invalid_skill_candidate',
+							index,
+						});
+						continue;
+					}
 					const ids = Array.isArray(
 						(item as { source_knowledge_ids?: unknown }).source_knowledge_ids,
 					)
@@ -413,7 +508,14 @@ export function parseStructuredCuratorBlocks(llmOutput: string): {
 								) as string[]
 							).slice(0, 50)
 						: [];
-					if (ids.length === 0) continue;
+					if (ids.length === 0) {
+						out.diagnostics.push({
+							block: kind,
+							reason: 'invalid_skill_candidate',
+							index,
+						});
+						continue;
+					}
 					out.candidates.push({
 						slug: String(slug).slice(0, 64),
 						title: String(title).slice(0, 200),
@@ -443,8 +545,12 @@ export function parseStructuredCuratorBlocks(llmOutput: string): {
 					});
 				}
 			}
-		} catch {
-			// malformed JSON — silently skip; never mutate knowledge from bad output.
+		} catch (err) {
+			out.diagnostics.push({
+				block: kind,
+				reason: 'malformed_json',
+				detail: err instanceof Error ? err.message.slice(0, 200) : String(err),
+			});
 		}
 	}
 	return out;
@@ -954,7 +1060,7 @@ export async function runCuratorPhase(
 	phase: number,
 	agentsDispatched: string[],
 	config: CuratorConfig,
-	_knowledgeConfig: { directory?: string },
+	knowledgeConfig: { directory?: string },
 	llmDelegate?: CuratorLLMDelegate,
 ): Promise<CuratorPhaseResult> {
 	try {
@@ -1048,9 +1154,11 @@ export async function runCuratorPhase(
 		// 6. LLM delegation: delegate to explorer agent in CURATOR_PHASE mode
 		// for knowledge recommendations and enhanced phase analysis
 		// Read current knowledge entries for curator review (capped to avoid context bloat)
-		const curatorKnowledgePath = resolveSwarmKnowledgePath(directory);
+		const knowledgeDirectory = knowledgeConfig.directory ?? directory;
+		const curatorKnowledgePath = resolveSwarmKnowledgePath(knowledgeDirectory);
 		const allKnowledgeEntries =
 			await readKnowledge<SwarmKnowledgeEntry>(curatorKnowledgePath);
+		const knownKnowledgeIds = new Set(allKnowledgeEntries.map((e) => e.id));
 		const knowledgeForCurator = [...allKnowledgeEntries]
 			.sort(
 				(a, b) =>
@@ -1113,9 +1221,43 @@ export async function runCuratorPhase(
 				}
 
 				if (llmOutput?.trim()) {
-					knowledgeRecommendations =
-						_internals.parseKnowledgeRecommendations(llmOutput);
+					const parsed =
+						_internals.parseKnowledgeRecommendationsWithDiagnostics(llmOutput);
+					for (const diagnostic of parsed.diagnostics) {
+						logger.warn('[curator] skipped malformed recommendation line', {
+							phase,
+							...diagnostic,
+						});
+					}
+					knowledgeRecommendations = parsed.recommendations.filter(
+						(recommendation) => {
+							if (
+								!recommendation.entry_id ||
+								knownKnowledgeIds.has(recommendation.entry_id)
+							) {
+								return true;
+							}
+							logger.warn(
+								'[curator] skipped recommendation for unknown knowledge entry',
+								{
+									phase,
+									entry_id: recommendation.entry_id,
+									action: recommendation.action,
+								},
+							);
+							return false;
+						},
+					);
 					const structured = parseStructuredCuratorBlocks(llmOutput);
+					for (const diagnostic of structured.diagnostics) {
+						logger.warn('[curator] skipped malformed structured block', {
+							phase,
+							block: diagnostic.block,
+							reason: diagnostic.reason,
+							index: diagnostic.index,
+							detail: diagnostic.detail,
+						});
+					}
 					knowledgeApplicationFindings = structured.findings;
 					skillCandidates = structured.candidates;
 				}
@@ -1144,29 +1286,35 @@ export async function runCuratorPhase(
 
 		let updatedSummary: CuratorSummary;
 		if (priorSummary) {
+			const phaseDigests = capPhaseDigests([
+				...priorSummary.phase_digests,
+				phaseDigest,
+			]);
 			// Extend existing summary
 			updatedSummary = {
 				...priorSummary,
 				last_updated: now,
 				last_phase_covered: Math.max(priorSummary.last_phase_covered, phase),
-				digest:
-					priorSummary.digest +
-					`\n\n### Phase ${phase}\n${phaseDigest.summary}`,
-				phase_digests: [...priorSummary.phase_digests, phaseDigest],
+				digest: buildDigestFromPhaseDigests(phaseDigests),
+				phase_digests: phaseDigests,
 				compliance_observations: [
 					...priorSummary.compliance_observations,
 					...complianceObservations,
 				],
-				knowledge_recommendations: knowledgeRecommendations,
+				knowledge_recommendations: [
+					...priorSummary.knowledge_recommendations,
+					...knowledgeRecommendations,
+				],
 			};
 		} else {
+			const phaseDigests = capPhaseDigests([phaseDigest]);
 			updatedSummary = {
 				schema_version: 1,
 				session_id: sessionId,
 				last_updated: now,
 				last_phase_covered: phase,
-				digest: `### Phase ${phase}\n${phaseDigest.summary}`,
-				phase_digests: [phaseDigest],
+				digest: buildDigestFromPhaseDigests(phaseDigests),
+				phase_digests: phaseDigests,
 				compliance_observations: complianceObservations,
 				knowledge_recommendations: knowledgeRecommendations,
 			};

--- a/src/hooks/curator.ts
+++ b/src/hooks/curator.ts
@@ -98,6 +98,8 @@ export type CuratorLLMDelegate = (
  * Used as fallback when config.llm_timeout_ms is not set. */
 const DEFAULT_CURATOR_LLM_TIMEOUT_MS = 300_000;
 const MAX_CURATOR_PHASE_DIGESTS = 50;
+const MAX_CURATOR_COMPLIANCE_OBSERVATIONS = 200;
+const MAX_CURATOR_RECOMMENDATIONS = 200;
 
 // ============================================================================
 // DI Seam — _internals (declared before functions that use it to avoid TDZ)
@@ -133,6 +135,18 @@ export interface RecommendationParseDiagnostic {
 
 function capPhaseDigests(digests: PhaseDigestEntry[]): PhaseDigestEntry[] {
 	return digests.slice(-MAX_CURATOR_PHASE_DIGESTS);
+}
+
+function capComplianceObservations(
+	observations: ComplianceObservation[],
+): ComplianceObservation[] {
+	return observations.slice(-MAX_CURATOR_COMPLIANCE_OBSERVATIONS);
+}
+
+function capKnowledgeRecommendations(
+	recommendations: KnowledgeRecommendation[],
+): KnowledgeRecommendation[] {
+	return recommendations.slice(-MAX_CURATOR_RECOMMENDATIONS);
 }
 
 function buildDigestFromPhaseDigests(digests: PhaseDigestEntry[]): string {
@@ -1297,14 +1311,14 @@ export async function runCuratorPhase(
 				last_phase_covered: Math.max(priorSummary.last_phase_covered, phase),
 				digest: buildDigestFromPhaseDigests(phaseDigests),
 				phase_digests: phaseDigests,
-				compliance_observations: [
+				compliance_observations: capComplianceObservations([
 					...priorSummary.compliance_observations,
 					...complianceObservations,
-				],
-				knowledge_recommendations: [
+				]),
+				knowledge_recommendations: capKnowledgeRecommendations([
 					...priorSummary.knowledge_recommendations,
 					...knowledgeRecommendations,
-				],
+				]),
 			};
 		} else {
 			const phaseDigests = capPhaseDigests([phaseDigest]);
@@ -1315,8 +1329,12 @@ export async function runCuratorPhase(
 				last_phase_covered: phase,
 				digest: buildDigestFromPhaseDigests(phaseDigests),
 				phase_digests: phaseDigests,
-				compliance_observations: complianceObservations,
-				knowledge_recommendations: knowledgeRecommendations,
+				compliance_observations: capComplianceObservations(
+					complianceObservations,
+				),
+				knowledge_recommendations: capKnowledgeRecommendations(
+					knowledgeRecommendations,
+				),
 			};
 		}
 

--- a/src/hooks/knowledge-curator.ts
+++ b/src/hooks/knowledge-curator.ts
@@ -1,5 +1,6 @@
 /** Knowledge curator hook for opencode-swarm v6.17 two-tier knowledge system. */
 
+import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
@@ -109,6 +110,10 @@ function recordSeenRetroSection(
 	capSeenRetroSections();
 }
 
+function hashContent(content: string): string {
+	return createHash('sha1').update(content).digest('hex');
+}
+
 // ============================================================================
 // Internal helpers (NOT exported)
 // ============================================================================
@@ -212,10 +217,9 @@ function extractRetrospectiveSection(planContent: string): string | null {
 
 /**
  * Check if the retrospective section has changed since last seen.
- * Uses a simple hash: section.length + ':' + section.slice(0, 100)
  */
 function checkRetroChanged(sessionID: string, section: string): boolean {
-	const hash = `${section.length}:${section.slice(0, 100)}`;
+	const hash = hashContent(section);
 	const lastSeen = seenRetroSections.get(sessionID);
 
 	if (lastSeen?.value === hash) {
@@ -1159,7 +1163,7 @@ export function createKnowledgeCuratorHook(
 			if (lessons.length === 0) return;
 
 			// Idempotency check for evidence
-			const evidenceHash = `${lessons.length}:${lessons.slice(0, 3).join('|')}`;
+			const evidenceHash = hashContent(JSON.stringify(lessons));
 			if (lastSeenEvidence?.value === evidenceHash) {
 				return; // no change
 			}
@@ -1248,6 +1252,7 @@ export const _internals: {
 	createKnowledgeCuratorHook: typeof createKnowledgeCuratorHook;
 	seenRetroSections: typeof seenRetroSections;
 	recordSeenRetroSection: typeof recordSeenRetroSection;
+	hashContent: typeof hashContent;
 	capSeenRetroSections: typeof capSeenRetroSections;
 	MAX_TRACKED_RETRO_SECTIONS: number;
 } = {
@@ -1257,6 +1262,7 @@ export const _internals: {
 	createKnowledgeCuratorHook,
 	seenRetroSections,
 	recordSeenRetroSection,
+	hashContent,
 	capSeenRetroSections,
 	MAX_TRACKED_RETRO_SECTIONS,
 };

--- a/src/hooks/trajectory-logger.ts
+++ b/src/hooks/trajectory-logger.ts
@@ -13,6 +13,11 @@ import * as path from 'node:path';
 import { sanitizeTaskId } from '../evidence/manager';
 import { appendTrajectoryEntry } from '../prm/trajectory-store';
 import { swarmState } from '../state';
+import {
+	clearTrajectoryStepCounters,
+	nextTrajectoryStep,
+	resetTrajectoryStepCounter,
+} from './trajectory-step-state.js';
 import { validateSwarmPath } from './utils';
 
 export interface TrajectoryConfig {
@@ -39,12 +44,6 @@ export interface TrajectoryEntry {
  * Populated by toolBefore (via recordToolCallStart), consumed by toolAfter.
  */
 const callStartTimes = new Map<string, number>();
-
-/**
- * Module-level map for tracking step counters per session.
- * Incremented on each tool call to provide sequential step numbers.
- */
-const sessionStepCounters = new Map<string, number>();
 
 /**
  * Sensitive field names to redact in args summaries.
@@ -315,9 +314,7 @@ export function createTrajectoryLoggerHook(
 			const verdict = deriveVerdict(output);
 
 			// Derive step counter for this session
-			const currentStep = sessionStepCounters.get(sessionId) ?? 0;
-			const step = currentStep + 1;
-			sessionStepCounters.set(sessionId, step);
+			const step = nextTrajectoryStep(sessionId);
 
 			// Derive action type from tool name
 			const action = deriveAction(input.tool);
@@ -381,7 +378,16 @@ export function createTrajectoryLoggerHook(
  * @param sessionId - Session identifier
  */
 export function resetTrajectoryStep(sessionId: string): void {
-	sessionStepCounters.set(sessionId, 0);
+	resetTrajectoryStepCounter(sessionId);
+}
+
+/**
+ * Clears trajectory step counters for one session, or all sessions when omitted.
+ *
+ * @param sessionId - Optional session identifier
+ */
+export function clearTrajectoryStep(sessionId?: string): void {
+	clearTrajectoryStepCounters(sessionId);
 }
 
 /**

--- a/src/hooks/trajectory-step-state.ts
+++ b/src/hooks/trajectory-step-state.ts
@@ -1,0 +1,24 @@
+/**
+ * Module-level trajectory step counters shared by runtime reset code and the
+ * trajectory logger without creating a state <-> hook import cycle.
+ */
+
+const sessionStepCounters = new Map<string, number>();
+
+export function nextTrajectoryStep(sessionId: string): number {
+	const step = (sessionStepCounters.get(sessionId) ?? 0) + 1;
+	sessionStepCounters.set(sessionId, step);
+	return step;
+}
+
+export function resetTrajectoryStepCounter(sessionId: string): void {
+	sessionStepCounters.set(sessionId, 0);
+}
+
+export function clearTrajectoryStepCounters(sessionId?: string): void {
+	if (sessionId !== undefined) {
+		sessionStepCounters.delete(sessionId);
+	} else {
+		sessionStepCounters.clear();
+	}
+}

--- a/src/hooks/trajectory-step-state.ts
+++ b/src/hooks/trajectory-step-state.ts
@@ -3,15 +3,27 @@
  * trajectory logger without creating a state <-> hook import cycle.
  */
 
+const MAX_TRACKED_STEP_SESSIONS = 500;
 const sessionStepCounters = new Map<string, number>();
 
+function evictOldestStepSessionIfNeeded(sessionId: string): void {
+	if (sessionStepCounters.has(sessionId)) return;
+	while (sessionStepCounters.size >= MAX_TRACKED_STEP_SESSIONS) {
+		const oldestSessionId = sessionStepCounters.keys().next().value;
+		if (oldestSessionId === undefined) break;
+		sessionStepCounters.delete(oldestSessionId);
+	}
+}
+
 export function nextTrajectoryStep(sessionId: string): number {
+	evictOldestStepSessionIfNeeded(sessionId);
 	const step = (sessionStepCounters.get(sessionId) ?? 0) + 1;
 	sessionStepCounters.set(sessionId, step);
 	return step;
 }
 
 export function resetTrajectoryStepCounter(sessionId: string): void {
+	evictOldestStepSessionIfNeeded(sessionId);
 	sessionStepCounters.set(sessionId, 0);
 }
 
@@ -22,3 +34,8 @@ export function clearTrajectoryStepCounters(sessionId?: string): void {
 		sessionStepCounters.clear();
 	}
 }
+
+export const _test_exports = {
+	MAX_TRACKED_STEP_SESSIONS,
+	getTrackedStepSessionCount: () => sessionStepCounters.size,
+};

--- a/src/prm/__tests__/escalation.test.ts
+++ b/src/prm/__tests__/escalation.test.ts
@@ -253,7 +253,7 @@ describe('EscalationTracker', () => {
 	});
 
 	describe('getState', () => {
-		test('returns reference to internal state (not a copy)', () => {
+		test('returns a defensive copy of internal state', () => {
 			const tracker = new EscalationTracker('session-1');
 			const match = createMockPatternMatch('repetition_loop');
 			tracker.recordDetection(match);
@@ -261,8 +261,22 @@ describe('EscalationTracker', () => {
 			const state1 = tracker.getState();
 			const state2 = tracker.getState();
 
-			expect(state1).toBe(state2); // Same reference
+			expect(state1).not.toBe(state2);
 			expect(state1.patternCounts.get('repetition_loop')).toBe(1);
+			state1.patternCounts.set('repetition_loop', 99);
+			state1.correctionsPending.push({
+				alert: 'mutated',
+				category: 'reasoning_error',
+				pattern: 'repetition_loop',
+				guidance: 'mutated',
+				action: 'mutated',
+				stepRange: [1, 1],
+				timestamp: new Date().toISOString(),
+			});
+
+			const freshState = tracker.getState();
+			expect(freshState.patternCounts.get('repetition_loop')).toBe(1);
+			expect(freshState.correctionsPending).toHaveLength(1);
 		});
 	});
 
@@ -339,16 +353,19 @@ describe('EscalationTracker', () => {
 			expect(tracker.getPendingCorrections()).toEqual([]);
 		});
 
-		test('returns reference to internal corrections array', () => {
+		test('returns defensive copies of internal corrections array', () => {
 			const tracker = new EscalationTracker('session-1');
 			const match = createMockPatternMatch('repetition_loop');
 			tracker.recordDetection(match);
 
 			const corrections = tracker.getPendingCorrections();
 			expect(corrections.length).toBe(1);
-			// Returns reference - mutations affect internal state
 			corrections.push({} as CourseCorrection);
-			expect(tracker.getPendingCorrections().length).toBe(2);
+			corrections[0].stepRange[0] = 99;
+
+			const freshCorrections = tracker.getPendingCorrections();
+			expect(freshCorrections.length).toBe(1);
+			expect(freshCorrections[0].stepRange[0]).not.toBe(99);
 		});
 	});
 

--- a/src/prm/__tests__/escalation.test.ts
+++ b/src/prm/__tests__/escalation.test.ts
@@ -264,6 +264,8 @@ describe('EscalationTracker', () => {
 			expect(state1).not.toBe(state2);
 			expect(state1.patternCounts.get('repetition_loop')).toBe(1);
 			state1.patternCounts.set('repetition_loop', 99);
+			state1.lastPatternDetected?.affectedAgents.push('mutated-agent');
+			state1.lastPatternDetected?.affectedTargets.push('mutated-target');
 			state1.correctionsPending.push({
 				alert: 'mutated',
 				category: 'reasoning_error',
@@ -276,6 +278,12 @@ describe('EscalationTracker', () => {
 
 			const freshState = tracker.getState();
 			expect(freshState.patternCounts.get('repetition_loop')).toBe(1);
+			expect(freshState.lastPatternDetected?.affectedAgents).toEqual([
+				'agent-a',
+			]);
+			expect(freshState.lastPatternDetected?.affectedTargets).toEqual([
+				'src/foo.ts',
+			]);
 			expect(freshState.correctionsPending).toHaveLength(1);
 		});
 	});

--- a/src/prm/__tests__/pattern-detector.test.ts
+++ b/src/prm/__tests__/pattern-detector.test.ts
@@ -11,6 +11,7 @@ import {
 	detectPingPong,
 	detectRepetitionLoop,
 	detectStuckOnTest,
+	sanitizeString,
 } from '../pattern-detector';
 import type { PrmConfig, TrajectoryEntry } from '../types';
 
@@ -236,6 +237,24 @@ describe('detectRepetitionLoop', () => {
 		const match = matches.find((m) => m.affectedTargets.includes('src/app.ts'));
 		expect(match).toBeDefined();
 		expect(match!.stepRange[0]).toBeLessThanOrEqual(match!.stepRange[1]);
+	});
+});
+
+describe('sanitizeString', () => {
+	test('removes newlines, backticks, and prompt-injection markers', () => {
+		const sanitized = sanitizeString(
+			'hello\n```ignore previous system prompt``` <script>alert(1)</script>',
+		);
+
+		expect(sanitized).not.toContain('\n');
+		expect(sanitized).not.toContain('```');
+		expect(sanitized).not.toContain('ignore previous');
+		expect(sanitized).not.toContain('<script>');
+	});
+
+	test('returns empty string for non-string inputs and truncates long strings', () => {
+		expect(sanitizeString(null as unknown as string)).toBe('');
+		expect(sanitizeString('a'.repeat(250))).toHaveLength(200);
 	});
 });
 

--- a/src/prm/__tests__/real-pipeline.test.ts
+++ b/src/prm/__tests__/real-pipeline.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	createTrajectoryLoggerHook,
+	recordToolCallStart,
+} from '../../hooks/trajectory-logger';
+import { resetSwarmState, swarmState } from '../../state';
+import { createPrmHook, _internals as prmInternals } from '../index';
+import {
+	clearTrajectoryCache,
+	getInMemoryTrajectory,
+	readTrajectory,
+} from '../trajectory-store';
+
+describe('PRM real trajectory pipeline', () => {
+	let tempDir: string;
+	const originalTelemetry = prmInternals.telemetry;
+
+	beforeEach(() => {
+		resetSwarmState();
+		clearTrajectoryCache();
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prm-real-pipeline-'));
+		fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+	});
+
+	afterEach(() => {
+		prmInternals.telemetry = originalTelemetry;
+		fs.rmSync(tempDir, { recursive: true, force: true });
+		clearTrajectoryCache();
+		resetSwarmState();
+	});
+
+	function seedSession(sessionId: string) {
+		const session = {
+			sessionID: sessionId,
+			agentName: 'coder',
+			delegationActive: true,
+			currentTaskId: '1.1',
+			pendingAdvisoryMessages: [] as string[],
+			prmPatternCounts: new Map(),
+			prmEscalationLevel: 0,
+			prmLastPatternDetected: null,
+			prmHardStopPending: false,
+			prmTrajectoryStep: 0,
+		};
+		swarmState.agentSessions.set(sessionId, session as never);
+		swarmState.activeAgent.set(sessionId, 'coder');
+		return session;
+	}
+
+	test('trajectory logger output feeds PRM cache, disk replay, and lastProcessedStep dedupe', async () => {
+		const sessionId = 'session-prm-real-pipeline';
+		prmInternals.telemetry = {
+			prmPatternDetected: () => {},
+			prmCourseCorrectionInjected: () => {},
+			prmEscalationTriggered: () => {},
+			prmHardStop: () => {},
+		} as typeof prmInternals.telemetry;
+		const session = seedSession(sessionId);
+
+		const trajectoryHook = createTrajectoryLoggerHook(
+			{ enabled: true, max_lines: 500 },
+			tempDir,
+		);
+		const prmHook = createPrmHook(
+			{
+				enabled: true,
+				pattern_thresholds: {
+					repetition_loop: 2,
+					ping_pong: 2,
+					expansion_drift: 3,
+					stuck_on_test: 3,
+					context_thrash: 3,
+				},
+				max_trajectory_lines: 500,
+				escalation_enabled: true,
+				detection_timeout_ms: 5000,
+			},
+			tempDir,
+		);
+
+		for (let i = 1; i <= 2; i++) {
+			recordToolCallStart(sessionId, `call-${i}`, Date.now() - 10);
+			await trajectoryHook.toolAfter(
+				{
+					tool: 'Edit',
+					sessionID: sessionId,
+					callID: `call-${i}`,
+					args: { filePath: 'src/repeated.ts' },
+				},
+				{
+					title: 'Edit Result',
+					output: 'ok',
+					metadata: { success: true },
+				},
+			);
+			await prmHook.toolAfter({ sessionID: sessionId });
+		}
+
+		expect(getInMemoryTrajectory(sessionId)).toHaveLength(2);
+		expect(await readTrajectory(sessionId, tempDir)).toHaveLength(2);
+		expect(session.pendingAdvisoryMessages).toHaveLength(1);
+		expect(session.replayArtifactPath).toContain(
+			path.join('.swarm', 'replays'),
+		);
+
+		const advisoriesBefore = session.pendingAdvisoryMessages.length;
+		await prmHook.toolAfter({ sessionID: sessionId });
+		expect(session.pendingAdvisoryMessages).toHaveLength(advisoriesBefore);
+
+		session.pendingAdvisoryMessages = [];
+		session.prmTrajectoryStep = 0;
+		clearTrajectoryCache(sessionId);
+		await prmHook.toolAfter({ sessionID: sessionId });
+		expect(getInMemoryTrajectory(sessionId)).toHaveLength(2);
+		expect(session.pendingAdvisoryMessages).toHaveLength(1);
+	});
+
+	test('resetSwarmState clears PRM trajectory cache and trajectory step counters', async () => {
+		const sessionId = 'session-prm-reset-pipeline';
+		const trajectoryHook = createTrajectoryLoggerHook(
+			{ enabled: true, max_lines: 500 },
+			tempDir,
+		);
+
+		seedSession(sessionId);
+		recordToolCallStart(sessionId, 'call-before-reset', Date.now() - 10);
+		await trajectoryHook.toolAfter(
+			{
+				tool: 'Edit',
+				sessionID: sessionId,
+				callID: 'call-before-reset',
+				args: { filePath: 'src/repeated.ts' },
+			},
+			{
+				title: 'Edit Result',
+				output: 'ok',
+				metadata: { success: true },
+			},
+		);
+		expect(getInMemoryTrajectory(sessionId)).toHaveLength(1);
+
+		resetSwarmState();
+		expect(getInMemoryTrajectory(sessionId)).toEqual([]);
+
+		seedSession(sessionId);
+		recordToolCallStart(sessionId, 'call-after-reset', Date.now() - 10);
+		await trajectoryHook.toolAfter(
+			{
+				tool: 'Edit',
+				sessionID: sessionId,
+				callID: 'call-after-reset',
+				args: { filePath: 'src/repeated.ts' },
+			},
+			{
+				title: 'Edit Result',
+				output: 'ok',
+				metadata: { success: true },
+			},
+		);
+
+		const entries = await readTrajectory(sessionId, tempDir);
+		expect(entries.map((entry) => entry.step)).toEqual([1, 1]);
+	});
+});

--- a/src/prm/__tests__/replay.test.ts
+++ b/src/prm/__tests__/replay.test.ts
@@ -1,13 +1,19 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
 import { promises as fs } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import type { ReplayEntry } from '../replay';
-import { recordReplayEntry, startReplayRecording } from '../replay';
+import {
+	_test_exports,
+	recordReplayEntry,
+	startReplayRecording,
+} from '../replay';
 
 describe('startReplayRecording', () => {
-	const directory = '/test/project';
+	let directory: string;
 
 	beforeEach(async () => {
+		directory = await fs.mkdtemp(path.join(os.tmpdir(), 'prm-replay-'));
 		// Clean up any test directories
 		const replayDir = path.join(directory, '.swarm', 'replays');
 		try {
@@ -18,13 +24,7 @@ describe('startReplayRecording', () => {
 	});
 
 	afterEach(async () => {
-		// Clean up test directories
-		const replayDir = path.join(directory, '.swarm', 'replays');
-		try {
-			await fs.rm(replayDir, { recursive: true, force: true });
-		} catch {
-			// ignore
-		}
+		await fs.rm(directory, { recursive: true, force: true });
 	});
 
 	test('creates replay directory if it does not exist', async () => {
@@ -79,10 +79,11 @@ describe('startReplayRecording', () => {
 });
 
 describe('recordReplayEntry', () => {
-	const directory = '/test/project';
+	let directory: string;
 	let artifactPath: string;
 
 	beforeEach(async () => {
+		directory = await fs.mkdtemp(path.join(os.tmpdir(), 'prm-replay-'));
 		// Create a test directory and get artifact path
 		const replayDir = path.join(directory, '.swarm', 'replays');
 		try {
@@ -95,13 +96,7 @@ describe('recordReplayEntry', () => {
 	});
 
 	afterEach(async () => {
-		// Clean up test directories
-		const replayDir = path.join(directory, '.swarm', 'replays');
-		try {
-			await fs.rm(replayDir, { recursive: true, force: true });
-		} catch {
-			// ignore
-		}
+		await fs.rm(directory, { recursive: true, force: true });
 	});
 
 	test('appends entry to replay artifact file', async () => {
@@ -173,10 +168,24 @@ describe('recordReplayEntry', () => {
 });
 
 describe('sanitizeFilename', () => {
+	let directory: string;
+
+	beforeEach(async () => {
+		directory = await fs.mkdtemp(path.join(os.tmpdir(), 'prm-replay-'));
+	});
+
+	afterEach(async () => {
+		await fs.rm(directory, { recursive: true, force: true });
+	});
+
+	test('directly sanitizes unsafe filename characters', () => {
+		expect(_test_exports.sanitizeFilename('../a b:c')).toBe('___a_b_c');
+	});
+
 	test('allows alphanumeric, underscore, and hyphen', async () => {
 		const artifactPath = await startReplayRecording(
 			'test_session-123',
-			'/test',
+			directory,
 		);
 		expect(artifactPath).not.toBeNull();
 		expect(artifactPath).toContain('test_session-123');
@@ -185,7 +194,7 @@ describe('sanitizeFilename', () => {
 	test('replaces special characters with underscore', async () => {
 		const artifactPath = await startReplayRecording(
 			'test@session#123',
-			'/test',
+			directory,
 		);
 		expect(artifactPath).not.toBeNull();
 		expect(artifactPath).toContain('test_session_123');
@@ -194,16 +203,41 @@ describe('sanitizeFilename', () => {
 	test('replaces spaces with underscore', async () => {
 		const artifactPath = await startReplayRecording(
 			'test session 123',
-			'/test',
+			directory,
 		);
 		expect(artifactPath).not.toBeNull();
 		expect(artifactPath).toContain('test_session_123');
 	});
 
 	test('handles unicode characters', async () => {
-		const artifactPath = await startReplayRecording('sessão-teste', '/test');
+		const artifactPath = await startReplayRecording('sessão-teste', directory);
 		expect(artifactPath).not.toBeNull();
 		// 'ã' is outside a-zA-Z0-9_- so it becomes underscore, but '-' is preserved
 		expect(artifactPath).toContain('sess_o-teste');
+	});
+});
+
+describe('replay path guards', () => {
+	test('isPathSafe rejects traversal outside the base directory', () => {
+		const base = path.join('/workspace', '.swarm', 'replays');
+		expect(_test_exports.isPathSafe(path.join(base, 'ok.jsonl'), base)).toBe(
+			true,
+		);
+		expect(
+			_test_exports.isPathSafe(path.join(base, '..', 'x.jsonl'), base),
+		).toBe(false);
+	});
+
+	test('isWithinReplaysDir requires a .swarm/replays path segment', () => {
+		expect(
+			_test_exports.isWithinReplaysDir(
+				path.join('/workspace', '.swarm', 'replays', 'a.jsonl'),
+			),
+		).toBe(true);
+		expect(
+			_test_exports.isWithinReplaysDir(
+				path.join('/workspace', '.swarm', 'not-replays', 'a.jsonl'),
+			),
+		).toBe(false);
 	});
 });

--- a/src/prm/__tests__/trajectory-store.test.ts
+++ b/src/prm/__tests__/trajectory-store.test.ts
@@ -11,9 +11,12 @@ import os from 'node:os';
 import path from 'node:path';
 
 import {
+	_test_exports,
 	appendTrajectoryEntry,
+	cleanupOldTrajectoryFiles,
 	clearTrajectoryCache,
 	getCurrentStep,
+	getInMemoryTrajectory,
 	getTrajectoryForSession,
 	readTrajectory,
 	truncateTrajectoryIfNeeded,
@@ -145,6 +148,26 @@ describe('trajectory-store', () => {
 				appendTrajectoryEntry(sessionId, createEntry(1), ''),
 			).resolves.toBeUndefined();
 		});
+
+		test('does not update cache when disk append fails', async () => {
+			const sessionId = 'test-session-cache-fail';
+
+			await appendTrajectoryEntry(sessionId, createEntry(1), '/invalid\0path');
+
+			expect(getInMemoryTrajectory(sessionId)).toEqual([]);
+		});
+
+		test('bounds tracked cached sessions with FIFO eviction', async () => {
+			const maxSessions = _test_exports.MAX_TRACKED_TRAJECTORY_SESSIONS;
+
+			for (let i = 0; i <= maxSessions; i++) {
+				await appendTrajectoryEntry(`session-${i}`, createEntry(1), tempDir);
+			}
+
+			expect(getInMemoryTrajectory('session-0')).toEqual([]);
+			expect(getInMemoryTrajectory('session-1')).toHaveLength(1);
+			expect(getInMemoryTrajectory(`session-${maxSessions}`)).toHaveLength(1);
+		});
 	});
 
 	// =========================================================================
@@ -237,6 +260,27 @@ describe('trajectory-store', () => {
 
 			const entries = await readTrajectory(sessionId, tempDir);
 			expect(entries).toEqual([]);
+		});
+
+		test('populates cache from disk on cold read', async () => {
+			const sessionId = 'test-session-cold-read';
+			await appendTrajectoryEntry(sessionId, createEntry(1), tempDir);
+			clearTrajectoryCache(sessionId);
+
+			const entries = await readTrajectory(sessionId, tempDir);
+
+			expect(entries).toHaveLength(1);
+			expect(getInMemoryTrajectory(sessionId)).toHaveLength(1);
+		});
+
+		test('getInMemoryTrajectory returns a defensive array copy', async () => {
+			const sessionId = 'test-session-cache-copy';
+			await appendTrajectoryEntry(sessionId, createEntry(1), tempDir);
+
+			const cached = getInMemoryTrajectory(sessionId);
+			cached.push(createEntry(2));
+
+			expect(getInMemoryTrajectory(sessionId)).toHaveLength(1);
 		});
 	});
 
@@ -446,6 +490,40 @@ describe('trajectory-store', () => {
 			await expect(readTrajectory('../traversal', tempDir)).resolves.toEqual(
 				[],
 			);
+		});
+	});
+
+	describe('cleanupOldTrajectoryFiles', () => {
+		test('removes old trajectory and replay files and keeps fresh files', async () => {
+			const trajectoriesDir = path.join(tempDir, '.swarm', 'trajectories');
+			const replaysDir = path.join(tempDir, '.swarm', 'replays');
+			fs.mkdirSync(trajectoriesDir, { recursive: true });
+			fs.mkdirSync(replaysDir, { recursive: true });
+			const oldTrajectory = path.join(trajectoriesDir, 'old.jsonl');
+			const freshTrajectory = path.join(trajectoriesDir, 'fresh.jsonl');
+			const oldReplay = path.join(replaysDir, 'old.jsonl');
+			const freshReplay = path.join(replaysDir, 'fresh.jsonl');
+			for (const file of [
+				oldTrajectory,
+				freshTrajectory,
+				oldReplay,
+				freshReplay,
+			]) {
+				fs.writeFileSync(file, '{}\n');
+			}
+			const old = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+			const fresh = new Date();
+			fs.utimesSync(oldTrajectory, old, old);
+			fs.utimesSync(oldReplay, old, old);
+			fs.utimesSync(freshTrajectory, fresh, fresh);
+			fs.utimesSync(freshReplay, fresh, fresh);
+
+			await cleanupOldTrajectoryFiles(tempDir, 7);
+
+			expect(fs.existsSync(oldTrajectory)).toBe(false);
+			expect(fs.existsSync(oldReplay)).toBe(false);
+			expect(fs.existsSync(freshTrajectory)).toBe(true);
+			expect(fs.existsSync(freshReplay)).toBe(true);
 		});
 	});
 

--- a/src/prm/escalation.ts
+++ b/src/prm/escalation.ts
@@ -27,6 +27,33 @@ export function createDefaultEscalationState(): EscalationState {
 	};
 }
 
+function cloneCourseCorrection(correction: CourseCorrection): CourseCorrection {
+	return {
+		...correction,
+		stepRange: [...correction.stepRange] as [number, number],
+	};
+}
+
+function cloneEscalationState(state: EscalationState): EscalationState {
+	return {
+		patternCounts: new Map(state.patternCounts),
+		escalationLevel: state.escalationLevel,
+		lastPatternDetected: state.lastPatternDetected
+			? {
+					...state.lastPatternDetected,
+					stepRange: [...state.lastPatternDetected.stepRange] as [
+						number,
+						number,
+					],
+					affectedAgents: [...state.lastPatternDetected.affectedAgents],
+					affectedTargets: [...state.lastPatternDetected.affectedTargets],
+				}
+			: null,
+		hardStopPending: state.hardStopPending,
+		correctionsPending: state.correctionsPending.map(cloneCourseCorrection),
+	};
+}
+
 /**
  * Generates a CourseCorrection from a PatternMatch.
  * Uses simple templates based on pattern type and escalation level.
@@ -182,12 +209,12 @@ export class EscalationTracker {
 	}
 
 	/**
-	 * Returns the current escalation state.
+	 * Returns a defensive copy of the current escalation state.
 	 *
-	 * @returns The current EscalationState (reference, not a copy)
+	 * @returns The current EscalationState copy
 	 */
 	getState(): EscalationState {
-		return this._state;
+		return cloneEscalationState(this._state);
 	}
 
 	/**
@@ -199,12 +226,12 @@ export class EscalationTracker {
 	}
 
 	/**
-	 * Returns all pending course corrections.
+	 * Returns defensive copies of all pending course corrections.
 	 *
 	 * @returns Array of pending CourseCorrection objects
 	 */
 	getPendingCorrections(): CourseCorrection[] {
-		return this._state.correctionsPending;
+		return this._state.correctionsPending.map(cloneCourseCorrection);
 	}
 
 	/**

--- a/src/prm/index.ts
+++ b/src/prm/index.ts
@@ -53,6 +53,7 @@ import { detectPatterns } from './pattern-detector';
 import { recordReplayEntry, startReplayRecording } from './replay';
 import {
 	cleanupOldTrajectoryFiles,
+	clearTrajectoryCache,
 	getInMemoryTrajectory,
 	readTrajectory,
 } from './trajectory-store';
@@ -74,6 +75,7 @@ export const _internals: {
 	generateCourseCorrection: typeof generateCourseCorrection;
 	formatCourseCorrectionForInjection: typeof formatCourseCorrectionForInjection;
 	cleanupOldTrajectoryFiles: typeof cleanupOldTrajectoryFiles;
+	clearTrajectoryCache: typeof clearTrajectoryCache;
 	recordReplayEntry: typeof recordReplayEntry;
 	startReplayRecording: typeof startReplayRecording;
 	telemetry: typeof telemetry;
@@ -85,6 +87,7 @@ export const _internals: {
 	generateCourseCorrection,
 	formatCourseCorrectionForInjection,
 	cleanupOldTrajectoryFiles,
+	clearTrajectoryCache,
 	recordReplayEntry,
 	startReplayRecording,
 	telemetry,
@@ -117,6 +120,35 @@ interface SessionPrmState {
 	prmInitialized?: boolean;
 	/** Replay artifact path for this session */
 	replayArtifactPath?: string | null;
+}
+
+interface ResettablePrmSessionState {
+	prmEscalationTracker?: EscalationTracker;
+	prmInitialized?: boolean;
+	prmPatternCounts?: Map<string, number>;
+	prmEscalationLevel?: number;
+	prmLastPatternDetected?: unknown;
+	prmHardStopPending?: boolean;
+	prmTrajectoryStep?: number;
+	replayArtifactPath?: string | null;
+}
+
+export function resetPrmSessionState(
+	session: ResettablePrmSessionState,
+	sessionId?: string,
+): void {
+	session.prmEscalationTracker = undefined;
+	session.prmInitialized = false;
+	session.prmPatternCounts = new Map();
+	session.prmEscalationLevel = 0;
+	session.prmLastPatternDetected = null;
+	session.prmHardStopPending = false;
+	session.prmTrajectoryStep = 0;
+	session.replayArtifactPath = null;
+
+	if (sessionId) {
+		_internals.clearTrajectoryCache(sessionId);
+	}
 }
 
 /**
@@ -248,9 +280,6 @@ export function createPrmHook(config: PrmConfig, directory: string): PrmHook {
 					hardStopPending = escalationResult.hardStop;
 				}
 
-				// Clear the corrections queue after injection to prevent unbounded growth
-				escalationTracker.clearPendingCorrections();
-
 				// Update session PRM state fields
 				session.prmPatternCounts.set(
 					match.pattern,
@@ -309,6 +338,10 @@ export function createPrmHook(config: PrmConfig, directory: string): PrmHook {
 					});
 				}
 			}
+
+			// Clear the corrections queue after all matches are injected so a batch
+			// cannot discard later matches before session state has observed them.
+			escalationTracker.clearPendingCorrections();
 
 			// Record escalation level change for replay (non-blocking, serialized)
 			if (

--- a/src/prm/pattern-detector.ts
+++ b/src/prm/pattern-detector.ts
@@ -53,6 +53,9 @@ export function sanitizeString(input: string): string {
 	// Remove backticks to prevent template literal injection
 	result = result.replace(/`/g, '');
 
+	// Remove HTML/script-style tags from prompt-bound diagnostic text
+	result = result.replace(/<[^>]*>/g, '');
+
 	// Remove prompt injection patterns
 	for (const pattern of INJECTION_PATTERNS) {
 		result = result.replace(pattern, '[REDACTED]');

--- a/src/prm/replay.ts
+++ b/src/prm/replay.ts
@@ -159,3 +159,9 @@ export async function recordReplayEntry(
 		console.warn(`[replay] Failed to record entry: ${err}`);
 	}
 }
+
+export const _test_exports = {
+	isPathSafe,
+	isWithinReplaysDir,
+	sanitizeFilename,
+} as const;

--- a/src/prm/trajectory-store.ts
+++ b/src/prm/trajectory-store.ts
@@ -13,6 +13,8 @@ import * as path from 'node:path';
 import { validateSwarmPath } from '../hooks/utils';
 import type { TrajectoryEntry } from './types';
 
+const MAX_TRACKED_TRAJECTORY_SESSIONS = 500;
+
 /**
  * Builds the validated absolute path to a session's trajectory file.
  */
@@ -25,6 +27,27 @@ function getTrajectoryPath(sessionId: string, directory: string): string {
 // Populated on write by appendTrajectoryEntry, used by pattern detection.
 // Eliminates full disk reads on every toolAfter call.
 const _inMemoryTrajectoryCache = new Map<string, TrajectoryEntry[]>();
+
+function setTrajectoryCache(
+	sessionId: string,
+	entries: TrajectoryEntry[],
+	maxLines: number = 1000,
+): void {
+	const boundedEntries =
+		entries.length > maxLines
+			? entries.slice(-Math.max(1, Math.floor(maxLines / 2)))
+			: [...entries];
+
+	if (!_inMemoryTrajectoryCache.has(sessionId)) {
+		while (_inMemoryTrajectoryCache.size >= MAX_TRACKED_TRAJECTORY_SESSIONS) {
+			const oldestSessionId = _inMemoryTrajectoryCache.keys().next().value;
+			if (oldestSessionId === undefined) break;
+			_inMemoryTrajectoryCache.delete(oldestSessionId);
+		}
+	}
+
+	_inMemoryTrajectoryCache.set(sessionId, boundedEntries);
+}
 
 /**
  * Returns cached trajectory entries for a session (empty array if not cached).
@@ -60,23 +83,15 @@ export async function appendTrajectoryEntry(
 	maxLines: number = 1000,
 ): Promise<void> {
 	try {
-		// 1. Update in-memory cache (always)
-		const cached = _inMemoryTrajectoryCache.get(sessionId) ?? [];
-		cached.push(entry);
-
-		// Keep in-memory cache bounded
-		if (cached.length > maxLines) {
-			const keepCount = Math.max(1, Math.floor(maxLines / 2));
-			_inMemoryTrajectoryCache.set(sessionId, cached.slice(-keepCount));
-		} else {
-			_inMemoryTrajectoryCache.set(sessionId, cached);
-		}
-
-		// 2. Append to disk (best-effort, no truncation read)
+		// Append to disk before updating cache so failed writes cannot create
+		// memory-only trajectory state that PRM later treats as durable.
 		const trajectoryPath = getTrajectoryPath(sessionId, directory);
 		await fs.mkdir(path.dirname(trajectoryPath), { recursive: true });
 		const line = `${JSON.stringify(entry)}\n`;
 		await fs.appendFile(trajectoryPath, line, 'utf-8');
+
+		const cached = _inMemoryTrajectoryCache.get(sessionId) ?? [];
+		setTrajectoryCache(sessionId, [...cached, entry], maxLines);
 	} catch (err) {
 		// Non-blocking: swallow errors to prevent PRM from breaking main flow
 		console.warn(
@@ -110,6 +125,7 @@ export async function readTrajectory(
 				// Skip malformed JSON lines
 			}
 		}
+		setTrajectoryCache(sessionId, entries);
 		return entries;
 	} catch (err) {
 		// File doesn't exist or read error - return empty array
@@ -120,6 +136,10 @@ export async function readTrajectory(
 		return [];
 	}
 }
+
+export const _test_exports = {
+	MAX_TRACKED_TRAJECTORY_SESSIONS,
+} as const;
 
 /**
  * Alias for readTrajectory - retrieves trajectory entries for a session.

--- a/src/services/learning-metrics.ts
+++ b/src/services/learning-metrics.ts
@@ -58,11 +58,22 @@ export interface NeverAppliedEntry {
 	phasesAlive: number;
 }
 
+export interface LearningMetricsOptions {
+	now?: Date;
+	currentPhase?: number;
+	signal?: AbortSignal;
+}
+
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const DEFAULT_PHASES_ALIVE_THRESHOLD = 3;
 const MAX_LESSON_DISPLAY_CHARS = 60;
+
+function throwIfAborted(signal?: AbortSignal): void {
+	if (!signal?.aborted) return;
+	throw new Error('Learning metrics computation aborted');
+}
 
 function safeDivide(numerator: number, denominator: number): number {
 	return denominator === 0 ? 0 : numerator / denominator;
@@ -136,8 +147,9 @@ function classifyROI(rollup: CounterRollup): EntryROI['roi'] {
 
 export async function computeLearningMetrics(
 	directory: string,
-	options?: { now?: Date; currentPhase?: number },
+	options?: LearningMetricsOptions,
 ): Promise<LearningMetrics> {
+	throwIfAborted(options?.signal);
 	const now = options?.now ?? new Date();
 	const nowMs = now.getTime();
 	const phasesThreshold =
@@ -148,6 +160,7 @@ export async function computeLearningMetrics(
 		readKnowledge<SwarmKnowledgeEntry>(resolveSwarmKnowledgePath(directory)),
 		readKnowledgeCounterRollups(directory),
 	]);
+	throwIfAborted(options?.signal);
 
 	if (events.length === 0 && entries.length === 0) {
 		return emptyMetrics();
@@ -155,11 +168,13 @@ export async function computeLearningMetrics(
 
 	const entryMap = new Map<string, SwarmKnowledgeEntry>();
 	for (const entry of entries) {
+		throwIfAborted(options?.signal);
 		entryMap.set(entry.id, entry);
 	}
 
 	const sessionIds = new Set<string>();
 	for (const e of events) {
+		throwIfAborted(options?.signal);
 		if ('session_id' in e && typeof e.session_id === 'string') {
 			sessionIds.add(e.session_id);
 		}
@@ -169,6 +184,7 @@ export async function computeLearningMetrics(
 	// Violation trends
 	const violationTrends: ViolationTrend[] = [];
 	for (const [entryId, rollup] of rollups) {
+		throwIfAborted(options?.signal);
 		if (rollup.violated_count === 0) continue;
 		const entry = entryMap.get(entryId);
 		const lesson = entry?.lesson ?? entryId;
@@ -197,6 +213,7 @@ export async function computeLearningMetrics(
 	let totalViolations30d = 0;
 	let totalReceipts30d = 0;
 	for (const e of events) {
+		throwIfAborted(options?.signal);
 		if (!isReceiptType(e)) continue;
 		const t = Date.parse(e.timestamp);
 		if (Number.isNaN(t)) continue;
@@ -217,6 +234,7 @@ export async function computeLearningMetrics(
 	// Application rate by priority
 	const priorityGroups = new Map<string, { applied: number; total: number }>();
 	for (const entry of entries) {
+		throwIfAborted(options?.signal);
 		const priority = entry.directive_priority ?? 'medium';
 		const rollup = rollups.get(entry.id);
 		if (!rollup) continue;
@@ -265,6 +283,7 @@ export async function computeLearningMetrics(
 
 	// Escalation frequency
 	const recentEscalations30d = await readRecentEscalations(directory, 30, now);
+	throwIfAborted(options?.signal);
 	const last7dCutoff = nowMs - SEVEN_DAYS_MS;
 	const last7d = recentEscalations30d.filter((esc) => {
 		const t = Date.parse(esc.at);
@@ -272,6 +291,7 @@ export async function computeLearningMetrics(
 	}).length;
 	let totalEscalations = 0;
 	for (const e of events) {
+		throwIfAborted(options?.signal);
 		if (e.type === 'escalation') totalEscalations++;
 	}
 	const escalationFrequency = {
@@ -283,6 +303,7 @@ export async function computeLearningMetrics(
 	// Unacknowledged critical
 	let unacknowledgedCriticalCount = 0;
 	for (const entry of entries) {
+		throwIfAborted(options?.signal);
 		if (entry.directive_priority !== 'critical') continue;
 		const rollup = rollups.get(entry.id);
 		if (!rollup) continue;
@@ -298,6 +319,7 @@ export async function computeLearningMetrics(
 	// Entry ROI
 	const entryROI: EntryROI[] = [];
 	for (const entry of entries) {
+		throwIfAborted(options?.signal);
 		const rollup = rollups.get(entry.id);
 		if (!rollup) {
 			entryROI.push({
@@ -325,6 +347,7 @@ export async function computeLearningMetrics(
 	// Never applied
 	const neverApplied: NeverAppliedEntry[] = [];
 	for (const entry of entries) {
+		throwIfAborted(options?.signal);
 		const rollup = rollups.get(entry.id);
 		const applied = rollup?.applied_explicit_count ?? 0;
 		const phasesAlive = entry.phases_alive ?? 0;

--- a/src/state.ts
+++ b/src/state.ts
@@ -33,9 +33,11 @@ import {
 	clearPendingCoderScope,
 	resetStandardWorktreeIsolationState,
 } from './hooks/delegation-gate.js';
+import { clearTrajectoryStepCounters } from './hooks/trajectory-step-state.js';
 import { loadPlanJsonOnly, updateTaskStatus } from './plan/manager.js';
 import { derivePlanId } from './plan/utils.js';
 import type { EscalationTracker } from './prm/escalation.js';
+import { clearTrajectoryCache } from './prm/trajectory-store.js';
 import type { PatternMatch } from './prm/types.js';
 import { AgentRunContext } from './state/agent-run-context.js';
 import { telemetry } from './telemetry.js';
@@ -498,6 +500,8 @@ export function resetSwarmState(): void {
 	swarmState.pendingEvents = 0;
 	swarmState.lastBudgetPct = 0;
 	swarmState.agentSessions.clear();
+	clearTrajectoryCache();
+	clearTrajectoryStepCounters();
 	swarmState.pendingRehydrations.clear();
 	swarmState.opencodeClient = null;
 	swarmState.curatorInitAgentNames = [];

--- a/tests/unit/commands/learning.test.ts
+++ b/tests/unit/commands/learning.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { handleLearningCommand } from '../../../src/commands/learning';
+import {
+	_internals,
+	handleLearningCommand,
+} from '../../../src/commands/learning';
+
+const originalComputeLearningMetrics = _internals.computeLearningMetrics;
 
 let tmp: string;
 
@@ -11,6 +16,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	_internals.computeLearningMetrics = originalComputeLearningMetrics;
 	rmSync(tmp, { recursive: true, force: true });
 });
 
@@ -136,5 +142,55 @@ describe('handleLearningCommand', () => {
 			result.includes('Learning Summary') ||
 				result.includes('No learning data'),
 		).toBe(true);
+	});
+
+	it('returns a structured markdown timeout when metric computation hangs', async () => {
+		_internals.computeLearningMetrics = (_directory, options) =>
+			new Promise((_, reject) => {
+				options?.signal?.addEventListener('abort', () =>
+					reject(new Error('aborted')),
+				);
+			});
+
+		const result = await handleLearningCommand(tmp, ['--timeout-ms', '5']);
+
+		expect(result).toContain('LEARNING_METRICS_TIMEOUT');
+		expect(result).toContain('5ms');
+	});
+
+	it('returns a structured JSON timeout when metric computation hangs in JSON mode', async () => {
+		_internals.computeLearningMetrics = (_directory, options) =>
+			new Promise((_, reject) => {
+				options?.signal?.addEventListener('abort', () =>
+					reject(new Error('aborted')),
+				);
+			});
+
+		const result = await handleLearningCommand(tmp, [
+			'--json',
+			'--timeout-ms',
+			'5',
+		]);
+
+		const jsonStr = result
+			.replace('[LEARNING_JSON]\n', '')
+			.replace('\n[/LEARNING_JSON]', '');
+		const parsed = JSON.parse(jsonStr);
+		expect(parsed.ok).toBe(false);
+		expect(parsed.error.code).toBe('LEARNING_METRICS_TIMEOUT');
+		expect(parsed.error.timeout_ms).toBe(5);
+	});
+
+	it('uses the default timeout when --timeout-ms is invalid', async () => {
+		let observedSignal: AbortSignal | undefined;
+		_internals.computeLearningMetrics = async (_directory, options) => {
+			observedSignal = options?.signal;
+			return originalComputeLearningMetrics(_directory, options);
+		};
+
+		const result = await handleLearningCommand(tmp, ['--timeout-ms', 'nope']);
+
+		expect(result).toContain('Learning Summary');
+		expect(observedSignal).toBeDefined();
 	});
 });

--- a/tests/unit/hooks/curator-issues-1411-1414.test.ts
+++ b/tests/unit/hooks/curator-issues-1411-1414.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	parseKnowledgeRecommendationsWithDiagnostics,
+	runCuratorPhase,
+} from '../../../src/hooks/curator';
+import type { CuratorSummary } from '../../../src/hooks/curator-types';
+
+let tempDir: string;
+
+const knownId = '00000000-0000-4000-8000-000000000001';
+const unknownId = '00000000-0000-4000-8000-000000000099';
+
+function swarmPath(...parts: string[]): string {
+	return path.join(tempDir, '.swarm', ...parts);
+}
+
+function writeJson(filePath: string, value: unknown): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(value, null, 2), 'utf-8');
+}
+
+function readSummary(): CuratorSummary {
+	return JSON.parse(
+		fs.readFileSync(swarmPath('curator-summary.json'), 'utf-8'),
+	) as CuratorSummary;
+}
+
+function writeKnowledge(): void {
+	fs.mkdirSync(swarmPath(), { recursive: true });
+	fs.writeFileSync(
+		swarmPath('knowledge.jsonl'),
+		`${JSON.stringify({
+			id: knownId,
+			tier: 'swarm',
+			lesson: 'Existing lesson',
+			category: 'testing',
+			tags: ['testing'],
+			scope: 'global',
+			confidence: 0.8,
+			status: 'established',
+			confirmed_by: [],
+			retrieval_outcomes: {
+				applied_count: 0,
+				succeeded_after_count: 0,
+				failed_after_count: 0,
+			},
+			schema_version: 2,
+			created_at: '2026-06-01T00:00:00.000Z',
+			updated_at: '2026-06-01T00:00:00.000Z',
+			project_name: 'test',
+		})}\n`,
+		'utf-8',
+	);
+}
+
+describe('curator issue regressions', () => {
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'curator-issues-'));
+		fs.mkdirSync(swarmPath(), { recursive: true });
+		writeKnowledge();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test('reports malformed recommendation lines without dropping valid lines', () => {
+		const parsed = parseKnowledgeRecommendationsWithDiagnostics(
+			[
+				'OBSERVATIONS:',
+				`- entry ${knownId} (could be tighter): Keep this valid recommendation`,
+				'- malformed observation',
+				'',
+				'KNOWLEDGE_UPDATES:',
+				'- unknown-action new: bad action',
+			].join('\n'),
+		);
+
+		expect(parsed.recommendations).toHaveLength(1);
+		expect(parsed.diagnostics).toHaveLength(2);
+		expect(parsed.diagnostics.map((d) => d.section)).toEqual([
+			'OBSERVATIONS',
+			'KNOWLEDGE_UPDATES',
+		]);
+	});
+
+	test('accumulates recommendations and filters unknown entry ids', async () => {
+		writeJson(swarmPath('curator-summary.json'), {
+			schema_version: 1,
+			session_id: 'prior',
+			last_updated: '2026-06-01T00:00:00.000Z',
+			last_phase_covered: 1,
+			digest: '### Phase 1\nprior',
+			phase_digests: [
+				{
+					phase: 1,
+					timestamp: '2026-06-01T00:00:00.000Z',
+					summary: 'prior',
+					agents_used: [],
+					tasks_completed: 0,
+					tasks_total: 0,
+					key_decisions: [],
+					blockers_resolved: [],
+				},
+			],
+			compliance_observations: [],
+			knowledge_recommendations: [
+				{
+					action: 'rewrite',
+					lesson: 'prior recommendation',
+					reason: 'prior recommendation',
+				},
+			],
+		});
+
+		await runCuratorPhase(
+			tempDir,
+			2,
+			['reviewer', 'test_engineer'],
+			{
+				enabled: true,
+				init_enabled: true,
+				phase_enabled: true,
+				max_summary_tokens: 2000,
+				min_knowledge_confidence: 0.5,
+				compliance_report: true,
+				suppress_warnings: false,
+				drift_inject_max_chars: 1000,
+			},
+			{},
+			async () =>
+				[
+					'OBSERVATIONS:',
+					`- entry ${knownId} (could be tighter): Known recommendation`,
+					`- entry ${unknownId} (could be tighter): Unknown recommendation`,
+				].join('\n'),
+		);
+
+		const summary = readSummary();
+		expect(summary.knowledge_recommendations).toHaveLength(2);
+		expect(summary.knowledge_recommendations.map((r) => r.lesson)).toEqual([
+			'prior recommendation',
+			'Known recommendation',
+		]);
+	});
+
+	test('caps phase digests to the most recent 50 and rebuilds digest from the cap', async () => {
+		writeJson(swarmPath('curator-summary.json'), {
+			schema_version: 1,
+			session_id: 'prior',
+			last_updated: '2026-06-01T00:00:00.000Z',
+			last_phase_covered: 50,
+			digest: Array.from(
+				{ length: 50 },
+				(_, i) => `### Phase ${i + 1}\nold`,
+			).join('\n\n'),
+			phase_digests: Array.from({ length: 50 }, (_, i) => ({
+				phase: i + 1,
+				timestamp: '2026-06-01T00:00:00.000Z',
+				summary: `phase-${i + 1}`,
+				agents_used: [],
+				tasks_completed: 0,
+				tasks_total: 0,
+				key_decisions: [],
+				blockers_resolved: [],
+			})),
+			compliance_observations: [],
+			knowledge_recommendations: [],
+		});
+
+		await runCuratorPhase(
+			tempDir,
+			51,
+			['reviewer', 'test_engineer'],
+			{
+				enabled: true,
+				init_enabled: true,
+				phase_enabled: true,
+				max_summary_tokens: 2000,
+				min_knowledge_confidence: 0.5,
+				compliance_report: true,
+				suppress_warnings: false,
+				drift_inject_max_chars: 1000,
+			},
+			{},
+		);
+
+		const summary = readSummary();
+		expect(summary.phase_digests).toHaveLength(50);
+		expect(summary.phase_digests[0].phase).toBe(2);
+		expect(summary.phase_digests.at(-1)?.phase).toBe(51);
+		expect(summary.digest.split('\n')).not.toContain('### Phase 1');
+		expect(summary.digest).toContain('### Phase 51');
+	});
+
+	test('documents enabled defaults and malformed structured-output diagnostics', () => {
+		const planning = fs.readFileSync(
+			path.join(process.cwd(), 'docs', 'planning.md'),
+			'utf-8',
+		);
+		const configuration = fs.readFileSync(
+			path.join(process.cwd(), 'docs', 'configuration.md'),
+			'utf-8',
+		);
+		const knowledge = fs.readFileSync(
+			path.join(process.cwd(), 'docs', 'knowledge.md'),
+			'utf-8',
+		);
+
+		expect(planning).toContain('| `enabled` | `true` |');
+		expect(configuration).toContain(
+			'| `enabled` | boolean | `true` | Master switch for Curator |',
+		);
+		expect(knowledge).toContain(
+			'reported through debug-gated curator diagnostics',
+		);
+		expect(knowledge).not.toContain('Malformed JSON is silently dropped');
+	});
+});

--- a/tests/unit/hooks/curator-issues-1411-1414.test.ts
+++ b/tests/unit/hooks/curator-issues-1411-1414.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
 	parseKnowledgeRecommendationsWithDiagnostics,
 	runCuratorPhase,
@@ -12,6 +13,10 @@ let tempDir: string;
 
 const knownId = '00000000-0000-4000-8000-000000000001';
 const unknownId = '00000000-0000-4000-8000-000000000099';
+const repoRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	'../../..',
+);
 
 function swarmPath(...parts: string[]): string {
 	return path.join(tempDir, '.swarm', ...parts);
@@ -26,6 +31,25 @@ function readSummary(): CuratorSummary {
 	return JSON.parse(
 		fs.readFileSync(swarmPath('curator-summary.json'), 'utf-8'),
 	) as CuratorSummary;
+}
+
+function readRepoFile(...parts: string[]): string {
+	return fs.readFileSync(path.join(repoRoot, ...parts), 'utf-8');
+}
+
+function markdownTableCell(
+	markdown: string,
+	field: string,
+	cellIndex: number,
+): string | undefined {
+	for (const line of markdown.split(/\r?\n/)) {
+		const cells = line
+			.split('|')
+			.slice(1, -1)
+			.map((cell) => cell.trim().replaceAll('`', ''));
+		if (cells[0] === field) return cells[cellIndex];
+	}
+	return undefined;
 }
 
 function writeKnowledge(): void {
@@ -196,24 +220,84 @@ describe('curator issue regressions', () => {
 		expect(summary.digest).toContain('### Phase 51');
 	});
 
-	test('documents enabled defaults and malformed structured-output diagnostics', () => {
-		const planning = fs.readFileSync(
-			path.join(process.cwd(), 'docs', 'planning.md'),
-			'utf-8',
-		);
-		const configuration = fs.readFileSync(
-			path.join(process.cwd(), 'docs', 'configuration.md'),
-			'utf-8',
-		);
-		const knowledge = fs.readFileSync(
-			path.join(process.cwd(), 'docs', 'knowledge.md'),
-			'utf-8',
+	test('caps accumulated compliance observations and knowledge recommendations', async () => {
+		writeJson(swarmPath('curator-summary.json'), {
+			schema_version: 1,
+			session_id: 'prior',
+			last_updated: '2026-06-01T00:00:00.000Z',
+			last_phase_covered: 1,
+			digest: '### Phase 1\nprior',
+			phase_digests: [
+				{
+					phase: 1,
+					timestamp: '2026-06-01T00:00:00.000Z',
+					summary: 'prior',
+					agents_used: [],
+					tasks_completed: 0,
+					tasks_total: 0,
+					key_decisions: [],
+					blockers_resolved: [],
+				},
+			],
+			compliance_observations: Array.from({ length: 201 }, (_, i) => ({
+				phase: i,
+				timestamp: '2026-06-01T00:00:00.000Z',
+				type: 'workflow_deviation',
+				description: `observation-${i}`,
+				severity: 'info',
+			})),
+			knowledge_recommendations: Array.from({ length: 201 }, (_, i) => ({
+				action: 'rewrite',
+				lesson: `recommendation-${i}`,
+				reason: `recommendation-${i}`,
+			})),
+		});
+
+		await runCuratorPhase(
+			tempDir,
+			2,
+			['reviewer', 'test_engineer'],
+			{
+				enabled: true,
+				init_enabled: true,
+				phase_enabled: true,
+				max_summary_tokens: 2000,
+				min_knowledge_confidence: 0.5,
+				compliance_report: true,
+				suppress_warnings: false,
+				drift_inject_max_chars: 1000,
+			},
+			{},
 		);
 
-		expect(planning).toContain('| `enabled` | `true` |');
-		expect(configuration).toContain(
-			'| `enabled` | boolean | `true` | Master switch for Curator |',
+		const summary = readSummary();
+		expect(summary.compliance_observations).toHaveLength(200);
+		expect(summary.compliance_observations[0].description).toBe(
+			'observation-1',
 		);
+		expect(summary.knowledge_recommendations).toHaveLength(200);
+		expect(summary.knowledge_recommendations[0].lesson).toBe(
+			'recommendation-1',
+		);
+	});
+
+	test('documents enabled defaults and malformed structured-output diagnostics', () => {
+		const planning = readRepoFile('docs', 'planning.md');
+		const configuration = readRepoFile('docs', 'configuration.md');
+		const knowledge = readRepoFile('docs', 'knowledge.md');
+
+		expect(markdownTableCell(planning, 'enabled', 1)).toBe('true');
+		expect(markdownTableCell(planning, 'postmortem_enabled', 1)).toBe('true');
+		expect(markdownTableCell(planning, 'llm_timeout_ms', 1)).toBe('300000');
+		expect(markdownTableCell(planning, 'skill_generation_enabled', 1)).toBe(
+			'true',
+		);
+		expect(markdownTableCell(planning, 'skill_generation_mode', 1)).toBe(
+			'draft',
+		);
+		expect(markdownTableCell(planning, 'min_skill_confidence', 1)).toBe('0.7');
+		expect(markdownTableCell(planning, 'min_skill_confirmations', 1)).toBe('2');
+		expect(markdownTableCell(configuration, 'enabled', 2)).toBe('true');
 		expect(knowledge).toContain(
 			'reported through debug-gated curator diagnostics',
 		);

--- a/tests/unit/hooks/curator-structured-blocks.test.ts
+++ b/tests/unit/hooks/curator-structured-blocks.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the curator's strict-JSON parser:
  *  - parses well-formed knowledge_application_findings + skill_candidates
- *  - silently drops malformed JSON without mutating anything
+ *  - reports malformed JSON without mutating anything
  *  - rejects entries with bad verdict / missing required fields
  */
 
@@ -46,14 +46,21 @@ describe('parseStructuredCuratorBlocks', () => {
 		expect(out.findings[0].verdict).toBe('violated');
 		expect(out.candidates.length).toBe(1);
 		expect(out.candidates[0].slug).toBe('coder-scope-discipline');
+		expect(out.diagnostics).toEqual([]);
 	});
 
-	it('silently drops malformed JSON', () => {
+	it('reports malformed JSON without producing writes', () => {
 		const out = parseStructuredCuratorBlocks(
 			'```json knowledge_application_findings\n{ not json\n```',
 		);
 		expect(out.findings).toEqual([]);
 		expect(out.candidates).toEqual([]);
+		expect(out.diagnostics).toMatchObject([
+			{
+				block: 'knowledge_application_findings',
+				reason: 'malformed_json',
+			},
+		]);
 	});
 
 	it('rejects findings with invalid verdict', () => {
@@ -65,6 +72,13 @@ describe('parseStructuredCuratorBlocks', () => {
 			].join('\n'),
 		);
 		expect(out.findings).toEqual([]);
+		expect(out.diagnostics).toMatchObject([
+			{
+				block: 'knowledge_application_findings',
+				reason: 'invalid_finding',
+				index: 0,
+			},
+		]);
 	});
 
 	it('rejects skill candidates without source_knowledge_ids', () => {
@@ -76,5 +90,12 @@ describe('parseStructuredCuratorBlocks', () => {
 			].join('\n'),
 		);
 		expect(out.candidates).toEqual([]);
+		expect(out.diagnostics).toMatchObject([
+			{
+				block: 'skill_candidates',
+				reason: 'invalid_skill_candidate',
+				index: 0,
+			},
+		]);
 	});
 });

--- a/tests/unit/hooks/knowledge-curator-retro-cap.test.ts
+++ b/tests/unit/hooks/knowledge-curator-retro-cap.test.ts
@@ -12,6 +12,7 @@ import { _internals } from '../../../src/hooks/knowledge-curator.js';
 const {
 	seenRetroSections,
 	recordSeenRetroSection,
+	hashContent,
 	MAX_TRACKED_RETRO_SECTIONS,
 } = _internals;
 
@@ -56,5 +57,15 @@ describe('seenRetroSections size cap (Invariant 8)', () => {
 		recordSeenRetroSection('session-B', 'hash-B', Date.now());
 		expect(seenRetroSections.get('session-A')?.value).toBe('hash-A');
 		expect(seenRetroSections.get('session-B')?.value).toBe('hash-B');
+	});
+
+	it('hashes full retrospective content, not only length and prefix', () => {
+		const prefix = 'x'.repeat(100);
+		const first = `${prefix}${'a'.repeat(20)}`;
+		const second = `${prefix}${'b'.repeat(20)}`;
+
+		expect(first.length).toBe(second.length);
+		expect(first.slice(0, 100)).toBe(second.slice(0, 100));
+		expect(hashContent(first)).not.toBe(hashContent(second));
 	});
 });

--- a/tests/unit/hooks/trajectory-step-state.test.ts
+++ b/tests/unit/hooks/trajectory-step-state.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import {
+	_test_exports,
+	clearTrajectoryStepCounters,
+	nextTrajectoryStep,
+	resetTrajectoryStepCounter,
+} from '../../../src/hooks/trajectory-step-state';
+
+describe('trajectory-step-state -- regression: bounded session counters (F-001/F-002)', () => {
+	beforeEach(() => {
+		clearTrajectoryStepCounters();
+	});
+
+	test('increments steps independently per session', () => {
+		expect(nextTrajectoryStep('session-a')).toBe(1);
+		expect(nextTrajectoryStep('session-a')).toBe(2);
+		expect(nextTrajectoryStep('session-b')).toBe(1);
+		expect(nextTrajectoryStep('session-a')).toBe(3);
+	});
+
+	test('resetTrajectoryStepCounter restarts a session at step one', () => {
+		nextTrajectoryStep('session-a');
+		nextTrajectoryStep('session-a');
+
+		resetTrajectoryStepCounter('session-a');
+
+		expect(nextTrajectoryStep('session-a')).toBe(1);
+	});
+
+	test('clearTrajectoryStepCounters clears one session or all sessions', () => {
+		nextTrajectoryStep('session-a');
+		nextTrajectoryStep('session-b');
+
+		clearTrajectoryStepCounters('session-a');
+
+		expect(nextTrajectoryStep('session-a')).toBe(1);
+		expect(nextTrajectoryStep('session-b')).toBe(2);
+
+		clearTrajectoryStepCounters();
+
+		expect(nextTrajectoryStep('session-a')).toBe(1);
+		expect(nextTrajectoryStep('session-b')).toBe(1);
+	});
+
+	test('evicts oldest sessions with a FIFO cap', () => {
+		for (let i = 0; i < _test_exports.MAX_TRACKED_STEP_SESSIONS; i++) {
+			expect(nextTrajectoryStep(`session-${i}`)).toBe(1);
+		}
+		expect(_test_exports.getTrackedStepSessionCount()).toBe(
+			_test_exports.MAX_TRACKED_STEP_SESSIONS,
+		);
+
+		expect(nextTrajectoryStep('session-new')).toBe(1);
+
+		expect(_test_exports.getTrackedStepSessionCount()).toBe(
+			_test_exports.MAX_TRACKED_STEP_SESSIONS,
+		);
+		// Previous code had no eviction, so this would have returned step 2.
+		expect(nextTrajectoryStep('session-0')).toBe(1);
+	});
+});


### PR DESCRIPTION
Closes #1410
Closes #1411
Closes #1412
Closes #1413
Closes #1414
Closes #1415

## Summary
- Harden PRM trajectory persistence so cache updates happen after durable writes, cold reads refill cache, cache size stays bounded, and reset flows clear PRM trajectory/session state.
- Fix Curator defaults and behavior so docs match the enabled-by-default config, recommendations and observations stay capped, malformed structured output is reported through diagnostics, and phase digests retain a bounded latest-50 window.
- Add `/swarm learning --timeout-ms` with cancellation-aware metric computation and structured timeout output for markdown and JSON modes.
- Address PR feedback by adding direct trajectory-step-state coverage, capping Curator summary arrays consistently, documenting migration behavior, and rebasing the branch to remove unrelated planning work.

## Invariant audit
- 1 (plugin init): not touched - no init-path code changed.
- 2 (runtime portability): touched - original validation passed `bun run build`, `node scripts/repro-704.mjs`, and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`.
- 3 (subprocesses): not touched - no subprocess call sites changed.
- 4 (.swarm containment): touched - PRM replay/trajectory helpers stayed under `.swarm/`; `src/prm/__tests__/replay.test.ts` and the focused PRM suite passed.
- 5 (plan durability): not touched - no plan ledger/schema/projection changes.
- 6 (test_runner safety): not touched - validation used shell `bun` commands, not broad repo `test_runner` scopes.
- 7 (test writing): touched - new and modified tests use `bun:test` and no new `mock.module`; feedback validation passed `tests/unit/hooks/trajectory-step-state.test.ts`, `tests/unit/hooks/curator-issues-1411-1414.test.ts`, and `src/prm/__tests__/escalation.test.ts`.
- 8 (session state): touched - `src/hooks/trajectory-step-state.ts` now has FIFO eviction, Curator summary arrays are capped, and regression tests cover both.
- 9 (guardrails/retry): touched - `/swarm learning` bounds metric computation with timeout/cancellation; `tests/unit/commands/learning.test.ts` passed in the original focused suite.
- 10 (chat/system msg): not touched - no chat/system hook changes.
- 11 (tool registration): not touched - no tool registration or agent-map changes.
- 12 (release/cache): touched - updated `docs/releases/pending/1410-1415-prm-curator-learning-hardening.md`; no version files were edited.

## Test plan
- [x] `bun --smol test src/prm/__tests__/trajectory-store.test.ts src/prm/__tests__/replay.test.ts src/prm/__tests__/pattern-detector.test.ts src/prm/__tests__/escalation.test.ts src/prm/__tests__/real-pipeline.test.ts tests/unit/commands/learning.test.ts tests/unit/hooks/curator-issues-1411-1414.test.ts tests/unit/hooks/curator-structured-blocks.test.ts tests/unit/hooks/knowledge-curator-retro-cap.test.ts tests/unit/hooks/trajectory-step-state.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/hooks/trajectory-step-state.test.ts tests/unit/hooks/curator-issues-1411-1414.test.ts src/prm/__tests__/escalation.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/hooks/trajectory-logger.test.ts --timeout 30000`
- [x] `bun run typecheck`
- [x] `bunx biome ci .`
- [x] `git diff --check`
- [x] `git diff --check origin/main..HEAD`
- [x] `bun run build`
- [x] `node scripts/repro-704.mjs`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`

## Feedback closure
- F-001: fixed - `src/hooks/trajectory-step-state.ts` now uses `MAX_TRACKED_STEP_SESSIONS = 500` with FIFO eviction before adding new sessions.
- F-002: fixed - added `tests/unit/hooks/trajectory-step-state.test.ts` covering increments, per-session isolation, reset/clear behavior, and FIFO eviction.
- F-003: fixed - release fragment now warns that existing projects with more than 50 phase digests retain the latest 50 on the next Curator write.
- F-004: fixed - `compliance_observations` and `knowledge_recommendations` now use explicit caps alongside `phase_digests`, with regression coverage.
- F-005: fixed - `docs/planning.md` quick reference now lists the six Curator fields already present in `docs/configuration.md`.
- F-006: fixed - release fragment now calls out `postmortem_enabled`, `min_skill_confidence`, and `min_skill_confirmations`.
- F-007: fixed - the docs/defaults test now reads files relative to the test file and parses markdown table cells instead of relying on broad exact row matches.
- F-008: fixed - the escalation defensive-copy test now mutates and verifies `lastPatternDetected.affectedAgents` and `affectedTargets` isolation.
- F-009: pre-existing - `trajectory-logger.ts` `callStartTimes` time-sweep behavior predates this PR.
- F-010: pre-existing - `delegation-ledger.ts` `callStartTimes` behavior predates this PR.
- F-011: pre-existing/mitigated - schema sub-versioning predates this PR; F-003 release note documents the one-time format/cap behavior.
- F-012: pre-existing - existing `vi.mock` usage in unrelated escalation queue tests was not introduced here.
- F-013: fixed - rebased this branch onto `origin/main`, removing the unrelated planning commit from PR #1421.
