### PR TITLE
fix(knowledge): repair knowledge feedback-loop state tracking

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -12,8 +12,8 @@ When an architect receives a new message, entries from both stores are merged an
 > `applies_to_agents`, `directive_priority`, `generated_skill_path`). The
 > Architect receives these as a structured `<swarm_knowledge_directives>`
 > block and must acknowledge each applicable directive (`KNOWLEDGE_APPLIED`)
-> or explicitly skip it (`KNOWLEDGE_IGNORED reason=...`). See [Actionable
-> directives](#actionable-directives-v2) and
+> or explicitly close it as skipped or violated (`KNOWLEDGE_IGNORED reason=...`
+> / `KNOWLEDGE_VIOLATED reason=...`). See [Actionable directives](#actionable-directives-v2) and
 > [Knowledge application contract](#knowledge-application-contract-v2) below.
 
 ---
@@ -218,7 +218,7 @@ Defaults:
 
 ## Configuration
 
-All keys live under `knowledge.*` in your config (see `src/config/schema.ts:804`):
+All keys live under `knowledge.*` in your config (see `src/config/schema.ts:1043`):
 
 | Key | Type | Default | Purpose |
 |-----|------|:---:|---------|
@@ -453,7 +453,8 @@ generatedSkillPath, sessionId}`.
 
 In `enforce` mode the gate (`gateKnowledgeApplication` in
 `src/hooks/knowledge-application.ts`) blocks high-risk actions when a critical
-directive was shown but received no acknowledgment.
+directive was shown but received no terminal acknowledgment
+(`KNOWLEDGE_APPLIED`, `KNOWLEDGE_IGNORED`, or `KNOWLEDGE_VIOLATED`).
 
 **`high_risk_tools`** — optionally override the set of tools that trigger the
 acknowledgment gate. When absent, defaults to `["save_plan",

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -384,8 +384,10 @@ Ranking rules:
   repetition.
 - Archived entries are excluded (also enforced by `knowledge_recall`).
 
-Cache key: phase + tool + action + targetAgent + taskId + filePaths hash. The
-phase-only cache from v1 has been retired.
+Cache key: phase + tool + action + targetAgent + taskId + filePaths hash +
+SHA-1(ctx.lastUserMessage)[:16]. The phase-only cache from v1 has been
+retired. The user-message hash invalidates the cache between user turns
+and within a turn (e.g., after message compaction).
 
 ---
 

--- a/docs/releases/pending/knowledge-system-feedback-loop-fixes.md
+++ b/docs/releases/pending/knowledge-system-feedback-loop-fixes.md
@@ -1,0 +1,6 @@
+Fixes several knowledge feedback-loop correctness issues: injected critical
+directive gate state now reflects only rendered directive records, phase-start
+knowledge cache keys include the latest user prompt, stale critical gate state is
+cleared on preamble-only injection, hive `knowledge_query` results honor
+`knowledge.scope_filter`, verdict feedback markers advance to processed event
+timestamps, and same-session knowledge acknowledgments survive UTC day changes.

--- a/src/hooks/knowledge-application-gate.ts
+++ b/src/hooks/knowledge-application-gate.ts
@@ -115,12 +115,11 @@ export async function knowledgeApplicationGateBefore(
 	const cached = swarmState.currentCriticalShownIds.get(sessionID);
 	if (!cached || cached.ids.length === 0) return;
 
-	// Has an architect ack landed in this session for any of the critical ids?
-	const dayKey = new Date().toISOString().slice(0, 10);
+	// Has an architect terminal ack landed in this session for any critical id?
 	const ackedIds = new Set<string>();
 	for (const id of cached.ids) {
-		// Either explicit-applied OR explicit-ignored counts as "acknowledged"
-		// for the purpose of the gate (the architect chose; we audit elsewhere).
+		// Applied, ignored, and violated all count as "acknowledged" for the
+		// purpose of the gate (the architect chose; we audit elsewhere).
 		for (const result of ['applied', 'ignored', 'violated'] as const) {
 			const key = buildAckDedupKey(sessionID, id, result);
 			if (swarmState.knowledgeAckDedup.has(key)) {
@@ -139,7 +138,7 @@ export async function knowledgeApplicationGateBefore(
 	if (config.mode === 'enforce' && config.critical_requires_ack) {
 		const ids = unacked.join(', ');
 		throw new Error(
-			`KNOWLEDGE_ENFORCE_GATE_DENY: ${toolName} blocked — critical knowledge directive(s) ${ids} require KNOWLEDGE_APPLIED:<id> or KNOWLEDGE_IGNORED:<id> reason=... before this action.`,
+			`KNOWLEDGE_ENFORCE_GATE_DENY: ${toolName} blocked — critical knowledge directive(s) ${ids} require KNOWLEDGE_APPLIED:<id>, KNOWLEDGE_IGNORED:<id> reason=..., or KNOWLEDGE_VIOLATED:<id> reason=... before this action.`,
 		);
 	}
 
@@ -150,7 +149,6 @@ export async function knowledgeApplicationGateBefore(
 		tool: toolName,
 		agent: agentRaw,
 		sessionID,
-		dayKey,
 		unacknowledged_critical_ids: unacked,
 	}).catch(() => {
 		/* never block tool path */

--- a/src/hooks/knowledge-application.ts
+++ b/src/hooks/knowledge-application.ts
@@ -254,7 +254,7 @@ export async function recordKnowledgeShown(
 }
 
 /** Record an explicit acknowledgment outcome (applied / ignored / violated).
- *  Per-(sessionId, knowledgeId, result, dayKey) dedup is enforced by the
+ *  Per-(sessionId, knowledgeId, result) dedup is enforced by the
  *  caller via swarmState.knowledgeAckDedup; this fn always records when
  *  invoked, so test code can trigger duplicates if needed. The runtime
  *  integration in src/index.ts uses recordAcknowledgmentDeduped instead. */
@@ -303,20 +303,15 @@ export async function recordAcknowledgment(
 	}
 }
 
-/** Day key in UTC; matches the default skill_improver quota window. */
-function utcDayKey(d: Date = new Date()): string {
-	return d.toISOString().slice(0, 10);
-}
-
 /** Build the dedup key. Exported so test code and the runtime integration
  *  share the exact format. */
 export function buildAckDedupKey(
 	sessionId: string,
 	id: string,
 	result: KnowledgeApplicationResult | 'n_a',
-	now: Date = new Date(),
+	_now: Date = new Date(),
 ): string {
-	return `${sessionId}|${id}|${result}|${utcDayKey(now)}`;
+	return `${sessionId}|${id}|${result}`;
 }
 
 /** Acknowledgment recording with dedup. Returns whether a record was actually
@@ -459,7 +454,7 @@ export function gateKnowledgeApplication(args: {
 	const warnings: GateResult['warnings'] = [];
 	for (const id of criticalShownIds) {
 		if (!ackIds.has(id)) {
-			const reason = `critical directive ${id} requires KNOWLEDGE_APPLIED/IGNORED ack`;
+			const reason = `critical directive ${id} requires KNOWLEDGE_APPLIED/IGNORED/VIOLATED ack`;
 			if (config.mode === 'enforce' && config.critical_requires_ack) {
 				violations.push({ id, reason });
 			} else {

--- a/src/hooks/knowledge-events.ts
+++ b/src/hooks/knowledge-events.ts
@@ -1030,12 +1030,25 @@ const VERDICT_CONFIDENCE_DECAY = 0.05;
  */
 export async function applyKnowledgeVerdictFeedback(
 	directory: string,
-	options?: { sinceTimestamp?: string },
-): Promise<{ processed: number; bumps: number }> {
+	options?: { sinceTimestamp?: string; sinceEventId?: string },
+): Promise<{
+	processed: number;
+	bumps: number;
+	lastProcessedTimestamp?: string;
+	lastProcessedEventId?: string;
+}> {
 	try {
 		const events = await readKnowledgeEvents(directory);
+		const markerIndex =
+			options?.sinceTimestamp && options.sinceEventId
+				? events.findIndex(
+						(e) =>
+							e.timestamp === options.sinceTimestamp &&
+							e.event_id === options.sinceEventId,
+					)
+				: -1;
 
-		const actionable = events.filter((e): e is ReceiptEvent => {
+		const actionable = events.filter((e, index): e is ReceiptEvent => {
 			if (
 				e.type !== 'applied' &&
 				e.type !== 'violated' &&
@@ -1045,9 +1058,21 @@ export async function applyKnowledgeVerdictFeedback(
 			}
 			if (
 				options?.sinceTimestamp &&
-				(e as ReceiptEvent).timestamp <= options.sinceTimestamp
+				(e as ReceiptEvent).timestamp < options.sinceTimestamp
 			) {
 				return false;
+			}
+			if (
+				options?.sinceTimestamp &&
+				(e as ReceiptEvent).timestamp === options.sinceTimestamp
+			) {
+				if (!options.sinceEventId) {
+					return false;
+				}
+				if (markerIndex < 0) {
+					return false;
+				}
+				return index > markerIndex;
 			}
 			return true;
 		});
@@ -1060,7 +1085,16 @@ export async function applyKnowledgeVerdictFeedback(
 			string,
 			{ applied: number; violated: number; ignored: number }
 		>();
+		let lastProcessedTimestamp: string | undefined;
+		let lastProcessedEventId: string | undefined;
 		for (const event of actionable) {
+			if (
+				typeof event.timestamp === 'string' &&
+				(!lastProcessedTimestamp || event.timestamp >= lastProcessedTimestamp)
+			) {
+				lastProcessedTimestamp = event.timestamp;
+				lastProcessedEventId = event.event_id;
+			}
 			const kid = event.knowledge_id;
 			if (!kid) continue;
 			const g = groups.get(kid) ?? { applied: 0, violated: 0, ignored: 0 };
@@ -1089,7 +1123,12 @@ export async function applyKnowledgeVerdictFeedback(
 			await bumpKnowledgeConfidenceBatch(directory, deltas);
 		}
 
-		return { processed: groups.size, bumps: deltas.length };
+		return {
+			processed: groups.size,
+			bumps: deltas.length,
+			lastProcessedTimestamp,
+			lastProcessedEventId,
+		};
 	} catch (err) {
 		warn(
 			`[knowledge-events] applyKnowledgeVerdictFeedback failed (fail-open): ${

--- a/src/hooks/knowledge-injector.ts
+++ b/src/hooks/knowledge-injector.ts
@@ -53,6 +53,39 @@ import { readSwarmFileAsync, safeHook } from './utils.js';
 const INJECTION_SENTINEL = `${String.fromCharCode(0x200c)}[[KNOWLEDGE-INJECTED]]`;
 const defaultSearchKnowledge = searchKnowledge;
 
+function getRenderedEntryIds(
+	entries: RankedEntry[],
+	renderedBlock: string | null,
+	cfg: KnowledgeConfig,
+	currentProject?: string,
+): string[] {
+	if (!renderedBlock) return [];
+	const maxDisplayChars = cfg.max_lesson_display_chars ?? 120;
+	const ids: string[] = [];
+	for (const entry of entries) {
+		if (renderedBlock.includes(`- id: ${entry.id}`)) {
+			ids.push(entry.id);
+			continue;
+		}
+		let lessonText = sanitizeLessonForContext(entry.lesson);
+		if (lessonText.length > maxDisplayChars) {
+			lessonText = `${lessonText.slice(0, maxDisplayChars)}…`;
+		}
+		const rawSource =
+			entry.tier === 'hive' && 'source_project' in entry
+				? ((entry as { source_project?: string }).source_project ?? null)
+				: null;
+		const source =
+			rawSource !== null && rawSource !== currentProject
+				? ` (from: ${sanitizeLessonForContext(rawSource)})`
+				: '';
+		if (renderedBlock.includes(`${lessonText}${source}`)) {
+			ids.push(entry.id);
+		}
+	}
+	return ids;
+}
+
 /**
  * Builds a compact knowledge block from ranked entries, respecting a character budget.
  * Returns the formatted block string, or null if entries is empty.
@@ -604,6 +637,12 @@ export function createKnowledgeInjectorHook(
 			ctx.targetAgent ?? '',
 			ctx.taskId ?? '',
 			(ctx.filePaths ?? []).slice(0, 8).join(','),
+			ctx.lastUserMessage
+				? createHash('sha1')
+						.update(ctx.lastUserMessage)
+						.digest('hex')
+						.slice(0, 16)
+				: '',
 		].join('|');
 		return createHash('sha1').update(parts).digest('hex').slice(0, 16);
 	}
@@ -611,6 +650,7 @@ export function createKnowledgeInjectorHook(
 	let lastSeenCacheKey: string | null = null;
 	let cachedInjectionText: string | null = null;
 	let cachedShownIds: string[] = [];
+	let cachedCriticalIds: string[] = [];
 
 	return safeHook(
 		async (
@@ -721,10 +761,24 @@ export function createKnowledgeInjectorHook(
 			if (cacheKey === lastSeenCacheKey && cachedInjectionText !== null) {
 				// Same context, cached text available — re-inject (handles compaction).
 				injectKnowledgeMessage(output, cachedInjectionText);
+				const sessionID = systemMsg?.info?.sessionID;
+				if (sessionID) {
+					if (cachedCriticalIds.length > 0) {
+						setCriticalShownIds(sessionID, {
+							ids: cachedCriticalIds,
+							phase: `Phase ${currentPhase}`,
+							generatedAt: Date.now(),
+						});
+					} else {
+						clearCriticalShownIds(sessionID);
+					}
+				}
 				return;
 			}
 			lastSeenCacheKey = cacheKey;
 			cachedInjectionText = null;
+			cachedShownIds = [];
+			cachedCriticalIds = [];
 
 			// Build legacy ProjectContext for the lesson-block fallback path.
 			const _context: ProjectContext = {
@@ -753,8 +807,6 @@ export function createKnowledgeInjectorHook(
 			// in-scope, low-confidence directive could never surface. Ranking +
 			// MMR + the cold-start bonus now govern which entries appear.
 			const filteredEntries = search.results;
-			// Track which IDs we showed so application-tracking can split shown from applied.
-			cachedShownIds = filteredEntries.map((e) => e.id);
 
 			// Build drift/briefing preamble into a LOCAL variable so cachedInjectionText
 			// is never mutated before we know whether entries exist. This prevents the
@@ -798,6 +850,12 @@ export function createKnowledgeInjectorHook(
 
 			// If no knowledge entries AND no drift/briefing, nothing to inject
 			if (filteredEntries.length === 0) {
+				const sessionID = systemMsg?.info?.sessionID;
+				if (sessionID) {
+					clearCriticalShownIds(sessionID);
+				}
+				cachedShownIds = [];
+				cachedCriticalIds = [];
 				if (freshPreamble === null) return;
 				// Drift or briefing exists — cache and inject it directly
 				cachedInjectionText = freshPreamble;
@@ -839,6 +897,25 @@ export function createKnowledgeInjectorHook(
 				config,
 				projectName,
 			);
+			const renderedDirectiveIds = getRenderedEntryIds(
+				directiveEntries,
+				directiveBlock,
+				config,
+				projectName,
+			);
+			const renderedIdSet = new Set([
+				...renderedDirectiveIds,
+				...getRenderedEntryIds(
+					filteredEntries,
+					lessonBlock,
+					config,
+					projectName,
+				),
+			]);
+			const renderedDirectiveIdSet = new Set(renderedDirectiveIds);
+			cachedShownIds = filteredEntries
+				.map((entry) => entry.id)
+				.filter((id) => renderedIdSet.has(id));
 
 			const parts: string[] = [];
 			let remaining = effectiveBudget;
@@ -919,11 +996,13 @@ export function createKnowledgeInjectorHook(
 			const sessionID = systemMsg?.info?.sessionID;
 			if (sessionID) {
 				const criticalIds = filteredEntries
+					.filter((e) => renderedDirectiveIdSet.has(e.id))
 					.filter(
 						(e) =>
 							e.directive_priority === 'critical' && e.status !== 'archived',
 					)
 					.map((e) => e.id);
+				cachedCriticalIds = criticalIds;
 				if (criticalIds.length > 0) {
 					setCriticalShownIds(sessionID, {
 						ids: criticalIds,

--- a/src/state.ts
+++ b/src/state.ts
@@ -469,9 +469,9 @@ export const swarmState = {
 		{ ids: string[]; taskId?: string; phase?: string; generatedAt: number }
 	>(),
 
-	/** v2: dedup set for ack records. Key = `${sessionId}|${id}|${result}|${dayKey}`.
+	/** v2: dedup set for ack records. Key = `${sessionId}|${id}|${result}`.
 	 *  Prevents the chat.messages.transform path AND a knowledge_ack tool call
-	 *  from double-counting the same ack within a session-day. FIFO-capped —
+	 *  from double-counting the same ack within a session. FIFO-capped —
 	 *  see addKnowledgeAckDedup. */
 	knowledgeAckDedup: new Set<string>(),
 

--- a/src/tools/knowledge-query.ts
+++ b/src/tools/knowledge-query.ts
@@ -187,6 +187,7 @@ function filterHiveEntries(
 	entries: HiveKnowledgeEntry[],
 	filters: FilterOptions,
 	suppressedLessons: Set<string>,
+	scopeFilter?: string[],
 ): HiveKnowledgeEntry[] {
 	return entries.filter((entry) => {
 		if (filters.status) {
@@ -201,6 +202,12 @@ function filterHiveEntries(
 		}
 		if (filters.minScore !== undefined && entry.confidence < filters.minScore) {
 			return false;
+		}
+		if (scopeFilter && scopeFilter.length > 0) {
+			const entryScope = entry.scope ?? 'global';
+			if (!scopeFilter.some((pattern) => entryScope === pattern)) {
+				return false;
+			}
 		}
 		if (suppressedLessons.has(normalize(entry.lesson))) {
 			return false;
@@ -363,6 +370,7 @@ export const knowledge_query: ReturnType<typeof tool> = createSwarmTool({
 				hiveEntries,
 				filters,
 				suppressedLessons,
+				scopeFilter,
 			);
 			for (const entry of filtered) {
 				results.push({ entry, tier: 'hive' });

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -1181,33 +1181,38 @@ export async function executePhaseComplete(
 			'verdict-feedback-last-processed.json',
 		);
 		let verdictSinceTimestamp: string | undefined;
+		let verdictSinceEventId: string | undefined;
 		try {
 			const markerData = JSON.parse(
 				fs.readFileSync(verdictMarkerPath, 'utf-8'),
 			);
 			verdictSinceTimestamp = markerData.lastProcessedTimestamp;
+			verdictSinceEventId = markerData.lastProcessedEventId;
 		} catch {
 			// marker doesn't exist yet — process all entries
 		}
 
-		const verdictMarkerTimestamp = new Date().toISOString();
 		const { applyKnowledgeVerdictFeedback } = await import(
 			'../hooks/knowledge-events.js'
 		);
 		const verdictResult = await applyKnowledgeVerdictFeedback(dir, {
 			sinceTimestamp: verdictSinceTimestamp,
+			sinceEventId: verdictSinceEventId,
 		});
 
-		try {
-			fs.writeFileSync(
-				verdictMarkerPath,
-				JSON.stringify({
-					lastProcessedTimestamp: verdictMarkerTimestamp,
-				}),
-				'utf-8',
-			);
-		} catch {
-			// best-effort marker write
+		if (verdictResult.lastProcessedTimestamp) {
+			try {
+				fs.writeFileSync(
+					verdictMarkerPath,
+					JSON.stringify({
+						lastProcessedTimestamp: verdictResult.lastProcessedTimestamp,
+						lastProcessedEventId: verdictResult.lastProcessedEventId,
+					}),
+					'utf-8',
+				);
+			} catch {
+				// best-effort marker write
+			}
 		}
 
 		if (verdictResult.bumps > 0) {

--- a/tests/unit/hooks/knowledge-application-gate.test.ts
+++ b/tests/unit/hooks/knowledge-application-gate.test.ts
@@ -190,6 +190,22 @@ describe('knowledgeApplicationGateBefore', () => {
 		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
 	});
 
+	it('enforce denial text lists all accepted terminal ack markers', async () => {
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				{ ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' },
+			),
+		).rejects.toThrow(
+			/KNOWLEDGE_APPLIED.*KNOWLEDGE_IGNORED.*KNOWLEDGE_VIOLATED/,
+		);
+	});
+
 	it('enforce mode allows when dedup set already records an ack for the id', async () => {
 		swarmState.currentCriticalShownIds.set('s1', {
 			ids: [ID_A],
@@ -213,6 +229,23 @@ describe('knowledgeApplicationGateBefore', () => {
 		await knowledgeApplicationGateBefore(
 			tmp,
 			{ tool: 'phase_complete', agent: 'architect', sessionID: 's1' },
+			{ ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' },
+		);
+		// no throw
+	});
+
+	it('regression GATE-002: prior-day ack still satisfies same-session gate', async () => {
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		swarmState.knowledgeAckDedup.add(
+			buildAckDedupKey('s1', ID_A, 'applied', new Date('2024-01-01T00:00:00Z')),
+		);
+
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
 			{ ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' },
 		);
 		// no throw

--- a/tests/unit/hooks/knowledge-application-gate.test.ts
+++ b/tests/unit/hooks/knowledge-application-gate.test.ts
@@ -234,6 +234,20 @@ describe('knowledgeApplicationGateBefore', () => {
 		// no throw
 	});
 
+	it('enforce mode allows when ack is "violated" (architect chose)', async () => {
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		swarmState.knowledgeAckDedup.add(buildAckDedupKey('s1', ID_A, 'violated'));
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'phase_complete', agent: 'architect', sessionID: 's1' },
+			{ ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' },
+		);
+		// no throw
+	});
+
 	it('regression GATE-002: prior-day ack still satisfies same-session gate', async () => {
 		swarmState.currentCriticalShownIds.set('s1', {
 			ids: [ID_A],

--- a/tests/unit/hooks/knowledge-injector-events.test.ts
+++ b/tests/unit/hooks/knowledge-injector-events.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { KnowledgeConfigSchema } from '../../../src/config/schema';
 import type { KnowledgeEventInput } from '../../../src/hooks/knowledge-events';
@@ -9,6 +9,7 @@ import {
 } from '../../../src/hooks/knowledge-injector';
 import type { RankedEntry } from '../../../src/hooks/knowledge-reader';
 import type { MessageWithParts } from '../../../src/hooks/knowledge-types';
+import { swarmState } from '../../../src/state';
 
 const baseConfig = KnowledgeConfigSchema.parse({});
 let tempDir: string;
@@ -49,6 +50,7 @@ beforeEach(() => {
 	mkdirSync('.tmp-tests', { recursive: true });
 	tempDir = mkdtempSync(path.join('.tmp-tests', 'swarm-kinj-'));
 	mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+	swarmState.currentCriticalShownIds.clear();
 	originalSearch = _internals.searchKnowledge;
 	originalRecordEvent = _internals.recordKnowledgeEvent;
 	originalRecordShown = _internals.recordKnowledgeShown;
@@ -58,11 +60,31 @@ afterEach(() => {
 	_internals.searchKnowledge = originalSearch;
 	_internals.recordKnowledgeEvent = originalRecordEvent;
 	_internals.recordKnowledgeShown = originalRecordShown;
+	swarmState.currentCriticalShownIds.clear();
 	rmSync(tempDir, { recursive: true, force: true });
 	rmSync('.tmp-tests', { recursive: true, force: true });
 });
 
 describe('knowledge injector retrieved events', () => {
+	function outputForUser(text: string): { messages?: MessageWithParts[] } {
+		return {
+			messages: [
+				{
+					info: {
+						role: 'system',
+						agent: 'architect',
+						sessionID: 'session-1',
+					},
+					parts: [{ type: 'text', text: 'system' }],
+				},
+				{
+					info: { role: 'user' },
+					parts: [{ type: 'text', text }],
+				},
+			],
+		};
+	}
+
 	test('emits retrieved telemetry for the final displayed IDs (no confidence pre-filter, Task 6.1)', async () => {
 		let searchParams: Record<string, unknown> | undefined;
 		let emittedEvent: KnowledgeEventInput | undefined;
@@ -190,5 +212,145 @@ describe('knowledge injector retrieved events', () => {
 
 		expect(searchCalled).toBe(false);
 		expect(output.messages).toHaveLength(3);
+	});
+
+	test('regression INJ-001: changed user message invalidates cached injection', async () => {
+		const calls: string[] = [];
+		_internals.searchKnowledge = async (params) => {
+			calls.push(params.context.lastUserMessage ?? '');
+			return {
+				trace_id: `trace-${calls.length}`,
+				results: [
+					rankedEntry(`shown-${calls.length}`, {
+						lesson: `lesson for ${params.context.lastUserMessage}`,
+					}),
+				],
+			};
+		};
+		_internals.recordKnowledgeEvent = async () => null;
+		_internals.recordKnowledgeShown = async () => {};
+
+		const hook = createKnowledgeInjectorHook(tempDir, {
+			...baseConfig,
+			enabled: true,
+			inject_char_budget: 1200,
+		});
+
+		const first = outputForUser('first request');
+		await hook({}, first);
+		const second = outputForUser('second request');
+		await hook({}, second);
+
+		expect(calls).toEqual(['first request', 'second request']);
+		const injectedText = second.messages
+			?.flatMap((m) => m.parts ?? [])
+			.map((p) => p.text ?? '')
+			.join('\n');
+		expect(injectedText).toContain('lesson for second request');
+		expect(injectedText).not.toContain('lesson for first request');
+	});
+
+	test('regression INJ-002: critical gate IDs come only from rendered directive records', async () => {
+		let shownIds: string[] | undefined;
+		_internals.searchKnowledge = async () => ({
+			trace_id: 'trace-trimmed',
+			results: [
+				rankedEntry('crit-visible', {
+					directive_priority: 'critical',
+					triggers: ['save'],
+					required_actions: ['ack visible'],
+				}),
+				rankedEntry('crit-trimmed', {
+					directive_priority: 'critical',
+					triggers: ['save'],
+					required_actions: ['ack trimmed'],
+				}),
+			],
+		});
+		_internals.recordKnowledgeEvent = async () => null;
+		_internals.recordKnowledgeShown = async (_directory, ids) => {
+			shownIds = ids;
+		};
+
+		const hook = createKnowledgeInjectorHook(tempDir, {
+			...baseConfig,
+			enabled: true,
+			inject_char_budget: 500,
+			max_lesson_display_chars: 40,
+		});
+		const output = outputForUser('please save');
+
+		await hook({}, output);
+
+		const injectedText = output.messages
+			?.flatMap((m) => m.parts ?? [])
+			.map((p) => p.text ?? '')
+			.join('\n');
+		expect(injectedText).toContain('- id: crit-visible');
+		expect(injectedText).not.toContain('- id: crit-trimmed');
+		expect(shownIds).toContain('crit-visible');
+		const criticalState = swarmState.currentCriticalShownIds.get('session-1');
+		expect(criticalState?.ids).toEqual(['crit-visible']);
+	});
+
+	test('regression INJ-002b: truncated lesson-block entries still count as shown', async () => {
+		let shownIds: string[] | undefined;
+		_internals.searchKnowledge = async () => ({
+			trace_id: 'trace-truncated-lesson',
+			results: [
+				rankedEntry('long-lesson', {
+					lesson: 'abcdefghij1234567890 extra lesson detail',
+				}),
+			],
+		});
+		_internals.recordKnowledgeEvent = async () => null;
+		_internals.recordKnowledgeShown = async (_directory, ids) => {
+			shownIds = ids;
+		};
+
+		const hook = createKnowledgeInjectorHook(tempDir, {
+			...baseConfig,
+			enabled: true,
+			inject_char_budget: 1200,
+			max_lesson_display_chars: 10,
+		});
+		const output = outputForUser('surface lesson');
+
+		await hook({}, output);
+
+		const injectedText = output.messages
+			?.flatMap((m) => m.parts ?? [])
+			.map((p) => p.text ?? '')
+			.join('\n');
+		expect(injectedText).toContain('[S] abcdefghij');
+		expect(shownIds).toEqual(['long-lesson']);
+	});
+
+	test('regression INJ-003: preamble-only injection clears stale critical gate IDs', async () => {
+		swarmState.currentCriticalShownIds.set('session-1', {
+			ids: ['stale-critical'],
+			generatedAt: Date.now(),
+		});
+		_internals.searchKnowledge = async () => ({
+			trace_id: 'trace-empty',
+			results: [],
+		});
+		_internals.recordKnowledgeEvent = async () => null;
+		_internals.recordKnowledgeShown = async () => {};
+		writeFileSync(
+			path.join(tempDir, '.swarm', 'curator-briefing.md'),
+			'briefing only',
+			'utf-8',
+		);
+
+		const hook = createKnowledgeInjectorHook(tempDir, {
+			...baseConfig,
+			enabled: true,
+			inject_char_budget: 1200,
+		});
+
+		await hook({}, outputForUser('empty retrieval'));
+
+		expect(swarmState.currentCriticalShownIds.has('session-1')).toBe(false);
 	});
 });

--- a/tests/unit/hooks/knowledge-verdict-feedback.test.ts
+++ b/tests/unit/hooks/knowledge-verdict-feedback.test.ts
@@ -51,11 +51,12 @@ function ensureSwarmDir(dir: string): string {
 function makeReceiptEvent(overrides: {
 	type: string;
 	knowledge_id: string;
+	event_id?: string;
 	timestamp?: string;
 }): string {
 	return JSON.stringify({
 		type: overrides.type,
-		event_id: randomUUID(),
+		event_id: overrides.event_id ?? randomUUID(),
 		trace_id: randomUUID(),
 		knowledge_id: overrides.knowledge_id,
 		timestamp: overrides.timestamp ?? new Date().toISOString(),
@@ -70,6 +71,7 @@ function writeEvents(
 	events: Array<{
 		type: string;
 		knowledge_id: string;
+		event_id?: string;
 		timestamp?: string;
 	}>,
 ): void {
@@ -238,6 +240,59 @@ describe('applyKnowledgeVerdictFeedback', () => {
 		// Only the 2 new applied events count → applied (2) > violated+ignored (0) → boost
 		const entries = await readKnowledgeById(dir);
 		expect(entries.get(kid)!.confidence).toBeCloseTo(0.53); // 0.5 + 0.03
+	});
+
+	test('regression FEEDBACK-001: returns max processed event timestamp as marker', async () => {
+		const kid = randomUUID();
+		writeKnowledgeEntries(dir, [
+			{ id: kid, lesson: 'marker tracks processed events', confidence: 0.5 },
+		]);
+		const first = '2026-06-01T12:00:00.001Z';
+		const second = '2026-06-01T12:00:00.003Z';
+		writeEvents(dir, [
+			{ type: 'applied', knowledge_id: kid, timestamp: second },
+			{ type: 'applied', knowledge_id: kid, timestamp: first },
+		]);
+
+		const result = await applyKnowledgeVerdictFeedback(dir);
+
+		expect(result.processed).toBe(1);
+		expect(result.bumps).toBe(1);
+		expect(result.lastProcessedTimestamp).toBe(second);
+	});
+
+	test('regression FEEDBACK-002: event id marker includes same-timestamp tail events', async () => {
+		const kid = randomUUID();
+		writeKnowledgeEntries(dir, [
+			{ id: kid, lesson: 'same timestamp tail marker', confidence: 0.5 },
+		]);
+		const timestamp = '2026-06-01T12:00:00.005Z';
+		writeEvents(dir, [
+			{
+				type: 'violated',
+				knowledge_id: kid,
+				event_id: 'marker-event',
+				timestamp,
+			},
+			{
+				type: 'applied',
+				knowledge_id: kid,
+				event_id: 'tail-event',
+				timestamp,
+			},
+		]);
+
+		const result = await applyKnowledgeVerdictFeedback(dir, {
+			sinceTimestamp: timestamp,
+			sinceEventId: 'marker-event',
+		});
+
+		expect(result.processed).toBe(1);
+		expect(result.bumps).toBe(1);
+		expect(result.lastProcessedTimestamp).toBe(timestamp);
+		expect(result.lastProcessedEventId).toBe('tail-event');
+		const entries = await readKnowledgeById(dir);
+		expect(entries.get(kid)!.confidence).toBeCloseTo(0.53);
 	});
 
 	// --------------------------------------------------------------------------

--- a/tests/unit/tools/knowledge-query.test.ts
+++ b/tests/unit/tools/knowledge-query.test.ts
@@ -12,11 +12,14 @@ import {
 	it,
 	mock,
 } from 'bun:test';
-import { rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { SwarmKnowledgeEntry } from '../../../src/hooks/knowledge-types';
+import type {
+	HiveKnowledgeEntry,
+	SwarmKnowledgeEntry,
+} from '../../../src/hooks/knowledge-types';
 import { knowledge_query } from '../../../src/tools/knowledge-query';
 
 describe('knowledge-query tool verification tests', () => {
@@ -69,6 +72,25 @@ describe('knowledge-query tool verification tests', () => {
 		writeFileSync(
 			swarmPath,
 			entries.map((e) => JSON.stringify(e)).join('\n') + '\n',
+			'utf-8',
+		);
+	}
+
+	function writeHiveKnowledge(entries: HiveKnowledgeEntry[]): void {
+		const hivePath = path.join(tmpDir, '.swarm', 'shared-learnings.jsonl');
+		writeFileSync(
+			hivePath,
+			entries.map((e) => JSON.stringify(e)).join('\n') + '\n',
+			'utf-8',
+		);
+	}
+
+	function writeProjectConfig(config: Record<string, unknown>): void {
+		const configDir = path.join(tmpDir, '.opencode');
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			path.join(configDir, 'opencode-swarm.json'),
+			JSON.stringify(config),
 			'utf-8',
 		);
 	}
@@ -1122,6 +1144,63 @@ describe('knowledge-query tool verification tests', () => {
 		it('Hive tier returns no results when no hive file exists', async () => {
 			const result = await knowledge_query.execute({ tier: 'hive' });
 			expect(result).toContain("No knowledge entries found for tier 'hive'");
+		});
+
+		it('regression KQ-001: scope_filter applies to hive query results', async () => {
+			writeProjectConfig({
+				knowledge: {
+					scope_filter: ['global'],
+				},
+			});
+			writeHiveKnowledge([
+				{
+					id: 'hive-global-visible',
+					tier: 'hive',
+					lesson: 'Global hive lesson',
+					category: 'process',
+					tags: [],
+					scope: 'global',
+					confidence: 0.9,
+					status: 'promoted',
+					confirmed_by: [],
+					retrieval_outcomes: {
+						applied_count: 0,
+						succeeded_after_count: 0,
+						failed_after_count: 0,
+					},
+					schema_version: 1,
+					created_at: '2024-01-01T00:00:00Z',
+					updated_at: '2024-01-01T00:00:00Z',
+					source_project: 'shared-project',
+					encounter_score: 0.8,
+				} as HiveKnowledgeEntry,
+				{
+					id: 'hive-project-hidden',
+					tier: 'hive',
+					lesson: 'Project hive lesson',
+					category: 'process',
+					tags: [],
+					scope: 'project',
+					confidence: 0.9,
+					status: 'promoted',
+					confirmed_by: [],
+					retrieval_outcomes: {
+						applied_count: 0,
+						succeeded_after_count: 0,
+						failed_after_count: 0,
+					},
+					schema_version: 1,
+					created_at: '2024-01-01T00:00:00Z',
+					updated_at: '2024-01-01T00:00:00Z',
+					source_project: 'shared-project',
+					encounter_score: 0.8,
+				} as HiveKnowledgeEntry,
+			]);
+
+			const result = await knowledge_query.execute({ tier: 'hive' });
+
+			expect(result).toContain('hive-global-visible');
+			expect(result).not.toContain('hive-project-hidden');
 		});
 	});
 

--- a/tests/unit/tools/knowledge-query.test.ts
+++ b/tests/unit/tools/knowledge-query.test.ts
@@ -1202,6 +1202,63 @@ describe('knowledge-query tool verification tests', () => {
 			expect(result).toContain('hive-global-visible');
 			expect(result).not.toContain('hive-project-hidden');
 		});
+
+		it('regression KQ-001b: scope_filter applies to swarm (default tier) query results', async () => {
+			// Mirror of KQ-001 for the swarm tier (default): swarm entries with
+			// `scope='project'` must be filtered out when scope_filter=['global'].
+			writeProjectConfig({
+				knowledge: {
+					scope_filter: ['global'],
+				},
+			});
+			writeSwarmKnowledge([
+				{
+					id: 'swarm-global-visible',
+					tier: 'swarm',
+					lesson: 'Global swarm lesson',
+					category: 'process',
+					tags: [],
+					scope: 'global',
+					confidence: 0.9,
+					status: 'promoted',
+					confirmed_by: [],
+					retrieval_outcomes: {
+						applied_count: 0,
+						succeeded_after_count: 0,
+						failed_after_count: 0,
+					},
+					schema_version: 1,
+					created_at: '2024-01-01T00:00:00Z',
+					updated_at: '2024-01-01T00:00:00Z',
+					project_name: 'kq-001b-test',
+				} as SwarmKnowledgeEntry,
+				{
+					id: 'swarm-project-hidden',
+					tier: 'swarm',
+					lesson: 'Project swarm lesson',
+					category: 'process',
+					tags: [],
+					scope: 'project',
+					confidence: 0.9,
+					status: 'promoted',
+					confirmed_by: [],
+					retrieval_outcomes: {
+						applied_count: 0,
+						succeeded_after_count: 0,
+						failed_after_count: 0,
+					},
+					schema_version: 1,
+					created_at: '2024-01-01T00:00:00Z',
+					updated_at: '2024-01-01T00:00:00Z',
+					project_name: 'kq-001b-test',
+				} as SwarmKnowledgeEntry,
+			]);
+
+			const result = await knowledge_query.execute();
+
+			expect(result).toContain('swarm-global-visible');
+			expect(result).not.toContain('swarm-project-hidden');
+		});
 	});
 
 	// ========== GROUP 9: Architect-only access assumptions ==========


### PR DESCRIPTION
## Summary

- repair the verdict-feedback loop so knowledge reinforcement is recorded once per verdict cycle and keyed by processed verdict markers instead of repeating on every phase close
- carry knowledge application evidence forward through injector and application paths so applied knowledge gets marked as used and surfaced in events/query output
- tighten the phase-complete gate and docs/tests around stored, improved, and used knowledge behavior

## Invariant audit

- 1 (plugin init): not touched G�� branch changes are limited to knowledge hooks, state, query tool output, docs, and targeted tests
- 2 (runtime portability): not touched G�� portability preflight passed via `bun run build` and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- 3 (subprocesses): not touched G�� no subprocess callsites changed in branch diff
- 4 (.swarm containment): touched G�� `src/tools/phase-complete.ts` continues to persist verdict-feedback progress under project `.swarm/`; focused knowledge tests passed and branch diff adds no new `process.cwd()`-anchored runtime writes
- 5 (plan durability): not touched G�� no ledger/projection/checkpoint files or plan durability logic changed
- 6 (test_runner safety): not touched G�� no `test_runner` logic or usage changes in branch diff
- 7 (test writing): touched G�� added/updated focused `bun:test` coverage in `tests/unit/hooks/knowledge-application-gate.test.ts`, `tests/unit/hooks/knowledge-injector-events.test.ts`, `tests/unit/hooks/knowledge-verdict-feedback.test.ts`, and `tests/unit/tools/knowledge-query.test.ts`; all changed-surface tests passed
- 8 (session state): touched G�� `src/state.ts` and knowledge hook flow were updated; regression coverage passed in `knowledge-injector-events`, `knowledge-verdict-feedback`, and `knowledge-application-gate`
- 9 (guardrails/retry): not touched G�� no guardrail or retry paths changed
- 10 (chat/system msg): touched G�� `src/hooks/knowledge-injector.ts` and `src/hooks/knowledge-application.ts` change injected knowledge/evidence messaging; focused injector/application tests passed
- 11 (tool registration): not touched G�� no tool export/registration/agent-map files changed
- 12 (release/cache): touched G�� added `docs/releases/pending/knowledge-system-feedback-loop-fixes.md`; `dist/` remains generated-only and unstaged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


## Test plan

- `bun run build`
- `bun run typecheck`
- `bunx @biomejs/biome@2.3.14 ci .`
- `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- `bun --smol test tests/unit/hooks/knowledge-injector-events.test.ts --timeout 30000`
- `bun --smol test tests/unit/hooks/knowledge-verdict-feedback.test.ts --timeout 30000`
- `bun --smol test tests/unit/hooks/knowledge-application-gate.test.ts --timeout 30000`
- `bun --smol test tests/unit/tools/knowledge-query.test.ts --timeout 30000`
- `bun --smol test tests/unit/tools/git-blame.test.ts --timeout 30000` (passed when rerun with sufficient filesystem access)

## Notes

- confirmed no existing PR for `codex/knowledge-system-fixes` before creation
- issue `#1290` is already closed, so this PR intentionally does not use a closing keyword
- several unrelated tests fail on clean `origin/main`; details are captured in `.swarm/evidence/commit-pr-validation.md`


