### PR TITLE
fix(tui): migrate hook-path console.warn to advisoryWarn/log (PR3/5 #1754)

### DIFF
--- a/docs/releases/pending/1754-tui-pollution-pr3-hook-path.md
+++ b/docs/releases/pending/1754-tui-pollution-pr3-hook-path.md
@@ -1,0 +1,93 @@
+# TUI pollution sweep — hook path (PR3 of epic #1752)
+
+## What
+
+Migrates every remaining raw `console.warn` on the plugin-host hook path
+(chat/tool/system message hooks and their service dependencies, plus the
+`prm` recording subsystem) to the PR1 foundation helpers:
+
+- **43 diagnostic fail-open catches** → `logger.log(msg)` — debug-gated
+  (`OPENCODE_SWARM_DEBUG=1`), NOT buffered. These are best-effort evidence
+  records, git provisioning fallbacks, confidence-floor sweeps, JSONL-parse
+  skips, budget-state writes, and PRM recording failures. They would flood
+  `/swarm diagnose` if buffered.
+- **2 operator-actionable / security-adjacent signals** → `advisoryWarn(msg)`
+  — buffered for `/swarm diagnose` + emitted under debug. Never raw stderr.
+
+Migrated files (`src/`):
+
+- `hooks/delegation-gate.ts` — 3 evidence-record / parse-failure catches.
+- `hooks/delegation-gate/worktree-isolation.ts` — 20 provisioning-fallback
+  catches (serialization cap, git worktree/add/commit/rev-parse/tag failures,
+  orphan recovery, collision cleanup, lane-env read).
+- `hooks/knowledge-store.ts` — 7 confidence-floor sweep / JSONL-parse /
+  delta-apply fail-open catches.
+- `hooks/skill-usage-log.ts` — 2 usage-feedback fail-open catches.
+- `council/council-evidence-writer.ts` — 1 round-history audit-log append catch.
+- `diff/ast-diff.ts` — 1 AST-timeout fallback.
+- `services/context-budget-service.ts` — 1 budget-state write catch.
+- `session/worktree-link-suggestion.ts` — 1 actionable advisory (>1 worktree
+  → run `/swarm link`).
+- `prm/index.ts` — 1 toolAfter error catch.
+- `prm/replay.ts` — 4 sites (1 path-traversal-blocked defense-in-depth signal
+  → `advisoryWarn`; 3 recording-failure catches → `log`).
+- `prm/trajectory-store.ts` — 4 non-blocking swallow-error catches.
+
+## Why
+
+Raw `console.warn` writes to stderr corrupt the OpenCode bubbletea TUI when
+it owns the terminal (issue #1249 class). The hook path fires these on any
+diagnostic fail-open condition mid-turn — with no error surfaced to the user.
+PR1 built the `advisoryWarn` helper; PR2 closed the init path; this PR closes
+the hook path so the TUI stays clean during delegation, evidence recording,
+confidence-floor sweeps, council rounds, AST diffing, context-budget writes,
+worktree provisioning, and PRM trajectory recording.
+
+## Behavior changes
+
+- The 43 diagnostic catches are now silent unless `OPENCODE_SWARM_DEBUG=1`.
+  Previously they wrote raw stderr on every fail-open. No operational
+  information is lost — operators debugging a specific failure set the env
+  var or inspect the return values (the catches already fail open).
+- The worktree-link suggestion and the replay path-traversal-blocked signal
+  are now discoverable in `/swarm diagnose` (buffered) instead of polluting
+  stderr. The worktree-link suggestion remains once-per-session (deduped).
+- The replay path-traversal signal is defense-in-depth: under normal flow it
+  is unreachable (`sanitizeFilename` neutralizes traversal before the
+  `isPathSafe` guard runs), but if it ever fires it signals an internal-
+  invariant violation worth surfacing via `/swarm diagnose`.
+- No breaking API changes. All function signatures, return values, and
+  default fail-open behavior are preserved; only the warning delivery channel
+  changed.
+
+## Regression guard
+
+Extended `tests/unit/plugin-tui-safety.test.ts` to cover the 11 migrated
+files (matching the PR2 precedent). The scan asserts each file contains zero
+raw `console.warn`. This is the interim guard until PR5 of epic #1752 enables
+Biome `suspicious/noConsole` globally.
+
+## Testing
+
+- Updated `tests/unit/session/worktree-link-suggestion.test.ts` to assert via
+  `getDeferredWarnings()` / `clearDeferredWarnings()` (PR2 buffer pattern)
+  instead of `spyOn(console, 'warn')`, with `clearDeferredWarnings()` in
+  `beforeEach`/`afterEach` (AGENTS.md Invariant 7).
+- Updated 3 test files whose assertions observed `console.warn`/`console.log`
+  output from migrated diagnostic sites (`council/evidence-writer-gaps`,
+  `hooks/delegation-gate-worktree-isolation.serialization`,
+  `hooks/delegation-gate.evidence`) to set `OPENCODE_SWARM_DEBUG='1'` and
+  capture via `console.log`, restoring env + console in `finally`.
+- The 4 other test files the issue listed (`curator-atomic-write`,
+  `delegation-tracker`, `guardrails-directory`, `diagnose-buffered-warning`)
+  were verified by direct grep + import inspection to assert on non-migrated
+  source or inline test logic; no edits were needed.
+
+## Scope notes
+
+- Biome `suspicious/noConsole` enforcement remains deferred to PR5 of epic
+  #1752.
+- `src/agents/index.ts` (hand-rolled `if (!quiet) console.warn` pattern),
+  `src/commands/dark-matter.ts`, and the ~85 other `TUI_POLLUTING_UNGUARDED`
+  sites identified in the broader sweep are explicitly out of scope for PR3
+  and belong to PR4/PR5.

--- a/src/council/council-evidence-writer.ts
+++ b/src/council/council-evidence-writer.ts
@@ -23,6 +23,7 @@ import {
 	taskEvidencePath,
 	withTaskEvidenceLock,
 } from '../evidence/task-file.js';
+import * as logger from '../utils/logger.js';
 import type { CouncilSynthesis } from './types';
 
 const EVIDENCE_DIR = '.swarm/evidence';
@@ -190,7 +191,7 @@ export async function writeCouncilEvidence(
 		);
 	} catch (auditError) {
 		// Audit log failure must not break the primary evidence write.
-		console.warn(
+		logger.log(
 			`writeCouncilEvidence: failed to append round-history audit log: ${auditError instanceof Error ? auditError.message : String(auditError)}`,
 		);
 	}

--- a/src/diff/ast-diff.ts
+++ b/src/diff/ast-diff.ts
@@ -5,6 +5,7 @@ import {
 	type LanguageDefinition,
 } from '../lang/registry.js';
 import { loadGrammar } from '../lang/runtime.js';
+import * as logger from '../utils/logger.js';
 
 export interface ASTChange {
 	type: 'added' | 'modified' | 'removed' | 'renamed';
@@ -236,7 +237,7 @@ export async function computeASTDiff(
 		// On timeout or error, fall back to raw diff
 		const errorMsg = error instanceof Error ? error.message : 'Unknown error';
 		if (errorMsg === 'AST_TIMEOUT') {
-			console.warn(
+			logger.log(
 				`[ast-diff] Timeout for ${filePath}, falling back to raw diff`,
 			);
 		}

--- a/src/hooks/delegation-gate.evidence.test.ts
+++ b/src/hooks/delegation-gate.evidence.test.ts
@@ -210,7 +210,7 @@ describe('delegation-gate evidence recording', () => {
 		expect(await hasPassedAllGates(tmpDir, '3.1')).toBe(true);
 	});
 
-	it('11. evidence-write failure emits console.warn but does not block delegation', async () => {
+	it('11. evidence-write failure is logged but does not block delegation', async () => {
 		startAgentSession('sess-11', 'architect');
 		const session = ensureAgentSession('sess-11');
 		session.currentTaskId = '1.11';
@@ -222,28 +222,37 @@ describe('delegation-gate evidence recording', () => {
 		rmSync(swarmDir, { recursive: true, force: true });
 		writeFileSync(swarmDir, 'blocked'); // Make it a file instead of directory
 
-		// Spy on console.warn
-		const originalWarn = console.warn;
-		const warnCalls: string[] = [];
-		console.warn = (...args: unknown[]) => {
-			warnCalls.push(args.map(String).join(' '));
+		// Epic #1752 PR3: the evidence-record-failure diagnostic now routes
+		// through logger.log (debug-gated via OPENCODE_SWARM_DEBUG=1) instead
+		// of raw console.warn. Enable debug to observe the call.
+		const originalDebug = process.env.OPENCODE_SWARM_DEBUG;
+		process.env.OPENCODE_SWARM_DEBUG = '1';
+		const originalLog = console.log;
+		const logCalls: string[] = [];
+		console.log = (...args: unknown[]) => {
+			logCalls.push(args.map(String).join(' '));
 		};
 
 		try {
 			// This should NOT throw - evidence write failure should be non-blocking
 			await fireToolAfter('sess-11', 'reviewer', 'call-1');
 
-			// Verify console.warn was called with task context
+			// Verify the failure was logged via the debug-gated logger.
 			expect(
-				warnCalls.some(
+				logCalls.some(
 					(msg) =>
 						msg.includes('evidence recording failed') ||
 						msg.includes('evidence write failed'),
 				),
 			).toBe(true);
 		} finally {
-			// Restore console.warn
-			console.warn = originalWarn;
+			// Restore env + console.
+			if (originalDebug === undefined) {
+				delete process.env.OPENCODE_SWARM_DEBUG;
+			} else {
+				process.env.OPENCODE_SWARM_DEBUG = originalDebug;
+			}
+			console.log = originalLog;
 		}
 	});
 

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -1737,7 +1737,7 @@ export function createDelegationGateHook(
 					}
 				}
 			} catch (err) {
-				console.warn(
+				logger.log(
 					`[delegation-gate] toolAfter submit_council_verdicts: failed to parse output: ${err instanceof Error ? err.message : String(err)}`,
 				);
 			}
@@ -2261,7 +2261,7 @@ export function createDelegationGateHook(
 					}
 				} catch (err) {
 					/* non-fatal — evidence is additive, never blocks delegation */
-					console.warn(
+					logger.log(
 						`[delegation-gate] evidence recording failed: ${err instanceof Error ? err.message : String(err)}`,
 					);
 				} finally {
@@ -2468,7 +2468,7 @@ export function createDelegationGateHook(
 					}
 				} catch (err) {
 					/* non-fatal — evidence is additive, never blocks delegation */
-					console.warn(
+					logger.log(
 						`[delegation-gate] fallback evidence recording failed: ${err instanceof Error ? err.message : String(err)}`,
 					);
 				}

--- a/src/hooks/delegation-gate/worktree-isolation.ts
+++ b/src/hooks/delegation-gate/worktree-isolation.ts
@@ -16,6 +16,7 @@ import { DEFAULT_WORKTREE_ISOLATION_CONFIG } from '../../config/constants';
 import { isValidEnvKey } from '../../sandbox/executor';
 import { ensureAgentSession, swarmState } from '../../state';
 import { bunSpawn } from '../../utils/bun-compat';
+import * as logger from '../../utils/logger.js';
 import type { WorktreeHandle } from '../../worktree';
 import {
 	attemptMergeBackFromDirty,
@@ -365,7 +366,7 @@ function rememberStandardWorktreeSerializationSession(
 		}
 		if (!evicted) {
 			// All 256 entries are active — log and REFUSE to add rather than break isolation
-			console.warn(
+			logger.log(
 				`[worktree-isolation] serialization set at cap with all sessions active; refusing eviction for ${sessionID}`,
 			);
 			return false;
@@ -441,7 +442,7 @@ export async function preProvisionCollisionCheck(
 		if (exitCode !== 0) {
 			// git worktree list failed — fail open with no collision detected.
 			// The actual provisioning will report the error if needed.
-			console.warn(
+			logger.log(
 				`[swarm] preProvisionCollisionCheck: git worktree list failed (exit ${exitCode}): ${stderr}`,
 			);
 			return { collision: false };
@@ -599,7 +600,7 @@ export async function precreateStandardWorktreeSession(args: {
 			args.parentSessionID,
 		]);
 	} catch (recoveryError) {
-		console.warn(`[swarm] startup orphan recovery failed: ${recoveryError}`);
+		logger.log(`[swarm] startup orphan recovery failed: ${recoveryError}`);
 	}
 
 	// SC-004.2: Also delete stale lane branches from inactive sessions so
@@ -611,7 +612,7 @@ export async function precreateStandardWorktreeSession(args: {
 			args.parentSessionID,
 		]);
 	} catch (cleanupError) {
-		console.warn(`[swarm] orphaned branch cleanup failed: ${cleanupError}`);
+		logger.log(`[swarm] orphaned branch cleanup failed: ${cleanupError}`);
 	}
 
 	// FR-001b SC-004/SC-005: Pre-provision collision check — detect a stale lane
@@ -706,7 +707,7 @@ export async function precreateStandardWorktreeSession(args: {
 					);
 				}
 			} catch (cleanupError) {
-				console.warn(
+				logger.log(
 					`[swarm] preProvision collision cleanup failed: ${cleanupError}; proceeding with provisioning anyway`,
 				);
 			}
@@ -905,7 +906,7 @@ export async function preserveDirtyWorktreeForCallId(
 		statusStdout = await statusProc.stdout.text();
 		statusStderr = await statusProc.stderr.text();
 		if (exitCode !== 0) {
-			console.warn(
+			logger.log(
 				`[swarm] preserveDirtyWorktreeForCallId: git status failed for ${callID}: ${statusStderr}`,
 			);
 			return {
@@ -941,7 +942,7 @@ export async function preserveDirtyWorktreeForCallId(
 		const addExit = await addProc.exited;
 		if (addExit !== 0) {
 			const addErr = await addProc.stderr.text();
-			console.warn(
+			logger.log(
 				`[swarm] preserveDirtyWorktreeForCallId: git add failed for ${callID}: ${addErr}`,
 			);
 			return {
@@ -977,7 +978,7 @@ export async function preserveDirtyWorktreeForCallId(
 		const commitExit = await commitProc.exited;
 		if (commitExit !== 0) {
 			const commitErr = await commitProc.stderr.text();
-			console.warn(
+			logger.log(
 				`[swarm] preserveDirtyWorktreeForCallId: git commit failed for ${callID}: ${commitErr}`,
 			);
 			return {
@@ -1008,7 +1009,7 @@ export async function preserveDirtyWorktreeForCallId(
 		const hashExit = await hashProc.exited;
 		if (hashExit !== 0) {
 			const hashErr = await hashProc.stderr.text();
-			console.warn(
+			logger.log(
 				`[swarm] preserveDirtyWorktreeForCallId: git rev-parse failed for ${callID}: ${hashErr}`,
 			);
 			return {
@@ -1051,7 +1052,7 @@ export async function preserveDirtyWorktreeForCallId(
 		const tagExit = await tagProc.exited;
 		if (tagExit !== 0) {
 			const tagErr = await tagProc.stderr.text();
-			console.warn(
+			logger.log(
 				`[swarm] preserveDirtyWorktreeForCallId: git tag failed for ${callID}: ${tagErr}`,
 			);
 			return {
@@ -1122,7 +1123,7 @@ export async function preserveDirtyWorktreeAtPath(
 		statusStdout = await statusProc.stdout.text();
 		statusStderr = await statusProc.stderr.text();
 		if (exitCode !== 0) {
-			console.warn(
+			logger.log(
 				`[swarm] preserveDirtyWorktreeAtPath: git status failed for ${worktreePath}: ${statusStderr}`,
 			);
 			return {
@@ -1158,7 +1159,7 @@ export async function preserveDirtyWorktreeAtPath(
 		const addExit = await addProc.exited;
 		if (addExit !== 0) {
 			const addErr = await addProc.stderr.text();
-			console.warn(
+			logger.log(
 				`[swarm] preserveDirtyWorktreeAtPath: git add failed for ${worktreePath}: ${addErr}`,
 			);
 			return {
@@ -1199,7 +1200,7 @@ export async function preserveDirtyWorktreeAtPath(
 		const commitExit = await commitProc.exited;
 		if (commitExit !== 0) {
 			const commitErr = await commitProc.stderr.text();
-			console.warn(
+			logger.log(
 				`[swarm] preserveDirtyWorktreeAtPath: git commit failed for ${worktreePath}: ${commitErr}`,
 			);
 			return {
@@ -1230,7 +1231,7 @@ export async function preserveDirtyWorktreeAtPath(
 		const hashExit = await hashProc.exited;
 		if (hashExit !== 0) {
 			const hashErr = await hashProc.stderr.text();
-			console.warn(
+			logger.log(
 				`[swarm] preserveDirtyWorktreeAtPath: git rev-parse failed for ${worktreePath}: ${hashErr}`,
 			);
 			return {
@@ -1273,7 +1274,7 @@ export async function preserveDirtyWorktreeAtPath(
 		const tagExit = await tagProc.exited;
 		if (tagExit !== 0) {
 			const tagErr = await tagProc.stderr.text();
-			console.warn(
+			logger.log(
 				`[swarm] preserveDirtyWorktreeAtPath: git tag failed for ${worktreePath}: ${tagErr}`,
 			);
 			return {
@@ -1352,7 +1353,7 @@ export async function cleanupStandardWorktreeForCallId(
 				worktree_dir,
 			);
 		} catch (err) {
-			console.warn(
+			logger.log(
 				`[swarm] cleanupStandardWorktreeForCallId: preserveDirtyWorktreeForCallId threw for ${callID}: ${err}`,
 			);
 			preserveResult = {
@@ -1374,7 +1375,7 @@ export async function cleanupStandardWorktreeForCallId(
 					worktree_dir,
 				);
 			} catch (err) {
-				console.warn(
+				logger.log(
 					`[swarm] cleanupStandardWorktreeForCallId: final preservation check threw for ${callID}: ${err}`,
 				);
 				preserveResult = {
@@ -1412,7 +1413,7 @@ export async function cleanupStandardWorktreeForCallId(
 			worktreeDir: worktree_dir,
 		})
 		.catch((err) =>
-			console.warn(
+			logger.log(
 				`[swarm] cleanupStandardWorktreeForCallId: removeWorktree failed for ${callID}: ${err}`,
 			),
 		);
@@ -1425,7 +1426,7 @@ export async function cleanupStandardWorktreeForCallId(
 	await _internals
 		.postMergeCleanup(directory, branchName)
 		.catch((err) =>
-			console.warn(
+			logger.log(
 				`[swarm] cleanupStandardWorktreeForCallId: postMergeCleanup failed for ${callID}: ${err}`,
 			),
 		);
@@ -1631,7 +1632,7 @@ export async function readLaneEnvFileFromDisk(
 			return {};
 		}
 		// Other errors: warn and return empty so spawns degrade gracefully.
-		console.warn(
+		logger.log(
 			`[worktree-isolation] failed to read lane env file ${envPath}: ${(err as Error).message}`,
 		);
 		return {};

--- a/src/hooks/knowledge-store.ts
+++ b/src/hooks/knowledge-store.ts
@@ -6,6 +6,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import lockfile from 'proper-lockfile';
 import { atomicWriteFile } from '../evidence/task-file.js';
+import * as logger from '../utils/logger.js';
 import { readCachedParsedFile } from '../utils/swarm-artifact-cache.js';
 import { resolveKnowledgeStoreDir } from './knowledge-link.js';
 import { reinforceSwarmKnowledgeEntry } from './knowledge-reinforcement.js';
@@ -130,7 +131,7 @@ function parseKnowledgeContent<T>(content: string, max: number): T[] {
 		try {
 			results.push(normalizeEntry(JSON.parse(trimmed) as T));
 		} catch {
-			console.warn(
+			logger.log(
 				`[knowledge-store] Skipping corrupted JSONL line: ${trimmed.slice(
 					0,
 					80,
@@ -971,13 +972,13 @@ export async function bumpKnowledgeConfidenceBatch(
 			[...touchedSwarm, ...touchedHive],
 			options,
 		).catch((err) => {
-			console.warn(
+			logger.log(
 				'[knowledge-store] confidence-floor action sweep failed (best-effort):',
 				err instanceof Error ? err.message : String(err),
 			);
 		});
 	} catch (err) {
-		console.warn(
+		logger.log(
 			'[knowledge-store] bumpKnowledgeConfidenceBatch failed (fail-open):',
 			err instanceof Error ? err.message : String(err),
 		);
@@ -1075,7 +1076,7 @@ async function applyConfidenceFloorAction(
 		}
 		return swarmEntries;
 	}).catch((err) => {
-		console.warn(
+		logger.log(
 			'[knowledge-store] confidence-floor swarm flag transaction failed (best-effort):',
 			err instanceof Error ? err.message : String(err),
 		);
@@ -1109,7 +1110,7 @@ async function applyConfidenceFloorAction(
 			}
 			return hiveEntries;
 		}).catch((err) => {
-			console.warn(
+			logger.log(
 				'[knowledge-store] confidence-floor hive flag transaction failed (best-effort):',
 				err instanceof Error ? err.message : String(err),
 			);
@@ -1128,7 +1129,7 @@ async function applyConfidenceFloorAction(
 				'confidence_floor_negative_outcome',
 				'auto',
 			).catch((err) => {
-				console.warn(
+				logger.log(
 					'[knowledge-store] confidence-floor quarantine failed (best-effort):',
 					err instanceof Error ? err.message : String(err),
 				);
@@ -1207,7 +1208,7 @@ async function applyConfidenceDeltas(
 			await atomicWriteFile(filePath, content);
 		}
 	} catch (err) {
-		console.warn(
+		logger.log(
 			`[knowledge-store] applyConfidenceDeltas failed on ${filePath} (fail-open):`,
 			err instanceof Error ? err.message : String(err),
 		);

--- a/src/hooks/skill-usage-log.ts
+++ b/src/hooks/skill-usage-log.ts
@@ -8,6 +8,7 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as logger from '../utils/logger.js';
 import type { ConfidenceFloorOptions } from './knowledge-store.js';
 import { bumpKnowledgeConfidenceBatch } from './knowledge-store.js';
 import { validateSwarmPath } from './utils.js';
@@ -690,7 +691,7 @@ export async function resolveSourceKnowledgeIds(
 		const content = _internals.readFileSync(absolute, 'utf-8');
 		return parseGeneratedFromKnowledge(content);
 	} catch (err) {
-		console.warn(
+		logger.log(
 			'[skill-usage-log] resolveSourceKnowledgeIds failed (fail-open):',
 			err instanceof Error ? err.message : String(err),
 		);
@@ -856,7 +857,7 @@ export async function applySkillUsageFeedback(
 			appendFeedbackAppliedMarker(directory, processedEntryIds);
 		}
 	} catch (err) {
-		console.warn(
+		logger.log(
 			'[skill-usage-log] applySkillUsageFeedback failed (fail-open):',
 			err instanceof Error ? err.message : String(err),
 		);

--- a/src/prm/index.ts
+++ b/src/prm/index.ts
@@ -44,6 +44,7 @@ export type {
 
 import { getAgentSession } from '../state';
 import { telemetry } from '../telemetry';
+import * as logger from '../utils/logger.js';
 import {
 	formatCourseCorrectionForInjection,
 	generateCourseCorrection,
@@ -379,7 +380,7 @@ export function createPrmHook(config: PrmConfig, directory: string): PrmHook {
 			}
 		} catch (err) {
 			// Non-blocking: log error and continue
-			console.warn(`[prm] toolAfter error for session ${sessionID}: ${err}`);
+			logger.log(`[prm] toolAfter error for session ${sessionID}: ${err}`);
 		}
 	}
 

--- a/src/prm/replay.ts
+++ b/src/prm/replay.ts
@@ -9,6 +9,8 @@
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { advisoryWarn } from '../services/warning-buffer.js';
+import * as logger from '../utils/logger.js';
 
 /**
  * Validates that a path is within a base directory using canonical path resolution.
@@ -106,7 +108,12 @@ export async function startReplayRecording(
 
 		// Validate path is within .swarm/replays/
 		if (!isPathSafe(filepath, replayDir)) {
-			console.warn(
+			// Defense-in-depth signal: under normal flow this is unreachable
+			// (sanitizeFilename neutralizes traversal first), but if the guard
+			// fires it signals an internal-invariant violation. Surface via
+			// /swarm diagnose + debug log; never raw stderr (the attempt is
+			// blocked, not corrupting — Invariant 10).
+			advisoryWarn(
 				`[replay] Invalid path detected - path traversal attempt blocked for session ${sessionID}`,
 			);
 			return null;
@@ -118,7 +125,7 @@ export async function startReplayRecording(
 		return filepath;
 	} catch (err) {
 		// Non-blocking: log error and return null
-		console.warn(
+		logger.log(
 			`[replay] Failed to start recording for session ${sessionID}: ${err}`,
 		);
 		return null;
@@ -141,7 +148,7 @@ export async function recordReplayEntry(
 	try {
 		// Validate artifactPath is within .swarm/replays/ using path segment validation
 		if (!isWithinReplaysDir(artifactPath)) {
-			console.warn(
+			logger.log(
 				`[replay] Invalid artifact path - not within .swarm/replays/: ${artifactPath}`,
 			);
 			return;
@@ -156,7 +163,7 @@ export async function recordReplayEntry(
 		await fs.appendFile(artifactPath, line, 'utf-8');
 	} catch (err) {
 		// Non-blocking: log error and continue
-		console.warn(`[replay] Failed to record entry: ${err}`);
+		logger.log(`[replay] Failed to record entry: ${err}`);
 	}
 }
 

--- a/src/prm/trajectory-store.ts
+++ b/src/prm/trajectory-store.ts
@@ -11,6 +11,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { validateSwarmPath } from '../hooks/utils';
+import * as logger from '../utils/logger.js';
 import type { TrajectoryEntry } from './types';
 
 const MAX_TRACKED_TRAJECTORY_SESSIONS = 500;
@@ -94,9 +95,7 @@ export async function appendTrajectoryEntry(
 		setTrajectoryCache(sessionId, [...cached, entry], maxLines);
 	} catch (err) {
 		// Non-blocking: swallow errors to prevent PRM from breaking main flow
-		console.warn(
-			`[trajectory-store] Failed to append trajectory entry: ${err}`,
-		);
+		logger.log(`[trajectory-store] Failed to append trajectory entry: ${err}`);
 	}
 }
 
@@ -132,7 +131,7 @@ export async function readTrajectory(
 		if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
 			return [];
 		}
-		console.warn(`[trajectory-store] Failed to read trajectory: ${err}`);
+		logger.log(`[trajectory-store] Failed to read trajectory: ${err}`);
 		return [];
 	}
 }
@@ -183,7 +182,7 @@ export async function truncateTrajectoryIfNeeded(
 		await fs.writeFile(trajectoryPath, `${keptLines.join('\n')}\n`, 'utf-8');
 	} catch (err) {
 		// Non-blocking: swallow errors
-		console.warn(`[trajectory-store] Failed to truncate trajectory: ${err}`);
+		logger.log(`[trajectory-store] Failed to truncate trajectory: ${err}`);
 	}
 }
 
@@ -225,7 +224,7 @@ export async function getCurrentStep(
 		if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
 			return 0;
 		}
-		console.warn(`[trajectory-store] Failed to get current step: ${err}`);
+		logger.log(`[trajectory-store] Failed to get current step: ${err}`);
 		return 0;
 	}
 }

--- a/src/services/context-budget-service.ts
+++ b/src/services/context-budget-service.ts
@@ -9,6 +9,7 @@
 import { resolveSwarmKnowledgePath } from '../hooks/knowledge-store';
 import { readSwarmFileAsync, validateSwarmPath } from '../hooks/utils';
 import { bunFile, bunWrite } from '../utils/bun-compat';
+import * as logger from '../utils/logger.js';
 import { validateDirectory } from '../utils/path-security';
 import { readCachedTextFile } from '../utils/swarm-artifact-cache';
 
@@ -177,7 +178,7 @@ async function writeBudgetState(
 		const content = JSON.stringify(state, null, 2);
 		await bunWrite(resolvedPath, content);
 	} catch (error) {
-		console.warn(
+		logger.log(
 			'[context-budget] Failed to write budget state:',
 			error instanceof Error ? error.message : String(error),
 		);

--- a/src/session/worktree-link-suggestion.ts
+++ b/src/session/worktree-link-suggestion.ts
@@ -15,6 +15,7 @@
 
 import { execFile } from 'node:child_process';
 import { isLinked } from '../hooks/knowledge-link.js';
+import { advisoryWarn } from '../services/warning-buffer.js';
 
 const GIT_TIMEOUT_MS = 1_500;
 
@@ -95,7 +96,7 @@ export async function maybeSuggestWorktreeLink(
 
 		const worktrees = await countWorktrees(directory);
 		if (worktrees > 1) {
-			console.warn(
+			advisoryWarn(
 				`[opencode-swarm] Detected ${worktrees} git worktrees of this repo. ` +
 					'Run `/swarm link` in each to share swarm knowledge across them ' +
 					'(or `/swarm link <name>` to share with similar projects).',

--- a/tests/unit/council/evidence-writer-gaps.test.ts
+++ b/tests/unit/council/evidence-writer-gaps.test.ts
@@ -729,48 +729,60 @@ describe('evidence writer — round-history audit log', () => {
 		});
 	});
 
-	test('appendFileSync failure does not break primary evidence write and console.warn is called', async () => {
-		// Spy on console.warn to verify it gets called on audit failure.
-		const warnings: string[] = [];
-		const originalWarn = console.warn;
-		console.warn = (msg: string) => warnings.push(msg);
+	test('appendFileSync failure does not break primary evidence write and audit failure is logged', async () => {
+		// Epic #1752 PR3: the audit-failure site now routes through logger.log
+		// (debug-gated via OPENCODE_SWARM_DEBUG=1) instead of raw console.warn.
+		// Enable debug to observe the call, then capture console.log output.
+		const originalDebug = process.env.OPENCODE_SWARM_DEBUG;
+		process.env.OPENCODE_SWARM_DEBUG = '1';
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => logs.push(String(args[0]));
 
-		// Mock appendFileSync to throw on audit log paths — simulating permission error.
-		// The primary evidence write uses atomicWriteFile (bunWrite + rename), not
-		// appendFileSync, so mocking appendFileSync only affects the audit log path.
-		const realFs = await import('node:fs');
-		const mockAppendFileSync = mock((path: string, data: string) => {
-			if (path.includes('.rounds.jsonl')) {
-				throw new Error('EPERM: permission denied');
+		try {
+			// Mock appendFileSync to throw on audit log paths — simulating permission error.
+			// The primary evidence write uses atomicWriteFile (bunWrite + rename), not
+			// appendFileSync, so mocking appendFileSync only affects the audit log path.
+			const realFs = await import('node:fs');
+			const mockAppendFileSync = mock((path: string, data: string) => {
+				if (path.includes('.rounds.jsonl')) {
+					throw new Error('EPERM: permission denied');
+				}
+				// Delegate non-audit writes to the real implementation.
+				return realFs.appendFileSync(path, data);
+			});
+			mock.module('node:fs', () => ({
+				...realFs,
+				appendFileSync: mockAppendFileSync,
+			}));
+
+			// Primary evidence write must succeed even when audit log fails.
+			await expect(
+				writeCouncilEvidence(tempDir, makeRoundSynthesis()),
+			).resolves.toBeUndefined();
+
+			// Verify the primary evidence file was written correctly.
+			const evidence = JSON.parse(
+				readFileSync(join(tempDir, '.swarm', 'evidence', '1.1.json'), 'utf-8'),
+			);
+			expect(evidence.gates.council).toBeDefined();
+			expect(evidence.gates.council.verdict).toBe('APPROVE');
+
+			// Verify the audit failure was logged via the debug-gated logger.
+			expect(
+				logs.some((w) =>
+					w.includes('failed to append round-history audit log'),
+				),
+			).toBe(true);
+		} finally {
+			// Restore env + console.
+			if (originalDebug === undefined) {
+				delete process.env.OPENCODE_SWARM_DEBUG;
+			} else {
+				process.env.OPENCODE_SWARM_DEBUG = originalDebug;
 			}
-			// Delegate non-audit writes to the real implementation.
-			return realFs.appendFileSync(path, data);
-		});
-		mock.module('node:fs', () => ({
-			...realFs,
-			appendFileSync: mockAppendFileSync,
-		}));
-
-		// Primary evidence write must succeed even when audit log fails.
-		await expect(
-			writeCouncilEvidence(tempDir, makeRoundSynthesis()),
-		).resolves.toBeUndefined();
-
-		// Verify the primary evidence file was written correctly.
-		const evidence = JSON.parse(
-			readFileSync(join(tempDir, '.swarm', 'evidence', '1.1.json'), 'utf-8'),
-		);
-		expect(evidence.gates.council).toBeDefined();
-		expect(evidence.gates.council.verdict).toBe('APPROVE');
-
-		// Verify console.warn was called with the audit failure message.
-		expect(
-			warnings.some((w) =>
-				w.includes('failed to append round-history audit log'),
-			),
-		).toBe(true);
-
-		console.warn = originalWarn;
-		mock.restore();
+			console.log = originalLog;
+			mock.restore();
+		}
 	});
 });

--- a/tests/unit/hooks/delegation-gate-worktree-isolation.serialization.test.ts
+++ b/tests/unit/hooks/delegation-gate-worktree-isolation.serialization.test.ts
@@ -335,10 +335,16 @@ describe('FR-104 SC-113: FIFO eviction must not remove active sessions', () => {
 		// Approach: Call rememberStandardWorktreeSerializationSession via _internals
 		// directly. This bypasses the handleStandardWorktreeFailure collision issue
 		// and directly exercises the FIFO cap check.
+		//
+		// Epic #1752 PR3: the cap-refusal diagnostic now routes through logger.log
+		// (debug-gated via OPENCODE_SWARM_DEBUG=1) instead of raw console.warn.
+		// Enable debug to observe the call, then capture console.log output.
+		const originalDebug = process.env.OPENCODE_SWARM_DEBUG;
+		process.env.OPENCODE_SWARM_DEBUG = '1';
 		const consoleWarnings: string[] = [];
-		const originalWarn = console.warn;
-		console.warn = (msg: string) => {
-			consoleWarnings.push(msg);
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => {
+			consoleWarnings.push(String(args[0]));
 		};
 
 		try {
@@ -386,7 +392,13 @@ describe('FR-104 SC-113: FIFO eviction must not remove active sessions', () => {
 				),
 			).toBe(true);
 		} finally {
-			console.warn = originalWarn;
+			// Restore env + console.
+			if (originalDebug === undefined) {
+				delete process.env.OPENCODE_SWARM_DEBUG;
+			} else {
+				process.env.OPENCODE_SWARM_DEBUG = originalDebug;
+			}
+			console.log = originalLog;
 		}
 	});
 

--- a/tests/unit/plugin-tui-safety.test.ts
+++ b/tests/unit/plugin-tui-safety.test.ts
@@ -71,6 +71,66 @@ const TUI_SAFETY_SCOPES: Array<{
 		label: 'project-init.ts',
 		quietTokens: [],
 	},
+	// PR3 of epic #1752 migrated these hook-path modules (chat/tool/system
+	// message hooks + their service deps + the prm subsystem) to
+	// advisoryWarn/log. Same contract as the PR2 block above: zero raw
+	// console.warn. This is the interim regression guard until PR5 enables
+	// Biome `noConsole` globally.
+	{
+		file: 'src/hooks/delegation-gate.ts',
+		label: 'delegation-gate.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/hooks/delegation-gate/worktree-isolation.ts',
+		label: 'worktree-isolation.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/hooks/knowledge-store.ts',
+		label: 'knowledge-store.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/hooks/skill-usage-log.ts',
+		label: 'skill-usage-log.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/council/council-evidence-writer.ts',
+		label: 'council-evidence-writer.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/diff/ast-diff.ts',
+		label: 'ast-diff.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/services/context-budget-service.ts',
+		label: 'context-budget-service.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/session/worktree-link-suggestion.ts',
+		label: 'worktree-link-suggestion.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/prm/index.ts',
+		label: 'prm-index.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/prm/replay.ts',
+		label: 'prm-replay.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/prm/trajectory-store.ts',
+		label: 'prm-trajectory-store.ts',
+		quietTokens: [],
+	},
 ];
 
 function readScope(file: string): string {
@@ -181,19 +241,22 @@ describe('Plugin TUI safety', () => {
 		}
 	});
 
-	test('PR2-migrated init-path modules have zero raw console.warn (epic #1752)', () => {
-		// loader.ts, architect.ts, snapshot-reader.ts, project-init.ts were
-		// migrated to advisoryWarn/log in PR2. They must contain ZERO raw
+	test('PR2/PR3-migrated modules have zero raw console.warn (epic #1752)', () => {
+		// PR2 (loader.ts, architect.ts, snapshot-reader.ts, project-init.ts)
+		// and PR3 (delegation-gate, worktree-isolation, knowledge-store,
+		// skill-usage-log, council-evidence-writer, ast-diff,
+		// context-budget-service, worktree-link-suggestion, prm/*) were
+		// migrated to advisoryWarn/log. They must contain ZERO raw
 		// console.warn so the bubbletea TUI is never corrupted on the init
-		// path (issue #1249 class). This is the interim regression guard until
-		// PR5 enables Biome `noConsole` globally.
+		// and hook paths (issue #1249 class). This is the interim regression
+		// guard until PR5 enables Biome `noConsole` globally.
 		for (const scope of TUI_SAFETY_SCOPES) {
 			if (scope.quietTokens.length > 0) continue; // skip guarded-scope files
 			const src = readScope(scope.file);
 			const warnCount = (src.match(/console\.warn\(/g) || []).length;
 			expect(
 				warnCount,
-				`${scope.file} must contain zero raw console.warn after epic #1752 PR2 migration`,
+				`${scope.file} must contain zero raw console.warn after epic #1752 PR2/PR3 migration`,
 			).toBe(0);
 		}
 	});

--- a/tests/unit/session/worktree-link-suggestion.test.ts
+++ b/tests/unit/session/worktree-link-suggestion.test.ts
@@ -7,6 +7,10 @@ import {
 	type LinkPointer,
 	writeLinkPointer,
 } from '../../../src/hooks/knowledge-link.js';
+import {
+	clearDeferredWarnings,
+	getDeferredWarnings,
+} from '../../../src/services/warning-buffer.js';
 import { _internals } from '../../../src/session/worktree-link-suggestion.js';
 import { createSafeTestDir } from '../../helpers/safe-test-dir.js';
 
@@ -36,10 +40,17 @@ describe('worktree-link-suggestion', () => {
 	beforeEach(() => {
 		_internals.resetSuggested();
 		invalidateKnowledgeStoreDirCache();
+		// Epic #1752 PR3: the worktree-link advisory now routes through
+		// advisoryWarn (buffered for /swarm diagnose) instead of raw
+		// console.warn. Clear the module-level deferred-warning buffer between
+		// tests (AGENTS.md Invariant 7 — no cross-test pollution in the shared
+		// bun test-runner process).
+		clearDeferredWarnings();
 	});
 	afterEach(() => {
 		_internals.resetSuggested();
 		invalidateKnowledgeStoreDirCache();
+		clearDeferredWarnings();
 	});
 
 	test('countWorktrees returns 0 for a non-git directory (fail-open)', async () => {
@@ -72,6 +83,8 @@ describe('worktree-link-suggestion', () => {
 			const warn = spyOn(console, 'warn').mockImplementation(() => {});
 			await _internals.maybeSuggestWorktreeLink(dir, 'sess-single');
 			expect(warn).not.toHaveBeenCalled();
+			// Single-worktree repo: no advisory buffered.
+			expect(getDeferredWarnings()).toHaveLength(0);
 			warn.mockRestore();
 		} finally {
 			cleanup();
@@ -104,16 +117,26 @@ describe('worktree-link-suggestion', () => {
 			// Unlinked + 2 worktrees → suggestion fires once.
 			const warn = spyOn(console, 'warn').mockImplementation(() => {});
 			await _internals.maybeSuggestWorktreeLink(main.dir, 'sess-multi');
-			expect(warn).toHaveBeenCalledTimes(1);
-			expect(String(warn.mock.calls[0]?.[0])).toContain('/swarm link');
+			// Epic #1752 PR3: the advisory now routes through advisoryWarn
+			// (buffered), NOT raw console.warn. Prove no raw stderr is emitted.
+			expect(warn).not.toHaveBeenCalled();
+			expect(getDeferredWarnings().some((m) => m.includes('/swarm link'))).toBe(
+				true,
+			);
 
-			// Same session again → deduped (no second warning).
+			// Same session again → deduped (no second warning). The source's
+			// _suggestedSessions.has() check returns early before advisoryWarn,
+			// so the buffer still holds exactly one /swarm link entry.
 			await _internals.maybeSuggestWorktreeLink(main.dir, 'sess-multi');
-			expect(warn).toHaveBeenCalledTimes(1);
+			expect(warn).not.toHaveBeenCalled();
+			expect(
+				getDeferredWarnings().filter((m) => m.includes('/swarm link')).length,
+			).toBe(1);
 			warn.mockRestore();
 
 			// Once linked, a fresh session does not suggest.
 			_internals.resetSuggested();
+			clearDeferredWarnings();
 			const pointer: LinkPointer = {
 				version: 1,
 				linkId: 'linked-proj',
@@ -124,6 +147,7 @@ describe('worktree-link-suggestion', () => {
 			const warn2 = spyOn(console, 'warn').mockImplementation(() => {});
 			await _internals.maybeSuggestWorktreeLink(main.dir, 'sess-after-link');
 			expect(warn2).not.toHaveBeenCalled();
+			expect(getDeferredWarnings()).toHaveLength(0);
 			warn2.mockRestore();
 
 			// Clean up the linked worktree to avoid leaking git worktree registrations.


### PR DESCRIPTION
Closes #1754

## Summary

Migrates every remaining raw `console.warn` on the plugin-host hook path (chat/tool/system message hooks + their service dependencies + the `prm` recording subsystem) to the PR1 foundation helpers introduced in #1758:

- **43 diagnostic fail-open catches** → `logger.log(msg)` — debug-gated (`OPENCODE_SWARM_DEBUG=1`), NOT buffered. These are best-effort evidence records, git provisioning fallbacks, confidence-floor sweeps, JSONL-parse skips, budget-state writes, and PRM recording failures. They would flood `/swarm diagnose` if buffered.
- **2 operator-actionable / security-adjacent signals** → `advisoryWarn(msg)` — buffered for `/swarm diagnose` + emitted under debug. Never raw stderr.
  - `src/session/worktree-link-suggestion.ts:98` — the >1-worktree `/swarm link` hint (the one genuinely actionable advisory in the batch).
  - `src/prm/replay.ts:109` — path-traversal-blocked defense-in-depth signal (effectively unreachable under normal flow since `sanitizeFilename` neutralizes traversal first, but worth surfacing via `/swarm diagnose` if the guard ever fires). `criticalWarn` was rejected because it writes raw `console.warn` to stderr — self-defeating for a PR eliminating raw `console.warn`.

This is PR3 of epic #1752. PR1 (#1758) added `advisoryWarn`; PR2 (#1789) swept the init path; this PR sweeps the hook path. PR4/PR5 will sweep the remaining ~85 sites and enable Biome `noConsole` globally.

**45 sites across 11 files** (the issue table cited ~22 with stale line numbers; the real count is higher because `worktree-isolation.ts` was undercounted at 4 vs 20 actual). Message strings preserved verbatim — only the delivery channel changed.

### Why
Raw `console.warn` writes to stderr corrupt the OpenCode bubbletea TUI when it owns the terminal (issue #1249 class). The hook path fires these on any diagnostic fail-open condition mid-turn — with no error surfaced to the user.

## Invariant audit

- **1 (plugin init):** not touched — no init-path code changed.
- **2 (runtime portability):** not touched — no `src/index.ts`, package exports, or bundle config changed. `bun run build` succeeds; bundle shape unchanged.
- **3 (subprocesses):** not touched — no spawn calls changed.
- **4 (.swarm containment):** not touched — no `.swarm/` paths or `process.cwd()` introduced.
- **5 (plan durability):** not touched.
- **6 (test_runner safety):** not touched — no `test_runner` scope changes.
- **7 (test writing):** touched — 3 debug-capture test files set `OPENCODE_SWARM_DEBUG='1'` and monkeypatch `console.log`, restoring env + console in `finally` (handles `undefined` original). `worktree-link-suggestion.test.ts` uses `clearDeferredWarnings()` in BOTH `beforeEach` AND `afterEach` (bun runs `afterEach` even on assertion throw). Evidence: `bun test` for all 5 affected files = 63/63 pass.
- **8 (session state):** not touched — no session-scoped state added. The `deferredWarnings` buffer is module-level with a 50-entry cap + truncation sentinel (pre-existing, unchanged).
- **9 (guardrails/retry):** not touched.
- **10 (chat/system msg):** touched — IMPROVED. Migration reduces raw stderr output (43 sites now debug-gated, 2 buffered). `logger.log` is gated behind `OPENCODE_SWARM_DEBUG === '1'` (`src/utils/logger.ts:6`); default runs see zero stderr from these sites. `advisoryWarn` routes to buffer + debug log, never raw stderr.
- **11 (tool registration):** not touched — no tools/agents/commands changed.
- **12 (release/cache):** touched — release fragment `docs/releases/pending/1754-tui-pollution-pr3-hook-path.md` added. No version files hand-edited; release-please owns the version.

## Test plan

### Validation commands run (commit a50d00d7)
```
$ bun run build
→ Copied grammars to dist/lang/grammars/ · Total grammar files: 20 · exit 0

$ bun run lint
→ biome lint . · Checked 2444 files in 886ms. No fixes applied. · exit 0

$ bunx biome ci .
→ Checked 2444 files in 1186ms. No fixes applied. · exit 0 (CI gate)

$ bun test tests/unit/session/worktree-link-suggestion.test.ts tests/unit/plugin-tui-safety.test.ts tests/unit/council/evidence-writer-gaps.test.ts tests/unit/hooks/delegation-gate-worktree-isolation.serialization.test.ts src/hooks/delegation-gate.evidence.test.ts
→ 63 pass, 0 fail, 846 expect() calls · Ran 63 tests across 5 files

$ bun test src/prm/__tests__/
→ 229 pass, 0 fail, 617 expect() calls · Ran 229 tests across 9 files

$ bun test tests/unit/diff/
→ 41 pass, 0 fail, 91 expect() calls · Ran 41 tests across 1 file
```

### Grep proof (zero raw console.warn per migrated file)
All 11 migrated source files: `grep -c 'console.warn'` = 0.
Committed counts: 43 `logger.log` + 2 `advisoryWarn` = 45 sites.

### Tests updated (not deleted)
1. `tests/unit/session/worktree-link-suggestion.test.ts` — flipped to `getDeferredWarnings()`/`clearDeferredWarnings()` buffer pattern.
2. `tests/unit/council/evidence-writer-gaps.test.ts` — audit-log test: set `OPENCODE_SWARM_DEBUG=1`, capture `console.log`, restore in `finally`.
3. `tests/unit/hooks/delegation-gate-worktree-isolation.serialization.test.ts` — SC-113: same debug-gate pattern.
4. `src/hooks/delegation-gate.evidence.test.ts` — test 11: same debug-gate pattern.
5. `tests/unit/plugin-tui-safety.test.ts` — extended `TUI_SAFETY_SCOPES` with 11 entries (PR2 precedent); renamed scan test to PR2/PR3.

### Independent review gates
- **Implementation reviewer (GLM-5.2):** APPROVED after fixing 3 Biome format/import-order errors (auto-fixed via `bun run check`).
- **Final critic (GLM-5.2):** APPROVE. Verified all 45 sites, 5 test updates, regression scan, invariant compliance. 1 non-blocking observation: a `console.log` monkeypatch race in `delegation-gate-worktree-isolation.serialization.test.ts` when run in a shared process with `full-auto-intercept*.test.ts` (CI runs each file in its own subprocess, so unaffected; worth a follow-up to capture at `logger._internals.log` instead).

### Pre-existing failures (NOT caused by this PR)
`tests/unit/hooks/` has ~870 pre-existing failures on clean main (10a98ae3) when run as a full directory — confirmed by stashing this PR's diff and re-running. These are test-isolation issues unrelated to this migration. The 5 modified test files pass both alone and together (63/63). CI runs each file in its own subprocess, so these local-only isolation failures do not affect CI.

### Scope notes
- Biome `suspicious/noConsole` enforcement remains deferred to PR5 of epic #1752.
- `src/agents/index.ts` (hand-rolled `if (!quiet) console.warn` pattern), `src/commands/dark-matter.ts`, and the ~85 other `TUI_POLLUTING_UNGUARDED` sites are explicitly out of scope for PR3 and belong to PR4/PR5.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

