### PR TITLE
fix(tui): migrate tool-path console.warn/error to logger.log (PR4/5 #1755)

### DIFF
--- a/docs/releases/pending/1755-tui-pollution-pr4-tool-path.md
+++ b/docs/releases/pending/1755-tui-pollution-pr4-tool-path.md
@@ -1,0 +1,99 @@
+# TUI pollution sweep — tool execute path (PR4 of epic #1752)
+
+## What
+
+Migrates every remaining raw `console.warn` / `console.error` on the tool
+execute path (the tool handler bodies in `src/tools/*`, plus the mutation
+patch generator and the Semgrep SAST runner) to the PR1 foundation helper:
+
+- **21 diagnostic fail-open catches** → `logger.log(msg)` — debug-gated
+  (`OPENCODE_SWARM_DEBUG=1`), NOT buffered. These are best-effort evidence
+  saves, coverage/SBOM report writes, cleanup failures, lock releases,
+  explorer-format-suffix skips, LLM-call/session-create/parse fallbacks,
+  force-override operational modes, corrupt-evidence gate blocks, and
+  Semgrep `child.kill` failures (ESRCH-guarded). They would flood
+  `/swarm diagnose` if buffered.
+
+All 21 are purely diagnostic — the operator cannot act on any of them at
+runtime (the catches already fail open and return a result), so none use
+`advisoryWarn`.
+
+Migrated files (`src/`):
+
+- `tools/build-check.ts` — 1 build-evidence save catch.
+- `tools/convene-general-council.ts` — 1 council-evidence write catch.
+- `tools/dispatch-lanes.ts` — 1 explorer-format-suffix overflow skip.
+- `tools/lean-turbo-run-phase.ts` — 1 runner cleanup-failure catch.
+- `tools/req-coverage.ts` — 1 coverage-report write catch.
+- `tools/sbom-generate.ts` — 1 SBOM-evidence save catch.
+- `tools/update-task-status.ts` — 3 sites (corrupt-evidence gate block,
+  force-override re-open notice, lock-release failure catch).
+- `tools/write-drift-evidence.ts` — 2 sites (QA-gate-profile lock failure,
+  critic-approved snapshot failure).
+- `mutation/generator.ts` — 6 graceful-fallback catches (no ToolContext,
+  no opencodeClient, session-create failed, LLM prompt failed, JSON parse
+  failed, LLM call threw).
+- `sast/semgrep.ts` — 4 `child.kill` failure catches (SIGTERM/SIGKILL on
+  normal settle, stdout-overflow kill, stderr-overflow kill; all
+  ESRCH-guarded).
+
+## Why
+
+Raw `console.warn` / `console.error` writes to stderr corrupt the OpenCode
+bubbletea TUI when it owns the terminal (issue #1249 class). The tool
+execute path fires these on any diagnostic fail-open condition during an
+agent turn — with no error surfaced to the user. PR1 built the
+`advisoryWarn` helper; PR2 closed the init path; PR3 closed the hook path;
+this PR closes the tool execute path so the TUI stays clean during build
+checks, council convening, lane dispatch, Lean Turbo phases, coverage
+reporting, SBOM generation, task-status updates, drift-evidence writes,
+mutation generation, and Semgrep scans.
+
+## Behavior changes
+
+- The 21 diagnostic catches are now silent unless `OPENCODE_SWARM_DEBUG=1`.
+  Previously they wrote raw stderr on every fail-open. No operational
+  information is lost — operators debugging a specific failure set the env
+  var or inspect the return values (the catches already fail open).
+- No breaking API changes. All function signatures, return values, and
+  default fail-open behavior are preserved; only the warning delivery
+  channel changed.
+
+## Regression guard
+
+Extended `tests/unit/plugin-tui-safety.test.ts` to cover the 10 migrated
+files (matching the PR2/PR3 precedent). The scan now asserts each file
+contains zero raw `console.warn`, `console.error`, **and** `console.log`
+(the regex was widened from `console.warn(` to `console.(warn|error|log)(`
+so the 3 `.error`-only files — `build-check`, `lean-turbo-run-phase`,
+`semgrep` — are actually enforced). This is the interim guard until PR5 of
+epic #1752 enables Biome `suspicious/noConsole` globally.
+
+## Testing
+
+- Updated `tests/unit/tools/update-task-status.test.ts` `adversarial warn`
+  describe block to use the PR3 debug-capture pattern: set
+  `OPENCODE_SWARM_DEBUG='1'`, capture `console.log`, and assert the
+  corrupt-evidence diagnostic fires (2 positive assertions: 10000-char
+  taskId → 1, null/undefined taskId → 2). The 6 negative assertions in the
+  same block assert zero matching debug-logs, preserving the ENOENT-vs-
+  corrupt coverage. Env + console restored in `afterEach`.
+- The Issue #81 and Task 2.2 describe blocks in the same file are left
+  unchanged: they guard a different, already-removed idle-state regression
+  warn and remain valid.
+- The 4 test files the issue listed as potentially impacted
+  (`save-plan-snapshot-retry`, `save-plan-snapshot-retry.adversarial`,
+  `pre-check-batch.adversarial`, `pre-check-batch-cwd.adversarial`) were
+  verified by direct grep + import inspection to assert on non-migrated
+  source modules (`save-plan`, `plan/manager`, `pre-check-batch`); no edits
+  were needed.
+
+## Scope notes
+
+- Biome `suspicious/noConsole` enforcement remains deferred to PR5 of epic
+  #1752. A repo-wide `src/` sweep confirms zero remaining raw
+  `console.warn`/`error`/`log` in non-test, non-logger source outside
+  `src/cli/index.ts` (the standalone CLI installer UX, intentionally raw).
+- `update-task-status.ts:1012` (force-override re-open) defaults to `log()`
+  as an expected operational mode (matches the issue's triage
+  recommendation), not `advisoryWarn()`.

--- a/src/mutation/generator.ts
+++ b/src/mutation/generator.ts
@@ -7,6 +7,7 @@
 
 import type { ToolContext } from '@opencode-ai/plugin';
 import { swarmState } from '../state.js';
+import * as logger from '../utils/logger.js';
 import type { MutationPatch } from './engine.js';
 
 /** Slugify a string for use in mutation IDs */
@@ -61,7 +62,7 @@ export async function generateMutants(
 ): Promise<MutationPatch[]> {
 	// Graceful fallback: no ToolContext means no LLM access
 	if (!ctx) {
-		console.warn(
+		logger.log(
 			'[generateMutants] No ToolContext — cannot call LLM; returning empty patch set',
 		);
 		return [];
@@ -70,7 +71,7 @@ export async function generateMutants(
 	// Graceful fallback: no opencodeClient available
 	const client = swarmState.opencodeClient;
 	if (!client) {
-		console.warn(
+		logger.log(
 			'[generateMutants] opencodeClient not available; returning empty patch set',
 		);
 		return [];
@@ -108,7 +109,7 @@ export async function generateMutants(
 			query: { directory },
 		});
 		if (!createResult.data) {
-			console.warn(
+			logger.log(
 				`[generateMutants] Failed to create session: ${JSON.stringify(createResult.error)}; returning empty patch set`,
 			);
 			return [];
@@ -149,7 +150,7 @@ Return ONLY a valid JSON array. No markdown, no code fences, no explanation. Sta
 		});
 
 		if (!promptResult.data) {
-			console.warn(
+			logger.log(
 				`[generateMutants] LLM prompt failed: ${JSON.stringify(promptResult.error)}; returning empty patch set`,
 			);
 			return [];
@@ -171,7 +172,7 @@ Return ONLY a valid JSON array. No markdown, no code fences, no explanation. Sta
 				msg.includes('EOF') || msg.includes('Unexpected end')
 					? ' (response appears truncated — LLM may have hit an output token limit)'
 					: '';
-			console.warn(
+			logger.log(
 				`[generateMutants] Failed to parse LLM response as MutationPatch[]: ${msg}${hint}; returning empty patch set`,
 			);
 			return [];
@@ -220,7 +221,7 @@ Return ONLY a valid JSON array. No markdown, no code fences, no explanation. Sta
 
 		return patches;
 	} catch (error) {
-		console.warn(
+		logger.log(
 			`[generateMutants] LLM call failed: ${error instanceof Error ? error.message : String(error)}; returning empty patch set`,
 		);
 		return [];

--- a/src/sast/semgrep.ts
+++ b/src/sast/semgrep.ts
@@ -6,6 +6,7 @@
 import * as child_process from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as logger from '../utils/logger.js';
 import type { SastFinding } from './rules/index.js';
 
 /**
@@ -279,7 +280,7 @@ async function executeWithTimeout(
 				} catch (e) {
 					// Only log non-ESRCH errors (ESRCH = process already gone, expected)
 					if (e instanceof Error && !e.message.includes('ESRCH')) {
-						console.error('[semgrep] child.kill failed:', e.message);
+						logger.log('[semgrep] child.kill failed:', e.message);
 					}
 				}
 				escalation = setTimeout(() => {
@@ -288,7 +289,7 @@ async function executeWithTimeout(
 					} catch (e) {
 						// Only log non-ESRCH errors (ESRCH = process already gone, expected)
 						if (e instanceof Error && !e.message.includes('ESRCH')) {
-							console.error('[semgrep] child.kill failed:', e.message);
+							logger.log('[semgrep] child.kill failed:', e.message);
 						}
 					}
 				}, KILL_GRACE_MS);
@@ -339,7 +340,7 @@ async function executeWithTimeout(
 				} catch (e) {
 					// Only log non-ESRCH errors (ESRCH = process already gone, expected)
 					if (e instanceof Error && !e.message.includes('ESRCH')) {
-						console.error('[semgrep] child.kill failed:', e.message);
+						logger.log('[semgrep] child.kill failed:', e.message);
 					}
 				}
 			} else {
@@ -371,7 +372,7 @@ async function executeWithTimeout(
 				} catch (e) {
 					// Only log non-ESRCH errors (ESRCH = process already gone, expected)
 					if (e instanceof Error && !e.message.includes('ESRCH')) {
-						console.error('[semgrep] child.kill failed:', e.message);
+						logger.log('[semgrep] child.kill failed:', e.message);
 					}
 				}
 			} else {

--- a/src/tools/build-check.ts
+++ b/src/tools/build-check.ts
@@ -10,6 +10,7 @@ import { type BuildCommand, discoverBuildCommands } from '../build/discovery';
 import type { BuildEvidence, EvidenceVerdict } from '../config/evidence-schema';
 import { saveEvidence } from '../evidence/manager';
 import { bunSpawn } from '../utils/bun-compat';
+import * as logger from '../utils/logger.js';
 import { createSwarmTool } from './create-tool';
 
 // ============ Constants ============
@@ -322,7 +323,7 @@ export const build_check: ReturnType<typeof tool> = createSwarmTool({
 		try {
 			await saveEvidence(workingDir, 'build', evidence);
 		} catch (error) {
-			console.error(
+			logger.log(
 				'Failed to save build evidence:',
 				error instanceof Error ? error.message : String(error),
 			);

--- a/src/tools/convene-general-council.ts
+++ b/src/tools/convene-general-council.ts
@@ -35,6 +35,7 @@ import type {
 	GeneralCouncilMemberResponse,
 } from '../council/general-council-types';
 import { getAgentSession } from '../state';
+import * as logger from '../utils/logger.js';
 import { createSwarmTool } from './create-tool';
 import { resolveWorkingDirectory } from './resolve-working-directory';
 
@@ -260,7 +261,7 @@ export const convene_general_council: ReturnType<typeof tool> = createSwarmTool(
 			} catch (err) {
 				// Evidence write is best-effort; surface but do not abort.
 				const message = err instanceof Error ? err.message : String(err);
-				console.warn(
+				logger.log(
 					`[convene_general_council] Failed to write evidence to ${evidencePath}: ${message}`,
 				);
 			}

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -19,6 +19,7 @@ import {
 import type { ParallelDispatcher } from '../parallel/dispatcher/parallel-dispatcher.js';
 import { createParallelDispatcher } from '../parallel/dispatcher/parallel-dispatcher.js';
 import { swarmState } from '../state.js';
+import * as logger from '../utils/logger.js';
 import { createSwarmTool } from './create-tool.js';
 
 const MAX_LANES = 8;
@@ -1542,7 +1543,7 @@ function applyExplorerFormatSuffix(
 		if (lane.prompt.includes('[CANDIDATE]')) return lane;
 		const prompt = `${lane.prompt}${EXPLORER_CANDIDATE_FORMAT_SUFFIX}`;
 		if (prompt.length > MAX_PROMPT_CHARS) {
-			console.warn(
+			logger.log(
 				`[dispatch-lanes] applyExplorerFormatSuffix: lane "${lane.id}" prompt too long ` +
 					`(${lane.prompt.length} chars + suffix = ${prompt.length}, max ${MAX_PROMPT_CHARS}); ` +
 					`format enforcement skipped — explorer may not emit [CANDIDATE] rows`,

--- a/src/tools/lean-turbo-run-phase.ts
+++ b/src/tools/lean-turbo-run-phase.ts
@@ -9,6 +9,7 @@ import { loadPluginConfigWithMeta as loadPluginConfigWithMeta_import } from '../
 import { swarmState } from '../state';
 import type { LaneResult, MergeBackFailureInfo } from '../turbo/lean/runner';
 import { LeanTurboRunner as LeanTurboRunner_import } from '../turbo/lean/runner';
+import * as logger from '../utils/logger.js';
 import { createSwarmTool } from './create-tool';
 
 /**
@@ -95,7 +96,7 @@ export async function executeLeanTurboRunPhase(
 			}
 		} catch (cleanupError) {
 			// Log cleanup error but do not throw
-			console.error('[lean_turbo_run_phase] Cleanup failed:', cleanupError);
+			logger.log('[lean_turbo_run_phase] Cleanup failed:', cleanupError);
 		}
 	}
 

--- a/src/tools/req-coverage.ts
+++ b/src/tools/req-coverage.ts
@@ -9,6 +9,7 @@ import * as path from 'node:path';
 import type { tool } from '@opencode-ai/plugin';
 import { z } from 'zod';
 import { readEffectiveSpecSync } from '../sdd/effective-spec';
+import * as logger from '../utils/logger.js';
 import { createSwarmTool } from './create-tool';
 
 // ============ Constants ============
@@ -548,7 +549,7 @@ export const req_coverage: ReturnType<typeof tool> = createSwarmTool({
 			fs.writeFileSync(reportPath, JSON.stringify(result, null, 2), 'utf-8');
 		} catch (writeError) {
 			// Non-blocking - return result even if report write fails
-			console.warn(
+			logger.log(
 				`Failed to write coverage report: ${writeError instanceof Error ? writeError.message : String(writeError)}`,
 			);
 		}

--- a/src/tools/sbom-generate.ts
+++ b/src/tools/sbom-generate.ts
@@ -17,6 +17,7 @@ import {
 	type SbomComponent,
 } from '../sbom/detectors/index';
 import { simpleGlobToRegex } from '../utils';
+import * as logger from '../utils/logger.js';
 import { createSwarmTool } from './create-tool';
 
 // ============ Constants ============
@@ -410,7 +411,7 @@ export const sbom_generate: ReturnType<typeof tool> = createSwarmTool({
 			});
 		} catch (error) {
 			// Log warning but don't fail - SBOM file was still written
-			console.warn(
+			logger.log(
 				`Warning: Failed to save SBOM evidence: ${error instanceof Error ? error.message : String(error)}`,
 			);
 		}

--- a/src/tools/update-task-status.ts
+++ b/src/tools/update-task-status.ts
@@ -28,6 +28,7 @@ import {
 } from '../state';
 import { telemetry } from '../telemetry.js';
 import { verifyLeanTurboTaskCompletion } from '../turbo/lean/task-completion';
+import * as logger from '../utils/logger.js';
 import { validateTaskIdFormat as _validateTaskIdFormat } from '../validation/task-id';
 import { createSwarmTool } from './create-tool';
 import { resolveWorkingDirectory } from './resolve-working-directory';
@@ -311,7 +312,7 @@ export function checkReviewerGate(
 			}
 		} catch (error) {
 			// Malformed JSON, permission error, or other non-ENOENT issue — BLOCK
-			console.warn(
+			logger.log(
 				`[gate-evidence] Evidence file for task ${taskId} is corrupt or unreadable:`,
 				error instanceof Error ? error.message : String(error),
 			);
@@ -1009,7 +1010,7 @@ export async function executeUpdateTaskStatus(
 	}
 
 	if (args.status === 'in_progress' && args.force === true) {
-		console.warn(
+		logger.log(
 			`[update-task-status] Force-override: re-opening settled task ${args.task_id} to in_progress`,
 		);
 	}
@@ -1231,10 +1232,7 @@ export async function executeUpdateTaskStatus(
 				await lockResult.lock._release();
 			} catch (releaseError) {
 				// Log but don't propagate - original error/context takes precedence
-				console.error(
-					'[update-task-status] Lock release failed:',
-					releaseError,
-				);
+				logger.log('[update-task-status] Lock release failed:', releaseError);
 			}
 		}
 	}

--- a/src/tools/write-drift-evidence.ts
+++ b/src/tools/write-drift-evidence.ts
@@ -18,6 +18,7 @@ import { validateSwarmPath } from '../hooks/utils';
 import { takeSnapshotEvent } from '../plan/ledger';
 import { loadPlanJsonOnly } from '../plan/manager';
 import { derivePlanId } from '../plan/utils.js';
+import * as logger from '../utils/logger.js';
 import { createSwarmTool } from './create-tool';
 
 /**
@@ -205,7 +206,7 @@ export async function executeWriteDriftEvidence(
 						// A missing profile is expected when gates were never configured.
 						if (!/No QA gate profile/i.test(msg)) {
 							qaProfileLockError = msg;
-							console.warn(
+							logger.log(
 								'[write_drift_evidence] QA gate profile lock failed:',
 								msg,
 							);
@@ -216,7 +217,7 @@ export async function executeWriteDriftEvidence(
 				}
 			} catch (err) {
 				snapshotError = err instanceof Error ? err.message : String(err);
-				console.warn(
+				logger.log(
 					'[write_drift_evidence] critic-approved snapshot failed:',
 					snapshotError,
 				);

--- a/tests/unit/plugin-tui-safety.test.ts
+++ b/tests/unit/plugin-tui-safety.test.ts
@@ -131,6 +131,61 @@ const TUI_SAFETY_SCOPES: Array<{
 		label: 'prm-trajectory-store.ts',
 		quietTokens: [],
 	},
+	// PR4 of epic #1752 migrated these tool-execute-path modules (the tool
+	// handler bodies in src/tools/*, plus the mutation generator and semgrep
+	// SAST runner) to logger.log. Same contract as the PR2/PR3 blocks above:
+	// zero raw console.warn/error/log. This is the interim regression guard
+	// until PR5 enables Biome `noConsole` globally.
+	{
+		file: 'src/tools/build-check.ts',
+		label: 'build-check.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/tools/convene-general-council.ts',
+		label: 'convene-general-council.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/tools/dispatch-lanes.ts',
+		label: 'dispatch-lanes.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/tools/lean-turbo-run-phase.ts',
+		label: 'lean-turbo-run-phase.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/tools/req-coverage.ts',
+		label: 'req-coverage.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/tools/sbom-generate.ts',
+		label: 'sbom-generate.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/tools/update-task-status.ts',
+		label: 'update-task-status.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/tools/write-drift-evidence.ts',
+		label: 'write-drift-evidence.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/mutation/generator.ts',
+		label: 'mutation-generator.ts',
+		quietTokens: [],
+	},
+	{
+		file: 'src/sast/semgrep.ts',
+		label: 'semgrep.ts',
+		quietTokens: [],
+	},
 ];
 
 function readScope(file: string): string {
@@ -241,22 +296,29 @@ describe('Plugin TUI safety', () => {
 		}
 	});
 
-	test('PR2/PR3-migrated modules have zero raw console.warn (epic #1752)', () => {
-		// PR2 (loader.ts, architect.ts, snapshot-reader.ts, project-init.ts)
-		// and PR3 (delegation-gate, worktree-isolation, knowledge-store,
+	test('PR2/PR3/PR4-migrated modules have zero raw console.* (epic #1752)', () => {
+		// PR2 (loader.ts, architect.ts, snapshot-reader.ts, project-init.ts),
+		// PR3 (delegation-gate, worktree-isolation, knowledge-store,
 		// skill-usage-log, council-evidence-writer, ast-diff,
-		// context-budget-service, worktree-link-suggestion, prm/*) were
-		// migrated to advisoryWarn/log. They must contain ZERO raw
-		// console.warn so the bubbletea TUI is never corrupted on the init
-		// and hook paths (issue #1249 class). This is the interim regression
-		// guard until PR5 enables Biome `noConsole` globally.
+		// context-budget-service, worktree-link-suggestion, prm/*), and PR4
+		// (build-check, convene-general-council, dispatch-lanes,
+		// lean-turbo-run-phase, req-coverage, sbom-generate, update-task-status,
+		// write-drift-evidence, mutation/generator, sast/semgrep) were migrated
+		// to advisoryWarn/log. They must contain ZERO raw console.warn/error/log
+		// so the bubbletea TUI is never corrupted on the init, hook, and tool
+		// execute paths (issue #1249 class). This is the interim regression
+		// guard until PR5 enables Biome `noConsole` globally. The regex covers
+		// all three console channels because PR4 migrated `console.error` sites
+		// (semgrep kill-failed, build-check evidence, lean-turbo cleanup) in
+		// addition to `console.warn`.
 		for (const scope of TUI_SAFETY_SCOPES) {
 			if (scope.quietTokens.length > 0) continue; // skip guarded-scope files
 			const src = readScope(scope.file);
-			const warnCount = (src.match(/console\.warn\(/g) || []).length;
+			const consoleCount = (src.match(/console\.(warn|error|log)\(/g) || [])
+				.length;
 			expect(
-				warnCount,
-				`${scope.file} must contain zero raw console.warn after epic #1752 PR2/PR3 migration`,
+				consoleCount,
+				`${scope.file} must contain zero raw console.warn/error/log after epic #1752 PR2/PR3/PR4 migration`,
 			).toBe(0);
 		}
 	});

--- a/tests/unit/tools/update-task-status.test.ts
+++ b/tests/unit/tools/update-task-status.test.ts
@@ -1321,8 +1321,9 @@ describe('checkReviewerGate — adversarial warn', () => {
 	let tempDir: string;
 	let originalCwd: string;
 	let originalAgentSessions: typeof swarmState.agentSessions;
-	let originalConsoleWarn: typeof console.warn;
-	let warnCalls: string[];
+	let originalConsoleLog: typeof console.log;
+	let originalDebug: string | undefined;
+	let logCalls: string[];
 
 	beforeEach(() => {
 		// Create isolated temp directory for test isolation
@@ -1375,10 +1376,15 @@ describe('checkReviewerGate — adversarial warn', () => {
 
 		originalAgentSessions = new Map(swarmState.agentSessions);
 		swarmState.agentSessions.clear();
-		warnCalls = [];
-		originalConsoleWarn = console.warn;
-		console.warn = (...args: any[]) => {
-			warnCalls.push(args.join(' '));
+		// Epic #1752 PR4: the corrupt-evidence diagnostic now routes through
+		// logger.log (debug-gated via OPENCODE_SWARM_DEBUG=1) instead of raw
+		// console.warn. Enable debug and capture console.log to observe it.
+		originalDebug = process.env.OPENCODE_SWARM_DEBUG;
+		process.env.OPENCODE_SWARM_DEBUG = '1';
+		logCalls = [];
+		originalConsoleLog = console.log;
+		console.log = (...args: any[]) => {
+			logCalls.push(args.join(' '));
 		};
 	});
 
@@ -1387,7 +1393,13 @@ describe('checkReviewerGate — adversarial warn', () => {
 		for (const [key, value] of originalAgentSessions) {
 			swarmState.agentSessions.set(key, value);
 		}
-		console.warn = originalConsoleWarn;
+		// Restore env + console.
+		if (originalDebug === undefined) {
+			delete process.env.OPENCODE_SWARM_DEBUG;
+		} else {
+			process.env.OPENCODE_SWARM_DEBUG = originalDebug;
+		}
+		console.log = originalConsoleLog;
 		process.chdir(originalCwd);
 		fs.rmSync(tempDir, { recursive: true, force: true });
 	});
@@ -1405,8 +1417,8 @@ describe('checkReviewerGate — adversarial warn', () => {
 
 	// ====== Attack Vector 2: taskId with very long string (10,000 chars) ======
 	test('does not throw with extremely long taskId (10000 chars)', () => {
-		// Reset warnCalls to ensure clean state - there may be leftover warns from previous tests
-		warnCalls = [];
+		// Reset logCalls to ensure clean state - there may be leftover logs from previous tests
+		logCalls = [];
 
 		const longTaskId = 'a'.repeat(10000);
 		const session = createWorkflowTestSession();
@@ -1414,11 +1426,14 @@ describe('checkReviewerGate — adversarial warn', () => {
 		swarmState.agentSessions.clear();
 		swarmState.agentSessions.set('ses_abc', session);
 
-		// Should not throw, and warn should be suppressed (not fired)
+		// Should not throw, and the corrupt-evidence diagnostic should fire once
+		// (long taskId causes readTaskEvidenceRaw to throw → catch → logger.log).
 		const result = checkReviewerGate(longTaskId, tempDir);
 		expect(result.blocked).toBe(true);
-		// Should fire warn because taskId validation fails
-		expect(warnCalls.length).toBe(1);
+		// Should fire the corrupt-evidence diagnostic once (now debug-gated via logger.log).
+		expect(
+			logCalls.filter((m) => m.includes('corrupt or unreadable')).length,
+		).toBe(1);
 	});
 
 	// ====== Attack Vector 3: taskId is empty string ======
@@ -1447,8 +1462,11 @@ describe('checkReviewerGate — adversarial warn', () => {
 
 		const result = checkReviewerGate('1.1', tempDir);
 		expect(result.blocked).toBe(true);
-		// Should NOT fire warn because state is coder_delegated, not idle
-		expect(warnCalls.length).toBe(0);
+		// Should NOT fire the corrupt-evidence diagnostic because the evidence path
+		// reads cleanly (no throw) for this taskId.
+		expect(
+			logCalls.filter((m) => m.includes('corrupt or unreadable')).length,
+		).toBe(0);
 	});
 
 	// ====== Attack Vector 5: Mixed case status ======
@@ -1462,8 +1480,10 @@ describe('checkReviewerGate — adversarial warn', () => {
 		const result = checkReviewerGate('1.1', tempDir);
 		// Should still be blocked (not tests_run or complete)
 		expect(result.blocked).toBe(true);
-		// Should NOT fire warn because 'IDLE' (uppercase) doesn't end with ': idle' (lowercase)
-		expect(warnCalls.length).toBe(0);
+		// Should NOT fire the corrupt-evidence diagnostic for this taskId.
+		expect(
+			logCalls.filter((m) => m.includes('corrupt or unreadable')).length,
+		).toBe(0);
 	});
 
 	// ====== Attack Vector 6: 100 sessions all idle ======
@@ -1477,8 +1497,10 @@ describe('checkReviewerGate — adversarial warn', () => {
 		const result = checkReviewerGate('1.1', tempDir);
 		expect(result.blocked).toBe(true);
 
-		// Should NOT fire any warn - regression warning is now suppressed
-		expect(warnCalls.length).toBe(0);
+		// Should NOT fire the corrupt-evidence diagnostic for this taskId.
+		expect(
+			logCalls.filter((m) => m.includes('corrupt or unreadable')).length,
+		).toBe(0);
 	});
 
 	// ====== Attack Vector 7: Session state advances during check (mutation) ======
@@ -1490,14 +1512,16 @@ describe('checkReviewerGate — adversarial warn', () => {
 		// the function uses a snapshot of stateEntries collected synchronously
 		const result = checkReviewerGate('1.1', tempDir);
 		expect(result.blocked).toBe(true);
-		// Should NOT fire warn - regression warning is suppressed when all sessions idle
-		expect(warnCalls.length).toBe(0);
+		// Should NOT fire the corrupt-evidence diagnostic for this taskId.
+		expect(
+			logCalls.filter((m) => m.includes('corrupt or unreadable')).length,
+		).toBe(0);
 	});
 
 	// ====== Attack Vector 8: Null/undefined taskId injection ======
 	test('handles null/undefined taskId gracefully (getTaskState returns idle)', () => {
-		// Reset warnCalls to ensure clean state
-		warnCalls = [];
+		// Reset logCalls to ensure clean state
+		logCalls = [];
 
 		const session = createWorkflowTestSession();
 		swarmState.agentSessions.clear();
@@ -1516,8 +1540,11 @@ describe('checkReviewerGate — adversarial warn', () => {
 		expect(resultNull.blocked).toBe(true);
 		expect(resultUndefined.blocked).toBe(true);
 
-		// Should fire 2 warnings - one for null and one for undefined taskId
-		expect(warnCalls.length).toBe(2);
+		// Should fire the corrupt-evidence diagnostic twice (one per invalid taskId),
+		// now debug-gated via logger.log.
+		expect(
+			logCalls.filter((m) => m.includes('corrupt or unreadable')).length,
+		).toBe(2);
 	});
 
 	// ====== Additional edge case: Zero sessions should not warn ======
@@ -1527,7 +1554,9 @@ describe('checkReviewerGate — adversarial warn', () => {
 		const result = checkReviewerGate('1.1', tempDir);
 		// Returns early with blocked: false
 		expect(result.blocked).toBe(false);
-		expect(warnCalls.length).toBe(0);
+		expect(
+			logCalls.filter((m) => m.includes('corrupt or unreadable')).length,
+		).toBe(0);
 	});
 
 	// ====== Additional edge case: Empty stateEntries should not warn ======
@@ -1540,8 +1569,10 @@ describe('checkReviewerGate — adversarial warn', () => {
 		// Even with a session, the allIdle check requires length > 0
 		const result = checkReviewerGate('1.1', tempDir);
 		expect(result.blocked).toBe(true);
-		// Should NOT fire warn - regression warning is suppressed when all sessions idle
-		expect(warnCalls.length).toBe(0);
+		// Should NOT fire the corrupt-evidence diagnostic for this taskId.
+		expect(
+			logCalls.filter((m) => m.includes('corrupt or unreadable')).length,
+		).toBe(0);
 	});
 });
 


### PR DESCRIPTION
Closes #1755

## Summary

PR4 of epic #1752. Migrates every remaining raw `console.warn` / `console.error` on the **tool execute path** (tool handler bodies in `src/tools/*`, plus `src/mutation/generator.ts` and `src/sast/semgrep.ts`) to the PR1 foundation helper:

- **21 diagnostic fail-open catches** → `logger.log(msg)` — debug-gated (`OPENCODE_SWARM_DEBUG=1`), not buffered.

All 21 are purely diagnostic (evidence-save failed, cleanup failed, kill failed, LLM call failed, corrupt evidence gate block, force-override operational mode, format-suffix skip, coverage/SBOM report write failed, etc.). The operator cannot act on any of them at runtime — the catches already fail open and return a result — so none use `advisoryWarn()`. This matches the PR2/PR3 precedent and the issue's own classification (the triage comment recommended `log()` for `:1012` force-override as an expected operational mode).

**Why:** Raw `console.warn`/`console.error` writes to stderr corrupt the OpenCode bubbletea TUI when it owns the terminal (issue #1249 class). PR1 built `advisoryWarn`/`log`; PR2 closed the init path; PR3 closed the hook path; this PR closes the tool execute path. PR5 will enable Biome `noConsole` globally.

Message strings are preserved **verbatim** — only the delivery channel changed.

### Files migrated (zero raw `console.*` each)
- `tools/build-check.ts` (1), `tools/convene-general-council.ts` (1), `tools/dispatch-lanes.ts` (1), `tools/lean-turbo-run-phase.ts` (1), `tools/req-coverage.ts` (1), `tools/sbom-generate.ts` (1)
- `tools/update-task-status.ts` (3: corrupt-evidence gate, force-override, lock-release)
- `tools/write-drift-evidence.ts` (2: QA-profile lock, snapshot failure)
- `mutation/generator.ts` (6: no-ctx, no-client, session-create, prompt, parse, call-failed)
- `sast/semgrep.ts` (4: child.kill failures, all ESRCH-guarded)

## Invariant audit
- 1 (plugin init): not touched — no init-path code changed.
- 2 (runtime portability): touched — `bun run build` succeeds; `node --input-type=module -e "await import('./dist/index.js')"` exits 0 (ESM bundle loads). No top-level `bun:` imports added; default export shape unchanged.
- 3 (subprocesses): not touched — semgrep `child.kill` calls unchanged; only the diagnostic-on-kill-failure channel changed.
- 4 (.swarm containment): not touched.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — targeted `bun test <files>`, no broad `scope: 'all'`.
- 7 (test writing): touched — bun:test only; debug-capture pattern (PR3 precedent: `src/hooks/delegation-gate.evidence.test.ts`); env+console restored in `afterEach`; no `mock.module`. `OPENCODE_SWARM_DEBUG` is read live by `isDebug()` so the env-var flip works in-test.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): touched — this IS the TUI-noise fix (issue #1249 class). Zero raw `console.warn`/`error`/`log` remain in the 10 migrated files (grep evidence); repo-wide `src/` sweep confirms zero remaining outside `src/cli/index.ts` (standalone CLI installer UX, intentionally raw).
- 11 (tool registration): not touched.
- 12 (release/cache): touched — release fragment added at `docs/releases/pending/1755-tui-pollution-pr4-tool-path.md`; no version files hand-edited.

## Regression guard

Extended `tests/unit/plugin-tui-safety.test.ts`:
- Added the 10 migrated files to `TUI_SAFETY_SCOPES` (`quietTokens: []`).
- **Widened the enforcement regex** from `console\.warn\(` to `console\.(warn|error|log)\(` so the 3 `.error`-only files (`build-check`, `lean-turbo-run-phase`, `semgrep`) are actually enforced (the old regex would have let a `console.error` regression through silently).

## Test plan

Validation run (all green):
- `bun run lint:ci` (= `biome ci .`) — `Checked 2449 files. No fixes applied.` EXIT 0
- `bun run build` — succeeded (ESM bundle + grammars)
- `node --input-type=module -e "await import('./dist/index.js')"` — EXIT 0
- `bun test tests/unit/plugin-tui-safety.test.ts` — 9 pass (incl. widened-regex assertion over 10 new files)
- `bun test tests/unit/tools/update-task-status.test.ts` — 71 pass (incl. flipped adversarial-warn block: 2 positive + 6 negative assertions via debug-capture)
- `bun test src/tools/update-task-status.test.ts` — 9 pass (colocated fallbackDir guard, unchanged)
- Migrated-module suites (build-check, convene-general-council, dispatch-lanes, lean-turbo-run-phase, sbom-generate, write-drift-evidence, generator, semgrep ×2, req-coverage) — all pass
- update-task-status sibling suites (adversarial, gates, recovery, lean-turbo, adversarial-v2, concurrent-write, council-gate, gate-fix, locking, locking-adversarial, ledger-stale, colocated adversarial/gates/turbo-bypass) — all pass
- grep: zero `console.(warn|error|log)(` in all 10 migrated files

Reproduction re-check: the issue's bug class (raw `console.*` polluting the TUI on tool paths) is closed — the source-scan test now enforces zero raw `console.*` across all 10 files with the widened regex.

### Scope notes
- `save-plan-snapshot-retry*.test.ts` and `pre-check-batch*.adversarial.test.ts` were named in the issue but verified to test different source modules (`save-plan`, `plan/manager`, `pre-check-batch`) — no edits needed.
- The Issue #81 and Task 2.2 describe blocks in `update-task-status.test.ts` are left unchanged: they guard a different, already-removed idle-state regression warn.
- Biome `noConsole` global enforcement remains deferred to PR5 of epic #1752.

## Review gates
- Plan critic (GLM-5.2): NEEDS_REVISION → 3 items addressed (missed 2nd positive assertion at L1520, 3 describe-blocks mapped, regex widened). Re-approved.
- Implementation reviewer (GLM-5.2): NEEDS_REVISION → 4 Biome `ci` format violations auto-fixed via `biome check --write`; re-verified `lint:ci` EXIT 0. The `bun run lint` script omits format checking; `lint:ci` is the real CI gate.
- Final critic (GLM-5.2): APPROVE — all 6 challenge points resolved (requirement drift clean, negative assertions empirically non-vacuous, sibling sweep clean, format fix zero semantic change, dispatch-lanes log() defensible, test isolation verified).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

