### PR TITLE
feat(apply-patch): opt-in fuzzy text-matching fallback (port hermes 9-strategy chain)

### DIFF
--- a/docs/releases/pending/1718-apply-patch-fuzzy-match.md
+++ b/docs/releases/pending/1718-apply-patch-fuzzy-match.md
@@ -3,7 +3,10 @@
 ## What changed
 - New `src/utils/sequence-matcher.ts` — a faithful TypeScript port of CPython's
   `difflib.SequenceMatcher` (Ratcliff/Obershelp + the autojunk/popular-element
-  guard), so the fuzzy thresholds produce ratios identical to Python's `2M/T`.
+  guard), so the fuzzy thresholds produce ratios matching Python's `2M/T`
+  formula for ASCII/BMP content. (Astral-plane characters consume two UTF-16
+  code units in JS vs one code point in Python, so ratios for emoji-heavy input
+  may differ marginally — see caveat below.)
 - New `src/utils/fuzzy-match.ts` — a port of hermes-agent's 9-strategy
   fuzzy-matching chain (exact, line-trimmed, whitespace-normalized,
   indentation-flexible, escape-normalized, trimmed-boundary, unicode-normalized,
@@ -16,8 +19,9 @@
   - `fuzzy_match` (default `false`) — enables strategies 1–8 (whitespace,
     indent, escape, unicode, block-anchor tolerance).
   - `fuzzy_match_context_aware` (default `false`) — additionally enables
-    strategy 9 (loosest; 50% per-line similarity). Only effective with
-    `fuzzy_match: true`.
+    strategy 9 (loosest; requires 50% of lines to reach 0.80 per-line
+    similarity). Only effective with `fuzzy_match: true`. Bounded by an
+    internal cell-count cap to prevent quadratic-cost hangs on large files.
 - On a fuzzy-attempted miss, the `context-mismatch` diagnostic now appends a
   "Did you mean one of these sections?" hint (ported from hermes) so the model
   can self-correct.
@@ -64,5 +68,11 @@ To additionally enable the loose `context_aware` strategy:
 - The matcher operates on UTF-16 code units; astral-plane (emoji) content is
   round-trip-safe but ratios may differ marginally from CPython code-point
   semantics.
+- Unicode preservation is fully effective for strategy 7 (`unicode_normalized`).
+  For strategies 8/9 (`block_anchor`/`context_aware`), preservation is
+  best-effort: when the matched block's normalized form does not align with the
+  file region (e.g. a fuzzy middle), unchanged spans may have their Unicode
+  characters (smart quotes, em-dashes) written as ASCII equivalents. This is a
+  narrow residual on a doubly-opt-in path.
 
 Closes #1718

--- a/docs/releases/pending/1718-apply-patch-fuzzy-match.md
+++ b/docs/releases/pending/1718-apply-patch-fuzzy-match.md
@@ -1,0 +1,68 @@
+# feat(apply-patch): opt-in fuzzy text-matching fallback (#1718)
+
+## What changed
+- New `src/utils/sequence-matcher.ts` — a faithful TypeScript port of CPython's
+  `difflib.SequenceMatcher` (Ratcliff/Obershelp + the autojunk/popular-element
+  guard), so the fuzzy thresholds produce ratios identical to Python's `2M/T`.
+- New `src/utils/fuzzy-match.ts` — a port of hermes-agent's 9-strategy
+  fuzzy-matching chain (exact, line-trimmed, whitespace-normalized,
+  indentation-flexible, escape-normalized, trimmed-boundary, unicode-normalized,
+  block-anchor, context-aware) plus the ambiguity guard, escape-drift guard,
+  selective `\t`/`\r` unescape, Unicode preservation, and indent re-alignment.
+- `apply-patch` now retries the fuzzy chain as a **fallback** when exact
+  positional match fails — but only when the new opt-in config flags are set.
+  The default (exact-match, the "B3 decision") is unchanged.
+- New config keys under `apply_patch`:
+  - `fuzzy_match` (default `false`) — enables strategies 1–8 (whitespace,
+    indent, escape, unicode, block-anchor tolerance).
+  - `fuzzy_match_context_aware` (default `false`) — additionally enables
+    strategy 9 (loosest; 50% per-line similarity). Only effective with
+    `fuzzy_match: true`.
+- On a fuzzy-attempted miss, the `context-mismatch` diagnostic now appends a
+  "Did you mean one of these sections?" hint (ported from hermes) so the model
+  can self-correct.
+
+## Why
+LLM-proposed patches frequently drift from the file text in trailing
+whitespace, indentation, escape sequences (`\t` vs real tab), and Unicode
+lookalikes (smart quotes, em-dashes). The exact-match-only default rejected
+these, forcing costly retries. The fuzzy fallback salvages such edits while
+keeping the safe exact-match default intact and gating the loosest strategy
+behind a separate flag.
+
+## Migration
+None required — default behavior is unchanged. To opt in, add to
+`.opencode/opencode-swarm.json`:
+
+```json
+{
+  "apply_patch": {
+    "fuzzy_match": true
+  }
+}
+```
+
+To additionally enable the loose `context_aware` strategy:
+
+```json
+{
+  "apply_patch": {
+    "fuzzy_match": true,
+    "fuzzy_match_context_aware": true
+  }
+}
+```
+
+## Known caveats
+- Fuzzy is a per-hunk tolerance layer, not a whole-diff position searcher.
+  Multi-hunk patches where a fuzzy relocation overlaps a later hunk's declared
+  context will still report a clean `context-mismatch` on that later hunk (no
+  file corruption).
+- The selective `\r` unescape path is inert under `apply-patch` (content is
+  LF-normalized before matching); it remains active at the utility level for
+  other consumers.
+- The matcher operates on UTF-16 code units; astral-plane (emoji) content is
+  round-trip-safe but ratios may differ marginally from CPython code-point
+  semantics.
+
+Closes #1718

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -84,6 +84,7 @@ export {
 } from './plan-schema';
 export type {
 	AgentOverrideConfig,
+	ApplyPatchConfig,
 	AutomationCapabilities,
 	AutomationConfig,
 	AutomationMode,
@@ -102,6 +103,7 @@ export type {
 } from './schema';
 export {
 	AgentOverrideConfigSchema,
+	ApplyPatchConfigSchema,
 	AutomationCapabilitiesSchema,
 	AutomationConfigSchema,
 	AutomationModeSchema,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1032,8 +1032,10 @@ export const ApplyPatchConfigSchema = z
 		// false preserves the B3 exact-match decision.
 		fuzzy_match: z.boolean().default(false),
 		// Separately opts in to strategy 9 (context_aware) — the loosest,
-		// most-false-positive-prone strategy (50% line similarity threshold).
-		// Only effective when `fuzzy_match` is also true.
+		// most-false-positive-prone strategy (requires 50% of lines to reach
+		// 0.80 per-line similarity). Only effective when `fuzzy_match` is also
+		// true. Bounded by an internal cell-count cap to prevent quadratic-cost
+		// hangs on large files.
 		fuzzy_match_context_aware: z.boolean().default(false),
 	})
 	.strict();

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1017,6 +1017,29 @@ export const CheckpointConfigSchema = z
 
 export type CheckpointConfig = z.infer<typeof CheckpointConfigSchema>;
 
+// Apply-patch configuration (issue #1718 opt-in fuzzy matching fallback)
+//
+// Ports hermes-agent's 9-strategy fuzzy text-matching chain as an OPT-IN
+// fallback for `apply-patch`. The exact-match default (the "B3 decision") is
+// preserved when both flags are false. Strategy 9 (`context_aware`) is the
+// loosest/most-false-positive-prone strategy and is gated behind a SEPARATE
+// flag so users opt into it independently of the broader fuzzy fallback.
+export const ApplyPatchConfigSchema = z
+	.object({
+		// Opt-in fuzzy text-matching fallback for apply-patch hunks. When true,
+		// applyHunks retries strategies 1-8 (whitespace, indent, escape, unicode,
+		// block-anchor tolerance) when exact positional match fails. Default
+		// false preserves the B3 exact-match decision.
+		fuzzy_match: z.boolean().default(false),
+		// Separately opts in to strategy 9 (context_aware) — the loosest,
+		// most-false-positive-prone strategy (50% line similarity threshold).
+		// Only effective when `fuzzy_match` is also true.
+		fuzzy_match_context_aware: z.boolean().default(false),
+	})
+	.strict();
+
+export type ApplyPatchConfig = z.infer<typeof ApplyPatchConfigSchema>;
+
 // Automation mode enum: controls background-first automation rollout
 // - manual: No background automation, all actions via slash commands (v6.6 behavior)
 // - hybrid: Background automation for safe operations, slash commands for sensitive ones
@@ -2633,6 +2656,9 @@ export const PluginConfigSchema = z.object({
 
 	// Checkpoint configuration
 	checkpoint: CheckpointConfigSchema.optional(),
+
+	// Apply-patch opt-in fuzzy matching fallback (issue #1718)
+	apply_patch: ApplyPatchConfigSchema.optional(),
 
 	// Automation configuration (v6.7 background-first rollout)
 	// Controls background automation mode and per-feature toggles

--- a/src/services/config-doctor.ts
+++ b/src/services/config-doctor.ts
@@ -1212,6 +1212,11 @@ function validateConfigKey(path: string, value: unknown): ConfigFinding[] {
 			break;
 		}
 
+		case 'apply_patch': {
+			emitObjectTypeMismatch('apply_patch', value, findings);
+			break;
+		}
+
 		case 'automation': {
 			emitObjectTypeMismatch('automation', value, findings);
 			break;

--- a/src/tools/apply-patch.test.ts
+++ b/src/tools/apply-patch.test.ts
@@ -10,7 +10,7 @@ import {
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import type { ApplyPatchResult } from './apply-patch';
-import { swarmApplyPatch } from './apply-patch';
+import { _internals, swarmApplyPatch } from './apply-patch';
 
 // Helper: create a temp directory
 function createTempDir(): string {
@@ -843,5 +843,185 @@ describe('swarm_apply_patch tool', () => {
 		expect(result.files[0]?.errors?.[0]?.message).toContain(
 			'Unsupported patch format',
 		);
+	});
+});
+
+// =============================================================================
+// Opt-in fuzzy matching fallback (issue #1718)
+//
+// These tests prove the opt-in contract: with the config flags off (default),
+// behavior is byte-identical to the B3 exact-match decision. With
+// `apply_patch.fuzzy_match: true`, applyHunks retries the fuzzy chain on
+// exact-match failure. Strategy 9 is separately gated by
+// `apply_patch.fuzzy_match_context_aware`.
+//
+// Config is injected hermetically via the `_internals.loadPluginConfigWithMeta`
+// DI seam (AGENTS.md invariant 7) — no real config files are written, so the
+// tests are immune to the user-config merge path in `loadPluginConfig`.
+// =============================================================================
+
+describe('swarm_apply_patch fuzzy-match fallback', () => {
+	let workspace: string;
+	const originalLoader = _internals.loadPluginConfigWithMeta;
+
+	beforeEach(() => {
+		workspace = createTempDir();
+	});
+
+	afterEach(() => {
+		_internals.loadPluginConfigWithMeta = originalLoader;
+		try {
+			rmSync(workspace, { recursive: true, force: true });
+		} catch {
+			// Ignore cleanup errors
+		}
+	});
+
+	/** Override the config loader to return a config with the given fuzzy flags. */
+	function setFuzzyConfig(fuzzyMatch: boolean, fuzzyMatchContextAware = false): void {
+		_internals.loadPluginConfigWithMeta = (() => ({
+			config: {
+				apply_patch: {
+					fuzzy_match: fuzzyMatch,
+					fuzzy_match_context_aware: fuzzyMatchContextAware,
+				},
+			},
+			loadedFromFile: true,
+			configHadErrors: false,
+		})) as typeof _internals.loadPluginConfigWithMeta;
+	}
+
+	test('default-off: exact-match patch still applies (no regression on default path)', async () => {
+		// Flags off → exact match only → a clean patch must still succeed.
+		setFuzzyConfig(false);
+		const targetFile = 'clean.txt';
+		createFile(workspace, targetFile, 'line1\nline2\nline3\n');
+		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,3 +1,3 @@\n line1\n-line2\n+line2-modified\n line3\n`;
+
+		const resultStr = await swarmApplyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+		expect(result.success).toBe(true);
+		expect(result.files[0]?.status).toBe('applied');
+	});
+
+	test('fuzzy-on: indentation drift (2-line block) is tolerated via a fuzzy strategy', async () => {
+		setFuzzyConfig(true);
+		const targetFile = 'drift.txt';
+		// File uses 4-space indent for the body. The patch's context+removal
+		// lines use 2-space body indent — this is NOT a substring of the file
+		// (because `\n  return` ≠ `\n    return`), so strategyExact cannot
+		// match; line_trimmed / indentation_flexible must handle it.
+		createFile(workspace, targetFile, 'def foo():\n    return x + y\n');
+		// Patch: context "def foo():" (exact), removal "  return x + y" (2-space,
+		// drifted from 4), addition "  return x + z".
+		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,2 +1,2 @@\n def foo():\n-  return x + y\n+  return x + z\n`;
+
+		const resultStr = await swarmApplyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+		expect(result.success).toBe(true);
+		expect(result.files[0]?.status).toBe('applied');
+		const finalContent = readFileContent(workspace, targetFile);
+		expect(finalContent).toContain('return x + z');
+		expect(finalContent).not.toContain('return x + y');
+	});
+
+	test('default-off: same drifting patch fails (proves fuzzy is the cause of success)', async () => {
+		setFuzzyConfig(false);
+		const targetFile = 'drift2.txt';
+		createFile(workspace, targetFile, 'def foo():\n    return x + y\n');
+		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,2 +1,2 @@\n def foo():\n-  return x + y\n+  return x + z\n`;
+
+		const resultStr = await swarmApplyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+		expect(result.success).toBe(false);
+		expect(result.files[0]?.errors?.[0]?.type).toBe('context-mismatch');
+	});
+
+	test('strategy 9 gated: block only context_aware matches — fails without the flag, succeeds with it', async () => {
+		// A block where strategies 1-8 all reject (anchor lines differ,
+		// whitespace/indent/escape/unicode cannot salvage, middle similarity
+		// below block_anchor's 0.50 threshold) but strategy 9 (50% per-line
+		// similarity ≥0.80) accepts. Verified: each pair of lines is ≥0.80
+		// similar via SequenceMatcher, so context_aware matches all 3.
+		const targetFile = 'ctx9.txt';
+		createFile(workspace, targetFile, 'def foo():\n    x = 1\n    return x\n');
+		// Old context: same structure, x→y rename + value change. Each line is
+		// highly similar to its counterpart (def foo() ==, "x = 1" vs "y = 2",
+		// "return x" vs "return y"). block_anchor fails because the anchor lines
+		// ("def foo():" / "return x") — first matches, last ("return x" vs
+		// "return y") stripped-equality fails the anchor. context_aware succeeds.
+		const oldBlock = 'def foo():\n    y = 2\n    return y';
+		const newBlock = 'def foo():\n    x = 1\n    return x';
+		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,3 +1,3 @@\n-${oldBlock.split('\n').join('\n-')}\n+${newBlock.split('\n').join('\n+')}\n`;
+
+		// With context_aware OFF: must fail (strategies 1-8 reject).
+		setFuzzyConfig(true, false);
+		const offResult = parseResult(
+			await swarmApplyPatch.execute(
+				{ patch, files: [targetFile] },
+				workspaceOf(workspace) as any,
+			),
+		);
+		expect(offResult.success).toBe(false);
+		expect(offResult.files[0]?.errors?.[0]?.type).toBe('context-mismatch');
+
+		// Fresh file, then with context_aware ON: must succeed (strategy 9 accepts).
+		createFile(workspace, targetFile, 'def foo():\n    x = 1\n    return x\n');
+		setFuzzyConfig(true, true);
+		const onResult = parseResult(
+			await swarmApplyPatch.execute(
+				{ patch, files: [targetFile] },
+				workspaceOf(workspace) as any,
+			),
+		);
+		expect(onResult.success).toBe(true);
+	});
+
+	test('fuzzy-fail appends a "did you mean?" hint to the diagnostic', async () => {
+		// Fuzzy enabled, but the patch context is genuinely absent from the file
+		// (no strategy can match). The error message should include the hint.
+		setFuzzyConfig(true);
+		const targetFile = 'hint.txt';
+		// File has a similar-but-different line so findClosestLines returns content.
+		createFile(workspace, targetFile, 'def bar():\n    return 1\n');
+		// Patch looks for "def foo():" which does not exist.
+		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,1 +1,1 @@\n-def foo():\n+def baz():\n`;
+
+		const resultStr = await swarmApplyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+		expect(result.success).toBe(false);
+		const message = result.files[0]?.errors?.[0]?.message ?? '';
+		expect(message).toContain('Did you mean one of these sections?');
+	});
+
+	test('multi-hunk: first hunk fuzzy, second hunk exact (non-overlapping)', async () => {
+		setFuzzyConfig(true);
+		const targetFile = 'multi.txt';
+		// Two well-separated regions. First has whitespace drift; second is exact.
+		createFile(workspace, targetFile, 'header  line\nbody1\nMIDDLE\nbody2\nfooter  line\n');
+		// Hunk 1: context "header line" (single space) vs file "header  line" → fuzzy.
+		// Hunk 2: exact context "footer  line" → exact match.
+		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,1 +1,1 @@\n-header line\n+HEADER LINE\n@@ -5,1 +5,1 @@\n-footer  line\n+FOOTER LINE\n`;
+		const resultStr = await swarmApplyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+		expect(result.success).toBe(true);
+		const finalContent = readFileContent(workspace, targetFile);
+		expect(finalContent).toContain('HEADER LINE');
+		expect(finalContent).toContain('FOOTER LINE');
 	});
 });

--- a/src/tools/apply-patch.test.ts
+++ b/src/tools/apply-patch.test.ts
@@ -878,7 +878,10 @@ describe('swarm_apply_patch fuzzy-match fallback', () => {
 	});
 
 	/** Override the config loader to return a config with the given fuzzy flags. */
-	function setFuzzyConfig(fuzzyMatch: boolean, fuzzyMatchContextAware = false): void {
+	function setFuzzyConfig(
+		fuzzyMatch: boolean,
+		fuzzyMatchContextAware = false,
+	): void {
 		_internals.loadPluginConfigWithMeta = (() => ({
 			config: {
 				apply_patch: {
@@ -1010,7 +1013,11 @@ describe('swarm_apply_patch fuzzy-match fallback', () => {
 		setFuzzyConfig(true);
 		const targetFile = 'multi.txt';
 		// Two well-separated regions. First has whitespace drift; second is exact.
-		createFile(workspace, targetFile, 'header  line\nbody1\nMIDDLE\nbody2\nfooter  line\n');
+		createFile(
+			workspace,
+			targetFile,
+			'header  line\nbody1\nMIDDLE\nbody2\nfooter  line\n',
+		);
 		// Hunk 1: context "header line" (single space) vs file "header  line" → fuzzy.
 		// Hunk 2: exact context "footer  line" → exact match.
 		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,1 +1,1 @@\n-header line\n+HEADER LINE\n@@ -5,1 +5,1 @@\n-footer  line\n+FOOTER LINE\n`;
@@ -1023,5 +1030,59 @@ describe('swarm_apply_patch fuzzy-match fallback', () => {
 		const finalContent = readFileContent(workspace, targetFile);
 		expect(finalContent).toContain('HEADER LINE');
 		expect(finalContent).toContain('FOOTER LINE');
+	});
+
+	test('multi-hunk: fuzzy relocation into a later hunk region fails cleanly (no corruption)', async () => {
+		// Documents the limitation at apply-patch.ts:587-589: fuzzy is a per-hunk
+		// tolerance layer; if a fuzzy relocation shifts content into a later
+		// hunk's declared context, that later hunk reports a clean
+		// context-mismatch (no corruption). This test proves the no-corruption
+		// invariant: regardless of whether the patch succeeds or fails, the
+		// written file is coherent line structure (never garbled/partial).
+		setFuzzyConfig(true);
+		const targetFile = 'overlap.txt';
+		// File with two regions; hunk 1 drifts on whitespace (forces fuzzy),
+		// hunk 2 targets a nearby region. The key assertion is integrity, not
+		// a specific pass/fail outcome (the outcome depends on whether fuzzy
+		// relocation happens to collide with hunk 2's declared offset).
+		createFile(workspace, targetFile, 'AAA  target\nBBB marker\nCCC\nDDD\n');
+		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,1 +1,1 @@\n-AAA target\n+AAA fixed\n@@ -2,1 +2,1 @@\n-BBB marker\n+bbb marker\n`;
+		const resultStr = await swarmApplyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+		// No-corruption invariant: the file, if written, must be coherent.
+		if (result.success) {
+			const finalContent = readFileContent(workspace, targetFile);
+			// Every original marker that wasn't an edit target must survive intact.
+			expect(finalContent.includes('CCC')).toBe(true);
+			expect(finalContent.includes('DDD')).toBe(true);
+		} else {
+			// Clean failure path: a context-mismatch, not a crash or garbled write.
+			expect(result.files[0]?.errors?.[0]?.type).toBe('context-mismatch');
+		}
+	});
+
+	test('escape-drift guard fires through the integration path', async () => {
+		// PRR-010: guards (escape-drift, ambiguity, selective unescape) were
+		// previously tested only at the unit level. This test exercises the
+		// escape-drift guard through execute() — a hunk whose context lines
+		// contain `\\'` (transport drift artifact) that the file does NOT have.
+		setFuzzyConfig(true);
+		const targetFile = 'drift-guard.txt';
+		createFile(workspace, targetFile, 'line\n    x = 1\nline\n');
+		// Context+removal lines carry `\\'` which the file lacks → escape-drift
+		// guard must block even though a fuzzy strategy would otherwise match.
+		const patch = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,3 +1,3 @@\n line\n-  x = \\'a\\'\n+  x = \\'b\\'\n line\n`;
+		const resultStr = await swarmApplyPatch.execute(
+			{ patch, files: [targetFile] },
+			workspaceOf(workspace) as any,
+		);
+		const result = parseResult(resultStr);
+		// The escape-drift guard blocks the write; the file is untouched.
+		expect(result.success).toBe(false);
+		const finalContent = readFileContent(workspace, targetFile);
+		expect(finalContent).toBe('line\n    x = 1\nline\n');
 	});
 });

--- a/src/tools/apply-patch.ts
+++ b/src/tools/apply-patch.ts
@@ -21,12 +21,12 @@ import {
 import * as path from 'node:path';
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
 import { z } from 'zod';
+import { loadPluginConfigWithMeta } from '../config';
+import { findClosestLines, fuzzyFindAndReplace } from '../utils/fuzzy-match';
 import {
 	containsControlChars,
 	containsPathTraversal,
 } from '../utils/path-security';
-import { fuzzyFindAndReplace, findClosestLines } from '../utils/fuzzy-match';
-import { loadPluginConfigWithMeta } from '../config';
 import { createSwarmTool } from './create-tool';
 
 /**
@@ -666,12 +666,23 @@ function applyHunks(
 			const currentContent = fileLines.join('\n');
 			const oldString = expectedOldLines.join('\n');
 			const newString = newLinesForHunk.join('\n');
-			const fuzzy = fuzzyFindAndReplace(currentContent, oldString, newString, false, {
-				includeContextAware: options.fuzzyMatchContextAware,
-			});
+			const fuzzy = fuzzyFindAndReplace(
+				currentContent,
+				oldString,
+				newString,
+				false,
+				{
+					includeContextAware: options.fuzzyMatchContextAware,
+				},
+			);
 			if (fuzzy.error === null && fuzzy.matchCount === 1) {
 				fileLines.length = 0;
-				fileLines.push(...fuzzy.content.split('\n'));
+				// Push line-by-line rather than `fileLines.push(...split('\n'))`:
+				// the spread-into-push form throws RangeError on very large line
+				// counts (~125k on Node, ~700k on Bun) because it routes through
+				// Function.prototype.apply, which is stack-bound. The loop has no
+				// such limit. (PRR-003 from the PR review.)
+				for (const line of fuzzy.content.split('\n')) fileLines.push(line);
 				accumulatedDelta += newLinesForHunk.length - expectedOldLines.length;
 				continue; // next hunk — skip the mismatch return below
 			}
@@ -1086,12 +1097,19 @@ function processFileDiff(
 		// types share matchCount=0; here we only call when fuzzy genuinely
 		// failed, so direct findClosestLines is correct).
 		let errors = hunkResult.error ? [hunkResult.error] : [];
-		if (hunkResult.fuzzyAttempted && errors.length > 0 && hunkOptions?.fuzzyMatch) {
+		if (
+			hunkResult.fuzzyAttempted &&
+			errors.length > 0 &&
+			hunkOptions?.fuzzyMatch
+		) {
 			const expectedAnchor = errors[0].expected ?? '';
 			const hint = findClosestLines(expectedAnchor, content);
 			if (hint) {
 				errors = [
-					{ ...errors[0], message: `${errors[0].message}\n\nDid you mean one of these sections?\n${hint}` },
+					{
+						...errors[0],
+						message: `${errors[0].message}\n\nDid you mean one of these sections?\n${hint}`,
+					},
 				];
 			}
 		}
@@ -1274,7 +1292,8 @@ export const swarmApplyPatch: ToolDefinition = createSwarmTool({
 		// `_internals` DI seam so tests can substitute hermetically.
 		const { config } = _internals.loadPluginConfigWithMeta(directory);
 		const fuzzyMatch = config.apply_patch?.fuzzy_match === true;
-		const fuzzyMatchContextAware = config.apply_patch?.fuzzy_match_context_aware === true;
+		const fuzzyMatchContextAware =
+			config.apply_patch?.fuzzy_match_context_aware === true;
 		const hunkOptions: ApplyHunksOptions | undefined =
 			fuzzyMatch || fuzzyMatchContextAware
 				? { fuzzyMatch, fuzzyMatchContextAware }

--- a/src/tools/apply-patch.ts
+++ b/src/tools/apply-patch.ts
@@ -25,7 +25,20 @@ import {
 	containsControlChars,
 	containsPathTraversal,
 } from '../utils/path-security';
+import { fuzzyFindAndReplace, findClosestLines } from '../utils/fuzzy-match';
+import { loadPluginConfigWithMeta } from '../config';
 import { createSwarmTool } from './create-tool';
+
+/**
+ * DI seam for hermetic config-load substitution in tests (AGENTS.md invariant 7).
+ * Mirrors the pattern at `src/tools/context-status.ts:81-88`. Tests override
+ * `_internals.loadPluginConfigWithMeta` and restore it in `afterEach` instead
+ * of writing real config files or using `mock.module` (which leaks across
+ * test files in Bun's shared runner).
+ */
+export const _internals = {
+	loadPluginConfigWithMeta,
+};
 
 // ============ Types ============
 
@@ -519,6 +532,23 @@ interface HunkApplyResult {
 	appliedLines?: string[];
 	failedHunkIndex?: number;
 	error?: ApplyPatchFileError;
+	/**
+	 * Set when a fuzzy fallback was attempted (config flag on) and failed.
+	 * Used by `processFileDiff` to append a "did you mean?" hint to the
+	 * diagnostic message — only when fuzzy actually ran and still missed.
+	 */
+	fuzzyAttempted?: boolean;
+}
+
+/**
+ * Opt-in fuzzy-matching options threaded from `execute` → `processFileDiff`
+ * → `applyHunks`. Both flags default false (exact-match-only, B3 decision).
+ */
+export interface ApplyHunksOptions {
+	/** Enable fuzzy fallback (strategies 1-8) on exact-match failure. */
+	fuzzyMatch: boolean;
+	/** Additionally enable strategy 9 (context_aware). Only effective with fuzzyMatch. */
+	fuzzyMatchContextAware: boolean;
 }
 
 /**
@@ -535,13 +565,25 @@ function arraysEqual(a: string[], b: string[]): boolean {
 /**
  * Attempt to apply all hunks from a ParsedFileDiff to the given file content.
  * Hunks are applied sequentially; on first failure, stops and returns diagnostics.
- * Uses exact context matching — no fuzzy or offset matching (B3 decision).
+ *
+ * Matching strategy:
+ * - **Default (no options, or `fuzzyMatch: false`):** exact positional context
+ *   matching only — the B3 decision. No fuzzy or offset matching.
+ * - **Opt-in (`fuzzyMatch: true`):** on exact-match failure, retries the
+ *   hermes-derived fuzzy text-matching chain (strategies 1-8) as a tolerance
+ *   layer before returning diagnostics. `fuzzyMatchContextAware: true` adds
+ *   strategy 9 (loosest). The exact `arraysEqual` path is never removed.
+ *
+ * Fuzzy is a per-hunk tolerance layer, not a whole-diff position searcher.
+ * If a fuzzy relocation overlaps a later hunk's declared context, that later
+ * hunk may still report a clean context-mismatch (not file corruption).
  *
  * @returns HunkApplyResult with success/appliedLines or the first failing hunk's diagnostics.
  */
 function applyHunks(
 	content: string,
 	fileDiff: ParsedFileDiff,
+	options?: ApplyHunksOptions,
 ): HunkApplyResult {
 	// Normalize CRLF to LF so context matching works regardless of file line endings
 	const normalizedContent = content.replace(/\r\n/g, '\n');
@@ -572,6 +614,8 @@ function applyHunks(
 
 	for (let hunkIdx = 0; hunkIdx < fileDiff.hunks.length; hunkIdx++) {
 		const hunk = fileDiff.hunks[hunkIdx];
+		// Reset per-hunk: true when fuzzy fallback ran and still missed.
+		let fuzzyAttemptedThisHunk = false;
 
 		// Compute match position: declared position adjusted by accumulated delta from prior hunks
 		const searchStart = Math.max(0, hunk.oldStart - 1 + accumulatedDelta);
@@ -609,6 +653,31 @@ function applyHunks(
 			);
 			const delta = newLinesForHunk.length - expectedOldLines.length;
 			accumulatedDelta += delta;
+		} else if (options?.fuzzyMatch) {
+			// Opt-in fuzzy fallback (issue #1718): when exact positional match
+			// fails and the config flag is set, retry via the hermes-derived
+			// fuzzy chain. We feed the in-progress content (which already
+			// reflects prior-hunk edits) so earlier hunks are preserved.
+			//
+			// `replaceAll: false` enforces uniqueness — the ambiguity guard
+			// fails rather than writing an ambiguous patch. The line-count
+			// delta uses the hunk's declared lines (fuzzy strategies preserve
+			// line counts; they transform within-line whitespace/unicode).
+			const currentContent = fileLines.join('\n');
+			const oldString = expectedOldLines.join('\n');
+			const newString = newLinesForHunk.join('\n');
+			const fuzzy = fuzzyFindAndReplace(currentContent, oldString, newString, false, {
+				includeContextAware: options.fuzzyMatchContextAware,
+			});
+			if (fuzzy.error === null && fuzzy.matchCount === 1) {
+				fileLines.length = 0;
+				fileLines.push(...fuzzy.content.split('\n'));
+				accumulatedDelta += newLinesForHunk.length - expectedOldLines.length;
+				continue; // next hunk — skip the mismatch return below
+			}
+			// Fuzzy also failed — fall through to the context-mismatch return,
+			// flagging that fuzzy was attempted so the caller can append a hint.
+			fuzzyAttemptedThisHunk = true;
 		}
 
 		if (!matchFound) {
@@ -624,6 +693,7 @@ function applyHunks(
 			return {
 				success: false,
 				failedHunkIndex: hunkIdx,
+				fuzzyAttempted: fuzzyAttemptedThisHunk ? true : undefined,
 				error: {
 					hunkIndex: hunkIdx,
 					type: 'context-mismatch',
@@ -734,6 +804,7 @@ function processFileDiff(
 	dryRun: boolean,
 	allowCreates: boolean,
 	allowDeletes: boolean,
+	hunkOptions?: ApplyHunksOptions,
 ): ApplyPatchFileResult {
 	const hunksTotal = fileDiff.hunks.length;
 
@@ -1001,16 +1072,36 @@ function processFileDiff(
 	// Detect dominant line ending to preserve CRLF on write (Problem 2)
 	const originalLineEnding = detectLineEnding(content);
 
-	// Apply hunks with exact context matching (FR-010)
-	const hunkResult = applyHunks(content, fileDiff);
+	// Apply hunks with exact context matching (FR-010); opt-in fuzzy fallback
+	// (issue #1718) retries the hermes chain when exact match fails and the
+	// config flag is set.
+	const hunkResult = applyHunks(content, fileDiff, hunkOptions);
 	if (!hunkResult.success) {
+		// When fuzzy was attempted and still missed, append a "did you mean?"
+		// hint (ported from hermes) so the model can self-correct. We call
+		// findClosestLines directly with the expected context as the anchor —
+		// NOT formatNoMatchHint, whose message-prefix gate ("Could not find")
+		// never matches apply-patch's "Context mismatch in hunk..." message
+		// (the gate exists for hermes' shared caller where multiple error
+		// types share matchCount=0; here we only call when fuzzy genuinely
+		// failed, so direct findClosestLines is correct).
+		let errors = hunkResult.error ? [hunkResult.error] : [];
+		if (hunkResult.fuzzyAttempted && errors.length > 0 && hunkOptions?.fuzzyMatch) {
+			const expectedAnchor = errors[0].expected ?? '';
+			const hint = findClosestLines(expectedAnchor, content);
+			if (hint) {
+				errors = [
+					{ ...errors[0], message: `${errors[0].message}\n\nDid you mean one of these sections?\n${hint}` },
+				];
+			}
+		}
 		return {
 			file: targetPath,
 			status: 'error',
 			hunks: hunksTotal,
 			hunksApplied: 0,
 			hunksFailed: hunksTotal,
-			errors: hunkResult.error ? [hunkResult.error] : [],
+			errors,
 		};
 	}
 
@@ -1178,6 +1269,17 @@ export const swarmApplyPatch: ToolDefinition = createSwarmTool({
 		const allowCreates = (obj.allowCreates as boolean) ?? false;
 		const allowDeletes = (obj.allowDeletes as boolean) ?? false;
 
+		// Load opt-in fuzzy-match config (issue #1718). Default off — preserves
+		// the B3 exact-match decision. Loaded once per invocation via the
+		// `_internals` DI seam so tests can substitute hermetically.
+		const { config } = _internals.loadPluginConfigWithMeta(directory);
+		const fuzzyMatch = config.apply_patch?.fuzzy_match === true;
+		const fuzzyMatchContextAware = config.apply_patch?.fuzzy_match_context_aware === true;
+		const hunkOptions: ApplyHunksOptions | undefined =
+			fuzzyMatch || fuzzyMatchContextAware
+				? { fuzzyMatch, fuzzyMatchContextAware }
+				: undefined;
+
 		// Validate workspace directory
 		if (!existsSync(directory)) {
 			return JSON.stringify(
@@ -1302,6 +1404,7 @@ export const swarmApplyPatch: ToolDefinition = createSwarmTool({
 				dryRun,
 				allowCreates,
 				allowDeletes,
+				hunkOptions,
 			);
 
 			fileResults.push(result);

--- a/src/utils/__tests__/fuzzy-match-2.test.ts
+++ b/src/utils/__tests__/fuzzy-match-2.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { fuzzyFindAndReplace, findClosestLines, formatNoMatchHint } from '../fuzzy-match';
+import {
+	findClosestLines,
+	formatNoMatchHint,
+	fuzzyFindAndReplace,
+} from '../fuzzy-match';
 
 /**
  * Fuzzy-match acceptance tests — part 2 of 2.
@@ -55,7 +59,11 @@ describe('TestEscapeDriftGuard', () => {
 	test('drift allowed on exact match', () => {
 		// Exact matches bypass the drift guard entirely.
 		const content = "hello \\'world\\'";
-		const r = fuzzyFindAndReplace(content, "hello \\'world\\'", "hello \\'there\\'");
+		const r = fuzzyFindAndReplace(
+			content,
+			"hello \\'world\\'",
+			"hello \\'there\\'",
+		);
 		expect(r.error).toBeNull();
 		expect(r.matchCount).toBe(1);
 		expect(r.strategy).toBe('exact');
@@ -174,12 +182,18 @@ describe('TestEscapeNormalizedNewString', () => {
 
 describe('TestFindClosestLines', () => {
 	test('finds similar line', () => {
-		const result = findClosestLines('def baz():', 'def foo():\n    pass\ndef bar():\n    return 1\n');
+		const result = findClosestLines(
+			'def baz():',
+			'def foo():\n    pass\ndef bar():\n    return 1\n',
+		);
 		expect(result.includes('def foo') || result.includes('def bar')).toBe(true);
 	});
 
 	test('returns empty for no match', () => {
-		const result = findClosestLines('xyzzy_no_match_possible_!!!', 'completely different content here');
+		const result = findClosestLines(
+			'xyzzy_no_match_possible_!!!',
+			'completely different content here',
+		);
 		expect(result).toBe('');
 	});
 
@@ -189,12 +203,18 @@ describe('TestFindClosestLines', () => {
 	});
 
 	test('includes context lines', () => {
-		const result = findClosestLines('def target():', 'line1\nline2\ndef target():\n    pass\nline5\n');
+		const result = findClosestLines(
+			'def target():',
+			'line1\nline2\ndef target():\n    pass\nline5\n',
+		);
 		expect(result).toContain('target');
 	});
 
 	test('includes line numbers', () => {
-		const result = findClosestLines('def foo():', 'line1\nline2\ndef foo():\n    pass\n');
+		const result = findClosestLines(
+			'def foo():',
+			'line1\nline2\ndef foo():\n    pass\n',
+		);
 		// Format "   N| content"
 		expect(result).toContain('|');
 	});

--- a/src/utils/__tests__/fuzzy-match-2.test.ts
+++ b/src/utils/__tests__/fuzzy-match-2.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, test } from 'bun:test';
+import { fuzzyFindAndReplace, findClosestLines, formatNoMatchHint } from '../fuzzy-match';
+
+/**
+ * Fuzzy-match acceptance tests — part 2 of 2.
+ *
+ * Verbatim port of these hermes test classes from
+ * `E:/ZCode/hermes/tests/tools/test_fuzzy_match.py`:
+ * - TestEscapeDriftGuard (6)
+ * - TestEscapeNormalizedNewString (7 — tab/CR unescape, \n exclusion)
+ * - TestFindClosestLines (5)
+ * - TestFormatNoMatchHint (7)
+ *
+ * Part 1 (`fuzzy-match.test.ts`) covers the exact/whitespace/indent/unicode/
+ * block-anchor/strategy-name/replace-all classes.
+ */
+
+describe('TestEscapeDriftGuard', () => {
+	test('drift blocked on apostrophe', () => {
+		// File has no apostrophe; old_string and new_string both have `\\'` —
+		// classic tool-call drift. Guard must block instead of writing `\\'`.
+		const content = 'line\n    x = 1\nline';
+		const old = "line\n  x = \\'a\\'\nline";
+		const newS = "line\n  x = \\'b\\'\nline";
+		const r = fuzzyFindAndReplace(content, old, newS);
+		expect(r.matchCount).toBe(0);
+		expect(r.error).not.toBeNull();
+		expect(r.error).toContain('Escape-drift');
+		expect(r.error!.toLowerCase()).toContain('backslash');
+		expect(r.content).toBe(content); // file untouched
+	});
+
+	test('drift blocked on double quote', () => {
+		const content = 'line\n    x = 1\nline';
+		const old = 'line\n  x = \\"a\\"\nline';
+		const newS = 'line\n  x = \\"b\\"\nline';
+		const r = fuzzyFindAndReplace(content, old, newS);
+		expect(r.matchCount).toBe(0);
+		expect(r.error).not.toBeNull();
+		expect(r.error).toContain('Escape-drift');
+	});
+
+	test('drift allowed when file genuinely has backslash escapes', () => {
+		// File already contains `\\'` inside an existing escaped string → model
+		// is legitimately preserving it. Guard must NOT fire.
+		const content = "line\n  x = \\'a\\'\nline";
+		const old = "line\n  x = \\'a\\'\nline";
+		const newS = "line\n  x = \\'b\\'\nline";
+		const r = fuzzyFindAndReplace(content, old, newS);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toContain("\\'b\\'");
+	});
+
+	test('drift allowed on exact match', () => {
+		// Exact matches bypass the drift guard entirely.
+		const content = "hello \\'world\\'";
+		const r = fuzzyFindAndReplace(content, "hello \\'world\\'", "hello \\'there\\'");
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.strategy).toBe('exact');
+	});
+
+	test('drift allowed when adding escaped strings', () => {
+		// old_string has no `\\'` → guard doesn't fire even when new adds one.
+		const content = 'line1\nline2\nline3';
+		const old = 'line1\nline2\nline3';
+		const newS = "line1\nprint(\\'added\\')\nline2\nline3";
+		const r = fuzzyFindAndReplace(content, old, newS);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toContain("\\'added\\'");
+	});
+
+	test('no drift check when new_string lacks suspect chars', () => {
+		// Fast-path: new_string has no `\\'` or `\\"` → guard never fires.
+		const content = 'def foo():\n    pass';
+		const old = 'def foo():\n  pass';
+		const newS = 'def bar():\n  return 1';
+		const r = fuzzyFindAndReplace(content, old, newS);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+	});
+});
+
+describe('TestEscapeNormalizedNewString', () => {
+	test('tab in new_string unescaped under escape_normalized', () => {
+		// File has real tab; model sends literal `\\t` in both old and new.
+		const content = 'def hello():\n\tprint("before")\n';
+		const old = 'def hello():\n\\tprint("before")\n';
+		const newS = 'def hello():\n\\tprint("after")\n';
+		const r = fuzzyFindAndReplace(content, old, newS);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.strategy).toBe('escape_normalized');
+		expect(r.content).toContain('\tprint("after")');
+		expect(r.content).not.toContain('\\t');
+	});
+
+	test('tab in new_string unescaped under exact', () => {
+		// File has real tab, old_string has real tab (matches exact), but
+		// new_string still arrives with literal `\\t`. Selective unescape
+		// fires regardless of which strategy matched.
+		const content = 'def hello():\n\tprint("before")\n';
+		const old = '\tprint("before")';
+		const newS = '\\tprint("after")';
+		const r = fuzzyFindAndReplace(content, old, newS);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.strategy).toBe('exact');
+		expect(r.content).toContain('\tprint("after")');
+		expect(r.content).not.toContain('\\t');
+	});
+
+	test('carriage return in new_string unescaped', () => {
+		const content = 'line1\r\nline2\r\n';
+		const old = 'line1\\r\\nline2\\r\\n';
+		const newS = 'replaced\\r\\n';
+		const r = fuzzyFindAndReplace(content, old, newS);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.strategy).toBe('escape_normalized');
+		expect(r.content).toContain('replaced\r');
+	});
+
+	test('newline in new_string NOT unescaped', () => {
+		// `\\n` is intentionally left alone — newlines serialize correctly
+		// through JSON; unescaping would corrupt source-code escape sequences.
+		const content = 'line1\nline2\n';
+		const old = 'line1\nline2';
+		const newS = 'alpha\\nbeta';
+		const r = fuzzyFindAndReplace(content, old, newS);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toContain('alpha\\nbeta');
+		expect(r.content).not.toContain('alpha\nbeta');
+	});
+
+	test('mixed tab and newline: only tab unescaped', () => {
+		const content = 'def foo():\n\tpass\n';
+		const old = 'def foo():\n\tpass\n';
+		const newS = 'def bar():\\n\\treturn 1\\n';
+		const r = fuzzyFindAndReplace(content, old, newS);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toContain('\treturn 1');
+		expect(r.content).not.toContain('\\t');
+		expect(r.content).toContain('\\n');
+	});
+
+	test('exact match preserves literal backslash-t in string literal', () => {
+		// Matched region has NO real tab → new_string's literal `\\t` preserved.
+		const content = 'sep = "\\t"\n';
+		const old = 'sep = "\\t"\n';
+		const newS = 'sep = "\\tab"\n';
+		const r = fuzzyFindAndReplace(content, old, newS);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.strategy).toBe('exact');
+		expect(r.content).toContain('sep = "\\tab"');
+		expect(r.content).not.toContain('\t');
+	});
+
+	test('no escape sequences: passthrough', () => {
+		const content = 'def foo():\n    return 1\n';
+		const old = 'def foo():\n    return 1\n';
+		const newS = 'def foo():\n    return 2\n';
+		const r = fuzzyFindAndReplace(content, old, newS);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toContain('return 2');
+	});
+});
+
+describe('TestFindClosestLines', () => {
+	test('finds similar line', () => {
+		const result = findClosestLines('def baz():', 'def foo():\n    pass\ndef bar():\n    return 1\n');
+		expect(result.includes('def foo') || result.includes('def bar')).toBe(true);
+	});
+
+	test('returns empty for no match', () => {
+		const result = findClosestLines('xyzzy_no_match_possible_!!!', 'completely different content here');
+		expect(result).toBe('');
+	});
+
+	test('returns empty for empty inputs', () => {
+		expect(findClosestLines('', 'some content')).toBe('');
+		expect(findClosestLines('old string', '')).toBe('');
+	});
+
+	test('includes context lines', () => {
+		const result = findClosestLines('def target():', 'line1\nline2\ndef target():\n    pass\nline5\n');
+		expect(result).toContain('target');
+	});
+
+	test('includes line numbers', () => {
+		const result = findClosestLines('def foo():', 'line1\nline2\ndef foo():\n    pass\n');
+		// Format "   N| content"
+		expect(result).toContain('|');
+	});
+});
+
+describe('TestFormatNoMatchHint', () => {
+	test('fires on could-not-find with similar content', () => {
+		const result = formatNoMatchHint(
+			'Could not find a match for old_string in the file',
+			0,
+			'def baz():',
+			'def foo():\n    pass\ndef bar():\n    pass\n',
+		);
+		expect(result).toContain('Did you mean');
+		expect(result.includes('foo') || result.includes('bar')).toBe(true);
+	});
+
+	test('silent on ambiguous-match error', () => {
+		const result = formatNoMatchHint(
+			'Found 2 matches for old_string. Provide more context to make it unique, or use replace_all=true.',
+			0,
+			'aaa',
+			'aaa bbb aaa\n',
+		);
+		expect(result).toBe('');
+	});
+
+	test('silent on escape-drift error', () => {
+		const result = formatNoMatchHint(
+			"Escape-drift detected: old_string and new_string contain the literal sequence '\\''...",
+			0,
+			"x = \\'1\\'",
+			'x = 1\n',
+		);
+		expect(result).toBe('');
+	});
+
+	test('silent on identical-strings error', () => {
+		const result = formatNoMatchHint(
+			'old_string and new_string are identical',
+			0,
+			'foo',
+			'foo bar\n',
+		);
+		expect(result).toBe('');
+	});
+
+	test('silent when match_count nonzero (defense in depth)', () => {
+		const result = formatNoMatchHint(
+			'Could not find a match for old_string in the file',
+			1,
+			'foo',
+			'foo bar\n',
+		);
+		expect(result).toBe('');
+	});
+
+	test('silent on null error', () => {
+		expect(formatNoMatchHint(null, 0, 'foo', 'bar\n')).toBe('');
+	});
+
+	test('silent when no similar content exists', () => {
+		const result = formatNoMatchHint(
+			'Could not find a match for old_string in the file',
+			0,
+			'totally_unique_xyzzy_qux',
+			'abc\nxyz\n',
+		);
+		expect(result).toBe('');
+	});
+});

--- a/src/utils/__tests__/fuzzy-match.test.ts
+++ b/src/utils/__tests__/fuzzy-match.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, test } from 'bun:test';
+import { fuzzyFindAndReplace } from '../fuzzy-match';
+
+/**
+ * Fuzzy-match acceptance tests — part 1 of 2.
+ *
+ * Verbatim port of these hermes test classes from
+ * `E:/ZCode/hermes/tests/tools/test_fuzzy_match.py`:
+ * - TestExactMatch (5)
+ * - TestWhitespaceDifference (4 — word-boundary regression)
+ * - TestIndentDifference (1)
+ * - TestIndentationPreservation (6 — `ast.parse` replaced with exact string assertion)
+ * - TestReplaceAll (3 — self-overlapping regression)
+ * - TestUnicodeNormalized (7)
+ * - TestBlockAnchorThreshold (2)
+ * - TestStrategyNameSurfaced (2)
+ *
+ * Strategy-9 gating, escape-drift, escape-normalized, closest-lines and
+ * hint tests live in `fuzzy-match-2.test.ts` (FR-006 cap split).
+ */
+
+describe('TestExactMatch', () => {
+	test('single replacement', () => {
+		const r = fuzzyFindAndReplace('hello world', 'hello', 'hi');
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toBe('hi world');
+	});
+
+	test('no match', () => {
+		const r = fuzzyFindAndReplace('hello world', 'xyz', 'abc');
+		expect(r.matchCount).toBe(0);
+		expect(r.error).not.toBeNull();
+		expect(r.content).toBe('hello world');
+	});
+
+	test('empty old_string', () => {
+		const r = fuzzyFindAndReplace('abc', '', 'x');
+		expect(r.matchCount).toBe(0);
+		expect(r.error).not.toBeNull();
+	});
+
+	test('identical strings', () => {
+		const r = fuzzyFindAndReplace('abc', 'abc', 'abc');
+		expect(r.matchCount).toBe(0);
+		expect(r.error).toContain('identical');
+	});
+
+	test('multiline exact', () => {
+		const r = fuzzyFindAndReplace('line1\nline2\nline3', 'line1\nline2', 'replaced');
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toBe('replaced\nline3');
+	});
+});
+
+describe('TestWhitespaceDifference', () => {
+	test('extra spaces match', () => {
+		const r = fuzzyFindAndReplace('def  foo(  x,  y  ):', 'def foo( x, y ):', 'def bar(x, y):');
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toContain('bar');
+	});
+
+	test('boundary space preserved after match (word boundary regression)', () => {
+		// Regression: a whitespace_normalized match ending with a non-space must
+		// NOT consume the word-boundary space that follows.
+		const r = fuzzyFindAndReplace('foo   bar baz', 'foo bar', 'XY');
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.strategy).toBe('whitespace_normalized');
+		expect(r.content).toBe('XY baz');
+	});
+
+	test('boundary space preserved in code edit', () => {
+		const r = fuzzyFindAndReplace('result = compute(a,  b) + tail', 'compute(a, b)', 'compute(a, b, c)');
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.strategy).toBe('whitespace_normalized');
+		expect(r.content).toBe('result = compute(a, b, c) + tail');
+	});
+
+	test('trailing whitespace still consumed when match ends with space', () => {
+		// Pattern has trailing space → normalized match ends with space → the
+		// expansion must consume the full whitespace run in the original.
+		const r = fuzzyFindAndReplace('a = foo   + bar', 'foo +', 'XY');
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toContain('XY');
+		expect(r.content).toContain('bar');
+	});
+});
+
+describe('TestIndentDifference', () => {
+	test('different indentation matches', () => {
+		const r = fuzzyFindAndReplace(
+			'    def foo():\n        pass',
+			'def foo():\n    pass',
+			'def bar():\n    return 1',
+		);
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toContain('bar');
+	});
+});
+
+describe('TestIndentationPreservation', () => {
+	test('unindented input reindented to match file', () => {
+		const content =
+			'class Calculator:\n' +
+			'    def add(self, a, b):\n' +
+			'        result = a + b\n' +
+			'        return result\n';
+		// LLM sends zero-indent old/new.
+		const old = 'result = a + b\nreturn result';
+		const replacement = 'result = a + b\nresult *= 2\nreturn result';
+		const r = fuzzyFindAndReplace(content, old, replacement);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.strategy).not.toBe('exact');
+		// Every replaced line must be at 8-space indent (exact structural check
+		// replaces the Python `ast.parse(out)` validity assertion).
+		const expected =
+			'class Calculator:\n' +
+			'    def add(self, a, b):\n' +
+			'        result = a + b\n' +
+			'        result *= 2\n' +
+			'        return result\n';
+		expect(r.content).toBe(expected);
+	});
+
+	test('dedent at start anchors to file base', () => {
+		const content = '  return 1\n  return 2\n';
+		const old = 'return 1\nreturn 2';
+		const replacement = 'class X:\n  return 99\n  return 100';
+		const r = fuzzyFindAndReplace(content, old, replacement);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.strategy).not.toBe('exact');
+		const lines = r.content.split('\n');
+		expect(lines[0]).toBe('  class X:');
+		expect(lines[1]).toBe('    return 99');
+		expect(lines[2]).toBe('    return 100');
+	});
+
+	test('exact match: no reindent (passthrough)', () => {
+		const content = '    def foo():\n        return 1\n';
+		const old = '    def foo():\n        return 1';
+		const replacement = '    def foo():\n        return 2';
+		const r = fuzzyFindAndReplace(content, old, replacement);
+		expect(r.error).toBeNull();
+		expect(r.strategy).toBe('exact');
+		expect(r.content).toBe('    def foo():\n        return 2\n');
+	});
+
+	test('LLM zero-indent shifts to file two-space', () => {
+		const content = '  def x():\n    return 1\n';
+		const old = 'def x():\n  return 1';
+		const replacement = 'def x():\n  return 99';
+		const r = fuzzyFindAndReplace(content, old, replacement);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		const lines = r.content.replace(/\n$/, '').split('\n');
+		expect(lines[0]).toBe('  def x():');
+		expect(lines[1]).toBe('    return 99');
+	});
+
+	test('indent already matches → passthrough', () => {
+		const content = '  def  x(  ):\n    return 1\n';
+		const old = '  def x():\n    return 1';
+		const replacement = '  def x():\n    return 42';
+		const r = fuzzyFindAndReplace(content, old, replacement);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		expect(r.strategy).not.toBe('exact');
+		expect(r.content).toContain('    return 42');
+	});
+
+	test('blank lines left alone', () => {
+		const content = '    a = 1\n    b = 2\n';
+		const old = 'a = 1\nb = 2';
+		const replacement = 'a = 1\n\nb = 99';
+		const r = fuzzyFindAndReplace(content, old, replacement);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(1);
+		const lines = r.content.split('\n');
+		expect(lines[0]).toBe('    a = 1');
+		expect(lines[1]).toBe('');
+		expect(lines[2]).toBe('    b = 99');
+	});
+});
+
+describe('TestReplaceAll', () => {
+	test('multiple matches without flag errors', () => {
+		const r = fuzzyFindAndReplace('aaa bbb aaa', 'aaa', 'ccc', false);
+		expect(r.matchCount).toBe(0);
+		expect(r.error).toContain('Found 2 matches');
+	});
+
+	test('multiple matches with flag', () => {
+		const r = fuzzyFindAndReplace('aaa bbb aaa', 'aaa', 'ccc', true);
+		expect(r.error).toBeNull();
+		expect(r.matchCount).toBe(2);
+		expect(r.content).toBe('ccc bbb ccc');
+	});
+
+	test('self-overlapping pattern produces non-overlapping matches', () => {
+		// Regression: advancing the scan cursor by 1 instead of pattern.length
+		// produced overlapping matches that corrupted the file under replace_all.
+		const a = fuzzyFindAndReplace('aaaa', 'aa', 'b', true);
+		expect(a.error).toBeNull();
+		expect(a.matchCount).toBe(2);
+		expect(a.content).toBe('bb');
+
+		const b = fuzzyFindAndReplace('aaa', 'a', 'b', true);
+		expect(b.matchCount).toBe(3);
+		expect(b.content).toBe('bbb');
+
+		const c = fuzzyFindAndReplace('prefix aaaa suffix', 'aa', 'b', true);
+		expect(c.error).toBeNull();
+		expect(c.matchCount).toBe(2);
+		expect(c.content).toBe('prefix bb suffix');
+
+		// Without the flag, the non-overlapping count is reported (2, not 3).
+		const d = fuzzyFindAndReplace('aaaa', 'aa', 'b', false);
+		expect(d.matchCount).toBe(0);
+		expect(d.error).toContain('2 matches');
+	});
+});
+
+describe('TestUnicodeNormalized', () => {
+	test('em-dash in content matches ASCII "--" in pattern', () => {
+		const r = fuzzyFindAndReplace('return value\u2014fallback', 'return value--fallback', 'return value or fallback');
+		expect(r.matchCount).toBe(1);
+		expect(r.strategy).toBe('unicode_normalized');
+		expect(r.content).toContain('return value or fallback');
+	});
+
+	test('smart quotes in content match straight quotes in pattern', () => {
+		const r = fuzzyFindAndReplace('print(\u201chello\u201d)', 'print("hello")', 'print("world")');
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toContain('world');
+	});
+
+	test('no unicode → strategy skipped (exact wins)', () => {
+		const r = fuzzyFindAndReplace('hello world', 'hello', 'hi');
+		expect(r.matchCount).toBe(1);
+		expect(r.strategy).toBe('exact');
+	});
+
+	test('unicode preserved in output (em-dash)', () => {
+		const r = fuzzyFindAndReplace('Hello\u2014world', 'Hello--world', 'Hello--there');
+		expect(r.matchCount).toBe(1);
+		expect(r.strategy).toBe('unicode_normalized');
+		expect(r.content).toBe('Hello\u2014there');
+	});
+
+	test('smart quotes preserved', () => {
+		const r = fuzzyFindAndReplace('He said \u201chello\u201d to her', 'He said "hello" to her', 'He said "goodbye" to her');
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toBe('He said \u201cgoodbye\u201d to her');
+	});
+
+	test('ellipsis preserved', () => {
+		const r = fuzzyFindAndReplace('Wait for it\u2026and done', 'Wait for it...and done', 'Wait for it...then done');
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toBe('Wait for it\u2026then done');
+	});
+
+	test('mixed unicode multiline all preserved', () => {
+		const content = 'Line 1 \u2014 with dash\nLine 2 \u201cquoted\u201d text\nLine 3 plain';
+		const old = 'Line 1 -- with dash\nLine 2 "quoted" text\nLine 3 plain';
+		const replacement = 'Line 1 -- with dash\nLine 2 "quoted" text\nLine 3 changed';
+		const r = fuzzyFindAndReplace(content, old, replacement);
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toBe('Line 1 \u2014 with dash\nLine 2 \u201cquoted\u201d text\nLine 3 changed');
+	});
+});
+
+describe('TestBlockAnchorThreshold', () => {
+	test('high-similarity middle matches', () => {
+		const content = 'def foo():\n    x = 1\n    y = 2\n    return x + y\n';
+		const pattern = 'def foo():\n    x = 1\n    y = 9\n    return x + y';
+		const r = fuzzyFindAndReplace(content, pattern, 'def foo():\n    return 0\n');
+		expect(r.matchCount).toBe(1);
+	});
+
+	test('completely different middle does NOT match under 0.50 threshold', () => {
+		const content =
+			'class Foo:\n' +
+			"    completely = 'unrelated'\n" +
+			"    content = 'here'\n" +
+			"    nothing = 'in common'\n" +
+			'    pass\n';
+		const pattern =
+			'class Foo:\n    x = 1\n    y = 2\n    z = 3\n    pass';
+		const r = fuzzyFindAndReplace(content, pattern, 'replaced');
+		// Near-zero-similarity middle (0.4423 < 0.50) must not match.
+		expect(r.matchCount).toBe(0);
+	});
+});
+
+describe('TestStrategyNameSurfaced', () => {
+	test('exact strategy name', () => {
+		const r = fuzzyFindAndReplace('hello', 'hello', 'world');
+		expect(r.strategy).toBe('exact');
+		expect(r.matchCount).toBe(1);
+	});
+
+	test('failed match returns null strategy', () => {
+		const r = fuzzyFindAndReplace('hello', 'xyz', 'world');
+		expect(r.matchCount).toBe(0);
+		expect(r.strategy).toBeNull();
+	});
+});

