### PR TITLE
ci(coverage): run coverage gate in dedicated job to fix merge-queue timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,11 @@ jobs:
             [ -f "$f" ] || continue
             tmp="$tmpdir/bun-out-$$-${f##*/}"
             exit_code=0
-            bun scripts/ci/run-test-with-timeout.ts "$f" --timeout 120000 --kill-timeout 180 --coverage > "$tmp" 2>&1 || exit_code=$?
+            # No --coverage here: per-file coverage is overwritten each invocation
+            # and never aggregated. The coverage gate (the dedicated coverage job)
+            # owns the full-suite measurement; instrumenting every sharded test
+            # process was pure overhead on every cell.
+            bun scripts/ci/run-test-with-timeout.ts "$f" --timeout 120000 --kill-timeout 180 > "$tmp" 2>&1 || exit_code=$?
             if [ $exit_code -ne 0 ]; then
               if grep -qE "^[[:space:]]*(FAIL|✗|AssertionError|\[TIMEOUT\])" "$tmp"; then
                 echo "::error file=$f::FAILED: $f"
@@ -172,9 +176,64 @@ jobs:
             rm -f "$tmp"
           done < "$tmpdir/shard-tests.txt"
           exit $failed
+      # NOTE: the coverage gate used to run here as an extra step on
+      # `unit (ubuntu-latest, 1)`, which made that one cell execute the entire
+      # unit suite twice (sharded run + full-suite coverage run) inside the 40m
+      # budget — ~30-35 min in practice, intermittently timing out and blocking
+      # the merge queue (PR #1573). It now lives in the dedicated `coverage` job
+      # below so the full-suite run gets its own timeout and the unit cells stay
+      # fast. Blocking power is NOT automatic: nothing here `needs: coverage`, so
+      # the gate only blocks the queue once `coverage` is added to ruleset
+      # 17809658's required status checks. That must happen AFTER this lands on
+      # main (adding it earlier blocks other open PRs whose merge groups don't
+      # yet define this job). Until then the gate runs but does not block.
 
+  # Merge-queue-only coverage gate. Runs the full unit suite once with coverage
+  # and enforces the line-coverage threshold. Isolated from the `unit` job so the
+  # inherently ~26-31 min full-suite coverage measurement gets its own generous
+  # timeout instead of stacking onto a sharded unit cell's 40m budget (see the
+  # NOTE in the `unit` job above and PR #1573). On pull_request all steps are
+  # skipped and the job reports success to satisfy the required check without
+  # doing work (same pattern as integration/smoke). Skipped for release-please
+  # branches (version bumps don't change coverage).
+  coverage:
+    needs: [detect-release, quality]
+    runs-on: ubuntu-latest
+    # Standalone cost: ~2-3 min setup/build + ~26-31 min full-suite coverage
+    # (the measurement alone has been observed at 30.6 min, PR #1566) = ~29-34 min
+    # worst case. This job does NOT run the sharded suite, so it sheds the ~3.5 min
+    # that helped push the old in-`unit` cell to its 40m cap. The cap balances two
+    # ceilings: it must clear the ~34 min worst-observed run (45m leaves ~11 min
+    # for slow-runner / cache-miss variance) AND stay under the merge_queue
+    # ruleset's check_response_timeout_minutes: 60 end-to-end, since coverage runs
+    # after `quality` (~5-10 min) via `needs` — quality(~10) + 45 = 55 < 60. This
+    # makes a timeout very unlikely for a normal run by removing the structural
+    # double-run; it is not an absolute guarantee against a pathologically slow runner.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        with:
+          bun-version: "1.3.13"
+      - name: Cache bun dependencies
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+      - name: Install dependencies
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        run: bun install --frozen-lockfile
+      # The full suite includes tests/unit/build/ tests that load the bundle, so
+      # dist/ must exist (matches the unit job's rationale).
+      - name: Build
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        run: bun run build
       - name: Coverage gate enforcement
