### PR TITLE
fix(security): correct drive-letter asymmetry in validateSymlinkBoundary

### DIFF
--- a/docs/releases/pending/validate-symlink-boundary-drive-letter-fix.md
+++ b/docs/releases/pending/validate-symlink-boundary-drive-letter-fix.md
@@ -1,0 +1,21 @@
+# `fix(security)`: correct drive-letter asymmetry in validateSymlinkBoundary on Windows
+
+## Summary
+
+- `validateSymlinkBoundary` (`src/utils/path-security.ts`) could throw a spurious "Symlink resolution escaped boundary" error on Windows whenever exactly one of its two inputs (`targetPath`, `rootPath`) happened to exist on disk while the other did not.
+- Root cause: when `fs.realpathSync` throws for a nonexistent path, the function fell back to `path.normalize`, which does **not** attach a drive letter to a rootless POSIX-style absolute path (e.g. `/foo/bar`) on Windows. Meanwhile, `fs.realpathSync` on the side that *does* exist returns a fully resolved, drive-letter-qualified path. Comparing a drive-lettered path against a non-drive-lettered one via `startsWith` is an apples-to-oranges comparison that fails regardless of whether a real boundary violation occurred.
+- Fix: the fallback now uses `path.resolve` instead of `path.normalize`. `path.resolve` anchors a rootless-absolute path to the current process drive — the same anchoring `realpathSync` implicitly performs for a path that exists — so both fallback branches produce a consistent comparison basis whether or not either side happens to exist.
+
+## User-facing changes
+
+None directly — this is an internal path-security utility. The practical effect: `validateSymlinkBoundary`'s one real caller (`getGraphPath` in `src/tools/repo-graph/storage.ts`, guarding `.swarm/repo-graph.json` against symlink escapes) no longer risks a false-positive boundary-violation error caused by incidental filesystem state unrelated to the actual paths being validated.
+
+## Migration notes
+
+None required.
+
+## Discovery context
+
+Found while investigating why PR #1800 was removed from the GitHub merge queue for a `unit (windows-latest)` failure. The repo's CI intentionally runs Windows/macOS shards only on `merge_group` (not on regular `pull_request` checks, for fast feedback — see `.github/workflows/ci.yml:114-125`), so this pre-existing bug was never caught by ordinary PR validation.
+
+The failure was traced to `tests/unit/utils/path-security.test.ts`'s `validateSymlinkBoundary > handles non-existent paths gracefully`, which failed because an unrelated test elsewhere in the repo (`src/state.rehydration-adversarial.test.ts`, which uses a hardcoded literal path `/non/existent/dir/67890` instead of an `os.tmpdir()`-scoped path — itself an AGENTS.md invariant-7 violation, out of scope for this fix) leaves a real directory behind at that exact location, creating the asymmetric-existence condition that exposed the bug. The bug was reproduced deterministically, independent of that incidental pollution, via a new regression test that explicitly forces one side to exist and the other not to (Windows-only, since the drive-letter concept doesn't exist elsewhere).

