### PR TITLE
feat(background): wire async stage b gates

### DIFF
--- a/docs/releases/pending/1151-background-stage-b-gates.md
+++ b/docs/releases/pending/1151-background-stage-b-gates.md
@@ -1,0 +1,5 @@
+---
+type: feature
+---
+
+Wire trusted background Stage B completions into reviewer/test_engineer gate evidence, review receipts, workflow-state advancement, and stale-workspace rejection. Accepted gate completions are marked `consumed`; stale or errored background gates remain non-satisfying terminal ledger rows.

--- a/docs/troubleshooting/recovery-guide.md
+++ b/docs/troubleshooting/recovery-guide.md
@@ -89,11 +89,15 @@ await importCheckpoint()
 A background `Task` returns a **running placeholder immediately** and delivers the real
 result **later** via a synthetic parent message. Swarm's delegation gate treats a `Task`
 result as completion, so consuming the placeholder would advance Stage B and record gate
-evidence **before any review/test output exists**. Until swarm can correlate the deferred
-completion safely (tracked as a separate, spike-gated change), swarm **fail-closed-blocks**
+evidence **before any review/test output exists**. By default, swarm **fail-closed-blocks**
 background delegations for any swarm role (reviewer, test_engineer, coder, explorer, etc.).
 Swarm never silently rewrites `background` to `false` — the unsupported capability is
 surfaced explicitly.
+
+With `hooks.background_subagents: true`, this is no longer future work for
+Stage B reviewer/test_engineer gates: swarm tracks the background dispatch and
+waits for trusted terminal completion ingestion instead of treating the running
+placeholder as completion.
 
 **Action needed (default):** Re-issue the delegation **without** `background` (or with
 `background: false`). Foreground swarm delegations are unaffected. Non-swarm OpenCode
@@ -102,7 +106,7 @@ in `tool.execute.before`, so OpenCode rejects the call before the background tas
 a belt-and-suspenders check in `tool.execute.after` ensures a running placeholder never
 advances workflow state even if it slips through.
 
-### Opt-in tracking and advisory ingestion
+### Opt-in tracking and Stage B ingestion
 
 Setting `hooks.background_subagents: true` lifts the block: background swarm dispatches are
 **allowed and tracked** as durable pending records in `.swarm/background-delegations.jsonl`,
@@ -110,10 +114,11 @@ and the observer ingests trusted `synthetic` task envelopes into that advisory l
 they correlate to a real dispatch. Unresolved pendings are transitioned to `stale` after
 `hooks.background_pending_timeout_minutes` (default 30); the on-disk log is append-only.
 
-> **Advisory only:** a background completion does **not** advance workflow gates or
-> record gate evidence yet. Background swarm delegations are tracked and collectable, but they
-> do not satisfy reviewer/test_engineer gates — use foreground delegations when you
-> need a gate to advance. Requires upstream `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true`.
+For Stage B reviewer/test_engineer background delegations, the completion is no
+longer advisory-only after PR2: it must correlate to a pending record, match the
+parent session, pass workspace freshness checks, and record durable gate evidence
+before live workflow state can advance. Requires upstream
+`OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true`.
 
 ---
 
@@ -150,6 +155,41 @@ fresh `batch_id`.
 session when the tool context supplies one. If a batch was launched in a
 different session, collect it from that parent session, or relaunch the advisory
 lanes in the current session.
+
+## 9. Recovering from Background Stage B Gate Batches
+
+When `hooks.background_subagents: true` is enabled, native background `Task`
+dispatches to gate-bearing agents are tracked in `.swarm/background-delegations.jsonl`.
+Reviewer and `test_engineer` completions are correctness-critical: they only
+advance `.swarm/evidence/{taskId}.json` and `taskWorkflowStates` after the
+trusted synthetic terminal envelope is correlated to the original parent
+session and the workspace snapshot still matches.
+
+**Pending reviewer/test gate:** do not mark the task complete while the matching
+background row is `pending` or `running`. Wait for the synthetic completion. The
+task should remain before `tests_run`, so `update_task_status(... completed)`
+continues to block.
+
+**Consumed Stage B row:** `consumed` means the terminal background completion was
+accepted and applied to gate evidence, review receipts when applicable, and the
+live Stage B state machine. If both reviewer and `test_engineer` evidence rows
+exist, completion can proceed normally.
+
+**Stale workspace:** a Stage B row becomes `stale` when the git head, dirty-tree
+hash, PR head SHA, or project directory no longer matches the dispatch snapshot.
+Treat the stale result as not reviewed. Re-dispatch the affected reviewer or
+`test_engineer` gate against the current workspace; do not reuse the stale gate
+as evidence.
+
+**Error row:** terminal `error` records do not advance gates. Inspect the stored
+result/error text, fix the underlying problem, and re-run the missing Stage B
+agent. The task is not complete until the required gate evidence is present.
+
+**Ingestion error:** `ingestion_error` means the terminal background result was
+trusted and stored, but swarm could not apply the evidence, receipt, or workflow
+state update. Fix the reported local storage/problem and replay the trusted
+completion event if available, or re-dispatch the missing Stage B gate. Do not
+count the gate as satisfied until the row becomes `consumed`.
 
 ---
 

--- a/src/background/completion-observer.ts
+++ b/src/background/completion-observer.ts
@@ -1,19 +1,10 @@
 /**
  * Background subagent completion observer/ingester.
  *
- * Registers as a swarm `event` hook to watch for the upstream background-completion signal:
- * a message part with `synthetic === true` whose text is a task envelope with
- * `state="completed"` or `state="error"`. When such a part correlates to a durable pending
- * background-delegation record, it is logged (debug-gated) as the empirical confirmation
- * instrument operators use to verify the runtime signal in a real environment.
- *
- * PR1 async advisory lanes ingest trusted terminal completions into the durable
- * background-delegation ledger only. This still NEVER advances workflow gates or records
- * gate evidence; gate-bearing execution is intentionally outside this advisory path.
- *
- * The `synthetic` flag is the trust gate (set by OpenCode, not the model/user). Non-synthetic
- * text that merely looks like an envelope is ignored. The observer is fail-open: any error is
- * swallowed so it can never block event delivery or plugin load (Invariant 1/10).
+ * Trusted synthetic background completions always settle the durable
+ * background-delegation ledger. Correctness-critical Stage B completions then
+ * pass through workspace freshness validation before gate evidence, receipts, or
+ * task workflow state can advance.
  */
 
 import { createHash } from 'node:crypto';
@@ -22,6 +13,11 @@ import {
 	appendDelegationTransition,
 	findByCorrelationId,
 } from './pending-delegations.js';
