### PR TITLE
feat(swarm): close workflow friction gaps

### DIFF
--- a/.opencode/skills/ci-failure-batching/SKILL.md
+++ b/.opencode/skills/ci-failure-batching/SKILL.md
@@ -6,7 +6,8 @@ description: Batch collection and fix protocol for CI failures. Triggered when a
 # CI Failure Batching
 
 ## Trigger
-When ANY CI check fails on the PR (pr-monitor surfaces `pr.ci.failed`).
+When the PR monitor surfaces `pr.ci.failed`. The event is batched after the
+check set is complete and includes all known failed checks in `failedChecks`.
 
 ## Protocol
 1. **DO NOT immediately fix the first failure.** Check if other jobs are still running:
@@ -29,11 +30,7 @@ Example from session #1685:
 - Without batching: 6 pushes (format → stale-assertion-1 → stale-assertion-2 → integration → merge-group → clean)
 - With batching: 2 pushes (collect all → fix all → push once → clean)
 
-## Pr-monitor workaround
-The pr-monitor fires `pr.ci.failed` per-check. When the first event arrives:
-1. Check `gh pr checks` — are other jobs still running?
-2. If yes: WAIT for completion
-3. If no: the single failure IS the only failure — proceed normally
-
-## Root cause
-The pr-monitor should batch-fire after the CI run completes (issue #1746 item 7). This playbook is the manual protocol.
+## Pr-monitor expectation
+The pr-monitor should fire one `pr.ci.failed` event for the completed failing
+check set, not one event per check. Still verify with `gh pr checks` before
+fixing, because GitHub can append late merge-group or matrix jobs.

--- a/.opencode/skills/gate-attribution/SKILL.md
+++ b/.opencode/skills/gate-attribution/SKILL.md
@@ -1,24 +1,38 @@
 ﻿---
 name: gate-attribution
-description: Per-task gate dispatch protocol. Documents the single-taskId attribution rule and parallel-lane optimization for reviewer/test_engineer gates.
+description: Per-task gate dispatch protocol. Documents single-task attribution plus parseable set-dispatch reviewer/test_engineer rows.
 ---
 
 # Gate Attribution
 
 ## The rule
-The gate tracker attributes reviewer/test_engineer dispatches PER TASK (single taskId in the prompt). Set-dispatches covering multiple tasks do NOT count per-task, even with per-task verdicts.
+The gate tracker attributes reviewer/test_engineer dispatches PER TASK. A
+single-task prompt still attributes by `task_id` / `taskId` / unambiguous prompt
+task ID. A set-dispatch can also count per-task when the reviewer/test_engineer
+output includes parseable per-task rows:
+
+```
+[REVIEWED] | task-2.1 | APPROVED | ...
+[REVIEWED] | 2.2 | PASS | ...
+```
+
+Rows with `task-X.Y` are normalized to `X.Y`; unsafe or non-plan IDs are ignored.
+Only passing verdicts (`APPROVED`, `PASS`, or `PASSED`) create gate evidence.
+Rows such as `NEEDS_REVISION` are reviewed rows but do not satisfy the gate. If
+no reviewed rows are parseable, attribution falls back to the single-task rule.
 
 ## Protocol
-1. **For each task requiring a gate:** Dispatch a separate reviewer and/or test_engineer with exactly ONE taskId
-2. **Minimize overhead via parallel dispatch:**
+1. **For unrelated or high-risk tasks:** Dispatch separate reviewer and/or test_engineer lanes with exactly ONE taskId.
+2. **For a true set-dispatch:** Require one `[REVIEWED] | task-id | verdict | ...` row per task in the returned output. Only passing verdict rows count.
+3. **Minimize overhead via parallel dispatch when set-dispatch is not appropriate:**
    ```
    dispatch_lanes_async with:
    - common_prompt: shared verification context
    - lanes: one lane per task, each with a single taskId
    - max_concurrent: up to 3
    ```
-3. **Collect + attribute:** Each lane result auto-attributes to its taskId
-4. **Do NOT batch:** Even for identical reviews, dispatch separately
+4. **Collect + attribute:** Single-task lanes auto-attribute to their taskId; set-dispatch rows auto-attribute per parsed row.
+5. **Do NOT rely on prose summaries:** A batched dispatch without parseable rows is ambiguous and does not count per-task.
 
 ## Optimization for trivial tasks
 For pure ceremony gates (1-line doc fix):
@@ -28,4 +42,7 @@ taskId: X.Y
 ```
 
 ## Why this exists
-The gate tracker (`src/hooks/delegation-gate.ts`) keys delegation chains by `sessionID`, and task attribution resolves exactly ONE taskId per dispatch (`args.task_id ?? args.taskId`). Ambiguous multi-task prompts fail closed (resolve to null) rather than attributing to any task — so a set-dispatch covering multiple tasks does not count per-task even with per-task verdicts. Tracked in issue #1746 item 6.
+The gate tracker (`src/hooks/delegation-gate.ts`) keys delegation chains by
+`sessionID`. Ambiguous multi-task prompts still fail closed, but parseable
+`[REVIEWED] | task-id | ...` rows provide explicit per-task attribution for
+set-dispatches. Tracked in issue #1746 item 6.

--- a/.opencode/skills/merge-queue-readiness/SKILL.md
+++ b/.opencode/skills/merge-queue-readiness/SKILL.md
@@ -10,21 +10,33 @@ Before adding the PR to the merge queue (or before the final push if the repo us
 
 ## Protocol
 1. **Fetch latest main:** `git fetch origin main`
-2. **Create a temporary simulation worktree (do NOT mutate the PR branch).** Use a project-relative path UNDER the swarm worktree base so the path is portable across OSes and its later removal is permitted by the worktree guardrail (paths outside `.swarm-worktrees/` are blocked). Do NOT hardcode `/tmp` — it does not exist on Windows.
+2. **Run the simulation command (preferred):**
+   ```
+   /swarm ci-simulate --base origin/main --head <pr-branch>
+   ```
+   By default this runs fixed local CI gates: `bun run typecheck`,
+   `bun run lint:ci`, `bun run build`, `bun run test:unit:ci`,
+   integration/security/smoke tests, and `bun run drift:check`.
+   `test:unit:ci` runs unit tests per file with the repo's quarantine filters
+   and retry budget, matching CI's mock-isolation semantics. The command creates
+   a temporary detached worktree under `.swarm/ci-simulate`, merges the PR branch
+   or current worktree commit, runs the gate sequence, removes the worktree, and
+   prunes metadata. It does not accept arbitrary shell commands.
+3. **Manual fallback:** If the command is unavailable, create a temporary simulation worktree (do NOT mutate the PR branch). Use a project-relative path UNDER the swarm worktree base so the path is portable across OSes and its later removal is permitted by the worktree guardrail (paths outside `.swarm-worktrees/` are blocked). Do NOT hardcode `/tmp` — it does not exist on Windows.
    ```
    git worktree add .swarm-worktrees/merge-sim origin/main
    cd .swarm-worktrees/merge-sim
    git merge <pr-branch> --no-edit
    ```
-3. **Run integration + unit tests against the merged result:**
+4. **Run integration + unit tests against the merged result:**
    ```
    bun test tests/integration --timeout 120000
    bun test tests/unit --timeout 120000
    ```
    (Use per-file loops for hot modules per AGENTS.md invariant 6)
-4. **If failures:** Fix on the PR branch, re-push, re-simulate. Always run the cleanup step (5) before re-simulating or on any exit path — do not leave the simulation worktree behind.
-5. **Cleanup (run on EVERY exit path, including failure):** `git worktree remove --force .swarm-worktrees/merge-sim`. If the remove is guardrail-blocked or fails, delete the directory directly and run `git worktree prune`.
-6. **Only after simulation passes,** add PR to the merge queue.
+5. **If failures:** Fix on the PR branch, re-push, re-simulate. Always run the cleanup step (6) before re-simulating or on any exit path — do not leave the simulation worktree behind.
+6. **Cleanup for manual fallback (run on EVERY exit path, including failure):** `git worktree remove --force .swarm-worktrees/merge-sim`. If the remove is guardrail-blocked or fails, delete the directory directly and run `git worktree prune`.
+7. **Only after simulation passes,** add PR to the merge queue.
 
 ## Why this matters
 PR-branch CI and merge-group CI test DIFFERENT things:
@@ -33,5 +45,7 @@ PR-branch CI and merge-group CI test DIFFERENT things:
 
 Integration tests that pass on the PR branch may fail in merge-group context due to test interactions exposed by the merged result.
 
-## Root cause
-A `swarm ci-simulate` command would automate this (issue #1746 item 5). This playbook is the manual protocol.
+## Automation
+`/swarm ci-simulate` automates the merge-result worktree, merge, command run,
+worktree removal, and metadata prune. Use the manual protocol only when the
+command is unavailable or the repo needs bespoke setup.

--- a/.opencode/skills/skill-edit-validation/SKILL.md
+++ b/.opencode/skills/skill-edit-validation/SKILL.md
@@ -19,11 +19,18 @@ After editing ANY `.md` file under `.opencode/skills/`, `.claude/skills/`, or `.
    - Does the assertion still hold against the new content?
    - Is it checking a substring containing the old phrase?
    - Is it checking for the ABSENCE of a word the new wording introduces? (e.g., `not.toContain('skip')` catches "this check is skipped")
-4. **Update stale assertions in the same changeset.** Do NOT defer to CI.
-5. **Preserve behavioral intent:** When updating, preserve what the assertion TESTS (e.g., "the plan skill has a spec-absent branch"), not just the string match.
+4. **Prefer the semantic registry:** If the assertion is checking skill behavior
+   rather than an exact contract string, move it behind
+   `tests/helpers/skill-content-registry.ts` (or add a concept there) and assert
+   the named concept from the test.
+5. **Update stale assertions in the same changeset.** Do NOT defer to CI.
+6. **Preserve behavioral intent:** When updating, preserve what the assertion TESTS (e.g., "the plan skill has a spec-absent branch"), not just the string match.
 
 ## Constraint
 Do NOT rubber-stamp brittle assertions. If an assertion tests implementation detail rather than behavioral intent, flag it for refactoring to a semantic check.
 
 ## Root cause
-A skill-content test registry would auto-adjust (issue #1746 item 3). This playbook is the manual safety net.
+Skill-content tests should assert named semantic concepts where possible. The
+registry in `tests/helpers/skill-content-registry.ts` is the preferred safety
+net for recurring skill wording checks; use the manual grep sweep for exact
+contract strings and any tests not yet migrated.

--- a/.opencode/skills/worktree-retry-cleanup/SKILL.md
+++ b/.opencode/skills/worktree-retry-cleanup/SKILL.md
@@ -9,16 +9,12 @@ description: Protocol for cleaning parallel-coder worktree lanes before retry. T
 Before re-dispatching a coder for a task that already has a lane (any prior dispatch status).
 
 ## Protocol
-1. **Ownership check — do this FIRST, before any deletion.** Confirm the lane is not owned by another ACTIVE session: read `.swarm/session/state.json` and verify no other session's `delegationChains` reference `<session>/<task>`. If another active session owns it, STOP — surface the conflict and do not delete.
-2. **Check for existing lane branch:** `git branch --list "swarm/lane/<session>/<task>"`
-3. **If branch exists:**
-   - Verify 0-commits-ahead: `git log --oneline HEAD..swarm/lane/<session>/<task>` — empty = safe
-   - Delete: `git branch -d swarm/lane/<session>/<task>` (use `-D` only if `-d` fails AND the commits are confirmed unneeded)
-   - Under full-auto, `-D` is deny-pattern-blocked — use `-d`
-4. **Remove the per-lane worktree directory.** Target the SPECIFIC lane `.swarm-worktrees/<session>/<task>`, NOT the session parent (the parent holds sibling lanes). Prefer `git worktree remove .swarm-worktrees/<session>/<task>` — this is permitted because the path is under the `.swarm-worktrees/` base. A bare `rm -rf` / `Remove-Item -Recurse -Force` on `.swarm-worktrees/` is deny-pattern-blocked by the guardrail, so do not use it here.
-5. **Prune:** `git worktree prune`
-6. **Verify:** `git branch --list "swarm/lane/<session>/<task>"` returns empty
-7. Only after cleanup, proceed to `declare_scope` + coder dispatch
+1. **Prefer built-in provisioning cleanup.** Re-dispatch normally through the standard coder/worktree path. Provisioning pre-cleans stale same-lane worktrees/branches when ownership is safe and the existing lane is clean.
+2. **If provisioning blocks:** Treat the error as signal. Dirty lanes, lanes active in another worktree, and lanes owned by another active session must be surfaced to the user instead of deleted.
+3. **If manual cleanup is explicitly required:** Do the ownership check FIRST. Confirm the lane is not owned by another ACTIVE session: read `.swarm/session/state.json` and verify no other session's `delegationChains` reference `<session>/<task>`. If another active session owns it, STOP.
+4. **Remove only the specific lane.** Target `.swarm-worktrees/<session>/<task>`, never the session parent. Prefer `git worktree remove .swarm-worktrees/<session>/<task>` and then `git worktree prune`.
+5. **Delete only confirmed stale branches.** `git branch -d swarm/lane/<session>/<task>` is allowed after confirming the branch is not checked out and contains no needed commits. Use force deletion only with explicit human approval.
+6. **Verify:** `git branch --list "swarm/lane/<session>/<task>"` returns empty before retrying.
 
 ## Root cause
-The provisioning code should auto-clean after coder completion/denial/cancellation (tracked in issue #1746 item 1). This playbook is the temporary protocol.
+Stale same-lane worktrees and branches used to require manual cleanup before retry. Provisioning now handles the safe clean/stale cases automatically and fails closed for dirty, active, or cross-session-owned lanes.

--- a/docs/releases/pending/issue-1746-swarm-friction-fixes.md
+++ b/docs/releases/pending/issue-1746-swarm-friction-fixes.md
@@ -1,0 +1,9 @@
+Fixes several swarm workflow friction points from issue #1746: same-task lane
+retries now clean stale worktree branches instead of adopting old state,
+placeholder scans are diff-aware with sentinel allowances, Full-Auto oversight
+retries transient server failures before pausing, reviewer set-dispatch output
+can attribute gate evidence per task, PR monitor CI failures are batched after
+checks complete, `/swarm pr status` surfaces recent merge-group run log access,
+and `/swarm ci-simulate` can validate a merge-result worktree with fixed local
+CI gates before merge-queue entry, including the same per-file unit isolation
+used by CI.

--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
 		"typecheck": "tsc --noEmit",
 		"test": "bun test",
 		"lint": "biome lint .",
+		"lint:ci": "biome ci .",
+		"test:unit:ci": "bun scripts/ci/run-unit-tests-local.ts",
 		"drift:check": "bun run scripts/drift-check.ts",
 		"format": "biome format . --write",
 		"check": "biome check --write .",

--- a/scripts/ci/run-unit-tests-local.ts
+++ b/scripts/ci/run-unit-tests-local.ts
@@ -1,0 +1,154 @@
+#!/usr/bin/env bun
+/**
+ * Local CI-equivalent unit gate.
+ *
+ * Mirrors the GitHub Actions unit job's important semantics without depending
+ * on Bash: discover unit test files, remove quarantined files, and run
+ * each remaining file through run-test-with-timeout.ts with the same retry
+ * budget used in CI.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MAX_RETRIES = 2;
+const TEST_TIMEOUT_MS = '120000';
+const KILL_TIMEOUT_SECONDS = '180';
+
+function repoRelative(filePath: string): string {
+	return filePath.split(path.sep).join('/');
+}
+
+function normalizeRequestedTest(filePath: string): string {
+	return repoRelative(path.relative(process.cwd(), path.resolve(filePath)));
+}
+
+function walkTestFiles(root: string): string[] {
+	const files: string[] = [];
+	for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+		const fullPath = path.join(root, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...walkTestFiles(fullPath));
+		} else if (entry.isFile() && entry.name.endsWith('.test.ts')) {
+			files.push(repoRelative(path.relative(process.cwd(), fullPath)));
+		}
+	}
+	return files.sort();
+}
+
+function readQuarantineFile(filePath: string): string[] {
+	if (!fs.existsSync(filePath)) return [];
+	return fs
+		.readFileSync(filePath, 'utf8')
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0 && !line.startsWith('#'))
+		.map((line) => line.replace(/\\/g, '/'));
+}
+
+function currentPlatformQuarantineFile(): string | null {
+	if (process.platform === 'darwin') {
+		return 'scripts/ci/quarantined-tests-macos.txt';
+	}
+	if (process.platform === 'win32') {
+		return 'scripts/ci/quarantined-tests-windows.txt';
+	}
+	return null;
+}
+
+function collectQuarantinedTests(): Set<string> {
+	const files = ['scripts/ci/quarantined-tests.txt'];
+	const platformFile = currentPlatformQuarantineFile();
+	if (platformFile) files.push(platformFile);
+
+	return new Set(
+		files.flatMap((filePath) => readQuarantineFile(path.join(process.cwd(), filePath))),
+	);
+}
+
+async function runOneTest(filePath: string): Promise<{
+	exitCode: number;
+	output: string;
+}> {
+	const wrapperPath = fileURLToPath(
+		new URL('./run-test-with-timeout.ts', import.meta.url),
+	);
+	const child = Bun.spawn(
+		[
+			'bun',
+			wrapperPath,
+			filePath,
+			'--timeout',
+			TEST_TIMEOUT_MS,
+			'--kill-timeout',
+			KILL_TIMEOUT_SECONDS,
+		],
+		{
+			cwd: process.cwd(),
+			stdin: 'ignore',
+			stdout: 'pipe',
+			stderr: 'pipe',
+		},
+	);
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+		child.exited,
+	]);
+	return {
+		exitCode,
+		output: [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join('\n'),
+	};
+}
+
+async function main(): Promise<void> {
+	const unitRoot = path.join(process.cwd(), 'tests', 'unit');
+	const quarantined = collectQuarantinedTests();
+	const requestedTests = process.argv.slice(2).map(normalizeRequestedTest);
+	const allTests = requestedTests.length > 0 ? requestedTests.sort() : walkTestFiles(unitRoot);
+	const gatedTests = allTests.filter((filePath) => !quarantined.has(filePath));
+
+	if (gatedTests.length === 0) {
+		console.error('No unit test files found after quarantine filtering.');
+		process.exit(1);
+	}
+
+	console.log(
+		`Running ${gatedTests.length} unit test file(s) individually (${quarantined.size} quarantined).`,
+	);
+
+	let failed = false;
+	for (const filePath of gatedTests) {
+		let result = await runOneTest(filePath);
+		let attempt = 0;
+		while (result.exitCode !== 0 && attempt < MAX_RETRIES) {
+			attempt++;
+			console.warn(
+				`Attempt ${attempt} failed, retrying (${attempt}/${MAX_RETRIES}): ${filePath}`,
+			);
+			result = await runOneTest(filePath);
+			if (result.exitCode === 0) {
+				console.log(`Passed on retry ${attempt} (flaky): ${filePath}`);
+			}
+		}
+		if (result.exitCode !== 0) {
+			failed = true;
+			console.error(`FAILED: ${filePath}`);
+			if (result.output) {
+				console.error(result.output);
+			}
+		} else {
+			const timingLines = result.output
+				.split(/\r?\n/)
+				.filter((line) => line.startsWith('[TIMING]') || line.startsWith('[TIMEOUT]'));
+			for (const line of timingLines) {
+				console.log(line);
+			}
+		}
+	}
+
+	process.exit(failed ? 1 : 0);
+}
+
+main();

--- a/src/background/pr-event-subscribers.ts
+++ b/src/background/pr-event-subscribers.ts
@@ -115,6 +115,12 @@ interface PrEventPayload {
 	prUrl?: string;
 	checkName?: string;
 	checkState?: string;
+	failedChecks?: Array<{
+		name?: string;
+		status?: string;
+		conclusion?: string | null;
+		checkUrl?: string | null;
+	}>;
 	errorMessage?: string;
 	author?: string;
 	body?: string;
@@ -332,6 +338,36 @@ function formatAdvisory(type: string, payload: PrEventPayload): string | null {
 
 	switch (type) {
 		case 'pr.ci.failed':
+			if (
+				Array.isArray(payload.failedChecks) &&
+				payload.failedChecks.length > 0
+			) {
+				const failedChecks = payload.failedChecks
+					.map((check) => {
+						if (!check || typeof check !== 'object') return null;
+						const c = check as Record<string, unknown>;
+						const name =
+							typeof c.name === 'string'
+								? c.name
+								: payload.checkName || 'unknown';
+						const conclusion =
+							typeof c.conclusion === 'string'
+								? c.conclusion
+								: payload.checkState || 'failure';
+						return `  - ${name} — ${conclusion}`;
+					})
+					.filter(Boolean);
+				return [
+					`${dedupToken} (advisory) PR #${payload.prNumber} — ${failedChecks.length} CI check(s) failed`,
+					`  Repository: ${payload.repoFullName}`,
+					`  URL: ${payload.prUrl || ''}`,
+					'  Failed checks:',
+					...failedChecks,
+					payload.errorMessage ? `  Details: ${payload.errorMessage}` : '',
+				]
+					.filter(Boolean)
+					.join('\n');
+			}
 			return [
 				`${dedupToken} (advisory) PR #${payload.prNumber} — CI check "${payload.checkName || 'unknown'}" failed`,
 				`  Repository: ${payload.repoFullName}`,

--- a/src/background/pr-monitor-worker.ts
+++ b/src/background/pr-monitor-worker.ts
@@ -631,27 +631,55 @@ export class PrMonitorWorker {
 	): void {
 		let allPassed = true;
 		const prevMap = new Map(prevChecks.map((c) => [c.name, c.conclusion]));
+		const allComplete =
+			currentChecks.length > 0 &&
+			currentChecks.every(
+				(check) =>
+					check.status === 'completed' ||
+					check.status === 'COMPLETED' ||
+					check.conclusion !== null,
+			);
+		const failedChecks = currentChecks.filter(
+			(check) =>
+				check.conclusion === 'failure' || check.conclusion === 'FAILURE',
+		);
 
 		for (const check of currentChecks) {
-			if (check.conclusion === 'failure' || check.conclusion === 'FAILURE') {
-				const prev = prevMap.get(check.name);
-				if (prev !== 'failure' && prev !== 'FAILURE') {
-					events.push({
-						type: 'pr.ci.failed',
-						payload: {
-							prNumber: sub.prNumber,
-							repoFullName: sub.repoFullName,
-							prUrl: sub.prUrl,
-							checkName: check.name,
-							checkUrl: null,
-							conclusion: check.conclusion,
-						},
-					});
-				}
-			}
-
 			if (check.conclusion !== 'success' && check.conclusion !== 'SUCCESS') {
 				allPassed = false;
+			}
+		}
+
+		if (allComplete && failedChecks.length > 0) {
+			const prevWasIncomplete = prevChecks.some(
+				(check) =>
+					check.conclusion !== 'success' &&
+					check.conclusion !== 'SUCCESS' &&
+					check.conclusion !== 'failure' &&
+					check.conclusion !== 'FAILURE',
+			);
+			const hasNewFailure = failedChecks.some((check) => {
+				const prev = prevMap.get(check.name);
+				return prev !== 'failure' && prev !== 'FAILURE';
+			});
+			if (hasNewFailure || prevWasIncomplete || prevChecks.length === 0) {
+				events.push({
+					type: 'pr.ci.failed',
+					payload: {
+						prNumber: sub.prNumber,
+						repoFullName: sub.repoFullName,
+						prUrl: sub.prUrl,
+						checkName: failedChecks[0]?.name,
+						checkUrl: null,
+						conclusion: failedChecks[0]?.conclusion,
+						failedChecks: failedChecks.map((check) => ({
+							name: check.name,
+							status: check.status,
+							conclusion: check.conclusion,
+							checkUrl: null,
+						})),
+					},
+				});
 			}
 		}
 

--- a/src/commands/ci-simulate.ts
+++ b/src/commands/ci-simulate.ts
@@ -1,0 +1,210 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	type ExternalToolRunResult,
+	runExternalTool,
+} from '../utils/external-tool-runner';
+
+const DEFAULT_BASE = 'origin/main';
+const DEFAULT_HEAD = 'HEAD';
+const DEFAULT_CI_COMMANDS = [
+	['bun', 'run', 'typecheck'],
+	['bun', 'run', 'lint:ci'],
+	['bun', 'run', 'build'],
+	['bun', 'run', 'test:unit:ci'],
+	['bun', 'test', 'tests/integration', '--timeout', '120000'],
+	['bun', 'test', 'tests/security', '--timeout', '120000'],
+	['bun', 'test', 'tests/smoke', '--timeout', '120000'],
+	['bun', 'run', 'drift:check'],
+];
+const COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
+const GIT_TIMEOUT_MS = 60 * 1000;
+const OUTPUT_LIMIT = 12_000;
+
+type RunResult = {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+	stdoutTruncated?: boolean;
+	stderrTruncated?: boolean;
+};
+
+async function runCommand(
+	cmd: string[],
+	cwd: string,
+	timeout: number,
+): Promise<RunResult> {
+	const [executable, ...args] = cmd;
+	const result: ExternalToolRunResult = await runExternalTool({
+		executable,
+		args,
+		cwd,
+		timeoutMs: timeout,
+		maxStdoutBytes: OUTPUT_LIMIT,
+		maxStderrBytes: OUTPUT_LIMIT,
+	});
+	return {
+		exitCode: result.exitCode ?? 1,
+		stdout: result.message
+			? [result.message, result.stdout].filter(Boolean).join('\n')
+			: result.stdout,
+		stderr: result.stderr,
+		stdoutTruncated: result.stdoutTruncated,
+		stderrTruncated: result.stderrTruncated,
+	};
+}
+
+function readOptionalFlag(args: string[], name: string): string | null {
+	const index = args.indexOf(name);
+	if (index < 0) return null;
+	const value = args[index + 1];
+	return value && !value.startsWith('--') ? value : null;
+}
+
+function readFlag(args: string[], name: string, fallback: string): string {
+	return readOptionalFlag(args, name) ?? fallback;
+}
+
+function hasUnsupportedArgs(args: string[]): string | null {
+	const allowedWithValue = new Set(['--base', '--head']);
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (!arg.startsWith('--')) return `unexpected positional argument ${arg}`;
+		if (!allowedWithValue.has(arg)) return arg;
+		const value = args[i + 1];
+		if (!value || value.startsWith('--')) return `missing value for ${arg}`;
+		i++;
+	}
+	return null;
+}
+
+export const _internals = {
+	runCommand,
+	now: () => Date.now(),
+	mkdirSync: fs.mkdirSync,
+};
+
+function formatResult(prefix: string, result: RunResult): string {
+	const output = [result.stdout.trim(), result.stderr.trim()]
+		.filter(Boolean)
+		.join('\n');
+	const suffix =
+		result.stdoutTruncated || result.stderrTruncated
+			? '\n\n[output truncated to bounded limit]'
+			: '';
+	return output ? `${prefix}\n\n${output}${suffix}` : `${prefix}${suffix}`;
+}
+
+export async function handleCiSimulateCommand(
+	directory: string,
+	args: string[],
+): Promise<string> {
+	const unsupportedArg = hasUnsupportedArgs(args);
+	if (unsupportedArg) {
+		const reason = unsupportedArg.startsWith('--')
+			? `unsupported argument ${unsupportedArg}`
+			: unsupportedArg;
+		return `CI simulation failed: ${reason}. Supported arguments: --base <ref> --head <ref>.`;
+	}
+	const base = readFlag(args, '--base', DEFAULT_BASE);
+	const headFlag = readOptionalFlag(args, '--head');
+	const ciCommands = DEFAULT_CI_COMMANDS;
+	let head = headFlag ?? DEFAULT_HEAD;
+	if (!headFlag) {
+		const currentHead = await _internals.runCommand(
+			['git', '-C', directory, 'rev-parse', 'HEAD'],
+			directory,
+			GIT_TIMEOUT_MS,
+		);
+		if (currentHead.exitCode !== 0) {
+			return formatResult(
+				'CI simulation failed: could not resolve the current worktree HEAD.',
+				currentHead,
+			);
+		}
+		head = currentHead.stdout.trim();
+	}
+	const worktreeBase = path.join(directory, '.swarm', 'ci-simulate');
+	const worktreePath = path.join(
+		worktreeBase,
+		`merge-${_internals.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	_internals.mkdirSync(worktreeBase, { recursive: true });
+
+	let cleanupError: string | undefined;
+	let createdWorktree = false;
+	let response: string | undefined;
+	try {
+		const add = await _internals.runCommand(
+			[
+				'git',
+				'-C',
+				directory,
+				'worktree',
+				'add',
+				'--detach',
+				worktreePath,
+				base,
+			],
+			directory,
+			GIT_TIMEOUT_MS,
+		);
+		if (add.exitCode !== 0) {
+			response = formatResult(
+				`CI simulation failed: could not create temp worktree from ${base}.`,
+				add,
+			);
+		} else {
+			createdWorktree = true;
+
+			const merge = await _internals.runCommand(
+				['git', '-C', worktreePath, 'merge', '--no-edit', head],
+				worktreePath,
+				GIT_TIMEOUT_MS,
+			);
+			if (merge.exitCode !== 0) {
+				response = formatResult(
+					`CI simulation failed: ${head} does not merge cleanly into ${base}.`,
+					merge,
+				);
+			} else {
+				for (const ciCommand of ciCommands) {
+					const ci = await _internals.runCommand(
+						ciCommand,
+						worktreePath,
+						COMMAND_TIMEOUT_MS,
+					);
+					if (ci.exitCode !== 0) {
+						response = formatResult(
+							`CI simulation failed after merging ${head} into ${base}: ${ciCommand.join(' ')}`,
+							ci,
+						);
+						break;
+					}
+				}
+				response ??= `CI simulation passed after merging ${head} into ${base}: ${ciCommands.map((cmd) => cmd.join(' ')).join(' && ')}`;
+			}
+		}
+	} finally {
+		if (createdWorktree) {
+			const remove = await _internals.runCommand(
+				['git', '-C', directory, 'worktree', 'remove', '--force', worktreePath],
+				directory,
+				GIT_TIMEOUT_MS,
+			);
+			if (remove.exitCode !== 0) {
+				cleanupError = remove.stderr.trim() || remove.stdout.trim();
+			}
+		}
+		await _internals.runCommand(
+			['git', '-C', directory, 'worktree', 'prune'],
+			directory,
+			GIT_TIMEOUT_MS,
+		);
+	}
+	if (cleanupError) {
+		const cleanupMessage = `CI simulation cleanup failed: ${cleanupError}`;
+		return response ? `${response}\n\n${cleanupMessage}` : cleanupMessage;
+	}
+	return response ?? 'CI simulation failed: no result was produced.';
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -33,6 +33,7 @@ export { handleAutoProceedCommand } from './auto-proceed';
 export { handleBenchmarkCommand } from './benchmark';
 export { handleBrainstormCommand } from './brainstorm';
 export { handleCheckpointCommand } from './checkpoint';
+export { handleCiSimulateCommand } from './ci-simulate';
 export { handleClarifyCommand } from './clarify';
 export { handleCloseCommand } from './close';
 export { handleCodebaseReviewCommand } from './codebase-review';

--- a/src/commands/pr-monitor-status.ts
+++ b/src/commands/pr-monitor-status.ts
@@ -11,6 +11,20 @@
  */
 
 import { listActive } from '../background/pr-subscriptions.js';
+import { runExternalTool } from '../utils/external-tool-runner.js';
+
+const GH_RUN_LIST_TIMEOUT_MS = 10_000;
+const GH_RUN_LIST_MAX_BYTES = 20_000;
+
+type MergeGroupRun = {
+	databaseId: number;
+	headBranch: string;
+	status: string;
+	conclusion: string | null;
+	url: string;
+	displayTitle?: string;
+	name?: string;
+};
 
 /**
  * Format an epoch-ms timestamp as a human-friendly relative time string.
@@ -38,12 +52,90 @@ function formatRelativeTime(epochMs: number): string {
 	return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
 }
 
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+function parseMergeGroupRuns(raw: string, prNumber: number): MergeGroupRun[] {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return [];
+	}
+	if (!Array.isArray(parsed)) return [];
+
+	const prToken = `pr-${prNumber}-`;
+	const issueToken = `#${prNumber}`;
+	const runs: MergeGroupRun[] = [];
+	for (const item of parsed) {
+		if (!isObject(item)) continue;
+		const databaseId = Number(item.databaseId);
+		const headBranch = String(item.headBranch ?? '');
+		const displayTitle = String(item.displayTitle ?? '');
+		const name = String(item.name ?? '');
+		if (
+			!headBranch.includes(prToken) &&
+			!displayTitle.includes(issueToken) &&
+			!name.includes(issueToken)
+		) {
+			continue;
+		}
+		if (!Number.isFinite(databaseId) || databaseId <= 0) continue;
+		runs.push({
+			databaseId,
+			headBranch,
+			status: String(item.status ?? ''),
+			conclusion: typeof item.conclusion === 'string' ? item.conclusion : null,
+			url: String(item.url ?? ''),
+			displayTitle,
+			name,
+		});
+	}
+	return runs.slice(0, 3);
+}
+
+async function listMergeGroupRuns(
+	directory: string,
+	repoFullName: string,
+	prNumber: number,
+): Promise<{ runs: MergeGroupRun[]; error?: string }> {
+	const result = await runExternalTool({
+		executable: 'gh',
+		args: [
+			'run',
+			'list',
+			'--repo',
+			repoFullName,
+			'--event',
+			'merge_group',
+			'--limit',
+			'20',
+			'--json',
+			'databaseId,headBranch,conclusion,status,url,displayTitle,name',
+		],
+		cwd: directory,
+		timeoutMs: GH_RUN_LIST_TIMEOUT_MS,
+		maxStdoutBytes: GH_RUN_LIST_MAX_BYTES,
+		maxStderrBytes: GH_RUN_LIST_MAX_BYTES,
+	});
+	if (result.status !== 'completed' || result.exitCode !== 0) {
+		return {
+			runs: [],
+			error: result.stderr.trim() || result.message || result.status,
+		};
+	}
+	return { runs: parseMergeGroupRuns(result.stdout, prNumber) };
+}
+
 /**
  * Exposed for unit testing via _internals.
  */
 export const _internals = {
 	formatRelativeTime,
 	listActive,
+	listMergeGroupRuns,
+	parseMergeGroupRuns,
 };
 
 /**
@@ -97,6 +189,35 @@ export async function handlePrMonitorStatusCommand(
 		const index = i + 1;
 		lines.push(`  ${index}. ${sub.repoFullName}#${sub.prNumber}`);
 		lines.push(`     URL: ${sub.prUrl}`);
+		const mergeGroupRuns = await _internals.listMergeGroupRuns(
+			directory,
+			sub.repoFullName,
+			sub.prNumber,
+		);
+		if (mergeGroupRuns.runs.length > 0) {
+			lines.push('     Merge-group runs:');
+			for (const run of mergeGroupRuns.runs) {
+				const conclusion = run.conclusion ?? run.status;
+				lines.push(`       - ${run.databaseId}: ${conclusion} ${run.url}`);
+				if (run.conclusion && run.conclusion !== 'success') {
+					lines.push(
+						`         Failed logs: gh run view ${run.databaseId} --repo ${sub.repoFullName} --log-failed`,
+					);
+				}
+			}
+		} else if (mergeGroupRuns.error) {
+			lines.push(
+				`     Merge-group runs: unavailable (${mergeGroupRuns.error})`,
+			);
+		} else {
+			lines.push('     Merge-group runs: none found in recent runs');
+		}
+		lines.push(
+			`     Merge-group checks: gh pr checks ${sub.prNumber} --repo ${sub.repoFullName}`,
+		);
+		lines.push(
+			`     Failed logs: gh run view <run-id> --repo ${sub.repoFullName} --log-failed`,
+		);
 		// Disambiguate ownership only in the cross-session (CLI) listing.
 		if (allSessions) {
 			lines.push(`     Session: ${sub.sessionID}`);

--- a/src/commands/registry.tool-policy.test.ts
+++ b/src/commands/registry.tool-policy.test.ts
@@ -68,6 +68,8 @@ describe('toolPolicy classification snapshot — no regression', () => {
 		// toolPolicy: 'agent')
 		'guardrail explain',
 		'guardrail-log',
+		'lanes',
+		'ci-simulate',
 	]);
 
 	const EXPECTED_HUMAN_ONLY = new Set<string>([
@@ -338,6 +340,7 @@ describe('derived-set reproduction from registry toolPolicy fields', () => {
 			'memory',
 			'memory status',
 			'memory export',
+			'lanes',
 		]);
 		const derived = new Set<string>();
 		for (const [name, entry] of Object.entries(COMMAND_REGISTRY)) {
@@ -384,6 +387,11 @@ describe('gap command classification', () => {
 
 	test('costs: toolPolicy === "agent"', () => {
 		expect(cmd('costs').toolPolicy).toBe('agent');
+	});
+
+	test('ci-simulate: toolPolicy === "agent" with fixed CI gate arguments only', () => {
+		expect(cmd('ci-simulate').toolPolicy).toBe('agent');
+		expect(cmd('ci-simulate').args).not.toContain('--cmd');
 	});
 });
 

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -9,6 +9,7 @@ import { handleAutoProceedCommand } from './auto-proceed.js';
 import { handleBenchmarkCommand } from './benchmark.js';
 import { handleBrainstormCommand } from './brainstorm.js';
 import { handleCheckpointCommand } from './checkpoint.js';
+import { handleCiSimulateCommand } from './ci-simulate.js';
 import { handleClarifyCommand } from './clarify.js';
 import { handleCloseCommand } from './close.js';
 import { handleCodebaseReviewCommand } from './codebase-review.js';
@@ -973,6 +974,16 @@ export const COMMAND_REGISTRY = {
 		description: 'Show PR monitor subscription status for the current session',
 		aliasOf: 'pr status',
 		deprecated: true,
+	},
+	'ci-simulate': {
+		handler: (ctx) => handleCiSimulateCommand(ctx.directory, ctx.args),
+		description:
+			'Create a temporary merge-result worktree and run CI before merge queue entry',
+		args: '[--base origin/main] [--head <ref>]',
+		details:
+			'Creates a detached temporary worktree under .swarm/ci-simulate from the base ref, merges the current worktree HEAD (or --head ref), runs fixed local CI gates (typecheck, Biome CI, build, unit/integration/security/smoke tests, drift check), then removes the worktree and prunes metadata. Intended as a pre-queue merge_group simulation helper.',
+		category: 'agent',
+		toolPolicy: 'agent',
 	},
 	'deep-dive': {
 		handler: (ctx) =>

--- a/src/commands/shortcut-resolution.test.ts
+++ b/src/commands/shortcut-resolution.test.ts
@@ -77,6 +77,7 @@ describe('TUI shortcut resolution parity', () => {
 		'swarm-memory-export',
 		'swarm-memory-import',
 		'swarm-memory-migrate',
+		'swarm-ci-simulate',
 	];
 
 	for (const key of previouslyBroken) {

--- a/src/full-auto/oversight.ts
+++ b/src/full-auto/oversight.ts
@@ -46,6 +46,12 @@ import {
 // the durable state file.
 let oversightSequenceCounter = 0;
 void oversightSequenceCounter; // referenced via _internals.resetSequence
+const OVERSIGHT_DISPATCH_MAX_ATTEMPTS = 3;
+const OVERSIGHT_DISPATCH_RETRY_BASE_MS = 250;
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export interface FullAutoCriticResult extends ParsedCriticResponse {}
 
@@ -168,6 +174,74 @@ function decisionFromVerdict(
 	if (verdict === 'BLOCKED') return 'deny';
 	if (verdict === 'PENDING') return 'pending';
 	return 'deny';
+}
+
+function isTransientDispatchError(error: unknown): boolean {
+	const text = error instanceof Error ? error.message : String(error);
+	return /(?:\b429\b|\b500\b|\b502\b|\b503\b|\b504\b|\b529\b|timeout|timed out|temporarily unavailable|server error|unexpected server error|rate limit)/i.test(
+		text,
+	);
+}
+
+async function dispatchOversightAttempt(
+	client: NonNullable<typeof stateInternals.swarmState.opencodeClient>,
+	input: DispatchFullAutoOversightInput,
+): Promise<string> {
+	let ephemeralSessionId: string | undefined;
+	const promptController = new AbortController();
+	const cleanup = () => {
+		promptController.abort();
+		if (ephemeralSessionId) {
+			const id = ephemeralSessionId;
+			ephemeralSessionId = undefined;
+			client.session.delete({ path: { id } }).catch(() => {});
+		}
+	};
+
+	try {
+		const createResult = await client.session.create({
+			...(input.sessionID
+				? {
+						body: {
+							parentID: input.sessionID,
+							title: 'full_auto_oversight background',
+						},
+					}
+				: {}),
+			query: { directory: input.directory },
+		});
+		if (!createResult.data) {
+			throw new Error(
+				`Failed to create critic session: ${JSON.stringify(createResult.error)}`,
+			);
+		}
+		ephemeralSessionId = createResult.data.id;
+
+		const promptResult = await client.session.prompt({
+			path: { id: ephemeralSessionId },
+			body: {
+				agent: input.oversightAgentName,
+				tools: { write: false, edit: false, patch: false },
+				parts: [{ type: 'text', text: buildOversightPrompt(input) }],
+			},
+			signal: promptController.signal,
+		});
+
+		if (!promptResult.data) {
+			throw new Error(
+				`Critic prompt failed: ${JSON.stringify(promptResult.error)}`,
+			);
+		}
+		const textParts = promptResult.data.parts.filter(
+			(p): p is typeof p & { text: string } => p.type === 'text',
+		);
+		const response = textParts.map((p) => p.text).join('\n');
+		return response.trim()
+			? response
+			: 'VERDICT: NEEDS_REVISION\nREASONING: Critic returned empty response\nEVIDENCE_CHECKED: none\nANTI_PATTERNS_DETECTED: empty_response\nESCALATION_NEEDED: NO';
+	} finally {
+		cleanup();
+	}
 }
 
 /**
@@ -360,74 +434,32 @@ export async function dispatchFullAutoOversight(
 		`[full-auto/oversight] Dispatching ${oversightAgent.name} via ${input.oversightAgentName} (model=${input.criticModel}, trigger=${input.triggerSource})`,
 	);
 
-	let ephemeralSessionId: string | undefined;
-	const promptController = new AbortController();
-	const cleanup = () => {
-		promptController.abort();
-		if (ephemeralSessionId) {
-			const id = ephemeralSessionId;
-			ephemeralSessionId = undefined;
-			client.session.delete({ path: { id } }).catch(() => {});
-		}
-	};
-
 	let criticResponse = '';
 	let dispatchError: unknown;
-	try {
-		// Bind to the calling session as parent so OpenCode treats this as
-		// a child session and does not persist it as a new root in the TUI.
-		const createResult = await client.session.create({
-			...(input.sessionID
-				? {
-						body: {
-							parentID: input.sessionID,
-							title: 'full_auto_oversight background',
-						},
-					}
-				: {}),
-			query: { directory: input.directory },
-		});
-		if (!createResult.data) {
-			throw new Error(
-				`Failed to create critic session: ${JSON.stringify(createResult.error)}`,
+	let dispatchAttempts = 0;
+	for (let attempt = 1; attempt <= OVERSIGHT_DISPATCH_MAX_ATTEMPTS; attempt++) {
+		dispatchAttempts = attempt;
+		try {
+			criticResponse = await dispatchOversightAttempt(client, input);
+			dispatchError = undefined;
+			break;
+		} catch (error) {
+			dispatchError = error;
+			const transient = isTransientDispatchError(error);
+			logger.error(
+				`[full-auto/oversight] dispatch attempt ${attempt}/${OVERSIGHT_DISPATCH_MAX_ATTEMPTS} failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			if (!transient || attempt === OVERSIGHT_DISPATCH_MAX_ATTEMPTS) {
+				break;
+			}
+			await _internals.sleep(
+				OVERSIGHT_DISPATCH_RETRY_BASE_MS * 2 ** (attempt - 1),
 			);
 		}
-		ephemeralSessionId = createResult.data.id;
-
-		const promptResult = await client.session.prompt({
-			path: { id: ephemeralSessionId },
-			body: {
-				agent: input.oversightAgentName,
-				tools: { write: false, edit: false, patch: false },
-				parts: [{ type: 'text', text: buildOversightPrompt(input) }],
-			},
-			signal: promptController.signal,
-		});
-
-		if (!promptResult.data) {
-			throw new Error(
-				`Critic prompt failed: ${JSON.stringify(promptResult.error)}`,
-			);
-		}
-		const textParts = promptResult.data.parts.filter(
-			(p): p is typeof p & { text: string } => p.type === 'text',
-		);
-		criticResponse = textParts.map((p) => p.text).join('\n');
-		if (!criticResponse.trim()) {
-			criticResponse =
-				'VERDICT: NEEDS_REVISION\nREASONING: Critic returned empty response\nEVIDENCE_CHECKED: none\nANTI_PATTERNS_DETECTED: empty_response\nESCALATION_NEEDED: NO';
-		}
-	} catch (error) {
-		dispatchError = error;
-		logger.error(
-			`[full-auto/oversight] dispatch error: ${error instanceof Error ? error.message : String(error)}`,
-		);
-	} finally {
-		cleanup();
 	}
 
 	if (dispatchError) {
-		const reason = `oversight dispatch failed: ${dispatchError instanceof Error ? dispatchError.message : String(dispatchError)}`;
+		const reason = `oversight dispatch failed after ${dispatchAttempts} attempt(s): ${dispatchError instanceof Error ? dispatchError.message : String(dispatchError)}`;
 		pauseFullAutoRun(input.directory, input.sessionID, reason);
 		const event: FullAutoOversightEvent = {
 			...baseEvent,
@@ -586,8 +618,10 @@ export async function dispatchFullAutoOversight(
  */
 export const _internals: {
 	resetSequence: () => void;
+	sleep: (ms: number) => Promise<void>;
 } = {
 	resetSequence: () => {
 		oversightSequenceCounter = 0;
 	},
+	sleep,
 };

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -686,6 +686,47 @@ function resolveDelegatedPlanTaskId(
 	return null;
 }
 
+function normalizeReviewedTaskId(raw: string): string | null {
+	const trimmed = raw.trim();
+	const taskPrefix = /^task-(\d+\.\d+(?:\.\d+)*)$/i.exec(trimmed);
+	const candidate = taskPrefix ? taskPrefix[1] : trimmed;
+	return isStrictTaskId(candidate) ? candidate : null;
+}
+
+function isPassingReviewedVerdict(raw: string): boolean {
+	const verdict = raw
+		.trim()
+		.toUpperCase()
+		.replace(/[\s-]+/g, '_');
+	return verdict === 'APPROVED' || verdict === 'PASS' || verdict === 'PASSED';
+}
+
+export function hasReviewedTaskRows(output: string): boolean {
+	for (const line of output.split(/\r?\n/)) {
+		const match = /^\s*\[REVIEWED\]\s*\|\s*([^|]+)\s*\|/i.exec(line);
+		if (!match) continue;
+		if (normalizeReviewedTaskId(match[1])) return true;
+	}
+	return false;
+}
+
+export function parseReviewedTaskIdsFromSetDispatchOutput(
+	output: string,
+): string[] {
+	const taskIds: string[] = [];
+	const seen = new Set<string>();
+	for (const line of output.split(/\r?\n/)) {
+		const match = /^\s*\[REVIEWED\]\s*\|\s*([^|]+)\s*\|\s*([^|]+)/i.exec(line);
+		if (!match) continue;
+		const taskId = normalizeReviewedTaskId(match[1]);
+		if (!isPassingReviewedVerdict(match[2])) continue;
+		if (!taskId || seen.has(taskId)) continue;
+		seen.add(taskId);
+		taskIds.push(taskId);
+	}
+	return taskIds;
+}
+
 async function findTaskAwaitingCompletion(
 	directory: string | undefined,
 	session: AgentSessionState,
@@ -1986,12 +2027,21 @@ export function createDelegationGateHook(
 			if (typeof subagentType === 'string') {
 				try {
 					const mergedArgs = { ...(storedArgs ?? {}), ...directArgs };
-					const evidenceTaskId = await resolveEvidenceTaskId(
-						mergedArgs,
-						session,
-						directory,
-					);
-					if (evidenceTaskId) {
+					const outputText = String(_output ?? '');
+					const reviewedTaskIds =
+						parseReviewedTaskIdsFromSetDispatchOutput(outputText);
+					const hasReviewedRows = hasReviewedTaskRows(outputText);
+					const fallbackTaskId =
+						!hasReviewedRows && reviewedTaskIds.length === 0
+							? await resolveEvidenceTaskId(mergedArgs, session, directory)
+							: null;
+					const evidenceTaskIds =
+						reviewedTaskIds.length > 0
+							? reviewedTaskIds
+							: fallbackTaskId
+								? [fallbackTaskId]
+								: [];
+					if (evidenceTaskIds.length > 0) {
 						const turbo = hasActiveTurboMode(input.sessionID);
 						const gateAgents = [
 							'reviewer',
@@ -2005,21 +2055,25 @@ export function createDelegationGateHook(
 						const targetAgentForEvidence = stripKnownSwarmPrefix(subagentType);
 						if (gateAgents.includes(targetAgentForEvidence)) {
 							const { recordGateEvidence } = await import('../gate-evidence');
-							await recordGateEvidence(
-								directory,
-								evidenceTaskId,
-								targetAgentForEvidence,
-								input.sessionID,
-								turbo,
-							);
+							for (const evidenceTaskId of evidenceTaskIds) {
+								await recordGateEvidence(
+									directory,
+									evidenceTaskId,
+									targetAgentForEvidence,
+									input.sessionID,
+									turbo,
+								);
+							}
 						} else {
 							const { recordAgentDispatch } = await import('../gate-evidence');
-							await recordAgentDispatch(
-								directory,
-								evidenceTaskId,
-								targetAgentForEvidence,
-								turbo,
-							);
+							for (const evidenceTaskId of evidenceTaskIds) {
+								await recordAgentDispatch(
+									directory,
+									evidenceTaskId,
+									targetAgentForEvidence,
+									turbo,
+								);
+							}
 						}
 					}
 				} catch (err) {
@@ -2197,32 +2251,45 @@ export function createDelegationGateHook(
 				// Record gate evidence for delegation-chain fallback path
 				// v6.33.7: Entire block wrapped in try-catch (same fix as stored-args path)
 				try {
-					const evidenceTaskId = await resolveEvidenceTaskId(
-						directArgs,
-						session,
-						directory,
-					);
-					if (evidenceTaskId) {
+					const outputText = String(_output ?? '');
+					const reviewedTaskIds =
+						parseReviewedTaskIdsFromSetDispatchOutput(outputText);
+					const hasReviewedRows = hasReviewedTaskRows(outputText);
+					const fallbackTaskId =
+						!hasReviewedRows && reviewedTaskIds.length === 0
+							? await resolveEvidenceTaskId(directArgs, session, directory)
+							: null;
+					const evidenceTaskIds =
+						reviewedTaskIds.length > 0
+							? reviewedTaskIds
+							: fallbackTaskId
+								? [fallbackTaskId]
+								: [];
+					if (evidenceTaskIds.length > 0) {
 						const turbo = hasActiveTurboMode(input.sessionID);
 						if (hasReviewer) {
 							const { recordGateEvidence } = await import('../gate-evidence');
-							await recordGateEvidence(
-								directory,
-								evidenceTaskId,
-								'reviewer',
-								input.sessionID,
-								turbo,
-							);
+							for (const evidenceTaskId of evidenceTaskIds) {
+								await recordGateEvidence(
+									directory,
+									evidenceTaskId,
+									'reviewer',
+									input.sessionID,
+									turbo,
+								);
+							}
 						}
 						if (hasTestEngineer) {
 							const { recordGateEvidence } = await import('../gate-evidence');
-							await recordGateEvidence(
-								directory,
-								evidenceTaskId,
-								'test_engineer',
-								input.sessionID,
-								turbo,
-							);
+							for (const evidenceTaskId of evidenceTaskIds) {
+								await recordGateEvidence(
+									directory,
+									evidenceTaskId,
+									'test_engineer',
+									input.sessionID,
+									turbo,
+								);
+							}
 						}
 					}
 				} catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1589,6 +1589,10 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 					template: '/swarm pr status',
 					description: shortcutDescription('pr status'),
 				},
+				'swarm-ci-simulate': {
+					template: '/swarm ci-simulate $ARGUMENTS',
+					description: shortcutDescription('ci-simulate'),
+				},
 				'swarm-learning': {
 					template: '/swarm learning',
 					description: shortcutDescription('learning'),

--- a/src/tools/placeholder-scan.ts
+++ b/src/tools/placeholder-scan.ts
@@ -6,6 +6,7 @@ import type { EvidenceVerdict } from '../config/evidence-schema';
 import { saveEvidence } from '../evidence/manager';
 import { getParserForFile } from '../lang/registry';
 import { escapeRegex } from '../utils';
+import { runExternalTool } from '../utils/external-tool-runner';
 import { createSwarmTool } from './create-tool';
 
 // ============ Types ============
@@ -14,6 +15,8 @@ export interface PlaceholderScanInput {
 	changed_files: string[];
 	allow_globs?: string[];
 	deny_patterns?: string[];
+	added_lines?: Record<string, number[]>;
+	allow_sentinels?: string[];
 }
 
 export interface PlaceholderFinding {
@@ -37,6 +40,9 @@ export interface PlaceholderScanResult {
 // ============ Constants ============
 
 const MAX_FILE_SIZE = 1024 * 1024; // 1MB
+const GIT_DIFF_TIMEOUT_MS = 5000;
+const GIT_DIFF_MAX_BYTES = 512 * 1024;
+const DEFAULT_ALLOW_SENTINELS = ['SC-PLACEHOLDER'];
 
 // Default deny patterns (comment patterns)
 const DEFAULT_COMMENT_PATTERNS = [
@@ -603,6 +609,168 @@ async function scanWithParser(
 	return findings;
 }
 
+function normalizeRelativePathForDiff(filePath: string): string {
+	return filePath.replace(/\\/g, '/').replace(/^\.\/+/, '');
+}
+
+function parseAddedLinesFromUnifiedDiff(
+	diffOutput: string,
+): Map<string, Set<number>> {
+	const result = new Map<string, Set<number>>();
+	let currentFile: string | null = null;
+
+	for (const line of diffOutput.split('\n')) {
+		if (line.startsWith('+++ b/')) {
+			currentFile = normalizeRelativePathForDiff(line.slice(6).trim());
+			if (!result.has(currentFile)) {
+				result.set(currentFile, new Set());
+			}
+			continue;
+		}
+
+		if (line.startsWith('@@') && currentFile) {
+			const match = line.match(/^@@ [^+]*\+(\d+)(?:,(\d+))? @@/);
+			if (!match) continue;
+			const start = Number.parseInt(match[1], 10);
+			const count = match[2] !== undefined ? Number.parseInt(match[2], 10) : 1;
+			const lines = result.get(currentFile)!;
+			for (let i = start; i < start + count; i++) {
+				lines.add(i);
+			}
+		}
+	}
+
+	return result;
+}
+
+function mergeAddedLineMaps(
+	target: Map<string, Set<number>>,
+	source: Map<string, Set<number>> | null,
+): void {
+	if (!source) return;
+	for (const [filePath, lines] of source) {
+		let existing = target.get(filePath);
+		if (!existing) {
+			existing = new Set<number>();
+			target.set(filePath, existing);
+		}
+		for (const line of lines) {
+			existing.add(line);
+		}
+	}
+}
+
+async function getAddedLinesFromGitDiff(
+	directory: string,
+	changedFiles: string[],
+): Promise<Map<string, Set<number>> | null> {
+	if (changedFiles.length === 0) return new Map();
+
+	const runGitDiff = async (
+		args: string[],
+	): Promise<Map<string, Set<number>> | null> => {
+		try {
+			const result = await runExternalTool({
+				executable: 'git',
+				args: [
+					'-C',
+					directory,
+					'diff',
+					'--unified=0',
+					'--no-ext-diff',
+					...args,
+					'--',
+					...changedFiles.map(normalizeRelativePathForDiff),
+				],
+				cwd: directory,
+				timeoutMs: GIT_DIFF_TIMEOUT_MS,
+				maxStdoutBytes: GIT_DIFF_MAX_BYTES,
+				maxStderrBytes: GIT_DIFF_MAX_BYTES,
+			});
+			if (result.status !== 'completed' || result.exitCode !== 0) return null;
+			if (result.stdoutTruncated) return null;
+			return parseAddedLinesFromUnifiedDiff(result.stdout);
+		} catch {
+			return null;
+		}
+	};
+
+	try {
+		const combined = new Map<string, Set<number>>();
+		for (const baseBranch of [
+			'origin/main',
+			'origin/master',
+			'main',
+			'master',
+		]) {
+			const result = await runExternalTool({
+				executable: 'git',
+				args: ['-C', directory, 'merge-base', baseBranch, 'HEAD'],
+				cwd: directory,
+				timeoutMs: GIT_DIFF_TIMEOUT_MS,
+				maxStdoutBytes: GIT_DIFF_MAX_BYTES,
+				maxStderrBytes: GIT_DIFF_MAX_BYTES,
+			});
+			const mergeBase = result.stdout.trim();
+			if (
+				result.status === 'completed' &&
+				result.exitCode === 0 &&
+				!result.stdoutTruncated &&
+				mergeBase
+			) {
+				const diff = await runGitDiff([`${mergeBase}..HEAD`]);
+				mergeAddedLineMaps(combined, diff);
+				break;
+			}
+		}
+
+		mergeAddedLineMaps(combined, await runGitDiff(['HEAD']));
+		return combined.size > 0 ? combined : null;
+	} catch {
+		return null;
+	}
+}
+
+async function buildAddedLineMap(
+	input: PlaceholderScanInput,
+	directory: string,
+): Promise<Map<string, Set<number>> | null> {
+	if (input.added_lines) {
+		const fromInput = new Map<string, Set<number>>();
+		for (const [filePath, lines] of Object.entries(input.added_lines)) {
+			fromInput.set(normalizeRelativePathForDiff(filePath), new Set(lines));
+		}
+		return fromInput;
+	}
+
+	return getAddedLinesFromGitDiff(directory, input.changed_files);
+}
+
+function filterFindingsToAddedLines(
+	findings: PlaceholderFinding[],
+	filePath: string,
+	addedLineMap: Map<string, Set<number>> | null,
+): PlaceholderFinding[] {
+	if (!addedLineMap) return findings;
+	const allowedLines = addedLineMap.get(normalizeRelativePathForDiff(filePath));
+	if (!allowedLines) return [];
+	return findings.filter((finding) => allowedLines.has(finding.line));
+}
+
+function filterAllowedSentinels(
+	findings: PlaceholderFinding[],
+	allowSentinels: string[] | undefined,
+): PlaceholderFinding[] {
+	const sentinels = [...DEFAULT_ALLOW_SENTINELS, ...(allowSentinels ?? [])]
+		.map((s) => s.trim())
+		.filter(Boolean);
+	if (sentinels.length === 0) return findings;
+	return findings.filter(
+		(finding) =>
+			!sentinels.some((sentinel) => finding.excerpt.includes(sentinel)),
+	);
+}
+
 // ============ Main Function ============
 
 /**
@@ -613,6 +781,7 @@ export async function placeholderScan(
 	directory: string,
 ): Promise<PlaceholderScanResult> {
 	const { changed_files, allow_globs, deny_patterns } = input;
+	const addedLineMap = await buildAddedLineMap(input, directory);
 
 	// Build deny patterns
 	// If custom patterns are provided, they replace the defaults
@@ -713,6 +882,13 @@ export async function placeholderScan(
 			fileFindings = scanWithRegex(content, filePath, denyPatterns);
 		}
 
+		fileFindings = filterFindingsToAddedLines(
+			fileFindings,
+			relativeFilePath,
+			addedLineMap,
+		);
+		fileFindings = filterAllowedSentinels(fileFindings, input.allow_sentinels);
+
 		// Add findings to result
 		if (fileFindings.length > 0) {
 			findings.push(...fileFindings);
@@ -762,6 +938,18 @@ export const placeholder_scan: ReturnType<typeof tool> = createSwarmTool({
 			.array(z.string())
 			.optional()
 			.describe('Custom deny patterns to search for'),
+		added_lines: z
+			.record(z.string(), z.array(z.number().int().positive()))
+			.optional()
+			.describe(
+				'Optional map of file path to added line numbers. When omitted, placeholder_scan computes added lines from git diff.',
+			),
+		allow_sentinels: z
+			.array(z.string())
+			.optional()
+			.describe(
+				'Intentional sentinel strings that suppress matching findings on the same line.',
+			),
 	},
 	async execute(args: unknown, directory: string): Promise<string> {
 		const result = await placeholderScan(
@@ -769,6 +957,8 @@ export const placeholder_scan: ReturnType<typeof tool> = createSwarmTool({
 				changed_files: string[];
 				allow_globs?: string[];
 				deny_patterns?: string[];
+				added_lines?: Record<string, number[]>;
+				allow_sentinels?: string[];
 			},
 			directory,
 		);

--- a/src/worktree/core.ts
+++ b/src/worktree/core.ts
@@ -666,42 +666,64 @@ export async function provisionWorktree(
 		// Case (b) active collision: branch is checked out in ANY registered
 		// worktree, OR the expected path is itself registered (regardless of
 		// on-disk presence).
-		const branchIsActiveSomewhere = entries.some(
-			(e) => e.branch === `refs/heads/${branchName}`,
-		);
 		const expectedPathIsRegistered = entries.some(
 			(e) => e.path === expectedPath,
 		);
+		const branchIsActiveAtExpectedPath = entries.some(
+			(e) => e.branch === `refs/heads/${branchName}` && e.path === expectedPath,
+		);
+		const branchIsActiveElsewhere = entries.some(
+			(e) => e.branch === `refs/heads/${branchName}` && e.path !== expectedPath,
+		);
 
-		if (branchIsActiveSomewhere || expectedPathIsRegistered) {
+		if (
+			branchIsActiveElsewhere ||
+			(expectedPathIsRegistered && !branchIsActiveAtExpectedPath)
+		) {
 			return {
 				error: `Branch already exists and worktree is active: ${branchName} (owned by another session)`,
 			};
 		}
 
-		// Case (a): branch exists but is NOT registered in any active worktree — adopt it
-		console.warn(
-			`[swarm] adopting existing branch ${branchName} (stale worktree)`,
-		);
-
-		// Adopt: check out the existing branch into the worktree path
-		const adoptResult = await runGit(
-			['worktree', 'add', '-f', worktreePath, branchName],
+		const aheadResult = await runGit(
+			['rev-list', '--count', `HEAD..${branchName}`],
 			directory,
 		);
-		if (adoptResult.exitCode !== 0) {
+		if (aheadResult.exitCode !== 0) {
 			return {
-				error: `Failed to adopt existing worktree: ${adoptResult.stderr.trim() || adoptResult.stdout.trim()}`,
+				error: `Failed to inspect stale worktree branch: ${aheadResult.stderr.trim() || aheadResult.stdout.trim()}`,
+			};
+		}
+		const aheadCount = Number.parseInt(aheadResult.stdout.trim(), 10);
+		if (!Number.isFinite(aheadCount) || aheadCount > 0) {
+			return {
+				error: `Branch already exists and has unmerged commits: ${branchName}`,
 			};
 		}
 
-		return {
-			worktreePath,
-			branchName,
-			purpose: options.purpose,
-			id,
-			sessionId,
-		};
+		if (branchIsActiveAtExpectedPath) {
+			const clean = await isCleanWorktree(worktreePath);
+			if (!clean) {
+				return {
+					error: `Branch already exists and expected worktree is dirty: ${branchName}`,
+				};
+			}
+			const removeResult = await removeWorktree(worktreePath, directory, {
+				force: true,
+				worktreeDir: options.worktreeDir,
+			});
+			if (!('success' in removeResult)) {
+				return { error: removeResult.error };
+			}
+		}
+
+		const deleteResult = await runGit(['branch', '-d', branchName], directory);
+		if (deleteResult.exitCode !== 0) {
+			return {
+				error: `Failed to delete stale worktree branch: ${deleteResult.stderr.trim() || deleteResult.stdout.trim()}`,
+			};
+		}
+		await runGit(['worktree', 'prune'], directory);
 	}
 
 	// Create the worktree: git worktree add -b <branch> <path> HEAD

--- a/tests/helpers/skill-content-registry.ts
+++ b/tests/helpers/skill-content-registry.ts
@@ -1,0 +1,71 @@
+import { expect } from 'bun:test';
+
+type SkillConcept = {
+	required: RegExp[];
+	forbidden?: RegExp[];
+};
+
+const SKILL_CONCEPTS = {
+	softSpecGateBranches: {
+		required: [/NO effective spec/i, /\bEXISTS\b/i],
+	},
+	softSpecGateNoSpecChoices: {
+		required: [/Create a spec first/i, /Skip and plan directly/i],
+	},
+	softSpecGateSpecAlignment: {
+		required: [/FR-###/i, /gold-plating/i],
+	},
+	softSpecGateNonBlocking: {
+		required: [
+			/proceed to the steps below exactly as before|do NOT modify any planning behavior/i,
+		],
+		forbidden: [
+			/cannot proceed/i,
+			/must have spec/i,
+			/planning is blocked/i,
+			/blocked until/i,
+		],
+	},
+	planTraceability: {
+		required: [/TRACEABILITY CHECK/i, /FR-###/i, /gold-plating/i],
+	},
+	planTraceabilityHeader: {
+		required: [/TRACEABILITY CHECK/i],
+	},
+	planTraceabilityNoSpecSkip: {
+		required: [
+			/TRACEABILITY CHECK[\s\S]*(no effective spec.*skip|skip this check silently)/i,
+		],
+	},
+	specifyQaGateSelection: {
+		required: [
+			/5b\.\s+\*\*QA GATE SELECTION/i,
+			/## Pending QA Gate Selection/i,
+			/Do NOT call `set_qa_gates` yet/i,
+			/reviewer/i,
+			/test_engineer/i,
+			/sme_enabled/i,
+			/critic_pre_plan/i,
+			/sast_enabled/i,
+			/council_mode/i,
+			/hallucination_guard/i,
+			/\.swarm\/context\.md/i,
+			/MODE: PLAN[\s\S]*set_qa_gates/i,
+		],
+	},
+} satisfies Record<string, SkillConcept>;
+
+export type SkillConceptName = keyof typeof SKILL_CONCEPTS;
+
+export function expectSkillConcept(
+	content: string,
+	conceptName: SkillConceptName,
+): void {
+	const concept = SKILL_CONCEPTS[conceptName];
+	for (const pattern of concept.required) {
+		expect(content).toMatch(pattern);
+	}
+	for (const pattern of concept.forbidden ?? []) {
+		expect(content).not.toMatch(pattern);
+	}
+}

--- a/tests/integration/soft-spec-gate.test.ts
+++ b/tests/integration/soft-spec-gate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createArchitectAgent } from '../../src/agents/architect';
+import { expectSkillConcept } from '../helpers/skill-content-registry';
 
 describe('Soft Spec Gate — integration (v6.15 Task 7.6)', () => {
 	// Extract PLAN protocol text from the extracted plan skill.
@@ -14,48 +15,33 @@ describe('Soft Spec Gate — integration (v6.15 Task 7.6)', () => {
 
 	describe('Gate completeness (both branches present)', () => {
 		it('SPEC GATE presents exactly two branches: spec absent and spec present', () => {
-			const hasNoSpecBranch = planSection.includes('NO effective spec');
-			const hasSpecExistsBranch = planSection.includes('EXISTS');
-			expect(hasNoSpecBranch).toBe(true);
-			expect(hasSpecExistsBranch).toBe(true);
+			expectSkillConcept(planSection, 'softSpecGateBranches');
 		});
 
 		it('No-spec branch mentions spec creation option', () => {
-			expect(planSection).toContain('Create a spec first');
+			expectSkillConcept(planSection, 'softSpecGateNoSpecChoices');
 		});
 
 		it('No-spec branch mentions skip option', () => {
-			expect(planSection).toContain('Skip and plan directly');
+			expectSkillConcept(planSection, 'softSpecGateNoSpecChoices');
 		});
 
 		it('Spec-exists branch mentions FR-### cross-referencing', () => {
-			expect(planSection).toContain('FR-###');
+			expectSkillConcept(planSection, 'softSpecGateSpecAlignment');
 		});
 
 		it('Spec-exists branch flags gold-plating risk', () => {
-			expect(planSection).toContain('gold-plating');
+			expectSkillConcept(planSection, 'softSpecGateSpecAlignment');
 		});
 	});
 
 	describe('Gate coherence (non-contradictory)', () => {
 		it('Gate does not promise to block planning when spec is absent', () => {
-			const blockingPhrases = [
-				'cannot proceed',
-				'must have spec',
-				'planning is blocked',
-				'blocked until',
-			];
-			const planSectionLower = planSection.toLowerCase();
-			blockingPhrases.forEach((phrase) => {
-				expect(planSectionLower).not.toContain(phrase);
-			});
+			expectSkillConcept(planSection, 'softSpecGateNonBlocking');
 		});
 
 		it('Skip path preserves exact existing planning steps', () => {
-			const hasPreserveLanguage =
-				planSection.includes('proceed to the steps below exactly as before') ||
-				planSection.includes('do NOT modify any planning behavior');
-			expect(hasPreserveLanguage).toBe(true);
+			expectSkillConcept(planSection, 'softSpecGateNonBlocking');
 		});
 
 		it('Gate instructions appear BEFORE the main planning steps', () => {

--- a/tests/unit/agents/agent-audit-p2.test.ts
+++ b/tests/unit/agents/agent-audit-p2.test.ts
@@ -14,6 +14,7 @@ import { createExplorerAgent } from '../../../src/agents/explorer';
 import { createReviewerAgent } from '../../../src/agents/reviewer';
 import { createSMEAgent } from '../../../src/agents/sme';
 import { createTestEngineerAgent } from '../../../src/agents/test-engineer';
+import { expectSkillConcept } from '../../helpers/skill-content-registry';
 
 // ─── X3: Structured output enforcement ───────────────────────────────────────
 
@@ -507,28 +508,20 @@ describe('A3: Traceability check in MODE: PLAN', () => {
 	);
 
 	it('contains TRACEABILITY CHECK', () => {
-		expect(prompt).toContain('TRACEABILITY CHECK');
-		expect(planSkill).toContain('TRACEABILITY CHECK');
+		expectSkillConcept(prompt, 'planTraceabilityHeader');
+		expectSkillConcept(planSkill, 'planTraceability');
 	});
 
 	it('requires every FR-### to map to at least one task', () => {
-		const traceIdx = planSkill.indexOf('TRACEABILITY CHECK');
-		const traceSection = planSkill.substring(traceIdx, traceIdx + 1000);
-		expect(traceSection).toContain('FR-###');
+		expectSkillConcept(planSkill, 'planTraceability');
 	});
 
 	it('flags tasks with no FR as gold-plating risk', () => {
-		const traceIdx = planSkill.indexOf('TRACEABILITY CHECK');
-		const traceSection = planSkill.substring(traceIdx, traceIdx + 1000);
-		expect(traceSection).toContain('gold-plating');
+		expectSkillConcept(planSkill, 'planTraceability');
 	});
 
 	it('traceability check is skipped when no spec.md exists', () => {
-		const traceIdx = planSkill.indexOf('TRACEABILITY CHECK');
-		const traceSection = planSkill.substring(traceIdx, traceIdx + 2000);
-		expect(traceSection).toMatch(
-			/no effective spec.*skip|skip this check silently/i,
-		);
+		expectSkillConcept(planSkill, 'planTraceabilityNoSpecSkip');
 	});
 
 	it('TRACEABILITY CHECK appears after save_plan in MODE: PLAN', () => {

--- a/tests/unit/agents/architect-specify-gates.test.ts
+++ b/tests/unit/agents/architect-specify-gates.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createArchitectAgent } from '../../../src/agents/architect';
+import { expectSkillConcept } from '../../helpers/skill-content-registry';
 
 /**
  * MODE: SPECIFY step 5b - QA gate selection dialogue.
@@ -27,39 +28,27 @@ describe('architect prompt - MODE: SPECIFY step 5b QA gate selection', () => {
 	}
 
 	test('SPECIFY block contains a step labeled "5b"', () => {
-		const block = getSpecifySection();
-		expect(block).toMatch(/5b\.\s+\*\*QA GATE SELECTION/);
+		expectSkillConcept(getSpecifySection(), 'specifyQaGateSelection');
 	});
 
 	test('SPECIFY block references the "## Pending QA Gate Selection" section', () => {
-		const block = getSpecifySection();
-		expect(block).toContain('## Pending QA Gate Selection');
+		expectSkillConcept(getSpecifySection(), 'specifyQaGateSelection');
 	});
 
 	test('SPECIFY block explicitly says "Do NOT call `set_qa_gates` yet"', () => {
-		const block = getSpecifySection();
-		expect(block).toContain('Do NOT call `set_qa_gates` yet');
+		expectSkillConcept(getSpecifySection(), 'specifyQaGateSelection');
 	});
 
 	test('SPECIFY block lists all seven QA gate names in the dialogue text', () => {
-		const block = getSpecifySection();
-		expect(block).toContain('reviewer');
-		expect(block).toContain('test_engineer');
-		expect(block).toContain('sme_enabled');
-		expect(block).toContain('critic_pre_plan');
-		expect(block).toContain('sast_enabled');
-		expect(block).toContain('council_mode');
-		expect(block).toContain('hallucination_guard');
+		expectSkillConcept(getSpecifySection(), 'specifyQaGateSelection');
 	});
 
 	test('SPECIFY block instructs writing to .swarm/context.md', () => {
-		const block = getSpecifySection();
-		expect(block).toContain('.swarm/context.md');
+		expectSkillConcept(getSpecifySection(), 'specifyQaGateSelection');
 	});
 
 	test('SPECIFY block mentions persistence happens in MODE: PLAN', () => {
-		const block = getSpecifySection();
-		expect(block).toMatch(/MODE: PLAN.*set_qa_gates/s);
+		expectSkillConcept(getSpecifySection(), 'specifyQaGateSelection');
 	});
 
 	test('SPECIFY block does not leave {{QA_GATE_DIALOGUE_SPECIFY}} placeholder unexpanded', () => {

--- a/tests/unit/background/pr-monitor-worker.test.ts
+++ b/tests/unit/background/pr-monitor-worker.test.ts
@@ -405,7 +405,7 @@ describe('PrMonitorWorker — CI change detection', () => {
 		restoreInternals();
 	});
 
-	test('publishes pr.ci.failed when a check transitions to failure', async () => {
+	test('publishes one batched pr.ci.failed when checks complete with failures', async () => {
 		const sub = makeSubscription({
 			lastCheckRunSet: JSON.stringify([
 				{ n: 'ci/build', c: 'success' },
@@ -418,7 +418,7 @@ describe('PrMonitorWorker — CI change detection', () => {
 			makePRStatus({
 				statusCheckRollup: [
 					{ name: 'ci/build', status: 'completed', conclusion: 'failure' },
-					{ name: 'ci/test', status: 'completed', conclusion: 'success' },
+					{ name: 'ci/test', status: 'completed', conclusion: 'failure' },
 				],
 			}),
 		);
@@ -435,8 +435,96 @@ describe('PrMonitorWorker — CI change detection', () => {
 				prNumber: 42,
 				repoFullName: 'owner/repo',
 				checkName: 'ci/build',
+				failedChecks: [
+					expect.objectContaining({ name: 'ci/build' }),
+					expect.objectContaining({ name: 'ci/test' }),
+				],
 			}),
 			'pr-monitor-worker',
+		);
+	});
+
+	test('does not publish pr.ci.failed until the check set is complete', async () => {
+		const sub = makeSubscription({
+			lastCheckRunSet: JSON.stringify([
+				{ n: 'ci/build', c: 'success' },
+				{ n: 'ci/test', c: null },
+			]),
+		});
+
+		mockState.listActive.mockResolvedValueOnce([sub]);
+		mockState.getPRStatus.mockResolvedValue(
+			makePRStatus({
+				statusCheckRollup: [
+					{ name: 'ci/build', status: 'completed', conclusion: 'failure' },
+					{ name: 'ci/test', status: 'in_progress', conclusion: null },
+				],
+			}),
+		);
+		mockState.getPRComments.mockResolvedValue(makePRComments());
+		mockState.getMergeState.mockResolvedValue(makeMergeState());
+		mockState.updateSnapshot.mockResolvedValue(sub);
+
+		const worker = createWorker();
+		await worker.pollCycle();
+
+		const ciFailedCalls = mockState.busInstance.publish.mock.calls.filter(
+			(c: Array<unknown>) => c[0] === 'pr.ci.failed',
+		);
+		expect(ciFailedCalls).toHaveLength(0);
+	});
+
+	test('publishes batched pr.ci.failed when an earlier failure waits for remaining checks', async () => {
+		const initialSub = makeSubscription({
+			lastCheckRunSet: JSON.stringify([
+				{ n: 'ci/build', c: 'success' },
+				{ n: 'ci/test', c: null },
+			]),
+		});
+		const incompleteSub = makeSubscription({
+			lastCheckRunSet: JSON.stringify([
+				{ n: 'ci/build', c: 'failure' },
+				{ n: 'ci/test', c: null },
+			]),
+		});
+
+		mockState.listActive
+			.mockResolvedValueOnce([initialSub])
+			.mockResolvedValueOnce([incompleteSub]);
+		mockState.getPRStatus
+			.mockResolvedValueOnce(
+				makePRStatus({
+					statusCheckRollup: [
+						{ name: 'ci/build', status: 'completed', conclusion: 'failure' },
+						{ name: 'ci/test', status: 'in_progress', conclusion: null },
+					],
+				}),
+			)
+			.mockResolvedValueOnce(
+				makePRStatus({
+					statusCheckRollup: [
+						{ name: 'ci/build', status: 'completed', conclusion: 'failure' },
+						{ name: 'ci/test', status: 'completed', conclusion: 'success' },
+					],
+				}),
+			);
+		mockState.getPRComments.mockResolvedValue(makePRComments());
+		mockState.getMergeState.mockResolvedValue(makeMergeState());
+		mockState.updateSnapshot.mockResolvedValue(initialSub);
+
+		const worker = createWorker();
+		await worker.pollCycle();
+		await worker.pollCycle();
+
+		const ciFailedCalls = mockState.busInstance.publish.mock.calls.filter(
+			(c: Array<unknown>) => c[0] === 'pr.ci.failed',
+		);
+		expect(ciFailedCalls).toHaveLength(1);
+		expect(ciFailedCalls[0][1]).toEqual(
+			expect.objectContaining({
+				checkName: 'ci/build',
+				failedChecks: [expect.objectContaining({ name: 'ci/build' })],
+			}),
 		);
 	});
 

--- a/tests/unit/commands/ci-simulate.test.ts
+++ b/tests/unit/commands/ci-simulate.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import * as path from 'node:path';
+import {
+	_internals,
+	handleCiSimulateCommand,
+} from '../../../src/commands/ci-simulate';
+import { COMMAND_REGISTRY } from '../../../src/commands/registry';
+
+const original = {
+	runCommand: _internals.runCommand,
+	now: _internals.now,
+	mkdirSync: _internals.mkdirSync,
+};
+
+afterEach(() => {
+	_internals.runCommand = original.runCommand;
+	_internals.now = original.now;
+	_internals.mkdirSync = original.mkdirSync;
+});
+
+describe('ci-simulate command', () => {
+	test('creates merge-result worktree, runs fixed CI gates, and cleans up', async () => {
+		const calls: Array<{ cmd: string[]; cwd: string }> = [];
+		const repoRoot = path.join('C:', 'work', 'repo');
+		_internals.now = () => 123;
+		_internals.mkdirSync = mock(() => undefined) as typeof _internals.mkdirSync;
+		_internals.runCommand = mock(async (cmd: string[], cwd: string) => {
+			calls.push({ cmd, cwd });
+			return { exitCode: 0, stdout: '', stderr: '' };
+		}) as typeof _internals.runCommand;
+
+		const result = await handleCiSimulateCommand(repoRoot, [
+			'--base',
+			'origin/main',
+			'--head',
+			'feature',
+		]);
+
+		expect(result).toContain('CI simulation passed');
+		expect(calls[0].cmd.slice(0, 7)).toEqual([
+			'git',
+			'-C',
+			repoRoot,
+			'worktree',
+			'add',
+			'--detach',
+			expect.stringContaining(path.join('.swarm', 'ci-simulate')),
+		]);
+		expect(calls[0].cmd.at(-1)).toBe('origin/main');
+		expect(calls[1].cmd).toEqual([
+			'git',
+			'-C',
+			calls[0].cmd[6],
+			'merge',
+			'--no-edit',
+			'feature',
+		]);
+		expect(calls[2].cmd).toEqual(['bun', 'run', 'typecheck']);
+		expect(calls[2].cwd).toBe(calls[0].cmd[6]);
+		expect(calls).toContainEqual({
+			cmd: ['bun', 'run', 'lint:ci'],
+			cwd: calls[0].cmd[6],
+		});
+		expect(calls).toContainEqual({
+			cmd: ['bun', 'run', 'test:unit:ci'],
+			cwd: calls[0].cmd[6],
+		});
+		expect(calls).toContainEqual({
+			cmd: ['bun', 'test', 'tests/integration', '--timeout', '120000'],
+			cwd: calls[0].cmd[6],
+		});
+		expect(calls.at(-2)?.cmd.slice(0, 6)).toEqual([
+			'git',
+			'-C',
+			repoRoot,
+			'worktree',
+			'remove',
+			'--force',
+		]);
+		expect(calls.at(-1)?.cmd).toEqual([
+			'git',
+			'-C',
+			repoRoot,
+			'worktree',
+			'prune',
+		]);
+	});
+
+	test('defaults to current worktree HEAD and CI-equivalent gates', async () => {
+		const calls: Array<string[]> = [];
+		const repoRoot = path.join('C:', 'work', 'default-repo');
+		_internals.now = () => 456;
+		_internals.mkdirSync = mock(() => undefined) as typeof _internals.mkdirSync;
+		_internals.runCommand = mock(async (cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes('rev-parse')) {
+				return { exitCode: 0, stdout: 'abc123\n', stderr: '' };
+			}
+			return { exitCode: 0, stdout: '', stderr: '' };
+		}) as typeof _internals.runCommand;
+
+		await handleCiSimulateCommand(repoRoot, []);
+
+		expect(calls[0]).toEqual(['git', '-C', repoRoot, 'rev-parse', 'HEAD']);
+		expect(calls[2]).toEqual([
+			'git',
+			'-C',
+			calls[1][6],
+			'merge',
+			'--no-edit',
+			'abc123',
+		]);
+		expect(calls).toContainEqual(['bun', 'run', 'typecheck']);
+		expect(calls).toContainEqual(['bun', 'run', 'lint:ci']);
+		expect(calls).toContainEqual(['bun', 'run', 'build']);
+		expect(calls).toContainEqual(['bun', 'run', 'test:unit:ci']);
+		expect(calls).toContainEqual([
+			'bun',
+			'test',
+			'tests/integration',
+			'--timeout',
+			'120000',
+		]);
+		expect(calls).toContainEqual([
+			'bun',
+			'test',
+			'tests/security',
+			'--timeout',
+			'120000',
+		]);
+		expect(calls).toContainEqual([
+			'bun',
+			'test',
+			'tests/smoke',
+			'--timeout',
+			'120000',
+		]);
+		expect(calls).toContainEqual(['bun', 'run', 'drift:check']);
+	});
+
+	test('rejects arbitrary command arguments', async () => {
+		const result = await handleCiSimulateCommand(
+			path.join('C:', 'work', 'repo'),
+			['--cmd', 'bun', 'test'],
+		);
+
+		expect(result).toContain('unsupported argument --cmd');
+	});
+
+	test('rejects flags hidden behind missing allowed flag values', async () => {
+		const result = await handleCiSimulateCommand(
+			path.join('C:', 'work', 'repo'),
+			['--base', '--cmd', 'bun', 'test'],
+		);
+
+		expect(result).toContain('missing value for --base');
+	});
+
+	test('rejects stray positional arguments', async () => {
+		const result = await handleCiSimulateCommand(
+			path.join('C:', 'work', 'repo'),
+			['feature'],
+		);
+
+		expect(result).toContain('unexpected positional argument feature');
+	});
+
+	test('is registered as an agent command', () => {
+		expect(COMMAND_REGISTRY['ci-simulate'].toolPolicy).toBe('agent');
+		expect(COMMAND_REGISTRY['ci-simulate'].description).toContain(
+			'temporary merge-result worktree',
+		);
+	});
+});

--- a/tests/unit/commands/pr-monitor-status.test.ts
+++ b/tests/unit/commands/pr-monitor-status.test.ts
@@ -25,6 +25,7 @@ function withFixedNow<T>(callback: () => T): T {
 // Mock listActive via _internals DI seam — no mock.module needed
 // ---------------------------------------------------------------------------
 const mockListActive = mock(() => Promise.resolve([]));
+const mockListMergeGroupRuns = mock(() => Promise.resolve({ runs: [] }));
 
 // ---------------------------------------------------------------------------
 // Temp directory
@@ -36,13 +37,20 @@ beforeEach(() => {
 	tempDir = mkdtempSync(join(tmpdir(), 'pr-status-test-'));
 	savedInternals = { ..._internals };
 	_internals.listActive = mockListActive;
+	_internals.listMergeGroupRuns = mockListMergeGroupRuns;
 	mockListActive.mockReset();
+	mockListMergeGroupRuns.mockReset();
+	mockListMergeGroupRuns.mockImplementation(() =>
+		Promise.resolve({ runs: [] }),
+	);
 });
 
 afterEach(() => {
 	rmSync(tempDir, { recursive: true, force: true });
 	mockListActive.mockReset();
+	mockListMergeGroupRuns.mockReset();
 	_internals.listActive = savedInternals.listActive;
+	_internals.listMergeGroupRuns = savedInternals.listMergeGroupRuns;
 });
 
 // ---------------------------------------------------------------------------
@@ -191,9 +199,64 @@ describe('handlePrMonitorStatusCommand', () => {
 			expect(result).toContain('Active subscriptions (1):');
 			expect(result).toContain('  1. owner/repo#42');
 			expect(result).toContain('URL: https://github.com/owner/repo/pull/42');
+			expect(result).toContain('Merge-group runs: none found in recent runs');
+			expect(result).toContain(
+				'Merge-group checks: gh pr checks 42 --repo owner/repo',
+			);
+			expect(result).toContain(
+				'Failed logs: gh run view <run-id> --repo owner/repo --log-failed',
+			);
 			expect(result).toContain('Last checked: 1 minute ago');
 			expect(result).toContain('Watching: yes');
 			expect(result).toContain('Errors: 0');
+		});
+
+		test('renders recent failed merge-group runs with log commands', async () => {
+			mockListActive.mockImplementation(() =>
+				Promise.resolve([
+					{
+						correlationId: 'session-1::owner/repo::42',
+						sessionID: 'session-1',
+						prNumber: 42,
+						repoFullName: 'owner/repo',
+						prUrl: 'https://github.com/owner/repo/pull/42',
+						lastCheckedAt: Date.now() - 90_000,
+						isWatching: true,
+						hasUnaddressedEvents: false,
+						status: 'active' as const,
+						createdAt: Date.now() - 300_000,
+						updatedAt: Date.now() - 90_000,
+						errorCount: 0,
+					},
+				]),
+			);
+			mockListMergeGroupRuns.mockImplementation(() =>
+				Promise.resolve({
+					runs: [
+						{
+							databaseId: 123,
+							headBranch: 'gh-readonly-queue/main/pr-42-abc',
+							status: 'completed',
+							conclusion: 'failure',
+							url: 'https://github.com/owner/repo/actions/runs/123',
+						},
+					],
+				}),
+			);
+
+			const result = await handlePrMonitorStatusCommand(
+				tempDir,
+				[],
+				'session-1',
+			);
+
+			expect(result).toContain('Merge-group runs:');
+			expect(result).toContain(
+				'123: failure https://github.com/owner/repo/actions/runs/123',
+			);
+			expect(result).toContain(
+				'Failed logs: gh run view 123 --repo owner/repo --log-failed',
+			);
 		});
 
 		test('shows "Watching: no" when isWatching is false', async () => {
@@ -324,11 +387,17 @@ describe('handlePrMonitorStatusCommand', () => {
 			expect(lines[1]).toBe('');
 			expect(lines[2]).toBe('Active subscriptions (1):');
 			expect(lines[3]).toBe('  1. owner/repo#1');
-			expect(lines[7]).toBe('     Errors: 0');
+			expect(lines).toContain(
+				'     Merge-group checks: gh pr checks 1 --repo owner/repo',
+			);
+			expect(lines).toContain(
+				'     Failed logs: gh run view <run-id> --repo owner/repo --log-failed',
+			);
+			expect(lines).toContain('     Errors: 0');
 			// Blank after last sub before total
-			expect(lines[8]).toBe('');
+			expect(lines[lines.indexOf('     Errors: 0') + 1]).toBe('');
 			// No total line shown when session count equals total (1 === 1)
-			expect(lines[9]).toBeUndefined();
+			expect(lines[lines.indexOf('     Errors: 0') + 2]).toBeUndefined();
 		});
 	});
 

--- a/tests/unit/full-auto/oversight.test.ts
+++ b/tests/unit/full-auto/oversight.test.ts
@@ -9,12 +9,13 @@
  *   - dispatchFullAutoOversight fallback (no client) with active durable run:
  *     fail-closed pause + BLOCKED verdict.
  */
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
 	dispatchFullAutoOversight,
+	_internals as oversightInternals,
 	parseFullAutoCriticResponse,
 } from '../../../src/full-auto/oversight';
 import {
@@ -25,6 +26,7 @@ import { _internals as stateInternals } from '../../../src/state';
 
 let tmpDir: string;
 let origClient: typeof stateInternals.swarmState.opencodeClient;
+let origSleep: typeof oversightInternals.sleep;
 
 beforeEach(() => {
 	tmpDir = fs.realpathSync(
@@ -32,11 +34,14 @@ beforeEach(() => {
 	);
 	fs.mkdirSync(path.join(tmpDir, '.swarm'), { recursive: true });
 	origClient = stateInternals.swarmState.opencodeClient;
+	origSleep = oversightInternals.sleep;
 	stateInternals.swarmState.opencodeClient = null;
+	oversightInternals.sleep = async () => {};
 });
 
 afterEach(() => {
 	stateInternals.swarmState.opencodeClient = origClient;
+	oversightInternals.sleep = origSleep;
 	try {
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 	} catch {
@@ -148,6 +153,47 @@ describe('dispatchFullAutoOversight fail-closed behavior', () => {
 			.readdirSync(evidenceDir)
 			.filter((f) => f.startsWith('full-auto-'));
 		expect(files.length).toBe(1);
+	});
+
+	test('retries transient server dispatch errors before pausing', async () => {
+		startFullAutoRun(tmpDir, 'sess-1', { enabled: true });
+		const create = mock()
+			.mockRejectedValueOnce(new Error('Unexpected server error 500'))
+			.mockRejectedValueOnce(new Error('temporarily unavailable 503'))
+			.mockResolvedValueOnce({ data: { id: 'critic-session' } });
+		const prompt = mock().mockResolvedValueOnce({
+			data: {
+				parts: [
+					{
+						type: 'text',
+						text: 'VERDICT: APPROVED\nREASONING: retry recovered\nEVIDENCE_CHECKED: diff\nANTI_PATTERNS_DETECTED: none\nESCALATION_NEEDED: NO',
+					},
+				],
+			},
+		});
+		const deleteSession = mock().mockResolvedValue({});
+		stateInternals.swarmState.opencodeClient = {
+			session: {
+				create,
+				prompt,
+				delete: deleteSession,
+			},
+		} as unknown as typeof stateInternals.swarmState.opencodeClient;
+
+		const out = await dispatchFullAutoOversight({
+			directory: tmpDir,
+			sessionID: 'sess-1',
+			trigger: 'test',
+			triggerSource: 'tool_action',
+			criticModel: 'm',
+			oversightAgentName: 'critic_oversight',
+		});
+
+		expect(create).toHaveBeenCalledTimes(3);
+		expect(prompt).toHaveBeenCalledTimes(1);
+		expect(out.verdict).toBe('APPROVED');
+		expect(out.decision).toBe('allow');
+		expect(loadFullAutoRunState(tmpDir, 'sess-1')?.status).toBe('running');
 	});
 });
 

--- a/tests/unit/hooks/delegation-gate-evidence-taskid.extraction.test.ts
+++ b/tests/unit/hooks/delegation-gate-evidence-taskid.extraction.test.ts
@@ -11,7 +11,11 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { PluginConfig } from '../../../src/config';
 import type { Plan } from '../../../src/config/plan-schema';
-import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import {
+	createDelegationGateHook,
+	hasReviewedTaskRows,
+	parseReviewedTaskIdsFromSetDispatchOutput,
+} from '../../../src/hooks/delegation-gate';
 import { ensureAgentSession, resetSwarmState } from '../../../src/state';
 import { recordPlanCriticApproval } from './_delegation-gate-helpers';
 
@@ -166,5 +170,23 @@ describe('delegation-gate: evidence task ID extraction', () => {
 		}
 
 		expect(threw).toBe(true);
+	});
+});
+
+describe('delegation-gate: set-dispatch reviewed row parsing', () => {
+	it('extracts and normalizes passing per-task reviewed rows', () => {
+		const output = [
+			'[REVIEWED] | task-2.1 | APPROVED | source | none',
+			'[REVIEWED] | 2.2 | NEEDS_REVISION | source | issue',
+			'[REVIEWED] | task-2.3 | PASS | source | none',
+			'[REVIEWED] | ../escape | APPROVED | source | unsafe',
+			'[reviewed] | task-2.1 | APPROVED | duplicate | ignored',
+		].join('\n');
+
+		expect(parseReviewedTaskIdsFromSetDispatchOutput(output)).toEqual([
+			'2.1',
+			'2.3',
+		]);
+		expect(hasReviewedTaskRows(output)).toBe(true);
 	});
 });

--- a/tests/unit/index-commands.test.ts
+++ b/tests/unit/index-commands.test.ts
@@ -39,7 +39,7 @@ describe('Swarm subcommand registration', () => {
 		const commandKeys = Object.keys(commands);
 
 		// Catch-all plus the current command registry entries.
-		expect(commandKeys.length).toBe(69);
+		expect(commandKeys.length).toBe(70);
 
 		// Verify catch-all exists
 		expect(commands.swarm).toBeDefined();
@@ -153,6 +153,7 @@ describe('Swarm subcommand registration', () => {
 			'swarm-finalize',
 			'swarm-close',
 			'swarm-diagnosis',
+			'swarm-ci-simulate',
 		];
 
 		// Verify all expected subcommands exist
@@ -261,6 +262,22 @@ describe('Swarm subcommand registration', () => {
 
 		// This command should be registered
 		expect(commands['swarm-simulate']).toBeDefined();
+	});
+
+	it('should register ci-simulate command', async () => {
+		const plugin = await OpenCodeSwarm.server(mockPluginInput);
+		const mockConfig: Record<string, unknown> = {};
+
+		await plugin.config?.(mockConfig);
+		const commands = mockConfig.command as Record<
+			string,
+			{ template: string; description: string }
+		>;
+
+		expect(commands['swarm-ci-simulate']).toBeDefined();
+		expect(commands['swarm-ci-simulate'].template).toBe(
+			'/swarm ci-simulate $ARGUMENTS',
+		);
 	});
 
 	it('should have correct templates for specific subcommands', async () => {

--- a/tests/unit/tools/placeholder-scan.test.ts
+++ b/tests/unit/tools/placeholder-scan.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { placeholderScan } from '../../../src/tools/placeholder-scan';
+import { bunSpawn } from '../../../src/utils/bun-compat';
 
 // Helper to create temp test directories
 function createTempDir(): string {
@@ -22,6 +23,23 @@ function createTestFile(
 	}
 	fs.writeFileSync(filePath, content, 'utf-8');
 	return filePath;
+}
+
+async function runGit(args: string[], cwd: string): Promise<void> {
+	const proc = bunSpawn(['git', ...args], {
+		cwd,
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+		timeout: 10_000,
+	});
+	const [exitCode, stderr] = await Promise.all([
+		proc.exited,
+		proc.stderr.text(),
+	]);
+	if (exitCode !== 0) {
+		throw new Error(`git ${args.join(' ')} failed: ${stderr}`);
+	}
 }
 
 describe('placeholder_scan tool', () => {
@@ -71,6 +89,82 @@ describe('placeholder_scan tool', () => {
 			expect(result.findings).toHaveLength(1);
 			expect(result.findings[0].rule_id).toBe('placeholder/comment-todo');
 			expect(result.findings[0].kind).toBe('comment');
+		});
+
+		it('only reports placeholder findings on added diff lines', async () => {
+			createTestFile(
+				tempDir,
+				'diff-aware.ts',
+				`// TODO: pre-existing debt
+export function value() {
+  return null;
+}
+`,
+			);
+
+			const result = await placeholderScan(
+				{
+					changed_files: ['diff-aware.ts'],
+					added_lines: { 'diff-aware.ts': [2] },
+				},
+				tempDir,
+			);
+
+			expect(result.verdict).toBe('pass');
+			expect(result.findings).toHaveLength(0);
+		});
+
+		it('suppresses intentional sentinel placeholders on added lines', async () => {
+			createTestFile(
+				tempDir,
+				'sentinel.ts',
+				`export const acceptance = "SC-PLACEHOLDER: user chooses this later";
+`,
+			);
+
+			const result = await placeholderScan(
+				{
+					changed_files: ['sentinel.ts'],
+					added_lines: { 'sentinel.ts': [1] },
+				},
+				tempDir,
+			);
+
+			expect(result.verdict).toBe('pass');
+			expect(result.findings).toHaveLength(0);
+		});
+
+		it('auto-diff includes uncommitted added lines when branch commits already exist', async () => {
+			await runGit(['init', '-b', 'main'], tempDir);
+			await runGit(['config', 'user.email', 'test@example.com'], tempDir);
+			await runGit(['config', 'user.name', 'Test User'], tempDir);
+			createTestFile(tempDir, 'auto-diff.ts', 'export const base = 1;\n');
+			await runGit(['add', 'auto-diff.ts'], tempDir);
+			await runGit(['commit', '-m', 'base'], tempDir);
+			await runGit(['checkout', '-b', 'feature'], tempDir);
+			createTestFile(
+				tempDir,
+				'auto-diff.ts',
+				'export const base = 1;\nexport const committed = 2;\n',
+			);
+			await runGit(['add', 'auto-diff.ts'], tempDir);
+			await runGit(['commit', '-m', 'feature'], tempDir);
+			createTestFile(
+				tempDir,
+				'auto-diff.ts',
+				`export const base = 1;
+export const committed = 2;
+// TODO: uncommitted placeholder
+`,
+			);
+
+			const result = await placeholderScan(
+				{ changed_files: ['auto-diff.ts'] },
+				tempDir,
+			);
+
+			expect(result.verdict).toBe('fail');
+			expect(result.findings.map((finding) => finding.line)).toContain(3);
 		});
 
 		it('should detect FIXME in comments', async () => {

--- a/tests/unit/worktree/provision-worktree.adversarial.test.ts
+++ b/tests/unit/worktree/provision-worktree.adversarial.test.ts
@@ -5,7 +5,7 @@
  *     worktree path → error fires (not adopt-with-force)
  * A2: Unbounded output injection — fake git emits huge stderr → capped ~500 chars
  * A3: Malformed porcelain — garbage lines → parse resilience (skip, don't crash)
- * A4: Empty porcelain (no worktrees) + branch exists → adopt (correct)
+ * A4: Empty porcelain (no worktrees) + ahead branch exists → refuse unmerged commits
  * A5: Force-flag abuse — confirm no path lets caller force-adopt an active branch
  *
  * @note Uses _internals.bunSpawn mock (file-scoped, trivially restorable).
@@ -301,8 +301,8 @@ branch refs/heads/main
 		fs.rmSync(repoDir, { recursive: true, force: true });
 	});
 
-	// A4: EMPTY porcelain (no worktrees) + branch exists → adopt
-	test('A4: empty porcelain (no worktrees) + branch exists → adopts correctly', async () => {
+	// A4: EMPTY porcelain (no worktrees) + ahead branch exists → refuse
+	test('A4: empty porcelain (no worktrees) + ahead branch exists → refuses unmerged commits', async () => {
 		const repoDir = tmpDir();
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
@@ -329,23 +329,9 @@ branch refs/heads/main
 			purpose: 'lane',
 		});
 
-		// Since branch is NOT in any worktree (empty porcelain), it should ADOPT
-		expect(result).toHaveProperty('worktreePath');
-		expect(result).toHaveProperty('branchName', branchName);
-		if ('worktreePath' in result) {
-			// Verify adopted worktree appears in real git worktree list
-			const listResult = await runGit(
-				['worktree', 'list', '--porcelain'],
-				repoDir,
-			);
-			// Issue #1729 Windows quarantine: compare the worktree-relative
-			// suffix (after Temp/) rather than the full path — see A1 comment.
-			const toPosix = (p: string) => p.replace(/\\/g, '/').replace(/\/+$/, '');
-			const wtSuffix = toPosix(result.worktreePath).split('Temp/')[1] ?? '';
-			expect(toPosix(listResult.stdout)).toContain(wtSuffix);
-			// Cleanup
-			await runGit(['worktree', 'remove', result.worktreePath], repoDir);
-			fs.rmSync(result.worktreePath, { recursive: true, force: true });
+		expect(result).toHaveProperty('error');
+		if ('error' in result) {
+			expect(result.error).toContain('has unmerged commits');
 		}
 
 		// Cleanup

--- a/tests/unit/worktree/provision-worktree.test.ts
+++ b/tests/unit/worktree/provision-worktree.test.ts
@@ -176,25 +176,25 @@ describe('provisionWorktree — verification (FR-004)', () => {
 		fs.rmSync(repoDir, { recursive: true, force: true });
 	});
 
-	// V2: Branch exists + NOT in any worktree (stale) → ADOPT
-	test('V2: branch exists but not in any worktree → adopts via git worktree add -f', async () => {
+	// V2: Branch exists + NOT in any worktree + no commits ahead -> recreate
+	test('V2: branch exists but not in any worktree and has no commits ahead -> recreates safely', async () => {
 		const repoDir = tmpDir();
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
 
 		const branchName = 'swarm/lane/parent-session/2.1';
 
-		// Create the branch (but no worktree) — simulating a stale branch
+		// Create the branch (but no worktree), then switch back to main so it is
+		// stale but has no commits ahead of HEAD.
 		await runGit(['checkout', '-b', branchName], repoDir);
-		await runGit(['commit', '--allow-empty', '-m', 'stale commit'], repoDir);
-		// Switch back to main so the branch is "stale" (not checked out)
 		await runGit(['checkout', 'main'], repoDir);
 
 		const result = await provisionWorktree(repoDir, '2.1', 'parent-session', {
 			purpose: 'lane',
 		});
 
-		// Should succeed and adopt the branch
+		// Should succeed and recreate the branch from the current HEAD, not adopt
+		// the stale branch state.
 		expect(result).toHaveProperty('worktreePath');
 		expect(result).toHaveProperty('branchName', branchName);
 		if ('worktreePath' in result) {
@@ -215,6 +215,31 @@ describe('provisionWorktree — verification (FR-004)', () => {
 
 		// Cleanup branch
 		await runGit(['branch', '-D', branchName], repoDir);
+		fs.rmSync(repoDir, { recursive: true, force: true });
+	});
+
+	test('V2b: stale branch with commits ahead is rejected, not force-deleted', async () => {
+		const repoDir = tmpDir();
+		fs.mkdirSync(repoDir, { recursive: true });
+		await initGitRepo(repoDir);
+
+		const branchName = 'swarm/lane/parent-session/2.1';
+		await runGit(['checkout', '-b', branchName], repoDir);
+		await runGit(['commit', '--allow-empty', '-m', 'stale commit'], repoDir);
+		await runGit(['checkout', 'main'], repoDir);
+
+		const result = await provisionWorktree(repoDir, '2.1', 'parent-session', {
+			purpose: 'lane',
+		});
+
+		expect(result).toEqual({
+			error: `Branch already exists and has unmerged commits: ${branchName}`,
+		});
+		const branchStillExists = await runGit(
+			['branch', '--list', branchName],
+			repoDir,
+		);
+		expect(branchStillExists.stdout).toContain(branchName);
 		fs.rmSync(repoDir, { recursive: true, force: true });
 	});
 
@@ -285,20 +310,23 @@ describe('provisionWorktree — verification (FR-004)', () => {
 			repoDir,
 		);
 		// May fail if directory already exists, but that's fine for our purposes
+		if (addResult.exitCode === 0) {
+			fs.writeFileSync(path.join(expectedPath, 'dirty.txt'), 'do not delete');
+		}
 
 		const result = await provisionWorktree(repoDir, '4.1', 'parent-session', {
 			purpose: 'lane',
 		});
 
-		// Should return error (expected path is registered)
+		// Should return error because same-task cleanup must not delete dirty work.
 		expect(result).toHaveProperty('error');
 		if ('error' in result) {
-			expect(result.error).toMatch(/already exists|active|worktree/i);
+			expect(result.error).toMatch(/dirty|already exists|active|worktree/i);
 		}
 
 		// Cleanup
 		const removeResult = await runGit(
-			['worktree', 'remove', expectedPath],
+			['worktree', 'remove', '--force', expectedPath],
 			repoDir,
 		);
 		if (removeResult.exitCode === 0) {


### PR DESCRIPTION
Closes #1746

## Summary
- Add `/swarm ci-simulate`, backed by fixed CI-equivalent gates in an isolated `.swarm/ci-simulate` merge worktree, with no arbitrary command execution.
- Make workflow friction checks safer and more actionable: stale worktree cleanup refuses active or ahead branches, placeholder scans only fail on added lines, PR monitor CI failures are batched after check completion, merge-group runs are visible from `/swarm pr status`, and full-auto retries transient dispatch errors before pausing.
- Replace brittle skill-text assertions with a shared skill-content registry helper, update the affected skills, and add the release fragment for the user-visible changes.

## Invariant audit
- 1 (plugin init): touched - `src/index.ts` only registers the new shortcut/command surface; no new init-time filesystem scan, subprocess, network call, or package-manager call. Verified by `bun run build`, `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`, and `bun test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts`.
- 2 (runtime portability): touched - plugin entry and package scripts changed. Verified by `bun run build`, `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`, and bundle portability/plugin-shape tests.
- 3 (subprocesses): touched - `/swarm ci-simulate`, placeholder diff discovery, merge-group status, and the local unit CI helper use bounded array-form commands through existing helpers or explicit Bun spawn options. Verified by lint/typecheck and affected tests including `tests/unit/commands/ci-simulate.test.ts`, `tests/unit/tools/placeholder-scan.test.ts`, and `tests/unit/commands/pr-monitor-status.test.ts`.
- 4 (.swarm containment): touched - ci simulation writes its temporary merge worktree under `.swarm/ci-simulate`, and worktree cleanup now refuses unsafe active/ahead branch cleanup. Verified by `tests/unit/commands/ci-simulate.test.ts` and `tests/unit/worktree/provision-worktree.test.ts`.
- 5 (plan durability): not touched - no plan ledger, projection, checkpoint, import/export, or plan docs code changed.
- 6 (test_runner safety): touched - added shell-based `test:unit:ci` and `/swarm ci-simulate` gates; no broad OpenCode `test_runner` usage added. Verified by `bun run test:unit:ci tests/unit/commands/ci-simulate.test.ts tests/unit/worktree/provision-worktree.test.ts`.
- 7 (test writing): touched - writing-tests skill loaded; tests remain `bun:test`, use existing `_internals` seams, and restore mutated seams. Verified by the affected unit/integration/security/smoke test commands listed below.
- 8 (session state): not touched - no new session-scoped module globals or global session maps introduced.
- 9 (guardrails/retry): touched - full-auto dispatch retry and delegation-gate attribution semantics changed. Verified by `tests/unit/full-auto/oversight.test.ts` and `tests/unit/hooks/delegation-gate-evidence-taskid.extraction.test.ts`.
- 10 (chat/system msg): not touched - no chat/system-message hook code changed.
- 11 (tool registration): touched - command registry and shortcuts now include `ci-simulate`. Verified by `src/commands/shortcut-resolution.test.ts`, `src/commands/registry.tool-policy.test.ts`, and `bun run drift:check`.
- 12 (release/cache): touched - added `docs/releases/pending/issue-1746-swarm-friction-fixes.md`; no release-please-owned version/changelog/manifest edits and no cache deletion logic changed. Verified by `git status --short` and `bun run drift:check`.

## Test plan
- `bun run lint:ci`
- `bun run typecheck`
- `bun run test:unit:ci tests/unit/commands/ci-simulate.test.ts tests/unit/worktree/provision-worktree.test.ts`
- `bun test tests/unit/background/pr-monitor-worker.test.ts tests/unit/background/pr-event-subscribers.test.ts tests/unit/tools/placeholder-scan.test.ts tests/unit/commands/ci-simulate.test.ts tests/unit/commands/pr-monitor-status.test.ts tests/unit/hooks/delegation-gate-evidence-taskid.extraction.test.ts tests/unit/full-auto/oversight.test.ts tests/unit/worktree/provision-worktree.test.ts tests/integration/soft-spec-gate.test.ts tests/unit/agents/agent-audit-p2.test.ts tests/unit/agents/architect-specify-gates.test.ts src/commands/shortcut-resolution.test.ts src/commands/registry.tool-policy.test.ts`
- `bun test tests/security tests/smoke --timeout 120000`
- `bun run build`
- `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- `bun test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts`
- `bun run drift:check`
- `git diff --check`
- `graphify update .`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

