### PR TITLE
fix(repo-graph): harden ts js symbol graph

### DIFF
--- a/docs/releases/pending/1526-ts-js-symbol-graph.md
+++ b/docs/releases/pending/1526-ts-js-symbol-graph.md
@@ -1,0 +1,5 @@
+# repo-graph: harden TypeScript and JavaScript symbol extraction
+
+- Added `.mjs` and `.cjs` to the language registry so Node ESM/CJS files route through JavaScript parser support.
+- Extended tree-sitter-backed TS/JS symbol extraction to report side-effect imports and re-export statements, including named/default re-export aliases.
+- Improved async repo-graph output so named/default barrel re-exports produce graph edges, exported alias ranges, and symbol edges for `callers`, `dead_exports`, and `context_pack`.

--- a/docs/releases/pending/1526-ts-js-symbol-graph.md
+++ b/docs/releases/pending/1526-ts-js-symbol-graph.md
@@ -1,5 +1,16 @@
 # repo-graph: harden TypeScript and JavaScript symbol extraction
 
-- Added `.mjs` and `.cjs` to the language registry so Node ESM/CJS files route through JavaScript parser support.
-- Extended tree-sitter-backed TS/JS symbol extraction to report side-effect imports and re-export statements, including named/default re-export aliases.
-- Improved async repo-graph output so named/default barrel re-exports produce graph edges, exported alias ranges, and symbol edges for `callers`, `dead_exports`, and `context_pack`.
+## What changed
+- Added `.mjs` and `.cjs` to the language registry so they route through the JavaScript parser.
+- Extended tree-sitter TS/JS symbol extraction to report side-effect imports and re-export statements (named/default/`export *`/`export * as`).
+- Improved async repo-graph output: re-exports produce graph edges, exported alias ranges, and symbol edges — improving `callers`, `dead_exports`, and `context_pack` accuracy for re-export chains.
+
+## Why
+TypeScript/JavaScript is the most common Swarm target language. Re-export tracking (barrel files, `export *`, default re-exports) was incomplete, causing `dead_exports` false positives and inaccurate `context_pack` spans for re-export-heavy codebases.
+
+## Migration steps
+None. The change is transparent — existing repo-graph queries return more accurate results for re-export patterns.
+
+## Known caveats
+- Star and namespace re-exports (`export *`, `export * as ns`) remain conservative: namespace names appear in `exports` but per-symbol edges to `*` are not synthesized.
+- Statement-level type-only re-exports (`export type { Foo } from`) are recognized as type-only (no runtime edges).

--- a/docs/repo-graph-symbol-graph.md
+++ b/docs/repo-graph-symbol-graph.md
@@ -14,7 +14,7 @@ module: per-edge `usedSymbols` (which exported names an importer actually
 references) and per-node `exportLines` (exported symbol → definition line), plus
 the `repo_map` actions `callers` and `dead_exports`. That work deliberately used
 the module's existing **conservative regex scanner** and covered only TS/JS/Python
-(`SUPPORTED_EXTENSIONS` at `src/tools/repo-graph/builder.ts:106`).
+(`SUPPORTED_EXTENSIONS` at `src/tools/repo-graph/builder.ts:113`).
 
 Two ceilings remain, and they are exactly what an external "codebase memory" MCP
 server claims to break through:

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -13,7 +13,8 @@ export type ImportType =
 	| 'default'
 	| 'namespace'
 	| 'sideeffect'
