### PR TITLE
fix(gates): harden skill and evidence workflows

### DIFF
--- a/.opencode/skills/engineering-conventions/SKILL.md
+++ b/.opencode/skills/engineering-conventions/SKILL.md
@@ -149,6 +149,11 @@ A baseline captured post-edit silently encodes the very bugs the scan is meant
 to catch as "pre-existing," suppressing them indefinitely. This turns the SAST
 gate into theater.
 
+Baseline capture also requires at least one supported, existing file to be
+successfully scanned. Omitted, empty, or entirely unscannable `changed_files`
+returns `capture_baseline requires changed_files to produce a non-empty baseline`
+instead of reporting a successful no-op capture.
+
 ### How to use it
 
 1. Identify the files to scan. In a phase, use the union of declared task-scope

--- a/.opencode/skills/gate-attribution/SKILL.md
+++ b/.opencode/skills/gate-attribution/SKILL.md
@@ -35,6 +35,8 @@ no reviewed rows are parseable, attribution falls back to the single-task rule.
 4. **Collect + attribute:** Single-task lanes auto-attribute to their taskId; set-dispatch rows auto-attribute per parsed row.
 5. **Do NOT rely on prose summaries:** A batched dispatch without parseable rows is ambiguous and does not count per-task.
 
+Gate evidence is persisted independently as `.swarm/evidence/{taskId}.json` for each task. Passing set-dispatch rows cause the hook to write one task-scoped file per task; a single multi-task evidence file cannot satisfy any task.
+
 ## Optimization for trivial tasks
 For pure ceremony gates (1-line doc fix):
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1098,10 +1098,17 @@ The QA gate profile (per-plan, persisted in the project DB) controls which quali
 
 All gates are **ratchet-tighter** — once enabled they cannot be disabled until the profile is reset, and once locked (after critic approval) no changes are accepted at all.
 
+`test_engineer` is exempted for a coder task only when both its immutable
+declared scope and the observed Git changes are non-empty, contain exact
+case-sensitive `.md` final extensions, and the observed paths remain within
+the declaration. Missing Git provenance, mixed files, scope mismatches, legacy
+background records, and any non-`.md` path keep the full gate. `reviewer` and
+`council_mode` behavior are unchanged.
+
 | Gate | Default | Description |
 |------|---------|-------------|
 | `reviewer` | ON | Code review of coder output |
-| `test_engineer` | ON | Test verification of coder output |
+| `test_engineer` | ON | Test verification of coder output; automatically exempted only for proven exact `.md`-only tasks |
 | `sme_enabled` | ON | SME consultation during planning / clarification |
 | `critic_pre_plan` | ON | Critic review before plan finalization |
 | `sast_enabled` | ON | Static security scanning |

--- a/docs/engineering-invariants.md
+++ b/docs/engineering-invariants.md
@@ -511,7 +511,7 @@ Two failures motivated the automated check:
 
 | Category | What it checks | Source of truth |
 |---|---|---|
-| `skill-mirror` | `.opencode`↔`.claude` byte identity / divergence / adapter / opencode-only; unclassified both-tree pairs | `src/config/skill-mirrors.ts` (shared with `tests/unit/skills/skill-mirrors.test.ts`) |
+| `skill-mirror` | `.opencode`↔`.claude` byte identity / divergence / adapter / opencode-only; declared extra identical paths such as `.agents`; unclassified both-tree pairs | `src/config/skill-mirrors.ts` (shared with `tests/unit/skills/skill-mirrors.test.ts`) |
 | `bundled-skill` | `.opencode/skills/` ⊆ `BUNDLED_PROJECT_SKILLS`; no phantom entries; `package.json#files` coverage | `src/config/bundled-skills.ts`, `package.json` |
 | `skill-audience` | tracked static skills declare valid top-level audience metadata; generated lifecycle skills are excluded | static skill frontmatter parsed by `src/hooks/skill-scoring.ts` |
 | `tool` | metadata / handler / plugin-object / `TOOL_NAMES` / `AGENT_TOOL_MAP` coherence | reuses `scripts/check-tool-registration.ts` |

--- a/docs/engineering-invariants.md
+++ b/docs/engineering-invariants.md
@@ -316,6 +316,15 @@ if (!resolved) return { success: false, error: 'working_directory must resolve t
 
 - `grep -rn "process.cwd()" src/tools src/hooks` — every remaining match has a comment justifying it as a documented direct-CLI/test fallback.
 
+**Evidence trust boundary:** Runtime JSON under `.swarm/`, including
+`.swarm/evidence/{taskId}.json`, is durable audit and recovery state for
+cooperative agents running as the same OS user. Evidence writes are atomic and
+path-safe, but workspace files are not tamper-proof authorization records: a
+process with the same user's filesystem access can replace them. Treat gate
+evidence as trustworthy only within that cooperative-agent threat model. Strong
+integrity against a same-user adversarial process would require a protected
+trust root outside the workspace.
+
 **Session-reset worktree resilience (FR-004):** `.swarm-worktrees/` directories created by parallel lanes must be reconciled on session resume/reset. `provisionWorktree` in `src/worktree/core.ts` implements idempotent provisioning: if a branch exists but is not checked out in any active worktree, it is adopted; if it is active elsewhere, an error is returned. `reset-session.ts` wipes `.swarm-worktrees/` and orphan branches. The resume skill explicitly calls out reconciliation as the first step. This prevents stale worktrees from causing provisioning failures or silent git state corruption when a session resumes after reset.
 
 **Anti-pattern:**

--- a/docs/releases/pending/issue-1764-skill-tool-hardening.md
+++ b/docs/releases/pending/issue-1764-skill-tool-hardening.md
@@ -1,0 +1,31 @@
+# Skill infrastructure and QA tool hardening
+
+## What changed
+
+- Reject SAST baseline capture when no supported file was scanned, replacing a
+  successful-looking no-op with an explicit validation failure.
+- Exempt `test_engineer` only when immutable declared scope and observed Git
+  changes independently prove the same non-empty exact `.md`-only boundary.
+- Complete the `test-file-split` and `fork-pr-operations` skill wiring with
+  plugin audience metadata and enforced byte identity across OpenCode, Claude,
+  and Codex skill trees.
+- Document that gate evidence is persisted independently for every task in a
+  set-dispatch.
+
+## Why
+
+Issue #1764 identified a false-success SAST baseline response, unnecessary test
+delegations for proven documentation-only work, and incomplete cross-runtime
+skill contracts after the post-mortem skill additions.
+
+## Migration
+
+No migration is required.
+
+## Breaking changes
+
+None.
+
+## Known caveats
+
+None.

--- a/docs/releases/pending/issue-1764-skill-tool-hardening.md
+++ b/docs/releases/pending/issue-1764-skill-tool-hardening.md
@@ -28,4 +28,11 @@ None.
 
 ## Known caveats
 
-None.
+- The workspace snapshot's `dirtyHash` now includes Git's NUL-delimited (`-z`)
+  status encoding. During an upgrade, dirty in-flight background records created
+  by the previous encoding conservatively compare as stale and require the
+  affected Stage B gate to be re-dispatched; clean empty-status hashes are
+  unchanged.
+- `.swarm/evidence/{taskId}.json` is durable audit state for cooperative agents,
+  not tamper-proof authorization against a process with the same user's
+  workspace access.

--- a/scripts/drift-check.ts
+++ b/scripts/drift-check.ts
@@ -253,6 +253,25 @@ export function detectSkillMirrorDrift(root: string = REPO_ROOT): DriftFinding[]
 					message: `skill "${slug}" mirror drifted: ${opencodePath} and ${claudePath} must be byte-identical (canonical: ${contract.canonical ?? '.claude'})`,
 				});
 			}
