### PR TITLE
fix(tools): rename swarm patch tool to restore native apply_patch

### DIFF
--- a/docs/releases/pending/1303-test-engineer-write-scope.md
+++ b/docs/releases/pending/1303-test-engineer-write-scope.md
@@ -3,10 +3,11 @@
 The `test_engineer` agent was unable to write test files and would fall into
 retry loops. Three root causes were fixed:
 
-1. **`apply_patch` added to test_engineer's tool map** — `apply_patch` (the
-   plugin's unified-diff write tool) was only registered for `coder`. Adding it
-   to `test_engineer` allows the agent to create and modify test files using the
-   same write mechanism that `coder` uses.
+1. **`swarm_apply_patch` added to test_engineer's tool map** — the plugin-owned
+   unified-diff write tool was renamed from `apply_patch` to
+   `swarm_apply_patch` and was only registered for `coder`. Adding
+   `swarm_apply_patch` to `test_engineer` allows the agent to create and modify
+   test files using the same write mechanism that `coder` uses.
 
 2. **Architect prompt updated with `declare_scope` guidance for test_engineer** —
    Rule 1a and new Rule 3b now instruct the architect to call `declare_scope`

--- a/docs/releases/pending/add-researcher-agent.md
+++ b/docs/releases/pending/add-researcher-agent.md
@@ -16,8 +16,8 @@
 - **Tool access**: the `researcher` agent is granted `web_search`,
   `swarm_command`, `summarize_work`, `symbols`, `imports`,
   `complexity_hotspots`, `schema_drift`, and `todo_extract`. All write tools
-  are disabled: `write`, `edit`, `patch`, `apply_patch`, `create_file`,
-  `insert`, `replace`, `append`, `prepend`.
+  are disabled: `write`, `edit`, `patch`, `apply_patch`, `swarm_apply_patch`,
+  `create_file`, `insert`, `replace`, `append`, `prepend`.
 
 - **Structured output contract**: the agent always emits CONFIDENCE, SUMMARY,
   FINDINGS (with per-finding confidence and source URLs), CONTRADICTIONS,

--- a/docs/releases/pending/native-apply-patch-tool.md
+++ b/docs/releases/pending/native-apply-patch-tool.md
@@ -2,10 +2,11 @@
 
 ## What changed
 
-- Added a native `apply_patch` Swarm tool that parses and applies unified diffs in-process under Swarm's safety model
+- Added a native OpenCode `apply_patch` tool for `*** Begin Patch` / `*** Update File` edits
+- Renamed the Swarm unified-diff patch tool from `apply_patch` to `swarm_apply_patch`
 - Extended `scope-guard` to extract paths from array-based tool arguments (`files[]`, `paths[]`, `targetFiles[]`)
 
-The `apply_patch` tool replaces shell-based `git apply` calls for swarm agents with a pure TypeScript implementation that:
+The `swarm_apply_patch` tool replaces shell-based `git apply` calls for swarm agents with a pure TypeScript implementation that:
 - Parses unified diffs (`---`/`+++` headers, `@@` hunk headers, context/addition/removal lines)
 - Rejects binary, rename, and copy patches
 - Enforces workspace boundaries with canonical symlink protection (`realpathSync`)
@@ -20,11 +21,15 @@ The scope-guard enhancement prevents scope bypass via multi-file tool calls by e
 
 ## Why
 
-Issue #1103: Swarm agents needed a safe, in-process patch application tool that works under Swarm's safety model without shell access or external binaries. The scope-guard had a first-match-wins gap where array-based path arguments (like `apply_patch`'s `files[]`) could bypass scope enforcement.
+Issue #1103: Swarm agents needed a safe, in-process patch application tool that works under Swarm's safety model without shell access or external binaries. The scope-guard had a first-match-wins gap where array-based path arguments (like `swarm_apply_patch`'s `files[]`) could bypass scope enforcement.
 
 ## Migration
 
-No migration required. The tool is automatically available to `coder` agents via the manifest registration. Existing tools and agents are unaffected.
+Update any Swarm-specific unified-diff tool references from `apply_patch` to `swarm_apply_patch`.
+
+- Use `swarm_apply_patch` for standard unified diffs with `---` / `+++` headers and `@@` hunks.
+- Use the native OpenCode `apply_patch` tool for `*** Begin Patch` / `*** Update File` edit payloads.
+- Existing behavior is otherwise unchanged; the rename only disambiguates the two patch tools.
 
 ## Known caveats
 

--- a/docs/releases/pending/patch-ux-native-apply-patch.md
+++ b/docs/releases/pending/patch-ux-native-apply-patch.md
@@ -1,0 +1,52 @@
+# Native apply_patch UX Restoration and swarm_apply_patch Rename
+
+## Summary
+
+The Swarm plugin no longer registers a plugin tool named `apply_patch`. This
+restores the native opencode `apply_patch` tool to full visibility for all
+agents — it was previously shadowed by the Swarm plugin's own unified-diff
+handler, which caused the native tool's `*** Begin Patch / *** Update File`
+format to be silently rejected.
+
+## Changes
+
+### `swarm_apply_patch` (renamed from `apply_patch`)
+
+The Swarm unified-diff patch writer is now registered as **`swarm_apply_patch`**
+instead of `apply_patch`. Its behavior is unchanged: it accepts standard unified
+diffs (`--- a/file / +++ b/file / @@ hunks`), validates paths against workspace
+boundaries, matches hunk context exactly, and writes atomically.
+
+Agents (`coder`, `test_engineer`) that previously used `apply_patch` for
+unified-diff patches should now use `swarm_apply_patch`.
+
+### Native `apply_patch` restored
+
+The native opencode `apply_patch` tool is now available without interference.
+It handles `*** Begin Patch / *** Update File` style payloads produced by
+opencode's built-in patch writer. It remains classified as a write-capable tool
+in Swarm's guardrails (`WRITE_TOOL_NAMES`) so scope-guard and authority checks
+continue to apply.
+
+### Hard-fail on unsupported format
+
+`swarm_apply_patch` now hard-fails with a clear error message when it receives
+a `*** Begin Patch / *** Update File` style payload instead of silently
+returning a no-op success. This prevents silent data loss when the wrong tool
+is called with the wrong format.
+
+### Guardrail preservation
+
+- `apply_patch`, `swarm_apply_patch`, and `patch` are all covered by the
+  scope-guard, authority checks, symlink/junction checks, universal-deny
+  prefixes, and plan-state protection guardrails.
+- `WRITE_TOOL_NAMES` now includes both `apply_patch` and `swarm_apply_patch`.
+- Path extraction from patch payloads (`extractPatchTargetPaths`) handles all
+  three tool names and also reads the `files[]` argument for `swarm_apply_patch`.
+
+## Migration
+
+| Before | After |
+|--------|-------|
+| `apply_patch` (Swarm unified-diff tool) | `swarm_apply_patch` |
+| `apply_patch` (native opencode tool) | `apply_patch` (restored, no longer shadowed) |

