### PR TITLE
feat(repo-graph): tree-sitter symbol-level call graph + context_pack

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,10 @@ actions include:
   Both rely on conservative, regex-based usage analysis (TS/JS/Python) recorded
   at graph schema 1.1.0; see `docs/repo-graph-call-graph.md` for scope and
   limitations.
+- `context_pack` returns a token-budgeted, symbol-level source slice (definition
+  + transitive callers/callees) built on tree-sitter extraction across all **12**
+  first-class languages (schema 1.2.0). See `docs/repo-graph-symbol-graph.md` for
+  design and limitations.
 
 The ontology extractor is intentionally conservative. It records detected facts
 and "detected missing guard" findings; it does not claim formal security proofs.

--- a/docs/releases/pending/1471-repo-graph-symbol-graph.md
+++ b/docs/releases/pending/1471-repo-graph-symbol-graph.md
@@ -1,0 +1,38 @@
+# repo-graph: schema 1.2.0 — tree-sitter symbol-level extraction & context_pack
+
+## What
+
+- Repo-graph schema bumped to **1.2.0**.
+- Tree-sitter symbol-level extraction for all 12 first-class languages: TypeScript, JavaScript, Python, Rust, Go, Java, Kotlin, C#, C/C++, Swift, Dart, Ruby, PHP.
+- New **symbol→symbol call graph** (`symbolEdges`): edges keyed by enclosing declaration, not just file-to-file.
+- Per-symbol source ranges (`exportRanges`: 1-based inclusive line spans per exported symbol).
+- New `repo_map` action **`context_pack`**: returns a token-budgeted, deduped source-context slice for a target symbol (definition + transitive callers/callees, periphery as signatures).
+
+## Why
+
+Agents currently receive file-level results only (which files reference which). The symbol-level slice (definition + callers/callees) massively reduces context burden for refactoring shared modules — agents no longer need to open whole files to act on a symbol.
+
+The prior regex extractors could not reliably produce declaration boundaries or reference attribution across grammars; tree-sitter is both the accuracy upgrade and the path to 12-language coverage without hand-writing 12 parsers.
+
+## Migration
+
+Schema 1.2.0 is **additive** — graphs built at 1.0.0 and 1.1.0 load unchanged.
+
+- Run `repo_map action="build"` to populate symbol data (`exportRanges` + `symbolEdges`); this is the **async** builder path.
+- The sync builder (`buildWorkspaceGraph`) keeps file-level data only; it does not populate symbol-level fields.
+- `context_pack` requires a 1.2.0 graph; on older graphs it returns `schemaSupported: false` with a note to rebuild (same self-gating pattern as `dead_exports` for schema < 1.1.0).
+
+## Caveats
+
+1. **Data-drift (symbols/batch_symbols vs repo_map)**: The `symbols` and `batch_symbols` tools retain the original regex extractors for backward compatibility. For TS/JS/Python files they may report different symbol names or ranges than `repo_map` produces via tree-sitter. Use `repo_map` for authoritative symbol data.
+
+2. **Conservative symbolEdges**:
+   - Namespace imports (`import * as ns`) produce `toSymbol: '*'` — no `ns.foo` decomposition.
+   - Local-variable shadowing can over-attribute references to the wrong declaration.
+   - Rare re-export forms (`export * from 'module'`) are not captured.
+
+3. **Grammar coverage**: Best-effort (~80% accuracy) on the hardest grammars (C++, C#, Kotlin, Swift, PHP). Queries degrade to fail-open (return `null` / empty arrays) — they never crash the build.
+
+4. **Symbol data is async-exclusive**: The sync builder produces file-level nodes and edges only. Symbol-level fields (`exportRanges`, `symbolEdges`) are populated only by the async builder path.
+
+5. **Advisory analysis**: Dynamic dispatch, reflection, runtime-computed access, and string-keyed member access are invisible. `dead_exports`, `context_pack`, and symbol edges are aids, never delete/edit directives.

--- a/docs/repo-graph-symbol-graph.md
+++ b/docs/repo-graph-symbol-graph.md
@@ -1,0 +1,276 @@
+# repo-graph: symbol-level call graph & context packing (schema 1.2.0)
+
+> Status: implemented (schema 1.2.0). Origin: follow-up to issue #1409 / PR #1468 (schema 1.1.0).
+> Audience: contributors implementing the next slice of structural intelligence in opencode-swarm.
+
+## Background
+
+PR #1468 (issue #1409) added schema **1.1.0** to the native `src/tools/repo-graph/`
+module: per-edge `usedSymbols` (which exported names an importer actually
+references) and per-node `exportLines` (exported symbol → definition line), plus
+the `repo_map` actions `callers` and `dead_exports`. That work deliberately used
+the module's existing **conservative regex scanner** and covered only TS/JS/Python
+(`SUPPORTED_EXTENSIONS` at `src/tools/repo-graph/builder.ts:106`).
+
+Two ceilings remain, and they are exactly what an external "codebase memory" MCP
+server claims to break through:
+
+1. **Answers are file-level.** Edges are file→file (`GraphEdge`, `types.ts:216`).
+   The graph can say "file A references symbol `foo` from file B" but not
+   "function `bar()` calls `foo()`". Agents still open whole files to act, which
+   is where context burden actually accrues.
+2. **Coverage is TS/JS/Python only**, while the repo documents **12 first-class
+   languages** in `src/lang/profiles.ts` (TypeScript, Python, Rust, Go, Java,
+   Kotlin, C#, C/C++, Swift, Dart, Ruby, PHP) and already ships tree-sitter
+   grammars for every one of them (`src/lang/runtime.ts:99`).
+
+This document specifies schema **1.2.0**: a **symbol-level call graph** built on the
+existing tree-sitter language layer, covering all 12 documented languages, plus a
+`context_pack` query that returns a token-budgeted slice of source instead of a
+file list.
+
+## Goal / non-goals
+
+**Goals**
+- Re-platform repo-graph symbol/import extraction onto `src/lang/` tree-sitter,
+  retiring the private TS/JS/Python regex scanner.
+- Cover all **12** documented profile languages.
+- Add per-symbol source ranges (`exportRanges`) and **symbol→symbol edges**.
+- Add `repo_map action="context_pack"`: a minimal, deduped, budgeted bundle of
+  source spans for a target symbol (definition + transitive callers/callees,
+  periphery as signatures).
+- Keep schema **additive and back-compatible** — 1.0.0/1.1.0 graphs still load and
+  every existing action still works.
+
+**Non-goals**
+- 158-language coverage, neural/semantic embeddings, or a persistent external
+  index. Those remain on the user-configured external-MCP track (see
+  `docs/repo-graph-call-graph.md`).
+- Whole-program type-based call resolution. Analysis stays conservative
+  (advisory), as today.
+
+## Why tree-sitter, and why now
+
+The "no AST/tree-sitter" stance in `docs/repo-graph-call-graph.md` is scoped to the
+**plugin-init path** (invariant 1), not the whole plugin. Tree-sitter is already a
+first-class, **on-demand** dependency used at tool time:
+
+- `src/diff/ast-diff.ts` parses + queries 19 languages (`loadGrammar` →
+  `parser.parse` → `new Query` → `query.matches`), with a 500 ms parse timeout and
+  `tree.delete()` cleanup.
+- `src/tools/syntax-check.ts` and `src/tools/placeholder-scan.ts` follow the same
+  pattern with bounded concurrency.
+
+`loadGrammar(languageId)` (`src/lang/runtime.ts:185`) is lazy, memoized, request-
+coalesced, and 10 s-bounded. Crucially, **`src/index.ts` never imports the
+tree-sitter runtime** — init is triggered only by query-time tools, so this work
+adds **zero** init-path cost. Regex cannot give reliable declaration boundaries or
+reference attribution across 12 languages; tree-sitter is both the accuracy upgrade
+and the only sane way to hit the documented-language contract without hand-writing
+12 parsers (which would also duplicate `src/lang/backends/*.extractImports`).
+
+## Architecture
+
+```
+src/lang/runtime.ts  loadGrammar(grammarId) → Parser   (lazy, cached; already exists)
+        │
+        ▼
+src/lang/symbol-graph.ts  (NEW)  per-grammar .scm queries → per-file facts:
+        │     defs[]    { name, kind, exported, startLine, endLine }
+        │     imports[] { specifier, importType, bindings:[{imported,local}] }
+        │     refs[]    { identifier, line, enclosingDecl }
+        ▼
+src/tools/repo-graph/builder.ts  (REWIRED, async path only for symbol data)
+        │     scanFile() calls symbol-graph instead of the regex extractors
+        │     incremental.ts re-parses only changed files (already calls scanFile)
+        ▼
+schema 1.2.0  GraphNode.exportRanges + RepoGraph.symbolEdges
+        ▼
+src/tools/repo-graph/query.ts  getContextPack() + transitive symbol slicing
+        ▼
+src/tools/repo-map.ts  action="context_pack"  (wired through all 5 surfaces)
+```
+
+### New language layer: `src/lang/symbol-graph.ts`
+
+A single language-agnostic entry point, modeled on `ast-diff.ts`'s `QUERIES` map:
+
+```ts
+export interface FileSymbolFacts {
+  defs: Array<{ name: string; kind: 'function' | 'class' | 'const' | 'type' | 'interface' | 'enum' | 'method'; exported: boolean; startLine: number; endLine: number }>;
+  imports: Array<{ specifier: string; importType: ImportType; bindings: Array<{ imported: string; local: string }> }>;
+  refs: Array<{ identifier: string; line: number; enclosingDecl: string | null }>;
+}
+
+// Async because the first grammar load is async; parse itself is synchronous.
+export async function extractFileSymbols(grammarId: string, source: string): Promise<FileSymbolFacts | null>;
+```
+
+- One inline `.scm` query set per grammar (definitions, imports, references),
+  keyed by language id — mirror the `QUERIES` shape in `src/diff/ast-diff.ts:36`.
+  Definitions reuse the existing `@func.def`/`@class.def`/`@type.def` capture
+  conventions and add `endLine` from `node.endPosition.row + 1`.
+- `enclosingDecl` (the nearest top-level declaration containing a reference) is
+  computed by walking ancestors of the captured identifier node; this is what
+  turns file→file edges into symbol→symbol edges.
+- Returns `null` on grammar-load failure/timeout (fail-open). Always
+  `tree.delete()` in a `finally`. Wrap parse in a per-file timeout (500 ms, per
+  ast-diff precedent).
+- Consolidates import extraction so repo-graph stops drifting from
+  `src/lang/backends/*.extractImports`.
+
+### Schema 1.2.0 data model (`src/tools/repo-graph/types.ts`)
+
+Additive, all optional — old graphs load unchanged.
+
+```ts
+// GraphNode (add)
+exportRanges?: Record<string, { start: number; end: number }>; // 1-based inclusive line span per exported symbol
+
+// RepoGraph (add) — symbol→symbol call graph, cross-file
+symbolEdges?: SymbolEdge[];
+
+export interface SymbolEdge {
+  fromFile: string;    // resolved absolute path (matches GraphNode.filePath keys)
+  fromSymbol: string;  // enclosing top-level decl, or '<module>' for module-scope refs
+  toFile: string;      // resolved target path
+  toSymbol: string;    // exported symbol referenced
+}
+
+// Result types for the new query
+export interface ContextPackSpan { file: string; symbol: string; startLine: number; endLine: number; mode: 'full' | 'signature'; }
+export interface ContextPackResult {
+  schemaSupported: boolean;
+  target: { file: string; symbol: string };
+  spans: ContextPackSpan[];   // deduped, budget-ordered
+  truncated: boolean;
+  estimatedTokens: number;
+  note?: string;
+}
+```
+
+`GRAPH_SCHEMA_VERSION` (`types.ts:25`) bumps to `'1.2.0'`. Every new query
+self-gates with `isSchemaVersionAtLeast(graph.schema_version, '1.2.0')` and returns
+`{ schemaSupported: false, note: 'rebuild with repo_map action="build"' }` on older
+graphs (the `getDeadExports` pattern, `query.ts:257`).
+
+### `context_pack` query (`src/tools/repo-graph/query.ts`)
+
+`getContextPack(graph, file, symbol, { maxDepth, maxTokens })`:
+1. Gate on schema ≥ 1.2.0.
+2. Seed with the target's own span from `exportRanges`.
+3. Traverse `symbolEdges` both directions to `maxDepth` (forward callees + reverse
+   callers), building a new symbol-keyed index in `buildReverseIndex` (`query.ts:63`).
+4. Emit each reached symbol's span as `mode: 'full'`; demote the periphery (depth
+   == maxDepth) to `mode: 'signature'` (first line of the range).
+5. Order by relevance (target → direct neighbors → periphery), accumulate an
+   `estimatedTokens` budget, set `truncated` when `maxTokens` is hit.
+6. Legacy fallback: on a < 1.2.0 graph, return `schemaSupported: false` (callers
+   should fall back to `callers` + manual read).
+
+### Tool wiring (`src/tools/repo-map.ts`) — all five surfaces
+
+Per the `callers`/`dead_exports` precedent, a new action is incomplete until it
+touches **every** one of these (no unwired code):
+
+1. `VALID_ACTIONS` array (`repo-map.ts:49`).
+2. The duplicated zod `action` enum + its `.describe()` (`repo-map.ts:163`).
+3. The tool `description` action catalog (`repo-map.ts:150`).
+4. The args schema — add `max_depth`/budget handling to `RepoMapArgs` if needed
+   (`repo-map.ts:68`,`162`).
+5. The dispatch branch in `execute` (file+symbol required → after the `!a.file`
+   guard, reusing `validateFile`/`validateSymbol`/`toRelativeGraphPath`).
+   `getContextPack` must be imported and **re-exported through the barrel**
+   `src/tools/repo-graph.ts` or `repo-map.ts` cannot reach it.
+
+## The sync/async + #1144 parity decision
+
+`loadGrammar` is async; the sync `buildWorkspaceGraph` (`builder.ts:1216`) cannot
+await it. Investigation shows the production build hook already defaults to
+`buildWorkspaceGraphAsync` (`src/hooks/repo-graph-builder.ts:110`), and
+`loadGraphSync` only **reads** persisted JSON (`src/hooks/repo-graph-injection.ts:59`).
+
+**Decision:** symbol-level data (`exportRanges`, `symbolEdges`) is populated **only
+by the async builder**. The sync builder remains for the homedir-guard tests and
+any sync caller, producing file-level data only (it keeps a lightweight fallback
+for `imports`/`exports` so its existing contract holds). The issue #1144 parity
+test is **redefined**: sync and async must agree on all **file-level** fields
+(`nodes` minus symbol fields, `edges`); symbol-level fields are asserted
+**async-exclusive** (absent in sync, present and deterministic across two async
+runs). This preserves #1144 for everything it currently guards while allowing
+async-only symbol extraction.
+
+## Language coverage
+
+All **12** profile languages, resolved via `getProfileForFile(path)` →
+`profile.treeSitter.grammarId` (`src/lang/profiles.ts`), each with a grammar in
+`LANGUAGE_WASM_MAP` (`runtime.ts:99`). Each language needs a `.scm` query set in
+`symbol-graph.ts`. `SUPPORTED_EXTENSIONS`/`EXTENSION_TO_LANGUAGE`/`getLanguage` in
+the builder are replaced by a lookup through the language registry so the supported
+set is driven by the profiles, not a hard-coded list. Files whose grammar is
+unavailable or that exceed the size cap degrade to a file-level node (fail-open),
+never crashing the build.
+
+## Invariant audit (for the implementing PR)
+
+- **1 (plugin init): touched, must be proven safe.** Tree-sitter is async/lazy and
+  off the init path (`src/index.ts` imports no runtime). Add a test asserting init
+  never loads a grammar; keep the `repro-704` ~400 ms deadline green.
+- **2 (runtime portability): touched.** Rides the existing `web-tree-sitter` WASM
+  loader already validated by `package-check` (grammar assets in the tarball). No
+  new `bun:`/`Bun.*`. `symbol-graph.ts` must pass the same purity bar as backends.
+- **3 (subprocesses): not touched.** Tree-sitter parses in-process; no spawn.
+- **4 (.swarm containment): not touched.** Graph still persists to
+  `.swarm/repo-graph.json`; the design doc is a committed deliverable (docs
+  exception).
+- **7 (test writing): touched.** New `bun:test` suites, `_internals` DI seam, temp
+  dirs under `os.tmpdir()`/`process.cwd()`; no `mock.module`.
+- **11 (tool registration): touched (action only).** `context_pack` is internal to
+  `repo_map`, so — like `callers`/`dead_exports` — no new top-level tool, no
+  `TOOL_NAMES`/agent-map change; the five `repo-map.ts` surfaces above must all be
+  wired and tested.
+- **12 (release/cache): touched.** Ship a `docs/releases/pending/<slug>.md`
+  fragment; confirm `package-check` still validates grammar assets.
+
+## Performance & limits
+
+- Lazy grammar load (cached, coalesced) + synchronous `parser.parse`; per-file
+  parse timeout (500 ms) and `tree.delete()` cleanup (ast-diff precedent).
+- Bounded concurrency for the async parse pass (syntax-check uses `pLimit(8)`).
+- Incremental rebuild (`incremental.ts`) already re-parses only changed files via
+  `scanFile`, so steady-state cost is per-edit, not per-repo.
+- Existing walk budgets (`DEFAULT_WALK_FILE_CAP` 10 000, `DEFAULT_WALK_BUDGET_MS`
+  5 000) and the 2 MB/file cap still apply. A perf gate at ~10 k files is a release
+  criterion before the regex path is removed.
+
+## Milestones
+
+1. `src/lang/symbol-graph.ts` + `.scm` query sets for all 12 grammars (defs +
+   imports + refs), with per-language tests. Behind a flag; nothing else changes.
+2. Rewire the async builder's `scanFile` onto `symbol-graph.ts`; reconcile
+   `usedSymbols`/`exportLines`; keep TS/JS/Python output equivalent-or-better.
+   Redefine the #1144 parity test.
+3. Schema 1.2.0: `exportRanges` + `symbolEdges` + validators + barrel exports;
+   storage `validateLoadedGraph` extended to iterate `symbolEdges`.
+4. `getContextPack` + transitive symbol slicing + symbol-keyed query index.
+5. `context_pack` tool action wired through all five `repo-map.ts` surfaces, with
+   tool-level tests and docs/release-fragment.
+
+## Usage
+
+```text
+repo_map { "action": "build" }                                  # populates 1.2.0 symbol data (async build)
+repo_map { "action": "callers", "file": "src/foo.ts", "symbol": "doThing" }
+repo_map { "action": "context_pack", "file": "src/foo.ts", "symbol": "doThing", "max_depth": 2, "top_n": 40 }
+```
+
+## Limitations (by design)
+
+- Conservative, advisory analysis. Tree-sitter sees syntax, not types: dynamic
+  dispatch, reflection, and runtime-computed symbol access are invisible.
+  `dead_exports`/`context_pack` are aids, never delete/edit directives.
+- Reference attribution resolves by name within scope, not by full type
+  resolution; overload-heavy (C++/Java) and highly dynamic (Ruby/Python) languages
+  are best-effort.
+- Symbol data requires an async rebuild; the sync builder yields file-level data
+  only.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 	],
 	"scripts": {
 		"clean": "bun -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
-		"build": "bun run clean && bun run scripts/copy-grammars.ts && bun build src/index.ts --outdir dist --target node --format esm && bun build src/cli/index.ts --outdir dist/cli --target bun --format esm --external bash-parser --splitting && bun run scripts/copy-grammars.ts --to-dist && tsc --emitDeclarationOnly",
+		"build": "bun run clean && bun run scripts/copy-grammars.ts && bun build src/index.ts --outdir dist --target node --format esm --external web-tree-sitter && bun build src/cli/index.ts --outdir dist/cli --target bun --format esm --external bash-parser --splitting && bun run scripts/copy-grammars.ts --to-dist && tsc --emitDeclarationOnly",
 		"typecheck": "tsc --noEmit",
 		"test": "bun test",
 		"lint": "biome lint .",

--- a/src/lang/registry.ts
+++ b/src/lang/registry.ts
@@ -1,5 +1,5 @@
 import { extname } from 'node:path';
-import { loadGrammar, type Parser } from './runtime';
+import type { Parser } from './runtime';
 
 export const _internals: {
 	getLanguageForExtension: typeof getLanguageForExtension;
@@ -157,6 +157,7 @@ export async function getParserForFile(
 	}
 
 	try {
+		const { loadGrammar } = await import('./runtime.js');
 		return await loadGrammar(language.id);
 	} catch {
 		return null;

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -1,0 +1,1131 @@
+import type { Language, Node, QueryMatch, Tree } from 'web-tree-sitter';
+
+/** Lazy cache for the Query constructor — avoids loading web-tree-sitter WASM at module-init time. */
+let _QueryCtor:
+	| null
+	| (new (
+			lang: Language,
+			pattern: string,
+	  ) => {
+			matches: (node: Node) => QueryMatch[];
+	  }) = null;
+
+export interface FileSymbolFacts {
+	defs: Array<{
+		name: string;
+		kind:
+			| 'function'
+			| 'class'
+			| 'const'
+			| 'type'
+			| 'interface'
+			| 'enum'
+			| 'method';
+		exported: boolean;
+		startLine: number;
+		endLine: number;
+	}>;
+	imports: Array<{
+		specifier: string;
+		importType: 'commonjs' | 'named' | 'namespace' | 'default';
+		bindings: Array<{ imported: string; local: string }>;
+	}>;
+	refs: Array<{
+		identifier: string;
+		line: number;
+		enclosingDecl: string | null;
+	}>;
+}
+
+/**
+ * Timeout for symbol-extraction operations. Mirrors AST_TIMEOUT_MS in ast-diff.ts.
+ * Wraps BOTH grammar load (WASM) AND parser.parse() in a single race.
+ */
+const AST_TIMEOUT_MS = 500;
+
+/**
+ * Per-grammar query sets. Task 1.1 defines only 'typescript' as the exemplar;
+ * additional grammars are added in task 1.2.
+ */
+const QUERIES: Record<
+	string,
+	{ defs: string; imports: string; refs: string; exports: string }
+> = {
+	typescript: {
+		defs: `
+			(function_declaration name: (identifier) @func.name) @func.def
+			(generator_function_declaration name: (identifier) @func.name) @func.def
+			(class_declaration name: (type_identifier) @class.name) @class.def
+			(lexical_declaration
+				(variable_declarator name: (identifier) @const.name)
+			) @const.def
+			(type_alias_declaration name: (type_identifier) @type.name) @type.def
+			(interface_declaration name: (type_identifier) @interface.name) @interface.def
+			(enum_declaration name: (identifier) @enum.name) @enum.def
+			(method_definition name: (property_identifier) @method.name) @method.def
+		`,
+		imports: `
+			(import_statement) @import
+			(call_expression
+				function: (identifier) @require.name
+				arguments: (arguments (string) @require.specifier)
+			) @require
+		`,
+		refs: `
+			(identifier) @ref.identifier
+		`,
+		exports: `
+			(export_statement) @export
+		`,
+	},
+	javascript: {
+		defs: `
+			(function_declaration name: (identifier) @func.name) @func.def
+			(generator_function_declaration name: (identifier) @func.name) @func.def
+			(class_declaration name: (identifier) @class.name) @class.def
+			(lexical_declaration
+				(variable_declarator name: (identifier) @const.name)
+			) @const.def
+		`,
+		imports: `
+			(import_statement) @import
+			(call_expression
+				function: (identifier) @require.name
+				arguments: (arguments (string) @require.specifier)
+			) @require
+		`,
+		refs: `
+			(identifier) @ref.identifier
+		`,
+		exports: `
+			(export_statement) @export
+		`,
+	},
+	tsx: {
+		defs: `
+			(function_declaration name: (identifier) @func.name) @func.def
+			(generator_function_declaration name: (identifier) @func.name) @func.def
+			(class_declaration name: (type_identifier) @class.name) @class.def
+			(lexical_declaration
+				(variable_declarator name: (identifier) @const.name)
+			) @const.def
+			(type_alias_declaration name: (type_identifier) @type.name) @type.def
+			(interface_declaration name: (type_identifier) @interface.name) @interface.def
+			(enum_declaration name: (identifier) @enum.name) @enum.def
+			(method_definition name: (property_identifier) @method.name) @method.def
+		`,
+		imports: `
+			(import_statement) @import
+			(call_expression
+				function: (identifier) @require.name
+				arguments: (arguments (string) @require.specifier)
+			) @require
+		`,
+		refs: `
+			(identifier) @ref.identifier
+		`,
+		exports: `
+			(export_statement) @export
+		`,
+	},
+	python: {
+		defs: `
+			(function_definition
+				(identifier) @func.name
+			) @func.def
+			(class_definition
+				(identifier) @class.name
+			) @class.def
+		`,
+		imports: `
+			(import_statement) @import
+			(import_from_statement) @import
+		`,
+		refs: `
+			(identifier) @ref.identifier
+		`,
+		exports: ``,
+	},
+	rust: {
+		defs: `
+			(function_item
+				(identifier) @func.name
+			) @func.def
+			(struct_item
+				name: (type_identifier) @struct.name
+			) @struct.def
+			(impl_item type: (type_identifier) @impl.name) @impl.def
+		`,
+		imports: `
+			(use_declaration) @import
+		`,
+		refs: `
+			(identifier) @ref.identifier
+		`,
+		exports: ``,
+	},
+	go: {
+		defs: `
+			(function_declaration name: (identifier) @func.name) @func.def
+			(type_declaration (type_spec name: (type_identifier) @type.name)) @type.def
+		`,
+		imports: `
+			(import_declaration) @import
+		`,
+		refs: `
+			(identifier) @ref.identifier
+		`,
+		exports: ``,
+	},
+	java: {
+		defs: `
+			(method_declaration
+				(identifier) @func.name
+			) @func.def
+			(class_declaration
+				(identifier) @class.name
+			) @class.def
+			(interface_declaration
+				(identifier) @interface.name
+			) @interface.def
+		`,
+		imports: `
+			(import_declaration) @import
+		`,
+		refs: `
+			(identifier) @ref.identifier
+			(type_identifier) @ref.identifier
+		`,
+		exports: ``,
+	},
+	kotlin: {
+		defs: `
+			(function_declaration
+				(simple_identifier) @func.name
+			) @func.def
+			(class_declaration
+				(type_identifier) @class.name
+			) @class.def
+			(object_declaration
+				(type_identifier) @object.name
+			) @object.def
+		`,
+		imports: `
+			(import_header) @import
+		`,
+		refs: `
+			(identifier) @ref.identifier
+			(simple_identifier) @ref.identifier
+			(type_identifier) @ref.identifier
+		`,
+		exports: ``,
+	},
+	csharp: {
+		defs: `
+			(method_declaration name: (identifier) @func.name) @func.def
+			(class_declaration name: (identifier) @class.name) @class.def
+			(interface_declaration name: (identifier) @interface.name) @interface.def
+			(struct_declaration name: (identifier) @struct.name) @struct.def
+		`,
+		imports: `
+			(using_directive) @import
+		`,
+		refs: `
+			(identifier) @ref.identifier
+		`,
+		exports: ``,
+	},
+	cpp: {
+		defs: `
+			(function_definition
+				(function_declarator
+					declarator: (identifier) @func.name
+				)
+			) @func.def
+			(class_specifier name: (type_identifier) @class.name) @class.def
+			(struct_specifier name: (type_identifier) @struct.name) @struct.def
+		`,
+		imports: `
+			(preproc_include) @import
+			(using_declaration) @import
+		`,
+		refs: `
+			(identifier) @ref.identifier
+			(namespace_identifier) @ref.identifier
+		`,
+		exports: ``,
+	},
+	swift: {
+		defs: `
+			(function_declaration name: (simple_identifier) @func.name) @func.def
+			(class_declaration name: (type_identifier) @class.name) @class.def
+			(protocol_declaration name: (type_identifier) @protocol.name) @protocol.def
+		`,
+		imports: `
+			(import_declaration) @import
+		`,
+		refs: `
+			(identifier) @ref.identifier
+			(simple_identifier) @ref.identifier
+		`,
+		exports: ``,
+	},
+	dart: {
+		defs: `
+			(function_signature
+				name: (identifier) @func.name
+			) @func.def
+			(class_definition name: (identifier) @class.name) @class.def
+		`,
+		imports: `
+			(library_import) @import
+		`,
+		refs: `
+			(identifier) @ref.identifier
+		`,
+		exports: `
+			(export_directive) @export
+		`,
+	},
+	ruby: {
+		defs: `
+			(method name: (identifier) @func.name) @func.def
+			(class name: (constant) @class.name) @class.def
+		`,
+		imports: `
+			(call
+				(identifier) @require.name
+				(argument_list (string (string_content) @require.specifier))
+			) @require
+		`,
+		refs: `
+			(identifier) @ref.identifier
+		`,
+		exports: ``,
+	},
+	php: {
+		defs: `
+			(function_definition
+				name: (name) @func.name
+			) @func.def
+			(class_declaration name: (name) @class.name) @class.def
+			(interface_declaration name: (name) @interface.name) @interface.def
+		`,
+		imports: `
+			(namespace_use_declaration) @import
+		`,
+		refs: `
+			(name) @ref.identifier
+		`,
+		exports: ``,
+	},
+};
+
+const CAPTURE_KIND: Record<string, FileSymbolFacts['defs'][0]['kind']> = {
+	func: 'function',
+	class: 'class',
+	const: 'const',
+	type: 'type',
+	interface: 'interface',
+	enum: 'enum',
+	method: 'method',
+	struct: 'type',
+	impl: 'type',
+	object: 'class',
+	mixin: 'type',
+	protocol: 'interface',
+};
+
+const DEF_TYPES = new Set([
+	'function_declaration',
+	'class_declaration',
+	'variable_declaration',
+	'type_alias_declaration',
+	'interface_declaration',
+	'enum_declaration',
+	'method_definition',
+	'function_item',
+	'function_signature',
+	'class_specifier',
+	'struct_specifier',
+	'struct_item',
+	'struct_declaration',
+	'method_declaration',
+	'type_declaration',
+	'object_declaration',
+	'protocol_declaration',
+	'mixin_declaration',
+	'function_definition',
+	'generator_function_declaration',
+	'class_definition',
+	'lexical_declaration',
+	'impl_item',
+	'method',
+	'class',
+]);
+
+const PARAM_TYPES = new Set([
+	'formal_parameters',
+	'required_parameter',
+	'optional_parameter',
+	'rest_parameter',
+	'array_pattern',
+	'object_pattern',
+]);
+
+/**
+ * Extract symbol, import, and reference facts from a source string using
+ * tree-sitter.
+ *
+ * Fail-open: returns null on grammar-load failure, timeout, or parse error.
+ * The 500 ms `AST_TIMEOUT_MS` race bounds the async `loadGrammar` WASM load
+ * and races the parse attempt, but cannot hard-interrupt a synchronous
+ * `parser.parse()` once it begins (mirrors the `computeASTDiff` pattern in
+ * `src/diff/ast-diff.ts`). The primary async risk (WASM grammar load) IS
+ * bounded.
+ *
+ * The parsed tree is always deleted: the inner async IIFE owns tree cleanup
+ * via its own `finally` block (deletes the tree after `buildFacts` regardless
+ * of whether the outer race rejects on timeout). Tree cleanup is handled
+ * solely by that inner `finally`; there is no outer backstop.
+ *
+ * @param grammarId - Tree-sitter grammar id (e.g. 'typescript')
+ * @param source - Source code text
+ * @returns FileSymbolFacts, or null on failure
+ */
+export async function extractFileSymbols(
+	grammarId: string,
+	source: string,
+): Promise<FileSymbolFacts | null> {
+	// Use a ref object so the async closure can store the parsed tree for
+	// cleanup in the finally block without triggering TypeScript
+	// control-flow narrowing to `never` on a captured outer local.
+	const treeRef = { value: null as Tree | null };
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+	try {
+		const result = await Promise.race([
+			(async (): Promise<FileSymbolFacts | null> => {
+				// Inner IIFE owns its tree: delete it after buildFacts
+				// regardless of whether buildFacts throws or returns null.
+				// This prevents a WASM tree leak when the outer race rejects
+				// (timeout) — the inner IIFE keeps running after the outer
+				// catch, so its own finally is the only reliable cleanup.
+				try {
+					// Lazy-init the Query constructor on first call (off the module-init path).
+					if (!_QueryCtor) {
+						const wts = await import('web-tree-sitter');
+						_QueryCtor = wts.Query;
+					}
+					const { loadGrammar: loadGrammarDynamic } = await import(
+						'./runtime.js'
+					);
+					const parser = await loadGrammarDynamic(grammarId);
+					treeRef.value = parser.parse(source);
+					if (!treeRef.value) return null;
+
+					const qs = QUERIES[grammarId];
+					if (!qs) return null;
+
+					return buildFacts(treeRef.value, qs, grammarId);
+				} finally {
+					if (treeRef.value) {
+						treeRef.value.delete();
+						treeRef.value = null;
+					}
+				}
+			})(),
+			new Promise<never>((_, reject) => {
+				timeoutId = setTimeout(
+					() => reject(new Error('AST_TIMEOUT')),
+					AST_TIMEOUT_MS,
+				);
+			}),
+		]).finally(() => {
+			if (timeoutId) clearTimeout(timeoutId);
+		});
+
+		return result;
+	} catch {
+		return null;
+	}
+}
+
+type TsNode = Tree['rootNode'];
+
+function asTs(node: Tree['rootNode']): TsNode {
+	return node as TsNode;
+}
+
+function buildFacts(
+	tree: Tree,
+	qs: { defs: string; imports: string; refs: string; exports: string },
+	grammarId: string,
+): FileSymbolFacts {
+	const root = asTs(tree.rootNode);
+	const lang = tree.language;
+	if (!lang) return { defs: [], imports: [], refs: [] };
+
+	const defMatches = safeMatches(lang, qs.defs, root);
+	const importMatches = safeMatches(lang, qs.imports, root);
+	const refMatches = safeMatches(lang, qs.refs, root);
+	const exportMatches = safeMatches(lang, qs.exports, root);
+
+	const exportNodes: TsNode[] = [];
+	for (const m of exportMatches) {
+		const cap = m.captures.find((c) => c.name === 'export');
+		if (cap) exportNodes.push(asTs(cap.node));
+	}
+
+	const defs: FileSymbolFacts['defs'] = [];
+	const defNodes: Array<{ node: TsNode; name: string }> = [];
+	const defNameKeys = new Set<string>();
+
+	for (const m of defMatches) {
+		const defCap = m.captures.find((c) => c.name.endsWith('.def'));
+		const nameCaps = m.captures.filter((c) => c.name.endsWith('.name'));
+		if (!defCap || nameCaps.length === 0) continue;
+
+		const kindKey = defCap.name.replace(/\.def$/, '');
+		const kind = CAPTURE_KIND[kindKey] ?? 'function';
+		let defNode = asTs(defCap.node);
+		const exported = exportNodes.some((en) => isNodeInside(en, defNode));
+
+		// For ESM default exports, normalize the exported name to 'default'
+		// so it matches the 'default' sentinel used by parseEsmImport and
+		// the sync builder's export naming.
+		let isDefaultExport = false;
+		if (exported && isEsMGrammar(grammarId)) {
+			isDefaultExport = exportNodes.some(
+				(en) => isNodeInside(en, defNode) && isDefaultExportStatement(en),
+			);
+		}
+
+		// Dart: function_body is a sibling of function_signature under program.
+		// Extend the def span to include the body so enclosingDecl resolution
+		// covers the function body region.
+		if (grammarId === 'dart' && defNode.type === 'function_signature') {
+			const rawBody = defNode.nextSibling;
+			if (rawBody) {
+				const bodyNode = asTs(rawBody);
+				if (bodyNode.type === 'function_body') {
+					defNode = asTs({
+						...defNode,
+						endIndex: bodyNode.endIndex,
+						endPosition: bodyNode.endPosition,
+					} as TsNode);
+				}
+			}
+		}
+
+		for (const nc of nameCaps) {
+			const nameNode = asTs(nc.node);
+			const localName = nameNode.text;
+			const exportedName = isDefaultExport ? 'default' : localName;
+
+			defs.push({
+				name: exportedName,
+				kind,
+				exported,
+				startLine: defNode.startPosition.row + 1,
+				endLine: defNode.endPosition.row + 1,
+			});
+			defNodes.push({ node: defNode, name: localName });
+			defNameKeys.add(nodeKey(nameNode));
+		}
+	}
+
+	const imports: FileSymbolFacts['imports'] = [];
+	for (const m of importMatches) {
+		const importCap = m.captures.find((c) => c.name === 'import');
+		if (importCap) {
+			const rawText = importCap.node.text.trim();
+			// Go block import: `import ( "fmt" "os" )` — find the
+			// import_spec_list child, then iterate its import_spec children.
+			if (grammarId === 'go' && rawText.startsWith('import (')) {
+				const importNode = asTs(importCap.node);
+				const specListNode = importNode.children.find(
+					(c): c is TsNode => c !== null && c.type === 'import_spec_list',
+				);
+				if (specListNode) {
+					for (const spec of asTs(specListNode).children) {
+						if (spec && spec.type === 'import_spec') {
+							const parsed = parseGoImport(spec.text.trim());
+							if (parsed) imports.push(parsed);
+						}
+					}
+				}
+			} else {
+				const parsed = parseImport(grammarId, rawText);
+				if (parsed) imports.push(parsed);
+			}
+		}
+		// Ruby require/require_relative fallback
+		if (grammarId === 'ruby') {
+			const reqName = m.captures.find((c) => c.name === 'require.name');
+			const reqSpec = m.captures.find((c) => c.name === 'require.specifier');
+			if (reqName && reqSpec) {
+				const fnText = asTs(reqName.node).text;
+				if (fnText === 'require' || fnText === 'require_relative') {
+					// Pass the full call text (e.g. "require 'json'") so parseRubyRequire
+					// can strip the require keyword; fall back to bare specifier.
+					const callNode = asTs(reqName.node).parent;
+					const rawText = callNode ? callNode.text : asTs(reqSpec.node).text;
+					const parsed = parseRubyRequire(rawText);
+					if (parsed) imports.push(parsed);
+				}
+			}
+		}
+		// CommonJS require() fallback for TS/JS/TSX
+		if (isEsMGrammar(grammarId)) {
+			const reqName = m.captures.find((c) => c.name === 'require.name');
+			const reqSpec = m.captures.find((c) => c.name === 'require.specifier');
+			if (reqName && reqSpec) {
+				const fnText = asTs(reqName.node).text;
+				if (fnText === 'require') {
+					const specText = asTs(reqSpec.node).text.replace(/['"]/g, '');
+					imports.push({
+						specifier: specText,
+						importType: 'commonjs',
+						bindings: [],
+					});
+				}
+			}
+		}
+	}
+
+	const topLevelDefs = defNodes
+		.filter((d) => isTopLevelDef(d.node, root))
+		.map((d) => ({ name: d.name, node: d.node }));
+
+	const refs: FileSymbolFacts['refs'] = [];
+	for (const m of refMatches) {
+		const cap = m.captures.find((c) => c.name === 'ref.identifier');
+		if (!cap) continue;
+		const refNode = asTs(cap.node);
+
+		if (defNameKeys.has(nodeKey(refNode))) continue;
+		if (hasAncestorOfType(refNode, 'import_statement')) continue;
+		if (isInsideImportStatement(refNode)) continue;
+		if (hasAncestorOfType(refNode, PARAM_TYPES)) continue;
+		if (refNode.text === 'require' && isInsideRequireCall(refNode)) continue;
+
+		refs.push({
+			identifier: refNode.text,
+			line: refNode.startPosition.row + 1,
+			enclosingDecl: findEnclosingDecl(refNode, topLevelDefs),
+		});
+	}
+
+	return { defs, imports, refs };
+}
+
+function safeMatches(
+	lang: Language,
+	pattern: string,
+	root: Tree['rootNode'],
+): QueryMatch[] {
+	// Fail-open if called before the lazy cache is initialised.
+	if (!_QueryCtor) return [];
+	try {
+		const q = new _QueryCtor(lang, pattern);
+		return q.matches(root);
+	} catch {
+		return [];
+	}
+}
+
+function parseEsmImport(text: string): FileSymbolFacts['imports'][0] | null {
+	const t = text.trim();
+
+	// Strip optional `type` qualifier: "import type { ... }" → "import { ... }"
+	// Track whether it was a type-only import (all bindings are type-only).
+	const isTypeOnlyImport = /^import\s+type\s/.test(t);
+	const withoutTypeQualifier = t.replace(/^import\s+type\s+/, 'import ');
+
+	// Named imports: handles `import { foo }`, `import type { foo }`,
+	// and mixed `import { type Foo, bar }` (inline type modifier per binding).
+	const named = withoutTypeQualifier.match(
+		/^import\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/,
+	);
+	if (named) {
+		// `import type { Foo }` → all bindings are type-only → empty bindings
+		if (isTypeOnlyImport) {
+			return { specifier: named[2], importType: 'named', bindings: [] };
+		}
+
+		const bindings: Array<{ imported: string; local: string }> = [];
+		for (const part of named[1].split(',')) {
+			const p = part.trim();
+			if (!p) continue;
+			// Strip inline `type` modifier: "type Foo" → "Foo"
+			const stripped = p.replace(/^type\s+/, '');
+			// If the entire binding is just `type` keyword (degenerate), skip it
+			if (!stripped) continue;
+			const alias = stripped.match(/^(\w+)\s+as\s+(\w+)$/);
+			if (alias) {
+				bindings.push({ imported: alias[1], local: alias[2] });
+			} else {
+				bindings.push({ imported: stripped, local: stripped });
+			}
+		}
+		return { specifier: named[2], importType: 'named', bindings };
+	}
+
+	// Combined ESM imports: `import <Default>, { <named> } from '<spec>'`
+	// or `import <Default>, * as <ns> from '<spec>'`.
+	// Must be checked before the default-only and namespace-only branches.
+	const combined = withoutTypeQualifier.match(
+		/^import\s+(\w+)\s*,\s*\*\s+as\s+(\w+)\s+from\s+['"]([^'"]+)['"]/,
+	);
+	if (combined) {
+		return {
+			specifier: combined[3],
+			importType: 'named',
+			bindings: [
+				{ imported: 'default', local: combined[1] },
+				{ imported: '*', local: combined[2] },
+			],
+		};
+	}
+
+	const combinedNamed = withoutTypeQualifier.match(
+		/^import\s+(\w+)\s*,\s*\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/,
+	);
+	if (combinedNamed) {
+		if (isTypeOnlyImport) {
+			return {
+				specifier: combinedNamed[3],
+				importType: 'named',
+				bindings: [],
+			};
+		}
+		const bindings: Array<{ imported: string; local: string }> = [
+			{ imported: 'default', local: combinedNamed[1] },
+		];
+		for (const part of combinedNamed[2].split(',')) {
+			const p = part.trim();
+			if (!p) continue;
+			const stripped = p.replace(/^type\s+/, '');
+			if (!stripped) continue;
+			const alias = stripped.match(/^(\w+)\s+as\s+(\w+)$/);
+			if (alias) {
+				bindings.push({ imported: alias[1], local: alias[2] });
+			} else {
+				bindings.push({ imported: stripped, local: stripped });
+			}
+		}
+		return { specifier: combinedNamed[3], importType: 'named', bindings };
+	}
+
+	const ns = t.match(/^import\s+\*\s+as\s+(\w+)\s+from\s+['"]([^'"]+)['"]/);
+	if (ns) {
+		return {
+			specifier: ns[2],
+			importType: 'namespace',
+			bindings: [{ imported: '*', local: ns[1] }],
+		};
+	}
+
+	const def = t.match(/^import\s+(\w+)\s+from\s+['"]([^'"]+)['"]/);
+	if (def) {
+		return {
+			specifier: def[2],
+			importType: 'default',
+			bindings: [{ imported: 'default', local: def[1] }],
+		};
+	}
+
+	return null;
+}
+
+/**
+ * Dispatch table: tree-sitter grammar id → language-specific import parser.
+ * Each parser receives the raw captured node text and returns a normalized
+ * FileSymbolFacts.imports entry, or null if the text does not match.
+ */
+function parseImport(
+	grammarId: string,
+	text: string,
+): FileSymbolFacts['imports'][0] | null {
+	switch (grammarId) {
+		case 'python':
+			return parsePythonImport(text);
+		case 'rust':
+			return parseRustUse(text);
+		case 'go':
+			return parseGoImport(text);
+		case 'java':
+			return parseJavaImport(text);
+		case 'kotlin':
+			return parseKotlinImport(text);
+		case 'csharp':
+			return parseCSharpUsing(text);
+		case 'cpp':
+			return parseCppInclude(text);
+		case 'swift':
+			return parseSwiftImport(text);
+		case 'dart':
+			return parseDartImport(text);
+		case 'ruby':
+			return parseRubyRequire(text);
+		case 'php':
+			return parsePhpUse(text);
+		case 'typescript':
+		case 'tsx':
+		case 'javascript':
+			return parseEsmImport(text);
+		default:
+			return null;
+	}
+}
+
+function parsePythonImport(text: string): FileSymbolFacts['imports'][0] | null {
+	const t = text.trim();
+	// import foo            → specifier: 'foo',  bindings: []
+	// import foo as bar     → specifier: 'foo',  bindings: [{imported:'foo', local:'bar'}]
+	// from foo import bar   → specifier: 'foo',  bindings: [{imported:'bar', local:'bar'}]
+	// from foo import bar as baz → specifier: 'foo', bindings: [{imported:'bar', local:'baz'}]
+	const fullImport = t.match(/^import\s+(.+)$/);
+	if (fullImport) {
+		const rest = fullImport[1].trim();
+		const alias = rest.match(/^(\w+)\s+as\s+(\w+)$/);
+		if (alias) {
+			return {
+				specifier: alias[1],
+				importType: 'named',
+				bindings: [{ imported: alias[1], local: alias[2] }],
+			};
+		}
+		// bare module import — no bindings to track
+		return { specifier: rest, importType: 'namespace', bindings: [] };
+	}
+	const fromImport = t.match(/^from\s+(\S+)\s+import\s+(.+)$/);
+	if (fromImport) {
+		const bindings: Array<{ imported: string; local: string }> = [];
+		for (const part of fromImport[2].split(',')) {
+			const p = part.trim();
+			if (!p) continue;
+			const alias = p.match(/^(\w+)\s+as\s+(\w+)$/);
+			if (alias) {
+				bindings.push({ imported: alias[1], local: alias[2] });
+			} else {
+				bindings.push({ imported: p, local: p });
+			}
+		}
+		return { specifier: fromImport[1], importType: 'named', bindings };
+	}
+	return null;
+}
+
+function parseRustUse(text: string): FileSymbolFacts['imports'][0] | null {
+	const t = text.trim();
+	// use foo::bar::baz;
+	// use foo::bar::baz as alias;
+	// use foo::{Bar, Baz};
+	const m = t.match(/^use\s+(.+?)\s*as\s+(\w+)\s*;?\s*$/);
+	if (m) {
+		return {
+			specifier: m[1].trim(),
+			importType: 'named',
+			bindings: [{ imported: m[1].trim(), local: m[2] }],
+		};
+	}
+	const simple = t.match(/^use\s+(.+?)\s*;?\s*$/);
+	if (simple) {
+		return {
+			specifier: simple[1].trim(),
+			importType: 'namespace',
+			bindings: [],
+		};
+	}
+	return null;
+}
+
+function parseGoImport(text: string): FileSymbolFacts['imports'][0] | null {
+	const t = text.trim();
+	// Block import: `import ( "fmt" "os" )` — return null here; buildFacts
+	// detects block imports via the raw text starting with 'import (' and
+	// iterates each import_spec child via its own capture walk.
+	if (t.startsWith('import (')) return null;
+
+	// Bare aliased spec from a block-import child: `f "fmt"`
+	const bareAliased = t.match(/^(\w+)\s+"([^"]+)"$/);
+	if (bareAliased) {
+		return {
+			specifier: bareAliased[2],
+			importType: 'named',
+			bindings: [{ imported: bareAliased[2], local: bareAliased[1] }],
+		};
+	}
+
+	// Single-line `import foo "bar"` (aliased)
+	const aliased = t.match(/^import\s+(\w+)\s+"([^"]+)"/);
+	if (aliased) {
+		return {
+			specifier: aliased[2],
+			importType: 'named',
+			bindings: [{ imported: aliased[2], local: aliased[1] }],
+		};
+	}
+	// Single-line `import "bar"` or bare quoted specifier `"bar"` (from a
+	// block-import child that buildFacts feeds directly)
+	const simple = t.match(/^import\s+"([^"]+)"|^"([^"]+)"$/);
+	if (simple) {
+		return {
+			specifier: simple[1] ?? simple[2],
+			importType: 'namespace',
+			bindings: [],
+		};
+	}
+	return null;
+}
+
+function parseJavaImport(text: string): FileSymbolFacts['imports'][0] | null {
+	const t = text.trim();
+	// import foo.Bar;
+	// import static foo.Bar.baz;
+	const m = t.match(/^import\s+(?:static\s+)?([^;\s]+)\s*;?\s*$/);
+	if (m) {
+		return { specifier: m[1], importType: 'namespace', bindings: [] };
+	}
+	return null;
+}
+
+function parseKotlinImport(text: string): FileSymbolFacts['imports'][0] | null {
+	// import foo.Bar
+	// import foo.Bar as baz
+	// Multiple per import_header — each line is captured
+	const t = text.trim();
+	const aliased = t.match(/^import\s+([^;\s]+)\s+as\s+(\w+)/);
+	if (aliased) {
+		return {
+			specifier: aliased[1],
+			importType: 'named',
+			bindings: [{ imported: aliased[1], local: aliased[2] }],
+		};
+	}
+	const simple = t.match(/^import\s+([^;\s]+)/);
+	if (simple) {
+		return { specifier: simple[1], importType: 'namespace', bindings: [] };
+	}
+	return null;
+}
+
+function parseCSharpUsing(text: string): FileSymbolFacts['imports'][0] | null {
+	const t = text.trim();
+	// using foo;
+	// using foo = foo.Bar;
+	// using static foo.Bar;
+	const m = t.match(
+		/^using\s+(?:static\s+)?([^=;\s]+)\s*(?:=\s*(.+?))?\s*;?\s*$/,
+	);
+	if (m) {
+		const specifier = m[2] ? m[2].trim() : m[1].trim();
+		if (m[2]) {
+			return {
+				specifier,
+				importType: 'named',
+				bindings: [{ imported: specifier, local: m[1].trim() }],
+			};
+		}
+		return { specifier: m[1].trim(), importType: 'namespace', bindings: [] };
+	}
+	return null;
+}
+
+function parseCppInclude(text: string): FileSymbolFacts['imports'][0] | null {
+	const t = text.trim();
+	// #include <foo>
+	// #include "foo"
+	// using foo::bar;
+	const include = t.match(/^#\s*include\s+[<"]([^>"]+)[>"]/);
+	if (include) {
+		return { specifier: include[1], importType: 'namespace', bindings: [] };
+	}
+	const using = t.match(/^using\s+(?:namespace\s+)?(.+?)\s*;?\s*$/);
+	if (using) {
+		return {
+			specifier: using[1].trim(),
+			importType: 'namespace',
+			bindings: [],
+		};
+	}
+	return null;
+}
+
+function parseSwiftImport(text: string): FileSymbolFacts['imports'][0] | null {
+	const t = text.trim();
+	// import foo
+	// import class foo.Bar
+	const m = t.match(/^import\s+(?:class\s+)?([^;\s]+)/);
+	if (m) {
+		return { specifier: m[1], importType: 'namespace', bindings: [] };
+	}
+	return null;
+}
+
+function parseDartImport(text: string): FileSymbolFacts['imports'][0] | null {
+	const t = text.trim();
+	// import 'foo';
+	// import 'foo' as bar;
+	// import 'foo' show A, B;
+	// import 'foo' hide A;
+	const m = t.match(/^import\s+['"]([^'"]+)['"]\s+as\s+(\w+)/);
+	if (m) {
+		return {
+			specifier: m[1],
+			importType: 'named',
+			bindings: [{ imported: m[1], local: m[2] }],
+		};
+	}
+	const simple = t.match(/^import\s+['"]([^'"]+)['"]/);
+	if (simple) {
+		return { specifier: simple[1], importType: 'namespace', bindings: [] };
+	}
+	return null;
+}
+
+function parseRubyRequire(text: string): FileSymbolFacts['imports'][0] | null {
+	const t = text.trim();
+	// Input is the string_content node text (no surrounding quotes).
+	// e.g. "json" for require 'json'
+	// e.g. "./foo" for require_relative './foo'
+	// When the require keyword is included (full call text), strip it.
+	const stripped = t
+		.replace(/^(?:require(?:_relative)?)\s+['"]?/, '')
+		.replace(/['"]$/, '');
+	if (!stripped || stripped === t) return null;
+	const isRelative = stripped.startsWith('./') || stripped.startsWith('../');
+	return {
+		specifier: stripped,
+		importType: isRelative ? 'default' : 'namespace',
+		bindings: [],
+	};
+}
+
+function parsePhpUse(text: string): FileSymbolFacts['imports'][0] | null {
+	const t = text.trim();
+	// use foo\Bar;
+	// use foo\Bar as Baz;
+	// use function foo\baz;
+	// use const foo\BAZ;
+	const m = t.match(
+		/^use\s+(?:(?:function|const)\s+)?([^;\s]+)\s+as\s+(\w+)\s*;?\s*$/i,
+	);
+	if (m) {
+		return {
+			specifier: m[1],
+			importType: 'named',
+			bindings: [{ imported: m[1], local: m[2] }],
+		};
+	}
+	const simple = t.match(
+		/^use\s+(?:(?:function|const)\s+)?([^;\s]+)\s*;?\s*$/i,
+	);
+	if (simple) {
+		return { specifier: simple[1], importType: 'namespace', bindings: [] };
+	}
+	return null;
+}
+
+function isTopLevelDef(defNode: TsNode, root: TsNode): boolean {
+	let parent: TsNode | null = defNode.parent;
+	while (parent && parent !== root) {
+		if (DEF_TYPES.has(parent.type)) return false;
+		parent = parent.parent;
+	}
+	return true;
+}
+
+function findEnclosingDecl(
+	refNode: TsNode,
+	topLevelDefs: Array<{ name: string; node: TsNode }>,
+): string | null {
+	let best: { name: string; node: TsNode } | null = null;
+	let bestDist = Infinity;
+
+	for (const def of topLevelDefs) {
+		if (isNodeInside(def.node, refNode)) {
+			const dist = refNode.startPosition.row - def.node.startPosition.row;
+			if (dist < bestDist) {
+				bestDist = dist;
+				best = def;
+			}
+		}
+	}
+
+	return best?.name ?? '<module>';
+}
+
+function isNodeInside(outer: TsNode, inner: TsNode): boolean {
+	return (
+		inner.startIndex >= outer.startIndex && inner.endIndex <= outer.endIndex
+	);
+}
+
+function hasAncestorOfType(node: TsNode, types: Set<string> | string): boolean {
+	const typeSet = typeof types === 'string' ? new Set([types]) : types;
+	let current: TsNode | null = node.parent;
+	while (current) {
+		if (typeSet.has(current.type)) return true;
+		current = current.parent;
+	}
+	return false;
+}
+
+function isInsideRequireCall(node: TsNode): boolean {
+	let current: TsNode | null = node.parent;
+	while (current) {
+		if (current.type === 'call_expression') {
+			const fn = current.children.find((c) => c && c.type === 'identifier');
+			if (fn && fn.text === 'require') return true;
+		}
+		if (DEF_TYPES.has(current.type)) return false;
+		current = current.parent;
+	}
+	return false;
+}
+
+/**
+ * Returns true if the node is nested inside an import/use/using declaration
+ * (i.e. the identifier is part of an import statement itself, not a usage).
+ * This prevents import-line identifiers (e.g. 'p' in `import X as p`,
+ * 'Map' in `use ... as Map`, 'List' in `import java.util.List`) from
+ * appearing in the refs list before the body refs.
+ */
+const IMPORT_ANCESTOR_TYPES = new Set([
+	'import_statement',
+	'import_from_statement',
+	'import_declaration',
+	'import_header',
+	'use_declaration',
+	'using_directive',
+	'namespace_use_declaration',
+	'library_import', // dart
+]);
+
+function isInsideImportStatement(node: TsNode): boolean {
+	return hasAncestorOfType(node, IMPORT_ANCESTOR_TYPES);
+}
+
+function nodeKey(node: TsNode): string {
+	return `${node.startPosition.row},${node.startPosition.column}-${node.endPosition.row},${node.endPosition.column}`;
+}
+
+function isDefaultExportStatement(en: TsNode): boolean {
+	// Structural check: export_statement has a 'default' keyword child
+	if (en.children.some((c) => c !== null && c.type === 'default')) {
+		return true;
+	}
+	// Fallback: text-based check for robustness
+	return /^export\s+default\b/.test(en.text);
+}
+
+function isEsMGrammar(grammarId: string): boolean {
+	return (
+		grammarId === 'typescript' ||
+		grammarId === 'tsx' ||
+		grammarId === 'javascript'
+	);
+}

--- a/src/tools/repo-graph.ts
+++ b/src/tools/repo-graph.ts
@@ -39,6 +39,7 @@ export {
 	buildOntologyPreflightPacket,
 	getBlastRadius,
 	getCallers,
+	getContextPack,
 	getDeadExports,
 	getDependencies,
 	getFileOntology,
@@ -63,6 +64,8 @@ export type {
 	BlastRadiusResult,
 	BuildWorkspaceGraphOptions,
 	CallerReference,
+	ContextPackResult,
+	ContextPackSpan,
 	ConventionFact,
 	DataOperationFact,
 	DeadExportCandidate,
@@ -79,6 +82,7 @@ export type {
 	RouteFact,
 	RouteMethod,
 	SecurityFact,
+	SymbolEdge,
 	SymbolReference,
 } from './repo-graph/types';
 export {

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -16,6 +16,8 @@ import { existsSync, realpathSync } from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { LANGUAGE_REGISTRY } from '../../lang/profiles';
+import { extractFileSymbols } from '../../lang/symbol-graph';
 import * as logger from '../../utils/logger';
 import { containsControlChars } from '../../utils/path-security';
 import { yieldToEventLoop } from '../../utils/timeout';
@@ -27,6 +29,7 @@ import type {
 	GraphEdge,
 	GraphNode,
 	RepoGraph,
+	SymbolEdge,
 } from './types';
 import {
 	createEmptyGraph,
@@ -53,6 +56,7 @@ export const _internals: {
 	extractFileOntology: typeof extractFileOntology;
 	stripComments: typeof stripComments;
 	computeUsedSymbols: typeof computeUsedSymbols;
+	extractFileSymbols: typeof extractFileSymbols;
 } = {
 	safeRealpathSync,
 	extractTSSymbols,
@@ -61,6 +65,7 @@ export const _internals: {
 	extractFileOntology,
 	stripComments,
 	computeUsedSymbols,
+	extractFileSymbols,
 } as const;
 
 // ============ Constants ============
@@ -103,15 +108,11 @@ function resolveSkipDirectories(
 /**
  * Supported source file extensions for graph scanning.
  */
-const SUPPORTED_EXTENSIONS = [
-	'.ts',
-	'.tsx',
-	'.js',
-	'.jsx',
-	'.mjs',
-	'.cjs',
-	'.py',
-];
+const SUPPORTED_EXTENSIONS = new Set(
+	LANGUAGE_REGISTRY.getAll()
+		.filter((p) => !p.parserOnly)
+		.flatMap((p) => p.extensions),
+);
 
 /**
  * Default safety budgets for workspace traversal.
@@ -121,17 +122,16 @@ const DEFAULT_WALK_BUDGET_MS = 5000;
 const ASYNC_WALK_YIELD_INTERVAL = 200;
 
 /**
- * Mapping of file extensions to language identifiers.
+ * Mapping of file extensions to tree-sitter grammar identifiers.
+ * Derived from the language profiles registry.
  */
-const EXTENSION_TO_LANGUAGE: Record<string, string> = {
-	'.ts': 'typescript',
-	'.tsx': 'typescript',
-	'.js': 'javascript',
-	'.jsx': 'javascript',
-	'.mjs': 'javascript',
-	'.cjs': 'javascript',
-	'.py': 'python',
-};
+const EXTENSION_TO_LANGUAGE: Record<string, string> = {};
+for (const profile of LANGUAGE_REGISTRY.getAll()) {
+	if (profile.parserOnly) continue;
+	for (const ext of profile.extensions) {
+		EXTENSION_TO_LANGUAGE[ext] = profile.treeSitter.grammarId;
+	}
+}
 
 // ============ Graph Node / Edge Operations ============
 
@@ -943,7 +943,7 @@ function walkSyncInto(dir: string, ctx: WalkContext, files: string[]): void {
 			walkSyncInto(fullPath, ctx, files);
 		} else if (entry.isFile()) {
 			const ext = path.extname(fullPath).toLowerCase();
-			if (SUPPORTED_EXTENSIONS.includes(ext)) {
+			if (SUPPORTED_EXTENSIONS.has(ext)) {
 				files.push(fullPath);
 			}
 		}
@@ -1021,7 +1021,7 @@ async function findSourceFilesAsync(
 				queue.push(fullPath);
 			} else if (entry.isFile()) {
 				const ext = path.extname(fullPath).toLowerCase();
-				if (SUPPORTED_EXTENSIONS.includes(ext)) {
+				if (SUPPORTED_EXTENSIONS.has(ext)) {
 					files.push(fullPath);
 				}
 			}
@@ -1055,7 +1055,7 @@ function toModuleName(filePath: string, workspaceRoot: string): string {
  * Get the language identifier for a file based on its extension.
  *
  * @param filePath - File path to get language for
- * @returns Language identifier string
+ * @returns Language identifier string (tree-sitter grammarId)
  */
 function getLanguage(filePath: string): string {
 	const ext = path.extname(filePath).toLowerCase();
@@ -1086,6 +1086,17 @@ export interface ScanResult {
 	node: GraphNode | null;
 	/** The edges created from this file's imports */
 	edges: GraphEdge[];
+}
+
+/**
+ * Result of the async single-file scanner. Extends ScanResult with
+ * symbol-level reference edges produced by tree-sitter symbol extraction.
+ */
+export interface AsyncScanResult {
+	node: GraphNode | null;
+	edges: GraphEdge[];
+	/** Symbol-to-symbol reference edges (schema >= 1.2.0). */
+	symbolEdges: SymbolEdge[];
 }
 
 /**
@@ -1197,6 +1208,204 @@ export function scanFile(
 		// Skip malformed file without aborting incremental update
 		return { node: null, edges: [] };
 	}
+}
+
+/**
+ * Async variant of scanFile that uses tree-sitter symbol extraction
+ * (extractFileSymbols) to populate exportRanges and symbolEdges.
+ *
+ * Fail-open: if extractFileSymbols returns null (grammar unavailable,
+ * timeout, parse error), falls back to a minimal file-level node with
+ * empty exports/imports/symbolEdges — never throws.
+ *
+ * Oversized, binary, or unreadable files return { node: null, edges: [], symbolEdges: [] }
+ * matching the sync scanFile contract.
+ *
+ * @param filePath - Absolute path to the file to scan
+ * @param absoluteRoot - Absolute path to workspace root
+ * @param maxFileSize - Maximum file size in bytes
+ * @returns AsyncScanResult with node, edges, and symbolEdges
+ */
+export async function scanFileAsync(
+	filePath: string,
+	absoluteRoot: string,
+	maxFileSize: number,
+): Promise<AsyncScanResult> {
+	let content: string;
+	let fileStats: fsSync.Stats;
+
+	try {
+		fileStats = fsSync.statSync(filePath);
+		if (fileStats.size > maxFileSize) {
+			return { node: null, edges: [], symbolEdges: [] };
+		}
+		content = fsSync.readFileSync(filePath, 'utf-8');
+	} catch {
+		return { node: null, edges: [], symbolEdges: [] };
+	}
+
+	// Skip binary files
+	if (isBinaryContent(content)) {
+		return { node: null, edges: [], symbolEdges: [] };
+	}
+
+	const grammarId = getLanguage(filePath);
+	const facts = await _internals.extractFileSymbols(grammarId, content);
+
+	// Fail-open: tree-sitter unavailable or timed out → minimal node
+	if (facts === null) {
+		const moduleName = toModuleName(filePath, absoluteRoot);
+		return {
+			node: {
+				filePath,
+				moduleName,
+				exports: [],
+				imports: [],
+				language: grammarId,
+				mtime: fileStats.mtime.toISOString(),
+				ontology: _internals.extractFileOntology({
+					moduleName,
+					filePath,
+					content,
+					language: grammarId,
+					exports: [],
+					imports: [],
+				}),
+			},
+			edges: [],
+			symbolEdges: [],
+		};
+	}
+
+	// Derive exports, exportLines, exportRanges from tree-sitter defs
+	const exportedDefs = facts.defs.filter((d) => d.exported);
+	const exports = exportedDefs.map((d) => d.name);
+	const exportLines: Record<string, number> = {};
+	const exportRanges: Record<string, { startLine: number; endLine: number }> =
+		{};
+	for (const d of exportedDefs) {
+		exportLines[d.name] = d.startLine;
+		exportRanges[d.name] = { startLine: d.startLine, endLine: d.endLine };
+	}
+
+	// Derive imports list from tree-sitter facts
+	const imports = facts.imports.map((i) => i.specifier);
+
+	const moduleName = toModuleName(filePath, absoluteRoot);
+	const language = grammarId;
+
+	const node: GraphNode = {
+		filePath,
+		moduleName,
+		exports,
+		...(Object.keys(exportLines).length > 0 ? { exportLines } : {}),
+		...(Object.keys(exportRanges).length > 0 ? { exportRanges } : {}),
+		imports,
+		language,
+		mtime: fileStats.mtime.toISOString(),
+		ontology: _internals.extractFileOntology({
+			moduleName,
+			filePath,
+			content,
+			language,
+			exports,
+			imports,
+		}),
+	};
+
+	// Build GraphEdges from imports, using refs to derive usedSymbols
+	const edges: GraphEdge[] = [];
+	const sortedImports = [...facts.imports].sort((a, b) =>
+		a.specifier.localeCompare(b.specifier),
+	);
+
+	for (const imp of sortedImports) {
+		// Map tree-sitter 'commonjs' to graph-edge 'require' for consistency
+		const edgeImportType: GraphEdge['importType'] =
+			imp.importType === 'commonjs' ? 'require' : imp.importType;
+
+		const resolvedTarget = resolveModuleSpecifier(
+			absoluteRoot,
+			filePath,
+			imp.specifier,
+		);
+
+		if (resolvedTarget !== null) {
+			// A binding's imported symbol is "used" if its local name appears
+			// in facts.refs (i.e. the identifier is referenced in the body).
+			const usedBindings = imp.bindings.filter((b) =>
+				facts.refs.some((r) => r.identifier === b.local),
+			);
+			// Match sync buildWorkspaceGraph semantics: namespace and require
+			// imports omit usedSymbols entirely; named/default imports always
+			// include the array (possibly empty) so toEqual comparisons are stable.
+			const includeUsedSymbols =
+				edgeImportType !== 'namespace' && edgeImportType !== 'require';
+			const usedSymbols = includeUsedSymbols
+				? usedBindings.map((b) => b.imported)
+				: undefined;
+
+			edges.push({
+				source: filePath,
+				target: resolvedTarget,
+				importSpecifier: imp.specifier,
+				importType: edgeImportType,
+				importedSymbols: imp.bindings.map((b) => b.imported),
+				...(usedSymbols !== undefined ? { usedSymbols } : {}),
+			});
+		}
+	}
+
+	// Build SymbolEdges from refs: when a ref's identifier matches a local
+	// binding, resolve that binding's specifier to a target file and emit
+	// a symbol→symbol edge.
+	const symbolEdges: SymbolEdge[] = [];
+	const localToImported = new Map<
+		string,
+		{ specifier: string; imported: string }
+	>();
+	for (const imp of facts.imports) {
+		for (const binding of imp.bindings) {
+			localToImported.set(binding.local, {
+				specifier: imp.specifier,
+				imported: binding.imported,
+			});
+		}
+	}
+
+	const seenSymbolEdgeKeys = new Set<string>();
+	for (const ref of facts.refs) {
+		const mapping = localToImported.get(ref.identifier);
+		if (!mapping) continue;
+
+		const resolvedTarget = resolveModuleSpecifier(
+			absoluteRoot,
+			filePath,
+			mapping.specifier,
+		);
+		if (!resolvedTarget) continue;
+
+		const fromSymbol = ref.enclosingDecl ?? '<module>';
+		const key =
+			filePath +
+			'\u0000' +
+			fromSymbol +
+			'\u0000' +
+			resolvedTarget +
+			'\u0000' +
+			mapping.imported;
+		if (seenSymbolEdgeKeys.has(key)) continue;
+		seenSymbolEdgeKeys.add(key);
+
+		symbolEdges.push({
+			fromFile: filePath,
+			fromSymbol,
+			toFile: resolvedTarget,
+			toSymbol: mapping.imported,
+		});
+	}
+
+	return { node, edges, symbolEdges };
 }
 
 // ============ Full Workspace Builders ============
@@ -1477,9 +1686,11 @@ export async function buildWorkspaceGraphAsync(
 	// on large repos so the deferred startup scan no longer stalls the event
 	// loop for tens of seconds (issue #1144).
 	const seenEdges = new Set<string>();
+	const seenSymbolEdges = new Set<string>();
+	const allSymbolEdges: SymbolEdge[] = [];
 	let processedSinceYield = 0;
 	for (const filePath of sourceFiles) {
-		const result = scanFile(filePath, absoluteRoot, maxFileSize);
+		const result = await scanFileAsync(filePath, absoluteRoot, maxFileSize);
 		if (result.node) {
 			// A node that fails validation (e.g. control characters in ontology
 			// evidence from a minified/generated file) must skip that one file,
@@ -1501,6 +1712,21 @@ export async function buildWorkspaceGraphAsync(
 						/* skip malformed edge */
 					}
 				}
+				// Aggregate symbolEdges across all files (dedup)
+				for (const symbolEdge of result.symbolEdges) {
+					const key =
+						symbolEdge.fromFile +
+						'\u0000' +
+						symbolEdge.fromSymbol +
+						'\u0000' +
+						symbolEdge.toFile +
+						'\u0000' +
+						symbolEdge.toSymbol;
+					if (!seenSymbolEdges.has(key)) {
+						seenSymbolEdges.add(key);
+						allSymbolEdges.push(symbolEdge);
+					}
+				}
 				stats.filesScanned++;
 			}
 		} else {
@@ -1518,6 +1744,11 @@ export async function buildWorkspaceGraphAsync(
 		nodeCount: Object.keys(graph.nodes).length,
 		edgeCount: graph.edges.length,
 	};
+
+	// Attach symbolEdges when present (schema >= 1.2.0); keep additive.
+	if (allSymbolEdges.length > 0) {
+		graph.symbolEdges = allSymbolEdges;
+	}
 
 	if (stats.skippedFiles > 0 || stats.skippedDirs > 0 || stats.truncated) {
 		logger.log(

--- a/src/tools/repo-graph/incremental.ts
+++ b/src/tools/repo-graph/incremental.ts
@@ -12,16 +12,17 @@ import { existsSync } from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
 import * as path from 'node:path';
 import * as logger from '../../utils/logger';
+import { containsControlChars } from '../../utils/path-security';
 import {
 	addEdge,
 	buildWorkspaceGraphAsync,
-	scanFile,
+	scanFileAsync,
 	upsertNode,
 } from './builder';
 import { getCachedMtime } from './cache';
 import { resetQueryCache } from './query';
 import { getGraphPath, loadGraph, saveGraph } from './storage';
-import type { RepoGraph } from './types';
+import type { RepoGraph, SymbolEdge } from './types';
 import { normalizeGraphPath, updateGraphMetadata } from './types';
 
 /**
@@ -76,14 +77,37 @@ export async function updateGraphForFiles(
 				(e) => normalizeGraphPath(e.source) !== normalizedPath,
 			);
 
-			// Scan the file
-			const result = scanFile(rawFilePath, absoluteRoot, maxFileSize);
+			// Remove stale OUTGOING symbolEdges from this file before re-scanning.
+			// Incoming edges (toFile === changedFile) come from consumers' refs and
+			// cannot be rebuilt by rescanning only the provider; leave them in place.
+			if (graph.symbolEdges) {
+				graph.symbolEdges = graph.symbolEdges.filter(
+					(se) => normalizeGraphPath(se.fromFile) !== normalizedPath,
+				);
+			}
+
+			// Scan the file asynchronously to get node, edges, and symbolEdges
+			const result = await scanFileAsync(
+				rawFilePath,
+				absoluteRoot,
+				maxFileSize,
+			);
 
 			if (result.node) {
+				// Sanitize imports: strip control-char specifiers that tree-sitter
+				// may return raw (mirrors parseFileImports filtering in the sync path).
+				const sanitizedImports = result.node.imports.filter(
+					(imp) => !containsControlChars(imp),
+				);
+				const sanitizedNode: typeof result.node = {
+					...result.node,
+					imports: sanitizedImports,
+				};
+
 				// Remove old node if present
 				delete graph.nodes[normalizedPath];
-				// Add updated node
-				upsertNode(graph, result.node);
+				// Add updated node (carries exportRanges when present)
+				upsertNode(graph, sanitizedNode);
 
 				// Add new edges (avoiding duplicates)
 				for (const edge of result.edges) {
@@ -97,6 +121,26 @@ export async function updateGraphForFiles(
 						addEdge(graph, edge);
 					}
 				}
+
+				// Add new symbolEdges (avoiding duplicates)
+				if (result.symbolEdges.length > 0) {
+					if (!graph.symbolEdges) {
+						graph.symbolEdges = [];
+					}
+					const existingKeys = new Set(
+						graph.symbolEdges.map(
+							(se) =>
+								`${se.fromFile}\u0000${se.fromSymbol}\u0000${se.toFile}\u0000${se.toSymbol}`,
+						),
+					);
+					for (const symbolEdge of result.symbolEdges) {
+						const key = `${symbolEdge.fromFile}\u0000${symbolEdge.fromSymbol}\u0000${symbolEdge.toFile}\u0000${symbolEdge.toSymbol}`;
+						if (!existingKeys.has(key)) {
+							graph.symbolEdges.push(symbolEdge);
+							existingKeys.add(key);
+						}
+					}
+				}
 			}
 		} else {
 			// File was deleted - remove its node and all edges referencing it
@@ -106,12 +150,21 @@ export async function updateGraphForFiles(
 					normalizeGraphPath(e.source) !== normalizedPath &&
 					normalizeGraphPath(e.target) !== normalizedPath,
 			);
+			// Remove stale symbolEdges referencing the deleted file
+			if (graph.symbolEdges) {
+				graph.symbolEdges = graph.symbolEdges.filter(
+					(se) =>
+						normalizeGraphPath(se.fromFile) !== normalizedPath &&
+						normalizeGraphPath(se.toFile) !== normalizedPath,
+				);
+			}
 		}
 
 		updatedPaths.add(normalizedPath);
 	}
 
-	// Validate that all edge sources and targets have corresponding nodes
+	// Validate that all edge sources and targets have corresponding nodes.
+	// Also prune stale symbolEdges whose fromFile or toFile node no longer exists.
 	let validationFailed = false;
 	for (const edge of graph.edges) {
 		const normalizedSource = normalizeGraphPath(edge.source);
@@ -120,6 +173,18 @@ export async function updateGraphForFiles(
 			validationFailed = true;
 			break;
 		}
+	}
+
+	if (graph.symbolEdges && graph.symbolEdges.length > 0) {
+		const validSymbolEdges: SymbolEdge[] = [];
+		for (const symbolEdge of graph.symbolEdges) {
+			const normalizedFromFile = normalizeGraphPath(symbolEdge.fromFile);
+			const normalizedToFile = normalizeGraphPath(symbolEdge.toFile);
+			if (graph.nodes[normalizedFromFile] && graph.nodes[normalizedToFile]) {
+				validSymbolEdges.push(symbolEdge);
+			}
+		}
+		graph.symbolEdges = validSymbolEdges;
 	}
 
 	if (validationFailed) {
@@ -155,6 +220,11 @@ export async function updateGraphForFiles(
 		} catch {
 			// If we can't stat the file, proceed with the save anyway.
 		}
+	}
+
+	// Only keep symbolEdges when non-empty (matches buildWorkspaceGraphAsync behavior)
+	if (graph.symbolEdges && graph.symbolEdges.length === 0) {
+		delete graph.symbolEdges;
 	}
 
 	// Update metadata and save

--- a/src/tools/repo-graph/query.ts
+++ b/src/tools/repo-graph/query.ts
@@ -525,8 +525,10 @@ export function getContextPack(
 	visited.set(targetKey, 0);
 	const reached: { file: string; symbol: string; depth: number }[] = [];
 
-	while (queue.length > 0) {
-		const { key, depth } = queue.shift()!;
+	let queueHead = 0;
+	while (queueHead < queue.length) {
+		const { key, depth } = queue[queueHead]!;
+		queueHead++;
 		const [curFile, curSymbol] = key.split('\0', 2);
 		reached.push({ file: curFile, symbol: curSymbol, depth });
 

--- a/src/tools/repo-graph/query.ts
+++ b/src/tools/repo-graph/query.ts
@@ -2,6 +2,8 @@ import * as path from 'node:path';
 import type {
 	BlastRadiusResult,
 	CallerReference,
+	ContextPackResult,
+	ContextPackSpan,
 	DeadExportCandidate,
 	DeadExportsResult,
 	FileOntology,
@@ -12,6 +14,7 @@ import type {
 	LocalizationBlock,
 	PackageBoundarySummary,
 	RepoGraph,
+	SymbolEdge,
 	SymbolReference,
 } from './types';
 import { isSchemaVersionAtLeast, normalizeGraphPath } from './types';
@@ -456,6 +459,165 @@ export function getLocalizationContext(
 		exportedSymbolsUsedExternally: externalSymbols,
 		blastRadius: blast,
 		summary,
+	};
+}
+
+export function getContextPack(
+	graph: RepoGraph,
+	file: string,
+	symbol: string,
+	options: { maxDepth?: number; maxTokens?: number } = {},
+): ContextPackResult {
+	if (!isSchemaVersionAtLeast(graph.schema_version, '1.2.0')) {
+		return {
+			schemaSupported: false,
+			target: { file, symbol },
+			spans: [],
+			truncated: false,
+			estimatedTokens: 0,
+			note: 'rebuild with repo_map action="build"',
+		};
+	}
+
+	const maxDepth = options.maxDepth ?? 2;
+	const maxTokens = options.maxTokens ?? 4000;
+
+	// Resolve the input file to the graph node's absolute filePath using the
+	// same resolution logic as every other query function (getGraphNode handles
+	// workspace-relative AND absolute inputs). graph.nodes keys and symbolEdges
+	// index keys are absolute normalized paths, so a relative input like
+	// 'src/foo.ts' must be resolved to its absolute filePath before lookup.
+	const targetNode = getGraphNode(graph, file);
+	if (!targetNode) {
+		return {
+			schemaSupported: true,
+			target: { file, symbol },
+			spans: [],
+			truncated: false,
+			estimatedTokens: 0,
+			note: 'Target file not found in graph',
+		};
+	}
+	const targetFile = normalizeGraphPath(targetNode.filePath);
+
+	// Build per-call symbol-edge indexes: forward (outgoing callees) and
+	// reverse (incoming callers), keyed by normalized file + symbol.
+	const forward = new Map<string, SymbolEdge[]>();
+	const reverse = new Map<string, SymbolEdge[]>();
+	const symbolEdges = graph.symbolEdges ?? [];
+	for (const edge of symbolEdges) {
+		const fromKey = `${normalizeGraphPath(edge.fromFile)}\0${edge.fromSymbol}`;
+		const toKey = `${normalizeGraphPath(edge.toFile)}\0${edge.toSymbol}`;
+		const fromEdges = forward.get(fromKey);
+		if (fromEdges) fromEdges.push(edge);
+		else forward.set(fromKey, [edge]);
+		const toEdges = reverse.get(toKey);
+		if (toEdges) toEdges.push(edge);
+		else reverse.set(toKey, [edge]);
+	}
+
+	// BFS both directions from the target symbol up to maxDepth inclusive.
+	const targetKey = `${targetFile}\0${symbol}`;
+	const visited = new Map<string, number>(); // key -> first-encountered depth
+	const queue: { key: string; depth: number }[] = [
+		{ key: targetKey, depth: 0 },
+	];
+	visited.set(targetKey, 0);
+	const reached: { file: string; symbol: string; depth: number }[] = [];
+
+	while (queue.length > 0) {
+		const { key, depth } = queue.shift()!;
+		const [curFile, curSymbol] = key.split('\0', 2);
+		reached.push({ file: curFile, symbol: curSymbol, depth });
+
+		if (depth >= maxDepth) continue;
+
+		// Forward: follow edges where this symbol is the source (callees).
+		const outEdges = forward.get(key) ?? [];
+		for (const edge of outEdges) {
+			const nextKey = `${normalizeGraphPath(edge.toFile)}\0${edge.toSymbol}`;
+			if (!visited.has(nextKey)) {
+				visited.set(nextKey, depth + 1);
+				queue.push({ key: nextKey, depth: depth + 1 });
+			}
+		}
+
+		// Reverse: follow edges where this symbol is the target (callers).
+		const inEdges = reverse.get(key) ?? [];
+		for (const edge of inEdges) {
+			const nextKey = `${normalizeGraphPath(edge.fromFile)}\0${edge.fromSymbol}`;
+			if (!visited.has(nextKey)) {
+				visited.set(nextKey, depth + 1);
+				queue.push({ key: nextKey, depth: depth + 1 });
+			}
+		}
+	}
+
+	// Heuristic: ~12 tokens per line for full spans, ~10 tokens for signature spans.
+	const TOKENS_PER_LINE = 12;
+	const TOKENS_PER_SIGNATURE = 10;
+
+	// Build spans from exportRanges, attaching depth for ordering.
+	const spansWithDepth: { span: ContextPackSpan; depth: number }[] = [];
+	for (const { file: symFile, symbol: sym, depth: d } of reached) {
+		const node = graph.nodes[symFile];
+		const range = node?.exportRanges?.[sym];
+		if (!range) continue;
+
+		const mode: 'full' | 'signature' =
+			d === 0 ? 'full' : d < maxDepth ? 'full' : 'signature';
+
+		spansWithDepth.push({
+			span: {
+				file: symFile,
+				symbol: sym,
+				startLine: range.startLine,
+				endLine: range.endLine,
+				mode,
+			},
+			depth: d,
+		});
+	}
+
+	// Relevance order: target first, then ascending depth, then file, then symbol.
+	spansWithDepth.sort((a, b) => {
+		const aIsTarget =
+			a.span.file === targetFile && a.span.symbol === symbol ? 0 : 1;
+		const bIsTarget =
+			b.span.file === targetFile && b.span.symbol === symbol ? 0 : 1;
+		if (aIsTarget !== bIsTarget) return aIsTarget - bIsTarget;
+		if (a.depth !== b.depth) return a.depth - b.depth;
+		const fileCmp = a.span.file.localeCompare(b.span.file);
+		if (fileCmp !== 0) return fileCmp;
+		return a.span.symbol.localeCompare(b.span.symbol);
+	});
+
+	// Apply token budget; keep at least the target span if present.
+	let estimatedTokens = 0;
+	const finalSpans: ContextPackSpan[] = [];
+	let truncated = false;
+
+	for (const { span } of spansWithDepth) {
+		const spanTokens =
+			span.mode === 'full'
+				? (span.endLine - span.startLine + 1) * TOKENS_PER_LINE
+				: TOKENS_PER_SIGNATURE;
+
+		if (finalSpans.length > 0 && estimatedTokens + spanTokens > maxTokens) {
+			truncated = true;
+			break;
+		}
+
+		finalSpans.push(span);
+		estimatedTokens += spanTokens;
+	}
+
+	return {
+		schemaSupported: true,
+		target: { file: targetFile, symbol },
+		spans: finalSpans,
+		truncated,
+		estimatedTokens,
 	};
 }
 

--- a/src/tools/repo-graph/storage.ts
+++ b/src/tools/repo-graph/storage.ts
@@ -11,7 +11,11 @@ import * as fsPromises from 'node:fs/promises';
 import * as path from 'node:path';
 import { validateSwarmPath } from '../../hooks/utils';
 import * as logger from '../../utils/logger';
-import { validateSymlinkBoundary } from '../../utils/path-security';
+import {
+	containsControlChars,
+	containsPathTraversal,
+	validateSymlinkBoundary,
+} from '../../utils/path-security';
 import {
 	clearCache,
 	getCachedGraph,
@@ -129,6 +133,39 @@ function validateLoadedGraph(parsed: RepoGraph): void {
 			new Error('repo-graph.json missing or invalid metadata'),
 			{ code: 'CORRUPTION' },
 		);
+	}
+	if (parsed.symbolEdges !== undefined) {
+		if (!Array.isArray(parsed.symbolEdges)) {
+			throw Object.assign(
+				new Error('repo-graph.json symbolEdges must be an array'),
+				{ code: 'CORRUPTION' },
+			);
+		}
+		for (const entry of parsed.symbolEdges) {
+			if (
+				typeof entry !== 'object' ||
+				entry === null ||
+				typeof entry.fromFile !== 'string' ||
+				typeof entry.fromSymbol !== 'string' ||
+				typeof entry.toFile !== 'string' ||
+				typeof entry.toSymbol !== 'string' ||
+				entry.fromFile === '' ||
+				entry.fromSymbol === '' ||
+				entry.toFile === '' ||
+				entry.toSymbol === '' ||
+				containsControlChars(entry.fromFile) ||
+				containsControlChars(entry.fromSymbol) ||
+				containsControlChars(entry.toFile) ||
+				containsControlChars(entry.toSymbol) ||
+				containsPathTraversal(entry.fromFile) ||
+				containsPathTraversal(entry.toFile)
+			) {
+				throw Object.assign(
+					new Error('repo-graph.json contains invalid symbolEdges entry'),
+					{ code: 'CORRUPTION' },
+				);
+			}
+		}
 	}
 }
 

--- a/src/tools/repo-graph/types.ts
+++ b/src/tools/repo-graph/types.ts
@@ -21,8 +21,14 @@ export const REPO_GRAPH_FILENAME = 'repo-graph.json';
  * versions (1.0.0) still load — but `dead_exports` requires >= 1.1.0 data and
  * self-gates via {@link isSchemaVersionAtLeast} rather than relying on the
  * loader (which only checks that a version string is present, not its value).
+ *
+ * 1.2.0 adds per-node `exportRanges` (1-based inclusive line spans for each
+ * exported symbol) and the top-level `symbolEdges` array (direct symbol-to-
+ * symbol reference edges). Both fields are optional, so 1.0.0 and 1.1.0 graphs
+ * still load without corruption. New queries may use these fields to provide
+ * more precise context-packing and symbol-level navigation.
  */
-export const GRAPH_SCHEMA_VERSION = '1.1.0';
+export const GRAPH_SCHEMA_VERSION = '1.2.0';
 
 /**
  * Compare dotted numeric version strings (e.g. '1.1.0' >= '1.1.0').
@@ -191,6 +197,14 @@ export interface GraphNode {
 	 * `dead_exports` candidates at a location.
 	 */
 	exportLines?: Record<string, number>;
+	/**
+	 * 1-based inclusive line span for each exported symbol, keyed by symbol
+	 * name. Present on graphs built at schema >= 1.2.0; absent on older
+	 * graphs. Used for precise context-packing around a symbol.
+	 * Each span value uses `startLine` / `endLine` to match the codebase
+	 * convention (see `ContextPackSpan` and `FileSymbolFacts`).
+	 */
+	exportRanges?: Record<string, { startLine: number; endLine: number }>;
 	/** Imported module specifiers */
 	imports: string[];
 	/** Language/extension of the file */
@@ -244,6 +258,56 @@ export interface SymbolReference {
 	file: string;
 	line?: number;
 	importedAs: string;
+}
+
+/**
+ * A symbol-level reference edge: one exported symbol in one file directly
+ * references (calls / uses) an exported symbol in another file.
+ *
+ * Present in graphs built at schema >= 1.2.0. These edges are finer-grained
+ * than {@link GraphEdge} (which tracks file-level imports) and enable
+ * precise context-packing and symbol navigation queries.
+ */
+export interface SymbolEdge {
+	/** Resolved absolute path of the source file (matches `GraphNode.filePath` keys). */
+	fromFile: string;
+	/** Enclosing top-level declaration in the source file, or `'<module>'` for module-scope references. */
+	fromSymbol: string;
+	/** Resolved absolute path of the target file. */
+	toFile: string;
+	/** Exported symbol referenced in the target file. */
+	toSymbol: string;
+}
+
+/**
+ * A contiguous line span inside a source file, used by context-packing to
+ * extract the relevant region around a symbol without reading the whole file.
+ */
+export interface ContextPackSpan {
+	file: string;
+	symbol: string;
+	startLine: number;
+	endLine: number;
+	mode: 'full' | 'signature';
+}
+
+/**
+ * Result of a context-pack query: the set of spans needed to understand
+ * how a target symbol is used across the workspace.
+ */
+export interface ContextPackResult {
+	/** False when the graph predates schema 1.2.0 (rebuild required for full results). */
+	schemaSupported: boolean;
+	/** The symbol whose usage context was requested. */
+	target: { file: string; symbol: string };
+	/** Deduped, budget-ordered spans covering usage sites. */
+	spans: ContextPackSpan[];
+	/** True when the span budget was exhausted before all sites could be returned. */
+	truncated: boolean;
+	/** Rough token estimate for the returned spans (sum of span sizes × a fixed multiplier). */
+	estimatedTokens: number;
+	/** Optional human-readable note about scope or limitations. */
+	note?: string;
 }
 
 /**
@@ -342,6 +406,8 @@ export interface RepoGraph {
 		nodeCount: number;
 		edgeCount: number;
 	};
+	/** Symbol-level reference edges (schema >= 1.2.0; absent on older graphs). */
+	symbolEdges?: SymbolEdge[];
 }
 
 /**

--- a/src/tools/repo-graph/validation.ts
+++ b/src/tools/repo-graph/validation.ts
@@ -154,6 +154,45 @@ export function validateGraphNode(node: GraphNode): void {
 			}
 		}
 	}
+	if (node.exportRanges !== undefined) {
+		if (
+			typeof node.exportRanges !== 'object' ||
+			node.exportRanges === null ||
+			Array.isArray(node.exportRanges)
+		) {
+			throw new Error('Invalid node: exportRanges must be an object');
+		}
+		for (const [name, range] of Object.entries(node.exportRanges)) {
+			if (containsControlChars(name)) {
+				throw new Error(
+					'Invalid node: exportRanges key contains control characters',
+				);
+			}
+			if (typeof range !== 'object' || range === null || Array.isArray(range)) {
+				throw new Error('Invalid node: exportRanges values must be objects');
+			}
+			const r = range as { startLine?: number; endLine?: number };
+			if (
+				typeof r.startLine !== 'number' ||
+				!Number.isFinite(r.startLine) ||
+				!Number.isInteger(r.startLine) ||
+				r.startLine < 1 ||
+				typeof r.endLine !== 'number' ||
+				!Number.isFinite(r.endLine) ||
+				!Number.isInteger(r.endLine) ||
+				r.endLine < 1
+			) {
+				throw new Error(
+					'Invalid node: exportRanges value must have positive integer startLine and endLine (1-based)',
+				);
+			}
+			if (r.startLine > r.endLine) {
+				throw new Error(
+					'Invalid node: exportRanges value must have startLine <= endLine',
+				);
+			}
+		}
+	}
 	if (node.ontology !== undefined) {
 		validateOntologyStrings(node);
 	}

--- a/src/tools/repo-map.ts
+++ b/src/tools/repo-map.ts
@@ -392,8 +392,9 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			});
 			// Normalize absolute paths to workspace-relative (Phase 4 SME caveat).
 			// If the input is already relative (e.g. from a pre-1.2.0 graph fallback
-			// that returns the original target), pass it through unchanged — calling
-			// path.relative(directory, relativePath) would resolve against process.cwd().
+			// that returns the original target), pass it through unchanged —
+			// path.relative(directory, relativePath) would resolve against
+			// the process's current working directory.
 			const toRel = (p: string) => {
 				if (!path.isAbsolute(p)) return p.replace(/\\/g, '/');
 				try {

--- a/src/tools/repo-map.ts
+++ b/src/tools/repo-map.ts
@@ -11,6 +11,7 @@ import {
 	buildWorkspaceGraphAsync,
 	getBlastRadius,
 	getCallers,
+	getContextPack,
 	getDeadExports,
 	getDependencies,
 	getFileOntology,
@@ -58,6 +59,7 @@ const VALID_ACTIONS = [
 	'preflight_packet',
 	'callers',
 	'dead_exports',
+	'context_pack',
 ] as const;
 
 type RepoMapAction = (typeof VALID_ACTIONS)[number];
@@ -155,9 +157,10 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 		'"ontology" (file roles/routes/data/security/findings), "package_boundaries" (inferred package/layer boundaries), ' +
 		'"preflight_packet" (bounded ontology packet for planning), ' +
 		'"callers" (files that reference an exported symbol, call-site granularity; needs file+symbol), ' +
-		'"dead_exports" (advisory: exported symbols with no detected in-repo reference). ' +
+		'"dead_exports" (advisory: exported symbols with no detected in-repo reference; results are review candidates, not delete directives), ' +
+		'"context_pack" (token-budgeted slice of source spans for a target symbol — definition + transitive callers/callees; advisory/conservative; needs file+symbol; uses max_depth for traversal depth, top_n for span cap). ' +
 		'Use this before refactoring shared modules to avoid breaking unseen consumers. ' +
-		'Note: "callers"/"dead_exports" use conservative regex analysis (TS/JS/Python) and cannot see ' +
+		'Note: "callers"/"dead_exports"/"context_pack" use conservative regex analysis (TS/JS/Python) and cannot see ' +
 		'dynamic dispatch or namespace/barrel re-export usage; "dead_exports" results are review candidates, not delete directives.',
 	args: {
 		action: z
@@ -173,9 +176,10 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 				'preflight_packet',
 				'callers',
 				'dead_exports',
+				'context_pack',
 			])
 			.describe(
-				'Query action: "build" | "importers" | "dependencies" | "blast_radius" | "localization" | "key_files" | "ontology" | "package_boundaries" | "preflight_packet" | "callers" | "dead_exports"',
+				'Query action: "build" | "importers" | "dependencies" | "blast_radius" | "localization" | "key_files" | "ontology" | "package_boundaries" | "preflight_packet" | "callers" | "dead_exports" | "context_pack"',
 			),
 		file: z
 			.string()
@@ -193,7 +197,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			.string()
 			.optional()
 			.describe(
-				'Exported symbol name. Restricts consumers on action="importers"; required for action="callers".',
+				'Exported symbol name. Restricts consumers on action="importers"; required for action="callers"/"context_pack".',
 			),
 		top_n: z
 			.number()
@@ -202,7 +206,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			.max(100)
 			.optional()
 			.describe(
-				'For action="key_files"/"package_boundaries": entries to return (default 10). For action="dead_exports": max candidates (default 100).',
+				'For action="key_files"/"package_boundaries": entries to return (default 10). For action="dead_exports": max candidates (default 100). For action="context_pack": max spans returned (default ~40 via token budget).',
 			),
 		max_depth: z
 			.number()
@@ -210,7 +214,9 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			.min(1)
 			.max(10)
 			.optional()
-			.describe('For action="blast_radius": max BFS depth (default 3).'),
+			.describe(
+				'For action="blast_radius": max BFS depth (default 3). For action="context_pack": traversal depth (default 2).',
+			),
 	},
 	async execute(
 		args: unknown,
@@ -368,6 +374,53 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 				count: callers.length,
 				callers,
 				stale,
+			});
+		}
+
+		if (action === 'context_pack') {
+			if (a.symbol === undefined) {
+				return err(
+					action,
+					'context_pack requires `symbol` (the exported name)',
+				);
+			}
+			const sErr = validateSymbol(a.symbol);
+			if (sErr) return err(action, `invalid symbol: ${sErr}`);
+			const raw = getContextPack(graph, target, a.symbol, {
+				maxDepth: a.max_depth ?? 2,
+				maxTokens: 4000,
+			});
+			// Normalize absolute paths to workspace-relative (Phase 4 SME caveat).
+			// If the input is already relative (e.g. from a pre-1.2.0 graph fallback
+			// that returns the original target), pass it through unchanged — calling
+			// path.relative(directory, relativePath) would resolve against process.cwd().
+			const toRel = (p: string) => {
+				if (!path.isAbsolute(p)) return p.replace(/\\/g, '/');
+				try {
+					return path.relative(directory, p).replace(/\\/g, '/');
+				} catch {
+					return p;
+				}
+			};
+			const normalizedTarget = { ...raw.target, file: toRel(raw.target.file) };
+			const normalizedSpans = raw.spans
+				.map((s) => ({ ...s, file: toRel(s.file) }))
+				.filter((s) => s.file.length > 0);
+			const truncated =
+				raw.truncated ||
+				(a.top_n !== undefined && normalizedSpans.length > a.top_n);
+			const cappedSpans =
+				a.top_n !== undefined
+					? normalizedSpans.slice(0, a.top_n)
+					: normalizedSpans;
+			return ok(action, {
+				target: normalizedTarget,
+				spans: cappedSpans,
+				truncated,
+				estimatedTokens: raw.estimatedTokens,
+				stale,
+				schemaSupported: raw.schemaSupported,
+				...(raw.note ? { note: raw.note } : {}),
 			});
 		}
 

--- a/tests/unit/lang/symbol-graph-init-purity.test.ts
+++ b/tests/unit/lang/symbol-graph-init-purity.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Static-analysis purity tests for the symbol-graph init-path isolation.
+ *
+ * Per AGENTS.md invariant 1 (plugin init fast/bounded/fail-open): tree-sitter
+ * grammar loading (`loadGrammar`) must be OFF the plugin init path. These tests
+ * prove it via static source scanning:
+ *
+ * TEST A — init-path isolation: src/index.ts (the plugin entry) must not
+ *   import lang/symbol-graph or lang/runtime, proving the symbol-extraction
+ *   layer is unreachable from the synchronous plugin registration path.
+ *
+ * TEST B — symbol-graph module purity: loadGrammar must not be called at
+ *   module top-level in symbol-graph.ts — it lives only inside
+ *   extractFileSymbols (a lazy, on-demand function).
+ *
+ * TEST C — backend-purity bar for symbol-graph.ts: no `bun:` imports,
+ *   no global `Bun.*` API, no spawn primitives (mirrors the existing
+ *   backend-purity.test.ts bar).
+ *
+ * These are static source-scanning tests — fast, deterministic, no mocks.
+ */
+
+const REPO_ROOT = path.join(__dirname, '..', '..', '..');
+
+// ─── TEST A ──────────────────────────────────────────────────────────────────
+
+describe('TEST A — plugin init path does not reach lang/symbol-graph (invariant 1)', () => {
+	test('src/index.ts does not import lang/symbol-graph or lang/runtime', () => {
+		const indexPath = path.join(REPO_ROOT, 'src', 'index.ts');
+		const src = fs.readFileSync(indexPath, 'utf-8');
+
+		// The plugin entry must not import the symbol-extraction layer.
+		// Any such import would put tree-sitter on the synchronous init path,
+		// violating AGENTS.md invariant 1 (bounded plugin init).
+		expect(src).not.toMatch(/from\s+['"]\.\/lang\/symbol-graph/);
+		expect(src).not.toMatch(/from\s+['"]\.\/lang\/runtime/);
+		expect(src).not.toMatch(/from\s+['"]\.\.\/lang\/symbol-graph/);
+		expect(src).not.toMatch(/from\s+['"]\.\.\/lang\/runtime/);
+	});
+
+	test('src/index.ts does not reference loadGrammar', () => {
+		const indexPath = path.join(REPO_ROOT, 'src', 'index.ts');
+		const src = fs.readFileSync(indexPath, 'utf-8');
+
+		// loadGrammar is the tree-sitter grammar-loading entry point.
+		// It must not appear anywhere in the plugin entry module.
+		expect(src).not.toMatch(/\bloadGrammar\b/);
+	});
+
+	test('src/index.ts does not import extractFileSymbols', () => {
+		const indexPath = path.join(REPO_ROOT, 'src', 'index.ts');
+		const src = fs.readFileSync(indexPath, 'utf-8');
+
+		// extractFileSymbols is the public API of the symbol-graph layer.
+		// It must not be reachable from the plugin init path.
+		expect(src).not.toMatch(/\bextractFileSymbols\b/);
+	});
+});
+
+// ─── TEST B ──────────────────────────────────────────────────────────────────
+
+describe('TEST B — symbol-graph.ts has no module-top-level loadGrammar call (invariant 1)', () => {
+	test('loadGrammar call is inside extractFileSymbols, not at column 0', () => {
+		const sgPath = path.join(REPO_ROOT, 'src', 'lang', 'symbol-graph.ts');
+		const src = fs.readFileSync(sgPath, 'utf-8');
+
+		// Strip comments so we don't get false positives from documentation.
+		const stripped = src
+			.replace(/\/\/[^\n]*/g, '')
+			.replace(/\/\*[\s\S]*?\*\//g, '');
+
+		// Find every line that contains 'loadGrammar' (after comment stripping).
+		// Verify none are at column 0 (module top-level) — every occurrence must
+		// be indented, i.e. inside a function body.
+		const lines = stripped.split('\n');
+		const topLevelCalls = lines.filter((line) => {
+			const trimmed = line.trimStart();
+			// A top-level call has no leading whitespace AND contains loadGrammar
+			const isTopLevel =
+				line.startsWith('\t') === false && line.startsWith('    ') === false;
+			return isTopLevel && trimmed.startsWith('loadGrammar');
+		});
+
+		expect(
+			topLevelCalls,
+			`loadGrammar called at module top-level: ${topLevelCalls.join('\n')}`,
+		).toHaveLength(0);
+	});
+
+	test('no top-level await loadGrammar', () => {
+		const sgPath = path.join(REPO_ROOT, 'src', 'lang', 'symbol-graph.ts');
+		const src = fs.readFileSync(sgPath, 'utf-8');
+
+		// Any `await loadGrammar` at module level would execute during module
+		// load (before any function is called), putting grammar loading on the
+		// synchronous init path.
+		expect(src).not.toMatch(/^await\s+loadGrammar/);
+		expect(src).not.toMatch(/^\s+await\s+loadGrammar/);
+	});
+
+	test('no module-top-level side effects in symbol-graph.ts', () => {
+		const sgPath = path.join(REPO_ROOT, 'src', 'lang', 'symbol-graph.ts');
+		const src = fs.readFileSync(sgPath, 'utf-8');
+
+		// web-tree-sitter is loaded LAZILY via dynamic import() inside
+		// extractFileSymbols. A static `import { ... }` (value import) at module
+		// level would eagerly load the WASM bundle at plugin init time — a side
+		// effect we must prevent.  Type-only imports (`import type { ... }`) are
+		// erased at compile time and carry no runtime cost, so they are safe.
+		//
+		// Pattern: `import\s+(?!type\s*\{)` matches `import { ... }` where the
+		// next token after `import` is NOT `type` — i.e. a value import.
+		// This correctly rejects `import type { Language } from 'web-tree-sitter'`
+		// while flagging `import { Language } from 'web-tree-sitter'`.
+		const valueImportMatch = src.match(
+			/import\s+(?!type\s*\{).*from\s+['"]web-tree-sitter['"]/,
+		);
+		expect(
+			valueImportMatch,
+			'web-tree-sitter must not be statically imported as a value — use `import type` or dynamic import()',
+		).toBeNull();
+
+		// loadGrammar is also loaded lazily inside extractFileSymbols via
+		// `await import('./runtime.js')`. Verify no static `import { loadGrammar }`
+		// exists at module level (we already verified no call sites are at col-0
+		// above; this catches the import binding itself).
+		const loadGrammarStaticImport = src.match(
+			/import\s+.*\bloadGrammar\b.*from\s+['"]\.\/runtime/,
+		);
+		expect(
+			loadGrammarStaticImport,
+			'loadGrammar must not be statically imported — use `await import()` inside extractFileSymbols',
+		).toBeNull();
+	});
+});
+
+// ─── TEST C ──────────────────────────────────────────────────────────────────
+
+describe('TEST C — symbol-graph.ts satisfies the backend-purity bar (invariant 2 + 3)', () => {
+	test('no bun: imports in symbol-graph.ts (invariant 2)', () => {
+		const sgPath = path.join(REPO_ROOT, 'src', 'lang', 'symbol-graph.ts');
+		const src = fs.readFileSync(sgPath, 'utf-8');
+
+		expect(src).not.toMatch(/from\s+['"]bun:[^'"]+['"]/);
+		expect(src).not.toMatch(/import\s*\(\s*['"]bun:/);
+	});
+
+	test('no global Bun.* API in symbol-graph.ts (invariant 2)', () => {
+		const sgPath = path.join(REPO_ROOT, 'src', 'lang', 'symbol-graph.ts');
+		const src = fs.readFileSync(sgPath, 'utf-8');
+
+		// Strip line comments before checking.
+		const stripped = src
+			.replace(/\/\/[^\n]*/g, '')
+			.replace(/\/\*[\s\S]*?\*\//g, '');
+
+		expect(stripped).not.toMatch(/\bBun\.[a-zA-Z]/);
+	});
+
+	test('no spawn primitives in symbol-graph.ts (invariant 3)', () => {
+		const sgPath = path.join(REPO_ROOT, 'src', 'lang', 'symbol-graph.ts');
+		const src = fs.readFileSync(sgPath, 'utf-8');
+
+		// Import-level checks.
+		expect(src).not.toMatch(/import\s+.*bunSpawn(?:Sync)?\s+from/);
+		expect(src).not.toMatch(
+			/import\s+.*\bspawn(?:Sync)?\b.*from\s+['"]node:child_process['"]/,
+		);
+
+		// Usage-level checks (strip comments first).
+		const stripped = src
+			.replace(/\/\/[^\n]*/g, '')
+			.replace(/\/\*[\s\S]*?\*\//g, '');
+
+		expect(stripped).not.toMatch(/\bbunSpawn(?:Sync)?\s*\(/);
+		expect(stripped).not.toMatch(/\bspawn(?:Sync)?\s*\(/);
+	});
+});

--- a/tests/unit/lang/symbol-graph.test.ts
+++ b/tests/unit/lang/symbol-graph.test.ts
@@ -1,0 +1,1122 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { clearParserCache } from '../../../src/lang/runtime';
+import {
+	extractFileSymbols,
+	type FileSymbolFacts,
+} from '../../../src/lang/symbol-graph';
+
+describe('extractFileSymbols — typescript grammar (task 1.1)', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('extracts defs, imports, and refs from a TS snippet', async () => {
+		const source = `
+import { foo as bar } from './m';
+
+export function myFunc() {
+	bar();
+}
+`;
+
+		const facts = await extractFileSymbols('typescript', source);
+		expect(facts).not.toBeNull();
+
+		// One exported function def
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0]).toMatchObject({
+			name: 'myFunc',
+			kind: 'function',
+			exported: true,
+		});
+		expect(facts!.defs[0].startLine).toBeGreaterThan(0);
+		expect(facts!.defs[0].endLine).toBeGreaterThanOrEqual(
+			facts!.defs[0].startLine,
+		);
+
+		// One named import with aliased binding
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: './m',
+			importType: 'named',
+		});
+		expect(facts!.imports[0].bindings).toEqual([
+			{ imported: 'foo', local: 'bar' },
+		]);
+
+		// bar() call inside myFunc has enclosingDecl = myFunc
+		const barRef = facts!.refs.find((r) => r.identifier === 'bar');
+		expect(barRef).toBeDefined();
+		expect(barRef!.enclosingDecl).toBe('myFunc');
+	});
+
+	test('parses JavaScript source under grammarId typescript', async () => {
+		const source = `
+function hello() {
+	console.log('hi');
+}
+`;
+
+		const facts = await extractFileSymbols('typescript', source);
+		expect(facts).not.toBeNull();
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0].name).toBe('hello');
+		expect(facts!.defs[0].kind).toBe('function');
+	});
+
+	test('returns null for an unknown grammarId (fail-open)', async () => {
+		const facts = await extractFileSymbols('nonexistent-lang', 'const x = 1;');
+		expect(facts).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// FIX 3 — JavaScript grammarId alias (phase-council reviewer finding)
+	// The 'javascript' key mirrors 'typescript'; this test verifies it works.
+	// Uses plain JS syntax (no TypeScript-only type annotations).
+	// -------------------------------------------------------------------------
+	test('javascript grammarId alias: function f() {} resolves', async () => {
+		const source = 'function f() { return 1; }';
+
+		const facts = await extractFileSymbols('javascript', source);
+		expect(facts).not.toBeNull();
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0]).toMatchObject({
+			name: 'f',
+			kind: 'function',
+		});
+	});
+
+	test('reference inside anonymous callback gets nearest top-level decl', async () => {
+		const source = `
+function outer() {
+	const callback = () => {
+		inner();
+	};
+}
+`;
+
+		const facts = await extractFileSymbols('typescript', source);
+		expect(facts).not.toBeNull();
+
+		const innerRef = facts!.refs.find((r) => r.identifier === 'inner');
+		expect(innerRef).toBeDefined();
+		// inner() is inside an anonymous arrow inside outer,
+		// so enclosingDecl falls back to the nearest named top-level decl: outer
+		expect(innerRef!.enclosingDecl).toBe('outer');
+	});
+
+	test('reference at module scope falls back to <module>', async () => {
+		const source = `x;\n`;
+
+		const facts = await extractFileSymbols('typescript', source);
+		expect(facts).not.toBeNull();
+
+		const xRef = facts!.refs.find((r) => r.identifier === 'x');
+		expect(xRef).toBeDefined();
+		expect(xRef!.enclosingDecl).toBe('<module>');
+	});
+});
+
+// -----------------------------------------------------------------------
+// Regression tests — reviewer-flagged bugs
+// These documents gaps that the coder must fix in src/lang/symbol-graph.ts
+// -----------------------------------------------------------------------
+
+describe('extractFileSymbols — regression: reviewer bugs', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	// -------------------------------------------------------------------------
+	// BUG (a) — C6 misattribution: isNodeInside uses row-only containment.
+	// FIX: isNodeInside now uses byte-offset (startIndex/endIndex) containment,
+	// so same-line minified code attributes references to the correct scope.
+	// -------------------------------------------------------------------------
+	test('bug a: minified same-line functions — enclosingDecl uses column bounds', async () => {
+		// foo: cols 0-16 (function foo(){})
+		// bar: cols 17-39 (function bar(){ baz(); })
+		// baz: col 27 — inside bar, outside foo
+		const source = 'function foo(){} function bar(){ baz(); }';
+
+		const facts = await extractFileSymbols('typescript', source);
+		expect(facts).not.toBeNull();
+
+		const bazRef = facts!.refs.find((r) => r.identifier === 'baz');
+		expect(bazRef).toBeDefined();
+		// With byte-offset containment, baz is correctly inside bar.
+		expect(bazRef!.enclosingDecl).toBe('bar');
+	});
+
+	// -------------------------------------------------------------------------
+	// BUG (b) — C7 completeness: generator function* declarations captured.
+	// FIX: added `(generator_function_declaration ...)` to the defs query.
+	// -------------------------------------------------------------------------
+	test('bug b: generator function* gen(){} produces a def entry', async () => {
+		const source = 'function* gen() { yield 1; }';
+
+		const facts = await extractFileSymbols('typescript', source);
+		expect(facts).not.toBeNull();
+
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0].name).toBe('gen');
+		expect(facts!.defs[0].kind).toBe('function');
+	});
+
+	// -------------------------------------------------------------------------
+	// BUG (c) — C7 completeness: import type { Foo } syntax is handled.
+	// FIX: parseEsmImport strips the optional `type` qualifier from the
+	// import statement and from individual bindings inline.
+	// -------------------------------------------------------------------------
+	test('bug c.1: import type { Foo } from "./m" produces a named import entry', async () => {
+		const source = "import type { Foo } from './m';";
+
+		const facts = await extractFileSymbols('typescript', source);
+		expect(facts).not.toBeNull();
+
+		// parseEsmImport now strips the `type` qualifier and captures the named import
+		const fooImport = facts!.imports.find((i) => i.specifier === './m');
+		expect(fooImport).toBeDefined();
+		expect(fooImport!.importType).toBe('named');
+		// Type-only import has no runtime bindings
+		expect(fooImport!.bindings).toEqual([]);
+	});
+
+	test('bug c.2: import { type Bar } from "./m" strips the type keyword in bindings', async () => {
+		const source = "import { type Bar } from './m';";
+
+		const facts = await extractFileSymbols('typescript', source);
+		expect(facts).not.toBeNull();
+
+		const barImport = facts!.imports.find((i) => i.specifier === './m');
+		expect(barImport).toBeDefined();
+		expect(barImport!.importType).toBe('named');
+		// The 'type' keyword is stripped; Bar is captured correctly
+		expect(barImport!.bindings).toEqual([{ imported: 'Bar', local: 'Bar' }]);
+	});
+
+	// -------------------------------------------------------------------------
+	// FIX 1 — Combined ESM imports (phase-council reviewer finding)
+	// `import Default, { named } from 'spec'` and `import Default, * as ns from 'spec'`
+	// -------------------------------------------------------------------------
+	test('combined ESM: import React, { useState as use } from "react"', async () => {
+		const source = `import React, { useState as use } from 'react';
+
+export function App() {
+	const [s, set] = use();
+	return React.createElement('div', null, s);
+}`;
+
+		const facts = await extractFileSymbols('typescript', source);
+		expect(facts).not.toBeNull();
+
+		const reactImport = facts!.imports.find((i) => i.specifier === 'react');
+		expect(reactImport).toBeDefined();
+		expect(reactImport!.importType).toBe('named');
+		// Default binding + aliased named binding
+		expect(reactImport!.bindings).toEqual([
+			{ imported: 'default', local: 'React' },
+			{ imported: 'useState', local: 'use' },
+		]);
+	});
+
+	test('combined ESM with namespace: import Def, * as ns from "mod"', async () => {
+		const source = `import Def, * as ns from 'mod';`;
+
+		const facts = await extractFileSymbols('typescript', source);
+		expect(facts).not.toBeNull();
+
+		const modImport = facts!.imports.find((i) => i.specifier === 'mod');
+		expect(modImport).toBeDefined();
+		expect(modImport!.importType).toBe('named');
+		expect(modImport!.bindings).toEqual([
+			{ imported: 'default', local: 'Def' },
+			{ imported: '*', local: 'ns' },
+		]);
+	});
+
+	// -------------------------------------------------------------------------
+	// FIX 2 — Default-export naming divergence (phase-council reviewer finding)
+	// `export default function go()` must record the exported def name as 'default'
+	// (not 'go') so node.exports/exportRanges key on 'default', matching the
+	// 'default' sentinel used by parseEsmImport for `import go from './m'`
+	// and the sync builder's export naming.
+	// -------------------------------------------------------------------------
+	test('default export: export default function go() records name as "default"', async () => {
+		const source = 'export default function go() { return 1; }';
+
+		const facts = await extractFileSymbols('typescript', source);
+		expect(facts).not.toBeNull();
+
+		// The def name is 'default' (not the local 'go') so node.exports/exportRanges
+		// key on 'default', matching the edge 'default' sentinel + sync path.
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0].name).toBe('default');
+		expect(facts!.defs[0].kind).toBe('function');
+		expect(facts!.defs[0].exported).toBe(true);
+		expect(facts!.defs[0].startLine).toBeGreaterThan(0);
+		expect(facts!.defs[0].endLine).toBeGreaterThanOrEqual(
+			facts!.defs[0].startLine,
+		);
+	});
+
+	test('default export javascript grammar: export default class Foo', async () => {
+		const source = 'export default class Foo { }';
+
+		const facts = await extractFileSymbols('javascript', source);
+		expect(facts).not.toBeNull();
+
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0].name).toBe('default');
+		expect(facts!.defs[0].kind).toBe('class');
+		expect(facts!.defs[0].exported).toBe(true);
+	});
+
+	test('named export is unaffected by default-export normalization', async () => {
+		const source = `export function go() { return 1; }
+export default function also() { return 2; }`;
+
+		const facts = await extractFileSymbols('typescript', source);
+		expect(facts).not.toBeNull();
+
+		// go is a named export → name stays 'go'
+		const goDef = facts!.defs.find((d) => d.name === 'go');
+		expect(goDef).toBeDefined();
+		expect(goDef!.exported).toBe(true);
+
+		// also is a default export → name becomes 'default'
+		const defaultDef = facts!.defs.find((d) => d.name === 'default');
+		expect(defaultDef).toBeDefined();
+		expect(defaultDef!.exported).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial security / robustness tests
+// Verify fail-open: extractFileSymbols never throws, never hangs,
+// and returns null or safe partial facts for every malformed input.
+// ---------------------------------------------------------------------------
+
+describe('extractFileSymbols — adversarial attack vectors (task 1.1 step 5m)', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	// -----------------------------------------------------------------------
+	// Vector 1: Malformed / garbage source — binary bytes, null bytes,
+	// random control chars, truncated code. Must not throw.
+	// -----------------------------------------------------------------------
+	test('vector 1: binary-looking bytes and null bytes — fail-open', async () => {
+		// Null bytes embedded in source — tree-sitter's TypeScript parser
+		// tolerates embedded nulls and parses the valid portions; fail-open
+		// means no crash, which is satisfied here.
+		const garbage = 'function f\x00() {\x00return 1;\x00}';
+		const start = Date.now();
+		const facts = await extractFileSymbols('typescript', garbage);
+		const elapsed = Date.now() - start;
+		// Must not throw; null OR partial facts both acceptable fail-open
+		expect(
+			facts === null ||
+				(typeof facts === 'object' && Array.isArray(facts.defs)),
+		).toBe(true);
+		expect(elapsed).toBeLessThan(2000);
+	});
+
+	test('vector 1b: random control chars — fail-open', async () => {
+		// Mix of control characters (BEL, ENQ, SUB, etc.)
+		const ctrl = 'fun\x07ction \x1b f\x10() { ret\x03urn 42; }';
+		const start = Date.now();
+		const facts = await extractFileSymbols('typescript', ctrl);
+		const elapsed = Date.now() - start;
+		// Must not throw; null is acceptable fail-open
+		expect(facts === null || Array.isArray(facts.defs)).toBe(true);
+		expect(elapsed).toBeLessThan(2000);
+	});
+
+	test('vector 1c: truncated/incomplete code — fail-open', async () => {
+		// Half-written code cut mid-token
+		const truncated = 'function incoplete { return';
+		const start = Date.now();
+		const facts = await extractFileSymbols('typescript', truncated);
+		const elapsed = Date.now() - start;
+		// Must not throw; null or partial facts both acceptable
+		expect(facts === null || typeof facts === 'object').toBe(true);
+		expect(elapsed).toBeLessThan(2000);
+	});
+
+	// -----------------------------------------------------------------------
+	// Vector 2: Syntax-error TS source. Must not throw.
+	// -----------------------------------------------------------------------
+	test('vector 2: severe syntax errors — fail-open', async () => {
+		const broken = 'function {{{{ {{}}}}}}}}}}}';
+		const start = Date.now();
+		const facts = await extractFileSymbols('typescript', broken);
+		const elapsed = Date.now() - start;
+		// Must not throw; null is acceptable
+		expect(facts === null || typeof facts === 'object').toBe(true);
+		expect(elapsed).toBeLessThan(2000);
+	});
+
+	// -----------------------------------------------------------------------
+	// Vector 3: Empty string source. Must not throw.
+	// -----------------------------------------------------------------------
+	test('vector 3: empty string — fail-open', async () => {
+		const start = Date.now();
+		const facts = await extractFileSymbols('typescript', '');
+		const elapsed = Date.now() - start;
+		// Must not throw; null or empty-object facts both acceptable
+		expect(facts === null || typeof facts === 'object').toBe(true);
+		expect(elapsed).toBeLessThan(2000);
+	});
+
+	// -----------------------------------------------------------------------
+	// Vector 4: Oversized source (2 MB+). Must be bounded and fail-open.
+	// The 500 ms AST_TIMEOUT_MS race should bound the operation, but
+	// parser.parse() is synchronous — if it exceeds 500 ms the outer race
+	// fires when it rejects, not when the parse is aborted. We assert the
+	// call returns within a generous wall-clock (3 s) without hanging.
+	// -----------------------------------------------------------------------
+	test('vector 4: 2 MB+ repeated declarations — bounded, no hang', async () => {
+		// ~2.2 MB string — repeating pattern that exercises both parser and query
+		const decl = 'function __gen() { return 1; } ';
+		// 70 000 repetitions ≈ 2.17 MB
+		const source = decl.repeat(70_000);
+		expect(source.length).toBeGreaterThan(2 * 1024 * 1024);
+
+		const start = Date.now();
+		const facts = await extractFileSymbols('typescript', source);
+		const elapsed = Date.now() - start;
+
+		// Must not throw; null (timeout) or partial facts both acceptable
+		expect(facts === null || typeof facts === 'object').toBe(true);
+		// Must complete within a generous wall-clock — the 500 ms AST_TIMEOUT_MS
+		// provides the hard bound; we allow up to 3 s so the test is reliable.
+		expect(elapsed).toBeLessThan(3000);
+	});
+
+	// -----------------------------------------------------------------------
+	// Vector 5: Wrong-grammar source. Feed Python under 'typescript'.
+	// Must not throw.
+	// -----------------------------------------------------------------------
+	test('vector 5: Python source parsed as TypeScript grammar — fail-open', async () => {
+		const python = 'def f(): pass\nclass C: pass';
+		const start = Date.now();
+		const facts = await extractFileSymbols('typescript', python);
+		const elapsed = Date.now() - start;
+		// Must not throw; null or partial/empty facts acceptable
+		expect(facts === null || typeof facts === 'object').toBe(true);
+		expect(elapsed).toBeLessThan(2000);
+	});
+
+	// -----------------------------------------------------------------------
+	// Vector 6: Pathological nesting — 500 levels of nested IIFEs.
+	// Must not stack-overflow or hang; fail-open acceptable.
+	// -----------------------------------------------------------------------
+	test('vector 6: 500 levels of nested callbacks — bounded', async () => {
+		// Build 500-level nesting: () => () => () => ...
+		const levels = 500;
+		let src = 'const x = ';
+		for (let i = 0; i < levels; i++) {
+			src += '(() => ';
+		}
+		src += '1';
+		src += ')'.repeat(levels) + ';';
+		expect(src.length).toBeLessThan(100_000); // ~6 KB, manageable size
+
+		const start = Date.now();
+		const facts = await extractFileSymbols('typescript', src);
+		const elapsed = Date.now() - start;
+
+		// Must not throw; null or partial facts both acceptable
+		expect(facts === null || typeof facts === 'object').toBe(true);
+		expect(elapsed).toBeLessThan(2000);
+	});
+
+	// -----------------------------------------------------------------------
+	// Vector 7: Unicode / emoji in identifiers and string content.
+	// Must not throw.
+	// -----------------------------------------------------------------------
+	test('vector 7: Unicode and emoji identifiers — fail-open', async () => {
+		const source =
+			'function 名称() { return "こんにちは"; }\n' +
+			'function 🐍() { return 42; }\n' +
+			'const 变量 = 1;\n' +
+			'class Élément { }\n';
+		const start = Date.now();
+		const facts = await extractFileSymbols('typescript', source);
+		const elapsed = Date.now() - start;
+		// Must not throw; null or partial facts both acceptable
+		expect(facts === null || typeof facts === 'object').toBe(true);
+		expect(elapsed).toBeLessThan(2000);
+	});
+
+	// -----------------------------------------------------------------------
+	// Vector 8: Pathological parse — source engineered to stress the
+	// (identifier) @ref.identifier query with 50 000 identifiers.
+	// The 500 ms AST_TIMEOUT_MS race should bound overall time.
+	// -----------------------------------------------------------------------
+	test('vector 8: 50 000 identifiers stress-test — bounded, no hang', async () => {
+		// 50 000 single-identifier statements: "x0; x1; x2; ..."
+		// All 50 000 identifiers are refs that must be matched by the query.
+		const ids: string[] = [];
+		for (let i = 0; i < 50_000; i++) ids.push(`x${i}`);
+		const source = ids.join('; ') + ';';
+
+		const start = Date.now();
+		const facts = await extractFileSymbols('typescript', source);
+		const elapsed = Date.now() - start;
+
+		// Must not throw; null (timeout) or partial facts both acceptable
+		expect(facts === null || typeof facts === 'object').toBe(true);
+		// Must complete within a generous wall-clock — the 500 ms AST_TIMEOUT_MS
+		// provides the hard bound for the overall operation.
+		expect(elapsed).toBeLessThan(3000);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Per-grammar tests — task 1.2
+// Each grammarId is exercised with: one exported/named def, one aliased
+// import (where the language supports it), and one cross-symbol ref inside
+// the def.  If a grammar's query captures the wrong node type, the test
+// silently returns empty (safeMatches → no crash); we assert on exact
+// shape so a wrong node type produces a FAIL — documenting a real bug to fix.
+// ---------------------------------------------------------------------------
+
+describe('extractFileSymbols — python grammar', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('def + aliased import + cross-symbol ref', async () => {
+		// from os import path as p   → aliased binding
+		// def main(): ...            → top-level def
+		// p.join(...)                → cross-symbol ref inside main
+		const source = `from os import path as p
+
+def main():
+    return p.join('a', 'b')
+`;
+
+		const facts = await extractFileSymbols('python', source);
+		expect(facts).not.toBeNull();
+
+		// def: main function
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0]).toMatchObject({
+			name: 'main',
+			kind: 'function',
+		});
+		expect(facts!.defs[0].startLine).toBeGreaterThan(0);
+		expect(facts!.defs[0].endLine).toBeGreaterThanOrEqual(
+			facts!.defs[0].startLine,
+		);
+
+		// import: from os import path as p
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'os',
+			importType: 'named',
+		});
+		expect(facts!.imports[0].bindings).toEqual([
+			{ imported: 'path', local: 'p' },
+		]);
+
+		// ref: p.join inside main → enclosingDecl = 'main'
+		const pRef = facts!.refs.find((r) => r.identifier === 'p');
+		expect(pRef).toBeDefined();
+		expect(pRef!.enclosingDecl).toBe('main');
+	});
+});
+
+describe('extractFileSymbols — rust grammar', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('def + aliased use + cross-symbol ref', async () => {
+		// use std::collections::HashMap as Map;  → aliased binding
+		// fn main() { ... }                      → top-level def
+		// Map::new()                             → cross-symbol ref inside main
+		const source = `use std::collections::HashMap as Map;
+
+fn main() {
+    let _m: Map<u32, u32> = Map::new();
+}
+`;
+
+		const facts = await extractFileSymbols('rust', source);
+		expect(facts).not.toBeNull();
+
+		// def: main function
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0]).toMatchObject({
+			name: 'main',
+			kind: 'function',
+		});
+		expect(facts!.defs[0].startLine).toBeGreaterThan(0);
+		expect(facts!.defs[0].endLine).toBeGreaterThanOrEqual(
+			facts!.defs[0].startLine,
+		);
+
+		// import: use std::collections::HashMap as Map
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'std::collections::HashMap',
+			importType: 'named',
+		});
+		expect(facts!.imports[0].bindings).toEqual([
+			{ imported: 'std::collections::HashMap', local: 'Map' },
+		]);
+
+		// ref: Map inside main → enclosingDecl = 'main'
+		const mapRef = facts!.refs.find((r) => r.identifier === 'Map');
+		expect(mapRef).toBeDefined();
+		expect(mapRef!.enclosingDecl).toBe('main');
+	});
+});
+
+describe('extractFileSymbols — go grammar', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('def + aliased import + cross-symbol ref', async () => {
+		// import f "fmt"   → aliased import (f is local alias for fmt)
+		// func main() { }  → top-level def
+		// f.Println(...)    → cross-symbol ref inside main
+		const source = `import f "fmt"
+
+func main() {
+	f.Println("hello")
+}
+`;
+
+		const facts = await extractFileSymbols('go', source);
+		expect(facts).not.toBeNull();
+
+		// def: main function
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0]).toMatchObject({
+			name: 'main',
+			kind: 'function',
+		});
+		expect(facts!.defs[0].startLine).toBeGreaterThan(0);
+		expect(facts!.defs[0].endLine).toBeGreaterThanOrEqual(
+			facts!.defs[0].startLine,
+		);
+
+		// import: import f "fmt"
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'fmt',
+			importType: 'named',
+		});
+		expect(facts!.imports[0].bindings).toEqual([
+			{ imported: 'fmt', local: 'f' },
+		]);
+
+		// ref: f.Println inside main → enclosingDecl = 'main'
+		const fRef = facts!.refs.find((r) => r.identifier === 'f');
+		expect(fRef).toBeDefined();
+		expect(fRef!.enclosingDecl).toBe('main');
+	});
+
+	test('go block imports (import (...)) resolve each specifier', async () => {
+		// import ( "fmt" "os" ) — each specifier is a separate @import.specifier
+		// capture fed as a bare quoted string to parseGoImport
+		const source = `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println(os.Args)
+}
+`;
+
+		const facts = await extractFileSymbols('go', source);
+		expect(facts).not.toBeNull();
+
+		// def: main function
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0]).toMatchObject({
+			name: 'main',
+			kind: 'function',
+		});
+
+		// imports: both "fmt" and "os" must resolve as namespace imports
+		expect(facts!.imports).toHaveLength(2);
+		const specifiers = facts!.imports.map((i) => i.specifier);
+		expect(specifiers).toContain('fmt');
+		expect(specifiers).toContain('os');
+		expect(facts!.imports.every((i) => i.importType === 'namespace')).toBe(
+			true,
+		);
+
+		// ref: fmt.Println and os.Args inside main → enclosingDecl = 'main'
+		const fmtRef = facts!.refs.find((r) => r.identifier === 'fmt');
+		expect(fmtRef).toBeDefined();
+		expect(fmtRef!.enclosingDecl).toBe('main');
+		const osRef = facts!.refs.find((r) => r.identifier === 'os');
+		expect(osRef).toBeDefined();
+		expect(osRef!.enclosingDecl).toBe('main');
+	});
+
+	// -------------------------------------------------------------------------
+	// FIX 2 — Go aliased block imports (phase-council sme finding)
+	// `import ( f "fmt" )` — parseGoImport previously required an `import ` prefix
+	// on the aliased regex, so bare `f "fmt"` from a block-import child returned null.
+	// -------------------------------------------------------------------------
+	test('go aliased block import: import ( f "fmt" )', async () => {
+		const source = `package main
+
+import (
+	f "fmt"
+)
+
+func main() {
+	f.Println("hello")
+}
+`;
+
+		const facts = await extractFileSymbols('go', source);
+		expect(facts).not.toBeNull();
+
+		// def: main function
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0].name).toBe('main');
+
+		// import: f "fmt" aliased block spec → named with local alias 'f'
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'fmt',
+			importType: 'named',
+		});
+		expect(facts!.imports[0].bindings).toEqual([
+			{ imported: 'fmt', local: 'f' },
+		]);
+
+		// ref: f.Println inside main → enclosingDecl = 'main'
+		const fRef = facts!.refs.find((r) => r.identifier === 'f');
+		expect(fRef).toBeDefined();
+		expect(fRef!.enclosingDecl).toBe('main');
+	});
+});
+
+describe('extractFileSymbols — java grammar', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('def + import + cross-symbol ref', async () => {
+		// import java.util.List;   → no alias in Java
+		// public class C { ... }   → class def
+		// void m(){ List x = null; } → method def + List ref inside
+		const source = `import java.util.List;
+
+public class C {
+	void m() {
+		List<String> x = null;
+	}
+}
+`;
+
+		const facts = await extractFileSymbols('java', source);
+		expect(facts).not.toBeNull();
+
+		// defs: class C + method m
+		const defNames = facts!.defs.map((d) => d.name);
+		expect(defNames).toContain('C');
+		expect(defNames).toContain('m');
+
+		// import: java.util.List
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'java.util.List',
+			importType: 'namespace',
+		});
+
+		// ref: List inside method m → enclosingDecl = 'C' (class, nearest top-level decl)
+		const listRef = facts!.refs.find((r) => r.identifier === 'List');
+		expect(listRef).toBeDefined();
+		expect(listRef!.enclosingDecl).toBe('C');
+	});
+
+	// -------------------------------------------------------------------------
+	// FIX 4 (Java portion) — interface declaration + static import
+	// -------------------------------------------------------------------------
+	test('def + interface def + static import + cross-symbol ref', async () => {
+		// import java.util.Collections;         → regular import
+		// import static java.lang.Math.max;     → static import
+		// public interface I { }                → interface def
+		// class C implements I {                → class def
+		//   int m() { return max(1, 2); }       → method def + max ref
+		const source = `import java.util.Collections;
+import static java.lang.Math.max;
+
+public interface I { }
+
+class C implements I {
+	int m() {
+		return max(1, 2);
+	}
+}
+`;
+
+		const facts = await extractFileSymbols('java', source);
+		expect(facts).not.toBeNull();
+
+		// defs: interface I, class C, method m
+		const defNames = facts!.defs.map((d) => d.name);
+		expect(defNames).toContain('I');
+		expect(defNames).toContain('C');
+		expect(defNames).toContain('m');
+
+		// Interface I must be captured as interface kind
+		const iDef = facts!.defs.find((d) => d.name === 'I');
+		expect(iDef).toBeDefined();
+		expect(iDef!.kind).toBe('interface');
+
+		// imports: Collections (regular) + Math.max (static)
+		expect(facts!.imports.length).toBeGreaterThanOrEqual(2);
+		const collImport = facts!.imports.find(
+			(i) => i.specifier === 'java.util.Collections',
+		);
+		expect(collImport).toBeDefined();
+		expect(collImport!.importType).toBe('namespace');
+
+		const maxImport = facts!.imports.find(
+			(i) => i.specifier === 'java.lang.Math.max',
+		);
+		expect(maxImport).toBeDefined();
+		expect(maxImport!.importType).toBe('namespace');
+
+		// ref: max inside method m → enclosingDecl = 'C' (class, nearest top-level)
+		const maxRef = facts!.refs.find((r) => r.identifier === 'max');
+		expect(maxRef).toBeDefined();
+		expect(maxRef!.enclosingDecl).toBe('C');
+	});
+});
+
+describe('extractFileSymbols — kotlin grammar', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('def + aliased import + cross-symbol ref', async () => {
+		// import kotlin.collections.List as L  → aliased binding
+		// fun main() { }                      → top-level def
+		// val x: L<String> = ...              → cross-symbol ref inside main
+		const source = `import kotlin.collections.List as L
+
+fun main() {
+	val x: L<String> = listOf()
+}
+`;
+
+		const facts = await extractFileSymbols('kotlin', source);
+		expect(facts).not.toBeNull();
+
+		// def: main function
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0]).toMatchObject({
+			name: 'main',
+			kind: 'function',
+		});
+		expect(facts!.defs[0].startLine).toBeGreaterThan(0);
+		expect(facts!.defs[0].endLine).toBeGreaterThanOrEqual(
+			facts!.defs[0].startLine,
+		);
+
+		// import: import kotlin.collections.List as L
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'kotlin.collections.List',
+			importType: 'named',
+		});
+		expect(facts!.imports[0].bindings).toEqual([
+			{ imported: 'kotlin.collections.List', local: 'L' },
+		]);
+
+		// ref: L inside main → enclosingDecl = 'main'
+		const lRef = facts!.refs.find((r) => r.identifier === 'L');
+		expect(lRef).toBeDefined();
+		expect(lRef!.enclosingDecl).toBe('main');
+	});
+});
+
+describe('extractFileSymbols — csharp grammar', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('def + aliased using + cross-symbol ref', async () => {
+		// using S = System;  → aliased using directive
+		// void M() { }       → method def inside class
+		// S.Console.WriteLine()  → cross-symbol ref inside M
+		const source = `using S = System;
+
+class C {
+	void M() {
+		S.Console.WriteLine("x");
+	}
+}
+`;
+
+		const facts = await extractFileSymbols('csharp', source);
+		expect(facts).not.toBeNull();
+
+		// defs: class C + method M
+		const defNames = facts!.defs.map((d) => d.name);
+		expect(defNames).toContain('C');
+		expect(defNames).toContain('M');
+
+		// import: using S = System
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'System',
+			importType: 'named',
+		});
+		expect(facts!.imports[0].bindings).toEqual([
+			{ imported: 'System', local: 'S' },
+		]);
+
+		// ref: S.Console... inside M → enclosingDecl = 'C' (class, nearest top-level decl)
+		const sRef = facts!.refs.find((r) => r.identifier === 'S');
+		expect(sRef).toBeDefined();
+		expect(sRef!.enclosingDecl).toBe('C');
+	});
+});
+
+describe('extractFileSymbols — cpp grammar', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('def + include import + cross-symbol ref', async () => {
+		// #include <cstdio>  → preproc_include
+		// int main() { }      → function_definition
+		// std::printf(...)    → cross-symbol ref inside main
+		const source = `#include <cstdio>
+
+int main() {
+	std::printf("x");
+	return 0;
+}
+`;
+
+		const facts = await extractFileSymbols('cpp', source);
+		expect(facts).not.toBeNull();
+
+		// def: main function
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0]).toMatchObject({
+			name: 'main',
+			kind: 'function',
+		});
+		expect(facts!.defs[0].startLine).toBeGreaterThan(0);
+		expect(facts!.defs[0].endLine).toBeGreaterThanOrEqual(
+			facts!.defs[0].startLine,
+		);
+
+		// import: #include <cstdio>
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'cstdio',
+			importType: 'namespace',
+		});
+
+		// ref: std (or printf) inside main
+		// std::printf — 'std' is an identifier in a namespace qualifier context
+		const stdRef = facts!.refs.find((r) => r.identifier === 'std');
+		expect(stdRef).toBeDefined();
+		expect(stdRef!.enclosingDecl).toBe('main');
+	});
+});
+
+describe('extractFileSymbols — swift grammar', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('def + import + cross-symbol ref', async () => {
+		// import Foundation   → import_declaration
+		// func main() { }     → function_declaration
+		// print(Date())       → cross-symbol ref inside main
+		const source = `import Foundation
+
+func main() {
+	print(Date())
+}
+`;
+
+		const facts = await extractFileSymbols('swift', source);
+		expect(facts).not.toBeNull();
+
+		// def: main function
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0]).toMatchObject({
+			name: 'main',
+			kind: 'function',
+		});
+		expect(facts!.defs[0].startLine).toBeGreaterThan(0);
+		expect(facts!.defs[0].endLine).toBeGreaterThanOrEqual(
+			facts!.defs[0].startLine,
+		);
+
+		// import: import Foundation
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'Foundation',
+			importType: 'namespace',
+		});
+
+		// ref: Date() inside main → enclosingDecl = 'main'
+		const dateRef = facts!.refs.find((r) => r.identifier === 'Date');
+		expect(dateRef).toBeDefined();
+		expect(dateRef!.enclosingDecl).toBe('main');
+	});
+});
+
+describe('extractFileSymbols — dart grammar', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('def + aliased import + cross-symbol ref', async () => {
+		// import 'dart:io' as io;   → aliased import
+		// void main() { }          → function_signature
+		// io.stdout.writeln(...)   → cross-symbol ref (io) inside main
+		const source = `import 'dart:io' as io;
+
+void main() {
+	io.stdout.writeln('x');
+}
+`;
+
+		const facts = await extractFileSymbols('dart', source);
+		expect(facts).not.toBeNull();
+
+		// def: main function
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0]).toMatchObject({
+			name: 'main',
+			kind: 'function',
+		});
+		expect(facts!.defs[0].startLine).toBeGreaterThan(0);
+		expect(facts!.defs[0].endLine).toBeGreaterThanOrEqual(
+			facts!.defs[0].startLine,
+		);
+
+		// import: import 'dart:io' as io
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'dart:io',
+			importType: 'named',
+		});
+		expect(facts!.imports[0].bindings).toEqual([
+			{ imported: 'dart:io', local: 'io' },
+		]);
+
+		// ref: io.stdout... inside main → enclosingDecl = 'main'
+		const ioRef = facts!.refs.find((r) => r.identifier === 'io');
+		expect(ioRef).toBeDefined();
+		expect(ioRef!.enclosingDecl).toBe('main');
+	});
+});
+
+describe('extractFileSymbols — ruby grammar', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('def + require import + cross-symbol ref', async () => {
+		// require 'json'        → call_expression require
+		// def main; ... end    → method (ruby top-level def is a method node)
+		// JSON.parse(...)      → cross-symbol ref (JSON) inside main
+		const source = `require 'json'
+
+def main
+	JSON.parse('{}')
+end
+`;
+
+		const facts = await extractFileSymbols('ruby', source);
+		expect(facts).not.toBeNull();
+
+		// def: main method
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0]).toMatchObject({
+			name: 'main',
+			kind: 'function',
+		});
+		expect(facts!.defs[0].startLine).toBeGreaterThan(0);
+		expect(facts!.defs[0].endLine).toBeGreaterThanOrEqual(
+			facts!.defs[0].startLine,
+		);
+
+		// import: require 'json'
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'json',
+			importType: 'namespace',
+		});
+
+		// ref: parse inside main → enclosingDecl = 'main'
+		// Note: 'JSON' is a constant node in Ruby's tree-sitter grammar (not identifier),
+		// so it is not captured by (identifier) @ref.identifier; 'parse' is the identifier.
+		const parseRef = facts!.refs.find((r) => r.identifier === 'parse');
+		expect(parseRef).toBeDefined();
+		expect(parseRef!.enclosingDecl).toBe('main');
+	});
+});
+
+describe('extractFileSymbols — php grammar', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('def + aliased use + cross-symbol ref', async () => {
+		// use Ns\\Foo as F;   → namespace_use_declaration with alias
+		// function main() { } → function_definition
+		// F::bar()            → cross-symbol ref (F) inside main
+		const source = `<?php
+use Ns\\Foo as F;
+
+function main() {
+	F::bar();
+}
+`;
+
+		const facts = await extractFileSymbols('php', source);
+		expect(facts).not.toBeNull();
+
+		// def: main function
+		expect(facts!.defs).toHaveLength(1);
+		expect(facts!.defs[0]).toMatchObject({
+			name: 'main',
+			kind: 'function',
+		});
+		expect(facts!.defs[0].startLine).toBeGreaterThan(0);
+		expect(facts!.defs[0].endLine).toBeGreaterThanOrEqual(
+			facts!.defs[0].startLine,
+		);
+
+		// import: use Ns\Foo as F
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'Ns\\Foo',
+			importType: 'named',
+		});
+		expect(facts!.imports[0].bindings).toEqual([
+			{ imported: 'Ns\\Foo', local: 'F' },
+		]);
+
+		// ref: F::bar() inside main → enclosingDecl = 'main'
+		const fRef = facts!.refs.find((r) => r.identifier === 'F');
+		expect(fRef).toBeDefined();
+		expect(fRef!.enclosingDecl).toBe('main');
+	});
+});

