### PR TITLE
fix(curator): execute postmortem action output

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -653,7 +653,13 @@ Manually promote a lesson to hive (cross-project) knowledge. Either pass lesson 
 
 ### `/swarm curate`
 
-Run knowledge curation and review hive promotion candidates. Identifies evergreen lessons for cross-project reuse.
+Run knowledge curation and review hive promotion candidates. Identifies evergreen lessons for cross-project reuse. When invoked from an active session, this also runs an on-demand `CURATOR_PHASE` pass, applies returned knowledge recommendations through the existing curator update gate, and reports applied/skipped counts.
+
+### `/swarm post-mortem [--force] [--scope session|project]`
+
+Run the curator post-mortem agent over recorded `.swarm/` evidence and write `.swarm/post-mortem-{planId}.md`. The report includes the improvement agenda, final curation pass, proposal queue triage, drift summary, and an architect-facing summary.
+
+By default the command is project-scoped. Use `--scope session` to limit knowledge event aggregation to the active session; use `--force` to regenerate an existing report for the same plan ID.
 
 ### `/swarm consolidate [--force] [--respect-interval] [--evaluate]`
 
@@ -712,6 +718,7 @@ Idempotent 4-stage project finalization:
 4. **Align** â€” aggressive alignment to the default remote branch via `git reset --hard` plus `git clean -fd`, discarding uncommitted changes and untracked files; falls back to a cautious reset that preserves uncommitted changes when the aggressive path cannot proceed.
 
 Reads `.swarm/close-lessons.md` for explicit lessons and runs curation.
+Finalize also runs the curator post-mortem when curator postmortems are enabled; existing reports are reused unless regeneration is forced through `/swarm post-mortem --force`.
 When close creates knowledge entries, the summary nudges the user to run `skill_improve` or `skill_generate` to compile mature entries into skills.
 Use `--skill-review` to run the quota-bounded `skill_improver` in proposal mode for skills and knowledge; failures are advisory and do not block finalization.
 Use `--force` to finalize sessions with in-progress phases. Produces a different retro summary and bypasses the guard against closing active work.
@@ -721,8 +728,9 @@ cycles â€” cumulative project knowledge survives and is not deleted. Delete
 include `plan.json`, `plan.md`, `plan-ledger.jsonl`, `events.jsonl`, `handoff.*`,
 `escalation-report.md`, `knowledge-rejected.jsonl`, `repo-graph.json`,
 `doc-manifest.json`, `dark-matter.md`, `telemetry.jsonl`, `swarm.db` (and
-shm/wal variants), and the `evidence/`, `session/`, `scopes/`, `locks/`,
-`spec-archive/` directories.
+shm/wal variants), generated `post-mortem-*.md` reports,
+`drift-report-phase-*.json`, and the `evidence/`, `session/`, `scopes/`,
+`locks/`, `spec-archive/` directories.
 
 **Hive promotion:** During finalize, lessons in `knowledge.jsonl` are evaluated
 against a three-route eligibility gate before promotion to hive:

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -302,7 +302,7 @@ This prevents one noisy project from dominating hive promotions.
 | `/swarm knowledge restore <id>` | Un-quarantine an entry |
 | `/swarm promote <text>` | Write new hive entry |
 | `/swarm promote --from-swarm <id>` | Promote existing swarm entry |
-| `/swarm curate` | Run curator review and hive promotion pass |
+| `/swarm curate` | Run curator review, apply gated recommendations when session context exists, and review hive promotion candidates |
 
 See [Commands Reference](commands.md) for full flag details.
 

--- a/docs/releases/pending/1684-postmortem-curator-actions.md
+++ b/docs/releases/pending/1684-postmortem-curator-actions.md
@@ -1,0 +1,6 @@
+# Issue 1684: Execute curator post-mortem actions
+
+- `CURATOR_POSTMORTEM` output now has an explicit `postmortem_actions` JSON fence contract. Parsed summaries are returned to the architect instead of being replaced by mechanical counts.
+- Post-mortem curation recommendations now execute through the existing knowledge update and hive promotion paths, while proposal triage is limited to the proposal IDs named by the post-mortem output.
+- `/swarm post-mortem` supports `--scope session|project`, and `/swarm curate` runs an on-demand curator pass when session context is available.
+- Finalize now archives and cleans generated post-mortem reports and advisory drift reports after they are safely copied into the close bundle.

--- a/src/agents/explorer.ts
+++ b/src/agents/explorer.ts
@@ -284,6 +284,17 @@ Use the UUID from KNOWLEDGE_ENTRIES when observing about existing entries. Use "
 EXTENDED_DIGEST:
 [the full running digest with this phase appended]
 
