### PR TITLE
feat(symbol-graph): harden python rust and go support

### DIFF
--- a/docs/releases/pending/1527-1528-symbol-graph-python-rust-go.md
+++ b/docs/releases/pending/1527-1528-symbol-graph-python-rust-go.md
@@ -1,0 +1,6 @@
+# Symbol graph language hardening
+
+- Harden Python symbol extraction for `.py` and `.pyw` files, including `__all__`, package-root re-exports, decorator ranges, methods, and richer import bindings.
+- Add Rust and Go exported-symbol coverage across the symbols tool, sync graph builder, and async repo_map context packs.
+- Improve conservative Rust grouped-use and Go blank/dot import handling in graph import metadata.
+

--- a/src/graph/import-extractor.ts
+++ b/src/graph/import-extractor.ts
@@ -43,6 +43,7 @@ export const SOURCE_EXTENSIONS = [
 	'.mjs',
 	'.cjs',
 	'.py',
+	'.pyw',
 	'.go',
 	'.rs',
 ] as const;
@@ -70,15 +71,15 @@ const RESOLVE_INDEX_CANDIDATES = [
 	'index.mjs',
 ];
 
-const PY_EXTENSION_CANDIDATES = ['.py'];
-const PY_INDEX_CANDIDATES = ['__init__.py'];
+const PY_EXTENSION_CANDIDATES = ['.py', '.pyw'];
+const PY_INDEX_CANDIDATES = ['__init__.py', '__init__.pyw'];
 
 export function getLanguageFromExtension(ext: string): string | null {
 	const lower = ext.toLowerCase();
 	if (TS_JS_EXTENSIONS.includes(lower)) {
 		return lower === '.ts' || lower === '.tsx' ? 'typescript' : 'javascript';
 	}
-	if (lower === '.py') return 'python';
+	if (lower === '.py' || lower === '.pyw') return 'python';
 	if (lower === '.go') return 'go';
 	if (lower === '.rs') return 'rust';
 	return null;
@@ -162,7 +163,10 @@ function tryResolvePython(
 		}
 		return null;
 	};