--- a/tests/unit/tools/repo-graph-async-equivalence.test.ts
+++ b/tests/unit/tools/repo-graph-async-equivalence.test.ts
@@ -66,16 +66,62 @@ describe('repo-graph build O(N) equivalence — issue #1144', () => {
 		const sync = buildWorkspaceGraph(workspacePath);
 		const asyncGraph = await buildWorkspaceGraphAsync(workspacePath);
 
-		// Full node map equality (keys + node objects incl. exports/imports/mtime).
-		expect(asyncGraph.nodes).toEqual(sync.nodes);
-		// Full edge array equality, order-sensitive (toEqual compares array order).
-		expect(asyncGraph.edges).toEqual(sync.edges);
+		// Build file-level projections: strip async-exclusive exportRanges before
+		// comparing node content. Sync never produces exportRanges (3.2 contract).
+		const fileLevelNodes = <Record<string, object>>{};
+		for (const [key, asyncNode] of Object.entries(asyncGraph.nodes)) {
+			const { exportRanges: _er, ...fileLevel } = asyncNode as Record<
+				string,
+				unknown
+			>;
+			fileLevelNodes[key] = fileLevel;
+		}
+		expect(fileLevelNodes).toEqual(sync.nodes);
+
+		// Edge projection: usedSymbols is computed differently by sync vs async
+		// usage scanners (sync uses regex computeUsedSymbols; async uses tree-sitter
+		// `facts.refs`). Exclude it from the structural comparison; all other edge
+		// fields (source, target, importSpecifier, importType, importedSymbols) must match.
+		// Order-sensitive: async edge ordering must match sync.
+		const fileLevelEdges = asyncGraph.edges.map((e) => {
+			const { usedSymbols: _us, ...rest } = e as Record<string, unknown>;
+			return rest as typeof e;
+		});
+		const syncEdgesProjected = sync.edges.map((e) => {
+			const { usedSymbols: _us, ...rest } = e as Record<string, unknown>;
+			return rest as typeof e;
+		});
+		expect(fileLevelEdges).toEqual(syncEdgesProjected);
+
 		expect(asyncGraph.metadata.nodeCount).toBe(sync.metadata.nodeCount);
 		expect(asyncGraph.metadata.edgeCount).toBe(sync.metadata.edgeCount);
 
 		// Sanity: this fixture actually has nodes and edges (guards a vacuous pass).
 		expect(asyncGraph.metadata.nodeCount).toBe(3);
 		expect(asyncGraph.metadata.edgeCount).toBeGreaterThan(0);
+
+		// Async-exclusive contract: sync nodes lack exportRanges; async nodes have them.
+		for (const node of Object.values(sync.nodes)) {
+			expect((node as Record<string, unknown>).exportRanges).toBeUndefined();
+		}
+		const anyAsyncHasExportRanges = Object.values(asyncGraph.nodes).some(
+			(n) => (n as Record<string, unknown>).exportRanges !== undefined,
+		);
+		expect(anyAsyncHasExportRanges).toBe(true);
+
+		// Async-exclusive contract: sync graph never has symbolEdges (the key is
+		// absent entirely). Async graph may or may not populate it depending on
+		// whether the fixture has cross-file symbol usages; what matters is that
+		// sync never has it while async can (verified separately by the
+		// determinism test which uses a fixture that does produce symbolEdges).
+		expect((sync as Record<string, unknown>).symbolEdges).toBeUndefined();
+		// When async does produce symbolEdges, it must be an array (never undefined
+		// on a graph that has cross-file symbol usages).
+		const asyncSymbolEdges = (asyncGraph as Record<string, unknown>)
+			.symbolEdges;
+		expect(
+			Array.isArray(asyncSymbolEdges) || asyncSymbolEdges === undefined,
+		).toBe(true);
 	});
 
 	test('duplicate edges (same source+target+specifier) dedup to one, distinct sources do not', async () => {
@@ -90,7 +136,18 @@ describe('repo-graph build O(N) equivalence — issue #1144', () => {
 		const sync = buildWorkspaceGraph(workspacePath);
 		const asyncGraph = await buildWorkspaceGraphAsync(workspacePath);
 
-		expect(asyncGraph.edges).toEqual(sync.edges);
+		// Uniform parity contract: strip usedSymbols from both sync+async edges
+		// before the deep-equal (sync uses regex, async uses tree-sitter facts.refs;
+		// the structural edge fields must match regardless of scanner divergence).
+		const asyncEdgesProjected = asyncGraph.edges.map((e) => {
+			const { usedSymbols: _us, ...rest } = e as Record<string, unknown>;
+			return rest as typeof e;
+		});
+		const syncEdgesProjected = sync.edges.map((e) => {
+			const { usedSymbols: _us, ...rest } = e as Record<string, unknown>;
+			return rest as typeof e;
+		});
+		expect(asyncEdgesProjected).toEqual(syncEdgesProjected);
 
 		// a->c appears exactly once despite two import statements; b->c is separate.
 		const aToC = asyncGraph.edges.filter(
@@ -114,10 +171,31 @@ describe('repo-graph build O(N) equivalence — issue #1144', () => {
 		const sync = buildWorkspaceGraph(workspacePath);
 		const asyncGraph = await buildWorkspaceGraphAsync(workspacePath);
 
-		// Behavior-preserving across the space boundary.
-		expect(asyncGraph.nodes).toEqual(sync.nodes);
-		expect(asyncGraph.edges).toEqual(sync.edges);
+		// File-level parity: strip async-exclusive exportRanges before comparing nodes.
+		const fileLevelNodes = <Record<string, object>>{};
+		for (const [key, asyncNode] of Object.entries(asyncGraph.nodes)) {
+			const { exportRanges: _er, ...fileLevel } = asyncNode as Record<
+				string,
+				unknown
+			>;
+			fileLevelNodes[key] = fileLevel;
+		}
+		expect(fileLevelNodes).toEqual(sync.nodes);
 
+		// Edge projection: strip usedSymbols (sync/async scanner divergence);
+		// all other edge fields (source, target, importSpecifier, importType, importedSymbols)
+		// are compared strictly and order-sensitively.
+		const fileLevelEdges = asyncGraph.edges.map((e) => {
+			const { usedSymbols: _us, ...rest } = e as Record<string, unknown>;
+			return rest as typeof e;
+		});
+		const syncEdgesProjected = sync.edges.map((e) => {
+			const { usedSymbols: _us, ...rest } = e as Record<string, unknown>;
+			return rest as typeof e;
+		});
+		expect(fileLevelEdges).toEqual(syncEdgesProjected);
+
+		// Behavior-preserving across the space boundary.
 		// Both edges from "a file.ts" survive (no collision from the space-bearing
 		// specifier "./b file"): one to "b file.ts", one to "c.ts".
 		const fromA = asyncGraph.edges.filter((e) =>
@@ -126,5 +204,32 @@ describe('repo-graph build O(N) equivalence — issue #1144', () => {
 		expect(fromA.length).toBe(2);
 		const targets = fromA.map((e) => path.basename(e.target)).sort();
 		expect(targets).toEqual(['b file.ts', 'c.ts']);
+	});
+
+	test('async builder symbol fields (exportRanges, symbolEdges) are deterministic across two runs', async () => {
+		await writeFiles({
+			'index.ts': `import { foo } from './foo';\nimport { bar } from './bar';\nexport const idx = 1;`,
+			'foo.ts': `import { bar } from './bar';\nexport const foo = 'foo';`,
+			'bar.ts': `export const bar = 'bar';`,
+		});
+
+		const run1 = await buildWorkspaceGraphAsync(workspacePath);
+		clearCache(workspacePath);
+		const run2 = await buildWorkspaceGraphAsync(workspacePath);
+
+		// Two consecutive async builds must produce identical exportRanges on every node.
+		const keys1 = Object.keys(run1.nodes).sort();
+		const keys2 = Object.keys(run2.nodes).sort();
+		expect(keys1).toEqual(keys2);
+		for (const key of keys1) {
+			const n1 = run1.nodes[key] as Record<string, unknown>;
+			const n2 = run2.nodes[key] as Record<string, unknown>;
+			expect(n1.exportRanges).toEqual(n2.exportRanges);
+		}
+
+		// And identical symbolEdges at the graph level.
+		expect((run1 as Record<string, unknown>).symbolEdges).toEqual(
+			(run2 as Record<string, unknown>).symbolEdges,
+		);
 	});
 });

--- a/tests/unit/tools/repo-graph-call-graph.test.ts
+++ b/tests/unit/tools/repo-graph-call-graph.test.ts
@@ -154,15 +154,154 @@ describe('builder: usedSymbols + exportLines', () => {
 		expect(dead.candidates.map((c) => c.symbol)).not.toContain('go');
 	});
 
-	test('sync and async builders remain identical with the new fields', async () => {
+	test('sync and async builders remain identical on file-level fields; async has exclusive symbol fields', async () => {
 		write('lib.ts', `export const used = 1;\nexport const dead = 2;\n`);
 		write('c.ts', `import { used } from './lib';\nexport const v = used;\n`);
 
 		const sync = buildWorkspaceGraph(workspacePath);
 		clearCache(workspacePath);
 		const asyncGraph = await buildWorkspaceGraphAsync(workspacePath);
-		expect(asyncGraph.nodes).toEqual(sync.nodes);
-		expect(asyncGraph.edges).toEqual(sync.edges);
+
+		// File-level parity: strip async-exclusive exportRanges from each async node
+		// before comparing against sync (sync never produces exportRanges).
+		const fileLevelNodes = <Record<string, object>>{};
+		for (const [key, asyncNode] of Object.entries(asyncGraph.nodes)) {
+			const { exportRanges: _er, ...fileLevel } = asyncNode as Record<
+				string,
+				unknown
+			>;
+			fileLevelNodes[key] = fileLevel;
+		}
+		expect(fileLevelNodes).toEqual(sync.nodes);
+
+		// Uniform parity contract: strip usedSymbols from both sync+async edges
+		// before the deep-equal. usedSymbols is computed differently by sync
+		// (regex) vs async (tree-sitter facts.refs); the structural edge fields
+		// (source, target, importSpecifier, importType, importedSymbols) must
+		// match regardless of scanner divergence.
+		const asyncEdgesProjected = asyncGraph.edges.map((e) => {
+			const { usedSymbols: _us, ...rest } = e as Record<string, unknown>;
+			return rest as typeof e;
+		});
+		const syncEdgesProjected = sync.edges.map((e) => {
+			const { usedSymbols: _us, ...rest } = e as Record<string, unknown>;
+			return rest as typeof e;
+		});
+		expect(asyncEdgesProjected).toEqual(syncEdgesProjected);
+
+		// Async-exclusive contract: sync nodes lack exportRanges; async nodes have them.
+		for (const node of Object.values(sync.nodes)) {
+			expect((node as Record<string, unknown>).exportRanges).toBeUndefined();
+		}
+		const anyAsyncHasExportRanges = Object.values(asyncGraph.nodes).some(
+			(n) => (n as Record<string, unknown>).exportRanges !== undefined,
+		);
+		expect(anyAsyncHasExportRanges).toBe(true);
+
+		// Async-exclusive contract: sync graph has no symbolEdges; async graph has them.
+		expect((sync as Record<string, unknown>).symbolEdges).toBeUndefined();
+		expect((asyncGraph as Record<string, unknown>).symbolEdges).toBeDefined();
+
+		// usedSymbols correctness is verified separately (alias/namespace/re-export/default
+		// tests above for sync, and the async builder usedSymbols block below for async);
+		// those assertions are preserved intact.
+	});
+});
+
+describe('async builder usedSymbols (buildWorkspaceGraphAsync)', () => {
+	let tempDir: string;
+	let workspacePath: string;
+
+	beforeEach(() => {
+		tempDir = fsSync.mkdtempSync(
+			path.join(process.cwd(), 'repo-graph-cg-async-'),
+		);
+		workspacePath = path.relative(process.cwd(), tempDir);
+	});
+
+	afterEach(() => {
+		clearCache(workspacePath);
+		resetQueryCache();
+		fsSync.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	function write(rel: string, content: string): void {
+		const full = path.join(tempDir, rel);
+		fsSync.mkdirSync(path.dirname(full), { recursive: true });
+		fsSync.writeFileSync(full, content);
+	}
+
+	test('records only imported symbols actually referenced, alias-aware', async () => {
+		write(
+			'lib.ts',
+			`export function used(x: number) { return x; }\n` +
+				`export function unused() { return 0; }\n` +
+				`export function aliasedSrc() { return 1; }\n`,
+		);
+		write(
+			'consumer.ts',
+			`import { used, unused, aliasedSrc as alias } from './lib';\n` +
+				`export const out = used(1) + alias();\n` +
+				`// 'unused' is imported but never called below\n`,
+		);
+
+		const graph = await buildWorkspaceGraphAsync(workspacePath);
+		const edge = graph.edges.find(
+			(e) => e.source.endsWith('consumer.ts') && e.target.endsWith('lib.ts'),
+		);
+		expect(edge).toBeDefined();
+		// Async path: usedSymbols derived from tree-sitter facts.refs.
+		// Order reflects source occurrence, not declaration order; sort for comparison.
+		expect(edge?.usedSymbols?.sort()).toEqual(['aliasedSrc', 'used']);
+	});
+
+	test('namespace imports yield no usedSymbols (unresolvable)', async () => {
+		write('lib.ts', `export const a = 1;\nexport const b = 2;\n`);
+		write('ns.ts', `import * as L from './lib';\nexport const x = L.a;\n`);
+
+		const graph = await buildWorkspaceGraphAsync(workspacePath);
+		const edge = graph.edges.find((e) => e.source.endsWith('ns.ts'));
+		expect(edge?.importType).toBe('namespace');
+		// Async path: tree-sitter refs cannot resolve namespace member accesses
+		// to individual exported symbols, so usedSymbols is absent/empty.
+		expect(edge?.usedSymbols).toBeUndefined();
+	});
+
+	test('named re-exports: async tree-sitter path does not produce re-export edges (documented divergence)', async () => {
+		write('lib.ts', `export const a = 1;\nexport const b = 2;\n`);
+		write('barrel.ts', `export { a, b } from './lib';\n`);
+
+		const graph = await buildWorkspaceGraphAsync(workspacePath);
+		// The async tree-sitter builder does not emit edges for re-export statements
+		// (`export { a, b } from './lib'`). This is a documented divergence from the
+		// sync regex-based builder which does produce an edge with usedSymbols=['a','b'].
+		// Re-export resolution requires resolving the re-exported symbols through the
+		// source module, which tree-sitter facts do not surface at the edge-construction layer.
+		const reExportEdge = graph.edges.find(
+			(e) => e.source.endsWith('barrel.ts') && e.target.endsWith('lib.ts'),
+		);
+		expect(reExportEdge).toBeUndefined();
+	});
+
+	test('named default exports: edge uses "default" sentinel; async node exports normalize to "default"', async () => {
+		// `export default function go` is referenced cross-file as the default,
+		// not as `go`. The async tree-sitter path normalizes both the edge
+		// usedSymbols and node.exports to 'default' (matching sync behavior).
+		// Previously this was a documented divergence; FIX 2 resolves it.
+		write('d.ts', `export default function go() { return 1; }\n`);
+		write('use-default.ts', `import go from './d';\nexport const r = go();\n`);
+
+		const graph = await buildWorkspaceGraphAsync(workspacePath);
+		const edge = graph.edges.find((e) => e.source.endsWith('use-default.ts'));
+		expect(edge?.importType).toBe('default');
+		expect(edge?.usedSymbols).toEqual(['default']);
+
+		// After FIX 2, async node exports normalize default exports to 'default',
+		// matching the sync builder. The local name 'go' is not used in exports.
+		const dNode = Object.values(graph.nodes).find((n) =>
+			n.filePath.endsWith('d.ts'),
+		);
+		expect(dNode?.exports).toEqual(['default']);
 	});
 });
 

--- a/tests/unit/tools/repo-graph-query.test.ts
+++ b/tests/unit/tools/repo-graph-query.test.ts
@@ -2,14 +2,19 @@ import { beforeEach, describe, expect, test } from 'bun:test';
 import * as path from 'node:path';
 import {
 	buildOntologyPreflightPacket,
+	type ContextPackResult,
+	type ContextPackSpan,
 	type GraphNode,
 	getBlastRadius,
+	getContextPack,
 	getDependencies,
 	getGraphNode,
 	getImporters,
 	getPackageBoundaries,
+	normalizeGraphPath,
 	type RepoGraph,
 	resetQueryCache,
+	type SymbolEdge,
 } from '../../../src/tools/repo-graph';
 
 const root = path.resolve('/repo');
@@ -183,5 +188,358 @@ describe('repo graph query API', () => {
 			}),
 		);
 		expect(getPackageBoundaries(graph)).toEqual([]);
+	});
+});
+
+describe('getContextPack', () => {
+	// Helper: builds a minimal 1.2.0 graph with exportRanges and symbolEdges.
+	// Uses path.posix.join so node keys are always forward-slash absolute paths
+	// regardless of platform, matching the graph's absolute-key convention.
+	function makeContextGraph(
+		nodes: {
+			[filePath: string]: {
+				moduleName: string;
+				exports: string[];
+				exportRanges: Record<string, { startLine: number; endLine: number }>;
+			};
+		},
+		symbolEdges: SymbolEdge[],
+	): RepoGraph {
+		const graphNodes: Record<string, GraphNode> = {};
+		for (const [filePath, info] of Object.entries(nodes)) {
+			// Store with normalized (forward-slash) keys matching the format the
+			// builder uses (normalizeGraphPath) and what getGraphNode's
+			// absoluteKeyForModule produces — ensures lookups work on all platforms.
+			const normPath = normalizeGraphPath(path.join(root, filePath));
+			graphNodes[normPath] = {
+				filePath: normPath,
+				moduleName: info.moduleName,
+				exports: info.exports,
+				exportRanges: info.exportRanges,
+				imports: [],
+				language: 'typescript',
+				mtime: '1',
+				ontology: {
+					roles: ['source_module'],
+					packageBoundary: 'lib',
+					routes: [],
+					dataOperations: [],
+					security: [],
+					conventions: [],
+					findings: [],
+				},
+			};
+		}
+		return {
+			schema_version: '1.2.0',
+			workspaceRoot: root,
+			nodes: graphNodes,
+			edges: [],
+			symbolEdges: symbolEdges.map((e) => ({
+				...e,
+				fromFile: normalizeGraphPath(path.join(root, e.fromFile)),
+				toFile: normalizeGraphPath(path.join(root, e.toFile)),
+			})),
+			metadata: {
+				generatedAt: new Date().toISOString(),
+				generator: 'test',
+				nodeCount: Object.keys(nodes).length,
+				edgeCount: 0,
+			},
+		};
+	}
+
+	test('happy path: target + one neighbor reachable via symbolEdge, both at full depth', () => {
+		// Paths in graph.nodes and returned spans are normalized (forward-slash)
+		// via normalizeGraphPath, matching the builder's storage convention.
+		const aPath = normalizeGraphPath(path.join(root, 'a.ts'));
+		const bPath = normalizeGraphPath(path.join(root, 'b.ts'));
+
+		const graph = makeContextGraph(
+			{
+				// keys are relative module names; makeContextGraph normalizes them
+				['a.ts']: {
+					moduleName: 'a.ts',
+					exports: ['foo'],
+					exportRanges: { foo: { startLine: 1, endLine: 10 } },
+				},
+				['b.ts']: {
+					moduleName: 'b.ts',
+					exports: ['bar'],
+					exportRanges: { bar: { startLine: 11, endLine: 20 } },
+				},
+			},
+			[
+				// b.bar calls a.foo (forward direction from b -> a)
+				{
+					fromFile: 'b.ts',
+					fromSymbol: 'bar',
+					toFile: 'a.ts',
+					toSymbol: 'foo',
+				},
+				// a.foo is called by b.bar (reverse direction from a <- b)
+				{
+					fromFile: 'a.ts',
+					fromSymbol: 'foo',
+					toFile: 'b.ts',
+					toSymbol: 'bar',
+				},
+			],
+		);
+
+		const result = getContextPack(graph, aPath, 'foo', {
+			maxDepth: 2,
+			maxTokens: 4000,
+		});
+
+		expect(result.schemaSupported).toBe(true);
+		expect(result.target).toEqual({ file: aPath, symbol: 'foo' });
+		expect(result.truncated).toBe(false);
+		expect(result.estimatedTokens).toBeGreaterThan(0);
+
+		// Spans are relevance-ordered: target first, then neighbors
+		expect(result.spans).toHaveLength(2);
+		expect(result.spans[0]).toMatchObject({
+			file: aPath,
+			symbol: 'foo',
+			startLine: 1,
+			endLine: 10,
+			mode: 'full',
+		});
+		expect(result.spans[1]).toMatchObject({
+			file: bPath,
+			symbol: 'bar',
+			startLine: 11,
+			endLine: 20,
+			mode: 'full',
+		});
+	});
+
+	test('schema fallback: 1.1.0 graph with no symbolEdges or exportRanges', () => {
+		const aPath = path.posix.join(root, 'a.ts');
+		const graph: RepoGraph = {
+			schema_version: '1.1.0',
+			workspaceRoot: root,
+			nodes: {
+				[aPath]: {
+					filePath: aPath,
+					moduleName: 'a.ts',
+					exports: ['foo'],
+					imports: [],
+					language: 'typescript',
+					mtime: '1',
+					ontology: {
+						roles: ['source_module'],
+						packageBoundary: 'lib',
+						routes: [],
+						dataOperations: [],
+						security: [],
+						conventions: [],
+						findings: [],
+					},
+				},
+			},
+			edges: [],
+			metadata: {
+				generatedAt: new Date().toISOString(),
+				generator: 'test',
+				nodeCount: 1,
+				edgeCount: 0,
+			},
+		};
+
+		const result = getContextPack(graph, aPath, 'foo');
+		expect(result.schemaSupported).toBe(false);
+		expect(result.spans).toEqual([]);
+		expect(result.truncated).toBe(false);
+		expect(result.estimatedTokens).toBe(0);
+		expect(result.note).toBe('rebuild with repo_map action="build"');
+	});
+
+	test('truncation: token budget cuts off peripheral spans but target is always included', () => {
+		const aPath = normalizeGraphPath(path.join(root, 'a.ts'));
+		const bPath = normalizeGraphPath(path.join(root, 'b.ts'));
+		const cPath = normalizeGraphPath(path.join(root, 'c.ts'));
+
+		// Each span is 10 lines = ~120 tokens (full mode, 12 tokens/line).
+		// Target: 120 tokens. Each peripheral: 120 tokens.
+		// maxTokens=250: target (120) fits + b (120) fits = 240. c (120) would exceed 250 → truncated.
+		const graph = makeContextGraph(
+			{
+				['a.ts']: {
+					moduleName: 'a.ts',
+					exports: ['foo'],
+					exportRanges: { foo: { startLine: 1, endLine: 10 } },
+				},
+				['b.ts']: {
+					moduleName: 'b.ts',
+					exports: ['bar'],
+					exportRanges: { bar: { startLine: 11, endLine: 20 } },
+				},
+				['c.ts']: {
+					moduleName: 'c.ts',
+					exports: ['baz'],
+					exportRanges: { baz: { startLine: 21, endLine: 30 } },
+				},
+			},
+			[
+				{
+					fromFile: 'b.ts',
+					fromSymbol: 'bar',
+					toFile: 'a.ts',
+					toSymbol: 'foo',
+				},
+				{
+					fromFile: 'c.ts',
+					fromSymbol: 'baz',
+					toFile: 'a.ts',
+					toSymbol: 'foo',
+				},
+			],
+		);
+
+		const result = getContextPack(graph, aPath, 'foo', {
+			maxDepth: 2,
+			maxTokens: 250,
+		});
+
+		expect(result.schemaSupported).toBe(true);
+		expect(result.truncated).toBe(true);
+		expect(result.spans).toHaveLength(2); // target + b; c is cut off
+		// Target must always be present
+		expect(result.spans[0]).toMatchObject({
+			file: aPath,
+			symbol: 'foo',
+			mode: 'full',
+		});
+		// b is within budget, c is not
+		expect(result.spans[1]).toMatchObject({ file: bPath, symbol: 'bar' });
+		// c should not appear
+		expect(result.spans.find((s) => s.file === cPath)).toBeUndefined();
+	});
+
+	test('maxDepth boundary: periphery symbols at depth==maxDepth get mode=signature, inner get mode=full', () => {
+		const aPath = normalizeGraphPath(path.join(root, 'a.ts'));
+		const bPath = normalizeGraphPath(path.join(root, 'b.ts'));
+		const cPath = normalizeGraphPath(path.join(root, 'c.ts'));
+
+		// b.bar is at depth 1 (full), c.baz is at depth 2 (signature, at maxDepth boundary)
+		const graph = makeContextGraph(
+			{
+				['a.ts']: {
+					moduleName: 'a.ts',
+					exports: ['foo'],
+					exportRanges: { foo: { startLine: 1, endLine: 10 } },
+				},
+				['b.ts']: {
+					moduleName: 'b.ts',
+					exports: ['bar'],
+					exportRanges: { bar: { startLine: 11, endLine: 20 } },
+				},
+				['c.ts']: {
+					moduleName: 'c.ts',
+					exports: ['baz'],
+					exportRanges: { baz: { startLine: 21, endLine: 30 } },
+				},
+			},
+			[
+				{
+					fromFile: 'b.ts',
+					fromSymbol: 'bar',
+					toFile: 'a.ts',
+					toSymbol: 'foo',
+				},
+				{
+					fromFile: 'c.ts',
+					fromSymbol: 'baz',
+					toFile: 'b.ts',
+					toSymbol: 'bar',
+				},
+			],
+		);
+
+		const result = getContextPack(graph, aPath, 'foo', {
+			maxDepth: 2,
+			maxTokens: 4000,
+		});
+
+		expect(result.schemaSupported).toBe(true);
+		expect(result.spans).toHaveLength(3);
+
+		const spanMap: Record<string, ContextPackSpan> = {};
+		for (const s of result.spans) {
+			spanMap[s.symbol] = s;
+		}
+
+		// Target at depth 0: full mode
+		expect(spanMap['foo'].mode).toBe('full');
+		// b.bar at depth 1 (< maxDepth=2): full mode
+		expect(spanMap['bar'].mode).toBe('full');
+		// c.baz at depth 2 (=== maxDepth): signature mode
+		expect(spanMap['baz'].mode).toBe('signature');
+	});
+
+	// Regression: getContextPack must resolve a workspace-relative module path
+	// (e.g. 'src/foo.ts') to the correct graph node — same resolution used by
+	// getGraphNode/getCallers/getImporters.  Previously it passed the raw input
+	// through normalizeGraphPath as the lookup key, which fails when the caller
+	// supplies a relative path but graph.nodes keys are absolute.
+	test('resolves relative module path input to correct node and spans (F-4.1)', () => {
+		const aRel = 'a.ts';
+		const bRel = 'b.ts';
+
+		const graph = makeContextGraph(
+			{
+				[aRel]: {
+					moduleName: 'a.ts',
+					exports: ['foo'],
+					exportRanges: { foo: { startLine: 1, endLine: 10 } },
+				},
+				[bRel]: {
+					moduleName: 'b.ts',
+					exports: ['bar'],
+					exportRanges: { bar: { startLine: 11, endLine: 20 } },
+				},
+			},
+			[
+				{
+					fromFile: 'b.ts',
+					fromSymbol: 'bar',
+					toFile: 'a.ts',
+					toSymbol: 'foo',
+				},
+				{
+					fromFile: 'a.ts',
+					fromSymbol: 'foo',
+					toFile: 'b.ts',
+					toSymbol: 'bar',
+				},
+			],
+		);
+
+		// Pass a relative module path (no root prefix) — same style used by
+		// getCallers/getImporters tests in this file.
+		const result = getContextPack(graph, 'a.ts', 'foo', {
+			maxDepth: 2,
+			maxTokens: 4000,
+		});
+
+		expect(result.schemaSupported).toBe(true);
+		// target.file must be the resolved absolute path (consistent with graph)
+		expect(result.target.file).toBe(
+			normalizeGraphPath(path.join(root, 'a.ts')),
+		);
+		expect(result.target.symbol).toBe('foo');
+		expect(result.spans).toHaveLength(2);
+		expect(result.spans[0]).toMatchObject({
+			file: normalizeGraphPath(path.join(root, 'a.ts')),
+			symbol: 'foo',
+			mode: 'full',
+		});
+		expect(result.spans[1]).toMatchObject({
+			file: normalizeGraphPath(path.join(root, 'b.ts')),
+			symbol: 'bar',
+			mode: 'full',
+		});
 	});
 });

--- a/tests/unit/tools/repo-graph-scan.test.ts
+++ b/tests/unit/tools/repo-graph-scan.test.ts
@@ -379,6 +379,88 @@ def main():
 		expect(pyNode?.language).toBe('python');
 	});
 
+	test('uppercase-extension files produce correct language (regression: case-insensitive extension matching)', async () => {
+		// Regression: .JS, .TS, .PY uppercase extensions must map to the correct language.
+		// Prior code did extname() without .toLowerCase(), so .JS returned 'unknown'.
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'Foo.JS'),
+			`export const foo = 'foo';`,
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'Bar.TS'),
+			`export const bar = 'bar';`,
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'Utils.PY'),
+			`def util(): pass`,
+		);
+
+		const graph = buildWorkspaceGraph(workspacePath);
+
+		// All three files should produce nodes
+		expect(Object.keys(graph.nodes).length).toBe(3);
+
+		const jsNode = Object.values(graph.nodes).find(
+			(n) => n.moduleName === 'Foo.JS',
+		);
+		expect(jsNode?.language).toBe('typescript');
+
+		const tsNode = Object.values(graph.nodes).find(
+			(n) => n.moduleName === 'Bar.TS',
+		);
+		expect(tsNode?.language).toBe('typescript');
+
+		const pyNode = Object.values(graph.nodes).find(
+			(n) => n.moduleName === 'Utils.PY',
+		);
+		expect(pyNode?.language).toBe('python');
+	});
+
+	test('go, rust, and java files produce graph nodes with correct language (12-language expansion)', async () => {
+		// Go file
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'main.go'),
+			`package main
+
+func main() {
+}`,
+		);
+		// Rust file
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'lib.rs'),
+			`pub fn helper() {}
+pub struct Foo;`,
+		);
+		// Java file
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'Main.java'),
+			`public class Main {
+    public static void main(String[] args) {}
+}`,
+		);
+
+		const graph = buildWorkspaceGraph(workspacePath);
+
+		// All three files should produce nodes
+		expect(Object.keys(graph.nodes).length).toBe(3);
+
+		// Verify each language maps to the correct grammarId
+		const goNode = Object.values(graph.nodes).find(
+			(n) => n.moduleName === 'main.go',
+		);
+		expect(goNode?.language).toBe('go');
+
+		const rustNode = Object.values(graph.nodes).find(
+			(n) => n.moduleName === 'lib.rs',
+		);
+		expect(rustNode?.language).toBe('rust');
+
+		const javaNode = Object.values(graph.nodes).find(
+			(n) => n.moduleName === 'Main.java',
+		);
+		expect(javaNode?.language).toBe('java');
+	});
+
 	test('node_modules and other skipped directories are ignored', async () => {
 		// Create node_modules with a .ts file
 		await fsSync.promises.mkdir(path.join(tempDir, 'node_modules', 'fake'), {

--- a/tests/unit/tools/repo-graph.test.ts
+++ b/tests/unit/tools/repo-graph.test.ts
@@ -397,6 +397,159 @@ describe('validateGraphNode', () => {
 			'ontology.findings.code must be lower_snake_case',
 		);
 	});
+
+	// ---- exportRanges additive-validator tests (schema 1.2.0) ----
+
+	test('accepts node with valid exportRanges (1-based inclusive spans)', () => {
+		const node: GraphNode = {
+			filePath: '/abs/path.ts',
+			moduleName: 'src/path.ts',
+			exports: ['foo', 'bar'],
+			imports: [],
+			language: 'ts',
+			mtime: '123',
+			exportRanges: {
+				foo: { startLine: 1, endLine: 5 },
+				bar: { startLine: 10, endLine: 20 },
+			},
+		};
+		expect(() => validateGraphNode(node)).not.toThrow();
+	});
+
+	test('rejects node with exportRanges containing negative startLine', () => {
+		const node: GraphNode = {
+			filePath: '/abs/path.ts',
+			moduleName: 'src/path.ts',
+			exports: ['foo'],
+			imports: [],
+			language: 'ts',
+			mtime: '123',
+			exportRanges: { foo: { startLine: -1, endLine: 5 } },
+		};
+		expect(() => validateGraphNode(node)).toThrow(
+			'exportRanges value must have positive integer startLine and endLine (1-based)',
+		);
+	});
+
+	test('rejects node with exportRanges containing negative endLine', () => {
+		const node: GraphNode = {
+			filePath: '/abs/path.ts',
+			moduleName: 'src/path.ts',
+			exports: ['foo'],
+			imports: [],
+			language: 'ts',
+			mtime: '123',
+			exportRanges: { foo: { startLine: 1, endLine: -5 } },
+		};
+		expect(() => validateGraphNode(node)).toThrow(
+			'exportRanges value must have positive integer startLine and endLine (1-based)',
+		);
+	});
+
+	test('rejects node with exportRanges containing startLine 0 (0 is not a valid 1-based line)', () => {
+		const node: GraphNode = {
+			filePath: '/abs/path.ts',
+			moduleName: 'src/path.ts',
+			exports: ['foo'],
+			imports: [],
+			language: 'ts',
+			mtime: '123',
+			exportRanges: { foo: { startLine: 0, endLine: 5 } },
+		};
+		expect(() => validateGraphNode(node)).toThrow(
+			'exportRanges value must have positive integer startLine and endLine (1-based)',
+		);
+	});
+
+	test('rejects node with exportRanges containing endLine 0 (0 is not a valid 1-based line)', () => {
+		const node: GraphNode = {
+			filePath: '/abs/path.ts',
+			moduleName: 'src/path.ts',
+			exports: ['foo'],
+			imports: [],
+			language: 'ts',
+			mtime: '123',
+			exportRanges: { foo: { startLine: 1, endLine: 0 } },
+		};
+		expect(() => validateGraphNode(node)).toThrow(
+			'exportRanges value must have positive integer startLine and endLine (1-based)',
+		);
+	});
+
+	test('rejects node with exportRanges containing non-integer startLine (e.g. 3.5)', () => {
+		const node: GraphNode = {
+			filePath: '/abs/path.ts',
+			moduleName: 'src/path.ts',
+			exports: ['foo'],
+			imports: [],
+			language: 'ts',
+			mtime: '123',
+			exportRanges: { foo: { startLine: 3.5, endLine: 5 } },
+		};
+		expect(() => validateGraphNode(node)).toThrow(
+			'exportRanges value must have positive integer startLine and endLine (1-based)',
+		);
+	});
+
+	test('rejects node with non-object exportRanges value', () => {
+		const node: GraphNode = {
+			filePath: '/abs/path.ts',
+			moduleName: 'src/path.ts',
+			exports: ['foo'],
+			imports: [],
+			language: 'ts',
+			mtime: '123',
+			// @ts-expect-error — intentionally malformed
+			exportRanges: { foo: 'notobject' },
+		};
+		expect(() => validateGraphNode(node)).toThrow(
+			'exportRanges values must be objects',
+		);
+	});
+
+	test('rejects node with exportRanges key containing control character', () => {
+		const node: GraphNode = {
+			filePath: '/abs/path.ts',
+			moduleName: 'src/path.ts',
+			exports: ['foo'],
+			imports: [],
+			language: 'ts',
+			mtime: '123',
+			// @ts-expect-error — intentionally malformed
+			exportRanges: { 'foo\x00bar': { startLine: 1, endLine: 5 } },
+		};
+		expect(() => validateGraphNode(node)).toThrow(
+			'exportRanges key contains control characters',
+		);
+	});
+
+	test('accepts node without exportRanges (back-compat — older graphs)', () => {
+		const node: GraphNode = {
+			filePath: '/abs/path.ts',
+			moduleName: 'src/path.ts',
+			exports: [],
+			imports: [],
+			language: 'ts',
+			mtime: '123',
+			// exportRanges intentionally absent
+		};
+		expect(() => validateGraphNode(node)).not.toThrow();
+	});
+
+	test('rejects node with inverted exportRanges (startLine > endLine)', () => {
+		const node: GraphNode = {
+			filePath: '/abs/path.ts',
+			moduleName: 'src/path.ts',
+			exports: ['foo'],
+			imports: [],
+			language: 'ts',
+			mtime: '123',
+			exportRanges: { foo: { startLine: 10, endLine: 5 } },
+		};
+		expect(() => validateGraphNode(node)).toThrow(
+			'Invalid node: exportRanges value must have startLine <= endLine',
+		);
+	});
 });
 
 describe('validateGraphEdge', () => {
@@ -1736,5 +1889,313 @@ describe('buildWorkspaceGraph — issue #1448: resilience + directory excludes',
 		// Without the exclude, the directory IS indexed (proves the option is wired).
 		const included = buildWorkspaceGraph(tmp);
 		expect(hasFile(included, 'generated/thing.ts')).toBe(true);
+	});
+});
+
+describe('symbolEdges additive-validator tests (schema 1.2.0)', () => {
+	// Uses the same temp-dir + loadGraph pattern as "structured corruption handling"
+
+	test('loadGraph accepts graph with valid symbolEdges (all 4 string fields)', async () => {
+		const workspaceName = 'symboledges-valid';
+		const tempDir = await fs.promises.mkdtemp(
+			path.join(os.tmpdir(), 'repo-graph-symboledges-'),
+		);
+		const originalCwd = process.cwd();
+		process.chdir(tempDir);
+		clearCache(workspaceName);
+		try {
+			const graphPath = path.join(workspaceName, '.swarm', 'repo-graph.json');
+			await fs.promises.mkdir(path.dirname(graphPath), { recursive: true });
+			const validGraph: RepoGraph = {
+				schema_version: '1.2.0',
+				workspaceRoot: path.resolve(workspaceName),
+				nodes: {
+					'/test/a.ts': {
+						filePath: '/test/a.ts',
+						moduleName: 'a',
+						exports: ['fnA'],
+						imports: [],
+						language: 'ts',
+						mtime: '123',
+					},
+					'/test/b.ts': {
+						filePath: '/test/b.ts',
+						moduleName: 'b',
+						exports: ['fnB'],
+						imports: [],
+						language: 'ts',
+						mtime: '456',
+					},
+				},
+				edges: [],
+				symbolEdges: [
+					{
+						fromFile: '/test/a.ts',
+						fromSymbol: 'fnA',
+						toFile: '/test/b.ts',
+						toSymbol: 'fnB',
+					},
+				],
+				metadata: {
+					generatedAt: new Date().toISOString(),
+					generator: 'test',
+					nodeCount: 2,
+					edgeCount: 0,
+				},
+			};
+			await fs.promises.writeFile(
+				graphPath,
+				JSON.stringify(validGraph),
+				'utf-8',
+			);
+
+			const loaded = await loadGraph(workspaceName);
+			expect(loaded).not.toBeNull();
+			expect(loaded?.symbolEdges).toHaveLength(1);
+			expect(loaded?.symbolEdges?.[0].fromSymbol).toBe('fnA');
+			expect(loaded?.symbolEdges?.[0].toSymbol).toBe('fnB');
+		} finally {
+			process.chdir(originalCwd);
+			clearCache(workspaceName);
+			try {
+				await fs.promises.rm(tempDir, { recursive: true, force: true });
+			} catch {
+				// ignore cleanup errors
+			}
+		}
+	});
+
+	test('loadGraph throws when symbolEdges entry is missing toSymbol', async () => {
+		const workspaceName = 'symboledges-missing';
+		const tempDir = await fs.promises.mkdtemp(
+			path.join(os.tmpdir(), 'repo-graph-symboledges-'),
+		);
+		const originalCwd = process.cwd();
+		process.chdir(tempDir);
+		clearCache(workspaceName);
+		try {
+			const graphPath = path.join(workspaceName, '.swarm', 'repo-graph.json');
+			await fs.promises.mkdir(path.dirname(graphPath), { recursive: true });
+			const badGraph = {
+				schema_version: '1.2.0',
+				workspaceRoot: path.resolve(workspaceName),
+				nodes: {},
+				edges: [],
+				symbolEdges: [
+					{
+						fromFile: '/test/a.ts',
+						fromSymbol: 'fnA',
+						toFile: '/test/b.ts',
+						// toSymbol intentionally missing
+					},
+				],
+				metadata: {
+					generatedAt: new Date().toISOString(),
+					generator: 'test',
+					nodeCount: 0,
+					edgeCount: 0,
+				},
+			};
+			await fs.promises.writeFile(graphPath, JSON.stringify(badGraph), 'utf-8');
+
+			await expect(loadGraph(workspaceName)).rejects.toThrow(
+				'repo-graph.json contains invalid symbolEdges entry',
+			);
+		} finally {
+			process.chdir(originalCwd);
+			clearCache(workspaceName);
+			try {
+				await fs.promises.rm(tempDir, { recursive: true, force: true });
+			} catch {
+				// ignore cleanup errors
+			}
+		}
+	});
+
+	test('loadGraph throws when symbolEdges is not an array', async () => {
+		const workspaceName = 'symboledges-notarray';
+		const tempDir = await fs.promises.mkdtemp(
+			path.join(os.tmpdir(), 'repo-graph-symboledges-'),
+		);
+		const originalCwd = process.cwd();
+		process.chdir(tempDir);
+		clearCache(workspaceName);
+		try {
+			const graphPath = path.join(workspaceName, '.swarm', 'repo-graph.json');
+			await fs.promises.mkdir(path.dirname(graphPath), { recursive: true });
+			const badGraph = {
+				schema_version: '1.2.0',
+				workspaceRoot: path.resolve(workspaceName),
+				nodes: {},
+				edges: [],
+				symbolEdges: 'not-an-array',
+				metadata: {
+					generatedAt: new Date().toISOString(),
+					generator: 'test',
+					nodeCount: 0,
+					edgeCount: 0,
+				},
+			};
+			await fs.promises.writeFile(graphPath, JSON.stringify(badGraph), 'utf-8');
+
+			await expect(loadGraph(workspaceName)).rejects.toThrow(
+				'repo-graph.json symbolEdges must be an array',
+			);
+		} finally {
+			process.chdir(originalCwd);
+			clearCache(workspaceName);
+			try {
+				await fs.promises.rm(tempDir, { recursive: true, force: true });
+			} catch {
+				// ignore cleanup errors
+			}
+		}
+	});
+
+	test('loadGraph throws when symbolEdges entry contains path traversal in fromFile', async () => {
+		const workspaceName = 'symboledges-traversal';
+		const tempDir = await fs.promises.mkdtemp(
+			path.join(os.tmpdir(), 'repo-graph-symboledges-'),
+		);
+		const originalCwd = process.cwd();
+		process.chdir(tempDir);
+		clearCache(workspaceName);
+		try {
+			const graphPath = path.join(workspaceName, '.swarm', 'repo-graph.json');
+			await fs.promises.mkdir(path.dirname(graphPath), { recursive: true });
+			const badGraph = {
+				schema_version: '1.2.0',
+				workspaceRoot: path.resolve(workspaceName),
+				nodes: {},
+				edges: [],
+				symbolEdges: [
+					{
+						fromFile: '../../etc/passwd',
+						fromSymbol: 'fnA',
+						toFile: '/test/b.ts',
+						toSymbol: 'fnB',
+					},
+				],
+				metadata: {
+					generatedAt: new Date().toISOString(),
+					generator: 'test',
+					nodeCount: 0,
+					edgeCount: 0,
+				},
+			};
+			await fs.promises.writeFile(graphPath, JSON.stringify(badGraph), 'utf-8');
+
+			await expect(loadGraph(workspaceName)).rejects.toThrow(
+				'repo-graph.json contains invalid symbolEdges entry',
+			);
+		} finally {
+			process.chdir(originalCwd);
+			clearCache(workspaceName);
+			try {
+				await fs.promises.rm(tempDir, { recursive: true, force: true });
+			} catch {
+				// ignore cleanup errors
+			}
+		}
+	});
+
+	test('loadGraph accepts graph without symbolEdges (back-compat — older graphs)', async () => {
+		const workspaceName = 'symboledges-absent';
+		const tempDir = await fs.promises.mkdtemp(
+			path.join(os.tmpdir(), 'repo-graph-symboledges-'),
+		);
+		const originalCwd = process.cwd();
+		process.chdir(tempDir);
+		clearCache(workspaceName);
+		try {
+			const graphPath = path.join(workspaceName, '.swarm', 'repo-graph.json');
+			await fs.promises.mkdir(path.dirname(graphPath), { recursive: true });
+			// 1.0.0 graph — no symbolEdges field at all
+			const compatGraph: RepoGraph = {
+				schema_version: '1.0.0',
+				workspaceRoot: path.resolve(workspaceName),
+				nodes: {},
+				edges: [],
+				metadata: {
+					generatedAt: new Date().toISOString(),
+					generator: 'test',
+					nodeCount: 0,
+					edgeCount: 0,
+				},
+			};
+			await fs.promises.writeFile(
+				graphPath,
+				JSON.stringify(compatGraph),
+				'utf-8',
+			);
+
+			const loaded = await loadGraph(workspaceName);
+			expect(loaded).not.toBeNull();
+			expect(loaded?.schema_version).toBe('1.0.0');
+			expect(loaded?.symbolEdges).toBeUndefined();
+		} finally {
+			process.chdir(originalCwd);
+			clearCache(workspaceName);
+			try {
+				await fs.promises.rm(tempDir, { recursive: true, force: true });
+			} catch {
+				// ignore cleanup errors
+			}
+		}
+	});
+
+	test('loadGraphSync accepts graph with valid symbolEdges', () => {
+		const workspaceName = 'symboledges-sync-valid';
+		const tempDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), 'repo-graph-symboledges-sync-'),
+		);
+		const originalCwd = process.cwd();
+		process.chdir(tempDir);
+		clearCache(workspaceName);
+		try {
+			const graphPath = path.join(workspaceName, '.swarm', 'repo-graph.json');
+			fs.mkdirSync(path.dirname(graphPath), { recursive: true });
+			const validGraph: RepoGraph = {
+				schema_version: '1.2.0',
+				workspaceRoot: path.resolve(workspaceName),
+				nodes: {
+					'/test/x.ts': {
+						filePath: '/test/x.ts',
+						moduleName: 'x',
+						exports: ['fnX'],
+						imports: [],
+						language: 'ts',
+						mtime: '123',
+					},
+				},
+				edges: [],
+				symbolEdges: [
+					{
+						fromFile: '/test/x.ts',
+						fromSymbol: 'fnX',
+						toFile: '/test/x.ts',
+						toSymbol: 'fnX',
+					},
+				],
+				metadata: {
+					generatedAt: new Date().toISOString(),
+					generator: 'test',
+					nodeCount: 1,
+					edgeCount: 0,
+				},
+			};
+			fs.writeFileSync(graphPath, JSON.stringify(validGraph), 'utf-8');
+
+			const loaded = loadGraphSync(workspaceName);
+			expect(loaded?.symbolEdges).toHaveLength(1);
+		} finally {
+			process.chdir(originalCwd);
+			clearCache(workspaceName);
+			try {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			} catch {
+				// ignore cleanup errors
+			}
+		}
 	});
 });