--- a/src/utils/path-security.ts
+++ b/src/utils/path-security.ts
@@ -89,6 +89,19 @@ export function validateDirectory(directory: string): void {
  * Resolves symlinks via realpathSync for both the target path and the root,
  * then verifies the resolved target is within the resolved root.
  *
+ * The non-existent-path fallback uses path.resolve (not path.normalize):
+ * path.resolve anchors a rootless-absolute path (e.g. POSIX-style '/foo/bar'
+ * passed on Windows) to the current drive, matching what realpathSync would
+ * produce for a path that DOES exist. path.normalize does not add a drive
+ * letter. Without this, a case where exactly one of targetPath/rootPath
+ * happens to exist on disk (e.g. leftover state from an unrelated test, or
+ * any incidental real path) resolves that side via realpathSync (drive
+ * letter attached) while the other falls back to normalize (no drive
+ * letter) — an apples-to-oranges comparison that spuriously throws
+ * regardless of whether a real boundary escape occurred. Using resolve for
+ * both fallback branches keeps the comparison basis consistent whether
+ * realpathSync succeeds or not, independent of incidental filesystem state.
+ *
  * @param targetPath - The path to validate (absolute)
  * @param rootPath - The root directory boundary (absolute)
  * @throws Error if the resolved target escapes the root boundary
@@ -101,14 +114,14 @@ export function validateSymlinkBoundary(
 	try {
 		realTarget = fs.realpathSync(targetPath);
 	} catch {
-		realTarget = path.normalize(targetPath);
+		realTarget = path.resolve(targetPath);
 	}
 
 	let realRoot: string;
 	try {
 		realRoot = fs.realpathSync(rootPath);
 	} catch {
-		realRoot = path.normalize(rootPath);
+		realRoot = path.resolve(rootPath);
 	}
 
 	const normalizedTarget = path.normalize(realTarget);

--- a/tests/unit/utils/path-security.test.ts
+++ b/tests/unit/utils/path-security.test.ts
@@ -142,11 +142,59 @@ describe('validateSymlinkBoundary', () => {
 	});
 
 	test('handles non-existent paths gracefully', () => {
-		// realpathSync throws for non-existent paths, should fall back to normalize
+		// realpathSync throws for non-existent paths, should fall back to resolve
 		expect(() =>
 			validateSymlinkBoundary('/non/existent/path', '/non/existent'),
 		).not.toThrow();
 	});
+
+	test.skipIf(process.platform !== 'win32')(
+		'handles asymmetric existence of a rootless-absolute path (root exists, target does not) without a spurious throw',
+		() => {
+			// Regression test for the drive-letter asymmetry bug: a rootless
+			// POSIX-style absolute path (leading '/', no drive letter) is
+			// resolved by Windows APIs relative to the CURRENT PROCESS DRIVE.
+			// If such a path happens to exist on disk (e.g. leftover state from
+			// an unrelated process/test) while a nested path under it does not,
+			// realpathSync succeeds for the existing one (producing a
+			// drive-letter-qualified resolved path) but throws for the
+			// non-existent one, falling back to the normalize/resolve branch.
+			// Before the fix (path.normalize fallback), that fallback did NOT
+			// add a drive letter, so the comparison was drive-lettered root vs
+			// non-drive-lettered target — a spurious "escaped boundary" throw
+			// unrelated to any real boundary violation. path.resolve anchors
+			// both consistently to the current drive regardless of which side
+			// actually exists.
+			//
+			// This exercises a genuinely current-drive-relative Windows path,
+			// which os.tmpdir() cannot express portably (it may live on a
+			// different drive than process.cwd()) — so this test intentionally
+			// creates a real directory directly under the current drive root
+			// rather than under os.tmpdir(), with a unique name and
+			// unconditional cleanup, and is skipped entirely off win32 where
+			// the drive-letter concept (and therefore this bug class) does not
+			// exist.
+			const rootless = `/boundary-asymmetric-test-${process.pid}-${Date.now()}`;
+			// Rootless target — keep it a POSIX-style string (no drive letter) so
+			// its realpathSync failure falls back through the same code path as
+			// root, rather than inheriting a drive letter via path.join from an
+			// already-resolved parent.
+			const targetRootless = `${rootless}/definitely-does-not-exist-subpath`;
+			const realRootDir = path.resolve(rootless);
+
+			// Create only the root — the nested target subpath must NOT exist,
+			// so realpathSync succeeds for root (drive-lettered) but throws for
+			// target (falls back to the normalize/resolve branch under test).
+			fs.mkdirSync(realRootDir, { recursive: true });
+			try {
+				expect(() =>
+					validateSymlinkBoundary(targetRootless, rootless),
+				).not.toThrow();
+			} finally {
+				fs.rmSync(realRootDir, { recursive: true, force: true });
+			}
+		},
+	);
 
 	test('works with subdirectory of root', () => {
 		expect(() => validateSymlinkBoundary('/foo/bar/baz', '/foo')).not.toThrow();


### PR DESCRIPTION
## Summary

- `validateSymlinkBoundary` (`src/utils/path-security.ts`) could throw a spurious "Symlink resolution escaped boundary" error on Windows whenever exactly one of its two inputs (`targetPath`, `rootPath`) happened to exist on disk while the other did not.
- Root cause: when `fs.realpathSync` throws for a nonexistent path, the function fell back to `path.normalize`, which does **not** attach a drive letter to a rootless POSIX-style absolute path (e.g. `/foo/bar`) on Windows — while `fs.realpathSync` on the side that *does* exist returns a fully resolved, drive-letter-qualified path. Comparing a drive-lettered path against a non-drive-lettered one via `startsWith` is an apples-to-oranges comparison that fails regardless of whether a real boundary violation occurred.
- Fix: the fallback now uses `path.resolve` instead of `path.normalize`. `path.resolve` anchors a rootless-absolute path to the current process drive — the same anchoring `realpathSync` implicitly performs for a path that exists — so both fallback branches produce a consistent comparison basis whether or not either side happens to exist.
- Added a Windows-only regression test that deterministically forces the asymmetric-existence condition (one real directory, one guaranteed-absent nested path, both expressed as rootless POSIX-style strings) rather than relying on incidental filesystem pollution to reproduce it.

## Discovery context

Found while investigating why PR #1800 was removed from the GitHub merge queue for a `unit (windows-latest)` failure. This repo's CI intentionally runs the Windows/macOS matrix **only** on `merge_group`, not on regular `pull_request` checks (`.github/workflows/ci.yml:114-125`, for fast per-PR feedback), so this pre-existing bug was never caught by ordinary PR validation — it only surfaces once a PR enters the merge queue.

The specific trigger on the CI runner: `src/state.rehydration-adversarial.test.ts` uses a hardcoded literal path (`/non/existent/dir/67890`) instead of an `os.tmpdir()`-scoped one when testing that `ensureAgentSession` doesn't crash for a "nonexistent" directory — the function under test actually creates real files there as a side effect, leaving `/non/existent` (though not the full nested path) behind on disk. That's a separate, out-of-scope AGENTS.md invariant-7 test-hygiene violation (not fixed here — flagged for a follow-up); this PR fixes the underlying `validateSymlinkBoundary` fragility so it is correct regardless of any such incidental pollution.

## Invariant audit
- 1 (plugin init): not touched.
- 2 (runtime portability): not touched — no `src/index.ts`/plugin-entry changes; `bun run build` succeeds and `node --input-type=module -e "await import('./dist/index.js')"` confirms Node-ESM loadability.
- 3 (subprocesses): not touched.
- 4 (.swarm containment): not touched directly, but the one real caller of `validateSymlinkBoundary` (`getGraphPath` in `src/tools/repo-graph/storage.ts:184-190`) guards `.swarm/repo-graph.json` symlink-escape detection — `bun --smol test tests/unit/tools/repo-graph*.test.ts` (103 pass / 0 fail) confirms the fix does not weaken that boundary check; the escape-detection tests (`'throws when target is outside root'`, `'throws for Windows path outside boundary'`) still pass unchanged.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — all validation via shell `bun test` commands.
- 7 (test writing): touched — extended `tests/unit/utils/path-security.test.ts` with a `bun:test`-only, `test.skipIf(process.platform !== 'win32')`-gated regression test. No `mock.module` introduced (deliberately avoided for `node:fs`, given its pervasive use elsewhere in the shared test-runner process — see PR discussion). Fault-injection proof: reverting only the `path.resolve` change locally reproduces the failure in both the pre-existing test and the new regression test; restoring makes both pass.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched.
- 12 (release/cache): touched (docs only) — added `docs/releases/pending/validate-symlink-boundary-drive-letter-fix.md`; did not hand-edit `package.json#version`, `CHANGELOG.md`, or `.release-please-manifest.json`.

## Test plan
- [x] `bun run build` — succeeds.
- [x] `node --input-type=module -e "await import('./dist/index.js')"` — `dist import OK`.
- [x] `bun run typecheck` — clean, no errors.
- [x] `bunx @biomejs/biome@2.3.14 check src/utils/path-security.ts tests/unit/utils/path-security.test.ts` — clean.
- [x] `bun test tests/unit/utils/path-security.test.ts` → **29 pass / 1 skip / 0 fail** (the skip is the pre-existing POSIX-only symlink-escape test, correctly skipped on win32).
- [x] Fault-injection proof: reverting only the two `path.normalize` → `path.resolve` lines causes both `'handles non-existent paths gracefully'` (pre-existing) and the new asymmetric-existence regression test to fail with the exact documented error; restoring makes both pass again.
- [x] Blast-radius check: `bun --smol test tests/unit/tools/repo-graph.test.ts tests/unit/tools/repo-graph-safe-realpath.test.ts tests/unit/tools/repo-graph-comment-stripping.test.ts tests/unit/tools/repo-graph-js-family.test.ts` (the real call site) → **103 pass / 0 fail**.
- [x] `bun --smol test tests/unit/utils` → 99 pass / 2 skip / 0 fail.
- [x] `bun test tests/security` → 163 pass / 4 skip / 0 fail.
- [x] `bun test tests/adversarial` → **829 pass / 0 fail** (fully green — this suite had 13 pre-existing unrelated failures as of `origin/main`@ff7b690d; they were independently resolved by other main commits between then and this branch's base@bdf75695).
- [x] `bun --smol test tests/unit/cli tests/unit/commands tests/unit/config` → 3127 pass / 700 fail — **pre-existing**, reproduced identically (byte-for-byte same 3127/700) on clean `origin/main`@bdf75695 via `git worktree add`. Cross-file `mock.module` pollution in Bun's shared test-runner process (documented repo-wide issue, AGENTS.md invariant 7), unrelated to this 2-file change.
- [x] `bun test tests/integration ./test` → 746 pass / 199 fail — same documented pre-existing, non-deterministic (run-order-dependent) failure class established and reproduced against clean `origin/main` in the companion PR #1800; this change touches a disjoint, self-contained path utility with its own fully-green direct test suite.
- [x] `bun test tests/smoke` → 10 pass / 0 fail.

## Pre-existing failures
`tests/unit/{cli,commands,config}` (700 fail) reproduces identically on clean `origin/main`@bdf75695. `tests/integration`+`./test` (199 fail) is the same known non-deterministic cross-file `mock.module` pollution class documented in PR #1800 — unrelated to this change, which is scoped entirely to `src/utils/path-security.ts` and its direct test file.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

