### PR TITLE
feat(symbol-graph): harden native and dynamic languages

### DIFF
--- a/docs/php-laravel.md
+++ b/docs/php-laravel.md
@@ -69,7 +69,7 @@ Note: `path.extname('view.blade.php')` returns `.php`, so Blade files are scanne
 
 Repo-graph symbol extraction treats Blade templates as best-effort PHP syntax.
 Plain PHP functions, classes, traits, namespaces, and `use` declarations are
-represented when the PHP parser can recover them, but Blade directives, embedded
+represented when the regex-based extractor can recover them, but Blade directives, embedded
 HTML, template inheritance, and Laravel runtime binding are not resolved. Use
 `repo_map context_pack` output for Blade files as advisory context, not as proof
 that a template reference is complete.

--- a/docs/php-laravel.md
+++ b/docs/php-laravel.md
@@ -67,6 +67,13 @@ Audit:          composer audit --locked --format=json
 
 Note: `path.extname('view.blade.php')` returns `.php`, so Blade files are scanned via the `.php` extension in all tools, with `.blade.php` also explicitly registered for direct extension lookups.
 
+Repo-graph symbol extraction treats Blade templates as best-effort PHP syntax.
+Plain PHP functions, classes, traits, namespaces, and `use` declarations are
+represented when the PHP parser can recover them, but Blade directives, embedded
+HTML, template inheritance, and Laravel runtime binding are not resolved. Use
+`repo_map context_pack` output for Blade files as advisory context, not as proof
+that a template reference is complete.
+
 ## Laravel SAST rules
 
 Three Laravel-specific SAST rules are active (in addition to 10 generic PHP rules):

--- a/docs/releases/pending/1530-1531-native-dynamic-symbol-graph.md
+++ b/docs/releases/pending/1530-1531-native-dynamic-symbol-graph.md
@@ -1,0 +1,10 @@
+## Symbol graph language hardening
+
+- Hardened repo-graph symbol extraction for C/C++, Swift, Dart, Ruby, and PHP
+  with conservative visibility metadata, local include/import handling,
+  re-export facts, and context-packable ranges for representative native and
+  dynamic-language symbols.
+- Documented the remaining native and dynamic limitations, including build-system
+  include paths, overload/template resolution, Swift/Xcode module metadata,
+  Flutter widgets, Ruby metaprogramming, PHP dynamic calls, Composer boundaries,
+  and Blade directives.

--- a/docs/releases/pending/1530-1531-native-dynamic-symbol-graph.md
+++ b/docs/releases/pending/1530-1531-native-dynamic-symbol-graph.md
@@ -4,6 +4,8 @@
   with conservative visibility metadata, local include/import handling,
   re-export facts, and context-packable ranges for representative native and
   dynamic-language symbols.
+- Wired the same languages through the direct `symbols` tool extraction path
+  (`extractSymbolsForFile`) with a dependency-injection seam for testability.
 - Documented the remaining native and dynamic limitations, including build-system
   include paths, overload/template resolution, Swift/Xcode module metadata,
   Flutter widgets, Ruby metaprogramming, PHP dynamic calls, Composer boundaries,