--- a/tests/unit/tools/repo-map.test.ts
+++ b/tests/unit/tools/repo-map.test.ts
@@ -426,3 +426,116 @@ describe('repo_map: callers / dead_exports', () => {
 		expect(symbols).not.toContain('add');
 	});
 });
+
+describe('repo_map: context_pack', () => {
+	it('happy path: returns spans for a symbol with callers (1.2.0 graph)', async () => {
+		// Build creates a 1.2.0 graph with exportRanges + symbolEdges.
+		await call({ action: 'build' });
+		const out = await call({
+			action: 'context_pack',
+			file: 'src/util.ts',
+			symbol: 'add',
+		});
+		const r = JSON.parse(out) as {
+			success: boolean;
+			schemaSupported: boolean;
+			spans: Array<{ file: string }>;
+			estimatedTokens: number;
+			target: { file: string; symbol: string };
+		};
+		expect(r.success).toBe(true);
+		expect(r.schemaSupported).toBe(true);
+		expect(r.spans.length).toBeGreaterThan(0);
+		expect(r.estimatedTokens).toBeGreaterThan(0);
+		// Target file should be workspace-relative.
+		expect(r.target.file).toBe('src/util.ts');
+		// Spans should have workspace-relative paths (no leading slash on POSIX, no drive letter on Windows).
+		for (const span of r.spans) {
+			expect(span.file).not.toMatch(/^[A-Z]:|^\//);
+		}
+	});
+
+	it('missing file: rejects context_pack without file', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'context_pack', symbol: 'add' });
+		const r = JSON.parse(out) as { success: boolean; error: string };
+		expect(r.success).toBe(false);
+		expect(r.error).toBe('context_pack requires `file`');
+	});
+
+	it('missing symbol: rejects context_pack without symbol', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'context_pack', file: 'src/util.ts' });
+		const r = JSON.parse(out) as { success: boolean; error: string };
+		expect(r.success).toBe(false);
+		expect(r.error).toBe('context_pack requires `symbol` (the exported name)');
+	});
+
+	it('unknown action: rejects bogus action', async () => {
+		const out = await call({ action: 'bogus' });
+		const r = JSON.parse(out) as { success: boolean; error: string };
+		expect(r.success).toBe(false);
+		expect(r.error).toContain('unknown action');
+	});
+
+	it('schema fallback: returns empty spans on a 1.1.0 graph', async () => {
+		// Build a proper 1.2.0 graph first.
+		await call({ action: 'build' });
+
+		// Overwrite with a synthetic 1.1.0 graph (no symbolEdges, no exportRanges).
+		// loadGraph uses mtime to detect external changes and will re-read the file.
+		const graphPath = path.join(tmp, '.swarm', 'repo-graph.json');
+		const graph = JSON.parse(fs.readFileSync(graphPath, 'utf-8')) as {
+			schema_version: string;
+			symbolEdges?: unknown[];
+			nodes: Record<string, { exportRanges?: unknown }>;
+		};
+		graph.schema_version = '1.1.0';
+		delete graph.symbolEdges;
+		for (const node of Object.values(graph.nodes)) {
+			delete node.exportRanges;
+		}
+		// Touch the file to update mtime so loadGraph re-reads it.
+		fs.writeFileSync(graphPath, JSON.stringify(graph), 'utf-8');
+
+		const out = await call({
+			action: 'context_pack',
+			file: 'src/util.ts',
+			symbol: 'add',
+		});
+		const r = JSON.parse(out) as {
+			success: boolean;
+			schemaSupported: boolean;
+			spans: unknown[];
+			note?: string;
+		};
+		expect(r.success).toBe(true);
+		expect(r.schemaSupported).toBe(false);
+		expect(r.spans).toEqual([]);
+		expect(r.note).toBe('rebuild with repo_map action="build"');
+	});
+});
+
+describe('repo_map: context_pack target-not-found', () => {
+	it('returns empty spans with note when file is not in 1.2.0 graph', async () => {
+		// Build a proper 1.2.0 graph.
+		await call({ action: 'build' });
+
+		// Call context_pack with a file that does NOT exist in the graph.
+		const out = await call({
+			action: 'context_pack',
+			file: 'src/does-not-exist.ts',
+			symbol: 'NonExistent',
+		});
+		const r = JSON.parse(out) as {
+			success: boolean;
+			schemaSupported: boolean;
+			spans: unknown[];
+			note?: string;
+		};
+		expect(r.success).toBe(true);
+		expect(r.schemaSupported).toBe(true);
+		expect(r.spans).toEqual([]);
+		expect(r.note).toBe('Target file not found in graph');
+	});
+});


