### PR TITLE
fix(test): restore makeMockFn pattern in curator-auto-retire.test.ts

### DIFF
--- a/docs/releases/pending/1436-restore-makemockfn-curator-auto-retire.md
+++ b/docs/releases/pending/1436-restore-makemockfn-curator-auto-retire.md
@@ -1,0 +1,41 @@
+# Restore makeMockFn pattern in curator-auto-retire tests
+
+## What changed
+
+- Restored the `makeMockFn` call-recording helper in
+  `tests/unit/hooks/curator-auto-retire.test.ts` and removed the `mock` import
+  from `bun:test`.
+- Converted all `mock(() => ...)` instantiations to `makeMockFn(() => ...)`
+  and migrated assertions from `toHaveBeenCalledTimes` / `toHaveBeenCalledWith` /
+  `not.toHaveBeenCalled` to the helper's `.calls` array
+  (`toHaveLength` / `toEqual`).
+- Updated the file header comment to accurately describe the isolation
+  mechanism (`mock()` internal-state leakage, not just `mock.module()`).
+- Added a regression test locking in the `makeMockFn` call-recording contract.
+
+## Why
+
+PR #1325 reintroduced `bun:test`'s `mock()` into this test file, undoing the
+prior CI-pollution fix. Bun's `mock()` retains internal mock-tracking state that
+can leak across test files in the shared test-runner process (AGENTS.md
+invariant 7). The `_internals` DI seam protects production-code references but
+not Bun's internal mock object state, so `mock()` reintroduces a latent
+cross-file pollution surface. `makeMockFn` records calls without registering a
+Bun mock, eliminating that surface while preserving identical assertion
+capability.
+
+## Impact
+
+- Eliminates the latent cross-file mock-state leakage from
+  `curator-auto-retire.test.ts`.
+- All 9 existing test cases continue to pass (behavior-equivalent conversion);
+  3 consecutive runs show no flakiness.
+- Adds 2 regression tests covering the `makeMockFn` contract.
+
+## Migration
+
+No migration required — test-only change.
+
+## Breaking changes
+
+None.

--- a/tests/unit/hooks/curator-auto-retire.test.ts
+++ b/tests/unit/hooks/curator-auto-retire.test.ts
@@ -2,11 +2,30 @@
  * Unit tests for curator.ts autoRetireSkills function.
  * Tests the auto-retirement health check logic via _internals DI seam.
  *
- * All mocking is done through the _internals DI seam — no mock.module calls.
- * This avoids Bun's known mock.module leak across test files.
+ * Isolation: the _internals DI seam restores production-code references in
+ * afterEach, but Bun's `mock()` from bun:test also retains internal
+ * mock-tracking state that can leak across test files in the shared test-runner
+ * process (AGENTS.md invariant 7). To eliminate that cross-file pollution
+ * surface we use a plain `makeMockFn` helper that records calls without
+ * registering a Bun mock — there are no `mock()` or `mock.module()` calls here.
  */
 
-import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// makeMockFn — plain call-recording helper (no bun:test mock() registration).
+// Avoids Bun mock() internal-state leakage across test files while still
+// exposing call counts/arguments via the `.calls` array for assertions.
+// ---------------------------------------------------------------------------
+function makeMockFn<T extends (...args: any[]) => any>(fn: T) {
+	const calls: Parameters<T>[] = [];
+	const mockFn = ((...args: Parameters<T>) => {
+		calls.push(args);
+		return fn(...args);
+	}) as T & { calls: Parameters<T>[] };
+	mockFn.calls = calls;
+	return mockFn;
+}
 
 // ---------------------------------------------------------------------------
 // Import curator _internals — no module-level mocking required
