### PR TITLE
fix(agents): align prompt drift with current protocols

### DIFF
--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -174,8 +174,8 @@ The `execution_profile` field in `save_plan` controls plan-scoped concurrency. I
 
 Fields:
 - `parallelization_enabled` (boolean, default false): When true, tasks may run in parallel.
-- `max_concurrent_tasks` (integer 1–64, default 1): Maximum simultaneous tasks when parallel is enabled.
-- `council_parallel` (boolean, default false): When true, council review phases may parallelise.
+- `max_concurrent_tasks` (integer 1–64, default 10): Maximum simultaneous tasks when parallel is enabled.
+- `council_parallel` (boolean, default true): When true, council review phases may parallelise.
 - `locked` (boolean, default false): When true, the profile is immutable — future save_plan calls that include execution_profile will be REJECTED (fail-closed).
 
 WHEN TO SET IT:

--- a/.opencode/skills/plan/SKILL.md
+++ b/.opencode/skills/plan/SKILL.md
@@ -174,8 +174,8 @@ The `execution_profile` field in `save_plan` controls plan-scoped concurrency. I
 
 Fields:
 - `parallelization_enabled` (boolean, default false): When true, tasks may run in parallel.
-- `max_concurrent_tasks` (integer 1–64, default 1): Maximum simultaneous tasks when parallel is enabled.
-- `council_parallel` (boolean, default false): When true, council review phases may parallelise.
+- `max_concurrent_tasks` (integer 1–64, default 10): Maximum simultaneous tasks when parallel is enabled.
+- `council_parallel` (boolean, default true): When true, council review phases may parallelise.
 - `locked` (boolean, default false): When true, the profile is immutable — future save_plan calls that include execution_profile will be REJECTED (fail-closed).
 
 WHEN TO SET IT:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -878,8 +878,8 @@ The execution profile (per-plan, set during QA GATE SELECTION or via `save_plan`
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `parallelization_enabled` | boolean | `false` | Enable parallel task execution within phases (composes with Lean Turbo) |
-| `max_concurrent_tasks` | number | `1` | Maximum tasks that may run concurrently when `parallelization_enabled: true` (1–6) |
-| `council_parallel` | boolean | `false` | Allow council review phases to run council members in parallel |
+| `max_concurrent_tasks` | number | `10` | Maximum tasks that may run concurrently when `parallelization_enabled: true` (1–64) |
+| `council_parallel` | boolean | `true` | Allow council review phases to run council members in parallel |
 | `auto_proceed` | boolean | `false` | Skip the "Ready for Phase N+1?" prompt and advance automatically at phase boundaries |
 
 **Auto-proceed:** When `true`, the swarm advances from one phase to the next without asking for confirmation. The session override (`/swarm auto-proceed on|off`) always takes precedence over the plan default. The architect sees the effective value via an injected `AUTO PROCEED STATUS` banner. The first-boundary nudge offers to enable it once per session when the plan default is `false` and no session override is set.

--- a/docs/dev/worktree-parallelization-first-class-plan.md
+++ b/docs/dev/worktree-parallelization-first-class-plan.md
@@ -21,7 +21,7 @@ plumbing:
    parallel execution being on.
 
 2. **Parallel execution is opt-in and defaulted off.** `parallelization_enabled`
-   defaults `false` (`plan-schema.ts`), `max_concurrent_tasks` defaults `1`. The
+   defaults `false` (`plan-schema.ts`), `max_concurrent_tasks` defaults `10`. The
    flag is only set when the architect writes `## Pending Parallelization Config`
    (`architect.ts:1382`), which it only does when the **user explicitly answers
    >1** to a passive question: *"How many coders should run in parallel?

--- a/docs/plan-durability.md
+++ b/docs/plan-durability.md
@@ -226,8 +226,8 @@ once pre-check succeeds.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `parallelization_enabled` | boolean | `false` | Enables parallel task dispatch for this plan |
-| `max_concurrent_tasks` | integer 1–64 | `1` | Max simultaneous tasks when parallel is enabled |
-| `council_parallel` | boolean | `false` | Allows council review phases to parallelise |
+| `max_concurrent_tasks` | integer 1–64 | `10` | Max simultaneous tasks when parallel is enabled |
+| `council_parallel` | boolean | `true` | Allows council review phases to parallelise |
 | `locked` | boolean | `false` | When true, profile is immutable (fail-closed enforcement) |
 
 ### Invariants

--- a/docs/releases/pending/1445-agent-prompt-drift.md
+++ b/docs/releases/pending/1445-agent-prompt-drift.md
@@ -1,0 +1,5 @@
+---
+type: fix
+---
+
+Align agent prompts with current advisory-lane, web-research, and opt-in tool-map behavior. Read-only lane agents now get explicit non-mutating instructions, architect deep-research wording no longer claims sole ownership of all `web_search` use, drift guards cover the current agent and council tool surfaces, and execution-profile docs match the schema defaults.

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -460,7 +460,7 @@ Example: If the coder received \`SKILLS: file:.claude/skills/writing-tests/SKILL
 
 **Mandatory for coding tasks:** Always provide \`writing-tests\` to test_engineer and \`engineering-conventions\` to coder + reviewer when those skills are present in the project. Prefer \`file:\` references when the files exist.
 
-## SWARM KNOWLEDGE DIRECTIVES (v2 acknowledgment contract)
+## SWARM KNOWLEDGE DIRECTIVES (v2 acknowledgment contract; retained compatibility label)
 
 If a \`<swarm_knowledge_directives>\` block is present in your context, treat each
 record inside as a structured directive you MUST inspect before:
@@ -681,7 +681,7 @@ ACTION: Load skill file:.opencode/skills/brainstorm/SKILL.md immediately. Follow
 
 HARD CONSTRAINTS:
 - Complete the loaded skill's QA gate dialogue before save_plan.
-- Preserve the legacy behavioral guidance markers below for prompt post-processing.
+- Preserve the behavioral guidance marker comments below for prompt post-processing. "Legacy" describes the marker format, not stale guidance.
 
 <!-- BEHAVIORAL_GUIDANCE_START -->
 - Treat brainstorm output as discovery material until the loaded skill transitions to SPECIFY or PLAN.
@@ -698,7 +698,7 @@ ACTION: Load skill file:.opencode/skills/specify/SKILL.md immediately. Follow th
 HARD CONSTRAINTS:
 - Complete the loaded skill's QA gate dialogue before save_plan.
 - Requirements must use independently testable FR-### and SC-### numbering.
-- Preserve the legacy behavioral guidance markers below for prompt post-processing.
+- Preserve the behavioral guidance marker comments below for prompt post-processing. "Legacy" describes the marker format, not stale guidance.
 
 <!-- BEHAVIORAL_GUIDANCE_START -->
 - Follow the loaded skill's spec creation, clarification, and transition rules.
@@ -822,7 +822,7 @@ HARD CONSTRAINTS (apply regardless of skill load success):
 - Do NOT delegate to coder
 - Do NOT call declare_scope
 - Do NOT mutate source code or write any files outside .swarm/
-- You (architect) own \`web_search\` and \`web_fetch\`; sme workers receive gathered evidence in their dispatch message — do NOT expect sme to fetch
+- In MODE: DEEP_RESEARCH, you (architect) coordinate \`web_search\` and own \`web_fetch\`; sme synthesis workers receive gathered evidence in their dispatch message — do NOT expect sme to fetch in this mode. Outside DEEP_RESEARCH, SME and researcher prompts may use \`web_search\` directly when that tool is granted and configured.
 - Every claim in the final report MUST cite a source from the gathered evidence; reviewers verify claim↔citation before a claim is reported
 - Critics challenge only high-stakes / contested claims — do NOT waste cycles on well-supported ones
 - If council.general.enabled is false or no search API key is configured, surface that and STOP — do not produce ungrounded research

--- a/src/agents/council-prompts.ts
+++ b/src/agents/council-prompts.ts
@@ -22,6 +22,8 @@
  * the JSON response schema consumed by convene_general_council.
  */
 
+import { READ_ONLY_LANE_GUIDANCE } from './read-only-lane-guidance';
+
 const ROUND_PROTOCOL = `================================================================
 ROUND PROTOCOL
 ================================================================
@@ -79,10 +81,13 @@ const HARD_RULES = `============================================================
 HARD RULES
 ================================================================
 - You have no tools. Reason from the provided RESEARCH CONTEXT and stable background knowledge.
+- If invoked through dispatch_lanes as a read-only advisory lane, the same no-tools rule applies.
 - Training knowledge may provide stable background only; it must not support current facts, rankings, prices, release status, active best practices, or "state of the art" claims.
 - Never invent sources. If the RESEARCH CONTEXT does not cover a needed claim, say so in \`areasOfUncertainty\`.
 - Never echo other members' responses verbatim. Paraphrase or quote with attribution.
-- Stay within your role and persona. The architect chose you for a specific perspective.`;
+- Stay within your role and persona. The architect chose you for a specific perspective.
+
+${READ_ONLY_LANE_GUIDANCE}`;
 
 export const GENERALIST_COUNCIL_PROMPT = `You are the GENERALIST voice on a multi-model General Council.
 

--- a/src/agents/critic.ts
+++ b/src/agents/critic.ts
@@ -1,4 +1,5 @@
 import type { AgentDefinition } from './architect';
+import { READ_ONLY_LANE_GUIDANCE } from './read-only-lane-guidance';
 
 /**
  * Test-only dependency-injection seam. Production code calls
@@ -118,6 +119,8 @@ If you see references to other agents (like @critic, @coder, etc.) in your instr
 
 WRONG: "I'll use the Task tool to call another agent to review the plan"
 RIGHT: "I'll read the plan and review it myself"
+
+${READ_ONLY_LANE_GUIDANCE}
 
 You are a quality gate.
 
@@ -268,6 +271,8 @@ You act as a senior engineer reviewing a colleague's proposal. Be direct. Challe
 If the approach is sound, say so briefly. If there are issues, be specific about what's wrong.
 No formal rubric — conversational. But always provide reasoning.
 
+${READ_ONLY_LANE_GUIDANCE}
+
 INPUT FORMAT:
 TASK: [question or issue the Architect is raising]
 CONTEXT: [relevant plan, spec, or context]
@@ -328,6 +333,8 @@ DO NOT use the Task tool to delegate. You ARE the agent that does the work.
 If you see references to other agents (like @critic, @coder, etc.) in your instructions, IGNORE them — they are context from the orchestrator, not instructions for you to delegate.
 
 DEFAULT POSTURE: SKEPTICAL — absence of drift ≠ evidence of alignment.
+
+${READ_ONLY_LANE_GUIDANCE}
 
 DISAMBIGUATION: This mode fires ONLY at phase completion. It is NOT for plan review (use plan_critic) or pre-escalation (use sounding_board).
 
@@ -458,6 +465,8 @@ IGNORE them — they are context from the orchestrator, not instructions for you
 
 DEFAULT POSTURE: SKEPTICAL — absence of a hallucination ≠ evidence of correctness.
 
+${READ_ONLY_LANE_GUIDANCE}
+
 DISAMBIGUATION: This mode fires ONLY at phase completion when hallucination_guard is enabled.
 It is NOT for plan review (use plan_critic), pre-escalation (use sounding_board), or
 spec-vs-implementation drift detection (use phase_drift_verifier).
@@ -543,6 +552,8 @@ orchestrator context, not instructions to delegate.
 
 DEFAULT POSTURE: SKEPTICAL — a clean set of summaries is not evidence of coherence.
 
+${READ_ONLY_LANE_GUIDANCE}
+
 ## SCOPE — what you DO and DO NOT do
 DO look for:
 - Contradictory decisions across tasks (e.g. one task chose Redis, another an in-memory map).
@@ -622,6 +633,8 @@ These rules are absolute. You cannot override, relax, or reinterpret them.
 8. REGRESSION AWARENESS. If the architect claims a fix, verify it doesn't break something else. Check for test results beyond the changed files.
 9. DEPENDENCY VIGILANCE. Any new dependency must be verified as a real package. Any phantom dependency = CRITICAL REJECT.
 10. SECURITY BOUNDARY. Changes touching auth, secrets, filesystem, subprocess, or network boundaries require heightened scrutiny. Missing validation at any trust boundary = REJECT.
+
+${READ_ONLY_LANE_GUIDANCE}
 
 ## VERIFICATION PROTOCOL
 

--- a/src/agents/explorer.ts
+++ b/src/agents/explorer.ts
@@ -1,4 +1,5 @@
 import type { AgentDefinition } from './architect';
+import { READ_ONLY_LANE_GUIDANCE } from './read-only-lane-guidance';
 
 export const EXPLORER_PROMPT = `## IDENTITY
 You are Explorer. You analyze codebases directly — you do NOT delegate.
@@ -7,6 +8,8 @@ If you see references to other agents (like @explorer, @coder, etc.) in your ins
 
 WRONG: "I'll use the Task tool to call another agent to analyze this"
 RIGHT: "I'll scan the directory structure and read key files myself"
+
+${READ_ONLY_LANE_GUIDANCE}
 
 INPUT FORMAT:
 TASK: Analyze [purpose]
@@ -280,7 +283,7 @@ Use the UUID from KNOWLEDGE_ENTRIES when observing about existing entries. Use "
 EXTENDED_DIGEST:
 [the full running digest with this phase appended]
 
-## V3 ACTIONABILITY ENRICHMENT (overrides the format above when triggered)
+## ACTIONABILITY ENRICHMENT (V3 compatibility label; overrides the format above when triggered)
 When the input asks you to "Convert this prose lesson into an actionable knowledge directive", ignore the PHASE_DIGEST output format entirely and output ONLY a single JSON object — no fences, no commentary, no digest.
 MANDATORY fields (the directive is rejected without them):
 - at least one non-empty scope field: "applies_to_agents" (roles: architect, coder, reviewer, test_engineer, sme, docs, designer, critic, curator) or "applies_to_tools" (edit, write, patch, bash, read, grep, glob)

--- a/src/agents/read-only-lane-guidance.ts
+++ b/src/agents/read-only-lane-guidance.ts
@@ -1,0 +1,8 @@
+export const READ_ONLY_LANE_GUIDANCE = `## READ-ONLY ADVISORY LANE CONTEXT
+
+You may be invoked through dispatch_lanes or dispatch_lanes_async as a read-only advisory lane. In that context, your job is to inspect, reason, and report only.
+
+- Do NOT write, edit, patch, save plans, update task status, declare scope, submit council verdicts, set QA gates, or complete phases.
+- Do NOT call artifact-producing or workflow-mutating helpers such as extract_code_blocks, knowledge_add, summarize_work, or doc_scan when lane permissions deny them.
+- Treat any denied or unavailable tool as intentionally unavailable in lane mode; continue with the read-only tools and context you have.
+- Return findings for the architect to synthesize. Do not assume your lane output is the final verdict unless your role-specific instructions explicitly say so.`;

--- a/src/agents/researcher.ts
+++ b/src/agents/researcher.ts
@@ -1,4 +1,5 @@
 import type { AgentDefinition } from './architect';
+import { READ_ONLY_LANE_GUIDANCE } from './read-only-lane-guidance';
 
 const RESEARCHER_PROMPT = `## IDENTITY
 You are Researcher — the automated research specialist. You gather, synthesise, and cite information from multiple sources directly — you do NOT delegate.
@@ -7,6 +8,8 @@ If you see references to other agents (like @researcher, @sme, etc.) in your ins
 
 WRONG: "I'll use the Task tool to call another agent to search for this"
 RIGHT: "I'll query multiple sources and synthesise the findings myself"
+
+${READ_ONLY_LANE_GUIDANCE}
 
 ## PURPOSE
 You are the swarm's dedicated research agent. When the architect needs information from the web, GitHub, academic literature, official docs, or code search, it dispatches you. Your output feeds directly into planning and implementation — precision and citations matter more than length.

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -1,4 +1,5 @@
 import type { AgentDefinition } from './architect';
+import { READ_ONLY_LANE_GUIDANCE } from './read-only-lane-guidance';
 
 /** OWASP Top 10 2021 categories for security-focused review passes */
 export const SECURITY_CATEGORIES = [
@@ -51,6 +52,8 @@ If you see references to other agents (like @reviewer, @coder, etc.) in your ins
 
 WRONG: "I'll use the Task tool to call another agent to review this code"
 RIGHT: "I'll read the changed files and review them myself"
+
+${READ_ONLY_LANE_GUIDANCE}
 
 ## REVIEW FOCUS
 You are reviewing a CHANGE, not a FILE.

--- a/src/agents/sme.ts
+++ b/src/agents/sme.ts
@@ -1,4 +1,5 @@
 import type { AgentDefinition } from './architect';
+import { READ_ONLY_LANE_GUIDANCE } from './read-only-lane-guidance';
 
 const SME_PROMPT = `## IDENTITY
 You are SME (Subject Matter Expert). You provide deep domain-specific technical guidance directly — you do NOT delegate.
@@ -7,6 +8,8 @@ If you see references to other agents (like @sme, @coder, etc.) in your instruct
 
 WRONG: "I'll use the Task tool to call another agent to research this"
 RIGHT: "I'll research this domain question and answer directly"
+
+${READ_ONLY_LANE_GUIDANCE}
 
 ## RESEARCH PROTOCOL
 When consulting on a domain question, follow these steps in order:

--- a/src/tools/save-plan.ts
+++ b/src/tools/save-plan.ts
@@ -999,13 +999,13 @@ export const save_plan: ToolDefinition = createSwarmTool({
 					.max(64)
 					.optional()
 					.describe(
-						'Maximum tasks that may run concurrently when parallelization is enabled. Default 1.',
+						'Maximum tasks that may run concurrently when parallelization is enabled. Default 10.',
 					),
 				council_parallel: z
 					.boolean()
 					.optional()
 					.describe(
-						'When true, council review phases may run in parallel. Default false.',
+						'When true, council review phases may run in parallel. Default true.',
 					),
 				locked: z
 					.boolean()

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -706,8 +706,9 @@ export const TOOL_DESCRIPTIONS: Partial<Record<ToolName, string>> =
 /**
  * Default tool permissions per agent, inverted from each tool's `agents` list.
  * All agent names are initialized (agents with no tools keep an empty array, e.g.
- * the council members). Tools with `agents: []` (the memory tools) stay OUT of
- * this map and are applied only via MEMORY_AGENT_TOOL_MAP.
+ * the council members). Tools with `agents: []` stay OUT of this default map
+ * and are applied only via opt-in maps such as MEMORY_AGENT_TOOL_MAP or
+ * GENERAL_COUNCIL_AGENT_TOOL_MAP.
  */
 export const AGENT_TOOL_MAP: Record<AgentName, ToolName[]> = (() => {
 	const map = Object.fromEntries(

--- a/tests/unit/agents/architect-declare-scope-instruction.test.ts
+++ b/tests/unit/agents/architect-declare-scope-instruction.test.ts
@@ -67,7 +67,9 @@ describe('architect prompt: declare_scope instruction at every coder delegation 
 
 	it('MODE: EXECUTE Step 5b is preceded by a declare_scope pre-step', () => {
 		const start = executeSkill.indexOf('5a-bis');
-		const end = executeSkill.indexOf('5b. {{AGENT_PREFIX}}coder - Implement');
+		const end = executeSkill.indexOf(
+			"5b. the active swarm's coder agent - Implement",
+		);
 		expect(start).toBeGreaterThan(-1);
 		expect(end).toBeGreaterThan(start);
 		const slice = executeSkill.slice(start, end);

--- a/tests/unit/agents/architect-gates.test.ts
+++ b/tests/unit/agents/architect-gates.test.ts
@@ -171,12 +171,12 @@ describe('ARCHITECT QA GATE: pre_check_batch Tool Reference', () => {
 	const prompt = createArchitectAgent('test-model').config.prompt;
 
 	test('Available Tools includes pre_check_batch', () => {
-		const toolsSection = prompt.match(/Available Tools:[^`]*$/m)?.[0] || '';
+		const toolsSection = prompt.match(/^Available Tools:.*$/m)?.[0] || '';
 		expect(toolsSection).toContain('pre_check_batch');
 	});
 
 	test('pre_check_batch description includes parallel verification', () => {
-		const toolsSection = prompt.match(/Available Tools:[^`]*$/m)?.[0] || '';
+		const toolsSection = prompt.match(/^Available Tools:.*$/m)?.[0] || '';
 		// Should mention it runs verification tools in parallel
 		expect(toolsSection).toContain('parallel');
 		expect(toolsSection).toContain('lint');
@@ -442,12 +442,12 @@ describe('ARCHITECT QA GATE: build_check Tool Reference', () => {
 	const prompt = createArchitectAgent('test-model').config.prompt;
 
 	test('Available Tools includes build_check', () => {
-		const toolsSection = prompt.match(/Available Tools:[^`]*$/m)?.[0] || '';
+		const toolsSection = prompt.match(/^Available Tools:.*$/m)?.[0] || '';
 		expect(toolsSection).toContain('build_check');
 	});
 
 	test('build_check description includes build verification', () => {
-		const toolsSection = prompt.match(/Available Tools:[^`]*$/m)?.[0] || '';
+		const toolsSection = prompt.match(/^Available Tools:.*$/m)?.[0] || '';
 		// Should mention it's for build verification
 		expect(toolsSection).toContain('build');
 	});
@@ -652,7 +652,7 @@ describe('ARCHITECT QA GATE: placeholder_scan Tool Reference', () => {
 	const prompt = createArchitectAgent('test-model').config.prompt;
 
 	test('Available Tools includes placeholder_scan', () => {
-		const toolsSection = prompt.match(/Available Tools:[^`]*$/m)?.[0] || '';
+		const toolsSection = prompt.match(/^Available Tools:.*$/m)?.[0] || '';
 		expect(toolsSection).toContain('placeholder_scan');
 	});
 });