--- a/src/utils/__tests__/fuzzy-match.test.ts
+++ b/src/utils/__tests__/fuzzy-match.test.ts
@@ -11,7 +11,7 @@ import { fuzzyFindAndReplace } from '../fuzzy-match';
  * - TestIndentDifference (1)
  * - TestIndentationPreservation (6 — `ast.parse` replaced with exact string assertion)
  * - TestReplaceAll (3 — self-overlapping regression)
- * - TestUnicodeNormalized (7)
+ * - TestUnicodeNormalized (8)
  * - TestBlockAnchorThreshold (2)
  * - TestStrategyNameSurfaced (2)
  *
@@ -47,7 +47,11 @@ describe('TestExactMatch', () => {
 	});
 
 	test('multiline exact', () => {
-		const r = fuzzyFindAndReplace('line1\nline2\nline3', 'line1\nline2', 'replaced');
+		const r = fuzzyFindAndReplace(
+			'line1\nline2\nline3',
+			'line1\nline2',
+			'replaced',
+		);
 		expect(r.error).toBeNull();
 		expect(r.matchCount).toBe(1);
 		expect(r.content).toBe('replaced\nline3');
@@ -56,7 +60,11 @@ describe('TestExactMatch', () => {
 
 describe('TestWhitespaceDifference', () => {
 	test('extra spaces match', () => {
-		const r = fuzzyFindAndReplace('def  foo(  x,  y  ):', 'def foo( x, y ):', 'def bar(x, y):');
+		const r = fuzzyFindAndReplace(
+			'def  foo(  x,  y  ):',
+			'def foo( x, y ):',
+			'def bar(x, y):',
+		);
 		expect(r.matchCount).toBe(1);
 		expect(r.content).toContain('bar');
 	});
@@ -72,7 +80,11 @@ describe('TestWhitespaceDifference', () => {
 	});
 
 	test('boundary space preserved in code edit', () => {
-		const r = fuzzyFindAndReplace('result = compute(a,  b) + tail', 'compute(a, b)', 'compute(a, b, c)');
+		const r = fuzzyFindAndReplace(
+			'result = compute(a,  b) + tail',
+			'compute(a, b)',
+			'compute(a, b, c)',
+		);
 		expect(r.error).toBeNull();
 		expect(r.matchCount).toBe(1);
 		expect(r.strategy).toBe('whitespace_normalized');
@@ -228,14 +240,22 @@ describe('TestReplaceAll', () => {
 
 describe('TestUnicodeNormalized', () => {
 	test('em-dash in content matches ASCII "--" in pattern', () => {
-		const r = fuzzyFindAndReplace('return value\u2014fallback', 'return value--fallback', 'return value or fallback');
+		const r = fuzzyFindAndReplace(
+			'return value\u2014fallback',
+			'return value--fallback',
+			'return value or fallback',
+		);
 		expect(r.matchCount).toBe(1);
 		expect(r.strategy).toBe('unicode_normalized');
 		expect(r.content).toContain('return value or fallback');
 	});
 
 	test('smart quotes in content match straight quotes in pattern', () => {
-		const r = fuzzyFindAndReplace('print(\u201chello\u201d)', 'print("hello")', 'print("world")');
+		const r = fuzzyFindAndReplace(
+			'print(\u201chello\u201d)',
+			'print("hello")',
+			'print("world")',
+		);
 		expect(r.matchCount).toBe(1);
 		expect(r.content).toContain('world');
 	});
@@ -247,31 +267,61 @@ describe('TestUnicodeNormalized', () => {
 	});
 
 	test('unicode preserved in output (em-dash)', () => {
-		const r = fuzzyFindAndReplace('Hello\u2014world', 'Hello--world', 'Hello--there');
+		const r = fuzzyFindAndReplace(
+			'Hello\u2014world',
+			'Hello--world',
+			'Hello--there',
+		);
 		expect(r.matchCount).toBe(1);
 		expect(r.strategy).toBe('unicode_normalized');
 		expect(r.content).toBe('Hello\u2014there');
 	});
 
 	test('smart quotes preserved', () => {
-		const r = fuzzyFindAndReplace('He said \u201chello\u201d to her', 'He said "hello" to her', 'He said "goodbye" to her');
+		const r = fuzzyFindAndReplace(
+			'He said \u201chello\u201d to her',
+			'He said "hello" to her',
+			'He said "goodbye" to her',
+		);
 		expect(r.matchCount).toBe(1);
 		expect(r.content).toBe('He said \u201cgoodbye\u201d to her');
 	});
 
 	test('ellipsis preserved', () => {
-		const r = fuzzyFindAndReplace('Wait for it\u2026and done', 'Wait for it...and done', 'Wait for it...then done');
+		const r = fuzzyFindAndReplace(
+			'Wait for it\u2026and done',
+			'Wait for it...and done',
+			'Wait for it...then done',
+		);
 		expect(r.matchCount).toBe(1);
 		expect(r.content).toBe('Wait for it\u2026then done');
 	});
 
 	test('mixed unicode multiline all preserved', () => {
-		const content = 'Line 1 \u2014 with dash\nLine 2 \u201cquoted\u201d text\nLine 3 plain';
+		const content =
+			'Line 1 \u2014 with dash\nLine 2 \u201cquoted\u201d text\nLine 3 plain';
 		const old = 'Line 1 -- with dash\nLine 2 "quoted" text\nLine 3 plain';
-		const replacement = 'Line 1 -- with dash\nLine 2 "quoted" text\nLine 3 changed';
+		const replacement =
+			'Line 1 -- with dash\nLine 2 "quoted" text\nLine 3 changed';
 		const r = fuzzyFindAndReplace(content, old, replacement);
 		expect(r.matchCount).toBe(1);
-		expect(r.content).toBe('Line 1 \u2014 with dash\nLine 2 \u201cquoted\u201d text\nLine 3 changed');
+		expect(r.content).toBe(
+			'Line 1 \u2014 with dash\nLine 2 \u201cquoted\u201d text\nLine 3 changed',
+		);
+	});
+
+	test('no unicode: replacement is direct (no-op guard)', () => {
+		// Ported from hermes test_no_unicode_no_change (test_fuzzy_match.py:313).
+		// When the file has no Unicode, replacement is direct — the unicode
+		// preservation pass is a no-op (its normalized-forms-equal guard
+		// returns newString unchanged).
+		const r = fuzzyFindAndReplace(
+			'plain text here',
+			'plain text here',
+			'plain text there',
+		);
+		expect(r.matchCount).toBe(1);
+		expect(r.content).toBe('plain text there');
 	});
 });
 
@@ -279,7 +329,11 @@ describe('TestBlockAnchorThreshold', () => {
 	test('high-similarity middle matches', () => {
 		const content = 'def foo():\n    x = 1\n    y = 2\n    return x + y\n';
 		const pattern = 'def foo():\n    x = 1\n    y = 9\n    return x + y';
-		const r = fuzzyFindAndReplace(content, pattern, 'def foo():\n    return 0\n');
+		const r = fuzzyFindAndReplace(
+			content,
+			pattern,
+			'def foo():\n    return 0\n',
+		);
 		expect(r.matchCount).toBe(1);
 	});
 
@@ -290,8 +344,7 @@ describe('TestBlockAnchorThreshold', () => {
 			"    content = 'here'\n" +
 			"    nothing = 'in common'\n" +
 			'    pass\n';
-		const pattern =
-			'class Foo:\n    x = 1\n    y = 2\n    z = 3\n    pass';
+		const pattern = 'class Foo:\n    x = 1\n    y = 2\n    z = 3\n    pass';
 		const r = fuzzyFindAndReplace(content, pattern, 'replaced');
 		// Near-zero-similarity middle (0.4423 < 0.50) must not match.
 		expect(r.matchCount).toBe(0);

--- a/src/utils/__tests__/sequence-matcher.test.ts
+++ b/src/utils/__tests__/sequence-matcher.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'bun:test';
+import { SequenceMatcher } from '../sequence-matcher';
+
+/** Assert two floats are equal within a small epsilon (diffeq-style). */
+function expectRatio(actual: number, expected: number): void {
+	expect(Math.abs(actual - expected)).toBeLessThan(1e-9);
+}
+
+/**
+ * Faithful-port acceptance tests for the TypeScript SequenceMatcher.
+ *
+ * Every ratio/opcodes/matching-blocks value below was computed against
+ * CPython 3.x `difflib.SequenceMatcher` so the fuzzy-match thresholds
+ * (0.50 / 0.70 / 0.80) behave identically to the Python original.
+ */
+describe('SequenceMatcher.ratio', () => {
+	test("'abcd' vs 'bcde' is 0.75", () => {
+		expectRatio(new SequenceMatcher(null, 'abcd', 'bcde').ratio(), 0.75);
+	});
+
+	test("identical strings ratio 1.0", () => {
+		expectRatio(new SequenceMatcher(null, 'hello', 'hello').ratio(), 1.0);
+	});
+
+	test("both empty ratio 1.0", () => {
+		expectRatio(new SequenceMatcher(null, '', '').ratio(), 1.0);
+	});
+
+	test("single identical char ratio 1.0", () => {
+		expectRatio(new SequenceMatcher(null, 'a', 'a').ratio(), 1.0);
+	});
+
+	test("disjoint single chars ratio 0.0", () => {
+		expectRatio(new SequenceMatcher(null, 'a', 'b').ratio(), 0.0);
+	});
+
+	test("disjoint strings ratio 0.0", () => {
+		expectRatio(new SequenceMatcher(null, 'abc', 'xyz').ratio(), 0.0);
+	});
+
+	test("'qabxcd' vs 'abycdf' ratio 2/3", () => {
+		// CPython: SequenceMatcher(None, 'qabxcd', 'abycdf').ratio() = 0.6666...
+		expectRatio(new SequenceMatcher(null, 'qabxcd', 'abycdf').ratio(), 0.6666666666666666);
+	});
+
+	test("block_anchor high-sim middle ratio 0.9474", () => {
+		// Used by strategy 8 threshold (>=0.50 for unique). Real CPython value.
+		const r = new SequenceMatcher(null, '    x = 1\n    y = 2', '    x = 1\n    y = 9').ratio();
+		expectRatio(r, 0.9473684210526315);
+	});
+
+	test("block_anchor low-sim middle ratio 0.4423", () => {
+		// Below 0.50 → block_anchor must NOT match. Real CPython value.
+		const cm = "    completely = 'unrelated'\n    content = 'here'\n    nothing = 'in common'";
+		const pm = '    x = 1\n    y = 2\n    z = 3';
+		expectRatio(new SequenceMatcher(null, cm, pm).ratio(), 0.4423076923076923);
+	});
+});
+
+describe('SequenceMatcher.getMatchingBlocks', () => {
+	test("returns matching blocks plus zero-size sentinel", () => {
+		const mb = new SequenceMatcher(null, 'qabxcd', 'abycdf').getMatchingBlocks();
+		expect(mb).toEqual([
+			{ a: 1, b: 0, size: 2 },
+			{ a: 4, b: 3, size: 2 },
+			{ a: 6, b: 6, size: 0 },
+		]);
+	});
+
+	test("identical strings produce a single full match + sentinel", () => {
+		const mb = new SequenceMatcher(null, 'abc', 'abc').getMatchingBlocks();
+		expect(mb).toEqual([
+			{ a: 0, b: 0, size: 3 },
+			{ a: 3, b: 3, size: 0 },
+		]);
+	});
+
+	test("disjoint strings produce only the sentinel", () => {
+		const mb = new SequenceMatcher(null, 'abc', 'xyz').getMatchingBlocks();
+		expect(mb).toEqual([{ a: 3, b: 3, size: 0 }]);
+	});
+});
+
+describe('SequenceMatcher.getOpcodes', () => {
+	test("'qabxcd' → 'abycdf' opcodes match CPython doc example", () => {
+		const ops = new SequenceMatcher(null, 'qabxcd', 'abycdf').getOpcodes();
+		expect(ops).toEqual([
+			{ tag: 'delete', i1: 0, i2: 1, j1: 0, j2: 0 },
+			{ tag: 'equal', i1: 1, i2: 3, j1: 0, j2: 2 },
+			{ tag: 'replace', i1: 3, i2: 4, j1: 2, j2: 3 },
+			{ tag: 'equal', i1: 4, i2: 6, j1: 3, j2: 5 },
+			{ tag: 'insert', i1: 6, i2: 6, j1: 5, j2: 6 },
+		]);
+	});
+
+	test("identical strings produce a single equal opcode", () => {
+		const ops = new SequenceMatcher(null, 'abc', 'abc').getOpcodes();
+		expect(ops).toEqual([{ tag: 'equal', i1: 0, i2: 3, j1: 0, j2: 3 }]);
+	});
+
+	test("pure insertion produces an insert opcode", () => {
+		const ops = new SequenceMatcher(null, 'ab', 'axb').getOpcodes();
+		expect(ops).toEqual([
+			{ tag: 'equal', i1: 0, i2: 1, j1: 0, j2: 1 },
+			{ tag: 'insert', i1: 1, i2: 1, j1: 1, j2: 2 },
+			{ tag: 'equal', i1: 1, i2: 2, j1: 2, j2: 3 },
+		]);
+	});
+});
+
+describe('SequenceMatcher autojunk (popular-element guard)', () => {
+	test("autojunk=True excludes popular elements from anchoring", () => {
+		// b has 300 chars: 'x' ~16.7%, 'y' ~83.3% — both >1% are popular.
+		// CPython with autojunk=True: ratio 0.006622516556291391.
+		const b = 'x'.repeat(50) + 'y'.repeat(250);
+		expectRatio(new SequenceMatcher(null, 'xy', b, true).ratio(), 0.006622516556291391);
+	});
+
+	test("autojunk=False allows popular elements to anchor", () => {
+		// Same input, autojunk off → longer matching blocks → higher ratio.
+		// CPython with autojunk=False: 0.013245033112582781.
+		const b = 'x'.repeat(50) + 'y'.repeat(250);
+		expectRatio(new SequenceMatcher(null, 'xy', b, false).ratio(), 0.013245033112582781);
+	});
+
+	test("autojunk does not fire on short sequences (< 200 chars)", () => {
+		// b is short — popular guard is inert, autojunk on/off give the same ratio.
+		const b = 'a'.repeat(50) + 'b'.repeat(50); // 100 chars
+		const on = new SequenceMatcher(null, 'ab', b, true).ratio();
+		const off = new SequenceMatcher(null, 'ab', b, false).ratio();
+		expectRatio(on, off);
+	});
+});
+
+describe('SequenceMatcher edge cases', () => {
+	test("empty `a` against non-empty `b` ratio 0.0", () => {
+		expectRatio(new SequenceMatcher(null, '', 'abc').ratio(), 0.0);
+	});
+
+	test("non-empty `a` against empty `b` ratio 0.0", () => {
+		expectRatio(new SequenceMatcher(null, 'abc', '').ratio(), 0.0);
+	});
+
+	test("astral-plane (emoji) input does not crash or corrupt", () => {
+		// Round-trip safety: UTF-16 code-unit indexing must be internally
+		// consistent. An emoji consumes 2 units; the matcher must not throw
+		// or produce NaN.
+		const a = '😀 hello';
+		const b = '😀 world';
+		const r = new SequenceMatcher(null, a, b).ratio();
+		expect(Number.isFinite(r)).toBe(true);
+		expect(r).toBeGreaterThan(0.0);
+		expect(r).toBeLessThanOrEqual(1.0);
+		const ops = new SequenceMatcher(null, a, b).getOpcodes();
+		// Must cover the full sequences.
+		const last = ops[ops.length - 1];
+		expect(last.i2).toBe(a.length);
+		expect(last.j2).toBe(b.length);
+	});
+
+	test("setSeqs resets cached matching blocks", () => {
+		const sm = new SequenceMatcher(null, 'abc', 'xyz');
+		const r1 = sm.ratio();
+		expect(r1).toBe(0.0);
+		sm.setSeqs('abc', 'abc');
+		expect(sm.ratio()).toBe(1.0);
+	});
+});

--- a/src/utils/__tests__/sequence-matcher.test.ts
+++ b/src/utils/__tests__/sequence-matcher.test.ts
@@ -18,48 +18,60 @@ describe('SequenceMatcher.ratio', () => {
 		expectRatio(new SequenceMatcher(null, 'abcd', 'bcde').ratio(), 0.75);
 	});
 
-	test("identical strings ratio 1.0", () => {
+	test('identical strings ratio 1.0', () => {
 		expectRatio(new SequenceMatcher(null, 'hello', 'hello').ratio(), 1.0);
 	});
 
-	test("both empty ratio 1.0", () => {
+	test('both empty ratio 1.0', () => {
 		expectRatio(new SequenceMatcher(null, '', '').ratio(), 1.0);
 	});
 
-	test("single identical char ratio 1.0", () => {
+	test('single identical char ratio 1.0', () => {
 		expectRatio(new SequenceMatcher(null, 'a', 'a').ratio(), 1.0);
 	});
 
-	test("disjoint single chars ratio 0.0", () => {
+	test('disjoint single chars ratio 0.0', () => {
 		expectRatio(new SequenceMatcher(null, 'a', 'b').ratio(), 0.0);
 	});
 
-	test("disjoint strings ratio 0.0", () => {
+	test('disjoint strings ratio 0.0', () => {
 		expectRatio(new SequenceMatcher(null, 'abc', 'xyz').ratio(), 0.0);
 	});
 
 	test("'qabxcd' vs 'abycdf' ratio 2/3", () => {
 		// CPython: SequenceMatcher(None, 'qabxcd', 'abycdf').ratio() = 0.6666...
-		expectRatio(new SequenceMatcher(null, 'qabxcd', 'abycdf').ratio(), 0.6666666666666666);
+		expectRatio(
+			new SequenceMatcher(null, 'qabxcd', 'abycdf').ratio(),
+			0.6666666666666666,
+		);
 	});
 
-	test("block_anchor high-sim middle ratio 0.9474", () => {
+	test('block_anchor high-sim middle ratio 0.9474', () => {
 		// Used by strategy 8 threshold (>=0.50 for unique). Real CPython value.
-		const r = new SequenceMatcher(null, '    x = 1\n    y = 2', '    x = 1\n    y = 9').ratio();
+		const r = new SequenceMatcher(
+			null,
+			'    x = 1\n    y = 2',
+			'    x = 1\n    y = 9',
+		).ratio();
 		expectRatio(r, 0.9473684210526315);
 	});
 
-	test("block_anchor low-sim middle ratio 0.4423", () => {
+	test('block_anchor low-sim middle ratio 0.4423', () => {
 		// Below 0.50 → block_anchor must NOT match. Real CPython value.
-		const cm = "    completely = 'unrelated'\n    content = 'here'\n    nothing = 'in common'";
+		const cm =
+			"    completely = 'unrelated'\n    content = 'here'\n    nothing = 'in common'";
 		const pm = '    x = 1\n    y = 2\n    z = 3';
 		expectRatio(new SequenceMatcher(null, cm, pm).ratio(), 0.4423076923076923);
 	});
 });
 
 describe('SequenceMatcher.getMatchingBlocks', () => {
-	test("returns matching blocks plus zero-size sentinel", () => {
-		const mb = new SequenceMatcher(null, 'qabxcd', 'abycdf').getMatchingBlocks();
+	test('returns matching blocks plus zero-size sentinel', () => {
+		const mb = new SequenceMatcher(
+			null,
+			'qabxcd',
+			'abycdf',
+		).getMatchingBlocks();
 		expect(mb).toEqual([
 			{ a: 1, b: 0, size: 2 },
 			{ a: 4, b: 3, size: 2 },
@@ -67,7 +79,7 @@ describe('SequenceMatcher.getMatchingBlocks', () => {
 		]);
 	});
 
-	test("identical strings produce a single full match + sentinel", () => {
+	test('identical strings produce a single full match + sentinel', () => {
 		const mb = new SequenceMatcher(null, 'abc', 'abc').getMatchingBlocks();
 		expect(mb).toEqual([
 			{ a: 0, b: 0, size: 3 },
@@ -75,7 +87,7 @@ describe('SequenceMatcher.getMatchingBlocks', () => {
 		]);
 	});
 
-	test("disjoint strings produce only the sentinel", () => {
+	test('disjoint strings produce only the sentinel', () => {
 		const mb = new SequenceMatcher(null, 'abc', 'xyz').getMatchingBlocks();
 		expect(mb).toEqual([{ a: 3, b: 3, size: 0 }]);
 	});
@@ -93,12 +105,12 @@ describe('SequenceMatcher.getOpcodes', () => {
 		]);
 	});
 
-	test("identical strings produce a single equal opcode", () => {
+	test('identical strings produce a single equal opcode', () => {
 		const ops = new SequenceMatcher(null, 'abc', 'abc').getOpcodes();
 		expect(ops).toEqual([{ tag: 'equal', i1: 0, i2: 3, j1: 0, j2: 3 }]);
 	});
 
-	test("pure insertion produces an insert opcode", () => {
+	test('pure insertion produces an insert opcode', () => {
 		const ops = new SequenceMatcher(null, 'ab', 'axb').getOpcodes();
 		expect(ops).toEqual([
 			{ tag: 'equal', i1: 0, i2: 1, j1: 0, j2: 1 },
@@ -109,21 +121,27 @@ describe('SequenceMatcher.getOpcodes', () => {
 });
 
 describe('SequenceMatcher autojunk (popular-element guard)', () => {
-	test("autojunk=True excludes popular elements from anchoring", () => {
+	test('autojunk=True excludes popular elements from anchoring', () => {
 		// b has 300 chars: 'x' ~16.7%, 'y' ~83.3% — both >1% are popular.
 		// CPython with autojunk=True: ratio 0.006622516556291391.
 		const b = 'x'.repeat(50) + 'y'.repeat(250);
-		expectRatio(new SequenceMatcher(null, 'xy', b, true).ratio(), 0.006622516556291391);
+		expectRatio(
+			new SequenceMatcher(null, 'xy', b, true).ratio(),
+			0.006622516556291391,
+		);
 	});
 
-	test("autojunk=False allows popular elements to anchor", () => {
+	test('autojunk=False allows popular elements to anchor', () => {
 		// Same input, autojunk off → longer matching blocks → higher ratio.
 		// CPython with autojunk=False: 0.013245033112582781.
 		const b = 'x'.repeat(50) + 'y'.repeat(250);
-		expectRatio(new SequenceMatcher(null, 'xy', b, false).ratio(), 0.013245033112582781);
+		expectRatio(
+			new SequenceMatcher(null, 'xy', b, false).ratio(),
+			0.013245033112582781,
+		);
 	});
 
-	test("autojunk does not fire on short sequences (< 200 chars)", () => {
+	test('autojunk does not fire on short sequences (< 200 chars)', () => {
 		// b is short — popular guard is inert, autojunk on/off give the same ratio.
 		const b = 'a'.repeat(50) + 'b'.repeat(50); // 100 chars
 		const on = new SequenceMatcher(null, 'ab', b, true).ratio();
@@ -133,15 +151,15 @@ describe('SequenceMatcher autojunk (popular-element guard)', () => {
 });
 
 describe('SequenceMatcher edge cases', () => {
-	test("empty `a` against non-empty `b` ratio 0.0", () => {
+	test('empty `a` against non-empty `b` ratio 0.0', () => {
 		expectRatio(new SequenceMatcher(null, '', 'abc').ratio(), 0.0);
 	});
 
-	test("non-empty `a` against empty `b` ratio 0.0", () => {
+	test('non-empty `a` against empty `b` ratio 0.0', () => {
 		expectRatio(new SequenceMatcher(null, 'abc', '').ratio(), 0.0);
 	});
 
-	test("astral-plane (emoji) input does not crash or corrupt", () => {
+	test('astral-plane (emoji) input does not crash or corrupt', () => {
 		// Round-trip safety: UTF-16 code-unit indexing must be internally
 		// consistent. An emoji consumes 2 units; the matcher must not throw
 		// or produce NaN.
@@ -158,7 +176,7 @@ describe('SequenceMatcher edge cases', () => {
 		expect(last.j2).toBe(b.length);
 	});
 
-	test("setSeqs resets cached matching blocks", () => {
+	test('setSeqs resets cached matching blocks', () => {
 		const sm = new SequenceMatcher(null, 'abc', 'xyz');
 		const r1 = sm.ratio();
 		expect(r1).toBe(0.0);

--- a/src/utils/fuzzy-match.ts
+++ b/src/utils/fuzzy-match.ts
@@ -1,0 +1,820 @@
+/**
+ * Fuzzy text-matching engine — faithful TypeScript port of hermes-agent's
+ * `tools/fuzzy_match.py` (issue #1718).
+ *
+ * Implements a 9-strategy matching chain that finds and replaces text,
+ * tolerating the whitespace, indentation, escape-sequence, and Unicode
+ * drift common in LLM-generated patches. Integrated into `apply-patch`
+ * as an **opt-in fallback** (default off) gated by the `apply_patch.fuzzy_match`
+ * and `apply_patch.fuzzy_match_context_aware` config flags.
+ *
+ * Porting conventions:
+ * - Operates on **UTF-16 code units** consistently (`s[i]`, `s.length`).
+ *   Matches `src/utils/sequence-matcher.ts`. Round-trip safe.
+ * - Per-line stripping uses JS `String.prototype.trim()`, which strips the
+ *   Unicode WhiteSpace + LineTerminator set. Coincides with Python
+ *   `str.strip()` for the ASCII/BMP content in the test suite; minor
+ *   divergence on exotic whitespace categories is acceptable.
+ * - Strategy 9 (`contextAware`) is opt-in via the `includeContextAware`
+ *   option to `fuzzyFindAndReplace`. It is the loosest, most-false-positive-
+ *   prone strategy and is separately gated in apply-patch by
+ *   `apply_patch.fuzzy_match_context_aware`.
+ */
+
+import { SequenceMatcher } from './sequence-matcher';
+
+/** A `[start, end)` character span in the content string. */
+type Span = [number, number];
+
+/** Result of {@link fuzzyFindAndReplace}. */
+export interface FuzzyResult {
+	/** Modified content on success; original content on failure. */
+	content: string;
+	/** Number of replacements made (0 on failure). */
+	matchCount: number;
+	/** Name of the strategy that matched, or `null` on failure. */
+	strategy: string | null;
+	/** `null` on success; an error description on failure. */
+	error: string | null;
+}
+
+/** Options for {@link fuzzyFindAndReplace}. */
+export interface FuzzyOptions {
+	/**
+	 * When true (default), the `context_aware` strategy (9) is included in the
+	 * chain. Strategy 9 is the loosest/most-false-positive-prone strategy
+	 * (50% line similarity), so the `apply-patch` integration passes `false`
+	 * unless the separate `apply_patch.fuzzy_match_context_aware` flag is set.
+	 *
+	 * The utility itself defaults it to `true` so the byte-faithful ported
+	 * hermes test suite passes unmodified — strategy 9 is a legitimate part
+	 * of the matching chain and several test cases depend on it.
+	 */
+	includeContextAware?: boolean;
+}
+
+// =============================================================================
+// Unicode normalization (strategy 7)
+// =============================================================================
+
+/**
+ * Maps Unicode typographic characters to their ASCII equivalents.
+ * Some replacements EXPAND a single code point into multiple ASCII chars
+ * (em-dash → "--", ellipsis → "..."); the position-remap helpers handle the
+ * resulting offset divergence.
+ */
+export const UNICODE_MAP: Record<string, string> = {
+	'\u201c': '"', // left double quotation mark
+	'\u201d': '"', // right double quotation mark
+	'\u2018': "'", // left single quotation mark
+	'\u2019': "'", // right single quotation mark
+	'\u2014': '--', // em dash
+	'\u2013': '-', // en dash
+	'\u2026': '...', // horizontal ellipsis
+	'\u00a0': ' ', // no-break space
+};
+
+/** Normalize Unicode typographic characters to ASCII equivalents. */
+export function unicodeNormalize(text: string): string {
+	let out = text;
+	for (const [char, repl] of Object.entries(UNICODE_MAP)) {
+		out = out.split(char).join(repl);
+	}
+	return out;
+}
+
+// =============================================================================
+// Whitespace / indent helpers
+// =============================================================================
+
+/** Return the leading spaces/tabs prefix of a line. */
+function leadingWhitespace(line: string): string {
+	let i = 0;
+	while (i < line.length && (line[i] === ' ' || line[i] === '\t')) i++;
+	return line.slice(0, i);
+}
+
+/** First line of `text` with non-whitespace content, or `null` if none. */
+function firstMeaningfulLine(text: string): string | null {
+	for (const line of text.split('\n')) {
+		if (line.trim()) return line;
+	}
+	return null;
+}
+
+// =============================================================================
+// Public entry: fuzzyFindAndReplace
+// =============================================================================
+
+/**
+ * Find and replace text using a chain of increasingly fuzzy strategies.
+ *
+ * Strategies are tried in order; the first that yields matches wins. On a
+ * unique match (or when `replaceAll` is true), the replacement is applied.
+ * On failure, returns the original content with an error description.
+ *
+ * Guards (ported verbatim from hermes):
+ * - Ambiguity: `>1 match && !replaceAll` → fail with a helpful message.
+ * - Escape-drift: `\'`/`\"` present in both old+new but absent from the
+ *   matched file region → block (transport serialization artifact).
+ * - Selective unescape: `\t`/`\r` in new_string → real bytes only when the
+ *   matched file region contains the corresponding control char. `\n` excluded.
+ * - Unicode preservation: under strategy 7, unchanged spans keep the file's
+ *   original Unicode characters rather than the ASCII-normalized equivalents.
+ */
+export function fuzzyFindAndReplace(
+	content: string,
+	oldString: string,
+	newString: string,
+	replaceAll = false,
+	options: FuzzyOptions = {},
+): FuzzyResult {
+	if (!oldString) {
+		return { content, matchCount: 0, strategy: null, error: 'old_string cannot be empty' };
+	}
+	if (oldString === newString) {
+		return {
+			content,
+			matchCount: 0,
+			strategy: null,
+			error: 'old_string and new_string are identical',
+		};
+	}
+
+	type StrategyEntry = [string, (content: string, pattern: string) => Span[]];
+	const strategies: StrategyEntry[] = [
+		['exact', strategyExact],
+		['line_trimmed', strategyLineTrimmed],
+		['whitespace_normalized', strategyWhitespaceNormalized],
+		['indentation_flexible', strategyIndentationFlexible],
+		['escape_normalized', strategyEscapeNormalized],
+		['trimmed_boundary', strategyTrimmedBoundary],
+		['unicode_normalized', strategyUnicodeNormalized],
+		['block_anchor', strategyBlockAnchor],
+	];
+	if (options.includeContextAware !== false) {
+		strategies.push(['context_aware', strategyContextAware]);
+	}
+
+	for (const [strategyName, strategyFn] of strategies) {
+		const matches = strategyFn(content, oldString);
+		if (matches.length === 0) continue;
+
+		// Ambiguity guard.
+		if (matches.length > 1 && !replaceAll) {
+			return {
+				content,
+				matchCount: 0,
+				strategy: null,
+				error: `Found ${matches.length} matches for old_string. Provide more context to make it unique, or use replace_all=true.`,
+			};
+		}
+
+		// Escape-drift guard (skipped for exact matches).
+		if (strategyName !== 'exact') {
+			const driftErr = detectEscapeDrift(content, matches, oldString, newString);
+			if (driftErr) {
+				return { content, matchCount: 0, strategy: null, error: driftErr };
+			}
+		}
+
+		// Selective unescape of \t / \r in new_string based on the matched region.
+		let effectiveNew = maybeUnescapeNewString(newString, content, matches);
+
+		// Unicode preservation under strategy 7.
+		if (strategyName === 'unicode_normalized') {
+			effectiveNew = preserveUnicodeInReplacement(content, matches, oldString, effectiveNew);
+		}
+
+		const newContent = applyReplacements(
+			content,
+			matches,
+			effectiveNew,
+			strategyName !== 'exact' ? oldString : null,
+		);
+		return { content: newContent, matchCount: matches.length, strategy: strategyName, error: null };
+	}
+
+	return {
+		content,
+		matchCount: 0,
+		strategy: null,
+		error: 'Could not find a match for old_string in the file',
+	};
+}
+
+// =============================================================================
+// Guards and replacement-shaping helpers
+// =============================================================================
+
+/**
+ * Detect tool-call escape-drift artifacts in new_string.
+ *
+ * Looks for `\'` or `\"` sequences present in BOTH old_string and new_string
+ * (i.e. the model intended to preserve them) but absent from the matched file
+ * region. That pattern indicates the transport layer inserted spurious
+ * shell-style escapes; writing new_string verbatim would insert literal `\'`.
+ */
+function detectEscapeDrift(
+	content: string,
+	matches: Span[],
+	oldString: string,
+	newString: string,
+): string | null {
+	// Cheap pre-check.
+	if (!newString.includes("\\'") && !newString.includes('\\"')) return null;
+
+	let matchedRegions = '';
+	for (const [start, end] of matches) matchedRegions += content.slice(start, end);
+
+	for (const suspect of ["\\'", '\\"'] as const) {
+		if (newString.includes(suspect) && oldString.includes(suspect) && !matchedRegions.includes(suspect)) {
+			const plain = suspect[1]; // "'" or '"'
+			return (
+				`Escape-drift detected: old_string and new_string contain the literal sequence ` +
+				`${JSON.stringify(suspect)} but the matched region of the file does not. This is almost ` +
+				`always a tool-call serialization artifact where an apostrophe or quote got prefixed ` +
+				`with a spurious backslash. Re-read the file with read_file and pass ` +
+				`old_string/new_string without backslash-escaping ${JSON.stringify(plain)} characters.`
+			);
+		}
+	}
+	return null;
+}
+
+/**
+ * Conditionally unescape `\t`/`\r` in new_string.
+ *
+ * LLMs frequently send the two-character sequences `\t` and `\r` inside JSON
+ * tool-call arguments where they meant real control bytes. The unescape is
+ * applied per-sequence only when the matched file region actually contains the
+ * corresponding control byte. `\n` is intentionally excluded (newlines
+ * serialize correctly through JSON).
+ */
+function maybeUnescapeNewString(newString: string, content: string, matches: Span[]): string {
+	if (!newString.includes('\\t') && !newString.includes('\\r')) return newString;
+	let matchedRegions = '';
+	for (const [start, end] of matches) matchedRegions += content.slice(start, end);
+	let out = newString;
+	if (out.includes('\\t') && matchedRegions.includes('\t')) {
+		out = out.split('\\t').join('\t');
+	}
+	if (out.includes('\\r') && matchedRegions.includes('\r')) {
+		out = out.split('\\r').join('\r');
+	}
+	return out;
+}
+
+/**
+ * Adjust `newString` so its indentation matches the file region.
+ *
+ * After a non-exact match, the LLM's old_string/new_string may use a different
+ * indent style than the file (e.g. 2-space vs 4-space). This re-indents each
+ * non-blank line by swapping the LLM's base indent prefix for the file's actual
+ * base indent prefix, preserving relative nesting. No-op when the base indents
+ * already match.
+ */
+function reindentReplacement(fileRegion: string, oldString: string, newString: string): string {
+	if (!newString) return newString;
+
+	const oldFirst = firstMeaningfulLine(oldString);
+	const fileFirst = firstMeaningfulLine(fileRegion);
+	if (oldFirst === null || fileFirst === null) return newString;
+
+	const oldIndent = leadingWhitespace(oldFirst);
+	const fileIndent = leadingWhitespace(fileFirst);
+	if (oldIndent === fileIndent) return newString;
+
+	const outLines: string[] = [];
+	for (const line of newString.split('\n')) {
+		if (!line.trim()) {
+			// Blank lines: leave whitespace untouched.
+			outLines.push(line);
+			continue;
+		}
+		const lineIndent = leadingWhitespace(line);
+		if (lineIndent.startsWith(oldIndent)) {
+			// Common case: line has the LLM's base indent (possibly + extra).
+			const remainder = line.slice(oldIndent.length);
+			outLines.push(fileIndent + remainder);
+		} else {
+			// Line is less-indented than the LLM's base — anchor to file's base.
+			outLines.push(fileIndent + line.replace(/^[ \t]+/, ''));
+		}
+	}
+	return outLines.join('\n');
+}
+
+/**
+ * Preserve Unicode characters from the file in the replacement string.
+ *
+ * Under strategy 7 (unicode_normalized), the file has Unicode characters but
+ * old/new from the LLM are ASCII equivalents. Writing new_string verbatim
+ * would silently corrupt the file's Unicode. This diffs norm_old → new_string
+ * via SequenceMatcher and applies only the actual edits to the file's original
+ * text, preserving Unicode for unchanged spans.
+ */
+function preserveUnicodeInReplacement(
+	content: string,
+	matches: Span[],
+	oldString: string,
+	newString: string,
+): string {
+	let fileRegion = '';
+	for (const [start, end] of matches) fileRegion += content.slice(start, end);
+
+	const normOld = unicodeNormalize(oldString);
+	const normFile = unicodeNormalize(fileRegion);
+
+	// If the normalized forms don't match, fall back to direct replacement.
+	if (normOld !== normFile) return newString;
+
+	// Build position maps from normalized space back to original space.
+	const fileOrigToNorm = buildOrigToNormMap(fileRegion);
+	const fileNormToOrig: Map<number, number> = new Map();
+	for (let origPos = 0; origPos < fileOrigToNorm.length - 1; origPos++) {
+		const np = fileOrigToNorm[origPos];
+		if (!fileNormToOrig.has(np)) fileNormToOrig.set(np, origPos);
+	}
+
+	const sm = new SequenceMatcher(null, normOld, newString);
+	const opcodes = sm.getOpcodes();
+
+	const resultParts: string[] = [];
+	for (const op of opcodes) {
+		const { tag, i1, i2, j1, j2 } = op;
+		if (tag === 'equal') {
+			const origStart = fileNormToOrig.get(i1) ?? 0;
+			let origEnd = origStart;
+			while (origEnd < fileRegion.length && fileOrigToNorm[origEnd] < i2) {
+				origEnd++;
+			}
+			resultParts.push(fileRegion.slice(origStart, origEnd));
+		} else if (tag === 'replace') {
+			resultParts.push(newString.slice(j1, j2));
+		} else if (tag === 'delete') {
+			// skip deleted portion
+		} else if (tag === 'insert') {
+			resultParts.push(newString.slice(j1, j2));
+		}
+	}
+	return resultParts.join('');
+}
+
+/**
+ * Apply replacements at the given spans.
+ *
+ * Spans are processed in descending position order so earlier offsets remain
+ * valid. When `oldString` is non-null, the match came from a non-exact strategy
+ * and `newString` is re-indented to match the file region before substitution.
+ */
+function applyReplacements(
+	content: string,
+	matches: Span[],
+	newString: string,
+	oldString: string | null,
+): string {
+	const sorted = [...matches].sort((x, y) => y[0] - x[0]);
+	let result = content;
+	for (const [start, end] of sorted) {
+		const adjusted = oldString !== null
+			? reindentReplacement(content.slice(start, end), oldString, newString)
+			: newString;
+		result = result.slice(0, start) + adjusted + result.slice(end);
+	}
+	return result;
+}
+
+// =============================================================================
+// Position-remap helpers
+// =============================================================================
+
+/**
+ * Map each original character index to its normalized index.
+ *
+ * Because UNICODE_MAP replacements may expand a single character into multiple
+ * ASCII chars, the normalized string can be longer than the original. The
+ * returned array has length `original.length + 1`; entry `i` is the normalized
+ * index that original character `i` maps to. The final entry is the sentinel
+ * (one past the last character).
+ */
+function buildOrigToNormMap(original: string): number[] {
+	const result: number[] = [];
+	let normPos = 0;
+	for (let i = 0; i < original.length; i++) {
+		result.push(normPos);
+		const repl = UNICODE_MAP[original[i]];
+		normPos += repl !== undefined ? repl.length : 1;
+	}
+	result.push(normPos);
+	return result;
+}
+
+/** Convert (start, end) positions in the normalized string to original positions. */
+function mapPositionsNormToOrig(origToNorm: number[], normMatches: Span[]): Span[] {
+	const normToOrigStart: Map<number, number> = new Map();
+	for (let origPos = 0; origPos < origToNorm.length - 1; origPos++) {
+		const normPos = origToNorm[origPos];
+		if (!normToOrigStart.has(normPos)) normToOrigStart.set(normPos, origPos);
+	}
+
+	const results: Span[] = [];
+	const origLen = origToNorm.length - 1;
+	for (const [normStart, normEnd] of normMatches) {
+		if (!normToOrigStart.has(normStart)) continue;
+		const origStart = normToOrigStart.get(normStart)!;
+		let origEnd = origStart;
+		while (origEnd < origLen && origToNorm[origEnd] < normEnd) origEnd++;
+		results.push([origStart, origEnd]);
+	}
+	return results;
+}
+
+/**
+ * Calculate start/end character positions from line indices.
+ *
+ * Lines are assumed to be `\n`-separated with no trailing newline in the array
+ * form (i.e. `content.split('\n')`). Each line contributes `length + 1` to
+ * account for the newline that was the separator.
+ */
+function calculateLinePositions(
+	contentLines: string[],
+	startLine: number,
+	endLine: number,
+	contentLength: number,
+): Span {
+	let start = 0;
+	for (let i = 0; i < startLine; i++) start += contentLines[i].length + 1;
+	let end = 0;
+	for (let i = 0; i < endLine; i++) end += contentLines[i].length + 1;
+	end -= 1; // exclude the trailing newline of the last line
+	end = Math.min(contentLength, end);
+	return [start, end];
+}
+
+/**
+ * Find matches in line-normalized content and map back to original positions.
+ *
+ * Used by strategies that normalize per-line (trim, lstrip): the line-level
+ * normalization preserves line count, so original positions are recovered via
+ * {@link calculateLinePositions}.
+ */
+function findNormalizedMatches(
+	content: string,
+	contentLines: string[],
+	contentNormalizedLines: string[],
+	patternNormalized: string,
+): Span[] {
+	const patternNormLines = patternNormalized.split('\n');
+	const numPatternLines = patternNormLines.length;
+	const matches: Span[] = [];
+	for (let i = 0; i <= contentNormalizedLines.length - numPatternLines; i++) {
+		const block = contentNormalizedLines.slice(i, i + numPatternLines).join('\n');
+		if (block === patternNormalized) {
+			const [start, end] = calculateLinePositions(contentLines, i, i + numPatternLines, content.length);
+			matches.push([start, end]);
+		}
+	}
+	return matches;
+}
+
+/**
+ * Map positions from a whitespace-normalized string back to the original.
+ *
+ * Handles the case where `[ \t]+` was collapsed to a single space. Includes
+ * the word-boundary fix: trailing-whitespace expansion happens only when the
+ * normalized match itself ends with a space; when it ends with a non-space,
+ * the following whitespace in the original is a word boundary and must NOT be
+ * consumed.
+ */
+function mapNormalizedPositions(
+	original: string,
+	normalized: string,
+	normalizedMatches: Span[],
+): Span[] {
+	if (normalizedMatches.length === 0) return [];
+
+	// Build orig_to_norm: orig_to_norm[i] = normalized position for original char i.
+	const origToNorm: number[] = [];
+	let origIdx = 0;
+	let normIdx = 0;
+	while (origIdx < original.length && normIdx < normalized.length) {
+		if (original[origIdx] === normalized[normIdx]) {
+			origToNorm.push(normIdx);
+			origIdx++;
+			normIdx++;
+		} else if (
+			(original[origIdx] === ' ' || original[origIdx] === '\t') &&
+			normalized[normIdx] === ' '
+		) {
+			// Original has space/tab, normalized collapsed to space.
+			origToNorm.push(normIdx);
+			origIdx++;
+			// Don't advance norm_idx until all consecutive whitespace is consumed.
+			if (origIdx < original.length && original[origIdx] !== ' ' && original[origIdx] !== '\t') {
+				normIdx++;
+			}
+		} else if (original[origIdx] === ' ' || original[origIdx] === '\t') {
+			// Extra whitespace in original.
+			origToNorm.push(normIdx);
+			origIdx++;
+		} else {
+			// Mismatch — shouldn't happen with our normalization.
+			origToNorm.push(normIdx);
+			origIdx++;
+		}
+	}
+	// Fill remaining.
+	while (origIdx < original.length) {
+		origToNorm.push(normalized.length);
+		origIdx++;
+	}
+
+	// Reverse mapping: for each normalized position, find original range.
+	const normToOrigStart: Map<number, number> = new Map();
+	const normToOrigEnd: Map<number, number> = new Map();
+	for (let origPos = 0; origPos < origToNorm.length; origPos++) {
+		const normPos = origToNorm[origPos];
+		if (!normToOrigStart.has(normPos)) normToOrigStart.set(normPos, origPos);
+		normToOrigEnd.set(normPos, origPos);
+	}
+
+	const originalMatches: Span[] = [];
+	for (const [normStart, normEnd] of normalizedMatches) {
+		let origStart: number;
+		if (normToOrigStart.has(normStart)) {
+			origStart = normToOrigStart.get(normStart)!;
+		} else {
+			// Find nearest original position with normalized pos >= normStart.
+			origStart = origToNorm.length;
+			for (let i = 0; i < origToNorm.length; i++) {
+				if (origToNorm[i] >= normStart) { origStart = i; break; }
+			}
+		}
+
+		let origEnd: number;
+		if (normToOrigEnd.has(normEnd - 1)) {
+			origEnd = normToOrigEnd.get(normEnd - 1)! + 1;
+		} else {
+			origEnd = origStart + (normEnd - normStart);
+		}
+
+		// Word-boundary fix: expand trailing whitespace only when the normalized
+		// match itself ends with a space. When it ends with a non-space, the
+		// first whitespace in the original is a word boundary and must not be
+		// consumed.
+		if (normEnd < normalized.length && normalized[normEnd - 1] === ' ') {
+			while (origEnd < original.length && (original[origEnd] === ' ' || original[origEnd] === '\t')) {
+				origEnd++;
+			}
+		}
+		originalMatches.push([origStart, Math.min(origEnd, original.length)]);
+	}
+	return originalMatches;
+}
+
+// =============================================================================
+// Strategies
+// =============================================================================
+
+/** Strategy 1: exact string match, non-overlapping. */
+export function strategyExact(content: string, pattern: string): Span[] {
+	const matches: Span[] = [];
+	let start = 0;
+	while (true) {
+		const pos = content.indexOf(pattern, start);
+		if (pos === -1) break;
+		matches.push([pos, pos + pattern.length]);
+		// Advance past the whole match so self-overlapping patterns produce
+		// non-overlapping spans (matches str.replace semantics). Advancing by 1
+		// yielded overlapping matches that corrupt the file under replace_all.
+		start = pos + pattern.length;
+	}
+	return matches;
+}
+
+/** Strategy 2: per-line `.trim()` + block equality. */
+export function strategyLineTrimmed(content: string, pattern: string): Span[] {
+	const patternLines = pattern.split('\n').map((l) => l.trim());
+	const patternNormalized = patternLines.join('\n');
+	const contentLines = content.split('\n');
+	const contentNormalizedLines = contentLines.map((l) => l.trim());
+	return findNormalizedMatches(content, contentLines, contentNormalizedLines, patternNormalized);
+}
+
+/** Strategy 3: collapse `[ \t]+` → single space, preserve newlines. */
+export function strategyWhitespaceNormalized(content: string, pattern: string): Span[] {
+	const normalize = (s: string) => s.replace(/[ \t]+/g, ' ');
+	const patternNormalized = normalize(pattern);
+	const contentNormalized = normalize(content);
+	const matchesInNormalized = strategyExact(contentNormalized, patternNormalized);
+	if (matchesInNormalized.length === 0) return [];
+	return mapNormalizedPositions(content, contentNormalized, matchesInNormalized);
+}
+
+/** Strategy 4: strip all leading whitespace per line (lstrip). */
+export function strategyIndentationFlexible(content: string, pattern: string): Span[] {
+	const contentLines = content.split('\n');
+	const contentStripped = contentLines.map((l) => l.replace(/^[ \t]+/, ''));
+	const patternLines = pattern.split('\n').map((l) => l.replace(/^[ \t]+/, ''));
+	return findNormalizedMatches(content, contentLines, contentStripped, patternLines.join('\n'));
+}
+
+/** Strategy 5: unescape `\n`/`\t`/`\r` literals → bytes, then exact match. */
+export function strategyEscapeNormalized(content: string, pattern: string): Span[] {
+	const unescapeLiterals = (s: string) =>
+		s.split('\\n').join('\n').split('\\t').join('\t').split('\\r').join('\r');
+	const patternUnescaped = unescapeLiterals(pattern);
+	if (patternUnescaped === pattern) return []; // no escapes — skip
+	return strategyExact(content, patternUnescaped);
+}
+
+/** Strategy 6: trim only first and last lines, sliding window. */
+export function strategyTrimmedBoundary(content: string, pattern: string): Span[] {
+	const patternLines = pattern.split('\n');
+	if (patternLines.length === 0) return [];
+	patternLines[0] = patternLines[0].trim();
+	if (patternLines.length > 1) patternLines[patternLines.length - 1] = patternLines[patternLines.length - 1].trim();
+	const modifiedPattern = patternLines.join('\n');
+	const contentLines = content.split('\n');
+	const matches: Span[] = [];
+	const patternLineCount = patternLines.length;
+	for (let i = 0; i <= contentLines.length - patternLineCount; i++) {
+		const blockLines = contentLines.slice(i, i + patternLineCount);
+		const checkLines = blockLines.slice();
+		checkLines[0] = checkLines[0].trim();
+		if (checkLines.length > 1) checkLines[checkLines.length - 1] = checkLines[checkLines.length - 1].trim();
+		if (checkLines.join('\n') === modifiedPattern) {
+			const [start, end] = calculateLinePositions(contentLines, i, i + patternLineCount, content.length);
+			matches.push([start, end]);
+		}
+	}
+	return matches;
+}
+
+/** Strategy 7: Unicode normalization (smart quotes, em/en dash, ellipsis, NBSP). */
+export function strategyUnicodeNormalized(content: string, pattern: string): Span[] {
+	const normPattern = unicodeNormalize(pattern);
+	const normContent = unicodeNormalize(content);
+	if (normContent === content && normPattern === pattern) return [];
+
+	let normMatches = strategyExact(normContent, normPattern);
+	if (normMatches.length === 0) {
+		normMatches = strategyLineTrimmed(normContent, normPattern);
+	}
+	if (normMatches.length === 0) return [];
+
+	const origToNorm = buildOrigToNormMap(content);
+	return mapPositionsNormToOrig(origToNorm, normMatches);
+}
+
+/** Strategy 8: anchor on first+last lines, similarity for the middle. */
+export function strategyBlockAnchor(content: string, pattern: string): Span[] {
+	const normPattern = unicodeNormalize(pattern);
+	const normContent = unicodeNormalize(content);
+	const patternLines = normPattern.split('\n');
+	if (patternLines.length < 2) return [];
+	const firstLine = patternLines[0].trim();
+	const lastLine = patternLines[patternLines.length - 1].trim();
+
+	const normContentLines = normContent.split('\n');
+	const origContentLines = content.split('\n');
+	const patternLineCount = patternLines.length;
+
+	const potentialMatches: number[] = [];
+	for (let i = 0; i <= normContentLines.length - patternLineCount; i++) {
+		if (
+			normContentLines[i].trim() === firstLine &&
+			normContentLines[i + patternLineCount - 1].trim() === lastLine
+		) {
+			potentialMatches.push(i);
+		}
+	}
+
+	// Threshold: 0.50 for unique matches, 0.70 for multiple candidates.
+	const candidateCount = potentialMatches.length;
+	const threshold = candidateCount === 1 ? 0.5 : 0.7;
+
+	const matches: Span[] = [];
+	for (const i of potentialMatches) {
+		let similarity: number;
+		if (patternLineCount <= 2) {
+			similarity = 1.0;
+		} else {
+			const contentMiddle = normContentLines.slice(i + 1, i + patternLineCount - 1).join('\n');
+			const patternMiddle = patternLines.slice(1, -1).join('\n');
+			similarity = new SequenceMatcher(null, contentMiddle, patternMiddle).ratio();
+		}
+		if (similarity >= threshold) {
+			const [start, end] = calculateLinePositions(origContentLines, i, i + patternLineCount, content.length);
+			matches.push([start, end]);
+		}
+	}
+	return matches;
+}
+
+/**
+ * Strategy 9: line-by-line similarity, 50% threshold.
+ *
+ * Loosest strategy — accepts any block where half the lines have per-line
+ * similarity ≥ 0.80. Quadratic cost. Opt-in only (separate flag).
+ */
+export function strategyContextAware(content: string, pattern: string): Span[] {
+	const patternLines = pattern.split('\n');
+	const contentLines = content.split('\n');
+	if (patternLines.length === 0) return [];
+	const matches: Span[] = [];
+	const patternLineCount = patternLines.length;
+	for (let i = 0; i <= contentLines.length - patternLineCount; i++) {
+		const blockLines = contentLines.slice(i, i + patternLineCount);
+		let highSimilarityCount = 0;
+		for (let k = 0; k < patternLines.length; k++) {
+			const sim = new SequenceMatcher(null, patternLines[k].trim(), blockLines[k].trim()).ratio();
+			if (sim >= 0.8) highSimilarityCount++;
+		}
+		if (highSimilarityCount >= patternLines.length * 0.5) {
+			const [start, end] = calculateLinePositions(contentLines, i, i + patternLineCount, content.length);
+			matches.push([start, end]);
+		}
+	}
+	return matches;
+}
+
+// =============================================================================
+// "Did you mean?" hint helpers (wired into apply-patch diagnostics)
+// =============================================================================
+
+/**
+ * Find lines in `content` most similar to `oldString` for "did you mean?" feedback.
+ *
+ * Returns a formatted string showing the closest matching lines with context
+ * and line numbers, or `''` if no useful match is found.
+ */
+export function findClosestLines(
+	oldString: string,
+	content: string,
+	contextLines = 2,
+	maxResults = 3,
+): string {
+	if (!oldString || !content) return '';
+	const oldLines = oldString.split(/\r?\n/);
+	const contentLines = content.split(/\r?\n/);
+	if (oldLines.length === 0 || contentLines.length === 0) return '';
+
+	let anchor = oldLines[0].trim();
+	if (!anchor) {
+		const candidates = oldLines.filter((l) => l.trim());
+		if (candidates.length === 0) return '';
+		anchor = candidates[0].trim();
+	}
+
+	const scored: Array<[number, number]> = [];
+	for (let i = 0; i < contentLines.length; i++) {
+		const stripped = contentLines[i].trim();
+		if (!stripped) continue;
+		const ratio = new SequenceMatcher(null, anchor, stripped).ratio();
+		if (ratio > 0.3) scored.push([ratio, i]);
+	}
+	if (scored.length === 0) return '';
+
+	scored.sort((a, b) => b[0] - a[0]);
+	const top = scored.slice(0, maxResults);
+
+	const parts: string[] = [];
+	const seenRanges = new Set<string>();
+	for (const [, lineIdx] of top) {
+		const start = Math.max(0, lineIdx - contextLines);
+		const end = Math.min(contentLines.length, lineIdx + oldLines.length + contextLines);
+		const key = `${start}:${end}`;
+		if (seenRanges.has(key)) continue;
+		seenRanges.add(key);
+		const lines: string[] = [];
+		for (let j = start; j < end; j++) {
+			const num = String(j + 1).padStart(4, ' ');
+			lines.push(`${num}| ${contentLines[j]}`);
+		}
+		parts.push(lines.join('\n'));
+	}
+	if (parts.length === 0) return '';
+	return parts.join('\n---\n');
+}
+
+/**
+ * Return a "Did you mean..." snippet for plain no-match errors.
+ *
+ * Gated so the hint only fires for actual "old_string not found" failures.
+ * Ambiguous-match, escape-drift, and identical-strings errors all have
+ * `matchCount === 0` but a did-you-mean snippet would be misleading.
+ */
+export function formatNoMatchHint(
+	error: string | null,
+	matchCount: number,
+	oldString: string,
+	content: string,
+): string {
+	if (matchCount !== 0) return '';
+	if (!error || !error.startsWith('Could not find')) return '';
+	const hint = findClosestLines(oldString, content);
+	if (!hint) return '';
+	return `\n\nDid you mean one of these sections?\n${hint}`;
+}

--- a/src/utils/fuzzy-match.ts
+++ b/src/utils/fuzzy-match.ts
@@ -41,14 +41,21 @@ export interface FuzzyResult {
 /** Options for {@link fuzzyFindAndReplace}. */
 export interface FuzzyOptions {
 	/**
-	 * When true (default), the `context_aware` strategy (9) is included in the
-	 * chain. Strategy 9 is the loosest/most-false-positive-prone strategy
-	 * (50% line similarity), so the `apply-patch` integration passes `false`
-	 * unless the separate `apply_patch.fuzzy_match_context_aware` flag is set.
+	 * When true (default at the utility level), the `context_aware` strategy
+	 * (9) is included in the chain. Strategy 9 is the loosest/most-false-
+	 * positive-prone strategy (requires 50% of lines to reach 0.80 per-line
+	 * similarity) and has quadratic cost, so it is bounded by an internal
+	 * cell-count cap.
 	 *
-	 * The utility itself defaults it to `true` so the byte-faithful ported
-	 * hermes test suite passes unmodified — strategy 9 is a legitimate part
-	 * of the matching chain and several test cases depend on it.
+	 * **Default divergence (intentional):** the utility defaults this to
+	 * `true` so the byte-faithful ported hermes test suite passes unmodified
+	 * (strategy 9 is a legitimate part of the matching chain and some test
+	 * cases depend on it). The `apply-patch` integration — the only consumer
+	 * today — explicitly passes `false` unless the separate
+	 * `apply_patch.fuzzy_match_context_aware` config flag is set, honoring
+	 * issue #1718's Non-Goal "do not port strategy 9 as default-on" at the
+	 * integration layer. New callers should pass `false` unless they
+	 * specifically want strategy 9.
 	 */
 	includeContextAware?: boolean;
 }
@@ -130,7 +137,12 @@ export function fuzzyFindAndReplace(
 	options: FuzzyOptions = {},
 ): FuzzyResult {
 	if (!oldString) {
-		return { content, matchCount: 0, strategy: null, error: 'old_string cannot be empty' };
+		return {
+			content,
+			matchCount: 0,
+			strategy: null,
+			error: 'old_string cannot be empty',
+		};
 	}
 	if (oldString === newString) {
 		return {
@@ -172,7 +184,12 @@ export function fuzzyFindAndReplace(
 
 		// Escape-drift guard (skipped for exact matches).
 		if (strategyName !== 'exact') {
-			const driftErr = detectEscapeDrift(content, matches, oldString, newString);
+			const driftErr = detectEscapeDrift(
+				content,
+				matches,
+				oldString,
+				newString,
+			);
 			if (driftErr) {
 				return { content, matchCount: 0, strategy: null, error: driftErr };
 			}
@@ -181,9 +198,32 @@ export function fuzzyFindAndReplace(
 		// Selective unescape of \t / \r in new_string based on the matched region.
 		let effectiveNew = maybeUnescapeNewString(newString, content, matches);
 
-		// Unicode preservation under strategy 7.
-		if (strategyName === 'unicode_normalized') {
-			effectiveNew = preserveUnicodeInReplacement(content, matches, oldString, effectiveNew);
+		// Unicode preservation: strategies 7 (unicode_normalized), 8 (block_anchor),
+		// and 9 (context_aware) all normalize Unicode characters for matching.
+		// `preserveUnicodeInReplacement` is invoked for all three so that, when the
+		// normalized forms of old_string and the file region align, the file's
+		// original Unicode characters (smart quotes, em-dashes, ellipsis) are kept
+		// for unchanged spans rather than clobbered to ASCII equivalents.
+		//
+		// Note: the helper has an internal guard (`normOld !== normFile → return
+		// newString`) that makes it a no-op when the normalized forms don't align.
+		// In practice this means preservation is fully effective for strategy 7
+		// (which only fires when the normalized forms match), and best-effort for
+		// strategies 8/9 (which can match with a fuzzy middle). A residual clobber
+		// risk remains for the narrow case of a strategy-8/9 match on Unicode
+		// content with middle drift; that is pre-existing and documented in the
+		// release notes.
+		if (
+			strategyName === 'unicode_normalized' ||
+			strategyName === 'block_anchor' ||
+			strategyName === 'context_aware'
+		) {
+			effectiveNew = preserveUnicodeInReplacement(
+				content,
+				matches,
+				oldString,
+				effectiveNew,
+			);
 		}
 
 		const newContent = applyReplacements(
@@ -192,7 +232,12 @@ export function fuzzyFindAndReplace(
 			effectiveNew,
 			strategyName !== 'exact' ? oldString : null,
 		);
-		return { content: newContent, matchCount: matches.length, strategy: strategyName, error: null };
+		return {
+			content: newContent,
+			matchCount: matches.length,
+			strategy: strategyName,
+			error: null,
+		};
 	}
 
 	return {
@@ -225,10 +270,15 @@ function detectEscapeDrift(
 	if (!newString.includes("\\'") && !newString.includes('\\"')) return null;
 
 	let matchedRegions = '';
-	for (const [start, end] of matches) matchedRegions += content.slice(start, end);
+	for (const [start, end] of matches)
+		matchedRegions += content.slice(start, end);
 
 	for (const suspect of ["\\'", '\\"'] as const) {
-		if (newString.includes(suspect) && oldString.includes(suspect) && !matchedRegions.includes(suspect)) {
+		if (
+			newString.includes(suspect) &&
+			oldString.includes(suspect) &&
+			!matchedRegions.includes(suspect)
+		) {
 			const plain = suspect[1]; // "'" or '"'
 			return (
 				`Escape-drift detected: old_string and new_string contain the literal sequence ` +
@@ -251,10 +301,16 @@ function detectEscapeDrift(
  * corresponding control byte. `\n` is intentionally excluded (newlines
  * serialize correctly through JSON).
  */
-function maybeUnescapeNewString(newString: string, content: string, matches: Span[]): string {
-	if (!newString.includes('\\t') && !newString.includes('\\r')) return newString;
+function maybeUnescapeNewString(
+	newString: string,
+	content: string,
+	matches: Span[],
+): string {
+	if (!newString.includes('\\t') && !newString.includes('\\r'))
+		return newString;
 	let matchedRegions = '';
-	for (const [start, end] of matches) matchedRegions += content.slice(start, end);
+	for (const [start, end] of matches)
+		matchedRegions += content.slice(start, end);
 	let out = newString;
 	if (out.includes('\\t') && matchedRegions.includes('\t')) {
 		out = out.split('\\t').join('\t');
@@ -274,7 +330,11 @@ function maybeUnescapeNewString(newString: string, content: string, matches: Spa
  * base indent prefix, preserving relative nesting. No-op when the base indents
  * already match.
  */
-function reindentReplacement(fileRegion: string, oldString: string, newString: string): string {
+function reindentReplacement(
+	fileRegion: string,
+	oldString: string,
+	newString: string,
+): string {
 	if (!newString) return newString;
 
 	const oldFirst = firstMeaningfulLine(oldString);
@@ -377,9 +437,10 @@ function applyReplacements(
 	const sorted = [...matches].sort((x, y) => y[0] - x[0]);
 	let result = content;
 	for (const [start, end] of sorted) {
-		const adjusted = oldString !== null
-			? reindentReplacement(content.slice(start, end), oldString, newString)
-			: newString;
+		const adjusted =
+			oldString !== null
+				? reindentReplacement(content.slice(start, end), oldString, newString)
+				: newString;
 		result = result.slice(0, start) + adjusted + result.slice(end);
 	}
 	return result;
@@ -411,7 +472,10 @@ function buildOrigToNormMap(original: string): number[] {
 }
 
 /** Convert (start, end) positions in the normalized string to original positions. */
-function mapPositionsNormToOrig(origToNorm: number[], normMatches: Span[]): Span[] {
+function mapPositionsNormToOrig(
+	origToNorm: number[],
+	normMatches: Span[],
+): Span[] {
 	const normToOrigStart: Map<number, number> = new Map();
 	for (let origPos = 0; origPos < origToNorm.length - 1; origPos++) {
 		const normPos = origToNorm[origPos];
@@ -469,9 +533,16 @@ function findNormalizedMatches(
 	const numPatternLines = patternNormLines.length;
 	const matches: Span[] = [];
 	for (let i = 0; i <= contentNormalizedLines.length - numPatternLines; i++) {
-		const block = contentNormalizedLines.slice(i, i + numPatternLines).join('\n');
+		const block = contentNormalizedLines
+			.slice(i, i + numPatternLines)
+			.join('\n');
 		if (block === patternNormalized) {
-			const [start, end] = calculateLinePositions(contentLines, i, i + numPatternLines, content.length);
+			const [start, end] = calculateLinePositions(
+				contentLines,
+				i,
+				i + numPatternLines,
+				content.length,
+			);
 			matches.push([start, end]);
 		}
 	}
@@ -511,7 +582,11 @@ function mapNormalizedPositions(
 			origToNorm.push(normIdx);
 			origIdx++;
 			// Don't advance norm_idx until all consecutive whitespace is consumed.
-			if (origIdx < original.length && original[origIdx] !== ' ' && original[origIdx] !== '\t') {
+			if (
+				origIdx < original.length &&
+				original[origIdx] !== ' ' &&
+				original[origIdx] !== '\t'
+			) {
 				normIdx++;
 			}
 		} else if (original[origIdx] === ' ' || original[origIdx] === '\t') {
@@ -548,7 +623,10 @@ function mapNormalizedPositions(
 			// Find nearest original position with normalized pos >= normStart.
 			origStart = origToNorm.length;
 			for (let i = 0; i < origToNorm.length; i++) {
-				if (origToNorm[i] >= normStart) { origStart = i; break; }
+				if (origToNorm[i] >= normStart) {
+					origStart = i;
+					break;
+				}
 			}
 		}
 
@@ -564,7 +642,10 @@ function mapNormalizedPositions(
 		// first whitespace in the original is a word boundary and must not be
 		// consumed.
 		if (normEnd < normalized.length && normalized[normEnd - 1] === ' ') {
-			while (origEnd < original.length && (original[origEnd] === ' ' || original[origEnd] === '\t')) {
+			while (
+				origEnd < original.length &&
+				(original[origEnd] === ' ' || original[origEnd] === '\t')
+			) {
 				origEnd++;
 			}
 		}
@@ -599,29 +680,55 @@ export function strategyLineTrimmed(content: string, pattern: string): Span[] {
 	const patternNormalized = patternLines.join('\n');
 	const contentLines = content.split('\n');
 	const contentNormalizedLines = contentLines.map((l) => l.trim());
-	return findNormalizedMatches(content, contentLines, contentNormalizedLines, patternNormalized);
+	return findNormalizedMatches(
+		content,
+		contentLines,
+		contentNormalizedLines,
+		patternNormalized,
+	);
 }
 
 /** Strategy 3: collapse `[ \t]+` → single space, preserve newlines. */
-export function strategyWhitespaceNormalized(content: string, pattern: string): Span[] {
+export function strategyWhitespaceNormalized(
+	content: string,
+	pattern: string,
+): Span[] {
 	const normalize = (s: string) => s.replace(/[ \t]+/g, ' ');
 	const patternNormalized = normalize(pattern);
 	const contentNormalized = normalize(content);
-	const matchesInNormalized = strategyExact(contentNormalized, patternNormalized);
+	const matchesInNormalized = strategyExact(
+		contentNormalized,
+		patternNormalized,
+	);
 	if (matchesInNormalized.length === 0) return [];
-	return mapNormalizedPositions(content, contentNormalized, matchesInNormalized);
+	return mapNormalizedPositions(
+		content,
+		contentNormalized,
+		matchesInNormalized,
+	);
 }
 
 /** Strategy 4: strip all leading whitespace per line (lstrip). */
-export function strategyIndentationFlexible(content: string, pattern: string): Span[] {
+export function strategyIndentationFlexible(
+	content: string,
+	pattern: string,
+): Span[] {
 	const contentLines = content.split('\n');
 	const contentStripped = contentLines.map((l) => l.replace(/^[ \t]+/, ''));
 	const patternLines = pattern.split('\n').map((l) => l.replace(/^[ \t]+/, ''));
-	return findNormalizedMatches(content, contentLines, contentStripped, patternLines.join('\n'));
+	return findNormalizedMatches(
+		content,
+		contentLines,
+		contentStripped,
+		patternLines.join('\n'),
+	);
 }
 
 /** Strategy 5: unescape `\n`/`\t`/`\r` literals → bytes, then exact match. */
-export function strategyEscapeNormalized(content: string, pattern: string): Span[] {
+export function strategyEscapeNormalized(
+	content: string,
+	pattern: string,
+): Span[] {
 	const unescapeLiterals = (s: string) =>
 		s.split('\\n').join('\n').split('\\t').join('\t').split('\\r').join('\r');
 	const patternUnescaped = unescapeLiterals(pattern);
@@ -630,11 +737,16 @@ export function strategyEscapeNormalized(content: string, pattern: string): Span
 }
 
 /** Strategy 6: trim only first and last lines, sliding window. */
-export function strategyTrimmedBoundary(content: string, pattern: string): Span[] {
+export function strategyTrimmedBoundary(
+	content: string,
+	pattern: string,
+): Span[] {
 	const patternLines = pattern.split('\n');
 	if (patternLines.length === 0) return [];
 	patternLines[0] = patternLines[0].trim();
-	if (patternLines.length > 1) patternLines[patternLines.length - 1] = patternLines[patternLines.length - 1].trim();
+	if (patternLines.length > 1)
+		patternLines[patternLines.length - 1] =
+			patternLines[patternLines.length - 1].trim();
 	const modifiedPattern = patternLines.join('\n');
 	const contentLines = content.split('\n');
 	const matches: Span[] = [];
@@ -643,9 +755,16 @@ export function strategyTrimmedBoundary(content: string, pattern: string): Span[
 		const blockLines = contentLines.slice(i, i + patternLineCount);
 		const checkLines = blockLines.slice();
 		checkLines[0] = checkLines[0].trim();
-		if (checkLines.length > 1) checkLines[checkLines.length - 1] = checkLines[checkLines.length - 1].trim();
+		if (checkLines.length > 1)
+			checkLines[checkLines.length - 1] =
+				checkLines[checkLines.length - 1].trim();
 		if (checkLines.join('\n') === modifiedPattern) {
-			const [start, end] = calculateLinePositions(contentLines, i, i + patternLineCount, content.length);
+			const [start, end] = calculateLinePositions(
+				contentLines,
+				i,
+				i + patternLineCount,
+				content.length,
+			);
 			matches.push([start, end]);
 		}
 	}
@@ -653,7 +772,10 @@ export function strategyTrimmedBoundary(content: string, pattern: string): Span[
 }
 
 /** Strategy 7: Unicode normalization (smart quotes, em/en dash, ellipsis, NBSP). */
-export function strategyUnicodeNormalized(content: string, pattern: string): Span[] {
+export function strategyUnicodeNormalized(
+	content: string,
+	pattern: string,
+): Span[] {
 	const normPattern = unicodeNormalize(pattern);
 	const normContent = unicodeNormalize(content);
 	if (normContent === content && normPattern === pattern) return [];
@@ -701,12 +823,23 @@ export function strategyBlockAnchor(content: string, pattern: string): Span[] {
 		if (patternLineCount <= 2) {
 			similarity = 1.0;
 		} else {
-			const contentMiddle = normContentLines.slice(i + 1, i + patternLineCount - 1).join('\n');
+			const contentMiddle = normContentLines
+				.slice(i + 1, i + patternLineCount - 1)
+				.join('\n');
 			const patternMiddle = patternLines.slice(1, -1).join('\n');
-			similarity = new SequenceMatcher(null, contentMiddle, patternMiddle).ratio();
+			similarity = new SequenceMatcher(
+				null,
+				contentMiddle,
+				patternMiddle,
+			).ratio();
 		}
 		if (similarity >= threshold) {
-			const [start, end] = calculateLinePositions(origContentLines, i, i + patternLineCount, content.length);
+			const [start, end] = calculateLinePositions(
+				origContentLines,
+				i,
+				i + patternLineCount,
+				content.length,
+			);
 			matches.push([start, end]);
 		}
 	}
@@ -717,23 +850,50 @@ export function strategyBlockAnchor(content: string, pattern: string): Span[] {
  * Strategy 9: line-by-line similarity, 50% threshold.
  *
  * Loosest strategy — accepts any block where half the lines have per-line
- * similarity ≥ 0.80. Quadratic cost. Opt-in only (separate flag).
+ * similarity ≥ 0.80. Quadratic cost (O(contentLines × patternLines × ratioCost)
+ * per failing hunk). Opt-in only (separate flag).
+ *
+ * Bounded by `CONTEXT_AWARE_MAX_CELLS`: when `contentLines.length ×
+ * patternLines.length` exceeds the cap, the strategy returns no matches rather
+ * than risk a multi-second/multi-minute hang on large files. The cap is set so
+ * a typical source file (<~5k lines) with a typical hunk (<~40 lines) still
+ * runs strategy 9, but a 50k-line file with a 1k-line pattern (which the critic
+ * benchmarked at ~3.8 minutes) bails out instantly. The file size is NOT
+ * bounded by `MAX_PATCH_SIZE` (that caps only the patch text), so this guard is
+ * the only protection against a DoS when `fuzzy_match_context_aware` is enabled.
  */
+const CONTEXT_AWARE_MAX_CELLS = 200_000;
+const FIND_CLOSEST_LINES_MAX_LINES = 10_000;
+
 export function strategyContextAware(content: string, pattern: string): Span[] {
 	const patternLines = pattern.split('\n');
 	const contentLines = content.split('\n');
 	if (patternLines.length === 0) return [];
+	// Size guard: bail out before the quadratic blowup. Without this, a large
+	// file + large hunk hangs the tool for minutes (issue #1718 PR review).
+	if (contentLines.length * patternLines.length > CONTEXT_AWARE_MAX_CELLS) {
+		return [];
+	}
 	const matches: Span[] = [];
 	const patternLineCount = patternLines.length;
 	for (let i = 0; i <= contentLines.length - patternLineCount; i++) {
 		const blockLines = contentLines.slice(i, i + patternLineCount);
 		let highSimilarityCount = 0;
 		for (let k = 0; k < patternLines.length; k++) {
-			const sim = new SequenceMatcher(null, patternLines[k].trim(), blockLines[k].trim()).ratio();
+			const sim = new SequenceMatcher(
+				null,
+				patternLines[k].trim(),
+				blockLines[k].trim(),
+			).ratio();
 			if (sim >= 0.8) highSimilarityCount++;
 		}
 		if (highSimilarityCount >= patternLines.length * 0.5) {
-			const [start, end] = calculateLinePositions(contentLines, i, i + patternLineCount, content.length);
+			const [start, end] = calculateLinePositions(
+				contentLines,
+				i,
+				i + patternLineCount,
+				content.length,
+			);
 			matches.push([start, end]);
 		}
 	}
@@ -760,6 +920,11 @@ export function findClosestLines(
 	const oldLines = oldString.split(/\r?\n/);
 	const contentLines = content.split(/\r?\n/);
 	if (oldLines.length === 0 || contentLines.length === 0) return '';
+	// Size guard: findClosestLines runs SequenceMatcher.ratio() on every
+	// non-blank content line against the anchor. On a large file this is a
+	// full-file quadratic scan per fuzzy-miss. Bail out (return no hint) when
+	// the file is very large rather than compound the failed-fuzzy cost.
+	if (contentLines.length > FIND_CLOSEST_LINES_MAX_LINES) return '';
 
 	let anchor = oldLines[0].trim();
 	if (!anchor) {
@@ -784,7 +949,10 @@ export function findClosestLines(
 	const seenRanges = new Set<string>();
 	for (const [, lineIdx] of top) {
 		const start = Math.max(0, lineIdx - contextLines);
-		const end = Math.min(contentLines.length, lineIdx + oldLines.length + contextLines);
+		const end = Math.min(
+			contentLines.length,
+			lineIdx + oldLines.length + contextLines,
+		);
 		const key = `${start}:${end}`;
 		if (seenRanges.has(key)) continue;
 		seenRanges.add(key);

--- a/src/utils/sequence-matcher.ts
+++ b/src/utils/sequence-matcher.ts
@@ -186,11 +186,7 @@ export class SequenceMatcher {
 		// Extend the best match backward and forward over equal characters
 		// (CPython does this to coalesce adjacent equal runs that the
 		// dynamic-programming scan didn't merge).
-		while (
-			bestI > alo &&
-			bestJ > blo &&
-			a[bestI - 1] === b[bestJ - 1]
-		) {
+		while (bestI > alo && bestJ > blo && a[bestI - 1] === b[bestJ - 1]) {
 			bestI--;
 			bestJ--;
 			bestSize++;
@@ -214,9 +210,7 @@ export class SequenceMatcher {
 		const lb = this.b.length;
 		const matches: Match[] = [];
 
-		const stack: Array<[number, number, number, number]> = [
-			[0, la, 0, lb],
-		];
+		const stack: Array<[number, number, number, number]> = [[0, la, 0, lb]];
 		while (stack.length > 0) {
 			const [alo, ahi, blo, bhi] = stack.pop()!;
 			const m = this.findLongestMatch(alo, ahi, blo, bhi);
@@ -270,7 +264,13 @@ export class SequenceMatcher {
 			}
 			// Emit equal for the block itself (size 0 on the sentinel → skipped).
 			if (size > 0) {
-				opcodes.push({ tag: 'equal', i1: ai, i2: ai + size, j1: bj, j2: bj + size });
+				opcodes.push({
+					tag: 'equal',
+					i1: ai,
+					i2: ai + size,
+					j1: bj,
+					j2: bj + size,
+				});
 			}
 			i = ai + size;
 			j = bj + size;

--- a/src/utils/sequence-matcher.ts
+++ b/src/utils/sequence-matcher.ts
@@ -1,0 +1,280 @@
+/**
+ * Faithful TypeScript port of CPython's `difflib.SequenceMatcher`.
+ *
+ * Implements the Ratcliff/Obershelp pattern-matching algorithm with the
+ * "popular element" (autojunk) guard, so that `.ratio()` produces values
+ * identical to CPython 3.x for the BMP character content used by the
+ * fuzzy-match strategies. The thresholds in `src/utils/fuzzy-match.ts`
+ * (0.50 / 0.70 / 0.80) were tuned against CPython's exact `2*M/T` ratio
+ * formula, so substituting a Levenshtein-based library would silently
+ * break those thresholds.
+ *
+ * Porting notes:
+ * - Operates on **UTF-16 code units** (`s[i]`, `s.length`, `s.charCodeAt(i)`)
+ *   consistently throughout. CPython operates on Unicode code points; for
+ *   ASCII/BMP content the two coincide. Astral-plane characters (emoji)
+ *   consume two UTF-16 units, so ratios for emoji-heavy input may differ
+ *   marginally from CPython. This is acceptable for the fuzzy-match use
+ *   case (source-code patches) and is round-trip-safe — no index mixing,
+ *   no file corruption.
+ * - `autojunk` defaults to `true`, matching CPython. When `b.length >= 200`
+ *   and an element appears more than 1% of the time in `b`, it is treated
+ *   as "popular" and excluded as an anchor candidate in `find_longest_match`.
+ *   This is essential for ratio fidelity on real file sections.
+ */
+
+export interface Match {
+	/** Start index in sequence `a`. */
+	a: number;
+	/** Start index in sequence `b`. */
+	b: number;
+	/** Length of the matching block. */
+	size: number;
+}
+
+export type OpcodeTag = 'equal' | 'replace' | 'delete' | 'insert';
+
+export interface Opcode {
+	tag: OpcodeTag;
+	i1: number;
+	i2: number;
+	j1: number;
+	j2: number;
+}
+
+/** A predicate that marks a character as "junk" (never a sync point). */
+export type IsJunk = ((ch: string) => boolean) | null;
+
+/**
+ * Difflib-compatible sequence matcher. Construct with two strings, then
+ * call `.ratio()`, `.get_matching_blocks()`, or `.get_opcodes()`.
+ */
+export class SequenceMatcher {
+	private a: string;
+	private b: string;
+	private isJunk: IsJunk;
+	private autoJunk: boolean;
+
+	// `b2j[ch]` = array of indices in `b` where `ch` occurs (non-junk only).
+	private b2j: Map<string, number[]> = new Map();
+	// Characters treated as "popular" (heuristic) — excluded from anchoring.
+	private popularSet: Set<string> = new Set();
+	// Cached matching blocks.
+	private matchingBlocks: Match[] | null = null;
+
+	constructor(isJunk: IsJunk, a: string, b: string, autoJunk = true) {
+		this.a = a;
+		this.b = b;
+		this.isJunk = isJunk;
+		this.autoJunk = autoJunk;
+		this.chainB();
+	}
+
+	/** Allow changing the input sequences (mirrors CPython `set_seqs`/`set_seq2`). */
+	setSeqs(a: string, b: string): void {
+		this.a = a;
+		this.b = b;
+		this.matchingBlocks = null;
+		this.chainB();
+	}
+
+	/** Precompute the `b` index map and the popular-element set. */
+	private chainB(): void {
+		const b = this.b;
+		const b2j: Map<string, number[]> = new Map();
+		for (let i = 0; i < b.length; i++) {
+			const ch = b[i];
+			const positions = b2j.get(ch);
+			if (positions === undefined) {
+				b2j.set(ch, [i]);
+			} else {
+				positions.push(i);
+			}
+		}
+
+		// Remove junk elements from b2j.
+		if (this.isJunk) {
+			const junk: string[] = [];
+			for (const ch of b2j.keys()) {
+				if (this.isJunk(ch)) junk.push(ch);
+			}
+			for (const ch of junk) b2j.delete(ch);
+		}
+
+		// Popular heuristic: for long `b`, mark elements appearing > 1% of the
+		// time as popular and purge them from the index. This prevents
+		// pathological O(n*m) behavior on sequences dominated by a few
+		// repeated tokens (e.g. whitespace in source files). CPython applies
+		// this when `autojunk=true` (the default) and `len(b) >= 200`.
+		this.popularSet = new Set();
+		if (this.autoJunk && b.length >= 200) {
+			const threshold = b.length * 0.01 + 0.5;
+			const popular: string[] = [];
+			for (const [ch, indices] of b2j) {
+				if (indices.length > threshold) {
+					popular.push(ch);
+				}
+			}
+			for (const ch of popular) {
+				this.popularSet.add(ch);
+				b2j.delete(ch);
+			}
+		}
+		this.b2j = b2j;
+	}
+
+	/**
+	 * Find the longest matching block in `a[alo:ahi]` and `b[blo:bhi]`.
+	 *
+	 * Returns `{ a, b, size }` where `size` is maximal; ties are broken by
+	 * smallest `a`, then smallest `b` (CPython canonical tiebreak).
+	 *
+	 * A "match" means `a[i] === b[j]` and the run extends as far as possible.
+	 * Elements in the popular set are only used as anchor candidates when no
+	 * non-popular match exists (CPython behavior: popular elements are
+	 * excluded from `b2j`, so they only match opportunistically via the
+	 * extending run after a non-popular anchor).
+	 */
+	findLongestMatch(alo: number, ahi: number, blo: number, bhi: number): Match {
+		const a = this.a;
+		const b = this.b;
+		const b2j = this.b2j;
+
+		let bestI = alo;
+		let bestJ = blo;
+		let bestSize = 0;
+
+		// `j2len[j+1]` = length of the longest match ending at `a[i-1], b[j]`.
+		// Using a Map instead of CPython's array for sparse efficiency.
+		const j2len: Map<number, number> = new Map();
+
+		// CPython semantics: popular elements are removed from `b2j` and are
+		// NOT re-anchored in `findLongest_match`. They can still extend an
+		// existing run started by a non-popular anchor (via the DP `j2len`
+		// carry) but they do not initiate matches. We intentionally skip
+		// characters whose only presence is in `popularSet`. This is what
+		// produces ratio divergence between `autojunk=true|false` and is
+		// essential for threshold fidelity on long file sections.
+		for (let i = alo; i < ahi; i++) {
+			const ch = a[i];
+			const positions = b2j.get(ch);
+			if (positions === undefined) {
+				// `ch` is either junk, popular, or absent from b. In all three
+				// cases it cannot anchor a new match this iteration. The DP
+				// row simply resets (newJ2len stays empty).
+				j2len.clear();
+				continue;
+			}
+			const newJ2len: Map<number, number> = new Map();
+			// Iterate positions in `b` where `ch` occurs, within [blo, bhi).
+			for (const j of positions) {
+				if (j < blo) continue;
+				if (j >= bhi) break;
+				const k = j2len.get(j - 1) ?? 0;
+				const size = k + 1;
+				newJ2len.set(j, size);
+				if (size > bestSize) {
+					bestI = i - size + 1;
+					bestJ = j - size + 1;
+					bestSize = size;
+				}
+			}
+			j2len.clear();
+			for (const [k, v] of newJ2len) j2len.set(k, v);
+		}
+
+		// Extend the best match backward and forward over equal characters
+		// (CPython does this to coalesce adjacent equal runs that the
+		// dynamic-programming scan didn't merge).
+		while (
+			bestI > alo &&
+			bestJ > blo &&
+			a[bestI - 1] === b[bestJ - 1]
+		) {
+			bestI--;
+			bestJ--;
+			bestSize++;
+		}
+		while (
+			bestI + bestSize < ahi &&
+			bestJ + bestSize < bhi &&
+			a[bestI + bestSize] === b[bestJ + bestSize]
+		) {
+			bestSize++;
+		}
+
+		return { a: bestI, b: bestJ, size: bestSize };
+	}
+
+	/** Recursively compute the list of matching blocks (descending order). */
+	getMatchingBlocks(): Match[] {
+		if (this.matchingBlocks !== null) return this.matchingBlocks;
+
+		const la = this.a.length;
+		const lb = this.b.length;
+		const matches: Match[] = [];
+
+		const stack: Array<[number, number, number, number]> = [
+			[0, la, 0, lb],
+		];
+		while (stack.length > 0) {
+			const [alo, ahi, blo, bhi] = stack.pop()!;
+			const m = this.findLongestMatch(alo, ahi, blo, bhi);
+			const { a: i, b: j, size } = m;
+			if (size > 0) {
+				matches.push(m);
+				if (alo < i && blo < j) stack.push([alo, i, blo, j]);
+				if (i + size < ahi && j + size < bhi) {
+					stack.push([i + size, ahi, j + size, bhi]);
+				}
+			}
+		}
+		// Sort by `a` ascending (CPython does this via the recursion order;
+		// we sort defensively since our stack is LIFO).
+		matches.sort((x, y) => x.a - y.a || x.b - y.b);
+		// Append the terminal sentinel.
+		matches.push({ a: la, b: lb, size: 0 });
+		this.matchingBlocks = matches;
+		return matches;
+	}
+
+	/**
+	 * Return a float in [0, 1]: `2*M / T`, where `M` is the total matched
+	 * characters and `T` is the sum of the two sequence lengths.
+	 * Returns `1.0` when both sequences are empty (matches CPython).
+	 */
+	ratio(): number {
+		const matches = this.getMatchingBlocks();
+		let m = 0;
+		for (const block of matches) m += block.size;
+		const t = this.a.length + this.b.length;
+		if (t === 0) return 1.0;
+		return (2.0 * m) / t;
+	}
+
+	/** Compute the opcodes describing how to turn `a` into `b`. */
+	getOpcodes(): Opcode[] {
+		const blocks = this.getMatchingBlocks();
+		const opcodes: Opcode[] = [];
+		let i = 0;
+		let j = 0;
+		for (const block of blocks) {
+			const { a: ai, b: bj, size } = block;
+			// Emit replace/delete/insert for the gap before this equal block.
+			if (i < ai && j < bj) {
+				opcodes.push({ tag: 'replace', i1: i, i2: ai, j1: j, j2: bj });
+			} else if (i < ai) {
+				opcodes.push({ tag: 'delete', i1: i, i2: ai, j1: j, j2: bj });
+			} else if (j < bj) {
+				opcodes.push({ tag: 'insert', i1: i, i2: ai, j1: j, j2: bj });
+			}
+			// Emit equal for the block itself (size 0 on the sentinel → skipped).
+			if (size > 0) {
+				opcodes.push({ tag: 'equal', i1: ai, i2: ai + size, j1: bj, j2: bj + size });
+			}
+			i = ai + size;
+			j = bj + size;
+		}
+		return opcodes;
+	}
+}

--- a/tests/unit/hooks/knowledge-injector-drift-adversarial.test.ts
+++ b/tests/unit/hooks/knowledge-injector-drift-adversarial.test.ts
@@ -132,6 +132,7 @@ mock.module('../../../src/config/schema.js', () => ({
 	AdversarialTestingConfigSchema: zodStub,
 	AgentAuthorityRuleSchema: zodStub,
 	AgentOverrideConfigSchema: zodStub,
+	ApplyPatchConfigSchema: zodStub,
 	AgentReasoningConfigSchema: zodStub,
 	AgentThinkingConfigSchema: zodStub,
 	ArchitecturalSupervisionConfigSchema: zodStub,

--- a/tests/unit/hooks/knowledge-injector.adversarial.test.ts
+++ b/tests/unit/hooks/knowledge-injector.adversarial.test.ts
@@ -181,6 +181,7 @@ mock.module('../../../src/config/schema.js', () => ({
 	AdversarialTestingConfigSchema: zodStub,
 	AgentAuthorityRuleSchema: zodStub,
 	AgentOverrideConfigSchema: zodStub,
+	ApplyPatchConfigSchema: zodStub,
 	AgentReasoningConfigSchema: zodStub,
 	AgentThinkingConfigSchema: zodStub,
 	ArchitecturalSupervisionConfigSchema: zodStub,


### PR DESCRIPTION
# feat(apply-patch): opt-in fuzzy text-matching fallback (port hermes 9-strategy chain)

Closes #1718

## Summary

Ports hermes-agent's proven 9-strategy fuzzy text-matching chain as an **opt-in fallback** in `apply-patch`. The current exact-match-only behavior (the deliberate "B3 decision") is preserved as the default — fuzzy matching only activates when the new config flags are set.

LLM-proposed patches frequently drift from file text in trailing whitespace, indentation, escape sequences (`\t` vs real tab), and Unicode lookalikes (smart quotes, em-dashes). The exact-match default rejected these, forcing costly retries. This fallback salvages such edits while keeping the safe default intact.

**What changed:**
- New `src/utils/sequence-matcher.ts` — faithful TypeScript port of CPython's `difflib.SequenceMatcher` (Ratcliff/Obershelp + the autojunk/popular-element guard), so the fuzzy thresholds produce ratios matching Python's `2M/T` formula for ASCII/BMP content.
- New `src/utils/fuzzy-match.ts` — the 9-strategy chain (exact, line-trimmed, whitespace-normalized, indentation-flexible, escape-normalized, trimmed-boundary, unicode-normalized, block-anchor, context-aware) plus the ambiguity guard, escape-drift guard, selective `\t`/`\r` unescape, Unicode preservation, and indent re-alignment. Strategy 9 is bounded by an internal cell-count cap to prevent quadratic-cost hangs on large files.
- 3 test files (split for the FR-006 500-line cap) porting the hermes 668-line suite: `sequence-matcher.test.ts` (168 lines, 22 cases), `fuzzy-match.test.ts` (321 lines, 31 cases), `fuzzy-match-2.test.ts` (268 lines, 25 cases).
- `docs/releases/pending/1718-apply-patch-fuzzy-match.md` — release fragment.

**Modified files:**
- `src/config/schema.ts` — new `ApplyPatchConfigSchema` (`fuzzy_match`, `fuzzy_match_context_aware`, both default `false`) registered as `apply_patch:` in `PluginConfigSchema`.
- `src/config/index.ts` — re-export the schema + type.
- `src/tools/apply-patch.ts` — `_internals` config-load DI seam (AGENTS.md invariant 7); `applyHunks` gains an optional `ApplyHunksOptions` param; fuzzy fallback fires at the `!matchFound` branch **only when the flag is set**; on fuzzy-fail, a "did you mean?" hint is appended to the diagnostic.
- `src/tools/apply-patch.test.ts` — 8 hermetic integration tests via the `_internals` seam.

**Design contract:**
- **Default unchanged.** `apply_patch.fuzzy_match` defaults to `false`. With it off, the fuzzy branch is unreachable (the `else if (options?.fuzzyMatch)` guard is a no-op when `options` is `undefined`).
- **Two flags.** `fuzzy_match` (strategies 1-8) and `fuzzy_match_context_aware` (strategy 9, the loosest). Strategy 9 is separately gated and only effective when `fuzzy_match` is also true.
- **Byte-faithful port.** The SequenceMatcher ratios are validated against hand-computed CPython `difflib` reference values (including the autojunk edge case). The ported test suite is the acceptance gate.

## Invariant audit
- 1 (plugin init): not touched — fuzzy-match loaded lazily inside apply-patch execute; no init-path work.
- 2 (runtime portability): touched — new TS source only, no Bun-only APIs, no `bun:` imports. Validated by `node --input-type=module` import test post-build.
- 3 (subprocesses): not touched.
- 4 (.swarm containment): not touched.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — shell `bun test <file>`, not the tool.
- 7 (test writing): touched — bun:test, `_internals` seam for config DI (no mock.module), each new test file <500 lines (168/321/268).
- 8 (session state): not touched.
- 9 (guardrails): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no new tool/agent-map. apply-patch already registered.
- 12 (release/cache): touched — release-notes fragment per convention; no version bump (release-please owns).

## Test plan

All run from the repo root on this branch:

```
$ bun test src/utils/__tests__/fuzzy-match.test.ts src/utils/__tests__/fuzzy-match-2.test.ts src/utils/__tests__/sequence-matcher.test.ts src/tools/apply-patch.test.ts
  119 pass / 0 fail (317 expect() calls)

$ bunx biome ci .     # biome ci (CI mode) — clean, 0 errors
$ bun run typecheck   # tsc --noEmit — clean
$ bun run build       # succeeds
$ node --input-type=module -e "await import('./dist/index.js')"  # plugin loads under Node ESM
$ bun test tests/unit/config/   # 1619 pass — config schema intact
```

The 33 pre-existing apply-patch tests pass unchanged, proving no regression on the default path. The 8 new integration tests prove: default-off is unchanged, fuzzy-on tolerates drift (via a genuine fuzzy strategy, not a substring-exact false positive), strategy-9 is separately gated (positive-direction test: fails without the flag, succeeds with it), the "did you mean?" hint fires on fuzzy-fail, the escape-drift guard fires through the integration path, multi-hunk patches with one fuzzy + one exact hunk both apply, and the multi-hunk no-corruption invariant holds.

### Swarm review + feedback
This PR went through a full swarm review (`swarm-pr-review`) and feedback cycle (`swarm-pr-feedback`). The review produced 18 candidate findings; after independent reviewer validation (GLM-5.2) and a critic challenge (GLM-5.2), 15 were confirmed VALID and fixed in this commit, 3 were rejected as false positives (PRR-004/012/013 — documented in the closure ledger). The highest-value finding (PRR-005: strategy-9 quadratic DoS, empirically benchmarked at a 3.8-minute hang on a 50k-line file) is addressed by an internal `CONTEXT_AWARE_MAX_CELLS` cap.

## Known caveats (documented in code comments + release notes)

1. Fuzzy is a per-hunk tolerance layer, not a whole-diff position searcher. Multi-hunk patches where a fuzzy relocation overlaps a later hunk's context will still report a clean context-mismatch on that later hunk (no corruption).
2. The selective `\r` unescape path is inert under apply-patch (content is LF-normalized before matching); remains active at the utility level.
3. Operates on UTF-16 code units; astral-plane (emoji) content is round-trip-safe but ratios may differ marginally from CPython code-point semantics.
4. Unicode preservation is fully effective for strategy 7; for strategies 8/9 it is best-effort (narrow residual clobber risk on doubly-opt-in path).
