### PR TITLE
fix(knowledge): close the learning feedback loop

### DIFF
--- a/docs/releases/pending/1715-close-knowledge-feedback-loop.md
+++ b/docs/releases/pending/1715-close-knowledge-feedback-loop.md
@@ -1,0 +1,66 @@
+---
+title: Close the knowledge feedback loop
+issue: 1715
+---
+
+## What changed
+
+The knowledge feedback loop was an open circuit — outcome signals were
+recorded but nothing acted on them. Three gaps fixed:
+
+- **Phase-failure outcomes now record (G1).** `phase-complete` previously
+  called `updateRetrievalOutcome(dir, name, true)` with a hardcoded `true`,
+  so a failed phase could never emit a `'failure'` outcome event and
+  `failed_after_shown_count` was structurally dead. The call now runs after
+  the phase's real `success` value is determined and passes that value.
+- **Confidence-floor action (G2).** Confidence feedback bumped
+  `entry.confidence` but nothing acted on low confidence — the bumps
+  dead-ended. Now a just-bumped entry clamped to the floor (0.1) with a
+  net-negative outcome signal is demoted (`confidence_floor_demoted` flag,
+  which strips retrieval `statusBoost`) or quarantined per config. Defaults
+  are conservative: requires ≥3 outcome events and a net-negative signal.
+- **Contradiction signals unified (G3).** `contradicted_count` (incremented
+  only via `knowledge_receipt`) and the curator's `flag_contradiction`
+  (tag-only) were disconnected. The curator now emits `contradicted` events
+  post-transaction (with `agent: 'curator'` for audit), and a new
+  `maybeQuarantineOnContradiction` auto-quarantines entries whose in-window
+  contradicted count crosses the threshold (default 3 in 30d).
+
+## New config knobs
+
+- `knowledge.confidence_floor_action`: `'none' | 'demote' | 'quarantine'`
+  (default `'demote'`).
+- `knowledge.confidence_floor_min_outcomes`: minimum outcome evidence before
+  acting (default `3`).
+- `knowledge.confidence_floor_signal_threshold`: outcome-signal threshold
+  below which a floor entry is acted on (default `0` = net-negative).
+- `knowledge.contradiction_threshold_action`: `'tag_only' | 'quarantine'`
+  (default `'quarantine'`).
+- `knowledge.contradiction_quarantine_threshold`: default `3`.
+- `knowledge.contradiction_quarantine_window_days`: default `30`.
+
+## Why
+
+The genuinely-closed sub-loop was only the violation-count → escalator →
+enforce-block path. The confidence/contradiction/phase-failure halves were
+wired to record signal but nothing consumed it — counters bumped, behavior
+barely changed. This closes all three.
+
+## Migration
+
+No migration required. New config fields default to conservative behavior
+(`demote` is reversible; quarantine requires 3+ events). Existing entries
+without the new `confidence_floor_demoted` field read as `undefined` →
+treated as not-demoted (legacy behavior). Users who want the legacy dead-end
+behavior can set `confidence_floor_action: 'none'` and
+`contradiction_threshold_action: 'tag_only'`.
+
+## Known caveats
+
+- Floor-action quarantine applies only to swarm-tier entries (the quarantine
+  mechanism reads the swarm knowledge file). Hive floor-entries still get the
+  `confidence_floor_demoted` flag (honored by retrieval regardless of tier).
+- The negative-outcome signal depends on phase-failure outcomes actually
+  firing, which requires `policy === 'enforce'` + missing required agents.
+  Blocked phases never reach the outcome-recording call (pre-existing
+  behavior, unchanged here).

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1099,6 +1099,34 @@ export const KnowledgeConfigSchema = z.object({
 	todo_max_phases: z.number().int().positive().default(3),
 	/** Enable age-based sweep of stale knowledge entries */
 	sweep_enabled: z.boolean().default(true),
+	/** G2 (#1715): action when a knowledge entry sits at the confidence floor
+	 * (0.1) with a net-negative outcome signal. Previously confidence bumps
+	 * dead-ended with no consequence; this closes the loop.
+	 * - `demote` (default): strip retrieval `statusBoost` via the
+	 *   `confidence_floor_demoted` flag — reversible.
+	 * - `quarantine`: route through `quarantineEntry` (disruptive).
+	 * - `none`: legacy dead-end behavior. */
+	confidence_floor_action: z
+		.enum(['none', 'demote', 'quarantine'])
+		.default('demote'),
+	/** G2: minimum total outcome-evidence count required before acting on a
+	 * floor entry (avoids demoting brand-new entries with one stray negative). */
+	confidence_floor_min_outcomes: z.number().int().min(0).default(3),
+	/** G2: outcome-signal threshold below which a floor entry is acted on
+	 * (`computeOutcomeSignal` returns (-1, 1); net-negative is `< 0`). */
+	confidence_floor_signal_threshold: z.number().min(-1).max(1).default(0),
+	/** G3 (#1715): action when a knowledge entry's contradicted count crosses
+	 * the threshold within the window. `tag_only` preserves legacy behavior
+	 * (curator tags, no event/count action); `quarantine` auto-quarantines. */
+	contradiction_threshold_action: z
+		.enum(['tag_only', 'quarantine'])
+		.default('quarantine'),
+	/** G3: number of `contradicted` events within the window required to fire
+	 * the contradiction-threshold action. */
+	contradiction_quarantine_threshold: z.number().int().positive().default(3),
+	/** G3: window (in days) for counting `contradicted` events toward the
+	 * threshold. */
+	contradiction_quarantine_window_days: z.number().int().positive().default(30),
 	/** Architect-only in-session nudge to capture durable lessons while work is still live. */
 	realtime_learning_nudge: z
 		.object({

--- a/src/hooks/curator.ts
+++ b/src/hooks/curator.ts
@@ -72,6 +72,7 @@ import {
 	resolveSwarmKnowledgePath,
 	transactKnowledge,
 } from './knowledge-store.js';
+import { recordKnowledgeEvent } from './knowledge-events.js';
 import type {
 	KnowledgeConfig,
 	SwarmKnowledgeEntry,
@@ -1612,6 +1613,11 @@ export async function applyCuratorKnowledgeUpdates(
 	// post-transaction code (skipped counting, new-entry append) can see them.
 	const appliedIds = new Set<string>();
 	const foundIds = new Set<string>();
+	// G3 (#1715): collect (id, reason) for flag_contradiction actions so we can
+	// emit `contradicted` events post-transaction. Emitting inline inside the
+	// transactKnowledge callback would risk a directory-lock deadlock (the
+	// events file lives in the same `.swarm/` dir the transaction locks).
+	const contradictedEntries: Array<{ id: string; reason: string }> = [];
 
 	// Atomically read, mutate, and rewrite existing entries under a directory lock
 	// (CF-2 TOCTOU fix: concurrent appendKnowledge calls between an unlocked read
@@ -1620,6 +1626,7 @@ export async function applyCuratorKnowledgeUpdates(
 		// Reset closure state on each call (in case of future retry semantics).
 		appliedIds.clear();
 		foundIds.clear();
+		contradictedEntries.length = 0;
 		let txApplied = 0;
 		let modified = false;
 
@@ -1653,6 +1660,11 @@ export async function applyCuratorKnowledgeUpdates(
 					appliedIds.add(entry.id);
 					txApplied++;
 					modified = true;
+					// G3 (#1715): capture for post-transaction event emission.
+					contradictedEntries.push({
+						id: entry.id,
+						reason: (rec.reason ?? '').slice(0, 200),
+					});
 					return {
 						...entry,
 						tags: [
@@ -1702,6 +1714,53 @@ export async function applyCuratorKnowledgeUpdates(
 		applied += txApplied;
 		return modified ? updatedEntries : null;
 	});
+
+	// G3 (#1715): emit `contradicted` events for flag_contradiction actions,
+	// AFTER the transaction commits. This unifies the two previously-disconnected
+	// contradiction signals: `contradicted_count` (incremented only via
+	// knowledge_receipt) and the curator's tag-only `flag_contradiction`. Now
+	// both paths feed the same event-sourced counter. The curator-attributed
+	// context (agent: 'curator') makes these events distinguishable from
+	// delegate/reviewer ones for audit.
+	for (const { id, reason } of contradictedEntries) {
+		try {
+			await recordKnowledgeEvent(directory, {
+				type: 'contradicted' as const,
+				knowledge_id: id,
+				trace_id: `curator-${randomUUID()}`,
+				session_id: 'curator',
+				agent: 'curator',
+				reason: `flag_contradiction: ${reason}`,
+				evidence: { summary: reason },
+			});
+		} catch {
+			// best-effort — never fail the curator on event emission
+		}
+	}
+
+	// G3: after emitting, check the threshold and quarantine if configured +
+	// crossed. `tag_only` preserves legacy behavior; `quarantine` (default)
+	// auto-quarantines entries whose in-window contradicted count crossed.
+	if (
+		contradictedEntries.length > 0 &&
+		knowledgeConfig.contradiction_threshold_action === 'quarantine'
+	) {
+		const { maybeQuarantineOnContradiction } = await import(
+			'./knowledge-escalator.js'
+		);
+		for (const { id } of contradictedEntries) {
+			try {
+				await maybeQuarantineOnContradiction(
+					directory,
+					id,
+					knowledgeConfig.contradiction_quarantine_threshold,
+					knowledgeConfig.contradiction_quarantine_window_days,
+				);
+			} catch {
+				// best-effort
+			}
+		}
+	}
 
 	// Count skipped: recommendations that were not applied to existing entries
 	for (const rec of validRecommendations) {

--- a/src/hooks/knowledge-escalator.ts
+++ b/src/hooks/knowledge-escalator.ts
@@ -14,6 +14,7 @@
 
 import { existsSync } from 'node:fs';
 import {
+	countEntryContradictionsInWindow,
 	countEntryViolationsInWindow,
 	readKnowledgeEvents,
 	recordKnowledgeEvent,
@@ -275,4 +276,77 @@ export async function escalateViolatedEntries(
 		out.push(await maybeEscalateOnViolation(directory, id, now));
 	}
 	return out;
+}
+
+// ============================================================================
+// G3 (#1715): repeat-contradiction quarantine
+// ============================================================================
+
+export interface ContradictionQuarantineResult {
+	quarantined: boolean;
+	entryId: string;
+	contradictionsInWindow?: number;
+	/** True when the entry was already quarantined/archived (no-op, idempotent). */
+	alreadyInactive?: boolean;
+}
+
+/**
+ * G3 (#1715): if an entry's `contradicted` count within `windowDays` crosses
+ * `threshold`, auto-quarantine it. Mirrors {@link maybeEscalateOnViolation}
+ * (counts from the RAW event log via {@link countEntryContradictionsInWindow}
+ * — NOT the rollup cache, which is mtime-keyed and can be stale immediately
+ * after an append). Idempotent: already-quarantined/archived entries are
+ * skipped. Never throws.
+ */
+export async function maybeQuarantineOnContradiction(
+	directory: string,
+	entryId: string,
+	threshold: number,
+	windowDays: number,
+	now: Date = new Date(),
+): Promise<ContradictionQuarantineResult> {
+	try {
+		const count = await countEntryContradictionsInWindow(
+			directory,
+			entryId,
+			windowDays,
+			now,
+		);
+		if (count < threshold) {
+			return { quarantined: false, entryId, contradictionsInWindow: count };
+		}
+
+		// Idempotency: skip if already inactive. Read fresh under no lock (the
+		// quarantine call below does its own locking; this is just a guard).
+		const entries = await readKnowledge<KnowledgeEntryBase>(
+			resolveSwarmKnowledgePath(directory),
+		);
+		const entry = entries.find((e) => e.id === entryId);
+		if (!entry) {
+			return { quarantined: false, entryId, contradictionsInWindow: count };
+		}
+		if (
+			entry.status === 'quarantined' ||
+			entry.status === 'quarantined_unactionable' ||
+			entry.status === 'archived'
+		) {
+			return {
+				quarantined: false,
+				entryId,
+				contradictionsInWindow: count,
+				alreadyInactive: true,
+			};
+		}
+
+		const { quarantineEntry } = await import('./knowledge-validator.js');
+		await quarantineEntry(
+			directory,
+			entryId,
+			`repeat_contradiction: ${count} contradicted events in ${windowDays}d`,
+			'auto',
+		);
+		return { quarantined: true, entryId, contradictionsInWindow: count };
+	} catch {
+		return { quarantined: false, entryId };
+	}
 }

--- a/src/hooks/knowledge-events.ts
+++ b/src/hooks/knowledge-events.ts
@@ -29,6 +29,10 @@ import lockfile from 'proper-lockfile';
 import { atomicWriteFile } from '../evidence/task-file.js';
 import { warn } from '../utils/logger.js';
 import { resolveKnowledgeStoreDir } from './knowledge-link.js';
+// Type-only import: erased at runtime, so it does NOT create a dependency that
+// would break the test-mocking pattern (see comment at L247 below). The runtime
+// import of knowledge-store is dynamic, inside applyKnowledgeVerdictFeedback.
+import type { ConfidenceFloorOptions } from './knowledge-store.js';
 import type {
 	KnowledgeApplicationRecord,
 	RetrievalOutcome,
@@ -936,6 +940,34 @@ export async function countEntryViolationsInWindow(
 }
 
 /**
+ * G3 (#1715): count `contradicted` events for an entry within a window, reading
+ * from the RAW event log (NOT the rollup cache — `recomputeCounters` is mtime-
+ * keyed and can be stale immediately after an append, mirroring the
+ * `countEntryViolationsInWindow` discipline above). No legacy-record fold:
+ * contradicted has no legacy counterpart (unlike violated). Fail-open: returns 0.
+ */
+export async function countEntryContradictionsInWindow(
+	directory: string,
+	entryId: string,
+	windowDays: number,
+	now: Date = new Date(),
+): Promise<number> {
+	try {
+		const cutoff = now.getTime() - windowDays * 24 * 60 * 60 * 1000;
+		const events = await readKnowledgeEvents(directory);
+		let count = 0;
+		for (const e of events) {
+			if (e.type !== 'contradicted' || e.knowledge_id !== entryId) continue;
+			const t = Date.parse(e.timestamp);
+			if (!Number.isNaN(t) && t >= cutoff) count += 1;
+		}
+		return count;
+	} catch {
+		return 0;
+	}
+}
+
+/**
  * Fail-open rollup reader for hot paths. Search and promotion use this instead
  * of stale persisted counters so `knowledge_receipt` feedback affects ranking
  * and safety gates immediately.
@@ -1030,7 +1062,12 @@ const VERDICT_CONFIDENCE_DECAY = 0.05;
  */
 export async function applyKnowledgeVerdictFeedback(
 	directory: string,
-	options?: { sinceTimestamp?: string; sinceEventId?: string },
+	options?: {
+		sinceTimestamp?: string;
+		sinceEventId?: string;
+		/** G2: forwarded to bumpKnowledgeConfidenceBatch. */
+		floorOptions?: ConfidenceFloorOptions;
+	},
 ): Promise<{
 	processed: number;
 	bumps: number;
@@ -1120,7 +1157,7 @@ export async function applyKnowledgeVerdictFeedback(
 			const { bumpKnowledgeConfidenceBatch } = await import(
 				'./knowledge-store.js'
 			);
-			await bumpKnowledgeConfidenceBatch(directory, deltas);
+			await bumpKnowledgeConfidenceBatch(directory, deltas, options?.floorOptions);
 		}
 
 		return {

--- a/src/hooks/knowledge-store.ts
+++ b/src/hooks/knowledge-store.ts
@@ -859,23 +859,45 @@ const CONFIDENCE_CEILING = 1.0;
 export async function bumpKnowledgeConfidenceBatch(
 	directory: string,
 	deltas: Array<{ id: string; delta: number }>,
+	options?: ConfidenceFloorOptions,
 ): Promise<void> {
 	if (deltas.length === 0) return;
 
 	const swarmPath = resolveSwarmKnowledgePath(directory);
 	const hivePath = resolveHiveKnowledgePath();
 
+	const touchedSwarm: KnowledgeEntryBase[] = [];
+	const touchedHive: KnowledgeEntryBase[] = [];
+
 	try {
 		// --- Swarm pass ---
-		await applyConfidenceDeltas(swarmPath, deltas);
+		touchedSwarm.push(
+			...(await applyConfidenceDeltas(swarmPath, deltas)),
+		);
 
 		// --- Hive pass (only for IDs not found in swarm) ---
-		const swarmEntries = await readKnowledge<KnowledgeEntryBase>(swarmPath);
-		const swarmIds = new Set(swarmEntries.map((e) => e.id));
+		const swarmIds = new Set(touchedSwarm.map((e) => e.id));
+		// If a delta id was NOT touched in swarm it may live in hive; re-check
+		// against the full swarm file too (some entries may not have received
+		// a delta but the id set we care about is the deltas we tried to apply).
 		const hiveOnly = deltas.filter((d) => !swarmIds.has(d.id));
 		if (hiveOnly.length > 0) {
-			await applyConfidenceDeltas(hivePath, hiveOnly);
+			touchedHive.push(...(await applyConfidenceDeltas(hivePath, hiveOnly)));
 		}
+
+		// --- G2: confidence-floor action (post-bump sweep) ---
+		// Confidence used to dead-end at the floor with no consequence. Now an
+		// entry clamped to the floor with a net-negative outcome signal is
+		// demoted (default) or quarantined per config, closing the loop.
+		await applyConfidenceFloorAction(directory, [
+			...touchedSwarm,
+			...touchedHive,
+		], options).catch((err) => {
+			console.warn(
+				'[knowledge-store] confidence-floor action sweep failed (best-effort):',
+				err instanceof Error ? err.message : String(err),
+			);
+		});
 	} catch (err) {
 		console.warn(
 			'[knowledge-store] bumpKnowledgeConfidenceBatch failed (fail-open):',
@@ -885,19 +907,184 @@ export async function bumpKnowledgeConfidenceBatch(
 }
 
 /**
+ * G2 (#1715): for each just-bumped entry at the confidence floor with a
+ * net-negative outcome signal, fire the configured action (`demote` strips
+ * retrieval `statusBoost` via the `confidence_floor_demoted` flag; `quarantine`
+ * routes through `quarantineEntry`). Entries that recovered above the floor
+ * have a stale `confidence_floor_demoted` flag cleared.
+ *
+ * Best-effort: any failure is caught by the caller; never throws.
+ */
+async function applyConfidenceFloorAction(
+	directory: string,
+	touched: KnowledgeEntryBase[],
+	options?: ConfidenceFloorOptions,
+): Promise<void> {
+	const action = options?.floorAction ?? 'demote';
+	if (action === 'none' || touched.length === 0) return;
+
+	const minOutcomes = options?.floorMinOutcomes ?? 3;
+	const signalThreshold = options?.floorSignalThreshold ?? 0; // net-negative
+
+	// Floor-band epsilon: treat confidence within this distance of the floor as
+	// "at the floor" (float compare safety).
+	const FLOOR_EPSILON = 1e-9;
+	const atFloor = touched.filter(
+		(e) => e.confidence <= CONFIDENCE_FLOOR + FLOOR_EPSILON,
+	);
+	const recovered = touched.filter(
+		(e) => e.confidence > CONFIDENCE_FLOOR + FLOOR_EPSILON && e.confidence_floor_demoted,
+	);
+
+	if (atFloor.length === 0 && recovered.length === 0) return;
+
+	// Read the events rollup ONCE (the expensive re-read) — keyed by entry id.
+	// Dynamic import avoids a static store↔events cycle (events already
+	// dynamic-imports store for the bump itself; this mirrors that precedent).
+	const { readKnowledgeCounterRollups, effectiveRetrievalOutcomes } = await import(
+		'./knowledge-events.js'
+	);
+	const rollups = await readKnowledgeCounterRollups(directory);
+
+	// Helper: persist the confidence_floor_demoted flag flip on a single entry
+	// via a tiny locked transaction. Re-uses transactKnowledge for safety.
+	const flagIds = new Set<string>();
+	for (const e of atFloor) {
+		const outcomes = effectiveRetrievalOutcomes(e.retrieval_outcomes, rollups?.get(e.id));
+		const signal = computeOutcomeSignal(outcomes);
+		const totalEvidence =
+			(outcomes.applied_explicit_count ?? 0) +
+			(outcomes.succeeded_after_shown_count ?? 0) +
+			(outcomes.ignored_count ?? 0) +
+			(outcomes.violated_count ?? 0) +
+			(outcomes.contradicted_count ?? 0) +
+			(outcomes.failed_after_shown_count ?? 0);
+		// Require net-negative signal AND enough evidence to act on.
+		if (signal < signalThreshold && totalEvidence >= minOutcomes) {
+			flagIds.add(e.id);
+		}
+	}
+	for (const e of recovered) flagIds.add(e.id); // clear stale flag
+
+	if (flagIds.size === 0) return;
+
+	// Apply the flag flips + (optionally) quarantine via transactKnowledge.
+	// For 'quarantine' action, route the floor-quarantines through
+	// quarantineEntry after the flag transaction commits.
+	const swarmPath = resolveSwarmKnowledgePath(directory);
+	const hivePath = resolveHiveKnowledgePath();
+	const toQuarantine: Array<{ id: string; tier: 'swarm' | 'hive' }> = [];
+
+	await transactKnowledge<KnowledgeEntryBase>(swarmPath, (swarmEntries) => {
+		const now = new Date().toISOString();
+		for (const entry of swarmEntries) {
+			if (!flagIds.has(entry.id)) continue;
+			const atFloorEntry = atFloor.find((e) => e.id === entry.id);
+			if (atFloorEntry) {
+				entry.confidence_floor_demoted = true;
+				if (action === 'quarantine') {
+					toQuarantine.push({ id: entry.id, tier: 'swarm' });
+				}
+			} else {
+				// recovered — clear stale flag
+				entry.confidence_floor_demoted = false;
+			}
+			entry.updated_at = now;
+		}
+		return swarmEntries;
+	}).catch((err) => {
+		console.warn(
+			'[knowledge-store] confidence-floor swarm flag transaction failed (best-effort):',
+			err instanceof Error ? err.message : String(err),
+		);
+	});
+
+	// Hive flag flips (separate transaction).
+	// Note: quarantineEntry reads only the swarm knowledge file, so it cannot
+	// quarantine hive-tier entries. For hive entries the confidence_floor_demoted
+	// FLAG is the effective action (it's honored by search-knowledge.ts
+	// regardless of tier); we deliberately do NOT push hive IDs into
+	// toQuarantine, which would imply a quarantine that won't happen.
+	const hiveFlagIds = new Set<string>();
+	for (const e of atFloor) {
+		if (e.tier === 'hive' && flagIds.has(e.id)) hiveFlagIds.add(e.id);
+	}
+	for (const e of recovered) {
+		if (e.tier === 'hive' && flagIds.has(e.id)) hiveFlagIds.add(e.id);
+	}
+	if (hiveFlagIds.size > 0) {
+		await transactKnowledge<KnowledgeEntryBase>(hivePath, (hiveEntries) => {
+			const now = new Date().toISOString();
+			for (const entry of hiveEntries) {
+				if (!hiveFlagIds.has(entry.id)) continue;
+				const atFloorEntry = atFloor.find((e) => e.id === entry.id);
+				if (atFloorEntry) {
+					entry.confidence_floor_demoted = true;
+				} else {
+					entry.confidence_floor_demoted = false;
+				}
+				entry.updated_at = now;
+			}
+			return hiveEntries;
+		}).catch((err) => {
+			console.warn(
+				'[knowledge-store] confidence-floor hive flag transaction failed (best-effort):',
+				err instanceof Error ? err.message : String(err),
+			);
+		});
+	}
+
+	// Route quarantine action (deferred until after the flag transaction).
+	// Dynamic import avoids a static store↔validator cycle. Only swarm-tier
+	// entries are collected (see hive note above).
+	if (action === 'quarantine' && toQuarantine.length > 0) {
+		const { quarantineEntry } = await import('./knowledge-validator.js');
+		for (const { id } of toQuarantine) {
+			await quarantineEntry(directory, id, 'confidence_floor_negative_outcome', 'auto').catch((err) => {
+				console.warn(
+					'[knowledge-store] confidence-floor quarantine failed (best-effort):',
+					err instanceof Error ? err.message : String(err),
+				);
+			});
+		}
+	}
+}
+
+/** Options for the G2 confidence-floor action in bumpKnowledgeConfidenceBatch. */
+export interface ConfidenceFloorOptions {
+	/** Action when a just-bumped entry sits at the confidence floor with a
+	 * net-negative outcome signal. `'none'` preserves the legacy dead-end
+	 * behavior. Default `'demote'`. */
+	floorAction?: 'none' | 'demote' | 'quarantine';
+	/** Minimum total outcome-evidence count required before acting on a
+	 * floor entry. Avoids demoting brand-new entries with one stray negative.
+	 * Default 3. */
+	floorMinOutcomes?: number;
+	/** Outcome-signal threshold below which a floor entry is acted on
+	 * (`computeOutcomeSignal` returns (-1, 1); net-negative is `< 0`).
+	 * Default 0. */
+	floorSignalThreshold?: number;
+}
+
+/**
  * Internal helper: apply a set of confidence deltas to a single JSONL file.
  * Acquires a directory lock for the full read-modify-write cycle.
+ *
+ * Returns the entries that received a delta (post-mutation, with the new
+ * confidence), so the caller can run a post-bump sweep (e.g. the G2
+ * confidence-floor action) without a separate re-read of the file.
  */
 async function applyConfidenceDeltas(
 	filePath: string,
 	deltas: Array<{ id: string; delta: number }>,
-): Promise<void> {
+): Promise<KnowledgeEntryBase[]> {
 	const idDeltaMap = new Map<string, number>();
 	for (const d of deltas) {
 		const existing = idDeltaMap.get(d.id);
 		idDeltaMap.set(d.id, existing !== undefined ? existing + d.delta : d.delta);
 	}
 
+	const touched: KnowledgeEntryBase[] = [];
 	let release: (() => Promise<void>) | null = null;
 	try {
 		const dir = path.dirname(filePath);
@@ -908,7 +1095,7 @@ async function applyConfidenceDeltas(
 		});
 
 		const entries = await readKnowledge<KnowledgeEntryBase>(filePath);
-		if (entries.length === 0) return;
+		if (entries.length === 0) return [];
 
 		const now = new Date().toISOString();
 		let mutated = false;
@@ -923,6 +1110,7 @@ async function applyConfidenceDeltas(
 			);
 			entry.updated_at = now;
 			mutated = true;
+			touched.push(entry);
 		}
 
 		if (mutated) {
@@ -945,6 +1133,7 @@ async function applyConfidenceDeltas(
 			}
 		}
 	}
+	return touched;
 }
 
 // ============================================================================

--- a/src/hooks/knowledge-types.ts
+++ b/src/hooks/knowledge-types.ts
@@ -149,6 +149,11 @@ export interface KnowledgeEntryBase extends ActionableDirectiveFields {
 	auto_generated?: boolean; // true if created without human review
 	phases_alive?: number; // monotonic phase counter, incremented at phase-wrap (excluding promoted & archived)
 	max_phases?: number; // per-entry TTL in phases, falls back to KnowledgeConfig.default_max_phases
+	/** G2 (#1715): set when the confidence-floor action fired (demote).
+	 * Suppresses `statusBoost` in retrieval so a floor-clamped entry sinks to
+	 * the bottom of ranking without introducing a new retrieval-leaking status.
+	 * Cleared if confidence recovers above the floor. */
+	confidence_floor_demoted?: boolean;
 }
 
 /** v2 schema marker. v1 entries are still parseable and normalized in-memory by knowledge-store.normalizeEntry. */
@@ -235,6 +240,19 @@ export interface KnowledgeConfig {
 	todo_max_phases: number;
 	/** Enable age-based sweep of knowledge entries. Default: true */
 	sweep_enabled: boolean;
+	/** G2 (#1715): action when an entry sits at the confidence floor with a
+	 * net-negative outcome signal. Default: 'demote'. */
+	confidence_floor_action: 'none' | 'demote' | 'quarantine';
+	/** G2: minimum total outcome-evidence count required before acting. Default: 3. */
+	confidence_floor_min_outcomes: number;
+	/** G2: outcome-signal threshold below which a floor entry is acted on. Default: 0. */
+	confidence_floor_signal_threshold: number;
+	/** G3 (#1715): action when contradicted count crosses the threshold. Default: 'quarantine'. */
+	contradiction_threshold_action: 'tag_only' | 'quarantine';
+	/** G3: contradicted-event count in window to trigger the action. Default: 3. */
+	contradiction_quarantine_threshold: number;
+	/** G3: window in days for counting contradicted events. Default: 30. */
+	contradiction_quarantine_window_days: number;
 	/** Change 5: retrieval-upgrade tuning (MMR / cold-start / synonyms). */
 	retrieval?: {
 		mmr_lambda?: number;

--- a/src/hooks/search-knowledge.ts
+++ b/src/hooks/search-knowledge.ts
@@ -484,7 +484,12 @@ export async function searchKnowledge(
 						coldStartBonus +
 						synonymBoost +
 						triggerRecallBoost +
-						(hasQuery ? statusBoost(entry.status) : 0),
+						// G2 (#1715): a floor-demoted entry loses its status boost
+						// so it sinks to the bottom of ranking without introducing
+						// a new retrieval-leaking status.
+						(hasQuery && !entry.confidence_floor_demoted
+							? statusBoost(entry.status)
+							: 0),
 				),
 			);
 

--- a/src/hooks/skill-usage-log.ts
+++ b/src/hooks/skill-usage-log.ts
@@ -9,6 +9,7 @@ import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { bumpKnowledgeConfidenceBatch } from './knowledge-store.js';
+import type { ConfidenceFloorOptions } from './knowledge-store.js';
 import { validateSwarmPath } from './utils.js';
 
 // ============================================================================
@@ -757,7 +758,11 @@ const VIOLATION_DECAY = 0.1;
  */
 export async function applySkillUsageFeedback(
 	directory: string,
-	options?: { sinceTimestamp?: string },
+	options?: {
+		sinceTimestamp?: string;
+		/** G2: forwarded to bumpKnowledgeConfidenceBatch. */
+		floorOptions?: ConfidenceFloorOptions;
+	},
 ): Promise<{ processed: number; bumps: number }> {
 	let processed = 0;
 	let bumps = 0;
@@ -843,7 +848,7 @@ export async function applySkillUsageFeedback(
 
 		// Batch-apply clamped deltas in a single call
 		if (clampedDeltas.length > 0) {
-			await bumpKnowledgeConfidenceBatch(directory, clampedDeltas);
+			await bumpKnowledgeConfidenceBatch(directory, clampedDeltas, options?.floorOptions);
 			appendFeedbackAppliedMarker(directory, processedEntryIds);
 		}
 	} catch (err) {

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -36,6 +36,7 @@ import {
 	sweepAgedEntries,
 	sweepStaleTodos,
 } from '../hooks/knowledge-store.js';
+import type { ConfidenceFloorOptions } from '../hooks/knowledge-store.js';
 import type {
 	KnowledgeConfig,
 	KnowledgeEntryBase,
@@ -970,9 +971,10 @@ export async function executePhaseComplete(
 				}
 			}
 
-			// Record retrieval outcome: mark shown lessons from this phase as applied.
-			// Phase completed successfully at this point — lessons applied = positive signal.
-			await updateRetrievalOutcome(dir, `Phase ${phase}`, true);
+			// Retrieval-outcome recording moved below — it now runs after the
+			// phase's real success/failure is determined (see the call after
+			// `result` is built). Recording `true` here was wrong: it asserted
+			// success before the outcome was known.
 		} catch (error) {
 			// Log warning but don't block phase completion
 			safeWarn(
@@ -1163,11 +1165,19 @@ export async function executePhaseComplete(
 		);
 	}
 
+	// G2 (#1715): confidence-floor options derived from config once, reused by
+	// both feedback bridges (skill-usage and verdict) so they stay consistent.
+	const floorOptions: ConfidenceFloorOptions = {
+		floorAction: knowledgeConfig.confidence_floor_action,
+		floorMinOutcomes: knowledgeConfig.confidence_floor_min_outcomes,
+		floorSignalThreshold: knowledgeConfig.confidence_floor_signal_threshold,
+	};
+
 	// Skill usage feedback + pruning: close the learning loop at phase boundaries.
 	// Idempotency is provided by feedback_applied markers in the skill-usage log itself.
 	// Errors never block phase_complete.
 	try {
-		const feedbackResult = await applySkillUsageFeedback(dir);
+		const feedbackResult = await applySkillUsageFeedback(dir, { floorOptions });
 
 		if (feedbackResult.processed > 0) {
 			const sessionState = swarmState.agentSessions.get(sessionID);
@@ -1218,6 +1228,7 @@ export async function executePhaseComplete(
 		const verdictResult = await applyKnowledgeVerdictFeedback(dir, {
 			sinceTimestamp: verdictSinceTimestamp,
 			sinceEventId: verdictSinceEventId,
+			floorOptions,
 		});
 
 		if (verdictResult.lastProcessedTimestamp) {
@@ -1361,6 +1372,21 @@ export async function executePhaseComplete(
 		agentsMissing,
 		warnings,
 	};
+
+	// Record retrieval outcome for shown lessons from this phase, using the
+	// REAL outcome. Previously this was hardcoded `true` and ran before `success`
+	// was determined — so a failed phase (policy=enforce + missing required
+	// agents) could never record a 'failure' outcome, leaving the negative half
+	// of the outcome signal dead (G1). Now it runs after `success` is finalized.
+	if (
+		retroFound &&
+		retroEntry?.lessons_learned &&
+		retroEntry.lessons_learned.length > 0
+	) {
+		await updateRetrievalOutcome(dir, `Phase ${phase}`, success).catch(() => {
+			// Never throw out of phase-complete on a knowledge-store failure.
+		});
+	}
 
 	// Regression sweep check: advisory warning if enforce=true and no sweep found
 	if (phaseCompleteConfig.regression_sweep?.enforce) {

--- a/tests/unit/config/knowledge-config.test.ts
+++ b/tests/unit/config/knowledge-config.test.ts
@@ -40,6 +40,13 @@ describe('KnowledgeConfigSchema', () => {
 				default_max_phases: 10,
 				todo_max_phases: 3,
 				sweep_enabled: true,
+				// G2/G3 (#1715) feedback-loop closure fields
+				confidence_floor_action: 'demote',
+				confidence_floor_min_outcomes: 3,
+				confidence_floor_signal_threshold: 0,
+				contradiction_threshold_action: 'quarantine',
+				contradiction_quarantine_threshold: 3,
+				contradiction_quarantine_window_days: 30,
 				realtime_learning_nudge: {
 					enabled: true,
 					first_after_tool_calls: 10,
@@ -99,6 +106,13 @@ describe('KnowledgeConfigSchema', () => {
 				default_max_phases: 10,
 				todo_max_phases: 3,
 				sweep_enabled: true,
+				// G2/G3 (#1715) feedback-loop closure fields
+				confidence_floor_action: 'quarantine',
+				confidence_floor_min_outcomes: 5,
+				confidence_floor_signal_threshold: -0.1,
+				contradiction_threshold_action: 'tag_only',
+				contradiction_quarantine_threshold: 5,
+				contradiction_quarantine_window_days: 14,
 				realtime_learning_nudge: {
 					enabled: false,
 					first_after_tool_calls: 5,
@@ -224,6 +238,13 @@ describe('KnowledgeConfigSchema', () => {
 					default_max_phases: 10,
 					todo_max_phases: 3,
 					sweep_enabled: true,
+					// G2/G3 (#1715) feedback-loop closure fields
+					confidence_floor_action: 'quarantine',
+					confidence_floor_min_outcomes: 5,
+					confidence_floor_signal_threshold: -0.1,
+					contradiction_threshold_action: 'tag_only',
+					contradiction_quarantine_threshold: 5,
+					contradiction_quarantine_window_days: 14,
 					realtime_learning_nudge: {
 						enabled: false,
 						first_after_tool_calls: 5,

--- a/tests/unit/hooks/knowledge-contradiction.test.ts
+++ b/tests/unit/hooks/knowledge-contradiction.test.ts
@@ -1,0 +1,269 @@
+/**
+ * G3 (#1715) tests: contradiction signal unification.
+ *
+ * Previously `contradicted_count` (incremented only via knowledge_receipt) and
+ * curator `flag_contradiction` (tag-only) were disconnected. Now the curator
+ * emits `contradicted` events post-transaction AND threshold-based quarantine
+ * fires via maybeQuarantineOnContradiction.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { maybeQuarantineOnContradiction } from '../../../src/hooks/knowledge-escalator.js';
+import { readKnowledgeEvents } from '../../../src/hooks/knowledge-events.js';
+import {
+	readKnowledge,
+	resolveSwarmKnowledgePath,
+} from '../../../src/hooks/knowledge-store.js';
+import { applyCuratorKnowledgeUpdates } from '../../../src/hooks/curator.js';
+
+function makeTempDir(): string {
+	return mkdtempSync(join(tmpdir(), 'contradiction-test-'));
+}
+
+function ensureSwarmDir(dir: string): string {
+	const p = join(dir, '.swarm', 'knowledge-events.jsonl');
+	mkdirSync(join(dir, '.swarm'), { recursive: true });
+	return p;
+}
+
+function makeEvent(o: {
+	type: string;
+	knowledge_id: string;
+	timestamp?: string;
+}): string {
+	return JSON.stringify({
+		type: o.type,
+		event_id: randomUUID(),
+		trace_id: randomUUID(),
+		knowledge_id: o.knowledge_id,
+		timestamp: o.timestamp ?? new Date().toISOString(),
+		session_id: 'test-session',
+		agent: 'test-agent',
+	});
+}
+
+function writeEvents(
+	dir: string,
+	events: Array<{ type: string; knowledge_id: string; timestamp?: string }>,
+): void {
+	const fp = ensureSwarmDir(dir);
+	const content = events.map((e) => makeEvent(e)).join('\n') + '\n';
+	writeFileSync(fp, content, 'utf-8');
+}
+
+function writeEntry(
+	dir: string,
+	opts: { id: string; status?: string },
+): void {
+	const fp = resolveSwarmKnowledgePath(dir);
+	mkdirSync(join(dir, '.swarm'), { recursive: true });
+	writeFileSync(
+		fp,
+		JSON.stringify({
+			id: opts.id,
+			tier: 'swarm',
+			lesson: 'a test lesson long enough to pass validation checks here',
+			category: 'process',
+			tags: [],
+			scope: 'global',
+			confidence: 0.7,
+			status: opts.status ?? 'established',
+			confirmed_by: [],
+			retrieval_outcomes: {},
+			schema_version: 2,
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+		}) + '\n',
+		'utf-8',
+	);
+}
+
+async function readEntryStatus(
+	dir: string,
+	id: string,
+): Promise<string | undefined> {
+	const fp = resolveSwarmKnowledgePath(dir);
+	const entries = await readKnowledge<{ id: string; status: string }>(fp);
+	return entries.find((e) => e.id === id)?.status;
+}
+
+const defaultConfig = {
+	enabled: true,
+	swarm_max_entries: 100,
+	hive_max_entries: 200,
+	auto_promote_days: 90,
+	max_inject_count: 5,
+	dedup_threshold: 0.6,
+	scope_filter: ['global'],
+	hive_enabled: false,
+	rejected_max_entries: 20,
+	validation_enabled: false,
+	evergreen_confidence: 0.9,
+	evergreen_utility: 0.8,
+	low_utility_threshold: 0.3,
+	min_retrievals_for_utility: 3,
+	schema_version: 2,
+	same_project_weight: 1.0,
+	cross_project_weight: 0.5,
+	min_encounter_score: 0.1,
+	initial_encounter_score: 1.0,
+	encounter_increment: 0.1,
+	max_encounter_score: 10.0,
+	default_max_phases: 10,
+	todo_max_phases: 3,
+	sweep_enabled: true,
+	confidence_floor_action: 'none' as const,
+	confidence_floor_min_outcomes: 3,
+	confidence_floor_signal_threshold: 0,
+	contradiction_threshold_action: 'quarantine' as const,
+	contradiction_quarantine_threshold: 3,
+	contradiction_quarantine_window_days: 30,
+	enrichment: { max_calls_per_day: 30, quota_window: 'utc' as const },
+};
+
+describe('G3 contradiction unification (#1715)', () => {
+	let dir: string;
+	beforeEach(() => {
+		dir = makeTempDir();
+	});
+	afterEach(() => {
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	test('curator flag_contradiction emits a contradicted event post-transaction', async () => {
+		const id = randomUUID();
+		writeEntry(dir, { id });
+		await applyCuratorKnowledgeUpdates(
+			dir,
+			[{ action: 'flag_contradiction', entry_id: id, lesson: 'Test', reason: 'conflicts with new evidence' }],
+			defaultConfig,
+		);
+		const events = await readKnowledgeEvents(dir);
+		const contradicted = events.filter((e) => e.type === 'contradicted');
+		expect(contradicted.length).toBe(1);
+		expect(contradicted[0].knowledge_id).toBe(id);
+		expect((contradicted[0] as { agent?: string }).agent).toBe('curator');
+	});
+
+	test('curator flag_contradiction still adds the tag (backward compat)', async () => {
+		const id = randomUUID();
+		writeEntry(dir, { id });
+		await applyCuratorKnowledgeUpdates(
+			dir,
+			[{ action: 'flag_contradiction', entry_id: id, lesson: 'Test', reason: 'spaces vs tabs' }],
+			defaultConfig,
+		);
+		const entries = await readKnowledge<{ id: string; tags?: string[] }>(resolveSwarmKnowledgePath(dir));
+		expect(entries[0].tags).toContain('contradiction:spaces vs tabs');
+	});
+
+	test('maybeQuarantineOnContradiction quarantines when threshold crossed', async () => {
+		const id = randomUUID();
+		writeEntry(dir, { id });
+		// 3 contradicted events in window → threshold 3
+		writeEvents(dir, [
+			{ type: 'contradicted', knowledge_id: id },
+			{ type: 'contradicted', knowledge_id: id },
+			{ type: 'contradicted', knowledge_id: id },
+		]);
+		const result = await maybeQuarantineOnContradiction(dir, id, 3, 30);
+		expect(result.quarantined).toBe(true);
+		expect(result.contradictionsInWindow).toBe(3);
+		// quarantineEntry MOVES the entry to knowledge-quarantined.jsonl, so it
+		// is no longer in the active swarm file (the active read returns undefined).
+		expect(await readEntryStatus(dir, id)).toBeUndefined();
+		// And the quarantine file exists + contains the entry.
+		const quarantinePath = join(dir, '.swarm', 'knowledge-quarantined.jsonl');
+		expect(existsSync(quarantinePath)).toBe(true);
+		const qContent = readFileSync(quarantinePath, 'utf-8');
+		expect(qContent).toContain(id);
+	});
+
+	test('maybeQuarantineOnContradiction does NOT quarantine below threshold', async () => {
+		const id = randomUUID();
+		writeEntry(dir, { id });
+		writeEvents(dir, [
+			{ type: 'contradicted', knowledge_id: id },
+			{ type: 'contradicted', knowledge_id: id },
+		]);
+		const result = await maybeQuarantineOnContradiction(dir, id, 3, 30);
+		expect(result.quarantined).toBe(false);
+		expect(await readEntryStatus(dir, id)).toBe('established');
+	});
+
+	test('maybeQuarantineOnContradiction is idempotent on already-quarantined entry', async () => {
+		const id = randomUUID();
+		writeEntry(dir, { id, status: 'quarantined' });
+		writeEvents(dir, [
+			{ type: 'contradicted', knowledge_id: id },
+			{ type: 'contradicted', knowledge_id: id },
+			{ type: 'contradicted', knowledge_id: id },
+		]);
+		const result = await maybeQuarantineOnContradiction(dir, id, 3, 30);
+		expect(result.quarantined).toBe(false);
+		expect(result.alreadyInactive).toBe(true);
+	});
+
+	test('maybeQuarantineOnContradiction respects the window (old events excluded)', async () => {
+		const id = randomUUID();
+		writeEntry(dir, { id });
+		const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString(); // 60d ago
+		writeEvents(dir, [
+			{ type: 'contradicted', knowledge_id: id, timestamp: old },
+			{ type: 'contradicted', knowledge_id: id, timestamp: old },
+			{ type: 'contradicted', knowledge_id: id, timestamp: old },
+		]);
+		// 3 events but all >30d old → within 30d window = 0 → no quarantine
+		const result = await maybeQuarantineOnContradiction(dir, id, 3, 30);
+		expect(result.quarantined).toBe(false);
+	});
+
+	test('curator quarantine action fires when threshold crossed after flag_contradiction', async () => {
+		// Seed 2 prior contradicted events, then run a curator flag_contradiction
+		// (which emits a 3rd) with contradiction_threshold_action='quarantine'.
+		// The threshold check should fire and quarantine the entry.
+		const id = randomUUID();
+		writeEntry(dir, { id });
+		writeEvents(dir, [
+			{ type: 'contradicted', knowledge_id: id },
+			{ type: 'contradicted', knowledge_id: id },
+		]);
+		await applyCuratorKnowledgeUpdates(
+			dir,
+			[{ action: 'flag_contradiction', entry_id: id, lesson: 'Test', reason: 'third strike' }],
+			defaultConfig,
+		);
+		// 2 prior + 1 curator-emitted = 3 → threshold crossed → quarantined.
+		// quarantineEntry moves the entry to knowledge-quarantined.jsonl, so it
+		// is no longer in the active swarm file.
+		expect(await readEntryStatus(dir, id)).toBeUndefined();
+		const quarantinePath = join(dir, '.swarm', 'knowledge-quarantined.jsonl');
+		expect(existsSync(quarantinePath)).toBe(true);
+		expect(readFileSync(quarantinePath, 'utf-8')).toContain(id);
+	});
+
+	test('curator tag_only config preserves legacy behavior (no quarantine)', async () => {
+		const id = randomUUID();
+		writeEntry(dir, { id });
+		writeEvents(dir, [
+			{ type: 'contradicted', knowledge_id: id },
+			{ type: 'contradicted', knowledge_id: id },
+		]);
+		await applyCuratorKnowledgeUpdates(
+			dir,
+			[{ action: 'flag_contradiction', entry_id: id, lesson: 'Test', reason: 'third strike' }],
+			{ ...defaultConfig, contradiction_threshold_action: 'tag_only' },
+		);
+		// 3 contradicted events but tag_only → no quarantine, entry stays established
+		expect(await readEntryStatus(dir, id)).toBe('established');
+	});
+});

--- a/tests/unit/hooks/knowledge-floor-action.test.ts
+++ b/tests/unit/hooks/knowledge-floor-action.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for the G2 (#1715) confidence-floor action in bumpKnowledgeConfidenceBatch.
+ *
+ * Previously confidence feedback dead-ended at the floor with no consequence.
+ * Now a floor-clamped entry with a net-negative outcome signal is demoted
+ * (`confidence_floor_demoted` flag, strips retrieval `statusBoost`) or
+ * quarantined per config.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+	bumpKnowledgeConfidenceBatch,
+	resolveSwarmKnowledgePath,
+} from '../../../src/hooks/knowledge-store.js';
+
+function makeTempDir(): string {
+	return mkdtempSync(join(tmpdir(), 'floor-action-test-'));
+}
+
+function eventsPath(dir: string): string {
+	return join(dir, '.swarm', 'knowledge-events.jsonl');
+}
+
+function ensureSwarmDir(dir: string): string {
+	const p = eventsPath(dir);
+	mkdirSync(join(dir, '.swarm'), { recursive: true });
+	return p;
+}
+
+function makeReceiptEvent(o: {
+	type: string;
+	knowledge_id: string;
+	timestamp?: string;
+}): string {
+	return JSON.stringify({
+		type: o.type,
+		event_id: randomUUID(),
+		trace_id: randomUUID(),
+		knowledge_id: o.knowledge_id,
+		timestamp: o.timestamp ?? new Date().toISOString(),
+		session_id: 'test-session',
+		agent: 'test-agent',
+	});
+}
+
+function writeEvents(
+	dir: string,
+	events: Array<{ type: string; knowledge_id: string; timestamp?: string }>,
+): void {
+	const fp = ensureSwarmDir(dir);
+	const content = events.map((e) => makeReceiptEvent(e)).join('\n') + '\n';
+	writeFileSync(fp, content, 'utf-8');
+}
+
+function writeEntry(
+	dir: string,
+	opts: { id: string; confidence: number; status?: string },
+): void {
+	const fp = resolveSwarmKnowledgePath(dir);
+	mkdirSync(join(dir, '.swarm'), { recursive: true });
+	writeFileSync(
+		fp,
+		JSON.stringify({
+			id: opts.id,
+			tier: 'swarm',
+			lesson: 'a test lesson long enough to pass validation',
+			category: 'process',
+			tags: [],
+			scope: 'global',
+			confidence: opts.confidence,
+			status: opts.status ?? 'established',
+			confirmed_by: [],
+			retrieval_outcomes: {},
+			schema_version: 2,
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+		}) + '\n',
+		'utf-8',
+	);
+}
+
+async function readEntry(
+	dir: string,
+	id: string,
+): Promise<{ confidence: number; confidence_floor_demoted?: boolean; status?: string } | undefined> {
+	const fp = resolveSwarmKnowledgePath(dir);
+	const { readKnowledge } = await import('../../../src/hooks/knowledge-store.js');
+	const entries = await readKnowledge<{ id: string; confidence: number; confidence_floor_demoted?: boolean; status?: string }>(fp);
+	return entries.find((e) => e.id === id);
+}
+
+describe('G2 confidence-floor action (#1715)', () => {
+	let dir: string;
+	beforeEach(() => {
+		dir = makeTempDir();
+	});
+	afterEach(() => {
+		try {
+			import('node:fs').then(({ rmSync }) => rmSync(dir, { recursive: true, force: true }));
+		} catch {
+			/* ignore */
+		}
+	});
+
+	test('demotes a floor entry with net-negative outcome signal (default demote)', async () => {
+		const id = randomUUID();
+		writeEntry(dir, { id, confidence: 0.15 }); // one small decay will clamp to 0.1
+		// 4 violated events → net-negative signal, ≥3 outcomes (min default)
+		writeEvents(dir, [
+			{ type: 'violated', knowledge_id: id },
+			{ type: 'violated', knowledge_id: id },
+			{ type: 'violated', knowledge_id: id },
+			{ type: 'violated', knowledge_id: id },
+		]);
+		// -0.1 delta clamps to floor 0.1
+		await bumpKnowledgeConfidenceBatch(dir, [{ id, delta: -0.1 }]);
+		const entry = await readEntry(dir, id);
+		expect(entry?.confidence).toBe(0.1);
+		expect(entry?.confidence_floor_demoted).toBe(true);
+	});
+
+	test('does NOT demote when evidence is below floorMinOutcomes', async () => {
+		const id = randomUUID();
+		writeEntry(dir, { id, confidence: 0.15 });
+		// only 2 violated → below default min 3
+		writeEvents(dir, [
+			{ type: 'violated', knowledge_id: id },
+			{ type: 'violated', knowledge_id: id },
+		]);
+		await bumpKnowledgeConfidenceBatch(dir, [{ id, delta: -0.1 }]);
+		const entry = await readEntry(dir, id);
+		expect(entry?.confidence).toBe(0.1);
+		expect(entry?.confidence_floor_demoted).toBeUndefined();
+	});
+
+	test('does NOT demote when outcome signal is net-positive', async () => {
+		const id = randomUUID();
+		writeEntry(dir, { id, confidence: 0.15 });
+		// 5 applied vs 1 violated → net-positive
+		writeEvents(dir, [
+			{ type: 'applied', knowledge_id: id },
+			{ type: 'applied', knowledge_id: id },
+			{ type: 'applied', knowledge_id: id },
+			{ type: 'applied', knowledge_id: id },
+			{ type: 'applied', knowledge_id: id },
+			{ type: 'violated', knowledge_id: id },
+		]);
+		await bumpKnowledgeConfidenceBatch(dir, [{ id, delta: -0.1 }]);
+		const entry = await readEntry(dir, id);
+		expect(entry?.confidence).toBe(0.1);
+		expect(entry?.confidence_floor_demoted).toBeUndefined();
+	});
+
+	test('clears stale confidence_floor_demoted flag on recovery above floor', async () => {
+		const id = randomUUID();
+		// Start demoted at the floor.
+		writeEntry(dir, { id, confidence: 0.1 });
+		// First bump with no outcome evidence → flag would not be SET (no signal),
+		// so seed the flag manually first by writing it directly.
+		const fp = resolveSwarmKnowledgePath(dir);
+		const { readKnowledge } = await import('../../../src/hooks/knowledge-store.js');
+		const entries = await readKnowledge<{ id: string; confidence_floor_demoted?: boolean; confidence: number }>(fp);
+		entries[0].confidence_floor_demoted = true;
+		writeFileSync(fp, JSON.stringify(entries[0]) + '\n', 'utf-8');
+
+		// +0.4 boost → rises well above floor; no events → recovered branch fires
+		await bumpKnowledgeConfidenceBatch(dir, [{ id, delta: 0.4 }]);
+		const entry = await readEntry(dir, id);
+		expect(entry?.confidence).toBeGreaterThan(0.1);
+		expect(entry?.confidence_floor_demoted).toBe(false);
+	});
+
+	test('floorAction:"none" preserves legacy dead-end behavior (no flag)', async () => {
+		const id = randomUUID();
+		writeEntry(dir, { id, confidence: 0.15 });
+		writeEvents(dir, [
+			{ type: 'violated', knowledge_id: id },
+			{ type: 'violated', knowledge_id: id },
+			{ type: 'violated', knowledge_id: id },
+			{ type: 'violated', knowledge_id: id },
+		]);
+		await bumpKnowledgeConfidenceBatch(
+			dir,
+			[{ id, delta: -0.1 }],
+			{ floorAction: 'none' },
+		);
+		const entry = await readEntry(dir, id);
+		expect(entry?.confidence).toBe(0.1);
+		expect(entry?.confidence_floor_demoted).toBeUndefined();
+	});
+
+	test('idempotent: re-running the same delta re-sets the flag harmlessly', async () => {
+		const id = randomUUID();
+		writeEntry(dir, { id, confidence: 0.15 });
+		writeEvents(dir, [
+			{ type: 'violated', knowledge_id: id },
+			{ type: 'violated', knowledge_id: id },
+			{ type: 'violated', knowledge_id: id },
+			{ type: 'violated', knowledge_id: id },
+		]);
+		await bumpKnowledgeConfidenceBatch(dir, [{ id, delta: -0.1 }]);
+		// Second run with a no-op delta (0) — entry stays at floor, flag stays true
+		await bumpKnowledgeConfidenceBatch(dir, [{ id, delta: 0 }]);
+		const entry = await readEntry(dir, id);
+		expect(entry?.confidence).toBe(0.1);
+		expect(entry?.confidence_floor_demoted).toBe(true);
+	});
+});

--- a/tests/unit/hooks/search-knowledge.test.ts
+++ b/tests/unit/hooks/search-knowledge.test.ts
@@ -611,4 +611,46 @@ describe('searchKnowledge (unified retrieval)', () => {
 		// The valid entry must survive the malformed neighbor.
 		expect(results.map((r) => r.id)).toContain('valid');
 	});
+
+	it('G2 (#1715): a confidence-floor-demoted entry ranks below an equal healthy entry', async () => {
+		// Two DISTINCT lessons that both match the query (identical text would
+		// be deduped by the Jaccard≥0.6 rule). The only score-relevant
+		// difference: one carries the confidence_floor_demoted flag.
+		await appendKnowledge(
+			kp,
+			makeEntry({
+				id: 'healthy',
+				lesson: 'Always validate user input before processing http requests',
+			}),
+		);
+		await appendKnowledge(
+			kp,
+			makeEntry({
+				id: 'demoted',
+				lesson: 'Validate user input thoroughly before processing form submissions',
+				confidence_floor_demoted: true,
+			}),
+		);
+
+		const { results } = await searchKnowledge({
+			directory: dir,
+			config,
+			query: 'validate user input',
+			mode: 'manual',
+			agent: 'architect',
+			sessionId: 's1',
+			tier: 'swarm',
+			applyScopeFilter: false,
+			emitEvent: false,
+		});
+
+		// Both surface (demote suppresses the statusBoost, not retrieval entirely).
+		expect(results.map((r) => r.id)).toContain('healthy');
+		expect(results.map((r) => r.id)).toContain('demoted');
+		// The healthy entry must rank above the demoted one — the demoted entry
+		// loses its `established` statusBoost (0.1) so its score is strictly lower.
+		const healthyIdx = results.findIndex((r) => r.id === 'healthy');
+		const demotedIdx = results.findIndex((r) => r.id === 'demoted');
+		expect(healthyIdx).toBeLessThan(demotedIdx);
+	});
 });

--- a/tests/unit/tools/phase-complete-outcome-regression.test.ts
+++ b/tests/unit/tools/phase-complete-outcome-regression.test.ts
@@ -1,0 +1,52 @@
+/**
+ * G1 (#1715) regression guard: phase-complete must call updateRetrievalOutcome
+ * with the REAL phase outcome (the `success` variable), not a hardcoded `true`.
+ *
+ * The original bug was `updateRetrievalOutcome(dir, name, true)` at the old
+ * call site, which asserted success before the outcome was known. This test
+ * reads phase-complete.ts as source and asserts:
+ *   1. no call site passes a literal `true` as the third argument
+ *   2. the call passes the `success` variable
+ *
+ * This is a source-level guard rather than a behavioral integration test
+ * because phase-complete has a very heavy mock surface (see the locking /
+ * curator / evidence mocks in other phase-complete test files), and the bug
+ * is specifically about which argument value is wired through — a concern the
+ * type system alone cannot enforce (the signature is `boolean` either way).
+ * The companion behavioral test for `false` → 'failure' event lives in
+ * tests/unit/hooks/knowledge-reader.test.ts (Test 12).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC = readFileSync(
+	join(import.meta.dir, '..', '..', '..', 'src', 'tools', 'phase-complete.ts'),
+	'utf-8',
+);
+
+describe('G1 phase-complete outcome wiring regression (#1715)', () => {
+	test('no call site passes a literal `true` to updateRetrievalOutcome', () => {
+		// The bug: `updateRetrievalOutcome(dir, name, true)`. Match any call
+		// whose third arg is the literal `true` (with optional whitespace).
+		const literalTrueCall = /updateRetrievalOutcome\s*\([^)]*,\s*true\s*\)/;
+		expect(literalTrueCall.test(SRC)).toBe(false);
+	});
+
+	test('the call site passes the `success` variable (the real outcome)', () => {
+		// The fix passes `success` — the variable finalized from agentsMissing +
+		// policy. Match any call whose third arg is the identifier `success`.
+		const successVarCall = /updateRetrievalOutcome\s*\([^)]*,\s*success\b[^)]*\)/;
+		expect(successVarCall.test(SRC)).toBe(true);
+	});
+
+	test('the old comment about "Phase completed successfully at this point" is gone', () => {
+		// The old code carried a false-premise comment justifying the hardcoded
+		// true. Its presence would indicate a partial revert. The new code has
+		// a different explanatory comment instead.
+		expect(SRC).not.toContain(
+			'Phase completed successfully at this point — lessons applied = positive signal',
+		);
+	});
+});


### PR DESCRIPTION
Closes #1715

## Summary

The knowledge feedback loop was an open circuit — outcome signals were recorded but nothing acted on them. Three gaps fixed (G1/G2/G3 from the gap catalog):

- **G1 — phase-failure outcomes now record.** `phase-complete` previously called `updateRetrievalOutcome(dir, name, true)` with a hardcoded `true` at a point in the flow before `success` was determined. The call now runs after the real outcome is finalized and passes that value, so a failed phase (`policy=enforce` + missing required agents) emits `'failure'` outcome events and `failed_after_shown_count` can finally increment.
- **G2 — confidence-floor action.** Both feedback bridges (`applySkillUsageFeedback`, `applyKnowledgeVerdictFeedback`) bumped `entry.confidence` but nothing acted on low confidence — the bumps dead-ended at the floor. Now `bumpKnowledgeConfidenceBatch` runs a post-bump sweep that demotes (`confidence_floor_demoted` flag → strips retrieval `statusBoost`) or quarantines per config entries that are floor-clamped AND have a net-negative outcome signal over ≥3 outcome events. Reversible by default.
- **G3 — contradiction signals unified.** `contradicted_count` (incremented only via `knowledge_receipt`) and the curator's `flag_contradiction` (tag-only) were disconnected. The curator now emits `contradicted` events post-transaction (with `agent: 'curator'` for audit), and a new `maybeQuarantineOnContradiction` auto-quarantines entries whose in-window contradicted count crosses the threshold (default 3 in 30d). Counts come from the RAW event log, not the mtime-keyed rollup cache, to avoid stale-count risk.

The genuinely-closed sub-loop was previously only the violation-count → escalator → enforce-block path. This change closes the confidence/contradiction/phase-failure halves.

## Invariant audit

- 1 (plugin init): not touched — no plugin-registration changes.
- 2 (runtime portability): not touched — pure TS, no runtime-specific code.
- 3 (subprocesses): not touched.
- 4 (.swarm containment): not touched — new artifacts (`contradicted` events, `confidence_floor_demoted` flag) write only to existing `.swarm/` knowledge + events files; no new locations.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched.
- 7 (test writing): touched — 4 new/updated test files co-located with source per convention; each runs in its own process to avoid the cross-file contamination tracked in #1712.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched — fail-open semantics preserved (`bumpKnowledgeConfidenceBatch` and the new floor-action are best-effort, never throw).
- 10 (chat/system msg): not touched — the G2 `statusBoost` gate is read-only on retrieval scoring.
- 11 (tool registration): not touched.
- 12 (release/cache): touched — release fragment added at `docs/releases/pending/1715-close-knowledge-feedback-loop.md`; no version files edited.

## Test plan

Validation commands run + results:

```
$ bun run typecheck                    # tsc --noEmit
(empty — clean)

$ bun run lint                         # biome lint .
Checked 2313 files. No fixes applied.

# Each affected test file in its own process (per repo convention; the
# combined single-process run has pre-existing cross-file contamination
# tracked in #1712 — see proof below).
$ bun --smol test tests/unit/config/knowledge-config.test.ts            # 43 pass / 0 fail
$ bun --smol test tests/unit/hooks/knowledge-reader.test.ts             # 20 pass / 0 fail
$ bun --smol test tests/unit/hooks/knowledge-events.test.ts             # 24 pass / 0 fail
$ bun --smol test tests/unit/hooks/knowledge-store.test.ts              # 39 pass / 0 fail
$ bun --smol test tests/unit/hooks/knowledge-verdict-feedback.test.ts   # 10 pass / 0 fail
$ bun --smol test tests/unit/hooks/curator.test.ts                      # 118 pass / 0 fail
$ bun --smol test tests/unit/hooks/knowledge-escalator.test.ts          # 5 pass / 0 fail
$ bun --smol test tests/unit/hooks/knowledge-floor-action.test.ts       # 6 pass / 0 fail   (NEW)
$ bun --smol test tests/unit/hooks/knowledge-contradiction.test.ts      # 8 pass / 0 fail   (NEW)
$ bun --smol test tests/unit/hooks/search-knowledge.test.ts             # 14 pass / 0 fail
$ bun --smol test tests/unit/tools/phase-complete-outcome-regression.test.ts  # 3 pass / 0 fail  (NEW)
                                                                        # = 290 pass / 0 fail
```

**Pre-existing-failure proof (combined run is NOT a regression):** the combined single-process run produces 24 failures — but I verified this is identical on clean `origin/main` (worktree at HEAD c5eb59cd, before any of these edits): same 24 failures, same pass count. This is the documented cross-file mock/state contamination tracked in #1712, not caused by this change.

**Independent review:** GLM-5.2 reviewer (fresh context) returned NEEDS_REVISION with 5 findings (2 HIGH broken config fixtures + missing tests; 1 MED hive quarantine no-op; 2 LOW). All addressed. GLM-5.2 critic (separate fresh context) returned APPROVE with 2 optional LOW improvements, both applied (floor-action `console.warn`, behavioral retrieval-ranking test).

New test coverage:
- G2: floor-demote on net-negative signal, min-outcomes gate, net-positive skip, recovery clears stale flag, `none`=legacy, idempotency, retrieval down-ranking.
- G3: curator emits `contradicted` event, tag preserved (back-compat), threshold quarantine, below-threshold skip, idempotency on already-quarantined, window respected, curator→quarantine end-to-end, `tag_only`=legacy.
- G1: source-level regression guard (no literal `true`, passes `success` var, old false-premise comment gone). Companion behavioral test (`false` → `'failure'` event) already exists at `knowledge-reader.test.ts` Test 12.

## How to use

New config knobs (all optional, conservative defaults):
- `knowledge.confidence_floor_action`: `'none' | 'demote' | 'quarantine'` (default `'demote'`).
- `knowledge.confidence_floor_min_outcomes`: default `3`.
- `knowledge.confidence_floor_signal_threshold`: default `0` (net-negative).
- `knowledge.contradiction_threshold_action`: `'tag_only' | 'quarantine'` (default `'quarantine'`).
- `knowledge.contradiction_quarantine_threshold`: default `3`.
- `knowledge.contradiction_quarantine_window_days`: default `30`.

For the legacy dead-end behavior: `confidence_floor_action: 'none'` + `contradiction_threshold_action: 'tag_only'`.

## Migration

No migration required. New config fields default to conservative behavior. Existing entries without `confidence_floor_demoted` read as `undefined` → not-demoted (legacy). Hive floor-entries get the flag (honored by retrieval) but not quarantine (the quarantine mechanism reads only the swarm file — documented in the release fragment).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

