### PR TITLE
fix(plugin): remove SIGINT/SIGTERM handlers and guard console.warn calls

### DIFF
--- a/docs/releases/pending/tui-plugin-tui-stability-hardening.md
+++ b/docs/releases/pending/tui-plugin-tui-stability-hardening.md
@@ -14,14 +14,15 @@ During multi-agent swarm sessions, the OpenCode host TUI can display "Abort" tex
 
 - **`src/index.ts`**: Removed `process.once('SIGINT', ...)` and `process.once('SIGTERM', ...)` handlers entirely. `process.on('exit', cleanupAutomation)` remains as the sole cleanup hook — the correct host-plugin contract.
 - **`src/index.ts`**: Guarded Config Doctor advisory `console.warn()` calls (lines ~1150/1157) with `if (!config.quiet)`; when quiet, routes through `addDeferredWarning()` (visible via `/swarm diagnose`).
-- **`src/index.ts`**: Guarded skill-propagation-gate `console.warn()` calls (lines ~1991/2025) with `if (!config.quiet)`.
-- **`tests/unit/plugin-tui-safety.test.ts`**: New regression tests asserting no signal handler registrations and all `console.warn` calls are properly guarded.
+- **`src/index.ts`**: Guarded skill-propagation-gate `console.warn()` calls (lines ~1991/2025) with `if (!config.quiet)`. These per-invocation operational logs are suppressed (not deferred) when quiet — they are debug-level noise and have no deferred-buffer equivalent.
+- **`tests/unit/plugin-tui-safety.test.ts`**: New regression tests asserting no signal handler registrations and all `console.warn` calls in `src/index.ts` are properly guarded. Scope: `console.warn` only; `console.error` and logger `error()` calls on exceptional paths (init failure, pr-monitor worker errors) are intentionally retained as unconditional stderr.
 
 ## Migration steps
-None. When `config.quiet` is false (the default), all console output behavior is unchanged. When `config.quiet` is true, Config Doctor advisories are now deferred to `/swarm diagnose` rather than written to stderr on startup.
+`config.quiet` defaults to `true` (`schema.ts:2405`). Under the default, all four previously-unguarded `console.warn` calls are now suppressed or deferred instead of writing to stderr. Config Doctor advisories are deferred to `/swarm diagnose`; skill-propagation-gate logs are suppressed. When `config.quiet` is explicitly set to `false`, behavior is unchanged from before this PR.
 
 ## Breaking changes
-None.
+None for `quiet: false` configurations. Under the default `quiet: true`, Config Doctor startup advisories no longer appear on stderr — use `/swarm diagnose` to view them.
 
 ## Known caveats
-This change mitigates but does not fix the "Abort" prefix TUI rendering bug. The rendering defect is in the OpenCode host (`anomalyco/opencode`) and requires an upstream fix.
+- This change mitigates but does not fix the "Abort" prefix TUI rendering bug. The rendering defect is in the OpenCode host (`anomalyco/opencode`) and requires an upstream fix.
+- The connection between these plugin behaviors and the host TUI corruption is theoretical: the plugin emits no "Abort" text; the changes reduce stderr writes and prevent `process.exit()` calls that could short-circuit the host's terminal cleanup.

