### PR TITLE
fix(finalize): stop git clean -fdX from deleting .swarm/ knowledge

### DIFF
--- a/docs/releases/pending/finalize-preserve-swarm-knowledge.md
+++ b/docs/releases/pending/finalize-preserve-swarm-knowledge.md
@@ -1,0 +1,54 @@
+# Fix: `/swarm finalize` no longer destroys the swarm knowledge store
+
+## What
+
+`/swarm finalize` (and its deprecated alias `/swarm close`) could silently delete
+the entire gitignored `.swarm/` directory — including the cumulative
+`knowledge.jsonl` lessons store and the archive backup bundle created earlier in
+the same finalize run.
+
+The align stage's post-merge cleanup ran a blanket `git clean -fdX`. Because
+`.swarm/` is gitignored (by design — it is machine-local runtime state), the `-X`
+flag (remove *ignored* paths) matched and removed the whole `.swarm/` tree, undoing
+the clean stage's deliberate preservation of `knowledge.jsonl`. The same blanket
+clean also removed other gitignored-but-not-build-artifact paths, including
+`.claude/issue-traces/` (investigation traces) and the gitignored files inside
+`.opencode/` (its `node_modules/`, `package.json`, and lockfiles, via a nested
+`.opencode/.gitignore`).
+
+The alignment cleanup is now scoped to an explicit build-artifact allowlist
+(`GITIGNORED_BUILD_ARTIFACTS`, currently `dist/`) via a `git clean -fdX -- <paths>`
+pathspec, so it only removes regenerable build output and never touches `.swarm/`,
+`.claude/issue-traces/`, `.opencode/`, or `node_modules/`.
+
+To keep the clean-slate guarantee that the old blanket clean provided as a side
+effect, the finalize clean stage now removes the terminal `plan.json` and
+`plan-ledger.jsonl` unconditionally (even when archiving failed), so the next
+session cannot resurrect a CLOSED plan. This is behavior-preserving for those two
+files (the old blanket clean already removed them) and leaves cumulative
+`knowledge.jsonl` intact.
+
+Error-path note: because the align clean no longer wipes all of `.swarm/`, on the
+rare archive-failure path (e.g. EBUSY/EPERM/ENOSPC) non-terminal session artifacts
+that fail to archive — `events.jsonl`, `swarm.db*`, `telemetry.jsonl`,
+`repo-graph.json`, etc. — now survive into the next session instead of being force-
+deleted. This is the archive-first data-loss guard finally working as designed; the
+plan-resurrection vector stays closed because the terminal `plan.json`/
+`plan-ledger.jsonl` are still removed unconditionally.
+
+## Why
+
+`git clean -fdX` targets *all* gitignored paths, not just build artifacts. The
+previous code assumed "gitignored = safe-to-delete build output," but this repo
+also gitignores durable/runtime state (`.swarm/`) and local tooling (`.claude/`,
+`.opencode/`). A single `/swarm finalize` on a merged-and-pushed branch (the common
+post-PR cleanup path) therefore wiped every accumulated lesson. Candidate fixes
+using exclude flags (`-e .swarm/`) or pathspec excludes (`:!.swarm/`) were verified
+NOT to work with `-X`; only restricting the clean to an explicit allowlist reliably
+preserves runtime state.
+
+## Breaking changes
+
+None. Users on the merged-and-pushed finalize path will simply retain `.swarm/`
+knowledge and local `.claude/issue-traces/` / `.opencode/` state that was
+previously deleted.

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -341,6 +341,16 @@ const ACTIVE_STATE_TO_CLEAN = [
 ];
 
 /**
+ * Terminal plan-state files that must be removed at finalize UNCONDITIONALLY — even
+ * when archiving them failed — so the next session cannot resurrect the CLOSED plan
+ * (loadPlan Step 1 / replayFromLedger have no terminal-status filter). Kept as a
+ * shared constant so the archive-failure diagnostics and the unconditional removal
+ * below agree on the set; otherwise the "Preserved …" warning would contradict the
+ * removal that always follows for these files.
+ */
+const TERMINAL_STATE_FILES = ['plan.json', 'plan-ledger.jsonl'] as const;
+
+/**
  * Knowledge-family artifacts whose backing store redirects to a shared link
  * directory when the worktree is linked (`.swarm/link.json`). A single
  * worktree's `/swarm close` must NOT archive or delete the cohort-shared store —
@@ -1218,10 +1228,22 @@ export async function runCleanStage(
 				continue;
 			}
 			if (!ctx.archivedActiveStateFiles.has(artifact)) {
+				const reason = ctx.archiveFailureReasons?.get(artifact);
+				if ((TERMINAL_STATE_FILES as readonly string[]).includes(artifact)) {
+					// Terminal plan-state is removed unconditionally below (resurrection
+					// prevention), so it is NOT preserved here even though archiving failed.
+					// Warn accurately that the forensic copy is missing but the file is still
+					// removed — do not claim it was "preserved" (the removal contradicts that).
+					ctx.warnings.push(
+						reason
+							? `${artifact} was not archived (${reason}); removing it anyway to prevent CLOSED-plan resurrection next session — no archive copy retained.`
+							: `${artifact} was not archived; removing it anyway to prevent CLOSED-plan resurrection next session — no archive copy retained.`,
+					);
+					continue;
+				}
 				// This file was NOT successfully archived — do not delete it.
 				// Include the failure reason when one was recorded (e.g. EBUSY,
 				// EPERM, ENOSPC) so operators can diagnose without digging into logs.
-				const reason = ctx.archiveFailureReasons?.get(artifact);
 				ctx.warnings.push(
 					reason
 						? `Preserved ${artifact} because it was not successfully archived: ${reason}.`
@@ -1393,6 +1415,40 @@ export async function runCleanStage(
 	}
 	if (tmpFilesRemoved > 0) {
 		cleanedFiles.push(`${tmpFilesRemoved} .tmp.* file(s)`);
+	}
+
+	// Terminal-state removal (finalize knowledge-preservation fix): unconditionally
+	// remove plan.json + plan-ledger.jsonl so the next session cannot resurrect the
+	// CLOSED plan. loadPlan Step 1 and replayFromLedger have NO terminal-status filter
+	// (see the CRITICAL note on ACTIVE_STATE_TO_CLEAN above), so a surviving terminal
+	// plan.json OR ledger is materialized back into an active plan next session.
+	//
+	// Why here, unconditionally: the align stage's `git clean` previously deleted these
+	// as a backstop even when the archive-first guard preserved them (archive failure).
+	// Now that align only cleans an explicit build-artifact allowlist
+	// (GITIGNORED_BUILD_ARTIFACTS) and no longer touches `.swarm/`, the clean stage must
+	// own terminal-state removal itself. This is behavior-preserving for these two files
+	// (the old blanket clean removed them regardless of archive success). They are copied
+	// into the archive bundle first in stage 2 (ARCHIVE_ARTIFACTS), so the forensic trail
+	// is retained whenever archiving succeeds; the ENOENT branch below covers the case
+	// where the archive-gated cleanup already removed them.
+	for (const terminalFile of TERMINAL_STATE_FILES) {
+		try {
+			await fs.unlink(path.join(ctx.swarmDir, terminalFile));
+			if (!cleanedFiles.includes(terminalFile)) {
+				cleanedFiles.push(terminalFile);
+			}
+		} catch (err) {
+			const errno = (err as NodeJS.ErrnoException)?.code;
+			if (errno === 'ENOENT') {
+				// Already removed by the archive-gated cleanup above — expected; silent skip.
+			} else {
+				const reason = err instanceof Error ? err.message : String(err);
+				ctx.warnings.push(
+					`Failed to remove terminal-state file ${terminalFile} [${errno ?? 'unknown'}]: ${reason}`,
+				);
+			}
+		}
 	}
 
 	// #519 (v6.71.1): clear persisted declare_scope files so the next session

--- a/src/git/branch.ts
+++ b/src/git/branch.ts
@@ -593,6 +593,23 @@ export interface ResetToMainAfterMergeResult {
 }
 
 /**
+ * Gitignored build-artifact paths the post-merge alignment (`/swarm finalize`) is
+ * allowed to delete. Scoped to an explicit allowlist on purpose: `git clean -fdX`
+ * removes EVERY gitignored path under cwd — which in this repo also includes
+ * `.swarm/` (the cumulative runtime knowledge store), the gitignored
+ * `.claude/issue-traces/` directory (investigation traces), the gitignored files
+ * inside `.opencode/` (its `node_modules/`, `package.json`, lockfiles — via a
+ * nested `.opencode/.gitignore`), and root `node_modules/` (dependencies). A
+ * blanket `git clean -fdX` therefore silently destroyed `.swarm/knowledge.jsonl` —
+ * the exact file the finalize clean stage (`runCleanStage`) deliberately preserves.
+ * Restricting removal to this allowlist clears stale build output across the
+ * reset while leaving runtime/durable state and dependencies untouched.
+ * `dist/` is the repo's only committed build output (see the `clean`/`build`
+ * scripts in package.json); extend this list only with regenerable build output.
+ */
+export const GITIGNORED_BUILD_ARTIFACTS: readonly string[] = ['dist'];
+
+/**
  * Aggressive git reset for post-merge cleanup.
  * Handles the common scenario: feature branch PR merged, local has uncommitted artifacts.
  * Steps: detect default branch → safety check → fetch → checkout → discard changes → reset → delete branch.
@@ -783,12 +800,23 @@ export async function resetToMainAfterMerge(
 			changesDiscarded = discardSucceeded;
 		}
 
-		// Step 7b: Remove only gitignored files/directories (build artifacts); user-created untracked files are preserved (FR-013).
+		// Step 7b: Remove stale gitignored BUILD ARTIFACTS left over from the feature
+		// branch, restricted to an explicit allowlist (GITIGNORED_BUILD_ARTIFACTS).
+		// `-X` limits removal to gitignored paths; the trailing pathspec limits it
+		// further to the allowlist. This pathspec is REQUIRED, not cosmetic: a bare
+		// `git clean -fdX` also deletes `.swarm/` (gitignored runtime knowledge store),
+		// `.claude/issue-traces/`, gitignored files under `.opencode/`, and
+		// `node_modules/` — destroying cumulative knowledge that the finalize clean
+		// stage deliberately preserves (FR-013 only guarded non-ignored user files;
+		// ignored runtime state was still wiped).
 		// git checkout -- . only resets tracked files; git clean removes untracked.
 		try {
-			_internals.gitExec(['clean', '-fdX'], cwd);
+			_internals.gitExec(
+				['clean', '-fdX', '--', ...GITIGNORED_BUILD_ARTIFACTS],
+				cwd,
+			);
 		} catch {
-			warnings.push('Could not clean untracked files');
+			warnings.push('Could not clean build artifacts');
 		}
 
 		// Step 8: Delete previous branch if it's not the default

--- a/tests/integration/finalize-clean-preserves-swarm.test.ts
+++ b/tests/integration/finalize-clean-preserves-swarm.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Real-git regression for the finalize knowledge-loss bug.
+ *
+ * Bug: `runAlignStage` → `resetToMainAfterMerge` ran a blanket `git clean -fdX`.
+ * Because `.swarm/` is gitignored, `-X` (remove ignored paths) deleted the entire
+ * `.swarm/` tree — including the cumulative `knowledge.jsonl` the finalize clean
+ * stage deliberately preserves, and the archive backup bundle.
+ *
+ * Fix: scope the clean to an explicit build-artifact allowlist
+ * (`GITIGNORED_BUILD_ARTIFACTS`) via a `--` pathspec.
+ *
+ * This test uses REAL git (not a mocked gitExec) because the behavior is
+ * pattern-/version-sensitive: an earlier candidate fix (`-e '!.swarm/'`) and the
+ * anchored `-e '!/.swarm/'` variant were verified to FAIL, and pathspec-exclude
+ * approaches also failed. A mocked-args assertion cannot catch a regression that
+ * reintroduces a semantically-wrong-but-plausible clean invocation; only running
+ * real git against a real `.swarm/` can. The command under test is built from the
+ * SAME source constant the production code spreads, so changing the constant to
+ * something that wipes `.swarm/` fails this test.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { GITIGNORED_BUILD_ARTIFACTS } from '../../src/git/branch';
+import { createSafeTestDir } from '../helpers/safe-test-dir';
+
+function gitAvailable(): boolean {
+	try {
+		execFileSync('git', ['--version'], { stdio: 'pipe' });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+const GIT_OK = gitAvailable();
+
+function git(cwd: string, args: string[]): void {
+	execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function seedRepo(dir: string): void {
+	git(dir, ['init', '-q']);
+	git(dir, ['config', 'user.email', 'test@test.test']);
+	git(dir, ['config', 'user.name', 'test']);
+	// `dist/` ignored via .gitignore; `.swarm/` ignored via .git/info/exclude to
+	// mirror this repo's `ensureSwarmGitExcluded`, which writes `.swarm/` there.
+	fs.writeFileSync(path.join(dir, '.gitignore'), 'dist/\n');
+	fs.appendFileSync(
+		path.join(dir, '.git', 'info', 'exclude'),
+		'\n# opencode-swarm local runtime state\n.swarm/\n',
+	);
+	git(dir, ['add', '.gitignore']);
+	git(dir, ['commit', '-qm', 'init']);
+}
+
+function seedWorkingState(dir: string): void {
+	fs.mkdirSync(path.join(dir, '.swarm', 'archive', 'swarm-123'), {
+		recursive: true,
+	});
+	fs.mkdirSync(path.join(dir, 'dist'), { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, '.swarm', 'knowledge.jsonl'),
+		'{"lesson":"keep me"}\n',
+	);
+	fs.writeFileSync(
+		path.join(dir, '.swarm', 'archive', 'swarm-123', 'knowledge.jsonl'),
+		'{"lesson":"backup"}\n',
+	);
+	fs.writeFileSync(path.join(dir, 'dist', 'out.js'), 'build output\n');
+	fs.writeFileSync(path.join(dir, 'untracked-user-work.txt'), 'user work\n');
+}
+
+const exists = (dir: string, rel: string): boolean =>
+	fs.existsSync(path.join(dir, rel));
+
+describe.skipIf(!GIT_OK)(
+	'finalize git-clean preserves .swarm/ (real git)',
+	() => {
+		let dir: string;
+		let cleanup: () => void;
+
+		beforeEach(() => {
+			({ dir, cleanup } = createSafeTestDir('finalize-clean-'));
+			seedRepo(dir);
+		});
+
+		afterEach(() => {
+			cleanup();
+		});
+
+		test('scoped clean (production invocation) removes dist/ but preserves .swarm/', () => {
+			seedWorkingState(dir);
+
+			// Exact invocation the production code runs (branch.ts Step 7b), built from
+			// the same exported constant.
+			git(dir, ['clean', '-fdX', '--', ...GITIGNORED_BUILD_ARTIFACTS]);
+
+			expect(exists(dir, '.swarm/knowledge.jsonl')).toBe(true);
+			expect(exists(dir, '.swarm/archive/swarm-123/knowledge.jsonl')).toBe(
+				true,
+			);
+			expect(exists(dir, 'dist/out.js')).toBe(false);
+			expect(exists(dir, 'untracked-user-work.txt')).toBe(true);
+		});
+
+		test('baseline: a blanket `git clean -fdX` WOULD destroy .swarm/ (guards the test)', () => {
+			seedWorkingState(dir);
+
+			// The pre-fix invocation. Proves this harness can actually detect the bug —
+			// so the scoped-clean test above is a meaningful guard, not a tautology.
+			git(dir, ['clean', '-fdX']);
+
+			expect(exists(dir, '.swarm/knowledge.jsonl')).toBe(false);
+			expect(exists(dir, 'dist/out.js')).toBe(false);
+		});
+
+		test('allowlist contains only regenerable build output, never `.swarm`/`.claude`/`.opencode`', () => {
+			for (const p of GITIGNORED_BUILD_ARTIFACTS) {
+				const normalized = p.replace(/[\\/]+$/, '');
+				expect(normalized).not.toBe('.');
+				expect(normalized).not.toBe('.swarm');
+				expect(normalized).not.toBe('.claude');
+				expect(normalized).not.toBe('.opencode');
+				expect(normalized).not.toBe('node_modules');
+			}
+		});
+	},
+);

--- a/tests/unit/commands/close-terminal-state-removal.test.ts
+++ b/tests/unit/commands/close-terminal-state-removal.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Regression: finalize must remove terminal plan state even when archiving fails,
+ * so the next session cannot resurrect the CLOSED plan.
+ *
+ * Background: the align stage's blanket `git clean -fdX` used to delete the whole
+ * gitignored `.swarm/` tree — a backstop that (as a side effect) removed a
+ * surviving terminal `plan.json`/`plan-ledger.jsonl` on the archive-failure path.
+ * That blanket clean also destroyed `.swarm/knowledge.jsonl` (the reported bug).
+ * The fix scopes the align clean to a build-artifact allowlist, so the clean stage
+ * (`runCleanStage`) must now own terminal-state removal itself — unconditionally,
+ * not gated on archive success — while still preserving cumulative knowledge.
+ *
+ * This drives `runCleanStage` down the archive-FAILURE path (`archivedActiveStateFiles`
+ * empty, which triggers the "Skipped active-state cleanup ... Files preserved" branch),
+ * and asserts the terminal plan/ledger are still removed and knowledge is kept.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+	type CloseStageContext,
+	runCleanStage,
+} from '../../../src/commands/close';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+let dir: string;
+let cleanup: () => void;
+
+function swarmDir(): string {
+	return path.join(dir, '.swarm');
+}
+
+/**
+ * Build a CloseStageContext for the ARCHIVE-FAILURE path: `archivedActiveStateFiles`
+ * is empty, so `runCleanStage` takes the "nothing archived → preserve active state"
+ * branch. Cast through `unknown` to avoid re-declaring the full sub-type graph in a
+ * test fixture; `runCleanStage` only reads the fields set below.
+ */
+function makeCtx(): CloseStageContext {
+	return {
+		directory: dir,
+		swarmDir: swarmDir(),
+		planData: { title: 'Terminal State Test' },
+		planExists: true,
+		planAlreadyDone: true,
+		config: {},
+		projectName: 'Terminal State Test',
+		warnings: [],
+		closedPhases: [],
+		closedTasks: [],
+		sessionStart: undefined,
+		isForced: false,
+		runSkillReview: false,
+		options: {},
+		phases: [],
+		inProgressPhases: [],
+		curationSucceeded: false,
+		curationResult: undefined,
+		allLessons: [],
+		explicitLessons: [],
+		retroLessons: [],
+		knowledgeSkillHint: '',
+		skillReviewSummary: '',
+		postMortemSummary: '',
+		sessionReflection: undefined,
+		hivePromoted: 0,
+		sessionKnowledgeCreated: 0,
+		fallbackKnowledgeCreated: 0,
+		originalStatuses: new Map(),
+		guaranteeResult: { closedPhaseIds: [], closedTaskIds: [] },
+		archiveResult: '',
+		archivedFileCount: 0,
+		// EMPTY → simulate archive failure (nothing was archived).
+		archivedActiveStateFiles: new Set<string>(),
+		archivedActiveStateDirs: new Set<string>(),
+		archiveFailureReasons: new Map(),
+		timestamp: '',
+		archiveDir: '',
+		archiveSuffix: '',
+		args: [],
+	} as unknown as CloseStageContext;
+}
+
+describe('runCleanStage — terminal-state removal on archive failure', () => {
+	beforeEach(() => {
+		({ dir, cleanup } = createSafeTestDir('close-terminal-state-'));
+		mkdirSync(swarmDir(), { recursive: true });
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	test('removes plan.json + plan-ledger.jsonl but preserves knowledge.jsonl when archiving failed', async () => {
+		writeFileSync(path.join(swarmDir(), 'plan.json'), '{"title":"closed"}');
+		writeFileSync(
+			path.join(swarmDir(), 'plan-ledger.jsonl'),
+			'{"seq":1,"event":"created"}\n',
+		);
+		writeFileSync(
+			path.join(swarmDir(), 'knowledge.jsonl'),
+			'{"id":1,"lesson":"keep me"}\n',
+		);
+
+		const ctx = makeCtx();
+		await runCleanStage(ctx);
+
+		// Confirm we actually exercised the archive-failure branch.
+		expect(
+			ctx.warnings.some((w) => w.includes('Skipped active-state cleanup')),
+		).toBe(true);
+
+		// Terminal plan state is gone → no CLOSED-plan resurrection next session.
+		expect(existsSync(path.join(swarmDir(), 'plan.json'))).toBe(false);
+		expect(existsSync(path.join(swarmDir(), 'plan-ledger.jsonl'))).toBe(false);
+
+		// Cumulative knowledge is preserved. NOTE: `runCleanStage` never targets
+		// knowledge.jsonl, so this guards against a *future* regression that adds it to
+		// TERMINAL_STATE_FILES / ACTIVE_STATE_TO_CLEAN. The authoritative knowledge-
+		// preservation guard against the git-clean bug is the real-git integration test
+		// (tests/integration/finalize-clean-preserves-swarm.test.ts).
+		expect(existsSync(path.join(swarmDir(), 'knowledge.jsonl'))).toBe(true);
+	});
+
+	test('partial archive failure: terminal files removed WITHOUT a misleading "Preserved" warning (F1)', async () => {
+		// Prior wart: when plan.json/plan-ledger.jsonl specifically failed to archive,
+		// the archive-first guard pushed `Preserved plan-ledger.jsonl ...` — then the
+		// unconditional terminal-state removal deleted it anyway, contradicting the
+		// warning during a failure investigation. The warning is now reworded for these
+		// two files to say they are removed (no archive copy retained).
+		writeFileSync(path.join(swarmDir(), 'plan.json'), '{"title":"closed"}');
+		writeFileSync(
+			path.join(swarmDir(), 'plan-ledger.jsonl'),
+			'{"seq":1,"event":"created"}\n',
+		);
+		writeFileSync(
+			path.join(swarmDir(), 'knowledge.jsonl'),
+			'{"id":1,"lesson":"keep me"}\n',
+		);
+
+		const ctx = makeCtx();
+		// Simulate PARTIAL archive success: something archived (enters the guarded
+		// branch), but the two terminal files failed to archive with a reason.
+		ctx.archivedActiveStateFiles = new Set<string>(['events.jsonl']);
+		ctx.archiveFailureReasons = new Map<string, string>([
+			['plan.json', 'EBUSY'],
+			['plan-ledger.jsonl', 'EBUSY'],
+		]);
+
+		await runCleanStage(ctx);
+
+		// Terminal files are still removed (resurrection prevention).
+		expect(existsSync(path.join(swarmDir(), 'plan.json'))).toBe(false);
+		expect(existsSync(path.join(swarmDir(), 'plan-ledger.jsonl'))).toBe(false);
+		// Knowledge preserved.
+		expect(existsSync(path.join(swarmDir(), 'knowledge.jsonl'))).toBe(true);
+		// No contradictory "Preserved <terminal file>" diagnostic.
+		expect(
+			ctx.warnings.some((w) => /Preserved plan(-ledger\.jsonl|\.json)/.test(w)),
+		).toBe(false);
+		// Accurate diagnostic present instead.
+		expect(
+			ctx.warnings.some(
+				(w) =>
+					w.includes('plan-ledger.jsonl was not archived') &&
+					w.includes('resurrection'),
+			),
+		).toBe(true);
+	});
+
+	test('is idempotent when terminal files are already absent', async () => {
+		writeFileSync(
+			path.join(swarmDir(), 'knowledge.jsonl'),
+			'{"id":1,"lesson":"keep me"}\n',
+		);
+
+		const ctx = makeCtx();
+		await runCleanStage(ctx);
+
+		// No terminal-state removal failure warnings when the files never existed.
+		expect(
+			ctx.warnings.some((w) => w.includes('Failed to remove terminal-state')),
+		).toBe(false);
+		expect(existsSync(path.join(swarmDir(), 'knowledge.jsonl'))).toBe(true);
+	});
+});

--- a/tests/unit/git/branch-clean.test.ts
+++ b/tests/unit/git/branch-clean.test.ts
@@ -138,12 +138,64 @@ describe('resetToMainAfterMerge — FR-013: git clean -fdX regression', () => {
 
 		restore();
 
-		// Assert: the clean command uses -fdX, NOT -fd
+		// Assert: the clean command uses -fdX AND is scoped to the build-artifact
+		// allowlist via a `--` pathspec — NOT a bare `-fd` and NOT a blanket `-fdX`
+		// (which would also delete the gitignored `.swarm/` knowledge store).
 		const cleanCalls = capturedArgs.filter((args) => args[0] === 'clean');
 		expect(cleanCalls.length).toBeGreaterThan(0);
 
 		for (const cleanArgs of cleanCalls) {
-			expect(cleanArgs).toEqual(['clean', '-fdX']);
+			expect(cleanArgs).toEqual([
+				'clean',
+				'-fdX',
+				'--',
+				...branch.GITIGNORED_BUILD_ARTIFACTS,
+			]);
+		}
+	});
+
+	test('regression: clean is scoped to an allowlist and never wipes .swarm/ (blanket -fdX)', async () => {
+		// Prior bug: `git clean -fdX` with no pathspec removed EVERY gitignored path,
+		// including `.swarm/knowledge.jsonl`, silently defeating the finalize clean
+		// stage's deliberate preservation of cumulative knowledge.
+		const { capturedArgs, restore } = setup();
+
+		mockSpawnSync.mockImplementation(
+			(command: string, args: string[], options: { cwd: string }) => {
+				spawnCalls.push({ command, args: args as string[], cwd: options.cwd });
+				if (
+					args[0] === 'rev-parse' &&
+					args[1] === '--abbrev-ref' &&
+					args[2] === 'HEAD'
+				) {
+					return { status: 0, stdout: 'feat/x\n', stderr: '' };
+				}
+				return { status: 0, stdout: '', stderr: '' };
+			},
+		);
+
+		try {
+			await branch.resetToMainAfterMerge(testCwd);
+		} catch {
+			// ignore — capturing args only
+		}
+
+		restore();
+
+		const cleanCalls = capturedArgs.filter((args) => args[0] === 'clean');
+		expect(cleanCalls.length).toBeGreaterThan(0);
+		for (const cleanArgs of cleanCalls) {
+			// Must include a `--` pathspec separator (i.e. scoped, not blanket).
+			expect(cleanArgs).toContain('--');
+			const sepIndex = cleanArgs.indexOf('--');
+			const pathspec = cleanArgs.slice(sepIndex + 1);
+			// Must clean at least one path, and none may be `.swarm/`, `.swarm`, or a
+			// blanket `.` that would recurse into `.swarm/`.
+			expect(pathspec.length).toBeGreaterThan(0);
+			for (const p of pathspec) {
+				expect(p).not.toBe('.');
+				expect(p.replace(/[\\/]+$/, '')).not.toBe('.swarm');
+			}
 		}
 	});
 


### PR DESCRIPTION
## Summary
- `/swarm finalize` (and its deprecated alias `/swarm close`) could silently delete the entire gitignored `.swarm/` tree — including the cumulative `knowledge.jsonl` lessons store and the archive backup — via a blanket `git clean -fdX` in the post-merge align stage.
- The align clean is now scoped to an explicit build-artifact allowlist (`GITIGNORED_BUILD_ARTIFACTS`, currently `dist/`) via a `git clean -fdX -- <paths>` pathspec, so it only removes regenerable build output and never touches `.swarm/`, `.claude/issue-traces/`, `.opencode/`'s ignored files, or `node_modules/`.
- The finalize clean stage now owns terminal-state removal: `plan.json` + `plan-ledger.jsonl` are removed unconditionally (even on archive failure) so a CLOSED plan cannot be resurrected next session — behavior-preserving, since the old blanket clean already removed these two files.
- `/swarm reset`, `reset-session`, `checkpoint`, and `archive` were independently verified to NOT delete `knowledge.jsonl` — no change needed there.

## Invariant audit
- 1 (plugin init): not touched — no changes to `src/index.ts` or plugin registration. `node scripts/repro-704.mjs` still reports all three checks OK (T1 183.6ms/400ms deadline, T2 108.2ms/10000ms, T3 98.9ms/10000ms).
- 2 (runtime portability): not touched — no `bun:`/`Bun.*` calls added, plugin export shape unchanged. `bun run build` succeeds; `node --input-type=module -e "await import('./dist/index.js')"` → `dist import OK`.
- 3 (subprocesses): touched (argv only) — `src/git/branch.ts` Step 7b now passes `['clean','-fdX','--',...GITIGNORED_BUILD_ARTIFACTS]` to the existing `gitExec` wrapper. The wrapper itself (array-form `spawnSync`, explicit `cwd`, `timeout: GIT_TIMEOUT_MS`, `stdio: ['ignore','pipe','pipe']`, bounded `maxBuffer`) is unchanged — only the argument list changed. `git diff --name-only origin/main..HEAD | xargs grep -nE "spawn\(|spawnSync\("` finds no new spawn call sites.
- 4 (.swarm containment): touched — this IS the fix. `ensureSwarmGitExcluded` is untouched (not referenced in this diff) and still runs from the init path only. No new `.swarm/` directory creation; the only new file write uses the existing injected `ctx.swarmDir`. Real-git integration test (`tests/integration/finalize-clean-preserves-swarm.test.ts`) proves `.swarm/knowledge.jsonl` and nested `.swarm/archive/**` now survive the align clean, and a baseline test proves the harness would catch a regression to blanket `-fdX`.
- 5 (plan durability): touched — `plan-ledger.jsonl` remains the authoritative source; no ledger schema change. `runCleanStage` now unconditionally removes the terminal `plan.json`/`plan-ledger.jsonl` copies from `.swarm/` (after Stage 2 has already archived them when possible) so `loadPlan`/`replayFromLedger` cannot resurrect a CLOSED plan next session — this is behavior-preserving versus the old blanket align-clean, which already removed both files unconditionally. Verified by `tests/unit/commands/close-terminal-state-removal.test.ts` (archive-failure path + partial-archive-failure diagnostic wording).
- 6 (test_runner safety): not touched — no `test_runner` tool invocations used; validation used shell commands per-file/tier as required.
- 7 (test writing): touched — all new/changed tests use `bun:test` only. `tests/unit/git/branch-clean.test.ts` preserves the existing `mock.module('node:child_process', ...)` spread-real-exports pattern. `tests/integration/finalize-clean-preserves-swarm.test.ts` uses `createSafeTestDir` (tmpdir-scoped) and real `git` via `execFileSync`, gated with `describe.skipIf(!GIT_OK)`. No new `mock.module` leakage introduced.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no new tools, agents, or commands.
- 12 (release/cache): touched (release fragment only) — `docs/releases/pending/finalize-preserve-swarm-knowledge.md` added; `package.json#version`, `CHANGELOG.md`, and `.release-please-manifest.json` untouched.

## Test plan
- `bun --smol test tests/unit/git/branch-clean.test.ts tests/unit/commands/close-terminal-state-removal.test.ts tests/integration/finalize-clean-preserves-swarm.test.ts --timeout 30000` → 9 pass / 0 fail.
- `bun run typecheck` → 0 errors.
- `bunx @biomejs/biome@2.3.14 ci src tests` → clean (scoped to avoid unrelated local nested-worktree `biome.json` conflicts under `.claude/worktrees/`, which are not part of the CI checkout).
- Full `tests/unit/git` per-file isolation loop → all pass (branch.adversarial 73, branch.busy-wait 6, branch.integration 3, branch.resetToMainAfterMerge 22, branch.resetToRemoteBranch 16, branch.test 60, pr* suites all pass).
- `bun run build` succeeds; dist import check passes; `repro-704` all three checks OK.
- `tests/security` → 163 pass / 0 fail (4 skip).
- `tests/smoke` → 10 pass / 0 fail.
- Broader batch tiers (`tests/unit/cli+commands+config`, `tests/integration`, `tests/adversarial`) show pre-existing failures identical in count when reproduced on a clean `origin/main` worktree (verified via `git worktree add /tmp/repro-check origin/main` + isolated re-runs) — cross-file `mock.module` contamination and unrelated fixture/schema drift, not touched by this change. None of the failing test names reference git-clean, finalize, or plan cleanup.
- Independent adversarial implementation review (Phase 4.5) and final critic gate (Phase 4.6) both ran in separate contexts against the actual diff; both approved after two rounds of fixes (a misleading partial-archive-failure warning, and an imprecise `.claude/`/`.opencode/` doc claim reconciled against `git check-ignore` output).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

