### PR TITLE
fix(cache): diagnose missing treesitter wasm caches

### DIFF
--- a/docs/releases/pending/1591-treesitter-wasm-cache-diagnosis.md
+++ b/docs/releases/pending/1591-treesitter-wasm-cache-diagnosis.md
@@ -1,0 +1,1 @@
+Fixes the Tree-sitter WASM failure path for incomplete OpenCode plugin caches. The runtime now reports a direct cache-repair error before `web-tree-sitter` emits low-level Emscripten output, and `/swarm diagnose` flags installed cache directories that are missing bundled grammar WASM assets.

--- a/src/lang/runtime.ts
+++ b/src/lang/runtime.ts
@@ -59,6 +59,8 @@ export const _internals = {
 	parserInit: TreeSitterParser.init as (opts?: {
 		locateFile: (scriptName: string) => string;
 	}) => Promise<void>,
+	getModuleDir: () => path.dirname(fileURLToPath(import.meta.url)),
+	fileExists: existsSync,
 };
 
 /**
@@ -68,7 +70,7 @@ export const _internals = {
 async function initTreeSitter(): Promise<void> {
 	if (!treeSitterInitPromise) {
 		treeSitterInitPromise = (async () => {
-			const thisDir = path.dirname(fileURLToPath(import.meta.url));
+			const thisDir = _internals.getModuleDir();
 			const isSource = thisDir.replace(/\\/g, '/').endsWith('/src/lang');
 
 			if (isSource) {
@@ -79,6 +81,15 @@ async function initTreeSitter(): Promise<void> {
 				// In bundle, import.meta.url points to dist/index.js so web-tree-sitter
 				// looks for dist/tree-sitter.wasm — redirect to dist/lang/grammars/
 				const grammarsDir = getGrammarsDirAbsolute();
+				const coreWasmPath = path.join(grammarsDir, 'tree-sitter.wasm');
+				if (!_internals.fileExists(coreWasmPath)) {
+					throw new Error(
+						`Core tree-sitter WASM runtime missing: ${coreWasmPath}\n` +
+							`The installed OpenCode plugin cache is incomplete or stale. Run ` +
+							`'bunx opencode-swarm update', then restart OpenCode so it fetches ` +
+							`a fresh package from npm.`,
+					);
+				}
 				await _internals.parserInit({
 					locateFile(scriptName: string) {
 						return path.join(grammarsDir, scriptName);
@@ -170,7 +181,7 @@ export function resolveGrammarsDir(thisDir: string): string {
  * across Windows, macOS, and Linux.
  */
 function getGrammarsDirAbsolute(): string {
-	const thisDir = path.dirname(fileURLToPath(import.meta.url));
+	const thisDir = _internals.getModuleDir();
 	return resolveGrammarsDir(thisDir);
 }
 
