### PR TITLE
fix(pr-monitor): make CLI pr status visible across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,7 +1105,7 @@ Control how tool outputs are summarized for LLM context.
 | `/swarm pr-feedback [<pr-url\|owner/repo#N\|N>] [instructions...]` | Ingest and close known PR feedback (review comments, CI failures, conflicts) without a fresh review |
 | `/swarm pr subscribe <pr-url\|owner/repo#N\|N>` | Subscribe current session to PR monitoring (session-scoped); requires `pr_monitor.enabled: true` |
 | `/swarm pr unsubscribe <pr-url\|owner/repo#N\|N>` | Remove session's subscription to a PR |
-| `/swarm pr status` | List active PR subscriptions for current session with relative timestamps |
+| `/swarm pr status` | List active PR subscriptions for current session with relative timestamps (the `bunx opencode-swarm run pr status` CLI has no session context, so it lists subscriptions across all sessions) |
 | `/swarm deep-dive <scope> [--profile <name>] [--max-explorers <n>]` | Read-only codebase audit with parallel explorers, dual reviewers, and critic challenge |
 | `/swarm design-docs <description> [--out <dir>] [--lang <name>] [--update]` | Generate or sync language-agnostic design docs (requires `design_docs.enabled`) |
 | `/swarm dark-matter` | Detect hidden file couplings from co-change history |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -772,7 +772,7 @@ When you type a two-word command like `/swarm config doctor`, Swarm tries the co
 | `/swarm evidence summary` | `/swarm evidence-summary` | |
 | `/swarm pr subscribe` | `/swarm pr-subscribe` | TUI shim (deprecated) |
 | `/swarm pr unsubscribe` | `/swarm pr-unsubscribe` | TUI shim (deprecated) |
-| `/swarm pr status` | `/swarm pr-status` | TUI shim (deprecated) |
+| `/swarm pr status` | `/swarm pr-status` | TUI shim (deprecated). In a session (TUI/chat) it is session-scoped; the `bunx opencode-swarm run pr status` CLI has no session context and lists all sessions. |
 | `/swarm sdd status` | `/swarm sdd-status` | TUI shim (deprecated) |
 | `/swarm sdd validate` | `/swarm sdd-validate` | TUI shim (deprecated) |
 | `/swarm sdd project` | `/swarm sdd-project` | TUI shim (deprecated) |

--- a/docs/releases/pending/1484-pr-status-sessionless-visibility.md
+++ b/docs/releases/pending/1484-pr-status-sessionless-visibility.md
@@ -1,0 +1,48 @@
+# PR status CLI false-negative + clearer session-less subscribe error
+
+## What changed
+
+- **`/swarm pr status` from the CLI now lists subscriptions across all sessions**
+  (`src/commands/pr-monitor-status.ts`, `src/commands/registry.ts`): The
+  `bunx opencode-swarm run pr status` path has no session context (it passes an
+  empty `sessionID`), so the previous `record.sessionID === sessionID` filter
+  always matched zero rows and reported "No active PR subscriptions for this
+  session" even when subscriptions existed. The status handler now takes the
+  command `source`; when `source === 'cli'` it lists every active subscription
+  with the owning session id per record and an "all sessions" header. Every
+  other caller — TUI, chat, and the agent-facing `swarm_command` tool
+  (`source: 'chat'`) — stays session-scoped, so an agent can never be handed a
+  cross-session dump.
+
+- **`/swarm pr subscribe` returns a clear "no active session" error when invoked
+  without a session** (`src/commands/pr-subscribe.ts`): Previously a session-less
+  caller surfaced the store-layer `sessionID is required` throw as an opaque
+  "Failed to subscribe" error. The handler now fails up front with an actionable
+  message and never calls the store.
+
+## Why
+
+Issue #1484: `/swarm pr subscribe` showed a success message while
+`bunx opencode-swarm pr status` reported "No active PR subscriptions for this
+session", which looked like a silent subscribe failure. Investigation showed the
+subscribe actually succeeds; the CLI `pr status` was a blind verifier — it could
+never display a subscription created inside a session because it filtered on an
+empty session id. There is no "finalized session" no-op: subscribe writes
+regardless of plan state, and an empty session id throws rather than silently
+succeeding.
+
+## How to use
+
+No config changes. `bunx opencode-swarm run pr status` now shows active
+subscriptions (across sessions, with the owning session id). Inside a session,
+`/swarm pr status` remains session-scoped. PR subscriptions remain session-scoped
+and must be created from inside an OpenCode session.
+
+## Invariant audit
+
+- INV-4 (.swarm containment): no path changes; store path unchanged
+- INV-7 (tests): new bun:test cases for the CLI source path and the session-less
+  subscribe error; no `mock.module` added (uses existing `_internals` DI seam)
+- INV-8 (session state): no session-state changes; status read is lock-free
+- INV-10 (chat hooks): no chat-hook changes
+- INV-12 (release): this fragment

