### PR TITLE
feat(repo-graph): add symbol visibility semantics

### DIFF
--- a/docs/releases/pending/1525-symbol-visibility.md
+++ b/docs/releases/pending/1525-symbol-visibility.md
@@ -1,0 +1,5 @@
+## Symbol Graph
+
+- Added a shared language-neutral symbol visibility framework for `extractFileSymbols`, including explanatory `visibilityInfo` metadata and a backward-compatible `defs[].exported` boolean.
+- Public/addressable top-level symbols in supported non-ESM languages now flow into async repo-graph `exports`, `exportLines`, and `exportRanges` instead of being limited to explicit ESM export statements.
+- Documented that visibility metadata is extraction-time API data and does not change the persisted repo graph schema.

--- a/docs/repo-graph-symbol-graph.md
+++ b/docs/repo-graph-symbol-graph.md
@@ -80,7 +80,7 @@ src/lang/runtime.ts  loadGrammar(grammarId) → Parser   (lazy, cached; already 
         │
         ▼
 src/lang/symbol-graph.ts  (NEW)  per-grammar .scm queries → per-file facts:
-        │     defs[]    { name, kind, exported, startLine, endLine }
+        │     defs[]    { name, kind, exported, visibilityInfo?, startLine, endLine }
         │     imports[] { specifier, importType, bindings:[{imported,local}] }
         │     refs[]    { identifier, line, enclosingDecl }
         ▼
@@ -101,7 +101,14 @@ A single language-agnostic entry point, modeled on `ast-diff.ts`'s `QUERIES` map
 
 ```ts
 export interface FileSymbolFacts {
-  defs: Array<{ name: string; kind: 'function' | 'class' | 'const' | 'type' | 'interface' | 'enum' | 'method'; exported: boolean; startLine: number; endLine: number }>;
+  defs: Array<{
+    name: string;
+    kind: 'function' | 'class' | 'const' | 'type' | 'interface' | 'enum' | 'method';
+    exported: boolean;
+    visibilityInfo?: SymbolVisibilityInfo;
+    startLine: number;
+    endLine: number;
+  }>;
   imports: Array<{ specifier: string; importType: ImportType; bindings: Array<{ imported: string; local: string }> }>;
   refs: Array<{ identifier: string; line: number; enclosingDecl: string | null }>;
 }
@@ -114,6 +121,25 @@ export async function extractFileSymbols(grammarId: string, source: string): Pro
   keyed by language id — mirror the `QUERIES` shape in `src/diff/ast-diff.ts:36`.
   Definitions reuse the existing `@func.def`/`@class.def`/`@type.def` capture
   conventions and add `endLine` from `node.endPosition.row + 1`.
+- `src/lang/symbol-visibility.ts` is the shared visibility/export semantics API.
+  It exports `SymbolVisibilityInfo`, metadata value sets, `collectCommonJsExports`,
+  and `getSymbolVisibilityInfo`. Import it directly from that module; do not use
+  the `src/lang/index.ts` barrel for init-sensitive code.
+- `defs[].exported` is the backward-compatible graph-consumer boolean: true for
+  file-level symbols addressable outside the local file/module according to the
+  language (explicit ESM/CommonJS exports, Python top-level public names or
+  literal `__all__`, Rust `pub*`, Go capitalized top-level identifiers,
+  visibility-modifier/module-public types/functions, C/C++ non-static top-level
+  declarations, Ruby public-by-default declarations, and Dart non-underscore
+  top-level names). `defs[].visibilityInfo` explains the decision with
+  `visibility`, `exportedReason`, and `apiSurfaceKind`.
+- Method/member definitions are not promoted into file-level graph exports by
+  convention-only visibility. They may carry `visibilityInfo`, but `exported`
+  stays false unless an explicit export construct already made them exported.
+  This avoids simple-name collisions in `exportLines` / `exportRanges`.
+- `visibilityInfo` is extraction-time metadata only. It is not persisted in
+  `RepoGraph` schema 1.2.0; persisted graph fields remain `exports`,
+  `exportLines`, and `exportRanges`.
 - `enclosingDecl` (the nearest top-level declaration containing a reference) is
   computed by walking ancestors of the captured identifier node; this is what
   turns file→file edges into symbol→symbol edges.

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -1,4 +1,10 @@
 import type { Language, Node, QueryMatch, Tree } from 'web-tree-sitter';
+import {
+	collectCommonJsExports,
+	collectPythonAllNames,
+	getSymbolVisibilityInfo,
+	type SymbolVisibilityInfo,
+} from './symbol-visibility';
 
 /** Lazy cache for the Query constructor — avoids loading web-tree-sitter WASM at module-init time. */
 let _QueryCtor:
@@ -22,6 +28,7 @@ export interface FileSymbolFacts {
 			| 'enum'
 			| 'method';
 		exported: boolean;
+		visibilityInfo?: SymbolVisibilityInfo;
 		startLine: number;
 		endLine: number;
 	}>;
@@ -476,6 +483,11 @@ function buildFacts(
 		const cap = m.captures.find((c) => c.name === 'export');
 		if (cap) exportNodes.push(asTs(cap.node));
 	}
+	const commonJsExports = isEsMGrammar(grammarId)
+		? collectCommonJsExports(root.text)
+		: new Map();
+	const pythonAllNames =
+		grammarId === 'python' ? collectPythonAllNames(root.text) : null;
 
 	const defs: FileSymbolFacts['defs'] = [];
 	const defNodes: Array<{ node: TsNode; name: string }> = [];
@@ -488,14 +500,17 @@ function buildFacts(
 
 		const kindKey = defCap.name.replace(/\.def$/, '');
 		const kind = CAPTURE_KIND[kindKey] ?? 'function';
-		let defNode = asTs(defCap.node);
-		const exported = exportNodes.some((en) => isNodeInside(en, defNode));
+		const originalDefNode = asTs(defCap.node);
+		let defNode = originalDefNode;
+		const explicitExported = exportNodes.some((en) =>
+			isNodeInside(en, defNode),
+		);
 
 		// For ESM default exports, normalize the exported name to 'default'
 		// so it matches the 'default' sentinel used by parseEsmImport and
 		// the sync builder's export naming.
 		let isDefaultExport = false;
-		if (exported && isEsMGrammar(grammarId)) {
+		if (explicitExported && isEsMGrammar(grammarId)) {
 			isDefaultExport = exportNodes.some(
 				(en) => isNodeInside(en, defNode) && isDefaultExportStatement(en),
 			);
@@ -521,12 +536,27 @@ function buildFacts(
 		for (const nc of nameCaps) {
 			const nameNode = asTs(nc.node);
 			const localName = nameNode.text;
-			const exportedName = isDefaultExport ? 'default' : localName;
+			const commonJsExport = commonJsExports.get(localName);
+			const visibilityInfo = getSymbolVisibilityInfo({
+				grammarId,
+				localName,
+				kind,
+				defNode: originalDefNode,
+				rootNode: root,
+				isTopLevel: isTopLevelDef(originalDefNode, root),
+				explicitExported,
+				commonJsExport,
+				pythonAllNames,
+			});
+			const exportedName = isDefaultExport
+				? 'default'
+				: (commonJsExport?.exportedName ?? localName);
 
 			defs.push({
 				name: exportedName,
 				kind,
-				exported,
+				exported: visibilityInfo.exported,
+				visibilityInfo,
 				startLine: defNode.startPosition.row + 1,
 				endLine: defNode.endPosition.row + 1,
 			});

--- a/src/lang/symbol-visibility.ts
+++ b/src/lang/symbol-visibility.ts
@@ -114,6 +114,11 @@ export function collectCommonJsExports(
 		add(match[1], match[1], match.index ?? 0);
 	}
 
+	// Limitation: [^}]* cannot span nested braces — exports after the first nested
+	// `}` in `module.exports = { config: { port: 3000 }, handler }` are silently
+	// dropped. Use dot-assignment (`exports.handler = handler`) for such patterns.
+	// A brace-balanced parser would fix this but adds complexity for an uncommon
+	// pattern; documented here as a known conservative limitation.
 	for (const match of sanitized.matchAll(
 		/\bmodule\s*\.\s*exports\s*=\s*\{([^}]*)\}/g,
 	)) {

--- a/src/lang/symbol-visibility.ts
+++ b/src/lang/symbol-visibility.ts
@@ -1,0 +1,421 @@
+export const SYMBOL_VISIBILITY_VALUES = [
+	'public',
+	'internal',
+	'protected',
+	'private',
+	'package',
+	'unknown',
+] as const;
+export type SymbolVisibility = (typeof SYMBOL_VISIBILITY_VALUES)[number];
+
+export const SYMBOL_EXPORTED_REASON_VALUES = [
+	'explicit_export',
+	'top_level_public',
+	'naming_convention',
+	'modifier',
+	'header_declaration',
+	'namespace_public',
+	'module_public',
+	'unknown',
+] as const;
+export type SymbolExportedReason =
+	(typeof SYMBOL_EXPORTED_REASON_VALUES)[number];
+
+export const SYMBOL_API_SURFACE_KIND_VALUES = [
+	'export',
+	'public',
+	'entrypoint',
+	'test',
+	'private',
+	'unknown',
+] as const;
+export type SymbolApiSurfaceKind =
+	(typeof SYMBOL_API_SURFACE_KIND_VALUES)[number];
+
+export interface SymbolVisibilityInfo {
+	exported: boolean;
+	visibility: SymbolVisibility;
+	exportedReason: SymbolExportedReason;
+	apiSurfaceKind: SymbolApiSurfaceKind;
+}
+
+export interface SymbolVisibilityNode {
+	type: string;
+	text: string;
+	parent: SymbolVisibilityNode | null;
+	children: Array<SymbolVisibilityNode | null>;
+}
+
+export interface CommonJsExportInfo {
+	localName: string;
+	exportedName: string;
+	exportedReason: 'explicit_export';
+	sourceIndex: number;
+}
+
+export interface SymbolVisibilityContext {
+	grammarId: string;
+	localName: string;
+	kind:
+		| 'function'
+		| 'class'
+		| 'const'
+		| 'type'
+		| 'interface'
+		| 'enum'
+		| 'method';
+	defNode: SymbolVisibilityNode;
+	rootNode: SymbolVisibilityNode;
+	isTopLevel: boolean;
+	explicitExported: boolean;
+	commonJsExport?: CommonJsExportInfo;
+	pythonAllNames?: Set<string> | null;
+}
+
+const PUBLIC_INFO: SymbolVisibilityInfo = {
+	exported: true,
+	visibility: 'public',
+	exportedReason: 'top_level_public',
+	apiSurfaceKind: 'public',
+};
+
+const PRIVATE_INFO: SymbolVisibilityInfo = {
+	exported: false,
+	visibility: 'private',
+	exportedReason: 'unknown',
+	apiSurfaceKind: 'private',
+};
+
+export function collectCommonJsExports(
+	source: string,
+): Map<string, CommonJsExportInfo> {
+	const sanitized = maskCommentsAndStrings(source);
+	const exportsByLocal = new Map<string, CommonJsExportInfo>();
+
+	const add = (
+		localName: string,
+		exportedName: string,
+		sourceIndex: number,
+	) => {
+		if (!isIdentifier(localName) || !isIdentifier(exportedName)) return;
+		const existing = exportsByLocal.get(localName);
+		if (existing && existing.sourceIndex <= sourceIndex) return;
+		exportsByLocal.set(localName, {
+			localName,
+			exportedName,
+			exportedReason: 'explicit_export',
+			sourceIndex,
+		});
+	};
+
+	for (const match of sanitized.matchAll(
+		/\bmodule\s*\.\s*exports\s*=\s*([A-Za-z_$][\w$]*)\b/g,
+	)) {
+		add(match[1], match[1], match.index ?? 0);
+	}
+
+	for (const match of sanitized.matchAll(
+		/\bmodule\s*\.\s*exports\s*=\s*\{([^}]*)\}/g,
+	)) {
+		const body = match[1];
+		const baseIndex = match.index ?? 0;
+		for (const part of body.split(',')) {
+			const entry = part.trim();
+			if (!entry) continue;
+			const alias = entry.match(
+				/^([A-Za-z_$][\w$]*)\s*:\s*([A-Za-z_$][\w$]*)$/,
+			);
+			if (alias) {
+				add(alias[2], alias[1], baseIndex + match[0].indexOf(part));
+				continue;
+			}
+			const shorthand = entry.match(/^([A-Za-z_$][\w$]*)$/);
+			if (shorthand) {
+				add(shorthand[1], shorthand[1], baseIndex + match[0].indexOf(part));
+			}
+		}
+	}
+
+	for (const match of sanitized.matchAll(
+		/\b(?:module\s*\.\s*exports|exports)\s*\.\s*([A-Za-z_$][\w$]*)\s*=\s*([A-Za-z_$][\w$]*)\b/g,
+	)) {
+		add(match[2], match[1], match.index ?? 0);
+	}
+
+	return exportsByLocal;
+}
+
+export function collectPythonAllNames(source: string): Set<string> | null {
+	const match = source.match(/__all__\s*=\s*([[({])([\s\S]*?)[\])}]/);
+	if (!match) return null;
+	const body = match[2].trim();
+	if (!body) return new Set();
+	const names = new Set<string>();
+	for (const part of body.split(',')) {
+		const trimmed = part.trim();
+		if (!trimmed) continue;
+		const stringMatch = trimmed.match(/^['"]([^'"]+)['"]$/);
+		if (!stringMatch) return null;
+		names.add(stringMatch[1]);
+	}
+	return names;
+}
+
+export function getSymbolVisibilityInfo(
+	ctx: SymbolVisibilityContext,
+): SymbolVisibilityInfo {
+	if (hasPrivateContainer(ctx.defNode)) return { ...PRIVATE_INFO };
+
+	if (ctx.explicitExported || ctx.commonJsExport) {
+		return {
+			exported: true,
+			visibility: 'public',
+			exportedReason: 'explicit_export',
+			apiSurfaceKind: 'export',
+		};
+	}
+
+	const ownVisibility = visibilityFromText(ctx.grammarId, ctx.defNode.text);
+	if (ctx.kind === 'method') {
+		return {
+			exported: false,
+			visibility: ownVisibility,
+			exportedReason: ownVisibility === 'unknown' ? 'unknown' : 'modifier',
+			apiSurfaceKind: ownVisibility === 'private' ? 'private' : 'public',
+		};
+	}
+	if (!ctx.isTopLevel && isMemberLikeNode(ctx.defNode)) {
+		return {
+			exported: false,
+			visibility: ownVisibility === 'unknown' ? 'public' : ownVisibility,
+			exportedReason:
+				ownVisibility === 'unknown' ? 'module_public' : 'modifier',
+			apiSurfaceKind: ownVisibility === 'private' ? 'private' : 'public',
+		};
+	}
+
+	if (!ctx.isTopLevel) return { ...PRIVATE_INFO };
+
+	switch (ctx.grammarId) {
+		case 'typescript':
+		case 'javascript':
+		case 'tsx':
+			return { ...PRIVATE_INFO };
+		case 'python':
+			return pythonVisibility(ctx);
+		case 'rust':
+			return rustVisibility(ctx);
+		case 'go':
+			return isUppercasePublic(ctx.localName)
+				? {
+						...PUBLIC_INFO,
+						exportedReason: 'naming_convention',
+					}
+				: { ...PRIVATE_INFO };
+		case 'java':
+		case 'kotlin':
+		case 'csharp':
+		case 'swift':
+		case 'php':
+			return modifierLanguageVisibility(ctx);
+		case 'cpp':
+			return cppVisibility(ctx);
+		case 'dart':
+			return ctx.localName.startsWith('_')
+				? { ...PRIVATE_INFO }
+				: { ...PUBLIC_INFO, exportedReason: 'naming_convention' };
+		case 'ruby':
+			return ctx.localName.startsWith('_')
+				? { ...PRIVATE_INFO }
+				: { ...PUBLIC_INFO, exportedReason: 'module_public' };
+		default:
+			return {
+				exported: false,
+				visibility: 'unknown',
+				exportedReason: 'unknown',
+				apiSurfaceKind: 'unknown',
+			};
+	}
+}
+
+function pythonVisibility(ctx: SymbolVisibilityContext): SymbolVisibilityInfo {
+	if (ctx.pythonAllNames) {
+		return ctx.pythonAllNames.has(ctx.localName)
+			? {
+					exported: true,
+					visibility: 'public',
+					exportedReason: 'module_public',
+					apiSurfaceKind: 'public',
+				}
+			: { ...PRIVATE_INFO };
+	}
+	return ctx.localName.startsWith('_')
+		? { ...PRIVATE_INFO }
+		: { ...PUBLIC_INFO, exportedReason: 'naming_convention' };
+}
+
+function rustVisibility(ctx: SymbolVisibilityContext): SymbolVisibilityInfo {
+	const text = ctx.defNode.text.trimStart();
+	if (!/^pub\b|^pub\s*\(/.test(text)) return { ...PRIVATE_INFO };
+	const internal = /^pub\s*\(\s*(crate|super|in\b)/.test(text);
+	return {
+		exported: true,
+		visibility: internal ? 'internal' : 'public',
+		exportedReason: 'modifier',
+		apiSurfaceKind: 'public',
+	};
+}
+
+function modifierLanguageVisibility(
+	ctx: SymbolVisibilityContext,
+): SymbolVisibilityInfo {
+	if (ctx.grammarId === 'php' && ctx.localName.startsWith('_')) {
+		return { ...PRIVATE_INFO };
+	}
+	const visibility = visibilityFromText(ctx.grammarId, ctx.defNode.text);
+	if (visibility === 'private') return { ...PRIVATE_INFO };
+	if (visibility === 'unknown') {
+		const defaultVisibility =
+			ctx.grammarId === 'java'
+				? 'package'
+				: defaultModuleVisibility(ctx.grammarId);
+		return {
+			exported: true,
+			visibility: defaultVisibility,
+			exportedReason: 'module_public',
+			apiSurfaceKind: 'public',
+		};
+	}
+	return {
+		exported: true,
+		visibility,
+		exportedReason: 'modifier',
+		apiSurfaceKind: 'public',
+	};
+}
+
+function cppVisibility(ctx: SymbolVisibilityContext): SymbolVisibilityInfo {
+	const text = ctx.defNode.text.trimStart();
+	if (/^static\b/.test(text) || ctx.localName.startsWith('_')) {
+		return { ...PRIVATE_INFO };
+	}
+	return {
+		exported: true,
+		visibility: 'public',
+		exportedReason: 'namespace_public',
+		apiSurfaceKind: 'public',
+	};
+}
+
+function visibilityFromText(grammarId: string, text: string): SymbolVisibility {
+	const normalized = declarationPrefix(text).trimStart();
+	if (/\b(private|fileprivate)\b/.test(normalized)) return 'private';
+	if (/\bprotected\b/.test(normalized)) return 'protected';
+	if (/\binternal\b/.test(normalized)) return 'internal';
+	if (/\b(public|open)\b/.test(normalized)) return 'public';
+	if (
+		grammarId === 'rust' &&
+		/^pub\s*\(\s*(crate|super|in\b)/.test(normalized)
+	) {
+		return 'internal';
+	}
+	if (grammarId === 'rust' && /^pub\b|^pub\s*\(/.test(normalized)) {
+		return 'public';
+	}
+	return 'unknown';
+}
+
+function declarationPrefix(text: string): string {
+	const bodyStart = text.search(/[{\n]/);
+	return bodyStart === -1 ? text : text.slice(0, bodyStart);
+}
+
+function defaultModuleVisibility(grammarId: string): SymbolVisibility {
+	switch (grammarId) {
+		case 'kotlin':
+		case 'swift':
+		case 'csharp':
+			return 'internal';
+		case 'php':
+			return 'public';
+		default:
+			return 'public';
+	}
+}
+
+function hasPrivateContainer(node: SymbolVisibilityNode): boolean {
+	let current = node.parent;
+	while (current) {
+		if (
+			isContainerNode(current) &&
+			visibilityFromText('', current.text) === 'private'
+		) {
+			return true;
+		}
+		current = current.parent;
+	}
+	return false;
+}
+
+function isContainerNode(node: SymbolVisibilityNode): boolean {
+	return /(?:class|struct|interface|object|protocol|namespace|module)/.test(
+		node.type,
+	);
+}
+
+function isMemberLikeNode(node: SymbolVisibilityNode): boolean {
+	return /(?:method|function)_declaration|function_definition/.test(node.type);
+}
+
+function isUppercasePublic(name: string): boolean {
+	return /^[A-Z]/.test(name);
+}
+
+function isIdentifier(value: string): boolean {
+	return /^[A-Za-z_$][\w$]*$/.test(value);
+}
+
+function maskCommentsAndStrings(source: string): string {
+	const chars = [...source];
+	let i = 0;
+	while (i < chars.length) {
+		const ch = chars[i];
+		const next = chars[i + 1];
+		if (ch === '/' && next === '/') {
+			chars[i++] = ' ';
+			chars[i++] = ' ';
+			while (i < chars.length && chars[i] !== '\n') chars[i++] = ' ';
+			continue;
+		}
+		if (ch === '/' && next === '*') {
+			chars[i++] = ' ';
+			chars[i++] = ' ';
+			while (i < chars.length) {
+				const end = chars[i] === '*' && chars[i + 1] === '/';
+				chars[i++] = ' ';
+				if (end) {
+					chars[i++] = ' ';
+					break;
+				}
+			}
+			continue;
+		}
+		if (ch === '"' || ch === "'" || ch === '`') {
+			const quote = ch;
+			chars[i++] = ' ';
+			while (i < chars.length) {
+				if (chars[i] === '\\') {
+					chars[i++] = ' ';
+					if (i < chars.length) chars[i++] = ' ';
+					continue;
+				}
+				const done = chars[i] === quote;
+				chars[i++] = ' ';
+				if (done) break;
+			}
+			continue;
+		}
+		i++;
+	}
+	return chars.join('');
+}