@@ -214,10 +225,12 @@ export async function loadGrammar(languageId: string): Promise<ParserType> {
 		const wasmPath = path.join(getGrammarsDirAbsolute(), wasmFileName);
 
 		// Check if file exists before attempting to load
-		if (!existsSync(wasmPath)) {
+		if (!_internals.fileExists(wasmPath)) {
 			throw new Error(
 				`Grammar file not found for ${languageId}: ${wasmPath}\n` +
-					`Make sure to run 'bun run build' to copy grammar files to dist/lang/grammars/`,
+					`Make sure to run 'bun run build' to copy grammar files to dist/lang/grammars/. ` +
+					`If this is an installed OpenCode plugin cache, run ` +
+					`'bunx opencode-swarm update' and restart OpenCode.`,
 			);
 		}
 

--- a/src/services/diagnose-service.ts
+++ b/src/services/diagnose-service.ts
@@ -19,6 +19,20 @@ import { getDeferredWarnings } from './warning-buffer.js';
 
 const { version } = packageJson;
 const sandboxCapabilityProbe = new SandboxCapabilityProbe();
+const REQUIRED_CACHE_GRAMMAR_ASSETS = [
+	'tree-sitter.wasm',
+	'tree-sitter-javascript.wasm',
+	'tree-sitter-typescript.wasm',
+] as const;
+
+function resolveCachePackageRoot(cachePath: string): string {
+	const nestedPackageRoot = path.join(
+		cachePath,
+		'node_modules',
+		'opencode-swarm',
+	);
+	return existsSync(nestedPackageRoot) ? nestedPackageRoot : cachePath;
+}
 
 export const _internals = {
 	detectSandboxCapability: () => sandboxCapabilityProbe.detect(),
@@ -1086,15 +1100,30 @@ export async function getDiagnoseData(
 				cacheRows.push(`⬜ ${cachePath} — absent`);
 				continue;
 			}
-			const pkgJsonPath = path.join(cachePath, 'package.json');
+			const packageRoot = resolveCachePackageRoot(cachePath);
+			const cacheLabel =
+				packageRoot === cachePath
+					? cachePath
+					: `${cachePath} -> ${packageRoot}`;
+			const missingGrammarAssets = REQUIRED_CACHE_GRAMMAR_ASSETS.filter(
+				(file) =>
+					!existsSync(path.join(packageRoot, 'dist', 'lang', 'grammars', file)),
+			);
+			const pkgJsonPath = path.join(packageRoot, 'package.json');
 			try {
 				const raw = readFileSync(pkgJsonPath, 'utf-8');
 				const parsed = JSON.parse(raw) as { version?: unknown };
 				const installedVersion =
 					typeof parsed.version === 'string' ? parsed.version : '?';
-				cacheRows.push(`✅ ${cachePath} — v${installedVersion}`);
+				if (missingGrammarAssets.length > 0) {
+					cacheRows.push(
+						`⚠️ ${cacheLabel} — v${installedVersion}, missing grammar assets: ${missingGrammarAssets.join(', ')}; run \`bunx opencode-swarm update\` and restart OpenCode`,
+					);
+					continue;
+				}
+				cacheRows.push(`✅ ${cacheLabel} — v${installedVersion}`);
 			} catch {
-				cacheRows.push(`⚠️ ${cachePath} — present (package.json unreadable)`);
+				cacheRows.push(`⚠️ ${cacheLabel} — present (package.json unreadable)`);
 			}
 		} catch {
 			cacheRows.push(`⚠️ ${cachePath} — status unknown (read error)`);

--- a/tests/unit/lang/runtime-security.test.ts
+++ b/tests/unit/lang/runtime-security.test.ts
@@ -532,4 +532,47 @@ describe('runtime.ts - Security Verification Tests', () => {
 			expect(parserCache.size).toBe(1);
 		});
 	});
+
+	describe('14. Bundled core WASM preflight', () => {
+		let originalInit: typeof _internals.parserInit;
+		let originalGetModuleDir: typeof _internals.getModuleDir;
+		let originalFileExists: typeof _internals.fileExists;
+
+		beforeEach(() => {
+			clearParserCache();
+			originalInit = _internals.parserInit;
+			originalGetModuleDir = _internals.getModuleDir;
+			originalFileExists = _internals.fileExists;
+		});
+
+		afterEach(() => {
+			_internals.parserInit = originalInit;
+			_internals.getModuleDir = originalGetModuleDir;
+			_internals.fileExists = originalFileExists;
+			clearParserCache();
+		});
+
+		it('should report missing bundled tree-sitter.wasm before calling Parser.init', async () => {
+			let initCallCount = 0;
+			_internals.getModuleDir = () =>
+				'/cache/opencode/node_modules/opencode-swarm/dist';
+			_internals.fileExists = (filePath: string) =>
+				!filePath.endsWith('tree-sitter.wasm');
+			_internals.parserInit = async () => {
+				initCallCount++;
+			};
+
+			let error: Error | null = null;
+			try {
+				await loadGrammar('javascript');
+			} catch (err) {
+				error = err as Error;
+			}
+
+			expect(error).toBeDefined();
+			expect(error!.message).toContain('Core tree-sitter WASM runtime missing');
+			expect(error!.message).toContain('bunx opencode-swarm update');
+			expect(initCallCount).toBe(0);
+		});
+	});
 });

--- a/tests/unit/services/diagnose-service.test.ts
+++ b/tests/unit/services/diagnose-service.test.ts
@@ -3,7 +3,8 @@ import * as realChildProcess from 'node:child_process';
 import { execSync } from 'node:child_process';
 
 import * as realFs from 'node:fs';
