### PR TITLE
fix(knowledge): preserve linked injection after optional read failures

### DIFF
--- a/docs/releases/pending/fix-linked-knowledge-injection.md
+++ b/docs/releases/pending/fix-linked-knowledge-injection.md
@@ -1,0 +1,1 @@
+Fix linked knowledge auto-injection so optional run-memory lookup failures no longer suppress lessons retrieved from a shared `/swarm link` store.

--- a/src/hooks/knowledge-injector.ts
+++ b/src/hooks/knowledge-injector.ts
@@ -805,8 +805,18 @@ export function createKnowledgeInjectorHook(
 				return;
 			}
 
-			// Get run memory summary
-			const runMemory = await getRunMemorySummary(directory);
+			// Get run memory summary. This is optional context; failures must not
+			// suppress the knowledge block retrieved above.
+			let runMemory: string | null = null;
+			try {
+				runMemory = await getRunMemorySummary(directory);
+			} catch (err) {
+				warn(
+					`[knowledge-injector] run memory summary unavailable: ${
+						err instanceof Error ? err.message : String(err)
+					}`,
+				);
+			}
 
 			// Priority-ordered assembly respecting effectiveBudget
 			// Priority: 1. Lessons, 2. Run memory, 3. Drift preamble, 4. Rejected warnings
@@ -894,20 +904,29 @@ export function createKnowledgeInjectorHook(
 				}
 			}
 
