### PR TITLE
perf(ci): skip CI for release-please PRs in both PR and merge-queue tiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
 
   # Two-tier CI: on pull_request, run ubuntu-only with 4 shards for fast feedback.
   # On merge_group (merge queue), run the full 3-OS matrix for merge safety.
+  # On release-please branches, all steps are skipped (version bumps don't need
+  # unit tests — quality job still runs typecheck and lint).
   # Test files are discovered automatically via find and distributed round-robin
   # across shards — no hardcoded file lists, no duplication.
   unit:
@@ -69,11 +71,14 @@ jobs:
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
         id: cache-bun
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
@@ -82,12 +87,15 @@ jobs:
             ${{ runner.os }}-bun-
             ${{ runner.os }}-bun
       - name: Install dependencies
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         run: bun install --frozen-lockfile
       # dist/ is generated output and no longer committed (#1047); build it so the
       # tests under tests/unit/build/ that load the bundle have a dist/ to read.
       - name: Build
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         run: bun run build
       - name: Collect and partition test files
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         shell: bash
         env:
           SHARD: ${{ matrix.shard }}
@@ -102,6 +110,7 @@ jobs:
           fi
           echo "Shard ${SHARD}/${num_shards}"
       - name: Run unit tests
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         shell: bash
         run: |
           failed=0
@@ -168,47 +177,61 @@ jobs:
           done
           exit $failed
 
+  # Release-please PRs skip package-check (version bumps don't change the bundle).
   package-check:
     needs: quality
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         with:
           bun-version: "1.3.13"
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         with:
           node-version: "22"
       - name: Cache bun dependencies
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - name: Install dependencies
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         run: bun install --frozen-lockfile
       - name: Build
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         run: bun run build
       - name: Validate packed npm artifact
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         run: bun run package:smoke
 
+  # Release-please PRs skip security tests (version bumps don't affect security).
   security:
     needs: quality
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - name: Install dependencies
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         run: bun install --frozen-lockfile
       - name: Security tests
+        if: "!startsWith(github.head_ref || '', 'release-please--')"
         run: bun test tests/security --timeout 120000
 
   # Merge-queue-only: on pull_request all steps are skipped, job reports success.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,45 +20,85 @@ permissions:
   contents: read
 
 jobs:
+  # Fast (~5s) detection of release-please branches. Works for both PR events
+  # (checks github.head_ref) and merge-queue events (checks commit messages
+  # since github.head_ref is unavailable in merge groups).
+  detect-release:
+    runs-on: ubuntu-latest
+    outputs:
+      is-release: ${{ steps.check.outputs.is-release }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 10
+      - name: Detect release-please
+        id: check
+        shell: bash
+        run: |
+          if [[ "$BRANCH" == release-please--* ]]; then
+            echo "is-release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$EVENT" == "merge_group" ]] && git log --format='%s' --max-count=10 | grep -q '^chore(main): release'; then
+            echo "is-release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "is-release=false" >> "$GITHUB_OUTPUT"
+        env:
+          BRANCH: ${{ github.head_ref }}
+          EVENT: ${{ github.event_name }}
+
   quality:
+    needs: [detect-release]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: needs.detect-release.outputs.is-release != 'true'
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        if: needs.detect-release.outputs.is-release != 'true'
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
+        if: needs.detect-release.outputs.is-release != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - name: Install dependencies
+        if: needs.detect-release.outputs.is-release != 'true'
         run: bun install --frozen-lockfile
       - name: Type check
+        if: needs.detect-release.outputs.is-release != 'true'
         run: bun run typecheck
       - name: Biome CI
+        if: needs.detect-release.outputs.is-release != 'true'
         run: bunx biome ci .
       - name: Mock isolation compliance check
+        if: needs.detect-release.outputs.is-release != 'true'
         shell: bash
         run: chmod +x scripts/check-mock-cleanup.sh && bash scripts/check-mock-cleanup.sh
       - name: Engineering invariant checks
+        if: needs.detect-release.outputs.is-release != 'true'
         shell: bash
         run: chmod +x scripts/check-invariants.sh && bash scripts/check-invariants.sh
       - name: Tool registration coherence check
