### PR TITLE
feat(tools): add bounded external cli wrappers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -565,18 +565,32 @@ Added as the default structured search path for workspace pattern lookup. Replac
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `pattern` | `string` | required | Search pattern (literal or regex) |
-| `workspace` | `string` | required | Root directory to search |
+| `query` | `string` | required | Search query (literal or regex depending on `mode`) |
 | `mode` | `"literal" \| "regex"` | `"literal"` | Match mode |
-| `glob` | `string[]` | `[]` | Include globs (e.g. `["**/*.ts"]`) |
-| `exclude` | `string[]` | `[]` | Exclude globs |
-| `maxResults` | `number` | `100` | Hard cap on returned matches |
-| `maxLines` | `number` | `10` | Max lines per match snippet |
-| `context` | `number` | `0` | Surrounding lines per match (only when > 0) |
+| `include` | `string` | unset | Comma-separated include globs (e.g. `"src/**/*.ts"`) |
+| `exclude` | `string` | unset | Comma-separated exclude globs |
+| `max_results` | `number` | `100` | Hard cap on returned matches |
+| `max_lines` | `number` | `200` | Max characters per matched line |
 
-Returns structured JSON with `file`, `line`, `text`, and `truncated` fields per hit. Falls back to a graceful error when ripgrep is unavailable. **Not a structural AST search** — combine with `symbols` and `imports` for full module analysis.
+Returns structured JSON with normalized match metadata. **Not a structural AST search** — use `ast_grep` for syntax-aware pattern matching, or combine with `symbols` and `imports` for full module analysis.
 
 **Registered for**: architect, coder, reviewer, explorer, test_engineer.
+
+Current output includes `matches[].file`, `matches[].lineNumber`, `matches[].lineText`, `truncated`, `total`, `query`, `mode`, `maxResults`, and `engine`. The ripgrep path uses a bounded subprocess runner with explicit `cwd`, ignored stdin, timeout, capped stdout/stderr, and cleanup. Its argv places options and globs before `--`, then the query and `.` path operand, so dash-prefixed queries cannot become flags. If ripgrep is unavailable, the fallback engine performs bounded filesystem traversal, skips heavy runtime directories such as `.git`, `.swarm`, `node_modules`, build outputs, and coverage directories, and discloses that it does not fully emulate ripgrep gitignore semantics.
+
+### Structural AST Search Tool - `ast_grep`
+
+Read-only structural search using the ast-grep CLI. The tool resolves `ast-grep` or `sg` lazily at call time, never during plugin initialization, and runs `ast-grep run --pattern <pattern> --json=stream` through the bounded external-tool runner. It supports optional `language`, comma-separated `include` and `exclude` globs, and `max_results`. Output normalizes ast-grep's JSON stream into workspace-relative `matches[]` entries with 1-based line and column numbers. It does not rewrite files.
+
+### External QA CLI Tools
+
+Three read-only wrappers expose high-yield external project checks without adding plugin-init probes or package dependencies:
+
+- `actionlint_scan` runs `actionlint -format '{{json .}}'` against `.github/workflows/**/*.yml,yaml` or explicit workspace-relative workflow files, returning structured findings.
+- `osv_scan` runs `osv-scanner scan --format json <path>` against a workspace-relative path and normalizes OSV vulnerability records.
+- `gh_evidence` runs `gh pr view` or `gh issue view` with a bounded JSON field allowlist for review and CI evidence.
+
+All three tools resolve their executable lazily at call time and share the bounded external-tool runner: explicit `cwd`, ignored stdin, timeout, capped stdout/stderr, and best-effort cleanup. Missing binaries return structured guidance instead of failing plugin registration.
 
 ### Reviewer-Safe Patch Suggestion Tool — `suggest_patch` (v6.45.0)
 

--- a/docs/releases/pending/search-ripgrep-runner-hardening.md
+++ b/docs/releases/pending/search-ripgrep-runner-hardening.md
@@ -1,0 +1,7 @@
+# Search ripgrep runner hardening
+
+Hardened the `search` tool's ripgrep execution path so it uses an explicit working directory, ignored stdin, bounded stdout/stderr, a concrete timeout, and best-effort cleanup through a shared external-tool runner.
+
+The Node fallback search now uses bounded traversal, default skips for heavy runtime directories, realpath-based containment checks, and a warning that fallback behavior does not fully emulate ripgrep gitignore semantics.
+
+Added read-only `ast_grep`, `actionlint_scan`, `osv_scan`, and `gh_evidence` tools that run structural search, GitHub Actions linting, OSV dependency scanning, and bounded GitHub evidence collection through the same bounded external-tool runner, with lazy binary resolution, workspace-relative output normalization where applicable, and structured missing-binary guidance.

--- a/src/tools/actionlint-scan.ts
+++ b/src/tools/actionlint-scan.ts
@@ -1,0 +1,377 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { ToolDefinition } from '@opencode-ai/plugin/tool';
+import { z } from 'zod';
+import {
+	resolveExecutableFromPath,
+	runExternalTool,
+} from '../utils/external-tool-runner';
+import {
+	containsControlChars,
+	containsPathTraversal,
+} from '../utils/path-security';
+import { createSwarmTool } from './create-tool';
+
+const ACTIONLINT_TIMEOUT_MS = 15_000;
+const ACTIONLINT_MAX_STDOUT_BYTES = 4 * 1024 * 1024;
+const ACTIONLINT_MAX_STDERR_BYTES = 128 * 1024;
+const DEFAULT_MAX_RESULTS = 200;
+const HARD_CAP_RESULTS = 2_000;
+const MAX_WORKFLOW_FILES = 500;
+const MAX_WORKFLOW_DIRS = 200;
+const MAX_WORKFLOW_DEPTH = 20;
+
+interface ActionlintFinding {
+	file: string;
+	line: number;
+	column: number;
+	kind: string;
+	message: string;
+	endColumn?: number;
+}
+
+interface ActionlintResult {
+	clean: boolean;
+	findings: ActionlintFinding[];
+	total: number;
+	truncated: boolean;
+	files: string[];
+	command: string[];
+	outputTruncated?: boolean;
+	note?: string;
+}
+
+interface WorkflowDiscoveryResult {
+	files: string[];
+	truncated: boolean;
+}
+
+interface ActionlintError {
+	error: true;
+	type:
+		| 'actionlint-not-found'
+		| 'invalid-input'
+		| 'path-escape'
+		| 'timeout'
+		| 'unknown';
+	message: string;
+}
+
+function resolveActionlintBinary(): string | null {
+	return _internals.resolveExecutableFromPath(['actionlint']);
+}
+
+function normalizeRelativeWorkflowFile(
+	file: string,
+	workspace: string,
+): string | null {
+	if (!file || containsControlChars(file) || containsPathTraversal(file)) {
+		return null;
+	}
+	if (path.isAbsolute(file) || /^[A-Za-z]:[/\\]/.test(file)) {
+		return null;
+	}
+	const normalizedInput = file
+		.split(/[\\/]+/)
+		.filter(Boolean)
+		.join(path.sep);
+	if (!/\.(ya?ml)$/i.test(normalizedInput)) {
+		return null;
+	}
+	try {
+		const realWorkspace = fs.realpathSync(workspace);
+		const resolved = path.resolve(realWorkspace, normalizedInput);
+		const realFile = fs.realpathSync(resolved);
+		const relative = path.relative(realWorkspace, realFile);
+		if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+			return null;
+		}
+		return relative.split(path.sep).join('/');
+	} catch {
+		return null;
+	}
+}
+
+function discoverWorkflowFiles(workspace: string): WorkflowDiscoveryResult {
+	const root = path.join(workspace, '.github', 'workflows');
+	if (!fs.existsSync(root)) return { files: [], truncated: false };
+	const files: string[] = [];
+	let dirCount = 0;
+	let truncated = false;
+
+	const visit = (dir: string, depth = 0) => {
+		if (
+			files.length >= MAX_WORKFLOW_FILES ||
+			dirCount >= MAX_WORKFLOW_DIRS ||
+			depth > MAX_WORKFLOW_DEPTH
+		) {
+			truncated = true;
+			return;
+		}
+		dirCount++;
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(dir, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			if (files.length >= MAX_WORKFLOW_FILES || dirCount >= MAX_WORKFLOW_DIRS) {
+				truncated = true;
+				break;
+			}
+			const full = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				visit(full, depth + 1);
+			} else if (entry.isFile() && /\.(ya?ml)$/i.test(entry.name)) {
+				const rel = normalizeRelativeWorkflowFile(
+					path.relative(workspace, full),
+					workspace,
+				);
+				if (rel) files.push(rel);
+			}
+		}
+	};
+
+	visit(root);
+	return { files, truncated };
+}
+
+function parseActionlintOutput(
+	stdout: string,
+	workspace: string,
+	maxResults: number,
+): { findings: ActionlintFinding[]; total: number } {
+	const findings: ActionlintFinding[] = [];
+	let total = 0;
+
+	for (const line of stdout.split('\n')) {
+		if (!line.trim()) continue;
+		try {
+			const entry = JSON.parse(line);
+			const file =
+				typeof entry.filepath === 'string'
+					? normalizeRelativeWorkflowFile(
+							path.isAbsolute(entry.filepath)
+								? path.relative(workspace, entry.filepath)
+								: entry.filepath,
+							workspace,
+						)
+					: null;
+			if (!file) continue;
+			total++;
+			if (findings.length >= maxResults) continue;
+			findings.push({
+				file,
+				line: typeof entry.line === 'number' ? entry.line : 1,
+				column: typeof entry.column === 'number' ? entry.column : 1,
+				kind: typeof entry.kind === 'string' ? entry.kind : 'unknown',
+				message: typeof entry.message === 'string' ? entry.message : '',
+				endColumn:
+					typeof entry.end_column === 'number' ? entry.end_column : undefined,
+			});
+		} catch {
+			// Ignore malformed lines from mixed stdout.
+		}
+	}
+
+	return { findings, total };
+}
+
+function sanitizeMaxResults(value: unknown): number {
+	const numeric =
+		typeof value === 'number' && Number.isFinite(value)
+			? value
+			: DEFAULT_MAX_RESULTS;
+	return Math.min(Math.max(0, numeric), HARD_CAP_RESULTS);
+}
+
+export const actionlint_scan: ToolDefinition = createSwarmTool({
+	description:
+		'Run actionlint against GitHub Actions workflow YAML files and return structured findings. Read-only; resolves actionlint lazily.',
+	args: {
+		files: z
+			.array(z.string())
+			.optional()
+			.describe(
+				'Optional workspace-relative workflow YAML files. Defaults to .github/workflows/**/*.yml,yaml.',
+			),
+		max_results: z
+			.number()
+			.default(DEFAULT_MAX_RESULTS)
+			.describe('Maximum findings to return'),
+	},
+	execute: async (args: unknown, directory: string) => {
+		const obj = (
+			typeof args === 'object' && args !== null ? args : {}
+		) as Record<string, unknown>;
+		const maxResults = sanitizeMaxResults(obj.max_results);
+		const requestedFiles = Array.isArray(obj.files) ? obj.files : undefined;
+		if (requestedFiles?.some((f) => typeof f !== 'string')) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'invalid-input',
+					message: 'files must be an array of strings',
+				} satisfies ActionlintError,
+				null,
+				2,
+			);
+		}
+
+		const discovery = requestedFiles
+			? {
+					files: requestedFiles
+						.map((f) => normalizeRelativeWorkflowFile(f, directory))
+						.filter((f): f is string => Boolean(f)),
+					truncated: false,
+				}
+			: _internals.discoverWorkflowFiles(directory);
+		let files = discovery.files;
+
+		if (requestedFiles && files.length !== requestedFiles.length) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'path-escape',
+					message:
+						'files must be existing workspace-relative GitHub Actions YAML files',
+				} satisfies ActionlintError,
+				null,
+				2,
+			);
+		}
+		const uniqueFiles = Array.from(new Set(files));
+		const cappedFiles = uniqueFiles.slice(0, MAX_WORKFLOW_FILES);
+		const discoveryTruncated =
+			discovery.truncated || uniqueFiles.length > cappedFiles.length;
+		files = cappedFiles;
+
+		if (files.length === 0) {
+			return JSON.stringify(
+				{
+					clean: !discoveryTruncated,
+					findings: [],
+					total: 0,
+					truncated: discoveryTruncated,
+					files: [],
+					command: ['actionlint', '-format', '{{json .}}'],
+					note: discoveryTruncated
+						? `Workflow discovery was truncated at ${MAX_WORKFLOW_FILES} files, ${MAX_WORKFLOW_DIRS} directories, or depth ${MAX_WORKFLOW_DEPTH}; result is incomplete.`
+						: 'No GitHub Actions workflow YAML files found',
+				} satisfies ActionlintResult,
+				null,
+				2,
+			);
+		}
+
+		const executable = _internals.resolveActionlintBinary();
+		if (!executable) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'actionlint-not-found',
+					message:
+						'actionlint executable not found. Install actionlint and ensure it is on PATH.',
+				} satisfies ActionlintError,
+				null,
+				2,
+			);
+		}
+
+		const lintArgs = [
+			'-format',
+			'{{json .}}',
+			...files.map((file) => `./${file}`),
+		];
+		const run = await _internals.runExternalTool({
+			executable,
+			args: lintArgs,
+			cwd: directory,
+			timeoutMs: ACTIONLINT_TIMEOUT_MS,
+			maxStdoutBytes: ACTIONLINT_MAX_STDOUT_BYTES,
+			maxStderrBytes: ACTIONLINT_MAX_STDERR_BYTES,
+		});
+
+		if (run.status === 'timeout') {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'timeout',
+					message: `actionlint timed out after ${ACTIONLINT_TIMEOUT_MS}ms`,
+				} satisfies ActionlintError,
+				null,
+				2,
+			);
+		}
+		if (run.status === 'spawn-error') {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'unknown',
+					message: run.message ?? 'actionlint failed to start',
+				} satisfies ActionlintError,
+				null,
+				2,
+			);
+		}
+
+		const { findings, total } = parseActionlintOutput(
+			run.stdout,
+			directory,
+			maxResults,
+		);
+		const hardError = run.exitCode !== 0 && findings.length === 0 && run.stderr;
+		if (hardError) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'unknown',
+					message: run.stderr.split('\n')[0],
+				} satisfies ActionlintError,
+				null,
+				2,
+			);
+		}
+
+		return JSON.stringify(
+			{
+				findings,
+				total,
+				truncated:
+					discoveryTruncated ||
+					total > maxResults ||
+					run.stdoutTruncated ||
+					run.stderrTruncated,
+				files,
+				command: ['actionlint', ...lintArgs],
+				outputTruncated: run.stdoutTruncated || run.stderrTruncated,
+				clean:
+					findings.length === 0 &&
+					total === 0 &&
+					!discoveryTruncated &&
+					!run.stdoutTruncated &&
+					!run.stderrTruncated,
+				note: discoveryTruncated
+					? `Workflow discovery was truncated at ${MAX_WORKFLOW_FILES} files, ${MAX_WORKFLOW_DIRS} directories, or depth ${MAX_WORKFLOW_DEPTH}; result is incomplete.`
+					: undefined,
+			} satisfies ActionlintResult,
+			null,
+			2,
+		);
+	},
+});
+
+export const _internals: {
+	resolveExecutableFromPath: typeof resolveExecutableFromPath;
+	resolveActionlintBinary: typeof resolveActionlintBinary;
+	runExternalTool: typeof runExternalTool;
+	discoverWorkflowFiles: typeof discoverWorkflowFiles;
+	parseActionlintOutput: typeof parseActionlintOutput;
+} = {
+	resolveExecutableFromPath,
+	resolveActionlintBinary,
+	runExternalTool,
+	discoverWorkflowFiles,
+	parseActionlintOutput,
+};

