### PR TITLE
refactor(sast): remove unused tree-sitter query scaffolding

### DIFF
--- a/docs/releases/pending/issue-1654-sast-dead-code-removal.md
+++ b/docs/releases/pending/issue-1654-sast-dead-code-removal.md
@@ -1,0 +1,32 @@
+﻿# SAST dead-code cleanup (issue #1654)
+
+## What changed
+
+- **`src/sast/rules/index.ts` ΓÇö `SastRule` interface:** Removed `query?: string` optional field.
+  No rule implementation ever populated this field.
+
+- **`src/sast/rules/index.ts` ΓÇö `SastContext` interface:** Removed `parser?: unknown` and `tree?: unknown`
+  optional fields. Neither field was ever populated by any caller.
+
+- **`src/sast/rules/index.ts`:** Deleted the `executeRules()` async wrapper function.
+  `sast-scan.ts` imports `executeRulesSync` directly; the async wrapper had zero external consumers.
+
+- **`src/sast/rules/index.ts`:** Removed `executeRules` from the `_internals` type signature and value object.
+
+- **`src/sast/rules/index.ts`:** Updated a comment from "Detection: either query OR pattern" to
+  "Detection: regex pattern" to reflect actual behavior.
+
+## Why
+
+The SAST rule infrastructure accumulated fields and a wrapper function that were never used by any
+rule implementation. Audit confirmed zero in-tree or external consumers. Removing this dead code
+reduces interface surface area and eliminates maintenance overhead with no impact on SAST rule
+matching behavior. Net change: +1/-20 lines.
+
+## Migration
+
+No migration required.
+
+## Known caveats
+
+None.

--- a/src/sast/rules/index.ts
+++ b/src/sast/rules/index.ts
@@ -11,8 +11,7 @@ export interface SastRule {
 	languages: string[];
 	description: string;
 	remediation?: string;
-	// Detection: either query OR pattern
-	query?: string;
+	// Detection: regex pattern
 	pattern?: RegExp;
 	// Optional validation for context-aware filtering
 	validate?: (match: SastMatch, context: SastContext) => boolean;
@@ -31,8 +30,6 @@ export interface SastContext {
 	filePath: string;
 	content: string;
 	language: string;
-	parser?: unknown;
-	tree?: unknown;
 }
 
 export interface SastFinding {
@@ -78,7 +75,6 @@ export const _internals: {
 	getRuleById: typeof getRuleById;
 	findPatternMatches: typeof findPatternMatches;
 	executeRulesSync: typeof executeRulesSync;
-	executeRules: typeof executeRules;
 	getRuleStats: typeof getRuleStats;
 } = {
 	getAllRules,
@@ -86,7 +82,6 @@ export const _internals: {
 	getRuleById,
 	findPatternMatches,
 	executeRulesSync,
-	executeRules,
 	getRuleStats,
 } as const;
 
@@ -202,20 +197,6 @@ export function executeRulesSync(
 	}
 
 	return findings;
-}
-
-/**
- * Execute rules against a file (async version with tree-sitter support)
- * Falls back to pattern matching if tree-sitter is unavailable
- */
-export async function executeRules(
-	filePath: string,
-	content: string,
-	language: string,
-): Promise<SastFinding[]> {
-	// For now, just use the sync version
-	// Tree-sitter integration can be added later
-	return _internals.executeRulesSync(filePath, content, language);
 }
 
 /**


### PR DESCRIPTION
Closes #1654

## Summary
- Removed unused tree-sitter/query scaffolding from src/sast/rules/index.ts
- Deleted query?: string from SastRule interface (no rule ever used it)
- Deleted parser?: unknown and 	ree?: unknown from SastContext (never populated)
- Deleted executeRules() async wrapper (zero external consumers; sast-scan.ts imports executeRulesSync directly)
- Removed executeRules from _internals type signature and value object
- Updated comment from "either query OR pattern" to "regex pattern"
- Net: +1/-20 lines, zero behavioral change to SAST rule matching

## Invariant audit
- 1 (plugin init): not touched â€” no changes to plugin initialization path
- 2 (runtime portability): not touched â€” no bundle/build/package changes; 
ode --input-type=module -e "await import('./dist/index.js')" passes
- 3 (subprocesss): not touched â€” no subprocess code modified
- 4 (.swarm containment): not touched â€” no runtime state paths changed
- 5 (plan durability): not touched â€” no plan schema or ledger changes
- 6 (test_runner safety): not touched â€” no test runner code changed
- 7 (test writing): not touched â€” no test files modified
- 8 (session state): not touched â€” no session-scoped state changes
- 9 (guardrails/retry): not touched â€” no guardrail code changed
- 10 (chat/system msg): not touched â€” no hook code changed
- 11 (tool registration): not touched â€” no tools added/removed/modified; executeRules was not a registered tool
- 12 (release/cache): not touched â€” release note fragment created, version files untouched

## Test plan
- [x] un run build passes
- [x] 
ode --input-type=module -e "await import('./dist/index.js')" passes
- [x] un run typecheck (tsc --noEmit) clean
- [x] unx @biomejs/biome ci . clean (2424 files)
- [x] 76/76 SAST unit tests pass (	ests/unit/sast/)
- [x] 43/43 SAST tool tests pass (	ests/unit/tools/sast-scan.test.ts)
- [x] pre_check_batch: lint/secretscan/sast_scan/quality_budget all pass

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