+        if: needs.detect-release.outputs.is-release != 'true'
         run: bun run scripts/check-tool-registration.ts
       - name: Cross-contamination check (mock.module / vi.mock leaks)
+        if: needs.detect-release.outputs.is-release != 'true'
         shell: bash
         run: chmod +x scripts/check-cross-contamination.sh && bash scripts/check-cross-contamination.sh
 
   # Two-tier CI: on pull_request, run ubuntu-only with 4 shards for fast feedback.
   # On merge_group (merge queue), run the full 3-OS matrix for merge safety.
-  # On release-please branches, all steps are skipped (version bumps don't need
-  # unit tests — quality job still runs typecheck and lint).
+  # On release-please branches, all steps are skipped via detect-release job
+  # (version bumps don't need tests — applies to both PR and merge-queue tiers).
   # Test files are discovered automatically via find and distributed round-robin
   # across shards — no hardcoded file lists, no duplication.
   unit:
-    needs: quality
+    needs: [detect-release, quality]
     strategy:
       fail-fast: false
       matrix:
@@ -71,14 +111,14 @@ jobs:
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
         id: cache-bun
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
@@ -87,15 +127,15 @@ jobs:
             ${{ runner.os }}-bun-
             ${{ runner.os }}-bun
       - name: Install dependencies
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         run: bun install --frozen-lockfile
       # dist/ is generated output and no longer committed (#1047); build it so the
       # tests under tests/unit/build/ that load the bundle have a dist/ to read.
       - name: Build
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         run: bun run build
       - name: Collect and partition test files
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         shell: bash
         env:
           SHARD: ${{ matrix.shard }}
@@ -110,7 +150,7 @@ jobs:
           fi
           echo "Shard ${SHARD}/${num_shards}"
       - name: Run unit tests
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         shell: bash
         run: |
           failed=0
@@ -134,30 +174,30 @@ jobs:
           exit $failed
 
   # Merge-queue-only: on pull_request all steps are skipped, job reports success
-  # to satisfy required checks without doing work.
+  # to satisfy required checks without doing work. Also skipped for release-please.
   integration:
-    needs: unit
+    needs: [detect-release, unit]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - name: Install dependencies
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         run: bun install --frozen-lockfile
       - name: Integration tests
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         shell: bash
         run: |
           failed=0
@@ -179,121 +219,122 @@ jobs:
 
   # Release-please PRs skip package-check (version bumps don't change the bundle).
   package-check:
-    needs: quality
+    needs: [detect-release, quality]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         with:
           bun-version: "1.3.13"
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         with:
           node-version: "22"
       - name: Cache bun dependencies
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - name: Install dependencies
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         run: bun install --frozen-lockfile
       - name: Build
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         run: bun run build
       - name: Validate packed npm artifact
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         run: bun run package:smoke
 
   # Release-please PRs skip security tests (version bumps don't affect security).
   security:
-    needs: quality
+    needs: [detect-release, quality]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - name: Install dependencies
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         run: bun install --frozen-lockfile
       - name: Security tests
-        if: "!startsWith(github.head_ref || '', 'release-please--')"
+        if: needs.detect-release.outputs.is-release != 'true'
         run: bun test tests/security --timeout 120000
 
   # Merge-queue-only: on pull_request all steps are skipped, job reports success.
   php-validation:
-    needs: quality
+    needs: [detect-release, quality]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         with:
           php-version: "8.2"
           tools: composer
           coverage: none
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - name: Install dependencies
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         run: bun install --frozen-lockfile
       - name: PHP profile command surface tests
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         run: bun --smol test tests/unit/lang/profiles-php.test.ts --timeout 60000
       - name: PHP framework detection and command overlay tests
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         run: bun --smol test tests/unit/lang/framework-detector.test.ts --timeout 60000
       - name: PHP Composer ecosystem discovery tests
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         run: bun --smol test tests/unit/build/discovery-php.test.ts --timeout 60000
       - name: Composer audit handler tests
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         run: bun --smol test tests/unit/tools/pkg-audit-composer.test.ts --timeout 60000
       - name: Laravel SAST rule tests
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         run: bun --smol test tests/unit/tools/sast-scan-laravel.test.ts --timeout 60000
       - name: Laravel fixture detection and SAST coverage tests
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         run: bun --smol test tests/unit/lang/laravel-fixture.test.ts --timeout 60000
 
   # Merge-queue-only: on pull_request all steps are skipped, job reports success.
   rust-sandbox-runner:
