### PR TITLE
fix(guardrails): scope-exempt git worktree remove --force for swarm-managed worktrees

### DIFF
--- a/docs/releases/pending/1708-worktree-remove-force-scope-exemption.md
+++ b/docs/releases/pending/1708-worktree-remove-force-scope-exemption.md
@@ -1,0 +1,47 @@
+# Unblock legitimate `git worktree remove --force` cleanup (#1708)
+
+Phase 0 of the full-auto/sandbox epic (#1707). A legitimate `git worktree remove --force <path>`
+was hard-blocked unconditionally by the destructive-command guard, even when the target was a
+swarm-managed worktree — a guaranteed false positive, since git requires `--force` to remove any
+worktree with uncommitted/untracked content (the normal state of an abandoned worktree awaiting
+cleanup). Separately, swarm's own internal cleanup silently abandoned worktrees that failed
+non-forced removal (observed as Windows `EBUSY`/`EPERM`), leaking them on disk indefinitely.
+
+## Changes
+
+- **Scope-aware guard for `git worktree remove --force`** (`src/hooks/guardrails/tool-before.ts`):
+  the guard now parses the target path (handling `--force`/`-f` before or after the path, quoted
+  or unquoted, and git's accepted abbreviation/stacking forms like `--forc`/`-ff`), canonicalizes
+  it via `fs.realpathSync`, and allows the command only when the resolved target is inside the
+  swarm-managed worktree base directory or a coder's declared scope — mirroring the existing
+  `rsync --delete` exemption in the same function. Any other target, or a target that can't be
+  parsed or resolved, is still hard-blocked (fail closed).
+- **New shared helpers** (`src/worktree/core.ts`): `resolveWorktreeBaseDir()` and
+  `isPathUnderSwarmWorktreeBase()` compute and check containment against the swarm worktree base
+  (`config.worktree_dir` when set, else the default `<project-parent>/.swarm-worktrees/`), reused
+  by both the guard and the internal cleanup path so they agree on what counts as swarm-managed.
+- **Opt-in `--force` fallback in `removeWorktree()`** (`src/worktree/core.ts`): after non-forced
+  removal attempts are exhausted, an opt-in `{ force: true }` option retries once with `--force` —
+  restricted to targets inside the swarm worktree base; default (non-opt-in) behavior is unchanged.
+  Wired into all four of swarm's own cleanup call sites (session-create-failure rollback,
+  successful merge-back cleanup, and error-exit/shutdown lane cleanup in Lean Turbo), so genuinely
+  stale in-root worktrees are now actually reclaimed instead of silently leaked.
+
+## Migration
+
+No migration required. This only affects `git worktree remove --force` invocations made through
+the guarded bash/shell tool path, and swarm's own internal worktree cleanup.
+
+## Known caveats
+
+- The `declaredScope` exemption path (shared with the pre-existing `rsync --delete` exemption)
+  does not canonicalize/realpath its target the way the new worktree-base check does — this is an
+  existing, not newly-introduced, gap. A follow-up could harden both exemptions symmetrically.
+- The swarm worktree base directory is always trusted even when a custom `worktree_dir` override
+  is configured (in addition to the override), so a deployment that relocates worktrees away from
+  the default location cannot fully de-trust that default path. Low-risk: it only affects
+  force-removal of git-registered worktrees.
+- `resolveWorktreeBaseDir()` does not reject a `worktree_dir` config value containing `..`
+  traversal or an absolute path that escapes the project tree; this mirrors pre-existing behavior
+  in `provisionWorktree()` and is a configuration footgun (not attacker-controlled), tracked as a
+  follow-up.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -137,3 +137,7 @@ export {
 	SwarmSpecSchema,
 	validateSpecContent,
 } from './spec-schema';
+
+// Worktree-isolation config resolver — lives in this leaf module (no heavy
+// worktree runtime imports) so the plugin entry can call it during init.
+export { resolveWorktreeIsolationConfig } from './worktree-isolation-config';

--- a/src/config/worktree-isolation-config.ts
+++ b/src/config/worktree-isolation-config.ts
@@ -1,0 +1,33 @@
+import { DEFAULT_WORKTREE_ISOLATION_CONFIG } from './constants';
+import type { PluginConfig, WorktreeIsolationConfig } from './schema';
+
+/**
+ * Pure config helper that resolves the worktree-isolation configuration
+ * from a PluginConfig. Lives in this leaf module (no heavy imports) so
+ * the plugin entry (src/index.ts) can call it during init without
+ * pulling in the worktree lifecycle module.
+ *
+ * @see tests/unit/turbo/lean/init-safety.test.ts (static source check)
+ */
+export function resolveWorktreeIsolationConfig(
+	config: PluginConfig,
+): WorktreeIsolationConfig {
+	if (config.worktree) {
+		return { ...DEFAULT_WORKTREE_ISOLATION_CONFIG, ...config.worktree };
+	}
+	const lean =
+		config.turbo?.strategy === 'lean' ? config.turbo.lean : undefined;
+	if (lean?.worktree_isolation) {
+		return {
+			...DEFAULT_WORKTREE_ISOLATION_CONFIG,
+			policy: 'auto',
+			merge_strategy: lean.merge_strategy ?? 'merge',
+			worktree_dir: lean.worktree_dir,
+			deps_strategy: lean.deps_strategy ?? 'skip',
+			runtime_isolation:
+				lean.runtime_isolation ??
+				DEFAULT_WORKTREE_ISOLATION_CONFIG.runtime_isolation,
+		};
+	}
+	return DEFAULT_WORKTREE_ISOLATION_CONFIG;
+}

--- a/src/hooks/delegation-gate/worktree-isolation.ts
+++ b/src/hooks/delegation-gate/worktree-isolation.ts
@@ -385,28 +385,8 @@ export function sanitizeWorktreeTaskId(raw: string): string {
 	return sanitized || 'task';
 }
 
-export function resolveWorktreeIsolationConfig(
-	config: PluginConfig,
-): WorktreeIsolationConfig {
-	if (config.worktree) {
-		return { ...DEFAULT_WORKTREE_ISOLATION_CONFIG, ...config.worktree };
-	}
-	const lean =
-		config.turbo?.strategy === 'lean' ? config.turbo.lean : undefined;
-	if (lean?.worktree_isolation) {
-		return {
-			...DEFAULT_WORKTREE_ISOLATION_CONFIG,
-			policy: 'auto',
-			merge_strategy: lean.merge_strategy ?? 'merge',
-			worktree_dir: lean.worktree_dir,
-			deps_strategy: lean.deps_strategy ?? 'skip',
-			runtime_isolation:
-				lean.runtime_isolation ??
-				DEFAULT_WORKTREE_ISOLATION_CONFIG.runtime_isolation,
-		};
-	}
-	return DEFAULT_WORKTREE_ISOLATION_CONFIG;
-}
+import { resolveWorktreeIsolationConfig } from '../../config/worktree-isolation-config';
+export { resolveWorktreeIsolationConfig };
 
 export async function precreateStandardWorktreeSession(args: {
 	config: PluginConfig;

--- a/src/hooks/delegation-gate/worktree-isolation.ts
+++ b/src/hooks/delegation-gate/worktree-isolation.ts
@@ -155,6 +155,8 @@ export interface StandardWorktreeDispatch {
 	mergeStrategy: 'merge' | 'rebase' | 'cherry-pick';
 	/** FR-201: 0-based lane index for runtime profile derivation. */
 	laneIndex: number;
+	/** Configured worktree-dir override, so cleanup trusts the same base. */
+	worktree_dir?: string;
 }
 
 export interface AwaitingMergeRecord {
@@ -564,7 +566,10 @@ export async function precreateStandardWorktreeSession(args: {
 	});
 	if (!createResult.data?.id) {
 		await _internals
-			.removeWorktree(provisionResult.worktreePath, args.directory)
+			.removeWorktree(provisionResult.worktreePath, args.directory, {
+				force: true,
+				worktreeDir: worktreeConfig.worktree_dir,
+			})
 			.catch(() => {});
 		const createError = (createResult as { error?: unknown }).error;
 		const detail =
@@ -589,6 +594,7 @@ export async function precreateStandardWorktreeSession(args: {
 		handle: provisionResult,
 		mergeStrategy: worktreeConfig.merge_strategy,
 		laneIndex,
+		worktree_dir: worktreeConfig.worktree_dir,
 	});
 }
 
@@ -642,7 +648,10 @@ export async function finishStandardWorktreeDispatch(
 			}
 
 			await _internals
-				.removeWorktree(dispatch.handle.worktreePath, directory)
+				.removeWorktree(dispatch.handle.worktreePath, directory, {
+					force: true,
+					worktreeDir: dispatch.worktree_dir,
+				})
 				.catch(() => {});
 			await _internals
 				.postMergeCleanup(directory, dispatch.handle.branchName)

--- a/src/hooks/guardrails/index.ts
+++ b/src/hooks/guardrails/index.ts
@@ -401,6 +401,7 @@ export function createGuardrailsHooks(
 	directoryOrConfig?: string | GuardrailsConfig,
 	config?: GuardrailsConfig,
 	authorityConfig?: AuthorityConfig,
+	worktreeBaseDirOverrides?: string[],
 ): {
 	toolBefore: (
 		input: { tool: string; sessionID: string; callID: string },
@@ -518,6 +519,7 @@ export function createGuardrailsHooks(
 		interpreterAllowedAgents,
 		authorityConfig,
 		consecutiveNoToolTurns,
+		worktreeBaseDirOverrides,
 	});
 
 	// Create messagesTransform handler via factory

--- a/src/hooks/guardrails/tool-before.ts
+++ b/src/hooks/guardrails/tool-before.ts
@@ -33,6 +33,7 @@ import {
 } from '../../state';
 import { telemetry } from '../../telemetry.js';
 import { warn } from '../../utils';
+import { isPathUnderSwarmWorktreeBase } from '../../worktree/core.js';
 import { pendingCoderScopeByTaskId } from '../delegation-gate.js';
 import { detectLoop } from '../loop-detector';
 import { normalizeToolName } from '../normalize-tool-name';
@@ -87,6 +88,11 @@ export interface ToolBeforeContext {
 	authorityConfig: AuthorityConfig | undefined;
 	/** Shared consecutiveNoToolTurns Map (also used by messagesTransform) */
 	consecutiveNoToolTurns: Map<string, number>;
+	/**
+	 * Configured swarm worktree-dir override(s), if any. Treated as additional
+	 * trusted roots when exempting `git worktree remove --force` (issue #1708).
+	 */
+	worktreeBaseDirOverrides?: string[];
 }
 
 // Shared helper functions extracted to helpers.ts (task 1.4 / FR-005)
@@ -119,6 +125,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		interpreterAllowedAgents,
 		authorityConfig,
 		consecutiveNoToolTurns,
+		worktreeBaseDirOverrides,
 	} = ctx;
 
 	/**
@@ -453,10 +460,68 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 					`BLOCKED: "git clean -fd" detected — permanently deletes untracked files and directories`,
 				);
 			}
-			if (/^git\s+worktree\s+remove\s+.*--force\b/i.test(seg)) {
-				throw new Error(
-					`BLOCKED: "git worktree remove --force" detected — can delete working tree contents`,
+			// git worktree remove --force: scope-exempt when the target resolves inside
+			// the swarm-managed worktree base directory or a coder's declared scope.
+			// Mirrors the rsync --delete scopeExempt pattern below. Unlike rsync, this
+			// call path often runs with no declared coder scope (orchestrator/cleanup),
+			// so the swarm worktree base directory is also a trusted root — see
+			// isPathUnderSwarmWorktreeBase in src/worktree/core.ts.
+			const worktreeRemoveMatch = /^git\s+worktree\s+remove\s+(.+)$/i.exec(seg);
+			if (worktreeRemoveMatch) {
+				const rawArgs = worktreeRemoveMatch[1]
+					.trim()
+					.split(/\s+/)
+					.filter(Boolean);
+				// Strip a single surrounding quote pair from every token BEFORE the
+				// force check. A real shell strips these quotes before git ever sees
+				// the args, so `git worktree remove "--force" <path>` is executed by
+				// git exactly as `--force`. dcNormalizeCommand only collapses *doubled*
+				// quotes, not a single surrounding pair, so `"--force"`/`'--force'`
+				// reach us with quotes attached. Without this normalization the exact
+				// force check below fails and the entire containment guard is skipped —
+				// a bypass. (Mirrors the quote-stripping already done on the path arg.)
+				const normalizedArgs = rawArgs.map((a) =>
+					a.replace(/^["']|["']$/g, ''),
 				);
+				// Recognize the force flag spellings git actually honors, so no
+				// abbreviation slips past the containment check:
+				//   - short form: -f and stacked repeats (-ff, -fff, …) → /^-f+$/
+				//   - long form: any non-empty prefix of --force that is longer than
+				//     the bare "--" end-of-options marker (--f, --fo, --for, --forc,
+				//     --force) → length > 2 && '--force'.startsWith(token)
+				// Case-insensitive to preserve the prior /i regex's behavior (an
+				// uppercase "--FORCE" evasion attempt is still treated as force intent).
+				const isForceToken = (a: string): boolean => {
+					const lower = a.toLowerCase();
+					return (
+						/^-f+$/.test(lower) ||
+						(lower.length > 2 && '--force'.startsWith(lower))
+					);
+				};
+				const hasForce = normalizedArgs.some(isForceToken);
+				if (hasForce) {
+					// Every force spelling (isForceToken) begins with '-', so the
+					// leading-dash filter already excludes them along with any other
+					// flag; positional path args are what remain.
+					const pathArgs = normalizedArgs.filter((a) => !a.startsWith('-'));
+					const target = pathArgs.length === 1 ? pathArgs[0].trim() : null;
+					const scopeExempt =
+						target != null &&
+						target.length > 0 &&
+						((declaredScope != null &&
+							declaredScope.length > 0 &&
+							isInDeclaredScope(target, declaredScope, cwd)) ||
+							isPathUnderSwarmWorktreeBase(
+								target,
+								cwd,
+								worktreeBaseDirOverrides ?? [],
+							));
+					if (!scopeExempt) {
+						throw new Error(
+							`BLOCKED: "git worktree remove --force" detected — can delete working tree contents`,
+						);
+					}
+				}
 			}
 
 			// rsync mirror / sync with delete

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ import { createContextCapsuleInjectHook } from './hooks/context-capsule-inject.j
 import { createDarkMatterDetectorHook } from './hooks/dark-matter-detector.js';
 import { collectDelegateAcksAfter } from './hooks/delegate-ack-collector.js';
 import { injectDelegateDirectivesBefore } from './hooks/delegate-directive-injection.js';
+import { resolveWorktreeIsolationConfig } from './hooks/delegation-gate/worktree-isolation.js';
 import { createDelegationLedgerHook } from './hooks/delegation-ledger.js';
 import { createFullAutoDelegationHook } from './hooks/full-auto-delegation.js';
 import { createFullAutoInputProbeHook } from './hooks/full-auto-input-probe.js';
@@ -737,11 +738,17 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 		guardrailsConfig.enabled,
 	);
 	const authorityConfig = AuthorityConfigSchema.parse(config.authority ?? {});
+	const worktreeDirOverride =
+		resolveWorktreeIsolationConfig(config).worktree_dir;
+	const worktreeBaseDirOverrides = worktreeDirOverride
+		? [worktreeDirOverride]
+		: [];
 	const guardrailsHooks = createGuardrailsHooks(
 		ctx.directory,
 		undefined,
 		guardrailsConfig,
 		authorityConfig,
+		worktreeBaseDirOverrides,
 	);
 
 	// Full-auto intercept: autonomous oversight when full-auto mode is active

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { COMMAND_REGISTRY, VALID_COMMANDS } from './commands/registry.js';
 import { loadPluginConfigWithMetaAsync } from './config';
 import { syncBundledProjectSkillsIfMissingAsync } from './config/bundled-skills.js';
 import { DEFAULT_MODELS, ORCHESTRATOR_NAME } from './config/constants';
+import { resolveWorktreeIsolationConfig } from './config/index.js';
 import {
 	writeProjectConfigIfNew,
 	writeSwarmConfigExampleIfNew,
@@ -80,7 +81,6 @@ import { createContextCapsuleInjectHook } from './hooks/context-capsule-inject.j
 import { createDarkMatterDetectorHook } from './hooks/dark-matter-detector.js';
 import { collectDelegateAcksAfter } from './hooks/delegate-ack-collector.js';
 import { injectDelegateDirectivesBefore } from './hooks/delegate-directive-injection.js';
-import { resolveWorktreeIsolationConfig } from './hooks/delegation-gate/worktree-isolation.js';
 import { createDelegationLedgerHook } from './hooks/delegation-ledger.js';
 import { createFullAutoDelegationHook } from './hooks/full-auto-delegation.js';
 import { createFullAutoInputProbeHook } from './hooks/full-auto-input-probe.js';

--- a/src/turbo/lean/runner.ts
+++ b/src/turbo/lean/runner.ts
@@ -827,6 +827,7 @@ export class LeanTurboRunner {
 					await LeanTurboRunner._internals.removeWorktree(
 						lane.worktreePath,
 						this._directory,
+						{ force: true, worktreeDir: this._leanConfig?.worktree_dir },
 					);
 				} catch {
 					// Best-effort cleanup
@@ -1451,6 +1452,7 @@ export class LeanTurboRunner {
 				await LeanTurboRunner._internals.removeWorktree(
 					laneInState.worktreePath,
 					this._directory,
+					{ force: true, worktreeDir: leanConfig.worktree_dir },
 				);
 			} catch {
 				// Best-effort cleanup

--- a/src/worktree/core.ts
+++ b/src/worktree/core.ts
@@ -481,6 +481,7 @@ export function makeWorktreeBranchName(
  * @param options   - Worktree purpose, branch naming, and path options.
  * @returns A worktree handle on success, or `{ error: string }` on failure.
  */
+
 /**
  * Resolves the swarm-managed worktree base directory: `directory/worktreeDir`
  * when an override is configured, otherwise the DD-6 default

--- a/src/worktree/core.ts
+++ b/src/worktree/core.ts
@@ -481,6 +481,78 @@ export function makeWorktreeBranchName(
  * @param options   - Worktree purpose, branch naming, and path options.
  * @returns A worktree handle on success, or `{ error: string }` on failure.
  */
+/**
+ * Resolves the swarm-managed worktree base directory: `directory/worktreeDir`
+ * when an override is configured, otherwise the DD-6 default
+ * `<project-parent>/.swarm-worktrees`. Shared by `provisionWorktree` (path
+ * construction) and the destructive-command guard / removeWorktree force
+ * fallback (containment checks) so both sides agree on what counts as
+ * "swarm-managed".
+ *
+ * @param directory   - Project root (an absolute path to the git working tree).
+ * @param worktreeDir - Optional worktree-dir override (relative to `directory`
+ *                      or absolute). When absent, the DD-6 default base is used.
+ * @returns The absolute worktree base directory.
+ */
+export function resolveWorktreeBaseDir(
+	directory: string,
+	worktreeDir?: string,
+): string {
+	return worktreeDir
+		? path.resolve(directory, worktreeDir)
+		: path.resolve(path.dirname(directory), '.swarm-worktrees');
+}
+
+/**
+ * Checks whether `targetPath` is contained within the swarm-managed worktree
+ * base directory (default base, plus any `worktreeDirOverrides`), using
+ * `fs.realpathSync` on both sides to resolve symlinks/junctions before the
+ * containment comparison — this both establishes containment AND defeats a
+ * symlink/junction escape in one step. Fails closed (returns false) if the
+ * target cannot be resolved (e.g. does not exist, or a permission error).
+ * Case-insensitive comparison on Windows, matching `isInDeclaredScope` in
+ * `src/hooks/guardrails/helpers.ts`.
+ *
+ * @param targetPath           - Path to check (relative to `directory` or absolute).
+ * @param directory            - Project root, used to resolve relative targets
+ *                               and the default base.
+ * @param worktreeDirOverrides - Additional configured worktree-dir overrides
+ *                               whose resolved bases are also treated as trusted.
+ * @returns `true` when the resolved target is inside a trusted base, else `false`.
+ */
+export function isPathUnderSwarmWorktreeBase(
+	targetPath: string,
+	directory: string,
+	worktreeDirOverrides: string[] = [],
+): boolean {
+	const caseInsensitive = process.platform === 'win32';
+	let realTarget: string;
+	try {
+		realTarget = fs.realpathSync(path.resolve(directory, targetPath));
+	} catch {
+		return false;
+	}
+	const bases = [
+		resolveWorktreeBaseDir(directory),
+		...worktreeDirOverrides.map((d) => resolveWorktreeBaseDir(directory, d)),
+	];
+	const cmpTarget = caseInsensitive ? realTarget.toLowerCase() : realTarget;
+	return bases.some((base) => {
+		let realBase: string;
+		try {
+			realBase = fs.realpathSync(base);
+		} catch {
+			// Base may not exist yet (e.g. no worktrees created) — fall back to
+			// the literal resolved path.
+			realBase = path.resolve(base);
+		}
+		const cmpBase = caseInsensitive ? realBase.toLowerCase() : realBase;
+		if (cmpTarget === cmpBase) return true;
+		const rel = path.relative(cmpBase, cmpTarget);
+		return rel.length > 0 && !rel.startsWith('..') && !path.isAbsolute(rel);
+	});
+}
+
 export async function provisionWorktree(
 	directory: string,
 	id: string,
@@ -490,9 +562,11 @@ export async function provisionWorktree(
 	const branchName = makeWorktreeBranchName(sessionId, id, options);
 
 	// Resolve worktree path: explicit config or DD-6 default
-	let worktreePath = options.worktreeDir
-		? path.resolve(directory, options.worktreeDir, sessionId, id)
-		: path.resolve(path.dirname(directory), '.swarm-worktrees', sessionId, id);
+	let worktreePath = path.resolve(
+		resolveWorktreeBaseDir(directory, options.worktreeDir),
+		sessionId,
+		id,
+	);
 
 	// Windows path budget check (DD-8)
 	const budgetResult = await checkPathBudget(worktreePath, directory);
@@ -727,23 +801,40 @@ export async function provisionWorktree(
 }
 
 /**
- * Removes a git worktree **without** `--force`.
+ * Removes a git worktree, **without** `--force` by default.
  *
  * On Windows (`process.platform === 'win32'`), retries up to 3 times with a
  * 2-second delay when the error contains `EBUSY` or `EPERM` (DD-10). After
  * exhausting retries the worktree is abandoned — the function returns an
  * error but does NOT throw.
  *
- * @param worktreePath - Absolute path to the worktree directory to remove.
- * @param projectRoot  - Absolute path to the project root (a git repository)
- *                       used as `cwd` for the `git worktree remove` command.
- *                       Required because the worktree's parent directory may
- *                       not itself be a git repository.
+ * When `options.force` is set, the removal is escalated (issue #1708): if the
+ * default non-forced removal gives up (either a non-retryable error such as the
+ * "contains modified or untracked files, use --force" message on the first
+ * attempt, or EBUSY/EPERM retries exhausted on Windows), a single
+ * `git worktree remove --force` is attempted — but ONLY when `worktreePath`
+ * resolves inside the swarm-managed worktree base directory
+ * (`isPathUnderSwarmWorktreeBase`). A path outside that trusted base is NEVER
+ * force-removed even if `force` is requested. When `force` is not set, behavior
+ * is unchanged (non-force only; returns an error, does not throw, on exhaustion).
+ *
+ * @param worktreePath        - Absolute path to the worktree directory to remove.
+ * @param projectRoot         - Absolute path to the project root (a git repository)
+ *                              used as `cwd` for the `git worktree remove` command.
+ *                              Required because the worktree's parent directory may
+ *                              not itself be a git repository.
+ * @param options             - Optional escalation controls.
+ * @param options.force       - When true, opt into the forced-fallback removal
+ *                              described above (scoped to the trusted base).
+ * @param options.worktreeDir - The configured worktree-dir override, if any, so
+ *                              the containment check trusts the same base
+ *                              `provisionWorktree` used.
  * @returns `{ success: true }` on success or `{ error: string }` on failure.
  */
 export async function removeWorktree(
 	worktreePath: string,
 	projectRoot: string,
+	options?: { force?: boolean; worktreeDir?: string },
 ): Promise<RemoveSuccess | RemoveFailure> {
 	const isWindows = _internals.platform === 'win32';
 	const MAX_RETRIES = 4;
@@ -773,7 +864,31 @@ export async function removeWorktree(
 			continue;
 		}
 
-		// Non-retryable error or final attempt exhausted
+		// Non-retryable error or final attempt exhausted. This is the single
+		// reachable give-up point (the post-loop return below is unreachable
+		// because attempt 3 hits `attempt < MAX_RETRIES - 1` === false and
+		// returns here). Opt-in force fallback (issue #1708): escalate to a
+		// single `--force` removal, but ONLY when the target resolves inside the
+		// trusted swarm worktree base. Never force-remove a path outside it.
+		if (
+			options?.force &&
+			isPathUnderSwarmWorktreeBase(
+				worktreePath,
+				projectRoot,
+				options.worktreeDir ? [options.worktreeDir] : [],
+			)
+		) {
+			const forced = await runGit(
+				['worktree', 'remove', '--force', worktreePath],
+				projectRoot,
+			);
+			if (forced.exitCode === 0) {
+				return { success: true };
+			}
+			// Surface the force attempt's own failure, not the stale lastError.
+			return { error: forced.stderr.trim() || forced.stdout.trim() };
+		}
+
 		return { error: lastError };
 	}
 

--- a/src/worktree/index.ts
+++ b/src/worktree/index.ts
@@ -17,9 +17,11 @@ export {
 	checkPathBudget,
 	cleanUntrackedFiles,
 	isCleanWorktree,
+	isPathUnderSwarmWorktreeBase,
 	makeWorktreeBranchName,
 	provisionWorktree,
 	removeWorktree,
+	resolveWorktreeBaseDir,
 	shortenWorktreePath,
 } from './core';
 export type {

--- a/tests/unit/hooks/guardrails-swarm-path-guard.test.ts
+++ b/tests/unit/hooks/guardrails-swarm-path-guard.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, realpathSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { GuardrailsConfig } from '../../../src/config/schema';
 import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
 import { resetSwarmState, startAgentSession } from '../../../src/state';
@@ -569,7 +569,7 @@ describe('destructive command guard - .swarm path protection (sections 16-21)', 
 
 	// ============================================================
 	// Section 22: Git clean -fd and worktree remove --force
-	// (Already covered by existing tests; just verify no regression)
+	// (issue #1708: worktree remove --force is now scope-exempt)
 	// ============================================================
 	describe('Section 22: Git clean -fd and worktree remove (regression)', () => {
 		test('git clean -fd → BLOCKED', async () => {
@@ -582,17 +582,293 @@ describe('destructive command guard - .swarm path protection (sections 16-21)', 
 			);
 		});
 
-		test('git worktree remove --force → BLOCKED', async () => {
+		// --- issue #1708: other git destructive patterns stay hard-blocked ---
+		test('git reset --hard → BLOCKED (unchanged)', async () => {
 			const config = defaultConfig();
 			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
-			const input = makeBashInput(
-				'test-session',
-				'git worktree remove --force',
+			const input = makeBashInput('test-session', 'git reset --hard');
+			const output = makeBashOutput('git reset --hard HEAD~1');
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/git reset --hard.*detected/,
 			);
-			const output = makeBashOutput('git worktree remove --force');
+		});
+
+		test('git reset --mixed <target> → BLOCKED (unchanged)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'git reset --mixed HEAD~1');
+			const output = makeBashOutput('git reset --mixed HEAD~1');
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/git reset --mixed.*not allowed/,
+			);
+		});
+
+		test('git push --force → BLOCKED (unchanged)', async () => {
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const input = makeBashInput('test-session', 'git push --force');
+			const output = makeBashOutput('git push --force origin main');
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/Force push detected/,
+			);
+		});
+	});
+
+	// ============================================================
+	// Section 22b: git worktree remove --force scope-exemption (#1708)
+	// ============================================================
+	describe('Section 22b: git worktree remove --force scope-exemption (#1708)', () => {
+		/** Creates a fresh worktree base dir + an in-base worktree that exists on disk. */
+		function makeWorktreeFixture(): { base: string; worktreePath: string } {
+			const base = realpathSync(mkdtempSync(join(tmpdir(), 'wt-base-')));
+			const worktreePath = join(base, 'sess', 'lane-1');
+			mkdirSync(worktreePath, { recursive: true });
+			return { base, worktreePath };
+		}
+
+		test('--force before path, target under configured worktree base → ALLOWED', async () => {
+			const { base, worktreePath } = makeWorktreeFixture();
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[base],
+			);
+			const cmd = `git worktree remove --force ${worktreePath}`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+
+		test('--force after path, target under configured worktree base → ALLOWED', async () => {
+			const { base, worktreePath } = makeWorktreeFixture();
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[base],
+			);
+			const cmd = `git worktree remove ${worktreePath} --force`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+
+		test('-f short flag, target under configured worktree base → ALLOWED', async () => {
+			const { base, worktreePath } = makeWorktreeFixture();
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[base],
+			);
+			const cmd = `git worktree remove -f ${worktreePath}`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+
+		test('--force on path OUTSIDE the worktree base (e.g. src/) → BLOCKED', async () => {
+			const { base } = makeWorktreeFixture();
+			const outside = join(TEST_DIR, 'src');
+			mkdirSync(outside, { recursive: true });
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[base],
+			);
+			const cmd = `git worktree remove --force ${outside}`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
 			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
 				/git worktree remove --force.*detected/,
 			);
+		});
+
+		test('--force on an in-base symlink/junction that resolves OUTSIDE → BLOCKED (fail closed)', async () => {
+			const { base } = makeWorktreeFixture();
+			const outsideReal = realpathSync(
+				mkdtempSync(join(tmpdir(), 'wt-escape-')),
+			);
+			const link = join(base, 'sess', 'escape-link');
+			mkdirSync(dirname(link), { recursive: true });
+			// 'junction' type is creatable by non-admin users on Windows and is
+			// ignored (dir symlink) on POSIX.
+			symlinkSync(outsideReal, link, 'junction');
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[base],
+			);
+			const cmd = `git worktree remove --force ${link}`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/git worktree remove --force.*detected/,
+			);
+		});
+
+		test('--force with NO target → BLOCKED (unparseable, fail closed)', async () => {
+			const { base } = makeWorktreeFixture();
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[base],
+			);
+			const cmd = 'git worktree remove --force';
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/git worktree remove --force.*detected/,
+			);
+		});
+
+		test('--force with TWO positional targets → BLOCKED (ambiguous, fail closed)', async () => {
+			const { base, worktreePath } = makeWorktreeFixture();
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[base],
+			);
+			const cmd = `git worktree remove --force ${worktreePath} ${worktreePath}`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/git worktree remove --force.*detected/,
+			);
+		});
+
+		test('non-force git worktree remove <path> → ALLOWED (never blocked by this guard)', async () => {
+			const outside = join(TEST_DIR, 'some-worktree');
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(TEST_DIR, undefined, config);
+			const cmd = `git worktree remove ${outside}`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+
+		// --------------------------------------------------------------
+		// Regression: quoted / abbreviated force flags must not bypass the
+		// containment check. A real shell strips surrounding quotes and git
+		// honors force-flag abbreviations, so `"--force"`, `'--force'`,
+		// `--forc`, and `-ff` all execute as force. If the guard only matched
+		// the exact tokens `--force`/`-f`, these forms slipped past hasForce
+		// and the entire scope check was skipped — allowing a force-remove of
+		// a path OUTSIDE the swarm worktree base with zero scrutiny.
+		// --------------------------------------------------------------
+		test('double-quoted "--force" on path OUTSIDE base → BLOCKED (regression)', async () => {
+			const { base } = makeWorktreeFixture();
+			const outside = join(TEST_DIR, 'src');
+			mkdirSync(outside, { recursive: true });
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[base],
+			);
+			const cmd = `git worktree remove "--force" ${outside}`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/git worktree remove --force.*detected/,
+			);
+		});
+
+		test("single-quoted '--force' on path OUTSIDE base → BLOCKED (regression)", async () => {
+			const { base } = makeWorktreeFixture();
+			const outside = join(TEST_DIR, 'src');
+			mkdirSync(outside, { recursive: true });
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[base],
+			);
+			const cmd = `git worktree remove '--force' ${outside}`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/git worktree remove --force.*detected/,
+			);
+		});
+
+		test('abbreviated --forc on path OUTSIDE base → BLOCKED (regression)', async () => {
+			const { base } = makeWorktreeFixture();
+			const outside = join(TEST_DIR, 'src');
+			mkdirSync(outside, { recursive: true });
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[base],
+			);
+			const cmd = `git worktree remove --forc ${outside}`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/git worktree remove --force.*detected/,
+			);
+		});
+
+		test('stacked short form -ff on path OUTSIDE base → BLOCKED (regression)', async () => {
+			const { base } = makeWorktreeFixture();
+			const outside = join(TEST_DIR, 'src');
+			mkdirSync(outside, { recursive: true });
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[base],
+			);
+			const cmd = `git worktree remove -ff ${outside}`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+				/git worktree remove --force.*detected/,
+			);
+		});
+
+		test('double-quoted "--force" on path INSIDE base → ALLOWED (not blocked unconditionally)', async () => {
+			const { base, worktreePath } = makeWorktreeFixture();
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[base],
+			);
+			const cmd = `git worktree remove "--force" ${worktreePath}`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
 		});
 	});
 

