### PR TITLE
ci(smoke): raise main-bundle size cap to 6.5 MiB to fix merge-queue flake

### DIFF
--- a/docs/releases/pending/ci-bundle-size-cap-flake.md
+++ b/docs/releases/pending/ci-bundle-size-cap-flake.md
@@ -1,0 +1,25 @@
+# CI: Raise main-bundle smoke cap to 6.5 MiB to fix a merge-queue flake
+
+## What changed
+
+`MAIN_BUNDLE_MAX_BYTES` in `tests/smoke/packaging.test.ts` is raised from 5.5 MiB to 6.5 MiB.
+
+- The smoke test `dist/index.js file size is reasonable` now allows up to 6.5 MiB (was 5.5 MiB).
+- The accompanying comment documents the bump history (5 → 5.5 → 6.5 MiB), the cross-platform build variance that caused the flake, and points to the minify investigation in #1582.
+
+## Why
+
+The unminified `dist/index.js` bundle had grown to sit ~1 KB below the 5.5 MiB cap. Builds are deterministic per platform but vary ~2 KB across platforms/toolchains (Windows local ≈ 5,766,141 B — under; Linux CI ≈ 5,768,289 B — over). So the smoke size assertion flipped pass/fail depending on the runner, intermittently failing on `merge_group` and blocking the merge queue for unrelated PRs (observed on PR #1579's first queue attempt and on PR #1560).
+
+A sub-10 KB trim would not help — the overage (~1–2 KB) is within build-environment variance, so any small reduction would re-flake on the next dependency bump. Raising the cap to 6.5 MiB restores ~1 MiB of headroom (well above the variance) while staying tight enough to keep genuine bundle growth visible in smoke CI. This mirrors the project's precedented cap-bump convention (main 5 → 5.5; CLI 1 → 2 → 2.2 → 2.4).
+
+The structural alternative — minifying the main bundle, which measures ~43% smaller (5.50 → 3.13 MiB) with all bundle and smoke tests passing — is deferred to #1582 because it changes the distributed artifact (stack-trace debuggability for a plugin that runs in users' environments) and warrants its own decision.
+
+## Migration steps
+
+None. Test-only change.
+
+## Known caveats
+
+- This raises a tripwire rather than reducing the bundle; the bundle will eventually approach 6.5 MiB and need either another bump or the minify path in #1582.
+- The smoke size gate runs on `merge_group` (and PR smoke); it is OS-sensitive by ~2 KB, so the cap is intentionally kept comfortably above the observed build-variance band rather than at the bundle's exact size.

--- a/tests/smoke/packaging.test.ts
+++ b/tests/smoke/packaging.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 const ROOT = path.resolve(import.meta.dir, '../../');
-const MAIN_BUNDLE_MAX_BYTES = 5.5 * 1024 * 1024;
+const MAIN_BUNDLE_MAX_BYTES = 6.5 * 1024 * 1024;
 
 describe('packaging smoke tests', () => {
 	test('dist/index.js exists', () => {
@@ -38,12 +38,17 @@ describe('packaging smoke tests', () => {
 		expect(typeof plugin.config).toBe('function');
 	});
 
-	test('dist/index.js file size is reasonable (< 5.5MB)', () => {
+	test('dist/index.js file size is reasonable (< 6.5MB)', () => {
 		const stats = Bun.file(path.join(ROOT, 'dist/index.js'));
-		// Raised from 5MiB by #1302 Wave 2's eval-gated skill machinery and
-		// #1263 config-doctor validation expansion: 62+ switch cases, Levenshtein
-		// suggestion, atomic writes, symlink rejection; keep the cap narrow so
-		// future bundle growth remains visible in smoke CI.
+		// History: 5MiB → 5.5MiB (#1302 Wave 2 eval-gated skill machinery +
+		// #1263 config-doctor validation) → 6.5MiB here. The 5.5MiB cap became a
+		// merge-queue flake: the unminified bundle sat ~1KB from the limit, and
+		// builds vary ~2KB across platforms/toolchains (Windows ~5,766,141 under;
+		// Linux CI ~5,768,289 over), so the gate flipped pass/fail by runner and
+		// intermittently blocked unrelated PRs. 6.5MiB restores ~1MiB headroom,
+		// far above that variance, while staying tight enough to keep growth
+		// visible in smoke CI. The structural alternative (minify the bundle,
+		// ~43% smaller) is tracked in #1582.
 		expect(stats.size).toBeLessThan(MAIN_BUNDLE_MAX_BYTES);
 		// But should be at least 10KB (non-empty)
 		expect(stats.size).toBeGreaterThan(10 * 1024);


### PR DESCRIPTION
## Summary

Raise `MAIN_BUNDLE_MAX_BYTES` in `tests/smoke/packaging.test.ts` from **5.5 MiB → 6.5 MiB** (test name + comment updated) and add a release-note fragment, to fix a merge-queue flake.

The unminified `dist/index.js` bundle had grown to ~1 KB below the 5.5 MiB smoke cap. Builds are deterministic per platform but vary ~2 KB across platforms/toolchains:

| build | `dist/index.js` | vs 5.5 MiB cap (5,767,168 B) |
|---|---|---|
| Windows local | 5,766,141 B | **under** by 1,027 B → passes |
| Linux CI | 5,768,289 B | **over** by 1,121 B → fails |

So the smoke assertion `dist/index.js file size is reasonable` flipped pass/fail by runner and intermittently failed on `merge_group`, blocking the queue for **unrelated** PRs (observed on [#1579](https://github.com/ZaxbyHub/opencode-swarm/pull/1579)'s first queue attempt and on [#1560](https://github.com/ZaxbyHub/opencode-swarm/pull/1560)). A sub-10 KB trim would not help — the overage is within build-environment variance, so it would re-flake on the next dependency bump. 6.5 MiB restores **~1 MiB headroom** (≈487× the ~2 KB variance) while staying tight enough to keep growth visible. Mirrors the project's precedented cap-bump convention (main 5 → 5.5; CLI 1 → 2 → 2.2 → 2.4).

The structural alternative — minifying the bundle (~43% smaller: 5.50 → 3.13 MiB, all bundle+smoke tests pass) — changes the distributed artifact's stack-trace debuggability and is tracked separately in **#1582**, not bundled into this flake fix.

## Invariant audit
- 1 (plugin init): not touched - no change to `src/index.ts`/`server()`/plugin entry; only `tests/` + `docs/`.
- 2 (runtime portability): not touched - no runtime/source code changed; test-only constant + markdown.
- 3 (subprocesses): not touched - no spawn/subprocess code; `git diff origin/main..HEAD` is `tests/smoke/packaging.test.ts` + a release-note fragment.
- 4 (.swarm containment): not touched - no `.swarm` storage code changed.
- 5 (plan durability): not touched - no plan/persistence code changed.
- 6 (test_runner safety): not touched - no test-runner/CI runner logic changed; the smoke test command is unchanged.
- 7 (test writing): touched - one numeric cap constant (`MAIN_BUNDLE_MAX_BYTES` 5.5→6.5 MiB) + the matching test-name string + comment in `tests/smoke/packaging.test.ts`. No new test, no `mock.module`, no isolation/seam change. `bunx biome ci` clean; existing assertions (10 KB floor, CLI cap) intact; 10/10 pass.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched.
- 12 (release/cache): not touched - dist/ not committed; added a `docs/releases/pending/` fragment per the release-note convention; no version/manifest edit.

## Test plan
- `bun test tests/smoke/packaging.test.ts --timeout 60000` → **10 pass / 0 fail**.
- `bunx biome ci tests/smoke/packaging.test.ts` → clean.
- `bun run typecheck` (`tsc --noEmit`) → clean.
- Bundle sizes measured: Windows local `dist/index.js` 5,766,141 B; Linux CI 5,768,289 B; minified 3,277,592 B (evidence for #1582).
- Independent reviewer: **APPROVE**; critic: **APPROVE_WITH_NITS** (recorded in `.swarm/evidence/bundle-cap-08b-review.md` and `bundle-cap-09-critic.md`).

**Limitation:** the `smoke` job runs only on `merge_group` (skipped → success on `pull_request`), so this cap change is only exercised at merge-queue time — it cannot be fully validated by this PR's per-PR CI. Mirrors the validation limitation noted for #1570 and #1578.

Relates to #1582 (does not close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
