### PR TITLE
feat(guardrails): add transparency suite (explain, decision log, diagnose sandbox)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,7 +1080,9 @@ Control how tool outputs are summarized for LLM context.
 | `/swarm agents` | Registered agents with models and permissions |
 | `/swarm history` | Completed phases with status |
 | `/swarm config` | Current resolved configuration |
-| `/swarm diagnose` | Health check for `.swarm/` files and config |
+| `/swarm diagnose` | Health check for `.swarm/` files, config, and sandbox executor status |
+| `/swarm guardrail explain [--agent <role>] [--scope <path>] [--write <path>...] [--] <command>` | Dry-run guardrail decisions — report what would be allowed/blocked without executing anything |
+| `/swarm guardrail-log [--blocks-only]` | Read and print the guardrail decision log most-recent-first; `--blocks-only` shows only block decisions |
 | `/swarm export` | Export plan and context as portable JSON |
 | `/swarm evidence [task]` | Evidence bundles for a task or all tasks |
 | `/swarm archive [--dry-run]` | Archive old evidence with retention policy |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -71,6 +71,8 @@ A 3-line learning summary is automatically injected into the curator phase diges
 
 Run a health check on `.swarm/` files, plan structure, and evidence completeness. Reports missing files, schema mismatches, and recovery steps.
 
+A **Sandbox** health-check line is also reported, showing the detected executor mechanism (bubblewrap / sandbox-exec / windows-runner / none), availability, and whether commands are actually being sandboxed (sandboxing / silent pass-through / none). This is advisory only — absence of a sandbox executor never causes a hard failure.
+
 ### `/swarm history`
 
 Show completed phases with status icons.
@@ -82,6 +84,60 @@ Show completed phases with status icons.
 ### `/swarm agents`
 
 List all registered agents with their model, temperature, read-only status, and guardrail profile.
+
+---
+
+## Guardrails
+
+### `/swarm guardrail explain [--agent <role>] [--scope <path>] [--write <path>...] [--] <command>`
+
+Dry-run guardrail decisions for a shell command or write target — reports what the guardrail system **would** do without executing anything. Agent-callable via `swarm_command`.
+
+**Shell mode** (default — pass a command string after any flags):
+
+```text
+/swarm guardrail explain rm -rf node_modules/
+/swarm guardrail explain --agent reviewer git push --force origin main
+```
+
+Returns: decision (`allow`/`block`), firing rule, resolved scope, and detected write categories.
+
+**Write mode** (`--write`, repeatable — inspect individual file/directory targets):
+
+```text
+/swarm guardrail explain --write src/hooks/guardrails.ts --write .swarm/plan.json
+```
+
+Returns per-target: decision, firing rule, resolved scope, and zone classification.
+
+**Flags:**
+
+| Flag | Effect |
+|------|--------|
+| `--agent <role>` | Simulate decisions as if issued by a different agent role (e.g., `reviewer`, `test_engineer`) |
+| `--scope <path>` | Simulate decisions scoped to a specific working directory |
+| `--write <path>` | Inspect a write target instead of a shell command (repeatable for multiple targets) |
+| `--` | Explicit flag terminator — required when `<command>` starts with `--` |
+
+Output is fully advisory and redacted. No side effects, no writes, no process execution.
+
+### `/swarm guardrail-log [--blocks-only]`
+
+Read and print the unified guardrail decision log (`.swarm/session/shell-audit.jsonl`) most-recent-first. Agent-callable via `swarm_command`.
+
+```text
+/swarm guardrail-log
+/swarm guardrail-log --blocks-only
+```
+
+**`--blocks-only`** limits output to block decisions only (`file_write`, `scope_violation`, `destructive_block`). Legacy shell command entries and sandbox wrap/skip entries are excluded.
+
+**Output characteristics:**
+
+- Entries sorted most-recent-first
+- Commands and paths are redacted
+- Missing log file → friendly message: "No guardrail decisions recorded yet."
+- On-demand only — no hot-path cost; reads the log only when invoked
 
 ---
 

