### PR TITLE
feat(sdd): GitHub Spec-Kit interop for /swarm sdd (v1)

### DIFF
--- a/docs/planning.md
+++ b/docs/planning.md
@@ -212,7 +212,7 @@ If you prefer to plan inside OpenCode rather than in a separate tool, the swarm 
 | `/swarm specify [description]` | You have a feature idea but no spec yet | Generates `.swarm/spec.md` with FR-### requirements, SC-### success criteria, and user scenarios |
 | `/swarm clarify [topic]` | Your spec has `[NEEDS CLARIFICATION]` markers or vague language | Asks targeted questions one at a time, updates spec.md after each accepted answer |
 | `/swarm analyze` | You have both a spec and a plan and want a coverage check | Maps FR-### requirements to plan tasks, flags gaps (untasked requirements) and gold-plating (untasked work) |
-| `/swarm sdd status|validate|project` | You keep requirements in OpenSpec-compatible files | Inspects `openspec/`, validates the projected effective spec, or materializes `.swarm/spec.md` |
+| `/swarm sdd status|validate|project` | You keep requirements in OpenSpec or Spec-Kit format | Inspects SDD source artifacts, validates or projects the effective spec; `--source <openspec|speckit>` disambiguates when both layouts are present |
 
 ### The Workflow
 
@@ -228,11 +228,69 @@ If you already have a plan (e.g. from a prior tool or another session), you can 
 **Using OpenSpec-compatible artifacts:**
 Keep current requirements in `openspec/specs/**/spec.md` and pending deltas in `openspec/changes/*/specs/**/spec.md`. When `.swarm/spec.md` is absent, planning, spec hashing, drift checks, linting, and requirement coverage use an effective Swarm spec projected from those artifacts. Run `/swarm sdd validate` before planning and `/swarm sdd project` when you want to materialize the projection into `.swarm/spec.md`.
 
+**Using Spec-Kit artifacts:**
+When your repository has a `.specify/` marker directory and `specs/<feature-dir>/spec.md` files, `/swarm sdd project` auto-detects the Spec-Kit layout and projects the feature into `.swarm/spec.md`. Use `--feature <id>` when multiple feature directories exist; see _Spec-Kit SDD support_ below for detection rules, feature selection, source precedence, and validation details.
+
 **Without a spec:**
 Planning works fine without a spec. When you enter PLAN mode without a spec.md, the architect offers to create one first or skip straight to planning. If you skip, planning behavior is identical to prior versions — no behavioral change.
 
 **Using General Council before planning:**
 When `council.general.enabled` is true and a Tavily or Brave search API key is configured, MODE: PLAN asks whether to use the three-agent General Council before `save_plan`. If accepted, the architect gathers current external context, records the council consensus/disagreements in `.swarm/context.md`, and uses that input before writing the plan and before critic pre-plan review.
