### PR TITLE
fix(planning): resolve residual audit findings (#660, #1267, #1269, #1270)

### DIFF
--- a/docs/releases/pending/660-1267-1269-1270-planning-residuals.md
+++ b/docs/releases/pending/660-1267-1269-1270-planning-residuals.md
@@ -1,0 +1,90 @@
+# Planning-system residual hardening (#660, #1267, #1269, #1270)
+
+## What changed
+
+A batch of planning-system correctness and hardening fixes, resolving the
+residual findings left open across four tracking/bug issues. Most of the
+original #660 audit findings (F-03/F-05/F-06/F-07/F-09/F-12) were already
+fixed in earlier releases; this change closes what genuinely remained.
+
+**Plan/markdown sync (#660 F-11).** `isPlanMdInSync` no longer treats a
+`plan.md` that merely *contains* the expected rendering as a substring as
+"in sync". A non-equivalent `plan.md` is now reported out of sync, so the
+authoritative `plan.json` is re-projected instead of silently trusting a
+stale or partial markdown file. The legitimate paths (PLAN_HASH header match
+and exact normalized equality) are preserved.
+
+**Last-resort phase-completion write (#660 F-08).** When `phase_complete`
+falls back to its emergency direct write of `plan.json` (plan unloadable and
+no ledger present), the write is now validated against the plan schema before
+persisting and records a traceability event to `.swarm/events.jsonl`, in
+addition to the existing atomic temp+rename. A fallback completion is no
+longer invisible to a later audit.
+
+**Single source of truth for plan-id derivation (#660 F-14).** ~15 test
+files that re-implemented the `plan_id` formula inline now import the
+canonical `derivePlanId` from `src/plan/utils.ts`. Four of them used a
+divergent regex (`/\W/g`, which stripped the joining hyphen) that could
+disagree with production's canonical derivation; they now match exactly.
+
+**Regression guards (#660 FR-004).** New tests pin three previously-resolved
+fixes so they cannot silently revert: `phase_complete` acquires the
+`plan.json` lock before `savePlan` (F-03), the council stores write
+atomically (F-05), and the file-lock retry/backoff configuration stays in
+place (F-09).
+
+**Structured staleness signal (#1269).** When the plan loader detects that
+`plan.json` is unrecoverably stale (hash-mismatches the ledger, ledger replay
+fails, and no critic-approved snapshot exists), it now records the workspace
+and attaches a runtime-only `_ledgerReplayStale` flag to the loaded plan
+(mirroring the existing `_specStale` overlay). Because the expensive detection
+is startup-gated, the verdict is *persisted per workspace* and re-surfaced on
+every subsequent load, so `update_task_status` and `phase_complete` reliably
+see it in long-lived hosts (not just on the first load) and refuse to mutate a
+known-stale plan with actionable recovery guidance instead of relying on a
+logged warning. It self-heals: once `plan.json` and the ledger reconverge
+(e.g. an architect `save_plan`), a cheap hash recheck clears the verdict on the
+next load — the refusal lasts only until the workspace actually recovers. The
+flag is never persisted to disk and never affects plan hashing.
+
+**Idle session reclamation (#1269).** Accumulated session state is now
+reclaimed by an opportunistic, cooldown-bounded sweep that runs off the
+per-tool-call path, independent of a new session starting. Previously stale
+sessions were only evicted when a *new* session began (or at `/swarm close`),
+so a long-lived host could accumulate sessions indefinitely. No timer is
+introduced (respecting the bounded-init contract).
+
+**Concurrency + traversal correctness (#1267).** Investigated the reported
+update-task-status test failures: the "multiple lock winners" tests encoded
+the obsolete `retries: 0` lock behavior — under the current retry/backoff
+config, contending callers serialize on the `plan.json` lock and each
+read-modify-writes fresh state, which is correct (no lost update, no bypass);
+those tests were corrected to assert serialization safety. A genuine
+Windows-only path-traversal gap was fixed: `resolveWorkingDirectory` detected
+`..` segments by splitting on `path.sep` (`\` on Windows), so a
+forward-slash traversal evaded detection — it now splits on both separators.
+
+**Defense-in-depth hardening (#1270).** `validateSwarmPath` now resolves
+symlinks (realpath) before its `.swarm` containment check, closing a gap
+where a symlink inside `.swarm/` pointing outside passed validation.
+`version-check` strictly validates the registry response (JSON content-type,
+bounded length, strict semver) before use. `composeHandlers` gained a
+fail-closed brand guard so a handler marked fail-closed cannot be silently
+composed onto the error-swallowing path.
+
+## Why
+
+These are correctness, security, and observability fixes in the planning
+subsystem — the layer that owns plan-state mutation under file locking.
+Each addresses a concrete gap: silent stale-state propagation, an invisible
+emergency write path, a cross-platform traversal-detection hole, a symlink
+containment gap, and unbounded session growth in long-lived hosts.
+
+## Migration steps
+
+None. All changes are backward-compatible. The `_ledgerReplayStale` flag is
+runtime-only and not part of any persisted or hashed shape.
+
+## Breaking changes
+
+None.

--- a/src/config/plan-schema.ts
+++ b/src/config/plan-schema.ts
@@ -112,11 +112,32 @@ export type Plan = z.infer<typeof PlanSchema>;
  * `_midLoadRemovals` is attached by loadPlan-recovery paths that auto-
  * acknowledged task removals (issue #853) so the system-enhancer Layer A
  * can disclose the count to the model without re-reading the ledger.
+ *
+ * `_ledgerReplayStale` / `_ledgerReplayStaleReason` are attached by loadPlan
+ * when it returns a STALE plan.json: the plan.json hash mismatched the ledger,
+ * ledger replay failed (threw), AND no critic-approved snapshot was available,
+ * so the loader fell back to the (stale) plan.json (#1269 finding 2). Consumers
+ * in phase-complete.ts and update-task-status.ts read these to surface a
+ * structured staleness signal instead of silently trusting plan.json.
+ *
+ * RUNTIME-ONLY CONTRACT (mirrors `_specStale`): every field on RuntimePlan is a
+ * TypeScript-only overlay on the persisted `Plan`. It is NOT part of the durable
+ * `PlanSchema` (see this file ~line 95 — a plain `z.object`, no `.passthrough()`,
+ * so Zod strips unknown keys), so `savePlan`'s `JSON.stringify(PlanSchema.parse(...))`
+ * can never write these to .swarm/plan.json. It is also excluded from plan hashing:
+ * both `computePlanHash` (src/plan/ledger.ts) and `computePlanContentHash`
+ * (src/plan/manager.ts) hash an explicit allow-list of fields, never the whole
+ * object. Because of this, AGENTS.md invariant-5's "six places" (ledger replay,
+ * projection, checkpoint import/export, get_approved_plan, tests, docs) do NOT
+ * all apply — these are not durable schema fields. Do NOT move these into
+ * `PlanSchema`.
  */
 export type RuntimePlan = Plan & {
 	_specStale?: boolean;
 	_specStaleReason?: string;
 	_midLoadRemovals?: { count: number; source: string };
+	_ledgerReplayStale?: boolean;
+	_ledgerReplayStaleReason?: string;
 };
 
 /**

--- a/src/plan/ledger-snapshot-adversarial.test.ts
+++ b/src/plan/ledger-snapshot-adversarial.test.ts
@@ -14,6 +14,7 @@ import {
 	takeSnapshotEvent,
 } from './ledger';
 import { savePlan } from './manager';
+import { derivePlanId } from './utils';
 
 function createTempDir(): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ledger-snap-adv-'));
@@ -108,10 +109,10 @@ describe('in-ledger snapshot adversarial tests', () => {
 			const legacyEvent = {
 				seq: 1,
 				timestamp: new Date().toISOString(),
-				plan_id: `${initialPlan.swarm}-${initialPlan.title}`.replace(
-					/[^a-zA-Z0-9-_]/g,
-					'_',
-				),
+				plan_id: derivePlanId({
+					swarm: initialPlan.swarm,
+					title: initialPlan.title,
+				}),
 				event_type: 'plan_created',
 				source: 'initLedger',
 				plan_hash_before: '',

--- a/src/plan/manager.ts
+++ b/src/plan/manager.ts
@@ -102,6 +102,24 @@ import { derivePlanId } from './utils';
 // per process lifetime, even when a long-lived process touches multiple repos.
 const startupLedgerCheckedWorkspaces = new Set<string>();
 
+// #1269 finding-2 (hardened): persist the unrecoverable ledger-stale condition
+// per-workspace so it can be surfaced on EVERY loadPlan return, not just the
+// first one per process. The expensive replay that DETECTS staleness is gated to
+// startup-only (startupLedgerCheckedWorkspaces) because active-session hash
+// mismatches are expected from concurrent writes — but the flag set there landed
+// only on a throwaway clone and never reached later update_task_status /
+// phase_complete loads. This Set records "this workspace genuinely failed ledger
+// replay at startup with no approved snapshot," and the chokepoint near
+// `return validated` re-attaches `_ledgerReplayStale` after a CHEAP self-heal
+// recheck (plan↔ledger hash) that auto-clears once the workspace reconverges.
+//
+// Invariant 8: keyed by `path.resolve(directory)` and bounded by the number of
+// distinct workspaces a single process touches — identical lifetime, keying, and
+// eviction profile to `startupLedgerCheckedWorkspaces` above. It is NOT
+// session-keyed, so MAX_TRACKED_SESSIONS / FIFO session eviction does not apply;
+// it mirrors the pre-existing per-workspace precedent.
+const ledgerStaleWorkspaces = new Set<string>();
+
 // In-process mutex for the loadPlan recovery path (Step 4b).
 // Prevents two concurrent loadPlan calls from racing through the
 // approved-snapshot recovery and both calling savePlan (#444 item 6).
@@ -112,6 +130,10 @@ const PLAN_JSON_CACHE_NAMESPACE = 'plan-json:validated:v1';
 /** Reset the startup ledger check flag. For testing only. */
 export function resetStartupLedgerCheck(): void {
 	startupLedgerCheckedWorkspaces.clear();
+	// Clear the persisted ledger-stale set alongside the startup-check set: a
+	// reset re-opens the expensive startup replay, so any prior staleness verdict
+	// must be re-derived from scratch rather than lingering as a stuck refusal.
+	ledgerStaleWorkspaces.clear();
 	recoveryMutexes.clear();
 }
 
@@ -264,6 +286,67 @@ async function getLatestLedgerHash(directory: string): Promise<string> {
 	}
 }
 
+/**
+ * #1269 finding-2 (hardened): surface the persisted ledger-stale verdict on the
+ * live-plan return chokepoint, with a CHEAP self-heal recheck.
+ *
+ * The expensive startup-only replay (gated by `startupLedgerCheckedWorkspaces`)
+ * records a workspace in `ledgerStaleWorkspaces` when it genuinely failed to
+ * reconverge plan.json with the ledger AND no critic-approved snapshot existed.
+ * That detection attaches `_ledgerReplayStale` to the plan it returns, but every
+ * later loadPlan gets a fresh `structuredClone` of plan.json (see
+ * `parsePlanJsonCached` → `readCachedParsedFile`) and skips the startup block, so
+ * the flag never reached `update_task_status` / `phase_complete` in long-lived
+ * hosts. This re-attaches it on every return for a persisted-stale workspace.
+ *
+ * Self-heal: before flagging, recompute `computePlanHash(plan)` vs the latest
+ * ledger hash. If they now MATCH the projection reconverged (e.g. an architect
+ * `save_plan` rewrote plan.json + appended a ledger event) — clear the verdict
+ * and return clean. This is the mechanism (together with `resetStartupLedgerCheck`
+ * and a `/swarm reset-session` follow-up) that prevents a permanent stuck refusal:
+ * the refusal lasts only until the workspace's state actually recovers.
+ *
+ * Invariant 5: `_ledgerReplayStale` / `_ledgerReplayStaleReason` are RuntimePlan
+ * overlays only. They are never written by `savePlan` (PlanSchema strips unknown
+ * keys) and never hashed (`computePlanHash` uses an explicit allow-list), so the
+ * mutation below cannot leak into durable plan.json or any hash.
+ */
+async function surfaceLedgerStaleIfPersisted(
+	directory: string,
+	plan: RuntimePlan,
+): Promise<RuntimePlan> {
+	const resolvedWorkspace = path.resolve(directory);
+	if (!ledgerStaleWorkspaces.has(resolvedWorkspace)) {
+		return plan;
+	}
+	// Cheap recheck only — never the expensive replay (that stays startup-gated).
+	try {
+		const planHash = computePlanHash(plan);
+		const ledgerHash = await getLatestLedgerHash(directory);
+		if (ledgerHash !== '' && planHash === ledgerHash) {
+			// Reconverged → the workspace recovered. Auto-clear and return clean.
+			ledgerStaleWorkspaces.delete(resolvedWorkspace);
+			return plan;
+		}
+	} catch {
+		// If the recheck itself fails (e.g. transient ledger read error), fall
+		// through and surface staleness conservatively. Better a visible refusal
+		// the architect can clear than a silent stale-read of plan.json.
+	}
+	plan._ledgerReplayStale = true;
+	if (
+		typeof plan._ledgerReplayStaleReason !== 'string' ||
+		plan._ledgerReplayStaleReason.length === 0
+	) {
+		// Preserve the detailed startup-detection reason when it is already set
+		// (the first load, where the replay error string is available); only
+		// supply a generic reason for the later persisted-surface loads.
+		plan._ledgerReplayStaleReason =
+			'plan.json still hash-mismatches the ledger after a startup ledger-replay failure (replay could not be applied and no critic-approved snapshot was available). Run /swarm reset-session if this persists.';
+	}
+	return plan;
+}
+
 async function parsePlanJsonCached(directory: string): Promise<Plan | null> {
 	const planJsonPath = path.resolve(directory, '.swarm', 'plan.json');
 	return readCachedParsedFile<Plan>(
@@ -350,7 +433,7 @@ function extractPlanHashFromMarkdown(markdown: string): string | null {
  * Returns true if plan.md exists and matches the plan's content hash.
  * This avoids timestamp comparison issues by using a deterministic hash.
  */
-async function isPlanMdInSync(
+export async function isPlanMdInSync(
 	directory: string,
 	plan: Plan,
 	cache?: Map<string, Promise<string | null>>,
@@ -382,14 +465,20 @@ async function isPlanMdInSync(
 		return true;
 	}
 
-	// F-11: Fuzzy substring matching fallback — permissive for backward compatibility
-	// Once PLAN_HASH headers are universally present (no old plan.md files), this check
-	// should be removed or replaced with an exact-match-only check to reduce false positives.
-	// For now, keep it to support plan.md files generated before hashing was added.
-	return (
-		normalizedActual.includes(normalizedExpected) ||
-		normalizedExpected.includes(normalizedActual.replace(/^#.*$/gm, '').trim())
-	);
+	// F-11 (FR-001): the former permissive substring fallback
+	// (`normalizedActual.includes(normalizedExpected) || ...`) is intentionally
+	// REMOVED. It produced false positives: a plan.md that merely CONTAINS the
+	// expected rendering as a strict superset (extra phases/tasks appended) was
+	// reported "in sync" even though it is not equivalent to plan.json. The two
+	// legitimate paths above cover every real case:
+	//   1. PLAN_HASH header match — robust, timestamp-independent (every plan.md
+	//      written by savePlan/regeneratePlanMarkdown carries this header).
+	//   2. Normalized exact equality — the backward-compat path for legacy
+	//      plan.md files generated before hashing was added.
+	// Anything else is treated as OUT of sync so loadPlan regenerates plan.md
+	// from the authoritative plan.json (plan.md is a derived projection —
+	// AGENTS.md invariant 5).
+	return false;
 }
 
 /**
@@ -558,6 +647,28 @@ export async function loadPlan(
 										} catch {
 											// Fall through to the stale-plan warning below
 										}
+										// #1269 finding 2: we are about to return the STALE
+										// plan.json (hash mismatched the ledger, ledger replay
+										// threw, and no critic-approved snapshot was available).
+										// Attach a structured runtime-only staleness signal so
+										// consumers (phase-complete.ts, update-task-status.ts) can
+										// detect this instead of silently trusting plan.json.
+										// Mirrors the `_specStale` attach pattern above. These
+										// fields live on RuntimePlan (a TS overlay) and are never
+										// persisted (PlanSchema strips unknown keys) nor hashed
+										// (computePlanHash/computePlanContentHash use explicit
+										// field allow-lists).
+										{
+											const runtimeStale = validated as RuntimePlan;
+											runtimeStale._ledgerReplayStale = true;
+											runtimeStale._ledgerReplayStaleReason = `Ledger replay failed during hash-mismatch rebuild and no approved snapshot was available: ${replayError instanceof Error ? replayError.message : String(replayError)}`;
+											// #1269 finding-2 (hardened): persist the verdict so it is
+											// re-surfaced on EVERY subsequent loadPlan (the startup
+											// replay above runs at most once per workspace per process).
+											// The chokepoint near `return validated` re-attaches the
+											// flag and self-heals when plan↔ledger reconverge.
+											ledgerStaleWorkspaces.add(resolvedWorkspace);
+										}
 										warn(
 											`[loadPlan] Ledger replay failed during hash-mismatch rebuild: ${replayError instanceof Error ? replayError.message : String(replayError)}. Returning stale plan.json. To recover: check .swarm/plan-export/SWARM_PLAN.md for a checkpoint, or run /swarm reset-session.`,
 										);
@@ -638,7 +749,15 @@ export async function loadPlan(
 							}
 						}
 					}
-					return validated;
+					// #1269 finding-2 (hardened) chokepoint: this is the only return
+					// that yields the live (potentially stale) plan.json. Re-surface a
+					// persisted ledger-stale verdict here — and self-heal it if plan and
+					// ledger have reconverged — so the signal reaches consumers on EVERY
+					// load, not just the first per process.
+					return await surfaceLedgerStaleIfPersisted(
+						directory,
+						validated as RuntimePlan,
+					);
 				}
 			} catch (error) {
 				// Step 2: Validation failed, log warning and fall through to legacy

--- a/src/services/version-check.ts
+++ b/src/services/version-check.ts
@@ -23,6 +23,30 @@ const NPM_REGISTRY_URL = 'https://registry.npmjs.org/opencode-swarm/latest';
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const FETCH_TIMEOUT_MS = 5_000;
 
+/**
+ * Upper bound on the registry response body (issue #1270-4). The npm `latest`
+ * document is a few KB; anything close to this is either an error page or a
+ * hostile/compromised endpoint. We refuse to buffer more than this.
+ */
+const MAX_RESPONSE_BYTES = 256 * 1024; // 256 KiB
+
+/**
+ * Strict semver matcher (semver.org 2.0.0 grammar). Used to validate the
+ * version string from the registry BEFORE it is cached, compared, or shown to
+ * the user. Rejects anything that is not `MAJOR.MINOR.PATCH` with optional
+ * `-prerelease` / `+build` metadata — including HTML, empty strings, ranges,
+ * and `latest`-style dist-tags.
+ */
+const STRICT_SEMVER =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+/**
+ * Returns true if `value` is a strictly-valid semver string. Pure; never throws.
+ */
+export function isStrictSemver(value: unknown): value is string {
+	return typeof value === 'string' && STRICT_SEMVER.test(value);
+}
+
 interface VersionCheckCache {
 	checkedAt: number;
 	npmLatest: string | null;
@@ -87,19 +111,82 @@ export function compareVersions(a: string, b: string): number {
 	return 0;
 }
 
-async function fetchLatestVersion(signal: AbortSignal): Promise<string | null> {
+/**
+ * Fetch the latest published version from the npm registry with strict,
+ * fail-safe validation (issue #1270-4):
+ *   (a) HTTP status must be ok.
+ *   (b) Content-Type must look like JSON — a mislabeled HTML error page or
+ *       proxy interstitial is rejected rather than parsed.
+ *   (c) The body is length-bounded both by the advertised Content-Length and
+ *       by the actual decoded length, so a hostile endpoint cannot make us
+ *       buffer an unbounded response.
+ *   (d) The `version` field must be a STRICT semver string before it is
+ *       returned (and thus before it is cached, compared, or surfaced).
+ *
+ * Any validation failure returns null. This function NEVER throws into its
+ * caller — staleness checking must never disrupt plugin startup.
+ *
+ * Exported so tests can exercise the validation directly via the
+ * `_internals.fetch` seam (mocking the global `fetch` would leak across files
+ * in Bun's shared test process).
+ */
+export async function fetchLatestVersion(
+	signal: AbortSignal,
+): Promise<string | null> {
 	try {
-		const res = await fetch(NPM_REGISTRY_URL, {
+		const res = await _internals.fetch(NPM_REGISTRY_URL, {
 			signal,
 			headers: { Accept: 'application/json' },
 		});
 		if (!res.ok) return null;
-		const body = (await res.json()) as { version?: unknown };
-		return typeof body.version === 'string' ? body.version : null;
+
+		// (b) Content-Type must be JSON. Accept `application/json`,
+		// `application/vnd.npm.install-v1+json`, and `; charset=...` suffixes;
+		// reject `text/html`, `text/plain`, `application/octet-stream`, etc.
+		const contentType = (res.headers.get('content-type') ?? '').toLowerCase();
+		if (!contentType.includes('json')) return null;
+
+		// (c) Reject an oversized body up front via the advertised length.
+		const lengthHeader = res.headers.get('content-length');
+		if (lengthHeader) {
+			const advertised = Number.parseInt(lengthHeader, 10);
+			if (Number.isFinite(advertised) && advertised > MAX_RESPONSE_BYTES) {
+				return null;
+			}
+		}
+
+		// Defense in depth: bound the actual decoded body too, in case the
+		// Content-Length header was absent or lied.
+		const text = await res.text();
+		if (text.length > MAX_RESPONSE_BYTES) return null;
+
+		let body: { version?: unknown };
+		try {
+			body = JSON.parse(text) as { version?: unknown };
+		} catch {
+			return null;
+		}
+
+		// (d) Strict semver validation before the value escapes this function.
+		return isStrictSemver(body.version) ? body.version : null;
 	} catch {
 		return null;
 	}
 }
+
+/**
+ * Test-only dependency-injection seam. Production reads `_internals.fetch(...)`
+ * at the call site so tests can replace it without `mock.module` (which leaks
+ * across files in Bun's shared test-runner process). Restore in `afterEach`.
+ */
+export const _internals: {
+	fetch: (
+		input: string | URL | Request,
+		init?: RequestInit,
+	) => Promise<Response>;
+} = {
+	fetch: (input, init) => fetch(input, init),
+};
 
 /**
  * Schedule a one-shot, fully detached version check. Returns immediately.

--- a/src/state.ts
+++ b/src/state.ts
@@ -508,6 +508,10 @@ export function resetSwarmState(): void {
 	swarmState.pendingEvents = 0;
 	swarmState.lastBudgetPct = 0;
 	swarmState.agentSessions.clear();
+	// Reset the opportunistic idle-sweep cooldown so a fresh process / test run
+	// sweeps on first session activity (invariant 8: bounded global state with
+	// an explicit reset path).
+	_lastIdleSweepAtMs = 0;
 	clearTrajectoryCache();
 	clearTrajectoryStepCounters();
 	swarmState.pendingRehydrations.clear();
@@ -582,6 +586,95 @@ export function resetSwarmStatePreservingSingletons(): void {
 }
 
 /**
+ * Default idle-TTL (ms) after which a session with no tool activity is
+ * considered stale and eligible for eviction (2 hours). Extracted to a single
+ * constant so startAgentSession (eager eviction) and the opportunistic idle
+ * sweep share one source of truth instead of duplicating the literal.
+ */
+const STALE_SESSION_TTL_MS = 7_200_000;
+
+/**
+ * Minimum interval (ms) between opportunistic idle sweeps triggered from the
+ * per-tool-call hot path. Bounds the O(n) stale scan to at most once per
+ * window so per-tool-call accounting stays effectively O(1) in the common
+ * case while still reclaiming idle session state on a long-lived host.
+ */
+const IDLE_SWEEP_COOLDOWN_MS = 60_000;
+
+/**
+ * Cooldown timestamp (ms epoch) of the most recent opportunistic idle sweep.
+ * Module-level state, but bounded by IDLE_SWEEP_COOLDOWN_MS and reset to 0 by
+ * resetSwarmState so a fresh process / test sweeps on first activity
+ * (invariant 8: keyed/bounded global state with an explicit reset path).
+ */
+let _lastIdleSweepAtMs = 0;
+
+/**
+ * Evict every agent session whose last tool activity is older than
+ * staleDurationMs, and drop the delegation chain keyed by that same sessionID
+ * (delegationChains is keyed by sessionID — see delegation-tracker.ts, which
+ * does `delegationChains.set(input.sessionID, ...)`). This is the single
+ * eviction loop reused by BOTH startAgentSession (eager, on new session start)
+ * and maybeSweepStaleSessions (opportunistic, on the hot path) so the logic is
+ * never duplicated.
+ *
+ * @param staleDurationMs - Age threshold in ms (default 2h)
+ * @param now - Current time in ms (injectable for deterministic tests)
+ * @returns The list of evicted session IDs
+ */
+export function sweepStaleSessions(
+	staleDurationMs = STALE_SESSION_TTL_MS,
+	now = Date.now(),
+): string[] {
+	// Preserve the original strict-greater-than comparison so the existing
+	// eager-eviction behavior and tests are byte-for-byte unchanged.
+	const staleIds: string[] = [];
+	for (const [id, session] of swarmState.agentSessions) {
+		if (now - session.lastToolCallTime > staleDurationMs) {
+			staleIds.push(id);
+		}
+	}
+	for (const id of staleIds) {
+		swarmState.agentSessions.delete(id);
+		// delegationChains is keyed by sessionID; the evicted session's chain is
+		// now unreachable, so drop it in the same pass to reclaim its memory.
+		swarmState.delegationChains.delete(id);
+	}
+	return staleIds;
+}
+
+/**
+ * Opportunistic, cooldown-guarded wrapper around sweepStaleSessions, intended
+ * to be called from a frequently-hit code path (per-tool-call accounting in
+ * ensureAgentSession). This reclaims accumulated session state even when no
+ * new session is ever started — closing the gap where eager eviction only ran
+ * inside startAgentSession, so a long-lived host that stopped creating
+ * sessions never reclaimed old ones.
+ *
+ * Bounded work (invariant 8): the O(n) scan runs at most once per
+ * IDLE_SWEEP_COOLDOWN_MS. The cooldown timestamp advances whenever the cooldown
+ * has elapsed — even when zero sessions are evicted — so an idle/empty map does
+ * not re-scan on every call.
+ *
+ * No timers, no init-path work (invariant 1): this only runs when a hook
+ * actively calls it on the hot path; it never schedules background work.
+ *
+ * @param staleDurationMs - Age threshold in ms (default 2h)
+ * @param now - Current time in ms (injectable for deterministic tests)
+ * @returns Evicted session IDs ([] when the cooldown blocks this run)
+ */
+export function maybeSweepStaleSessions(
+	staleDurationMs = STALE_SESSION_TTL_MS,
+	now = Date.now(),
+): string[] {
+	if (now - _lastIdleSweepAtMs < IDLE_SWEEP_COOLDOWN_MS) {
+		return [];
+	}
+	_lastIdleSweepAtMs = now;
+	return sweepStaleSessions(staleDurationMs, now);
+}
+
+/**
  * Start a new agent session with initialized guardrail state.
  * Also removes any stale sessions older than staleDurationMs.
  * @param sessionId - The session identifier
@@ -592,22 +685,16 @@ export function resetSwarmStatePreservingSingletons(): void {
 export function startAgentSession(
 	sessionId: string,
 	agentName: string,
-	staleDurationMs = 7200000,
+	staleDurationMs = STALE_SESSION_TTL_MS,
 	directory?: string,
 ): void {
 	const now = Date.now();
 
-	// Evict stale sessions based on last activity, not start time
-	// Default: 2 hours — should exceed typical agent durations (evicts inactive sessions)
-	const staleIds: string[] = [];
-	for (const [id, session] of swarmState.agentSessions) {
-		if (now - session.lastToolCallTime > staleDurationMs) {
-			staleIds.push(id);
-		}
-	}
-	for (const id of staleIds) {
-		swarmState.agentSessions.delete(id);
-	}
+	// Evict stale sessions based on last activity, not start time.
+	// Default: 2 hours — should exceed typical agent durations (evicts inactive
+	// sessions). Reuses the shared eviction loop (also used by the opportunistic
+	// idle sweep) so the logic stays single-sourced.
+	sweepStaleSessions(staleDurationMs, now);
 
 	// Create new session state
 	const sessionState: AgentSessionState = {
@@ -966,6 +1053,13 @@ export function ensureAgentSession(
 		}
 
 		session.lastToolCallTime = now;
+		// Opportunistic idle-TTL sweep (cooldown-guarded) on the per-tool-call
+		// hot path. Reclaims stale SIBLING sessions even when this long-lived
+		// host has stopped starting new sessions — independent of
+		// startAgentSession. The session just refreshed above (lastToolCallTime
+		// = now) is never its own victim, so there is no cross-session
+		// pollution.
+		maybeSweepStaleSessions();
 		return session;
 	}
 

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -333,7 +333,7 @@ async function fallbackWritePlanWithTrace(
 		return false;
 	}
 
-	await atomicWriteFile(planPath, JSON.stringify(candidate, null, 2));
+	await atomicWriteFile(planPath, JSON.stringify(validation.data, null, 2));
 
 	// Best-effort traceability event. Reuses the canonical events.jsonl append
 	// pattern used for the phase_complete event above

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -9,6 +9,7 @@ import type { ToolDefinition } from '@opencode-ai/plugin/tool';
 import { z } from 'zod';
 import { loadPluginConfigWithMeta } from '../config';
 import type { EvidenceBundle } from '../config/evidence-schema';
+import { PlanSchema, type RuntimePlan } from '../config/plan-schema';
 import {
 	CuratorConfigSchema,
 	KnowledgeConfigSchema,
@@ -283,6 +284,74 @@ interface PhaseCompleteEvent {
 	agents_missing: string[];
 	status: PhaseCompleteResult['status'];
 	summary: string | null;
+}
+
+/**
+ * Last-resort emergency plan.json writer, made traceable + validated (FR-002,
+ * issue #660 / F-08).
+ *
+ * INVARIANT 5 (plan durability): this is NOT a new plan.json writer. It is the
+ * EXISTING "Last resort: direct write" emergency fallback — the only path that
+ * persists a phase-status flip when both ledger-replay and the normal savePlan
+ * path are unavailable — refactored so that it (a) refuses to persist a
+ * schema-invalid candidate and (b) records a traceability event when it does
+ * write. The durable `PlanSchema` is unchanged and no additional plan.json write
+ * site is introduced; `candidate` is the JSON-parsed + mutated copy of the
+ * on-disk plan that the legacy code already wrote verbatim.
+ *
+ * @param dir - Project root directory (.swarm/ lives under it).
+ * @param planPath - Pre-resolved path to .swarm/plan.json.
+ * @param candidate - The mutated plan object about to be persisted.
+ * @param phase - The phase whose status was flipped (for the trace event).
+ * @param warnings - Warnings array; failures are surfaced here, never thrown.
+ * @returns true if the candidate validated and was written, false otherwise.
+ */
+async function fallbackWritePlanWithTrace(
+	dir: string,
+	planPath: string,
+	candidate: unknown,
+	phase: number,
+	warnings: string[],
+): Promise<boolean> {
+	// Defense-in-depth: never persist a schema-invalid plan.json. The candidate
+	// is a parsed+mutated copy of the on-disk plan, so this should normally pass;
+	// if it does not, the on-disk plan was already corrupt and we must not make it
+	// worse by rewriting it.
+	const validation = PlanSchema.safeParse(candidate);
+	if (!validation.success) {
+		const detail = validation.error.issues
+			.slice(0, 5)
+			.map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+			.join('; ');
+		logger.warn(
+			'[phase_complete] Last-resort plan.json write aborted — mutated plan failed PlanSchema validation:',
+			detail,
+		);
+		warnings.push(
+			`Warning: last-resort plan.json write skipped — mutated plan failed schema validation (${detail})`,
+		);
+		return false;
+	}
+
+	await atomicWriteFile(planPath, JSON.stringify(candidate, null, 2));
+
+	// Best-effort traceability event. Reuses the canonical events.jsonl append
+	// pattern used for the phase_complete event above
+	// (validateSwarmPath + fs.appendFileSync). Never throw out of the fallback.
+	try {
+		const traceEvent = {
+			event: 'phase_complete_fallback_write' as const,
+			phase,
+			timestamp: new Date().toISOString(),
+		};
+		const eventsPath = validateSwarmPath(dir, 'events.jsonl');
+		fs.appendFileSync(eventsPath, `${JSON.stringify(traceEvent)}\n`, 'utf-8');
+	} catch (eventError) {
+		warnings.push(
+			`Warning: failed to record phase_complete_fallback_write trace event: ${eventError instanceof Error ? eventError.message : String(eventError)}`,
+		);
+	}
+	return true;
 }
 
 /**
@@ -1572,6 +1641,30 @@ export async function executePhaseComplete(
 
 		try {
 			const plan = await loadPlan(dir);
+			// #1269 finding 2: if loadPlan fell back to a STALE plan.json (the ledger
+			// hash mismatched, ledger replay threw, AND no critic-approved snapshot was
+			// available), refuse to mutate phase status against it instead of silently
+			// trusting plan.json. This MUST sit before any savePlan / plan.json write
+			// below; the plan.json lock acquired above is released by the finally block
+			// on this early return.
+			const runtimePlan = plan as RuntimePlan | null;
+			if (runtimePlan?._ledgerReplayStale === true) {
+				const staleReason =
+					runtimePlan._ledgerReplayStaleReason ?? 'unknown reason';
+				return JSON.stringify({
+					success: false,
+					phase: args.phase,
+					status: 'incomplete' as const,
+					message: `Plan write refused: plan.json is stale from a failed ledger replay (${staleReason}). Refusing to complete phase ${args.phase} against a known-stale plan.`,
+					agentsDispatched,
+					agentsMissing,
+					warnings,
+					errors: [`Stale plan from failed ledger replay: ${staleReason}`],
+					recovery_guidance:
+						'The ledger replay failed and no critic-approved snapshot was available, so loadPlan fell back to a stale plan.json. Do NOT retry blindly. Recover first: re-verify the plan (re-run completion verification), reset the session, or restore from the latest checkpoint under .swarm/plan-export/, then retry phase_complete.',
+					_ledgerReplayStaleReason: staleReason,
+				});
+			}
 			if (plan === null) {
 				// loadPlan() returned null (malformed JSON and no plan.md to migrate from)
 				// Try ledger-first rebuild before direct write
@@ -1617,7 +1710,14 @@ export async function executePhaseComplete(
 					);
 					if (phaseObj) {
 						phaseObj.status = 'complete';
-						await atomicWriteFile(planPath, JSON.stringify(plan, null, 2));
+						// FR-002: validate + traceable emergency write (not a new writer).
+						await fallbackWritePlanWithTrace(
+							dir,
+							planPath,
+							plan,
+							phase,
+							warnings,
+						);
 					}
 				} catch {
 					/* fallback failed */
@@ -1685,7 +1785,14 @@ export async function executePhaseComplete(
 				);
 				if (phaseObj) {
 					phaseObj.status = 'complete';
-					await atomicWriteFile(planPath, JSON.stringify(plan, null, 2));
+					// FR-002: validate + traceable emergency write (not a new writer).
+					await fallbackWritePlanWithTrace(
+						dir,
+						planPath,
+						plan,
+						phase,
+						warnings,
+					);
 				}
 			} catch {
 				/* fallback failed */

--- a/src/tools/resolve-working-directory.ts
+++ b/src/tools/resolve-working-directory.ts
@@ -88,8 +88,11 @@ export function resolveWorkingDirectory(
 		}
 	}
 
-	// Check for traversal in raw input before normalizing (normalize resolves .. before we can detect it)
-	const rawPathParts = workingDirectory.split(path.sep);
+	// Check for traversal in raw input before normalizing (normalize resolves .. before we can detect it).
+	// Split on BOTH separators (`/` and `\`) so a forward-slash input is detected on Windows too.
+	// On Windows path.sep === '\\', so splitting only on path.sep left forward-slash traversal like
+	// `foo/../../../bar` as a single unsplit segment, bypassing the `..` check (invariant 4 security bug).
+	const rawPathParts = workingDirectory.split(/[\\/]/);
 	if (rawPathParts.includes('..')) {
 		return {
 			success: false,

--- a/src/tools/update-task-status.ts
+++ b/src/tools/update-task-status.ts
@@ -8,13 +8,13 @@ import * as path from 'node:path';
 import type { ToolContext, ToolDefinition } from '@opencode-ai/plugin/tool';
 import { z } from 'zod';
 import { loadPluginConfig } from '../config/loader';
-import type { TaskStatus } from '../config/plan-schema';
+import type { RuntimePlan, TaskStatus } from '../config/plan-schema';
 import { stripKnownSwarmPrefix } from '../config/schema';
 import { getProfile } from '../db/qa-gate-profile.js';
 import { readTaskEvidenceRaw } from '../gate-evidence.js';
 import { validateDiffScope } from '../hooks/diff-scope';
 import { tryAcquireLock } from '../parallel/file-locks.js';
-import { updateTaskStatus } from '../plan/manager';
+import { loadPlan, updateTaskStatus } from '../plan/manager';
 import { derivePlanId } from '../plan/utils.js';
 import {
 	advanceTaskState,
@@ -41,6 +41,7 @@ export const _internals = {
 	tryAcquireLock,
 	updateTaskStatus,
 	resolveWorkingDirectory,
+	loadPlan,
 } as const;
 
 /**
@@ -970,6 +971,35 @@ export async function executeUpdateTaskStatus(
 				],
 			};
 		}
+	}
+
+	// #1269 finding 2: consult the ledger-replay staleness signal BEFORE any mutation.
+	// loadPlan attaches `_ledgerReplayStale` when it fell back to a stale plan.json
+	// (plan.json hash mismatched the ledger, ledger replay threw, AND no critic-approved
+	// snapshot was available). Mutating on top of that stale projection would silently
+	// overwrite the authoritative ledger view, so refuse with structured recovery guidance
+	// (mirroring the lock-blocked return shape) instead of relying on a logged warning.
+	// Placed before the evidence write and lock acquisition so no mutation occurs on stale state.
+	let loadedPlan: RuntimePlan | null = null;
+	try {
+		loadedPlan = await _internals.loadPlan(directory);
+	} catch {
+		// loadPlan failure is non-fatal here — the mutation path (updateTaskStatus) performs
+		// its own load and will surface a hard error; we only gate on a positive stale signal.
+		loadedPlan = null;
+	}
+	if (loadedPlan?._ledgerReplayStale === true) {
+		const staleReason =
+			loadedPlan._ledgerReplayStaleReason ??
+			'plan.json is stale relative to the authoritative ledger (.swarm/plan-ledger.jsonl)';
+		return {
+			success: false,
+			message: `Task status update refused: plan.json is stale relative to the ledger (ledger replay failed). ${staleReason}`,
+			errors: [staleReason],
+			recovery_guidance:
+				'Plan state could not be reconciled with the authoritative ledger (.swarm/plan-ledger.jsonl). ' +
+				'Restore from a critic-approved snapshot or re-run plan recovery to rebuild plan.json from the ledger, then retry update_task_status.',
+		};
 	}
 
 	// Write minimal gate-tracking evidence to persist across session restarts.

--- a/tests/integration/critic-drift-approved-plan.test.ts
+++ b/tests/integration/critic-drift-approved-plan.test.ts
@@ -22,6 +22,7 @@ import {
 	initLedger,
 	takeSnapshotEvent,
 } from '../../src/plan/ledger';
+import { derivePlanId } from '../../src/plan/utils';
 import { get_approved_plan } from '../../src/tools/get-approved-plan';
 
 function createTestPlan(overrides?: Partial<Plan>): Plan {
@@ -67,7 +68,7 @@ describe('get_approved_plan integration: full drift detection flow', () => {
 			'utf-8',
 		);
 
-		const planId = `${plan.swarm}-${plan.title}`.replace(/\W/g, '_');
+		const planId = derivePlanId(plan);
 		await initLedger(dir, planId);
 	});
 

--- a/tests/unit/council/council-stores-atomic-write.regression.test.ts
+++ b/tests/unit/council/council-stores-atomic-write.regression.test.ts
@@ -1,0 +1,134 @@
+/**
+ * REGRESSION GUARD — issue #660 FR-004, finding F-05.
+ *
+ * Pins the fix that both Work-Complete-Council stores route their primary
+ * writes through `atomicWriteFile` (temp-file + atomic rename) from
+ * `src/evidence/task-file.ts`, instead of a raw `writeFileSync`.
+ *
+ * Prior buggy behavior (what the fix corrected): `criteria-store.writeCriteria`
+ * and `council-evidence-writer.writeCouncilEvidence` wrote their JSON payloads
+ * with a direct, non-atomic `writeFileSync`. A reader (e.g. council evaluation
+ * reading criteria, or `check_gate_status` reading evidence) could observe a
+ * torn/partial file mid-write, and a concurrent writer could clobber updates.
+ * The fix switched both to `atomicWriteFile`, which writes to
+ * `<target>.tmp.<n>` then `renameSync`s it over the target so readers only ever
+ * see a complete file.
+ *
+ * How this guard works (and how it fails on revert):
+ *   `atomicWriteFile` is the ONLY caller of `task-file._internals.renameSync`,
+ *   and it reads that property at call time. So if — and only if — a store
+ *   routes its write through `atomicWriteFile`, we observe a `renameSync` call
+ *   whose destination is exactly the store's target file. We intercept the
+ *   genuine `_internals.renameSync` DI seam (no `mock.module`, real I/O) and
+ *   assert that exact destination was renamed.
+ *
+ *   Revert that breaks this guard: replacing `atomicWriteFile(target, json)`
+ *   with `writeFileSync(target, json)` in either store. Then `renameSync` is
+ *   never called for that target → the `some(... target === expected)`
+ *   assertion fails.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+	_internals as councilWriterInternals,
+	writeCouncilEvidence,
+} from '../../../src/council/council-evidence-writer';
+import { writeCriteria } from '../../../src/council/criteria-store';
+import type { CouncilSynthesis } from '../../../src/council/types';
+import {
+	taskEvidencePath,
+	_internals as taskFileInternals,
+} from '../../../src/evidence/task-file';
+
+// The real renameSync, captured once at module load.
+const realRenameSync = taskFileInternals.renameSync;
+const realWithTaskEvidenceLock = councilWriterInternals.withTaskEvidenceLock;
+
+let tempDir: string;
+let renameCalls: Array<{ source: string; target: string }>;
+
+beforeEach(() => {
+	tempDir = mkdtempSync(path.join(tmpdir(), 'council-atomic-guard-'));
+	renameCalls = [];
+	// Record every renameSync that flows through atomicWriteFile, then call
+	// through to the real implementation so the write actually completes.
+	taskFileInternals.renameSync = ((source: unknown, target: unknown) => {
+		renameCalls.push({ source: String(source), target: String(target) });
+		return realRenameSync(source as string, target as string);
+	}) as typeof taskFileInternals.renameSync;
+});
+
+afterEach(() => {
+	taskFileInternals.renameSync = realRenameSync;
+	councilWriterInternals.withTaskEvidenceLock = realWithTaskEvidenceLock;
+	try {
+		rmSync(tempDir, { recursive: true, force: true });
+	} catch {
+		// ignore cleanup errors
+	}
+});
+
+describe('council stores — regression: primary writes are atomic (F-05)', () => {
+	test('criteria-store.writeCriteria routes through atomicWriteFile (temp + rename)', async () => {
+		// Before the fix, writeCriteria used a raw writeFileSync — no rename, so a
+		// reader could observe a torn .swarm/council/<id>.json. The fix routes the
+		// write through atomicWriteFile, which renames a temp file over the target.
+		await writeCriteria(tempDir, '1.1', [
+			{ id: 'C1', description: 'All tests pass', mandatory: true },
+		]);
+
+		// safeId('1.1') => '1_1' (dots become underscores for council filenames).
+		const expectedTarget = path.join(tempDir, '.swarm', 'council', '1_1.json');
+
+		const matching = renameCalls.find(
+			(c) => path.resolve(c.target) === path.resolve(expectedTarget),
+		);
+		expect(matching).toBeDefined();
+		// The atomic write renames a temp sentinel (…tmp.<ts>.<rand>) over the
+		// target — proof it was NOT a direct in-place writeFileSync.
+		expect(matching?.source).toContain('.tmp.');
+	});
+
+	test('council-evidence-writer.writeCouncilEvidence routes through atomicWriteFile (temp + rename)', async () => {
+		// Before the fix, the council evidence write was non-atomic; a concurrent
+		// gate writer reading-modifying-writing the same {taskId}.json could lose
+		// updates or see a torn file (#978). The fix uses atomicWriteFile under the
+		// shared evidence lock. We bypass the real lock via the writer's own
+		// _internals seam so this test stays focused on the atomic-write routing.
+		councilWriterInternals.withTaskEvidenceLock = (async (
+			_directory: string,
+			_taskId: string,
+			_agent: string,
+			fn: () => Promise<unknown>,
+		) => fn()) as typeof councilWriterInternals.withTaskEvidenceLock;
+
+		const synthesis: CouncilSynthesis = {
+			taskId: '1.1',
+			swarmId: 'test-swarm',
+			timestamp: new Date().toISOString(),
+			overallVerdict: 'APPROVE',
+			vetoedBy: null,
+			memberVerdicts: [],
+			unresolvedConflicts: [],
+			requiredFixes: [],
+			advisoryFindings: [],
+			unifiedFeedbackMd: '',
+			roundNumber: 1,
+			allCriteriaMet: true,
+			quorumSize: 3,
+			blockingConcernsCount: 0,
+		};
+
+		await writeCouncilEvidence(tempDir, synthesis);
+
+		const expectedTarget = taskEvidencePath(tempDir, '1.1');
+		const matching = renameCalls.find(
+			(c) => path.resolve(c.target) === path.resolve(expectedTarget),
+		);
+		expect(matching).toBeDefined();
+		expect(matching?.source).toContain('.tmp.');
+	});
+});

--- a/tests/unit/hooks/delegation-gate-council-fallback.test.ts
+++ b/tests/unit/hooks/delegation-gate-council-fallback.test.ts
@@ -13,6 +13,7 @@ import * as path from 'node:path';
 import type { PluginConfig } from '../../../src/config';
 import { getOrCreateProfile, setGates } from '../../../src/db/qa-gate-profile';
 import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import { derivePlanId } from '../../../src/plan/utils';
 import {
 	ensureAgentSession,
 	getTaskState,
@@ -20,10 +21,6 @@ import {
 	startAgentSession,
 	swarmState,
 } from '../../../src/state';
-
-function derivePlanId(plan: { swarm: string; title: string }): string {
-	return `${plan.swarm}-${plan.title}`.replace(/[^a-zA-Z0-9-_]/g, '_');
-}
 
 const PLAN_FIXTURE = {
 	schema_version: '1.0.0' as const,

--- a/tests/unit/hooks/delegation-gate-council-phase.test.ts
+++ b/tests/unit/hooks/delegation-gate-council-phase.test.ts
@@ -13,16 +13,13 @@ import * as path from 'node:path';
 import type { PluginConfig } from '../../../src/config';
 import { getOrCreateProfile, setGates } from '../../../src/db/qa-gate-profile';
 import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import { derivePlanId } from '../../../src/plan/utils';
 import {
 	ensureAgentSession,
 	getTaskState,
 	resetSwarmState,
 	startAgentSession,
 } from '../../../src/state';
-
-function derivePlanId(plan: { swarm: string; title: string }): string {
-	return `${plan.swarm}-${plan.title}`.replace(/[^a-zA-Z0-9-_]/g, '_');
-}
 
 const PLAN_FIXTURE = {
 	schema_version: '1.0.0' as const,

--- a/tests/unit/hooks/utils.test.ts
+++ b/tests/unit/hooks/utils.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import {
+	composeBlockingHandlers,
 	composeHandlers,
 	estimateTokens,
+	markFailClosed,
 	readSwarmFileAsync,
 	safeHook,
 	validateSwarmPath,
@@ -258,6 +260,49 @@ describe('Hook Utilities', () => {
 
 			expect(called).toBe(true);
 			expect(output.called).toBe(true);
+		});
+	});
+
+	describe('composeHandlers — fail-closed footgun guard (#1270-5)', () => {
+		it('throws synchronously when handed a markFailClosed-tagged handler', () => {
+			// A fail-closed policy handler tagged via markFailClosed must never be
+			// wrapped in safeHook (which swallows throws and fails OPEN). The guard
+			// must reject it at composition time, before any wiring.
+			const policyHook = markFailClosed(async () => {
+				throw new Error('policy denied');
+			});
+
+			expect(() => composeHandlers(policyHook)).toThrow(/fail-closed handler/i);
+		});
+
+		it('rejects a tagged handler even when mixed with untagged handlers', () => {
+			const advisory = async () => {};
+			const policyHook = markFailClosed(async () => {});
+
+			expect(() => composeHandlers(advisory, policyHook)).toThrow(
+				/composeBlockingHandlers/i,
+			);
+		});
+
+		it('does not affect ordinary (untagged) handlers', () => {
+			const advisory = async () => {};
+			expect(() => composeHandlers(advisory, advisory)).not.toThrow();
+		});
+
+		it('composeBlockingHandlers accepts a tagged handler and propagates its throw', async () => {
+			const policyHook = markFailClosed(async () => {
+				throw new Error('policy denied');
+			});
+			const composed = composeBlockingHandlers(policyHook);
+
+			await expect(
+				composed('input' as never, 'output' as never),
+			).rejects.toThrow('policy denied');
+		});
+
+		it('markFailClosed returns the same function reference', () => {
+			const fn = async () => {};
+			expect(markFailClosed(fn)).toBe(fn);
 		});
 	});
 

--- a/tests/unit/parallel/file-locks-retry-config.regression.test.ts
+++ b/tests/unit/parallel/file-locks-retry-config.regression.test.ts
@@ -1,0 +1,106 @@
+/**
+ * REGRESSION GUARD — issue #660 FR-004, finding F-09.
+ *
+ * Pins the retry configuration that `tryAcquireLock` passes to
+ * `proper-lockfile`'s `lock()` (src/parallel/file-locks.ts ~L163-172):
+ *   retries: { retries: 5, minTimeout: 10, maxTimeout: 500, factor: 2 }
+ *
+ * Prior buggy behavior (what the fix corrected): lock acquisition used
+ * `retries: 0` (no automatic retry). Transient lock contention immediately
+ * returned `acquired: false`, forcing a manual LLM-driven retry of the whole
+ * tool call. The fix added bounded exponential-backoff retries so transient
+ * contention is absorbed in-process before reporting contention.
+ *
+ * How this guard works (and how it fails on revert):
+ *   `tryAcquireLock` calls `lockfile.lock(path, options)` directly (there is no
+ *   `_internals` seam for the proper-lockfile dependency), so we intercept the
+ *   `proper-lockfile` module via `mock.module` (normalizes to the allowlisted
+ *   `src/proper-lockfile`) and capture the options object.
+ *
+ *   Revert that breaks this guard: changing the option back to `retries: 0`
+ *   makes `options.retries` a number, so `typeof options.retries === 'object'`
+ *   fails; any reduction below 5, removal of exponential backoff (factor < 2),
+ *   or a non-growing window (maxTimeout <= minTimeout) also fails.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+interface LockRetries {
+	retries: number;
+	minTimeout?: number;
+	maxTimeout?: number;
+	factor?: number;
+}
+interface LockOptions {
+	retries?: LockRetries | number;
+	stale?: number;
+	realpath?: boolean;
+}
+
+const capturedOptions: LockOptions[] = [];
+
+// Capture the options proper-lockfile.lock() is invoked with, then return a
+// no-op release function so tryAcquireLock reports success.
+const lockSpy = mock(async (_lockPath: string, options: LockOptions) => {
+	capturedOptions.push(options);
+	return async () => {};
+});
+
+mock.module('proper-lockfile', () => ({
+	default: {
+		lock: lockSpy,
+		unlock: mock(async () => {}),
+	},
+}));
+
+// Import AFTER the mock is registered so file-locks binds the mocked module.
+import { tryAcquireLock } from '../../../src/parallel/file-locks';
+
+let tmpDir: string;
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'file-locks-retry-guard-'));
+	capturedOptions.length = 0;
+	lockSpy.mockClear();
+});
+
+afterEach(() => {
+	mock.restore();
+	try {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	} catch {
+		// ignore cleanup errors
+	}
+});
+
+describe('file-locks — regression: tryAcquireLock retry config (F-09)', () => {
+	test('passes bounded exponential-backoff retries (>=5) to proper-lockfile.lock', async () => {
+		// Before the fix, the options were `retries: 0` (no retry), so transient
+		// ELOCKED contention surfaced immediately. The fix passes a retries object
+		// with exponential backoff.
+		const result = await tryAcquireLock(tmpDir, 'target.ts', 'agent', 'task');
+
+		expect(result.acquired).toBe(true);
+		expect(lockSpy).toHaveBeenCalledTimes(1);
+		expect(capturedOptions.length).toBe(1);
+
+		const opts = capturedOptions[0];
+
+		// retries must be an OBJECT (not the number 0 from the reverted config).
+		expect(typeof opts.retries).toBe('object');
+		const retries = opts.retries as LockRetries;
+
+		// At least 5 retries — the core of the F-09 fix.
+		expect(retries.retries).toBeGreaterThanOrEqual(5);
+		// Exponential backoff (factor >= 2) over a growing window.
+		expect(retries.factor ?? 0).toBeGreaterThanOrEqual(2);
+		expect(retries.minTimeout ?? 0).toBeGreaterThan(0);
+		expect(retries.maxTimeout ?? 0).toBeGreaterThan(retries.minTimeout ?? 0);
+
+		// Stale timeout is still configured so dead locks expire.
+		expect(opts.stale ?? 0).toBeGreaterThan(0);
+	});
+});

--- a/tests/unit/plan/ledger-approved-snapshot.test.ts
+++ b/tests/unit/plan/ledger-approved-snapshot.test.ts
@@ -29,6 +29,7 @@ import {
 	loadLastApprovedPlan,
 	takeSnapshotEvent,
 } from '../../../src/plan/ledger';
+import { derivePlanId } from '../../../src/plan/utils';
 
 function createTestPlan(overrides?: Partial<Plan>): Plan {
 	return {
@@ -81,7 +82,7 @@ async function setupDirWithInitializedLedger(): Promise<{
 		'utf-8',
 	);
 
-	await initLedger(dir, `${plan.swarm}-${plan.title}`.replace(/\W/g, '_'));
+	await initLedger(dir, derivePlanId(plan));
 	return { dir, plan };
 }
 

--- a/tests/unit/plan/manager-ledger-replay-stale.test.ts
+++ b/tests/unit/plan/manager-ledger-replay-stale.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Plan, RuntimePlan } from '../../../src/config/plan-schema';
+import * as realLedger from '../../../src/plan/ledger';
+import { loadPlan, resetStartupLedgerCheck } from '../../../src/plan/manager';
+import { derivePlanId } from '../../../src/plan/utils';
+
+// ---------------------------------------------------------------------------
+// #1269 finding 2: structured staleness signal on the stale-return path.
+//
+// When loadPlan finds a plan.json whose hash mismatches the ledger, ledger
+// replay THROWS, AND no critic-approved snapshot is available, it falls back to
+// returning the STALE plan.json. Previously it returned that plan with no
+// structured flag — a silent stale-read. It must now attach
+// `_ledgerReplayStale === true` (+ a reason) so phase-complete.ts and
+// update-task-status.ts can detect the condition.
+//
+// We mock the ledger module (spread real, override four functions) to force the
+// exact path: ledger present, hash mismatch, replay throws, no approved
+// snapshot. `computePlanHash` stays REAL so it produces a value that differs
+// from our sentinel ledger hash, guaranteeing the mismatch branch.
+// ---------------------------------------------------------------------------
+
+function createTestPlan(overrides?: Partial<Plan>): Plan {
+	return {
+		schema_version: '1.0.0',
+		// NOTE: deliberately NO specHash — keeps the spec-staleness block from
+		// running so it cannot touch the returned object.
+		title: 'Ledger Replay Stale Plan',
+		swarm: 'replay-stale-swarm',
+		current_phase: 1,
+		phases: [
+			{
+				id: 1,
+				name: 'Phase 1',
+				status: 'in_progress',
+				tasks: [
+					{
+						id: '1.1',
+						phase: 1,
+						status: 'in_progress',
+						size: 'small',
+						description: 'Task one',
+						depends: [],
+						files_touched: [],
+					},
+				],
+			},
+		],
+		...overrides,
+	};
+}
+
+async function writePlanJson(dir: string, plan: Plan): Promise<void> {
+	const swarmDir = join(dir, '.swarm');
+	await mkdir(swarmDir, { recursive: true });
+	await writeFile(
+		join(swarmDir, 'plan.json'),
+		JSON.stringify(plan, null, 2),
+		'utf-8',
+	);
+}
+
+describe('loadPlan — #1269 finding 2: _ledgerReplayStale on stale-return path', () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), 'ledger-replay-stale-'));
+		resetStartupLedgerCheck();
+	});
+
+	afterEach(async () => {
+		mock.restore();
+		resetStartupLedgerCheck();
+		if (existsSync(tempDir)) {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test('hash mismatch + replay throws + no approved snapshot → returns plan with _ledgerReplayStale=true and reason', async () => {
+		const plan = createTestPlan();
+		await writePlanJson(tempDir, plan);
+
+		const planId = derivePlanId(plan);
+		// A ledger event whose plan_id matches the plan identity (so loadPlan takes
+		// the rebuild branch, not the migration/identity-mismatch branch) and whose
+		// plan_hash_after is a sentinel that will never equal the real
+		// computePlanHash(plan) → forces the hash-mismatch branch.
+		const fakeEvent = {
+			seq: 1,
+			plan_id: planId,
+			event_type: 'plan_created',
+			plan_hash_after: 'SENTINEL_LEDGER_HASH_NEVER_MATCHES',
+			timestamp: '2026-01-01T00:00:00.000Z',
+		};
+
+		mock.module('../../../src/plan/ledger', () => ({
+			...realLedger,
+			ledgerExists: async () => true,
+			readLedgerEvents: async () => [fakeEvent],
+			replayFromLedger: async () => {
+				throw new Error('simulated replay failure');
+			},
+			loadLastApprovedPlan: async () => null,
+		}));
+
+		const result = (await loadPlan(tempDir)) as RuntimePlan | null;
+
+		expect(result).not.toBeNull();
+		// Proves we returned the (stale) plan.json, not some other object.
+		expect(result!.title).toBe('Ledger Replay Stale Plan');
+		expect(result!.swarm).toBe('replay-stale-swarm');
+
+		// The structured staleness signal (the assertion this test exists for).
+		expect(result!._ledgerReplayStale).toBe(true);
+		expect(typeof result!._ledgerReplayStaleReason).toBe('string');
+		expect(result!._ledgerReplayStaleReason).toContain('Ledger replay failed');
+		expect(result!._ledgerReplayStaleReason).toContain(
+			'simulated replay failure',
+		);
+	});
+
+	test('persistence (core fix): a SECOND loadPlan WITHOUT resetStartupLedgerCheck STILL returns _ledgerReplayStale=true', async () => {
+		// Regression for #1269 finding-2 production gap: the stale verdict used to be
+		// set only inside the startup-gated block, on a throwaway structuredClone, so
+		// it was attached on the FIRST loadPlan per workspace per process and never
+		// reached later update_task_status / phase_complete loads. The fix persists
+		// the verdict per-workspace (ledgerStaleWorkspaces) and re-surfaces it at the
+		// live-plan return chokepoint. This drives the REAL loadPlan (only the LEDGER
+		// internals are mocked — loadPlan itself is never mocked).
+		const plan = createTestPlan();
+		await writePlanJson(tempDir, plan);
+
+		const planId = derivePlanId(plan);
+		const fakeEvent = {
+			seq: 1,
+			plan_id: planId,
+			event_type: 'plan_created',
+			plan_hash_after: 'SENTINEL_LEDGER_HASH_NEVER_MATCHES',
+			timestamp: '2026-01-01T00:00:00.000Z',
+		};
+
+		mock.module('../../../src/plan/ledger', () => ({
+			...realLedger,
+			ledgerExists: async () => true,
+			readLedgerEvents: async () => [fakeEvent],
+			replayFromLedger: async () => {
+				throw new Error('simulated replay failure');
+			},
+			loadLastApprovedPlan: async () => null,
+		}));
+
+		// First load: startup replay runs, detects unrecoverable staleness, persists
+		// the verdict, and attaches the detailed reason.
+		const first = (await loadPlan(tempDir)) as RuntimePlan | null;
+		expect(first).not.toBeNull();
+		expect(first!._ledgerReplayStale).toBe(true);
+		expect(first!._ledgerReplayStaleReason).toContain(
+			'simulated replay failure',
+		);
+
+		// Second load WITHOUT resetStartupLedgerCheck(): the expensive startup replay
+		// is now skipped (active-session window), so before the fix this returned the
+		// plan with NO staleness flag — the dead-guard bug. It must STILL be flagged.
+		const second = (await loadPlan(tempDir)) as RuntimePlan | null;
+		expect(second).not.toBeNull();
+		// Proves it is the live plan.json being returned, re-flagged.
+		expect(second!.title).toBe('Ledger Replay Stale Plan');
+		expect(second!._ledgerReplayStale).toBe(true);
+		// On the persisted (non-startup) surface the detailed replay-error string is
+		// not available; assert only that a non-empty reason rides the object.
+		expect(typeof second!._ledgerReplayStaleReason).toBe('string');
+		expect(second!._ledgerReplayStaleReason!.length).toBeGreaterThan(0);
+	});
+
+	test('self-heal: once plan.json reconverges with the ledger, the next loadPlan CLEARS the flag', async () => {
+		// Proves the fix is "refuse until fixed, then auto-clear" — not a permanent
+		// stuck refusal. After detection, we make the ledger tail hash equal the real
+		// computePlanHash of the returned plan (simulating an architect save_plan /
+		// rebuild that reconverged plan.json with the ledger). The cheap self-heal
+		// recheck at the chokepoint must then drop the verdict.
+		const plan = createTestPlan({
+			title: 'Self Heal Plan',
+			swarm: 'self-heal-swarm',
+		});
+		await writePlanJson(tempDir, plan);
+		const planId = derivePlanId(plan);
+
+		// Mutable ledger tail hash so the same mock can present a mismatch first and
+		// a match after reconvergence. Derived from the RETURNED object (not the raw
+		// literal) so schema-defaulted fields cannot make the heal hash unreachable.
+		let ledgerTail = 'SENTINEL_LEDGER_HASH_NEVER_MATCHES';
+		const makeEvent = () => ({
+			seq: 1,
+			plan_id: planId,
+			event_type: 'plan_created',
+			plan_hash_after: ledgerTail,
+			timestamp: '2026-01-01T00:00:00.000Z',
+		});
+
+		mock.module('../../../src/plan/ledger', () => ({
+			...realLedger,
+			ledgerExists: async () => true,
+			readLedgerEvents: async () => [makeEvent()],
+			replayFromLedger: async () => {
+				throw new Error('simulated replay failure');
+			},
+			loadLastApprovedPlan: async () => null,
+		}));
+
+		// Phase 1 — detect + persist.
+		const stale = (await loadPlan(tempDir)) as RuntimePlan | null;
+		expect(stale).not.toBeNull();
+		expect(stale!._ledgerReplayStale).toBe(true);
+
+		// Invariant 5 evidence: the runtime-only flag does NOT affect the plan hash
+		// (computePlanHash uses an explicit field allow-list). Hash the SAME object
+		// with the flag, then strip the runtime overlay and hash again — isolating
+		// the flag's (non-)effect, so this is safe to use as the reconverged tail.
+		const reconvergedHash = realLedger.computePlanHash(stale!);
+		const flaglessClone = { ...stale! } as RuntimePlan;
+		flaglessClone._ledgerReplayStale = undefined;
+		flaglessClone._ledgerReplayStaleReason = undefined;
+		expect(realLedger.computePlanHash(flaglessClone)).toBe(reconvergedHash);
+
+		// Phase 2 — reconverge: ledger tail now matches the live plan.json hash.
+		ledgerTail = reconvergedHash;
+
+		// Next load WITHOUT resetStartupLedgerCheck(): the self-heal recheck sees
+		// plan == ledger and must clear the verdict.
+		const healed = (await loadPlan(tempDir)) as RuntimePlan | null;
+		expect(healed).not.toBeNull();
+		expect(healed!.title).toBe('Self Heal Plan');
+		expect(healed!._ledgerReplayStale).toBeUndefined();
+		expect(healed!._ledgerReplayStaleReason).toBeUndefined();
+
+		// And it stays cleared on the subsequent load (verdict was removed from the
+		// persisted set, not merely suppressed for one call).
+		const stillHealed = (await loadPlan(tempDir)) as RuntimePlan | null;
+		expect(stillHealed).not.toBeNull();
+		expect(stillHealed!._ledgerReplayStale).toBeUndefined();
+	});
+
+	test('healthy load (no ledger) does NOT set _ledgerReplayStale', async () => {
+		const plan = createTestPlan({
+			title: 'Healthy Plan',
+			swarm: 'healthy-swarm',
+		});
+		await writePlanJson(tempDir, plan);
+
+		// No ledger present → loadPlan never enters the rebuild/stale path.
+		mock.module('../../../src/plan/ledger', () => ({
+			...realLedger,
+			ledgerExists: async () => false,
+		}));
+
+		const result = (await loadPlan(tempDir)) as RuntimePlan | null;
+
+		expect(result).not.toBeNull();
+		expect(result!.title).toBe('Healthy Plan');
+		expect(result!._ledgerReplayStale).toBeUndefined();
+		expect(result!._ledgerReplayStaleReason).toBeUndefined();
+	});
+});

--- a/tests/unit/plan/manager-plan-md-sync.test.ts
+++ b/tests/unit/plan/manager-plan-md-sync.test.ts
@@ -1,0 +1,137 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	spyOn,
+	test,
+} from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Plan } from '../../../src/config/plan-schema';
+import {
+	derivePlanMarkdown,
+	isPlanMdInSync,
+	regeneratePlanMarkdown,
+} from '../../../src/plan/manager';
+
+// ---------------------------------------------------------------------------
+// FR-001 / F-11: isPlanMdInSync must NOT treat a non-equivalent plan.md that
+// merely CONTAINS the expected rendering (strict superset / substring) as
+// "in sync". The legitimate sync paths are (1) PLAN_HASH header match and
+// (2) normalized exact equality. The former permissive substring fallback
+// produced false positives and has been removed.
+//
+// derivePlanMarkdown() embeds a fresh `Updated: <ISO>` timestamp on every call,
+// so the exact-equality and substring paths are non-deterministic at runtime
+// unless time is frozen. We freeze Date.prototype.toISOString for the
+// timestamp-dependent cases so the test is deterministic. The PLAN_HASH path is
+// timestamp-independent (computePlanContentHash excludes timestamps) and does
+// not require freezing.
+// ---------------------------------------------------------------------------
+
+function createTestPlan(overrides?: Partial<Plan>): Plan {
+	return {
+		schema_version: '1.0.0',
+		title: 'Sync Test Plan',
+		swarm: 'sync-swarm',
+		current_phase: 1,
+		phases: [
+			{
+				id: 1,
+				name: 'Phase 1',
+				status: 'in_progress',
+				tasks: [
+					{
+						id: '1.1',
+						phase: 1,
+						status: 'in_progress',
+						size: 'small',
+						description: 'Task one',
+						depends: [],
+						files_touched: [],
+					},
+				],
+			},
+		],
+		...overrides,
+	};
+}
+
+async function writePlanMd(dir: string, content: string): Promise<void> {
+	const swarmDir = join(dir, '.swarm');
+	await mkdir(swarmDir, { recursive: true });
+	await writeFile(join(swarmDir, 'plan.md'), content, 'utf-8');
+}
+
+describe('isPlanMdInSync — FR-001 / F-11 substring-fallback tightening', () => {
+	let tempDir: string;
+	let toISOStringSpy: ReturnType<typeof spyOn> | null = null;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), 'plan-md-sync-'));
+		// Freeze the timestamp embedded by derivePlanMarkdown so the
+		// exact-equality and superset cases are deterministic.
+		toISOStringSpy = spyOn(Date.prototype, 'toISOString').mockReturnValue(
+			'2026-01-01T00:00:00.000Z',
+		);
+	});
+
+	afterEach(async () => {
+		toISOStringSpy?.mockRestore();
+		toISOStringSpy = null;
+		mock.restore();
+		if (existsSync(tempDir)) {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test('PLAN_HASH header match → in sync (true)', async () => {
+		const plan = createTestPlan();
+		// regeneratePlanMarkdown writes plan.md with the `<!-- PLAN_HASH: ... -->`
+		// header that the primary sync check extracts and compares.
+		await regeneratePlanMarkdown(tempDir, plan);
+
+		expect(await isPlanMdInSync(tempDir, plan)).toBe(true);
+	});
+
+	test('normalized exact-equality (no PLAN_HASH header) → in sync (true)', async () => {
+		const plan = createTestPlan();
+		// Legacy plan.md generated before hashing was added: no header, but the
+		// content is byte-for-byte the derived rendering (time frozen).
+		const exact = derivePlanMarkdown(plan);
+		await writePlanMd(tempDir, exact);
+
+		expect(await isPlanMdInSync(tempDir, plan)).toBe(true);
+	});
+
+	test('regression (F-11): strict superset of the expected rendering → OUT of sync (false)', async () => {
+		// Previous buggy behavior: the permissive fallback
+		//   `normalizedActual.includes(normalizedExpected) || ...`
+		// reported a plan.md that merely CONTAINS the expected rendering (with
+		// extra, non-equivalent phases/tasks appended) as "in sync". With time
+		// frozen, `includes()` is true for this input, so the OLD code returned
+		// true. The tightened code returns false because there is neither a
+		// PLAN_HASH header match nor exact equality.
+		const plan = createTestPlan();
+		const expected = derivePlanMarkdown(plan);
+		const superset = `${expected}\n\n## Phase 99: Injected [PENDING]\n- [ ] 99.1: an extra task not present in plan.json [SMALL]\n`;
+		await writePlanMd(tempDir, superset);
+
+		// Sanity: the superset genuinely contains the expected rendering, so the
+		// removed substring fallback would have matched.
+		expect(superset.trim().includes(expected.trim())).toBe(true);
+
+		expect(await isPlanMdInSync(tempDir, plan)).toBe(false);
+	});
+
+	test('missing plan.md → OUT of sync (false)', async () => {
+		const plan = createTestPlan();
+		await mkdir(join(tempDir, '.swarm'), { recursive: true });
+		// No plan.md written.
+		expect(await isPlanMdInSync(tempDir, plan)).toBe(false);
+	});
+});

--- a/tests/unit/services/version-check.test.ts
+++ b/tests/unit/services/version-check.test.ts
@@ -11,8 +11,11 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+	_internals,
 	_resetVersionCheckLatchForTests,
 	compareVersions,
+	fetchLatestVersion,
+	isStrictSemver,
 	readVersionCache,
 	scheduleVersionCheck,
 } from '../../../src/services/version-check';
@@ -243,6 +246,162 @@ describe('readVersionCache', () => {
 		);
 		const entry = readVersionCache();
 		expect(entry).toEqual({ checkedAt: 42, npmLatest: '1.2.3' });
+	});
+});
+
+describe('fetchLatestVersion — strict response validation (#1270-4)', () => {
+	const realFetch = _internals.fetch;
+
+	afterEach(() => {
+		// Restore the DI seam so the real global fetch is reinstated. The seam
+		// is file-scoped state; leaving a mock in place would corrupt other
+		// suites in the shared test-runner process.
+		_internals.fetch = realFetch;
+	});
+
+	// Minimal Response-shaped fake: fetchLatestVersion only reads `.ok`,
+	// `.headers.get(...)`, and `.text()`. Using a plain object keeps the test
+	// deterministic and avoids runtime-specific Response/Content-Length quirks.
+	function fakeResponse(opts: {
+		ok?: boolean;
+		contentType?: string | null;
+		contentLength?: string | null;
+		body: string;
+	}): Response {
+		const headers = new Map<string, string>();
+		if (opts.contentType != null) headers.set('content-type', opts.contentType);
+		if (opts.contentLength != null)
+			headers.set('content-length', opts.contentLength);
+		return {
+			ok: opts.ok ?? true,
+			headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
+			text: async () => opts.body,
+		} as unknown as Response;
+	}
+
+	const signal = new AbortController().signal;
+
+	test('accepts a well-formed JSON response with a strict semver', async () => {
+		_internals.fetch = async () =>
+			fakeResponse({
+				contentType: 'application/json; charset=utf-8',
+				body: JSON.stringify({ version: '6.86.7' }),
+			});
+		expect(await fetchLatestVersion(signal)).toBe('6.86.7');
+	});
+
+	test('accepts the npm install-v1 +json content-type variant', async () => {
+		_internals.fetch = async () =>
+			fakeResponse({
+				contentType: 'application/vnd.npm.install-v1+json',
+				body: JSON.stringify({ version: '7.0.0-rc.1' }),
+			});
+		expect(await fetchLatestVersion(signal)).toBe('7.0.0-rc.1');
+	});
+
+	test('rejects a non-JSON content-type (HTML error page)', async () => {
+		_internals.fetch = async () =>
+			fakeResponse({
+				contentType: 'text/html; charset=utf-8',
+				body: '<!doctype html><html><body>502 Bad Gateway</body></html>',
+			});
+		expect(await fetchLatestVersion(signal)).toBeNull();
+	});
+
+	test('rejects a text/plain content-type', async () => {
+		_internals.fetch = async () =>
+			fakeResponse({
+				contentType: 'text/plain',
+				body: JSON.stringify({ version: '6.86.7' }),
+			});
+		expect(await fetchLatestVersion(signal)).toBeNull();
+	});
+
+	test('rejects an oversized body via advertised content-length', async () => {
+		_internals.fetch = async () =>
+			fakeResponse({
+				contentType: 'application/json',
+				contentLength: String(5 * 1024 * 1024), // 5 MiB > 256 KiB cap
+				body: JSON.stringify({ version: '6.86.7' }),
+			});
+		expect(await fetchLatestVersion(signal)).toBeNull();
+	});
+
+	test('rejects an oversized actual body even without a content-length header', async () => {
+		const huge = `{"version":"6.86.7","pad":"${'x'.repeat(300 * 1024)}"}`;
+		_internals.fetch = async () =>
+			fakeResponse({ contentType: 'application/json', body: huge });
+		expect(await fetchLatestVersion(signal)).toBeNull();
+	});
+
+	test('rejects a non-semver version string', async () => {
+		_internals.fetch = async () =>
+			fakeResponse({
+				contentType: 'application/json',
+				body: JSON.stringify({ version: 'latest' }),
+			});
+		expect(await fetchLatestVersion(signal)).toBeNull();
+	});
+
+	test('rejects a version field that is not a string', async () => {
+		_internals.fetch = async () =>
+			fakeResponse({
+				contentType: 'application/json',
+				body: JSON.stringify({ version: { major: 6 } }),
+			});
+		expect(await fetchLatestVersion(signal)).toBeNull();
+	});
+
+	test('rejects a non-ok HTTP status', async () => {
+		_internals.fetch = async () =>
+			fakeResponse({
+				ok: false,
+				contentType: 'application/json',
+				body: JSON.stringify({ version: '6.86.7' }),
+			});
+		expect(await fetchLatestVersion(signal)).toBeNull();
+	});
+
+	test('returns null (never throws) when fetch itself rejects', async () => {
+		_internals.fetch = async () => {
+			throw new Error('network down');
+		};
+		let result: string | null = 'unset';
+		await expect(
+			(async () => {
+				result = await fetchLatestVersion(signal);
+			})(),
+		).resolves.toBeUndefined();
+		expect(result).toBeNull();
+	});
+});
+
+describe('isStrictSemver (#1270-4)', () => {
+	test('accepts the live package.json version (guards against over-strict regex)', () => {
+		const pkg = JSON.parse(
+			readFileSync(
+				join(import.meta.dir, '..', '..', '..', 'package.json'),
+				'utf-8',
+			),
+		) as { version: string };
+		// If this fails, the strict regex would silently reject a legitimate
+		// npm `latest` response and disable update checks for everyone.
+		expect(isStrictSemver(pkg.version)).toBe(true);
+	});
+
+	test('accepts standard release and prerelease forms', () => {
+		expect(isStrictSemver('6.86.7')).toBe(true);
+		expect(isStrictSemver('7.0.0-rc.1')).toBe(true);
+		expect(isStrictSemver('1.2.3+build.5')).toBe(true);
+	});
+
+	test('rejects dist-tags, ranges, partials, and junk', () => {
+		expect(isStrictSemver('latest')).toBe(false);
+		expect(isStrictSemver('^6.86.7')).toBe(false);
+		expect(isStrictSemver('6.86')).toBe(false);
+		expect(isStrictSemver('')).toBe(false);
+		expect(isStrictSemver('6.86.7 ')).toBe(false);
+		expect(isStrictSemver(42 as unknown)).toBe(false);
 	});
 });
 

--- a/tests/unit/state.test.ts
+++ b/tests/unit/state.test.ts
@@ -9,10 +9,12 @@ import {
 	getAgentSession,
 	getTaskState,
 	type InvocationWindow,
+	maybeSweepStaleSessions,
 	pruneOldWindows,
 	resetSwarmState,
 	startAgentSession,
 	swarmState,
+	sweepStaleSessions,
 	type TaskWorkflowState,
 	type ToolAggregate,
 	type ToolCallEntry,
@@ -539,6 +541,110 @@ describe('state module', () => {
 			expect(getAgentSession('recent-session')).toBeDefined();
 			// New session should exist
 			expect(getAgentSession('new-session')).toBeDefined();
+		});
+	});
+
+	describe('idle-TTL session sweep (issue #1269 finding 1, residual)', () => {
+		const STALE_TTL_MS = 7_200_000; // 2h, matches the production default
+		const COOLDOWN_MS = 60_000; // matches IDLE_SWEEP_COOLDOWN_MS
+
+		it('reclaims a stale session via the hot path WITHOUT a new startAgentSession', () => {
+			// Two live sessions. Only the SECOND startAgentSession (and no later
+			// one) is allowed — the reclaim of the stale session must come from
+			// the per-tool-call hot path, not a fresh session start.
+			startAgentSession('active-session', 'coder');
+			startAgentSession('stale-session', 'reviewer');
+
+			// Give the stale session a delegation chain so we can prove the chain
+			// (keyed by sessionID) is reclaimed alongside the session.
+			swarmState.delegationChains.set('stale-session', [
+				{ from: 'architect', to: 'reviewer', timestamp: Date.now() },
+			]);
+
+			// Age the stale session past the 2h idle TTL.
+			const stale = getAgentSession('stale-session');
+			expect(stale).toBeDefined();
+			stale!.lastToolCallTime = Date.now() - (STALE_TTL_MS + 100_000);
+
+			// From here on: NO startAgentSession call. Only the per-tool-call
+			// accounting path (ensureAgentSession on an existing session) runs.
+			ensureAgentSession('active-session', 'coder');
+
+			// Stale session AND its delegation chain are reclaimed.
+			expect(getAgentSession('stale-session')).toBeUndefined();
+			expect(swarmState.delegationChains.has('stale-session')).toBe(false);
+			// The active session that drove the sweep survives.
+			expect(getAgentSession('active-session')).toBeDefined();
+		});
+
+		it('does NOT evict a fresh/active session', () => {
+			// A single recently-active session must survive a sweep — it is never
+			// its own victim because its lastToolCallTime was just refreshed.
+			startAgentSession('fresh-session', 'coder');
+			const fresh = getAgentSession('fresh-session');
+			expect(fresh).toBeDefined();
+			fresh!.lastToolCallTime = Date.now() - 300_000; // 5 min ago, well within TTL
+
+			// Drive the hot path repeatedly; the fresh session must persist.
+			ensureAgentSession('fresh-session', 'coder');
+			ensureAgentSession('fresh-session', 'coder');
+
+			expect(getAgentSession('fresh-session')).toBeDefined();
+			expect(swarmState.agentSessions.size).toBe(1);
+		});
+
+		it('cooldown bounds the sweep so it does not run on every call', () => {
+			const t0 = 1_000_000_000_000; // fixed virtual clock — no real time/sleep
+
+			// Seed two already-stale sessions relative to the injected clock.
+			startAgentSession('stale-1', 'coder');
+			startAgentSession('stale-2', 'reviewer');
+			getAgentSession('stale-1')!.lastToolCallTime = t0 - (STALE_TTL_MS + 1);
+			getAgentSession('stale-2')!.lastToolCallTime = t0 - (STALE_TTL_MS + 1);
+
+			// First sweep at t0: cooldown is open (reset to 0), so stale-1 and
+			// stale-2 are both old enough — both evicted.
+			const firstEvicted = maybeSweepStaleSessions(STALE_TTL_MS, t0);
+			expect(firstEvicted.sort()).toEqual(['stale-1', 'stale-2']);
+
+			// Add a third stale session AFTER the first sweep.
+			startAgentSession('stale-3', 'explorer');
+			getAgentSession('stale-3')!.lastToolCallTime = t0 - (STALE_TTL_MS + 1);
+
+			// Second call WITHIN the cooldown window: the O(n) scan is skipped
+			// entirely, so stale-3 survives. This survival IS the bounded-work
+			// proof — the sweep did not run despite a reclaimable session.
+			const blocked = maybeSweepStaleSessions(STALE_TTL_MS, t0 + 1_000);
+			expect(blocked).toEqual([]);
+			expect(getAgentSession('stale-3')).toBeDefined();
+
+			// Once the cooldown elapses, the next call sweeps again and reclaims
+			// stale-3 — proving the cooldown bounds frequency, not capability.
+			const afterCooldown = maybeSweepStaleSessions(
+				STALE_TTL_MS,
+				t0 + COOLDOWN_MS + 1,
+			);
+			expect(afterCooldown).toEqual(['stale-3']);
+			expect(getAgentSession('stale-3')).toBeUndefined();
+		});
+
+		it('sweepStaleSessions reuses one eviction loop and drops the keyed delegation chain', () => {
+			// Direct unit coverage of the extracted loop used by both eager and
+			// opportunistic paths.
+			startAgentSession('keep', 'coder');
+			startAgentSession('drop', 'reviewer');
+			swarmState.delegationChains.set('drop', [
+				{ from: 'architect', to: 'reviewer', timestamp: Date.now() },
+			]);
+			getAgentSession('drop')!.lastToolCallTime =
+				Date.now() - (STALE_TTL_MS + 1);
+
+			const evicted = sweepStaleSessions();
+
+			expect(evicted).toEqual(['drop']);
+			expect(getAgentSession('drop')).toBeUndefined();
+			expect(swarmState.delegationChains.has('drop')).toBe(false);
+			expect(getAgentSession('keep')).toBeDefined();
 		});
 	});
 

