### PR TITLE
feat(dispatch): persist full lane outputs

### DIFF
--- a/.agents/skills/codebase-review-swarm/SKILL.md
+++ b/.agents/skills/codebase-review-swarm/SKILL.md
@@ -18,6 +18,10 @@ the canonical workflow.
 - Run Phase 0 inventory first and stop for review-mode selection unless the
   user already selected tracks and explicitly authorized continuing.
 - Preserve the skill's evidence rule: no quote, no claim.
+- For dispatch lanes, treat `output` as a preview and call
+  `retrieve_lane_output` for full `output_ref` artifacts before consuming
+  ledgers, counting candidates, routing validation, or declaring coverage clean;
+  degraded or incomplete lane output is an explicit coverage limitation.
 - Use `rg`, focused file reads, targeted shell commands, and independent
   validation to close coverage units before writing the final report.
 - If the user asks for fixes after the report, start a separate implementation

--- a/.agents/skills/swarm-pr-feedback/SKILL.md
+++ b/.agents/skills/swarm-pr-feedback/SKILL.md
@@ -25,6 +25,10 @@ canonical workflow.
   PR metadata prove or disprove it.
 - Preserve original finding IDs and reviewer/critic provenance from review
   handoff artifacts.
+- For async verification lanes, treat `output` as a preview and call
+  `retrieve_lane_output` for full `output_ref` artifacts before classifying or
+  resolving feedback; degraded or incomplete lane outputs keep the affected
+  items open as evidence gaps.
 - Do not resolve GitHub review threads unless the user explicitly instructs it.
 - Load `$writing-tests` before changing tests and `$commit-pr` before pushing or
   updating the PR.

--- a/.agents/skills/swarm-pr-review/SKILL.md
+++ b/.agents/skills/swarm-pr-review/SKILL.md
@@ -31,6 +31,9 @@ canonical workflow.
 - Use the canonical deterministic lane flow: `dispatch_lanes_async` plus
   `collect_lane_results`, falling back to blocking `dispatch_lanes` only when
   async collection is unavailable.
+- When lane results include `output_ref`, call `retrieve_lane_output` and use
+  the full artifact before candidate extraction, candidate routing, or declaring
+  a lane clean; degraded or incomplete outputs are coverage gaps.
 - If actionable findings remain, write the handoff artifact described by the
   canonical skill and ask the user whether to continue with
   `swarm-pr-feedback`.

--- a/.claude/skills/codebase-review-swarm/SKILL.md
+++ b/.claude/skills/codebase-review-swarm/SKILL.md
@@ -18,4 +18,8 @@ the canonical workflow.
 - Run Phase 0 inventory first and stop for review-mode selection unless the
   user already selected tracks and explicitly authorized continuing.
 - Preserve the skill's evidence rule: no quote, no claim.
+- For dispatch lanes, treat `output` as a preview and call
+  `retrieve_lane_output` for full `output_ref` artifacts before consuming
+  ledgers, counting candidates, routing validation, or declaring coverage clean;
+  degraded or incomplete lane output is an explicit coverage limitation.
 - Use independent reviewer and critic passes before finalizing report findings.

--- a/.claude/skills/council/SKILL.md
+++ b/.claude/skills/council/SKILL.md
@@ -113,7 +113,12 @@ Do NOT share other agents' responses at this stage.
    unavailable. The `round1Responses` array will contain
    entries with `memberId` of `council_generalist`, `council_skeptic`, and
    `council_domain_expert` and `role` of `generalist`, `skeptic`, and
-   `domain_expert` respectively. These come from the agents' JSON output; no
+   `domain_expert` respectively. If any lane result has `output_ref`, call
+   `retrieve_lane_output` and parse the full artifact rather than the preview.
+   If a lane is degraded, incomplete, truncated without a usable ref, missing,
+   stale, cancelled, or failed, treat the council round as blocked or incomplete;
+   do not synthesize from partial member JSON.
+   These come from the agents' JSON output; no
    manual construction is needed.
 
 #### Synthesis and Deliberation (when council.general.deliberate is true; default true)

--- a/.claude/skills/deep-dive/SKILL.md
+++ b/.claude/skills/deep-dive/SKILL.md
@@ -75,6 +75,8 @@ Explorer missions are dispatched in parallel waves. Launch the wave promptly —
 
 At the Step 4 boundary, call `collect_lane_results` with `wait: true` for every open wave batch. Treat missing, stale, cancelled, or failed lanes as explicit coverage gaps; do not silently proceed past a required lane. If `dispatch_lanes_async` is unavailable, use blocking `dispatch_lanes` or parallel Task calls and record that async advisory lanes were unavailable.
 
+When a collected or blocking lane result includes `output_ref`, treat `output` as a preview and call `retrieve_lane_output` before extracting candidate findings or declaring a lane clean. If the result is `output_degraded`, `transcript_incomplete`, truncated without a usable ref, missing, stale, cancelled, or failed, record the lane as a coverage gap and re-dispatch a narrower lane or mark the affected findings/coverage UNVERIFIED.
+
 Explorers generate CANDIDATE FINDINGS only — they do NOT make verdicts. All findings are unverified until Step 5.
 
 ## Step 4 — Normalize Candidates

--- a/.claude/skills/deep-research/SKILL.md
+++ b/.claude/skills/deep-research/SKILL.md
@@ -128,6 +128,12 @@ that async advisory lanes were unavailable.
 
 ## Step 5 — Dual-Reviewer Claim Verification
 
+When a lane result includes `output_ref`, treat `output` as a preview and call
+`retrieve_lane_output` before extracting claims, summarizing a subtopic, or marking
+the subtopic clean. If the result is `output_degraded`, `transcript_incomplete`, or
+truncated without a usable ref, mark the affected subtopic UNVERIFIED or
+re-dispatch a narrower lane; do not treat preview absence as evidence absence.
+
 Split the candidate findings into 2 shards. Dispatch 2 parallel
 `the active swarm's reviewer agent` calls. Each reviewer receives its shard plus
 the relevant RESEARCH CONTEXT and the instruction:

--- a/.claude/skills/swarm-pr-feedback/SKILL.md
+++ b/.claude/skills/swarm-pr-feedback/SKILL.md
@@ -25,6 +25,10 @@ canonical workflow.
   PR metadata prove or disprove it.
 - Preserve original finding IDs and reviewer/critic provenance from review
   handoff artifacts.
+- For async verification lanes, treat `output` as a preview and call
+  `retrieve_lane_output` for full `output_ref` artifacts before classifying or
+  resolving feedback; degraded or incomplete lane outputs keep the affected
+  items open as evidence gaps.
 - Do not resolve GitHub review threads unless the user explicitly instructs it.
 - Use the repository commit/PR workflow before pushing or updating the PR.
 

--- a/.claude/skills/swarm-pr-review/SKILL.md
+++ b/.claude/skills/swarm-pr-review/SKILL.md
@@ -31,6 +31,9 @@ canonical workflow.
 - Use the canonical deterministic lane flow: `dispatch_lanes_async` plus
   `collect_lane_results`, falling back to blocking `dispatch_lanes` only when
   async collection is unavailable.
+- When lane results include `output_ref`, call `retrieve_lane_output` and use
+  the full artifact before candidate extraction, candidate routing, or declaring
+  a lane clean; degraded or incomplete outputs are coverage gaps.
 - If actionable findings remain, write the handoff artifact described by the
   canonical skill and ask the user whether to continue with
   `swarm-pr-feedback`.

--- a/.opencode/skills/codebase-review-swarm/references/review-protocol-v8.2.md
+++ b/.opencode/skills/codebase-review-swarm/references/review-protocol-v8.2.md
@@ -138,6 +138,8 @@ Before writing under `.swarm/`, verify `.swarm/` is ignored or locally excluded.
 
 Collect every async batch with `collect_lane_results` before consuming its ledger output or advancing to a dependent step. If `dispatch_lanes_async` or `collect_lane_results` is unavailable, fall back to blocking `dispatch_lanes`; if deterministic dispatch is unavailable, run isolated local passes and record that fallback. Do not run dependent inventory passes merely to keep agents busy. Missing dependency context is `unknown`, not guessed.
 
+For every collected or blocking lane result, treat `output` as a preview when `output_ref` is present. Call `retrieve_lane_output` and use the full artifact before consuming inventory ledgers, linking claims, deciding that a unit produced no candidates, or advancing a dependent step. If a lane is degraded, incomplete, truncated without a usable ref, missing, stale, cancelled, or failed, record the affected coverage unit as a limitation and re-dispatch a narrower lane or mark it UNVERIFIED; do not infer absence from preview text.
+
 ## Phase 0 inventory
 
 ### 0A — Bootstrap and prior context
@@ -206,6 +208,8 @@ Rules:
 ## Phase 1 — Candidate generation
 
 Every dispatch includes selected track(s), exact file list or surface IDs, source-of-truth packet, repository-context packet, relevant ledgers, the applicable `TRACK_DEPTH_PLAN`, candidate format, `out_of_scope_note` rule, and anti-cursory/non-dilution reminder. Prefer `dispatch_lanes_async` for independent candidate-generation coverage units so the Architect can continue building the review ledger, coverage map, and validation routing while lanes inspect subsystems. Call `collect_lane_results` before Phase 2 reviewer validation; no candidate may be routed, counted, or synthesized until its async batch has settled or been explicitly marked blocked/skipped.
+
+If candidate-generation lane results include `output_ref`, retrieve and parse the full artifact before candidate counting, deduplication, routing, or synthesis. Preview-only, degraded, or incomplete lane output is a coverage limitation, not negative evidence.
 
 File-size rule: no more than 15 files per deep pass; no more than 8 dense files per deep pass. Dense = >300 logical lines, multiple unrelated responsibilities, or interleaved UI/state/network/security logic. No sampling inside assigned scope. Large selections require more deep passes, not larger batches or lower depth.
 

--- a/.opencode/skills/council/SKILL.md
+++ b/.opencode/skills/council/SKILL.md
@@ -113,7 +113,12 @@ Do NOT share other agents' responses at this stage.
    unavailable. The `round1Responses` array will contain
    entries with `memberId` of `council_generalist`, `council_skeptic`, and
    `council_domain_expert` and `role` of `generalist`, `skeptic`, and
