### PR TITLE
test(pr-review): cover incomplete clean attestations

### DIFF
--- a/docs/releases/pending/pr-review-incomplete-clean-regression.md
+++ b/docs/releases/pending/pr-review-incomplete-clean-regression.md
@@ -1,0 +1,16 @@
+# Incomplete CLEAN attestation regression coverage
+
+## What changed
+
+- Added direct regression coverage proving that an incomplete lane transcript
+  cannot produce a trusted CLEAN attestation, even when partial candidate
+  parsing is explicitly enabled.
+
+## Why
+
+The runtime already enforced this stricter CLEAN contract, but the incomplete
+transcript branch was not pinned independently from degraded-artifact coverage.
+
+## Migration
+
+No runtime behavior or configuration changed.

--- a/tests/unit/background/candidate-parser-phase4-contract.test.ts
+++ b/tests/unit/background/candidate-parser-phase4-contract.test.ts
@@ -243,6 +243,29 @@ describe('candidate parser Phase 4 contract', () => {
 		});
 	}
 
+	test('rejects CLEAN from an incomplete transcript even when partial candidates are allowed', () => {
+		const result = parseCandidates(
+			input(`${microHeader}\n[CLEAN] | subprocess | scope | evidence`, {
+				transcriptIncomplete: true,
+			}),
+			flags({
+				accept_partial: true,
+				expected_family: 'micro_lane',
+				expected_micro_lane: 'subprocess',
+			}),
+		);
+
+		expect(result.error_code).toBe('untrusted-clean-attestation');
+		expect(result.clean_attestation).toBeUndefined();
+		expect(result.diagnostics.parse_error_details).toContainEqual(
+			expect.objectContaining({
+				field: 'clean_attestation',
+				message:
+					'CLEAN attestation cannot come from a degraded or partial artifact',
+			}),
+		);
+	});
+
 	test('header-only zero output remains unattested', () => {
 		const result = parseCandidates(
 			input(microHeader),


### PR DESCRIPTION
Follow-up to #1827; refs #1805

## Summary

- Add the one direct regression requested by the old-head review closure: an incomplete transcript cannot attest CLEAN even when partial candidate parsing is explicitly allowed.
- Keep the follow-up isolated to the regression test and required release fragment on current canonical `main`; no runtime behavior changes.

## Invariant audit

- 1 (plugin init): not touched — test-only change.
- 2 (runtime portability): not touched — test-only change.
- 3 (subprocesses): not touched — test-only change.
- 4 (.swarm containment): not touched — test-only change.
- 5 (plan durability): not touched — test-only change.
- 6 (test_runner safety): not touched — test-only change.
- 7 (test writing): touched — added a focused `bun:test` regression in the existing Phase 4 contract suite; the test file remains below 500 lines and passes through per-file isolation.
- 8 (session state): not touched — test-only change.
- 9 (guardrails/retry): not touched — test-only change.
- 10 (chat/system msg): not touched — test-only change.
- 11 (tool registration): not touched — test-only change.
- 12 (release/cache): touched — added the required pending fragment; no version, changelog, manifest, or cache behavior changed.

## Test plan

- `bun run test:unit:ci tests/unit/background/candidate-parser-phase4-contract.test.ts tests/unit/background/candidate-parser.test.ts tests/unit/tools/parse-lane-candidates.test.ts`
- `bun run build`
- `bun run typecheck`
- `bun run drift:check`
- `bunx @biomejs/biome@2.3.14 ci tests/unit/background/candidate-parser-phase4-contract.test.ts`
- `git diff --check zaxbyhub/main...HEAD`
- Stage B reviewer APPROVE and test engineer PASS; separate closeout reviewer and critic APPROVE on the current-main branch.