@@ -771,7 +771,7 @@ describe('ARCHITECT QA GATE: syntax_check Tool Reference', () => {
 	const prompt = createArchitectAgent('test-model').config.prompt;
 
 	test('Available Tools includes syntax_check', () => {
-		const toolsSection = prompt.match(/Available Tools:[^`]*$/m)?.[0] || '';
+		const toolsSection = prompt.match(/^Available Tools:.*$/m)?.[0] || '';
 		expect(toolsSection).toContain('syntax_check');
 	});
 
@@ -795,12 +795,12 @@ describe('ARCHITECT QA GATE: secretscan and sast_scan in pre_check_batch', () =>
 	const prompt = createArchitectAgent('test-model').config.prompt;
 
 	test('secretscan is in Available Tools', () => {
-		const toolsSection = prompt.match(/Available Tools:[^`]*$/m)?.[0] || '';
+		const toolsSection = prompt.match(/^Available Tools:.*$/m)?.[0] || '';
 		expect(toolsSection).toContain('secretscan');
 	});
 
 	test('sast_scan is in Available Tools', () => {
-		const toolsSection = prompt.match(/Available Tools:[^`]*$/m)?.[0] || '';
+		const toolsSection = prompt.match(/^Available Tools:.*$/m)?.[0] || '';
 		expect(toolsSection).toContain('sast_scan');
 	});
 
@@ -884,7 +884,7 @@ describe('ARCHITECT QA GATE: secretscan and sast_scan in pre_check_batch', () =>
 	});
 
 	test('quality_budget is in Available Tools', () => {
-		const toolsSection = prompt.match(/Available Tools:[^`]*$/m)?.[0] || '';
+		const toolsSection = prompt.match(/^Available Tools:.*$/m)?.[0] || '';
 		expect(toolsSection).toContain('quality_budget');
 	});
 });