+OPTIONAL_STRUCTURED_BLOCKS:
+When you have evidence for knowledge application outcomes, append this exact fenced JSON block:
+\`\`\`json knowledge_application_findings
+[{"knowledge_id":"<uuid>","expected_behavior":"...","observed_behavior":"...","verdict":"applied|ignored|violated|not_applicable","evidence_refs":[".swarm/evidence/..."]}]
+\`\`\`
+When you find skill candidates, append this exact fenced JSON block:
+\`\`\`json skill_candidates
+[{"slug":"short-kebab-slug","title":"...","source_knowledge_ids":["<uuid>"],"trigger":"...","required_procedure":["..."],"forbidden_shortcuts":["..."],"target_agents":["architect"],"reviewer_checks":["..."],"confidence":0.8,"reason":"..."}]
+\`\`\`
+Omit a block when you have no valid entries for it. Malformed or differently named blocks are ignored.
+
 ## ACTIONABILITY ENRICHMENT (V3 compatibility label; overrides the format above when triggered)
 When the input asks you to "Convert this prose lesson into an actionable knowledge directive", ignore the PHASE_DIGEST output format entirely and output ONLY a single JSON object — no fences, no commentary, no digest.
 MANDATORY fields (the directive is rejected without them):
@@ -334,19 +345,34 @@ IMPROVEMENT_AGENDA:
 2. ...
 
 CURATION_RECOMMENDATIONS:
-- merge: [entry_a UUID] + [entry_b UUID] — [reason]
-- promote_to_hive: [entry UUID] — [evidence of cross-phase confirmation]
-- flag_stale: [entry UUID] — [never applied in N phases]
-- rewrite: [entry UUID] — [what's verbose/outdated]
+- promote: [entry UUID] - [evidence of cross-phase confirmation]
+- archive: [entry UUID] - [never applied in N phases]
+- rewrite: [entry UUID] - [replacement lesson text, max 280 chars]
+- flag_contradiction: [entry UUID] - [observable conflict]
+- promote: new - [new concise lesson text]
 
 QUEUE_TRIAGE:
-- [proposal_id]: APPLY|REJECT — [one-line reasoning]
+- [proposal_id]: APPLY|REJECT - [one-line reasoning]
 
 LEARNING_METRICS:
 [3-line summary of trends if data available, or "metrics data not provided"]
 
 SUMMARY:
 [3-line executive summary for architect briefing]
+
+REQUIRED_ACTION_BLOCK:
+Append exactly one fenced JSON block after SUMMARY. This block is the executable contract; unsupported actions such as merge are ignored.
+\`\`\`json postmortem_actions
+{
+  "summary": "3-line executive summary for architect briefing",
+  "curation_recommendations": [
+    {"action": "promote", "entry_id": "<uuid or omit for new>", "lesson": "concise lesson text", "reason": "evidence-backed reason", "category": "process", "confidence": 0.8}
+  ],
+  "queue_triage": [
+    {"proposal_id": "proposal-slug", "action": "apply", "reason": "one-line reason"}
+  ]
+}
+\`\`\`
 `;
 
 export const CURATOR_CONSOLIDATION_PROMPT = `## IDENTITY

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -862,6 +862,8 @@ export async function runFinalizeStage(ctx: CloseStageContext): Promise<void> {
 					'postmortem',
 					ctx.options.sessionID,
 				),
+				scope: 'project',
+				sessionID: ctx.options.sessionID,
 			});
 			if (pmResult.success && pmResult.summary) {
 				ctx.postMortemSummary = pmResult.summary;
@@ -1104,6 +1106,35 @@ export async function runArchiveStage(ctx: CloseStageContext): Promise<void> {
 			}
 		}
 
+		const dynamicArchiveArtifacts = (
+			await fs.readdir(ctx.swarmDir).catch(() => [] as string[])
+		).filter(
+			(name) =>
+				/^post-mortem-[^/\\]+\.md$/.test(name) ||
+				/^drift-report-phase-\d+\.json$/.test(name),
+		);
+		for (const artifact of dynamicArchiveArtifacts) {
+			const srcPath = path.join(ctx.swarmDir, artifact);
+			const destPath = path.join(ctx.archiveDir, artifact);
+			try {
+				await fs.copyFile(srcPath, destPath);
+				ctx.archivedFileCount++;
+				ctx.archivedActiveStateFiles.add(artifact);
+			} catch (err: unknown) {
+				const errno = (err as NodeJS.ErrnoException)?.code;
+				if (errno !== 'ENOENT') {
+					const reason = err instanceof Error ? err.message : String(err);
+					ctx.archiveFailureReasons.set(
+						artifact,
+						`${errno ?? 'unknown'}: ${reason}`,
+					);
+					ctx.warnings.push(
+						`Failed to archive ${artifact} [${errno ?? 'unknown'}]: ${reason}. File preserved (not cleaned up).`,
+					);
+				}
+			}
+		}
+
 		// Archive directories (evidence/, session/, scopes/, locks/, spec-archive/)
 		for (const dirName of ACTIVE_STATE_DIRS_TO_CLEAN) {
 			const srcDir = path.join(ctx.swarmDir, dirName);
@@ -1271,6 +1302,27 @@ export async function runCleanStage(
 		ctx.warnings.push(
 			'Skipped active-state cleanup because no active-state files were archived. Files preserved to prevent data loss.',
 		);
+	}
+
+	for (const artifact of ctx.archivedActiveStateFiles) {
+		if (
+			!/^post-mortem-[^/\\]+\.md$/.test(artifact) &&
+			!/^drift-report-phase-\d+\.json$/.test(artifact)
+		) {
+			continue;
+		}
+		try {
+			await fs.unlink(path.join(ctx.swarmDir, artifact));
+			cleanedFiles.push(artifact);
+		} catch (err) {
+			const errno = (err as NodeJS.ErrnoException)?.code;
+			if (errno !== 'ENOENT') {
+				const reason = err instanceof Error ? err.message : String(err);
+				ctx.warnings.push(
+					`Failed to clean active-state file ${artifact} [${errno ?? 'unknown'}]: ${reason}`,
+				);
+			}
+		}
 	}
 
 	// Delete directories that were successfully archived

--- a/src/commands/curate.test.ts
+++ b/src/commands/curate.test.ts
@@ -84,10 +84,7 @@ describe('/swarm curate', () => {
 					return async () => 'OBSERVATIONS:\n- new candidate: durable lesson';
 				},
 				curator: {
-					runCuratorPhase: async (
-						_directory: string,
-						phase: number,
-					) => {
+					runCuratorPhase: async (_directory: string, phase: number) => {
 						phaseSeen = phase;
 						return {
 							knowledge_recommendations: [
@@ -116,7 +113,9 @@ describe('/swarm curate', () => {
 			expect(delegateSession).toBe('session-1684');
 			expect(phaseSeen).toBe(5);
 			expect(appliedRecommendations).toBe(1);
-			expect(result).toContain('Knowledge recommendations: 1 applied, 0 skipped');
+			expect(result).toContain(
+				'Knowledge recommendations: 1 applied, 0 skipped',
+			);
 			expect(result).toContain('Curator digest phase: 5');
 		});
 	});

--- a/src/commands/curate.test.ts
+++ b/src/commands/curate.test.ts
@@ -26,6 +26,7 @@ describe('/swarm curate', () => {
 	let tempDir: string;
 	const realLoadCuratorDeps = _internals.loadCuratorDeps;
 	const realReadSwarmFileAsync = _internals.readSwarmFileAsync;
+	const realCheckHivePromotions = _internals.checkHivePromotions;
 
 	beforeEach(() => {
 		tempDir = createTempDir();
@@ -35,6 +36,7 @@ describe('/swarm curate', () => {
 	afterEach(() => {
 		_internals.loadCuratorDeps = realLoadCuratorDeps;
 		_internals.readSwarmFileAsync = realReadSwarmFileAsync;
+		_internals.checkHivePromotions = realCheckHivePromotions;
 		cleanupDir(tempDir);
 	});
 
@@ -122,23 +124,14 @@ describe('/swarm curate', () => {
 
 	describe('Error handling', () => {
 		it('should return clear user-facing error when error is thrown', async () => {
-			// The implementation catches errors and returns user-friendly messages
-			// Test that error handling path is in place by verifying the format function exists
-			// and that errors from checkHivePromotions would be caught
+			_internals.checkHivePromotions = async () => {
+				throw new Error('hive promoter exploded');
+			};
 
-			// The try-catch block in curate.ts will catch any errors from:
-			// - KnowledgeConfigSchema.parse()
-			// - resolveSwarmKnowledgePath()
-			// - readKnowledge()
-			// - checkHivePromotions()
-			// And format them as "❌ Curation failed: {message}"
+			const result = await handleCurateCommand(tempDir, []);
 
-			// Verify the error format is defined in the implementation
-			const hasErrorFormat = true; // Verified by reading curate.ts lines 53-58
-
-			expect(hasErrorFormat).toBe(true);
-			// Error message format is: "❌ Curation failed: {error.message}"
-			// This is checked via code inspection - see curate.ts:55-56
+			expect(result).toContain('❌ Curation failed:');
+			expect(result).toContain('hive promoter exploded');
 		});
 
 		it('should not expose stack traces in error output', async () => {

--- a/src/commands/curate.test.ts
+++ b/src/commands/curate.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { handleCurateCommand } from '../commands/curate';
+import { _internals, handleCurateCommand } from '../commands/curate';
 
 // Test utilities
 function createTempDir(): string {
@@ -24,6 +24,8 @@ function createSwarmDir(dir: string): string {
 
 describe('/swarm curate', () => {
 	let tempDir: string;
+	const realLoadCuratorDeps = _internals.loadCuratorDeps;
+	const realReadSwarmFileAsync = _internals.readSwarmFileAsync;
 
 	beforeEach(() => {
 		tempDir = createTempDir();
@@ -31,6 +33,8 @@ describe('/swarm curate', () => {
 	});
 
 	afterEach(() => {
+		_internals.loadCuratorDeps = realLoadCuratorDeps;
+		_internals.readSwarmFileAsync = realReadSwarmFileAsync;
 		cleanupDir(tempDir);
 	});
 
@@ -59,6 +63,61 @@ describe('/swarm curate', () => {
 				) || []
 			).length;
 			expect(labelCount).toBe(4); // All 4 fields present
+		});
+
+		it('runs curator phase and applies recommendations when session context exists', async () => {
+			let delegateSession: string | undefined;
+			let phaseSeen = 0;
+			let appliedRecommendations = 0;
+			_internals.readSwarmFileAsync = async () =>
+				JSON.stringify({ last_phase_covered: 4 });
+			_internals.loadCuratorDeps = async () => ({
+				CuratorConfigSchema: {
+					parse: () => ({ enabled: true, phase_enabled: true }),
+				},
+				createCuratorLLMDelegate: (
+					_directory: string,
+					_mode: string,
+					sessionID?: string,
+				) => {
+					delegateSession = sessionID;
+					return async () => 'OBSERVATIONS:\n- new candidate: durable lesson';
+				},
+				curator: {
+					runCuratorPhase: async (
+						_directory: string,
+						phase: number,
+					) => {
+						phaseSeen = phase;
+						return {
+							knowledge_recommendations: [
+								{
+									action: 'promote',
+									lesson: 'durable lesson from manual curation',
+									reason: 'manual curation',
+								},
+							],
+						};
+					},
+					applyCuratorKnowledgeUpdates: async (
+						_directory: string,
+						recommendations: unknown[],
+					) => {
+						appliedRecommendations = recommendations.length;
+						return { applied: recommendations.length, skipped: 0 };
+					},
+				},
+			});
+
+			const result = await handleCurateCommand(tempDir, [], {
+				sessionID: 'session-1684',
+			});
+
+			expect(delegateSession).toBe('session-1684');
+			expect(phaseSeen).toBe(5);
+			expect(appliedRecommendations).toBe(1);
+			expect(result).toContain('Knowledge recommendations: 1 applied, 0 skipped');
+			expect(result).toContain('Curator digest phase: 5');
 		});
 	});
 

--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -71,6 +71,7 @@ export async function handleCurateCommand(
 		);
 
 		if (options?.sessionID) {
+			let onDemandPhase = 1;
 			try {
 				const { CuratorConfigSchema, curator, createCuratorLLMDelegate } =
 					await _internals.loadCuratorDeps();
@@ -79,7 +80,6 @@ export async function handleCurateCommand(
 					directory,
 					'curator-summary.json',
 				);
-				let onDemandPhase = 1;
 				if (priorSummary) {
 					try {
 						const parsed = JSON.parse(priorSummary) as {
@@ -95,30 +95,80 @@ export async function handleCurateCommand(
 						// Corrupt summary should not block manual curation.
 					}
 				}
-				const delegate = createCuratorLLMDelegate(
-					directory,
-					'phase',
-					options.sessionID,
-				);
-				const curatorResult = await curator.runCuratorPhase(
-					directory,
-					onDemandPhase,
-					['curator'],
-					curatorConfig,
-					{},
-					delegate,
-				);
-				const applied = await curator.applyCuratorKnowledgeUpdates(
-					directory,
-					curatorResult.knowledge_recommendations,
-					config,
-				);
-				summary.knowledge_applied = applied.applied;
-				summary.knowledge_skipped = applied.skipped;
-				summary.curator_phase = onDemandPhase;
-			} catch {
+
+				// F-004: clamp onDemandPhase to the plan's phase count so we
+				// don't run a phantom digest for a non-existent phase.
+				let planPhaseCount = Infinity;
+				try {
+					const planRaw = await _internals.readSwarmFileAsync(
+						directory,
+						'plan.json',
+					);
+					if (planRaw) {
+						const plan = JSON.parse(planRaw) as { phases?: unknown[] };
+						if (Array.isArray(plan.phases)) planPhaseCount = plan.phases.length;
+					}
+				} catch {
+					// No plan or unreadable — leave unbounded.
+				}
+
+				if (planPhaseCount !== Infinity && onDemandPhase > planPhaseCount) {
+					// All plan phases already covered — skip the on-demand phase pass.
+					summary.knowledge_applied = 0;
+					summary.knowledge_skipped = 0;
+					summary.curator_phase = onDemandPhase;
+				} else {
+					const delegate = createCuratorLLMDelegate(
+						directory,
+						'phase',
+						options.sessionID,
+					);
+					const curatorResult = await curator.runCuratorPhase(
+						directory,
+						onDemandPhase,
+						['curator'],
+						curatorConfig,
+						{},
+						delegate,
+					);
+					const applied = await curator.applyCuratorKnowledgeUpdates(
+						directory,
+						curatorResult.knowledge_recommendations,
+						config,
+					);
+					summary.knowledge_applied = applied.applied;
+					summary.knowledge_skipped = applied.skipped;
+					summary.curator_phase = onDemandPhase;
+
+					// F-002: re-check hive promotion after knowledge updates so
+					// newly hive_eligible entries are considered in the same run
+					// (mirrors executePostMortemActions).
+					try {
+						const updatedEntries =
+							(await _internals.readKnowledge<SwarmKnowledgeEntry>(
+								swarmPath,
+							)) ?? [];
+						const postUpdateHive = await _internals.checkHivePromotions(
+							updatedEntries,
+							config,
+						);
+						summary.new_promotions += postUpdateHive.new_promotions;
+						summary.encounters_incremented +=
+							postUpdateHive.encounters_incremented;
+						summary.advancements += postUpdateHive.advancements;
+						summary.total_hive_entries = postUpdateHive.total_hive_entries;
+					} catch {
+						// Hive re-check is advisory; do not fail the curation.
+					}
+				}
+			} catch (err) {
+				// F-005: surface the error so the user can distinguish
+				// "nothing to curate" from "hard failure".
 				summary.knowledge_applied = 0;
 				summary.knowledge_skipped = 0;
+				summary.curator_phase = onDemandPhase;
+				const reason = err instanceof Error ? err.message : String(err);
+				return `${formatCurationSummary(summary)}\n\n⚠️ On-demand curator phase skipped: ${reason}`;
 			}
 		}
 

--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -18,6 +18,23 @@ import type {
 	KnowledgeConfig,
 	SwarmKnowledgeEntry,
 } from '../hooks/knowledge-types.js';
+import { readSwarmFileAsync } from '../hooks/utils.js';
+
+export const _internals = {
+	checkHivePromotions,
+	readKnowledge,
+	resolveSwarmKnowledgePath,
+	readSwarmFileAsync,
+	loadCuratorDeps: async () => {
+		const [{ CuratorConfigSchema }, curator, { createCuratorLLMDelegate }] =
+			await Promise.all([
+				import('../config/schema.js'),
+				import('../hooks/curator.js'),
+				import('../hooks/curator-llm-factory.js'),
+			]);
+		return { CuratorConfigSchema, curator, createCuratorLLMDelegate };
+	},
+};
 
 export interface CurationSummary {
 	timestamp: string;
@@ -25,6 +42,9 @@ export interface CurationSummary {
 	encounters_incremented: number;
 	advancements: number;
 	total_hive_entries: number;
+	knowledge_applied?: number;
+	knowledge_skipped?: number;
+	curator_phase?: number;
 }
 
 /**
@@ -34,18 +54,73 @@ export interface CurationSummary {
 export async function handleCurateCommand(
 	directory: string,
 	_args: string[],
+	options?: { sessionID?: string },
 ): Promise<string> {
 	try {
 		// Use default config for manual curation
 		const config: KnowledgeConfig = KnowledgeConfigSchema.parse({});
 
 		// Read existing swarm entries
-		const swarmPath = resolveSwarmKnowledgePath(directory);
+		const swarmPath = _internals.resolveSwarmKnowledgePath(directory);
 		const swarmEntries =
-			(await readKnowledge<SwarmKnowledgeEntry>(swarmPath)) ?? [];
+			(await _internals.readKnowledge<SwarmKnowledgeEntry>(swarmPath)) ?? [];
 
-		// Run hive promotion check
-		const summary = await checkHivePromotions(swarmEntries, config);
+		const summary: CurationSummary = await _internals.checkHivePromotions(
+			swarmEntries,
+			config,
+		);
+
+		if (options?.sessionID) {
+			try {
+				const { CuratorConfigSchema, curator, createCuratorLLMDelegate } =
+					await _internals.loadCuratorDeps();
+				const curatorConfig = CuratorConfigSchema.parse({});
+				const priorSummary = await _internals.readSwarmFileAsync(
+					directory,
+					'curator-summary.json',
+				);
+				let onDemandPhase = 1;
+				if (priorSummary) {
+					try {
+						const parsed = JSON.parse(priorSummary) as {
+							last_phase_covered?: unknown;
+						};
+						if (
+							typeof parsed.last_phase_covered === 'number' &&
+							Number.isFinite(parsed.last_phase_covered)
+						) {
+							onDemandPhase = Math.max(1, parsed.last_phase_covered + 1);
+						}
+					} catch {
+						// Corrupt summary should not block manual curation.
+					}
+				}
+				const delegate = createCuratorLLMDelegate(
+					directory,
+					'phase',
+					options.sessionID,
+				);
+				const curatorResult = await curator.runCuratorPhase(
+					directory,
+					onDemandPhase,
+					['curator'],
+					curatorConfig,
+					{},
+					delegate,
+				);
+				const applied = await curator.applyCuratorKnowledgeUpdates(
+					directory,
+					curatorResult.knowledge_recommendations,
+					config,
+				);
+				summary.knowledge_applied = applied.applied;
+				summary.knowledge_skipped = applied.skipped;
+				summary.curator_phase = onDemandPhase;
+			} catch {
+				summary.knowledge_applied = 0;
+				summary.knowledge_skipped = 0;
+			}
+		}
 
 		// Return human-readable summary
 		// Zero counts indicate empty-state (nothing to promote)
@@ -72,6 +147,14 @@ function formatCurationSummary(summary: CurationSummary): string {
 		`Advancements: ${summary.advancements}`,
 		`Total hive entries: ${summary.total_hive_entries}`,
 	];
+	if (summary.knowledge_applied !== undefined) {
+		lines.push(
+			`Knowledge recommendations: ${summary.knowledge_applied} applied, ${summary.knowledge_skipped ?? 0} skipped`,
+		);
+	}
+	if (summary.curator_phase !== undefined) {
+		lines.push(`Curator digest phase: ${summary.curator_phase}`);
+	}
 
 	return lines.join('\n');
 }

--- a/src/commands/post-mortem.ts
+++ b/src/commands/post-mortem.ts
@@ -25,7 +25,8 @@ function parsePostMortemArgs(args: string[]): {
 				return {
 					force: args.includes('--force'),
 					scope,
-					error: 'Invalid --scope value. Use --scope session or --scope project.',
+					error:
+						'Invalid --scope value. Use --scope session or --scope project.',
 				};
 			}
 			scope = value;
@@ -38,7 +39,8 @@ function parsePostMortemArgs(args: string[]): {
 				return {
 					force: args.includes('--force'),
 					scope,
-					error: 'Invalid --scope value. Use --scope=session or --scope=project.',
+					error:
+						'Invalid --scope value. Use --scope=session or --scope=project.',
 				};
 			}
 			scope = value;

--- a/src/commands/post-mortem.ts
+++ b/src/commands/post-mortem.ts
@@ -11,6 +11,42 @@ export const _internals = {
 	runCuratorPostMortem,
 };
 
+function parsePostMortemArgs(args: string[]): {
+	force: boolean;
+	scope: 'session' | 'project';
+	error?: string;
+} {
+	let scope: 'session' | 'project' = 'project';
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === '--scope') {
+			const value = args[i + 1];
+			if (value !== 'session' && value !== 'project') {
+				return {
+					force: args.includes('--force'),
+					scope,
+					error: 'Invalid --scope value. Use --scope session or --scope project.',
+				};
+			}
+			scope = value;
+			i++;
+			continue;
+		}
+		if (arg.startsWith('--scope=')) {
+			const value = arg.slice('--scope='.length);
+			if (value !== 'session' && value !== 'project') {
+				return {
+					force: args.includes('--force'),
+					scope,
+					error: 'Invalid --scope value. Use --scope=session or --scope=project.',
+				};
+			}
+			scope = value;
+		}
+	}
+	return { force: args.includes('--force'), scope };
+}
+
 // ── Command handler ───────────────────────────────────────────────────
 
 export async function handlePostMortemCommand(
@@ -19,10 +55,15 @@ export async function handlePostMortemCommand(
 	options?: { sessionID?: string },
 ): Promise<string> {
 	try {
-		const force = args.includes('--force');
+		const parsedArgs = parsePostMortemArgs(args);
+		if (parsedArgs.error) {
+			return parsedArgs.error;
+		}
 
 		const pmOptions: PostMortemOptions = {
-			force,
+			force: parsedArgs.force,
+			scope: parsedArgs.scope,
+			sessionID: options?.sessionID,
 		};
 
 		if (options?.sessionID) {

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -610,7 +610,10 @@ export const COMMAND_REGISTRY = {
 		toolPolicy: 'none',
 	},
 	curate: {
-		handler: (ctx) => handleCurateCommand(ctx.directory, ctx.args),
+		handler: (ctx) =>
+			handleCurateCommand(ctx.directory, ctx.args, {
+				sessionID: ctx.sessionID,
+			}),
 		description: 'Run knowledge curation and hive promotion review',
 		args: '',
 		category: 'utility',
@@ -691,8 +694,8 @@ export const COMMAND_REGISTRY = {
 		description:
 			'Run the post-mortem agent: project-end synthesis, queue triage, and final curation pass',
 		details:
-			'Reads .swarm/ evidence (knowledge entries, events, curator digests, proposals, retrospectives, drift reports) and produces a post-mortem report at .swarm/post-mortem-{planId}.md. Idempotent: re-runs skip if report exists unless --force is passed.',
-		args: '--force',
+			'Reads .swarm/ evidence (knowledge entries, events, curator digests, proposals, retrospectives, drift reports) and produces a post-mortem report at .swarm/post-mortem-{planId}.md. Idempotent: re-runs skip if report exists unless --force is passed. Use --scope session to limit knowledge event aggregation to the current session; project scope is the default.',
+		args: '--force, --scope session|project',
 		category: 'core',
 		toolPolicy: 'agent',
 	},

--- a/src/hooks/curator-postmortem.ts
+++ b/src/hooks/curator-postmortem.ts
@@ -105,10 +105,7 @@ async function collectKnowledgeSummary(
 		resolveSwarmKnowledgePath(directory),
 		MAX_KNOWLEDGE_ENTRIES,
 	);
-	let events = await readKnowledgeEvents(
-		directory,
-		MAX_KNOWLEDGE_ENTRIES * 4,
-	);
+	let events = await readKnowledgeEvents(directory, MAX_KNOWLEDGE_ENTRIES * 4);
 	if (scope === 'session' && sessionID) {
 		events = events.filter(
 			(e) => (e as { session_id?: string }).session_id === sessionID,
@@ -163,7 +160,9 @@ function extractSection(text: string, sectionName: string): string | null {
 function normalizeRecommendationAction(
 	raw: unknown,
 ): KnowledgeRecommendation['action'] | null {
-	const value = String(raw ?? '').toLowerCase().trim();
+	const value = String(raw ?? '')
+		.toLowerCase()
+		.trim();
 	if (value === 'promote' || value === 'promote_to_hive') return 'promote';
 	if (value === 'archive' || value === 'flag_stale') return 'archive';
 	if (value === 'rewrite') return 'rewrite';
@@ -189,8 +188,7 @@ function parseStructuredPostMortemActions(
 		queueTriage: [],
 		diagnostics: [],
 	};
-	const fence =
-		/```(?:json|jsonc)?\s+postmortem_actions\s*\n([\s\S]*?)\n```/g;
+	const fence = /```(?:json|jsonc)?\s+postmortem_actions\s*\n([\s\S]*?)\n```/g;
 	for (const match of llmOutput.matchAll(fence)) {
 		let data: unknown;
 		try {
@@ -275,11 +273,10 @@ function parseStructuredPostMortemActions(
 					reason?: unknown;
 				};
 				const proposalId = String(triage.proposal_id ?? '').trim();
-				const action = String(triage.action ?? '').toLowerCase().trim();
-				if (
-					!proposalId ||
-					(action !== 'apply' && action !== 'reject')
-				) {
+				const action = String(triage.action ?? '')
+					.toLowerCase()
+					.trim();
+				if (!proposalId || (action !== 'apply' && action !== 'reject')) {
 					parsed.diagnostics.push(
 						`queue_triage[${index}] missing proposal_id/action`,
 					);
@@ -296,7 +293,9 @@ function parseStructuredPostMortemActions(
 	return parsed;
 }
 
-function parseLegacyPostMortemActions(llmOutput: string): ParsedPostMortemActions {
+function parseLegacyPostMortemActions(
+	llmOutput: string,
+): ParsedPostMortemActions {
 	const parsed: ParsedPostMortemActions = {
 		summary: extractSection(llmOutput, 'SUMMARY'),
 		recommendations: [],

--- a/src/hooks/curator-postmortem.ts
+++ b/src/hooks/curator-postmortem.ts
@@ -19,14 +19,14 @@ import { tryAcquireLock } from '../parallel/file-locks.js';
 import { loadPlanJsonOnly } from '../plan/manager.js';
 import { derivePlanId } from '../plan/utils.js';
 import type { CuratorLLMDelegate } from './curator.js';
+import type { KnowledgeRecommendation } from './curator-types.js';
 import { readKnowledgeEvents } from './knowledge-events.js';
 import { resolveKnowledgeStoreDir } from './knowledge-link.js';
 import { readKnowledge, resolveSwarmKnowledgePath } from './knowledge-store.js';
-import type { KnowledgeRecommendation } from './curator-types.js';
 import type {
+	KnowledgeCategory,
 	KnowledgeConfig,
 	KnowledgeEntryBase,
-	KnowledgeCategory,
 	SwarmKnowledgeEntry,
 } from './knowledge-types.js';
 import { readSwarmFileAsync, validateSwarmPath } from './utils.js';

--- a/src/hooks/curator-postmortem.ts
+++ b/src/hooks/curator-postmortem.ts
@@ -304,39 +304,65 @@ function parseLegacyPostMortemActions(
 	};
 	const curation = extractSection(llmOutput, 'CURATION_RECOMMENDATIONS');
 	if (curation) {
+		let recIndex = 0;
 		for (const line of curation.split('\n')) {
 			const trimmed = line.trim();
 			if (!trimmed.startsWith('-')) continue;
 			const body = trimmed.replace(/^-\s*/, '');
 			const [head, reasonPart = ''] = body.split(/\s+—\s+|\s+-\s+/, 2);
 			const [rawAction, rest = ''] = head.split(/:\s*/, 2);
+			const lowerRaw = rawAction.toLowerCase().trim();
 			const action = normalizeRecommendationAction(rawAction);
-			if (!action) continue;
+			if (!action) {
+				if (lowerRaw === 'merge') {
+					parsed.diagnostics.push(
+						"legacy curation_recommendations unsupported action 'merge' — dropped",
+					);
+				} else if (lowerRaw) {
+					parsed.diagnostics.push(
+						`legacy curation_recommendations unrecognized action '${lowerRaw}'`,
+					);
+				}
+				continue;
+			}
 			const idMatch = rest.match(
 				/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i,
 			);
 			const reason = (reasonPart || rest).trim();
-			if (!reason) continue;
+			if (!reason) {
+				parsed.diagnostics.push(
+					`legacy curation_recommendations[${recIndex}] missing reason`,
+				);
+				continue;
+			}
 			parsed.recommendations.push({
 				action,
 				entry_id: idMatch?.[0],
 				lesson: reason.slice(0, 280),
 				reason: reason.slice(0, 280),
 			});
+			recIndex++;
 		}
 	}
 	const queue = extractSection(llmOutput, 'QUEUE_TRIAGE');
 	if (queue) {
 		for (const line of queue.split('\n')) {
-			const match = line
-				.trim()
-				.match(/^-\s*([^:]+):\s*(APPLY|REJECT)\b\s*(?:—|-)?\s*(.*)$/i);
-			if (!match) continue;
-			parsed.queueTriage.push({
-				proposal_id: match[1].trim().slice(0, 120),
-				action: match[2].toLowerCase() as 'apply' | 'reject',
-				reason: match[3].trim().slice(0, 280),
-			});
+			const trimmed = line.trim();
+			if (!trimmed.startsWith('-')) continue;
+			if (trimmed.includes(':')) {
+				const match = trimmed.match(
+					/^-\s*([^:]+):\s*(APPLY|REJECT)\b\s*(?:—|-)?\s*(.*)$/i,
+				);
+				if (!match) {
+					parsed.diagnostics.push('legacy queue_triage malformed line');
+					continue;
+				}
+				parsed.queueTriage.push({
+					proposal_id: match[1].trim().slice(0, 120),
+					action: match[2].toLowerCase() as 'apply' | 'reject',
+					reason: match[3].trim().slice(0, 280),
+				});
+			}
 		}
 	}
 	return parsed;
@@ -355,7 +381,7 @@ function parsePostMortemActions(llmOutput: string): ParsedPostMortemActions {
 			structured.queueTriage.length > 0
 				? structured.queueTriage
 				: legacy.queueTriage,
-		diagnostics: structured.diagnostics,
+		diagnostics: [...structured.diagnostics, ...legacy.diagnostics],
 	};
 }
 
@@ -821,12 +847,13 @@ export async function runCuratorPostMortem(
 		warnings.push('Failed to load plan data.');
 	}
 
-	// Check for existing report (dedup protection)
-	// When planId is 'unknown' (plan.json absent/unreadable), use a distinct
-	// timestamped identifier so a stale post-mortem-unknown.md from a prior
-	// run cannot permanently block regeneration.
-	const effectivePlanId =
-		planId === 'unknown' ? `unknown-${Date.now()}` : planId;
+	// Check for existing report (idempotent dedup).
+	// For planless runs (planId === 'unknown') we keep the stable 'unknown'
+	// identifier so the isReportValid dedup check below works idempotently;
+	// isReportValid rejects empty/invalid/partial reports, and --force
+	// overrides for explicit regeneration. /swarm finalize archives and
+	// cleans post-mortem-*.md at project end.
+	const effectivePlanId = planId;
 	const reportFilename = `post-mortem-${effectivePlanId}.md`;
 	let reportPath: string;
 	try {

--- a/src/hooks/curator-postmortem.ts
+++ b/src/hooks/curator-postmortem.ts
@@ -22,7 +22,13 @@ import type { CuratorLLMDelegate } from './curator.js';
 import { readKnowledgeEvents } from './knowledge-events.js';
 import { resolveKnowledgeStoreDir } from './knowledge-link.js';
 import { readKnowledge, resolveSwarmKnowledgePath } from './knowledge-store.js';
-import type { KnowledgeEntryBase } from './knowledge-types.js';
+import type { KnowledgeRecommendation } from './curator-types.js';
+import type {
+	KnowledgeConfig,
+	KnowledgeEntryBase,
+	KnowledgeCategory,
+	SwarmKnowledgeEntry,
+} from './knowledge-types.js';
 import { readSwarmFileAsync, validateSwarmPath } from './utils.js';
 
 const MAX_INPUT_TEXT_CHARS = 500;
@@ -42,11 +48,16 @@ export interface PostMortemResult {
 	reportPath: string | null;
 	summary: string | null;
 	warnings: string[];
+	actions?: PostMortemActionResult;
 }
 
 export interface PostMortemOptions {
 	llmDelegate?: CuratorLLMDelegate;
 	force?: boolean;
+	scope?: 'session' | 'project';
+	sessionID?: string;
+	knowledgeConfig?: KnowledgeConfig;
+	llmTimeoutMs?: number;
 }
 
 interface KnowledgeEventSummary {
@@ -59,21 +70,50 @@ interface KnowledgeEventSummary {
 	status: string;
 }
 
+interface ParsedPostMortemActions {
+	summary: string | null;
+	recommendations: KnowledgeRecommendation[];
+	queueTriage: Array<{
+		proposal_id: string;
+		action: 'apply' | 'reject';
+		reason: string;
+	}>;
+	diagnostics: string[];
+}
+
+export interface PostMortemActionResult {
+	knowledge_applied: number;
+	knowledge_skipped: number;
+	hive_promotions: number;
+	hive_encounters_incremented: number;
+	hive_advancements: number;
+	proposals_approved: number;
+	proposals_rejected: number;
+	proposals_skipped: number;
+}
+
 // ============================================================================
 // Data collection helpers
 // ============================================================================
 
 async function collectKnowledgeSummary(
 	directory: string,
+	scope: 'session' | 'project' = 'project',
+	sessionID?: string,
 ): Promise<KnowledgeEventSummary[]> {
 	const entries = await readKnowledge<KnowledgeEntryBase>(
 		resolveSwarmKnowledgePath(directory),
 		MAX_KNOWLEDGE_ENTRIES,
 	);
-	const events = await readKnowledgeEvents(
+	let events = await readKnowledgeEvents(
 		directory,
 		MAX_KNOWLEDGE_ENTRIES * 4,
 	);
+	if (scope === 'session' && sessionID) {
+		events = events.filter(
+			(e) => (e as { session_id?: string }).session_id === sessionID,
+		);
+	}
 
 	const countsMap = new Map<
 		string,
@@ -109,6 +149,322 @@ async function collectKnowledgeSummary(
 			status: entry.status ?? 'active',
 		};
 	});
+}
+
+function extractSection(text: string, sectionName: string): string | null {
+	const pattern = new RegExp(
+		`^${sectionName}:\\s*\\n([\\s\\S]*?)(?=\\n[A-Z_]+:\\s*(?:\\n|$)|$)`,
+		'm',
+	);
+	const match = text.match(pattern);
+	return match?.[1]?.trim() || null;
+}
+
+function normalizeRecommendationAction(
+	raw: unknown,
+): KnowledgeRecommendation['action'] | null {
+	const value = String(raw ?? '').toLowerCase().trim();
+	if (value === 'promote' || value === 'promote_to_hive') return 'promote';
+	if (value === 'archive' || value === 'flag_stale') return 'archive';
+	if (value === 'rewrite') return 'rewrite';
+	if (value === 'flag_contradiction') return 'flag_contradiction';
+	if (value === 'merge') return null;
+	return null;
+}
+
+function normalizeProposalSlug(raw: string): string {
+	return raw
+		.trim()
+		.replace(/^proposals[\\/]/, '')
+		.replace(/\.md$/i, '')
+		.replace(/\.json$/i, '');
+}
+
+function parseStructuredPostMortemActions(
+	llmOutput: string,
+): ParsedPostMortemActions {
+	const parsed: ParsedPostMortemActions = {
+		summary: extractSection(llmOutput, 'SUMMARY'),
+		recommendations: [],
+		queueTriage: [],
+		diagnostics: [],
+	};
+	const fence =
+		/```(?:json|jsonc)?\s+postmortem_actions\s*\n([\s\S]*?)\n```/g;
+	for (const match of llmOutput.matchAll(fence)) {
+		let data: unknown;
+		try {
+			data = JSON.parse(match[1]);
+		} catch (err) {
+			parsed.diagnostics.push(
+				`postmortem_actions malformed_json: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+			continue;
+		}
+		if (!data || typeof data !== 'object' || Array.isArray(data)) {
+			parsed.diagnostics.push('postmortem_actions expected object');
+			continue;
+		}
+		const obj = data as {
+			summary?: unknown;
+			curation_recommendations?: unknown;
+			queue_triage?: unknown;
+		};
+		if (typeof obj.summary === 'string' && obj.summary.trim()) {
+			parsed.summary = obj.summary.trim().slice(0, 1000);
+		}
+		if (Array.isArray(obj.curation_recommendations)) {
+			for (const [index, item] of obj.curation_recommendations.entries()) {
+				if (!item || typeof item !== 'object') {
+					parsed.diagnostics.push(
+						`curation_recommendations[${index}] invalid object`,
+					);
+					continue;
+				}
+				const rec = item as {
+					action?: unknown;
+					entry_id?: unknown;
+					lesson?: unknown;
+					reason?: unknown;
+					category?: unknown;
+					confidence?: unknown;
+				};
+				const action = normalizeRecommendationAction(rec.action);
+				const lesson = String(rec.lesson ?? rec.reason ?? '').trim();
+				const reason = String(rec.reason ?? lesson).trim();
+				if (!action || !reason) {
+					parsed.diagnostics.push(
+						`curation_recommendations[${index}] missing action/reason`,
+					);
+					continue;
+				}
+				if (action === 'rewrite' && lesson.length < 15) {
+					parsed.diagnostics.push(
+						`curation_recommendations[${index}] rewrite missing lesson`,
+					);
+					continue;
+				}
+				parsed.recommendations.push({
+					action,
+					entry_id:
+						typeof rec.entry_id === 'string' && rec.entry_id.trim()
+							? rec.entry_id.trim()
+							: undefined,
+					lesson: (lesson || reason).slice(0, 280),
+					reason: reason.slice(0, 280),
+					category:
+						typeof rec.category === 'string'
+							? (rec.category as KnowledgeCategory)
+							: undefined,
+					confidence:
+						typeof rec.confidence === 'number' ? rec.confidence : undefined,
+				});
+			}
+		}
+		if (Array.isArray(obj.queue_triage)) {
+			for (const [index, item] of obj.queue_triage.entries()) {
+				if (!item || typeof item !== 'object') {
+					parsed.diagnostics.push(`queue_triage[${index}] invalid object`);
+					continue;
+				}
+				const triage = item as {
+					proposal_id?: unknown;
+					action?: unknown;
+					reason?: unknown;
+				};
+				const proposalId = String(triage.proposal_id ?? '').trim();
+				const action = String(triage.action ?? '').toLowerCase().trim();
+				if (
+					!proposalId ||
+					(action !== 'apply' && action !== 'reject')
+				) {
+					parsed.diagnostics.push(
+						`queue_triage[${index}] missing proposal_id/action`,
+					);
+					continue;
+				}
+				parsed.queueTriage.push({
+					proposal_id: proposalId.slice(0, 120),
+					action,
+					reason: String(triage.reason ?? '').slice(0, 280),
+				});
+			}
+		}
+	}
+	return parsed;
+}
+
+function parseLegacyPostMortemActions(llmOutput: string): ParsedPostMortemActions {
+	const parsed: ParsedPostMortemActions = {
+		summary: extractSection(llmOutput, 'SUMMARY'),
+		recommendations: [],
+		queueTriage: [],
+		diagnostics: [],
+	};
+	const curation = extractSection(llmOutput, 'CURATION_RECOMMENDATIONS');
+	if (curation) {
+		for (const line of curation.split('\n')) {
+			const trimmed = line.trim();
+			if (!trimmed.startsWith('-')) continue;
+			const body = trimmed.replace(/^-\s*/, '');
+			const [head, reasonPart = ''] = body.split(/\s+—\s+|\s+-\s+/, 2);
+			const [rawAction, rest = ''] = head.split(/:\s*/, 2);
+			const action = normalizeRecommendationAction(rawAction);
+			if (!action) continue;
+			const idMatch = rest.match(
+				/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i,
+			);
+			const reason = (reasonPart || rest).trim();
+			if (!reason) continue;
+			parsed.recommendations.push({
+				action,
+				entry_id: idMatch?.[0],
+				lesson: reason.slice(0, 280),
+				reason: reason.slice(0, 280),
+			});
+		}
+	}
+	const queue = extractSection(llmOutput, 'QUEUE_TRIAGE');
+	if (queue) {
+		for (const line of queue.split('\n')) {
+			const match = line
+				.trim()
+				.match(/^-\s*([^:]+):\s*(APPLY|REJECT)\b\s*(?:—|-)?\s*(.*)$/i);
+			if (!match) continue;
+			parsed.queueTriage.push({
+				proposal_id: match[1].trim().slice(0, 120),
+				action: match[2].toLowerCase() as 'apply' | 'reject',
+				reason: match[3].trim().slice(0, 280),
+			});
+		}
+	}
+	return parsed;
+}
+
+function parsePostMortemActions(llmOutput: string): ParsedPostMortemActions {
+	const structured = parseStructuredPostMortemActions(llmOutput);
+	const legacy = parseLegacyPostMortemActions(llmOutput);
+	return {
+		summary: structured.summary ?? legacy.summary,
+		recommendations:
+			structured.recommendations.length > 0
+				? structured.recommendations
+				: legacy.recommendations,
+		queueTriage:
+			structured.queueTriage.length > 0
+				? structured.queueTriage
+				: legacy.queueTriage,
+		diagnostics: structured.diagnostics,
+	};
+}
+
+async function executePostMortemActions(
+	directory: string,
+	parsed: ParsedPostMortemActions,
+	options: PostMortemOptions,
+): Promise<{ result: PostMortemActionResult; warnings: string[] }> {
+	const warnings: string[] = [];
+	const result: PostMortemActionResult = {
+		knowledge_applied: 0,
+		knowledge_skipped: 0,
+		hive_promotions: 0,
+		hive_encounters_incremented: 0,
+		hive_advancements: 0,
+		proposals_approved: 0,
+		proposals_rejected: 0,
+		proposals_skipped: 0,
+	};
+	const knowledgeConfig =
+		options.knowledgeConfig ?? (await _internals.loadDefaultKnowledgeConfig());
+	if (parsed.recommendations.length > 0) {
+		try {
+			const knowledgeResult = await _internals.applyCuratorKnowledgeUpdates(
+				directory,
+				parsed.recommendations,
+				knowledgeConfig,
+			);
+			result.knowledge_applied = knowledgeResult.applied;
+			result.knowledge_skipped = knowledgeResult.skipped;
+		} catch (err) {
+			warnings.push(
+				`Post-mortem knowledge actions failed: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+		}
+		try {
+			const entries = await _internals.readSwarmKnowledge(directory);
+			const hiveResult = await _internals.checkHivePromotions(
+				entries,
+				knowledgeConfig,
+			);
+			result.hive_promotions = hiveResult.new_promotions;
+			result.hive_encounters_incremented = hiveResult.encounters_incremented;
+			result.hive_advancements = hiveResult.advancements;
+		} catch (err) {
+			warnings.push(
+				`Post-mortem hive promotion check failed: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+		}
+	}
+	if (parsed.queueTriage.length > 0) {
+		try {
+			const proposalResult = await _internals.applyProposalTriage(
+				directory,
+				parsed.queueTriage,
+			);
+			result.proposals_approved = proposalResult.approved.length;
+			result.proposals_rejected = proposalResult.rejected.length;
+			result.proposals_skipped = proposalResult.skipped.length;
+		} catch (err) {
+			warnings.push(
+				`Post-mortem proposal triage failed: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+		}
+	}
+	return { result, warnings };
+}
+
+async function repairPostMortemActions(
+	llmOutput: string,
+	diagnostics: string[],
+	options: PostMortemOptions,
+): Promise<ParsedPostMortemActions | null> {
+	if (!options.llmDelegate || diagnostics.length === 0) return null;
+	const ac = new AbortController();
+	const timer = setTimeout(() => ac.abort(), 30_000);
+	try {
+		const repairPrompt = [
+			'Repair the supplied CURATOR_POSTMORTEM output into one valid fenced JSON block.',
+			'Return only this fence:',
+			'```json postmortem_actions',
+			'{"summary":"...","curation_recommendations":[],"queue_triage":[]}',
+			'```',
+			'Allowed curation action values: promote, archive, rewrite, flag_contradiction.',
+			'Allowed queue_triage action values: apply, reject.',
+			'Do not include unsupported actions such as merge.',
+			'Diagnostics:',
+			diagnostics.join('; '),
+			'Original output:',
+			llmOutput.slice(0, 8000),
+		].join('\n');
+		const repaired = await options.llmDelegate('', repairPrompt, ac.signal);
+		const parsed = _internals.parsePostMortemActions(repaired);
+		if (parsed.diagnostics.length === 0) {
+			return parsed;
+		}
+		return null;
+	} catch {
+		return null;
+	} finally {
+		clearTimeout(timer);
+	}
 }
 
 function readJsonlFile(filePath: string, maxLines?: number): unknown[] {
@@ -156,25 +512,15 @@ function collectRetrospectives(directory: string): string[] {
 	return results;
 }
 
-function collectDriftReports(directory: string): string[] {
-	const results: string[] = [];
-	const swarmDir = path.join(directory, '.swarm');
+async function collectDriftReports(directory: string): Promise<string[]> {
 	try {
-		if (!existsSync(swarmDir)) return results;
-		const driftFiles = readdirSync(swarmDir)
-			.filter((e) => e.startsWith('drift-report-phase-') && e.endsWith('.json'))
-			.slice(0, MAX_DRIFT_REPORTS);
-		for (const entry of driftFiles) {
-			try {
-				results.push(readFileSync(path.join(swarmDir, entry), 'utf-8'));
-			} catch {
-				// skip
-			}
-		}
+		const reports = await _internals.readPriorDriftReports(directory);
+		return reports
+			.slice(-MAX_DRIFT_REPORTS)
+			.map((report) => JSON.stringify(report, null, 2));
 	} catch {
-		// fail-open
+		return [];
 	}
-	return results;
 }
 
 function collectPendingProposals(
@@ -380,6 +726,8 @@ function buildDataOnlyReport(
 
 function assembleLLMInput(
 	planId: string,
+	scope: 'session' | 'project',
+	sessionID: string | undefined,
 	planSummary: string,
 	knowledgeSummary: KnowledgeEventSummary[],
 	curatorDigest: string | null,
@@ -391,6 +739,7 @@ function assembleLLMInput(
 	const sections: string[] = [];
 
 	sections.push(`TASK: CURATOR_POSTMORTEM ${planId}`);
+	sections.push(`SCOPE: ${scope}${sessionID ? ` (${sessionID})` : ''}`);
 	sections.push(`PLAN_SUMMARY: ${planSummary}`);
 
 	sections.push(`CURATOR_DIGESTS: ${curatorDigest ?? 'none'}`);
@@ -452,6 +801,7 @@ export async function runCuratorPostMortem(
 	options: PostMortemOptions = {},
 ): Promise<PostMortemResult> {
 	const warnings: string[] = [];
+	const scope = options.scope ?? 'project';
 
 	// Load plan to derive the plan ID
 	let planId = 'unknown';
@@ -525,7 +875,11 @@ export async function runCuratorPostMortem(
 		// Collect evidence
 		let knowledgeSummary: KnowledgeEventSummary[] = [];
 		try {
-			knowledgeSummary = await collectKnowledgeSummary(directory);
+			knowledgeSummary = await collectKnowledgeSummary(
+				directory,
+				scope,
+				options.sessionID,
+			);
 		} catch {
 			warnings.push('Failed to collect knowledge summary.');
 		}
@@ -572,7 +926,7 @@ export async function runCuratorPostMortem(
 			);
 			retrospectives = retrospectives.slice(0, MAX_RETROSPECTIVES);
 		}
-		let driftReports = collectDriftReports(directory);
+		let driftReports = await collectDriftReports(directory);
 		if (driftReports.length > MAX_DRIFT_REPORTS) {
 			warnings.push(
 				`Drift reports capped at ${MAX_DRIFT_REPORTS} (had ${driftReports.length}); older entries truncated.`,
@@ -582,6 +936,8 @@ export async function runCuratorPostMortem(
 
 		// Generate report
 		let reportContent: string;
+		let llmSummary: string | null = null;
+		let actionResult: PostMortemActionResult | undefined;
 
 		if (options.llmDelegate) {
 			try {
@@ -590,6 +946,8 @@ export async function runCuratorPostMortem(
 				);
 				const userInput = assembleLLMInput(
 					effectivePlanId,
+					scope,
+					options.sessionID,
 					planSummary,
 					knowledgeSummary,
 					curatorDigest,
@@ -599,7 +957,10 @@ export async function runCuratorPostMortem(
 					driftReports,
 				);
 				const ac = new AbortController();
-				const timer = setTimeout(() => ac.abort(), 300_000);
+				const timer = setTimeout(
+					() => ac.abort(),
+					options.llmTimeoutMs ?? 300_000,
+				);
 				let llmOutput: string;
 				try {
 					// Hoist to attach no-op catch before race — prevents unhandled
@@ -621,7 +982,36 @@ export async function runCuratorPostMortem(
 				} finally {
 					clearTimeout(timer);
 				}
-				reportContent = `# Post-Mortem Report: ${effectivePlanId}\nGenerated: ${new Date().toISOString()}\n\n${llmOutput}`;
+				let parsedActions = _internals.parsePostMortemActions(llmOutput);
+				if (parsedActions.diagnostics.length > 0) {
+					warnings.push(
+						`Post-mortem structured action parse diagnostics: ${parsedActions.diagnostics.join('; ')}`,
+					);
+					const repaired = await _internals.repairPostMortemActions(
+						llmOutput,
+						parsedActions.diagnostics,
+						options,
+					);
+					if (repaired) {
+						parsedActions = repaired;
+						warnings.push('Post-mortem structured actions repaired by LLM.');
+					}
+				}
+				llmSummary = parsedActions.summary;
+				const executed = await _internals.executePostMortemActions(
+					directory,
+					parsedActions,
+					options,
+				);
+				actionResult = executed.result;
+				warnings.push(...executed.warnings);
+				const actionSummary = [
+					'## Executed Post-Mortem Actions',
+					`- Knowledge actions: ${actionResult.knowledge_applied} applied, ${actionResult.knowledge_skipped} skipped`,
+					`- Hive actions: ${actionResult.hive_promotions} new promotions, ${actionResult.hive_encounters_incremented} encounters incremented, ${actionResult.hive_advancements} advancements`,
+					`- Proposal actions: ${actionResult.proposals_approved} approved, ${actionResult.proposals_rejected} rejected, ${actionResult.proposals_skipped} skipped`,
+				].join('\n');
+				reportContent = `# Post-Mortem Report: ${effectivePlanId}\nGenerated: ${new Date().toISOString()}\nScope: ${scope}\n\n${llmOutput}\n\n${actionSummary}`;
 			} catch (err) {
 				const msg = err instanceof Error ? err.message : String(err);
 				warnings.push(
@@ -676,11 +1066,12 @@ export async function runCuratorPostMortem(
 			(s, e) => s + e.violated,
 			0,
 		);
-		const summary = [
+		const mechanicalSummary = [
 			`Post-mortem for plan "${effectivePlanId}": ${totalEntries} knowledge entries reviewed.`,
 			`${neverAppliedCount} never-applied entries flagged; ${totalViolations} total violations recorded.`,
 			`${proposals.length} pending proposals, ${unactionable.length} quarantined entries.`,
 		].join(' ');
+		const summary = llmSummary ?? mechanicalSummary;
 
 		return {
 			success: true,
@@ -688,6 +1079,7 @@ export async function runCuratorPostMortem(
 			reportPath,
 			summary,
 			warnings,
+			actions: actionResult,
 		};
 	} finally {
 		if (lock.release) {
@@ -714,4 +1106,85 @@ export const _internals = {
 	buildDataOnlyReport,
 	assembleLLMInput,
 	isReportValid,
+	parsePostMortemActions,
+	executePostMortemActions,
+	repairPostMortemActions,
+	loadDefaultKnowledgeConfig: async (): Promise<KnowledgeConfig> => {
+		const { KnowledgeConfigSchema } = await import('../config/schema.js');
+		return KnowledgeConfigSchema.parse({});
+	},
+	applyCuratorKnowledgeUpdates: async (
+		directory: string,
+		recommendations: KnowledgeRecommendation[],
+		knowledgeConfig: KnowledgeConfig,
+	) => {
+		const { applyCuratorKnowledgeUpdates } = await import('./curator.js');
+		return applyCuratorKnowledgeUpdates(
+			directory,
+			recommendations,
+			knowledgeConfig,
+		);
+	},
+	checkHivePromotions: async (
+		entries: SwarmKnowledgeEntry[],
+		knowledgeConfig: KnowledgeConfig,
+	) => {
+		const { checkHivePromotions } = await import('./hive-promoter.js');
+		return checkHivePromotions(entries, knowledgeConfig);
+	},
+	applyProposalTriage: async (
+		directory: string,
+		triage: ParsedPostMortemActions['queueTriage'],
+	) => {
+		const {
+			_internals: skillInternals,
+			activateProposal,
+			listSkills,
+			sanitizeSlug,
+		} = await import('../services/skill-generator.js');
+		const result = {
+			approved: [] as string[],
+			rejected: [] as string[],
+			skipped: [] as string[],
+		};
+		const skills = await listSkills(directory);
+		const proposalSlugs = new Set(skills.proposals.map((p) => p.slug));
+		for (const item of triage) {
+			const slug = sanitizeSlug(normalizeProposalSlug(item.proposal_id));
+			if (!slug || !proposalSlugs.has(slug)) {
+				result.skipped.push(slug || item.proposal_id);
+				continue;
+			}
+			if (item.action === 'apply') {
+				const activation = await activateProposal(directory, slug, false, {
+					evaluate: true,
+					operation: 'post_mortem_queue_triage',
+				});
+				if (activation.activated) {
+					result.approved.push(slug);
+				} else {
+					result.skipped.push(slug);
+				}
+				continue;
+			}
+			const proposal = skills.proposals.find((p) => p.slug === slug);
+			if (!proposal) {
+				result.skipped.push(slug);
+				continue;
+			}
+			try {
+				skillInternals.unlinkSync(proposal.path);
+				result.rejected.push(slug);
+			} catch {
+				result.skipped.push(slug);
+			}
+		}
+		return result;
+	},
+	readPriorDriftReports: async (directory: string) => {
+		const { readPriorDriftReports } = await import('./curator-drift.js');
+		return readPriorDriftReports(directory);
+	},
+	readSwarmKnowledge: (directory: string) =>
+		readKnowledge<SwarmKnowledgeEntry>(resolveSwarmKnowledgePath(directory)),
 };

--- a/src/hooks/curator.ts
+++ b/src/hooks/curator.ts
@@ -537,7 +537,9 @@ function readLatestPostMortemDigest(directory: string): string | null {
 		const latest = candidates[0];
 		if (!latest) return null;
 		const content = fs.readFileSync(latest.filePath, 'utf-8');
-		const summary = content.match(/SUMMARY:\s*\n([\s\S]*?)(?:\n[A-Z_]+:|\n##|$)/);
+		const summary = content.match(
+			/SUMMARY:\s*\n([\s\S]*?)(?:\n[A-Z_]+:|\n##|$)/,
+		);
 		const body = (summary?.[1]?.trim() || content.slice(0, 1500)).slice(
 			0,
 			1500,
@@ -910,9 +912,8 @@ export async function runCuratorInit(
 			briefingParts.push(contextMd.slice(0, maxContextChars));
 		}
 
-		const latestPostMortemDigest = _internals.readLatestPostMortemDigest(
-			directory,
-		);
+		const latestPostMortemDigest =
+			_internals.readLatestPostMortemDigest(directory);
 		if (latestPostMortemDigest) {
 			briefingParts.push('\n## Latest Post-Mortem');
 			briefingParts.push(latestPostMortemDigest);

--- a/src/hooks/curator.ts
+++ b/src/hooks/curator.ts
@@ -128,10 +128,12 @@ export const _internals = {
 	readKnowledge,
 	reviseSkill,
 	getSkillVersion,
+	readLatestPostMortemDigest: (directory: string) =>
+		readLatestPostMortemDigest(directory),
 };
 
 export interface RecommendationParseDiagnostic {
-	section: 'OBSERVATIONS' | 'KNOWLEDGE_UPDATES';
+	section: 'OBSERVATIONS';
 	line: string;
 	reason: string;
 }
@@ -316,56 +318,6 @@ export function parseKnowledgeRecommendationsWithDiagnostics(
 
 			recommendations.push({
 				action,
-				entry_id: entryId,
-				lesson: text,
-				reason: text,
-			});
-		}
-	}
-
-	// Parse KNOWLEDGE_UPDATES: section (direct format: "- <action> <id>: <text>")
-	const updatesSection = llmOutput.match(
-		/KNOWLEDGE_UPDATES:\s*\n([\s\S]*?)(?:\n\n|\n[A-Z_]+:|$)/,
-	);
-	if (updatesSection) {
-		const validActions = new Set([
-			'promote',
-			'archive',
-			'rewrite',
-			'flag_contradiction',
-		]);
-		const lines = updatesSection[1].split('\n');
-		for (const line of lines) {
-			const trimmed = line.trim();
-			if (!trimmed.startsWith('-')) continue;
-
-			// Match "- <action> <id>: <text>"
-			const match = trimmed.match(/^-\s+(\S+)\s+(\S+):\s+(.+)$/);
-			if (!match) {
-				diagnostics.push({
-					section: 'KNOWLEDGE_UPDATES',
-					line: trimmed,
-					reason: 'expected "- <action> <id>: <text>"',
-				});
-				continue;
-			}
-
-			const action = match[1].toLowerCase();
-			if (!validActions.has(action)) {
-				diagnostics.push({
-					section: 'KNOWLEDGE_UPDATES',
-					line: trimmed,
-					reason: `unknown action "${action}"`,
-				});
-				continue;
-			}
-
-			const id = match[2];
-			const text = match[3].trim();
-			const entryId = UUID_V4.test(id) ? id : undefined;
-
-			recommendations.push({
-				action: action as KnowledgeRecommendation['action'],
 				entry_id: entryId,
 				lesson: text,
 				reason: text,
@@ -568,6 +520,32 @@ function arrayOfStrings(v: unknown): string[] {
 		.filter((x) => typeof x === 'string')
 		.map((x) => (x as string).slice(0, 200))
 		.slice(0, 20);
+}
+
+function readLatestPostMortemDigest(directory: string): string | null {
+	try {
+		const swarmDir = path.join(directory, '.swarm');
+		if (!fs.existsSync(swarmDir)) return null;
+		const candidates = fs
+			.readdirSync(swarmDir)
+			.filter((name) => /^post-mortem-[^/\\]+\.md$/.test(name))
+			.map((name) => {
+				const filePath = path.join(swarmDir, name);
+				return { name, filePath, mtimeMs: fs.statSync(filePath).mtimeMs };
+			})
+			.sort((a, b) => b.mtimeMs - a.mtimeMs);
+		const latest = candidates[0];
+		if (!latest) return null;
+		const content = fs.readFileSync(latest.filePath, 'utf-8');
+		const summary = content.match(/SUMMARY:\s*\n([\s\S]*?)(?:\n[A-Z_]+:|\n##|$)/);
+		const body = (summary?.[1]?.trim() || content.slice(0, 1500)).slice(
+			0,
+			1500,
+		);
+		return `${latest.name}\n${body}`;
+	} catch {
+		return null;
+	}
 }
 
 function clampConf(v: unknown): number {
@@ -932,6 +910,14 @@ export async function runCuratorInit(
 			briefingParts.push(contextMd.slice(0, maxContextChars));
 		}
 
+		const latestPostMortemDigest = _internals.readLatestPostMortemDigest(
+			directory,
+		);
+		if (latestPostMortemDigest) {
+			briefingParts.push('\n## Latest Post-Mortem');
+			briefingParts.push(latestPostMortemDigest);
+		}
+
 		// 5. Find contradictions in knowledge entries (entries with 'contradiction' in tags)
 		const contradictions = allEntries
 			.filter(
@@ -968,6 +954,7 @@ export async function runCuratorInit(
 					`PRIOR_SUMMARY: ${priorSummary ? JSON.stringify(priorSummary) : 'none'}`,
 					`KNOWLEDGE_ENTRIES: ${JSON.stringify(allEntriesForCurator)}`,
 					`PROJECT_CONTEXT: ${contextMd?.slice(0, config.max_summary_tokens * 2) ?? 'none'}`,
+					`POST_MORTEM_DIGEST: ${latestPostMortemDigest ?? 'none'}`,
 				].join('\n');
 
 				const systemPrompt = CURATOR_INIT_PROMPT;

--- a/src/hooks/curator.ts
+++ b/src/hooks/curator.ts
@@ -1666,6 +1666,24 @@ export async function applyCuratorKnowledgeUpdates(
 					if (newLesson.length < 15 || newLesson.length > 280) {
 						return entry;
 					}
+					// F-001: validate rewritten lesson text through the same
+					// content-safety gates as the new-entry path
+					// (INJECTION_PATTERNS, dangerous-command patterns,
+					// security-degrading patterns). Pass [] for existingLessons
+					// to skip dedup — cross-entry dedup is the new-entry path's job.
+					if (knowledgeConfig.validation_enabled !== false) {
+						const validation = validateLesson(newLesson, [], {
+							category: entry.category,
+							scope: entry.scope,
+							confidence: entry.confidence ?? 0.5,
+						});
+						if (!validation.valid) {
+							logger.warn(
+								`[curator] rewrite for entry '${entry.id}' rejected by content validation`,
+							);
+							return entry;
+						}
+					}
 					appliedIds.add(entry.id);
 					txApplied++;
 					modified = true;
@@ -1702,8 +1720,11 @@ export async function applyCuratorKnowledgeUpdates(
 	// Only 'promote' actions are meaningful without an existing entry_id —
 	// 'archive' and 'flag_contradiction' require a real entry to operate on.
 	// These are appended after the transaction to avoid nested locking.
-	// Re-read lessons from the file for dedup purposes.
-	// This is a separate unlocked read; the append below is independently locked.
+
+	// Unlocked read for post-transaction dedup and validation.
+	// The append below is independently locked, so a race with a concurrent
+	// appendKnowledge is possible but benign (worst case: a duplicate lesson
+	// appears and is cleaned up on the next curator pass).
 	const currentEntries =
 		await readKnowledge<SwarmKnowledgeEntry>(knowledgePath);
 	const currentLessons: string[] = currentEntries.map((e) => e.lesson);

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -1049,6 +1049,26 @@ export async function executePhaseComplete(
 				curatorResult.knowledge_recommendations,
 				knowledgeConfig,
 			);
+			try {
+				const { runDeterministicDriftCheck } = await import(
+					'../hooks/curator-drift'
+				);
+				await runDeterministicDriftCheck(
+					dir,
+					phase,
+					curatorResult,
+					curatorConfig,
+					(message) => {
+						const sessionState = swarmState.agentSessions.get(sessionID);
+						if (sessionState) {
+							sessionState.pendingAdvisoryMessages ??= [];
+							sessionState.pendingAdvisoryMessages.push(message);
+						}
+					},
+				);
+			} catch {
+				// Non-blocking: drift reports are advisory and must not gate phase completion.
+			}
 			// Advisory injection: push actionable curator message to architect session
 			const callerSessionState = swarmState.agentSessions.get(sessionID);
 			if (callerSessionState) {
@@ -1844,6 +1864,8 @@ export async function executePhaseComplete(
 					);
 					const pmResult = await runCuratorPostMortem(dir, {
 						llmDelegate: createCuratorLLMDelegate(dir, 'postmortem', sessionID),
+						scope: 'project',
+						sessionID,
 					});
 					if (pmResult.success && pmResult.summary) {
 						warnings.push(`[POST-MORTEM] ${pmResult.summary}`);

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -1051,7 +1051,7 @@ export async function executePhaseComplete(
 			);
 			try {
 				const { runDeterministicDriftCheck } = await import(
-					'../hooks/curator-drift'
+					'../hooks/curator-drift.js'
 				);
 				await runDeterministicDriftCheck(
 					dir,
@@ -1096,7 +1096,7 @@ export async function executePhaseComplete(
 				// Check for drift advisories from prior deterministic drift checks
 				try {
 					const { readPriorDriftReports } = await import(
-						'../hooks/curator-drift'
+						'../hooks/curator-drift.js'
 					);
 					const priorReports = await readPriorDriftReports(dir);
 					const phaseReport = priorReports
@@ -1139,7 +1139,7 @@ export async function executePhaseComplete(
 		if (config.design_docs?.enabled === true) {
 			const outDir = config.design_docs.out_dir ?? 'docs';
 			const { runDesignDocDriftCheck } = await import(
-				'../hooks/design-doc-drift'
+				'../hooks/design-doc-drift.js'
 			);
 			const docReport = await runDesignDocDriftCheck(dir, phase, outDir);
 			if (docReport?.verdict === 'DOC_STALE') {

--- a/tests/integration/curator-llm-delegation.test.ts
+++ b/tests/integration/curator-llm-delegation.test.ts
@@ -38,7 +38,7 @@ describe('curator LLM delegation', () => {
 		const delegate: CuratorLLMDelegate = vi
 			.fn()
 			.mockResolvedValue(
-				'KNOWLEDGE_UPDATES:\n- promote entry_1: good lesson\n',
+				'OBSERVATIONS:\n- new candidate: good lesson with enough durable detail\n',
 			);
 		const result = await runCuratorPhase(
 			'/tmp/test',
@@ -85,7 +85,7 @@ describe('curator LLM delegation', () => {
 
 	test('parseKnowledgeRecommendations parses promote actions', () => {
 		const output =
-			'KNOWLEDGE_UPDATES:\n- promote entry_1: good lesson\n- archive entry_2: outdated\n';
+			'OBSERVATIONS:\n- new candidate: good lesson with enough durable detail\n- entry 550e8400-e29b-41d4-a716-446655440000 appears stale: outdated\n';
 		const recs = parseKnowledgeRecommendations(output);
 		expect(recs).toHaveLength(2);
 		expect(recs[0].action).toBe('promote');

--- a/tests/unit/commands/post-mortem.test.ts
+++ b/tests/unit/commands/post-mortem.test.ts
@@ -113,6 +113,43 @@ describe('handlePostMortemCommand (FR-002)', () => {
 
 			expect(capturedForce).toBe(false);
 		});
+
+		it('passes session scope and session ID to runCuratorPostMortem', async () => {
+			let capturedScope: string | undefined;
+			let capturedSessionID: string | undefined;
+			pmInternals.runCuratorPostMortem = mock(
+				async (
+					_dir: string,
+					options: { scope?: string; sessionID?: string },
+				) => {
+					capturedScope = options.scope;
+					capturedSessionID = options.sessionID;
+					return {
+						success: true,
+						planId: 'test',
+						reportPath: null,
+						summary: null,
+						warnings: [],
+					};
+				},
+			);
+
+			await handlePostMortemCommand(testDir, ['--scope', 'session'], {
+				sessionID: 'session-1684',
+			});
+
+			expect(capturedScope).toBe('session');
+			expect(capturedSessionID).toBe('session-1684');
+		});
+
+		it('rejects invalid scope values before running post-mortem', async () => {
+			const result = await handlePostMortemCommand(testDir, [
+				'--scope=workspace',
+			]);
+
+			expect(result).toContain('Invalid --scope value');
+			expect(pmInternals.runCuratorPostMortem).not.toHaveBeenCalled();
+		});
 	});
 
 	// ── Test 2: LLM delegate creation failure → data-only fallback ────

--- a/tests/unit/hooks/curator-coverage.test.ts
+++ b/tests/unit/hooks/curator-coverage.test.ts
@@ -712,8 +712,8 @@ describe('runCuratorInit uncovered paths', () => {
 // ---------------------------------------------------------------------------
 
 describe('parseKnowledgeRecommendations additional coverage', () => {
-	it('returns empty array when KNOWLEDGE_UPDATES section is empty', () => {
-		const output = `KNOWLEDGE_UPDATES:
+	it('returns empty array when OBSERVATIONS section is empty', () => {
+		const output = `OBSERVATIONS:
 -
 
 NEXT_SECTION:
@@ -722,8 +722,8 @@ something`;
 		expect(recs).toEqual([]);
 	});
 
-	it('returns empty array when KNOWLEDGE_UPDATES section has only whitespace', () => {
-		const output = `KNOWLEDGE_UPDATES:
+	it('returns empty array when OBSERVATIONS section has only whitespace', () => {
+		const output = `OBSERVATIONS:
    
 NEXT_SECTION:
 `;
@@ -732,10 +732,8 @@ NEXT_SECTION:
 	});
 
 	it('parses flag_contradiction action correctly with valid UUID', () => {
-		// entry-123 is NOT a valid UUID, so it gets treated as undefined (hallucination safe)
-		// Use a real UUID for this test
-		const output = `KNOWLEDGE_UPDATES:
-- flag_contradiction 550e8400-e29b-41d4-a716-446655440000: Reason for contradiction
+		const output = `OBSERVATIONS:
+- entry 550e8400-e29b-41d4-a716-446655440000 (contradicts project state): Reason for contradiction
 `;
 		const recs = parseKnowledgeRecommendations(output);
 		expect(recs).toHaveLength(1);
@@ -746,8 +744,8 @@ NEXT_SECTION:
 
 	it('flag_contradiction with non-UUID entry_id is treated as new (undefined)', () => {
 		// This is the anti-hallucination behavior: non-UUID slugs become undefined
-		const output = `KNOWLEDGE_UPDATES:
-- flag_contradiction entry-123: Reason for contradiction
+		const output = `OBSERVATIONS:
+- entry entry-123 (contradicts project state): Reason for contradiction
 `;
 		const recs = parseKnowledgeRecommendations(output);
 		expect(recs).toHaveLength(1);
@@ -758,8 +756,8 @@ NEXT_SECTION:
 
 	it('non-UUID entry_id is treated as undefined (hallucination safe)', () => {
 		// This is the key anti-hallucination behavior
-		const output = `KNOWLEDGE_UPDATES:
-- promote tool-name-normalization: Lesson text here
+		const output = `OBSERVATIONS:
+- entry tool-name-normalization (new candidate): Lesson text here
 `;
 		const recs = parseKnowledgeRecommendations(output);
 		expect(recs).toHaveLength(1);

--- a/tests/unit/hooks/curator-drift-verifier-gate.test.ts
+++ b/tests/unit/hooks/curator-drift-verifier-gate.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	readPriorDriftReports,
+	runDeterministicDriftCheck,
+	writeDriftReport,
+} from '../../../src/hooks/curator-drift.js';
+import type {
+	CuratorConfig,
+	CuratorPhaseResult,
+} from '../../../src/hooks/curator-types.js';
+
+/**
+ * Minimal CuratorConfig for testing — covers fields actually read by runDeterministicDriftCheck.
+ */
+function makeCuratorConfig(overrides?: Partial<CuratorConfig>): CuratorConfig {
+	return {
+		enabled: true,
+		init_enabled: true,
+		phase_enabled: true,
+		max_summary_tokens: 2000,
+		min_knowledge_confidence: 0.7,
+		compliance_report: true,
+		suppress_warnings: true,
+		drift_inject_max_chars: 500,
+		...overrides,
+	};
+}
+
+/**
+ * Minimal CuratorPhaseResult stub — only fields actually read by runDeterministicDriftCheck.
+ */
+function makeCuratorResult(phase: number): CuratorPhaseResult {
+	return {
+		phase,
+		digest: {
+			phase,
+			timestamp: new Date().toISOString(),
+			summary: 'Test phase digest',
+			agents_used: [],
+			tasks_completed: 0,
+			tasks_total: 0,
+			key_decisions: [],
+			blockers_resolved: [],
+		},
+		compliance: [],
+		knowledge_recommendations: [],
+		summary_updated: false,
+	};
+}
+
+describe('runDeterministicDriftCheck — gate invariants', () => {
+	let tempDir: string;
+	let originalCwd: string;
+
+	beforeEach(() => {
+		tempDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'curator-drift-gate-test-')),
+		);
+		originalCwd = process.cwd();
+		process.chdir(tempDir);
+
+		// Create .swarm directory
+		fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+
+		// Write a minimal plan.md so the function has a plan to read
+		fs.writeFileSync(
+			path.join(tempDir, 'plan.md'),
+			'# Test Plan\n\n## Phase 1\n\n- [ ] Task 1.1\n',
+		);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			// Ignore cleanup errors
+		}
+	});
+
+	test('runDeterministicDriftCheck does NOT create drift-verifier.json at the flat .swarm path', async () => {
+		const curatorResult = makeCuratorResult(1);
+		const config = makeCuratorConfig();
+
+		await runDeterministicDriftCheck(tempDir, 1, curatorResult, config);
+
+		const flatGatePath = path.join(tempDir, '.swarm', 'drift-verifier.json');
+		expect(fs.existsSync(flatGatePath)).toBe(false);
+	});
+
+	test('advisory drift report is written under .swarm/', async () => {
+		const curatorResult = makeCuratorResult(1);
+		const config = makeCuratorConfig();
+
+		const result = await runDeterministicDriftCheck(
+			tempDir,
+			1,
+			curatorResult,
+			config,
+		);
+
+		// The function must return a valid report path
+		expect(result.report_path).toBeTruthy();
+		expect(result.report_path.length).toBeGreaterThan(0);
+
+		// The advisory drift report must exist at that path
+		expect(fs.existsSync(result.report_path)).toBe(true);
+
+		// It must be valid JSON with a DriftReport shape
+		const content = fs.readFileSync(result.report_path, 'utf-8');
+		expect(() => JSON.parse(content)).not.toThrow();
+
+		const report = JSON.parse(content);
+		expect(report).toHaveProperty('schema_version');
+		expect(report).toHaveProperty('phase');
+		expect(report.phase).toBe(1);
+		expect(report).toHaveProperty('alignment');
+		expect(report).toHaveProperty('drift_score');
+		expect(report).toHaveProperty('timestamp');
+	});
+
+	test('injectAdvisory callback receives messages when drift is detected', async () => {
+		// With no plan.md: alignment=MINOR_DRIFT, driftScore=0.3 → callback fires
+		fs.rmSync(path.join(tempDir, 'plan.md'), { force: true });
+		fs.writeFileSync(path.join(tempDir, 'plan.md'), '# Test Plan\n');
+
+		const curatorResult: CuratorPhaseResult = {
+			...makeCuratorResult(1),
+			compliance: [{ severity: 'warning', description: 'Test warning' }],
+		};
+		const config = makeCuratorConfig();
+		const receivedMessages: string[] = [];
+
+		await runDeterministicDriftCheck(
+			tempDir,
+			1,
+			curatorResult,
+			config,
+			(msg) => {
+				receivedMessages.push(msg);
+			},
+		);
+
+		expect(receivedMessages.length).toBeGreaterThan(0);
+		expect(typeof receivedMessages[0]).toBe('string');
+		expect(receivedMessages[0].length).toBeGreaterThan(0);
+	});
+
+	test('readPriorDriftReports returns empty array when no prior reports exist', async () => {
+		const reports = await readPriorDriftReports(tempDir);
+		expect(Array.isArray(reports)).toBe(true);
+		expect(reports.length).toBe(0);
+	});
+
+	test('writeDriftReport writes a correctly named file under .swarm/', async () => {
+		const report = {
+			schema_version: 1 as const,
+			phase: 99,
+			timestamp: new Date().toISOString(),
+			alignment: 'ALIGNED' as const,
+			drift_score: 0,
+			first_deviation: null,
+			compounding_effects: [],
+			corrections: [],
+			requirements_checked: 0,
+			requirements_satisfied: 0,
+			scope_additions: [],
+			injection_summary: 'Phase 99: ALIGNED',
+		};
+
+		const filePath = await writeDriftReport(tempDir, report);
+
+		expect(filePath).toContain('drift-report-phase-99.json');
+		expect(fs.existsSync(filePath)).toBe(true);
+
+		const content = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+		expect(content.phase).toBe(99);
+		expect(content.alignment).toBe('ALIGNED');
+	});
+});

--- a/tests/unit/hooks/curator-issues-1411-1414.test.ts
+++ b/tests/unit/hooks/curator-issues-1411-1414.test.ts
@@ -97,18 +97,12 @@ describe('curator issue regressions', () => {
 				'OBSERVATIONS:',
 				`- entry ${knownId} (could be tighter): Keep this valid recommendation`,
 				'- malformed observation',
-				'',
-				'KNOWLEDGE_UPDATES:',
-				'- unknown-action new: bad action',
 			].join('\n'),
 		);
 
 		expect(parsed.recommendations).toHaveLength(1);
-		expect(parsed.diagnostics).toHaveLength(2);
-		expect(parsed.diagnostics.map((d) => d.section)).toEqual([
-			'OBSERVATIONS',
-			'KNOWLEDGE_UPDATES',
-		]);
+		expect(parsed.diagnostics).toHaveLength(1);
+		expect(parsed.diagnostics[0].section).toBe('OBSERVATIONS');
 	});
 
 	test('accumulates recommendations and filters unknown entry ids', async () => {

--- a/tests/unit/hooks/curator-postmortem-actions.test.ts
+++ b/tests/unit/hooks/curator-postmortem-actions.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 

--- a/tests/unit/hooks/curator-postmortem-actions.test.ts
+++ b/tests/unit/hooks/curator-postmortem-actions.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+	_internals,
+	runCuratorPostMortem,
+} from '../../../src/hooks/curator-postmortem.js';
+
+const ENTRY_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+function makeTempDir(): string {
+	return mkdtempSync(join(tmpdir(), 'postmortem-actions-'));
+}
+
+function writePlan(dir: string): void {
+	const swarmDir = join(dir, '.swarm');
+	mkdirSync(swarmDir, { recursive: true });
+	writeFileSync(
+		join(swarmDir, 'plan.json'),
+		JSON.stringify({
+			schema_version: '1.0.0',
+			title: 'Issue 1684',
+			swarm: 'test',
+			phases: [{ id: 1, name: 'Fix', status: 'complete', tasks: [] }],
+		}),
+	);
+}
+
+function writeKnowledge(dir: string): void {
+	const swarmDir = join(dir, '.swarm');
+	mkdirSync(swarmDir, { recursive: true });
+	writeFileSync(
+		join(swarmDir, 'knowledge.jsonl'),
+		`${JSON.stringify({
+			id: ENTRY_ID,
+			tier: 'swarm',
+			lesson: 'Always verify postmortem curation actions after LLM synthesis.',
+			category: 'process',
+			status: 'active',
+			confidence: 0.7,
+			tags: [],
+			scope: 'global',
+			confirmed_by: [],
+			project_name: 'test',
+			created_at: '2026-07-03T00:00:00.000Z',
+			updated_at: '2026-07-03T00:00:00.000Z',
+		})}\n`,
+	);
+}
+
+function readKnowledgeEntry(dir: string): Record<string, unknown> {
+	return JSON.parse(
+		readFileSync(join(dir, '.swarm', 'knowledge.jsonl'), 'utf-8').trim(),
+	);
+}
+
+describe('curator post-mortem executable actions', () => {
+	let dir: string;
+	const originalCheckHivePromotions = _internals.checkHivePromotions;
+	const originalApplyProposalTriage = _internals.applyProposalTriage;
+
+	beforeEach(() => {
+		dir = makeTempDir();
+		writePlan(dir);
+		writeKnowledge(dir);
+	});
+
+	afterEach(() => {
+		_internals.checkHivePromotions = originalCheckHivePromotions;
+		_internals.applyProposalTriage = originalApplyProposalTriage;
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	test('executes parsed LLM actions and returns the LLM summary', async () => {
+		let proposalIds: string[] = [];
+		_internals.checkHivePromotions = async () => ({
+			new_promotions: 1,
+			encounters_incremented: 2,
+			advancements: 0,
+			total_hive_entries: 1,
+			timestamp: '2026-07-03T00:00:00.000Z',
+		});
+		_internals.applyProposalTriage = async (_directory, triage) => {
+			proposalIds = triage.map((item) => item.proposal_id);
+			return { approved: ['useful-skill'], rejected: [], skipped: [] };
+		};
+
+		const result = await runCuratorPostMortem(dir, {
+			force: true,
+			llmDelegate: async () =>
+				[
+					'POST_MORTEM_REPORT:',
+					'SUMMARY:',
+					'LLM synthesis: curator found one actionable promotion.',
+					'',
+					'```json postmortem_actions',
+					JSON.stringify({
+						summary: 'LLM synthesis: curator found one actionable promotion.',
+						curation_recommendations: [
+							{
+								action: 'promote',
+								entry_id: ENTRY_ID,
+								lesson:
+									'Always verify postmortem curation actions after LLM synthesis.',
+								reason: 'Confirmed by final postmortem evidence.',
+								category: 'process',
+								confidence: 0.9,
+							},
+						],
+						queue_triage: [
+							{
+								proposal_id: 'proposals/useful-skill.md',
+								action: 'apply',
+								reason: 'General reusable workflow.',
+							},
+						],
+					}),
+					'```',
+				].join('\n'),
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.summary).toBe(
+			'LLM synthesis: curator found one actionable promotion.',
+		);
+		expect(result.actions?.knowledge_applied).toBe(1);
+		expect(result.actions?.hive_promotions).toBe(1);
+		expect(result.actions?.proposals_approved).toBe(1);
+		expect(proposalIds).toEqual(['proposals/useful-skill.md']);
+		expect(readKnowledgeEntry(dir).hive_eligible).toBe(true);
+	});
+});

--- a/tests/unit/hooks/curator-postmortem-actions.test.ts
+++ b/tests/unit/hooks/curator-postmortem-actions.test.ts
@@ -137,4 +137,182 @@ describe('curator post-mortem executable actions', () => {
 		expect(proposalIds).toEqual(['proposals/useful-skill.md']);
 		expect(readKnowledgeEntry(dir).hive_eligible).toBe(true);
 	});
+
+	test('malformed postmortem_actions JSON pushes diagnostics and triggers repair when llmDelegate present', async () => {
+		let callCount = 0;
+		_internals.checkHivePromotions = async () => ({
+			new_promotions: 1,
+			encounters_incremented: 0,
+			advancements: 0,
+			total_hive_entries: 1,
+			timestamp: '2026-07-03T00:00:00.000Z',
+		});
+
+		const result = await runCuratorPostMortem(dir, {
+			force: true,
+			llmDelegate: async (_system: string, prompt: string) => {
+				callCount++;
+				if (callCount === 1) {
+					// First call — return malformed JSON inside the fence
+					return [
+						'POST_MORTEM_REPORT:',
+						'```json postmortem_actions',
+						'{bad json here -- missing closing brace',
+						'```',
+					].join('\n');
+				}
+				// Second call — repair prompt should contain the repair marker
+				if (prompt.includes('Repair the supplied CURATOR_POSTMORTEM')) {
+					return [
+						'```json postmortem_actions',
+						JSON.stringify({
+							summary: 'Repaired summary after parse failure.',
+							curation_recommendations: [
+								{
+									action: 'promote',
+									entry_id: ENTRY_ID,
+									lesson:
+										'Always verify postmortem curation actions after LLM synthesis.',
+									reason: 'Confirmed by repair pass.',
+									category: 'process',
+									confidence: 0.9,
+								},
+							],
+							queue_triage: [],
+						}),
+						'```',
+					].join('\n');
+				}
+				return '```json postmortem_actions\n{}\n```';
+			},
+		});
+
+		expect(result.success).toBe(true);
+		expect(
+			result.warnings.some(
+				(w) =>
+					w.includes('structured action parse diagnostics') &&
+					w.includes('malformed_json'),
+			),
+		).toBe(true);
+		expect(result.warnings.some((w) => w.includes('repaired'))).toBe(true);
+		// The repaired recommendation should have been executed
+		expect(
+			(result.actions?.knowledge_applied ?? 0) +
+				(result.actions?.hive_promotions ?? 0),
+		).toBeGreaterThan(0);
+	});
+
+	test('empty curation_recommendations with valid summary extracts the summary without executing actions', async () => {
+		const result = await runCuratorPostMortem(dir, {
+			force: true,
+			llmDelegate: async () =>
+				[
+					'```json postmortem_actions',
+					JSON.stringify({
+						summary: 'Summary from structured output with no recommendations.',
+						curation_recommendations: [],
+						queue_triage: [],
+					}),
+					'```',
+				].join('\n'),
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.summary).toBe(
+			'Summary from structured output with no recommendations.',
+		);
+		// No recommendations → executePostMortemActions not called or is no-op
+		// actions may be undefined or all-zero
+		const applied = result.actions?.knowledge_applied ?? 0;
+		const hive = result.actions?.hive_promotions ?? 0;
+		const proposals =
+			(result.actions?.proposals_approved ?? 0) +
+			(result.actions?.proposals_rejected ?? 0);
+		expect(applied + hive + proposals).toBe(0);
+		// No knowledge write occurred (hive_eligible should still be absent/undefined)
+		const entry = readKnowledgeEntry(dir);
+		expect(entry.hive_eligible).toBeUndefined();
+	});
+
+	test('legacy CURATION_RECOMMENDATIONS / QUEUE_TRIAGE fallback when no structured fence present', async () => {
+		let capturedTriage: Parameters<typeof _internals.applyProposalTriage>[1] =
+			[];
+		_internals.checkHivePromotions = async () => ({
+			new_promotions: 1,
+			encounters_incremented: 0,
+			advancements: 0,
+			total_hive_entries: 1,
+			timestamp: '2026-07-03T00:00:00.000Z',
+		});
+		_internals.applyProposalTriage = async (_dir: string, triage) => {
+			capturedTriage = triage;
+			return { approved: ['useful-skill'], rejected: [], skipped: [] };
+		};
+
+		const result = await runCuratorPostMortem(dir, {
+			force: true,
+			llmDelegate: async () =>
+				[
+					'SUMMARY:',
+					'Legacy fallback summary text.',
+					'',
+					'CURATION_RECOMMENDATIONS:',
+					`- promote: ${ENTRY_ID} - confirmed across phases`,
+					'',
+					'QUEUE_TRIAGE:',
+					'- useful-skill: APPLY - reusable',
+				].join('\n'),
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.summary).toContain('Legacy fallback summary text');
+		// promote recommendation was parsed and executed
+		expect(result.actions?.knowledge_applied ?? 0).toBeGreaterThanOrEqual(1);
+		// queue triage was passed to applyProposalTriage
+		expect(
+			capturedTriage.some(
+				(t) => t.proposal_id === 'useful-skill' && t.action === 'apply',
+			),
+		).toBe(true);
+	});
+
+	test('unsupported merge action in legacy CURATION_RECOMMENDATIONS emits a diagnostic and is dropped', async () => {
+		_internals.checkHivePromotions = async () => ({
+			new_promotions: 0,
+			encounters_incremented: 0,
+			advancements: 0,
+			total_hive_entries: 0,
+			timestamp: '2026-07-03T00:00:00.000Z',
+		});
+		_internals.applyProposalTriage = async () => ({
+			approved: [],
+			rejected: [],
+			skipped: [],
+		});
+
+		const result = await runCuratorPostMortem(dir, {
+			force: true,
+			llmDelegate: async () =>
+				[
+					'SUMMARY:',
+					'Post-mortem with unsupported merge action.',
+					'',
+					'CURATION_RECOMMENDATIONS:',
+					`- merge: ${ENTRY_ID} + 660e8400-e29b-41d4-a716-446655440001 - combine these`,
+				].join('\n'),
+		});
+
+		expect(result.success).toBe(true);
+		expect(
+			result.warnings.some(
+				(w) =>
+					w.includes('structured action parse diagnostics') &&
+					w.includes("'merge'") &&
+					w.includes('unsupported'),
+			),
+		).toBe(true);
+		// merge action should NOT have been executed (knowledge_applied stays 0)
+		expect(result.actions?.knowledge_applied ?? 0).toBe(0);
+	});
 });

--- a/tests/unit/hooks/curator-postmortem-digest.test.ts
+++ b/tests/unit/hooks/curator-postmortem-digest.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { _internals } from '../../../src/hooks/curator.js';
+
+function makeTempDir(): string {
+	return mkdtempSync(join(tmpdir(), 'postmortem-digest-'));
+}
+
+describe('readLatestPostMortemDigest', () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = makeTempDir();
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	test('returns null when .swarm does not exist', () => {
+		// dir has no .swarm directory
+		const result = _internals.readLatestPostMortemDigest(dir);
+		expect(result).toBeNull();
+	});
+
+	test('returns null when no post-mortem-*.md files exist', () => {
+		mkdirSync(join(dir, '.swarm'), { recursive: true });
+		// Write some other files but no post-mortem-*.md
+		writeFileSync(join(dir, '.swarm', 'plan.json'), '{}');
+		const result = _internals.readLatestPostMortemDigest(dir);
+		expect(result).toBeNull();
+	});
+
+	test('selects the latest by mtime', () => {
+		const swarmDir = mkdirSync(join(dir, '.swarm'), { recursive: true });
+
+		// Write two post-mortem files — second one gets older mtime
+		const olderPath = join(swarmDir, 'post-mortem-old-plan.md');
+		const newerPath = join(swarmDir, 'post-mortem-new-plan.md');
+		writeFileSync(
+			olderPath,
+			'# Post-Mortem: Old Plan\nSUMMARY:\nOlder file content.\n',
+		);
+		writeFileSync(
+			newerPath,
+			'# Post-Mortem: New Plan\nSUMMARY:\nNewer file content.\n',
+		);
+
+		// Make newer file actually newer by touching both with different times
+		// older: 2026-01-01, newer: 2026-07-03
+		utimesSync(
+			olderPath,
+			new Date('2026-01-01T00:00:00Z'),
+			new Date('2026-01-01T00:00:00Z'),
+		);
+		utimesSync(
+			newerPath,
+			new Date('2026-07-03T00:00:00Z'),
+			new Date('2026-07-03T00:00:00Z'),
+		);
+
+		const result = _internals.readLatestPostMortemDigest(dir);
+		expect(result).not.toBeNull();
+		expect(result!.startsWith('post-mortem-new-plan.md')).toBe(true);
+		expect(result).toContain('Newer file content.');
+	});
+
+	test('extracts SUMMARY section', () => {
+		const swarmDir = mkdirSync(join(dir, '.swarm'), { recursive: true });
+		const filePath = join(swarmDir, 'post-mortem-test-plan.md');
+		writeFileSync(
+			filePath,
+			[
+				'# Post-Mortem Report: test-plan',
+				'',
+				'SUMMARY:',
+				'This is the digest.',
+				'',
+				'OTHER_SECTION:',
+				'stuff that should not appear',
+			].join('\n'),
+		);
+
+		const result = _internals.readLatestPostMortemDigest(dir);
+		expect(result).not.toBeNull();
+		expect(result).toContain('This is the digest.');
+		expect(result).not.toContain('stuff that should not appear');
+		expect(result).toContain('post-mortem-test-plan.md');
+	});
+
+	test('falls back to first 1500 chars when no SUMMARY section', () => {
+		const swarmDir = mkdirSync(join(dir, '.swarm'), { recursive: true });
+		const filePath = join(swarmDir, 'post-mortem-nosummary.md');
+		const content =
+			'# Post-Mortem: No Summary\n\nSome narrative text without a SUMMARY marker.\n';
+		writeFileSync(filePath, content);
+
+		const result = _internals.readLatestPostMortemDigest(dir);
+		expect(result).not.toBeNull();
+		expect(result).toContain('Some narrative text without a SUMMARY marker.');
+	});
+
+	test('truncates to 1500 chars', () => {
+		const swarmDir = mkdirSync(join(dir, '.swarm'), { recursive: true });
+		const filePath = join(swarmDir, 'post-mortem-long.md');
+		// Build a SUMMARY body > 1500 chars with a sentinel placed beyond the 1500-char mark.
+		// The regex /SUMMARY:\s*\n([\s\S]*?)(?:\n[A-Z_]+:|\n##|$)/ captures everything
+		// between "SUMMARY:\n" and the next \n[A-Z_]+: or \n## or $. A single long line
+		// with no terminator before $ means the full longBody is captured, then slice(0,1500)
+		// cuts it off — removing the sentinel.
+		const longBody = 'A'.repeat(1600) + 'SENTINEL_AFTER_1500';
+		const content = `# Post-Mortem Report: Long Plan\n\nSUMMARY:\n${longBody}\n`;
+		writeFileSync(filePath, content);
+
+		const result = _internals.readLatestPostMortemDigest(dir);
+		expect(result).not.toBeNull();
+		// The body portion (after the filename\n) must be <= 1500 chars — the slice(0,1500) cap
+		const body = result!.split('\n').slice(1).join('\n');
+		expect(body.length).toBeLessThanOrEqual(1500);
+		// The sentinel must NOT be present — truncation cut it off
+		expect(result).not.toContain('SENTINEL_AFTER_1500');
+	});
+});

--- a/tests/unit/hooks/curator-postmortem.test.ts
+++ b/tests/unit/hooks/curator-postmortem.test.ts
@@ -215,67 +215,63 @@ describe('runCuratorPostMortem', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// Regression: FR-004 / SC-007 — stale post-mortem-unknown.md must not block
-	// future regeneration. When plan.json is absent, effectivePlanId gets a
-	// timestamp suffix so every run uses a fresh filename.
+	// Regression: FR-004 / SC-007 — stale post-mortem-unknown.md handling.
+	// F-010: effectivePlanId is stable 'unknown'; idempotent dedup relies on
+	// isReportValid (rejects empty/invalid/partial reports) + --force for
+	// explicit regeneration. A stale VALID report correctly triggers the
+	// idempotent skip; stale INVALID junk is auto-regenerated.
 	// -------------------------------------------------------------------------
 
-	test('stale post-mortem-unknown.md does NOT block regeneration (FR-004 SC-007)', async () => {
+	test('stale INVALID post-mortem-unknown.md does not block regeneration', async () => {
 		// Arrange: .swarm dir exists but plan.json does NOT.
 		ensureSwarmDir(dir);
 
-		// Simulate a stale report from a prior run (pre-fix this would be
-		// post-mortem-unknown.md and would permanently block regeneration).
+		// Simulate stale INVALID junk (wrong header) — isReportValid must reject it.
 		const staleReportPath = join(dir, '.swarm', 'post-mortem-unknown.md');
-		writeFileSync(
-			staleReportPath,
-			`# Post-Mortem Report: unknown\nGenerated: ${new Date().toISOString()}\n\nStale content from prior run.`,
-		);
+		writeFileSync(staleReportPath, 'corrupt partial content - no valid header');
 
 		// Act: run without force.
 		const result = await runCuratorPostMortem(dir);
 
-		// Assert: it regenerates (does NOT skip as idempotent).
+		// Assert: it regenerates because isReportValid rejected the stale junk.
 		expect(result.success).toBe(true);
 		expect(result.summary!).not.toContain('already exists');
-		// A new report was written at a timestamped path (not the stale unknown.md).
-		expect(result.reportPath!).not.toBe(staleReportPath);
+		expect(result.reportPath).toBe(staleReportPath); // same stable path, overwritten
 		expect(existsSync(result.reportPath!)).toBe(true);
 		const content = readFileSync(result.reportPath!, 'utf-8');
 		expect(content).toContain('Post-Mortem Report');
-		// The stale file is untouched.
-		expect(readFileSync(staleReportPath, 'utf-8')).toContain('Stale content');
+		expect(content).not.toContain('corrupt partial content');
 	});
 
-	test('effectivePlanId includes timestamp when plan.json is absent', async () => {
+	test('effectivePlanId is stable unknown when plan.json is absent (idempotent dedup)', async () => {
 		ensureSwarmDir(dir);
 
 		const result = await runCuratorPostMortem(dir);
 
 		expect(result.success).toBe(true);
-		// effectivePlanId must carry a timestamp so subquent runs never reuse it.
-		expect(result.planId!).toMatch(/^unknown-\d+$/);
-		// Report filename also reflects the timestamped effectivePlanId.
-		expect(result.reportPath!).toContain(
-			`post-mortem-unknown-${result.planId!.split('-')[1]}`,
-		);
+		// F-010: effectivePlanId is stable 'unknown' (no timestamp) so the
+		// isReportValid dedup check works idempotently across runs.
+		expect(result.planId).toBe('unknown');
+		expect(result.reportPath!).toContain('post-mortem-unknown.md');
 	});
 
-	test('force:true regenerates even when stale post-mortem-unknown.md exists', async () => {
+	test('force:true regenerates even when a valid stale post-mortem-unknown.md exists', async () => {
 		ensureSwarmDir(dir);
 
-		// Pre-create stale report.
+		// Pre-create a VALID stale report (correct header) that would normally idempotent-skip.
 		const staleReportPath = join(dir, '.swarm', 'post-mortem-unknown.md');
-		writeFileSync(
-			staleReportPath,
-			`# Post-Mortem Report: unknown\nGenerated: ${new Date().toISOString()}\n\nStale content.`,
-		);
+		const staleContent = `# Post-Mortem Report: unknown\nGenerated: 2000-01-01T00:00:00.000Z\n\nStale content from prior run.`;
+		writeFileSync(staleReportPath, staleContent);
 
 		const result = await runCuratorPostMortem(dir, { force: true });
 
 		expect(result.success).toBe(true);
 		expect(result.summary!).not.toContain('already exists');
-		expect(result.reportPath!).not.toBe(staleReportPath);
+		// Same path (force overwrites in place), but content is regenerated.
+		expect(result.reportPath).toBe(staleReportPath);
+		const newContent = readFileSync(result.reportPath!, 'utf-8');
+		expect(newContent).not.toBe(staleContent);
+		expect(newContent).toContain('Post-Mortem Report');
 	});
 
 	test('falls back to data-only when LLM delegate fails', async () => {
@@ -306,9 +302,8 @@ describe('runCuratorPostMortem', () => {
 		const result = await runCuratorPostMortem(dir);
 
 		expect(result.success).toBe(true);
-		// planId is 'unknown' but effectivePlanId includes a timestamp suffix so
-		// every run generates a fresh report (no stale-unknown.md poisoning).
-		expect(result.planId).toMatch(/^unknown-\d+$/);
+		// F-010: effectivePlanId is stable 'unknown' for idempotent dedup.
+		expect(result.planId).toBe('unknown');
 		expect(result.warnings).toContainEqual(
 			expect.stringContaining('Plan not found'),
 		);

--- a/tests/unit/hooks/curator-postmortem.test.ts
+++ b/tests/unit/hooks/curator-postmortem.test.ts
@@ -372,9 +372,18 @@ describe('runCuratorPostMortem', () => {
 		writeFileSync(
 			join(swarmDir, 'drift-report-phase-1.json'),
 			JSON.stringify({
+				schema_version: 1,
 				phase: 1,
+				timestamp: new Date().toISOString(),
 				alignment: 'ALIGNED',
 				drift_score: 0.0,
+				first_deviation: null,
+				compounding_effects: [],
+				corrections: [],
+				requirements_checked: 0,
+				requirements_satisfied: 0,
+				scope_additions: [],
+				injection_summary: '',
 			}),
 		);
 

--- a/tests/unit/hooks/curator.test.ts
+++ b/tests/unit/hooks/curator.test.ts
@@ -966,7 +966,18 @@ invalid json here
 					last_updated: '2026-01-01T00:00:00Z',
 					last_phase_covered: 1,
 					digest: 'Phase 1 initial digest',
-					phase_digests: [],
+					phase_digests: [
+						{
+							phase: 1,
+							timestamp: '2026-01-01T00:00:00Z',
+							summary: 'Phase 1 initial digest',
+							agents_used: ['reviewer'],
+							tasks_completed: 1,
+							tasks_total: 1,
+							key_decisions: [],
+							blockers_resolved: [],
+						},
+					],
 					compliance_observations: [],
 					knowledge_recommendations: [],
 				}),
@@ -984,8 +995,9 @@ invalid json here
 			const content = JSON.parse(fs.readFileSync(summaryPath, 'utf-8'));
 
 			expect(content.last_phase_covered).toBe(2);
-			expect(content.phase_digests).toHaveLength(1);
-			expect(content.phase_digests[0].phase).toBe(2);
+			expect(content.phase_digests).toHaveLength(2);
+			expect(content.phase_digests[0].phase).toBe(1);
+			expect(content.phase_digests[1].phase).toBe(2);
 			expect(content.digest).toContain('Phase 1 initial digest');
 		});
 
@@ -3219,7 +3231,7 @@ describe('runCuratorPhase passes KNOWLEDGE_ENTRIES to LLM', () => {
 		let capturedUserInput = '';
 		const mockLlmDelegate = async (_system: string, user: string) => {
 			capturedUserInput = user;
-			return 'PHASE_DIGEST:\nphase: 1\nsummary: done\n\nKNOWLEDGE_UPDATES:\n- promote new: Good lesson\n\nEXTENDED_DIGEST:\nDone';
+			return 'PHASE_DIGEST:\nphase: 1\nsummary: done\n\nOBSERVATIONS:\n- entry new (new candidate): Good lesson with enough detail\n\nEXTENDED_DIGEST:\nDone';
 		};
 
 		// Create temp dir with knowledge entries

--- a/tests/unit/tools/_phase-complete-test-helpers.ts
+++ b/tests/unit/tools/_phase-complete-test-helpers.ts
@@ -1,0 +1,181 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Helper function to write a valid retro bundle for a phase
+ */
+export function writeRetroBundle(
+	directory: string,
+	phaseNumber: number,
+	verdict: 'pass' | 'fail' = 'pass',
+): void {
+	const retroDir = path.join(
+		directory,
+		'.swarm',
+		'evidence',
+		`retro-${phaseNumber}`,
+	);
+	fs.mkdirSync(retroDir, { recursive: true });
+
+	const retroBundle = {
+		schema_version: '1.0.0',
+		task_id: `retro-${phaseNumber}`,
+		entries: [
+			{
+				task_id: `retro-${phaseNumber}`,
+				type: 'retrospective',
+				timestamp: new Date().toISOString(),
+				agent: 'architect',
+				verdict: verdict,
+				summary: 'Phase retrospective',
+				metadata: {},
+				phase_number: phaseNumber,
+				total_tool_calls: 10,
+				coder_revisions: 1,
+				reviewer_rejections: 0,
+				test_failures: 0,
+				security_findings: 0,
+				integration_issues: 0,
+				task_count: 5,
+				task_complexity: 'moderate',
+				top_rejection_reasons: [],
+				lessons_learned: ['Lesson 1'],
+			},
+		],
+		created_at: new Date().toISOString(),
+		updated_at: new Date().toISOString(),
+	};
+
+	fs.writeFileSync(
+		path.join(retroDir, 'evidence.json'),
+		JSON.stringify(retroBundle, null, 2),
+	);
+}
+
+/**
+ * Helper function to write gate evidence files for Phase 4 mandatory gates
+ */
+export function writeGateEvidence(directory: string, phase: number): void {
+	const evidenceDir = path.join(directory, '.swarm', 'evidence', `${phase}`);
+	fs.mkdirSync(evidenceDir, { recursive: true });
+
+	// Write completion-verify.json
+	const completionVerify = {
+		status: 'passed',
+		tasksChecked: 1,
+		tasksPassed: 1,
+		tasksBlocked: 0,
+		reason: 'All task identifiers found in source files',
+	};
+	fs.writeFileSync(
+		path.join(evidenceDir, 'completion-verify.json'),
+		JSON.stringify(completionVerify, null, 2),
+	);
+
+	// Write drift-verifier.json
+	const driftVerifier = {
+		schema_version: '1.0.0',
+		task_id: 'drift-verifier',
+		entries: [
+			{
+				task_id: 'drift-verifier',
+				type: 'drift_verification',
+				timestamp: new Date().toISOString(),
+				agent: 'critic',
+				verdict: 'approved',
+				summary: 'Drift check passed',
+			},
+		],
+	};
+	fs.writeFileSync(
+		path.join(evidenceDir, 'drift-verifier.json'),
+		JSON.stringify(driftVerifier, null, 2),
+	);
+}
+
+/**
+ * Helper: write completion-verify.json evidence
+ */
+export function writeCompletionVerify(directory: string, phase: number): void {
+	const evidenceDir = path.join(directory, '.swarm', 'evidence', `${phase}`);
+	fs.mkdirSync(evidenceDir, { recursive: true });
+
+	const completionVerify = {
+		status: 'passed',
+		tasksChecked: 1,
+		tasksPassed: 1,
+		tasksBlocked: 0,
+		reason: 'All task identifiers found in source files',
+	};
+	fs.writeFileSync(
+		path.join(evidenceDir, 'completion-verify.json'),
+		JSON.stringify(completionVerify, null, 2),
+	);
+}
+
+/**
+ * Helper: write drift-verifier.json evidence (the enforcement gate file)
+ */
+export function writeDriftVerifier(
+	directory: string,
+	phase: number,
+	verdict: 'approved' | 'rejected',
+	summary?: string,
+): void {
+	const evidenceDir = path.join(directory, '.swarm', 'evidence', `${phase}`);
+	fs.mkdirSync(evidenceDir, { recursive: true });
+
+	const driftVerifier = {
+		schema_version: '1.0.0',
+		task_id: 'drift-verifier',
+		entries: [
+			{
+				task_id: 'drift-verifier',
+				type: 'drift_verification',
+				timestamp: new Date().toISOString(),
+				agent: 'critic',
+				verdict: verdict,
+				summary:
+					summary ??
+					(verdict === 'approved'
+						? 'Drift check passed'
+						: 'NEEDS_REVISION: Drift detected'),
+			},
+		],
+	};
+	fs.writeFileSync(
+		path.join(evidenceDir, 'drift-verifier.json'),
+		JSON.stringify(driftVerifier, null, 2),
+	);
+}
+
+/**
+ * Create config with optional curator settings
+ */
+export function createConfig(curatorConfig?: {
+	enabled?: boolean;
+	phase_enabled?: boolean;
+}): string {
+	const config: Record<string, unknown> = {
+		phase_complete: {
+			enabled: true,
+			required_agents: [],
+			require_docs: false,
+			policy: 'enforce',
+		},
+		// Always write explicit curator config to override any user-level config that may
+		// have curator.enabled=true (user config deep-merges with project config).
+		curator: {
+			enabled: curatorConfig?.enabled ?? false,
+			phase_enabled: curatorConfig?.phase_enabled ?? true,
+			init_enabled: true,
+			max_summary_tokens: 2000,
+			min_knowledge_confidence: 0.7,
+			compliance_report: true,
+			suppress_warnings: true,
+			drift_inject_max_chars: 500,
+		},
+	};
+
+	return JSON.stringify(config);
+}

--- a/tests/unit/tools/phase-complete-curator-compliance.test.ts
+++ b/tests/unit/tools/phase-complete-curator-compliance.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as realCurator from '../../../src/hooks/curator';
+import * as realCuratorDrift from '../../../src/hooks/curator-drift';
+import * as realKnowledgeCurator from '../../../src/hooks/knowledge-curator.js';
+import {
+	ensureAgentSession,
+	recordPhaseAgentDispatch,
+	resetSwarmState,
+} from '../../../src/state';
+import {
+	createConfig,
+	writeGateEvidence,
+	writeRetroBundle,
+} from './_phase-complete-test-helpers';
+
+// Mock curator functions BEFORE importing the module under test
+const mockRunCuratorPhase = mock(async () => ({
+	phase: 1,
+	agents_dispatched: ['coder', 'reviewer', 'test_engineer'],
+	compliance: [],
+	knowledge_recommendations: [],
+	summary: 'Test curator phase result',
+	timestamp: new Date().toISOString(),
+}));
+
+const mockApplyCuratorKnowledgeUpdates = mock(async () => ({
+	applied: 0,
+	skipped: 0,
+}));
+
+const mockRunDeterministicDriftCheck = mock(async () => ({
+	phase: 1,
+	report: {
+		schema_version: 1 as const,
+		phase: 1,
+		timestamp: new Date().toISOString(),
+		alignment: 'ALIGNED' as const,
+		drift_score: 0,
+		first_deviation: null,
+		compounding_effects: [],
+		corrections: [],
+		requirements_checked: 0,
+		requirements_satisfied: 0,
+		scope_additions: [],
+		injection_summary: '',
+	},
+	report_path: '',
+	injection_text: '',
+}));
+
+// Mock the curator modules — spread real exports, override only the mocked functions
+mock.module('../../../src/hooks/curator', () => ({
+	...realCurator,
+	runCuratorPhase: mockRunCuratorPhase,
+	applyCuratorKnowledgeUpdates: mockApplyCuratorKnowledgeUpdates,
+}));
+
+mock.module('../../../src/hooks/curator-drift', () => ({
+	...realCuratorDrift,
+	runDeterministicDriftCheck: mockRunDeterministicDriftCheck,
+	readPriorDriftReports: mock(async () => []),
+}));
+
+// Also mock the knowledge-curator module to avoid interference from curateAndStoreSwarm
+mock.module('../../../src/hooks/knowledge-curator.js', () => ({
+	...realKnowledgeCurator,
+	curateAndStoreSwarm: mock(async () => {}),
+}));
+
+// Import the tool after setting up mocks
+const { phase_complete } = await import('../../../src/tools/phase-complete');
+
+/**
+ * Task 5.3: Curator wiring fix - compliance warnings surfacing
+ *
+ * Phase 4.2 fix: phase_complete surfaces compliance warnings when suppress_warnings is false.
+ *
+ * Tests:
+ * - phase_complete surfaces compliance warnings when suppress_warnings: false
+ * - phase_complete does NOT surface compliance warnings when suppress_warnings: true
+ */
+describe('Task 5.3: curator compliance warnings surfacing', () => {
+	let tempDir: string;
+	let originalCwd: string;
+
+	beforeEach(() => {
+		resetSwarmState();
+		mockRunCuratorPhase.mockClear();
+		mockApplyCuratorKnowledgeUpdates.mockClear();
+		mockRunDeterministicDriftCheck.mockClear();
+
+		tempDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'phase-complete-compliance-test-')),
+		);
+		originalCwd = process.cwd();
+		process.chdir(tempDir);
+
+		fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+		fs.mkdirSync(path.join(tempDir, '.swarm', 'evidence'), { recursive: true });
+
+		writeRetroBundle(tempDir, 1, 'pass');
+		writeGateEvidence(tempDir, 1);
+		writeRetroBundle(tempDir, 2, 'pass');
+		writeGateEvidence(tempDir, 2);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			// Ignore
+		}
+		resetSwarmState();
+		// Restore cross-module mocks per two-tier DI convention
+		mock.restore();
+	});
+
+	describe('compliance warnings are surfaced when suppress_warnings: false', () => {
+		test('phase_complete surfaces compliance warnings in result when curator returns compliance observations', async () => {
+			// Set up config with curator enabled and suppress_warnings: false
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			// Create custom config with suppress_warnings: false
+			const customConfig = {
+				phase_complete: {
+					enabled: true,
+					required_agents: [],
+					require_docs: false,
+					policy: 'enforce',
+				},
+				curator: {
+					enabled: true,
+					phase_enabled: true,
+					init_enabled: true,
+					max_summary_tokens: 2000,
+					min_knowledge_confidence: 0.7,
+					compliance_report: true,
+					suppress_warnings: false, // Key setting for this test
+					drift_inject_max_chars: 500,
+				},
+			};
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify(customConfig),
+			);
+
+			// Set up runCuratorPhase to return compliance observations
+			mockRunCuratorPhase.mockResolvedValueOnce({
+				phase: 1,
+				agents_dispatched: ['coder'],
+				compliance: [
+					{ severity: 'warning', description: 'Reviewer skipped for task 1.1' },
+					{
+						severity: 'error',
+						description: 'No retrospective written for phase 1',
+					},
+				],
+				knowledge_recommendations: [],
+				summary: 'Test phase result',
+				timestamp: new Date().toISOString(),
+			});
+
+			ensureAgentSession('sess1');
+			recordPhaseAgentDispatch('sess1', 'coder');
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'sess1',
+			});
+			const parsed = JSON.parse(result);
+
+			expect(parsed.success).toBe(true);
+			expect(parsed.warnings).toBeDefined();
+
+			// Compliance warnings should be surfaced
+			const complianceWarning = parsed.warnings.find((w: string) =>
+				w.includes('Curator compliance'),
+			);
+			expect(complianceWarning).toBeDefined();
+			expect(complianceWarning).toContain('Reviewer skipped');
+			expect(complianceWarning).toContain('No retrospective');
+		});
+
+		test('compliance warnings are capped at 5 observations', async () => {
+			// Set up config with curator enabled and suppress_warnings: false
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			// Create custom config with suppress_warnings: false
+			const customConfig = {
+				phase_complete: {
+					enabled: true,
+					required_agents: [],
+					require_docs: false,
+					policy: 'enforce',
+				},
+				curator: {
+					enabled: true,
+					phase_enabled: true,
+					init_enabled: true,
+					max_summary_tokens: 2000,
+					min_knowledge_confidence: 0.7,
+					compliance_report: true,
+					suppress_warnings: false, // Key setting for this test
+					drift_inject_max_chars: 500,
+				},
+			};
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify(customConfig),
+			);
+
+			// Set up runCuratorPhase to return more than 5 compliance observations
+			const manyObservations = Array.from({ length: 10 }, (_, i) => ({
+				severity: 'warning' as const,
+				description: `Compliance observation ${i + 1}`,
+			}));
+
+			mockRunCuratorPhase.mockResolvedValueOnce({
+				phase: 1,
+				agents_dispatched: ['coder'],
+				compliance: manyObservations,
+				knowledge_recommendations: [],
+				summary: 'Test phase result',
+				timestamp: new Date().toISOString(),
+			});
+
+			ensureAgentSession('sess1');
+			recordPhaseAgentDispatch('sess1', 'coder');
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'sess1',
+			});
+			const parsed = JSON.parse(result);
+
+			expect(parsed.success).toBe(true);
+
+			// Find the curator compliance warning
+			const complianceWarning = parsed.warnings.find((w: string) =>
+				w.includes('Curator compliance'),
+			);
+			expect(complianceWarning).toBeDefined();
+
+			// Should contain only 5 observations (capped)
+			const warningText = complianceWarning as string;
+			// Each observation appears as [WARNING] or [ERROR] description
+			const warningCount = (warningText.match(/\[WARNING\]/g) || []).length;
+			const errorCount = (warningText.match(/\[ERROR\]/g) || []).length;
+			expect(warningCount + errorCount).toBeLessThanOrEqual(5);
+		});
+	});
+
+	describe('compliance warnings are NOT surfaced when suppress_warnings: true', () => {
+		test('phase_complete does NOT surface compliance warnings when suppress_warnings: true', async () => {
+			// Set up config with curator enabled and suppress_warnings: true (default)
+			// createConfig already sets suppress_warnings: true by default
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				createConfig({ enabled: true, phase_enabled: true }),
+			);
+
+			// Set up runCuratorPhase to return compliance observations
+			mockRunCuratorPhase.mockResolvedValueOnce({
+				phase: 1,
+				agents_dispatched: ['coder'],
+				compliance: [
+					{ severity: 'warning', description: 'Reviewer skipped for task 1.1' },
+				],
+				knowledge_recommendations: [],
+				summary: 'Test phase result',
+				timestamp: new Date().toISOString(),
+			});
+
+			ensureAgentSession('sess1');
+			recordPhaseAgentDispatch('sess1', 'coder');
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'sess1',
+			});
+			const parsed = JSON.parse(result);
+
+			expect(parsed.success).toBe(true);
+			expect(parsed.warnings).toBeDefined();
+
+			// Compliance warnings should NOT be surfaced
+			const complianceWarning = parsed.warnings.find((w: string) =>
+				w.includes('Curator compliance'),
+			);
+			expect(complianceWarning).toBeUndefined();
+		});
+
+		test('phase_complete does NOT surface compliance warnings when curator returns empty compliance array', async () => {
+			// Set up config with curator enabled
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				createConfig({ enabled: true, phase_enabled: true }),
+			);
+
+			// Set up runCuratorPhase to return empty compliance array
+			mockRunCuratorPhase.mockResolvedValueOnce({
+				phase: 1,
+				agents_dispatched: ['coder'],
+				compliance: [],
+				knowledge_recommendations: [],
+				summary: 'Test phase result',
+				timestamp: new Date().toISOString(),
+			});
+
+			ensureAgentSession('sess1');
+			recordPhaseAgentDispatch('sess1', 'coder');
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'sess1',
+			});
+			const parsed = JSON.parse(result);
+
+			expect(parsed.success).toBe(true);
+			expect(parsed.warnings).toBeDefined();
+
+			// Compliance warnings should NOT be surfaced (empty array)
+			const complianceWarning = parsed.warnings.find((w: string) =>
+				w.includes('Curator compliance'),
+			);
+			expect(complianceWarning).toBeUndefined();
+		});
+	});
+});

--- a/tests/unit/tools/phase-complete-curator-errors.test.ts
+++ b/tests/unit/tools/phase-complete-curator-errors.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as realCurator from '../../../src/hooks/curator';
+import * as realCuratorDrift from '../../../src/hooks/curator-drift';
+import * as realKnowledgeCurator from '../../../src/hooks/knowledge-curator.js';
+import {
+	ensureAgentSession,
+	recordPhaseAgentDispatch,
+	resetSwarmState,
+} from '../../../src/state';
+import {
+	createConfig,
+	writeGateEvidence,
+	writeRetroBundle,
+} from './_phase-complete-test-helpers';
+
+// Mock curator functions BEFORE importing the module under test
+const mockRunCuratorPhase = mock(async () => ({
+	phase: 1,
+	agents_dispatched: ['coder', 'reviewer', 'test_engineer'],
+	compliance: [],
+	knowledge_recommendations: [],
+	summary: 'Test curator phase result',
+	timestamp: new Date().toISOString(),
+}));
+
+const mockApplyCuratorKnowledgeUpdates = mock(async () => ({
+	applied: 0,
+	skipped: 0,
+}));
+
+const mockRunDeterministicDriftCheck = mock(async () => ({
+	phase: 1,
+	report: {
+		schema_version: 1 as const,
+		phase: 1,
+		timestamp: new Date().toISOString(),
+		alignment: 'ALIGNED' as const,
+		drift_score: 0,
+		first_deviation: null,
+		compounding_effects: [],
+		corrections: [],
+		requirements_checked: 0,
+		requirements_satisfied: 0,
+		scope_additions: [],
+		injection_summary: '',
+	},
+	report_path: '',
+	injection_text: '',
+}));
+
+// Mock the curator modules — spread real exports, override only the mocked functions
+mock.module('../../../src/hooks/curator', () => ({
+	...realCurator,
+	runCuratorPhase: mockRunCuratorPhase,
+	applyCuratorKnowledgeUpdates: mockApplyCuratorKnowledgeUpdates,
+}));
+
+mock.module('../../../src/hooks/curator-drift', () => ({
+	...realCuratorDrift,
+	runDeterministicDriftCheck: mockRunDeterministicDriftCheck,
+	readPriorDriftReports: mock(async () => []),
+}));
+
+// Also mock the knowledge-curator module to avoid interference from curateAndStoreSwarm
+mock.module('../../../src/hooks/knowledge-curator.js', () => ({
+	...realKnowledgeCurator,
+	curateAndStoreSwarm: mock(async () => {}),
+}));
+
+// Import the tool after setting up mocks
+const { phase_complete } = await import('../../../src/tools/phase-complete');
+
+describe('curator error does not block phase_complete', () => {
+	let tempDir: string;
+	let originalCwd: string;
+
+	beforeEach(() => {
+		resetSwarmState();
+		mockRunCuratorPhase.mockClear();
+		mockApplyCuratorKnowledgeUpdates.mockClear();
+		mockRunDeterministicDriftCheck.mockClear();
+
+		tempDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'phase-complete-curator-test-')),
+		);
+		originalCwd = process.cwd();
+		process.chdir(tempDir);
+
+		fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+		fs.mkdirSync(path.join(tempDir, '.swarm', 'evidence'), { recursive: true });
+		fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+
+		writeRetroBundle(tempDir, 1, 'pass');
+		writeGateEvidence(tempDir, 1);
+		writeRetroBundle(tempDir, 2, 'pass');
+		writeGateEvidence(tempDir, 2);
+
+		fs.writeFileSync(
+			path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+			createConfig({ enabled: true, phase_enabled: true }),
+		);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			// Ignore cleanup errors
+		}
+		resetSwarmState();
+		mock.restore();
+	});
+
+	test('phase_complete returns success even when runCuratorPhase throws', async () => {
+		// Make runCuratorPhase throw an error
+		mockRunCuratorPhase.mockRejectedValueOnce(
+			new Error('Curator phase failed'),
+		);
+
+		ensureAgentSession('sess1');
+		recordPhaseAgentDispatch('sess1', 'coder');
+
+		const result = await phase_complete.execute({
+			phase: 1,
+			sessionID: 'sess1',
+		});
+		const parsed = JSON.parse(result);
+
+		// Phase complete should STILL succeed (not blocked by curator error)
+		expect(parsed.success).toBe(true);
+		expect(parsed.status).toBe('success');
+	});
+
+	test('phase_complete returns success even when applyCuratorKnowledgeUpdates throws', async () => {
+		// Make applyCuratorKnowledgeUpdates throw an error
+		mockApplyCuratorKnowledgeUpdates.mockRejectedValueOnce(
+			new Error('Knowledge update failed'),
+		);
+
+		ensureAgentSession('sess1');
+		recordPhaseAgentDispatch('sess1', 'coder');
+
+		const result = await phase_complete.execute({
+			phase: 1,
+			sessionID: 'sess1',
+		});
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.status).toBe('success');
+	});
+
+	test('phase_complete returns success even when runDeterministicDriftCheck throws', async () => {
+		// Make runDeterministicDriftCheck throw an error
+		mockRunDeterministicDriftCheck.mockRejectedValueOnce(
+			new Error('Drift check failed'),
+		);
+
+		ensureAgentSession('sess1');
+		recordPhaseAgentDispatch('sess1', 'coder');
+
+		const result = await phase_complete.execute({
+			phase: 1,
+			sessionID: 'sess1',
+		});
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.status).toBe('success');
+	});
+
+	test('result is valid JSON with success:true when curator errors occur', async () => {
+		// Make all curator functions throw
+		mockRunCuratorPhase.mockRejectedValueOnce(new Error('Curator error 1'));
+		mockApplyCuratorKnowledgeUpdates.mockRejectedValueOnce(
+			new Error('Curator error 2'),
+		);
+		mockRunDeterministicDriftCheck.mockRejectedValueOnce(
+			new Error('Curator error 3'),
+		);
+
+		ensureAgentSession('sess1');
+
+		const result = await phase_complete.execute({
+			phase: 1,
+			sessionID: 'sess1',
+		});
+
+		// Should be valid JSON
+		expect(() => JSON.parse(result)).not.toThrow();
+
+		const parsed = JSON.parse(result);
+
+		// Should have expected structure
+		expect(parsed).toHaveProperty('success');
+		expect(parsed).toHaveProperty('phase');
+		expect(parsed).toHaveProperty('message');
+		expect(parsed).toHaveProperty('agentsDispatched');
+		expect(parsed).toHaveProperty('agentsMissing');
+		expect(parsed).toHaveProperty('status');
+		expect(parsed).toHaveProperty('warnings');
+
+		// Should indicate success
+		expect(parsed.success).toBe(true);
+	});
+});

--- a/tests/unit/tools/phase-complete-curator.test.ts
+++ b/tests/unit/tools/phase-complete-curator.test.ts
@@ -345,8 +345,12 @@ describe('phase_complete - curator pipeline', () => {
 			// applyCuratorKnowledgeUpdates should be called after runCuratorPhase
 			expect(mockApplyCuratorKnowledgeUpdates).toHaveBeenCalled();
 
-			// runDeterministicDriftCheck is no longer called from phase_complete
-			expect(mockRunDeterministicDriftCheck).not.toHaveBeenCalled();
+			// Advisory drift runs after curator updates, but it must not recreate
+			// the old critic_drift_verifier evidence gate.
+			expect(mockRunDeterministicDriftCheck).toHaveBeenCalled();
+			expect(
+				fs.existsSync(path.join(tempDir, '.swarm', 'drift-verifier.json')),
+			).toBe(false);
 		});
 	});
 

--- a/tests/unit/tools/phase-complete-curator.test.ts
+++ b/tests/unit/tools/phase-complete-curator.test.ts
@@ -2,12 +2,19 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-
+import * as realCurator from '../../../src/hooks/curator';
+import * as realCuratorDrift from '../../../src/hooks/curator-drift';
+import * as realKnowledgeCurator from '../../../src/hooks/knowledge-curator.js';
 import {
 	ensureAgentSession,
 	recordPhaseAgentDispatch,
 	resetSwarmState,
 } from '../../../src/state';
+import {
+	createConfig,
+	writeGateEvidence,
+	writeRetroBundle,
+} from './_phase-complete-test-helpers';
 
 // Mock curator functions BEFORE importing the module under test
 const mockRunCuratorPhase = mock(async () => ({
@@ -44,147 +51,27 @@ const mockRunDeterministicDriftCheck = mock(async () => ({
 	injection_text: '',
 }));
 
-// Mock the curator modules
+// Mock the curator modules — spread real exports, override only the mocked functions
 mock.module('../../../src/hooks/curator', () => ({
+	...realCurator,
 	runCuratorPhase: mockRunCuratorPhase,
 	applyCuratorKnowledgeUpdates: mockApplyCuratorKnowledgeUpdates,
 }));
 
 mock.module('../../../src/hooks/curator-drift', () => ({
+	...realCuratorDrift,
 	runDeterministicDriftCheck: mockRunDeterministicDriftCheck,
 	readPriorDriftReports: mock(async () => []),
 }));
 
 // Also mock the knowledge-curator module to avoid interference from curateAndStoreSwarm
 mock.module('../../../src/hooks/knowledge-curator.js', () => ({
+	...realKnowledgeCurator,
 	curateAndStoreSwarm: mock(async () => {}),
 }));
 
 // Import the tool after setting up mocks
 const { phase_complete } = await import('../../../src/tools/phase-complete');
-
-/**
- * Helper function to write a valid retro bundle for a phase
- */
-function writeRetroBundle(
-	directory: string,
-	phaseNumber: number,
-	verdict: 'pass' | 'fail' = 'pass',
-): void {
-	const retroDir = path.join(
-		directory,
-		'.swarm',
-		'evidence',
-		`retro-${phaseNumber}`,
-	);
-	fs.mkdirSync(retroDir, { recursive: true });
-
-	const retroBundle = {
-		schema_version: '1.0.0',
-		task_id: `retro-${phaseNumber}`,
-		entries: [
-			{
-				task_id: `retro-${phaseNumber}`,
-				type: 'retrospective',
-				timestamp: new Date().toISOString(),
-				agent: 'architect',
-				verdict: verdict,
-				summary: 'Phase retrospective',
-				metadata: {},
-				phase_number: phaseNumber,
-				total_tool_calls: 10,
-				coder_revisions: 1,
-				reviewer_rejections: 0,
-				test_failures: 0,
-				security_findings: 0,
-				integration_issues: 0,
-				task_count: 5,
-				task_complexity: 'moderate',
-				top_rejection_reasons: [],
-				lessons_learned: ['Lesson 1'],
-			},
-		],
-		created_at: new Date().toISOString(),
-		updated_at: new Date().toISOString(),
-	};
-
-	fs.writeFileSync(
-		path.join(retroDir, 'evidence.json'),
-		JSON.stringify(retroBundle, null, 2),
-	);
-}
-
-/**
- * Helper function to write gate evidence files for Phase 4 mandatory gates
- */
-function writeGateEvidence(directory: string, phase: number): void {
-	const evidenceDir = path.join(directory, '.swarm', 'evidence', `${phase}`);
-	fs.mkdirSync(evidenceDir, { recursive: true });
-
-	// Write completion-verify.json
-	const completionVerify = {
-		status: 'passed',
-		tasksChecked: 1,
-		tasksPassed: 1,
-		tasksBlocked: 0,
-		reason: 'All task identifiers found in source files',
-	};
-	fs.writeFileSync(
-		path.join(evidenceDir, 'completion-verify.json'),
-		JSON.stringify(completionVerify, null, 2),
-	);
-
-	// Write drift-verifier.json
-	const driftVerifier = {
-		schema_version: '1.0.0',
-		task_id: 'drift-verifier',
-		entries: [
-			{
-				task_id: 'drift-verifier',
-				type: 'drift_verification',
-				timestamp: new Date().toISOString(),
-				agent: 'critic',
-				verdict: 'approved',
-				summary: 'Drift check passed',
-			},
-		],
-	};
-	fs.writeFileSync(
-		path.join(evidenceDir, 'drift-verifier.json'),
-		JSON.stringify(driftVerifier, null, 2),
-	);
-}
-
-/**
- * Create config with optional curator settings
- */
-function createConfig(curatorConfig?: {
-	enabled?: boolean;
-	phase_enabled?: boolean;
-}): string {
-	const config: Record<string, unknown> = {
-		phase_complete: {
-			enabled: true,
-			required_agents: [],
-			require_docs: false,
-			policy: 'enforce',
-		},
-		// Always write explicit curator config to override any user-level config that may
-		// have curator.enabled=true (user config deep-merges with project config).
-		curator: {
-			enabled: curatorConfig?.enabled ?? false,
-			phase_enabled: curatorConfig?.phase_enabled ?? true,
-			init_enabled: true,
-			max_summary_tokens: 2000,
-			min_knowledge_confidence: 0.7,
-			compliance_report: true,
-			suppress_warnings: true,
-			drift_inject_max_chars: 500,
-		},
-	};
-
-	return JSON.stringify(config);
-}
 
 describe('phase_complete - curator pipeline', () => {
 	let tempDir: string;
@@ -354,125 +241,6 @@ describe('phase_complete - curator pipeline', () => {
 		});
 	});
 
-	describe('curator error does not block phase_complete', () => {
-		test('phase_complete returns success even when runCuratorPhase throws', async () => {
-			// Set up config with curator enabled
-			fs.writeFileSync(
-				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
-				createConfig({ enabled: true, phase_enabled: true }),
-			);
-
-			// Make runCuratorPhase throw an error
-			mockRunCuratorPhase.mockRejectedValueOnce(
-				new Error('Curator phase failed'),
-			);
-
-			ensureAgentSession('sess1');
-			recordPhaseAgentDispatch('sess1', 'coder');
-
-			const result = await phase_complete.execute({
-				phase: 1,
-				sessionID: 'sess1',
-			});
-			const parsed = JSON.parse(result);
-
-			// Phase complete should STILL succeed (not blocked by curator error)
-			expect(parsed.success).toBe(true);
-			expect(parsed.status).toBe('success');
-
-			// The error should have been caught and logged as a warning
-			// (we can't easily test the console.warn output, but we verify the result is valid)
-		});
-
-		test('phase_complete returns success even when applyCuratorKnowledgeUpdates throws', async () => {
-			fs.writeFileSync(
-				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
-				createConfig({ enabled: true, phase_enabled: true }),
-			);
-
-			// Make applyCuratorKnowledgeUpdates throw an error
-			mockApplyCuratorKnowledgeUpdates.mockRejectedValueOnce(
-				new Error('Knowledge update failed'),
-			);
-
-			ensureAgentSession('sess1');
-			recordPhaseAgentDispatch('sess1', 'coder');
-
-			const result = await phase_complete.execute({
-				phase: 1,
-				sessionID: 'sess1',
-			});
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-			expect(parsed.status).toBe('success');
-		});
-
-		test('phase_complete returns success even when runDeterministicDriftCheck throws', async () => {
-			fs.writeFileSync(
-				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
-				createConfig({ enabled: true, phase_enabled: true }),
-			);
-
-			// Make runDeterministicDriftCheck throw an error
-			mockRunDeterministicDriftCheck.mockRejectedValueOnce(
-				new Error('Drift check failed'),
-			);
-
-			ensureAgentSession('sess1');
-			recordPhaseAgentDispatch('sess1', 'coder');
-
-			const result = await phase_complete.execute({
-				phase: 1,
-				sessionID: 'sess1',
-			});
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-			expect(parsed.status).toBe('success');
-		});
-
-		test('result is valid JSON with success:true when curator errors occur', async () => {
-			fs.writeFileSync(
-				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
-				createConfig({ enabled: true, phase_enabled: true }),
-			);
-
-			// Make all curator functions throw
-			mockRunCuratorPhase.mockRejectedValueOnce(new Error('Curator error 1'));
-			mockApplyCuratorKnowledgeUpdates.mockRejectedValueOnce(
-				new Error('Curator error 2'),
-			);
-			mockRunDeterministicDriftCheck.mockRejectedValueOnce(
-				new Error('Curator error 3'),
-			);
-
-			ensureAgentSession('sess1');
-
-			const result = await phase_complete.execute({
-				phase: 1,
-				sessionID: 'sess1',
-			});
-
-			// Should be valid JSON
-			expect(() => JSON.parse(result)).not.toThrow();
-
-			const parsed = JSON.parse(result);
-
-			// Should have expected structure
-			expect(parsed).toHaveProperty('success');
-			expect(parsed).toHaveProperty('phase');
-			expect(parsed).toHaveProperty('message');
-			expect(parsed).toHaveProperty('agentsDispatched');
-			expect(parsed).toHaveProperty('agentsMissing');
-			expect(parsed).toHaveProperty('status');
-			expect(parsed).toHaveProperty('warnings');
-
-			// Should indicate success
-			expect(parsed.success).toBe(true);
-		});
-	});
-
 	describe('curator pipeline skipped when phase_enabled=false', () => {
 		test('runCuratorPhase is NOT called when phase_enabled=false but enabled=true', async () => {
 			// Config with curator.enabled=true but phase_enabled=false
@@ -565,269 +333,6 @@ describe('phase_complete - curator pipeline', () => {
 				expect.objectContaining({}), // _knowledgeConfig: { directory?: string }, passed as {}
 				undefined,
 			);
-		});
-	});
-});
-
-/**
- * Task 5.3: Curator wiring fix - compliance warnings surfacing
- *
- * Phase 4.2 fix: phase_complete surfaces compliance warnings when suppress_warnings is false.
- *
- * Tests:
- * - phase_complete surfaces compliance warnings when suppress_warnings: false
- * - phase_complete does NOT surface compliance warnings when suppress_warnings: true
- */
-describe('Task 5.3: curator compliance warnings surfacing', () => {
-	let tempDir: string;
-	let originalCwd: string;
-
-	beforeEach(() => {
-		resetSwarmState();
-		mockRunCuratorPhase.mockClear();
-		mockApplyCuratorKnowledgeUpdates.mockClear();
-		mockRunDeterministicDriftCheck.mockClear();
-
-		tempDir = fs.realpathSync(
-			fs.mkdtempSync(path.join(os.tmpdir(), 'phase-complete-compliance-test-')),
-		);
-		originalCwd = process.cwd();
-		process.chdir(tempDir);
-
-		fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
-		fs.mkdirSync(path.join(tempDir, '.swarm', 'evidence'), { recursive: true });
-
-		writeRetroBundle(tempDir, 1, 'pass');
-		writeGateEvidence(tempDir, 1);
-		writeRetroBundle(tempDir, 2, 'pass');
-		writeGateEvidence(tempDir, 2);
-	});
-
-	afterEach(() => {
-		process.chdir(originalCwd);
-		try {
-			fs.rmSync(tempDir, { recursive: true, force: true });
-		} catch {
-			// Ignore
-		}
-		resetSwarmState();
-		// Restore cross-module mocks per two-tier DI convention
-		mock.restore();
-	});
-
-	describe('compliance warnings are surfaced when suppress_warnings: false', () => {
-		test('phase_complete surfaces compliance warnings in result when curator returns compliance observations', async () => {
-			// Set up config with curator enabled and suppress_warnings: false
-			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
-			// Create custom config with suppress_warnings: false
-			const customConfig = {
-				phase_complete: {
-					enabled: true,
-					required_agents: [],
-					require_docs: false,
-					policy: 'enforce',
-				},
-				curator: {
-					enabled: true,
-					phase_enabled: true,
-					init_enabled: true,
-					max_summary_tokens: 2000,
-					min_knowledge_confidence: 0.7,
-					compliance_report: true,
-					suppress_warnings: false, // Key setting for this test
-					drift_inject_max_chars: 500,
-				},
-			};
-			fs.writeFileSync(
-				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
-				JSON.stringify(customConfig),
-			);
-
-			// Override suppress_warnings to false in the mock config that will be parsed
-			// The config object has suppress_warnings: true by default in createConfig
-			// We need to mock runCuratorPhase to return compliance observations
-
-			// Set up runCuratorPhase to return compliance observations
-			mockRunCuratorPhase.mockResolvedValueOnce({
-				phase: 1,
-				agents_dispatched: ['coder'],
-				compliance: [
-					{ severity: 'warning', description: 'Reviewer skipped for task 1.1' },
-					{
-						severity: 'error',
-						description: 'No retrospective written for phase 1',
-					},
-				],
-				knowledge_recommendations: [],
-				summary: 'Test phase result',
-				timestamp: new Date().toISOString(),
-			});
-
-			ensureAgentSession('sess1');
-			recordPhaseAgentDispatch('sess1', 'coder');
-
-			const result = await phase_complete.execute({
-				phase: 1,
-				sessionID: 'sess1',
-			});
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-			expect(parsed.warnings).toBeDefined();
-
-			// Compliance warnings should be surfaced
-			const complianceWarning = parsed.warnings.find((w: string) =>
-				w.includes('Curator compliance'),
-			);
-			expect(complianceWarning).toBeDefined();
-			expect(complianceWarning).toContain('Reviewer skipped');
-			expect(complianceWarning).toContain('No retrospective');
-		});
-
-		test('compliance warnings are capped at 5 observations', async () => {
-			// Set up config with curator enabled and suppress_warnings: false
-			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
-			// Create custom config with suppress_warnings: false
-			const customConfig = {
-				phase_complete: {
-					enabled: true,
-					required_agents: [],
-					require_docs: false,
-					policy: 'enforce',
-				},
-				curator: {
-					enabled: true,
-					phase_enabled: true,
-					init_enabled: true,
-					max_summary_tokens: 2000,
-					min_knowledge_confidence: 0.7,
-					compliance_report: true,
-					suppress_warnings: false, // Key setting for this test
-					drift_inject_max_chars: 500,
-				},
-			};
-			fs.writeFileSync(
-				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
-				JSON.stringify(customConfig),
-			);
-
-			// Set up runCuratorPhase to return more than 5 compliance observations
-			const manyObservations = Array.from({ length: 10 }, (_, i) => ({
-				severity: 'warning' as const,
-				description: `Compliance observation ${i + 1}`,
-			}));
-
-			mockRunCuratorPhase.mockResolvedValueOnce({
-				phase: 1,
-				agents_dispatched: ['coder'],
-				compliance: manyObservations,
-				knowledge_recommendations: [],
-				summary: 'Test phase result',
-				timestamp: new Date().toISOString(),
-			});
-
-			ensureAgentSession('sess1');
-			recordPhaseAgentDispatch('sess1', 'coder');
-
-			const result = await phase_complete.execute({
-				phase: 1,
-				sessionID: 'sess1',
-			});
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-
-			// Find the curator compliance warning
-			const complianceWarning = parsed.warnings.find((w: string) =>
-				w.includes('Curator compliance'),
-			);
-			expect(complianceWarning).toBeDefined();
-
-			// Should contain only 5 observations (capped)
-			const warningText = complianceWarning as string;
-			// Each observation appears as [WARNING] or [ERROR] description
-			const warningCount = (warningText.match(/\[WARNING\]/g) || []).length;
-			const errorCount = (warningText.match(/\[ERROR\]/g) || []).length;
-			expect(warningCount + errorCount).toBeLessThanOrEqual(5);
-		});
-	});
-
-	describe('compliance warnings are NOT surfaced when suppress_warnings: true', () => {
-		test('phase_complete does NOT surface compliance warnings when suppress_warnings: true', async () => {
-			// Set up config with curator enabled and suppress_warnings: true (default)
-			// createConfig already sets suppress_warnings: true by default
-			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
-			fs.writeFileSync(
-				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
-				createConfig({ enabled: true, phase_enabled: true }),
-			);
-
-			// Set up runCuratorPhase to return compliance observations
-			mockRunCuratorPhase.mockResolvedValueOnce({
-				phase: 1,
-				agents_dispatched: ['coder'],
-				compliance: [
-					{ severity: 'warning', description: 'Reviewer skipped for task 1.1' },
-				],
-				knowledge_recommendations: [],
-				summary: 'Test phase result',
-				timestamp: new Date().toISOString(),
-			});
-
-			ensureAgentSession('sess1');
-			recordPhaseAgentDispatch('sess1', 'coder');
-
-			const result = await phase_complete.execute({
-				phase: 1,
-				sessionID: 'sess1',
-			});
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-			expect(parsed.warnings).toBeDefined();
-
-			// Compliance warnings should NOT be surfaced
-			const complianceWarning = parsed.warnings.find((w: string) =>
-				w.includes('Curator compliance'),
-			);
-			expect(complianceWarning).toBeUndefined();
-		});
-
-		test('phase_complete does NOT surface compliance warnings when curator returns empty compliance array', async () => {
-			// Set up config with curator enabled
-			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
-			fs.writeFileSync(
-				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
-				createConfig({ enabled: true, phase_enabled: true }),
-			);
-
-			// Set up runCuratorPhase to return empty compliance array
-			mockRunCuratorPhase.mockResolvedValueOnce({
-				phase: 1,
-				agents_dispatched: ['coder'],
-				compliance: [],
-				knowledge_recommendations: [],
-				summary: 'Test phase result',
-				timestamp: new Date().toISOString(),
-			});
-
-			ensureAgentSession('sess1');
-			recordPhaseAgentDispatch('sess1', 'coder');
-
-			const result = await phase_complete.execute({
-				phase: 1,
-				sessionID: 'sess1',
-			});
-			const parsed = JSON.parse(result);
-
-			expect(parsed.success).toBe(true);
-			expect(parsed.warnings).toBeDefined();
-
-			// Compliance warnings should NOT be surfaced (empty array)
-			const complianceWarning = parsed.warnings.find((w: string) =>
-				w.includes('Curator compliance'),
-			);
-			expect(complianceWarning).toBeUndefined();
 		});
 	});
 });

--- a/tests/unit/tools/phase-complete-timing-bug-drift.test.ts
+++ b/tests/unit/tools/phase-complete-timing-bug-drift.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as realCurator from '../../../src/hooks/curator';
 import * as realCuratorDrift from '../../../src/hooks/curator-drift';
+import type { DriftReport } from '../../../src/hooks/curator-types';
 import * as realKnowledgeCurator from '../../../src/hooks/knowledge-curator.js';
 import {
 	ensureAgentSession,
@@ -35,7 +36,6 @@ const mockApplyCuratorKnowledgeUpdates = mock(async () => ({
 	skipped: 0,
 }));
 
-// This mock tracks advisory drift calls. It must never write drift-verifier.json.
 const mockRunDeterministicDriftCheck = mock(async () => {
 	runDeterministicDriftCheckCalled = true;
 	return {
@@ -81,20 +81,7 @@ mock.module('../../../src/hooks/knowledge-curator.js', () => ({
 // Import the tool after setting up mocks
 const { phase_complete } = await import('../../../src/tools/phase-complete');
 
-/**
- * Task 2.3: Core timing bug fix in phase-complete.ts
- *
- * The bug: runDeterministicDriftCheck wrote drift-verifier.json INSIDE phase_complete
- * AFTER the drift gate had already checked for it. This created a race condition
- * where the evidence didn't exist when checked.
- *
- * The fix:
- * 1. curator-drift.ts: Removed drift-verifier.json writing — only writes advisory drift reports
- * 2. phase-complete.ts: runDeterministicDriftCheck may run only as an advisory
- *    drift-report writer; it must not create critic_drift_verifier evidence.
- * 3. phase_complete remains a pure enforcement gate for drift-verifier.json.
- */
-describe('Task 2.3: phase_complete timing bug fix — drift gate architecture', () => {
+describe('Task 2.3: drift gate — verdicts and prior reports', () => {
 	let tempDir: string;
 	let originalCwd: string;
 
@@ -107,8 +94,6 @@ describe('Task 2.3: phase_complete timing bug fix — drift gate architecture', 
 		mockRunDeterministicDriftCheck.mockClear();
 		mockReadPriorDriftReports.mockClear();
 
-		// Use realpathSync to resolve macOS /var→/private/var symlink so that
-		// process.cwd() (which resolves symlinks after chdir) matches tempDir.
 		tempDir = fs.realpathSync(
 			fs.mkdtempSync(path.join(os.tmpdir(), 'phase-complete-timing-test-')),
 		);
@@ -136,20 +121,14 @@ describe('Task 2.3: phase_complete timing bug fix — drift gate architecture', 
 			// Ignore cleanup errors
 		}
 		resetSwarmState();
-		// Restore cross-module mocks per two-tier DI convention
 		mock.restore();
 	});
 
-	describe('1. advisory drift writer does not recreate drift-verifier evidence', () => {
-		test('runDeterministicDriftCheck may run but does not rewrite approved verifier evidence', async () => {
-			ensureAgentSession('sess1');
-			fs.writeFileSync(
-				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
-				createConfig({ enabled: true, phase_enabled: true }),
-			);
-
-			// Write approved drift-verifier.json so drift gate passes
+	describe('3. drift-verifier.json with verdict=approved passes gate', () => {
+		test('phase_complete succeeds when drift-verifier.json has verdict approved', async () => {
 			writeDriftVerifier(tempDir, 1, 'approved');
+
+			ensureAgentSession('sess1');
 
 			const result = await phase_complete.execute({
 				phase: 1,
@@ -158,20 +137,74 @@ describe('Task 2.3: phase_complete timing bug fix — drift gate architecture', 
 			const parsed = JSON.parse(result);
 
 			expect(parsed.success).toBe(true);
-
-			expect(mockRunDeterministicDriftCheck).toHaveBeenCalled();
-			expect(runDeterministicDriftCheckCalled).toBe(true);
-			expect(
-				fs.existsSync(
-					path.join(tempDir, '.swarm', 'evidence', '1', 'drift-verifier.json'),
-				),
-			).toBe(true);
-			expect(
-				fs.existsSync(path.join(tempDir, '.swarm', 'drift-verifier.json')),
-			).toBe(false);
+			expect(parsed.status).toBe('success');
 		});
 
-		test('runDeterministicDriftCheck is advisory when curator pipeline runs', async () => {
+		test('phase_complete succeeds with custom approved summary', async () => {
+			writeDriftVerifier(tempDir, 1, 'approved', 'All requirements verified');
+
+			ensureAgentSession('sess1');
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'sess1',
+			});
+			const parsed = JSON.parse(result);
+
+			expect(parsed.success).toBe(true);
+		});
+	});
+
+	describe('4. drift-verifier.json with verdict=rejected blocks gate', () => {
+		test('phase_complete blocks when drift-verifier.json has verdict rejected', async () => {
+			writeDriftVerifier(
+				tempDir,
+				1,
+				'rejected',
+				'NEEDS_REVISION: Spec drift detected',
+			);
+
+			ensureAgentSession('sess1');
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'sess1',
+			});
+			const parsed = JSON.parse(result);
+
+			expect(parsed.success).toBe(false);
+			expect(parsed.status).toBe('blocked');
+			expect(parsed.reason).toBe('DRIFT_VERIFICATION_REJECTED');
+			expect(parsed.message).toContain(
+				"drift verifier returned verdict 'rejected'",
+			);
+		});
+
+		test('phase_complete blocks when summary contains NEEDS_REVISION', async () => {
+			// verdict is 'approved' but summary indicates needs revision
+			writeDriftVerifier(
+				tempDir,
+				1,
+				'approved',
+				'NEEDS_REVISION: Some drift detected',
+			);
+
+			ensureAgentSession('sess1');
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'sess1',
+			});
+			const parsed = JSON.parse(result);
+
+			expect(parsed.success).toBe(false);
+			expect(parsed.status).toBe('blocked');
+			expect(parsed.reason).toBe('DRIFT_VERIFICATION_REJECTED');
+		});
+	});
+
+	describe('5. readPriorDriftReports is called for advisory injection', () => {
+		test('readPriorDriftReports is called when curator pipeline runs with session state', async () => {
 			// Enable curator pipeline
 			fs.writeFileSync(
 				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
@@ -190,84 +223,44 @@ describe('Task 2.3: phase_complete timing bug fix — drift gate architecture', 
 
 			expect(parsed.success).toBe(true);
 
-			// runCuratorPhase WAS called (curator pipeline runs)
-			expect(mockRunCuratorPhase).toHaveBeenCalled();
-
-			expect(mockRunDeterministicDriftCheck).toHaveBeenCalled();
-			expect(
-				fs.existsSync(
-					path.join(tempDir, '.swarm', 'evidence', '1', 'drift-verifier.json'),
-				),
-			).toBe(true);
-			expect(
-				fs.existsSync(path.join(tempDir, '.swarm', 'drift-verifier.json')),
-			).toBe(false);
+			// readPriorDriftReports should have been called (for advisory injection)
+			expect(mockReadPriorDriftReports).toHaveBeenCalled();
+			expect(mockReadPriorDriftReports).toHaveBeenCalledWith(tempDir);
 		});
 
-		test('advisory drift does not create drift-verifier.json when it is missing', async () => {
-			// NO drift-verifier.json written — should trigger advisory-only warning
-			// but still succeed because spec.md doesn't exist
-			ensureAgentSession('sess1');
+		test('readPriorDriftReports returns drift reports that trigger advisory messages', async () => {
+			// Enable curator pipeline
 			fs.writeFileSync(
 				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
 				createConfig({ enabled: true, phase_enabled: true }),
 			);
 
-			const result = await phase_complete.execute({
-				phase: 1,
-				sessionID: 'sess1',
-			});
-			const parsed = JSON.parse(result);
+			writeDriftVerifier(tempDir, 1, 'approved');
 
-			// Should succeed with advisory warning about missing drift evidence
-			expect(parsed.success).toBe(true);
-			expect(parsed.warnings).toContainEqual(
-				expect.stringContaining('No effective spec'),
-			);
-
-			expect(mockRunDeterministicDriftCheck).toHaveBeenCalled();
-			expect(
-				fs.existsSync(path.join(tempDir, '.swarm', 'drift-verifier.json')),
-			).toBe(false);
-			expect(
-				fs.existsSync(
-					path.join(tempDir, '.swarm', 'evidence', '1', 'drift-verifier.json'),
-				),
-			).toBe(false);
-		});
-	});
-
-	describe('2. Advisory-only mode when no drift-verifier.json and no spec.md', () => {
-		test('phase_complete succeeds with warning when drift-verifier.json missing and no spec.md', async () => {
-			ensureAgentSession('sess1');
-
-			// Ensure NO drift-verifier.json and NO spec.md
-			// (setup already doesn't create these)
-
-			const result = await phase_complete.execute({
-				phase: 1,
-				sessionID: 'sess1',
-			});
-			const parsed = JSON.parse(result);
-
-			// Should succeed (advisory-only mode)
-			expect(parsed.success).toBe(true);
-			expect(parsed.status).toBe('success');
-
-			// Should contain advisory warning about missing drift evidence
-			expect(parsed.warnings).toContainEqual(
-				expect.stringContaining('No effective spec'),
-			);
-		});
-
-		test('phase_complete BLOCKS when drift-verifier.json missing but spec.md exists', async () => {
-			// Create spec.md
-			fs.writeFileSync(
-				path.join(tempDir, '.swarm', 'spec.md'),
-				'# Test Spec\nSome requirements.',
-			);
+			// Mock readPriorDriftReports to return a report with drift_score > 0
+			mockReadPriorDriftReports.mockResolvedValueOnce([
+				{
+					schema_version: 1,
+					phase: 1,
+					timestamp: new Date().toISOString(),
+					alignment: 'MINOR_DRIFT' as const,
+					drift_score: 0.35,
+					first_deviation: {
+						phase: 1,
+						task: '1.1',
+						description: 'Implementation deviates from spec',
+					},
+					compounding_effects: [],
+					corrections: ['Update spec to match implementation'],
+					requirements_checked: 10,
+					requirements_satisfied: 8,
+					scope_additions: [],
+					injection_summary: 'Phase 1: MINOR_DRIFT (0.35)',
+				},
+			]);
 
 			ensureAgentSession('sess1');
+			recordPhaseAgentDispatch('sess1', 'coder');
 
 			const result = await phase_complete.execute({
 				phase: 1,
@@ -275,10 +268,7 @@ describe('Task 2.3: phase_complete timing bug fix — drift gate architecture', 
 			});
 			const parsed = JSON.parse(result);
 
-			// Should be blocked
-			expect(parsed.success).toBe(false);
-			expect(parsed.status).toBe('blocked');
-			expect(parsed.reason).toBe('DRIFT_VERIFICATION_MISSING');
+			expect(parsed.success).toBe(true);
 		});
 	});
 });

--- a/tests/unit/tools/phase-complete-timing-bug-errors.test.ts
+++ b/tests/unit/tools/phase-complete-timing-bug-errors.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as realCurator from '../../../src/hooks/curator';
+import * as realCuratorDrift from '../../../src/hooks/curator-drift';
+import * as realKnowledgeCurator from '../../../src/hooks/knowledge-curator.js';
+import {
+	ensureAgentSession,
+	recordPhaseAgentDispatch,
+	resetSwarmState,
+} from '../../../src/state';
+import {
+	createConfig,
+	writeCompletionVerify,
+	writeDriftVerifier,
+	writeRetroBundle,
+} from './_phase-complete-test-helpers';
+
+// Track whether runDeterministicDriftCheck was called as the advisory report writer.
+let runDeterministicDriftCheckCalled = false;
+
+// Mock curator functions BEFORE importing the module under test
+const mockRunCuratorPhase = mock(async () => ({
+	phase: 1,
+	agents_dispatched: ['coder', 'reviewer', 'test_engineer'],
+	compliance: [],
+	knowledge_recommendations: [],
+	summary: 'Test curator phase result',
+	timestamp: new Date().toISOString(),
+}));
+
+const mockApplyCuratorKnowledgeUpdates = mock(async () => ({
+	applied: 0,
+	skipped: 0,
+}));
+
+const mockRunDeterministicDriftCheck = mock(async () => {
+	runDeterministicDriftCheckCalled = true;
+	return {
+		phase: 1,
+		report: {
+			schema_version: 1 as const,
+			phase: 1,
+			timestamp: new Date().toISOString(),
+			alignment: 'ALIGNED' as const,
+			drift_score: 0,
+			first_deviation: null,
+			compounding_effects: [],
+			corrections: [],
+			requirements_checked: 0,
+			requirements_satisfied: 0,
+			scope_additions: [],
+			injection_summary: '',
+		},
+		report_path: '',
+		injection_text: '',
+	};
+});
+
+const mockReadPriorDriftReports = mock(async () => []);
+
+mock.module('../../../src/hooks/curator', () => ({
+	...realCurator,
+	runCuratorPhase: mockRunCuratorPhase,
+	applyCuratorKnowledgeUpdates: mockApplyCuratorKnowledgeUpdates,
+}));
+
+mock.module('../../../src/hooks/curator-drift', () => ({
+	...realCuratorDrift,
+	runDeterministicDriftCheck: mockRunDeterministicDriftCheck,
+	readPriorDriftReports: mockReadPriorDriftReports,
+}));
+
+mock.module('../../../src/hooks/knowledge-curator.js', () => ({
+	...realKnowledgeCurator,
+	curateAndStoreSwarm: mock(async () => {}),
+}));
+
+// Import the tool after setting up mocks
+const { phase_complete } = await import('../../../src/tools/phase-complete');
+
+describe('Task 2.3: curator pipeline errors do not block phase_complete', () => {
+	let tempDir: string;
+	let originalCwd: string;
+
+	beforeEach(() => {
+		resetSwarmState();
+		runDeterministicDriftCheckCalled = false;
+
+		mockRunCuratorPhase.mockClear();
+		mockApplyCuratorKnowledgeUpdates.mockClear();
+		mockRunDeterministicDriftCheck.mockClear();
+		mockReadPriorDriftReports.mockClear();
+
+		tempDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'phase-complete-timing-test-')),
+		);
+		originalCwd = process.cwd();
+		process.chdir(tempDir);
+
+		fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+		fs.mkdirSync(path.join(tempDir, '.swarm', 'evidence'), { recursive: true });
+		fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+
+		writeRetroBundle(tempDir, 1, 'pass');
+		writeCompletionVerify(tempDir, 1);
+
+		fs.writeFileSync(
+			path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+			createConfig({ enabled: true, phase_enabled: true }),
+		);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			// Ignore cleanup errors
+		}
+		resetSwarmState();
+		mock.restore();
+	});
+
+	test('phase_complete succeeds even when runCuratorPhase throws', async () => {
+		writeDriftVerifier(tempDir, 1, 'approved');
+		mockRunCuratorPhase.mockRejectedValueOnce(
+			new Error('Curator phase failed'),
+		);
+
+		ensureAgentSession('sess1');
+		recordPhaseAgentDispatch('sess1', 'coder');
+
+		const result = await phase_complete.execute({
+			phase: 1,
+			sessionID: 'sess1',
+		});
+		const parsed = JSON.parse(result);
+
+		// Should still succeed (curator errors are non-blocking)
+		expect(parsed.success).toBe(true);
+		expect(parsed.status).toBe('success');
+	});
+
+	test('phase_complete succeeds even when applyCuratorKnowledgeUpdates throws', async () => {
+		writeDriftVerifier(tempDir, 1, 'approved');
+		mockApplyCuratorKnowledgeUpdates.mockRejectedValueOnce(
+			new Error('Knowledge update failed'),
+		);
+
+		ensureAgentSession('sess1');
+		recordPhaseAgentDispatch('sess1', 'coder');
+
+		const result = await phase_complete.execute({
+			phase: 1,
+			sessionID: 'sess1',
+		});
+		const parsed = JSON.parse(result);
+
+		expect(parsed.success).toBe(true);
+	});
+
+	test('phase_complete succeeds even when readPriorDriftReports throws', async () => {
+		writeDriftVerifier(tempDir, 1, 'approved');
+		mockReadPriorDriftReports.mockRejectedValueOnce(
+			new Error('Read drift reports failed'),
+		);
+
+		ensureAgentSession('sess1');
+		recordPhaseAgentDispatch('sess1', 'coder');
+
+		const result = await phase_complete.execute({
+			phase: 1,
+			sessionID: 'sess1',
+		});
+		const parsed = JSON.parse(result);
+
+		// Should still succeed (drift advisory injection is non-blocking)
+		expect(parsed.success).toBe(true);
+	});
+});

--- a/tests/unit/tools/phase-complete-timing-bug.test.ts
+++ b/tests/unit/tools/phase-complete-timing-bug.test.ts
@@ -9,7 +9,7 @@ import {
 	resetSwarmState,
 } from '../../../src/state';
 
-// Track whether runDeterministicDriftCheck was called
+// Track whether runDeterministicDriftCheck was called as the advisory report writer.
 let runDeterministicDriftCheckCalled = false;
 
 // Mock curator functions BEFORE importing the module under test
@@ -27,7 +27,7 @@ const mockApplyCuratorKnowledgeUpdates = mock(async () => ({
 	skipped: 0,
 }));
 
-// This mock tracks calls but is NOT actually invoked by phase_complete (per Task 2.3 fix)
+// This mock tracks advisory drift calls. It must never write drift-verifier.json.
 const mockRunDeterministicDriftCheck = mock(async () => {
 	runDeterministicDriftCheckCalled = true;
 	return {
@@ -214,9 +214,9 @@ function createConfig(curatorConfig?: {
  *
  * The fix:
  * 1. curator-drift.ts: Removed drift-verifier.json writing — only writes advisory drift reports
- * 2. phase-complete.ts: Removed runDeterministicDriftCheck call, replaced with readPriorDriftReports for
- *    informational advisory messages
- * 3. phase_complete is now a pure enforcement gate that reads pre-written evidence
+ * 2. phase-complete.ts: runDeterministicDriftCheck may run only as an advisory
+ *    drift-report writer; it must not create critic_drift_verifier evidence.
+ * 3. phase_complete remains a pure enforcement gate for drift-verifier.json.
  */
 describe('Task 2.3: phase_complete timing bug fix — drift gate architecture', () => {
 	let tempDir: string;
@@ -264,9 +264,13 @@ describe('Task 2.3: phase_complete timing bug fix — drift gate architecture', 
 		mock.restore();
 	});
 
-	describe('1. runDeterministicDriftCheck is NOT called by phase_complete (core fix)', () => {
-		test('runDeterministicDriftCheck mock is never called during phase_complete execution', async () => {
+	describe('1. advisory drift writer does not recreate drift-verifier evidence', () => {
+		test('runDeterministicDriftCheck may run but does not rewrite approved verifier evidence', async () => {
 			ensureAgentSession('sess1');
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				createConfig({ enabled: true, phase_enabled: true }),
+			);
 
 			// Write approved drift-verifier.json so drift gate passes
 			writeDriftVerifier(tempDir, 1, 'approved');
@@ -279,13 +283,19 @@ describe('Task 2.3: phase_complete timing bug fix — drift gate architecture', 
 
 			expect(parsed.success).toBe(true);
 
-			// KEY ASSERTION: runDeterministicDriftCheck should NOT have been called
-			// The fix removed this call from phase_complete
-			expect(mockRunDeterministicDriftCheck).not.toHaveBeenCalled();
-			expect(runDeterministicDriftCheckCalled).toBe(false);
+			expect(mockRunDeterministicDriftCheck).toHaveBeenCalled();
+			expect(runDeterministicDriftCheckCalled).toBe(true);
+			expect(
+				fs.existsSync(
+					path.join(tempDir, '.swarm', 'evidence', '1', 'drift-verifier.json'),
+				),
+			).toBe(true);
+			expect(
+				fs.existsSync(path.join(tempDir, '.swarm', 'drift-verifier.json')),
+			).toBe(false);
 		});
 
-		test('runDeterministicDriftCheck is not called even when curator pipeline runs', async () => {
+		test('runDeterministicDriftCheck is advisory when curator pipeline runs', async () => {
 			// Enable curator pipeline
 			fs.writeFileSync(
 				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
@@ -307,14 +317,25 @@ describe('Task 2.3: phase_complete timing bug fix — drift gate architecture', 
 			// runCuratorPhase WAS called (curator pipeline runs)
 			expect(mockRunCuratorPhase).toHaveBeenCalled();
 
-			// But runDeterministicDriftCheck was NOT called
-			expect(mockRunDeterministicDriftCheck).not.toHaveBeenCalled();
+			expect(mockRunDeterministicDriftCheck).toHaveBeenCalled();
+			expect(
+				fs.existsSync(
+					path.join(tempDir, '.swarm', 'evidence', '1', 'drift-verifier.json'),
+				),
+			).toBe(true);
+			expect(
+				fs.existsSync(path.join(tempDir, '.swarm', 'drift-verifier.json')),
+			).toBe(false);
 		});
 
-		test('runDeterministicDriftCheck is not called even when drift-verifier.json is missing', async () => {
+		test('advisory drift does not create drift-verifier.json when it is missing', async () => {
 			// NO drift-verifier.json written — should trigger advisory-only warning
 			// but still succeed because spec.md doesn't exist
 			ensureAgentSession('sess1');
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				createConfig({ enabled: true, phase_enabled: true }),
+			);
 
 			const result = await phase_complete.execute({
 				phase: 1,
@@ -328,8 +349,15 @@ describe('Task 2.3: phase_complete timing bug fix — drift gate architecture', 
 				expect.stringContaining('No effective spec'),
 			);
 
-			// runDeterministicDriftCheck should NOT have been called to "fix" the missing evidence
-			expect(mockRunDeterministicDriftCheck).not.toHaveBeenCalled();
+			expect(mockRunDeterministicDriftCheck).toHaveBeenCalled();
+			expect(
+				fs.existsSync(path.join(tempDir, '.swarm', 'drift-verifier.json')),
+			).toBe(false);
+			expect(
+				fs.existsSync(
+					path.join(tempDir, '.swarm', 'evidence', '1', 'drift-verifier.json'),
+				),
+			).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
Closes #1684

## Summary
- Execute `CURATOR_POSTMORTEM` LLM output instead of archiving raw recommendations: parse `SUMMARY`, `CURATION_RECOMMENDATIONS`, `QUEUE_TRIAGE`, and the new fenced `postmortem_actions` block.
- Route post-mortem recommendations through existing gated paths: curator knowledge updates, hive promotion, and explicitly scoped proposal triage.
- Add `/swarm post-mortem --scope session|project`, wire `/swarm curate` into an on-demand curator phase, and feed latest post-mortem summaries back into `CURATOR_INIT`.
- Restore advisory drift report generation while preserving the `drift-verifier.json` gate contract, and archive/clean generated post-mortem/drift artifacts during finalize.

## Invariant audit
- 1 (plugin init):       touched - avoided new eager post-mortem imports by lazy-loading curator/hive/skill/drift dependencies through DI wrappers; verified with `bun run build` and `node --input-type=module -e "await import('./dist/index.js')"`.
- 2 (runtime portability): touched - command/hook imports and bundle output changed; verified with `bun run build` and Node ESM import smoke.
- 3 (subprocesses):       not touched - no subprocess code added or changed.
- 4 (.swarm containment): touched - finalize now archives and archive-first cleans `.swarm/post-mortem-*.md` and `.swarm/drift-report-phase-*.json`; verified by focused close/phase tests and `bun test ... phase-complete-timing-bug.test.ts`.
- 5 (plan durability):    not touched - no ledger, plan projection, checkpoint import/export, or plan schema changes.
- 6 (test_runner safety): not touched - validation used shell `bun test` commands only; no OpenCode `test_runner` broad scope.
- 7 (test writing):       touched - added/updated bun:test coverage; new test file is 134 lines and edited command tests remain under 500 lines; verified by focused tests and line-count check.
- 8 (session state):      touched - session ID now flows through post-mortem scope and `/swarm curate`; no new global session maps; verified by post-mortem command and curate command tests.
- 9 (guardrails/retry):   not touched - no guardrail or transient retry semantics changed.
- 10 (chat/system msg):   not touched - no chat/system hook shape changes.
- 11 (tool registration): touched - command registry help/args changed for post-mortem and curate handler session wiring; verified by `bun run drift:check`.
- 12 (release/cache):     touched - added `docs/releases/pending/1684-postmortem-curator-actions.md`; no cache/version changes.

## Test plan
- `bun test tests/unit/hooks/curator-postmortem-actions.test.ts tests/unit/hooks/curator-postmortem.test.ts tests/unit/commands/post-mortem.test.ts src/commands/curate.test.ts tests/unit/hooks/curator-coverage.test.ts tests/unit/hooks/curator-issues-1411-1414.test.ts tests/unit/hooks/curator.test.ts tests/unit/tools/phase-complete-curator.test.ts tests/unit/tools/phase-complete-timing-bug.test.ts tests/unit/agents/explorer-curator-observations.test.ts src/agents/explorer-consumer-contract.test.ts`
- `bun test tests/unit/hooks/curator-coverage.test.ts tests/unit/hooks/curator-postmortem.test.ts tests/unit/hooks/curator.test.ts`
- `bun test src/commands/curate.test.ts`
- `bun run typecheck`
- `bun run build`
- `node --input-type=module -e "await import('./dist/index.js')"`
- `bun run lint`
- `bun run drift:check`
- `git diff --check`
