### PR TITLE
fix(npm): update repository URL for provenance verification after repo move

### DIFF
--- a/docs/releases/pending/npm-repo-url-provenance.md
+++ b/docs/releases/pending/npm-repo-url-provenance.md
@@ -1,0 +1,18 @@
+# npm: Fix repository URL for sigstore provenance verification
+
+## What changed
+
+Updated `package.json` `repository.url` from `https://github.com/zaxbysauce/opencode-swarm.git` to `https://github.com/ZaxbyHub/opencode-swarm.git` to match the repository's current location after the org move.
+
+## Why
+
+npm's `--provenance` flag performs sigstore verification that requires the `repository.url` in `package.json` to exactly match the GitHub repository running the workflow. After the repository moved from `zaxbysauce` to `ZaxbyHub`, the stale URL caused:
+
+```
+npm error 422 Unprocessable Entity
+Error verifying sigstore provenance bundle: package.json repository.url
+is git+https://github.com/zaxbysauce/opencode-swarm.git, expected to match
+https://github.com/ZaxbyHub/opencode-swarm from provenance
+```
+
+GitHub's redirect masked this for non-provenance operations, but the sigstore check is stricter.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/zaxbysauce/opencode-swarm.git"
+		"url": "https://github.com/ZaxbyHub/opencode-swarm.git"
 	},
 	"publishConfig": {
 		"access": "public",


### PR DESCRIPTION
## Summary

The repository moved from zaxbysauce/opencode-swarm to ZaxbyHub/opencode-swarm. npm's sigstore provenance verification (--provenance) compares the epository.url in package.json against the actual GitHub repo running the workflow. The stale URL caused:

`
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/opencode-swarm
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: repository.url is git+https://github.com/zaxbysauce/opencode-swarm.git,
expected to match https://github.com/ZaxbyHub/opencode-swarm from provenance
`

This was transparent before because GitHub's redirect worked for non-provenance operations. The provenance check is stricter and requires an exact URL match.

## Invariant audit
- 1-11: not touched
- 12 (release/cache): touched — package.json repository.url updated (NOT version — release-please owns version)

## Test plan
- [x] No code changes — only metadata URL field
- [x] npm publish with --provenance will pass once the URL matches the workflow repo