--- a/docs/releases/pending/tui-plugin-tui-stability-hardening.md
+++ b/docs/releases/pending/tui-plugin-tui-stability-hardening.md
@@ -1,0 +1,27 @@
+# Plugin TUI stability hardening
+
+## What changed
+Removed SIGINT/SIGTERM signal handlers from the plugin entry point and guarded previously unguarded `console.warn()` calls with `config.quiet` checks.
+
+## Why
+During multi-agent swarm sessions, the OpenCode host TUI can display "Abort" text on every output line — a rendering bug in the host (`anomalyco/opencode`). Investigation confirmed the plugin cannot produce this text, but two plugin behaviors could contribute to host TUI instability:
+
+1. The plugin registered `process.once('SIGINT', () => { cleanupAutomation(); process.exit(130); })` and equivalent for SIGTERM. A plugin calling `process.exit()` inside the host process kills the entire host, short-circuiting the host TUI's terminal cleanup (alternate screen restore, cursor reset, raw mode disable).
+
+2. Four `console.warn()` call sites (Config Doctor startup advisories, skill-propagation-gate logs) wrote directly to stderr without checking `config.quiet`, bypassing the host TUI's rendering pipeline.
+
+## Changes
+
+- **`src/index.ts`**: Removed `process.once('SIGINT', ...)` and `process.once('SIGTERM', ...)` handlers entirely. `process.on('exit', cleanupAutomation)` remains as the sole cleanup hook — the correct host-plugin contract.
+- **`src/index.ts`**: Guarded Config Doctor advisory `console.warn()` calls (lines ~1150/1157) with `if (!config.quiet)`; when quiet, routes through `addDeferredWarning()` (visible via `/swarm diagnose`).
+- **`src/index.ts`**: Guarded skill-propagation-gate `console.warn()` calls (lines ~1991/2025) with `if (!config.quiet)`.
+- **`tests/unit/plugin-tui-safety.test.ts`**: New regression tests asserting no signal handler registrations and all `console.warn` calls are properly guarded.
+
+## Migration steps
+None. When `config.quiet` is false (the default), all console output behavior is unchanged. When `config.quiet` is true, Config Doctor advisories are now deferred to `/swarm diagnose` rather than written to stderr on startup.
+
+## Breaking changes
+None.
+
+## Known caveats
+This change mitigates but does not fix the "Abort" prefix TUI rendering bug. The rendering defect is in the OpenCode host (`anomalyco/opencode`) and requires an upstream fix.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1105,14 +1105,6 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 		prEventCleanup?.();
 	};
 	process.on('exit', cleanupAutomation);
-	process.once('SIGINT', () => {
-		cleanupAutomation();
-		process.exit(130);
-	});
-	process.once('SIGTERM', () => {
-		cleanupAutomation();
-		process.exit(143);
-	});
 
 	// v6.7 Task 5.7: Config Doctor - run on startup if automation flags permit
 	// Runs in background-safe way (non-blocking, no errors propagate)
@@ -1138,8 +1130,8 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 							autofixEnabled: enableAutofix,
 						});
 