--- a/docs/releases/pending/tool-improvements-batch.md
+++ b/docs/releases/pending/tool-improvements-batch.md
@@ -3,7 +3,7 @@
 ## What changed
 
 - **New `git_blame` tool** — per-line git blame metadata via `git blame --porcelain`; returns sha (abbreviated), author, date (ISO), summary, and content for each line; supports optional `start`/`end` line range filtering; rejects binary files and validates paths
-- **`suggest_patch`** — added `format` parameter (`'json'`|`'unified'`); unified mode outputs valid unified diff with `diff --git` headers, hunks, and context lines for `apply_patch` parser compatibility
+- **`suggest_patch`** — added `format` parameter (`'json'`|`'unified'`); unified mode outputs valid unified diff with `diff --git` headers, hunks, and context lines for `swarm_apply_patch` parser compatibility
 - **`test_runner`** — added `bail` parameter (boolean, default false); injects framework-specific bail flags for early exit on first test failure
 - **`symbols`** — added `workspace` (boolean) and `name` (string) parameters for multi-file symbol search across the workspace
 - **`diff`** — added `summaryOnly` parameter; returns file list with additions/deletions counts without full diff content

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -148,7 +148,7 @@ Output to .swarm/plan.md MUST use "## Phase N" headers. Do not write MODE labels
 1. DELEGATE all coding to {{AGENT_PREFIX}}coder. You do NOT write code.
 // IMPORTANT: This list is auto-generated from AGENT_TOOL_MAP['architect'] in src/config/constants.ts
 YOUR TOOLS: {{YOUR_TOOLS}}
-CODER'S TOOLS: write, edit, patch, apply_patch, create_file, insert, replace — any tool that modifies file contents.
+CODER'S TOOLS: write, edit, patch, apply_patch, swarm_apply_patch, create_file, insert, replace — any tool that modifies file contents.
 If a tool modifies a file, it is a CODER tool. Delegate.
 <!-- BEHAVIORAL_GUIDANCE_START -->
 1a. SCOPE DISCIPLINE — call declare_scope BEFORE every coder delegation AND before any test_engineer delegation that will write new test files.
@@ -190,7 +190,7 @@ Two small delegations with two QA gates > one large delegation with one QA gate.
       ✗ "I already know what to write" → knowing what to write is planning, not writing. Delegate to {{AGENT_PREFIX}}coder.
       ✗ "It's faster if I just do it" → speed without QA gates is how bugs ship
       ✗ "The coder succeeded on the last tasks, this one is trivial" → Rule 1 has no complexity exemption
-      ✗ "I'll just use apply_patch / edit / write directly" → these are coder tools, not architect tools
+      ✗ "I'll just use apply_patch / swarm_apply_patch / edit / write directly" → these are coder tools, not architect tools
       ✗ "I'll do the simple parts, coder does the hard parts" → ALL parts go to coder. You are not a coder.
       ✗ "This is time-critical / urgent / blocking" → WRONG. You are an AI with no deadlines. No urgency is real. Delegate to {{AGENT_PREFIX}}coder.
       ✗ "The fix is obvious — explaining it takes more effort than doing it" → WRONG. Writing the task spec IS your job. Delegate the implementation.