--- a/tests/unit/hooks/guardrails-swarm-path-guard.test.ts
+++ b/tests/unit/hooks/guardrails-swarm-path-guard.test.ts
@@ -3,8 +3,13 @@ import { mkdirSync, mkdtempSync, realpathSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import type { GuardrailsConfig } from '../../../src/config/schema';
+import { pendingCoderScopeByTaskId } from '../../../src/hooks/delegation-gate';
 import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
-import { resetSwarmState, startAgentSession } from '../../../src/state';
+import {
+	resetSwarmState,
+	startAgentSession,
+	swarmState,
+} from '../../../src/state';
 
 const TEST_DIR = realpathSync(
 	mkdtempSync(join(tmpdir(), 'guardrail-swarm-path-')),
@@ -866,6 +871,60 @@ describe('destructive command guard - .swarm path protection (sections 16-21)', 
 				[base],
 			);
 			const cmd = `git worktree remove "--force" ${worktreePath}`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+		});
+
+		// ─────────────────────────────────────────────────────────────
+		// F-002: declaredScope exemption branch (branch 1 of issue #1708)
+		// The scope-exemption at tool-before.ts:511-513 has TWO branches:
+		//   branch 1: isInDeclaredScope(target, declaredScope, cwd)
+		//   branch 2: isPathUnderSwarmWorktreeBase(target, cwd, worktreeBaseDirOverrides)
+		// This test exercises branch 1 by seeding declaredScope via pendingCoderScopeByTaskId
+		// and passing an EMPTY worktreeBaseDirOverrides so only branch 1 can succeed.
+		// ─────────────────────────────────────────────────────────────
+		test('git worktree remove --force via declaredScope exemption (no worktreeBaseDirOverrides) → ALLOWED', async () => {
+			// Create a worktree that is NOT under any worktree base directory
+			const { worktreePath } = makeWorktreeFixture();
+			// Verify it is NOT inside TEST_DIR/.swarm/worktrees (makeWorktreeFixture uses tmpdir)
+			// Seed declaredScope via pendingCoderScopeByTaskId so branch 1 fires
+			const session = swarmState.agentSessions.get('test-session')!;
+			session.currentTaskId = '1.1';
+			pendingCoderScopeByTaskId.set('1.1', [worktreePath]);
+			const config = defaultConfig();
+			// EMPTY worktreeBaseDirOverrides → branch 2 CANNOT trigger
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[],
+			);
+			const cmd = `git worktree remove --force ${worktreePath}`;
+			const input = makeBashInput('test-session', cmd);
+			const output = makeBashOutput(cmd);
+			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();
+			// Cleanup: unset currentTaskId so it doesn't bleed into other tests
+			session.currentTaskId = null;
+			pendingCoderScopeByTaskId.delete('1.1');
+		});
+
+		// ─────────────────────────────────────────────────────────────
+		// F-009: single-quote symmetry for inside-base ALLOW
+		// Sibling to the double-quoted test above; both quote styles must behave identically.
+		// ─────────────────────────────────────────────────────────────
+		test("single-quoted '--force' on path INSIDE base → ALLOWED (not blocked unconditionally)", async () => {
+			const { base, worktreePath } = makeWorktreeFixture();
+			const config = defaultConfig();
+			const hooks = createGuardrailsHooks(
+				TEST_DIR,
+				undefined,
+				config,
+				undefined,
+				[base],
+			);
+			const cmd = `git worktree remove '--force' ${worktreePath}`;
 			const input = makeBashInput('test-session', cmd);
 			const output = makeBashOutput(cmd);
 			await expect(hooks.toolBefore(input, output)).resolves.toBeUndefined();

--- a/tests/unit/turbo/lean/guardrails-safety.test.ts
+++ b/tests/unit/turbo/lean/guardrails-safety.test.ts
@@ -3,9 +3,10 @@
  *
  * Verifies three safety properties:
  * 1. git worktree remove --force is blocked by the destructive-command guardrails.
- * 2. removeWorktree never passes --force to its git subprocess.
+ * 2. removeWorktree never passes --force to its git subprocess (unless
+ *    opt-in force fallback is requested — issue #1708).
  * 3. removeWorktree uses bounded retry on Windows EBUSY/EPERM (DD-10) and
- *    abandons (never falls back to --force).
+ *    falls back to --force only when explicitly requested for a trusted path.
  *
  * Uses the _internals DI seam pattern — no mock.module calls.
  */
@@ -19,7 +20,7 @@ import {
 	mock,
 	test,
 } from 'bun:test';
-import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { GuardrailsConfig } from '../../../../src/config/schema';
@@ -181,7 +182,7 @@ describe('guardrails: git worktree remove --force blocked', () => {
 // Test 2: removeWorktree never uses --force
 // ===========================================================================
 
-describe('removeWorktree: never uses --force flag', () => {
+describe('removeWorktree: --force opt-in fallback (#1708)', () => {
 	const fakeWorktreePath = join('C:', 'worktrees', 'session-abc', 'lane-1');
 	const fakeProjectRoot = join('C:', 'project-root');
 
@@ -224,6 +225,57 @@ describe('removeWorktree: never uses --force flag', () => {
 		// Verify retry attempts actually happened
 		const worktreeCalls = allSpawnArgs.filter((a) => a[1] === 'worktree');
 		expect(worktreeCalls.length).toBe(4); // initial + 3 retries
+	});
+
+	test('removeWorktree uses --force when opt-in force fallback is requested for trusted path', async () => {
+		const spawnCalls: string[][] = [];
+		let callCount = 0;
+
+		_internals.bunSpawn = (args: string[]) => {
+			spawnCalls.push(args);
+			callCount++;
+			// First non-force call: non-retryable error.
+			// Force call: success.
+			if (callCount === 1) {
+				return mockProc(
+					1,
+					'',
+					'contains modified or untracked files, use --force to delete it',
+				);
+			}
+			return mockProc(0, '', '');
+		};
+
+		// Build a real temp base and a worktree subdirectory so
+		// isPathUnderSwarmWorktreeBase() resolves successfully.
+		const base = realpathSync(mkdtempSync(join(tmpdir(), 'guardrails-force-')));
+		const worktreePath = join(base, 'lane-x');
+		mkdirSync(worktreePath, { recursive: true });
+
+		const result = await removeWorktree(worktreePath, base, {
+			force: true,
+			worktreeDir: base,
+		});
+
+		expect(result).toEqual({ success: true });
+
+		const forceCalls = spawnCalls.filter((args) => args.includes('--force'));
+		expect(forceCalls.length).toBeGreaterThan(0);
+
+		const forceArgv = spawnCalls.find(
+			(args) =>
+				args[0] === 'git' &&
+				args[1] === 'worktree' &&
+				args[2] === 'remove' &&
+				args[3] === '--force',
+		);
+		expect(forceArgv).toEqual([
+			'git',
+			'worktree',
+			'remove',
+			'--force',
+			worktreePath,
+		]);
 	});
 });
 

--- a/tests/unit/turbo/lean/integration-worktree.test.ts
+++ b/tests/unit/turbo/lean/integration-worktree.test.ts
@@ -1140,30 +1140,6 @@ describe('AC-8: guardrails safety — git worktree remove --force blocked at run
 });
 
 describe('AC-8: supplemental static source checks — no --force in worktree source', () => {
-	test('worktree.ts source does not contain "worktree remove --force"', () => {
-		const source = fs.readFileSync(
-			path.resolve(__dirname, '../../../../src/turbo/lean/worktree.ts'),
-			'utf-8',
-		);
-		expect(source).not.toContain('worktree remove --force');
-	});
-
-	test('runner.ts source does not contain "worktree remove --force"', () => {
-		const source = fs.readFileSync(
-			path.resolve(__dirname, '../../../../src/turbo/lean/runner.ts'),
-			'utf-8',
-		);
-		expect(source).not.toContain('worktree remove --force');
-	});
-
-	test('merge-back.ts source does not contain "worktree remove --force"', () => {
-		const source = fs.readFileSync(
-			path.resolve(__dirname, '../../../../src/turbo/lean/merge-back.ts'),
-			'utf-8',
-		);
-		expect(source).not.toContain('worktree remove --force');
-	});
-
 	test('removeWorktree escalates to --force only under opt-in + containment guard (#1708)', () => {
 		// Implementation moved to src/worktree/core.ts; lean/worktree.ts is a thin re-export.
 		// Issue #1708 changed the old "never --force" invariant: removeWorktree now

--- a/tests/unit/turbo/lean/integration-worktree.test.ts
+++ b/tests/unit/turbo/lean/integration-worktree.test.ts
@@ -1164,14 +1164,23 @@ describe('AC-8: supplemental static source checks — no --force in worktree sou
 		expect(source).not.toContain('worktree remove --force');
 	});
 
-	test('removeWorktree function calls git worktree remove WITHOUT --force flag', () => {
+	test('removeWorktree escalates to --force only under opt-in + containment guard (#1708)', () => {
 		// Implementation moved to src/worktree/core.ts; lean/worktree.ts is a thin re-export.
+		// Issue #1708 changed the old "never --force" invariant: removeWorktree now
+		// offers an opt-in forced fallback, but ONLY when the target resolves inside
+		// the trusted swarm worktree base. Assert both the escalation exists AND its
+		// guards are present, rather than the (now obsolete) blanket "no --force".
 		const source = fs.readFileSync(
 			path.resolve(__dirname, '../../../../src/worktree/core.ts'),
 			'utf-8',
 		);
-		expect(source).toContain("'worktree', 'remove'");
-		expect(source).not.toMatch(/'worktree',\s*'remove'.*--force/);
+		// Default non-force removal path is still present.
+		expect(source).toContain("['worktree', 'remove', worktreePath]");
+		// The forced-fallback removal exists (issue #1708).
+		expect(source).toMatch(/'worktree',\s*'remove',\s*'--force'/);
+		// ...but is gated behind the opt-in flag AND the trusted-base containment check.
+		expect(source).toContain('options?.force');
+		expect(source).toContain('isPathUnderSwarmWorktreeBase(');
 	});
 });
 

--- a/tests/unit/worktree/core.test.ts
+++ b/tests/unit/worktree/core.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, test } from 'bun:test';
-
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { BunCompatSubprocess } from '../../../src/utils/bun-compat';
 import { makeWorktreeBranchName } from '../../../src/worktree';
+import { _internals, removeWorktree } from '../../../src/worktree/core';
 
 describe('shared worktree branch naming', () => {
 	test('uses generalized purpose-prefixed branch names by default', () => {
@@ -16,5 +20,147 @@ describe('shared worktree branch naming', () => {
 				branchStyle: 'legacy-lane',
 			}),
 		).toBe('swarm-lane/parent-session/lane-a');
+	});
+});
+
+describe('removeWorktree opt-in force fallback (#1708)', () => {
+	const realBunSpawn = _internals.bunSpawn;
+	const realPlatform = _internals.platform;
+	const realSleep = _internals.sleep;
+
+	afterEach(() => {
+		_internals.bunSpawn = realBunSpawn;
+		_internals.platform = realPlatform;
+		_internals.sleep = realSleep;
+	});
+
+	function mockProc(
+		exitCode: number,
+		stdout = '',
+		stderr = '',
+	): BunCompatSubprocess {
+		return {
+			exited: Promise.resolve(exitCode),
+			exitCode,
+			stdout: { text: () => Promise.resolve(stdout) },
+			stderr: { text: () => Promise.resolve(stderr) },
+			kill: () => {},
+		} as unknown as BunCompatSubprocess;
+	}
+
+	/** Creates a real worktree base + an in-base worktree dir on disk. */
+	function makeInRootFixture(): { base: string; worktreePath: string } {
+		const base = realpathSync(mkdtempSync(join(tmpdir(), 'core-wt-base-')));
+		const worktreePath = join(base, 'wt');
+		mkdirSync(worktreePath, { recursive: true });
+		return { base, worktreePath };
+	}
+
+	/** Installs a spawn stub that records every git argv and routes by --force. */
+	function installSpawn(routes: {
+		nonForce: () => BunCompatSubprocess;
+		force: () => BunCompatSubprocess;
+	}): string[][] {
+		const calls: string[][] = [];
+		_internals.bunSpawn = ((cmd: string[]) => {
+			calls.push(cmd);
+			return cmd.includes('--force') ? routes.force() : routes.nonForce();
+		}) as typeof _internals.bunSpawn;
+		return calls;
+	}
+
+	test('dirty-worktree failure + force:true + in-root → escalates to --force and succeeds', async () => {
+		const { base, worktreePath } = makeInRootFixture();
+		const calls = installSpawn({
+			// Non-retryable, non-EBUSY "use --force" error → hits give-up on attempt 0.
+			nonForce: () =>
+				mockProc(
+					1,
+					'',
+					"fatal: '...' contains modified or untracked files, use --force to delete it",
+				),
+			force: () => mockProc(0),
+		});
+
+		const result = await removeWorktree(worktreePath, base, {
+			force: true,
+			worktreeDir: base,
+		});
+
+		expect(result).toEqual({ success: true });
+		// Exactly one non-force attempt, then exactly one --force attempt.
+		const forceCalls = calls.filter((c) => c.includes('--force'));
+		expect(forceCalls.length).toBe(1);
+		expect(forceCalls[0]).toEqual([
+			'git',
+			'worktree',
+			'remove',
+			'--force',
+			worktreePath,
+		]);
+	});
+
+	test('EBUSY exhaustion (Windows) + force:true + in-root → escalates to --force after retries', async () => {
+		const { base, worktreePath } = makeInRootFixture();
+		_internals.platform = 'win32';
+		_internals.sleep = () => Promise.resolve();
+		const calls = installSpawn({
+			nonForce: () => mockProc(1, '', 'EBUSY: resource busy or locked'),
+			force: () => mockProc(0),
+		});
+
+		const result = await removeWorktree(worktreePath, base, {
+			force: true,
+			worktreeDir: base,
+		});
+
+		expect(result).toEqual({ success: true });
+		const nonForceCalls = calls.filter((c) => !c.includes('--force'));
+		const forceCalls = calls.filter((c) => c.includes('--force'));
+		// 4 non-force attempts (MAX_RETRIES) then a single force escalation.
+		expect(nonForceCalls.length).toBe(4);
+		expect(forceCalls.length).toBe(1);
+	});
+
+	test('force:true but target OUTSIDE trusted base → NO --force attempt, returns error', async () => {
+		const { base } = makeInRootFixture();
+		// A real dir that is NOT under `base` (so realpathSync succeeds and it is
+		// containment, not fail-closed, that rejects it).
+		const outside = realpathSync(mkdtempSync(join(tmpdir(), 'core-wt-out-')));
+		const calls = installSpawn({
+			nonForce: () =>
+				mockProc(
+					1,
+					'',
+					'fatal: contains modified or untracked files, use --force to delete it',
+				),
+			force: () => mockProc(0),
+		});
+
+		const result = await removeWorktree(outside, base, {
+			force: true,
+			worktreeDir: base,
+		});
+
+		expect('error' in result).toBe(true);
+		expect(calls.some((c) => c.includes('--force'))).toBe(false);
+	});
+
+	test('force unset + in-root failure → preserves legacy behavior (error, no --force)', async () => {
+		const { base, worktreePath } = makeInRootFixture();
+		const calls = installSpawn({
+			nonForce: () =>
+				mockProc(
+					1,
+					'',
+					'fatal: contains modified or untracked files, use --force to delete it',
+				),
+			force: () => mockProc(0),
+		});
+
+		const result = await removeWorktree(worktreePath, base);
+
+		expect('error' in result).toBe(true);
+		expect(calls.some((c) => c.includes('--force'))).toBe(false);
 	});
 });


### PR DESCRIPTION
Closes #1708

## Summary

- `git worktree remove --force <path>` was hard-blocked unconditionally by the destructive-command
  guard, even for swarm's own worktrees — a guaranteed false positive, since git requires `--force`
  to remove any worktree with uncommitted/untracked content (the normal state of an abandoned
  worktree awaiting cleanup). The guard now allows it when the resolved target is inside the
  swarm-managed worktree base directory or a coder's declared scope, mirroring the existing
  `rsync --delete` exemption in the same function — otherwise it still hard-blocks, fail-closed on
  any unparseable or unresolvable target.
- Swarm's own internal `removeWorktree()` never used `--force` and silently abandoned worktrees
  that failed non-forced removal (observed as Windows `EBUSY`/`EPERM`), leaking them on disk. It
  now has an opt-in `--force` fallback restricted to the same trusted root, wired into all four of
  swarm's own cleanup call sites.
- New shared helpers `resolveWorktreeBaseDir()` / `isPathUnderSwarmWorktreeBase()` in
  `src/worktree/core.ts` (realpath-based, fail-closed, symlink/junction-safe) are reused by both
  the guard and the internal cleanup path so they agree on what counts as swarm-managed.

## Invariant audit

- 1 (plugin init): touched — `src/index.ts` gained one new static import and a few synchronous
  lines computing `worktreeBaseDirOverrides` (via the existing `resolveWorktreeIsolationConfig`
  unifier, newly exported) before `createGuardrailsHooks(...)`. `node scripts/repro-704.mjs`: 4
  consecutive clean runs at 212–283ms, comfortably under the 400ms T1 deadline. (An initial
  anomalous ~4008ms reading was traced to concurrent disk/CPU contention from a background build
  in a comparison worktree, not the code — see `.swarm/evidence/commit-pr-validation.md`.)
- 2 (runtime portability): touched — `src/index.ts` modified. `bun run build` succeeds;
  `node --input-type=module -e "await import('./dist/index.js')"` confirms the bundle loads under
  Node ESM; `bundle-plugin-shape.test.ts` + `bundle-portability.test.ts` pass (4/4).
- 3 (subprocesses): touched (new call site) — `removeWorktree`'s force-retry reuses the existing,
  already-compliant `runGit()` helper unchanged (array-form, explicit cwd, `stdin: 'ignore'`,
  bounded timeout, `proc.kill()` in `finally`). `grep -nE "bunSpawn\(|spawn\(|spawnSync\("` on the
  diff shows only the pre-existing call sites in `src/worktree/core.ts` — no new subprocess pattern.
- 4 (.swarm containment): not touched — no tool creates or writes `.swarm/` state; this PR is
  guardrail/worktree logic only.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — all validation used direct shell `bun test` invocations,
  per-file where the repo convention calls for it.
- 7 (test writing): touched — new/modified tests use `bun:test` only; no `mock.module` in any
  touched test file (`grep -rn "mock.module"` on the two touched test files returns no matches);
  the symlink-escape test drives a real junction against the real `toolBefore` handler rather than
  mocking the containment check.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched — this is destructive-command detection, not the transient-
  error/circuit-breaker retry system invariant 9 covers.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no new tools, agents, or commands.
- 12 (release/cache): not touched beyond the mandatory release fragment
  (`docs/releases/pending/1708-worktree-remove-force-scope-exemption.md`); `package.json#version`,
  `CHANGELOG.md`, `.release-please-manifest.json` untouched.

## Test plan

- [x] `bun run build` succeeds; dist import under Node ESM confirmed
- [x] `bun run typecheck` clean
- [x] `bunx @biomejs/biome@2.3.14 check` on the full diff: clean (2 formatting issues in
      `tests/unit/worktree/core.test.ts` fixed with `--write`, re-verified)
- [x] Touched-file suite: `tests/unit/worktree/core.test.ts`,
      `tests/unit/hooks/guardrails-swarm-path-guard.test.ts`,
      `tests/unit/turbo/lean/integration-worktree.test.ts` → 126 pass, 0 fail
- [x] Independent reviewer (opus, separate context from implementation): APPROVE
- [x] Critic gate cycle 1 (opus): NEEDS_REVISION — found a real regression the reviewer missed: a
      quoted `"--force"`/`'--force'` flag silently bypassed the entire new guard (worse than the
      pre-diff behavior). Fixed (quote-stripping + git's accepted abbreviation/stacking forms);
      regression tests added and confirmed to fail pre-fix, pass post-fix.
- [x] Critic gate cycle 2 (opus, final): APPROVED
- [x] Full mandatory validation suite (Tiers 2–5) run; every failing tier independently verified
      against a clean `origin/main` worktree using the identical command — see
      `.swarm/evidence/commit-pr-validation.md` for the full comparison table. Net result: zero
      test regressions introduced by this diff.

## Known caveats

- The `declaredScope` exemption path (shared with the pre-existing `rsync --delete` exemption)
  does not realpath-canonicalize its target the way the new worktree-base check does. Confirmed
  by the critic to be an existing gap (identical in the pre-existing `rsync` exemption), not one
  introduced by this diff — not a regression, tracked as a possible follow-up.
- The swarm worktree base directory is always trusted even when a custom `worktree_dir` override
  is configured (in addition to the override) — low-risk over-inclusion, not a containment
  weakening (only affects force-removal of git-registered worktrees).
- `resolveWorktreeBaseDir()` does not reject a `worktree_dir` config value containing `..`
  traversal or an absolute escape path; this mirrors pre-existing behavior in `provisionWorktree()`
  and is a configuration footgun (not attacker-controlled), tracked as a follow-up.
- An embedded-quote force-flag form (e.g. `--"force"`) still bypasses detection — critic-confirmed
  non-regression (the pre-diff code allowed this too), and this guard is defense-in-depth, not the
  primary security boundary (the sandbox is).

## Pre-existing failures (found, not introduced, out of scope for this PR)

Every failing test tier was independently reproduced on a clean `origin/main` worktree (commit
`c5eb59cd`) using the identical command — full comparison table in
`.swarm/evidence/commit-pr-validation.md`. Summary:

- `tests/unit/hooks/utils.test.ts` (2 fail), `tests/unit/hooks/write-lstat-authority.test.ts`
  (5 fail), `tests/unit/agents/project-context.test.ts` (2 fail) — reproduce identically via
  `git stash` re-run on this branch.
- `tests/unit/cli tests/unit/commands tests/unit/config` (734 fail / 2932 pass) and
  `tests/adversarial` (10 fail / 819 pass) — exact-match counts on clean `origin/main`.
- `tests/integration ./test` combined-invocation numbers vary run-to-run due to a known
  cross-file `mock.module` cascade in this execution mode (the same class of bug issue #1683
  targets on a separate branch); per-file isolation confirms no real regression (see evidence file
  for the specific investigation, including a stale unrelated leftover directory found and cleared
  during verification).
- `tests/unit/tools/*.test.ts` per-file run showed a 9-test delta from clean main that was **not**
  a code difference — traced to `validateWorkspace()` rejecting the specific absolute path of the
  comparison worktree as "path traversal"; re-run at this branch's own repo path is stable at 0
  fail for those tests.

None of the above relate to worktree, guardrails, or destructive-command logic.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

