### PR TITLE
fix(config): preserve config around invalid gates entries

### DIFF
--- a/docs/releases/pending/gates-config-section-fallback.md
+++ b/docs/releases/pending/gates-config-section-fallback.md
@@ -1,0 +1,7 @@
+Fixes gates config parsing so partial or typoed `gates` blocks no longer wipe the entire user configuration.
+
+- Partial `gates` configs now receive defaults for omitted gate sections instead of failing full config validation.
+- Invalid or unknown `gates` subsections are ignored with a warning while the rest of the user's valid config remains active.
+- `/swarm config doctor` now reports invalid or typoed raw `gates` entries so users can find and repair the ignored section.
+
+No migration is required.

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -4,6 +4,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import {
 	ExternalSkillsConfigSchema,
+	GATE_CONFIG_KNOWN_SECTION_KEYS,
+	GateConfigSchema,
 	type PluginConfig,
 	PluginConfigSchema,
 	resolveExternalSkillsConfig,
@@ -170,6 +172,93 @@ function sanitizeExternalSkillsConfig(
 	return cleaned;
 }
 
+function sanitizeGatesConfig(
+	raw: Record<string, unknown>,
+): Record<string, unknown> {
+	if (!('gates' in raw) || raw.gates === undefined) {
+		return raw;
+	}
+	if (
+		typeof raw.gates !== 'object' ||
+		raw.gates === null ||
+		Array.isArray(raw.gates)
+	) {
+		console.warn(
+			'[opencode-swarm] gates config validation failed: expected an object. Quality gates will use defaults; other config sections remain active.',
+		);
+		const cleaned = { ...raw };
+		delete cleaned.gates;
+		return cleaned;
+	}
+
+	const gateSchemas = GateConfigSchema.shape;
+	const cleanedGates = { ...(raw.gates as Record<string, unknown>) };
+	for (const [key, value] of Object.entries(cleanedGates)) {
+		const schema = gateSchemas[key as keyof typeof gateSchemas];
+		if (!schema) {
+			console.warn(
+				`[opencode-swarm] Unknown gates config section "gates.${key}" ignored. Other config sections remain active.`,
+			);
+			delete cleanedGates[key];
+			continue;
+		}
+		const knownFields =
+			GATE_CONFIG_KNOWN_SECTION_KEYS[
+				key as keyof typeof GATE_CONFIG_KNOWN_SECTION_KEYS
+			];
+		let sectionValue = value;
+		if (
+			knownFields &&
+			typeof value === 'object' &&
+			value !== null &&
+			!Array.isArray(value)
+		) {
+			const cleanedSection = { ...(value as Record<string, unknown>) };
+			const knownFieldSet = new Set<string>(knownFields);
+			for (const fieldName of Object.keys(cleanedSection)) {
+				if (!knownFieldSet.has(fieldName)) {
+					console.warn(
+						`[opencode-swarm] Unknown gates config key "gates.${key}.${fieldName}" ignored. Other config sections remain active.`,
+					);
+					delete cleanedSection[fieldName];
+				}
+			}
+			sectionValue = cleanedSection;
+			cleanedGates[key] = cleanedSection;
+		}
+		const sectionResult = schema.safeParse(sectionValue);
+		if (!sectionResult.success) {
+			console.warn(
+				`[opencode-swarm] gates.${key} config validation failed; that gate section will use defaults and other config sections remain active:`,
+			);
+			console.warn(sectionResult.error.format());
+			delete cleanedGates[key];
+		}
+	}
+
+	const gatesResult = GateConfigSchema.safeParse(cleanedGates);
+	if (gatesResult.success) {
+		return {
+			...raw,
+			gates: gatesResult.data,
+		};
+	}
+
+	console.warn(
+		'[opencode-swarm] gates config validation failed after section cleanup; quality gates will use defaults and other config sections remain active:',
+	);
+	console.warn(gatesResult.error.format());
+	const cleaned = { ...raw };
+	delete cleaned.gates;
+	return cleaned;
+}
+
+function sanitizeSectionConfigs(
+	raw: Record<string, unknown>,
+): Record<string, unknown> {
+	return sanitizeGatesConfig(sanitizeExternalSkillsConfig(raw));
+}
+
 /**
  * Load plugin configuration from user and project config files.
  *
@@ -242,8 +331,8 @@ export function loadPluginConfig(directory: string): PluginConfig {
 	// Migrate v6.12 presets format to v6.13+ agents format
 	mergedRaw = migratePresetsConfig(mergedRaw);
 
-	// Pre-validate external_skills so invalid config doesn't block plugin load
-	mergedRaw = sanitizeExternalSkillsConfig(mergedRaw);
+	// Pre-validate section-local configs so one invalid section doesn't block plugin load.
+	mergedRaw = sanitizeSectionConfigs(mergedRaw);
 
 	// Validate merged config with Zod (applies defaults ONCE).
 	// Nested optional schemas (e.g. council.general) surface automatically
@@ -255,7 +344,7 @@ export function loadPluginConfig(directory: string): PluginConfig {
 		// (project config may have invalid values that should be ignored)
 		if (rawUserConfig) {
 			const userParseResult = PluginConfigSchema.safeParse(
-				sanitizeExternalSkillsConfig(rawUserConfig ?? {}),
+				sanitizeSectionConfigs(rawUserConfig ?? {}),
 			);
 			if (userParseResult.success) {
 				console.warn(
@@ -399,12 +488,12 @@ function reduceParsedConfig(
 		>;
 	}
 	mergedRaw = migratePresetsConfig(mergedRaw);
-	mergedRaw = sanitizeExternalSkillsConfig(mergedRaw);
+	mergedRaw = sanitizeSectionConfigs(mergedRaw);
 	const result = PluginConfigSchema.safeParse(mergedRaw);
 	if (!result.success) {
 		if (rawUserConfig) {
 			const userParseResult = PluginConfigSchema.safeParse(
-				sanitizeExternalSkillsConfig(rawUserConfig ?? {}),
+				sanitizeSectionConfigs(rawUserConfig ?? {}),
 			);
 			if (userParseResult.success) {
 				console.warn(

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -374,6 +374,28 @@ export const QualityBudgetConfigSchema = GateFeatureSchema.extend({
 
 export type QualityBudgetConfig = z.infer<typeof QualityBudgetConfigSchema>;
 
+export const GATE_CONFIG_KNOWN_SECTION_KEYS = {
+	syntax_check: ['enabled'],
+	placeholder_scan: [
+		'enabled',
+		'deny_patterns',
+		'allow_globs',
+		'max_allowed_findings',
+	],
+	sast_scan: ['enabled'],
+	sbom_generate: ['enabled'],
+	build_check: ['enabled'],
+	quality_budget: [
+		'enabled',
+		'max_complexity_delta',
+		'max_public_api_delta',
+		'max_duplication_ratio',
+		'min_test_to_code_ratio',
+		'enforce_on_globs',
+		'exclude_globs',
+	],
+} as const;
+
 export const GateConfigSchema = z.object({
 	syntax_check: GateFeatureSchema.default({ enabled: true }),
 	placeholder_scan: PlaceholderScanConfigSchema.default({
@@ -402,7 +424,9 @@ export const GateConfigSchema = z.object({
 	sast_scan: GateFeatureSchema.default({ enabled: true }),
 	sbom_generate: GateFeatureSchema.default({ enabled: true }),
 	build_check: GateFeatureSchema.default({ enabled: true }),
-	quality_budget: QualityBudgetConfigSchema,
+	quality_budget: QualityBudgetConfigSchema.default(() =>
+		QualityBudgetConfigSchema.parse({}),
+	),
 });
 
 export type GateConfig = z.infer<typeof GateConfigSchema>;

--- a/src/services/config-doctor.test.ts
+++ b/src/services/config-doctor.test.ts
@@ -306,6 +306,34 @@ describe('Config Doctor Service', () => {
 			expect(typoFinding).toBeDefined();
 			expect(typoFinding!.description).toContain('ignored by the loader');
 		});
+
+		it('should surface unknown gates section name that the loader ignores', () => {
+			createTestConfig(tempDir, {
+				max_iterations: 5,
+				gates: {
+					syntax_check: { enabled: true },
+					unknown_gate_type: { enabled: true },
+				},
+			});
+			const config = createTestConfigObj({
+				max_iterations: 5,
+				gates: {
+					syntax_check: { enabled: true },
+				},
+			});
+
+			const result = runConfigDoctor(config, tempDir);
+
+			const unknownSectionFinding = result.findings.find(
+				(f) =>
+					f.id === 'unknown-gates-section' &&
+					f.path === 'gates.unknown_gate_type',
+			);
+			expect(unknownSectionFinding).toBeDefined();
+			expect(unknownSectionFinding!.description).toContain(
+				'ignored by the loader',
+			);
+		});
 	});
 
 	describe('Swarms validation — empty and path-traversal (AC-4 SC-004)', () => {

--- a/src/services/config-doctor.test.ts
+++ b/src/services/config-doctor.test.ts
@@ -245,6 +245,67 @@ describe('Config Doctor Service', () => {
 				`'swarms' must emit a finding when set to a non-object value (got string)`,
 			).toBeGreaterThan(0);
 		});
+
+		it('should surface invalid raw gates subsection after loader sanitization', () => {
+			createTestConfig(tempDir, {
+				max_iterations: 7,
+				gates: {
+					syntax_check: { enabled: false },
+					placeholder_scan: {
+						deny_patterns: 'TODO',
+					},
+				},
+			});
+			const config = createTestConfigObj({
+				max_iterations: 7,
+				gates: {
+					syntax_check: { enabled: false },
+				},
+			});
+
+			const result = runConfigDoctor(config, tempDir);
+
+			const gatesFinding = result.findings.find(
+				(f) =>
+					f.id === 'invalid-gates-section' &&
+					f.path === 'gates.placeholder_scan',
+			);
+			expect(gatesFinding).toBeDefined();
+			expect(gatesFinding!.description).toContain(
+				'keeps other valid config sections active',
+			);
+		});
+
+		it('should surface typoed raw gates keys that Zod would otherwise strip', () => {
+			createTestConfig(tempDir, {
+				max_iterations: 6,
+				gates: {
+					placeholder_scan: {
+						enabled: false,
+						max_allowed_finding: 2,
+					},
+				},
+			});
+			const config = createTestConfigObj({
+				max_iterations: 6,
+				gates: {
+					placeholder_scan: {
+						enabled: false,
+						max_allowed_findings: 0,
+					},
+				},
+			});
+
+			const result = runConfigDoctor(config, tempDir);
+
+			const typoFinding = result.findings.find(
+				(f) =>
+					f.id === 'unknown-gates-key' &&
+					f.path === 'gates.placeholder_scan.max_allowed_finding',
+			);
+			expect(typoFinding).toBeDefined();
+			expect(typoFinding!.description).toContain('ignored by the loader');
+		});
 	});
 
 	describe('Swarms validation — empty and path-traversal (AC-4 SC-004)', () => {

--- a/src/services/config-doctor.ts
+++ b/src/services/config-doctor.ts
@@ -11,8 +11,15 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { ALL_AGENT_NAMES } from '../config/constants';
 import type { PluginConfig } from '../config/schema';
-import { PluginConfigSchema, stripKnownSwarmPrefix } from '../config/schema';
+import {
+	GATE_CONFIG_KNOWN_SECTION_KEYS,
+	GateConfigSchema,
+	PluginConfigSchema,
+	stripKnownSwarmPrefix,
+} from '../config/schema';
 import { log } from '../utils';
+
+const CONFIG_DOCTOR_MAX_CONFIG_FILE_BYTES = 102_400;
 
 /**
  * Cached set of all top-level keys from PluginConfigSchema.
@@ -120,6 +127,96 @@ function emitObjectTypeMismatch(
 			autoFixable: false,
 		});
 	}
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function collectRawGatesConfigFindings(directory: string): ConfigFinding[] {
+	const findings: ConfigFinding[] = [];
+	const { userConfigPath, projectConfigPath } = getConfigPaths(directory);
+
+	for (const configPath of [userConfigPath, projectConfigPath]) {
+		if (!fs.existsSync(configPath)) continue;
+		try {
+			const stats = fs.statSync(configPath);
+			if (stats.size > CONFIG_DOCTOR_MAX_CONFIG_FILE_BYTES) continue;
+			const raw = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as unknown;
+			if (!isPlainObject(raw) || raw.gates === undefined) continue;
+
+			if (!isPlainObject(raw.gates)) {
+				findings.push({
+					id: 'invalid-gates-config',
+					title: 'Invalid gates config',
+					description: `"gates" in ${configPath} must be an object. The loader ignores that section and keeps other valid config sections active.`,
+					severity: 'error',
+					path: 'gates',
+					currentValue: raw.gates,
+					autoFixable: false,
+				});
+				continue;
+			}
+
+			for (const [sectionName, sectionValue] of Object.entries(raw.gates)) {
+				const schema =
+					GateConfigSchema.shape[
+						sectionName as keyof typeof GateConfigSchema.shape
+					];
+				if (!schema) {
+					findings.push({
+						id: 'unknown-gates-section',
+						title: 'Unknown gates config section',
+						description: `Unknown gates section "gates.${sectionName}" in ${configPath} is ignored by the loader.`,
+						severity: 'warn',
+						path: `gates.${sectionName}`,
+						currentValue: sectionValue,
+						autoFixable: false,
+					});
+					continue;
+				}
+
+				const knownFields =
+					GATE_CONFIG_KNOWN_SECTION_KEYS[
+						sectionName as keyof typeof GATE_CONFIG_KNOWN_SECTION_KEYS
+					];
+				if (knownFields && isPlainObject(sectionValue)) {
+					const knownFieldSet = new Set<string>(knownFields);
+					for (const fieldName of Object.keys(sectionValue)) {
+						if (!knownFieldSet.has(fieldName)) {
+							findings.push({
+								id: 'unknown-gates-key',
+								title: 'Unknown gates config key',
+								description: `Unknown gates key "gates.${sectionName}.${fieldName}" in ${configPath} is ignored by the loader.`,
+								severity: 'warn',
+								path: `gates.${sectionName}.${fieldName}`,
+								currentValue: sectionValue[fieldName],
+								autoFixable: false,
+							});
+						}
+					}
+				}
+
+				const sectionResult = schema.safeParse(sectionValue);
+				if (!sectionResult.success) {
+					findings.push({
+						id: 'invalid-gates-section',
+						title: 'Invalid gates config section',
+						description: `"gates.${sectionName}" in ${configPath} failed validation. The loader uses defaults for that gate section and keeps other valid config sections active.`,
+						severity: 'error',
+						path: `gates.${sectionName}`,
+						currentValue: sectionValue,
+						autoFixable: false,
+					});
+				}
+			}
+		} catch {
+			// Raw config load failures are already handled by the loader; the doctor
+			// should stay best-effort and non-blocking.
+		}
+	}
+
+	return findings;
 }
 
 function emitWorktreeIsolationLayeringAdvisory(
@@ -1348,6 +1445,7 @@ export function runConfigDoctor(
 
 	// Walk the config and validate
 	walkConfigAndValidate(config, '', findings);
+	findings.push(...collectRawGatesConfigFindings(directory));
 	emitWorktreeIsolationLayeringAdvisory(config, findings);
 
 	// Count by severity

--- a/tests/unit/config/loader.test.ts
+++ b/tests/unit/config/loader.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -678,6 +678,155 @@ describe('config/loader', () => {
 			expect(Object.hasOwn(result, '_loadedFromFile')).toBe(false);
 
 			fs.rmSync(projectDir, { recursive: true, force: true });
+		});
+
+		it('loads partial gates config without falling back to bare defaults', () => {
+			const userConfigDir = path.join(tempDir, 'opencode');
+			const userConfigFile = path.join(userConfigDir, 'opencode-swarm.json');
+			fs.mkdirSync(userConfigDir, { recursive: true });
+			fs.writeFileSync(
+				userConfigFile,
+				JSON.stringify({
+					max_iterations: 7,
+					gates: {
+						placeholder_scan: {
+							enabled: false,
+							max_allowed_findings: 2,
+						},
+					},
+				}),
+			);
+
+			const projectDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'project-test-')),
+			);
+
+			const result = loadPluginConfig(projectDir);
+
+			expect(result.max_iterations).toBe(7);
+			expect(result.gates?.placeholder_scan.enabled).toBe(false);
+			expect(result.gates?.placeholder_scan.max_allowed_findings).toBe(2);
+			expect(result.gates?.quality_budget.enabled).toBe(true);
+
+			fs.rmSync(projectDir, { recursive: true, force: true });
+		});
+
+		it('warns and keeps valid config when one gates subsection is invalid', () => {
+			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+			const userConfigDir = path.join(tempDir, 'opencode');
+			const userConfigFile = path.join(userConfigDir, 'opencode-swarm.json');
+			fs.mkdirSync(userConfigDir, { recursive: true });
+			fs.writeFileSync(
+				userConfigFile,
+				JSON.stringify({
+					max_iterations: 7,
+					qa_retry_limit: 8,
+					gates: {
+						syntax_check: { enabled: false },
+						placeholder_scan: {
+							deny_patterns: 'TODO',
+						},
+					},
+				}),
+			);
+
+			const projectDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'project-test-')),
+			);
+
+			try {
+				const result = loadPluginConfig(projectDir);
+
+				expect(result.max_iterations).toBe(7);
+				expect(result.qa_retry_limit).toBe(8);
+				expect(result.gates?.syntax_check.enabled).toBe(false);
+				expect(result.gates?.placeholder_scan.enabled).toBe(true);
+				expect(
+					Array.isArray(result.gates?.placeholder_scan.deny_patterns),
+				).toBe(true);
+
+				const warnings = warnSpy.mock.calls.flat().join('\n');
+				expect(warnings).toContain('gates.placeholder_scan');
+				expect(warnings).toContain('other config sections remain active');
+			} finally {
+				warnSpy.mockRestore();
+				fs.rmSync(projectDir, { recursive: true, force: true });
+			}
+		});
+
+		it('warns and ignores typoed gates sections without disabling other config', () => {
+			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+			const userConfigDir = path.join(tempDir, 'opencode');
+			const userConfigFile = path.join(userConfigDir, 'opencode-swarm.json');
+			fs.mkdirSync(userConfigDir, { recursive: true });
+			fs.writeFileSync(
+				userConfigFile,
+				JSON.stringify({
+					max_iterations: 6,
+					gates: {
+						placeholder_scn: { enabled: false },
+						syntax_check: { enabled: false },
+					},
+				}),
+			);
+
+			const projectDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'project-test-')),
+			);
+
+			try {
+				const result = loadPluginConfig(projectDir);
+
+				expect(result.max_iterations).toBe(6);
+				expect(result.gates?.syntax_check.enabled).toBe(false);
+
+				const warnings = warnSpy.mock.calls.flat().join('\n');
+				expect(warnings).toContain('gates.placeholder_scn');
+				expect(warnings).toContain('Other config sections remain active');
+			} finally {
+				warnSpy.mockRestore();
+				fs.rmSync(projectDir, { recursive: true, force: true });
+			}
+		});
+
+		it('warns and ignores typoed gates keys without disabling other config', () => {
+			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+			const userConfigDir = path.join(tempDir, 'opencode');
+			const userConfigFile = path.join(userConfigDir, 'opencode-swarm.json');
+			fs.mkdirSync(userConfigDir, { recursive: true });
+			fs.writeFileSync(
+				userConfigFile,
+				JSON.stringify({
+					max_iterations: 6,
+					gates: {
+						placeholder_scan: {
+							enabled: false,
+							max_allowed_finding: 2,
+						},
+					},
+				}),
+			);
+
+			const projectDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'project-test-')),
+			);
+
+			try {
+				const result = loadPluginConfig(projectDir);
+
+				expect(result.max_iterations).toBe(6);
+				expect(result.gates?.placeholder_scan.enabled).toBe(false);
+				expect(result.gates?.placeholder_scan.max_allowed_findings).toBe(0);
+
+				const warnings = warnSpy.mock.calls.flat().join('\n');
+				expect(warnings).toContain(
+					'gates.placeholder_scan.max_allowed_finding',
+				);
+				expect(warnings).toContain('Other config sections remain active');
+			} finally {
+				warnSpy.mockRestore();
+				fs.rmSync(projectDir, { recursive: true, force: true });
+			}
 		});
 
 		// Security fix: fail-secure fallback tests

--- a/tests/unit/config/loader.test.ts
+++ b/tests/unit/config/loader.test.ts
@@ -744,6 +744,7 @@ describe('config/loader', () => {
 				expect(
 					Array.isArray(result.gates?.placeholder_scan.deny_patterns),
 				).toBe(true);
+				expect(result.gates?.quality_budget.enabled).toBe(true);
 
 				const warnings = warnSpy.mock.calls.flat().join('\n');
 				expect(warnings).toContain('gates.placeholder_scan');
@@ -779,6 +780,7 @@ describe('config/loader', () => {
 
 				expect(result.max_iterations).toBe(6);
 				expect(result.gates?.syntax_check.enabled).toBe(false);
+				expect(result.gates?.quality_budget.enabled).toBe(true);
 
 				const warnings = warnSpy.mock.calls.flat().join('\n');
 				expect(warnings).toContain('gates.placeholder_scn');
@@ -817,12 +819,77 @@ describe('config/loader', () => {
 				expect(result.max_iterations).toBe(6);
 				expect(result.gates?.placeholder_scan.enabled).toBe(false);
 				expect(result.gates?.placeholder_scan.max_allowed_findings).toBe(0);
+				expect(result.gates?.quality_budget.enabled).toBe(true);
 
 				const warnings = warnSpy.mock.calls.flat().join('\n');
 				expect(warnings).toContain(
 					'gates.placeholder_scan.max_allowed_finding',
 				);
 				expect(warnings).toContain('Other config sections remain active');
+			} finally {
+				warnSpy.mockRestore();
+				fs.rmSync(projectDir, { recursive: true, force: true });
+			}
+		});
+
+		it('handles gates: null by removing gates and using defaults', () => {
+			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+			const userConfigDir = path.join(tempDir, 'opencode');
+			const userConfigFile = path.join(userConfigDir, 'opencode-swarm.json');
+			fs.mkdirSync(userConfigDir, { recursive: true });
+			fs.writeFileSync(
+				userConfigFile,
+				JSON.stringify({
+					max_iterations: 5,
+					gates: null,
+				}),
+			);
+
+			const projectDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'project-test-')),
+			);
+
+			try {
+				const result = loadPluginConfig(projectDir);
+
+				expect(result.max_iterations).toBe(5);
+				// gates: null is stripped by sanitizeGatesConfig; gates becomes undefined
+				expect(result.gates).toBeUndefined();
+
+				const warnings = warnSpy.mock.calls.flat().join('\n');
+				expect(warnings).toContain('expected an object');
+			} finally {
+				warnSpy.mockRestore();
+				fs.rmSync(projectDir, { recursive: true, force: true });
+			}
+		});
+
+		it('handles gates: [] (empty array) by removing gates and using defaults', () => {
+			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+			const userConfigDir = path.join(tempDir, 'opencode');
+			const userConfigFile = path.join(userConfigDir, 'opencode-swarm.json');
+			fs.mkdirSync(userConfigDir, { recursive: true });
+			fs.writeFileSync(
+				userConfigFile,
+				JSON.stringify({
+					max_iterations: 5,
+					gates: [],
+				}),
+			);
+
+			const projectDir = fs.realpathSync(
+				fs.mkdtempSync(path.join(os.tmpdir(), 'project-test-')),
+			);
+
+			try {
+				const result = loadPluginConfig(projectDir);
+
+				expect(result.max_iterations).toBe(5);
+				// gates: [] is stripped by sanitizeGatesConfig; gates becomes undefined
+				expect(result.gates).toBeUndefined();
+
+				const warnings = warnSpy.mock.calls.flat().join('\n');
+				expect(warnings).toContain('expected an object');
 			} finally {
 				warnSpy.mockRestore();
 				fs.rmSync(projectDir, { recursive: true, force: true });

--- a/tests/unit/hooks/knowledge-injector-allowlist.test.ts
+++ b/tests/unit/hooks/knowledge-injector-allowlist.test.ts
@@ -91,6 +91,7 @@ mock.module('../../../src/config/schema.js', () => ({
 		}
 		return name;
 	}),
+	GATE_CONFIG_KNOWN_SECTION_KEYS: {},
 }));
 mock.module('../../../src/hooks/curator-drift.js', () => ({
 	readPriorDriftReports: mock(async () => []),

--- a/tests/unit/hooks/knowledge-injector-drift-adversarial.test.ts
+++ b/tests/unit/hooks/knowledge-injector-drift-adversarial.test.ts
@@ -208,6 +208,7 @@ mock.module('../../../src/config/schema.js', () => ({
 	UIReviewConfigSchema: zodStub,
 	WatchdogConfigSchema: zodStub,
 	WorktreeIsolationConfigSchema: zodStub,
+	GATE_CONFIG_KNOWN_SECTION_KEYS: {},
 	_internals: {},
 }));
 mock.module('../../../src/services/run-memory.js', () => ({
@@ -241,6 +242,7 @@ mock.module('../../../src/hooks/knowledge-events.js', () => ({
 	recomputeCounters: mock(() => ({})),
 	countViolationsInWindow: mock(() => 0),
 	countEntryViolationsInWindow: mock(async () => 0),
+	countEntryContradictionsInWindow: mock(async () => 0),
 	readKnowledgeCounterRollups: mock(async () => []),
 	applyKnowledgeVerdictFeedback: mock(async () => ({})),
 	_internals: {},

--- a/tests/unit/hooks/knowledge-injector-drift.test.ts
+++ b/tests/unit/hooks/knowledge-injector-drift.test.ts
@@ -65,6 +65,7 @@ mock.module('../../../src/config/schema.js', () => ({
 		}
 		return name;
 	}),
+	GATE_CONFIG_KNOWN_SECTION_KEYS: {},
 }));
 mock.module('../../../src/services/run-memory.js', () => ({
 	getRunMemorySummary: mock(async () => null),

--- a/tests/unit/hooks/knowledge-injector.adversarial.test.ts
+++ b/tests/unit/hooks/knowledge-injector.adversarial.test.ts
@@ -255,6 +255,7 @@ mock.module('../../../src/config/schema.js', () => ({
 	UIReviewConfigSchema: zodStub,
 	WatchdogConfigSchema: zodStub,
 	WorktreeIsolationConfigSchema: zodStub,
+	GATE_CONFIG_KNOWN_SECTION_KEYS: {},
 	_internals: {},
 }));
 mock.module('../../../src/services/run-memory.js', () => ({

--- a/tests/unit/hooks/knowledge-injector.test.ts
+++ b/tests/unit/hooks/knowledge-injector.test.ts
@@ -111,6 +111,7 @@ mock.module('../../../src/config/schema.js', () => ({
 		}
 		return name;
 	}),
+	GATE_CONFIG_KNOWN_SECTION_KEYS: {},
 }));
 mock.module('../../../src/services/run-memory.js', () => ({
 	getRunMemorySummary: mock(async () => null),

--- a/tests/unit/tools/skill-improve.test.ts
+++ b/tests/unit/tools/skill-improve.test.ts
@@ -112,6 +112,7 @@ mock.module('../../../src/config/schema.ts', () => ({
 	TaskSchema: zodStub,
 	TaskSizeSchema: zodStub,
 	TaskStatusSchema: zodStub,
+	GATE_CONFIG_KNOWN_SECTION_KEYS: {},
 }));
 
 mock.module('../../../src/services/skill-improver.js', () => ({


### PR DESCRIPTION
Refs #1690 (config parsing portion; turbo disclosure and QA-dialogue single-sourcing remain follow-up scope).

## Summary
- preserve valid user config when `gates` contains a partial block, invalid subsection, unknown gate section, or typoed nested key
- add defaults for omitted gate sections, including `quality_budget`, so partial `gates` configs no longer trigger bare guardrails-only fallback
- surface ignored raw `gates` entries through `/swarm config doctor` so users can see which section/key was skipped

## Invariant audit
- 1 (plugin init): not touched - no `src/index.ts`, init scheduling, startup subprocess, or plugin entry-path changes
- 2 (runtime portability): not touched - no platform-specific imports or bundle export shape changes; `bun run build` and Node ESM dist import passed
- 3 (subprocesses): not touched - no subprocess code changed
- 4 (.swarm containment): not touched - no runtime artifact path or working-directory behavior changed
- 5 (plan durability): not touched - no plan schema, replay, checkpoint, or plan projection changes
- 6 (test_runner safety): touched - validation used shell `bun` commands only; no OpenCode `test_runner` broad scope was invoked
- 7 (test writing): touched - loaded `.opencode/skills/writing-tests/SKILL.md`; tests use `bun:test` and `spyOn(console, 'warn')` with `mockRestore`, no `mock.module`
- 8 (session state): not touched - no session/global state changes
- 9 (guardrails/retry): not touched - guardrails runtime and retry counters unchanged; this only prevents unrelated config sections from being discarded when `gates` is malformed
- 10 (chat/system msg): not touched - no chat/system transform code changed
- 11 (tool registration): not touched - no tools, command registration, `TOOL_NAMES`, or agent tool maps changed
- 12 (release/cache): touched - added `docs/releases/pending/gates-config-section-fallback.md`; no cache, install, or update-path behavior changed

## Test plan
- [x] `bun --smol test tests/unit/config/loader.test.ts --timeout 30000`
- [x] `bun --smol test src/services/config-doctor.test.ts --timeout 30000`
- [x] `bun --smol test tests/unit/config/loader.test.ts src/services/config-doctor.test.ts --timeout 60000`
- [x] `bun run typecheck`
- [x] `bunx @biomejs/biome@2.3.14 ci .`
- [x] `git diff --check`
- [x] `bun run build`
- [x] `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- [x] `bun --smol test tests/unit/config/backward-compatibility-v67.test.ts --timeout 120000`

## Pre-existing failures
- `bun --smol test tests/unit/config --timeout 120000` currently fails 29 tests in `tests/unit/config/backward-compatibility-v67.test.ts` when run as a batch. The same batch failure reproduces on clean `origin/main` at `72ede1b`, while `tests/unit/config/backward-compatibility-v67.test.ts` passes when run by itself on both `origin/main` and this branch. This points to an existing config-suite batch isolation issue, not this `gates` change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

