### PR TITLE
build(bundle): minify main bundle with identifier-preserving flags

### DIFF
--- a/docs/releases/pending/minify-main-bundle.md
+++ b/docs/releases/pending/minify-main-bundle.md
@@ -1,0 +1,31 @@
+# Adopt identifier-preserving minification for the main bundle
+
+## What changed
+
+The main plugin bundle (`dist/index.js`) is now built with `--minify-whitespace --minify-syntax`. This is the identifier-preserving minification variant — function, variable, and class names remain intact in the shipped artifact.
+
+Measured result (experimental, Windows local):
+- Unminified: ~5.77 MiB
+- Minified: **4,480,989 bytes** (~4.48 MiB)
+- Savings: **~1.28 MiB (~22.3%)**
+
+Final CI-built figures may differ by ~2 KB across platforms/toolchains; the smoke cap is tightened to the new minified baseline in #1582's companion task.
+
+## Why this variant
+
+Full minification (`--minify`, which also mangles identifiers) was evaluated and rejected by General Council (2 rounds, generalist / domain_expert / skeptic). It breaks 13 identifier-grepping guardrail assertions in `tests/unit/build/full-auto-toolbefore-fail-closed.test.ts` and `tests/unit/turbo/lean/runtime-conformance.test.ts`, and mangles user-reported stack traces. Source maps were ruled out as non-viable: the plugin has no error-service pipeline, users cannot be assumed to run Node with `--enable-source-maps`, and the ~4× map-size tax would erase the savings.
+
+Identifier-preserving minification (`--minify-whitespace --minify-syntax`) retains human-readable names in stack traces without requiring source maps, while still delivering the measured size reduction.
+
+## Why now
+
+The unminified bundle had reached its smoke cap (6.5 MiB), triggering repeated cap bumps (5 → 5.5 → 6.5 MiB) and merge-queue flakes from ~2 KB cross-platform build variance. Minification bends the size curve; the cap is re-tightened to the new minified baseline so future growth remains visible in CI.
+
+## Migration steps
+
+None. The build flag change is transparent to consumers. `dist/index.js` remains a single Node-ESM-loadable file (invariant 2).
+
+## Known caveats
+
+- Cross-platform build variance of ~2 KB still applies; the smoke cap accounts for this band.
+- Stack traces remain fully triageable without source maps because identifier names are preserved.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 	],
 	"scripts": {
 		"clean": "bun -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
-		"build": "bun run clean && bun run scripts/copy-grammars.ts && bun build src/index.ts --outdir dist --target node --format esm --external web-tree-sitter && bun build src/cli/index.ts --outdir dist/cli --target bun --format esm --external bash-parser --splitting && bun run scripts/copy-grammars.ts --to-dist && tsc --emitDeclarationOnly",
+		"build": "bun run clean && bun run scripts/copy-grammars.ts && bun build src/index.ts --outdir dist --target node --format esm --external web-tree-sitter --minify-whitespace --minify-syntax && bun build src/cli/index.ts --outdir dist/cli --target bun --format esm --external bash-parser --splitting && bun run scripts/copy-grammars.ts --to-dist && tsc --emitDeclarationOnly",
 		"typecheck": "tsc --noEmit",
 		"test": "bun test",
 		"lint": "biome lint .",

--- a/tests/smoke/packaging.test.ts
+++ b/tests/smoke/packaging.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 const ROOT = path.resolve(import.meta.dir, '../../');
-const MAIN_BUNDLE_MAX_BYTES = 6.5 * 1024 * 1024;
+const MAIN_BUNDLE_MAX_BYTES = 4.6 * 1024 * 1024;
 
 describe('packaging smoke tests', () => {
 	test('dist/index.js exists', () => {
@@ -38,17 +38,18 @@ describe('packaging smoke tests', () => {
 		expect(typeof plugin.config).toBe('function');
 	});
 
-	test('dist/index.js file size is reasonable (< 6.5MB)', () => {
+	test('dist/index.js file size is reasonable (< 4.6MB)', () => {
 		const stats = Bun.file(path.join(ROOT, 'dist/index.js'));
-		// History: 5MiB → 5.5MiB (#1302 Wave 2 eval-gated skill machinery +
-		// #1263 config-doctor validation) → 6.5MiB here. The 5.5MiB cap became a
-		// merge-queue flake: the unminified bundle sat ~1KB from the limit, and
-		// builds vary ~2KB across platforms/toolchains (Windows ~5,766,141 under;
-		// Linux CI ~5,768,289 over), so the gate flipped pass/fail by runner and
-		// intermittently blocked unrelated PRs. 6.5MiB restores ~1MiB headroom,
-		// far above that variance, while staying tight enough to keep growth
-		// visible in smoke CI. The structural alternative (minify the bundle,
-		// ~43% smaller) is tracked in #1582.
+		// The main bundle is built with identifier-preserving minification
+		// (`--minify-whitespace --minify-syntax`, no `--minify-identifiers`).
+		// 4.6 × 1024 × 1024 = 4,823,449.6 bytes (cap); measured 4,481,025 bytes;
+		// headroom ≈ 342 KB (≈ 167× the ~2 KB cross-platform build variance, well
+		// above the ≥4× requirement). ≥10% growth = 4,481,025 × 1.1 = 4,929,127.5
+		// bytes, which EXCEEDS the 4,823,449.6 cap, so the gate fires on ≥10%
+		// growth (keeps growth visible). Decision: identifier-preserving minify
+		// adopted; full identifier mangling + source maps rejected (General
+		// Council, #1582). Debuggability preserved (identifier names intact; no
+		// source maps needed). #1582 is resolved.
 		expect(stats.size).toBeLessThan(MAIN_BUNDLE_MAX_BYTES);
 		// But should be at least 10KB (non-empty)
 		expect(stats.size).toBeGreaterThan(10 * 1024);

--- a/tests/unit/build/throw-and-verify-located.test.ts
+++ b/tests/unit/build/throw-and-verify-located.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dir, '../../../');
+const BUNDLE = path.join(ROOT, 'dist/index.js');
+
+// FR-007.1 throw-and-verify-located release gate.
+// Verifies the BUILT minified bundle (dist/index.js, built with
+// --minify-whitespace --minify-syntax, NO --minify-identifiers) runs correctly
+// and propagates errors — de-risking --minify-syntax scope/correctness
+// (esbuild #648 precedent). Identifier names are preserved, so function names
+// remain readable in stack traces.
+describe('throw-and-verify-located release gate (FR-007.1)', () => {
+	test('minified bundle: server() runs and returns a plugin with a config hook', async () => {
+		const mod = await import(BUNDLE);
+		expect(mod.default).toEqual(
+			expect.objectContaining({ id: 'opencode-swarm' }),
+		);
+		expect(typeof mod.default.server).toBe('function');
+
+		// Positive runtime-integrity: server() with a real temp directory must
+		// execute the bundled init path and return the plugin object. If
+		// --minify-syntax had broken scope/control-flow, this would fail.
+		const dir = mkdtempSync(path.join(os.tmpdir(), 'ocsm-tv-'));
+		try {
+			const plugin = await mod.default.server({ directory: dir });
+			expect(plugin).toEqual(
+				expect.objectContaining({ config: expect.any(Function) }),
+			);
+			// config() requires a valid config object for a real project; for this
+			// release-gate test we only need to prove the hook survived minification.
+			expect(typeof plugin.config).toBe('function');
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test('minified bundle: server() re-throws when initialization fails (error propagation intact)', async () => {
+		const mod = await import(BUNDLE);
+		// server() wraps init in try/catch and re-throws (src/index.ts OpenCodeSwarm).
+		// Calling with an invalid ctx (no usable directory) forces init to throw,
+		// which the wrapper re-throws — proving the try/catch/rethrow scope survived
+		// minification and errors propagate to the caller.
+		await expect(
+			mod.default.server({ directory: null as never }),
+		).rejects.toThrow();
+	});
+
+	test('minified bundle: a thrown error carries a readable stack with preserved identifiers', async () => {
+		const mod = await import(BUNDLE);
+		let caught: unknown;
+		try {
+			await mod.default.server({ directory: null as never });
+		} catch (err) {
+			caught = err;
+		}
+		expect(caught).toBeInstanceOf(Error);
+		// Assertion 1: a bundled frame with file:line:col (FR-007.1 "reported file/line").
+		// Assertion 2: a preserved function identifier — path-only matches cannot satisfy this,
+		// which proves --minify-identifiers was NOT enabled (the runtime complement to the
+		// distContains grep assertions).
+		const stack = (caught as Error).stack ?? '';
+		expect(stack).toMatch(/dist[\\/]index\.js:\d+:\d+/);
+		expect(stack).toMatch(/\binitializeOpenCodeSwarm\b/);
+	});
+});


### PR DESCRIPTION
Closes #1582

## Summary
- Adopted **identifier-preserving minification** (`--minify-whitespace --minify-syntax`, no `--minify-identifiers`) for the main bundle in `package.json`. The shipped `dist/index.js` drops from ~5.77 MB to ~4.48 MB (**22.3% / ~1.28 MB smaller**), bending the size curve below the smoke cap instead of repeatedly bumping it (5→5.5→6.5 MiB). Identifier names are preserved so user-reported stack traces stay readable **without source maps**.
- Re-tightened the smoke cap `MAIN_BUNDLE_MAX_BYTES` 6.5 MiB → **4.6 MiB** (`tests/smoke/packaging.test.ts`): headroom ~342 KB (~167× the ~2 KB cross-platform variance); ≥10% bundle growth still breaches the cap, keeping growth visible in CI.
- Added a **throw-and-verify-located release gate** (`tests/unit/build/throw-and-verify-located.test.ts`, FR-007) proving the minified bundle runs, re-throws init errors, and preserves identifier names in stack traces (`at initializeOpenCodeSwarm (…\dist\index.js:5783:3037)`).
- Decision was **measurement-gated** (cleared `max(300 KB, 5%)`) and **General-Council-deliberated** (full identifier mangling + source maps rejected as non-viable for a distributed plugin: breaks 13 grep guardrails; no error-service pipeline; users can't be assumed to run `--enable-source-maps`; ~4× map-size tax).
- CLI bundle is untouched.

## Invariant audit
- 1 (plugin init): not touched — `src/index.ts` init path unchanged; only the bun build flags changed.
- 2 (runtime portability): touched — `node --input-type=module -e "await import('./dist/index.js')"` → OK; bundle-node-load/plugin-shape/portability tests pass; no top-level `bun:` imports (bundle-portability). (`scripts/repro-704.mjs` init-deadline script timed out locally and was not completed; the node-import + bundle-test evidence is the substantive portability proof.)
- 3 (subprocesses): not touched — no spawn calls changed.
- 4 (.swarm containment): not touched — no shipped runtime-state changes.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — used per-file `bun test` shell runs (no `scope:all`).
- 7 (test writing): touched — new test file uses `bun:test`, no `mock.module`, <500 lines, follows the writing-tests skill.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched.
- 12 (release/cache): touched — added `docs/releases/pending/minify-main-bundle.md`; version NOT computed; `CHANGELOG.md` / `.release-please-manifest.json` untouched.

## Test plan
- [x] `bun run build` succeeds; minified `dist/index.js` = 4,481,025 bytes (~4.48 MB).
- [x] `node --input-type=module -e "await import('./dist/index.js')"` → dist import OK.
- [x] `bun run typecheck` → exit 0.
- [x] `biome check` on changed files → clean.
- [x] All **13 identifier-grep guardrail assertions** pass against the minified bundle (8 in `full-auto-toolbefore-fail-closed.test.ts` + 5 in `runtime-conformance.test.ts`).
- [x] bundle-node-load / bundle-plugin-shape / bundle-portability pass.
- [x] `tests/smoke/packaging.test.ts` → 10/10 (import, v1 shape, config hook, size < 4.6 MiB, CLI < 2.4 MiB, no postinstall, grammars).
- [x] `bun run package:smoke` → tarball packs + imports + CLI `--help` OK.
- [x] `tests/unit/build/throw-and-verify-located.test.ts` → 3/3 (server runs, re-throws, stack has file:line:col + `initializeOpenCodeSwarm`).

## Pre-existing failure (unrelated, not introduced here)
- `tests/unit/turbo/lean/runtime-conformance.test.ts:457` (`executePhaseComplete … verifyLeanTurboPhaseReady returns ok:true` → `parsed.status === 'blocked'`): a phase_complete lean-gate mock-coverage gap that predates this change. The 5 `distContains` minification assertions in the same file pass. Tracked separately; does not block this PR.

## Operational note
Phase 2 executed under a serial profile after a session reset corrupted the parallel worktree state (resolved via the sanctioned `reset_statuses` unlock). This changed only execution concurrency, not any implementation or the spec. `dist/` is generated and not committed (#1047).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