--- a/src/agents/researcher.ts
+++ b/src/agents/researcher.ts
@@ -146,6 +146,7 @@ export function createResearcherAgent(
 				edit: false,
 				patch: false,
 				apply_patch: false,
+				swarm_apply_patch: false,
 				create_file: false,
 				insert: false,
 				replace: false,

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -308,6 +308,7 @@ export const WRITE_TOOL_NAMES = [
 	'edit',
 	'patch',
 	'apply_patch',
+	'swarm_apply_patch',
 	'create_file',
 	'insert',
 	'replace',

--- a/src/hooks/co-change-suggester.ts
+++ b/src/hooks/co-change-suggester.ts
@@ -141,9 +141,14 @@ export function createCoChangeSuggesterHook(
 
 		// Only fire on file-write tools
 		if (
-			!['write', 'edit', 'apply_patch', 'patch', 'create_file'].includes(
-				toolName,
-			)
+			![
+				'write',
+				'edit',
+				'apply_patch',
+				'swarm_apply_patch',
+				'patch',
+				'create_file',
+			].includes(toolName)
 		) {
 			return;
 		}

--- a/src/hooks/context-budget.ts
+++ b/src/hooks/context-budget.ts
@@ -407,7 +407,7 @@ function extractMessageText(msg: MessageWithParts): string {
 function extractToolName(text: string): string | undefined {
 	// Try to extract tool name from common patterns
 	const match = text.match(
-		/^(read_file|write|edit|apply_patch|task|bun|npm|git|bash|glob|grep|mkdir|cp|mv|rm)\b/i,
+		/^(read_file|write|edit|apply_patch|swarm_apply_patch|task|bun|npm|git|bash|glob|grep|mkdir|cp|mv|rm)\b/i,
 	);
 	return match?.[1];
 }

--- a/src/hooks/guardrails/tool-before.ts
+++ b/src/hooks/guardrails/tool-before.ts
@@ -1191,7 +1191,11 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 					}
 				}
 			}
-			if (tool === 'apply_patch' || tool === 'patch') {
+			if (
+				tool === 'apply_patch' ||
+				tool === 'swarm_apply_patch' ||
+				tool === 'patch'
+			) {
 				const agentName = swarmState.activeAgent.get(sessionID) ?? 'unknown';
 				const cwd = effectiveDirectory;
 				for (const p of extractPatchTargetPaths(tool, args)) {
@@ -1427,24 +1431,43 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 	}
 
 	/**
-	 * Extracts target file paths from apply_patch / patch tool arguments.
+	 * Extracts target file paths from apply_patch / swarm_apply_patch / patch tool arguments.
+	 * For native apply_patch (no files[] arg), extracts paths from the patch text itself.
+	 * For swarm_apply_patch, the files[] arg is required and is the primary source.
 	 */
 	function extractPatchTargetPaths(tool: string, args: unknown): string[] {
-		if (tool !== 'apply_patch' && tool !== 'patch') return [];
+		if (
+			tool !== 'apply_patch' &&
+			tool !== 'swarm_apply_patch' &&
+			tool !== 'patch'
+		)
+			return [];
 		const toolArgs = args as Record<string, unknown> | undefined;
+
+		// For swarm_apply_patch, the files[] arg is the declared scope — include it
+		// as the primary source of target paths (it is required by the tool schema).
+		// For native apply_patch, files[] may not be present; fall back to patch text.
+		const paths = new Set<string>();
+		if (Array.isArray(toolArgs?.files)) {
+			for (const f of toolArgs.files as unknown[]) {
+				if (typeof f === 'string' && f.length > 0 && f !== '/dev/null') {
+					paths.add(f);
+				}
+			}
+		}
+
 		const patchText = (toolArgs?.input ??
 			toolArgs?.patch ??
 			toolArgs?.diff ??
 			(Array.isArray(toolArgs?.cmd) ? toolArgs.cmd[1] : undefined)) as
 			| string
 			| undefined;
-		if (typeof patchText !== 'string') return [];
+		if (typeof patchText !== 'string') return Array.from(paths);
 		if (patchText.length > 1_000_000) {
 			throw new Error(
 				'WRITE BLOCKED: Patch payload exceeds 1 MB — authority cannot be verified for all modified paths. Split into smaller patches.',
 			);
 		}
-		const paths = new Set<string>();
 		const patchPathPattern = /\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)/gi;
 		const diffPathPattern = /\+\+\+\s+b\/(.+)/gm;
 		const gitDiffPathPattern = /^diff --git a\/(.+?) b\/(.+?)$/gm;
@@ -1495,10 +1518,14 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			toolArgs?.file ??
 			toolArgs?.target;
 
-		if (tool === 'apply_patch' || tool === 'patch') {
+		if (
+			tool === 'apply_patch' ||
+			tool === 'swarm_apply_patch' ||
+			tool === 'patch'
+		) {
 			if (patchPayloadHasHumanOnlyInvocation(args)) {
 				throw new Error(
-					'BLOCKED: apply_patch would introduce a script invoking a human-only swarm CLI subcommand. ' +
+					'BLOCKED: apply_patch/swarm_apply_patch would introduce a script invoking a human-only swarm CLI subcommand. ' +
 						'Present the situation to the user and ask them to run the command themselves.',
 				);
 			}
@@ -1552,7 +1579,12 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			}
 		}
 
-		if (!targetPath && (tool === 'apply_patch' || tool === 'patch')) {
+		if (
+			!targetPath &&
+			(tool === 'apply_patch' ||
+				tool === 'swarm_apply_patch' ||
+				tool === 'patch')
+		) {
 			for (const p of extractPatchTargetPaths(tool, args)) {
 				const resolvedP = path.resolve(effectiveDirectory, p);
 				const planMdPath = path
@@ -1590,7 +1622,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 					const session = swarmState.agentSessions.get(sessionID);
 					if (session) {
 						session.architectWriteCount++;
-						warn('Architect direct code edit detected via apply_patch', {
+						warn('Architect direct code edit detected via patch tool', {
 							tool,
 							sessionID,
 							targetPath: p,
@@ -2108,8 +2140,12 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			}
 		}
 
-		// Authority + lstat + universal-deny for apply_patch / patch
-		if (input.tool === 'apply_patch' || input.tool === 'patch') {
+		// Authority + lstat + universal-deny for apply_patch / swarm_apply_patch / patch
+		if (
+			input.tool === 'apply_patch' ||
+			input.tool === 'swarm_apply_patch' ||
+			input.tool === 'patch'
+		) {
 			const patchAgentName =
 				swarmState.activeAgent.get(input.sessionID) ?? 'unknown';
 			if (!swarmState.activeAgent.has(input.sessionID)) {

--- a/src/hooks/knowledge-curator.ts
+++ b/src/hooks/knowledge-curator.ts
@@ -128,7 +128,8 @@ function isWriteToSwarmPlan(input: unknown): boolean {
 	const toolName = record.toolName as string | undefined;
 
 	if (typeof toolName !== 'string') return false;
-	if (!['write', 'edit', 'apply_patch'].includes(toolName)) return false;
+	if (!['write', 'edit', 'apply_patch', 'swarm_apply_patch'].includes(toolName))
+		return false;
 
 	// Normalize path separators (Windows uses backslash)
 	const rawPath = record.path as string | undefined;
@@ -159,7 +160,8 @@ export function isWriteToEvidenceFile(input: unknown): boolean {
 	const toolName = record.toolName as string | undefined;
 
 	if (typeof toolName !== 'string') return false;
-	if (!['write', 'edit', 'apply_patch'].includes(toolName)) return false;
+	if (!['write', 'edit', 'apply_patch', 'swarm_apply_patch'].includes(toolName))
+		return false;
 
 	// Normalize path separators (Windows uses backslash)
 	const rawPath = record.path as string | undefined;

--- a/src/hooks/scope-guard-array-paths.test.ts
+++ b/src/hooks/scope-guard-array-paths.test.ts
@@ -808,4 +808,71 @@ describe('scope-guard array-path parameter handling', () => {
 			}).not.toThrow();
 		});
 	});
+
+	// ─────────────────────────────────────────────────────────────
+	// swarm_apply_patch: renamed plugin patch tool must also be guarded
+	// Regression: if scope-guard only checked 'apply_patch', the renamed
+	// swarm_apply_patch would bypass array-path scope enforcement.
+	// ─────────────────────────────────────────────────────────────
+	describe('swarm_apply_patch array-path scope enforcement', () => {
+		it('swarm_apply_patch: out-of-scope path in files[] triggers SCOPE VIOLATION', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{
+						tool: 'swarm_apply_patch',
+						sessionID: SESSION_ID,
+						callID: 'call-sap-1',
+					},
+					{
+						args: {
+							files: [
+								'/workspace/src/hooks/scope-guard.ts', // in scope
+								'/workspace/src/tools/out.ts', // out of scope
+							],
+						},
+					},
+				);
+			}).toThrow(/SCOPE VIOLATION.*src\/tools\/out\.ts/);
+		});
+
+		it('swarm_apply_patch: all in-scope files[] does not throw', async () => {
+			ensureAgentSession(SESSION_ID, 'coder');
+			const session = swarmState.agentSessions.get(SESSION_ID)!;
+			session.declaredCoderScope = ['/workspace/src/hooks'];
+
+			const hook = createScopeGuardHook(
+				{ enabled: true },
+				WORKSPACE_DIR,
+				() => {},
+			);
+
+			await expect(async () => {
+				await hook.toolBefore(
+					{
+						tool: 'swarm_apply_patch',
+						sessionID: SESSION_ID,
+						callID: 'call-sap-2',
+					},
+					{
+						args: {
+							files: [
+								'/workspace/src/hooks/scope-guard.ts',
+								'/workspace/src/hooks/another.ts',
+							],
+						},
+					},
+				);
+			}).not.toThrow();
+		});
+	});
 });

--- a/src/hooks/scope-guard-mixed-args.test.ts
+++ b/src/hooks/scope-guard-mixed-args.test.ts
@@ -429,4 +429,62 @@ describe('scope-guard mixed-args bypass — regression: first-match-wins bypass 
 			);
 		}).toThrow(/SCOPE VIOLATION/);
 	});
