### PR TITLE
fix(ledger): serialize plan ledger appends

### DIFF
--- a/docs/plan-durability.md
+++ b/docs/plan-durability.md
@@ -17,6 +17,16 @@
 
 > **Migration note:** As of v7.x, SWARM_PLAN files live inside `.swarm/plan-export/` instead of the project root. The `/swarm close` and `/swarm reset --confirm` commands clean up all three locations (`.swarm/plan-export/`, flat `.swarm/`, and project root) during the transition window.
 
+### Ledger append concurrency
+
+`appendLedgerEvent()` serializes its read -> validate -> rewrite sequence under
+a project-scoped lock keyed to `.swarm/plan-ledger.jsonl`. The lock is acquired
+before reading the latest ledger sequence and released only after the canonical
+ledger file has been replaced. This preserves monotonic sequence assignment and
+keeps `expectedSeq` / `expectedHash` stale-writer checks tied to the latest
+committed ledger state even when two OpenCode processes or background workers
+try to append at the same time.
+
 ### Ledger Event Types
 
 ```json

--- a/docs/releases/pending/1613-ledger-append-lock.md
+++ b/docs/releases/pending/1613-ledger-append-lock.md
@@ -1,0 +1,26 @@
+# Serialize plan ledger appends
+
+## What changed
+
+- Wrapped `appendLedgerEvent()` in a project-scoped lock keyed to
+  `.swarm/plan-ledger.jsonl`, so concurrent plan/task mutations cannot both
+  observe the same latest sequence and rewrite the authoritative ledger from a
+  stale snapshot.
+- Added focused regression coverage for concurrent ledger appends and
+  same-`expectedSeq` contention.
+
+## Why
+
+The plan ledger is the authoritative source of plan state. Two near-simultaneous
+append writers could previously assign duplicate sequence numbers, and
+cross-process timing could silently drop one writer's event when the later
+rename replaced the canonical ledger.
+
+## Migration steps
+
+No manual migration is required. Existing ledgers keep the same JSONL format.
+
+## Known caveats
+
+Lock acquisition now fails closed if the project-scoped ledger lock cannot be
+acquired within the bounded timeout.

--- a/src/plan/ledger-concurrency.regression.test.ts
+++ b/src/plan/ledger-concurrency.regression.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	appendLedgerEvent,
+	initLedger,
+	type LedgerEvent,
+	LedgerStaleWriterError,
+	readLedgerEvents,
+} from './ledger';
+
+let testDir: string;
+
+function eventInput(taskId: string, source: string) {
+	return {
+		plan_id: 'test-plan',
+		event_type: 'task_added' as const,
+		task_id: taskId,
+		source,
+	};
+}
+
+beforeEach(() => {
+	testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ledger-concurrency-'));
+	fs.mkdirSync(path.join(testDir, '.swarm'), { recursive: true });
+});
+
+afterEach(() => {
+	fs.rmSync(testDir, { recursive: true, force: true });
+});
+
+describe('appendLedgerEvent concurrency regression', () => {
+	test('concurrent appends both persist with unique monotonic sequence numbers', async () => {
+		await initLedger(testDir, 'test-plan');
+
+		const results = await Promise.all([
+			appendLedgerEvent(testDir, eventInput('1.1', 'race-1')),
+			appendLedgerEvent(testDir, eventInput('1.2', 'race-2')),
+		]);
+
+		const events = await readLedgerEvents(testDir);
+		const appended = events.filter((event) => event.source.startsWith('race-'));
+		const persistedSeqs = appended
+			.map((event) => event.seq)
+			.sort((a, b) => a - b);
+		const returnedSeqs = results
+			.map((event) => event.seq)
+			.sort((a, b) => a - b);
+
+		expect(appended.map((event) => event.source).sort()).toEqual([
+			'race-1',
+			'race-2',
+		]);
+		expect(persistedSeqs).toEqual([2, 3]);
+		expect(returnedSeqs).toEqual([2, 3]);
+	});
+
+	test('concurrent writers using the same expectedSeq produce one stale-writer error', async () => {
+		await initLedger(testDir, 'test-plan');
+
+		const results = await Promise.allSettled([
+			appendLedgerEvent(testDir, eventInput('1.1', 'cas-1'), {
+				expectedSeq: 1,
+			}),
+			appendLedgerEvent(testDir, eventInput('1.2', 'cas-2'), {
+				expectedSeq: 1,
+			}),
+		]);
+
+		const fulfilled = results.filter(
+			(result): result is PromiseFulfilledResult<LedgerEvent> =>
+				result.status === 'fulfilled',
+		);
+		const rejected = results.filter(
+			(result): result is PromiseRejectedResult => result.status === 'rejected',
+		);
+
+		expect(fulfilled).toHaveLength(1);
+		expect(fulfilled[0].value.seq).toBe(2);
+		expect(rejected).toHaveLength(1);
+		expect(rejected[0].reason).toBeInstanceOf(LedgerStaleWriterError);
+
+		const events = await readLedgerEvents(testDir);
+		const casSources = events
+			.filter((event) => event.source.startsWith('cas-'))
+			.map((event) => event.source);
+		expect(casSources).toHaveLength(1);
+	});
+});

--- a/src/plan/ledger.test.ts
+++ b/src/plan/ledger.test.ts
@@ -8,6 +8,7 @@ import {
 	computePlanHash,
 	getLatestLedgerSeq,
 	initLedger,
+	LEDGER_SCHEMA_VERSION,
 	type LedgerEvent,
 	LedgerStaleWriterError,
 	ledgerExists,
@@ -180,7 +181,7 @@ describe('ledger', () => {
 			expect(events[0].plan_id).toBe('test-plan-id');
 			expect(events[0].seq).toBe(1);
 			expect(events[0].source).toBe('initLedger');
-			expect(events[0].schema_version).toBe('1.0.0');
+			expect(events[0].schema_version).toBe(LEDGER_SCHEMA_VERSION);
 		});
 
 		test('creates ledger file', async () => {
@@ -274,7 +275,7 @@ describe('ledger', () => {
 			expect(event.source).toBe('updateTaskStatus');
 			expect(event.plan_hash_before).toHaveLength(64);
 			expect(event.plan_hash_after).toHaveLength(64);
-			expect(event.schema_version).toBe('1.0.0');
+			expect(event.schema_version).toBe(LEDGER_SCHEMA_VERSION);
 		});
 
 		test('multiple events have incrementing seq', async () => {

--- a/src/plan/ledger.ts
+++ b/src/plan/ledger.ts
@@ -14,6 +14,7 @@ import {
 	PlanSchema,
 	TaskStatusSchema,
 } from '../config/plan-schema';
+import { withEvidenceLock } from '../evidence/lock.js';
 import { emit } from '../telemetry.js';
 import { derivePlanId } from './utils';
 
@@ -106,6 +107,13 @@ export interface SnapshotEventPayload {
  * Ledger file name
  */
 const LEDGER_FILENAME = 'plan-ledger.jsonl';
+
+/**
+ * Relative path used as the project-scoped lock key for ledger append writes.
+ * Must match the real runtime ledger path so every append caller coordinates
+ * on the same proper-lockfile sentinel.
+ */
+const LEDGER_LOCK_PATH = path.join('.swarm', LEDGER_FILENAME);
 
 /**
  * Plan JSON file name
@@ -390,66 +398,78 @@ export async function appendLedgerEvent(
 		planHashAfter?: string;
 	},
 ): Promise<LedgerEvent> {
-	const ledgerPath = getLedgerPath(directory);
+	return withEvidenceLock(
+		directory,
+		LEDGER_LOCK_PATH,
+		'plan-ledger',
+		'append-ledger-event',
+		async () => {
+			const ledgerPath = getLedgerPath(directory);
 
-	// Get current state
-	const latestSeq = await getLatestLedgerSeq(directory);
-	const nextSeq = latestSeq + 1;
+			// Get current state while holding the ledger write lock so concurrent
+			// writers cannot observe the same seq and both rewrite the canonical file.
+			const latestSeq = await getLatestLedgerSeq(directory);
+			const nextSeq = latestSeq + 1;
 
-	// Compute plan_hash_before from current plan.json
-	const planHashBefore = computeCurrentPlanHash(directory);
+			// Compute plan_hash_before from current plan.json
+			const planHashBefore = computeCurrentPlanHash(directory);
 
-	// Validate concurrency constraints if provided
-	if (options?.expectedSeq !== undefined && options.expectedSeq !== latestSeq) {
-		throw new LedgerStaleWriterError(
-			`Stale writer: expected seq ${options.expectedSeq} but found ${latestSeq}`,
-		);
-	}
+			// Validate concurrency constraints if provided
+			if (
+				options?.expectedSeq !== undefined &&
+				options.expectedSeq !== latestSeq
+			) {
+				throw new LedgerStaleWriterError(
+					`Stale writer: expected seq ${options.expectedSeq} but found ${latestSeq}`,
+				);
+			}
 
-	if (
-		options?.expectedHash !== undefined &&
-		options.expectedHash !== planHashBefore
-	) {
-		throw new LedgerStaleWriterError(
-			`Stale writer: expected hash ${options.expectedHash} but found ${planHashBefore}`,
-		);
-	}
+			if (
+				options?.expectedHash !== undefined &&
+				options.expectedHash !== planHashBefore
+			) {
+				throw new LedgerStaleWriterError(
+					`Stale writer: expected hash ${options.expectedHash} but found ${planHashBefore}`,
+				);
+			}
 
-	// Use provided planHashAfter if available (allows caller to compute hash from
-	// in-memory mutated plan before writing to disk), otherwise fall back to
-	// computing from current plan.json (backward-compatible)
-	const planHashAfter = options?.planHashAfter ?? planHashBefore;
+			// Use provided planHashAfter if available (allows caller to compute hash from
+			// in-memory mutated plan before writing to disk), otherwise fall back to
+			// computing from current plan.json (backward-compatible)
+			const planHashAfter = options?.planHashAfter ?? planHashBefore;
 
-	const event: LedgerEvent = {
-		...eventInput,
-		seq: nextSeq,
-		timestamp: new Date().toISOString(),
-		plan_hash_before: planHashBefore,
-		plan_hash_after: planHashAfter,
-		schema_version: LEDGER_SCHEMA_VERSION,
-	};
+			const event: LedgerEvent = {
+				...eventInput,
+				seq: nextSeq,
+				timestamp: new Date().toISOString(),
+				plan_hash_before: planHashBefore,
+				plan_hash_after: planHashAfter,
+				schema_version: LEDGER_SCHEMA_VERSION,
+			};
 
-	// Ensure .swarm/ directory exists
-	fs.mkdirSync(path.join(directory, '.swarm'), { recursive: true });
+			// Ensure .swarm/ directory exists
+			fs.mkdirSync(path.join(directory, '.swarm'), { recursive: true });
 
-	// Write to temp file then rename for atomicity.
-	// Random suffix prevents concurrent writers across processes from clobbering
-	// each other's temp file (each process writes its own uniquely-named temp).
-	const tempPath = `${ledgerPath}.tmp.${Date.now()}.${Math.floor(Math.random() * 1e9)}`;
-	const line = `${JSON.stringify(event)}\n`;
+			// Write to temp file then rename for atomicity.
+			// Random suffix prevents concurrent writers across processes from clobbering
+			// each other's temp file (each process writes its own uniquely-named temp).
+			const tempPath = `${ledgerPath}.tmp.${Date.now()}.${Math.floor(Math.random() * 1e9)}`;
+			const line = `${JSON.stringify(event)}\n`;
 
-	// If ledger exists, append to it via temp file
-	if (fs.existsSync(ledgerPath)) {
-		const existingContent = fs.readFileSync(ledgerPath, 'utf8');
-		fs.writeFileSync(tempPath, existingContent + line, 'utf8');
-	} else {
-		// Ledger not initialized - cannot append without plan_created event
-		throw new Error('Ledger not initialized. Call initLedger() first.');
-	}
+			// If ledger exists, append to it via temp file
+			if (fs.existsSync(ledgerPath)) {
+				const existingContent = fs.readFileSync(ledgerPath, 'utf8');
+				fs.writeFileSync(tempPath, existingContent + line, 'utf8');
+			} else {
+				// Ledger not initialized - cannot append without plan_created event
+				throw new Error('Ledger not initialized. Call initLedger() first.');
+			}
 
-	fs.renameSync(tempPath, ledgerPath);
+			fs.renameSync(tempPath, ledgerPath);
 
-	return event;
+			return event;
+		},
+	);
 }
 
 /**


### PR DESCRIPTION
Closes #1613

## Summary
- Serialize `appendLedgerEvent()` under a project-scoped lock keyed to `.swarm/plan-ledger.jsonl` so concurrent append writers cannot observe the same latest sequence or rewrite the authoritative ledger from a stale snapshot.
- Add focused regression coverage for concurrent append monotonicity and same-`expectedSeq` stale-writer behavior.
- Document the ledger append locking contract and add a pending release fragment.

## Invariant audit
- 1 (plugin init): not touched - no plugin initialization path changed.
- 2 (runtime portability): touched - `bun run build` passed; `node scripts\repro-704.mjs` passed T1 at 168.7ms under the 400ms deadline; `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` printed `dist import OK`.
- 3 (subprocesses): not touched - no subprocess code changed.
- 4 (.swarm containment): touched - lock key is `path.join('.swarm', LEDGER_FILENAME)` and lock helper stores sentinels under `.swarm/locks`; `bun --smol test src\__tests__\evidence-lock.test.ts --timeout 60000` passed with 8 tests.
- 5 (plan durability): touched - `bun --smol test src\plan\ledger-concurrency.regression.test.ts --timeout 60000` passed with concurrent appends producing unique seqs and same-`expectedSeq` contention producing one stale writer.
- 6 (test_runner safety): not touched - repo validation used shell `bun` commands, not broad `test_runner` scopes.
- 7 (test writing): touched - new test file uses `bun:test`, no `mock.module`, and remains under 500 lines; focused and colocated ledger tests passed.
- 8 (session state): not touched - no session/global state changed.
- 9 (guardrails/retry): not touched - no provider/transient retry logic changed.
- 10 (chat/system msg): not touched - no chat/system hook changed.
- 11 (tool registration): not touched - no tool registration, agent maps, or command surfaces changed.
- 12 (release/cache): touched - added `docs/releases/pending/1613-ledger-append-lock.md`; did not edit `package.json` version, `CHANGELOG.md`, or `.release-please-manifest.json`.

## Test plan
- [x] `bun --smol test src\plan\ledger-concurrency.regression.test.ts --timeout 60000`
- [x] `bun --smol test src\__tests__\evidence-lock.test.ts --timeout 60000`
- [x] `bun --smol test src\plan\ledger.test.ts src\plan\ledger-integrity.test.ts src\plan\ledger-snapshot-adversarial.test.ts src\plan\migration-revert.regression.test.ts --timeout 120000`
- [x] `bun --smol test tests\unit\plan\ledger-approved-snapshot.test.ts --timeout 60000`
- [x] `bun --smol test tests\unit\plan\ledger-execution-profile.test.ts --timeout 60000`
- [x] `bun --smol test tests\unit\plan\ledger-task-removed-replay.test.ts --timeout 60000`
- [x] `bun --smol test src\plan\manager.cas-backoff.test.ts --timeout 60000`
- [x] `bun --smol test tests\unit\plan\close-plan-terminal-state.test.ts --timeout 60000`
- [x] `bunx @biomejs/biome@2.3.14 ci .`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `node scripts\repro-704.mjs`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `git diff --check`

## Notes
- `bun --smol test tests\unit\plan --timeout 120000` was also attempted and failed due to known batch mock-pollution/isolation behavior after files that mock `src/plan/ledger`; the same impacted ledger files passed in separate per-file/focused runs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