+			for (const extraPath of contract.extraIdenticalPaths ?? []) {
+				if (!fileExists(extraPath)) {
+					findings.push({
+						category,
+						severity: 'error',
+						file: extraPath,
+						message: `skill "${slug}" missing extra identical mirror ${extraPath}`,
+					});
+					continue;
+				}
+				if (readFile(opencodePath) !== readFile(extraPath)) {
+					findings.push({
+						category,
+						severity: 'error',
+						file: extraPath,
+						message: `skill "${slug}" extra mirror drifted: ${opencodePath} and ${extraPath} must be byte-identical (canonical: ${contract.canonical ?? '.claude'})`,
+					});
+				}
+			}
 		} else if (kind === 'divergent') {
 			for (const p of [opencodePath, claudePath]) {
 				if (!fileExists(p)) {

--- a/src/background/pending-delegations.ts
+++ b/src/background/pending-delegations.ts
@@ -79,6 +79,8 @@ export interface BackgroundDelegationRecord {
 	promptHash?: string;
 	/** Project/root provenance captured at dispatch time. */
 	workspace?: BackgroundWorkspaceSnapshot;
+	/** Immutable pre-coder provenance for doc-only gate classification. */
+	taskChangeContext?: BackgroundTaskChangeContext;
 	prompt?: BackgroundPromptSnapshot;
 	generation?: number;
 	result?: BackgroundDelegationResult;
@@ -89,8 +91,14 @@ export interface BackgroundWorkspaceSnapshot {
 	directory: string;
 	gitHead: string | null;
 	dirtyHash: string | null;
+	changedFiles?: string[] | null;
 	prHeadSha: string | null;
 	scope: string | null;
+}
+
+export interface BackgroundTaskChangeContext {
+	declaredFiles: string[] | null;
+	baseline: BackgroundWorkspaceSnapshot;
 }
 
 export interface BackgroundPromptSnapshot {
@@ -135,8 +143,16 @@ const WorkspaceSchema = z
 		directory: z.string(),
 		gitHead: z.string().nullable(),
 		dirtyHash: z.string().nullable(),
+		changedFiles: z.array(z.string()).nullable().optional(),
 		prHeadSha: z.string().nullable(),
 		scope: z.string().nullable(),
+	})
+	.strict();
+
+const TaskChangeContextSchema = z
+	.object({
+		declaredFiles: z.array(z.string()).nullable(),
+		baseline: WorkspaceSchema,
 	})
 	.strict();
 
@@ -178,6 +194,7 @@ const RecordSchema = z
 		mode: z.string().optional(),
 		promptHash: z.string().optional(),
 		workspace: WorkspaceSchema.optional(),
+		taskChangeContext: TaskChangeContextSchema.optional(),
 		prompt: PromptSchema.optional(),
 		generation: z.number().optional(),
 		result: ResultSchema.optional(),
@@ -273,6 +290,7 @@ export interface RecordPendingInput {
 	mode?: string;
 	promptHash?: string;
 	workspace?: BackgroundWorkspaceSnapshot;
+	taskChangeContext?: BackgroundTaskChangeContext;
 	prompt?: BackgroundPromptSnapshot;
 	generation?: number;
 }
@@ -309,6 +327,9 @@ export async function recordPendingDelegation(
 		...(input.mode ? { mode: input.mode } : {}),
 		...(input.promptHash ? { promptHash: input.promptHash } : {}),
 		...(input.workspace ? { workspace: input.workspace } : {}),
+		...(input.taskChangeContext
+			? { taskChangeContext: input.taskChangeContext }
+			: {}),
 		...(input.prompt ? { prompt: input.prompt } : {}),
 		...(input.generation !== undefined ? { generation: input.generation } : {}),
 	};

--- a/src/background/stage-b-gates.ts
+++ b/src/background/stage-b-gates.ts
@@ -1,4 +1,9 @@
-import { recordAgentDispatch, recordGateEvidence } from '../gate-evidence.js';
+import {
+	readTaskEvidence,
+	recordAgentDispatch,
+	recordGateEvidence,
+} from '../gate-evidence.js';
+import { isMarkdownOnlyTaskChange } from '../gate-evidence-classification.js';
 import { collectReviewerReceiptFromTranscript } from '../hooks/review-receipt-collector.js';
 import {
 	type AgentSessionState,
@@ -16,6 +21,7 @@ import type {
 } from './pending-delegations.js';
 import {
 	captureWorkspaceSnapshot,
+	changedFilesSinceSnapshot,
 	compareWorkspaceSnapshots,
 } from './workspace-snapshot.js';
 
@@ -73,9 +79,39 @@ export async function ingestBackgroundStageBCompletion(args: {
 	result: BackgroundDelegationResult;
 }): Promise<StageBIngestionResult> {
 	const taskId = args.record.evidenceTaskId ?? args.record.planTaskId;
-	if (!taskId || !isBackgroundGateBearingRecord(args.record)) {
+	if (!taskId) {
 		// The trusted terminal completion is still settled in the durable ledger by
 		// the caller; it simply has no Stage B evidence/state side effects.
+		return { ok: true, consumed: false };
+	}
+
+	if (args.record.normalizedAgent === 'coder') {
+		const taskChangeContext = args.record.taskChangeContext;
+		const observedFiles = taskChangeContext
+			? changedFilesSinceSnapshot(
+					taskChangeContext.baseline.directory,
+					taskChangeContext.baseline,
+				)
+			: null;
+		try {
+			await recordAgentDispatch(args.directory, taskId, 'coder', undefined, {
+				testEngineerExempt: isMarkdownOnlyTaskChange(
+					taskChangeContext?.declaredFiles,
+					observedFiles,
+				),
+			});
+			return { ok: true, consumed: true };
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			return {
+				ok: false,
+				consumed: false,
+				reason: `background coder evidence ingestion failed: ${message}`,
+			};
+		}
+	}
+
+	if (!isBackgroundGateBearingRecord(args.record)) {
 		return { ok: true, consumed: false };
 	}
 
@@ -91,12 +127,16 @@ export async function ingestBackgroundStageBCompletion(args: {
 	}
 
 	try {
-		await recordAgentDispatch(
-			args.directory,
-			taskId,
-			stageBRequiredGateAgent(args.record.normalizedAgent),
-			hasActiveTurboMode(args.record.parentSessionId),
-		);
+		const existingEvidence = await readTaskEvidence(args.directory, taskId);
+		if (existingEvidence?.test_engineer_exempt !== true) {
+			// Legacy/missing coder provenance fails closed to the full Stage B pair.
+			await recordAgentDispatch(
+				args.directory,
+				taskId,
+				stageBRequiredGateAgent(args.record.normalizedAgent),
+				hasActiveTurboMode(args.record.parentSessionId),
+			);
+		}
 		await recordGateEvidence(
 			args.directory,
 			taskId,
@@ -122,6 +162,7 @@ export async function ingestBackgroundStageBCompletion(args: {
 				taskId,
 				args.record.normalizedAgent,
 				args.record.parentSessionId,
+				existingEvidence?.test_engineer_exempt === true,
 			);
 		}
 
@@ -150,13 +191,17 @@ function applyStageBStateCompletion(
 	taskId: string,
 	agent: StageBStateRole,
 	parentSessionId: string,
+	testEngineerExempt: boolean,
 ): void {
 	for (const session of candidateSessions(parentSessionId)) {
 		recordStageBCompletion(session, taskId, agent);
 		const state = getTaskState(session, taskId);
 		if (state === 'tests_run' || state === 'complete') continue;
 
-		if (hasBothStageBCompletions(session, taskId)) {
+		if (
+			hasBothStageBCompletions(session, taskId) ||
+			(testEngineerExempt && agent === 'reviewer')
+		) {
 			try {
 				if (state === 'coder_delegated' || state === 'pre_check_passed') {
 					advanceTaskState(session, taskId, 'reviewer_run', {

--- a/src/background/workspace-snapshot.ts
+++ b/src/background/workspace-snapshot.ts
@@ -31,6 +31,30 @@ function runGit(directory: string, args: string[]): string | null {
 	return typeof result.stdout === 'string' ? result.stdout.trimEnd() : null;
 }
 
+function parseNulPaths(output: string): string[] {
+	return output.split('\0').filter((entry) => entry.length > 0);
+}
+
+/** Parse `git status --porcelain=v1 -z`, including both sides of renames. */
+export function parsePorcelainPaths(output: string): string[] | null {
+	const entries = parseNulPaths(output);
+	const paths: string[] = [];
+	for (let index = 0; index < entries.length; index++) {
+		const entry = entries[index];
+		if (entry.length < 4 || entry[2] !== ' ') return null;
+		const status = entry.slice(0, 2);
+		const changedPath = entry.slice(3);
+		if (!changedPath) return null;
+		paths.push(changedPath);
+		if (status.includes('R') || status.includes('C')) {
+			const originalPath = entries[++index];
+			if (!originalPath) return null;
+			paths.push(originalPath);
+		}
+	}
+	return [...new Set(paths)];
+}
+
 export function captureWorkspaceSnapshot(
 	directory: string,
 	optionsOrScope: string | null | CaptureWorkspaceSnapshotOptions = null,
@@ -53,15 +77,51 @@ export function captureWorkspaceSnapshot(
 	const porcelain = runGit(directory, [
 		'status',
 		'--porcelain=v1',
+		'-z',
 		'--untracked-files=all',
 	]);
+	const changedFiles =
+		porcelain === null ? null : parsePorcelainPaths(porcelain);
 	return {
 		directory: path.resolve(directory),
 		gitHead,
 		dirtyHash: porcelain === null ? null : digest(porcelain),
+		changedFiles,
 		prHeadSha,
 		scope,
 	};
+}
+
+/**
+ * Conservatively derive final paths changed since a pre-task snapshot.
+ * Git or parsing failures return null so gate classification fails closed.
+ */
+export function changedFilesSinceSnapshot(
+	directory: string,
+	baseline: BackgroundWorkspaceSnapshot | undefined,
+): string[] | null {
+	if (!baseline?.gitHead || baseline.changedFiles == null) return null;
+	// A dirty baseline cannot prove which same-path edits belong to this task.
+	// Fail closed instead of treating unchanged pre-existing dirt as task output.
+	if (baseline.changedFiles.length > 0) return null;
+	const current = captureWorkspaceSnapshot(directory);
+	if (!current.gitHead || current.changedFiles == null) return null;
+
+	const changed = new Set(current.changedFiles);
+	if (baseline.gitHead !== current.gitHead) {
+		const committed = runGit(directory, [
+			'diff',
+			'--name-only',
+			'-z',
+			baseline.gitHead,
+			current.gitHead,
+		]);
+		if (committed === null) return null;
+		for (const changedPath of parseNulPaths(committed))
+			changed.add(changedPath);
+	}
+
+	return [...changed];
 }
 
 export function workspaceSnapshotMatches(

--- a/src/config/skill-mirrors.ts
+++ b/src/config/skill-mirrors.ts
@@ -211,7 +211,8 @@ export const OPENCODE_ONLY_ARCHITECT_MODE_SKILLS: Array<{
  * `kind`:
  *  - `identical`: `.opencode` and `.claude` SKILL.md must be byte-identical.
  *    `canonical` records which side wins when they drift (fix direction only;
- *    detection is symmetric).
+ *    detection is symmetric). `extraIdenticalPaths` narrowly extends the same
+ *    byte-identity contract to additional runtime mirrors when present.
  *  - `divergent`: both must exist; content intentionally differs per runtime.
  *  - `opencode-only`: `.opencode` exists; no `.claude` mirror expected.
  */
@@ -219,6 +220,7 @@ export const ADDITIONAL_SKILL_MIRROR_CONTRACTS: Array<{
 	slug: string;
 	kind: 'identical' | 'divergent' | 'opencode-only';
 	canonical?: '.claude' | '.opencode';
+	extraIdenticalPaths?: string[];
 	reason: string;
 }> = [
 	{
@@ -269,6 +271,7 @@ export const ADDITIONAL_SKILL_MIRROR_CONTRACTS: Array<{
 		slug: 'test-file-split',
 		kind: 'identical',
 		canonical: '.opencode',
+		extraIdenticalPaths: ['.agents/skills/test-file-split/SKILL.md'],
 		reason:
 			'Byte-identical across .opencode, .claude, and .agents trees; .opencode is the canonical source.',
 	},
@@ -276,6 +279,7 @@ export const ADDITIONAL_SKILL_MIRROR_CONTRACTS: Array<{
 		slug: 'fork-pr-operations',
 		kind: 'identical',
 		canonical: '.opencode',
+		extraIdenticalPaths: ['.agents/skills/fork-pr-operations/SKILL.md'],
 		reason:
 			'Byte-identical across .opencode, .claude, and .agents trees; .opencode is the canonical source.',
 	},

--- a/src/gate-evidence-classification.test.ts
+++ b/src/gate-evidence-classification.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
 	isExactMarkdownPath,
+	isMarkdownOnlyDeclaredScope,
 	isMarkdownOnlyTaskChange,
 } from './gate-evidence-classification';
 
@@ -47,6 +48,17 @@ describe('doc-only gate classification', () => {
 		expect(
 			isMarkdownOnlyTaskChange(['README.md'], ['README.md', 'docs/extra.md']),
 		).toBe(false);
+	});
+
+	test('cheap declared-scope pre-classification rejects ineligible tasks', () => {
+		expect(isMarkdownOnlyDeclaredScope(['README.md', 'docs/guide.md'])).toBe(
+			true,
+		);
+		expect(isMarkdownOnlyDeclaredScope([])).toBe(false);
+		expect(isMarkdownOnlyDeclaredScope(['README.md', 'src/code.ts'])).toBe(
+			false,
+		);
+		expect(isMarkdownOnlyDeclaredScope(null)).toBe(false);
 	});
 
 	test('fails closed for malformed runtime values', () => {

--- a/src/gate-evidence-classification.test.ts
+++ b/src/gate-evidence-classification.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	isExactMarkdownPath,
+	isMarkdownOnlyTaskChange,
+} from './gate-evidence-classification';
+
+describe('doc-only gate classification', () => {
+	test.each([
+		'README.md',
+		'docs/guide.md',
+		'docs\\windows.md',
+		'src/example.ts.md',
+	])('accepts exact final .md path %s', (candidate) => {
+		expect(isExactMarkdownPath(candidate)).toBe(true);
+	});
+
+	test.each([
+		'',
+		'.md',
+		'README.MD',
+		'README.Md',
+		'README.md ',
+		'README.md.exe',
+		'docs.md/file.ts',
+		'README.md:evil.ts',
+		'../README.md',
+		'./README.md',
+		'/tmp/README.md',
+		'C:\\tmp\\README.md',
+		'README.md\0.ts',
+	])('rejects non-exact or unsafe path %s', (candidate) => {
+		expect(isExactMarkdownPath(candidate)).toBe(false);
+	});
+
+	test('requires independent non-empty declared and observed proof', () => {
+		expect(
+			isMarkdownOnlyTaskChange(['README.md', 'docs/guide.md'], ['README.md']),
+		).toBe(true);
+		expect(isMarkdownOnlyTaskChange([], ['README.md'])).toBe(false);
+		expect(isMarkdownOnlyTaskChange(['README.md'], [])).toBe(false);
+		expect(isMarkdownOnlyTaskChange(['README.md'], ['src/code.ts'])).toBe(
+			false,
+		);
+		expect(
+			isMarkdownOnlyTaskChange(['README.md', 'src/code.ts'], ['README.md']),
+		).toBe(false);
+		expect(
+			isMarkdownOnlyTaskChange(['README.md'], ['README.md', 'docs/extra.md']),
+		).toBe(false);
+	});
+
+	test('fails closed for malformed runtime values', () => {
+		expect(isMarkdownOnlyTaskChange(null, ['README.md'])).toBe(false);
+		expect(isMarkdownOnlyTaskChange(['README.md'], 'README.md')).toBe(false);
+		expect(isMarkdownOnlyTaskChange(['README.md'], [42])).toBe(false);
+	});
+});

--- a/src/gate-evidence-classification.ts
+++ b/src/gate-evidence-classification.ts
@@ -1,0 +1,50 @@
+import * as path from 'node:path';
+
+function normalizeCandidate(value: unknown): string | null {
+	if (typeof value !== 'string' || value.length === 0) return null;
+	if (
+		[...value].some((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			return codePoint <= 0x1f || codePoint === 0x7f;
+		})
+	)
+		return null;
+	if (path.win32.isAbsolute(value) || path.posix.isAbsolute(value)) return null;
+	const normalized = value.replace(/\\/g, '/');
+	const segments = normalized.split('/');
+	if (
+		segments.some(
+			(segment) => segment === '' || segment === '.' || segment === '..',
+		)
+	) {
+		return null;
+	}
+	return normalized;
+}
+
+export function isExactMarkdownPath(value: unknown): boolean {
+	const normalized = normalizeCandidate(value);
+	return normalized !== null && path.posix.extname(normalized) === '.md';
+}
+
+/** Require independent non-empty declared and observed exact-.md proof. */
+export function isMarkdownOnlyTaskChange(
+	declaredFiles: unknown,
+	observedFiles: unknown,
+): boolean {
+	if (!Array.isArray(declaredFiles) || !Array.isArray(observedFiles))
+		return false;
+	if (declaredFiles.length === 0 || observedFiles.length === 0) return false;
+	if (!declaredFiles.every(isExactMarkdownPath)) return false;
+	if (!observedFiles.every(isExactMarkdownPath)) return false;
+
+	const declared = new Set(
+		declaredFiles
+			.map(normalizeCandidate)
+			.filter((value): value is string => value !== null),
+	);
+	return observedFiles.every((value) => {
+		const normalized = normalizeCandidate(value);
+		return normalized !== null && declared.has(normalized);
+	});
+}

--- a/src/gate-evidence-classification.ts
+++ b/src/gate-evidence-classification.ts
@@ -27,6 +27,13 @@ export function isExactMarkdownPath(value: unknown): boolean {
 	return normalized !== null && path.posix.extname(normalized) === '.md';
 }
 
+/** Cheap pre-classification used to avoid Git snapshots for ineligible tasks. */
+export function isMarkdownOnlyDeclaredScope(value: unknown): value is string[] {
+	return (
+		Array.isArray(value) && value.length > 0 && value.every(isExactMarkdownPath)
+	);
+}
+
 /** Require independent non-empty declared and observed exact-.md proof. */
 export function isMarkdownOnlyTaskChange(
 	declaredFiles: unknown,
@@ -34,8 +41,8 @@ export function isMarkdownOnlyTaskChange(
 ): boolean {
 	if (!Array.isArray(declaredFiles) || !Array.isArray(observedFiles))
 		return false;
-	if (declaredFiles.length === 0 || observedFiles.length === 0) return false;
-	if (!declaredFiles.every(isExactMarkdownPath)) return false;
+	if (!isMarkdownOnlyDeclaredScope(declaredFiles) || observedFiles.length === 0)
+		return false;
 	if (!observedFiles.every(isExactMarkdownPath)) return false;
 
 	const declared = new Set(

--- a/src/gate-evidence.doc-only.test.ts
+++ b/src/gate-evidence.doc-only.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	deriveRequiredGates,
+	readTaskEvidence,
+	recordAgentDispatch,
+} from './gate-evidence';
+
+describe('doc-only required gate persistence', () => {
+	let directory: string;
+
+	beforeEach(() => {
+		directory = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-gate-evidence-'));
+	});
+
+	afterEach(() => {
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+
+	test('trusted exemption requires reviewer but not test_engineer', async () => {
+		expect(deriveRequiredGates('coder', { testEngineerExempt: true })).toEqual([
+			'reviewer',
+		]);
+		await recordAgentDispatch(directory, '1.1', 'coder', false, {
+			testEngineerExempt: true,
+		});
+		const evidence = await readTaskEvidence(directory, '1.1');
+		expect(evidence?.required_gates).toEqual(['reviewer']);
+		expect(evidence?.test_engineer_exempt).toBe(true);
+	});
+
+	test('missing classification fails closed to the full pair', async () => {
+		await recordAgentDispatch(directory, '1.2', 'coder');
+		const evidence = await readTaskEvidence(directory, '1.2');
+		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+		expect(evidence?.test_engineer_exempt).toBe(false);
+	});
+
+	test('append-only evidence never downgrades an existing code task', async () => {
+		await recordAgentDispatch(directory, '1.3', 'coder');
+		await recordAgentDispatch(directory, '1.3', 'coder', false, {
+			testEngineerExempt: true,
+		});
+		const evidence = await readTaskEvidence(directory, '1.3');
+		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+		expect(evidence?.test_engineer_exempt).toBe(false);
+	});
+});

--- a/src/gate-evidence.ts
+++ b/src/gate-evidence.ts
@@ -9,6 +9,11 @@
  * Evidence files survive session restarts (unlike in-memory state).
  * Agents never write these files directly — only the hook does.
  * Gates are append-only: required_gates can only grow, never shrink.
+ *
+ * Threat boundary: this store provides atomic, path-contained durability and
+ * auditability for cooperative same-user agents. It is not tamper-proof
+ * authorization against a process with arbitrary same-user workspace access;
+ * that requires a protected trust root outside the project workspace.
  */
 
 import { mkdirSync, readFileSync, realpathSync } from 'node:fs';

--- a/src/gate-evidence.ts
+++ b/src/gate-evidence.ts
@@ -33,6 +33,8 @@ export interface TaskEvidence {
 	required_gates: string[];
 	gates: Record<string, GateEvidence>;
 	turbo?: boolean;
+	/** Durable proof that the coder dispatch was classified as exact Markdown-only. */
+	test_engineer_exempt?: boolean;
 }
 
 const GateEvidenceSchema = z
@@ -48,9 +50,15 @@ const TaskEvidenceSchema = z.object({
 	required_gates: z.array(z.string()).default([]),
 	gates: z.record(z.string(), GateEvidenceSchema),
 	turbo: z.boolean().optional(),
+	test_engineer_exempt: z.boolean().optional(),
 });
 
 export const DEFAULT_REQUIRED_GATES = ['reviewer', 'test_engineer'];
+
+export interface GateDerivationContext {
+	/** Trusted pre/post workspace classification; false/absent fails closed. */
+	testEngineerExempt?: boolean;
+}
 
 /**
  * Canonical task-id validation helper.
@@ -69,10 +77,15 @@ function assertValidTaskId(taskId: string): void {
  * Maps the first-dispatched agent type to the initial required_gates array.
  * Unknown agent types fall back to the safe default ["reviewer", "test_engineer"].
  */
-export function deriveRequiredGates(agentType: string): string[] {
+export function deriveRequiredGates(
+	agentType: string,
+	context: GateDerivationContext = {},
+): string[] {
 	switch (agentType) {
 		case 'coder':
-			return ['reviewer', 'test_engineer'];
+			return context.testEngineerExempt === true
+				? ['reviewer']
+				: ['reviewer', 'test_engineer'];
 		case 'docs':
 			return ['docs'];
 		case 'designer':
@@ -107,8 +120,9 @@ export function deriveRequiredGates(agentType: string): string[] {
 export function expandRequiredGates(
 	existingGates: string[],
 	newAgentType: string,
+	context: GateDerivationContext = {},
 ): string[] {
-	const newGates = deriveRequiredGates(newAgentType);
+	const newGates = deriveRequiredGates(newAgentType, context);
 	const combined = [...new Set([...(existingGates ?? []), ...newGates])];
 	return combined.sort();
 }
@@ -195,6 +209,7 @@ export async function recordGateEvidence(
 			taskId,
 			required_gates: requiredGates,
 			turbo: turbo === true ? true : existing?.turbo,
+			test_engineer_exempt: existing?.test_engineer_exempt,
 			gates: {
 				...(existing?.gates ?? {}),
 				[gate]: {
@@ -220,6 +235,7 @@ export async function recordAgentDispatch(
 	taskId: string,
 	agentType: string,
 	turbo?: boolean,
+	context: GateDerivationContext = {},
 ): Promise<void> {
 	assertValidTaskId(taskId);
 
@@ -234,13 +250,18 @@ export async function recordAgentDispatch(
 			throw error;
 		}
 		const requiredGates = existing
-			? expandRequiredGates(existing.required_gates, agentType)
-			: deriveRequiredGates(agentType);
+			? expandRequiredGates(existing.required_gates, agentType, context)
+			: deriveRequiredGates(agentType, context);
 
 		const updated: TaskEvidence = {
 			taskId,
 			required_gates: requiredGates,
 			turbo: turbo === true ? true : existing?.turbo,
+			test_engineer_exempt:
+				agentType === 'coder'
+					? context.testEngineerExempt === true &&
+						!requiredGates.includes('test_engineer')
+					: existing?.test_engineer_exempt,
 			gates: existing?.gates ?? {},
 		};
 

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -16,7 +16,10 @@ import {
 import type { PluginConfig } from '../config';
 import type { Phase, Plan, Task } from '../config/plan-schema';
 import { isKnownCanonicalRole, stripKnownSwarmPrefix } from '../config/schema';
-import { isMarkdownOnlyTaskChange } from '../gate-evidence-classification.js';
+import {
+	isMarkdownOnlyDeclaredScope,
+	isMarkdownOnlyTaskChange,
+} from '../gate-evidence-classification.js';
 import {
 	routeReviewForChanges,
 	shouldParallelizeReview,
@@ -1160,16 +1163,38 @@ export function createDelegationGateHook(
 		BackgroundTaskChangeContext
 	>();
 	const coderObservedFilesByCallID = new Map<string, string[] | null>();
+	const clearCoderTaskChangeContext = (callID: string): void => {
+		coderTaskChangeContextByCallID.delete(callID);
+		coderObservedFilesByCallID.delete(callID);
+	};
+	const rememberCoderObservedFiles = (
+		callID: string,
+		observedFiles: string[] | null,
+	): void => {
+		if (
+			!coderObservedFilesByCallID.has(callID) &&
+			coderObservedFilesByCallID.size >= MAX_PENDING_CODER_CHANGE_CONTEXTS
+		) {
+			const oldest = coderObservedFilesByCallID.keys().next().value;
+			if (oldest !== undefined) coderObservedFilesByCallID.delete(oldest);
+		}
+		coderObservedFilesByCallID.set(callID, observedFiles);
+	};
 	const rememberCoderTaskChangeContext = (
 		callID: string,
 		declaredFiles: string[] | null,
 		observationDirectory = directory,
 	): void => {
+		if (!isMarkdownOnlyDeclaredScope(declaredFiles)) {
+			clearCoderTaskChangeContext(callID);
+			return;
+		}
 		if (
+			!coderTaskChangeContextByCallID.has(callID) &&
 			coderTaskChangeContextByCallID.size >= MAX_PENDING_CODER_CHANGE_CONTEXTS
 		) {
 			const oldest = coderTaskChangeContextByCallID.keys().next().value;
-			if (oldest !== undefined) coderTaskChangeContextByCallID.delete(oldest);
+			if (oldest !== undefined) clearCoderTaskChangeContext(oldest);
 		}
 		coderTaskChangeContextByCallID.set(callID, {
 			declaredFiles,
@@ -1339,9 +1364,9 @@ export function createDelegationGateHook(
 		const incomingCoderTaskId = resolveDelegatedPlanTaskId(args, planTaskIds);
 
 		await assertPlanCriticApprovedForExecution(directory, plan);
-		rememberCoderTaskChangeContext(
-			input.callID,
-			getPlanTaskDeclaredFiles(plan, incomingCoderTaskId),
+		const incomingCoderDeclaredFiles = getPlanTaskDeclaredFiles(
+			plan,
+			incomingCoderTaskId,
 		);
 
 		// Reviewer gate: block coder re-delegation when a prior coder task awaits
@@ -1441,8 +1466,14 @@ export function createDelegationGateHook(
 			}
 		}
 
-		if (!plan) return;
-		if (!parallelModeActive) return;
+		if (!plan) {
+			clearCoderTaskChangeContext(input.callID);
+			return;
+		}
+		if (!parallelModeActive) {
+			rememberCoderTaskChangeContext(input.callID, incomingCoderDeclaredFiles);
+			return;
+		}
 
 		const resolvedTaskId = incomingCoderTaskId;
 		// FR-102: pass declared scope (from pending map populated by FILE: extraction
@@ -1470,9 +1501,13 @@ export function createDelegationGateHook(
 		if (standardDispatch) {
 			rememberCoderTaskChangeContext(
 				input.callID,
-				getPlanTaskDeclaredFiles(plan, incomingCoderTaskId),
+				incomingCoderDeclaredFiles,
 				standardDispatch.handle.worktreePath,
 			);
+		} else {
+			// Isolation may degrade to the project root; capture only after the
+			// provisioning attempt and before the upstream coder begins execution.
+			rememberCoderTaskChangeContext(input.callID, incomingCoderDeclaredFiles);
 		}
 	};
 
@@ -1822,7 +1857,7 @@ export function createDelegationGateHook(
 						);
 					}
 				}
-				coderTaskChangeContextByCallID.delete(input.callID);
+				clearCoderTaskChangeContext(input.callID);
 				if (storedArgs !== undefined) deleteStoredInputArgs(input.callID);
 				return;
 			}
@@ -1848,7 +1883,7 @@ export function createDelegationGateHook(
 					input.callID,
 				);
 				if (taskChangeContext) {
-					coderObservedFilesByCallID.set(
+					rememberCoderObservedFiles(
 						input.callID,
 						changedFilesSinceSnapshot(
 							taskChangeContext.baseline.directory,
@@ -2231,8 +2266,7 @@ export function createDelegationGateHook(
 					);
 				} finally {
 					if (stripKnownSwarmPrefix(subagentType) === 'coder') {
-						coderTaskChangeContextByCallID.delete(input.callID);
-						coderObservedFilesByCallID.delete(input.callID);
+						clearCoderTaskChangeContext(input.callID);
 					}
 				}
 			}

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -8,10 +8,15 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { ZodError, z } from 'zod';
-
+import type { BackgroundTaskChangeContext } from '../background/pending-delegations.js';
+import {
+	captureWorkspaceSnapshot,
+	changedFilesSinceSnapshot,
+} from '../background/workspace-snapshot.js';
 import type { PluginConfig } from '../config';
 import type { Phase, Plan, Task } from '../config/plan-schema';
 import { isKnownCanonicalRole, stripKnownSwarmPrefix } from '../config/schema';
+import { isMarkdownOnlyTaskChange } from '../gate-evidence-classification.js';
 import {
 	routeReviewForChanges,
 	shouldParallelizeReview,
@@ -624,6 +629,18 @@ function getPlanTaskStatus(plan: Plan, taskId: string): string | null {
 	return null;
 }
 
+function getPlanTaskDeclaredFiles(
+	plan: Plan | null,
+	taskId: string | null,
+): string[] | null {
+	if (!plan || !taskId) return null;
+	for (const phase of plan.phases) {
+		const task = phase.tasks.find((candidate) => candidate.id === taskId);
+		if (task) return [...task.files_touched];
+	}
+	return null;
+}
+
 function resolveDelegatedPlanTaskId(
 	args: Record<string, unknown>,
 	knownPlanTaskIds?: ReadonlySet<string>,
@@ -1137,6 +1154,28 @@ export function createDelegationGateHook(
 		(((config.hooks as Record<string, unknown> | undefined)
 			?.background_pending_timeout_minutes as number | undefined) ?? 30) *
 		60_000;
+	const MAX_PENDING_CODER_CHANGE_CONTEXTS = 128;
+	const coderTaskChangeContextByCallID = new Map<
+		string,
+		BackgroundTaskChangeContext
+	>();
+	const coderObservedFilesByCallID = new Map<string, string[] | null>();
+	const rememberCoderTaskChangeContext = (
+		callID: string,
+		declaredFiles: string[] | null,
+		observationDirectory = directory,
+	): void => {
+		if (
+			coderTaskChangeContextByCallID.size >= MAX_PENDING_CODER_CHANGE_CONTEXTS
+		) {
+			const oldest = coderTaskChangeContextByCallID.keys().next().value;
+			if (oldest !== undefined) coderTaskChangeContextByCallID.delete(oldest);
+		}
+		coderTaskChangeContextByCallID.set(callID, {
+			declaredFiles,
+			baseline: captureWorkspaceSnapshot(observationDirectory),
+		});
+	};
 
 	if (!enabled) {
 		return {
@@ -1300,6 +1339,10 @@ export function createDelegationGateHook(
 		const incomingCoderTaskId = resolveDelegatedPlanTaskId(args, planTaskIds);
 
 		await assertPlanCriticApprovedForExecution(directory, plan);
+		rememberCoderTaskChangeContext(
+			input.callID,
+			getPlanTaskDeclaredFiles(plan, incomingCoderTaskId),
+		);
 
 		// Reviewer gate: block coder re-delegation when a prior coder task awaits
 		// review. In parallel mode (parallelization_enabled), dispatching a coder
@@ -1423,6 +1466,14 @@ export function createDelegationGateHook(
 					? { taskId: resolvedTaskId, files: laneScope }
 					: undefined,
 		});
+		const standardDispatch = standardWorktreeByCallID.get(input.callID);
+		if (standardDispatch) {
+			rememberCoderTaskChangeContext(
+				input.callID,
+				getPlanTaskDeclaredFiles(plan, incomingCoderTaskId),
+				standardDispatch.handle.worktreePath,
+			);
+		}
 	};
 
 	// toolAfter: resets qaSkip fields and advances task states based on delegation type
@@ -1722,6 +1773,10 @@ export function createDelegationGateHook(
 								mergedArgs.prHeadSha ?? mergedArgs.pr_head_sha;
 							const prHeadSha =
 								typeof prHeadShaRaw === 'string' ? prHeadShaRaw : null;
+							const taskChangeContext =
+								stripKnownSwarmPrefix(subagentType) === 'coder'
+									? coderTaskChangeContextByCallID.get(input.callID)
+									: undefined;
 							await recordPendingDelegation(
 								directory,
 								{
@@ -1734,10 +1789,13 @@ export function createDelegationGateHook(
 									swarmPrefixedAgent: subagentType,
 									planTaskId: evidenceTaskId,
 									evidenceTaskId,
-									workspace: captureWorkspaceSnapshot(directory, {
-										prHeadSha,
-										scope,
-									}),
+									workspace: taskChangeContext
+										? { ...taskChangeContext.baseline, prHeadSha, scope }
+										: captureWorkspaceSnapshot(directory, {
+												prHeadSha,
+												scope,
+											}),
+									taskChangeContext,
 									prompt:
 										typeof mergedArgs.prompt === 'string'
 											? buildPromptSnapshot(
@@ -1764,6 +1822,7 @@ export function createDelegationGateHook(
 						);
 					}
 				}
+				coderTaskChangeContextByCallID.delete(input.callID);
 				if (storedArgs !== undefined) deleteStoredInputArgs(input.callID);
 				return;
 			}
@@ -1785,6 +1844,18 @@ export function createDelegationGateHook(
 			}
 
 			if (standardDispatch) {
+				const taskChangeContext = coderTaskChangeContextByCallID.get(
+					input.callID,
+				);
+				if (taskChangeContext) {
+					coderObservedFilesByCallID.set(
+						input.callID,
+						changedFilesSinceSnapshot(
+							taskChangeContext.baseline.directory,
+							taskChangeContext.baseline,
+						),
+					);
+				}
 				// SC-115: Move from active → awaiting-merge BEFORE calling merge-back.
 				// The dispatch is removed from standardWorktreeByCallID here and
 				// added to awaitingMergeByCallID so /swarm lanes can show the real state.
@@ -1889,6 +1960,7 @@ export function createDelegationGateHook(
 							// to prevent over-attribution. When no verdicts are parseable, iterate
 							// over all eligible tasks (existing fallback behavior).
 
+							const { readTaskEvidence } = await import('../gate-evidence');
 							for (const [taskId, state] of session.taskWorkflowStates) {
 								if (
 									!(stageBEligibleStates as readonly string[]).includes(state)
@@ -1926,7 +1998,14 @@ export function createDelegationGateHook(
 									}
 								}
 
-								if (hasBothStageBCompletions(session, taskId)) {
+								const taskEvidence = await readTaskEvidence(directory, taskId);
+								const reviewerCompletesStageB =
+									targetAgent === 'reviewer' &&
+									taskEvidence?.test_engineer_exempt === true;
+								if (
+									hasBothStageBCompletions(session, taskId) ||
+									reviewerCompletesStageB
+								) {
 									// Barrier reached: both reviewer and test_engineer have completed.
 									// Advance through reviewer_run → tests_run in a single compound
 									// step so the state machine stays consistent.
@@ -1985,6 +2064,13 @@ export function createDelegationGateHook(
 							// in every other session would contaminate unrelated tasks.
 							const seedTaskId = getSeedTaskId(session);
 							if (seedTaskId) {
+								const seedEvidence = await readTaskEvidence(
+									directory,
+									seedTaskId,
+								);
+								const reviewerCompletesSeedStageB =
+									targetAgent === 'reviewer' &&
+									seedEvidence?.test_engineer_exempt === true;
 								for (const [, otherSession] of swarmState.agentSessions) {
 									if (otherSession === session) continue;
 									if (!otherSession.taskWorkflowStates) continue;
@@ -2012,7 +2098,10 @@ export function createDelegationGateHook(
 										seedTaskId,
 										targetAgent as 'reviewer' | 'test_engineer',
 									);
-									if (hasBothStageBCompletions(otherSession, seedTaskId)) {
+									if (
+										hasBothStageBCompletions(otherSession, seedTaskId) ||
+										reviewerCompletesSeedStageB
+									) {
 										try {
 											if (
 												seedEligibleState === 'coder_delegated' ||
@@ -2108,11 +2197,30 @@ export function createDelegationGateHook(
 							);
 						} else {
 							const { recordAgentDispatch } = await import('../gate-evidence');
+							const taskChangeContext =
+								targetAgentForEvidence === 'coder'
+									? coderTaskChangeContextByCallID.get(input.callID)
+									: undefined;
+							const observedFiles = taskChangeContext
+								? (coderObservedFilesByCallID.get(input.callID) ??
+									changedFilesSinceSnapshot(
+										taskChangeContext.baseline.directory,
+										taskChangeContext.baseline,
+									))
+								: null;
 							await recordAgentDispatch(
 								directory,
 								evidenceTaskId,
 								targetAgentForEvidence,
 								turbo,
+								{
+									testEngineerExempt:
+										targetAgentForEvidence === 'coder' &&
+										isMarkdownOnlyTaskChange(
+											taskChangeContext?.declaredFiles,
+											observedFiles,
+										),
+								},
 							);
 						}
 					}
@@ -2121,6 +2229,11 @@ export function createDelegationGateHook(
 					console.warn(
 						`[delegation-gate] evidence recording failed: ${err instanceof Error ? err.message : String(err)}`,
 					);
+				} finally {
+					if (stripKnownSwarmPrefix(subagentType) === 'coder') {
+						coderTaskChangeContextByCallID.delete(input.callID);
+						coderObservedFilesByCallID.delete(input.callID);
+					}
 				}
 			}
 

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -2057,3 +2057,7 @@ export const phase_complete: ToolDefinition = createSwarmTool({
 		);
 	},
 });
+
+export const _test_exports = {
+	allCompletedTasksHavePassedGateEvidence,
+};

--- a/src/tools/sast-scan.ts
+++ b/src/tools/sast-scan.ts
@@ -52,6 +52,8 @@ export interface SastScanInput {
 export interface SastScanResult {
 	/** Overall verdict: pass if no findings above threshold, fail otherwise */
 	verdict: EvidenceVerdict;
+	/** Validation error when the requested scan cannot safely run */
+	error?: string;
 	/** Array of security findings */
 	findings: SastScanFinding[];
 	/** Summary information */
@@ -438,8 +440,8 @@ export async function sastScan(
 	}
 
 	// ── Capture mode ─────────────────────────────────────────────────────────
-	// Records a baseline snapshot WITHOUT applying severity_threshold and WITHOUT
-	// the zero-coverage-fail invariant (capturing nothing is legitimate).
+	// Records a baseline snapshot WITHOUT applying severity_threshold. A scan of
+	// supported files with zero findings is legitimate; scanning zero files is not.
 	if (capture_baseline) {
 		if (phase === undefined || !Number.isInteger(phase) || phase < 1) {
 			// Capture without a valid phase is a hard error
@@ -456,6 +458,22 @@ export async function sastScan(
 				},
 			};
 			return errorResult;
+		}
+
+		if (scannedFilePaths.length === 0) {
+			const finalFindings = allFindings.slice(0, MAX_FINDINGS);
+			return {
+				verdict: 'fail',
+				error:
+					'capture_baseline requires changed_files to produce a non-empty baseline',
+				findings: finalFindings,
+				summary: {
+					engine,
+					files_scanned: filesScanned,
+					findings_count: finalFindings.length,
+					findings_by_severity: countBySeverity(finalFindings),
+				},
+			};
 		}
 
 		// Use raised cap for baseline capture so mediums/lows aren't silently lost.

--- a/tests/unit/background/pending-delegations.test.ts
+++ b/tests/unit/background/pending-delegations.test.ts
@@ -63,6 +63,34 @@ describe('pending-delegations store', () => {
 		).toBe(true);
 	});
 
+	it('round-trips immutable coder task-change provenance', async () => {
+		const baseline = {
+			directory: dir,
+			gitHead: 'abc123',
+			dirtyHash: 'clean-hash',
+			changedFiles: [],
+			prHeadSha: null,
+			scope: '1.1',
+		};
+		await recordPendingDelegation(
+			dir,
+			input({
+				normalizedAgent: 'coder',
+				swarmPrefixedAgent: 'coder',
+				taskChangeContext: {
+					declaredFiles: ['README.md'],
+					baseline,
+				},
+			}),
+		);
+
+		const restored = readDelegations(dir)[0];
+		expect(restored.taskChangeContext).toEqual({
+			declaredFiles: ['README.md'],
+			baseline,
+		});
+	});
+
 	it('returns empty for a missing store (no throw)', () => {
 		expect(readDelegations(dir)).toEqual([]);
 		expect(findByCorrelationId(dir, 'nope')).toBeNull();

--- a/tests/unit/background/stage-b-doc-only.test.ts
+++ b/tests/unit/background/stage-b-doc-only.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { BackgroundDelegationRecord } from '../../../src/background/pending-delegations';
+import { ingestBackgroundStageBCompletion } from '../../../src/background/stage-b-gates';
+import { captureWorkspaceSnapshot } from '../../../src/background/workspace-snapshot';
+import {
+	readTaskEvidence,
+	recordGateEvidence,
+} from '../../../src/gate-evidence';
+import {
+	resetSwarmState,
+	startAgentSession,
+	swarmState,
+} from '../../../src/state';
+
+function git(directory: string, args: string[]): void {
+	const result = spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdio: 'pipe',
+		encoding: 'utf-8',
+		timeout: 5_000,
+		maxBuffer: 128 * 1024,
+	});
+	if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+}
+
+function record(
+	agent: string,
+	taskId: string,
+	workspace = captureWorkspaceSnapshot(testDirectory),
+): BackgroundDelegationRecord {
+	return {
+		schemaVersion: 1,
+		correlationId: `${agent}-${taskId}`,
+		jobId: null,
+		subagentSessionId: `${agent}-session`,
+		parentSessionId: 'parent-session',
+		callID: `${agent}-call`,
+		normalizedAgent: agent,
+		swarmPrefixedAgent: agent,
+		planTaskId: taskId,
+		evidenceTaskId: taskId,
+		status: 'completed',
+		createdAt: 1,
+		updatedAt: 2,
+		workspace,
+	};
+}
+
+let testDirectory = '';
+
+describe('background doc-only gate evidence', () => {
+	beforeEach(() => {
+		resetSwarmState();
+		testDirectory = fs.mkdtempSync(
+			path.join(os.tmpdir(), 'background-doc-gate-'),
+		);
+		git(testDirectory, ['init']);
+		git(testDirectory, ['config', 'user.email', 'tests@example.com']);
+		git(testDirectory, ['config', 'user.name', 'Tests']);
+		fs.writeFileSync(path.join(testDirectory, 'base.txt'), 'base\n');
+		git(testDirectory, ['add', 'base.txt']);
+		git(testDirectory, ['commit', '-m', 'test: seed repository']);
+		startAgentSession('parent-session', 'architect');
+	});
+
+	afterEach(() => {
+		resetSwarmState();
+		fs.rmSync(testDirectory, { recursive: true, force: true });
+	});
+
+	test('coder provenance makes reviewer-only evidence durable', async () => {
+		swarmState.agentSessions
+			.get('parent-session')
+			?.taskWorkflowStates?.set('1.1', 'coder_delegated');
+		const baseline = captureWorkspaceSnapshot(testDirectory);
+		fs.writeFileSync(path.join(testDirectory, 'README.md'), '# docs\n');
+		const coder = record('coder', '1.1', baseline);
+		coder.taskChangeContext = { declaredFiles: ['README.md'], baseline };
+
+		expect(
+			(
+				await ingestBackgroundStageBCompletion({
+					directory: testDirectory,
+					record: coder,
+					result: { text: 'done', chars: 4, truncated: false, digest: 'coder' },
+				})
+			).consumed,
+		).toBe(true);
+
+		const reviewer = record('reviewer', '1.1');
+		await ingestBackgroundStageBCompletion({
+			directory: testDirectory,
+			record: reviewer,
+			result: { text: 'pass', chars: 4, truncated: false, digest: 'reviewer' },
+		});
+		const evidence = await readTaskEvidence(testDirectory, '1.1');
+		expect(evidence?.required_gates).toEqual(['reviewer']);
+		expect(evidence?.gates.reviewer).toBeDefined();
+		expect(
+			swarmState.agentSessions
+				.get('parent-session')
+				?.taskWorkflowStates?.get('1.1'),
+		).toBe('tests_run');
+	});
+
+	test('prior non-coder evidence cannot suppress the full coder gates', async () => {
+		await recordGateEvidence(testDirectory, '1.5', 'critic', 'critic-session');
+		const reviewer = record('reviewer', '1.5');
+		await ingestBackgroundStageBCompletion({
+			directory: testDirectory,
+			record: reviewer,
+			result: { text: 'pass', chars: 4, truncated: false, digest: 'reviewer' },
+		});
+
+		const evidence = await readTaskEvidence(testDirectory, '1.5');
+		expect(evidence?.required_gates).toContain('test_engineer');
+		expect(evidence?.test_engineer_exempt).not.toBe(true);
+	});
+
+	test('background coder observes its captured linked-worktree directory', async () => {
+		const worktree = `${testDirectory}-linked`;
+		git(testDirectory, [
+			'worktree',
+			'add',
+			'-b',
+			'docs-lane',
+			worktree,
+			'HEAD',
+		]);
+		try {
+			const baseline = captureWorkspaceSnapshot(worktree);
+			fs.writeFileSync(path.join(worktree, 'README.md'), '# linked docs\n');
+			const coder = record('coder', '1.6', baseline);
+			coder.taskChangeContext = { declaredFiles: ['README.md'], baseline };
+
+			await ingestBackgroundStageBCompletion({
+				directory: testDirectory,
+				record: coder,
+				result: { text: 'done', chars: 4, truncated: false, digest: 'linked' },
+			});
+			const evidence = await readTaskEvidence(testDirectory, '1.6');
+			expect(evidence?.test_engineer_exempt).toBe(true);
+		} finally {
+			git(testDirectory, ['worktree', 'remove', '--force', worktree]);
+		}
+	});
+
+	test('legacy reviewer completion without coder provenance fails closed', async () => {
+		const reviewer = record('reviewer', '1.2');
+		await ingestBackgroundStageBCompletion({
+			directory: testDirectory,
+			record: reviewer,
+			result: { text: 'pass', chars: 4, truncated: false, digest: 'legacy' },
+		});
+		const evidence = await readTaskEvidence(testDirectory, '1.2');
+		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+	});
+
+	test('immutable code declaration cannot be downgraded by later plan changes', async () => {
+		const baseline = captureWorkspaceSnapshot(testDirectory);
+		fs.mkdirSync(path.join(testDirectory, '.swarm'), { recursive: true });
+		fs.writeFileSync(
+			path.join(testDirectory, '.swarm', 'plan.json'),
+			JSON.stringify({ files_touched: ['README.md'] }),
+		);
+		fs.writeFileSync(path.join(testDirectory, 'README.md'), '# docs\n');
+		const coder = record('coder', '1.3', baseline);
+		coder.taskChangeContext = { declaredFiles: ['src/code.ts'], baseline };
+
+		await ingestBackgroundStageBCompletion({
+			directory: testDirectory,
+			record: coder,
+			result: { text: 'done', chars: 4, truncated: false, digest: 'immutable' },
+		});
+		const evidence = await readTaskEvidence(testDirectory, '1.3');
+		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+	});
+
+	test('observed code beside docs prevents cross-task exemption', async () => {
+		const baseline = captureWorkspaceSnapshot(testDirectory);
+		fs.writeFileSync(path.join(testDirectory, 'README.md'), '# docs\n');
+		fs.writeFileSync(
+			path.join(testDirectory, 'code.ts'),
+			'export const x = 1;\n',
+		);
+		const coder = record('coder', '1.4', baseline);
+		coder.taskChangeContext = {
+			declaredFiles: ['README.md', 'code.ts'],
+			baseline,
+		};
+
+		await ingestBackgroundStageBCompletion({
+			directory: testDirectory,
+			record: coder,
+			result: { text: 'done', chars: 4, truncated: false, digest: 'mixed' },
+		});
+		const evidence = await readTaskEvidence(testDirectory, '1.4');
+		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+	});
+});

--- a/tests/unit/background/stage-b-doc-only.test.ts
+++ b/tests/unit/background/stage-b-doc-only.test.ts
@@ -202,4 +202,30 @@ describe('background doc-only gate evidence', () => {
 		const evidence = await readTaskEvidence(testDirectory, '1.4');
 		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
 	});
+
+	describe('regression: dirty background baseline fails closed (F-005)', () => {
+		test('requires both gates when a declared Markdown path was already dirty', async () => {
+			fs.writeFileSync(
+				path.join(testDirectory, 'README.md'),
+				'# pre-existing\n',
+			);
+			const baseline = captureWorkspaceSnapshot(testDirectory);
+			expect(baseline.changedFiles).toEqual(['README.md']);
+			fs.writeFileSync(path.join(testDirectory, 'README.md'), '# later docs\n');
+			const coder = record('coder', '1.7', baseline);
+			coder.taskChangeContext = { declaredFiles: ['README.md'], baseline };
+
+			// A dirty baseline cannot attribute same-path changes to this coder. An
+			// exemption here would turn pre-existing workspace dirt into trusted proof.
+			await ingestBackgroundStageBCompletion({
+				directory: testDirectory,
+				record: coder,
+				result: { text: 'done', chars: 4, truncated: false, digest: 'dirty' },
+			});
+
+			const evidence = await readTaskEvidence(testDirectory, '1.7');
+			expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+			expect(evidence?.test_engineer_exempt).not.toBe(true);
+		});
+	});
 });

--- a/tests/unit/background/workspace-snapshot-doc-only.test.ts
+++ b/tests/unit/background/workspace-snapshot-doc-only.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	captureWorkspaceSnapshot,
+	changedFilesSinceSnapshot,
+	parsePorcelainPaths,
+} from '../../../src/background/workspace-snapshot';
+
+function git(directory: string, args: string[]): void {
+	const result = spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdio: 'pipe',
+		encoding: 'utf-8',
+		timeout: 5_000,
+		maxBuffer: 128 * 1024,
+	});
+	if (result.status !== 0) {
+		throw new Error(
+			result.stderr || result.stdout || `git ${args.join(' ')} failed`,
+		);
+	}
+}
+
+describe('task workspace change observation', () => {
+	let directory: string;
+
+	beforeEach(() => {
+		directory = fs.mkdtempSync(path.join(os.tmpdir(), 'task-change-snapshot-'));
+		git(directory, ['init']);
+		git(directory, ['config', 'user.email', 'tests@example.com']);
+		git(directory, ['config', 'user.name', 'Tests']);
+		fs.writeFileSync(path.join(directory, 'base.txt'), 'base\n');
+		git(directory, ['add', 'base.txt']);
+		git(directory, ['commit', '-m', 'test: seed repository']);
+	});
+
+	afterEach(() => {
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+
+	test('parses tracked, untracked, and rename porcelain paths', () => {
+		expect(
+			parsePorcelainPaths(' M README.md\0?? docs/new.md\0R  new.md\0old.md\0'),
+		).toEqual(['README.md', 'docs/new.md', 'new.md', 'old.md']);
+		expect(parsePorcelainPaths('malformed\0')).toBeNull();
+	});
+
+	test('observes uncommitted and committed paths since the baseline', () => {
+		const baseline = captureWorkspaceSnapshot(directory);
+		expect(baseline.changedFiles).toEqual([]);
+
+		fs.writeFileSync(path.join(directory, 'README.md'), '# docs\n');
+		expect(changedFilesSinceSnapshot(directory, baseline)).toEqual([
+			'README.md',
+		]);
+
+		git(directory, ['add', 'README.md']);
+		git(directory, ['commit', '-m', 'docs: add readme']);
+		expect(changedFilesSinceSnapshot(directory, baseline)).toEqual([
+			'README.md',
+		]);
+	});
+
+	test('fails closed when the baseline is already dirty', () => {
+		fs.writeFileSync(path.join(directory, 'src.ts'), 'export const x = 1;\n');
+		const baseline = captureWorkspaceSnapshot(directory);
+		fs.writeFileSync(path.join(directory, 'README.md'), '# docs\n');
+
+		expect(changedFilesSinceSnapshot(directory, baseline)).toBeNull();
+	});
+
+	test('does not treat unchanged pre-existing Markdown dirt as task output', () => {
+		fs.writeFileSync(path.join(directory, 'README.md'), '# pre-existing\n');
+		const baseline = captureWorkspaceSnapshot(directory);
+
+		expect(changedFilesSinceSnapshot(directory, baseline)).toBeNull();
+	});
+
+	test('keeps tracked non-Markdown files under .swarm visible', () => {
+		fs.mkdirSync(path.join(directory, '.swarm'), { recursive: true });
+		fs.writeFileSync(
+			path.join(directory, '.swarm', 'payload.ts'),
+			'export {};\n',
+		);
+		git(directory, ['add', '.swarm/payload.ts']);
+		git(directory, ['commit', '-m', 'test: track swarm payload']);
+		const baseline = captureWorkspaceSnapshot(directory);
+
+		fs.writeFileSync(path.join(directory, 'README.md'), '# docs\n');
+		fs.writeFileSync(
+			path.join(directory, '.swarm', 'payload.ts'),
+			'export const unsafe = true;\n',
+		);
+		expect(new Set(changedFilesSinceSnapshot(directory, baseline))).toEqual(
+			new Set(['README.md', '.swarm/payload.ts']),
+		);
+	});
+});

--- a/tests/unit/hooks/delegation-gate-doc-only-evidence.test.ts
+++ b/tests/unit/hooks/delegation-gate-doc-only-evidence.test.ts
@@ -3,9 +3,13 @@ import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { _internals as workspaceSnapshotInternals } from '../../../src/background/workspace-snapshot';
 import type { Plan } from '../../../src/config/plan-schema';
 import { readTaskEvidence } from '../../../src/gate-evidence';
-import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import {
+	createDelegationGateHook,
+	_internals as delegationGateInternals,
+} from '../../../src/hooks/delegation-gate';
 import {
 	resetSwarmState,
 	startAgentSession,
@@ -61,6 +65,7 @@ function makePlan(filesTouched: string[]): Plan {
 
 describe('delegation gate doc-only durable evidence', () => {
 	let directory: string;
+	const originalWorkspaceSpawnSync = workspaceSnapshotInternals.spawnSync;
 
 	beforeEach(() => {
 		resetSwarmState();
@@ -80,6 +85,9 @@ describe('delegation gate doc-only durable evidence', () => {
 	});
 
 	afterEach(() => {
+		workspaceSnapshotInternals.spawnSync = originalWorkspaceSpawnSync;
+		delegationGateInternals.resetStandardWorktreeIsolationState();
+		swarmState.opencodeClient = undefined;
 		resetSwarmState();
 		fs.rmSync(directory, { recursive: true, force: true });
 	});
@@ -177,5 +185,129 @@ describe('delegation gate doc-only durable evidence', () => {
 		await runCoder(['README.md'], ['README.md', 'src/undeclared.ts']);
 		const evidence = await readTaskEvidence(directory, '1.1');
 		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+	});
+
+	describe('regression: snapshot work is limited to exemption candidates (F-002)', () => {
+		test('non-Markdown declared scope performs no workspace snapshot Git calls', async () => {
+			const plan = makePlan(['src/code.ts']);
+			fs.writeFileSync(
+				path.join(directory, '.swarm', 'plan.json'),
+				JSON.stringify(plan, null, 2),
+			);
+			await recordPlanCriticApproval(directory, plan);
+			const hook = createDelegationGateHook(makeConfig(), directory);
+			let snapshotSpawnCalls = 0;
+			workspaceSnapshotInternals.spawnSync = ((..._args: unknown[]) => {
+				snapshotSpawnCalls++;
+				throw new Error('non-Markdown dispatch must not capture a snapshot');
+			}) as typeof workspaceSnapshotInternals.spawnSync;
+
+			// Before F-002, every coder dispatch synchronously captured HEAD and status,
+			// so this seam threw before toolBefore could complete.
+			await hook.toolBefore(
+				{
+					tool: 'Task',
+					sessionID: 'architect-session',
+					callID: 'non-doc-coder-call',
+				},
+				{
+					args: {
+						subagent_type: 'coder',
+						task_id: '1.1',
+						prompt: 'TASK: 1.1\nImplement the approved code task.',
+					},
+				},
+			);
+
+			expect(snapshotSpawnCalls).toBe(0);
+		});
+	});
+
+	describe('regression: foreground standard-worktree evidence (F-003)', () => {
+		test('observes the lane before merge rather than project-root changes', async () => {
+			const plan = makePlan(['README.md']);
+			plan.execution_profile = {
+				parallelization_enabled: true,
+				max_concurrent_tasks: 2,
+				council_parallel: true,
+				locked: true,
+				auto_proceed: false,
+			};
+			fs.writeFileSync(
+				path.join(directory, '.swarm', 'plan.json'),
+				JSON.stringify(plan, null, 2),
+			);
+			await recordPlanCriticApproval(directory, plan);
+
+			swarmState.opencodeClient = {
+				session: {
+					create: async () => ({ data: { id: 'foreground-lane-session' } }),
+				},
+			} as never;
+			const originalProvisionWorktree =
+				delegationGateInternals.provisionWorktree;
+			let lanePath: string | undefined;
+			delegationGateInternals.provisionWorktree = async (...args) => {
+				const result = await originalProvisionWorktree(...args);
+				if ('worktreePath' in result) lanePath = result.worktreePath;
+				return result;
+			};
+			const hook = createDelegationGateHook(
+				makeConfig({ worktree: { policy: 'auto', merge_strategy: 'merge' } }),
+				directory,
+			);
+			const args = {
+				subagent_type: 'coder',
+				task_id: '1.1',
+				prompt: 'TASK: 1.1\nUpdate the approved documentation.',
+			};
+
+			try {
+				await hook.toolBefore(
+					{
+						tool: 'Task',
+						sessionID: 'architect-session',
+						callID: 'worktree-doc-coder-call',
+					},
+					{ args },
+				);
+				expect(lanePath).toBeDefined();
+
+				fs.writeFileSync(path.join(lanePath!, 'README.md'), '# lane docs\n');
+				fs.mkdirSync(path.join(directory, 'src'), { recursive: true });
+				fs.writeFileSync(
+					path.join(directory, 'src', 'root-only.ts'),
+					'export const rootOnly = true;\n',
+				);
+
+				// Before F-003, observing the project root here sees root-only.ts and
+				// fails closed. The lane itself contains exactly the declared Markdown.
+				await hook.toolAfter(
+					{
+						tool: 'Task',
+						sessionID: 'architect-session',
+						callID: 'worktree-doc-coder-call',
+						args,
+					},
+					{},
+				);
+
+				const evidence = await readTaskEvidence(directory, '1.1');
+				expect(fs.existsSync(path.join(directory, 'src', 'root-only.ts'))).toBe(
+					true,
+				);
+				expect(evidence?.required_gates).toEqual(['reviewer']);
+				expect(evidence?.test_engineer_exempt).toBe(true);
+			} finally {
+				delegationGateInternals.provisionWorktree = originalProvisionWorktree;
+				if (lanePath && fs.existsSync(lanePath)) {
+					try {
+						git(directory, ['worktree', 'remove', '--force', lanePath]);
+					} catch {
+						// Best-effort cleanup; the enclosing temp repository is removed next.
+					}
+				}
+			}
+		});
 	});
 });

--- a/tests/unit/hooks/delegation-gate-doc-only-evidence.test.ts
+++ b/tests/unit/hooks/delegation-gate-doc-only-evidence.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { Plan } from '../../../src/config/plan-schema';
+import { readTaskEvidence } from '../../../src/gate-evidence';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import {
+	resetSwarmState,
+	startAgentSession,
+	swarmState,
+} from '../../../src/state';
+import {
+	checkReviewerGate,
+	executeUpdateTaskStatus,
+} from '../../../src/tools/update-task-status';
+import {
+	makeConfig,
+	recordPlanCriticApproval,
+} from './_delegation-gate-helpers';
+
+function git(directory: string, args: string[]): void {
+	const result = spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdio: 'pipe',
+		encoding: 'utf-8',
+		timeout: 5_000,
+		maxBuffer: 128 * 1024,
+	});
+	if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+}
+
+function makePlan(filesTouched: string[]): Plan {
+	return {
+		schema_version: '1.0.0',
+		title: 'Doc-only evidence test',
+		swarm: 'mega',
+		current_phase: 1,
+		phases: [
+			{
+				id: 1,
+				name: 'Implementation',
+				status: 'in_progress',
+				tasks: [
+					{
+						id: '1.1',
+						phase: 1,
+						status: 'in_progress',
+						size: 'small',
+						description: 'Update documentation',
+						depends: [],
+						files_touched: filesTouched,
+					},
+				],
+			},
+		],
+	};
+}
+
+describe('delegation gate doc-only durable evidence', () => {
+	let directory: string;
+
+	beforeEach(() => {
+		resetSwarmState();
+		directory = fs.mkdtempSync(path.join(os.tmpdir(), 'foreground-doc-gate-'));
+		git(directory, ['init']);
+		git(directory, ['config', 'user.email', 'tests@example.com']);
+		git(directory, ['config', 'user.name', 'Tests']);
+		fs.writeFileSync(path.join(directory, 'base.txt'), 'base\n');
+		git(directory, ['add', 'base.txt']);
+		git(directory, ['commit', '-m', 'test: seed repository']);
+		fs.appendFileSync(
+			path.join(directory, '.git', 'info', 'exclude'),
+			'\n.swarm/\n',
+		);
+		fs.mkdirSync(path.join(directory, '.swarm'), { recursive: true });
+		startAgentSession('architect-session', 'architect');
+	});
+
+	afterEach(() => {
+		resetSwarmState();
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+
+	async function runCoder(filesTouched: string[], actualFiles: string[]) {
+		const plan = makePlan(filesTouched);
+		fs.writeFileSync(
+			path.join(directory, '.swarm', 'plan.json'),
+			JSON.stringify(plan, null, 2),
+		);
+		await recordPlanCriticApproval(directory, plan);
+		const hook = createDelegationGateHook(makeConfig(), directory);
+		const args = {
+			subagent_type: 'coder',
+			task_id: '1.1',
+			prompt: 'TASK: 1.1\nImplement the approved task.',
+		};
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'architect-session', callID: 'coder-call' },
+			{ args },
+		);
+		for (const relativePath of actualFiles) {
+			const target = path.join(directory, relativePath);
+			fs.mkdirSync(path.dirname(target), { recursive: true });
+			fs.writeFileSync(target, `changed ${relativePath}\n`);
+		}
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 'architect-session',
+				callID: 'coder-call',
+				args,
+			},
+			{},
+		);
+		swarmState.agentSessions
+			.get('architect-session')
+			?.taskWorkflowStates?.set('1.1', 'coder_delegated');
+		return hook;
+	}
+
+	test('foreground coder plus reviewer completes exact Markdown-only gates', async () => {
+		const hook = await runCoder(['README.md'], ['README.md']);
+		let evidence = await readTaskEvidence(directory, '1.1');
+		expect(evidence?.required_gates).toEqual(['reviewer']);
+
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 'architect-session',
+				callID: 'reviewer-call',
+				args: { subagent_type: 'reviewer', task_id: '1.1' },
+			},
+			{ output: 'APPROVED' },
+		);
+		evidence = await readTaskEvidence(directory, '1.1');
+		expect(evidence?.gates.reviewer).toBeDefined();
+		expect(
+			swarmState.agentSessions
+				.get('architect-session')
+				?.taskWorkflowStates?.get('1.1'),
+		).toBe('tests_run');
+		expect(checkReviewerGate('1.1', directory).blocked).toBe(false);
+		const completion = await executeUpdateTaskStatus(
+			{ task_id: '1.1', status: 'completed' },
+			directory,
+		);
+		expect(completion.success).toBe(true);
+		await hook.toolAfter(
+			{
+				tool: 'update_task_status',
+				sessionID: 'architect-session',
+				callID: 'completion-call',
+				args: { task_id: '1.1', status: 'completed' },
+			},
+			{},
+		);
+		expect(
+			swarmState.agentSessions
+				.get('architect-session')
+				?.taskWorkflowStates?.get('1.1'),
+		).toBe('complete');
+
+		resetSwarmState();
+		expect(checkReviewerGate('1.1', directory).blocked).toBe(false);
+	});
+
+	test('observed or declared code keeps test_engineer required', async () => {
+		await runCoder(['README.md', 'src/code.ts'], ['README.md', 'src/code.ts']);
+		const evidence = await readTaskEvidence(directory, '1.1');
+		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+	});
+
+	test('scope mismatch fails closed', async () => {
+		await runCoder(['README.md'], ['README.md', 'src/undeclared.ts']);
+		const evidence = await readTaskEvidence(directory, '1.1');
+		expect(evidence?.required_gates).toEqual(['reviewer', 'test_engineer']);
+	});
+});

--- a/tests/unit/scripts/drift-check.test.ts
+++ b/tests/unit/scripts/drift-check.test.ts
@@ -86,6 +86,43 @@ describe('drift-check: skill-mirror detection', () => {
 		expect(hit).toBeDefined();
 	});
 
+	test('detects drift in an extra identical .agents mirror', () => {
+		const root = makeTempRoot();
+		const canonical = 'canonical body\n';
+		writeFile(root, '.opencode/skills/test-file-split/SKILL.md', canonical);
+		writeFile(root, '.claude/skills/test-file-split/SKILL.md', canonical);
+		writeFile(
+			root,
+			'.agents/skills/test-file-split/SKILL.md',
+			'DRIFTED body\n',
+		);
+
+		const findings = detectSkillMirrorDrift(root);
+		const hit = findings.find(
+			(f) =>
+				f.severity === 'error' &&
+				f.file === '.agents/skills/test-file-split/SKILL.md' &&
+				f.message.includes('extra mirror drifted'),
+		);
+		expect(hit).toBeDefined();
+	});
+
+	test('detects a missing extra identical .agents mirror', () => {
+		const root = makeTempRoot();
+		const canonical = 'canonical body\n';
+		writeFile(root, '.opencode/skills/fork-pr-operations/SKILL.md', canonical);
+		writeFile(root, '.claude/skills/fork-pr-operations/SKILL.md', canonical);
+
+		const findings = detectSkillMirrorDrift(root);
+		const hit = findings.find(
+			(f) =>
+				f.severity === 'error' &&
+				f.file === '.agents/skills/fork-pr-operations/SKILL.md' &&
+				f.message.includes('missing extra identical mirror'),
+		);
+		expect(hit).toBeDefined();
+	});
+
 	test('does not flag the generated/ directory as an unclassified pair', () => {
 		const root = makeTempRoot();
 		writeFile(root, '.opencode/skills/generated/x/SKILL.md', 'a\n');

--- a/tests/unit/skills/skill-mirrors.test.ts
+++ b/tests/unit/skills/skill-mirrors.test.ts
@@ -110,12 +110,16 @@ describe('architect mode skill mirrors - regression: prevent mirror drift (F-001
 			);
 
 			if (contract.kind === 'identical') {
-				it(`${contract.slug}: .opencode and .claude are byte-identical`, () => {
+				it(`${contract.slug}: every declared mirror is byte-identical`, () => {
 					expect(existsSync(opencodePath)).toBe(true);
 					expect(existsSync(claudePath)).toBe(true);
-					expect(readFileSync(claudePath, 'utf-8')).toBe(
-						readFileSync(opencodePath, 'utf-8'),
-					);
+					const canonical = readFileSync(opencodePath, 'utf-8');
+					expect(readFileSync(claudePath, 'utf-8')).toBe(canonical);
+					for (const extraPath of contract.extraIdenticalPaths ?? []) {
+						const resolvedExtraPath = join(process.cwd(), extraPath);
+						expect(existsSync(resolvedExtraPath)).toBe(true);
+						expect(readFileSync(resolvedExtraPath, 'utf-8')).toBe(canonical);
+					}
 				});
 			} else if (contract.kind === 'divergent') {
 				it(`${contract.slug}: both .opencode and .claude mirrors exist (divergent)`, () => {

--- a/tests/unit/tools/phase-complete-doc-only-evidence.test.ts
+++ b/tests/unit/tools/phase-complete-doc-only-evidence.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	recordAgentDispatch,
+	recordGateEvidence,
+} from '../../../src/gate-evidence';
+import { _test_exports } from '../../../src/tools/phase-complete';
+
+describe('phase_complete doc-only durable fallback', () => {
+	let directory: string;
+
+	beforeEach(() => {
+		directory = fs.mkdtempSync(path.join(os.tmpdir(), 'phase-doc-gate-'));
+	});
+
+	afterEach(() => {
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+
+	test('accepts completed reviewer-only doc evidence after restart', async () => {
+		await recordAgentDispatch(directory, '1.1', 'coder', false, {
+			testEngineerExempt: true,
+		});
+		await recordGateEvidence(directory, '1.1', 'reviewer', 'review-session');
+
+		expect(
+			await _test_exports.allCompletedTasksHavePassedGateEvidence(directory, [
+				{ id: '1.1', status: 'completed' },
+			]),
+		).toBe(true);
+	});
+
+	test('rejects completed code evidence missing test_engineer', async () => {
+		await recordAgentDispatch(directory, '1.2', 'coder');
+		await recordGateEvidence(directory, '1.2', 'reviewer', 'review-session');
+
+		expect(
+			await _test_exports.allCompletedTasksHavePassedGateEvidence(directory, [
+				{ id: '1.2', status: 'completed' },
+			]),
+		).toBe(false);
+	});
+});

--- a/tests/unit/tools/sast-scan.adversarial.test.ts
+++ b/tests/unit/tools/sast-scan.adversarial.test.ts
@@ -18,7 +18,12 @@ import {
 	spyOn,
 } from 'bun:test';
 import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
 import { sastScan } from '../../../src/tools/sast-scan';
+
+const BASELINE_COVERAGE_ERROR =
+	'capture_baseline requires changed_files to produce a non-empty baseline';
 
 describe('SAST Scan - Adversarial Tests (R2)', () => {
 	const MOCK_DIR = process.cwd();
@@ -60,6 +65,17 @@ describe('SAST Scan - Adversarial Tests (R2)', () => {
 		expect(result.summary.files_scanned).toBe(0);
 	});
 
+	it('empty baseline capture fails with an actionable error', async () => {
+		const result = await sastScan(
+			{ changed_files: [], capture_baseline: true, phase: 1 },
+			MOCK_DIR,
+		);
+
+		expect(result.verdict).toBe('fail');
+		expect(result.error).toBe(BASELINE_COVERAGE_ERROR);
+		expect(result.summary.files_scanned).toBe(0);
+	});
+
 	/**
 	 * ATTACK VECTOR 2: Invalid non-existent paths
 	 * Attempt to bypass by providing paths that don't exist
@@ -96,6 +112,45 @@ describe('SAST Scan - Adversarial Tests (R2)', () => {
 		existsSyncMock.mockRestore();
 	});
 
+	it('baseline capture fails when every requested file is unscannable', async () => {
+		const result = await sastScan(
+			{
+				changed_files: ['missing.ts', 'README.md'],
+				capture_baseline: true,
+				phase: 1,
+			},
+			MOCK_DIR,
+		);
+
+		expect(result.verdict).toBe('fail');
+		expect(result.error).toBe(BASELINE_COVERAGE_ERROR);
+		expect(result.summary.files_scanned).toBe(0);
+	});
+
+	it('baseline capture allows a supported file with zero findings', async () => {
+		mock.restore();
+		const tempDir = fs.mkdtempSync(
+			path.join(tmpdir(), 'sast-valid-baseline-test-'),
+		);
+		const testFile = path.join(tempDir, 'valid.ts');
+		fs.writeFileSync(testFile, 'const answer = 42;');
+
+		try {
+			const result = await sastScan(
+				{ changed_files: [testFile], capture_baseline: true, phase: 1 },
+				tempDir,
+			);
+
+			expect(result.verdict).toBe('pass');
+			expect(result.error).toBeUndefined();
+			expect(result.status).toBe('baseline_captured');
+			expect(result.finding_count).toBe(0);
+			expect(result.summary.files_scanned).toBe(1);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	/**
 	 * ATTACK VECTOR 4: Enabled mode with zero coverage must FAIL (not PASS)
 	 * This is the critical security invariant - zero coverage cannot be treated as success
@@ -124,21 +179,26 @@ describe('SAST Scan - Adversarial Tests (R2)', () => {
 	 * When feature is disabled, zero coverage should return PASS
 	 */
 	it('disabled mode bypasses zero coverage → PASS (control test)', async () => {
-		const result = await sastScan({ changed_files: [] }, MOCK_DIR, {
-			gates: {
-				syntax_check: { enabled: true },
-				placeholder_scan: {
-					enabled: true,
-					deny_patterns: [],
-					allow_globs: [],
-					max_allowed_findings: 0,
+		const result = await sastScan(
+			{ changed_files: [], capture_baseline: true, phase: 1 },
+			MOCK_DIR,
+			{
+				gates: {
+					syntax_check: { enabled: true },
+					placeholder_scan: {
+						enabled: true,
+						deny_patterns: [],
+						allow_globs: [],
+						max_allowed_findings: 0,
+					},
+					sast_scan: { enabled: false },
+					sbom_generate: { enabled: true },
+					build_check: { enabled: true },
+					quality_budget: { enabled: true },
 				},
-				sast_scan: { enabled: false },
-				sbom_generate: { enabled: true },
-				build_check: { enabled: true },
-				quality_budget: { enabled: true },
-			},
-		} as any);
+			} as any,
+		);
 		expect(result.verdict).toBe('pass');
+		expect(result.error).toBeUndefined();
 	});
 });


### PR DESCRIPTION
Closes #1764

## Summary
- reject SAST baseline capture when no supported changed file was scanned, while preserving valid zero-finding captures
- exempt `test_engineer` only from coder tasks whose immutable declared scope and observed Git delta independently prove a non-empty, exact `.md`-only change; persist the decision across foreground, background, worktree, and restart paths
- avoid synchronous Git snapshot work for coder tasks that are not declared Markdown-only candidates, capture eligible snapshots only after dispatch admission/provisioning, and bound both pending provenance maps
- document the cooperative same-user evidence trust boundary and the conservative dirty-hash upgrade caveat; add direct foreground-worktree and dirty-baseline regression coverage
- enforce three-tree skill mirror identity, document per-task evidence persistence, and ship the required release/configuration guidance with the dependency infrastructure merged via PR #1785

## Invariant audit
- 1 (plugin init): not touched - no initialization-path behavior changed; `bun run build` and the Node ESM import pass
- 2 (runtime portability): not touched - no Bun-only runtime APIs added; rebuilt `dist/index.js` imports under Node ESM
- 3 (subprocesses): touched - Git observation uses array-form `spawnSync` with explicit `git -C`, `cwd`, `stdin: 'ignore'`, 3-second timeout, piped bounded output, and 512 KiB `maxBuffer`; non-Markdown coder tasks now perform zero snapshot subprocesses, and eligible capture is delayed until dispatch admission/provisioning
- 4 (.swarm containment): touched - durable coder provenance extends the existing `.swarm/background-delegations.jsonl` and `.swarm/evidence/{taskId}.json` stores only; documentation now states that workspace evidence is audit/recovery state for cooperative same-user agents, not a tamper-proof authorization boundary
- 5 (plan durability): not touched - ledger/projection/checkpoint schemas and writers are unchanged
- 6 (test_runner safety): not touched - validation used shell-driven explicit test files, never broad `test_runner`
- 7 (test writing): touched - new tests use `bun:test`, real temp Git repositories, bounded subprocess helpers, and no `mock.module`; issue-focused and legacy gate suites pass
- 8 (session state): touched - foreground coder context and observed-file maps are keyed by `callID`, independently capped at 128 entries, evicted FIFO, and deleted together on completion
- 9 (guardrails/retry): touched - exact Markdown classification fails closed for missing provenance, dirty baselines, unsafe paths, undeclared files, tracked non-Markdown `.swarm` files, and legacy/arbitrary evidence; adversarial tests cover each boundary
- 10 (chat/system msg): not touched - no chat or system-message hooks changed
- 11 (tool registration): not touched - no tools or agent maps changed; `drift:check` and skill-mirror coherence tests pass
- 12 (release/cache): touched - pending release fragment added and updated with the evidence trust boundary plus dirty in-flight hash upgrade caveat; package smoke passes with 785 files and both dependency skills are supplied by merged PR #1785

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint:ci` (2,435 files)
- [x] 108 issue-focused tests across classification, evidence, foreground/background/worktree state, SAST, drift, mirrors, and phase completion
- [x] 143 existing gate/background/update-status/phase regressions
- [x] feedback regression bundle: 93 passed, 0 failed across classification, evidence, Stage B dirty-baseline, workspace snapshot, foreground worktree, and delegation evidence suites
- [x] feedback Stage B and closeout: test engineer passed isolated/combined runs; reviewer, closeout reviewer, and final critic approved
- [x] `bun --smol test tests/security --timeout 120000` (163 passed, 4 skipped)
- [x] `bun test tests/smoke --timeout 120000` (10 passed)
- [x] `bun run drift:check`
- [x] `bun run build`
- [x] `node --input-type=module -e "await import('./dist/index.js')"`
- [x] `bun run package:smoke` (785 files)
- [x] two fresh post-fix QA reviews approved; final completeness confidence 97%

## Pre-existing local validation findings
- The CI-equivalent all-unit local runner exceeded its 20-minute safety timeout; the explicit impacted and legacy suites above passed, and remote CI remains authoritative.
- Broad shared-process integration/adversarial invocations expose existing mock/state leakage and 15 stale Windows adversarial assertions. The same 15 adversarial failures reproduce unchanged at PR #1785's earlier head `48a22cca`; representative integration failures pass when isolated. Merged PR #1785 head `5972d3e4` and this PR's current head are fully green across all four unit shards, integration, security, package, coverage, and Windows/macOS/Linux smoke.
