### PR TITLE
fix(swarm-close): remove stale spec-drift state on finalize and reset

### DIFF
--- a/docs/releases/pending/close-reset-stale-spec-drift-state.md
+++ b/docs/releases/pending/close-reset-stale-spec-drift-state.md
@@ -1,0 +1,24 @@
+# `fix(swarm-close)`: remove stale spec-drift state on finalize and reset
+
+## Summary
+
+- `/swarm close` archived `.swarm/spec.md` but never deleted it from the active `.swarm/` directory, so the **next** session's `readEffectiveSpecSync` picked up the stale file as the current spec, mis-routing the architect into `CLARIFY-SPEC` / overwrite prompts against the prior session's task.
+- The same gap applied to two related single-session spec-drift artifacts, neither previously cleaned by close or reset:
+  - `.swarm/spec-staleness.json` — an existence-only marker checked unconditionally by `enforceSpecDriftGate`. A survivor **hard-blocked** `save_plan`, `update_task_status`, `phase_complete`, `lean_turbo_run_phase`, and `lean_turbo_acquire_locks` in the next session against drift that no longer applied.
+  - `.swarm/spec-snapshot.md` — the diff source feeding the `SPEC_DRIFT_BLOCK` error message.
+- `/swarm reset --confirm` had the identical three-file gap, plus omitted `.swarm/plan-ledger.jsonl`. A surviving ledger is replayed by `replayFromLedger()` on the next `loadPlan()`, risking resurrection of a plan that `reset` was supposed to wipe.
+- Fixed a companion issue in the close clean stage: the "Preserved `<artifact>` because it was not successfully archived" warning now fires only when a genuine archive failure was recorded, not for optional files that were simply absent (`ENOENT`).
+
+## User-facing changes
+
+- `/swarm close` now archives-then-removes `spec.md`, `spec-staleness.json`, and `spec-snapshot.md` from `.swarm/` (forensic copies remain in the archive bundle via the existing archive-first guard). Fresh sessions after a close no longer see a stale spec or a phantom drift block.
+- `/swarm reset --confirm` now also deletes `spec.md`, `spec-staleness.json`, `spec-snapshot.md`, and `plan-ledger.jsonl`, matching its "delete all swarm state" description and eliminating the plan-resurrection risk.
+- Close no longer emits spurious "Preserved ... not successfully archived" warnings for optional artifacts that were never present.
+
+## Migration notes
+
+None required. No schema or config changes; existing `.swarm/` directories are cleaned up automatically on the next `/swarm close` or `/swarm reset --confirm`.
+
+## Discovery context
+
+Root-caused via the `issue-tracer` skill in response to a report that "swarm finalize is not removing stale spec.md," which caused future sessions to be confused and ask for permission to overwrite or archive old plan state. A full writer/reader audit of every `.swarm/` artifact (parallel explorer sweep) confirmed `spec.md` was not an isolated case — `spec-staleness.json` and `spec-snapshot.md` shared the same single-session-state-survives-cleanup defect class, and `/swarm reset` had a parallel, independently-discovered gap. Every fix was fault-injection-proven (new/inverted tests fail without the corresponding code change) and independently verified by a fresh-context adversarial reviewer.

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -289,6 +289,8 @@ const ARCHIVE_ARTIFACTS = [
 	'close-summary.md',
 	'session-reflection.md',
 	'spec.md',
+	'spec-staleness.json',
+	'spec-snapshot.md',
 ];
 
 /**
@@ -317,10 +319,24 @@ const ARCHIVE_ARTIFACTS = [
  * Note: knowledge.jsonl is intentionally NOT cleaned because it contains cumulative
  * project knowledge (lessons learned) that should persist across sessions and finalize
  * cycles. The archive step still creates a backup for safety.
- * close-summary.md and spec.md are NOT cleaned because close-summary.md
- * is written as the final close output after cleanup and spec.md may not exist.
+ * close-summary.md is NOT cleaned because it is written as the final close output
+ * AFTER the clean stage runs. spec.md IS cleaned: it is single-session state coupled
+ * to the plan lifecycle (the plan it produced is removed above), so leaving it behind
+ * makes the next session pick up a stale spec via readEffectiveSpecSync and mis-route
+ * the architect into CLARIFY-SPEC/overwrite prompts. It is archived first (archive-first
+ * guard), so the forensic copy is preserved in the bundle. The earlier "spec.md may not
+ * exist" rationale was wrong — handoff.md is equally optional and is cleaned the same way.
  * session-reflection.md is a single-session snapshot (not cumulative like
  * knowledge.jsonl) so it IS cleaned to maintain the clean-slate invariant.
+ * spec-staleness.json and spec-snapshot.md are the same class of single-session
+ * spec-drift state as spec.md. spec-staleness.json is an existence-only gate
+ * checked unconditionally by enforceSpecDriftGate, which hard-blocks the core
+ * write tools (save_plan, update_task_status, phase_complete,
+ * lean_turbo_run_phase, lean_turbo_acquire_locks) with SPEC_DRIFT_BLOCK — a
+ * survivor would block the NEXT session against drift that no longer applies.
+ * spec-snapshot.md is its companion diff source, feeding the mismatch shown in
+ * the SPEC_DRIFT_BLOCK message. Both are archived first (archive-first guard),
+ * then cleaned so the next session starts drift-free.
  */
 const ACTIVE_STATE_TO_CLEAN = [
 	'plan.json',
@@ -337,6 +353,9 @@ const ACTIVE_STATE_TO_CLEAN = [
 	'dark-matter.md',
 	'telemetry.jsonl',
 	'session-reflection.md',
+	'spec.md',
+	'spec-staleness.json',
+	'spec-snapshot.md',
 	'swarm.db',
 	'swarm.db-shm',
 	'swarm.db-wal',
@@ -1277,13 +1296,17 @@ export async function runCleanStage(
 					continue;
 				}
 				// This file was NOT successfully archived — do not delete it.
-				// Include the failure reason when one was recorded (e.g. EBUSY,
+				// Only warn when a genuine archive failure was recorded (e.g. EBUSY,
 				// EPERM, ENOSPC) so operators can diagnose without digging into logs.
-				ctx.warnings.push(
-					reason
-						? `Preserved ${artifact} because it was not successfully archived: ${reason}.`
-						: `Preserved ${artifact} because it was not successfully archived.`,
-				);
+				// Absent optional files (ENOENT during the archive stage) have no
+				// recorded reason — they were simply never present, so we skip
+				// silently rather than spuriously warning about a "preserved" file
+				// that never existed.
+				if (reason) {
+					ctx.warnings.push(
+						`Preserved ${artifact} because it was not successfully archived: ${reason}.`,
+					);
+				}
 				continue;
 			}
 			const filePath = path.join(ctx.swarmDir, artifact);

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -369,7 +369,17 @@ const ACTIVE_STATE_TO_CLEAN = [
  * below agree on the set; otherwise the "Preserved …" warning would contradict the
  * removal that always follows for these files.
  */
-const TERMINAL_STATE_FILES = ['plan.json', 'plan-ledger.jsonl'] as const;
+const TERMINAL_STATE_FILES = [
+	'plan.json',
+	'plan-ledger.jsonl',
+	// spec-staleness.json / spec-snapshot.md are unconditionally removed even when
+	// archive fails. They are the existence-only drift-gate input for
+	// enforceSpecDriftGate; if archive-failed the file would survive and
+	// hard-block save_plan etc. in the next session. Mirror coverage in
+	// tests/unit/commands/close-cleanup.test.ts.
+	'spec-staleness.json',
+	'spec-snapshot.md',
+] as const;
 
 /**
  * Knowledge-family artifacts whose backing store redirects to a shared link

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -35,7 +35,17 @@ export async function handleResetCommand(
 	const filesToReset = [
 		'plan.md',
 		'plan.json',
+		// Plan backing-state: a surviving ledger gets replayed by replayFromLedger()
+		// on the next loadPlan(), resurrecting the wiped plan back into plan.json.
+		'plan-ledger.jsonl',
 		'context.md',
+		// Single-session spec-drift state. spec-staleness.json is an existence-only
+		// gate (enforceSpecDriftGate) that hard-blocks the core write tools
+		// (save_plan, update_task_status, phase_complete, lean_turbo_run_phase,
+		// lean_turbo_acquire_locks) — a survivor mis-routes or blocks the next session.
+		'spec.md',
+		'spec-staleness.json',
+		'spec-snapshot.md',
 		'SWARM_PLAN.md',
 		'SWARM_PLAN.json',
 		'plan-export/SWARM_PLAN.md',

--- a/tests/unit/commands/close-cleanup.test.ts
+++ b/tests/unit/commands/close-cleanup.test.ts
@@ -3,13 +3,15 @@
  *
  * Verifies the flat-file and directory archiving/deletion behavior:
  *   - 21 flat files in ARCHIVE_ARTIFACTS are copied to the archive bundle
- *   - 17 flat files in ACTIVE_STATE_TO_CLEAN are removed from .swarm/ after archiving
+ *   - 20 flat files in ACTIVE_STATE_TO_CLEAN are removed from .swarm/ after archiving
  *   - 4 active-state directories (evidence/, session/, scopes/, spec-archive/)
  *     are recursively copied to the archive and then deleted. (locks/ is
  *     intentionally excluded — per-run locks are managed via proper-lockfile,
  *     not archived/cleaned by close.)
  *   - Archive-first-guard: directories are only deleted if they were successfully archived
- *   - close-summary.md and spec.md are NOT in ACTIVE_STATE_TO_CLEAN — survive the clean stage
+ *   - close-summary.md is NOT in ACTIVE_STATE_TO_CLEAN — survives the clean stage.
+ *     spec.md IS in ACTIVE_STATE_TO_CLEAN — it is archived AND then cleaned, so a
+ *     stale spec never survives into the next session.
  *   - .swarm/archive/ itself survives the close
  *   - context.md is rewritten with "Session closed" content
  *   - Idempotent: running close twice produces no errors
@@ -48,6 +50,13 @@ import * as actualEvidenceManager from '../../../src/evidence/manager.js';
 // exports beyond curateAndStoreSwarm (e.g. enrichLessonToV3), so spread the
 // real module and only override the entry point this suite mocks.
 import * as actualKnowledgeCurator from '../../../src/hooks/knowledge-curator.js';
+// Same rationale as above: enforceSpecDriftGate (used by the regression test
+// below) lives in src/hooks/guardrails/index.ts, which transitively imports
+// src/state.js for exports beyond the ones this suite overrides (e.g.
+// getAgentSession, advanceTaskState, getActiveWindow). Spread the real module
+// and only override the entry points this suite needs deterministic/no-op
+// behavior for.
+import * as actualState from '../../../src/state.js';
 
 // ── Mocks (must precede the dynamic import) ──────────────────────────
 
@@ -83,6 +92,7 @@ mock.module('../../../src/session/snapshot-writer.js', () => ({
 }));
 
 mock.module('../../../src/state.js', () => ({
+	...actualState,
 	swarmState: {
 		activeToolCalls: new Map(),
 		toolAggregates: new Map(),
@@ -858,9 +868,9 @@ describe('handleCloseCommand — expanded artifact cleanup', () => {
 		});
 	});
 
-	// ── Test 8: close-summary.md and spec.md NOT in ACTIVE_STATE_TO_CLEAN ──
+	// ── Test 8: close-summary.md survives; spec.md is archived and cleaned ──
 
-	describe('close-summary.md and spec.md survive the clean stage', () => {
+	describe('close-summary.md survives; spec.md is archived and cleaned', () => {
 		it('close-summary.md is NOT deleted after close', async () => {
 			writePlan();
 
@@ -871,7 +881,7 @@ describe('handleCloseCommand — expanded artifact cleanup', () => {
 			expect(existsSync(path.join(swarmDir(), 'close-summary.md'))).toBe(true);
 		});
 
-		it('spec.md (when present) is NOT deleted after close', async () => {
+		it('spec.md is archived then removed after close', async () => {
 			writePlan();
 			writeFileSync(
 				path.join(swarmDir(), 'spec.md'),
@@ -880,11 +890,72 @@ describe('handleCloseCommand — expanded artifact cleanup', () => {
 
 			await handleCloseCommand(testDir, []);
 
-			// spec.md is in ARCHIVE_ARTIFACTS but NOT in ACTIVE_STATE_TO_CLEAN.
-			// It should be archived but NOT deleted from .swarm/.
+			// spec.md is in both ARCHIVE_ARTIFACTS and ACTIVE_STATE_TO_CLEAN: it is
+			// archived first (forensic copy preserved in the bundle), then removed
+			// from .swarm/ so the next session starts spec-free instead of picking
+			// up a stale spec.
 			const archivePath = getLatestArchivePath();
 			expect(existsSync(path.join(archivePath, 'spec.md'))).toBe(true);
-			expect(existsSync(path.join(swarmDir(), 'spec.md'))).toBe(true);
+			expect(existsSync(path.join(swarmDir(), 'spec.md'))).toBe(false);
+		});
+
+		it('spec-staleness.json is archived then removed after close', async () => {
+			writePlan();
+			writeFileSync(
+				path.join(swarmDir(), 'spec-staleness.json'),
+				'{"type":"spec_stale_detected"}',
+			);
+
+			await handleCloseCommand(testDir, []);
+
+			// spec-staleness.json is in both ARCHIVE_ARTIFACTS and
+			// ACTIVE_STATE_TO_CLEAN: archived first (forensic copy preserved in
+			// the bundle), then removed from .swarm/ so a stale drift gate never
+			// survives into the next session.
+			const archivePath = getLatestArchivePath();
+			expect(existsSync(path.join(archivePath, 'spec-staleness.json'))).toBe(
+				true,
+			);
+			expect(existsSync(path.join(swarmDir(), 'spec-staleness.json'))).toBe(
+				false,
+			);
+		});
+
+		it('spec-snapshot.md is archived then removed after close', async () => {
+			writePlan();
+			writeFileSync(
+				path.join(swarmDir(), 'spec-snapshot.md'),
+				'# Spec snapshot\n',
+			);
+
+			await handleCloseCommand(testDir, []);
+
+			const archivePath = getLatestArchivePath();
+			expect(existsSync(path.join(archivePath, 'spec-snapshot.md'))).toBe(true);
+			expect(existsSync(path.join(swarmDir(), 'spec-snapshot.md'))).toBe(false);
+		});
+
+		it('after close, a stale spec-staleness.json no longer blocks the core write tools', async () => {
+			writePlan();
+			writeFileSync(
+				path.join(swarmDir(), 'spec-staleness.json'),
+				'{"type":"spec_stale_detected"}',
+			);
+
+			const { enforceSpecDriftGate } = await import(
+				'../../../src/hooks/guardrails/index.js'
+			);
+
+			// Sanity: before close, the gate blocks save_plan against the stale marker.
+			expect(() => enforceSpecDriftGate(testDir, 'save_plan')).toThrow();
+
+			await handleCloseCommand(testDir, []);
+
+			expect(existsSync(path.join(swarmDir(), 'spec-staleness.json'))).toBe(
+				false,
+			);
+			// After close, the marker is gone, so the gate no longer blocks.
+			expect(() => enforceSpecDriftGate(testDir, 'save_plan')).not.toThrow();
 		});
 
 		it('events.jsonl IS deleted (in ACTIVE_STATE_TO_CLEAN)', async () => {
@@ -894,6 +965,39 @@ describe('handleCloseCommand — expanded artifact cleanup', () => {
 			await handleCloseCommand(testDir, []);
 
 			expect(existsSync(path.join(swarmDir(), 'events.jsonl'))).toBe(false);
+		});
+
+		it('after close, a stale spec.md is gone and no longer resolves as the effective spec', async () => {
+			writePlan();
+			writeFileSync(
+				path.join(swarmDir(), 'spec.md'),
+				'# Specification\n\nStale spec that must not survive close.',
+			);
+
+			await handleCloseCommand(testDir, []);
+
+			expect(existsSync(path.join(swarmDir(), 'spec.md'))).toBe(false);
+
+			const { readEffectiveSpecSync } = await import(
+				'../../../src/sdd/effective-spec.js'
+			);
+			expect(readEffectiveSpecSync(testDir)).toBeNull();
+		});
+
+		it('does not warn "Preserved" for optional ACTIVE_STATE_TO_CLEAN files that were never present', async () => {
+			// No spec.md, handoff.md, etc. are written — these are optional files
+			// that simply don't exist. The archive stage silently skips them
+			// (ENOENT), recording no failure reason. The clean stage must not
+			// mistake "never archived because absent" for "archive failed" and
+			// must not emit a spurious "Preserved <file> because it was not
+			// successfully archived" warning for them.
+			writePlan();
+
+			const result = await handleCloseCommand(testDir, []);
+
+			expect(result).not.toContain('Preserved spec.md');
+			expect(result).not.toContain('Preserved handoff.md');
+			expect(result).not.toContain('because it was not successfully archived');
 		});
 	});
 

--- a/tests/unit/commands/close-fb001-spec-staleness-archive-fail.test.ts
+++ b/tests/unit/commands/close-fb001-spec-staleness-archive-fail.test.ts
@@ -17,7 +17,10 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { type CloseStageContext, runCleanStage } from '../../../src/commands/close';
+import {
+	type CloseStageContext,
+	runCleanStage,
+} from '../../../src/commands/close';
 import { createSafeTestDir } from '../../helpers/safe-test-dir';
 
 let dir: string;
@@ -86,96 +89,86 @@ describe('FB-001 falsification probe: spec-staleness.json and spec-snapshot.md',
 		cleanupFn();
 	});
 
-	test(
-		'FB-001: spec-staleness.json is removed even when archive fails with EACCES',
-		async () => {
-			const specStalenessPath = path.join(swarmDir(), 'spec-staleness.json');
-			writeFileSync(specStalenessPath, '{"specHash":"abc","planHash":"def"}');
+	test('FB-001: spec-staleness.json is removed even when archive fails with EACCES', async () => {
+		const specStalenessPath = path.join(swarmDir(), 'spec-staleness.json');
+		writeFileSync(specStalenessPath, '{"specHash":"abc","planHash":"def"}');
 
-			const ctx = makeCtx();
-			await runCleanStage(ctx);
+		const ctx = makeCtx();
+		await runCleanStage(ctx);
 
-			// The file must be GONE — this is the core of FB-001.
-			// Before the fix: spec-staleness.json would be "Preserved" (not deleted)
-			// because it was not in TERMINAL_STATE_FILES.
-			// After the fix: it is in TERMINAL_STATE_FILES and the unconditional
-			// removal loop (close.ts:1524) deletes it regardless of archive failure.
-			expect(existsSync(specStalenessPath)).toBe(false);
+		// The file must be GONE — this is the core of FB-001.
+		// Before the fix: spec-staleness.json would be "Preserved" (not deleted)
+		// because it was not in TERMINAL_STATE_FILES.
+		// After the fix: it is in TERMINAL_STATE_FILES and the unconditional
+		// removal loop (close.ts:1524) deletes it regardless of archive failure.
+		expect(existsSync(specStalenessPath)).toBe(false);
 
-			// Confirm we actually hit the archive-failure path (not silently skipped).
-			const acccesWarning = ctx.warnings.find((w) =>
-				w.includes('spec-staleness.json was not archived'),
-			);
-			expect(acccesWarning).toBeDefined();
-			expect(acccesWarning).toContain('EACCES');
-			expect(acccesWarning).toContain('resurrection'); // confirms it is the correct warning
-		},
-	);
+		// Confirm we actually hit the archive-failure path (not silently skipped).
+		const acccesWarning = ctx.warnings.find((w) =>
+			w.includes('spec-staleness.json was not archived'),
+		);
+		expect(acccesWarning).toBeDefined();
+		expect(acccesWarning).toContain('EACCES');
+		expect(acccesWarning).toContain('resurrection'); // confirms it is the correct warning
+	});
 
-	test(
-		'FB-001: spec-snapshot.md is removed even when archive fails with EBUSY',
-		async () => {
-			const specSnapshotPath = path.join(swarmDir(), 'spec-snapshot.md');
-			writeFileSync(specSnapshotPath, '# Snapshot\nSome spec content');
+	test('FB-001: spec-snapshot.md is removed even when archive fails with EBUSY', async () => {
+		const specSnapshotPath = path.join(swarmDir(), 'spec-snapshot.md');
+		writeFileSync(specSnapshotPath, '# Snapshot\nSome spec content');
 
-			const ctx = makeCtx();
-			await runCleanStage(ctx);
+		const ctx = makeCtx();
+		await runCleanStage(ctx);
 
-			// The file must be GONE — same fix as spec-staleness.json.
-			expect(existsSync(specSnapshotPath)).toBe(false);
+		// The file must be GONE — same fix as spec-staleness.json.
+		expect(existsSync(specSnapshotPath)).toBe(false);
 
-			// Confirm we actually hit the archive-failure path.
-			const busyWarning = ctx.warnings.find((w) =>
-				w.includes('spec-snapshot.md was not archived'),
-			);
-			expect(busyWarning).toBeDefined();
-			expect(busyWarning).toContain('EBUSY');
-			expect(busyWarning).toContain('resurrection');
-		},
-	);
+		// Confirm we actually hit the archive-failure path.
+		const busyWarning = ctx.warnings.find((w) =>
+			w.includes('spec-snapshot.md was not archived'),
+		);
+		expect(busyWarning).toBeDefined();
+		expect(busyWarning).toContain('EBUSY');
+		expect(busyWarning).toContain('resurrection');
+	});
 
-	test(
-		'FB-001: NO "Preserved <spec file>" warning is emitted for spec-staleness.json or spec-snapshot.md',
-		async () => {
-			writeFileSync(
-				path.join(swarmDir(), 'spec-staleness.json'),
-				'{"specHash":"abc"}',
-			);
-			writeFileSync(path.join(swarmDir(), 'spec-snapshot.md'), '# Snapshot');
+	test('FB-001: NO "Preserved <spec file>" warning is emitted for spec-staleness.json or spec-snapshot.md', async () => {
+		writeFileSync(
+			path.join(swarmDir(), 'spec-staleness.json'),
+			'{"specHash":"abc"}',
+		);
+		writeFileSync(path.join(swarmDir(), 'spec-snapshot.md'), '# Snapshot');
 
-			const ctx = makeCtx();
-			await runCleanStage(ctx);
+		const ctx = makeCtx();
+		await runCleanStage(ctx);
 
-			// The original bug emitted "Preserved spec-staleness.json because it was
-			// not successfully archived: EACCES." — which was misleading because the
-			// unconditional removal would delete it anyway.
-			// The fix replaces this with the "was not archived; removing it anyway"
-			// message, so no "Preserved" diagnostic should appear.
-			const preservedWarnings = ctx.warnings.filter((w) =>
-				/Preserved spec-(staleness|snapshot)/.test(w),
-			);
-			expect(preservedWarnings).toHaveLength(0);
-		},
-	);
+		// The original bug emitted "Preserved spec-staleness.json because it was
+		// not successfully archived: EACCES." — which was misleading because the
+		// unconditional removal would delete it anyway.
+		// The fix replaces this with the "was not archived; removing it anyway"
+		// message, so no "Preserved" diagnostic should appear.
+		const preservedWarnings = ctx.warnings.filter((w) =>
+			/Preserved spec-(staleness|snapshot)/.test(w),
+		);
+		expect(preservedWarnings).toHaveLength(0);
+	});
 
-	test(
-		'FB-001: both spec files removed together in one close run',
-		async () => {
-			const specStalenessPath = path.join(swarmDir(), 'spec-staleness.json');
-			const specSnapshotPath = path.join(swarmDir(), 'spec-snapshot.md');
-			writeFileSync(specStalenessPath, '{"specHash":"abc"}');
-			writeFileSync(specSnapshotPath, '# Snapshot');
+	test('FB-001: both spec files removed together in one close run', async () => {
+		const specStalenessPath = path.join(swarmDir(), 'spec-staleness.json');
+		const specSnapshotPath = path.join(swarmDir(), 'spec-snapshot.md');
+		writeFileSync(specStalenessPath, '{"specHash":"abc"}');
+		writeFileSync(specSnapshotPath, '# Snapshot');
 
-			const ctx = makeCtx();
-			await runCleanStage(ctx);
+		const ctx = makeCtx();
+		await runCleanStage(ctx);
 
-			// Both must be gone.
-			expect(existsSync(specStalenessPath)).toBe(false);
-			expect(existsSync(specSnapshotPath)).toBe(false);
+		// Both must be gone.
+		expect(existsSync(specStalenessPath)).toBe(false);
+		expect(existsSync(specSnapshotPath)).toBe(false);
 
-			// Both warnings present.
-			expect(ctx.warnings.some((w) => w.includes('spec-staleness.json'))).toBe(true);
-			expect(ctx.warnings.some((w) => w.includes('spec-snapshot.md'))).toBe(true);
-		},
-	);
+		// Both warnings present.
+		expect(ctx.warnings.some((w) => w.includes('spec-staleness.json'))).toBe(
+			true,
+		);
+		expect(ctx.warnings.some((w) => w.includes('spec-snapshot.md'))).toBe(true);
+	});
 });

--- a/tests/unit/commands/close-fb001-spec-staleness-archive-fail.test.ts
+++ b/tests/unit/commands/close-fb001-spec-staleness-archive-fail.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Falsification probe: FB-001 / PR #1800
+ *
+ * Finding: When handleCloseCommand runs and the archive step fails
+ * (EPERM/EACCES/EBUSY) for `spec-staleness.json` or `spec-snapshot.md`,
+ * the file was preserved on disk because it was in ACTIVE_STATE_TO_CLEAN
+ * but NOT in TERMINAL_STATE_FILES. Next session's enforceSpecDriftGate
+ * would hard-block core write tools.
+ *
+ * Fix: spec-staleness.json and spec-snapshot.md were added to
+ * TERMINAL_STATE_FILES at close.ts:372-382, so the unconditional
+ * removal loop at close.ts:1524 removes them even when archiving failed.
+ *
+ * This probe exercises the archive-FAILURE path for both files and
+ * asserts they are removed unconditionally.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { type CloseStageContext, runCleanStage } from '../../../src/commands/close';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+let dir: string;
+let cleanupFn: () => void;
+
+function swarmDir(): string {
+	return path.join(dir, '.swarm');
+}
+
+function makeCtx(): CloseStageContext {
+	return {
+		directory: dir,
+		swarmDir: swarmDir(),
+		planData: { title: 'FB-001 Probe' },
+		planExists: true,
+		planAlreadyDone: true,
+		config: {},
+		projectName: 'FB-001 Probe',
+		warnings: [],
+		closedPhases: [],
+		closedTasks: [],
+		sessionStart: undefined,
+		isForced: false,
+		runSkillReview: false,
+		options: {},
+		phases: [],
+		inProgressPhases: [],
+		curationSucceeded: false,
+		curationResult: undefined,
+		allLessons: [],
+		explicitLessons: [],
+		retroLessons: [],
+		knowledgeSkillHint: '',
+		skillReviewSummary: '',
+		postMortemSummary: '',
+		sessionReflection: undefined,
+		hivePromoted: 0,
+		sessionKnowledgeCreated: 0,
+		fallbackKnowledgeCreated: 0,
+		originalStatuses: new Map(),
+		guaranteeResult: { closedPhaseIds: [], closedTaskIds: [] },
+		archiveResult: '',
+		archivedFileCount: 0,
+		// Simulate PARTIAL archive success: something was archived,
+		// but spec-staleness.json and spec-snapshot.md failed.
+		archivedActiveStateFiles: new Set<string>(['events.jsonl']),
+		archivedActiveStateDirs: new Set<string>(),
+		archiveFailureReasons: new Map<string, string>([
+			['spec-staleness.json', 'EACCES'],
+			['spec-snapshot.md', 'EBUSY'],
+		]),
+		timestamp: '',
+		archiveDir: '',
+		archiveSuffix: '',
+		args: [],
+	} as unknown as CloseStageContext;
+}
+
+describe('FB-001 falsification probe: spec-staleness.json and spec-snapshot.md', () => {
+	beforeEach(() => {
+		({ dir, cleanup: cleanupFn } = createSafeTestDir('fb001-probe-'));
+		mkdirSync(swarmDir(), { recursive: true });
+	});
+
+	afterEach(() => {
+		cleanupFn();
+	});
+
+	test(
+		'FB-001: spec-staleness.json is removed even when archive fails with EACCES',
+		async () => {
+			const specStalenessPath = path.join(swarmDir(), 'spec-staleness.json');
+			writeFileSync(specStalenessPath, '{"specHash":"abc","planHash":"def"}');
+
+			const ctx = makeCtx();
+			await runCleanStage(ctx);
+
+			// The file must be GONE — this is the core of FB-001.
+			// Before the fix: spec-staleness.json would be "Preserved" (not deleted)
+			// because it was not in TERMINAL_STATE_FILES.
+			// After the fix: it is in TERMINAL_STATE_FILES and the unconditional
+			// removal loop (close.ts:1524) deletes it regardless of archive failure.
+			expect(existsSync(specStalenessPath)).toBe(false);
+
+			// Confirm we actually hit the archive-failure path (not silently skipped).
+			const acccesWarning = ctx.warnings.find((w) =>
+				w.includes('spec-staleness.json was not archived'),
+			);
+			expect(acccesWarning).toBeDefined();
+			expect(acccesWarning).toContain('EACCES');
+			expect(acccesWarning).toContain('resurrection'); // confirms it is the correct warning
+		},
+	);
+
+	test(
+		'FB-001: spec-snapshot.md is removed even when archive fails with EBUSY',
+		async () => {
+			const specSnapshotPath = path.join(swarmDir(), 'spec-snapshot.md');
+			writeFileSync(specSnapshotPath, '# Snapshot\nSome spec content');
+
+			const ctx = makeCtx();
+			await runCleanStage(ctx);
+
+			// The file must be GONE — same fix as spec-staleness.json.
+			expect(existsSync(specSnapshotPath)).toBe(false);
+
+			// Confirm we actually hit the archive-failure path.
+			const busyWarning = ctx.warnings.find((w) =>
+				w.includes('spec-snapshot.md was not archived'),
+			);
+			expect(busyWarning).toBeDefined();
+			expect(busyWarning).toContain('EBUSY');
+			expect(busyWarning).toContain('resurrection');
+		},
+	);
+
+	test(
+		'FB-001: NO "Preserved <spec file>" warning is emitted for spec-staleness.json or spec-snapshot.md',
+		async () => {
+			writeFileSync(
+				path.join(swarmDir(), 'spec-staleness.json'),
+				'{"specHash":"abc"}',
+			);
+			writeFileSync(path.join(swarmDir(), 'spec-snapshot.md'), '# Snapshot');
+
+			const ctx = makeCtx();
+			await runCleanStage(ctx);
+
+			// The original bug emitted "Preserved spec-staleness.json because it was
+			// not successfully archived: EACCES." — which was misleading because the
+			// unconditional removal would delete it anyway.
+			// The fix replaces this with the "was not archived; removing it anyway"
+			// message, so no "Preserved" diagnostic should appear.
+			const preservedWarnings = ctx.warnings.filter((w) =>
+				/Preserved spec-(staleness|snapshot)/.test(w),
+			);
+			expect(preservedWarnings).toHaveLength(0);
+		},
+	);
+
+	test(
+		'FB-001: both spec files removed together in one close run',
+		async () => {
+			const specStalenessPath = path.join(swarmDir(), 'spec-staleness.json');
+			const specSnapshotPath = path.join(swarmDir(), 'spec-snapshot.md');
+			writeFileSync(specStalenessPath, '{"specHash":"abc"}');
+			writeFileSync(specSnapshotPath, '# Snapshot');
+
+			const ctx = makeCtx();
+			await runCleanStage(ctx);
+
+			// Both must be gone.
+			expect(existsSync(specStalenessPath)).toBe(false);
+			expect(existsSync(specSnapshotPath)).toBe(false);
+
+			// Both warnings present.
+			expect(ctx.warnings.some((w) => w.includes('spec-staleness.json'))).toBe(true);
+			expect(ctx.warnings.some((w) => w.includes('spec-snapshot.md'))).toBe(true);
+		},
+	);
+});

--- a/tests/unit/commands/reset.test.ts
+++ b/tests/unit/commands/reset.test.ts
@@ -311,6 +311,58 @@ describe('handleResetCommand', () => {
 		expect(result).toContain('⏭️ events.jsonl not found (skipped)');
 	});
 
+	// ── SPEC-DRIFT + PLAN-LEDGER STATE (resurrection guard) ──────────────────────
+	// Verifies reset wipes single-session spec-drift state (spec.md,
+	// spec-staleness.json, spec-snapshot.md) and plan-ledger.jsonl, matching the
+	// fix applied to /swarm close. Without this, spec-staleness.json survives as
+	// an existence-only gate that hard-blocks core write tools, and a surviving
+	// plan-ledger.jsonl gets replayed by replayFromLedger() on the next
+	// loadPlan(), resurrecting the wiped plan back into plan.json.
+	test('With --confirm - deletes spec-drift state files (spec.md, spec-staleness.json, spec-snapshot.md)', async () => {
+		await writeFile(join(tempDir, '.swarm', 'spec.md'), '# Spec');
+		await writeFile(
+			join(tempDir, '.swarm', 'spec-staleness.json'),
+			JSON.stringify({ stale: true }),
+		);
+		await writeFile(join(tempDir, '.swarm', 'spec-snapshot.md'), '# Snapshot');
+
+		const result = await handleResetCommand(tempDir, ['--confirm']);
+
+		expect(result).toContain('## Swarm Reset Complete');
+		expect(result).toContain('✅ Deleted spec.md');
+		expect(result).toContain('✅ Deleted spec-staleness.json');
+		expect(result).toContain('✅ Deleted spec-snapshot.md');
+		expect(existsSync(join(tempDir, '.swarm', 'spec.md'))).toBe(false);
+		expect(existsSync(join(tempDir, '.swarm', 'spec-staleness.json'))).toBe(
+			false,
+		);
+		expect(existsSync(join(tempDir, '.swarm', 'spec-snapshot.md'))).toBe(false);
+	});
+
+	test('With --confirm - deletes plan-ledger.jsonl and prevents plan resurrection via replayFromLedger', async () => {
+		await writeFile(
+			join(tempDir, '.swarm', 'plan.json'),
+			JSON.stringify({ swarm: 'test', title: 'Test Plan', phases: [] }),
+		);
+		await writeFile(
+			join(tempDir, '.swarm', 'plan-ledger.jsonl'),
+			`${JSON.stringify({ op: 'create', title: 'Test Plan' })}\n`,
+		);
+
+		const result = await handleResetCommand(tempDir, ['--confirm']);
+
+		expect(result).toContain('## Swarm Reset Complete');
+		expect(result).toContain('✅ Deleted plan-ledger.jsonl');
+		expect(result).toContain('✅ Deleted plan.json');
+
+		// Resurrection guard: both plan.json and plan-ledger.jsonl must be absent
+		// so a subsequent loadPlan()/replayFromLedger() has nothing to resurrect.
+		expect(existsSync(join(tempDir, '.swarm', 'plan.json'))).toBe(false);
+		expect(existsSync(join(tempDir, '.swarm', 'plan-ledger.jsonl'))).toBe(
+			false,
+		);
+	});
+
 	// ── SINGLETON PRESERVATION (FR-001d) ─────────────────────────────────
 	// Verifies that the reset command path does not disturb the 7 module-scoped
 	// singletons that are preserved by resetSwarmStatePreservingSingletons (used by close).


### PR DESCRIPTION
## Summary

- `/swarm close` archived `.swarm/spec.md` but never deleted it from the active `.swarm/` directory. The next session's `readEffectiveSpecSync` picked up the stale file as the current spec (native swarm spec always wins), mis-routing the architect into `CLARIFY-SPEC` / overwrite prompts against the prior session's task — this was the originally reported bug ("swarm finalize is not removing stale spec.md... causes all future sessions to be confused and ask for clarification and permission to overwrite or archive the old plan").
- A full `.swarm/` writer/reader audit found the same defect class in two more single-session spec-drift artifacts, neither previously cleaned:
  - `.swarm/spec-staleness.json` — an existence-only marker checked unconditionally by `enforceSpecDriftGate` (`src/hooks/guardrails/index.ts`, called at `src/hooks/guardrails/tool-before.ts:2088` with no plan-state guard). A survivor **hard-blocked** `save_plan`, `update_task_status`, `phase_complete`, `lean_turbo_run_phase`, and `lean_turbo_acquire_locks` in the next session, against drift that no longer applied.
  - `.swarm/spec-snapshot.md` — the diff source feeding the `SPEC_DRIFT_BLOCK` message.
- `/swarm reset --confirm` had the identical three-file gap, plus omitted `.swarm/plan-ledger.jsonl` — a surviving ledger is replayed by `replayFromLedger()` on the next `loadPlan()`, risking resurrection of a plan `reset` was supposed to wipe.
- Companion fix: the close clean-stage "Preserved `<artifact>` because it was not successfully archived" warning now fires only on a genuine recorded archive failure, not for optional files that were simply absent (`ENOENT`).

All four artifacts are now archived-then-cleaned by `/swarm close` (archive-first guard preserves the forensic copy in the bundle) and unconditionally removed by `/swarm reset --confirm`.

## Invariant audit
- 1 (plugin init): not touched — no changes to `src/index.ts`, plugin registration, or init-path code.
- 2 (runtime portability): not touched — no changes to `src/index.ts`, no `Bun.*` calls added; `bun run build` succeeds and `node --input-type=module -e "await import('./dist/index.js')"` confirms Node-ESM loadability.
- 3 (subprocesses): not touched — `grep -nE "bunSpawn\(|spawn\(|spawnSync\("` against the changed files (`src/commands/close.ts`, `src/commands/reset.ts`) shows no new subprocess call sites; the pre-existing `copySqliteSafe` spawnSync path in `close.ts` is untouched.
- 4 (.swarm containment): touched — all new cleanup targets (`spec.md`, `spec-staleness.json`, `spec-snapshot.md`, `plan-ledger.jsonl`) are added as plain filenames to `close.ts`'s `ARCHIVE_ARTIFACTS`/`ACTIVE_STATE_TO_CLEAN` arrays and `reset.ts`'s `filesToReset` array — both resolved exclusively via `path.join(ctx.swarmDir, ...)` / `validateSwarmPath(directory, ...)`, the existing containment helpers. No new `process.cwd()` usage, no new directory creation outside `.swarm/`.
- 5 (plan durability): touched — `reset.ts` now also deletes `.swarm/plan-ledger.jsonl` (previously omitted), closing a plan-resurrection gap where `replayFromLedger()` would rematerialize a wiped plan on the next `loadPlan()`. This mirrors `close.ts`'s pre-existing unconditional `TERMINAL_STATE_FILES` removal of the same file and does not introduce any new write path to `plan.json` outside the ledger-replay flow. New regression test `tests/unit/commands/reset.test.ts` asserts both `plan.json` and `plan-ledger.jsonl` are absent post-reset (resurrection guard).
- 6 (test_runner safety): not touched — all validation run via shell `bun test` commands, not the `test_runner` tool.
- 7 (test writing): touched — `tests/unit/commands/close-cleanup.test.ts` and `tests/unit/commands/reset.test.ts` extended with `bun:test`-only additions. The `close-cleanup.test.ts` end-to-end regression test required spreading the real `src/state.js` exports into the file's existing `mock.module('../../../src/state.js', ...)` factory (`...actualState`) so the dynamically-imported `enforceSpecDriftGate` resolves its transitive `state.js` dependency — follows the documented spread-real-exports pattern (AGENTS.md invariant 7). Verified this caused no collateral: all 46 tests in the file (old + new) pass together, and `bun --smol test tests/unit/commands/close-cleanup.test.ts tests/unit/commands/reset.test.ts` together = 63 pass / 0 fail.
- 8 (session state): not touched — no changes to session-keyed state, `swarmState`, or eviction logic.
- 9 (guardrails/retry): not touched — `enforceSpecDriftGate` and its blocked-tools set in `src/hooks/guardrails/index.ts` are unchanged; this PR only ensures the file it gates on (`spec-staleness.json`) is cleaned up at session boundaries.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no new tools, no `TOOL_NAMES` or agent-map changes.
- 12 (release/cache): touched (docs only) — added `docs/releases/pending/close-reset-stale-spec-drift-state.md`; did not hand-edit `package.json#version`, `CHANGELOG.md`, or `.release-please-manifest.json`.

## Test plan
- [x] `bun run build` — succeeds.
- [x] `node --input-type=module -e "await import('./dist/index.js')"` — `dist import OK`.
- [x] `bun run typecheck` — clean, no errors.
- [x] `bunx @biomejs/biome@2.3.14 check <changed files>` — clean (one auto-fix applied for line-wrap formatting, re-verified clean).
- [x] `bun --smol test tests/unit/commands/close-cleanup.test.ts tests/unit/commands/reset.test.ts` → **63 pass / 0 fail** (218 expect() calls).
- [x] Fault-injection proof: reverting only the array-entry additions in `close.ts`/`reset.ts` causes the new/inverted tests to fail (3 in close-cleanup, 2 in reset); restoring the fix makes them pass again. Confirms the tests actually exercise the fix.
- [x] `bun --smol test tests/unit/cli tests/unit/commands tests/unit/config` → 3131 pass / 696 fail — **pre-existing**, reproduced identically (694 fail, 2-test delta = my own added tests) on clean `origin/main` via `git worktree add`. Root cause: cross-file `mock.module` pollution in Bun's shared test-runner process (documented repo-wide issue, AGENTS.md invariant 7), not introduced by this change.
- [x] `bun test tests/security` → 163 pass / 4 skip / 0 fail.
- [x] `bun test tests/adversarial` → 816 pass / 13 fail — **pre-existing**, reproduced identically (816/13, same failure count) on clean `origin/main`. Unrelated subsystems (architect tool whitelists, evidence timestamp/task-id validation, config schema mutation).
- [x] `bun test tests/integration ./test` → 803 pass / 142 fail — **pre-existing**, reproduced identically (803/142) on clean `origin/main`. Failure *set* is non-deterministic run-to-run even on the same commit (confirmed via two consecutive runs on this branch with differing failure identities but identical counts) — run-order-dependent shared-process mock pollution, not a regression.
- [x] `bun test tests/smoke` → 10 pass / 0 fail.
- [x] Independent fresh-context adversarial verification (separate `verifier` subagent, opus) confirmed the `close.ts` fix: archive-first invariant holds, real (non-mocked) `enforceSpecDriftGate` gate exercised, no collateral damage, idempotent double-close safe, genuine archive failures still preserved+warned.

## Pre-existing failures
See Test plan above — `tests/unit/{cli,commands,config}` (696 fail), `tests/adversarial` (13 fail), and `tests/integration`+`./test` (142 fail) all reproduce identically on clean `origin/main` (verified via `git worktree add origin/main` + symlinked `node_modules`). These are cross-file `mock.module` pollution in Bun's shared test-runner process, a known repo-wide issue distinct from this change's scope.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