-   `domain_expert` respectively. These come from the agents' JSON output; no
+   `domain_expert` respectively. If any lane result has `output_ref`, call
+   `retrieve_lane_output` and parse the full artifact rather than the preview.
+   If a lane is degraded, incomplete, truncated without a usable ref, missing,
+   stale, cancelled, or failed, treat the council round as blocked or incomplete;
+   do not synthesize from partial member JSON.
+   These come from the agents' JSON output; no
    manual construction is needed.
 
 #### Synthesis and Deliberation (when council.general.deliberate is true; default true)

--- a/.opencode/skills/deep-dive/SKILL.md
+++ b/.opencode/skills/deep-dive/SKILL.md
@@ -75,6 +75,8 @@ Explorer missions are dispatched in parallel waves. Launch the wave promptly —
 
 At the Step 4 boundary, call `collect_lane_results` with `wait: true` for every open wave batch. Treat missing, stale, cancelled, or failed lanes as explicit coverage gaps; do not silently proceed past a required lane. If `dispatch_lanes_async` is unavailable, use blocking `dispatch_lanes` or parallel Task calls and record that async advisory lanes were unavailable.
 
+When a collected or blocking lane result includes `output_ref`, treat `output` as a preview and call `retrieve_lane_output` before extracting candidate findings or declaring a lane clean. If the result is `output_degraded`, `transcript_incomplete`, truncated without a usable ref, missing, stale, cancelled, or failed, record the lane as a coverage gap and re-dispatch a narrower lane or mark the affected findings/coverage UNVERIFIED.
+
 Explorers generate CANDIDATE FINDINGS only — they do NOT make verdicts. All findings are unverified until Step 5.
 
 ## Step 4 — Normalize Candidates

--- a/.opencode/skills/deep-research/SKILL.md
+++ b/.opencode/skills/deep-research/SKILL.md
@@ -128,6 +128,12 @@ that async advisory lanes were unavailable.
 
 ## Step 5 — Dual-Reviewer Claim Verification
 
+When a lane result includes `output_ref`, treat `output` as a preview and call
+`retrieve_lane_output` before extracting claims, summarizing a subtopic, or marking
+the subtopic clean. If the result is `output_degraded`, `transcript_incomplete`, or
+truncated without a usable ref, mark the affected subtopic UNVERIFIED or
+re-dispatch a narrower lane; do not treat preview absence as evidence absence.
+
 Split the candidate findings into 2 shards. Dispatch 2 parallel
 `the active swarm's reviewer agent` calls. Each reviewer receives its shard plus
 the relevant RESEARCH CONTEXT and the instruction:

--- a/.opencode/skills/swarm-pr-feedback/SKILL.md
+++ b/.opencode/skills/swarm-pr-feedback/SKILL.md
@@ -172,6 +172,12 @@ Missing, stale, cancelled, or failed lanes remain explicit ledger limitations.
 If `dispatch_lanes_async` is unavailable, use blocking verification and record
 that async advisory lanes were unavailable.
 
+When a verification lane result includes `output_ref`, treat `output` as a
+preview and call `retrieve_lane_output` before using it to classify, resolve,
+disprove, or group feedback items. If the result is `output_degraded`,
+`transcript_incomplete`, or truncated without a usable ref, keep the affected
+ledger items as `NEEDS_MORE_EVIDENCE` or re-dispatch a narrower read-only lane.
+
 ### CI matrix cascade check (do this before fixing)
 
 When the PR's `unit` job is a matrix across multiple OSes and downstream jobs

--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -495,6 +495,8 @@ Launch all base lanes with `dispatch_lanes_async` when available. Pass the six l
 
 Before Phase 4 or synthesis, call `collect_lane_results` with `wait: true` for the base-lane batch and treat the collected `lane_results` as the join barrier. Missing, stale, cancelled, or failed base lanes are explicit review coverage gaps. If `dispatch_lanes_async` is unavailable, use blocking `dispatch_lanes`; if that is also unavailable, simulate isolated passes. Do not let one lane's conclusions bias another lane, and record unavailable deterministic dispatch in the validation gate.
 
+When any collected or blocking `lane_results[]` item has `output_ref`, treat `output` as a preview only. Call `retrieve_lane_output` and consume the full artifact before extracting candidates, deciding that a lane produced no candidates, or routing work to reviewers. If a lane has `output_truncated: true`, `output_degraded: true`, `transcript_incomplete: true`, or no usable `output_ref`, record an explicit coverage gap and re-dispatch a narrower lane or mark affected candidates/coverage UNVERIFIED; never infer candidate absence from a preview.
+
 **lane id uniqueness for parallel dispatches:** When re-dispatching failed or re-running explorer lanes, every `dispatch_lanes_async` or `dispatch_lanes` lane `id` MUST be unique within that dispatch batch and should include lane and attempt suffixes (e.g. `pr_review_explore_lane1_attempt2`). Never reuse an id in the same batch unless intentionally replacing that exact lane before dispatch.
 
 Explorers optimize for recall. Over-reporting is expected. Explorers produce candidates only.
@@ -534,6 +536,8 @@ Explorers must not use `CONFIRMED`, `DISPROVED`, or `PRE_EXISTING`.
 ## Phase 4: Triggered Swarm Plugin Micro-Lanes
 
 After `collect_lane_results` returns for base lanes, inspect the context pack risk triggers. Launch focused micro-lanes for triggered categories only, using `dispatch_lanes_async` again when more than one read-only micro-lane is needed. Collect every micro-lane batch with `wait: true` before reviewer classification. Do not launch irrelevant micro-lanes.
