### PR TITLE
fix(tui): migrate init-path console.warn to advisoryWarn (PR2/5 #1753)

### DIFF
--- a/docs/releases/pending/1753-tui-pollution-pr2-init-path.md
+++ b/docs/releases/pending/1753-tui-pollution-pr2-init-path.md
@@ -1,0 +1,84 @@
+# TUI pollution sweep — init path (PR2 of epic #1752)
+
+## What
+
+Migrates every unguarded `console.warn`/`console.error`/`console.log` on the
+plugin-host init path (and its shared helpers) to the PR1 foundation helpers
+introduced in #1752 PR1:
+
+- Actionable advisories (malformed/oversized config, unreadable prompt files,
+  git-hygiene conditions) now route through `advisoryWarn(msg)` — buffered for
+  `/swarm diagnose` + emitted under `OPENCODE_SWARM_DEBUG=1`. Never raw stderr.
+- Purely diagnostic skips (malformed session snapshot) route through `log(msg)`
+  — debug-only, NOT buffered (would flood `/swarm diagnose`).
+- The one intentionally-unguarded security warning (`.swarm/` files tracked by
+  Git) is left as raw `console.warn` — it is a must-see-always remediation.
+
+Migrated files (`src/`):
+- `config/loader.ts` — all 36 `console.warn` sites across the sync and async
+  load/validation paths (config-too-large, invalid-format, load-failure,
+  gates-validation, external-skills-validation, preset-migration,
+  merged-config-fallback, agent-prompt-read-error).
+- `agents/architect.ts` — the custom-prompt designer-reference warning.
+- `session/snapshot-reader.ts` — the malformed-session-skip diagnostic.
+- `config/project-init.ts` — the "created opencode-swarm.json" advisory.
+- `utils/gitignore-warning.ts` — the ".swarm/ not gitignored" and "Added .swarm/
+  to exclude" cosmetic advisories.
+
+## Why
+
+Raw `console.warn` writes to stderr corrupt the OpenCode bubbletea TUI when it
+owns the terminal (issue #1249 class). The init path fires these on every
+`server()` call with a malformed/oversized config or a stale session snapshot —
+mid-turn, with no error surfaced to the user. PR1 built the `advisoryWarn`
+helper and fixed the single most frequent polluter (bundled-skill sync); this
+PR closes the rest of the init-path surface so the TUI stays clean during
+plugin registration.
+
+## Migration / behavior changes
+
+- Config-validation Zod detail dumps (`result.error.format()`) are now visible
+  only under `OPENCODE_SWARM_DEBUG=1`. The headline message ("gates config
+  validation failed", "Merged config validation failed", etc.) is always
+  available in `/swarm diagnose`. Operators debugging a bad config without
+  debug mode will see the headline in `/swarm diagnose` rather than the full
+  Zod path dump on stderr.
+- `writeProjectConfigIfNew(directory, quiet)` and
+  `warnIfSwarmNotGitignored(directory, quiet)`: the `quiet` parameter is now a
+  no-op (renamed `_quiet`). Previously `quiet:true` suppressed the advisory
+  entirely; now it is always buffered for `/swarm diagnose`. This matches the
+  epic's intent — a recoverable condition should be discoverable, not silently
+  dropped.
+- `ensureSwarmGitExcluded(directory, { quiet })`: the `quiet` option is
+  deprecated/no-op for the cosmetic "Added .swarm/" advisory. The tracked-file
+  security warning remains always-emitted regardless of `quiet`.
+- No breaking API changes. All function signatures, return values, and default
+  behavior are preserved; only the warning delivery channel changed.
+
+## Scope notes
+
+- Biome `suspicious/noConsole` enforcement is deferred to PR5 of epic #1752
+  (per the PR1 review). This PR makes the migrated files clean so PR5 can
+  enable the rule without exemptions (except the one intentional security
+  warning site and the allowlisted logger/cli modules).
+- The `src/agents/index.ts` deprecation/variant warning (uses the older
+  hand-rolled `if (!quiet) console.warn else addDeferredWarning` pattern) is
+  out of scope for this PR and unchanged.
+
+## Testing
+
+Updated 5 test files to assert via `getDeferredWarnings()` instead of
+`spyOn(console, 'warn')`, with `clearDeferredWarnings()` in
+`beforeEach`/`afterEach` to prevent cross-test buffer pollution (Invariant 7):
+`tests/unit/config/loader.test.ts`, `src/agents/architect.designer-gate.test.ts`,
+`tests/unit/config/project-init.test.ts`, `tests/cli/writeProjectConfigIfNew.test.ts`,
+`tests/gitignore-warning.test.ts`.
+
+Also extended `tests/unit/plugin-tui-safety.test.ts` to regression-guard the
+5 migrated files (zero raw `console.warn` except the one intentional
+tracked-file security site in `gitignore-warning.ts`), per the test header's
+standing invitation.
+
+`tests/unit/config/quiet-config.test.ts` requires no changes (asserts on
+`src/agents/index.ts`, which is out of scope). Snapshot-reader tests have no
+console assertions and are unaffected.

--- a/src/agents/architect.designer-gate.test.ts
+++ b/src/agents/architect.designer-gate.test.ts
@@ -1,7 +1,23 @@
-import { describe, expect, it, spyOn } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import {
+	clearDeferredWarnings,
+	getDeferredWarnings,
+} from '../services/warning-buffer';
 import { createArchitectAgent } from './architect';
 
 describe('createArchitectAgent — designer gate (ui_review)', () => {
+	// Epic #1752 PR2: the designer-reference warning now routes through
+	// advisoryWarn (buffered for /swarm diagnose) instead of raw console.warn.
+	// Clear the module-level deferred-warning buffer between tests (AGENTS.md
+	// Invariant 7 — no cross-test pollution in the shared bun test-runner
+	// process).
+	beforeEach(() => {
+		clearDeferredWarnings();
+	});
+	afterEach(() => {
+		clearDeferredWarnings();
+	});
+
 	describe('when ui_review is not enabled (default)', () => {
 		const agent = createArchitectAgent('test-model');
 		const prompt = agent.config.prompt ?? '';
@@ -113,7 +129,7 @@ describe('createArchitectAgent — designer gate (ui_review)', () => {
 	});
 
 	describe('custom prompt designer-reference warning (issue #653)', () => {
-		it('emits console.warn when custom prompt retains designer refs after stripping', () => {
+		it('buffers a warning when custom prompt retains designer refs after stripping', () => {
 			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
 			const customPrompt =
 				'You are an architect. Delegate UI tasks to @designer for scaffold generation.';
@@ -127,21 +143,25 @@ describe('createArchitectAgent — designer gate (ui_review)', () => {
 					enabled: false,
 				},
 			);
-			expect(warnSpy).toHaveBeenCalledWith(
-				expect.stringContaining(
-					'Custom architect prompt may still contain designer references',
+			expect(
+				getDeferredWarnings().some((m) =>
+					m.includes(
+						'Custom architect prompt may still contain designer references',
+					),
 				),
-			);
+			).toBe(true);
+			expect(warnSpy).not.toHaveBeenCalled();
 			warnSpy.mockRestore();
 		});
 
-		it('emits console.warn when ui_review is absent (default) and custom prompt has designer refs', () => {
+		it('buffers a warning when ui_review is absent (default) and custom prompt has designer refs', () => {
 			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
 			const customPrompt = 'Architect prompt that mentions @designer agent.';
 			createArchitectAgent('test-model', customPrompt);
-			expect(warnSpy).toHaveBeenCalledWith(
-				expect.stringContaining('[swarm] WARNING'),
-			);
+			expect(
+				getDeferredWarnings().some((m) => m.includes('[swarm] WARNING')),
+			).toBe(true);
+			expect(warnSpy).not.toHaveBeenCalled();
 			warnSpy.mockRestore();
 		});
 
@@ -186,7 +206,7 @@ describe('createArchitectAgent — designer gate (ui_review)', () => {
 			warnSpy.mockRestore();
 		});
 
-		it('emits console.warn for @Designer (capital D) in custom prompt when ui_review is disabled', () => {
+		it('buffers a warning for @Designer (capital D) in custom prompt when ui_review is disabled', () => {
 			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
 			const customPrompt = 'Delegate UI tasks to @Designer agent.';
 			createArchitectAgent(
@@ -199,15 +219,18 @@ describe('createArchitectAgent — designer gate (ui_review)', () => {
 					enabled: false,
 				},
 			);
-			expect(warnSpy).toHaveBeenCalledWith(
-				expect.stringContaining(
-					'Custom architect prompt may still contain designer references',
+			expect(
+				getDeferredWarnings().some((m) =>
+					m.includes(
+						'Custom architect prompt may still contain designer references',
+					),
 				),
-			);
+			).toBe(true);
+			expect(warnSpy).not.toHaveBeenCalled();
 			warnSpy.mockRestore();
 		});
 
-		it('emits console.warn for {{AGENT_PREFIX}}designer (no @ prefix) in custom prompt', () => {
+		it('buffers a warning for {{AGENT_PREFIX}}designer (no @ prefix) in custom prompt', () => {
 			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
 			const customPrompt =
 				'You can delegate UI tasks to {{AGENT_PREFIX}}designer for scaffolding.';
@@ -221,11 +244,14 @@ describe('createArchitectAgent — designer gate (ui_review)', () => {
 					enabled: false,
 				},
 			);
-			expect(warnSpy).toHaveBeenCalledWith(
-				expect.stringContaining(
-					'Custom architect prompt may still contain designer references',
+			expect(
+				getDeferredWarnings().some((m) =>
+					m.includes(
+						'Custom architect prompt may still contain designer references',
+					),
 				),
-			);
+			).toBe(true);
+			expect(warnSpy).not.toHaveBeenCalled();
 			warnSpy.mockRestore();
 		});
 	});

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -19,6 +19,7 @@ import {
 	TOOL_DESCRIPTIONS,
 	TURBO_AGENT_TOOL_MAP,
 } from '../config/constants';
+import { advisoryWarn } from '../services/warning-buffer.js';
 
 export interface AgentDefinition {
 	name: string;
@@ -1833,7 +1834,7 @@ export function createArchitectAgent(
 				prompt ?? '',
 			)
 		) {
-			console.warn(
+			advisoryWarn(
 				'[swarm] WARNING: Custom architect prompt may still contain designer references after stripping. ' +
 					'Verify your custom prompt does not reference @designer when ui_review is disabled.',
 			);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { advisoryWarn } from '../services/warning-buffer.js';
 import {
 	ExternalSkillsConfigSchema,
 	GATE_CONFIG_KNOWN_SECTION_KEYS,
@@ -36,10 +37,10 @@ function loadRawConfigFromPath(configPath: string): {
 	try {
 		const stats = fs.statSync(configPath);
 		if (stats.size > MAX_CONFIG_FILE_BYTES) {
-			console.warn(
+			advisoryWarn(
 				`[opencode-swarm] Config file too large (max 100 KB): ${configPath}`,
 			);
-			console.warn(
+			advisoryWarn(
 				'[opencode-swarm] ⚠️ SECURITY: Config file exceeds size limit. Falling back to safe defaults with guardrails ENABLED.',
 			);
 			return { config: null, fileExisted: true, hadError: true };
@@ -48,10 +49,10 @@ function loadRawConfigFromPath(configPath: string): {
 		const content = fs.readFileSync(configPath, 'utf-8');
 		// TOCTOU guard: re-check size after read (file may have grown between statSync and readFileSync)
 		if (content.length > MAX_CONFIG_FILE_BYTES) {
-			console.warn(
+			advisoryWarn(
 				`[opencode-swarm] Config file too large after read (max 100 KB): ${configPath}`,
 			);
-			console.warn(
+			advisoryWarn(
 				'[opencode-swarm] ⚠️ SECURITY: Config file exceeds size limit. Falling back to safe defaults with guardrails ENABLED.',
 			);
 			return { config: null, fileExisted: true, hadError: true };
@@ -70,10 +71,10 @@ function loadRawConfigFromPath(configPath: string): {
 			rawConfig === null ||
 			Array.isArray(rawConfig)
 		) {
-			console.warn(
+			advisoryWarn(
 				`[opencode-swarm] Invalid config at ${configPath}: expected an object`,
 			);
-			console.warn(
+			advisoryWarn(
 				'[opencode-swarm] ⚠️ SECURITY: Config format invalid. Falling back to safe defaults with guardrails ENABLED.',
 			);
 			return { config: null, fileExisted: true, hadError: true };
@@ -95,10 +96,10 @@ function loadRawConfigFromPath(configPath: string): {
 			// Any other error (JSON parse error, permission denied, etc.) - treat as load failure
 			const errorMessage =
 				error instanceof Error ? error.message : String(error);
-			console.warn(
+			advisoryWarn(
 				`[opencode-swarm] ⚠️ CONFIG LOAD FAILURE — config exists at ${configPath} but could not be loaded: ${errorMessage}`,
 			);
-			console.warn(
+			advisoryWarn(
 				'[opencode-swarm] ⚠️ SECURITY: Config load failed. Falling back to safe defaults with guardrails ENABLED.',
 			);
 			return { config: null, fileExisted: true, hadError: true };
@@ -135,7 +136,7 @@ function migratePresetsConfig(
 			delete migrated.preset;
 			delete migrated.presets;
 			delete migrated.swarm_mode;
-			console.warn(
+			advisoryWarn(
 				'[opencode-swarm] Migrated v6.12 presets config to agents format. Consider updating your opencode-swarm.json.',
 			);
 			return migrated;
@@ -162,9 +163,11 @@ function sanitizeExternalSkillsConfig(
 			external_skills: resolveExternalSkillsConfig(esResult.data),
 		};
 	}
-	console.warn('[opencode-swarm] external_skills config validation failed:');
-	console.warn(esResult.error.format());
-	console.warn(
+	advisoryWarn(
+		'[opencode-swarm] external_skills config validation failed:',
+		esResult.error.format(),
+	);
+	advisoryWarn(
 		'[opencode-swarm] External skills curation disabled due to invalid config. Fix the external_skills section to enable it.',
 	);
 	const cleaned = { ...raw };
@@ -183,7 +186,7 @@ function sanitizeGatesConfig(
 		raw.gates === null ||
 		Array.isArray(raw.gates)
 	) {
-		console.warn(
+		advisoryWarn(
 			'[opencode-swarm] gates config validation failed: expected an object. Quality gates will use defaults; other config sections remain active.',
 		);
 		const cleaned = { ...raw };
@@ -196,7 +199,7 @@ function sanitizeGatesConfig(
 	for (const [key, value] of Object.entries(cleanedGates)) {
 		const schema = gateSchemas[key as keyof typeof gateSchemas];
 		if (!schema) {
-			console.warn(
+			advisoryWarn(
 				`[opencode-swarm] Unknown gates config section "gates.${key}" ignored. Other config sections remain active.`,
 			);
 			delete cleanedGates[key];
@@ -217,7 +220,7 @@ function sanitizeGatesConfig(
 			const knownFieldSet = new Set<string>(knownFields);
 			for (const fieldName of Object.keys(cleanedSection)) {
 				if (!knownFieldSet.has(fieldName)) {
-					console.warn(
+					advisoryWarn(
 						`[opencode-swarm] Unknown gates config key "gates.${key}.${fieldName}" ignored. Other config sections remain active.`,
 					);
 					delete cleanedSection[fieldName];
@@ -228,10 +231,10 @@ function sanitizeGatesConfig(
 		}
 		const sectionResult = schema.safeParse(sectionValue);
 		if (!sectionResult.success) {
-			console.warn(
+			advisoryWarn(
 				`[opencode-swarm] gates.${key} config validation failed; that gate section will use defaults and other config sections remain active:`,
+				sectionResult.error.format(),
 			);
-			console.warn(sectionResult.error.format());
 			delete cleanedGates[key];
 		}
 	}
@@ -244,10 +247,10 @@ function sanitizeGatesConfig(
 		};
 	}
 
-	console.warn(
+	advisoryWarn(
 		'[opencode-swarm] gates config validation failed after section cleanup; quality gates will use defaults and other config sections remain active:',
+		gatesResult.error.format(),
 	);
-	console.warn(gatesResult.error.format());
 	const cleaned = { ...raw };
 	delete cleaned.gates;
 	return cleaned;
@@ -347,16 +350,18 @@ export function loadPluginConfig(directory: string): PluginConfig {
 				sanitizeSectionConfigs(rawUserConfig ?? {}),
 			);
 			if (userParseResult.success) {
-				console.warn(
+				advisoryWarn(
 					'[opencode-swarm] Project config ignored due to validation errors. Using user config.',
 				);
 				return userParseResult.data;
 			}
 		}
 		// Neither merged nor user config is valid, return defaults with guardrails ENABLED (fail-secure)
-		console.warn('[opencode-swarm] Merged config validation failed:');
-		console.warn(result.error.format());
-		console.warn(
+		advisoryWarn(
+			'[opencode-swarm] Merged config validation failed:',
+			result.error.format(),
+		);
+		advisoryWarn(
 			'[opencode-swarm] ⚠️ SECURITY: Falling back to conservative defaults with guardrails ENABLED. Fix the config file to restore custom configuration.',
 		);
 		// Fail-secure: return defaults with guardrails explicitly enabled
@@ -420,20 +425,20 @@ async function loadRawConfigFromPathAsync(configPath: string): Promise<{
 	try {
 		const stats = await fsPromises.stat(configPath);
 		if (stats.size > MAX_CONFIG_FILE_BYTES) {
-			console.warn(
+			advisoryWarn(
 				`[opencode-swarm] Config file too large (max 100 KB): ${configPath}`,
 			);
-			console.warn(
+			advisoryWarn(
 				'[opencode-swarm] ⚠️ SECURITY: Config file exceeds size limit. Falling back to safe defaults with guardrails ENABLED.',
 			);
 			return { config: null, fileExisted: true, hadError: true };
 		}
 		const content = await fsPromises.readFile(configPath, 'utf-8');
 		if (content.length > MAX_CONFIG_FILE_BYTES) {
-			console.warn(
+			advisoryWarn(
 				`[opencode-swarm] Config file too large after read (max 100 KB): ${configPath}`,
 			);
-			console.warn(
+			advisoryWarn(
 				'[opencode-swarm] ⚠️ SECURITY: Config file exceeds size limit. Falling back to safe defaults with guardrails ENABLED.',
 			);
 			return { config: null, fileExisted: true, hadError: true };
@@ -448,10 +453,10 @@ async function loadRawConfigFromPathAsync(configPath: string): Promise<{
 			rawConfig === null ||
 			Array.isArray(rawConfig)
 		) {
-			console.warn(
+			advisoryWarn(
 				`[opencode-swarm] Invalid config at ${configPath}: expected an object`,
 			);
-			console.warn(
+			advisoryWarn(
 				'[opencode-swarm] ⚠️ SECURITY: Config format invalid. Falling back to safe defaults with guardrails ENABLED.',
 			);
 			return { config: null, fileExisted: true, hadError: true };
@@ -466,7 +471,7 @@ async function loadRawConfigFromPathAsync(configPath: string): Promise<{
 		if (code === 'ENOENT') {
 			return { config: null, fileExisted: false, hadError: false };
 		}
-		console.warn(
+		advisoryWarn(
 			`[opencode-swarm] Failed to load config from ${configPath}:`,
 			error instanceof Error ? error.message : String(error),
 		);
@@ -496,15 +501,17 @@ function reduceParsedConfig(
 				sanitizeSectionConfigs(rawUserConfig ?? {}),
 			);
 			if (userParseResult.success) {
-				console.warn(
+				advisoryWarn(
 					'[opencode-swarm] Project config ignored due to validation errors. Using user config.',
 				);
 				return userParseResult.data;
 			}
 		}
-		console.warn('[opencode-swarm] Merged config validation failed:');
-		console.warn(result.error.format());
-		console.warn(
+		advisoryWarn(
+			'[opencode-swarm] Merged config validation failed:',
+			result.error.format(),
+		);
+		advisoryWarn(
 			'[opencode-swarm] ⚠️ SECURITY: Falling back to conservative defaults with guardrails ENABLED. Fix the config file to restore custom configuration.',
 		);
 		return PluginConfigSchema.parse({ guardrails: { enabled: true } });
@@ -571,7 +578,7 @@ export function loadAgentPrompt(agentName: string): {
 		try {
 			result.prompt = fs.readFileSync(promptPath, 'utf-8');
 		} catch (error) {
-			console.warn(
+			advisoryWarn(
 				`[opencode-swarm] Error reading prompt file ${promptPath}:`,
 				error instanceof Error ? error.message : String(error),
 			);
@@ -584,7 +591,7 @@ export function loadAgentPrompt(agentName: string): {
 		try {
 			result.appendPrompt = fs.readFileSync(appendPromptPath, 'utf-8');
 		} catch (error) {
-			console.warn(
+			advisoryWarn(
 				`[opencode-swarm] Error reading append prompt ${appendPromptPath}:`,
 				error instanceof Error ? error.message : String(error),
 			);

--- a/src/config/project-init.ts
+++ b/src/config/project-init.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { advisoryWarn } from '../services/warning-buffer.js';
 import { DEFAULT_MODELS } from './constants';
 
 const STARTER_CONTENT = '{}\n';
@@ -14,7 +15,7 @@ const STARTER_CONTENT = '{}\n';
  */
 export function writeProjectConfigIfNew(
 	directory: string,
-	quiet = false,
+	_quiet = false,
 ): void {
 	try {
 		const opencodeDir = path.join(directory, '.opencode');
@@ -55,12 +56,10 @@ export function writeProjectConfigIfNew(
 				encoding: 'utf-8',
 				flag: 'wx',
 			});
-			if (!quiet) {
-				console.warn(
-					'[opencode-swarm] Created .opencode/opencode-swarm.json — ' +
-						'edit it to customize agent LLMs for this project, or commit it to share settings with your team',
-				);
-			}
+			advisoryWarn(
+				'[opencode-swarm] Created .opencode/opencode-swarm.json — ' +
+					'edit it to customize agent LLMs for this project, or commit it to share settings with your team',
+			);
 		} catch (_writeErr) {
 			// EEXIST means the file already exists — skip silently.
 			// All other write errors (EACCES, ENOSPC, etc.) are also non-fatal.

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,12 +344,19 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 // does not trip excess-property checks against `Hooks`. The wrapper above is
 // typed as `Plugin`, which validates the structural shape at the call site.
 async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
+	// Clear deferred warnings at the very start of the session, BEFORE any
+	// init-path work that buffers advisories via advisoryWarn (config load,
+	// ensureSwarmGitExcluded, writeProjectConfigIfNew). The clear isolates the
+	// new session from the PREVIOUS session's buffer; running it after config
+	// load (the historical placement) would wipe the current session's
+	// config-validation warnings before /swarm diagnose can surface them
+	// (epic #1752 PR2 — config-load warnings now route through advisoryWarn,
+	// not raw stderr, so the buffer is the only /swarm diagnose channel).
+	clearDeferredWarnings();
+
 	const { config, loadedFromFile } = await loadPluginConfigWithMetaAsync(
 		ctx.directory,
 	);
-
-	// Clear deferred warnings at session start for per-session isolation
-	clearDeferredWarnings();
 
 	// Full-auto mode validation: critic model must differ from architect model
 	if (config.full_auto?.enabled === true) {

--- a/src/services/warning-buffer.ts
+++ b/src/services/warning-buffer.ts
@@ -10,10 +10,25 @@ import { log } from '../utils/logger.js';
 
 const deferredWarnings: string[] = [];
 const MAX_DEFERRED_WARNINGS = 50;
+// Set once the cap is reached so a single trailing sentinel can be appended
+// by addDeferredWarning. Prevents silent truncation from hiding actionable
+// advisories (epic #1752 PR2 review F-003).
+let deferredWarningsTruncated = false;
 
 export function addDeferredWarning(warning: string): void {
-	if (deferredWarnings.length < MAX_DEFERRED_WARNINGS) {
+	if (deferredWarnings.length < MAX_DEFERRED_WARNINGS - 1) {
 		deferredWarnings.push(warning);
+		return;
+	}
+	// Reserve the last slot for a truncation sentinel so /swarm diagnose can
+	// tell the operator that further advisories were dropped, rather than
+	// silently losing them. SECURITY/fallback messages emitted after the cap
+	// is hit would otherwise vanish without trace.
+	if (!deferredWarningsTruncated) {
+		deferredWarnings.push(
+			`[opencode-swarm] ${MAX_DEFERRED_WARNINGS - 1} deferred warnings buffered; additional advisories were dropped (cap reached). Run with OPENCODE_SWARM_DEBUG=1 to see all advisories in the debug log.`,
+		);
+		deferredWarningsTruncated = true;
 	}
 }
 
@@ -67,4 +82,5 @@ export function getDeferredWarnings(): readonly string[] {
  */
 export function clearDeferredWarnings(): void {
 	deferredWarnings.length = 0;
+	deferredWarningsTruncated = false;
 }

--- a/src/session/snapshot-reader.ts
+++ b/src/session/snapshot-reader.ts
@@ -13,6 +13,7 @@ import {
 	swarmState,
 } from '../state';
 import { bunFile } from '../utils/bun-compat';
+import { log } from '../utils/logger.js';
 import type {
 	SerializedAgentSession,
 	SerializedInvocationWindow,
@@ -315,9 +316,8 @@ export async function rehydrateState(
 				typeof serializedSession.lastToolCallTime !== 'number' ||
 				typeof serializedSession.delegationActive !== 'boolean'
 			) {
-				console.warn(
-					'[snapshot-reader] Skipping malformed session %s: missing required fields (agentName, lastToolCallTime, delegationActive)',
-					sessionId,
+				log(
+					`[snapshot-reader] Skipping malformed session ${sessionId}: missing required fields (agentName, lastToolCallTime, delegationActive)`,
 				);
 				continue;
 			}

--- a/src/utils/gitignore-warning.ts
+++ b/src/utils/gitignore-warning.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { advisoryWarn } from '../services/warning-buffer.js';
 import { bunSpawn } from './bun-compat';
 
 /**
@@ -96,7 +97,8 @@ function readFileSafe(filePath: string): string | null {
 /**
  * Checks whether `.swarm/` is covered by `.gitignore` or `.git/info/exclude`
  * in the git repo rooted at or above `directory`. If not covered, emits a
- * single `console.warn` (unless `quiet` is true). Fires at most once per process.
+ * single advisory via `advisoryWarn` (buffered for `/swarm diagnose` + debug
+ * log). Fires at most once per process.
  *
  * Never throws — any file-system error silently skips the check.
  *
@@ -105,7 +107,7 @@ function readFileSafe(filePath: string): string | null {
  */
 export function warnIfSwarmNotGitignored(
 	directory: string,
-	quiet = false,
+	_quiet = false,
 ): void {
 	if (_gitignoreWarningEmitted) return;
 
@@ -127,13 +129,12 @@ export function warnIfSwarmNotGitignored(
 			return;
 		}
 
-		// Not covered by either source — emit warning (suppressed when quiet:true)
+		// Not covered by either source — emit advisory (buffered for /swarm
+		// diagnose + debug-gated log; never raw stderr, per epic #1752).
 		_gitignoreWarningEmitted = true;
-		if (!quiet) {
-			console.warn(
-				'[opencode-swarm] WARNING: .swarm/ is not in your .gitignore. Shell audit logs may contain API keys. Add ".swarm/" to your .gitignore to prevent accidental commits.',
-			);
-		}
+		advisoryWarn(
+			'[opencode-swarm] WARNING: .swarm/ is not in your .gitignore. Shell audit logs may contain API keys. Add ".swarm/" to your .gitignore to prevent accidental commits.',
+		);
 	} catch {
 		// Silently swallow any unexpected error — never block plugin init
 	}
@@ -206,8 +207,11 @@ const GIT_SPAWN_OPTIONS = {
  *
  * Never throws. Fires at most once per process.
  *
- * quiet option: only suppresses cosmetic logs. The exclude write and tracked-file
- * warning are never suppressed regardless of quiet mode.
+ * quiet option: deprecated/no-op since epic #1752 PR2 — cosmetic advisories now
+ * route through `advisoryWarn` (buffered for `/swarm diagnose` + debug log)
+ * regardless of quiet. The exclude write always runs; the tracked-file warning
+ * (step 6) is intentionally always emitted as raw `console.warn` because it is
+ * a must-see security/hygiene remediation, not a recoverable advisory.
  */
 export async function ensureSwarmGitExcluded(
 	directory: string,
@@ -216,7 +220,8 @@ export async function ensureSwarmGitExcluded(
 	if (_swarmGitExcludedChecked) return;
 	_swarmGitExcludedChecked = true;
 
-	const { quiet = false } = options;
+	const { quiet: _quiet = false } = options;
+	void _quiet;
 
 	try {
 		// Steps 1, 2, and 3 are independent — run them in parallel to reduce
@@ -322,11 +327,9 @@ export async function ensureSwarmGitExcluded(
 						'\n# opencode-swarm local runtime state\n.swarm/\n',
 						'utf8',
 					);
-					if (!quiet) {
-						console.warn(
-							'[opencode-swarm] Added .swarm/ to .git/info/exclude to prevent runtime state from appearing in git status.',
-						);
-					}
+					advisoryWarn(
+						'[opencode-swarm] Added .swarm/ to .git/info/exclude to prevent runtime state from appearing in git status.',
+					);
 				}
 			} catch {
 				// Failed to write exclude — non-fatal (read-only repo, permissions, etc.)

--- a/tests/cli/writeProjectConfigIfNew.test.ts
+++ b/tests/cli/writeProjectConfigIfNew.test.ts
@@ -3,6 +3,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { writeProjectConfigIfNew } from '../../src/config/project-init';
+import {
+	clearDeferredWarnings,
+	getDeferredWarnings,
+} from '../../src/services/warning-buffer';
 
 describe('writeProjectConfigIfNew', () => {
 	let tmpDir: string;
@@ -11,11 +15,15 @@ describe('writeProjectConfigIfNew', () => {
 	beforeEach(() => {
 		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-test-'));
 		origWarn = console.warn;
+		// Epic #1752 PR2: advisoryWarn writes to the module-level deferred-warning
+		// buffer. Clear it between tests (AGENTS.md Invariant 7).
+		clearDeferredWarnings();
 	});
 
 	afterEach(() => {
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 		console.warn = origWarn;
+		clearDeferredWarnings();
 	});
 
 	// 1. .opencode/opencode-swarm.json created in cwd
@@ -55,8 +63,9 @@ describe('writeProjectConfigIfNew', () => {
 		});
 	});
 
-	// 4. Quiet mode suppresses success console.warn
-	test('4. quiet mode suppresses success console.warn', () => {
+	// 4. Epic #1752 PR2: advisory now routes through advisoryWarn (buffered for
+	// /swarm diagnose) regardless of quiet. console.warn is never called.
+	test('4. quiet=true routes advisory to buffer, never raw stderr', () => {
 		let warned = false;
 		console.warn = (..._args: unknown[]) => {
 			warned = true;
@@ -65,10 +74,14 @@ describe('writeProjectConfigIfNew', () => {
 		writeProjectConfigIfNew(tmpDir, true);
 
 		expect(warned).toBe(false);
+		expect(
+			getDeferredWarnings().some((m) => m.includes('opencode-swarm.json')),
+		).toBe(true);
 	});
 
-	// 5. Non-quiet mode emits success console.warn
-	test('5. non-quiet mode emits success console.warn', () => {
+	// 5. Epic #1752 PR2: even with quiet=false the advisory routes through
+	// advisoryWarn (never raw stderr).
+	test('5. quiet=false routes advisory to buffer, never raw stderr', () => {
 		let warned = false;
 		console.warn = (..._args: unknown[]) => {
 			warned = true;
@@ -76,6 +89,9 @@ describe('writeProjectConfigIfNew', () => {
 
 		writeProjectConfigIfNew(tmpDir, false);
 
-		expect(warned).toBe(true);
+		expect(warned).toBe(false);
+		expect(
+			getDeferredWarnings().some((m) => m.includes('opencode-swarm.json')),
+		).toBe(true);
 	});
 });

--- a/tests/gitignore-warning.test.ts
+++ b/tests/gitignore-warning.test.ts
@@ -24,6 +24,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+	clearDeferredWarnings,
+	getDeferredWarnings,
+} from '../src/services/warning-buffer';
+import {
 	_internals,
 	ensureSwarmGitExcluded,
 	resetGitignoreWarningState,
@@ -71,11 +75,15 @@ describe('warnIfSwarmNotGitignored', () => {
 	beforeEach(() => {
 		tmpDir = makeTmpDir();
 		resetGitignoreWarningState();
+		// Epic #1752 PR2: advisoryWarn writes to the module-level deferred-warning
+		// buffer. Clear it between tests (AGENTS.md Invariant 7).
+		clearDeferredWarnings();
 		warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
 	});
 
 	afterEach(() => {
 		warnSpy.mockRestore();
+		clearDeferredWarnings();
 		rmrf(tmpDir);
 		resetGitignoreWarningState();
 	});
@@ -89,11 +97,14 @@ describe('warnIfSwarmNotGitignored', () => {
 
 		warnIfSwarmNotGitignored(tmpDir);
 
-		expect(warnSpy).toHaveBeenCalledTimes(1);
-		const [message] = warnSpy.mock.calls[0] as [string];
-		expect(message).toContain('[opencode-swarm] WARNING');
-		expect(message).toContain('.swarm/');
-		expect(message).toContain('.gitignore');
+		// Epic #1752 PR2: advisory routes through advisoryWarn (buffered for
+		// /swarm diagnose), never raw console.warn.
+		expect(warnSpy).not.toHaveBeenCalled();
+		const buffered = getDeferredWarnings();
+		expect(buffered.length).toBe(1);
+		expect(buffered[0]).toContain('[opencode-swarm] WARNING');
+		expect(buffered[0]).toContain('.swarm/');
+		expect(buffered[0]).toContain('.gitignore');
 	});
 
 	// -------------------------------------------------------------------------
@@ -169,7 +180,12 @@ describe('warnIfSwarmNotGitignored', () => {
 		warnIfSwarmNotGitignored(tmpDir);
 		warnIfSwarmNotGitignored(tmpDir);
 
-		expect(warnSpy).toHaveBeenCalledTimes(1);
+		// Dedup flag prevents repeated buffering — only one advisory entry.
+		const gitignoreWarnings = getDeferredWarnings().filter((m) =>
+			m.includes('[opencode-swarm] WARNING'),
+		);
+		expect(gitignoreWarnings.length).toBe(1);
+		expect(warnSpy).not.toHaveBeenCalled();
 	});
 
 	it('does NOT fire a second call after flag was set by a covered repo', () => {
@@ -202,7 +218,10 @@ describe('warnIfSwarmNotGitignored', () => {
 
 		warnIfSwarmNotGitignored(tmpDir);
 
-		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy).not.toHaveBeenCalled();
+		expect(
+			getDeferredWarnings().some((m) => m.includes('[opencode-swarm] WARNING')),
+		).toBe(true);
 	});
 
 	it('handles whitespace around .swarm/ in .gitignore', () => {
@@ -221,7 +240,10 @@ describe('warnIfSwarmNotGitignored', () => {
 
 		warnIfSwarmNotGitignored(tmpDir);
 
-		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy).not.toHaveBeenCalled();
+		expect(
+			getDeferredWarnings().some((m) => m.includes('[opencode-swarm] WARNING')),
+		).toBe(true);
 	});
 
 	it('walks up to the git root when called from a subdirectory', () => {
@@ -235,7 +257,10 @@ describe('warnIfSwarmNotGitignored', () => {
 		warnIfSwarmNotGitignored(subDir);
 
 		// Should find tmpDir/.git and read tmpDir/.gitignore
-		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy).not.toHaveBeenCalled();
+		expect(
+			getDeferredWarnings().some((m) => m.includes('[opencode-swarm] WARNING')),
+		).toBe(true);
 	});
 
 	it('does NOT fire when walking up finds a covered .gitignore', () => {
@@ -280,11 +305,15 @@ describe('ensureSwarmGitExcluded', () => {
 	beforeEach(() => {
 		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-ensure-git-test-'));
 		resetSwarmGitExcludedState();
+		// Epic #1752 PR2: advisoryWarn writes to the module-level deferred-warning
+		// buffer. Clear it between tests (AGENTS.md Invariant 7).
+		clearDeferredWarnings();
 		warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
 	});
 
 	afterEach(() => {
 		warnSpy.mockRestore();
+		clearDeferredWarnings();
 		rmrf(tmpDir);
 		resetSwarmGitExcludedState();
 	});
@@ -330,19 +359,25 @@ describe('ensureSwarmGitExcluded', () => {
 		expect(matches?.length ?? 0).toBe(1);
 	});
 
-	// 4. quiet mode — exclude write still runs, no cosmetic log
-	it('still writes to exclude in quiet mode (no cosmetic log)', async () => {
+	// 4. quiet mode — exclude write still runs; the cosmetic "Added .swarm/"
+	// advisory now routes through advisoryWarn (buffered for /swarm diagnose)
+	// regardless of quiet, never raw console.warn (epic #1752 PR2).
+	it('still writes to exclude in quiet mode (cosmetic advisory buffered, not raw stderr)', async () => {
 		makeRealGitRepo(tmpDir);
 
 		await ensureSwarmGitExcluded(tmpDir, { quiet: true });
 
 		const exclude = readExclude(tmpDir);
 		expect(exclude).toContain('.swarm/');
-		// Cosmetic "Added .swarm/" log suppressed in quiet mode
+		// Cosmetic advisory never reaches raw stderr.
 		const addedMsg = warnSpy.mock.calls.find((c) =>
 			String(c[0]).includes('Added .swarm/'),
 		);
 		expect(addedMsg).toBeUndefined();
+		// It IS buffered so /swarm diagnose can surface it.
+		expect(getDeferredWarnings().some((m) => m.includes('Added .swarm/'))).toBe(
+			true,
+		);
 	});
 
 	// 5. Tracked .swarm/foo.json — emits unsuppressed warning with remediation

--- a/tests/unit/config/loader.test.ts
+++ b/tests/unit/config/loader.test.ts
@@ -9,6 +9,10 @@ import {
 	MAX_CONFIG_FILE_BYTES,
 	MAX_MERGE_DEPTH,
 } from '../../../src/config/loader';
+import {
+	clearDeferredWarnings,
+	getDeferredWarnings,
+} from '../../../src/services/warning-buffer';
 
 describe('config/loader', () => {
 	describe('deepMerge', () => {
@@ -179,9 +183,16 @@ describe('config/loader', () => {
 			// Override XDG_CONFIG_HOME to isolate from real user config
 			originalXDG = process.env.XDG_CONFIG_HOME;
 			process.env.XDG_CONFIG_HOME = tempDir;
+			// The deferred-warning buffer is module-level
+			// (src/services/warning-buffer); clear it between tests so a prior
+			// test's advisoryWarn entry cannot leak into this one (AGENTS.md
+			// Invariant 7 — no cross-test pollution in the shared bun test-runner
+			// process).
+			clearDeferredWarnings();
 		});
 
 		afterEach(() => {
+			clearDeferredWarnings();
 			// Restore original XDG_CONFIG_HOME
 			if (originalXDG === undefined) {
 				delete process.env.XDG_CONFIG_HOME;
@@ -714,6 +725,9 @@ describe('config/loader', () => {
 		});
 
 		it('warns and keeps valid config when one gates subsection is invalid', () => {
+			// Epic #1752 PR2: validation warnings now route through advisoryWarn
+			// (buffered for /swarm diagnose) instead of raw console.warn. Assert
+			// via getDeferredWarnings(); spy stays to prove no raw stderr.
 			const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
 			const userConfigDir = path.join(tempDir, 'opencode');
 			const userConfigFile = path.join(userConfigDir, 'opencode-swarm.json');
@@ -748,9 +762,10 @@ describe('config/loader', () => {
 				).toBe(true);
 				expect(result.gates?.quality_budget.enabled).toBe(true);
 
-				const warnings = warnSpy.mock.calls.flat().join('\n');
+				const warnings = getDeferredWarnings().join('\n');
 				expect(warnings).toContain('gates.placeholder_scan');
 				expect(warnings).toContain('other config sections remain active');
+				expect(warnSpy).not.toHaveBeenCalled();
 			} finally {
 				warnSpy.mockRestore();
 				fs.rmSync(projectDir, { recursive: true, force: true });
@@ -784,9 +799,10 @@ describe('config/loader', () => {
 				expect(result.gates?.syntax_check.enabled).toBe(false);
 				expect(result.gates?.quality_budget.enabled).toBe(true);
 
-				const warnings = warnSpy.mock.calls.flat().join('\n');
+				const warnings = getDeferredWarnings().join('\n');
 				expect(warnings).toContain('gates.placeholder_scn');
 				expect(warnings).toContain('Other config sections remain active');
+				expect(warnSpy).not.toHaveBeenCalled();
 			} finally {
 				warnSpy.mockRestore();
 				fs.rmSync(projectDir, { recursive: true, force: true });
@@ -823,11 +839,12 @@ describe('config/loader', () => {
 				expect(result.gates?.placeholder_scan.max_allowed_findings).toBe(0);
 				expect(result.gates?.quality_budget.enabled).toBe(true);
 
-				const warnings = warnSpy.mock.calls.flat().join('\n');
+				const warnings = getDeferredWarnings().join('\n');
 				expect(warnings).toContain(
 					'gates.placeholder_scan.max_allowed_finding',
 				);
 				expect(warnings).toContain('Other config sections remain active');
+				expect(warnSpy).not.toHaveBeenCalled();
 			} finally {
 				warnSpy.mockRestore();
 				fs.rmSync(projectDir, { recursive: true, force: true });
@@ -858,8 +875,9 @@ describe('config/loader', () => {
 				// gates: null is stripped by sanitizeGatesConfig; gates becomes undefined
 				expect(result.gates).toBeUndefined();
 
-				const warnings = warnSpy.mock.calls.flat().join('\n');
+				const warnings = getDeferredWarnings().join('\n');
 				expect(warnings).toContain('expected an object');
+				expect(warnSpy).not.toHaveBeenCalled();
 			} finally {
 				warnSpy.mockRestore();
 				fs.rmSync(projectDir, { recursive: true, force: true });
@@ -890,8 +908,9 @@ describe('config/loader', () => {
 				// gates: [] is stripped by sanitizeGatesConfig; gates becomes undefined
 				expect(result.gates).toBeUndefined();
 
-				const warnings = warnSpy.mock.calls.flat().join('\n');
+				const warnings = getDeferredWarnings().join('\n');
 				expect(warnings).toContain('expected an object');
+				expect(warnSpy).not.toHaveBeenCalled();
 			} finally {
 				warnSpy.mockRestore();
 				fs.rmSync(projectDir, { recursive: true, force: true });

--- a/tests/unit/config/project-init.test.ts
+++ b/tests/unit/config/project-init.test.ts
@@ -6,6 +6,10 @@ import {
 	writeProjectConfigIfNew,
 	writeSwarmConfigExampleIfNew,
 } from '../../../src/config/project-init';
+import {
+	clearDeferredWarnings,
+	getDeferredWarnings,
+} from '../../../src/services/warning-buffer';
 import { createSafeTestDir } from '../../helpers/safe-test-dir';
 
 describe('writeProjectConfigIfNew', () => {
@@ -21,10 +25,14 @@ describe('writeProjectConfigIfNew', () => {
 		console.warn = (...args: unknown[]) => {
 			warnOutput.push(args.map(String).join(' '));
 		};
+		// Epic #1752 PR2: advisoryWarn writes to the module-level deferred-warning
+		// buffer. Clear it between tests (AGENTS.md Invariant 7).
+		clearDeferredWarnings();
 	});
 
 	afterEach(() => {
 		console.warn = origWarn;
+		clearDeferredWarnings();
 		cleanup();
 	});
 
@@ -179,10 +187,17 @@ describe('writeProjectConfigIfNew', () => {
 		expect(fs.existsSync(configPath(dir))).toBe(false);
 	});
 
-	// 8. Respects quiet flag — no console.warn when quiet=true
-	test('8. suppresses console.warn when quiet=true', () => {
+	// 8. Epic #1752 PR2: advisory now routes through advisoryWarn (buffered for
+	// /swarm diagnose) regardless of quiet. console.warn is never called; the
+	// message reaches the deferred-warning buffer.
+	test('8. routes the created-config advisory to the deferred buffer (quiet=true)', () => {
 		writeProjectConfigIfNew(dir, true);
+		// advisoryWarn never writes raw stderr — the console.warn override stays empty.
 		expect(warnOutput).toHaveLength(0);
+		// The advisory IS buffered so /swarm diagnose can surface it.
+		expect(
+			getDeferredWarnings().some((m) => m.includes('opencode-swarm.json')),
+		).toBe(true);
 	});
 
 	// 9a. Symlink guard: skips creation when .opencode is a symlink
@@ -228,12 +243,15 @@ describe('writeProjectConfigIfNew', () => {
 		).toBe(true);
 	});
 
-	// 9. Emits console.warn when quiet=false (default)
-	test('9. emits console.warn when quiet=false', () => {
+	// 9. Epic #1752 PR2: even with quiet=false the advisory routes through
+	// advisoryWarn (never raw stderr). The message reaches the deferred-warning
+	// buffer so /swarm diagnose can surface it.
+	test('9. routes the created-config advisory to the deferred buffer (quiet=false)', () => {
 		writeProjectConfigIfNew(dir, false);
-		expect(warnOutput.some((m) => m.includes('opencode-swarm.json'))).toBe(
-			true,
-		);
+		expect(warnOutput).toHaveLength(0);
+		expect(
+			getDeferredWarnings().some((m) => m.includes('opencode-swarm.json')),
+		).toBe(true);
 	});
 });
 

--- a/tests/unit/plugin-tui-safety.test.ts
+++ b/tests/unit/plugin-tui-safety.test.ts
@@ -47,6 +47,30 @@ const TUI_SAFETY_SCOPES: Array<{
 		label: 'registry.ts',
 		quietTokens: ['!config.quiet', '!quiet'],
 	},
+	// PR2 of epic #1752 migrated these init-path modules to advisoryWarn/log.
+	// They must contain ZERO raw console.warn/error/log (the `noConsole` lint
+	// rule is deferred to PR5, so this static guard is the interim regression
+	// net). quietTokens: [] means findUnguardedWarns flags ANY console.warn.
+	{
+		file: 'src/config/loader.ts',
+		label: 'loader.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/agents/architect.ts',
+		label: 'architect.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/session/snapshot-reader.ts',
+		label: 'snapshot-reader.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/config/project-init.ts',
+		label: 'project-init.ts',
+		quietTokens: [],
+	},
 ];
 
 function readScope(file: string): string {
@@ -155,5 +179,34 @@ describe('Plugin TUI safety', () => {
 				0,
 			);
 		}
+	});
+
+	test('PR2-migrated init-path modules have zero raw console.warn (epic #1752)', () => {
+		// loader.ts, architect.ts, snapshot-reader.ts, project-init.ts were
+		// migrated to advisoryWarn/log in PR2. They must contain ZERO raw
+		// console.warn so the bubbletea TUI is never corrupted on the init
+		// path (issue #1249 class). This is the interim regression guard until
+		// PR5 enables Biome `noConsole` globally.
+		for (const scope of TUI_SAFETY_SCOPES) {
+			if (scope.quietTokens.length > 0) continue; // skip guarded-scope files
+			const src = readScope(scope.file);
+			const warnCount = (src.match(/console\.warn\(/g) || []).length;
+			expect(
+				warnCount,
+				`${scope.file} must contain zero raw console.warn after epic #1752 PR2 migration`,
+			).toBe(0);
+		}
+	});
+
+	test('gitignore-warning.ts has exactly one intentional raw console.warn (tracked-file security)', () => {
+		// src/utils/gitignore-warning.ts retains ONE intentionally-unguarded
+		// console.warn — the ".swarm/ files are tracked by Git" remediation
+		// warning (must-see-always security/hygiene). All other advisories in
+		// this file route through advisoryWarn. Assert the count is exactly 1
+		// and the comment rationale is present.
+		const src = readScope('src/utils/gitignore-warning.ts');
+		const warnMatches = src.match(/console\.warn\(/g) || [];
+		expect(warnMatches.length).toBe(1);
+		expect(src).toContain('INTENTIONALLY NOT gated behind quiet');
 	});
 });

--- a/tests/unit/services/warning-buffer.test.ts
+++ b/tests/unit/services/warning-buffer.test.ts
@@ -58,17 +58,34 @@ describe('deferred warning buffer', () => {
 		expect(getDeferredWarnings().length).toBe(0);
 	});
 
-	test('addDeferredWarning respects the MAX_DEFERRED_WARNINGS cap (50)', () => {
+	test('addDeferredWarning respects the MAX_DEFERRED_WARNINGS cap (50) with a truncation sentinel', () => {
+		// Epic #1752 PR2 review F-003: overflow must not silently drop
+		// advisories. The buffer reserves the last slot for a truncation
+		// sentinel so /swarm diagnose can tell the operator entries were
+		// dropped, rather than losing them without trace.
 		for (let i = 0; i < 60; i += 1) {
 			addDeferredWarning(`warning ${i}`);
 		}
 
 		const warnings = getDeferredWarnings();
+		// 49 real entries + 1 truncation sentinel = 50 total.
 		expect(warnings.length).toBe(50);
-		// The cap drops overflow entries silently; the last accepted entry is
-		// warning 49 (the 50th), not warning 59.
-		expect(warnings[49]).toBe('warning 49');
+		expect(warnings[48]).toBe('warning 48');
+		// The 50th slot is the sentinel, not warning 49.
+		expect(warnings[49]).toContain('additional advisories were dropped');
+		expect(warnings).not.toContain('warning 49');
 		expect(warnings).not.toContain('warning 59');
+	});
+
+	test('addDeferredWarning sentinel appears exactly once even if the cap is hit repeatedly', () => {
+		for (let i = 0; i < 80; i += 1) {
+			addDeferredWarning(`warning ${i}`);
+		}
+		const warnings = getDeferredWarnings();
+		const sentinels = warnings.filter((w) =>
+			w.includes('additional advisories were dropped'),
+		);
+		expect(sentinels.length).toBe(1);
 	});
 });
 

--- a/tests/unit/session/snapshot-reader-adversarial.test.ts
+++ b/tests/unit/session/snapshot-reader-adversarial.test.ts
@@ -4,7 +4,7 @@
  * Focus: Path traversal, malicious JSON, prototype pollution, edge cases.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import * as fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
@@ -230,6 +230,44 @@ describe('snapshot-reader ADVERSARIAL tests', () => {
 			await expect(rehydrateState(snapshot)).resolves.toBeUndefined();
 			// The null session should NOT appear in agentSessions
 			expect(swarmState.agentSessions.has('session1')).toBe(false);
+		});
+
+		it('routes the malformed-session skip to the debug-gated logger (epic #1752 PR2)', async () => {
+			// A non-null object missing required fields hits the `log()` skip
+			// path (snapshot-reader.ts:319), not the null guard. The skip must
+			// route through the debug-gated `log()` — NEVER raw console.warn —
+			// so 50 malformed sessions cannot flood /swarm diagnose or corrupt
+			// the TUI (issue #1249 class). Under OPENCODE_SWARM_DEBUG=1 the
+			// skip is observable via console.log; otherwise it is silent.
+			const originalDebug = process.env.OPENCODE_SWARM_DEBUG;
+			process.env.OPENCODE_SWARM_DEBUG = '1';
+			const logSpy = spyOn(console, 'log').mockImplementation(() => undefined);
+			try {
+				const snapshot: SnapshotData = {
+					version: 1,
+					writtenAt: Date.now(),
+					toolAggregates: {},
+					activeAgent: {},
+					delegationChains: {},
+					agentSessions: {
+						badSession: { agentName: 'orphan' } as any, // missing lastToolCallTime + delegationActive
+					},
+				};
+
+				await expect(rehydrateState(snapshot)).resolves.toBeUndefined();
+				expect(swarmState.agentSessions.has('badSession')).toBe(false);
+				// The skip was logged (debug-gated), referencing the session id.
+				expect(
+					logSpy.mock.calls.some((c) =>
+						String(c[0]).includes('Skipping malformed session badSession'),
+					),
+				).toBe(true);
+			} finally {
+				logSpy.mockRestore();
+				if (originalDebug === undefined)
+					delete process.env.OPENCODE_SWARM_DEBUG;
+				else process.env.OPENCODE_SWARM_DEBUG = originalDebug;
+			}
 		});
 
 		it('should filter out NaN keys in reviewerCallCount', async () => {


### PR DESCRIPTION
Closes #1753

## Summary

PR2 of epic #1752. Migrates every unguarded `console.warn` on the plugin-host init path (and its shared helpers, per the scoping decision) to the PR1 foundation helpers so they stop corrupting the bubbletea TUI (issue #1249 class).

- Actionable advisories (config errors, hygiene, unreadable prompts) → `advisoryWarn(msg)` — buffered for `/swarm diagnose` + debug-gated `log`. Never raw stderr.
- Purely diagnostic skips (malformed session snapshot) → `log(msg)` — debug-only, NOT buffered (would flood `/swarm diagnose`).
- The one intentionally-unguarded security warning (`.swarm/` tracked by Git) is kept as raw `console.warn` — must-see-always remediation.

### Scope decision (user-approved)
The issue said "async variants only," but the shared sanitize helpers (`sanitizeGatesConfig`, `sanitizeExternalSkillsConfig`, `migratePresetsConfig`) are reached by BOTH the async init path AND the sync turn-time `loadPluginConfig`. Per the user's decision, **all** loader.ts sites (sync + async + shared) were migrated for consistency — leaving a split delivery channel within a single function would be harder to maintain. The sync `loadPluginConfig` is only called by tools/commands at turn-time (not during `server()` init), but routing its warnings to the buffer is the epic's explicit goal (stop TUI corruption whenever it occurs).

### Source changes (5 files, 36 loader sites + 5 others)
- `src/config/loader.ts` — all 36 `console.warn` → `advisoryWarn`. Zod `error.format()` dumps go to the `data` arg (debug-only); the 7 SECURITY messages ("Falling back to safe defaults with guardrails ENABLED") emit as **separate** `advisoryWarn` calls so they reach the `/swarm diagnose` buffer.
- `src/agents/architect.ts:1836` — designer-reference warning → `advisoryWarn`.
- `src/session/snapshot-reader.ts:318` — malformed-session skip → `log` (printf `%s` interpolated into template literal).
- `src/config/project-init.ts:59` — created-config advisory → `advisoryWarn`; `quiet` param renamed `_quiet` (now a documented no-op).
- `src/utils/gitignore-warning.ts` — 2 cosmetic advisories (`.swarm/` not gitignored, Added to exclude) → `advisoryWarn`; site 359 (tracked-by-Git security) intentionally kept raw; `quiet` deprecated.

### Test changes (6 files)
- `tests/unit/config/loader.test.ts`, `src/agents/architect.designer-gate.test.ts`, `tests/unit/config/project-init.test.ts`, `tests/cli/writeProjectConfigIfNew.test.ts`, `tests/gitignore-warning.test.ts` — flipped `spyOn(console,'warn')` assertions to `getDeferredWarnings()` with `clearDeferredWarnings()` in `beforeEach`/`afterEach` (Invariant 7). Negative assertions stay on `warnSpy.not.toHaveBeenCalled()` (valid: advisoryWarn never touches console.warn).
- `tests/unit/plugin-tui-safety.test.ts` — extended `TUI_SAFETY_SCOPES` to regression-guard the 5 migrated files (zero raw `console.warn` except the one intentional tracked-file site in gitignore-warning.ts).
- `tests/unit/config/quiet-config.test.ts` — no change needed (asserts on `src/agents/index.ts`, out of scope); verified green.

## Invariant audit
- **1 (plugin init):** touched — warning delivery channel on the init path changed from raw stderr to buffered `advisoryWarn`/`log` (loader.ts, project-init.ts, gitignore-warning.ts, architect.ts are all init-reachable). `advisoryWarn` is O(1) sync buffer-push + debug-gated `log` — strictly lighter than the synchronous stderr `console.warn` it replaced, so no new init-path I/O/awaits/subprocesses and `withTimeout`/`queueMicrotask` wrapping is unchanged. Also moved `clearDeferredWarnings()` to the start of `initializeOpenCodeSwarm` (before config load) so config warnings survive to `/swarm diagnose` (review F-001) — reorder of an existing O(1) call, no new work.
- **2 (runtime portability):** touched trivially — `node --input-type=module -e "await import('./dist/index.js')"` loads (EXIT=0); bundle-portability + plugin-shape + node-load tests green. No new bun:/top-level imports; default export shape unchanged.
- **3 (subprocesses):** not touched.
- **4 (.swarm containment):** not touched.
- **5 (plan durability):** not touched.
- **6 (test_runner safety):** not touched (used shell loops + `bun test`, not `test_runner`).
- **7 (test writing):** touched — `bun:test` only; tests updated/strengthened, none deleted; `clearDeferredWarnings()` in `beforeEach` AND `afterEach` of every test touching the buffer; no `mock.module` used; `_quiet` uses Biome's `_` prefix convention.
- **8 (session state):** touched — the deferred-warning buffer is a module-level singleton cleared once per session at the start of `initializeOpenCodeSwarm` (`src/index.ts`, before config load). It is NOT keyed by sessionID (a known latent limitation tracked as review F-006, out of scope for this PR); isolation relies on the per-session clear. Added a truncation sentinel so overflow is surfaced rather than silently dropped (review F-003).
- **9 (guardrails/retry):** not touched.
- **10 (chat/system msg):** touched — THIS IS THE FIX (removes raw stderr noise per Invariant 10: "Do not emit diagnostic noise into chat-visible streams").
- **11 (tool registration):** not touched — no tool/command/agent/skill changes (drift check confirms).
- **12 (release/cache):** release fragment written (`docs/releases/pending/1753-tui-pollution-pr2-init-path.md`); no version/CHANGELOG edits (release-please owns those).

## Test plan
All commands run on branch `fix/issue-1753-tui-pollution-pr2-init-path` rebased onto `origin/main`.
```
$ bun test tests/unit/config/loader.test.ts tests/unit/config/project-init.test.ts tests/unit/config/quiet-config.test.ts tests/cli/writeProjectConfigIfNew.test.ts src/agents/architect.designer-gate.test.ts tests/gitignore-warning.test.ts tests/unit/session/snapshot-reader.test.ts tests/unit/session/snapshot-reader-adversarial.test.ts tests/unit/plugin-tui-safety.test.ts tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts tests/unit/build/bundle-node-load.test.ts --timeout 120000
213 pass, 0 fail, 505 expect() calls — Ran 213 tests across 12 files. [6.01s]

$ bun test tests/unit/config/ --timeout 120000
1597 pass, 0 fail, 4331 expect() calls

$ bunx @biomejs/biome@2.3.14 ci .; echo CI=$?
Checked 2419 files. No fixes applied. CI=0

$ bunx tsc --noEmit; echo TSC=$?
TSC=0

$ bun run build && node --input-type=module -e "await import('./dist/index.js')"; echo BUILD=$? LOAD=$?
BUILD=0  LOAD=0

$ bun run drift:check
✅ No drift detected across skills, tools, commands, agents, and docs claims.
```

Falsifiability verified: reverting the `architect.ts` migration causes 7 `getDeferredWarnings()` assertions to fail for the correct reason (buffer unpopulated); restoring passes.

## Reviewer/critic gates
- Independent implementation reviewer (GLM-5.2): NEEDS_REVISION → fixed 3 blocking items (missed test file `tests/cli/writeProjectConfigIfNew.test.ts`, biome import ordering, 7 collapsed SECURITY messages) → re-verified APPROVE.
- Final critic (GLM-5.2): APPROVE → addressed 2 non-blocking observations (extended `plugin-tui-safety.test.ts` regression guard, corrected release-fragment test-file count).
- Swarm PR feedback (8 items F-001..F-008): 3 VALID items fixed — **F-001** moved `clearDeferredWarnings()` before config load so config warnings reach `/swarm diagnose` (HIGH, was wiping the current session's buffered config warnings); **F-003** added truncation sentinel to the 50-entry buffer cap so overflow is surfaced, not silently dropped; **F-005** added snapshot-reader test proving the malformed-session skip routes through debug-gated `log()`. 5 items classified out-of-scope/pre-existing/intentional (see closure ledger in review comment). Independent reviewer (GLM-5.2) APPROVE + final critic (GLM-5.2) APPROVE on the feedback-fix diff.
