### PR TITLE
fix(quality-gates): wire missing language coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ Built-in tools verify every task before it ships:
 
 - **syntax_check** — Tree-sitter validation across the configured language grammar map
 - **placeholder_scan** — Catches TODOs, stubs, incomplete code
-- **sast_scan** — 65 security rules across 7 languages (offline)
+- **sast_scan** — 68 security rules across 8 languages (offline)
 - **sbom_generate** — Dependency tracking (CycloneDX)
 - **quality_budget** — Complexity, duplication, test ratio limits
 
@@ -798,7 +798,7 @@ Every candidate passes a 3-gate pipeline before entering quarantine:
 |------|-------------|
 | syntax_check | Tree-sitter validation across the configured language grammar map |
 | placeholder_scan | Catches TODOs, FIXMEs, stubs, placeholder text |
-| sast_scan | Offline security analysis, 65 rules, 7 languages |
+| sast_scan | Offline security analysis, 68 rules, 8 languages |
 | sbom_generate | CycloneDX dependency tracking, 8 ecosystems |
 | build_check | Runs your project's native build/typecheck |
 | incremental_verify | Post-coder hook for TS/JS, Go, Rust, Python, and C#; configured by `incremental_verify.*`, not invoked as a registered tool |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1081,7 +1081,7 @@ v6.9.0 "Quality & Anti-Slop Tooling" adds 6 automated gates to the pre-reviewer 
 |------|---------|------------|
 | `syntax_check` | Tree-sitter parse validation across 20 languages | ✅ |
 | `placeholder_scan` | Anti-slop detection for TODO/FIXME/stubs | ✅ |
-| `sast_scan` | Static security analysis with 65 rules across 7 languages | ✅ |
+| `sast_scan` | Static security analysis with 68 rules across 8 languages | ✅ |
 | `sbom_generate` | CycloneDX SBOM generation for dependencies | ✅ |
 | `build_check` | Build/typecheck verification | ✅ |
 | `pre_check_batch` | Parallel verification batch (4x faster) | ✅ |
@@ -1403,7 +1403,7 @@ Six new automated gates enforce code quality before human review. All gates run 
 |------|----------|-------------|
 | `syntax_check` | Tree-sitter parse validation | Return to coder for fix |
 | `placeholder_scan` | Detect TODO/FIXME/stubs | Return to coder to complete |
-| `sast_scan` | Static security analysis (65 rules across 7 languages) | Return to coder for fix |
+| `sast_scan` | Static security analysis (68 rules across 8 languages) | Return to coder for fix |
 | `sbom_generate` | CycloneDX SBOM generation | Log for audit trail |
 | `build_check` | Build/typecheck verification | Return to coder for fix |
 | `pre_check_batch` | Parallel verification (v6.10.0) | Return to coder for fix |
@@ -1438,7 +1438,7 @@ Detects patterns indicating incomplete implementation:
 
 ### sast_scan - Static Security Analysis
 
-65 security rules across 7 languages covering:
+68 security rules across 8 languages covering:
 - SQL injection vectors (including Laravel-specific `DB::raw()` concatenation)
 - Path traversal patterns
 - Hardcoded secrets

--- a/docs/design-rationale.md
+++ b/docs/design-rationale.md
@@ -436,7 +436,7 @@ Coder → syntax_check → placeholder_scan → sast_scan → sbom_generate → 
 |------|---------|---------------|
 | `syntax_check` | Parse errors, invalid syntax | Machine finds syntax errors instantly |
 | `placeholder_scan` | TODO/FIXME comments, stubs | Prevents shipping incomplete code |
-| `sast_scan` | Security vulnerabilities (65 rules across 7 languages) | Security review before human review |
+| `sast_scan` | Security vulnerabilities (68 rules across 8 languages) | Security review before human review |
 | `sbom_generate` | Dependency inventory | Audit trail for compliance |
 | `build_check` | Compilation errors, type failures | Build must pass before review |
 | `quality_budget` | Complexity, duplication, test coverage | Maintainability enforcement |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -875,7 +875,7 @@ Enable all gates with defaults:
 |------|-------------|---------|-------------|
 | `syntax_check` | Tree-sitter parse validation (20 languages) | `true` | Block review |
 | `placeholder_scan` | Detect TODO/FIXME/stub implementations | `true` | Block review |
-| `sast_scan` | Static security analysis (65 rules across 7 languages) | `true` | Block review |
+| `sast_scan` | Static security analysis (68 rules across 8 languages) | `true` | Block review |
 | `sbom_generate` | Generate CycloneDX SBOM | `true` | Continue (informational) |
 | `build_check` | Build/typecheck verification | `true` | Block review |
 | `quality_budget` | Enforce maintainability thresholds | `true` | Block review |

--- a/docs/releases/pending/1689-quality-gate-language-coverage.md
+++ b/docs/releases/pending/1689-quality-gate-language-coverage.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Wired Go and Rust SAST into the native rule path so seeded Go/Rust vulnerabilities are detected without relying on optional Semgrep availability.
+- Reused the full `secretscan` detector registry for file-scoped `pre_check_batch` runs, restoring hard-gate coverage for AWS, Stripe, Slack, SendGrid, Twilio, and entropy-based secrets.
+- Added PHP test-runner and lint-tool support for PHPUnit/Pest/Laravel and common Composer linters.
+- Corrected profile build-command priority ordering and prevented generic Gradle Checkstyle detection from masking ktlint in Kotlin projects.

--- a/docs/releases/pending/1689-quality-gate-language-coverage.md
+++ b/docs/releases/pending/1689-quality-gate-language-coverage.md
@@ -1,4 +1,6 @@
-### Fixed
+# Quality-gate language coverage (Go/Rust SAST, secretscan registry, PHP test/lint)
+
+## Fixed
 
 - Wired Go and Rust SAST into the native rule path so seeded Go/Rust vulnerabilities are detected without relying on optional Semgrep availability.
 - Reused the full `secretscan` detector registry for file-scoped `pre_check_batch` runs, restoring hard-gate coverage for AWS, Stripe, Slack, SendGrid, Twilio, and entropy-based secrets.

--- a/src/build/discovery.ts
+++ b/src/build/discovery.ts
@@ -12,7 +12,7 @@ export interface BuildCommand {
 	ecosystem: string;
 	command: string;
 	cwd: string;
-	priority: number; // Lower = higher priority
+	priority: number; // Higher = higher priority
 }
 
 export interface BuildDiscoveryResult {
@@ -41,9 +41,9 @@ const ECOSYSTEMS: EcosystemConfig[] = [
 		buildFiles: ['package.json'],
 		toolchainCommands: ['npm', 'yarn', 'pnpm'],
 		commands: [
-			{ command: 'npm run build', priority: 1 },
-			{ command: 'npm run typecheck', priority: 2 },
-			{ command: 'npm run check', priority: 3 },
+			{ command: 'npm run build', priority: 30 },
+			{ command: 'npm run typecheck', priority: 20 },
+			{ command: 'npm run check', priority: 10 },
 		],
 		repoDefinedScripts: ['build', 'typecheck', 'check', 'compile'],
 	},
@@ -52,30 +52,30 @@ const ECOSYSTEMS: EcosystemConfig[] = [
 		buildFiles: ['Cargo.toml'],
 		toolchainCommands: ['cargo'],
 		commands: [
-			{ command: 'cargo build', priority: 1 },
-			{ command: 'cargo check', priority: 2 },
+			{ command: 'cargo build', priority: 20 },
+			{ command: 'cargo check', priority: 10 },
 		],
 	},
 	{
 		ecosystem: 'go',
 		buildFiles: ['go.mod'],
 		toolchainCommands: ['go'],
-		commands: [{ command: 'go build ./...', priority: 1 }],
+		commands: [{ command: 'go build ./...', priority: 10 }],
 	},
 	{
 		ecosystem: 'python',
 		buildFiles: ['pyproject.toml', 'setup.py', 'setup.cfg'],
 		toolchainCommands: ['python', 'python3', 'py'],
 		commands: [
-			{ command: 'python -m py_compile', priority: 1 },
-			{ command: 'python -m build', priority: 2 },
+			{ command: 'python -m build', priority: 20 },
+			{ command: 'python -m py_compile', priority: 10 },
 		],
 	},
 	{
 		ecosystem: 'java-maven',
 		buildFiles: ['pom.xml'],
 		toolchainCommands: ['mvn'],
-		commands: [{ command: 'mvn compile', priority: 1 }],
+		commands: [{ command: 'mvn compile', priority: 10 }],
 	},
 	{
 		ecosystem: 'java-gradle',
@@ -87,30 +87,30 @@ const ECOSYSTEMS: EcosystemConfig[] = [
 					process.platform === 'win32'
 						? 'gradlew.bat build'
 						: './gradlew build',
-				priority: 1,
+				priority: 20,
 			},
-			{ command: 'gradle build', priority: 2 },
+			{ command: 'gradle build', priority: 10 },
 		],
 	},
 	{
 		ecosystem: 'dotnet',
 		buildFiles: ['*.csproj', '*.fsproj', '*.vbproj'],
 		toolchainCommands: ['dotnet'],
-		commands: [{ command: 'dotnet build', priority: 1 }],
+		commands: [{ command: 'dotnet build', priority: 10 }],
 	},
 	{
 		ecosystem: 'swift',
 		buildFiles: ['Package.swift'],
 		toolchainCommands: ['swift'],
-		commands: [{ command: 'swift build', priority: 1 }],
+		commands: [{ command: 'swift build', priority: 10 }],
 	},
 	{
 		ecosystem: 'dart',
 		buildFiles: ['pubspec.yaml', 'pubspec.lock'],
 		toolchainCommands: ['dart', 'flutter'],
 		commands: [
-			{ command: 'dart analyze', priority: 1 },
-			{ command: 'dart compile', priority: 2 },
+			{ command: 'dart compile', priority: 20 },
+			{ command: 'dart analyze', priority: 10 },
 		],
 	},
 	{
@@ -118,8 +118,8 @@ const ECOSYSTEMS: EcosystemConfig[] = [
 		buildFiles: ['Makefile', 'CMakeLists.txt'],
 		toolchainCommands: ['make', 'cmake'],
 		commands: [
-			{ command: 'make', priority: 1 },
-			{ command: 'cmake -B build && cmake --build build', priority: 2 },
+			{ command: 'make', priority: 20 },
+			{ command: 'cmake -B build && cmake --build build', priority: 10 },
 		],
 	},
 	{
@@ -129,7 +129,7 @@ const ECOSYSTEMS: EcosystemConfig[] = [
 		commands: [
 			{
 				command: 'composer install --no-interaction --prefer-dist',
-				priority: 1,
+				priority: 10,
 			},
 		],
 	},
@@ -271,7 +271,7 @@ function getRepoDefinedScripts(
 			if (pkg.scripts[scriptName]) {
 				found.push({
 					script: `npm run ${scriptName}`,
-					priority: 0, // Repo-defined scripts have highest priority
+					priority: 100, // Repo-defined scripts have highest priority
 				});
 			}
 		}
@@ -404,9 +404,9 @@ export async function discoverBuildCommandsFromProfiles(
 			continue;
 		}
 
-		// Sort commands by priority (lower = higher priority)
+		// Sort commands by priority (higher = higher priority)
 		const sortedCommands = [...fullProfile.build.commands].sort(
-			(a, b) => a.priority - b.priority,
+			(a, b) => b.priority - a.priority,
 		);
 
 		// Find first available binary
@@ -548,8 +548,8 @@ export async function discoverBuildCommands(
 		}
 	}
 
-	// Sort by priority (lower = higher priority)
-	commands.sort((a, b) => a.priority - b.priority);
+	// Sort by priority (higher = higher priority)
+	commands.sort((a, b) => b.priority - a.priority);
 
 	return { commands, skipped };
 }

