### PR TITLE
docs(skills): add empirical fix-verification and mock-cascade scope guidance

### DIFF
--- a/.claude/skills/issue-tracer/SKILL.md
+++ b/.claude/skills/issue-tracer/SKILL.md
@@ -264,6 +264,14 @@ Use `references/critic-gate.md`.
 
 For high-risk or close-call fixes, do not commit to a single patch shape prematurely. Draft 2-3 concrete candidate patches for the selected root cause, and choose between them by which one makes the reproduction test pass while keeping the regression suite green and the diff minimal. On a genuine tie, prefer the smallest, most contract-preserving patch and record why the alternatives were rejected. This mirrors validate-then-select repair: a patch is chosen on evidence (tests + minimality), not on first-draft intuition.
 
+#### Diagnosis correctness does not imply fix correctness
+
+A pasted second opinion, an external agent's finding, or your own recollection of CLI/shell flag semantics can localize the root cause correctly while proposing a fix that does not actually work. Treat the diagnosis and the proposed fix as two separate claims requiring separate verification — do not adopt a suggested patch just because the file:line diagnosis it came with checked out. This risk is sharpest for fixes that hinge on subtle CLI/subprocess flag semantics (e.g. `git clean -e/-x/-X` interactions, gitignore pattern anchoring, `chmod`/`sed`/`awk` flag combinations): these read as plausible in prose but are easy to get wrong. Before finalizing such a fix, empirically run the *exact* candidate invocation in an isolated throwaway environment (a scratch git repo, a temp directory) and observe the actual result — do not rely on documented or remembered semantics alone.
+
+#### Verify the fix against the real blast radius, not a minimal repro
+
+A minimal two-file reproduction can validate that a fix's *mechanism* works while hiding that its *scope* is wrong. Before finalizing a fix for a destructive or broad-acting operation (recursive deletes, blanket cleans, glob-based rewrites), also run a dry-run/no-op form of the fixed operation against the actual target environment (e.g. `git clean -fdXn` in the real repo, not a synthetic one) to see everything it would still touch. A fix that passes its toy reproduction can still leave real, higher-value paths unprotected or under/over-scoped.
+
 ### Phase 3 Gate
 
 Do not write production code until:

--- a/.claude/skills/issue-tracer/references/critic-gate.md
+++ b/.claude/skills/issue-tracer/references/critic-gate.md
@@ -105,6 +105,8 @@ The critic must answer:
 8. Does the patch preserve public API and backward compatibility?
 9. Does the plan avoid broad refactors and unrelated cleanup?
 10. Is rollback straightforward?
+11. If the fix's exact invocation depends on subtle CLI/subprocess/flag semantics (git flags, gitignore anchoring, shell globs), was the exact candidate invocation empirically verified in an isolated environment — not just asserted as correct by the tracer or an external source?
+12. If the fix scopes or restricts a destructive/broad-acting operation, was it checked against the real target's full blast radius (e.g. a dry-run against the actual repo/environment), not only a minimal reproduction?
 
 ## Verdict Semantics
 
@@ -147,6 +149,8 @@ Find, with concrete evidence:
 - any changed path that is not wired into the real runtime path
 - any regressed public API, CLI, UI, config, persistence, or concurrency contract
 - any "passed"/"validated" claim in 08-test-results.md not backed by a shown command + output
+- if the fix depends on CLI/subprocess/flag semantics, independently re-run the exact invocation yourself (don't just re-read the implementer's transcript) and confirm the observed behavior matches the claim
+- if the fix scopes a destructive/broad-acting operation, independently re-check it against the real target's full blast radius (not just the implementer's toy reproduction)
 
 Return exactly:
 

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -299,6 +299,10 @@ Adding stubs for ESM resolution is NOT test theater — it's a Bun runtime requi
 
 The stubs exist solely to satisfy the module loader. Test assertions must verify behavior through the real-mocked functions (the ones your test actually calls), not through the stubs.
 
+### Scope discipline when completing a pre-existing incomplete mock
+
+If you complete a `mock.module()` factory for a pre-existing broken test (e.g. the target module gained exports after the mock was written) and doing so surfaces a *cascade* — the same test then fails on a second, unrelated module's incomplete mock, then a third — stop and back out rather than chasing the cascade to green inside an unrelated bug-fix PR. Revert the test file to its original (broken) state, verify with `git stash`/a worktree that the failure is identical on a clean base branch, and document it as a pre-existing failure with that evidence. Fixing a multi-module mock-completeness cascade is its own test-infrastructure task — pulling it into an unrelated change bloats the diff and risks introducing new drift under time pressure. One or two missing exports in the module you're actually testing is worth completing; a cascade across several unrelated modules is a signal to stop.
+
 ### Files Intentionally Using File-Scoped Mocks
 
 Some test files use top-level `mock.module` that must persist across all tests in the file. These files use `mockReset()`/`mockClear()` in `beforeEach` instead of `mock.restore()` in `afterEach`:

--- a/docs/releases/pending/skill-lessons-fix-verification-mock-scope.md
+++ b/docs/releases/pending/skill-lessons-fix-verification-mock-scope.md
@@ -1,0 +1,46 @@
+# Skill updates: empirical fix-verification and mock-cascade scope discipline
+
+## What
+
+Adds two lessons captured while tracing and fixing the `/swarm finalize` knowledge-
+loss bug (PR #1592) to the agent skill docs, so future issue-tracer and test-writing
+work benefits from them automatically:
+
+- `.claude/skills/issue-tracer/SKILL.md` and `references/critic-gate.md`: a
+  diagnosis (even one with exact file:line evidence, from another agent or a pasted
+  second opinion) does not guarantee its accompanying fix is correct — especially
+  for fixes that hinge on subtle CLI/subprocess flag semantics. New guidance
+  requires empirically testing the exact candidate invocation in an isolated
+  environment, and dry-running scoped fixes for destructive/broad-acting operations
+  against the real target (not just a minimal reproduction) before finalizing scope.
+  Two new critic questions (11, 12) and two new Phase 4.5 implementation-reviewer
+  checklist items encode this as an active gate, not just prose.
+- `.claude/skills/writing-tests/SKILL.md`: when completing a pre-existing
+  incomplete `mock.module()` factory (test drift remediation) surfaces a *cascade*
+  of other unrelated modules' incomplete mocks, the guidance is to stop, revert,
+  and document the failure as pre-existing (with a clean-base repro) rather than
+  chase the cascade to green inside an unrelated change.
+
+## Why
+
+During PR #1592, an externally-sourced diagnosis correctly located a
+`git clean -fdX` data-loss bug, but its proposed fix (`git clean -fdX -e '.swarm/'`)
+was empirically wrong — verified only by testing real git behavior in a throwaway
+repo. A first candidate fix that passed a minimal two-file reproduction still turned
+out to be under-scoped once dry-run against the real repository's full
+`git clean -fdXn` output. Separately, completing one pre-existing test's incomplete
+mock revealed the same class of gap in two more unrelated modules; chasing it would
+have turned a focused bug fix into an unrelated test-infrastructure refactor.
+
+These are narrow, evidence-grounded additions (not blanket "test everything
+exhaustively" mandates) — each carries an explicit trigger condition and a concrete
+action, reviewed and approved by an independent reviewer subagent before this PR.
+
+## Migration
+
+No migration required — these are additive documentation changes to existing skill
+files; no runtime code or schema changed.
+
+## Breaking changes
+
+None.


### PR DESCRIPTION
## Summary
- Adds two lessons captured while tracing and fixing the `/swarm finalize` knowledge-loss bug (#1592) to the agent skill docs, so future issue-tracer and test-writing work benefits automatically.
- `.claude/skills/issue-tracer/SKILL.md` + `references/critic-gate.md`: a diagnosis (even with exact file:line evidence, from another agent or a pasted second opinion) does not guarantee its accompanying fix is correct — especially for fixes hinging on subtle CLI/subprocess flag semantics. New guidance requires empirically testing the exact candidate invocation in an isolated environment, and dry-running scoped fixes for destructive/broad-acting operations against the real target before finalizing scope. Two new critic questions (11, 12) and two new Phase 4.5 implementation-reviewer checklist items make this an active gate, not just prose.
- `.claude/skills/writing-tests/SKILL.md`: when completing a pre-existing incomplete `mock.module()` factory reveals a cascade of other unrelated modules' incomplete mocks, stop, revert, and document as pre-existing rather than chase the cascade inside an unrelated change.
- Pure documentation change — no source code, tests, tool registrations, or agent behavior wiring touched.

## Invariant audit
- 1 (plugin init): not touched — no `src/` files in this diff.
- 2 (runtime portability): not touched — no `src/` files in this diff; no build/bundle impact.
- 3 (subprocesses): not touched — no source files changed.
- 4 (.swarm containment): not touched.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — no `test_runner` tool used; validation was a direct diff/drift-check review.
- 7 (test writing): not touched (no test files added/changed) — though the content itself documents test-writing guidance (`writing-tests/SKILL.md`), no test files in `tests/` are part of this diff.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — `bun run drift:check` → "No drift detected across skills, tools, commands, and agents."
- 12 (release/cache): touched (release fragment only) — `docs/releases/pending/skill-lessons-fix-verification-mock-scope.md` added; `package.json#version`, `CHANGELOG.md`, `.release-please-manifest.json` untouched (confirmed: `git diff --name-only origin/main -- .` shows only the 4 intended files).

## Test plan
- This is a documentation-only change: `git diff --name-only origin/main -- .` confirms zero files under `src/` or `tests/` are touched, so the code validation tiers (build, typecheck, biome, unit/integration/security/adversarial/smoke) do not apply — `biome.json`'s own `files.includes` (`src/**`, `tests/**`, `test/**`, `biome.json`, `package.json`, `tsconfig.json`) confirms markdown/skill files are outside its lint scope entirely.
- `bun run drift:check` → "No drift detected across skills, tools, commands, and agents." (relevant since `.claude/skills/*` were touched; `writing-tests` is classified `divergent` in `src/config/skill-mirrors.ts`, not `identical`, so no `.opencode` mirror update is required; `issue-tracer` has no `.opencode` mirror at all).
- Push protection scan (`git log origin/main..HEAD -p | grep -E "sk_live|ghp_|xox[abprs]-|AKIA|eyJ|AIza"`) → clean.
- Independent adversarial review: a separate reviewer subagent (opus, distinct context) checked the full diff for placement/structural fit, duplication against existing guidance (`localization-playbook.md`, `evidence-artifacts.md`, existing writing-tests sections), critic-question numbering/reference integrity, and markdown validity. Verdict: **APPROVE** — purely additive (16/62 insertions, 0 deletions), correctly placed adjacent to sibling sections, no duplication found, no stale cross-references, guidance judged actionable and appropriately scoped (not a blanket "test everything" mandate).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