+
+Apply the same `output_ref` rule to micro-lanes: retrieve full output before candidate routing, and treat degraded or incomplete lane artifacts as UNVERIFIED coverage rather than as clean negative evidence.
 
 Each micro-lane receives:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,6 +103,8 @@ Current signal-triggered modes: `DEEP_DIVE`, `PR_REVIEW`, `PR_FEEDBACK`, `DESIGN
 Current contract: PR review starts with Phase 0A signal ingestion before the explorer lanes run. The architect captures PR comments, review summaries, requested changes, bot findings, CI/check failures, merge conflicts, stale branch state, PR body claims, linked issues, and commit messages in the initial evidence ledger, then validates those signals alongside explorer findings. The workflow stays read-only, writes a handoff artifact under `.swarm/pr-review/<run_id>/`, and stops to ask whether to continue into `/swarm pr-feedback`.
 Triggered by `/swarm pr-review`. A read-only, structured review: intent reconstruction -> 6 parallel explorer lanes launched with `dispatch_lanes_async` while the architect continues non-dependent PR inspection -> `collect_lane_results` join barrier -> independent reviewer confirmation -> critic challenge on HIGH/CRITICAL -> synthesis. The architect checks out the PR branch locally before exploring (explorers read the working tree, not git history) and launches the skill's triggered micro-lanes for risk categories present in the diff. Does NOT mutate source or delegate to the coder. If async collection is unavailable, the workflow falls back to blocking `dispatch_lanes`.
 
+Dispatch lane joins return bounded previews in `lane_results[].output` and durable full-output refs in `lane_results[].output_ref`. The architect retrieves full artifacts with `retrieve_lane_output` before candidate extraction, JSON response parsing, or reviewer routing. Degraded, incomplete, stale, cancelled, failed, or preview-only lanes are explicit coverage gaps rather than negative evidence.
+
 #### PR_FEEDBACK Protocol
 Current contract: PR feedback ingests all known feedback sources plus any validated handoff artifact from `PR_REVIEW`, preserves prior IDs/provenance, and uses the broader closure statuses `CONFIRMED`, `PARTIAL`, `DISPROVED`, `PRE_EXISTING`, `NEEDS_MORE_EVIDENCE`, and `NEEDS_USER_DECISION`.
 Triggered by `/swarm pr-feedback`. Ingests and closes **known** feedback (review threads, requested changes, CI failures, conflicts, pasted notes) rather than discovering new findings. The architect checks out the PR branch, builds a complete feedback ledger, verifies every item against source (CONFIRMED / PARTIAL / DISPROVED / PRE_EXISTING / NEEDS_MORE_EVIDENCE / NEEDS_USER_DECISION), fixes confirmed items plus their tests/docs, and reports a closure ledger for every item. GitHub review threads are resolved only on explicit user instruction.
@@ -1304,6 +1306,8 @@ Registered on `experimental.session.compacting`:
 - When `.swarm/summaries/` exists and contains files:
   - Injects `[CONTEXT OPTIMIZATION]` hint: instructs LLM to replace large tool output blocks (bash, test_runner, lint, diff) with retrieve references, preserving tool name, exit status, and errors
   - Injects `[STORED OUTPUTS]` count showing how many tool outputs are stored
+- Dispatch lane artifacts are stored separately under `.swarm/lane-results/` and
+  are retrieved with `retrieve_lane_output`, not `retrieve_summary`.
 - Guides OpenCode's built-in compaction to preserve swarm-relevant context
 
 ### System Prompt Enhancement

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -165,7 +165,7 @@ Launch a structured deep PR review using multi-lane parallel analysis with indep
 4. **Critic Challenge** â€” Adversarial review of HIGH/CRITICAL findings only
 5. **Synthesis** â€” Obligation assessment, findings table, merge recommendation
 
-The architect checks out the PR branch locally before launching explorers, ingests the existing feedback surfaces into the initial ledger, and runs the skill's triggered micro-lanes automatically. OpenCode uses `dispatch_lanes_async` plus `collect_lane_results` for read-only lane fan-out so local models do not need to emit background Agent calls by hand; if async collection is unavailable, the workflow falls back to blocking `dispatch_lanes`. When the review ends with actionable findings, it writes a handoff artifact under `.swarm/pr-review/<run_id>/` and stops to ask whether to continue into `/swarm pr-feedback`.
+The architect checks out the PR branch locally before launching explorers, ingests the existing feedback surfaces into the initial ledger, and runs the skill's triggered micro-lanes automatically. OpenCode uses `dispatch_lanes_async` plus `collect_lane_results` for read-only lane fan-out so local models do not need to emit background Agent calls by hand; if async collection is unavailable, the workflow falls back to blocking `dispatch_lanes`. Lane results expose bounded `output` previews plus `output_ref` for full artifact retrieval; the review protocol retrieves `output_ref` before candidate extraction or routing. When the review ends with actionable findings, it writes a handoff artifact under `.swarm/pr-review/<run_id>/` and stops to ask whether to continue into `/swarm pr-feedback`.
 
 **Council variant** (`--council`): After standard review, convene a General Council to evaluate review quality and hunt for blind spots. Council findings are supplementary.
 
@@ -511,6 +511,11 @@ Show performance metrics: tool call rates, delegation chains, evidence pass rate
 ### `/swarm retrieve <summary-id>`
 
 Load the full tool output that was previously summarized (IDs like `S1`, `S2`). Use when the summary is insufficient and you need the raw data.
+
+Dispatch lane output uses separate opaque `output_ref` values returned by
+`dispatch_lanes`, `dispatch_lanes_async`, and `collect_lane_results`. Agents with
+access use `retrieve_lane_output` to page through those full lane artifacts; `/swarm
+retrieve` remains for summary IDs only.
 
 ---
 

--- a/docs/releases/pending/durable-lane-output.md
+++ b/docs/releases/pending/durable-lane-output.md
@@ -6,8 +6,23 @@ under `.swarm/lane-results/`. Architects can page full lane output with
 `retrieve_lane_output` before candidate extraction, JSON parsing, or reviewer
 routing, so long-running lanes are no longer limited by the result preview.
 
+`output_ref` is present when the artifact was stored successfully. In degraded
+cases — lane output exceeds the 10 MB per-artifact storage limit, or a write
+failure occurred — `output_ref` is absent and `output_degraded: true` is set
+instead. Callers should check `output_degraded` and `transcript_incomplete` as
+coverage gap signals.
+
 Migration: no configuration change required. Existing callers can keep reading
 `output`; workflows that need complete lane evidence should use `output_ref` and
 handle `output_degraded` or `transcript_incomplete` as coverage gaps.
 
 Breaking changes: none.
+
+Behavioral changes for operators with custom `exempt_tools` configuration:
+- `retrieve_lane_output` is added to the `exempt_tools` default list in
+  `src/config/schema.ts`. Operators who override `exempt_tools` with a full
+  replacement (not an extension) will need to add `retrieve_lane_output`
+  manually to preserve the exemption.
+- `retrieve_lane_output` is exempt from context-budget masking so paged
+  artifacts remain visible in the architect's context window.
+- `retrieve_lane_output` is added to `PROBED_TOOLS` for input-probe telemetry.

--- a/docs/releases/pending/durable-lane-output.md
+++ b/docs/releases/pending/durable-lane-output.md
@@ -1,0 +1,13 @@
+Add durable full-output artifacts for dispatch lane results.
+
+`dispatch_lanes`, `dispatch_lanes_async`, and `collect_lane_results` now return
+bounded previews plus `output_ref` provenance for full lane transcripts stored
+under `.swarm/lane-results/`. Architects can page full lane output with
+`retrieve_lane_output` before candidate extraction, JSON parsing, or reviewer
+routing, so long-running lanes are no longer limited by the result preview.
+
+Migration: no configuration change required. Existing callers can keep reading
+`output`; workflows that need complete lane evidence should use `output_ref` and
+handle `output_degraded` or `transcript_incomplete` as coverage gaps.
+
+Breaking changes: none.

--- a/docs/troubleshooting/recovery-guide.md
+++ b/docs/troubleshooting/recovery-guide.md
@@ -156,6 +156,14 @@ session when the tool context supplies one. If a batch was launched in a
 different session, collect it from that parent session, or relaunch the advisory
 lanes in the current session.
 
+**Preview or truncated output:** `dispatch_lanes`, `dispatch_lanes_async`, and
+`collect_lane_results` return bounded `output` previews. When a lane result has
+`output_ref`, recover the full text with `retrieve_lane_output` before parsing
+findings, candidates, JSON member responses, or verification conclusions. If a
+lane result is `output_degraded`, `transcript_incomplete`, truncated without a
+usable ref, stale, cancelled, or failed, treat it as missing advisory evidence and
+re-dispatch a narrower lane or mark the affected coverage UNVERIFIED.
+
 ## 9. Recovering from Background Stage B Gate Batches
 
 When `hooks.background_subagents: true` is enabled, native background `Task`

--- a/src/background/lane-output-store.ts
+++ b/src/background/lane-output-store.ts
@@ -166,9 +166,14 @@ export function readLaneOutput(
 	if (!REF_RE.test(ref)) return null;
 	const absPath = validateSwarmPath(directory, laneOutputRelativePath(ref));
 	if (!existsSync(absPath)) return null;
-	const parsed = LaneOutputArtifactSchema.safeParse(
-		JSON.parse(readFileSync(absPath, 'utf-8')),
-	);
+	let parsed: ReturnType<typeof LaneOutputArtifactSchema.safeParse>;
+	try {
+		parsed = LaneOutputArtifactSchema.safeParse(
+			JSON.parse(readFileSync(absPath, 'utf-8')),
+		);
+	} catch {
+		return null;
+	}
 	if (!parsed.success || parsed.data.ref !== ref) return null;
 	return { artifact: parsed.data };
 }

--- a/src/background/lane-output-store.ts
+++ b/src/background/lane-output-store.ts
@@ -269,12 +269,27 @@ function laneOutputRelativePath(ref: string): string {
 	);
 }
 
+// Windows can briefly hold a file handle after close; retry on transient errors.
+const WINDOWS_RENAME_MAX_RETRIES = 3;
+
 function writeAtomicJson(absPath: string, value: unknown): void {
 	mkdirSync(path.dirname(absPath), { recursive: true });
 	const tempFile = `${absPath}.tmp-${Date.now()}-${process.pid}`;
 	try {
 		writeFileSync(tempFile, JSON.stringify(value, null, 2), 'utf-8');
-		renameSync(tempFile, absPath);
+		let lastRenameError: unknown;
+		for (let attempt = 0; attempt < WINDOWS_RENAME_MAX_RETRIES; attempt++) {
+			try {
+				renameSync(tempFile, absPath);
+				lastRenameError = undefined;
+				break;
+			} catch (err) {
+				lastRenameError = err;
+				const code = (err as NodeJS.ErrnoException).code;
+				if (code !== 'EEXIST' && code !== 'EBUSY' && code !== 'EPERM') break;
+			}
+		}
+		if (lastRenameError) throw lastRenameError;
 	} finally {
 		if (existsSync(tempFile)) {
 			try {

--- a/src/background/lane-output-store.ts
+++ b/src/background/lane-output-store.ts
@@ -1,0 +1,291 @@
+import { createHash } from 'node:crypto';
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	unlinkSync,
+	writeFileSync,
+} from 'node:fs';
+import * as path from 'node:path';
+import { z } from 'zod';
+import { validateSwarmPath } from '../hooks/utils';
+
+export const LANE_OUTPUT_REF_PREFIX = 'L1';
+export const MAX_LANE_OUTPUT_STORED_BYTES = 10 * 1024 * 1024;
+const LANE_OUTPUT_SCHEMA_VERSION = 1;
+const REF_RE = /^L1:[a-f0-9]{64}:[a-f0-9]{64}:[a-f0-9]{64}$/;
+
+const LaneOutputArtifactSchema = z
+	.object({
+		schemaVersion: z.literal(LANE_OUTPUT_SCHEMA_VERSION),
+		ref: z.string().regex(REF_RE),
+		batchId: z.string().min(1),
+		laneId: z.string().min(1),
+		agent: z.string().min(1),
+		role: z.string().min(1),
+		sessionId: z.string().min(1).optional(),
+		parentSessionId: z.string().min(1).optional(),
+		mode: z.string().min(1).optional(),
+		source: z.enum(['dispatch_lanes', 'collect_lane_results']),
+		text: z.string(),
+		chars: z.number().int().nonnegative(),
+		bytes: z.number().int().nonnegative(),
+		digest: z.string().regex(/^[a-f0-9]{64}$/),
+		messageCount: z.number().int().nonnegative().optional(),
+		transcriptIncomplete: z.boolean().optional(),
+		createdAt: z.string(),
+		updatedAt: z.string(),
+	})
+	.strict();
+
+export type LaneOutputSource = z.infer<
+	typeof LaneOutputArtifactSchema
+>['source'];
+export type LaneOutputArtifact = z.infer<typeof LaneOutputArtifactSchema>;
+
+export interface StoreLaneOutputInput {
+	batchId: string;
+	laneId: string;
+	agent: string;
+	role: string;
+	sessionId?: string;
+	parentSessionId?: string;
+	mode?: string;
+	source: LaneOutputSource;
+	text: string;
+	messageCount?: number;
+	transcriptIncomplete?: boolean;
+}
+
+export interface StoreLaneOutputResult {
+	ref?: string;
+	digest: string;
+	chars: number;
+	bytes: number;
+	degraded: boolean;
+	error?: string;
+}
+
+export interface ReadLaneOutputResult {
+	artifact: LaneOutputArtifact;
+}
+
+export function storeLaneOutput(
+	directory: string,
+	input: StoreLaneOutputInput,
+	now: () => number = Date.now,
+): StoreLaneOutputResult {
+	const bytes = Buffer.byteLength(input.text, 'utf-8');
+	const digest = digestText(input.text);
+	if (bytes > MAX_LANE_OUTPUT_STORED_BYTES) {
+		return {
+			digest,
+			chars: input.text.length,
+			bytes,
+			degraded: true,
+			error: `lane output exceeds ${MAX_LANE_OUTPUT_STORED_BYTES} byte storage limit`,
+		};
+	}
+
+	const batchDigest = digestText(input.batchId);
+	const laneDigest = digestText(input.laneId);
+	const ref = `${LANE_OUTPUT_REF_PREFIX}:${batchDigest}:${laneDigest}:${digest}`;
+	const relPath = laneOutputRelativePath(ref);
+	const absPath = validateSwarmPath(directory, relPath);
+	const timestamp = new Date(now()).toISOString();
+
+	try {
+		if (existsSync(absPath)) {
+			const existing = LaneOutputArtifactSchema.safeParse(
+				JSON.parse(readFileSync(absPath, 'utf-8')),
+			);
+			if (existing.success && existing.data.digest === digest) {
+				return {
+					ref,
+					digest,
+					chars: existing.data.chars,
+					bytes: existing.data.bytes,
+					degraded: false,
+				};
+			}
+		}
+
+		const artifact: LaneOutputArtifact = {
+			schemaVersion: LANE_OUTPUT_SCHEMA_VERSION,
+			ref,
+			batchId: input.batchId,
+			laneId: input.laneId,
+			agent: input.agent,
+			role: input.role,
+			...(input.sessionId ? { sessionId: input.sessionId } : {}),
+			...(input.parentSessionId
+				? { parentSessionId: input.parentSessionId }
+				: {}),
+			...(input.mode ? { mode: input.mode } : {}),
+			source: input.source,
+			text: input.text,
+			chars: input.text.length,
+			bytes,
+			digest,
+			...(input.messageCount !== undefined
+				? { messageCount: input.messageCount }
+				: {}),
+			...(input.transcriptIncomplete !== undefined
+				? { transcriptIncomplete: input.transcriptIncomplete }
+				: {}),
+			createdAt: timestamp,
+			updatedAt: timestamp,
+		};
+		writeAtomicJson(absPath, artifact);
+		return {
+			ref,
+			digest,
+			chars: artifact.chars,
+			bytes: artifact.bytes,
+			degraded: false,
+		};
+	} catch (error) {
+		return {
+			digest,
+			chars: input.text.length,
+			bytes,
+			degraded: true,
+			error:
+				error instanceof Error
+					? error.message
+					: 'failed to store lane output artifact',
+		};
+	}
+}
+
+export function readLaneOutput(
+	directory: string,
+	ref: string,
+): ReadLaneOutputResult | null {
+	if (!REF_RE.test(ref)) return null;
+	const absPath = validateSwarmPath(directory, laneOutputRelativePath(ref));
+	if (!existsSync(absPath)) return null;
+	const parsed = LaneOutputArtifactSchema.safeParse(
+		JSON.parse(readFileSync(absPath, 'utf-8')),
+	);
+	if (!parsed.success || parsed.data.ref !== ref) return null;
+	return { artifact: parsed.data };
+}
+
+export function buildLaneOutputPreview(args: {
+	text: string;
+	ref?: string;
+	degraded?: boolean;
+	maxChars: number;
+}): { output: string; output_chars: number; output_truncated: boolean } {
+	const { text, ref, degraded, maxChars } = args;
+	const needsPreview = text.length > maxChars;
+	if (!needsPreview && !degraded) {
+		return {
+			output: text,
+			output_chars: text.length,
+			output_truncated: false,
+		};
+	}
+
+	const marker = buildPreviewMarker({
+		omittedChars: Math.max(0, text.length - maxChars),
+		ref,
+		degraded: degraded === true,
+	});
+	if (text.length <= maxChars && degraded) {
+		return {
+			output: `${text}${marker}`,
+			output_chars: text.length,
+			output_truncated: false,
+		};
+	}
+
+	const budget = Math.max(0, maxChars - marker.length);
+	const headChars = Math.ceil(budget / 2);
+	const tailChars = Math.floor(budget / 2);
+	const head = text.slice(0, headChars);
+	const tail = tailChars > 0 ? text.slice(text.length - tailChars) : '';
+	return {
+		output: `${head}${marker}${tail}`,
+		output_chars: text.length,
+		output_truncated: true,
+	};
+}
+
+export function paginateLaneOutput(
+	text: string,
+	offset: number,
+	limit: number,
+): {
+	totalLines: number;
+	startLine: number;
+	endLine: number;
+	content: string;
+	exhausted: boolean;
+} {
+	const lines = text.length === 0 ? [] : text.split('\n');
+	const totalLines = lines.length;
+	const startLine = Math.max(0, offset);
+	if (startLine >= totalLines) {
+		return {
+			totalLines,
+			startLine,
+			endLine: totalLines,
+			content: '',
+			exhausted: true,
+		};
+	}
+	const endLine = Math.min(startLine + limit, totalLines);
+	return {
+		totalLines,
+		startLine,
+		endLine,
+		content: lines.slice(startLine, endLine).join('\n'),
+		exhausted: false,
+	};
+}
+
+function buildPreviewMarker(args: {
+	omittedChars: number;
+	ref?: string;
+	degraded: boolean;
+}): string {
+	const retrieval = args.ref
+		? ` retrieve_lane_output ref=${args.ref} for full output.`
+		: ' no full output artifact is available; treat this lane as degraded.';
+	const degraded = args.degraded ? ' Artifact storage degraded.' : '';
+	return `\n[... lane output preview omitted middle content.${degraded}${retrieval} ...]\n`;
+}
+
+function laneOutputRelativePath(ref: string): string {
+	const [, batchDigest, laneDigest, outputDigest] = ref.split(':');
+	return path.join(
+		'lane-results',
+		batchDigest,
+		laneDigest,
+		`${outputDigest}.json`,
+	);
+}
+
+function writeAtomicJson(absPath: string, value: unknown): void {
+	mkdirSync(path.dirname(absPath), { recursive: true });
+	const tempFile = `${absPath}.tmp-${Date.now()}-${process.pid}`;
+	try {
+		writeFileSync(tempFile, JSON.stringify(value, null, 2), 'utf-8');
+		renameSync(tempFile, absPath);
+	} finally {
+		if (existsSync(tempFile)) {
+			try {
+				unlinkSync(tempFile);
+			} catch {
+				/* best-effort cleanup */
+			}
+		}
+	}
+}
+
+function digestText(text: string): string {
+	return createHash('sha256').update(text).digest('hex');
+}

--- a/src/background/pending-delegations.ts
+++ b/src/background/pending-delegations.ts
@@ -106,6 +106,12 @@ export interface BackgroundDelegationResult {
 	chars: number;
 	truncated: boolean;
 	digest: string;
+	outputRef?: string;
+	outputPreviewChars?: number;
+	outputDegraded?: boolean;
+	outputArtifactError?: string;
+	transcriptIncomplete?: boolean;
+	messageCount?: number;
 }
 
 const ResultSchema = z
@@ -115,6 +121,12 @@ const ResultSchema = z
 		chars: z.number(),
 		truncated: z.boolean(),
 		digest: z.string(),
+		outputRef: z.string().optional(),
+		outputPreviewChars: z.number().optional(),
+		outputDegraded: z.boolean().optional(),
+		outputArtifactError: z.string().optional(),
+		transcriptIncomplete: z.boolean().optional(),
+		messageCount: z.number().optional(),
 	})
 	.strict();
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -421,7 +421,7 @@ export const SummaryConfigSchema = z.object({
 	retention_days: z.number().min(1).max(365).default(7),
 	exempt_tools: z
 		.array(z.string())
-		.default(['retrieve_summary', 'task', 'read']),
+		.default(['retrieve_summary', 'retrieve_lane_output', 'task', 'read']),
 });
 
 export type SummaryConfig = z.infer<typeof SummaryConfigSchema>;

--- a/src/hooks/context-budget.ts
+++ b/src/hooks/context-budget.ts
@@ -436,6 +436,8 @@ function shouldMaskToolOutput(
 	}
 
 	// Exempt retrieval tools and small read/task outputs.
+	// - retrieve_lane_output / retrieve_summary: paged artifacts must stay visible so the
+	//   architect can page through them; masking defeats the delivery mechanism.
 	// - task: results are already summarized by the agent that created the task call
 	// Check structured tool name first (reliable); fall back to text heuristic for
 	// legacy tool result formats that may not carry toolName in msg.info.

--- a/src/hooks/context-budget.ts
+++ b/src/hooks/context-budget.ts
@@ -437,13 +437,23 @@ function shouldMaskToolOutput(
 
 	// Exempt retrieval tools and small read/task outputs.
 	// - task: results are already summarized by the agent that created the task call
-	const toolName = extractToolName(text);
+	// Check structured tool name first (reliable); fall back to text heuristic for
+	// legacy tool result formats that may not carry toolName in msg.info.
+	const structuredToolName = msg.info.toolName as string | undefined;
+	const exemptList = [
+		'retrieve_summary',
+		'retrieve_lane_output',
+		'task',
+		'read',
+	];
 	if (
-		toolName &&
-		['retrieve_summary', 'retrieve_lane_output', 'task', 'read'].includes(
-			toolName.toLowerCase(),
-		)
+		structuredToolName &&
+		exemptList.includes(structuredToolName.toLowerCase())
 	) {
+		return false;
+	}
+	const toolName = extractToolName(text);
+	if (toolName && exemptList.includes(toolName.toLowerCase())) {
 		return false;
 	}
 

--- a/src/hooks/context-budget.ts
+++ b/src/hooks/context-budget.ts
@@ -435,13 +435,14 @@ function shouldMaskToolOutput(
 		return false;
 	}
 
-	// Exempt tools: retrieve_summary, task
-	// - retrieve_summary: already a summary, no value to mask
+	// Exempt retrieval tools and small read/task outputs.
 	// - task: results are already summarized by the agent that created the task call
 	const toolName = extractToolName(text);
 	if (
 		toolName &&
-		['retrieve_summary', 'task', 'read'].includes(toolName.toLowerCase())
+		['retrieve_summary', 'retrieve_lane_output', 'task', 'read'].includes(
+			toolName.toLowerCase(),
+		)
 	) {
 		return false;
 	}

--- a/src/hooks/full-auto-input-probe.ts
+++ b/src/hooks/full-auto-input-probe.ts
@@ -33,6 +33,7 @@ const PROBED_TOOLS = new Set<string>([
 	'gitingest',
 	'extract_code_blocks',
 	'retrieve_summary',
+	'retrieve_lane_output',
 	'search',
 	'read',
 	'view',

--- a/src/hooks/tool-summarizer.ts
+++ b/src/hooks/tool-summarizer.ts
@@ -50,6 +50,7 @@ export function createToolSummarizerHook(
 		// creates a retrieval loop where the summary itself gets summarized.
 		const exemptTools = config.exempt_tools ?? [
 			'retrieve_summary',
+			'retrieve_lane_output',
 			'task',
 			'read',
 		];

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -877,6 +877,9 @@ function extractAssistantTranscript(
 	return {
 		text: assistantTexts.join('\n\n'),
 		messageCount: assistantTexts.length,
+		// Total message count (not just assistant) is the correct signal: the API
+		// limit is applied to all message types, so hitting it means there may be
+		// earlier messages of any role — including assistant — that were not fetched.
 		transcriptIncomplete: messages.length >= ASYNC_MESSAGE_FETCH_LIMIT,
 	};
 }

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -2,6 +2,10 @@ import { createHash } from 'node:crypto';
 import pLimit from 'p-limit';
 import { z } from 'zod';
 import {
+	buildLaneOutputPreview,
+	storeLaneOutput,
+} from '../background/lane-output-store.js';
+import {
 	appendDelegationTransition,
 	type BackgroundDelegationRecord,
 	findByBatchId,
@@ -24,6 +28,7 @@ const COMMON_PROMPT_SEPARATOR = '\n\n';
 const DEFAULT_TIMEOUT_MS = 300_000;
 const MAX_TIMEOUT_MS = 1_800_000;
 const MAX_LANE_OUTPUT_CHARS = 20_000;
+const ASYNC_MESSAGE_FETCH_LIMIT = 50;
 const MAX_ERROR_CHARS = 200;
 const ERROR_TRUNCATION_SUFFIX = '...';
 const MAX_BATCH_ID_CHARS = 120;
@@ -205,6 +210,13 @@ export interface DispatchLaneResult {
 	output?: string;
 	output_chars?: number;
 	output_truncated?: boolean;
+	output_ref?: string;
+	output_digest?: string;
+	output_preview_chars?: number;
+	output_degraded?: boolean;
+	output_artifact_error?: string;
+	transcript_incomplete?: boolean;
+	message_count?: number;
 	error?: string;
 }
 
@@ -312,7 +324,7 @@ export const _internals: {
 
 export const _test_exports = {
 	applyCommonPrompt,
-	extractLastAssistantText,
+	extractAssistantTranscript,
 	formatError,
 	nextCollectPollInterval,
 	promptHash,
@@ -804,40 +816,69 @@ async function collectOnce(
 		try {
 			messages = await session.messages!({
 				path: { id: record.subagentSessionId },
-				query: { directory, limit: 50 },
+				query: { directory, limit: ASYNC_MESSAGE_FETCH_LIMIT },
 			});
 		} catch {
 			continue;
 		}
 		if (!messages.data) continue;
-		const text = extractLastAssistantText(messages.data);
-		if (!text) continue;
-		const bounded = boundLaneOutput(text);
+		const transcript = extractAssistantTranscript(messages.data);
+		if (!transcript.text) continue;
+		const output = prepareLaneOutput({
+			directory,
+			batchId: record.batchId ?? record.callID,
+			laneId: record.laneId ?? record.correlationId,
+			agent: record.swarmPrefixedAgent,
+			role: record.normalizedAgent,
+			sessionId: record.subagentSessionId,
+			parentSessionId: record.parentSessionId,
+			mode: record.mode,
+			source: 'collect_lane_results',
+			text: transcript.text,
+			messageCount: transcript.messageCount,
+			transcriptIncomplete: transcript.transcriptIncomplete,
+		});
 		await appendDelegationTransition(directory, record.correlationId, {
 			status: 'completed',
 			result: {
-				text: bounded.output,
-				chars: bounded.output_chars,
-				truncated: bounded.output_truncated,
-				digest: digestText(text),
+				text: output.output,
+				chars: output.output_chars,
+				truncated: output.output_truncated,
+				digest: output.output_digest,
+				...(output.output_ref ? { outputRef: output.output_ref } : {}),
+				outputPreviewChars: output.output.length,
+				...(output.output_degraded !== undefined
+					? { outputDegraded: output.output_degraded }
+					: {}),
+				...(output.output_artifact_error
+					? { outputArtifactError: output.output_artifact_error }
+					: {}),
+				...(output.transcript_incomplete !== undefined
+					? { transcriptIncomplete: output.transcript_incomplete }
+					: {}),
+				messageCount: transcript.messageCount,
 			},
 		});
 	}
 }
 
-function extractLastAssistantText(
+function extractAssistantTranscript(
 	messages: Array<{
 		info?: { role?: string };
 		parts?: Array<{ type: string; text?: string }>;
 	}>,
-): string {
-	for (let i = messages.length - 1; i >= 0; i--) {
-		const message = messages[i];
+): { text: string; messageCount: number; transcriptIncomplete: boolean } {
+	const assistantTexts: string[] = [];
+	for (const message of messages) {
 		if (message.info?.role !== 'assistant') continue;
 		const text = extractText(message.parts);
-		if (text.trim().length > 0) return text;
+		if (text.trim().length > 0) assistantTexts.push(text);
 	}
-	return '';
+	return {
+		text: assistantTexts.join('\n\n'),
+		messageCount: assistantTexts.length,
+		transcriptIncomplete: messages.length >= ASYNC_MESSAGE_FETCH_LIMIT,
+	};
 }
 
 function nextCollectPollInterval(currentMs: number): number {
@@ -942,7 +983,17 @@ async function runLane(
 			);
 		}
 
-		const boundedOutput = boundLaneOutput(extractText(promptResult.data.parts));
+		const laneOutput = prepareLaneOutput({
+			directory,
+			batchId: `blocking:${sessionId}`,
+			laneId: lane.id,
+			agent: lane.agent,
+			role,
+			sessionId,
+			parentSessionId: context.sessionID,
+			source: 'dispatch_lanes',
+			text: extractText(promptResult.data.parts),
+		});
 		return {
 			id: lane.id,
 			agent: lane.agent,
@@ -953,7 +1004,7 @@ async function runLane(
 			run_id: decision.slot.runId,
 			started_at: startedAt,
 			completed_at: isoNow(),
-			...boundedOutput,
+			...laneOutput,
 		};
 	} catch (error) {
 		return failedLane(
@@ -1062,6 +1113,25 @@ function recordToLaneResult(
 					output: record.result.text,
 					output_chars: record.result.chars,
 					output_truncated: record.result.truncated,
+					output_digest: record.result.digest,
+					...(record.result.outputRef
+						? { output_ref: record.result.outputRef }
+						: {}),
+					...(record.result.outputPreviewChars !== undefined
+						? { output_preview_chars: record.result.outputPreviewChars }
+						: {}),
+					...(record.result.outputDegraded !== undefined
+						? { output_degraded: record.result.outputDegraded }
+						: {}),
+					...(record.result.outputArtifactError
+						? { output_artifact_error: record.result.outputArtifactError }
+						: {}),
+					...(record.result.transcriptIncomplete !== undefined
+						? { transcript_incomplete: record.result.transcriptIncomplete }
+						: {}),
+					...(record.result.messageCount !== undefined
+						? { message_count: record.result.messageCount }
+						: {}),
 				}
 			: {}),
 		...(record.result?.error !== undefined
@@ -1165,25 +1235,63 @@ function buildReadOnlyTools(): ReadOnlyToolPermissions {
 	return tools as ReadOnlyToolPermissions;
 }
 
-function boundLaneOutput(output: string): {
+function prepareLaneOutput(args: {
+	directory: string;
+	batchId: string;
+	laneId: string;
+	agent: string;
+	role: string;
+	sessionId?: string;
+	parentSessionId?: string;
+	mode?: string;
+	source: 'dispatch_lanes' | 'collect_lane_results';
+	text: string;
+	messageCount?: number;
+	transcriptIncomplete?: boolean;
+}): {
 	output: string;
 	output_chars: number;
 	output_truncated: boolean;
+	output_ref?: string;
+	output_digest: string;
+	output_preview_chars: number;
+	output_degraded?: boolean;
+	output_artifact_error?: string;
+	transcript_incomplete?: boolean;
+	message_count?: number;
 } {
-	if (output.length <= MAX_LANE_OUTPUT_CHARS) {
-		return {
-			output,
-			output_chars: output.length,
-			output_truncated: false,
-		};
-	}
-	const omitted = output.length - MAX_LANE_OUTPUT_CHARS;
-	const suffix = `\n[... ${omitted} chars truncated by dispatch_lanes ...]`;
-	const maxContent = Math.max(0, MAX_LANE_OUTPUT_CHARS - suffix.length);
+	const stored = storeLaneOutput(args.directory, {
+		batchId: args.batchId,
+		laneId: args.laneId,
+		agent: args.agent,
+		role: args.role,
+		sessionId: args.sessionId,
+		parentSessionId: args.parentSessionId,
+		mode: args.mode,
+		source: args.source,
+		text: args.text,
+		messageCount: args.messageCount,
+		transcriptIncomplete: args.transcriptIncomplete,
+	});
+	const preview = buildLaneOutputPreview({
+		text: args.text,
+		ref: stored.ref,
+		degraded: stored.degraded,
+		maxChars: MAX_LANE_OUTPUT_CHARS,
+	});
 	return {
-		output: `${output.slice(0, maxContent)}${suffix}`,
-		output_chars: output.length,
-		output_truncated: true,
+		...preview,
+		output_ref: stored.ref,
+		output_digest: stored.digest,
+		output_preview_chars: preview.output.length,
+		...(stored.degraded ? { output_degraded: true } : {}),
+		...(stored.error ? { output_artifact_error: stored.error } : {}),
+		...(args.transcriptIncomplete !== undefined
+			? { transcript_incomplete: args.transcriptIncomplete }
+			: {}),
+		...(args.messageCount !== undefined
+			? { message_count: args.messageCount }
+			: {}),
 	};
 }
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -83,6 +83,7 @@ export {
 } from './repo-graph';
 export { repo_map } from './repo-map';
 export { req_coverage } from './req-coverage';
+export { retrieve_lane_output } from './retrieve-lane-output';
 export { retrieve_summary } from './retrieve-summary';
 export {
 	type SastScanFinding,

--- a/src/tools/manifest.ts
+++ b/src/tools/manifest.ts
@@ -82,6 +82,7 @@ import { pre_check_batch } from './pre-check-batch';
 import { quality_budget } from './quality-budget';
 import { repo_map } from './repo-map';
 import { req_coverage } from './req-coverage';
+import { retrieve_lane_output } from './retrieve-lane-output';
 import { retrieve_summary } from './retrieve-summary';
 import { sast_scan } from './sast-scan';
 import { save_plan } from './save-plan';
@@ -167,6 +168,7 @@ export const TOOL_MANIFEST = defineHandlers({
 	git_blame: () => git_blame,
 	gitingest: () => gitingest,
 	retrieve_summary: () => retrieve_summary,
+	retrieve_lane_output: () => retrieve_lane_output,
 	extract_code_blocks: () => extract_code_blocks,
 	phase_complete: () => phase_complete,
 	save_plan: () => save_plan,

--- a/src/tools/retrieve-lane-output.ts
+++ b/src/tools/retrieve-lane-output.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod';
+import {
+	paginateLaneOutput,
+	readLaneOutput,
+} from '../background/lane-output-store';
+import { createSwarmTool } from './create-tool';
+
+const RetrieveLaneOutputArgsSchema = z.object({
+	ref: z
+		.string()
+		.min(1)
+		.describe(
+			'Opaque lane output ref returned as output_ref by dispatch tools.',
+		),
+	offset: z
+		.number()
+		.int()
+		.min(0)
+		.default(0)
+		.describe('Line offset to start from.'),
+	limit: z
+		.number()
+		.int()
+		.min(1)
+		.max(500)
+		.default(100)
+		.describe('Number of lines to return, max 500.'),
+});
+
+export const retrieve_lane_output: ReturnType<typeof createSwarmTool> =
+	createSwarmTool({
+		description:
+			'Retrieve paged full output for a dispatch_lanes or collect_lane_results lane by output_ref. Use when a lane preview is truncated, degraded, or needs candidate routing from full text.',
+		args: {
+			ref: RetrieveLaneOutputArgsSchema.shape.ref,
+			offset: RetrieveLaneOutputArgsSchema.shape.offset,
+			limit: RetrieveLaneOutputArgsSchema.shape.limit,
+		},
+		async execute(args: unknown, directory: string): Promise<string> {
+			const parsed = RetrieveLaneOutputArgsSchema.safeParse(args);
+			if (!parsed.success) {
+				return JSON.stringify(
+					{
+						success: false,
+						failure_class: 'invalid_args',
+						message: 'Invalid retrieve_lane_output arguments',
+						errors: parsed.error.issues.map(
+							(issue) => `${issue.path.join('.')}: ${issue.message}`,
+						),
+					},
+					null,
+					2,
+				);
+			}
+
+			let loaded: ReturnType<typeof readLaneOutput>;
+			try {
+				loaded = readLaneOutput(directory, parsed.data.ref);
+			} catch {
+				loaded = null;
+			}
+			if (!loaded) {
+				return JSON.stringify(
+					{
+						success: false,
+						failure_class: 'not_found',
+						message: `No lane output artifact found for ${parsed.data.ref}`,
+					},
+					null,
+					2,
+				);
+			}
+
+			const page = paginateLaneOutput(
+				loaded.artifact.text,
+				parsed.data.offset,
+				Math.min(parsed.data.limit, 500),
+			);
+			if (page.exhausted) {
+				return (
+					`--- Lane output ${loaded.artifact.ref} offset beyond range ---\n` +
+					`Lane: ${loaded.artifact.laneId} (${loaded.artifact.agent})\n` +
+					`Digest: ${loaded.artifact.digest}\n` +
+					`Content has ${page.totalLines} line${page.totalLines === 1 ? '' : 's'}.`
+				);
+			}
+
+			const header =
+				`--- Lane output ${loaded.artifact.ref} lines ${page.startLine + 1}-${page.endLine} of ${page.totalLines} ---\n` +
+				`Batch: ${loaded.artifact.batchId}\n` +
+				`Lane: ${loaded.artifact.laneId}\n` +
+				`Agent: ${loaded.artifact.agent}\n` +
+				`Source: ${loaded.artifact.source}\n` +
+				`Digest: ${loaded.artifact.digest}\n` +
+				`Chars: ${loaded.artifact.chars}\n` +
+				(loaded.artifact.transcriptIncomplete
+					? 'Warning: transcript may be incomplete because the session message fetch hit its limit.\n'
+					: '');
+			let response = `${header}\n${page.content}`;
+			if (page.endLine < page.totalLines) {
+				const remaining = page.totalLines - page.endLine;
+				response += `\n\n... ${remaining} more line${remaining === 1 ? '' : 's'}. Use offset=${page.endLine} to retrieve more.`;
+			}
+			return response;
+		},
+	});

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -257,6 +257,11 @@ export const TOOL_METADATA = {
 			'test_engineer',
 		],
 	},
+	retrieve_lane_output: {
+		description:
+			'retrieve paged full dispatch lane output by output_ref; use before consuming truncated lane previews or routing candidates from lane results',
+		agents: ['architect'],
+	},
 	extract_code_blocks: {
 		description: 'extract code blocks from text content and save them to files',
 		agents: [

--- a/tests/unit/background/lane-output-store.test.ts
+++ b/tests/unit/background/lane-output-store.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+	buildLaneOutputPreview,
+	MAX_LANE_OUTPUT_STORED_BYTES,
+	readLaneOutput,
+	storeLaneOutput,
+} from '../../../src/background/lane-output-store';
+
+function makeTempDir(): string {
+	return fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'lane-output-store-')),
+	);
+}
+
+describe('lane-output-store', () => {
+	test('stores output under hashed .swarm lane-results path and reads by opaque ref', () => {
+		const directory = makeTempDir();
+		const stored = storeLaneOutput(directory, {
+			batchId: 'batch:with:windows-unsafe-chars',
+			laneId: '../lane',
+			agent: 'mega_explorer',
+			role: 'explorer',
+			sessionId: 'session-1',
+			source: 'collect_lane_results',
+			text: 'full lane output',
+		});
+
+		expect(stored.degraded).toBe(false);
+		expect(stored.ref).toMatch(/^L1:[a-f0-9]{64}:[a-f0-9]{64}:[a-f0-9]{64}$/);
+		const artifact = readLaneOutput(directory, stored.ref!)?.artifact;
+		expect(artifact?.text).toBe('full lane output');
+		expect(artifact?.batchId).toBe('batch:with:windows-unsafe-chars');
+		expect(artifact?.laneId).toBe('../lane');
+
+		const files = fs.readdirSync(
+			path.join(directory, '.swarm', 'lane-results'),
+		);
+		expect(files[0]).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	test('idempotently returns the same ref for repeated identical output', () => {
+		const directory = makeTempDir();
+		const first = storeLaneOutput(directory, {
+			batchId: 'batch',
+			laneId: 'lane',
+			agent: 'explorer',
+			role: 'explorer',
+			source: 'dispatch_lanes',
+			text: 'same output',
+		});
+		const second = storeLaneOutput(directory, {
+			batchId: 'batch',
+			laneId: 'lane',
+			agent: 'explorer',
+			role: 'explorer',
+			source: 'dispatch_lanes',
+			text: 'same output',
+		});
+
+		expect(second).toEqual(first);
+	});
+
+	test('returns degraded metadata instead of writing oversized artifacts', () => {
+		const directory = makeTempDir();
+		const stored = storeLaneOutput(directory, {
+			batchId: 'batch',
+			laneId: 'lane',
+			agent: 'explorer',
+			role: 'explorer',
+			source: 'dispatch_lanes',
+			text: 'x'.repeat(MAX_LANE_OUTPUT_STORED_BYTES + 1),
+		});
+
+		expect(stored.degraded).toBe(true);
+		expect(stored.ref).toBeUndefined();
+		expect(stored.error).toContain('storage limit');
+		expect(fs.existsSync(path.join(directory, '.swarm', 'lane-results'))).toBe(
+			false,
+		);
+	});
+
+	test('builds head and tail preview with retrieval hint', () => {
+		const preview = buildLaneOutputPreview({
+			text: `head-${'x'.repeat(400)}-tail`,
+			ref:
+				'L1:a'.replace('a', 'a'.repeat(64)) +
+				`:${'b'.repeat(64)}:${'c'.repeat(64)}`,
+			maxChars: 300,
+		});
+
+		expect(preview.output_truncated).toBe(true);
+		expect(preview.output.startsWith('hea')).toBe(true);
+		expect(preview.output.endsWith('il')).toBe(true);
+		expect(preview.output).toContain('retrieve_lane_output ref=');
+	});
+});

--- a/tests/unit/config/schema.test.ts
+++ b/tests/unit/config/schema.test.ts
@@ -1585,6 +1585,7 @@ describe('SummaryConfigSchema', () => {
 			expect(result.data.retention_days).toBe(7);
 			expect(result.data.exempt_tools).toEqual([
 				'retrieve_summary',
+				'retrieve_lane_output',
 				'task',
 				'read',
 			]);
@@ -1674,6 +1675,7 @@ describe('SummaryConfigSchema', () => {
 			expect(result.data.max_summary_chars).toBe(1000); // Default
 			expect(result.data.exempt_tools).toEqual([
 				'retrieve_summary',
+				'retrieve_lane_output',
 				'task',
 				'read',
 			]); // Default

--- a/tests/unit/hooks/context-budget.test.ts
+++ b/tests/unit/hooks/context-budget.test.ts
@@ -1415,5 +1415,56 @@ describe('context-budget hook', () => {
 
 			expect(config.context_budget.enforce_on_agent_switch).toBe(false);
 		});
+
+		test('[Task 4.2] retrieve_lane_output messages are NOT masked during enforcement', async () => {
+			// Verify the structured-toolName exemption path: when msg.info.toolName is
+			// 'retrieve_lane_output', shouldMaskToolOutput must return false even when
+			// enforcement fires and the message is large/old.
+			const config = {
+				context_budget: {
+					enabled: true,
+					model_limits: { default: 60 },
+					critical_threshold: 0.5,
+					enforce: true,
+					prune_target: 0.3,
+					recent_window: 1,
+					preserve_last_n_turns: 1,
+					tool_output_mask_threshold: 50,
+				},
+				max_iterations: 5,
+				qa_retry_limit: 3,
+				inject_phase_reminders: true,
+			};
+
+			const handler = createContextBudgetHandler(config);
+
+			const largeText = 'z'.repeat(600);
+			const messages = [
+				// Old, large retrieve_lane_output result — must NOT be masked
+				{
+					info: { role: 'assistant', toolName: 'retrieve_lane_output' },
+					parts: [{ type: 'text', text: largeText }],
+				},
+				// Old, large generic tool result — eligible for masking
+				{
+					info: { role: 'assistant', toolName: 'bash' },
+					parts: [{ type: 'text', text: largeText }],
+				},
+				// Recent user message (preserves the turn)
+				{
+					info: { role: 'user', agent: 'architect' },
+					parts: [{ type: 'text', text: 'retrieve the lane output' }],
+				},
+			];
+
+			const output = { messages: JSON.parse(JSON.stringify(messages)) };
+			await handler({}, output);
+
+			const retrieveMsg = output.messages[0];
+			const retrieveText = retrieveMsg.parts[0].text as string;
+			expect(retrieveText).not.toContain('[Tool output masked');
+			expect(retrieveText).not.toContain('[Context pruned');
+			expect(retrieveText).toBe(largeText);
+		});
 	});
 });

--- a/tests/unit/hooks/context-budget.test.ts
+++ b/tests/unit/hooks/context-budget.test.ts
@@ -1242,7 +1242,7 @@ describe('context-budget hook', () => {
 					parts: [{ type: 'text', text: 'user msg' }],
 				},
 				{
-					info: { role: 'assistant', toolName: 'read' },
+					info: { role: 'assistant', toolName: 'bash' },
 					parts: [{ type: 'text', text: originalOutput }],
 				}, // Large output, index 1
 				{
@@ -1298,7 +1298,7 @@ describe('context-budget hook', () => {
 					parts: [{ type: 'text', text: 'user' }],
 				},
 				{
-					info: { role: 'assistant', toolName: 'read' },
+					info: { role: 'assistant', toolName: 'bash' },
 					parts: [{ type: 'text', text: largeToolOutput }],
 				}, // Index 1, age = 4 > recent_window (3)
 				{

--- a/tests/unit/hooks/tool-summarizer-exempt.adversarial.test.ts
+++ b/tests/unit/hooks/tool-summarizer-exempt.adversarial.test.ts
@@ -1092,4 +1092,103 @@ describe('createToolSummarizerHook - Adversarial Tests for exempt_tools', () => 
 			}
 		});
 	});
+
+	/**
+	 * Attack Vector 11: retrieve_lane_output exemption ratchet
+	 * Verify retrieve_lane_output is treated like retrieve_summary — exempt by default,
+	 * not bypassable via suffix/prefix/case variations.
+	 */
+	describe('retrieve_lane_output exemption ratchet', () => {
+		it('should exempt retrieve_lane_output when in exempt list', async () => {
+			const config: SummaryConfig = {
+				enabled: true,
+				threshold_bytes: 1024,
+				max_summary_chars: 500,
+				max_stored_bytes: 1024 * 1024,
+				retention_days: 7,
+				exempt_tools: [
+					'retrieve_summary',
+					'retrieve_lane_output',
+					'task',
+					'read',
+				],
+			};
+
+			const hook = createToolSummarizerHook(config, tempDir);
+
+			const output = {
+				title: 'Test Tool',
+				output: largeOutput,
+				metadata: {},
+			};
+
+			await hook(
+				{ tool: 'retrieve_lane_output', sessionID: 'test', callID: 'test' },
+				output,
+			);
+
+			expect(output.output).toBe(largeOutput);
+		});
+
+		it('should NOT exempt retrieve_lane_output with suffix', async () => {
+			const config: SummaryConfig = {
+				enabled: true,
+				threshold_bytes: 1024,
+				max_summary_chars: 500,
+				max_stored_bytes: 1024 * 1024,
+				retention_days: 7,
+				exempt_tools: [
+					'retrieve_summary',
+					'retrieve_lane_output',
+					'task',
+					'read',
+				],
+			};
+
+			const hook = createToolSummarizerHook(config, tempDir);
+
+			const output = {
+				title: 'Test Tool',
+				output: largeOutput,
+				metadata: {},
+			};
+
+			await hook(
+				{
+					tool: 'retrieve_lane_output_extra',
+					sessionID: 'test',
+					callID: 'test',
+				},
+				output,
+			);
+
+			expect(output.output).not.toBe(largeOutput);
+		});
+
+		it('should NOT exempt retrieve_lane_output when missing from exempt list', async () => {
+			const config: SummaryConfig = {
+				enabled: true,
+				threshold_bytes: 1024,
+				max_summary_chars: 500,
+				max_stored_bytes: 1024 * 1024,
+				retention_days: 7,
+				exempt_tools: ['retrieve_summary', 'task', 'read'],
+			};
+
+			const hook = createToolSummarizerHook(config, tempDir);
+
+			const output = {
+				title: 'Test Tool',
+				output: largeOutput,
+				metadata: {},
+			};
+
+			await hook(
+				{ tool: 'retrieve_lane_output', sessionID: 'test', callID: 'test' },
+				output,
+			);
+
+			expect(output.output).not.toBe(largeOutput);
+		});
+	});
 });

--- a/tests/unit/hooks/tool-summarizer-exempt.test.ts
+++ b/tests/unit/hooks/tool-summarizer-exempt.test.ts
@@ -29,7 +29,12 @@ describe('tool-summarizer exempt_tools feature', () => {
 			max_summary_chars: 1000,
 			max_stored_bytes: 10485760,
 			retention_days: 7,
-			exempt_tools: ['retrieve_summary', 'task', 'read'], // explicit default
+			exempt_tools: [
+				'retrieve_summary',
+				'retrieve_lane_output',
+				'task',
+				'read',
+			], // explicit default
 			...overrides,
 		};
 	}
@@ -63,6 +68,19 @@ describe('tool-summarizer exempt_tools feature', () => {
 			// Verify output was NOT modified
 			expect(output.output).toBe(originalOutput);
 			expect(output.output).toBe('x'.repeat(2000));
+		});
+
+		it('retrieve_lane_output is never summarized', async () => {
+			const config = defaultConfig();
+			hook = createToolSummarizerHook(config, tempDir);
+
+			const originalOutput = 'x'.repeat(2000);
+			const output = { output: originalOutput };
+			const input = { tool: 'retrieve_lane_output' };
+
+			await hook(input, output);
+
+			expect(output.output).toBe(originalOutput);
 		});
 
 		it('read tool is exempt by default', async () => {

--- a/tests/unit/skills/dispatch-lane-output-guidance.test.ts
+++ b/tests/unit/skills/dispatch-lane-output-guidance.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const GUIDANCE_FILES = [
+	'.opencode/skills/deep-dive/SKILL.md',
+	'.claude/skills/deep-dive/SKILL.md',
+	'.opencode/skills/deep-research/SKILL.md',
+	'.claude/skills/deep-research/SKILL.md',
+	'.opencode/skills/council/SKILL.md',
+	'.claude/skills/council/SKILL.md',
+	'.opencode/skills/swarm-pr-feedback/SKILL.md',
+	'.agents/skills/swarm-pr-feedback/SKILL.md',
+	'.claude/skills/swarm-pr-feedback/SKILL.md',
+	'.opencode/skills/codebase-review-swarm/references/review-protocol-v8.2.md',
+	'.agents/skills/codebase-review-swarm/SKILL.md',
+	'.claude/skills/codebase-review-swarm/SKILL.md',
+] as const;
+
+function readRepoFile(filePath: string): string {
+	return readFileSync(join(process.cwd(), filePath), 'utf-8');
+}
+
+describe('dispatch lane full-output retrieval guidance', () => {
+	for (const filePath of GUIDANCE_FILES) {
+		test(`${filePath} requires full output retrieval before consuming lane results`, () => {
+			const source = readRepoFile(filePath);
+
+			expect(source).toContain('output_ref');
+			expect(source).toContain('retrieve_lane_output');
+			expect(source).toMatch(/preview/i);
+			expect(source).toMatch(
+				/degraded|incomplete|coverage gap|coverage limitation|evidence gaps/i,
+			);
+		});
+	}
+});

--- a/tests/unit/skills/swarm-pr-review-dispatch-guidance.test.ts
+++ b/tests/unit/skills/swarm-pr-review-dispatch-guidance.test.ts
@@ -46,6 +46,9 @@ describe('swarm-pr-review deterministic async lane dispatch guidance', () => {
 		expect(phase3Section).toContain('dispatch_lanes_async');
 		expect(phase3Section).toContain('collect_lane_results');
 		expect(phase3Section).toContain('lane_results');
+		expect(phase3Section).toContain('output_ref');
+		expect(phase3Section).toContain('retrieve_lane_output');
+		expect(phase3Section).toContain('UNVERIFIED');
 		expect(phase3Section).toContain('dispatch_lanes');
 		expect(phase3Section).not.toContain('run_in_background');
 		expect(phase3Section).not.toContain(
@@ -88,6 +91,8 @@ describe('swarm-pr-review deterministic async lane dispatch guidance', () => {
 			expect(source).toContain('read-only');
 			expect(source).toContain('dispatch_lanes_async');
 			expect(source).toContain('collect_lane_results');
+			expect(source).toContain('retrieve_lane_output');
+			expect(source).toContain('output_ref');
 			expect(source).not.toContain('## Phase 0A:');
 			expect(source).not.toContain('## Phase 0B:');
 			expect(source).not.toContain(

--- a/tests/unit/tools/dispatch-lanes.test.ts
+++ b/tests/unit/tools/dispatch-lanes.test.ts
@@ -10,6 +10,7 @@ import {
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { readLaneOutput } from '../../../src/background/lane-output-store';
 import {
 	findByBatchId,
 	recordPendingDelegation,
@@ -526,9 +527,9 @@ describe('executeDispatchLanes', () => {
 		});
 	});
 
-	test('truncates oversized lane output with metadata', async () => {
+	test('returns bounded preview and durable ref for oversized lane output', async () => {
 		const directory = makeTempDir();
-		const hugeOutput = 'x'.repeat(25_000);
+		const hugeOutput = `head-${'x'.repeat(24_980)}-tail`;
 		const ops: SessionOps = {
 			create: mock(async () => ({
 				data: { id: 'session-1' },
@@ -550,15 +551,26 @@ describe('executeDispatchLanes', () => {
 		);
 
 		expect(result.success).toBe(true);
-		expect(result.lane_results[0].output_chars).toBe(25_000);
+		expect(result.lane_results[0].output_chars).toBe(24_990);
 		expect(result.lane_results[0].output_truncated).toBe(true);
+		expect(result.lane_results[0].output_ref).toMatch(
+			/^L1:[a-f0-9]{64}:[a-f0-9]{64}:[a-f0-9]{64}$/,
+		);
+		expect(result.lane_results[0].output_digest).toMatch(/^[a-f0-9]{64}$/);
 		expect(result.lane_results[0].output?.length).toBeLessThan(
 			hugeOutput.length,
 		);
 		expect(result.lane_results[0].output?.length).toBe(20_000);
 		expect(result.lane_results[0].output).toContain(
-			'chars truncated by dispatch_lanes',
+			'retrieve_lane_output ref=',
 		);
+		expect(result.lane_results[0].output).toContain('-tail');
+		const loaded = readLaneOutput(
+			directory,
+			result.lane_results[0].output_ref!,
+		);
+		expect(loaded?.artifact.text).toBe(hugeOutput);
+		expect(loaded?.artifact.source).toBe('dispatch_lanes');
 	});
 
 	test('fails closed when the OpenCode session client is unavailable', async () => {
@@ -1025,6 +1037,61 @@ describe('executeDispatchLanesAsync and executeCollectLaneResults', () => {
 		expect(result.completed).toBe(1);
 		expect(result.pending).toBe(0);
 		expect(result.lane_results[0].output).toBe('lane output');
+		expect(result.lane_results[0].output_ref).toMatch(
+			/^L1:[a-f0-9]{64}:[a-f0-9]{64}:[a-f0-9]{64}$/,
+		);
+		expect(
+			readLaneOutput(directory, result.lane_results[0].output_ref!)?.artifact
+				.text,
+		).toBe('lane output');
+	});
+
+	test('collects all assistant transcript messages and marks message-limit incompleteness', async () => {
+		const directory = makeTempDir();
+		const messages = Array.from({ length: 50 }, (_, index) => ({
+			info: { role: 'assistant' },
+			parts: [{ type: 'text', text: `part-${index}` }],
+		}));
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: 'session-transcript' },
+				error: undefined,
+			})),
+			prompt: mock(async () => ({
+				data: { parts: [{ type: 'text' as const, text: 'unused' }] },
+				error: undefined,
+			})),
+			promptAsync: mock(async () => ({ data: undefined, error: undefined })),
+			messages: mock(async () => ({
+				data: messages,
+				error: undefined,
+			})),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+
+		await executeDispatchLanesAsync(
+			{
+				batch_id: 'batch-transcript',
+				lanes: [{ id: 'runtime', agent: 'explorer', prompt: 'inspect' }],
+			},
+			directory,
+		);
+		const result = await executeCollectLaneResults(
+			{ batch_id: 'batch-transcript', wait: false },
+			directory,
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.lane_results[0].message_count).toBe(50);
+		expect(result.lane_results[0].transcript_incomplete).toBe(true);
+		const artifact = readLaneOutput(
+			directory,
+			result.lane_results[0].output_ref!,
+		)?.artifact;
+		expect(artifact?.text).toContain('part-0\n\npart-1');
+		expect(artifact?.text).toContain('part-49');
+		expect(artifact?.transcriptIncomplete).toBe(true);
 	});
 
 	test('collects only the current parent session when context is available', async () => {
@@ -1425,7 +1492,7 @@ describe('executeDispatchLanesAsync and executeCollectLaneResults', () => {
 		}
 	});
 
-	test('collects only text parts and returns the last non-empty assistant message', async () => {
+	test('collects only assistant text parts into a chronological transcript', async () => {
 		const directory = makeTempDir();
 		const ops: SessionOps = {
 			create: mock(async () => ({
@@ -1478,16 +1545,16 @@ describe('executeDispatchLanesAsync and executeCollectLaneResults', () => {
 		);
 
 		expect(result.success).toBe(true);
-		expect(result.lane_results[0].output).toBe('newer output');
+		expect(result.lane_results[0].output).toBe('older output\n\nnewer output');
 		expect(
-			_test_exports.extractLastAssistantText([
+			_test_exports.extractAssistantTranscript([
 				{
 					info: { role: 'assistant' },
 					parts: [{ type: 'text', text: 'first' }],
 				},
 				{ info: { role: 'assistant' }, parts: [{ type: 'text', text: '   ' }] },
 				{ info: { role: 'user' }, parts: [{ type: 'text', text: 'user' }] },
-			]),
+			]).text,
 		).toBe('first');
 	});
 });

--- a/tests/unit/tools/retrieve-lane-output.test.ts
+++ b/tests/unit/tools/retrieve-lane-output.test.ts
@@ -44,4 +44,44 @@ describe('retrieve_lane_output', () => {
 		expect(parsed.success).toBe(false);
 		expect(parsed.failure_class).toBe('not_found');
 	});
+
+	test('returns exhausted header when offset is beyond total lines', async () => {
+		const directory = makeTempDir();
+		const stored = storeLaneOutput(directory, {
+			batchId: 'batch-2',
+			laneId: 'lane-2',
+			agent: 'explorer',
+			role: 'explorer',
+			source: 'dispatch_lanes',
+			text: 'only one line',
+		});
+
+		const output = await retrieve_lane_output.execute(
+			{ ref: stored.ref, offset: 99, limit: 10 },
+			{ directory } as never,
+		);
+
+		expect(output).toContain('offset beyond range');
+		expect(output).toContain(stored.ref);
+		expect(output).not.toContain('Use offset=');
+	});
+
+	test('includes transcriptIncomplete warning when artifact flag is set', async () => {
+		const directory = makeTempDir();
+		const stored = storeLaneOutput(directory, {
+			batchId: 'batch-3',
+			laneId: 'lane-3',
+			agent: 'reviewer',
+			role: 'reviewer',
+			source: 'collect_lane_results',
+			text: 'review findings',
+			transcriptIncomplete: true,
+		});
+
+		const output = await retrieve_lane_output.execute({ ref: stored.ref }, {
+			directory,
+		} as never);
+
+		expect(output).toContain('Warning: transcript may be incomplete');
+	});
 });

--- a/tests/unit/tools/retrieve-lane-output.test.ts
+++ b/tests/unit/tools/retrieve-lane-output.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { storeLaneOutput } from '../../../src/background/lane-output-store';
+import { retrieve_lane_output } from '../../../src/tools/retrieve-lane-output';
+
+function makeTempDir(): string {
+	return fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'retrieve-lane-output-')),
+	);
+}
+
+describe('retrieve_lane_output', () => {
+	test('retrieves a bounded page of stored lane output', async () => {
+		const directory = makeTempDir();
+		const stored = storeLaneOutput(directory, {
+			batchId: 'batch-1',
+			laneId: 'lane-1',
+			agent: 'explorer',
+			role: 'explorer',
+			source: 'collect_lane_results',
+			text: ['line 1', 'line 2', 'line 3'].join('\n'),
+		});
+
+		const output = await retrieve_lane_output.execute(
+			{ ref: stored.ref, offset: 1, limit: 1 },
+			{ directory } as never,
+		);
+
+		expect(output).toContain(`Lane output ${stored.ref} lines 2-2 of 3`);
+		expect(output).toContain('Batch: batch-1');
+		expect(output).toContain('line 2');
+		expect(output).not.toContain('line 1');
+		expect(output).toContain('Use offset=2 to retrieve more');
+	});
+
+	test('returns structured not_found for invalid refs', async () => {
+		const output = await retrieve_lane_output.execute({ ref: '../not-a-ref' }, {
+			directory: makeTempDir(),
+		} as never);
+
+		const parsed = JSON.parse(output);
+		expect(parsed.success).toBe(false);
+		expect(parsed.failure_class).toBe('not_found');
+	});
+});


### PR DESCRIPTION
Related: #1456

## Summary
- Persist full dispatch lane outputs under `.swarm/lane-results/` before returning bounded lane previews, for both blocking `dispatch_lanes` and async `dispatch_lanes_async` collection.
- Add architect-only `retrieve_lane_output` pagination so workflows can retrieve full lane artifacts by `output_ref` instead of relying on truncated tool previews.
- Wire preview/ref/degraded/transcript metadata through the background delegation ledger and update review/research/council/feedback/codebase-review skill guidance to retrieve artifacts before consuming lane results.
- Document recovery behavior, architecture, command guidance, and release notes for durable lane outputs.

## Invariant audit
- 1 (plugin init):       not touched — no changes to `src/index.ts` init path or startup work.
- 2 (runtime portability): touched — `bun run build` passed; `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` printed `dist import OK`.
- 3 (subprocesses):       not touched — grep over touched runtime files found no `process.cwd(`, `Bun.`, `spawn(`, `spawnSync(`, or `bunSpawn(` usage.
- 4 (.swarm containment): touched — `lane-output-store.ts` and `retrieve-lane-output.ts` use `validateSwarmPath` and store artifacts only under `.swarm/lane-results/`; covered by `tests/unit/background/lane-output-store.test.ts` and `tests/unit/tools/retrieve-lane-output.test.ts`.
- 5 (plan durability):    not touched — no plan ledger/projection/checkpoint schema changes.
- 6 (test_runner safety): not touched — validation used shell `bun --smol test` commands only.
- 7 (test writing):       touched — loaded writing-tests guidance before adding bun:test files; new tests use DI/local temp directories and no `mock.module`.
- 8 (session state):      not touched — no new module-level session maps or cross-session state.
- 9 (guardrails/retry):   not touched — no guardrail or retry accounting changes.
- 10 (chat/system msg):   not touched — no chat/system-message hook changes.
- 11 (tool registration): touched — `retrieve_lane_output` is exported, registered in manifest metadata, included in `TOOL_NAMES` via metadata, covered by registration/conformance tests and architect-only metadata.
- 12 (release/cache):     touched — added `docs/releases/pending/durable-lane-output.md`; no version, changelog, manifest, or cache changes.

## Test plan
- `bun --smol test tests/unit/background/lane-output-store.test.ts --timeout 30000`
- `bun --smol test tests/unit/tools/retrieve-lane-output.test.ts --timeout 30000`
- `bun --smol test tests/unit/tools/dispatch-lanes.test.ts --timeout 30000`
- `bun --smol test tests/unit/config/schema.test.ts tests/unit/config/agent-tool-map.test.ts --timeout 60000`
- `bun --smol test tests/unit/tools/tool-registration-conformance.test.ts tests/unit/tools/manifest-parity.test.ts tests/unit/tools/wiring-adversarial.test.ts --timeout 60000`
- `bun --smol test tests/unit/hooks/tool-summarizer-exempt.test.ts tests/unit/hooks/tool-summarizer-exempt.adversarial.test.ts --timeout 60000`
- `bun --smol test tests/unit/skills/dispatch-lane-output-guidance.test.ts tests/unit/skills/swarm-pr-review-dispatch-guidance.test.ts --timeout 60000`
- `bun --smol test tests/unit/background/lane-output-store.test.ts tests/unit/tools/retrieve-lane-output.test.ts tests/unit/tools/dispatch-lanes.test.ts tests/unit/hooks/tool-summarizer-exempt.test.ts tests/unit/skills/dispatch-lane-output-guidance.test.ts tests/unit/skills/swarm-pr-review-dispatch-guidance.test.ts --timeout 120000`
- `bun --smol test tests/unit/config/constants.test.ts src/services/tool-doctor.test.ts src/tools/plugin-registration-adversarial.test.ts --timeout 60000` (critic rerun)
- `bunx biome ci .` (pass; reports one pre-existing informational `useTemplate` suggestion in `src/session/session-start-store.ts`)
- `bun run typecheck`
- `bun run build`
- `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- `git diff --check`

Additional sweeps attempted:
- `bun --smol test tests/unit/config --timeout 120000` hit two unrelated failures already present on `origin/main`: `tests/unit/config/execution-profile-schema.test.ts` default expectation and `tests/unit/config/quiet-config.test.ts` debug warning expectation.
- Per-file `tests/unit/tools/*.test.ts` loop hit unrelated `tests/unit/tools/doc-scan.adversarial.test.ts` expectation that is unchanged on `origin/main`.

Independent review:
- Implementation reviewer: APPROVE, no confirmed findings.
- Final critic: APPROVE, no concrete blockers; noted the intentional 10 MB per-artifact degradation boundary documented by tests/docs.