### PR TITLE
fix(ci): add shell: bash and scope coverage gate to single cell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,8 @@ jobs:
           exit $failed
 
       - name: Coverage gate enforcement
-        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        if: github.event_name == 'merge_group' && matrix.os == 'ubuntu-latest' && matrix.shard == 1 && needs.detect-release.outputs.is-release != 'true'
+        shell: bash
         run: |
           set -e
           echo "Running coverage measurement for gate enforcement..."
@@ -200,7 +201,7 @@ jobs:
           fi
           echo "Coverage gate passed: ${COVERAGE}% >= ${THRESHOLD}%"
       - name: Upload coverage report
-        if: always() && github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        if: always() && github.event_name == 'merge_group' && matrix.os == 'ubuntu-latest' && matrix.shard == 1 && needs.detect-release.outputs.is-release != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report


### PR DESCRIPTION
## Summary
- Added `shell: bash` to the "Coverage gate enforcement" step in CI, which was missing it — causing PowerShell parse errors on Windows merge-queue runners (`if [ ! -s ... ]` is not valid PowerShell)
- Scoped both the coverage gate and upload steps to `ubuntu-latest` shard 1 only, since coverage numbers are platform-independent and running the full test suite on all 12 matrix cells (especially 4-7x slower Windows runners) would cause timeouts
- This was the root cause of all merge queue failures since PR #1562 merged

## Invariant audit
- **CI-only change**: no source code, tests, docs, or package metadata modified
- **No new shell scripts**: only adds `shell: bash` to an existing step and tightens its `if:` condition
- **No test coverage impact**: the coverage gate itself is unchanged; only which matrix cell runs it
- **No breaking change**: the coverage gate behavior is identical on the one cell that runs it

## Test plan
- [x] Verified no other steps in Windows-capable jobs are affected
- [x] Syntax-checked script body under Git Bash on Windows (`bash -n`)
- [x] Confirmed sibling steps ("Collect and partition test files", "Run unit tests") already have `shell: bash`
- [ ] Merge queue run succeeds (can only be verified at merge time — the step is guarded by `merge_group` and Windows only appears in the merge_group matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)