-			// 4. Rejected warnings (lowest priority)
-			const rejected = await readRejectedLessons(directory);
-			if (rejected.length > 0 && remaining > 150) {
-				const recentRejected = rejected.slice(-3);
-				const rejectedLines = recentRejected.map(
-					(r) =>
-						`  ⚠️ REJECTED PATTERN: "${sanitizeLessonForContext(r.lesson).slice(0, 80)}" — ${sanitizeLessonForContext(r.rejection_reason)}`,
-				);
-				const rejectedBlock =
-					'⚠️ Previously rejected patterns (do not re-learn):\n' +
-					rejectedLines.join('\n');
-				if (rejectedBlock.length <= remaining) {
-					parts.push(rejectedBlock);
+			// 4. Rejected warnings (lowest priority). Optional guardrail context must
+			// not suppress the primary knowledge block.
+			try {
+				const rejected = await readRejectedLessons(directory);
+				if (rejected.length > 0 && remaining > 150) {
+					const recentRejected = rejected.slice(-3);
+					const rejectedLines = recentRejected.map(
+						(r) =>
+							`  ⚠️ REJECTED PATTERN: "${sanitizeLessonForContext(r.lesson).slice(0, 80)}" — ${sanitizeLessonForContext(r.rejection_reason)}`,
+					);
+					const rejectedBlock =
+						'⚠️ Previously rejected patterns (do not re-learn):\n' +
+						rejectedLines.join('\n');
+					if (rejectedBlock.length <= remaining) {
+						parts.push(rejectedBlock);
+					}
 				}
+			} catch (err) {
+				warn(
+					`[knowledge-injector] rejected pattern warnings unavailable: ${
+						err instanceof Error ? err.message : String(err)
+					}`,
+				);
 			}
 
 			cachedInjectionText = parts.join('\n\n');

--- a/tests/unit/hooks/knowledge-injector-linked-store.test.ts
+++ b/tests/unit/hooks/knowledge-injector-linked-store.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { KnowledgeConfigSchema } from '../../../src/config/schema.js';
+import { createKnowledgeInjectorHook } from '../../../src/hooks/knowledge-injector.js';
+import {
+	invalidateKnowledgeStoreDirCache,
+	resolveLinkDir,
+	writeLinkPointer,
+} from '../../../src/hooks/knowledge-link.js';
+import {
+	appendKnowledge,
+	resolveSwarmKnowledgePath,
+} from '../../../src/hooks/knowledge-store.js';
+import type {
+	MessageWithParts,
+	SwarmKnowledgeEntry,
+} from '../../../src/hooks/knowledge-types.js';
+import { createSafeTestDir } from '../../helpers/safe-test-dir.js';
+
+function makeEntry(
+	overrides: Partial<SwarmKnowledgeEntry>,
+): SwarmKnowledgeEntry {
+	return {
+		id: 'linked-inject-lesson',
+		tier: 'swarm',
+		lesson: 'linked worktrees must read sibling lessons before closing work',
+		category: 'process',
+		tags: ['linked-store'],
+		scope: 'global',
+		confidence: 0.95,
+		status: 'established',
+		confirmed_by: [],
+		retrieval_outcomes: {
+			applied_count: 0,
+			succeeded_after_count: 0,
+			failed_after_count: 0,
+		},
+		schema_version: 2,
+		created_at: '2026-01-01T00:00:00.000Z',
+		updated_at: '2026-01-01T00:00:00.000Z',
+		project_name: 'linked-project',
+		triggers: ['linked worktrees'],
+		applies_to_agents: ['architect'],
+		required_actions: ['read sibling lessons before closing work'],
+		directive_priority: 'high',
+		...overrides,
+	};
+}
+
+describe('knowledge injector linked-store regression', () => {
+	let platformSpy: ReturnType<typeof spyOn> | undefined;
+	let prevXdg: string | undefined;
+	let dataCleanup: () => void;
+
+	beforeEach(() => {
+		invalidateKnowledgeStoreDirCache();
+		platformSpy = spyOn(process, 'platform', 'get').mockReturnValue('linux');
+		prevXdg = process.env.XDG_DATA_HOME;
+		const data = createSafeTestDir('knowledge-injector-link-data-');
+		dataCleanup = data.cleanup;
+		process.env.XDG_DATA_HOME = data.dir;
+	});
+
+	afterEach(() => {
+		platformSpy?.mockRestore();
+		if (prevXdg === undefined) delete process.env.XDG_DATA_HOME;
+		else process.env.XDG_DATA_HOME = prevXdg;
+		invalidateKnowledgeStoreDirCache();
+		dataCleanup?.();
+	});
+
+	test('injects a lesson written by a sibling worktree linked to the same store', async () => {
+		const a = createSafeTestDir('knowledge-injector-link-a-');
+		const b = createSafeTestDir('knowledge-injector-link-b-');
+		try {
+			for (const dir of [a.dir, b.dir]) {
+				await writeLinkPointer(dir, {
+					version: 1,
+					linkId: 'team-lessons',
+					createdAt: '2026-01-01T00:00:00.000Z',
+					source: 'manual',
+				});
+			}
+
+			expect(path.dirname(resolveSwarmKnowledgePath(a.dir))).toBe(
+				resolveLinkDir('team-lessons'),
+			);
+			expect(resolveSwarmKnowledgePath(a.dir)).toBe(
+				resolveSwarmKnowledgePath(b.dir),
+			);
+
+			await appendKnowledge(
+				resolveSwarmKnowledgePath(a.dir),
+				makeEntry({
+					id: 'sibling-linked-lesson',
+					lesson:
+						'linked worktrees must read sibling lessons before closing work',
+				}),
+			);
+
+			const output: { messages: MessageWithParts[] } = {
+				messages: [
+					{
+						info: {
+							role: 'system',
+							agent: 'architect',
+							sessionID: 'linked-injection-session',
+						},
+						parts: [{ type: 'text', text: 'system prompt' }],
+					},
+					{
+						info: { role: 'user' },
+						parts: [
+							{
+								type: 'text',
+								text: 'Please finish the linked worktrees regression safely.',
+							},
+						],
+					},
+				],
+			};
+
+			const hook = createKnowledgeInjectorHook(
+				b.dir,
+				KnowledgeConfigSchema.parse({}),
+			);
+			await hook({}, output);
+
+			const injectedText = output.messages
+				.flatMap((message) => message.parts ?? [])
+				.map((part) => part.text ?? '')
+				.join('\n');
+			expect(injectedText).toContain(
+				'linked worktrees must read sibling lessons before closing work',
+			);
+			expect(fs.existsSync(path.join(b.dir, '.swarm', 'knowledge.jsonl'))).toBe(
+				false,
+			);
+		} finally {
+			a.cleanup();
+			b.cleanup();
+		}
+	});
+});

--- a/tests/unit/hooks/knowledge-injector.test.ts
+++ b/tests/unit/hooks/knowledge-injector.test.ts
@@ -1089,6 +1089,25 @@ describe('Rejected pattern warnings', () => {
 		// Should NOT contain old ones
 		expect(text).not.toContain('Old rejected 1');
 	});
+
+	it('Test 11b: rejected-pattern read failures do not suppress the knowledge block', async () => {
+		readRejectedLessons.mockRejectedValue(
+			new Error('rejected store unreadable'),
+		);
+
+		const hook = createKnowledgeInjectorHook('/proj', makeConfig());
+		const output = makeOutput('architect');
+
+		await hook({}, output);
+		await hook({}, output);
+
+		const knowledgeMsg = output.messages.find((m) =>
+			m.parts?.some((p) => p.text?.includes('📚 Lessons:')),
+		);
+		const text = knowledgeMsg?.parts[0].text ?? '';
+		expect(text).toContain('Some lesson');
+		expect(text).not.toContain('REJECTED PATTERN');
+	});
 });
 
 // ============================================================================

