### PR TITLE
chore(skills): add session-retrospective guidance to execute, running-tests, writing-tests

### DIFF
--- a/.claude/skills/execute/SKILL.md
+++ b/.claude/skills/execute/SKILL.md
@@ -54,6 +54,7 @@ All other gates: failure → return to coder. No self-fixes. No workarounds.
     → REQUIRED: Print "sast-baseline: [WRITTEN — N fingerprints | MERGED — N fingerprints | SKIPPED — gate disabled | ERROR — details]"
     → Subsequent `pre_check_batch` calls with `phase: <N>` will automatically diff against this baseline — only NEW findings (not in baseline) drive the fail verdict.
 5b. the active swarm's coder agent - Implement (if designer scaffold produced, include it as INPUT).
+5b-bis. **CODER OUTPUT VERIFICATION**: After the coder reports completion, do NOT accept the self-report alone. Run `diff` (step 5c) and inspect at least one of the modified files yourself to confirm the change exists. The coder may report DONE without having produced any diff. A 30-second read of the changed file(s) catches this failure mode. This is NOT a separate explorer dispatch — the existing `diff` tool at step 5c is the verification mechanism; the key discipline is checking that `diff` returns actual changes before proceeding, rather than forwarding the coder's self-report to the next gate.
 5c. Run `diff` tool. If `hasContractChanges` → the active swarm's explorer agent integration analysis. If COMPATIBILITY SIGNALS=INCOMPATIBLE or MIGRATION_SURFACE=yes → coder retry. If COMPATIBILITY SIGNALS=COMPATIBLE and MIGRATION_SURFACE=no → proceed.
     → REQUIRED: Print "diff: [PASS | CONTRACT CHANGE — details]"
     5d. Run `syntax_check` tool. SYNTACTIC ERRORS → return to coder. NO ERRORS → proceed to placeholder_scan.

--- a/.opencode/skills/execute/SKILL.md
+++ b/.opencode/skills/execute/SKILL.md
@@ -54,6 +54,7 @@ All other gates: failure → return to coder. No self-fixes. No workarounds.
     → REQUIRED: Print "sast-baseline: [WRITTEN — N fingerprints | MERGED — N fingerprints | SKIPPED — gate disabled | ERROR — details]"
     → Subsequent `pre_check_batch` calls with `phase: <N>` will automatically diff against this baseline — only NEW findings (not in baseline) drive the fail verdict.
 5b. the active swarm's coder agent - Implement (if designer scaffold produced, include it as INPUT).
+5b-bis. **CODER OUTPUT VERIFICATION**: After the coder reports completion, do NOT accept the self-report alone. Run `diff` (step 5c) and inspect at least one of the modified files yourself to confirm the change exists. The coder may report DONE without having produced any diff. A 30-second read of the changed file(s) catches this failure mode. This is NOT a separate explorer dispatch — the existing `diff` tool at step 5c is the verification mechanism; the key discipline is checking that `diff` returns actual changes before proceeding, rather than forwarding the coder's self-report to the next gate.
 5c. Run `diff` tool. If `hasContractChanges` → the active swarm's explorer agent integration analysis. If COMPATIBILITY SIGNALS=INCOMPATIBLE or MIGRATION_SURFACE=yes → coder retry. If COMPATIBILITY SIGNALS=COMPATIBLE and MIGRATION_SURFACE=no → proceed.
     → REQUIRED: Print "diff: [PASS | CONTRACT CHANGE — details]"
     5d. Run `syntax_check` tool. SYNTACTIC ERRORS → return to coder. NO ERRORS → proceed to placeholder_scan.

--- a/.opencode/skills/running-tests/SKILL.md
+++ b/.opencode/skills/running-tests/SKILL.md
@@ -137,6 +137,7 @@ Get-Content "$env:TEMP\test_out.txt" | Select-Object -Last 50
 - `Select-String -Last N` — invalid parameter, use `Select-Object -Last N`
 - `2>&1 2>&1` — duplicate redirection, causes parse error; use `2>&1` once
 - `&&` — not supported in PowerShell 5.1; use `; if ($?) { cmd2 }` instead
+- `bun test --exec bash` — fails on Windows hosts with ENOENT (bash is not available in standard PowerShell). Use `bun test` directly or a PowerShell-based loop instead.
 - After `bun install --frozen-lockfile --force`, non-elevated Windows shells can hit `EPERM` while reading refreshed `node_modules` entries. Treat that as a host permission/access issue: rerun the same focused Bun command with approved/elevated access before diagnosing it as a code or test failure.
 
 ---

--- a/.opencode/skills/writing-tests/SKILL.md
+++ b/.opencode/skills/writing-tests/SKILL.md
@@ -736,6 +736,7 @@ The `--timeout 120000` flag sets per-test timeout to 120 seconds. Individual tes
 3. Verify no `process.cwd()` usage — use the `directory` parameter from `createSwarmTool` or hook constructor
 4. Verify no hardcoded paths (`/tmp/...`, `C:\...`) — use `os.tmpdir()` + `path.join()`
 5. Verify mocks are restored in `afterEach` if using `spyOn` or `mock.module`
+6. Run `bunx @biomejs/biome@2.3.14 check --write <touched-test-files>` to auto-format only the files you created or modified. Formatting issues are a common first-pass failure — scoping the command to touched files avoids accidental workspace-wide rewrites.
 
 ## Known Pre-existing Test Failures
 

--- a/docs/releases/pending/chore-skill-updates-session-lessons.md
+++ b/docs/releases/pending/chore-skill-updates-session-lessons.md
@@ -1,0 +1,21 @@
+# Skill updates: session-retrospective guidance to execute, running-tests, writing-tests
+
+## What changed
+
+- `.opencode/skills/execute/SKILL.md`: Added step 5b-bis "Coder output verification" — guidance to verify coder actually produced changes via `diff` rather than accepting self-report alone. Addresses a recurring coder instability failure mode where coder reports DONE without having produced any diff.
+
+- `.opencode/skills/running-tests/SKILL.md`: Added `bun test --exec bash` caveat to the Common PowerShell pitfalls section — this command fails on Windows hosts with ENOENT.
+
+- `.opencode/skills/writing-tests/SKILL.md`: Added step 6 to the "Before Submitting" section recommending `biome check --write` scoped to touched test files only, to catch formatting issues before they reach CI.
+
+## Why
+
+Captured from the session-level retrospective. Three concrete cross-session failure modes with proven fixes now encoded in the relevant skills.
+
+## Migration
+
+No migration required — additive documentation changes to existing skill files; no runtime code or schema changed.
+
+## Breaking changes
+
+None.


### PR DESCRIPTION
Closes #1590-review

## Summary
- .opencode/skills/execute/SKILL.md: Added step 5b-bis coder output verification guidance
- .opencode/skills/running-tests/SKILL.md: Added bun test --exec bash Windows caveat
- .opencode/skills/writing-tests/SKILL.md: Added step 6 biome check --write scoped to touched files

## Invariant audit
- 7 (test writing): touched - updated writing-tests skill
- 11 (tool registration): touched - drift:check passes
- 12 (release/cache): touched - release fragment added
- All others: not touched

## Test plan
- [x] bun run drift:check - no drift detected

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