--- a/src/commands/pr-monitor-status.ts
+++ b/src/commands/pr-monitor-status.ts
@@ -58,38 +58,59 @@ export async function handlePrMonitorStatusCommand(
 	directory: string,
 	_args: string[],
 	sessionID: string,
+	source?: 'cli' | 'chat',
 ): Promise<string> {
 	const allActive = await _internals.listActive(directory);
-	const sessionSubs = allActive.filter(
-		(record) => record.sessionID === sessionID,
-	);
 
-	if (sessionSubs.length === 0) {
-		return 'No active PR subscriptions for this session.';
+	// Subscriptions are session-scoped, but the `bunx opencode-swarm run pr
+	// status` CLI path has no session context (it passes sessionID ''), so a
+	// session-equality filter there always yields zero rows and falsely reports
+	// "no subscriptions" even when subscriptions exist (issue #1484). For the
+	// human CLI ONLY, list every active subscription across sessions so the CLI
+	// is a usable verifier. Every other caller — TUI, chat, and the agent-facing
+	// `swarm_command` tool (source 'chat') — stays session-scoped, so an agent
+	// can never be handed a cross-session dump even if its sessionID is empty.
+	const allSessions = source === 'cli';
+	const subs = allSessions
+		? allActive
+		: allActive.filter((record) => record.sessionID === sessionID);
+
+	if (subs.length === 0) {
+		return allSessions
+			? 'No active PR subscriptions.'
+			: 'No active PR subscriptions for this session.';
 	}
 
 	const lines: string[] = [];
-	lines.push(`PR Monitor Status — Session: ${sessionID}`);
+	lines.push(
+		allSessions
+			? 'PR Monitor Status — all sessions'
+			: `PR Monitor Status — Session: ${sessionID}`,
+	);
 	lines.push('');
 
 	const totalActive = allActive.length;
-	lines.push(`Active subscriptions (${sessionSubs.length}):`);
+	lines.push(`Active subscriptions (${subs.length}):`);
 
-	for (let i = 0; i < sessionSubs.length; i++) {
-		const sub = sessionSubs[i];
+	for (let i = 0; i < subs.length; i++) {
+		const sub = subs[i];
 		const index = i + 1;
 		lines.push(`  ${index}. ${sub.repoFullName}#${sub.prNumber}`);
 		lines.push(`     URL: ${sub.prUrl}`);
+		// Disambiguate ownership only in the cross-session (CLI) listing.
+		if (allSessions) {
+			lines.push(`     Session: ${sub.sessionID}`);
+		}
 		lines.push(`     Last checked: ${formatRelativeTime(sub.lastCheckedAt)}`);
 		lines.push(`     Watching: ${sub.isWatching ? 'yes' : 'no'}`);
 		lines.push(`     Errors: ${sub.errorCount}`);
-		if (i < sessionSubs.length - 1) {
+		if (i < subs.length - 1) {
 			lines.push('');
 		}
 	}
 
 	lines.push('');
-	if (totalActive !== sessionSubs.length) {
+	if (!allSessions && totalActive !== subs.length) {
 		lines.push(`Total active across all sessions: ${totalActive}`);
 	}
 

--- a/src/commands/pr-subscribe.ts
+++ b/src/commands/pr-subscribe.ts
@@ -72,6 +72,21 @@ export async function handlePrSubscribeCommand(
 		].join('\n');
 	}
 
+	// PR monitoring is session-scoped: the subscription is keyed by the active
+	// session id. Without a live session (e.g. the `bunx opencode-swarm run`
+	// CLI, which has no session context) there is nothing to scope the
+	// subscription to. Fail clearly here instead of letting the store-layer
+	// `sessionID is required` throw surface as an opaque "Failed to subscribe"
+	// error, and never imply success (issue #1484).
+	if (!sessionID || sessionID.trim() === '') {
+		return [
+			'Error: Cannot subscribe — no active session.',
+			'',
+			'PR subscriptions are session-scoped and require a live OpenCode session.',
+			'Subscribe from inside OpenCode; the bunx CLI has no session context.',
+		].join('\n');
+	}
+
 	const repoFullName = `${prInfo.owner}/${prInfo.repo}`;
 	const prUrl = `https://github.com/${prInfo.owner}/${prInfo.repo}/pull/${prInfo.number}`;
 

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -900,7 +900,12 @@ export const COMMAND_REGISTRY = {
 	},
 	'pr status': {
 		handler: (ctx) =>
-			handlePrMonitorStatusCommand(ctx.directory, ctx.args, ctx.sessionID),
+			handlePrMonitorStatusCommand(
+				ctx.directory,
+				ctx.args,
+				ctx.sessionID,
+				ctx.source,
+			),
 		description: 'Show PR monitor subscription status for the current session',
 		args: '',
 		details:
@@ -913,7 +918,12 @@ export const COMMAND_REGISTRY = {
 	// See the 'pr-subscribe' alias note above.
 	'pr-status': {
 		handler: (ctx) =>
-			handlePrMonitorStatusCommand(ctx.directory, ctx.args, ctx.sessionID),
+			handlePrMonitorStatusCommand(
+				ctx.directory,
+				ctx.args,
+				ctx.sessionID,
+				ctx.source,
+			),
 		description: 'Show PR monitor subscription status for the current session',
 		aliasOf: 'pr status',
 		deprecated: true,

--- a/tests/unit/commands/pr-monitor-status.test.ts
+++ b/tests/unit/commands/pr-monitor-status.test.ts
@@ -492,12 +492,7 @@ describe('handlePrMonitorStatusCommand', () => {
 			);
 
 			// CLI passes sessionID '' — pre-fix this filtered to zero rows.
-			const result = await handlePrMonitorStatusCommand(
-				tempDir,
-				[],
-				'',
-				'cli',
-			);
+			const result = await handlePrMonitorStatusCommand(tempDir, [], '', 'cli');
 
 			expect(result).toContain('PR Monitor Status — all sessions');
 			expect(result).toContain('Active subscriptions (2):');
@@ -513,12 +508,7 @@ describe('handlePrMonitorStatusCommand', () => {
 		test('empty store returns the generic no-subscriptions message', async () => {
 			mockListActive.mockImplementation(() => Promise.resolve([]));
 
-			const result = await handlePrMonitorStatusCommand(
-				tempDir,
-				[],
-				'',
-				'cli',
-			);
+			const result = await handlePrMonitorStatusCommand(tempDir, [], '', 'cli');
 
 			expect(result).toBe('No active PR subscriptions.');
 		});

--- a/tests/unit/commands/pr-monitor-status.test.ts
+++ b/tests/unit/commands/pr-monitor-status.test.ts
@@ -452,6 +452,110 @@ describe('handlePrMonitorStatusCommand', () => {
 			expect(result).not.toContain('Total active across all sessions');
 		});
 	});
+	// Regression for issue #1484: the CLI `run pr status` path has no session
+	// context (sessionID ''), so a session filter falsely reported "no
+	// subscriptions". With source 'cli', list every active subscription across
+	// sessions; all other callers stay session-scoped.
+	describe('CLI source (source="cli") — cross-session listing', () => {
+		test('lists subscriptions from all sessions with per-record session id', async () => {
+			mockListActive.mockImplementation(() =>
+				Promise.resolve([
+					{
+						correlationId: 'ses_real::owner/repo::1',
+						sessionID: 'ses_real',
+						prNumber: 1,
+						repoFullName: 'owner/repo',
+						prUrl: 'https://github.com/owner/repo/pull/1',
+						lastCheckedAt: Date.now() - 60_000,
+						isWatching: true,
+						hasUnaddressedEvents: false,
+						status: 'active' as const,
+						createdAt: Date.now() - 120_000,
+						updatedAt: Date.now() - 60_000,
+						errorCount: 0,
+					},
+					{
+						correlationId: 'ses_other::other/repo::2',
+						sessionID: 'ses_other',
+						prNumber: 2,
+						repoFullName: 'other/repo',
+						prUrl: 'https://github.com/other/repo/pull/2',
+						lastCheckedAt: Date.now() - 60_000,
+						isWatching: true,
+						hasUnaddressedEvents: false,
+						status: 'active' as const,
+						createdAt: Date.now() - 120_000,
+						updatedAt: Date.now() - 60_000,
+						errorCount: 0,
+					},
+				]),
+			);
+
+			// CLI passes sessionID '' — pre-fix this filtered to zero rows.
+			const result = await handlePrMonitorStatusCommand(
+				tempDir,
+				[],
+				'',
+				'cli',
+			);
+
+			expect(result).toContain('PR Monitor Status — all sessions');
+			expect(result).toContain('Active subscriptions (2):');
+			expect(result).toContain('owner/repo#1');
+			expect(result).toContain('other/repo#2');
+			// Cross-session listing discloses the owning session per record.
+			expect(result).toContain('Session: ses_real');
+			expect(result).toContain('Session: ses_other');
+			// Session-scoped artifacts must not appear in the CLI listing.
+			expect(result).not.toContain('Total active across all sessions');
+		});
+
+		test('empty store returns the generic no-subscriptions message', async () => {
+			mockListActive.mockImplementation(() => Promise.resolve([]));
+
+			const result = await handlePrMonitorStatusCommand(
+				tempDir,
+				[],
+				'',
+				'cli',
+			);
+
+			expect(result).toBe('No active PR subscriptions.');
+		});
+
+		test('non-CLI source with empty sessionID stays session-scoped (no leak)', async () => {
+			mockListActive.mockImplementation(() =>
+				Promise.resolve([
+					{
+						correlationId: 'ses_other::other/repo::2',
+						sessionID: 'ses_other',
+						prNumber: 2,
+						repoFullName: 'other/repo',
+						prUrl: 'https://github.com/other/repo/pull/2',
+						lastCheckedAt: Date.now() - 60_000,
+						isWatching: true,
+						hasUnaddressedEvents: false,
+						status: 'active' as const,
+						createdAt: Date.now() - 120_000,
+						updatedAt: Date.now() - 60_000,
+						errorCount: 0,
+					},
+				]),
+			);
+
+			// e.g. the agent `swarm_command` tool path (source 'chat') with an
+			// empty sessionID must NOT receive a cross-session dump.
+			const result = await handlePrMonitorStatusCommand(
+				tempDir,
+				[],
+				'',
+				'chat',
+			);
+
+			expect(result).toBe('No active PR subscriptions for this session.');
+			expect(result).not.toContain('other/repo#2');
+		});
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/commands/pr-subscribe.test.ts
+++ b/tests/unit/commands/pr-subscribe.test.ts
@@ -445,8 +445,13 @@ describe('pr-subscribe adversarial security tests', () => {
 		});
 	});
 
-	describe('4 — empty sessionID', () => {
-		test('empty sessionID is passed through to subscribe (no handler validation)', async () => {
+	describe('4 — no active session (empty sessionID)', () => {
+		// Regression for issue #1484: a session-less caller (e.g. the bunx CLI,
+		// which passes sessionID '') must get a clear "no active session" error,
+		// not a success message and not the opaque store-layer
+		// "Failed to subscribe … sessionID is required" throw. subscribe() must
+		// not be invoked.
+		test('empty sessionID returns a clear no-session error and does not subscribe', async () => {
 			mockSubscribe.mockImplementation(() => Promise.resolve({}));
 
 			const result = await handlePrSubscribeCommand(
@@ -455,28 +460,41 @@ describe('pr-subscribe adversarial security tests', () => {
 				'', // empty sessionID
 			);
 
-			expect(result).toContain('Subscribed to');
-			expect(mockSubscribe).toHaveBeenCalledWith(
-				tempDir,
-				expect.objectContaining({
-					sessionID: '',
-					prNumber: 123,
-					repoFullName: 'owner/repo',
-				}),
-			);
+			expect(result).toContain('Cannot subscribe — no active session.');
+			expect(result).not.toContain('Subscribed to');
+			expect(mockSubscribe).not.toHaveBeenCalled();
 		});
 
-		test('whitespace-only sessionID is passed through', async () => {
+		test('whitespace-only sessionID returns the no-session error and does not subscribe', async () => {
 			mockSubscribe.mockImplementation(() => Promise.resolve({}));
 
-			await handlePrSubscribeCommand(tempDir, ['owner/repo#456'], '   ');
-
-			expect(mockSubscribe).toHaveBeenCalledWith(
+			const result = await handlePrSubscribeCommand(
 				tempDir,
-				expect.objectContaining({
-					sessionID: '   ',
-				}),
+				['owner/repo#456'],
+				'   ',
 			);
+
+			expect(result).toContain('Cannot subscribe — no active session.');
+			expect(result).not.toContain('Subscribed to');
+			expect(mockSubscribe).not.toHaveBeenCalled();
+		});
+
+		test('invalid PR reference is reported before the no-session check', async () => {
+			mockSubscribe.mockImplementation(() => Promise.resolve({}));
+
+			// PR-ref validation runs first, so an invalid ref wins over the
+			// no-session error even when the sessionID is also empty. Either way,
+			// subscribe() is never called.
+			const result = await handlePrSubscribeCommand(
+				tempDir,
+				['not-a-pr-ref'],
+				'',
+			);
+
+			expect(result).toContain('is not a valid PR reference');
+			expect(result).not.toContain('Cannot subscribe — no active session.');
+			expect(result).not.toContain('Subscribed to');
+			expect(mockSubscribe).not.toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
Closes #1484

## Summary

`/swarm pr subscribe` was reported to show a success message while a subsequent
`bunx opencode-swarm pr status` returned "No active PR subscriptions for this
session", which looked like a silent subscribe failure in a finalized session.

Runtime investigation disproved that mechanism. `/swarm pr subscribe` actually
writes the subscription (and an empty session id throws rather than silently
succeeding). The real defect is that the **CLI `pr status` path passes an empty
`sessionID`**, and the status command filtered `record.sessionID === sessionID`,
so it could never display a subscription created inside a session — a guaranteed
false negative used as the user's "ground truth". There is no finalized-session
no-op; subscribe works regardless of plan state (the finalized-gate from the
issue was declined by the reporter as it would block legitimate post-plan
monitoring).

Changes:
- **`pr status` from the human CLI now lists subscriptions across all sessions.**
  The status handler takes the command `source`; when `source === 'cli'` it lists
  every active subscription with the owning session id and an "all sessions"
  header. TUI, chat, and the agent `swarm_command` tool (`source: 'chat'`) stay
  session-scoped, so an agent can never receive a cross-session dump.
  (`src/commands/pr-monitor-status.ts`, `src/commands/registry.ts`)
- **`pr subscribe` returns a clear "no active session" error** when invoked
  without a session, instead of the opaque store-layer "Failed to subscribe"
  throw, and never implies success. (`src/commands/pr-subscribe.ts`)
- Docs + release fragment.

## Invariant audit

- INV-4 (.swarm containment): no path/store changes; subscription store key logic
  untouched.
- INV-7 (tests): new bun:test cases via the existing `_internals` DI seam; no
  `mock.module` added; typecheck + lint clean.
- INV-8 (session state): status read remains a lock-free fold; no session-state
  writes.
- INV-10 (chat hooks): no chat-hook changes.
- INV-12 (release): fragment `docs/releases/pending/1484-pr-status-sessionless-visibility.md`.

## Test plan

- `bun test tests/unit/commands/pr-monitor-status.test.ts` → 24 pass / 0 fail
  (new: CLI cross-session listing, empty-store CLI message, non-CLI no-leak).
- `bun test tests/unit/commands/pr-subscribe.test.ts` → 35 pass / 6 fail; the 6
  are pre-existing and identical on the untouched baseline (PR-ref resolution
  requires a real git origin, absent in CI sandbox); +1 net pass from the new
  no-session/priority tests.
- `bun run typecheck` → clean. `biome lint` (changed files) → clean.
- End-to-end repro: after a real subscribe, CLI status now shows the subscription
  ("all sessions" + "Session: …"); agent/chat path stays scoped; TUI unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGWnHcjkHJR3dmi34ZxQp5)_