-	for (const ext of PY_EXTENSION_CANDIDATES) {
+	const sourceExt = path.extname(sourceFileAbs).toLowerCase();
+	const extensionCandidates =
+		sourceExt === '.pyw' ? ['.pyw', '.py'] : [...PY_EXTENSION_CANDIDATES];
+	for (const ext of extensionCandidates) {
 		const hit = accept(baseAbs + ext);
 		if (hit) return hit;
 	}
@@ -589,9 +593,9 @@ function parsePythonImports(content: string): ParsedImport[] {
 	return out;
 }
 
-const GO_SINGLE_IMPORT_RE = /^\s*import\s+(?:[\w.]+\s+)?["`]([^"`]+)["`]/gm;
+const GO_SINGLE_IMPORT_RE = /^\s*import\s+(?:(\.|_|\w+)\s+)?["`]([^"`]+)["`]/gm;
 const GO_BLOCK_IMPORT_RE = /^\s*import\s*\(([\s\S]*?)\)/gm;
-const GO_BLOCK_LINE_RE = /(?:[\w.]+\s+)?["`]([^"`]+)["`]/g;
+const GO_BLOCK_LINE_RE = /(?:(\.|_|\w+)\s+)?["`]([^"`]+)["`]/g;
 
 function parseGoImports(content: string): ParsedImport[] {
 	const out: ParsedImport[] = [];
@@ -601,9 +605,9 @@ function parseGoImports(content: string): ParsedImport[] {
 		m = GO_SINGLE_IMPORT_RE.exec(content)
 	) {
 		out.push({
-			rawModule: m[1],
+			rawModule: m[2],
 			importedSymbols: [],
-			importType: 'namespace',
+			importType: m[1] === '_' ? 'sideeffect' : 'namespace',
 			line: lineNumberFor(content, m.index),
 		});
 	}
@@ -620,9 +624,9 @@ function parseGoImports(content: string): ParsedImport[] {
 			inner = GO_BLOCK_LINE_RE.exec(block)
 		) {
 			out.push({
-				rawModule: inner[1],
+				rawModule: inner[2],
 				importedSymbols: [],
-				importType: 'namespace',
+				importType: inner[1] === '_' ? 'sideeffect' : 'namespace',
 				line: lineNumberFor(content, blockStart + inner.index),
 			});
 		}
@@ -631,7 +635,7 @@ function parseGoImports(content: string): ParsedImport[] {
 	return out;
 }
 
-const RUST_USE_RE = /^\s*use\s+([\w:]+(?:\s*::\s*\{[^}]*\})?)\s*;/gm;
+const RUST_USE_RE = /^\s*use\s+(.+?)\s*;/gm;
 
 function parseRustUses(content: string): ParsedImport[] {
 	const out: ParsedImport[] = [];
@@ -640,10 +644,27 @@ function parseRustUses(content: string): ParsedImport[] {
 		m !== null;
 		m = RUST_USE_RE.exec(content)
 	) {
+		const raw = m[1].trim();
+		const grouped = raw.match(/^(.+?)::\{(.+)\}$/);
+		if (grouped) {
+			const importedSymbols = grouped[2]
+				.split(',')
+				.map((part) => part.trim())
+				.map((part) => part.match(/^(\w+)(?:\s+as\s+\w+)?$/)?.[1])
+				.filter((part): part is string => Boolean(part));
+			out.push({
+				rawModule: grouped[1].trim(),
+				importedSymbols,
+				importType: 'named',
+				line: lineNumberFor(content, m.index),
+			});
+			continue;
+		}
+		const alias = raw.match(/^(.+?)\s+as\s+\w+$/);
 		out.push({
-			rawModule: m[1].trim(),
+			rawModule: alias ? alias[1].trim() : raw,
 			importedSymbols: [],
-			importType: 'namespace',
+			importType: alias ? 'named' : 'namespace',
 			line: lineNumberFor(content, m.index),
 		});
 	}

--- a/src/graph/import-extractor.ts
+++ b/src/graph/import-extractor.ts
@@ -650,7 +650,12 @@ function parseRustUses(content: string): ParsedImport[] {
 			const importedSymbols = grouped[2]
 				.split(',')
 				.map((part) => part.trim())
-				.map((part) => part.match(/^(\w+)(?:\s+as\s+\w+)?$/)?.[1])
+				.map((part) => {
+					const [_full, _path_prefix, symbol, alias] =
+						part.match(/^(?:(.+?)::)?(\w+)(?:\s+as\s+(\w+))?$/) ?? [];
+					// If there's an alias, use it; otherwise use the symbol (last path segment)
+					return alias ?? symbol;
+				})
 				.filter((part): part is string => Boolean(part));
 			out.push({
 				rawModule: grouped[1].trim(),

--- a/src/graph/symbol-extractor.ts
+++ b/src/graph/symbol-extractor.ts
@@ -1,5 +1,10 @@
 import * as path from 'node:path';
-import { extractPythonSymbols, extractTSSymbols } from '../tools/symbols';
+import {
+	extractGoSymbols,
+	extractPythonSymbols,
+	extractRustSymbols,
+	extractTSSymbols,
+} from '../tools/symbols';
 import { getLanguageFromExtension } from './import-extractor';
 import type { ExportedSymbol, SymbolKind } from './types';
 
@@ -33,6 +38,14 @@ export function extractExportedSymbols(
 	}
 	if (language === 'python') {
 		const raw = extractPythonSymbols(relativeFilePath, workspaceRoot);
+		return raw.filter((s) => s.exported).map(toExported);
+	}
+	if (language === 'rust') {
+		const raw = extractRustSymbols(relativeFilePath, workspaceRoot);
+		return raw.filter((s) => s.exported).map(toExported);
+	}
+	if (language === 'go') {
+		const raw = extractGoSymbols(relativeFilePath, workspaceRoot);
 		return raw.filter((s) => s.exported).map(toExported);
 	}
 	return [];

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -171,7 +171,15 @@ const QUERIES: Record<
 			(struct_item
 				name: (type_identifier) @struct.name
 			) @struct.def
-			(impl_item type: (type_identifier) @impl.name) @impl.def
+			(enum_item
+				name: (type_identifier) @enum.name
+			) @enum.def
+			(trait_item
+				name: (type_identifier) @trait.name
+			) @trait.def
+			(mod_item
+				name: (identifier) @mod.name
+			) @mod.def
 		`,
 		imports: `
 			(use_declaration) @import
@@ -184,7 +192,10 @@ const QUERIES: Record<
 	go: {
 		defs: `
 			(function_declaration name: (identifier) @func.name) @func.def
+			(method_declaration name: (field_identifier) @method.name) @method.def
 			(type_declaration (type_spec name: (type_identifier) @type.name)) @type.def
+			(var_declaration (var_spec name: (identifier) @const.name)) @const.def
+			(const_declaration (const_spec name: (identifier) @const.name)) @const.def
 		`,
 		imports: `
 			(import_declaration) @import
@@ -347,7 +358,8 @@ const CAPTURE_KIND: Record<string, FileSymbolFacts['defs'][0]['kind']> = {
 	enum: 'enum',
 	method: 'method',
 	struct: 'type',
-	impl: 'type',
+	trait: 'interface',
+	mod: 'type',
 	object: 'class',
 	mixin: 'type',
 	protocol: 'interface',
@@ -377,6 +389,11 @@ const DEF_TYPES = new Set([
 	'class_definition',
 	'lexical_declaration',
 	'impl_item',
+	'enum_item',
+	'trait_item',
+	'mod_item',
+	'var_declaration',
+	'const_declaration',
 	'method',
 	'class',
 ]);
@@ -509,9 +526,23 @@ function buildFacts(
 		if (!defCap || nameCaps.length === 0) continue;
 
 		const kindKey = defCap.name.replace(/\.def$/, '');
-		const kind = CAPTURE_KIND[kindKey] ?? 'function';
 		const originalDefNode = asTs(defCap.node);
 		let defNode = originalDefNode;
+		let kind = CAPTURE_KIND[kindKey] ?? 'function';
+		if (
+			grammarId === 'python' &&
+			kindKey === 'func' &&
+			hasAncestorOfType(originalDefNode, 'class_definition')
+		) {
+			kind = 'method';
+		}
+		if (
+			grammarId === 'rust' &&
+			kindKey === 'func' &&
+			hasAncestorOfType(originalDefNode, 'impl_item')
+		) {
+			kind = 'method';
+		}
 		const explicitExported = exportNodes.some((en) =>
 			isNodeInside(en, defNode),
 		);
@@ -541,6 +572,12 @@ function buildFacts(
 					} as TsNode);
 				}
 			}
+		}
+		if (
+			grammarId === 'python' &&
+			defNode.parent?.type === 'decorated_definition'
+		) {
+			defNode = asTs(defNode.parent);
 		}
 
 		for (const nc of nameCaps) {
@@ -580,20 +617,39 @@ function buildFacts(
 		entry: FileSymbolFacts['imports'][0];
 	}> = [];
 	const addImport = (
-		entry: FileSymbolFacts['imports'][0] | null,
+		entry: FileSymbolFacts['imports'][0] | FileSymbolFacts['imports'] | null,
 		node: TsNode,
 	) => {
 		if (!entry) return;
-		importsWithIndex.push({
-			index: node.startIndex,
-			entry: entry.reExport
-				? {
-						...entry,
-						startLine: node.startPosition.row + 1,
-						endLine: node.endPosition.row + 1,
-					}
-				: entry,
-		});
+		for (const item of Array.isArray(entry) ? entry : [entry]) {
+			const pythonExportedBindings =
+				grammarId === 'python' && pythonAllNames && item.bindings.length > 0
+					? item.bindings
+							.filter((binding) => pythonAllNames.has(binding.local))
+							.map((binding) => ({
+								imported: binding.imported,
+								exported: binding.local,
+							}))
+					: [];
+			const normalizedItem =
+				pythonExportedBindings.length > 0
+					? {
+							...item,
+							reExport: true,
+							exportedBindings: pythonExportedBindings,
+						}
+					: item;
+			importsWithIndex.push({
+				index: node.startIndex,
+				entry: normalizedItem.reExport
+					? {
+							...normalizedItem,
+							startLine: node.startPosition.row + 1,
+							endLine: node.endPosition.row + 1,
+						}
+					: normalizedItem,
+			});
+		}
 	};
 	for (const m of importMatches) {
 		const importCap = m.captures.find((c) => c.name === 'import');
@@ -603,16 +659,22 @@ function buildFacts(
 			// Go block import: `import ( "fmt" "os" )` — find the
 			// import_spec_list child, then iterate its import_spec children.
 			if (grammarId === 'go' && rawText.startsWith('import (')) {
+				const seenGoSpecifiers = new Set<string>();
 				const specListNode = importNode.children.find(
 					(c): c is TsNode => c !== null && c.type === 'import_spec_list',
 				);
 				if (specListNode) {
 					for (const spec of asTs(specListNode).children) {
 						if (spec && spec.type === 'import_spec') {
-							const parsed = parseGoImport(spec.text.trim());
+							const parsed = parseGoImportHardened(spec.text.trim());
+							if (parsed) seenGoSpecifiers.add(parsed.specifier);
 							addImport(parsed, asTs(spec));
 						}
 					}
+				}
+				for (const parsed of parseGoBlockImports(rawText)) {
+					if (seenGoSpecifiers.has(parsed.specifier)) continue;
+					addImport(parsed, importNode);
 				}
 			} else {
 				const parsed = parseImport(grammarId, rawText);
@@ -899,14 +961,14 @@ function parseEsmImport(text: string): FileSymbolFacts['imports'][0] | null {
 function parseImport(
 	grammarId: string,
 	text: string,
-): FileSymbolFacts['imports'][0] | null {
+): FileSymbolFacts['imports'][0] | FileSymbolFacts['imports'] | null {
 	switch (grammarId) {
 		case 'python':
-			return parsePythonImport(text);
+			return parsePythonImportHardened(text);
 		case 'rust':
-			return parseRustUse(text);
+			return parseRustUseHardened(text);
 		case 'go':
-			return parseGoImport(text);
+			return parseGoImportHardened(text);
 		case 'java':
 			return parseJavaImport(text);
 		case 'kotlin':
@@ -932,7 +994,9 @@ function parseImport(
 	}
 }
 
-function parsePythonImport(text: string): FileSymbolFacts['imports'][0] | null {
+function _parsePythonImport(
+	text: string,
+): FileSymbolFacts['imports'][0] | null {
 	const t = text.trim();
 	// import foo            → specifier: 'foo',  bindings: []
 	// import foo as bar     → specifier: 'foo',  bindings: [{imported:'foo', local:'bar'}]
@@ -970,7 +1034,66 @@ function parsePythonImport(text: string): FileSymbolFacts['imports'][0] | null {
 	return null;
 }
 
-function parseRustUse(text: string): FileSymbolFacts['imports'][0] | null {
+function parsePythonImportHardened(
+	text: string,
+): FileSymbolFacts['imports'][0] | FileSymbolFacts['imports'] | null {
+	const t = text.trim();
+	const fullImport = t.match(/^import\s+(.+)$/);
+	if (fullImport) {
+		const entries: FileSymbolFacts['imports'] = [];
+		for (const rawPart of fullImport[1].split(',')) {
+			const part = rawPart.trim();
+			if (!part) continue;
+			const alias = part.match(/^([\w.]+)\s+as\s+(\w+)$/);
+			const specifier = alias ? alias[1] : part;
+			const local = alias ? alias[2] : specifier.split('.')[0];
+			if (!specifier || !/^\w+$/.test(local)) continue;
+			entries.push({
+				specifier,
+				importType: alias ? 'named' : 'namespace',
+				bindings: [{ imported: specifier, local }],
+			});
+		}
+		if (entries.length === 0) return null;
+		return entries.length === 1 ? entries[0] : entries;
+	}
+
+	const fromImport = t.match(/^from\s+(\S+)\s+import\s+(.+)$/);
+	if (!fromImport) return null;
+	const bindings: Array<{ imported: string; local: string }> = [];
+	for (const rawPart of fromImport[2].split(',')) {
+		const part = rawPart.trim();
+		if (!part) continue;
+		if (part === '*') {
+			return {
+				specifier: normalizePythonModuleSpecifier(fromImport[1]),
+				importType: 'namespace',
+				bindings: [],
+			};
+		}
+		const alias = part.match(/^(\w+)\s+as\s+(\w+)$/);
+		if (alias) {
+			bindings.push({ imported: alias[1], local: alias[2] });
+		} else if (/^\w+$/.test(part)) {
+			bindings.push({ imported: part, local: part });
+		}
+	}
+	return {
+		specifier: normalizePythonModuleSpecifier(fromImport[1]),
+		importType: 'named',
+		bindings,
+	};
+}
+
+function normalizePythonModuleSpecifier(specifier: string): string {
+	const leadingDots = specifier.match(/^\.+/)?.[0].length ?? 0;
+	if (leadingDots === 0) return specifier;
+	const rest = specifier.slice(leadingDots).replace(/\./g, '/');
+	const prefix = leadingDots === 1 ? './' : '../'.repeat(leadingDots - 1);
+	return `${prefix}${rest}`;
+}
+
+function _parseRustUse(text: string): FileSymbolFacts['imports'][0] | null {
 	const t = text.trim();
 	// use foo::bar::baz;
 	// use foo::bar::baz as alias;
@@ -994,7 +1117,67 @@ function parseRustUse(text: string): FileSymbolFacts['imports'][0] | null {
 	return null;
 }
 
-function parseGoImport(text: string): FileSymbolFacts['imports'][0] | null {
+function parseRustUseHardened(
+	text: string,
+): FileSymbolFacts['imports'][0] | null {
+	const t = text.trim();
+	const aliased = t.match(/^use\s+(.+?)\s+as\s+(\w+)\s*;?\s*$/);
+	if (aliased) {
+		const parts = aliased[1].trim().split('::').filter(Boolean);
+		const imported = parts.pop() ?? aliased[1].trim();
+		const specifier = parts.length > 0 ? parts.join('::') : aliased[1].trim();
+		return {
+			specifier,
+			importType: 'named',
+			bindings: [{ imported, local: aliased[2] }],
+		};
+	}
+
+	const grouped = t.match(/^use\s+(.+?)::\{(.+)\}\s*;?\s*$/);
+	if (grouped) {
+		const base = grouped[1].trim();
+		const bindings: Array<{ imported: string; local: string }> = [];
+		for (const rawPart of grouped[2].split(',')) {
+			const part = rawPart.trim();
+			if (!part) continue;
+			const alias = part.match(/^(\w+)\s+as\s+(\w+)$/);
+			if (alias) {
+				bindings.push({ imported: alias[1], local: alias[2] });
+			} else if (/^\w+$/.test(part)) {
+				const local = part === 'self' ? base.split('::').pop() || base : part;
+				bindings.push({ imported: part, local });
+			}
+		}
+		return { specifier: base, importType: 'named', bindings };
+	}
+
+	const simple = t.match(/^use\s+(.+?)\s*;?\s*$/);
+	if (!simple) return null;
+	const parts = simple[1].trim().split('::').filter(Boolean);
+	const imported = parts.pop() ?? simple[1].trim();
+	const specifier = parts.length > 0 ? parts.join('::') : simple[1].trim();
+	const local = imported;
+	return {
+		specifier,
+		importType: 'named',
+		bindings: /^\w+$/.test(imported) ? [{ imported, local }] : [],
+	};
+}
+
+function parseGoBlockImports(text: string): FileSymbolFacts['imports'] {
+	const entries: FileSymbolFacts['imports'] = [];
+	const body = text.match(/^import\s*\(([\s\S]*?)\)\s*$/)?.[1];
+	if (!body) return entries;
+	for (const line of body.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith('//')) continue;
+		const parsed = parseGoImportHardened(trimmed);
+		if (parsed) entries.push(parsed);
+	}
+	return entries;
+}
+
+function _parseGoImport(text: string): FileSymbolFacts['imports'][0] | null {
 	const t = text.trim();
 	// Block import: `import ( "fmt" "os" )` — return null here; buildFacts
 	// detects block imports via the raw text starting with 'import (' and
@@ -1031,6 +1214,42 @@ function parseGoImport(text: string): FileSymbolFacts['imports'][0] | null {
 		};
 	}
 	return null;
+}
+
+function parseGoImportHardened(
+	text: string,
+): FileSymbolFacts['imports'][0] | null {
+	const t = text.trim();
+	if (t.startsWith('import (')) return null;
+
+	const aliased =
+		t.match(/^([\w._]+)\s+["`]([^"`]+)["`]$/) ??
+		t.match(/^import\s+([\w._]+)\s+["`]([^"`]+)["`]/);
+	if (aliased) {
+		if (aliased[1] === '_') {
+			return { specifier: aliased[2], importType: 'sideeffect', bindings: [] };
+		}
+		if (aliased[1] === '.') {
+			return {
+				specifier: aliased[2],
+				importType: 'namespace',
+				bindings: [{ imported: '*', local: '.' }],
+			};
+		}
+		return {
+			specifier: aliased[2],
+			importType: 'named',
+			bindings: [{ imported: aliased[2], local: aliased[1] }],
+		};
+	}
+
+	const simple = t.match(/^import\s+["`]([^"`]+)["`]|^["`]([^"`]+)["`]$/);
+	if (!simple) return null;
+	return {
+		specifier: simple[1] ?? simple[2],
+		importType: 'namespace',
+		bindings: [],
+	};
 }
 
 function parseJavaImport(text: string): FileSymbolFacts['imports'][0] | null {

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -580,6 +580,27 @@ function buildFacts(
 			defNode = asTs(defNode.parent);
 		}
 
+		// For Python methods, determine if the parent class is exported
+		let pythonParentClassExported = false;
+		if (grammarId === 'python' && kind === 'method') {
+			let current: TsNode | null = originalDefNode.parent;
+			while (current) {
+				if (current.type === 'class_definition') {
+					const classNameNode = current.children?.find(
+						(c): c is TsNode => c != null && c.type === 'identifier',
+					);
+					if (classNameNode) {
+						const className = classNameNode.text;
+						pythonParentClassExported = pythonAllNames
+							? pythonAllNames.has(className)
+							: !className.startsWith('_');
+					}
+					break;
+				}
+				current = current.parent;
+			}
+		}
+
 		for (const nc of nameCaps) {
 			const nameNode = asTs(nc.node);
 			const localName = nameNode.text;
@@ -594,6 +615,7 @@ function buildFacts(
 				explicitExported,
 				commonJsExport,
 				pythonAllNames,
+				pythonParentClassExported,
 			});
 			const exportedName = isDefaultExport
 				? 'default'

--- a/src/lang/symbol-visibility.ts
+++ b/src/lang/symbol-visibility.ts
@@ -182,6 +182,14 @@ export function getSymbolVisibilityInfo(
 
 	const ownVisibility = visibilityFromText(ctx.grammarId, ctx.defNode.text);
 	if (ctx.kind === 'method') {
+		if (ctx.grammarId === 'go') {
+			return isUppercasePublic(ctx.localName)
+				? {
+						...PUBLIC_INFO,
+						exportedReason: 'naming_convention',
+					}
+				: { ...PRIVATE_INFO };
+		}
 		return {
 			exported: false,
 			visibility: ownVisibility,

--- a/src/lang/symbol-visibility.ts
+++ b/src/lang/symbol-visibility.ts
@@ -70,6 +70,8 @@ export interface SymbolVisibilityContext {
 	explicitExported: boolean;
 	commonJsExport?: CommonJsExportInfo;
 	pythonAllNames?: Set<string> | null;
+	/** For Python methods: true if the enclosing class is exported (in __all__ or public naming convention) */
+	pythonParentClassExported?: boolean;
 }
 
 const PUBLIC_INFO: SymbolVisibilityInfo = {
@@ -189,6 +191,21 @@ export function getSymbolVisibilityInfo(
 						exportedReason: 'naming_convention',
 					}
 				: { ...PRIVATE_INFO };
+		}
+		if (ctx.grammarId === 'python' && ctx.pythonParentClassExported) {
+			// Python methods are exported if their parent class is exported
+			// (unless the method starts with _ or is __init__)
+			const isPrivate = ctx.localName.startsWith('_');
+			const isInit = ctx.localName === '__init__';
+			if (isPrivate || isInit) {
+				return { ...PRIVATE_INFO };
+			}
+			return {
+				exported: true,
+				visibility: 'public',
+				exportedReason: 'modifier',
+				apiSurfaceKind: 'public',
+			};
 		}
 		return {
 			exported: false,

--- a/src/tools/batch-symbols.test.ts
+++ b/src/tools/batch-symbols.test.ts
@@ -426,6 +426,34 @@ export class MyClass {
 			expect(typeof fileResult.errorType).toBe('string');
 		});
 
+		test('omitting exported_only defaults to exported-only behavior', async () => {
+			createTestFile(
+				'mixed.ts',
+				`
+export function exportedFunc() {}
+function privateFunc() {}
+export const exportedConst = 42;
+const privateConst = 100;
+`,
+			);
+
+			// Omit exported_only entirely — should default to true (only exported symbols)
+			const result = await executeBatchSymbols(
+				{ files: ['mixed.ts'] },
+				tempDir,
+			);
+
+			const parsed = JSON.parse(result);
+			const symbols = parsed.results[0].symbols;
+
+			// Should only contain the two exported symbols
+			const symbolNames = symbols.map((s: any) => s.name);
+			expect(symbolNames).toContain('exportedFunc');
+			expect(symbolNames).toContain('exportedConst');
+			expect(symbolNames).not.toContain('privateFunc');
+			expect(symbolNames).not.toContain('privateConst');
+		});
+
 		test('exported_only filter affects symbol count', async () => {
 			createTestFile(
 				'exported.ts',

--- a/src/tools/batch-symbols.ts
+++ b/src/tools/batch-symbols.ts
@@ -3,7 +3,12 @@ import * as path from 'node:path';
 import { tool } from '@opencode-ai/plugin';
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
 import { createSwarmTool } from './create-tool';
-import { extractPythonSymbols, extractTSSymbols } from './symbols';
+import {
+	extractGoSymbols,
+	extractPythonSymbols,
+	extractRustSymbols,
+	extractTSSymbols,
+} from './symbols';
 
 // Re-export SymbolInfo for use in batch results
 export interface SymbolInfo {
@@ -179,13 +184,20 @@ function processFile(
 			syms = extractTSSymbols(file, cwd);
 			break;
 		case '.py':
+		case '.pyw':
 			syms = extractPythonSymbols(file, cwd);
+			break;
+		case '.rs':
+			syms = extractRustSymbols(file, cwd);
+			break;
+		case '.go':
+			syms = extractGoSymbols(file, cwd);
 			break;
 		default:
 			return {
 				file,
 				success: false,
-				error: `Unsupported file extension: ${ext}. Supported: .ts, .tsx, .js, .jsx, .mjs, .cjs, .py`,
+				error: `Unsupported file extension: ${ext}. Supported: .ts, .tsx, .js, .jsx, .mjs, .cjs, .py, .pyw, .rs, .go`,
 				errorType: 'unsupported-language',
 			};
 	}

--- a/src/tools/batch-symbols.ts
+++ b/src/tools/batch-symbols.ts
@@ -288,7 +288,7 @@ export const batch_symbols: ToolDefinition = createSwarmTool({
 				);
 			}
 			files = obj.files.map((f) => String(f));
-			exportedOnly = obj.exported_only === true;
+			exportedOnly = obj.exported_only !== false;
 		} catch {
 			return JSON.stringify(
 				{

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -21,7 +21,12 @@ import { extractFileSymbols } from '../../lang/symbol-graph';
 import * as logger from '../../utils/logger';
 import { containsControlChars } from '../../utils/path-security';
 import { yieldToEventLoop } from '../../utils/timeout';
-import { extractPythonSymbols, extractTSSymbols } from '../symbols';
+import {
+	extractGoSymbols,
+	extractPythonSymbols,
+	extractRustSymbols,
+	extractTSSymbols,
+} from '../symbols';
 import { extractFileOntology } from './ontology';
 import { safeRealpathSync } from './safe-realpath';
 import type {
@@ -54,6 +59,8 @@ export const _internals: {
 	safeRealpathSync: typeof safeRealpathSync;
 	extractTSSymbols: typeof extractTSSymbols;
 	extractPythonSymbols: typeof extractPythonSymbols;
+	extractRustSymbols: typeof extractRustSymbols;
+	extractGoSymbols: typeof extractGoSymbols;
 	parseFileImports: typeof parseFileImports;
 	extractFileOntology: typeof extractFileOntology;
 	stripComments: typeof stripComments;
@@ -63,6 +70,8 @@ export const _internals: {
 	safeRealpathSync,
 	extractTSSymbols,
 	extractPythonSymbols,
+	extractRustSymbols,
+	extractGoSymbols,
 	parseFileImports,
 	extractFileOntology,
 	stripComments,
@@ -275,10 +284,37 @@ export function resolveModuleSpecifier(
 	}
 
 	try {
+		let normalizedSpecifier = specifier;
+		const rustParts = specifier.split('::').filter(Boolean);
+		if (rustParts[0] === 'crate') {
+			let target = path.join(workspaceRoot, ...rustParts.slice(1));
+			const targetExists =
+				existsSync(target) ||
+				existsSync(`${target}.rs`) ||
+				existsSync(path.join(target, 'mod.rs'));
+			if (!targetExists) {
+				target = path.join(path.dirname(sourceFile), ...rustParts.slice(1));
+			}
+			normalizedSpecifier = path
+				.relative(path.dirname(sourceFile), target)
+				.replace(/\\/g, '/');
+			if (!normalizedSpecifier.startsWith('.')) {
+				normalizedSpecifier = `./${normalizedSpecifier}`;
+			}
+		} else if (rustParts[0] === 'self') {
+			normalizedSpecifier = `./${rustParts.slice(1).join('/')}`;
+		} else if (rustParts[0] === 'super') {
+			let superCount = 0;
+			while (rustParts[superCount] === 'super') superCount++;
+			normalizedSpecifier = `${'../'.repeat(superCount)}${rustParts
+				.slice(superCount)
+				.join('/')}`;
+		}
+
 		// Resolve relative to source file
-		if (specifier.startsWith('.')) {
+		if (normalizedSpecifier.startsWith('.')) {
 			const sourceDir = path.dirname(sourceFile);
-			let resolved = path.resolve(sourceDir, specifier);
+			let resolved = path.resolve(sourceDir, normalizedSpecifier);
 
 			// SECURITY: Resolve symlinks to get the real path, then verify the
 			// real path is still within the workspace boundary. This prevents
@@ -301,20 +337,79 @@ export function resolveModuleSpecifier(
 				return null;
 			}
 
+			const findDirectoryEntry = (directory: string): string | null => {
+				for (const initName of ['__init__.py', '__init__.pyw', 'mod.rs']) {
+					const candidate = path.join(directory, initName);
+					if (existsSync(candidate)) return candidate;
+				}
+				if (path.extname(sourceFile).toLowerCase() === '.go') {
+					const basenameCandidate = path.join(
+						directory,
+						`${path.basename(directory)}.go`,
+					);
+					if (existsSync(basenameCandidate)) return basenameCandidate;
+					try {
+						const firstGo = fsSync
+							.readdirSync(directory)
+							.filter(
+								(entry) => entry.endsWith('.go') && !entry.endsWith('_test.go'),
+							)
+							.sort((a, b) => a.localeCompare(b))[0];
+						if (firstGo) return path.join(directory, firstGo);
+					} catch {
+						return null;
+					}
+				}
+				return null;
+			};
+
+			if (existsSync(resolved)) {
+				try {
+					if (fsSync.statSync(resolved).isDirectory()) {
+						const found = findDirectoryEntry(resolved);
+						if (!found) return null;
+						const foundRealPath = _internals.safeRealpathSync(found, found);
+						if (foundRealPath === null) return null;
+						realResolved = foundRealPath;
+						resolved = found;
+					}
+				} catch {
+					return null;
+				}
+			}
+
 			// Try to resolve the extensionless path to a real file.
 			// TypeScript/JavaScript imports commonly omit extensions: import { foo } from './utils'
 			// We need to find the actual file: ./utils.ts, ./utils.js, etc.
 			if (!existsSync(resolved)) {
-				const EXTENSIONS = [
-					'.ts',
-					'.tsx',
-					'.js',
-					'.jsx',
-					'.mjs',
-					'.cjs',
-					'.py',
-					'.json',
-				];
+				const EXTENSIONS =
+					path.extname(sourceFile).toLowerCase() === '.pyw'
+						? [
+								'.pyw',
+								'.py',
+								'.rs',
+								'.go',
+								'.ts',
+								'.tsx',
+								'.js',
+								'.jsx',
+								'.mjs',
+								'.cjs',
+								'.json',
+							]
+						: [
+								'.ts',
+								'.tsx',
+								'.js',
+								'.jsx',
+								'.mjs',
+								'.cjs',
+								'.py',
+								'.pyw',
+								'.rs',
+								'.go',
+								'.json',
+							];
 				let found: string | null = null;
 				for (const ext of EXTENSIONS) {
 					const candidate = resolved + ext;
@@ -322,6 +417,9 @@ export function resolveModuleSpecifier(
 						found = candidate;
 						break;
 					}
+				}
+				if (!found) {
+					found = findDirectoryEntry(resolved);
 				}
 				if (found) {
 					// Re-resolve symlinks for the found file
@@ -675,7 +773,22 @@ function stripComments(content: string): string {
 	return out;
 }
 
-function parseFileImports(rawContent: string): ParsedImport[] {
+function parseFileImports(
+	rawContent: string,
+	sourceFile?: string,
+	workspaceRoot?: string,
+): ParsedImport[] {
+	const ext = sourceFile ? path.extname(sourceFile).toLowerCase() : '';
+	if (ext === '.py' || ext === '.pyw') {
+		return parsePythonFileImports(rawContent, sourceFile);
+	}
+	if (ext === '.rs') {
+		return parseRustFileImports(rawContent, sourceFile, workspaceRoot);
+	}
+	if (ext === '.go') {
+		return parseGoFileImports(rawContent);
+	}
+
 	const imports: ParsedImport[] = [];
 	const content = stripComments(rawContent);
 
@@ -737,6 +850,228 @@ function parseFileImports(rawContent: string): ParsedImport[] {
 		});
 	}
 
+	return imports;
+}
+
+function makeParsedImport(
+	specifier: string,
+	importType: ParsedImport['importType'],
+	bindings: ImportBinding[],
+	reExport = false,
+): ParsedImport | null {
+	if (!specifier || containsControlChars(specifier)) return null;
+	return {
+		specifier,
+		importType,
+		importedSymbols: bindings.map((binding) => binding.imported),
+		bindings,
+		reExport,
+	};
+}
+
+function parsePythonFileImports(
+	rawContent: string,
+	sourceFile?: string,
+): ParsedImport[] {
+	const imports: ParsedImport[] = [];
+	const isPackageInit = sourceFile
+		? ['__init__.py', '__init__.pyw'].includes(path.basename(sourceFile))
+		: false;
+
+	for (const line of rawContent.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith('#')) continue;
+
+		const fullImport = trimmed.match(/^import\s+(.+?)(?:\s*#.*)?$/);
+		if (fullImport) {
+			for (const rawPart of fullImport[1].split(',')) {
+				const part = rawPart.trim();
+				if (!part) continue;
+				const alias = part.match(/^([\w.]+)\s+as\s+(\w+)$/);
+				const specifier = alias ? alias[1] : part;
+				const local = alias ? alias[2] : specifier.split('.')[0];
+				if (!/^\w+$/.test(local)) continue;
+				const parsed = makeParsedImport(specifier, 'namespace', [
+					{ imported: specifier, local },
+				]);
+				if (parsed) imports.push(parsed);
+			}
+			continue;
+		}
+
+		const fromImport = trimmed.match(
+			/^from\s+(\S+)\s+import\s+(.+?)(?:\s*#.*)?$/,
+		);
+		if (!fromImport) continue;
+		if (fromImport[2].trim() === '*') {
+			const parsed = makeParsedImport(
+				normalizePythonModuleSpecifier(fromImport[1]),
+				'namespace',
+				[],
+				isPackageInit,
+			);
+			if (parsed) imports.push(parsed);
+			continue;
+		}
+
+		const bindings: ImportBinding[] = [];
+		for (const rawPart of fromImport[2].split(',')) {
+			const part = rawPart.trim();
+			if (!part) continue;
+			const alias = part.match(/^(\w+)\s+as\s+(\w+)$/);
+			if (alias) {
+				bindings.push({ imported: alias[1], local: alias[2] });
+			} else if (/^\w+$/.test(part)) {
+				bindings.push({ imported: part, local: part });
+			}
+		}
+		const parsed = makeParsedImport(
+			normalizePythonModuleSpecifier(fromImport[1]),
+			'named',
+			bindings,
+			isPackageInit,
+		);
+		if (parsed) imports.push(parsed);
+	}
+
+	return imports;
+}
+
+function normalizePythonModuleSpecifier(specifier: string): string {
+	const leadingDots = specifier.match(/^\.+/)?.[0].length ?? 0;
+	if (leadingDots === 0) return specifier;
+	const rest = specifier.slice(leadingDots).replace(/\./g, '/');
+	const prefix = leadingDots === 1 ? './' : '../'.repeat(leadingDots - 1);
+	return `${prefix}${rest}`;
+}
+
+function rustModulePathToSpecifier(
+	modulePath: string,
+	sourceFile?: string,
+	workspaceRoot?: string,
+): string {
+	const parts = modulePath.split('::').filter(Boolean);
+	if (parts.length === 0) return modulePath;
+	if (parts[0] === 'self') {
+		return `./${parts.slice(1).join('/')}`;
+	}
+	if (parts[0] === 'super') {
+		let superCount = 0;
+		while (parts[superCount] === 'super') superCount++;
+		return `${'../'.repeat(superCount)}${parts.slice(superCount).join('/')}`;
+	}
+	if (parts[0] === 'crate' && sourceFile && workspaceRoot) {
+		const target = path.join(workspaceRoot, ...parts.slice(1));
+		let relative = path
+			.relative(path.dirname(sourceFile), target)
+			.replace(/\\/g, '/');
+		if (!relative.startsWith('.')) relative = `./${relative}`;
+		return relative;
+	}
+	return modulePath;
+}
+
+function parseRustFileImports(
+	rawContent: string,
+	sourceFile?: string,
+	workspaceRoot?: string,
+): ParsedImport[] {
+	const imports: ParsedImport[] = [];
+	for (const line of rawContent.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (!trimmed.startsWith('use ')) continue;
+
+		const grouped = trimmed.match(/^use\s+(.+?)::\{(.+)\}\s*;?\s*$/);
+		if (grouped) {
+			const specifier = rustModulePathToSpecifier(
+				grouped[1].trim(),
+				sourceFile,
+				workspaceRoot,
+			);
+			const bindings: ImportBinding[] = [];
+			for (const rawPart of grouped[2].split(',')) {
+				const part = rawPart.trim();
+				if (!part) continue;
+				const alias = part.match(/^(\w+)\s+as\s+(\w+)$/);
+				if (alias) {
+					bindings.push({ imported: alias[1], local: alias[2] });
+				} else if (/^\w+$/.test(part)) {
+					const local =
+						part === 'self' ? grouped[1].split('::').pop() || grouped[1] : part;
+					bindings.push({ imported: part, local });
+				}
+			}
+			const parsed = makeParsedImport(specifier, 'named', bindings);
+			if (parsed) imports.push(parsed);
+			continue;
+		}
+
+		const simple = trimmed.match(/^use\s+(.+?)\s*;?\s*$/);
+		if (!simple) continue;
+		const rawPath = simple[1].trim();
+		const alias = rawPath.match(/^(.+?)\s+as\s+(\w+)$/);
+		const fullPath = (alias ? alias[1] : rawPath).trim();
+		const parts = fullPath.split('::').filter(Boolean);
+		const imported = parts.pop() ?? fullPath;
+		const specifier = rustModulePathToSpecifier(
+			parts.join('::') || fullPath,
+			sourceFile,
+			workspaceRoot,
+		);
+		const local = alias ? alias[2] : imported;
+		const parsed = makeParsedImport(
+			specifier,
+			'named',
+			/^\w+$/.test(imported) && /^\w+$/.test(local)
+				? [{ imported, local }]
+				: [],
+		);
+		if (parsed) imports.push(parsed);
+	}
+	return imports;
+}
+
+function parseGoFileImports(rawContent: string): ParsedImport[] {
+	const imports: ParsedImport[] = [];
+	const content = stripComments(rawContent);
+	const parseSpec = (text: string) => {
+		const spec = text.trim();
+		if (!spec) return;
+		const aliased = spec.match(/^([\w._]+)\s+["`]([^"`]+)["`]$/);
+		if (aliased) {
+			if (aliased[1] === '_') {
+				const parsed = makeParsedImport(aliased[2], 'sideeffect', []);
+				if (parsed) imports.push(parsed);
+				return;
+			}
+			if (aliased[1] === '.') {
+				const parsed = makeParsedImport(aliased[2], 'namespace', [
+					{ imported: '*', local: '.' },
+				]);
+				if (parsed) imports.push(parsed);
+				return;
+			}
+			const parsed = makeParsedImport(aliased[2], 'named', [
+				{ imported: aliased[2], local: aliased[1] },
+			]);
+			if (parsed) imports.push(parsed);
+			return;
+		}
+
+		const simple = spec.match(/^["`]([^"`]+)["`]$/);
+		if (simple) {
+			const parsed = makeParsedImport(simple[1], 'namespace', []);
+			if (parsed) imports.push(parsed);
+		}
+	};
+
+	for (const block of content.matchAll(/import\s*\(([\s\S]*?)\)/g)) {
+		for (const line of block[1].split(/\r?\n/)) parseSpec(line);
+	}
+	const withoutBlocks = content.replace(/import\s*\([\s\S]*?\)/g, '');
+	for (const match of withoutBlocks.matchAll(/^\s*import\s+(.+)$/gm)) {
+		parseSpec(match[1]);
+	}
 	return imports;
 }
 
@@ -1249,15 +1584,29 @@ export function scanFile(
 			({ exports, exportLines } = collectExports(
 				_internals.extractTSSymbols(relativePath, absoluteRoot),
 			));
-		} else if (ext === '.py') {
+		} else if (ext === '.py' || ext === '.pyw') {
 			const relativePath = path.relative(absoluteRoot, filePath);
 			({ exports, exportLines } = collectExports(
 				_internals.extractPythonSymbols(relativePath, absoluteRoot),
 			));
+		} else if (ext === '.rs') {
+			const relativePath = path.relative(absoluteRoot, filePath);
+			({ exports, exportLines } = collectExports(
+				_internals.extractRustSymbols(relativePath, absoluteRoot),
+			));
+		} else if (ext === '.go') {
+			const relativePath = path.relative(absoluteRoot, filePath);
+			({ exports, exportLines } = collectExports(
+				_internals.extractGoSymbols(relativePath, absoluteRoot),
+			));
 		}
 
 		// Parse imports to get specifiers with types
-		const parsedImports = _internals.parseFileImports(content);
+		const parsedImports = _internals.parseFileImports(
+			content,
+			filePath,
+			absoluteRoot,
+		);
 
 		// Comment-stripped content for conservative call-site usage detection.
 		// Computed once per file; only needed when there are imports to attribute.
@@ -1379,7 +1728,11 @@ export async function scanFileAsync(
 		const fallback = scanFile(filePath, absoluteRoot, maxFileSize);
 		let parsedImports: ParsedImport[] = [];
 		try {
-			parsedImports = _internals.parseFileImports(content);
+			parsedImports = _internals.parseFileImports(
+				content,
+				filePath,
+				absoluteRoot,
+			);
 		} catch {
 			parsedImports = [];
 		}
@@ -1414,9 +1767,25 @@ export async function scanFileAsync(
 		exportRanges[d.name] = { startLine: d.startLine, endLine: d.endLine };
 	}
 	const exportsSet = new Set(exports);
+	const isPythonPackageInit =
+		grammarId === 'python' &&
+		['__init__.py', '__init__.pyw'].includes(path.basename(filePath));
 	for (const imp of facts.imports) {
-		if (!imp.reExport || !imp.exportedBindings) continue;
-		for (const binding of imp.exportedBindings) {
+		const packageInitBindings =
+			isPythonPackageInit && imp.bindings.length > 0
+				? imp.bindings
+						.filter((binding) => !binding.local.startsWith('_'))
+						.map((binding) => ({
+							imported: binding.imported,
+							exported: binding.local,
+						}))
+				: [];
+		const exportedBindings =
+			imp.reExport && imp.exportedBindings
+				? imp.exportedBindings
+				: packageInitBindings;
+		if (exportedBindings.length === 0) continue;
+		for (const binding of exportedBindings) {
 			if (binding.imported === '*') {
 				// Include namespace re-export name in exports for dead_exports
 				// visibility, but skip per-symbol edge creation (conservative).
@@ -1597,14 +1966,27 @@ export async function scanFileAsync(
 		});
 	}
 	for (const imp of facts.imports) {
-		if (!imp.reExport || !imp.exportedBindings) continue;
+		const packageInitBindings =
+			isPythonPackageInit && imp.bindings.length > 0
+				? imp.bindings
+						.filter((binding) => !binding.local.startsWith('_'))
+						.map((binding) => ({
+							imported: binding.imported,
+							exported: binding.local,
+						}))
+				: [];
+		const exportedBindings =
+			imp.reExport && imp.exportedBindings
+				? imp.exportedBindings
+				: packageInitBindings;
+		if (exportedBindings.length === 0) continue;
 		const resolvedTarget = resolveModuleSpecifier(
 			absoluteRoot,
 			filePath,
 			imp.specifier,
 		);
 		if (!resolvedTarget) continue;
-		for (const binding of imp.exportedBindings) {
+		for (const binding of exportedBindings) {
 			if (binding.imported === '*') continue;
 			const key =
 				filePath +
@@ -1746,14 +2128,28 @@ export function buildWorkspaceGraph(
 				({ exports, exportLines } = collectExports(
 					_internals.extractTSSymbols(relativePath, absoluteRoot),
 				));
-			} else if (ext === '.py') {
+			} else if (ext === '.py' || ext === '.pyw') {
 				const relativePath = path.relative(absoluteRoot, filePath);
 				({ exports, exportLines } = collectExports(
 					_internals.extractPythonSymbols(relativePath, absoluteRoot),
 				));
+			} else if (ext === '.rs') {
+				const relativePath = path.relative(absoluteRoot, filePath);
+				({ exports, exportLines } = collectExports(
+					_internals.extractRustSymbols(relativePath, absoluteRoot),
+				));
+			} else if (ext === '.go') {
+				const relativePath = path.relative(absoluteRoot, filePath);
+				({ exports, exportLines } = collectExports(
+					_internals.extractGoSymbols(relativePath, absoluteRoot),
+				));
 			}
 
-			parsedImports = _internals.parseFileImports(content);
+			parsedImports = _internals.parseFileImports(
+				content,
+				filePath,
+				absoluteRoot,
+			);
 		} catch {
 			// Skip malformed file without aborting entire graph build
 			continue;

--- a/src/tools/symbols.ts
+++ b/src/tools/symbols.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
 import { z } from 'zod';
+import { collectPythonAllNames } from '../lang/symbol-visibility';
 import { createSwarmTool } from './create-tool';
 
 interface SymbolInfo {
@@ -38,6 +39,9 @@ const SYMBOL_EXTENSIONS = new Set([
 	'.mjs',
 	'.cjs',
 	'.py',
+	'.pyw',
+	'.rs',
+	'.go',
 ]);
 
 // Directories to skip during workspace scanning
@@ -130,6 +134,19 @@ function isPathInWorkspace(filePath: string, workspace: string): boolean {
  */
 function validatePathForRead(filePath: string, workspace: string): boolean {
 	return isPathInWorkspace(filePath, workspace);
+}
+
+function readValidatedSourceFile(filePath: string, cwd: string): string | null {
+	const fullPath = path.join(cwd, filePath);
+	if (!validatePathForRead(fullPath, cwd)) return null;
+
+	try {
+		const stats = fs.statSync(fullPath);
+		if (stats.size > MAX_FILE_SIZE_BYTES) return null;
+		return fs.readFileSync(fullPath, 'utf-8');
+	} catch {
+		return null;
+	}
 }
 
 // ============ TypeScript/JavaScript Extraction ============
@@ -362,47 +379,59 @@ export function extractPythonSymbols(
 	filePath: string,
 	cwd: string,
 ): SymbolInfo[] {
-	const fullPath = path.join(cwd, filePath);
-
-	// Re-validate path right before file read to catch any TOCTOU issues
-	if (!validatePathForRead(fullPath, cwd)) {
-		return [];
-	}
-
-	// Reduce TOCTOU: use single try-catch for exists+stat+read instead of separate checks
-	let content: string;
-	try {
-		const stats = fs.statSync(fullPath);
-		if (stats.size > MAX_FILE_SIZE_BYTES) {
-			throw new Error(
-				`File too large: ${stats.size} bytes (max: ${MAX_FILE_SIZE_BYTES})`,
-			);
-		}
-		content = fs.readFileSync(fullPath, 'utf-8');
-	} catch {
-		return [];
-	}
+	const content = readValidatedSourceFile(filePath, cwd);
+	if (content === null) return [];
 
 	const lines = content.split('\n');
 	const symbols: SymbolInfo[] = [];
 
-	// Check __all__ for explicit exports
-	const allMatch = content.match(/__all__\s*=\s*\[([^\]]+)\]/);
-	const explicitExports = allMatch
-		? allMatch[1].split(',').map((s) => s.trim().replace(/['"]/g, ''))
-		: null;
+	const explicitExports = collectPythonAllNames(content);
+	const isExplicitlyExported = (name: string): boolean =>
+		explicitExports ? explicitExports.has(name) : !name.startsWith('_');
+	const isPackageInit = ['__init__.py', '__init__.pyw'].includes(
+		path.basename(filePath),
+	);
+	const seenNames = new Set<string>();
+	let currentClass: { name: string; exported: boolean; indent: number } | null =
+		null;
+	const addSymbol = (symbol: SymbolInfo) => {
+		if (seenNames.has(symbol.name)) return;
+		seenNames.add(symbol.name);
+		symbols.push(symbol);
+	};
 
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i];
-		if (line.startsWith(' ') || line.startsWith('\t')) continue; // Skip nested definitions
+		const indent = line.match(/^\s*/)?.[0].length ?? 0;
+		if (indent === 0) currentClass = null;
+		if (currentClass && indent > currentClass.indent) {
+			const methodMatch = line
+				.trim()
+				.match(/^(?:async\s+)?def\s+(\w+)\s*\(([^)]*)\)(?:\s*->\s*(.+?))?:/);
+			if (methodMatch) {
+				const name = `${currentClass.name}.${methodMatch[1]}`;
+				addSymbol({
+					name,
+					kind: 'method',
+					exported:
+						currentClass.exported &&
+						!methodMatch[1].startsWith('_') &&
+						methodMatch[1] !== '__init__',
+					signature: `def ${methodMatch[1]}(${methodMatch[2].trim()})${methodMatch[3] ? ` -> ${methodMatch[3].trim()}` : ''}`,
+					line: i + 1,
+				});
+				continue;
+			}
+		}
+		if (line.startsWith(' ') || line.startsWith('\t')) continue; // Skip other nested definitions
 
 		// Functions
 		const fnMatch = line.match(
 			/^(?:async\s+)?def\s+(\w+)\s*\(([^)]*)\)(?:\s*->\s*(.+?))?:/,
 		);
-		if (fnMatch && !fnMatch[1].startsWith('_')) {
-			const exported = !explicitExports || explicitExports.includes(fnMatch[1]);
-			symbols.push({
+		if (fnMatch) {
+			const exported = isExplicitlyExported(fnMatch[1]);
+			addSymbol({
 				name: fnMatch[1],
 				kind: 'function',
 				exported,
@@ -413,10 +442,10 @@ export function extractPythonSymbols(
 
 		// Classes
 		const classMatch = line.match(/^class\s+(\w+)(?:\(([^)]*)\))?:/);
-		if (classMatch && !classMatch[1].startsWith('_')) {
-			const exported =
-				!explicitExports || explicitExports.includes(classMatch[1]);
-			symbols.push({
+		if (classMatch) {
+			const exported = isExplicitlyExported(classMatch[1]);
+			currentClass = { name: classMatch[1], exported, indent };
+			addSymbol({
 				name: classMatch[1],
 				kind: 'class',
 				exported,
@@ -428,17 +457,173 @@ export function extractPythonSymbols(
 		// Module-level constants (UPPER_CASE)
 		const constMatch = line.match(/^([A-Z][A-Z0-9_]+)\s*[:=]/);
 		if (constMatch) {
-			symbols.push({
+			addSymbol({
 				name: constMatch[1],
 				kind: 'const',
-				exported: true,
+				exported: isExplicitlyExported(constMatch[1]),
+				signature: line.trim().substring(0, 100),
+				line: i + 1,
+			});
+		}
+
+		const importMatch = line.match(
+			/^from\s+[\w.]+\s+import\s+(.+?)(?:\s*#.*)?$/,
+		);
+		if (importMatch && (isPackageInit || explicitExports)) {
+			for (const rawPart of importMatch[1].split(',')) {
+				const part = rawPart.trim();
+				if (!part || part === '*') continue;
+				const alias = part.match(/^(\w+)\s+as\s+(\w+)$/);
+				const importedName = alias ? alias[1] : part;
+				const localName = alias ? alias[2] : part;
+				if (!/^\w+$/.test(importedName) || !/^\w+$/.test(localName)) continue;
+				const exported = isExplicitlyExported(localName);
+				if (!exported && explicitExports) continue;
+				addSymbol({
+					name: localName,
+					kind: 'variable',
+					exported,
+					signature: line.trim().substring(0, 100),
+					line: i + 1,
+				});
+			}
+		}
+	}
+
+	// Sort by line number for deterministic ordering, with tie-breaker on symbol name
+	return symbols.sort((a, b) => {
+		if (a.line !== b.line) return a.line - b.line;
+		return a.name.localeCompare(b.name);
+	});
+}
+
+export function extractRustSymbols(
+	filePath: string,
+	cwd: string,
+): SymbolInfo[] {
+	const content = readValidatedSourceFile(filePath, cwd);
+	if (content === null) return [];
+
+	const symbols: SymbolInfo[] = [];
+	const lines = content.split('\n');
+	let implDepth = 0;
+	const braceDelta = (text: string): number =>
+		(text.match(/{/g)?.length ?? 0) - (text.match(/}/g)?.length ?? 0);
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		const trimmed = line.trim();
+		const inImpl = implDepth > 0;
+
+		if (!inImpl && /^impl\b/.test(trimmed)) {
+			implDepth = Math.max(0, implDepth + braceDelta(trimmed));
+			continue;
+		}
+
+		if (inImpl) {
+			const method = trimmed.match(
+				/^(pub(?:\s*\([^)]*\))?\s+)?(?:async\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)/,
+			);
+			if (method) {
+				const modifier = method[1] ?? '';
+				symbols.push({
+					name: method[2],
+					kind: 'method',
+					exported: modifier.trim().startsWith('pub'),
+					signature: trimmed.substring(0, 100),
+					line: i + 1,
+				});
+			}
+			implDepth = Math.max(0, implDepth + braceDelta(trimmed));
+			continue;
+		}
+
+		if (/^\s/.test(line)) continue;
+		const item = trimmed.match(
+			/^(pub(?:\s*\([^)]*\))?\s+)?(?:async\s+)?(fn|struct|enum|trait|mod)\s+([A-Za-z_][A-Za-z0-9_]*)/,
+		);
+		if (!item) continue;
+		const modifier = item[1] ?? '';
+		const exported = modifier.trim().startsWith('pub');
+		const kindMap: Record<string, SymbolInfo['kind']> = {
+			fn: 'function',
+			struct: 'type',
+			enum: 'enum',
+			trait: 'interface',
+			mod: 'type',
+		};
+		symbols.push({
+			name: item[3],
+			kind: kindMap[item[2]] ?? 'type',
+			exported,
+			signature: trimmed.substring(0, 100),
+			line: i + 1,
+		});
+	}
+
+	return symbols.sort((a, b) => {
+		if (a.line !== b.line) return a.line - b.line;
+		return a.name.localeCompare(b.name);
+	});
+}
+
+export function extractGoSymbols(filePath: string, cwd: string): SymbolInfo[] {
+	const content = readValidatedSourceFile(filePath, cwd);
+	if (content === null) return [];
+
+	const symbols: SymbolInfo[] = [];
+	const lines = content.split('\n');
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		const method = line.match(
+			/^func\s+\([^)]*\)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/,
+		);
+		if (method) {
+			symbols.push({
+				name: method[1],
+				kind: 'method',
+				exported: /^[A-Z]/.test(method[1]),
+				signature: line.trim().substring(0, 100),
+				line: i + 1,
+			});
+			continue;
+		}
+
+		const fn = line.match(/^func\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/);
+		if (fn) {
+			symbols.push({
+				name: fn[1],
+				kind: 'function',
+				exported: /^[A-Z]/.test(fn[1]),
+				signature: line.trim().substring(0, 100),
+				line: i + 1,
+			});
+			continue;
+		}
+
+		const typeDecl = line.match(/^type\s+([A-Za-z_][A-Za-z0-9_]*)\b/);
+		if (typeDecl) {
+			symbols.push({
+				name: typeDecl[1],
+				kind: 'type',
+				exported: /^[A-Z]/.test(typeDecl[1]),
+				signature: line.trim().substring(0, 100),
+				line: i + 1,
+			});
+			continue;
+		}
+
+		const valueDecl = line.match(/^(var|const)\s+([A-Za-z_][A-Za-z0-9_]*)\b/);
+		if (valueDecl) {
+			symbols.push({
+				name: valueDecl[2],
+				kind: valueDecl[1] === 'const' ? 'const' : 'variable',
+				exported: /^[A-Z]/.test(valueDecl[2]),
 				signature: line.trim().substring(0, 100),
 				line: i + 1,
 			});
 		}
 	}
 
-	// Sort by line number for deterministic ordering, with tie-breaker on symbol name
 	return symbols.sort((a, b) => {
 		if (a.line !== b.line) return a.line - b.line;
 		return a.name.localeCompare(b.name);
@@ -528,7 +713,14 @@ function searchWorkspaceSymbols(
 				syms = extractTSSymbols(relFile, cwd);
 				break;
 			case '.py':
+			case '.pyw':
 				syms = extractPythonSymbols(relFile, cwd);
+				break;
+			case '.rs':
+				syms = extractRustSymbols(relFile, cwd);
+				break;
+			case '.go':
+				syms = extractGoSymbols(relFile, cwd);
 				break;
 			default:
 				continue;
@@ -582,7 +774,7 @@ export const symbols: ToolDefinition = createSwarmTool({
 	description:
 		'Extract all exported symbols from a source file: functions with signatures, ' +
 		'classes with public members, interfaces, types, enums, constants. ' +
-		'Supports TypeScript/JavaScript and Python. Use for architect planning, ' +
+		'Supports TypeScript/JavaScript, Python, Rust, and Go. Use for architect planning, ' +
 		'designer scaffolding, and understanding module public API surface.',
 	args: {
 		file: z
@@ -620,7 +812,7 @@ export const symbols: ToolDefinition = createSwarmTool({
 			const obj = args as Record<string, unknown>;
 			file =
 				obj.file != null && typeof obj.file === 'string' ? obj.file : undefined;
-			exportedOnly = obj.exported_only === true;
+			exportedOnly = obj.exported_only !== false;
 			workspace = obj.workspace === true;
 			name =
 				obj.name != null && typeof obj.name === 'string' ? obj.name : undefined;
@@ -724,13 +916,20 @@ export const symbols: ToolDefinition = createSwarmTool({
 				syms = extractTSSymbols(file, cwd);
 				break;
 			case '.py':
+			case '.pyw':
 				syms = extractPythonSymbols(file, cwd);
+				break;
+			case '.rs':
+				syms = extractRustSymbols(file, cwd);
+				break;
+			case '.go':
+				syms = extractGoSymbols(file, cwd);
 				break;
 			default:
 				return JSON.stringify(
 					{
 						file,
-						error: `Unsupported file extension: ${ext}. Supported: .ts, .tsx, .js, .jsx, .mjs, .cjs, .py`,
+						error: `Unsupported file extension: ${ext}. Supported: .ts, .tsx, .js, .jsx, .mjs, .cjs, .py, .pyw, .rs, .go`,
 						symbols: [],
 					},
 					null,

--- a/tests/unit/graph/graph-builder.test.ts
+++ b/tests/unit/graph/graph-builder.test.ts
@@ -41,6 +41,44 @@ beforeAll(() => {
 	fs.writeFileSync(path.join(tmp, '.git/config'), '[core]\nbare = false\n');
 });
 
+describe('buildRepoGraph - Python, Rust, and Go exports', () => {
+	it('extracts conservative exports for .pyw, .rs, and .go files', async () => {
+		const mixedTmp = fs.mkdtempSync(
+			path.join(os.tmpdir(), 'graph-builder-mixed-'),
+		);
+		try {
+			fs.writeFileSync(
+				path.join(mixedTmp, 'service.pyw'),
+				"__all__ = ['_private_api']\n\ndef _private_api():\n    pass\n\ndef hidden():\n    pass\n",
+			);
+			fs.writeFileSync(
+				path.join(mixedTmp, 'lib.rs'),
+				'pub fn public_api() {}\npub(crate) struct InternalThing;\nfn hidden() {}\n',
+			);
+			fs.writeFileSync(
+				path.join(mixedTmp, 'main.go'),
+				'package main\n\nfunc PublicFunc() {}\nfunc privateFunc() {}\nconst MaxRetries = 3\n',
+			);
+
+			const graph = await buildRepoGraph(mixedTmp);
+
+			expect(graph.files['service.pyw'].exports.map((s) => s.name)).toEqual([
+				'_private_api',
+			]);
+			expect(graph.files['lib.rs'].exports.map((s) => s.name)).toEqual([
+				'public_api',
+				'InternalThing',
+			]);
+			expect(graph.files['main.go'].exports.map((s) => s.name)).toEqual([
+				'PublicFunc',
+				'MaxRetries',
+			]);
+		} finally {
+			fs.rmSync(mixedTmp, { recursive: true, force: true });
+		}
+	});
+});
+
 afterAll(() => {
 	fs.rmSync(tmp, { recursive: true, force: true });
 });

--- a/tests/unit/graph/import-extractor.test.ts
+++ b/tests/unit/graph/import-extractor.test.ts
@@ -31,6 +31,7 @@ describe('getLanguageFromExtension', () => {
 		expect(getLanguageFromExtension('.tsx')).toBe('typescript');
 		expect(getLanguageFromExtension('.js')).toBe('javascript');
 		expect(getLanguageFromExtension('.py')).toBe('python');
+		expect(getLanguageFromExtension('.pyw')).toBe('python');
 		expect(getLanguageFromExtension('.go')).toBe('go');
 		expect(getLanguageFromExtension('.rs')).toBe('rust');
 	});
@@ -41,6 +42,7 @@ describe('getLanguageFromExtension', () => {
 	it('exports the source extensions array', () => {
 		expect(SOURCE_EXTENSIONS).toContain('.ts');
 		expect(SOURCE_EXTENSIONS).toContain('.py');
+		expect(SOURCE_EXTENSIONS).toContain('.pyw');
 	});
 });
 
@@ -155,6 +157,34 @@ describe('extractImports — Python', () => {
 		expect(edges.length).toBeGreaterThanOrEqual(1);
 		const target = edges[0].target;
 		expect(target.endsWith('util.py')).toBe(true);
+	});
+
+	it('recognizes .pyw as Python', () => {
+		write('pkg/util.pyw', 'def foo(): pass\n');
+		const a = write('pkg/main.pyw', 'from .util import foo\n');
+		const edges = extractImports({ absoluteFilePath: a, workspaceRoot: tmp });
+		expect(edges[0].target.endsWith('util.pyw')).toBe(true);
+	});
+});
+
+describe('extractImports - Go and Rust', () => {
+	it('marks Go blank imports as side effects', () => {
+		const a = write('main.go', 'package main\n\nimport _ "embed"\n');
+		const edges = extractImports({ absoluteFilePath: a, workspaceRoot: tmp });
+		expect(edges[0]).toMatchObject({
+			rawModule: 'embed',
+			importType: 'sideeffect',
+		});
+	});
+
+	it('decomposes Rust grouped uses into named imported symbols', () => {
+		const a = write('lib.rs', 'use crate::models::{User, Account as Acct};\n');
+		const edges = extractImports({ absoluteFilePath: a, workspaceRoot: tmp });
+		expect(edges[0]).toMatchObject({
+			rawModule: 'crate::models',
+			importType: 'named',
+			importedSymbols: ['User', 'Account'],
+		});
 	});
 });
 

--- a/tests/unit/graph/import-extractor.test.ts
+++ b/tests/unit/graph/import-extractor.test.ts
@@ -183,7 +183,20 @@ describe('extractImports - Go and Rust', () => {
 		expect(edges[0]).toMatchObject({
 			rawModule: 'crate::models',
 			importType: 'named',
-			importedSymbols: ['User', 'Account'],
+			importedSymbols: ['User', 'Acct'],
+		});
+	});
+
+	it('extracts symbols with :: paths inside grouped braces (FB-003)', () => {
+		const a = write(
+			'lib.rs',
+			'use crate::{Item, submodule::Item2, alias_name::Item3 as Renamed};\n',
+		);
+		const edges = extractImports({ absoluteFilePath: a, workspaceRoot: tmp });
+		expect(edges[0]).toMatchObject({
+			rawModule: 'crate',
+			importType: 'named',
+			importedSymbols: ['Item', 'Item2', 'Renamed'],
 		});
 	});
 });

--- a/tests/unit/lang/symbol-graph.test.ts
+++ b/tests/unit/lang/symbol-graph.test.ts
@@ -526,6 +526,55 @@ def main():
 		expect(pRef).toBeDefined();
 		expect(pRef!.enclosingDecl).toBe('main');
 	});
+
+	test('decorators, methods, multi-imports, and star imports', async () => {
+		const source = `import os, sys as system
+from .pkg import Public as Alias, helper
+from plugins import *
+
+class Service:
+    @cached
+    async def run(self):
+        return helper(os.getcwd())
+`;
+
+		const facts = await extractFileSymbols('python', source);
+		expect(facts).not.toBeNull();
+
+		const service = facts!.defs.find((d) => d.name === 'Service');
+		const run = facts!.defs.find((d) => d.name === 'run');
+		expect(service).toMatchObject({ kind: 'class', exported: true });
+		expect(run).toMatchObject({ kind: 'method', exported: false });
+		expect(run!.startLine).toBe(6);
+
+		expect(facts!.imports).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					specifier: 'os',
+					importType: 'namespace',
+					bindings: [{ imported: 'os', local: 'os' }],
+				}),
+				expect.objectContaining({
+					specifier: 'sys',
+					importType: 'named',
+					bindings: [{ imported: 'sys', local: 'system' }],
+				}),
+				expect.objectContaining({
+					specifier: './pkg',
+					importType: 'named',
+					bindings: [
+						{ imported: 'Public', local: 'Alias' },
+						{ imported: 'helper', local: 'helper' },
+					],
+				}),
+				expect.objectContaining({
+					specifier: 'plugins',
+					importType: 'namespace',
+					bindings: [],
+				}),
+			]),
+		);
+	});
 });
 
 describe('extractFileSymbols — rust grammar', () => {
@@ -561,17 +610,75 @@ fn main() {
 		// import: use std::collections::HashMap as Map
 		expect(facts!.imports).toHaveLength(1);
 		expect(facts!.imports[0]).toMatchObject({
-			specifier: 'std::collections::HashMap',
+			specifier: 'std::collections',
 			importType: 'named',
 		});
 		expect(facts!.imports[0].bindings).toEqual([
-			{ imported: 'std::collections::HashMap', local: 'Map' },
+			{ imported: 'HashMap', local: 'Map' },
 		]);
 
 		// ref: Map inside main → enclosingDecl = 'main'
 		const mapRef = facts!.refs.find((r) => r.identifier === 'Map');
 		expect(mapRef).toBeDefined();
 		expect(mapRef!.enclosingDecl).toBe('main');
+	});
+
+	test('captures Rust visibility, item kinds, impl methods, and grouped uses', async () => {
+		const source = `use crate::models::{User, Account as Acct};
+
+pub fn public_api() {}
+pub(crate) struct InternalThing;
+pub enum Mode { Fast }
+pub trait Runner {}
+mod private_mod {}
+
+impl InternalThing {
+    pub fn run(&self) {
+        User::new();
+    }
+}
+`;
+
+		const facts = await extractFileSymbols('rust', source);
+		expect(facts).not.toBeNull();
+
+		expect(facts!.defs).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: 'public_api',
+					kind: 'function',
+					exported: true,
+					visibilityInfo: expect.objectContaining({ visibility: 'public' }),
+				}),
+				expect.objectContaining({
+					name: 'InternalThing',
+					kind: 'type',
+					exported: true,
+					visibilityInfo: expect.objectContaining({ visibility: 'internal' }),
+				}),
+				expect.objectContaining({ name: 'Mode', kind: 'enum', exported: true }),
+				expect.objectContaining({
+					name: 'Runner',
+					kind: 'interface',
+					exported: true,
+				}),
+				expect.objectContaining({
+					name: 'private_mod',
+					kind: 'type',
+					exported: false,
+				}),
+				expect.objectContaining({ name: 'run', kind: 'method' }),
+			]),
+		);
+
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'crate::models',
+			importType: 'named',
+			bindings: [
+				{ imported: 'User', local: 'User' },
+				{ imported: 'Account', local: 'Acct' },
+			],
+		});
 	});
 });
 
@@ -702,6 +809,89 @@ func main() {
 		const fRef = facts!.refs.find((r) => r.identifier === 'f');
 		expect(fRef).toBeDefined();
 		expect(fRef!.enclosingDecl).toBe('main');
+	});
+
+	test('captures Go exported names, methods, vars, consts, and special imports', async () => {
+		const source = `package main
+
+import (
+	. "math"
+	_ "embed"
+	f "fmt"
+)
+
+type Service struct{}
+var Version = "1"
+const MaxRetries = 3
+
+func PublicFunc() {
+	f.Println(Sqrt(4))
+}
+
+func privateFunc() {}
+
+func (s Service) Run() {
+	PublicFunc()
+}
+`;
+
+		const facts = await extractFileSymbols('go', source);
+		expect(facts).not.toBeNull();
+
+		expect(facts!.defs).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: 'Service',
+					kind: 'type',
+					exported: true,
+				}),
+				expect.objectContaining({
+					name: 'Version',
+					kind: 'const',
+					exported: true,
+				}),
+				expect.objectContaining({
+					name: 'MaxRetries',
+					kind: 'const',
+					exported: true,
+				}),
+				expect.objectContaining({
+					name: 'PublicFunc',
+					kind: 'function',
+					exported: true,
+				}),
+				expect.objectContaining({
+					name: 'privateFunc',
+					kind: 'function',
+					exported: false,
+				}),
+				expect.objectContaining({
+					name: 'Run',
+					kind: 'method',
+					exported: true,
+				}),
+			]),
+		);
+
+		expect(facts!.imports).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					specifier: 'math',
+					importType: 'namespace',
+					bindings: [{ imported: '*', local: '.' }],
+				}),
+				expect.objectContaining({
+					specifier: 'embed',
+					importType: 'sideeffect',
+					bindings: [],
+				}),
+				expect.objectContaining({
+					specifier: 'fmt',
+					importType: 'named',
+					bindings: [{ imported: 'fmt', local: 'f' }],
+				}),
+			]),
+		);
 	});
 });
 

--- a/tests/unit/lang/symbol-graph.test.ts
+++ b/tests/unit/lang/symbol-graph.test.ts
@@ -544,7 +544,7 @@ class Service:
 		const service = facts!.defs.find((d) => d.name === 'Service');
 		const run = facts!.defs.find((d) => d.name === 'run');
 		expect(service).toMatchObject({ kind: 'class', exported: true });
-		expect(run).toMatchObject({ kind: 'method', exported: false });
+		expect(run).toMatchObject({ kind: 'method', exported: true });
 		expect(run!.startLine).toBe(6);
 
 		expect(facts!.imports).toEqual(
@@ -574,6 +574,97 @@ class Service:
 				}),
 			]),
 		);
+	});
+
+	test('FB-002: exported class methods are marked exported, private methods are not', async () => {
+		// Regression test: tree-sitter path should match regex extractor behavior
+		// for Python class method exported determination
+		const source = `class Foo:
+    def public_method(self): pass
+    def _private_method(self): pass
+`;
+		const facts = await extractFileSymbols('python', source);
+		expect(facts).not.toBeNull();
+
+		const foo = facts!.defs.find((d) => d.name === 'Foo');
+		const publicMethod = facts!.defs.find((d) => d.name === 'public_method');
+		const privateMethod = facts!.defs.find((d) => d.name === '_private_method');
+
+		// Foo is exported (public naming convention, no __all__)
+		expect(foo).toMatchObject({ kind: 'class', exported: true });
+
+		// public_method is exported because its parent class is exported
+		expect(publicMethod).toMatchObject({ kind: 'method', exported: true });
+
+		// _private_method is NOT exported (starts with _)
+		expect(privateMethod).toMatchObject({ kind: 'method', exported: false });
+	});
+
+	test('FB-002: __init__ method is not exported even on exported class', async () => {
+		const source = `class Foo:
+    def __init__(self): pass
+`;
+		const facts = await extractFileSymbols('python', source);
+		expect(facts).not.toBeNull();
+
+		const foo = facts!.defs.find((d) => d.name === 'Foo');
+		const init = facts!.defs.find((d) => d.name === '__init__');
+
+		expect(foo).toMatchObject({ kind: 'class', exported: true });
+		// __init__ is special: not exported even on exported class
+		expect(init).toMatchObject({ kind: 'method', exported: false });
+	});
+
+	test('FB-002: methods on private class are not exported', async () => {
+		const source = `class _Private:
+    def public_method(self): pass
+`;
+		const facts = await extractFileSymbols('python', source);
+		expect(facts).not.toBeNull();
+
+		const privateClass = facts!.defs.find((d) => d.name === '_Private');
+		const publicMethod = facts!.defs.find((d) => d.name === 'public_method');
+
+		// _Private is not exported (starts with _)
+		expect(privateClass).toMatchObject({ kind: 'class', exported: false });
+
+		// public_method is NOT exported because its parent class is private
+		expect(publicMethod).toMatchObject({ kind: 'method', exported: false });
+	});
+
+	test('FB-002: __all__ controls class export status, methods follow parent', async () => {
+		const source = `__all__ = ['Foo', 'Bar']
+
+class Foo:
+    def foo_method(self): pass
+
+class Bar:
+    def bar_method(self): pass
+
+class Baz:
+    def baz_method(self): pass
+`;
+		const facts = await extractFileSymbols('python', source);
+		expect(facts).not.toBeNull();
+
+		const foo = facts!.defs.find((d) => d.name === 'Foo');
+		const bar = facts!.defs.find((d) => d.name === 'Bar');
+		const baz = facts!.defs.find((d) => d.name === 'Baz');
+		const fooMethod = facts!.defs.find((d) => d.name === 'foo_method');
+		const barMethod = facts!.defs.find((d) => d.name === 'bar_method');
+		const bazMethod = facts!.defs.find((d) => d.name === 'baz_method');
+
+		// Foo and Bar are in __all__, Baz is not
+		expect(foo).toMatchObject({ kind: 'class', exported: true });
+		expect(bar).toMatchObject({ kind: 'class', exported: true });
+		expect(baz).toMatchObject({ kind: 'class', exported: false });
+
+		// Methods on exported classes are exported
+		expect(fooMethod).toMatchObject({ kind: 'method', exported: true });
+		expect(barMethod).toMatchObject({ kind: 'method', exported: true });
+
+		// Method on non-exported class is not exported
+		expect(bazMethod).toMatchObject({ kind: 'method', exported: false });
 	});
 });
 

--- a/tests/unit/tools/repo-graph-scan.test.ts
+++ b/tests/unit/tools/repo-graph-scan.test.ts
@@ -74,6 +74,84 @@ export const indexExport = 'hello';`,
 		expect(indexNode?.exports).toContain('indexExport');
 	});
 
+	test('sync scan resolves Python, Rust, and Go import edges', async () => {
+		await fsSync.promises.mkdir(path.join(tempDir, 'pkg'), { recursive: true });
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'pkg', '__init__.py'),
+			'from .api import public_api\n',
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'pkg', 'api.py'),
+			'def public_api():\n    return 1\n',
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'main.py'),
+			'from .pkg import public_api\n\npublic_api()\n',
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'lib.rs'),
+			'use crate::helper::Worker;\npub fn run(_: Worker) {}\n',
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'helper.rs'),
+			'pub struct Worker;\n',
+		);
+		await fsSync.promises.mkdir(path.join(tempDir, 'worker'), {
+			recursive: true,
+		});
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'go_main.go'),
+			'package main\n\nimport w "./worker"\n\nfunc PublicFunc() { _ = w.Name }\n',
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'worker', 'worker.go'),
+			'package worker\n\nconst Name = "worker"\n',
+		);
+
+		const graph = buildWorkspaceGraph(workspacePath);
+		const modulesByPath = new Map(
+			Object.values(graph.nodes).map((node) => [
+				node.filePath,
+				node.moduleName,
+			]),
+		);
+		const edgeModules = graph.edges.map((edge) => ({
+			source: modulesByPath.get(edge.source),
+			target: modulesByPath.get(edge.target),
+			importedSymbols: edge.importedSymbols,
+			usedSymbols: edge.usedSymbols,
+		}));
+
+		expect(edgeModules).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					source: 'main.py',
+					target: 'pkg/__init__.py',
+					importedSymbols: ['public_api'],
+					usedSymbols: ['public_api'],
+				}),
+				expect.objectContaining({
+					source: 'pkg/__init__.py',
+					target: 'pkg/api.py',
+					importedSymbols: ['public_api'],
+					usedSymbols: ['public_api'],
+				}),
+				expect.objectContaining({
+					source: 'lib.rs',
+					target: 'helper.rs',
+					importedSymbols: ['Worker'],
+					usedSymbols: ['Worker'],
+				}),
+				expect.objectContaining({
+					source: 'go_main.go',
+					target: 'worker/worker.go',
+					importedSymbols: ['./worker'],
+					usedSymbols: ['./worker'],
+				}),
+			]),
+		);
+	});
+
 	test('files are processed in sorted (deterministic) order', async () => {
 		// Create files in non-alphabetical order
 		const files = {

--- a/tests/unit/tools/repo-graph-symbol-visibility.test.ts
+++ b/tests/unit/tools/repo-graph-symbol-visibility.test.ts
@@ -54,6 +54,72 @@ func privateHelper() {}
 		expect(node!.exports).not.toContain('privateHelper');
 	});
 
+	test('Python decorator ranges and Rust/Go exported names reach async graph metadata', async () => {
+		await write(
+			'pkg/__init__.py',
+			`__all__ = ['_private_api']
+
+@decorator
+def _private_api():
+    return 1
+
+def hidden():
+    return 2
+`,
+		);
+		await write(
+			'lib.rs',
+			`pub(crate) struct InternalThing;
+pub enum Mode { Fast }
+pub trait Runner {}
+mod private_mod {}
+`,
+		);
+		await write(
+			'cmd/main.go',
+			`package main
+
+var Version = "1"
+const MaxRetries = 3
+func PublicFunc() {}
+func privateFunc() {}
+`,
+		);
+
+		const graph = await buildWorkspaceGraphAsync(workspacePath);
+		const py = Object.values(graph.nodes).find((n) =>
+			n.filePath.endsWith(path.join('pkg', '__init__.py')),
+		);
+		const rust = Object.values(graph.nodes).find((n) =>
+			n.filePath.endsWith('lib.rs'),
+		);
+		const go = Object.values(graph.nodes).find((n) =>
+			n.filePath.endsWith(path.join('cmd', 'main.go')),
+		);
+
+		expect(py).toBeDefined();
+		expect(py!.exports).toEqual(['_private_api']);
+		expect(py!.exportRanges).toEqual({
+			_private_api: { startLine: 3, endLine: 5 },
+		});
+
+		expect(rust).toBeDefined();
+		expect(rust!.exports).toEqual(['InternalThing', 'Mode', 'Runner']);
+		expect(rust!.exportRanges).toEqual({
+			InternalThing: { startLine: 1, endLine: 1 },
+			Mode: { startLine: 2, endLine: 2 },
+			Runner: { startLine: 3, endLine: 3 },
+		});
+
+		expect(go).toBeDefined();
+		expect(go!.exports).toEqual(['Version', 'MaxRetries', 'PublicFunc']);
+		expect(go!.exportRanges).toEqual({
+			Version: { startLine: 3, endLine: 3 },
+			MaxRetries: { startLine: 4, endLine: 4 },
+			PublicFunc: { startLine: 5, endLine: 5 },
+		});
+	});
+
 	test('temp fixture is created inside the workspace root', () => {
 		expect(fsSync.existsSync(tempDir)).toBe(true);
 		expect(path.resolve(workspacePath)).toBe(tempDir);

--- a/tests/unit/tools/repo-map.test.ts
+++ b/tests/unit/tools/repo-map.test.ts
@@ -528,6 +528,89 @@ describe('repo_map: context_pack', () => {
 		}
 	});
 
+	it('returns context for Python package-root exports and Rust/Go symbols', async () => {
+		fs.mkdirSync(path.join(tmp, 'src/pkg'), { recursive: true });
+		fs.writeFileSync(
+			path.join(tmp, 'src/pkg/__init__.py'),
+			"__all__ = ['public_fn']\nfrom .api import public_fn\n",
+		);
+		fs.writeFileSync(
+			path.join(tmp, 'src/pkg/api.py'),
+			'@cached\nasync def public_fn():\n    return 1\n',
+		);
+		fs.writeFileSync(
+			path.join(tmp, 'src/consumer.py'),
+			'from .pkg import public_fn\n\n\ndef call_it():\n    return public_fn()\n',
+		);
+		fs.writeFileSync(
+			path.join(tmp, 'src/lib.rs'),
+			'use crate::helper::Worker;\npub enum Mode { Fast }\npub trait Runner {}\npub fn run(_: Worker) {}\n',
+		);
+		fs.writeFileSync(path.join(tmp, 'src/helper.rs'), 'pub struct Worker;\n');
+		fs.writeFileSync(
+			path.join(tmp, 'src/main.go'),
+			'package main\n\nfunc PublicFunc() {}\n',
+		);
+
+		await call({ action: 'build' });
+
+		const py = JSON.parse(
+			await call({
+				action: 'context_pack',
+				file: 'src/pkg/__init__.py',
+				symbol: 'public_fn',
+			}),
+		) as {
+			success: boolean;
+			target: { file: string; symbol: string };
+			spans: Array<{ file: string; startLine: number }>;
+		};
+		expect(py.success).toBe(true);
+		expect(py.target).toEqual({
+			file: 'src/pkg/__init__.py',
+			symbol: 'public_fn',
+		});
+		expect(py.spans).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					file: 'src/pkg/__init__.py',
+					startLine: 2,
+				}),
+			]),
+		);
+
+		const rust = JSON.parse(
+			await call({
+				action: 'context_pack',
+				file: 'src/lib.rs',
+				symbol: 'Mode',
+			}),
+		) as { success: boolean; spans: Array<{ file: string }> };
+		expect(rust.success).toBe(true);
+		expect(rust.spans).toEqual(
+			expect.arrayContaining([expect.objectContaining({ file: 'src/lib.rs' })]),
+		);
+		const rustDeps = JSON.parse(
+			await call({ action: 'dependencies', file: 'src/lib.rs' }),
+		) as { success: boolean; dependencies: Array<{ file: string }> };
+		expect(rustDeps.success).toBe(true);
+		expect(rustDeps.dependencies.map((d) => d.file)).toContain('src/helper.rs');
+
+		const go = JSON.parse(
+			await call({
+				action: 'context_pack',
+				file: 'src/main.go',
+				symbol: 'PublicFunc',
+			}),
+		) as { success: boolean; spans: Array<{ file: string }> };
+		expect(go.success).toBe(true);
+		expect(go.spans).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ file: 'src/main.go' }),
+			]),
+		);
+	});
+
 	it('missing file: rejects context_pack without file', async () => {
 		await call({ action: 'build' });
 		const out = await call({ action: 'context_pack', symbol: 'add' });

--- a/tests/unit/tools/symbols.test.ts
+++ b/tests/unit/tools/symbols.test.ts
@@ -243,9 +243,12 @@ class UserService:
 			const parsed = parseResult(result);
 
 			expect(parsed.error).toBeUndefined();
-			expect(parsed.symbolCount).toBe(1);
-			expect(parsed.symbols[0].name).toBe('UserService');
+			expect(parsed.symbols.map((s: any) => s.name)).toEqual([
+				'UserService',
+				'UserService.get_user',
+			]);
 			expect(parsed.symbols[0].kind).toBe('class');
+			expect(parsed.symbols[1].kind).toBe('method');
 		});
 
 		it('should extract Python constants', async () => {
@@ -285,6 +288,85 @@ class PublicClass:
 			expect(parsed.symbolCount).toBeGreaterThanOrEqual(1);
 			const names = parsed.symbols.map((s: any) => s.name);
 			expect(names).toContain('public_function');
+		});
+
+		it('should allow __all__ to export private names and constrain constants', async () => {
+			const content = `
+__all__ = ['_private_function']
+
+def _private_function():
+    pass
+
+PUBLIC_CONSTANT = 1
+`;
+			createTestFile(tempDir, 'test.pyw', content);
+			const result = await symbols.execute({ file: 'test.pyw' }, {} as any);
+			const parsed = parseResult(result);
+
+			expect(parsed.error).toBeUndefined();
+			expect(parsed.symbols.map((s: any) => s.name)).toEqual([
+				'_private_function',
+			]);
+		});
+
+		it('should extract __init__.pyw package re-exports', async () => {
+			const content = `
+from ..api import public_api as exposed_api
+`;
+			createTestFile(tempDir, 'pkg/sub/__init__.pyw', content);
+			const result = await symbols.execute(
+				{ file: 'pkg/sub/__init__.pyw' },
+				{} as any,
+			);
+			const parsed = parseResult(result);
+
+			expect(parsed.error).toBeUndefined();
+			expect(parsed.symbols.map((s: any) => s.name)).toEqual(['exposed_api']);
+		});
+	});
+
+	describe('happy path - Rust and Go', () => {
+		it('should extract Rust exported items', async () => {
+			const content = `pub fn public_api() {}
+pub(crate) struct InternalThing;
+impl InternalThing {
+    pub fn run(&self) {}
+    fn hidden_method(&self) {}
+}
+fn hidden() {}
+`;
+			createTestFile(tempDir, 'lib.rs', content);
+			const result = await symbols.execute({ file: 'lib.rs' }, {} as any);
+			const parsed = parseResult(result);
+
+			expect(parsed.error).toBeUndefined();
+			expect(parsed.symbols.map((s: any) => s.name)).toEqual([
+				'public_api',
+				'InternalThing',
+				'run',
+			]);
+		});
+
+		it('should extract Go exported declarations', async () => {
+			const content = `package main
+
+type Service struct{}
+var Version = "1"
+const MaxRetries = 3
+func PublicFunc() {}
+func privateFunc() {}
+`;
+			createTestFile(tempDir, 'main.go', content);
+			const result = await symbols.execute({ file: 'main.go' }, {} as any);
+			const parsed = parseResult(result);
+
+			expect(parsed.error).toBeUndefined();
+			expect(parsed.symbols.map((s: any) => s.name)).toEqual([
+				'Service',
+				'Version',
+				'MaxRetries',
+				'PublicFunc',
+			]);
 		});
 	});
 


