### PR TITLE
feat(plan): relocate SWARM_PLAN exports to .swarm/plan-export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Every PR that touches a relevant area must list which of these invariants it tou
 ### 5. Plan durability — ledger is authoritative
 
 - `.swarm/plan-ledger.jsonl` is the authoritative source of plan state. `.swarm/plan.json` and `.swarm/plan.md` are derived projections.
-- `SWARM_PLAN.{json,md}` files are checkpoint / export artifacts, scoped to `.swarm/` (v7.0.1 / `#583`).
+- `SWARM_PLAN.{json,md}` files are checkpoint / export artifacts, scoped to `.swarm/plan-export/` (issue #852). Legacy reads from flat `.swarm/` and project root are supported with deprecation warnings; cleanup removes all three locations.
 - Do not hand-edit `plan.md` as a source of truth. Do not write to `plan.json` outside the ledger replay path.
 - Any plan-schema or status-shape change must update **all six** of: ledger replay, projection, checkpoint import/export, `get_approved_plan`, tests, and docs (`docs/plan-durability.md`).
 

--- a/docs/plan-durability.md
+++ b/docs/plan-durability.md
@@ -11,11 +11,11 @@
 | `.swarm/plan-ledger.jsonl` | Durable runtime record of all plan events | **Authoritative** — append-only, never delete |
 | `.swarm/plan.json` | Machine-readable projection of current plan state | Derived — can be rebuilt from ledger |
 | `.swarm/plan.md` | Human-readable plan view | Derived — generated from plan.json |
-| `.swarm/SWARM_PLAN.md` | Operator checkpoint artifact | Export-only — not live source of truth |
-| `.swarm/SWARM_PLAN.json` | Machine-readable checkpoint artifact | Export-only — for import/export workflows |
+| `.swarm/plan-export/SWARM_PLAN.md` | Operator checkpoint artifact | Export-only — not live source of truth |
+| `.swarm/plan-export/SWARM_PLAN.json` | Machine-readable checkpoint artifact | Export-only — for import/export workflows |
 | `.swarm/.plan-write-marker` | Advisory write counter for PlanSyncWorker | Advisory — used to detect unauthorized writes |
 
-> **Migration note:** As of v7.x, SWARM_PLAN files live inside `.swarm/` instead of the project root. The `/swarm close` command cleans up both locations during the transition window.
+> **Migration note:** As of v7.x, SWARM_PLAN files live inside `.swarm/plan-export/` instead of the project root. The `/swarm close` and `/swarm reset --confirm` commands clean up all three locations (`.swarm/plan-export/`, flat `.swarm/`, and project root) during the transition window.
 
 ### Ledger Event Types
 
@@ -29,7 +29,7 @@
 {"type":"phase_completed","phase":1,"ts":"ISO8601"}
 {"type":"snapshot","data":{"plan":{...},"payload_hash":"abc123"},"ts":"ISO8601"}
 {"type":"plan_rebuilt","source":"rebuildPlan","plan_id":"...","payload":{"reason":"ledger_replay_recovery | approved_snapshot_fallback | validation_failure_recovery | ...","phases_count":1,"tasks_count":3},"ts":"ISO8601"}
-{"type":"plan_exported","path":".swarm/SWARM_PLAN.json","ts":"ISO8601"}
+{"type":"plan_exported","path":".swarm/plan-export/SWARM_PLAN.json","ts":"ISO8601"}
 {"type":"plan_reset","ts":"ISO8601"}
 {"type":"execution_profile_set","data":{"execution_profile":{...}},"ts":"ISO8601"}
 {"type":"execution_profile_locked","ts":"ISO8601"}
@@ -116,10 +116,10 @@ loadPlan()
 
 ### Import
 
-`importCheckpoint()` reads `.swarm/SWARM_PLAN.json` (falling back to a legacy root-level `SWARM_PLAN.json` with a deprecation warning) → validates schema → calls `savePlan()` → appends `plan_rebuilt` event to ledger.
+`importCheckpoint()` reads `.swarm/plan-export/SWARM_PLAN.json` (with backward-compat fallback to flat `.swarm/` then project root, each with a deprecation warning) → validates schema → calls `savePlan()` → appends `plan_rebuilt` event to ledger.
 
 ```
-importCheckpoint(.swarm/SWARM_PLAN.json)
+importCheckpoint(.swarm/plan-export/SWARM_PLAN.json)
   → validateSchema()
   → savePlan(planData)
   → append {type:"plan_rebuilt"} to plan-ledger.jsonl
@@ -132,7 +132,7 @@ importCheckpoint(.swarm/SWARM_PLAN.json)
 - `phase_complete` command  
 - `/swarm close` command
 
-Writes `.swarm/SWARM_PLAN.md` and `.swarm/SWARM_PLAN.json` inside the working directory's `.swarm/` folder.
+Writes `.swarm/plan-export/SWARM_PLAN.md` and `.swarm/plan-export/SWARM_PLAN.json` inside the working directory's `.swarm/plan-export/` subfolder.
 
 ## Snapshot System
 
@@ -236,7 +236,7 @@ once pre-check succeeds.
 - **Fail-closed enforcement**: the delegation gate enforces a locked profile — `parallelization_enabled: false` blocks Stage B parallel dispatch regardless of global plugin config.
 - **Ledger authority**: profile changes are recorded as `execution_profile_set` / `execution_profile_locked` events. Replay rebuilds the profile deterministically from these events.
 - **Hash coverage**: `execution_profile` is included in `computePlanHash`, so profile changes are always reflected in the ledger's `plan_hash_after` chain.
-- **All surfaces carry the profile**: snapshot events, checkpoint export (`.swarm/SWARM_PLAN.json`), handoff data, export data, and `get_approved_plan` output all include `execution_profile`.
+- **All surfaces carry the profile**: snapshot events, checkpoint export (`.swarm/plan-export/SWARM_PLAN.json`), handoff data, export data, and `get_approved_plan` output all include `execution_profile`.
 
 ### Lifecycle
 
@@ -256,7 +256,7 @@ once pre-check succeeds.
 | `plan.json` | ✅ Persisted in schema |
 | Ledger replay | ✅ Via `execution_profile_set` events |
 | Snapshot events | ✅ Embedded in Plan payload |
-| `.swarm/SWARM_PLAN.json` checkpoint | ✅ Via full Plan payload |
+| `.swarm/plan-export/SWARM_PLAN.json` checkpoint | ✅ Via full Plan payload |
 | `get_approved_plan` tool | ✅ Explicit `execution_profile` field |
 | Handoff data | ✅ In `HandoffData.execution_profile` |
 | Export data | ✅ In `ExportData.execution_profile` |

--- a/docs/releases/pending/852-swarm-plan-export-relocation.md
+++ b/docs/releases/pending/852-swarm-plan-export-relocation.md
@@ -1,0 +1,21 @@
+# SWARM_PLAN export artifacts relocated to `.swarm/plan-export/` (issue #852)
+
+## What
+
+`SWARM_PLAN.{json,md}` checkpoint/export artifacts are now written to `.swarm/plan-export/` instead of flat `.swarm/`. This separates static export artifacts from live plan state.
+
+- **`writeCheckpoint()`** now writes to `.swarm/plan-export/SWARM_PLAN.{json,md}` with a self-documenting header in the `.md` file.
+- **`importCheckpoint()`** uses a 3-tier read fallback (`.swarm/plan-export/` → legacy flat `.swarm/` → legacy project root), each legacy tier emits a deprecation warning.
+- **`/swarm close`** and **`/swarm reset --confirm`** cleanup now removes SWARM_PLAN artifacts from all three locations (`.swarm/plan-export/`, flat `.swarm/`, and project root).
+
+## Why
+
+Flat `.swarm/` mixed live plan state (`.swarm/plan.json`, `.swarm/plan.md`) with static export checkpoints. Separating them makes the artifact layout more intuitive and makes cleanup unambiguous.
+
+## Migration
+
+No user action required. The change is fully backward-compatible:
+
+- **Reads:** `importCheckpoint()` automatically falls back to legacy flat `.swarm/SWARM_PLAN.json` or root-level `SWARM_PLAN.json` if the new location is empty, emitting a deprecation warning in each case.
+- **Writes:** New sessions write to `.swarm/plan-export/` only. Old sessions that still have artifacts in flat `.swarm/` or project root will continue to work; running `/swarm close` cleans up those legacy copies.
+- **Cleanup:** `/swarm close` and `/swarm reset --confirm` now target all three locations, so switching to the new layout does not leave orphaned files behind.

--- a/docs/troubleshooting/recovery-guide.md
+++ b/docs/troubleshooting/recovery-guide.md
@@ -14,7 +14,7 @@ This guide covers common recovery scenarios for the opencode-swarm plan durabili
 import { importCheckpoint } from './src/plan/checkpoint'
 await importCheckpoint()
 
-# Option 2: Restore from .swarm/SWARM_PLAN.json by copying it to `.swarm/plan.json`
+# Option 2: Restore from .swarm/plan-export/SWARM_PLAN.json by copying it to `.swarm/plan.json`
 ```
 
 ---
@@ -40,7 +40,7 @@ await importCheckpoint()
 
 **Fix:** Automatic rebuild from ledger. If rebuild fails:
 ```bash
-# Restore from .swarm/SWARM_PLAN.json by copying it to `.swarm/plan.json`
+# Restore from .swarm/plan-export/SWARM_PLAN.json by copying it to `.swarm/plan.json`
 ```
 
 ---
@@ -54,7 +54,7 @@ await importCheckpoint()
 
 **Do NOT use for:**
 - Ledger corruption (use rebuild/import instead)
-- Missing plan files (use `importCheckpoint()` programmatically or restore from .swarm/SWARM_PLAN.json instead)
+- Missing plan files (use `importCheckpoint()` programmatically or restore from `.swarm/plan-export/SWARM_PLAN.json` instead)
 
 ---
 
@@ -65,7 +65,7 @@ await importCheckpoint()
 - Ledger is intact but plan projection is corrupted
 
 **Use import when:**
-- Starting fresh in a new repo with an existing `.swarm/SWARM_PLAN.json` checkpoint
+- Starting fresh in a new repo with an existing `.swarm/plan-export/SWARM_PLAN.json` checkpoint
 - Ledger is also missing/corrupted and you have a checkpoint backup
 
 ---

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -1326,11 +1326,14 @@ export async function runCleanStage(
 	}
 
 	// Remove SWARM_PLAN checkpoint artifacts written by writeCheckpoint().
-	// Cleans both the canonical .swarm/ location and any legacy root-level
-	// artifacts from pre-7.0 sessions. These are redundant copies of
-	// plan.json/plan.md (already archived) and should not be left behind.
+	// Cleans the new .swarm/plan-export/ location, the canonical .swarm/
+	// location, and any legacy root-level artifacts from pre-7.0 sessions.
+	// These are redundant copies of plan.json/plan.md (already archived)
+	// and should not be left behind.
 	let swarmPlanFilesRemoved = 0;
 	const candidates = [
+		path.join(ctx.directory, '.swarm', 'plan-export', 'SWARM_PLAN.json'),
+		path.join(ctx.directory, '.swarm', 'plan-export', 'SWARM_PLAN.md'),
 		path.join(ctx.directory, '.swarm', 'SWARM_PLAN.json'),
 		path.join(ctx.directory, '.swarm', 'SWARM_PLAN.md'),
 		path.join(ctx.directory, 'SWARM_PLAN.json'),
@@ -1745,7 +1748,7 @@ export async function handleCloseCommand(
 				: []),
 			...(cleanResult.swarmPlanFilesRemoved > 0
 				? [
-						`- Removed ${cleanResult.swarmPlanFilesRemoved} SWARM_PLAN checkpoint artifact(s)`,
+						`- Removed ${cleanResult.swarmPlanFilesRemoved} SWARM_PLAN checkpoint artifact(s) from .swarm/plan-export/ and legacy locations`,
 					]
 				: []),
 			...(ctx.planExists && !ctx.planAlreadyDone

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -23,7 +23,7 @@ export async function handleResetCommand(
 		return [
 			'## Swarm Reset',
 			'',
-			'⚠️ This will delete all swarm state from .swarm/ (plan, context, checkpoints, SWARM_PLAN artifacts)',
+			'⚠️ This will delete all swarm state from .swarm/ (plan, context, checkpoints, SWARM_PLAN artifacts including .swarm/plan-export/)',
 			'',
 			'**Tip**: Run `/swarm export` first to backup your state.',
 			'',
@@ -38,6 +38,8 @@ export async function handleResetCommand(
 		'context.md',
 		'SWARM_PLAN.md',
 		'SWARM_PLAN.json',
+		'plan-export/SWARM_PLAN.md',
+		'plan-export/SWARM_PLAN.json',
 		'checkpoints.json',
 		'events.jsonl',
 	];

--- a/src/plan/checkpoint.test.ts
+++ b/src/plan/checkpoint.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { importCheckpoint, writeCheckpoint } from './checkpoint';
+import { _fsInternals, importCheckpoint, writeCheckpoint } from './checkpoint';
 import { savePlan } from './manager';
 
 function createTempDir(): string {
@@ -60,7 +66,12 @@ describe('writeCheckpoint', () => {
 				await writeCheckpoint(tmpDir);
 
 				// Verify SWARM_PLAN.json exists and contains valid JSON
-				const jsonPath = join(tmpDir, '.swarm', 'SWARM_PLAN.json');
+				const jsonPath = join(
+					tmpDir,
+					'.swarm',
+					'plan-export',
+					'SWARM_PLAN.json',
+				);
 				expect(existsSync(jsonPath)).toBe(true);
 
 				const content = readFileSync(jsonPath, 'utf8');
@@ -82,7 +93,7 @@ describe('writeCheckpoint', () => {
 		});
 	});
 
-	describe('writes SWARM_PLAN.md inside .swarm/', () => {
+	describe('writes SWARM_PLAN.md inside .swarm/plan-export/', () => {
 		test('writes markdown content with plan details', async () => {
 			const tmpDir = createTempDir();
 			try {
@@ -91,7 +102,7 @@ describe('writeCheckpoint', () => {
 
 				await writeCheckpoint(tmpDir);
 
-				const mdPath = join(tmpDir, '.swarm', 'SWARM_PLAN.md');
+				const mdPath = join(tmpDir, '.swarm', 'plan-export', 'SWARM_PLAN.md');
 				expect(existsSync(mdPath)).toBe(true);
 
 				const content = readFileSync(mdPath, 'utf8');
@@ -99,6 +110,27 @@ describe('writeCheckpoint', () => {
 				expect(content).toContain('Swarm: test-swarm');
 				expect(content).toContain('Phase 1');
 				expect(content).toContain('Test task');
+			} finally {
+				cleanupTempDir(tmpDir);
+			}
+		});
+
+		test('SWARM_PLAN.md contains self-documenting auto-generated header', async () => {
+			const tmpDir = createTempDir();
+			try {
+				mkdirSync(join(tmpDir, '.swarm'), { recursive: true });
+				await savePlan(tmpDir, validPlan);
+
+				await writeCheckpoint(tmpDir);
+
+				const mdPath = join(tmpDir, '.swarm', 'plan-export', 'SWARM_PLAN.md');
+				const content = readFileSync(mdPath, 'utf8');
+
+				expect(content).toContain('AUTO-GENERATED');
+				expect(content).toContain('NOT the live plan');
+				expect(content).toContain('.swarm/plan-ledger.jsonl');
+				expect(content).toContain('.swarm/plan.json');
+				expect(content).toContain('.swarm/plan.md');
 			} finally {
 				cleanupTempDir(tmpDir);
 			}
@@ -133,7 +165,12 @@ describe('writeCheckpoint', () => {
 
 				await writeCheckpoint(tmpDir);
 
-				const jsonPath = join(tmpDir, '.swarm', 'SWARM_PLAN.json');
+				const jsonPath = join(
+					tmpDir,
+					'.swarm',
+					'plan-export',
+					'SWARM_PLAN.json',
+				);
 				const originalContent = readFileSync(jsonPath, 'utf8');
 
 				// Modify the plan and save again
@@ -160,7 +197,7 @@ describe('writeCheckpoint', () => {
 
 				await writeCheckpoint(tmpDir);
 
-				const mdPath = join(tmpDir, '.swarm', 'SWARM_PLAN.md');
+				const mdPath = join(tmpDir, '.swarm', 'plan-export', 'SWARM_PLAN.md');
 				const originalContent = readFileSync(mdPath, 'utf8');
 
 				// Modify the plan and save again
@@ -190,7 +227,12 @@ describe('writeCheckpoint', () => {
 				await writeCheckpoint(tmpDir);
 
 				// Read both files
-				const checkpointPath = join(tmpDir, '.swarm', 'SWARM_PLAN.json');
+				const checkpointPath = join(
+					tmpDir,
+					'.swarm',
+					'plan-export',
+					'SWARM_PLAN.json',
+				);
 				const planPath = join(tmpDir, '.swarm', 'plan.json');
 
 				const checkpointContent = readFileSync(checkpointPath, 'utf8');
@@ -324,6 +366,163 @@ describe('importCheckpoint', () => {
 			// Verify the savePlan side effect created .swarm/plan.json
 			const savedPlanPath = join(tmpDir, '.swarm', 'plan.json');
 			expect(existsSync(savedPlanPath)).toBe(true);
+		} finally {
+			cleanupTempDir(tmpDir);
+		}
+	});
+
+	test('imports legacy flat .swarm/SWARM_PLAN.json (tier 2) with deprecation warning', async () => {
+		const tmpDir = createTempDir();
+		try {
+			// Note: do NOT create .swarm/plan-export/SWARM_PLAN.json — we're testing
+			// the tier 2 fallback to the legacy flat .swarm/ location.
+			mkdirSync(join(tmpDir, '.swarm'), { recursive: true });
+			const { writeFileSync } = await import('node:fs');
+			const legacyPath = join(tmpDir, '.swarm', 'SWARM_PLAN.json');
+			writeFileSync(legacyPath, JSON.stringify(validPlan, null, 2), 'utf8');
+
+			const result = await importCheckpoint(tmpDir);
+			expect(result.success).toBe(true);
+			expect(result.plan).not.toBeNull();
+			expect(result.plan!.title).toBe('Import Test Plan');
+
+			// Verify the savePlan side effect created .swarm/plan.json
+			const savedPlanPath = join(tmpDir, '.swarm', 'plan.json');
+			expect(existsSync(savedPlanPath)).toBe(true);
+		} finally {
+			cleanupTempDir(tmpDir);
+		}
+	});
+});
+
+// ============================================================================
+// Adversarial path-handling edge cases
+// ============================================================================
+
+describe('writeCheckpoint — adversarial edge cases', () => {
+	const validPlan = {
+		schema_version: '1.0.0' as const,
+		title: 'Adv Test Plan',
+		swarm: 'test-swarm',
+		current_phase: 1,
+		phases: [
+			{
+				id: 1,
+				name: 'Phase 1',
+				status: 'pending' as const,
+				tasks: [
+					{
+						id: '1.1',
+						phase: 1,
+						status: 'pending' as const,
+						size: 'small' as const,
+						description: 'Adv task',
+						depends: [],
+						files_touched: [],
+					},
+				],
+			},
+		],
+	};
+
+	// Vector 1: read-only parent — mkdirSync fails; writeCheckpoint stays non-blocking
+	test('writeCheckpoint returns normally when mkdirSync throws (non-blocking property)', async () => {
+		const tmpDir = createTempDir();
+		try {
+			mkdirSync(join(tmpDir, '.swarm'), { recursive: true });
+			await savePlan(tmpDir, validPlan);
+
+			// Force mkdirSync to throw via _fsInternals DI seam, simulating a read-only parent.
+			const original = _fsInternals.mkdirSync;
+			_fsInternals.mkdirSync = () => {
+				throw new Error('EACCES: permission denied');
+			};
+
+			// Must NOT throw — non-blocking contract: catch block swallows the error
+			await writeCheckpoint(tmpDir);
+
+			// Restore
+			_fsInternals.mkdirSync = original;
+		} finally {
+			cleanupTempDir(tmpDir);
+		}
+	});
+
+	// Vector 3: malformed JSON at new plan-export path returns {success:false} cleanly
+	test('importCheckpoint returns failure when new plan-export SWARM_PLAN.json is malformed JSON', async () => {
+		const tmpDir = createTempDir();
+		try {
+			mkdirSync(join(tmpDir, '.swarm'), { recursive: true });
+			mkdirSync(join(tmpDir, '.swarm', 'plan-export'), { recursive: true });
+
+			// Write malformed JSON at the new location
+			writeFileSync(
+				join(tmpDir, '.swarm', 'plan-export', 'SWARM_PLAN.json'),
+				'{"schema_version": "1.0.0", this is not valid JSON',
+				'utf8',
+			);
+
+			const result = await importCheckpoint(tmpDir);
+			expect(result.success).toBe(false);
+			expect(result.error).toBeDefined();
+			expect(result.error).toContain('JSON');
+		} finally {
+			cleanupTempDir(tmpDir);
+		}
+	});
+});
+
+describe('importCheckpoint — adversarial edge cases', () => {
+	const validPlan = {
+		schema_version: '1.0.0' as const,
+		title: 'Adv Test Plan',
+		swarm: 'test-swarm',
+		current_phase: 1,
+		phases: [
+			{
+				id: 1,
+				name: 'Phase 1',
+				status: 'pending' as const,
+				tasks: [
+					{
+						id: '1.1',
+						phase: 1,
+						status: 'pending' as const,
+						size: 'small' as const,
+						description: 'Adv task',
+						depends: [],
+						files_touched: [],
+					},
+				],
+			},
+		],
+	};
+
+	// Vector 2: new location preferred over legacy — stale legacy must NOT shadow new
+	test('new .swarm/plan-export/SWARM_PLAN.json is preferred over stale legacy tiers', async () => {
+		const tmpDir = createTempDir();
+		try {
+			mkdirSync(join(tmpDir, '.swarm'), { recursive: true });
+			mkdirSync(join(tmpDir, '.swarm', 'plan-export'), { recursive: true });
+
+			// Put a valid plan at NEW location
+			writeFileSync(
+				join(tmpDir, '.swarm', 'plan-export', 'SWARM_PLAN.json'),
+				JSON.stringify({ ...validPlan, title: 'New Location Plan' }, null, 2),
+				'utf8',
+			);
+
+			// Put a DIFFERENT (stale) plan at legacy tier-2 location
+			writeFileSync(
+				join(tmpDir, '.swarm', 'SWARM_PLAN.json'),
+				JSON.stringify({ ...validPlan, title: 'Legacy Stale Plan' }, null, 2),
+				'utf8',
+			);
+
+			const result = await importCheckpoint(tmpDir);
+			expect(result.success).toBe(true);
+			// Must load from NEW location, NOT legacy
+			expect(result.plan!.title).toBe('New Location Plan');
 		} finally {
 			cleanupTempDir(tmpDir);
 		}

--- a/src/plan/checkpoint.ts
+++ b/src/plan/checkpoint.ts
@@ -1,11 +1,23 @@
 /**
  * Checkpoint artifact writer.
- * Writes SWARM_PLAN.md and SWARM_PLAN.json inside .swarm/.
+ * Writes SWARM_PLAN.md and SWARM_PLAN.json inside .swarm/plan-export/.
  * Export-only — not a live runtime source of truth.
  * Called on: save_plan, phase completion, /swarm close.
  * NOT called on every task update.
  */
 import * as fs from 'node:fs';
+
+// _internals DI seam — allows tests to mock fs operations without mock.module pollution
+export const _fsInternals = {
+	mkdirSync: (...args: Parameters<typeof fs.mkdirSync>) =>
+		fs.mkdirSync(...args),
+	writeFileSync: (path: string, data: string, encoding?: BufferEncoding) =>
+		fs.writeFileSync(path, data, encoding ?? 'utf8'),
+	readFileSync: (path: string, encoding?: BufferEncoding) =>
+		fs.readFileSync(path, encoding ?? 'utf8'),
+	existsSync: (path: string) => fs.existsSync(path),
+};
+
 import * as path from 'node:path';
 import { type Plan, PlanSchema } from '../config/plan-schema';
 import { appendLedgerEvent } from '../plan/ledger';
@@ -17,7 +29,7 @@ import {
 } from './manager';
 
 /**
- * Write SWARM_PLAN.json and SWARM_PLAN.md inside the .swarm/ directory under the project root.
+ * Write SWARM_PLAN.json and SWARM_PLAN.md inside the .swarm/plan-export/ directory under the project root.
  * Non-blocking: logs a warning on failure but never throws.
  * @param directory - The working directory (project root)
  */
@@ -26,17 +38,25 @@ export async function writeCheckpoint(directory: string): Promise<void> {
 		const plan = await loadPlan(directory);
 		if (!plan) return;
 
-		const swarmDir = path.join(directory, '.swarm');
-		fs.mkdirSync(swarmDir, { recursive: true });
-		const jsonPath = path.join(swarmDir, 'SWARM_PLAN.json');
-		const mdPath = path.join(swarmDir, 'SWARM_PLAN.md');
+		const exportDir = path.join(directory, '.swarm', 'plan-export');
+		_fsInternals.mkdirSync(exportDir, { recursive: true });
+		const jsonPath = path.join(exportDir, 'SWARM_PLAN.json');
+		const mdPath = path.join(exportDir, 'SWARM_PLAN.md');
 
 		// Write JSON checkpoint
-		fs.writeFileSync(jsonPath, JSON.stringify(plan, null, 2), 'utf8');
+		_fsInternals.writeFileSync(jsonPath, JSON.stringify(plan, null, 2));
 
 		// Write Markdown checkpoint
 		const md = derivePlanMarkdown(plan);
-		fs.writeFileSync(mdPath, md, 'utf8');
+		const header = `<!--
+AUTO-GENERATED EXPORT/CHECKPOINT SNAPSHOT — DO NOT EDIT
+This file is NOT the live plan. It is a derived export artifact.
+- .swarm/plan-ledger.jsonl is the authoritative source of plan state.
+- .swarm/plan.json and .swarm/plan.md are derived projections.
+Regenerated on: save_plan and phase_complete.
+-->
+`;
+		_fsInternals.writeFileSync(mdPath, header + md);
 	} catch (error) {
 		// Non-blocking: checkpoint failure must never break the calling operation
 		console.warn(
@@ -55,7 +75,7 @@ export interface ImportCheckpointResult {
 }
 
 /**
- * Import a checkpoint from .swarm/SWARM_PLAN.json (with backward-compat fallback to project root).
+ * Import a checkpoint from .swarm/plan-export/SWARM_PLAN.json (with backward-compat fallback to .swarm/ and project root).
  * Validates the checkpoint against PlanSchema, persists it as the live plan
  * via savePlan, and appends a 'plan_rebuilt' ledger event.
  *
@@ -68,23 +88,36 @@ export async function importCheckpoint(
 	source?: string,
 ): Promise<ImportCheckpointResult> {
 	try {
+		const exportPath = path.join(
+			directory,
+			'.swarm',
+			'plan-export',
+			'SWARM_PLAN.json',
+		);
 		const swarmDirPath = path.join(directory, '.swarm', 'SWARM_PLAN.json');
 		const rootPath = path.join(directory, 'SWARM_PLAN.json');
 		let checkpointPath: string;
 		let rawContent: string;
-		if (fs.existsSync(swarmDirPath)) {
+		if (_fsInternals.existsSync(exportPath)) {
+			checkpointPath = exportPath;
+			rawContent = _fsInternals.readFileSync(checkpointPath);
+		} else if (_fsInternals.existsSync(swarmDirPath)) {
 			checkpointPath = swarmDirPath;
-			rawContent = fs.readFileSync(checkpointPath, 'utf8');
-		} else if (fs.existsSync(rootPath)) {
+			rawContent = _fsInternals.readFileSync(checkpointPath);
+			console.warn(
+				'[checkpoint] importCheckpoint: using legacy flat .swarm/SWARM_PLAN.json. This location is deprecated and will be removed in a future version. Run /swarm close to migrate.',
+			);
+		} else if (_fsInternals.existsSync(rootPath)) {
 			checkpointPath = rootPath;
-			rawContent = fs.readFileSync(checkpointPath, 'utf8');
+			rawContent = _fsInternals.readFileSync(checkpointPath);
 			console.warn(
 				'[checkpoint] importCheckpoint: using legacy root-level SWARM_PLAN.json. Consider running /swarm close to migrate.',
 			);
 		} else {
 			return {
 				success: false,
-				error: 'SWARM_PLAN.json not found in .swarm/ or project root',
+				error:
+					'SWARM_PLAN.json not found in .swarm/plan-export/, .swarm/, or project root',
 			};
 		}
 		const parsed = JSON.parse(rawContent);

--- a/src/plan/manager.ts
+++ b/src/plan/manager.ts
@@ -493,7 +493,7 @@ export async function loadPlan(directory: string): Promise<RuntimePlan | null> {
 												reason: 'ledger_hash_mismatch_recovery',
 											});
 											warn(
-												'[loadPlan] Rebuilt plan from ledger. Checkpoint available at .swarm/SWARM_PLAN.md if it exists.',
+												'[loadPlan] Rebuilt plan from ledger. Checkpoint available at .swarm/plan-export/SWARM_PLAN.md if it exists.',
 											);
 											return rebuilt;
 										}
@@ -544,7 +544,7 @@ export async function loadPlan(directory: string): Promise<RuntimePlan | null> {
 											// Fall through to the stale-plan warning below
 										}
 										warn(
-											`[loadPlan] Ledger replay failed during hash-mismatch rebuild: ${replayError instanceof Error ? replayError.message : String(replayError)}. Returning stale plan.json. To recover: check .swarm/SWARM_PLAN.md for a checkpoint, or run /swarm reset-session.`,
+											`[loadPlan] Ledger replay failed during hash-mismatch rebuild: ${replayError instanceof Error ? replayError.message : String(replayError)}. Returning stale plan.json. To recover: check .swarm/plan-export/SWARM_PLAN.md for a checkpoint, or run /swarm reset-session.`,
 										);
 									}
 									// Fall through and return the validated plan.json
@@ -628,7 +628,7 @@ export async function loadPlan(directory: string): Promise<RuntimePlan | null> {
 			} catch (error) {
 				// Step 2: Validation failed, log warning and fall through to legacy
 				warn(
-					`[loadPlan] plan.json validation failed: ${error instanceof Error ? error.message : String(error)}. Attempting rebuild from ledger. If rebuild fails, check .swarm/SWARM_PLAN.md for a checkpoint.`,
+					`[loadPlan] plan.json validation failed: ${error instanceof Error ? error.message : String(error)}. Attempting rebuild from ledger. If rebuild fails, check .swarm/plan-export/SWARM_PLAN.md for a checkpoint.`,
 				);
 				// MIGRATION GUARD (catch path): Extract swarm+title from the raw JSON
 				// before schema validation even though validation failed. If we can determine

--- a/tests/unit/commands/close-finalizer.test.ts
+++ b/tests/unit/commands/close-finalizer.test.ts
@@ -566,6 +566,26 @@ describe('handleCloseCommand — finalizer stages', () => {
 			expect(existsSync(path.join(swarmDir(), 'SWARM_PLAN.md'))).toBe(false);
 		});
 
+		it('removes SWARM_PLAN.{json,md} from .swarm/plan-export/ after close', async () => {
+			await writePlan();
+			// Create the new plan-export/ SWARM_PLAN checkpoint artifacts
+			const planExportDir = path.join(swarmDir(), 'plan-export');
+			mkdirSync(planExportDir, { recursive: true });
+			writeFileSync(
+				path.join(planExportDir, 'SWARM_PLAN.json'),
+				'{"title":"Test"}',
+			);
+			writeFileSync(path.join(planExportDir, 'SWARM_PLAN.md'), '# Test Plan');
+
+			await handleCloseCommand(testDir, []);
+
+			// plan-export/ SWARM_PLAN artifacts must be removed
+			expect(existsSync(path.join(planExportDir, 'SWARM_PLAN.json'))).toBe(
+				false,
+			);
+			expect(existsSync(path.join(planExportDir, 'SWARM_PLAN.md'))).toBe(false);
+		});
+
 		it('SWARM_PLAN cleanup is non-blocking — close succeeds even if removal fails', async () => {
 			await writePlan();
 

--- a/tests/unit/commands/reset.test.ts
+++ b/tests/unit/commands/reset.test.ts
@@ -254,6 +254,30 @@ describe('handleResetCommand', () => {
 		expect(existsSync(join(tempDir, '.swarm', 'SWARM_PLAN.md'))).toBe(false);
 	});
 
+	test('With --confirm - deletes SWARM_PLAN artifacts from .swarm/plan-export/', async () => {
+		await mkdir(join(tempDir, '.swarm', 'plan-export'), { recursive: true });
+		await writeFile(
+			join(tempDir, '.swarm', 'plan-export', 'SWARM_PLAN.json'),
+			'{}',
+		);
+		await writeFile(
+			join(tempDir, '.swarm', 'plan-export', 'SWARM_PLAN.md'),
+			'# Plan',
+		);
+
+		const result = await handleResetCommand(tempDir, ['--confirm']);
+
+		expect(result).toContain('## Swarm Reset Complete');
+		expect(result).toContain('✅ Deleted plan-export/SWARM_PLAN.json');
+		expect(result).toContain('✅ Deleted plan-export/SWARM_PLAN.md');
+		expect(
+			existsSync(join(tempDir, '.swarm', 'plan-export', 'SWARM_PLAN.json')),
+		).toBe(false);
+		expect(
+			existsSync(join(tempDir, '.swarm', 'plan-export', 'SWARM_PLAN.md')),
+		).toBe(false);
+	});
+
 	test('With --confirm - deletes legacy root-level SWARM_PLAN artifacts', async () => {
 		await writeFile(join(tempDir, 'SWARM_PLAN.json'), '{}');
 		await writeFile(join(tempDir, 'SWARM_PLAN.md'), '# Plan');


### PR DESCRIPTION
Closes #852

## Summary
- Relocate `SWARM_PLAN.{json,md}` export/checkpoint artifacts from the flat `.swarm/` root into a dedicated `.swarm/plan-export/` subfolder so static exports are visually separated from live plan state, resolving beginner confusion about what `SWARM_PLAN` is (it is an export, not the live plan).
- `writeCheckpoint` now writes to `.swarm/plan-export/` and prepends a self-documenting "AUTO-GENERATED EXPORT — NOT the live plan" header; `importCheckpoint` uses a 3-tier backward-compatible read fallback (`.swarm/plan-export/` -> legacy flat `.swarm/` -> legacy project root) with deprecation warnings on legacy tiers.
- `/swarm reset` and `/swarm close` cleanup extended to remove SWARM_PLAN artifacts from all three locations; `src/plan/manager.ts` recovery log strings point to the new location. Docs updated (AGENTS.md invariant #5, `docs/plan-durability.md`, `docs/troubleshooting/recovery-guide.md`); release fragment created.

Live plan state (`plan.md`, `plan.json`, `plan-ledger.jsonl`) is untouched — the ledger remains authoritative (AGENTS.md invariant #5). Existing export files written by prior versions remain importable via the legacy fallback tiers.

## Invariant audit
- 1 (plugin init): not touched — no init-path changes; no new unbounded init work.
- 2 (runtime portability): not touched — no top-level `bun:` imports, no `Bun.*` calls, no plugin-shape change (`checkpoint.ts` uses `node:fs`).
- 3 (subprocesses): not touched — no `spawn`/`bunSpawn`/`spawnSync` added.
- 4 (.swarm containment): touched — exports relocated to `.swarm/plan-export/` (still scoped under `.swarm/`); all paths built with `path.join`. Evidence: `checkpoint.ts:41` `path.join(directory, '.swarm', 'plan-export')`; reset/close reuse `validateSwarmPath`/`path.join`. No new `.swarm/` creation under `src/`/`tests/`.
- 5 (plan durability): touched — SWARM_PLAN export location changed; `plan-ledger.jsonl` remains authoritative; `plan.json`/`plan.md` not modified by the writer. Evidence: drift-verifier APPROVED (all 4 tasks ALIGNED); `checkpoint.ts` writeCheckpoint only writes export artifacts, never the ledger or live plan. Docs (`AGENTS.md`, `docs/plan-durability.md`) updated.
- 6 (test_runner safety): not touched — no `test_runner` scope/logic changes.
- 7 (test writing): touched — added a `_fsInternals` DI seam (preferred over `mock.module` per invariant #7) to `checkpoint.ts`; tests use `bun:test`, temp dirs via `os.tmpdir()`. Evidence: `bun run build` + `bun run typecheck` exit 0; `checkpoint.test.ts` 17/17.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no tools/commands added or changed; no `TOOL_NAMES`/agent-map edits.
- 12 (release/cache): touched — release fragment `docs/releases/pending/852-swarm-plan-export-relocation.md` created; `package.json`/`CHANGELOG.md`/`.release-please-manifest.json` NOT edited.

## Test plan
- [x] `bun run build` (exit 0)
- [x] `node --input-type=module -e "await import('./dist/index.js')"` (dist import OK)
- [x] `bun run typecheck` (exit 0)
- [x] `bunx biome ci .` (exit 0, clean)
- [x] Affected unit tests: `src/plan/checkpoint.test.ts` 17/17, `tests/unit/commands/reset.test.ts` 15/15, `tests/unit/commands/close-finalizer.test.ts` 75/77 (2 pre-existing — see below)
- [x] Per-task QA gates: reviewer APPROVED + test_engineer PASS (all 4 tasks); drift APPROVED; phase council APPROVED (5/5); final council APPROVED (5/5)
- [ ] CI full suite green

## Pre-existing failures
Two failures in `tests/unit/commands/close-finalizer.test.ts` are pre-existing and unrelated to this change:
- `partial archive failure path ... (FR-018)`
- `preserves ALL active-state files when only non-active-state artifacts are archived`

Both are Windows `EPERM` archive-guard failures (`copyFile` on a directory-where-file-expected) in the **archive** logic, not the SWARM_PLAN cleanup. Proof: this PR's diff to `close-finalizer.test.ts` is purely additive (one new plan-export removal test, zero existing tests modified), and the `close.ts` diff (7 insertions / 4 deletions) only extends the SWARM_PLAN removal-candidate list and updates the summary label — it does not touch the archive-guard / `copyFile` code path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

