### PR TITLE
fix(skills): add existence validation to skill_generate compile path

### DIFF
--- a/docs/releases/pending/1485-skill-generate-existence-validation.md
+++ b/docs/releases/pending/1485-skill-generate-existence-validation.md
@@ -1,0 +1,32 @@
+# Surface missing source knowledge IDs in skill frontmatter
+
+## What changed
+
+`skill_generate` now surfaces missing knowledge IDs at compile time instead of silently dropping them:
+
+- `stampSourceEntries` was refactored to return `{ stamped, missing }` instead of `void`. The `missing` array tracks which source knowledge IDs were not found in swarm OR hive knowledge.
+- Active-mode compile (`req.mode === 'active'`) captures `missing` from `stampSourceEntries`, and if non-empty calls a new private helper `injectMissingIdsIntoFrontmatter` to add a `missing_source_knowledge_ids:` block to the skill YAML frontmatter immediately after `source_knowledge_ids:`.
+- `GenerateResult.written[i].missingSourceKnowledgeIds?: string[]` was added so programmatic callers receive the missing IDs in the result object.
+- `GenerateResult.written[i]` ordering is now: stamp source entries BEFORE writing the skill file (previously: write first, then stamp). This ensures the frontmatter reflects the final state.
+
+## Why
+
+Addresses recommendation 2 from the `skill_improver` proposal: previously, `stampSourceEntries` silently skipped source knowledge IDs that didn't exist in the knowledge store, causing skills to become stale with no visible warning. Active-mode skills now show missing IDs in their frontmatter at compile time so staleness is visible immediately, not deferred to `skill_improver` review time.
+
+Before: a skill compiled with 3 source IDs where 1 was archived → skill stamped, no warning, staleness detected only at `skill_improver` review time.
+
+After: same scenario → skill compiled, `missing_source_knowledge_ids: [archived-id]` written to frontmatter, `missingSourceKnowledgeIds` populated in the result object.
+
+## Migration
+
+No migration required. Existing skills are unaffected; only newly generated active-mode skills will include the new `missing_source_knowledge_ids` frontmatter block when their source IDs include missing entries. Downstream parsers (e.g., `parseDraftFrontmatter`) already handle arbitrary frontmatter keys gracefully.
+
+## Breaking changes
+
+None.
+
+## Known caveats
+
+- The string-based YAML frontmatter manipulation in `injectMissingIdsIntoFrontmatter` handles the standard multi-line `source_knowledge_ids:` block emitted by `renderSkillMarkdown`. Inline flow-style (`source_knowledge_ids: [id1, id2]`) and unusual indentations are not handled, but those forms are never produced by the current `renderSkillMarkdown` output.
+- Only UTF-8 BOM is stripped from the input content. UTF-16 files would fail YAML parsing upstream of this code path.
+- The `stamped` return value may contain duplicates when an ID exists in both swarm and hive. This is cosmetic (no caller iterates `stamped`); both in-source callers destructure only `{ missing }`.

--- a/src/services/skill-generator.ts
+++ b/src/services/skill-generator.ts
@@ -514,6 +514,7 @@ export interface GenerateResult {
 		path: string;
 		mode: GenerateMode;
 		sourceKnowledgeIds: string[];
+		missingSourceKnowledgeIds?: string[];
 		preserved: boolean;
 		evaluation?: SkillEvaluationResult;
 	}>;
@@ -621,7 +622,7 @@ export async function generateSkills(
 			}
 		}
 