--- a/src/tools/ast-grep.test.ts
+++ b/src/tools/ast-grep.test.ts
@@ -154,10 +154,11 @@ describe('ast_grep', () => {
 
 	test('normalizes malformed and outside-workspace JSON stream entries', async () => {
 		createTestFile('src/inside.ts', 'const value = 1\n');
-		const outsideDir = realpathSync(
-			mkdtempSync(path.join(os.tmpdir(), 'ast-grep-outside-')),
-		);
+		let outsideDir: string | undefined;
 		try {
+			outsideDir = realpathSync(
+				mkdtempSync(path.join(os.tmpdir(), 'ast-grep-outside-')),
+			);
 			writeFileSync(path.join(outsideDir, 'outside.ts'), 'const value = 2\n');
 			_internals.resolveAstGrepBinary = () => 'ast-grep';
 			_internals.runExternalTool = mock(async () => ({
@@ -197,7 +198,7 @@ describe('ast_grep', () => {
 			]);
 			expect(parsed.total).toBe(1);
 		} finally {
-			rmSync(outsideDir, { recursive: true, force: true });
+			if (outsideDir) rmSync(outsideDir, { recursive: true, force: true });
 		}
 	});
 });

--- a/src/tools/ast-grep.test.ts
+++ b/src/tools/ast-grep.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+	mkdirSync,
+	mkdtempSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ToolContext } from '@opencode-ai/plugin';
+import { _internals, ast_grep } from './ast-grep';
+import type { ToolResult } from './create-tool';
+
+function resultToString(result: ToolResult): string {
+	return typeof result === 'string' ? result : result.output;
+}
+
+async function executeAstGrep(
+	args: Record<string, unknown>,
+	directory: string,
+): Promise<string> {
+	const result = await ast_grep.execute(args, {
+		directory,
+	} as unknown as ToolContext);
+	return resultToString(result);
+}
+
+let tmpDir: string;
+const realResolveAstGrepBinary = _internals.resolveAstGrepBinary;
+const realRunExternalTool = _internals.runExternalTool;
+
+beforeEach(() => {
+	tmpDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'ast-grep-test-')));
+	mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+});
+
+afterEach(() => {
+	_internals.resolveAstGrepBinary = realResolveAstGrepBinary;
+	_internals.runExternalTool = realRunExternalTool;
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function createTestFile(relativePath: string, content: string): void {
+	const fullPath = path.join(tmpDir, relativePath);
+	mkdirSync(path.dirname(fullPath), { recursive: true });
+	writeFileSync(fullPath, content);
+}
+
+describe('ast_grep', () => {
+	test('returns structured missing-binary guidance', async () => {
+		_internals.resolveAstGrepBinary = () => null;
+
+		const result = await executeAstGrep({ pattern: 'console.log($A)' }, tmpDir);
+		const parsed = JSON.parse(result);
+
+		expect(parsed.error).toBe(true);
+		expect(parsed.type).toBe('ast-grep-not-found');
+		expect(parsed.message).toContain('Install ast-grep');
+	});
+
+	test('uses bounded runner options and safe ast-grep argv', async () => {
+		createTestFile('src/app.ts', 'console.log(value)\n');
+		const executable = path.join(
+			tmpDir,
+			process.platform === 'win32' ? 'ast-grep.exe' : 'ast-grep',
+		);
+		let captured: Parameters<typeof realRunExternalTool>[0] | undefined;
+
+		_internals.resolveAstGrepBinary = () => executable;
+		_internals.runExternalTool = mock(async (options) => {
+			captured = options;
+			return {
+				status: 'completed',
+				exitCode: 0,
+				stdout: `${JSON.stringify({
+					file: path.join(tmpDir, 'src', 'app.ts'),
+					range: {
+						start: { line: 0, column: 0 },
+						end: { line: 0, column: 18 },
+					},
+					text: 'console.log(value)',
+					lines: 'console.log(value)\n',
+					language: 'TypeScript',
+					metaVariables: { single: { A: { text: 'value' } } },
+				})}\n`,
+				stderr: '',
+				stdoutTruncated: false,
+				stderrTruncated: false,
+			};
+		}) as typeof realRunExternalTool;
+
+		const result = await executeAstGrep(
+			{
+				pattern: 'console.log($A)',
+				language: 'ts',
+				include: 'src/**/*.ts',
+				exclude: '**/*.test.ts',
+				max_results: 5,
+			},
+			tmpDir,
+		);
+		const parsed = JSON.parse(result);
+
+		expect(captured).toBeDefined();
+		expect(captured?.executable).toBe(executable);
+		expect(captured?.cwd).toBe(tmpDir);
+		expect(captured?.timeoutMs).toBe(10000);
+		expect(captured?.args).toEqual([
+			'run',
+			'--pattern',
+			'console.log($A)',
+			'--json=stream',
+			'--color',
+			'never',
+			'--lang',
+			'ts',
+			'--globs',
+			'src/**/*.ts',
+			'--globs',
+			'!**/*.test.ts',
+			'.',
+		]);
+		expect(parsed.matches).toEqual([
+			{
+				file: 'src/app.ts',
+				lineNumber: 1,
+				column: 1,
+				endLineNumber: 1,
+				endColumn: 19,
+				text: 'console.log(value)',
+				lines: 'console.log(value)',
+				language: 'TypeScript',
+				metaVariables: { single: { A: { text: 'value' } } },
+			},
+		]);
+		expect(parsed.truncated).toBe(false);
+		expect(parsed.total).toBe(1);
+	});
+
+	test('rejects invalid patterns and path traversal globs', async () => {
+		let result = await executeAstGrep({ pattern: '' }, tmpDir);
+		expect(JSON.parse(result).type).toBe('invalid-pattern');
+
+		result = await executeAstGrep(
+			{ pattern: '$A', include: '../outside/**' },
+			tmpDir,
+		);
+		expect(JSON.parse(result).type).toBe('path-escape');
+
+		result = await executeAstGrep({ pattern: '$A', language: '../ts' }, tmpDir);
+		expect(JSON.parse(result).type).toBe('invalid-pattern');
+	});
+
+	test('normalizes malformed and outside-workspace JSON stream entries', async () => {
+		createTestFile('src/inside.ts', 'const value = 1\n');
+		const outsideDir = realpathSync(
+			mkdtempSync(path.join(os.tmpdir(), 'ast-grep-outside-')),
+		);
+		try {
+			writeFileSync(path.join(outsideDir, 'outside.ts'), 'const value = 2\n');
+			_internals.resolveAstGrepBinary = () => 'ast-grep';
+			_internals.runExternalTool = mock(async () => ({
+				status: 'completed',
+				exitCode: 0,
+				stdout: [
+					'not json',
+					JSON.stringify({
+						file: path.join(outsideDir, 'outside.ts'),
+						range: {
+							start: { line: 0, column: 0 },
+							end: { line: 0, column: 1 },
+						},
+						text: 'const value = 2',
+						lines: 'const value = 2\n',
+					}),
+					JSON.stringify({
+						file: path.join(tmpDir, 'src', 'inside.ts'),
+						range: {
+							start: { line: 0, column: 0 },
+							end: { line: 0, column: 5 },
+						},
+						text: 'const',
+						lines: 'const value = 1\n',
+					}),
+				].join('\n'),
+				stderr: '',
+				stdoutTruncated: false,
+				stderrTruncated: false,
+			})) as typeof realRunExternalTool;
+
+			const result = await executeAstGrep({ pattern: 'const $A = $B' }, tmpDir);
+			const parsed = JSON.parse(result);
+
+			expect(parsed.matches.map((m: { file: string }) => m.file)).toEqual([
+				'src/inside.ts',
+			]);
+			expect(parsed.total).toBe(1);
+		} finally {
+			rmSync(outsideDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/tools/ast-grep.ts
+++ b/src/tools/ast-grep.ts
@@ -1,0 +1,368 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { ToolDefinition } from '@opencode-ai/plugin/tool';
+import { z } from 'zod';
+import {
+	resolveExecutableFromPath,
+	runExternalTool,
+} from '../utils/external-tool-runner';
+import {
+	containsControlChars,
+	containsPathTraversal,
+} from '../utils/path-security';
+import { createSwarmTool } from './create-tool';
+
+const AST_GREP_TIMEOUT_MS = 10_000;
+const AST_GREP_MAX_STDOUT_BYTES = 8 * 1024 * 1024;
+const AST_GREP_MAX_STDERR_BYTES = 64 * 1024;
+const DEFAULT_MAX_RESULTS = 100;
+const HARD_CAP_RESULTS = 10_000;
+const MAX_PATTERN_LENGTH = 20_000;
+
+interface AstGrepMatch {
+	file: string;
+	lineNumber: number;
+	column: number;
+	endLineNumber: number;
+	endColumn: number;
+	text: string;
+	lines: string;
+	language?: string;
+	metaVariables?: unknown;
+}
+
+interface AstGrepResult {
+	matches: AstGrepMatch[];
+	truncated: boolean;
+	total: number;
+	pattern: string;
+	language?: string;
+	maxResults: number;
+	outputTruncated?: boolean;
+}
+
+interface AstGrepError {
+	error: true;
+	type:
+		| 'ast-grep-not-found'
+		| 'invalid-pattern'
+		| 'path-escape'
+		| 'timeout'
+		| 'unknown';
+	message: string;
+}
+
+function splitGlobPatterns(value?: string): string[] {
+	return value
+		? value
+				.split(',')
+				.map((p) => p.trim())
+				.filter(Boolean)
+		: [];
+}
+
+function resolveAstGrepBinary(): string | null {
+	return _internals.resolveExecutableFromPath(['ast-grep', 'sg']);
+}
+
+function toWorkspaceRelativePath(
+	filePath: string,
+	workspace: string,
+): string | null {
+	try {
+		const resolved = path.resolve(workspace, filePath);
+		const realWorkspace = fs.realpathSync(workspace);
+		const realResolved = fs.realpathSync(resolved);
+		const relative = path.relative(realWorkspace, realResolved);
+		if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+			return null;
+		}
+		return relative.split(path.sep).join('/');
+	} catch {
+		return null;
+	}
+}
+
+function parseAstGrepStream(
+	stdout: string,
+	workspace: string,
+	maxResults: number,
+): { matches: AstGrepMatch[]; total: number } {
+	const matches: AstGrepMatch[] = [];
+	let total = 0;
+
+	for (const line of stdout.split('\n')) {
+		if (!line.trim()) continue;
+		try {
+			const entry = JSON.parse(line);
+			const relativePath =
+				typeof entry.file === 'string'
+					? toWorkspaceRelativePath(entry.file, workspace)
+					: null;
+			if (!relativePath) continue;
+
+			total++;
+			if (matches.length >= maxResults) continue;
+
+			const start = entry.range?.start ?? {};
+			const end = entry.range?.end ?? {};
+			matches.push({
+				file: relativePath,
+				lineNumber: typeof start.line === 'number' ? start.line + 1 : 1,
+				column: typeof start.column === 'number' ? start.column + 1 : 1,
+				endLineNumber: typeof end.line === 'number' ? end.line + 1 : 1,
+				endColumn: typeof end.column === 'number' ? end.column + 1 : 1,
+				text: typeof entry.text === 'string' ? entry.text : '',
+				lines: typeof entry.lines === 'string' ? entry.lines.trimEnd() : '',
+				language:
+					typeof entry.language === 'string' ? entry.language : undefined,
+				metaVariables:
+					entry.metaVariables && typeof entry.metaVariables === 'object'
+						? entry.metaVariables
+						: undefined,
+			});
+		} catch {
+			// Ignore malformed lines. ast-grep --json=stream emits one object per line.
+		}
+	}
+
+	return { matches, total };
+}
+
+function validateGlobArg(
+	kind: 'Include' | 'Exclude',
+	value?: string,
+): AstGrepError | null {
+	if (!value) return null;
+	if (containsControlChars(value)) {
+		return {
+			error: true,
+			type: 'path-escape',
+			message: `${kind} pattern contains invalid control characters`,
+		};
+	}
+	if (containsPathTraversal(value)) {
+		return {
+			error: true,
+			type: 'path-escape',
+			message: `${kind} pattern contains path traversal sequence`,
+		};
+	}
+	return null;
+}
+
+export const ast_grep: ToolDefinition = createSwarmTool({
+	description:
+		'Read-only structural AST search using ast-grep. Searches code patterns with optional language and glob filters; does not rewrite files.',
+	args: {
+		pattern: z.string().describe('ast-grep pattern to search for'),
+		language: z
+			.string()
+			.optional()
+			.describe('Optional ast-grep language, e.g. ts, tsx, js, py, rust'),
+		include: z
+			.string()
+			.optional()
+			.describe('Comma-separated include globs, passed to ast-grep --globs'),
+		exclude: z
+			.string()
+			.optional()
+			.describe('Comma-separated exclude globs, passed to ast-grep as !glob'),
+		max_results: z
+			.number()
+			.default(DEFAULT_MAX_RESULTS)
+			.describe('Maximum number of matches to return'),
+	},
+	execute: async (args: unknown, directory: string) => {
+		let pattern: string;
+		let language: string | undefined;
+		let include: string | undefined;
+		let exclude: string | undefined;
+		let maxResults = DEFAULT_MAX_RESULTS;
+
+		try {
+			const obj = args as Record<string, unknown>;
+			pattern = typeof obj.pattern === 'string' ? obj.pattern : '';
+			language = typeof obj.language === 'string' ? obj.language : undefined;
+			include = typeof obj.include === 'string' ? obj.include : undefined;
+			exclude = typeof obj.exclude === 'string' ? obj.exclude : undefined;
+			const rawMaxResults =
+				typeof obj.max_results === 'number'
+					? obj.max_results
+					: DEFAULT_MAX_RESULTS;
+			const sanitizedMaxResults = Number.isFinite(rawMaxResults)
+				? rawMaxResults
+				: DEFAULT_MAX_RESULTS;
+			maxResults = Math.min(Math.max(0, sanitizedMaxResults), HARD_CAP_RESULTS);
+		} catch {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'invalid-pattern',
+					message: 'Could not parse ast_grep arguments',
+				} satisfies AstGrepError,
+				null,
+				2,
+			);
+		}
+
+		if (!pattern || pattern.trim() === '') {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'invalid-pattern',
+					message: 'Pattern cannot be empty',
+				} satisfies AstGrepError,
+				null,
+				2,
+			);
+		}
+		if (pattern.length > MAX_PATTERN_LENGTH || containsControlChars(pattern)) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'invalid-pattern',
+					message: `Pattern is invalid or exceeds ${MAX_PATTERN_LENGTH} characters`,
+				} satisfies AstGrepError,
+				null,
+				2,
+			);
+		}
+		if (language && !/^[A-Za-z0-9_-]+$/.test(language)) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'invalid-pattern',
+					message: 'Language must contain only letters, numbers, _ or -',
+				} satisfies AstGrepError,
+				null,
+				2,
+			);
+		}
+
+		const includeError = validateGlobArg('Include', include);
+		if (includeError) return JSON.stringify(includeError, null, 2);
+		const excludeError = validateGlobArg('Exclude', exclude);
+		if (excludeError) return JSON.stringify(excludeError, null, 2);
+
+		if (!fs.existsSync(directory)) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'unknown',
+					message: 'Workspace directory does not exist',
+				} satisfies AstGrepError,
+				null,
+				2,
+			);
+		}
+
+		const executable = _internals.resolveAstGrepBinary();
+		if (!executable) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'ast-grep-not-found',
+					message:
+						'ast-grep executable not found. Install ast-grep and ensure ast-grep or sg is on PATH.',
+				} satisfies AstGrepError,
+				null,
+				2,
+			);
+		}
+
+		const sgArgs = [
+			'run',
+			'--pattern',
+			pattern,
+			'--json=stream',
+			'--color',
+			'never',
+		];
+		if (language) {
+			sgArgs.push('--lang', language);
+		}
+		for (const glob of splitGlobPatterns(include)) {
+			sgArgs.push('--globs', glob);
+		}
+		for (const glob of splitGlobPatterns(exclude)) {
+			sgArgs.push('--globs', `!${glob}`);
+		}
+		sgArgs.push('.');
+
+		const run = await _internals.runExternalTool({
+			executable,
+			args: sgArgs,
+			cwd: directory,
+			timeoutMs: AST_GREP_TIMEOUT_MS,
+			maxStdoutBytes: AST_GREP_MAX_STDOUT_BYTES,
+			maxStderrBytes: AST_GREP_MAX_STDERR_BYTES,
+		});
+
+		if (run.status === 'timeout') {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'timeout',
+					message: `ast-grep timed out after ${AST_GREP_TIMEOUT_MS}ms`,
+				} satisfies AstGrepError,
+				null,
+				2,
+			);
+		}
+		if (run.status === 'spawn-error') {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'unknown',
+					message: run.message ?? 'ast-grep failed to start',
+				} satisfies AstGrepError,
+				null,
+				2,
+			);
+		}
+		if (run.exitCode !== 0 && run.stderr) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'invalid-pattern',
+					message: run.stderr.split('\n')[0],
+				} satisfies AstGrepError,
+				null,
+				2,
+			);
+		}
+
+		const { matches, total } = parseAstGrepStream(
+			run.stdout,
+			directory,
+			maxResults,
+		);
+		return JSON.stringify(
+			{
+				matches,
+				truncated:
+					total > maxResults || run.stdoutTruncated || run.stderrTruncated,
+				total,
+				pattern,
+				language,
+				maxResults,
+				outputTruncated: run.stdoutTruncated || run.stderrTruncated,
+			} satisfies AstGrepResult,
+			null,
+			2,
+		);
+	},
+});
+
+export const _internals: {
+	resolveExecutableFromPath: typeof resolveExecutableFromPath;
+	resolveAstGrepBinary: typeof resolveAstGrepBinary;
+	runExternalTool: typeof runExternalTool;
+	parseAstGrepStream: typeof parseAstGrepStream;
+} = {
+	resolveExecutableFromPath,
+	resolveAstGrepBinary,
+	runExternalTool,
+	parseAstGrepStream,
+};