+
+### Spec-Kit SDD support
+
+Starting with issue [#1228](https://github.com/ZaxbyHub/opencode-swarm/issues/1228), `/swarm sdd` detects and projects [GitHub Spec-Kit](https://github.com/github/spec-kit) artifacts alongside OpenSpec, so teams already using Spec-Kit can enforce their existing specs with the Swarm drift gate without rewriting anything.
+
+#### Detection
+
+A Spec-Kit layout is identified by two conditions being true simultaneously:
+
+- A `.specify/` marker directory at the repository root, **and**
+- One or more `specs/<feature-dir>/spec.md` files. Any non-symlink directory directly under `specs/` that contains a `spec.md` is detected as a feature; the `NNN-` numbering prefix (e.g. `001-my-feature`) is Spec-Kit convention, not an enforced rule.
+
+A repository that has a `specs/` directory but no `.specify/` marker is **not** treated as Spec-Kit. `/swarm sdd status` reports the Spec-Kit source in a dedicated section, separate from the OpenSpec output.
+
+#### Projection
+
+`/swarm sdd project` projects a single Spec-Kit feature into `.swarm/spec.md`:
+
+```
+/swarm sdd project                                             # auto-detect; single feature only
+/swarm sdd project --feature 001-my-feature                   # required when multiple features exist
+/swarm sdd project --source speckit --feature 001-my-feature  # explicit when both layouts are present
+```
+
+`--feature <id>` takes the full feature directory name (e.g. `001-my-feature`). It is required when more than one `specs/<dir>` exists and produces an error when used with `--source openspec` or `--source swarm`.
+
+Original `FR-###` identifiers in the feature's `spec.md` are preserved unchanged. When a requirement carries no explicit identifier, a stable one is synthesized — re-running the same source produces an identical projection. The resulting `.swarm/spec.md` is treated identically to an OpenSpec projection by all downstream tools: drift verification, lint, and requirement coverage apply with no source-specific handling.
+
+#### Source precedence
+
+When resolving which source feeds planning and drift enforcement:
+
+1. **Native `.swarm/spec.md` present** — always used, regardless of `--source`.
+2. **`--source <openspec|speckit>`** — explicit selection (applied after the native-spec check).
+3. **Auto-detect (no `--source`):**
+   - Only Spec-Kit detected → Spec-Kit projection used.
+   - Only OpenSpec detected → OpenSpec projection used (unchanged behavior).
+   - **Both detected, no `--source`** — the two paths differ by layer. For library consumers (planning/drift), `readEffectiveSpecSync` returns no effective spec and logs a single ambiguity warning, so drift enforcement degrades to advisory rather than guessing. The `/swarm sdd` commands (`status`, `validate`, `project`) treat the same situation as a **hard error**, naming both sources and requiring `--source` to disambiguate.
+
+`--source swarm` is accepted by `status` and `validate` but is rejected by `project` — the native `.swarm/spec.md` does not require projection.
+
+#### Validation (read-only)
+
+`/swarm sdd validate` inspects Spec-Kit artifacts and reports structural problems without modifying any file:
+
+- **Required sections** — `## Functional Requirements` and `## Success Criteria` must be present in `spec.md`.
+- **Task references** — Each checkbox task line that carries a `T###` id (e.g. `- [ ] T001 …`) must also carry a `[US#]` user-story tag or an `FR-###` requirement id; such task lines with neither are flagged. Lines without a `T###` id are not task lines and are not checked.
+- **Zero functional requirements** — A feature whose `spec.md` yields no parsable functional requirements is surfaced as a structural problem. Requirements include both explicit `FR-###` lines and id-less obligation bullets under `## Functional Requirements` (which are assigned synthesized ids); the problem fires only when neither form is present.
+
+`--source speckit` and `--feature <id>` apply to `validate` by the same rules as `project`.
+
+#### v1 boundaries
+
+- **Single-feature only.** When multiple `specs/<dir>` directories exist, exactly one must be selected with `--feature`; omitting it produces a hard error naming the detected features.
+- **Multi-feature aggregation** (projecting all features into one effective spec) and **round-trip `tasks.md` check-off** (writing completed tasks back to the source file) are deferred to issue [#1577](https://github.com/ZaxbyHub/opencode-swarm/issues/1577).
 
 ### Spec Format
 

--- a/docs/releases/pending/feat-1228-speckit-sdd-interop.md
+++ b/docs/releases/pending/feat-1228-speckit-sdd-interop.md
@@ -1,0 +1,36 @@
+# Spec-Kit SDD interop for `/swarm sdd`
+
+## What changed
+
+`/swarm sdd` now detects and consumes [GitHub Spec-Kit](https://github.com/github/spec-kit) artifacts (issue [#1228](https://github.com/ZaxbyHub/opencode-swarm/issues/1228)):
+
+- **Detection.** A `.specify/` marker directory alongside `specs/<feature-dir>/spec.md` files is recognized as a Spec-Kit layout. `/swarm sdd status` reports it as a distinct source, separate from the OpenSpec output.
+- **Projection.** `/swarm sdd project` projects a single Spec-Kit feature into `.swarm/spec.md`, preserving original `FR-###` identifiers and synthesizing stable identifiers when none are present. The resulting spec feeds drift verification, lint, and requirement coverage unchanged — identically to an OpenSpec projection.
+- **`--source <openspec|speckit>`** disambiguates when both SDD layouts are present in the same repository. Without `--source`, detecting both produces a hard error naming both sources and stating the remedy.
+- **`--feature <id>`** selects a specific Spec-Kit feature by its full directory name (e.g. `--feature 001-my-feature`). It is required when more than one feature directory exists and is invalid with `--source openspec` or `--source swarm`.
+- **Read-only validate.** `/swarm sdd validate` checks Spec-Kit artifacts — required `spec.md` sections, task lines without a spec or requirement reference, and features with zero functional requirements — without modifying any file.
+
+## Why
+
+Teams already using Spec-Kit mid-project can now enforce their existing specs with the Swarm drift gate without rewriting anything into Swarm's native format. The integration is incremental: OpenSpec behavior is byte-identical to before, and all downstream consumers of the effective-spec pipeline (drift gate, lint, requirement coverage, plan hashing, preflight) are unchanged.
+
+## How to use
+
+```
+/swarm sdd project                                             # auto-detect; single feature only
+/swarm sdd project --feature 001-my-feature                   # required when multiple features exist
+/swarm sdd project --source speckit --feature 001-my-feature  # explicit when both layouts are present
+/swarm sdd validate --source speckit --feature 001-my-feature # validate spec.md / tasks.md read-only
+/swarm sdd status                                              # shows Spec-Kit detection alongside OpenSpec
+```
+
+## Migration
+
+No migration required. Existing OpenSpec-only repositories are unaffected; the Spec-Kit detection path only activates when `.specify/` is present.
+
+## Known caveats and follow-ups
+
+- **Single-feature only (v1).** When multiple `specs/<dir>` directories exist, `--feature <id>` is required; omitting it is a hard error. Multi-feature aggregation and round-trip `tasks.md` check-off are tracked in issue [#1577](https://github.com/ZaxbyHub/opencode-swarm/issues/1577).
+- `--source swarm` is accepted by `status` and `validate` but is rejected by `project` — the native `.swarm/spec.md` does not require projection.
+
+Closes: #1228

--- a/docs/releases/pending/fix-sdd-validate-source-swarm.md
+++ b/docs/releases/pending/fix-sdd-validate-source-swarm.md
@@ -1,0 +1,33 @@
+# fix(sdd): --source swarm validate returns correct provider and validity
+
+## What changed
+
+`/swarm sdd validate --source swarm` previously fell through to the OpenSpec validation path, building an OpenSpec projection unconditionally and reporting `openspec_projection` as the provider instead of `swarm`. With only a native `.swarm/spec.md` and no OpenSpec, `valid` became `false` even for a perfectly valid swarm spec.
+
+The validate command now has a dedicated native-only branch for `--source swarm` that:
+- Calls `loadSddStatusSync` with `source: 'swarm'`
+- Filters out OpenSpec-specific errors and warnings
+- Returns `provider: 'swarm'` and `valid: true` when the native spec exists and is valid
+
+## Why
+
+The `--source` flag was added to `/swarm sdd status|validate|project` in #1228 (Spec-Kit interop v1), but the validate handler did not route `--source swarm` to a native-only path — it shared the OpenSpec fallback branch, producing incorrect provider and validity results. The status and project handlers already handled `--source swarm` correctly.
+
+## How to use
+
+No API change — `validate --source swarm` now works as documented:
+
+```sh
+/swarm sdd validate --source swarm
+/swarm sdd validate --source swarm --json
+```
+
+## Migration
+
+None — this is a bugfix. The `--source swarm` flag was documented but not correctly implemented in the validate subcommand.
+
+## Known caveats
+
+- The pre-existing `loadSddStatusSync` does not emit an error when a native spec is oversized (>256KiB); it silently returns `effectiveSpec: null`. This is a pre-existing gap, not introduced by this fix.
+
+Closes: #1589

--- a/src/commands/sdd.ts
+++ b/src/commands/sdd.ts
@@ -365,6 +365,51 @@ export async function handleSddValidateCommand(
 		].join('\n');
 	}
 
+	if (parsed.source === 'swarm') {
+		// Native-only validation branch for --source swarm (bugfix).
+		// Placed before OpenSpec path so provider/valid reflect native spec only.
+		const status = loadSddStatusSync(directory, {
+			source: 'swarm',
+			feature: parsed.feature,
+		});
+		const filteredErrors = status.errors.filter(
+			(e) =>
+				!e.includes('openspec/') &&
+				!e.includes('proposal.md') &&
+				!e.includes('tasks.md') &&
+				!e.includes('specs/**/spec.md'),
+		);
+		const filteredWarnings = status.warnings.filter(
+			(w) =>
+				!w.includes('openspec/') &&
+				!w.includes('proposal.md') &&
+				!w.includes('tasks.md') &&
+				!w.includes('specs/**/spec.md'),
+		);
+		const result = {
+			valid: status.effectiveSpec !== null && filteredErrors.length === 0,
+			provider: status.provider,
+			changeId: null as string | null,
+			sourcePaths: status.effectiveSpec?.sourcePaths ?? [],
+			hash: status.effectiveSpec?.hash ?? null,
+			errors: filteredErrors,
+			warnings: [
+				...filteredWarnings,
+				...(status.effectiveSpec?.warnings ?? []),
+			],
+		};
+		if (parsed.json) return JSON.stringify(result, null, 2);
+		return [
+			`SDD validation: ${result.valid ? 'valid' : 'invalid'}`,
+			`Provider: ${result.provider}`,
+			`Projected sources: ${result.sourcePaths.length}`,
+			result.errors.length > 0 ? `\nErrors:\n${formatList(result.errors)}` : '',
+			result.warnings.length > 0
+				? `\nWarnings:\n${formatList(result.warnings)}`
+				: '',
+		].join('\n');
+	}
+
 	// OpenSpec path — byte-identical to pre-task behavior (regression-guard, FR-011).
 	// Thread parsed.source/feature so --source openspec on a both-present repo does not
 	// trigger the resolver's console.warn inside loadSddStatusSync (advisor item 1).

--- a/src/commands/sdd.ts
+++ b/src/commands/sdd.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import type { SpeckitResolution } from '../sdd/effective-spec';
 import {
 	buildOpenSpecProjectionSync,
 	detectSpeckit,
@@ -8,7 +9,6 @@ import {
 	validateSpeckit,
 	writeProjectedSpecSync,
 } from '../sdd/effective-spec';
-import type { SpeckitResolution } from '../sdd/effective-spec';
 
 /**
  * Native swarm-spec relative path — MUST match the engine's
@@ -79,7 +79,8 @@ function parseArgs(args: string[]): ParsedSddArgs {
 			if (isUnsafeId(value)) {
 				return {
 					...parsed,
-					error: '--change must be a single OpenSpec change id with no path separators, traversal, or brackets',
+					error:
+						'--change must be a single OpenSpec change id with no path separators, traversal, or brackets',
 				};
 			}
 			parsed.changeId = value;
@@ -103,7 +104,8 @@ function parseArgs(args: string[]): ParsedSddArgs {
 			if (isUnsafeId(value)) {
 				return {
 					...parsed,
-					error: '--feature must be a single Spec-Kit feature directory name with no path separators, traversal, or brackets',
+					error:
+						'--feature must be a single Spec-Kit feature directory name with no path separators, traversal, or brackets',
 				};
 			}
 			parsed.feature = value;
@@ -356,9 +358,7 @@ export async function handleSddValidateCommand(
 			`SDD validation: ${result.valid ? 'valid' : 'invalid'}`,
 			`Provider: ${result.provider}`,
 			`Projected sources: ${result.sourcePaths.length}`,
-			result.errors.length > 0
-				? `\nErrors:\n${formatList(result.errors)}`
-				: '',
+			result.errors.length > 0 ? `\nErrors:\n${formatList(result.errors)}` : '',
 			result.warnings.length > 0
 				? `\nWarnings:\n${formatList(result.warnings)}`
 				: '',

--- a/src/commands/sdd.ts
+++ b/src/commands/sdd.ts
@@ -1,24 +1,57 @@
 import {
 	buildOpenSpecProjectionSync,
+	detectSpeckit,
 	loadSddStatusSync,
+	resolveSpeckitProjection,
+	validateSpeckit,
 	writeProjectedSpecSync,
 } from '../sdd/effective-spec';
+import type { SpeckitResolution } from '../sdd/effective-spec';
 
 const USAGE = `Usage:
-  /swarm sdd status [--json]
-  /swarm sdd validate [--json] [--change <id>]
-  /swarm sdd project [--dry-run] [--json] [--change <id>]
+  /swarm sdd status [--json] [--source <provider>]
+  /swarm sdd validate [--json] [--change <id>] [--source <provider>] [--feature <id>]
+  /swarm sdd project [--dry-run] [--json] [--change <id>] [--source <provider>] [--feature <id>]
+
+Source options (required when both openspec and speckit are detected):
+  --source <swarm|openspec|speckit>  select the SDD provider explicitly
+  --feature <id>                     Spec-Kit feature directory name to project
+                                     (required when multiple Spec-Kit features exist)
 
 OpenSpec-compatible SDD support:
   - reads checked-in openspec/specs and openspec/changes artifacts
   - produces one effective Swarm spec for planning
-  - keeps tasks.md as proposal input; .swarm/plan-ledger.jsonl remains execution state`;
+  - keeps tasks.md as proposal input; .swarm/plan-ledger.jsonl remains execution state
+
+Spec-Kit SDD support:
+  - detects .specify/ marker + specs/NNN-feature-name/spec.md layout
+  - projects a single Spec-Kit feature into .swarm/spec.md via /swarm sdd project
+  - use --source speckit or --source openspec to disambiguate when both are present`;
 
 interface ParsedSddArgs {
 	json: boolean;
 	dryRun: boolean;
 	changeId?: string;
+	source?: 'swarm' | 'openspec' | 'speckit';
+	feature?: string;
 	error?: string;
+}
+
+/**
+ * Returns true when `value` contains characters that are unsafe in a directory
+ * name id: path separators, traversal sequences, or bracket characters.
+ *
+ * Shared by both --change and --feature so the same rejection logic is reused
+ * (task 2.2 explicit requirement; matches sdd.ts:36-49 pre-task baseline).
+ */
+function isUnsafeId(value: string): boolean {
+	return (
+		value.includes('/') ||
+		value.includes('\\') ||
+		value.includes('..') ||
+		value.includes('[') ||
+		value.includes(']')
+	);
 }
 
 function parseArgs(args: string[]): ParsedSddArgs {
@@ -34,20 +67,37 @@ function parseArgs(args: string[]): ParsedSddArgs {
 				return { ...parsed, error: '--change requires a value' };
 			}
 			const value = args[++i];
-			if (
-				value.includes('/') ||
-				value.includes('\\') ||
-				value.includes('..') ||
-				value.includes('[') ||
-				value.includes(']')
-			) {
+			if (isUnsafeId(value)) {
 				return {
 					...parsed,
-					error:
-						'--change must be a single OpenSpec change id with no path separators, traversal, or brackets',
+					error: '--change must be a single OpenSpec change id with no path separators, traversal, or brackets',
 				};
 			}
 			parsed.changeId = value;
+		} else if (token === '--source') {
+			if (i + 1 >= args.length || args[i + 1].startsWith('--')) {
+				return { ...parsed, error: '--source requires a value' };
+			}
+			const value = args[++i];
+			if (value !== 'swarm' && value !== 'openspec' && value !== 'speckit') {
+				return {
+					...parsed,
+					error: `--source must be one of: swarm | openspec | speckit; got "${value}"`,
+				};
+			}
+			parsed.source = value as 'swarm' | 'openspec' | 'speckit';
+		} else if (token === '--feature') {
+			if (i + 1 >= args.length || args[i + 1].startsWith('--')) {
+				return { ...parsed, error: '--feature requires a value' };
+			}
+			const value = args[++i];
+			if (isUnsafeId(value)) {
+				return {
+					...parsed,
+					error: '--feature must be a single Spec-Kit feature directory name with no path separators, traversal, or brackets',
+				};
+			}
+			parsed.feature = value;
 		} else {
 			return { ...parsed, error: `Unknown flag "${token}"` };
 		}
@@ -61,19 +111,99 @@ function formatList(items: string[]): string {
 		: '- none';
 }
 
+/**
+ * Map a non-ok SpeckitResolution to a user-facing error string (FR-008, FR-013).
+ * Covers every non-ok kind so the command layer never re-detects ad hoc.
+ */
+function formatSpeckitError(resolution: SpeckitResolution): string {
+	switch (resolution.kind) {
+		case 'empty':
+			return 'Spec-Kit layout detected (.specify/ marker present) but no feature directories found under specs/.';
+		case 'ambiguous':
+			return [
+				`Multiple Spec-Kit features detected: ${resolution.features.join(', ')}.`,
+				'Use --feature <id> to select one.',
+			].join('\n');
+		case 'unknown_feature':
+			return [
+				`Unknown Spec-Kit feature '${resolution.feature}'.`,
+				`Available features: ${resolution.available.join(', ')}.`,
+			].join('\n');
+		case 'zero_requirements':
+			return `Spec-Kit feature '${resolution.feature}' contains no parsable functional requirements.`;
+		case 'too_large':
+			return `Spec-Kit feature '${resolution.feature}' projected output exceeds the size limit (${resolution.bytes} bytes).`;
+		case 'not_speckit':
+			return 'No Spec-Kit layout detected (.specify/ marker not present).';
+		case 'ok':
+			// Should not be reached — callers guard on kind !== 'ok' before calling.
+			return '';
+	}
+}
+
 export async function handleSddStatusCommand(
 	directory: string,
 	args: string[],
 ): Promise<string> {
 	const parsed = parseArgs(args);
 	if (parsed.error) return `Error: ${parsed.error}\n\n${USAGE}`;
-	const status = loadSddStatusSync(directory);
-	if (parsed.json) return JSON.stringify(status, null, 2);
+
+	// --feature is only meaningful with Spec-Kit.
+	if (parsed.feature && parsed.source && parsed.source !== 'speckit') {
+		return `Error: --feature is only valid with --source speckit\n\n${USAGE}`;
+	}
+
+	// Call detectSpeckit directly — SddStatus/loadSddStatusSync are OpenSpec-only
+	// and carry no Spec-Kit fields (task 2.2; plan.md critic Finding 3).
+	// Do this BEFORE loadSddStatusSync so we can short-circuit on ambiguity without
+	// triggering the resolver's console.warn (which fires inside readEffectiveSpecSync).
+	const speckitDetection = detectSpeckit(directory);
+	const speckitPresent = speckitDetection.features.length > 0;
+
+	// FR-009/010: both sources present and no --source → hard error naming both.
+	// Discriminator mirrors readEffectiveSpecSync: speckitPresent = features.length > 0,
+	// openspecPresent = buildOpenSpecProjectionSync !== null.
+	if (speckitPresent && !parsed.source) {
+		const openspecProjection = buildOpenSpecProjectionSync(directory);
+		if (openspecProjection !== null) {
+			const errLines = [
+				'Error: Multiple SDD sources detected (openspec, speckit).',
+				'Pass --source openspec or --source speckit to select a provider.',
+			];
+			return parsed.json
+				? JSON.stringify(
+						{ error: errLines.join(' '), sources: ['openspec', 'speckit'] },
+						null,
+						2,
+					)
+				: errLines.join('\n');
+		}
+	}
+
+	// Thread --source/--feature so an explicit selection wins (FR-009). The no-source
+	// both-present case is already short-circuited above, so this only affects the
+	// explicit-selection path and never triggers the resolver's ambiguity console.warn.
+	const status = loadSddStatusSync(directory, {
+		source: parsed.source,
+		feature: parsed.feature,
+	});
+
+	if (parsed.json) {
+		return JSON.stringify({ ...status, speckit: speckitDetection }, null, 2);
+	}
 
 	const changes = status.changes.map(
 		(change) =>
 			`${change.id} (${change.specs.length} spec file${change.specs.length === 1 ? '' : 's'}, proposal=${change.proposal}, design=${change.design}, tasks=${change.tasks})`,
 	);
+
+	const speckitLines = [
+		'### Spec-Kit',
+		`Spec-Kit provider: ${speckitDetection.markerPresent ? 'detected' : 'not present'}`,
+		speckitDetection.features.length > 0
+			? `Features:\n${speckitDetection.features.map((f) => `- ${f.featureId}`).join('\n')}`
+			: 'Features: none',
+	].join('\n');
 
 	return [
 		'## SDD Status',
@@ -83,6 +213,8 @@ export async function handleSddStatusCommand(
 		`OpenSpec root: ${status.openSpecExists ? 'present' : 'missing'}`,
 		`Current OpenSpec specs: ${status.currentSpecs.length}`,
 		`Active OpenSpec changes: ${status.changes.length}`,
+		'',
+		speckitLines,
 		'',
 		'### Changes',
 		formatList(changes),
@@ -109,7 +241,116 @@ export async function handleSddValidateCommand(
 ): Promise<string> {
 	const parsed = parseArgs(args);
 	if (parsed.error) return `Error: ${parsed.error}\n\n${USAGE}`;
-	const status = loadSddStatusSync(directory);
+
+	// --feature is only meaningful with Spec-Kit (same guard as status/project).
+	if (parsed.feature && parsed.source && parsed.source !== 'speckit') {
+		return `Error: --feature is only valid with --source speckit\n\n${USAGE}`;
+	}
+
+	// Determine whether to use the Spec-Kit validation path.
+	// Mirrors the detection logic from handleSddProjectCommand (task 2.2).
+	let useSpeckit = false;
+
+	if (parsed.source === 'speckit') {
+		useSpeckit = true;
+	} else if (!parsed.source) {
+		// Auto-detect: check for Spec-Kit marker and feature dirs.
+		const speckitDetection = detectSpeckit(directory);
+
+		if (speckitDetection.features.length > 0) {
+			// Spec-Kit features present — check for OpenSpec ambiguity.
+			const openspecProjection = buildOpenSpecProjectionSync(directory);
+			if (openspecProjection !== null) {
+				// FR-009/010: both sources present, no --source → hard error naming both.
+				// Reuses the same messaging path task 2.2 added (no second messaging scheme).
+				const errLines = [
+					'Error: Multiple SDD sources detected (openspec, speckit).',
+					'Pass --source openspec or --source speckit to select a provider.',
+				];
+				// valid:false keeps validate's --json error shape uniform across all
+				// three Spec-Kit error paths (multi-source, FR-012 empty, resolution-level).
+				return parsed.json
+					? JSON.stringify(
+							{
+								valid: false,
+								error: errLines.join(' '),
+								sources: ['openspec', 'speckit'],
+							},
+							null,
+							2,
+						)
+					: errLines.join('\n');
+			}
+			useSpeckit = true;
+		} else if (speckitDetection.markerPresent) {
+			// FR-012: .specify/ marker present but no feature dirs (detected-but-empty).
+			const openspecProjection = buildOpenSpecProjectionSync(directory);
+			if (openspecProjection === null) {
+				const resolution = resolveSpeckitProjection(directory);
+				return parsed.json
+					? JSON.stringify(
+							{ valid: false, error: formatSpeckitError(resolution) },
+							null,
+							2,
+						)
+					: `Error: ${formatSpeckitError(resolution)}\n\n${USAGE}`;
+			}
+			// OpenSpec compensates — fall through to the OpenSpec path.
+		}
+		// else: no .specify/ marker → fall through to OpenSpec path.
+	}
+	// parsed.source === 'openspec' → useSpeckit = false (OpenSpec path, byte-identical regression guard).
+
+	if (useSpeckit) {
+		// Spec-Kit validation path (FR-007, FR-013).
+		const { resolution, problems } = validateSpeckit(directory, {
+			feature: parsed.feature,
+		});
+
+		if (resolution.kind !== 'ok' && resolution.kind !== 'zero_requirements') {
+			// Resolution-level error — reuse the task 2.2 messaging path (FR-008/012).
+			return parsed.json
+				? JSON.stringify(
+						{ valid: false, error: formatSpeckitError(resolution) },
+						null,
+						2,
+					)
+				: `Error: ${formatSpeckitError(resolution)}\n\n${USAGE}`;
+		}
+
+		// Projection metadata comes from the ok-resolution spec (or nulls for zero_requirements).
+		const spec = resolution.kind === 'ok' ? resolution.spec : null;
+		const result = {
+			valid: problems.length === 0 && resolution.kind === 'ok',
+			provider: 'speckit_projection' as const,
+			changeId: null as string | null,
+			sourcePaths: spec?.sourcePaths ?? [],
+			hash: spec?.hash ?? null,
+			errors: problems,
+			warnings: spec?.warnings ?? [],
+		};
+
+		if (parsed.json) return JSON.stringify(result, null, 2);
+		return [
+			`SDD validation: ${result.valid ? 'valid' : 'invalid'}`,
+			`Provider: ${result.provider}`,
+			`Projected sources: ${result.sourcePaths.length}`,
+			result.errors.length > 0
+				? `\nErrors:\n${formatList(result.errors)}`
+				: '',
+			result.warnings.length > 0
+				? `\nWarnings:\n${formatList(result.warnings)}`
+				: '',
+		].join('\n');
+	}
+
+	// OpenSpec path — byte-identical to pre-task behavior (regression-guard, FR-011).
+	// Thread parsed.source/feature so --source openspec on a both-present repo does not
+	// trigger the resolver's console.warn inside loadSddStatusSync (advisor item 1).
+	const status = loadSddStatusSync(directory, {
+		source: parsed.source,
+		feature: parsed.feature,
+	});
 	const projection = buildOpenSpecProjectionSync(directory, {
 		changeId: parsed.changeId,
 	});
@@ -157,6 +398,100 @@ export async function handleSddProjectCommand(
 ): Promise<string> {
 	const parsed = parseArgs(args);
 	if (parsed.error) return `Error: ${parsed.error}\n\n${USAGE}`;
+
+	// --feature is only meaningful with Spec-Kit.
+	if (parsed.feature && parsed.source && parsed.source !== 'speckit') {
+		return `Error: --feature is only valid with --source speckit\n\n${USAGE}`;
+	}
+
+	// --source swarm selects the native .swarm/spec.md and cannot generate a projection.
+	if (parsed.source === 'swarm') {
+		return `Error: --source swarm selects the native .swarm/spec.md and does not generate a projection. Use --source openspec or --source speckit.\n\n${USAGE}`;
+	}
+
+	// Determine whether to use the Spec-Kit projection path.
+	let useSpeckit = false;
+
+	if (parsed.source === 'speckit') {
+		useSpeckit = true;
+	} else if (!parsed.source) {
+		// Auto-detect: check for Spec-Kit marker and feature dirs.
+		const speckitDetection = detectSpeckit(directory);
+
+		if (speckitDetection.features.length > 0) {
+			// Spec-Kit present (features.length > 0 mirrors readEffectiveSpecSync discriminator).
+			// Check for openspec using the same predicate as the resolver.
+			const openspecProjection = buildOpenSpecProjectionSync(directory);
+			if (openspecProjection !== null) {
+				// FR-009/010: both sources present, no --source → hard error naming both.
+				return [
+					'Error: Multiple SDD sources detected (openspec, speckit).',
+					'Pass --source openspec or --source speckit to select a provider.',
+				].join('\n');
+			}
+			useSpeckit = true;
+		} else if (speckitDetection.markerPresent) {
+			// FR-012: .specify/ marker present but no feature dirs (detected-but-empty).
+			// Only error when OpenSpec is also absent — with OpenSpec present, empty .specify/
+			// is a non-competing source and the OpenSpec path is correct (mirrors 2.1 resolver).
+			const openspecProjection = buildOpenSpecProjectionSync(directory);
+			if (openspecProjection === null) {
+				const resolution = resolveSpeckitProjection(directory);
+				return `Error: ${formatSpeckitError(resolution)}\n\n${USAGE}`;
+			}
+			// OpenSpec compensates — fall through to the OpenSpec projection path.
+		}
+		// else: no .specify/ marker → fall through to OpenSpec path.
+	}
+	// parsed.source === 'openspec' → useSpeckit = false (OpenSpec path, default behavior).
+
+	if (useSpeckit) {
+		// Spec-Kit projection path (FR-002, FR-008, FR-013).
+		const resolution = resolveSpeckitProjection(directory, {
+			feature: parsed.feature,
+		});
+		if (resolution.kind !== 'ok') {
+			return `Error: ${formatSpeckitError(resolution)}\n\n${USAGE}`;
+		}
+
+		// Reuse the atomic-write + archive logic in writeProjectedSpecSync (task 2.2).
+		// Pass resolution.feature so the auto-selected feature id is always explicit.
+		const result = writeProjectedSpecSync(directory, {
+			source: 'speckit',
+			feature: resolution.feature,
+			dryRun: parsed.dryRun,
+		});
+
+		const response = {
+			written: result.written,
+			dryRun: parsed.dryRun,
+			path: result.path,
+			archivePath: result.archivePath ?? null,
+			hash: result.projection?.hash ?? null,
+			sourcePaths: result.projection?.sourcePaths ?? [],
+			warnings: result.projection?.warnings ?? [],
+		};
+		if (parsed.json) return JSON.stringify(response, null, 2);
+		if (!result.projection) {
+			return [
+				'SDD projection failed: no valid Spec-Kit projection could be built.',
+				'',
+				USAGE,
+			].join('\n');
+		}
+		return [
+			parsed.dryRun ? 'SDD projection preview' : 'SDD projection written',
+			`Path: ${result.path}`,
+			`Hash: ${result.projection.hash}`,
+			`Sources: ${result.projection.sourcePaths.length}`,
+			result.archivePath ? `Archived previous spec: ${result.archivePath}` : '',
+			result.projection.warnings.length > 0
+				? `\nWarnings:\n${formatList(result.projection.warnings)}`
+				: '',
+		].join('\n');
+	}
+
+	// OpenSpec projection path — byte-identical to pre-task behavior (FR-011).
 	const result = writeProjectedSpecSync(directory, {
 		changeId: parsed.changeId,
 		dryRun: parsed.dryRun,

--- a/src/commands/sdd.ts
+++ b/src/commands/sdd.ts
@@ -9,6 +9,7 @@ import {
 	validateSpeckit,
 	writeProjectedSpecSync,
 } from '../sdd/effective-spec';
+import { containsControlChars } from '../utils/path-security';
 
 /**
  * Native swarm-spec relative path — MUST match the engine's
@@ -48,10 +49,11 @@ interface ParsedSddArgs {
 
 /**
  * Returns true when `value` contains characters that are unsafe in a directory
- * name id: path separators, traversal sequences, or bracket characters.
+ * name id: path separators, traversal sequences, bracket characters, or control/bidi
+ * characters.
  *
  * Shared by both --change and --feature so the same rejection logic is reused
- * (task 2.2 explicit requirement; matches sdd.ts:36-49 pre-task baseline).
+ * (task 2.2 explicit requirement; matches the pre-task baseline).
  */
 function isUnsafeId(value: string): boolean {
 	return (
@@ -59,7 +61,12 @@ function isUnsafeId(value: string): boolean {
 		value.includes('\\') ||
 		value.includes('..') ||
 		value.includes('[') ||
-		value.includes(']')
+		value.includes(']') ||
+		// Reject control/bidi characters (null bytes, RTL override, etc.) — aligns with
+		// the repo's canonical containsControlChars used by validateDirectory. Defense-
+		// in-depth: current callers exact-match the value against detected dir names, so
+		// there is no path-construction exploit today, but this keeps the guard consistent.
+		containsControlChars(value)
 	);
 }
 
@@ -80,7 +87,7 @@ function parseArgs(args: string[]): ParsedSddArgs {
 				return {
 					...parsed,
 					error:
-						'--change must be a single OpenSpec change id with no path separators, traversal, or brackets',
+						'--change must be a single OpenSpec change id with no path separators, traversal, brackets, or control characters',
 				};
 			}
 			parsed.changeId = value;
@@ -105,7 +112,7 @@ function parseArgs(args: string[]): ParsedSddArgs {
 				return {
 					...parsed,
 					error:
-						'--feature must be a single Spec-Kit feature directory name with no path separators, traversal, or brackets',
+						'--feature must be a single Spec-Kit feature directory name with no path separators, traversal, brackets, or control characters',
 				};
 			}
 			parsed.feature = value;

--- a/src/commands/sdd.ts
+++ b/src/commands/sdd.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {
 	buildOpenSpecProjectionSync,
 	detectSpeckit,
@@ -7,6 +9,13 @@ import {
 	writeProjectedSpecSync,
 } from '../sdd/effective-spec';
 import type { SpeckitResolution } from '../sdd/effective-spec';
+
+/**
+ * Native swarm-spec relative path — MUST match the engine's
+ * `SWARM_SPEC_REL` in src/sdd/effective-spec.ts so the command layer's native
+ * precedence check (FR-009) agrees with the resolver's branch (a).
+ */
+const SWARM_SPEC_REL = path.join('.swarm', 'spec.md');
 
 const USAGE = `Usage:
   /swarm sdd status [--json] [--source <provider>]
@@ -159,11 +168,17 @@ export async function handleSddStatusCommand(
 	// triggering the resolver's console.warn (which fires inside readEffectiveSpecSync).
 	const speckitDetection = detectSpeckit(directory);
 	const speckitPresent = speckitDetection.features.length > 0;
+	// FR-009 step 1 / planning.md:271: a native .swarm/spec.md ALWAYS wins, even over an
+	// ambiguous openspec+speckit pair. Only fire the both-detected hard error when no
+	// native spec exists; otherwise fall through to loadSddStatusSync, whose
+	// readEffectiveSpecSync resolves native-first (branch a) and never reaches the
+	// resolver's ambiguity console.warn.
+	const nativeSpecExists = fs.existsSync(path.join(directory, SWARM_SPEC_REL));
 
 	// FR-009/010: both sources present and no --source → hard error naming both.
 	// Discriminator mirrors readEffectiveSpecSync: speckitPresent = features.length > 0,
 	// openspecPresent = buildOpenSpecProjectionSync !== null.
-	if (speckitPresent && !parsed.source) {
+	if (speckitPresent && !parsed.source && !nativeSpecExists) {
 		const openspecProjection = buildOpenSpecProjectionSync(directory);
 		if (openspecProjection !== null) {
 			const errLines = [
@@ -251,9 +266,15 @@ export async function handleSddValidateCommand(
 	// Mirrors the detection logic from handleSddProjectCommand (task 2.2).
 	let useSpeckit = false;
 
+	// FR-009 step 1 / planning.md:271: a native .swarm/spec.md ALWAYS wins. When one
+	// exists and the user gave no explicit --source, skip Spec-Kit auto-detect entirely
+	// (so the both-detected hard error never fires) and fall through to the OpenSpec/native
+	// path below, where loadSddStatusSync resolves native-first via readEffectiveSpecSync.
+	const nativeSpecExists = fs.existsSync(path.join(directory, SWARM_SPEC_REL));
+
 	if (parsed.source === 'speckit') {
 		useSpeckit = true;
-	} else if (!parsed.source) {
+	} else if (!parsed.source && !nativeSpecExists) {
 		// Auto-detect: check for Spec-Kit marker and feature dirs.
 		const speckitDetection = detectSpeckit(directory);
 

--- a/src/sdd/effective-spec.test.ts
+++ b/src/sdd/effective-spec.test.ts
@@ -11,6 +11,7 @@ import {
 	loadSddStatusSync,
 	readEffectiveSpecSync,
 	resolveSpeckitProjection,
+	validateSpeckit,
 	writeProjectedSpecSync,
 } from './effective-spec';
 
@@ -442,5 +443,301 @@ describe('resolveSpeckitProjection — discriminated resolution (task 1.4)', () 
 		}
 		expect(resolution.feature).toBe('001-huge');
 		expect(resolution.bytes).toBeGreaterThan(256 * 1024);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// readEffectiveSpecSync — resolver precedence (task 2.1, FR-009/010/011)
+// ---------------------------------------------------------------------------
+describe('readEffectiveSpecSync — resolver precedence (task 2.1)', () => {
+	test('openspec-only (no .specify/): returns byte-identical output to buildOpenSpecProjectionSync (FR-011)', () => {
+		// OpenSpec layout with no .specify/ marker at all.
+		write(
+			path.join('openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow users to sign in.\n',
+		);
+
+		const viaResolver = readEffectiveSpecSync(tempDir);
+		const viaDirect = buildOpenSpecProjectionSync(tempDir);
+
+		// Byte-identical proof (FR-011): not just non-null, but the same content.
+		expect(viaResolver).not.toBeNull();
+		expect(viaResolver?.source).toBe('openspec_projection');
+		expect(viaResolver?.content).toBe(viaDirect?.content);
+	});
+
+	test('.swarm/spec.md + speckit layout, no opts → swarm wins (native spec always takes precedence)', () => {
+		write(
+			path.join('.swarm', 'spec.md'),
+			'# Specification: Swarm Native\n\n## Requirements\n- FR-001 MUST use the native Swarm spec.\n',
+		);
+		// Also write a speckit layout so the resolver would have a speckit candidate.
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		const spec = readEffectiveSpecSync(tempDir);
+
+		expect(spec?.source).toBe('swarm');
+		expect(spec?.content).toContain('Swarm Native');
+	});
+
+	test('.swarm/spec.md present: swarm wins even when opts.source explicitly names another provider (FR-009 1a)', () => {
+		// This test guards the "native swarm spec always wins, even over opts.source"
+		// invariant.  A refactor that checked opts.source before the swarm-file read
+		// would break this test while still passing the no-opts tests above.
+		write(
+			path.join('.swarm', 'spec.md'),
+			'# Specification: Swarm Native\n\n## Requirements\n- FR-001 MUST use the native Swarm spec.\n',
+		);
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		// opts.source: 'speckit' explicitly requests Spec-Kit — swarm must still win.
+		const specViaSpeckit = readEffectiveSpecSync(tempDir, { source: 'speckit' });
+		expect(specViaSpeckit?.source).toBe('swarm');
+		expect(specViaSpeckit?.content).toContain('Swarm Native');
+
+		// opts.source: 'openspec' — same invariant.
+		const specViaOpenspec = readEffectiveSpecSync(tempDir, { source: 'openspec' });
+		expect(specViaOpenspec?.source).toBe('swarm');
+	});
+
+	test('opts.source swarm with no .swarm/spec.md → null (explicit swarm source, file absent)', () => {
+		// No .swarm/spec.md is written.  opts.source: 'swarm' with no file → null.
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		const spec = readEffectiveSpecSync(tempDir, { source: 'swarm' });
+
+		expect(spec).toBeNull();
+	});
+
+	test('speckit-only (no openspec, no .swarm/spec.md): returns speckit projection (source speckit_projection)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		const spec = readEffectiveSpecSync(tempDir);
+
+		expect(spec).not.toBeNull();
+		expect(spec?.source).toBe('speckit_projection');
+		expect(spec?.sourcePaths).toEqual(['specs/001-auth-service/spec.md']);
+	});
+
+	test('opts.source speckit: selects Spec-Kit even when openspec is also present', () => {
+		// Write both sources.
+		write(
+			path.join('openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
+		);
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		const spec = readEffectiveSpecSync(tempDir, { source: 'speckit' });
+
+		expect(spec?.source).toBe('speckit_projection');
+	});
+
+	test('opts.source openspec: selects OpenSpec even when .specify/ also exists', () => {
+		// Write both sources.
+		write(
+			path.join('openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
+		);
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		const spec = readEffectiveSpecSync(tempDir, { source: 'openspec' });
+
+		expect(spec?.source).toBe('openspec_projection');
+	});
+
+	test('BOTH openspec + valid single-feature speckit, no source: returns null AND console.warn fires (FR-010, anti-silent-suppression)', () => {
+		// OpenSpec layout that yields a real projection (needs a parsable requirement).
+		write(
+			path.join('openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow users to sign in.\n',
+		);
+		// Valid single-feature Spec-Kit layout — must be non-empty so it registers
+		// as a competing source (plan.md task 3.1; test note: "NOT empty, or it
+		// won't register as a competing source").
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		// Manual console.warn capture: portable across bun:test versions where
+		// spyOn(console, 'warn') + mockRestore() before assertions clears call history.
+		// This approach intercepts console.warn at the JS property level — the diagnostic
+		// fires through the same `console.warn(...)` call in effective-spec.ts.
+		const warnMessages: string[] = [];
+		const realWarn = console.warn;
+		console.warn = (...args: unknown[]) => {
+			warnMessages.push(args.map(String).join(' '));
+		};
+
+		let result: ReturnType<typeof readEffectiveSpecSync>;
+		try {
+			result = readEffectiveSpecSync(tempDir);
+		} finally {
+			// Restore before any throw so the test suite output stays clean.
+			console.warn = realWarn;
+		}
+
+		// Return value must be null (ambiguous → no effective spec).
+		expect(result!).toBeNull();
+
+		// Diagnostic MUST have fired — independent of the null return.
+		// This is the anti-silent-suppression contract from critic Finding 2:
+		// returning null downgrades the drift gate to advisory-only; without this
+		// warn a repo that had ONE source (enforcing) would silently stop enforcing
+		// when a second inert source is added, with no observable signal.
+		expect(warnMessages.length).toBeGreaterThan(0);
+		const firstMsg = warnMessages[0] ?? '';
+		// Message must name the disambiguation flag.
+		expect(firstMsg).toContain('--source');
+		// Message must name the detected sources so the developer knows what to pick.
+		expect(firstMsg.toLowerCase()).toContain('openspec');
+		expect(firstMsg.toLowerCase()).toContain('speckit');
+	});
+
+	test('empty .specify/ + valid openspec: returns openspec projection, console.warn NOT called (discriminator proof)', () => {
+		// This test proves "Spec-Kit present" uses features.length > 0, NOT just
+		// markerPresent.  An empty .specify/ (no feature dirs) must NOT be treated
+		// as a competing source — the resolver must fall through to openspec silently.
+		// If we used markerPresent as the discriminator, this test would fail because
+		// markerPresent=true for empty-specify and we would emit the warn + return null.
+		writeSpeckitFixture(tempDir, { variant: 'empty-specify' });
+		write(
+			path.join('openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow users to sign in.\n',
+		);
+
+		const warnMessages: string[] = [];
+		const realWarn = console.warn;
+		console.warn = (...args: unknown[]) => {
+			warnMessages.push(args.map(String).join(' '));
+		};
+
+		let result: ReturnType<typeof readEffectiveSpecSync>;
+		try {
+			result = readEffectiveSpecSync(tempDir);
+		} finally {
+			console.warn = realWarn;
+		}
+
+		// Should return the openspec projection — not null, no diagnostic.
+		expect(result?.source).toBe('openspec_projection');
+		expect(warnMessages).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// validateSpeckit — structural validation, read-only (task 2.3, FR-007/013)
+// ---------------------------------------------------------------------------
+describe('validateSpeckit — structural validation (task 2.3, FR-007, FR-013)', () => {
+	test('valid single-feature Spec-Kit: resolution is ok and no problems reported', () => {
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		const { resolution, problems } = validateSpeckit(tempDir);
+
+		expect(resolution.kind).toBe('ok');
+		expect(problems).toHaveLength(0);
+	});
+
+	test('malformed fixture: reports missing ## Success Criteria AND T001 missing [US#] (FR-007)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'malformed' });
+
+		const { resolution, problems } = validateSpeckit(tempDir);
+
+		// malformed has FR bullets → resolution ok (missing section does not affect resolution)
+		expect(resolution.kind).toBe('ok');
+		// Must flag the missing Success Criteria section.
+		expect(problems.some((p) => p.includes('## Success Criteria'))).toBe(true);
+		// Must flag T001 (which has [P] but no [US#]).
+		expect(problems.some((p) => p.includes('T001'))).toBe(true);
+		// Must NOT flag T002 (which has [US1]).
+		expect(problems.some((p) => p.includes('T002'))).toBe(false);
+		// Both problems detected — at least two problems total.
+		expect(problems.length).toBeGreaterThanOrEqual(2);
+	});
+
+	test('task-reference check accepts an FR-### reference, not only [US#] (FR-007 — no false positive)', () => {
+		// Valid feature (both required sections + FRs → resolution ok), with a custom
+		// tasks.md exercising the three cases: story ref, requirement ref, and neither.
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+		const tasksPath = path.join(tempDir, 'specs', '001-auth-service', 'tasks.md');
+		fs.writeFileSync(
+			tasksPath,
+			[
+				'# Tasks',
+				'',
+				'- [ ] T001 [P] [US1] Implement the story-referenced task in src/a.ts',
+				'- [ ] T002 [P] [FR-001] Implement the requirement-referenced task in src/b.ts',
+				'- [ ] T003 [P] Setup task with no reference at all in src/c.ts',
+				'',
+			].join('\n'),
+			'utf-8',
+		);
+
+		const { resolution, problems } = validateSpeckit(tempDir);
+
+		expect(resolution.kind).toBe('ok');
+		// T001 ([US1]) and T002 ([FR-001]) both carry a valid reference → NOT flagged.
+		expect(problems.some((p) => p.includes('T001'))).toBe(false);
+		expect(problems.some((p) => p.includes('T002'))).toBe(false);
+		// T003 references neither a story nor a requirement → flagged.
+		expect(problems.some((p) => p.includes('T003'))).toBe(true);
+	});
+
+	test('zero-fr fixture: reports zero_requirements problem and no false missing-section error (FR-013)', () => {
+		// zero-fr has BOTH required sections but no FR bullets.
+		writeSpeckitFixture(tempDir, { variant: 'zero-fr' });
+
+		const { resolution, problems } = validateSpeckit(tempDir);
+
+		expect(resolution.kind).toBe('zero_requirements');
+		// Zero-requirements problem must be present.
+		expect(
+			problems.some((p) =>
+				p.toLowerCase().includes('no parsable functional requirements'),
+			),
+		).toBe(true);
+		// Section check still runs on the readable spec.md and MUST NOT flag
+		// missing sections (zero-fr has both ## Functional Requirements and ## Success Criteria).
+		expect(problems.some((p) => p.includes('## Functional Requirements'))).toBe(
+			false,
+		);
+		expect(problems.some((p) => p.includes('## Success Criteria'))).toBe(false);
+	});
+
+	test('READ-ONLY proof: spec.md and tasks.md bytes unchanged after validateSpeckit (FR-007)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'malformed' });
+
+		const specPath = path.join(
+			tempDir,
+			'specs',
+			'001-broken-feature',
+			'spec.md',
+		);
+		const tasksPath = path.join(
+			tempDir,
+			'specs',
+			'001-broken-feature',
+			'tasks.md',
+		);
+		const specBefore = fs.readFileSync(specPath, 'utf-8');
+		const tasksBefore = fs.readFileSync(tasksPath, 'utf-8');
+
+		validateSpeckit(tempDir);
+
+		// File content must be byte-for-byte identical after the call.
+		expect(fs.readFileSync(specPath, 'utf-8')).toBe(specBefore);
+		expect(fs.readFileSync(tasksPath, 'utf-8')).toBe(tasksBefore);
+		// The .swarm directory must NOT have been created (no write-back of any kind).
+		expect(fs.existsSync(path.join(tempDir, '.swarm', 'spec.md'))).toBe(false);
+	});
+
+	test('not_speckit resolution: no problems, resolution.kind is not_speckit', () => {
+		// No .specify/ marker — validate on an openspec-only repo should get not_speckit.
+		write(
+			path.join('openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
+		);
+
+		const { resolution, problems } = validateSpeckit(tempDir);
+
+		expect(resolution.kind).toBe('not_speckit');
+		expect(problems).toHaveLength(0);
 	});
 });

--- a/src/sdd/effective-spec.test.ts
+++ b/src/sdd/effective-spec.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { validateSpecContent } from '../config/spec-schema';
 import { writeSpeckitFixture } from '../../tests/helpers/speckit-fixture';
+import { validateSpecContent } from '../config/spec-schema';
 import {
 	buildOpenSpecProjectionSync,
 	buildSpeckitProjectionSync,
@@ -149,7 +149,9 @@ describe('detectSpeckit', () => {
 		expect(result.markerPresent).toBe(true);
 		expect(result.features).toHaveLength(1);
 		expect(result.features[0]?.featureId).toBe('001-auth-service');
-		expect(result.features[0]?.specRelPath).toBe('specs/001-auth-service/spec.md');
+		expect(result.features[0]?.specRelPath).toBe(
+			'specs/001-auth-service/spec.md',
+		);
 	});
 
 	test('detects a multi-feature layout and enumerates both features in sorted order', () => {
@@ -226,7 +228,9 @@ describe('detectSpeckit', () => {
 			'utf-8',
 		);
 		// 002-nospec is a dir under specs/ with NO spec.md → excluded
-		fs.mkdirSync(path.join(tempDir, 'specs', '002-nospec'), { recursive: true });
+		fs.mkdirSync(path.join(tempDir, 'specs', '002-nospec'), {
+			recursive: true,
+		});
 		fs.writeFileSync(
 			path.join(tempDir, 'specs', '002-nospec', 'notes.md'),
 			'# Not a spec\n',
@@ -273,7 +277,9 @@ describe('buildSpeckitProjectionSync', () => {
 		// No bold-markup id prefix — confirms synthesis, not preservation of an existing id.
 		expect(spec?.content).not.toContain('**FR-');
 		// Obligation text survived into the projected output.
-		expect(spec?.content).toContain('System MUST authenticate users with valid credentials.');
+		expect(spec?.content).toContain(
+			'System MUST authenticate users with valid credentials.',
+		);
 	});
 
 	test('golden stability: byte-identical output across two calls — explicit-fr fixture (SC-003)', () => {
@@ -358,10 +364,14 @@ describe('FR-003 — explicit ids survive an id-less bullet placed before them (
 		// DISCRIMINATING (advisor): the id-less bullet must synthesize FR-002, NOT steal FR-001.
 		// Pre-fix this line renders as `FR-001: The system MUST log out idle users.` and fails.
 		expect(content).toContain('FR-002: The system MUST log out idle users.');
-		expect(content).not.toContain('FR-001: The system MUST log out idle users.');
+		expect(content).not.toContain(
+			'FR-001: The system MUST log out idle users.',
+		);
 
 		// The explicit requirement keeps its original id unchanged (bold-markup preserve form).
-		expect(content).toContain('**FR-001**: The system MUST authenticate valid users.');
+		expect(content).toContain(
+			'**FR-001**: The system MUST authenticate valid users.',
+		);
 
 		// DISCRIMINATING: synthesis must not have stolen the explicit id, so no duplicate warning.
 		// Pre-fix the renderer emits "Duplicate requirement id FR-001 ...; generated FR-002.".
@@ -399,8 +409,12 @@ describe('FR-003 — explicit ids survive an id-less bullet placed before them (
 
 		expect(spec).not.toBeNull();
 		// First keeps FR-001; second is renumbered to FR-002 with the duplicate warning.
-		expect(spec!.warnings.some((w) => w.includes('Duplicate requirement id FR-001'))).toBe(true);
-		expect(spec!.content).toContain('FR-002: **FR-001**: The system MUST do the second thing.');
+		expect(
+			spec!.warnings.some((w) => w.includes('Duplicate requirement id FR-001')),
+		).toBe(true);
+		expect(spec!.content).toContain(
+			'FR-002: **FR-001**: The system MUST do the second thing.',
+		);
 	});
 });
 
@@ -452,7 +466,9 @@ describe('resolveSpeckitProjection — discriminated resolution (task 1.4)', () 
 	test('unknown_feature: multi-feature, non-existent feature id given', () => {
 		writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
 
-		const resolution = resolveSpeckitProjection(tempDir, { feature: '999-nope' });
+		const resolution = resolveSpeckitProjection(tempDir, {
+			feature: '999-nope',
+		});
 
 		expect(resolution).toEqual({
 			kind: 'unknown_feature',
@@ -487,13 +503,17 @@ describe('resolveSpeckitProjection — discriminated resolution (task 1.4)', () 
 		expect(resolution.spec.content).toContain('**FR-001**');
 		expect(resolution.spec.content).toContain('**FR-002**');
 		expect(resolution.spec.content).toContain('**FR-003**');
-		expect(resolution.spec.sourcePaths).toEqual(['specs/001-auth-service/spec.md']);
+		expect(resolution.spec.sourcePaths).toEqual([
+			'specs/001-auth-service/spec.md',
+		]);
 	});
 
 	test('ok: multi-feature with explicit valid feature yields projection for that feature only', () => {
 		writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
 
-		const resolution = resolveSpeckitProjection(tempDir, { feature: '002-beta' });
+		const resolution = resolveSpeckitProjection(tempDir, {
+			feature: '002-beta',
+		});
 
 		if (resolution.kind !== 'ok') {
 			throw new Error(`Expected kind 'ok', got '${resolution.kind}'`);
@@ -577,12 +597,16 @@ describe('readEffectiveSpecSync — resolver precedence (task 2.1)', () => {
 		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
 
 		// opts.source: 'speckit' explicitly requests Spec-Kit — swarm must still win.
-		const specViaSpeckit = readEffectiveSpecSync(tempDir, { source: 'speckit' });
+		const specViaSpeckit = readEffectiveSpecSync(tempDir, {
+			source: 'speckit',
+		});
 		expect(specViaSpeckit?.source).toBe('swarm');
 		expect(specViaSpeckit?.content).toContain('Swarm Native');
 
 		// opts.source: 'openspec' — same invariant.
-		const specViaOpenspec = readEffectiveSpecSync(tempDir, { source: 'openspec' });
+		const specViaOpenspec = readEffectiveSpecSync(tempDir, {
+			source: 'openspec',
+		});
 		expect(specViaOpenspec?.source).toBe('swarm');
 	});
 
@@ -742,7 +766,12 @@ describe('validateSpeckit — structural validation (task 2.3, FR-007, FR-013)',
 		// Valid feature (both required sections + FRs → resolution ok), with a custom
 		// tasks.md exercising the three cases: story ref, requirement ref, and neither.
 		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
-		const tasksPath = path.join(tempDir, 'specs', '001-auth-service', 'tasks.md');
+		const tasksPath = path.join(
+			tempDir,
+			'specs',
+			'001-auth-service',
+			'tasks.md',
+		);
 		fs.writeFileSync(
 			tasksPath,
 			[

--- a/src/sdd/effective-spec.test.ts
+++ b/src/sdd/effective-spec.test.ts
@@ -243,6 +243,46 @@ describe('detectSpeckit', () => {
 		expect(result.features).toHaveLength(1);
 		expect(result.features[0]?.featureId).toBe('001-real');
 	});
+
+	test('symlinked feature directories and symlinked spec.md files are skipped (symlink safety)', () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'speckit-symlink-'));
+		try {
+			fs.mkdirSync(path.join(tempDir, '.specify'));
+			fs.mkdirSync(path.join(tempDir, 'specs'));
+
+			// Real feature dir with a real spec.md — must be detected.
+			fs.mkdirSync(path.join(tempDir, 'specs', '001-real'));
+			fs.writeFileSync(
+				path.join(tempDir, 'specs', '001-real', 'spec.md'),
+				'## Functional Requirements\n- FR-001 System MUST work.\n',
+			);
+
+			// Symlinked feature dir — must be skipped (isSymbolicLink filter).
+			const symlinkFeatureTarget = path.join(tempDir, 'specs', '001-real');
+			fs.symlinkSync(
+				symlinkFeatureTarget,
+				path.join(tempDir, 'specs', '002-symlinked-dir'),
+				'dir',
+			);
+
+			// Real feature dir whose spec.md is a symlink — must be skipped
+			// (lstatSync+isFile returns false for a symlinked file).
+			fs.mkdirSync(path.join(tempDir, 'specs', '003-symlinked-spec'));
+			fs.symlinkSync(
+				path.join(tempDir, 'specs', '001-real', 'spec.md'),
+				path.join(tempDir, 'specs', '003-symlinked-spec', 'spec.md'),
+				'file',
+			);
+
+			const result = detectSpeckit(tempDir);
+
+			expect(result.markerPresent).toBe(true);
+			// Only the real, non-symlinked feature with a real spec.md is detected.
+			expect(result.features.map((f) => f.featureId)).toEqual(['001-real']);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
 });
 
 describe('buildSpeckitProjectionSync', () => {
@@ -856,3 +896,143 @@ describe('validateSpeckit — structural validation (task 2.3, FR-007, FR-013)',
 		expect(problems).toHaveLength(0);
 	});
 });
+
+// readTextBounded null-return path — detectSpeckit filters non-files before readTextBounded is called
+// ---------------------------------------------------------------------------
+// NOTE: when spec.md is a non-file (directory), detectSpeckit's isFile() guard at line 414
+// filters the feature out before readTextBounded is ever called. The null-return path in
+// readTextBounded is exercised by the vanishing-file TOCTOU (lstatSync throws) — testable
+// only via a race or node:fs mock. The defensive try/catch at readTextBounded L136 means
+// vanishing files return null (folded to zero_requirements) rather than crashing.
+//
+// The behavioral guarantee we CAN test: replacing spec.md with a directory causes
+// detectSpeckit to return { markerPresent: true, features: [] } and resolveSpeckitProjection
+// to return kind: 'empty' — not a crash.
+describe('readTextBounded null-return coverage', () => {
+	test('spec.md replaced by a directory: resolveSpeckitProjection returns empty (not crash)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		// Replace spec.md with a directory so detectSpeckit's isFile() guard skips it.
+		const specPath = path.join(tempDir, 'specs', '001-auth-service', 'spec.md');
+		fs.rmSync(specPath);
+		fs.mkdirSync(specPath); // now a directory, not a file
+
+		const resolution = resolveSpeckitProjection(tempDir);
+
+		expect(resolution).toEqual({
+			kind: 'empty',
+		});
+	});
+
+	test('validateSpeckit: spec.md replaced by a directory returns not_speckit-like problems (no crash)', () => {
+		// When detectSpeckit returns zero features (non-file spec.md filtered out),
+		// validateSpeckit returns early with kind: 'empty' and zero problems.
+		// The try/catch in readTextBounded is never triggered here because
+		// detectSpeckit skips the feature before readTextBounded is called.
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		const specPath = path.join(tempDir, 'specs', '001-auth-service', 'spec.md');
+		fs.rmSync(specPath);
+		fs.mkdirSync(specPath);
+
+		const { resolution, problems } = validateSpeckit(tempDir);
+
+		// Resolution is 'empty' because marker is present but no features remain.
+		expect(resolution.kind).toBe('empty');
+		expect(problems).toHaveLength(0);
+	});
+});
+
+// detectSpeckit — marker isDirectory guard (statSync vs existsSync)
+// ----------------------------------------------------------------
+describe('detectSpeckit marker isDirectory guard', () => {
+	test('.specify as a regular file is rejected (markerPresent=false, not a crash)', () => {
+		// A bare file named .specify should not be treated as the marker directory.
+		// statSync?.isDirectory() returns false for a regular file, so markerPresent=false.
+		fs.mkdirSync(path.join(tempDir, 'specs', '001-feature'), {
+			recursive: true,
+		});
+		fs.writeFileSync(
+			path.join(tempDir, 'specs', '001-feature', 'spec.md'),
+			'## Functional Requirements\n- **FR-001**: System MUST do something.\n',
+			'utf-8',
+		);
+		// Create .specify as a FILE (not a directory) to exercise the isDirectory() guard.
+		fs.writeFileSync(
+			path.join(tempDir, '.specify'),
+			'# Not a directory\n',
+			'utf-8',
+		);
+
+		const result = detectSpeckit(tempDir);
+
+		expect(result.markerPresent).toBe(false);
+		expect(result.features).toHaveLength(0);
+	});
+
+	test('.specify as a symlinked directory IS followed and detected (statSync behavior)', () => {
+		// statSync (not lstatSync) follows symlinks, so a symlinked marker dir resolves
+		// to the real path and is accepted. This is intentional — the guard rejects
+		// REGULAR FILES named .specify, not symlinked directories.
+		fs.mkdirSync(path.join(tempDir, 'specs', '001-feature'), {
+			recursive: true,
+		});
+		fs.writeFileSync(
+			path.join(tempDir, 'specs', '001-feature', 'spec.md'),
+			'## Functional Requirements\n- **FR-001**: System MUST work.\n',
+			'utf-8',
+		);
+		// Real marker dir at alternate path, symlinked into the project root.
+		fs.mkdirSync(path.join(tempDir, '.specify-target'));
+		fs.symlinkSync(
+			path.join(tempDir, '.specify-target'),
+			path.join(tempDir, '.specify'),
+			'dir',
+		);
+
+		const result = detectSpeckit(tempDir);
+
+		expect(result.markerPresent).toBe(true);
+		expect(result.features).toHaveLength(1);
+		expect(result.features[0]?.featureId).toBe('001-feature');
+	});
+});
+
+// validateSpeckit — FR-000 is flagged as "has no spec/requirement reference"
+// -------------------------------------------------------------------------
+describe('validateSpeckit FR-000 exclusion', () => {
+	test('tasks.md line referencing FR-000 is flagged as "has no spec/requirement reference" (hasReqRef (?!000) lookahead)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+		const tasksPath = path.join(
+			tempDir,
+			'specs',
+			'001-auth-service',
+			'tasks.md',
+		);
+		fs.writeFileSync(
+			tasksPath,
+			[
+				'# Tasks',
+				'',
+				'- [ ] T001 [P] [FR-001] Valid requirement reference — must NOT be flagged',
+				'- [ ] T002 [P] [FR-000] The null-requirement reference — must be flagged',
+				'- [ ] T003 [P] [US1] Valid story reference — must NOT be flagged',
+				'- [ ] T004 [P] No reference at all — must be flagged',
+				'',
+			].join('\n'),
+			'utf-8',
+		);
+
+		const { resolution, problems } = validateSpeckit(tempDir);
+
+		expect(resolution.kind).toBe('ok');
+		// FR-001 and US1 are valid references → not flagged.
+		expect(problems.some((p) => p.includes('T001'))).toBe(false);
+		expect(problems.some((p) => p.includes('T003'))).toBe(false);
+		// FR-000 is NOT a valid reference (the (?!000) negative lookahead excludes it)
+		// and no-story → flagged. T004 has no reference → flagged.
+		expect(problems.some((p) => p.includes('T002'))).toBe(true);
+		expect(problems.some((p) => p.includes('T004'))).toBe(true);
+	});
+});
+// vi: ft=typescript

--- a/src/sdd/effective-spec.test.ts
+++ b/src/sdd/effective-spec.test.ts
@@ -318,6 +318,92 @@ describe('buildSpeckitProjectionSync', () => {
 	});
 });
 
+describe('FR-003 — explicit ids survive an id-less bullet placed before them (Bug 1)', () => {
+	// Hand-built inline fixture (matching the repo's one-off fixture pattern, e.g. the
+	// too_large / bare-specs tests). An id-LESS obligation bullet appears BEFORE an
+	// explicit FR-001 bullet in document order. Pre-fix, synthesis steals FR-001 for the
+	// id-less bullet and renumbers the real explicit FR-001 to FR-002 (with a duplicate
+	// warning), violating FR-003. Post-fix, the explicit id is reserved before synthesis.
+	function writeMixedOrderFixture(): void {
+		write(
+			path.join('.specify', 'memory', 'constitution.md'),
+			'# Constitution\n',
+		);
+		write(
+			path.join('specs', '001-mixed', 'spec.md'),
+			[
+				'# 001-mixed — Mixed Feature',
+				'',
+				'## Functional Requirements',
+				'',
+				'- The system MUST log out idle users.',
+				'- **FR-001**: The system MUST authenticate valid users.',
+				'',
+				'## Success Criteria',
+				'',
+				'- **SC-001**: Idle users are logged out and valid users authenticate.',
+				'',
+			].join('\n'),
+		);
+	}
+
+	test('explicit FR-001 is preserved and the earlier id-less bullet gets FR-002, no duplicate warning', () => {
+		writeMixedOrderFixture();
+
+		const spec = buildSpeckitProjectionSync(tempDir);
+
+		expect(spec).not.toBeNull();
+		const content = spec!.content;
+
+		// DISCRIMINATING (advisor): the id-less bullet must synthesize FR-002, NOT steal FR-001.
+		// Pre-fix this line renders as `FR-001: The system MUST log out idle users.` and fails.
+		expect(content).toContain('FR-002: The system MUST log out idle users.');
+		expect(content).not.toContain('FR-001: The system MUST log out idle users.');
+
+		// The explicit requirement keeps its original id unchanged (bold-markup preserve form).
+		expect(content).toContain('**FR-001**: The system MUST authenticate valid users.');
+
+		// DISCRIMINATING: synthesis must not have stolen the explicit id, so no duplicate warning.
+		// Pre-fix the renderer emits "Duplicate requirement id FR-001 ...; generated FR-002.".
+		expect(spec!.warnings.join('\n')).not.toContain('Duplicate requirement id');
+
+		// The projection must still be valid (FR-005) — no collateral regression.
+		expect(validateSpecContent(content).valid).toBe(true);
+	});
+
+	test('two genuinely-duplicate explicit ids still warn and renumber the second (invariant preserved)', () => {
+		// The Bug 1 fix must NOT suppress the real duplicate-explicit-id warning: two
+		// explicit requirements truly sharing FR-001 is a source error, not synthesis.
+		write(
+			path.join('.specify', 'memory', 'constitution.md'),
+			'# Constitution\n',
+		);
+		write(
+			path.join('specs', '001-dup', 'spec.md'),
+			[
+				'# 001-dup — Duplicate Feature',
+				'',
+				'## Functional Requirements',
+				'',
+				'- **FR-001**: The system MUST do the first thing.',
+				'- **FR-001**: The system MUST do the second thing.',
+				'',
+				'## Success Criteria',
+				'',
+				'- **SC-001**: Both things happen.',
+				'',
+			].join('\n'),
+		);
+
+		const spec = buildSpeckitProjectionSync(tempDir);
+
+		expect(spec).not.toBeNull();
+		// First keeps FR-001; second is renumbered to FR-002 with the duplicate warning.
+		expect(spec!.warnings.some((w) => w.includes('Duplicate requirement id FR-001'))).toBe(true);
+		expect(spec!.content).toContain('FR-002: **FR-001**: The system MUST do the second thing.');
+	});
+});
+
 describe('resolveSpeckitProjection — discriminated resolution (task 1.4)', () => {
 	test('not_speckit: openspec-only repo with no .specify/ marker (A-001)', () => {
 		// Write an OpenSpec layout — no .specify/ marker at all.

--- a/src/sdd/effective-spec.test.ts
+++ b/src/sdd/effective-spec.test.ts
@@ -2,10 +2,15 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { validateSpecContent } from '../config/spec-schema';
+import { writeSpeckitFixture } from '../../tests/helpers/speckit-fixture';
 import {
 	buildOpenSpecProjectionSync,
+	buildSpeckitProjectionSync,
+	detectSpeckit,
 	loadSddStatusSync,
 	readEffectiveSpecSync,
+	resolveSpeckitProjection,
 	writeProjectedSpecSync,
 } from './effective-spec';
 
@@ -131,5 +136,311 @@ describe('effective spec provider', () => {
 		const spec = buildOpenSpecProjectionSync(tempDir);
 
 		expect(spec).toBeNull();
+	});
+});
+
+describe('detectSpeckit', () => {
+	test('detects a single-feature Spec-Kit layout and returns the correct feature entry', () => {
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		const result = detectSpeckit(tempDir);
+
+		expect(result.markerPresent).toBe(true);
+		expect(result.features).toHaveLength(1);
+		expect(result.features[0]?.featureId).toBe('001-auth-service');
+		expect(result.features[0]?.specRelPath).toBe('specs/001-auth-service/spec.md');
+	});
+
+	test('detects a multi-feature layout and enumerates both features in sorted order', () => {
+		writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+
+		const result = detectSpeckit(tempDir);
+
+		expect(result.markerPresent).toBe(true);
+		expect(result.features).toHaveLength(2);
+		// Sorted lexicographically: 001-alpha before 002-beta
+		expect(result.features[0]?.featureId).toBe('001-alpha');
+		expect(result.features[0]?.specRelPath).toBe('specs/001-alpha/spec.md');
+		expect(result.features[1]?.featureId).toBe('002-beta');
+		expect(result.features[1]?.specRelPath).toBe('specs/002-beta/spec.md');
+	});
+
+	test('reports markerPresent=true with empty feature list when .specify/ exists but no specs/ dirs', () => {
+		writeSpeckitFixture(tempDir, { variant: 'empty-specify' });
+
+		const result = detectSpeckit(tempDir);
+
+		expect(result.markerPresent).toBe(true);
+		expect(result.features).toHaveLength(0);
+	});
+
+	test('does not detect Spec-Kit when only openspec/ is present (no .specify/ marker, A-001)', () => {
+		// Hand-create a plain OpenSpec repo — writeSpeckitFixture always writes .specify/
+		fs.mkdirSync(path.join(tempDir, 'openspec', 'specs', '001-feature'), {
+			recursive: true,
+		});
+		fs.writeFileSync(
+			path.join(tempDir, 'openspec', 'specs', '001-feature', 'spec.md'),
+			'# Not a Spec-Kit repo\n',
+			'utf-8',
+		);
+
+		const result = detectSpeckit(tempDir);
+
+		expect(result.markerPresent).toBe(false);
+		expect(result.features).toHaveLength(0);
+	});
+
+	test('does not detect Spec-Kit when a bare specs/ exists with no .specify/ marker (A-001)', () => {
+		// Hand-create a repo with specs/ at root but no .specify/
+		fs.mkdirSync(path.join(tempDir, 'specs', '001-feature'), {
+			recursive: true,
+		});
+		fs.writeFileSync(
+			path.join(tempDir, 'specs', '001-feature', 'spec.md'),
+			'# Bare specs dir — not Spec-Kit\n\n## Functional Requirements\n- **FR-001**: System MUST do something.\n',
+			'utf-8',
+		);
+
+		const result = detectSpeckit(tempDir);
+
+		expect(result.markerPresent).toBe(false);
+		expect(result.features).toHaveLength(0);
+	});
+
+	test('excludes a specs/ subdir that has no spec.md (only feature dirs with a spec.md are enumerated)', () => {
+		// Hand-built: the shared helper always writes spec.md in every feature dir,
+		// so build directly to exercise the spec.md-presence exclusion branch.
+		fs.mkdirSync(path.join(tempDir, '.specify', 'memory'), { recursive: true });
+		fs.writeFileSync(
+			path.join(tempDir, '.specify', 'memory', 'constitution.md'),
+			'# Constitution\n',
+			'utf-8',
+		);
+		// 001-real HAS a spec.md → included
+		fs.mkdirSync(path.join(tempDir, 'specs', '001-real'), { recursive: true });
+		fs.writeFileSync(
+			path.join(tempDir, 'specs', '001-real', 'spec.md'),
+			'# Real feature\n\n## Functional Requirements\n- **FR-001**: System MUST work.\n',
+			'utf-8',
+		);
+		// 002-nospec is a dir under specs/ with NO spec.md → excluded
+		fs.mkdirSync(path.join(tempDir, 'specs', '002-nospec'), { recursive: true });
+		fs.writeFileSync(
+			path.join(tempDir, 'specs', '002-nospec', 'notes.md'),
+			'# Not a spec\n',
+			'utf-8',
+		);
+
+		const result = detectSpeckit(tempDir);
+
+		expect(result.markerPresent).toBe(true);
+		expect(result.features).toHaveLength(1);
+		expect(result.features[0]?.featureId).toBe('001-real');
+	});
+});
+
+describe('buildSpeckitProjectionSync', () => {
+	test('single-explicit-fr: preserves FR-001/FR-002/FR-003 identifiers unchanged (FR-003)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		const spec = buildSpeckitProjectionSync(tempDir);
+
+		expect(spec).not.toBeNull();
+		expect(spec?.source).toBe('speckit_projection');
+		// Preservation proof: the bold-markup form survives only via the preserve branch.
+		// The synthesis path produces `FR-001: …` (plain colon prefix, no bold markers).
+		expect(spec?.content).toContain('**FR-001**');
+		expect(spec?.content).toContain('**FR-002**');
+		expect(spec?.content).toContain('**FR-003**');
+		// validateSpecContent must pass (FR-005)
+		const validation = validateSpecContent(spec!.content);
+		expect(validation.valid).toBe(true);
+	});
+
+	test('single-idless-requirements: synthesises stable FR-### ids and preserves obligation text (FR-004)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+
+		const spec = buildSpeckitProjectionSync(tempDir);
+
+		expect(spec).not.toBeNull();
+		expect(spec?.source).toBe('speckit_projection');
+		// Synthesis proof: colon-form prefix is emitted by the nextFrId path only.
+		expect(spec?.content).toContain('FR-001:');
+		expect(spec?.content).toContain('FR-002:');
+		expect(spec?.content).toContain('FR-003:');
+		// No bold-markup id prefix — confirms synthesis, not preservation of an existing id.
+		expect(spec?.content).not.toContain('**FR-');
+		// Obligation text survived into the projected output.
+		expect(spec?.content).toContain('System MUST authenticate users with valid credentials.');
+	});
+
+	test('golden stability: byte-identical output across two calls — explicit-fr fixture (SC-003)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		const a = buildSpeckitProjectionSync(tempDir);
+		const b = buildSpeckitProjectionSync(tempDir);
+
+		// Guard against a double-null vacuous pass: byte-equality must be over real content.
+		expect(a).not.toBeNull();
+		expect(a?.content).toBe(b?.content);
+	});
+
+	test('golden stability: byte-identical output across two calls — id-less fixture (SC-003)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+
+		const a = buildSpeckitProjectionSync(tempDir);
+		const b = buildSpeckitProjectionSync(tempDir);
+
+		// Guard against a double-null vacuous pass: byte-equality must be over real content.
+		expect(a).not.toBeNull();
+		expect(a?.content).toBe(b?.content);
+	});
+
+	test('multi-feature with no feature option returns null (clean seam for task 1.4)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+
+		const spec = buildSpeckitProjectionSync(tempDir);
+
+		expect(spec).toBeNull();
+	});
+
+	test('multi-feature with explicit feature option projects only that feature', () => {
+		writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+
+		const spec = buildSpeckitProjectionSync(tempDir, { feature: '002-beta' });
+
+		expect(spec).not.toBeNull();
+		expect(spec?.sourcePaths).toEqual(['specs/002-beta/spec.md']);
+		expect(spec?.content).toContain('beta capability');
+		expect(spec?.content).not.toContain('alpha');
+	});
+});
+
+describe('resolveSpeckitProjection — discriminated resolution (task 1.4)', () => {
+	test('not_speckit: openspec-only repo with no .specify/ marker (A-001)', () => {
+		// Write an OpenSpec layout — no .specify/ marker at all.
+		write(
+			path.join('openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
+		);
+
+		const resolution = resolveSpeckitProjection(tempDir);
+
+		expect(resolution).toEqual({ kind: 'not_speckit' });
+	});
+
+	test('not_speckit: bare specs/ at root with no .specify/ marker (A-001)', () => {
+		// A repo with specs/ at root but no .specify/ is still not_speckit.
+		write(
+			path.join('specs', '001-feature', 'spec.md'),
+			'## Functional Requirements\n- **FR-001**: System MUST do something.\n',
+		);
+
+		const resolution = resolveSpeckitProjection(tempDir);
+
+		expect(resolution).toEqual({ kind: 'not_speckit' });
+	});
+
+	test('empty: .specify/ marker present but no specs/NNN/spec.md feature dirs (FR-012)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'empty-specify' });
+
+		const resolution = resolveSpeckitProjection(tempDir);
+
+		expect(resolution).toEqual({ kind: 'empty' });
+	});
+
+	test('ambiguous: multi-feature, no feature option — features listed sorted (FR-008)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+
+		const resolution = resolveSpeckitProjection(tempDir);
+
+		// Full object equality asserts both kind AND the sorted features list.
+		expect(resolution).toEqual({
+			kind: 'ambiguous',
+			features: ['001-alpha', '002-beta'],
+		});
+	});
+
+	test('unknown_feature: multi-feature, non-existent feature id given', () => {
+		writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+
+		const resolution = resolveSpeckitProjection(tempDir, { feature: '999-nope' });
+
+		expect(resolution).toEqual({
+			kind: 'unknown_feature',
+			feature: '999-nope',
+			available: ['001-alpha', '002-beta'],
+		});
+	});
+
+	test('zero_requirements: feature dir exists but spec.md has no parsable FRs (FR-013)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'zero-fr' });
+
+		const resolution = resolveSpeckitProjection(tempDir);
+
+		expect(resolution).toEqual({
+			kind: 'zero_requirements',
+			feature: '001-empty-feature',
+		});
+	});
+
+	test('ok: single-feature auto-select yields a valid projection (FR-008)', () => {
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+
+		const resolution = resolveSpeckitProjection(tempDir);
+
+		// Guard narrows the union for TypeScript; throw makes the failure message readable.
+		if (resolution.kind !== 'ok') {
+			throw new Error(`Expected kind 'ok', got '${resolution.kind}'`);
+		}
+		expect(resolution.feature).toBe('001-auth-service');
+		expect(resolution.spec.source).toBe('speckit_projection');
+		// FR-003: original ids preserved.
+		expect(resolution.spec.content).toContain('**FR-001**');
+		expect(resolution.spec.content).toContain('**FR-002**');
+		expect(resolution.spec.content).toContain('**FR-003**');
+		expect(resolution.spec.sourcePaths).toEqual(['specs/001-auth-service/spec.md']);
+	});
+
+	test('ok: multi-feature with explicit valid feature yields projection for that feature only', () => {
+		writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+
+		const resolution = resolveSpeckitProjection(tempDir, { feature: '002-beta' });
+
+		if (resolution.kind !== 'ok') {
+			throw new Error(`Expected kind 'ok', got '${resolution.kind}'`);
+		}
+		expect(resolution.feature).toBe('002-beta');
+		expect(resolution.spec.source).toBe('speckit_projection');
+		expect(resolution.spec.sourcePaths).toEqual(['specs/002-beta/spec.md']);
+		expect(resolution.spec.content).toContain('beta capability');
+		expect(resolution.spec.content).not.toContain('alpha');
+	});
+
+	test('too_large: requirements parse but projected output exceeds the byte cap (distinct from zero_requirements)', () => {
+		// Hand-built: one valid FR whose text alone exceeds MAX_SPEC_BYTES (256 KiB),
+		// so requirements parse (count > 0) but the projected output is refused.
+		fs.mkdirSync(path.join(tempDir, '.specify', 'memory'), { recursive: true });
+		fs.writeFileSync(
+			path.join(tempDir, '.specify', 'memory', 'constitution.md'),
+			'# Constitution\n',
+			'utf-8',
+		);
+		fs.mkdirSync(path.join(tempDir, 'specs', '001-huge'), { recursive: true });
+		const hugeText = 'x'.repeat(300_000); // > 256 KiB, < 512 KiB input cap
+		fs.writeFileSync(
+			path.join(tempDir, 'specs', '001-huge', 'spec.md'),
+			`# Huge\n\n## Functional Requirements\n- **FR-001**: System MUST ${hugeText}.\n`,
+			'utf-8',
+		);
+
+		const resolution = resolveSpeckitProjection(tempDir);
+
+		if (resolution.kind !== 'too_large') {
+			throw new Error(`Expected kind 'too_large', got '${resolution.kind}'`);
+		}
+		expect(resolution.feature).toBe('001-huge');
+		expect(resolution.bytes).toBeGreaterThan(256 * 1024);
 	});
 });

--- a/src/sdd/effective-spec.ts
+++ b/src/sdd/effective-spec.ts
@@ -12,6 +12,21 @@ const MAX_SOURCE_BYTES = 512 * 1024;
 const MAX_SPEC_FILES = 100;
 const MAX_WALK_DEPTH = 10;
 
+/**
+ * Required top-level section headers for a Spec-Kit feature spec.md (FR-007).
+ *
+ * Justification for the minimal list:
+ * - `## Functional Requirements` — the content basis for all drift / coverage / projection
+ *   work; absent means nothing can be enforced (FR-007, FR-013).
+ * - `## Success Criteria` — the only Spec-Kit-required acceptance gate; the malformed
+ *   fixture deliberately drops it to exercise the validator.
+ * Keeping the list small and justified avoids over-specifying the Spec-Kit template.
+ */
+const SPECKIT_REQUIRED_SECTIONS = [
+	'## Functional Requirements',
+	'## Success Criteria',
+] as const;
+
 export type EffectiveSpecSource = 'swarm' | 'openspec_projection' | 'speckit_projection';
 
 export interface OpenSpecArtifact {
@@ -592,7 +607,10 @@ export function buildSpeckitProjectionSync(
 	return resolution.kind === 'ok' ? resolution.spec : null;
 }
 
-export function loadSddStatusSync(directory: string): SddStatus {
+export function loadSddStatusSync(
+	directory: string,
+	opts?: ReadEffectiveSpecOpts,
+): SddStatus {
 	const root = path.resolve(directory);
 	const swSpecPath = path.join(root, SWARM_SPEC_REL);
 	const openSpecPath = path.join(root, OPENSPEC_ROOT);
@@ -602,7 +620,9 @@ export function loadSddStatusSync(directory: string): SddStatus {
 	const openSpecExists = fs.existsSync(openSpecPath);
 	const currentSpecs = walkSpecFiles(root, path.join(OPENSPEC_ROOT, 'specs'));
 	const changes = listOpenSpecChanges(root);
-	const effectiveSpec = readEffectiveSpecSync(root);
+	// Forward opts so an explicit --source selection is honored (FR-009); with no
+	// opts this is byte-identical to the prior auto-detect behavior.
+	const effectiveSpec = readEffectiveSpecSync(root, opts);
 
 	if (openSpecExists && currentSpecs.length === 0 && changes.length === 0) {
 		errors.push('openspec/ exists but contains no specs or active changes.');
@@ -757,9 +777,74 @@ export function buildOpenSpecProjectionSync(
 	};
 }
 
-export function readEffectiveSpecSync(directory: string): EffectiveSpec | null {
+/**
+ * Resolver options for {@link readEffectiveSpecSync} (task 2.1, FR-009).
+ *
+ * Both fields are optional so that all 13 existing single-argument call sites
+ * continue to work unchanged.
+ */
+export interface ReadEffectiveSpecOpts {
+	/**
+	 * Explicit provider selection (FR-009 step b).
+	 * When given, the specified provider is used directly after the native swarm
+	 * spec check.  A `'swarm'` selection with no `.swarm/spec.md` returns null.
+	 */
+	source?: 'swarm' | 'openspec' | 'speckit';
+	/**
+	 * Feature selector forwarded to {@link buildSpeckitProjectionSync} when the
+	 * effective provider is Spec-Kit.  Ignored for `source: 'openspec'` or
+	 * `source: 'swarm'` (feature-vs-non-speckit source validation is enforced at
+	 * the command layer in task 2.2, not here).
+	 */
+	feature?: string;
+}
+
+/**
+ * Read (or build) the effective spec for a directory, applying deterministic
+ * source precedence (FR-009, FR-010, FR-011).
+ *
+ * **Precedence:**
+ * a. `.swarm/spec.md` present → return the native swarm spec.  This branch is
+ *    IDENTICAL to the pre-task-2.1 code and wins even over an explicit
+ *    `opts.source` — native swarm spec always wins (FR-009).
+ * b. `opts.source` given → use that provider: `'openspec'` calls
+ *    {@link buildOpenSpecProjectionSync}; `'speckit'` calls
+ *    {@link buildSpeckitProjectionSync}; `'swarm'` with no `.swarm/spec.md`
+ *    returns null.
+ * c. Auto-detect:
+ *    - **No `.specify/` marker** → byte-identical to pre-task-2.1 behavior:
+ *      call {@link buildOpenSpecProjectionSync} and return its result (FR-011).
+ *    - **`.specify/` present but no feature dirs** (empty marker) → Spec-Kit is
+ *      NOT counted as a competing source; behaves like the no-marker case.
+ *    - **`.specify/` with ≥1 feature dir and no openspec projection** → return
+ *      the Spec-Kit projection.
+ *    - **`.specify/` with ≥1 feature dir AND openspec yields a projection** →
+ *      AMBIGUOUS (FR-010): emit a concrete diagnostic via `console.warn` (the
+ *      anti-silent-suppression requirement; critic Finding 2) and return null.
+ *      The diagnostic is independent of the return value so it fires even when
+ *      no consumer inspects the null return (e.g. the drift gate, which only
+ *      checks for null to decide advisory-vs-blocking mode).
+ *
+ * **Backward-compat (FR-011):** when `.detectSpeckit(directory).markerPresent`
+ * is false, the function is byte-identical to pre-task-2.1.  The additional
+ * `detectSpeckit` call (a single `fs.existsSync`) is the only overhead.
+ *
+ * **Deviation from task-2.1 literal text:** the task body says "Spec-Kit
+ * present (`detectSpeckit(dir).markerPresent`)" but plan.md task 3.1 and the
+ * test note both state that an empty `.specify/` "would never reach the
+ * ambiguity branch."  `markerPresent` is true for empty-specify, so it cannot
+ * be the discriminator.  We use `features.length > 0` instead, which is
+ * symmetric with "OpenSpec present (yields a projection)" and makes empty
+ * `.specify/` a non-competing source, matching both citations.
+ */
+export function readEffectiveSpecSync(
+	directory: string,
+	opts?: ReadEffectiveSpecOpts,
+): EffectiveSpec | null {
 	const root = path.resolve(directory);
 	const swSpecPath = path.join(root, SWARM_SPEC_REL);
+
+	// a. Native swarm spec always wins — EXACTLY today's behavior, unchanged.
 	try {
 		const stat = fs.lstatSync(swSpecPath);
 		if (stat.isFile() && stat.size <= MAX_SPEC_BYTES) {
@@ -778,12 +863,73 @@ export function readEffectiveSpecSync(directory: string): EffectiveSpec | null {
 			throw error;
 		}
 	}
-	return buildOpenSpecProjectionSync(root);
+
+	// b. Explicit source selection — use the named provider directly.
+	if (opts?.source) {
+		switch (opts.source) {
+			case 'openspec':
+				return buildOpenSpecProjectionSync(root);
+			case 'speckit':
+				return buildSpeckitProjectionSync(root, { feature: opts.feature });
+			case 'swarm':
+				// No .swarm/spec.md present (already checked above) → null.
+				return null;
+		}
+	}
+
+	// c. Auto-detect: determine which projection sources are present.
+
+	// BACKWARD-COMPAT (FR-011): when no .specify/ marker, behavior is
+	// byte-identical to today — swarm spec (handled above) else openspec.
+	const speckitDetection = detectSpeckit(root);
+	if (!speckitDetection.markerPresent) {
+		return buildOpenSpecProjectionSync(root);
+	}
+
+	// "Spec-Kit present" = marker present AND at least one valid feature dir.
+	// An empty .specify/ (features.length === 0) is NOT a competing source —
+	// fall through to openspec as if the marker were absent (plan.md task 3.1;
+	// test note: "NOT empty, or it won't register as a competing source").
+	const speckitPresent = speckitDetection.features.length > 0;
+
+	if (!speckitPresent) {
+		// .specify/ exists but is empty — not a competing source.
+		return buildOpenSpecProjectionSync(root);
+	}
+
+	// Spec-Kit present: check whether OpenSpec is also present.
+	// "OpenSpec present" = openspec/ layout yields a non-null projection.
+	const openspecProjection = buildOpenSpecProjectionSync(root);
+	const openspecPresent = openspecProjection !== null;
+
+	if (openspecPresent) {
+		// FR-010 / critic Finding 2: BOTH sources present, no --source given.
+		// Emit a concrete resolver-side diagnostic BEFORE returning null.
+		// This is INDEPENDENT of the null return value: the drift gate (and all
+		// other consumers) see only the null; this warn fires regardless of
+		// whether any consumer checks the return or its contents.
+		console.warn(
+			'[opencode-swarm] Multiple SDD sources detected (openspec and speckit). ' +
+				'Enforcement/projection is suppressed until you disambiguate. ' +
+				'Pass --source openspec or --source speckit to select a provider.',
+		);
+		return null;
+	}
+
+	// Only Spec-Kit present — return the Spec-Kit projection.
+	return buildSpeckitProjectionSync(root, { feature: opts?.feature });
 }
 
 export function writeProjectedSpecSync(
 	directory: string,
-	options: { changeId?: string; dryRun?: boolean } = {},
+	options: {
+		changeId?: string;
+		dryRun?: boolean;
+		/** When `'speckit'`, builds a Spec-Kit projection instead of OpenSpec (task 2.2). */
+		source?: 'openspec' | 'speckit';
+		/** Feature selector forwarded to buildSpeckitProjectionSync when source is speckit. */
+		feature?: string;
+	} = {},
 ): {
 	written: boolean;
 	projection: EffectiveSpec | null;
@@ -791,9 +937,10 @@ export function writeProjectedSpecSync(
 	path: string;
 } {
 	const root = path.resolve(directory);
-	const projection = buildOpenSpecProjectionSync(root, {
-		changeId: options.changeId,
-	});
+	const projection =
+		options.source === 'speckit'
+			? buildSpeckitProjectionSync(root, { feature: options.feature })
+			: buildOpenSpecProjectionSync(root, { changeId: options.changeId });
 	const target = path.join(root, SWARM_SPEC_REL);
 	if (!projection || options.dryRun) {
 		return { written: false, projection, path: target };
@@ -816,4 +963,111 @@ export function writeProjectedSpecSync(
 	fs.writeFileSync(tmp, projection.content, 'utf-8');
 	fs.renameSync(tmp, target);
 	return { written: true, projection, archivePath, path: target };
+}
+
+/**
+ * Validate Spec-Kit artifacts READ-ONLY (FR-007, task 2.3).
+ *
+ * MUST NOT write or modify any Spec-Kit artifact — it only reads spec.md and
+ * tasks.md to report structural problems.
+ *
+ * Returns the {@link SpeckitResolution} from {@link resolveSpeckitProjection}
+ * alongside a flat `problems` array.  Returning both avoids a second
+ * `resolveSpeckitProjection` call in the command layer (which would need the
+ * projection's hash / sourcePaths from `resolution.spec`).
+ *
+ * **Problems reported** (only when `resolution.kind` is `'ok'` or
+ * `'zero_requirements'` — i.e. when we have a feature to inspect):
+ * - Zero parsable functional requirements (`zero_requirements` kind, FR-013).
+ * - Missing required spec.md sections (`SPECKIT_REQUIRED_SECTIONS`).
+ * - `tasks.md` task lines that carry no `[US#]` user-story reference (FR-007).
+ *
+ * For other resolution kinds (`not_speckit`, `empty`, `ambiguous`,
+ * `unknown_feature`, `too_large`) the command layer uses
+ * {@link formatSpeckitError} on the returned resolution — same messaging path
+ * as task 2.2 (plan.md task 2.3 requirement: no second messaging scheme).
+ */
+export function validateSpeckit(
+	directory: string,
+	options: { feature?: string } = {},
+): { resolution: SpeckitResolution; problems: string[] } {
+	const root = path.resolve(directory);
+	const resolution = resolveSpeckitProjection(root, options);
+	const problems: string[] = [];
+
+	// Structural validation only applies when we resolved to a specific feature.
+	if (resolution.kind !== 'ok' && resolution.kind !== 'zero_requirements') {
+		return { resolution, problems };
+	}
+
+	// FR-013: surface zero parsable requirements as a problem.
+	if (resolution.kind === 'zero_requirements') {
+		problems.push(
+			`Feature '${resolution.feature}' contains no parsable functional requirements.`,
+		);
+	}
+
+	// Locate the feature entry to derive spec.md / tasks.md absolute paths.
+	// detectSpeckit is read-only (no side effects) and deterministic.
+	const detection = detectSpeckit(root);
+	const featureEntry = detection.features.find(
+		(f) => f.featureId === resolution.feature,
+	);
+	if (!featureEntry) {
+		// Race condition: feature disappeared between the two reads. Be defensive.
+		return { resolution, problems };
+	}
+
+	const specAbs = path.join(root, featureEntry.specRelPath);
+
+	// --- spec.md structural check (READ-ONLY) ---
+	let specContent: string | null = null;
+	try {
+		specContent = readTextBounded(specAbs);
+	} catch {
+		// File missing or unreadable — skip section checks.
+	}
+
+	if (specContent !== null) {
+		const specLines = specContent.replace(/\r\n/g, '\n').split('\n');
+		for (const requiredHeader of SPECKIT_REQUIRED_SECTIONS) {
+			// Exact line match after stripping trailing whitespace.  This correctly
+			// rejects `### Functional Requirements` (wrong level) and ignores
+			// `## Functional Requirements Details` (extra text on the same line).
+			if (!specLines.some((line) => line.trimEnd() === requiredHeader)) {
+				problems.push(`Missing required spec.md section: ${requiredHeader}`);
+			}
+		}
+	}
+
+	// --- tasks.md structural check (READ-ONLY) ---
+	// tasks.md sits alongside spec.md in the same feature directory.
+	const tasksAbs = path.join(path.dirname(specAbs), 'tasks.md');
+	let tasksContent: string | null = null;
+	try {
+		tasksContent = readTextBounded(tasksAbs);
+	} catch {
+		// tasks.md absent or unreadable — skip; it is optional.
+	}
+
+	if (tasksContent !== null) {
+		const tasksLines = tasksContent.replace(/\r\n/g, '\n').split('\n');
+		for (const line of tasksLines) {
+			// Match a task checkbox line and capture the task id (T### pattern).
+			const taskMatch = line.match(/^\s*-\s+\[[ xX]\]\s+(T\d+)/);
+			if (!taskMatch) continue;
+			const taskId = taskMatch[1]!;
+			// FR-007: a task must carry a spec/requirement reference. Accept EITHER a
+			// `[US#]` user-story tag OR an `FR-###` requirement id — flag only when the
+			// task has neither (a task that explicitly references FR-001, or a setup task
+			// tagged to a story, is a legitimate reference and must not be flagged).
+			const hasStoryRef = /\[US\d+\]/i.test(line);
+			const hasReqRef = /\bFR-\d{3}\b/i.test(line);
+			if (!hasStoryRef && !hasReqRef) {
+				problems.push(`Task ${taskId} has no spec/requirement reference.`);
+			}
+		}
+	}
+
+	return { resolution, problems };
 }

--- a/src/sdd/effective-spec.ts
+++ b/src/sdd/effective-spec.ts
@@ -27,7 +27,10 @@ const SPECKIT_REQUIRED_SECTIONS = [
 	'## Success Criteria',
 ] as const;
 
-export type EffectiveSpecSource = 'swarm' | 'openspec_projection' | 'speckit_projection';
+export type EffectiveSpecSource =
+	| 'swarm'
+	| 'openspec_projection'
+	| 'speckit_projection';
 
 export interface OpenSpecArtifact {
 	relPath: string;
@@ -509,7 +512,9 @@ export function resolveSpeckitProjection(
 	// Feature selection.
 	let selectedFeature: SpeckitFeatureEntry;
 	if (options.feature) {
-		const found = detection.features.find((f) => f.featureId === options.feature);
+		const found = detection.features.find(
+			(f) => f.featureId === options.feature,
+		);
 		if (!found) {
 			return {
 				kind: 'unknown_feature',
@@ -541,7 +546,10 @@ export function resolveSpeckitProjection(
 	const warnings: string[] = [];
 	const usedIds = new Set<string>();
 
-	const requirements = parseSpeckitRequirements(content, selectedFeature.specRelPath);
+	const requirements = parseSpeckitRequirements(
+		content,
+		selectedFeature.specRelPath,
+	);
 
 	// Mirror buildOpenSpecProjectionSync :450-453 — zero FRs → advisory (FR-013).
 	if (requirements.length === 0) {

--- a/src/sdd/effective-spec.ts
+++ b/src/sdd/effective-spec.ts
@@ -5,12 +5,14 @@ import { validateSpecContent } from '../config/spec-schema';
 
 const SWARM_SPEC_REL = path.join('.swarm', 'spec.md');
 const OPENSPEC_ROOT = 'openspec';
+const SPECKIT_MARKER = '.specify';
+const SPECKIT_SPECS_DIR = 'specs';
 const MAX_SPEC_BYTES = 256 * 1024;
 const MAX_SOURCE_BYTES = 512 * 1024;
 const MAX_SPEC_FILES = 100;
 const MAX_WALK_DEPTH = 10;
 
-export type EffectiveSpecSource = 'swarm' | 'openspec_projection';
+export type EffectiveSpecSource = 'swarm' | 'openspec_projection' | 'speckit_projection';
 
 export interface OpenSpecArtifact {
 	relPath: string;
@@ -45,6 +47,53 @@ export interface SddStatus {
 	errors: string[];
 	warnings: string[];
 }
+
+/** A single Spec-Kit feature directory containing a spec.md. */
+export interface SpeckitFeatureEntry {
+	/** Full directory name, e.g. `001-feature-name`. */
+	featureId: string;
+	/** Posix-normalized path relative to the repo root, e.g. `specs/001-feature-name/spec.md`. */
+	specRelPath: string;
+}
+
+/** Result returned by {@link detectSpeckit}. */
+export interface SpeckitDetection {
+	/** Whether the `.specify/` marker directory is present at the repo root (A-001). */
+	markerPresent: boolean;
+	/**
+	 * Detected feature directories, sorted lexicographically by {@link SpeckitFeatureEntry.featureId}.
+	 * Empty when no `specs/<feature>/spec.md` files are found (or when markerPresent is false).
+	 */
+	features: SpeckitFeatureEntry[];
+}
+
+/**
+ * Discriminated union returned by {@link resolveSpeckitProjection} (task 1.4).
+ *
+ * Each kind carries exactly the information the command layer (task 2.2) needs to
+ * produce the correct error message per FR-008, FR-012, FR-013 without re-detecting.
+ *
+ * - `not_speckit`      — no `.specify/` marker at the repo root (A-001).
+ * - `empty`            — marker present but no `specs/NNN/spec.md` feature dirs (FR-012).
+ * - `ambiguous`        — more than one feature and no `options.feature` given (FR-008);
+ *                        `features` = sorted feature ids for naming in the error message.
+ * - `unknown_feature`  — `options.feature` was given but matches no detected feature.
+ * - `zero_requirements`— the selected feature's spec.md yielded zero parsable functional
+ *                        requirements (covers unreadable/oversized *input* files too) (FR-013).
+ * - `too_large`        — requirements parsed, but the projected *output* exceeds the byte
+ *                        cap and is refused; `bytes` is the projected size. Distinct from
+ *                        zero_requirements so the command layer reports the real reason.
+ * - `ok`               — a valid projection was built; `spec` is ready for use, `feature`
+ *                        identifies the projected feature dir name.
+ */
+export type SpeckitResolution =
+	| { kind: 'not_speckit' }
+	| { kind: 'empty' }
+	| { kind: 'ambiguous'; features: string[] }
+	| { kind: 'unknown_feature'; feature: string; available: string[] }
+	| { kind: 'zero_requirements'; feature: string }
+	| { kind: 'too_large'; feature: string; bytes: number }
+	| { kind: 'ok'; spec: EffectiveSpec; feature: string };
 
 type DeltaKind = 'ADDED' | 'MODIFIED' | 'REMOVED' | 'CURRENT';
 
@@ -251,6 +300,296 @@ function renderRequirement(
 		text = `${id}: ${text}`;
 	}
 	return `- ${text} _(source: ${req.sourceRel})_`;
+}
+
+/**
+ * Detect whether `directory` is a GitHub Spec-Kit project (FR-001, A-001).
+ *
+ * Detection key: the `.specify/` marker directory at the repo root.
+ * A repo with `specs/` but no `.specify/` is NOT a Spec-Kit repo (A-001).
+ *
+ * When the marker is present, enumerates all direct children of `specs/` that
+ * contain a `spec.md` file.  The enumeration is:
+ * - One level deep (depth is bounded by construction — stronger than MAX_WALK_DEPTH).
+ * - Bounded by MAX_SPEC_FILES.
+ * - Symlink-safe: directories and spec.md files that are symlinks are skipped.
+ * - Size-bounded: spec.md files exceeding MAX_SOURCE_BYTES are skipped.
+ * - Error-swallowing: unreadable directories are skipped silently.
+ * - Deterministic: feature entries are sorted lexicographically by featureId.
+ *
+ * Does NOT read or parse spec.md content — detection only (FR-001).
+ */
+export function detectSpeckit(directory: string): SpeckitDetection {
+	const root = path.resolve(directory);
+
+	// A-001: detection is keyed on the .specify/ marker directory.
+	const markerPath = path.join(root, SPECKIT_MARKER);
+	const markerPresent = fs.existsSync(markerPath);
+
+	if (!markerPresent) {
+		return { markerPresent: false, features: [] };
+	}
+
+	const specsRoot = path.join(root, SPECKIT_SPECS_DIR);
+	if (!fs.existsSync(specsRoot)) {
+		return { markerPresent: true, features: [] };
+	}
+
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(specsRoot, { withFileTypes: true });
+	} catch {
+		return { markerPresent: true, features: [] };
+	}
+
+	// Feature dirs are direct children of specs/ that are not symlinks.
+	const featureDirs = entries
+		.filter(
+			(entry): entry is fs.Dirent =>
+				typeof entry?.name === 'string' &&
+				!entry.isSymbolicLink() &&
+				entry.isDirectory(),
+		)
+		.sort((a, b) => a.name.localeCompare(b.name));
+
+	const features: SpeckitFeatureEntry[] = [];
+	for (const entry of featureDirs) {
+		if (features.length >= MAX_SPEC_FILES) break;
+
+		const specAbs = path.join(specsRoot, entry.name, 'spec.md');
+		let stat: fs.Stats;
+		try {
+			stat = fs.lstatSync(specAbs);
+		} catch {
+			// spec.md missing or unreadable — not a feature dir
+			continue;
+		}
+		// isFile() returns false for symlinks under lstatSync, so no separate
+		// isSymbolicLink() check is needed here.
+		if (!stat.isFile() || stat.size > MAX_SOURCE_BYTES) continue;
+
+		features.push({
+			featureId: entry.name,
+			specRelPath: toPosix(path.relative(root, specAbs)),
+		});
+	}
+
+	return { markerPresent: true, features };
+}
+
+/**
+ * Parse Spec-Kit functional requirements from a feature's spec.md content.
+ *
+ * Separate from the shared parseRequirements (:196) which MUST remain
+ * byte-untouched for OpenSpec compatibility (FR-011, critic Finding 1).
+ *
+ * Handles two cases within the `## Functional Requirements` section:
+ * (a) Explicit FR-### id (e.g. `- **FR-001**: System MUST …`) — preserve id unchanged (FR-003).
+ * (b) Id-less obligation bullet (e.g. `- System MUST …`) — id: null so nextFrId synthesises
+ *     a stable id at render time (FR-004).  This is the primary synthesis path: the shared
+ *     parseRequirements drops these lines silently because they match neither the explicit-FR
+ *     branch nor the `### Requirement:` header branch.
+ *
+ * Traversal is deterministic (top-to-bottom within the section) so synthesised ids are
+ * stable across repeated calls on the same content (FR-004, SC-003).
+ */
+function parseSpeckitRequirements(
+	content: string,
+	sourceRel: string,
+): ParsedRequirement[] {
+	const requirements: ParsedRequirement[] = [];
+	const lines = content.replace(/\r\n/g, '\n').split('\n');
+	let inFrSection = false;
+
+	for (const line of lines) {
+		// Track ## section boundaries (## only — ### or #### do not reset inFrSection).
+		if (/^##\s+/.test(line)) {
+			inFrSection = /^##\s+Functional Requirements\s*$/i.test(line);
+			continue;
+		}
+
+		if (!inFrSection) continue;
+
+		// Only process list bullets (- or *).
+		if (!/^\s*[-*]\s+/.test(line)) continue;
+
+		// Must carry an obligation keyword.
+		if (!/\b(MUST|SHALL|SHOULD|MAY)\b/i.test(line)) continue;
+
+		const text = line.trim().replace(/^\s*[-*]\s+/, '');
+
+		// Case (a): explicit FR-### id — preserve it unchanged (FR-003).
+		const explicit = line.match(/\b(FR-(?!000)\d{3})\b/);
+		if (explicit) {
+			requirements.push({
+				id: explicit[1].toUpperCase(),
+				kind: 'CURRENT',
+				title: explicit[1].toUpperCase(),
+				text,
+				sourceRel,
+			});
+			continue;
+		}
+
+		// Case (b): id-less obligation bullet — id: null for nextFrId synthesis (FR-004).
+		requirements.push({
+			id: null,
+			kind: 'CURRENT',
+			title: text,
+			text,
+			sourceRel,
+		});
+	}
+
+	return requirements;
+}
+
+/**
+ * Resolve a Spec-Kit feature projection with a discriminated result (FR-008, FR-012, FR-013).
+ *
+ * Returns one of six kinds so the command layer can produce the right error message without
+ * re-running detection:
+ * - `not_speckit`       — no `.specify/` marker (A-001).
+ * - `empty`             — marker present but no feature dirs (FR-012).
+ * - `ambiguous`         — multiple features, no `options.feature` (FR-008).
+ * - `unknown_feature`   — `options.feature` not among detected features.
+ * - `zero_requirements` — feature found but yields zero parsable FRs, or spec.md unreadable
+ *                         (FR-013; covers oversized files too).
+ * - `ok`                — valid EffectiveSpec built (FR-002, FR-003, FR-004, FR-005).
+ *
+ * This function is the single source of truth for feature selection logic.
+ * {@link buildSpeckitProjectionSync} delegates here and maps `ok → spec | null`.
+ */
+export function resolveSpeckitProjection(
+	directory: string,
+	options: { feature?: string } = {},
+): SpeckitResolution {
+	const root = path.resolve(directory);
+	const detection = detectSpeckit(root);
+
+	if (!detection.markerPresent) {
+		return { kind: 'not_speckit' };
+	}
+
+	if (detection.features.length === 0) {
+		return { kind: 'empty' };
+	}
+
+	// Feature selection.
+	let selectedFeature: SpeckitFeatureEntry;
+	if (options.feature) {
+		const found = detection.features.find((f) => f.featureId === options.feature);
+		if (!found) {
+			return {
+				kind: 'unknown_feature',
+				feature: options.feature,
+				// detectSpeckit already sorts features lexicographically.
+				available: detection.features.map((f) => f.featureId),
+			};
+		}
+		selectedFeature = found;
+	} else if (detection.features.length === 1) {
+		// Single-feature auto-select (FR-008).
+		selectedFeature = detection.features[0]!;
+	} else {
+		// Multiple features, no explicit selection — caller must name one (FR-008).
+		return {
+			kind: 'ambiguous',
+			// detectSpeckit already sorts lexicographically.
+			features: detection.features.map((f) => f.featureId),
+		};
+	}
+
+	const specAbs = path.join(root, selectedFeature.specRelPath);
+	const content = readTextBounded(specAbs);
+	// Unreadable/oversized spec.md — fold into zero_requirements (nothing to project).
+	if (content === null) {
+		return { kind: 'zero_requirements', feature: selectedFeature.featureId };
+	}
+
+	const warnings: string[] = [];
+	const usedIds = new Set<string>();
+
+	const requirements = parseSpeckitRequirements(content, selectedFeature.specRelPath);
+
+	// Mirror buildOpenSpecProjectionSync :450-453 — zero FRs → advisory (FR-013).
+	if (requirements.length === 0) {
+		return { kind: 'zero_requirements', feature: selectedFeature.featureId };
+	}
+
+	let mtimeMs = 0;
+	try {
+		mtimeMs = fs.lstatSync(specAbs).mtimeMs;
+	} catch {
+		// mtime unavailable — leave 0; caller sees mtime: null in the returned spec.
+	}
+
+	const lines: string[] = [
+		'# Specification: Effective SDD Projection',
+		'',
+		'Generated from Spec-Kit feature artifacts. Update the source artifacts, then run `/swarm sdd project` to refresh this projection.',
+		'',
+		'## Source Artifacts',
+		`- ${selectedFeature.specRelPath}`,
+		'',
+		'## Functional Requirements',
+	];
+
+	for (const req of requirements) {
+		lines.push(renderRequirement(req, usedIds, warnings));
+	}
+
+	const projected = `${lines.join('\n')}\n`;
+
+	if (projected.length > MAX_SPEC_BYTES) {
+		// Requirements parsed successfully but the projected output is too large to use.
+		// This is a distinct reason from zero_requirements — surface it accurately so the
+		// command layer (FR-013 messaging) does not falsely report "no requirements".
+		return {
+			kind: 'too_large',
+			feature: selectedFeature.featureId,
+			bytes: projected.length,
+		};
+	}
+
+	const validation = validateSpecContent(projected);
+	if (!validation.valid) {
+		warnings.push(
+			...validation.issues.map(
+				(issue) => `Projection line ${issue.line}: ${issue.message}`,
+			),
+		);
+	}
+
+	const spec: EffectiveSpec = {
+		source: 'speckit_projection',
+		content: projected,
+		hash: hash(projected),
+		mtime: mtimeMs > 0 ? new Date(mtimeMs).toISOString() : null,
+		sourcePaths: [selectedFeature.specRelPath],
+		warnings,
+	};
+
+	return { kind: 'ok', spec, feature: selectedFeature.featureId };
+}
+
+/**
+ * Project a single Spec-Kit feature into an EffectiveSpec (FR-002, FR-003, FR-004, FR-005).
+ *
+ * Delegates all selection and build logic to {@link resolveSpeckitProjection} — that function
+ * is the single source of truth for feature selection.  This wrapper preserves the existing
+ * `EffectiveSpec | null` contract so all call sites (task 2.2, tests) are unchanged.
+ *
+ * Returns null when resolution is anything other than `ok` (not_speckit, empty, ambiguous,
+ * unknown_feature, zero_requirements).  Callers that need the failure reason should call
+ * {@link resolveSpeckitProjection} directly.
+ */
+export function buildSpeckitProjectionSync(
+	directory: string,
+	options: { feature?: string } = {},
+): EffectiveSpec | null {
+	const resolution = resolveSpeckitProjection(directory, options);
+	return resolution.kind === 'ok' ? resolution.spec : null;
 }
 
 export function loadSddStatusSync(directory: string): SddStatus {

--- a/src/sdd/effective-spec.ts
+++ b/src/sdd/effective-spec.ts
@@ -132,11 +132,25 @@ function hash(content: string): string {
 }
 
 function readTextBounded(absPath: string): string | null {
-	const stat = fs.lstatSync(absPath);
+	let stat: fs.Stats;
+	try {
+		stat = fs.lstatSync(absPath);
+	} catch {
+		// File vanished between detection and read (narrow TOCTOU) or is unreadable.
+		// Return null so callers (resolveSpeckitProjection, validateSpeckit) fold this
+		// into their existing null-handling instead of crashing. Mirrors fileArtifact.
+		return null;
+	}
 	if (!stat.isFile() || stat.size > MAX_SOURCE_BYTES) {
 		return null;
 	}
-	return fs.readFileSync(absPath, 'utf-8');
+	try {
+		return fs.readFileSync(absPath, 'utf-8');
+	} catch {
+		// File vanished or became unreadable between the lstatSync check and the read.
+		// Same null-folding contract as the lstatSync guard above.
+		return null;
+	}
 }
 
 function fileArtifact(root: string, absPath: string): OpenSpecArtifact | null {
@@ -356,9 +370,12 @@ function renderRequirement(
 export function detectSpeckit(directory: string): SpeckitDetection {
 	const root = path.resolve(directory);
 
-	// A-001: detection is keyed on the .specify/ marker directory.
+	// A-001: detection is keyed on the .specify/ marker DIRECTORY at the repo root.
+	// statSync (not lstatSync) so a symlinked marker dir is followed; a regular file
+	// named .specify is correctly rejected as non-conformant with the Spec-Kit layout.
 	const markerPath = path.join(root, SPECKIT_MARKER);
-	const markerPresent = fs.existsSync(markerPath);
+	const markerPresent =
+		fs.statSync(markerPath, { throwIfNoEntry: false })?.isDirectory() ?? false;
 
 	if (!markerPresent) {
 		return { markerPresent: false, features: [] };
@@ -414,7 +431,7 @@ export function detectSpeckit(directory: string): SpeckitDetection {
 /**
  * Parse Spec-Kit functional requirements from a feature's spec.md content.
  *
- * Separate from the shared parseRequirements (:196) which MUST remain
+ * Separate from parseRequirements (the OpenSpec parser) which MUST remain
  * byte-untouched for OpenSpec compatibility (FR-011, critic Finding 1).
  *
  * Handles two cases within the `## Functional Requirements` section:
@@ -551,7 +568,7 @@ export function resolveSpeckitProjection(
 		selectedFeature.specRelPath,
 	);
 
-	// Mirror buildOpenSpecProjectionSync :450-453 — zero FRs → advisory (FR-013).
+	// Mirror buildOpenSpecProjectionSync's zero-FR handling — zero FRs → advisory (FR-013).
 	if (requirements.length === 0) {
 		return { kind: 'zero_requirements', feature: selectedFeature.featureId };
 	}
@@ -1098,7 +1115,7 @@ export function validateSpeckit(
 			// task has neither (a task that explicitly references FR-001, or a setup task
 			// tagged to a story, is a legitimate reference and must not be flagged).
 			const hasStoryRef = /\[US\d+\]/i.test(line);
-			const hasReqRef = /\bFR-\d{3}\b/i.test(line);
+			const hasReqRef = /\bFR-(?!000)\d{3}\b/i.test(line);
 			if (!hasStoryRef && !hasReqRef) {
 				problems.push(`Task ${taskId} has no spec/requirement reference.`);
 			}

--- a/src/sdd/effective-spec.ts
+++ b/src/sdd/effective-spec.ts
@@ -285,10 +285,24 @@ function parseRequirements(
 	return requirements;
 }
 
-function nextFrId(used: Set<string>, warnings: string[]): string {
+/**
+ * Allocate the next free synthesized FR id.
+ *
+ * `reserved` (optional) holds ids that explicit requirements own but have not yet
+ * been emitted (e.g. an explicit `FR-001` that appears AFTER an id-less bullet in
+ * document order). Synthesis must skip those so it never steals an explicit id and
+ * forces a spurious renumber (FR-003, Bug 1). When `reserved` is undefined the
+ * behavior is byte-identical to the pre-fix allocator — the OpenSpec path relies on
+ * this, so its projection output is unchanged.
+ */
+function nextFrId(
+	used: Set<string>,
+	warnings: string[],
+	reserved?: Set<string>,
+): string {
 	for (let n = 1; n <= 999; n++) {
 		const id = `FR-${String(n).padStart(3, '0')}`;
-		if (!used.has(id)) {
+		if (!used.has(id) && !reserved?.has(id)) {
 			used.add(id);
 			return id;
 		}
@@ -301,8 +315,10 @@ function renderRequirement(
 	req: ParsedRequirement,
 	used: Set<string>,
 	warnings: string[],
+	reserved?: Set<string>,
 ): string {
-	const id = req.id && !used.has(req.id) ? req.id : nextFrId(used, warnings);
+	const id =
+		req.id && !used.has(req.id) ? req.id : nextFrId(used, warnings, reserved);
 	if (req.id && req.id !== id) {
 		warnings.push(
 			`Duplicate requirement id ${req.id} in ${req.sourceRel}; generated ${id}.`,
@@ -532,6 +548,18 @@ export function resolveSpeckitProjection(
 		return { kind: 'zero_requirements', feature: selectedFeature.featureId };
 	}
 
+	// FR-003 (Bug 1): pre-scan and reserve every explicit id BEFORE the render loop so
+	// synthesis (nextFrId) never steals an explicit FR-### that appears later in document
+	// order. Without this, an id-less bullet before an explicit `FR-001` would allocate
+	// FR-001 for itself and force the real explicit `FR-001` to renumber (FR-002) with a
+	// "Duplicate requirement id" warning. Reserving (rather than seeding usedIds) keeps each
+	// explicit requirement rendering with its OWN id and preserves the genuine
+	// duplicate-explicit-id warning (two explicit reqs truly sharing an id).
+	const reservedIds = new Set<string>();
+	for (const req of requirements) {
+		if (req.id) reservedIds.add(req.id);
+	}
+
 	let mtimeMs = 0;
 	try {
 		mtimeMs = fs.lstatSync(specAbs).mtimeMs;
@@ -551,7 +579,7 @@ export function resolveSpeckitProjection(
 	];
 
 	for (const req of requirements) {
-		lines.push(renderRequirement(req, usedIds, warnings));
+		lines.push(renderRequirement(req, usedIds, warnings, reservedIds));
 	}
 
 	const projected = `${lines.join('\n')}\n`;

--- a/tests/helpers/speckit-fixture.test.ts
+++ b/tests/helpers/speckit-fixture.test.ts
@@ -43,7 +43,11 @@ function readFile(absPath: string): string {
 describe('writeSpeckitFixture — single-explicit-fr', () => {
 	test('writes .specify/memory/constitution.md', () => {
 		const d = writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
-		const constitutionPath = path.join(d.specifyDir, 'memory', 'constitution.md');
+		const constitutionPath = path.join(
+			d.specifyDir,
+			'memory',
+			'constitution.md',
+		);
 		expect(fs.existsSync(constitutionPath)).toBe(true);
 		expect(readFile(constitutionPath)).toContain('Spec-Kit');
 	});
@@ -115,12 +119,16 @@ describe('writeSpeckitFixture — single-explicit-fr', () => {
 
 describe('writeSpeckitFixture — single-idless-requirements', () => {
 	test('descriptor has exactly one feature dir', () => {
-		const d = writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+		const d = writeSpeckitFixture(tempDir, {
+			variant: 'single-idless-requirements',
+		});
 		expect(d.featureDirs).toHaveLength(1);
 	});
 
 	test('spec.md has no FR-### ids at all (any form)', () => {
-		const d = writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+		const d = writeSpeckitFixture(tempDir, {
+			variant: 'single-idless-requirements',
+		});
 		const content = readFile(d.specPaths[0]!);
 		// There must be NO FR-### token in any form — the FR-004 synthesis path
 		// depends on this variant being genuinely id-less.
@@ -128,13 +136,17 @@ describe('writeSpeckitFixture — single-idless-requirements', () => {
 	});
 
 	test('spec.md still contains obligation keywords (MUST/SHALL/SHOULD)', () => {
-		const d = writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+		const d = writeSpeckitFixture(tempDir, {
+			variant: 'single-idless-requirements',
+		});
 		const content = readFile(d.specPaths[0]!);
 		expect(content).toMatch(/\b(MUST|SHALL|SHOULD)\b/);
 	});
 
 	test('spec.md has all three required Spec-Kit sections', () => {
-		const d = writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+		const d = writeSpeckitFixture(tempDir, {
+			variant: 'single-idless-requirements',
+		});
 		const content = readFile(d.specPaths[0]!);
 		expect(content).toContain('## Functional Requirements');
 		expect(content).toContain('## User Scenarios & Testing');
@@ -142,10 +154,14 @@ describe('writeSpeckitFixture — single-idless-requirements', () => {
 	});
 
 	test('has at least two obligation bullets so synthesis ordering can be tested', () => {
-		const d = writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+		const d = writeSpeckitFixture(tempDir, {
+			variant: 'single-idless-requirements',
+		});
 		const content = readFile(d.specPaths[0]!);
 		// Each obligation bullet starts with "- System"
-		const bullets = content.split('\n').filter((line) => /^- System\s+(MUST|SHALL|SHOULD)/.test(line));
+		const bullets = content
+			.split('\n')
+			.filter((line) => /^- System\s+(MUST|SHALL|SHOULD)/.test(line));
 		expect(bullets.length).toBeGreaterThanOrEqual(2);
 	});
 });
@@ -204,7 +220,11 @@ describe('writeSpeckitFixture — empty-specify', () => {
 
 	test('.specify/memory/constitution.md is still written', () => {
 		const d = writeSpeckitFixture(tempDir, { variant: 'empty-specify' });
-		const constitutionPath = path.join(d.specifyDir, 'memory', 'constitution.md');
+		const constitutionPath = path.join(
+			d.specifyDir,
+			'memory',
+			'constitution.md',
+		);
 		expect(fs.existsSync(constitutionPath)).toBe(true);
 	});
 
@@ -281,7 +301,7 @@ describe('writeSpeckitFixture — malformed', () => {
 		// T001 has [P] (parallelizable flag) but deliberately has no [US#] reference
 		const t001Line = content.split('\n').find((l) => l.includes('T001'));
 		expect(t001Line).toBeDefined();
-		expect(t001Line).toContain('[P]');       // has the parallelizable flag
+		expect(t001Line).toContain('[P]'); // has the parallelizable flag
 		expect(t001Line).not.toMatch(/\[US\d+\]/); // but no story/requirement reference
 	});
 
@@ -312,7 +332,9 @@ describe('writeSpeckitFixture — cross-variant invariants', () => {
 		test(`variant "${variant}" — .specify/ is always written`, () => {
 			const d = writeSpeckitFixture(tempDir, { variant });
 			expect(fs.existsSync(d.specifyDir)).toBe(true);
-			expect(fs.existsSync(path.join(d.specifyDir, 'memory', 'constitution.md'))).toBe(true);
+			expect(
+				fs.existsSync(path.join(d.specifyDir, 'memory', 'constitution.md')),
+			).toBe(true);
 		});
 
 		test(`variant "${variant}" — descriptor paths are absolute`, () => {

--- a/tests/helpers/speckit-fixture.test.ts
+++ b/tests/helpers/speckit-fixture.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Self-test for tests/helpers/speckit-fixture.ts (task 1.1, issue #1228).
+ *
+ * Verifies that writeSpeckitFixture correctly writes all six fixture variants
+ * and that the descriptor paths resolve to files with the expected content.
+ * Assertions are content-based (not just "file exists") to catch content bugs.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { writeSpeckitFixture } from './speckit-fixture';
+
+// ---------------------------------------------------------------------------
+// Temp-dir lifecycle — mirrors effective-spec.test.ts convention
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+
+beforeEach(() => {
+	tempDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'speckit-fixture-test-')),
+	);
+});
+
+afterEach(() => {
+	fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function readFile(absPath: string): string {
+	return fs.readFileSync(absPath, 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Variant 1 — single-explicit-fr
+// ---------------------------------------------------------------------------
+
+describe('writeSpeckitFixture — single-explicit-fr', () => {
+	test('writes .specify/memory/constitution.md', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+		const constitutionPath = path.join(d.specifyDir, 'memory', 'constitution.md');
+		expect(fs.existsSync(constitutionPath)).toBe(true);
+		expect(readFile(constitutionPath)).toContain('Spec-Kit');
+	});
+
+	test('descriptor has exactly one feature dir', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+		expect(d.featureDirs).toHaveLength(1);
+		expect(d.specPaths).toHaveLength(1);
+		expect(d.tasksPaths).toHaveLength(1);
+	});
+
+	test('feature dir is named 001-auth-service', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+		expect(path.basename(d.featureDirs[0]!)).toBe('001-auth-service');
+	});
+
+	test('spec.md exists and contains ## Functional Requirements section', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+		expect(fs.existsSync(d.specPaths[0]!)).toBe(true);
+		expect(readFile(d.specPaths[0]!)).toContain('## Functional Requirements');
+	});
+
+	test('spec.md contains ## User Scenarios & Testing section', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+		expect(readFile(d.specPaths[0]!)).toContain('## User Scenarios & Testing');
+	});
+
+	test('spec.md contains ## Success Criteria section', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+		expect(readFile(d.specPaths[0]!)).toContain('## Success Criteria');
+	});
+
+	test('spec.md contains explicit FR-### ids in Spec-Kit bold form', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+		const content = readFile(d.specPaths[0]!);
+		expect(content).toContain('**FR-001**');
+		expect(content).toContain('**FR-002**');
+		expect(content).toContain('**FR-003**');
+	});
+
+	test('spec.md contains obligation keywords', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+		const content = readFile(d.specPaths[0]!);
+		expect(content).toMatch(/\b(MUST|SHALL|SHOULD|MAY)\b/);
+	});
+
+	test('tasks.md exists and contains a Spec-Kit task with literal [P] parallelizable marker and [US#] reference', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+		expect(fs.existsSync(d.tasksPaths[0]!)).toBe(true);
+		const content = readFile(d.tasksPaths[0]!);
+		expect(content).toContain('- [ ] T001');
+		// [P] is the literal parallelizable flag — NOT [P1] or [P2]
+		expect(content).toMatch(/- \[ \] T\d{3} \[P\] /);
+		expect(content).toContain('[US1]');
+	});
+
+	test('descriptor paths are absolute and under the temp dir', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+		expect(path.isAbsolute(d.specifyDir)).toBe(true);
+		expect(path.isAbsolute(d.featureDirs[0]!)).toBe(true);
+		expect(d.specifyDir.startsWith(tempDir)).toBe(true);
+		expect(d.featureDirs[0]!.startsWith(tempDir)).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Variant 2 — single-idless-requirements
+// ---------------------------------------------------------------------------
+
+describe('writeSpeckitFixture — single-idless-requirements', () => {
+	test('descriptor has exactly one feature dir', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+		expect(d.featureDirs).toHaveLength(1);
+	});
+
+	test('spec.md has no FR-### ids at all (any form)', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+		const content = readFile(d.specPaths[0]!);
+		// There must be NO FR-### token in any form — the FR-004 synthesis path
+		// depends on this variant being genuinely id-less.
+		expect(content).not.toMatch(/\bFR-\d{3}\b/);
+	});
+
+	test('spec.md still contains obligation keywords (MUST/SHALL/SHOULD)', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+		const content = readFile(d.specPaths[0]!);
+		expect(content).toMatch(/\b(MUST|SHALL|SHOULD)\b/);
+	});
+
+	test('spec.md has all three required Spec-Kit sections', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+		const content = readFile(d.specPaths[0]!);
+		expect(content).toContain('## Functional Requirements');
+		expect(content).toContain('## User Scenarios & Testing');
+		expect(content).toContain('## Success Criteria');
+	});
+
+	test('has at least two obligation bullets so synthesis ordering can be tested', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+		const content = readFile(d.specPaths[0]!);
+		// Each obligation bullet starts with "- System"
+		const bullets = content.split('\n').filter((line) => /^- System\s+(MUST|SHALL|SHOULD)/.test(line));
+		expect(bullets.length).toBeGreaterThanOrEqual(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Variant 3 — multi-feature
+// ---------------------------------------------------------------------------
+
+describe('writeSpeckitFixture — multi-feature', () => {
+	test('descriptor has exactly two feature dirs', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+		expect(d.featureDirs).toHaveLength(2);
+		expect(d.specPaths).toHaveLength(2);
+		expect(d.tasksPaths).toHaveLength(2);
+	});
+
+	test('feature dirs are sorted: 001-alpha before 002-beta', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+		expect(path.basename(d.featureDirs[0]!)).toBe('001-alpha');
+		expect(path.basename(d.featureDirs[1]!)).toBe('002-beta');
+	});
+
+	test('both spec.md files exist on disk', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+		expect(fs.existsSync(d.specPaths[0]!)).toBe(true);
+		expect(fs.existsSync(d.specPaths[1]!)).toBe(true);
+	});
+
+	test('both features restart at FR-001 (per-feature numbering)', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+		const alphaContent = readFile(d.specPaths[0]!);
+		const betaContent = readFile(d.specPaths[1]!);
+		// Both contain FR-001 — this is the cross-feature collision Follow-up A must resolve
+		expect(alphaContent).toContain('**FR-001**');
+		expect(betaContent).toContain('**FR-001**');
+	});
+
+	test('both tasks.md files exist', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+		expect(fs.existsSync(d.tasksPaths[0]!)).toBe(true);
+		expect(fs.existsSync(d.tasksPaths[1]!)).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Variant 4 — empty-specify
+// ---------------------------------------------------------------------------
+
+describe('writeSpeckitFixture — empty-specify', () => {
+	test('descriptor has empty feature arrays', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'empty-specify' });
+		expect(d.featureDirs).toHaveLength(0);
+		expect(d.specPaths).toHaveLength(0);
+		expect(d.tasksPaths).toHaveLength(0);
+	});
+
+	test('.specify/memory/constitution.md is still written', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'empty-specify' });
+		const constitutionPath = path.join(d.specifyDir, 'memory', 'constitution.md');
+		expect(fs.existsSync(constitutionPath)).toBe(true);
+	});
+
+	test('no specs/ directory is created', () => {
+		writeSpeckitFixture(tempDir, { variant: 'empty-specify' });
+		expect(fs.existsSync(path.join(tempDir, 'specs'))).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Variant 5 — zero-fr
+// ---------------------------------------------------------------------------
+
+describe('writeSpeckitFixture — zero-fr', () => {
+	test('descriptor has exactly one feature dir', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'zero-fr' });
+		expect(d.featureDirs).toHaveLength(1);
+	});
+
+	test('spec.md contains ## Functional Requirements section', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'zero-fr' });
+		expect(readFile(d.specPaths[0]!)).toContain('## Functional Requirements');
+	});
+
+	test('spec.md has NO **FR-###** bold ids', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'zero-fr' });
+		expect(readFile(d.specPaths[0]!)).not.toMatch(/\*\*FR-\d{3}\*\*/);
+	});
+
+	test('spec.md has no plain FR-### ids either', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'zero-fr' });
+		expect(readFile(d.specPaths[0]!)).not.toMatch(/\bFR-\d{3}\b/);
+	});
+
+	test('spec.md has all three required Spec-Kit headings', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'zero-fr' });
+		const content = readFile(d.specPaths[0]!);
+		expect(content).toContain('## Functional Requirements');
+		expect(content).toContain('## User Scenarios & Testing');
+		expect(content).toContain('## Success Criteria');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Variant 6 — malformed
+// ---------------------------------------------------------------------------
+
+describe('writeSpeckitFixture — malformed', () => {
+	test('descriptor has exactly one feature dir', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'malformed' });
+		expect(d.featureDirs).toHaveLength(1);
+	});
+
+	test('spec.md has a valid FR requirement (so it is not a zero-fr)', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'malformed' });
+		expect(readFile(d.specPaths[0]!)).toContain('**FR-001**');
+	});
+
+	test('spec.md is MISSING the ## Success Criteria section', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'malformed' });
+		expect(readFile(d.specPaths[0]!)).not.toContain('## Success Criteria');
+	});
+
+	test('spec.md still has ## Functional Requirements and ## User Scenarios & Testing', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'malformed' });
+		const content = readFile(d.specPaths[0]!);
+		expect(content).toContain('## Functional Requirements');
+		expect(content).toContain('## User Scenarios & Testing');
+	});
+
+	test('tasks.md contains a task with NO [US#] reference (T001) — T001 keeps [P] so validator must key on missing story reference specifically', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'malformed' });
+		const content = readFile(d.tasksPaths[0]!);
+		// T001 has [P] (parallelizable flag) but deliberately has no [US#] reference
+		const t001Line = content.split('\n').find((l) => l.includes('T001'));
+		expect(t001Line).toBeDefined();
+		expect(t001Line).toContain('[P]');       // has the parallelizable flag
+		expect(t001Line).not.toMatch(/\[US\d+\]/); // but no story/requirement reference
+	});
+
+	test('tasks.md contains a valid task (T002) to distinguish which is flagged', () => {
+		const d = writeSpeckitFixture(tempDir, { variant: 'malformed' });
+		const content = readFile(d.tasksPaths[0]!);
+		const t002Line = content.split('\n').find((l) => l.includes('T002'));
+		expect(t002Line).toBeDefined();
+		expect(t002Line).toMatch(/\[US\d+\]/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Cross-variant invariants
+// ---------------------------------------------------------------------------
+
+describe('writeSpeckitFixture — cross-variant invariants', () => {
+	const variants = [
+		'single-explicit-fr',
+		'single-idless-requirements',
+		'multi-feature',
+		'empty-specify',
+		'zero-fr',
+		'malformed',
+	] as const;
+
+	for (const variant of variants) {
+		test(`variant "${variant}" — .specify/ is always written`, () => {
+			const d = writeSpeckitFixture(tempDir, { variant });
+			expect(fs.existsSync(d.specifyDir)).toBe(true);
+			expect(fs.existsSync(path.join(d.specifyDir, 'memory', 'constitution.md'))).toBe(true);
+		});
+
+		test(`variant "${variant}" — descriptor paths are absolute`, () => {
+			const d = writeSpeckitFixture(tempDir, { variant });
+			expect(path.isAbsolute(d.specifyDir)).toBe(true);
+			for (const p of [...d.featureDirs, ...d.specPaths, ...d.tasksPaths]) {
+				expect(path.isAbsolute(p)).toBe(true);
+			}
+		});
+
+		test(`variant "${variant}" — all descriptor paths are under tempDir`, () => {
+			const d = writeSpeckitFixture(tempDir, { variant });
+			const allPaths = [
+				d.specifyDir,
+				...d.featureDirs,
+				...d.specPaths,
+				...d.tasksPaths,
+			];
+			for (const p of allPaths) {
+				expect(p.startsWith(tempDir)).toBe(true);
+			}
+		});
+
+		test(`variant "${variant}" — featureDirs, specPaths, tasksPaths have equal length`, () => {
+			const d = writeSpeckitFixture(tempDir, { variant });
+			expect(d.specPaths.length).toBe(d.featureDirs.length);
+			expect(d.tasksPaths.length).toBe(d.featureDirs.length);
+		});
+	}
+});

--- a/tests/helpers/speckit-fixture.ts
+++ b/tests/helpers/speckit-fixture.ts
@@ -301,7 +301,10 @@ export function writeSpeckitFixture(
 
 	// Always write the marker directory
 	const specifyDir = path.join(dir, '.specify');
-	writeFile(path.join(specifyDir, 'memory', 'constitution.md'), CONSTITUTION_CONTENT);
+	writeFile(
+		path.join(specifyDir, 'memory', 'constitution.md'),
+		CONSTITUTION_CONTENT,
+	);
 
 	const specsRoot = path.join(dir, 'specs');
 

--- a/tests/helpers/speckit-fixture.ts
+++ b/tests/helpers/speckit-fixture.ts
@@ -1,0 +1,386 @@
+/**
+ * Spec-Kit test fixture helper — task 1.1 (issue #1228, v1).
+ *
+ * Writes a minimal, valid GitHub Spec-Kit layout into a caller-provided
+ * temp directory.  The caller owns temp-dir lifecycle (create + cleanup);
+ * this helper only writes files.
+ *
+ * Spec-Kit layout (verified against github.com/github/spec-kit templates):
+ *   .specify/memory/constitution.md          — marker directory; stub content
+ *   specs/NNN-feature-name/spec.md           — FR section in bold form
+ *   specs/NNN-feature-name/tasks.md          — task list with [US#] references
+ *
+ * Usage:
+ *   import { writeSpeckitFixture } from '../helpers/speckit-fixture';
+ *   const descriptor = writeSpeckitFixture(dir, { variant: 'single-explicit-fr' });
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * The six fixture variants the later tests (1.2–3.1) need.
+ *
+ * 1. single-explicit-fr         — happy path: one feature, explicit FR-### ids
+ * 2. single-idless-requirements — FR-004 synthesis: obligations with no FR-### prefix
+ * 3. multi-feature              — two feature dirs, each restarting at FR-001
+ * 4. empty-specify              — .specify/ marker present; no specs/ dirs
+ * 5. zero-fr                    — feature dir exists; spec.md has no FR bullets
+ * 6. malformed                  — missing "## Success Criteria" section +
+ *                                  a tasks.md task with no [US#]/FR reference
+ */
+export type SpeckitVariant =
+	| 'single-explicit-fr'
+	| 'single-idless-requirements'
+	| 'multi-feature'
+	| 'empty-specify'
+	| 'zero-fr'
+	| 'malformed';
+
+/** Paths returned by writeSpeckitFixture so callers avoid hardcoding names. */
+export interface SpeckitFixtureDescriptor {
+	/** Absolute path to the .specify/ directory (always written). */
+	specifyDir: string;
+	/**
+	 * Absolute paths to specs/NNN-.../ feature directories, sorted
+	 * lexicographically.  Empty for the 'empty-specify' variant.
+	 */
+	featureDirs: string[];
+	/**
+	 * Absolute paths to spec.md files, index-parallel to featureDirs.
+	 * Empty for the 'empty-specify' variant.
+	 */
+	specPaths: string[];
+	/**
+	 * Absolute paths to tasks.md files, index-parallel to featureDirs.
+	 * Empty for the 'empty-specify' variant.
+	 */
+	tasksPaths: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Content helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal content for `.specify/memory/constitution.md`.
+ * This is Spec-Kit's unambiguous marker directory.
+ */
+const CONSTITUTION_CONTENT =
+	'# Spec-Kit Constitution\n\nThis repository uses GitHub Spec-Kit for specification-driven development.\n';
+
+/**
+ * Canonical valid spec.md for a single feature with explicit FR-### identifiers.
+ * Tests FR-001–FR-003, FR-005, SC-001.
+ */
+const SPEC_SINGLE_EXPLICIT_FR = `\
+# 001-auth-service — Authentication Service
+
+## Functional Requirements
+
+- **FR-001**: System MUST authenticate users with valid credentials.
+- **FR-002**: System SHALL invalidate sessions after 24 hours of inactivity.
+- **FR-003**: System SHOULD support multi-factor authentication.
+
+## User Scenarios & Testing
+
+### Scenario: Successful login
+- **Given** a registered user with valid credentials
+- **When** the user submits their credentials
+- **Then** the system grants access and creates a session
+
+### Scenario: Session expiry
+- **Given** an authenticated user with an inactive session
+- **When** the inactivity threshold is exceeded
+- **Then** the system invalidates the session and requires re-authentication
+
+## Success Criteria
+
+- **SC-001**: Authenticated users can access protected resources.
+- **SC-002**: Sessions expire after the configured inactivity period.
+`;
+
+/**
+ * Valid tasks.md for a single feature (used by explicit-fr, idless, multi variants).
+ * Format: `- [ ] T### [P] [US#] <description> <file path>`
+ * [P] = parallelizable flag (task can run simultaneously with others, different files)
+ * [US#] = user story assignment (required for user-story-phase tasks)
+ */
+const TASKS_SINGLE = `\
+- [ ] T001 [P] [US1] Implement credential validation src/auth/credential-validator.ts
+- [ ] T002 [P] [US1] Implement session management src/auth/session-manager.ts
+- [ ] T003 [US2] Implement session expiry job src/auth/session-expiry.ts
+`;
+
+/**
+ * Spec.md for a feature whose requirements are id-less obligation bullets.
+ * These have MUST/SHALL/SHOULD but no FR-### prefix — the FR-004 synthesis path.
+ * Three bullets give the stability test (SC-003) ordering to exercise.
+ */
+const SPEC_SINGLE_IDLESS = `\
+# 001-auth-service — Authentication Service
+
+## Functional Requirements
+
+- System MUST authenticate users with valid credentials.
+- System SHALL invalidate sessions after 24 hours of inactivity.
+- System SHOULD support multi-factor authentication.
+
+## User Scenarios & Testing
+
+### Scenario: Successful login
+- **Given** a registered user with valid credentials
+- **When** the user submits their credentials
+- **Then** the system grants access and creates a session
+
+## Success Criteria
+
+- Users can access protected resources after authentication.
+- Sessions expire automatically after the configured period.
+`;
+
+/**
+ * spec.md for feature 001-alpha (multi-feature variant).
+ * Starts at FR-001 — Spec-Kit resets per feature.
+ */
+const SPEC_ALPHA = `\
+# 001-alpha — Alpha Feature
+
+## Functional Requirements
+
+- **FR-001**: System MUST provide the alpha capability.
+- **FR-002**: System SHALL report alpha telemetry metrics.
+
+## User Scenarios & Testing
+
+### Scenario: Alpha invocation
+- **Given** a configured alpha integration
+- **When** the user requests alpha processing
+- **Then** the system delivers the alpha result and records metrics
+
+## Success Criteria
+
+- **SC-001**: Alpha capability is available and observable.
+`;
+
+const TASKS_ALPHA = `\
+- [ ] T001 [P] [US1] Implement alpha capability src/alpha/capability.ts
+- [ ] T002 [P] [US1] Implement alpha metrics src/alpha/metrics.ts
+`;
+
+/**
+ * spec.md for feature 002-beta (multi-feature variant).
+ * Also starts at FR-001 — demonstrates per-feature collision that Follow-up A must resolve.
+ */
+const SPEC_BETA = `\
+# 002-beta — Beta Feature
+
+## Functional Requirements
+
+- **FR-001**: System MUST provide the beta capability.
+- **FR-002**: System SHALL report beta telemetry metrics.
+
+## User Scenarios & Testing
+
+### Scenario: Beta invocation
+- **Given** a configured beta integration
+- **When** the user requests beta processing
+- **Then** the system delivers the beta result and records metrics
+
+## Success Criteria
+
+- **SC-001**: Beta capability is available and observable.
+`;
+
+const TASKS_BETA = `\
+- [ ] T001 [P] [US1] Implement beta capability src/beta/capability.ts
+- [ ] T002 [P] [US1] Implement beta metrics src/beta/metrics.ts
+`;
+
+/**
+ * spec.md for variant 5 (zero-fr): has the required Spec-Kit headings but NO
+ * FR-### bullets.  The `## Functional Requirements` section exists with prose only —
+ * this tests the "zero parsable FRs" advisory path (FR-013).
+ */
+const SPEC_ZERO_FR = `\
+# 001-empty-feature — Empty Feature
+
+## Functional Requirements
+
+This feature is currently in discovery. No functional requirements have been
+defined yet. Requirements will be added once the design phase is complete.
+
+## User Scenarios & Testing
+
+TBD — scenarios will be defined alongside functional requirements.
+
+## Success Criteria
+
+TBD — success criteria will be defined once functional requirements are known.
+`;
+
+const TASKS_ZERO_FR = `\
+- [ ] T001 [P] [US1] Scaffold the feature directory src/empty-feature/index.ts
+`;
+
+/**
+ * spec.md for variant 6 (malformed): has a valid FR-001 but is MISSING the
+ * `## Success Criteria` section.  This tests the "missing required section"
+ * validation path (FR-007).
+ *
+ * Note: the missing section is `## Success Criteria`, NOT `## Functional
+ * Requirements` — that would collapse this into the zero-fr variant.
+ */
+const SPEC_MALFORMED = `\
+# 001-broken-feature — Broken Feature
+
+## Functional Requirements
+
+- **FR-001**: System MUST process requests correctly.
+- **FR-002**: System SHALL return errors for invalid input.
+
+## User Scenarios & Testing
+
+### Scenario: Valid request
+- **Given** a valid incoming request
+- **When** the system processes it
+- **Then** the correct response is returned
+
+`;
+// Intentionally omits "## Success Criteria"
+
+/**
+ * tasks.md for variant 6 (malformed): T001 has no [US#]/FR reference —
+ * this tests the "task lacking a requirement reference" validation path (FR-007).
+ * T001 keeps [P] (parallelizable flag) to ensure the validator keys on the
+ * missing story/requirement reference specifically, not on mere bracket absence.
+ * T002 is fully valid so the test can distinguish exactly which task is flagged.
+ */
+const TASKS_MALFORMED = `\
+- [ ] T001 [P] Implement request processing without any spec reference src/broken/handler.ts
+- [ ] T002 [P] [US1] Implement error handling for invalid input src/broken/error-handler.ts
+`;
+
+// ---------------------------------------------------------------------------
+// Writer utility
+// ---------------------------------------------------------------------------
+
+function writeFile(filePath: string, content: string): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a minimal, valid GitHub Spec-Kit layout into `dir`.
+ *
+ * @param dir      Absolute path to the root of a temp directory.
+ * @param options  `{ variant }` — selects which of the six fixture layouts to write.
+ * @returns        A descriptor with absolute paths for all written files.
+ *
+ * Variant summary:
+ *   'single-explicit-fr'         — 1 feature, 3 explicit FR-### ids
+ *   'single-idless-requirements' — 1 feature, 3 id-less obligation bullets (FR-004 path)
+ *   'multi-feature'              — 2 features (001-alpha, 002-beta), each with FR-001..FR-002
+ *   'empty-specify'              — .specify/ marker only; no specs/ dirs
+ *   'zero-fr'                    — 1 feature; spec.md has no FR bullets
+ *   'malformed'                  — 1 feature; missing ## Success Criteria + unreferenced task
+ */
+export function writeSpeckitFixture(
+	dir: string,
+	options: { variant: SpeckitVariant },
+): SpeckitFixtureDescriptor {
+	const { variant } = options;
+
+	// Always write the marker directory
+	const specifyDir = path.join(dir, '.specify');
+	writeFile(path.join(specifyDir, 'memory', 'constitution.md'), CONSTITUTION_CONTENT);
+
+	const specsRoot = path.join(dir, 'specs');
+
+	if (variant === 'empty-specify') {
+		return { specifyDir, featureDirs: [], specPaths: [], tasksPaths: [] };
+	}
+
+	if (variant === 'single-explicit-fr') {
+		const featureDir = path.join(specsRoot, '001-auth-service');
+		const specPath = path.join(featureDir, 'spec.md');
+		const tasksPath = path.join(featureDir, 'tasks.md');
+		writeFile(specPath, SPEC_SINGLE_EXPLICIT_FR);
+		writeFile(tasksPath, TASKS_SINGLE);
+		return {
+			specifyDir,
+			featureDirs: [featureDir],
+			specPaths: [specPath],
+			tasksPaths: [tasksPath],
+		};
+	}
+
+	if (variant === 'single-idless-requirements') {
+		const featureDir = path.join(specsRoot, '001-auth-service');
+		const specPath = path.join(featureDir, 'spec.md');
+		const tasksPath = path.join(featureDir, 'tasks.md');
+		writeFile(specPath, SPEC_SINGLE_IDLESS);
+		writeFile(tasksPath, TASKS_SINGLE);
+		return {
+			specifyDir,
+			featureDirs: [featureDir],
+			specPaths: [specPath],
+			tasksPaths: [tasksPath],
+		};
+	}
+
+	if (variant === 'multi-feature') {
+		const alphaDir = path.join(specsRoot, '001-alpha');
+		const betaDir = path.join(specsRoot, '002-beta');
+		const alphaSpec = path.join(alphaDir, 'spec.md');
+		const alphaTasks = path.join(alphaDir, 'tasks.md');
+		const betaSpec = path.join(betaDir, 'spec.md');
+		const betaTasks = path.join(betaDir, 'tasks.md');
+		writeFile(alphaSpec, SPEC_ALPHA);
+		writeFile(alphaTasks, TASKS_ALPHA);
+		writeFile(betaSpec, SPEC_BETA);
+		writeFile(betaTasks, TASKS_BETA);
+		// Sorted lexicographically — 001-alpha before 002-beta
+		return {
+			specifyDir,
+			featureDirs: [alphaDir, betaDir],
+			specPaths: [alphaSpec, betaSpec],
+			tasksPaths: [alphaTasks, betaTasks],
+		};
+	}
+
+	if (variant === 'zero-fr') {
+		const featureDir = path.join(specsRoot, '001-empty-feature');
+		const specPath = path.join(featureDir, 'spec.md');
+		const tasksPath = path.join(featureDir, 'tasks.md');
+		writeFile(specPath, SPEC_ZERO_FR);
+		writeFile(tasksPath, TASKS_ZERO_FR);
+		return {
+			specifyDir,
+			featureDirs: [featureDir],
+			specPaths: [specPath],
+			tasksPaths: [tasksPath],
+		};
+	}
+
+	// variant === 'malformed'
+	const featureDir = path.join(specsRoot, '001-broken-feature');
+	const specPath = path.join(featureDir, 'spec.md');
+	const tasksPath = path.join(featureDir, 'tasks.md');
+	writeFile(specPath, SPEC_MALFORMED);
+	writeFile(tasksPath, TASKS_MALFORMED);
+	return {
+		specifyDir,
+		featureDirs: [featureDir],
+		specPaths: [specPath],
+		tasksPaths: [tasksPath],
+	};
+}

--- a/tests/unit/commands/sdd.test.ts
+++ b/tests/unit/commands/sdd.test.ts
@@ -3,10 +3,14 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+	_test_exports,
 	handleSddProjectCommand,
 	handleSddStatusCommand,
 	handleSddValidateCommand,
 } from '../../../src/commands/sdd';
+import { writeSpeckitFixture } from '../../helpers/speckit-fixture';
+
+const { parseArgs } = _test_exports;
 
 let tempDir: string;
 
@@ -111,5 +115,453 @@ describe('/swarm sdd command handlers', () => {
 		expect(out).toContain('SDD projection written');
 		expect(spec).toContain('Effective SDD Projection');
 		expect(spec).toContain('FR-001: The system MUST let users sign in.');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// parseArgs — new flags (task 2.2)
+// ---------------------------------------------------------------------------
+describe('parseArgs — --source and --feature flags', () => {
+	test('accepts valid --source swarm', () => {
+		const result = parseArgs(['--source', 'swarm']);
+		expect(result.error).toBeUndefined();
+		expect(result.source).toBe('swarm');
+	});
+
+	test('accepts valid --source openspec', () => {
+		const result = parseArgs(['--source', 'openspec']);
+		expect(result.error).toBeUndefined();
+		expect(result.source).toBe('openspec');
+	});
+
+	test('accepts valid --source speckit', () => {
+		const result = parseArgs(['--source', 'speckit']);
+		expect(result.error).toBeUndefined();
+		expect(result.source).toBe('speckit');
+	});
+
+	test('rejects invalid --source value with the valid set listed', () => {
+		const result = parseArgs(['--source', 'bogus']);
+		expect(result.error).toBeDefined();
+		expect(result.error).toContain('swarm');
+		expect(result.error).toContain('openspec');
+		expect(result.error).toContain('speckit');
+		expect(result.error).toContain('"bogus"');
+	});
+
+	test('rejects --source with no value', () => {
+		const result = parseArgs(['--source']);
+		expect(result.error).toBeDefined();
+		expect(result.error).toContain('--source requires a value');
+	});
+
+	test('accepts a valid safe --feature value', () => {
+		const result = parseArgs(['--feature', '001-auth-service']);
+		expect(result.error).toBeUndefined();
+		expect(result.feature).toBe('001-auth-service');
+	});
+
+	test('rejects --feature with a path separator (same check as --change)', () => {
+		const result = parseArgs(['--feature', '001/escape']);
+		expect(result.error).toBeDefined();
+		expect(result.error).toContain('--feature must be a single Spec-Kit feature directory name');
+	});
+
+	test('rejects --feature with a traversal sequence (same check as --change)', () => {
+		const result = parseArgs(['--feature', '../traverse']);
+		expect(result.error).toBeDefined();
+		expect(result.error).toContain('--feature must be a single Spec-Kit feature directory name');
+	});
+
+	test('rejects --feature with bracket characters (same check as --change)', () => {
+		const result = parseArgs(['--feature', 'bad[value]']);
+		expect(result.error).toBeDefined();
+		expect(result.error).toContain('--feature must be a single Spec-Kit feature directory name');
+	});
+
+	test('rejects --feature with no value', () => {
+		const result = parseArgs(['--feature']);
+		expect(result.error).toBeDefined();
+		expect(result.error).toContain('--feature requires a value');
+	});
+
+	test('accepts --source and --feature together', () => {
+		const result = parseArgs(['--source', 'speckit', '--feature', '001-auth']);
+		expect(result.error).toBeUndefined();
+		expect(result.source).toBe('speckit');
+		expect(result.feature).toBe('001-auth');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Spec-Kit command integration tests (task 2.2 — FR-001, FR-008, FR-009, FR-010)
+// ---------------------------------------------------------------------------
+describe('/swarm sdd command handlers — Spec-Kit', () => {
+	// Each test in this group uses a SEPARATE tempDir that starts clean (no OpenSpec).
+	let skDir: string;
+
+	beforeEach(() => {
+		skDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-sk-')),
+		);
+	});
+
+	afterEach(() => {
+		fs.rmSync(skDir, { recursive: true, force: true });
+	});
+
+	// FR-001 / SC-006: status on a Spec-Kit-only repo names the provider + features.
+	test('status on a single-feature Spec-Kit repo reports Spec-Kit provider and feature (FR-001)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
+
+		const out = await handleSddStatusCommand(skDir, []);
+
+		expect(out).toContain('## SDD Status');
+		// Spec-Kit section must appear with the feature listed.
+		expect(out).toContain('Spec-Kit provider: detected');
+		expect(out).toContain('001-auth-service');
+	});
+
+	// status --json includes speckit detection data.
+	test('status --json includes speckit field with features list', async () => {
+		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
+
+		const out = await handleSddStatusCommand(skDir, ['--json']);
+		const parsed = JSON.parse(out);
+
+		expect(parsed.speckit).toBeDefined();
+		expect(parsed.speckit.markerPresent).toBe(true);
+		expect(parsed.speckit.features).toHaveLength(1);
+		expect(parsed.speckit.features[0].featureId).toBe('001-auth-service');
+	});
+
+	// SC-001 / FR-002: project on a single-feature Spec-Kit repo writes a valid .swarm/spec.md.
+	test('project on a single-feature Spec-Kit repo materializes .swarm/spec.md (SC-001)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
+
+		const out = await handleSddProjectCommand(skDir, []);
+		const spec = fs.readFileSync(
+			path.join(skDir, '.swarm', 'spec.md'),
+			'utf-8',
+		);
+
+		expect(out).toContain('SDD projection written');
+		expect(spec).toContain('Effective SDD Projection');
+		// FR-003: original FR-### ids are preserved.
+		expect(spec).toContain('**FR-001**');
+		expect(spec).toContain('**FR-002**');
+		expect(spec).toContain('**FR-003**');
+	});
+
+	// SC-005 / FR-009 / FR-010: multi-source-no-source → error naming both + --source.
+	test('status with both openspec and speckit and no --source errors naming both sources (FR-010)', async () => {
+		// Write both sources.
+		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
+		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), { recursive: true });
+		fs.writeFileSync(
+			path.join(skDir, 'openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
+			'utf-8',
+		);
+
+		const out = await handleSddStatusCommand(skDir, []);
+
+		expect(out).toContain('Error:');
+		expect(out.toLowerCase()).toContain('openspec');
+		expect(out.toLowerCase()).toContain('speckit');
+		expect(out).toContain('--source');
+	});
+
+	// FR-009: an explicit --source must win on a both-present repo — status must
+	// report that provider and must NOT leak the resolver's ambiguity console.warn.
+	test('status --source openspec on a both-present repo honors the selection and emits no warning (FR-009)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
+		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), { recursive: true });
+		fs.writeFileSync(
+			path.join(skDir, 'openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
+			'utf-8',
+		);
+
+		const original = console.warn;
+		const warnMessages: string[] = [];
+		console.warn = (...a: unknown[]) => {
+			warnMessages.push(a.map(String).join(' '));
+		};
+		let out: string;
+		try {
+			out = await handleSddStatusCommand(skDir, ['--source', 'openspec']);
+		} finally {
+			console.warn = original;
+		}
+
+		expect(out).toContain('Provider: openspec_projection');
+		expect(out).not.toContain('Provider: none');
+		expect(warnMessages).toEqual([]);
+	});
+
+	test('project with both openspec and speckit and no --source errors naming both sources (FR-010)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
+		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), { recursive: true });
+		fs.writeFileSync(
+			path.join(skDir, 'openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
+			'utf-8',
+		);
+
+		const out = await handleSddProjectCommand(skDir, []);
+
+		expect(out).toContain('Error:');
+		expect(out.toLowerCase()).toContain('openspec');
+		expect(out.toLowerCase()).toContain('speckit');
+		expect(out).toContain('--source');
+	});
+
+	// SC-009 / FR-008: multi-feature-no-feature → error naming features + --feature.
+	test('project with multi-feature Spec-Kit and no --feature errors naming features (FR-008)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'multi-feature' });
+
+		const out = await handleSddProjectCommand(skDir, []);
+
+		expect(out).toContain('Error:');
+		expect(out).toContain('001-alpha');
+		expect(out).toContain('002-beta');
+		expect(out).toContain('--feature');
+	});
+
+	// --source speckit selects speckit when openspec is also present (SC-005).
+	test('project --source speckit selects speckit when openspec also present (SC-005)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
+		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), { recursive: true });
+		fs.writeFileSync(
+			path.join(skDir, 'openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
+			'utf-8',
+		);
+
+		const out = await handleSddProjectCommand(skDir, ['--source', 'speckit']);
+		const spec = fs.readFileSync(
+			path.join(skDir, '.swarm', 'spec.md'),
+			'utf-8',
+		);
+
+		expect(out).toContain('SDD projection written');
+		// Content must be from the Spec-Kit feature (has bold FR markers), not OpenSpec.
+		expect(spec).toContain('**FR-001**');
+		// Source path must be specs/... (speckit), not openspec/...
+		expect(spec).toContain('specs/001-auth-service/spec.md');
+		expect(spec).not.toContain('openspec/');
+	});
+
+	// SC-009 / FR-008: --feature selects the correct feature in a multi-feature repo.
+	test('project --feature selects the correct feature in a multi-feature Spec-Kit repo (SC-009)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'multi-feature' });
+
+		const out = await handleSddProjectCommand(skDir, ['--feature', '002-beta']);
+		const spec = fs.readFileSync(
+			path.join(skDir, '.swarm', 'spec.md'),
+			'utf-8',
+		);
+
+		expect(out).toContain('SDD projection written');
+		expect(spec).toContain('beta capability');
+		expect(spec).not.toContain('alpha');
+		expect(spec).toContain('specs/002-beta/spec.md');
+	});
+
+	// FR-008: --feature against a non-speckit source errors.
+	test('project --feature with --source openspec errors (--feature only valid with speckit)', async () => {
+		const out = await handleSddProjectCommand(skDir, [
+			'--source',
+			'openspec',
+			'--feature',
+			'001-auth',
+		]);
+
+		expect(out).toContain('Error:');
+		expect(out).toContain('--feature is only valid with --source speckit');
+	});
+
+	// FR-012: detected-but-empty Spec-Kit source errors clearly.
+	test('project on empty-specify Spec-Kit (no feature dirs) errors with detected-but-empty message (FR-012)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'empty-specify' });
+
+		// empty-specify with --source speckit → 'empty' resolution kind
+		const out = await handleSddProjectCommand(skDir, ['--source', 'speckit']);
+
+		expect(out).toContain('Error:');
+		expect(out.toLowerCase()).toContain('.specify/');
+		expect(out.toLowerCase()).toContain('no feature');
+	});
+
+	// FR-012 auto-detect: no --source, empty .specify/ and no OpenSpec → detected-but-empty (not "no OpenSpec provider").
+	test('project auto-detect on empty-specify with no openspec errors with Spec-Kit empty message (FR-012)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'empty-specify' });
+		// Explicitly no OpenSpec layout written — skDir starts clean.
+
+		const out = await handleSddProjectCommand(skDir, []);
+
+		expect(out).toContain('Error:');
+		// Must report the Spec-Kit empty condition, not the OpenSpec "no projection" message.
+		expect(out.toLowerCase()).toContain('.specify/');
+		expect(out.toLowerCase()).toContain('no feature');
+		expect(out).not.toContain('no valid OpenSpec-compatible projection');
+	});
+
+	// FR-013: zero-requirements feature errors with the accurate reason.
+	test('project on zero-fr Spec-Kit feature errors with zero-requirements reason (FR-013)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'zero-fr' });
+
+		const out = await handleSddProjectCommand(skDir, []);
+
+		expect(out).toContain('Error:');
+		expect(out).toContain('no parsable functional requirements');
+	});
+
+	// OpenSpec byte-identity guard (FR-011): project with no speckit present is unchanged.
+	test('project with no .specify/ present uses OpenSpec path byte-identically (FR-011)', async () => {
+		// tempDir already has an OpenSpec layout from the outer beforeEach but we are
+		// using skDir here (clean).  Write an OpenSpec layout into skDir directly.
+		const openspecContent =
+			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n';
+		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), {
+			recursive: true,
+		});
+		fs.writeFileSync(
+			path.join(skDir, 'openspec', 'specs', 'auth', 'spec.md'),
+			openspecContent,
+			'utf-8',
+		);
+
+		const out = await handleSddProjectCommand(skDir, []);
+
+		// Must follow the OpenSpec path and produce the OpenSpec error message format.
+		expect(out).toContain('SDD projection written');
+		const spec = fs.readFileSync(
+			path.join(skDir, '.swarm', 'spec.md'),
+			'utf-8',
+		);
+		expect(spec).toContain('Effective SDD Projection');
+		// OpenSpec projection line (not Spec-Kit).
+		expect(spec).toContain('openspec/specs/auth/spec.md');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// /swarm sdd validate — Spec-Kit routing (task 2.3, FR-007, FR-013)
+// ---------------------------------------------------------------------------
+describe('/swarm sdd validate — Spec-Kit (task 2.3)', () => {
+	let skDir: string;
+
+	beforeEach(() => {
+		skDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-sk-validate-')),
+		);
+	});
+
+	afterEach(() => {
+		fs.rmSync(skDir, { recursive: true, force: true });
+	});
+
+	// SC-007 (partial): valid single-feature Spec-Kit → provider is speckit_projection, no errors.
+	test('validate on valid single-feature Spec-Kit repo reports provider speckit_projection and no errors (SC-007)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
+
+		const out = await handleSddValidateCommand(skDir, ['--json']);
+		const parsed = JSON.parse(out);
+
+		expect(parsed.valid).toBe(true);
+		expect(parsed.provider).toBe('speckit_projection');
+		expect(parsed.errors).toHaveLength(0);
+		expect(parsed.sourcePaths.length).toBeGreaterThan(0);
+	});
+
+	// SC-007: malformed fixture → both missing Success Criteria AND T001 no-[US#] named.
+	test('validate on malformed Spec-Kit fixture reports missing Success Criteria and T001 [US#] problem (SC-007)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'malformed' });
+
+		const out = await handleSddValidateCommand(skDir, ['--json']);
+		const parsed = JSON.parse(out);
+
+		expect(parsed.valid).toBe(false);
+		expect(parsed.provider).toBe('speckit_projection');
+		// Missing section must be named.
+		expect(parsed.errors.some((e: string) => e.includes('## Success Criteria'))).toBe(true);
+		// T001 with no [US#] must be named.
+		expect(parsed.errors.some((e: string) => e.includes('T001'))).toBe(true);
+		// T002 (which has [US1]) must NOT be flagged.
+		expect(parsed.errors.some((e: string) => e.includes('T002'))).toBe(false);
+	});
+
+	// SC-010 (partial) / FR-013: zero-fr fixture → zero-requirements problem surface.
+	test('validate on zero-fr Spec-Kit fixture reports zero-requirements problem (FR-013)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'zero-fr' });
+
+		const out = await handleSddValidateCommand(skDir, ['--json']);
+		const parsed = JSON.parse(out);
+
+		expect(parsed.valid).toBe(false);
+		expect(parsed.provider).toBe('speckit_projection');
+		expect(
+			parsed.errors.some((e: string) =>
+				e.toLowerCase().includes('no parsable functional requirements'),
+			),
+		).toBe(true);
+	});
+
+	// FR-007 read-only proof: command-level — no file modified, no .swarm/spec.md created.
+	test('READ-ONLY proof: validate command does not modify any Spec-Kit artifact (FR-007)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'malformed' });
+
+		const specPath = path.join(skDir, 'specs', '001-broken-feature', 'spec.md');
+		const tasksPath = path.join(
+			skDir,
+			'specs',
+			'001-broken-feature',
+			'tasks.md',
+		);
+		const specBefore = fs.readFileSync(specPath, 'utf-8');
+		const tasksBefore = fs.readFileSync(tasksPath, 'utf-8');
+
+		await handleSddValidateCommand(skDir, []);
+
+		// Artifact bytes must be byte-for-byte identical.
+		expect(fs.readFileSync(specPath, 'utf-8')).toBe(specBefore);
+		expect(fs.readFileSync(tasksPath, 'utf-8')).toBe(tasksBefore);
+		// The command must NOT have written a projection (.swarm/spec.md must not exist).
+		expect(fs.existsSync(path.join(skDir, '.swarm', 'spec.md'))).toBe(false);
+	});
+
+	// Regression guard: existing OpenSpec validate tests are not disturbed.
+	// (Those tests live in the outer describe block above and are not duplicated here.)
+
+	// FR-009/010: both sources, no --source → clear error naming both (same path as project).
+	test('validate with both openspec and speckit and no --source errors naming both sources (FR-010)', async () => {
+		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
+		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), {
+			recursive: true,
+		});
+		fs.writeFileSync(
+			path.join(skDir, 'openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
+			'utf-8',
+		);
+
+		const out = await handleSddValidateCommand(skDir, []);
+
+		expect(out).toContain('Error:');
+		expect(out.toLowerCase()).toContain('openspec');
+		expect(out.toLowerCase()).toContain('speckit');
+		expect(out).toContain('--source');
+	});
+
+	// Validate non-Markdown output (human-readable path, not --json).
+	test('validate on valid single-feature Spec-Kit reports provider in human-readable output', async () => {
+		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
+
+		const out = await handleSddValidateCommand(skDir, []);
+
+		expect(out).toContain('SDD validation: valid');
+		expect(out).toContain('Provider: speckit_projection');
 	});
 });

--- a/tests/unit/commands/sdd.test.ts
+++ b/tests/unit/commands/sdd.test.ts
@@ -795,7 +795,10 @@ describe('/swarm sdd validate --source swarm', () => {
 	});
 
 	test('validate --source swarm without --json outputs human-readable text', async () => {
-		const out = await handleSddValidateCommand(nativeDir, ['--source', 'swarm']);
+		const out = await handleSddValidateCommand(nativeDir, [
+			'--source',
+			'swarm',
+		]);
 
 		expect(out).toContain('SDD validation: valid');
 		expect(out).toContain('Provider: swarm');
@@ -809,7 +812,8 @@ describe('/swarm sdd validate --source swarm', () => {
 		);
 		fs.mkdirSync(path.join(oversizedDir, '.swarm'), { recursive: true });
 		// Write a spec larger than MAX_SPEC_BYTES (256 KiB)
-		const largeContent = '# Specification: Oversized\n\n## Requirements\n' +
+		const largeContent =
+			'# Specification: Oversized\n\n## Requirements\n' +
 			'### Requirement: Large\n' +
 			'The system MUST handle large content.'.repeat(20000); // ~1MB
 		fs.writeFileSync(

--- a/tests/unit/commands/sdd.test.ts
+++ b/tests/unit/commands/sdd.test.ts
@@ -164,19 +164,25 @@ describe('parseArgs — --source and --feature flags', () => {
 	test('rejects --feature with a path separator (same check as --change)', () => {
 		const result = parseArgs(['--feature', '001/escape']);
 		expect(result.error).toBeDefined();
-		expect(result.error).toContain('--feature must be a single Spec-Kit feature directory name');
+		expect(result.error).toContain(
+			'--feature must be a single Spec-Kit feature directory name',
+		);
 	});
 
 	test('rejects --feature with a traversal sequence (same check as --change)', () => {
 		const result = parseArgs(['--feature', '../traverse']);
 		expect(result.error).toBeDefined();
-		expect(result.error).toContain('--feature must be a single Spec-Kit feature directory name');
+		expect(result.error).toContain(
+			'--feature must be a single Spec-Kit feature directory name',
+		);
 	});
 
 	test('rejects --feature with bracket characters (same check as --change)', () => {
 		const result = parseArgs(['--feature', 'bad[value]']);
 		expect(result.error).toBeDefined();
-		expect(result.error).toContain('--feature must be a single Spec-Kit feature directory name');
+		expect(result.error).toContain(
+			'--feature must be a single Spec-Kit feature directory name',
+		);
 	});
 
 	test('rejects --feature with no value', () => {
@@ -201,9 +207,7 @@ describe('/swarm sdd command handlers — Spec-Kit', () => {
 	let skDir: string;
 
 	beforeEach(() => {
-		skDir = fs.realpathSync(
-			fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-sk-')),
-		);
+		skDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-sk-')));
 	});
 
 	afterEach(() => {
@@ -257,7 +261,9 @@ describe('/swarm sdd command handlers — Spec-Kit', () => {
 	test('status with both openspec and speckit and no --source errors naming both sources (FR-010)', async () => {
 		// Write both sources.
 		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
-		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), { recursive: true });
+		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), {
+			recursive: true,
+		});
 		fs.writeFileSync(
 			path.join(skDir, 'openspec', 'specs', 'auth', 'spec.md'),
 			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
@@ -276,7 +282,9 @@ describe('/swarm sdd command handlers — Spec-Kit', () => {
 	// report that provider and must NOT leak the resolver's ambiguity console.warn.
 	test('status --source openspec on a both-present repo honors the selection and emits no warning (FR-009)', async () => {
 		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
-		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), { recursive: true });
+		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), {
+			recursive: true,
+		});
 		fs.writeFileSync(
 			path.join(skDir, 'openspec', 'specs', 'auth', 'spec.md'),
 			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
@@ -302,7 +310,9 @@ describe('/swarm sdd command handlers — Spec-Kit', () => {
 
 	test('project with both openspec and speckit and no --source errors naming both sources (FR-010)', async () => {
 		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
-		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), { recursive: true });
+		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), {
+			recursive: true,
+		});
 		fs.writeFileSync(
 			path.join(skDir, 'openspec', 'specs', 'auth', 'spec.md'),
 			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
@@ -332,7 +342,9 @@ describe('/swarm sdd command handlers — Spec-Kit', () => {
 	// --source speckit selects speckit when openspec is also present (SC-005).
 	test('project --source speckit selects speckit when openspec also present (SC-005)', async () => {
 		writeSpeckitFixture(skDir, { variant: 'single-explicit-fr' });
-		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), { recursive: true });
+		fs.mkdirSync(path.join(skDir, 'openspec', 'specs', 'auth'), {
+			recursive: true,
+		});
 		fs.writeFileSync(
 			path.join(skDir, 'openspec', 'specs', 'auth', 'spec.md'),
 			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
@@ -486,7 +498,9 @@ describe('/swarm sdd validate — Spec-Kit (task 2.3)', () => {
 		expect(parsed.valid).toBe(false);
 		expect(parsed.provider).toBe('speckit_projection');
 		// Missing section must be named.
-		expect(parsed.errors.some((e: string) => e.includes('## Success Criteria'))).toBe(true);
+		expect(
+			parsed.errors.some((e: string) => e.includes('## Success Criteria')),
+		).toBe(true);
 		// T001 with no [US#] must be named.
 		expect(parsed.errors.some((e: string) => e.includes('T001'))).toBe(true);
 		// T002 (which has [US1]) must NOT be flagged.

--- a/tests/unit/commands/sdd.test.ts
+++ b/tests/unit/commands/sdd.test.ts
@@ -658,3 +658,176 @@ describe('/swarm sdd — native .swarm/spec.md precedence (FR-009)', () => {
 		expect(warnMessages).toEqual([]);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// validate --source swarm (bugfix for PR #1589)
+// ---------------------------------------------------------------------------
+describe('/swarm sdd validate --source swarm', () => {
+	let nativeDir: string;
+	let emptyDir: string;
+	let mixedDir: string;
+
+	beforeEach(() => {
+		nativeDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-validate-swarm-native-')),
+		);
+		emptyDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-validate-swarm-empty-')),
+		);
+		mixedDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-validate-swarm-mixed-')),
+		);
+
+		// nativeDir: only native .swarm/spec.md
+		fs.mkdirSync(path.join(nativeDir, '.swarm'), { recursive: true });
+		fs.writeFileSync(
+			path.join(nativeDir, '.swarm', 'spec.md'),
+			'# Specification: Native\n\n## Requirements\n### Requirement: Native\nThe system MUST use native.\n#### Scenario: Works\n- **WHEN** native\n- **THEN** works\n',
+			'utf-8',
+		);
+
+		// emptyDir: no native spec (and no other sources)
+		// (left empty)
+
+		// mixedDir: native + OpenSpec
+		fs.mkdirSync(path.join(mixedDir, '.swarm'), { recursive: true });
+		fs.writeFileSync(
+			path.join(mixedDir, '.swarm', 'spec.md'),
+			'# Specification: Native Mixed\n\n## Requirements\n### Requirement: Mixed\nThe system MUST prefer native.\n#### Scenario: Native wins\n- **WHEN** source=swarm\n- **THEN** provider=swarm\n',
+			'utf-8',
+		);
+		fs.mkdirSync(path.join(mixedDir, 'openspec', 'specs', 'auth'), {
+			recursive: true,
+		});
+		fs.writeFileSync(
+			path.join(mixedDir, 'openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
+			'utf-8',
+		);
+	});
+
+	afterEach(() => {
+		fs.rmSync(nativeDir, { recursive: true, force: true });
+		fs.rmSync(emptyDir, { recursive: true, force: true });
+		fs.rmSync(mixedDir, { recursive: true, force: true });
+	});
+
+	test('validate --source swarm with native spec present returns valid:true, provider:swarm', async () => {
+		const out = await handleSddValidateCommand(nativeDir, [
+			'--source',
+			'swarm',
+			'--json',
+		]);
+		const parsed = JSON.parse(out);
+
+		expect(parsed.valid).toBe(true);
+		expect(parsed.provider).toBe('swarm');
+		expect(parsed.sourcePaths).toContain('.swarm/spec.md');
+		expect(parsed.errors).toHaveLength(0);
+	});
+
+	test('validate --source swarm with no native spec returns valid:false, provider:none', async () => {
+		const out = await handleSddValidateCommand(emptyDir, [
+			'--source',
+			'swarm',
+			'--json',
+		]);
+		const parsed = JSON.parse(out);
+
+		expect(parsed.valid).toBe(false);
+		expect(parsed.provider).toBe('none');
+		expect(parsed.sourcePaths).toHaveLength(0);
+	});
+
+	test('validate --source swarm with native + OpenSpec present uses provider:swarm and filters OpenSpec errors', async () => {
+		const out = await handleSddValidateCommand(mixedDir, [
+			'--source',
+			'swarm',
+			'--json',
+		]);
+		const parsed = JSON.parse(out);
+
+		expect(parsed.provider).toBe('swarm');
+		expect(parsed.valid).toBe(true);
+		// Must not contain OpenSpec-specific error strings
+		const allText = JSON.stringify(parsed);
+		expect(allText).not.toContain('openspec/');
+		expect(allText).not.toContain('proposal.md');
+		expect(allText).not.toContain('tasks.md');
+		expect(allText).not.toContain('specs/**/spec.md');
+		// sourcePaths must be native only
+		expect(parsed.sourcePaths).toContain('.swarm/spec.md');
+		expect(parsed.sourcePaths.some((p: string) => p.includes('openspec'))).toBe(
+			false,
+		);
+	});
+
+	test('validate --source swarm without --json outputs human-readable text', async () => {
+		const out = await handleSddValidateCommand(nativeDir, ['--source', 'swarm']);
+
+		expect(out).toContain('SDD validation: valid');
+		expect(out).toContain('Provider: swarm');
+		expect(out).toContain('Projected sources: 1');
+	});
+
+	test('validate --source swarm with oversized native spec (>256KiB) returns valid:false with size error', async () => {
+		// Create an oversized native spec
+		const oversizedDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-validate-swarm-oversized-')),
+		);
+		fs.mkdirSync(path.join(oversizedDir, '.swarm'), { recursive: true });
+		// Write a spec larger than MAX_SPEC_BYTES (256 KiB)
+		const largeContent = '# Specification: Oversized\n\n## Requirements\n' +
+			'### Requirement: Large\n' +
+			'The system MUST handle large content.'.repeat(20000); // ~1MB
+		fs.writeFileSync(
+			path.join(oversizedDir, '.swarm', 'spec.md'),
+			largeContent,
+			'utf-8',
+		);
+
+		const out = await handleSddValidateCommand(oversizedDir, [
+			'--source',
+			'swarm',
+			'--json',
+		]);
+		const parsed = JSON.parse(out);
+
+		expect(parsed.valid).toBe(false);
+		// Provider should be 'none' because the oversized spec was not used
+		expect(parsed.provider).toBe('none');
+		// sourcePaths should be empty since no valid spec was loaded
+		expect(parsed.sourcePaths).toHaveLength(0);
+
+		fs.rmSync(oversizedDir, { recursive: true, force: true });
+	});
+
+	test('validate --source swarm with native spec containing non-OpenSpec errors surfaces those errors', async () => {
+		// Create a native spec with a malformed structure that might cause errors
+		const errorDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-validate-swarm-error-')),
+		);
+		fs.mkdirSync(path.join(errorDir, '.swarm'), { recursive: true });
+		// Write a minimal but valid native spec - no errors expected here
+		// The key edge case is that non-OpenSpec errors should pass through
+		fs.writeFileSync(
+			path.join(errorDir, '.swarm', 'spec.md'),
+			'# Specification: Valid Native\n\n## Requirements\n### Requirement: Valid\nThe system MUST work correctly.\n#### Scenario: Works\n- **WHEN** valid\n- **THEN** works\n',
+			'utf-8',
+		);
+
+		const out = await handleSddValidateCommand(errorDir, [
+			'--source',
+			'swarm',
+			'--json',
+		]);
+		const parsed = JSON.parse(out);
+
+		// Valid native spec should pass
+		expect(parsed.valid).toBe(true);
+		expect(parsed.provider).toBe('swarm');
+		expect(parsed.errors).toHaveLength(0);
+
+		fs.rmSync(errorDir, { recursive: true, force: true });
+	});
+});

--- a/tests/unit/commands/sdd.test.ts
+++ b/tests/unit/commands/sdd.test.ts
@@ -565,3 +565,82 @@ describe('/swarm sdd validate — Spec-Kit (task 2.3)', () => {
 		expect(out).toContain('Provider: speckit_projection');
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Native .swarm/spec.md precedence in status + validate (Bug 2 / FR-009)
+// ---------------------------------------------------------------------------
+describe('/swarm sdd — native .swarm/spec.md precedence (FR-009)', () => {
+	let allThreeDir: string;
+
+	beforeEach(() => {
+		allThreeDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-native-')),
+		);
+		// (1) Native swarm spec — must win per FR-009 / planning.md:271.
+		fs.mkdirSync(path.join(allThreeDir, '.swarm'), { recursive: true });
+		fs.writeFileSync(
+			path.join(allThreeDir, '.swarm', 'spec.md'),
+			'# Specification: Swarm Native\n\n## Requirements\n- FR-001 MUST use the native Swarm spec.\n',
+			'utf-8',
+		);
+		// (2) Valid OpenSpec — a single parsable requirement, no half-finished change,
+		// so the OpenSpec projection is clean and validate stays valid.
+		fs.mkdirSync(path.join(allThreeDir, 'openspec', 'specs', 'auth'), {
+			recursive: true,
+		});
+		fs.writeFileSync(
+			path.join(allThreeDir, 'openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow login.\n',
+			'utf-8',
+		);
+		// (3) Valid Spec-Kit single feature.
+		writeSpeckitFixture(allThreeDir, { variant: 'single-explicit-fr' });
+	});
+
+	afterEach(() => {
+		fs.rmSync(allThreeDir, { recursive: true, force: true });
+	});
+
+	// FR-009: native present + openspec + speckit, no --source → status reports the
+	// native provider and does NOT hard-error or emit the resolver console.warn.
+	test('status reports Provider: swarm and does not emit the multi-source error (FR-009)', async () => {
+		const original = console.warn;
+		const warnMessages: string[] = [];
+		console.warn = (...a: unknown[]) => {
+			warnMessages.push(a.map(String).join(' '));
+		};
+		let out: string;
+		try {
+			out = await handleSddStatusCommand(allThreeDir, []);
+		} finally {
+			console.warn = original;
+		}
+
+		expect(out).toContain('Provider: swarm');
+		expect(out).not.toContain('Multiple SDD sources detected');
+		expect(warnMessages).toEqual([]);
+	});
+
+	// FR-009: same repo via validate — must not hard-error, must stay valid, must not warn.
+	// (Provider stays openspec_projection so native+openspec+speckit behaves identically to
+	// native+openspec; native precedence is honored by the resolver for actual enforcement.)
+	test('validate does not emit the multi-source error and stays valid (FR-009)', async () => {
+		const original = console.warn;
+		const warnMessages: string[] = [];
+		console.warn = (...a: unknown[]) => {
+			warnMessages.push(a.map(String).join(' '));
+		};
+		let out: string;
+		try {
+			out = await handleSddValidateCommand(allThreeDir, ['--json']);
+		} finally {
+			console.warn = original;
+		}
+
+		const parsed = JSON.parse(out);
+		expect(parsed.valid).toBe(true);
+		expect(parsed.error).toBeUndefined();
+		expect(out).not.toContain('Multiple SDD sources detected');
+		expect(warnMessages).toEqual([]);
+	});
+});

--- a/tests/unit/commands/sdd.test.ts
+++ b/tests/unit/commands/sdd.test.ts
@@ -185,6 +185,38 @@ describe('parseArgs — --source and --feature flags', () => {
 		);
 	});
 
+	test('rejects --feature with a null byte (containsControlChars)', () => {
+		const result = parseArgs(['--feature', 'auth\x00service']);
+		expect(result.error).toBeDefined();
+		expect(result.error).toContain(
+			'--feature must be a single Spec-Kit feature directory name',
+		);
+	});
+
+	test('rejects --feature with a tab control char (containsControlChars)', () => {
+		const result = parseArgs(['--feature', 'auth\tservice']);
+		expect(result.error).toBeDefined();
+		expect(result.error).toContain(
+			'--feature must be a single Spec-Kit feature directory name',
+		);
+	});
+
+	test('rejects --change with a null byte (containsControlChars)', () => {
+		const result = parseArgs(['--change', 'add\x00reset']);
+		expect(result.error).toBeDefined();
+		expect(result.error).toContain(
+			'--change must be a single OpenSpec change id',
+		);
+	});
+
+	test('rejects --change with a tab control char (containsControlChars)', () => {
+		const result = parseArgs(['--change', 'add\treset']);
+		expect(result.error).toBeDefined();
+		expect(result.error).toContain(
+			'--change must be a single OpenSpec change id',
+		);
+	});
+
 	test('rejects --feature with no value', () => {
 		const result = parseArgs(['--feature']);
 		expect(result.error).toBeDefined();

--- a/tests/unit/sdd/speckit-integration.test.ts
+++ b/tests/unit/sdd/speckit-integration.test.ts
@@ -12,14 +12,13 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-
+import { handleSddProjectCommand } from '../../../src/commands/sdd';
 import {
 	buildOpenSpecProjectionSync,
 	buildSpeckitProjectionSync,
 	readEffectiveSpecSync,
 	writeProjectedSpecSync,
 } from '../../../src/sdd/effective-spec';
-import { handleSddProjectCommand } from '../../../src/commands/sdd';
 import { writeSpeckitFixture } from '../../helpers/speckit-fixture';
 
 let tempDir: string;
@@ -44,55 +43,52 @@ afterEach(() => {
 // 1. Projection determinism via full write path (SC-003, FR-004)
 // ---------------------------------------------------------------------------
 describe('1: Projection determinism — full writeProjectedSpecSync path (SC-003, FR-004)', () => {
-	test(
-		'idless-synthesis variant: two writes produce byte-identical .swarm/spec.md and hash',
-		() => {
-			// Guard: idless synthesis (nextFrId) is the non-trivial path — explicit ids are trivially
-			// stable.  The per-unit golden tests stop at buildSpeckitProjectionSync; this integration
-			// test goes through the full WRITE path and compares the WRITTEN file bytes, catching
-			// any non-determinism in traversal order, timestamp injection, or hash computation.
-			writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+	test('idless-synthesis variant: two writes produce byte-identical .swarm/spec.md and hash', () => {
+		// Guard: idless synthesis (nextFrId) is the non-trivial path — explicit ids are trivially
+		// stable.  The per-unit golden tests stop at buildSpeckitProjectionSync; this integration
+		// test goes through the full WRITE path and compares the WRITTEN file bytes, catching
+		// any non-determinism in traversal order, timestamp injection, or hash computation.
+		writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
 
-			// First write
-			const r1 = writeProjectedSpecSync(tempDir, { source: 'speckit' });
-			expect(r1.written).toBe(true);
-			expect(r1.projection).not.toBeNull();
-			const hash1 = r1.projection!.hash;
-			const content1 = fs.readFileSync(
-				path.join(tempDir, '.swarm', 'spec.md'),
-				'utf-8',
-			);
+		// First write
+		const r1 = writeProjectedSpecSync(tempDir, { source: 'speckit' });
+		expect(r1.written).toBe(true);
+		expect(r1.projection).not.toBeNull();
+		const hash1 = r1.projection!.hash;
+		const content1 = fs.readFileSync(
+			path.join(tempDir, '.swarm', 'spec.md'),
+			'utf-8',
+		);
 
-			// Remove the written file so the second call performs a clean write
-			// (decouples the two writes — no archiving branch).
-			fs.rmSync(path.join(tempDir, '.swarm', 'spec.md'));
+		// Remove the written file so the second call performs a clean write
+		// (decouples the two writes — no archiving branch).
+		fs.rmSync(path.join(tempDir, '.swarm', 'spec.md'));
 
-			// Second write — same Spec-Kit source, no mutation to specs/
-			const r2 = writeProjectedSpecSync(tempDir, { source: 'speckit' });
-			expect(r2.written).toBe(true);
-			expect(r2.projection).not.toBeNull();
-			const hash2 = r2.projection!.hash;
-			const content2 = fs.readFileSync(
-				path.join(tempDir, '.swarm', 'spec.md'),
-				'utf-8',
-			);
+		// Second write — same Spec-Kit source, no mutation to specs/
+		const r2 = writeProjectedSpecSync(tempDir, { source: 'speckit' });
+		expect(r2.written).toBe(true);
+		expect(r2.projection).not.toBeNull();
+		const hash2 = r2.projection!.hash;
+		const content2 = fs.readFileSync(
+			path.join(tempDir, '.swarm', 'spec.md'),
+			'utf-8',
+		);
 
-			// BYTE-IDENTICAL: non-deterministic ordering or a timestamp injected into content
-			// would make content1 !== content2 and expose the regression.
-			expect(content1).toBe(content2);
-			// Hash is over content only (not Date.now()); must be stable across calls.
-			expect(hash1).toBe(hash2);
+		// BYTE-IDENTICAL: non-deterministic ordering or a timestamp injected into content
+		// would make content1 !== content2 and expose the regression.
+		expect(content1).toBe(content2);
+		// Hash is over content only (not Date.now()); must be stable across calls.
+		expect(hash1).toBe(hash2);
 
-			// Anti-vacuous guards: content must be substantial and show synthesis was exercised.
-			expect(content1.length).toBeGreaterThan(100);
-			// Synthesized ids must be present and stable (FR-004).
-			expect(content1).toContain('FR-001:');
-			expect(content1).toContain('FR-002:');
-			expect(content1).toContain('FR-003:');
-			// Synthesized ids do NOT appear in bold (**FR-###**) — that form means preserved.
-			expect(content1).not.toContain('**FR-');
-		},
-	);
+		// Anti-vacuous guards: content must be substantial and show synthesis was exercised.
+		expect(content1.length).toBeGreaterThan(100);
+		// Synthesized ids must be present and stable (FR-004).
+		expect(content1).toContain('FR-001:');
+		expect(content1).toContain('FR-002:');
+		expect(content1).toContain('FR-003:');
+		// Synthesized ids do NOT appear in bold (**FR-###**) — that form means preserved.
+		expect(content1).not.toContain('**FR-');
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -117,17 +113,18 @@ describe('2: FR-011 OpenSpec regression guard: parseRequirements drops id-less o
 	// If parseRequirements was altered to also capture id-less obligation bullets (mirroring
 	// parseSpeckitRequirements), the output would gain a second FR bullet for "skip this…"
 	// and the golden assertion would fail, exposing the regression.
-	const OPENSPEC_GOLDEN = [
-		'# Specification: Effective SDD Projection',
-		'',
-		'Generated from OpenSpec-compatible artifacts. Update the source artifacts, then run `/swarm sdd project` to refresh this projection.',
-		'',
-		'## Source Artifacts',
-		'- openspec/specs/auth/spec.md',
-		'',
-		'## Current Requirements',
-		'- FR-001: The system MUST allow users to sign in. #### Scenario: Successful login - **WHEN** the user submits valid credentials - **THEN** the system signs them in. _(source: openspec/specs/auth/spec.md)_',
-	].join('\n') + '\n';
+	const OPENSPEC_GOLDEN =
+		[
+			'# Specification: Effective SDD Projection',
+			'',
+			'Generated from OpenSpec-compatible artifacts. Update the source artifacts, then run `/swarm sdd project` to refresh this projection.',
+			'',
+			'## Source Artifacts',
+			'- openspec/specs/auth/spec.md',
+			'',
+			'## Current Requirements',
+			'- FR-001: The system MUST allow users to sign in. #### Scenario: Successful login - **WHEN** the user submits valid credentials - **THEN** the system signs them in. _(source: openspec/specs/auth/spec.md)_',
+		].join('\n') + '\n';
 
 	beforeEach(() => {
 		writeFile(
@@ -152,52 +149,46 @@ describe('2: FR-011 OpenSpec regression guard: parseRequirements drops id-less o
 		);
 	});
 
-	test(
-		'buildOpenSpecProjectionSync: standalone obligation bullet absent; golden byte-identical (FR-011)',
-		() => {
-			const proj = buildOpenSpecProjectionSync(tempDir);
+	test('buildOpenSpecProjectionSync: standalone obligation bullet absent; golden byte-identical (FR-011)', () => {
+		const proj = buildOpenSpecProjectionSync(tempDir);
 
-			expect(proj).not.toBeNull();
-			expect(proj?.source).toBe('openspec_projection');
+		expect(proj).not.toBeNull();
+		expect(proj?.source).toBe('openspec_projection');
 
-			// Golden (byte-identical): a patched parseRequirements that captures id-less
-			// bullets would produce LONGER output with an extra FR-002 for the "skip" line,
-			// breaking this assertion and exposing the regression.
-			expect(proj?.content).toBe(OPENSPEC_GOLDEN);
+		// Golden (byte-identical): a patched parseRequirements that captures id-less
+		// bullets would produce LONGER output with an extra FR-002 for the "skip" line,
+		// breaking this assertion and exposing the regression.
+		expect(proj?.content).toBe(OPENSPEC_GOLDEN);
 
-			// Absence proof: the standalone obligation bullet text must NOT appear.
-			expect(proj?.content).not.toContain('skip this standalone');
+		// Absence proof: the standalone obligation bullet text must NOT appear.
+		expect(proj?.content).not.toContain('skip this standalone');
 
-			// Presence proof: the Requirement: block is projected correctly.
-			expect(proj?.content).toContain('The system MUST allow users to sign in.');
-			// Scenario lines in the block body are joined into the requirement text.
-			expect(proj?.content).toContain('#### Scenario: Successful login');
+		// Presence proof: the Requirement: block is projected correctly.
+		expect(proj?.content).toContain('The system MUST allow users to sign in.');
+		// Scenario lines in the block body are joined into the requirement text.
+		expect(proj?.content).toContain('#### Scenario: Successful login');
 
-			// Count guard: exactly one FR bullet.  Two would mean the standalone bullet leaked.
-			const frLines = proj!.content.match(/^- .*\bFR-\d{3}\b/gm);
-			expect(frLines).toHaveLength(1);
-		},
-	);
+		// Count guard: exactly one FR bullet.  Two would mean the standalone bullet leaked.
+		const frLines = proj!.content.match(/^- .*\bFR-\d{3}\b/gm);
+		expect(frLines).toHaveLength(1);
+	});
 
-	test(
-		'readEffectiveSpecSync (openspec-only): content byte-identical to buildOpenSpecProjectionSync (FR-011 cross-module)',
-		() => {
-			// No .specify/ marker → readEffectiveSpecSync delegates to buildOpenSpecProjectionSync.
-			// If the resolver added Spec-Kit contamination on the openspec-only path, the
-			// two outputs would diverge.
-			const viaResolver = readEffectiveSpecSync(tempDir);
-			const viaDirect = buildOpenSpecProjectionSync(tempDir);
+	test('readEffectiveSpecSync (openspec-only): content byte-identical to buildOpenSpecProjectionSync (FR-011 cross-module)', () => {
+		// No .specify/ marker → readEffectiveSpecSync delegates to buildOpenSpecProjectionSync.
+		// If the resolver added Spec-Kit contamination on the openspec-only path, the
+		// two outputs would diverge.
+		const viaResolver = readEffectiveSpecSync(tempDir);
+		const viaDirect = buildOpenSpecProjectionSync(tempDir);
 
-			expect(viaResolver).not.toBeNull();
-			expect(viaDirect).not.toBeNull();
-			expect(viaResolver?.source).toBe('openspec_projection');
+		expect(viaResolver).not.toBeNull();
+		expect(viaDirect).not.toBeNull();
+		expect(viaResolver?.source).toBe('openspec_projection');
 
-			// Byte-identical (FR-011): any resolver-side modification to the openspec-only
-			// path would break this comparison and expose the cross-module regression.
-			expect(viaResolver?.content).toBe(viaDirect?.content);
-			expect(viaResolver?.content).toBe(OPENSPEC_GOLDEN);
-		},
-	);
+		// Byte-identical (FR-011): any resolver-side modification to the openspec-only
+		// path would break this comparison and expose the cross-module regression.
+		expect(viaResolver?.content).toBe(viaDirect?.content);
+		expect(viaResolver?.content).toBe(OPENSPEC_GOLDEN);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -214,134 +205,122 @@ describe('3: FR-010 ambiguity diagnostic — warn count is exactly 1 per call (s
 		);
 	}
 
-	test(
-		'both-present repo: returns null AND emits EXACTLY ONE console.warn (not 0, not 2+)',
-		() => {
-			buildBothPresentFixture();
+	test('both-present repo: returns null AND emits EXACTLY ONE console.warn (not 0, not 2+)', () => {
+		buildBothPresentFixture();
 
-			const warnMessages: string[] = [];
-			const realWarn = console.warn;
-			console.warn = (...args: unknown[]) => {
-				warnMessages.push(args.map(String).join(' '));
-			};
+		const warnMessages: string[] = [];
+		const realWarn = console.warn;
+		console.warn = (...args: unknown[]) => {
+			warnMessages.push(args.map(String).join(' '));
+		};
 
-			let result: ReturnType<typeof readEffectiveSpecSync>;
-			try {
-				result = readEffectiveSpecSync(tempDir);
-			} finally {
-				console.warn = realWarn;
-			}
+		let result: ReturnType<typeof readEffectiveSpecSync>;
+		try {
+			result = readEffectiveSpecSync(tempDir);
+		} finally {
+			console.warn = realWarn;
+		}
 
-			// Must return null (ambiguous → no effective spec).
-			expect(result!).toBeNull();
+		// Must return null (ambiguous → no effective spec).
+		expect(result!).toBeNull();
 
-			// EXACTLY ONE warning: not zero (silent suppression defeats critic Finding 2)
-			// and not 2+ (double-firing from a loop or nested call path).
-			// The existing unit test asserts `> 0`; this integration test nails it to `=== 1`.
-			expect(warnMessages).toHaveLength(1);
+		// EXACTLY ONE warning: not zero (silent suppression defeats critic Finding 2)
+		// and not 2+ (double-firing from a loop or nested call path).
+		// The existing unit test asserts `> 0`; this integration test nails it to `=== 1`.
+		expect(warnMessages).toHaveLength(1);
 
-			const msg = warnMessages[0]!;
-			// Warning must name both competing sources so the developer knows what to pick.
-			expect(msg.toLowerCase()).toContain('openspec');
-			expect(msg.toLowerCase()).toContain('speckit');
-			// Warning must name the disambiguation flag.
-			expect(msg).toContain('--source');
-		},
-	);
+		const msg = warnMessages[0]!;
+		// Warning must name both competing sources so the developer knows what to pick.
+		expect(msg.toLowerCase()).toContain('openspec');
+		expect(msg.toLowerCase()).toContain('speckit');
+		// Warning must name the disambiguation flag.
+		expect(msg).toContain('--source');
+	});
 
-	test(
-		'two sequential calls on the same ambiguous repo: emits exactly 2 total warnings (1 per call)',
-		() => {
-			// Guards against global deduplication (second call → 0 warns) AND multi-fire
-			// bugs (first call → 2+ warns).  Together with the single-call test, this pins
-			// the per-call count to exactly 1 independently of call count.
-			buildBothPresentFixture();
+	test('two sequential calls on the same ambiguous repo: emits exactly 2 total warnings (1 per call)', () => {
+		// Guards against global deduplication (second call → 0 warns) AND multi-fire
+		// bugs (first call → 2+ warns).  Together with the single-call test, this pins
+		// the per-call count to exactly 1 independently of call count.
+		buildBothPresentFixture();
 
-			const warnMessages: string[] = [];
-			const realWarn = console.warn;
-			console.warn = (...args: unknown[]) => {
-				warnMessages.push(args.map(String).join(' '));
-			};
+		const warnMessages: string[] = [];
+		const realWarn = console.warn;
+		console.warn = (...args: unknown[]) => {
+			warnMessages.push(args.map(String).join(' '));
+		};
 
-			try {
-				readEffectiveSpecSync(tempDir);
-				readEffectiveSpecSync(tempDir);
-			} finally {
-				console.warn = realWarn;
-			}
+		try {
+			readEffectiveSpecSync(tempDir);
+			readEffectiveSpecSync(tempDir);
+		} finally {
+			console.warn = realWarn;
+		}
 
-			expect(warnMessages).toHaveLength(2);
-		},
-	);
+		expect(warnMessages).toHaveLength(2);
+	});
 });
 
 // ---------------------------------------------------------------------------
 // 4. Multi-feature end-to-end via command (SC-009, FR-008)
 // ---------------------------------------------------------------------------
 describe('4: Multi-feature end-to-end via handleSddProjectCommand (SC-009, FR-008)', () => {
-	test(
-		'no --feature: error names both features + --feature remedy; NO .swarm/spec.md written',
-		async () => {
-			writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+	test('no --feature: error names both features + --feature remedy; NO .swarm/spec.md written', async () => {
+		writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
 
-			const out = await handleSddProjectCommand(tempDir, []);
+		const out = await handleSddProjectCommand(tempDir, []);
 
-			expect(out).toContain('Error:');
-			expect(out).toContain('001-alpha');
-			expect(out).toContain('002-beta');
-			expect(out).toContain('--feature');
+		expect(out).toContain('Error:');
+		expect(out).toContain('001-alpha');
+		expect(out).toContain('002-beta');
+		expect(out).toContain('--feature');
 
-			// Critical gate: on the error path, .swarm/spec.md must NOT exist.
-			// Regression caught: an implementation that projects the first feature BEFORE
-			// detecting ambiguity would write a stale spec silently and this check would fail.
-			expect(fs.existsSync(path.join(tempDir, '.swarm', 'spec.md'))).toBe(false);
-		},
-	);
+		// Critical gate: on the error path, .swarm/spec.md must NOT exist.
+		// Regression caught: an implementation that projects the first feature BEFORE
+		// detecting ambiguity would write a stale spec silently and this check would fail.
+		expect(fs.existsSync(path.join(tempDir, '.swarm', 'spec.md'))).toBe(false);
+	});
 
-	test(
-		'--feature 002-beta: sourcePaths exact; written file is 002-beta only; readEffectiveSpecSync round-trip (FR-009)',
-		async () => {
-			writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+	test('--feature 002-beta: sourcePaths exact; written file is 002-beta only; readEffectiveSpecSync round-trip (FR-009)', async () => {
+		writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
 
-			// Use --json to get structured sourcePaths (avoids substring-scraping the content).
-			const jsonOut = await handleSddProjectCommand(tempDir, [
-				'--feature',
-				'002-beta',
-				'--json',
-			]);
-			const response = JSON.parse(jsonOut) as {
-				written: boolean;
-				sourcePaths: string[];
-				hash: string | null;
-			};
+		// Use --json to get structured sourcePaths (avoids substring-scraping the content).
+		const jsonOut = await handleSddProjectCommand(tempDir, [
+			'--feature',
+			'002-beta',
+			'--json',
+		]);
+		const response = JSON.parse(jsonOut) as {
+			written: boolean;
+			sourcePaths: string[];
+			hash: string | null;
+		};
 
-			expect(response.written).toBe(true);
-			// sourcePaths must contain ONLY 002-beta — not 001-alpha, not both.
-			expect(response.sourcePaths).toEqual(['specs/002-beta/spec.md']);
-			expect(response.hash).toBeDefined();
-			expect(response.hash).not.toBeNull();
+		expect(response.written).toBe(true);
+		// sourcePaths must contain ONLY 002-beta — not 001-alpha, not both.
+		expect(response.sourcePaths).toEqual(['specs/002-beta/spec.md']);
+		expect(response.hash).toBeDefined();
+		expect(response.hash).not.toBeNull();
 
-			// Written file: .swarm/spec.md must contain ONLY 002-beta content.
-			const specContent = fs.readFileSync(
-				path.join(tempDir, '.swarm', 'spec.md'),
-				'utf-8',
-			);
-			expect(specContent).toContain('beta capability');
-			expect(specContent).toContain('specs/002-beta/spec.md');
-			// No bleed of 001-alpha content into the 002-beta projection.
-			expect(specContent).not.toContain('alpha');
+		// Written file: .swarm/spec.md must contain ONLY 002-beta content.
+		const specContent = fs.readFileSync(
+			path.join(tempDir, '.swarm', 'spec.md'),
+			'utf-8',
+		);
+		expect(specContent).toContain('beta capability');
+		expect(specContent).toContain('specs/002-beta/spec.md');
+		// No bleed of 001-alpha content into the 002-beta projection.
+		expect(specContent).not.toContain('alpha');
 
-			// Cross-module round-trip: readEffectiveSpecSync now reads the written .swarm/spec.md
-			// as a NATIVE swarm spec (FR-009: native spec wins over any projection source).
-			// This crosses the command module (writes) → resolver module (reads) boundary.
-			const resolved = readEffectiveSpecSync(tempDir);
-			expect(resolved?.source).toBe('swarm');
-			// Content must be byte-identical to the written file.
-			expect(resolved?.content).toBe(specContent);
-			expect(resolved?.content).toContain('beta capability');
-			expect(resolved?.content).not.toContain('alpha');
-		},
-	);
+		// Cross-module round-trip: readEffectiveSpecSync now reads the written .swarm/spec.md
+		// as a NATIVE swarm spec (FR-009: native spec wins over any projection source).
+		// This crosses the command module (writes) → resolver module (reads) boundary.
+		const resolved = readEffectiveSpecSync(tempDir);
+		expect(resolved?.source).toBe('swarm');
+		// Content must be byte-identical to the written file.
+		expect(resolved?.content).toBe(specContent);
+		expect(resolved?.content).toContain('beta capability');
+		expect(resolved?.content).not.toContain('alpha');
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -359,78 +338,82 @@ describe('5: CRLF robustness — CRLF spec.md projects byte-identically to LF ve
 	// not single-path regression tests.  They freeze the current behaviour as a defense-in-depth
 	// invariant and are explicitly documented as such per the task description.
 
-	test(
-		'explicit-fr variant: CRLF spec.md projection is byte-identical to LF (content + hash)',
-		() => {
-			const crlfDir = fs.realpathSync(
-				fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-crlf-explicit-')),
+	test('explicit-fr variant: CRLF spec.md projection is byte-identical to LF (content + hash)', () => {
+		const crlfDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-crlf-explicit-')),
+		);
+		try {
+			writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+			writeSpeckitFixture(crlfDir, { variant: 'single-explicit-fr' });
+
+			// Rewrite the fixture spec.md with CRLF line endings.
+			const specPath = path.join(
+				crlfDir,
+				'specs',
+				'001-auth-service',
+				'spec.md',
 			);
-			try {
-				writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
-				writeSpeckitFixture(crlfDir, { variant: 'single-explicit-fr' });
+			const lfContent = fs.readFileSync(specPath, 'utf-8');
+			const crlfContent = lfContent.replace(/\n/g, '\r\n');
+			// Sanity: fixture must use LF so the CRLF version actually differs.
+			expect(crlfContent).not.toBe(lfContent);
+			fs.writeFileSync(specPath, crlfContent, 'utf-8');
 
-				// Rewrite the fixture spec.md with CRLF line endings.
-				const specPath = path.join(crlfDir, 'specs', '001-auth-service', 'spec.md');
-				const lfContent = fs.readFileSync(specPath, 'utf-8');
-				const crlfContent = lfContent.replace(/\n/g, '\r\n');
-				// Sanity: fixture must use LF so the CRLF version actually differs.
-				expect(crlfContent).not.toBe(lfContent);
-				fs.writeFileSync(specPath, crlfContent, 'utf-8');
+			const lfSpec = buildSpeckitProjectionSync(tempDir);
+			const crlfSpec = buildSpeckitProjectionSync(crlfDir);
 
-				const lfSpec = buildSpeckitProjectionSync(tempDir);
-				const crlfSpec = buildSpeckitProjectionSync(crlfDir);
+			expect(lfSpec).not.toBeNull();
+			expect(crlfSpec).not.toBeNull();
 
-				expect(lfSpec).not.toBeNull();
-				expect(crlfSpec).not.toBeNull();
+			// Defense-in-depth: CRLF input must not pollute the projected output.
+			expect(crlfSpec?.content).toBe(lfSpec?.content);
+			expect(crlfSpec?.hash).toBe(lfSpec?.hash);
 
-				// Defense-in-depth: CRLF input must not pollute the projected output.
-				expect(crlfSpec?.content).toBe(lfSpec?.content);
-				expect(crlfSpec?.hash).toBe(lfSpec?.hash);
+			// FR-003: explicit ids are preserved in both line-ending variants.
+			expect(crlfSpec?.content).toContain('**FR-001**');
+			expect(crlfSpec?.content).toContain('**FR-002**');
+			expect(crlfSpec?.content).toContain('**FR-003**');
+		} finally {
+			fs.rmSync(crlfDir, { recursive: true, force: true });
+		}
+	});
 
-				// FR-003: explicit ids are preserved in both line-ending variants.
-				expect(crlfSpec?.content).toContain('**FR-001**');
-				expect(crlfSpec?.content).toContain('**FR-002**');
-				expect(crlfSpec?.content).toContain('**FR-003**');
-			} finally {
-				fs.rmSync(crlfDir, { recursive: true, force: true });
-			}
-		},
-	);
+	test('idless-synthesis variant: CRLF spec.md synthesizes identical FR-### ids as LF (FR-004)', () => {
+		const crlfDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-crlf-idless-')),
+		);
+		try {
+			writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+			writeSpeckitFixture(crlfDir, { variant: 'single-idless-requirements' });
 
-	test(
-		'idless-synthesis variant: CRLF spec.md synthesizes identical FR-### ids as LF (FR-004)',
-		() => {
-			const crlfDir = fs.realpathSync(
-				fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-crlf-idless-')),
+			const specPath = path.join(
+				crlfDir,
+				'specs',
+				'001-auth-service',
+				'spec.md',
 			);
-			try {
-				writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
-				writeSpeckitFixture(crlfDir, { variant: 'single-idless-requirements' });
+			const lfContent = fs.readFileSync(specPath, 'utf-8');
+			const crlfContent = lfContent.replace(/\n/g, '\r\n');
+			expect(crlfContent).not.toBe(lfContent);
+			fs.writeFileSync(specPath, crlfContent, 'utf-8');
 
-				const specPath = path.join(crlfDir, 'specs', '001-auth-service', 'spec.md');
-				const lfContent = fs.readFileSync(specPath, 'utf-8');
-				const crlfContent = lfContent.replace(/\n/g, '\r\n');
-				expect(crlfContent).not.toBe(lfContent);
-				fs.writeFileSync(specPath, crlfContent, 'utf-8');
+			const lfSpec = buildSpeckitProjectionSync(tempDir);
+			const crlfSpec = buildSpeckitProjectionSync(crlfDir);
 
-				const lfSpec = buildSpeckitProjectionSync(tempDir);
-				const crlfSpec = buildSpeckitProjectionSync(crlfDir);
+			expect(lfSpec).not.toBeNull();
+			expect(crlfSpec).not.toBeNull();
 
-				expect(lfSpec).not.toBeNull();
-				expect(crlfSpec).not.toBeNull();
+			// FR-004: synthesized ids must be identical whether input uses LF or CRLF.
+			expect(crlfSpec?.content).toBe(lfSpec?.content);
+			expect(crlfSpec?.hash).toBe(lfSpec?.hash);
 
-				// FR-004: synthesized ids must be identical whether input uses LF or CRLF.
-				expect(crlfSpec?.content).toBe(lfSpec?.content);
-				expect(crlfSpec?.hash).toBe(lfSpec?.hash);
-
-				// Confirm synthesis path was exercised (synthesized ids, not bold-markup).
-				expect(crlfSpec?.content).toContain('FR-001:');
-				expect(crlfSpec?.content).toContain('FR-002:');
-				expect(crlfSpec?.content).toContain('FR-003:');
-				expect(crlfSpec?.content).not.toContain('**FR-');
-			} finally {
-				fs.rmSync(crlfDir, { recursive: true, force: true });
-			}
-		},
-	);
+			// Confirm synthesis path was exercised (synthesized ids, not bold-markup).
+			expect(crlfSpec?.content).toContain('FR-001:');
+			expect(crlfSpec?.content).toContain('FR-002:');
+			expect(crlfSpec?.content).toContain('FR-003:');
+			expect(crlfSpec?.content).not.toContain('**FR-');
+		} finally {
+			fs.rmSync(crlfDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/tests/unit/sdd/speckit-integration.test.ts
+++ b/tests/unit/sdd/speckit-integration.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Cross-cutting integration / regression tests for the #1228 Spec-Kit SDD interop.
+ *
+ * These tests span the resolver + command modules and are deliberately NOT duplicating
+ * the per-task unit tests already in:
+ *   src/sdd/effective-spec.test.ts  (per-task library behaviour)
+ *   tests/unit/commands/sdd.test.ts (per-task command behaviour)
+ *
+ * Each test names the exact regression or invariant it guards.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+	buildOpenSpecProjectionSync,
+	buildSpeckitProjectionSync,
+	readEffectiveSpecSync,
+	writeProjectedSpecSync,
+} from '../../../src/sdd/effective-spec';
+import { handleSddProjectCommand } from '../../../src/commands/sdd';
+import { writeSpeckitFixture } from '../../helpers/speckit-fixture';
+
+let tempDir: string;
+
+function writeFile(relPath: string, content: string): void {
+	const abs = path.join(tempDir, relPath);
+	fs.mkdirSync(path.dirname(abs), { recursive: true });
+	fs.writeFileSync(abs, content, 'utf-8');
+}
+
+beforeEach(() => {
+	tempDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-integration-')),
+	);
+});
+
+afterEach(() => {
+	fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// 1. Projection determinism via full write path (SC-003, FR-004)
+// ---------------------------------------------------------------------------
+describe('1: Projection determinism — full writeProjectedSpecSync path (SC-003, FR-004)', () => {
+	test(
+		'idless-synthesis variant: two writes produce byte-identical .swarm/spec.md and hash',
+		() => {
+			// Guard: idless synthesis (nextFrId) is the non-trivial path — explicit ids are trivially
+			// stable.  The per-unit golden tests stop at buildSpeckitProjectionSync; this integration
+			// test goes through the full WRITE path and compares the WRITTEN file bytes, catching
+			// any non-determinism in traversal order, timestamp injection, or hash computation.
+			writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+
+			// First write
+			const r1 = writeProjectedSpecSync(tempDir, { source: 'speckit' });
+			expect(r1.written).toBe(true);
+			expect(r1.projection).not.toBeNull();
+			const hash1 = r1.projection!.hash;
+			const content1 = fs.readFileSync(
+				path.join(tempDir, '.swarm', 'spec.md'),
+				'utf-8',
+			);
+
+			// Remove the written file so the second call performs a clean write
+			// (decouples the two writes — no archiving branch).
+			fs.rmSync(path.join(tempDir, '.swarm', 'spec.md'));
+
+			// Second write — same Spec-Kit source, no mutation to specs/
+			const r2 = writeProjectedSpecSync(tempDir, { source: 'speckit' });
+			expect(r2.written).toBe(true);
+			expect(r2.projection).not.toBeNull();
+			const hash2 = r2.projection!.hash;
+			const content2 = fs.readFileSync(
+				path.join(tempDir, '.swarm', 'spec.md'),
+				'utf-8',
+			);
+
+			// BYTE-IDENTICAL: non-deterministic ordering or a timestamp injected into content
+			// would make content1 !== content2 and expose the regression.
+			expect(content1).toBe(content2);
+			// Hash is over content only (not Date.now()); must be stable across calls.
+			expect(hash1).toBe(hash2);
+
+			// Anti-vacuous guards: content must be substantial and show synthesis was exercised.
+			expect(content1.length).toBeGreaterThan(100);
+			// Synthesized ids must be present and stable (FR-004).
+			expect(content1).toContain('FR-001:');
+			expect(content1).toContain('FR-002:');
+			expect(content1).toContain('FR-003:');
+			// Synthesized ids do NOT appear in bold (**FR-###**) — that form means preserved.
+			expect(content1).not.toContain('**FR-');
+		},
+	);
+});
+
+// ---------------------------------------------------------------------------
+// 2. FR-011 OpenSpec regression guard: parseRequirements unchanged by #1228
+// ---------------------------------------------------------------------------
+describe('2: FR-011 OpenSpec regression guard: parseRequirements drops id-less obligation bullets', () => {
+	// Golden for buildOpenSpecProjectionSync on the fixture below.
+	//
+	// Computed by tracing parseRequirements (src/sdd/effective-spec.ts):
+	//   Line "- The system MUST skip…" in ## Notes:
+	//     • explicit = null (no FR-### on the line)
+	//     • openSpecReq = null (not a ### Requirement: header)
+	//     • → hits `if (!openSpecReq) continue;` → silently DROPPED.
+	//   ### Requirement: Login block:
+	//     • Captured; body scan stops at `## Notes` (next level-2 header).
+	//     • Body: ['The system MUST allow users to sign in.', '#### Scenario: Successful login',
+	//              '- **WHEN** the user submits valid credentials', '- **THEN** the system signs them in.']
+	//     • id = null (no FR-### in body) → nextFrId assigns FR-001.
+	//     • text = requirementTextFromBlock → joined block (obligation present → return joined).
+	//     • renderRequirement → "- FR-001: <joined> _(source: …)_"
+	//
+	// If parseRequirements was altered to also capture id-less obligation bullets (mirroring
+	// parseSpeckitRequirements), the output would gain a second FR bullet for "skip this…"
+	// and the golden assertion would fail, exposing the regression.
+	const OPENSPEC_GOLDEN = [
+		'# Specification: Effective SDD Projection',
+		'',
+		'Generated from OpenSpec-compatible artifacts. Update the source artifacts, then run `/swarm sdd project` to refresh this projection.',
+		'',
+		'## Source Artifacts',
+		'- openspec/specs/auth/spec.md',
+		'',
+		'## Current Requirements',
+		'- FR-001: The system MUST allow users to sign in. #### Scenario: Successful login - **WHEN** the user submits valid credentials - **THEN** the system signs them in. _(source: openspec/specs/auth/spec.md)_',
+	].join('\n') + '\n';
+
+	beforeEach(() => {
+		writeFile(
+			path.join('openspec', 'specs', 'auth', 'spec.md'),
+			[
+				'# Auth Service',
+				'',
+				'## Requirements',
+				'',
+				'### Requirement: Login',
+				'The system MUST allow users to sign in.',
+				'',
+				'#### Scenario: Successful login',
+				'- **WHEN** the user submits valid credentials',
+				'- **THEN** the system signs them in.',
+				'',
+				'## Notes',
+				'',
+				'- The system MUST skip this standalone obligation (id-less; Spec-Kit would capture, OpenSpec must not)',
+				'',
+			].join('\n'),
+		);
+	});
+
+	test(
+		'buildOpenSpecProjectionSync: standalone obligation bullet absent; golden byte-identical (FR-011)',
+		() => {
+			const proj = buildOpenSpecProjectionSync(tempDir);
+
+			expect(proj).not.toBeNull();
+			expect(proj?.source).toBe('openspec_projection');
+
+			// Golden (byte-identical): a patched parseRequirements that captures id-less
+			// bullets would produce LONGER output with an extra FR-002 for the "skip" line,
+			// breaking this assertion and exposing the regression.
+			expect(proj?.content).toBe(OPENSPEC_GOLDEN);
+
+			// Absence proof: the standalone obligation bullet text must NOT appear.
+			expect(proj?.content).not.toContain('skip this standalone');
+
+			// Presence proof: the Requirement: block is projected correctly.
+			expect(proj?.content).toContain('The system MUST allow users to sign in.');
+			// Scenario lines in the block body are joined into the requirement text.
+			expect(proj?.content).toContain('#### Scenario: Successful login');
+
+			// Count guard: exactly one FR bullet.  Two would mean the standalone bullet leaked.
+			const frLines = proj!.content.match(/^- .*\bFR-\d{3}\b/gm);
+			expect(frLines).toHaveLength(1);
+		},
+	);
+
+	test(
+		'readEffectiveSpecSync (openspec-only): content byte-identical to buildOpenSpecProjectionSync (FR-011 cross-module)',
+		() => {
+			// No .specify/ marker → readEffectiveSpecSync delegates to buildOpenSpecProjectionSync.
+			// If the resolver added Spec-Kit contamination on the openspec-only path, the
+			// two outputs would diverge.
+			const viaResolver = readEffectiveSpecSync(tempDir);
+			const viaDirect = buildOpenSpecProjectionSync(tempDir);
+
+			expect(viaResolver).not.toBeNull();
+			expect(viaDirect).not.toBeNull();
+			expect(viaResolver?.source).toBe('openspec_projection');
+
+			// Byte-identical (FR-011): any resolver-side modification to the openspec-only
+			// path would break this comparison and expose the cross-module regression.
+			expect(viaResolver?.content).toBe(viaDirect?.content);
+			expect(viaResolver?.content).toBe(OPENSPEC_GOLDEN);
+		},
+	);
+});
+
+// ---------------------------------------------------------------------------
+// 3. FR-010 ambiguity diagnostic: EXACTLY ONE console.warn per call
+// ---------------------------------------------------------------------------
+describe('3: FR-010 ambiguity diagnostic — warn count is exactly 1 per call (strengthens unit > 0)', () => {
+	function buildBothPresentFixture(): void {
+		// Valid single-feature Spec-Kit (features.length > 0 → registers as competing source).
+		writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+		// Valid OpenSpec that yields a non-null projection (registers as competing source).
+		writeFile(
+			path.join('openspec', 'specs', 'auth', 'spec.md'),
+			'## Requirements\n### Requirement: Login\nThe system MUST allow users to sign in.\n',
+		);
+	}
+
+	test(
+		'both-present repo: returns null AND emits EXACTLY ONE console.warn (not 0, not 2+)',
+		() => {
+			buildBothPresentFixture();
+
+			const warnMessages: string[] = [];
+			const realWarn = console.warn;
+			console.warn = (...args: unknown[]) => {
+				warnMessages.push(args.map(String).join(' '));
+			};
+
+			let result: ReturnType<typeof readEffectiveSpecSync>;
+			try {
+				result = readEffectiveSpecSync(tempDir);
+			} finally {
+				console.warn = realWarn;
+			}
+
+			// Must return null (ambiguous → no effective spec).
+			expect(result!).toBeNull();
+
+			// EXACTLY ONE warning: not zero (silent suppression defeats critic Finding 2)
+			// and not 2+ (double-firing from a loop or nested call path).
+			// The existing unit test asserts `> 0`; this integration test nails it to `=== 1`.
+			expect(warnMessages).toHaveLength(1);
+
+			const msg = warnMessages[0]!;
+			// Warning must name both competing sources so the developer knows what to pick.
+			expect(msg.toLowerCase()).toContain('openspec');
+			expect(msg.toLowerCase()).toContain('speckit');
+			// Warning must name the disambiguation flag.
+			expect(msg).toContain('--source');
+		},
+	);
+
+	test(
+		'two sequential calls on the same ambiguous repo: emits exactly 2 total warnings (1 per call)',
+		() => {
+			// Guards against global deduplication (second call → 0 warns) AND multi-fire
+			// bugs (first call → 2+ warns).  Together with the single-call test, this pins
+			// the per-call count to exactly 1 independently of call count.
+			buildBothPresentFixture();
+
+			const warnMessages: string[] = [];
+			const realWarn = console.warn;
+			console.warn = (...args: unknown[]) => {
+				warnMessages.push(args.map(String).join(' '));
+			};
+
+			try {
+				readEffectiveSpecSync(tempDir);
+				readEffectiveSpecSync(tempDir);
+			} finally {
+				console.warn = realWarn;
+			}
+
+			expect(warnMessages).toHaveLength(2);
+		},
+	);
+});
+
+// ---------------------------------------------------------------------------
+// 4. Multi-feature end-to-end via command (SC-009, FR-008)
+// ---------------------------------------------------------------------------
+describe('4: Multi-feature end-to-end via handleSddProjectCommand (SC-009, FR-008)', () => {
+	test(
+		'no --feature: error names both features + --feature remedy; NO .swarm/spec.md written',
+		async () => {
+			writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+
+			const out = await handleSddProjectCommand(tempDir, []);
+
+			expect(out).toContain('Error:');
+			expect(out).toContain('001-alpha');
+			expect(out).toContain('002-beta');
+			expect(out).toContain('--feature');
+
+			// Critical gate: on the error path, .swarm/spec.md must NOT exist.
+			// Regression caught: an implementation that projects the first feature BEFORE
+			// detecting ambiguity would write a stale spec silently and this check would fail.
+			expect(fs.existsSync(path.join(tempDir, '.swarm', 'spec.md'))).toBe(false);
+		},
+	);
+
+	test(
+		'--feature 002-beta: sourcePaths exact; written file is 002-beta only; readEffectiveSpecSync round-trip (FR-009)',
+		async () => {
+			writeSpeckitFixture(tempDir, { variant: 'multi-feature' });
+
+			// Use --json to get structured sourcePaths (avoids substring-scraping the content).
+			const jsonOut = await handleSddProjectCommand(tempDir, [
+				'--feature',
+				'002-beta',
+				'--json',
+			]);
+			const response = JSON.parse(jsonOut) as {
+				written: boolean;
+				sourcePaths: string[];
+				hash: string | null;
+			};
+
+			expect(response.written).toBe(true);
+			// sourcePaths must contain ONLY 002-beta — not 001-alpha, not both.
+			expect(response.sourcePaths).toEqual(['specs/002-beta/spec.md']);
+			expect(response.hash).toBeDefined();
+			expect(response.hash).not.toBeNull();
+
+			// Written file: .swarm/spec.md must contain ONLY 002-beta content.
+			const specContent = fs.readFileSync(
+				path.join(tempDir, '.swarm', 'spec.md'),
+				'utf-8',
+			);
+			expect(specContent).toContain('beta capability');
+			expect(specContent).toContain('specs/002-beta/spec.md');
+			// No bleed of 001-alpha content into the 002-beta projection.
+			expect(specContent).not.toContain('alpha');
+
+			// Cross-module round-trip: readEffectiveSpecSync now reads the written .swarm/spec.md
+			// as a NATIVE swarm spec (FR-009: native spec wins over any projection source).
+			// This crosses the command module (writes) → resolver module (reads) boundary.
+			const resolved = readEffectiveSpecSync(tempDir);
+			expect(resolved?.source).toBe('swarm');
+			// Content must be byte-identical to the written file.
+			expect(resolved?.content).toBe(specContent);
+			expect(resolved?.content).toContain('beta capability');
+			expect(resolved?.content).not.toContain('alpha');
+		},
+	);
+});
+
+// ---------------------------------------------------------------------------
+// 5. CRLF robustness (defense-in-depth invariant locks)
+// ---------------------------------------------------------------------------
+describe('5: CRLF robustness — CRLF spec.md projects byte-identically to LF version', () => {
+	// NOTE ON TEST STRENGTH: parseSpeckitRequirements defends against CRLF at THREE
+	// independent layers:
+	//   (1) content.replace(/\r\n/g, '\n') — explicit normalization
+	//   (2) line.trim() — removes trailing \r from every captured text
+	//   (3) \s*$ in the section-header regex — \s matches \r so headers are detected either way
+	//
+	// These tests would NOT fail by reverting layer (1) alone because (2) and (3) compensate.
+	// They are therefore COMPOUND-REVERT guards (both (1) and (2) must be removed to break them),
+	// not single-path regression tests.  They freeze the current behaviour as a defense-in-depth
+	// invariant and are explicitly documented as such per the task description.
+
+	test(
+		'explicit-fr variant: CRLF spec.md projection is byte-identical to LF (content + hash)',
+		() => {
+			const crlfDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-crlf-explicit-')),
+			);
+			try {
+				writeSpeckitFixture(tempDir, { variant: 'single-explicit-fr' });
+				writeSpeckitFixture(crlfDir, { variant: 'single-explicit-fr' });
+
+				// Rewrite the fixture spec.md with CRLF line endings.
+				const specPath = path.join(crlfDir, 'specs', '001-auth-service', 'spec.md');
+				const lfContent = fs.readFileSync(specPath, 'utf-8');
+				const crlfContent = lfContent.replace(/\n/g, '\r\n');
+				// Sanity: fixture must use LF so the CRLF version actually differs.
+				expect(crlfContent).not.toBe(lfContent);
+				fs.writeFileSync(specPath, crlfContent, 'utf-8');
+
+				const lfSpec = buildSpeckitProjectionSync(tempDir);
+				const crlfSpec = buildSpeckitProjectionSync(crlfDir);
+
+				expect(lfSpec).not.toBeNull();
+				expect(crlfSpec).not.toBeNull();
+
+				// Defense-in-depth: CRLF input must not pollute the projected output.
+				expect(crlfSpec?.content).toBe(lfSpec?.content);
+				expect(crlfSpec?.hash).toBe(lfSpec?.hash);
+
+				// FR-003: explicit ids are preserved in both line-ending variants.
+				expect(crlfSpec?.content).toContain('**FR-001**');
+				expect(crlfSpec?.content).toContain('**FR-002**');
+				expect(crlfSpec?.content).toContain('**FR-003**');
+			} finally {
+				fs.rmSync(crlfDir, { recursive: true, force: true });
+			}
+		},
+	);
+
+	test(
+		'idless-synthesis variant: CRLF spec.md synthesizes identical FR-### ids as LF (FR-004)',
+		() => {
+			const crlfDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-crlf-idless-')),
+			);
+			try {
+				writeSpeckitFixture(tempDir, { variant: 'single-idless-requirements' });
+				writeSpeckitFixture(crlfDir, { variant: 'single-idless-requirements' });
+
+				const specPath = path.join(crlfDir, 'specs', '001-auth-service', 'spec.md');
+				const lfContent = fs.readFileSync(specPath, 'utf-8');
+				const crlfContent = lfContent.replace(/\n/g, '\r\n');
+				expect(crlfContent).not.toBe(lfContent);
+				fs.writeFileSync(specPath, crlfContent, 'utf-8');
+
+				const lfSpec = buildSpeckitProjectionSync(tempDir);
+				const crlfSpec = buildSpeckitProjectionSync(crlfDir);
+
+				expect(lfSpec).not.toBeNull();
+				expect(crlfSpec).not.toBeNull();
+
+				// FR-004: synthesized ids must be identical whether input uses LF or CRLF.
+				expect(crlfSpec?.content).toBe(lfSpec?.content);
+				expect(crlfSpec?.hash).toBe(lfSpec?.hash);
+
+				// Confirm synthesis path was exercised (synthesized ids, not bold-markup).
+				expect(crlfSpec?.content).toContain('FR-001:');
+				expect(crlfSpec?.content).toContain('FR-002:');
+				expect(crlfSpec?.content).toContain('FR-003:');
+				expect(crlfSpec?.content).not.toContain('**FR-');
+			} finally {
+				fs.rmSync(crlfDir, { recursive: true, force: true });
+			}
+		},
+	);
+});


### PR DESCRIPTION
Closes #1228

## Summary
- Detects and projects a single GitHub Spec-Kit feature (`.specify/` marker + `specs/<feature>/spec.md`) into `.swarm/spec.md`, alongside the existing OpenSpec projection.
- Adds `--source <swarm|openspec|speckit>` and `--feature <id>` to `/swarm sdd status|validate|project`, with explicit precedence: native `.swarm/spec.md` always wins → `--source` → auto-detect → both-present is a hard error naming both sources.
- `/swarm sdd validate` is read-only for Spec-Kit: reports missing required sections, tasks lacking a spec/requirement reference, and zero parsable functional requirements — never writes.
- v1 is single-feature only; multi-feature aggregation and `tasks.md` round-trip write-back are deferred to #1577.

Independent per-task review (opus) plus a phase-wrap drift/hallucination gate caught and fixed two real correctness bugs before merge:
- **FR-003**: synthesized ids for id-less requirement bullets could steal an explicit `FR-001` if it appeared earlier in document order, silently renumbering the real requirement. Fixed by reserving all explicit ids before synthesis; OpenSpec projection output is unaffected (proven byte-identical).
- **FR-009**: `status`/`validate` ignored native `.swarm/spec.md` precedence when both OpenSpec and Spec-Kit were also present, hard-erroring instead of reporting the native spec. Fixed with a native-existence guard; `project` is intentionally unchanged (native is authored, not projected).

Both fixes shipped with failing-first regression tests, confirmed to fail pre-fix and pass post-fix, then independently re-reviewed.

## Invariant audit
- 1 (plugin init): not touched — no changes to `src/index.ts`, init path, or startup hooks (`git diff --name-only origin/main..HEAD` confirms).
- 2 (runtime portability): not touched — no `bun:` imports outside test files (`bun:test` only, expected), no `Bun.*` calls, no bundle/plugin-shape changes; `dist/index.js` builds and imports cleanly (`node --input-type=module -e "await import('./dist/index.js')"` → `dist import OK`).
- 3 (subprocesses): not touched — `git diff --name-only origin/main..HEAD | xargs grep -nE "bunSpawn\(|spawn\(|spawnSync\("` returns empty.
- 4 (.swarm containment): touched, existing pattern reused — `writeProjectedSpecSync`/`readEffectiveSpecSync` write/read only `path.join(directory, '.swarm', 'spec.md')` via the caller-supplied `directory` param (same pattern as the pre-existing OpenSpec projector); no new `process.cwd()` callers (`git diff --name-only origin/main..HEAD | xargs grep -n "process.cwd()"` returns empty).
- 5 (plan durability): not touched — no changes to `plan-ledger.jsonl`/`plan.json`/`plan.md` handling.
- 6 (test_runner safety): not touched — validation was run via direct `bun test`/per-file shell loops, not the `test_runner` tool.
- 7 (test writing): touched — all new/modified tests use `bun:test` only; no `mock.module` usage (real `fs` via `mkdtempSync` fixtures throughout, confirmed by grep). Two pre-existing test files (`src/sdd/effective-spec.test.ts`, `tests/unit/commands/sdd.test.ts`) grew past the 500-line guidance through incremental additive coverage across this feature's phases (829 and 646 lines respectively, up from 135/115 lines pre-#1228); both were pre-existing files (created in `61bd9e2f`), not new files created by this PR, but are flagged here as follow-up split candidates rather than silently omitted. The one genuinely new large test file, `tests/unit/sdd/speckit-integration.test.ts` (436 lines), is under the 500-line cap.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no new tools; `src/tools/index.ts`, `src/index.ts` tool block, `src/tools/tool-names.ts`, and `src/config/constants.ts` are all untouched (confirmed by diff).
- 12 (release/cache): touched — `docs/releases/pending/feat-1228-speckit-sdd-interop.md` fragment added; `package.json`, `CHANGELOG.md`, `.release-please-manifest.json` untouched (confirmed by diff).

## Test plan
- [x] `bun run build` succeeds; `node --input-type=module -e "await import('./dist/index.js')"` → `dist import OK`
- [x] `bun run typecheck` clean
- [x] `bunx @biomejs/biome@2.3.14 check` clean on all touched files (formatting fixes applied and re-verified with `--write`, then re-ran tests to confirm no behavior change)
- [x] Full SDD suite: `bun test src/sdd/effective-spec.test.ts tests/unit/commands/sdd.test.ts tests/unit/sdd/speckit-integration.test.ts tests/helpers/speckit-fixture.test.ts` → **150 pass / 0 fail**, run both standalone and in isolation
- [x] Cross-cutting integration tests: projection determinism through the write path, an OpenSpec regression golden (standalone obligation bullets still don't leak into OpenSpec parsing), library-level ambiguity `console.warn` exactly-once, multi-feature `--feature` selection end-to-end, CRLF parse-equivalence
- [x] `docs/planning.md` Spec-Kit section + release fragment, both verified against shipped code by an independent reviewer pass (4 inaccuracies found and corrected)
- [x] Tier 2 (`tests/unit/cli tests/unit/commands tests/unit/config`) run; failures investigated — see `## Pre-existing failures` below

## Pre-existing failures
Running `bun --smol test tests/unit/cli tests/unit/commands tests/unit/config` as one combined process surfaces widespread unrelated failures (725 of 3569 tests) caused by cross-file `mock.module` pollution in Bun's shared test-runner process (the exact failure mode AGENTS.md invariant 7 documents). Root cause traced precisely: `tests/unit/commands/reset.test.ts` mocks `node:fs`'s `rmSync` to throw `EACCES` without spreading the real module's exports, and that mock leaks into every test file that runs afterward in the same process — including `sdd.test.ts`, which fails with `EACCES: permission denied` thrown from inside `reset.test.ts`'s own mock body.

Verified pre-existing and unrelated to this PR:
- Reproduced identically on a clean `origin/main` worktree with no #1228 changes present (`git worktree add /tmp/repro-check-1228 origin/main`, same command → 465 fail / 126 errors of 945 tests).
- `sdd.test.ts` and every other file this PR touches or adds (`effective-spec.test.ts`, `speckit-integration.test.ts`, `speckit-fixture.test.ts`) pass 150/150 when run standalone/in isolation, with zero appearances in a 25-file per-file-isolation sweep of `tests/unit/commands/*.test.ts` that surfaces the same widespread pre-existing breakage independent of any combined-run pollution.
- Tiers 3–5 (`tests/security`, `tests/adversarial`, `tests/integration`, `tests/smoke`, `./test`) were not run in full: none reference `sdd`/`speckit` (confirmed by grep), and this PR touches no security-sensitive, subprocess, or plugin-init/CLI-entry surface.

Not fixed here — `reset.test.ts` is a pre-existing, unrelated file outside this PR's scope; fixing its mock isolation is a separate, repo-wide test-infrastructure task.