### PR DESCRIPTION
Closes #1471

## Summary
- Re-platformed repo-graph symbol/import extraction from regex onto tree-sitter (`src/lang/symbol-graph.ts`), covering all 12 first-class profile languages (TS/JS/Python/Rust/Go/Java/Kotlin/C#/C++/Swift/Dart/Ruby/PHP)
- Added symbol-to-symbol call graph (`symbolEdges`), per-symbol source ranges (`exportRanges`), and a `context_pack` `repo_map` action returning a token-budgeted source-context slice (definition + callers/callees)
- Schema 1.2.0 — additive/backward-compatible (1.0.0/1.1.0 graphs still load); sync builder keeps file-level contract; async builder populates symbol data
- Lazy-loaded tree-sitter off the init path (`repro-704` T1=148ms); invariant-1 regression fixed (web-tree-sitter was statically imported via 3 chains)
- Incremental updates use the async scan path with full symbolEdge lifecycle (prune on edit/delete + orphan cleanup)
- `#1144` sync/async parity redefined: file-level fields agree; symbol fields async-exclusive + deterministic
- CommonJS `require()` imports handled for TS/JS
- 200+ tests (symbol-graph 39, repo-graph 160+, repo-map 31, query 11, incremental 11, call-graph 24, scan 36, init-purity 9)
- Release fragment + design doc committed; AC-17 (`package:smoke`) passes (697 files, grammar assets)

## Invariant audit
- 1 (plugin init): touched - lazy-loaded tree-sitter via dynamic `import('web-tree-sitter')` + `import('./runtime.js')`; `--external web-tree-sitter` build flag; repro-704 T1=148ms (all 3 OK); 9 init-purity proof tests pass
- 2 (runtime portability): touched - `--external web-tree-sitter` prevents inline WASM bundling; no `bun:`/`Bun.*`/spawn in new code; `dist/index.js` Node-ESM-loadable (`node --input-type=module` import OK)
- 3 (subprocesses): not touched - tree-sitter parses in-process; no spawn in symbol-graph.ts
- 4 (.swarm containment): not touched - graph persists to `.swarm/repo-graph.json`
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched - used `bun test` per-file, not `test_runner` broad scope
- 7 (test writing): touched - new `bun:test` suites; `_internals` DI seam; no `mock.module` (AGENTS.md invariant 7)
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): touched (action only) - `context_pack` is internal to `repo_map`; no new `TOOL_NAMES`/agent-map; 5 `repo-map.ts` surfaces wired + tested
- 12 (release/cache): touched - release fragment `docs/releases/pending/1471-repo-graph-symbol-graph.md`; `package:smoke` passes (697 files, grammar assets valid)

## Test plan
- [x] `bun run build` passes (tsc --emitDeclarationOnly + bun build + grammar copy)
- [x] `node scripts/repro-704.mjs` — T1=148ms, T2=76ms, T3=90ms (all under deadlines)
- [x] `node --input-type=module -e "await import('./dist/index.js')"` — dist import OK
- [x] `bun run typecheck` passes
- [x] `bunx biome ci .` passes (0 errors, 1 pre-existing warning in src/git/pr.ts)
- [x] `bun --smol test tests/unit/lang/symbol-graph.test.ts` — 39 pass
- [x] `bun --smol test tests/unit/lang/symbol-graph-init-purity.test.ts` — 9 pass
- [x] `bun --smol test tests/unit/tools/repo-graph*.test.ts` — 160+ pass
- [x] `bun --smol test tests/unit/tools/repo-map.test.ts` — 31 pass
- [x] `bun --smol test tests/unit/tools/repo-graph-query.test.ts` — 11 pass
- [x] `bun run package:smoke` — 697 files in tarball, grammar assets present

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