-        if: github.event_name == 'merge_group' && matrix.os == 'ubuntu-latest' && matrix.shard == 1 && needs.detect-release.outputs.is-release != 'true'
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         shell: bash
         run: |
           set -e
@@ -201,7 +260,7 @@ jobs:
           fi
           echo "Coverage gate passed: ${COVERAGE}% >= ${THRESHOLD}%"
       - name: Upload coverage report
-        if: always() && github.event_name == 'merge_group' && matrix.os == 'ubuntu-latest' && matrix.shard == 1 && needs.detect-release.outputs.is-release != 'true'
+        if: always() && github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report

--- a/TESTING.md
+++ b/TESTING.md
@@ -143,7 +143,7 @@ coverageReporter = ["lcov", "text"]
 coverageDir = "./coverage"
 ```
 
-The coverage gate runs as part of the `unit` job but only on `merge_group` events (not on every PR for speed). To measure coverage locally:
+The coverage gate runs in a dedicated `coverage` job (a required status check) but only on `merge_group` events (not on every PR for speed). It runs the full unit suite once with coverage in its own job, separate from the sharded `unit` job, so the long full-suite measurement does not stack onto a unit shard's timeout budget. To measure coverage locally:
 
 ```bash
 bun test --coverage tests/unit/ --timeout 60000

--- a/docs/releases/pending/ci-coverage-gate-dedicated-job.md
+++ b/docs/releases/pending/ci-coverage-gate-dedicated-job.md
@@ -1,0 +1,23 @@
+# CI: Move coverage gate to a dedicated job to stop double-running the unit suite
+
+## What changed
+
+The merge-queue coverage gate no longer runs as an extra step inside the `unit (ubuntu-latest, 1)` shard. It now runs in its own `coverage` job.
+
+- **No more double-run.** Previously, on every non-release `merge_group` run, ubuntu shard 1 executed the entire unit suite twice: once as its sharded test run, then again as a full-suite `bun --smol test --coverage` for the gate. That cell measured ~30–35 min against the `unit` job's 40-min timeout and intermittently timed out, cancelling the run and re-blocking the merge queue (e.g. PR #1573 hit the 40-min wall). The full-suite coverage measurement now lives in the dedicated `coverage` job with its own 45-min timeout, and the `unit` ubuntu-1 cell drops to the ~3–6 min of its sibling shards. The 45-min cap clears the ~34-min worst-observed standalone run (coverage measurement alone has hit 30.6 min) with ~11 min of slow-runner/cache-miss headroom, while `quality` (~5–10 min) + 45 = 55 stays under the merge queue's 60-min end-to-end window.
+- **Gate semantics unchanged.** The threshold (41.48% line coverage), the parse of the `All files` row, the pass/fail behavior, and the `coverage-report` artifact upload are relocated verbatim. The `coverage` job runs only on `merge_group` (skipped + reported success on `pull_request`, same pattern as `integration`/`smoke`) and is skipped for release-please branches.
+- **Required check (added post-merge).** Nothing in the workflow `needs: coverage`, so the gate's blocking power comes solely from the branch ruleset's required-status-check list. `coverage` must be added there *after* this merges to `main` (see Migration steps) — adding it earlier would block every other open PR, whose merge group built from `main` would not yet produce a `coverage` check.
+- **Dropped dead instrumentation.** The sharded `Run unit tests` step previously passed `--coverage` per file; that per-file coverage was overwritten on each invocation and never aggregated or read. It is removed, which lightens every unit cell on every OS.
+
+## Why
+
+The double-run was a latent flake: a normal PR's `merge_group` run could exceed the `unit` job's 40-min timeout purely because of the in-job coverage measurement, cancelling the run and blocking the queue. Isolating the inherently long (~26–31 min) full-suite coverage run in its own job removes that structural double-run and sizes the job's timeout above the observed worst case with margin, so a normal merge-queue run is very unlikely to hit a job timeout because of the coverage gate — while keeping the sharded unit cells fast. (This is not an absolute guarantee against a pathologically slow runner; see the timeout note under Known caveats.)
+
+## Migration steps
+
+None for local workflows. **Post-merge:** a repository maintainer must add `coverage` to the `main` branch ruleset's required status checks so the gate keeps blocking the merge queue. This must happen *after* this PR merges (so `main`'s CI defines the `coverage` job) — not before, or other open PRs would be blocked on a check their merge groups cannot produce.
+
+## Known caveats
+
+- This change only affects `merge_group` events. PR CI is ubuntu-only and skips the coverage gate, so the new `coverage` job's real behavior — and its effect on queue timing — can only be fully validated at merge-queue time, after merge. This mirrors the validation limitation noted for PR #1570 and PR #1578.
+- The 45-min timeout on `coverage` is sized to the ~29–34 min standalone run (setup/build + full-suite coverage; it does not run the sharded suite, and the coverage measurement alone has been observed at 30.6 min) with ~11 min of headroom, and kept under the merge queue's 60-min end-to-end window after `quality` (~10 + 45 = 55). The worst-observed run leaves real but finite headroom: a runner substantially slower than anything observed could still approach the cap. If the suite grows substantially, that timeout (not the `unit` job's) is the value to revisit.


