### PR TITLE
docs: Document the complete knowledge lifecycle and skills system

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -32,7 +32,7 @@ During phase execution, knowledge is **retrieved and injected** into the archite
    - Unified `searchKnowledge()` queries both swarm and hive
    - Near-duplicate removal via Jaccard bigram similarity (threshold 0.6)
     - Action-aware ranking: triggers, `applies_to_agents/tools`, priority level, trigger phrase boost
-    - For ranking algorithm details, see [Knowledge System](knowledge.md#query-ranking).
+    - For ranking algorithm details, see [Knowledge System](knowledge.md#query-and-injection).
 
 2. **Injection Budget** (context-adaptive)
    - \>60% headroom: full budget (up to 5 entries, 2000 chars)
@@ -65,7 +65,7 @@ During phase execution, knowledge is **retrieved and injected** into the archite
    - Chat-visible `KNOWLEDGE_*` markers are the enforcement gate
    - `knowledge_receipt` tool records outcomes to `.swarm/knowledge-application.jsonl`
     - Counters: `shown_count`, `acknowledged_count`, `applied_explicit_count`, `ignored_count`, `violated_count`, `succeeded_after_shown_count`, `failed_after_shown_count`
-    - See [Evidence and Telemetry](evidence-and-telemetry.md) for the outcome persistence schema.
+    - See [Knowledge System](knowledge.md#retrieval-outcome-counters) for the counter schema.
 
 ### Phase 3: Feedback & Learning
 
@@ -80,7 +80,7 @@ After phase completion, feedback is collected:
 2. **Knowledge Durability**
    - **TTL decay**: Active entries age every successful phase (increments `phases_alive`)
     - Archived when `phases_alive > max_phases` (default 10 phases for general, 3 for `todo`)
-    - Archived entries are excluded from query results but preserved on disk (not deleted). They can be restored via the quarantine/workflow tools if needed.
+    - Archived entries are excluded from query results but preserved on disk (not deleted). They can be manually restored via `/swarm knowledge restore` if needed. Note that TTL-archived entries are in a distinct state from quarantined entries.
    - **Promoted entries are TTL-exempt** — live until explicitly quarantined
    - Quarantine workflow: `/swarm knowledge quarantine <id> [reason]` hides but preserves
 
@@ -163,7 +163,7 @@ Agent task / curator review
    - Becomes available to all agents via `SKILLS:` delegation field
    - Locked against overwrite (requires `force=true` if generator marker removed)
     - Rejected candidates recorded to `.swarm/skills/rejected-edits.jsonl`
-    - Entries are added to this file when `isRejectedSkillContent` detects a hash match with previously rejected content, or when skill evaluation fails required-phrases or forbidden-phrases checks.
+    - Entries are added to this file by `appendRejectedSkillEdit` when skill evaluation fails (e.g., required-phrases or forbidden-phrases checks). `isRejectedSkillContent` reads this file later to detect hash matches with previously rejected content.
 
 5. **Ongoing Refinement** — `skill_regenerate <slug>` rebuilds active skill from updated source knowledge
 
@@ -339,7 +339,7 @@ When reviewing a draft skill before applying:
 | **Generated skill** | Compilable SKILL.md derived from mature knowledge (review checklist, triggers, directives) |
 | **Maturity gate** | Decision logic determining if an entry can become a skill (outcome signal, confidence, confirmations) |
 | **Outcome signal** | Rollup of `applied_explicit_count`, `succeeded_after_shown_count`, `violated_count`, etc. |
-| **Knowledge injection** | Retrieval of relevant entries and inclusion in architect's prompt at phase start — see [knowledge.md#injection](knowledge.md#injection) |
+| **Knowledge injection** | Retrieval of relevant entries and inclusion in architect's prompt at phase start — see [knowledge.md#query-and-injection](knowledge.md#query-and-injection) |
 | **Promotion** | Swarm → Hive transition after threshold (3 phases confirmed, fast-track, or 90-day age) |
 | **v2 directives** | Optional fields on knowledge entries (`triggers`, `required_actions`, `applies_to_agents/tools`, priority) |
 | **Knowledge application contract** | Architect MUST emit `KNOWLEDGE_APPLIED/IGNORED/VIOLATED` for applicable directives |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,86 +1,338 @@
-# Generated Skills
+# Knowledge Lifecycle & Skills System
 
-Generated skills turn mature knowledge entries into reviewable `SKILL.md`
-files that agents can load through the normal skill system.
+This document describes the complete lifecycle of knowledge in OpenCode Swarm: from creation through retrieval, feedback, promotion, and compilation into reusable skills. For knowledge storage schema and configuration details, see [Knowledge System](knowledge.md).
 
-## Lifecycle
+## Complete Knowledge Lifecycle
 
-1. Knowledge starts as swarm or hive entries in the knowledge store.
-2. Event-sourced feedback records whether the entry was shown, acknowledged,
-   applied, ignored, violated, or followed by a successful phase.
-3. `skill_generate` and `skill_improve` select candidates using confirmations
-   plus effective outcome rollups. Strong positive outcomes can mature a
-   singleton; clearly negative outcome signal blocks compilation.
-4. Drafts are written under `.swarm/skills/proposals/`.
-5. `skill_apply` promotes a reviewed draft to
-   `.opencode/skills/generated/<slug>/SKILL.md`.
+### Phase 1: Knowledge Creation
 
-Scheduled consolidation never activates generated skills automatically. A human
-or architect must review and apply staged drafts from that path.
+Knowledge enters the system through four routes:
 
-Generated frontmatter carries the same trigger phrases that matured the source
-knowledge:
+| Route | Source | Command | Tier | Scope |
+|-------|--------|---------|------|-------|
+| **Agent tool** | Active agent (coder, reviewer, test, SME, docs) during a phase | `knowledge_add` | Swarm | Project-specific |
+| **Manual promotion** | Human contributor | `/swarm promote "<lesson>"` | Hive | Cross-project |
+| **Curator recommendation** | Curator agent after phase analysis | Auto-generated via curator insights | Swarm/Hive | Project-specific or evergreen |
+| **Legacy migration** | v6 projects | `/swarm knowledge migrate` | Swarm | One-time import |
+
+Each entry carries:
+- **`lesson`** — the knowledge claim (15–280 chars, validated for safety)
+- **`category`** — `pattern`, `lesson`, `decision`, `domain`, `todo`
+- **`confidence`** — 0.0–1.0, reflecting certainty
+- **`tier`** — `swarm` (project) or `hive` (cross-project)
+- **Optional v2 directives** — `triggers`, `required_actions`, `forbidden_actions`, `applies_to_agents`, `applies_to_tools`, `directive_priority`, source references
+
+Storage: `.swarm/knowledge.jsonl` (swarm) or `~/.local/share/opencode-swarm/shared-learnings.jsonl` (hive, platform-specific).
+
+### Phase 2: Knowledge Injection & Application
+
+During phase execution, knowledge is **retrieved and injected** into the architect's context:
+
+1. **Search & Rank**
+   - Unified `searchKnowledge()` queries both swarm and hive
+   - Near-duplicate removal via Jaccard bigram similarity (threshold 0.6)
+   - Action-aware ranking: triggers, `applies_to_agents/tools`, priority level, trigger phrase boost
+
+2. **Injection Budget** (context-adaptive)
+   - \>60% headroom: full budget (up to 5 entries, 2000 chars)
+   - 20–60% headroom: half budget
+   - 5–20% headroom: quarter budget
+   - \<5%: skipped
+
+3. **Architect Application Contract** (v2)
+   - Architect receives structured `<swarm_knowledge_directives>` block
+   - For each applicable directive, architect **MUST** emit one of:
+     - `KNOWLEDGE_APPLIED: <id>` — observed in next action
+     - `KNOWLEDGE_IGNORED: <id> reason=...` — not applicable this turn
+     - `KNOWLEDGE_VIOLATED: <id> reason=...` — runtime evidence shows breach
+
+   Example:
+   ```
+   <swarm_knowledge_directives>
+   - id: lesson-abc123
+     confidence: 0.94
+     priority: critical
+     trigger: coder delegation modifying source files
+     required: call declare_scope before coder delegation
+     forbidden: bash/eval/heredoc file writes
+     skill: file:.opencode/skills/generated/scope-discipline/SKILL.md
+     verification: reviewer must reject scope bypass
+   </swarm_knowledge_directives>
+   ```
+
+4. **Outcomes Recorded**
+   - Chat-visible `KNOWLEDGE_*` markers are the enforcement gate
+   - `knowledge_receipt` tool records outcomes to `.swarm/knowledge-application.jsonl`
+   - Counters: `shown_count`, `acknowledged_count`, `applied_explicit_count`, `ignored_count`, `violated_count`, `succeeded_after_shown_count`, `failed_after_shown_count`
+
+### Phase 3: Feedback & Learning
+
+After phase completion, feedback is collected:
+
+1. **Outcome Scoring**
+   - Entries with **positive outcome signal** (`applied_explicit_count >= 3` OR `succeeded_after_shown_count >= 3`) → candidate for skill generation
+   - **Negative outcome signal** (`violated_count` + `failed_after_shown_count > threshold`) → blocked from promotion
+   - **Evergreen threshold**: `confidence >= 0.9` AND `utility_score >= 0.8`
+   - **Low-utility flag**: `utility_score <= 0.3` after `>= 3` retrievals AND `shown_count >= 5`
+
+2. **Knowledge Durability**
+   - **TTL decay**: Active entries age every successful phase (increments `phases_alive`)
+   - Archived when `phases_alive > max_phases` (default 10 phases for general, 3 for `todo`)
+   - **Promoted entries are TTL-exempt** — live until explicitly quarantined
+   - Quarantine workflow: `/swarm knowledge quarantine <id> [reason]` hides but preserves
+
+3. **Curator Review** (optional, if enabled)
+   - Curator agent reviews phase outcomes, detects repeated violations, missing guidance
+   - Emits optional `skill_candidates` JSON block (high-confidence directives for skill compilation)
+   - Triggers hive promotion check via `checkHivePromotions()`
+
+### Phase 4: Promotion to Hive (Cross-Project)
+
+Swarm entries can be promoted to hive knowledge via three routes:
+
+| Route | Trigger | Speed |
+|-------|---------|-------|
+| **Explicit** | `hive_eligible=true` AND ≥3 distinct phase confirmations | Manual or curator |
+| **Fast-track** | Entry tagged `hive-fast-track` | Immediate (bypasses phase count) |
+| **Age-based** | Entry age ≥ `auto_promote_days` (default 90 days) | Automatic on next curator run |
+
+Manual promotion: `/swarm promote --from-swarm <id>`
+
+Promoted hive entries gain cross-project weight: `encounter_score` weighted by `same_project_weight` (1.0, same project) vs `cross_project_weight` (0.5, other projects).
+
+### Phase 5: Skill Generation & Compilation
+
+Mature, high-confidence knowledge can be compiled into reusable **SKILL.md** files.
+
+#### Maturity Gate
+
+An entry passes the maturity gate if:
+
+1. **Not negatively evidenced** — `computeOutcomeSignal >= 0` (no strong negative outcome)
+2. **Strong outcome bypass** — `applied_explicit_count >= 3` OR `succeeded_after_shown_count >= 3` AND `computeOutcomeSignal > 0`
+   - Bypasses confidence floor and confirmation count
+   - Allows well-evidenced singletons to become skills early
+3. **Legacy AND gates** — for other entries:
+   - Confidence >= `min_skill_confidence` (default 0.70)
+   - Either `confirmed_by` count >= `min_skill_confirmations` (default 2 distinct phases) OR strong outcome record
+   - Both conditions must independently hold (neither alone is sufficient)
+
+#### Generation Workflow
+
+```
+Agent task / curator review
+  ↓
+  skill_generate (creates draft)
+  ↓
+  .swarm/skills/proposals/<slug>.md
+  ↓
+  [optional] skill evaluation + validation
+  ↓
+  Human review via skill_inspect / skill_list
+  ↓
+  skill_apply (promotes to active)
+  ↓
+  .opencode/skills/generated/<slug>/SKILL.md
+```
+
+1. **Candidate Compilation** — `skill_generate` reads source knowledge entries, creates **draft** at `.swarm/skills/proposals/<slug>.md`
+   - Frontmatter includes `triggers:` phrases from source knowledge
+   - Includes generator marker: `<!-- generated by opencode-swarm skill-generator -->`
+
+2. **Optional Validation** — If eval fixtures exist at `.swarm/skills/evals/<slug>/*.json`, candidate is checked:
+   ```json
+   {
+     "required_phrases": ["call declare_scope"],
+     "forbidden_phrases": ["skip scope declaration"]
+   }
+   ```
+   - Missing evals fail open and report `unevaluated`
+   - Existing active skills must strictly improve incumbent
+
+3. **Human Review** — Human inspects draft via:
+   - `skill_list` — list all drafts and active skills
+   - `skill_inspect <slug>` — print skill with source knowledge IDs
+   - Edit draft if needed (preserved on skill_apply unless it diverges too much)
+
+4. **Activation** — `skill_apply <slug>` promotes draft to `.opencode/skills/generated/<slug>/SKILL.md`
+   - Becomes available to all agents via `SKILLS:` delegation field
+   - Locked against overwrite (requires `force=true` if generator marker removed)
+   - Rejected candidates recorded to `.swarm/skills/rejected-edits.jsonl`
+
+5. **Ongoing Refinement** — `skill_regenerate <slug>` rebuilds active skill from updated source knowledge
+
+#### Skill File Layout
+
+```
+.swarm/skills/proposals/<slug>.md              # drafts (awaiting review)
+.swarm/skills/evals/<slug>/*.json              # validation fixtures
+.swarm/skills/rejected-edits.jsonl             # audit buffer
+.opencode/skills/generated/<slug>/SKILL.md     # active generated skills
+```
+
+#### Frontmatter Example
+
+Generated skills inherit trigger phrases and metadata from source knowledge:
 
 ```yaml
 ---
-name: biome-lint
-description: Fix lint config
+name: declare-scope-before-delegation
+description: Enforce scope declaration before coder/reviewer delegation
 triggers:
-  - biome
-  - lint config
+  - coder delegation
+  - scope declaration
+  - declare_scope
+applies_to_agents:
+  - coder
+  - reviewer
+applies_to_tools:
+  - task
+  - Task
+directive_priority: high
 ---
+
+# Declare Scope Before Delegation
+
+When delegating to coder or reviewer, first call `declare_scope` to...
 ```
 
-The skill scorer treats `triggers` as bounded literal hints. A task that contains
-a trigger phrase receives a relevance boost, while short phrases are ignored so
-generic tokens do not dominate ranking.
+---
 
-## File Layout
+## Generated Skills: Deep Dive
 
-```text
-.swarm/skills/proposals/<slug>.md
-.swarm/skills/evals/<slug>/*.json
-.swarm/skills/rejected-edits.jsonl
-.opencode/skills/generated/<slug>/SKILL.md
-```
+Generated skills turn mature knowledge entries into reviewable SKILL.md files that agents load through the normal skill system.
 
-Active generated skills include a generator marker comment. `skill_apply`
-refuses to overwrite an active skill that lacks that marker unless `force=true`
-is passed.
+### Lifecycle Summary (Short Form)
 
-## Validation Evals
+1. Knowledge starts as swarm or hive entries in the knowledge store
+2. Event-sourced feedback records outcomes (shown, acknowledged, applied, ignored, violated, or succeeded)
+3. `skill_generate` and `skill_improve` select candidates using maturity gate (confirmations + outcome rollups)
+4. Drafts are written under `.swarm/skills/proposals/`
+5. `skill_apply` promotes a reviewed draft to `.opencode/skills/generated/<slug>/SKILL.md`
+6. Scheduled consolidation never activates generated skills automatically — human or architect must review
 
-Place optional deterministic eval fixtures under
-`.swarm/skills/evals/<slug>/*.json`. A fixture can be a single case, an array,
-or `{ "cases": [...] }`:
+### Skill Improver Agent
 
-```json
-{
-  "required_phrases": ["call declare_scope"],
-  "forbidden_phrases": ["skip scope declaration"]
+The optional `skill_improver` agent (issue #629) runs rare, high-capability reviews:
+
+```jsonc
+"skill_improver": {
+  "enabled": false,
+  "max_calls_per_day": 10,
+  "trigger": "manual",              // 'manual' (default) | 'automatic'
+  "consolidation_interval_hours": 24,
+  "write_mode": "proposal",         // 'proposal' (no mutation) | 'draft_skills'
+  "targets": ["skills", "spec", "architect_prompt", "knowledge"],
+  "require_user_approval": true,
+  "quota_window": "utc"
 }
 ```
 
-When `evaluate=true` is passed to `skill_generate`, `skill_apply`,
-`skill_regenerate`, or `skill_improve` in `draft_skills` mode, candidate content
-is checked before any file write, knowledge stamp, proposal deletion, or
-changelog append. Missing eval fixtures fail open and report `unevaluated`.
-Scheduled consolidation uses this validation path for drafted skills by default.
-Existing active skills require a strict improvement over the incumbent. Rejected
-candidates are recorded in `.swarm/skills/rejected-edits.jsonl`.
+When invoked, emits proposal with sections: Inventory snapshot, Repeated ignored/violated directives, Concrete recommendations, Cluster suggestions, Risks.
 
-## Review Checklist
+### Curator Integration
 
-- Confirm the source knowledge IDs still match the intended behavior.
-- Check that required and forbidden actions are concrete enough for an agent to
-  follow.
-- Remove stale project-specific references before applying a cross-project
-  skill.
-- Prefer a narrow skill over broad procedural advice when only one workflow is
-  supported by evidence.
+When `curator.skill_generation_enabled: true` (default), the curator can emit `skill_candidates` JSON blocks:
 
-## Related Docs
+- High-confidence candidates (>= `curator.min_skill_confidence`, default 0.70) trigger `skill_generate` in **draft** mode
+- Activation always requires human review via `skill_apply`
+- Curator diagnostics (debug-gated) report malformed JSON without writes
 
-- [Knowledge System](knowledge.md) - storage, lifecycle, scoring, and curation
-- [Writing Tests Skill](../.opencode/skills/writing-tests/SKILL.md) - test
-  authoring rules for generated-skill changes
+---
+
+## Tools & Commands
+
+### Skills Management
+
+| Tool | Purpose | Mode |
+|------|---------|------|
+| `skill_generate` | Compile knowledge into draft (`.swarm/`) or active (`.opencode/`) skill | Architect → curator |
+| `skill_list` | List drafts and active generated skills | Any agent |
+| `skill_apply` | Activate a draft into `.opencode/skills/generated/<slug>/SKILL.md` | Human (manual command) |
+| `skill_inspect` | Print skill body with source knowledge IDs | Any agent |
+| `skill_regenerate` | Rebuild active skill from updated source knowledge | Human or curator |
+| `skill_improve` | (Optional) Invoke skill_improver agent for capability review | Architect with curator enabled |
+
+### Knowledge Commands (See [Commands Reference](commands.md) for full detail)
+
+| Command | Purpose |
+|---------|---------|
+| `/swarm knowledge` | List active entries |
+| `/swarm knowledge migrate` | Import legacy `.swarm/context.md` |
+| `/swarm knowledge quarantine <id> [reason]` | Hide entry (preserved) |
+| `/swarm knowledge restore <id>` | Un-quarantine |
+| `/swarm promote <text>` | Create new hive entry |
+| `/swarm promote --from-swarm <id>` | Promote existing swarm entry |
+| `/swarm curate` | Run curator review + hive promotion pass |
+| `/swarm learning [--json]` | Show aggregate metrics and ROI |
+
+---
+
+## Configuration
+
+Key settings (full reference: `src/config/schema.ts`):
+
+```jsonc
+{
+  "knowledge": {
+    "enabled": true,
+    "swarm_max_entries": 100,
+    "hive_max_entries": 200,
+    "auto_promote_days": 90,
+    "default_max_phases": 10,
+    "todo_max_phases": 3
+  },
+  "knowledge_application": {
+    "enabled": true,
+    "mode": "warn",                    // 'warn' (default) | 'enforce'
+    "min_confidence": 0.85,
+    "critical_requires_ack": true,
+    "high_risk_tools": ["save_plan", "update_task_status", "phase_complete"]
+  },
+  "curator": {
+    "skill_generation_enabled": true,
+    "min_skill_confidence": 0.70,
+    "min_skill_confirmations": 2
+  }
+}
+```
+
+---
+
+## Review Checklist for Generated Skills
+
+When reviewing a draft skill before applying:
+
+- [ ] Confirm the source knowledge IDs still match the intended behavior
+- [ ] Check that required and forbidden actions are concrete enough for an agent to follow
+- [ ] Remove stale project-specific references before applying a cross-project skill
+- [ ] Prefer a narrow skill over broad procedural advice when only one workflow is supported by evidence
+- [ ] Verify frontmatter `triggers:` and `applies_to_*` fields are specific (no generic tokens)
+- [ ] Ensure examples use realistic scenarios agents will encounter
+
+---
+
+## Related Documentation
+
+- **[Knowledge System](knowledge.md)** — storage schema, TTL decay, curation, validation, query ranking
+- **[Commands Reference](commands.md)** — `/swarm` subcommands including knowledge, skill, curator commands
+- **[Configuration Reference](configuration.md)** — all knowledge.*, knowledge_application.*, curator.* schema keys
+- **[Evidence and Telemetry](evidence-and-telemetry.md)** — how retrieval outcomes feed learning signals
+- **[Writing Tests Skill](../.opencode/skills/writing-tests/SKILL.md)** — test rules for skill changes
+- **[Architecture Deep Dive](architecture.md)** — knowledge in the control loop, evidence schema
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Swarm knowledge** | Project-specific, session-local entries in `.swarm/knowledge.jsonl` |
+| **Hive knowledge** | Cross-project, persistent entries in platform-specific user data directory |
+| **Generated skill** | Compilable SKILL.md derived from mature knowledge (review checklist, triggers, directives) |
+| **Maturity gate** | Decision logic determining if an entry can become a skill (outcome signal, confidence, confirmations) |
+| **Outcome signal** | Rollup of `applied_explicit_count`, `succeeded_after_shown_count`, `violated_count`, etc. |
+| **Knowledge injection** | Retrieval of relevant entries and inclusion in architect's prompt at phase start |
+| **Promotion** | Swarm → Hive transition after threshold (3 phases confirmed, fast-track, or 90-day age) |
+| **v2 directives** | Optional fields on knowledge entries (`triggers`, `required_actions`, `applies_to_agents/tools`, priority) |
+| **Knowledge application contract** | Architect MUST emit `KNOWLEDGE_APPLIED/IGNORED/VIOLATED` for applicable directives |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -31,7 +31,8 @@ During phase execution, knowledge is **retrieved and injected** into the archite
 1. **Search & Rank**
    - Unified `searchKnowledge()` queries both swarm and hive
    - Near-duplicate removal via Jaccard bigram similarity (threshold 0.6)
-   - Action-aware ranking: triggers, `applies_to_agents/tools`, priority level, trigger phrase boost
+    - Action-aware ranking: triggers, `applies_to_agents/tools`, priority level, trigger phrase boost
+    - For ranking algorithm details, see [Knowledge System](knowledge.md#query-ranking).
 
 2. **Injection Budget** (context-adaptive)
    - \>60% headroom: full budget (up to 5 entries, 2000 chars)
@@ -63,7 +64,8 @@ During phase execution, knowledge is **retrieved and injected** into the archite
 4. **Outcomes Recorded**
    - Chat-visible `KNOWLEDGE_*` markers are the enforcement gate
    - `knowledge_receipt` tool records outcomes to `.swarm/knowledge-application.jsonl`
-   - Counters: `shown_count`, `acknowledged_count`, `applied_explicit_count`, `ignored_count`, `violated_count`, `succeeded_after_shown_count`, `failed_after_shown_count`
+    - Counters: `shown_count`, `acknowledged_count`, `applied_explicit_count`, `ignored_count`, `violated_count`, `succeeded_after_shown_count`, `failed_after_shown_count`
+    - See [Evidence and Telemetry](evidence-and-telemetry.md) for the outcome persistence schema.
 
 ### Phase 3: Feedback & Learning
 
@@ -77,7 +79,8 @@ After phase completion, feedback is collected:
 
 2. **Knowledge Durability**
    - **TTL decay**: Active entries age every successful phase (increments `phases_alive`)
-   - Archived when `phases_alive > max_phases` (default 10 phases for general, 3 for `todo`)
+    - Archived when `phases_alive > max_phases` (default 10 phases for general, 3 for `todo`)
+    - Archived entries are excluded from query results but preserved on disk (not deleted). They can be restored via the quarantine/workflow tools if needed.
    - **Promoted entries are TTL-exempt** — live until explicitly quarantined
    - Quarantine workflow: `/swarm knowledge quarantine <id> [reason]` hides but preserves
 
@@ -109,13 +112,15 @@ Mature, high-confidence knowledge can be compiled into reusable **SKILL.md** fil
 An entry passes the maturity gate if:
 
 1. **Not negatively evidenced** — `computeOutcomeSignal >= 0` (no strong negative outcome)
-2. **Strong outcome bypass** — `applied_explicit_count >= 3` OR `succeeded_after_shown_count >= 3` AND `computeOutcomeSignal > 0`
+ 2. **Strong outcome bypass** — (`applied_explicit_count >= 3` OR `succeeded_after_shown_count >= 3`) AND `computeOutcomeSignal > 0`
    - Bypasses confidence floor and confirmation count
    - Allows well-evidenced singletons to become skills early
 3. **Legacy AND gates** — for other entries:
    - Confidence >= `min_skill_confidence` (default 0.70)
    - Either `confirmed_by` count >= `min_skill_confirmations` (default 2 distinct phases) OR strong outcome record
-   - Both conditions must independently hold (neither alone is sufficient)
+    - Both conditions must independently hold (neither alone is sufficient)
+
+> **Note:** `confirmed_by` tracks distinct phase numbers where the entry was actually applied (recorded via `KNOWLEDGE_APPLIED` markers). Only phases with evidence of use count toward the threshold.
 
 #### Generation Workflow
 
@@ -157,7 +162,8 @@ Agent task / curator review
 4. **Activation** — `skill_apply <slug>` promotes draft to `.opencode/skills/generated/<slug>/SKILL.md`
    - Becomes available to all agents via `SKILLS:` delegation field
    - Locked against overwrite (requires `force=true` if generator marker removed)
-   - Rejected candidates recorded to `.swarm/skills/rejected-edits.jsonl`
+    - Rejected candidates recorded to `.swarm/skills/rejected-edits.jsonl`
+    - Entries are added to this file when `isRejectedSkillContent` detects a hash match with previously rejected content, or when skill evaluation fails required-phrases or forbidden-phrases checks.
 
 5. **Ongoing Refinement** — `skill_regenerate <slug>` rebuilds active skill from updated source knowledge
 
@@ -235,7 +241,7 @@ When invoked, emits proposal with sections: Inventory snapshot, Repeated ignored
 When `curator.skill_generation_enabled: true` (default), the curator can emit `skill_candidates` JSON blocks:
 
 - High-confidence candidates (>= `curator.min_skill_confidence`, default 0.70) trigger `skill_generate` in **draft** mode
-- Activation always requires human review via `skill_apply`
+- When `skill_generation_mode: "draft"` (default), activation always requires human review via `skill_apply`. When `"active"`, generated skills are placed directly into `.opencode/skills/generated/` without a draft step.
 - Curator diagnostics (debug-gated) report malformed JSON without writes
 
 ---
@@ -290,6 +296,7 @@ Key settings (full reference: `src/config/schema.ts`):
     "high_risk_tools": ["save_plan", "update_task_status", "phase_complete"]
   },
   "curator": {
+    "skill_generation_mode": "draft",        // 'draft' (default) | 'active': 'active' bypasses draft review
     "skill_generation_enabled": true,
     "min_skill_confidence": 0.70,
     "min_skill_confirmations": 2
@@ -332,7 +339,7 @@ When reviewing a draft skill before applying:
 | **Generated skill** | Compilable SKILL.md derived from mature knowledge (review checklist, triggers, directives) |
 | **Maturity gate** | Decision logic determining if an entry can become a skill (outcome signal, confidence, confirmations) |
 | **Outcome signal** | Rollup of `applied_explicit_count`, `succeeded_after_shown_count`, `violated_count`, etc. |
-| **Knowledge injection** | Retrieval of relevant entries and inclusion in architect's prompt at phase start |
+| **Knowledge injection** | Retrieval of relevant entries and inclusion in architect's prompt at phase start — see [knowledge.md#injection](knowledge.md#injection) |
 | **Promotion** | Swarm → Hive transition after threshold (3 phases confirmed, fast-track, or 90-day age) |
 | **v2 directives** | Optional fields on knowledge entries (`triggers`, `required_actions`, `applies_to_agents/tools`, priority) |
 | **Knowledge application contract** | Architect MUST emit `KNOWLEDGE_APPLIED/IGNORED/VIOLATED` for applicable directives |


### PR DESCRIPTION
Closes #1298

## Summary

This PR comprehensively documents the complete knowledge lifecycle in OpenCode Swarm, transforming `docs/skills.md` from a narrow focus on "Generated Skills" into a dedicated source of truth for how knowledge flows through the entire system—from creation through retrieval, feedback, promotion, and skill compilation.

### Key Changes

**Complete Knowledge Lifecycle** — All 5 phases now documented:
1. **Phase 1: Knowledge Creation** — 4 routes (agent tool, manual, curator, migration)
2. **Phase 2: Knowledge Injection & Application** — Search, ranking, injection budget, architect contract
3. **Phase 3: Feedback & Learning** — Outcome scoring, TTL decay, curator review
4. **Phase 4: Promotion to Hive** — Cross-project transitions (explicit, fast-track, age-based)
5. **Phase 5: Skill Generation & Compilation** — Maturity gate, generation workflow, file layout

**Enhanced Documentation** includes:
- Tools & Commands reference (skill_generate, skill_list, skill_apply, etc.)
- Configuration section with practical JSON examples
- Review checklist for generated skills
- Comprehensive glossary (swarm knowledge, hive knowledge, maturity gate, directives, etc.)
- Proper cross-references to knowledge.md, commands.md, configuration.md, architecture.md

### Why This Matters

- **Unified Narrative**: Users now see the end-to-end flow instead of isolated concepts
- **Complements knowledge.md**: skills.md covers lifecycle & generation; knowledge.md covers storage & curation
- **Clarity for Contributors**: Clear mental model of when/how knowledge becomes skills
- **Better Discoverability**: 5 phases + glossary makes it easier to find what you need

## Invariant audit

- 1 (plugin init): not touched - documentation only
- 2 (runtime portability): not touched - documentation only
- 3 (subprocesses): not touched - documentation only
- 4 (.swarm containment): not touched - documentation only
- 5 (plan durability): not touched - documentation only
- 6 (test_runner safety): not touched - documentation only
- 7 (test writing): not touched - documentation only
- 8 (session state): not touched - documentation only
- 9 (guardrails/retry): not touched - documentation only
- 10 (chat/system msg): not touched - documentation only
- 11 (tool registration): not touched - documentation only
- 12 (release/cache): not touched - documentation only

No release fragment required — documentation change only.

## Test plan

- ✅ Content validation: All cross-links verified (knowledge.md, commands.md, configuration.md, architecture.md exist)
- ✅ Markdown syntax: No linting issues
- ✅ Terminology consistency: Glossary terms used throughout
- ✅ Code examples: YAML and JSON syntax validated
- ✅ Table formatting: All markdown tables render correctly