+    needs: [detect-release]
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         with:
           components: rustfmt, clippy
       - name: Cache cargo
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -303,29 +344,29 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('runners/swarm-sandbox-runner/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
       - name: Check formatting
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         working-directory: runners/swarm-sandbox-runner
         run: cargo fmt --check
       - name: Clippy lint
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         working-directory: runners/swarm-sandbox-runner
         run: cargo clippy --all-targets -- -D warnings
       - name: Run tests
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         working-directory: runners/swarm-sandbox-runner
         run: cargo test --all-targets
       - name: Build release binary
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         working-directory: runners/swarm-sandbox-runner
         run: cargo build --release
       - name: Probe smoke test
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         working-directory: runners/swarm-sandbox-runner
         run: ./target/release/swarm-sandbox-runner.exe --probe
 
   # Merge-queue-only: on pull_request all steps are skipped, job reports success.
   smoke:
-    needs: [unit, integration, package-check, php-validation, rust-sandbox-runner]
+    needs: [detect-release, unit, integration, package-check, php-validation, rust-sandbox-runner]
     strategy:
       fail-fast: false
       matrix:
@@ -334,32 +375,32 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         with:
           bun-version: "1.3.13"
       - name: Cache bun dependencies
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - name: Install dependencies
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         run: bun install --frozen-lockfile
       - name: Build package
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         run: bun run build
       - name: Smoke tests
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         run: bun test tests/smoke --timeout 120000
       - name: Issue #704 repro — Desktop init under Node
         # Loads the compiled dist/ under Node (the runtime OpenCode Desktop's
         # sidecar uses on macOS) and asserts the plugin's `server()` resolves
         # within 10s. Pre-fix this would hang. Runs on Linux, macOS, Windows
         # so the cycle/cap/budget guards are exercised on each OS.
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         shell: bash
         run: node scripts/repro-704.mjs

--- a/docs/releases/pending/ci-two-tier-sharding.md
+++ b/docs/releases/pending/ci-two-tier-sharding.md
@@ -32,6 +32,8 @@ The `unit` job matrix gains a `shard` dimension, changing required check names:
 - Enable the GitHub merge queue on `main` in branch protection settings
 - Disable "Require branches to be up to date before merging" (the merge queue handles freshness validation)
 
+**Release-please fast-track:** A `detect-release` job (~5s) identifies release-please branches for both PR and merge-queue events. When detected, all downstream jobs (quality, unit, integration, security, package-check, php-validation, rust-sandbox-runner, smoke) skip their steps and report success immediately. This avoids 15+ minutes of pointless testing on auto-generated version bumps. Detection uses `github.head_ref` for PR events and commit-message matching (`chore(main): release`) for merge-group events where `github.head_ref` is unavailable.
+
 ## Known caveats
 
 - PR runs no longer run integration, smoke, php-validation, or rust-sandbox-runner. Cross-platform and integration bugs are caught at merge queue time instead of during development.

--- a/docs/releases/pending/external-content-scanning-1278.md
+++ b/docs/releases/pending/external-content-scanning-1278.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Fixed [#1278](https://github.com/zaxbysauce/opencode-swarm/issues/1278): inconsistent prompt-injection treatment across external content sources.
+Fixed [#1278](https://github.com/ZaxbyHub/opencode-swarm/issues/1278): inconsistent prompt-injection treatment across external content sources.
 
 Previously, `gitingest` and `web_search` returned external content directly to the LLM without scanning, while the external-skill curation pipeline applied comprehensive threat detection. This asymmetry created a security gap where attacker-controlled repository content or malicious web snippets could inject prompts directly into model context.
 

--- a/docs/releases/pending/multi-swarm-agent-config-fallback.md
+++ b/docs/releases/pending/multi-swarm-agent-config-fallback.md
@@ -42,4 +42,4 @@ This pre-existing architectural gap was exposed by PR #1216 (fix: respect top-le
 
 The root cause: module-level `_swarmAgents` variable was designed for single-slot use and never updated when multi-swarm support was added in earlier versions.
 
-Related issue #1225: https://github.com/zaxbysauce/opencode-swarm/issues/1225
+Related issue #1225: https://github.com/ZaxbyHub/opencode-swarm/issues/1225

--- a/docs/releases/pending/prepare-build-source-install.md
+++ b/docs/releases/pending/prepare-build-source-install.md
@@ -5,7 +5,7 @@
 Added a `prepare` lifecycle script (`"prepare": "bun run build"`) to `package.json`
 so that `dist/` is built automatically whenever the package is installed **from
 source** — a local checkout (`bun install` / `npm install`) or a git/GitHub
-reference (`npm i github:zaxbysauce/opencode-swarm`). The now-redundant
+reference (`npm i github:ZaxbyHub/opencode-swarm`). The now-redundant
 `prepublishOnly` build hook was removed (`prepare` already builds before
 `pack`/`publish`). `scripts/package-smoke.mjs` was hardened to tolerate the build
 output that `npm pack` now prints ahead of its `--json` payload. Documented in


### PR DESCRIPTION
## Summary

- **Add `detect-release` job** (~5s) that identifies release-please branches for both PR events (`github.head_ref` prefix check) and merge-queue events (`git log` commit-message matching for `chore(main): release`), since `github.head_ref` is unavailable in merge groups
- **Skip all CI jobs** (quality, unit, security, package-check, integration, smoke, php-validation, rust-sandbox-runner) for release-please PRs in both tiers — steps are skipped but jobs report success to satisfy required checks
- **Fix stale org references** in 3 pending release fragments (`zaxbysauce` → `ZaxbyHub`)

## Why

Release-please PRs only change `package.json` (version bump), `CHANGELOG.md`, and `.release-please-manifest.json`. Running the full merge-queue test suite (3-OS unit tests × 4 shards, integration, smoke, PHP, Rust) takes 15+ minutes on auto-generated version bumps with zero test value.

## How it works

1. `detect-release` runs before all other jobs and outputs `is-release=true/false`
2. **PR events**: checks `github.head_ref` for `release-please--` prefix (no checkout needed)
3. **Merge-queue events**: shallow checkout + `git log --max-count=10` to find `chore(main): release` commit message
4. All 8 downstream jobs reference `needs.detect-release.outputs.is-release` in step-level `if:` conditions
5. **Fail-safe**: if detection fails, `is-release` defaults to empty string (`!= 'true'` → all jobs run normally)

## Impact

| Scenario | Before | After |
|---|---|---|
| Release-please PR (PR tier) | ~5 min (quality + unit + security + package-check) | ~30s |
| Release-please PR (merge queue) | 15+ min (full 3-OS matrix + integration + smoke + PHP + Rust) | ~30s |
| Normal PR (PR tier) | ~12 min | ~12 min (+5s for detect-release) |
| Normal PR (merge queue) | ~25 min | ~25 min (+5s for detect-release) |

## Invariant audit
- 1 (plugin init): not touched - CI config only, no source changes
- 2 (runtime portability): not touched - CI config only
- 3 (subprocesses): not touched - no subprocess changes
- 4 (.swarm containment): not touched - no .swarm changes
- 5 (plan durability): not touched - no plan changes
- 6 (test_runner safety): not touched - CI step guards only, test runner unchanged
- 7 (test writing): not touched - no test changes
- 8 (session state): not touched - no state changes
- 9 (guardrails/retry): not touched - no guardrail changes
- 10 (chat/system msg): not touched - no chat/system message changes
- 11 (tool registration): not touched - no tool changes
- 12 (release/cache): not touched - CI workflow only; release-please config, CHANGELOG, and manifest unchanged

## Test plan

- [ ] Open a release-please PR → verify all CI jobs complete in <1 min with all steps skipped
- [ ] Queue a release-please PR in merge queue → verify detect-release outputs `is-release=true` and all jobs fast-track
- [ ] Open a normal PR → verify CI runs normally (detect-release outputs `is-release=false`)
- [ ] Queue a normal PR → verify full merge-queue CI executes
- [x] PR CI run confirms detect-release outputs `is-release=false` and all jobs execute normally (17/17 checks pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187xL8DepuSE3AJAi7FvEfZ