--- a/src/tools/external-cli-tools.test.ts
+++ b/src/tools/external-cli-tools.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+	mkdirSync,
+	mkdtempSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ToolContext } from '@opencode-ai/plugin';
+import {
+	actionlint_scan,
+	_internals as actionlintInternals,
+} from './actionlint-scan';
+import type { ToolResult } from './create-tool';
+import { gh_evidence, _internals as ghInternals } from './gh-evidence';
+import { osv_scan, _internals as osvInternals } from './osv-scan';
+
+function resultToString(result: ToolResult): string {
+	return typeof result === 'string' ? result : result.output;
+}
+
+async function executeTool(
+	tool: { execute: (args: unknown, ctx: ToolContext) => Promise<unknown> },
+	args: Record<string, unknown>,
+	directory: string,
+): Promise<Record<string, unknown>> {
+	const result = await tool.execute(args, {
+		directory,
+	} as unknown as ToolContext);
+	return JSON.parse(resultToString(result as ToolResult));
+}
+
+let tmpDir: string;
+const realResolveActionlintBinary = actionlintInternals.resolveActionlintBinary;
+const realRunActionlint = actionlintInternals.runExternalTool;
+const realDiscoverWorkflowFiles = actionlintInternals.discoverWorkflowFiles;
+const realResolveOsvScannerBinary = osvInternals.resolveOsvScannerBinary;
+const realRunOsv = osvInternals.runExternalTool;
+const realResolveGhBinary = ghInternals.resolveGhBinary;
+const realRunGh = ghInternals.runExternalTool;
+
+beforeEach(() => {
+	tmpDir = realpathSync(
+		mkdtempSync(path.join(os.tmpdir(), 'external-cli-test-')),
+	);
+});
+
+afterEach(() => {
+	actionlintInternals.resolveActionlintBinary = realResolveActionlintBinary;
+	actionlintInternals.runExternalTool = realRunActionlint;
+	actionlintInternals.discoverWorkflowFiles = realDiscoverWorkflowFiles;
+	osvInternals.resolveOsvScannerBinary = realResolveOsvScannerBinary;
+	osvInternals.runExternalTool = realRunOsv;
+	ghInternals.resolveGhBinary = realResolveGhBinary;
+	ghInternals.runExternalTool = realRunGh;
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function createTestFile(relativePath: string, content: string): void {
+	const fullPath = path.join(tmpDir, relativePath);
+	mkdirSync(path.dirname(fullPath), { recursive: true });
+	writeFileSync(fullPath, content);
+}
+
+describe('actionlint_scan', () => {
+	test('returns missing-binary guidance without probing during init', async () => {
+		createTestFile('.github/workflows/ci.yml', 'name: ci\n');
+		actionlintInternals.resolveActionlintBinary = () => null;
+
+		const parsed = await executeTool(actionlint_scan, {}, tmpDir);
+
+		expect(parsed.error).toBe(true);
+		expect(parsed.type).toBe('actionlint-not-found');
+		expect(String(parsed.message)).toContain('Install actionlint');
+	});
+
+	test('uses bounded runner argv and parses JSON findings', async () => {
+		createTestFile('.github/workflows/ci.yml', 'name: ci\n');
+		const executable = path.join(
+			tmpDir,
+			process.platform === 'win32' ? 'actionlint.exe' : 'actionlint',
+		);
+		let captured: Parameters<typeof realRunActionlint>[0] | undefined;
+		actionlintInternals.resolveActionlintBinary = () => executable;
+		actionlintInternals.runExternalTool = mock(async (options) => {
+			captured = options;
+			return {
+				status: 'completed',
+				exitCode: 1,
+				stdout: `${JSON.stringify({
+					filepath: path.join(tmpDir, '.github', 'workflows', 'ci.yml'),
+					line: 3,
+					column: 5,
+					end_column: 12,
+					kind: 'syntax-check',
+					message: 'bad workflow',
+				})}\n`,
+				stderr: '',
+				stdoutTruncated: false,
+				stderrTruncated: false,
+			};
+		}) as typeof realRunActionlint;
+
+		const parsed = await executeTool(
+			actionlint_scan,
+			{ max_results: 10 },
+			tmpDir,
+		);
+
+		expect(captured?.cwd).toBe(tmpDir);
+		expect(captured?.timeoutMs).toBe(15000);
+		expect(captured?.args).toEqual([
+			'-format',
+			'{{json .}}',
+			'./.github/workflows/ci.yml',
+		]);
+		expect(parsed.clean).toBe(false);
+		expect(parsed.total).toBe(1);
+		expect(parsed.findings).toEqual([
+			{
+				file: '.github/workflows/ci.yml',
+				line: 3,
+				column: 5,
+				endColumn: 12,
+				kind: 'syntax-check',
+				message: 'bad workflow',
+			},
+		]);
+	});
+
+	test('rejects unsafe requested workflow paths', async () => {
+		const parsed = await executeTool(
+			actionlint_scan,
+			{ files: ['../ci.yml'] },
+			tmpDir,
+		);
+
+		expect(parsed.error).toBe(true);
+		expect(parsed.type).toBe('path-escape');
+	});
+
+	test('does not report clean when workflow discovery is truncated', async () => {
+		actionlintInternals.discoverWorkflowFiles = () => ({
+			files: [],
+			truncated: true,
+		});
+
+		const parsed = await executeTool(actionlint_scan, {}, tmpDir);
+
+		expect(parsed.clean).toBe(false);
+		expect(parsed.truncated).toBe(true);
+		expect(String(parsed.note)).toContain('result is incomplete');
+	});
+});
+
+describe('osv_scan', () => {
+	test('uses bounded runner argv and parses OSV vulnerabilities', async () => {
+		const executable = path.join(
+			tmpDir,
+			process.platform === 'win32' ? 'osv-scanner.exe' : 'osv-scanner',
+		);
+		let captured: Parameters<typeof realRunOsv>[0] | undefined;
+		osvInternals.resolveOsvScannerBinary = () => executable;
+		osvInternals.runExternalTool = mock(async (options) => {
+			captured = options;
+			return {
+				status: 'completed',
+				exitCode: 1,
+				stdout: JSON.stringify({
+					results: [
+						{
+							packages: [
+								{
+									package: {
+										name: 'left-pad',
+										ecosystem: 'npm',
+										version: '1.0.0',
+									},
+									vulnerabilities: [
+										{
+											id: 'GHSA-test',
+											summary: 'test vuln',
+											aliases: ['CVE-2026-0001'],
+											references: [{ url: 'https://example.com/vuln' }],
+											groups: [{ fixed: ['1.0.1'] }],
+										},
+									],
+								},
+							],
+						},
+					],
+				}),
+				stderr: '',
+				stdoutTruncated: false,
+				stderrTruncated: false,
+			};
+		}) as typeof realRunOsv;
+
+		const parsed = await executeTool(osv_scan, {}, tmpDir);
+
+		expect(captured?.cwd).toBe(tmpDir);
+		expect(captured?.timeoutMs).toBe(60000);
+		expect(captured?.args).toEqual(['scan', '--format', 'json', '.']);
+		expect(parsed.clean).toBe(false);
+		expect(parsed.total).toBe(1);
+		expect(parsed.findings).toEqual([
+			{
+				id: 'GHSA-test',
+				summary: 'test vuln',
+				packageName: 'left-pad',
+				ecosystem: 'npm',
+				installedVersion: '1.0.0',
+				fixedVersion: '1.0.1',
+				aliases: ['CVE-2026-0001'],
+				references: ['https://example.com/vuln'],
+			},
+		]);
+	});
+
+	test('rejects unsafe scan paths and reports missing binary', async () => {
+		let parsed = await executeTool(
+			osv_scan,
+			{ scan_path: '../outside' },
+			tmpDir,
+		);
+		expect(parsed.error).toBe(true);
+		expect(parsed.type).toBe('path-escape');
+
+		osvInternals.resolveOsvScannerBinary = () => null;
+		parsed = await executeTool(osv_scan, {}, tmpDir);
+		expect(parsed.error).toBe(true);
+		expect(parsed.type).toBe('osv-scanner-not-found');
+	});
+
+	test('does not report clean on malformed or truncated OSV JSON', async () => {
+		osvInternals.resolveOsvScannerBinary = () => 'osv-scanner';
+		osvInternals.runExternalTool = mock(async () => ({
+			status: 'completed',
+			exitCode: 0,
+			stdout: '{not json',
+			stderr: '',
+			stdoutTruncated: true,
+			stderrTruncated: false,
+		})) as typeof realRunOsv;
+
+		const parsed = await executeTool(osv_scan, {}, tmpDir);
+
+		expect(parsed.error).toBe(true);
+		expect(parsed.type).toBe('unknown');
+		expect(String(parsed.message)).toContain('truncated');
+	});
+});
+
+describe('gh_evidence', () => {
+	test('uses bounded runner argv and parses PR evidence', async () => {
+		const executable = path.join(
+			tmpDir,
+			process.platform === 'win32' ? 'gh.exe' : 'gh',
+		);
+		let captured: Parameters<typeof realRunGh>[0] | undefined;
+		ghInternals.resolveGhBinary = () => executable;
+		ghInternals.runExternalTool = mock(async (options) => {
+			captured = options;
+			return {
+				status: 'completed',
+				exitCode: 0,
+				stdout: JSON.stringify({
+					number: 42,
+					title: 'Add tool',
+					body: 'x'.repeat(25_000),
+				}),
+				stderr: '',
+				stdoutTruncated: false,
+				stderrTruncated: false,
+			};
+		}) as typeof realRunGh;
+
+		const parsed = await executeTool(
+			gh_evidence,
+			{ number: 42, repo: 'owner/repo', fields: 'number,title,body' },
+			tmpDir,
+		);
+
+		expect(captured?.cwd).toBe(tmpDir);
+		expect(captured?.timeoutMs).toBe(20000);
+		expect(captured?.args).toEqual([
+			'pr',
+			'view',
+			'42',
+			'--json',
+			'number,title,body',
+			'--repo',
+			'owner/repo',
+		]);
+		expect(parsed.target).toBe('pr');
+		expect((parsed.data as { body: string }).body).toEndWith('... [truncated]');
+	});
+
+	test('rejects invalid gh inputs and reports missing binary', async () => {
+		let parsed = await executeTool(gh_evidence, { number: 0 }, tmpDir);
+		expect(parsed.error).toBe(true);
+		expect(parsed.type).toBe('invalid-input');
+
+		parsed = await executeTool(
+			gh_evidence,
+			{ number: 1, repo: 'bad repo' },
+			tmpDir,
+		);
+		expect(parsed.error).toBe(true);
+		expect(parsed.type).toBe('invalid-input');
+
+		ghInternals.resolveGhBinary = () => null;
+		parsed = await executeTool(gh_evidence, { number: 1 }, tmpDir);
+		expect(parsed.error).toBe(true);
+		expect(parsed.type).toBe('gh-not-found');
+	});
+});

--- a/src/tools/gh-evidence.ts
+++ b/src/tools/gh-evidence.ts
@@ -1,0 +1,307 @@
+import type { ToolDefinition } from '@opencode-ai/plugin/tool';
+import { z } from 'zod';
+import {
+	resolveExecutableFromPath,
+	runExternalTool,
+} from '../utils/external-tool-runner';
+import { containsControlChars } from '../utils/path-security';
+import { createSwarmTool } from './create-tool';
+
+const GH_TIMEOUT_MS = 20_000;
+const GH_MAX_STDOUT_BYTES = 2 * 1024 * 1024;
+const GH_MAX_STDERR_BYTES = 128 * 1024;
+
+const DEFAULT_PR_FIELDS = [
+	'number',
+	'title',
+	'state',
+	'isDraft',
+	'author',
+	'headRefName',
+	'headRefOid',
+	'baseRefName',
+	'baseRefOid',
+	'mergeable',
+	'mergeStateStatus',
+	'reviewDecision',
+	'statusCheckRollup',
+	'url',
+] as const;
+
+const DEFAULT_ISSUE_FIELDS = [
+	'number',
+	'title',
+	'state',
+	'author',
+	'labels',
+	'assignees',
+	'url',
+] as const;
+
+const PR_FIELD_ALLOWLIST = new Set([
+	...DEFAULT_PR_FIELDS,
+	'additions',
+	'body',
+	'changedFiles',
+	'commits',
+	'deletions',
+	'files',
+	'latestReviews',
+	'reviews',
+]);
+
+const ISSUE_FIELD_ALLOWLIST = new Set([
+	...DEFAULT_ISSUE_FIELDS,
+	'body',
+	'comments',
+	'closed',
+	'closedAt',
+	'createdAt',
+	'milestone',
+	'updatedAt',
+]);
+
+interface GhEvidenceResult {
+	target: 'pr' | 'issue';
+	number: number;
+	repo?: string;
+	fields: string[];
+	command: string[];
+	data: unknown;
+	outputTruncated?: boolean;
+}
+
+interface GhEvidenceError {
+	error: true;
+	type: 'gh-not-found' | 'invalid-input' | 'timeout' | 'unknown';
+	message: string;
+}
+
+function resolveGhBinary(): string | null {
+	return _internals.resolveExecutableFromPath(['gh']);
+}
+
+function normalizeRepo(value: unknown): string | undefined | GhEvidenceError {
+	if (value === undefined || value === null || value === '') return undefined;
+	if (typeof value !== 'string' || containsControlChars(value)) {
+		return {
+			error: true,
+			type: 'invalid-input',
+			message: 'repo must be an owner/name string',
+		};
+	}
+	if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value)) {
+		return {
+			error: true,
+			type: 'invalid-input',
+			message: 'repo must match owner/name',
+		};
+	}
+	return value;
+}
+
+function normalizeFields(
+	target: 'pr' | 'issue',
+	value: unknown,
+): string[] | GhEvidenceError {
+	const defaults =
+		target === 'pr'
+			? Array.from(DEFAULT_PR_FIELDS)
+			: Array.from(DEFAULT_ISSUE_FIELDS);
+	if (value === undefined || value === null || value === '') return defaults;
+	const raw = Array.isArray(value)
+		? value
+		: typeof value === 'string'
+			? value.split(',')
+			: null;
+	if (!raw || raw.some((f) => typeof f !== 'string')) {
+		return {
+			error: true,
+			type: 'invalid-input',
+			message: 'fields must be a comma-separated string or string array',
+		};
+	}
+	const allowlist =
+		target === 'pr' ? PR_FIELD_ALLOWLIST : ISSUE_FIELD_ALLOWLIST;
+	const fields = Array.from(new Set(raw.map((f) => f.trim()).filter(Boolean)));
+	if (
+		fields.length === 0 ||
+		fields.some((f) => containsControlChars(f) || !allowlist.has(f))
+	) {
+		return {
+			error: true,
+			type: 'invalid-input',
+			message: `fields must be selected from the ${target} allowlist`,
+		};
+	}
+	return fields;
+}
+
+function sanitizeParsedJson(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(sanitizeParsedJson);
+	}
+	if (value && typeof value === 'object') {
+		const out: Record<string, unknown> = {};
+		for (const [key, entry] of Object.entries(value)) {
+			if (
+				typeof entry === 'string' &&
+				(entry.length > 20_000 || key === 'body')
+			) {
+				out[key] = `${entry.slice(0, 20_000)}... [truncated]`;
+			} else {
+				out[key] = sanitizeParsedJson(entry);
+			}
+		}
+		return out;
+	}
+	return value;
+}
+
+export const gh_evidence: ToolDefinition = createSwarmTool({
+	description:
+		'Fetch bounded GitHub pull request or issue metadata via gh for review evidence. Read-only; resolves gh lazily.',
+	args: {
+		target: z
+			.enum(['pr', 'issue'])
+			.default('pr')
+			.describe('GitHub object type to view: pr or issue'),
+		number: z.number().describe('Pull request or issue number'),
+		repo: z
+			.string()
+			.optional()
+			.describe('Optional owner/repo. If omitted, gh uses the current repo.'),
+		fields: z
+			.union([z.string(), z.array(z.string())])
+			.optional()
+			.describe(
+				'Optional JSON fields. Defaults to high-signal bounded PR or issue fields.',
+			),
+	},
+	execute: async (args: unknown, directory: string) => {
+		const obj = (
+			typeof args === 'object' && args !== null ? args : {}
+		) as Record<string, unknown>;
+		const target = obj.target === 'issue' ? 'issue' : 'pr';
+		const number = typeof obj.number === 'number' ? obj.number : NaN;
+		if (!Number.isInteger(number) || number <= 0) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'invalid-input',
+					message: 'number must be a positive integer',
+				} satisfies GhEvidenceError,
+				null,
+				2,
+			);
+		}
+		const repo = normalizeRepo(obj.repo);
+		if (repo && typeof repo === 'object') {
+			return JSON.stringify(repo, null, 2);
+		}
+		const fields = normalizeFields(target, obj.fields);
+		if (!Array.isArray(fields)) {
+			return JSON.stringify(fields, null, 2);
+		}
+
+		const executable = _internals.resolveGhBinary();
+		if (!executable) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'gh-not-found',
+					message:
+						'GitHub CLI executable not found. Install gh and ensure it is on PATH.',
+				} satisfies GhEvidenceError,
+				null,
+				2,
+			);
+		}
+
+		const ghArgs = [target, 'view', String(number), '--json', fields.join(',')];
+		if (repo) {
+			ghArgs.push('--repo', repo);
+		}
+		const run = await _internals.runExternalTool({
+			executable,
+			args: ghArgs,
+			cwd: directory,
+			timeoutMs: GH_TIMEOUT_MS,
+			maxStdoutBytes: GH_MAX_STDOUT_BYTES,
+			maxStderrBytes: GH_MAX_STDERR_BYTES,
+		});
+
+		if (run.status === 'timeout') {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'timeout',
+					message: `gh ${target} view timed out after ${GH_TIMEOUT_MS}ms`,
+				} satisfies GhEvidenceError,
+				null,
+				2,
+			);
+		}
+		if (run.status === 'spawn-error') {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'unknown',
+					message: run.message ?? 'gh failed to start',
+				} satisfies GhEvidenceError,
+				null,
+				2,
+			);
+		}
+		if (run.exitCode !== 0) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'unknown',
+					message: run.stderr.split('\n')[0] || `gh exited ${run.exitCode}`,
+				} satisfies GhEvidenceError,
+				null,
+				2,
+			);
+		}
+
+		let data: unknown;
+		try {
+			data = sanitizeParsedJson(JSON.parse(run.stdout));
+		} catch {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'unknown',
+					message: 'gh output was not valid JSON',
+				} satisfies GhEvidenceError,
+				null,
+				2,
+			);
+		}
+
+		return JSON.stringify(
+			{
+				target,
+				number,
+				repo,
+				fields,
+				command: ['gh', ...ghArgs],
+				data,
+				outputTruncated: run.stdoutTruncated || run.stderrTruncated,
+			} satisfies GhEvidenceResult,
+			null,
+			2,
+		);
+	},
+});
+
+export const _internals: {
+	resolveExecutableFromPath: typeof resolveExecutableFromPath;
+	resolveGhBinary: typeof resolveGhBinary;
+	runExternalTool: typeof runExternalTool;
+} = {
+	resolveExecutableFromPath,
+	resolveGhBinary,
+	runExternalTool,
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,6 +3,8 @@ import { swarmApplyPatch } from './apply-patch';
 export { swarmApplyPatch };
 // Alias for TOOL_NAMES compliance - swarm_apply_patch and swarmApplyPatch are the same tool
 export const swarm_apply_patch: typeof swarmApplyPatch = swarmApplyPatch;
+export { actionlint_scan } from './actionlint-scan';
+export { ast_grep } from './ast-grep';
 export { batch_symbols } from './batch-symbols';
 export { build_check } from './build-check';
 export { check_gate_status } from './check-gate-status';
@@ -36,6 +38,7 @@ export { external_skill_revoke } from './external-skill-revoke';
 export { extract_code_blocks } from './file-extractor';
 export { get_approved_plan } from './get-approved-plan';
 export { get_qa_gate_profile } from './get-qa-gate-profile';
+export { gh_evidence } from './gh-evidence';
 export { git_blame } from './git-blame';
 export { fetchGitingest, type GitingestArgs, gitingest } from './gitingest';
 export { imports } from './imports';
@@ -46,6 +49,7 @@ export { knowledge_recall } from './knowledge-recall';
 export { knowledge_receipt } from './knowledge-receipt';
 export { knowledge_remove } from './knowledge-remove';
 export { lint } from './lint';
+export { osv_scan } from './osv-scan';
 export { parse_lane_candidates } from './parse-lane-candidates';
 // Phase completion tracking
 export { phase_complete } from './phase-complete';

--- a/src/tools/manifest.ts
+++ b/src/tools/manifest.ts
@@ -23,7 +23,9 @@
  * Neither is implemented (no current tool needs them). Not tree-shakeable.
  */
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
+import { actionlint_scan } from './actionlint-scan';
 import { swarmApplyPatch } from './apply-patch';
+import { ast_grep } from './ast-grep';
 import { batch_symbols } from './batch-symbols';
 import { build_check } from './build-check';
 import { check_gate_status } from './check-gate-status';
@@ -60,6 +62,7 @@ import { extract_code_blocks } from './file-extractor';
 import { generate_mutants } from './generate-mutants';
 import { get_approved_plan } from './get-approved-plan';
 import { get_qa_gate_profile } from './get-qa-gate-profile';
+import { gh_evidence } from './gh-evidence';
 import { git_blame } from './git-blame';
 import { gitingest } from './gitingest';
 import { imports } from './imports';
@@ -78,6 +81,7 @@ import { lean_turbo_status } from './lean-turbo-status';
 import { lint } from './lint';
 import { lint_spec } from './lint-spec';
 import { mutation_test } from './mutation-test';
+import { osv_scan } from './osv-scan';
 import { parse_lane_candidates } from './parse-lane-candidates';
 import { phase_complete } from './phase-complete';
 import { pkg_audit } from './pkg-audit';
@@ -194,6 +198,10 @@ export const TOOL_MANIFEST = defineHandlers({
 	knowledge_remove: () => knowledge_remove,
 	co_change_analyzer: () => co_change_analyzer,
 	search: () => search,
+	ast_grep: () => ast_grep,
+	actionlint_scan: () => actionlint_scan,
+	osv_scan: () => osv_scan,
+	gh_evidence: () => gh_evidence,
 	batch_symbols: () => batch_symbols,
 	suggest_patch: () => suggestPatch,
 	req_coverage: () => req_coverage,

--- a/src/tools/osv-scan.ts
+++ b/src/tools/osv-scan.ts
@@ -1,0 +1,308 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { ToolDefinition } from '@opencode-ai/plugin/tool';
+import { z } from 'zod';
+import {
+	resolveExecutableFromPath,
+	runExternalTool,
+} from '../utils/external-tool-runner';
+import {
+	containsControlChars,
+	containsPathTraversal,
+} from '../utils/path-security';
+import { createSwarmTool } from './create-tool';
+
+const OSV_TIMEOUT_MS = 60_000;
+const OSV_MAX_STDOUT_BYTES = 12 * 1024 * 1024;
+const OSV_MAX_STDERR_BYTES = 256 * 1024;
+const DEFAULT_MAX_RESULTS = 200;
+const HARD_CAP_RESULTS = 2_000;
+
+interface OsvFinding {
+	id: string;
+	summary?: string;
+	packageName?: string;
+	ecosystem?: string;
+	installedVersion?: string;
+	fixedVersion?: string;
+	aliases?: string[];
+	references?: string[];
+}
+
+interface OsvResult {
+	clean: boolean;
+	findings: OsvFinding[];
+	total: number;
+	truncated: boolean;
+	command: string[];
+	scanPath: string;
+	outputTruncated?: boolean;
+	note?: string;
+}
+
+interface OsvError {
+	error: true;
+	type:
+		| 'osv-scanner-not-found'
+		| 'invalid-input'
+		| 'path-escape'
+		| 'timeout'
+		| 'unknown';
+	message: string;
+}
+
+interface ParsedOsvOutput {
+	findings: OsvFinding[];
+	total: number;
+	parseError: boolean;
+}
+
+function resolveOsvScannerBinary(): string | null {
+	return _internals.resolveExecutableFromPath(['osv-scanner']);
+}
+
+function normalizeScanPath(value: unknown, workspace: string): string | null {
+	const raw = typeof value === 'string' && value.trim() ? value.trim() : '.';
+	if (containsControlChars(raw) || containsPathTraversal(raw)) return null;
+	if (path.isAbsolute(raw) || /^[A-Za-z]:[/\\]/.test(raw)) return null;
+	try {
+		const realWorkspace = fs.realpathSync(workspace);
+		const resolved = path.resolve(realWorkspace, raw);
+		const realTarget = fs.realpathSync(resolved);
+		const relative = path.relative(realWorkspace, realTarget);
+		if (relative.startsWith('..') || path.isAbsolute(relative)) return null;
+		return relative ? relative.split(path.sep).join('/') : '.';
+	} catch {
+		return null;
+	}
+}
+
+function firstString(value: unknown): string | undefined {
+	return typeof value === 'string' && value ? value : undefined;
+}
+
+function collectReferences(
+	vuln: Record<string, unknown>,
+): string[] | undefined {
+	const refs = Array.isArray(vuln.references) ? vuln.references : [];
+	const urls = refs
+		.map((ref) =>
+			ref && typeof ref === 'object'
+				? firstString((ref as Record<string, unknown>).url)
+				: undefined,
+		)
+		.filter((url): url is string => Boolean(url));
+	return urls.length > 0 ? urls.slice(0, 10) : undefined;
+}
+
+function parseOsvOutput(stdout: string, maxResults: number): ParsedOsvOutput {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		return { findings: [], total: 0, parseError: true };
+	}
+
+	const findings: OsvFinding[] = [];
+	let total = 0;
+	const results = Array.isArray((parsed as Record<string, unknown>)?.results)
+		? ((parsed as Record<string, unknown>).results as unknown[])
+		: [];
+
+	for (const result of results) {
+		const resultObj = result as Record<string, unknown>;
+		const packages = Array.isArray(resultObj.packages)
+			? (resultObj.packages as unknown[])
+			: [];
+		for (const pkg of packages) {
+			const pkgObj = pkg as Record<string, unknown>;
+			const pkgInfo = (pkgObj.package ?? {}) as Record<string, unknown>;
+			const vulnerabilities = Array.isArray(pkgObj.vulnerabilities)
+				? (pkgObj.vulnerabilities as unknown[])
+				: [];
+			for (const vulnerability of vulnerabilities) {
+				const vuln = vulnerability as Record<string, unknown>;
+				total++;
+				if (findings.length >= maxResults) continue;
+				const groups = Array.isArray(vuln.groups) ? vuln.groups : [];
+				const fixedVersion = groups
+					.flatMap((group) =>
+						Array.isArray((group as Record<string, unknown>).fixed)
+							? ((group as Record<string, unknown>).fixed as unknown[])
+							: [],
+					)
+					.map(firstString)
+					.find(Boolean);
+				findings.push({
+					id: firstString(vuln.id) ?? firstString(vuln.osv) ?? 'UNKNOWN',
+					summary: firstString(vuln.summary),
+					packageName:
+						firstString(pkgInfo.name) ??
+						firstString(pkgObj.name) ??
+						firstString(pkgObj.package),
+					ecosystem: firstString(pkgInfo.ecosystem),
+					installedVersion:
+						firstString(pkgInfo.version) ?? firstString(pkgObj.version),
+					fixedVersion,
+					aliases: Array.isArray(vuln.aliases)
+						? vuln.aliases.filter((a): a is string => typeof a === 'string')
+						: undefined,
+					references: collectReferences(vuln),
+				});
+			}
+		}
+	}
+
+	return { findings, total, parseError: false };
+}
+
+function sanitizeMaxResults(value: unknown): number {
+	const numeric =
+		typeof value === 'number' && Number.isFinite(value)
+			? value
+			: DEFAULT_MAX_RESULTS;
+	return Math.min(Math.max(0, numeric), HARD_CAP_RESULTS);
+}
+
+export const osv_scan: ToolDefinition = createSwarmTool({
+	description:
+		'Run OSV-Scanner against a workspace path and return structured dependency vulnerability findings. Read-only; resolves osv-scanner lazily.',
+	args: {
+		scan_path: z
+			.string()
+			.default('.')
+			.describe('Workspace-relative path to scan, default "."'),
+		max_results: z
+			.number()
+			.default(DEFAULT_MAX_RESULTS)
+			.describe('Maximum vulnerabilities to return'),
+	},
+	execute: async (args: unknown, directory: string) => {
+		const obj = (
+			typeof args === 'object' && args !== null ? args : {}
+		) as Record<string, unknown>;
+		const scanPath = normalizeScanPath(obj.scan_path, directory);
+		if (!scanPath) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'path-escape',
+					message: 'scan_path must be an existing workspace-relative path',
+				} satisfies OsvError,
+				null,
+				2,
+			);
+		}
+		const maxResults = sanitizeMaxResults(obj.max_results);
+		const executable = _internals.resolveOsvScannerBinary();
+		if (!executable) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'osv-scanner-not-found',
+					message:
+						'osv-scanner executable not found. Install OSV-Scanner and ensure osv-scanner is on PATH.',
+				} satisfies OsvError,
+				null,
+				2,
+			);
+		}
+
+		const target = scanPath === '.' ? '.' : `./${scanPath}`;
+		const osvArgs = ['scan', '--format', 'json', target];
+		const run = await _internals.runExternalTool({
+			executable,
+			args: osvArgs,
+			cwd: directory,
+			timeoutMs: OSV_TIMEOUT_MS,
+			maxStdoutBytes: OSV_MAX_STDOUT_BYTES,
+			maxStderrBytes: OSV_MAX_STDERR_BYTES,
+		});
+
+		if (run.status === 'timeout') {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'timeout',
+					message: `osv-scanner timed out after ${OSV_TIMEOUT_MS}ms`,
+				} satisfies OsvError,
+				null,
+				2,
+			);
+		}
+		if (run.status === 'spawn-error') {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'unknown',
+					message: run.message ?? 'osv-scanner failed to start',
+				} satisfies OsvError,
+				null,
+				2,
+			);
+		}
+
+		const { findings, total, parseError } = parseOsvOutput(
+			run.stdout,
+			maxResults,
+		);
+		if (parseError) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'unknown',
+					message:
+						run.stdoutTruncated || run.stderrTruncated
+							? 'osv-scanner JSON output was truncated and could not be parsed'
+							: 'osv-scanner output was not valid JSON',
+				} satisfies OsvError,
+				null,
+				2,
+			);
+		}
+		if (run.exitCode !== 0 && findings.length === 0 && run.stderr) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'unknown',
+					message: run.stderr.split('\n')[0],
+				} satisfies OsvError,
+				null,
+				2,
+			);
+		}
+
+		return JSON.stringify(
+			{
+				clean: total === 0 && !run.stdoutTruncated && !run.stderrTruncated,
+				findings,
+				total,
+				truncated:
+					total > maxResults || run.stdoutTruncated || run.stderrTruncated,
+				command: ['osv-scanner', ...osvArgs],
+				scanPath,
+				outputTruncated: run.stdoutTruncated || run.stderrTruncated,
+				note:
+					run.exitCode !== 0 && total > 0
+						? `osv-scanner exited ${run.exitCode} after finding vulnerabilities`
+						: run.stdoutTruncated || run.stderrTruncated
+							? 'osv-scanner output was truncated; result is incomplete.'
+							: undefined,
+			} satisfies OsvResult,
+			null,
+			2,
+		);
+	},
+});
+
+export const _internals: {
+	resolveExecutableFromPath: typeof resolveExecutableFromPath;
+	resolveOsvScannerBinary: typeof resolveOsvScannerBinary;
+	runExternalTool: typeof runExternalTool;
+	parseOsvOutput: typeof parseOsvOutput;
+} = {
+	resolveExecutableFromPath,
+	resolveOsvScannerBinary,
+	runExternalTool,
+	parseOsvOutput,
+};