--- a/docs/repo-graph-symbol-graph.md
+++ b/docs/repo-graph-symbol-graph.md
@@ -355,5 +355,12 @@ repo_map { "action": "context_pack", "file": "src/foo.ts", "symbol": "doThing", 
 - Reference attribution resolves by name within scope, not by full type
   resolution; overload-heavy (C++/Java) and highly dynamic (Ruby/Python) languages
   are best-effort.
+- C/C++ header declarations, local includes, namespaces, static functions,
+  anonymous namespaces, Swift extensions, Dart exports, Ruby privacy markers, and
+  PHP method visibility are represented conservatively. Build-system include
+  paths, template instantiations, overload resolution, SourceKit/Xcode module
+  metadata, Flutter widget trees, Ruby metaprogramming, PHP variable
+  functions/classes, Composer autoload boundaries, and Blade directives are not
+  resolved.
 - Symbol data requires an async rebuild; the sync builder yields file-level data
   only.

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -2367,7 +2367,6 @@ const IMPORT_ANCESTOR_TYPES = new Set([
 	'using_directive',
 	'namespace_use_declaration',
 	'namespace_use_clause',
-	'namespace_definition',
 	'library_import', // dart
 	'library_export', // dart
 	'export_directive', // dart

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -988,13 +988,29 @@ function declarationEnd(source: string, start: number): number {
 	return semi === -1 ? start : semi;
 }
 
+const cppAnonymousNamespaceRe = /\bnamespace\s*\{/g;
+const cppTypeRe = /\b(class|struct|enum)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+const cppFunctionRe =
+	/(?:^|[;\n}])\s*(static\s+)?(?:[A-Za-z_~][A-Za-z0-9_:<>,~*&\s]*?\s+)([A-Za-z_][A-Za-z0-9_]*)\s*\([^;{}]*\)\s*(?:const\s*)?(;|\{)/g;
+
+const swiftTypeRe =
+	/\b(?:(open|public|internal|fileprivate|private)\s+)?(class|struct|enum|protocol)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+const swiftExtensionRe =
+	/\b(?:(open|public|internal|fileprivate|private)\s+)?extension\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+const swiftFunctionRe =
+	/\b(?:(open|public|internal|fileprivate|private)\s+)?func\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+
+const dartTypeRe = /\b(class|mixin|enum|extension)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+const dartFunctionRe =
+	/\b(?:void|[A-Za-z_][A-Za-z0-9_<>,?]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+
 function augmentCppDefs(source: string, defs: FileSymbolFacts['defs']): void {
 	const anonymousRanges: Array<{ start: number; end: number }> = [];
-	const anonymousNamespaceRe = /\bnamespace\s*\{/g;
+	cppAnonymousNamespaceRe.lastIndex = 0;
 	for (
-		let m = anonymousNamespaceRe.exec(source);
+		let m = cppAnonymousNamespaceRe.exec(source);
 		m !== null;
-		m = anonymousNamespaceRe.exec(source)
+		m = cppAnonymousNamespaceRe.exec(source)
 	) {
 		const open = source.indexOf('{', m.index);
 		const close = open === -1 ? null : findMatchingBrace(source, open);
@@ -1005,8 +1021,8 @@ function augmentCppDefs(source: string, defs: FileSymbolFacts['defs']): void {
 	const isInAnonymousNamespace = (index: number): boolean =>
 		anonymousRanges.some((range) => index >= range.start && index <= range.end);
 
-	const typeRe = /\b(class|struct|enum)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
-	for (let m = typeRe.exec(source); m !== null; m = typeRe.exec(source)) {
+	cppTypeRe.lastIndex = 0;
+	for (let m = cppTypeRe.exec(source); m !== null; m = cppTypeRe.exec(source)) {
 		const exported = !isInAnonymousNamespace(m.index);
 		addRegexDef(
 			defs,
@@ -1021,13 +1037,12 @@ function augmentCppDefs(source: string, defs: FileSymbolFacts['defs']): void {
 		);
 	}
 
-	const functionRe =
-		/(?:^|[;\n}])\s*(static\s+)?(?:[A-Za-z_~][A-Za-z0-9_:<>,~*&\s]*?\s+)([A-Za-z_][A-Za-z0-9_]*)\s*\([^;{}]*\)\s*(?:const\s*)?(;|\{)/g;
 	const skip = new Set(['if', 'for', 'while', 'switch', 'catch', 'return']);
+	cppFunctionRe.lastIndex = 0;
 	for (
-		let m = functionRe.exec(source);
+		let m = cppFunctionRe.exec(source);
 		m !== null;
-		m = functionRe.exec(source)
+		m = cppFunctionRe.exec(source)
 	) {
 		const name = m[2];
 		if (skip.has(name)) continue;
@@ -1076,8 +1091,7 @@ function augmentSwiftDefs(source: string, defs: FileSymbolFacts['defs']): void {
 			blocks.push({ start: open, end: close, visibility, exported });
 		}
 	};
-	const swiftTypeRe =
-		/\b(?:(open|public|internal|fileprivate|private)\s+)?(class|struct|enum|protocol)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+	swiftTypeRe.lastIndex = 0;
 	for (
 		let m = swiftTypeRe.exec(source);
 		m !== null;
@@ -1106,8 +1120,7 @@ function augmentSwiftDefs(source: string, defs: FileSymbolFacts['defs']): void {
 		);
 		addBlock(m.index, visibility, exported);
 	}
-	const swiftExtensionRe =
-		/\b(?:(open|public|internal|fileprivate|private)\s+)?extension\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+	swiftExtensionRe.lastIndex = 0;
 	for (
 		let m = swiftExtensionRe.exec(source);
 		m !== null;
@@ -1116,8 +1129,7 @@ function augmentSwiftDefs(source: string, defs: FileSymbolFacts['defs']): void {
 		const visibility = normalizeVisibility(m[1]);
 		addBlock(m.index, visibility, visibility !== 'private');
 	}
-	const swiftFunctionRe =
-		/\b(?:(open|public|internal|fileprivate|private)\s+)?func\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+	swiftFunctionRe.lastIndex = 0;
 	for (
 		let m = swiftFunctionRe.exec(source);
 		m !== null;
@@ -1145,8 +1157,7 @@ function augmentSwiftDefs(source: string, defs: FileSymbolFacts['defs']): void {
 }
 
 function augmentDartDefs(source: string, defs: FileSymbolFacts['defs']): void {
-	const dartTypeRe =
-		/\b(class|mixin|enum|extension)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+	dartTypeRe.lastIndex = 0;
 	for (
 		let m = dartTypeRe.exec(source);
 		m !== null;
@@ -1165,13 +1176,16 @@ function augmentDartDefs(source: string, defs: FileSymbolFacts['defs']): void {
 			exported ? 'naming_convention' : 'unknown',
 		);
 	}
-	const dartFunctionRe =
-		/\b(?:void|[A-Za-z_][A-Za-z0-9_<>,?]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+	dartFunctionRe.lastIndex = 0;
 	for (
 		let m = dartFunctionRe.exec(source);
 		m !== null;
 		m = dartFunctionRe.exec(source)
 	) {
+		// Exclude "new ClassName(" constructor calls — the "return type"
+		// position is occupied by the "new" keyword, not a real type name.
+		const beforeName = source.slice(Math.max(0, m.index - 4), m.index);
+		if (beforeName.endsWith('new ')) continue;
 		const exported = !m[1].startsWith('_');
 		addRegexDef(
 			defs,
@@ -1263,12 +1277,17 @@ function augmentRubyDefs(source: string, defs: FileSymbolFacts['defs']): void {
 	}
 }
 
+const phpNamespaceRe = /\bnamespace\s+([^;{]+)\s*[;{]/g;
+const phpTypeRe = /\b(trait|class|interface)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+const phpFunctionRe =
+	/\b(?:(public|protected|private|static|final|abstract)\s+)*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+
 function augmentPhpDefs(source: string, defs: FileSymbolFacts['defs']): void {
-	const namespaceRe = /\bnamespace\s+([^;{]+)\s*[;{]/g;
+	phpNamespaceRe.lastIndex = 0;
 	for (
-		let m = namespaceRe.exec(source);
+		let m = phpNamespaceRe.exec(source);
 		m !== null;
-		m = namespaceRe.exec(source)
+		m = phpNamespaceRe.exec(source)
 	) {
 		addRegexDef(
 			defs,
@@ -1282,8 +1301,8 @@ function augmentPhpDefs(source: string, defs: FileSymbolFacts['defs']): void {
 			'namespace_public',
 		);
 	}
-	const phpTypeRe = /\b(trait|class|interface)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
 	const typeRanges: Array<{ start: number; end: number }> = [];
+	phpTypeRe.lastIndex = 0;
 	for (let m = phpTypeRe.exec(source); m !== null; m = phpTypeRe.exec(source)) {
 		const bodyStart = source.indexOf('{', m.index);
 		const bodyEnd =
@@ -1303,8 +1322,7 @@ function augmentPhpDefs(source: string, defs: FileSymbolFacts['defs']): void {
 			'module_public',
 		);
 	}
-	const phpFunctionRe =
-		/\b(?:(public|protected|private|static|final|abstract)\s+)*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+	phpFunctionRe.lastIndex = 0;
 	for (
 		let m = phpFunctionRe.exec(source);
 		m !== null;
@@ -2227,7 +2245,7 @@ function parsePhpUse(text: string): FileSymbolFacts['imports'][0] | null {
 		return {
 			specifier: m[1],
 			importType: 'named',
-			bindings: [{ imported: m[1], local: m[2] }],
+			bindings: [{ imported: m[1].split('\\').pop() ?? m[1], local: m[2] }],
 		};
 	}
 	const simple = t.match(

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -636,6 +636,7 @@ function buildFacts(
 	}
 
 	augmentJvmDotnetDefs(grammarId, source, defs);
+	augmentNativeDynamicDefs(grammarId, source, defs);
 
 	const importsWithIndex: Array<{
 		index: number;
@@ -747,9 +748,25 @@ function buildFacts(
 			addImport(parseImport(grammarId, exportNode.text.trim()), exportNode);
 		}
 	}
+	for (const fallback of fallbackImportsForSource(grammarId, source)) {
+		importsWithIndex.push(fallback);
+	}
+	const seenImports = new Set<string>();
 	const imports = importsWithIndex
 		.sort((a, b) => a.index - b.index)
-		.map((item) => item.entry);
+		.map((item) => item.entry)
+		.filter((entry) => {
+			const key = JSON.stringify([
+				entry.specifier,
+				entry.importType,
+				entry.bindings,
+				entry.reExport ?? false,
+				entry.exportedBindings ?? [],
+			]);
+			if (seenImports.has(key)) return false;
+			seenImports.add(key);
+			return true;
+		});
 
 	const topLevelDefs = defNodes
 		.filter((d) => isTopLevelDef(d.node, root))
@@ -774,7 +791,11 @@ function buildFacts(
 		});
 	}
 
-	return { defs, imports, refs };
+	const normalizedDefs = defs.map((def) => ({
+		...def,
+		endLine: Math.max(def.endLine, def.startLine),
+	}));
+	return { defs: normalizedDefs, imports, refs };
 }
 
 function visibilityInfoForModifier(
@@ -791,6 +812,19 @@ function visibilityInfoForModifier(
 					? 'module_public'
 					: 'modifier',
 		apiSurfaceKind: visibility === 'private' ? 'private' : 'public',
+	};
+}
+
+function symbolVisibilityInfo(
+	visibility: SymbolVisibilityInfo['visibility'],
+	exported: boolean,
+	exportedReason: SymbolVisibilityInfo['exportedReason'],
+): SymbolVisibilityInfo {
+	return {
+		exported,
+		visibility,
+		exportedReason,
+		apiSurfaceKind: exported ? 'public' : 'private',
 	};
 }
 
@@ -888,10 +922,7 @@ function upsertAugmentedDef(
 	def: FileSymbolFacts['defs'][0],
 ): void {
 	const existing = defs.find(
-		(item) =>
-			item.name === def.name &&
-			item.kind === def.kind &&
-			item.startLine === def.startLine,
+		(item) => item.name === def.name && item.startLine === def.startLine,
 	);
 	if (existing) {
 		existing.kind = def.kind;
@@ -901,6 +932,408 @@ function upsertAugmentedDef(
 		return;
 	}
 	defs.push(def);
+}
+
+function augmentNativeDynamicDefs(
+	grammarId: string,
+	source: string,
+	defs: FileSymbolFacts['defs'],
+): void {
+	switch (grammarId) {
+		case 'cpp':
+			augmentCppDefs(source, defs);
+			return;
+		case 'swift':
+			augmentSwiftDefs(source, defs);
+			return;
+		case 'dart':
+			augmentDartDefs(source, defs);
+			return;
+		case 'ruby':
+			augmentRubyDefs(source, defs);
+			return;
+		case 'php':
+			augmentPhpDefs(source, defs);
+			return;
+	}
+}
+
+function addRegexDef(
+	defs: FileSymbolFacts['defs'],
+	source: string,
+	name: string,
+	kind: FileSymbolFacts['defs'][0]['kind'],
+	start: number,
+	end: number,
+	visibility: SymbolVisibilityInfo['visibility'],
+	exported: boolean,
+	exportedReason: SymbolVisibilityInfo['exportedReason'],
+): void {
+	upsertAugmentedDef(defs, {
+		name,
+		kind,
+		exported,
+		visibilityInfo: symbolVisibilityInfo(visibility, exported, exportedReason),
+		startLine: lineNumberAt(source, start),
+		endLine: lineNumberAt(source, end),
+	});
+}
+
+function declarationEnd(source: string, start: number): number {
+	const open = source.indexOf('{', start);
+	const semi = source.indexOf(';', start);
+	if (open !== -1 && (semi === -1 || open < semi)) {
+		return findMatchingBrace(source, open) ?? open;
+	}
+	return semi === -1 ? start : semi;
+}
+
+function augmentCppDefs(source: string, defs: FileSymbolFacts['defs']): void {
+	const anonymousRanges: Array<{ start: number; end: number }> = [];
+	const anonymousNamespaceRe = /\bnamespace\s*\{/g;
+	for (
+		let m = anonymousNamespaceRe.exec(source);
+		m !== null;
+		m = anonymousNamespaceRe.exec(source)
+	) {
+		const open = source.indexOf('{', m.index);
+		const close = open === -1 ? null : findMatchingBrace(source, open);
+		if (open !== -1 && close !== null) {
+			anonymousRanges.push({ start: open, end: close });
+		}
+	}
+	const isInAnonymousNamespace = (index: number): boolean =>
+		anonymousRanges.some((range) => index >= range.start && index <= range.end);
+
+	const typeRe = /\b(class|struct|enum)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+	for (let m = typeRe.exec(source); m !== null; m = typeRe.exec(source)) {
+		const exported = !isInAnonymousNamespace(m.index);
+		addRegexDef(
+			defs,
+			source,
+			m[2],
+			m[1] === 'enum' ? 'enum' : 'type',
+			m.index,
+			declarationEnd(source, m.index),
+			exported ? 'public' : 'private',
+			exported,
+			exported ? 'namespace_public' : 'unknown',
+		);
+	}
+
+	const functionRe =
+		/(?:^|[;\n}])\s*(static\s+)?(?:[A-Za-z_~][A-Za-z0-9_:<>,~*&\s]*?\s+)([A-Za-z_][A-Za-z0-9_]*)\s*\([^;{}]*\)\s*(?:const\s*)?(;|\{)/g;
+	const skip = new Set(['if', 'for', 'while', 'switch', 'catch', 'return']);
+	for (
+		let m = functionRe.exec(source);
+		m !== null;
+		m = functionRe.exec(source)
+	) {
+		const name = m[2];
+		if (skip.has(name)) continue;
+		const isStatic = Boolean(m[1]);
+		const exported = !isStatic && !isInAnonymousNamespace(m.index);
+		const start = m.index + m[0].indexOf(name);
+		addRegexDef(
+			defs,
+			source,
+			name,
+			'function',
+			start,
+			declarationEnd(source, m.index),
+			exported ? 'public' : 'private',
+			exported,
+			m[3] === ';' ? 'header_declaration' : 'namespace_public',
+		);
+	}
+}
+
+function augmentSwiftDefs(source: string, defs: FileSymbolFacts['defs']): void {
+	type Block = {
+		start: number;
+		end: number;
+		exported: boolean;
+		visibility: SymbolVisibilityInfo['visibility'];
+	};
+	const blocks: Block[] = [];
+	const normalizeVisibility = (
+		raw: string | undefined,
+	): SymbolVisibilityInfo['visibility'] => {
+		if (raw === 'open') return 'public';
+		if (raw === 'fileprivate') return 'private';
+		return (
+			(raw as SymbolVisibilityInfo['visibility'] | undefined) ?? 'internal'
+		);
+	};
+	const addBlock = (
+		start: number,
+		visibility: SymbolVisibilityInfo['visibility'],
+		exported: boolean,
+	): void => {
+		const open = source.indexOf('{', start);
+		const close = open === -1 ? null : findMatchingBrace(source, open);
+		if (open !== -1 && close !== null) {
+			blocks.push({ start: open, end: close, visibility, exported });
+		}
+	};
+	const swiftTypeRe =
+		/\b(?:(open|public|internal|fileprivate|private)\s+)?(class|struct|enum|protocol)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+	for (
+		let m = swiftTypeRe.exec(source);
+		m !== null;
+		m = swiftTypeRe.exec(source)
+	) {
+		const visibility = normalizeVisibility(m[1]);
+		const exported = visibility !== 'private';
+		const kind =
+			m[2] === 'protocol'
+				? 'interface'
+				: m[2] === 'enum'
+					? 'enum'
+					: m[2] === 'class'
+						? 'class'
+						: 'type';
+		addRegexDef(
+			defs,
+			source,
+			m[3],
+			kind,
+			m.index,
+			declarationEnd(source, m.index),
+			visibility,
+			exported,
+			visibility === 'internal' ? 'module_public' : 'modifier',
+		);
+		addBlock(m.index, visibility, exported);
+	}
+	const swiftExtensionRe =
+		/\b(?:(open|public|internal|fileprivate|private)\s+)?extension\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+	for (
+		let m = swiftExtensionRe.exec(source);
+		m !== null;
+		m = swiftExtensionRe.exec(source)
+	) {
+		const visibility = normalizeVisibility(m[1]);
+		addBlock(m.index, visibility, visibility !== 'private');
+	}
+	const swiftFunctionRe =
+		/\b(?:(open|public|internal|fileprivate|private)\s+)?func\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+	for (
+		let m = swiftFunctionRe.exec(source);
+		m !== null;
+		m = swiftFunctionRe.exec(source)
+	) {
+		const container = blocks.find(
+			(block) => m.index >= block.start && m.index <= block.end,
+		);
+		const visibility = m[1]
+			? normalizeVisibility(m[1])
+			: (container?.visibility ?? 'internal');
+		const exported = (container?.exported ?? true) && visibility !== 'private';
+		addRegexDef(
+			defs,
+			source,
+			m[2],
+			container ? 'method' : 'function',
+			m.index,
+			declarationEnd(source, m.index),
+			visibility,
+			exported,
+			visibility === 'internal' ? 'module_public' : 'modifier',
+		);
+	}
+}
+
+function augmentDartDefs(source: string, defs: FileSymbolFacts['defs']): void {
+	const dartTypeRe =
+		/\b(class|mixin|enum|extension)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+	for (
+		let m = dartTypeRe.exec(source);
+		m !== null;
+		m = dartTypeRe.exec(source)
+	) {
+		const exported = !m[2].startsWith('_');
+		addRegexDef(
+			defs,
+			source,
+			m[2],
+			m[1] === 'enum' ? 'enum' : m[1] === 'class' ? 'class' : 'type',
+			m.index,
+			declarationEnd(source, m.index),
+			exported ? 'public' : 'private',
+			exported,
+			exported ? 'naming_convention' : 'unknown',
+		);
+	}
+	const dartFunctionRe =
+		/\b(?:void|[A-Za-z_][A-Za-z0-9_<>,?]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+	for (
+		let m = dartFunctionRe.exec(source);
+		m !== null;
+		m = dartFunctionRe.exec(source)
+	) {
+		const exported = !m[1].startsWith('_');
+		addRegexDef(
+			defs,
+			source,
+			m[1],
+			'function',
+			m.index,
+			declarationEnd(source, m.index),
+			exported ? 'public' : 'private',
+			exported,
+			exported ? 'naming_convention' : 'unknown',
+		);
+	}
+}
+
+function augmentRubyDefs(source: string, defs: FileSymbolFacts['defs']): void {
+	const lines = source.split(/\r?\n/);
+	let offset = 0;
+	let currentVisibility: SymbolVisibilityInfo['visibility'] = 'public';
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (trimmed === 'private' || trimmed === 'protected') {
+			currentVisibility = trimmed;
+		}
+		const moduleMatch = trimmed.match(/^module\s+([A-Z][A-Za-z0-9_:]*)/);
+		if (moduleMatch) {
+			currentVisibility = 'public';
+			addRegexDef(
+				defs,
+				source,
+				moduleMatch[1],
+				'type',
+				offset + line.indexOf(moduleMatch[0]),
+				offset + line.length,
+				'public',
+				true,
+				'module_public',
+			);
+		}
+		const classMatch = trimmed.match(/^class\s+([A-Z][A-Za-z0-9_:]*)/);
+		if (classMatch) {
+			currentVisibility = 'public';
+			addRegexDef(
+				defs,
+				source,
+				classMatch[1],
+				'class',
+				offset + line.indexOf(classMatch[0]),
+				offset + line.length,
+				'public',
+				true,
+				'module_public',
+			);
+		}
+		const constMatch = trimmed.match(/^([A-Z][A-Za-z0-9_]*)\s*=/);
+		if (constMatch) {
+			addRegexDef(
+				defs,
+				source,
+				constMatch[1],
+				'const',
+				offset + line.indexOf(constMatch[1]),
+				offset + line.length,
+				'public',
+				true,
+				'module_public',
+			);
+		}
+		const methodMatch = trimmed.match(
+			/^def\s+(?:(self)\.)?([A-Za-z_][A-Za-z0-9_]*)/,
+		);
+		if (methodMatch) {
+			const name = methodMatch[1] ? `self.${methodMatch[2]}` : methodMatch[2];
+			const visibility = methodMatch[1] ? 'public' : currentVisibility;
+			const exported = visibility !== 'private' && !name.startsWith('_');
+			addRegexDef(
+				defs,
+				source,
+				name,
+				'method',
+				offset + line.indexOf('def'),
+				offset + line.length,
+				visibility,
+				exported,
+				exported ? 'module_public' : 'unknown',
+			);
+		}
+		offset += line.length + 1;
+	}
+}
+
+function augmentPhpDefs(source: string, defs: FileSymbolFacts['defs']): void {
+	const namespaceRe = /\bnamespace\s+([^;{]+)\s*[;{]/g;
+	for (
+		let m = namespaceRe.exec(source);
+		m !== null;
+		m = namespaceRe.exec(source)
+	) {
+		addRegexDef(
+			defs,
+			source,
+			m[1].trim(),
+			'type',
+			m.index,
+			m.index + m[0].length,
+			'public',
+			true,
+			'namespace_public',
+		);
+	}
+	const phpTypeRe = /\b(trait|class|interface)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+	const typeRanges: Array<{ start: number; end: number }> = [];
+	for (let m = phpTypeRe.exec(source); m !== null; m = phpTypeRe.exec(source)) {
+		const bodyStart = source.indexOf('{', m.index);
+		const bodyEnd =
+			bodyStart === -1 ? null : findMatchingBrace(source, bodyStart);
+		if (bodyStart !== -1 && bodyEnd !== null) {
+			typeRanges.push({ start: bodyStart, end: bodyEnd });
+		}
+		addRegexDef(
+			defs,
+			source,
+			m[2],
+			m[1] === 'class' ? 'class' : 'interface',
+			m.index,
+			declarationEnd(source, m.index),
+			'public',
+			true,
+			'module_public',
+		);
+	}
+	const phpFunctionRe =
+		/\b(?:(public|protected|private|static|final|abstract)\s+)*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+	for (
+		let m = phpFunctionRe.exec(source);
+		m !== null;
+		m = phpFunctionRe.exec(source)
+	) {
+		const modifiers = m[0].slice(0, m[0].indexOf('function'));
+		const visibility =
+			(modifiers.match(/\b(public|protected|private)\b/)?.[1] as
+				| SymbolVisibilityInfo['visibility']
+				| undefined) ?? 'public';
+		const exported = visibility !== 'private' && !m[2].startsWith('_');
+		const effectiveVisibility = m[2].startsWith('_') ? 'private' : visibility;
+		const kind = typeRanges.some(
+			(range) => m.index >= range.start && m.index <= range.end,
+		)
+			? 'method'
+			: 'function';
+		addRegexDef(
+			defs,
+			source,
+			m[2],
+			kind,
+			m.index,
+			declarationEnd(source, m.index),
+			effectiveVisibility,
+			exported,
+			exported ? 'module_public' : 'unknown',
+		);
+	}
 }
 
 function augmentJvmDotnetDefs(
@@ -1674,9 +2107,24 @@ function parseCppInclude(text: string): FileSymbolFacts['imports'][0] | null {
 	// #include <foo>
 	// #include "foo"
 	// using foo::bar;
-	const include = t.match(/^#\s*include\s+[<"]([^>"]+)[>"]/);
-	if (include) {
-		return { specifier: include[1], importType: 'namespace', bindings: [] };
+	const quotedInclude = t.match(/^#\s*include\s+\\?"([^"\\]+)\\?"/);
+	if (quotedInclude) {
+		const specifier = quotedInclude[1].startsWith('.')
+			? quotedInclude[1]
+			: `./${quotedInclude[1]}`;
+		return {
+			specifier,
+			importType: 'default',
+			bindings: [],
+		};
+	}
+	const angleInclude = t.match(/^#\s*include\s+<([^>]+)>/);
+	if (angleInclude) {
+		return {
+			specifier: angleInclude[1],
+			importType: 'namespace',
+			bindings: [],
+		};
 	}
 	const using = t.match(/^using\s+(?:namespace\s+)?(.+?)\s*;?\s*$/);
 	if (using) {
@@ -1706,12 +2154,36 @@ function parseDartImport(text: string): FileSymbolFacts['imports'][0] | null {
 	// import 'foo' as bar;
 	// import 'foo' show A, B;
 	// import 'foo' hide A;
+	// export 'foo' show A, B;
+	const exportMatch = t.match(
+		/^export\s+['"]([^'"]+)['"](?:\s+show\s+([^;]+))?/,
+	);
+	if (exportMatch) {
+		const shown = exportMatch[2]
+			?.split(',')
+			.map((part) => part.trim())
+			.filter(Boolean);
+		const bindings =
+			shown && shown.length > 0
+				? shown.map((name) => ({ imported: name, local: name }))
+				: [{ imported: '*', local: '*' }];
+		return {
+			specifier: exportMatch[1],
+			importType: shown && shown.length > 0 ? 'named' : 'namespace',
+			bindings,
+			reExport: true,
+			exportedBindings: bindings.map((binding) => ({
+				imported: binding.imported,
+				exported: binding.local,
+			})),
+		};
+	}
 	const m = t.match(/^import\s+['"]([^'"]+)['"]\s+as\s+(\w+)/);
 	if (m) {
 		return {
 			specifier: m[1],
-			importType: 'named',
-			bindings: [{ imported: m[1], local: m[2] }],
+			importType: 'namespace',
+			bindings: [],
 		};
 	}
 	const simple = t.match(/^import\s+['"]([^'"]+)['"]/);
@@ -1727,13 +2199,16 @@ function parseRubyRequire(text: string): FileSymbolFacts['imports'][0] | null {
 	// e.g. "json" for require 'json'
 	// e.g. "./foo" for require_relative './foo'
 	// When the require keyword is included (full call text), strip it.
+	const isRequireRelative = /^require_relative\b/.test(t);
 	const stripped = t
 		.replace(/^(?:require(?:_relative)?)\s+['"]?/, '')
 		.replace(/['"]$/, '');
 	if (!stripped || stripped === t) return null;
-	const isRelative = stripped.startsWith('./') || stripped.startsWith('../');
+	const specifier =
+		isRequireRelative && !stripped.startsWith('.') ? `./${stripped}` : stripped;
+	const isRelative = specifier.startsWith('./') || specifier.startsWith('../');
 	return {
-		specifier: stripped,
+		specifier,
 		importType: isRelative ? 'default' : 'namespace',
 		bindings: [],
 	};
@@ -1762,6 +2237,42 @@ function parsePhpUse(text: string): FileSymbolFacts['imports'][0] | null {
 		return { specifier: simple[1], importType: 'namespace', bindings: [] };
 	}
 	return null;
+}
+
+function fallbackImportsForSource(
+	grammarId: string,
+	source: string,
+): Array<{ index: number; entry: FileSymbolFacts['imports'][0] }> {
+	const entries: Array<{
+		index: number;
+		entry: FileSymbolFacts['imports'][0];
+	}> = [];
+	const lines = source.split(/\r?\n/);
+	let offset = 0;
+	for (const line of lines) {
+		const trimmed = line.trim();
+		const startLine = lineNumberAt(source, offset);
+		const withLocation = (
+			entry: FileSymbolFacts['imports'][0] | null,
+		): FileSymbolFacts['imports'][0] | null =>
+			entry ? { ...entry, startLine, endLine: startLine } : null;
+		let parsed: FileSymbolFacts['imports'][0] | null = null;
+		if (grammarId === 'cpp') {
+			parsed = parseCppInclude(trimmed);
+		} else if (grammarId === 'swift') {
+			parsed = parseSwiftImport(trimmed);
+		} else if (grammarId === 'dart') {
+			parsed = parseDartImport(trimmed);
+		} else if (grammarId === 'ruby') {
+			parsed = parseRubyRequire(trimmed);
+		} else if (grammarId === 'php') {
+			parsed = parsePhpUse(trimmed);
+		}
+		const located = withLocation(parsed);
+		if (located) entries.push({ index: offset, entry: located });
+		offset += line.length + 1;
+	}
+	return entries;
 }
 
 function isTopLevelDef(defNode: TsNode, root: TsNode): boolean {
@@ -1837,7 +2348,12 @@ const IMPORT_ANCESTOR_TYPES = new Set([
 	'use_declaration',
 	'using_directive',
 	'namespace_use_declaration',
+	'namespace_use_clause',
+	'namespace_definition',
 	'library_import', // dart
+	'library_export', // dart
+	'export_directive', // dart
+	'preproc_include', // c/c++
 ]);
 
 function isInsideImportStatement(node: TsNode): boolean {

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -1001,8 +1001,6 @@ const swiftFunctionRe =
 	/\b(?:(open|public|internal|fileprivate|private)\s+)?func\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
 
 const dartTypeRe = /\b(class|mixin|enum|extension)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
-const dartFunctionRe =
-	/\b(?:void|[A-Za-z_][A-Za-z0-9_<>,?]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
 
 function augmentCppDefs(source: string, defs: FileSymbolFacts['defs']): void {
 	const anonymousRanges: Array<{ start: number; end: number }> = [];
@@ -1176,29 +1174,9 @@ function augmentDartDefs(source: string, defs: FileSymbolFacts['defs']): void {
 			exported ? 'naming_convention' : 'unknown',
 		);
 	}
-	dartFunctionRe.lastIndex = 0;
-	for (
-		let m = dartFunctionRe.exec(source);
-		m !== null;
-		m = dartFunctionRe.exec(source)
-	) {
-		// Exclude "new ClassName(" constructor calls — the "return type"
-		// position is occupied by the "new" keyword, not a real type name.
-		const beforeName = source.slice(Math.max(0, m.index - 4), m.index);
-		if (beforeName.endsWith('new ')) continue;
-		const exported = !m[1].startsWith('_');
-		addRegexDef(
-			defs,
-			source,
-			m[1],
-			'function',
-			m.index,
-			declarationEnd(source, m.index),
-			exported ? 'public' : 'private',
-			exported,
-			exported ? 'naming_convention' : 'unknown',
-		);
-	}
+	// Note: Dart function declarations are already captured by tree-sitter's
+	// (function_signature name: (identifier) @func.name) query, so no regex
+	// fallback is needed here.
 }
 
 function augmentRubyDefs(source: string, defs: FileSymbolFacts['defs']): void {

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -480,6 +480,19 @@ export function resolveModuleSpecifier(
 								'.kts',
 								'.cs',
 								'.csx',
+								'.c',
+								'.h',
+								'.cpp',
+								'.hpp',
+								'.cc',
+								'.cxx',
+								'.swift',
+								'.dart',
+								'.rb',
+								'.rake',
+								'.gemspec',
+								'.php',
+								'.phtml',
 								'.ts',
 								'.tsx',
 								'.js',
@@ -504,6 +517,19 @@ export function resolveModuleSpecifier(
 								'.kts',
 								'.cs',
 								'.csx',
+								'.c',
+								'.h',
+								'.cpp',
+								'.hpp',
+								'.cc',
+								'.cxx',
+								'.swift',
+								'.dart',
+								'.rb',
+								'.rake',
+								'.gemspec',
+								'.php',
+								'.phtml',
 								'.json',
 							];
 				let found: string | null = null;
@@ -900,6 +926,25 @@ function parseFileImports(
 	if (ext === '.cs' || ext === '.csx') {
 		return parseCSharpFileImports(rawContent);
 	}
+	if (['.c', '.h', '.cpp', '.hpp', '.cc', '.cxx'].includes(ext)) {
+		return parseCppFileImports(rawContent);
+	}
+	if (ext === '.swift') {
+		return parseSwiftFileImports(rawContent);
+	}
+	if (ext === '.dart') {
+		return parseDartFileImports(rawContent);
+	}
+	if (['.rb', '.rake', '.gemspec'].includes(ext)) {
+		return parseRubyFileImports(rawContent);
+	}
+	if (
+		ext === '.php' ||
+		ext === '.phtml' ||
+		sourceFile?.endsWith('.blade.php')
+	) {
+		return parsePhpFileImports(rawContent);
+	}
 
 	const imports: ParsedImport[] = [];
 	const content = stripComments(rawContent);
@@ -1047,6 +1092,109 @@ function parseCSharpFileImports(rawContent: string): ParsedImport[] {
 				: isStatic
 					? [{ imported: '*', local: '*' }]
 					: [],
+		);
+		if (parsed) imports.push(parsed);
+	}
+	return imports;
+}
+
+function parseCppFileImports(rawContent: string): ParsedImport[] {
+	const imports: ParsedImport[] = [];
+	const content = rawContent
+		.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+		.replace(/\/\/[^\n\r]*/g, (m) => ' '.repeat(m.length));
+	for (const line of content.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		const quotedInclude = trimmed.match(/^#\s*include\s+\\?"([^"\\]+)\\?"/);
+		if (quotedInclude) {
+			const specifier = quotedInclude[1].startsWith('.')
+				? quotedInclude[1]
+				: `./${quotedInclude[1]}`;
+			const parsed = makeParsedImport(specifier, 'default', []);
+			if (parsed) imports.push(parsed);
+			continue;
+		}
+		const angleInclude = trimmed.match(/^#\s*include\s+<([^>]+)>/);
+		if (angleInclude) {
+			const parsed = makeParsedImport(angleInclude[1], 'namespace', []);
+			if (parsed) imports.push(parsed);
+		}
+	}
+	for (const match of content.matchAll(
+		/^\s*using\s+(?:namespace\s+)?(.+?)\s*;?\s*$/gm,
+	)) {
+		const parsed = makeParsedImport(match[1].trim(), 'namespace', []);
+		if (parsed) imports.push(parsed);
+	}
+	return imports;
+}
+
+function parseSwiftFileImports(rawContent: string): ParsedImport[] {
+	const imports: ParsedImport[] = [];
+	for (const match of rawContent.matchAll(
+		/^\s*import\s+(?:class\s+)?([^;\s]+)/gm,
+	)) {
+		const parsed = makeParsedImport(match[1], 'namespace', []);
+		if (parsed) imports.push(parsed);
+	}
+	return imports;
+}
+
+function parseDartFileImports(rawContent: string): ParsedImport[] {
+	const imports: ParsedImport[] = [];
+	for (const match of rawContent.matchAll(
+		/^\s*(import|export)\s+['"]([^'"]+)['"]([^;]*)/gm,
+	)) {
+		const shown = match[3]
+			?.match(/\bshow\s+([^;]+)/)?.[1]
+			.split(',')
+			.map((part) => part.trim())
+			.filter(Boolean);
+		const alias = match[3]?.match(/\bas\s+(\w+)/)?.[1];
+		const bindings =
+			shown && shown.length > 0
+				? shown.map((name) => ({ imported: name, local: name }))
+				: [];
+		const parsed = makeParsedImport(
+			match[2],
+			bindings.length > 0 && !alias ? 'named' : 'namespace',
+			bindings,
+			match[1] === 'export',
+		);
+		if (parsed) imports.push(parsed);
+	}
+	return imports;
+}
+
+function parseRubyFileImports(rawContent: string): ParsedImport[] {
+	const imports: ParsedImport[] = [];
+	for (const match of rawContent.matchAll(
+		/^\s*(require_relative|require)\s+['"]([^'"]+)['"]/gm,
+	)) {
+		const relative = match[1] === 'require_relative';
+		const specifier =
+			relative && !match[2].startsWith('.') ? `./${match[2]}` : match[2];
+		const parsed = makeParsedImport(
+			specifier,
+			relative ? 'default' : 'namespace',
+			[],
+		);
+		if (parsed) imports.push(parsed);
+	}
+	return imports;
+}
+
+function parsePhpFileImports(rawContent: string): ParsedImport[] {
+	const imports: ParsedImport[] = [];
+	for (const match of rawContent.matchAll(
+		/^\s*use\s+(?:(?:function|const)\s+)?([^;\s]+)(?:\s+as\s+(\w+))?\s*;?\s*$/gim,
+	)) {
+		const imported = match[1].split('\\').pop() ?? match[1];
+		const bindings = match[2] ? [{ imported, local: match[2] }] : [];
+		const parsed = makeParsedImport(
+			match[1],
+			bindings.length > 0 ? 'named' : 'namespace',
+			bindings,
 		);
 		if (parsed) imports.push(parsed);
 	}
@@ -1935,7 +2083,10 @@ export async function scanFileAsync(
 		const count = rangeCounts.get(d.name) ?? 0;
 		const rangeKey = count === 0 ? d.name : `${d.name}#${count + 1}`;
 		rangeCounts.set(d.name, count + 1);
-		exportRanges[rangeKey] = { startLine: d.startLine, endLine: d.endLine };
+		exportRanges[rangeKey] = {
+			startLine: d.startLine,
+			endLine: Math.max(d.endLine, d.startLine),
+		};
 	}
 	const exportsSet = new Set(exports);
 	const isPythonPackageInit =

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -1151,6 +1151,9 @@ function parseDartFileImports(rawContent: string): ParsedImport[] {
 			.map((part) => part.trim())
 			.filter(Boolean);
 		const alias = match[3]?.match(/\bas\s+(\w+)/)?.[1];
+		// F-006: hide clause is intentionally unhandled — the import is still
+		// recorded as a namespace import (all symbols minus hidden ones) and
+		// classified as 'namespace', which is correct for symbol-graph purposes.
 		const bindings =
 			shown && shown.length > 0
 				? shown.map((name) => ({ imported: name, local: name }))

--- a/src/tools/symbols.ts
+++ b/src/tools/symbols.ts
@@ -1274,7 +1274,7 @@ export function extractPhpSymbols(filePath: string, cwd: string): SymbolInfo[] {
 	const seen = new Set<string>();
 	const typeRanges: Array<{ start: number; end: number }> = [];
 	for (const match of content.matchAll(
-		/\bnamespace\s+([A-Za-z_\\][A-Za-z0-9_\\]*)\s*;/g,
+		/\bnamespace\s+([A-Za-z_\\][A-Za-z0-9_\\]*)\s*[;{]/g,
 	)) {
 		addUniqueSymbol(symbols, seen, {
 			name: match[1],
@@ -1356,21 +1356,21 @@ export function extractSymbolsForFile(
 		case '.hpp':
 		case '.cc':
 		case '.cxx':
-			return extractCppSymbols(filePath, cwd);
+			return _internals.extractCppSymbols(filePath, cwd);
 		case '.swift':
-			return extractSwiftSymbols(filePath, cwd);
+			return _internals.extractSwiftSymbols(filePath, cwd);
 		case '.dart':
-			return extractDartSymbols(filePath, cwd);
+			return _internals.extractDartSymbols(filePath, cwd);
 		case '.rb':
 		case '.rake':
 		case '.gemspec':
-			return extractRubySymbols(filePath, cwd);
+			return _internals.extractRubySymbols(filePath, cwd);
 		case '.php':
 		case '.phtml':
-			return extractPhpSymbols(filePath, cwd);
+			return _internals.extractPhpSymbols(filePath, cwd);
 		default:
 			if (filePath.endsWith('.blade.php'))
-				return extractPhpSymbols(filePath, cwd);
+				return _internals.extractPhpSymbols(filePath, cwd);
 			return null;
 	}
 }
@@ -1658,3 +1658,16 @@ export const symbols: ToolDefinition = createSwarmTool({
 		);
 	},
 });
+
+/**
+ * DI seam for testability — tests substitute via `_internals.fn` rather than
+ * `mock.module`, which leaks across Bun's shared test-runner process.
+ * @see AGENTS.md invariant #7
+ */
+export const _internals = {
+	extractCppSymbols,
+	extractSwiftSymbols,
+	extractDartSymbols,
+	extractRubySymbols,
+	extractPhpSymbols,
+};

--- a/src/tools/symbols.ts
+++ b/src/tools/symbols.ts
@@ -47,6 +47,19 @@ const SYMBOL_EXTENSIONS = new Set([
 	'.kts',
 	'.cs',
 	'.csx',
+	'.c',
+	'.h',
+	'.cpp',
+	'.hpp',
+	'.cc',
+	'.cxx',
+	'.swift',
+	'.dart',
+	'.rb',
+	'.rake',
+	'.gemspec',
+	'.php',
+	'.phtml',
 ]);
 
 export const SUPPORTED_SYMBOL_EXTENSIONS = [...SYMBOL_EXTENSIONS].sort();
@@ -1023,6 +1036,292 @@ export function extractCSharpSymbols(
 	);
 }
 
+function declarationSignature(content: string, index: number): string {
+	return lineTextAt(content, index);
+}
+
+export function extractCppSymbols(filePath: string, cwd: string): SymbolInfo[] {
+	const raw = readValidatedSourceFile(filePath, cwd);
+	if (raw === null) return [];
+	const content = stripJvmDotnetComments(raw);
+	const symbols: SymbolInfo[] = [];
+	const seen = new Set<string>();
+	const anonymousRanges: Array<{ start: number; end: number }> = [];
+	for (const match of content.matchAll(/\bnamespace\s*\{/g)) {
+		const open = content.indexOf('{', match.index);
+		const close = open === -1 ? null : findMatchingBrace(content, open);
+		if (open !== -1 && close !== null) {
+			anonymousRanges.push({ start: open, end: close });
+		}
+	}
+	const isAnonymous = (index: number) =>
+		anonymousRanges.some((range) => index >= range.start && index <= range.end);
+
+	for (const match of content.matchAll(
+		/\b(class|struct|enum)\s+([A-Za-z_][A-Za-z0-9_]*)/g,
+	)) {
+		const kind: SymbolInfo['kind'] =
+			match[1] === 'enum' ? 'enum' : match[1] === 'class' ? 'class' : 'type';
+		addUniqueSymbol(symbols, seen, {
+			name: match[2],
+			kind,
+			exported: !isAnonymous(match.index),
+			signature: declarationSignature(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+
+	const fnRe =
+		/^\s*(static\s+)?(?:inline\s+|constexpr\s+|extern\s+|virtual\s+|friend\s+)*[A-Za-z_~][A-Za-z0-9_:<>~*&\s]*?\s+([A-Za-z_~][A-Za-z0-9_:~]*)\s*\([^;{}]*\)\s*(?:const\s*)?(?:[;{])/gm;
+	for (const match of content.matchAll(fnRe)) {
+		const name = match[2].split('::').pop() ?? match[2];
+		if (!name || ['if', 'for', 'while', 'switch', 'return'].includes(name)) {
+			continue;
+		}
+		addUniqueSymbol(symbols, seen, {
+			name,
+			kind: 'function',
+			exported: !match[1] && !isAnonymous(match.index),
+			signature: declarationSignature(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+	return symbols.sort((a, b) =>
+		a.line === b.line ? a.name.localeCompare(b.name) : a.line - b.line,
+	);
+}
+
+function normalizeSwiftVisibility(
+	value: string | undefined,
+): 'public' | 'internal' | 'private' {
+	if (value === 'private' || value === 'fileprivate') return 'private';
+	if (value === 'open' || value === 'public') return 'public';
+	return 'internal';
+}
+
+export function extractSwiftSymbols(
+	filePath: string,
+	cwd: string,
+): SymbolInfo[] {
+	const raw = readValidatedSourceFile(filePath, cwd);
+	if (raw === null) return [];
+	const content = stripJvmDotnetComments(raw);
+	const symbols: SymbolInfo[] = [];
+	const seen = new Set<string>();
+	const blocks: Array<{
+		name: string;
+		start: number;
+		end: number;
+		exported: boolean;
+		visibility: 'public' | 'internal' | 'private';
+	}> = [];
+	const typeRe =
+		/\b(?:(open|public|internal|fileprivate|private)\s+)?(class|struct|enum|protocol)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+	for (const match of content.matchAll(typeRe)) {
+		const visibility = normalizeSwiftVisibility(match[1]);
+		const kind: SymbolInfo['kind'] =
+			match[2] === 'protocol'
+				? 'interface'
+				: match[2] === 'enum'
+					? 'enum'
+					: match[2] === 'class'
+						? 'class'
+						: 'type';
+		const open = content.indexOf('{', match.index);
+		const close = open === -1 ? null : findMatchingBrace(content, open);
+		const exported = visibility !== 'private';
+		if (open !== -1 && close !== null) {
+			blocks.push({
+				name: match[3],
+				start: open,
+				end: close,
+				exported,
+				visibility,
+			});
+		}
+		addUniqueSymbol(symbols, seen, {
+			name: match[3],
+			kind,
+			exported,
+			signature: declarationSignature(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+
+	const fnRe =
+		/\b(?:(open|public|internal|fileprivate|private)\s+)?func\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+	for (const match of content.matchAll(fnRe)) {
+		const block = blocks.find(
+			(candidate) =>
+				match.index >= candidate.start && match.index <= candidate.end,
+		);
+		const visibility = match[1]
+			? normalizeSwiftVisibility(match[1])
+			: (block?.visibility ?? 'internal');
+		const exported = (block?.exported ?? true) && visibility !== 'private';
+		addUniqueSymbol(symbols, seen, {
+			name: block ? `${block.name}.${match[2]}` : match[2],
+			kind: block ? 'method' : 'function',
+			exported,
+			signature: declarationSignature(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+	return symbols.sort((a, b) =>
+		a.line === b.line ? a.name.localeCompare(b.name) : a.line - b.line,
+	);
+}
+
+export function extractDartSymbols(
+	filePath: string,
+	cwd: string,
+): SymbolInfo[] {
+	const raw = readValidatedSourceFile(filePath, cwd);
+	if (raw === null) return [];
+	const symbols: SymbolInfo[] = [];
+	const seen = new Set<string>();
+	for (const match of raw.matchAll(
+		/\b(class|mixin|enum|extension)\s+([A-Za-z_][A-Za-z0-9_]*)/g,
+	)) {
+		const kind: SymbolInfo['kind'] =
+			match[1] === 'enum' ? 'enum' : match[1] === 'class' ? 'class' : 'type';
+		addUniqueSymbol(symbols, seen, {
+			name: match[2],
+			kind,
+			exported: !match[2].startsWith('_'),
+			signature: declarationSignature(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+	for (const match of raw.matchAll(
+		/\b(?:void|[A-Za-z_][A-Za-z0-9_<>,?]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g,
+	)) {
+		if (['if', 'for', 'while', 'switch'].includes(match[1])) continue;
+		addUniqueSymbol(symbols, seen, {
+			name: match[1],
+			kind: 'function',
+			exported: !match[1].startsWith('_'),
+			signature: declarationSignature(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+	return symbols.sort((a, b) =>
+		a.line === b.line ? a.name.localeCompare(b.name) : a.line - b.line,
+	);
+}
+
+export function extractRubySymbols(
+	filePath: string,
+	cwd: string,
+): SymbolInfo[] {
+	const raw = readValidatedSourceFile(filePath, cwd);
+	if (raw === null) return [];
+	const symbols: SymbolInfo[] = [];
+	const seen = new Set<string>();
+	let offset = 0;
+	let currentVisibility: 'public' | 'protected' | 'private' = 'public';
+	for (const line of raw.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (trimmed === 'private' || trimmed === 'protected') {
+			currentVisibility = trimmed;
+		}
+		const moduleMatch = trimmed.match(/^module\s+([A-Z][A-Za-z0-9_:]*)/);
+		const classMatch = trimmed.match(/^class\s+([A-Z][A-Za-z0-9_:]*)/);
+		if (moduleMatch || classMatch) {
+			currentVisibility = 'public';
+		}
+		const constMatch = trimmed.match(/^([A-Z][A-Za-z0-9_]*)\s*=/);
+		const methodMatch = trimmed.match(
+			/^def\s+(?:self\.)?([A-Za-z_][A-Za-z0-9_?!]*)/,
+		);
+		const singleton = /^def\s+self\./.test(trimmed);
+		const lineIndex = offset + Math.max(0, line.indexOf(trimmed));
+		if (moduleMatch || classMatch || constMatch || methodMatch) {
+			const name =
+				moduleMatch?.[1] ??
+				classMatch?.[1] ??
+				constMatch?.[1] ??
+				methodMatch?.[1];
+			if (!name) continue;
+			addUniqueSymbol(symbols, seen, {
+				name,
+				kind: moduleMatch
+					? 'type'
+					: classMatch
+						? 'class'
+						: constMatch
+							? 'const'
+							: 'method',
+				exported: methodMatch
+					? singleton || currentVisibility === 'public'
+					: true,
+				signature: trimmed.substring(0, 100),
+				line: lineNumberAt(raw, lineIndex),
+			});
+		}
+		offset += line.length + 1;
+	}
+	return symbols.sort((a, b) =>
+		a.line === b.line ? a.name.localeCompare(b.name) : a.line - b.line,
+	);
+}
+
+export function extractPhpSymbols(filePath: string, cwd: string): SymbolInfo[] {
+	const raw = readValidatedSourceFile(filePath, cwd);
+	if (raw === null) return [];
+	const content = stripJvmDotnetComments(raw);
+	const symbols: SymbolInfo[] = [];
+	const seen = new Set<string>();
+	const typeRanges: Array<{ start: number; end: number }> = [];
+	for (const match of content.matchAll(
+		/\bnamespace\s+([A-Za-z_\\][A-Za-z0-9_\\]*)\s*;/g,
+	)) {
+		addUniqueSymbol(symbols, seen, {
+			name: match[1],
+			kind: 'type',
+			exported: true,
+			signature: declarationSignature(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+	for (const match of content.matchAll(
+		/\b(final\s+|abstract\s+)?(class|interface|trait)\s+([A-Za-z_][A-Za-z0-9_]*)/g,
+	)) {
+		const bodyStart = content.indexOf('{', match.index);
+		const bodyEnd =
+			bodyStart === -1 ? null : findMatchingBrace(content, bodyStart);
+		if (bodyStart !== -1 && bodyEnd !== null) {
+			typeRanges.push({ start: bodyStart, end: bodyEnd });
+		}
+		addUniqueSymbol(symbols, seen, {
+			name: match[3],
+			kind: match[2] === 'class' ? 'class' : 'interface',
+			exported: true,
+			signature: declarationSignature(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+	for (const match of content.matchAll(
+		/\b(?:(public|protected|private|static|final|abstract)\s+)*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g,
+	)) {
+		const insideType = typeRanges.some(
+			(range) => match.index >= range.start && match.index <= range.end,
+		);
+		const modifiers = match[0].slice(0, match[0].indexOf('function'));
+		const visibility = modifiers.match(/\b(public|protected|private)\b/)?.[1];
+		addUniqueSymbol(symbols, seen, {
+			name: match[2],
+			kind: insideType ? 'method' : 'function',
+			exported: visibility !== 'private' && !match[2].startsWith('_'),
+			signature: declarationSignature(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+	return symbols.sort((a, b) =>
+		a.line === b.line ? a.name.localeCompare(b.name) : a.line - b.line,
+	);
+}
+
 export function extractSymbolsForFile(
 	filePath: string,
 	cwd: string,
@@ -1051,7 +1350,27 @@ export function extractSymbolsForFile(
 		case '.cs':
 		case '.csx':
 			return extractCSharpSymbols(filePath, cwd);
+		case '.c':
+		case '.h':
+		case '.cpp':
+		case '.hpp':
+		case '.cc':
+		case '.cxx':
+			return extractCppSymbols(filePath, cwd);
+		case '.swift':
+			return extractSwiftSymbols(filePath, cwd);
+		case '.dart':
+			return extractDartSymbols(filePath, cwd);
+		case '.rb':
+		case '.rake':
+		case '.gemspec':
+			return extractRubySymbols(filePath, cwd);
+		case '.php':
+		case '.phtml':
+			return extractPhpSymbols(filePath, cwd);
 		default:
+			if (filePath.endsWith('.blade.php'))
+				return extractPhpSymbols(filePath, cwd);
 			return null;
 	}
 }

--- a/src/tools/symbols.ts
+++ b/src/tools/symbols.ts
@@ -1196,7 +1196,41 @@ export function extractDartSymbols(
 	for (const match of raw.matchAll(
 		/\b(?:void|[A-Za-z_][A-Za-z0-9_<>,?]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g,
 	)) {
-		if (['if', 'for', 'while', 'switch'].includes(match[1])) continue;
+		// Skip control-flow keywords and expressions that look like declarations
+		// but aren't (e.g. "return foo()", "else if (", "throw Err(")
+		if (
+			[
+				'if',
+				'for',
+				'while',
+				'switch',
+				'return',
+				'else',
+				'throw',
+				'new',
+				'await',
+				'yield',
+				'case',
+				'catch',
+			].includes(match[1])
+		)
+			continue;
+		// Also skip if the "type" position is actually a non-type keyword
+		if (
+			[
+				'return',
+				'else',
+				'throw',
+				'new',
+				'await',
+				'yield',
+				'case',
+				'catch',
+				'final',
+				'const',
+			].includes(match[0].split(/\s+/)[0])
+		)
+			continue;
 		addUniqueSymbol(symbols, seen, {
 			name: match[1],
 			kind: 'function',

--- a/tests/unit/lang/symbol-graph-native-dynamic.test.ts
+++ b/tests/unit/lang/symbol-graph-native-dynamic.test.ts
@@ -65,6 +65,20 @@ int make_widget() { return hidden(); }
 		expect(overloads.every((item) => item.exported)).toBe(true);
 	});
 
+	test('cpp refs inside namespaces are not suppressed', async () => {
+		const source = `namespace api {
+int compute() { return helper(); }
+int helper() { return 42; }
+}
+`;
+		const facts = await extractFileSymbols('cpp', source);
+		expect(facts).not.toBeNull();
+		// The 'helper' call inside namespace api { ... } must NOT be filtered
+		// by isInsideImportStatement (regression: namespace_definition was
+		// wrongly in IMPORT_ANCESTOR_TYPES, suppressing all refs inside namespaces)
+		expect(facts!.refs.some((r) => r.identifier === 'helper')).toBe(true);
+	});
+
 	test('swift captures visibility modifiers, structs/enums/protocols, and extension members', async () => {
 		const source = `import Foundation
 

--- a/tests/unit/lang/symbol-graph-native-dynamic.test.ts
+++ b/tests/unit/lang/symbol-graph-native-dynamic.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { clearParserCache } from '../../../src/lang/runtime';
+import { extractFileSymbols } from '../../../src/lang/symbol-graph';
+
+function def(
+	facts: NonNullable<Awaited<ReturnType<typeof extractFileSymbols>>>,
+	name: string,
+) {
+	return facts.defs.find((item) => item.name === name);
+}
+
+describe('extractFileSymbols - native language hardening', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('cpp captures local/system includes, header declarations, enums, and static internals', async () => {
+		const source = `#include "api.h"
+#include <vector>
+
+static int hidden() { return 0; }
+namespace api {
+enum Mode { Fast };
+struct Widget {};
+int make_widget();
+int score(int value);
+int score(double value);
+}
+int make_widget() { return hidden(); }
+`;
+
+		const facts = await extractFileSymbols('cpp', source);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({
+				specifier: './api.h',
+				importType: 'default',
+			}),
+		);
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({
+				specifier: 'vector',
+				importType: 'namespace',
+			}),
+		);
+		expect(def(facts!, 'Mode')).toMatchObject({
+			kind: 'enum',
+			exported: true,
+		});
+		expect(def(facts!, 'Widget')).toMatchObject({
+			kind: 'type',
+			exported: true,
+		});
+		expect(def(facts!, 'make_widget')).toMatchObject({
+			kind: 'function',
+			exported: true,
+		});
+		expect(def(facts!, 'hidden')).toMatchObject({
+			kind: 'function',
+			exported: false,
+			visibilityInfo: { visibility: 'private' },
+		});
+		const overloads = facts!.defs.filter((item) => item.name === 'score');
+		expect(overloads).toHaveLength(2);
+		expect(overloads.every((item) => item.exported)).toBe(true);
+	});
+
+	test('swift captures visibility modifiers, structs/enums/protocols, and extension members', async () => {
+		const source = `import Foundation
+
+public struct Model {}
+internal enum Mode { case fast }
+open protocol Renderable {}
+fileprivate func hidden() {}
+public extension Model {
+	func render() { hidden() }
+}
+`;
+
+		const facts = await extractFileSymbols('swift', source);
+		expect(facts).not.toBeNull();
+		expect(def(facts!, 'Model')).toMatchObject({
+			kind: 'type',
+			exported: true,
+			visibilityInfo: { visibility: 'public' },
+		});
+		expect(def(facts!, 'Mode')).toMatchObject({
+			kind: 'enum',
+			exported: true,
+			visibilityInfo: { visibility: 'internal' },
+		});
+		expect(def(facts!, 'Renderable')).toMatchObject({
+			kind: 'interface',
+			exported: true,
+			visibilityInfo: { visibility: 'public' },
+		});
+		expect(def(facts!, 'hidden')).toMatchObject({
+			exported: false,
+			visibilityInfo: { visibility: 'private' },
+		});
+		expect(def(facts!, 'render')).toMatchObject({
+			kind: 'method',
+			exported: true,
+			visibilityInfo: { visibility: 'public' },
+		});
+	});
+});
+
+describe('extractFileSymbols - dynamic language hardening', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('dart captures import/export directives and underscore-private API convention', async () => {
+		const source = `import './src/helper.dart' as helper;
+export './src/public_api.dart' show PublicApi;
+
+class PublicWidget {}
+void _hidden() {}
+`;
+
+		const facts = await extractFileSymbols('dart', source);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({
+				specifier: './src/helper.dart',
+				importType: 'namespace',
+				bindings: [],
+			}),
+		);
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({
+				specifier: './src/public_api.dart',
+				reExport: true,
+				exportedBindings: [{ imported: 'PublicApi', exported: 'PublicApi' }],
+			}),
+		);
+		expect(def(facts!, 'PublicWidget')).toMatchObject({
+			kind: 'class',
+			exported: true,
+		});
+		expect(def(facts!, '_hidden')).toMatchObject({
+			kind: 'function',
+			exported: false,
+		});
+	});
+
+	test('ruby captures require_relative, modules, constants, singleton methods, and private methods', async () => {
+		const source = `require_relative 'helper'
+
+module Api
+	VERSION = '1'
+	class Client
+		def call
+			Helper.run
+		end
+
+		private
+
+		def hidden
+		end
+
+		def self.build
+			new
+		end
+	end
+
+	class Other
+		def visible
+		end
+	end
+end
+`;
+
+		const facts = await extractFileSymbols('ruby', source);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({
+				specifier: './helper',
+				importType: 'default',
+			}),
+		);
+		expect(def(facts!, 'Api')).toMatchObject({ kind: 'type', exported: true });
+		expect(def(facts!, 'VERSION')).toMatchObject({
+			kind: 'const',
+			exported: true,
+		});
+		expect(def(facts!, 'Client')).toMatchObject({
+			kind: 'class',
+			exported: true,
+		});
+		expect(def(facts!, 'call')).toMatchObject({
+			kind: 'method',
+			exported: true,
+		});
+		expect(def(facts!, 'hidden')).toMatchObject({
+			kind: 'method',
+			exported: false,
+			visibilityInfo: { visibility: 'private' },
+		});
+		expect(def(facts!, 'self.build')).toMatchObject({
+			kind: 'method',
+			exported: true,
+		});
+		expect(def(facts!, 'visible')).toMatchObject({
+			kind: 'method',
+			exported: true,
+			visibilityInfo: { visibility: 'public' },
+		});
+	});
+
+	test('php captures namespaces, traits, functions, classes, and method visibility', async () => {
+		const source = `<?php
+namespace App\\Services;
+use App\\Models\\User as U;
+
+trait Logs {}
+class Service {
+	function run(U $user) {}
+	static function build() {}
+	final protected function flush() {}
+	private function hidden() {}
+}
+function helper() {}
+`;
+
+		const facts = await extractFileSymbols('php', source);
+		expect(facts).not.toBeNull();
+		expect(def(facts!, 'App\\Services')).toMatchObject({
+			kind: 'type',
+			exported: true,
+		});
+		expect(def(facts!, 'Logs')).toMatchObject({
+			kind: 'interface',
+			exported: true,
+		});
+		expect(def(facts!, 'Service')).toMatchObject({
+			kind: 'class',
+			exported: true,
+		});
+		expect(def(facts!, 'run')).toMatchObject({
+			kind: 'method',
+			exported: true,
+			visibilityInfo: { visibility: 'public' },
+		});
+		expect(def(facts!, 'build')).toMatchObject({
+			kind: 'method',
+			exported: true,
+			visibilityInfo: { visibility: 'public' },
+		});
+		expect(def(facts!, 'flush')).toMatchObject({
+			kind: 'method',
+			exported: true,
+			visibilityInfo: { visibility: 'protected' },
+		});
+		expect(def(facts!, 'hidden')).toMatchObject({
+			kind: 'method',
+			exported: false,
+			visibilityInfo: { visibility: 'private' },
+		});
+		expect(def(facts!, 'helper')).toMatchObject({
+			kind: 'function',
+			exported: true,
+		});
+	});
+});

--- a/tests/unit/lang/symbol-graph-visibility.test.ts
+++ b/tests/unit/lang/symbol-graph-visibility.test.ts
@@ -157,14 +157,14 @@ module.exports = { publicName: localImpl };`,
 		expect(byName(facts!.defs, 'hidden')?.exported).toBe(false);
 	});
 
-	test('methods are not promoted into file-level exports by convention alone', async () => {
+	test('public methods retain export-range visibility for context packs', async () => {
 		const facts = await extractFileSymbols(
 			'java',
 			'public class PublicC { public void visibleMethod() {} }',
 		);
 		expect(facts).not.toBeNull();
 		expect(byName(facts!.defs, 'PublicC')?.exported).toBe(true);
-		expect(byName(facts!.defs, 'visibleMethod')?.exported).toBe(false);
+		expect(byName(facts!.defs, 'visibleMethod')?.exported).toBe(true);
 		expect(
 			byName(facts!.defs, 'visibleMethod')?.visibilityInfo?.visibility,
 		).toBe('public');

--- a/tests/unit/lang/symbol-graph.test.ts
+++ b/tests/unit/lang/symbol-graph.test.ts
@@ -1403,7 +1403,7 @@ function main() {
 			importType: 'named',
 		});
 		expect(facts!.imports[0].bindings).toEqual([
-			{ imported: 'Ns\\Foo', local: 'F' },
+			{ imported: 'Foo', local: 'F' },
 		]);
 
 		// ref: F::bar() inside main → enclosingDecl = 'main'

--- a/tests/unit/lang/symbol-graph.test.ts
+++ b/tests/unit/lang/symbol-graph.test.ts
@@ -1307,11 +1307,9 @@ void main() {
 		expect(facts!.imports).toHaveLength(1);
 		expect(facts!.imports[0]).toMatchObject({
 			specifier: 'dart:io',
-			importType: 'named',
+			importType: 'namespace',
 		});
-		expect(facts!.imports[0].bindings).toEqual([
-			{ imported: 'dart:io', local: 'io' },
-		]);
+		expect(facts!.imports[0].bindings).toEqual([]);
 
 		// ref: io.stdout... inside main → enclosingDecl = 'main'
 		const ioRef = facts!.refs.find((r) => r.identifier === 'io');
@@ -1343,7 +1341,8 @@ end
 		expect(facts!.defs).toHaveLength(1);
 		expect(facts!.defs[0]).toMatchObject({
 			name: 'main',
-			kind: 'function',
+			kind: 'method',
+			exported: true,
 		});
 		expect(facts!.defs[0].startLine).toBeGreaterThan(0);
 		expect(facts!.defs[0].endLine).toBeGreaterThanOrEqual(

--- a/tests/unit/tools/repo-map-native-dynamic.test.ts
+++ b/tests/unit/tools/repo-map-native-dynamic.test.ts
@@ -174,6 +174,55 @@ public extension Model {
 		);
 	});
 
+	test('context_pack returns Ruby class and method spans from the tool path', async () => {
+		write(
+			'billing.rb',
+			`module Billing
+class Service
+  def self.build; end
+  private
+  def token; end
+end
+class Other
+  def visible; end
+end
+end
+`,
+		);
+
+		const build = await callRepoMap({ action: 'build' });
+		expect(build.success).toBe(true);
+
+		const context = await callRepoMap({
+			action: 'context_pack',
+			file: 'billing.rb',
+			symbol: 'Service',
+			top_n: 3,
+		});
+		expect(context.success).toBe(true);
+		expect(context.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'billing.rb',
+				symbol: 'Service',
+				startLine: 2,
+			}),
+		);
+		const methodContext = await callRepoMap({
+			action: 'context_pack',
+			file: 'billing.rb',
+			symbol: 'self.build',
+			top_n: 3,
+		});
+		expect(methodContext.success).toBe(true);
+		expect(methodContext.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'billing.rb',
+				symbol: 'self.build',
+				startLine: 3,
+			}),
+		);
+	});
+
 	test('build records Dart alias imports as namespace edges, not fake symbol imports', async () => {
 		write(
 			'helper.dart',

--- a/tests/unit/tools/repo-map-native-dynamic.test.ts
+++ b/tests/unit/tools/repo-map-native-dynamic.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { repo_map } from '../../../src/tools/repo-map';
+
+let root: string;
+
+async function callRepoMap(args: Record<string, unknown>): Promise<any> {
+	type Executable = {
+		execute: (
+			args: Record<string, unknown>,
+			ctx: { directory: string },
+		) => Promise<string | { output: string }>;
+	};
+	const out = await (repo_map as unknown as Executable).execute(args, {
+		directory: root,
+	});
+	return JSON.parse(typeof out === 'string' ? out : out.output);
+}
+
+function write(rel: string, content: string): void {
+	const full = path.join(root, rel);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content, 'utf-8');
+}
+
+beforeEach(() => {
+	root = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'repo-map-native-dynamic-')),
+	);
+});
+
+afterEach(() => {
+	fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('repo_map native and dynamic language context surfaces', () => {
+	test('build resolves quoted C++ includes and context_pack returns header symbol spans', async () => {
+		write(
+			'api.h',
+			`#pragma once
+struct Widget {};
+int make_widget();
+`,
+		);
+		write(
+			'app.cpp',
+			`#include "api.h"
+int make_widget() { return 1; }
+`,
+		);
+
+		const build = await callRepoMap({ action: 'build' });
+		expect(build.success).toBe(true);
+		expect(build.fileCount).toBe(2);
+
+		const graph = JSON.parse(
+			fs.readFileSync(path.join(root, '.swarm', 'repo-graph.json'), 'utf-8'),
+		);
+		const app = Object.values(graph.nodes).find(
+			(node: any) => node.moduleName === 'app.cpp',
+		) as any;
+		expect(app.imports).toContain('./api.h');
+		expect(graph.edges).toContainEqual(
+			expect.objectContaining({
+				importSpecifier: './api.h',
+			}),
+		);
+
+		const context = await callRepoMap({
+			action: 'context_pack',
+			file: 'api.h',
+			symbol: 'Widget',
+			top_n: 3,
+		});
+		expect(context.success).toBe(true);
+		expect(context.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'api.h',
+				symbol: 'Widget',
+				startLine: 2,
+			}),
+		);
+	});
+
+	test('context_pack returns PHP trait and method spans from the tool path', async () => {
+		write(
+			'Service.php',
+			`<?php
+namespace App\\Services;
+trait Logs {}
+class Service {
+	function run() {}
+	static function build() {}
+}
+`,
+		);
+
+		const build = await callRepoMap({ action: 'build' });
+		expect(build.success).toBe(true);
+
+		const context = await callRepoMap({
+			action: 'context_pack',
+			file: 'Service.php',
+			symbol: 'Logs',
+			top_n: 3,
+		});
+		expect(context.success).toBe(true);
+		expect(context.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'Service.php',
+				symbol: 'Logs',
+				startLine: 3,
+			}),
+		);
+		const methodContext = await callRepoMap({
+			action: 'context_pack',
+			file: 'Service.php',
+			symbol: 'run',
+			top_n: 3,
+		});
+		expect(methodContext.success).toBe(true);
+		expect(methodContext.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'Service.php',
+				symbol: 'run',
+				startLine: 5,
+			}),
+		);
+		const staticMethodContext = await callRepoMap({
+			action: 'context_pack',
+			file: 'Service.php',
+			symbol: 'build',
+			top_n: 3,
+		});
+		expect(staticMethodContext.success).toBe(true);
+		expect(staticMethodContext.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'Service.php',
+				symbol: 'build',
+				startLine: 6,
+			}),
+		);
+	});
+
+	test('context_pack returns Swift public type spans from the tool path', async () => {
+		write(
+			'Model.swift',
+			`import Foundation
+public struct Model {}
+public extension Model {
+	public func render() {}
+}
+`,
+		);
+
+		const build = await callRepoMap({ action: 'build' });
+		expect(build.success).toBe(true);
+
+		const context = await callRepoMap({
+			action: 'context_pack',
+			file: 'Model.swift',
+			symbol: 'Model',
+			top_n: 3,
+		});
+		expect(context.success).toBe(true);
+		expect(context.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'Model.swift',
+				symbol: 'Model',
+				startLine: 2,
+			}),
+		);
+	});
+
+	test('build records Dart alias imports as namespace edges, not fake symbol imports', async () => {
+		write(
+			'helper.dart',
+			`void run() {}
+`,
+		);
+		write(
+			'main.dart',
+			`import './helper.dart' as helper;
+
+void main() {
+	helper.run();
+}
+`,
+		);
+
+		const build = await callRepoMap({ action: 'build' });
+		expect(build.success).toBe(true);
+
+		const graph = JSON.parse(
+			fs.readFileSync(path.join(root, '.swarm', 'repo-graph.json'), 'utf-8'),
+		);
+		expect(graph.edges).toContainEqual(
+			expect.objectContaining({
+				importSpecifier: './helper.dart',
+				importType: 'namespace',
+				importedSymbols: [],
+			}),
+		);
+		expect(graph.edges).not.toContainEqual(
+			expect.objectContaining({
+				importSpecifier: './helper.dart',
+				importedSymbols: ['./helper.dart'],
+			}),
+		);
+	});
+});

--- a/tests/unit/tools/symbols-native-dynamic.test.ts
+++ b/tests/unit/tools/symbols-native-dynamic.test.ts
@@ -58,6 +58,32 @@ static int hidden();
 		);
 	});
 
+	test('extracts Dart class and method symbols while filtering private members', () => {
+		write(
+			'model.dart',
+			`class Foo {
+  void bar() {}
+  final int _privateField = 0;
+  static void staticBaz() {}
+}
+`,
+		);
+
+		const symbols = extractSymbolsForFile('model.dart', root);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Foo', exported: true }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'bar', exported: true }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'staticBaz', exported: true }),
+		);
+		expect(symbols).not.toContainEqual(
+			expect.objectContaining({ name: '_privateField' }),
+		);
+	});
+
 	test('extracts Swift public types and methods while hiding private functions', () => {
 		write(
 			'Model.swift',

--- a/tests/unit/tools/symbols-native-dynamic.test.ts
+++ b/tests/unit/tools/symbols-native-dynamic.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { extractSymbolsForFile } from '../../../src/tools/symbols';
+
+let root: string;
+
+function write(rel: string, content: string): void {
+	const full = path.join(root, rel);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content, 'utf-8');
+}
+
+beforeEach(() => {
+	root = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'symbols-native-')),
+	);
+});
+
+afterEach(() => {
+	fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('extractSymbolsForFile - native and dynamic languages', () => {
+	test('extracts public C++ header declarations and hides static internals', () => {
+		write(
+			'api.h',
+			`#pragma once
+struct Widget {};
+int make_widget();
+static int hidden();
+`,
+		);
+
+		const symbols = extractSymbolsForFile('api.h', root);
+		expect(symbols).not.toBeNull();
+		expect(symbols).toContainEqual(
+			expect.objectContaining({
+				name: 'Widget',
+				kind: 'type',
+				exported: true,
+			}),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({
+				name: 'make_widget',
+				kind: 'function',
+				exported: true,
+			}),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({
+				name: 'hidden',
+				kind: 'function',
+				exported: false,
+			}),
+		);
+	});
+
+	test('extracts Swift public types and methods while hiding private functions', () => {
+		write(
+			'Model.swift',
+			`public struct Model {
+  public func render() {}
+}
+fileprivate func hidden() {}
+`,
+		);
+
+		const symbols = extractSymbolsForFile('Model.swift', root);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Model', exported: true }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Model.render', exported: true }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'hidden', exported: false }),
+		);
+	});
+
+	test('extracts Ruby and PHP public dynamic symbols conservatively', () => {
+		write(
+			'service.rb',
+			`module Billing
+class Service
+  def self.build; end
+  private
+  def token; end
+end
+class Other
+  def visible; end
+end
+end
+`,
+		);
+		write(
+			'Service.php',
+			`<?php
+namespace App\\Billing;
+trait Logs {}
+class Service {
+  function run() {}
+  static function build() {}
+  private function token() {}
+}
+`,
+		);
+
+		expect(extractSymbolsForFile('service.rb', root)).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: 'Billing',
+					kind: 'type',
+					exported: true,
+				}),
+				expect.objectContaining({
+					name: 'Service',
+					kind: 'class',
+					exported: true,
+				}),
+				expect.objectContaining({
+					name: 'build',
+					kind: 'method',
+					exported: true,
+				}),
+				expect.objectContaining({
+					name: 'token',
+					kind: 'method',
+					exported: false,
+				}),
+				expect.objectContaining({
+					name: 'visible',
+					kind: 'method',
+					exported: true,
+				}),
+			]),
+		);
+		expect(extractSymbolsForFile('Service.php', root)).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: 'App\\Billing',
+					kind: 'type',
+					exported: true,
+				}),
+				expect.objectContaining({
+					name: 'Logs',
+					kind: 'interface',
+					exported: true,
+				}),
+				expect.objectContaining({
+					name: 'Service',
+					kind: 'class',
+					exported: true,
+				}),
+				expect.objectContaining({
+					name: 'run',
+					kind: 'method',
+					exported: true,
+				}),
+				expect.objectContaining({
+					name: 'build',
+					kind: 'method',
+					exported: true,
+				}),
+				expect.objectContaining({
+					name: 'token',
+					kind: 'method',
+					exported: false,
+				}),
+			]),
+		);
+	});
+});


### PR DESCRIPTION
Closes #1530.
Closes #1531.

## Summary
- harden symbol-graph facts for C/C++, Swift, Dart, Ruby, and PHP, including visibility/export metadata, imports, local headers, and public declaration ranges
- wire native/dynamic language coverage through repo_map context packs and direct symbols extraction
- document limitations for native/dynamic extraction and add a pending release fragment

## Invariant audit
- 1 (plugin init):       touched - `src/lang/symbol-graph.ts` import chain was changed; verified by `tests/unit/lang/symbol-graph-init-purity.test.ts` and `bun run repro:704` T1 206.0ms under 400ms.
- 2 (runtime portability): touched - changed language/repo-map code used by the bundle; verified by `bun run build`, `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`, `bundle-portability.test.ts`, and `bundle-plugin-shape.test.ts`.
- 3 (subprocesses):       not touched - no subprocess calls added; `rg -n "process\\.cwd\\(|bunSpawn\\(|spawn\\(|spawnSync\\(" src/lang/symbol-graph.ts src/tools/repo-graph/builder.ts src/tools/symbols.ts` returned no matches.
- 4 (.swarm containment): not touched - repo_map still writes graph state through existing `.swarm/repo-graph.json` path; new tests use `os.tmpdir()` workspaces.
- 5 (plan durability):    not touched - no plan ledger/projection code changed.
- 6 (test_runner safety): not touched - validation used shell `bun --smol test`, not broad OpenCode `test_runner`.
- 7 (test writing):       touched - added focused bun:test files under 500 lines; verified by focused tests listed in Test plan.
- 8 (session state):      not touched - no module session/global maps added.
- 9 (guardrails/retry):   not touched - no guardrail/retry behavior changed.
- 10 (chat/system msg):   not touched - no chat/system hook behavior changed.
- 11 (tool registration): not touched - no tool registration or agent map changed.
- 12 (release/cache):     touched - added `docs/releases/pending/1530-1531-native-dynamic-symbol-graph.md`; did not edit version, changelog, manifest, or cache code.

## Test plan
- `node node_modules/@biomejs/biome/bin/biome check --write src/lang/symbol-graph.ts src/tools/repo-graph/builder.ts src/tools/symbols.ts tests/unit/lang/symbol-graph-native-dynamic.test.ts tests/unit/tools/repo-map-native-dynamic.test.ts tests/unit/tools/symbols-native-dynamic.test.ts tests/unit/lang/symbol-graph-visibility.test.ts tests/unit/lang/symbol-graph.test.ts docs/php-laravel.md docs/repo-graph-symbol-graph.md docs/releases/pending/1530-1531-native-dynamic-symbol-graph.md`
- `node node_modules/@biomejs/biome/bin/biome ci .`
- `git diff --check`
- `bun --smol test tests/unit/tools/symbols-native-dynamic.test.ts tests/unit/tools/repo-map-native-dynamic.test.ts tests/unit/tools/repo-map.test.ts tests/unit/tools/repo-map-jvm-dotnet.test.ts --timeout 30000`
- `bun --smol test tests/unit/lang/symbol-graph-native-dynamic.test.ts tests/unit/lang/symbol-graph.test.ts tests/unit/lang/symbol-graph-visibility.test.ts tests/unit/lang/symbol-graph-jvm-dotnet.test.ts --timeout 30000`
- `bun --smol test tests/unit/lang/symbol-graph-init-purity.test.ts tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts --timeout 30000`
- `bun run typecheck`
- `bun run build`
- `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- `bun run repro:704`

## Review evidence
- Independent implementation review found Dart alias and PHP default-method gaps; both were fixed and retested.
- Final critic found PHP modifier-bearing method gap; it was fixed and retested.
- Final critic verdict after fixes: APPROVE.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