--- a/src/lang/backends/php.ts
+++ b/src/lang/backends/php.ts
@@ -13,7 +13,13 @@
  * filesystem-only (no subprocess), so they are safe on the session-init path.
  */
 
-import type { FrameworkSelection, LanguageBackend } from '../backend';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type {
+	FrameworkSelection,
+	LanguageBackend,
+	TestFrameworkSelection,
+} from '../backend';
 import { defaultBackendFor } from '../default-backend';
 import { detectLaravelProject } from '../framework-detector';
 import { LANGUAGE_REGISTRY } from '../profiles';
@@ -37,6 +43,52 @@ async function selectFramework(
 	return null;
 }
 
+async function selectTestFramework(
+	dir: string,
+): Promise<TestFrameworkSelection | null> {
+	if (detectLaravelProject(dir)) {
+		return {
+			name: 'php-artisan',
+			cmd: ['php', 'artisan', 'test'],
+			cwd: dir,
+			detectedVia: 'Laravel signals (artisan / composer.json / config/app.php)',
+		};
+	}
+	if (fs.existsSync(path.join(dir, 'Pest.php'))) {
+		return {
+			name: 'pest',
+			cmd: [phpVendorBin('pest')],
+			cwd: dir,
+			detectedVia: 'Pest.php',
+		};
+	}
+	if (fs.existsSync(path.join(dir, 'phpunit.xml'))) {
+		return {
+			name: 'phpunit',
+			cmd: [phpVendorBin('phpunit')],
+			cwd: dir,
+			detectedVia: 'phpunit.xml',
+		};
+	}
+	if (fs.existsSync(path.join(dir, 'phpunit.xml.dist'))) {
+		return {
+			name: 'phpunit',
+			cmd: [phpVendorBin('phpunit')],
+			cwd: dir,
+			detectedVia: 'phpunit.xml.dist',
+		};
+	}
+	return null;
+}
+
+function phpVendorBin(name: string): string {
+	return path.join(
+		'vendor',
+		'bin',
+		process.platform === 'win32' ? `${name}.bat` : name,
+	);
+}
+
 /**
  * Build the PHP backend from the registered profile.
  */
@@ -51,5 +103,6 @@ export function buildPhpBackend(): LanguageBackend {
 	return {
 		...defaultBackendFor(profile),
 		selectFramework,
+		selectTestFramework,
 	};
 }

--- a/src/lang/default-backend.ts
+++ b/src/lang/default-backend.ts
@@ -271,6 +271,21 @@ export function defaultBuildTestCommand(
 				'-e',
 				'Dir.glob("test/**/*_test.rb").sort.each { |f| require_relative f }',
 			];
+		case 'pest': {
+			const args: string[] = [phpVendorBin('pest')];
+			if (scope !== 'all' && files.length > 0) args.push(...files);
+			return args;
+		}
+		case 'phpunit': {
+			const args: string[] = [phpVendorBin('phpunit')];
+			if (scope !== 'all' && files.length > 0) args.push(...files);
+			return args;
+		}
+		case 'php-artisan': {
+			const args: string[] = ['php', 'artisan', 'test'];
+			if (scope !== 'all' && files.length > 0) args.push(...files);
+			return args;
+		}
 		default: {
 			// Unknown framework — fall back to registry-driven tokenization so
 			// a profile that adds a new framework entry without updating this
@@ -283,6 +298,14 @@ export function defaultBuildTestCommand(
 			return [...argv, ...files];
 		}
 	}