--- a/docs/releases/pending/guardrail-transparency-suite.md
+++ b/docs/releases/pending/guardrail-transparency-suite.md
@@ -1,0 +1,122 @@
+# Guardrail Transparency Suite — Complete
+
+## What changed
+
+The guardrail transparency suite (issue #1274) is now complete. Phase 1 delivered the foundation; Phase 2 completed the observability stack.
+
+---
+
+## Phase 1 — Foundation
+
+### `/swarm guardrail explain` — dry-run guardrail decisions before execution
+
+A diagnostics command that reports what the guardrail system **would** do to a given shell command or write target — without executing anything. Available to agents via `swarm_command`.
+
+**Shell mode** (default — pass a command string):
+
+```
+/swarm guardrail explain rm -rf node_modules/
+```
+
+Returns: decision (`allow`/`block`), the firing rule, resolved scope, and detected write categories.
+
+**Write mode** (`--write`, repeatable — inspect individual file/directory targets):
+
+```
+/swarm guardrail explain --write src/hooks/guardrails.ts --write .swarm/plan.json
+```
+
+Returns: per-target decision, firing rule, resolved scope, and zone classification for each path.
+
+**Simulation flags:**
+
+- `--agent <role>` — simulate guardrail decisions as if issued by a different agent role (e.g., `reviewer`, `test_engineer`)
+- `--scope <path>` — simulate decisions scoped to a specific working directory
+
+Output is advisory and fully redacted — no side effects, no writes, no process execution.
+
+### `/swarm diagnose` — Sandbox status
+
+`/swarm diagnose` includes a **Sandbox** health-check line reporting:
+
+- **Executor mechanism** detected (bubblewrap / sandbox-exec / windows-runner / none)
+- **Availability** of the sandbox executor
+- **Whether commands are actually being sandboxed** (sandboxing / silent pass-through / none)
+
+This is advisory only — absence of a sandbox executor never causes a hard failure.
+
+### Unified guardrail decision-log schema (Phase 1 foundation)
+
+The shell-audit log at `.swarm/session/shell-audit.jsonl` uses an additive type-discriminated JSONL schema. Five decision types are written to the same stream alongside existing shell entries:
+
+- `file_write`
+- `scope_violation`
+- `destructive_block`
+- `sandbox_wrap`
+- `sandbox_skip`
+
+---
+
+## Phase 2 — Decision-Log Reader and Full Capture
+
+### `/swarm guardrail-log [--blocks-only]`
+
+A new diagnostics command that reads the unified guardrail decision log (`.swarm/session/shell-audit.jsonl`) and prints entries most-recent-first. Agent-callable via `swarm_command`.
+
+```
+/swarm guardrail-log
+/swarm guardrail-log --blocks-only
+```
+
+**`--blocks-only`** filters to show only block decisions (`file_write`, `scope_violation`, `destructive_block`). Legacy shell command entries and sandbox wrap/skip entries are excluded.
+
+**Output characteristics:**
+
+- Entries are sorted most-recent-first
+- Commands and paths are redacted in output
+- If no log file exists yet, prints a friendly message: "No guardrail decisions recorded yet."
+- On-demand only — no hot-path cost; reads the log file only when the command is invoked
+
+**Example output:**
+
+```
+=== Guardrail Decision Log ===
+2026-06-20T10:42:01.000Z  destructive_block  rm -rf node_modules/
+2026-06-20T10:41:55.000Z  file_write         src/hooks/guardrails.ts
+2026-06-20T10:41:48.000Z  scope_violation    ./src/secrets.json
+
+No guardrail decisions recorded yet.
+```
+
+### Unified decision-log capture (internal)
+
+The guardrail hook now records **all** decision types — file-write blocks, scope violations, destructive-command blocks, sandbox wraps, and sandbox skips — to the unified log. Each entry is redacted before writing. Blocking behavior is unchanged; the capture is purely additive observability.
+
+This completes the unified guardrail decision log capability from issue #1274: the schema was introduced in Phase 1, and the full capture wiring + reader command landed in Phase 2.
+
+## Complete suite at a glance
+
+| Capability | Status | Notes |
+|---|---|---|
+| `guardrail explain` dry-run | ✅ Phase 1 | Shell + write modes, simulation flags |
+| Sandbox status in `diagnose` | ✅ Phase 1 | Executor, availability, enforcement |
+| Unified log schema | ✅ Phase 1 | Five new decision types in JSONL |
+| `guardrail-log` reader | ✅ Phase 2 | Most-recent-first, `--blocks-only`, redacted |
+| Full capture wiring | ✅ Phase 2 | All decision types now logged |
+
+## Why
+
+Guardrail decisions were previously opaque — agents and users had no reliable way to predict whether a given command would be allowed, blocked, or sandboxed. The `explain` command makes guardrail behavior observable and debuggable *before* a command runs, eliminating guesswork.
+
+The `guardrail-log` command and full capture wiring make the *history* of decisions observable *after* the fact, completing the observability loop: before (`explain`), during (logging), and after (`guardrail-log`).
+
+The Sandbox line in `diagnose` closes a visibility gap: users on Linux (bubblewrap), macOS (sandbox-exec), or Windows (windows-runner) can confirm whether their runtime is actually enforcing sandbox boundaries.
+
+## Migration
+
+No breaking changes. All changes are additive:
+
+- `/swarm guardrail explain` — new command, safe to use immediately
+- `/swarm diagnose` — gains a new Sandbox line; existing output unchanged
+- `/swarm guardrail-log` — new command, reads existing log file
+- The JSONL schema is additive only — existing log readers are unaffected

--- a/docs/releases/pending/guardrail-transparency-suite.md
+++ b/docs/releases/pending/guardrail-transparency-suite.md
@@ -120,3 +120,13 @@ No breaking changes. All changes are additive:
 - `/swarm diagnose` — gains a new Sandbox line; existing output unchanged
 - `/swarm guardrail-log` — new command, reads existing log file
 - The JSONL schema is additive only — existing log readers are unaffected
+
+## Known limitations
+
+- `guardrail explain` still mirrors the destructive-command pattern table locally
+  because the real guardrail evaluator is nested in the hot-path hook. The shared
+  `dc*` helpers are reused and parity regressions are covered by tests; future
+  cleanup can extract a shared top-level evaluator.
+- Audit-log path redaction is best-effort. It redacts standard POSIX/macOS home
+  paths, Windows profile paths, and UNC server prefixes, but domain-specific
+  secrets embedded in arbitrary path segments remain caller responsibility.

--- a/scripts/mock-allowlist.txt
+++ b/scripts/mock-allowlist.txt
@@ -9,7 +9,7 @@
 # To add a NEW mock target: append it here with a comment explaining why.
 # Prefer _internals DI seam for new code — mock.module is a legacy pattern.
 #
-# Last updated: 2026-06-17
+# Last updated: 2026-06-20
 
 # --- Node builtins ---
 node:child_process
@@ -25,6 +25,7 @@ src/build/discovery
 src/config
 src/config/index
 src/config/index.ts
+src/config/loader
 src/config/schema
 src/config/schema.ts
 src/db/qa-gate-profile
@@ -57,7 +58,10 @@ src/plan/checkpoint
 src/plan/ledger
 src/plan/manager
 src/proper-lockfile
+src/sandbox/capability-probe
+src/sandbox/executor
 src/sandbox/linux/bubblewrap-executor
+src/sdd/effective-spec
 src/sast/rules/index
 src/sast/semgrep
 src/services/evidence-summary-service

--- a/src/commands/guardrail-explain.ts
+++ b/src/commands/guardrail-explain.ts
@@ -1,0 +1,2 @@
+// Delegate to service layer - thin adapter for backward compatibility
+export { handleGuardrailExplain } from '../services/guardrail-explain-service';

--- a/src/commands/guardrail-log.ts
+++ b/src/commands/guardrail-log.ts
@@ -1,0 +1,1 @@
+export { handleGuardrailLog } from '../services/guardrail-log-service';

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -59,6 +59,8 @@ export {
 } from './evidence';
 export { handleExportCommand } from './export';
 export { handleFullAutoCommand } from './full-auto';
+export { handleGuardrailExplain } from './guardrail-explain';
+export { handleGuardrailLog } from './guardrail-log';
 export { handleHandoffCommand } from './handoff';
 export { handleHistoryCommand } from './history';
 export {

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -28,6 +28,8 @@ import {
 } from './evidence.js';
 import { handleExportCommand } from './export.js';
 import { handleFullAutoCommand } from './full-auto.js';
+import { handleGuardrailExplain } from './guardrail-explain.js';
+import { handleGuardrailLog } from './guardrail-log.js';
 import { handleHandoffCommand } from './handoff.js';
 import { handleHistoryCommand } from './history.js';
 import { handleIssueCommand } from './issue.js';
@@ -432,6 +434,22 @@ export const COMMAND_REGISTRY = {
 		category: 'diagnostics',
 		aliasOf: 'diagnose',
 		deprecated: true,
+	},
+	'guardrail explain': {
+		handler: (ctx) => handleGuardrailExplain(ctx.directory, ctx.args),
+		description:
+			'Dry-run: show what the guardrails would do to a command or write target (executes nothing)',
+		category: 'diagnostics',
+		toolPolicy: 'agent',
+		toolNoArgs: false,
+	},
+	'guardrail-log': {
+		handler: (ctx) => handleGuardrailLog(ctx.directory, ctx.args),
+		description:
+			'Read the guardrail decision log (use --blocks-only for blocks)',
+		category: 'diagnostics',
+		toolPolicy: 'agent',
+		toolNoArgs: false,
 	},
 	preflight: {
 		handler: (ctx) => handlePreflightCommand(ctx.directory, ctx.args),

--- a/src/hooks/guardrails/audit-log.ts
+++ b/src/hooks/guardrails/audit-log.ts
@@ -264,6 +264,18 @@ function validateEntry(entry: unknown): entry is GuardrailDecisionEntry {
 export function redactPath(filePath: string): string {
 	if (typeof filePath !== 'string' || filePath.length === 0) return filePath;
 
+	// POSIX home: /home/<name>/... -> ~/...
+	const rawPosixHomeMatch = filePath.match(/^(\/home\/[^/]+)(\/.*)$/);
+	if (rawPosixHomeMatch) {
+		return `~${rawPosixHomeMatch[2]}`;
+	}
+
+	// macOS home: /Users/<name>/... -> ~/... (parity with redactShellCommand)
+	const rawMacHomeMatch = filePath.match(/^(\/Users\/[^/]+)(\/.*)$/);
+	if (rawMacHomeMatch) {
+		return `~${rawMacHomeMatch[2]}`;
+	}
+
 	const normalized = path.normalize(filePath);
 
 	// Windows user profile: C:\Users\<name>\... -> ~\<name>\...
@@ -274,19 +286,27 @@ export function redactPath(filePath: string): string {
 		return `~\\${windowsHomeMatch[2]}`;
 	}
 
-	// POSIX home: /home/<name>/... -> ~/<name>/...
-	const posixHomeMatch = normalized.match(/^(\/home\/[^/]+)(\/.*)$/);
-	if (posixHomeMatch) {
-		return `~${posixHomeMatch[2]}`;
-	}
-
-	// macOS home: /Users/<name>/... -> ~/<name>/... (parity with redactShellCommand)
-	const macHomeMatch = normalized.match(/^(\/Users\/[^/]+)(\/.*)$/);
-	if (macHomeMatch) {
-		return `~${macHomeMatch[2]}`;
+	// Windows UNC profile/share path: \\server\share\user\... -> ~\share\user\...
+	const uncHomeMatch = normalized.match(
+		/^\\\\[^\\]+\\([^\\]+)\\([^\\]+)(\\.*)$/,
+	);
+	if (uncHomeMatch) {
+		return `~\\${uncHomeMatch[1]}\\${uncHomeMatch[2]}${uncHomeMatch[3]}`;
 	}
 
 	return normalized;
+}
+
+function redactEmbeddedPaths(text: string): string {
+	return text
+		.replace(/\/home\/[^/\s]+(\/[^\s"'`)]*)?/g, (match) => redactPath(match))
+		.replace(/\/Users\/[^/\s]+(\/[^\s"'`)]*)?/g, (match) => redactPath(match))
+		.replace(/[A-Za-z]:\\Users\\[^\\\s]+(\\[^\s"'`)]*)?/g, (match) =>
+			redactPath(match),
+		)
+		.replace(/\\\\[^\\\s]+\\[^\\\s]+\\[^\\\s]+(\\[^\s"'`)]*)?/g, (match) =>
+			redactPath(match),
+		);
 }
 
 // ---------------------------------------------------------------------------
@@ -342,6 +362,7 @@ export async function appendGuardrailDecision(
 			line = `${JSON.stringify({
 				...entry,
 				path: redactPath(entry.path),
+				reason: redactEmbeddedPaths(entry.reason),
 				resolvedScope: redactPath(entry.resolvedScope),
 			})}\n`;
 			break;

--- a/src/hooks/guardrails/audit-log.ts
+++ b/src/hooks/guardrails/audit-log.ts
@@ -1,0 +1,368 @@
+/**
+ * Unified Guardrail Decision Audit Log
+ *
+ * Additive JSONL schema for guardrail decisions. Each append writes one
+ * validated JSON line to the configured audit path under `.swarm/session/`.
+ *
+ * The existing shell audit entry shape is preserved byte-for-byte when
+ * `type: 'shell'` is used (fields: ts, sessionID, agent, tool, command).
+ *
+ * Path redaction: there is no cross-cutting path-redaction helper in this
+ * module today. Callers MAY pass a pre-redacted path via `redactPath(...)`
+ * before constructing the entry; the module itself does not mutate path
+ * strings beyond normalizing separators. Future hardening: add a shared
+ * path-redaction utility and call it here.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { log } from '../../utils/logger';
+import { redactShellCommand } from './helpers';
+
+// DI seam for testability — tests mock these function references directly (function mocks
+// restore cleanly in afterEach) instead of mock.module('node:fs/promises'), which leaks
+// across test files in Bun's shared test-runner process (AGENTS.md invariant 7).
+export const _internals = {
+	mkdir: fs.mkdir,
+	appendFile: fs.appendFile,
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union of guardrail decision types.
+ *
+ * Invariants:
+ * - `ts` is an ISO-8601 datetime string.
+ * - `sessionID` is the swarm session identifier.
+ * - `agent` is the role string (e.g. "architect", "coder").
+ * - `tool` is the original tool name as invoked.
+ */
+export type GuardrailDecisionType =
+	| 'shell'
+	| 'file_write'
+	| 'scope_violation'
+	| 'destructive_block'
+	| 'sandbox_wrap'
+	| 'sandbox_skip';
+
+export interface ShellDecision {
+	type: 'shell';
+	ts: string;
+	sessionID: string;
+	agent: string;
+	tool: string;
+	command: string;
+}
+
+export interface FileWriteDecision {
+	type: 'file_write';
+	ts: string;
+	sessionID: string;
+	agent: string;
+	tool: string;
+	path: string;
+	reason: string;
+	resolvedScope: string;
+}
+
+export interface ScopeViolationDecision {
+	type: 'scope_violation';
+	ts: string;
+	sessionID: string;
+	agent: string;
+	tool: string;
+	path: string;
+	declaredScope: string;
+	resolvedScope: string;
+	action: string;
+}
+
+export interface DestructiveBlockDecision {
+	type: 'destructive_block';
+	ts: string;
+	sessionID: string;
+	agent: string;
+	tool: string;
+	command: string;
+	destructiveCategory: string;
+}
+
+export interface SandboxWrapDecision {
+	type: 'sandbox_wrap';
+	ts: string;
+	sessionID: string;
+	agent: string;
+	tool: string;
+	command: string;
+	executorMechanism: string;
+}
+
+export interface SandboxSkipDecision {
+	type: 'sandbox_skip';
+	ts: string;
+	sessionID: string;
+	agent: string;
+	tool: string;
+	command: string;
+	executorMechanism: string;
+	skipReason: string;
+}
+
+export type GuardrailDecisionEntry =
+	| ShellDecision
+	| FileWriteDecision
+	| ScopeViolationDecision
+	| DestructiveBlockDecision
+	| SandboxWrapDecision
+	| SandboxSkipDecision;
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+const REQUIRED_STRING_FIELDS = [
+	'ts',
+	'sessionID',
+	'agent',
+	'tool',
+	'type',
+] as const satisfies ReadonlyArray<keyof GuardrailDecisionEntry>;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value.constructor === Object || Object.getPrototypeOf(value) === null)
+	);
+}
+
+function validateEntry(entry: unknown): entry is GuardrailDecisionEntry {
+	if (!isPlainObject(entry)) {
+		log('guardrail audit: rejected non-object entry', entry);
+		return false;
+	}
+
+	for (const field of REQUIRED_STRING_FIELDS) {
+		if (typeof entry[field] !== 'string') {
+			log('guardrail audit: rejected entry missing string field', {
+				field,
+				entry,
+			});
+			return false;
+		}
+	}
+
+	const validTypes: GuardrailDecisionType[] = [
+		'shell',
+		'file_write',
+		'scope_violation',
+		'destructive_block',
+		'sandbox_wrap',
+		'sandbox_skip',
+	];
+	if (!validTypes.includes(entry.type as GuardrailDecisionType)) {
+		log('guardrail audit: rejected entry with invalid type', {
+			type: entry.type,
+			entry,
+		});
+		return false;
+	}
+
+	// Per-type field validation: verify type-specific required fields are
+	// present and are strings. Reject (return false, never throw) on failure.
+	switch (entry.type) {
+		case 'shell':
+			// No extra fields beyond the shared set.
+			break;
+		case 'file_write': {
+			const required = ['path', 'reason', 'resolvedScope'] as const;
+			for (const field of required) {
+				if (typeof entry[field] !== 'string') {
+					log(
+						'guardrail audit: rejected file_write entry missing string field',
+						{ field, entry },
+					);
+					return false;
+				}
+			}
+			break;
+		}
+		case 'scope_violation': {
+			const required = [
+				'path',
+				'declaredScope',
+				'resolvedScope',
+				'action',
+			] as const;
+			for (const field of required) {
+				if (typeof entry[field] !== 'string') {
+					log(
+						'guardrail audit: rejected scope_violation entry missing string field',
+						{ field, entry },
+					);
+					return false;
+				}
+			}
+			break;
+		}
+		case 'destructive_block': {
+			const required = ['command', 'destructiveCategory'] as const;
+			for (const field of required) {
+				if (typeof entry[field] !== 'string') {
+					log(
+						'guardrail audit: rejected destructive_block entry missing string field',
+						{ field, entry },
+					);
+					return false;
+				}
+			}
+			break;
+		}
+		case 'sandbox_wrap': {
+			const required = ['command', 'executorMechanism'] as const;
+			for (const field of required) {
+				if (typeof entry[field] !== 'string') {
+					log(
+						'guardrail audit: rejected sandbox_wrap entry missing string field',
+						{ field, entry },
+					);
+					return false;
+				}
+			}
+			break;
+		}
+		case 'sandbox_skip': {
+			const required = ['command', 'executorMechanism', 'skipReason'] as const;
+			for (const field of required) {
+				if (typeof entry[field] !== 'string') {
+					log(
+						'guardrail audit: rejected sandbox_skip entry missing string field',
+						{ field, entry },
+					);
+					return false;
+				}
+			}
+			break;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Best-effort path redaction for audit logs.
+ *
+ * Replaces leading home/profile segments with a tilde placeholder so
+ * absolute paths do not leak user-specific directory names.
+ *
+ * This is intentionally minimal — callers remain responsible for
+ * stripping any domain-specific secrets that may appear in path segments.
+ */
+export function redactPath(filePath: string): string {
+	if (typeof filePath !== 'string' || filePath.length === 0) return filePath;
+
+	const normalized = path.normalize(filePath);
+
+	// Windows user profile: C:\Users\<name>\... -> ~\<name>\...
+	const windowsHomeMatch = normalized.match(
+		/^([A-Za-z]:\\Users\\[^\\]+)(\\.*)$/,
+	);
+	if (windowsHomeMatch) {
+		return `~\\${windowsHomeMatch[2]}`;
+	}
+
+	// POSIX home: /home/<name>/... -> ~/<name>/...
+	const posixHomeMatch = normalized.match(/^(\/home\/[^/]+)(\/.*)$/);
+	if (posixHomeMatch) {
+		return `~${posixHomeMatch[2]}`;
+	}
+
+	// macOS home: /Users/<name>/... -> ~/<name>/... (parity with redactShellCommand)
+	const macHomeMatch = normalized.match(/^(\/Users\/[^/]+)(\/.*)$/);
+	if (macHomeMatch) {
+		return `~${macHomeMatch[2]}`;
+	}
+
+	return normalized;
+}
+
+// ---------------------------------------------------------------------------
+// Append
+// ---------------------------------------------------------------------------
+
+export interface AppendGuardrailDecisionOptions {
+	auditPath: string;
+	enabled: boolean;
+}
+
+/**
+ * Append a validated guardrail decision entry to the JSONL audit log.
+ *
+ * - Writes exactly one JSON line per call (`JSON.stringify(entry) + '\n'`).
+ * - Skips silently when `enabled` is false.
+ * - Skips malformed entries after debug logging; never throws.
+ * - `.swarm/` containment is enforced by the caller-supplied `auditPath`.
+ *
+ * @param entry Decision entry to persist.
+ * @param ctx Audit destination and enablement flag.
+ */
+export async function appendGuardrailDecision(
+	entry: GuardrailDecisionEntry,
+	ctx: AppendGuardrailDecisionOptions,
+): Promise<void> {
+	if (!ctx.enabled) return;
+	if (!validateEntry(entry)) return;
+
+	// Legacy shell entries persist as the exact 5-field shape
+	// {ts, sessionID, agent, tool, command} with the `type` discriminator stripped.
+	// Command-bearing variants redact the command; path-bearing variants redact the path.
+	let line: string;
+	switch (entry.type) {
+		case 'shell':
+			line = `${JSON.stringify({
+				ts: entry.ts,
+				sessionID: entry.sessionID,
+				agent: entry.agent,
+				tool: entry.tool,
+				command: redactShellCommand(entry.command),
+			})}\n`;
+			break;
+		case 'destructive_block':
+		case 'sandbox_wrap':
+		case 'sandbox_skip':
+			line = `${JSON.stringify({
+				...entry,
+				command: redactShellCommand(entry.command),
+			})}\n`;
+			break;
+		case 'file_write':
+			line = `${JSON.stringify({
+				...entry,
+				path: redactPath(entry.path),
+				resolvedScope: redactPath(entry.resolvedScope),
+			})}\n`;
+			break;
+		case 'scope_violation':
+			line = `${JSON.stringify({
+				...entry,
+				path: redactPath(entry.path),
+				declaredScope: redactPath(entry.declaredScope),
+				resolvedScope: redactPath(entry.resolvedScope),
+			})}\n`;
+			break;
+	}
+
+	try {
+		await _internals.mkdir(path.dirname(ctx.auditPath), { recursive: true });
+		await _internals.appendFile(ctx.auditPath, line, 'utf-8');
+	} catch (error) {
+		// Audit failures must never block tool execution.
+		log('guardrail audit: append failed', {
+			auditPath: ctx.auditPath,
+			error,
+		});
+	}
+}

--- a/src/hooks/guardrails/helpers.ts
+++ b/src/hooks/guardrails/helpers.ts
@@ -154,7 +154,12 @@ export function isInDeclaredScope(
  */
 export function redactShellCommand(cmd: string): string {
 	if (typeof cmd !== 'string') return '';
-	let out = cmd.replace(
+	let out = cmd
+		.replace(/\/home\/[^/\s"']+/g, '~')
+		.replace(/[A-Za-z]:\\Users\\[^\\\s"']+/g, '~')
+		.replace(/\/Users\/[^/\s"']+/g, '~');
+
+	out = out.replace(
 		/\b([A-Z_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_]?KEY|APIKEY|AUTH|CREDENTIAL|PRIVATE[_]?KEY|ACCESS[_]?KEY|_KEY)[A-Z_0-9]*)\s*=\s*(\S+)/gi,
 		'$1=[REDACTED]',
 	);

--- a/src/hooks/guardrails/tool-before.ts
+++ b/src/hooks/guardrails/tool-before.ts
@@ -1769,7 +1769,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		// Shell audit log
 		const normalizedAuditTool = normalizeToolName(input.tool).toLowerCase();
 		if (normalizedAuditTool === 'bash' || normalizedAuditTool === 'shell') {
-			await appendGuardrailDecision(
+			void appendGuardrailDecision(
 				{
 					type: 'shell',
 					ts: new Date().toISOString(),

--- a/src/hooks/guardrails/tool-before.ts
+++ b/src/hooks/guardrails/tool-before.ts
@@ -9,7 +9,6 @@
  * target checks, and circuit breaker limits.
  */
 
-import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { HUMAN_ONLY_SWARM_COMMANDS } from '../../commands/tool-policy.js';
 import {
@@ -44,6 +43,7 @@ import {
 	resolveWriteTargets,
 	type WriteAnalysis,
 } from '../shell-write-detect';
+import { appendGuardrailDecision } from './audit-log';
 import {
 	DC_SAFE_TARGETS,
 	dcCheckJunctionCreation,
@@ -173,44 +173,6 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 				`BLOCKED: Agent "${agentRole}" is not permitted to use the bash/shell interpreter. ` +
 					`Allowed agents: [${interpreterAllowedAgents.map((a) => `"${a}"`).join(', ')}]`,
 			);
-		}
-	}
-
-	/**
-	 * Appends a redacted audit entry to .swarm/session/shell-audit.jsonl.
-	 * Errors are swallowed — audit failures must not block tool execution.
-	 */
-	async function appendShellAuditLog(
-		sessionID: string,
-		tool: string,
-		args: unknown,
-	): Promise<void> {
-		if (!shellAuditEnabled) return;
-		const normalizedAuditTool = normalizeToolName(tool).toLowerCase();
-		if (normalizedAuditTool !== 'bash' && normalizedAuditTool !== 'shell')
-			return;
-
-		const bashArgs = args as Record<string, unknown> | undefined;
-		const rawCmd =
-			typeof bashArgs?.command === 'string' ? bashArgs.command : '';
-		const redacted = redactShellCommand(rawCmd);
-
-		const rawAgent = swarmState.activeAgent.get(sessionID);
-		const agentRole = rawAgent ? stripKnownSwarmPrefix(rawAgent) : 'unknown';
-
-		const entry = JSON.stringify({
-			ts: new Date().toISOString(),
-			sessionID,
-			agent: agentRole,
-			tool,
-			command: redacted,
-		});
-
-		try {
-			await fs.mkdir(path.dirname(shellAuditPath), { recursive: true });
-			await fs.appendFile(shellAuditPath, `${entry}\n`, 'utf-8');
-		} catch {
-			// Intentionally swallowed — audit failures must never block shell execution
 		}
 	}
 
@@ -943,11 +905,30 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		sessionID: string,
 		tool: string,
 		args: unknown,
+		agent: string,
+		command: string,
+		auditPath: string,
+		auditEnabled: boolean,
 	): Promise<void> {
 		if (tool !== 'bash' && tool !== 'shell') return;
 
 		const executor = await getExecutor();
-		if (!executor || !executor.isAvailable()) return;
+		if (!executor || !executor.isAvailable()) {
+			void appendGuardrailDecision(
+				{
+					type: 'sandbox_skip',
+					ts: new Date().toISOString(),
+					sessionID,
+					agent,
+					tool,
+					command,
+					executorMechanism: executor?.mechanism ?? 'none',
+					skipReason: 'executor not available',
+				},
+				{ auditPath, enabled: auditEnabled },
+			);
+			return;
+		}
 
 		const toolArgs = args as Record<string, unknown> | undefined;
 		const rawCommand =
@@ -963,6 +944,19 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		try {
 			const wrappedCommand = executor.wrapCommand(rawCommand, resolved.paths);
 			toolArgs.command = wrappedCommand;
+
+			void appendGuardrailDecision(
+				{
+					type: 'sandbox_wrap',
+					ts: new Date().toISOString(),
+					sessionID,
+					agent,
+					tool,
+					command: rawCommand,
+					executorMechanism: executor.mechanism,
+				},
+				{ auditPath, enabled: auditEnabled },
+			);
 
 			const envOverrides = executor.getEnvOverrides();
 			if (Object.keys(envOverrides).length > 0) {
@@ -1773,16 +1767,186 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		handleTestSuiteBlocking(input.tool, output.args);
 
 		// Shell audit log
-		await appendShellAuditLog(input.sessionID, input.tool, output.args);
+		const normalizedAuditTool = normalizeToolName(input.tool).toLowerCase();
+		if (normalizedAuditTool === 'bash' || normalizedAuditTool === 'shell') {
+			await appendGuardrailDecision(
+				{
+					type: 'shell',
+					ts: new Date().toISOString(),
+					sessionID: input.sessionID,
+					agent: (() => {
+						const rawAgent = swarmState.activeAgent.get(input.sessionID);
+						return rawAgent ? stripKnownSwarmPrefix(rawAgent) : 'unknown';
+					})(),
+					tool: input.tool,
+					command: (() => {
+						const bashArgs = output.args as Record<string, unknown> | undefined;
+						const rawCmd =
+							typeof bashArgs?.command === 'string' ? bashArgs.command : '';
+						return redactShellCommand(rawCmd);
+					})(),
+				},
+				{
+					auditPath: shellAuditPath,
+					enabled: shellAuditEnabled,
+				},
+			);
+		}
 
 		// Interpreter gating
 		handleInterpreterGating(input.sessionID, input.tool);
 
 		// Block destructive shell commands
-		checkDestructiveCommand(input.sessionID, input.tool, output.args);
+		try {
+			checkDestructiveCommand(input.sessionID, input.tool, output.args);
+		} catch (err) {
+			const destructiveCategory = (() => {
+				const msg = err instanceof Error ? err.message : String(err);
+				if (/fork bomb/i.test(msg)) return 'fork bomb';
+				if (/rm\b.*recursive|recursive.*rm/i.test(msg))
+					return 'recursive delete';
+				if (/rmdir|rd\b/i.test(msg)) return 'recursive directory delete';
+				if (/\bdel\b/i.test(msg)) return 'recursive file delete';
+				if (/Remove-Item|ri\b/i.test(msg)) return 'recursive remove';
+				if (/format/i.test(msg)) return 'disk format';
+				if (/robocopy/i.test(msg)) return 'mirror sync';
+				if (/chmod.*000/i.test(msg)) return 'permission wipe';
+				if (/chattr/i.test(msg)) return 'immutable flag';
+				if (/icacls/i.test(msg)) return 'permission deny';
+				if (/\bdd\b/i.test(msg)) return 'data wipe';
+				if (/git push.*--force|git push.*-f/i.test(msg)) return 'force push';
+				if (/git reset/i.test(msg)) return 'git reset';
+				if (/git clean/i.test(msg)) return 'git clean';
+				if (/git worktree/i.test(msg)) return 'git worktree remove';
+				if (/rsync.*--delete/i.test(msg)) return 'rsync delete';
+				if (/kubectl delete/i.test(msg)) return 'kubectl delete';
+				if (/docker system prune/i.test(msg)) return 'docker prune';
+				if (/DROP\s+TABLE|DROP\s+DATABASE|DROP\s+SCHEMA/i.test(msg))
+					return 'sql drop';
+				if (/TRUNCATE\s+TABLE/i.test(msg)) return 'sql truncate';
+				if (/mkfs/i.test(msg)) return 'disk format';
+				if (/\bmv\b.*\.swarm/i.test(msg)) return 'swarm path move';
+				if (/\bmove\b|\bren\b/i.test(msg)) return 'move/rename';
+				if (/Move-Item|Rename-Item/i.test(msg)) return 'move/rename';
+				if (/\brm\b.*\.swarm/i.test(msg)) return 'swarm path delete';
+				if (/cp\b.*\.swarm.*rm\b|rm\b.*\.swarm/i.test(msg))
+					return 'copy-and-delete bypass';
+				if (
+					/rsync.*remove-source|tar.*remove-files|zip.*-m\b|7z.*-sdel/i.test(
+						msg,
+					)
+				)
+					return 'archive delete source';
+				if (/human-only swarm command/i.test(msg))
+					return 'human-only swarm command';
+				if (/spec-staleness\.json/i.test(msg)) return 'system file tampering';
+				return 'destructive shell command';
+			})();
+			void appendGuardrailDecision(
+				{
+					type: 'destructive_block',
+					ts: new Date().toISOString(),
+					sessionID: input.sessionID,
+					agent: (() => {
+						const rawAgent = swarmState.activeAgent.get(input.sessionID);
+						return rawAgent ? stripKnownSwarmPrefix(rawAgent) : 'unknown';
+					})(),
+					tool: input.tool,
+					command: (() => {
+						const bashArgs = output.args as Record<string, unknown> | undefined;
+						const rawCmd =
+							typeof bashArgs?.command === 'string' ? bashArgs.command : '';
+						return rawCmd;
+					})(),
+					destructiveCategory,
+				},
+				{
+					auditPath: shellAuditPath,
+					enabled: shellAuditEnabled,
+				},
+			);
+			throw err;
+		}
 
 		// Shell write scope enforcement
-		checkShellWriteScope(input.sessionID, input.tool, output.args);
+		try {
+			checkShellWriteScope(input.sessionID, input.tool, output.args);
+		} catch (err) {
+			const toolArgs = output.args as Record<string, unknown> | undefined;
+			const declaredScope = resolveDeclaredScope(input.sessionID);
+			const declaredScopeText =
+				declaredScope != null && declaredScope.length > 0
+					? declaredScope.join(', ')
+					: '';
+			const resolvedScopeText =
+				declaredScope != null && declaredScope.length > 0
+					? resolveScopePaths(declaredScope, effectiveDirectory).paths.join(
+							', ',
+						)
+					: '';
+			const pathMatch = /[^\s]+/.exec(
+				err instanceof Error ? err.message : String(err),
+			);
+			const targetPath = (() => {
+				const p =
+					toolArgs?.filePath ??
+					toolArgs?.path ??
+					toolArgs?.file ??
+					toolArgs?.target;
+				if (typeof p === 'string' && p.length > 0) return p;
+
+				const rawMessage = err instanceof Error ? err.message : String(err);
+
+				// Extract the violating write target from known guardrail error formats
+				// before falling back to the first error-message token or placeholder.
+				const extracted =
+					/(?:write|target|file|path|scope|prefix)[^:]*:\s*(?:"([^"]+)"|'([^']+)'|(\S+))/i.exec(
+						rawMessage,
+					) ??
+					/(?:write|target|file|path)\s+(?:"([^"]+)"|'([^']+)'|(\S+))/i.exec(
+						rawMessage,
+					);
+
+				const candidate =
+					extracted != null
+						? (extracted[1] ??
+							extracted[2] ??
+							extracted[3] ??
+							extracted[4] ??
+							extracted[5] ??
+							extracted[6])
+						: null;
+
+				if (candidate && candidate.length > 0 && candidate.length < 200) {
+					return candidate;
+				}
+
+				if (pathMatch) return pathMatch[0];
+				return '<shell write>';
+			})();
+			const agentName = (() => {
+				const rawAgent = swarmState.activeAgent.get(input.sessionID);
+				return rawAgent ? stripKnownSwarmPrefix(rawAgent) : 'unknown';
+			})();
+			void appendGuardrailDecision(
+				{
+					type: 'scope_violation',
+					ts: new Date().toISOString(),
+					sessionID: input.sessionID,
+					agent: agentName,
+					tool: input.tool,
+					path: targetPath,
+					declaredScope: declaredScopeText,
+					resolvedScope: resolvedScopeText,
+					action: 'bash',
+				},
+				{
+					auditPath: shellAuditPath,
+					enabled: shellAuditEnabled,
+				},
+			);
+			throw err;
+		}
 
 		// Issue #853 Layer B: structural spec-drift block
 		enforceSpecDriftGate(effectiveDirectory, input.tool);
@@ -1801,16 +1965,38 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 				toolArgs?.file ??
 				toolArgs?.target;
 			if (typeof targetPath === 'string' && targetPath.length > 0) {
+				const agentName =
+					swarmState.activeAgent.get(input.sessionID) ?? 'unknown';
 				// lstat: block writes through symlinks
 				const lstatBlock = checkWriteTargetForSymlink(
 					targetPath,
 					effectiveDirectory,
 				);
 				if (lstatBlock) {
+					void appendGuardrailDecision(
+						{
+							type: 'file_write',
+							ts: new Date().toISOString(),
+							sessionID: input.sessionID,
+							agent: agentName,
+							tool: input.tool,
+							path: targetPath,
+							reason: lstatBlock,
+							resolvedScope: (() => {
+								const scope = resolveDeclaredScope(input.sessionID);
+								return scope != null && scope.length > 0
+									? scope.join(', ')
+									: '';
+							})(),
+						},
+						{
+							auditPath: shellAuditPath,
+							enabled: shellAuditEnabled,
+						},
+					);
 					throw new Error(lstatBlock);
 				}
 
-				const agentName = swarmState.activeAgent.get(input.sessionID);
 				if (!agentName) {
 					throw new Error(
 						`WRITE BLOCKED: No active agent registered for session "${input.sessionID}". Call startAgentSession before issuing write tool calls.`,
@@ -1827,6 +2013,27 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 						.replace(/\\/g, '/');
 					for (const prefix of universalDenyPrefixes) {
 						if (normalizedPath.toLowerCase().startsWith(prefix.toLowerCase())) {
+							void appendGuardrailDecision(
+								{
+									type: 'file_write',
+									ts: new Date().toISOString(),
+									sessionID: input.sessionID,
+									agent: agentName,
+									tool: input.tool,
+									path: targetPath,
+									reason: `Path is under universal deny prefix "${prefix}"`,
+									resolvedScope: (() => {
+										const scope = resolveDeclaredScope(input.sessionID);
+										return scope != null && scope.length > 0
+											? scope.join(', ')
+											: '';
+									})(),
+								},
+								{
+									auditPath: shellAuditPath,
+									enabled: shellAuditEnabled,
+								},
+							);
 							throw new Error(
 								`WRITE BLOCKED: Agent "${agentName}" is not authorised to write "${targetPath}". Reason: Path is under universal deny prefix "${prefix}"`,
 							);
@@ -1845,6 +2052,27 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 					{ declaredScope: writeDeclaredScope },
 				);
 				if (!authorityCheck.allowed) {
+					void appendGuardrailDecision(
+						{
+							type: 'file_write',
+							ts: new Date().toISOString(),
+							sessionID: input.sessionID,
+							agent: agentName,
+							tool: input.tool,
+							path: targetPath,
+							reason: authorityCheck.reason,
+							resolvedScope: (() => {
+								const scope = writeDeclaredScope;
+								return scope != null && scope.length > 0
+									? scope.join(', ')
+									: '';
+							})(),
+						},
+						{
+							auditPath: shellAuditPath,
+							enabled: shellAuditEnabled,
+						},
+					);
 					throw new Error(
 						`WRITE BLOCKED: Agent "${agentName}" is not authorised to write "${targetPath}". Reason: ${authorityCheck.reason}`,
 					);
@@ -1882,8 +2110,9 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 
 		// Authority + lstat + universal-deny for apply_patch / patch
 		if (input.tool === 'apply_patch' || input.tool === 'patch') {
-			const patchAgentName = swarmState.activeAgent.get(input.sessionID);
-			if (!patchAgentName) {
+			const patchAgentName =
+				swarmState.activeAgent.get(input.sessionID) ?? 'unknown';
+			if (!swarmState.activeAgent.has(input.sessionID)) {
 				throw new Error(
 					`WRITE BLOCKED: No active agent registered for session "${input.sessionID}". Call startAgentSession before issuing write tool calls.`,
 				);
@@ -1891,6 +2120,27 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			for (const p of extractPatchTargetPaths(input.tool, output.args)) {
 				const lstatBlock = checkWriteTargetForSymlink(p, effectiveDirectory);
 				if (lstatBlock) {
+					void appendGuardrailDecision(
+						{
+							type: 'file_write',
+							ts: new Date().toISOString(),
+							sessionID: input.sessionID,
+							agent: patchAgentName,
+							tool: input.tool,
+							path: p,
+							reason: lstatBlock,
+							resolvedScope: (() => {
+								const scope = resolveDeclaredScope(input.sessionID);
+								return scope != null && scope.length > 0
+									? scope.join(', ')
+									: '';
+							})(),
+						},
+						{
+							auditPath: shellAuditPath,
+							enabled: shellAuditEnabled,
+						},
+					);
 					throw new Error(lstatBlock);
 				}
 
@@ -1903,6 +2153,27 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 						.replace(/\\/g, '/');
 					for (const prefix of universalDenyPrefixes) {
 						if (normalizedP.toLowerCase().startsWith(prefix.toLowerCase())) {
+							void appendGuardrailDecision(
+								{
+									type: 'file_write',
+									ts: new Date().toISOString(),
+									sessionID: input.sessionID,
+									agent: patchAgentName,
+									tool: input.tool,
+									path: p,
+									reason: `Path is under universal deny prefix "${prefix}"`,
+									resolvedScope: (() => {
+										const scope = resolveDeclaredScope(input.sessionID);
+										return scope != null && scope.length > 0
+											? scope.join(', ')
+											: '';
+									})(),
+								},
+								{
+									auditPath: shellAuditPath,
+									enabled: shellAuditEnabled,
+								},
+							);
 							throw new Error(
 								`WRITE BLOCKED: Agent "${patchAgentName}" is not authorised to write "${p}" (via patch). Reason: Path is under universal deny prefix "${prefix}"`,
 							);
@@ -1920,6 +2191,27 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 					{ declaredScope: patchDeclaredScope },
 				);
 				if (!authorityCheck.allowed) {
+					void appendGuardrailDecision(
+						{
+							type: 'file_write',
+							ts: new Date().toISOString(),
+							sessionID: input.sessionID,
+							agent: patchAgentName,
+							tool: input.tool,
+							path: p,
+							reason: authorityCheck.reason,
+							resolvedScope: (() => {
+								const scope = patchDeclaredScope;
+								return scope != null && scope.length > 0
+									? scope.join(', ')
+									: '';
+							})(),
+						},
+						{
+							auditPath: shellAuditPath,
+							enabled: shellAuditEnabled,
+						},
+					);
 					throw new Error(
 						`WRITE BLOCKED: Agent "${patchAgentName}" is not authorised to write "${p}" (via patch). Reason: ${authorityCheck.reason}`,
 					);
@@ -1985,7 +2277,23 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		});
 
 		// OS-level sandbox enforcement
-		await applySandboxExecution(input.sessionID, input.tool, output.args);
+		await applySandboxExecution(
+			input.sessionID,
+			input.tool,
+			output.args,
+			(() => {
+				const rawAgent = swarmState.activeAgent.get(input.sessionID);
+				return rawAgent ? stripKnownSwarmPrefix(rawAgent) : 'unknown';
+			})(),
+			(() => {
+				const bashArgs = output.args as Record<string, unknown> | undefined;
+				const rawCmd =
+					typeof bashArgs?.command === 'string' ? bashArgs.command : '';
+				return rawCmd;
+			})(),
+			shellAuditPath,
+			shellAuditEnabled,
+		);
 
 		// v6.12: Store input args for delegation detection in toolAfter
 		setStoredInputArgs(input.callID, output.args);

--- a/src/services/diagnose-service.ts
+++ b/src/services/diagnose-service.ts
@@ -10,6 +10,8 @@ import { getDurableGateEvidenceStatusForTask } from '../evidence/gate-bridge.js'
 import { listEvidenceTaskIds } from '../evidence/manager';
 import { readSwarmFileAsync } from '../hooks/utils';
 import { loadPlanJsonOnly } from '../plan/manager';
+import { SandboxCapabilityProbe } from '../sandbox/capability-probe.js';
+import { getExecutor } from '../sandbox/executor.js';
 import { readEffectiveSpecSync } from '../sdd/effective-spec';
 import { checkKnowledgeHealth } from './knowledge-diagnostics.js';
 import { compareVersions, readVersionCache } from './version-check.js';
@@ -799,6 +801,52 @@ async function checkCurator(directory: string): Promise<HealthCheck> {
 }
 
 /**
+ * Get sandbox health-check entry.
+ *
+ * Consumes the cached sandbox capability probe and, if available,
+ * the cached sandbox executor. Never re-probes and never crashes
+ * diagnose on sandbox errors.
+ */
+async function getSandboxStatus(): Promise<HealthCheck> {
+	try {
+		const capability = await new SandboxCapabilityProbe().detect();
+		const mechanism = capability.mechanism ?? 'none';
+
+		const executor = await getExecutor();
+		const hasExecutor = executor !== null;
+
+		if (hasExecutor) {
+			return {
+				name: 'Sandbox',
+				status: '✅',
+				detail: `Mechanism: ${mechanism.toLowerCase()} | Available: yes | Sandboxing commands: yes`,
+			};
+		}
+
+		if (mechanism !== 'none') {
+			return {
+				name: 'Sandbox',
+				status: '⚠️',
+				detail: `Mechanism: ${mechanism.toLowerCase()} | Available: no (silent pass-through) | Commands NOT sandboxed`,
+			};
+		}
+
+		return {
+			name: 'Sandbox',
+			status: '⬜',
+			detail: `Mechanism: ${mechanism.toLowerCase()} | Commands not sandboxed`,
+		};
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'Unknown error';
+		return {
+			name: 'Sandbox',
+			status: '⬜',
+			detail: `Sandbox status unknown (${message})`,
+		};
+	}
+}
+
+/**
  * Get diagnose data from the swarm directory.
  * Returns structured health checks for GUI, background flows, or commands.
  */
@@ -953,6 +1001,9 @@ export async function getDiagnoseData(
 
 	// Check: Git Repository
 	checks.push(await checkGitRepository(directory));
+
+	// Check: Sandbox
+	checks.push(await getSandboxStatus());
 
 	// Check: Spec Staleness
 	checks.push(await checkSpecStaleness(directory, plan));

--- a/src/services/diagnose-service.ts
+++ b/src/services/diagnose-service.ts
@@ -18,6 +18,12 @@ import { compareVersions, readVersionCache } from './version-check.js';
 import { getDeferredWarnings } from './warning-buffer.js';
 
 const { version } = packageJson;
+const sandboxCapabilityProbe = new SandboxCapabilityProbe();
+
+export const _internals = {
+	detectSandboxCapability: () => sandboxCapabilityProbe.detect(),
+	getSandboxExecutor: getExecutor,
+};
 
 /**
  * A single health check result.
@@ -809,10 +815,10 @@ async function checkCurator(directory: string): Promise<HealthCheck> {
  */
 async function getSandboxStatus(): Promise<HealthCheck> {
 	try {
-		const capability = await new SandboxCapabilityProbe().detect();
+		const capability = await _internals.detectSandboxCapability();
 		const mechanism = capability.mechanism ?? 'none';
 
-		const executor = await getExecutor();
+		const executor = await _internals.getSandboxExecutor();
 		const hasExecutor = executor !== null;
 
 		if (hasExecutor) {

--- a/src/services/guardrail-explain-service.ts
+++ b/src/services/guardrail-explain-service.ts
@@ -1,0 +1,917 @@
+import path from 'node:path';
+import { HUMAN_ONLY_SWARM_COMMANDS } from '../commands/tool-policy.js';
+import { classifyFile, type FileZone } from '../context/zone-classifier.js';
+import { redactPath } from '../hooks/guardrails/audit-log.js';
+import {
+	DC_SAFE_TARGETS,
+	dcCheckJunctionCreation,
+	dcExtractPowerShellTargets,
+	dcExtractWindowsCmdTargets,
+	dcNormalizeCommand,
+	dcSplitSegments,
+	dcUnwrapWrappers,
+	dcValidateTargets,
+} from '../hooks/guardrails/destructive-command.js';
+import { checkFileAuthority } from '../hooks/guardrails/file-authority.js';
+import {
+	isInDeclaredScope,
+	redactShellCommand,
+} from '../hooks/guardrails/helpers.js';
+import {
+	detectPosixWrites,
+	detectWindowsWrites,
+	resolveWriteTargets,
+} from '../hooks/shell-write-detect.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of dry-run shell analysis.
+ */
+export interface GuardrailShellResult {
+	decision: 'allow' | 'block';
+	firingRule: string;
+	resolvedScope: string;
+	writeCategories: string[];
+	command: string;
+}
+
+/**
+ * Result of dry-run write-target analysis for a single path.
+ */
+export interface GuardrailWriteTargetResult {
+	path: string;
+	decision: 'allow' | 'block';
+	firingRule: string;
+	resolvedScope: string;
+	zone: FileZone;
+}
+
+/**
+ * Top-level result returned by handleGuardrailExplain.
+ */
+export interface GuardrailExplainResult {
+	mode: 'shell' | 'write';
+	shell?: GuardrailShellResult;
+	writeTargets?: GuardrailWriteTargetResult[];
+}
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+interface ParsedArgs {
+	agent: string;
+	scope: string | null;
+	writeTargets: string[];
+	shellCommand: string;
+}
+
+/**
+ * Parse command-line arguments for the guardrail-explain command.
+ *
+ * Supported flags:
+ *   --agent <role>       Agent role (default: 'coder')
+ *   --scope <path>       Override declared scope path
+ *   --write <path>       Write-target mode (repeatable)
+ *
+ * Any non-flag tokens are joined as the positional shell command.
+ */
+function parseGuardrailExplainArgs(args: string[]): ParsedArgs {
+	let agent = 'coder';
+	let scope: string | null = null;
+	const writeTargets: string[] = [];
+	const positional: string[] = [];
+
+	let i = 0;
+	while (i < args.length) {
+		const token = args[i];
+		if (token === '--agent' && i + 1 < args.length) {
+			agent = args[i + 1];
+			i += 2;
+		} else if (token === '--scope' && i + 1 < args.length) {
+			scope = args[i + 1];
+			i += 2;
+		} else if (token === '--write' && i + 1 < args.length) {
+			writeTargets.push(args[i + 1]);
+			i += 2;
+		} else {
+			positional.push(token);
+			i++;
+		}
+	}
+
+	return {
+		agent,
+		scope,
+		writeTargets,
+		shellCommand: positional.join(' '),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Shell-type resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Heuristic shell-type detection used for write-target detection.
+ * Mirrors the logic in tool-before.ts.
+ */
+function resolveShellType(command: string): 'posix' | 'powershell' | 'cmd' {
+	const trimmed = command.trim().toLowerCase();
+	if (
+		trimmed.startsWith('powershell') ||
+		trimmed.startsWith('pwsh') ||
+		/^(?:remove-item|ri|rm\b|rmdir|del\b|erase|rd)\b/i.test(trimmed)
+	) {
+		return 'powershell';
+	}
+	if (trimmed.startsWith('cmd') || trimmed.startsWith('cmd.exe')) {
+		return 'cmd';
+	}
+	return 'posix';
+}
+
+// ---------------------------------------------------------------------------
+// Destructive-command dry-run (mirrors checkDestructiveCommand)
+// ---------------------------------------------------------------------------
+
+// TODO(#1274): checkDestructiveCommand is a nested closure in tool-before.ts:182
+// (captures cfg.block_destructive_commands, effectiveDirectory, resolveDeclaredScope) and
+// cannot be exported without refactoring the guardrail hot path. This block mirrors its
+// destructive-pattern detection; the heavy helpers (dc*, isInDeclaredScope, DC_SAFE_TARGETS)
+// are shared imports. Future refactor: extract a top-level evaluateDestructiveDecision().
+
+/**
+ * Evaluate the destructive-command decision for a shell command in dry-run mode.
+ * Returns { decision, firingRule } without throwing.
+ *
+ * Assumes block_destructive_commands is TRUE (explain predicts default guardrail behavior).
+ * cwd = the directory parameter. declaredScope = --scope override or null.
+ */
+function evaluateDestructiveDecision(
+	rawCommand: string,
+	cwd: string,
+	declaredScope: string[] | null,
+): { decision: 'allow' | 'block'; firingRule: string } {
+	if (!rawCommand) {
+		return { decision: 'allow', firingRule: 'allow: no rule matched' };
+	}
+
+	const command = dcNormalizeCommand(rawCommand);
+
+	// Fork bomb (mirror real checkDestructiveCommand: allows whitespace after the leading ':')
+	if (/:\s*\(\s*\)\s*\{[^}]*\|[^}]*:/.test(command)) {
+		return {
+			decision: 'block',
+			firingRule: 'destructive_block: fork bomb pattern',
+		};
+	}
+
+	const unwrapped = dcUnwrapWrappers(command);
+	const outerSegments = dcSplitSegments(command);
+	const innerSegments = dcSplitSegments(unwrapped);
+	const perSegmentUnwrapped = outerSegments.map((s) => dcUnwrapWrappers(s));
+	const allSegments = [
+		...new Set([...outerSegments, ...innerSegments, ...perSegmentUnwrapped]),
+	];
+
+	for (const segment of allSegments) {
+		const seg = segment.trim();
+		if (!seg) continue;
+
+		// Junction/symlink creation with out-of-cwd target
+		const junctionBlock = dcCheckJunctionCreation(seg, cwd);
+		if (junctionBlock) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: junction creation',
+			};
+		}
+
+		// POSIX rm — short flags (-rf, -fr, -r -f) and long flags
+		const rmShortMatch = seg.match(
+			/^rm\s+(-[rRfF]+(?:\s+-[rRfF]+)*|-r\s+-f|-f\s+-r)\s+(.+)$/,
+		);
+		const rmLongMatch = seg.match(
+			/^rm\s+(?:--(?:recursive|force)\s+){1,2}(.+)$/,
+		);
+		const rmAnyMatch = rmShortMatch ?? rmLongMatch;
+		if (rmAnyMatch) {
+			const targetPart = rmAnyMatch[rmShortMatch ? 2 : 1].trim();
+			const targets = targetPart.split(/\s+/);
+			const validateBlock = dcValidateTargets(targets, cwd);
+			if (validateBlock) {
+				return {
+					decision: 'block',
+					firingRule: `destructive_block: rm with unsafe target: ${redactPath(targetPart)}`,
+				};
+			}
+			const allSafe = targets.every((t) =>
+				DC_SAFE_TARGETS.has(t.replace(/^["']|["']$/g, '').trim()),
+			);
+			if (!allSafe) {
+				const scopeExempt =
+					declaredScope != null &&
+					declaredScope.length > 0 &&
+					targets.every((t) =>
+						isInDeclaredScope(
+							t.replace(/^["']|["']$/g, '').trim(),
+							declaredScope,
+							cwd,
+						),
+					);
+				if (!scopeExempt) {
+					return {
+						decision: 'block',
+						firingRule: `destructive_block: rm recursive/force on unsafe path: ${redactPath(targetPart)}`,
+					};
+				}
+			}
+		}
+
+		// Windows cmd.exe: rmdir /s, rd /s
+		if (/^(?:rmdir|rd)(?:\.exe)?\s+.*\/[sS]/i.test(seg)) {
+			const targets = dcExtractWindowsCmdTargets(seg);
+			if (targets.length === 0) {
+				return {
+					decision: 'block',
+					firingRule:
+						'destructive_block: Windows recursive directory delete (rmdir /s)',
+				};
+			}
+			const validateBlock = dcValidateTargets(targets, cwd);
+			if (validateBlock) {
+				return {
+					decision: 'block',
+					firingRule: `destructive_block: rmdir /s unsafe: ${redactPath(targets.join(', '))}`,
+				};
+			}
+			const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.trim()));
+			if (!allSafe) {
+				const scopeExempt =
+					declaredScope != null &&
+					declaredScope.length > 0 &&
+					targets.every((t) => isInDeclaredScope(t.trim(), declaredScope, cwd));
+				if (!scopeExempt) {
+					return {
+						decision: 'block',
+						firingRule: `destructive_block: rmdir /s on unsafe path: ${redactPath(targets.join(', '))}`,
+					};
+				}
+			}
+		}
+
+		// Windows cmd.exe: del /s /q /f
+		if (/^del(?:\.exe)?\s+.*\/[sS]/i.test(seg)) {
+			const targets = dcExtractWindowsCmdTargets(seg);
+			if (targets.length > 0) {
+				const validateBlock = dcValidateTargets(targets, cwd);
+				if (validateBlock) {
+					return {
+						decision: 'block',
+						firingRule: `destructive_block: del /s unsafe: ${redactPath(targets.join(', '))}`,
+					};
+				}
+				const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.trim()));
+				if (!allSafe) {
+					const scopeExempt =
+						declaredScope != null &&
+						declaredScope.length > 0 &&
+						targets.every((t) =>
+							isInDeclaredScope(t.trim(), declaredScope, cwd),
+						);
+					if (!scopeExempt) {
+						return {
+							decision: 'block',
+							firingRule: `destructive_block: del /s on unsafe path: ${redactPath(targets.join(', '))}`,
+						};
+					}
+				}
+			}
+		}
+
+		// PowerShell: Remove-Item / aliases with -Recurse
+		if (
+			/^(?:Remove-Item|ri|rm|rmdir|del|erase|rd)\b.*-[Rr]ecurse\b/i.test(seg) ||
+			/^(?:Remove-Item|ri|rm|rmdir|del|erase|rd)\b.*-[Rr]\b/i.test(seg)
+		) {
+			const targets = dcExtractPowerShellTargets(seg);
+			if (targets.length > 0) {
+				const validateBlock = dcValidateTargets(targets, cwd);
+				if (validateBlock) {
+					return {
+						decision: 'block',
+						firingRule: `destructive_block: PowerShell recursive delete unsafe: ${redactPath(targets.join(', '))}`,
+					};
+				}
+				const allSafe = targets.every((t) => DC_SAFE_TARGETS.has(t.trim()));
+				if (!allSafe) {
+					const scopeExempt =
+						declaredScope != null &&
+						declaredScope.length > 0 &&
+						targets.every((t) =>
+							isInDeclaredScope(t.trim(), declaredScope, cwd),
+						);
+					if (!scopeExempt) {
+						return {
+							decision: 'block',
+							firingRule: `destructive_block: PowerShell recursive delete on unsafe path: ${redactPath(targets.join(', '))}`,
+						};
+					}
+				}
+			} else {
+				return {
+					decision: 'block',
+					firingRule:
+						'destructive_block: PowerShell Remove-Item -Recurse (target unverifiable)',
+				};
+			}
+		}
+
+		// PowerShell: Get-ChildItem | Remove-Item -Recurse (pipe form)
+		if (
+			/Get-ChildItem\b.*\|\s*Remove-Item\b.*-[Rr]ecurse/i.test(seg) ||
+			/gci\b.*\|\s*ri\b.*-[Rr]ecurse/i.test(seg)
+		) {
+			return {
+				decision: 'block',
+				firingRule:
+					'destructive_block: PowerShell pipeline Get-ChildItem | Remove-Item -Recurse',
+			};
+		}
+
+		// Ransomware-grade / disk-level destruction
+		if (/^vssadmin(?:\.exe)?\s+delete\b/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: vssadmin delete (ransomware-grade)',
+			};
+		}
+		if (/^wbadmin(?:\.exe)?\s+delete\b/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule:
+					'destructive_block: wbadmin delete (backup catalog deletion)',
+			};
+		}
+		if (/^diskpart(?:\.exe)?$/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule:
+					'destructive_block: diskpart (interactive disk partitioning)',
+			};
+		}
+		if (/^bcdedit(?:\.exe)?\s+\/delete\b/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule:
+					'destructive_block: bcdedit /delete (boot config modification)',
+			};
+		}
+		if (/^sdelete(?:\.exe)?\s+/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: sdelete (secure file deletion)',
+			};
+		}
+		if (
+			/^fsutil(?:\.exe)?\s+reparsepoint\s+delete\b/i.test(seg) ||
+			/^fsutil(?:\.exe)?\s+file\s+setzerodata\b/i.test(seg)
+		) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: fsutil destructive subcommand',
+			};
+		}
+		if (/^takeown(?:\.exe)?\s+.*\/[rR]\b/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule:
+					'destructive_block: takeown /R (recursive ownership takeover)',
+			};
+		}
+		if (/^cipher(?:\.exe)?\s+\/[wW]\b/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: cipher /w (free disk space wipe)',
+			};
+		}
+		if (/^format\s+[A-Za-z]:/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: Windows disk format command',
+			};
+		}
+		if (/^robocopy(?:\.exe)?\s+.*\/(?:MIR|mir)\b/.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: robocopy /MIR (mirror delete)',
+			};
+		}
+
+		// POSIX: chmod/chattr/icacls denial-of-service patterns
+		if (/^chmod\s+.*-[rR]\b.*000\b/.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: chmod -R 000 (permission wipe)',
+			};
+		}
+		if (/^chattr\s+.*\+i\b/.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: chattr +i (immutable flag)',
+			};
+		}
+		if (/^icacls(?:\.exe)?\s+.*\/deny\b/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: icacls /deny (permission denial)',
+			};
+		}
+
+		// dd data-wipe patterns
+		if (/^dd\b.*\bif=\/dev\/(zero|null|urandom)\b/.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule:
+					'destructive_block: dd with /dev/zero|null|urandom (data wipe)',
+			};
+		}
+
+		// Git destructive operations
+		if (/^git\s+push\b.*?(--force|-f)\b/.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: git push --force',
+			};
+		}
+		if (/^git\s+reset\s+--hard/.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: git reset --hard',
+			};
+		}
+		if (/^git\s+reset\s+--mixed\s+\S+/.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: git reset --mixed with target',
+			};
+		}
+		if (/^git\s+clean\s+.*-[fF].*[dD]/.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: git clean -fd',
+			};
+		}
+		if (/^git\s+worktree\s+remove\s+.*--force\b/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: git worktree remove --force',
+			};
+		}
+
+		// rsync mirror / sync with delete
+		if (/^rsync\b.*--delete(?:-after|-before|-during|-delay)?\b/.test(seg)) {
+			const rsyncArgs = seg.split(/\s+/).slice(1);
+			const rsyncTarget = rsyncArgs
+				.filter((a) => !a.startsWith('-') && !a.includes('@'))
+				.pop();
+			const scopeExempt =
+				rsyncTarget != null &&
+				declaredScope != null &&
+				declaredScope.length > 0 &&
+				isInDeclaredScope(rsyncTarget, declaredScope, cwd);
+			if (!scopeExempt) {
+				return {
+					decision: 'block',
+					firingRule: `destructive_block: rsync --delete (target: ${redactPath(rsyncTarget ?? 'unknown')})`,
+				};
+			}
+		}
+
+		// kubectl / docker
+		if (/^kubectl\s+delete\b/.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: kubectl delete',
+			};
+		}
+		if (/^docker\s+system\s+prune\b/.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: docker system prune',
+			};
+		}
+
+		// SQL DDL
+		if (/^\s*DROP\s+(TABLE|DATABASE|SCHEMA)\b/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: SQL DROP statement',
+			};
+		}
+		if (/^\s*TRUNCATE\s+TABLE\b/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: SQL TRUNCATE TABLE statement',
+			};
+		}
+
+		// POSIX mv targeting .swarm/ paths
+		if (/^\\?mv\s/i.test(seg)) {
+			const mvMatch = seg.match(/^\\?mv\s+(.+)$/i);
+			if (mvMatch) {
+				const argsStr = mvMatch[1].replace(/["']/g, '');
+				if (/\.swarm(?:[\x5c/\s]|$)/.test(argsStr)) {
+					return {
+						decision: 'block',
+						firingRule:
+							'destructive_block: "mv" targeting .swarm/ detected — move operations under .swarm/ are not allowed from shell commands',
+					};
+				}
+			}
+		}
+
+		// Windows cmd move/ren targeting .swarm\ paths
+		if (/^\\?(?:move|ren)(?:\.exe)?\s/i.test(seg)) {
+			const moveMatch = seg.match(/^\\?(?:move|ren)(?:\.exe)?\s+(.+)$/i);
+			if (moveMatch) {
+				const argsStr = moveMatch[1].replace(/["']/g, '');
+				if (/\.swarm(?:[\x5c/\s]|$)/i.test(argsStr)) {
+					return {
+						decision: 'block',
+						firingRule:
+							'destructive_block: "move" or "ren" targeting .swarm/ detected — move/rename operations under .swarm/ are not allowed from shell commands',
+					};
+				}
+			}
+		}
+
+		// PowerShell Move-Item/Rename-Item targeting .swarm/ paths
+		if (
+			/^\\?(?:Move-Item|Rename-Item|move|mi|mv|ren|rni)\b.*\.swarm(?:[\x5c/\s]|$)/i.test(
+				seg,
+			)
+		) {
+			return {
+				decision: 'block',
+				firingRule:
+					'destructive_block: PowerShell Move-Item or Rename-Item targeting .swarm/ detected — move/rename operations under .swarm/ are not allowed from shell commands',
+			};
+		}
+
+		// Non-recursive rm targeting .swarm/ paths
+		if (
+			/^\\?rm\b/i.test(seg) &&
+			!/^\\?rm\s+(?:-[a-zA-Z]*[rR][a-zA-Z]*|--recursive)\b/i.test(seg) &&
+			/\.swarm(?:[\x5c/\s]|$)/i.test(seg)
+		) {
+			return {
+				decision: 'block',
+				firingRule:
+					'destructive_block: "rm" targeting .swarm/ detected — deleting files under .swarm/ is not allowed from shell commands',
+			};
+		}
+
+		// cp + rm chain detection (copy-then-delete bypass)
+		if (
+			/\bcp\b.*\.swarm(?:[\x5c/\s]|$)/i.test(seg) &&
+			/\brm\b.*\.swarm(?:[\x5c/\s]|$)/i.test(seg)
+		) {
+			return {
+				decision: 'block',
+				firingRule:
+					'destructive_block: "cp" of .swarm/ file followed by "rm" of .swarm/ source detected — copy-and-delete bypass is not allowed',
+			};
+		}
+
+		// Archive tools with delete-source flags targeting .swarm/
+		if (
+			/^rsync\b.*--remove-source-files\b/i.test(seg) &&
+			/\.swarm(?:[\x5c/\s]|$)/i.test(seg)
+		) {
+			return {
+				decision: 'block',
+				firingRule:
+					'destructive_block: "rsync" with delete-source flag targeting .swarm/ detected — archive with source deletion under .swarm/ is not allowed',
+			};
+		}
+		if (
+			/^tar\b.*--remove-files\b/i.test(seg) &&
+			/\.swarm(?:[\x5c/\s]|$)/i.test(seg)
+		) {
+			return {
+				decision: 'block',
+				firingRule:
+					'destructive_block: "tar" with delete-source flag targeting .swarm/ detected — archive with source deletion under .swarm/ is not allowed',
+			};
+		}
+		if (/^zip\b.*\s-m\b/i.test(seg) && /\.swarm(?:[\x5c/\s]|$)/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule:
+					'destructive_block: "zip" with delete-source flag targeting .swarm/ detected — archive with source deletion under .swarm/ is not allowed',
+			};
+		}
+		if (/^7z\b.*\s-sdel\b/i.test(seg) && /\.swarm(?:[\x5c/\s]|$)/i.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule:
+					'destructive_block: "7z" with delete-source flag targeting .swarm/ detected — archive with source deletion under .swarm/ is not allowed',
+			};
+		}
+
+		// Disk format (mkfs only — matches real checkDestructiveCommand). NOTE: wipefs/shred/
+		// truncate/sed -i/perl -i are NOT in real enforcement, so explain must NOT block them
+		// either (over-mirroring causes drift — explain would predict a block that never fires).
+		if (/^mkfs[./]/.test(seg)) {
+			return {
+				decision: 'block',
+				firingRule: 'destructive_block: mkfs (filesystem format)',
+			};
+		}
+
+		// Human-only swarm CLI bypass — mirror real checkDestructiveCommand (tool-before.ts:598-702).
+		// Agents must not invoke human-only /swarm subcommands via shell (e.g. `opencode-swarm run reset`).
+		{
+			let probe = seg
+				.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)+/, '')
+				.replace(/^eval(?:\s+--)?\s+["']?/, '')
+				.replace(/["']\s*$/, '')
+				.replace(/^\$\(\s*/, '')
+				.replace(/^\(\s*/, '')
+				.replace(/\s*\)$/, '')
+				.replace(/^`/, '')
+				.replace(/`$/, '')
+				.trim();
+			for (let i = 0; i < 4; i++) {
+				const before = probe;
+				probe = probe
+					.replace(
+						/^env\s+(?:-i\b|--ignore-environment\b|-u\s+\S+|-[a-zA-Z]+\s+)*\s*/,
+						'',
+					)
+					.replace(/^command\s+(?:-[pvV]\s+)*/, '')
+					.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)+/, '')
+					.trim();
+				if (probe === before) break;
+			}
+			const swarmCliMatches = [
+				probe.match(
+					/^\\?(?:bunx|npx|pnpx|npm(?:\s+(?:exec|x)(?:\s+--)?)?|pnpm(?:\s+(?:dlx|exec))?|yarn(?:\s+(?:dlx|exec))?|bun(?:\s+x)?|node|deno\s+run|tsx|ts-node)\b[^|;&]*?\bopencode-swarm\b[^|;&]*?\brun\s+([A-Za-z0-9_-]+(?:\s+(?!-)[A-Za-z0-9_-]+)?)/i,
+				),
+				probe.match(
+					/^\\?opencode-swarm\b[^|;&]*?\brun\s+([A-Za-z0-9_-]+(?:\s+(?!-)[A-Za-z0-9_-]+)?)/i,
+				),
+				probe.match(
+					/\bcli[/\\]+index\.[mc]?(?:js|ts)\b[^|;&]*?\brun\s+([A-Za-z0-9_-]+(?:\s+(?!-)[A-Za-z0-9_-]+)?)/i,
+				),
+			];
+			for (const m of swarmCliMatches) {
+				if (!m) continue;
+				const captured = m[1];
+				const normalized = captured.trim().split(/\s+/).join(' ');
+				const firstToken = normalized.includes(' ')
+					? normalized.split(' ')[0]!
+					: normalized;
+				if (
+					HUMAN_ONLY_SWARM_COMMANDS.has(normalized) ||
+					HUMAN_ONLY_SWARM_COMMANDS.has(firstToken)
+				) {
+					const cmdName = HUMAN_ONLY_SWARM_COMMANDS.has(normalized)
+						? normalized
+						: firstToken;
+					return {
+						decision: 'block',
+						firingRule: `human_only_command: "${cmdName}" is a human-only swarm command (not invocable from shell by an agent)`,
+					};
+				}
+			}
+		}
+
+		// Direct shell manipulation of .swarm/spec-staleness.json — mirror real checkDestructiveCommand:704-725.
+		{
+			const normForPathCheck = seg
+				.replace(/\\/g, '/')
+				.replace(/\/(?:\.\/+)+/g, '/')
+				.replace(/\/{2,}/g, '/');
+			if (/\.swarm\/spec-staleness\.json\b/i.test(normForPathCheck)) {
+				const trimmed = seg.trim();
+				const looksReadOnly =
+					/^(?:cat|less|more|head|tail|file|stat|ls|dir|Get-Content|gc|Get-Item|gi|type)\b/i.test(
+						trimmed,
+					);
+				const hasWriteRedirect = />{1,2}\s*[^\s>]/.test(trimmed);
+				if (!looksReadOnly || hasWriteRedirect) {
+					return {
+						decision: 'block',
+						firingRule:
+							'system_file_tampering: shell command targeting .swarm/spec-staleness.json (system-managed file)',
+					};
+				}
+			}
+		}
+	}
+
+	return {
+		decision: 'allow',
+		firingRule: 'allow: no destructive/scope rule matched',
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Main handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Dry-run guardrail explainer — analyzes a shell command or write target
+ * WITHOUT executing anything. Returns a markdown report of what the
+ * guardrails WOULD do.
+ *
+ * Arg interface:
+ *   guardrail explain <command>                    — shell mode
+ *   guardrail explain --agent <role> <command>     — shell mode with agent override
+ *   guardrail explain --scope <path> <command>     — shell mode with scope override
+ *   guardrail explain --write <path>               — write-target mode
+ *   guardrail explain --write <p1> --write <p2>    — multiple write targets
+ */
+export async function handleGuardrailExplain(
+	directory: string,
+	args: string[],
+): Promise<string> {
+	const { agent, scope, writeTargets, shellCommand } =
+		parseGuardrailExplainArgs(args);
+
+	const resolvedScope = scope ?? directory;
+	// Build scope entries array for isInDeclaredScope checks. When no --scope override is
+	// given, default to the project directory (== resolvedScope) so in-project writes are
+	// allowed — matching the displayed "resolved scope". An empty array here would wrongly
+	// block every write as out-of-scope.
+	const scopeEntries: string[] =
+		scope != null && scope.length > 0 ? [scope] : [resolvedScope];
+
+	// ---------------------------------------------------------------
+	// WRITE-TARGET mode
+	// ---------------------------------------------------------------
+	if (writeTargets.length > 0) {
+		const results: GuardrailWriteTargetResult[] = [];
+
+		for (const rawPath of writeTargets) {
+			const absolutePath = path.resolve(directory, rawPath);
+			const decision = checkFileAuthority(
+				agent,
+				absolutePath,
+				directory,
+				undefined,
+				{ declaredScope: scope != null ? [scope] : null },
+			);
+			const zoneResult = classifyFile(absolutePath);
+			const allowed = decision.allowed === true;
+			const zone = allowed
+				? zoneResult.zone
+				: (decision.zone ?? zoneResult.zone);
+
+			results.push({
+				path: rawPath,
+				decision: allowed ? 'allow' : 'block',
+				firingRule: allowed
+					? 'allow: no rule matched'
+					: redactPath(decision.reason),
+				resolvedScope: redactPath(resolvedScope),
+				zone,
+			});
+		}
+
+		const redactedResolvedScope = redactPath(resolvedScope);
+		const lines: string[] = [
+			'## Guardrail Explain (dry-run)',
+			'',
+			`**Mode**: write-target | **Agent**: ${agent} | **Resolved scope**: ${redactedResolvedScope}`,
+			'',
+			'| Path | Decision | Firing Rule | Resolved Scope | Zone |',
+			'| --- | --- | --- | --- | --- |',
+			...results.map(
+				(r) =>
+					`| ${redactPath(r.path)} | ${r.decision} | ${r.firingRule} | ${redactPath(r.resolvedScope)} | ${r.zone} |`,
+			),
+			'',
+		];
+
+		return lines.join('\n');
+	}
+
+	// ---------------------------------------------------------------
+	// SHELL mode
+	// ---------------------------------------------------------------
+	if (!shellCommand) {
+		return [
+			'## Guardrail Explain (dry-run)',
+			'',
+			'Provide a shell command to analyze, or use `--write <path>` for write-target mode.',
+			'',
+			'```',
+			'/swarm guardrail explain <command>',
+			'/swarm guardrail explain --agent <role> --scope <path> <command>',
+			'/swarm guardrail explain --write <path> [--write <path2> ...]',
+			'```',
+			'',
+		].join('\n');
+	}
+
+	let decision: 'allow' | 'block' = 'allow';
+	let firingRule = 'allow: no rule matched';
+	const writeCategories = new Set<string>();
+
+	// --- Destructive-command dry-run (self-contained, mirrors checkDestructiveCommand) ---
+	const destructiveEval = evaluateDestructiveDecision(
+		shellCommand,
+		directory,
+		scopeEntries,
+	);
+	if (destructiveEval.decision === 'block') {
+		decision = 'block';
+		firingRule = destructiveEval.firingRule;
+	}
+
+	// --- Shell-write-scope check (mirrors checkShellWriteScope decision) ---
+	if (decision === 'allow') {
+		const shellType = resolveShellType(shellCommand);
+		const analysis =
+			shellType === 'powershell' || shellType === 'cmd'
+				? detectWindowsWrites(shellCommand, shellType)
+				: detectPosixWrites(shellCommand);
+
+		if (!analysis.parseError && analysis.hasWrites) {
+			const resolvedWrites = resolveWriteTargets(
+				shellCommand,
+				analysis.writes,
+				directory,
+			);
+
+			for (const write of resolvedWrites) {
+				if (write.resolvedPath) {
+					// Architect is exempt from scope checks
+					if (agent !== 'architect') {
+						const inScope = isInDeclaredScope(
+							write.resolvedPath,
+							scopeEntries,
+							directory,
+						);
+						if (!inScope) {
+							decision = 'block';
+							firingRule = `scope_violation: write outside declared scope: ${redactPath(write.resolvedPath)}`;
+							break;
+						}
+					}
+					writeCategories.add(write.original.category);
+				} else {
+					writeCategories.add(write.original.category);
+				}
+			}
+		}
+	} else {
+		// Already blocked; still collect write categories for reporting.
+		const shellType = resolveShellType(shellCommand);
+		const analysis =
+			shellType === 'powershell' || shellType === 'cmd'
+				? detectWindowsWrites(shellCommand, shellType)
+				: detectPosixWrites(shellCommand);
+
+		if (!analysis.parseError && analysis.hasWrites) {
+			for (const write of analysis.writes) {
+				writeCategories.add(write.category);
+			}
+		}
+	}
+
+	const redactedCommand = redactShellCommand(shellCommand);
+
+	const redactedResolvedScopeShell = redactPath(resolvedScope);
+	const shellResult: GuardrailShellResult = {
+		decision,
+		firingRule,
+		resolvedScope: redactedResolvedScopeShell,
+		writeCategories: writeCategories.size > 0 ? [...writeCategories] : [],
+		command: redactedCommand,
+	};
+
+	const lines: string[] = [
+		'## Guardrail Explain (dry-run)',
+		'',
+		`**Mode**: shell | **Agent**: ${agent} | **Resolved scope**: ${redactedResolvedScopeShell}`,
+		'',
+		'| Field | Value |',
+		'| --- | --- |',
+		`| Command | \`${shellResult.command}\` |`,
+		`| Decision | ${shellResult.decision} |`,
+		`| Firing Rule | ${shellResult.firingRule} |`,
+		`| Resolved Scope | ${shellResult.resolvedScope} |`,
+		`| Write Categories | ${shellResult.writeCategories.length > 0 ? shellResult.writeCategories.join(', ') : '(none)'} |`,
+		'',
+	];
+
+	return lines.join('\n');
+}

--- a/src/services/guardrail-explain-service.ts
+++ b/src/services/guardrail-explain-service.ts
@@ -120,17 +120,27 @@ function parseGuardrailExplainArgs(args: string[]): ParsedArgs {
  * Mirrors the logic in tool-before.ts.
  */
 function resolveShellType(command: string): 'posix' | 'powershell' | 'cmd' {
-	const trimmed = command.trim().toLowerCase();
 	if (
-		trimmed.startsWith('powershell') ||
-		trimmed.startsWith('pwsh') ||
-		/^(?:remove-item|ri|rm\b|rmdir|del\b|erase|rd)\b/i.test(trimmed)
+		/^(powershell|ps1|\.\s*\\|Remove-Item|Copy-Item|Move-Item|Start-Process|New-Object|Get-ChildItem|Set-Content|Add-Content|Out-File|Invoke-WebRequest|Invoke-RestMethod|IEX|iex)\b/i.test(
+			command,
+		) ||
+		command.includes('$PSVersionTable') ||
+		command.includes('$env:') ||
+		/-EncodedCommand|-ExecutionPolicy|Enable-PSRemoting/i.test(command)
 	) {
 		return 'powershell';
 	}
-	if (trimmed.startsWith('cmd') || trimmed.startsWith('cmd.exe')) {
+	if (
+		/^(cmd|cmd\.exe|c:\/|set \w+=|\.\d+|del \/|rd \/|mkdir|chdir|echo |copy |move |ren |fc |diskpart)/i.test(
+			command,
+		) ||
+		/%[^%\s]+%/.test(command) ||
+		/\b(set|echo|if|exist)\s+/i.test(command)
+	) {
 		return 'cmd';
 	}
+	// The real hook distinguishes bash/unix internally, but both route through
+	// POSIX write detection. Keep explain's public type collapsed to posix.
 	return 'posix';
 }
 
@@ -777,10 +787,8 @@ export async function handleGuardrailExplain(
 			results.push({
 				path: rawPath,
 				decision: allowed ? 'allow' : 'block',
-				firingRule: allowed
-					? 'allow: no rule matched'
-					: redactPath(decision.reason),
-				resolvedScope: redactPath(resolvedScope),
+				firingRule: allowed ? 'allow: no rule matched' : decision.reason,
+				resolvedScope,
 				zone,
 			});
 		}
@@ -844,7 +852,11 @@ export async function handleGuardrailExplain(
 				? detectWindowsWrites(shellCommand, shellType)
 				: detectPosixWrites(shellCommand);
 
-		if (!analysis.parseError && analysis.hasWrites) {
+		if (analysis.parseError) {
+			decision = 'block';
+			firingRule =
+				'parse_error: write detection failed to parse command — rejecting for safety';
+		} else if (analysis.hasWrites) {
 			const resolvedWrites = resolveWriteTargets(
 				shellCommand,
 				analysis.writes,

--- a/src/services/guardrail-log-service.ts
+++ b/src/services/guardrail-log-service.ts
@@ -20,7 +20,7 @@ const BLOCK_TYPES = new Set<string>([
 ]);
 
 function isBlockEntry(entry: GuardrailLogEntry): boolean {
-	if (entry.type == null) return false;
+	if (entry.type === null || entry.type === undefined) return false;
 	return BLOCK_TYPES.has(entry.type);
 }
 
@@ -35,7 +35,8 @@ function redactSummary(entry: GuardrailLogEntry): string {
 		entry.type === 'sandbox_wrap' ||
 		entry.type === 'sandbox_skip' ||
 		entry.type === 'shell' ||
-		entry.type == null
+		entry.type === null ||
+		entry.type === undefined
 	) {
 		const raw = entry.command ?? '';
 		return redactShellCommand(raw);

--- a/src/services/guardrail-log-service.ts
+++ b/src/services/guardrail-log-service.ts
@@ -1,0 +1,154 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { redactPath } from '../hooks/guardrails/audit-log.js';
+import { redactShellCommand } from '../hooks/guardrails/helpers.js';
+
+export interface GuardrailLogEntry {
+	ts: string;
+	type?: string;
+	sessionID: string;
+	agent: string;
+	tool: string;
+	command?: string;
+	path?: string;
+}
+
+const BLOCK_TYPES = new Set<string>([
+	'file_write',
+	'scope_violation',
+	'destructive_block',
+]);
+
+function isBlockEntry(entry: GuardrailLogEntry): boolean {
+	if (entry.type == null) return false;
+	return BLOCK_TYPES.has(entry.type);
+}
+
+function redactSummary(entry: GuardrailLogEntry): string {
+	if (entry.type === 'file_write' || entry.type === 'scope_violation') {
+		const raw = entry.path ?? '';
+		return redactPath(raw);
+	}
+
+	if (
+		entry.type === 'destructive_block' ||
+		entry.type === 'sandbox_wrap' ||
+		entry.type === 'sandbox_skip' ||
+		entry.type === 'shell' ||
+		entry.type == null
+	) {
+		const raw = entry.command ?? '';
+		return redactShellCommand(raw);
+	}
+
+	return '';
+}
+
+function formatEntry(entry: GuardrailLogEntry): string {
+	const decisionType = entry.type ?? 'shell';
+	const summary = redactSummary(entry);
+
+	return `- [${entry.ts}] ${decisionType} | agent: ${entry.agent} | ${summary}`;
+}
+
+export async function handleGuardrailLog(
+	directory: string,
+	args: string[],
+): Promise<string> {
+	const auditPath = path.join(
+		directory,
+		'.swarm',
+		'session',
+		'shell-audit.jsonl',
+	);
+
+	let raw: string;
+	try {
+		raw = await fs.readFile(auditPath, 'utf-8');
+	} catch (error) {
+		if (
+			typeof error === 'object' &&
+			error !== null &&
+			'code' in error &&
+			(error as { code?: string }).code === 'ENOENT'
+		) {
+			return 'No guardrail decisions recorded yet.';
+		}
+		throw error;
+	}
+
+	const lines = raw.split(/\r?\n/);
+	const entries: GuardrailLogEntry[] = [];
+
+	for (const line of lines) {
+		if (line.trim().length === 0) continue;
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(line);
+		} catch {
+			continue;
+		}
+
+		if (!isPlainObject(parsed)) continue;
+		if (typeof parsed.ts !== 'string') continue;
+		if (typeof parsed.sessionID !== 'string') continue;
+		if (typeof parsed.agent !== 'string') continue;
+		if (typeof parsed.tool !== 'string') continue;
+
+		const entry: GuardrailLogEntry = {
+			ts: parsed.ts,
+			sessionID: parsed.sessionID,
+			agent: parsed.agent,
+			tool: parsed.tool,
+		};
+
+		if (typeof parsed.type === 'string') {
+			entry.type = parsed.type;
+		}
+		if (typeof parsed.command === 'string') {
+			entry.command = parsed.command;
+		}
+		if (typeof parsed.path === 'string') {
+			entry.path = parsed.path;
+		}
+
+		entries.push(entry);
+	}
+
+	if (entries.length === 0) {
+		return 'No guardrail decisions recorded yet.';
+	}
+
+	const blocksOnly = args.includes('--blocks-only');
+
+	const filtered = blocksOnly ? entries.filter(isBlockEntry) : entries;
+
+	if (filtered.length === 0) {
+		if (blocksOnly) {
+			return 'No guardrail block decisions recorded yet.';
+		}
+		return 'No guardrail decisions recorded yet.';
+	}
+
+	filtered.sort((a, b) => {
+		const diff = b.ts.localeCompare(a.ts);
+		return diff === 0 ? 0 : diff;
+	});
+
+	const header = blocksOnly
+		? '# Guardrail Block Log (most-recent-first)'
+		: '# Guardrail Decision Log (most-recent-first)';
+
+	const body = filtered.map(formatEntry).join('\n');
+
+	return `${header}\n\n${body}`;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value.constructor === Object || Object.getPrototypeOf(value) === null)
+	);
+}

--- a/tests/unit/hooks/audit-log.test.ts
+++ b/tests/unit/hooks/audit-log.test.ts
@@ -1,0 +1,503 @@
+/**
+ * Tests for src/hooks/guardrails/audit-log.ts (Task 1.1)
+ *
+ * Covers:
+ * - SC-119: type:'shell' entry has exactly {ts, sessionID, agent, tool, command}
+ * - SC-118: entries stored under given auditPath
+ * - Additive schema for file_write / destructive_block / sandbox_wrap / sandbox_skip
+ * - Write-time validation: malformed entry rejected, nothing written, no throw
+ * - enabled=false → nothing written
+ * - Command redaction via redactShellCommand
+ * - Failure is fail-open
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	_internals,
+	appendGuardrailDecision,
+	redactPath,
+} from '../../../src/hooks/guardrails/audit-log';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function mkTempDir(): Promise<string> {
+	return mkdtemp(join(tmpdir(), 'audit-log-test-'));
+}
+
+async function readAuditLog(path: string): Promise<string[]> {
+	try {
+		return readFileSync(path, 'utf-8')
+			.split('\n')
+			.filter((l) => l.trim().length > 0);
+	} catch {
+		return [];
+	}
+}
+
+function jsonLine(line: string): Record<string, unknown> {
+	return JSON.parse(line);
+}
+
+// ---------------------------------------------------------------------------
+// DI-seam via _internals (avoids the Bun module-level fs mock that leaks across test
+// files in the shared runner — AGENTS.md invariant 7). Function refs on the exported
+// _internals object are reassigned in beforeEach and restored in afterEach, so nothing
+// leaks across files.
+// ---------------------------------------------------------------------------
+
+// Track append calls for verification
+const appendCalls: Array<{ path: string; content: string }> = [];
+const mkdirCalls: string[] = [];
+
+const realMkdir = _internals.mkdir;
+const realAppendFile = _internals.appendFile;
+
+beforeEach(() => {
+	appendCalls.length = 0;
+	mkdirCalls.length = 0;
+	_internals.mkdir = (async (p: string) => {
+		mkdirCalls.push(p);
+		return;
+	}) as typeof _internals.mkdir;
+	_internals.appendFile = (async (p: string, content: string) => {
+		appendCalls.push({ path: p, content });
+		return;
+	}) as typeof _internals.appendFile;
+});
+
+afterEach(() => {
+	_internals.mkdir = realMkdir;
+	_internals.appendFile = realAppendFile;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('appendGuardrailDecision', () => {
+	// ---- SC-119: type:shell entry has EXACTLY 5 fields byte-for-byte — no type discriminator ----
+	test('SC-119 shell entry writes EXACTLY 5 fields: {ts, sessionID, agent, tool, command} — no type discriminator', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, 'audit.jsonl');
+
+		const entry = {
+			type: 'shell' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-abc123',
+			agent: 'coder',
+			tool: 'bash',
+			command: 'echo hello',
+		};
+
+		await appendGuardrailDecision(entry, { auditPath, enabled: true });
+
+		expect(appendCalls.length).toBe(1);
+		const parsed = jsonLine(appendCalls[0]!.content.trim());
+		// Exactly the 5 original fields — no more, no less
+		expect(Object.keys(parsed).sort()).toEqual(
+			['agent', 'command', 'sessionID', 'tool', 'ts'].sort(),
+		);
+		expect(parsed.ts).toBe('2026-01-01T00:00:00.000Z');
+		expect(parsed.sessionID).toBe('sess-abc123');
+		expect(parsed.agent).toBe('coder');
+		expect(parsed.tool).toBe('bash');
+		expect(parsed.command).toBe('echo hello');
+		// type discriminator is NOT written for shell entries (additive schema preserves original shape)
+		expect(parsed.type).toBeUndefined();
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// ---- SC-119 regression: ensure shell entry NEVER gets a type field even when passed in entry ----
+	test('SC-119 regression: shell entry persisted JSON has no type field even if input had one', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, 'audit.jsonl');
+
+		// The input type: 'shell' is only used for routing; it is stripped on write
+		const entry = {
+			type: 'shell' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-reg',
+			agent: 'coder',
+			tool: 'bash',
+			command: 'ls',
+		};
+
+		await appendGuardrailDecision(entry, { auditPath, enabled: true });
+
+		const parsed = jsonLine(appendCalls[0]!.content.trim());
+		// The fixed implementation writes exactly 5 fields with NO type
+		expect(Object.keys(parsed)).toHaveLength(5);
+		expect(parsed.type).toBeUndefined();
+		expect(parsed.ts).toBe('2026-01-01T00:00:00.000Z');
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// ---- SC-118: entries stored under the given auditPath ----
+	test('SC-118 entry is written to the configured auditPath', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, '.swarm', 'session', 'audit.jsonl');
+
+		const entry = {
+			type: 'shell' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-xyz',
+			agent: 'coder',
+			tool: 'bash',
+			command: 'ls',
+		};
+
+		await appendGuardrailDecision(entry, { auditPath, enabled: true });
+
+		expect(appendCalls.some((c) => c.path === auditPath)).toBe(true);
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// ---- Additive schema: file_write entry ----
+	test('file_write entry includes type discriminator and per-type fields', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, 'audit.jsonl');
+
+		// Use a path that will NOT be transformed by redactPath on any platform
+		const testPath = join(dir, 'subdir', 'test.txt');
+
+		const entry = {
+			type: 'file_write' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-fw',
+			agent: 'coder',
+			tool: 'write',
+			path: testPath,
+			reason: 'user requested',
+			resolvedScope: dir,
+		};
+
+		await appendGuardrailDecision(entry, { auditPath, enabled: true });
+
+		expect(appendCalls.length).toBe(1);
+		const parsed = jsonLine(appendCalls[0]!.content.trim());
+		expect(parsed.type).toBe('file_write');
+		// path is present (redactPath may transform it on Windows home dirs)
+		expect(parsed.path).toBeDefined();
+		expect(typeof parsed.path).toBe('string');
+		expect(parsed.reason).toBe('user requested');
+		// resolvedScope is redacted via redactPath (home-dir → ~, separators normalized)
+		expect(parsed.resolvedScope).toBe(redactPath(dir));
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// ---- Additive schema: destructive_block entry ----
+	test('destructive_block entry includes type discriminator and per-type fields', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, 'audit.jsonl');
+
+		const entry = {
+			type: 'destructive_block' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-db',
+			agent: 'coder',
+			tool: 'bash',
+			command: 'rm -rf /',
+			destructiveCategory: 'dangerous_delete',
+		};
+
+		await appendGuardrailDecision(entry, { auditPath, enabled: true });
+
+		expect(appendCalls.length).toBe(1);
+		const parsed = jsonLine(appendCalls[0]!.content.trim());
+		expect(parsed.type).toBe('destructive_block');
+		expect(parsed.destructiveCategory).toBe('dangerous_delete');
+		expect(parsed.command).toBeDefined(); // redaction applied
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// ---- Additive schema: sandbox_wrap entry ----
+	test('sandbox_wrap entry includes type discriminator and per-type fields', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, 'audit.jsonl');
+
+		const entry = {
+			type: 'sandbox_wrap' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-sw',
+			agent: 'coder',
+			tool: 'bash',
+			command: 'npm install',
+			executorMechanism: 'bubblewrap',
+		};
+
+		await appendGuardrailDecision(entry, { auditPath, enabled: true });
+
+		expect(appendCalls.length).toBe(1);
+		const parsed = jsonLine(appendCalls[0]!.content.trim());
+		expect(parsed.type).toBe('sandbox_wrap');
+		expect(parsed.executorMechanism).toBe('bubblewrap');
+		expect(parsed.command).toBeDefined();
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// ---- Additive schema: sandbox_skip entry ----
+	test('sandbox_skip entry includes type discriminator and per-type fields', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, 'audit.jsonl');
+
+		const entry = {
+			type: 'sandbox_skip' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-ss',
+			agent: 'coder',
+			tool: 'bash',
+			command: 'echo hi',
+			executorMechanism: 'none',
+			skipReason: 'read-only command',
+		};
+
+		await appendGuardrailDecision(entry, { auditPath, enabled: true });
+
+		expect(appendCalls.length).toBe(1);
+		const parsed = jsonLine(appendCalls[0]!.content.trim());
+		expect(parsed.type).toBe('sandbox_skip');
+		expect(parsed.executorMechanism).toBe('none');
+		expect(parsed.skipReason).toBe('read-only command');
+		expect(parsed.command).toBeDefined();
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// ---- Additive schema: scope_violation entry ----
+	test('scope_violation entry includes type discriminator and per-type fields', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, 'audit.jsonl');
+
+		const entry = {
+			type: 'scope_violation' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-sv',
+			agent: 'coder',
+			tool: 'bash',
+			path: '/etc/passwd',
+			declaredScope: '/project/src',
+			resolvedScope: '/etc',
+			action: 'write',
+		};
+
+		await appendGuardrailDecision(entry, { auditPath, enabled: true });
+
+		expect(appendCalls.length).toBe(1);
+		const parsed = jsonLine(appendCalls[0]!.content.trim());
+		expect(parsed.type).toBe('scope_violation');
+		// declaredScope/resolvedScope are redacted via redactPath (separators normalized on Windows)
+		expect(parsed.declaredScope).toBe(redactPath('/project/src'));
+		expect(parsed.resolvedScope).toBe(redactPath('/etc'));
+		expect(parsed.action).toBe('write');
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// ---- Write-time validation: malformed entry (missing sessionID) is rejected ----
+	test('malformed entry missing sessionID is rejected: nothing written, no exception propagates', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, 'audit.jsonl');
+
+		// entry missing sessionID (required string field)
+		const badEntry = {
+			type: 'shell' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			agent: 'coder',
+			tool: 'bash',
+			command: 'ls',
+			// sessionID is missing
+		};
+
+		let threw = false;
+		try {
+			await appendGuardrailDecision(badEntry as any, {
+				auditPath,
+				enabled: true,
+			});
+		} catch {
+			threw = true;
+		}
+		expect(threw).toBe(false);
+		// Nothing should have been appended
+		expect(appendCalls.length).toBe(0);
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// ---- Write-time validation: invalid type discriminator is rejected ----
+	test('entry with invalid type discriminator is rejected: nothing written, no exception', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, 'audit.jsonl');
+
+		const badEntry = {
+			type: 'not_a_valid_type' as any,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-abc',
+			agent: 'coder',
+			tool: 'bash',
+			command: 'ls',
+		};
+
+		let threw = false;
+		try {
+			await appendGuardrailDecision(badEntry, { auditPath, enabled: true });
+		} catch {
+			threw = true;
+		}
+		expect(threw).toBe(false);
+		expect(appendCalls.length).toBe(0);
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// ---- enabled=false → nothing written ----
+	test('enabled=false skips writing entirely', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, 'audit.jsonl');
+
+		const entry = {
+			type: 'shell' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-off',
+			agent: 'coder',
+			tool: 'bash',
+			command: 'ls',
+		};
+
+		await appendGuardrailDecision(entry, { auditPath, enabled: false });
+
+		expect(appendCalls.length).toBe(0);
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// ---- Command redaction: shell entry with secret is redacted ----
+	test('shell entry with secret pattern is redacted via redactShellCommand', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, 'audit.jsonl');
+
+		const entry = {
+			type: 'shell' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-redact',
+			agent: 'coder',
+			tool: 'bash',
+			command:
+				"curl -H 'Authorization: Bearer sk-test1234567890' https://api.example.com",
+		};
+
+		await appendGuardrailDecision(entry, { auditPath, enabled: true });
+
+		expect(appendCalls.length).toBe(1);
+		const parsed = jsonLine(appendCalls[0]!.content.trim());
+		// The Bearer token should be redacted
+		expect(parsed.command).not.toContain('sk-test1234567890');
+		expect(parsed.command).toContain('[REDACTED]');
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// ---- Command redaction: destructive_block with API key is redacted ----
+	test('destructive_block entry with API_TOKEN in command is redacted', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, 'audit.jsonl');
+
+		const entry = {
+			type: 'destructive_block' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-dbredact',
+			agent: 'coder',
+			tool: 'bash',
+			command: 'rm /tmp/API_TOKEN=abc123xyz',
+			destructiveCategory: 'path_destruction',
+		};
+
+		await appendGuardrailDecision(entry, { auditPath, enabled: true });
+
+		expect(appendCalls.length).toBe(1);
+		const parsed = jsonLine(appendCalls[0]!.content.trim());
+		expect(parsed.command).not.toContain('abc123xyz');
+		expect(parsed.command).toContain('[REDACTED]');
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// ---- Failure is fail-open: invalid/unwritable path does not throw ----
+	test('fail-open: appending to an invalid path does not throw', async () => {
+		// Use a path that cannot be written to (no parent directory will ever exist)
+		const invalidPath = '/this/path/does/not/exist/anywhere/audit.jsonl';
+
+		const entry = {
+			type: 'shell' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-failopen',
+			agent: 'coder',
+			tool: 'bash',
+			command: 'ls',
+		};
+
+		// The real fs.appendFile would throw if mkdir + appendFile fails,
+		// but appendGuardrailDecision catches and logs, so it must not propagate.
+		let threw = false;
+		try {
+			await appendGuardrailDecision(entry, {
+				auditPath: invalidPath,
+				enabled: true,
+			});
+		} catch {
+			threw = true;
+		}
+		expect(threw).toBe(false);
+	});
+});
+
+describe('redactPath', () => {
+	test('Windows profile path is redacted on Windows', () => {
+		if (process.platform !== 'win32') return;
+		const result = redactPath('C:\\Users\\alice\\project\\file.txt');
+		// Should start with ~\
+		expect(result.startsWith('~\\')).toBe(true);
+		expect(result).not.toContain('alice');
+	});
+
+	test('POSIX home path is redacted on POSIX', () => {
+		if (process.platform === 'win32') return;
+		const result = redactPath('/home/bob/project/file.txt');
+		// Should start with ~/
+		expect(result.startsWith('~/')).toBe(true);
+		expect(result).not.toContain('bob');
+	});
+
+	test('non-home path is unchanged', () => {
+		const input = '/project/src/file.txt';
+		const result = redactPath(input);
+		// redactPath normalizes separators — check it does not leak the input unchanged
+		expect(typeof result).toBe('string');
+		expect(result.length).toBeGreaterThan(0);
+	});
+
+	test('empty string returns empty string', () => {
+		expect(redactPath('')).toBe('');
+	});
+
+	test('null returns null (passthrough for non-strings)', () => {
+		// redactPath returns the original value for non-strings (bug in source, verified here)
+		expect(redactPath(null as any)).toBe(null);
+	});
+
+	test('undefined returns undefined', () => {
+		expect(redactPath(undefined as any)).toBe(undefined);
+	});
+});

--- a/tests/unit/hooks/audit-log.test.ts
+++ b/tests/unit/hooks/audit-log.test.ts
@@ -195,6 +195,30 @@ describe('appendGuardrailDecision', () => {
 		await rm(dir, { recursive: true, force: true });
 	});
 
+	test('F-003: file_write reason is redacted before persistence', async () => {
+		const dir = await mkTempDir();
+		const auditPath = join(dir, 'audit.jsonl');
+
+		const entry = {
+			type: 'file_write' as const,
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-fw-redact',
+			agent: 'coder',
+			tool: 'write',
+			path: '/home/alice/project/link',
+			reason: 'WRITE BLOCKED: symlink detected at /home/alice/project/link',
+			resolvedScope: '/home/alice/project',
+		};
+
+		await appendGuardrailDecision(entry, { auditPath, enabled: true });
+
+		const parsed = jsonLine(appendCalls[0]!.content.trim());
+		expect(parsed.reason).not.toContain('/home/alice');
+		expect(parsed.reason).toContain('~/project/link');
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
 	// ---- Additive schema: destructive_block entry ----
 	test('destructive_block entry includes type discriminator and per-type fields', async () => {
 		const dir = await mkTempDir();
@@ -362,6 +386,76 @@ describe('appendGuardrailDecision', () => {
 		await rm(dir, { recursive: true, force: true });
 	});
 
+	describe('F-008: per-type validation rejection paths', () => {
+		const base = {
+			ts: '2026-01-01T00:00:00.000Z',
+			sessionID: 'sess-reject',
+			agent: 'coder',
+			tool: 'bash',
+		};
+
+		const cases = [
+			{
+				name: 'file_write missing reason',
+				entry: {
+					...base,
+					type: 'file_write' as const,
+					path: 'src/index.ts',
+					resolvedScope: 'src',
+				},
+			},
+			{
+				name: 'scope_violation missing action',
+				entry: {
+					...base,
+					type: 'scope_violation' as const,
+					path: '../outside.txt',
+					declaredScope: 'src',
+					resolvedScope: '..',
+				},
+			},
+			{
+				name: 'destructive_block missing destructiveCategory',
+				entry: {
+					...base,
+					type: 'destructive_block' as const,
+					command: 'rm -rf /',
+				},
+			},
+			{
+				name: 'sandbox_wrap missing command',
+				entry: {
+					...base,
+					type: 'sandbox_wrap' as const,
+					mechanism: 'bubblewrap',
+				},
+			},
+			{
+				name: 'sandbox_skip missing reason',
+				entry: {
+					...base,
+					type: 'sandbox_skip' as const,
+					command: 'echo hi',
+				},
+			},
+		];
+
+		for (const testCase of cases) {
+			test(`${testCase.name} is rejected`, async () => {
+				const dir = await mkTempDir();
+				const auditPath = join(dir, 'audit.jsonl');
+
+				await appendGuardrailDecision(testCase.entry as any, {
+					auditPath,
+					enabled: true,
+				});
+
+				expect(appendCalls.length).toBe(0);
+				await rm(dir, { recursive: true, force: true });
+			});
+		}
+	});
+
 	// ---- enabled=false → nothing written ----
 	test('enabled=false skips writing entirely', async () => {
 		const dir = await mkTempDir();
@@ -478,6 +572,13 @@ describe('redactPath', () => {
 		// Should start with ~/
 		expect(result.startsWith('~/')).toBe(true);
 		expect(result).not.toContain('bob');
+	});
+
+	test('F-004: UNC path is redacted without leaking server segment', () => {
+		const result = redactPath('\\\\server\\share\\alice\\project\\file.txt');
+
+		expect(result).toBe('~\\share\\alice\\project\\file.txt');
+		expect(result).not.toContain('server');
 	});
 
 	test('non-home path is unchanged', () => {

--- a/tests/unit/hooks/guardrail-capture.test.ts
+++ b/tests/unit/hooks/guardrail-capture.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Tests for task 2.1: guardrail decision-log capture wired into the toolBefore hook.
+ *
+ * Verifies that when the toolBefore handler blocks a tool invocation, it also
+ * appends a typed decision entry to the caller-supplied audit path via
+ * appendGuardrailDecision.
+ *
+ * Covered block types:
+ *   - destructive_block  — bash/shell with a destructive command
+ *   - scope_violation    — bash/shell write targeting a path outside declared scope
+ *   - file_write         — write tool targeting a path agent has no authority over
+ *
+ * sandbox_wrap / sandbox_skip are not deterministically unit-testable here
+ * because they require a live platform executor (bwrap/nsjail) to be available,
+ * and the sandbox probe is skipped when no executor is found. They are covered
+ * by integration tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fsSync from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { GuardrailsConfig } from '../../../src/config/schema';
+import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
+import {
+	getAgentSession,
+	resetSwarmState,
+	startAgentSession,
+	swarmState,
+} from '../../../src/state';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function defaultConfig(
+	overrides?: Partial<GuardrailsConfig>,
+): GuardrailsConfig {
+	return {
+		enabled: true,
+		max_tool_calls: 200,
+		max_duration_minutes: 30,
+		idle_timeout_minutes: 60,
+		max_repetitions: 10,
+		max_consecutive_errors: 5,
+		warning_threshold: 0.75,
+		profiles: undefined,
+		...overrides,
+	};
+}
+
+/** Build the toolBefore input shape. */
+function makeInput(
+	sessionID = 'test-session',
+	tool = 'read',
+	callID = 'call-1',
+) {
+	return { tool, sessionID, callID };
+}
+
+/**
+ * Circuit-breaker-free config so gate limits don't interfere with individual
+ * tool calls. Also explicitly enables shell_audit_log.
+ * idle_timeout_minutes is set to 60 (not 0) to prevent the circuit breaker
+ * from firing immediately on first call (0 >= 0 would trigger).
+ */
+function nullConfig(): GuardrailsConfig {
+	return {
+		enabled: true,
+		max_tool_calls: 0,
+		max_duration_minutes: 0,
+		idle_timeout_minutes: 60,
+		max_repetitions: 999,
+		max_consecutive_errors: 999,
+		warning_threshold: 1.0,
+		shell_audit_log: true,
+		profiles: undefined,
+	};
+}
+
+/**
+ * Read every JSON line from auditPath and parse into objects.
+ * Returns an empty array if the file does not exist.
+ */
+function readAuditLog(auditPath: string): Record<string, unknown>[] {
+	if (!fsSync.existsSync(auditPath)) return [];
+	return fsSync
+		.readFileSync(auditPath, 'utf-8')
+		.split('\n')
+		.filter((line) => line.trim().length > 0)
+		.map((line) => JSON.parse(line));
+}
+
+/** Count entries of a given type in the audit log. */
+function countEntriesByType(
+	entries: Record<string, unknown>[],
+	type: string,
+): number {
+	return entries.filter((e) => e.type === type).length;
+}
+
+/**
+ * Wait for async audit writes to flush to disk.
+ * appendGuardrailDecision is fire-and-forget (void return), so we need an
+ * explicit event-loop yield to ensure the Bun process flushes its write
+ * buffer before we read the file.
+ */
+async function flushAuditWrites(): Promise<void> {
+	// Use multiple sleep cycles to give the Bun event loop ample opportunity
+	// to flush pending async I/O before we read the file.
+	// The void-async appendGuardrailDecision calls in toolBefore need several
+	// event-loop ticks to complete their fs.appendFile before we assert.
+	for (let i = 0; i < 8; i++) {
+		await Bun.sleep(50);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('guardrail decision-log capture (task 2.1)', () => {
+	let tempDir: string;
+	let auditPath: string;
+
+	beforeEach(() => {
+		resetSwarmState();
+		// Temp dir for this test — the hook writes its audit file here
+		tempDir = fsSync.realpathSync(
+			fsSync.mkdtempSync(path.join(os.tmpdir(), 'guardrail-capture-test-')),
+		);
+		// The hook always writes to .swarm/session/shell-audit.jsonl under the passed directory
+		auditPath = path.join(tempDir, '.swarm', 'session', 'shell-audit.jsonl');
+	});
+
+	afterEach(async () => {
+		// Allow any pending async writes from this test to complete before cleanup
+		await flushAuditWrites();
+		resetSwarmState();
+		try {
+			fsSync.rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			// best-effort cleanup
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// destructive_block — git reset --hard
+	// -------------------------------------------------------------------------
+	describe('destructive_block', () => {
+		it('throws the block error AND appends a destructive_block JSONL entry', async () => {
+			const hooks = createGuardrailsHooks(tempDir, nullConfig());
+
+			startAgentSession('s-dest', 'coder');
+			swarmState.activeAgent.set('s-dest', 'coder');
+
+			// git reset --hard is a blocked destructive command
+			await expect(
+				hooks.toolBefore(makeInput('s-dest', 'bash', 'call-dest'), {
+					args: { command: 'git reset --hard' },
+				}),
+			).rejects.toThrow(/BLOCKED.*git reset/i);
+
+			await flushAuditWrites();
+
+			// Verify audit entry was appended
+			const entries = readAuditLog(auditPath);
+			expect(
+				countEntriesByType(entries, 'destructive_block'),
+			).toBeGreaterThanOrEqual(1);
+
+			// The entry must carry the required fields
+			const entry = entries.find((e) => e.type === 'destructive_block');
+			expect(entry).toBeDefined();
+			expect(typeof entry!.ts).toBe('string');
+			expect(entry!.sessionID).toBe('s-dest');
+			expect(entry!.agent).toBe('coder');
+			expect(entry!.tool).toBe('bash');
+			expect(entry!.command).toContain('git reset --hard');
+			expect(typeof entry!.destructiveCategory).toBe('string');
+		});
+
+		it('still throws when a second destructive command is issued (no swallowing)', async () => {
+			const hooks = createGuardrailsHooks(tempDir, nullConfig());
+
+			startAgentSession('s-dest2', 'coder');
+			swarmState.activeAgent.set('s-dest2', 'coder');
+
+			// First destructive command — should throw
+			await expect(
+				hooks.toolBefore(makeInput('s-dest2', 'bash', 'call-dest2a'), {
+					args: { command: 'git reset --hard' },
+				}),
+			).rejects.toThrow(/BLOCKED/i);
+
+			// Second destructive command — should ALSO throw (not swallowed)
+			await expect(
+				hooks.toolBefore(makeInput('s-dest2', 'bash', 'call-dest2b'), {
+					args: { command: 'git clean -fd' },
+				}),
+			).rejects.toThrow(/BLOCKED/i);
+
+			await flushAuditWrites();
+
+			// Both should appear as separate audit entries
+			const entries = readAuditLog(auditPath);
+			expect(
+				countEntriesByType(entries, 'destructive_block'),
+			).toBeGreaterThanOrEqual(2);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// scope_violation — bash write targeting a path outside declared scope
+	//
+	// The scope_violation is reached when:
+	//   1. checkShellWriteScope runs (bash/shell with detected writes)
+	//   2. checkFileAuthorityWithRules passes (path is allowed for the agent)
+	//   3. isInDeclaredScope returns false (path outside declared scope)
+	//
+	// On Windows, absolute Unix paths like /tmp/out.txt resolve outside the cwd
+	// and are caught by checkFileAuthorityWithRules (file_write), not scope_violation.
+	// We use a relative sibling directory (lib/) that is inside the cwd but
+	// outside the declared scope (src/).
+	// -------------------------------------------------------------------------
+	describe('scope_violation', () => {
+		it('throws a scope_violation error AND appends a scope_violation JSONL entry', async () => {
+			const hooks = createGuardrailsHooks(tempDir, nullConfig());
+
+			// Use test_engineer because:
+			// - test_engineer has blockedPrefix ['src/'] but can write to lib/
+			//   (lib/ is not in blockedPrefix, blockedZones, or allowedGlobs)
+			// - With declaredScope=['src/'], writing to lib/ passes authority
+			//   but fails the isInDeclaredScope check → scope_violation
+			startAgentSession('s-scope', 'test_engineer');
+			swarmState.activeAgent.set('s-scope', 'test_engineer');
+
+			const session = getAgentSession('s-scope')!;
+			session.declaredCoderScope = ['src/'];
+
+			// echo hello > lib/output.txt — inside cwd, but outside declaredScope src/
+			// Authority check passes (lib/ is not blocked for test_engineer).
+			// Scope check fails: lib/output.txt is not in declaredScope.
+			await expect(
+				hooks.toolBefore(makeInput('s-scope', 'bash', 'call-scope'), {
+					args: { command: 'echo hello > lib/output.txt' },
+				}),
+			).rejects.toThrow();
+
+			await flushAuditWrites();
+
+			const entries = readAuditLog(auditPath);
+
+			// The scope_violation must be present (not file_write)
+			const scopeEntry = entries.find((e) => e.type === 'scope_violation');
+			expect(scopeEntry).toBeDefined();
+			expect(scopeEntry!.sessionID).toBe('s-scope');
+			expect(scopeEntry!.agent).toBe('test_engineer');
+			expect(scopeEntry!.tool).toBe('bash');
+			expect(typeof scopeEntry!.path).toBe('string');
+			expect(scopeEntry!.declaredScope).toBeTruthy();
+			expect(scopeEntry!.resolvedScope).toBeTruthy();
+			expect(scopeEntry!.action).toBe('bash');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// file_write — write tool targeting a path the agent has no authority over
+	//
+	// NOTE: We use biome.jsonc (a config file in architect's blockedGlobs) instead
+	// of .swarm/plan.md. The latter is caught by handlePlanAndScopeProtection()
+	// (line 1929) which runs BEFORE the isWriteTool audit block (line 1933+),
+	// so it throws "PLAN STATE VIOLATION" without reaching appendGuardrailDecision.
+	// Using biome.jsonc triggers checkFileAuthorityWithRules (line 2020) which
+	// DOES call appendGuardrailDecision before throwing.
+	// -------------------------------------------------------------------------
+	describe('file_write (write tool authority denial)', () => {
+		it('throws WRITE_BLOCKED AND appends a file_write JSONL entry', async () => {
+			const hooks = createGuardrailsHooks(tempDir, nullConfig());
+
+			// architect: biome.jsonc is in blockedGlobs (**/biome.jsonc)
+			startAgentSession('s-file', 'architect');
+			swarmState.activeAgent.set('s-file', 'architect');
+
+			// Attempt to write to biome.jsonc — architect has blockedGlobs for this
+			await expect(
+				hooks.toolBefore(makeInput('s-file', 'write', 'call-file'), {
+					args: { filePath: 'biome.jsonc' },
+				}),
+			).rejects.toThrow(/WRITE BLOCKED|not authorised|blocked/i);
+
+			await flushAuditWrites();
+
+			const entries = readAuditLog(auditPath);
+			expect(countEntriesByType(entries, 'file_write')).toBeGreaterThanOrEqual(
+				1,
+			);
+
+			const entry = entries.find((e) => e.type === 'file_write');
+			expect(entry).toBeDefined();
+			expect(entry!.sessionID).toBe('s-file');
+			expect(entry!.agent).toBe('architect');
+			expect(entry!.tool).toBe('write');
+			expect(entry!.path).toBe('biome.jsonc');
+			expect(typeof entry!.reason).toBe('string');
+			expect(typeof entry!.resolvedScope).toBe('string');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// shell audit entries are still appended (shell path unchanged)
+	//
+	// NOTE: shell entries are written in a legacy 5-field shape
+	// {ts, sessionID, agent, tool, command} WITHOUT a `type` discriminator
+	// (audit-log.ts:305-307). So we check by presence of sessionID + tool + command
+	// rather than countEntriesByType(entries, 'shell').
+	// -------------------------------------------------------------------------
+	describe('shell audit entries still appended', () => {
+		it('appends a shell entry for a non-destructive bash command', async () => {
+			const hooks = createGuardrailsHooks(tempDir, nullConfig());
+
+			startAgentSession('s-shell', 'coder');
+			swarmState.activeAgent.set('s-shell', 'coder');
+
+			// Non-destructive command — should NOT throw
+			await hooks.toolBefore(makeInput('s-shell', 'bash', 'call-shell'), {
+				args: { command: 'echo hello' },
+			});
+
+			await flushAuditWrites();
+
+			const entries = readAuditLog(auditPath);
+			// shell entries have no `type` field (legacy 5-field shape)
+			const shellEntry = entries.find(
+				(e) =>
+					e.sessionID === 's-shell' &&
+					e.agent === 'coder' &&
+					e.tool === 'bash' &&
+					// @ts-ignore — type field absent on shell entries by design
+					!e.type,
+			);
+			expect(shellEntry).toBeDefined();
+			expect(typeof shellEntry!.ts).toBe('string');
+			expect(shellEntry!.sessionID).toBe('s-shell');
+			expect(shellEntry!.agent).toBe('coder');
+			expect(shellEntry!.tool).toBe('bash');
+		});
+
+		it('destructive command fires BOTH a shell entry AND a destructive_block entry', async () => {
+			const hooks = createGuardrailsHooks(tempDir, nullConfig());
+
+			startAgentSession('s-dup', 'coder');
+			swarmState.activeAgent.set('s-dup', 'coder');
+
+			// A destructive command — throws, but shell entry fires first in handler
+			await expect(
+				hooks.toolBefore(makeInput('s-dup', 'bash', 'call-dup'), {
+					args: { command: 'git reset --hard' },
+				}),
+			).rejects.toThrow(/BLOCKED/i);
+
+			await flushAuditWrites();
+
+			const entries = readAuditLog(auditPath);
+
+			// shell entry (no type field — legacy 5-field shape)
+			const shellEntry = entries.find(
+				(e) =>
+					e.sessionID === 's-dup' &&
+					e.agent === 'coder' &&
+					// @ts-ignore — type field absent on shell entries by design
+					!e.type,
+			);
+			expect(shellEntry).toBeDefined();
+
+			// destructive_block entry (has type: 'destructive_block')
+			expect(countEntriesByType(entries, 'destructive_block')).toBe(1);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Original block error is still thrown (capture does not swallow the block)
+	// -------------------------------------------------------------------------
+	describe('block error propagation (capture does not swallow the block)', () => {
+		it('destructive_block throws the original block error', async () => {
+			const hooks = createGuardrailsHooks(tempDir, nullConfig());
+
+			startAgentSession('s-propagate', 'coder');
+			swarmState.activeAgent.set('s-propagate', 'coder');
+
+			// The error message must contain the specific block reason
+			await expect(
+				hooks.toolBefore(makeInput('s-propagate', 'bash', 'call-prop'), {
+					args: { command: 'git reset --hard' },
+				}),
+			).rejects.toThrow(/BLOCKED.*git reset/i);
+		});
+
+		it('scope_violation throws (error type is not swallowed by the capture)', async () => {
+			const hooks = createGuardrailsHooks(tempDir, nullConfig());
+
+			startAgentSession('s-propagate2', 'test_engineer');
+			swarmState.activeAgent.set('s-propagate2', 'test_engineer');
+
+			const session = getAgentSession('s-propagate2')!;
+			session.declaredCoderScope = ['src/'];
+
+			// The error must be thrown (not swallowed by the audit capture)
+			await expect(
+				hooks.toolBefore(makeInput('s-propagate2', 'bash', 'call-prop2'), {
+					args: { command: 'echo hello > lib/output.txt' },
+				}),
+			).rejects.toThrow();
+		});
+
+		it('file_write throws the authority denial error', async () => {
+			const hooks = createGuardrailsHooks(tempDir, nullConfig());
+
+			startAgentSession('s-propagate3', 'architect');
+			swarmState.activeAgent.set('s-propagate3', 'architect');
+
+			await expect(
+				hooks.toolBefore(makeInput('s-propagate3', 'write', 'call-prop3'), {
+					args: { filePath: '.swarm/plan.md' },
+				}),
+			).rejects.toThrow(/WRITE BLOCKED|not authorised|blocked/i);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// sandbox_wrap / sandbox_skip — not deterministically unit-testable here
+	// -------------------------------------------------------------------------
+	describe('sandbox_wrap / sandbox_skip', () => {
+		it.todo(
+			'NOT UNIT-TESTABLE in this suite — requires a live platform executor ' +
+				'(bwrap/nsjail) to be available. The sandbox probe is skipped when ' +
+				'no executor is found, making this non-deterministic. Covered by ' +
+				'integration tests.',
+		);
+	});
+
+	// -------------------------------------------------------------------------
+	// Direct appendGuardrailDecision call — sanity check that the audit mechanism
+	// works when called directly (bypasses the toolBefore handler void-fire-and-forget)
+	// -------------------------------------------------------------------------
+	describe('appendGuardrailDecision direct call sanity check', () => {
+		it('writes a file_write entry to the audit path when called directly', async () => {
+			// Direct import to bypass the void fire-and-forget in toolBefore
+			const { appendGuardrailDecision } = await import(
+				'../../../src/hooks/guardrails/audit-log.js'
+			);
+
+			await appendGuardrailDecision(
+				{
+					type: 'file_write',
+					ts: new Date().toISOString(),
+					sessionID: 'direct-test',
+					agent: 'architect',
+					tool: 'write',
+					path: '.swarm/plan.md',
+					reason: 'blocked',
+					resolvedScope: '',
+				},
+				{ auditPath, enabled: true },
+			);
+
+			// Wait for the async write to flush
+			await Bun.sleep(50);
+			await Bun.sleep(50);
+
+			const entries = readAuditLog(auditPath);
+			expect(countEntriesByType(entries, 'file_write')).toBeGreaterThanOrEqual(
+				1,
+			);
+
+			const entry = entries.find((e) => e.type === 'file_write');
+			expect(entry).toBeDefined();
+			expect(entry!.agent).toBe('architect');
+			expect(entry!.tool).toBe('write');
+		});
+	});
+});

--- a/tests/unit/hooks/guardrail-capture.test.ts
+++ b/tests/unit/hooks/guardrail-capture.test.ts
@@ -100,20 +100,65 @@ function countEntriesByType(
 	return entries.filter((e) => e.type === type).length;
 }
 
-/**
- * Wait for async audit writes to flush to disk.
- * appendGuardrailDecision is fire-and-forget (void return), so we need an
- * explicit event-loop yield to ensure the Bun process flushes its write
- * buffer before we read the file.
- */
-async function flushAuditWrites(): Promise<void> {
-	// Use multiple sleep cycles to give the Bun event loop ample opportunity
-	// to flush pending async I/O before we read the file.
-	// The void-async appendGuardrailDecision calls in toolBefore need several
-	// event-loop ticks to complete their fs.appendFile before we assert.
-	for (let i = 0; i < 8; i++) {
-		await Bun.sleep(50);
+async function waitForAuditEntries(
+	auditPath: string,
+	expectedCount = 1,
+	timeoutMs = 3000,
+): Promise<void> {
+	const start = Date.now();
+	let delayMs = 10;
+	while (Date.now() - start < timeoutMs) {
+		if (fsSync.existsSync(auditPath)) {
+			const entries = readAuditLog(auditPath);
+			if (entries.length >= expectedCount) return;
+		}
+		await Bun.sleep(delayMs);
+		delayMs = Math.min(delayMs * 2, 100);
 	}
+	const entries = readAuditLog(auditPath);
+	throw new Error(
+		`Timed out waiting for ${expectedCount} audit entries; saw ${entries.length}`,
+	);
+}
+
+async function waitForAuditEntryType(
+	auditPath: string,
+	type: string,
+	expectedCount = 1,
+	timeoutMs = 3000,
+): Promise<void> {
+	const start = Date.now();
+	let delayMs = 10;
+	while (Date.now() - start < timeoutMs) {
+		if (fsSync.existsSync(auditPath)) {
+			const entries = readAuditLog(auditPath);
+			if (countEntriesByType(entries, type) >= expectedCount) return;
+		}
+		await Bun.sleep(delayMs);
+		delayMs = Math.min(delayMs * 2, 100);
+	}
+	const entries = readAuditLog(auditPath);
+	throw new Error(
+		`Timed out waiting for ${expectedCount} ${type} audit entries; saw ${countEntriesByType(entries, type)}`,
+	);
+}
+
+async function waitForAuditEntry(
+	auditPath: string,
+	predicate: (entry: Record<string, unknown>) => boolean,
+	timeoutMs = 3000,
+): Promise<void> {
+	const start = Date.now();
+	let delayMs = 10;
+	while (Date.now() - start < timeoutMs) {
+		if (fsSync.existsSync(auditPath)) {
+			const entries = readAuditLog(auditPath);
+			if (entries.some(predicate)) return;
+		}
+		await Bun.sleep(delayMs);
+		delayMs = Math.min(delayMs * 2, 100);
+	}
+	throw new Error('Timed out waiting for matching audit entry');
 }
 
 // ---------------------------------------------------------------------------
@@ -135,8 +180,10 @@ describe('guardrail decision-log capture (task 2.1)', () => {
 	});
 
 	afterEach(async () => {
-		// Allow any pending async writes from this test to complete before cleanup
-		await flushAuditWrites();
+		// Best-effort cleanup guard if a test failed before its own wait.
+		if (fsSync.existsSync(auditPath)) {
+			await waitForAuditEntries(auditPath, 1, 200).catch(() => {});
+		}
 		resetSwarmState();
 		try {
 			fsSync.rmSync(tempDir, { recursive: true, force: true });
@@ -146,7 +193,7 @@ describe('guardrail decision-log capture (task 2.1)', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// destructive_block — git reset --hard
+	// destructive_block — fork bomb
 	// -------------------------------------------------------------------------
 	describe('destructive_block', () => {
 		it('throws the block error AND appends a destructive_block JSONL entry', async () => {
@@ -155,14 +202,15 @@ describe('guardrail decision-log capture (task 2.1)', () => {
 			startAgentSession('s-dest', 'coder');
 			swarmState.activeAgent.set('s-dest', 'coder');
 
-			// git reset --hard is a blocked destructive command
+			// Fork bomb is a blocked destructive command that does not overlap
+			// shell write-scope analysis.
 			await expect(
 				hooks.toolBefore(makeInput('s-dest', 'bash', 'call-dest'), {
-					args: { command: 'git reset --hard' },
+					args: { command: ':(){ :|:& };:' },
 				}),
-			).rejects.toThrow(/BLOCKED.*git reset/i);
+			).rejects.toThrow(/BLOCKED/i);
 
-			await flushAuditWrites();
+			await waitForAuditEntryType(auditPath, 'destructive_block');
 
 			// Verify audit entry was appended
 			const entries = readAuditLog(auditPath);
@@ -177,7 +225,7 @@ describe('guardrail decision-log capture (task 2.1)', () => {
 			expect(entry!.sessionID).toBe('s-dest');
 			expect(entry!.agent).toBe('coder');
 			expect(entry!.tool).toBe('bash');
-			expect(entry!.command).toContain('git reset --hard');
+			expect(entry!.command).toContain(':(){ :|:& };:');
 			expect(typeof entry!.destructiveCategory).toBe('string');
 		});
 
@@ -190,18 +238,18 @@ describe('guardrail decision-log capture (task 2.1)', () => {
 			// First destructive command — should throw
 			await expect(
 				hooks.toolBefore(makeInput('s-dest2', 'bash', 'call-dest2a'), {
-					args: { command: 'git reset --hard' },
+					args: { command: ':(){ :|:& };:' },
 				}),
 			).rejects.toThrow(/BLOCKED/i);
 
 			// Second destructive command — should ALSO throw (not swallowed)
 			await expect(
 				hooks.toolBefore(makeInput('s-dest2', 'bash', 'call-dest2b'), {
-					args: { command: 'git clean -fd' },
+					args: { command: ': () { :|:& };:' },
 				}),
 			).rejects.toThrow(/BLOCKED/i);
 
-			await flushAuditWrites();
+			await waitForAuditEntryType(auditPath, 'destructive_block', 2);
 
 			// Both should appear as separate audit entries
 			const entries = readAuditLog(auditPath);
@@ -248,7 +296,7 @@ describe('guardrail decision-log capture (task 2.1)', () => {
 				}),
 			).rejects.toThrow();
 
-			await flushAuditWrites();
+			await waitForAuditEntryType(auditPath, 'scope_violation');
 
 			const entries = readAuditLog(auditPath);
 
@@ -290,7 +338,7 @@ describe('guardrail decision-log capture (task 2.1)', () => {
 				}),
 			).rejects.toThrow(/WRITE BLOCKED|not authorised|blocked/i);
 
-			await flushAuditWrites();
+			await waitForAuditEntryType(auditPath, 'file_write');
 
 			const entries = readAuditLog(auditPath);
 			expect(countEntriesByType(entries, 'file_write')).toBeGreaterThanOrEqual(
@@ -328,7 +376,14 @@ describe('guardrail decision-log capture (task 2.1)', () => {
 				args: { command: 'echo hello' },
 			});
 
-			await flushAuditWrites();
+			await waitForAuditEntry(
+				auditPath,
+				(e) =>
+					e.sessionID === 's-shell' &&
+					e.agent === 'coder' &&
+					e.tool === 'bash' &&
+					!e.type,
+			);
 
 			const entries = readAuditLog(auditPath);
 			// shell entries have no `type` field (legacy 5-field shape)
@@ -356,11 +411,19 @@ describe('guardrail decision-log capture (task 2.1)', () => {
 			// A destructive command — throws, but shell entry fires first in handler
 			await expect(
 				hooks.toolBefore(makeInput('s-dup', 'bash', 'call-dup'), {
-					args: { command: 'git reset --hard' },
+					args: { command: ':(){ :|:& };:' },
 				}),
 			).rejects.toThrow(/BLOCKED/i);
 
-			await flushAuditWrites();
+			await waitForAuditEntry(
+				auditPath,
+				(e) =>
+					e.sessionID === 's-dup' &&
+					e.agent === 'coder' &&
+					e.tool === 'bash' &&
+					!e.type,
+			);
+			await waitForAuditEntryType(auditPath, 'destructive_block');
 
 			const entries = readAuditLog(auditPath);
 
@@ -465,9 +528,7 @@ describe('guardrail decision-log capture (task 2.1)', () => {
 				{ auditPath, enabled: true },
 			);
 
-			// Wait for the async write to flush
-			await Bun.sleep(50);
-			await Bun.sleep(50);
+			await waitForAuditEntryType(auditPath, 'file_write');
 
 			const entries = readAuditLog(auditPath);
 			expect(countEntriesByType(entries, 'file_write')).toBeGreaterThanOrEqual(

--- a/tests/unit/services/diagnose-sandbox.test.ts
+++ b/tests/unit/services/diagnose-sandbox.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for src/services/diagnose-service.ts — Sandbox HealthCheck (Task 1.2)
+ *
+ * Covers:
+ * - getDiagnoseData includes a HealthCheck with name 'Sandbox'
+ * - status is NEVER '❌' for any probe outcome
+ * - When probe/executor throws, diagnose does NOT crash (returns ⬜ advisory)
+ * - detail string mentions mechanism + availability + sandboxing status
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getDiagnoseData } from '../../../src/services/diagnose-service';
+
+// ---------------------------------------------------------------------------
+// Mock the sandbox modules before importing diagnose-service
+// ---------------------------------------------------------------------------
+
+interface MockSandboxCapability {
+	status: 'enabled' | 'disabled' | 'unsupported';
+	mechanism: string;
+	platform: 'linux' | 'darwin' | 'win32';
+	error?: string;
+}
+
+type MockExecutor = {
+	mechanism: string;
+	isAvailable: () => boolean;
+	wrapCommand: (cmd: string, scopes: string[], tempDir?: string) => string;
+	getEnvOverrides: () => Record<string, string | null>;
+} | null;
+
+let mockCapability: MockSandboxCapability = {
+	status: 'enabled',
+	mechanism: 'Bubblewrap',
+	platform: 'linux',
+};
+let mockExecutor: MockExecutor = {
+	mechanism: 'Bubblewrap',
+	isAvailable: () => true,
+	wrapCommand: (cmd) => cmd,
+	getEnvOverrides: () => ({}),
+};
+let probeThrows = false;
+let executorThrows = false;
+
+const mockDetect = mock(async (): Promise<MockSandboxCapability> => {
+	if (probeThrows) throw new Error('probe failure');
+	return mockCapability;
+});
+
+const mockGetExecutor = mock(async (): Promise<MockExecutor> => {
+	if (executorThrows) throw new Error('executor failure');
+	return mockExecutor;
+});
+
+// Mock sandbox/capability-probe
+mock.module('../../../src/sandbox/capability-probe.js', () => ({
+	SandboxCapabilityProbe: class {
+		async detect() {
+			return mockDetect();
+		}
+	},
+	isBubblewrapAvailable: () =>
+		mockCapability.status === 'enabled' && mockCapability.platform === 'linux',
+	isSandboxExecAvailable: () =>
+		mockCapability.status === 'enabled' && mockCapability.platform === 'darwin',
+	isWindowsSandboxAvailable: () =>
+		mockCapability.status === 'enabled' && mockCapability.platform === 'win32',
+}));
+
+// Mock sandbox/executor
+mock.module('../../../src/sandbox/executor.js', () => ({
+	getExecutor: mockGetExecutor,
+	_resetExecutorCache: () => {},
+	SandboxError: class SandboxError extends Error {
+		constructor(
+			message: string,
+			public readonly code: string,
+		) {
+			super(message);
+			this.name = 'SandboxError';
+		}
+	},
+}));
+
+// ---------------------------------------------------------------------------
+// Also mock the other modules that diagnose-service imports
+// ---------------------------------------------------------------------------
+
+mock.module('../../../src/plan/manager.js', () => ({
+	loadPlanJsonOnly: mock(async () => null),
+	closePlanTerminalState: async () => {},
+	_snapshot_test_exports: {},
+}));
+
+mock.module('../../../src/evidence/manager.js', () => ({
+	listEvidenceTaskIds: mock(async () => []),
+}));
+
+mock.module('../../../src/hooks/utils.js', () => ({
+	readSwarmFileAsync: mock(async () => null),
+}));
+
+mock.module('../../../src/config/loader.js', () => ({
+	loadPluginConfig: mock(() => ({ curator: { enabled: false } })),
+}));
+
+mock.module('../../../src/sdd/effective-spec.js', () => ({
+	readEffectiveSpecSync: () => null,
+}));
+
+mock.module('node:fs', () => ({
+	readdirSync: () => [],
+	existsSync: (p: string) => {
+		if (typeof p !== 'string') return false;
+		// Only the directory itself exists
+		return (
+			p === '/test/dir' || p.endsWith('/test/dir') || p.endsWith('\\test\\dir')
+		);
+	},
+	statSync: () => ({ isDirectory: () => true }),
+	readFileSync: () => '{}',
+}));
+
+mock.module('node:child_process', () => ({
+	execSync: () => Buffer.from('.git'),
+}));
+
+afterEach(() => {
+	mock.restore();
+	probeThrows = false;
+	executorThrows = false;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Sandbox HealthCheck in getDiagnoseData', () => {
+	test('getDiagnoseData includes a Sandbox HealthCheck', async () => {
+		const result = await getDiagnoseData('/test/dir');
+		const sandboxCheck = result.checks.find((c) => c.name === 'Sandbox');
+		expect(sandboxCheck).toBeDefined();
+		expect(sandboxCheck!.name).toBe('Sandbox');
+	});
+
+	test('Sandbox status is NEVER ❌ for any probe outcome', async () => {
+		// Scenario 1: capability enabled, executor available → ✅
+		mockCapability = {
+			status: 'enabled',
+			mechanism: 'Bubblewrap',
+			platform: 'linux',
+		};
+		mockExecutor = {
+			mechanism: 'Bubblewrap',
+			isAvailable: () => true,
+			wrapCommand: (c) => c,
+			getEnvOverrides: () => ({}),
+		};
+		executorThrows = false;
+		probeThrows = false;
+
+		let result = await getDiagnoseData('/test/dir');
+		let sandbox = result.checks.find((c) => c.name === 'Sandbox')!;
+		expect(sandbox.status).not.toBe('❌');
+		expect(sandbox.status).toBe('✅');
+
+		// Scenario 2: capability enabled, executor NOT available → ⚠️
+		mockExecutor = null;
+		result = await getDiagnoseData('/test/dir');
+		sandbox = result.checks.find((c) => c.name === 'Sandbox')!;
+		expect(sandbox.status).not.toBe('❌');
+		expect(sandbox.status).toBe('⚠️');
+
+		// Scenario 3: mechanism='none' (unsupported) → ⬜
+		mockExecutor = null;
+		mockCapability = {
+			status: 'unsupported',
+			mechanism: 'none',
+			platform: 'linux',
+		};
+		result = await getDiagnoseData('/test/dir');
+		sandbox = result.checks.find((c) => c.name === 'Sandbox')!;
+		expect(sandbox.status).not.toBe('❌');
+		expect(sandbox.status).toBe('⬜');
+
+		// Scenario 4: mechanism disabled (capability.status='disabled') with mechanism name → ⚠️
+		// (mechanism !== 'none', hasExecutor=false → ⚠️)
+		mockCapability = {
+			status: 'disabled',
+			mechanism: 'Bubblewrap',
+			platform: 'linux',
+		};
+		mockExecutor = null;
+		result = await getDiagnoseData('/test/dir');
+		sandbox = result.checks.find((c) => c.name === 'Sandbox')!;
+		expect(sandbox.status).not.toBe('❌');
+		expect(sandbox.status).toBe('⚠️');
+	});
+
+	test('When probe throws, getDiagnoseData does NOT crash — returns ⬜ advisory', async () => {
+		probeThrows = true;
+		mockExecutor = null;
+
+		// Should not throw
+		let threw = false;
+		try {
+			await getDiagnoseData('/test/dir');
+		} catch {
+			threw = true;
+		}
+		expect(threw).toBe(false);
+
+		const result = await getDiagnoseData('/test/dir');
+		const sandbox = result.checks.find((c) => c.name === 'Sandbox')!;
+		expect(sandbox.status).toBe('⬜');
+		expect(sandbox.detail).toContain('unknown');
+	});
+
+	test('When executor acquisition throws, getDiagnoseData does NOT crash', async () => {
+		probeThrows = false;
+		mockCapability = {
+			status: 'enabled',
+			mechanism: 'Bubblewrap',
+			platform: 'linux',
+		};
+		executorThrows = true;
+
+		let threw = false;
+		try {
+			await getDiagnoseData('/test/dir');
+		} catch {
+			threw = true;
+		}
+		expect(threw).toBe(false);
+
+		const result = await getDiagnoseData('/test/dir');
+		const sandbox = result.checks.find((c) => c.name === 'Sandbox')!;
+		expect(sandbox.status).toBe('⬜');
+	});
+
+	test('detail string mentions mechanism + availability + sandboxing status (✅ path)', async () => {
+		mockCapability = {
+			status: 'enabled',
+			mechanism: 'Bubblewrap',
+			platform: 'linux',
+		};
+		mockExecutor = {
+			mechanism: 'Bubblewrap',
+			isAvailable: () => true,
+			wrapCommand: (c) => c,
+			getEnvOverrides: () => ({}),
+		};
+
+		const result = await getDiagnoseData('/test/dir');
+		const sandbox = result.checks.find((c) => c.name === 'Sandbox')!;
+
+		expect(sandbox.detail).toContain('bubblewrap');
+		expect(sandbox.detail).toContain('Available: yes');
+		expect(sandbox.detail).toContain('Sandboxing commands: yes');
+	});
+
+	test('detail string mentions mechanism + availability for ⚠️ path', async () => {
+		mockCapability = {
+			status: 'enabled',
+			mechanism: 'Bubblewrap',
+			platform: 'linux',
+		};
+		mockExecutor = null;
+
+		const result = await getDiagnoseData('/test/dir');
+		const sandbox = result.checks.find((c) => c.name === 'Sandbox')!;
+
+		expect(sandbox.detail).toContain('bubblewrap');
+		expect(sandbox.detail).toContain('Available: no');
+		expect(sandbox.detail).toContain('Commands NOT sandboxed');
+	});
+
+	test('detail string mentions mechanism for ⬜ path', async () => {
+		mockCapability = {
+			status: 'unsupported',
+			mechanism: 'none',
+			platform: 'linux',
+		};
+		mockExecutor = null;
+
+		const result = await getDiagnoseData('/test/dir');
+		const sandbox = result.checks.find((c) => c.name === 'Sandbox')!;
+
+		expect(sandbox.detail).toContain('none');
+		expect(sandbox.detail).toContain('Commands not sandboxed');
+	});
+});

--- a/tests/unit/services/diagnose-sandbox.test.ts
+++ b/tests/unit/services/diagnose-sandbox.test.ts
@@ -13,7 +13,10 @@ import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { getDiagnoseData } from '../../../src/services/diagnose-service';
+import {
+	_internals,
+	getDiagnoseData,
+} from '../../../src/services/diagnose-service';
 
 // ---------------------------------------------------------------------------
 // Mock the sandbox modules before importing diagnose-service
@@ -57,35 +60,8 @@ const mockGetExecutor = mock(async (): Promise<MockExecutor> => {
 	return mockExecutor;
 });
 
-// Mock sandbox/capability-probe
-mock.module('../../../src/sandbox/capability-probe.js', () => ({
-	SandboxCapabilityProbe: class {
-		async detect() {
-			return mockDetect();
-		}
-	},
-	isBubblewrapAvailable: () =>
-		mockCapability.status === 'enabled' && mockCapability.platform === 'linux',
-	isSandboxExecAvailable: () =>
-		mockCapability.status === 'enabled' && mockCapability.platform === 'darwin',
-	isWindowsSandboxAvailable: () =>
-		mockCapability.status === 'enabled' && mockCapability.platform === 'win32',
-}));
-
-// Mock sandbox/executor
-mock.module('../../../src/sandbox/executor.js', () => ({
-	getExecutor: mockGetExecutor,
-	_resetExecutorCache: () => {},
-	SandboxError: class SandboxError extends Error {
-		constructor(
-			message: string,
-			public readonly code: string,
-		) {
-			super(message);
-			this.name = 'SandboxError';
-		}
-	},
-}));
+const realDetectSandboxCapability = _internals.detectSandboxCapability;
+const realGetSandboxExecutor = _internals.getSandboxExecutor;
 
 // ---------------------------------------------------------------------------
 // Also mock the other modules that diagnose-service imports
@@ -130,7 +106,16 @@ mock.module('node:child_process', () => ({
 	execSync: () => Buffer.from('.git'),
 }));
 
+beforeEach(() => {
+	_internals.detectSandboxCapability =
+		mockDetect as typeof _internals.detectSandboxCapability;
+	_internals.getSandboxExecutor =
+		mockGetExecutor as typeof _internals.getSandboxExecutor;
+});
+
 afterEach(() => {
+	_internals.detectSandboxCapability = realDetectSandboxCapability;
+	_internals.getSandboxExecutor = realGetSandboxExecutor;
 	mock.restore();
 	probeThrows = false;
 	executorThrows = false;

--- a/tests/unit/services/guardrail-explain-service.test.ts
+++ b/tests/unit/services/guardrail-explain-service.test.ts
@@ -212,6 +212,45 @@ describe('SC-105: --agent and --scope overrides reflected in resolved scope/deci
 	});
 });
 
+describe('guardrail explain parity regressions from PR feedback', () => {
+	test('F-001: malformed write syntax fails closed on parseError', async () => {
+		// Previous behavior silently ignored detectPosixWrites parseError and
+		// predicted allow, while the real hook blocks parse failures.
+		const result = await handleGuardrailExplain(tempDir, ['touch ")(']);
+
+		expect(result).toMatch(/\|\s*Decision\s*\|\s*block\s*\|/i);
+		expect(result).toContain('parse_error');
+		expect(result).toContain('rejecting for safety');
+	});
+
+	test('F-002: PowerShell env syntax routes through Windows write detection', async () => {
+		// Previous resolveShellType missed `$env:` heuristics and treated this as
+		// POSIX, diverging from the real hook's detectShellType routing.
+		const result = await handleGuardrailExplain(tempDir, [
+			'--scope',
+			'src/',
+			'$env:PATH > ../outside-scope.txt',
+		]);
+
+		expect(result).toMatch(/\|\s*Decision\s*\|\s*block\s*\|/i);
+		expect(result).toMatch(/scope_violation/i);
+		expect(result).toMatch(/file_redirect|file_write|write/i);
+	});
+
+	test('F-002: PowerShell cmdlet prefix routes through Windows write detection', async () => {
+		// Previous resolveShellType missed Copy-Item and could parse with the
+		// wrong engine, causing explain to diverge from real enforcement.
+		const result = await handleGuardrailExplain(tempDir, [
+			'--scope',
+			'src/',
+			'Copy-Item src/index.ts ../outside-scope.txt',
+		]);
+
+		expect(result).toMatch(/\|\s*Decision\s*\|\s*block\s*\|/i);
+		expect(result).toMatch(/scope_violation/i);
+	});
+});
+
 describe('SC-116: explain handler executes NOTHING', () => {
 	test('calling explain with rm -rf / does not modify filesystem', async () => {
 		// Create a marker file to prove the function didn't execute

--- a/tests/unit/services/guardrail-explain-service.test.ts
+++ b/tests/unit/services/guardrail-explain-service.test.ts
@@ -1,0 +1,504 @@
+/**
+ * Tests for src/services/guardrail-explain-service.ts (Task 1.3)
+ *
+ * Covers:
+ * - SC-101: shell command returns markdown with decision, firing rule, resolved scope, write categories
+ * - SC-102/103: --write outside scope returns block decision with firing rule + scope
+ * - SC-104: multiple --write targets → results for EACH independently
+ * - SC-105: --agent architect --scope docs/ overrides reflected in resolved scope/decision
+ * - SC-116 (CRITICAL): explain handler executes NOTHING — no subprocess spawned, no file created
+ * - SC-117: command containing secret is redacted in output
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { handleGuardrailExplain } from '../../../src/services/guardrail-explain-service';
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+
+beforeEach(async () => {
+	tempDir = await mkdtemp(join(tmpdir(), 'guardrail-explain-test-'));
+	await mkdir(join(tempDir, '.swarm'), { recursive: true });
+});
+
+afterEach(async () => {
+	if (existsSync(tempDir)) {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+	mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SC-101: shell command explain returns markdown with decision fields', () => {
+	test('handleGuardrailExplain returns a markdown string (not a crash) for rm -rf build', async () => {
+		const result = await handleGuardrailExplain(tempDir, [
+			'rm',
+			'-rf',
+			'build',
+		]);
+
+		expect(typeof result).toBe('string');
+		expect(result.length).toBeGreaterThan(0);
+		// Must not throw — must resolve to a string
+	});
+
+	test('SC-101: explain result contains decision, firing rule, resolved scope, write categories', async () => {
+		const result = await handleGuardrailExplain(tempDir, [
+			'rm',
+			'-rf',
+			'build',
+		]);
+
+		// Should contain a Decision field
+		expect(result).toContain('**Mode**: shell');
+		// Should contain Agent
+		expect(result).toContain('**Agent**:');
+		// Should contain Resolved scope
+		expect(result).toContain('Resolved Scope');
+		// Should mention the command (redacted or not)
+		expect(result).toContain('Command');
+		// Should contain Decision table row with allow or block
+		expect(result).toContain('Decision');
+		expect(result).toMatch(/\| *Decision *\| *(allow|block) */i);
+		// Should contain Firing Rule table row
+		expect(result).toContain('Firing Rule');
+	});
+
+	test('non-destructive command yields allow decision', async () => {
+		const result = await handleGuardrailExplain(tempDir, ['ls', '-la']);
+
+		expect(result).toContain('Decision');
+		// ls -la is a read-only command — should be allowed
+		expect(result).toMatch(/\| *Decision *\| *allow */i);
+	});
+});
+
+describe('SC-102/103: --write outside scope returns block decision', () => {
+	test('--write to path outside project scope returns block', async () => {
+		// /etc/passwd is definitely outside any reasonable project scope
+		const result = await handleGuardrailExplain(tempDir, [
+			'--write',
+			'/etc/passwd',
+		]);
+
+		expect(result).toContain('**Mode**: write-target');
+		// Should contain block decision in the table body (not just header)
+		expect(result).toContain('| block |');
+		// Should contain Firing Rule
+		expect(result).toContain('Firing Rule');
+		// Should contain Resolved Scope
+		expect(result).toContain('Resolved Scope');
+		// The path should appear in the table
+		// Path is echoed via redactPath (normalized separators / home-redacted), so assert the
+		// target's basename in a separator- and redaction-agnostic way rather than the raw path.
+		expect(result).toContain('passwd');
+	});
+
+	test('--write within project scope returns allow', async () => {
+		// Write to a path inside the project directory
+		const result = await handleGuardrailExplain(tempDir, [
+			'--write',
+			'src/index.ts',
+		]);
+
+		expect(result).toContain('**Mode**: write-target');
+		// Should contain allow decision in the table body
+		expect(result).toContain('| allow |');
+	});
+});
+
+describe('SC-104: multiple --write targets returns results for EACH independently', () => {
+	test('two --write targets produce results for each path', async () => {
+		const result = await handleGuardrailExplain(tempDir, [
+			'--write',
+			'/etc/passwd',
+			'--write',
+			'/tmp/allowed.txt',
+		]);
+
+		// Both paths should appear in the output independently
+		// Path is echoed via redactPath (normalized separators / home-redacted), so assert the
+		// target's basename in a separator- and redaction-agnostic way rather than the raw path.
+		expect(result).toContain('passwd');
+		expect(result).toContain('allowed');
+		// /etc/passwd should be blocked; /tmp/allowed.txt might be blocked on Windows
+		// Both should appear as separate table entries
+		expect(result).toContain('block');
+	});
+
+	test('three --write targets produce results for each path', async () => {
+		const result = await handleGuardrailExplain(tempDir, [
+			'--write',
+			'/etc/passwd',
+			'--write',
+			'/home/user/secret',
+			'--write',
+			'src/index.ts',
+		]);
+
+		// Path is echoed via redactPath (normalized separators / home-redacted), so assert the
+		// target's basename in a separator- and redaction-agnostic way rather than the raw path.
+		expect(result).toContain('passwd');
+		expect(result).toContain('secret');
+		expect(result).toContain('index.ts');
+	});
+});
+
+describe('SC-105: --agent and --scope overrides reflected in resolved scope/decision', () => {
+	test('--agent architect bypasses scope violations in shell mode', async () => {
+		// architect bypasses ONLY scope violations, NOT destructive blocks (file-authority.ts
+		// containment check applies to ALL agents, including architect). The architect bypass
+		// is in shell scope check at guardrail-explain-service.ts:691.
+		// Use shell mode (NOT --write) with a command that triggers scope check.
+		// On Unix: echo hello > /tmp/outside.txt with scope docs/ → out-of-scope → block for coder,
+		// allow for architect. On Windows /tmp resolves oddly; use a relative path with .. instead.
+		const coderResult = await handleGuardrailExplain(tempDir, [
+			'--agent',
+			'coder',
+			'--scope',
+			'src/',
+			'echo hello > ../outside-scope.txt',
+		]);
+		expect(coderResult).toContain('**Mode**: shell');
+		// scope_violation fires for coder (scope check at line 691 is NOT bypassed for coder)
+		expect(coderResult).toMatch(/\|\s*block\s*\|/i);
+		expect(coderResult).toMatch(/scope_violation/i);
+
+		const architectResult = await handleGuardrailExplain(tempDir, [
+			'--agent',
+			'architect',
+			'--scope',
+			'src/',
+			'echo hello > ../outside-scope.txt',
+		]);
+		expect(architectResult).toContain('**Mode**: shell');
+		// architect bypasses scope check → allow (no scope_violation, no destructive block)
+		expect(architectResult).toMatch(/\|\s*allow\s*\|/i);
+	});
+
+	test('--scope override changes resolved scope in output', async () => {
+		const result = await handleGuardrailExplain(tempDir, [
+			'--scope',
+			'docs/',
+			'--write',
+			'src/index.ts',
+		]);
+
+		// Resolved scope should reflect the --scope override (handle both slash styles)
+		expect(result).toMatch(/docs[/\\]/);
+	});
+
+	test('--agent coder with --scope shows agent in output', async () => {
+		const result = await handleGuardrailExplain(tempDir, [
+			'--agent',
+			'coder',
+			'--scope',
+			'src/',
+			'--write',
+			'src/index.ts',
+		]);
+
+		expect(result).toContain('**Agent**: coder');
+	});
+});
+
+describe('SC-116: explain handler executes NOTHING', () => {
+	test('calling explain with rm -rf / does not modify filesystem', async () => {
+		// Create a marker file to prove the function didn't execute
+		const markerPath = join(tempDir, 'marker.txt');
+		await writeFile(markerPath, 'original content');
+
+		// Call explain with obviously destructive command
+		const result = await handleGuardrailExplain(tempDir, ['rm', '-rf', '/']);
+
+		// Result must be a string (not an error)
+		expect(typeof result).toBe('string');
+		expect(result.length).toBeGreaterThan(0);
+
+		// Marker file must be UNCHANGED (proves rm was not executed)
+		const markerContent = await Bun.file(markerPath).text();
+		expect(markerContent).toBe('original content');
+	});
+
+	test('the returned string contains dry-run mode indicator', async () => {
+		const result = await handleGuardrailExplain(tempDir, ['rm', '-rf', '/']);
+
+		// The function must self-identify as dry-run
+		expect(result).toContain('dry-run');
+	});
+
+	test('guardrail-explain-service.ts does not import child_process', async () => {
+		// Static analysis: the source file must not contain 'child_process'
+		const fs = await import('node:fs');
+		const source = fs.readFileSync(
+			join(process.cwd(), 'src/services/guardrail-explain-service.ts'),
+			'utf-8',
+		);
+		expect(source).not.toContain('child_process');
+		expect(source).not.toContain('spawn');
+	});
+});
+
+describe('SC-117: command with secret is redacted in output', () => {
+	test('Bearer token in shell command is redacted in explain output', async () => {
+		const cmdWithSecret =
+			"curl -H 'Authorization: Bearer sk-test1234567890abcdef' https://api.example.com";
+		const result = await handleGuardrailExplain(tempDir, [cmdWithSecret]);
+
+		expect(result).not.toContain('sk-test1234567890abcdef');
+		expect(result).toContain('[REDACTED]');
+	});
+
+	test('API_TOKEN env var is redacted in explain output', async () => {
+		const cmdWithSecret =
+			'curl -H "Authorization: Bearer $API_TOKEN" https://api.example.com';
+		const result = await handleGuardrailExplain(tempDir, [cmdWithSecret]);
+
+		// The token should not appear literally in output
+		expect(result).not.toMatch(/sk-[a-zA-Z0-9]+/);
+	});
+
+	test('--write path containing secret is handled safely', async () => {
+		// Even if the user accidentally passes a path with a secret as --write argument,
+		// the explain should not crash
+		const result = await handleGuardrailExplain(tempDir, [
+			'--write',
+			'/home/user/secrets/API_TOKEN=mysecretkey123',
+		]);
+
+		expect(typeof result).toBe('string');
+		// The result should not expose the raw token in the path column
+		// (redaction depends on redactPath which strips home dir, not query strings)
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Helper: extract decision from markdown output
+// ---------------------------------------------------------------------------
+
+function extractDecision(markdown: string): 'allow' | 'block' | null {
+	const match = markdown.match(/\|\s*Decision\s*\|\s*(\w+)\s*\|/i);
+	if (!match) return null;
+	const val = match[1]!.toLowerCase();
+	if (val === 'allow' || val === 'block') return val;
+	return null;
+}
+
+function extractFiringRule(markdown: string): string {
+	const match = markdown.match(/\|\s*Firing Rule\s*\|\s*(.+?)\s*\|/i);
+	return match ? match[1]!.trim() : '';
+}
+
+// ---------------------------------------------------------------------------
+// Accuracy tests: decision matches real enforcement behavior
+// ---------------------------------------------------------------------------
+
+describe('Guardrail explain accuracy — destructive commands', () => {
+	test('git reset --hard HEAD~1 → decision === block (destructive git operation)', async () => {
+		const result = await handleGuardrailExplain(tempDir, [
+			'git reset --hard HEAD~1',
+		]);
+		const decision = extractDecision(result);
+		expect(decision).toBe('block');
+		const firingRule = extractFiringRule(result);
+		expect(firingRule.toLowerCase()).toContain('reset');
+	});
+
+	test('fork bomb :(){ :|:& };: → decision === block', async () => {
+		const result = await handleGuardrailExplain(tempDir, [':(){ :|:& };:']);
+		const decision = extractDecision(result);
+		expect(decision).toBe('block');
+		const firingRule = extractFiringRule(result);
+		expect(firingRule.toLowerCase()).toContain('fork bomb');
+	});
+
+	test('git push --force origin main → decision === block', async () => {
+		const result = await handleGuardrailExplain(tempDir, [
+			'git push --force origin main',
+		]);
+		const decision = extractDecision(result);
+		expect(decision).toBe('block');
+		const firingRule = extractFiringRule(result);
+		expect(firingRule.toLowerCase()).toContain('push');
+		expect(firingRule.toLowerCase()).toContain('force');
+	});
+
+	test('git clean -fd → decision === block', async () => {
+		const result = await handleGuardrailExplain(tempDir, ['git clean -fd']);
+		const decision = extractDecision(result);
+		expect(decision).toBe('block');
+		const firingRule = extractFiringRule(result);
+		expect(firingRule.toLowerCase()).toContain('git clean');
+	});
+
+	test('rm -rf / → decision === block', async () => {
+		const result = await handleGuardrailExplain(tempDir, ['rm -rf /']);
+		const decision = extractDecision(result);
+		expect(decision).toBe('block');
+		const firingRule = extractFiringRule(result);
+		expect(firingRule.toLowerCase()).toContain('rm');
+	});
+
+	test('rm -rf build with --scope build → decision === allow (in-scope safe target)', async () => {
+		const result = await handleGuardrailExplain(tempDir, [
+			'--scope',
+			'build',
+			'rm',
+			'-rf',
+			'build',
+		]);
+		const decision = extractDecision(result);
+		expect(decision).toBe('allow');
+	});
+
+	test('echo hello → decision === allow', async () => {
+		const result = await handleGuardrailExplain(tempDir, ['echo hello']);
+		const decision = extractDecision(result);
+		expect(decision).toBe('allow');
+	});
+
+	// Regression test for TRUNCATE TABLE detection (FR-119 / SC in review)
+	test('TRUNCATE TABLE users → decision === block (destructive SQL DDL)', async () => {
+		const result = await handleGuardrailExplain(tempDir, [
+			'TRUNCATE TABLE users',
+		]);
+		const decision = extractDecision(result);
+		expect(decision).toBe('block');
+		const firingRule = extractFiringRule(result);
+		// Must fire a SQL-destruction rule mentioning truncate
+		expect(firingRule.toLowerCase()).toContain('truncate');
+	});
+
+	test('fork bomb with whitespace after ":" (": () { :|:& };:") → decision === block', async () => {
+		// Real checkDestructiveCommand allows whitespace after the leading ':'; explain must match.
+		const result = await handleGuardrailExplain(tempDir, [': () { :|:& };:']);
+		const decision = extractDecision(result);
+		expect(decision).toBe('block');
+	});
+
+	test('mkfs with space ("mkfs /dev/sdb") → decision === allow (real only blocks mkfs[./])', async () => {
+		// Real checkDestructiveCommand blocks only /^mkfs[./]/ (e.g. mkfs.ext4); "mkfs /dev/sdb" is allowed.
+		const result = await handleGuardrailExplain(tempDir, ['mkfs /dev/sdb']);
+		const decision = extractDecision(result);
+		expect(decision).toBe('allow');
+	});
+
+	test('mkfs.ext4 → decision === block (real blocks mkfs[./])', async () => {
+		const result = await handleGuardrailExplain(tempDir, [
+			'mkfs.ext4 /dev/sdb',
+		]);
+		const decision = extractDecision(result);
+		expect(decision).toBe('block');
+	});
+
+	test('in-project write WITHOUT --scope (echo hi > local.txt) → decision === allow', async () => {
+		// Without --scope, scopeEntries defaults to the project dir, so an in-project write is
+		// allowed — matching the displayed resolved scope. Regression for the empty-scopeEntries bug
+		// (previously every write was wrongly blocked as scope_violation when no --scope was given).
+		const result = await handleGuardrailExplain(tempDir, [
+			'echo hi > local.txt',
+		]);
+		const decision = extractDecision(result);
+		expect(decision).toBe('allow');
+	});
+
+	test('human-only swarm command via shell (bunx opencode-swarm run reset) → decision === block', async () => {
+		// Real guardrails block agents from invoking human-only /swarm subcommands via shell.
+		// explain must mirror this (regression for the final-council drift finding).
+		const result = await handleGuardrailExplain(tempDir, [
+			'bunx opencode-swarm run reset',
+		]);
+		const decision = extractDecision(result);
+		expect(decision).toBe('block');
+		const firingRule = extractFiringRule(result);
+		expect(firingRule.toLowerCase()).toContain('human-only');
+	});
+
+	test('shell write to .swarm/spec-staleness.json → decision === block (system-managed file)', async () => {
+		const result = await handleGuardrailExplain(tempDir, [
+			'echo x > .swarm/spec-staleness.json',
+		]);
+		const decision = extractDecision(result);
+		expect(decision).toBe('block');
+		const firingRule = extractFiringRule(result);
+		expect(firingRule.toLowerCase()).toContain('spec-staleness');
+	});
+
+	test('read-only cat of .swarm/spec-staleness.json → decision === allow (not a write)', async () => {
+		// Real guardrails only block WRITES to spec-staleness.json; read-only cat is allowed.
+		const result = await handleGuardrailExplain(tempDir, [
+			'cat .swarm/spec-staleness.json',
+		]);
+		const decision = extractDecision(result);
+		expect(decision).toBe('allow');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Redaction strength tests: firingRule must NOT expose raw home directory paths
+// ---------------------------------------------------------------------------
+
+describe('Guardrail explain redaction — firingRule does not leak home directory', () => {
+	test('firingRule for rm -rf /tmp/absolute does not contain raw /home/<user> or C:\\Users\\<user> path', async () => {
+		// Pass an absolute path inside a mock home dir context to verify redactPath is called
+		const result = await handleGuardrailExplain(tempDir, [
+			'rm -rf /tmp/some-dir',
+		]);
+		const firingRule = extractFiringRule(result);
+		// The firingRule must not contain a raw home-dir path string
+		// (it may contain ~ or a redacted form, but never /home/<user>)
+		expect(firingRule).not.toMatch(/\/home\//);
+		// Must not contain the raw C:\Users\<name> pattern
+		expect(firingRule).not.toMatch(/C:\\Users\\/i);
+	});
+
+	test('firingRule output uses tilde notation or safe form for home-adjacent paths', async () => {
+		// The redactPath function replaces /home/<user> with ~ and C:\Users\<user> with ~\.
+		// Verify the pattern is either redacted with ~ or doesn't appear at all
+		const result = await handleGuardrailExplain(tempDir, [
+			'rm -rf ~/some-path',
+		]);
+		const firingRule = extractFiringRule(result);
+		// After redaction the firingRule should not contain 'home' or raw user profile
+		const containsRawHome =
+			/\/home\/[^/]+/.test(firingRule) || /C:\\Users\\[^/]+/.test(firingRule);
+		expect(containsRawHome).toBe(false);
+	});
+
+	test('safe command fires no blocking rule and allow rule is clean', async () => {
+		const result = await handleGuardrailExplain(tempDir, ['ls -la']);
+		const decision = extractDecision(result);
+		expect(decision).toBe('allow');
+		const firingRule = extractFiringRule(result);
+		// No home-dir references in allow rule either
+		expect(firingRule).not.toMatch(/\/home\//);
+		expect(firingRule).not.toMatch(/C:\\Users\\/i);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Argument parsing (existing)
+// ---------------------------------------------------------------------------
+
+describe('Argument parsing', () => {
+	test('empty args returns usage message', async () => {
+		const result = await handleGuardrailExplain(tempDir, []);
+		expect(result).toContain('dry-run');
+	});
+
+	test('unknown flag is ignored and joined as shell command', async () => {
+		const result = await handleGuardrailExplain(tempDir, ['--unknown', 'ls']);
+		expect(typeof result).toBe('string');
+		expect(result).toContain('ls');
+	});
+});

--- a/tests/unit/services/guardrail-log-service.test.ts
+++ b/tests/unit/services/guardrail-log-service.test.ts
@@ -1,0 +1,674 @@
+/**
+ * Tests for src/services/guardrail-log-service.ts (Task 2.2)
+ *
+ * Covers:
+ * - Missing audit file → friendly "no decisions" message, does NOT throw
+ * - Mixed entries → all returned, most-recent-first (assert ts ordering)
+ * - --blocks-only → only file_write/scope_violation/destructive_block; excludes legacy shell + sandbox_wrap
+ * - Malformed JSON line → skipped gracefully; valid lines still returned
+ * - Empty file / all-blank lines → friendly "no decisions" message
+ * - Redaction: command with secret (API_KEY, Bearer token) → output does NOT contain raw secret
+ * - Redaction: path under home dir (/home/<user>/, C:\Users\<user>\) → redacted via redactPath
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { handleGuardrailLog } from '../../../src/services/guardrail-log-service';
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+
+beforeEach(async () => {
+	tempDir = await mkdtemp(join(tmpdir(), 'guardrail-log-test-'));
+	// Create the .swarm/session/ directory structure the service expects
+	await mkdir(join(tempDir, '.swarm', 'session'), { recursive: true });
+});
+
+afterEach(async () => {
+	if (tempDir && existsSync(tempDir)) {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+	mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// Helper: write a shell-audit.jsonl file
+// ---------------------------------------------------------------------------
+
+async function writeAuditFile(contents: string): Promise<void> {
+	const auditPath = join(tempDir, '.swarm', 'session', 'shell-audit.jsonl');
+	await writeFile(auditPath, contents, 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Test: Missing audit file → friendly message, no throw
+// ---------------------------------------------------------------------------
+
+describe('Missing audit file → friendly message, no throw', () => {
+	test('returns "No guardrail decisions recorded yet." when file does not exist', async () => {
+		// Ensure the file definitely does not exist
+		const auditPath = join(tempDir, '.swarm', 'session', 'shell-audit.jsonl');
+		expect(existsSync(auditPath)).toBe(false);
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		expect(result).toBe('No guardrail decisions recorded yet.');
+	});
+
+	test('does NOT throw when audit file is absent', async () => {
+		// The function must reject with an error, not throw
+		await expect(handleGuardrailLog(tempDir, [])).resolves.toBe(
+			'No guardrail decisions recorded yet.',
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test: Empty file / all-blank lines → friendly message
+// ---------------------------------------------------------------------------
+
+describe('Empty file / all-blank lines → friendly message', () => {
+	test('completely empty file returns "No guardrail decisions recorded yet."', async () => {
+		await writeAuditFile('');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		expect(result).toBe('No guardrail decisions recorded yet.');
+	});
+
+	test('file with only whitespace / blank lines returns "No guardrail decisions recorded yet."', async () => {
+		await writeAuditFile('   \n\n\t\n  \n');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		expect(result).toBe('No guardrail decisions recorded yet.');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test: Malformed JSON line → skipped gracefully; valid lines still returned
+// ---------------------------------------------------------------------------
+
+describe('Malformed JSON line → skipped gracefully; valid lines still returned', () => {
+	test('malformed JSON line is skipped without throwing; valid entries returned', async () => {
+		// One valid entry surrounded by bad lines
+		const validEntry = JSON.stringify({
+			ts: '2025-01-01T12:00:00.000Z',
+			type: 'file_write',
+			sessionID: 'session-1',
+			agent: 'coder',
+			tool: 'write',
+			path: '/tmp/test.txt',
+			reason: 'testing',
+			resolvedScope: '/tmp/',
+		});
+
+		await writeAuditFile(
+			'NOT JSON\n{"broken": json\n' + validEntry + '\n{invalid:',
+		);
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		// The valid entry must appear in output
+		expect(result).toContain('file_write');
+		expect(result).toContain('coder');
+		// The malformed lines must NOT appear verbatim in output
+		expect(result).not.toContain('NOT JSON');
+		expect(result).not.toContain('{"broken": json');
+	});
+
+	test('valid entry with extra fields still parses correctly', async () => {
+		// Entry has extra unknown fields — must not break parsing
+		const entry = JSON.stringify({
+			ts: '2025-01-01T12:00:00.000Z',
+			type: 'destructive_block',
+			sessionID: 'session-2',
+			agent: 'coder',
+			tool: 'shell',
+			command: 'rm -rf /',
+			destructiveCategory: 'recursive-delete',
+			extraField: 'should be ignored',
+		});
+		await writeAuditFile(entry + '\n');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		// Output format shows type + redacted command; destructiveCategory is NOT in the format output
+		expect(result).toContain('destructive_block');
+		expect(result).toContain('coder');
+		// extraField should not appear (it's ignored during parsing)
+		expect(result).not.toContain('extraField');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test: Mixed entries → all returned, most-recent-first
+// ---------------------------------------------------------------------------
+
+describe('Mixed entries → all returned, most-recent-first (ts ordering)', () => {
+	test('returns ALL entry types when no --blocks-only flag; sorted most-recent-first', async () => {
+		// Build a log with 5 distinct entry types:
+		// 1. Legacy shell entry (no type field) — oldest
+		// 2. file_write
+		// 3. scope_violation
+		// 4. destructive_block
+		// 5. sandbox_wrap — newest
+		const oldest = '2025-01-01T10:00:00.000Z';
+		const middle = '2025-01-01T11:00:00.000Z';
+		const newest = '2025-01-01T12:00:00.000Z';
+
+		const entries = [
+			// Legacy shell entry — no type discriminator
+			JSON.stringify({
+				ts: oldest,
+				sessionID: 's1',
+				agent: 'coder',
+				tool: 'shell',
+				command: 'echo hello',
+			}),
+			// file_write
+			JSON.stringify({
+				ts: '2025-01-01T10:30:00.000Z',
+				type: 'file_write',
+				sessionID: 's2',
+				agent: 'coder',
+				tool: 'write',
+				path: '/tmp/test.txt',
+				reason: 'testing',
+				resolvedScope: '/tmp/',
+			}),
+			// scope_violation
+			JSON.stringify({
+				ts: middle,
+				type: 'scope_violation',
+				sessionID: 's3',
+				agent: 'coder',
+				tool: 'shell',
+				path: '/etc/passwd',
+				declaredScope: 'src/',
+				resolvedScope: '/etc/',
+				action: 'block',
+			}),
+			// destructive_block
+			JSON.stringify({
+				ts: '2025-01-01T11:30:00.000Z',
+				type: 'destructive_block',
+				sessionID: 's4',
+				agent: 'coder',
+				tool: 'shell',
+				command: 'rm -rf /',
+				destructiveCategory: 'recursive-delete',
+			}),
+			// sandbox_wrap — newest
+			JSON.stringify({
+				ts: newest,
+				type: 'sandbox_wrap',
+				sessionID: 's5',
+				agent: 'coder',
+				tool: 'shell',
+				command: 'curl https://example.com',
+				executorMechanism: 'passthrough',
+			}),
+		];
+
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		// Header confirms all-entries mode
+		expect(result).toContain('Guardrail Decision Log (most-recent-first)');
+
+		// All 5 entry types must appear
+		expect(result).toContain('shell'); // legacy shell
+		expect(result).toContain('file_write');
+		expect(result).toContain('scope_violation');
+		expect(result).toContain('destructive_block');
+		expect(result).toContain('sandbox_wrap');
+
+		// Most-recent-first ordering: newest timestamp (2025-01-01T12:00) appears first in body
+		const bodyStart = result.indexOf('\n\n') + 2;
+		const body = result.slice(bodyStart);
+		// Each entry line starts with "- [timestamp]" — extract timestamp from first line
+		const firstEntryTs = body.match(/- \[([^\]]+)\]/)?.[1];
+		expect(firstEntryTs).toBe(newest);
+
+		// Oldest appears last in body — split by newline and check the last non-empty line
+		const lines = body.split(/\r?\n/).filter((l) => l.trim().length > 0);
+		const lastLine = lines[lines.length - 1] ?? '';
+		const lastEntryTs = lastLine.match(/- \[([^\]]+)\]/)?.[1];
+		expect(lastEntryTs).toBe(oldest);
+	});
+
+	test('entries with identical timestamps are handled stably (no throw)', async () => {
+		const sameTs = '2025-01-01T12:00:00.000Z';
+		const entries = [
+			JSON.stringify({
+				ts: sameTs,
+				type: 'file_write',
+				sessionID: 's1',
+				agent: 'coder',
+				tool: 'write',
+				path: '/tmp/a.txt',
+				reason: 'a',
+				resolvedScope: '/tmp/',
+			}),
+			JSON.stringify({
+				ts: sameTs,
+				type: 'scope_violation',
+				sessionID: 's2',
+				agent: 'coder',
+				tool: 'shell',
+				path: '/tmp/b.txt',
+				declaredScope: 'src/',
+				resolvedScope: '/tmp/',
+				action: 'block',
+			}),
+		];
+
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		// Must not throw on equal timestamps
+		const result = await handleGuardrailLog(tempDir, []);
+		expect(result).toContain('file_write');
+		expect(result).toContain('scope_violation');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test: --blocks-only → only file_write/scope_violation/destructive_block
+// ---------------------------------------------------------------------------
+
+describe('--blocks-only → only block-type entries returned; legacy + sandbox_wrap excluded (SC-112)', () => {
+	test('--blocks-only returns ONLY file_write, scope_violation, destructive_block', async () => {
+		const oldest = '2025-01-01T10:00:00.000Z';
+		const newest = '2025-01-01T12:00:00.000Z';
+
+		const entries = [
+			// Legacy shell entry (no type) — must be EXCLUDED
+			JSON.stringify({
+				ts: oldest,
+				sessionID: 's1',
+				agent: 'coder',
+				tool: 'shell',
+				command: 'echo hello',
+			}),
+			// file_write — INCLUDED
+			JSON.stringify({
+				ts: '2025-01-01T10:30:00.000Z',
+				type: 'file_write',
+				sessionID: 's2',
+				agent: 'coder',
+				tool: 'write',
+				path: '/tmp/test.txt',
+				reason: 'testing',
+				resolvedScope: '/tmp/',
+			}),
+			// scope_violation — INCLUDED
+			JSON.stringify({
+				ts: '2025-01-01T11:00:00.000Z',
+				type: 'scope_violation',
+				sessionID: 's3',
+				agent: 'coder',
+				tool: 'shell',
+				path: '/etc/passwd',
+				declaredScope: 'src/',
+				resolvedScope: '/etc/',
+				action: 'block',
+			}),
+			// destructive_block — INCLUDED
+			JSON.stringify({
+				ts: '2025-01-01T11:30:00.000Z',
+				type: 'destructive_block',
+				sessionID: 's4',
+				agent: 'coder',
+				tool: 'shell',
+				command: 'rm -rf /',
+				destructiveCategory: 'recursive-delete',
+			}),
+			// sandbox_wrap — must be EXCLUDED
+			JSON.stringify({
+				ts: newest,
+				type: 'sandbox_wrap',
+				sessionID: 's5',
+				agent: 'coder',
+				tool: 'shell',
+				command: 'curl https://example.com',
+				executorMechanism: 'passthrough',
+			}),
+		];
+
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		const result = await handleGuardrailLog(tempDir, ['--blocks-only']);
+
+		expect(result).toContain('Guardrail Block Log (most-recent-first)');
+
+		// INCLUDED types must appear
+		expect(result).toContain('file_write');
+		expect(result).toContain('scope_violation');
+		expect(result).toContain('destructive_block');
+
+		// EXCLUDED types must NOT appear
+		expect(result).not.toContain('shell'); // legacy shell entry (no type field)
+		expect(result).not.toContain('sandbox_wrap');
+
+		// Number of entries in body: exactly 3 (file_write, scope_violation, destructive_block)
+		const bodyStart = result.indexOf('\n\n') + 2;
+		const body = result.slice(bodyStart);
+		const entryMatches = body.match(/- \[/g);
+		expect(entryMatches).toHaveLength(3);
+	});
+
+	test('--blocks-only returns "No guardrail block decisions recorded yet." when only non-block entries exist', async () => {
+		const entries = [
+			// Only legacy shell and sandbox_wrap entries — no block types
+			JSON.stringify({
+				ts: '2025-01-01T10:00:00.000Z',
+				sessionID: 's1',
+				agent: 'coder',
+				tool: 'shell',
+				command: 'echo hello',
+			}),
+			JSON.stringify({
+				ts: '2025-01-01T11:00:00.000Z',
+				type: 'sandbox_wrap',
+				sessionID: 's2',
+				agent: 'coder',
+				tool: 'shell',
+				command: 'curl https://example.com',
+				executorMechanism: 'passthrough',
+			}),
+		];
+
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		const result = await handleGuardrailLog(tempDir, ['--blocks-only']);
+
+		expect(result).toBe('No guardrail block decisions recorded yet.');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test: Redaction — command with secret → output does NOT contain raw secret
+// ---------------------------------------------------------------------------
+
+describe('Redaction: command with secret → output does NOT contain raw secret', () => {
+	test('API_KEY env var in command is redacted', async () => {
+		const entries = [
+			JSON.stringify({
+				ts: '2025-01-01T12:00:00.000Z',
+				type: 'destructive_block',
+				sessionID: 's1',
+				agent: 'coder',
+				tool: 'shell',
+				command:
+					'curl -H "Authorization: Bearer secret_token_abc123" https://api.example.com',
+				destructiveCategory: 'network-call',
+			}),
+		];
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		// The raw secret token must NOT appear in output
+		expect(result).not.toContain('secret_token_abc123');
+		// The redaction placeholder must appear
+		expect(result).toContain('[REDACTED]');
+	});
+
+	test('Bearer token in command is redacted', async () => {
+		const entries = [
+			JSON.stringify({
+				ts: '2025-01-01T12:00:00.000Z',
+				type: 'destructive_block',
+				sessionID: 's1',
+				agent: 'coder',
+				tool: 'shell',
+				command:
+					'curl -H "Authorization: Bearer my_super_secret_token_xyz" https://api.example.com',
+				destructiveCategory: 'network-call',
+			}),
+		];
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		// The raw Bearer token must NOT appear
+		expect(result).not.toContain('my_super_secret_token_xyz');
+		expect(result).toContain('[REDACTED]');
+	});
+
+	test('MY_API_TOKEN env var assignment in command is redacted', async () => {
+		const entries = [
+			JSON.stringify({
+				ts: '2025-01-01T12:00:00.000Z',
+				type: 'sandbox_wrap',
+				sessionID: 's1',
+				agent: 'coder',
+				tool: 'shell',
+				command:
+					'MY_API_TOKEN=sk-live-abcdefghijklmnop curl https://api.example.com',
+				executorMechanism: 'passthrough',
+			}),
+		];
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		// The raw token value must NOT appear
+		expect(result).not.toContain('sk-live-abcdefghijklmnop');
+		expect(result).toContain('[REDACTED]');
+	});
+
+	test('-H header with API key is redacted', async () => {
+		const entries = [
+			JSON.stringify({
+				ts: '2025-01-01T12:00:00.000Z',
+				type: 'shell',
+				sessionID: 's1',
+				agent: 'coder',
+				tool: 'shell',
+				command:
+					"curl -H 'X-API-Key: super_secret_api_key_12345' https://api.example.com",
+			}),
+		];
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		// The raw API key must NOT appear
+		expect(result).not.toContain('super_secret_api_key_12345');
+		expect(result).toContain('[REDACTED]');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test: Redaction — path under home dir → output redacted via redactPath
+// ---------------------------------------------------------------------------
+
+describe('Redaction: path under home dir → output redacted via redactPath (no raw /home/<user> or C:\\Users\\<user>)', () => {
+	test('POSIX /home/<user>/ path is redacted to ~ in file_write entry', async () => {
+		// Use a path inside the actual home directory so redactPath can match it
+		// On POSIX: /home/<user>/... On Windows: C:\Users\<user>\...
+		const homeDir = homedir();
+		const secretPath = join(homeDir, 'documents', 'secret.txt');
+		const resolvedScope = join(homeDir, 'documents');
+
+		const entries = [
+			JSON.stringify({
+				ts: '2025-01-01T12:00:00.000Z',
+				type: 'file_write',
+				sessionID: 's1',
+				agent: 'coder',
+				tool: 'write',
+				path: secretPath,
+				reason: 'user-request',
+				resolvedScope: resolvedScope,
+			}),
+		];
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		// The actual homedir path must NOT appear raw
+		expect(result).not.toContain(join(homeDir, 'documents'));
+		// The username segment must NOT appear raw
+		const homeBasename = homeDir.split(/[/\\]/).pop() ?? '';
+		expect(result).not.toContain(homeBasename);
+		// Redacted form must appear (tilde notation); on Windows backslash, on POSIX forward slash
+		// redactPath returns ~ followed by the platform separator
+		const isWindows = process.platform === 'win32';
+		if (isWindows) {
+			// Windows: ~\<rest> — the backslash is used as separator after tilde
+			expect(result).toMatch(/~\\/);
+		} else {
+			expect(result).toMatch(/~\//);
+		}
+	});
+
+	test('scope_violation entry with home-dir path is redacted', async () => {
+		const homeDir = homedir();
+		const sshPath = join(homeDir, '.ssh', 'id_rsa');
+
+		const entries = [
+			JSON.stringify({
+				ts: '2025-01-01T12:00:00.000Z',
+				type: 'scope_violation',
+				sessionID: 's1',
+				agent: 'coder',
+				tool: 'shell',
+				path: sshPath,
+				declaredScope: 'src/',
+				resolvedScope: sshPath,
+				action: 'block',
+			}),
+		];
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		// The home directory path must NOT appear raw
+		expect(result).not.toContain(join(homeDir, '.ssh'));
+		const homeBasename = homeDir.split(/[/\\]/).pop() ?? '';
+		expect(result).not.toContain(homeBasename);
+		// Redacted form must appear (tilde notation)
+		const isWindows = process.platform === 'win32';
+		if (isWindows) {
+			expect(result).toMatch(/~\\/);
+		} else {
+			expect(result).toMatch(/~\//);
+		}
+	});
+
+	test('destructive_block command does not expose home directory names', async () => {
+		const homeDir = homedir();
+		const deletedPath = join(homeDir, 'deleted');
+
+		const entries = [
+			JSON.stringify({
+				ts: '2025-01-01T12:00:00.000Z',
+				type: 'destructive_block',
+				sessionID: 's1',
+				agent: 'coder',
+				tool: 'shell',
+				command: `rm -rf ${deletedPath}`,
+				destructiveCategory: 'recursive-delete',
+			}),
+		];
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		// The raw home path must NOT appear
+		expect(result).not.toContain(join(homeDir, 'deleted'));
+		expect(result).not.toContain(deletedPath);
+		// Home dir in the command is redacted to ~ via redactShellCommand's home-dir pre-pass.
+		// ([REDACTED] is the secret/token redactor — this command has no secret, so it produces
+		// ~ not [REDACTED]; the raw home path is gone, which is what we assert.)
+		expect(result).toContain('~');
+	});
+
+	test('non-home paths are preserved as-is (no over-redaction)', async () => {
+		// Use the temp directory path which is definitely not a home directory
+		const safePath = join(tempDir, 'test-output.txt');
+
+		const entries = [
+			JSON.stringify({
+				ts: '2025-01-01T12:00:00.000Z',
+				type: 'file_write',
+				sessionID: 's1',
+				agent: 'coder',
+				tool: 'write',
+				path: safePath,
+				reason: 'testing',
+				resolvedScope: tempDir,
+			}),
+		];
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		// The temp file path should appear (redacted form of tempDir itself, not a home dir)
+		// At minimum the filename should be present
+		expect(result).toContain('test-output.txt');
+		// The result should not mention any home directory
+		const homeBasename = homedir().split(/[/\\]/).pop() ?? '';
+		expect(result).not.toContain(homeBasename);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test: Realistic audit-log schema compliance
+// ---------------------------------------------------------------------------
+
+describe('Realistic audit-log schema: legacy shell entries (no type) vs typed entries', () => {
+	test('legacy shell entry (5 fields, no type) is parsed and returned with type label "shell"', async () => {
+		const entries = [
+			JSON.stringify({
+				ts: '2025-01-01T12:00:00.000Z',
+				sessionID: 'session-abc',
+				agent: 'architect',
+				tool: 'shell',
+				command: 'git status',
+			}),
+		];
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		// Legacy entries should be displayed as type "shell"
+		// Output format: "- [ts] shell | agent: architect | git status"
+		expect(result).toContain('shell');
+		expect(result).toContain('architect');
+		expect(result).toContain('git status');
+	});
+
+	test('typed entry with type field is displayed with its correct type discriminator', async () => {
+		const entries = [
+			JSON.stringify({
+				ts: '2025-01-01T12:00:00.000Z',
+				type: 'sandbox_skip',
+				sessionID: 'session-xyz',
+				agent: 'coder',
+				tool: 'shell',
+				command: 'echo skipped',
+				executorMechanism: 'passthrough',
+				skipReason: 'idempotent operation',
+			}),
+		];
+		await writeAuditFile(entries.join('\n') + '\n');
+
+		const result = await handleGuardrailLog(tempDir, []);
+
+		// sandbox_skip appears in full log (not blocks-only)
+		// Output format: "- [ts] sandbox_skip | agent: coder | echo skipped"
+		expect(result).toContain('sandbox_skip');
+		expect(result).toContain('coder');
+	});
+});


### PR DESCRIPTION
Closes #1274

## Summary

Adds the Guardrail Transparency Suite: a dry-run `/swarm guardrail explain`, a unified guardrail decision log with `/swarm guardrail-log`, and sandbox status in `/swarm diagnose`.

- `/swarm guardrail explain` reports allow/block, firing rule, resolved scope, and write categories without executing the command. It now fails closed on shell write parse errors and mirrors the real shell classifier for PowerShell/cmd/posix routing.
- Guardrail decision logging keeps legacy shell entries readable and adds typed records for file-write blocks, scope violations, destructive-command blocks, sandbox wraps, and sandbox skips. New advisory telemetry is fire-and-forget so audit I/O cannot delay enforcement.
- Audit persistence redacts embedded paths in `file_write.reason`, handles POSIX/macOS/Windows/UNC home-like paths, and rejects malformed typed entries before writing.
- `/swarm diagnose` uses a cached sandbox capability probe through a DI seam so sandbox status remains advisory and testable.
- Tests were hardened away from fixed sleeps toward bounded JSONL observers, and sandbox diagnose tests now use `_internals` for the PR-introduced sandbox probe/executor path.

## Invariant audit
- 1 (plugin init): not touched - no `src/index.ts` or init-path changes.
- 2 (runtime portability): touched - no new `bun:` imports or `Bun.*` runtime calls outside tests; verified with `bun run build` and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`.
- 3 (subprocesses): not touched - no new subprocess execution.
- 4 (.swarm containment): touched - guardrail audit state remains under `.swarm/session/shell-audit.jsonl`; tests use temp project roots.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched - validation used shell commands, not broad `test_runner`.
- 7 (test writing): touched - `bun:test`; temp dirs use `os.tmpdir()`/`path.join()`/`realpathSync`; PR-introduced diagnose sandbox probe/executor mocks moved to `_internals`; capture tests use bounded observers instead of fixed sleeps.
- 8 (session state): not touched.
- 9 (guardrails/retry): touched - guardrail parse-error explain now fails closed; new audit telemetry is fire-and-forget and does not change retry/circuit-breaker semantics.
- 10 (chat/system msg): not touched.
- 11 (tool registration): touched by the original PR - command registry/export surfaces already covered by existing PR tests; feedback patch did not add tools.
- 12 (release/cache): touched - updated `docs/releases/pending/guardrail-transparency-suite.md`; no release-owned version files edited.

## Test plan
- [x] `bun --smol test tests/unit/services/guardrail-explain-service.test.ts tests/unit/hooks/audit-log.test.ts tests/unit/hooks/guardrail-capture.test.ts tests/unit/services/guardrail-log-service.test.ts tests/unit/services/diagnose-sandbox.test.ts --timeout 120000` - 103 pass, 1 todo, 0 fail
- [x] `bun run typecheck`
- [x] `bunx biome ci .` - exit 0; reports one unrelated pre-existing info in `src/session/session-start-store.ts`
- [x] `git diff --check`
- [x] `bun run build`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [ ] CI cross-platform suite

## Known caveats
- `/swarm guardrail explain` still duplicates part of the destructive-command evaluator because the real evaluator is nested in the hook. This PR adds parity regressions for the feedback cases; extracting a shared evaluator remains the follow-up direction.
- Redaction is best-effort and covers the standard POSIX, macOS, Windows profile, UNC, and embedded-path cases added here. It is not a full canonical secret scrubber for arbitrary custom path layouts.
