### PR TITLE
test(stability): freezeClock helper, detection gate, runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,13 @@ jobs:
         if: needs.detect-release.outputs.is-release != 'true'
         shell: bash
         run: chmod +x scripts/check-cross-contamination.sh && bash scripts/check-cross-contamination.sh
+      # Diff-scoped: fails only on NEW time-touching tests that don't reference
+      # the freezeClock helper. Pre-existing files are non-blocking warnings
+      # (issue #1782 root-cause class 1 prevention).
+      - name: Test-clock lint (freezeClock adoption)
+        if: needs.detect-release.outputs.is-release != 'true'
+        shell: bash
+        run: chmod +x scripts/check-test-clock.sh && bash scripts/check-test-clock.sh
 
   # Two-tier CI: on pull_request, run ubuntu-only with 4 shards for fast feedback.
   # On merge_group (merge queue), run the full 3-OS matrix for merge safety.
@@ -189,6 +196,12 @@ jobs:
           failed=0
           tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
           trap 'rm -f "$tmpdir"/bun-out-$$-*' EXIT
+          # flake-annotations.txt captures retry-flake + hard-failure signals so
+          # the downstream flake-detection workflow_run can suggest quarantines
+          # (issue #1782). Written to a workspace-relative path (survives the
+          # tmpdir trap cleanup) and uploaded if-always below.
+          flake_ann="flake-annotations-unit-shard-$SHARD.txt"
+          : > "$flake_ann"
           while IFS= read -r f; do
             [ -f "$f" ] || continue
             tmp="$tmpdir/bun-out-$$-${f##*/}"
@@ -213,6 +226,7 @@ jobs:
               bun scripts/ci/run-test-with-timeout.ts "$f" --timeout 120000 --kill-timeout 180 > "$tmp" 2>&1 || exit_code=$?
               if [ $exit_code -eq 0 ]; then
                 echo "::notice file=$f::Passed on retry $retry_num (flaky): $f"
+                echo "::notice file=$f::Passed on retry $retry_num (flaky): $f" >> "$flake_ann"
               fi
             done
             if [ $exit_code -ne 0 ]; then
@@ -229,6 +243,7 @@ jobs:
               cat "$tmp"
               echo "::endgroup::"
               echo "::error file=$f::FAILED: $f"
+              echo "::error file=$f::FAILED: $f" >> "$flake_ann"
               failed=1
             fi
             # Surface timing and timeout info to CI output (not just temp file)
@@ -236,6 +251,17 @@ jobs:
             rm -f "$tmp"
           done < "$tmpdir/shard-tests.txt"
           exit $failed
+      # Upload the per-shard flake-annotations file `if: always()` so the
+      # downstream flake-detection workflow_run can download it and suggest
+      # quarantines even when this job failed (issue #1782). if-no-files-found:
+      # ignore — an empty annotation file (no flakes/failures) is normal.
+      - name: Upload flake annotations
+        if: always() && needs.detect-release.outputs.is-release != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: flake-annotations-unit-shard-${{ matrix.shard }}
+          path: flake-annotations-unit-shard-*.txt
+          if-no-files-found: ignore
       # NOTE: the coverage gate used to run here as an extra step on
       # `unit (ubuntu-latest, 1)`, which made that one cell execute the entire
       # unit suite twice (sharded run + full-suite coverage run) inside the 40m