@@ -52,8 +71,8 @@ describe('autoRetireSkills', () => {
 	test('TC1: skill exceeding violation threshold is retired with violation reason', async () => {
 		const directory = '/fake/dir';
 
-		const mockRetireSkill = mock(() => Promise.resolve());
-		const mockListSkills = mock(() =>
+		const mockRetireSkill = makeMockFn(() => Promise.resolve());
+		const mockListSkills = makeMockFn(() =>
 			Promise.resolve({
 				active: [
 					makeSkill(
@@ -65,7 +84,7 @@ describe('autoRetireSkills', () => {
 				proposals: [],
 			}),
 		);
-		const mockReadSkillUsageEntries = mock(() => [
+		const mockReadSkillUsageEntries = makeMockFn(() => [
 			{
 				skillPath:
 					'file:/fake/dir/.opencode/skills/generated/high-violation/SKILL.md',
@@ -91,9 +110,11 @@ describe('autoRetireSkills', () => {
 		_internals.listSkills = mockListSkills;
 		_internals.readSkillUsageEntries = mockReadSkillUsageEntries;
 		_internals.retireSkill = mockRetireSkill;
-		_internals.parseDraftFrontmatter = mock(() => ({ sourceKnowledgeIds: [] }));
-		_internals.readKnowledge = mock(() => Promise.resolve([]));
-		_internals.readFileAsync = mock(() => Promise.resolve(''));
+		_internals.parseDraftFrontmatter = makeMockFn(() => ({
+			sourceKnowledgeIds: [],
+		}));
+		_internals.readKnowledge = makeMockFn(() => Promise.resolve([]));
+		_internals.readFileAsync = makeMockFn(() => Promise.resolve(''));
 
 		const observations = await _internals.autoRetireSkills(
 			directory,
@@ -103,12 +124,12 @@ describe('autoRetireSkills', () => {
 		expect(observations).toHaveLength(1);
 		expect(observations[0]).toContain('high-violation');
 		expect(observations[0]).toContain('violation rate');
-		expect(mockRetireSkill).toHaveBeenCalledTimes(1);
-		expect(mockRetireSkill).toHaveBeenCalledWith(
+		expect(mockRetireSkill.calls).toHaveLength(1);
+		expect(mockRetireSkill.calls[0]).toEqual([
 			directory,
 			'high-violation',
 			expect.stringContaining('violation rate'),
-		);
+		]);
 	});
 
 	// -----------------------------------------------------------------------
@@ -117,8 +138,8 @@ describe('autoRetireSkills', () => {
 	test('TC2: skill below violation threshold with no archived sources is NOT retired', async () => {
 		const directory = '/fake/dir';
 
-		const mockRetireSkill = mock(() => Promise.resolve());
-		const mockListSkills = mock(() =>
+		const mockRetireSkill = makeMockFn(() => Promise.resolve());
+		const mockListSkills = makeMockFn(() =>
 			Promise.resolve({
 				active: [
 					makeSkill(
@@ -130,7 +151,7 @@ describe('autoRetireSkills', () => {
 				proposals: [],
 			}),
 		);
-		const mockReadSkillUsageEntries = mock(() => [
+		const mockReadSkillUsageEntries = makeMockFn(() => [
 			{
 				skillPath:
 					'/fake/dir/.opencode/skills/generated/healthy-skill/SKILL.md',
@@ -146,9 +167,11 @@ describe('autoRetireSkills', () => {
 		_internals.listSkills = mockListSkills;
 		_internals.readSkillUsageEntries = mockReadSkillUsageEntries;
 		_internals.retireSkill = mockRetireSkill;
-		_internals.parseDraftFrontmatter = mock(() => ({ sourceKnowledgeIds: [] }));
-		_internals.readKnowledge = mock(() => Promise.resolve([]));
-		_internals.readFileAsync = mock(() => Promise.resolve(''));
+		_internals.parseDraftFrontmatter = makeMockFn(() => ({
+			sourceKnowledgeIds: [],
+		}));
+		_internals.readKnowledge = makeMockFn(() => Promise.resolve([]));
+		_internals.readFileAsync = makeMockFn(() => Promise.resolve(''));
 
 		const observations = await _internals.autoRetireSkills(
 			directory,
@@ -156,7 +179,7 @@ describe('autoRetireSkills', () => {
 		);
 
 		expect(observations).toHaveLength(0);
-		expect(mockRetireSkill).not.toHaveBeenCalled();
+		expect(mockRetireSkill.calls).toHaveLength(0);
 	});
 
 	// -----------------------------------------------------------------------
@@ -165,8 +188,8 @@ describe('autoRetireSkills', () => {
 	test('TC3: skill with no usage but all sources archived is retired with archived reason', async () => {
 		const directory = '/fake/dir';
 
-		const mockRetireSkill = mock(() => Promise.resolve());
-		const mockListSkills = mock(() =>
+		const mockRetireSkill = makeMockFn(() => Promise.resolve());
+		const mockListSkills = makeMockFn(() =>
 			Promise.resolve({
 				active: [
 					makeSkill(
@@ -178,8 +201,8 @@ describe('autoRetireSkills', () => {
 				proposals: [],
 			}),
 		);
-		const mockReadSkillUsageEntries = mock(() => []);
-		const mockParseDraftFrontmatter = mock(() => ({
+		const mockReadSkillUsageEntries = makeMockFn(() => []);
+		const mockParseDraftFrontmatter = makeMockFn(() => ({
 			sourceKnowledgeIds: ['src1', 'src2'],
 		}));
 
@@ -190,7 +213,7 @@ describe('autoRetireSkills', () => {
 		// Use call-count-based mock: first call = swarm, subsequent = hive (empty).
 		// This avoids duplicate entries when both swarm and hive knowledge are read.
 		let readCallCount = 0;
-		_internals.readKnowledge = mock(() => {
+		_internals.readKnowledge = makeMockFn(() => {
 			readCallCount++;
 			if (readCallCount === 1) {
 				return Promise.resolve([
@@ -235,7 +258,7 @@ describe('autoRetireSkills', () => {
 			// Subsequent calls (hive) return empty
 			return Promise.resolve([]);
 		});
-		_internals.readFileAsync = mock(() =>
+		_internals.readFileAsync = makeMockFn(() =>
 			Promise.resolve('---\nsourceKnowledgeIds:\n  - src1\n  - src2\n---\n'),
 		);
 
@@ -247,12 +270,12 @@ describe('autoRetireSkills', () => {
 		expect(observations).toHaveLength(1);
 		expect(observations[0]).toContain('archived-skill');
 		expect(observations[0]).toContain('archived');
-		expect(mockRetireSkill).toHaveBeenCalledTimes(1);
-		expect(mockRetireSkill).toHaveBeenCalledWith(
+		expect(mockRetireSkill.calls).toHaveLength(1);
+		expect(mockRetireSkill.calls[0]).toEqual([
 			directory,
 			'archived-skill',
 			'auto-retire: all source knowledge entries archived',
-		);
+		]);
 	});
 
 	// -----------------------------------------------------------------------
@@ -261,8 +284,8 @@ describe('autoRetireSkills', () => {
 	test('TC4: skill with no usage and no archived sources is NOT retired', async () => {
 		const directory = '/fake/dir';
 
-		const mockRetireSkill = mock(() => Promise.resolve());
-		const mockListSkills = mock(() =>
+		const mockRetireSkill = makeMockFn(() => Promise.resolve());
+		const mockListSkills = makeMockFn(() =>
 			Promise.resolve({
 				active: [
 					makeSkill(
@@ -274,16 +297,18 @@ describe('autoRetireSkills', () => {
 				proposals: [],
 			}),
 		);
-		const mockReadSkillUsageEntries = mock(() => []);
+		const mockReadSkillUsageEntries = makeMockFn(() => []);
 		// No sourceKnowledgeIds → no archived check
-		const mockParseDraftFrontmatter = mock(() => ({ sourceKnowledgeIds: [] }));
+		const mockParseDraftFrontmatter = makeMockFn(() => ({
+			sourceKnowledgeIds: [],
+		}));
 
 		_internals.listSkills = mockListSkills;
 		_internals.readSkillUsageEntries = mockReadSkillUsageEntries;
 		_internals.retireSkill = mockRetireSkill;
 		_internals.parseDraftFrontmatter = mockParseDraftFrontmatter;
-		_internals.readKnowledge = mock(() => Promise.resolve([]));
-		_internals.readFileAsync = mock(() => Promise.resolve(''));
+		_internals.readKnowledge = makeMockFn(() => Promise.resolve([]));
+		_internals.readFileAsync = makeMockFn(() => Promise.resolve(''));
 
 		const observations = await _internals.autoRetireSkills(
 			directory,
@@ -291,7 +316,7 @@ describe('autoRetireSkills', () => {
 		);
 
 		expect(observations).toHaveLength(0);
-		expect(mockRetireSkill).not.toHaveBeenCalled();
+		expect(mockRetireSkill.calls).toHaveLength(0);
 	});
 
 	// -----------------------------------------------------------------------
@@ -300,8 +325,8 @@ describe('autoRetireSkills', () => {
 	test('TC5: skill with no frontmatter skips archived check and only evaluates violation rate', async () => {
 		const directory = '/fake/dir';
 
-		const mockRetireSkill = mock(() => Promise.resolve());
-		const mockListSkills = mock(() =>
+		const mockRetireSkill = makeMockFn(() => Promise.resolve());
+		const mockListSkills = makeMockFn(() =>
 			Promise.resolve({
 				active: [
 					makeSkill(
@@ -314,7 +339,7 @@ describe('autoRetireSkills', () => {
 			}),
 		);
 		// 2 violations out of 3 = 66% > 30% → should retire
-		const mockReadSkillUsageEntries = mock(() => [
+		const mockReadSkillUsageEntries = makeMockFn(() => [
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/no-fm-skill/SKILL.md',
 				complianceVerdict: 'violated' as const,
@@ -329,14 +354,14 @@ describe('autoRetireSkills', () => {
 			},
 		]);
 		// parseDraftFrontmatter returns null → skips archived check
-		const mockParseDraftFrontmatter = mock(() => null);
+		const mockParseDraftFrontmatter = makeMockFn(() => null);
 
 		_internals.listSkills = mockListSkills;
 		_internals.readSkillUsageEntries = mockReadSkillUsageEntries;
 		_internals.retireSkill = mockRetireSkill;
 		_internals.parseDraftFrontmatter = mockParseDraftFrontmatter;
-		_internals.readKnowledge = mock(() => Promise.resolve([]));
-		_internals.readFileAsync = mock(() => Promise.resolve(''));
+		_internals.readKnowledge = makeMockFn(() => Promise.resolve([]));
+		_internals.readFileAsync = makeMockFn(() => Promise.resolve(''));
 
 		const observations = await _internals.autoRetireSkills(
 			directory,
@@ -345,7 +370,7 @@ describe('autoRetireSkills', () => {
 
 		expect(observations).toHaveLength(1);
 		expect(observations[0]).toContain('no-fm-skill');
-		expect(mockRetireSkill).toHaveBeenCalledTimes(1);
+		expect(mockRetireSkill.calls).toHaveLength(1);
 	});
 
 	// -----------------------------------------------------------------------
@@ -354,10 +379,10 @@ describe('autoRetireSkills', () => {
 	test('TC6: retireSkill error is caught and does not propagate', async () => {
 		const directory = '/fake/dir';
 
-		const mockRetireSkill = mock(() =>
+		const mockRetireSkill = makeMockFn(() =>
 			Promise.reject(new Error('retireSkill failed')),
 		);
-		const mockListSkills = mock(() =>
+		const mockListSkills = makeMockFn(() =>
 			Promise.resolve({
 				active: [
 					makeSkill(
@@ -369,7 +394,7 @@ describe('autoRetireSkills', () => {
 				proposals: [],
 			}),
 		);
-		const mockReadSkillUsageEntries = mock(() => [
+		const mockReadSkillUsageEntries = makeMockFn(() => [
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/fail-retire/SKILL.md',
 				complianceVerdict: 'violated' as const,
@@ -383,9 +408,11 @@ describe('autoRetireSkills', () => {
 		_internals.listSkills = mockListSkills;
 		_internals.readSkillUsageEntries = mockReadSkillUsageEntries;
 		_internals.retireSkill = mockRetireSkill;
-		_internals.parseDraftFrontmatter = mock(() => ({ sourceKnowledgeIds: [] }));
-		_internals.readKnowledge = mock(() => Promise.resolve([]));
-		_internals.readFileAsync = mock(() => Promise.resolve(''));
+		_internals.parseDraftFrontmatter = makeMockFn(() => ({
+			sourceKnowledgeIds: [],
+		}));
+		_internals.readKnowledge = makeMockFn(() => Promise.resolve([]));
+		_internals.readFileAsync = makeMockFn(() => Promise.resolve(''));
 
 		// Should NOT throw — fail-open
 		await expect(
@@ -397,7 +424,7 @@ describe('autoRetireSkills', () => {
 	// TC7: listSkills throws → caught, does not propagate (fail-open)
 	// -----------------------------------------------------------------------
 	test('TC7: listSkills error is caught and does not propagate', async () => {
-		const mockListSkills = mock(() =>
+		const mockListSkills = makeMockFn(() =>
 			Promise.reject(new Error('listSkills failed')),
 		);
 
@@ -415,8 +442,8 @@ describe('autoRetireSkills', () => {
 	test('TC8: multiple skills meeting different thresholds are both retired', async () => {
 		const directory = '/fake/dir';
 
-		const mockRetireSkill = mock(() => Promise.resolve());
-		const mockListSkills = mock(() =>
+		const mockRetireSkill = makeMockFn(() => Promise.resolve());
+		const mockListSkills = makeMockFn(() =>
 			Promise.resolve({
 				active: [
 					makeSkill(
@@ -433,7 +460,7 @@ describe('autoRetireSkills', () => {
 			}),
 		);
 		// violation-skill: 1/2 = 50% > 30%; archived-skill: no usage
-		const mockReadSkillUsageEntries = mock(() => [
+		const mockReadSkillUsageEntries = makeMockFn(() => [
 			{
 				skillPath:
 					'/fake/dir/.opencode/skills/generated/violation-skill/SKILL.md',
@@ -448,7 +475,7 @@ describe('autoRetireSkills', () => {
 		// First skill (violation-skill): no source IDs
 		// Second skill (archived-skill): has source IDs pointing to archived entries
 		let parseCallCount = 0;
-		const mockParseDraftFrontmatter = mock(() => {
+		const mockParseDraftFrontmatter = makeMockFn(() => {
 			parseCallCount++;
 			if (parseCallCount === 1) return { sourceKnowledgeIds: [] };
 			return { sourceKnowledgeIds: ['src1'] };
@@ -461,7 +488,7 @@ describe('autoRetireSkills', () => {
 		// Use call-count-based mock: first call = swarm, subsequent = hive (empty).
 		// This avoids duplicate entries when both swarm and hive knowledge are read.
 		let readCallCount = 0;
-		_internals.readKnowledge = mock(() => {
+		_internals.readKnowledge = makeMockFn(() => {
 			readCallCount++;
 			if (readCallCount === 1) {
 				return Promise.resolve([
@@ -488,7 +515,7 @@ describe('autoRetireSkills', () => {
 			// Subsequent calls (hive) return empty
 			return Promise.resolve([]);
 		});
-		_internals.readFileAsync = mock(() =>
+		_internals.readFileAsync = makeMockFn(() =>
 			Promise.resolve('---\nsourceKnowledgeIds:\n  - src1\n---\n'),
 		);
 
@@ -500,7 +527,7 @@ describe('autoRetireSkills', () => {
 		expect(observations).toHaveLength(2);
 		expect(observations.some((o) => o.includes('violation-skill'))).toBe(true);
 		expect(observations.some((o) => o.includes('archived-skill'))).toBe(true);
-		expect(mockRetireSkill).toHaveBeenCalledTimes(2);
+		expect(mockRetireSkill.calls).toHaveLength(2);
 	});
 
 	// -----------------------------------------------------------------------
@@ -510,8 +537,8 @@ describe('autoRetireSkills', () => {
 	test('TC9: slug does not match as substring of another skill path', async () => {
 		const directory = '/fake/dir';
 
-		const mockRetireSkill = mock(() => Promise.resolve());
-		const mockListSkills = mock(() =>
+		const mockRetireSkill = makeMockFn(() => Promise.resolve());
+		const mockListSkills = makeMockFn(() =>
 			Promise.resolve({
 				active: [
 					makeSkill(
@@ -524,7 +551,7 @@ describe('autoRetireSkills', () => {
 			}),
 		);
 		// Usage entries for a DIFFERENT skill ("test-skill") — should NOT match slug "test"
-		const mockReadSkillUsageEntries = mock(() => [
+		const mockReadSkillUsageEntries = makeMockFn(() => [
 			{
 				skillPath: '/fake/dir/.opencode/skills/generated/test-skill/SKILL.md',
 				complianceVerdict: 'violated' as const,
@@ -542,9 +569,11 @@ describe('autoRetireSkills', () => {
 		_internals.listSkills = mockListSkills;
 		_internals.readSkillUsageEntries = mockReadSkillUsageEntries;
 		_internals.retireSkill = mockRetireSkill;
-		_internals.parseDraftFrontmatter = mock(() => ({ sourceKnowledgeIds: [] }));
-		_internals.readKnowledge = mock(() => Promise.resolve([]));
-		_internals.readFileAsync = mock(() => Promise.resolve(''));
+		_internals.parseDraftFrontmatter = makeMockFn(() => ({
+			sourceKnowledgeIds: [],
+		}));
+		_internals.readKnowledge = makeMockFn(() => Promise.resolve([]));
+		_internals.readFileAsync = makeMockFn(() => Promise.resolve(''));
 
 		const observations = await _internals.autoRetireSkills(
 			directory,
@@ -553,6 +582,31 @@ describe('autoRetireSkills', () => {
 
 		// "test" skill should have zero usage entries (test-skill paths should NOT match)
 		expect(observations).toHaveLength(0);
-		expect(mockRetireSkill).not.toHaveBeenCalled();
+		expect(mockRetireSkill.calls).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Regression guard for the makeMockFn helper (issue #1436).
+// makeMockFn replaces bun:test's `mock()` to avoid cross-file mock-state
+// leakage (AGENTS.md invariant 7). This locks in its call-recording contract so
+// a future change cannot silently re-introduce `mock()` semantics that leak.
+// ---------------------------------------------------------------------------
+describe('makeMockFn', () => {
+	test('records each call arguments and exposes them via .calls', () => {
+		const fn = makeMockFn((a: number, b: number) => a + b);
+		expect(fn.calls).toHaveLength(0);
+		expect(fn(2, 3)).toBe(5);
+		expect(fn(10, 20)).toBe(30);
+		expect(fn.calls).toEqual([
+			[2, 3],
+			[10, 20],
+		]);
+	});
+
+	test('delegates to the wrapped function and preserves its return value', () => {
+		const fn = makeMockFn(() => 'ok');
+		expect(fn()).toBe('ok');
+		expect(fn.calls).toHaveLength(1);
 	});
 });

--- a/tests/unit/hooks/curator-auto-retire.test.ts
+++ b/tests/unit/hooks/curator-auto-retire.test.ts
@@ -7,7 +7,7 @@
  * mock-tracking state that can leak across test files in the shared test-runner
  * process (AGENTS.md invariant 7). To eliminate that cross-file pollution
  * surface we use a plain `makeMockFn` helper that records calls without
- * registering a Bun mock — there are no `mock()` or `mock.module()` calls here.
+ * registering a Bun mock — there are no `mock()` or `mock.module` calls here.
  */
 
 import { afterEach, describe, expect, test } from 'bun:test';


### PR DESCRIPTION
Closes #1436

## Summary
- Restores the plain `makeMockFn` call-recording helper in `tests/unit/hooks/curator-auto-retire.test.ts`, reverting only the test-file changes from PR #1325 (commit `8870463e`) that reintroduced `bun:test`'s `mock()`.
- `mock()` retains internal mock-tracking state that leaks across test files in Bun's shared test-runner process (AGENTS.md invariant 7). The `_internals` DI seam protects production-code references but not Bun's internal mock object state.
- Converts all `mock(() => ...)` instantiations and `toHaveBeenCalled*` assertions to the `.calls`-based equivalents.
- Updates the file header comment to accurately describe the isolation mechanism.
- Adds a regression test for the `makeMockFn` contract.
- Adds the release fragment per invariant 12.
- The source `curator.ts` fix from #1325 is untouched; only the test-file regression is reverted (issue Option A).

## Invariant audit
- 1 (plugin init): not touched — no source / init-path changes.
- 2 (runtime portability): not touched — no bundle / plugin-entry changes.
- 3 (subprocesses): not touched — no subprocess changes.
- 4 (.swarm containment): not touched — no runtime-state path changes.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched.
- 7 (test writing): touched — restored the `makeMockFn` pattern (plain call-recording helper, no Bun mock registration) to eliminate cross-file mock-state leakage. Verified 9 existing cases + 2 new `makeMockFn` contract cases pass across 3 consecutive runs with no flakiness.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched.
- 12 (release/cache): touched — added `docs/releases/pending/1436-restore-makemockfn-curator-auto-retire.md`.

## Test plan
- [x] `bun --smol test tests/unit/hooks/curator-auto-retire.test.ts` — 9 existing + 2 new cases pass.
- [x] 3 consecutive runs, no flakiness.
- [x] `tsc --noEmit` — 0 errors.
- [x] `biome check` — clean.
- [ ] CI (`pr-standards`, `check-title`, unit) — pending on push.

## Notes
- Autonomous cron-driven fix (auto-fix-issue workflow). Opened as **draft**; the human reviewer decides ready/merge.
- Source `curator.ts` from #1325 is intentionally left unchanged — only the test-file regression is addressed, per the issue's Option A.