+
+	// ─────────────────────────────────────────────────────────────
+	// swarm_apply_patch — renamed tool must also be guarded
+	// ─────────────────────────────────────────────────────────────
+
+	it('swarm_apply_patch: out-of-scope files[] triggers SCOPE VIOLATION', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'swarm_apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-swarm-out',
+				},
+				{
+					args: {
+						files: ['/workspace/src/tools/evil.ts'],
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+	});
+
+	it('swarm_apply_patch: in-scope files[] does not trigger violation', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'swarm_apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-swarm-in',
+				},
+				{
+					args: {
+						files: ['/workspace/src/hooks/safe.ts'],
+					},
+				},
+			);
+		}).not.toThrow();
+	});
 });

--- a/src/hooks/scope-guard-single-path-keys.test.ts
+++ b/src/hooks/scope-guard-single-path-keys.test.ts
@@ -420,4 +420,65 @@ describe('scope-guard single-path multi-key iteration — regression: first-matc
 			);
 		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
 	});
+
+	// ─────────────────────────────────────────────────────────────
+	// swarm_apply_patch: renamed plugin patch tool must also be guarded
+	// Regression: if scope-guard only checked 'apply_patch', the renamed
+	// swarm_apply_patch would bypass single-path-key scope enforcement.
+	// ─────────────────────────────────────────────────────────────
+	it('swarm_apply_patch: path in-scope + filePath out-of-scope → SCOPE VIOLATION', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'swarm_apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-sap-sp-1',
+				},
+				{
+					args: {
+						path: '/workspace/src/hooks/safe.ts', // in-scope (cover)
+						filePath: '/workspace/src/tools/evil.ts', // out-of-scope (bypass attempt)
+					},
+				},
+			);
+		}).toThrow(/SCOPE VIOLATION.*src\/tools\/evil\.ts/);
+	});
+
+	it('swarm_apply_patch: all single-path keys in-scope → no violation', async () => {
+		ensureAgentSession(SESSION_ID, 'coder');
+		const session = swarmState.agentSessions.get(SESSION_ID)!;
+		session.declaredCoderScope = ['/workspace/src/hooks'];
+
+		const hook = createScopeGuardHook(
+			{ enabled: true },
+			WORKSPACE_DIR,
+			() => {},
+		);
+
+		await expect(async () => {
+			await hook.toolBefore(
+				{
+					tool: 'swarm_apply_patch',
+					sessionID: SESSION_ID,
+					callID: 'call-sap-sp-2',
+				},
+				{
+					args: {
+						path: '/workspace/src/hooks/a.ts', // in-scope
+						filePath: '/workspace/src/hooks/b.ts', // in-scope
+					},
+				},
+			);
+		}).not.toThrow();
+	});
 });

--- a/src/hooks/slop-detector.ts
+++ b/src/hooks/slop-detector.ts
@@ -13,6 +13,7 @@ const WRITE_EDIT_TOOLS = new Set([
 	'write',
 	'edit',
 	'apply_patch',
+	'swarm_apply_patch',
 	'create_file',
 ]);
 