### PR DESCRIPTION
## Summary

On every non-release `merge_group` run, the `unit (ubuntu-latest, 1)` cell ran the **entire** unit suite twice: once as its sharded test run, then again as the "Coverage gate enforcement" step (`bun --smol test --coverage tests/unit/`). Measured per-cell durations (GitHub API, runs `28414230583` / `28412887907`):

| Cell | Duration |
|---|---|
| `unit (ubuntu-latest, 1)` — had the coverage gate | **34m 39s / 29m 44s** |
| `unit (ubuntu-latest, 2/3/4)` | 2m 47s – 5m 31s |
| `unit (windows-latest, *)` | ~7–10m |

Against the `unit` job's `timeout-minutes: 40`, that cell intermittently hit the wall and was cancelled, blocking the merge queue (PR #1573). This is a latent flake independent of the detect-release fix (PR #1578).

**Fix (chosen approach: dedicated coverage job):**
- Move the "Coverage gate enforcement" + "Upload coverage report" steps **verbatim** out of `unit` into a new `coverage` job (`needs: [detect-release, quality]`, `timeout-minutes: 45`, merge_group-only with the same skip→success PR pattern as `integration`/`smoke`). The `unit` ubuntu-1 cell now matches its siblings (~3–6m); the inherently ~26–31m full-suite coverage run gets its own budget.
- The 45m cap balances two ceilings: it clears the ~34m worst-observed standalone run (coverage measurement alone has hit 30.6m, PR #1566) with ~11m of slow-runner/cache-miss headroom, and stays under the merge-queue end-to-end window — `coverage` runs after `quality` (~5–10m) and the ruleset enforces `check_response_timeout_minutes: 60`, so `quality(~10) + 45 = 55 < 60`. This removes the structural double-run that caused the timeouts; it is not an absolute guarantee against a pathologically slow runner.
- Drop the per-file `--coverage` from the sharded `Run unit tests` step: that coverage was overwritten on each invocation and never aggregated or read (the gate parse and artifact upload both consume the full-suite run). Lightens every unit cell on every OS.
- Docs: update `TESTING.md`; add release fragment `docs/releases/pending/ci-coverage-gate-dedicated-job.md`.

**REQUIRED post-merge step (the gate is non-blocking until this lands):** add `coverage` to the `main` branch ruleset 17809658's required status checks. Nothing in the workflow `needs: coverage`, so the gate's blocking power comes solely from the ruleset. This must be done **after** this PR merges to `main` (adding it earlier would block the 9 other open PRs, whose merge groups built from `main` would lack the `coverage` check). Exact command:

```bash
# after merge to main:
gh api repos/ZaxbyHub/opencode-swarm/rulesets/17809658 \
  --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks' \
  # then PATCH the ruleset with {"context":"coverage"} appended to required_status_checks
```

## Pre-merge notes (from independent review/critic)
- **Add `coverage` to ruleset 17809658's required checks AFTER this merges** (see Migration steps). Until then the gate runs but does not block.
- **Stale base (optional rebase):** this branch is based on `5d32aa8e`; `origin/main` has since advanced (detect-release hardening). A `git merge-tree` check confirms the 3-way merge is **conflict-free and preserves main's detect-release** while adding the coverage job — the two-dot `origin/main..HEAD` diff looks like a revert but GitHub's 3-way merge (and the merge queue's re-validation against latest main) is not affected. Rebasing before merge is optional, only to make the two-dot diff honest.
- **Timeout nit (non-blocking):** the coverage comment's `quality(~10)+45=55<60` is an expected-case figure; `quality` has no `timeout-minutes` (360m default), so 55 is not a hard ceiling. The comment already hedges ("not an absolute guarantee against a pathologically slow runner"), and the dependency chain is no worse than the prior in-`unit` placement.

## Invariant audit
- 1 (plugin init): not touched — no plugin/server init code changed; diff is `.github/workflows/ci.yml` + 2 Markdown files. `dist import OK` after `bun run build`.
- 2 (runtime portability): not touched — no source changed; build + Node dist import verified.
- 3 (subprocesses): not touched — no `bunSpawn`/`spawn` call sites changed; only CI shell steps (which already used `bun` invocations).
- 4 (.swarm containment): not touched — no `.swarm` path logic changed.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — `scripts/ci/run-test-with-timeout.ts` invocation in the sharded step only had the unused `--coverage` flag removed; the wrapper itself is unchanged.
- 7 (test writing): not touched — no test files added/modified.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched.
- 12 (release/cache): not touched in the violating sense — added a `docs/releases/pending/` fragment (the sanctioned mechanism); `package.json`, `CHANGELOG.md`, `.release-please-manifest.json` untouched.

Workflow `uses:` pinning (Step 4): `checkout`, `setup-bun`, `actions/cache` in the new job are full-SHA-pinned (copied from existing jobs). `actions/upload-artifact@v4` is tag-pinned — pre-existing in the repo and relocated verbatim from the original gate step; not introduced here and no repo CI gate enforces SHA-pinning.

## Test plan
- [x] `ci.yml` parses (`yaml.safe_load`); `coverage` job: `needs: [detect-release, quality]`, `timeout-minutes: 45`, 7 steps, no leftover `matrix.*` references.
- [x] `unit` job no longer contains either coverage step.
- [x] Relocated gate steps are byte-identical to `HEAD` (threshold 41.48, `All files` awk parse, exit-1-on-fail, artifact paths) — verified by independent reviewer.
- [x] No other workflow/job/script consumes the sharded run's coverage output (repo-wide grep) — safe to drop per-file `--coverage`.
- [x] `bun run typecheck` clean.
- [x] `bunx @biomejs/biome@2.3.14 ci .` clean (2205 files).
- [x] `bun run build` succeeds; `node ... import('./dist/index.js')` → `dist import OK`.
- [x] `bun test tests/security` → 163 pass, 4 skip, 0 fail. The `security` job's `tests/security/ci-workflow-security.test.ts` (which lint-scans `ci.yml` itself) initially failed: its "Command Injection Patterns" check naively scans whole `run:` blocks for backticks and flagged a backtick-quoted word in a code comment I added. Fixed by removing the backticks from the comment; suite now green.
- [ ] Other test tiers (unit/integration/smoke) not run locally — justified: diff touches only `.github/workflows/ci.yml` and two Markdown docs; no source/test/config code path is exercised. (The security tier was run because it asserts on `ci.yml` content.)
- [ ] **Merge-queue-only behavior** (the new `coverage` job actually running, and end-to-end timing) can only be fully validated at merge-queue time — PR CI is ubuntu-only and skips the coverage gate. Same validation limitation noted for PR #1570 and PR #1578.
