### PR TITLE
fix(ci): detect release-please in merge queue via head commit message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           # release merge. Two traps this avoids:
           #   1. The release commit is the merge commit's SECOND parent, so it
           #      is absent from the first-parent history the shallow merge-queue
-          #      checkout traverses — the old `git log --max-count=10` grep for
+          #      checkout traverses — the old "git log --max-count=10" grep for
           #      the release subject silently missed it and ran the full suite.
           #   2. A 10-commit window false-positives: a recent release MERGE
           #      ("Merge pull request ... release-please--...") lingers in the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,20 @@ jobs:
             echo "is-release=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ "$EVENT" == "merge_group" ]] && git log --format='%s' --max-count=10 | grep -q '^chore(main): release'; then
+          # Inspect ONLY the merge-group head commit (-1), not a window of
+          # history. The queued merge commit is "Merge pull request #N from
+          # <owner>/release-please--..." with the release commit "chore(main):
+          # release X.Y.Z" in its body, so its full message (%B) identifies a
+          # release merge. Two traps this avoids:
+          #   1. The release commit is the merge commit's SECOND parent, so it
+          #      is absent from the first-parent history the shallow merge-queue
+          #      checkout traverses — the old `git log --max-count=10` grep for
+          #      the release subject silently missed it and ran the full suite.
+          #   2. A 10-commit window false-positives: a recent release MERGE
+          #      ("Merge pull request ... release-please--...") lingers in the
+          #      window of later, non-release PRs and would wrongly skip them.
+          # HEAD-only is both robust (no traversal) and specific (this group).
+          if [[ "$EVENT" == "merge_group" ]] && git log -1 --format='%B' | grep -qE 'release-please--|^chore\(main\): release'; then
             echo "is-release=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## Summary
- `detect-release` failed to flag release-please PRs in the **merge queue**, so they ran the full test suite instead of skipping. The coverage gate (full-suite `bun --smol test --coverage` on ubuntu shard 1) then ran ~35-40 min and hit the 40-min job timeout, cancelling the run and blocking the queue (PR #1573; PR #1566 squeaked under at 34.6 min).
- Root cause: the release commit (`chore(main): release X.Y.Z`) is the merge-queue merge commit's **second parent**, absent from the first-parent history the shallow `--depth=10` merge-queue checkout traverses. The old `git log --max-count=10 | grep '^chore(main): release'` never matched it.
- Fix: inspect only the merge-group **head commit's full message** (`git log -1 --format='%B'`) for `release-please--` or `chore(main): release`. No history traversal (robust against the shallow first-parent issue) and head-only (specific to this merge group, avoids false-positives from stale release merges lingering in a commit window).

## Invariant audit
- **CI-only change**: one line of executable change in the `detect-release` step plus an explanatory comment; no source, tests, or package metadata touched.
- **No false-positives (untested code must not skip tests)**: validated against 50 real merge_group head commits (19 release, 31 normal) — 0 false positives, 0 false negatives.
- **No false-negatives (release PRs must skip)**: the merge queue uses merge commits whose subject carries `release-please--` and body carries `chore(main): release`; both tokens are matched.
- **`pull_request` path untouched**: the `github.head_ref == release-please--*` branch is unchanged; the new `git log` stays gated behind `merge_group` (where the conditional checkout exists).
- **Assumption documented**: relies on the queue using merge commits (verified current). If the merge queue is switched to squash, re-validate — the `chore(main): release` body anchor would become the only surviving signal.

## Test plan
- [x] Positive control: release merge `b229022d` → `is-release=true` (exact new pipeline on a real `--depth=10` fetch)
- [x] Negative controls: non-release merges `76c69ab9`, `5d32aa8e` → `is-release=false`
- [x] Edge case: merge-group head IS the release commit (body `chore(main): release`) → matches via 2nd alternative
- [x] Regex escaping (`\(main\)` under `grep -E`), `bash -n` syntax, `set -eo pipefail` no-match-in-`if` all verified
- [x] Independent reviewer + critic approved; critic ran a full-dataset FP/FN scan
- [ ] Merge queue run skips test work on the next release PR (verifiable only at merge-queue time — this step is `merge_group`-only and the bug is invisible to PR CI; the SHA-level controls above are the proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

