### PR TITLE
feat(knowledge): add realtime learning nudge

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -748,6 +748,33 @@ Triggered by `/swarm council <question>` (see [Commands](commands.md#swarm-counc
 
 > **Reduced-council warning.** If `council.general.enabled` is `true` but you have disabled `reviewer`, `critic`, or `sme` in `agents`, the corresponding council role (`council_generalist`, `council_skeptic`, or `council_domain_expert` respectively) will not be registered and a deferred warning will be emitted. Re-enable the base agent or accept a reduced council. This warning is replayed when you run `/swarm diagnose`.
 
+## Real-Time Learning Nudges
+
+Architect sessions can receive a cadence-bounded learning nudge while work is
+still in progress. The nudge asks the architect to capture durable procedural
+lessons with `knowledge_add` when the lesson is obvious, and to leave
+evidence-level review to the existing curator phase/postmortem path when the
+signal depends on repeated outcomes or generated-skill health. It does not
+auto-activate skills.
+
+```jsonc
+{
+  "knowledge": {
+    "realtime_learning_nudge": {
+      "enabled": true,
+      "first_after_tool_calls": 10,
+      "repeat_after_tool_calls": 25
+    }
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `knowledge.realtime_learning_nudge.enabled` | boolean | `true` | Enables the architect-only in-session learning nudge when knowledge is enabled. |
+| `knowledge.realtime_learning_nudge.first_after_tool_calls` | number | `10` | First total session tool-call count that can trigger the nudge. |
+| `knowledge.realtime_learning_nudge.repeat_after_tool_calls` | number | `25` | Minimum additional tool calls before the same session can be nudged again. |
+
 ## Skill Improver Consolidation
 
 `skill_improver` can run manually or at safe scheduled cadence points.

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -540,6 +540,40 @@ High-confidence candidates (>= `curator.min_skill_confidence`) trigger
 `skill_generate` in **draft** mode; activation always requires a human or
 architect to call `skill_apply`.
 
+### Real-time learning nudge
+
+The system enhancer injects an architect-only `[SWARM LEARNING NUDGE]` during
+longer sessions. The nudge is cadence-gated by total session tool calls and
+asks the architect to decide whether the current work revealed a durable,
+actionable lesson that should be captured immediately with `knowledge_add` or
+left for curator phase/postmortem review.
+
+This is intentionally not automatic skill mutation. It mirrors the safe part of
+Hermes-style in-session learning - review while context is fresh - but keeps
+opencode-swarm's existing boundaries:
+
+- `knowledge_add` remains the write path for active knowledge and still runs
+  validation, deduplication, reinforcement, and quarantine rules.
+- The curator remains the review engine for evidence-level learning. Phase and
+  postmortem curator passes can emit `knowledge_application_findings`,
+  `skill_candidates`, draft skills, skill revisions, and stale-skill signals.
+- `skill_improve` remains quota-bounded and proposal/draft gated; generated
+  skills are never auto-activated.
+- Transient environment failures, stale negative tool claims, and one-off
+  repo accidents should not be captured unless they have a reusable trigger.
+
+Configure the cadence under `knowledge.realtime_learning_nudge`:
+
+```jsonc
+"knowledge": {
+  "realtime_learning_nudge": {
+    "enabled": true,
+    "first_after_tool_calls": 10,
+    "repeat_after_tool_calls": 25
+  }
+}
+```
+
 ### Maturity gate
 
 An entry passes the maturity gate according to the following decision logic:

--- a/docs/releases/pending/hermes-style-realtime-learning-nudge.md
+++ b/docs/releases/pending/hermes-style-realtime-learning-nudge.md
@@ -1,0 +1,25 @@
+# Real-time learning nudge
+
+## What changed
+
+- Architect sessions now receive a cadence-bounded `[SWARM LEARNING NUDGE]` during longer work loops.
+- The nudge prompts the architect to capture durable procedural lessons with `knowledge_add` while context is still fresh.
+- The nudge now routes broader evidence-level learning to the existing curator phase/postmortem system instead of introducing a parallel learning reviewer.
+- The cadence is configurable under `knowledge.realtime_learning_nudge`.
+
+## Why
+
+Hermes-style learning works by reviewing recent work while the context is still
+available. opencode-swarm now gets that in-session prompt without bypassing its
+existing validation, reinforcement, quarantine, skill proposal, and activation
+gates.
+
+## Migration steps
+
+None. The nudge is enabled by default when knowledge is enabled, and can be
+disabled with `knowledge.realtime_learning_nudge.enabled = false`.
+
+## Known caveats
+
+- The nudge does not auto-edit active skills.
+- `skill_improve` remains quota-bounded and proposal/draft gated.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1099,6 +1099,21 @@ export const KnowledgeConfigSchema = z.object({
 	todo_max_phases: z.number().int().positive().default(3),
 	/** Enable age-based sweep of stale knowledge entries */
 	sweep_enabled: z.boolean().default(true),
+	/** Architect-only in-session nudge to capture durable lessons while work is still live. */
+	realtime_learning_nudge: z
+		.object({
+			/** Enable/disable the real-time learning nudge. */
+			enabled: z.boolean().default(true),
+			/** First total session tool-call count at which to nudge the architect. */
+			first_after_tool_calls: z.number().int().min(1).max(1000).default(10),
+			/** Minimum additional tool calls before repeating the nudge. */
+			repeat_after_tool_calls: z.number().int().min(1).max(1000).default(25),
+		})
+		.default({
+			enabled: true,
+			first_after_tool_calls: 10,
+			repeat_after_tool_calls: 25,
+		}),
 	/** Change 5: retrieval-upgrade tuning (MMR diversity, cold-start, synonyms). */
 	retrieval: z
 		.object({

--- a/src/hooks/agent-activity.ts
+++ b/src/hooks/agent-activity.ts
@@ -11,6 +11,7 @@ import type { PluginConfig } from '../config/schema';
 import { swarmState } from '../state';
 import { warn } from '../utils';
 import { bunWrite } from '../utils/bun-compat';
+import { recordRealtimeLearningToolCall } from './realtime-learning-nudge';
 import { readSwarmFileAsync } from './utils';
 
 /**
@@ -98,6 +99,7 @@ export function createAgentActivityHooks(
 			existing.totalDuration += duration;
 
 			swarmState.toolAggregates.set(key, existing);
+			recordRealtimeLearningToolCall(entry.sessionID);
 
 			// Increment pending events counter
 			swarmState.pendingEvents++;

--- a/src/hooks/realtime-learning-nudge.ts
+++ b/src/hooks/realtime-learning-nudge.ts
@@ -1,0 +1,124 @@
+import type { PluginConfig } from '../config';
+
+const MAX_TRACKED_LEARNING_NUDGE_SESSIONS = 500;
+const DEFAULT_LEARNING_NUDGE_FIRST_TOOL_CALLS = 10;
+const DEFAULT_LEARNING_NUDGE_REPEAT_TOOL_CALLS = 25;
+
+export const REALTIME_LEARNING_NUDGE_ID_PREFIX = 'realtime-learning-nudge';
+
+type RealtimeLearningNudgeConfig = NonNullable<
+	NonNullable<PluginConfig['knowledge']>['realtime_learning_nudge']
+>;
+
+interface RealtimeLearningNudgeState {
+	observedToolCallCount: number;
+	lastNudgedAtToolCallCount: number;
+}
+
+const realtimeLearningNudgeBySession = new Map<
+	string,
+	RealtimeLearningNudgeState
+>();
+
+function positiveIntegerOrDefault(value: unknown, fallback: number): number {
+	return Number.isInteger(value) && Number(value) > 0
+		? Number(value)
+		: fallback;
+}
+
+function rememberSession(
+	sessionID: string,
+	state: RealtimeLearningNudgeState,
+): void {
+	if (realtimeLearningNudgeBySession.has(sessionID)) {
+		realtimeLearningNudgeBySession.delete(sessionID);
+	}
+	realtimeLearningNudgeBySession.set(sessionID, state);
+
+	while (
+		realtimeLearningNudgeBySession.size > MAX_TRACKED_LEARNING_NUDGE_SESSIONS
+	) {
+		const oldestSessionID = realtimeLearningNudgeBySession.keys().next().value;
+		if (oldestSessionID === undefined) break;
+		realtimeLearningNudgeBySession.delete(oldestSessionID);
+	}
+}
+
+export function recordRealtimeLearningToolCall(sessionID: string): number {
+	const prior = realtimeLearningNudgeBySession.get(sessionID);
+	const nextState = {
+		observedToolCallCount: (prior?.observedToolCallCount ?? 0) + 1,
+		lastNudgedAtToolCallCount: prior?.lastNudgedAtToolCallCount ?? 0,
+	};
+	rememberSession(sessionID, nextState);
+	return nextState.observedToolCallCount;
+}
+
+export function getRealtimeLearningToolCallCount(sessionID?: string): number {
+	if (!sessionID) return 0;
+	return (
+		realtimeLearningNudgeBySession.get(sessionID)?.observedToolCallCount ?? 0
+	);
+}
+
+export function shouldInjectRealtimeLearningNudge(args: {
+	sessionID?: string;
+	config?: RealtimeLearningNudgeConfig;
+}): boolean {
+	if (!args.sessionID) return false;
+	if (args.config?.enabled === false) return false;
+
+	const state = realtimeLearningNudgeBySession.get(args.sessionID);
+	const toolCallCount = state?.observedToolCallCount ?? 0;
+	const firstAfterToolCalls = positiveIntegerOrDefault(
+		args.config?.first_after_tool_calls,
+		DEFAULT_LEARNING_NUDGE_FIRST_TOOL_CALLS,
+	);
+	const repeatAfterToolCalls = positiveIntegerOrDefault(
+		args.config?.repeat_after_tool_calls,
+		DEFAULT_LEARNING_NUDGE_REPEAT_TOOL_CALLS,
+	);
+
+	if (toolCallCount < firstAfterToolCalls) return false;
+	if (!state || state.lastNudgedAtToolCallCount === 0) return true;
+
+	return (
+		toolCallCount - state.lastNudgedAtToolCallCount >= repeatAfterToolCalls
+	);
+}
+
+export function recordRealtimeLearningNudge(sessionID: string): void {
+	const prior = realtimeLearningNudgeBySession.get(sessionID);
+	if (!prior) return;
+	rememberSession(sessionID, {
+		...prior,
+		lastNudgedAtToolCallCount: prior.observedToolCallCount,
+	});
+}
+
+export function resetRealtimeLearningNudgeState(): void {
+	realtimeLearningNudgeBySession.clear();
+}
+
+export function clearRealtimeLearningNudgeSession(sessionID: string): void {
+	realtimeLearningNudgeBySession.delete(sessionID);
+}
+
+export function getTrackedRealtimeLearningNudgeSessionCount(): number {
+	return realtimeLearningNudgeBySession.size;
+}
+
+export function buildRealtimeLearningNudge(args: {
+	currentPhase: number;
+	toolCallCount: number;
+}): string {
+	return [
+		'[SWARM LEARNING NUDGE]',
+		`Session has ${args.toolCallCount} tool calls in phase ${args.currentPhase}. Before continuing, decide whether the current work revealed a durable procedural lesson.`,
+		'- If yes, call knowledge_add now with actionable when/then/scope fields so later turns can retrieve it.',
+		'- If the signal needs review across evidence, repeated outcomes, or generated-skill health, let the curator phase/postmortem path handle it; curator can emit knowledge_application_findings and skill_candidates without activating skills.',
+		'- Prefer reinforcing existing knowledge over noisy one-offs. Do not save transient setup failures, stale negative tool claims, or repo-specific accidents without a reusable trigger.',
+		'- If repeated KNOWLEDGE_IGNORED/VIOLATED outcomes or stale generated skills are accumulating, use skill_improve only when enabled/approved; generated skills stay proposal/draft gated and must not auto-activate.',
+		'- If there is nothing durable, continue without adding knowledge.',
+	].join('\n');
+}

--- a/src/hooks/system-enhancer.ts
+++ b/src/hooks/system-enhancer.ts
@@ -163,6 +163,13 @@ import { _internals as knowledgeStoreInternals } from './knowledge-store';
 import type { SwarmKnowledgeEntry } from './knowledge-types.js';
 import { validateActionability } from './knowledge-validator.js';
 import {
+	buildRealtimeLearningNudge,
+	getRealtimeLearningToolCallCount,
+	REALTIME_LEARNING_NUDGE_ID_PREFIX,
+	recordRealtimeLearningNudge,
+	shouldInjectRealtimeLearningNudge,
+} from './realtime-learning-nudge';
+import {
 	buildCoderLocalizationBlock,
 	buildReviewerBlastRadiusBlock,
 } from './repo-graph-injection';
@@ -183,6 +190,13 @@ function extractAgentPrefix(fullAgentName: string | null | undefined): string {
 	const baseName = stripKnownSwarmPrefix(fullAgentName);
 	if (baseName.length >= fullAgentName.length) return '';
 	return fullAgentName.substring(0, fullAgentName.length - baseName.length);
+}
+
+function getTotalAggregateToolCallCount(): number {
+	return Array.from(swarmState.toolAggregates.values()).reduce(
+		(sum, agg) => sum + agg.count,
+		0,
+	);
 }
 
 /**
@@ -610,7 +624,7 @@ export function createSystemEnhancerHook(
 						seAllocation = maxInjectionTokens;
 					}
 
-					function tryInject(text: string): void {
+					function tryInject(text: string): boolean {
 						const tokens = estimateTokens(text);
 						actualDemand += tokens;
 						const effectiveMax = seAllocation;
@@ -618,10 +632,11 @@ export function createSystemEnhancerHook(
 							warn(
 								`system-enhancer: injection budget exceeded (${injectedTokens + tokens} > ${effectiveMax} tokens) — truncating system prompt content`,
 							);
-							return;
+							return false;
 						}
 						output.system.push(text);
 						injectedTokens += tokens;
+						return true;
 					}
 
 					const contextContent = await readSwarmFileAsync(
@@ -1348,15 +1363,37 @@ ${handoffContent}`;
 								// Silently skip if evidence dir missing or unreadable
 							}
 
+							// Real-time learning nudge: architect-only, cadence-bounded.
+							if (
+								mode !== 'DISCOVER' &&
+								config.knowledge?.enabled !== false &&
+								sessionId_retro
+							) {
+								const sessionToolCalls =
+									getRealtimeLearningToolCallCount(sessionId_retro);
+								if (
+									shouldInjectRealtimeLearningNudge({
+										sessionID: sessionId_retro,
+										config: config.knowledge?.realtime_learning_nudge,
+									})
+								) {
+									const learningNudge = buildRealtimeLearningNudge({
+										currentPhase: plan?.current_phase ?? 1,
+										toolCallCount: sessionToolCalls,
+									});
+									if (tryInject(learningNudge)) {
+										recordRealtimeLearningNudge(sessionId_retro);
+									}
+								}
+							}
+
 							// v6.2: Soft compaction advisory
 							if (mode !== 'DISCOVER') {
 								const compactionConfig = config.compaction_advisory;
 								if (compactionConfig?.enabled !== false && sessionId_retro) {
 									const session = swarmState.agentSessions.get(sessionId_retro);
 									if (session) {
-										const totalToolCalls = Array.from(
-											swarmState.toolAggregates.values(),
-										).reduce((sum, agg) => sum + agg.count, 0);
+										const totalToolCalls = getTotalAggregateToolCallCount();
 
 										const thresholds = compactionConfig?.thresholds ?? [
 											50, 75, 100, 125, 150,
@@ -1967,6 +2004,34 @@ ${handoffContent}`;
 							// Silently skip if evidence dir missing or unreadable
 						}
 
+						if (
+							mode_b !== 'DISCOVER' &&
+							config.knowledge?.enabled !== false &&
+							sessionId_retro_b
+						) {
+							const sessionToolCalls_b =
+								getRealtimeLearningToolCallCount(sessionId_retro_b);
+							if (
+								shouldInjectRealtimeLearningNudge({
+									sessionID: sessionId_retro_b,
+									config: config.knowledge?.realtime_learning_nudge,
+								})
+							) {
+								const learningNudge_b = buildRealtimeLearningNudge({
+									currentPhase: plan?.current_phase ?? 1,
+									toolCallCount: sessionToolCalls_b,
+								});
+								candidates.push({
+									id: `${REALTIME_LEARNING_NUDGE_ID_PREFIX}-${idCounter++}`,
+									kind: 'phase' as ContextCandidate['kind'],
+									text: learningNudge_b,
+									tokens: estimateTokens(learningNudge_b),
+									priority: 1,
+									metadata: { contentType: 'prose' as ContentType },
+								});
+							}
+						}
+
 						// v6.2: Soft compaction advisory
 						if (mode_b !== 'DISCOVER') {
 							const compactionConfig_b = config.compaction_advisory;
@@ -1974,9 +2039,7 @@ ${handoffContent}`;
 								const session_b =
 									swarmState.agentSessions.get(sessionId_retro_b);
 								if (session_b) {
-									const totalToolCalls_b = Array.from(
-										swarmState.toolAggregates.values(),
-									).reduce((sum, agg) => sum + agg.count, 0);
+									const totalToolCalls_b = getTotalAggregateToolCallCount();
 
 									const thresholds_b = compactionConfig_b?.thresholds ?? [
 										50, 75, 100, 125, 150,
@@ -2249,6 +2312,12 @@ ${handoffContent}`;
 						}
 						output.system.push(candidate.text);
 						injectedTokens += candidate.tokens;
+						if (
+							candidate.id.startsWith(REALTIME_LEARNING_NUDGE_ID_PREFIX) &&
+							_input.sessionID
+						) {
+							recordRealtimeLearningNudge(_input.sessionID);
+						}
 					}
 
 					// Context budget check - run after all other assembly, architect-only

--- a/src/state.ts
+++ b/src/state.ts
@@ -33,6 +33,10 @@ import {
 	clearPendingCoderScope,
 	resetStandardWorktreeIsolationState,
 } from './hooks/delegation-gate.js';
+import {
+	clearRealtimeLearningNudgeSession,
+	resetRealtimeLearningNudgeState,
+} from './hooks/realtime-learning-nudge.js';
 import { clearTrajectoryStepCounters } from './hooks/trajectory-step-state.js';
 import { loadPlanJsonOnly, updateTaskStatus } from './plan/manager.js';
 import { derivePlanId } from './plan/utils.js';
@@ -524,6 +528,7 @@ export function resetSwarmState(): void {
 	swarmState.specWriterAgentNames = [];
 	swarmState.currentCriticalShownIds.clear();
 	swarmState.knowledgeAckDedup.clear();
+	resetRealtimeLearningNudgeState();
 	swarmState.generatedAgentNames = [];
 	_rehydrationCache = null;
 	// Full Auto Mode (Phase 4)
@@ -841,6 +846,7 @@ export function startAgentSession(
  */
 export function endAgentSession(sessionId: string): void {
 	swarmState.agentSessions.delete(sessionId);
+	clearRealtimeLearningNudgeSession(sessionId);
 }
 
 /**

--- a/tests/unit/config/knowledge-config.test.ts
+++ b/tests/unit/config/knowledge-config.test.ts
@@ -534,5 +534,31 @@ describe('KnowledgeConfigSchema', () => {
 				});
 			}).toThrow();
 		});
+
+		it('should accept and reject boundary values for tool-call thresholds', () => {
+			const result1 = KnowledgeConfigSchema.parse({
+				realtime_learning_nudge: { first_after_tool_calls: 1000 },
+			});
+			expect(result1.realtime_learning_nudge.first_after_tool_calls).toBe(1000);
+
+			expect(() => {
+				KnowledgeConfigSchema.parse({
+					realtime_learning_nudge: { first_after_tool_calls: 1001 },
+				});
+			}).toThrow();
+
+			const result2 = KnowledgeConfigSchema.parse({
+				realtime_learning_nudge: { repeat_after_tool_calls: 1000 },
+			});
+			expect(result2.realtime_learning_nudge.repeat_after_tool_calls).toBe(
+				1000,
+			);
+
+			expect(() => {
+				KnowledgeConfigSchema.parse({
+					realtime_learning_nudge: { repeat_after_tool_calls: 1001 },
+				});
+			}).toThrow();
+		});
 	});
 });

--- a/tests/unit/config/knowledge-config.test.ts
+++ b/tests/unit/config/knowledge-config.test.ts
@@ -40,6 +40,11 @@ describe('KnowledgeConfigSchema', () => {
 				default_max_phases: 10,
 				todo_max_phases: 3,
 				sweep_enabled: true,
+				realtime_learning_nudge: {
+					enabled: true,
+					first_after_tool_calls: 10,
+					repeat_after_tool_calls: 25,
+				},
 				// v7.10.0+ directive retrieval threshold
 				directive_min_confidence: 0.75,
 				enrichment: {
@@ -94,6 +99,11 @@ describe('KnowledgeConfigSchema', () => {
 				default_max_phases: 10,
 				todo_max_phases: 3,
 				sweep_enabled: true,
+				realtime_learning_nudge: {
+					enabled: false,
+					first_after_tool_calls: 5,
+					repeat_after_tool_calls: 15,
+				},
 				// v7.10.0+ directive retrieval threshold
 				directive_min_confidence: 0.75,
 				enrichment: {
@@ -214,6 +224,11 @@ describe('KnowledgeConfigSchema', () => {
 					default_max_phases: 10,
 					todo_max_phases: 3,
 					sweep_enabled: true,
+					realtime_learning_nudge: {
+						enabled: false,
+						first_after_tool_calls: 5,
+						repeat_after_tool_calls: 15,
+					},
 					// v7.10.0+ directive retrieval threshold
 					directive_min_confidence: 0.75,
 					enrichment: {
@@ -476,6 +491,48 @@ describe('KnowledgeConfigSchema', () => {
 			expect(result.default_max_phases).toBe(20);
 			expect(result.todo_max_phases).toBe(5);
 			expect(result.sweep_enabled).toBe(false);
+		});
+	});
+
+	describe('real-time learning nudge config', () => {
+		it('should use real-time learning nudge defaults when not provided', () => {
+			const result = KnowledgeConfigSchema.parse({});
+
+			expect(result.realtime_learning_nudge).toEqual({
+				enabled: true,
+				first_after_tool_calls: 10,
+				repeat_after_tool_calls: 25,
+			});
+		});
+
+		it('should preserve custom real-time learning nudge values', () => {
+			const result = KnowledgeConfigSchema.parse({
+				realtime_learning_nudge: {
+					enabled: false,
+					first_after_tool_calls: 3,
+					repeat_after_tool_calls: 7,
+				},
+			});
+
+			expect(result.realtime_learning_nudge).toEqual({
+				enabled: false,
+				first_after_tool_calls: 3,
+				repeat_after_tool_calls: 7,
+			});
+		});
+
+		it('should reject non-positive real-time learning nudge thresholds', () => {
+			expect(() => {
+				KnowledgeConfigSchema.parse({
+					realtime_learning_nudge: { first_after_tool_calls: 0 },
+				});
+			}).toThrow();
+
+			expect(() => {
+				KnowledgeConfigSchema.parse({
+					realtime_learning_nudge: { repeat_after_tool_calls: 0 },
+				});
+			}).toThrow();
 		});
 	});
 });

--- a/tests/unit/hooks/system-enhancer-realtime-learning.test.ts
+++ b/tests/unit/hooks/system-enhancer-realtime-learning.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { PluginConfig } from '../../../src/config';
+import { createAgentActivityHooks } from '../../../src/hooks/agent-activity';
+import {
+	buildRealtimeLearningNudge,
+	getTrackedRealtimeLearningNudgeSessionCount,
+	recordRealtimeLearningToolCall,
+	resetRealtimeLearningNudgeState,
+} from '../../../src/hooks/realtime-learning-nudge';
+import { createSystemEnhancerHook } from '../../../src/hooks/system-enhancer';
+import { endAgentSession, resetSwarmState } from '../../../src/state';
+
+describe('System Enhancer real-time learning nudge', () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), 'swarm-learning-nudge-test-'));
+		resetSwarmState();
+		resetRealtimeLearningNudgeState();
+		const swarmDir = join(tempDir, '.swarm');
+		await mkdir(swarmDir, { recursive: true });
+		await writeFile(join(swarmDir, 'plan.md'), '# Plan\nCurrent phase: 2\n');
+		await writeFile(join(swarmDir, 'context.md'), '# Context\n');
+	});
+
+	afterEach(async () => {
+		resetRealtimeLearningNudgeState();
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	async function invokeHook(
+		config: PluginConfig,
+		sessionID = 'learning-session',
+	): Promise<string[]> {
+		const hooks = createSystemEnhancerHook(config, tempDir);
+		const transform = hooks['experimental.chat.system.transform'] as (
+			input: { sessionID?: string },
+			output: { system: string[] },
+		) => Promise<void>;
+		const output = { system: ['Initial system prompt'] };
+		await transform({ sessionID }, output);
+		return output.system;
+	}
+
+	async function recordCompletedToolCalls(
+		sessionID: string,
+		count: number,
+	): Promise<void> {
+		const hooks = createAgentActivityHooks(defaultConfig, tempDir);
+		for (let i = 0; i < count; i++) {
+			const callID = `${sessionID}-call-${i}`;
+			await hooks.toolBefore(
+				{ tool: 'bash', sessionID, callID },
+				{ args: { index: i } },
+			);
+			await hooks.toolAfter(
+				{ tool: 'bash', sessionID, callID },
+				{ success: true },
+			);
+		}
+	}
+
+	const defaultConfig: PluginConfig = {
+		max_iterations: 5,
+		qa_retry_limit: 3,
+		inject_phase_reminders: true,
+	};
+
+	it('injects the nudge at the first default threshold and suppresses duplicates', async () => {
+		await recordCompletedToolCalls('learning-session', 10);
+
+		const firstOutput = await invokeHook(defaultConfig);
+		expect(
+			firstOutput.some((entry) => entry.includes('[SWARM LEARNING NUDGE]')),
+		).toBe(true);
+		expect(firstOutput.some((entry) => entry.includes('knowledge_add'))).toBe(
+			true,
+		);
+
+		const secondOutput = await invokeHook(defaultConfig);
+		expect(
+			secondOutput.some((entry) => entry.includes('[SWARM LEARNING NUDGE]')),
+		).toBe(false);
+	});
+
+	it('uses configured first and repeat thresholds', async () => {
+		const config = {
+			...defaultConfig,
+			knowledge: {
+				enabled: true,
+				realtime_learning_nudge: {
+					enabled: true,
+					first_after_tool_calls: 3,
+					repeat_after_tool_calls: 5,
+				},
+			} as PluginConfig['knowledge'],
+		};
+
+		await recordCompletedToolCalls('learning-session', 3);
+		expect(
+			(await invokeHook(config)).some((entry) =>
+				entry.includes('[SWARM LEARNING NUDGE]'),
+			),
+		).toBe(true);
+
+		await recordCompletedToolCalls('learning-session', 4);
+		expect(
+			(await invokeHook(config)).some((entry) =>
+				entry.includes('[SWARM LEARNING NUDGE]'),
+			),
+		).toBe(false);
+
+		await recordCompletedToolCalls('learning-session', 1);
+		expect(
+			(await invokeHook(config)).some((entry) =>
+				entry.includes('[SWARM LEARNING NUDGE]'),
+			),
+		).toBe(true);
+	});
+
+	it('respects knowledge and nudge disable flags', async () => {
+		await recordCompletedToolCalls('learning-session', 100);
+
+		const knowledgeDisabled = {
+			...defaultConfig,
+			knowledge: { enabled: false } as PluginConfig['knowledge'],
+		};
+		expect(
+			(await invokeHook(knowledgeDisabled)).some((entry) =>
+				entry.includes('[SWARM LEARNING NUDGE]'),
+			),
+		).toBe(false);
+
+		resetRealtimeLearningNudgeState();
+		const nudgeDisabled = {
+			...defaultConfig,
+			knowledge: {
+				enabled: true,
+				realtime_learning_nudge: { enabled: false },
+			} as PluginConfig['knowledge'],
+		};
+		expect(
+			(await invokeHook(nudgeDisabled)).some((entry) =>
+				entry.includes('[SWARM LEARNING NUDGE]'),
+			),
+		).toBe(false);
+	});
+
+	it('keeps cadence isolated between sessions', async () => {
+		await recordCompletedToolCalls('session-a', 10);
+
+		expect(
+			(await invokeHook(defaultConfig, 'session-a')).some((entry) =>
+				entry.includes('[SWARM LEARNING NUDGE]'),
+			),
+		).toBe(true);
+		expect(
+			(await invokeHook(defaultConfig, 'session-b')).some((entry) =>
+				entry.includes('[SWARM LEARNING NUDGE]'),
+			),
+		).toBe(false);
+
+		await recordCompletedToolCalls('session-b', 9);
+		expect(
+			(await invokeHook(defaultConfig, 'session-b')).some((entry) =>
+				entry.includes('[SWARM LEARNING NUDGE]'),
+			),
+		).toBe(false);
+
+		await recordCompletedToolCalls('session-b', 1);
+		expect(
+			(await invokeHook(defaultConfig, 'session-b')).some((entry) =>
+				entry.includes('[SWARM LEARNING NUDGE]'),
+			),
+		).toBe(true);
+	});
+
+	it('bounds tracked session state with FIFO eviction', () => {
+		for (let i = 0; i < 510; i++) {
+			recordRealtimeLearningToolCall(`session-${i}`);
+		}
+
+		expect(getTrackedRealtimeLearningNudgeSessionCount()).toBe(500);
+	});
+
+	it('clears tracked state on session teardown and swarm reset', () => {
+		recordRealtimeLearningToolCall('session-to-end');
+		recordRealtimeLearningToolCall('session-to-reset');
+
+		endAgentSession('session-to-end');
+		expect(getTrackedRealtimeLearningNudgeSessionCount()).toBe(1);
+
+		resetSwarmState();
+		expect(getTrackedRealtimeLearningNudgeSessionCount()).toBe(0);
+	});
+
+	it('keeps the prompt bounded and action-oriented', () => {
+		const prompt = buildRealtimeLearningNudge({
+			currentPhase: 2,
+			toolCallCount: 42,
+		});
+
+		expect(prompt).toContain('phase 2');
+		expect(prompt).toContain('knowledge_add');
+		expect(prompt).toContain('curator');
+		expect(prompt).toContain('knowledge_application_findings');
+		expect(prompt).toContain('skill_improve');
+		expect(prompt.length).toBeLessThan(1100);
+	});
+});

--- a/tests/unit/hooks/system-enhancer-realtime-learning.test.ts
+++ b/tests/unit/hooks/system-enhancer-realtime-learning.test.ts
@@ -208,6 +208,31 @@ describe('System Enhancer real-time learning nudge', () => {
 		expect(prompt).toContain('curator');
 		expect(prompt).toContain('knowledge_application_findings');
 		expect(prompt).toContain('skill_improve');
+		expect(prompt).toContain(
+			'generated skills stay proposal/draft gated and must not auto-activate',
+		);
 		expect(prompt.length).toBeLessThan(1100);
+	});
+
+	it('injects the nudge via the candidate-ranking path when scoring is enabled', async () => {
+		const config = {
+			...defaultConfig,
+			context_budget: { scoring: { enabled: true } },
+			knowledge: {
+				enabled: true,
+				realtime_learning_nudge: {
+					enabled: true,
+					first_after_tool_calls: 10,
+					repeat_after_tool_calls: 25,
+				},
+			} as PluginConfig['knowledge'],
+		};
+
+		await recordCompletedToolCalls('learning-session', 10);
+		const output = await invokeHook(config);
+		expect(
+			output.some((entry) => entry.includes('[SWARM LEARNING NUDGE]')),
+		).toBe(true);
+		expect(output.some((entry) => entry.includes('knowledge_add'))).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary
- Add a configurable architect-only real-time learning nudge under knowledge.realtime_learning_nudge.
- Track completed tool calls per session so the nudge cadence is session-isolated, FIFO-bounded, and cleared on session teardown/reset.
- Route immediate lessons to knowledge_add and broader evidence-level learning to existing curator phase/postmortem paths; generated skills remain draft/proposal gated.
- Document the cadence and add a pending release fragment.

## Invariant audit
- 1 (plugin init): not touched - no plugin initialization path changes; un run build and Node dist import passed.
- 2 (runtime portability): not touched - no package entry/export changes or Bun-only imports; 
ode --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')" passed.
- 3 (subprocesses): not touched - changed source files add no subprocess calls.
- 4 (.swarm containment): not touched - runtime state path behavior unchanged; .swarm/evidence/* files are publication artifacts and remain ignored.
- 5 (plan durability): not touched - no plan ledger/projection/checkpoint code changed.
- 6 (test_runner safety): not touched - validation used shell un commands; OpenCode 	est_runner was not used.
- 7 (test writing): touched - .opencode/skills/writing-tests/SKILL.md was loaded; new tests use un:test, temp dirs via os.tmpdir()/path.join, no mock.module; focused suite passed 55/55.
- 8 (session state): touched - ealtime-learning-nudge state is keyed by sessionID, FIFO-capped at 500, and cleared by endAgentSession/esetSwarmState; tests cover isolation, eviction, and cleanup.
- 9 (guardrails/retry): not touched - no guardrail, retry, or transient-error behavior changed.
- 10 (chat/system msg): touched - system-enhancer injects a bounded advisory candidate only for architect non-DISCOVER sessions; focused system-enhancer tests passed, including duplicate suppression and prompt bound checks.
- 11 (tool registration): not touched - no tool, command, agent map, or TOOL_NAMES changes.
- 12 (release/cache): touched - added docs/releases/pending/hermes-style-realtime-learning-nudge.md; no version, changelog, manifest, install, update, or cache path changes.

## Test plan
- [x] unx @biomejs/biome@2.3.14 ci docs/configuration.md docs/knowledge.md src/config/schema.ts src/hooks/agent-activity.ts src/hooks/system-enhancer.ts src/hooks/realtime-learning-nudge.ts src/state.ts tests/unit/config/knowledge-config.test.ts tests/unit/hooks/system-enhancer-realtime-learning.test.ts docs/releases/pending/hermes-style-realtime-learning-nudge.md
- [x] un --smol test tests/unit/hooks/system-enhancer-realtime-learning.test.ts tests/unit/hooks/system-enhancer-compaction.test.ts tests/unit/config/knowledge-config.test.ts --timeout 60000 (55 pass)
- [x] un run typecheck
- [x] git diff --check HEAD~1..HEAD
- [x] un run build
- [x] 
ode --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"
- [x] pre-push secret-pattern scan over git log zaxbyhub/main..HEAD -p
"@
 = @"
# Commit/PR validation

Branch: codex/hermes-realtime-learning
Commit: 573baeff feat(knowledge): add realtime learning nudge
Base: zaxbyhub/main

Commands run after rebase onto zaxbyhub/main:

- unx @biomejs/biome@2.3.14 ci docs/configuration.md docs/knowledge.md src/config/schema.ts src/hooks/agent-activity.ts src/hooks/system-enhancer.ts src/hooks/realtime-learning-nudge.ts src/state.ts tests/unit/config/knowledge-config.test.ts tests/unit/hooks/system-enhancer-realtime-learning.test.ts docs/releases/pending/hermes-style-realtime-learning-nudge.md - passed; checked 7 files, no fixes applied.
- un --smol test tests/unit/hooks/system-enhancer-realtime-learning.test.ts tests/unit/hooks/system-enhancer-compaction.test.ts tests/unit/config/knowledge-config.test.ts --timeout 60000 - passed; 55 pass, 0 fail.
- un run typecheck - passed.
- git diff --check HEAD~1..HEAD - passed.
- un run build - passed.
- 
ode --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')" - passed; output dist import OK.
- git log zaxbyhub/main..HEAD -p | Select-String -Pattern 'sk_live|ghp_|xox[abprs]-|AKIA|eyJ|AIza' - no matches.
- git diff --name-only HEAD zaxbyhub/main | Select-String -Pattern '\.(local\.json|vscode|idea)$' - no matches.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