--- a/.github/workflows/flake-detection.yml
+++ b/.github/workflows/flake-detection.yml
@@ -1,0 +1,90 @@
+# Flake detection (issue #1782, root-cause detection phase §6).
+#
+# Triggers on completion of the `ci.yml` workflow when the triggering event was
+# a merge_group run. Downloads the per-shard flake-annotations artifacts
+# uploaded by ci.yml's unit job, concatenates them, and runs
+# scripts/ci/detect-and-quarantine-flakes.sh to produce quarantine suggestions
+# + a best-effort tracking issue.
+#
+# This workflow is ADVISORY ONLY: it never fails a run (the detection script
+# always exits 0). A detected flake already failed in ci.yml; this workflow
+# only surfaces the suggestion to quarantine so the next PR isn't blocked.
+#
+# Why a separate workflow_run (not a step in ci.yml): the detection needs the
+# FULL set of shards' annotations, but each unit shard is a separate job. A
+# workflow_run runs once after ALL ci.yml jobs finish and can see every shard's
+# artifact. (Plan critic C1 fix.)
+name: Flake Detection
+
+on:
+  workflow_run:
+    workflows: ["ci"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+# Only one detection run per triggering ci run. Without this, two near-simultaneous
+# merge-group failures could each spawn a detection run and double-file tracking
+# issues (PR review F-006). cancel-in-progress is false so a queued run still
+# completes (detection is cheap and advisory — we don't want to lose a suggestion).
+concurrency:
+  group: flake-detection-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    # Only act when the triggering ci run was on the default branch's merge
+    # queue (merge_group). PR-branch runs don't hit the Windows/macOS/coverage
+    # matrix, so their flakes aren't the target population. Skips release-please
+    # runs and cancelled runs.
+    if: >-
+      github.event.workflow_run.event == 'merge_group' &&
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Download flake-annotation artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          # run-id pins the download to the artifacts of the triggering ci run,
+          # not this workflow's run (plan critic C1 fix — workflow_run otherwise
+          # cannot see the triggering run's artifacts).
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pattern: flake-annotations-unit-shard-*
+          merge-multiple: true
+          path: annotations
+
+      - name: Concatenate annotations
+        shell: bash
+        run: |
+          mkdir -p detection-out
+          cat annotations/flake-annotations-unit-shard-*.txt 2>/dev/null > detection-out/flake-annotations.txt || true
+          echo "Combined annotation line count: $(wc -l < detection-out/flake-annotations.txt | tr -d ' ')"
+          if [ ! -s detection-out/flake-annotations.txt ]; then
+            echo "No flake annotations found (ci.yml may have failed for a non-test reason)."
+          fi
+
+      - name: Run flake detection
+        shell: bash
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x scripts/ci/detect-and-quarantine-flakes.sh
+          bash scripts/ci/detect-and-quarantine-flakes.sh detection-out/flake-annotations.txt
+
+      - name: Upload flake suggestions
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: flake-suggestions
+          path: |
+            flake-suggestions.txt
+            detection-out/flake-annotations.txt
+          if-no-files-found: ignore

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,6 +2,8 @@
 
 > **For LLM agents:** Load the `writing-tests` skill (`.opencode/skills/writing-tests/SKILL.md`) before writing or modifying any test file. It contains the full mock isolation rules, CI pipeline structure, and anti-patterns. For agent operational safety and the broader engineering invariants of this repo (especially the `test_runner` broad-scope restriction and the `_internals` DI-seam pattern for mock isolation), read [`AGENTS.md`](./AGENTS.md) at the repo root.
 
+> **Writing stable tests?** See [`docs/testing/test-stability.md`](./docs/testing/test-stability.md) — the runbook for the four root-cause classes of merge-group flaky tests (time-sensitive, coverage-sensitivity, cross-platform, subprocess) and the `freezeClock` / `withIsolatedState` helpers that prevent them. The `check-test-clock.sh` lint (CI `quality` job) fails on NEW time-touching tests that don't use the helper.
+
 > **⚠️ Do NOT use the OpenCode `test_runner` tool to validate the full repo.** It is for targeted agent validation with explicit `files: [...]` or small targeted scopes. `scope: 'all'` requires `allow_full_suite: true` and is intended for opt-in CI mirrors only. Broad scopes can stall or kill OpenCode before the `MAX_SAFE_TEST_FILES = 50` guard in `src/tools/test-runner.ts` fires. For repo validation, use the shell commands below — per-file isolation loops match CI behavior. See [`AGENTS.md`](./AGENTS.md) invariant 6 for the full contract.
 
 ## Quick Reference

--- a/docs/audits/test-stability-audit.md
+++ b/docs/audits/test-stability-audit.md
@@ -1,0 +1,66 @@
+# Test-Stability Audit — opencode-swarm
+
+> Deliverable artifact (issue #1782, Phase 0). Lives under `docs/audits/` as a
+> version-controlled record of the known flaky-test inventory. The contributor
+> runbook is at `docs/testing/test-stability.md`.
+
+## Summary statistics
+
+- **Total known flaky tests (from issue #1782 audit baseline):** 7
+- **By root-cause class:**
+  - Class 1 (time-sensitive): 2 (#1 skill-scoring-e2e, #3 cross-process-scope) + suspected #5 (skill-scoring-workflow)
+  - Class 2 (coverage sensitivity): 3 (#1, #4 swarm-artifact-cache, #6 test-runner Pester)
+  - Class 3 (cross-platform runtime): 2 (#2 infra runner starvation, #4 Windows bun exit-code)
+  - Class 4 (subprocess/env): 1 (#6 test-runner Pester)
+- **By quarantine status:** 4 quarantined (#4, #5, + 4 macOS lean-turbo in macos list), 3 fixed-at-root (#1, #2/#3, #6 Pester case-gated).
+
+## Flake inventory
+
+| # | Test file | Test / area | Root-cause class | First/last seen | Proposed fix | Quarantined? | Status |
+|---|-----------|-------------|------------------|-----------------|--------------|--------------|--------|
+| 1 | `tests/unit/hooks/skill-scoring-e2e.test.ts` | "scoring results are deterministic" / "idempotency" | 1, 2 | 2026-07-08/09 | Freeze `Date.now()` | No | **FIXED** — migrated to `withFrozenClock` (PR #1784) |
+| 2 | merge-group `quality`+`rust-sandbox-runner` jobs | n/a (infra) | 3 | 2026-07-08/10 | n/a (transient infra) | No | Infra — not a test flake; retry handles it |
+| 3 | `tests/integration/cross-process-scope.test.ts` | "TTL of zero is treated as already expired" | 1 | 2026-07-08 | `now >= expiresAt` (was `>`) | No | **FIXED** — `src/scope/scope-persistence.ts:295` (PR #1767) |
+| 4 | `tests/unit/utils/swarm-artifact-cache.test.ts` | whole file (Windows bun exit-code quirk) | 2, 3 | 2026-07-09 | bun/Windows quirk | **Yes** (`quarantined-tests.txt`) + per-case `skipIf` | Quarantined (double-protected) |
+| 5 | `tests/unit/hooks/skill-scoring-workflow.test.ts` | `computeSkillRelevanceScore` workflow boost | 1 (suspected) | 2026-07-09 | Freeze clock | **Yes** (`quarantined-tests.txt`) | **FIXED (PR #1784)** — wrapped in `withFrozenClock`; STAYS quarantined until merge-group confirms green (plan critic H1) |
+| 6 | `tests/unit/tools/test-runner.test.ts` | Pester convention-scope case (~L543) | 2, 4 | 2026-07-09 | gate on `hasPwsh` | No (case-gated) | **FIXED** — `test.skipIf(!hasPwsh)` guards the subprocess case |
+| 7 | (unknown — the "next to surface") | unknown | unknown | future | TBD | — | Addressed structurally by the flake-detection workflow (PR #1784) |
+
+### macOS-only quarantined (not in the issue's baseline, but related — issue #1729 follow-up)
+
+| Test file | Root cause | Status |
+|-----------|-----------|--------|
+| `tests/unit/turbo/lean/integration-worktree.test.ts` | macOS lane-provisioning (provisionWorktree mock not called) | Quarantined (`quarantined-tests-macos.txt`) — needs macOS env to diagnose |
+| `tests/unit/turbo/lean/retroactive-adversarial.test.ts` | same cluster | Quarantined |
+| `tests/unit/turbo/lean/runner.adversarial.test.ts` | same cluster | Quarantined |
+| `tests/unit/turbo/lean/runner.test.ts` | same cluster | Quarantined |
+
+## Priority ranking
+
+- **P0 (blocking the queue right now):** none remaining after this PR — the
+  systemic fixes (freezeClock + detection + lint) address the recurring class.
+- **P1 (next most likely to surface):** #5 (skill-scoring-workflow) if the
+  freeze proves incomplete cross-platform; the 4 macOS lean-turbo tests.
+- **P2 (latent/rare):** #2 (infra runner starvation — transient, retried).
+
+## Acceptance-criteria status (issue #1782 §10)
+
+This PR (partial delivery of the 6-phase sprint) meets the criteria achievable
+without elapsed wall-clock; the rest are explicitly tracked as open:
+
+| AC | Status | Evidence |
+|----|--------|----------|
+| 1 (audit complete) | **MET** | this document (committed under `docs/audits/`) |
+| 2 (bulk quarantine + 5 green re-queues) | **NOT MET** | 5 consecutive green merge-group re-queues require elapsed wall-clock + multiple real PRs through the queue |
+| 3 (freezeClock adopted) | **PARTIAL** | helper + lint exist and work (PR #1784); 4 confirmed flaky sites migrated; the lint forces all NEW time-touching tests to use the helper. "Every Class 1 test" (~465 pre-existing files) is not migrated — diff-scoped lint is non-blocking for those by design |
+| 4 (coverage isolation) | **PARTIAL** | per-file coverage isolation already exists (`run-coverage-gate.sh`); `withIsolatedState` helper added. Coverage gate remains merge-group-only (extending to PR-branch is a separate change) |
+| 5 (cross-platform/subprocess) | **LARGELY PRE-EXISTING** | OS-specific quarantine lists + per-case `skipIf` guards already exist (#1729). Runbook documents the convention |
+| 6 (detection gate) | **PARTIAL** | detection workflow runs on failed merge-group runs; produces suggestion artifact + best-effort tracking issue. Auto-quarantine PR (needs PAT + branch-protection bypass) is out of scope |
+| 7 (runbook) | **MET** | `docs/testing/test-stability.md` |
+| 8 (2-week soak) | **NOT MET** | requires elapsed wall-clock with no new flakes |
+
+**This PR does NOT close #1782.** It delivers the systemic tooling layer
+(Phases 0, 2, 5, 6 of the sprint) and the prevention/detection infrastructure.
+AC2 and AC8 require ongoing CI observation over weeks; AC3/AC4/AC6 are
+partially met and have clear follow-up work. The issue should remain open
+until those criteria are satisfied.

--- a/docs/releases/pending/1782-test-stability-sprint.md
+++ b/docs/releases/pending/1782-test-stability-sprint.md
@@ -1,0 +1,62 @@
+# `test`: test-stability sprint — freezeClock helper, detection, runbook
+
+## Summary
+
+- Added a deterministic-clock test helper `tests/helpers/test-clock.ts`
+  (`freezeClock`, `withFrozenClock`, `withFrozenClockAsync`) so time-sensitive
+  assertions stop flaking under coverage instrumentation. bun's `bun:test` does
+  not export `FakeTime`, so the helper builds on the repo's proven `spyOn(Date)`
+  pattern.
+- Added `tests/helpers/test-isolation.ts` (`withIsolatedState`,
+  `setupIsolatedState`) composing the existing env + temp-dir + clock helpers
+  into one call.
+- Added a diff-scoped lint `scripts/check-test-clock.sh` (wired into the
+  `quality` CI job) that fails only on NEW test files touching the real clock
+  without referencing the helper — pre-existing files are non-blocking.
+- Added advisory flake detection: `.github/workflows/flake-detection.yml`
+  (`workflow_run` on failed merge-group ci runs) downloads the new
+  per-shard `flake-annotations-*` artifacts that ci.yml's unit job now uploads,
+  runs `scripts/ci/detect-and-quarantine-flakes.sh`, and best-effort opens a
+  tracking issue + uploads a `flake-suggestions` artifact.
+- Added `docs/testing/test-stability.md` — a contributor runbook for the four
+  root-cause classes (time-sensitive, coverage-sensitivity, cross-platform,
+  subprocess) and the helpers/conventions/detection that prevent them.
+- Migrated the 3 ad-hoc `spyOn(Date, ...)` sites (skill-scoring-e2e ×2,
+  manager-plan-md-sync ×1) and fixed the quarantined skill-scoring-workflow
+  test (wrapped in `withFrozenClock`; the file stays quarantined until a
+  merge-group run confirms greenness on all 3 OSes).
+- Added `docs/audits/test-stability-audit.md` — the flake inventory with
+  per-test root-cause classification and acceptance-criteria status.
+
+## User-facing changes
+
+None — test/CI infrastructure only. No runtime behavior changed.
+
+## Migration notes
+
+New time-sensitive tests must use `withFrozenClock` (or reference it) or the
+`check-test-clock.sh` lint will fail the `quality` job. See
+`docs/testing/test-stability.md`. The lint is diff-scoped: pre-existing test
+files that touch `Date.now()` / `new Date()` are non-blocking warnings and can
+be migrated opportunistically.
+
+## Why
+
+The merge-group CI matrix (Windows × 4 + macOS × 4 + coverage + integration)
+repeatedly kicked PRs out of the queue on pre-existing flakes invisible to the
+PR-branch Ubuntu-only CI (issue #1782). This ships the systemic layer
+(deterministic-time helper + detection + lint + runbook) so the class of flakes
+stops recurring and new ones are caught before they block a PR.
+
+## Honest limitations
+
+- 5-consecutive-green-merge-group-requeues and a two-week soak cannot be proven
+  in one PR — they require elapsed wall-clock and multiple real PRs through the
+  queue. Tracked in `docs/audits/test-stability-audit.md` as "requires ongoing
+  CI observation."
+- Auto-quarantine is advisory: it produces a suggestion artifact + best-effort
+  tracking issue. Auto-appending to `quarantined-tests.txt` (needs a PAT +
+  branch-protection bypass) is intentionally out of scope.
+
+Refs #1782 (partial delivery of the test-stability sprint — does not close it;
+AC2/AC8 require ongoing CI observation and AC3/AC4/AC6 have follow-up work).

--- a/docs/testing/test-stability.md
+++ b/docs/testing/test-stability.md
@@ -1,0 +1,201 @@
+# Test Stability Runbook
+
+How to write tests that stay green on the merge-group CI matrix
+(Windows × 4 + macOS × 4 + coverage + full integration), not just the
+PR-branch Ubuntu-only CI.
+
+> Origin: issue #1782 (test-stability sprint). This document is the
+> contributor-facing runbook for the four root-cause classes of flaky tests
+> and the helpers/conventions that prevent them.
+
+## TL;DR — the four rules
+
+1. **Time-sensitive test?** Freeze the clock with `withFrozenClock` — never
+   assert on a value derived from `Date.now()` against a live clock.
+2. **Test needs isolated state?** Use `withIsolatedState` — one call covers
+   env vars + temp dir + clock.
+3. **Platform-specific behavior?** Gate with `test.skipIf(process.platform ...)`
+   and explain why in a comment.
+4. **Test invokes a real subprocess?** Prefer an `_internals` DI seam over
+   running the real binary; if the binary is required, mark it and quarantine
+   coverage-sensitive cases.
+
+---
+
+## The four root-cause classes
+
+### Class 1 — Time-sensitive assertions
+
+**Symptom:** test passes standalone but flakes under coverage instrumentation,
+because the real clock advances between the call under test and a later
+equality assertion (e.g. `computeRecencyScore` in `src/hooks/skill-scoring.ts`
+is a continuous function of `Date.now()`).
+
+**Fix:** freeze the clock deterministically.
+
+```typescript
+import { withFrozenClock } from '../../helpers/test-clock.js';
+
+test('score is deterministic', () => {
+  withFrozenClock(() => {
+    const a = computeScore();
+    const b = computeScore();
+    expect(a).toBe(b); // deterministic — clock is frozen
+  }, { fixedNow: 1_700_000_000_000 });
+});
+```
+
+For `beforeEach`-scoped freezing (when a whole describe block needs a frozen
+clock), use `freezeClock()` and restore in `afterEach`:
+
+```typescript
+import { freezeClock, type Restore } from '../../helpers/test-clock.js';
+
+describe('plan.md sync', () => {
+  let restoreClock: Restore | null = null;
+  beforeEach(() => {
+    restoreClock = freezeClock({ isoNow: '2026-01-01T00:00:00.000Z' });
+  });
+  afterEach(() => { restoreClock?.(); restoreClock = null; });
+});
+```
+
+**Helpers:** `tests/helpers/test-clock.ts` — `freezeClock()`, `withFrozenClock()`,
+`withFrozenClockAsync()`. See the file's header for the full API.
+
+**Why `spyOn` and not `FakeTime`:** bun's `bun:test` does not export `FakeTime`
+(verified absent on 1.3.13/1.3.14). The repo's only proven time-mock surface is
+`spyOn(Date, 'now')` and `spyOn(Date.prototype, 'toISOString')`, which is what
+the helper uses internally.
+
+**Enforcement:** `scripts/check-test-clock.sh` (diff-scoped — runs in the
+`quality` CI job). Any NEW test file that touches `Date.now()` / `new Date()` /
+`spyOn(Date` without referencing `freezeClock` / `withFrozenClock` /
+`withIsolatedState` fails the build. Pre-existing files are non-blocking
+warnings.
+
+### Class 2 — Coverage-instrumentation sensitivity
+
+**Symptom:** test passes in a plain run but fails under `--coverage`, because
+instrumentation changes timing, module-load order, or mock-call counting.
+
+**Fix:**
+- Timing-dependent cases → route to Class 1 (`freezeClock`).
+- Module-load-order cases → reset module state in `afterEach`, or `await import`
+  dynamically. Use `_internals` DI seams (see `src/utils/gitignore-warning.ts`
+  and AGENTS.md invariant 7) instead of `mock.module` (which leaks across files
+  in Bun's shared test-runner process).
+- Shared global state → reset in `afterEach`.
+- For full isolation (env + temp dir + clock), use `withIsolatedState`:
+
+```typescript
+import { withIsolatedState } from '../../helpers/test-isolation.js';
+
+test('isolated', async () => {
+  await withIsolatedState(async (state) => {
+    // state.dir = realpath temp dir, state.configDir = isolated HOME/XDG
+    // clock frozen if you passed { clock: true }
+  }, { clock: { fixedNow: 0 } });
+});
+```
+
+**Why it works:** the merge-queue coverage gate (`scripts/ci/run-coverage-gate.sh`)
+already runs each test file in its own process (`bun test --isolate`), so
+file-scoped mocks cannot contaminate later files (issue #1712). The helpers
+above handle the per-test state that the process boundary doesn't.
+
+### Class 3 — Cross-platform runtime (Windows/macOS)
+
+**Symptom:** test passes on Ubuntu but fails on the Windows or macOS
+merge-group leg (path separators, bun exit-code quirks, filesystem timestamp
+semantics, runner environment).
+
+**Fix:** gate the test to the platform it actually tests, with a comment:
+
+```typescript
+test.skipIf(process.platform !== 'win32')(
+  'Windows ctime behavior',
+  () => { /* ... */ },
+);
+```
+
+If the failure is a genuine bun/platform bug that can't be fixed at the root,
+quarantine it (see "Quarantine convention" below) with a clear reason.
+
+### Class 4 — Subprocess / environment dependency
+
+**Symptom:** test invokes a real subprocess (Pester, pytest, cargo, the
+test-runner tool itself) and asserts on its output; sensitive to the runtime
+environment and coverage instrumentation.
+
+**Fix:**
+- Prefer mocking the subprocess at an `_internals` DI seam over running the
+  real binary.
+- Where a real binary is required (end-to-end tests), gate the case on binary
+  availability (`test.skipIf(!hasBinary)`) and quarantine coverage-sensitive
+  cases.
+
+---
+
+## Quarantine convention
+
+When a test is genuinely flaky and cannot be fixed at the root immediately,
+add it to a quarantine list so the merge-group CI stops blocking on it:
+
+- **Unit/coverage tests:** `scripts/ci/quarantined-tests.txt`
+- **macOS-only unit tests:** `scripts/ci/quarantined-tests-macos.txt`
+- **Windows-only unit tests:** `scripts/ci/quarantined-tests-windows.txt`
+- **Integration tests:** `scripts/ci/quarantined-integration-tests.txt`
+
+Format: one repo-relative test file path per line; blank lines and `#` lines
+ignored. **Always add a comment explaining why** (root cause, related issue,
+validation tier). CI reads these lists and subtracts them from the discovered
+test set (`comm -23`) at `.github/workflows/ci.yml`.
+
+Do NOT un-quarantine without a merge-group validation run confirming the fix.
+
+## Auto-detection (the flake-detection workflow)
+
+When a merge-group CI run fails, `.github/workflows/flake-detection.yml`
+(`workflow_run` trigger) downloads the per-shard `flake-annotations-*`
+artifacts that ci.yml's unit job uploads, concatenates them, and runs
+`scripts/ci/detect-and-quarantine-flakes.sh`. The script:
+
+1. Extracts candidate flaky/hard-failed test files from the annotations.
+2. Drops candidates that are already quarantined, have an infra-signature
+   failure (runner starvation, cancellation), or are in core trees
+   (`tests/unit/{scope,agents,hooks}/**` — flagged for human review).
+3. Writes survivors to a `flake-suggestions` artifact and best-effort opens a
+   tracking issue (best-effort because the Actions token's `issues:write` may
+   be restricted by repo settings).
+
+**The detection is advisory — it never fails a run.** A maintainer reviews the
+suggestion and, if warranted, appends the line to the appropriate quarantine
+file in a follow-up PR. Auto-appending directly to the quarantine file would
+require a PAT + branch-protection bypass and is intentionally out of scope.
+
+## Known limitations
+
+- **`process.hrtime.bigint()` / `performance.now()` are NOT frozen by
+  `freezeClock`.** The helper spies only `Date.now()` and
+  `Date.prototype.toISOString()`. Code that measures elapsed wall-clock via
+  `hrtime`/`performance.now()` (e.g. `src/tools/pre-check-batch.ts` duration
+  measurements) needs a separate seam. No current test asserts on those
+  durations; if you add one, add a dedicated mock at the call site rather than
+  relying on `freezeClock`.
+- **Merge-group greenness requires real queue runs.** A local `run-coverage-gate.sh`
+  pass approximates the coverage leg but cannot prove Windows/macOS stability —
+  only a real merge-group run on the 3-OS matrix can.
+- **The test-clock lint is diff-scoped.** It only blocks NEW violations; the
+  ~465 pre-existing files that touch the clock without the helper are
+  non-blocking warnings. Migrate them opportunistically when you touch a file.
+
+## Reference
+
+- Helpers: `tests/helpers/test-clock.ts`, `tests/helpers/test-isolation.ts`
+- Lint: `scripts/check-test-clock.sh`
+- Detection: `scripts/ci/detect-and-quarantine-flakes.sh`,
+  `.github/workflows/flake-detection.yml`
+- Coverage gate (per-file isolation): `scripts/ci/run-coverage-gate.sh`
+- Audit table (current flake inventory): `docs/audits/test-stability-audit.md`
+- Issue: #1782

--- a/scripts/check-test-clock.sh
+++ b/scripts/check-test-clock.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Check that test files using the real clock (Date.now / new Date / spyOn(Date))
+# also use the freezeClock helper, so time-sensitive assertions don't flake
+# under coverage instrumentation (issue #1782, root-cause class 1).
+#
+# A test file is a VIOLATION if it contains a raw time read
+# (Date.now() / new Date( / spyOn(Date) ) AND does NOT reference the helper
+# (freezeClock / withFrozenClock / withFrozenClockAsync).
+#
+# The helper reference is a proxy for "the author considered time-sensitivity."
+# It is deliberately permissive on the helper side: any reference counts,
+# because the lint cannot do call-graph analysis from bash. Most legitimate
+# raw-clock uses (fixture IDs, tmp suffixes) are fine in files that ALSO freeze
+# the clock for their assertions. Files that use the clock at all but never
+# reference the helper are the ones most likely to add a flaky assertion.
+#
+# This script is DIFFF-SCOPED (mirrors check-mock-cleanup.sh FB-001):
+#   - Pre-existing violations (files not in the PR diff) → WARNING, non-blocking.
+#   - NEW violations (files added/modified in the PR diff) → ERROR, blocking.
+# This avoids the day-1 wall of ~473 pre-existing files (issue #1782 plan
+# critic C3) while still forcing every NEW time-touching test to acknowledge
+# the helper.
+#
+# Portability (issue #1729 merge_group macOS): bash 3.2 on macOS — no
+# associative arrays, no `grep -P`. Plain indexed arrays + grep -E only.
+set -euo pipefail
+
+violations=0
+new_violations=0
+pre_existing_violations=0
+
+# Get list of files changed in PR diff (compare against main/master)
+get_pr_changed_files() {
+    local pr_files=""
+    local base_branch=""
+    for branch in origin/main origin/master main master; do
+        if git rev-parse "$branch" >/dev/null 2>&1; then
+            base_branch="$branch"
+            break
+        fi
+    done
+    if [ -n "$base_branch" ]; then
+        pr_files=$(git diff --name-only "$base_branch" HEAD 2>/dev/null || echo "")
+    fi
+    echo "$pr_files"
+}
+
+is_pr_file() {
+    local file="$1"
+    local pr_files="$2"
+    if [ -z "$pr_files" ]; then
+        return 1  # No PR context → treat as pre-existing (non-blocking).
+    fi
+    echo "$pr_files" | grep -qF "$file"
+    return $?
+}
+
+PR_CHANGED_FILES=$(get_pr_changed_files)
+
+# --- Check: raw clock use in tests must reference freezeClock ---
+# Find test files that touch the real clock.
+while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    # Does the file ACTIVELY use a clock-aware helper?
+    # Require an import of the helper module OR a call-site (function-call
+    # syntax), NOT a bare mention in a comment/string (PR review F-003: a
+    # `// TODO: use freezeClock` comment must not satisfy the lint).
+    # import-from: matches `from '.../test-clock.js'` or `.../test-isolation.js'`
+    # call-site: matches `withFrozenClock(` / `freezeClock(` / `withIsolatedState(` / `setupIsolatedState(`
+    has_import=$(grep -cE "from ['\"][^'\"]*(test-clock|test-isolation)\.js['\"]" "$file" || true)
+    has_call=$(grep -cE "(withFrozenClock|freezeClock|withFrozenClockAsync|withIsolatedState|setupIsolatedState)\s*\(" "$file" || true)
+    if [ "$has_import" -gt 0 ] || [ "$has_call" -gt 0 ]; then
+        continue
+    fi
+    if is_pr_file "$file" "$PR_CHANGED_FILES"; then
+        echo "ERROR: $file uses the real clock (Date.now / new Date / spyOn(Date)) but does not import or call the freezeClock helper."
+        echo "       Import from '../../helpers/test-clock.js' (adjust depth) and wrap"
+        echo "       time-sensitive assertions in withFrozenClock(() => { ... })."
+        echo "       (A comment mentioning the helper does NOT satisfy this check —"
+        echo "       you must import or call it.)"
+        echo "       See docs/testing/test-stability.md (issue #1782)."
+        violations=$((violations + 1))
+        new_violations=$((new_violations + 1))
+    else
+        pre_existing_violations=$((pre_existing_violations + 1))
+    fi
+done < <(grep -rlE "Date\.now\(\)|new Date\(|spyOn\(Date" tests/ --include="*.test.ts" \
+    --exclude-dir=node_modules --exclude-dir=dist 2>/dev/null || true)
+
+echo ""
+echo "=== Summary ==="
+echo "New violations (blocking): $new_violations"
+echo "Pre-existing violations (non-blocking warnings): $pre_existing_violations"
+
+if [ "$violations" -gt 0 ]; then
+    exit 1
+fi
+
+echo "All test-clock checks passed."

--- a/scripts/ci/detect-and-quarantine-flakes.sh
+++ b/scripts/ci/detect-and-quarantine-flakes.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Detect flaky tests from a merge-group CI run and produce quarantine
+# suggestions (issue #1782, root-cause detection phase §6).
+#
+# Input: a "flake annotations" file (passed as $1 or via $FLAKE_ANNOTATIONS)
+# containing the relevant GitHub Actions log lines. The producing ci.yml step
+# greps these from the job log:
+#   - `::notice file=PATH::Passed on retry N (flaky)`  (in-job retry caught a flake)
+#   - `::error file=PATH::...`                         (a hard failure)
+#
+# This script does NOT auto-append to quarantined-tests.txt. Auto-push needs a
+# PAT + branch-protection bypass and is explicitly out of scope (issue #1782
+# plan critic C1/C2). Instead it:
+#   1. Extracts candidate test file paths from the annotations.
+#   2. Applies conservative detection rules (see RULES below).
+#   3. Writes surviving candidates to flake-suggestions.txt (an artifact).
+#   4. Best-effort opens a tracking issue via `gh issue create` (may fail if the
+#      repo's Actions token lacks issues:write — see plan critic C2). The
+#      suggestions artifact is the durable fallback.
+#
+# Detection RULES (a candidate is DROPPED if any rule matches):
+#   A. Already in any quarantine list (quarantined-tests*.txt,
+#      quarantined-integration-tests.txt).
+#   B. Infra-signature failure (runner starvation, runner offline, timeout with
+#      no assertion) — these are transient infra, not test flakes.
+#   C. Core-tree test (tests/unit/{scope,agents,hooks}/**) — these are core;
+#      require human review rather than auto-suggestion.
+#
+# Portability: bash 3.2 on macOS (no associative arrays, no grep -P). Plain
+# indexed arrays + grep -E / grep -F only.
+set -euo pipefail
+
+ANNOTATIONS_FILE="${1:-${FLAKE_ANNOTATIONS:-flake-annotations.txt}}"
+SUGGESTIONS_FILE="${SUGGESTIONS_FILE:-flake-suggestions.txt}"
+REPO="${GH_REPO:-ZaxbyHub/opencode-swarm}"
+
+if [ ! -f "$ANNOTATIONS_FILE" ]; then
+    echo "::warning::No flake annotations file found at $ANNOTATIONS_FILE — nothing to detect."
+    : > "$SUGGESTIONS_FILE"
+    exit 0
+fi
+
+# --- Build the combined quarantine set (all 4 files, non-comment lines) ---
+QUARANTINE_TMP="$(mktemp)"
+{
+    for qf in scripts/ci/quarantined-tests.txt \
+              scripts/ci/quarantined-tests-macos.txt \
+              scripts/ci/quarantined-tests-windows.txt \
+              scripts/ci/quarantined-integration-tests.txt; do
+        if [ -f "$qf" ]; then
+            grep -vE '^[[:space:]]*#|^[[:space:]]*$' "$qf" || true
+        fi
+    done
+} | sort -u > "$QUARANTINE_TMP"
+
+is_quarantined() {
+    grep -qxF "$1" "$QUARANTINE_TMP"
+}
+
+# Infra-signature patterns (plan critic rule B). Matched case-insensitively
+# against the full annotation line.
+INFRA_SIGNATURES=(
+    "was not acquired by Runner"
+    "Runner offline"
+    "job was not acquired"
+    "The job was canceled"
+    "waiting for a runner"
+    "no space left on device"
+)
+
+is_infra_flake() {
+    local line="$1"
+    for sig in "${INFRA_SIGNATURES[@]}"; do
+        if echo "$line" | grep -qiF "$sig"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Core-tree prefixes (plan critic rule C). Tests under these dirs require human review.
+CORE_PREFIXES=(
+    "tests/unit/scope"
+    "tests/unit/agents"
+    "tests/unit/hooks"
+)
+
+is_core_tree() {
+    local f="$1"
+    for pre in "${CORE_PREFIXES[@]}"; do
+        case "$f" in
+            "$pre"*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+# --- Extract candidate (file, line) pairs from annotations ---
+# notice: `::notice file=PATH::...flaky...`
+# error:  `::error file=PATH::...`
+# Use grep -Eo to pull the file=PATH token, then strip the prefix.
+CANDIDATES_TMP="$(mktemp)"
+grep -hE "^::(notice|error) file=" "$ANNOTATIONS_FILE" 2>/dev/null \
+    | grep -Eo "file=[^:]+::" \
+    | sed -E 's/^file=//; s/::$//' \
+    | sort -u > "$CANDIDATES_TMP" || true
+
+: > "$SUGGESTIONS_FILE"
+suggestion_count=0
+dropped_quarantined=0
+dropped_infra=0
+dropped_core=0
+
+while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+
+    # Re-fetch the annotation line(s) for this candidate (for infra-signature check).
+    candidate_line="$(grep -F "file=$candidate" "$ANNOTATIONS_FILE" | head -1 || true)"
+
+    if is_quarantined "$candidate"; then
+        dropped_quarantined=$((dropped_quarantined + 1))
+        continue
+    fi
+
+    if [ -n "$candidate_line" ] && is_infra_flake "$candidate_line"; then
+        dropped_infra=$((dropped_infra + 1))
+        continue
+    fi
+
+    if is_core_tree "$candidate"; then
+        dropped_core=$((dropped_core + 1))
+        echo "# CORE-TREE (requires human review): $candidate" >> "$SUGGESTIONS_FILE"
+        continue
+    fi
+
+    echo "$candidate" >> "$SUGGESTIONS_FILE"
+    suggestion_count=$((suggestion_count + 1))
+done < "$CANDIDATES_TMP"
+
+echo "=== Flake detection summary ==="
+echo "Candidates scanned: $(wc -l < "$CANDIDATES_TMP" | tr -d ' ')"
+echo "Dropped (already quarantined): $dropped_quarantined"
+echo "Dropped (infra signature):    $dropped_infra"
+echo "Dropped (core tree, flagged): $dropped_core"
+echo "Quarantine suggestions:       $suggestion_count"
+echo "Suggestions written to:       $SUGGESTIONS_FILE"
+
+# --- Best-effort tracking issue (plan critic C2: may fail on token perms) ---
+if [ "$suggestion_count" -gt 0 ]; then
+    echo ""
+    echo "=== Opening tracking issue (best-effort) ==="
+    # Build the issue body via a heredoc to a temp file. Using printf '%b' would
+    # interpret backslash escapes in the SUGGESTIONS_FILE contents (which come
+    # from test file paths and could contain backslashes on Windows) — F-009.
+    issue_body_file="$(mktemp)"
+    {
+        echo "Flaky-test detection (issue #1782) found the following candidates"
+        echo "for quarantine during a merge-group CI run:"
+        echo ""
+        echo '```'
+        cat "$SUGGESTIONS_FILE"
+        echo ''
+        echo '```'
+        echo ""
+        echo "To quarantine: append each line to the appropriate"
+        echo "\`scripts/ci/quarantined-tests*.txt\` file."
+        echo ""
+        echo "This issue was filed automatically by the flake-detection workflow."
+    } > "$issue_body_file"
+    # F-005: use the existing \`area:testing\` label (there is no \`test-stability\`
+    # label in the repo; --label would silently fail the issue creation).
+    if gh issue create --repo "$REPO" \
+        --title "Auto-detected flaky tests (merge-group) — review for quarantine" \
+        --body-file "$issue_body_file" \
+        --label "area:testing" 2>/dev/null; then
+        echo "Tracking issue created."
+    else
+        # C2: do NOT fail the job. The suggestions artifact is the durable record.
+        echo "::warning::gh issue create failed (likely token permissions or label)."
+        echo "            The flake-suggestions.txt artifact is the durable fallback."
+        echo "            A maintainer can file the issue manually using the artifact."
+    fi
+    rm -f "$issue_body_file"
+fi
+
+rm -f "$QUARANTINE_TMP" "$CANDIDATES_TMP"
+# Always exit 0: detection is advisory. A detected flake is not a CI failure
+# in this workflow (it already failed in the triggering ci.yml run).
+exit 0

--- a/tests/helpers/test-clock.test.ts
+++ b/tests/helpers/test-clock.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Self-tests for the test-clock helper.
+ * Proves the helper itself is deterministic and restores correctly.
+ */
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import {
+	freezeClock,
+	withFrozenClock,
+	withFrozenClockAsync,
+} from './test-clock.js';
+
+// Ensure no spy leaks between tests regardless of helper behavior.
+afterEach(() => {
+	mock.restore();
+});
+
+describe('freezeClock', () => {
+	test('Date.now() returns the fixed instant when fixedNow is set', () => {
+		const restore = freezeClock({ fixedNow: 1_700_000_000_000 });
+		try {
+			expect(Date.now()).toBe(1_700_000_000_000);
+			expect(Date.now()).toBe(1_700_000_000_000);
+			expect(Date.now()).toBe(1_700_000_000_000);
+		} finally {
+			restore();
+		}
+	});
+
+	test('defaults to a deterministic constant (0) when no fixedNow given', () => {
+		const restore = freezeClock();
+		try {
+			expect(Date.now()).toBe(0);
+		} finally {
+			restore();
+		}
+	});
+
+	test('tickMs advances the reported instant on each call', () => {
+		const restore = freezeClock({ fixedNow: 100, tickMs: 50 });
+		try {
+			expect(Date.now()).toBe(100);
+			expect(Date.now()).toBe(150);
+			expect(Date.now()).toBe(200);
+		} finally {
+			restore();
+		}
+	});
+
+	test('restore() returns Date.now() to the real clock', () => {
+		const before = Date.now();
+		const restore = freezeClock({ fixedNow: 42 });
+		expect(Date.now()).toBe(42);
+		restore();
+		// Real clock should now be >= the pre-freeze instant (it advanced).
+		const after = Date.now();
+		expect(after).toBeGreaterThanOrEqual(before);
+		expect(after).not.toBe(42);
+	});
+
+	test('isoNow spies Date.prototype.toISOString', () => {
+		const restore = freezeClock({ isoNow: '2026-01-01T00:00:00.000Z' });
+		try {
+			expect(new Date().toISOString()).toBe('2026-01-01T00:00:00.000Z');
+		} finally {
+			restore();
+		}
+	});
+
+	test('isoNow is not spied when omitted', () => {
+		const restore = freezeClock({ fixedNow: 0 });
+		try {
+			// Real toISOString — should produce a valid ISO string, not a frozen one.
+			const s = new Date(0).toISOString();
+			expect(s).toBe('1970-01-01T00:00:00.000Z');
+		} finally {
+			restore();
+		}
+	});
+
+	test('restore() is idempotent (safe to call more than once)', () => {
+		const restore = freezeClock({ fixedNow: 99 });
+		restore();
+		expect(() => restore()).not.toThrow();
+	});
+});
+
+describe('withFrozenClock', () => {
+	test('runs fn with a frozen clock', () => {
+		const result = withFrozenClock(
+			() => {
+				return [Date.now(), Date.now(), Date.now()];
+			},
+			{ fixedNow: 5_000 },
+		);
+		expect(result).toEqual([5_000, 5_000, 5_000]);
+	});
+
+	test('restores the clock even when fn throws', () => {
+		expect(() =>
+			withFrozenClock(
+				() => {
+					throw new Error('boom');
+				},
+				{ fixedNow: 1 },
+			),
+		).toThrow('boom');
+		// Clock must be restored — Date.now() is real again.
+		expect(Date.now()).not.toBe(1);
+	});
+
+	test('returns the fn return value', () => {
+		const out = withFrozenClock(() => 'value', { fixedNow: 0 });
+		expect(out).toBe('value');
+	});
+
+	test('a nested direct Date.now() call does not drift', () => {
+		// Simulates the exact skill-scoring determinism case: calling the
+		// function-under-test multiple times must yield identical results
+		// because the clock is frozen.
+		function computeScoreFromClock(): number {
+			return Date.now();
+		}
+		const scores = withFrozenClock(
+			() => [
+				computeScoreFromClock(),
+				computeScoreFromClock(),
+				computeScoreFromClock(),
+			],
+			{ fixedNow: 1_234_567 },
+		);
+		expect(scores[0]).toBe(scores[1]);
+		expect(scores[1]).toBe(scores[2]);
+	});
+});
+
+describe('withFrozenClockAsync', () => {
+	test('runs async fn with a frozen clock and awaits the result', async () => {
+		const out = await withFrozenClockAsync(
+			async () => {
+				await Promise.resolve();
+				return Date.now();
+			},
+			{ fixedNow: 8_888 },
+		);
+		expect(out).toBe(8_888);
+	});
+
+	test('restores the clock even when async fn rejects', async () => {
+		await expect(
+			withFrozenClockAsync(
+				async () => {
+					throw new Error('async boom');
+				},
+				{ fixedNow: 1 },
+			),
+		).rejects.toThrow('async boom');
+		// Clock restored.
+		expect(Date.now()).not.toBe(1);
+	});
+});
+
+describe('freezeClock — interaction with the real clock after restore', () => {
+	test('successive freeze/restore cycles are independent', () => {
+		withFrozenClock(() => undefined, { fixedNow: 10 });
+		const a = withFrozenClock(() => Date.now(), { fixedNow: 20 });
+		withFrozenClock(() => undefined, { fixedNow: 30 });
+		expect(a).toBe(20);
+		// After all restores, real clock is back.
+		expect(Date.now()).not.toBe(10);
+		expect(Date.now()).not.toBe(20);
+		expect(Date.now()).not.toBe(30);
+	});
+
+	test('does not interfere with an independently-spied function', () => {
+		// Confirm freezeClock's restore does not clobber an unrelated spy.
+		const obj = { method: () => 'real' };
+		const unrelatedSpy = spyOn(obj, 'method').mockReturnValue('spied');
+		const restore = freezeClock({ fixedNow: 7 });
+		try {
+			expect(obj.method()).toBe('spied');
+			expect(Date.now()).toBe(7);
+		} finally {
+			restore();
+		}
+		// Unrelated spy survives freezeClock's restore.
+		expect(obj.method()).toBe('spied');
+		unrelatedSpy.mockRestore();
+		expect(obj.method()).toBe('real');
+	});
+});
+
+describe('freezeClock — nested freeze guard (F-004)', () => {
+	test('throws on nested freeze rather than silently breaking the outer freeze', () => {
+		const outer = freezeClock({ fixedNow: 1000 });
+		try {
+			expect(() => freezeClock({ fixedNow: 2000 })).toThrow(
+				/a freeze is already active/,
+			);
+			// Outer freeze is still intact (the rejected inner did not install a spy).
+			expect(Date.now()).toBe(1000);
+		} finally {
+			outer();
+		}
+	});
+
+	test('after restore, a new freeze can be started (flag resets)', () => {
+		const first = freezeClock({ fixedNow: 5 });
+		first();
+		// Should not throw — the active flag was cleared by restore.
+		const second = freezeClock({ fixedNow: 9 });
+		try {
+			expect(Date.now()).toBe(9);
+		} finally {
+			second();
+		}
+	});
+
+	test('withFrozenClock nested inside an active freeze also throws', () => {
+		const outer = freezeClock({ fixedNow: 1 });
+		try {
+			expect(() => withFrozenClock(() => undefined, { fixedNow: 2 })).toThrow(
+				/a freeze is already active/,
+			);
+		} finally {
+			outer();
+		}
+	});
+});
+
+describe('freezeClock — combined options (F-011 table tests)', () => {
+	test.each([
+		{ fixedNow: 1_700_000_000_000, isoNow: '2026-01-01T00:00:00.000Z' },
+		{ fixedNow: 0, isoNow: '1970-01-01T00:00:00.000Z' },
+		{ fixedNow: 42, isoNow: '2024-12-31T23:59:59.000Z' },
+	])('fixedNow + isoNow together: %j', ({ fixedNow, isoNow }) => {
+		const restore = freezeClock({ fixedNow, isoNow });
+		try {
+			expect(Date.now()).toBe(fixedNow);
+			expect(new Date().toISOString()).toBe(isoNow);
+		} finally {
+			restore();
+		}
+	});
+
+	test('tickMs + isoNow together: clock advances while toISOString stays fixed', () => {
+		const restore = freezeClock({
+			fixedNow: 100,
+			tickMs: 25,
+			isoNow: '2026-07-10T12:00:00.000Z',
+		});
+		try {
+			expect(Date.now()).toBe(100);
+			expect(Date.now()).toBe(125);
+			expect(new Date().toISOString()).toBe('2026-07-10T12:00:00.000Z');
+			expect(new Date().toISOString()).toBe('2026-07-10T12:00:00.000Z');
+		} finally {
+			restore();
+		}
+	});
+
+	test('all three options: fixedNow + tickMs + isoNow', () => {
+		const restore = freezeClock({
+			fixedNow: 1000,
+			tickMs: 10,
+			isoNow: '2025-06-15T08:30:00.000Z',
+		});
+		try {
+			expect(Date.now()).toBe(1000);
+			expect(Date.now()).toBe(1010);
+			expect(Date.now()).toBe(1020);
+			expect(new Date().toISOString()).toBe('2025-06-15T08:30:00.000Z');
+		} finally {
+			restore();
+		}
+	});
+});

--- a/tests/helpers/test-clock.ts
+++ b/tests/helpers/test-clock.ts
@@ -1,0 +1,169 @@
+/**
+ * Deterministic-clock test helper for opencode-swarm.
+ *
+ * Why this exists: several production functions are continuous functions of
+ * `Date.now()` (e.g. `computeRecencyScore` in `src/hooks/skill-scoring.ts`).
+ * Under coverage instrumentation or sub-millisecond timing, the real clock can
+ * advance between the call under test and a later equality assertion, flipping
+ * a comparison bit and producing a flake (issue #1782, root-cause class 1).
+ *
+ * Bun's `bun:test` does NOT export `FakeTime` (verified absent on 1.3.13/1.3.14),
+ * so this helper builds on the repo's only proven pattern — `spyOn(Date, ...)`.
+ *
+ * Usage (manual restore):
+ *   const restore = freezeClock();
+ *   try { /* assertions *\/ } finally { restore(); }
+ *
+ * Usage (auto restore, preferred inside a test body):
+ *   withFrozenClock(() => {
+ *     expect(computeThing()).toBe(computeThing()); // deterministic
+ *   });
+ *
+ * Restore contract: `withFrozenClock` relies on try/finally ONLY (no
+ * `afterEach` safety net) to avoid registration-ordering ambiguity with a
+ * file's own `afterEach(mock.restore())` hooks (issue #1782 plan critic M2).
+ * `freezeClock()` returns a `restore()` the caller MUST call in finally.
+ */
+import { type Mock, spyOn } from 'bun:test';
+
+export interface FreezeClockOptions {
+	/**
+	 * The fixed millisecond instant `Date.now()` will report. Defaults to a
+	 * stable constant (0) so the frozen instant is fully deterministic across
+	 * runs — NOT `Date.now()` captured at freeze time, which would itself be
+	 * non-deterministic across runs.
+	 */
+	fixedNow?: number;
+	/**
+	 * If set, each call to the mocked `Date.now()` advances the reported
+	 * instant by this many ms (controlled time-passage for decay/interval
+	 * tests). If unset, the clock is frozen exactly at `fixedNow`.
+	 */
+	tickMs?: number;
+	/**
+	 * If set, also spies `Date.prototype.toISOString` to return this string.
+	 * Use when the code under test stamps records with `new Date().toISOString()`
+	 * and an assertion compares the stamp byte-for-byte
+	 * (e.g. `manager-plan-md-sync.test.ts`).
+	 */
+	isoNow?: string;
+}
+
+/** A function that removes all spies installed by `freezeClock`. */
+export type Restore = () => void;
+
+interface InstalledSpies {
+	now: Mock<typeof Date.now> | null;
+	iso: Mock<typeof Date.prototype.toISOString> | null;
+}
+
+/**
+ * Module-level flag tracking whether a freeze is currently active. bun's
+ * `spyOn` + `mockRestore` does NOT stack: restoring an inner spy also removes
+ * the outer spy, so a nested `freezeClock` would silently break the outer
+ * freeze (the inner `restore()` resets `Date.now` to the real clock, not the
+ * outer frozen value). Rather than implement spy-stacking, we fail-fast on
+ * nested freezes with a clear error (PR review F-004). No current test nests
+ * freezes; if a future test needs nested time-scopes, restructure it into
+ * sequential freeze/restore cycles instead.
+ */
+let activeFreeze = false;
+
+/**
+ * Freeze the clock deterministically. Returns a `restore()` that MUST be
+ * called (typically in a `finally` block, or via `withFrozenClock`).
+ *
+ * Spies installed:
+ *   - `Date.now`        → returns fixedNow (advancing by tickMs per call if set)
+ *   - `Date.prototype.toISOString` → returns isoNow (only if `isoNow` is set)
+ *
+ * Note on completeness: this covers the two time-read surfaces that production
+ * code actually uses for now-reads (`Date.now()`) and stamp formatting
+ * (`new Date().toISOString()`). It does NOT freeze `process.hrtime.bigint()`
+ * or `performance.now()` — see `docs/testing/test-stability.md` "Known
+ * limitations". No current test asserts on those.
+ */
+export function freezeClock(options: FreezeClockOptions = {}): Restore {
+	if (activeFreeze) {
+		throw new Error(
+			'freezeClock: a freeze is already active. Nested freezes are not ' +
+				'supported (bun spyOn/mockRestore does not stack — the inner ' +
+				'restore would reset the outer freeze to the real clock). ' +
+				'Restructure into sequential freeze/restore cycles instead.',
+		);
+	}
+
+	const { fixedNow = 0, tickMs, isoNow } = options;
+
+	let current = fixedNow;
+
+	const installed: InstalledSpies = { now: null, iso: null };
+
+	// Install spies first; only claim the active-freeze flag after success, so a
+	// throw during installation cannot leak the flag as `true` and permanently
+	// block all future freezeClock calls (final critic F-004 residual gap).
+	try {
+		const nowSpy = spyOn(Date, 'now').mockImplementation(() => {
+			const returned = current;
+			if (tickMs !== undefined) {
+				current += tickMs;
+			}
+			return returned;
+		});
+		installed.now = nowSpy;
+
+		if (isoNow !== undefined) {
+			const isoSpy = spyOn(Date.prototype, 'toISOString').mockImplementation(
+				() => isoNow,
+			);
+			installed.iso = isoSpy;
+		}
+	} catch (err) {
+		// Defensive: spy-install should not throw under normal use (the guard
+		// above prevents the already-spied case), but if it does, leave the
+		// activeFreeze flag clear and restore anything partially installed.
+		installed.now?.mockRestore();
+		installed.iso?.mockRestore();
+		throw err;
+	}
+	activeFreeze = true;
+
+	return () => {
+		installed.now?.mockRestore();
+		installed.iso?.mockRestore();
+		activeFreeze = false;
+	};
+}
+
+/**
+ * Run `fn` with the clock frozen, always restoring afterward (try/finally).
+ * Preferred for use inside a test body. Re-throws anything `fn` throws after
+ * restoring the clock, so failures surface normally.
+ */
+export function withFrozenClock<T>(
+	fn: () => T,
+	options?: FreezeClockOptions,
+): T {
+	const restore = freezeClock(options);
+	try {
+		return fn();
+	} finally {
+		restore();
+	}
+}
+
+/**
+ * Run an async `fn` with the clock frozen, always restoring afterward.
+ * Async counterpart to `withFrozenClock`.
+ */
+export async function withFrozenClockAsync<T>(
+	fn: () => Promise<T>,
+	options?: FreezeClockOptions,
+): Promise<T> {
+	const restore = freezeClock(options);
+	try {
+		return await fn();
+	} finally {
+		restore();
+	}
+}

--- a/tests/helpers/test-isolation.test.ts
+++ b/tests/helpers/test-isolation.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Self-tests for the test-isolation helper.
+ * Proves the composition of env + tmpdir + clock isolates correctly and
+ * cleans up fully.
+ */
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { setupIsolatedState, withIsolatedState } from './test-isolation.js';
+
+afterEach(() => {
+	mock.restore();
+});
+
+describe('setupIsolatedState', () => {
+	test('returns a temp dir under os.tmpdir() and an isolated config dir', () => {
+		const state = setupIsolatedState({ prefix: 'iso-test-' });
+		try {
+			const tmpBase = fs.realpathSync(os.tmpdir());
+			expect(state.dir.startsWith(tmpBase)).toBe(true);
+			expect(fs.existsSync(state.dir)).toBe(true);
+			expect(state.configDir).toBeTruthy();
+			// Env vars pointed at the isolated config dir.
+			expect(process.env.XDG_CONFIG_HOME).toBe(state.configDir);
+			expect(process.env.APPDATA).toBe(state.configDir);
+		} finally {
+			state.cleanup();
+		}
+	});
+
+	test('cleanup removes the temp dir and restores env', () => {
+		let dir: string | undefined;
+		let configHomeBefore: string | undefined;
+		{
+			const state = setupIsolatedState({ prefix: 'iso-cleanup-' });
+			dir = state.dir;
+			configHomeBefore = process.env.XDG_CONFIG_HOME;
+			expect(fs.existsSync(dir)).toBe(true);
+			state.cleanup();
+		}
+		// dir gone
+		expect(dir).toBeDefined();
+		expect(fs.existsSync(dir as string)).toBe(false);
+		// env no longer points at the (now-deleted) config dir
+		expect(process.env.XDG_CONFIG_HOME).not.toBe(configHomeBefore);
+	});
+
+	test('restoreClock is null when no clock requested', () => {
+		const state = setupIsolatedState({});
+		try {
+			expect(state.restoreClock).toBeNull();
+		} finally {
+			state.cleanup();
+		}
+	});
+
+	test('clock: true freezes the clock at the default instant', () => {
+		const state = setupIsolatedState({ clock: true });
+		try {
+			expect(Date.now()).toBe(0);
+			expect(Date.now()).toBe(0);
+		} finally {
+			state.cleanup();
+		}
+	});
+
+	test('clock: { fixedNow } freezes the clock at the given instant', () => {
+		const state = setupIsolatedState({ clock: { fixedNow: 5_555 } });
+		try {
+			expect(Date.now()).toBe(5_555);
+		} finally {
+			state.cleanup();
+		}
+		expect(state.restoreClock).not.toBeNull();
+	});
+
+	test('cleanup restores the clock even when clock was requested', () => {
+		const frozen = Date.now();
+		void frozen;
+		{
+			const state = setupIsolatedState({ clock: { fixedNow: 1 } });
+			expect(Date.now()).toBe(1);
+			state.cleanup();
+		}
+		// Real clock back.
+		expect(Date.now()).not.toBe(1);
+	});
+
+	test('writing a file under state.dir works and is removed on cleanup', () => {
+		let dir: string | undefined;
+		{
+			const state = setupIsolatedState({ prefix: 'iso-write-' });
+			dir = state.dir;
+			const f = path.join(state.dir, 'hello.txt');
+			fs.writeFileSync(f, 'hi');
+			expect(fs.existsSync(f)).toBe(true);
+			state.cleanup();
+		}
+		expect(fs.existsSync(dir as string)).toBe(false);
+	});
+});
+
+describe('withIsolatedState', () => {
+	test('provides isolated state to fn and cleans up after', async () => {
+		let capturedDir: string | undefined;
+		const result = await withIsolatedState(
+			async (state) => {
+				capturedDir = state.dir;
+				fs.writeFileSync(path.join(state.dir, 'x'), '1');
+				return 42;
+			},
+			{ prefix: 'iso-with-' },
+		);
+		expect(result).toBe(42);
+		expect(capturedDir).toBeDefined();
+		expect(fs.existsSync(capturedDir as string)).toBe(false);
+	});
+
+	test('cleans up even when fn throws', async () => {
+		let capturedDir: string | undefined;
+		await expect(
+			withIsolatedState(
+				async (state) => {
+					capturedDir = state.dir;
+					throw new Error('nope');
+				},
+				{ prefix: 'iso-throw-' },
+			),
+		).rejects.toThrow('nope');
+		expect(capturedDir).toBeDefined();
+		expect(fs.existsSync(capturedDir as string)).toBe(false);
+	});
+
+	test('clock option freezes time within fn and restores after', async () => {
+		const out = await withIsolatedState(
+			async () => {
+				return [Date.now(), Date.now()];
+			},
+			{ clock: { fixedNow: 9_999 } },
+		);
+		expect(out).toEqual([9_999, 9_999]);
+		// Restored after.
+		expect(Date.now()).not.toBe(9_999);
+	});
+});
+
+describe('setupIsolatedState — cleanup robustness (F-007)', () => {
+	test('cleanup removes the temp dir even when a clock was active', () => {
+		// Covers the F-007 concern: all three teardown steps (clock, env, dir)
+		// run independently so a failure in one does not skip the dir removal.
+		let capturedDir: string | undefined;
+		{
+			const state = setupIsolatedState({ clock: { fixedNow: 5 } });
+			capturedDir = state.dir;
+			expect(fs.existsSync(capturedDir)).toBe(true);
+			expect(Date.now()).toBe(5);
+			state.cleanup();
+		}
+		expect(capturedDir).toBeDefined();
+		// The dir removal (the last step) ran despite the clock being active.
+		expect(fs.existsSync(capturedDir as string)).toBe(false);
+		// Clock restored.
+		expect(Date.now()).not.toBe(5);
+	});
+
+	test('cleanup is safe to call when no clock was requested', () => {
+		// The clock step is a no-op (restoreClock is null) — env + dir still run.
+		let capturedDir: string | undefined;
+		{
+			const state = setupIsolatedState({ prefix: 'iso-noclock-' });
+			capturedDir = state.dir;
+			state.cleanup();
+		}
+		expect(fs.existsSync(capturedDir as string)).toBe(false);
+	});
+
+	test('a throwing step does not skip later steps (F-007 error isolation)', () => {
+		// Drive the _internals.runCleanup seam directly with a throwing middle
+		// (env) step and assert the dir step STILL runs and the first error is
+		// re-thrown. This is the actual contract the per-step try/catch exists
+		// to enforce (a leak in one step must not skip the temp-dir removal).
+		const { _internals } = require('./test-isolation.js');
+		let dirRan = false;
+		let threw: unknown = null;
+		try {
+			_internals.runCleanup(
+				null,
+				() => {
+					throw new Error('env boom');
+				},
+				() => {
+					dirRan = true;
+				},
+			);
+		} catch (e) {
+			threw = e;
+		}
+		expect(dirRan).toBe(true); // dir step ran despite env throwing
+		expect((threw as Error)?.message).toBe('env boom'); // first error re-thrown
+	});
+});

--- a/tests/helpers/test-isolation.ts
+++ b/tests/helpers/test-isolation.ts
@@ -1,0 +1,131 @@
+/**
+ * Unified test-state isolation helper for opencode-swarm.
+ *
+ * Composes the repo's existing isolation primitives into one call so a test
+ * gets: an isolated config/HOME environment + a safe temp working dir + a
+ * deterministic clock — the three things tests most often need together to be
+ * stable under coverage instrumentation and across platforms (issue #1782,
+ * root-cause classes 1 & 2).
+ *
+ * This helper does NOT replace the individual primitives — it composes them.
+ * Use `createIsolatedTestEnv`, `createSafeTestDir`, or `freezeClock` directly
+ * when you only need one.
+ */
+import { createIsolatedTestEnv } from './isolated-test-env.js';
+import { createSafeTestDir } from './safe-test-dir.js';
+import {
+	type FreezeClockOptions,
+	freezeClock,
+	type Restore,
+} from './test-clock.js';
+
+export interface IsolatedStateOptions {
+	/** Directory prefix for the temp working dir. */
+	prefix?: string;
+	/** Clock options. Pass `true` for default freeze, or a full options object. */
+	clock?: true | FreezeClockOptions;
+}
+
+export interface IsolatedState {
+	/** The realpath-canonicalized temp working directory (under os.tmpdir()). */
+	dir: string;
+	/** The isolated config dir (XDG_CONFIG_HOME / APPDATA / HOME pointed here). */
+	configDir: string;
+	/** Restore the clock. Only present if a clock was requested. */
+	restoreClock: Restore | null;
+	/** Tear everything down: restore env, restore clock, remove temp dir. */
+	cleanup: () => void;
+}
+
+/**
+ * Set up fully isolated test state: temp working dir + isolated config env +
+ * (optionally) a frozen deterministic clock.
+ *
+ * The caller MUST call `cleanup()` — typically `afterEach(state.cleanup)` or
+ * in a `try/finally`. `withIsolatedState` is the auto-cleanup convenience.
+ */
+export function setupIsolatedState(
+	options: IsolatedStateOptions = {},
+): IsolatedState {
+	const { prefix, clock } = options;
+
+	const safeDir = createSafeTestDir(prefix);
+	const env = createIsolatedTestEnv();
+
+	let restoreClock: Restore | null = null;
+	if (clock) {
+		const clockOpts: FreezeClockOptions = clock === true ? {} : clock;
+		restoreClock = freezeClock(clockOpts);
+	}
+
+	// cleanup runs each teardown step independently so a throw in one (e.g. the
+	// clock restore) does not skip the env/dir teardown — which would leak a
+	// temp dir (PR review F-007). The first thrown error is re-thrown after all
+	// steps have been attempted. Steps are routed through `_internals.runCleanup`
+	// so a test can inject a throwing step to prove the error-isolation contract.
+	const cleanup = (): void => {
+		_internals.runCleanup(
+			restoreClock,
+			() => env.cleanup(),
+			() => safeDir.cleanup(),
+		);
+	};
+
+	return {
+		dir: safeDir.dir,
+		configDir: env.configDir,
+		restoreClock,
+		cleanup,
+	};
+}
+
+/**
+ * Test-only DI seam (AGENTS.md invariant 7). Tests inject throwing steps to
+ * prove the cleanup error-isolation contract (F-007) without needing mock.module
+ * (which leaks across files in Bun's shared test-runner process).
+ */
+export const _internals: {
+	runCleanup: (
+		restoreClock: Restore | null,
+		envCleanup: () => void,
+		dirCleanup: () => void,
+	) => void;
+} = {
+	runCleanup(restoreClock, envCleanup, dirCleanup) {
+		let firstError: unknown = null;
+		try {
+			restoreClock?.();
+		} catch (e) {
+			firstError = e;
+		}
+		try {
+			envCleanup();
+		} catch (e) {
+			firstError = firstError ?? e;
+		}
+		try {
+			dirCleanup();
+		} catch (e) {
+			firstError = firstError ?? e;
+		}
+		if (firstError !== null) {
+			throw firstError;
+		}
+	},
+};
+
+/**
+ * Run `fn` with fully isolated test state, always cleaning up afterward.
+ * Auto-restores env, clock, and removes the temp dir via try/finally.
+ */
+export async function withIsolatedState<T>(
+	fn: (state: IsolatedState) => Promise<T> | T,
+	options?: IsolatedStateOptions,
+): Promise<T> {
+	const state = setupIsolatedState(options);
+	try {
+		return await fn(state);
+	} finally {
+		state.cleanup();
+	}
+}

--- a/tests/unit/hooks/skill-scoring-e2e.test.ts
+++ b/tests/unit/hooks/skill-scoring-e2e.test.ts
@@ -12,7 +12,7 @@
  *           gateBefore scoring block integration, end-to-end ranking accuracy.
  */
 
-import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -31,6 +31,7 @@ import {
 	readSkillUsageEntriesTail,
 	type SkillUsageEntry,
 } from '../../../src/hooks/skill-usage-log.ts';
+import { withFrozenClock } from '../../helpers/test-clock.js';
 
 // ============================================================================
 // Helpers
@@ -672,30 +673,32 @@ describe('end-to-end ranking accuracy via tail-read + scoring', () => {
 		const tailEntries = readSkillUsageEntriesTail(tempDir, { sessionID });
 		const taskDesc = 'write tests for hooks';
 
-		const fixedNow = Date.now();
-		const nowSpy = spyOn(Date, 'now').mockReturnValue(fixedNow);
-		try {
-			const score1 = computeSkillRelevanceScore(
-				skillPath,
-				taskDesc,
-				tailEntries,
-			);
-			const score2 = computeSkillRelevanceScore(
-				skillPath,
-				taskDesc,
-				tailEntries,
-			);
-			const score3 = computeSkillRelevanceScore(
-				skillPath,
-				taskDesc,
-				tailEntries,
-			);
+		// Freeze the clock so computeSkillRelevanceScore (a continuous function
+		// of Date.now()) is deterministic across repeated calls — see
+		// tests/helpers/test-clock.ts and docs/testing/test-stability.md.
+		withFrozenClock(
+			() => {
+				const score1 = computeSkillRelevanceScore(
+					skillPath,
+					taskDesc,
+					tailEntries,
+				);
+				const score2 = computeSkillRelevanceScore(
+					skillPath,
+					taskDesc,
+					tailEntries,
+				);
+				const score3 = computeSkillRelevanceScore(
+					skillPath,
+					taskDesc,
+					tailEntries,
+				);
 
-			expect(score1).toBe(score2);
-			expect(score2).toBe(score3);
-		} finally {
-			nowSpy.mockRestore();
-		}
+				expect(score1).toBe(score2);
+				expect(score2).toBe(score3);
+			},
+			{ fixedNow: 1_700_000_000_000 },
+		);
 	});
 });
 
@@ -972,16 +975,17 @@ describe('scoring invariants — property tests', () => {
 		const skillPath = '.claude/skills/test/SKILL.md';
 		const taskDesc = 'testing idempotency';
 
-		const fixedNow = Date.now();
-		const nowSpy = spyOn(Date, 'now').mockReturnValue(fixedNow);
-		try {
-			const score1 = computeSkillRelevanceScore(skillPath, taskDesc, entries);
-			const score2 = computeSkillRelevanceScore(skillPath, taskDesc, entries);
+		// Freeze the clock so the score is deterministic across the two calls
+		// (computeSkillRelevanceScore is a continuous function of Date.now()).
+		withFrozenClock(
+			() => {
+				const score1 = computeSkillRelevanceScore(skillPath, taskDesc, entries);
+				const score2 = computeSkillRelevanceScore(skillPath, taskDesc, entries);
 
-			expect(score1).toBe(score2);
-		} finally {
-			nowSpy.mockRestore();
-		}
+				expect(score1).toBe(score2);
+			},
+			{ fixedNow: 1_700_000_000_000 },
+		);
 	});
 
 	test('round-trip: append → tail-read → score produces consistent result', () => {

--- a/tests/unit/hooks/skill-scoring-workflow.test.ts
+++ b/tests/unit/hooks/skill-scoring-workflow.test.ts
@@ -1,5 +1,13 @@
 /**
  * Tests for workflow skill scoring boost (#1234 Part 4D) and score clamping.
+ *
+ * NOTE: this file is currently quarantined in scripts/ci/quarantined-tests.txt
+ * (merge-group flake). The freezeClock wraps below are the root-cause fix
+ * (root-cause class 1: time-sensitive assertions — computeSkillRelevanceScore
+ * is a continuous function of Date.now() via computeRecencyScore, and
+ * makeUsageEntry stamps entries with live new Date().toISOString()). The file
+ * stays quarantined until a merge-group run confirms greenness on all 3 OSes
+ * (issue #1782, plan critic H1 — un-quarantine is gated, not in this PR).
  */
 
 import { describe, expect, it } from 'bun:test';
@@ -9,6 +17,7 @@ import {
 	type SkillMetadata,
 } from '../../../src/hooks/skill-scoring.js';
 import type { SkillUsageEntry } from '../../../src/hooks/skill-usage-log.js';
+import { withFrozenClock } from '../../helpers/test-clock.js';
 
 function makeUsageEntry(
 	skillPath: string,
@@ -84,115 +93,138 @@ describe('computeSkillRelevanceScore: workflow boost', () => {
 	const skillPath = '.opencode/skills/generated/edit-test-lint/SKILL.md';
 
 	it('gives a workflow boost when skill_type is workflow and context matches', () => {
-		const history = Array.from({ length: 5 }, (_, i) =>
-			makeUsageEntry(skillPath, { taskID: `task-${i}` }),
+		// Freeze the clock: makeUsageEntry stamps with new Date().toISOString()
+		// and computeSkillRelevanceScore reads Date.now() — freezing both makes
+		// the relative ordering of scores deterministic (issue #1782).
+		withFrozenClock(
+			() => {
+				const history = Array.from({ length: 5 }, (_, i) =>
+					makeUsageEntry(skillPath, { taskID: `task-${i}` }),
+				);
+
+				const directiveMeta: SkillMetadata = {
+					path: skillPath,
+					name: 'edit-test-lint',
+					description: 'A directive',
+					skillType: 'directive',
+				};
+
+				const workflowMeta: SkillMetadata = {
+					path: skillPath,
+					name: 'edit-test-lint',
+					description: 'A workflow',
+					skillType: 'workflow',
+				};
+
+				const taskDescription = 'edit the file and run test and lint';
+
+				const directiveScore = computeSkillRelevanceScore(
+					skillPath,
+					taskDescription,
+					history,
+					directiveMeta,
+				);
+				const workflowScore = computeSkillRelevanceScore(
+					skillPath,
+					taskDescription,
+					history,
+					workflowMeta,
+				);
+
+				expect(workflowScore).toBeGreaterThan(directiveScore);
+			},
+			{ fixedNow: 1_700_000_000_000 },
 		);
-
-		const directiveMeta: SkillMetadata = {
-			path: skillPath,
-			name: 'edit-test-lint',
-			description: 'A directive',
-			skillType: 'directive',
-		};
-
-		const workflowMeta: SkillMetadata = {
-			path: skillPath,
-			name: 'edit-test-lint',
-			description: 'A workflow',
-			skillType: 'workflow',
-		};
-
-		const taskDescription = 'edit the file and run test and lint';
-
-		const directiveScore = computeSkillRelevanceScore(
-			skillPath,
-			taskDescription,
-			history,
-			directiveMeta,
-		);
-		const workflowScore = computeSkillRelevanceScore(
-			skillPath,
-			taskDescription,
-			history,
-			workflowMeta,
-		);
-
-		expect(workflowScore).toBeGreaterThan(directiveScore);
 	});
 
 	it('does not give workflow boost when context does not match', () => {
-		const history = Array.from({ length: 5 }, (_, i) =>
-			makeUsageEntry(skillPath, { taskID: `task-${i}` }),
+		withFrozenClock(
+			() => {
+				const history = Array.from({ length: 5 }, (_, i) =>
+					makeUsageEntry(skillPath, { taskID: `task-${i}` }),
+				);
+
+				const workflowMeta: SkillMetadata = {
+					path: skillPath,
+					name: 'edit-test-lint',
+					description: 'A workflow',
+					skillType: 'workflow',
+				};
+
+				const taskDescription = 'unrelated database migration task';
+
+				const scoreWithMeta = computeSkillRelevanceScore(
+					skillPath,
+					taskDescription,
+					history,
+					workflowMeta,
+				);
+				const scoreWithoutMeta = computeSkillRelevanceScore(
+					skillPath,
+					taskDescription,
+					history,
+				);
+
+				expect(scoreWithMeta).toBe(scoreWithoutMeta);
+			},
+			{ fixedNow: 1_700_000_000_000 },
 		);
-
-		const workflowMeta: SkillMetadata = {
-			path: skillPath,
-			name: 'edit-test-lint',
-			description: 'A workflow',
-			skillType: 'workflow',
-		};
-
-		const taskDescription = 'unrelated database migration task';
-
-		const scoreWithMeta = computeSkillRelevanceScore(
-			skillPath,
-			taskDescription,
-			history,
-			workflowMeta,
-		);
-		const scoreWithoutMeta = computeSkillRelevanceScore(
-			skillPath,
-			taskDescription,
-			history,
-		);
-
-		expect(scoreWithMeta).toBe(scoreWithoutMeta);
 	});
 
 	it('clamps score to 1.0 maximum', () => {
-		const history = Array.from({ length: 20 }, (_, i) =>
-			makeUsageEntry(skillPath, {
-				taskID: `task-${i}`,
-				complianceVerdict: 'compliant',
-				timestamp: new Date().toISOString(),
-			}),
+		withFrozenClock(
+			() => {
+				const history = Array.from({ length: 20 }, (_, i) =>
+					makeUsageEntry(skillPath, {
+						taskID: `task-${i}`,
+						complianceVerdict: 'compliant',
+						timestamp: new Date(1_700_000_000_000).toISOString(),
+					}),
+				);
+
+				const workflowMeta: SkillMetadata = {
+					path: skillPath,
+					name: 'edit-test-lint',
+					description: 'A workflow',
+					skillType: 'workflow',
+				};
+
+				const taskDescription = 'edit test lint';
+
+				const score = computeSkillRelevanceScore(
+					skillPath,
+					taskDescription,
+					history,
+					workflowMeta,
+				);
+
+				expect(score).toBeLessThanOrEqual(1.0);
+			},
+			{ fixedNow: 1_700_000_000_000 },
 		);
-
-		const workflowMeta: SkillMetadata = {
-			path: skillPath,
-			name: 'edit-test-lint',
-			description: 'A workflow',
-			skillType: 'workflow',
-		};
-
-		const taskDescription = 'edit test lint';
-
-		const score = computeSkillRelevanceScore(
-			skillPath,
-			taskDescription,
-			history,
-			workflowMeta,
-		);
-
-		expect(score).toBeLessThanOrEqual(1.0);
 	});
 
 	it('clamps score to 1.0 even without workflow boost', () => {
-		const history = Array.from({ length: 20 }, (_, i) =>
-			makeUsageEntry(skillPath, {
-				taskID: `task-${i}`,
-				complianceVerdict: 'compliant',
-				timestamp: new Date().toISOString(),
-			}),
-		);
+		withFrozenClock(
+			() => {
+				const history = Array.from({ length: 20 }, (_, i) =>
+					makeUsageEntry(skillPath, {
+						taskID: `task-${i}`,
+						complianceVerdict: 'compliant',
+						timestamp: new Date(1_700_000_000_000).toISOString(),
+					}),
+				);
 
-		const taskDescription = 'edit test lint';
-		const score = computeSkillRelevanceScore(
-			skillPath,
-			taskDescription,
-			history,
-		);
+				const taskDescription = 'edit test lint';
+				const score = computeSkillRelevanceScore(
+					skillPath,
+					taskDescription,
+					history,
+				);
 
-		expect(score).toBeLessThanOrEqual(1.0);
+				expect(score).toBeLessThanOrEqual(1.0);
+			},
+			{ fixedNow: 1_700_000_000_000 },
+		);
 	});
 });

--- a/tests/unit/plan/manager-plan-md-sync.test.ts
+++ b/tests/unit/plan/manager-plan-md-sync.test.ts
@@ -1,12 +1,4 @@
-import {
-	afterEach,
-	beforeEach,
-	describe,
-	expect,
-	mock,
-	spyOn,
-	test,
-} from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -17,6 +9,7 @@ import {
 	isPlanMdInSync,
 	regeneratePlanMarkdown,
 } from '../../../src/plan/manager';
+import { freezeClock, type Restore } from '../../helpers/test-clock.js';
 
 // ---------------------------------------------------------------------------
 // FR-001 / F-11: isPlanMdInSync must NOT treat a non-equivalent plan.md that
@@ -69,20 +62,18 @@ async function writePlanMd(dir: string, content: string): Promise<void> {
 
 describe('isPlanMdInSync — FR-001 / F-11 substring-fallback tightening', () => {
 	let tempDir: string;
-	let toISOStringSpy: ReturnType<typeof spyOn> | null = null;
+	let restoreClock: Restore | null = null;
 
 	beforeEach(async () => {
 		tempDir = await mkdtemp(join(tmpdir(), 'plan-md-sync-'));
 		// Freeze the timestamp embedded by derivePlanMarkdown so the
 		// exact-equality and superset cases are deterministic.
-		toISOStringSpy = spyOn(Date.prototype, 'toISOString').mockReturnValue(
-			'2026-01-01T00:00:00.000Z',
-		);
+		restoreClock = freezeClock({ isoNow: '2026-01-01T00:00:00.000Z' });
 	});
 
 	afterEach(async () => {
-		toISOStringSpy?.mockRestore();
-		toISOStringSpy = null;
+		restoreClock?.();
+		restoreClock = null;
 		mock.restore();
 		if (existsSync(tempDir)) {
 			await rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
Refs #1782

## Summary

The merge-group CI matrix (Windows × 4 + macOS × 4 + coverage + integration) repeatedly kicked PRs out of the queue on pre-existing flakes invisible to the PR-branch Ubuntu-only CI. This PR ships the **systemic test-stability layer** (not a whack-a-mole fix): a deterministic-clock helper, a diff-scoped lint, an advisory flake-detection workflow, a contributor runbook, and migration of the 3 confirmed time-sensitive flaky sites.

### What's new
- **`tests/helpers/test-clock.ts`** — `freezeClock({fixedNow?, tickMs?, isoNow?})`, `withFrozenClock()`, `withFrozenClockAsync()`. Uses `spyOn(Date, 'now')` + `spyOn(Date.prototype, 'toISOString')` (bun 1.3.13/1.3.14 have no `FakeTime` export — verified). try/finally restore only (no `afterEach` safety-net, per plan-critic M2).
- **`tests/helpers/test-isolation.ts`** — `withIsolatedState` / `setupIsolatedState` composing the existing env + temp-dir + clock helpers.
- **`scripts/check-test-clock.sh`** — diff-scoped lint (mirrors `check-mock-cleanup.sh`): fails only on NEW time-touching tests without the helper; ~465 pre-existing files are non-blocking warnings.
- **`scripts/ci/detect-and-quarantine-flakes.sh`** + **`.github/workflows/flake-detection.yml`** — advisory detection: on a failed merge-group ci run, downloads the per-shard `flake-annotations-*` artifacts, applies conservative rules (already-quarantined/infra-signature/core-tree skips), and best-effort opens a tracking issue + uploads a `flake-suggestions` artifact.
- **`docs/testing/test-stability.md`** — runbook for the four root-cause classes + helpers + quarantine convention + known limitations (hrtime/performance.now gap).
- **`TESTING.md`** — one-line pointer to the new runbook.

### What's migrated
- `skill-scoring-e2e.test.ts` — 2 ad-hoc `spyOn(Date,'now')` → `withFrozenClock`.
- `manager-plan-md-sync.test.ts` — `spyOn(Date.prototype,'toISOString')` → `freezeClock({isoNow})`.
- `skill-scoring-workflow.test.ts` — wrapped `computeSkillRelevanceScore` block in `withFrozenClock` (the real fix); **file stays quarantined** until a merge-group run confirms greenness on all 3 OSes (plan-critic H1 — un-quarantine is gated, not in this PR).

### Process
This was run as a swarm-mode issue-tracer: intake → reproduction (3 parallel explorers) → localization → root-cause → fix plan → **independent plan critic (GLM-5.2, NEEDS_REVISION — all 7 findings incorporated)** → user approval → implementation → validation → **independent implementation reviewer (GLM-5.2, APPROVE)** → **final critic (GLM-5.2, APPROVE)**.

## Invariant audit
- **1 (plugin init):** not touched — no `src/index.ts` change.
- **2 (runtime portability):** not touched — no `src/` change. Verified anyway: `bun run build` exit 0; `node --input-type=module -e "await import('./dist/index.js')"` loads, default export = `{ id, server }`.
- **3 (subprocesses):** not touched — the detection script invokes `gh` best-effort with bounded output; no unbounded subprocess introduced.
- **4 (.swarm containment):** touched — the audit doc lives under `.swarm/test-stability-audit.md` (gitignored, local working state — correct per the invariant's runtime-state rationale). No tool creates `.swarm/` under `src/`/`tests/`/etc.
- **5 (plan durability):** not touched.
- **6 (test_runner safety):** not touched.
- **7 (test writing):** touched — helpers use `bun:test` + `spyOn`; self-tests follow FR-006 (<500 lines: test-clock.test.ts=190, test-isolation.test.ts=146). No `mock.module` in new code.
- **8 (session state):** not touched.
- **9 (guardrails/retry):** not touched.
- **10 (chat/system msg):** not touched.
- **11 (tool registration):** not touched.
- **12 (release/cache):** touched — release fragment added (`docs/releases/pending/1782-test-stability-sprint.md`); version files untouched (release-please owns them).

## Test plan

All run from `E:\ZCode\opencode-swarm`, bun 1.3.14 (CI pins 1.3.13; FakeTime absence is patch-invariant).

| Command | Result |
|---|---|
| `bun test tests/helpers/test-clock.test.ts tests/helpers/test-isolation.test.ts tests/unit/hooks/skill-scoring-{e2e,workflow}.test.ts tests/unit/plan/manager-plan-md-sync.test.ts` | **54 pass, 0 fail** |
| `bun test tests/security/ci-workflow-security.test.ts` | **7 pass, 0 fail** (ci.yml additions don't trip it) |
| `bash scripts/check-test-clock.sh` | **0 new violations** (465 pre-existing, non-blocking) |
| `bash scripts/check-mock-cleanup.sh` / `check-cross-contamination.sh` | exit 0, non-blocking pre-existing warnings |
| `bash scripts/check-invariants.sh` | 761 violations — **ALL pre-existing false-positives** from CRLF in `mock-allowlist.txt` on Windows Git Bash (my 9 files contribute 0; Ubuntu CI uses LF and matches correctly). Not a regression. |
| `bun run typecheck` | **exit 0** |
| `bunx biome ci .` | **exit 0** (8 formatting nits auto-fixed via `biome check --write`) |
| `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"` | **build exit 0**; bundle loads, `{id, server}` shape intact |
| `bun run drift:check` | **exit 0** — no drift |
| **Simulated coverage soak:** 5× `bun test --isolate --coverage --timeout 60000 <5 migrated files>` | **5 pass / 0 fail** |
| `bash scripts/ci/detect-and-quarantine-flakes.sh` (synthetic 7-line input) | correct: 1 dropped (quarantined), 2 dropped (infra), 2 flagged (core-tree), 2 suggested; best-effort issue failed gracefully |

### Honest limitations (documented in runbook + audit)
- **5 consecutive green merge-group re-queues** and a **two-week soak** cannot be proven in one PR — they require elapsed wall-clock and multiple real PRs through the queue. The local 5× coverage soak approximates the coverage leg only.
- **Auto-quarantine is advisory:** it produces a suggestion artifact + best-effort tracking issue. Auto-appending to `quarantined-tests.txt` (needs a PAT + branch-protection bypass) is intentionally out of scope.
- No big-bang migration of the ~465 pre-existing time-touching test files; the 4 actual flaky sites are fixed, the diff-scoped lint forces all NEW ones to use the helper, the runbook guides future migration.

## How to use
- New time-sensitive test? `import { withFrozenClock } from '../../helpers/test-clock.js'` and wrap the assertions. The lint fails otherwise.
- New flake detected in merge-group CI? The `flake-detection` workflow posts a `flake-suggestions` artifact + (best-effort) a tracking issue. Review and append to the quarantine list in a follow-up PR if warranted.
- See `docs/testing/test-stability.md` for the full runbook.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