### PR DESCRIPTION
Closes #1527
Closes #1528

## Summary
- Harden Python symbol graph support across `.py`/`.pyw`, decorators, class methods, `__all__`, package `__init__` re-exports, aliases, relative imports, and repo_map/context_pack package surfaces.
- Add Rust and Go symbol graph support for exported declarations, Rust impl methods/grouped/aliased/crate imports, and Go functions/methods/types/vars/consts plus alias/dot/blank imports.
- Wire the sync and async repo graph paths so symbols, imports, dependencies, symbol edges, `repo_map`, `context_pack`, `symbols`, and `batch_symbols` share the new language coverage.

## Invariant audit
- 1 (plugin init): not touched - no init-path files or startup hooks changed.
- 2 (runtime portability): touched - `bun run build` passed and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` printed `dist import OK`.
- 3 (subprocesses): not touched - no subprocess call sites changed.
- 4 (.swarm containment): not touched - code changes do not alter runtime `.swarm/` writes; publication evidence only is under `.swarm/evidence/` and is not staged.
- 5 (plan durability): not touched - no plan ledger/projection code changed.
- 6 (test_runner safety): not touched - validation used shell `bun` commands, not broad `test_runner`.
- 7 (test writing): touched - added focused `bun:test` coverage without `mock.module`; focused suites passed.
- 8 (session state): not touched - no session/global state changed.
- 9 (guardrails/retry): not touched - no guardrail, retry, or model fallback code changed.
- 10 (chat/system msg): not touched - no message hook or system message code changed.
- 11 (tool registration): not touched - no new tools or agent maps; existing tools gained language coverage.
- 12 (release/cache): touched - added `docs/releases/pending/1527-1528-symbol-graph-python-rust-go.md`; version files and `dist/` are unstaged.

## Test plan
- [x] `bun test tests/unit/tools/repo-graph-scan.test.ts -t "sync scan resolves Python, Rust, and Go import edges" --timeout 120000`
- [x] `bun test tests/unit/lang/symbol-graph.test.ts tests/unit/lang/symbol-graph-visibility.test.ts tests/unit/graph/import-extractor.test.ts tests/unit/graph/graph-builder.test.ts tests/unit/tools/symbols.test.ts tests/unit/tools/repo-graph-symbol-visibility.test.ts tests/unit/tools/repo-map.test.ts --timeout 120000`
- [x] `bun test src/tools/batch-symbols.test.ts --timeout 120000`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `bun run drift:check`
- [x] `git diff --check`

## Pre-existing failures
- `bun test --timeout 120000` remains red on the repository's existing broad-suite baseline: 11,573 passed, 92 skipped, 6,806 failed, 860 errors. Observed failures include unrelated missing `readSwarmFileAsync` exports from `src/hooks/utils.ts`, reset/rollback command expectations, SAST baseline state, logger/path-security tests, artifact-cache tests, calibration/epic-state tests, and lean-turbo planning/evidence tests.
- A full `tests/unit/tools/repo-graph-scan.test.ts` run still contains an unrelated uppercase-extension expectation where `Foo.JS` reports `javascript` while the historical assertion expects `typescript`; the new Python/Rust/Go sync import-edge regression in that file passes by name.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