--- a/src/tools/search.test.ts
+++ b/src/tools/search.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import {
 	mkdirSync,
 	mkdtempSync,
@@ -10,7 +10,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ToolContext } from '@opencode-ai/plugin';
 import type { ToolResult } from './create-tool';
-import { search } from './search';
+import { search, _internals as searchInternals } from './search';
 
 // Helper to extract string from ToolResult
 function resultToString(result: ToolResult): string {
@@ -29,6 +29,9 @@ async function executeSearch(
 }
 
 let tmpDir: string;
+const realResolveRipgrepBinary = searchInternals.resolveRipgrepBinary;
+const realRunExternalTool = searchInternals.runExternalTool;
+const realFallbackSearch = searchInternals.fallbackSearch;
 
 beforeEach(() => {
 	tmpDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'search-test-')));
@@ -41,6 +44,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	searchInternals.resolveRipgrepBinary = realResolveRipgrepBinary;
+	searchInternals.runExternalTool = realRunExternalTool;
+	searchInternals.fallbackSearch = realFallbackSearch;
 	try {
 		rmSync(tmpDir, { recursive: true, force: true });
 	} catch {
@@ -403,6 +409,74 @@ describe('search - glob filtering', () => {
 	});
 });
 
+// ============ Ripgrep Execution Contract Tests ============
+
+describe('search - ripgrep execution contract', () => {
+	it('uses bounded runner options, safe argv ordering, and relative result paths', async () => {
+		createTestFile('src/rg.ts', 'needle\n');
+		const rgPath = path.join(
+			tmpDir,
+			process.platform === 'win32' ? 'rg.exe' : 'rg',
+		);
+		let captured: Parameters<typeof realRunExternalTool>[0] | undefined;
+
+		searchInternals.resolveRipgrepBinary = () => rgPath;
+		searchInternals.runExternalTool = mock(async (options) => {
+			captured = options;
+			return {
+				status: 'completed',
+				exitCode: 0,
+				stdout: `${JSON.stringify({
+					type: 'match',
+					data: {
+						path: { text: path.join(tmpDir, 'src', 'rg.ts') },
+						line_number: 1,
+						lines: { text: 'needle\n' },
+					},
+				})}\n`,
+				stderr: '',
+				stdoutTruncated: false,
+				stderrTruncated: false,
+			};
+		}) as typeof realRunExternalTool;
+
+		const result = await executeSearch(
+			{
+				query: '-needle',
+				mode: 'literal',
+				include: 'src/**',
+				exclude: '**/*.test.ts',
+			},
+			tmpDir,
+		);
+		const parsed = JSON.parse(result);
+
+		expect(captured).toBeDefined();
+		expect(captured?.executable).toBe(rgPath);
+		expect(captured?.cwd).toBe(tmpDir);
+		expect(captured?.timeoutMs).toBe(5000);
+		expect(captured?.maxStdoutBytes).toBeGreaterThan(0);
+		expect(captured?.maxStderrBytes).toBeGreaterThan(0);
+		expect(captured?.args).toEqual([
+			'--json',
+			'--no-config',
+			'-n',
+			'--glob',
+			'src/**',
+			'--glob',
+			'!**/*.test.ts',
+			'--fixed-strings',
+			'--',
+			'-needle',
+			'.',
+		]);
+		expect(parsed.engine).toBe('ripgrep');
+		expect(parsed.matches).toEqual([
+			{ file: 'src/rg.ts', lineNumber: 1, lineText: 'needle' },
+		]);
+	});
+});
+
 // ============ Empty Query Validation Tests ============
 
 describe('search - query validation', () => {
@@ -500,6 +574,7 @@ describe('search - rg-not-found fallback', () => {
 	it('fallback search works when ripgrep not available', async () => {
 		// This tests the fallback path - even if rg IS available,
 		// the fallback should produce valid structured output
+		searchInternals.resolveRipgrepBinary = () => null;
 		createTestFile('src/fallback.ts', 'fallback search content\n');
 
 		const result = await executeSearch({ query: 'fallback' }, tmpDir);
@@ -512,7 +587,28 @@ describe('search - rg-not-found fallback', () => {
 		} else {
 			// If success, should have matches
 			expect(parsed.matches).toBeDefined();
+			expect(parsed.engine).toBe('fallback');
 		}
+	});
+
+	it('fallback search skips heavy runtime directories by default', async () => {
+		searchInternals.resolveRipgrepBinary = () => null;
+		createTestFile('src/app.ts', 'DEFAULT_SKIP_MARKER\n');
+		createTestFile('node_modules/pkg/index.js', 'DEFAULT_SKIP_MARKER\n');
+		createTestFile('.git/hooks/pre-commit', 'DEFAULT_SKIP_MARKER\n');
+		createTestFile('.swarm/cache/output.txt', 'DEFAULT_SKIP_MARKER\n');
+
+		const result = await executeSearch(
+			{ query: 'DEFAULT_SKIP_MARKER' },
+			tmpDir,
+		);
+		const parsed = JSON.parse(result);
+		const files = parsed.matches.map((m: { file: string }) => m.file);
+
+		expect(parsed.error).toBeUndefined();
+		expect(parsed.engine).toBe('fallback');
+		expect(files).toEqual(['src/app.ts']);
+		expect(parsed.warning).toContain('Fallback search');
 	});
 });
 

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,15 +1,21 @@
 // Structured workspace search tool — workspace-scoped ripgrep-style search with structured JSON output
 
 import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
 import { z } from 'zod';
-import { bunSpawn } from '../utils/bun-compat';
+import {
+	resolveExecutableFromPath,
+	runExternalTool,
+} from '../utils/external-tool-runner';
 import {
 	containsControlChars,
 	containsPathTraversal,
 } from '../utils/path-security';
 import { createSwarmTool } from './create-tool';
+
+const require = createRequire(import.meta.url);
 
 // ============ Types ============
 
@@ -27,6 +33,9 @@ export interface SearchResult {
 	query: string;
 	mode: 'literal' | 'regex';
 	maxResults: number;
+	engine: 'ripgrep' | 'fallback';
+	outputTruncated?: boolean;
+	warning?: string;
 }
 
 export interface SearchError {
@@ -57,6 +66,25 @@ const REGEX_TIMEOUT_MS = 5000;
 const MAX_FILE_SIZE_BYTES = 1024 * 1024; // 1MB per file
 const HARD_CAP_RESULTS = 10000;
 const HARD_CAP_LINES = 10000;
+const MAX_QUERY_LENGTH = 20_000;
+const MAX_RG_STDOUT_BYTES = 8 * 1024 * 1024;
+const MAX_RG_STDERR_BYTES = 64 * 1024;
+const FALLBACK_MAX_FILES = 20_000;
+const FALLBACK_MAX_DIRS = 5_000;
+const FALLBACK_MAX_DEPTH = 40;
+const FALLBACK_MAX_TOTAL_BYTES = 64 * 1024 * 1024;
+const DEFAULT_SKIP_DIRS = new Set([
+	'.git',
+	'.swarm',
+	'node_modules',
+	'dist',
+	'build',
+	'out',
+	'coverage',
+	'.next',
+	'.turbo',
+	'.cache',
+]);
 
 // ============ Glob Pattern Matching (Fallback) ============
 
@@ -134,40 +162,59 @@ function validatePathForRead(filePath: string, workspace: string): boolean {
 	return isPathInWorkspace(filePath, workspace);
 }
 
-// ============ Ripgrep Detection ============
+// ============ Helpers ============
 
-/**
- * Find ripgrep binary by scanning process.env.PATH directories.
- * Bun.which does not pick up runtime changes to process.env.PATH.
- */
-function findRgInEnvPath(): string | null {
-	const searchPath = process.env.PATH ?? '';
-	for (const dir of searchPath.split(path.delimiter)) {
-		if (!dir) continue;
-		const isWindows = process.platform === 'win32';
-		const candidate = path.join(dir, isWindows ? 'rg.exe' : 'rg');
-		if (fs.existsSync(candidate)) return candidate;
-	}
-	return null;
+function splitGlobPatterns(value?: string): string[] {
+	return value
+		? value
+				.split(',')
+				.map((p) => p.trim())
+				.filter(Boolean)
+		: [];
 }
 
-/**
- * Check if ripgrep is available.
- */
-async function isRipgrepAvailable(): Promise<boolean> {
-	const rgPath = findRgInEnvPath();
-	if (!rgPath) return false;
-
+function toWorkspaceRelativePath(
+	filePath: string,
+	workspace: string,
+): string | null {
 	try {
-		const proc = bunSpawn([rgPath, '--version'], {
-			stdout: 'pipe',
-			stderr: 'pipe',
-		});
-		const exitCode = await proc.exited;
-		return exitCode === 0;
+		const resolved = path.resolve(workspace, filePath);
+		const realWorkspace = fs.realpathSync(workspace);
+		const realResolved = fs.realpathSync(resolved);
+		const relative = path.relative(realWorkspace, realResolved);
+		if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+			return null;
+		}
+		return relative.split(path.sep).join('/');
 	} catch {
-		return false;
+		return null;
 	}
+}
+
+function truncateLine(line: string, maxLines: number): string {
+	const trimmed = line.trimEnd();
+	if (trimmed.length > maxLines) {
+		return `${trimmed.substring(0, maxLines)}...`;
+	}
+	return trimmed;
+}
+
+// ============ Ripgrep Detection ============
+
+function resolvePackagedRipgrep(): string | null {
+	try {
+		const mod = require('@vscode/ripgrep') as { rgPath?: unknown };
+		return typeof mod.rgPath === 'string' && mod.rgPath ? mod.rgPath : null;
+	} catch {
+		return null;
+	}
+}
+
+function resolveRipgrepBinary(): string | null {
+	return (
+		_internals.resolvePackagedRipgrep() ??
+		_internals.resolveExecutableFromPath(['rg'])
+	);
 }
 
 // ============ Ripgrep Search ============
@@ -188,30 +235,27 @@ interface RipgrepSearchOptions {
 async function ripgrepSearch(
 	opts: RipgrepSearchOptions,
 ): Promise<SearchResult | SearchError> {
-	const rgPath = findRgInEnvPath();
+	const rgPath = _internals.resolveRipgrepBinary();
 	if (!rgPath) {
 		return {
 			error: true,
 			type: 'rg-not-found',
-			message: 'ripgrep (rg) not found in PATH',
+			message: 'ripgrep (rg) not found; using fallback search was not possible',
 		};
 	}
 
 	const args: string[] = [
 		'--json',
+		'--no-config',
 		'-n', // line numbers
 	];
 
 	// Add glob patterns for include/exclude
-	if (opts.include) {
-		for (const pattern of opts.include.split(',')) {
-			args.push('--glob', pattern.trim());
-		}
+	for (const pattern of splitGlobPatterns(opts.include)) {
+		args.push('--glob', pattern);
 	}
-	if (opts.exclude) {
-		for (const pattern of opts.exclude.split(',')) {
-			args.push('--glob', `!${pattern.trim()}`); // ! negates glob in ripgrep
-		}
+	for (const pattern of splitGlobPatterns(opts.exclude)) {
+		args.push('--glob', `!${pattern}`); // ! negates glob in ripgrep
 	}
 
 	// Set search mode
@@ -219,46 +263,46 @@ async function ripgrepSearch(
 		args.push('--fixed-strings');
 	}
 
-	// Add the query
-	args.push(opts.query);
+	// Keep all options before `--`; query and path operands cannot be flags.
+	args.push('--', opts.query, '.');
 
-	// Search in workspace root
-	args.push(opts.workspace);
+	const run = await _internals.runExternalTool({
+		executable: rgPath,
+		args,
+		cwd: opts.workspace,
+		timeoutMs: REGEX_TIMEOUT_MS,
+		maxStdoutBytes: MAX_RG_STDOUT_BYTES,
+		maxStderrBytes: MAX_RG_STDERR_BYTES,
+	});
 
 	try {
-		const proc = bunSpawn([rgPath, ...args], {
-			stdout: 'pipe',
-			stderr: 'pipe',
-			cwd: opts.workspace,
-		});
-
-		// Set up regex timeout
-		const timeout = new Promise<'timeout'>((resolve) =>
-			setTimeout(() => resolve('timeout'), REGEX_TIMEOUT_MS),
-		);
-
-		const exitPromise = proc.exited;
-		const result = await Promise.race([exitPromise, timeout]);
-
-		if (result === 'timeout') {
-			proc.kill();
+		if (run.status === 'timeout') {
 			return {
 				error: true,
 				type: 'regex-timeout',
-				message: `Regex search timed out after ${REGEX_TIMEOUT_MS}ms`,
+				message: `Search timed out after ${REGEX_TIMEOUT_MS}ms`,
 			};
 		}
 
-		const stdout = await proc.stdout.text();
-		const stderr = await proc.stderr.text();
+		if (run.status === 'spawn-error') {
+			return {
+				error: true,
+				type: 'unknown',
+				message: run.message ?? 'ripgrep failed to start',
+			};
+		}
 
 		// If ripgrep exited with non-zero and has stderr, it might be an invalid regex
-		if (proc.exitCode !== 0 && stderr) {
-			if (stderr.includes('Invalid regex') || stderr.includes('SyntaxError')) {
+		if (run.exitCode !== 0 && run.stderr) {
+			if (
+				run.stderr.includes('Invalid regex') ||
+				run.stderr.includes('regex parse error') ||
+				run.stderr.includes('SyntaxError')
+			) {
 				return {
 					error: true,
 					type: 'invalid-query',
-					message: `Invalid query: ${stderr.split('\n')[0]}`,
+					message: `Invalid query: ${run.stderr.split('\n')[0]}`,
 				};
 			}
 		}
@@ -267,7 +311,7 @@ async function ripgrepSearch(
 		let total = 0;
 
 		// Parse ripgrep JSON output (line per match)
-		for (const line of stdout.split('\n')) {
+		for (const line of run.stdout.split('\n')) {
 			if (!line.trim()) continue;
 
 			try {
@@ -275,16 +319,19 @@ async function ripgrepSearch(
 
 				// ripgrep outputs different message types; we only care about matches
 				if (entry.type === 'match') {
+					const rawPath = entry.data?.path?.text ?? entry.data?.path;
+					const relativePath =
+						typeof rawPath === 'string'
+							? toWorkspaceRelativePath(rawPath, opts.workspace)
+							: null;
+					if (!relativePath) continue;
+
 					total++;
 					if (matches.length < opts.maxResults) {
-						let lineText = entry.data.lines.text.trimEnd();
-						if (lineText.length > opts.maxLines) {
-							lineText = `${lineText.substring(0, opts.maxLines)}...`;
-						}
 						const match: SearchMatch = {
-							file: entry.data.path.text || entry.data.path,
+							file: relativePath,
 							lineNumber: entry.data.line_number,
-							lineText,
+							lineText: truncateLine(entry.data.lines.text, opts.maxLines),
 						};
 						matches.push(match);
 					}
@@ -296,11 +343,14 @@ async function ripgrepSearch(
 
 		return {
 			matches,
-			truncated: total > opts.maxResults,
+			truncated:
+				total > opts.maxResults || run.stdoutTruncated || run.stderrTruncated,
 			total,
 			query: opts.query,
 			mode: opts.mode,
 			maxResults: opts.maxResults,
+			engine: 'ripgrep',
+			outputTruncated: run.stdoutTruncated || run.stderrTruncated,
 		};
 	} catch (err) {
 		return {
@@ -323,6 +373,13 @@ interface FallbackSearchOptions {
 	workspace: string;
 }
 
+interface CollectFilesState {
+	files: string[];
+	seenRealPaths: Set<string>;
+	dirCount: number;
+	truncated: boolean;
+}
+
 /**
  * Escape regex special characters for literal search.
  */
@@ -338,17 +395,45 @@ function collectFiles(
 	workspace: string,
 	includeGlobs: string[],
 	excludeGlobs: string[],
+	state: CollectFilesState,
+	depth = 0,
 ): string[] {
-	const files: string[] = [];
+	if (
+		depth > FALLBACK_MAX_DEPTH ||
+		state.files.length >= FALLBACK_MAX_FILES ||
+		state.dirCount >= FALLBACK_MAX_DIRS
+	) {
+		state.truncated = true;
+		return state.files;
+	}
+
+	try {
+		const realDir = fs.realpathSync(dir);
+		if (state.seenRealPaths.has(realDir)) {
+			return state.files;
+		}
+		state.seenRealPaths.add(realDir);
+		state.dirCount++;
+	} catch {
+		return state.files;
+	}
 
 	if (!validatePathForRead(dir, workspace)) {
-		return files;
+		return state.files;
 	}
 
 	try {
 		const entries = fs.readdirSync(dir, { withFileTypes: true });
 
 		for (const entry of entries) {
+			if (
+				state.files.length >= FALLBACK_MAX_FILES ||
+				state.dirCount >= FALLBACK_MAX_DIRS
+			) {
+				state.truncated = true;
+				break;
+			}
+
 			const fullPath = path.join(dir, entry.name);
 			const relativePath = path.relative(workspace, fullPath);
 
@@ -357,14 +442,17 @@ function collectFiles(
 			}
 
 			if (entry.isDirectory()) {
-				// Recurse into subdirectories
-				const subFiles = collectFiles(
+				if (DEFAULT_SKIP_DIRS.has(entry.name)) {
+					continue;
+				}
+				collectFiles(
 					fullPath,
 					workspace,
 					includeGlobs,
 					excludeGlobs,
+					state,
+					depth + 1,
 				);
-				files.push(...subFiles);
 			} else if (entry.isFile()) {
 				// Check against glob patterns
 				if (
@@ -379,14 +467,16 @@ function collectFiles(
 				) {
 					continue;
 				}
-				files.push(relativePath);
+				const normalized = toWorkspaceRelativePath(fullPath, workspace);
+				if (!normalized) continue;
+				state.files.push(normalized);
 			}
 		}
 	} catch {
 		// Skip directories we can't read
 	}
 
-	return files;
+	return state.files;
 }
 
 /**
@@ -409,12 +499,20 @@ async function fallbackSearch(
 				.filter(Boolean)
 		: [];
 
+	const collectState: CollectFilesState = {
+		files: [],
+		seenRealPaths: new Set(),
+		dirCount: 0,
+		truncated: false,
+	};
+
 	// Collect all matching files
 	const files = collectFiles(
 		opts.workspace,
 		opts.workspace,
 		includeGlobs,
 		excludeGlobs,
+		collectState,
 	);
 
 	// Compile regex based on mode
@@ -435,6 +533,8 @@ async function fallbackSearch(
 
 	const matches: SearchMatch[] = [];
 	let total = 0;
+	let totalBytesRead = 0;
+	let truncated = collectState.truncated;
 
 	for (const file of files) {
 		const fullPath = path.join(opts.workspace, file);
@@ -451,6 +551,11 @@ async function fallbackSearch(
 			if (stats.size > MAX_FILE_SIZE_BYTES) {
 				continue;
 			}
+			if (totalBytesRead + stats.size > FALLBACK_MAX_TOTAL_BYTES) {
+				truncated = true;
+				break;
+			}
+			totalBytesRead += stats.size;
 		} catch {
 			continue;
 		}
@@ -473,15 +578,10 @@ async function fallbackSearch(
 
 				if (matches.length < opts.maxResults) {
 					// Truncate line if too long
-					let lineText = line.trimEnd();
-					if (lineText.length > opts.maxLines) {
-						lineText = `${lineText.substring(0, opts.maxLines)}...`;
-					}
-
 					matches.push({
 						file,
 						lineNumber: i + 1,
-						lineText,
+						lineText: truncateLine(line, opts.maxLines),
 					});
 				}
 
@@ -493,11 +593,14 @@ async function fallbackSearch(
 
 	return {
 		matches,
-		truncated: total > opts.maxResults,
+		truncated: truncated || total > opts.maxResults,
 		total,
 		query: opts.query,
 		mode: opts.mode,
 		maxResults: opts.maxResults,
+		engine: 'fallback',
+		warning:
+			'Fallback search uses bounded filesystem traversal and does not fully emulate ripgrep gitignore behavior.',
 	};
 }
 
@@ -552,8 +655,8 @@ export const search: ToolDefinition = createSwarmTool({
 			const obj = args as Record<string, unknown>;
 			query = String(obj.query ?? '');
 			mode = obj.mode === 'regex' ? 'regex' : 'literal';
-			include = obj.include as string | undefined;
-			exclude = obj.exclude as string | undefined;
+			include = typeof obj.include === 'string' ? obj.include : undefined;
+			exclude = typeof obj.exclude === 'string' ? obj.exclude : undefined;
 			const rawMaxResults =
 				typeof obj.max_results === 'number'
 					? obj.max_results
@@ -588,6 +691,18 @@ export const search: ToolDefinition = createSwarmTool({
 					error: true,
 					type: 'invalid-query',
 					message: 'Query cannot be empty',
+				} satisfies SearchError,
+				null,
+				2,
+			);
+		}
+
+		if (query.length > MAX_QUERY_LENGTH) {
+			return JSON.stringify(
+				{
+					error: true,
+					type: 'invalid-query',
+					message: `Query exceeds maximum length of ${MAX_QUERY_LENGTH} characters`,
 				} satisfies SearchError,
 				null,
 				2,
@@ -670,12 +785,9 @@ export const search: ToolDefinition = createSwarmTool({
 			);
 		}
 
-		// Try ripgrep first, fall back to Node.js search
-		const rgAvailable = await isRipgrepAvailable();
-
 		let result: SearchResult | SearchError;
 
-		if (rgAvailable) {
+		if (_internals.resolveRipgrepBinary()) {
 			result = await ripgrepSearch({
 				query,
 				mode,
@@ -705,3 +817,17 @@ export const search: ToolDefinition = createSwarmTool({
 		return JSON.stringify(result, null, 2);
 	},
 });
+
+export const _internals: {
+	resolvePackagedRipgrep: typeof resolvePackagedRipgrep;
+	resolveExecutableFromPath: typeof resolveExecutableFromPath;
+	resolveRipgrepBinary: typeof resolveRipgrepBinary;
+	runExternalTool: typeof runExternalTool;
+	fallbackSearch: typeof fallbackSearch;
+} = {
+	resolvePackagedRipgrep,
+	resolveExecutableFromPath,
+	resolveRipgrepBinary,
+	runExternalTool,
+	fallbackSearch,
+};

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -401,6 +401,37 @@ export const TOOL_METADATA = {
 			'researcher',
 		],
 	},
+	ast_grep: {
+		description:
+			'Read-only structural AST search using ast-grep patterns with optional language and glob filters. Use for syntax-aware code pattern searches; does not rewrite files.',
+		agents: [
+			'architect',
+			'sme',
+			'docs',
+			'docs_design',
+			'critic_hallucination_verifier',
+			'spec_writer',
+			'explorer',
+			'coder',
+			'test_engineer',
+			'researcher',
+		],
+	},
+	actionlint_scan: {
+		description:
+			'Run actionlint against GitHub Actions workflow YAML files with structured findings. Resolves actionlint lazily and does not modify files.',
+		agents: ['architect', 'test_engineer'],
+	},
+	osv_scan: {
+		description:
+			'Run OSV-Scanner against a workspace path and return structured dependency vulnerability findings. Resolves osv-scanner lazily and does not modify files.',
+		agents: ['architect', 'test_engineer'],
+	},
+	gh_evidence: {
+		description:
+			'Fetch bounded GitHub pull request or issue metadata through gh for review and CI evidence. Resolves gh lazily and is read-only.',
+		agents: ['architect', 'researcher'],
+	},
 	batch_symbols: {
 		description:
 			'Batched symbol extraction across multiple files. Returns per-file symbol summaries with isolated error handling.',

--- a/src/utils/external-tool-runner.ts
+++ b/src/utils/external-tool-runner.ts
@@ -1,0 +1,232 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { type BunCompatSubprocess, bunSpawn } from './bun-compat';
+
+export interface ExternalToolRunOptions {
+	executable: string;
+	args: string[];
+	cwd: string;
+	timeoutMs: number;
+	maxStdoutBytes: number;
+	maxStderrBytes: number;
+	env?: Record<string, string | undefined>;
+}
+
+export interface ExternalToolRunResult {
+	status: 'completed' | 'timeout' | 'spawn-error';
+	exitCode: number | null;
+	stdout: string;
+	stderr: string;
+	stdoutTruncated: boolean;
+	stderrTruncated: boolean;
+	message?: string;
+}
+
+interface BoundedStreamResult {
+	text: string;
+	truncated: boolean;
+}
+
+const DEFAULT_WINDOWS_EXTENSIONS = ['.exe', '.cmd', '.bat'];
+
+function isExecutableFile(candidate: string): boolean {
+	try {
+		const stats = fs.statSync(candidate);
+		return stats.isFile();
+	} catch {
+		return false;
+	}
+}
+
+export function resolveExecutableFromPath(
+	names: string[],
+	envPath = process.env.PATH ?? '',
+	platform = process.platform,
+): string | null {
+	const pathEntries = envPath.split(path.delimiter).filter(Boolean);
+	const isWindows = platform === 'win32';
+
+	for (const rawName of names) {
+		if (!rawName) continue;
+		if (path.isAbsolute(rawName) && isExecutableFile(rawName)) {
+			return rawName;
+		}
+
+		const extensions =
+			isWindows && path.extname(rawName) === ''
+				? DEFAULT_WINDOWS_EXTENSIONS
+				: [''];
+
+		for (const dir of pathEntries) {
+			for (const ext of extensions) {
+				const candidate = path.join(dir, `${rawName}${ext}`);
+				if (isExecutableFile(candidate)) {
+					return candidate;
+				}
+			}
+		}
+	}
+
+	return null;
+}
+
+async function readBoundedStream(
+	stream: BunCompatSubprocess['stdout'],
+	maxBytes: number,
+): Promise<BoundedStreamResult> {
+	if (maxBytes <= 0) {
+		try {
+			await stream.getReader().cancel();
+		} catch {
+			// best effort
+		}
+		return { text: '', truncated: true };
+	}
+
+	const reader = stream.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	let truncated = false;
+
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!value) continue;
+
+			const remaining = maxBytes - total;
+			if (value.byteLength > remaining) {
+				if (remaining > 0) {
+					chunks.push(value.slice(0, remaining));
+					total += remaining;
+				}
+				truncated = true;
+				try {
+					await reader.cancel();
+				} catch {
+					// best effort
+				}
+				break;
+			}
+
+			chunks.push(value);
+			total += value.byteLength;
+		}
+	} finally {
+		try {
+			reader.releaseLock();
+		} catch {
+			// best effort
+		}
+	}
+
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const chunk of chunks) {
+		out.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+
+	return {
+		text: new TextDecoder().decode(out),
+		truncated,
+	};
+}
+
+export async function runExternalTool(
+	options: ExternalToolRunOptions,
+): Promise<ExternalToolRunResult> {
+	if (!path.isAbsolute(options.cwd)) {
+		return {
+			status: 'spawn-error',
+			exitCode: null,
+			stdout: '',
+			stderr: '',
+			stdoutTruncated: false,
+			stderrTruncated: false,
+			message: 'external tool cwd must be absolute',
+		};
+	}
+
+	let proc: BunCompatSubprocess | undefined;
+	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+	let timedOut = false;
+
+	try {
+		proc = _internals.bunSpawn([options.executable, ...options.args], {
+			cwd: options.cwd,
+			env: options.env,
+			stdin: 'ignore',
+			stdout: 'pipe',
+			stderr: 'pipe',
+			timeout: options.timeoutMs,
+		});
+
+		const timeout = new Promise<'timeout'>((resolve) => {
+			timeoutHandle = setTimeout(() => {
+				timedOut = true;
+				try {
+					proc?.kill('SIGKILL');
+				} catch {
+					// best effort
+				}
+				resolve('timeout');
+			}, options.timeoutMs);
+		});
+
+		const stdoutPromise = readBoundedStream(
+			proc.stdout,
+			options.maxStdoutBytes,
+		);
+		const stderrPromise = readBoundedStream(
+			proc.stderr,
+			options.maxStderrBytes,
+		);
+		const exitResult = await Promise.race([proc.exited, timeout]);
+		if (exitResult === 'timeout' || timedOut) {
+			return {
+				status: 'timeout',
+				exitCode: proc.exitCode,
+				stdout: '',
+				stderr: '',
+				stdoutTruncated: false,
+				stderrTruncated: false,
+			};
+		}
+		const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
+
+		return {
+			status: 'completed',
+			exitCode: exitResult,
+			stdout: stdout.text,
+			stderr: stderr.text,
+			stdoutTruncated: stdout.truncated,
+			stderrTruncated: stderr.truncated,
+		};
+	} catch (err) {
+		return {
+			status: 'spawn-error',
+			exitCode: proc?.exitCode ?? null,
+			stdout: '',
+			stderr: '',
+			stdoutTruncated: false,
+			stderrTruncated: false,
+			message: err instanceof Error ? err.message : String(err),
+		};
+	} finally {
+		if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+		if (proc) {
+			try {
+				proc.kill();
+			} catch {
+				// best effort
+			}
+		}
+	}
+}
+
+export const _internals: {
+	bunSpawn: typeof bunSpawn;
+} = {
+	bunSpawn,
+};

--- a/src/utils/external-tool-runner.ts
+++ b/src/utils/external-tool-runner.ts
@@ -29,6 +29,8 @@ interface BoundedStreamResult {
 
 const DEFAULT_WINDOWS_EXTENSIONS = ['.exe', '.cmd', '.bat'];
 
+type ExitRaceResult = { kind: 'exit'; exitCode: number } | { kind: 'timeout' };
+
 function isExecutableFile(candidate: string): boolean {
 	try {
 		const stats = fs.statSync(candidate);
@@ -74,16 +76,32 @@ async function readBoundedStream(
 	stream: BunCompatSubprocess['stdout'],
 	maxBytes: number,
 ): Promise<BoundedStreamResult> {
-	if (maxBytes <= 0) {
+	const reader = stream.getReader();
+	let lockReleased = false;
+	const releaseLock = () => {
+		if (lockReleased) return;
+		lockReleased = true;
 		try {
-			await stream.getReader().cancel();
+			reader.releaseLock();
 		} catch {
 			// best effort
 		}
+	};
+	const cancelAndRelease = async () => {
+		try {
+			await reader.cancel();
+		} catch {
+			// best effort
+		} finally {
+			releaseLock();
+		}
+	};
+
+	if (maxBytes <= 0) {
+		await cancelAndRelease();
 		return { text: '', truncated: true };
 	}
 
-	const reader = stream.getReader();
 	const chunks: Uint8Array[] = [];
 	let total = 0;
 	let truncated = false;
@@ -101,11 +119,7 @@ async function readBoundedStream(
 					total += remaining;
 				}
 				truncated = true;
-				try {
-					await reader.cancel();
-				} catch {
-					// best effort
-				}
+				await cancelAndRelease();
 				break;
 			}
 
@@ -113,11 +127,7 @@ async function readBoundedStream(
 			total += value.byteLength;
 		}
 	} finally {
-		try {
-			reader.releaseLock();
-		} catch {
-			// best effort
-		}
+		releaseLock();
 	}
 
 	const out = new Uint8Array(total);
@@ -131,6 +141,18 @@ async function readBoundedStream(
 		text: new TextDecoder().decode(out),
 		truncated,
 	};
+}
+
+function timeoutKillSignal(platform: NodeJS.Platform): NodeJS.Signals {
+	return platform === 'win32' ? 'SIGTERM' : 'SIGKILL';
+}
+
+function killProcess(proc: BunCompatSubprocess | undefined): void {
+	try {
+		proc?.kill(timeoutKillSignal(_internals.platform()));
+	} catch {
+		// best effort
+	}
 }
 
 export async function runExternalTool(
@@ -150,7 +172,8 @@ export async function runExternalTool(
 
 	let proc: BunCompatSubprocess | undefined;
 	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-	let timedOut = false;
+	let exitSettled = false;
+	let settledExitCode: number | null = null;
 
 	try {
 		proc = _internals.bunSpawn([options.executable, ...options.args], {
@@ -162,15 +185,24 @@ export async function runExternalTool(
 			timeout: options.timeoutMs,
 		});
 
-		const timeout = new Promise<'timeout'>((resolve) => {
+		const exitPromise: Promise<ExitRaceResult> = proc.exited.then(
+			(exitCode) => {
+				exitSettled = true;
+				settledExitCode = exitCode;
+				return { kind: 'exit', exitCode };
+			},
+		);
+		const timeout = new Promise<ExitRaceResult>((resolve) => {
 			timeoutHandle = setTimeout(() => {
-				timedOut = true;
-				try {
-					proc?.kill('SIGKILL');
-				} catch {
-					// best effort
+				if (exitSettled) {
+					resolve({
+						kind: 'exit',
+						exitCode: settledExitCode ?? proc?.exitCode ?? 0,
+					});
+					return;
 				}
-				resolve('timeout');
+				killProcess(proc);
+				resolve({ kind: 'timeout' });
 			}, options.timeoutMs);
 		});
 
@@ -182,8 +214,8 @@ export async function runExternalTool(
 			proc.stderr,
 			options.maxStderrBytes,
 		);
-		const exitResult = await Promise.race([proc.exited, timeout]);
-		if (exitResult === 'timeout' || timedOut) {
+		const exitResult = await Promise.race([exitPromise, timeout]);
+		if (exitResult.kind === 'timeout') {
 			return {
 				status: 'timeout',
 				exitCode: proc.exitCode,
@@ -197,7 +229,7 @@ export async function runExternalTool(
 
 		return {
 			status: 'completed',
-			exitCode: exitResult,
+			exitCode: exitResult.exitCode,
 			stdout: stdout.text,
 			stderr: stderr.text,
 			stdoutTruncated: stdout.truncated,
@@ -227,6 +259,8 @@ export async function runExternalTool(
 
 export const _internals: {
 	bunSpawn: typeof bunSpawn;
+	platform: () => NodeJS.Platform;
 } = {
 	bunSpawn,
+	platform: () => process.platform,
 };

--- a/tests/unit/utils/external-tool-runner.test.ts
+++ b/tests/unit/utils/external-tool-runner.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { BunCompatSubprocess } from '../../../src/utils/bun-compat';
+import {
+	_internals,
+	resolveExecutableFromPath,
+	runExternalTool,
+} from '../../../src/utils/external-tool-runner';
+
+const realBunSpawn = _internals.bunSpawn;
+
+function streamFromText(text: string): BunCompatSubprocess['stdout'] {
+	const bytes = new TextEncoder().encode(text);
+	return {
+		async text() {
+			return text;
+		},
+		async bytes() {
+			return bytes;
+		},
+		getReader() {
+			let done = false;
+			return new ReadableStream<Uint8Array>({
+				pull(controller) {
+					if (done) {
+						controller.close();
+						return;
+					}
+					done = true;
+					controller.enqueue(bytes);
+				},
+			}).getReader();
+		},
+	};
+}
+
+afterEach(() => {
+	_internals.bunSpawn = realBunSpawn;
+});
+
+describe('external-tool-runner', () => {
+	test('rejects non-absolute cwd before spawning', async () => {
+		let spawned = false;
+		_internals.bunSpawn = (() => {
+			spawned = true;
+			throw new Error('should not spawn');
+		}) as typeof realBunSpawn;
+
+		const result = await runExternalTool({
+			executable: 'tool',
+			args: [],
+			cwd: 'relative',
+			timeoutMs: 10,
+			maxStdoutBytes: 10,
+			maxStderrBytes: 10,
+		});
+
+		expect(result.status).toBe('spawn-error');
+		expect(result.message).toContain('cwd must be absolute');
+		expect(spawned).toBe(false);
+	});
+
+	test('passes bounded subprocess options and kills in cleanup', async () => {
+		const calls: Array<{ cmd: string[]; options: unknown }> = [];
+		let killCount = 0;
+		_internals.bunSpawn = ((cmd, options) => {
+			calls.push({ cmd, options });
+			return {
+				stdout: streamFromText('ok'),
+				stderr: streamFromText(''),
+				exited: Promise.resolve(0),
+				exitCode: 0,
+				kill: () => {
+					killCount++;
+				},
+			};
+		}) as typeof realBunSpawn;
+
+		const cwd = realpathSync(os.tmpdir());
+		const result = await runExternalTool({
+			executable: 'tool',
+			args: ['--flag'],
+			cwd,
+			timeoutMs: 1000,
+			maxStdoutBytes: 100,
+			maxStderrBytes: 100,
+		});
+
+		expect(result.status).toBe('completed');
+		expect(result.stdout).toBe('ok');
+		expect(calls[0].cmd).toEqual(['tool', '--flag']);
+		expect(calls[0].options).toMatchObject({
+			cwd,
+			stdin: 'ignore',
+			stdout: 'pipe',
+			stderr: 'pipe',
+			timeout: 1000,
+		});
+		expect(killCount).toBe(1);
+	});
+
+	test('returns timeout and kills a never-exiting process', async () => {
+		let killCount = 0;
+		_internals.bunSpawn = (() => ({
+			stdout: streamFromText(''),
+			stderr: streamFromText(''),
+			exited: new Promise<number>(() => {}),
+			exitCode: null,
+			kill: () => {
+				killCount++;
+			},
+		})) as typeof realBunSpawn;
+
+		const result = await runExternalTool({
+			executable: 'slow-tool',
+			args: [],
+			cwd: realpathSync(os.tmpdir()),
+			timeoutMs: 5,
+			maxStdoutBytes: 100,
+			maxStderrBytes: 100,
+		});
+
+		expect(result.status).toBe('timeout');
+		expect(killCount).toBeGreaterThanOrEqual(1);
+	});
+
+	test('resolves platform executable names from PATH lazily', () => {
+		const tmpDir = realpathSync(
+			mkdtempSync(path.join(os.tmpdir(), 'external-runner-')),
+		);
+		try {
+			const rgExe = path.join(tmpDir, 'rg.exe');
+			writeFileSync(rgExe, '');
+			expect(resolveExecutableFromPath(['rg'], tmpDir, 'win32')).toBe(rgExe);
+
+			const sg = path.join(tmpDir, 'sg');
+			writeFileSync(sg, '');
+			expect(resolveExecutableFromPath(['sg'], tmpDir, 'linux')).toBe(sg);
+		} finally {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/unit/utils/external-tool-runner.test.ts
+++ b/tests/unit/utils/external-tool-runner.test.ts
@@ -10,8 +10,15 @@ import {
 } from '../../../src/utils/external-tool-runner';
 
 const realBunSpawn = _internals.bunSpawn;
+const realPlatform = _internals.platform;
 
 function streamFromText(text: string): BunCompatSubprocess['stdout'] {
+	return streamFromChunks([text]);
+}
+
+function streamFromChunks(chunks: string[]): BunCompatSubprocess['stdout'] {
+	const encodedChunks = chunks.map((chunk) => new TextEncoder().encode(chunk));
+	const text = chunks.join('');
 	const bytes = new TextEncoder().encode(text);
 	return {
 		async text() {
@@ -21,15 +28,16 @@ function streamFromText(text: string): BunCompatSubprocess['stdout'] {
 			return bytes;
 		},
 		getReader() {
-			let done = false;
+			let index = 0;
 			return new ReadableStream<Uint8Array>({
 				pull(controller) {
-					if (done) {
+					const chunk = encodedChunks[index];
+					if (!chunk) {
 						controller.close();
 						return;
 					}
-					done = true;
-					controller.enqueue(bytes);
+					index += 1;
+					controller.enqueue(chunk);
 				},
 			}).getReader();
 		},
@@ -38,6 +46,7 @@ function streamFromText(text: string): BunCompatSubprocess['stdout'] {
 
 afterEach(() => {
 	_internals.bunSpawn = realBunSpawn;
+	_internals.platform = realPlatform;
 });
 
 describe('external-tool-runner', () => {
@@ -103,10 +112,14 @@ describe('external-tool-runner', () => {
 
 	test('returns timeout and kills a never-exiting process', async () => {
 		let killCount = 0;
+		let resolveExit!: (code: number) => void;
+		const exited = new Promise<number>((resolve) => {
+			resolveExit = resolve;
+		});
 		_internals.bunSpawn = (() => ({
 			stdout: streamFromText(''),
 			stderr: streamFromText(''),
-			exited: new Promise<number>(() => {}),
+			exited,
 			exitCode: null,
 			kill: () => {
 				killCount++;
@@ -124,6 +137,62 @@ describe('external-tool-runner', () => {
 
 		expect(result.status).toBe('timeout');
 		expect(killCount).toBeGreaterThanOrEqual(1);
+		resolveExit(143);
+	});
+
+	test('uses SIGTERM for timeout cleanup on Windows', async () => {
+		const signals: Array<NodeJS.Signals | number | undefined> = [];
+		let resolveExit!: (code: number) => void;
+		const exited = new Promise<number>((resolve) => {
+			resolveExit = resolve;
+		});
+		_internals.platform = () => 'win32';
+		_internals.bunSpawn = (() => ({
+			stdout: streamFromText(''),
+			stderr: streamFromText(''),
+			exited,
+			exitCode: null,
+			kill: (signal?: NodeJS.Signals | number) => {
+				signals.push(signal);
+			},
+		})) as typeof realBunSpawn;
+
+		const result = await runExternalTool({
+			executable: 'slow-tool',
+			args: [],
+			cwd: realpathSync(os.tmpdir()),
+			timeoutMs: 5,
+			maxStdoutBytes: 100,
+			maxStderrBytes: 100,
+		});
+
+		expect(result.status).toBe('timeout');
+		expect(signals).toContain('SIGTERM');
+		expect(signals).not.toContain('SIGKILL');
+		resolveExit(143);
+	});
+
+	test('truncates stdout across multiple chunks', async () => {
+		_internals.bunSpawn = (() => ({
+			stdout: streamFromChunks(['abc', 'defgh']),
+			stderr: streamFromText(''),
+			exited: Promise.resolve(0),
+			exitCode: 0,
+			kill: () => {},
+		})) as typeof realBunSpawn;
+
+		const result = await runExternalTool({
+			executable: 'chunky-tool',
+			args: [],
+			cwd: realpathSync(os.tmpdir()),
+			timeoutMs: 1000,
+			maxStdoutBytes: 6,
+			maxStderrBytes: 100,
+		});
+
+		expect(result.status).toBe('completed');
+		expect(result.stdout).toBe('abcdef');
+		expect(result.stdoutTruncated).toBe(true);
 	});
 
 	test('resolves platform executable names from PATH lazily', () => {


### PR DESCRIPTION
## Summary
- Harden `search` through a bounded shared external-tool runner and safer fallback traversal.
- Add read-only `ast_grep`, `actionlint_scan`, `osv_scan`, and `gh_evidence` wrappers with lazy binary resolution, structured missing-binary results, and bounded execution.
- Wire tool metadata/manifest/exports/docs/release notes and focused regression coverage for subprocess contracts, truncation, malformed output, registration coherence, and PR-feedback timeout cleanup.

## Invariant audit
- 1 (plugin init): touched - no new init-time probes; external binaries resolve only inside tool execution. Verified `node scripts\repro-704.mjs` PASS after sandbox escalation: T1 225.2ms/400ms, T2 85.6ms, T3 94.7ms. The harness printed all PASS results, then required manual cleanup of the lingering validation process.
- 2 (runtime portability): touched - external runner uses the existing Bun compatibility layer and array-form subprocess calls; verified `bun run build` PASS and `node --input-type=module -e "await import('./dist/index.js')"` PASS.
- 3 (subprocesses): touched - `src/utils/external-tool-runner.ts` centralizes explicit absolute `cwd`, `stdin: 'ignore'`, timeout, bounded stdout/stderr, Windows-safe timeout kill signal, and best-effort kill. Covered by `tests/unit/utils/external-tool-runner.test.ts`, focused tool tests, and subprocess grep of the only runner spawn call.
- 4 (.swarm containment): not touched - tools read under injected workspace directories; PR evidence files are runtime artifacts under `.swarm/` and are not committed.
- 5 (plan durability): not touched - no ledger, projection, checkpoint, or plan schema changes.
- 6 (test_runner safety): not touched - validation used shell commands, not broad OpenCode `test_runner` scopes.
- 7 (test writing): touched - tests use `bun:test`, temp directories, and `_internals` seams restored after each test; verified focused tool/runner tests PASS.
- 8 (session state): not touched - no session/global state changes.
- 9 (guardrails/retry): not touched - no guardrail or retry logic changes.
- 10 (chat/system msg): not touched - no chat or system-message hook changes.
- 11 (tool registration): touched - updated metadata, manifest, exports, and docs; verified `bun run scripts\check-tool-registration.ts` PASS with 104 coherent tools, registration test set PASS, drift check PASS, and config map subset PASS.
- 12 (release/cache): touched - added `docs/releases/pending/search-ripgrep-runner-hardening.md`; no version, changelog, release manifest, or cache deletion changes.

## Test plan
- PASS `bunx @biomejs/biome@2.3.14 ci .`
- PASS `bun run typecheck`
- PASS `bun --smol test tests\unit\utils\external-tool-runner.test.ts src\tools\ast-grep.test.ts src\tools\external-cli-tools.test.ts src\tools\search.test.ts src\tools\search.adversarial.test.ts --timeout 60000` (155 pass)
- PASS `bun --smol test src\tools\search.test.ts src\tools\search.adversarial.test.ts src\tools\ast-grep.test.ts src\tools\external-cli-tools.test.ts tests\unit\utils\external-tool-runner.test.ts --timeout 60000` (153 pass, prior head before feedback tests were added)
- PASS `bun --smol test tests\unit\tools\manifest-parity.test.ts tests\unit\tools\registration-smoke.test.ts tests\unit\tools\tool-registration-conformance.test.ts tests\unit\tools\tool-names.test.ts src\tools\plugin-registration-adversarial.test.ts --timeout 60000` (50 pass)
- PASS `bun run build`
- PASS `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- PASS `node scripts\repro-704.mjs` after sandbox escalation (T1 225.2ms/400ms, T2 85.6ms, T3 94.7ms; harness printed PASS and then needed manual cleanup of the lingering validation process)
- PASS `git diff --check`
- PASS `Select-String -Path src\utils\external-tool-runner.ts -Pattern 'bunSpawn\(|spawn\(|spawnSync\(' -Context 0,8` confirmed the runner spawn has explicit `cwd`, `stdin: 'ignore'`, bounded pipes, and timeout.
- PASS `bun run scripts\check-tool-registration.ts`
- PASS `bun run drift:check`
- PASS `bun --smol test tests\unit\config\agent-tool-map.test.ts tests\unit\config\critic-registration.test.ts tests\unit\config\constants.test.ts --timeout 60000` (48 pass)
- PASS `bun --smol test tests\unit\config\quiet-config.test.ts --timeout 60000` with sandbox escalation (19 pass)
- KNOWN BASELINE FAIL `bun --smol test tests\unit\config --timeout 120000` with sandbox escalation: 1464 pass, 1 fail in `ExecutionProfileSchema > defaults > parses empty object with all defaults` (`max_concurrent_tasks` expected 1, received 10). Reproduced on clean `origin/main` at `dc539021e34a1f8797abe7441ff6ea905a7f29e1` after `bun install --frozen-lockfile` in `C:\tmp\opencode-swarm-main-check`.