--- a/src/hooks/trajectory-logger.ts
+++ b/src/hooks/trajectory-logger.ts
@@ -129,7 +129,8 @@ export async function truncateTrajectoryFile(
 function deriveAction(tool: string): string {
 	const toolLower = tool.toLowerCase();
 	if (toolLower === 'task') return 'delegate';
-	if (['write', 'edit', 'apply_patch'].includes(toolLower)) return 'edit';
+	if (['write', 'edit', 'apply_patch', 'swarm_apply_patch'].includes(toolLower))
+		return 'edit';
 	if (['read', 'glob', 'search'].includes(toolLower)) return 'read';
 	if (['bash', 'shell'].includes(toolLower)) return 'execute';
 	if (toolLower === 'test_runner') return 'test';

--- a/src/tools/apply-patch.test.ts
+++ b/src/tools/apply-patch.test.ts
@@ -10,7 +10,7 @@ import {
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import type { ApplyPatchResult } from './apply-patch';
-import { applyPatch } from './apply-patch';
+import { swarmApplyPatch } from './apply-patch';
 
 // Helper: create a temp directory
 function createTempDir(): string {
@@ -126,7 +126,7 @@ function buildDeleteDiff(delPath: string, content: string): string {
 	return `--- ${delPath}\n+++ /dev/null\n@@ -1,${lines.length} +0,0 @@\n${hunkLines.join('\n')}\n`;
 }
 
-// Helper: call applyPatch.execute with correct ctx argument
+// Helper: call swarmApplyPatch.execute with correct ctx argument
 async function applyPatchExec(args: {
 	patch: string;
 	files: string[];
@@ -137,7 +137,7 @@ async function applyPatchExec(args: {
 }): Promise<string> {
 	// The createSwarmTool wrapper expects ctx as second arg, not directory
 	// It extracts directory from ctx.directory
-	return applyPatch.execute(args, { directory: args.directory } as any);
+	return swarmApplyPatch.execute(args, { directory: args.directory } as any);
 }
 
 // Helper: workspace for execute call
@@ -145,7 +145,7 @@ function workspaceOf(dir: string) {
 	return { directory: dir };
 }
 
-describe('apply-patch tool', () => {
+describe('swarm_apply_patch tool', () => {
 	let workspace: string;
 
 	beforeEach(() => {
@@ -172,7 +172,7 @@ describe('apply-patch tool', () => {
 			'line1\nline2-modified\nline3\n',
 		);
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [targetFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -202,7 +202,7 @@ describe('apply-patch tool', () => {
 		);
 
 		const combinedPatch = patch1 + patch2;
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch: combinedPatch, files: [targetFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -225,7 +225,7 @@ describe('apply-patch tool', () => {
 		const patchA = buildDiff(fileA, fileA, 'hello\nworld\n', 'hello\nswarm\n');
 		const patchB = buildDiff(fileB, fileB, 'foo\nbar\n', 'foo\nbaz\n');
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch: patchA + patchB, files: [fileA, fileB] },
 			workspaceOf(workspace) as any,
 		);
@@ -245,7 +245,7 @@ describe('apply-patch tool', () => {
 
 		const patch = buildDiff(targetFile, targetFile, 'original\n', 'modified\n');
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [targetFile], dryRun: true },
 			workspaceOf(workspace) as any,
 		);
@@ -264,7 +264,7 @@ describe('apply-patch tool', () => {
 
 		const patch = buildDiff(targetFile, targetFile, 'old\n', 'new\n');
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: ['other.txt'] },
 			workspaceOf(workspace) as any,
 		);
@@ -291,7 +291,7 @@ describe('apply-patch tool', () => {
 			'line1\nline2-modified\nline3\n',
 		);
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [targetFile, extraFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -311,7 +311,7 @@ describe('apply-patch tool', () => {
 
 		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,3 +1,3 @@\n line1\n-old\n+new\n line3\n`;
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [targetFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -328,7 +328,7 @@ describe('apply-patch tool', () => {
 	test('rejects absolute paths', async () => {
 		const patch = '--- /etc/passwd\n+++ /etc/passwd\n@@ -1 +1 @@\n-old\n+new\n';
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: ['/etc/passwd'] },
 			workspaceOf(workspace) as any,
 		);
@@ -342,7 +342,7 @@ describe('apply-patch tool', () => {
 	test('rejects ../ traversal', async () => {
 		const patch = `--- ../secret.txt\n+++ ../secret.txt\n@@ -1 +1 @@\n-old\n+new\n`;
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: ['../secret.txt'] },
 			workspaceOf(workspace) as any,
 		);
@@ -355,7 +355,7 @@ describe('apply-patch tool', () => {
 	// ===== Test 10: Rejects .git/ and .swarm/ targets =====
 	test('rejects .git/ and .swarm/ protected directory targets', async () => {
 		const gitPatch = `--- .git/config\n+++ .git/config\n@@ -1 +1 @@\n-old\n+new\n`;
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch: gitPatch, files: ['.git/config'] },
 			workspaceOf(workspace) as any,
 		);
@@ -366,7 +366,7 @@ describe('apply-patch tool', () => {
 		);
 
 		const swarmPatch = `--- .swarm/secret.txt\n+++ .swarm/secret.txt\n@@ -1 +1 @@\n-old\n+new\n`;
-		const resultStr2 = await applyPatch.execute(
+		const resultStr2 = await swarmApplyPatch.execute(
 			{ patch: swarmPatch, files: ['.swarm/secret.txt'] },
 			workspaceOf(workspace) as any,
 		);
@@ -383,7 +383,7 @@ describe('apply-patch tool', () => {
 	// segments.some() to check ALL segments, correctly rejecting nested protected dirs.
 	test('rejects .git/ hidden inside a subdirectory path (src/.git/config)', async () => {
 		const nestedGitPatch = `--- src/.git/config\n+++ src/.git/config\n@@ -1 +1 @@\n-old\n+new\n`;
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch: nestedGitPatch, files: ['src/.git/config'] },
 			workspaceOf(workspace) as any,
 		);
@@ -396,7 +396,7 @@ describe('apply-patch tool', () => {
 
 	test('rejects .swarm/ hidden inside a subdirectory path (src/.swarm/state)', async () => {
 		const nestedSwarmPatch = `--- src/.swarm/state\n+++ src/.swarm/state\n@@ -1 +1 @@\n-old\n+new\n`;
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch: nestedSwarmPatch, files: ['src/.swarm/state'] },
 			workspaceOf(workspace) as any,
 		);
@@ -409,7 +409,7 @@ describe('apply-patch tool', () => {
 
 	test('rejects .git/ at arbitrary depth (a/b/.git/c)', async () => {
 		const deepGitPatch = `--- a/b/.git/c\n+++ a/b/.git/c\n@@ -1 +1 @@\n-old\n+new\n`;
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch: deepGitPatch, files: ['a/b/.git/c'] },
 			workspaceOf(workspace) as any,
 		);
@@ -426,7 +426,7 @@ describe('apply-patch tool', () => {
 		const content = 'brand new content\n';
 		const patch = buildCreateDiff(newFile, content);
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [newFile], allowCreates: true },
 			workspaceOf(workspace) as any,
 		);
@@ -443,7 +443,7 @@ describe('apply-patch tool', () => {
 		const newFile = 'not-created.txt';
 		const patch = buildCreateDiff(newFile, 'some content\n');
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [newFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -461,7 +461,7 @@ describe('apply-patch tool', () => {
 		createFile(workspace, targetFile, 'content to delete\n');
 		const patch = buildDeleteDiff(targetFile, 'content to delete\n');
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [targetFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -479,7 +479,7 @@ describe('apply-patch tool', () => {
 		createFile(workspace, targetFile, 'content to delete\n');
 		const patch = buildDeleteDiff(targetFile, 'content to delete\n');
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [targetFile], allowDeletes: true },
 			workspaceOf(workspace) as any,
 		);
@@ -497,7 +497,7 @@ describe('apply-patch tool', () => {
 
 		const binaryPatch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1 +1 @@\n-old\n\\ No newline at end of file\n+new\n\\ No newline at end of file\nGIT binary patch\nliteral 1\nH Pf\n`;
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch: binaryPatch, files: [targetFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -516,7 +516,7 @@ describe('apply-patch tool', () => {
 
 		const renamePatch = `--- ${oldFile}\n+++ ${newFile}\nrename from ${oldFile}\nrename to ${newFile}\n`;
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch: renamePatch, files: [oldFile, newFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -540,7 +540,7 @@ describe('apply-patch tool', () => {
 			'line1\nmodified\nline3\n',
 		);
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [patchedFile, unrelatedFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -559,7 +559,7 @@ describe('apply-patch tool', () => {
 
 		const patch = buildDiff(targetFile, targetFile, 'original\n', 'modified\n');
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [targetFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -588,7 +588,7 @@ describe('apply-patch tool', () => {
 			'line1\r\nline2-modified\r\nline3\r\n',
 		);
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [targetFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -619,7 +619,7 @@ describe('apply-patch tool', () => {
 			'line1\nline2-modified\nline3',
 		);
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [targetFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -639,7 +639,7 @@ describe('apply-patch tool', () => {
 		// Patch with no hunks (just headers)
 		const emptyPatch = `--- ${targetFile}\n+++ ${targetFile}\n`;
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch: emptyPatch, files: [targetFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -666,7 +666,7 @@ describe('apply-patch tool', () => {
 		const badPatch = `--- ${badFile}\n+++ ${badFile}\n@@ -1 +1 @@\n-old\n+new\n`;
 
 		const combinedPatch = goodPatch + badPatch;
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch: combinedPatch, files: [goodFile, badFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -686,7 +686,7 @@ describe('apply-patch tool', () => {
 		for (const name of reservedNames) {
 			const patch = `--- ${name}.txt\n+++ ${name}.txt\n@@ -1 +1 @@\n-old\n+new\n`;
 
-			const resultStr = await applyPatch.execute(
+			const resultStr = await swarmApplyPatch.execute(
 				{ patch, files: [`${name}.txt`] },
 				workspaceOf(workspace) as any,
 			);
@@ -704,7 +704,7 @@ describe('apply-patch tool', () => {
 		const badPath = 'file\x00with\x01control.txt';
 		const patch = `--- ${badPath}\n+++ ${badPath}\n@@ -1 +1 @@\n-old\n+new\n`;
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [badPath] },
 			workspaceOf(workspace) as any,
 		);
@@ -724,7 +724,7 @@ describe('apply-patch tool', () => {
 		// Replace all content with spaces/tabs/newlines
 		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1 +1 @@\n-some content\n+   \t  \n`;
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [targetFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -743,7 +743,7 @@ describe('apply-patch tool', () => {
 
 		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,3 +0,0 @@\n-line1\n-line2\n-line3\n`;
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [targetFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -765,7 +765,7 @@ describe('apply-patch tool', () => {
 
 		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,3 +0,0 @@\n-line1\n-line2\n-line3\n`;
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [targetFile], allowDeletes: true },
 			workspaceOf(workspace) as any,
 		);
@@ -793,7 +793,7 @@ describe('apply-patch tool', () => {
 		// With exact-match-only, it should fail if the context at line 1 differs.
 		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,2 +1,2 @@\n block-x\n block-x\n+added\n`;
 
-		const resultStr = await applyPatch.execute(
+		const resultStr = await swarmApplyPatch.execute(
 			{ patch, files: [targetFile] },
 			workspaceOf(workspace) as any,
 		);
@@ -802,5 +802,46 @@ describe('apply-patch tool', () => {
 		expect(result.success).toBe(false);
 		expect(result.files[0]?.status).toBe('error');
 		expect(result.files[0]?.errors?.[0]?.type).toBe('context-mismatch');
+	});
+
+	// ===== Test 28: Hard-fail on unsupported *** Begin Patch / *** Update File format =====
+	test('rejects *** Begin Patch / *** Update File style payload with hard error', async () => {
+		const unsupportedPayload = [
+			'*** Begin Patch',
+			'*** Update File: src/foo.ts',
+			'@@',
+			'-old line',
+			'+new line',
+			'*** End Patch',
+		].join('\n');
+
+		const resultStr = await swarmApplyPatch.execute(
+			{ patch: unsupportedPayload, files: ['src/foo.ts'] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.errors?.[0]?.message).toContain(
+			'Unsupported patch format',
+		);
+		expect(result.files[0]?.errors?.[0]?.message).toContain(
+			'swarm_apply_patch',
+		);
+	});
+
+	test('rejects *** Update File style payload (no Begin Patch header)', async () => {
+		const unsupportedPayload = '*** Update File: src/bar.ts\n@@\n-old\n+new\n';
+
+		const resultStr = await swarmApplyPatch.execute(
+			{ patch: unsupportedPayload, files: ['src/bar.ts'] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.errors?.[0]?.message).toContain(
+			'Unsupported patch format',
+		);
 	});
 });

--- a/src/tools/apply-patch.ts
+++ b/src/tools/apply-patch.ts
@@ -1104,11 +1104,35 @@ function buildErrorResult(message: string): ApplyPatchResult {
 	};
 }
 
+// ============ Unsupported Format Detection ============
+
+/**
+ * Detect the *** Begin Patch / *** Update File style payload that opencode's
+ * native apply_patch tool uses. The Swarm unified-diff tool does NOT support
+ * this format and must hard-fail rather than silently returning no-op success.
+ */
+function isUnsupportedPatchFormat(patchText: string): boolean {
+	const trimmed = patchText.trimStart();
+	return (
+		trimmed.startsWith('*** Begin Patch') ||
+		trimmed.startsWith('*** Update File') ||
+		trimmed.startsWith('*** Add File') ||
+		trimmed.startsWith('*** Delete File') ||
+		trimmed.startsWith('*** End Patch')
+	);
+}
+
 // ============ Tool Definition ============
 
-export const applyPatch: ToolDefinition = createSwarmTool({
+/**
+ * Swarm unified-diff patch tool (formerly registered as apply_patch).
+ * Renamed to swarm_apply_patch so it no longer shadows the native opencode
+ * apply_patch tool. The native tool handles *** Begin Patch / *** Update File
+ * style payloads; this tool handles standard unified diffs only.
+ */
+export const swarmApplyPatch: ToolDefinition = createSwarmTool({
 	description:
-		'Apply a unified diff patch to workspace files. Validates paths, matches context exactly, and writes atomically. Coder-scoped write tool.',
+		'Apply a unified diff patch to workspace files. Validates paths, matches context exactly, and writes atomically. Coder-scoped write tool. Use standard unified diff format (--- a/file / +++ b/file / @@ hunks). Does NOT support *** Begin Patch / *** Update File payloads — use the native apply_patch tool for those.',
 	args: {
 		patch: z.string().min(1).describe('Unified diff text to parse and apply'),
 		files: z
@@ -1141,7 +1165,7 @@ export const applyPatch: ToolDefinition = createSwarmTool({
 		// Safe args extraction
 		if (!args || typeof args !== 'object') {
 			return JSON.stringify(
-				buildErrorResult('Could not parse apply_patch arguments'),
+				buildErrorResult('Could not parse swarm_apply_patch arguments'),
 				null,
 				2,
 			);
@@ -1176,6 +1200,21 @@ export const applyPatch: ToolDefinition = createSwarmTool({
 		if (!patchText || patchText.trim() === '') {
 			return JSON.stringify(
 				buildErrorResult('patch text cannot be empty'),
+				null,
+				2,
+			);
+		}
+
+		// Hard-fail unsupported *** Begin Patch / *** Update File format payloads.
+		// These are produced by opencode's native apply_patch tool and are NOT
+		// unified diffs. Returning success/no-op for them would silently swallow
+		// the payload. Callers must use the native apply_patch tool instead.
+		if (isUnsupportedPatchFormat(patchText)) {
+			return JSON.stringify(
+				buildErrorResult(
+					'Unsupported patch format: *** Begin Patch / *** Update File style payloads are not supported by swarm_apply_patch. ' +
+						'Use the native apply_patch tool for this format, or provide a standard unified diff (--- a/file / +++ b/file / @@ hunks).',
+				),
 				null,
 				2,
 			);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,8 +1,8 @@
-import { applyPatch } from './apply-patch';
+import { swarmApplyPatch } from './apply-patch';
 
-export { applyPatch };
-// Alias for TOOL_NAMES compliance - apply_patch and applyPatch are the same tool
-export const apply_patch: typeof applyPatch = applyPatch;
+export { swarmApplyPatch };
+// Alias for TOOL_NAMES compliance - swarm_apply_patch and swarmApplyPatch are the same tool
+export const swarm_apply_patch: typeof swarmApplyPatch = swarmApplyPatch;
 export { batch_symbols } from './batch-symbols';
 export { build_check } from './build-check';
 export { check_gate_status } from './check-gate-status';

--- a/src/tools/manifest.ts
+++ b/src/tools/manifest.ts
@@ -23,7 +23,7 @@
  * Neither is implemented (no current tool needs them). Not tree-shakeable.
  */
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
-import { applyPatch } from './apply-patch';
+import { swarmApplyPatch } from './apply-patch';
 import { batch_symbols } from './batch-symbols';
 import { build_check } from './build-check';
 import { check_gate_status } from './check-gate-status';
@@ -229,7 +229,7 @@ export const TOOL_MANIFEST = defineHandlers({
 	lean_turbo_review: () => lean_turbo_review,
 	lean_turbo_run_phase: () => lean_turbo_run_phase,
 	lean_turbo_status: () => lean_turbo_status,
-	apply_patch: () => applyPatch,
+	swarm_apply_patch: () => swarmApplyPatch,
 	external_skill_discover: () => external_skill_discover,
 	external_skill_list: () => external_skill_list,
 	external_skill_inspect: () => external_skill_inspect,

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -615,9 +615,9 @@ export const TOOL_METADATA = {
 			'returns Lean Turbo configuration and active status for the current session',
 		agents: [],
 	},
-	apply_patch: {
+	swarm_apply_patch: {
 		description:
-			'Apply a unified diff patch to workspace files with exact context matching, atomic writes, and path validation',
+			'Apply a unified diff patch to workspace files with exact context matching, atomic writes, and path validation. Use standard unified diff format only — does NOT support *** Begin Patch / *** Update File payloads (use native apply_patch for those).',
 		agents: ['coder', 'test_engineer'],
 	},
 	external_skill_discover: {

--- a/tests/adversarial/architect-check-gate-status-whitelist.adversarial.test.ts
+++ b/tests/adversarial/architect-check-gate-status-whitelist.adversarial.test.ts
@@ -120,7 +120,7 @@ describe('ADVERSARIAL: Architect whitelist check_gate_status', () => {
 				'knowledge_receipt',
 				'swarm_command',
 				'summarize_work',
-				'apply_patch',
+				'swarm_apply_patch',
 			];
 			expect(AGENT_TOOL_MAP['coder']).toEqual(expected);
 		});
@@ -143,7 +143,7 @@ describe('ADVERSARIAL: Architect whitelist check_gate_status', () => {
 				'search',
 				'swarm_command',
 				'summarize_work',
-				'apply_patch',
+				'swarm_apply_patch',
 			];
 			expect(AGENT_TOOL_MAP['test_engineer']).toEqual(expected);
 		});

--- a/tests/unit/agents/capability-drift-guard.test.ts
+++ b/tests/unit/agents/capability-drift-guard.test.ts
@@ -158,12 +158,18 @@ describe('WRITE_TOOL_NAMES is the canonical write-tool set', () => {
 		}
 	});
 
-	test('WRITE_TOOL_NAMES.length is 9 (canonical count)', () => {
-		expect(WRITE_TOOL_NAMES.length).toBe(9);
+	test('WRITE_TOOL_NAMES.length is 10 (canonical count — includes both apply_patch and swarm_apply_patch)', () => {
+		expect(WRITE_TOOL_NAMES.length).toBe(10);
 	});
 
-	test('WRITE_TOOL_NAMES contains the 4 core write tools', () => {
-		const coreWriteTools = ['write', 'edit', 'patch', 'apply_patch'] as const;
+	test('WRITE_TOOL_NAMES contains the 5 core write tools', () => {
+		const coreWriteTools = [
+			'write',
+			'edit',
+			'patch',
+			'apply_patch',
+			'swarm_apply_patch',
+		] as const;
 		for (const tool of coreWriteTools) {
 			expect(WRITE_TOOL_NAMES).toContain(tool);
 		}

--- a/tests/unit/config/agent-tool-map.test.ts
+++ b/tests/unit/config/agent-tool-map.test.ts
@@ -68,6 +68,7 @@ describe('AGENT_TOOL_MAP', () => {
 		expect(smeTools).toContain('web_search');
 		expect(smeTools).not.toContain('knowledge_add');
 		expect(smeTools).not.toContain('apply_patch');
+		expect(smeTools).not.toContain('swarm_apply_patch');
 	});
 
 	it('researcher has all 8 assigned tools and remains read-only', () => {
@@ -89,6 +90,7 @@ describe('AGENT_TOOL_MAP', () => {
 		// Read-only invariant: no write tools
 		const writeTools = [
 			'apply_patch',
+			'swarm_apply_patch',
 			'knowledge_add',
 			'save_plan',
 			'update_task_status',

--- a/tests/unit/config/critic-oversight-tools.test.ts
+++ b/tests/unit/config/critic-oversight-tools.test.ts
@@ -33,6 +33,7 @@ const FORBIDDEN_WRITE_TOOLS = [
 	'edit',
 	'patch',
 	'apply_patch',
+	'swarm_apply_patch',
 	'create_file',
 	'insert',
 	'replace',


### PR DESCRIPTION
Closes #1506

## Summary
- Rename Swarm's unified-diff patch tool from `apply_patch` to `swarm_apply_patch` across all registrations, manifests, tool metadata, and internal hook consumers
- Stop shadowing opencode's native `apply_patch` tool, restoring the native inline diff rendering UX
- Keep both `apply_patch` (native) and `swarm_apply_patch` (plugin) covered by Swarm write guardrails (`WRITE_TOOL_NAMES`, scope-guard, authority checks)
- Add hard-fail mechanism: `swarm_apply_patch` loudly rejects `*** Begin Patch` formatted payloads instead of silently returning a 0-file success
- Update all internal hook consumers (slop-detector, knowledge-curator, co-change-suggester, context-budget, trajectory-logger) and agent configs (architect prompt, researcher restrictions) to recognize the new tool name

## Invariant audit
- 1 (plugin init): not touched — no init-path code changed
- 2 (runtime portability): not touched — no bundle/build config changes
- 3 (subprocesses): not touched — no spawn/spawnSync changes
- 4 (.swarm containment): not touched — no `.swarm/` path changes
- 5 (plan durability): not touched — no plan/ledger changes
- 6 (test_runner safety): not touched — no test_runner scope changes
- 7 (test writing): touched — 3 scope-guard test files updated with `swarm_apply_patch` cases; apply-patch.test.ts renamed suite; capability-drift-guard and adversarial tests updated. All tests use `bun:test`, real temp dirs, no `mock.module` leakage.
- 8 (session state): not touched — no session-scoped state changes
- 9 (guardrails/retry): touched — `WRITE_TOOL_NAMES` extended with `swarm_apply_patch` (additive, no removals); all 5 guardrail checkpoints in `tool-before.ts` check both tool names; scope-guard `WRITE_TOOLS` Set includes both. Verified: 118 bypass-guard tests pass, 59 scope-guard tests pass.
- 10 (chat/system msg): not touched — no system message changes
- 11 (tool registration): touched — tool renamed in `manifest.ts` (`swarm_apply_patch` key), `tool-metadata.ts` (entry + `agents: ['coder', 'test_engineer']`), `index.ts` (export + alias), `constants.ts` (`WRITE_TOOL_NAMES`). Verified: `agent-tool-map.test.ts` passes, `critic-oversight-tools.test.ts` passes, `capability-drift-guard.test.ts` GROUP 4-5 pass (4 pre-existing failures unrelated). `swarm_apply_patch` restricted to `coder` + `test_engineer` only across all 22 agents.
- 12 (release/cache): not touched — no cache or release pipeline changes

## Test plan
- [x] `bun test src/tools/apply-patch.test.ts` — 36 tests pass (33 original + 3 format marker tests from review fix branch)
- [x] `bun test src/hooks/scope-guard-*.test.ts` — 59 tests pass (array-paths, mixed-args, single-path-keys)
- [x] `bun test tests/unit/hooks/destructive-command-swarm-cli-bypass.test.ts` — 118 tests pass (103 original + 15 swarm_apply_patch parallel tests from review fix branch)
- [x] `bun test tests/unit/config/agent-tool-map.test.ts` — 11 pass, 0 fail
- [x] `bun test tests/unit/config/critic-oversight-tools.test.ts` — 5 pass, 0 fail (4 original + 1 parity test from review fix branch)
- [x] `bun test tests/adversarial/architect-check-gate-status-whitelist.adversarial.test.ts` — 42 pass, 0 fail
- [x] `bun test tests/unit/agents/capability-drift-guard.test.ts` — 31 pass, 4 pre-existing failures (unrelated: `convene_general_council`, `curator_postmortem`)
- [x] swarm-pr-review completed: 10 explorer lanes (6 base + 4 micro-lanes), independent reviewer validation, critic challenge. 6 confirmed findings addressed in branch `fix/pr-1511-review-findings`.
- [ ] CI verification pending (head branch is `main` from fork — CI may not trigger automatically)