+import {
+	ingestBackgroundStageBCompletion,
+	isBackgroundGateBearingRecord,
+	validateStageBWorkspace,
+} from './stage-b-gates.js';
 import { parseTaskEnvelope } from './task-envelope.js';
 
 interface ObserverConfig {
@@ -40,10 +36,6 @@ interface MaybeEvent {
 	properties?: { part?: unknown } & Record<string, unknown>;
 }
 
-/**
- * Build the background completion observer. Returns an `event` handler suitable for the
- * OpenCode plugin `event` hook. No-op (cheap early return) when the feature is disabled.
- */
 export function createBackgroundCompletionObserver(opts: {
 	config: ObserverConfig;
 	directory: string;
@@ -60,13 +52,11 @@ export function createBackgroundCompletionObserver(opts: {
 			const part = evt.properties?.part as MaybeTextPart | undefined;
 			if (!part || part.type !== 'text') return;
 
-			// Trust gate: only OpenCode-set synthetic parts are considered.
 			if (part.synthetic !== true) return;
 			if (typeof part.text !== 'string') return;
 
 			const envelope = parseTaskEnvelope(part.text);
 			if (!envelope) return;
-			// Only terminal states are completion signals; running placeholders are dispatch.
 			if (envelope.state !== 'completed' && envelope.state !== 'error') return;
 
 			const pending = findByCorrelationId(directory, envelope.sessionId);
@@ -74,10 +64,8 @@ export function createBackgroundCompletionObserver(opts: {
 				typeof part.sessionID === 'string' ? part.sessionID : 'unknown';
 
 			if (!pending) {
-				// Synthetic completion with no matching durable record — log for visibility
-				// but take no action (could be a non-swarm background task or a spoof).
 				logger.log(
-					`[background] observed synthetic completion (state=${envelope.state}) for subagent ${envelope.sessionId} in parent ${parentSessionId} with NO matching pending record — ignored`,
+					`[background] observed synthetic completion (state=${envelope.state}) for subagent ${envelope.sessionId} in parent ${parentSessionId} with NO matching pending record - ignored`,
 				);
 				return;
 			}
@@ -87,7 +75,11 @@ export function createBackgroundCompletionObserver(opts: {
 				);
 				return;
 			}
-			if (pending.status !== 'pending' && pending.status !== 'running') {
+			if (
+				pending.status !== 'pending' &&
+				pending.status !== 'running' &&
+				pending.status !== 'ingestion_error'
+			) {
 				logger.log(
 					`[background] observed duplicate/late completion for ${envelope.sessionId}; current status=${pending.status}; ignored`,
 				);
@@ -98,24 +90,74 @@ export function createBackgroundCompletionObserver(opts: {
 				envelope.state === 'error'
 					? (envelope.errorText ?? '')
 					: (envelope.resultText ?? '');
-			await appendDelegationTransition(directory, envelope.sessionId, {
-				status: envelope.state === 'error' ? 'error' : 'completed',
-				result: {
-					...(envelope.state === 'error' ? { error: text } : { text }),
-					chars: envelope.resultChars ?? text.length,
-					truncated: envelope.resultTruncated ?? false,
-					digest: digest(text),
+			const result = {
+				...(envelope.state === 'error' ? { error: text } : { text }),
+				chars: envelope.resultChars ?? text.length,
+				truncated: envelope.resultTruncated ?? false,
+				digest: digest(text),
+			};
+			if (
+				envelope.state === 'completed' &&
+				isBackgroundGateBearingRecord(pending)
+			) {
+				const freshness = validateStageBWorkspace(directory, pending);
+				if (freshness.stale) {
+					const reason =
+						freshness.reason ??
+						'workspace changed before background Stage B completion';
+					await appendDelegationTransition(directory, envelope.sessionId, {
+						status: 'stale',
+						result: {
+							error: reason,
+							chars: reason.length,
+							truncated: false,
+							digest: digest(reason),
+						},
+					});
+					logger.warn(
+						`[background] stale Stage B completion ignored: agent=${pending.normalizedAgent} task=${pending.evidenceTaskId ?? pending.planTaskId ?? 'unknown'} reason=${reason}`,
+					);
+					return;
+				}
+			}
+			const terminal = await appendDelegationTransition(
+				directory,
+				envelope.sessionId,
+				{
+					status: envelope.state === 'error' ? 'error' : 'completed',
+					result,
 				},
-			});
+			);
+
+			if (envelope.state === 'completed' && terminal) {
+				const ingested = await ingestBackgroundStageBCompletion({
+					directory,
+					record: terminal,
+					result: terminal.result ?? result,
+				});
+				if (ingested.consumed) {
+					await appendDelegationTransition(directory, envelope.sessionId, {
+						status: 'consumed',
+					});
+				}
+				if (!ingested.ok) {
+					await appendDelegationTransition(directory, envelope.sessionId, {
+						status: 'ingestion_error',
+						result: terminal.result ?? result,
+					});
+					logger.warn(
+						`[background] Stage B completion was not applied: agent=${terminal.normalizedAgent} task=${terminal.evidenceTaskId ?? terminal.planTaskId ?? 'unknown'} reason=${ingested.reason ?? 'unknown'}`,
+					);
+				}
+			}
 
 			logger.log(
 				`[background] observed trusted completion (state=${envelope.state}) correlated to pending delegation: ` +
 					`agent=${pending.normalizedAgent} task=${pending.evidenceTaskId ?? pending.planTaskId ?? 'unknown'} ` +
 					`parent=${pending.parentSessionId} observedParent=${parentSessionId} pendingStatus=${pending.status} ` +
-					'(advisory ledger update only — no gate effect)',
+					`stageB=${isBackgroundGateBearingRecord(pending)}`,
 			);
 		} catch (err) {
-			// Fail-open: never block event delivery.
 			logger.warn(
 				`[background] completion observer error: ${err instanceof Error ? err.message : String(err)}`,
 			);

--- a/src/background/pending-delegations.ts
+++ b/src/background/pending-delegations.ts
@@ -12,8 +12,8 @@
  *
  * Scope: dispatch records `pending`/`running` snapshots, collection or trusted synthetic
  * completions record terminal snapshots, and the stale sweep records `stale` snapshots.
- * This store still has NO gate advancement and NO gate evidence side effect; it is an
- * advisory result ledger only.
+ * This store itself has no gate-advancement side effect. Stage B gate ingestion is a
+ * separate consumer of trusted terminal snapshots.
  *
  * Concurrency: all writes (append, sweep) run under a single project-scoped lock via
  * `withEvidenceLock`, so concurrent dispatches/sweeps cannot interleave appends. Reads are
@@ -23,6 +23,7 @@
  * `.swarm/` (Invariant 4).
  */
 
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { z } from 'zod';
@@ -39,6 +40,7 @@ const STORE_LOCK_TASK = 'background-delegations';
 export type BackgroundDelegationStatus =
 	| 'pending'
 	| 'running'
+	| 'ingestion_error'
 	| 'completed'
 	| 'error'
 	| 'cancelled'
@@ -77,6 +79,7 @@ export interface BackgroundDelegationRecord {
 	promptHash?: string;
 	/** Project/root provenance captured at dispatch time. */
 	workspace?: BackgroundWorkspaceSnapshot;
+	prompt?: BackgroundPromptSnapshot;
 	generation?: number;
 	result?: BackgroundDelegationResult;
 	completedAt?: number;
@@ -88,6 +91,13 @@ export interface BackgroundWorkspaceSnapshot {
 	dirtyHash: string | null;
 	prHeadSha: string | null;
 	scope: string | null;
+}
+
+export interface BackgroundPromptSnapshot {
+	text: string;
+	chars: number;
+	truncated: boolean;
+	digest: string;
 }
 
 export interface BackgroundDelegationResult {
@@ -118,6 +128,15 @@ const WorkspaceSchema = z
 	})
 	.strict();
 
+const PromptSchema = z
+	.object({
+		text: z.string(),
+		chars: z.number(),
+		truncated: z.boolean(),
+		digest: z.string(),
+	})
+	.strict();
+
 const RecordSchema = z
 	.object({
 		schemaVersion: z.union([z.literal(1), z.literal(2)]),
@@ -133,6 +152,7 @@ const RecordSchema = z
 		status: z.enum([
 			'pending',
 			'running',
+			'ingestion_error',
 			'completed',
 			'error',
 			'cancelled',
@@ -146,6 +166,7 @@ const RecordSchema = z
 		mode: z.string().optional(),
 		promptHash: z.string().optional(),
 		workspace: WorkspaceSchema.optional(),
+		prompt: PromptSchema.optional(),
 		generation: z.number().optional(),
 		result: ResultSchema.optional(),
 		completedAt: z.number().optional(),
@@ -240,6 +261,7 @@ export interface RecordPendingInput {
 	mode?: string;
 	promptHash?: string;
 	workspace?: BackgroundWorkspaceSnapshot;
+	prompt?: BackgroundPromptSnapshot;
 	generation?: number;
 }
 
@@ -275,6 +297,7 @@ export async function recordPendingDelegation(
 		...(input.mode ? { mode: input.mode } : {}),
 		...(input.promptHash ? { promptHash: input.promptHash } : {}),
 		...(input.workspace ? { workspace: input.workspace } : {}),
+		...(input.prompt ? { prompt: input.prompt } : {}),
 		...(input.generation !== undefined ? { generation: input.generation } : {}),
 	};
 
@@ -300,6 +323,21 @@ export async function recordPendingDelegation(
 	}
 }
 
+export function buildPromptSnapshot(
+	text: string,
+	maxChars: number,
+): BackgroundPromptSnapshot {
+	const boundedMax = Math.max(0, Math.min(maxChars, 20_000));
+	const truncated = text.length > boundedMax;
+	const bounded = truncated ? text.slice(0, boundedMax) : text;
+	return {
+		text: bounded,
+		chars: text.length,
+		truncated,
+		digest: createHash('sha256').update(text).digest('hex'),
+	};
+}
+
 export async function appendDelegationTransition(
 	directory: string,
 	correlationId: string,
@@ -320,7 +358,11 @@ export async function appendDelegationTransition(
 			async () => {
 				const current = findByCorrelationId(directory, correlationId);
 				if (!current) return;
-				if (isTerminal(current.status) && transition.status !== 'consumed') {
+				if (
+					isTerminal(current.status) &&
+					transition.status !== 'consumed' &&
+					transition.status !== 'ingestion_error'
+				) {
 					next = current;
 					return;
 				}
@@ -394,7 +436,12 @@ function sweepStaleLocked(
 ): number {
 	let swept = 0;
 	for (const record of readDelegations(directory)) {
-		if (record.status !== 'pending' && record.status !== 'running') continue;
+		if (
+			record.status !== 'pending' &&
+			record.status !== 'running' &&
+			record.status !== 'ingestion_error'
+		)
+			continue;
 		if (now - record.updatedAt <= timeoutMs) continue;
 		appendRecord(directory, {
 			...record,

--- a/src/background/stage-b-gates.ts
+++ b/src/background/stage-b-gates.ts
@@ -32,6 +32,8 @@ const GATE_EVIDENCE_ROLES = new Set([
 	'explorer',
 	'sme',
 ]);
+// Only reviewer/test_engineer advance the live task state machine. The broader
+// set above records gate evidence for other gate-bearing background roles.
 
 type StageBStateRole = 'reviewer' | 'test_engineer';
 
@@ -57,8 +59,9 @@ export function validateStageBWorkspace(
 	record: BackgroundDelegationRecord,
 ): { ok: boolean; stale: boolean; reason?: string } {
 	const actualWorkspace = captureWorkspaceSnapshot(directory, {
-		prHeadSha: record.workspace?.prHeadSha ?? null,
 		scope: record.workspace?.scope ?? null,
+		prHeadSha: record.workspace?.prHeadSha ?? null,
+		resolveCurrentPrHeadSha: record.workspace?.prHeadSha !== null,
 	});
 	const check = compareWorkspaceSnapshots(record.workspace, actualWorkspace);
 	return { ...check, ok: !check.stale };
@@ -71,6 +74,8 @@ export async function ingestBackgroundStageBCompletion(args: {
 }): Promise<StageBIngestionResult> {
 	const taskId = args.record.evidenceTaskId ?? args.record.planTaskId;
 	if (!taskId || !isBackgroundGateBearingRecord(args.record)) {
+		// The trusted terminal completion is still settled in the durable ledger by
+		// the caller; it simply has no Stage B evidence/state side effects.
 		return { ok: true, consumed: false };
 	}
 

--- a/src/background/stage-b-gates.ts
+++ b/src/background/stage-b-gates.ts
@@ -1,0 +1,199 @@
+import { recordAgentDispatch, recordGateEvidence } from '../gate-evidence.js';
+import { collectReviewerReceiptFromTranscript } from '../hooks/review-receipt-collector.js';
+import {
+	type AgentSessionState,
+	advanceTaskState,
+	getTaskState,
+	hasActiveTurboMode,
+	hasBothStageBCompletions,
+	recordStageBCompletion,
+	swarmState,
+} from '../state.js';
+import * as logger from '../utils/logger.js';
+import type {
+	BackgroundDelegationRecord,
+	BackgroundDelegationResult,
+} from './pending-delegations.js';
+import {
+	captureWorkspaceSnapshot,
+	compareWorkspaceSnapshots,
+} from './workspace-snapshot.js';
+
+const GATE_EVIDENCE_ROLES = new Set([
+	'reviewer',
+	'test_engineer',
+	'docs',
+	'designer',
+	'critic',
+	'critic_sounding_board',
+	'critic_drift_verifier',
+	'critic_hallucination_verifier',
+	'critic_architecture_supervisor',
+	'explorer',
+	'sme',
+]);
+
+type StageBStateRole = 'reviewer' | 'test_engineer';
+
+export interface StageBIngestionResult {
+	ok: boolean;
+	consumed: boolean;
+	stale?: boolean;
+	reason?: string;
+}
+
+export function isBackgroundGateBearingRecord(
+	record: BackgroundDelegationRecord,
+): boolean {
+	return (
+		record.batchId === undefined &&
+		record.evidenceTaskId !== null &&
+		GATE_EVIDENCE_ROLES.has(record.normalizedAgent)
+	);
+}
+
+export function validateStageBWorkspace(
+	directory: string,
+	record: BackgroundDelegationRecord,
+): { ok: boolean; stale: boolean; reason?: string } {
+	const actualWorkspace = captureWorkspaceSnapshot(directory, {
+		prHeadSha: record.workspace?.prHeadSha ?? null,
+		scope: record.workspace?.scope ?? null,
+	});
+	const check = compareWorkspaceSnapshots(record.workspace, actualWorkspace);
+	return { ...check, ok: !check.stale };
+}
+
+export async function ingestBackgroundStageBCompletion(args: {
+	directory: string;
+	record: BackgroundDelegationRecord;
+	result: BackgroundDelegationResult;
+}): Promise<StageBIngestionResult> {
+	const taskId = args.record.evidenceTaskId ?? args.record.planTaskId;
+	if (!taskId || !isBackgroundGateBearingRecord(args.record)) {
+		return { ok: true, consumed: false };
+	}
+
+	const workspaceCheck = validateStageBWorkspace(args.directory, args.record);
+	if (workspaceCheck.stale) {
+		return {
+			ok: false,
+			consumed: false,
+			stale: true,
+			reason:
+				workspaceCheck.reason ?? 'workspace changed while gate was running',
+		};
+	}
+
+	try {
+		await recordAgentDispatch(
+			args.directory,
+			taskId,
+			stageBRequiredGateAgent(args.record.normalizedAgent),
+			hasActiveTurboMode(args.record.parentSessionId),
+		);
+		await recordGateEvidence(
+			args.directory,
+			taskId,
+			args.record.normalizedAgent,
+			args.record.subagentSessionId,
+			hasActiveTurboMode(args.record.parentSessionId),
+		);
+
+		if (args.record.normalizedAgent === 'reviewer') {
+			await collectReviewerReceiptFromTranscript(args.directory, {
+				targetAgent: args.record.swarmPrefixedAgent,
+				prompt: args.record.prompt?.text ?? '',
+				transcript: args.result.text ?? '',
+				sessionID: args.record.subagentSessionId,
+			});
+		}
+
+		if (
+			args.record.normalizedAgent === 'reviewer' ||
+			args.record.normalizedAgent === 'test_engineer'
+		) {
+			applyStageBStateCompletion(
+				taskId,
+				args.record.normalizedAgent,
+				args.record.parentSessionId,
+			);
+		}
+
+		return { ok: true, consumed: true };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		logger.warn(`[background-stage-b] ingestion failed: ${message}`);
+		return {
+			ok: false,
+			consumed: false,
+			reason: `stage-b ingestion failed: ${message}`,
+		};
+	}
+}
+
+function stageBRequiredGateAgent(agent: string): string {
+	return agent === 'reviewer' || agent === 'test_engineer' ? 'coder' : agent;
+}
+
+function candidateSessions(parentSessionId: string): AgentSessionState[] {
+	const parent = swarmState.agentSessions.get(parentSessionId);
+	return parent ? [parent] : [];
+}
+
+function applyStageBStateCompletion(
+	taskId: string,
+	agent: StageBStateRole,
+	parentSessionId: string,
+): void {
+	for (const session of candidateSessions(parentSessionId)) {
+		recordStageBCompletion(session, taskId, agent);
+		const state = getTaskState(session, taskId);
+		if (state === 'tests_run' || state === 'complete') continue;
+
+		if (hasBothStageBCompletions(session, taskId)) {
+			try {
+				if (state === 'coder_delegated' || state === 'pre_check_passed') {
+					advanceTaskState(session, taskId, 'reviewer_run', {
+						telemetrySessionId: parentSessionId,
+					});
+				}
+				if (getTaskState(session, taskId) === 'reviewer_run') {
+					advanceTaskState(session, taskId, 'tests_run', {
+						telemetrySessionId: parentSessionId,
+					});
+				}
+			} catch (err) {
+				logger.warn(
+					`[background-stage-b] could not advance ${taskId} after ${agent}: ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
+			continue;
+		}
+
+		if (
+			agent === 'reviewer' &&
+			(state === 'coder_delegated' || state === 'pre_check_passed')
+		) {
+			try {
+				advanceTaskState(session, taskId, 'reviewer_run', {
+					telemetrySessionId: parentSessionId,
+				});
+			} catch (err) {
+				logger.warn(
+					`[background-stage-b] could not advance ${taskId} to reviewer_run: ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
+		} else if (agent === 'test_engineer' && state === 'reviewer_run') {
+			try {
+				advanceTaskState(session, taskId, 'tests_run', {
+					telemetrySessionId: parentSessionId,
+				});
+			} catch (err) {
+				logger.warn(
+					`[background-stage-b] could not advance ${taskId} to tests_run: ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
+		}
+	}
+}

--- a/src/background/workspace-snapshot.ts
+++ b/src/background/workspace-snapshot.ts
@@ -8,6 +8,17 @@ const GIT_SNAPSHOT_MAX_BUFFER = 512 * 1024;
 
 type SpawnSync = typeof child_process.spawnSync;
 
+interface CaptureWorkspaceSnapshotOptions {
+	scope?: string | null;
+	prHeadSha?: string | null;
+	/**
+	 * Re-resolve the current upstream ref for freshness validation. When the
+	 * dispatch captured an explicit PR head SHA, ingestion must compare against a
+	 * live local ref, not replay the stored metadata back into the snapshot.
+	 */
+	resolveCurrentPrHeadSha?: boolean;
+}
+
 function runGit(directory: string, args: string[]): string | null {
 	const result = _internals.spawnSync('git', ['-C', directory, ...args], {
 		cwd: directory,
@@ -22,20 +33,22 @@ function runGit(directory: string, args: string[]): string | null {
 
 export function captureWorkspaceSnapshot(
 	directory: string,
-	optionsOrScope:
-		| string
-		| null
-		| { scope?: string | null; prHeadSha?: string | null } = null,
+	optionsOrScope: string | null | CaptureWorkspaceSnapshotOptions = null,
 	prHeadShaArg: string | null = null,
 ): BackgroundWorkspaceSnapshot {
 	const scope =
 		typeof optionsOrScope === 'object' && optionsOrScope !== null
 			? (optionsOrScope.scope ?? null)
 			: optionsOrScope;
-	const prHeadSha =
-		typeof optionsOrScope === 'object' && optionsOrScope !== null
-			? (optionsOrScope.prHeadSha ?? null)
-			: prHeadShaArg;
+	const prHeadSha = (() => {
+		if (typeof optionsOrScope !== 'object' || optionsOrScope === null) {
+			return prHeadShaArg;
+		}
+		if (optionsOrScope.resolveCurrentPrHeadSha) {
+			return runGit(directory, ['rev-parse', '@{upstream}']);
+		}
+		return optionsOrScope.prHeadSha ?? null;
+	})();
 	const gitHead = runGit(directory, ['rev-parse', 'HEAD']);
 	const porcelain = runGit(directory, [
 		'status',

--- a/src/background/workspace-snapshot.ts
+++ b/src/background/workspace-snapshot.ts
@@ -1,0 +1,103 @@
+import * as child_process from 'node:child_process';
+import { createHash } from 'node:crypto';
+import * as path from 'node:path';
+import type { BackgroundWorkspaceSnapshot } from './pending-delegations.js';
+
+const GIT_SNAPSHOT_TIMEOUT_MS = 3_000;
+const GIT_SNAPSHOT_MAX_BUFFER = 512 * 1024;
+
+type SpawnSync = typeof child_process.spawnSync;
+
+function runGit(directory: string, args: string[]): string | null {
+	const result = _internals.spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		encoding: 'utf-8',
+		timeout: GIT_SNAPSHOT_TIMEOUT_MS,
+		maxBuffer: GIT_SNAPSHOT_MAX_BUFFER,
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+	if (result.error || result.status !== 0) return null;
+	return typeof result.stdout === 'string' ? result.stdout.trimEnd() : null;
+}
+
+export function captureWorkspaceSnapshot(
+	directory: string,
+	optionsOrScope:
+		| string
+		| null
+		| { scope?: string | null; prHeadSha?: string | null } = null,
+	prHeadShaArg: string | null = null,
+): BackgroundWorkspaceSnapshot {
+	const scope =
+		typeof optionsOrScope === 'object' && optionsOrScope !== null
+			? (optionsOrScope.scope ?? null)
+			: optionsOrScope;
+	const prHeadSha =
+		typeof optionsOrScope === 'object' && optionsOrScope !== null
+			? (optionsOrScope.prHeadSha ?? null)
+			: prHeadShaArg;
+	const gitHead = runGit(directory, ['rev-parse', 'HEAD']);
+	const porcelain = runGit(directory, [
+		'status',
+		'--porcelain=v1',
+		'--untracked-files=all',
+	]);
+	return {
+		directory: path.resolve(directory),
+		gitHead,
+		dirtyHash: porcelain === null ? null : digest(porcelain),
+		prHeadSha,
+		scope,
+	};
+}
+
+export function workspaceSnapshotMatches(
+	expected: BackgroundWorkspaceSnapshot | undefined,
+	current: BackgroundWorkspaceSnapshot,
+): { ok: true } | { ok: false; reason: string } {
+	if (!expected) return { ok: true };
+	if (path.resolve(expected.directory) !== path.resolve(current.directory)) {
+		return {
+			ok: false,
+			reason: `directory changed: expected ${expected.directory}, got ${current.directory}`,
+		};
+	}
+	const checks: Array<
+		keyof Pick<
+			BackgroundWorkspaceSnapshot,
+			'gitHead' | 'dirtyHash' | 'prHeadSha'
+		>
+	> = ['gitHead', 'dirtyHash', 'prHeadSha'];
+	for (const key of checks) {
+		const expectedValue = expected[key];
+		if (expectedValue === null) continue;
+		if (current[key] !== expectedValue) {
+			return {
+				ok: false,
+				reason: `${key} changed: expected ${expectedValue}, got ${current[key] ?? 'unknown'}`,
+			};
+		}
+	}
+	return { ok: true };
+}
+
+export type WorkspaceFreshness = ReturnType<typeof workspaceSnapshotMatches>;
+
+export const compareWorkspaceSnapshot = workspaceSnapshotMatches;
+
+export function compareWorkspaceSnapshots(
+	expected: BackgroundWorkspaceSnapshot | undefined,
+	current: BackgroundWorkspaceSnapshot,
+): { stale: boolean; reason?: string } {
+	const result = workspaceSnapshotMatches(expected, current);
+	if (result.ok) return { stale: false };
+	return { stale: true, reason: result.reason };
+}
+
+export function digest(text: string): string {
+	return createHash('sha256').update(text).digest('hex');
+}
+
+export const _internals: { spawnSync: SpawnSync } = {
+	spawnSync: child_process.spawnSync,
+};

--- a/src/gate-evidence.ts
+++ b/src/gate-evidence.ts
@@ -87,6 +87,14 @@ export function deriveRequiredGates(agentType: string): string[] {
 			return ['test_engineer'];
 		case 'critic':
 			return ['critic'];
+		case 'critic_sounding_board':
+			return ['critic_sounding_board'];
+		case 'critic_drift_verifier':
+			return ['critic_drift_verifier'];
+		case 'critic_hallucination_verifier':
+			return ['critic_hallucination_verifier'];
+		case 'critic_architecture_supervisor':
+			return ['critic_architecture_supervisor'];
 		default:
 			return ['reviewer', 'test_engineer'];
 	}

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -1360,8 +1360,10 @@ export function createDelegationGateHook(
 						const { extractDispatchIds } = await import(
 							'../background/task-envelope.js'
 						);
-						const { recordPendingDelegation } = await import(
-							'../background/pending-delegations.js'
+						const { buildPromptSnapshot, recordPendingDelegation } =
+							await import('../background/pending-delegations.js');
+						const { captureWorkspaceSnapshot } = await import(
+							'../background/workspace-snapshot.js'
 						);
 						const { subagentSessionId, jobId } = extractDispatchIds(_output);
 						if (subagentSessionId) {
@@ -1371,6 +1373,15 @@ export function createDelegationGateHook(
 								session,
 								directory,
 							);
+							const scope =
+								session.declaredCoderScope &&
+								session.declaredCoderScope.length > 0
+									? session.declaredCoderScope.join(',')
+									: evidenceTaskId;
+							const prHeadShaRaw =
+								mergedArgs.prHeadSha ?? mergedArgs.pr_head_sha;
+							const prHeadSha =
+								typeof prHeadShaRaw === 'string' ? prHeadShaRaw : null;
 							await recordPendingDelegation(
 								directory,
 								{
@@ -1383,6 +1394,18 @@ export function createDelegationGateHook(
 									swarmPrefixedAgent: subagentType,
 									planTaskId: evidenceTaskId,
 									evidenceTaskId,
+									workspace: captureWorkspaceSnapshot(directory, {
+										prHeadSha,
+										scope,
+									}),
+									prompt:
+										typeof mergedArgs.prompt === 'string'
+											? buildPromptSnapshot(
+													mergedArgs.prompt,
+													delegationMaxChars,
+												)
+											: undefined,
+									generation: 1,
 								},
 								{ staleTimeoutMs: backgroundPendingTimeoutMs },
 							);

--- a/src/hooks/review-receipt-collector.ts
+++ b/src/hooks/review-receipt-collector.ts
@@ -180,8 +180,73 @@ export interface ReviewerReceiptOutput {
 	output?: unknown;
 }
 
+export interface ReviewerReceiptTranscriptInput {
+	targetAgent?: string;
+	prompt: string;
+	transcript: string;
+	sessionID?: string;
+	sessionId?: string;
+}
+
 function isTaskTool(tool: unknown): boolean {
 	return tool === 'Task' || tool === 'task';
+}
+
+export async function collectReviewerReceiptFromTranscript(
+	directory: string,
+	input: ReviewerReceiptTranscriptInput,
+): Promise<string | null> {
+	try {
+		if (
+			input.targetAgent &&
+			stripKnownSwarmPrefix(input.targetAgent).toLowerCase() !== 'reviewer'
+		) {
+			return null;
+		}
+		if (!input.prompt || !input.transcript) return null;
+
+		const parsed = parseReviewerOutput(input.transcript);
+		if (!parsed) return null;
+
+		const receipt =
+			parsed.verdict === 'approved'
+				? buildApprovedReceipt({
+						agent: 'reviewer',
+						sessionId: input.sessionID ?? input.sessionId,
+						scopeContent: input.prompt,
+						scopeDescription: 'reviewer-task-prompt',
+						checkedAspects: ['code-review'],
+						validatedClaims: [
+							`VERDICT: APPROVED${parsed.risk ? ` (risk ${parsed.risk})` : ''}`,
+						],
+						caveats: parsed.issues.map((i) => i.text),
+					})
+				: buildRejectedReceipt({
+						agent: 'reviewer',
+						sessionId: input.sessionID ?? input.sessionId,
+						scopeContent: input.prompt,
+						scopeDescription: 'reviewer-task-prompt',
+						blockingFindings: parsed.issues.map(
+							(i): BlockingFinding => ({
+								location: i.location ?? 'unknown',
+								summary: i.text,
+								severity: i.severity,
+							}),
+						),
+						evidenceReferences: parsed.issues
+							.map((i) => i.location)
+							.filter((loc): loc is string => Boolean(loc)),
+						passConditions: parsed.fixes,
+						summary: `Reviewer REJECTED${parsed.risk ? ` (risk ${parsed.risk})` : ''}`,
+					});
+
+		return await persistReviewReceipt(directory, receipt);
+	} catch (err) {
+		logger.warn(
+			`[review-receipt-collector] failed: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return null;
+	}
 }
 
 /**
@@ -214,47 +279,15 @@ export async function collectReviewerReceiptAfter(
 				? argsRecord.prompt
 				: '';
 		const transcript = typeof output.output === 'string' ? output.output : '';
-		if (!prompt || !transcript) return null;
-
-		const parsed = parseReviewerOutput(transcript);
-		if (!parsed) return null;
-
-		const sessionId =
+		const sessionID =
 			typeof input.sessionID === 'string' ? input.sessionID : undefined;
 
-		const receipt =
-			parsed.verdict === 'approved'
-				? buildApprovedReceipt({
-						agent: 'reviewer',
-						sessionId,
-						scopeContent: prompt,
-						scopeDescription: 'reviewer-task-prompt',
-						checkedAspects: ['code-review'],
-						validatedClaims: [
-							`VERDICT: APPROVED${parsed.risk ? ` (risk ${parsed.risk})` : ''}`,
-						],
-						caveats: parsed.issues.map((i) => i.text),
-					})
-				: buildRejectedReceipt({
-						agent: 'reviewer',
-						sessionId,
-						scopeContent: prompt,
-						scopeDescription: 'reviewer-task-prompt',
-						blockingFindings: parsed.issues.map(
-							(i): BlockingFinding => ({
-								location: i.location ?? 'unknown',
-								summary: i.text,
-								severity: i.severity,
-							}),
-						),
-						evidenceReferences: parsed.issues
-							.map((i) => i.location)
-							.filter((loc): loc is string => Boolean(loc)),
-						passConditions: parsed.fixes,
-						summary: `Reviewer REJECTED${parsed.risk ? ` (risk ${parsed.risk})` : ''}`,
-					});
-
-		return await persistReviewReceipt(directory, receipt);
+		return await collectReviewerReceiptFromTranscript(directory, {
+			targetAgent: parsedArgs.targetAgent,
+			prompt,
+			transcript,
+			sessionID,
+		});
 	} catch (err) {
 		logger.warn(
 			`[review-receipt-collector] failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -967,7 +967,10 @@ function buildCollectResult(
 		)
 		.map(recordToLaneResult);
 	const completed = records.filter((record) => record.status === 'completed');
-	const failed = records.filter((record) => record.status === 'error');
+	const failed = records.filter(
+		(record) =>
+			record.status === 'error' || record.status === 'ingestion_error',
+	);
 	const cancelled = records.filter((record) => record.status === 'cancelled');
 	const stale = records.filter((record) => record.status === 'stale');
 	const pending = records.filter(
@@ -999,9 +1002,11 @@ function recordToLaneResult(
 	const status =
 		record.status === 'error'
 			? 'failed'
-			: record.status === 'running'
-				? 'pending'
-				: record.status;
+			: record.status === 'ingestion_error'
+				? 'failed'
+				: record.status === 'running'
+					? 'pending'
+					: record.status;
 	return {
 		id: record.laneId ?? record.correlationId,
 		agent: record.swarmPrefixedAgent,

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -553,7 +553,7 @@ export const TOOL_METADATA = {
 	},
 	collect_lane_results: {
 		description:
-			'collect or poll results for a dispatch_lanes_async advisory batch without advancing workflow gates',
+			'collect or poll results for a dispatch_lanes_async batch; this is the required join barrier for advisory lane workflows and does not advance workflow gates',
 		agents: ['architect'],
 	},
 	summarize_work: {

--- a/tests/unit/background/completion-observer.test.ts
+++ b/tests/unit/background/completion-observer.test.ts
@@ -114,6 +114,37 @@ describe('background completion observer', () => {
 		expect(record?.result?.text).toBe('done');
 	});
 
+	it('leaves non-gate-bearing background completions as settled ledger rows only', async () => {
+		await recordPendingDelegation(dir, {
+			correlationId: 'ses_lane_only',
+			jobId: 'job_lane_only',
+			subagentSessionId: 'ses_lane_only',
+			parentSessionId: 'parent_session',
+			callID: 'batch-1',
+			normalizedAgent: 'explorer',
+			swarmPrefixedAgent: 'explorer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId: 'batch-1',
+			laneId: 'lane-1',
+		});
+
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await obs.event(
+			syntheticPartEvent({
+				text: completedEnvelope('ses_lane_only'),
+				synthetic: true,
+			}),
+		);
+
+		const record = findByCorrelationId(dir, 'ses_lane_only');
+		expect(record?.status).toBe('completed');
+		expect(await readTaskEvidence(dir, 'lane-1')).toBeNull();
+	});
+
 	it('applies trusted background Stage B reviewer completion to workflow state, evidence, and receipt', async () => {
 		const session = ensureAgentSession('parent_session');
 		session.taskWorkflowStates.set('1.1', 'coder_delegated');
@@ -251,6 +282,59 @@ describe('background completion observer', () => {
 		expect(await readTaskEvidence(dir, '2.1')).toBeNull();
 	});
 
+	it('marks background Stage B completion stale when tracked prHeadSha changed', async () => {
+		const session = ensureAgentSession('parent_session');
+		session.taskWorkflowStates.set('2.1-pr', 'coder_delegated');
+		const staleWorkspace: BackgroundWorkspaceSnapshot = {
+			directory: dir,
+			gitHead: 'same-head',
+			dirtyHash: null,
+			prHeadSha: 'origin/pr-head-old',
+			scope: '2.1-pr',
+		};
+		workspaceSnapshotInternals.spawnSync = ((_command, args) => {
+			const argv = Array.isArray(args) ? args.map(String) : [];
+			if (argv.includes('HEAD')) {
+				return { status: 0, stdout: 'same-head\n', stderr: '' };
+			}
+			if (argv.includes('--porcelain=v1')) {
+				return { status: 0, stdout: '', stderr: '' };
+			}
+			if (argv.includes('@{upstream}')) {
+				return { status: 0, stdout: 'origin/pr-head-new\n', stderr: '' };
+			}
+			return { status: 1, stdout: '', stderr: 'unexpected git command' };
+		}) as typeof workspaceSnapshotInternals.spawnSync;
+
+		await recordPendingDelegation(dir, {
+			correlationId: 'ses_prhead_stale',
+			jobId: 'job_prhead_stale',
+			subagentSessionId: 'ses_prhead_stale',
+			parentSessionId: 'parent_session',
+			callID: 'c-pr-stale',
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: '2.1-pr',
+			evidenceTaskId: '2.1-pr',
+			workspace: staleWorkspace,
+		});
+
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await obs.event(
+			syntheticPartEvent({
+				text: completedEnvelope('ses_prhead_stale'),
+				synthetic: true,
+			}),
+		);
+
+		expect(getTaskState(session, '2.1-pr')).toBe('coder_delegated');
+		expect(findByCorrelationId(dir, 'ses_prhead_stale')?.status).toBe('stale');
+		expect(await readTaskEvidence(dir, '2.1-pr')).toBeNull();
+	});
+
 	it('keeps failed Stage B ingestion retryable until evidence is applied', async () => {
 		const session = ensureAgentSession('parent_session');
 		session.taskWorkflowStates.set('2.2', 'coder_delegated');
@@ -300,6 +384,49 @@ describe('background completion observer', () => {
 		expect(getTaskState(session, '2.2')).toBe('reviewer_run');
 		const evidence = await readTaskEvidence(dir, '2.2');
 		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+	});
+
+	it('keeps unrecoverable Stage B ingestion failures at ingestion_error on replay', async () => {
+		const session = ensureAgentSession('parent_session');
+		session.taskWorkflowStates.set('2.3', 'coder_delegated');
+		const evidenceDir = path.join(dir, '.swarm', 'evidence');
+		fs.mkdirSync(evidenceDir, { recursive: true });
+		fs.writeFileSync(path.join(evidenceDir, '2.3.json'), '{still bad json');
+
+		await recordPendingDelegation(dir, {
+			correlationId: 'ses_retry_still_broken',
+			jobId: 'job_retry_still_broken',
+			subagentSessionId: 'ses_retry_still_broken',
+			parentSessionId: 'parent_session',
+			callID: 'c-retry-still-broken',
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: '2.3',
+			evidenceTaskId: '2.3',
+		});
+
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await obs.event(
+			syntheticPartEvent({
+				text: completedEnvelope('ses_retry_still_broken'),
+				synthetic: true,
+			}),
+		);
+		await obs.event(
+			syntheticPartEvent({
+				text: completedEnvelope('ses_retry_still_broken'),
+				synthetic: true,
+			}),
+		);
+
+		expect(findByCorrelationId(dir, 'ses_retry_still_broken')?.status).toBe(
+			'ingestion_error',
+		);
+		expect(getTaskState(session, '2.3')).toBe('coder_delegated');
+		expect(await readTaskEvidence(dir, '2.3')).toBeNull();
 	});
 
 	it('applies trusted background test_engineer completion only after reviewer completion is present', async () => {

--- a/tests/unit/background/completion-observer.test.ts
+++ b/tests/unit/background/completion-observer.test.ts
@@ -10,9 +10,19 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { createBackgroundCompletionObserver } from '../../../src/background/completion-observer';
 import {
+	type BackgroundWorkspaceSnapshot,
 	findByCorrelationId,
 	recordPendingDelegation,
 } from '../../../src/background/pending-delegations';
+import { _internals as workspaceSnapshotInternals } from '../../../src/background/workspace-snapshot';
+import { readTaskEvidence } from '../../../src/gate-evidence';
+import { readAllReceipts } from '../../../src/hooks/review-receipt';
+import {
+	ensureAgentSession,
+	getTaskState,
+	resetSwarmState,
+} from '../../../src/state';
+import { checkReviewerGate } from '../../../src/tools/update-task-status';
 
 function makeTempProject(): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-bgobs-'));
@@ -46,10 +56,15 @@ const completedEnvelope = (id: string) =>
 
 describe('background completion observer', () => {
 	let dir: string;
+	const realSpawnSync = workspaceSnapshotInternals.spawnSync;
 	beforeEach(() => {
+		resetSwarmState();
+		workspaceSnapshotInternals.spawnSync = realSpawnSync;
 		dir = makeTempProject();
 	});
 	afterEach(() => {
+		workspaceSnapshotInternals.spawnSync = realSpawnSync;
+		resetSwarmState();
 		fs.rmSync(dir, { recursive: true, force: true });
 	});
 
@@ -75,10 +90,12 @@ describe('background completion observer', () => {
 			subagentSessionId: 'ses_obs',
 			parentSessionId: 'parent_session',
 			callID: 'c1',
-			normalizedAgent: 'reviewer',
-			swarmPrefixedAgent: 'reviewer',
-			planTaskId: '1.1',
-			evidenceTaskId: '1.1',
+			normalizedAgent: 'explorer',
+			swarmPrefixedAgent: 'explorer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId: 'batch-1',
+			laneId: 'lane-1',
 		});
 
 		const obs = createBackgroundCompletionObserver({
@@ -95,6 +112,295 @@ describe('background completion observer', () => {
 		const record = findByCorrelationId(dir, 'ses_obs');
 		expect(record?.status).toBe('completed');
 		expect(record?.result?.text).toBe('done');
+	});
+
+	it('applies trusted background Stage B reviewer completion to workflow state, evidence, and receipt', async () => {
+		const session = ensureAgentSession('parent_session');
+		session.taskWorkflowStates.set('1.1', 'coder_delegated');
+
+		await recordPendingDelegation(dir, {
+			correlationId: 'ses_reviewer',
+			jobId: 'job_reviewer',
+			subagentSessionId: 'ses_reviewer',
+			parentSessionId: 'parent_session',
+			callID: 'c-reviewer',
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: '1.1',
+			evidenceTaskId: '1.1',
+			prompt: {
+				text: 'TASK: 1.1\nCHECK: [security, correctness]',
+				chars: 40,
+				truncated: false,
+				digest: 'prompt-digest',
+			},
+		});
+
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await obs.event(
+			syntheticPartEvent({
+				text:
+					'<task id="ses_reviewer" state="completed">\n' +
+					'<task_result>VERDICT: APPROVED\nRISK: LOW\nISSUES: none\nFIXES: none</task_result>\n' +
+					'</task>',
+				synthetic: true,
+			}),
+		);
+
+		expect(getTaskState(session, '1.1')).toBe('reviewer_run');
+		const record = findByCorrelationId(dir, 'ses_reviewer');
+		expect(record?.status).toBe('consumed');
+
+		const evidence = await readTaskEvidence(dir, '1.1');
+		expect(evidence?.gates.reviewer?.agent).toBe('reviewer');
+		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+		expect(checkReviewerGate('1.1', dir, true, 'parent_session').blocked).toBe(
+			true,
+		);
+
+		const receipts = await readAllReceipts(dir);
+		expect(receipts).toHaveLength(1);
+		expect(receipts[0].verdict).toBe('approved');
+	});
+
+	it('does not advance unrelated sessions that share the same task id', async () => {
+		const parent = ensureAgentSession('parent_session');
+		parent.taskWorkflowStates.set('1.2', 'coder_delegated');
+		const unrelated = ensureAgentSession('other_parent_session');
+		unrelated.taskWorkflowStates.set('1.2', 'coder_delegated');
+
+		await recordPendingDelegation(dir, {
+			correlationId: 'ses_scoped_reviewer',
+			jobId: 'job_scoped',
+			subagentSessionId: 'ses_scoped_reviewer',
+			parentSessionId: 'parent_session',
+			callID: 'c-scoped',
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: '1.2',
+			evidenceTaskId: '1.2',
+		});
+
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await obs.event(
+			syntheticPartEvent({
+				text: completedEnvelope('ses_scoped_reviewer'),
+				synthetic: true,
+			}),
+		);
+
+		expect(getTaskState(parent, '1.2')).toBe('reviewer_run');
+		expect(getTaskState(unrelated, '1.2')).toBe('coder_delegated');
+	});
+
+	it('marks background Stage B completion stale when workspace changed and does not advance gates', async () => {
+		const session = ensureAgentSession('parent_session');
+		session.taskWorkflowStates.set('2.1', 'coder_delegated');
+		const staleWorkspace: BackgroundWorkspaceSnapshot = {
+			directory: dir,
+			gitHead: 'old-head',
+			dirtyHash: 'old-dirty',
+			prHeadSha: null,
+			scope: '2.1',
+		};
+		workspaceSnapshotInternals.spawnSync = ((_command, args) => {
+			const argv = Array.isArray(args) ? args.map(String) : [];
+			if (argv.includes('rev-parse')) {
+				return { status: 0, stdout: 'new-head\n', stderr: '' };
+			}
+			if (argv.includes('status')) {
+				return { status: 0, stdout: '', stderr: '' };
+			}
+			return { status: 1, stdout: '', stderr: 'unexpected git command' };
+		}) as typeof workspaceSnapshotInternals.spawnSync;
+
+		await recordPendingDelegation(dir, {
+			correlationId: 'ses_stale_reviewer',
+			jobId: 'job_stale',
+			subagentSessionId: 'ses_stale_reviewer',
+			parentSessionId: 'parent_session',
+			callID: 'c-stale',
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: '2.1',
+			evidenceTaskId: '2.1',
+			workspace: staleWorkspace,
+		});
+
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await obs.event(
+			syntheticPartEvent({
+				text: completedEnvelope('ses_stale_reviewer'),
+				synthetic: true,
+			}),
+		);
+
+		expect(getTaskState(session, '2.1')).toBe('coder_delegated');
+		expect(findByCorrelationId(dir, 'ses_stale_reviewer')?.status).toBe(
+			'stale',
+		);
+		expect(await readTaskEvidence(dir, '2.1')).toBeNull();
+	});
+
+	it('keeps failed Stage B ingestion retryable until evidence is applied', async () => {
+		const session = ensureAgentSession('parent_session');
+		session.taskWorkflowStates.set('2.2', 'coder_delegated');
+		const evidenceDir = path.join(dir, '.swarm', 'evidence');
+		fs.mkdirSync(evidenceDir, { recursive: true });
+		fs.writeFileSync(path.join(evidenceDir, '2.2.json'), '{bad json');
+
+		await recordPendingDelegation(dir, {
+			correlationId: 'ses_retry_reviewer',
+			jobId: 'job_retry',
+			subagentSessionId: 'ses_retry_reviewer',
+			parentSessionId: 'parent_session',
+			callID: 'c-retry',
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: '2.2',
+			evidenceTaskId: '2.2',
+		});
+
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await obs.event(
+			syntheticPartEvent({
+				text: completedEnvelope('ses_retry_reviewer'),
+				synthetic: true,
+			}),
+		);
+
+		expect(findByCorrelationId(dir, 'ses_retry_reviewer')?.status).toBe(
+			'ingestion_error',
+		);
+		expect(getTaskState(session, '2.2')).toBe('coder_delegated');
+
+		fs.unlinkSync(path.join(evidenceDir, '2.2.json'));
+		await obs.event(
+			syntheticPartEvent({
+				text: completedEnvelope('ses_retry_reviewer'),
+				synthetic: true,
+			}),
+		);
+
+		expect(findByCorrelationId(dir, 'ses_retry_reviewer')?.status).toBe(
+			'consumed',
+		);
+		expect(getTaskState(session, '2.2')).toBe('reviewer_run');
+		const evidence = await readTaskEvidence(dir, '2.2');
+		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+	});
+
+	it('applies trusted background test_engineer completion only after reviewer completion is present', async () => {
+		const session = ensureAgentSession('parent_session');
+		session.taskWorkflowStates.set('3.1', 'reviewer_run');
+
+		await recordPendingDelegation(dir, {
+			correlationId: 'ses_test_engineer',
+			jobId: 'job_test',
+			subagentSessionId: 'ses_test_engineer',
+			parentSessionId: 'parent_session',
+			callID: 'c-test',
+			normalizedAgent: 'test_engineer',
+			swarmPrefixedAgent: 'test_engineer',
+			planTaskId: '3.1',
+			evidenceTaskId: '3.1',
+		});
+
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await obs.event(
+			syntheticPartEvent({
+				text: completedEnvelope('ses_test_engineer'),
+				synthetic: true,
+			}),
+		);
+
+		expect(getTaskState(session, '3.1')).toBe('tests_run');
+		expect(findByCorrelationId(dir, 'ses_test_engineer')?.status).toBe(
+			'consumed',
+		);
+		const evidence = await readTaskEvidence(dir, '3.1');
+		expect(evidence?.gates.test_engineer?.agent).toBe('test_engineer');
+		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+	});
+
+	it('keeps test_engineer-first completion blocked until reviewer also completes', async () => {
+		const session = ensureAgentSession('parent_session');
+		session.taskWorkflowStates.set('3.2', 'coder_delegated');
+
+		await recordPendingDelegation(dir, {
+			correlationId: 'ses_test_first',
+			jobId: 'job_test_first',
+			subagentSessionId: 'ses_test_first',
+			parentSessionId: 'parent_session',
+			callID: 'c-test-first',
+			normalizedAgent: 'test_engineer',
+			swarmPrefixedAgent: 'test_engineer',
+			planTaskId: '3.2',
+			evidenceTaskId: '3.2',
+		});
+		await recordPendingDelegation(dir, {
+			correlationId: 'ses_reviewer_second',
+			jobId: 'job_reviewer_second',
+			subagentSessionId: 'ses_reviewer_second',
+			parentSessionId: 'parent_session',
+			callID: 'c-reviewer-second',
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: '3.2',
+			evidenceTaskId: '3.2',
+		});
+
+		const obs = createBackgroundCompletionObserver({
+			config: { enabled: true },
+			directory: dir,
+		});
+		await obs.event(
+			syntheticPartEvent({
+				text: completedEnvelope('ses_test_first'),
+				synthetic: true,
+			}),
+		);
+
+		expect(getTaskState(session, '3.2')).toBe('coder_delegated');
+		let evidence = await readTaskEvidence(dir, '3.2');
+		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+		expect(evidence?.gates.test_engineer?.agent).toBe('test_engineer');
+		expect(checkReviewerGate('3.2', dir, true, 'parent_session').blocked).toBe(
+			true,
+		);
+
+		await obs.event(
+			syntheticPartEvent({
+				text: completedEnvelope('ses_reviewer_second'),
+				synthetic: true,
+			}),
+		);
+
+		expect(getTaskState(session, '3.2')).toBe('tests_run');
+		expect(findByCorrelationId(dir, 'ses_test_first')?.status).toBe('consumed');
+		expect(findByCorrelationId(dir, 'ses_reviewer_second')?.status).toBe(
+			'consumed',
+		);
+		evidence = await readTaskEvidence(dir, '3.2');
+		expect(evidence?.gates.reviewer?.agent).toBe('reviewer');
+		expect(checkReviewerGate('3.2', dir, true, 'parent_session').blocked).toBe(
+			false,
+		);
 	});
 
 	it('ignores a correlated completion with the wrong parent session', async () => {

--- a/tests/unit/hooks/review-receipt.test.ts
+++ b/tests/unit/hooks/review-receipt.test.ts
@@ -321,7 +321,7 @@ describe('persistReviewReceipt', () => {
 		const receiptPath = await persistReviewReceipt(tmpDir, receipt);
 
 		expect(fs.existsSync(receiptPath)).toBe(true);
-		expect(receiptPath).toContain('.swarm/review-receipts');
+		expect(receiptPath).toContain(path.join('.swarm', 'review-receipts'));
 	});
 
 	it('receipt file is valid JSON matching the receipt', async () => {
@@ -784,14 +784,16 @@ describe('buildReceiptContextForDrift', () => {
 describe('resolveReceiptsDir', () => {
 	it('returns .swarm/review-receipts under the given directory', () => {
 		const dir = resolveReceiptsDir('/projects/myapp');
-		expect(dir).toBe('/projects/myapp/.swarm/review-receipts');
+		expect(dir).toBe(path.join('/projects/myapp', '.swarm', 'review-receipts'));
 	});
 });
 
 describe('resolveReceiptIndexPath', () => {
 	it('returns .swarm/review-receipts/index.json under the given directory', () => {
 		const p = resolveReceiptIndexPath('/projects/myapp');
-		expect(p).toBe('/projects/myapp/.swarm/review-receipts/index.json');
+		expect(p).toBe(
+			path.join('/projects/myapp', '.swarm', 'review-receipts', 'index.json'),
+		);
 	});
 });
 


### PR DESCRIPTION
Closes #1151

## Summary
- Wire trusted native background Task completions into Stage B gate ingestion for reviewer and test_engineer agents.
- Re-resolve tracked `prHeadSha` against the live local upstream ref during Stage B ingestion so PR-head drift is rejected as stale instead of replaying stored metadata.
- Preserve advisory lane behavior, tighten `collect_lane_results` join-barrier wording, and add regression coverage for non-gate-bearing completions plus recoverable and unrecoverable ingestion failures.

## Invariant audit
- 1 (plugin init): not touched - no plugin server/init path changes; `node scripts/repro-704.mjs` passed T1/T2/T3 after the follow-up fix.
- 2 (runtime portability): touched - `bun run build` passed and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` printed `dist import OK`.
- 3 (subprocesses): touched - `src/background/workspace-snapshot.ts` still uses array-form `git -C`, explicit `cwd`, ignored stdin, timeout, and bounded output; the follow-up only adds a second compliant `rev-parse @{upstream}` freshness probe. `rg -n "bunSpawn\(|spawn\(|spawnSync\(" src/background/workspace-snapshot.ts src/background/stage-b-gates.ts src/tools/tool-metadata.ts` returns the single compliant `spawnSync` call in `workspace-snapshot.ts`.
- 4 (.swarm containment): touched - background delegations, evidence, and review receipts remain under `.swarm/`; the completion-observer regression suite covers ledger settlement, stale rejection, evidence writes, and receipt persistence.
- 5 (plan durability): not touched - no plan ledger/projection/checkpoint code changed.
- 6 (test_runner safety): not touched - validation used shell `bun`/`node` commands, not broad OpenCode `test_runner` scopes.
- 7 (test writing): touched - writing-tests skill loaded; added bun:test coverage with the existing workspace-snapshot DI seam and no `mock.module`; `bun --smol test tests/unit/background/completion-observer.test.ts --timeout 30000` passed 16 tests.
- 8 (session state): touched - Stage B state mutation remains scoped to the dispatching parent session; the regression test for unrelated sessions with the same task id still passes.
- 9 (guardrails/retry): touched - failed Stage B ingestion remains retryable, and unrecoverable replays now stay at `ingestion_error`; both paths are covered by the focused completion-observer suite.
- 10 (chat/system msg): not touched - no system-message shaping or chat-visible diagnostics changed.
- 11 (tool registration): touched - tool metadata/help text for `collect_lane_results` now matches the shipped tool description; no exports, plugin tool block, TOOL_NAMES, or agent tool maps changed.
- 12 (release/cache): touched - existing release fragment `docs/releases/pending/1151-background-stage-b-gates.md` still covers this PR; no version, changelog, manifest, cache, or dist files were staged.

## Test plan
- `bun --smol test tests/unit/background/completion-observer.test.ts --timeout 30000`
- `bun run typecheck`
- `bunx biome ci .`
- `bun run build`
- `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- `node scripts/repro-704.mjs`
- `git diff --check`