### PR TITLE
fix(curator): bound hive promotion recommendations

### DIFF
--- a/docs/evidence-and-telemetry.md
+++ b/docs/evidence-and-telemetry.md
@@ -163,6 +163,23 @@ Written to `.swarm/curator-summary.json` after the curator runs each phase (`src
 }
 ```
 
+`knowledge_recommendations` is a bounded persistence surface: semantic
+duplicates collapse to their newest occurrence and at most 200 unique entries
+are retained. Hive promotion observations are recorded only when promotion state
+actually changes. On the first read of an older bloated summary, the curator
+deduplicates and caps the array in place so affected projects recover without a
+manual cleanup step.
+
+Evidence bundles under `.swarm/evidence/` may contain multiple retrospective
+entries. The knowledge curator ingests every eligible entry independently,
+preserving its phase metadata and avoiding replay of unchanged earlier entries
+when a later entry is appended. Idempotency claims are project-scoped, so
+identical relative evidence paths in separate workspaces cannot suppress one
+another. Physical project-root aliases, physical evidence-file aliases, and
+filesystem-equivalent relative paths share the same claim, preventing unchanged
+evidence from replaying through path spelling differences. Aliases that resolve
+outside the project's physical `.swarm/evidence/` tree are rejected.
+
 ---
 
 ## Curator Findings

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -377,7 +377,7 @@ The init call is wrapped in try/catch — if the Curator fails to initialize, th
 After each phase completes (and after the standard `curateAndStoreSwarm()` call), the Curator pipeline runs:
 
 1. **`runCuratorPhase`** — Collects phase events from the event bus, runs compliance checks, and produces a `CuratorPhaseResult`.
-2. **`applyCuratorKnowledgeUpdates`** — Merges the phase result's knowledge recommendations into `.swarm/curator-summary.json`, capped at `max_summary_tokens`.
+2. **`applyCuratorKnowledgeUpdates`** — Merges the phase result's knowledge recommendations into `.swarm/curator-summary.json`. Recommendation persistence deduplicates the complete stable semantic payload, keeps the newest occurrence, and caps the array at 200 entries.
 3. **`runCriticDriftCheck`** — Compares planned vs. actual decisions, writes a drift report to `.swarm/drift-report-phase-N.json`.
 4. **Compliance surfacing** — If compliance observations exist and `suppress_warnings` is false, they are added to the return value's warnings array (max 5).
 

--- a/docs/releases/pending/hive-promoter-curator-flooding.md
+++ b/docs/releases/pending/hive-promoter-curator-flooding.md
@@ -1,0 +1,24 @@
+# Bound curator promotion recommendations
+
+## What changed
+
+- Hive promotion checks no longer write curator recommendations when no hive state changed.
+- Curator recommendations are semantically deduplicated, capped at 200 entries, and updated through a shared locked persistence path.
+- Existing bloated `curator-summary.json` files are cleaned automatically on first read.
+- Knowledge curation now ingests lesson-bearing entries throughout an evidence bundle instead of inspecting only the first entry, with project-scoped idempotency.
+
+## Why
+
+Repeated all-zero hive observations could grow curator summaries to thousands of duplicate entries and inject that noise into every curator briefing. Later retrospective entries in evidence bundles could also be missed.
+
+## Migration
+
+No manual migration is required. Existing summaries are normalized automatically when reopened.
+
+## Breaking changes
+
+None.
+
+## Known caveats
+
+None.

--- a/src/hooks/curator.ts
+++ b/src/hooks/curator.ts
@@ -71,6 +71,7 @@ import {
 	getArchivedKnowledgeIds,
 	readKnowledge,
 	resolveSwarmKnowledgePath,
+	transactFile,
 	transactKnowledge,
 } from './knowledge-store.js';
 import type {
@@ -114,6 +115,11 @@ export const _internals = {
 	parseKnowledgeRecommendationsWithDiagnostics,
 	readCuratorSummary,
 	writeCuratorSummary,
+	appendCuratorRecommendation,
+	mergeCuratorPhaseSummary,
+	readCuratorSummaryState,
+	writeCuratorSummaryState,
+	transactFile,
 	filterPhaseEvents,
 	checkPhaseCompliance,
 	normalizeAgentName,
@@ -205,10 +211,66 @@ function capComplianceObservations(
 	return observations.slice(-MAX_CURATOR_COMPLIANCE_OBSERVATIONS);
 }
 
-function capKnowledgeRecommendations(
-	recommendations: KnowledgeRecommendation[],
+function canonicalizeJson(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(canonicalizeJson);
+	if (value === null || typeof value !== 'object') return value;
+	return Object.fromEntries(
+		Object.entries(value as Record<string, unknown>)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([key, nested]) => [key, canonicalizeJson(nested)]),
+	);
+}
+
+function recommendationIdentity(
+	recommendation: KnowledgeRecommendation,
+): string {
+	const stable = { ...recommendation } as Record<string, unknown>;
+	if (
+		recommendation.action === 'promote' &&
+		recommendation.lesson.startsWith('Hive promotion:')
+	) {
+		try {
+			const parsedReason = JSON.parse(recommendation.reason) as unknown;
+			if (
+				parsedReason !== null &&
+				typeof parsedReason === 'object' &&
+				!Array.isArray(parsedReason)
+			) {
+				const { timestamp: _volatileTimestamp, ...stableReason } =
+					parsedReason as Record<string, unknown>;
+				stable.reason = stableReason;
+			}
+		} catch {
+			// Keep an unparsable reason in the identity; only a recognized timestamp
+			// field in a valid hive payload is intentionally volatile.
+		}
+	}
+	return JSON.stringify(canonicalizeJson(stable));
+}
+
+function normalizeKnowledgeRecommendations(
+	recommendations: unknown,
 ): KnowledgeRecommendation[] {
-	return recommendations.slice(-MAX_CURATOR_RECOMMENDATIONS);
+	const input = Array.isArray(recommendations)
+		? recommendations.filter(
+				(entry): entry is KnowledgeRecommendation =>
+					entry !== null &&
+					typeof entry === 'object' &&
+					typeof (entry as { action?: unknown }).action === 'string' &&
+					typeof (entry as { lesson?: unknown }).lesson === 'string' &&
+					typeof (entry as { reason?: unknown }).reason === 'string',
+			)
+		: [];
+	const seen = new Set<string>();
+	const newestUnique: KnowledgeRecommendation[] = [];
+	for (let index = input.length - 1; index >= 0; index--) {
+		const recommendation = input[index];
+		const identity = recommendationIdentity(recommendation);
+		if (seen.has(identity)) continue;
+		seen.add(identity);
+		newestUnique.push(recommendation);
+	}
+	return newestUnique.reverse().slice(-MAX_CURATOR_RECOMMENDATIONS);
 }
 
 function buildDigestFromPhaseDigests(digests: PhaseDigestEntry[]): string {
@@ -653,49 +715,267 @@ function clampConf(v: unknown): number {
 	return v;
 }
 
+interface CuratorSummaryFileState {
+	summary: CuratorSummary | null;
+	dirty: boolean;
+}
+
+interface CuratorSummaryMutation<T> {
+	next?: CuratorSummary | null;
+	result: T;
+}
+
+interface CuratorSummaryTransaction<T> {
+	invoked: boolean;
+	result: T | undefined;
+}
+
+function normalizeCuratorSummary(summary: CuratorSummary): {
+	summary: CuratorSummary;
+	changed: boolean;
+} {
+	const recommendations = normalizeKnowledgeRecommendations(
+		(summary as { knowledge_recommendations?: unknown })
+			.knowledge_recommendations,
+	);
+	const original = Array.isArray(summary.knowledge_recommendations)
+		? summary.knowledge_recommendations
+		: [];
+	const changed =
+		!Array.isArray(summary.knowledge_recommendations) ||
+		original.length !== recommendations.length ||
+		original.some((entry, index) => entry !== recommendations[index]);
+	return {
+		summary: changed
+			? { ...summary, knowledge_recommendations: recommendations }
+			: summary,
+		changed,
+	};
+}
+
+async function readCuratorSummaryState(
+	filePath: string,
+): Promise<CuratorSummaryFileState> {
+	let content: string;
+	try {
+		content = await fs.promises.readFile(filePath, 'utf-8');
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+			return { summary: null, dirty: false };
+		}
+		throw error;
+	}
+
+	return parseCuratorSummaryContent(content);
+}
+
+function parseCuratorSummaryContent(content: string): CuratorSummaryFileState {
+	try {
+		const parsed = JSON.parse(content) as CuratorSummary;
+		if (parsed.schema_version !== 1) {
+			logger.warn(
+				`Curator summary has unsupported schema version: ${parsed.schema_version}. Expected 1.`,
+			);
+			return { summary: null, dirty: false };
+		}
+		const normalized = normalizeCuratorSummary(parsed);
+		return { summary: normalized.summary, dirty: normalized.changed };
+	} catch {
+		logger.warn('Failed to parse curator-summary.json: invalid JSON');
+		return { summary: null, dirty: false };
+	}
+}
+
+async function writeCuratorSummaryState(
+	filePath: string,
+	state: CuratorSummaryFileState,
+): Promise<void> {
+	if (!state.summary) return;
+	await bunWrite(filePath, JSON.stringify(state.summary, null, 2));
+}
+
+async function transactCuratorSummary<T>(
+	directory: string,
+	mutate: (summary: CuratorSummary | null) => CuratorSummaryMutation<T>,
+): Promise<CuratorSummaryTransaction<T>> {
+	const resolvedPath = validateSwarmPath(directory, 'curator-summary.json');
+	let invoked = false;
+	let mutationResult: T | undefined;
+	await _internals.transactFile<CuratorSummaryFileState>(
+		resolvedPath,
+		_internals.readCuratorSummaryState,
+		_internals.writeCuratorSummaryState,
+		(state) => {
+			invoked = true;
+			const mutation = mutate(state.summary);
+			mutationResult = mutation.result;
+			if (mutation.next === null) return null;
+			const candidate = mutation.next ?? state.summary;
+			if (!candidate) return null;
+			const normalized = normalizeCuratorSummary(candidate).summary;
+			const explicitlyChanged =
+				mutation.next !== undefined &&
+				JSON.stringify(normalized) !== JSON.stringify(state.summary);
+			if (!state.dirty && !explicitlyChanged) return null;
+			return { summary: normalized, dirty: false };
+		},
+	);
+	return { invoked, result: mutationResult };
+}
+
 /**
- * Read curator summary from .swarm/curator-summary.json
- * @param directory - The workspace directory
- * @returns CuratorSummary if valid, null if missing or invalid
+ * Read and normalize curator summary from .swarm/curator-summary.json.
+ * Legacy recommendation spam is deduplicated and capped on first successful read.
+ * Cleanup failure is fail-open: callers still receive the normalized in-memory state.
  */
 export async function readCuratorSummary(
 	directory: string,
 ): Promise<CuratorSummary | null> {
 	const content = await readSwarmFileAsync(directory, 'curator-summary.json');
+	if (content === null) return null;
+	const initial = parseCuratorSummaryContent(content);
+	if (!initial.summary || !initial.dirty) return initial.summary;
 
-	if (content === null) {
-		return null;
-	}
-
+	let normalized: CuratorSummary | null = initial.summary;
 	try {
-		const parsed = JSON.parse(content) as CuratorSummary;
-
-		if (parsed.schema_version !== 1) {
-			logger.warn(
-				`Curator summary has unsupported schema version: ${parsed.schema_version}. Expected 1.`,
-			);
-			return null;
-		}
-
-		return parsed;
-	} catch {
-		logger.warn('Failed to parse curator-summary.json: invalid JSON');
-		return null;
+		await transactCuratorSummary(directory, (summary) => {
+			if (summary) normalized = summary;
+			return { result: normalized };
+		});
+	} catch (error) {
+		logger.warn(
+			`Failed to persist curator-summary cleanup: ${error instanceof Error ? error.message : String(error)}`,
+		);
 	}
+	return normalized;
 }
 
-/**
- * Write curator summary to .swarm/curator-summary.json
- * @param directory - The workspace directory
- * @param summary - The curator summary to write
- */
+/** Write a fully normalized curator summary under the shared summary lock. */
 export async function writeCuratorSummary(
 	directory: string,
 	summary: CuratorSummary,
 ): Promise<void> {
-	const resolvedPath = validateSwarmPath(directory, 'curator-summary.json');
-	fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
-	await bunWrite(resolvedPath, JSON.stringify(summary, null, 2));
+	const transaction = await transactCuratorSummary(directory, () => ({
+		next: summary,
+		result: undefined,
+	}));
+	if (!transaction.invoked) {
+		throw new Error('Failed to persist curator summary');
+	}
+}
+
+/**
+ * Append one recommendation through the shared locked persistence boundary.
+ * Returns false when no summary exists or no persisted representation changes.
+ * A semantic duplicate can return true when it replaces the retained representative
+ * under the newest-wins policy (for example, a hive event with a newer timestamp).
+ */
+export async function appendCuratorRecommendation(
+	directory: string,
+	recommendation: KnowledgeRecommendation,
+): Promise<boolean> {
+	const transaction = await transactCuratorSummary(directory, (summary) => {
+		if (!summary) return { next: null, result: false };
+		const recommendations = normalizeKnowledgeRecommendations([
+			...normalizeKnowledgeRecommendations(summary.knowledge_recommendations),
+			recommendation,
+		]);
+		const current = normalizeKnowledgeRecommendations(
+			summary.knowledge_recommendations,
+		);
+		const changed =
+			current.length !== recommendations.length ||
+			current.some((entry, index) => entry !== recommendations[index]);
+		if (!changed) return { result: false };
+		return {
+			next: {
+				...summary,
+				last_updated: new Date().toISOString(),
+				knowledge_recommendations: recommendations,
+			},
+			result: true,
+		};
+	});
+	return transaction.invoked ? (transaction.result ?? false) : false;
+}
+
+interface CuratorPhaseSummaryMerge {
+	phase: number;
+	phaseDigest: PhaseDigestEntry;
+	complianceObservations: ComplianceObservation[];
+	knowledgeRecommendations: KnowledgeRecommendation[];
+	sessionId: string;
+	timestamp: string;
+}
+
+/** Merge a phase result against the latest on-disk summary under the shared lock. */
+export async function mergeCuratorPhaseSummary(
+	directory: string,
+	merge: CuratorPhaseSummaryMerge,
+): Promise<boolean> {
+	const transaction = await transactCuratorSummary(directory, (current) => {
+		if (
+			current?.phase_digests?.some((digest) => digest.phase === merge.phase)
+		) {
+			return { result: false };
+		}
+		if (current) {
+			const phaseDigests = capPhaseDigests([
+				...(Array.isArray(current.phase_digests) ? current.phase_digests : []),
+				merge.phaseDigest,
+			]);
+			return {
+				next: {
+					...current,
+					last_updated: merge.timestamp,
+					last_phase_covered: Math.max(
+						typeof current.last_phase_covered === 'number'
+							? current.last_phase_covered
+							: 0,
+						merge.phase,
+					),
+					digest: buildDigestFromPhaseDigests(phaseDigests),
+					phase_digests: phaseDigests,
+					compliance_observations: capComplianceObservations([
+						...(Array.isArray(current.compliance_observations)
+							? current.compliance_observations
+							: []),
+						...merge.complianceObservations,
+					]),
+					knowledge_recommendations: normalizeKnowledgeRecommendations([
+						...normalizeKnowledgeRecommendations(
+							current.knowledge_recommendations,
+						),
+						...merge.knowledgeRecommendations,
+					]),
+				},
+				result: true,
+			};
+		}
+
+		const phaseDigests = capPhaseDigests([merge.phaseDigest]);
+		return {
+			next: {
+				schema_version: 1,
+				session_id: merge.sessionId,
+				last_updated: merge.timestamp,
+				last_phase_covered: merge.phase,
+				digest: buildDigestFromPhaseDigests(phaseDigests),
+				phase_digests: phaseDigests,
+				compliance_observations: capComplianceObservations(
+					merge.complianceObservations,
+				),
+				knowledge_recommendations: normalizeKnowledgeRecommendations(
+					merge.knowledgeRecommendations,
+				),
+			},
+			result: true,
+		};
+	});
+	if (!transaction.invoked) {
+		throw new Error('Failed to persist curator phase summary');
+	}
+	return transaction.result ?? false;
 }
 
 /**
@@ -1375,47 +1655,17 @@ export async function runCuratorPhase(
 		const sessionId = `session-${Date.now()}`;
 		const now = new Date().toISOString();
 
-		let updatedSummary: CuratorSummary;
-		if (priorSummary) {
-			const phaseDigests = capPhaseDigests([
-				...priorSummary.phase_digests,
+		const summaryUpdated = await _internals.mergeCuratorPhaseSummary(
+			directory,
+			{
+				phase,
 				phaseDigest,
-			]);
-			// Extend existing summary
-			updatedSummary = {
-				...priorSummary,
-				last_updated: now,
-				last_phase_covered: Math.max(priorSummary.last_phase_covered, phase),
-				digest: buildDigestFromPhaseDigests(phaseDigests),
-				phase_digests: phaseDigests,
-				compliance_observations: capComplianceObservations([
-					...priorSummary.compliance_observations,
-					...complianceObservations,
-				]),
-				knowledge_recommendations: capKnowledgeRecommendations([
-					...priorSummary.knowledge_recommendations,
-					...knowledgeRecommendations,
-				]),
-			};
-		} else {
-			const phaseDigests = capPhaseDigests([phaseDigest]);
-			updatedSummary = {
-				schema_version: 1,
-				session_id: sessionId,
-				last_updated: now,
-				last_phase_covered: phase,
-				digest: buildDigestFromPhaseDigests(phaseDigests),
-				phase_digests: phaseDigests,
-				compliance_observations: capComplianceObservations(
-					complianceObservations,
-				),
-				knowledge_recommendations: capKnowledgeRecommendations(
-					knowledgeRecommendations,
-				),
-			};
-		}
-
-		await _internals.writeCuratorSummary(directory, updatedSummary);
+				complianceObservations,
+				knowledgeRecommendations,
+				sessionId,
+				timestamp: now,
+			},
+		);
 
 		// 7b. Persist knowledge application findings to per-phase evidence.
 		if (knowledgeApplicationFindings.length > 0) {
@@ -1633,7 +1883,7 @@ export async function runCuratorPhase(
 			digest: phaseDigest,
 			compliance: complianceObservations,
 			knowledge_recommendations: knowledgeRecommendations,
-			summary_updated: true,
+			summary_updated: summaryUpdated,
 			knowledge_application_findings: knowledgeApplicationFindings,
 			skill_candidates: skillCandidates,
 		};
@@ -1642,7 +1892,7 @@ export async function runCuratorPhase(
 		getGlobalEventBus().publish('curator.phase.completed', {
 			phase,
 			compliance_count: complianceObservations.length,
-			summary_updated: true,
+			summary_updated: summaryUpdated,
 		});
 
 		return result;

--- a/src/hooks/hive-promoter.ts
+++ b/src/hooks/hive-promoter.ts
@@ -1,8 +1,7 @@
 /** Hive promoter hook for opencode-swarm v6.17 two-tier knowledge system. */
 
 import path from 'node:path';
-import { readCuratorSummary, writeCuratorSummary } from './curator.js';
-import type { CuratorSummary } from './curator-types.js';
+import { appendCuratorRecommendation, readCuratorSummary } from './curator.js';
 import {
 	appendKnowledge,
 	enforceKnowledgeCap,
@@ -367,6 +366,14 @@ export async function checkHivePromotions(
 	};
 }
 
+export const _internals = {
+	readSwarmEntries: (directory: string) =>
+		readKnowledge<SwarmKnowledgeEntry>(resolveSwarmKnowledgePath(directory)),
+	checkHivePromotions,
+	readCuratorSummary,
+	appendCuratorRecommendation,
+};
+
 /**
  * Create a hook that promotes swarm entries to the hive.
  * The hook fires unconditionally - the caller decides when to invoke it.
@@ -377,45 +384,36 @@ export function createHivePromoterHook(
 ): (input: unknown, output: unknown) => Promise<void> {
 	const hook = async (_input: unknown, _output: unknown): Promise<void> => {
 		// Read swarm entries from the project directory
-		const swarmEntries = await readKnowledge<SwarmKnowledgeEntry>(
-			resolveSwarmKnowledgePath(directory),
-		);
+		const swarmEntries = await _internals.readSwarmEntries(directory);
 
 		// Run promotion logic and get summary
-		const promotionSummary = await checkHivePromotions(swarmEntries, config);
+		const promotionSummary = await _internals.checkHivePromotions(
+			swarmEntries,
+			config,
+		);
 
-		// Integrate with existing curator summary state
-		const curatorSummary = await readCuratorSummary(directory);
+		// Read first even on a no-op: this is the one-time migration path for
+		// legacy bloated curator summaries when a project is reopened.
+		const curatorSummary = await _internals.readCuratorSummary(directory);
+		if (!curatorSummary) return;
 
-		if (curatorSummary) {
-			// Defensive: ensure knowledge_recommendations is a valid array
-			const existingRecommendations = Array.isArray(
-				curatorSummary.knowledge_recommendations,
-			)
-				? curatorSummary.knowledge_recommendations
-				: [];
+		const hasActivity =
+			promotionSummary.new_promotions > 0 ||
+			promotionSummary.encounters_incremented > 0 ||
+			promotionSummary.advancements > 0;
+		if (!hasActivity) return;
 
-			// Add hive promotion summary as a knowledge recommendation
-			const recommendation = {
-				action: 'promote' as const,
-				lesson: `Hive promotion: ${promotionSummary.new_promotions} new, ${promotionSummary.encounters_incremented} encounters, ${promotionSummary.advancements} advancements, ${promotionSummary.total_hive_entries} total entries`,
-				reason: JSON.stringify({
-					timestamp: promotionSummary.timestamp,
-					new_promotions: promotionSummary.new_promotions,
-					encounters_incremented: promotionSummary.encounters_incremented,
-					advancements: promotionSummary.advancements,
-					total_hive_entries: promotionSummary.total_hive_entries,
-				}),
-			};
-
-			const updatedSummary: CuratorSummary = {
-				...curatorSummary,
-				knowledge_recommendations: [...existingRecommendations, recommendation],
-				last_updated: new Date().toISOString(),
-			};
-
-			await writeCuratorSummary(directory, updatedSummary);
-		}
+		await _internals.appendCuratorRecommendation(directory, {
+			action: 'promote',
+			lesson: `Hive promotion: ${promotionSummary.new_promotions} new, ${promotionSummary.encounters_incremented} encounters, ${promotionSummary.advancements} advancements, ${promotionSummary.total_hive_entries} total entries`,
+			reason: JSON.stringify({
+				timestamp: promotionSummary.timestamp,
+				new_promotions: promotionSummary.new_promotions,
+				encounters_incremented: promotionSummary.encounters_incremented,
+				advancements: promotionSummary.advancements,
+				total_hive_entries: promotionSummary.total_hive_entries,
+			}),
+		});
 	};
 
 	// Wrap in safeHook for fire-and-forget error suppression

--- a/src/hooks/knowledge-curator.ts
+++ b/src/hooks/knowledge-curator.ts
@@ -2,7 +2,13 @@
 
 import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import {
+	appendFile,
+	mkdir,
+	readFile,
+	realpath,
+	writeFile,
+} from 'node:fs/promises';
 import * as path from 'node:path';
 import { reserveQuota } from '../services/skill-improver-quota.js';
 import { rebuildSynonymMap } from '../services/synonym-map.js';
@@ -70,6 +76,8 @@ const seenRetroSections = new Map<
 // would otherwise grow this map without bound. Cap the entry count and evict the
 // oldest-timestamp entries (LRU-by-recency) once the cap is exceeded.
 const MAX_TRACKED_RETRO_SECTIONS = 500;
+const MAX_IN_FLIGHT_EVIDENCE_ENTRIES = 500;
+const inFlightEvidenceEntries = new Set<string>();
 
 /**
  * Prune entries from seenRetroSections that are older than 24 hours.
@@ -113,6 +121,137 @@ function recordSeenRetroSection(
 
 function hashContent(content: string): string {
 	return createHash('sha1').update(content).digest('hex');
+}
+
+async function canonicalExistingPath(candidate: string): Promise<string> {
+	let resolved = path.resolve(candidate);
+	try {
+		resolved = await _internals.realpath(resolved);
+	} catch {
+		// Paths can be absent in isolated tests or during teardown. Fall back to
+		// a lexical absolute path without blocking curation.
+	}
+	return resolved;
+}
+
+function isPathContained(root: string, candidate: string): boolean {
+	const relative = path.relative(root, candidate);
+	return (
+		relative === '' ||
+		(!relative.startsWith(`..${path.sep}`) &&
+			relative !== '..' &&
+			!path.isAbsolute(relative))
+	);
+}
+
+function physicalPathIdentity(candidate: string): string {
+	const normalized = candidate.replaceAll('\\', '/').normalize('NFC');
+	return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
+interface EvidencePathScope {
+	projectIdentity: string;
+	evidenceIdentity: string;
+}
+
+async function resolveEvidencePathScope(
+	directory: string,
+	relativeEvidencePath: string,
+): Promise<EvidencePathScope | null> {
+	const projectRoot = await canonicalExistingPath(directory);
+	const swarmRoot = await canonicalExistingPath(
+		path.join(projectRoot, '.swarm'),
+	);
+	if (!isPathContained(projectRoot, swarmRoot)) return null;
+	const evidenceRoot = await canonicalExistingPath(
+		path.join(swarmRoot, 'evidence'),
+	);
+	if (!isPathContained(swarmRoot, evidenceRoot)) return null;
+	const evidenceTarget = await canonicalExistingPath(
+		path.join(swarmRoot, ...relativeEvidencePath.split('/')),
+	);
+	if (!isPathContained(evidenceRoot, evidenceTarget)) return null;
+	return {
+		projectIdentity: hashContent(physicalPathIdentity(projectRoot)),
+		evidenceIdentity: hashContent(physicalPathIdentity(evidenceTarget)),
+	};
+}
+
+interface EvidenceLessonBatch {
+	identity: string;
+	lessons: string[];
+	projectName: string;
+	phaseNumber: number;
+}
+
+function sanitizeEvidenceLessons(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value
+		.filter((lesson): lesson is string => typeof lesson === 'string')
+		.map((lesson) => lesson.trim())
+		.filter((lesson) => lesson.length > 0 && lesson.length <= 280);
+}
+
+function evidenceProjectName(
+	entry: Record<string, unknown>,
+	root: Record<string, unknown>,
+): string {
+	const metadata = isRecord(entry.metadata) ? entry.metadata : null;
+	return typeof entry.project_name === 'string'
+		? entry.project_name
+		: typeof metadata?.project_name === 'string'
+			? metadata.project_name
+			: typeof root.project_name === 'string'
+				? root.project_name
+				: 'unknown';
+}
+
+function evidencePhaseNumber(
+	entry: Record<string, unknown>,
+	root: Record<string, unknown>,
+): number {
+	return typeof entry.phase_number === 'number'
+		? entry.phase_number
+		: typeof root.phase_number === 'number'
+			? root.phase_number
+			: 1;
+}
+
+function extractEvidenceLessonBatches(
+	evidenceData: Record<string, unknown>,
+): EvidenceLessonBatch[] {
+	const rawEntries = Array.isArray(evidenceData.entries)
+		? evidenceData.entries
+		: [evidenceData];
+	const batches: EvidenceLessonBatch[] = [];
+	for (const rawEntry of rawEntries) {
+		if (!isRecord(rawEntry)) continue;
+		if (Object.hasOwn(rawEntry, 'type') && rawEntry.type !== 'retrospective') {
+			continue;
+		}
+		const lessons = sanitizeEvidenceLessons(rawEntry.lessons_learned);
+		if (lessons.length === 0) continue;
+		const phaseNumber = evidencePhaseNumber(rawEntry, evidenceData);
+		const projectName = evidenceProjectName(rawEntry, evidenceData);
+		const identity = hashContent(
+			JSON.stringify([
+				rawEntry.type ?? 'legacy-retrospective',
+				rawEntry.task_id ?? evidenceData.task_id ?? '',
+				rawEntry.timestamp ?? '',
+				rawEntry.agent ?? '',
+				phaseNumber,
+				projectName,
+				lessons,
+			]),
+		);
+		batches.push({
+			identity,
+			lessons,
+			projectName,
+			phaseNumber,
+		});
+	}
+	return batches;
 }
 
 // ============================================================================
@@ -1489,11 +1628,16 @@ export function createKnowledgeCuratorHook(
 			// Compute normalized relative path (strip leading path up to and including .swarm/)
 			// Use this for both the read and the idempotency key to ensure stability
 			// across absolute vs relative path representations of the same file.
-			const relativeEvidencePath = trigger.filePath.replace(/^.*\.swarm\//, '');
-			// Create idempotency key for evidence: evidence:${sessionID}:${relativePath}
-			const evidenceKey = `evidence:${trigger.sessionID}:${relativeEvidencePath}`;
-			const lastSeenEvidence = seenRetroSections.get(evidenceKey);
-
+			const relativeEvidencePath = trigger.filePath
+				.replaceAll('\\', '/')
+				.replace(/^.*\.swarm\//i, '');
+			const canonicalRelativeEvidencePath =
+				path.posix.normalize(relativeEvidencePath);
+			const evidenceScope = await resolveEvidencePathScope(
+				directory,
+				canonicalRelativeEvidencePath,
+			);
+			if (!evidenceScope) return;
 			// Read and parse the evidence JSON file
 			const evidenceContent = await readSwarmFileAsync(
 				directory,
@@ -1508,49 +1652,40 @@ export function createKnowledgeCuratorHook(
 				return;
 			}
 
-			// Extract lessons_learned (handle both formats: { entries: [{ lessons_learned }] } and { lessons_learned })
-			let lessons: string[] = [];
-			if (
-				Array.isArray(evidenceData.entries) &&
-				evidenceData.entries.length > 0
-			) {
-				const firstEntry = evidenceData.entries[0] as Record<string, unknown>;
-				if (Array.isArray(firstEntry.lessons_learned)) {
-					lessons = firstEntry.lessons_learned as string[];
+			const batches = extractEvidenceLessonBatches(evidenceData);
+			for (const batch of batches) {
+				const evidenceKey = `evidence:${evidenceScope.projectIdentity}:${evidenceScope.evidenceIdentity}:entry:${batch.identity}`;
+				if (
+					seenRetroSections.has(evidenceKey) ||
+					inFlightEvidenceEntries.has(evidenceKey)
+				) {
+					continue;
 				}
-			} else if (Array.isArray(evidenceData.lessons_learned)) {
-				lessons = evidenceData.lessons_learned as string[];
+				if (inFlightEvidenceEntries.size >= MAX_IN_FLIGHT_EVIDENCE_ENTRIES) {
+					warn(
+						`Evidence curation overload: ${MAX_IN_FLIGHT_EVIDENCE_ENTRIES} entries already in flight; retrying ${relativeEvidencePath} on a later trigger`,
+					);
+					continue;
+				}
+
+				inFlightEvidenceEntries.add(evidenceKey);
+				try {
+					await _internals.curateAndStoreSwarm(
+						batch.lessons,
+						batch.projectName,
+						{ phase_number: batch.phaseNumber },
+						directory,
+						config,
+						{
+							llmDelegate: options.llmDelegateFactory?.(trigger.sessionID),
+							enrichmentQuota: options.enrichmentQuota,
+						},
+					);
+					recordSeenRetroSection(evidenceKey, batch.identity, Date.now());
+				} finally {
+					inFlightEvidenceEntries.delete(evidenceKey);
+				}
 			}
-
-			if (lessons.length === 0) return;
-
-			// Idempotency check for evidence
-			const evidenceHash = hashContent(JSON.stringify(lessons));
-			if (lastSeenEvidence?.value === evidenceHash) {
-				return; // no change
-			}
-			recordSeenRetroSection(evidenceKey, evidenceHash, Date.now());
-
-			// Extract project name from evidence data
-			const projectName = (evidenceData.project_name as string) ?? 'unknown';
-
-			// Extract phase number from evidence data
-			const phaseNumber =
-				typeof evidenceData.phase_number === 'number'
-					? evidenceData.phase_number
-					: 1;
-
-			await _internals.curateAndStoreSwarm(
-				lessons,
-				projectName,
-				{ phase_number: phaseNumber },
-				directory,
-				config,
-				{
-					llmDelegate: options.llmDelegateFactory?.(trigger.sessionID),
-					enrichmentQuota: options.enrichmentQuota,
-				},
-			);
 
 			return;
 		}
@@ -1618,6 +1753,10 @@ export const _internals: {
 	hashContent: typeof hashContent;
 	capSeenRetroSections: typeof capSeenRetroSections;
 	MAX_TRACKED_RETRO_SECTIONS: number;
+	inFlightEvidenceEntries: typeof inFlightEvidenceEntries;
+	MAX_IN_FLIGHT_EVIDENCE_ENTRIES: number;
+	extractEvidenceLessonBatches: typeof extractEvidenceLessonBatches;
+	realpath: typeof realpath;
 } = {
 	isWriteToEvidenceFile,
 	curateAndStoreSwarm,
@@ -1629,4 +1768,8 @@ export const _internals: {
 	hashContent,
 	capSeenRetroSections,
 	MAX_TRACKED_RETRO_SECTIONS,
+	inFlightEvidenceEntries,
+	MAX_IN_FLIGHT_EVIDENCE_ENTRIES,
+	extractEvidenceLessonBatches,
+	realpath,
 };

--- a/src/hooks/knowledge-curator.ts
+++ b/src/hooks/knowledge-curator.ts
@@ -1682,6 +1682,10 @@ export function createKnowledgeCuratorHook(
 						},
 					);
 					recordSeenRetroSection(evidenceKey, batch.identity, Date.now());
+				} catch (err) {
+					warn(
+						`Evidence curation failed for entry ${batch.identity}, will retry on next trigger: ${err instanceof Error ? err.message : String(err)}`,
+					);
 				} finally {
 					inFlightEvidenceEntries.delete(evidenceKey);
 				}

--- a/src/mutation/__tests__/engine.adversarial.test.ts
+++ b/src/mutation/__tests__/engine.adversarial.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from 'bun:test';
+import {
+	freezeClock,
+	type Restore,
+} from '../../../tests/helpers/test-clock.js';
 import type {
 	MutationOutcome,
 	MutationPatch,
@@ -306,26 +310,36 @@ describe('computeReport adversarial tests', () => {
 					'diff --git a/src/b.ts b/src/b.ts\n--- a/src/b.ts\n+++ b/src/b.ts\n@@ -1 +1 @@\n-old\n+new\n',
 			},
 		];
-		// With budgetMs = 0, first patch runs (0 > 0 is false), second is skipped
-		const report = await executeMutationSuite(
-			patches,
-			['node', '-e', 'process.exit(1)'],
-			[],
-			'/tmp',
-			0,
-		);
-		expect(report.totalMutants).toBe(2);
-		expect(report.skipped).toBe(1);
-		// First patch outcome: error (git apply fails on non-existent file) or killed (if it works)
-		// Either way exactly 1 is skipped — the key invariant
-		expect(
-			report.killed +
-				report.errors +
-				report.survived +
-				report.timeout +
-				report.equivalent,
-		).toBe(1);
-		expect(report.budgetExceeded).toBe(true);
+		let restoreClock: Restore = freezeClock({ fixedNow: 0 });
+		try {
+			// Hold elapsed time at zero through the first mutation, then restore the
+			// real clock so the second iteration deterministically exceeds the budget.
+			const report = await executeMutationSuite(
+				patches,
+				['node', '-e', 'process.exit(1)'],
+				[],
+				'/tmp',
+				0,
+				() => {
+					restoreClock();
+					restoreClock = () => {};
+				},
+			);
+			expect(report.totalMutants).toBe(2);
+			expect(report.skipped).toBe(1);
+			// First patch outcome: error (git apply fails on non-existent file) or killed (if it works)
+			// Either way exactly 1 is skipped — the key invariant
+			expect(
+				report.killed +
+					report.errors +
+					report.survived +
+					report.timeout +
+					report.equivalent,
+			).toBe(1);
+			expect(report.budgetExceeded).toBe(true);
+		} finally {
+			restoreClock();
+		}
 	});
 
 	// 9. Budget = Infinity — no patches should be skipped

--- a/tests/integration/curator-llm-delegation.test.ts
+++ b/tests/integration/curator-llm-delegation.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, test, vi } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
 import { CuratorConfigSchema } from '../../src/config/schema';
 import {
+	_internals,
 	type CuratorLLMDelegate,
 	parseKnowledgeRecommendations,
 	runCuratorInit,
@@ -26,14 +27,42 @@ vi.mock('../../src/hooks/knowledge-store', () => ({
 	sweepAgedEntries: async () => {},
 	sweepStaleTodos: async () => {},
 	bumpKnowledgeConfidenceBatch: async () => {},
+	transactFile: async (
+		_filePath: string,
+		_read: (filePath: string) => Promise<unknown>,
+		_write: (filePath: string, data: unknown) => Promise<void>,
+		mutate: (data: unknown) => unknown,
+	) => {
+		mutate({ summary: null, dirty: false });
+		return true;
+	},
 }));
 vi.mock('../../src/background/event-bus', () => ({
 	getGlobalEventBus: vi.fn().mockReturnValue({ publish: vi.fn() }),
 }));
 
 const defaultConfig: CuratorConfig = CuratorConfigSchema.parse({});
+const defaultTransactFile = _internals.transactFile;
+
+const transactFileStub = async (
+	_filePath: string,
+	_read: (filePath: string) => Promise<unknown>,
+	_write: (filePath: string, data: unknown) => Promise<void>,
+	mutate: (data: unknown) => unknown,
+): Promise<boolean> => {
+	mutate({ summary: null, dirty: false });
+	return true;
+};
 
 describe('curator LLM delegation', () => {
+	beforeEach(() => {
+		_internals.transactFile =
+			transactFileStub as typeof _internals.transactFile;
+	});
+	afterEach(() => {
+		_internals.transactFile = defaultTransactFile;
+	});
+
 	test('runCuratorPhase invokes llmDelegate in CURATOR_PHASE mode', async () => {
 		const delegate: CuratorLLMDelegate = vi
 			.fn()

--- a/tests/unit/hooks/curator-summary-recommendations.test.ts
+++ b/tests/unit/hooks/curator-summary-recommendations.test.ts
@@ -217,7 +217,7 @@ describe('curator recommendation persistence — regression: issue #1769', () =>
 		expect(loaded?.knowledge_recommendations).toHaveLength(3);
 		expect(
 			loaded?.knowledge_recommendations.map((entry) => entry.entry_id),
-		).toEqual(expect.arrayContaining(['entry-0', 'entry-2']));
+		).toEqual(expect.arrayContaining(['entry-0', 'entry-1', 'entry-2']));
 	});
 
 	test('a concurrent phase merge and hive append both survive', async () => {

--- a/tests/unit/hooks/curator-summary-recommendations.test.ts
+++ b/tests/unit/hooks/curator-summary-recommendations.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	_internals,
+	appendCuratorRecommendation,
+	mergeCuratorPhaseSummary,
+	readCuratorSummary,
+	writeCuratorSummary,
+} from '../../../src/hooks/curator.js';
+import type {
+	CuratorSummary,
+	KnowledgeRecommendation,
+} from '../../../src/hooks/curator-types.js';
+import { createSafeTestDir } from '../../helpers/safe-test-dir.js';
+
+function summary(
+	recommendations: KnowledgeRecommendation[] = [],
+): CuratorSummary {
+	return {
+		schema_version: 1,
+		session_id: 'recommendation-test',
+		last_updated: '2026-07-10T00:00:00.000Z',
+		last_phase_covered: 0,
+		digest: 'preserve-this-digest',
+		phase_digests: [],
+		compliance_observations: [],
+		knowledge_recommendations: recommendations,
+	};
+}
+
+function recommendation(index: number): KnowledgeRecommendation {
+	return {
+		action: 'rewrite',
+		entry_id: `entry-${index}`,
+		lesson: `lesson-${index}`,
+		reason: `reason-${index}`,
+	};
+}
+
+function rawWrite(directory: string, value: unknown): void {
+	const swarmDir = path.join(directory, '.swarm');
+	fs.mkdirSync(swarmDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(swarmDir, 'curator-summary.json'),
+		JSON.stringify(value, null, 2),
+	);
+}
+
+describe('curator recommendation persistence — regression: issue #1769', () => {
+	let directory: string;
+	let cleanup: () => void;
+	const realWriteState = _internals.writeCuratorSummaryState;
+
+	beforeEach(() => {
+		({ dir: directory, cleanup } = createSafeTestDir('curator-recs-'));
+		_internals.writeCuratorSummaryState = realWriteState;
+	});
+
+	afterEach(() => {
+		_internals.writeCuratorSummaryState = realWriteState;
+		cleanup();
+	});
+
+	test('direct writes enforce the newest 200 unique recommendations', async () => {
+		await writeCuratorSummary(
+			directory,
+			summary(Array.from({ length: 205 }, (_, index) => recommendation(index))),
+		);
+
+		const persisted = await readCuratorSummary(directory);
+		expect(persisted?.knowledge_recommendations).toHaveLength(200);
+		expect(persisted?.knowledge_recommendations[0].entry_id).toBe('entry-5');
+		expect(persisted?.knowledge_recommendations.at(-1)?.entry_id).toBe(
+			'entry-204',
+		);
+	});
+
+	test('first read deduplicates before capping and persists the newest hive records', async () => {
+		const flooded = Array.from({ length: 5_104 }, (_, index) => {
+			const kind = index % 5;
+			return {
+				action: 'promote' as const,
+				lesson: `Hive promotion: ${kind} new, 0 encounters, 0 advancements, 5 total entries`,
+				reason: JSON.stringify({
+					timestamp: `2026-07-10T00:00:${String(index).padStart(4, '0')}Z`,
+					new_promotions: kind,
+					encounters_incremented: 0,
+					advancements: 0,
+					total_hive_entries: 5,
+				}),
+			};
+		});
+		rawWrite(directory, summary(flooded));
+
+		const loaded = await readCuratorSummary(directory);
+		expect(loaded?.knowledge_recommendations).toHaveLength(5);
+		const persisted = JSON.parse(
+			fs.readFileSync(
+				path.join(directory, '.swarm', 'curator-summary.json'),
+				'utf-8',
+			),
+		) as CuratorSummary;
+		expect(persisted.knowledge_recommendations).toHaveLength(5);
+		expect(persisted.digest).toBe('preserve-this-digest');
+	});
+
+	test('canonical key ordering deduplicates equivalents but preserves distinct same-target directives', async () => {
+		const first = {
+			action: 'rewrite' as const,
+			entry_id: 'shared-entry',
+			lesson: 'same lesson',
+			reason: 'same reason',
+			triggers: ['one'],
+		};
+		const reordered = {
+			triggers: ['one'],
+			reason: 'same reason',
+			lesson: 'same lesson',
+			entry_id: 'shared-entry',
+			action: 'rewrite' as const,
+		};
+		const distinct = { ...first, reason: 'different reason' };
+		await writeCuratorSummary(directory, summary([first, reordered, distinct]));
+
+		const loaded = await readCuratorSummary(directory);
+		expect(loaded?.knowledge_recommendations).toHaveLength(2);
+		expect(
+			loaded?.knowledge_recommendations.map((entry) => entry.reason),
+		).toEqual(['same reason', 'different reason']);
+	});
+
+	test('newest-wins duplicate replacement returns true and persists the newest representative', async () => {
+		const hive = (timestamp: string): KnowledgeRecommendation => ({
+			action: 'promote',
+			lesson:
+				'Hive promotion: 1 new, 0 encounters, 0 advancements, 1 total entries',
+			reason: JSON.stringify({
+				timestamp,
+				new_promotions: 1,
+				encounters_incremented: 0,
+				advancements: 0,
+				total_hive_entries: 1,
+			}),
+		});
+		await writeCuratorSummary(
+			directory,
+			summary([hive('2026-07-10T00:00:00Z')]),
+		);
+
+		const changed = await appendCuratorRecommendation(
+			directory,
+			hive('2026-07-10T01:00:00Z'),
+		);
+
+		expect(changed).toBe(true);
+		const loaded = await readCuratorSummary(directory);
+		expect(loaded?.knowledge_recommendations).toHaveLength(1);
+		expect(loaded?.knowledge_recommendations[0].reason).toContain(
+			'2026-07-10T01:00:00Z',
+		);
+	});
+
+	test('already-normalized reads do not rewrite the file', async () => {
+		await writeCuratorSummary(directory, summary([recommendation(1)]));
+		const writeState = mock(realWriteState);
+		_internals.writeCuratorSummaryState = writeState;
+
+		const loaded = await readCuratorSummary(directory);
+		expect(loaded?.knowledge_recommendations).toHaveLength(1);
+		expect(writeState).not.toHaveBeenCalled();
+	});
+
+	test('missing or non-array containers normalize non-destructively', async () => {
+		rawWrite(directory, { ...summary(), knowledge_recommendations: null });
+		const loaded = await readCuratorSummary(directory);
+		expect(loaded?.knowledge_recommendations).toEqual([]);
+		expect(loaded?.digest).toBe('preserve-this-digest');
+	});
+
+	test('migration write failure returns normalized state and leaves the original file', async () => {
+		const duplicate = recommendation(1);
+		rawWrite(directory, summary([duplicate, { ...duplicate }]));
+		_internals.writeCuratorSummaryState = mock(async () => {
+			throw new Error('simulated read-only filesystem');
+		});
+
+		const loaded = await readCuratorSummary(directory);
+		expect(loaded?.knowledge_recommendations).toHaveLength(1);
+		const raw = JSON.parse(
+			fs.readFileSync(
+				path.join(directory, '.swarm', 'curator-summary.json'),
+				'utf-8',
+			),
+		) as CuratorSummary;
+		expect(raw.knowledge_recommendations).toHaveLength(2);
+	});
+
+	test('direct writes still report an inaccessible summary directory', async () => {
+		fs.writeFileSync(path.join(directory, '.swarm'), 'blocking file');
+
+		await expect(writeCuratorSummary(directory, summary())).rejects.toThrow(
+			'Failed to persist curator summary',
+		);
+	});
+
+	test('concurrent appends preserve every unique recommendation and deduplicate equivalents', async () => {
+		await writeCuratorSummary(directory, summary());
+		await Promise.all([
+			...Array.from({ length: 3 }, (_, index) =>
+				appendCuratorRecommendation(directory, recommendation(index)),
+			),
+			appendCuratorRecommendation(directory, { ...recommendation(1) }),
+		]);
+
+		const loaded = await readCuratorSummary(directory);
+		expect(loaded?.knowledge_recommendations).toHaveLength(3);
+		expect(
+			loaded?.knowledge_recommendations.map((entry) => entry.entry_id),
+		).toEqual(expect.arrayContaining(['entry-0', 'entry-2']));
+	});
+
+	test('a concurrent phase merge and hive append both survive', async () => {
+		await writeCuratorSummary(directory, summary());
+		const hive = {
+			action: 'promote' as const,
+			lesson:
+				'Hive promotion: 1 new, 0 encounters, 0 advancements, 1 total entries',
+			reason: JSON.stringify({ timestamp: new Date().toISOString() }),
+		};
+		await Promise.all([
+			appendCuratorRecommendation(directory, hive),
+			mergeCuratorPhaseSummary(directory, {
+				phase: 1,
+				phaseDigest: {
+					phase: 1,
+					timestamp: '2026-07-10T01:00:00.000Z',
+					summary: 'phase one',
+					agents_used: [],
+					tasks_completed: 1,
+					tasks_total: 1,
+					key_decisions: [],
+					blockers_resolved: [],
+				},
+				complianceObservations: [],
+				knowledgeRecommendations: [recommendation(99)],
+				sessionId: 'phase-session',
+				timestamp: '2026-07-10T01:00:00.000Z',
+			}),
+		]);
+
+		const loaded = await readCuratorSummary(directory);
+		expect(loaded?.phase_digests.map((entry) => entry.phase)).toEqual([1]);
+		expect(
+			loaded?.knowledge_recommendations.map((entry) => entry.lesson),
+		).toEqual(expect.arrayContaining([hive.lesson, 'lesson-99']));
+	});
+});

--- a/tests/unit/hooks/hive-promoter-recommendations.test.ts
+++ b/tests/unit/hooks/hive-promoter-recommendations.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	readCuratorSummary,
+	writeCuratorSummary,
+} from '../../../src/hooks/curator.js';
+import type { CuratorSummary } from '../../../src/hooks/curator-types.js';
+import {
+	_internals,
+	createHivePromoterHook,
+	type HivePromotionSummary,
+} from '../../../src/hooks/hive-promoter.js';
+import type { KnowledgeConfig } from '../../../src/hooks/knowledge-types.js';
+import { createSafeTestDir } from '../../helpers/safe-test-dir.js';
+
+const config = {
+	enabled: true,
+	hive_enabled: true,
+} as KnowledgeConfig;
+
+function summary(
+	recommendations: CuratorSummary['knowledge_recommendations'] = [],
+): CuratorSummary {
+	return {
+		schema_version: 1,
+		session_id: 'hive-hook-test',
+		last_updated: '2026-07-10T00:00:00.000Z',
+		last_phase_covered: 0,
+		digest: 'digest',
+		phase_digests: [],
+		compliance_observations: [],
+		knowledge_recommendations: recommendations,
+	};
+}
+
+function promotion(
+	overrides: Partial<HivePromotionSummary> = {},
+): HivePromotionSummary {
+	return {
+		timestamp: new Date().toISOString(),
+		new_promotions: 0,
+		encounters_incremented: 0,
+		advancements: 0,
+		total_hive_entries: 5,
+		...overrides,
+	};
+}
+
+describe('hive promoter recommendations — regression: issue #1769', () => {
+	let directory: string;
+	let cleanup: () => void;
+	const realReadEntries = _internals.readSwarmEntries;
+	const realCheck = _internals.checkHivePromotions;
+	const realReadSummary = _internals.readCuratorSummary;
+	const realAppend = _internals.appendCuratorRecommendation;
+
+	beforeEach(() => {
+		({ dir: directory, cleanup } = createSafeTestDir('hive-recs-'));
+		_internals.readSwarmEntries = mock(async () => []);
+		_internals.readCuratorSummary = readCuratorSummary;
+		_internals.appendCuratorRecommendation = realAppend;
+	});
+
+	afterEach(() => {
+		_internals.readSwarmEntries = realReadEntries;
+		_internals.checkHivePromotions = realCheck;
+		_internals.readCuratorSummary = realReadSummary;
+		_internals.appendCuratorRecommendation = realAppend;
+		cleanup();
+	});
+
+	test('zero activity adds no recommendation but still migrates a bloated summary', async () => {
+		const duplicate = {
+			action: 'promote' as const,
+			lesson:
+				'Hive promotion: 0 new, 0 encounters, 0 advancements, 5 total entries',
+			reason: JSON.stringify({ timestamp: '2026-07-10T00:00:00.000Z' }),
+		};
+		const swarmDir = path.join(directory, '.swarm');
+		fs.mkdirSync(swarmDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(swarmDir, 'curator-summary.json'),
+			JSON.stringify(
+				summary(Array.from({ length: 500 }, () => ({ ...duplicate }))),
+			),
+		);
+		_internals.checkHivePromotions = mock(async () => promotion());
+
+		await createHivePromoterHook(directory, config)({}, {});
+
+		const loaded = await readCuratorSummary(directory);
+		expect(loaded?.knowledge_recommendations).toHaveLength(1);
+	});
+
+	test('total hive entries alone is ambient state, not recommendation activity', async () => {
+		await writeCuratorSummary(directory, summary());
+		_internals.checkHivePromotions = mock(async () =>
+			promotion({ total_hive_entries: 999 }),
+		);
+
+		await createHivePromoterHook(directory, config)({}, {});
+
+		expect(
+			(await readCuratorSummary(directory))?.knowledge_recommendations,
+		).toEqual([]);
+	});
+
+	test('repeated semantic activity keeps one newest recommendation', async () => {
+		await writeCuratorSummary(directory, summary());
+		let invocation = 0;
+		_internals.checkHivePromotions = mock(async () =>
+			promotion({
+				timestamp: `2026-07-10T00:00:0${invocation++}.000Z`,
+				new_promotions: 1,
+				total_hive_entries: 1,
+			}),
+		);
+		const hook = createHivePromoterHook(directory, config);
+
+		await hook({}, {});
+		await hook({}, {});
+
+		const recommendations = (await readCuratorSummary(directory))
+			?.knowledge_recommendations;
+		expect(recommendations).toHaveLength(1);
+		expect(JSON.parse(recommendations?.[0].reason ?? '{}').timestamp).toBe(
+			'2026-07-10T00:00:01.000Z',
+		);
+	});
+
+	test('active promotion does not create a curator summary when none exists', async () => {
+		_internals.checkHivePromotions = mock(async () =>
+			promotion({ new_promotions: 1 }),
+		);
+
+		await createHivePromoterHook(directory, config)({}, {});
+
+		expect(
+			fs.existsSync(path.join(directory, '.swarm', 'curator-summary.json')),
+		).toBe(false);
+	});
+});

--- a/tests/unit/hooks/hive-promoter-task3-4.adversarial.test.ts
+++ b/tests/unit/hooks/hive-promoter-task3-4.adversarial.test.ts
@@ -16,10 +16,29 @@ afterEach(() => {
 // Mock curator module
 const mockReadCuratorSummary = mock();
 const mockWriteCuratorSummary = mock();
+const mockAppendCuratorRecommendation = mock(
+	async (directory: string, recommendation: unknown) => {
+		const summary = await mockReadCuratorSummary(directory);
+		if (!summary) return false;
+		await mockWriteCuratorSummary(directory, {
+			...summary,
+			last_updated: new Date().toISOString(),
+			knowledge_recommendations: [
+				...(Array.isArray(summary.knowledge_recommendations)
+					? summary.knowledge_recommendations
+					: []),
+				recommendation,
+			],
+		});
+		return true;
+	},
+);
 
 mock.module('../../../src/hooks/curator.js', () => ({
 	readCuratorSummary: (...args: unknown[]) => mockReadCuratorSummary(...args),
 	writeCuratorSummary: (...args: unknown[]) => mockWriteCuratorSummary(...args),
+	appendCuratorRecommendation: (...args: unknown[]) =>
+		mockAppendCuratorRecommendation(...args),
 }));
 
 // Mock knowledge-store module
@@ -49,11 +68,18 @@ mock.module('../../../src/hooks/knowledge-validator.js', () => ({
 }));
 
 // Import after mocking
-import { createHivePromoterHook } from '../../../src/hooks/hive-promoter.js';
+import {
+	_internals,
+	createHivePromoterHook,
+} from '../../../src/hooks/hive-promoter.js';
 import type { KnowledgeConfig } from '../../../src/hooks/knowledge-types.js';
 
 describe('Task 3.4: curator-summary feedback integration adversarial tests', () => {
 	let mockConfig: KnowledgeConfig;
+	const realCheckHivePromotions = _internals.checkHivePromotions;
+	const realReadCuratorSummary = _internals.readCuratorSummary;
+	const realAppendCuratorRecommendation =
+		_internals.appendCuratorRecommendation;
 
 	beforeEach(() => {
 		mock.restore();
@@ -82,6 +108,23 @@ describe('Task 3.4: curator-summary feedback integration adversarial tests', () 
 			encounter_increment: 0.1,
 			max_encounter_score: 5.0,
 		};
+		_internals.checkHivePromotions = mock(async () => ({
+			timestamp: new Date().toISOString(),
+			new_promotions: 1,
+			encounters_incremented: 0,
+			advancements: 0,
+			total_hive_entries: 1,
+		}));
+		_internals.readCuratorSummary = (...args) =>
+			mockReadCuratorSummary(...args);
+		_internals.appendCuratorRecommendation = (...args) =>
+			mockAppendCuratorRecommendation(...args);
+	});
+
+	afterEach(() => {
+		_internals.checkHivePromotions = realCheckHivePromotions;
+		_internals.readCuratorSummary = realReadCuratorSummary;
+		_internals.appendCuratorRecommendation = realAppendCuratorRecommendation;
 	});
 
 	describe('VULNERABILITY 2: Corrupted curator summary data', () => {

--- a/tests/unit/hooks/hive-promoter.test.ts
+++ b/tests/unit/hooks/hive-promoter.test.ts
@@ -55,6 +55,7 @@ mock.module('../../../src/hooks/knowledge-validator.js', () => ({
 }));
 
 import {
+	_internals,
 	checkHivePromotions,
 	createHivePromoterHook,
 } from '../../../src/hooks/hive-promoter.js';
@@ -1891,15 +1892,37 @@ describe('Task 3.3: same-run double-count prevention', () => {
 // Mock curator module for curator-summary tests
 const mockReadCuratorSummary = mock();
 const mockWriteCuratorSummary = mock();
+const mockAppendCuratorRecommendation = mock(
+	async (directory: string, recommendation: unknown) => {
+		const summary = await mockReadCuratorSummary(directory);
+		if (!summary) return false;
+		await mockWriteCuratorSummary(directory, {
+			...summary,
+			last_updated: new Date().toISOString(),
+			knowledge_recommendations: [
+				...(Array.isArray(summary.knowledge_recommendations)
+					? summary.knowledge_recommendations
+					: []),
+				recommendation,
+			],
+		});
+		return true;
+	},
+);
 
 mock.module('../../../src/hooks/curator.js', () => ({
 	readCuratorSummary: (...args: unknown[]) => mockReadCuratorSummary(...args),
 	writeCuratorSummary: (...args: unknown[]) => mockWriteCuratorSummary(...args),
+	appendCuratorRecommendation: (...args: unknown[]) =>
+		mockAppendCuratorRecommendation(...args),
 }));
 
 describe('Task 3.4: curator-summary feedback integration', () => {
 	let mockConfig: KnowledgeConfig;
 	let baseSwarmEntry: SwarmKnowledgeEntry;
+	const realReadCuratorSummary = _internals.readCuratorSummary;
+	const realAppendCuratorRecommendation =
+		_internals.appendCuratorRecommendation;
 
 	beforeEach(() => {
 		mock.restore();
@@ -1914,6 +1937,10 @@ describe('Task 3.4: curator-summary feedback integration', () => {
 		});
 		mockReadCuratorSummary.mockResolvedValue(null);
 		mockWriteCuratorSummary.mockResolvedValue(undefined);
+		_internals.readCuratorSummary = (...args) =>
+			mockReadCuratorSummary(...args);
+		_internals.appendCuratorRecommendation = (...args) =>
+			mockAppendCuratorRecommendation(...args);
 
 		// Base swarm entry for these tests
 		baseSwarmEntry = {
@@ -1967,6 +1994,11 @@ describe('Task 3.4: curator-summary feedback integration', () => {
 			max_encounter_score: 5.0,
 			initial_encounter_score: 1.0,
 		};
+	});
+
+	afterEach(() => {
+		_internals.readCuratorSummary = realReadCuratorSummary;
+		_internals.appendCuratorRecommendation = realAppendCuratorRecommendation;
 	});
 
 	it('createHivePromoterHook adds knowledge recommendation with promotion summary', async () => {

--- a/tests/unit/hooks/knowledge-curator-evidence-concurrency.test.ts
+++ b/tests/unit/hooks/knowledge-curator-evidence-concurrency.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+	createCuratorBeforeEach,
+	createCuratorMocks,
+	defaultConfig,
+	setupMockModules,
+} from './curator-test-fixtures.js';
+
+const mocks = createCuratorMocks();
+setupMockModules(mocks);
+
+const { mockReadSwarmFileAsync } = mocks;
+const { createKnowledgeCuratorHook, _internals } = await import(
+	'../../../src/hooks/knowledge-curator.js'
+);
+const { transactKnowledge: mockTransactKnowledge } = await import(
+	'../../../src/hooks/knowledge-store.js'
+);
+const resetFixtures = createCuratorBeforeEach(mocks, mockTransactKnowledge);
+const realCurate = _internals.curateAndStoreSwarm;
+const realRealpath = _internals.realpath;
+
+function trigger(sessionID = 'evidence-concurrency-session') {
+	return {
+		toolName: 'write',
+		path: '/project/.swarm/evidence/task-1/evidence.json',
+		sessionID,
+	};
+}
+
+describe('knowledge curator evidence concurrency — regression: issue #1769', () => {
+	beforeEach(() => {
+		resetFixtures();
+		_internals.seenRetroSections.clear();
+		_internals.inFlightEvidenceEntries.clear();
+		_internals.curateAndStoreSwarm = realCurate;
+		_internals.realpath = realRealpath;
+	});
+
+	afterEach(() => {
+		_internals.curateAndStoreSwarm = realCurate;
+		_internals.realpath = realRealpath;
+	});
+
+	test('concurrent duplicate triggers claim one entry once', async () => {
+		let release: (() => void) | undefined;
+		let signalStarted: (() => void) | undefined;
+		const blocked = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const started = new Promise<void>((resolve) => {
+			signalStarted = resolve;
+		});
+		const curate = mock(async () => {
+			signalStarted?.();
+			await blocked;
+			return {
+				stored: 1,
+				reinforced: 0,
+				skipped: 0,
+				rejected: 0,
+				quarantined: 0,
+			};
+		});
+		_internals.curateAndStoreSwarm = curate;
+		mockReadSwarmFileAsync.mockResolvedValue(
+			JSON.stringify({
+				entries: [
+					{
+						type: 'retrospective',
+						task_id: 'one',
+						timestamp: '2026-07-10T00:00:00.000Z',
+						agent: 'one',
+						phase_number: 1,
+						lessons_learned: ['Claim concurrent evidence exactly once'],
+					},
+				],
+			}),
+		);
+		const hook = createKnowledgeCuratorHook('/project', defaultConfig);
+
+		const calls = Promise.all([hook(trigger(), {}), hook(trigger(), {})]);
+		await started;
+		try {
+			expect(curate).toHaveBeenCalledTimes(1);
+		} finally {
+			release?.();
+			await calls;
+		}
+		expect(_internals.inFlightEvidenceEntries.size).toBe(0);
+	});
+
+	test('partial failure records earlier success and retries only the failed entry', async () => {
+		const curate = mock(async (lessons: string[]) => {
+			if (lessons[0].includes('fails') && curate.mock.calls.length === 2) {
+				throw new Error('simulated second-entry failure');
+			}
+			return {
+				stored: 1,
+				reinforced: 0,
+				skipped: 0,
+				rejected: 0,
+				quarantined: 0,
+			};
+		});
+		_internals.curateAndStoreSwarm = curate;
+		mockReadSwarmFileAsync.mockResolvedValue(
+			JSON.stringify({
+				entries: [
+					{
+						timestamp: '2026-07-10T00:00:00.000Z',
+						lessons_learned: ['The first entry succeeds and stays seen'],
+					},
+					{
+						timestamp: '2026-07-10T00:01:00.000Z',
+						lessons_learned: ['The second entry fails then retries'],
+					},
+				],
+			}),
+		);
+		const hook = createKnowledgeCuratorHook('/project', defaultConfig);
+
+		await expect(hook(trigger(), {})).rejects.toThrow(
+			'simulated second-entry failure',
+		);
+		await hook(trigger(), {});
+
+		expect(curate).toHaveBeenCalledTimes(3);
+		expect(curate.mock.calls[2][0]).toEqual([
+			'The second entry fails then retries',
+		]);
+		expect(_internals.inFlightEvidenceEntries.size).toBe(0);
+	});
+
+	test('in-flight overload does not evict active claims or mark skipped work seen', async () => {
+		const curate = mock(async () => ({
+			stored: 1,
+			reinforced: 0,
+			skipped: 0,
+			rejected: 0,
+			quarantined: 0,
+		}));
+		_internals.curateAndStoreSwarm = curate;
+		for (
+			let index = 0;
+			index < _internals.MAX_IN_FLIGHT_EVIDENCE_ENTRIES;
+			index++
+		) {
+			_internals.inFlightEvidenceEntries.add(`occupied-${index}`);
+		}
+		mockReadSwarmFileAsync.mockResolvedValue(
+			JSON.stringify({
+				lessons_learned: ['Retry overload work on a later trigger'],
+			}),
+		);
+		const hook = createKnowledgeCuratorHook('/project', defaultConfig);
+
+		await hook(trigger(), {});
+		expect(curate).not.toHaveBeenCalled();
+		expect(_internals.inFlightEvidenceEntries.size).toBe(
+			_internals.MAX_IN_FLIGHT_EVIDENCE_ENTRIES,
+		);
+
+		_internals.inFlightEvidenceEntries.clear();
+		await hook(trigger(), {});
+		expect(curate).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/unit/hooks/knowledge-curator-evidence-concurrency.test.ts
+++ b/tests/unit/hooks/knowledge-curator-evidence-concurrency.test.ts
@@ -120,9 +120,11 @@ describe('knowledge curator evidence concurrency — regression: issue #1769', (
 		);
 		const hook = createKnowledgeCuratorHook('/project', defaultConfig);
 
-		await expect(hook(trigger(), {})).rejects.toThrow(
-			'simulated second-entry failure',
-		);
+		// Per-entry error isolation: the hook resolves instead of throwing.
+		// Entry 1 succeeds (marked seen), entry 2 fails (warned, not marked seen).
+		await hook(trigger(), {});
+
+		// Second trigger retries entry 2 (entry 1 was already marked seen).
 		await hook(trigger(), {});
 
 		expect(curate).toHaveBeenCalledTimes(3);

--- a/tests/unit/hooks/knowledge-curator-evidence-curation.test.ts
+++ b/tests/unit/hooks/knowledge-curator-evidence-curation.test.ts
@@ -661,7 +661,7 @@ Phase: 1
 			expect(mockTransactKnowledge).toHaveBeenCalledTimes(1);
 		});
 
-		test('idempotency key uses sessionID + filePath', async () => {
+		test('evidence entry identity is stable across session IDs', async () => {
 			// Setup: evidence JSON with lessons
 			const evidenceContent = JSON.stringify({
 				lessons_learned: ['Lesson for session test'],
@@ -680,7 +680,7 @@ Phase: 1
 			};
 			await hook(input1, {});
 
-			// Second call with different sessionID 'session-2' - should NOT be idempotent
+			// Second call with a different session ID still targets the same entry.
 			const input2 = {
 				toolName: 'write',
 				path: '/project/.swarm/evidence/retro-1/evidence.json',
@@ -688,8 +688,8 @@ Phase: 1
 			};
 			await hook(input2, {});
 
-			// Expected: curateAndStoreSwarm called twice (different sessionIDs)
-			expect(mockTransactKnowledge).toHaveBeenCalledTimes(2);
+			// Expected: the stable entry identity suppresses cross-session replay.
+			expect(mockTransactKnowledge).toHaveBeenCalledTimes(1);
 		});
 	});
 
@@ -728,7 +728,14 @@ Phase: 1
 				project_name: 'test-project',
 				phase_number: 1,
 			});
-			mockReadSwarmFileAsync.mockResolvedValue(evidenceContent);
+			const patchedEvidenceContent = JSON.stringify({
+				lessons_learned: ['Lesson from apply patch operation'],
+				project_name: 'test-project',
+				phase_number: 1,
+			});
+			mockReadSwarmFileAsync
+				.mockResolvedValueOnce(evidenceContent)
+				.mockResolvedValueOnce(patchedEvidenceContent);
 
 			const hook = createKnowledgeCuratorHook('/project', defaultConfig);
 

--- a/tests/unit/hooks/knowledge-curator-multi-entry.test.ts
+++ b/tests/unit/hooks/knowledge-curator-multi-entry.test.ts
@@ -388,9 +388,7 @@ describe('knowledge curator multi-entry evidence — regression: issue #1769', (
 				normalized.endsWith('/evidence/alias-one.json') ||
 				normalized.endsWith('/evidence/alias-two.json')
 			) {
-				return process.platform === 'win32'
-					? 'C:\\project\\.swarm\\evidence\\physical.json'
-					: '/project/.swarm/evidence/physical.json';
+				return candidate.replace(/alias-(?:one|two)\.json$/i, 'physical.json');
 			}
 			return candidate;
 		});

--- a/tests/unit/hooks/knowledge-curator-multi-entry.test.ts
+++ b/tests/unit/hooks/knowledge-curator-multi-entry.test.ts
@@ -1,0 +1,455 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+	createCuratorBeforeEach,
+	createCuratorMocks,
+	defaultConfig,
+	setupMockModules,
+} from './curator-test-fixtures.js';
+
+const mocks = createCuratorMocks();
+setupMockModules(mocks);
+
+const { mockReadSwarmFileAsync } = mocks;
+const { createKnowledgeCuratorHook, _internals } = await import(
+	'../../../src/hooks/knowledge-curator.js'
+);
+const { transactKnowledge: mockTransactKnowledge } = await import(
+	'../../../src/hooks/knowledge-store.js'
+);
+const resetFixtures = createCuratorBeforeEach(mocks, mockTransactKnowledge);
+const realCurate = _internals.curateAndStoreSwarm;
+const realRealpath = _internals.realpath;
+
+function trigger(sessionID = 'multi-entry-session') {
+	return {
+		toolName: 'write',
+		path: '/project/.swarm/evidence/task-1/evidence.json',
+		sessionID,
+	};
+}
+
+describe('knowledge curator multi-entry evidence — regression: issue #1769', () => {
+	beforeEach(() => {
+		resetFixtures();
+		_internals.seenRetroSections.clear();
+		_internals.inFlightEvidenceEntries.clear();
+		_internals.curateAndStoreSwarm = realCurate;
+		_internals.realpath = realRealpath;
+	});
+
+	afterEach(() => {
+		_internals.curateAndStoreSwarm = realCurate;
+		_internals.realpath = realRealpath;
+	});
+
+	test('ingests a later retrospective when the first entry has no lessons', async () => {
+		const curate = mock(async () => ({
+			stored: 1,
+			reinforced: 0,
+			skipped: 0,
+			rejected: 0,
+			quarantined: 0,
+		}));
+		_internals.curateAndStoreSwarm = curate;
+		mockReadSwarmFileAsync.mockResolvedValueOnce(
+			JSON.stringify({
+				task_id: 'task-1',
+				entries: [
+					{ type: 'test', summary: 'no lessons here' },
+					{
+						type: 'retrospective',
+						task_id: 'task-1',
+						timestamp: '2026-07-10T00:00:00.000Z',
+						agent: 'reviewer',
+						phase_number: 4,
+						lessons_learned: ['Run the focused regression before publishing'],
+					},
+				],
+			}),
+		);
+
+		await createKnowledgeCuratorHook('/project', defaultConfig)(trigger(), {});
+
+		expect(curate).toHaveBeenCalledTimes(1);
+		expect(curate.mock.calls[0][0]).toEqual([
+			'Run the focused regression before publishing',
+		]);
+		expect(curate.mock.calls[0][2]).toEqual({ phase_number: 4 });
+	});
+
+	test('processes every eligible entry sequentially with entry metadata precedence', async () => {
+		const curate = mock(async () => ({
+			stored: 1,
+			reinforced: 0,
+			skipped: 0,
+			rejected: 0,
+			quarantined: 0,
+		}));
+		_internals.curateAndStoreSwarm = curate;
+		mockReadSwarmFileAsync.mockResolvedValueOnce(
+			JSON.stringify({
+				project_name: 'legacy-root',
+				phase_number: 1,
+				entries: [
+					{
+						type: 'retrospective',
+						task_id: 'one',
+						timestamp: '2026-07-10T00:00:00.000Z',
+						agent: 'one',
+						phase_number: 2,
+						metadata: { project_name: 'metadata-project' },
+						lessons_learned: ['Keep the first entry independently retryable'],
+					},
+					{
+						type: 'retrospective',
+						task_id: 'two',
+						timestamp: '2026-07-10T00:01:00.000Z',
+						agent: 'two',
+						phase_number: 3,
+						project_name: 'entry-project',
+						lessons_learned: ['Keep the second entry phase-specific'],
+					},
+				],
+			}),
+		);
+
+		await createKnowledgeCuratorHook('/project', defaultConfig)(trigger(), {});
+
+		expect(curate).toHaveBeenCalledTimes(2);
+		expect(curate.mock.calls[0][1]).toBe('metadata-project');
+		expect(curate.mock.calls[0][2]).toEqual({ phase_number: 2 });
+		expect(curate.mock.calls[1][1]).toBe('entry-project');
+		expect(curate.mock.calls[1][2]).toEqual({ phase_number: 3 });
+	});
+
+	test('entries that differ only by resolved project metadata are both curated', async () => {
+		const batches = _internals.extractEvidenceLessonBatches({
+			entries: [
+				{
+					type: 'retrospective',
+					task_id: 'shared',
+					timestamp: '2026-07-10T00:00:00.000Z',
+					project_name: 'project-one',
+					lessons_learned: ['Preserve project-specific attribution'],
+				},
+				{
+					type: 'retrospective',
+					task_id: 'shared',
+					timestamp: '2026-07-10T00:00:00.000Z',
+					metadata: { project_name: 'project-two' },
+					lessons_learned: ['Preserve project-specific attribution'],
+				},
+			],
+		});
+
+		expect(batches).toHaveLength(2);
+		expect(batches[0].identity).not.toBe(batches[1].identity);
+		expect(batches.map((batch) => batch.projectName)).toEqual([
+			'project-one',
+			'project-two',
+		]);
+	});
+
+	test('accepts missing-type legacy entries but rejects explicit non-retrospective spoofing', async () => {
+		const batches = _internals.extractEvidenceLessonBatches({
+			entries: [
+				{ lessons_learned: ['Preserve the legacy structural format'] },
+				{
+					type: 'test',
+					lessons_learned: ['Do not ingest a spoofed test entry'],
+				},
+				{
+					type: null,
+					lessons_learned: ['Do not ingest an explicit null type'],
+				},
+				{
+					type: 7,
+					lessons_learned: ['Do not ingest an explicit numeric type'],
+				},
+				{
+					type: {},
+					lessons_learned: ['Do not ingest an explicit object type'],
+				},
+				{
+					type: 'retrospective',
+					lessons_learned: [null, '   ', 'x'.repeat(281)],
+				},
+			],
+		});
+
+		expect(batches).toHaveLength(1);
+		expect(batches[0].lessons).toEqual([
+			'Preserve the legacy structural format',
+		]);
+	});
+
+	test('appending entry 2 processes only entry 2, independent of session id', async () => {
+		const curate = mock(async () => ({
+			stored: 1,
+			reinforced: 0,
+			skipped: 0,
+			rejected: 0,
+			quarantined: 0,
+		}));
+		_internals.curateAndStoreSwarm = curate;
+		const first = {
+			type: 'retrospective',
+			task_id: 'one',
+			timestamp: '2026-07-10T00:00:00.000Z',
+			agent: 'one',
+			phase_number: 1,
+			lessons_learned: ['Process the original entry once'],
+		};
+		const second = {
+			type: 'retrospective',
+			task_id: 'two',
+			timestamp: '2026-07-10T00:01:00.000Z',
+			agent: 'two',
+			phase_number: 2,
+			lessons_learned: ['Process only the appended entry next'],
+		};
+		mockReadSwarmFileAsync
+			.mockResolvedValueOnce(JSON.stringify({ entries: [first] }))
+			.mockResolvedValueOnce(JSON.stringify({ entries: [first, second] }));
+		const hook = createKnowledgeCuratorHook('/project', defaultConfig);
+
+		await hook(trigger('session-one'), {});
+		await hook(trigger('session-two'), {});
+
+		expect(curate).toHaveBeenCalledTimes(2);
+		expect(curate.mock.calls[1][0]).toEqual([
+			'Process only the appended entry next',
+		]);
+	});
+
+	test('identical evidence in different project roots is curated independently', async () => {
+		const curate = mock(async () => ({
+			stored: 1,
+			reinforced: 0,
+			skipped: 0,
+			rejected: 0,
+			quarantined: 0,
+		}));
+		_internals.curateAndStoreSwarm = curate;
+		const content = JSON.stringify({
+			entries: [
+				{
+					type: 'retrospective',
+					task_id: 'shared-task',
+					timestamp: '2026-07-10T00:00:00.000Z',
+					lessons_learned: ['Keep project-local evidence claims isolated'],
+				},
+			],
+		});
+		mockReadSwarmFileAsync.mockResolvedValue(content);
+		const firstProject = createKnowledgeCuratorHook(
+			'/project-one',
+			defaultConfig,
+		);
+		const secondProject = createKnowledgeCuratorHook(
+			'/project-two',
+			defaultConfig,
+		);
+
+		await firstProject(trigger('first-session'), {});
+		await secondProject(trigger('second-session'), {});
+		await firstProject(trigger('third-session'), {});
+
+		expect(curate).toHaveBeenCalledTimes(2);
+		expect(curate.mock.calls.map((call) => call[3])).toEqual([
+			'/project-one',
+			'/project-two',
+		]);
+	});
+
+	test('Windows path casing and separator variants share one evidence claim', async () => {
+		const curate = mock(async () => ({
+			stored: 1,
+			reinforced: 0,
+			skipped: 0,
+			rejected: 0,
+			quarantined: 0,
+		}));
+		_internals.curateAndStoreSwarm = curate;
+		mockReadSwarmFileAsync.mockResolvedValue(
+			JSON.stringify({
+				type: 'retrospective',
+				task_id: 'case-test',
+				lessons_learned: ['Normalize the complete Windows evidence key'],
+			}),
+		);
+		const onWindows = process.platform === 'win32';
+		const firstRoot = onWindows ? 'C:\\Repo' : '/repo';
+		const secondRoot = onWindows ? 'c:/repo' : '/repo';
+		const firstPath = onWindows
+			? 'C:\\Repo\\.SWARM\\EVIDENCE\\Task-1\\Evidence.JSON'
+			: '/repo/.SWARM/evidence/task-1/evidence.json';
+		const first = createKnowledgeCuratorHook(firstRoot, defaultConfig);
+		const second = createKnowledgeCuratorHook(secondRoot, defaultConfig);
+
+		await first(
+			{
+				toolName: 'write',
+				path: firstPath,
+				sessionID: 'case-one',
+			},
+			{},
+		);
+		await second(
+			{
+				toolName: 'write',
+				path: 'c:/repo/.swarm/evidence/task-1/evidence.json',
+				sessionID: 'case-two',
+			},
+			{},
+		);
+
+		expect(curate).toHaveBeenCalledTimes(1);
+		expect(mockReadSwarmFileAsync.mock.calls[0][1]).toBe(
+			onWindows
+				? 'EVIDENCE/Task-1/Evidence.JSON'
+				: 'evidence/task-1/evidence.json',
+		);
+	});
+
+	test('dot and redundant path segments share one evidence claim', async () => {
+		const curate = mock(async () => ({
+			stored: 1,
+			reinforced: 0,
+			skipped: 0,
+			rejected: 0,
+			quarantined: 0,
+		}));
+		_internals.curateAndStoreSwarm = curate;
+		mockReadSwarmFileAsync.mockResolvedValue(
+			JSON.stringify({
+				type: 'retrospective',
+				lessons_learned: ['Canonicalize equivalent evidence paths'],
+			}),
+		);
+		const hook = createKnowledgeCuratorHook('/project', defaultConfig);
+
+		for (const evidencePath of [
+			'/project/.swarm/evidence/task/evidence.json',
+			'/project/.swarm/evidence/task/./evidence.json',
+			'/project/.swarm/evidence//task/evidence.json',
+		]) {
+			await hook(
+				{ toolName: 'write', path: evidencePath, sessionID: evidencePath },
+				{},
+			);
+		}
+
+		expect(curate).toHaveBeenCalledTimes(1);
+	});
+
+	test('physical project-root aliases share one evidence claim', async () => {
+		const curate = mock(async () => ({
+			stored: 1,
+			reinforced: 0,
+			skipped: 0,
+			rejected: 0,
+			quarantined: 0,
+		}));
+		_internals.curateAndStoreSwarm = curate;
+		_internals.realpath = mock(async () =>
+			process.platform === 'win32'
+				? 'C:\\physical-project'
+				: '/physical-project',
+		);
+		mockReadSwarmFileAsync.mockResolvedValue(
+			JSON.stringify({
+				type: 'retrospective',
+				lessons_learned: ['Canonicalize physical project aliases'],
+			}),
+		);
+		const firstAlias = createKnowledgeCuratorHook('/alias-one', defaultConfig);
+		const secondAlias = createKnowledgeCuratorHook('/alias-two', defaultConfig);
+
+		await firstAlias(trigger('alias-one'), {});
+		await secondAlias(trigger('alias-two'), {});
+
+		expect(curate).toHaveBeenCalledTimes(1);
+		expect(_internals.realpath).toHaveBeenCalledTimes(8);
+	});
+
+	test('physical evidence-file aliases share one evidence claim', async () => {
+		const curate = mock(async () => ({
+			stored: 1,
+			reinforced: 0,
+			skipped: 0,
+			rejected: 0,
+			quarantined: 0,
+		}));
+		_internals.curateAndStoreSwarm = curate;
+		_internals.realpath = mock(async (candidate: string) => {
+			const normalized = candidate.replaceAll('\\', '/');
+			if (
+				normalized.endsWith('/evidence/alias-one.json') ||
+				normalized.endsWith('/evidence/alias-two.json')
+			) {
+				return process.platform === 'win32'
+					? 'C:\\project\\.swarm\\evidence\\physical.json'
+					: '/project/.swarm/evidence/physical.json';
+			}
+			return candidate;
+		});
+		mockReadSwarmFileAsync.mockResolvedValue(
+			JSON.stringify({
+				type: 'retrospective',
+				lessons_learned: ['Canonicalize physical evidence aliases'],
+			}),
+		);
+		const hook = createKnowledgeCuratorHook('/project', defaultConfig);
+
+		await hook(
+			{
+				toolName: 'write',
+				path: '/project/.swarm/evidence/alias-one.json',
+				sessionID: 'file-alias-one',
+			},
+			{},
+		);
+		await hook(
+			{
+				toolName: 'write',
+				path: '/project/.swarm/evidence/alias-two.json',
+				sessionID: 'file-alias-two',
+			},
+			{},
+		);
+
+		expect(curate).toHaveBeenCalledTimes(1);
+	});
+
+	test('physical evidence aliases outside the project are rejected', async () => {
+		const curate = mock(async () => ({
+			stored: 1,
+			reinforced: 0,
+			skipped: 0,
+			rejected: 0,
+			quarantined: 0,
+		}));
+		_internals.curateAndStoreSwarm = curate;
+		_internals.realpath = mock(async (candidate: string) =>
+			candidate.replaceAll('\\', '/').endsWith('/evidence/escape.json')
+				? process.platform === 'win32'
+					? 'C:\\outside\\escape.json'
+					: '/outside/escape.json'
+				: candidate,
+		);
+		const hook = createKnowledgeCuratorHook('/project', defaultConfig);
+
+		await hook(
+			{
+				toolName: 'write',
+				path: '/project/.swarm/evidence/escape.json',
+				sessionID: 'escape',
+			},
+			{},
+		);
+
+		expect(mockReadSwarmFileAsync).not.toHaveBeenCalled();
+		expect(curate).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Closes #1769

## Summary
- suppress hive-promoter curator recommendations when no promotion, encounter, or advancement state changed
- normalize curator recommendations through one locked persistence boundary with stable semantic deduplication, a newest-200 cap, and automatic first-read cleanup of legacy floods
- ingest every eligible retrospective entry in evidence bundles with strict explicit-type filtering, stable per-entry/project idempotency, bounded in-flight claims, and retry-safe partial progress
- make the physical evidence-alias regression fixture preserve the runner's actual drive and root so full Windows merge-queue shards validate the production containment behavior
- stabilize the merge-group coverage gate's zero-budget mutation assertion with the repository clock helper while preserving its first-runs/later-skips contract
- document the bounded recommendation and multi-entry evidence contracts and add the required pending release fragment

## Invariant audit
- 1 (plugin init): not touched — all new cleanup and curation work is runtime hook behavior; plugin registration and startup work are unchanged
- 2 (runtime portability): not touched — no package entry, bundle shape, Bun API, or top-level import contract changed; build and Node ESM import pass
- 3 (subprocesses): not touched — no subprocess code changed
- 4 (.swarm containment): touched — curator persistence remains anchored by `validateSwarmPath(directory, 'curator-summary.json')`; evidence identities reject physical aliases escaping the canonical project `.swarm/evidence` tree; focused containment, traversal, migration, and concurrency tests pass
- 5 (plan durability): not touched — no plan ledger, projection, checkpoint, or status code changed
- 6 (test_runner safety): not touched — validation used bounded shell-driven Bun processes, never broad `test_runner`
- 7 (test writing): touched — new Bun tests use DI seams, restore `_internals` after each case, and use repository safe temp-directory helpers; all 363 hook files were run in per-file isolation
- 8 (session state): touched — evidence idempotency is stable across sessions and scoped by physical project root plus canonical physical evidence target, the seen map retains its 500-entry/TTL bound, and the new in-flight claim set is capped at 500 and cleared in `finally`; project/path alias isolation, concurrency, overload, and retry tests pass
- 9 (guardrails/retry): not touched — no guardrail, provider retry, fallback, or circuit-breaker code changed
- 10 (chat/system msg): not touched — no chat or system-message hooks changed
- 11 (tool registration): not touched — no tools, agent maps, commands, or help registrations changed
- 12 (release/cache): touched — added `docs/releases/pending/hive-promoter-curator-flooding.md`; package versions, changelog, manifests, and cache behavior are unchanged

## Test plan
- four focused files in fresh Bun processes (`curator-summary-recommendations`, `hive-promoter-recommendations`, `knowledge-curator-multi-entry`, `knowledge-curator-evidence-concurrency`) — 28 pass; file sizes 258/143/455/168 lines
- merge-queue follow-up: `bun run test:unit:ci tests/unit/hooks/knowledge-curator-multi-entry.test.ts` — pass through the CI-equivalent isolated wrapper; adjacent multi-entry/concurrency suites — 14 pass
- coverage follow-up: mutation adversarial test failed 4/20 before stabilization and passes 30/30 under isolated coverage afterward; full mutation directory — 148 pass
- `bun --smol test ./tests/integration/curator-llm-delegation.test.ts --timeout 120000` — 6 pass
- all 363 hook test files in fresh Bun processes — 361 files pass; two unchanged canonical-main failures independently reproduced
- all integration files in fresh Bun processes — 69/70 files pass; sole failure is an unchanged Windows path-separator assertion in `issue-629-skill-improver.test.ts`
- isolated unit families: services 1,385 pass; agents 1,734 pass; CLI 334 pass; config 1,597 pass; tools 6,281 pass / 6 unchanged canonical failures; commands 1,881 pass / 2 unchanged canonical failures
- `bun test tests/security --timeout 120000` — 163 pass, 4 platform skips
- `bun test tests/smoke --timeout 120000` — 10 pass
- `bun run build` and `node --input-type=module -e "await import('./dist/index.js')"`
- `bun run typecheck`
- `bunx @biomejs/biome@2.3.14 ci .`
- `git diff --check`
- falsification: disabling the no-activity guard made exactly the two no-op/ambient-state assertions fail; restoring it returned the focused hive file to 4/4 pass

## Pre-existing failures
- `bun test tests/integration ./test --timeout 120000` is shared-process/order contaminated: this branch produced 798 pass / 147 fail, while pristine canonical main at `55cc0bf` produced 803 pass / 142 fail over the same 945 tests. The changed curator integration passes 6/6 alone; fresh-process integration isolation passes 69/70 files, with only the unchanged Windows separator assertion in `issue-629-skill-improver.test.ts` failing.
- `bun test tests/adversarial --timeout 120000` produced 814 pass / 15 fail. All failing tests and asserted source surfaces are outside this diff; signatures are stale agent-map/schema snapshots, existing evidence-contract expectations, and Windows tests that call `test.skip()` inside a running test.
- Fresh-process hook isolation passes 361/363 files. The two failures (illegal in-test `test.skip()` on Windows and missing canonical `confirmEntriesPhase` export) were independently reproduced at pristine `55cc0bf`.
- Fresh-process tools produced 6,281 pass / 6 fail in unchanged `knowledge-recall.test.ts`; fresh-process commands produced 1,881 pass / 2 fail in unchanged `cleanup-drift.test.ts` and `knowledge.adversarial.test.ts`. Each failing test and asserted/imported source surface is byte-identical to canonical main.
