### PR TITLE
fix(test): tolerate EBUSY/ENOTEMPTY in init-safety afterAll cleanup on Windows

### DIFF
--- a/docs/releases/pending/fix-init-safety-ebusy-cleanup.md
+++ b/docs/releases/pending/fix-init-safety-ebusy-cleanup.md
@@ -1,0 +1,3 @@
+## Fixed
+
+- Fixed intermittent Windows CI failure in `init-safety.test.ts` where `afterAll` cleanup threw `EBUSY` when temp directory file handles were still held by recently-terminated child processes. Both `rmSync` calls now tolerate `EBUSY` and `ENOTEMPTY` errors.

--- a/tests/unit/turbo/lean/init-safety.test.ts
+++ b/tests/unit/turbo/lean/init-safety.test.ts
@@ -48,8 +48,26 @@ const PLUGIN_INIT_DIR = realpathSync(
 );
 
 afterAll(() => {
-	rmSync(TEST_DIR, { recursive: true, force: true });
-	rmSync(PLUGIN_INIT_DIR, { recursive: true, force: true });
+	try {
+		rmSync(TEST_DIR, { recursive: true, force: true });
+	} catch (err: unknown) {
+		if (
+			!(err instanceof Error) ||
+			(err['code'] !== 'EBUSY' && err['code'] !== 'ENOTEMPTY')
+		) {
+			throw err;
+		}
+	}
+	try {
+		rmSync(PLUGIN_INIT_DIR, { recursive: true, force: true });
+	} catch (err: unknown) {
+		if (
+			!(err instanceof Error) ||
+			(err['code'] !== 'EBUSY' && err['code'] !== 'ENOTEMPTY')
+		) {
+			throw err;
+		}
+	}
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The \fterAll\ cleanup in \	ests/unit/turbo/lean/init-safety.test.ts\ fails intermittently on Windows CI with \EBUSY\ when file handles from recently-terminated child processes are still held. This wraps both \mSync\ calls in try-catch that silently ignores \EBUSY\ and \ENOTEMPTY\ while re-throwing all other errors.

## Invariant audit
- 1 (plugin init): not touched
- 2 (runtime portability): not touched
- 3 (subprocesses): not touched
- 4 (.swarm containment): not touched
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched
- 7 (test writing): touched — EBUSY/ENOTEMPTY try-catch follows existing patterns in other test files
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched
- 12 (release/cache): not touched

## Test plan

- [x] All 8 existing tests pass on Windows (verified locally)
- [x] No EBUSY errors during afterAll cleanup
- [x] Biome lint passes
- [x] Non-EBUSY/ENOTEMPTY errors are still re-thrown

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