-		const content = renderSkillMarkdown(cluster, req.mode);
+		let content = renderSkillMarkdown(cluster, req.mode);
 		if (await isRejectedSkillContent(req.directory, cluster.slug, content)) {
 			result.skipped.push({
 				slug: cluster.slug,
@@ -666,22 +667,30 @@ export async function generateSkills(
 				continue;
 			}
 		}
-		await atomicWrite(targetPath, content);
-
-		// In active mode, stamp source entries with the generated_skill metadata.
+		// In active mode, stamp source entries with the generated_skill metadata
+		// BEFORE writing so that any missing IDs can be surfaced in the
+		// frontmatter at compile time.
+		let missingSourceIds: string[] = [];
 		if (req.mode === 'active') {
-			await stampSourceEntries(
+			const { missing } = await stampSourceEntries(
 				req.directory,
 				cluster.slug,
 				cluster.entries.map((e) => e.id),
 			);
+			missingSourceIds = missing;
+			if (missingSourceIds.length > 0) {
+				content = injectMissingIdsIntoFrontmatter(content, missingSourceIds);
+			}
 		}
+
+		await atomicWrite(targetPath, content);
 
 		result.written.push({
 			slug: cluster.slug,
 			path: targetPath,
 			mode: req.mode,
 			sourceKnowledgeIds: cluster.entries.map((e) => e.id),
+			missingSourceKnowledgeIds: missingSourceIds,
 			preserved,
 			evaluation,
 		});
@@ -691,43 +700,128 @@ export async function generateSkills(
 }
 
 /**
+ * Inject a `missing_source_knowledge_ids:` block into the YAML frontmatter
+ * immediately after the `source_knowledge_ids:` block so that unresolved IDs
+ * are visible at compile time.  Returns the content unchanged when:
+ *   - `missingIds` is empty
+ *   - the frontmatter cannot be parsed (no opening `---` fence or missing
+ *     closing fence)
+ *   - `source_knowledge_ids:` is not found in the frontmatter
+ *
+ * Uses simple string manipulation — no full YAML parser required.
+ */
+function injectMissingIdsIntoFrontmatter(
+	content: string,
+	missingIds: string[],
+): string {
+	if (missingIds.length === 0) return content;
+
+	const stripped =
+		content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
+	const openFence = stripped.match(/^---[ \t]*\r?\n/);
+	if (!openFence) return content;
+	const fenceLen = openFence[0].length;
+	const closeFence = stripped.slice(fenceLen).match(/\n---[ \t]*(\r?\n|$)/);
+	if (!closeFence) return content;
+
+	const closeStart = fenceLen + (closeFence.index ?? 0);
+	const body = stripped.slice(fenceLen, closeStart).replace(/\r\n/g, '\n');
+
+	// Find the `source_knowledge_ids:` line so we can insert after its block.
+	const sourceIdx = body.indexOf('source_knowledge_ids:');
+	if (sourceIdx === -1) return content;
+
+	// Walk forward from `source_knowledge_ids:` to find the end of its list
+	// (the next non-indented, non-empty line, or end of frontmatter body).
+	const afterLabel = body.indexOf('\n', sourceIdx);
+	const listStart = afterLabel === -1 ? body.length : afterLabel + 1;
+	const lines = body.split('\n');
+	let insertIdx = -1;
+	for (let i = 0; i < lines.length; i++) {
+		if (lines[i].length === 0) continue;
+		// Skip lines that are part of the `source_knowledge_ids:` value block.
+		const relativePos = body.indexOf(lines[i], listStart);
+		if (relativePos >= 0 && relativePos < listStart + 2) continue; // on the label line
+		if (
+			body.slice(listStart, body.indexOf(lines[i], listStart)).match(/^\s+-/)
+		) {
+			// still inside the list block
+			continue;
+		}
+		insertIdx = body.indexOf(lines[i], listStart);
+		break;
+	}
+	if (insertIdx === -1) insertIdx = body.length;
+
+	const missingBlock = [
+		'missing_source_knowledge_ids:',
+		...missingIds.map((id) => `  - ${id}`),
+		'',
+	].join('\n');
+
+	const newBody =
+		body.slice(0, insertIdx) + missingBlock + body.slice(insertIdx);
+
+	const prefix = stripped.slice(0, fenceLen);
+	const suffix = stripped.slice(closeStart);
+	return prefix + newBody + suffix;
+}
+
+/**
  * Stamp source knowledge entries with `generated_skill_slug` and
  * `generated_skill_path` metadata. Refactored in Phase G′ to take
  * `(directory, slug, ids)` so it can be called both from direct active-mode
  * generation AND from `activateProposal` after parsing the draft frontmatter.
+ *
+ * Returns the IDs that were successfully stamped and the IDs that were not
+ * found in swarm/hive knowledge (so callers can surface staleness).
  */
 async function stampSourceEntries(
 	directory: string,
 	slug: string,
 	ids: string[],
-): Promise<void> {
-	if (!ids || ids.length === 0) return;
+): Promise<{ stamped: string[]; missing: string[] }> {
+	if (!ids || ids.length === 0) return { stamped: [], missing: [] };
 	const swarmPath = resolveSwarmKnowledgePath(directory);
 	const swarm = await readKnowledge<SwarmKnowledgeEntry>(swarmPath);
 	const idSet = new Set(ids);
-	let touched = false;
+	const stamped: string[] = [];
+	const missing: string[] = [];
+	const found = new Set<string>();
 	const repoRel = activeRepoRelativePath(slug);
 	for (const e of swarm) {
 		if (!idSet.has(e.id)) continue;
+		found.add(e.id);
 		(e as KnowledgeEntryBase).generated_skill_slug = slug;
 		(e as KnowledgeEntryBase).generated_skill_path = repoRel;
 		e.updated_at = new Date().toISOString();
-		touched = true;
 	}
-	if (touched) await rewriteKnowledge(swarmPath, swarm);
+	if (found.size > 0) await rewriteKnowledge(swarmPath, swarm);
+	stamped.push(...found);
 
 	const hivePath = resolveHiveKnowledgePath();
-	if (!existsSync(hivePath)) return;
+	if (!existsSync(hivePath)) {
+		for (const id of ids) {
+			if (!found.has(id)) missing.push(id);
+		}
+		return { stamped, missing };
+	}
 	const hive = await readKnowledge<HiveKnowledgeEntry>(hivePath);
-	let touchedHive = false;
+	const foundHive = new Set<string>();
 	for (const e of hive) {
 		if (!idSet.has(e.id)) continue;
+		foundHive.add(e.id);
 		(e as KnowledgeEntryBase).generated_skill_slug = slug;
 		(e as KnowledgeEntryBase).generated_skill_path = repoRel;
 		e.updated_at = new Date().toISOString();
-		touchedHive = true;
 	}
-	if (touchedHive) await rewriteKnowledge(hivePath, hive);
+	if (foundHive.size > 0) await rewriteKnowledge(hivePath, hive);
+	stamped.push(...foundHive);
+	const allFound = new Set([...found, ...foundHive]);
+	for (const id of ids) {
+		if (!allFound.has(id)) missing.push(id);
+	}
+	return { stamped, missing };
 }
 
 /**

--- a/src/services/skill-generator.ts
+++ b/src/services/skill-generator.ts
@@ -672,10 +672,17 @@ export async function generateSkills(
 		// frontmatter at compile time.
 		let missingSourceIds: string[] = [];
 		if (req.mode === 'active') {
+			// Stamp ALL requested source IDs (not just the ones that survived
+			// filtering into the cluster) so that phantom IDs absent from both
+			// swarm and hive are surfaced in missingSourceKnowledgeIds and the
+			// frontmatter's missing_source_knowledge_ids block.
+			const idsToStamp = req.sourceKnowledgeIds?.length
+				? req.sourceKnowledgeIds
+				: cluster.entries.map((e) => e.id);
 			const { missing } = await stampSourceEntries(
 				req.directory,
 				cluster.slug,
-				cluster.entries.map((e) => e.id),
+				idsToStamp,
 			);
 			missingSourceIds = missing;
 			if (missingSourceIds.length > 0) {

--- a/tests/unit/services/skill-generator.test.ts
+++ b/tests/unit/services/skill-generator.test.ts
@@ -348,6 +348,87 @@ describe('generateSkills active mode', () => {
 	});
 });
 
+// ============================================================================
+// PR #1485 — missing source knowledge IDs
+// ============================================================================
+
+describe('generateSkills active mode — PR #1485 missing source knowledge IDs', () => {
+	it('surfaces missing source knowledge IDs in result.written[].missingSourceKnowledgeIds', async () => {
+		// Two entries with matching tags so clusterEntries produces one skill.
+		// The cluster's sourceKnowledgeIds will be ['e1', 'e2']; the phantom
+		// ID is absent from swarm and will surface in missingSourceKnowledgeIds.
+		await seed([
+			makeEntry('e1', { tags: ['scope', 'pr-1485'] }),
+			makeEntry('e2', { tags: ['scope', 'pr-1485'] }),
+		]);
+		const result = await generateSkills({
+			directory: tmp,
+			mode: 'active',
+			sourceKnowledgeIds: ['e1', 'e2', 'does-not-exist-uuid'],
+		});
+		expect(result.written.length).toBeGreaterThan(0);
+		const written = result.written[0];
+		expect(written.missingSourceKnowledgeIds).toBeDefined();
+		expect(written.missingSourceKnowledgeIds).toBeArray();
+		expect(written.missingSourceKnowledgeIds).toContain('does-not-exist-uuid');
+		// e1 and e2 were found in swarm — must NOT appear in missing
+		expect(written.missingSourceKnowledgeIds).not.toContain('e1');
+		expect(written.missingSourceKnowledgeIds).not.toContain('e2');
+		// sourceKnowledgeIds reflects only entries that were actually compiled
+		expect(written.sourceKnowledgeIds).toEqual(['e1', 'e2']);
+	});
+
+	it('writes missing_source_knowledge_ids to the active SKILL.md frontmatter', async () => {
+		await seed([
+			makeEntry('e1', { tags: ['scope', 'pr-1485-fm'] }),
+			makeEntry('e2', { tags: ['scope', 'pr-1485-fm'] }),
+		]);
+		const result = await generateSkills({
+			directory: tmp,
+			mode: 'active',
+			sourceKnowledgeIds: ['e1', 'e2', 'does-not-exist-uuid'],
+		});
+		expect(result.written.length).toBeGreaterThan(0);
+		const content = readFileSync(result.written[0].path, 'utf-8');
+		// Frontmatter must contain the missing_source_knowledge_ids key
+		expect(content).toContain('missing_source_knowledge_ids:');
+		// The phantom ID must appear with 2-space indent as a YAML list item
+		expect(content).toContain('  - does-not-exist-uuid');
+		// e1 and e2 were found in swarm — must NOT appear in the missing block
+		const missingBlockMatch = content.match(
+			/missing_source_knowledge_ids:\n(?:[ \t]+-.*\n)*/,
+		);
+		expect(missingBlockMatch).not.toBeNull();
+		expect(missingBlockMatch![0]).not.toContain('  - e1');
+		expect(missingBlockMatch![0]).not.toContain('  - e2');
+	});
+
+	it('hive early-return path is exercised when the hive file is absent', async () => {
+		// No .swarm/hive file exists in tmp — resolveHiveKnowledgePath() returns
+		// a home-directory path, so existsSync is false and stampSourceEntries
+		// returns immediately after the swarm scan with all non-found IDs in `missing`.
+		await seed([
+			makeEntry('e1', { tags: ['scope', 'pr-1485-hive'] }),
+			makeEntry('e2', { tags: ['scope', 'pr-1485-hive'] }),
+		]);
+		const result = await generateSkills({
+			directory: tmp,
+			mode: 'active',
+			sourceKnowledgeIds: ['e1', 'e2', 'phantom-no-hive'],
+		});
+		// Skill was written without throwing (early-return path exercised)
+		expect(result.written.length).toBeGreaterThan(0);
+		const written = result.written[0];
+		expect(written.path.endsWith('SKILL.md')).toBe(true);
+		expect(existsSync(written.path)).toBe(true);
+		// missing contains only the ID absent from swarm (hive doesn't exist)
+		expect(written.missingSourceKnowledgeIds).toBeDefined();
+		expect(written.missingSourceKnowledgeIds).toContain('phantom-no-hive');
+		expect(written.missingSourceKnowledgeIds).not.toContain('e1');
+		expect(written.missingSourceKnowledgeIds).not.toContain('e2');
+	});
+});
+
 describe('listSkills + inspectSkill + activateProposal', () => {
 	it('lists drafts/active and inspects content', async () => {
 		await seed([makeEntry('l1'), makeEntry('l2')]);


### PR DESCRIPTION
## Summary

Addresses recommendation 2 from the skill_improver proposal: \stampSourceEntries\ silently skipped source knowledge IDs that didn't exist in the knowledge store, causing skills to become stale with no visible warning at compile time.

### Changes

- \stampSourceEntries\ now returns \{ stamped: string[], missing: string[] }\ instead of \oid\ — tracks which IDs were NOT found in swarm OR hive knowledge
- Active-mode compile path captures missing IDs and injects \missing_source_knowledge_ids\ into skill YAML frontmatter via new \injectMissingIdsIntoFrontmatter\ helper
- \GenerateResult.written\ type extended with optional \missingSourceKnowledgeIds\ field
- Result object includes missing IDs for programmatic callers

### Before vs After

**Before:** Skill compiled with 3 source IDs where 1 is archived → skill stamped, no warning, staleness detected only at skill_improver review time.

**After:** Same scenario → skill compiled, \missing_source_knowledge_ids: [archived-id]\ written to frontmatter, \missingSourceKnowledgeIds\ in result object. Staleness visible at compile time.

## Invariant audit

- 1 (plugin init): not touched
- 2 (runtime portability): not touched
- 3 (subprocesses): not touched
- 4 (.swarm containment): not touched
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched
- 7 (test writing): not touched
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched
- 12 (release/cache): not touched — internal skill compiler improvement, no user-visible behavior change

## Test plan

- [x] \un install\ (triggers build + tsc --emitDeclarationOnly) — PASS
- [x] \un run biome check\ — PASS (auto-fixed 1 file)