### PR TITLE
fix(ci): extract line coverage from correct awk column

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,8 +253,10 @@ jobs:
           echo "Running coverage measurement for gate enforcement..."
           # Run the full unit test suite with coverage
           bun --smol test --coverage tests/unit/ --timeout 60000 > coverage-output.txt 2>&1 || true
-          # Extract line coverage from "All files" row using awk (no command substitution)
-          awk -F'|' '/All files/ { gsub(/ /,"",$2); print substr($2, 1, 5); exit }' coverage-output.txt > coverage-value.txt
+          # Extract line coverage from "All files" row using awk (no command substitution).
+          # Bun's coverage table columns are: File | % Funcs | % Lines | Uncovered Line #s
+          # so line coverage is the 3rd pipe-delimited field ($3), not $2 (which is % Funcs).
+          awk -F'|' '/All files/ { gsub(/ /,"",$3); print substr($3, 1, 5); exit }' coverage-output.txt > coverage-value.txt
           if [ ! -s coverage-value.txt ]; then
             echo "::warning::Could not parse coverage output"
             : > coverage-value.txt
@@ -274,7 +276,7 @@ jobs:
           echo "Coverage gate passed: ${COVERAGE}% >= ${THRESHOLD}%"
       - name: Upload coverage report
         if: always() && github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report
           path: |

--- a/docs/releases/pending/fix-ci-coverage-gate-column.md
+++ b/docs/releases/pending/fix-ci-coverage-gate-column.md
@@ -1,0 +1,54 @@
+# fix(ci): extract line coverage from correct awk column
+
+## What changed
+
+The coverage gate in `.github/workflows/ci.yml` was extracting the wrong column from
+bun's coverage table. Bun's text-coverage output has the format:
+
+```
+File | % Funcs | % Lines | Uncovered Line #s
+```
+
+The awk expression used `$2` (% Funcs) instead of `$3` (% Lines), so the gate was
+comparing function coverage against a threshold documented and calibrated as line
+coverage.
+
+Also pins the previously-unpinned `actions/upload-artifact@v4` to the full SHA for
+`v4.6.2` as required by the workflow pinning policy.
+
+## Why
+
+The gate's intent was always line coverage. The originating commit (1362feb0) states
+"Add CI coverage instrumentation (--coverage + 41.48% line gate)" and
+`docs/releases/pending/1231-testing-infrastructure-audit.md` says
+"coverage gate enforced at 41.48% **line coverage** (baseline + 1%)". The comment
+in the step also says "Extract line coverage". All three pointed to the same intent;
+the implementation used the wrong awk field.
+
+CI evidence from a recent merge_group run (artifact `coverage-report`, run 28412887907):
+
+```
+All files | 66.42 | 63.74 |
+           $2=Funcs  $3=Lines
+```
+
+The CI log printed `Coverage: 66.42%` (the funcs value), confirming the bug was live.
+
+## Effect on the gate
+
+- **Before:** gate measured % Funcs = 66.42% vs threshold 41.48% → passed
+- **After:** gate measures % Lines = 63.74% vs threshold 41.48% → still passes
+
+The gate becomes marginally stricter (lines < funcs on this codebase) but clears the
+existing threshold with ≥22 points of margin. No currently-passing merge-queue runs
+will flip red.
+
+## Migration steps
+
+None. The threshold (41.48%) is unchanged. Users do not need to take any action.
+
+## Known caveats
+
+The 41.48% floor is now a loose lower bound (~22 pts below current line coverage).
+Consider ratcheting the threshold up (e.g. to ~58–60%) in a follow-up PR to give the
+gate more regression-catching power.


### PR DESCRIPTION
## Summary

- Fixes the coverage gate awk expression in `.github/workflows/ci.yml` to extract `` (% Lines) instead of `` (% Funcs) from bun's coverage table (`File | % Funcs | % Lines | Uncovered Line #s`).
- Pins the previously-unpinned `actions/upload-artifact@v4` to the full SHA `ea165f8d65b6e75b540449e92b4886f43607fa02` (v4.6.2) per the workflow SHA-pinning policy.
- Adds a column-layout comment so this bug cannot silently recur.
- The threshold (41.48%) is unchanged; the gate still passes on the corrected metric (line coverage 63.74% on CI, confirmed from merge_group artifact run 28412887907).

## Invariant audit

- 1 (plugin init): not touched — only `.github/workflows/ci.yml` and `docs/releases/pending/` changed; no plugin source
- 2 (runtime portability): not touched — no `src/`, `dist/`, or bundle config changes
- 3 (subprocesses): not touched — no subprocess code changed
- 4 (.swarm containment): not touched — no tool or hook code changed
- 5 (plan durability): not touched — no plan ledger code changed
- 6 (test_runner safety): not touched — no `test_runner` tool code changed
- 7 (test writing): not touched — no test files modified
- 8 (session state): not touched — no session or global-state code changed
- 9 (guardrails/retry): not touched — no guardrail code changed
- 10 (chat/system msg): not touched — no hook or message-shape code changed
- 11 (tool registration): not touched — no tool registration or agent map changes
- 12 (release/cache): not touched — no `package.json#version`, `CHANGELOG.md`, `.release-please-manifest.json`, or cache-eviction changes; release fragment added to `docs/releases/pending/` as required

## Test plan

- [x] `bun run typecheck` — passed (no type errors)
- [x] `bunx @biomejs/biome@2.3.14 ci .` — passed (2205 files, no issues)
- [x] Invariants 1, 2, 3 not touched — build/repro-704/dist-load not required
- [x] Column mapping confirmed empirically: `bun --smol test --coverage tests/unit/cli-dispatch.test.ts` showed header `File | % Funcs | % Lines | Uncovered Line #s` with ``=8.87 (funcs), ``=20.11 (lines)
- [x] End-to-end gate simulation on real CI artifact (run 28412887907): new `` awk extracts 63.74, gate passes (63.74 ≥ 41.48)
- [x] Old `` confirmed as funcs: CI log printed `Coverage: 66.42%` matching `=66.42` on the artifact
- [x] `actions/upload-artifact@v4` pinned to SHA `ea165f8d65b6e75b540449e92b4886f43607fa02` (v4.6.2) — confirmed via `gh api repos/actions/upload-artifact/git/refs/tags/v4.6.2`
- [x] All other `uses:` in ci.yml already SHA-pinned — verified via grep
- [x] Independent adversarial reviewer (opus) returned **APPROVED** with independent column mapping, ANSI-safety, substr edge-case, and gate-pass verification
- [x] Push protection scan: no forbidden patterns in diff

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