--- a/tests/unit/tools/get-approved-plan.test.ts
+++ b/tests/unit/tools/get-approved-plan.test.ts
@@ -22,6 +22,7 @@ import {
 	initLedger,
 	takeSnapshotEvent,
 } from '../../../src/plan/ledger';
+import { derivePlanId } from '../../../src/plan/utils';
 import { executeGetApprovedPlan } from '../../../src/tools/get-approved-plan';
 
 function createTestPlan(overrides?: Partial<Plan>): Plan {
@@ -75,7 +76,7 @@ async function setupDirWithLedger(): Promise<{
 		'utf-8',
 	);
 
-	await initLedger(dir, `${plan.swarm}-${plan.title}`.replace(/\W/g, '_'));
+	await initLedger(dir, derivePlanId(plan));
 	return { dir, plan };
 }
 

--- a/tests/unit/tools/phase-complete-fallback-trace.test.ts
+++ b/tests/unit/tools/phase-complete-fallback-trace.test.ts
@@ -1,0 +1,339 @@
+/**
+ * FR-002 (issue #660 / F-08): the last-resort "direct write" emergency fallback
+ * in phase_complete must (a) append a traceability event to .swarm/events.jsonl
+ * after a successful write, and (b) refuse to persist a schema-invalid candidate.
+ *
+ * This is NOT a new plan.json writer — it is the EXISTING emergency fallback
+ * (src/tools/phase-complete.ts "Last resort: direct write") made validated +
+ * traceable. The durable PlanSchema is unchanged; the real PlanSchema is used
+ * here (NOT mocked) so the validation gate is meaningful.
+ *
+ * phase-complete.ts exposes NO `_internals` seam, so — mirroring the sanctioned
+ * sibling scaffold in phase-complete-lock-before-saveplan.regression.test.ts —
+ * this drives the full executePhaseComplete via vi.mock against the public
+ * surface (the same pattern that regression guard explicitly permits).
+ *
+ * Path driven: loadPlan -> null AND ledgerExists -> false forces the
+ * `if (plan === null)` branch straight to the last-resort direct write, which
+ * reads the on-disk plan.json (real fs), mutates the phase status, validates,
+ * and (only if valid) writes + records the trace event.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { resetSwarmState, swarmState } from '../../../src/state';
+import { executePhaseComplete } from '../../../src/tools/phase-complete';
+
+// Control lock acquisition (always granted here so the plan-write block runs).
+vi.mock('../../../src/parallel/file-locks', () => ({
+	tryAcquireLock: vi.fn(),
+}));
+
+// Mirror the proven scaffold so executePhaseComplete reaches the plan-write
+// path without real LLM / evidence work.
+vi.mock('../../../src/evidence/manager', () => ({
+	listEvidenceTaskIds: vi.fn().mockResolvedValue([]),
+	loadEvidence: vi.fn().mockImplementation((_dir: string, taskId: string) => {
+		if (taskId.startsWith('retro-')) {
+			try {
+				const retroPath = path.join(
+					_dir,
+					'.swarm',
+					'evidence',
+					taskId,
+					'evidence.json',
+				);
+				if (fs.existsSync(retroPath)) {
+					const content = fs.readFileSync(retroPath, 'utf-8');
+					return { status: 'found', bundle: JSON.parse(content) };
+				}
+			} catch {
+				// fall through
+			}
+		}
+		return { status: 'not_found' };
+	}),
+}));
+
+vi.mock('../../../src/hooks/curator', () => ({
+	runCuratorPhase: vi.fn().mockResolvedValue({
+		digest: { summary: 'test' },
+		knowledge_recommendations: [],
+		compliance: [],
+	}),
+	applyCuratorKnowledgeUpdates: vi
+		.fn()
+		.mockResolvedValue({ applied: 0, skipped: 0 }),
+}));
+
+vi.mock('../../../src/hooks/curator-llm-factory.js', () => ({
+	createCuratorLLMDelegate: vi.fn().mockReturnValue({
+		delegate: vi.fn().mockResolvedValue({ summary: 'test' }),
+	}),
+}));
+
+vi.mock('../../../src/hooks/knowledge-curator.js', () => ({
+	curateAndStoreSwarm: vi
+		.fn()
+		.mockResolvedValue({ stored: 0, skipped: 0, rejected: 0 }),
+}));
+
+vi.mock('../../../src/hooks/knowledge-reader.js', () => ({
+	updateRetrievalOutcome: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/hooks/review-receipt.js', () => ({
+	buildApprovedReceipt: vi.fn().mockReturnValue({}),
+	buildRejectedReceipt: vi.fn().mockReturnValue({}),
+	persistReviewReceipt: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/plan/checkpoint', () => ({
+	writeCheckpoint: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/plan/ledger', () => ({
+	ledgerExists: vi.fn().mockResolvedValue(false),
+	replayFromLedger: vi.fn().mockResolvedValue(null),
+	takeSnapshotEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/plan/manager', () => ({
+	loadPlan: vi.fn().mockResolvedValue(null),
+	savePlan: vi.fn().mockResolvedValue(undefined),
+	savePlanWithAutoAcknowledgedRemovals: vi.fn().mockResolvedValue(undefined),
+	closePlanTerminalState: async () => {},
+	_snapshot_test_exports: {},
+}));
+
+vi.mock('../../../src/session/snapshot-writer', () => ({
+	flushPendingSnapshot: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/telemetry', () => ({
+	telemetry: {
+		phaseChanged: vi.fn(),
+		sessionStarted: vi.fn(),
+		agentActivated: vi.fn(),
+	},
+}));
+
+vi.mock('../../../src/tools/completion-verify', () => ({
+	executeCompletionVerify: vi
+		.fn()
+		.mockResolvedValue(JSON.stringify({ status: 'passed' })),
+}));
+
+// Map validateSwarmPath to the real on-disk .swarm/ path so the fallback writes
+// to the temp dir. The real atomicWriteFile (not mocked) performs the write.
+vi.mock('../../../src/hooks/utils', () => ({
+	validateSwarmPath: vi
+		.fn()
+		.mockImplementation((_dir: string, file: string) =>
+			path.join(_dir, '.swarm', file),
+		),
+}));
+
+vi.mock('../../../src/config', () => ({
+	loadPluginConfigWithMeta: vi.fn().mockReturnValue({
+		config: {
+			phase_complete: { enabled: true, required_agents: [], policy: 'warn' },
+			curator: { enabled: false },
+			knowledge: {},
+		},
+	}),
+}));
+
+vi.mock('../../../src/config/schema', () => ({
+	PhaseCompleteConfigSchema: {
+		parse: vi.fn().mockImplementation((cfg) => ({
+			enabled: cfg?.enabled ?? true,
+			required_agents: cfg?.required_agents ?? [],
+			policy: cfg?.policy ?? 'warn',
+		})),
+	},
+	CuratorConfigSchema: {
+		parse: vi.fn().mockReturnValue({ enabled: false, phase_enabled: false }),
+	},
+	KnowledgeConfigSchema: { parse: vi.fn().mockReturnValue({}) },
+	stripKnownSwarmPrefix: vi.fn().mockImplementation((name: string) => name),
+}));
+
+// Import mocked modules after vi.mock calls.
+import { tryAcquireLock } from '../../../src/parallel/file-locks';
+import { ledgerExists } from '../../../src/plan/ledger';
+import { loadPlan } from '../../../src/plan/manager';
+import { ensureAgentSession } from '../../../src/state';
+
+const mockTryAcquireLock = tryAcquireLock as ReturnType<typeof vi.fn>;
+const mockLoadPlan = loadPlan as ReturnType<typeof vi.fn>;
+const mockLedgerExists = ledgerExists as ReturnType<typeof vi.fn>;
+
+function acquiredLock(filePath: string) {
+	return {
+		acquired: true as const,
+		lock: {
+			filePath,
+			agent: 'phase-complete',
+			taskId: `phase-complete-${filePath}`,
+			timestamp: new Date().toISOString(),
+			expiresAt: Date.now() + 300000,
+			_release: vi.fn().mockResolvedValue(undefined),
+		},
+	};
+}
+
+function writeRetroEvidence(tempDir: string) {
+	const retroDir = path.join(tempDir, '.swarm', 'evidence', 'retro-1');
+	fs.mkdirSync(retroDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(retroDir, 'evidence.json'),
+		JSON.stringify({
+			schema_version: '1.0.0',
+			task_id: 'retro-1',
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+			entries: [
+				{
+					task_id: 'retro-1',
+					type: 'retrospective',
+					timestamp: new Date().toISOString(),
+					agent: 'architect',
+					verdict: 'pass',
+					summary: 'Phase 1 completed',
+					phase_number: 1,
+					total_tool_calls: 10,
+					coder_revisions: 1,
+					reviewer_rejections: 0,
+					test_failures: 0,
+					security_findings: 0,
+					integration_issues: 0,
+					task_count: 1,
+					task_complexity: 'simple',
+					top_rejection_reasons: [],
+					lessons_learned: [],
+				},
+			],
+		}),
+	);
+}
+
+function readFallbackEvents(tempDir: string) {
+	const eventsRaw = fs.readFileSync(
+		path.join(tempDir, '.swarm', 'events.jsonl'),
+		'utf-8',
+	);
+	return eventsRaw
+		.split('\n')
+		.filter(Boolean)
+		.map((line) => JSON.parse(line))
+		.filter((e) => e.event === 'phase_complete_fallback_write');
+}
+
+describe('phase_complete — FR-002: last-resort fallback write is traceable + validated', () => {
+	let tempDir: string;
+	let originalCwd: string;
+
+	beforeEach(() => {
+		tempDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'phase-complete-fr002-')),
+		);
+		originalCwd = process.cwd();
+		process.chdir(tempDir);
+
+		fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+		fs.writeFileSync(path.join(tempDir, '.swarm', 'events.jsonl'), '', 'utf-8');
+		writeRetroEvidence(tempDir);
+
+		resetSwarmState();
+		swarmState.activeAgent.set('current', 'test-agent');
+		const session = ensureAgentSession('test-session', 'test-agent', tempDir);
+		session.phaseAgentsDispatched = new Set();
+		session.lastPhaseCompleteTimestamp = 0;
+
+		vi.clearAllMocks();
+		// vi.clearAllMocks wipes default resolves — re-arm per test.
+		mockLoadPlan.mockResolvedValue(null);
+		mockLedgerExists.mockResolvedValue(false);
+		mockTryAcquireLock.mockImplementation(async (_dir: string, file: string) =>
+			acquiredLock(file),
+		);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			// ignore cleanup errors
+		}
+	});
+
+	test('valid candidate: writes plan.json AND appends a phase_complete_fallback_write trace event', async () => {
+		const planPath = path.join(tempDir, '.swarm', 'plan.json');
+		// Schema-valid on-disk plan (real PlanSchema must accept it).
+		fs.writeFileSync(
+			planPath,
+			JSON.stringify({
+				schema_version: '1.0.0',
+				title: 'Test Plan',
+				swarm: 'test-swarm',
+				current_phase: 1,
+				phases: [{ id: 1, name: 'Phase 1', status: 'in_progress', tasks: [] }],
+			}),
+		);
+
+		const result = await executePhaseComplete(
+			{ phase: 1, sessionID: 'test-session' },
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+		expect(parsed.success).toBe(true);
+
+		// (a) plan.json on disk was mutated to complete by the fallback writer.
+		const persisted = JSON.parse(fs.readFileSync(planPath, 'utf-8'));
+		expect(persisted.phases[0].status).toBe('complete');
+
+		// (b) exactly one traceability event for the fallback write, for phase 1.
+		const fallbackEvents = readFallbackEvents(tempDir);
+		expect(fallbackEvents.length).toBe(1);
+		expect(fallbackEvents[0].phase).toBe(1);
+		expect(typeof fallbackEvents[0].timestamp).toBe('string');
+	});
+
+	test('schema-invalid candidate: NOT persisted, no trace event, surfaces a validation warning', async () => {
+		const planPath = path.join(tempDir, '.swarm', 'plan.json');
+		// JSON-valid but schema-INVALID: missing schema_version/title/swarm and the
+		// phase is missing the required `name`. phaseObj (id===1) is still found and
+		// mutated in-memory, so the only thing standing between it and persistence is
+		// the new PlanSchema validation gate.
+		fs.writeFileSync(
+			planPath,
+			JSON.stringify({
+				phases: [{ id: 1, status: 'in_progress' }],
+			}),
+		);
+
+		const result = await executePhaseComplete(
+			{ phase: 1, sessionID: 'test-session' },
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		// Corrupt candidate must NOT be persisted — on-disk plan is unchanged.
+		const persisted = JSON.parse(fs.readFileSync(planPath, 'utf-8'));
+		expect(persisted.phases[0].status).toBe('in_progress');
+
+		// No traceability event written for a refused write.
+		expect(readFallbackEvents(tempDir).length).toBe(0);
+
+		// The refusal is surfaced as an actionable warning, not silently swallowed.
+		expect(
+			parsed.warnings.some((w: string) =>
+				w.includes('failed schema validation'),
+			),
+		).toBe(true);
+	});
+});

--- a/tests/unit/tools/phase-complete-lock-before-saveplan.regression.test.ts
+++ b/tests/unit/tools/phase-complete-lock-before-saveplan.regression.test.ts
@@ -1,0 +1,330 @@
+/**
+ * REGRESSION GUARD — issue #660 FR-004, finding F-03.
+ *
+ * Pins the fix that `phase_complete` acquires the `plan.json` file lock BEFORE
+ * it calls `savePlan` (src/tools/phase-complete.ts ~L1519-1629).
+ *
+ * Prior buggy behavior (what the fix corrected): `executePhaseComplete` updated
+ * the phase status and called `savePlan(dir, plan, …)` WITHOUT first acquiring
+ * the `plan.json` lock. Because `plan.json` is a read-modify-write file, a
+ * concurrent writer (e.g. `save_plan` / `update_task_status`) could interleave
+ * and lose the update. The fix wraps the plan write in
+ * `tryAcquireLock(dir, 'plan.json', …)` and fails closed when the lock cannot
+ * be acquired.
+ *
+ * How this guard works (and how it fails on revert):
+ *   `phase-complete.ts` exposes NO `_internals` seam for `tryAcquireLock` /
+ *   `savePlan`, so — mirroring the existing sibling `phase-complete.locking.test.ts`
+ *   — this guard drives the full `executePhaseComplete` with module mocks and
+ *   records call order. (Invariant 7 prefers native `_internals` DI; no such
+ *   seam exists here, so we test against the public surface, which the task
+ *   explicitly permits.)
+ *
+ *   Two assertions catch a revert:
+ *     1. Ordering: `tryAcquireLock('plan.json')` is recorded BEFORE `savePlan`,
+ *        and both are actually called (path provably exercised).
+ *     2. Lock-denied: when the `plan.json` lock is denied (`acquired:false`),
+ *        `savePlan` is NOT called and the result is `status:'incomplete'`.
+ *
+ *   Revert that breaks this guard: deleting the
+ *   `tryAcquireLock(dir, 'plan.json', …)` block so `savePlan` runs without the
+ *   lock. Then assertion (1) finds no `acquire:plan.json` before `savePlan`, and
+ *   assertion (2) sees `savePlan` called even though the lock was denied.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { resetSwarmState, swarmState } from '../../../src/state';
+import { executePhaseComplete } from '../../../src/tools/phase-complete';
+
+// Mock the parallel/file-locks module to control lock acquisition + record order.
+vi.mock('../../../src/parallel/file-locks', () => ({
+	tryAcquireLock: vi.fn(),
+}));
+
+// Mock other dependencies that phase_complete relies on (mirrors the proven
+// scaffold in phase-complete.locking.test.ts so executePhaseComplete reaches
+// the plan-write code path without real LLM / evidence work).
+vi.mock('../../../src/evidence/manager', () => ({
+	listEvidenceTaskIds: vi.fn().mockResolvedValue([]),
+	loadEvidence: vi.fn().mockImplementation((_dir: string, taskId: string) => {
+		if (taskId.startsWith('retro-')) {
+			try {
+				const retroPath = path.join(
+					_dir,
+					'.swarm',
+					'evidence',
+					taskId,
+					'evidence.json',
+				);
+				if (fs.existsSync(retroPath)) {
+					const content = fs.readFileSync(retroPath, 'utf-8');
+					return { status: 'found', bundle: JSON.parse(content) };
+				}
+			} catch {
+				// fall through
+			}
+		}
+		return { status: 'not_found' };
+	}),
+}));
+
+vi.mock('../../../src/hooks/curator', () => ({
+	runCuratorPhase: vi.fn().mockResolvedValue({
+		digest: { summary: 'test' },
+		knowledge_recommendations: [],
+		compliance: [],
+	}),
+	applyCuratorKnowledgeUpdates: vi
+		.fn()
+		.mockResolvedValue({ applied: 0, skipped: 0 }),
+}));
+
+vi.mock('../../../src/hooks/curator-llm-factory.js', () => ({
+	createCuratorLLMDelegate: vi.fn().mockReturnValue({
+		delegate: vi.fn().mockResolvedValue({ summary: 'test' }),
+	}),
+}));
+
+vi.mock('../../../src/hooks/knowledge-curator.js', () => ({
+	curateAndStoreSwarm: vi
+		.fn()
+		.mockResolvedValue({ stored: 0, skipped: 0, rejected: 0 }),
+}));
+
+vi.mock('../../../src/hooks/knowledge-reader.js', () => ({
+	updateRetrievalOutcome: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/hooks/review-receipt.js', () => ({
+	buildApprovedReceipt: vi.fn().mockReturnValue({}),
+	buildRejectedReceipt: vi.fn().mockReturnValue({}),
+	persistReviewReceipt: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/plan/checkpoint', () => ({
+	writeCheckpoint: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/plan/ledger', () => ({
+	ledgerExists: vi.fn().mockResolvedValue(false),
+	replayFromLedger: vi.fn().mockResolvedValue(null),
+	takeSnapshotEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/plan/manager', () => ({
+	loadPlan: vi.fn().mockResolvedValue({
+		phases: [{ id: 1, status: 'in_progress', tasks: [] }],
+	}),
+	savePlan: vi.fn().mockResolvedValue(undefined),
+	closePlanTerminalState: async () => {},
+	_snapshot_test_exports: {},
+}));
+
+vi.mock('../../../src/session/snapshot-writer', () => ({
+	flushPendingSnapshot: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/telemetry', () => ({
+	telemetry: {
+		phaseChanged: vi.fn(),
+		sessionStarted: vi.fn(),
+		agentActivated: vi.fn(),
+	},
+}));
+
+vi.mock('../../../src/tools/completion-verify', () => ({
+	executeCompletionVerify: vi
+		.fn()
+		.mockResolvedValue(JSON.stringify({ status: 'passed' })),
+}));
+
+vi.mock('../../../src/hooks/utils', () => ({
+	validateSwarmPath: vi
+		.fn()
+		.mockImplementation((_dir: string, file: string) =>
+			path.join(_dir, '.swarm', file),
+		),
+}));
+
+vi.mock('../../../src/config', () => ({
+	loadPluginConfigWithMeta: vi.fn().mockReturnValue({
+		config: {
+			phase_complete: { enabled: true, required_agents: [], policy: 'warn' },
+			curator: { enabled: false },
+			knowledge: {},
+		},
+	}),
+}));
+
+vi.mock('../../../src/config/schema', () => ({
+	PhaseCompleteConfigSchema: {
+		parse: vi.fn().mockImplementation((cfg) => ({
+			enabled: cfg?.enabled ?? true,
+			required_agents: cfg?.required_agents ?? [],
+			policy: cfg?.policy ?? 'warn',
+		})),
+	},
+	CuratorConfigSchema: {
+		parse: vi.fn().mockReturnValue({ enabled: false, phase_enabled: false }),
+	},
+	KnowledgeConfigSchema: { parse: vi.fn().mockReturnValue({}) },
+	stripKnownSwarmPrefix: vi.fn().mockImplementation((name: string) => name),
+}));
+
+// Import mocked modules after vi.mock calls.
+import { tryAcquireLock } from '../../../src/parallel/file-locks';
+import { savePlan } from '../../../src/plan/manager';
+import { ensureAgentSession } from '../../../src/state';
+
+const mockTryAcquireLock = tryAcquireLock as ReturnType<typeof vi.fn>;
+const mockSavePlan = savePlan as ReturnType<typeof vi.fn>;
+
+function acquiredLock(filePath: string) {
+	return {
+		acquired: true as const,
+		lock: {
+			filePath,
+			agent: 'phase-complete',
+			taskId: `phase-complete-${filePath}`,
+			timestamp: new Date().toISOString(),
+			expiresAt: Date.now() + 300000,
+			_release: vi.fn().mockResolvedValue(undefined),
+		},
+	};
+}
+
+describe('phase_complete — regression: acquires plan.json lock before savePlan (F-03)', () => {
+	let tempDir: string;
+	let originalCwd: string;
+
+	beforeEach(() => {
+		tempDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'phase-complete-f03-')),
+		);
+		originalCwd = process.cwd();
+		process.chdir(tempDir);
+
+		fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+		fs.writeFileSync(path.join(tempDir, '.swarm', 'events.jsonl'), '', 'utf-8');
+		fs.writeFileSync(
+			path.join(tempDir, '.swarm', 'plan.json'),
+			JSON.stringify({
+				schema_version: '1.0.0',
+				title: 'Test Plan',
+				swarm: 'test-swarm',
+				current_phase: 1,
+				migration_status: 'migrated',
+				phases: [{ id: 1, name: 'Phase 1', status: 'in_progress', tasks: [] }],
+			}),
+		);
+
+		const retroDir = path.join(tempDir, '.swarm', 'evidence', 'retro-1');
+		fs.mkdirSync(retroDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(retroDir, 'evidence.json'),
+			JSON.stringify({
+				schema_version: '1.0.0',
+				task_id: 'retro-1',
+				created_at: new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+				entries: [
+					{
+						task_id: 'retro-1',
+						type: 'retrospective',
+						timestamp: new Date().toISOString(),
+						agent: 'architect',
+						verdict: 'pass',
+						summary: 'Phase 1 completed',
+						phase_number: 1,
+						total_tool_calls: 10,
+						coder_revisions: 1,
+						reviewer_rejections: 0,
+						test_failures: 0,
+						security_findings: 0,
+						integration_issues: 0,
+						task_count: 1,
+						task_complexity: 'simple',
+						top_rejection_reasons: [],
+						lessons_learned: [],
+					},
+				],
+			}),
+		);
+
+		resetSwarmState();
+		swarmState.activeAgent.set('current', 'test-agent');
+		const session = ensureAgentSession('test-session', 'test-agent', tempDir);
+		session.phaseAgentsDispatched = new Set();
+		session.lastPhaseCompleteTimestamp = 0;
+
+		vi.clearAllMocks();
+		// vi.clearAllMocks resets the savePlan default-resolve, so re-arm it.
+		mockSavePlan.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			// ignore cleanup errors
+		}
+	});
+
+	test('plan.json lock is acquired BEFORE savePlan, and both are exercised', async () => {
+		const order: string[] = [];
+		mockTryAcquireLock.mockImplementation(
+			async (_dir: string, filePath: string) => {
+				order.push(`acquire:${filePath}`);
+				return acquiredLock(filePath);
+			},
+		);
+		mockSavePlan.mockImplementation(async () => {
+			order.push('savePlan');
+		});
+
+		const result = await executePhaseComplete(
+			{ phase: 1, sessionID: 'test-session' },
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+		expect(parsed.success).toBe(true);
+
+		// Both the plan.json lock acquisition and savePlan must have happened.
+		expect(order).toContain('acquire:plan.json');
+		expect(order).toContain('savePlan');
+
+		// The plan.json lock must be acquired strictly before savePlan runs.
+		const acquireIdx = order.indexOf('acquire:plan.json');
+		const saveIdx = order.indexOf('savePlan');
+		expect(acquireIdx).toBeGreaterThanOrEqual(0);
+		expect(saveIdx).toBeGreaterThan(acquireIdx);
+	});
+
+	test('when plan.json lock is denied, savePlan is NOT called and result is incomplete', async () => {
+		// events.jsonl lock succeeds (soft-fail append log); plan.json lock denied.
+		mockTryAcquireLock.mockImplementation(
+			async (_dir: string, filePath: string) => {
+				if (filePath === 'plan.json') {
+					return { acquired: false as const };
+				}
+				return acquiredLock(filePath);
+			},
+		);
+
+		const result = await executePhaseComplete(
+			{ phase: 1, sessionID: 'test-session' },
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		// Fail-closed: the plan must NOT be saved while the lock is held elsewhere.
+		expect(mockSavePlan).not.toHaveBeenCalled();
+		expect(parsed.success).toBe(false);
+		expect(parsed.status).toBe('incomplete');
+		expect(parsed.message).toContain('Plan write blocked: plan.json is locked');
+	});
+});

--- a/tests/unit/tools/phase-complete-stale-plan-refusal.test.ts
+++ b/tests/unit/tools/phase-complete-stale-plan-refusal.test.ts
@@ -1,0 +1,316 @@
+/**
+ * #1269 finding 2: phase_complete must consult the ledger-replay staleness
+ * signal (`RuntimePlan._ledgerReplayStale`) and REFUSE to mutate against a
+ * known-stale plan, returning structured recovery guidance — rather than
+ * relying on a logged warning. The check must sit BEFORE any savePlan / plan.json
+ * mutation.
+ *
+ * Discrimination: the staleness check lives inside `if (success)`, and savePlan
+ * is also skipped when success is false. So "savePlan not called" alone is NOT
+ * proof the staleness branch fired. This test therefore (1) uses the full
+ * success-reaching scaffold (retro evidence + passing completion-verify) and a
+ * control case proving that scaffold otherwise reaches savePlan, and (2) asserts
+ * the staleness-only signature `_ledgerReplayStaleReason` echoing the exact
+ * injected reason — a field that exists ONLY on the refusal branch.
+ *
+ * phase-complete.ts exposes no `_internals` seam, so this drives the public
+ * surface via vi.mock (the pattern the sibling lock regression guard sanctions).
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { resetSwarmState, swarmState } from '../../../src/state';
+import { executePhaseComplete } from '../../../src/tools/phase-complete';
+
+vi.mock('../../../src/parallel/file-locks', () => ({
+	tryAcquireLock: vi.fn(),
+}));
+
+vi.mock('../../../src/evidence/manager', () => ({
+	listEvidenceTaskIds: vi.fn().mockResolvedValue([]),
+	loadEvidence: vi.fn().mockImplementation((_dir: string, taskId: string) => {
+		if (taskId.startsWith('retro-')) {
+			try {
+				const retroPath = path.join(
+					_dir,
+					'.swarm',
+					'evidence',
+					taskId,
+					'evidence.json',
+				);
+				if (fs.existsSync(retroPath)) {
+					const content = fs.readFileSync(retroPath, 'utf-8');
+					return { status: 'found', bundle: JSON.parse(content) };
+				}
+			} catch {
+				// fall through
+			}
+		}
+		return { status: 'not_found' };
+	}),
+}));
+
+vi.mock('../../../src/hooks/curator', () => ({
+	runCuratorPhase: vi.fn().mockResolvedValue({
+		digest: { summary: 'test' },
+		knowledge_recommendations: [],
+		compliance: [],
+	}),
+	applyCuratorKnowledgeUpdates: vi
+		.fn()
+		.mockResolvedValue({ applied: 0, skipped: 0 }),
+}));
+
+vi.mock('../../../src/hooks/curator-llm-factory.js', () => ({
+	createCuratorLLMDelegate: vi.fn().mockReturnValue({
+		delegate: vi.fn().mockResolvedValue({ summary: 'test' }),
+	}),
+}));
+
+vi.mock('../../../src/hooks/knowledge-curator.js', () => ({
+	curateAndStoreSwarm: vi
+		.fn()
+		.mockResolvedValue({ stored: 0, skipped: 0, rejected: 0 }),
+}));
+
+vi.mock('../../../src/hooks/knowledge-reader.js', () => ({
+	updateRetrievalOutcome: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/hooks/review-receipt.js', () => ({
+	buildApprovedReceipt: vi.fn().mockReturnValue({}),
+	buildRejectedReceipt: vi.fn().mockReturnValue({}),
+	persistReviewReceipt: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/plan/checkpoint', () => ({
+	writeCheckpoint: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/plan/ledger', () => ({
+	ledgerExists: vi.fn().mockResolvedValue(false),
+	replayFromLedger: vi.fn().mockResolvedValue(null),
+	takeSnapshotEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/plan/manager', () => ({
+	loadPlan: vi.fn().mockResolvedValue(null),
+	savePlan: vi.fn().mockResolvedValue(undefined),
+	savePlanWithAutoAcknowledgedRemovals: vi.fn().mockResolvedValue(undefined),
+	closePlanTerminalState: async () => {},
+	_snapshot_test_exports: {},
+}));
+
+vi.mock('../../../src/session/snapshot-writer', () => ({
+	flushPendingSnapshot: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/telemetry', () => ({
+	telemetry: {
+		phaseChanged: vi.fn(),
+		sessionStarted: vi.fn(),
+		agentActivated: vi.fn(),
+	},
+}));
+
+vi.mock('../../../src/tools/completion-verify', () => ({
+	executeCompletionVerify: vi
+		.fn()
+		.mockResolvedValue(JSON.stringify({ status: 'passed' })),
+}));
+
+vi.mock('../../../src/hooks/utils', () => ({
+	validateSwarmPath: vi
+		.fn()
+		.mockImplementation((_dir: string, file: string) =>
+			path.join(_dir, '.swarm', file),
+		),
+}));
+
+vi.mock('../../../src/config', () => ({
+	loadPluginConfigWithMeta: vi.fn().mockReturnValue({
+		config: {
+			phase_complete: { enabled: true, required_agents: [], policy: 'warn' },
+			curator: { enabled: false },
+			knowledge: {},
+		},
+	}),
+}));
+
+vi.mock('../../../src/config/schema', () => ({
+	PhaseCompleteConfigSchema: {
+		parse: vi.fn().mockImplementation((cfg) => ({
+			enabled: cfg?.enabled ?? true,
+			required_agents: cfg?.required_agents ?? [],
+			policy: cfg?.policy ?? 'warn',
+		})),
+	},
+	CuratorConfigSchema: {
+		parse: vi.fn().mockReturnValue({ enabled: false, phase_enabled: false }),
+	},
+	KnowledgeConfigSchema: { parse: vi.fn().mockReturnValue({}) },
+	stripKnownSwarmPrefix: vi.fn().mockImplementation((name: string) => name),
+}));
+
+// Import mocked modules after vi.mock calls.
+import { tryAcquireLock } from '../../../src/parallel/file-locks';
+import { loadPlan, savePlan } from '../../../src/plan/manager';
+import { ensureAgentSession } from '../../../src/state';
+
+const mockTryAcquireLock = tryAcquireLock as ReturnType<typeof vi.fn>;
+const mockLoadPlan = loadPlan as ReturnType<typeof vi.fn>;
+const mockSavePlan = savePlan as ReturnType<typeof vi.fn>;
+
+const STALE_REASON = 'ledger replay threw: synthetic boom';
+
+function acquiredLock(filePath: string) {
+	return {
+		acquired: true as const,
+		lock: {
+			filePath,
+			agent: 'phase-complete',
+			taskId: `phase-complete-${filePath}`,
+			timestamp: new Date().toISOString(),
+			expiresAt: Date.now() + 300000,
+			_release: vi.fn().mockResolvedValue(undefined),
+		},
+	};
+}
+
+describe('phase_complete — #1269 finding 2: refuse to complete against a stale plan', () => {
+	let tempDir: string;
+	let originalCwd: string;
+
+	beforeEach(() => {
+		tempDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'phase-complete-stale-')),
+		);
+		originalCwd = process.cwd();
+		process.chdir(tempDir);
+
+		fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+		fs.writeFileSync(path.join(tempDir, '.swarm', 'events.jsonl'), '', 'utf-8');
+		fs.writeFileSync(
+			path.join(tempDir, '.swarm', 'plan.json'),
+			JSON.stringify({
+				schema_version: '1.0.0',
+				title: 'Test Plan',
+				swarm: 'test-swarm',
+				current_phase: 1,
+				phases: [{ id: 1, name: 'Phase 1', status: 'in_progress', tasks: [] }],
+			}),
+		);
+
+		const retroDir = path.join(tempDir, '.swarm', 'evidence', 'retro-1');
+		fs.mkdirSync(retroDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(retroDir, 'evidence.json'),
+			JSON.stringify({
+				schema_version: '1.0.0',
+				task_id: 'retro-1',
+				created_at: new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+				entries: [
+					{
+						task_id: 'retro-1',
+						type: 'retrospective',
+						timestamp: new Date().toISOString(),
+						agent: 'architect',
+						verdict: 'pass',
+						summary: 'Phase 1 completed',
+						phase_number: 1,
+						total_tool_calls: 10,
+						coder_revisions: 1,
+						reviewer_rejections: 0,
+						test_failures: 0,
+						security_findings: 0,
+						integration_issues: 0,
+						task_count: 1,
+						task_complexity: 'simple',
+						top_rejection_reasons: [],
+						lessons_learned: [],
+					},
+				],
+			}),
+		);
+
+		resetSwarmState();
+		swarmState.activeAgent.set('current', 'test-agent');
+		const session = ensureAgentSession('test-session', 'test-agent', tempDir);
+		session.phaseAgentsDispatched = new Set();
+		session.lastPhaseCompleteTimestamp = 0;
+
+		vi.clearAllMocks();
+		mockSavePlan.mockResolvedValue(undefined);
+		mockTryAcquireLock.mockImplementation(async (_dir: string, file: string) =>
+			acquiredLock(file),
+		);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			// ignore cleanup errors
+		}
+	});
+
+	test('stale plan: refuses with recovery guidance, echoes reason, does NOT savePlan', async () => {
+		mockLoadPlan.mockResolvedValue({
+			schema_version: '1.0.0',
+			title: 'Test Plan',
+			swarm: 'test-swarm',
+			current_phase: 1,
+			phases: [{ id: 1, name: 'Phase 1', status: 'in_progress', tasks: [] }],
+			_ledgerReplayStale: true,
+			_ledgerReplayStaleReason: STALE_REASON,
+		});
+
+		const result = await executePhaseComplete(
+			{ phase: 1, sessionID: 'test-session' },
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		// Structured refusal — not silent mutation.
+		expect(parsed.success).toBe(false);
+		expect(parsed.status).toBe('incomplete');
+		// staleness-only signature: this field exists ONLY on the refusal branch,
+		// and it echoes the exact injected reason, proving the check fired.
+		expect(parsed._ledgerReplayStaleReason).toBe(STALE_REASON);
+		expect(parsed.message).toContain('stale');
+		expect(parsed.message).toContain('ledger replay');
+		// Actionable recovery guidance is present.
+		expect(typeof parsed.recovery_guidance).toBe('string');
+		expect(parsed.recovery_guidance.length).toBeGreaterThan(0);
+
+		// The plan must NOT be saved/mutated against the stale plan.
+		expect(mockSavePlan).not.toHaveBeenCalled();
+	});
+
+	test('control: non-stale plan with the same scaffold DOES reach savePlan', async () => {
+		// Same success-reaching scaffold, but the plan is NOT stale. This proves the
+		// staleness refusal above is caused by the staleness signal — not by the
+		// scaffold failing to reach the write path.
+		mockLoadPlan.mockResolvedValue({
+			schema_version: '1.0.0',
+			title: 'Test Plan',
+			swarm: 'test-swarm',
+			current_phase: 1,
+			phases: [{ id: 1, name: 'Phase 1', status: 'in_progress', tasks: [] }],
+		});
+
+		const result = await executePhaseComplete(
+			{ phase: 1, sessionID: 'test-session' },
+			tempDir,
+		);
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed._ledgerReplayStaleReason).toBeUndefined();
+		expect(mockSavePlan).toHaveBeenCalled();
+	});
+});

--- a/tests/unit/tools/phase-complete.hallucination-gate.test.ts
+++ b/tests/unit/tools/phase-complete.hallucination-gate.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 
 import { closeAllProjectDbs } from '../../../src/db/project-db';
 import { getOrCreateProfile, setGates } from '../../../src/db/qa-gate-profile';
+import { derivePlanId } from '../../../src/plan/utils';
 import {
 	ensureAgentSession,
 	recordPhaseAgentDispatch,
@@ -17,7 +18,7 @@ const { phase_complete } = await import('../../../src/tools/phase-complete');
 // planId must match what loadPlan derives: "${swarm}-${title}".replace(...)
 const PLAN_SWARM = 'mega';
 const PLAN_TITLE = 'Test Plan';
-const PLAN_ID = `${PLAN_SWARM}-${PLAN_TITLE}`.replace(/[^a-zA-Z0-9-_]/g, '_');
+const PLAN_ID = derivePlanId({ swarm: PLAN_SWARM, title: PLAN_TITLE });
 
 function setupSwarmDir(dir: string): void {
 	fs.mkdirSync(path.join(dir, '.swarm', 'evidence'), { recursive: true });

--- a/tests/unit/tools/phase-complete.mutation-gate.test.ts
+++ b/tests/unit/tools/phase-complete.mutation-gate.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 
 import { closeAllProjectDbs } from '../../../src/db/project-db';
 import { getOrCreateProfile, setGates } from '../../../src/db/qa-gate-profile';
+import { derivePlanId } from '../../../src/plan/utils';
 import {
 	ensureAgentSession,
 	recordPhaseAgentDispatch,
@@ -17,7 +18,7 @@ const { phase_complete } = await import('../../../src/tools/phase-complete');
 // planId must match what loadPlan derives: "${swarm}-${title}".replace(...)
 const PLAN_SWARM = 'mega';
 const PLAN_TITLE = 'Test Plan';
-const PLAN_ID = `${PLAN_SWARM}-${PLAN_TITLE}`.replace(/[^a-zA-Z0-9-_]/g, '_');
+const PLAN_ID = derivePlanId({ swarm: PLAN_SWARM, title: PLAN_TITLE });
 
 function setupSwarmDir(dir: string): void {
 	fs.mkdirSync(path.join(dir, '.swarm', 'evidence'), { recursive: true });

--- a/tests/unit/tools/phase-complete.mutation-pipeline.e2e.test.ts
+++ b/tests/unit/tools/phase-complete.mutation-pipeline.e2e.test.ts
@@ -30,6 +30,7 @@ import {
 	type MutationResult,
 } from '../../../src/mutation/engine.js';
 import { evaluateMutationGate } from '../../../src/mutation/gate.js';
+import { derivePlanId } from '../../../src/plan/utils.js';
 import {
 	ensureAgentSession,
 	recordPhaseAgentDispatch,
@@ -43,7 +44,7 @@ const { phase_complete } = await import('../../../src/tools/phase-complete.js');
 // planId must match what loadPlan derives: "${swarm}-${title}".replace(...)
 const PLAN_SWARM = 'mega';
 const PLAN_TITLE = 'E2E Pipeline Test';
-const PLAN_ID = `${PLAN_SWARM}-${PLAN_TITLE}`.replace(/[^a-zA-Z0-9-_]/g, '_');
+const PLAN_ID = derivePlanId({ swarm: PLAN_SWARM, title: PLAN_TITLE });
 
 // ─── Setup helpers (mirroring phase-complete.mutation-gate.test.ts pattern) ──
 

--- a/tests/unit/tools/update-task-status.concurrent-write.test.ts
+++ b/tests/unit/tools/update-task-status.concurrent-write.test.ts
@@ -200,7 +200,10 @@ describe('executeUpdateTaskStatus concurrent writes', () => {
 
 	describe('lock winner persists data correctly', () => {
 		test('a winning call that returns success actually persists its status', async () => {
-			// Run 10 parallel updates - exactly 1 should win (the lock is on plan.json, not per-task)
+			// Run 10 parallel updates. The lock is on plan.json (not per-task), and
+			// file-locks.ts now retries with backoff (F-09, retries:5), so one OR MORE
+			// callers serialize through the lock and win; the loser count depends on
+			// timing. Every winner's status must be durably persisted (asserted below).
 			const statuses: UpdateTaskStatusArgs['status'][] = [
 				'blocked',
 				'in_progress',
@@ -226,8 +229,19 @@ describe('executeUpdateTaskStatus concurrent writes', () => {
 			// Find the winner(s) - calls that returned success: true
 			const winners = results.filter((r) => r.success);
 
-			// Exactly one should win - proper-lockfile retries:0 means only 1 acquires the lock
-			expect(winners.length).toBe(1);
+			// F-09 serialization rationale: file-locks.ts now uses proper-lockfile
+			// `retries:5` + exponential backoff (src/parallel/file-locks.ts:163-172)
+			// instead of the old `retries:0`. Contending callers therefore SERIALIZE
+			// and more than one can win within the retry budget; the exact winner
+			// count is timing/platform-dependent (it is NOT deterministically 1, and
+			// NOT necessarily all 10 — some contenders still exhaust the bounded retry
+			// budget and return success:false). The real correctness guarantee is the
+			// per-winner "status actually persisted" check below: every call that
+			// reported success must have its status durably written to plan.json with
+			// no lost update. That holds because the mutation (updateTaskStatus:
+			// loadPlan→modify→savePlan) runs INSIDE the lock, so each serialized winner
+			// reads fresh state.
+			expect(winners.length).toBeGreaterThanOrEqual(1);
 
 			// For each winner, verify its task's status in the final plan.json matches what it wrote
 			const plan = JSON.parse(fs.readFileSync(planPath, 'utf-8'));
@@ -243,6 +257,14 @@ describe('executeUpdateTaskStatus concurrent writes', () => {
 				expect(winner.new_status).toBeDefined();
 				const persistedStatus = taskStatusMap.get(winner.task_id!);
 				expect(persistedStatus).toBe(winner.new_status);
+			}
+
+			// Any loser (retry budget exhausted) must fail visibly with recovery guidance,
+			// never silently — so the bounded winner count is not a weak assertion.
+			const losers = results.filter((r) => !r.success);
+			for (const loser of losers) {
+				expect(typeof loser.recovery_guidance).toBe('string');
+				expect(loser.recovery_guidance!.toLowerCase()).toContain('retry');
 			}
 		});
 

--- a/tests/unit/tools/update-task-status.ledger-stale.test.ts
+++ b/tests/unit/tools/update-task-status.ledger-stale.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Ledger-replay staleness refusal tests for update-task-status.ts (#1269 finding 2).
+ *
+ * Acceptance (#1269 finding 2): "update_task_status consults the staleness signal
+ * (refuse or re-verify) rather than relying on a logged warning."
+ *
+ * When loadPlan attaches `_ledgerReplayStale === true` (plan.json hash mismatched the
+ * ledger, ledger replay threw, AND no critic-approved snapshot was available), the tool
+ * must REFUSE the mutation with structured recovery guidance and leave plan.json
+ * untouched — never silently overwrite the authoritative ledger view.
+ *
+ * Uses the `_internals.loadPlan` DI seam instead of module-scope mock.module to avoid
+ * cross-file leakage in Bun's shared test-runner process.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { RuntimePlan } from '../../../src/config/plan-schema';
+import { swarmState } from '../../../src/state';
+import {
+	_internals,
+	executeUpdateTaskStatus,
+} from '../../../src/tools/update-task-status';
+
+describe('executeUpdateTaskStatus — ledger-replay staleness refusal (#1269 finding 2)', () => {
+	let tempDir: string;
+	let originalCwd: string;
+	let planPath: string;
+	let originalAgentSessions: typeof swarmState.agentSessions;
+	let originalLoadPlan: typeof _internals.loadPlan;
+	let originalTryAcquireLock: typeof _internals.tryAcquireLock;
+	let originalUpdateTaskStatus: typeof _internals.updateTaskStatus;
+
+	const buildPlan = () => ({
+		schema_version: '1.0.0',
+		title: 'Ledger Stale Test Plan',
+		swarm: 'test-swarm',
+		current_phase: 1,
+		migration_status: 'migrated',
+		phases: [
+			{
+				id: 1,
+				name: 'Phase 1',
+				status: 'in_progress',
+				tasks: [
+					{
+						id: '1.1',
+						phase: 1,
+						status: 'pending',
+						size: 'small',
+						description: 'Task 1',
+						depends: [] as string[],
+						files_touched: [] as string[],
+					},
+				],
+			},
+		],
+	});
+
+	beforeEach(() => {
+		tempDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'uts-ledger-stale-')),
+		);
+		originalCwd = process.cwd();
+		process.chdir(tempDir);
+
+		fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+		planPath = path.join(tempDir, '.swarm', 'plan.json');
+		fs.writeFileSync(planPath, JSON.stringify(buildPlan(), null, 2));
+
+		originalAgentSessions = new Map(swarmState.agentSessions);
+		swarmState.agentSessions.clear();
+
+		originalLoadPlan = _internals.loadPlan;
+		originalTryAcquireLock = _internals.tryAcquireLock;
+		originalUpdateTaskStatus = _internals.updateTaskStatus;
+	});
+
+	afterEach(() => {
+		_internals.loadPlan = originalLoadPlan;
+		_internals.tryAcquireLock = originalTryAcquireLock;
+		_internals.updateTaskStatus = originalUpdateTaskStatus;
+		swarmState.agentSessions.clear();
+		for (const [key, value] of originalAgentSessions) {
+			swarmState.agentSessions.set(key, value);
+		}
+		process.chdir(originalCwd);
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test('refuses to mutate when the loaded plan is ledger-replay stale and leaves plan.json untouched', async () => {
+		// Arrange: loadPlan reports the loaded plan.json is stale relative to the ledger.
+		const staleReason =
+			'Ledger replay failed during hash-mismatch rebuild and no approved snapshot was available: boom';
+		const stalePlan: RuntimePlan = {
+			...buildPlan(),
+			_ledgerReplayStale: true,
+			_ledgerReplayStaleReason: staleReason,
+		} as unknown as RuntimePlan;
+		_internals.loadPlan = async () => stalePlan;
+
+		// Capture plan.json bytes before the call so "not mutated" is proven, not assumed.
+		const before = fs.readFileSync(planPath, 'utf-8');
+
+		// Act: use 'pending' to isolate the staleness gate from the in_progress evidence
+		// write and the completed reviewer/council gates.
+		const result = await executeUpdateTaskStatus(
+			{ task_id: '1.1', status: 'pending' },
+			tempDir,
+		);
+
+		// Assert: structured refusal (mirrors the lock-blocked shape).
+		expect(result.success).toBe(false);
+		expect(result.message.toLowerCase()).toContain('stale');
+		expect(Array.isArray(result.errors)).toBe(true);
+		// The staleness reason from loadPlan is surfaced to the caller.
+		expect(result.errors).toContain(staleReason);
+		expect(typeof result.recovery_guidance).toBe('string');
+		expect(result.recovery_guidance!.length).toBeGreaterThan(0);
+		// No partial mutation leaked through.
+		expect(result.task_id).toBeUndefined();
+		expect(result.new_status).toBeUndefined();
+
+		// Assert: plan.json is byte-for-byte unchanged — the mutation was refused.
+		const after = fs.readFileSync(planPath, 'utf-8');
+		expect(after).toBe(before);
+		const parsed = JSON.parse(after);
+		expect(parsed.phases[0].tasks[0].status).toBe('pending');
+	});
+
+	test('proceeds normally when loadPlan reports a non-stale plan', async () => {
+		// Arrange: loadPlan returns a fresh (non-stale) plan — the staleness gate must not fire.
+		_internals.loadPlan = async () => buildPlan() as unknown as RuntimePlan;
+
+		// Invariant 7 robustness: this control proves the *staleness gate* (not some
+		// unrelated scaffold failure) is what causes the refusal in the test above —
+		// i.e. a non-stale plan proceeds past the gate to the real mutation call.
+		// The cross-module persistence seams (`tryAcquireLock` from parallel/file-locks,
+		// `updateTaskStatus` from plan/manager) are injected through the same `_internals`
+		// DI seam this file already uses, so a leaked sibling `vi.mock('plan/manager')`
+		// (which omits `updateTaskStatus`) or `vi.mock('parallel/file-locks')` (which
+		// stubs `tryAcquireLock`) in Bun's shared test process cannot corrupt this control.
+		// We assert the post-gate mutation path is reached with the exact arguments —
+		// the discrimination the control exists for — rather than relying on real
+		// on-disk persistence, which a leaked mock can silently no-op.
+		const releaseSpy = mock(async () => {});
+		_internals.tryAcquireLock = mock(async () => ({
+			acquired: true as const,
+			lock: {
+				filePath: 'plan.json',
+				agent: 'update-task-status',
+				taskId: 'update-task-status-1.1',
+				timestamp: new Date().toISOString(),
+				expiresAt: Date.now() + 300000,
+				_release: releaseSpy,
+			},
+		})) as unknown as typeof _internals.tryAcquireLock;
+		const updateSpy = mock(
+			async () => buildPlan() as unknown as RuntimePlan,
+		) as unknown as typeof _internals.updateTaskStatus;
+		_internals.updateTaskStatus = updateSpy;
+
+		// Act
+		const result = await executeUpdateTaskStatus(
+			{ task_id: '1.1', status: 'in_progress' },
+			tempDir,
+		);
+
+		// Assert: the staleness gate did NOT fire — the call succeeded (no false-positive
+		// refusal) and proceeded all the way to the real mutation with the exact arguments.
+		expect(result.success).toBe(true);
+		expect(result.new_status).toBe('in_progress');
+		expect(result.message).not.toContain('stale');
+		expect(updateSpy).toHaveBeenCalledTimes(1);
+		expect(updateSpy).toHaveBeenCalledWith(tempDir, '1.1', 'in_progress');
+		// The acquired lock is released even on the success path.
+		expect(releaseSpy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/unit/tools/update-task-status.locking-adversarial.test.ts
+++ b/tests/unit/tools/update-task-status.locking-adversarial.test.ts
@@ -317,10 +317,12 @@ describe('update-task-status ADVERSARIAL LOCKING security tests', () => {
 	// ─────────────────────────────────────────────────────────────────────────────
 
 	describe('GROUP 4: Real lock race conditions', () => {
-		it('concurrent lock acquisition for SAME task - second should fail', async () => {
-			// Simulate two concurrent calls trying to update the SAME task
-			// Both will pass validation and reach the lock acquisition stage
-			// The second should fail to acquire the lock
+		it('concurrent SAME-task updates both succeed (serialized last-writer-wins)', async () => {
+			// Simulate two concurrent calls trying to update the SAME task.
+			// Both pass validation and reach the lock acquisition stage. Under the
+			// F-09 retries:5 + backoff policy (src/parallel/file-locks.ts:163-172) the
+			// second caller serializes on the plan.json lock and succeeds after the
+			// first releases — this is correct, not a lock bypass.
 
 			const args = {
 				task_id: '1.1',
@@ -334,23 +336,29 @@ describe('update-task-status ADVERSARIAL LOCKING security tests', () => {
 				executeUpdateTaskStatus(args),
 			]);
 
-			// At least one should succeed, one should be blocked
-			// (exact outcome depends on timing, but both shouldn't fully succeed)
+			// At least one should succeed.
 			const successes = [result1, result2].filter((r) => r.success);
 			expect(successes.length).toBeGreaterThanOrEqual(1);
 
-			// The key assertion: if both succeeded, there would be no lock protection
-			// One must be blocked due to lock
-			if (successes.length === 2) {
-				// Both succeeded - check if plan.json was actually protected
-				const plan = JSON.parse(
-					fs.readFileSync(path.join(tempDir, '.swarm', 'plan.json'), 'utf-8'),
-				);
-				// This is a race condition vulnerability if we get here
-				expect('RACE_CONDITION_DETECTED').toBe(
-					'Both calls succeeded - possible lock bypass',
-				);
-			}
+			// F-09 serialization rationale: file-locks.ts now uses proper-lockfile
+			// `retries:5` + backoff (src/parallel/file-locks.ts:163-172). Two concurrent
+			// SAME-task updates therefore SERIALIZE on the plan.json lock and can BOTH
+			// succeed (last-writer-wins) — this is correct behavior, NOT a lock bypass.
+			// The mutation (updateTaskStatus: loadPlan→modify→savePlan) runs INSIDE the
+			// lock, so the second winner reads the first winner's committed state; there
+			// is no lost update and no corruption. Assert that invariant directly instead
+			// of treating "both succeeded" as a race-condition failure.
+			const plan = JSON.parse(
+				fs.readFileSync(path.join(tempDir, '.swarm', 'plan.json'), 'utf-8'),
+			);
+			// plan.json is well-formed and structurally intact after serialized writes.
+			expect(Array.isArray(plan.phases)).toBe(true);
+			expect(plan.phases[0].tasks).toHaveLength(3);
+			// Both calls set task 1.1 to in_progress; serialized last-writer-wins leaves it in_progress.
+			const task11 = plan.phases[0].tasks.find(
+				(t: { id: string }) => t.id === '1.1',
+			);
+			expect(task11?.status).toBe('in_progress');
 		}, 30000);
 
 		it('concurrent lock acquisition for DIFFERENT tasks - both should succeed', async () => {

--- a/tests/unit/tools/write-drift-evidence.test.ts
+++ b/tests/unit/tools/write-drift-evidence.test.ts
@@ -28,6 +28,7 @@ import {
 	loadLastApprovedPlan,
 	readLedgerEvents,
 } from '../../../src/plan/ledger';
+import { derivePlanId } from '../../../src/plan/utils';
 // Import the function to test
 import {
 	executeWriteDriftEvidence,
@@ -68,7 +69,7 @@ async function setupSwarmDirWithPlan(dir: string, plan: Plan): Promise<void> {
 		JSON.stringify(plan, null, 2),
 		'utf-8',
 	);
-	await initLedger(dir, `${plan.swarm}-${plan.title}`.replace(/\W/g, '_'));
+	await initLedger(dir, derivePlanId(plan));
 }
 
 describe('executeWriteDriftEvidence', () => {


### PR DESCRIPTION
Closes #660
Closes #1267
Closes #1269
Closes #1270

## Summary

Resolves the genuinely-open residual findings across four planning-system issues. Most of #660's audit findings (F-03/F-05/F-06/F-07/F-09/F-12) were already fixed in earlier releases (verified against current source); this PR closes what actually remained, plus the adjacent #1267/#1269/#1270 residuals in the same subsystem.

- **#660 F-11** — `isPlanMdInSync` (`src/plan/manager.ts`) no longer treats a `plan.md` that merely *contains* the expected rendering as a substring as "in sync"; a non-equivalent `plan.md` is reported out of sync (PLAN_HASH-header and exact-equality paths preserved).
- **#660 F-08** — the two last-resort `phase_complete` fallback writes (`src/tools/phase-complete.ts`) now schema-validate before persisting and append a `phase_complete_fallback_write` event to `.swarm/events.jsonl` (atomic temp+rename unchanged). Consolidated to a single writer helper (2 → 1 write site).
- **#660 F-14** — ~15 test files now import the canonical `derivePlanId` from `src/plan/utils.ts`; 4 that used a divergent `/\W/g` regex (which stripped the joining hyphen) are aligned to canonical.
- **#660 FR-004** — new regression guards pin F-03 (plan.json lock before `savePlan`), F-05 (council atomic writes), F-09 (lock retry/backoff) so they cannot silently revert.
- **#1269** — structured, runtime-only `_ledgerReplayStale` signal: when the loader detects an unrecoverably-stale `plan.json` (hash-mismatch + ledger replay fails + no approved snapshot), the verdict is persisted per workspace and re-surfaced on every load (self-healing once plan↔ledger reconverge), so `update_task_status`/`phase_complete` reliably refuse to mutate a known-stale plan in long-lived hosts instead of relying on a logged warning. Plus a bounded, timer-free idle-TTL session sweep (`src/state.ts`) that reclaims sessions independent of new-session creation.
- **#1267** — fixed a real Windows path-traversal gap (`resolveWorkingDirectory` split on `path.sep`, missing `/`-style traversal → now splits on `/[\\/]/`); corrected the lock "winner" tests that encoded obsolete `retries:0` behavior (under `retries:5` callers serialize on the plan.json lock and each read-modify-write fresh state — verified no lost update / no bypass).
- **#1270** — `validateSwarmPath` realpath/symlink containment (closes the in-`.swarm` symlink-escape + its failing test); strict `version-check` response validation (JSON content-type, bounded length, strict semver); `composeHandlers` fail-closed brand guard (forward-looking).

Scope was reconciled against in-flight PRs: **#779 (draft PR #1564)** and **#1268 (PR #1561)** are handled separately and are NOT in this PR. The `validateSwarmPath` realpath fix is included here because its regression test fails on `main` today and gates validation; it coordinates with #1564 (whichever merges second rebases).

## Invariant audit
- 1 (plugin init): not touched — no `src/index.ts`/manifest/init-path changes; the idle sweep is hook-driven (no timer). `node scripts/repro-704.mjs` → T1 184ms / T2 106ms / T3 110ms, all within deadline.
- 2 (runtime portability): touched (additive) — only `node:*` imports added (`node:fs` in hooks/utils, `node:crypto` already present); no `bun:`/`Bun.*`. `bun run build` OK; `node --input-type=module -e "await import('./dist/index.js')"` → `dist import ok`.
- 3 (subprocesses): not touched — no spawn/exec added.
- 4 (.swarm containment): touched (strengthened) — `validateSwarmPath` now realpath-resolves before containment (#1270-1); `resolveWorkingDirectory` traversal detection fixed for forward-slash paths (#1267). All writes still route through `validateSwarmPath`.
- 5 (plan durability): touched (carefully) — F-08 hardens the EXISTING emergency plan.json writer (no new write site) with schema-validate + event trace. `_ledgerReplayStale`/`_ledgerReplayStaleReason` and `ledgerStaleWorkspaces` are runtime-only: never written by `savePlan` (PlanSchema strips unknown keys), never hashed (`computePlanHash`/`computePlanContentHash` allow-lists — test-proven). No ledger/projection/checkpoint/`get_approved_plan`/durable-schema change.
- 6 (test_runner safety): not touched — validated via shell per-file `bun test`, never `test_runner scope:all`.
- 7 (test writing): touched — bun:test, `_internals` DI seams (not leaking `mock.module`) with `afterEach` restore, `os.tmpdir()`. Two regression guards use `vi.mock` mirroring an existing sanctioned sibling; an isolated cross-file `vi.mock` leak surfaced during review was fixed by hardening the victim test via DI seams (verified: the four interacting files pass together).
- 8 (session state): touched — idle sweep keyed by `sessionID`, bounded by 60s cooldown + 2h TTL, reset path added; `ledgerStaleWorkspaces` keyed by resolved workspace path, same bounded lifetime as the pre-existing `startupLedgerCheckedWorkspaces`.
- 9 (guardrails/retry): not touched (relies on existing F-09 lock retry policy, read-only).
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no new tools/agent-maps; `isPlanMdInSync`/`derivePlanId` exports are helpers.
- 12 (release/cache): touched — adds `docs/releases/pending/660-1267-1269-1270-planning-residuals.md`; no version/CHANGELOG/manifest edits.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `biome ci` (v2.3.14) on changed files — clean
- [x] `bun run build` + Node ESM import of `dist/index.js` — OK
- [x] `node scripts/repro-704.mjs` — T1/T2/T3 within deadline
- [x] All 24 changed/new test files pass per-file (incl. new regression guards + staleness persistence/self-heal driven against the real `loadPlan` path)
- [x] Consumer differential vs pristine `origin/main` — no new failures (save-plan 66/0, system-enhancer 13/0, manager 56/0, update-task-status 71/0)
- [x] Independent reviewer + critic + post-approval delta review — all APPROVE (findings addressed)
- [ ] Full CI suite (Linux, per-file sharded) — runs on this PR

## Pre-existing failures (not introduced by this PR)
The local Windows environment has a large pre-existing failure baseline (e.g. `registration-parity` 12/6, `architect.dark-matter` 3/13, `write-final-council-evidence` 5/4) — verified identical on pristine `origin/main`. A separate test file hangs under per-file `bun test` on this host, which prevented an exhaustive local full-suite run; the differential and CI's per-file sharding cover this. None of these touch the changed modules.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