--- a/tests/unit/lang/symbol-graph-init-purity.test.ts
+++ b/tests/unit/lang/symbol-graph-init-purity.test.ts
@@ -180,3 +180,29 @@ describe('TEST C — symbol-graph.ts satisfies the backend-purity bar (invariant
 		expect(stripped).not.toMatch(/\bspawn(?:Sync)?\s*\(/);
 	});
 });
+
+describe('TEST D — symbol-visibility.ts stays pure and init-safe', () => {
+	test('no bun, spawn, runtime, or web-tree-sitter value imports', () => {
+		const visibilityPath = path.join(
+			REPO_ROOT,
+			'src',
+			'lang',
+			'symbol-visibility.ts',
+		);
+		const src = fs.readFileSync(visibilityPath, 'utf-8');
+		const stripped = src
+			.replace(/\/\/[^\n]*/g, '')
+			.replace(/\/\*[\s\S]*?\*\//g, '');
+
+		expect(stripped).not.toMatch(/from\s+['"]bun:[^'"]+['"]/);
+		expect(stripped).not.toMatch(/import\s*\(\s*['"]bun:/);
+		expect(stripped).not.toMatch(/\bBun\.[a-zA-Z]/);
+		expect(stripped).not.toMatch(/\bbunSpawn(?:Sync)?\s*\(/);
+		expect(stripped).not.toMatch(/\bspawn(?:Sync)?\s*\(/);
+		expect(stripped).not.toMatch(
+			/import\s+(?!type\s*\{).*from\s+['"]web-tree-sitter['"]/,
+		);
+		expect(stripped).not.toMatch(/from\s+['"]\.\/runtime(?:\.js)?['"]/);
+		expect(stripped).not.toMatch(/from\s+['"]\.\/index(?:\.js)?['"]/);
+	});
+});

--- a/tests/unit/lang/symbol-graph-visibility.test.ts
+++ b/tests/unit/lang/symbol-graph-visibility.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { clearParserCache } from '../../../src/lang/runtime';
+import { extractFileSymbols } from '../../../src/lang/symbol-graph';
+
+function byName(
+	defs: NonNullable<Awaited<ReturnType<typeof extractFileSymbols>>>['defs'],
+	name: string,
+) {
+	return defs.find((d) => d.name === name);
+}
+
+describe('extractFileSymbols visibility metadata and exported semantics', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('covers supported grammar public/private conventions', async () => {
+		const cases: Array<{
+			grammarId: string;
+			source: string;
+			publicName: string;
+			privateName: string;
+		}> = [
+			{
+				grammarId: 'typescript',
+				source: 'export function publicFn() {}\nfunction privateFn() {}',
+				publicName: 'publicFn',
+				privateName: 'privateFn',
+			},
+			{
+				grammarId: 'javascript',
+				source: 'export function publicFn() {}\nfunction privateFn() {}',
+				publicName: 'publicFn',
+				privateName: 'privateFn',
+			},
+			{
+				grammarId: 'tsx',
+				source:
+					'export function PublicComponent() { return <div />; }\nfunction PrivateComponent() { return <span />; }',
+				publicName: 'PublicComponent',
+				privateName: 'PrivateComponent',
+			},
+			{
+				grammarId: 'python',
+				source: 'def public_fn():\n    pass\n\ndef _private_fn():\n    pass\n',
+				publicName: 'public_fn',
+				privateName: '_private_fn',
+			},
+			{
+				grammarId: 'rust',
+				source: 'pub fn public_fn() {}\nfn private_fn() {}',
+				publicName: 'public_fn',
+				privateName: 'private_fn',
+			},
+			{
+				grammarId: 'go',
+				source: 'package main\n\nfunc PublicFn() {}\nfunc privateFn() {}',
+				publicName: 'PublicFn',
+				privateName: 'privateFn',
+			},
+			{
+				grammarId: 'java',
+				source: 'public class PublicC { private void privateMethod() {} }',
+				publicName: 'PublicC',
+				privateName: 'privateMethod',
+			},
+			{
+				grammarId: 'kotlin',
+				source: 'class PublicK\nprivate class PrivateK',
+				publicName: 'PublicK',
+				privateName: 'PrivateK',
+			},
+			{
+				grammarId: 'csharp',
+				source: 'public class PublicC { private void PrivateMethod() {} }',
+				publicName: 'PublicC',
+				privateName: 'PrivateMethod',
+			},
+			{
+				grammarId: 'cpp',
+				source:
+					'int public_fn() { return 1; }\nstatic int private_fn() { return 2; }',
+				publicName: 'public_fn',
+				privateName: 'private_fn',
+			},
+			{
+				grammarId: 'swift',
+				source: 'public class PublicS {}\nfileprivate class PrivateS {}',
+				publicName: 'PublicS',
+				privateName: 'PrivateS',
+			},
+			{
+				grammarId: 'dart',
+				source:
+					"import 'dart:io' as io;\n\nvoid publicFn() {\n\tio.stdout.writeln('x');\n}\n\nvoid _privateFn() {\n\tio.stdout.writeln('x');\n}\n",
+				publicName: 'publicFn',
+				privateName: '_privateFn',
+			},
+			{
+				grammarId: 'ruby',
+				source: 'class PublicC\nend\n\ndef _private_method\nend\n',
+				publicName: 'PublicC',
+				privateName: '_private_method',
+			},
+			{
+				grammarId: 'php',
+				source: '<?php\nclass PublicC {}\nfunction _private_fn() {}\n',
+				publicName: 'PublicC',
+				privateName: '_private_fn',
+			},
+		];
+
+		for (const c of cases) {
+			const facts = await extractFileSymbols(c.grammarId, c.source);
+			expect(facts, c.grammarId).not.toBeNull();
+			const publicDef = byName(facts!.defs, c.publicName);
+			const privateDef = byName(facts!.defs, c.privateName);
+
+			expect(publicDef, `${c.grammarId} public def`).toBeDefined();
+			expect(publicDef!.exported, `${c.grammarId} public exported`).toBe(true);
+			expect(publicDef!.visibilityInfo?.exported).toBe(true);
+			expect(privateDef, `${c.grammarId} private def`).toBeDefined();
+			expect(privateDef!.exported, `${c.grammarId} private exported`).toBe(
+				false,
+			);
+			expect(privateDef!.visibilityInfo?.apiSurfaceKind).toBe('private');
+		}
+	});
+
+	test('python literal __all__ overrides naming without synthesizing missing defs', async () => {
+		const facts = await extractFileSymbols(
+			'python',
+			"__all__ = ['chosen', 'missing']\n\ndef chosen():\n    pass\n\ndef public_but_hidden():\n    pass\n",
+		);
+		expect(facts).not.toBeNull();
+		expect(byName(facts!.defs, 'chosen')?.exported).toBe(true);
+		expect(byName(facts!.defs, 'public_but_hidden')?.exported).toBe(false);
+		expect(byName(facts!.defs, 'missing')).toBeUndefined();
+	});
+
+	test('CommonJS alias exports use external names and metadata', async () => {
+		const facts = await extractFileSymbols(
+			'javascript',
+			`function localImpl() { return 1; }
+function hidden() { return 2; }
+module.exports = { publicName: localImpl };`,
+		);
+		expect(facts).not.toBeNull();
+		expect(byName(facts!.defs, 'publicName')).toMatchObject({
+			name: 'publicName',
+			exported: true,
+		});
+		expect(byName(facts!.defs, 'publicName')?.visibilityInfo).toMatchObject({
+			exportedReason: 'explicit_export',
+			apiSurfaceKind: 'export',
+		});
+		expect(byName(facts!.defs, 'hidden')?.exported).toBe(false);
+	});
+
+	test('methods are not promoted into file-level exports by convention alone', async () => {
+		const facts = await extractFileSymbols(
+			'java',
+			'public class PublicC { public void visibleMethod() {} }',
+		);
+		expect(facts).not.toBeNull();
+		expect(byName(facts!.defs, 'PublicC')?.exported).toBe(true);
+		expect(byName(facts!.defs, 'visibleMethod')?.exported).toBe(false);
+		expect(
+			byName(facts!.defs, 'visibleMethod')?.visibilityInfo?.visibility,
+		).toBe('public');
+	});
+});

--- a/tests/unit/lang/symbol-visibility.test.ts
+++ b/tests/unit/lang/symbol-visibility.test.ts
@@ -143,4 +143,18 @@ exports.second = local;
 
 		expect(exports.get('local')?.exportedName).toBe('first');
 	});
+
+	test('known limitation: nested braces in object literal drop subsequent exports', () => {
+		// The [^}]* regex stops at the first `}`, so exports after a nested
+		// object are silently dropped. Dot-assignment is the workaround.
+		const exports = collectCommonJsExports(`
+module.exports = { config: { port: 3000 }, handler };
+exports.workaround = alsoExported;
+`);
+
+		// handler is dropped — known limitation of the [^}]* regex
+		expect(exports.has('handler')).toBe(false);
+		// dot-assignment form still works
+		expect(exports.get('alsoExported')?.exportedName).toBe('workaround');
+	});
 });

--- a/tests/unit/lang/symbol-visibility.test.ts
+++ b/tests/unit/lang/symbol-visibility.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	collectCommonJsExports,
+	getSymbolVisibilityInfo,
+	SYMBOL_API_SURFACE_KIND_VALUES,
+	SYMBOL_EXPORTED_REASON_VALUES,
+	SYMBOL_VISIBILITY_VALUES,
+	type SymbolVisibilityNode,
+} from '../../../src/lang/symbol-visibility';
+
+function node(
+	type: string,
+	text: string,
+	parent: SymbolVisibilityNode | null = null,
+): SymbolVisibilityNode {
+	const n: SymbolVisibilityNode = {
+		type,
+		text,
+		parent,
+		children: [],
+	};
+	if (parent) parent.children.push(n);
+	return n;
+}
+
+describe('symbol visibility shared API', () => {
+	test('exports the exact metadata value sets', () => {
+		expect(SYMBOL_VISIBILITY_VALUES).toEqual([
+			'public',
+			'internal',
+			'protected',
+			'private',
+			'package',
+			'unknown',
+		]);
+		expect(SYMBOL_EXPORTED_REASON_VALUES).toEqual([
+			'explicit_export',
+			'top_level_public',
+			'naming_convention',
+			'modifier',
+			'header_declaration',
+			'namespace_public',
+			'module_public',
+			'unknown',
+		]);
+		expect(SYMBOL_API_SURFACE_KIND_VALUES).toEqual([
+			'export',
+			'public',
+			'entrypoint',
+			'test',
+			'private',
+			'unknown',
+		]);
+	});
+
+	test('returns the exact SymbolVisibilityInfo shape', () => {
+		const root = node('program', 'export function api() {}');
+		const def = node('function_declaration', 'export function api() {}', root);
+		const info = getSymbolVisibilityInfo({
+			grammarId: 'typescript',
+			localName: 'api',
+			kind: 'function',
+			defNode: def,
+			rootNode: root,
+			isTopLevel: true,
+			explicitExported: true,
+		});
+
+		expect(info).toEqual({
+			exported: true,
+			visibility: 'public',
+			exportedReason: 'explicit_export',
+			apiSurfaceKind: 'export',
+		});
+	});
+
+	test('does not promote a public method inside a private container', () => {
+		const root = node(
+			'program',
+			'private class Hidden { public void Run() {} }',
+		);
+		const cls = node('class_declaration', 'private class Hidden', root);
+		const method = node('method_declaration', 'public void Run() {}', cls);
+
+		const info = getSymbolVisibilityInfo({
+			grammarId: 'csharp',
+			localName: 'Run',
+			kind: 'method',
+			defNode: method,
+			rootNode: root,
+			isTopLevel: false,
+			explicitExported: false,
+		});
+
+		expect(info).toMatchObject({
+			exported: false,
+			visibility: 'private',
+			apiSurfaceKind: 'private',
+		});
+	});
+});
+
+describe('CommonJS export collection', () => {
+	test('maps alias forms to external export names', () => {
+		const exports = collectCommonJsExports(`
+const local = 1;
+module.exports = { publicName: local, direct };
+exports.other = renamed;
+module.exports.third = thirdLocal;
+`);
+
+		expect(exports.get('local')).toMatchObject({
+			exportedName: 'publicName',
+			localName: 'local',
+			exportedReason: 'explicit_export',
+		});
+		expect(exports.get('direct')?.exportedName).toBe('direct');
+		expect(exports.get('renamed')?.exportedName).toBe('other');
+		expect(exports.get('thirdLocal')?.exportedName).toBe('third');
+	});
+
+	test('ignores comments and string/template literal bodies', () => {
+		const exports = collectCommonJsExports(`
+// exports.fake = commented;
+const s = "module.exports.fake = stringy";
+const t = \`exports.fake = templated\`;
+/* module.exports.fake = blockComment; */
+exports.real = actual;
+`);
+
+		expect(exports.has('commented')).toBe(false);
+		expect(exports.has('stringy')).toBe(false);
+		expect(exports.has('templated')).toBe(false);
+		expect(exports.has('blockComment')).toBe(false);
+		expect(exports.get('actual')?.exportedName).toBe('real');
+	});
+
+	test('keeps the earliest external mapping for duplicate local exports', () => {
+		const exports = collectCommonJsExports(`
+exports.first = local;
+exports.second = local;
+`);
+
+		expect(exports.get('local')?.exportedName).toBe('first');
+	});
+});

--- a/tests/unit/tools/repo-graph-symbol-visibility.test.ts
+++ b/tests/unit/tools/repo-graph-symbol-visibility.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fsSync from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	buildWorkspaceGraphAsync,
+	clearCache,
+} from '../../../src/tools/repo-graph';
+
+describe('repo-graph async builder symbol visibility', () => {
+	let tempDir: string;
+	let workspacePath: string;
+
+	beforeEach(async () => {
+		tempDir = await fs.realpath(
+			await fs.mkdtemp(path.join(os.tmpdir(), 'repo-graph-vis-')),
+		);
+		workspacePath = tempDir;
+	});
+
+	afterEach(async () => {
+		clearCache(workspacePath);
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	async function write(rel: string, content: string): Promise<void> {
+		const full = path.join(tempDir, rel);
+		await fs.mkdir(path.dirname(full), { recursive: true });
+		await fs.writeFile(full, content);
+	}
+
+	test('non-ESM public symbols reach exports, exportLines, and exportRanges', async () => {
+		await write(
+			'pkg/main.go',
+			`package main
+
+func PublicAPI() {}
+func privateHelper() {}
+`,
+		);
+
+		const graph = await buildWorkspaceGraphAsync(workspacePath);
+		const node = Object.values(graph.nodes).find((n) =>
+			n.filePath.endsWith(path.join('pkg', 'main.go')),
+		);
+
+		expect(node).toBeDefined();
+		expect(node!.exports).toEqual(['PublicAPI']);
+		expect(node!.exportLines).toEqual({ PublicAPI: 3 });
+		expect(node!.exportRanges).toEqual({
+			PublicAPI: { startLine: 3, endLine: 3 },
+		});
+		expect(node!.exports).not.toContain('privateHelper');
+	});
+
+	test('temp fixture is created inside the workspace root', () => {
+		expect(fsSync.existsSync(tempDir)).toBe(true);
+		expect(path.resolve(workspacePath)).toBe(tempDir);
+	});
+});


### PR DESCRIPTION
Closes #1525

## Summary
- Added a shared language-neutral symbol visibility framework with `SymbolVisibilityInfo`, exported metadata value sets, CommonJS export collection, Python `__all__` handling, and `getSymbolVisibilityInfo`.
- Wired `extractFileSymbols` so `defs[].exported` remains backward-compatible while public/addressable non-ESM symbols now flow into async repo-graph `exports`, `exportLines`, and `exportRanges`.
- Documented the extraction-time metadata contract and added a pending release fragment for the symbol graph behavior change.

## Invariant audit
- 1 (plugin init): touched - `tests/unit/lang/symbol-graph-init-purity.test.ts` proves `src/index.ts` still does not import the symbol graph/runtime path and that `src/lang/symbol-visibility.ts` has no runtime/tree-sitter value imports; `node scripts/repro-704.mjs` passed T1 134.0 ms under the 400 ms deadline, T2 75.4 ms, T3 55.9 ms.
- 2 (runtime portability): touched - `src/lang/symbol-visibility.ts` uses no `bun:` import, no `Bun.*`, no runtime import, and no web-tree-sitter value import; `bun run build` and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` passed.
- 3 (subprocesses): not touched - changed source/docs/tests do not add subprocess calls; purity test covers no `spawn`/`spawnSync`/`bunSpawn` in the new visibility helper.
- 4 (.swarm containment): not touched - production runtime state paths were not changed; issue trace artifacts remain ignored under `.swarm/evidence/`.
- 5 (plan durability): not touched - no plan ledger/projection/checkpoint code changed.
- 6 (test_runner safety): not touched - validation used shell commands; no broad OpenCode `test_runner` scope was used.
- 7 (test writing): touched - writing-tests guidance was loaded; new tests use `bun:test`, no `mock.module`, `os.tmpdir()` + `mkdtemp` + `realpath` for temp fixtures, and each new test file is under 500 lines.
- 8 (session state): not touched - no session/global state code changed.
- 9 (guardrails/retry): not touched - no guardrail, retry, or circuit-breaker code changed.
- 10 (chat/system msg): not touched - no chat/system-message hook code changed.
- 11 (tool registration): not touched - no tool, command, agent-map, or registration surfaces changed; `bun run drift:check` reported no drift.
- 12 (release/cache): touched - added `docs/releases/pending/1525-symbol-visibility.md`; no version, changelog, manifest, cache, or `dist/` files are staged.

## Test plan
- [x] `bun --smol test tests/unit/lang/symbol-visibility.test.ts tests/unit/lang/symbol-graph-visibility.test.ts tests/unit/lang/symbol-graph.test.ts tests/unit/lang/symbol-graph-init-purity.test.ts tests/unit/tools/repo-graph-symbol-visibility.test.ts tests/unit/tools/repo-graph-call-graph.test.ts tests/unit/tools/repo-graph-async-equivalence.test.ts --timeout 120000`
- [x] `bun run typecheck`
- [x] `bunx @biomejs/biome@2.3.14 ci .`
- [x] `bun run drift:check`
- [x] `git diff --check`
- [x] `bun run build`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `node scripts/repro-704.mjs`
- [x] `bun run package:smoke` (sandboxed run hit npm cache `EPERM`; elevated rerun passed)



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