-						// Emit chat-visible advisory for auto-fixable findings.
-						// Uses console.warn (always visible, non-blocking).
+						// Emit advisory for auto-fixable findings.
+						// Guarded by config.quiet to avoid stderr writes that bypass the host TUI.
 						// Wrapped in try/catch per AGENTS.md invariant #1 (fail-open).
 						try {
 							const autoFixableCount = doctorResult.result.findings.filter(
@@ -1147,16 +1139,22 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 							).length;
 
 							if (!enableAutofix && autoFixableCount > 0) {
-								console.warn(
-									`[opencode-swarm] Config Doctor found ${autoFixableCount} auto-fixable issue(s). Run /swarm config doctor --fix to apply.`,
-								);
+								const msg = `[opencode-swarm] Config Doctor found ${autoFixableCount} auto-fixable issue(s). Run /swarm config doctor --fix to apply.`;
+								if (!config.quiet) {
+									console.warn(msg);
+								} else {
+									addDeferredWarning(msg);
+								}
 							} else if (
 								enableAutofix &&
 								doctorResult.appliedFixes.length > 0
 							) {
-								console.warn(
-									`[opencode-swarm] Config Doctor applied ${doctorResult.appliedFixes.length} fix(es) automatically.`,
-								);
+								const msg = `[opencode-swarm] Config Doctor applied ${doctorResult.appliedFixes.length} fix(es) automatically.`;
+								if (!config.quiet) {
+									console.warn(msg);
+								} else {
+									addDeferredWarning(msg);
+								}
 							}
 						} catch {
 							// Advisory emission must never block startup
@@ -1988,9 +1986,11 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 							if (qualified.length === 0) {
 								// No skills above threshold — inject SKILLS: none
 								argsRecord.prompt = `SKILLS: none\n\n${promptRaw}`;
-								console.warn(
-									'[skill-propagation-gate] No skills above threshold 0.5 — injected SKILLS: none',
-								);
+								if (!config.quiet) {
+									console.warn(
+										'[skill-propagation-gate] No skills above threshold 0.5 — injected SKILLS: none',
+									);
+								}
 							} else {
 								// Take top 5 by score
 								const topSkills = qualified.slice(0, 5);
@@ -2022,9 +2022,11 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 											`${path.basename(s.skillPath)} (score: ${s.score.toFixed(2)})`,
 									)
 									.join(', ');
-								console.warn(
-									`[skill-propagation-gate] Injected skills: ${skillNames}`,
-								);
+								if (!config.quiet) {
+									console.warn(
+										`[skill-propagation-gate] Injected skills: ${skillNames}`,
+									);
+								}
 
 								// Record each injected skill to skill-usage.jsonl
 								for (const skill of topSkills) {

--- a/tests/unit/plugin-tui-safety.test.ts
+++ b/tests/unit/plugin-tui-safety.test.ts
@@ -7,6 +7,9 @@ const INDEX_SRC = readFileSync(
 	'utf-8',
 );
 
+// Scope: console.warn calls only. Unconditional console.error / logger.error()
+// calls on exceptional paths (init failure, pr-monitor errors) are intentionally
+// out of scope — they are not covered by these assertions.
 describe('Plugin TUI safety', () => {
 	test('no process.exit in SIGINT/SIGTERM handlers', () => {
 		const sigintBlock = /process\.once\(\s*['"]SIGINT['"][\s\S]*?process\.exit/;

--- a/tests/unit/plugin-tui-safety.test.ts
+++ b/tests/unit/plugin-tui-safety.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const INDEX_SRC = readFileSync(
+	path.resolve(import.meta.dir, '../../src/index.ts'),
+	'utf-8',
+);
+
+describe('Plugin TUI safety', () => {
+	test('no process.exit in SIGINT/SIGTERM handlers', () => {
+		const sigintBlock = /process\.once\(\s*['"]SIGINT['"][\s\S]*?process\.exit/;
+		const sigtermBlock =
+			/process\.once\(\s*['"]SIGTERM['"][\s\S]*?process\.exit/;
+		expect(sigintBlock.test(INDEX_SRC)).toBe(false);
+		expect(sigtermBlock.test(INDEX_SRC)).toBe(false);
+	});
+
+	test('no SIGINT/SIGTERM handler registrations via any method', () => {
+		const methods = ['process.once', 'process.on', 'process.addListener'];
+		const signals = ['SIGINT', 'SIGTERM'];
+		for (const method of methods) {
+			for (const signal of signals) {
+				expect(INDEX_SRC).not.toContain(`${method}('${signal}'`);
+				expect(INDEX_SRC).not.toContain(`${method}("${signal}"`);
+			}
+		}
+	});
+
+	test('Config Doctor console.warn calls are guarded by config.quiet', () => {
+		const doctorSection = INDEX_SRC.slice(
+			INDEX_SRC.indexOf('Config Doctor'),
+			INDEX_SRC.indexOf('Advisory emission must never block startup') + 50,
+		);
+		const warnCalls = doctorSection.match(/console\.warn\(/g) || [];
+		const quietGuards = doctorSection.match(/!config\.quiet/g) || [];
+		expect(warnCalls.length).toBeGreaterThan(0);
+		expect(quietGuards.length).toBeGreaterThanOrEqual(warnCalls.length);
+	});
+
+	test('every console.warn in index.ts is guarded by config.quiet check', () => {
+		const lines = INDEX_SRC.split('\n');
+		const unguarded: number[] = [];
+		for (let i = 0; i < lines.length; i++) {
+			if (/console\.warn\(/.test(lines[i])) {
+				const context = lines.slice(Math.max(0, i - 5), i + 1).join('\n');
+				const hasNegatedGuard = context.includes('!config.quiet');
+				const inElseBranch =
+					context.includes('config.quiet') && context.includes('} else');
+				if (!hasNegatedGuard && !inElseBranch) {
+					unguarded.push(i + 1);
+				}
+			}
+		}
+		expect(unguarded).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
- Remove SIGINT/SIGTERM signal handlers from the plugin — a plugin must not call `process.exit()` inside the host process, as it short-circuits the host TUI's shutdown and terminal cleanup sequence
- Guard 4 unguarded `console.warn()` calls with `config.quiet` checks to prevent stderr writes from bypassing the host TUI's rendering pipeline; Config Doctor advisories route through `addDeferredWarning()` when quiet, skill-propagation-gate logs are suppressed (debug-noise class)
- Add regression tests (`tests/unit/plugin-tui-safety.test.ts`) asserting no signal handler registrations and all `console.warn` calls in `src/index.ts` are guarded (scope: `console.warn` only; `console.error`/`logger.error()` on exceptional paths intentionally retained)

## Context
During multi-agent swarm sessions, the OpenCode host TUI can render "Abort" text on every output line — a rendering bug in `anomalyco/opencode`, not in this plugin. Investigation confirmed the plugin emits no "Abort" text. However, two plugin behaviors could plausibly contribute to host TUI instability:

1. `process.exit(130)` in the SIGINT handler kills the entire host process, preventing host TUI terminal cleanup
2. Unguarded `console.warn()` calls write directly to stderr, bypassing the host TUI's rendering pipeline

The connection is theoretical: this PR is defensive hardening to reduce these triggers. It **does not and cannot fix** the host TUI rendering bug itself — that requires an upstream fix in `anomalyco/opencode`.

`config.quiet` defaults to `true` (`schema.ts:2405`). Under the default, Config Doctor startup advisories are now deferred to `/swarm diagnose` rather than written to stderr.

## Invariant audit
- 1 (plugin init): touched — signal handlers removed from init path; `process.on('exit', cleanupAutomation)` retained. `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` → `dist import OK`.
- 2 (runtime portability): touched — `src/index.ts` modified; `bun run typecheck` clean, `bunx @biomejs/biome@2.3.14 ci .` clean (2206 files).
- 3 (subprocesses): not touched — no subprocess changes.
- 4 (.swarm containment): not touched.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched.
- 7 (test writing): touched — new `tests/unit/plugin-tui-safety.test.ts` uses `bun:test` only, no `mock.module`, reads source as string. Scope comment added clarifying `console.warn`-only coverage.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): touched — `console.warn()` calls guarded to prevent diagnostic noise in chat-visible streams. Exceptional-path `console.error`/`logger.error()` calls intentionally retained out of scope.
- 11 (tool registration): not touched.
- 12 (release/cache): not touched — release fragment added at `docs/releases/pending/tui-plugin-tui-stability-hardening.md`.

## Test plan
- [x] `bun run build` passes
- [x] `node --input-type=module -e "await import('./dist/index.js')"` → `dist import OK`
- [x] `bun run typecheck` clean
- [x] `bunx @biomejs/biome@2.3.14 ci .` clean (2206 files, no errors)
- [x] `bun test tests/unit/plugin-tui-safety.test.ts` → 4/4 pass, 17 assertions
- [x] CI all 14 checks pass on Linux (commit 3f07531f)
- [x] Independent reviewer verdict: APPROVE-WITH-FIXES (doc fixes applied)
- [x] Independent critic verdict: NEEDS_REVISION (revision applied — quiet default corrected, test scope documented)
- [ ] Manual: interrupt a multi-agent swarm session with Ctrl+C — confirm no hung process

## Pre-existing failures
`tests/unit/index.test.ts` — 0/4 pass, confirmed pre-existing on `origin/main`