-	| 'require';
+	| 'require'
+	| 'type';
 
 export interface ImportEdge {
 	/** Importing file (relative, forward-slash). */

--- a/src/lang/profiles.ts
+++ b/src/lang/profiles.ts
@@ -171,9 +171,9 @@ export const LANGUAGE_REGISTRY = new LanguageRegistry();
 
 LANGUAGE_REGISTRY.register({
 	id: 'typescript',
-	displayName: 'TypeScript / JavaScript',
+	displayName: 'TypeScript',
 	tier: 1,
-	extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'],
+	extensions: ['.ts', '.tsx'],
 	treeSitter: {
 		grammarId: 'typescript',
 		wasmFile: 'tree-sitter-typescript.wasm',
@@ -223,6 +223,115 @@ LANGUAGE_REGISTRY.register({
 				// project — the dispatch path requires this to avoid the
 				// false-positive where any plain Node project's package.json
 				// triggers bun:test detection. (PR #825 review finding P1 #2.)
+				name: 'bun:test',
+				detect: 'bun.lock',
+				cmd: 'bun test',
+				priority: 8,
+			},
+			{
+				name: 'mocha',
+				detect: '.mocharc.json',
+				cmd: 'npx mocha',
+				priority: 7,
+			},
+		],
+	},
+	lint: {
+		detectFiles: [
+			'biome.json',
+			'biome.jsonc',
+			'.eslintrc.js',
+			'.eslintrc.json',
+		],
+		linters: [
+			{
+				name: 'biome',
+				detect: 'biome.json',
+				cmd: 'biome check --write .',
+				priority: 10,
+			},
+			{
+				name: 'eslint',
+				detect: '.eslintrc.js',
+				cmd: 'npx eslint --fix .',
+				priority: 9,
+			},
+		],
+	},
+	audit: {
+		detectFiles: ['package.json'],
+		command: 'npm audit --json',
+		outputFormat: 'json',
+	},
+	sast: { nativeRuleSet: 'javascript', semgrepSupport: 'ga' },
+	prompts: {
+		coderConstraints: [
+			'Use strict TypeScript; no implicit any or type assertions without justification',
+			'Prefer async/await over raw Promises; always handle rejections',
+			'Use const/let, never var; prefer immutable data structures',
+			'Follow existing import style (ESM); no require() in .ts files',
+			'Add JSDoc for all exported functions and types',
+		],
+		reviewerChecklist: [
+			'Verify no implicit any or unsafe type casts',
+			'Check async error handling — unhandled Promises are bugs',
+			'Confirm ESM import consistency (no mixed require/import)',
+			'Validate exported API surface matches declared types',
+			'Check for missing null/undefined guards on optional fields',
+		],
+	},
+});
+
+LANGUAGE_REGISTRY.register({
+	id: 'javascript',
+	displayName: 'JavaScript',
+	tier: 1,
+	extensions: ['.js', '.jsx', '.mjs', '.cjs'],
+	treeSitter: {
+		grammarId: 'javascript',
+		wasmFile: 'tree-sitter-javascript.wasm',
+		commentNodes: ['comment', 'line_comment', 'block_comment'],
+	},
+	build: {
+		detectFiles: ['package.json'],
+		commands: [
+			{
+				name: 'bun build',
+				cmd: 'bun run build',
+				detectFile: 'package.json',
+				priority: 10,
+			},
+			{
+				name: 'tsc',
+				cmd: 'npx tsc --noEmit',
+				detectFile: 'tsconfig.json',
+				priority: 9,
+			},
+			{
+				name: 'vite build',
+				cmd: 'npx vite build',
+				detectFile: 'vite.config.ts',
+				priority: 8,
+			},
+		],
+	},
+	test: {
+		detectFiles: [
+			'package.json',
+			'vitest.config.ts',
+			'jest.config.js',
+			'.mocharc.js',
+			'.mocharc.json',
+		],
+		frameworks: [
+			{
+				name: 'vitest',
+				detect: 'vitest.config.ts',
+				cmd: 'bun test',
+				priority: 10,
+			},
+			{ name: 'jest', detect: 'jest.config.js', cmd: 'npx jest', priority: 9 },
+			{
 				name: 'bun:test',
 				detect: 'bun.lock',
 				cmd: 'bun test',

--- a/src/lang/registry.ts
+++ b/src/lang/registry.ts
@@ -22,7 +22,7 @@ export interface LanguageDefinition {
 export const languageDefinitions: LanguageDefinition[] = [
 	{
 		id: 'javascript',
-		extensions: ['.js', '.jsx'],
+		extensions: ['.js', '.jsx', '.mjs', '.cjs'],
 		commentNodes: ['comment', 'line_comment', 'block_comment'],
 	},
 	{

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -34,8 +34,12 @@ export interface FileSymbolFacts {
 	}>;
 	imports: Array<{
 		specifier: string;
-		importType: 'commonjs' | 'named' | 'namespace' | 'default';
+		importType: 'commonjs' | 'named' | 'namespace' | 'default' | 'sideeffect';
 		bindings: Array<{ imported: string; local: string }>;
+		reExport?: boolean;
+		exportedBindings?: Array<{ imported: string; exported: string }>;
+		startLine?: number;
+		endLine?: number;
 	}>;
 	refs: Array<{
 		identifier: string;
@@ -565,15 +569,34 @@ function buildFacts(
 		}
 	}
 
-	const imports: FileSymbolFacts['imports'] = [];
+	const importsWithIndex: Array<{
+		index: number;
+		entry: FileSymbolFacts['imports'][0];
+	}> = [];
+	const addImport = (
+		entry: FileSymbolFacts['imports'][0] | null,
+		node: TsNode,
+	) => {
+		if (!entry) return;
+		importsWithIndex.push({
+			index: node.startIndex,
+			entry: entry.reExport
+				? {
+						...entry,
+						startLine: node.startPosition.row + 1,
+						endLine: node.endPosition.row + 1,
+					}
+				: entry,
+		});
+	};
 	for (const m of importMatches) {
 		const importCap = m.captures.find((c) => c.name === 'import');
 		if (importCap) {
-			const rawText = importCap.node.text.trim();
+			const importNode = asTs(importCap.node);
+			const rawText = importNode.text.trim();
 			// Go block import: `import ( "fmt" "os" )` — find the
 			// import_spec_list child, then iterate its import_spec children.
 			if (grammarId === 'go' && rawText.startsWith('import (')) {
-				const importNode = asTs(importCap.node);
 				const specListNode = importNode.children.find(
 					(c): c is TsNode => c !== null && c.type === 'import_spec_list',
 				);
@@ -581,13 +604,13 @@ function buildFacts(
 					for (const spec of asTs(specListNode).children) {
 						if (spec && spec.type === 'import_spec') {
 							const parsed = parseGoImport(spec.text.trim());
-							if (parsed) imports.push(parsed);
+							addImport(parsed, asTs(spec));
 						}
 					}
 				}
 			} else {
 				const parsed = parseImport(grammarId, rawText);
-				if (parsed) imports.push(parsed);
+				addImport(parsed, importNode);
 			}
 		}
 		// Ruby require/require_relative fallback
@@ -602,7 +625,7 @@ function buildFacts(
 					const callNode = asTs(reqName.node).parent;
 					const rawText = callNode ? callNode.text : asTs(reqSpec.node).text;
 					const parsed = parseRubyRequire(rawText);
-					if (parsed) imports.push(parsed);
+					addImport(parsed, asTs(callNode ?? reqSpec.node));
 				}
 			}
 		}
@@ -614,15 +637,26 @@ function buildFacts(
 				const fnText = asTs(reqName.node).text;
 				if (fnText === 'require') {
 					const specText = asTs(reqSpec.node).text.replace(/['"]/g, '');
-					imports.push({
-						specifier: specText,
-						importType: 'commonjs',
-						bindings: [],
-					});
+					addImport(
+						{
+							specifier: specText,
+							importType: 'commonjs',
+							bindings: [],
+						},
+						asTs(reqName.node),
+					);
 				}
 			}
 		}
 	}
+	if (isEsMGrammar(grammarId)) {
+		for (const exportNode of exportNodes) {
+			addImport(parseImport(grammarId, exportNode.text.trim()), exportNode);
+		}
+	}
+	const imports = importsWithIndex
+		.sort((a, b) => a.index - b.index)
+		.map((item) => item.entry);
 
 	const topLevelDefs = defNodes
 		.filter((d) => isTopLevelDef(d.node, root))
@@ -668,6 +702,61 @@ function safeMatches(
 function parseEsmImport(text: string): FileSymbolFacts['imports'][0] | null {
 	const t = text.trim();
 
+	const sideEffect = t.match(/^import\s+['"]([^'"]+)['"]/);
+	if (sideEffect) {
+		return { specifier: sideEffect[1], importType: 'sideeffect', bindings: [] };
+	}
+
+	const reExportAllAs = t.match(
+		/^export\s+\*\s+as\s+([A-Za-z_$][\w$]*)\s+from\s+['"]([^'"]+)['"]/,
+	);
+	if (reExportAllAs) {
+		return {
+			specifier: reExportAllAs[2],
+			importType: 'namespace',
+			bindings: [{ imported: '*', local: reExportAllAs[1] }],
+			reExport: true,
+			exportedBindings: [{ imported: '*', exported: reExportAllAs[1] }],
+		};
+	}
+
+	const reExportAll = t.match(/^export\s+\*\s+from\s+['"]([^'"]+)['"]/);
+	if (reExportAll) {
+		return {
+			specifier: reExportAll[1],
+			importType: 'namespace',
+			bindings: [],
+			reExport: true,
+		};
+	}
+
+	const namedReExport = t.match(
+		/^export\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/,
+	);
+	if (namedReExport) {
+		const bindings: Array<{ imported: string; local: string }> = [];
+		const exportedBindings: Array<{ imported: string; exported: string }> = [];
+		for (const rawPart of namedReExport[1].split(',')) {
+			const p = rawPart.trim();
+			if (!p) continue;
+			if (/^type\s+/.test(p)) continue;
+			const alias = p.match(/^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/);
+			const imported = alias ? alias[1] : p;
+			const exported = alias ? alias[2] : p;
+			if (!/^[A-Za-z_$][\w$]*$/.test(imported)) continue;
+			if (!/^[A-Za-z_$][\w$]*$/.test(exported)) continue;
+			bindings.push({ imported, local: exported });
+			exportedBindings.push({ imported, exported });
+		}
+		return {
+			specifier: namedReExport[2],
+			importType: 'named',
+			bindings,
+			reExport: true,
+			exportedBindings,
+		};
+	}
+
 	// Strip optional `type` qualifier: "import type { ... }" → "import { ... }"
 	// Track whether it was a type-only import (all bindings are type-only).
 	const isTypeOnlyImport = /^import\s+type\s/.test(t);
@@ -688,14 +777,17 @@ function parseEsmImport(text: string): FileSymbolFacts['imports'][0] | null {
 		for (const part of named[1].split(',')) {
 			const p = part.trim();
 			if (!p) continue;
+			if (/^type\s+/.test(p)) continue;
 			// Strip inline `type` modifier: "type Foo" → "Foo"
 			const stripped = p.replace(/^type\s+/, '');
 			// If the entire binding is just `type` keyword (degenerate), skip it
 			if (!stripped) continue;
-			const alias = stripped.match(/^(\w+)\s+as\s+(\w+)$/);
+			const alias = stripped.match(
+				/^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/,
+			);
 			if (alias) {
 				bindings.push({ imported: alias[1], local: alias[2] });
-			} else {
+			} else if (/^[A-Za-z_$][\w$]*$/.test(stripped)) {
 				bindings.push({ imported: stripped, local: stripped });
 			}
 		}
@@ -706,7 +798,7 @@ function parseEsmImport(text: string): FileSymbolFacts['imports'][0] | null {
 	// or `import <Default>, * as <ns> from '<spec>'`.
 	// Must be checked before the default-only and namespace-only branches.
 	const combined = withoutTypeQualifier.match(
-		/^import\s+(\w+)\s*,\s*\*\s+as\s+(\w+)\s+from\s+['"]([^'"]+)['"]/,
+		/^import\s+([A-Za-z_$][\w$]*)\s*,\s*\*\s+as\s+([A-Za-z_$][\w$]*)\s+from\s+['"]([^'"]+)['"]/,
 	);
 	if (combined) {
 		return {
@@ -720,7 +812,7 @@ function parseEsmImport(text: string): FileSymbolFacts['imports'][0] | null {
 	}
 
 	const combinedNamed = withoutTypeQualifier.match(
-		/^import\s+(\w+)\s*,\s*\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/,
+		/^import\s+([A-Za-z_$][\w$]*)\s*,\s*\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/,
 	);
 	if (combinedNamed) {
 		if (isTypeOnlyImport) {
@@ -736,19 +828,24 @@ function parseEsmImport(text: string): FileSymbolFacts['imports'][0] | null {
 		for (const part of combinedNamed[2].split(',')) {
 			const p = part.trim();
 			if (!p) continue;
+			if (/^type\s+/.test(p)) continue;
 			const stripped = p.replace(/^type\s+/, '');
 			if (!stripped) continue;
-			const alias = stripped.match(/^(\w+)\s+as\s+(\w+)$/);
+			const alias = stripped.match(
+				/^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/,
+			);
 			if (alias) {
 				bindings.push({ imported: alias[1], local: alias[2] });
-			} else {
+			} else if (/^[A-Za-z_$][\w$]*$/.test(stripped)) {
 				bindings.push({ imported: stripped, local: stripped });
 			}
 		}
 		return { specifier: combinedNamed[3], importType: 'named', bindings };
 	}
 
-	const ns = t.match(/^import\s+\*\s+as\s+(\w+)\s+from\s+['"]([^'"]+)['"]/);
+	const ns = t.match(
+		/^import\s+\*\s+as\s+([A-Za-z_$][\w$]*)\s+from\s+['"]([^'"]+)['"]/,
+	);
 	if (ns) {
 		return {
 			specifier: ns[2],
@@ -757,7 +854,7 @@ function parseEsmImport(text: string): FileSymbolFacts['imports'][0] | null {
 		};
 	}
 
-	const def = t.match(/^import\s+(\w+)\s+from\s+['"]([^'"]+)['"]/);
+	const def = t.match(/^import\s+([A-Za-z_$][\w$]*)\s+from\s+['"]([^'"]+)['"]/);
 	if (def) {
 		return {
 			specifier: def[2],

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -34,7 +34,13 @@ export interface FileSymbolFacts {
 	}>;
 	imports: Array<{
 		specifier: string;
-		importType: 'commonjs' | 'named' | 'namespace' | 'default' | 'sideeffect';
+		importType:
+			| 'commonjs'
+			| 'named'
+			| 'namespace'
+			| 'default'
+			| 'sideeffect'
+			| 'type';
 		bindings: Array<{ imported: string; local: string }>;
 		reExport?: boolean;
 		exportedBindings?: Array<{ imported: string; exported: string }>;
@@ -730,6 +736,18 @@ function parseEsmImport(text: string): FileSymbolFacts['imports'][0] | null {
 		};
 	}
 
+	const namedTypeReExport = t.match(
+		/^export\s+type\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/,
+	);
+	if (namedTypeReExport) {
+		return {
+			specifier: namedTypeReExport[2],
+			importType: 'type',
+			bindings: [],
+			reExport: true,
+		};
+	}
+
 	const namedReExport = t.match(
 		/^export\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/,
 	);
@@ -801,6 +819,13 @@ function parseEsmImport(text: string): FileSymbolFacts['imports'][0] | null {
 		/^import\s+([A-Za-z_$][\w$]*)\s*,\s*\*\s+as\s+([A-Za-z_$][\w$]*)\s+from\s+['"]([^'"]+)['"]/,
 	);
 	if (combined) {
+		if (isTypeOnlyImport) {
+			return {
+				specifier: combined[3],
+				importType: 'named',
+				bindings: [],
+			};
+		}
 		return {
 			specifier: combined[3],
 			importType: 'named',

--- a/src/tools/imports.ts
+++ b/src/tools/imports.ts
@@ -95,7 +95,13 @@ function isBinaryFile(filePath: string, buffer: Buffer): boolean {
 interface ImportMatch {
 	line: number;
 	imports: string;
-	importType: 'default' | 'named' | 'namespace' | 'require' | 'sideeffect';
+	importType:
+		| 'default'
+		| 'named'
+		| 'namespace'
+		| 'require'
+		| 'sideeffect'
+		| 'type';
 	raw: string;
 }
 
@@ -289,7 +295,13 @@ interface ConsumerFile {
 	file: string;
 	line: number;
 	imports: string;
-	importType: 'default' | 'named' | 'namespace' | 'require' | 'sideeffect';
+	importType:
+		| 'default'
+		| 'named'
+		| 'namespace'
+		| 'require'
+		| 'sideeffect'
+		| 'type';
 	raw: string;
 }
 

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -518,7 +518,13 @@ interface ParsedImport {
 	/** The module specifier (e.g., './foo', 'lodash') */
 	specifier: string;
 	/** The type of import */
-	importType: 'default' | 'named' | 'namespace' | 'require' | 'sideeffect';
+	importType:
+		| 'default'
+		| 'named'
+		| 'namespace'
+		| 'require'
+		| 'sideeffect'
+		| 'type';
 	/** Named imported symbols when statically detectable */
 	importedSymbols: string[];
 	/** Alias-aware imported→local bindings for usage attribution */
@@ -1407,11 +1413,39 @@ export async function scanFileAsync(
 		exportLines[d.name] = d.startLine;
 		exportRanges[d.name] = { startLine: d.startLine, endLine: d.endLine };
 	}
+	const exportsSet = new Set(exports);
 	for (const imp of facts.imports) {
 		if (!imp.reExport || !imp.exportedBindings) continue;
 		for (const binding of imp.exportedBindings) {
-			if (binding.imported === '*') continue;
-			if (!exports.includes(binding.exported)) exports.push(binding.exported);
+			if (binding.imported === '*') {
+				// Include namespace re-export name in exports for dead_exports
+				// visibility, but skip per-symbol edge creation (conservative).
+				if (!exportsSet.has(binding.exported)) {
+					exportsSet.add(binding.exported);
+					exports.push(binding.exported);
+				}
+				if (
+					imp.startLine !== undefined &&
+					exportLines[binding.exported] === undefined
+				) {
+					exportLines[binding.exported] = imp.startLine;
+				}
+				if (
+					imp.startLine !== undefined &&
+					imp.endLine !== undefined &&
+					exportRanges[binding.exported] === undefined
+				) {
+					exportRanges[binding.exported] = {
+						startLine: imp.startLine,
+						endLine: imp.endLine,
+					};
+				}
+				continue;
+			}
+			if (!exportsSet.has(binding.exported)) {
+				exportsSet.add(binding.exported);
+				exports.push(binding.exported);
+			}
 			if (
 				imp.startLine !== undefined &&
 				exportLines[binding.exported] === undefined

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -135,6 +135,14 @@ for (const profile of LANGUAGE_REGISTRY.getAll()) {
 		EXTENSION_TO_LANGUAGE[ext] = profile.treeSitter.grammarId;
 	}
 }
+const JS_FAMILY_EXTENSION_TO_LANGUAGE: Record<string, string> = {
+	'.js': 'javascript',
+	'.jsx': 'javascript',
+	'.mjs': 'javascript',
+	'.cjs': 'javascript',
+	'.ts': 'typescript',
+	'.tsx': 'tsx',
+};
 
 // ============ Graph Node / Edge Operations ============
 
@@ -1148,6 +1156,8 @@ function toModuleName(filePath: string, workspaceRoot: string): string {
  */
 function getLanguage(filePath: string): string {
 	const ext = path.extname(filePath).toLowerCase();
+	const jsFamilyLanguage = JS_FAMILY_EXTENSION_TO_LANGUAGE[ext];
+	if (jsFamilyLanguage) return jsFamilyLanguage;
 	return EXTENSION_TO_LANGUAGE[ext] ?? 'unknown';
 }
 
@@ -1397,6 +1407,29 @@ export async function scanFileAsync(
 		exportLines[d.name] = d.startLine;
 		exportRanges[d.name] = { startLine: d.startLine, endLine: d.endLine };
 	}
+	for (const imp of facts.imports) {
+		if (!imp.reExport || !imp.exportedBindings) continue;
+		for (const binding of imp.exportedBindings) {
+			if (binding.imported === '*') continue;
+			if (!exports.includes(binding.exported)) exports.push(binding.exported);
+			if (
+				imp.startLine !== undefined &&
+				exportLines[binding.exported] === undefined
+			) {
+				exportLines[binding.exported] = imp.startLine;
+			}
+			if (
+				imp.startLine !== undefined &&
+				imp.endLine !== undefined &&
+				exportRanges[binding.exported] === undefined
+			) {
+				exportRanges[binding.exported] = {
+					startLine: imp.startLine,
+					endLine: imp.endLine,
+				};
+			}
+		}
+	}
 
 	// Derive imports list from tree-sitter facts
 	const imports = facts.imports.map((i) => i.specifier);
@@ -1441,16 +1474,20 @@ export async function scanFileAsync(
 		);
 
 		if (resolvedTarget !== null) {
-			// A binding's imported symbol is "used" if its local name appears
-			// in facts.refs (i.e. the identifier is referenced in the body).
-			const usedBindings = imp.bindings.filter((b) =>
-				facts.refs.some((r) => r.identifier === b.local),
-			);
+			// Re-exports expose the imported symbol to downstream consumers, so
+			// named re-export bindings count as used even without a body ref.
+			const usedBindings = imp.reExport
+				? imp.bindings
+				: imp.bindings.filter((b) =>
+						facts.refs.some((r) => r.identifier === b.local),
+					);
 			// Match sync buildWorkspaceGraph semantics: namespace and require
 			// imports omit usedSymbols entirely; named/default imports always
 			// include the array (possibly empty) so toEqual comparisons are stable.
 			const includeUsedSymbols =
-				edgeImportType !== 'namespace' && edgeImportType !== 'require';
+				edgeImportType !== 'namespace' &&
+				edgeImportType !== 'require' &&
+				edgeImportType !== 'sideeffect';
 			const usedSymbols = includeUsedSymbols
 				? usedBindings.map((b) => b.imported)
 				: undefined;
@@ -1485,6 +1522,7 @@ export async function scanFileAsync(
 		{ specifier: string; imported: string }
 	>();
 	for (const imp of facts.imports) {
+		if (imp.reExport) continue;
 		for (const binding of imp.bindings) {
 			localToImported.set(binding.local, {
 				specifier: imp.specifier,
@@ -1523,6 +1561,35 @@ export async function scanFileAsync(
 			toFile: resolvedTarget,
 			toSymbol: mapping.imported,
 		});
+	}
+	for (const imp of facts.imports) {
+		if (!imp.reExport || !imp.exportedBindings) continue;
+		const resolvedTarget = resolveModuleSpecifier(
+			absoluteRoot,
+			filePath,
+			imp.specifier,
+		);
+		if (!resolvedTarget) continue;
+		for (const binding of imp.exportedBindings) {
+			if (binding.imported === '*') continue;
+			const key =
+				filePath +
+				'\u0000' +
+				binding.exported +
+				'\u0000' +
+				resolvedTarget +
+				'\u0000' +
+				binding.imported;
+			if (seenSymbolEdgeKeys.has(key)) continue;
+			seenSymbolEdgeKeys.add(key);
+
+			symbolEdges.push({
+				fromFile: filePath,
+				fromSymbol: binding.exported,
+				toFile: resolvedTarget,
+				toSymbol: binding.imported,
+			});
+		}
 	}
 
 	return {

--- a/src/tools/repo-graph/types.ts
+++ b/src/tools/repo-graph/types.ts
@@ -225,6 +225,7 @@ export const IMPORT_TYPE_VALUES = [
 	'namespace',
 	'require',
 	'sideeffect',
+	'type',
 ] as const;
 export type ImportType = (typeof IMPORT_TYPE_VALUES)[number];
 

--- a/tests/unit/lang/registry.test.ts
+++ b/tests/unit/lang/registry.test.ts
@@ -21,6 +21,11 @@ describe('Language Registry', () => {
 			expect(lang?.id).toBe('javascript');
 		});
 
+		it('should return language for Node ESM/CJS JavaScript files', () => {
+			expect(getLanguageForExtension('.mjs')?.id).toBe('javascript');
+			expect(getLanguageForExtension('.cjs')?.id).toBe('javascript');
+		});
+
 		it('should return language for .ts files', () => {
 			const lang = getLanguageForExtension('.ts');
 			expect(lang).toBeDefined();
@@ -165,6 +170,8 @@ describe('Language Registry', () => {
 	describe('isSupportedFile', () => {
 		it('should return true for supported extensions', () => {
 			expect(isSupportedFile('file.js')).toBe(true);
+			expect(isSupportedFile('file.mjs')).toBe(true);
+			expect(isSupportedFile('file.cjs')).toBe(true);
 			expect(isSupportedFile('file.ts')).toBe(true);
 			expect(isSupportedFile('file.tsx')).toBe(true);
 			expect(isSupportedFile('file.py')).toBe(true);
@@ -219,6 +226,17 @@ describe('Language Registry', () => {
 			try {
 				const parser = await getParserForFile('test.jsx');
 				expect(parser === null || typeof parser === 'object').toBe(true);
+			} catch {
+				expect(false).toBe(true);
+			}
+		});
+
+		it('should attempt to load grammar for .mjs and .cjs files', async () => {
+			try {
+				const mjsParser = await getParserForFile('test.mjs');
+				const cjsParser = await getParserForFile('test.cjs');
+				expect(mjsParser === null || typeof mjsParser === 'object').toBe(true);
+				expect(cjsParser === null || typeof cjsParser === 'object').toBe(true);
 			} catch {
 				expect(false).toBe(true);
 			}

--- a/tests/unit/lang/registry.test.ts
+++ b/tests/unit/lang/registry.test.ts
@@ -235,8 +235,12 @@ describe('Language Registry', () => {
 			try {
 				const mjsParser = await getParserForFile('test.mjs');
 				const cjsParser = await getParserForFile('test.cjs');
-				expect(mjsParser === null || typeof mjsParser === 'object').toBe(true);
-				expect(cjsParser === null || typeof cjsParser === 'object').toBe(true);
+				if (mjsParser !== null) {
+					expect(typeof mjsParser.parse).toBe('function');
+				}
+				if (cjsParser !== null) {
+					expect(typeof cjsParser.parse).toBe('function');
+				}
 			} catch {
 				expect(false).toBe(true);
 			}

--- a/tests/unit/lang/symbol-graph-js-family.test.ts
+++ b/tests/unit/lang/symbol-graph-js-family.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { clearParserCache } from '../../../src/lang/runtime';
+import { extractFileSymbols } from '../../../src/lang/symbol-graph';
+
+describe('extractFileSymbols TS/JS family imports and re-exports', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('captures side-effect imports and re-export statements as import facts', async () => {
+		const facts = await extractFileSymbols(
+			'typescript',
+			[
+				`import './setup';`,
+				`export { Foo as Bar, default as DefaultThing } from './barrel-source';`,
+				`export * from './everything';`,
+				`export * as ns from './namespace';`,
+			].join('\n'),
+		);
+
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toEqual([
+			{
+				specifier: './setup',
+				importType: 'sideeffect',
+				bindings: [],
+			},
+			{
+				specifier: './barrel-source',
+				importType: 'named',
+				bindings: [
+					{ imported: 'Foo', local: 'Bar' },
+					{ imported: 'default', local: 'DefaultThing' },
+				],
+				reExport: true,
+				startLine: 2,
+				endLine: 2,
+				exportedBindings: [
+					{ imported: 'Foo', exported: 'Bar' },
+					{ imported: 'default', exported: 'DefaultThing' },
+				],
+			},
+			{
+				specifier: './everything',
+				importType: 'namespace',
+				bindings: [],
+				reExport: true,
+				startLine: 3,
+				endLine: 3,
+			},
+			{
+				specifier: './namespace',
+				importType: 'namespace',
+				bindings: [{ imported: '*', local: 'ns' }],
+				reExport: true,
+				startLine: 4,
+				endLine: 4,
+				exportedBindings: [{ imported: '*', exported: 'ns' }],
+			},
+		]);
+	});
+
+	test('preserves type-only imports as non-runtime bindings', async () => {
+		const facts = await extractFileSymbols(
+			'typescript',
+			`import type { Shape } from './types';
+import { type OnlyType, run as execute } from './runtime';
+export function call() { execute(); }`,
+		);
+
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toEqual([
+			{ specifier: './types', importType: 'named', bindings: [] },
+			{
+				specifier: './runtime',
+				importType: 'named',
+				bindings: [{ imported: 'run', local: 'execute' }],
+			},
+		]);
+	});
+
+	test('extracts TSX component-style functions with JSX references', async () => {
+		const facts = await extractFileSymbols(
+			'tsx',
+			`import { Button as UIButton } from './button';
+export function Panel() {
+	return <UIButton />;
+}`,
+		);
+
+		expect(facts).not.toBeNull();
+		expect(facts!.defs.find((d) => d.name === 'Panel')).toMatchObject({
+			kind: 'function',
+			exported: true,
+			startLine: 2,
+			endLine: 4,
+		});
+		expect(facts!.imports).toEqual([
+			{
+				specifier: './button',
+				importType: 'named',
+				bindings: [{ imported: 'Button', local: 'UIButton' }],
+			},
+		]);
+		expect(facts!.refs.some((r) => r.identifier === 'UIButton')).toBe(true);
+	});
+
+	test('captures JavaScript identifiers that contain dollar signs', async () => {
+		const facts = await extractFileSymbols(
+			'javascript',
+			`import $default, { $api as api$ } from './runtime';
+export function call$() {
+	return api$($default);
+}`,
+		);
+
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toEqual([
+			{
+				specifier: './runtime',
+				importType: 'named',
+				bindings: [
+					{ imported: 'default', local: '$default' },
+					{ imported: '$api', local: 'api$' },
+				],
+			},
+		]);
+		expect(facts!.defs.find((d) => d.name === 'call$')).toMatchObject({
+			kind: 'function',
+			exported: true,
+		});
+	});
+});

--- a/tests/unit/lang/symbol-graph-js-family.test.ts
+++ b/tests/unit/lang/symbol-graph-js-family.test.ts
@@ -109,9 +109,9 @@ export function Panel() {
 		const facts = await extractFileSymbols(
 			'javascript',
 			`import $default, { $api as api$ } from './runtime';
-export function call$() {
-	return api$($default);
-}`,
+ export function call$() {
+ 	return api$($default);
+ }`,
 		);
 
 		expect(facts).not.toBeNull();
@@ -129,5 +129,25 @@ export function call$() {
 			kind: 'function',
 			exported: true,
 		});
+	});
+
+	test('CRLF line endings produce correct startLine/endLine (issue #1526)', async () => {
+		const crlfSource = [
+			`export { foo } from './bar';`,
+			`export { baz } from './qux';`,
+		].join('\r\n');
+
+		const lfSource = crlfSource.replace(/\r\n/g, '\n');
+
+		const crlfFacts = await extractFileSymbols('typescript', crlfSource);
+		const lfFacts = await extractFileSymbols('typescript', lfSource);
+
+		expect(crlfFacts).not.toBeNull();
+		expect(lfFacts).not.toBeNull();
+
+		// tree-sitter normalizes CRLF, so line ranges should match LF source
+		expect(crlfFacts!.imports).toEqual(lfFacts!.imports);
+		expect(crlfFacts!.defs).toEqual(lfFacts!.defs);
+		expect(crlfFacts!.refs).toEqual(lfFacts!.refs);
 	});
 });

--- a/tests/unit/lang/symbol-graph.test.ts
+++ b/tests/unit/lang/symbol-graph.test.ts
@@ -181,7 +181,7 @@ describe('extractFileSymbols — regression: reviewer bugs', () => {
 		expect(fooImport!.bindings).toEqual([]);
 	});
 
-	test('bug c.2: import { type Bar } from "./m" strips the type keyword in bindings', async () => {
+	test('bug c.2: import { type Bar } from "./m" omits type-only runtime bindings', async () => {
 		const source = "import { type Bar } from './m';";
 
 		const facts = await extractFileSymbols('typescript', source);
@@ -190,8 +190,8 @@ describe('extractFileSymbols — regression: reviewer bugs', () => {
 		const barImport = facts!.imports.find((i) => i.specifier === './m');
 		expect(barImport).toBeDefined();
 		expect(barImport!.importType).toBe('named');
-		// The 'type' keyword is stripped; Bar is captured correctly
-		expect(barImport!.bindings).toEqual([{ imported: 'Bar', local: 'Bar' }]);
+		// Type-only imports do not create runtime binding facts.
+		expect(barImport!.bindings).toEqual([]);
 	});
 
 	// -------------------------------------------------------------------------

--- a/tests/unit/tools/repo-graph-call-graph.test.ts
+++ b/tests/unit/tools/repo-graph-call-graph.test.ts
@@ -9,6 +9,7 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fsSync from 'node:fs';
+import os from 'node:os';
 import * as path from 'node:path';
 
 import {
@@ -56,7 +57,7 @@ describe('builder: usedSymbols + exportLines', () => {
 	let workspacePath: string;
 
 	beforeEach(() => {
-		tempDir = fsSync.mkdtempSync(path.join(process.cwd(), 'repo-graph-cg-'));
+		tempDir = fsSync.mkdtempSync(path.join(os.tmpdir(), 'repo-graph-cg-'));
 		workspacePath = path.relative(process.cwd(), tempDir);
 	});
 
@@ -214,7 +215,7 @@ describe('async builder usedSymbols (buildWorkspaceGraphAsync)', () => {
 
 	beforeEach(() => {
 		tempDir = fsSync.mkdtempSync(
-			path.join(process.cwd(), 'repo-graph-cg-async-'),
+			path.join(os.tmpdir(), 'repo-graph-cg-async-'),
 		);
 		workspacePath = path.relative(process.cwd(), tempDir);
 	});

--- a/tests/unit/tools/repo-graph-call-graph.test.ts
+++ b/tests/unit/tools/repo-graph-call-graph.test.ts
@@ -267,20 +267,19 @@ describe('async builder usedSymbols (buildWorkspaceGraphAsync)', () => {
 		expect(edge?.usedSymbols).toBeUndefined();
 	});
 
-	test('named re-exports: async tree-sitter path does not produce re-export edges (documented divergence)', async () => {
+	test('named re-exports treat re-exported symbols as used in the async tree-sitter path', async () => {
 		write('lib.ts', `export const a = 1;\nexport const b = 2;\n`);
 		write('barrel.ts', `export { a, b } from './lib';\n`);
 
 		const graph = await buildWorkspaceGraphAsync(workspacePath);
-		// The async tree-sitter builder does not emit edges for re-export statements
-		// (`export { a, b } from './lib'`). This is a documented divergence from the
-		// sync regex-based builder which does produce an edge with usedSymbols=['a','b'].
-		// Re-export resolution requires resolving the re-exported symbols through the
-		// source module, which tree-sitter facts do not surface at the edge-construction layer.
 		const reExportEdge = graph.edges.find(
 			(e) => e.source.endsWith('barrel.ts') && e.target.endsWith('lib.ts'),
 		);
-		expect(reExportEdge).toBeUndefined();
+		expect(reExportEdge).toMatchObject({
+			importType: 'named',
+			importedSymbols: ['a', 'b'],
+			usedSymbols: ['a', 'b'],
+		});
 	});
 
 	test('named default exports: edge uses "default" sentinel; async node exports normalize to "default"', async () => {

--- a/tests/unit/tools/repo-graph-js-family.test.ts
+++ b/tests/unit/tools/repo-graph-js-family.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	buildWorkspaceGraphAsync,
+	clearCache,
+	getContextPack,
+	getDeadExports,
+} from '../../../src/tools/repo-graph';
+
+describe('repo-graph async builder TS/JS family behavior', () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await fs.realpath(
+			await fs.mkdtemp(path.join(os.tmpdir(), 'repo-graph-js-family-')),
+		);
+	});
+
+	afterEach(async () => {
+		clearCache(tempDir);
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	async function write(rel: string, content: string): Promise<void> {
+		const full = path.join(tempDir, rel);
+		await fs.mkdir(path.dirname(full), { recursive: true });
+		await fs.writeFile(full, content);
+	}
+
+	test('named re-exports create async edges and protect live exports from dead_exports', async () => {
+		await write(
+			'src/lib.ts',
+			`export function used() { return 1; }
+export function dead() { return 0; }`,
+		);
+		await write('src/barrel.ts', `export { used as publicUsed } from './lib';`);
+		await write(
+			'src/app.ts',
+			`import { publicUsed } from './barrel';
+export function main() { return publicUsed(); }`,
+		);
+
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const barrelEdge = graph.edges.find(
+			(e) => e.source.endsWith('barrel.ts') && e.target.endsWith('lib.ts'),
+		);
+		expect(barrelEdge).toMatchObject({
+			importType: 'named',
+			importedSymbols: ['used'],
+			usedSymbols: ['used'],
+		});
+
+		const barrelNode = Object.values(graph.nodes).find((n) =>
+			n.filePath.endsWith('barrel.ts'),
+		);
+		expect(barrelNode?.exports).toEqual(['publicUsed']);
+		expect(barrelNode?.exportRanges?.publicUsed).toEqual({
+			startLine: 1,
+			endLine: 1,
+		});
+
+		const dead = getDeadExports(graph);
+		expect(dead.candidates).toContainEqual({
+			file: 'src/lib.ts',
+			symbol: 'dead',
+			line: 2,
+			importerCount: 1,
+		});
+		expect(dead.candidates).not.toContainEqual(
+			expect.objectContaining({ file: 'src/lib.ts', symbol: 'used' }),
+		);
+	});
+
+	test('context_pack follows a default re-export barrel to the original target', async () => {
+		await write(
+			'src/widget.ts',
+			`export default function Widget() {
+	return 1;
+}`,
+		);
+		await write(
+			'src/index.ts',
+			`export { default as PublicWidget } from './widget';`,
+		);
+		await write(
+			'src/page.ts',
+			`import { PublicWidget } from './index';
+export function render() {
+	return PublicWidget();
+}`,
+		);
+
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const pack = getContextPack(graph, 'src/widget.ts', 'default');
+		expect(pack.schemaSupported).toBe(true);
+		expect(pack.spans).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					file: expect.stringMatching(/widget\.ts$/),
+					symbol: 'default',
+				}),
+				expect.objectContaining({
+					file: expect.stringMatching(/index\.ts$/),
+					symbol: 'PublicWidget',
+				}),
+				expect.objectContaining({
+					file: expect.stringMatching(/page\.ts$/),
+					symbol: 'render',
+				}),
+			]),
+		);
+	});
+
+	test('side-effect imports create conservative edges without usedSymbols', async () => {
+		await write('src/setup.ts', `export function init() { return 1; }`);
+		await write(
+			'src/app.ts',
+			`import './setup';
+export function main() { return 0; }`,
+		);
+
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const edge = graph.edges.find(
+			(e) => e.source.endsWith('app.ts') && e.target.endsWith('setup.ts'),
+		);
+		expect(edge).toMatchObject({
+			importType: 'sideeffect',
+			importedSymbols: [],
+		});
+		expect(edge?.usedSymbols).toBeUndefined();
+
+		const dead = getDeadExports(graph);
+		expect(dead.candidates).not.toContainEqual(
+			expect.objectContaining({ file: 'src/setup.ts', symbol: 'init' }),
+		);
+	});
+
+	test('async graph extracts useful TSX/JSX ranges and symbol edges', async () => {
+		await write(
+			'src/Button.tsx',
+			`export function Button() {
+	return <button />;
+}`,
+		);
+		await write(
+			'src/Panel.tsx',
+			`import { Button as UIButton } from './Button';
+export function Panel() {
+	const rendered = UIButton();
+	return <section>{rendered}</section>;
+}`,
+		);
+
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const buttonNode = Object.values(graph.nodes).find((n) =>
+			n.filePath.endsWith('Button.tsx'),
+		);
+		expect(buttonNode?.exports).toEqual(['Button']);
+		expect(buttonNode?.language).toBe('tsx');
+		expect(buttonNode?.exportRanges?.Button).toEqual({
+			startLine: 1,
+			endLine: 3,
+		});
+		expect(graph.symbolEdges).toContainEqual(
+			expect.objectContaining({
+				fromSymbol: 'Panel',
+				toSymbol: 'Button',
+			}),
+		);
+	});
+
+	test('async graph routes JSX files through the JavaScript grammar', async () => {
+		await write(
+			'src/Card.jsx',
+			`export function Card() {
+	return <article />;
+}`,
+		);
+		await write(
+			'src/CardPanel.jsx',
+			`import { Card as UICard } from './Card';
+export function CardPanel() {
+	return <UICard />;
+}`,
+		);
+
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const cardNode = Object.values(graph.nodes).find((n) =>
+			n.filePath.endsWith('Card.jsx'),
+		);
+		expect(cardNode?.language).toBe('javascript');
+		expect(cardNode?.exports).toEqual(['Card']);
+		expect(cardNode?.exportRanges?.Card).toEqual({
+			startLine: 1,
+			endLine: 3,
+		});
+		expect(graph.symbolEdges).toContainEqual(
+			expect.objectContaining({
+				fromSymbol: 'CardPanel',
+				toSymbol: 'Card',
+			}),
+		);
+	});
+});


### PR DESCRIPTION
Closes #1526

## Summary

- Add `.mjs`/`.cjs` JavaScript registry support and route repo-graph JS-family extensions to the correct tree-sitter grammars.
- Teach symbol facts and async repo-graph construction about side-effect imports and ESM re-exports, including named/default barrel exports, ranges, and symbol edges.
- Add focused TS/JS/TSX/JSX regression coverage for registry lookup, extractor facts, `dead_exports`, `context_pack`, async symbol edges, type-only imports, side-effect imports, and `$` identifiers.
- Address review feedback: namespace re-export names in exports, type-only combined import guard, `export type {}` recognition, grammar-id alignment, CRLF test, and doc/fragment fixes.

**Note:** This PR delivers re-export tracking, `.mjs`/`.cjs` routing, side-effect imports, and type-only import hardening. Remaining #1526 criteria (direct-call edges, constructor/class refs, React JSX detection, dynamic-import caveats) are tracked as follow-up sub-tasks.

## Invariant audit

- 1 (plugin init):       not touched - no startup path or manifest registration changes.
- 2 (runtime portability): touched - source changes were validated with `bun run build` and `node --input-type=module -e "await import('./dist/index.js')"`.
- 3 (subprocesses):       not touched - no subprocess code changed.
- 4 (.swarm containment): not touched - no runtime state path changes.
- 5 (plan durability):    not touched - no plan ledger/projection code changed.
- 6 (test_runner safety): not touched - validation used shell commands, not broad `test_runner`.
- 7 (test writing):       touched - new/updated tests use `bun:test`, focused files under 500 lines, `os.tmpdir()` temp fixtures, and no new `mock.module`.
- 8 (session state):      not touched - no session/global state changed.
- 9 (guardrails/retry):   not touched - no retry/guardrail code changed.
- 10 (chat/system msg):   not touched - no chat/system hook code changed.
- 11 (tool registration): not touched - no tools, commands, agents, or maps changed; `bun run drift:check` passed.
- 12 (release/cache):     touched - added `docs/releases/pending/1526-ts-js-symbol-graph.md`.

## Test plan

- [x] `bun run typecheck` - exit 0
- [x] `bun --smol test tests/unit/lang/symbol-graph.test.ts tests/unit/lang/symbol-graph-js-family.test.ts tests/unit/lang/registry.test.ts tests/unit/tools/repo-graph-js-family.test.ts tests/unit/tools/repo-graph-call-graph.test.ts --timeout 120000` - 114 pass, 0 fail
- [x] `bun run build` - succeeds
- [x] `node --input-type=module -e "await import('./dist/index.js')"` - dist import OK
- [x] `biome check` - clean
- [x] `git diff --check` - no whitespace errors

## Notes

Star and namespace re-exports remain conservative by design: they create namespace edges but do not synthesize per-symbol ranges or symbol edges.