--- a/tests/unit/tools/knowledge-add.test.ts
+++ b/tests/unit/tools/knowledge-add.test.ts
@@ -3,11 +3,20 @@
  * Covers valid lesson creation, validation errors, near-duplicate detection, and auto_generated flag
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import {
+	invalidateKnowledgeStoreDirCache,
+	resolveLinkDir,
+	writeLinkPointer,
+} from '../../../src/hooks/knowledge-link';
+import {
+	readKnowledge,
+	resolveSwarmKnowledgePath,
+} from '../../../src/hooks/knowledge-store';
 import { knowledge_add } from '../../../src/tools/knowledge-add';
 
 describe('knowledge_add tool verification tests', () => {
@@ -59,6 +68,59 @@ describe('knowledge_add tool verification tests', () => {
 		applies_to_agents: ['coder'],
 		required_actions: ['apply this lesson when relevant'],
 	};
+
+	describe('Linked store persistence', () => {
+		it('writes new lessons to the shared linked store', async () => {
+			const platformSpy = spyOn(process, 'platform', 'get').mockReturnValue(
+				'linux',
+			);
+			const prevXdg = process.env.XDG_DATA_HOME;
+			const dataDir = await fs.realpath(
+				await fs.mkdtemp(path.join(os.tmpdir(), 'knowledge-add-link-data-')),
+			);
+			process.env.XDG_DATA_HOME = dataDir;
+			invalidateKnowledgeStoreDirCache();
+
+			try {
+				await writeLinkPointer(tmpDir, {
+					version: 1,
+					linkId: 'linked-add',
+					createdAt: '2026-01-01T00:00:00.000Z',
+					source: 'manual',
+				});
+
+				const lessonText =
+					'Linked worktrees must persist new lessons into the shared store';
+				const result = await knowledge_add.execute(
+					{
+						lesson: lessonText,
+						category: 'process',
+						...V3_FIELDS,
+					},
+					tmpDir,
+				);
+
+				const parsed = JSON.parse(result);
+				expect(parsed.success).toBe(true);
+				expect(path.dirname(resolveSwarmKnowledgePath(tmpDir))).toBe(
+					resolveLinkDir('linked-add'),
+				);
+
+				const linkedEntries = await readKnowledge<Record<string, unknown>>(
+					resolveSwarmKnowledgePath(tmpDir),
+				);
+				expect(linkedEntries).toHaveLength(1);
+				expect(linkedEntries[0].lesson).toBe(lessonText);
+				expect(readKnowledgeEntries()).toHaveLength(0);
+			} finally {
+				if (prevXdg === undefined) delete process.env.XDG_DATA_HOME;
+				else process.env.XDG_DATA_HOME = prevXdg;
+				invalidateKnowledgeStoreDirCache();
+				platformSpy.mockRestore();
+				await fs.rm(dataDir, { recursive: true, force: true });
+			}
+		});
+	});
 
 	// ========== Test 1: Valid lesson is created ==========
 	describe('Valid lesson is created', () => {


### PR DESCRIPTION
## Summary
- Keep phase-start knowledge injection alive when optional run-memory or rejected-pattern context reads fail after retrieval.
- Add real linked-store coverage proving a lesson written through one linked worktree is injected by a sibling linked worktree.
- Add linked `knowledge_add` persistence coverage and a pending release fragment.

## Invariant audit
- 1 (plugin init): not touched - no changes to plugin registration, startup path, or `src/index.ts`; validation: `bun run build`.
- 2 (runtime portability): not touched - no bundle entry shape/package export changes; validation: `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`.
- 3 (subprocesses): not touched - no subprocess code changed.
- 4 (.swarm containment): not touched - no runtime storage path changes; linked-store behavior is tested through existing `resolveSwarmKnowledgePath`/link pointer APIs.
- 5 (plan durability): not touched - no plan ledger/projection/checkpoint code changed.
- 6 (test_runner safety): not touched - repo validation used shell `bun` commands, not broad `test_runner`.
- 7 (test writing): touched - loaded the writing-tests skill; added bun:test coverage without broad repo `test_runner`; validation: focused linked-store, injector, search, link, and tool tests passed.
- 8 (session state): not touched - no session/global state maps or eviction behavior changed.
- 9 (guardrails/retry): not touched - no guardrail or transient retry semantics changed.
- 10 (chat/system msg): touched - `createKnowledgeInjectorHook` now fail-opens optional context reads so retrieved knowledge still injects; validation: linked-store injector regression plus injector budget/long-session suites passed.
- 11 (tool registration): not touched - no tool exports, names, agent maps, commands, or help surfaces changed.
- 12 (release/cache): touched - added `docs/releases/pending/fix-linked-knowledge-injection.md`; no version files or cache code changed.

## Test plan
- [x] `bun run typecheck`
- [x] `bunx @biomejs/biome@2.3.14 ci .`
- [x] `bun run build`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `bun --smol test tests/unit/hooks/knowledge-injector-linked-store.test.ts tests/unit/hooks/search-knowledge.test.ts tests/unit/hooks/knowledge-link.test.ts tests/unit/commands/link.test.ts tests/unit/tools/knowledge-add.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/hooks/knowledge-injector-linked-store.test.ts tests/unit/hooks/knowledge-injector-events.test.ts tests/integration/knowledge-injector-budget.test.ts tests/integration/knowledge-long-session.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/hooks/knowledge-injector.test.ts --test-name-pattern "rejected-pattern read failures" --timeout 30000`

## Notes
- Full unfiltered `tests/unit/hooks/knowledge-injector.test.ts` was pathologically slow on this Windows host, with mocked cases taking about 21s each. The new regression was run directly with `--test-name-pattern`, and the non-pathological injector/link suites passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