+}
+
+function phpVendorBin(name: string): string {
+	return path.join(
+		'vendor',
+		'bin',
+		process.platform === 'win32' ? `${name}.bat` : name,
+	);
 }
 
 /**
@@ -508,6 +531,26 @@ export function defaultParseTestOutput(
 				skipped = parseInt(minitestMatch[4], 10);
 				failed = failures + errors;
 				passed = total - failed - skipped;
+			}
+			break;
+		}
+		case 'pest':
+		case 'phpunit':
+		case 'php-artisan': {
+			const phpunitMatch = output.match(
+				/Tests:\s*(\d+),\s*Assertions:\s*\d+(?:,\s*Failures:\s*(\d+))?(?:,\s*Errors:\s*(\d+))?(?:,\s*Skipped:\s*(\d+))?/,
+			);
+			const okMatch = output.match(/OK\s*\((\d+)\s+tests?/);
+			if (phpunitMatch) {
+				total = parseInt(phpunitMatch[1], 10);
+				const failures = phpunitMatch[2] ? parseInt(phpunitMatch[2], 10) : 0;
+				const errors = phpunitMatch[3] ? parseInt(phpunitMatch[3], 10) : 0;
+				skipped = phpunitMatch[4] ? parseInt(phpunitMatch[4], 10) : 0;
+				failed = failures + errors;
+				passed = total - failed - skipped;
+			} else if (okMatch) {
+				total = parseInt(okMatch[1], 10);
+				passed = total;
 			}
 			break;
 		}

--- a/src/lang/profiles.ts
+++ b/src/lang/profiles.ts
@@ -593,7 +593,7 @@ LANGUAGE_REGISTRY.register({
 		command: 'govulncheck -json ./...',
 		outputFormat: 'json',
 	},
-	sast: { nativeRuleSet: null, semgrepSupport: 'ga' },
+	sast: { nativeRuleSet: 'go', semgrepSupport: 'ga' },
 	prompts: {
 		coderConstraints: [
 			'Always check and return errors; never discard error return values',

--- a/src/sast/rules/go.ts
+++ b/src/sast/rules/go.ts
@@ -18,7 +18,7 @@ export const goRules: SastRule[] = [
 		remediation:
 			'Move secrets to environment variables using os.Getenv() or a secrets manager.',
 		pattern:
-			/(?:api_key|password|secret|token|auth)[_-]?\w*\s*[:=]\s*["'][a-zA-Z0-9_-]{10,}["']/i,
+			/(?:api_key|password|secret|token|auth)[_-]?\w*\s*(?::=|=|:)\s*["'][a-zA-Z0-9_-]{10,}["']/i,
 	},
 	{
 		id: 'sast/go-weak-tls',

--- a/src/sast/rules/go.ts
+++ b/src/sast/rules/go.ts
@@ -18,7 +18,7 @@ export const goRules: SastRule[] = [
 		remediation:
 			'Move secrets to environment variables using os.Getenv() or a secrets manager.',
 		pattern:
-			/(?:api_key|password|secret|token|auth)[_-]?\w*\s*(?::=|=|:)\s*["'][a-zA-Z0-9_-]{10,}["']/i,
+			/(?:api[_-]?key|apiKey|ApiKey|apikey|api[_-]?token|apiToken|auth[_-]?token|authToken|password|passwd|secret|token|auth)[_-]?\w*\s*(?::=|=|:)\s*["'][a-zA-Z0-9_-]{10,}["']/i,
 	},
 	{
 		id: 'sast/go-weak-tls',

--- a/src/sast/rules/index.ts
+++ b/src/sast/rules/index.ts
@@ -56,6 +56,7 @@ import { javaRules } from './java';
 import { javascriptRules } from './javascript';
 import { phpRules } from './php';
 import { pythonRules } from './python';
+import { rustRules } from './rust';
 
 /**
  * All registered SAST rules
@@ -64,6 +65,7 @@ const allRules: SastRule[] = [
 	...javascriptRules,
 	...pythonRules,
 	...goRules,
+	...rustRules,
 	...javaRules,
 	...phpRules,
 	...cRules,

--- a/src/sast/rules/rust.ts
+++ b/src/sast/rules/rust.ts
@@ -1,0 +1,42 @@
+/**
+ * Rust SAST Rules
+ * Detects common security vulnerabilities in Rust code
+ */
+
+import type { SastRule } from './index';
+
+export const rustRules: SastRule[] = [
+	{
+		id: 'sast/rust-hardcoded-secret',
+		name: 'Hardcoded secret detected',
+		severity: 'critical',
+		languages: ['rust'],
+		description: 'Potential hardcoded API key, password, or token detected',
+		remediation:
+			'Move secrets to environment variables or a secrets manager; do not commit credentials.',
+		pattern:
+			/(?:api_key|password|secret|token|auth)[_-]?\w*\s*(?::\s*&?str)?\s*(?:=|:)\s*["'][a-zA-Z0-9_-]{10,}["']/i,
+	},
+	{
+		id: 'sast/rust-command-injection',
+		name: 'Shell command injection risk',
+		severity: 'critical',
+		languages: ['rust'],
+		description:
+			'std::process::Command invokes a shell interpreter, which can enable command injection when user input is passed as arguments.',
+		remediation:
+			'Invoke the target binary directly and pass arguments separately; avoid sh -c, bash -c, cmd /C, and powershell -Command with user input.',
+		pattern: /Command::new\s*\(\s*["'](?:sh|bash|cmd|powershell|pwsh)["']\s*\)/,
+	},
+	{
+		id: 'sast/rust-unsafe-block',
+		name: 'Unsafe Rust block',
+		severity: 'medium',
+		languages: ['rust'],
+		description:
+			'Unsafe blocks bypass Rust safety checks and require careful manual validation.',
+		remediation:
+			'Minimize unsafe code and document invariants with a SAFETY comment.',
+		pattern: /\bunsafe\s*\{/,
+	},
+];

--- a/src/tools/lint.ts
+++ b/src/tools/lint.ts
@@ -24,7 +24,11 @@ export type AdditionalLinter =
 	| 'cppcheck'
 	| 'swiftlint'
 	| 'dart-analyze'
-	| 'rubocop';
+	| 'rubocop'
+	| 'phpstan'
+	| 'pint'
+	| 'php-cs-fixer'
+	| 'phpcs';
 
 // ============ Response Types ============
 export interface LintSuccessResult {
@@ -155,6 +159,18 @@ export function getAdditionalLinterCommand(
 			const base = useBundle ? ['bundle', 'exec', 'rubocop'] : ['rubocop'];
 			return mode === 'fix' ? [...base, '-A'] : base;
 		}
+		case 'phpstan':
+			return [phpVendorBin(cwd, 'phpstan'), 'analyse'];
+		case 'pint':
+			return mode === 'fix'
+				? [phpVendorBin(cwd, 'pint')]
+				: [phpVendorBin(cwd, 'pint'), '--test'];
+		case 'php-cs-fixer':
+			return mode === 'fix'
+				? [phpVendorBin(cwd, 'php-cs-fixer'), 'fix']
+				: [phpVendorBin(cwd, 'php-cs-fixer'), 'fix', '--dry-run', '--diff'];
+		case 'phpcs':
+			return [phpVendorBin(cwd, 'phpcs')];
 	}
 }
 
@@ -194,37 +210,98 @@ function detectGolangciLint(cwd: string): boolean {
 	);
 }
 
+function readTextFileSafe(filePath: string): string {
+	try {
+		return fs.readFileSync(filePath, 'utf-8');
+	} catch {
+		return '';
+	}
+}
+
+function phpVendorBin(_cwd: string, name: string): string {
+	const fileName = process.platform === 'win32' ? `${name}.bat` : name;
+	return path.join('vendor', 'bin', fileName);
+}
+
+function phpVendorBinExists(cwd: string, name: string): boolean {
+	const local = path.join(cwd, 'vendor', 'bin', name);
+	const localWin = path.join(cwd, 'vendor', 'bin', `${name}.bat`);
+	return fs.existsSync(local) || fs.existsSync(localWin);
+}
+
 /** Detect checkstyle (Java linter via mvn or checkstyle jar) */
 function detectCheckstyle(cwd: string): boolean {
-	// Maven: pom.xml + mvn binary; Gradle: build.gradle(.kts) + gradlew or gradle binary
+	// Maven: pom.xml + mvn binary; Gradle requires a Checkstyle-specific signal.
 	const hasMaven = fs.existsSync(path.join(cwd, 'pom.xml'));
-	const hasGradle =
-		fs.existsSync(path.join(cwd, 'build.gradle')) ||
-		fs.existsSync(path.join(cwd, 'build.gradle.kts'));
+	const gradleFiles = ['build.gradle', 'build.gradle.kts']
+		.map((file) => path.join(cwd, file))
+		.filter((file) => fs.existsSync(file));
+	const hasGradleCheckstyleSignal =
+		fs.existsSync(path.join(cwd, 'checkstyle.xml')) ||
+		fs.existsSync(path.join(cwd, 'config', 'checkstyle', 'checkstyle.xml')) ||
+		gradleFiles.some((file) => /\bcheckstyle\b/i.test(readTextFileSafe(file)));
 	const hasBinary =
 		(hasMaven && isCommandAvailable('mvn')) ||
-		(hasGradle &&
+		(hasGradleCheckstyleSignal &&
 			(fs.existsSync(path.join(cwd, 'gradlew')) ||
 				isCommandAvailable('gradle')));
-	return (hasMaven || hasGradle) && hasBinary;
+	return (hasMaven || hasGradleCheckstyleSignal) && hasBinary;
+}
+
+function hasRootKotlinFile(cwd: string): boolean {
+	try {
+		return fs
+			.readdirSync(cwd)
+			.some((f) => f.endsWith('.kt') || f.endsWith('.kts'));
+	} catch {
+		return false;
+	}
+}
+
+function buildGradleHasKotlinSignal(cwd: string): boolean {
+	const content = readTextFileSafe(path.join(cwd, 'build.gradle'));
+	return /\b(kotlin|org\.jetbrains\.kotlin|ktlint)\b/i.test(content);
 }
 
 /** Detect ktlint (Kotlin linter) */
 function detectKtlint(cwd: string): boolean {
-	// build.gradle.kts, build.gradle (Groovy DSL), or .kt/.kts files in root dir
+	// build.gradle.kts is Kotlin DSL. Groovy build.gradle needs a Kotlin signal.
 	const hasKotlin =
 		fs.existsSync(path.join(cwd, 'build.gradle.kts')) ||
-		fs.existsSync(path.join(cwd, 'build.gradle')) ||
-		(() => {
-			try {
-				return fs
-					.readdirSync(cwd)
-					.some((f) => f.endsWith('.kt') || f.endsWith('.kts'));
-			} catch {
-				return false;
-			}
-		})();
+		(fs.existsSync(path.join(cwd, 'build.gradle')) &&
+			buildGradleHasKotlinSignal(cwd)) ||
+		hasRootKotlinFile(cwd);
 	return hasKotlin && isCommandAvailable('ktlint');
+}
+
+/** Detect PHP linters from config + local Composer vendor binaries */
+function detectPhpLinter(cwd: string): AdditionalLinter | null {
+	if (
+		(fs.existsSync(path.join(cwd, 'phpstan.neon')) ||
+			fs.existsSync(path.join(cwd, 'phpstan.neon.dist'))) &&
+		phpVendorBinExists(cwd, 'phpstan')
+	) {
+		return 'phpstan';
+	}
+	if (
+		fs.existsSync(path.join(cwd, 'pint.json')) &&
+		phpVendorBinExists(cwd, 'pint')
+	) {
+		return 'pint';
+	}
+	if (
+		fs.existsSync(path.join(cwd, '.php-cs-fixer.php')) &&
+		phpVendorBinExists(cwd, 'php-cs-fixer')
+	) {
+		return 'php-cs-fixer';
+	}
+	if (
+		fs.existsSync(path.join(cwd, 'phpcs.xml')) &&
+		phpVendorBinExists(cwd, 'phpcs')
+	) {
+		return 'phpcs';
+	}
+	return null;
 }
 
 /** Detect dotnet-format (C#/.NET linter) */
@@ -311,12 +388,18 @@ export function detectAdditionalLinter(
 	| 'swiftlint'
 	| 'dart-analyze'
 	| 'rubocop'
+	| 'phpstan'
+	| 'pint'
+	| 'php-cs-fixer'
+	| 'phpcs'
 	| null {
 	if (detectRuff(cwd)) return 'ruff';
 	if (detectClippy(cwd)) return 'clippy';
 	if (detectGolangciLint(cwd)) return 'golangci-lint';
-	if (detectCheckstyle(cwd)) return 'checkstyle';
+	const phpLinter = detectPhpLinter(cwd);
+	if (phpLinter) return phpLinter;
 	if (detectKtlint(cwd)) return 'ktlint';
+	if (detectCheckstyle(cwd)) return 'checkstyle';
 	if (detectDotnetFormat(cwd)) return 'dotnet-format';
 	if (detectCppcheck(cwd)) return 'cppcheck';
 	if (detectSwiftlint(cwd)) return 'swiftlint';

--- a/src/tools/pre-check-batch.ts
+++ b/src/tools/pre-check-batch.ts
@@ -4,7 +4,6 @@
  * Returns unified result with gates_passed status
  */
 
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { tool } from '@opencode-ai/plugin';
 import pLimit from 'p-limit';
@@ -21,12 +20,8 @@ import type { QualityBudgetResult } from './quality-budget';
 import { qualityBudget } from './quality-budget';
 import type { SastScanFinding, SastScanResult } from './sast-scan';
 import { sastScan } from './sast-scan';
-import type {
-	SecretFinding,
-	SecretscanErrorResult,
-	SecretscanResult,
-} from './secretscan';
-import { runSecretscan } from './secretscan';
+import type { SecretscanErrorResult, SecretscanResult } from './secretscan';
+import { runSecretscan, runSecretscanOnFiles } from './secretscan';
 
 // ============ Constants ============
 const TOOL_TIMEOUT_MS = 60_000;
@@ -372,7 +367,7 @@ async function runSecretscanWrapped(
 		// If files are provided, run secretscan with explicit file scope
 		if (files && files.length > 0) {
 			const result = await runWithTimeout(
-				runSecretscanWithFiles(files, directory),
+				runSecretscanOnFiles(files, directory),
 				TOOL_TIMEOUT_MS,
 			);
 			return {
@@ -399,229 +394,6 @@ async function runSecretscanWrapped(
 			error: error instanceof Error ? error.message : 'Unknown error',
 			duration_ms: Number(process.hrtime.bigint() - start) / 1_000_000,
 		};
-	}
-}
-
-// ============ Secretscan File Scanning (for targeted scanning) ============
-
-/**
- * Run secretscan with explicit file scope - only scans specified files
- */
-async function runSecretscanWithFiles(
-	files: string[],
-	directory: string,
-): Promise<SecretscanResult | SecretscanErrorResult> {
-	const MAX_FILE_SIZE_BYTES = 512 * 1024; // 512KB per file
-	const MAX_FINDINGS = 100;
-
-	// Default exclusions for file extensions
-	const DEFAULT_EXCLUDE_EXTENSIONS = new Set([
-		'.png',
-		'.jpg',
-		'.jpeg',
-		'.gif',
-		'.ico',
-		'.svg',
-		'.pdf',
-		'.zip',
-		'.tar',
-		'.gz',
-		'.rar',
-		'.7z',
-		'.exe',
-		'.dll',
-		'.so',
-		'.dylib',
-		'.bin',
-		'.dat',
-		'.db',
-		'.sqlite',
-		'.lock',
-		'.log',
-		'.md',
-	]);
-
-	// Secret patterns for scanning (simplified version)
-	// Note: Patterns use non-global regex to avoid shared state mutation
-	// Each scan creates a fresh matcher to prevent lastIndex contamination
-	const SECRET_PATTERNS: Array<{
-		type: string;
-		pattern: string;
-		redactTemplate: (match?: string) => string;
-	}> = [
-		{
-			type: 'api_key',
-			pattern:
-				'(?:api[_-]?key|apikey|API[_-]?KEY)\\s*[=:]\\s*[\'"]?([a-zA-Z0-9_-]{16,64})[\'"]?',
-			redactTemplate: () => 'api_key=[REDACTED]',
-		},
-		{
-			type: 'password',
-			pattern:
-				'(?:password|passwd|pwd|PASSWORD|PASSWD)\\s*[=:]\\s*[\'"]?([^\\s\'"]{4,100})[\'"]?',
-			redactTemplate: () => 'password=[REDACTED]',
-		},
-		{
-			type: 'private_key',
-			pattern: '-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----',
-			redactTemplate: () => '-----BEGIN PRIVATE KEY-----',
-		},
-		{
-			type: 'github_token',
-			pattern: '(?:ghp|gho|ghu|ghs|ghr)_[a-zA-Z0-9]{36,}',
-			redactTemplate: () => 'ghp_[REDACTED]',
-		},
-		{
-			type: 'jwt',
-			pattern: 'eyJ[a-zA-Z0-9_-]*\\.eyJ[a-zA-Z0-9_-]*\\.[a-zA-Z0-9_-]*',
-			redactTemplate: (m) => `eyJ...${(m || '').slice(-10)}`,
-		},
-	];
-
-	try {
-		const findings: SecretFinding[] = [];
-		let filesScanned = 0;
-		let skippedFiles = 0;
-
-		// Security: Validate all resolved file paths before processing
-		const validatedFiles: string[] = [];
-		for (const file of files) {
-			// Hardened: Explicit type guard for non-string entries fail-closed
-			if (typeof file !== 'string') {
-				skippedFiles++;
-				continue;
-			}
-			// Resolve the path first
-			const resolvedPath = path.resolve(file);
-			// Validate the resolved path against workspace boundary
-			const validationError = validatePath(resolvedPath, directory, directory);
-			if (validationError) {
-				// Skip invalid files - fail closed
-				skippedFiles++;
-				continue;
-			}
-			validatedFiles.push(resolvedPath);
-		}
-
-		// Fail closed if no valid files after validation
-		if (validatedFiles.length === 0) {
-			return {
-				scan_dir: directory,
-				findings: [],
-				count: 0,
-				files_scanned: 0,
-				skipped_files: skippedFiles,
-			};
-		}
-
-		// Filter and scan only the validated files
-		for (const file of validatedFiles) {
-			const ext = path.extname(file).toLowerCase();
-
-			// Skip excluded file types
-			if (DEFAULT_EXCLUDE_EXTENSIONS.has(ext)) {
-				skippedFiles++;
-				continue;
-			}
-
-			// Check file size
-			let stat: fs.Stats;
-			try {
-				stat = fs.statSync(file);
-			} catch {
-				skippedFiles++;
-				continue;
-			}
-
-			if (stat.size > MAX_FILE_SIZE_BYTES) {
-				skippedFiles++;
-				continue;
-			}
-
-			// Read and scan file
-			let content: string;
-			try {
-				const buffer = fs.readFileSync(file);
-				// Skip binary files (check for null bytes)
-				if (buffer.includes(0)) {
-					skippedFiles++;
-					continue;
-				}
-				// Handle UTF-8 BOM
-				if (
-					buffer.length >= 3 &&
-					buffer[0] === 0xef &&
-					buffer[1] === 0xbb &&
-					buffer[2] === 0xbf
-				) {
-					content = buffer.slice(3).toString('utf-8');
-				} else {
-					content = buffer.toString('utf-8');
-				}
-			} catch {
-				skippedFiles++;
-				continue;
-			}
-
-			filesScanned++;
-
-			// Scan each line - create fresh regex per pattern to avoid shared state
-			const lines = content.split('\n');
-			for (let i = 0; i < lines.length && findings.length < MAX_FINDINGS; i++) {
-				const line = lines[i];
-				for (const pattern of SECRET_PATTERNS) {
-					// Create fresh regex instance for each line to avoid lastIndex mutation
-					const regex = new RegExp(pattern.pattern, 'gi');
-					let match: RegExpExecArray | null = regex.exec(line);
-					while (match !== null) {
-						findings.push({
-							path: file,
-							line: i + 1,
-							type: pattern.type as SecretFinding['type'],
-							confidence: 'medium',
-							severity: 'high',
-							redacted: pattern.redactTemplate(match[0]),
-							context: line,
-						});
-
-						// Prevent infinite loop on zero-length matches
-						if (match.index === regex.lastIndex) {
-							regex.lastIndex++;
-						}
-
-						match = regex.exec(line);
-					}
-				}
-			}
-		}
-
-		// Sort findings deterministically
-		findings.sort((a, b) => {
-			if (a.path < b.path) return -1;
-			if (a.path > b.path) return 1;
-			return a.line - b.line;
-		});
-
-		return {
-			scan_dir: directory,
-			findings,
-			count: findings.length,
-			files_scanned: filesScanned,
-			skipped_files: skippedFiles,
-		};
-	} catch (e) {
-		const errorResult: SecretscanErrorResult = {
-			error:
-				e instanceof Error
-					? `scan failed: ${e.message}`
-					: 'scan failed: unknown error',
-			scan_dir: directory,
-			findings: [],
-			count: 0,
-			files_scanned: 0,
-			skipped_files: 0,
-		};
-		return errorResult;
 	}
 }
 

--- a/src/tools/pre-check-batch.ts
+++ b/src/tools/pre-check-batch.ts
@@ -793,9 +793,27 @@ export async function runPreCheckBatch(
 	// Check secretscan (hard gate - MUST pass)
 	if (secretscanResult.ran && secretscanResult.result) {
 		const scanResult = secretscanResult.result as SecretscanResult;
-		if ('findings' in scanResult && scanResult.findings.length > 0) {
+		// F-003: an internal scan error returns SecretscanErrorResult (has `error`);
+		// fail closed instead of treating an errored scan as a clean pass.
+		if ('error' in scanResult && (scanResult as { error?: string }).error) {
+			gatesPassed = false;
+			warn(
+				`pre_check_batch: Secretscan error - GATE FAILED: ${(scanResult as { error?: string }).error}`,
+			);
+		} else if ('findings' in scanResult && scanResult.findings.length > 0) {
 			gatesPassed = false;
 			warn('pre_check_batch: Secretscan found secrets - GATE FAILED');
+		} else if (
+			// F-002: vacuous pass — scan ran but scanned zero files despite files being
+			// requested. Mirror SAST's zero-coverage-fail guard (sast-scan.ts:597).
+			files &&
+			files.length > 0 &&
+			(scanResult.files_scanned ?? 0) === 0
+		) {
+			gatesPassed = false;
+			warn(
+				'pre_check_batch: Secretscan scanned 0 files despite requested file scope - GATE FAILED (possible vacuous pass)',
+			);
 		}
 	} else if (secretscanResult.error) {
 		// Error in secretscan - fail closed

--- a/src/tools/secretscan.ts
+++ b/src/tools/secretscan.ts
@@ -1071,13 +1071,92 @@ export async function runSecretscan(
 }
 
 /**
+ * Run secretscan over an explicit, already-selected file set.
+ * Used by pre_check_batch so changed-file hard gates share the same detector
+ * registry and entropy logic as the standalone scanner.
+ */
+export async function runSecretscanOnFiles(
+	files: string[],
+	directory: string,
+): Promise<SecretscanResult | SecretscanErrorResult> {
+	try {
+		const findings: SecretFinding[] = [];
+		let filesScanned = 0;
+		let skippedFiles = 0;
+
+		for (const file of files) {
+			if (typeof file !== 'string') {
+				skippedFiles++;
+				continue;
+			}
+
+			const resolvedPath = path.isAbsolute(file)
+				? path.resolve(file)
+				: path.resolve(directory, file);
+
+			if (!isPathWithinScope(resolvedPath, directory)) {
+				skippedFiles++;
+				continue;
+			}
+
+			const ext = path.extname(resolvedPath).toLowerCase();
+			if (DEFAULT_EXCLUDE_EXTENSIONS.has(ext)) {
+				skippedFiles++;
+				continue;
+			}
+
+			if (!fs.existsSync(resolvedPath)) {
+				skippedFiles++;
+				continue;
+			}
+
+			const fileFindings = scanFileForSecrets(resolvedPath);
+			filesScanned++;
+			findings.push(...fileFindings);
+			if (findings.length >= MAX_FINDINGS) {
+				findings.length = MAX_FINDINGS;
+				break;
+			}
+		}
+
+		findings.sort((a, b) => {
+			if (a.path < b.path) return -1;
+			if (a.path > b.path) return 1;
+			return a.line - b.line;
+		});
+
+		return {
+			scan_dir: directory,
+			findings,
+			count: findings.length,
+			files_scanned: filesScanned,
+			skipped_files: skippedFiles,
+		};
+	} catch (e) {
+		return {
+			error:
+				e instanceof Error
+					? `scan failed: ${e.message}`
+					: 'scan failed: unknown error',
+			scan_dir: directory,
+			findings: [],
+			count: 0,
+			files_scanned: 0,
+			skipped_files: 0,
+		};
+	}
+}
+
+/**
  * DI seam for testability. Contains all test-mocked exports.
  * Internal calls should use _internals.fn() instead of fn() directly.
  */
 export const _internals: {
 	secretscan: typeof secretscan;
 	runSecretscan: typeof runSecretscan;
+	runSecretscanOnFiles: typeof runSecretscanOnFiles;
 } = {
 	secretscan,
 	runSecretscan,
+	runSecretscanOnFiles,
 } as const;

--- a/src/tools/secretscan.ts
+++ b/src/tools/secretscan.ts
@@ -1155,8 +1155,10 @@ export const _internals: {
 	secretscan: typeof secretscan;
 	runSecretscan: typeof runSecretscan;
 	runSecretscanOnFiles: typeof runSecretscanOnFiles;
+	SECRET_PATTERNS: typeof SECRET_PATTERNS;
 } = {
 	secretscan,
 	runSecretscan,
 	runSecretscanOnFiles,
+	SECRET_PATTERNS,
 } as const;

--- a/src/tools/test-runner.ts
+++ b/src/tools/test-runner.ts
@@ -84,6 +84,9 @@ export const SUPPORTED_FRAMEWORKS = [
 	'dart-test',
 	'rspec',
 	'minitest',
+	'pest',
+	'phpunit',
+	'php-artisan',
 ] as const;
 
 export type TestFramework = (typeof SUPPORTED_FRAMEWORKS)[number] | 'none';
@@ -379,11 +382,16 @@ export const DISPATCH_FRAMEWORK_MAP: Record<string, TestFramework> = {
 	'dart-test': 'dart-test',
 	rspec: 'rspec',
 	minitest: 'minitest',
+	pest: 'pest',
+	phpunit: 'phpunit',
+	'php-artisan': 'php-artisan',
 	// Genuine aliases (many profile names → one union framework).
 	'bun:test': 'bun',
 	'xcodebuild-test': 'swift-test',
 	'flutter test': 'dart-test',
 	'dart test': 'dart-test',
+	Pest: 'pest',
+	PHPUnit: 'phpunit',
 };
 
 export async function detectTestFrameworkViaDispatch(
@@ -582,6 +590,8 @@ export async function detectTestFramework(cwd: string): Promise<TestFramework> {
 	}
 
 	// Profile-driven detection for additional languages (soft warning on missing binary)
+	const phpFramework = detectPhpTest(baseDir);
+	if (phpFramework) return phpFramework;
 	if (detectGoTest(baseDir)) return 'go-test';
 	if (detectJavaMaven(baseDir)) return 'maven';
 	if (detectGradle(baseDir)) return 'gradle';
@@ -593,6 +603,23 @@ export async function detectTestFramework(cwd: string): Promise<TestFramework> {
 	if (detectMinitest(baseDir)) return 'minitest';
 
 	return 'none';
+}
+
+function detectPhpTest(cwd: string): TestFramework | null {
+	if (
+		fs.existsSync(path.join(cwd, 'artisan')) &&
+		fs.existsSync(path.join(cwd, 'composer.json'))
+	) {
+		return 'php-artisan';
+	}
+	if (fs.existsSync(path.join(cwd, 'Pest.php'))) return 'pest';
+	if (
+		fs.existsSync(path.join(cwd, 'phpunit.xml')) ||
+		fs.existsSync(path.join(cwd, 'phpunit.xml.dist'))
+	) {
+		return 'phpunit';
+	}
+	return null;
 }
 
 // ============ Test File Mapping (Convention Scope) ============
@@ -680,6 +707,12 @@ function buildLanguageSpecificTestNames(
 				`${nameWithoutExt}Test.kt`,
 				`${nameWithoutExt}Tests.kt`,
 				`Test${nameWithoutExt}.kt`,
+			];
+		case '.php':
+			return [
+				`${nameWithoutExt}Test.php`,
+				`${nameWithoutExt}Tests.php`,
+				`Test${nameWithoutExt}.php`,
 			];
 		case '.ps1':
 			return [`${nameWithoutExt}.Tests.ps1`, `${nameWithoutExt}.tests.ps1`];
@@ -789,6 +822,14 @@ export function isLanguageSpecificTestFile(basename: string): boolean {
 		(/^Test[A-Z]/.test(basename) ||
 			lower.endsWith('test.kt') ||
 			lower.endsWith('tests.kt'))
+	)
+		return true;
+	// PHP
+	if (
+		lower.endsWith('.php') &&
+		(/^Test[A-Z]/.test(basename) ||
+			basename.endsWith('Test.php') ||
+			basename.endsWith('Tests.php'))
 	)
 		return true;
 	// PowerShell
@@ -1256,9 +1297,32 @@ function buildTestCommand(
 				'-e',
 				'Dir.glob("test/**/*_test.rb").sort.each { |f| require_relative f }',
 			];
+		case 'pest': {
+			const args: string[] = [phpVendorBin('pest')];
+			if (scope !== 'all' && files.length > 0) args.push(...files);
+			return args;
+		}
+		case 'phpunit': {
+			const args: string[] = [phpVendorBin('phpunit')];
+			if (scope !== 'all' && files.length > 0) args.push(...files);
+			return args;
+		}
+		case 'php-artisan': {
+			const args: string[] = ['php', 'artisan', 'test'];
+			if (scope !== 'all' && files.length > 0) args.push(...files);
+			return args;
+		}
 		default:
 			return null;
 	}
+}
+
+function phpVendorBin(name: string): string {
+	return path.join(
+		'vendor',
+		'bin',
+		process.platform === 'win32' ? `${name}.bat` : name,
+	);
 }
 
 function mapFrameworkStatusToResult(
@@ -1673,6 +1737,26 @@ function parseTestOutput(
 			}
 			break;
 		}
+		case 'pest':
+		case 'phpunit':
+		case 'php-artisan': {
+			const phpunitMatch = output.match(
+				/Tests:\s*(\d+),\s*Assertions:\s*\d+(?:,\s*Failures:\s*(\d+))?(?:,\s*Errors:\s*(\d+))?(?:,\s*Skipped:\s*(\d+))?/,
+			);
+			const okMatch = output.match(/OK\s*\((\d+)\s+tests?/);
+			if (phpunitMatch) {
+				totals.total = parseInt(phpunitMatch[1], 10);
+				const failures = phpunitMatch[2] ? parseInt(phpunitMatch[2], 10) : 0;
+				const errors = phpunitMatch[3] ? parseInt(phpunitMatch[3], 10) : 0;
+				totals.skipped = phpunitMatch[4] ? parseInt(phpunitMatch[4], 10) : 0;
+				totals.failed = failures + errors;
+				totals.passed = totals.total - totals.failed - totals.skipped;
+			} else if (okMatch) {
+				totals.total = parseInt(okMatch[1], 10);
+				totals.passed = totals.total;
+			}
+			break;
+		}
 		default:
 			break;
 	}
@@ -1992,6 +2076,7 @@ const SOURCE_EXTENSIONS = new Set([
 	'.hpp',
 	'.cc',
 	'.cxx',
+	'.php',
 	'.swift',
 	'.dart',
 	'.rb',

--- a/tests/unit/build/discovery-profiles.test.ts
+++ b/tests/unit/build/discovery-profiles.test.ts
@@ -221,6 +221,49 @@ describe('discoverBuildCommandsFromProfiles - detectFile Filtering', () => {
 		expect(result.commands[0].ecosystem).toBe('python');
 		expect(result.skipped).toHaveLength(0);
 	});
+
+	it('selects the highest numeric priority profile command when multiple are available', async () => {
+		const mockProfile: MockLanguageProfile = {
+			id: 'custom',
+			displayName: 'Custom',
+			tier: 1,
+			extensions: ['.custom'],
+			treeSitter: { grammarId: 'custom', wasmFile: 'tree-sitter-custom.wasm' },
+			build: {
+				detectFiles: ['project.custom'],
+				commands: [
+					{
+						name: 'low',
+						cmd: 'node low.js',
+						detectFile: 'project.custom',
+						priority: 1,
+					},
+					{
+						name: 'high',
+						cmd: 'node high.js',
+						detectFile: 'project.custom',
+						priority: 10,
+					},
+				],
+			},
+			test: { detectFiles: [], frameworks: [] },
+			lint: { detectFiles: [], linters: [] },
+			audit: { detectFiles: [], command: null, outputFormat: 'json' },
+			sast: { nativeRuleSet: null, semgrepSupport: 'none' },
+			prompts: { coderConstraints: [], reviewerChecklist: [] },
+		};
+		fs.writeFileSync(path.join(TEST_DIR, 'project.custom'), '');
+		mockDetectProjectLanguages.mockResolvedValue([mockProfile]);
+		mockLangRegistryGet.mockReturnValue(mockProfile);
+
+		const module = await import('../../../src/build/discovery');
+		module.clearToolchainCache();
+
+		const result = await module.discoverBuildCommandsFromProfiles(TEST_DIR);
+
+		expect(result.commands).toHaveLength(1);
+		expect(result.commands[0].command).toBe('node high.js');
+	});
 });
 
 // ============ Test Suite 3: discoverBuildCommands - Profile vs ECOSYSTEMS Priority ============

--- a/tests/unit/tools/lint-detectors-adversarial.test.ts
+++ b/tests/unit/tools/lint-detectors-adversarial.test.ts
@@ -376,6 +376,7 @@ describe('Lint Detectors - Adversarial Security/Edge-Case Tests', () => {
 			mockIsCommandAvailable.mockImplementation((cmd: string) => {
 				return cmd === 'gradlew'; // gradlew is checked via existsSync, not isCommandAvailable
 			});
+			mockReadFileSync.mockImplementation(() => 'plugins { id("checkstyle") }');
 
 			const result = detectAdditionalLinter('/test/path');
 
@@ -387,6 +388,7 @@ describe('Lint Detectors - Adversarial Security/Edge-Case Tests', () => {
 				return path.includes('build.gradle') || path.includes('gradlew');
 			});
 			mockIsCommandAvailable.mockImplementation(() => false);
+			mockReadFileSync.mockImplementation(() => 'plugins { id("checkstyle") }');
 
 			const result = detectAdditionalLinter('/test/path');
 
@@ -417,9 +419,14 @@ describe('Lint Detectors - Adversarial Security/Edge-Case Tests', () => {
 
 		it('should detect with both pom.xml and build.gradle, mvn and gradle both available', () => {
 			mockExistsSync.mockImplementation((path: string) => {
-				return path.includes('pom.xml') || path.includes('build.gradle');
+				return (
+					path.includes('pom.xml') ||
+					(path.includes('build.gradle') && !path.includes('.kts'))
+				);
 			});
 			mockIsCommandAvailable.mockImplementation(() => true);
+			mockReadFileSync.mockImplementation(() => 'plugins { id("checkstyle") }');
+			mockReaddirSync.mockImplementation(() => []);
 
 			const result = detectAdditionalLinter('/test/path');
 

--- a/tests/unit/tools/lint-detectors.test.ts
+++ b/tests/unit/tools/lint-detectors.test.ts
@@ -5,7 +5,10 @@ afterEach(() => {
 });
 
 import * as realFs from 'node:fs';
-import { detectAdditionalLinter } from '../../../src/tools/lint';
+import {
+	detectAdditionalLinter,
+	getAdditionalLinterCommand,
+} from '../../../src/tools/lint';
 
 // Mock node:fs
 const mockExistsSync = mock();
@@ -52,7 +55,19 @@ describe('detectAdditionalLinter - Linter Detectors', () => {
 			expect(detectAdditionalLinter(testCwd)).toBe('ktlint');
 		});
 
-		it('returns "ktlint" when build.gradle (Groovy DSL) exists + ktlint available', () => {
+		it('prefers ktlint over generic Gradle checkstyle for Kotlin projects', () => {
+			mockIsCommandAvailable.mockImplementation(
+				(cmd: string) => cmd === 'ktlint' || cmd === 'gradle',
+			);
+			mockExistsSync.mockImplementation(
+				(p: string) => typeof p === 'string' && p.endsWith('build.gradle.kts'),
+			);
+			mockReaddirSync.mockImplementation(() => []);
+
+			expect(detectAdditionalLinter(testCwd)).toBe('ktlint');
+		});
+
+		it('returns "ktlint" when build.gradle (Groovy DSL) has a Kotlin signal + ktlint available', () => {
 			mockIsCommandAvailable.mockImplementation(
 				(cmd: string) => cmd === 'ktlint',
 			);
@@ -63,9 +78,28 @@ describe('detectAdditionalLinter - Linter Detectors', () => {
 					!p.endsWith('.kts')
 				);
 			});
+			mockReadFileSync.mockImplementation(
+				() => 'plugins { id("org.jetbrains.kotlin.jvm") version "2.0.0" }',
+			);
 			mockReaddirSync.mockImplementation(() => []);
 
 			expect(detectAdditionalLinter(testCwd)).toBe('ktlint');
+		});
+
+		it('does not choose ktlint for generic Groovy Gradle projects with checkstyle', () => {
+			mockIsCommandAvailable.mockImplementation(
+				(cmd: string) => cmd === 'ktlint' || cmd === 'gradle',
+			);
+			mockExistsSync.mockImplementation((p: string) => {
+				return (
+					typeof p === 'string' &&
+					(p.endsWith('build.gradle') || p.endsWith('gradlew'))
+				);
+			});
+			mockReadFileSync.mockImplementation(() => 'plugins { id("checkstyle") }');
+			mockReaddirSync.mockImplementation(() => []);
+
+			expect(detectAdditionalLinter(testCwd)).toBe('checkstyle');
 		});
 
 		it('returns "ktlint" when root dir has .kt file + ktlint available', () => {
@@ -128,7 +162,7 @@ describe('detectAdditionalLinter - Linter Detectors', () => {
 			expect(detectAdditionalLinter(testCwd)).toBe('checkstyle');
 		});
 
-		it('returns "checkstyle" when build.gradle + gradlew exists (Gradle path)', () => {
+		it('returns "checkstyle" when build.gradle declares checkstyle + gradlew exists', () => {
 			mockIsCommandAvailable.mockImplementation(
 				(cmd: string) => cmd === 'other-tool',
 			);
@@ -138,18 +172,20 @@ describe('detectAdditionalLinter - Linter Detectors', () => {
 					(p.endsWith('build.gradle') || p.endsWith('gradlew'))
 				);
 			});
+			mockReadFileSync.mockImplementation(() => 'plugins { id("checkstyle") }');
 			mockReaddirSync.mockImplementation(() => []);
 
 			expect(detectAdditionalLinter(testCwd)).toBe('checkstyle');
 		});
 
-		it('returns "checkstyle" when build.gradle.kts + gradle available (Gradle path)', () => {
+		it('returns "checkstyle" when build.gradle.kts declares checkstyle + gradle available', () => {
 			mockIsCommandAvailable.mockImplementation(
 				(cmd: string) => cmd === 'gradle',
 			);
 			mockExistsSync.mockImplementation(
 				(p: string) => typeof p === 'string' && p.endsWith('build.gradle.kts'),
 			);
+			mockReadFileSync.mockImplementation(() => 'plugins { checkstyle }');
 			mockReaddirSync.mockImplementation(() => []);
 
 			expect(detectAdditionalLinter(testCwd)).toBe('checkstyle');
@@ -406,6 +442,26 @@ describe('detectAdditionalLinter - Linter Detectors', () => {
 			mockReaddirSync.mockImplementation(() => []);
 
 			expect(detectAdditionalLinter(testCwd)).toBe(null);
+		});
+	});
+
+	describe('detectPhpLinters (via detectAdditionalLinter returning PHP linters)', () => {
+		it('returns "phpstan" when phpstan.neon and local vendor binary exist', () => {
+			mockExistsSync.mockImplementation((p: string) => {
+				return (
+					typeof p === 'string' &&
+					(p.endsWith('phpstan.neon') ||
+						p.endsWith('vendor/bin/phpstan') ||
+						p.endsWith('vendor\\bin\\phpstan') ||
+						p.endsWith('vendor\\bin\\phpstan.bat'))
+				);
+			});
+
+			expect(detectAdditionalLinter(testCwd)).toBe('phpstan');
+			expect(getAdditionalLinterCommand('phpstan', 'check', testCwd)).toEqual([
+				expect.stringContaining('phpstan'),
+				'analyse',
+			]);
 		});
 	});
 

--- a/tests/unit/tools/pre-check-batch-secretscan-registry.test.ts
+++ b/tests/unit/tools/pre-check-batch-secretscan-registry.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runPreCheckBatch } from '../../../src/tools/pre-check-batch';
+
+let tempDir: string;
+
+beforeEach(() => {
+	tempDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'precheck-secrets-')),
+	);
+});
+
+afterEach(() => {
+	fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('pre_check_batch file-scoped secretscan registry coverage', () => {
+	test('hard-fails the gate for AWS access keys in changed files', async () => {
+		const awsAccessKey = 'AK' + 'IAIOSFODNN7EXAMPLE';
+		fs.writeFileSync(
+			path.join(tempDir, 'secrets.env'),
+			`AWS_ACCESS_KEY_ID=${awsAccessKey}\n`,
+		);
+
+		const result = await runPreCheckBatch({
+			directory: tempDir,
+			files: ['secrets.env'],
+		});
+
+		expect(result.secretscan.ran).toBe(true);
+		expect(result.gates_passed).toBe(false);
+		expect(result.secretscan.result).toBeDefined();
+		const secrets = result.secretscan.result as {
+			count: number;
+			findings: Array<{ type: string }>;
+		};
+		expect(secrets.count).toBeGreaterThan(0);
+		expect(secrets.findings.some((f) => f.type === 'aws_access_key')).toBe(
+			true,
+		);
+	});
+});

--- a/tests/unit/tools/pre-check-batch-secretscan-registry.test.ts
+++ b/tests/unit/tools/pre-check-batch-secretscan-registry.test.ts
@@ -3,6 +3,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { runPreCheckBatch } from '../../../src/tools/pre-check-batch';
+// _internals is the DI seam for the detector registry.
+import { _internals } from '../../../src/tools/secretscan';
+
+const { SECRET_PATTERNS } = _internals;
 
 let tempDir: string;
 
@@ -16,9 +20,112 @@ afterEach(() => {
 	fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
-describe('pre_check_batch file-scoped secretscan registry coverage', () => {
+// ---------------------------------------------------------------------------
+// Pattern-based detector types — these are registered in SECRET_PATTERNS.
+// The SecretType union also lists 'secret_token' and 'high_entropy', but:
+//   - 'secret_token' has no implementation in the codebase (not a false negative)
+//   - 'high_entropy' is a heuristic run inline inside scanLineForSecrets and
+//     does NOT appear in SECRET_PATTERNS (tested separately below)
+// ---------------------------------------------------------------------------
+const PATTERN_DETECTOR_TYPES = [
+	'api_key',
+	'aws_access_key',
+	'aws_secret_key',
+	'private_key',
+	'password',
+	'bearer_token',
+	'basic_auth',
+	'database_url',
+	'jwt',
+	'github_token',
+	'slack_token',
+	'stripe_key',
+	'sendgrid_key',
+	'twilio_key',
+	'generic_token',
+] as const;
+
+describe('secretscan registry completeness (F-006)', () => {
+	/**
+	 * F-006: Prove the full detector set is wired so a regression dropping a
+	 * non-AWS detector is caught.
+	 *
+	 * We assert the registry STRUCTURE (SECRET_PATTERNS entries) rather than
+	 * seeding real-format secrets — this avoids GitHub Push Protection
+	 * blocking the push while still giving strong coverage: if any detector is
+	 * removed from SECRET_PATTERNS the test fails immediately.
+	 */
+
+	test('SECRET_PATTERNS contains an entry for every pattern-based detector type', () => {
+		const registeredTypes = SECRET_PATTERNS.map((p) => p.type);
+		const missing = PATTERN_DETECTOR_TYPES.filter(
+			(type) => !registeredTypes.includes(type),
+		);
+		expect(missing).toEqual([]);
+	});
+
+	test('SECRET_PATTERNS has at least 15 entries (one per provider/pattern)', () => {
+		// Guards against an accidental bulk removal of detector entries.
+		expect(SECRET_PATTERNS.length).toBeGreaterThanOrEqual(15);
+	});
+
+	test('every SECRET_PATTERNS entry has a regex, confidence, severity, and redactTemplate', () => {
+		for (const pattern of SECRET_PATTERNS) {
+			expect(pattern.regex).toBeInstanceOf(RegExp);
+			expect(pattern.confidence).toMatch(/^(high|medium|low)$/);
+			expect(pattern.severity).toMatch(/^(critical|high|medium|low)$/);
+			expect(typeof pattern.redactTemplate).toBe('function');
+		}
+	});
+
+	test('no duplicate detector types in SECRET_PATTERNS', () => {
+		const types = SECRET_PATTERNS.map((p) => p.type);
+		const unique = new Set(types);
+		expect(types.length).toBe(unique.size);
+	});
+
+	test('high_entropy is NOT in SECRET_PATTERNS (it runs as inline heuristic)', () => {
+		// Verifies our understanding is correct: high_entropy is NOT a regex entry.
+		// It is implemented inside scanLineForSecrets as a Shannon-entropy fallback.
+		const entry = SECRET_PATTERNS.find((p) => p.type === 'high_entropy');
+		expect(entry).toBeUndefined();
+	});
+
+	test('high_entropy integration: random 32-char base64 string triggers high_entropy finding', async () => {
+		// Shannon entropy of a 32-char random alphanumeric string is ~4.7 bits/char
+		// (> 4.0 threshold), so this exercises the inline heuristic without
+		// seeding any real secret format. This is safe for GitHub Push Protection.
+		const highEntropyValue = '5J8mP2nK4qL9rT6wX0zA3bC7dE1fG5hJ';
+		fs.writeFileSync(
+			path.join(tempDir, 'secrets.env'),
+			`secret=${highEntropyValue}\n`,
+		);
+
+		const result = await runPreCheckBatch({
+			directory: tempDir,
+			files: ['secrets.env'],
+		});
+
+		expect(result.secretscan.ran).toBe(true);
+		expect(result.gates_passed).toBe(false);
+		const secrets = result.secretscan.result as {
+			count: number;
+			findings: Array<{ type: string }>;
+		};
+		expect(secrets.count).toBeGreaterThan(0);
+		expect(secrets.findings.some((f) => f.type === 'high_entropy')).toBe(true);
+	});
+});
+
+describe('AWS integration — end-to-end gate', () => {
+	/**
+	 * Keeps the AWS end-to-end test: proves the full pipeline works
+	 * (file with secret → runPreCheckBatch → gate fails → aws_access_key finding).
+	 * Uses AWS's documented example value which GitHub explicitly allows.
+	 */
 	test('hard-fails the gate for AWS access keys in changed files', async () => {
-		const awsAccessKey = 'AK' + 'IAIOSFODNN7EXAMPLE';
+		// AWS documentation example — GitHub Push Protection allow-lists this.
+		const awsAccessKey = 'AKIAIOSFODNN7EXAMPLE';
 		fs.writeFileSync(
 			path.join(tempDir, 'secrets.env'),
 			`AWS_ACCESS_KEY_ID=${awsAccessKey}\n`,

--- a/tests/unit/tools/pre-check-batch-secretscan-registry.test.ts
+++ b/tests/unit/tools/pre-check-batch-secretscan-registry.test.ts
@@ -149,3 +149,32 @@ describe('AWS integration — end-to-end gate', () => {
 		);
 	});
 });
+
+describe('vacuous-pass guard (F-002)', () => {
+	/**
+	 * F-002: When files are provided but ALL are excluded by extension,
+	 * files_scanned === 0. The gate must fail closed (gates_passed === false)
+	 * to prevent a vacuous pass — a scan that scanned nothing reporting success.
+	 */
+	test('fails the gate when all provided files are excluded by extension', async () => {
+		// .png is in DEFAULT_EXCLUDE_EXTENSIONS — file exists but is never scanned
+		fs.writeFileSync(
+			path.join(tempDir, 'screenshot.png'),
+			Buffer.from([0x89, 0x50, 0x4e, 0x47]), // minimal PNG header
+		);
+
+		const result = await runPreCheckBatch({
+			directory: tempDir,
+			files: ['screenshot.png'],
+		});
+
+		expect(result.secretscan.ran).toBe(true);
+		expect(result.gates_passed).toBe(false);
+		const scanResult = result.secretscan.result as {
+			files_scanned: number;
+			skipped_files: number;
+		};
+		expect(scanResult.files_scanned).toBe(0);
+		expect(scanResult.skipped_files).toBe(1);
+	});
+});

--- a/tests/unit/tools/pre-check-batch.test.ts
+++ b/tests/unit/tools/pre-check-batch.test.ts
@@ -31,6 +31,24 @@ const mockRunSecretscan = mock(async () => ({
 		scan_time_ms: 0,
 	},
 }));
+const mockRunSecretscanOnFiles = mock(
+	async (files: string[], directory: string) => {
+		const findings: Array<{ type: string; path: string; line: number }> = [];
+		for (const file of files) {
+			const content = fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : '';
+			if (/api[_-]?key|sk-[a-z0-9]/i.test(content)) {
+				findings.push({ type: 'api_key', path: file, line: 1 });
+			}
+		}
+		return {
+			scan_dir: directory,
+			findings,
+			count: findings.length,
+			files_scanned: files.length,
+			skipped_files: 0,
+		};
+	},
+);
 const mockSastScan = mock(async () => ({
 	verdict: 'pass' as const,
 	findings: [],
@@ -76,6 +94,7 @@ mock.module('../../../src/tools/lint', () => ({
 
 mock.module('../../../src/tools/secretscan', () => ({
 	runSecretscan: mockRunSecretscan,
+	runSecretscanOnFiles: mockRunSecretscanOnFiles,
 }));
 
 mock.module('../../../src/tools/sast-scan', () => ({

--- a/tests/unit/tools/sast-scan-rust.test.ts
+++ b/tests/unit/tools/sast-scan-rust.test.ts
@@ -1,0 +1,169 @@
+/**
+ * SAST Scan Tool Tests — Rust Language
+ *
+ * Focused tests for Rust security patterns:
+ * - rust-command-injection
+ * - rust-hardcoded-secret (F-005)
+ * - rust-unsafe-block (F-005)
+ *
+ * Extracted from tests/unit/tools/sast-scan.test.ts to satisfy
+ * the per-file 500-line limit (FR-006 / SC-006.1).
+ */
+
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	vi,
+} from 'bun:test';
+import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import type { PluginConfig } from '../../../src/config';
+import { resetSemgrepCache } from '../../../src/sast/semgrep';
+import type { LoadBaselineResult } from '../../../src/tools/sast-baseline';
+import { type SastScanInput, sastScan } from '../../../src/tools/sast-scan';
+
+// Mock the saveEvidence function
+vi.mock('../../../src/evidence/manager', () => ({
+	saveEvidence: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock isSemgrepAvailable to control Semgrep availability in tests
+let mockSemgrepAvailable = false;
+
+vi.mock('../../../src/sast/semgrep', () => ({
+	isSemgrepAvailable: () => mockSemgrepAvailable,
+	runSemgrep: vi.fn().mockResolvedValue({
+		available: mockSemgrepAvailable,
+		findings: [],
+		engine: 'tier_a+tier_b',
+	}),
+	resetSemgrepCache: vi.fn(),
+}));
+
+// Mock sast-baseline I/O functions so tests don't write real files.
+const mockCaptureOrMergeBaseline = mock(async () => ({
+	status: 'written' as const,
+	path: '/fake/sast-baseline.json',
+	fingerprint_count: 1,
+}));
+const mockLoadBaseline = mock(
+	(): LoadBaselineResult => ({ status: 'not_found' }),
+);
+
+mock.module('../../../src/tools/sast-baseline', () => {
+	// Spread the real module so non-I/O exports (assignOccurrenceIndices,
+	// MAX_BASELINE_FINDINGS, etc.) remain functional.
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const actual =
+		require('../../../src/tools/sast-baseline') as typeof import('../../../src/tools/sast-baseline');
+	return {
+		...actual,
+		captureOrMergeBaseline: mockCaptureOrMergeBaseline,
+		loadBaseline: mockLoadBaseline,
+	};
+});
+
+describe('sastScan — Rust language', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(tmpdir(), 'sast-rust-test-'));
+		mockSemgrepAvailable = false;
+		mockCaptureOrMergeBaseline.mockClear();
+		mockLoadBaseline.mockClear();
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		mock.restore();
+	});
+
+	it('should detect command injection in Rust files', async () => {
+		const testFile = path.join(tempDir, 'test.rs');
+		fs.writeFileSync(
+			testFile,
+			`use std::process::Command;
+fn main() {
+	let _child = Command::new("sh").arg("-c").arg(user_input).spawn();
+}`,
+		);
+
+		const input: SastScanInput = {
+			changed_files: [testFile],
+			severity_threshold: 'medium',
+		};
+
+		const result = await sastScan(input, tempDir);
+
+		expect(result.summary.files_scanned).toBe(1);
+		expect(
+			result.findings.some((f) => f.rule_id === 'sast/rust-command-injection'),
+		).toBe(true);
+	});
+
+	it('should detect hardcoded secrets in Rust files (F-005)', async () => {
+		// Seed both idiomatic forms the rule is designed to catch:
+		// - typed &str form: const API_KEY: &str = "..."
+		// - untyped let form: let api_token = "..."
+		const testFile = path.join(tempDir, 'test.rs');
+		fs.writeFileSync(
+			testFile,
+			`fn main() {
+	const API_KEY: &str = "ak_live_1234567890abcdef";
+	let api_token = "ghp_1234567890abcdefghijklmnopqrstuvwxyz";
+}`,
+		);
+
+		const input: SastScanInput = {
+			changed_files: [testFile],
+			severity_threshold: 'medium',
+		};
+
+		const result = await sastScan(input, tempDir);
+
+		expect(result.summary.files_scanned).toBe(1);
+		// Both typed &str and untyped let forms should trigger the rule
+		expect(
+			result.findings.filter((f) => f.rule_id === 'sast/rust-hardcoded-secret')
+				.length,
+		).toBeGreaterThanOrEqual(2);
+		// Verify severity is critical
+		const secretFindings = result.findings.filter(
+			(f) => f.rule_id === 'sast/rust-hardcoded-secret',
+		);
+		expect(secretFindings.length).toBeGreaterThan(0);
+		expect(secretFindings[0]?.severity).toBe('critical');
+	});
+
+	it('should detect unsafe blocks in Rust files (F-005)', async () => {
+		const testFile = path.join(tempDir, 'test.rs');
+		fs.writeFileSync(
+			testFile,
+			`fn main() {
+	unsafe { std::ptr::null::<u8>(); }
+}`,
+		);
+
+		const input: SastScanInput = {
+			changed_files: [testFile],
+			severity_threshold: 'medium',
+		};
+
+		const result = await sastScan(input, tempDir);
+
+		expect(result.summary.files_scanned).toBe(1);
+		expect(
+			result.findings.some((f) => f.rule_id === 'sast/rust-unsafe-block'),
+		).toBe(true);
+		// Verify severity is medium
+		const unsafeFinding = result.findings.find(
+			(f) => f.rule_id === 'sast/rust-unsafe-block',
+		);
+		expect(unsafeFinding?.severity).toBe('medium');
+	});
+});

--- a/tests/unit/tools/sast-scan.test.ts
+++ b/tests/unit/tools/sast-scan.test.ts
@@ -303,13 +303,14 @@ func main() {
 			).toBe(true);
 		});
 
-		it('should detect command injection in Rust files', async () => {
-			const testFile = path.join(tempDir, 'test.rs');
+		it('should detect camelCase hardcoded secrets in Go (F-001)', async () => {
+			const testFile = path.join(tempDir, 'test.go');
 			fs.writeFileSync(
 				testFile,
-				`use std::process::Command;
-fn main() {
-	let _child = Command::new("sh").arg("-c").arg(user_input).spawn();
+				`package main
+func main() {
+	apiKey := "AKIAIOSFODNN7EXAMPLE"
+	_ = apiKey
 }`,
 			);
 
@@ -320,11 +321,8 @@ fn main() {
 
 			const result = await sastScan(input, tempDir);
 
-			expect(result.summary.files_scanned).toBe(1);
 			expect(
-				result.findings.some(
-					(f) => f.rule_id === 'sast/rust-command-injection',
-				),
+				result.findings.some((f) => f.rule_id === 'sast/go-hardcoded-secret'),
 			).toBe(true);
 		});
 

--- a/tests/unit/tools/sast-scan.test.ts
+++ b/tests/unit/tools/sast-scan.test.ts
@@ -256,9 +256,7 @@ describe('sastScan', () => {
 			expect(yamlFinding).toBeDefined();
 		});
 
-		it('should scan Go files', async () => {
-			// Note: Go has nativeRuleSet: null (no native Tier-A rules) and relies on Semgrep
-			// which is not available in test env, so no findings are expected
+		it('should detect command injection in Go files', async () => {
 			const testFile = path.join(tempDir, 'test.go');
 			fs.writeFileSync(
 				testFile,
@@ -276,21 +274,20 @@ func main() {
 
 			const result = await sastScan(input, tempDir);
 
-			// Go has no native rules and Semgrep is not available in tests
-			expect(result.findings.length).toBe(0);
+			expect(result.summary.files_scanned).toBe(1);
+			expect(
+				result.findings.some((f) => f.rule_id === 'sast/go-shell-injection'),
+			).toBe(true);
 		});
 
 		it('should detect hardcoded secrets in Go', async () => {
-			// Note: Go has nativeRuleSet: null and relies on Semgrep which is not
-			// available in test env, so no findings are expected
 			const testFile = path.join(tempDir, 'test.go');
-			// Use shell injection which would be a known working pattern if rules existed
 			fs.writeFileSync(
 				testFile,
 				`package main
-import "os/exec"
 func main() {
-	cmd := exec.Command("sh", "-c", userInput)
+	secret_token := "supersecret12345"
+	_ = secret_token
 }`,
 			);
 
@@ -301,8 +298,34 @@ func main() {
 
 			const result = await sastScan(input, tempDir);
 
-			// Go has no native rules and Semgrep is not available in tests
-			expect(result.findings.length).toBe(0);
+			expect(
+				result.findings.some((f) => f.rule_id === 'sast/go-hardcoded-secret'),
+			).toBe(true);
+		});
+
+		it('should detect command injection in Rust files', async () => {
+			const testFile = path.join(tempDir, 'test.rs');
+			fs.writeFileSync(
+				testFile,
+				`use std::process::Command;
+fn main() {
+	let _child = Command::new("sh").arg("-c").arg(user_input).spawn();
+}`,
+			);
+
+			const input: SastScanInput = {
+				changed_files: [testFile],
+				severity_threshold: 'medium',
+			};
+
+			const result = await sastScan(input, tempDir);
+
+			expect(result.summary.files_scanned).toBe(1);
+			expect(
+				result.findings.some(
+					(f) => f.rule_id === 'sast/rust-command-injection',
+				),
+			).toBe(true);
 		});
 
 		it('should scan Java files', async () => {

--- a/tests/unit/tools/test-runner-dispatch-parity.test.ts
+++ b/tests/unit/tools/test-runner-dispatch-parity.test.ts
@@ -156,7 +156,7 @@ describe('detectTestFramework legacy ↔ dispatch parity', () => {
 		expect(typeof viaDispatch).toBe('string');
 	});
 
-	test('PHP project: both return "none" (PHP framework names not in TestFramework union)', async () => {
+	test('PHP project: both return "phpunit"', async () => {
 		fs.writeFileSync(
 			path.join(tempDir, 'composer.json'),
 			JSON.stringify({ name: 'x/y' }),
@@ -164,11 +164,8 @@ describe('detectTestFramework legacy ↔ dispatch parity', () => {
 		fs.writeFileSync(path.join(tempDir, 'phpunit.xml'), '<phpunit></phpunit>');
 		const legacy = await detectTestFramework(tempDir);
 		const viaDispatch = await detectTestFrameworkViaDispatch(tempDir);
-		// PHP frameworks aren't represented in the legacy TestFramework union,
-		// so legacy returns 'none'. The dispatch path collapses unmapped
-		// names to 'none' to preserve parity.
-		expect(legacy).toBe('none');
-		expect(viaDispatch).toBe('none');
+		expect(legacy).toBe('phpunit');
+		expect(viaDispatch).toBe('phpunit');
 	});
 });
 
@@ -176,7 +173,7 @@ describe('DD-C026: profile framework name ↔ dispatch map coverage', () => {
 	// Names whose test frameworks the legacy TestFramework union intentionally
 	// does not represent — `detectTestFrameworkViaDispatch` collapses them to
 	// 'none' on purpose (legacy could not detect them either).
-	const INTENTIONALLY_UNMAPPED = new Set(['unittest', 'Pest', 'PHPUnit']);
+	const INTENTIONALLY_UNMAPPED = new Set(['unittest']);
 
 	test('every profile test-framework name is either mapped or explicitly unmapped', () => {
 		const unmapped: string[] = [];

--- a/tests/unit/tools/test-runner-php.test.ts
+++ b/tests/unit/tools/test-runner-php.test.ts
@@ -60,4 +60,34 @@ describe('PHP test_runner support', () => {
 			'tests/Feature/HealthTest.php',
 		]);
 	});
+
+	test('detects Laravel (php-artisan) through legacy and dispatch paths', async () => {
+		// Laravel projects have an `artisan` file and `composer.json`
+		fs.writeFileSync(
+			path.join(tempDir, 'artisan'),
+			'#!/usr/bin/env php\n<?php\n',
+		);
+		fs.writeFileSync(
+			path.join(tempDir, 'composer.json'),
+			JSON.stringify({
+				name: 'laravel/laravel',
+				require: { 'laravel/framework': '^10.0' },
+			}),
+		);
+
+		expect(await detectTestFramework(tempDir)).toBe('php-artisan');
+		expect(await detectTestFrameworkViaDispatch(tempDir)).toBe('php-artisan');
+	});
+
+	test('detects Pest through legacy and dispatch paths', async () => {
+		// Pest projects have a Pest.php file in the project root
+		fs.writeFileSync(path.join(tempDir, 'Pest.php'), '<?php\n');
+		fs.writeFileSync(
+			path.join(tempDir, 'composer.json'),
+			JSON.stringify({ name: 'pest/pest' }),
+		);
+
+		expect(await detectTestFramework(tempDir)).toBe('pest');
+		expect(await detectTestFrameworkViaDispatch(tempDir)).toBe('pest');
+	});
 });

--- a/tests/unit/tools/test-runner-php.test.ts
+++ b/tests/unit/tools/test-runner-php.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { clearDispatchCache } from '../../../src/lang/dispatch';
+import {
+	buildTestCommandViaDispatch,
+	detectTestFramework,
+	detectTestFrameworkViaDispatch,
+} from '../../../src/tools/test-runner';
+
+let tempDir: string;
+
+beforeEach(() => {
+	clearDispatchCache();
+	tempDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'test-runner-php-')),
+	);
+});
+
+afterEach(() => {
+	fs.rmSync(tempDir, { recursive: true, force: true });
+	clearDispatchCache();
+});
+
+describe('PHP test_runner support', () => {
+	test('detects PHPUnit through legacy and dispatch paths', async () => {
+		fs.writeFileSync(
+			path.join(tempDir, 'composer.json'),
+			JSON.stringify({ name: 'acme/app' }),
+		);
+		fs.writeFileSync(path.join(tempDir, 'phpunit.xml'), '<phpunit />');
+
+		expect(await detectTestFramework(tempDir)).toBe('phpunit');
+		expect(await detectTestFrameworkViaDispatch(tempDir)).toBe('phpunit');
+	});
+
+	test('builds file-scoped PHPUnit commands through dispatch', async () => {
+		fs.writeFileSync(
+			path.join(tempDir, 'composer.json'),
+			JSON.stringify({ name: 'acme/app' }),
+		);
+		fs.writeFileSync(path.join(tempDir, 'phpunit.xml'), '<phpunit />');
+
+		const cmd = await buildTestCommandViaDispatch(
+			'phpunit',
+			'convention',
+			['tests/Feature/HealthTest.php'],
+			false,
+			tempDir,
+			false,
+		);
+
+		expect(cmd).toEqual([
+			path.join(
+				'vendor',
+				'bin',
+				process.platform === 'win32' ? 'phpunit.bat' : 'phpunit',
+			),
+			'tests/Feature/HealthTest.php',
+		]);
+	});
+});

--- a/tests/unit/tools/test-runner-wiring-adversarial.test.ts
+++ b/tests/unit/tools/test-runner-wiring-adversarial.test.ts
@@ -425,6 +425,11 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 					'gradlew',
 					'gradlew.bat',
 					'spec',
+					'composer.json',
+					'phpunit.xml',
+					'artisan',
+					'Pest.php',
+					'pest.php',
 				];
 				const isFrameworkMarker = frameworkMarkers.some((marker) =>
 					pathStr.endsWith(marker),

--- a/tests/unit/tools/test-runner-wiring.test.ts
+++ b/tests/unit/tools/test-runner-wiring.test.ts
@@ -69,8 +69,8 @@ describe('Group 1: SUPPORTED_FRAMEWORKS constant', () => {
 		}
 	});
 
-	it('has 16 total frameworks (7 original + 9 new)', () => {
-		expect(SUPPORTED_FRAMEWORKS).toHaveLength(16);
+	it('has 19 total frameworks (7 original + 12 new)', () => {
+		expect(SUPPORTED_FRAMEWORKS).toHaveLength(19);
 	});
 
 	it('all values are distinct (no duplicates)', () => {


### PR DESCRIPTION
Closes #1689

## Summary
- Wired missing quality-gate coverage for Go/Rust SAST, file-scoped pre_check_batch secretscan, PHP test/lint flows, and language profile build priority.
- Reused the full secretscan detector registry for changed-file prechecks instead of maintaining a weaker inline scanner.
- Updated regression coverage, including the full legacy tests/unit/tools/test-runner.test.ts guard cases that previously timed out or asserted stale scope-all behavior.

## Invariant audit
- 1 (plugin init): not touched - no src/index.ts, package entry, or init-path change; node scripts/repro-704.mjs passed T1 in 162.9ms, T2 in 87.3ms, T3 in 77.4ms.
- 2 (runtime portability): touched - source changes are in bundled runtime paths; bun run build passed and node --input-type=module -e "await import('./dist/index.js')" passed.
- 3 (subprocesses): touched - PHP/linter/test command construction changed, but the changed-file spawn audit found no bunSpawn/spawn/spawnSync calls; command arrays are covered by tests/unit/tools/test-runner-php.test.ts and tests/unit/tools/lint-detectors.test.ts.
- 4 (.swarm containment): not touched - no runtime state path behavior changed.
- 5 (plan durability): not touched - no plan ledger, projection, import/export, or plan schema changes.
- 6 (test_runner safety): touched - tests/unit/tools/test-runner.test.ts now covers PHP source mapping and current SWARM_ALLOW_FULL_SUITE behavior; full file passed with 123 pass, 4 skip, 0 fail.
- 7 (test writing): touched - writing-tests guidance was loaded; new tests use bun:test and are under 500 lines (43 and 63 lines).
- 8 (session state): not touched - no session/global tracking state changed.
- 9 (guardrails/retry): not touched - no guardrail, retry, or transient-error code changed.
- 10 (chat/system msg): not touched - no chat/system-message hook code changed.
- 11 (tool registration): not touched - no tool exports, TOOL_NAMES, agent maps, or src/index.ts tool registration changed; bun run drift:check reported no drift.
- 12 (release/cache): touched - added docs/releases/pending/1689-quality-gate-language-coverage.md; package.json version, CHANGELOG.md, and .release-please-manifest.json were not modified.

## Test plan
- [x] bun test tests/unit/tools/test-runner.test.ts --timeout 60000
- [x] bun test tests/unit/tools/pre-check-batch-secretscan-registry.test.ts --timeout 60000
- [x] bun test tests/unit/tools/sast-scan.test.ts tests/unit/sast/rules.test.ts --timeout 60000
- [x] bun test tests/unit/tools/pre-check-batch-secretscan-registry.test.ts tests/unit/tools/pre-check-batch.test.ts --timeout 60000
- [x] bun test tests/unit/tools/test-runner-php.test.ts --timeout 60000
- [x] bun test tests/unit/tools/lint-detectors.test.ts --timeout 60000
- [x] bun test tests/unit/tools/test-runner-dispatch-parity.test.ts --timeout 60000
- [x] bun test tests/unit/build/discovery-profiles.test.ts --timeout 60000
- [x] bun run check
- [x] bun run typecheck
- [x] bun run drift:check
- [x] bun run build
- [x] node scripts/repro-704.mjs
- [x] node --input-type=module -e "await import('./dist/index.js')"
- [x] git diff --check
- [x] git diff --cached --check
- [x] git diff --cached --unified=0 | Select-String -Pattern '^\+.*(sk_live|ghp_|xox[abprs]-|AKIA|eyJ|AIza)'

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