-import { existsSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
 import { loadPluginConfig } from '../../../src/config/loader.js';
 import type { Plan } from '../../../src/config/plan-schema.js';
 import { listEvidenceTaskIds } from '../../../src/evidence/manager.js';
@@ -35,6 +36,7 @@ mock.module('node:fs', () => ({
 	...realFs,
 	readdirSync: mock(() => []),
 	existsSync: mock(() => true),
+	readFileSync: mock(() => '{"version":"7.99.6"}'),
 	statSync: mock(() => ({ isDirectory: () => true })),
 }));
 mock.module('node:child_process', () => ({
@@ -52,6 +54,7 @@ const mockReadEffectiveSpecSync = readEffectiveSpecSync as ReturnType<
 >;
 const mockReaddirSync = readdirSync as ReturnType<typeof mock>;
 const mockExistsSync = existsSync as ReturnType<typeof mock>;
+const mockReadFileSync = readFileSync as ReturnType<typeof mock>;
 const mockStatSync = statSync as ReturnType<typeof mock>;
 const mockExecSync = execSync as ReturnType<typeof mock>;
 
@@ -110,6 +113,7 @@ beforeEach(() => {
 	mockReadEffectiveSpecSync.mockReturnValue(null);
 	mockReaddirSync.mockReturnValue([]);
 	mockExistsSync.mockReturnValue(true);
+	mockReadFileSync.mockReturnValue('{"version":"7.99.6"}');
 	mockStatSync.mockReturnValue({ isDirectory: () => true });
 	mockExecSync.mockReturnValue(Buffer.from('.git'));
 	// restore env var
@@ -681,5 +685,50 @@ describe('checkSpecStaleness', () => {
 		expect(check).toBeDefined();
 		expect(check.status).toBe('✅');
 		expect(check.detail).toContain('not detectable');
+	});
+});
+
+describe('Plugin cache grammar asset diagnosis', () => {
+	it('warns when a present OpenCode plugin cache is missing tree-sitter wasm assets', async () => {
+		const cacheWrapperSuffix = path.win32.join(
+			'opencode',
+			'packages',
+			'opencode-swarm@latest',
+		);
+		const packageRootSuffix = path.win32.join(
+			cacheWrapperSuffix,
+			'node_modules',
+			'opencode-swarm',
+		);
+		mockExistsSync.mockImplementation((input: unknown) => {
+			if (typeof input !== 'string') return false;
+			if (input === '/test/dir') return true;
+			if (input.includes('opencode-swarm@latest')) {
+				const normalized = input.replaceAll('/', '\\');
+				if (
+					normalized.endsWith(cacheWrapperSuffix) ||
+					normalized.endsWith(packageRootSuffix)
+				) {
+					return true;
+				}
+				if (normalized.endsWith('\\package.json')) return true;
+				return !normalized.endsWith('\\tree-sitter.wasm');
+			}
+			if (input.includes('opencode-swarm')) {
+				return !input.endsWith('tree-sitter.wasm');
+			}
+			return false;
+		});
+
+		const result = await getDiagnoseData('/test/dir');
+		const check = findCheck(result.checks, 'Plugin Caches');
+
+		expect(check).toBeDefined();
+		expect(check.status).toBe('⚠️');
+		expect(check.detail).toContain('packages\\opencode-swarm@latest');
+		expect(check.detail).toContain('node_modules\\opencode-swarm');
+		expect(check.detail).toContain('missing grammar assets');
+		expect(check.detail).toContain('tree-sitter.wasm');
+		expect(check.detail).toContain('bunx opencode-swarm update');
 	});
 });

--- a/tests/unit/services/diagnose-service.test.ts
+++ b/tests/unit/services/diagnose-service.test.ts
@@ -690,12 +690,12 @@ describe('checkSpecStaleness', () => {
 
 describe('Plugin cache grammar asset diagnosis', () => {
 	it('warns when a present OpenCode plugin cache is missing tree-sitter wasm assets', async () => {
-		const cacheWrapperSuffix = path.win32.join(
+		const cacheWrapperSuffix = path.join(
 			'opencode',
 			'packages',
 			'opencode-swarm@latest',
 		);
-		const packageRootSuffix = path.win32.join(
+		const packageRootSuffix = path.join(
 			cacheWrapperSuffix,
 			'node_modules',
 			'opencode-swarm',
@@ -704,15 +704,14 @@ describe('Plugin cache grammar asset diagnosis', () => {
 			if (typeof input !== 'string') return false;
 			if (input === '/test/dir') return true;
 			if (input.includes('opencode-swarm@latest')) {
-				const normalized = input.replaceAll('/', '\\');
 				if (
-					normalized.endsWith(cacheWrapperSuffix) ||
-					normalized.endsWith(packageRootSuffix)
+					input.endsWith(cacheWrapperSuffix) ||
+					input.endsWith(packageRootSuffix)
 				) {
 					return true;
 				}
-				if (normalized.endsWith('\\package.json')) return true;
-				return !normalized.endsWith('\\tree-sitter.wasm');
+				if (input.endsWith(`${path.sep}package.json`)) return true;
+				return !input.endsWith(`${path.sep}tree-sitter.wasm`);
 			}
 			if (input.includes('opencode-swarm')) {
 				return !input.endsWith('tree-sitter.wasm');
@@ -725,8 +724,8 @@ describe('Plugin cache grammar asset diagnosis', () => {
 
 		expect(check).toBeDefined();
 		expect(check.status).toBe('⚠️');
-		expect(check.detail).toContain('packages\\opencode-swarm@latest');
-		expect(check.detail).toContain('node_modules\\opencode-swarm');
+		expect(check.detail).toContain(`packages${path.sep}opencode-swarm@latest`);
+		expect(check.detail).toContain(`node_modules${path.sep}opencode-swarm`);
 		expect(check.detail).toContain('missing grammar assets');
 		expect(check.detail).toContain('tree-sitter.wasm');
 		expect(check.detail).toContain('bunx opencode-swarm update');


### PR DESCRIPTION
Closes #1591

## Summary
- Add a bundled Tree-sitter core WASM preflight so an incomplete OpenCode plugin cache reports `Core tree-sitter WASM runtime missing` with `bunx opencode-swarm update` guidance before `web-tree-sitter` emits low-level Emscripten output.
- Extend `/swarm diagnose` plugin-cache inventory to resolve nested `packages/opencode-swarm@latest/node_modules/opencode-swarm` installs and warn when required grammar WASM assets are missing.
- Add focused regressions for the runtime preflight and the Windows nested-cache diagnose layout, plus a pending release fragment.

## Invariant audit
- 1 (plugin init): not touched - no plugin init path code changed; `node scripts/repro-704.mjs` passed T1 147.4ms under the 400ms deadline, T2 87.5ms, T3 67.7ms.
- 2 (runtime portability): touched - `bun run build` passed; `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` printed `dist import OK`; refreshed npm tarball contains `package/dist/lang/grammars/tree-sitter.wasm`, `tree-sitter-javascript.wasm`, and `tree-sitter-typescript.wasm`.
- 3 (subprocesses): not touched - no changed source file adds or modifies subprocess calls.
- 4 (.swarm containment): not touched - runtime state handling unchanged.
- 5 (plan durability): not touched - plan ledger/projection/import/export code unchanged.
- 6 (test_runner safety): not touched - validation used shell commands, not broad OpenCode `test_runner` scopes.
- 7 (test writing): touched - loaded writing-tests guidance; added focused bun:test coverage using `_internals` seams and restored them in `afterEach`; `bun --smol test tests/unit/lang/runtime-security.test.ts tests/unit/services/diagnose-service.test.ts --timeout 30000` passed, 82 tests.
- 8 (session state): not touched - no session/global state changes.
- 9 (guardrails/retry): not touched - guardrail and transient retry code unchanged.
- 10 (chat/system msg): not touched - chat/system hook behavior unchanged.
- 11 (tool registration): not touched - no tool, command, or agent map registration changed.
- 12 (release/cache): touched - cache diagnostics now inspect required grammar assets in direct and nested OpenCode cache layouts; `bun --smol test tests/unit/services/diagnose-service.test.ts --timeout 30000` passed and the release fragment `docs/releases/pending/1591-treesitter-wasm-cache-diagnosis.md` was added.

## Test plan
- [x] `bun run typecheck`
- [x] `node_modules\.bin\biome.cmd ci src/lang/runtime.ts src/services/diagnose-service.ts tests/unit/lang/runtime-security.test.ts tests/unit/services/diagnose-service.test.ts docs/releases/pending/1591-treesitter-wasm-cache-diagnosis.md`
- [x] `bun run build`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `node scripts/repro-704.mjs`
- [x] `bun --smol test tests/unit/lang/runtime-security.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/services/diagnose-service.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/services/diagnose-service-new-checks.test.ts tests/unit/services/diagnose-grammar-dir.test.ts tests/unit/commands/diagnose.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/lang/grammar-dir.test.ts tests/unit/lang/runtime-wasm-map.test.ts tests/unit/lang/runtime-wasm-map-adversarial.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/scripts/package-smoke.test.ts --timeout 30000`
- [x] `npm pack --json --ignore-scripts --pack-destination .tmp\packcheck` with `NPM_CONFIG_CACHE=.tmp\npm-cache`, then `tar -tf` confirmed `tree-sitter.wasm`, `tree-sitter-javascript.wasm`, and `tree-sitter-typescript.wasm` in `package/dist/lang/grammars/`.
- [x] `bun test tests/smoke --timeout 120000` - 10 pass.
- [x] `bun test tests/security --timeout 120000` - 163 pass, 4 skipped.
- [x] Independent reviewer pass - initial P1 nested-cache diagnostic gap fixed; final re-review found no blocking issues.
- [ ] `bun run package:smoke` - local Windows sandbox timed out in a spawned `node.exe` phase (`spawnSync ... ETIMEDOUT`) after the package-file grammar validation path; covered with package-smoke unit tests, direct `npm pack`, tarball grammar listing, bundle import, and smoke packaging tests.
- [ ] `bun test tests/adversarial --timeout 120000` - broad suite completed with 816 pass / 13 fail; failures are unrelated to this change and cover stale agent tool-map/config expectations, evidence-spoofing expectations, and symlink path traversal cases outside the touched files.
- [ ] `bun test tests/integration ./test --timeout 120000` - broad suite completed with 712 pass / 205 fail; failures are unrelated to this change and concentrated in curator/knowledge/phase/gate persistence paths plus local `C:\tmp\test\.swarm.lock` EPERM cases.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