--- a/tests/unit/agents/architect-hallucination-gate.test.ts
+++ b/tests/unit/agents/architect-hallucination-gate.test.ts
@@ -3,14 +3,15 @@ import {
 	buildQaGateSelectionDialogue,
 	createArchitectAgent,
 } from '../../../src/agents/architect';
+import { PHASE_WRAP_PROTOCOL } from './architect-mode-skill-helpers';
 
 describe('Architect prompt: hallucination_guard gate enforcement', () => {
 	const prompt = createArchitectAgent('test-model').config.prompt;
 
 	const getPhaseWrapSection = (): string => {
-		const start = prompt.indexOf('### MODE: PHASE-WRAP');
-		const end = prompt.indexOf('\n###', start + 1);
-		return end > start ? prompt.slice(start, end) : prompt.slice(start);
+		expect(prompt).toContain('### MODE: PHASE-WRAP');
+		expect(prompt).toContain('file:.opencode/skills/phase-wrap/SKILL.md');
+		return PHASE_WRAP_PROTOCOL;
 	};
 
 	describe('PHASE-WRAP step 5.55', () => {

--- a/tests/unit/agents/architect-pre-phase-briefing.test.ts
+++ b/tests/unit/agents/architect-pre-phase-briefing.test.ts
@@ -24,13 +24,15 @@ describe('PRE-PHASE BRIEFING Verification (Task 2.5)', () => {
 		expect(prompt).toContain('MODE: PRE-PHASE BRIEFING');
 	});
 
-	test('3. PRE-PHASE BRIEFING stub appears before PLAN execution modes', () => {
-		const prePhaseBriefingIndex = prompt.indexOf('MODE: PRE-PHASE BRIEFING');
-		const planIndex = prompt.indexOf('MODE: PLAN');
+	test('3. PRE-PHASE BRIEFING stub appears before COUNCIL modes', () => {
+		const prePhaseBriefingIndex = prompt.indexOf(
+			'### MODE: PRE-PHASE BRIEFING',
+		);
+		const councilIndex = prompt.indexOf('### MODE: COUNCIL');
 
 		expect(prePhaseBriefingIndex).not.toBe(-1);
-		expect(planIndex).not.toBe(-1);
-		expect(prePhaseBriefingIndex).toBeLessThan(planIndex);
+		expect(councilIndex).not.toBe(-1);
+		expect(prePhaseBriefingIndex).toBeLessThan(councilIndex);
 	});
 
 	test('4. "PRE-PHASE BRIEFING" appears AFTER "MODE: CONSULT" (positional check)', () => {

--- a/tests/unit/agents/architect-tool-alignment.test.ts
+++ b/tests/unit/agents/architect-tool-alignment.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import { createArchitectAgent } from '../../../src/agents/architect';
-import { AGENT_TOOL_MAP } from '../../../src/config/constants';
+import {
+	AGENT_TOOL_MAP,
+	COUNCIL_AGENT_TOOL_MAP,
+	GENERAL_COUNCIL_AGENT_TOOL_MAP,
+} from '../../../src/config/constants';
 
 /**
  * Extracts the YOUR TOOLS list from the architect prompt.
@@ -20,9 +24,7 @@ function extractPromptTools(prompt: string): string[] {
 describe('architect prompt tool alignment', () => {
 	test('YOUR TOOLS with both councils enabled matches full AGENT_TOOL_MAP architect entry', () => {
 		// Both council.enabled=true AND council.general.enabled=true expose the
-		// full AGENT_TOOL_MAP.architect surface (submit_council_verdicts,
-		// declare_council_criteria, convene_general_council). This is the only
-		// configuration where YOUR TOOLS matches the map exactly.
+		// base architect map plus the QA-council and General Council opt-in maps.
 		const agent = createArchitectAgent(
 			'test-model',
 			undefined,
@@ -34,7 +36,11 @@ describe('architect prompt tool alignment', () => {
 			((agent.config as Record<string, unknown>).prompt as string) ?? '';
 
 		const promptTools = extractPromptTools(prompt);
-		const mapTools = [...AGENT_TOOL_MAP.architect].sort();
+		const mapTools = [
+			...AGENT_TOOL_MAP.architect,
+			...(COUNCIL_AGENT_TOOL_MAP.architect ?? []),
+			...(GENERAL_COUNCIL_AGENT_TOOL_MAP.architect ?? []),
+		].sort();
 
 		// Remove 'Task (delegation)' from prompt tools — it's the built-in delegation tool, not in AGENT_TOOL_MAP
 		const promptToolsWithoutTask = promptTools

--- a/tests/unit/agents/capability-drift-guard.test.ts
+++ b/tests/unit/agents/capability-drift-guard.test.ts
@@ -4,6 +4,8 @@ import {
 	AGENT_TOOL_MAP,
 	type AgentName,
 	ALL_SUBAGENT_NAMES,
+	COUNCIL_AGENT_TOOL_MAP,
+	GENERAL_COUNCIL_AGENT_TOOL_MAP,
 	ORCHESTRATOR_NAME,
 	TOOL_DESCRIPTIONS,
 	WRITE_TOOL_NAMES,
@@ -65,7 +67,12 @@ function extractAvailableToolsNames(prompt: string): string[] {
 // ---------------------------------------------------------------------------
 // Shared setup: resolved architect prompt
 // ---------------------------------------------------------------------------
-const ARCHITECT_TOOL_COUNT = AGENT_TOOL_MAP.architect.length;
+const EXPECTED_ARCHITECT_TOOLS = [
+	...AGENT_TOOL_MAP.architect,
+	...(COUNCIL_AGENT_TOOL_MAP.architect ?? []),
+	...(GENERAL_COUNCIL_AGENT_TOOL_MAP.architect ?? []),
+];
+const ARCHITECT_TOOL_COUNT = EXPECTED_ARCHITECT_TOOLS.length;
 
 // Render with both councils enabled so the full AGENT_TOOL_MAP.architect
 // surface (including `submit_council_verdicts`, `declare_council_criteria`, AND
@@ -90,14 +97,14 @@ const resolvedPrompt = (() => {
 describe('YOUR TOOLS prompt list matches AGENT_TOOL_MAP.architect', () => {
 	test('every tool in AGENT_TOOL_MAP.architect appears in YOUR TOOLS line', () => {
 		const yourTools = extractYourToolsNames(resolvedPrompt);
-		for (const tool of AGENT_TOOL_MAP.architect) {
+		for (const tool of EXPECTED_ARCHITECT_TOOLS) {
 			expect(yourTools).toContain(tool);
 		}
 	});
 
 	test('no tool appears in YOUR TOOLS that is NOT in AGENT_TOOL_MAP.architect (except Task delegation)', () => {
 		const yourTools = extractYourToolsNames(resolvedPrompt);
-		const mapSet = new Set<string>(AGENT_TOOL_MAP.architect);
+		const mapSet = new Set<string>(EXPECTED_ARCHITECT_TOOLS);
 		for (const tool of yourTools) {
 			expect(
 				mapSet.has(tool),
@@ -118,7 +125,7 @@ describe('YOUR TOOLS prompt list matches AGENT_TOOL_MAP.architect', () => {
 describe('Available Tools prompt list matches AGENT_TOOL_MAP.architect', () => {
 	test('every tool in AGENT_TOOL_MAP.architect appears in Available Tools section', () => {
 		const availableTools = extractAvailableToolsNames(resolvedPrompt);
-		for (const tool of AGENT_TOOL_MAP.architect) {
+		for (const tool of EXPECTED_ARCHITECT_TOOLS) {
 			expect(availableTools).toContain(tool);
 		}
 	});
@@ -227,6 +234,8 @@ describe('No unknown agents in AGENT_TOOL_MAP', () => {
 			'council_generalist',
 			'council_skeptic',
 			'council_domain_expert',
+			'curator_postmortem',
+			'curator_consolidation',
 		]);
 
 		for (const subagent of ALL_SUBAGENT_NAMES) {

--- a/tests/unit/agents/factory.test.ts
+++ b/tests/unit/agents/factory.test.ts
@@ -25,9 +25,9 @@ afterEach(() => {
 
 describe('createAgents', () => {
 	describe('no config', () => {
-		it('returns 17 agents (docs enabled by default, designer opt-in)', () => {
+		it('returns 20 agents (docs enabled by default, designer opt-in)', () => {
 			const agents = createAgents();
-			expect(agents).toHaveLength(17);
+			expect(agents).toHaveLength(20);
 		});
 
 		it('agent names are correct', () => {
@@ -42,10 +42,13 @@ describe('createAgents', () => {
 				'critic_hallucination_verifier',
 				'critic_oversight',
 				'critic_sounding_board',
+				'curator_consolidation',
 				'curator_init',
 				'curator_phase',
+				'curator_postmortem',
 				'docs',
 				'explorer',
+				'researcher',
 				'reviewer',
 				'skill_improver',
 				'sme',
@@ -376,8 +379,8 @@ describe('createAgents', () => {
 			const agents = createAgents(config as unknown as PluginConfig);
 			const sme = agents.find((a) => a.name === 'sme');
 			expect(sme).toBeUndefined();
-			// 17 agents - 1 disabled = 16 agents (docs still included by default)
-			expect(agents).toHaveLength(16);
+			// 20 agents - 1 disabled = 19 agents (docs still included by default)
+			expect(agents).toHaveLength(19);
 		});
 	});
 
@@ -400,10 +403,13 @@ describe('createAgents', () => {
 				'critic_hallucination_verifier',
 				'critic_oversight',
 				'critic_sounding_board',
+				'curator_consolidation',
 				'curator_init',
 				'curator_phase',
+				'curator_postmortem',
 				'docs',
 				'explorer',
+				'researcher',
 				'reviewer',
 				'skill_improver',
 				'sme',
@@ -433,10 +439,13 @@ describe('createAgents', () => {
 				'local_critic_hallucination_verifier',
 				'local_critic_oversight',
 				'local_critic_sounding_board',
+				'local_curator_consolidation',
 				'local_curator_init',
 				'local_curator_phase',
+				'local_curator_postmortem',
 				'local_docs',
 				'local_explorer',
+				'local_researcher',
 				'local_reviewer',
 				'local_skill_improver',
 				'local_sme',
@@ -769,7 +778,7 @@ describe('getAgentConfigs', () => {
 
 		const configs = getAgentConfigs(config as unknown as PluginConfig);
 		expect(configs.sme).toBeUndefined();
-		// 17 agents - 1 disabled = 16 agents (docs included by default)
-		expect(Object.keys(configs)).toHaveLength(16);
+		// 20 agents - 1 disabled = 19 agents (docs included by default)
+		expect(Object.keys(configs)).toHaveLength(19);
 	});
 });

--- a/tests/unit/agents/read-only-lane-guidance.test.ts
+++ b/tests/unit/agents/read-only-lane-guidance.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { createArchitectAgent } from '../../../src/agents/architect';
+import { createCoderAgent } from '../../../src/agents/coder';
 import {
 	DOMAIN_EXPERT_COUNCIL_PROMPT,
 	GENERALIST_COUNCIL_PROMPT,
@@ -106,5 +107,21 @@ describe('web research ownership wording', () => {
 		expect(section).toContain(
 			'SME and researcher prompts may use `web_search`',
 		);
+	});
+});
+
+describe('write-capable agents do not receive read-only lane guidance', () => {
+	test('coder agent prompt excludes read-only lane guidance', () => {
+		const prompt = createCoderAgent('test-model').config.prompt ?? '';
+		expect(prompt).not.toContain('READ-ONLY ADVISORY LANE CONTEXT');
+	});
+
+	test('architect agent prompt excludes read-only lane guidance', () => {
+		const prompt =
+			createArchitectAgent('test-model', undefined, undefined, undefined, {
+				enabled: true,
+				general: { enabled: true },
+			}).config.prompt ?? '';
+		expect(prompt).not.toContain('READ-ONLY ADVISORY LANE CONTEXT');
 	});
 });

--- a/tests/unit/agents/read-only-lane-guidance.test.ts
+++ b/tests/unit/agents/read-only-lane-guidance.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'bun:test';
+import { createArchitectAgent } from '../../../src/agents/architect';
+import {
+	DOMAIN_EXPERT_COUNCIL_PROMPT,
+	GENERALIST_COUNCIL_PROMPT,
+	SKEPTIC_COUNCIL_PROMPT,
+} from '../../../src/agents/council-prompts';
+import {
+	AUTONOMOUS_OVERSIGHT_PROMPT,
+	createCriticAgent,
+} from '../../../src/agents/critic';
+import { createExplorerAgent } from '../../../src/agents/explorer';
+import { createResearcherAgent } from '../../../src/agents/researcher';
+import { createReviewerAgent } from '../../../src/agents/reviewer';
+import { createSMEAgent } from '../../../src/agents/sme';
+
+const laneGuidanceNeedles = [
+	'READ-ONLY ADVISORY LANE CONTEXT',
+	'dispatch_lanes',
+	'dispatch_lanes_async',
+	'knowledge_add',
+	'doc_scan',
+	'Return findings for the architect to synthesize',
+];
+
+function expectLaneGuidance(prompt: string): void {
+	for (const needle of laneGuidanceNeedles) {
+		expect(prompt).toContain(needle);
+	}
+}
+
+describe('read-only lane prompt guidance', () => {
+	test('lane-capable standard agents mention read-only lane restrictions', () => {
+		const prompts = [
+			createExplorerAgent('test-model').config.prompt ?? '',
+			createReviewerAgent('test-model').config.prompt ?? '',
+			createSMEAgent('test-model').config.prompt ?? '',
+			createResearcherAgent('test-model').config.prompt ?? '',
+		];
+
+		for (const prompt of prompts) {
+			expectLaneGuidance(prompt);
+		}
+	});
+
+	test('lane-capable critic variants mention read-only lane restrictions', () => {
+		const prompts = [
+			createCriticAgent('test-model', undefined, undefined, 'plan_critic')
+				.config.prompt ?? '',
+			createCriticAgent('test-model', undefined, undefined, 'sounding_board')
+				.config.prompt ?? '',
+			createCriticAgent(
+				'test-model',
+				undefined,
+				undefined,
+				'phase_drift_verifier',
+			).config.prompt ?? '',
+			createCriticAgent(
+				'test-model',
+				undefined,
+				undefined,
+				'hallucination_verifier',
+			).config.prompt ?? '',
+			createCriticAgent(
+				'test-model',
+				undefined,
+				undefined,
+				'architecture_supervisor',
+			).config.prompt ?? '',
+			AUTONOMOUS_OVERSIGHT_PROMPT,
+		];
+
+		for (const prompt of prompts) {
+			expectLaneGuidance(prompt);
+		}
+	});
+
+	test('council lane prompts keep no-tools rule and mention lane restrictions', () => {
+		for (const prompt of [
+			GENERALIST_COUNCIL_PROMPT,
+			SKEPTIC_COUNCIL_PROMPT,
+			DOMAIN_EXPERT_COUNCIL_PROMPT,
+		]) {
+			expect(prompt).toContain('You have no tools');
+			expectLaneGuidance(prompt);
+		}
+	});
+});
+
+describe('web research ownership wording', () => {
+	test('DEEP_RESEARCH scopes architect ownership to mode-specific web_fetch coordination', () => {
+		const prompt =
+			createArchitectAgent('test-model', undefined, undefined, undefined, {
+				enabled: true,
+				general: { enabled: true },
+			}).config.prompt ?? '';
+		const deepResearchStart = prompt.indexOf('### MODE: DEEP_RESEARCH');
+		const codebaseReviewStart = prompt.indexOf('### MODE: CODEBASE_REVIEW');
+		expect(deepResearchStart).toBeGreaterThan(-1);
+		expect(codebaseReviewStart).toBeGreaterThan(deepResearchStart);
+		const section = prompt.slice(deepResearchStart, codebaseReviewStart);
+
+		expect(section).toContain('In MODE: DEEP_RESEARCH');
+		expect(section).toContain('own `web_fetch`');
+		expect(section).toContain('Outside DEEP_RESEARCH');
+		expect(section).toContain(
+			'SME and researcher prompts may use `web_search`',
+		);
+	});
+});

--- a/tests/unit/config/execution-profile-schema.test.ts
+++ b/tests/unit/config/execution-profile-schema.test.ts
@@ -13,7 +13,7 @@ describe('ExecutionProfileSchema', () => {
 			if (!result.success) return;
 			const profile: ExecutionProfile = result.data;
 			expect(profile.parallelization_enabled).toBe(false);
-			expect(profile.max_concurrent_tasks).toBe(1);
+			expect(profile.max_concurrent_tasks).toBe(10);
 			expect(profile.council_parallel).toBe(true);
 			expect(profile.locked).toBe(false);
 			expect(profile.auto_proceed).toBe(false);

--- a/tests/unit/tools/save-plan-execution-profile.test.ts
+++ b/tests/unit/tools/save-plan-execution-profile.test.ts
@@ -77,7 +77,7 @@ describe('execution_profile: setting a profile on a new plan', () => {
 		const result = await executeSavePlan(args);
 		expect(result.success).toBe(true);
 		expect(result.execution_profile?.parallelization_enabled).toBe(true);
-		expect(result.execution_profile?.max_concurrent_tasks).toBe(1);
+		expect(result.execution_profile?.max_concurrent_tasks).toBe(10);
 		expect(result.execution_profile?.locked).toBe(false);
 	});
 

--- a/tests/unit/tools/save-plan-execution-profile.test.ts
+++ b/tests/unit/tools/save-plan-execution-profile.test.ts
@@ -460,3 +460,29 @@ describe('execution_profile: disk round-trip', () => {
 		expect(planData.execution_profile?.auto_proceed).toBe(false);
 	});
 });
+
+describe('F-002: explicit max_concurrent_tasks:1 is preserved (backward-compat)', () => {
+	test('explicit max_concurrent_tasks:1 survives save and disk round-trip', async () => {
+		const profile = {
+			parallelization_enabled: true,
+			max_concurrent_tasks: 1,
+		};
+		const result = await executeSavePlan(
+			makeArgs({ working_directory: tmpDir, execution_profile: profile }),
+		);
+
+		// Assert result carries the explicit 1 (not coerced to default 10)
+		expect(result.success).toBe(true);
+		expect(result.execution_profile?.max_concurrent_tasks).toBe(1);
+
+		// Assert disk persistence also preserves 1 (not coerced on write)
+		const planJson = await readFile(
+			join(tmpDir, '.swarm', 'plan.json'),
+			'utf8',
+		);
+		const planData = JSON.parse(planJson) as {
+			execution_profile?: { max_concurrent_tasks?: number };
+		};
+		expect(planData.execution_profile?.max_concurrent_tasks).toBe(1);
+	});
+});


### PR DESCRIPTION
Closes #1445

## Summary
- Added shared read-only advisory-lane guidance to lane-capable agents, critic variants, and General Council prompts so denied mutating tools are treated as intentional lane constraints.
- Scoped architect DEEP_RESEARCH web ownership to that mode, kept `web_fetch` architect-owned, and clarified compatibility marker labels that looked stale.
- Updated prompt/tool-map drift guards for current opt-in council maps, current default agent registrations, extracted skill fixtures, and `execution_profile` defaults in docs/tool schema/tests.

## Invariant audit
- 1 (plugin init): not touched - no init-path code changed; `node scripts/repro-704.mjs` passed T1/T2/T3 after rebase.
- 2 (runtime portability): touched - runtime prompt/tool schema modules changed; `bun run build` passed and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` printed `dist import OK`.
- 3 (subprocesses): not touched - `Select-String` over changed `src/*` files for `bunSpawn(`, `spawn(`, and `spawnSync(` returned no matches.
- 4 (.swarm containment): not touched - no runtime state path logic changed; trace files stayed under ignored `.Codex/issue-traces/`.
- 5 (plan durability): touched - `execution_profile` public defaults were aligned across `src/tools/save-plan.ts`, plan docs, and plan skills; `bun --smol test tests/unit/config/execution-profile-schema.test.ts tests/unit/tools/save-plan-execution-profile.test.ts tests/unit/plan/ledger-execution-profile.test.ts tests/unit/config/plan-schema.test.ts --timeout 120000` passed 83 tests.
- 6 (test_runner safety): not touched - used shell/Bun commands only; no broad OpenCode `test_runner` scope used.
- 7 (test writing): touched - loaded writing-tests guidance before editing tests; new `read-only-lane-guidance.test.ts` uses `bun:test` and no `mock.module`.
- 8 (session state): not touched - no session/global state changed.
- 9 (guardrails/retry): not touched - no guardrail or retry code changed.
- 10 (chat/system msg): touched - agent prompt text changed; focused prompt tests passed and full `tests/unit/agents/*.test.ts` per-file loop passed.
- 11 (tool registration): touched - tool-map drift tests were updated for opt-in council maps; focused tool alignment tests passed, and `bun run drift:check` reported no drift.
- 12 (release/cache): touched - added `docs/releases/pending/1445-agent-prompt-drift.md`; `dist/` was generated by build but is ignored and not committed.

## Test plan
- [x] `bun --smol test tests/unit/agents/architect-hallucination-gate.test.ts tests/unit/agents/capability-drift-guard.test.ts tests/unit/agents/architect-tool-alignment.test.ts tests/unit/agents/architect-declare-scope-instruction.test.ts tests/unit/agents/architect-pre-phase-briefing.test.ts tests/unit/agents/read-only-lane-guidance.test.ts --timeout 120000`
- [x] `bun --smol test tests/unit/config/execution-profile-schema.test.ts tests/unit/tools/save-plan-execution-profile.test.ts tests/unit/plan/ledger-execution-profile.test.ts tests/unit/config/plan-schema.test.ts --timeout 120000`
- [x] Per-file isolation loop for `tests/unit/agents/*.test.ts`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bunx @biomejs/biome@2.3.14 ci .`
- [x] `bun run drift:check`
- [x] `node scripts/repro-704.mjs`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`

## Notes
- `tests/unit/config/quiet-config.test.ts` still has an unrelated isolated debug logger warning assertion failure.
- `tests/integration/save-plan-round-trip.test.ts` still has unrelated isolated re-save/evidence-gate failures.