### PR TITLE
fix(tests): pay down knowledge-test quarantine debt and add CI portability lints (#1737)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,15 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         if: github.event_name == 'pull_request'
         with:
-          # Full history needed to diff base...head reliably (shallow clones
-          # can miss the merge-base). Matches drift-check.yml's convention.
+          # Full history needed so both BASE_SHA and HEAD_SHA below are
+          # guaranteed present locally for a plain two-dot `git diff` (a
+          # shallow clone can miss one of them, especially BASE_SHA on a
+          # long-lived PR). Two-dot, not three-dot/merge-base: this only
+          # needs "what changed between these two exact commits," and
+          # two-dot's tendency to also include unrelated upstream churn is
+          # the safe-direction failure mode here — it can only make this
+          # detector MORE likely to opt into the fuller matrix, never less.
+          # Matches drift-check.yml's fetch-depth: 0 convention.
           fetch-depth: 0
       # Single unconditional step (not split by event type) so the job-level
       # `outputs:` above always resolves from this one step's ID, regardless

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,22 +112,31 @@ jobs:
           set -euo pipefail
           # Only pull_request has a meaningful base...head diff to inspect
           # here; merge_group already gets the full 3-OS matrix unconditionally
-          # via the separate `github.event_name == 'merge_group'` branch in the
+          # via the separate github.event_name == 'merge_group' branch in the
           # unit job's matrix expression, so this output doesn't need to (and
           # can't, without a PR base/head pair) do anything for that event.
           if [ "$EVENT" != "pull_request" ]; then
             echo "touches-platform-paths=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "")"
           # Platform-sensitive: worktree/sandbox/plan isolation logic, the lean
           # turbo runner (where issue #1737's A1 macOS-only bug lives),
           # src/parallel (lock-directory creation / EACCES semantics — the
           # confirmed root cause of A2a's read-only-.swarm cross-platform
           # bug, added after a test-engineer review caught it missing from
           # the original 5-prefix list), CI scripts, and the workflow files
-          # themselves.
-          if echo "$changed" | grep -qE '^(src/worktree/|src/turbo/|src/sandbox/|src/plan/|src/parallel/|scripts/|\.github/workflows/)'; then
+          # themselves. Piped directly rather than captured into a variable
+          # first. Deliberately grep -E redirected to /dev/null below, and
+          # NOT grep -q: under set -o pipefail, grep -q exits as soon as it
+          # sees the first match and closes its stdin, which can send
+          # SIGPIPE to a still-writing git diff upstream on a large diff —
+          # pipefail then reports that SIGPIPE (128+13=141) as the
+          # pipeline's exit status, making this if silently false even
+          # though a match occurred (the unsafe direction — it would drop
+          # platform-path PRs to the ubuntu-only matrix). grep without -q
+          # or -m reads its input to EOF before exiting, so git diff always
+          # finishes writing normally and no SIGPIPE is possible.
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null | grep -E '^(src/worktree/|src/turbo/|src/sandbox/|src/plan/|src/parallel/|scripts/|\.github/workflows/)' >/dev/null; then
             echo "touches-platform-paths=true" >> "$GITHUB_OUTPUT"
           else
             echo "touches-platform-paths=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,24 @@ jobs:
         if: needs.detect-release.outputs.is-release != 'true'
         shell: bash
         run: chmod +x scripts/check-test-file-cap.sh && bash scripts/check-test-file-cap.sh
+      # Line-scoped (not file-scoped): fails only on NEW/changed lines that add
+      # a raw tmpdir() call not wrapped in realpathSync. Pre-existing raw calls
+      # elsewhere in a touched file are not flagged (issue #1737 FR-011 scope
+      # decision — retrofitting the ~250 pre-existing occurrences is out of
+      # scope). Prefer tests/helpers/tmpdir.ts (canonicalTmpDir/canonicalMkdtemp).
+      - name: Test tmpdir canonicalization lint (FR-011)
+        if: needs.detect-release.outputs.is-release != 'true'
+        shell: bash
+        run: chmod +x scripts/check-test-tmpdir.sh && bash scripts/check-test-tmpdir.sh
+      # Not diff-scoped (unlike the sibling checks above): a bash4+-only
+      # construct is exactly as broken on macOS as it was the day it was
+      # added, so this scans full current file content in scripts/, not just
+      # the diff (issue #1737 FR-012 — prevents recurrence of the
+      # check-invariants.sh `declare -A` incident, issue #1729).
+      - name: Bash portability lint (FR-012)
+        if: needs.detect-release.outputs.is-release != 'true'
+        shell: bash
+        run: chmod +x scripts/check-bash-portability.sh && bash scripts/check-bash-portability.sh
 
   # Two-tier CI: on pull_request, run ubuntu-only with 4 shards for fast feedback.
   # On merge_group (merge queue), run the full 3-OS matrix for merge safety.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,70 @@ jobs:
           BRANCH: ${{ github.head_ref }}
           EVENT: ${{ github.event_name }}
 
+  # Issue #1737 FR-013: closes the root cause of the #1729 debt-accumulation
+  # episode — pull_request CI ran ubuntu-only, so macOS/Windows-only failures
+  # were invisible until a merge_group bounce. This job detects whether the PR
+  # diff touches platform-sensitive paths and, if so, the `unit` job below
+  # automatically runs the full 3-OS matrix on pull_request too (previously
+  # only merge_group did). Modeled on the detect-release job above (fast,
+  # single ubuntu-latest job producing a boolean output the matrix consumes).
+  # No job-level `if:` here (unlike detect-release's own guard on its
+  # checkout step, not itself) — matching the established quality/unit
+  # pattern where downstream jobs never skip at the job level, only steps
+  # skip individually. A job-level `if:` here would report this job as
+  # "skipped" (not "success") on release-please branches, and by default
+  # `needs:` treats a skipped dependency as not-satisfied, which would
+  # cascade to skip the entire `unit` job on every release branch — release
+  # branches would then never even report the required `unit (*, N)` checks.
+  detect-paths:
+    needs: [detect-release]
+    runs-on: ubuntu-latest
+    outputs:
+      touches-platform-paths: ${{ steps.check.outputs.touches-platform-paths }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: github.event_name == 'pull_request'
+        with:
+          # Full history needed to diff base...head reliably (shallow clones
+          # can miss the merge-base). Matches drift-check.yml's convention.
+          fetch-depth: 0
+      # Single unconditional step (not split by event type) so the job-level
+      # `outputs:` above always resolves from this one step's ID, regardless
+      # of event — a prior split-step version left `steps.check` unset (and
+      # the job output empty) on non-pull_request events, since a step whose
+      # own `if:` is false produces no outputs at all, not empty-string ones.
+      - name: Detect platform-sensitive path changes
+        id: check
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Only pull_request has a meaningful base...head diff to inspect
+          # here; merge_group already gets the full 3-OS matrix unconditionally
+          # via the separate `github.event_name == 'merge_group'` branch in the
+          # unit job's matrix expression, so this output doesn't need to (and
+          # can't, without a PR base/head pair) do anything for that event.
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "touches-platform-paths=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "")"
+          # Platform-sensitive: worktree/sandbox/plan isolation logic, the lean
+          # turbo runner (where issue #1737's A1 macOS-only bug lives),
+          # src/parallel (lock-directory creation / EACCES semantics — the
+          # confirmed root cause of A2a's read-only-.swarm cross-platform
+          # bug, added after a test-engineer review caught it missing from
+          # the original 5-prefix list), CI scripts, and the workflow files
+          # themselves.
+          if echo "$changed" | grep -qE '^(src/worktree/|src/turbo/|src/sandbox/|src/plan/|src/parallel/|scripts/|\.github/workflows/)'; then
+            echo "touches-platform-paths=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "touches-platform-paths=false" >> "$GITHUB_OUTPUT"
+          fi
+
   quality:
     needs: [detect-release]
     runs-on: ubuntu-latest
@@ -137,18 +201,21 @@ jobs:
         shell: bash
         run: chmod +x scripts/check-bash-portability.sh && bash scripts/check-bash-portability.sh
 
-  # Two-tier CI: on pull_request, run ubuntu-only with 4 shards for fast feedback.
-  # On merge_group (merge queue), run the full 3-OS matrix for merge safety.
-  # On release-please branches, all steps are skipped via detect-release job
-  # (version bumps don't need tests — applies to both PR and merge-queue tiers).
-  # Test files are discovered automatically via find and distributed round-robin
-  # across shards — no hardcoded file lists, no duplication.
+  # Two-tier CI: on pull_request, run ubuntu-only with 4 shards for fast feedback
+  # UNLESS the diff touches a platform-sensitive path (issue #1737 FR-013,
+  # detect-paths job above), in which case the full 3-OS matrix runs on
+  # pull_request too. On merge_group (merge queue), the full 3-OS matrix
+  # always runs for merge safety. On release-please branches, all steps are
+  # skipped via detect-release job (version bumps don't need tests — applies
+  # to both PR and merge-queue tiers). Test files are discovered automatically
+  # via find and distributed round-robin across shards — no hardcoded file
+  # lists, no duplication.
   unit:
-    needs: [detect-release, quality]
+    needs: [detect-release, quality, detect-paths]
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'merge_group' && fromJSON('["ubuntu-latest","macos-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        os: ${{ (github.event_name == 'merge_group' || needs.detect-paths.outputs.touches-platform-paths == 'true') && fromJSON('["ubuntu-latest","macos-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
         shard: [1, 2, 3, 4, 5, 6]
     runs-on: ${{ matrix.os }}
     # 40m: was 90m before sharding (PR #1245). Issue #1778 H4 wired the
@@ -304,11 +371,33 @@ jobs:
       # budget — ~30-35 min in practice, intermittently timing out and blocking
       # the merge queue (PR #1573). It now lives in the dedicated `coverage` job
       # below so the full-suite run gets its own timeout and the unit cells stay
-      # fast. Blocking power is NOT automatic: nothing here `needs: coverage`, so
-      # the gate only blocks the queue once `coverage` is added to ruleset
-      # 17809658's required status checks. That must happen AFTER this lands on
-      # main (adding it earlier blocks other open PRs whose merge groups don't
-      # yet define this job). Until then the gate runs but does not block.
+      # fast. `coverage` is already enforced: it's a required status check in
+      # branch-protection ruleset 17809658 (confirmed active — issue #1737
+      # FR-014, correcting this comment, which previously and incorrectly
+      # described enforcement as still-pending).
+
+  # Issue #1737 FR-013: aggregate job so branch-protection ruleset 17809658 can
+  # require a single stable check name regardless of which OS cells the
+  # path-scoped conditional matrix above actually ran for a given PR — a
+  # per-cell required check (e.g. "unit (macos-latest, 1)") would never
+  # report at all on a PR where detect-paths decided macOS/Windows weren't
+  # needed, permanently blocking the merge queue for that PR. always() so this
+  # still runs (and can fail) even if a `unit` matrix cell failed upstream.
+  unit-passed:
+    needs: [unit]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check unit job result
+        shell: bash
+        env:
+          UNIT_RESULT: ${{ needs.unit.result }}
+        run: |
+          if [ "$UNIT_RESULT" != "success" ]; then
+            echo "::error::unit job result was '$UNIT_RESULT', not 'success'"
+            exit 1
+          fi
+          echo "All unit matrix cells that ran succeeded."
 
   # Merge-queue-only coverage gate. Runs the full unit suite once with coverage
   # and enforces the line-coverage threshold. Isolated from the `unit` job so the

--- a/docs/releases/pending/1737-quarantine-debt-and-ci-portability-lints.md
+++ b/docs/releases/pending/1737-quarantine-debt-and-ci-portability-lints.md
@@ -37,6 +37,28 @@
   aggregate job that checks `needs.unit.result` across the full matrix (not yet
   wired into branch protection — see Known caveats). Corrected a stale comment
   claiming the `coverage` check was not yet a required status check.
+- **`src/utils/swarm-artifact-cache.ts` / `src/evidence/task-file.ts`:** fixed a
+  lost-update bug (issue #1729 class) where `atomicWriteFile`'s stat-based cache
+  never invalidated on write. A same-size rewrite landing within one filesystem
+  timestamp tick of a prior cached read could produce an identical
+  mtime+ctime+size stamp, so a second locked read-modify-write immediately
+  following a write (e.g. `bumpKnowledgeConfidenceBatch`'s confidence-delta write
+  followed by its confidence-floor-flag transaction) would silently read the
+  pre-write content and clobber the just-committed value back to stale data.
+  Added `invalidateCachedArtifact()`, called from `atomicWriteFile` after every
+  successful write, closing the gap for all ~15 callers of the shared primitive.
+  Root-caused via `tests/unit/hooks/knowledge-floor-action.test.ts`'s "clears
+  stale confidence_floor_demoted flag on recovery above floor" case, which failed
+  deterministically (not flaky) on both this branch and clean `origin/main`.
+- **`src/turbo/lean/runner.ts`:** fixed a merge-back failure misclassification —
+  `_sequentialWorktreeCleanup` distinguished `'conflict'` from `'partial'` status
+  via `mergeResult.conflict === true`, but `attemptMergeBackFromDirty`'s
+  `DirtyMergePartial` result (`src/worktree/merge.ts`) never sets a `conflict`
+  field for a real conflict; it signals one via non-empty `conflictFiles` only.
+  Every dirty-worktree merge conflict reaching this path was reported as
+  `'partial'` instead of `'conflict'`. Root-caused via
+  `tests/unit/turbo/lean/integration-worktree.test.ts` AC-6, which also failed
+  deterministically on clean `origin/main`.
 
 ## New tests
 

--- a/docs/releases/pending/1737-quarantine-debt-and-ci-portability-lints.md
+++ b/docs/releases/pending/1737-quarantine-debt-and-ci-portability-lints.md
@@ -1,0 +1,61 @@
+# Pay down knowledge-test quarantine debt and add CI cross-platform lints (issue #1737)
+
+## What changed
+
+- **Phase 1 — quarantine debt:** fixed five genuinely broken knowledge-subsystem
+  tests that had been quarantined rather than fixed (`cleanup-drift.test.ts` drift
+  comment, `knowledge.adversarial.test.ts` missing `unarchiveEntry` mock,
+  `knowledge-injector-drift-adversarial.test.ts` missing `confirmEntriesPhase`/
+  `recordLessonsShown` stubs, `knowledge-recall.test.ts` hive-tier path and a stale
+  ranking assertion). All five are un-quarantined from
+  `scripts/ci/quarantined-tests.txt`.
+- **`tests/integration/phase-complete-events.adversarial.test.ts`:** corrected the
+  "read-only `.swarm` directory" test to match the actual documented split-fail
+  behavior — `events.jsonl` writes soft-fail with a warning, `plan.json` writes
+  fail closed (`success: false`) with a specific lock-failure message. The prior
+  assertions expected uniform fail-open behavior across both files.
+- **`src/hooks/system-enhancer.ts`:** the unified-injection-budget ledger write is
+  now guaranteed via a `finally` block, so a mid-flight exception no longer skips
+  the budget-ledger write. Added
+  `tests/unit/hooks/system-enhancer-budget-ledger-finally.test.ts` as a regression
+  test.
+- **`tests/helpers/tmpdir.ts` (new):** `canonicalTmpDir()` /
+  `canonicalMkdtemp(prefix)` helpers that resolve the macOS `/var` → `/private/var`
+  symlink gap, plus `scripts/check-test-tmpdir.sh`, a diff-scoped lint that flags
+  raw `tmpdir()` usage introduced in new/changed test-file lines.
+- **`scripts/check-bash-portability.sh` (new):** a full-scan lint for bash-4+-only
+  constructs (`declare/typeset/local/readonly -A`, `grep -P`/`--perl-regexp`,
+  `coproc`, `mapfile`/`readarray`) that are silently unsupported on macOS's system
+  bash (3.2). Prevents recurrence of the class of bug fixed in issue #1729.
+  `scripts/check-cross-contamination.sh` had one genuine pre-existing PCRE
+  violation (`grep -oP`), fixed to a POSIX-ERE equivalent.
+- **`.github/workflows/ci.yml`:** added a `detect-paths` job that path-scopes the
+  cross-OS (`macos-latest`/`windows-latest`) unit-test matrix to PRs that touch
+  platform-sensitive paths (`src/worktree/`, `src/turbo/`, `src/sandbox/`,
+  `src/plan/`, `src/parallel/`, `scripts/`, `.github/workflows/`) or to
+  `merge_group` runs, cutting matrix cost on unrelated PRs. Added a `unit-passed`
+  aggregate job that checks `needs.unit.result` across the full matrix (not yet
+  wired into branch protection — see Known caveats). Corrected a stale comment
+  claiming the `coverage` check was not yet a required status check.
+
+## New tests
+
+- `tests/unit/helpers/tmpdir.test.ts` — 6 cases for the new tmpdir helper.
+- `tests/unit/hooks/system-enhancer-budget-ledger-finally.test.ts` — reproduces
+  the missing-`finally` ledger-write bug via a marker-gated mock.
+
+## Migration
+
+No migration required.
+
+## Known caveats
+
+- The new `unit-passed` aggregate CI job is not yet added to the branch
+  protection ruleset's required checks, so it does not gate merges yet — this is
+  intentional, deferred to a follow-up change once this branch lands on `main`
+  (adding it now would break the merge queue for every other open PR, since the
+  check doesn't exist on `main` yet).
+- Several plan items from issue #1737 require live CI signal (a CI-only injection
+  budget test failure, remaining quarantined integration tests, and macOS
+  `provisionWorktree` root-cause diagnosis) and are intentionally left for
+  follow-up work once this PR provides that signal.

--- a/scripts/check-bash-portability.sh
+++ b/scripts/check-bash-portability.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Issue #1737 FR-012 — lint for bash-4+-only constructs in scripts/.
+#
+# Historic incident this prevents: scripts/check-invariants.sh used
+# `declare -A` (bash 4+ associative arrays), which silently died on macOS's
+# system bash (3.2, no associative array support) for months before it was
+# noticed (issue #1729). That script has since been fixed (indexed arrays,
+# no `grep -P`). This lint catches the same class of mistake recurring
+# anywhere else in scripts/.
+#
+# NOT diff-scoped, unlike scripts/check-test-tmpdir.sh: a bash4+ construct
+# is exactly as broken on macOS today as it was the day it was added — there
+# is no "pre-existing debt" carve-out reason here (confirmed during issue
+# #1737: no bash4+ constructs currently exist anywhere in scripts/, only
+# comments mentioning the terms as documentation of this exact constraint).
+# So this scans full current file content, not just the diff.
+#
+# Flagged constructs (each verified to be genuinely unsupported in bash 3.2,
+# the macOS system bash — not guessed):
+#   - `declare -A` — associative arrays, added in bash 4.0.
+#   - `grep -P` — PCRE support; BSD grep (macOS) has no -P flag at all.
+#   - `coproc` — coprocess keyword, added in bash 4.0.
+#   - `mapfile` / `readarray` — builtins added in bash 4.0 (synonyms).
+# NOT flagged: hex escapes like `\x27`. bash 3.2 DOES support `\xHH` inside
+# `$'...'` ANSI-C-quoted strings (that support predates 4.0) — the actual
+# check-invariants.sh incident was about `grep -P`'s `\x27`, not bash's own
+# string escaping, and that's already covered by the `grep -P` check above.
+# Flagging bare `\x` would false-positive on ordinary regex/string content.
+#
+# Portability of this script itself (it must run on the same macOS runner
+# it's protecting): bash 3.2 compatible — plain indexed arrays, grep -E only,
+# no `declare -A`, no `grep -P`. Verified by inspection (no bash 3.2 install
+# available on this dev machine to test directly): every construct used here
+# (arrays via `arr=(...)`/`"${arr[@]}"`, `[[ ]]`, `$(...)`, `grep -E`) is
+# bash 3.x-era syntax, matching the same idiom already proven in CI by the
+# sibling scripts (check-test-tmpdir.sh, check-test-clock.sh, etc.).
+set -euo pipefail
+
+violations=0
+violation_files=()
+
+# Every .sh file in scripts/ (recursively) — matches the set of shell scripts
+# that actually exist in this repo (confirmed via `find scripts/ -name '*.sh'`
+# during investigation: scripts/*.sh, scripts/ci/*.sh, scripts/lib/*.sh).
+while IFS= read -r file; do
+    file_has_violation=0
+
+    # Strip comment-only lines (leading whitespace then #) before matching —
+    # this script and several siblings document these exact constructs as
+    # things NOT to use, in comments; without this filter every such comment
+    # self-triggers as a false violation. This is a plain-text heuristic (no
+    # real bash parser available), same class of tradeoff as the substring
+    # matching in check-test-tmpdir.sh — it will not catch a construct
+    # deliberately hidden behind a trailing inline comment marker mid-line,
+    # but that's not a realistic authoring pattern for these constructs.
+    code_only="$(grep -vE '^[[:space:]]*#' "$file" || true)"
+
+    if echo "$code_only" | grep -qE 'declare[[:space:]]+-A'; then
+        echo "ERROR: $file uses \`declare -A\` (bash 4+ associative arrays) — not supported on macOS's bash 3.2."
+        echo "       Use a plain indexed array or parallel files instead (see scripts/check-invariants.sh for the established pattern)."
+        file_has_violation=1
+    fi
+
+    if echo "$code_only" | grep -qE '\bgrep\b[^|&;]*-[a-zA-Z]*P\b'; then
+        echo "ERROR: $file uses \`grep -P\` (PCRE support) — BSD grep on macOS has no -P flag."
+        echo "       Use \`grep -E\` with explicit alternation instead (see scripts/check-invariants.sh for the established pattern)."
+        file_has_violation=1
+    fi
+
+    if echo "$code_only" | grep -qE '(^|[^a-zA-Z0-9_])coproc([^a-zA-Z0-9_]|$)'; then
+        echo "ERROR: $file uses \`coproc\` (bash 4+ keyword) — not supported on macOS's bash 3.2."
+        file_has_violation=1
+    fi
+
+    if echo "$code_only" | grep -qE '(^|[^a-zA-Z0-9_])(mapfile|readarray)([^a-zA-Z0-9_]|$)'; then
+        echo "ERROR: $file uses \`mapfile\`/\`readarray\` (bash 4+ builtins) — not supported on macOS's bash 3.2."
+        echo "       Use a while-read loop instead (see scripts/check-invariants.sh for the established pattern)."
+        file_has_violation=1
+    fi
+
+    if [ "$file_has_violation" -eq 1 ]; then
+        violations=$((violations + 1))
+        violation_files+=("$file")
+    fi
+done < <(find scripts/ -name "*.sh" -type f ! -name "check-bash-portability.sh" 2>/dev/null)
+# Self-excluded: this script's own error-message text necessarily names the
+# constructs it detects (e.g. the literal string "declare -A" inside an echo
+# string), which would otherwise self-trigger every run. Its own source is
+# bash 3.2-compatible by construction (see the portability note above) and
+# was verified once by manual reasoning, not by running this checker on
+# itself.
+
+echo ""
+echo "=== Summary ==="
+echo "Files with bash4+-only constructs: $violations"
+
+if [ "$violations" -gt 0 ]; then
+    echo ""
+    echo "Violating files:"
+    for f in "${violation_files[@]}"; do
+        echo "  - $f"
+    done
+    exit 1
+fi
+
+echo "No bash4+-only constructs found in scripts/."

--- a/scripts/check-bash-portability.sh
+++ b/scripts/check-bash-portability.sh
@@ -17,8 +17,16 @@
 #
 # Flagged constructs (each verified to be genuinely unsupported in bash 3.2,
 # the macOS system bash — not guessed):
-#   - `declare -A` — associative arrays, added in bash 4.0.
-#   - `grep -P` — PCRE support; BSD grep (macOS) has no -P flag at all.
+#   - Associative arrays — `declare -A`/`typeset -A`/`local -A`/`readonly -A`
+#     (and flag-combined forms like `declare -gA`), added in bash 4.0. All
+#     four declaration keywords accept `-A`; catching only `declare -A` (the
+#     original cycle 1 implementation) missed `local -A`/`typeset -A`, which
+#     are equally common and equally broken on macOS's bash 3.2.
+#   - `grep -P` / `grep -Po` / `grep --perl-regexp` — PCRE support; BSD grep
+#     (macOS) has no -P flag at all, in any position or combination. Cycle 1's
+#     `-[a-zA-Z]*P\b` required P to be the LAST flag character, missing
+#     `-Po`/`-Pn`-style combinations where flags follow the P — verified via
+#     reviewer's independent re-derivation during issue #1737 review.
 #   - `coproc` — coprocess keyword, added in bash 4.0.
 #   - `mapfile` / `readarray` — builtins added in bash 4.0 (synonyms).
 # NOT flagged: hex escapes like `\x27`. bash 3.2 DOES support `\xHH` inside
@@ -55,14 +63,14 @@ while IFS= read -r file; do
     # but that's not a realistic authoring pattern for these constructs.
     code_only="$(grep -vE '^[[:space:]]*#' "$file" || true)"
 
-    if echo "$code_only" | grep -qE 'declare[[:space:]]+-A'; then
-        echo "ERROR: $file uses \`declare -A\` (bash 4+ associative arrays) — not supported on macOS's bash 3.2."
+    if echo "$code_only" | grep -qE '\b(declare|typeset|local|readonly)\b[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*\b'; then
+        echo "ERROR: $file uses an associative array (declare/typeset/local/readonly -A) — bash 4+ only, not supported on macOS's bash 3.2."
         echo "       Use a plain indexed array or parallel files instead (see scripts/check-invariants.sh for the established pattern)."
         file_has_violation=1
     fi
 
-    if echo "$code_only" | grep -qE '\bgrep\b[^|&;]*-[a-zA-Z]*P\b'; then
-        echo "ERROR: $file uses \`grep -P\` (PCRE support) — BSD grep on macOS has no -P flag."
+    if echo "$code_only" | grep -qE '\bgrep\b[^|&;]*(-[a-zA-Z]*P[a-zA-Z]*\b|--perl-regexp\b)'; then
+        echo "ERROR: $file uses \`grep -P\`/PCRE mode (any flag combination, or --perl-regexp) — BSD grep on macOS has no -P support at all."
         echo "       Use \`grep -E\` with explicit alternation instead (see scripts/check-invariants.sh for the established pattern)."
         file_has_violation=1
     fi

--- a/scripts/check-cross-contamination.sh
+++ b/scripts/check-cross-contamination.sh
@@ -33,7 +33,7 @@ for pair in "${PAIRS[@]}"; do
   bun --smol test "$file_a" "$file_b" --timeout 120000 > "$tmp" 2>&1 || exit_code=$?
 
   if [ $exit_code -ne 0 ]; then
-    actual=$(grep -oP '^\s*\d+ pass' "$tmp" | grep -oP '\d+' || echo "0")
+    actual=$(grep -oE '^[[:space:]]*[0-9]+ pass' "$tmp" | grep -oE '[0-9]+' || echo "0")
 
     if [ "$actual" -lt "$known_expected" ]; then
       # Pass count dropped below the known baseline — this is a NEW regression

--- a/scripts/check-test-tmpdir.sh
+++ b/scripts/check-test-tmpdir.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Issue #1737 FR-011 — lint for the macOS /var -> /private/var symlink gap.
+# `os.tmpdir()` returns a path under `/var/...` on macOS, but `/var` is itself
+# a symlink to `/private/var`; production code that canonicalizes paths (e.g.
+# containment guards) compares against the resolved `/private/var/...` form.
+# A test that creates a fixture via the raw path and checks it via the
+# canonicalized path silently diverges on macOS CI. tests/helpers/tmpdir.ts
+# (canonicalTmpDir / canonicalMkdtemp) exists so new tests don't reintroduce
+# this bug piecemeal.
+#
+# LINE-SCOPED (not file-scoped, unlike check-mock-cleanup.sh/check-test-clock.sh):
+# ingest found ~250 pre-existing raw os.tmpdir()/mkdtempSync() occurrences
+# across 30+ test files; retrofitting them is explicitly out of scope (FR-011
+# scope decision). A file-scoped check (flag the whole file if ANY PR touches
+# it) would false-fail on unrelated changes to those files. This check instead
+# diffs at the line level (`git diff --unified=0`) and only flags lines
+# ADDED by the current diff, so pre-existing raw calls elsewhere in a touched
+# file never trip it.
+#
+# A violation is an ADDED line calling `tmpdir()` — matching both `os.tmpdir()`
+# and the bare `tmpdir()` form used via `import { tmpdir } from 'node:os'`
+# (both idioms are in active use across tests/) — that does NOT also contain
+# `realpathSync` on the same line (the repo's established one-line idiom, e.g.
+# `fs.realpathSync(os.tmpdir())`). Prefer `canonicalTmpDir()` /
+# `canonicalMkdtemp(prefix)` from tests/helpers/tmpdir.ts instead of
+# hand-rolling the wrap.
+#
+# Deliberately NOT matched: a bare `mkdtempSync(...)` call whose argument does
+# not reference `tmpdir()` at all (e.g. a project-relative `mkdtempSync(path.
+# join('tmp', prefix))`) — that has nothing to do with the macOS symlink gap
+# this lint exists to catch, and flagging it would be a false positive. Any
+# `mkdtempSync(...)` call built from `tmpdir()` is still caught, because the
+# line then also matches the `tmpdir()` pattern above.
+#
+# KNOWN LIMITATION: Plain-text substring match, not syntax-aware, so `tmpdir()`
+# in string literals/comments also trips it. Accepted tradeoff for a portable bash
+# script (no JS/TS parser) — fails safe (over-flags) rather than silently missing
+# violations. Rephrase any false-positive string/comment to avoid the substring.
+#
+# Portability (issue #1729 merge_group macOS): bash 3.2 on macOS — no
+# associative arrays, no `grep -P`. Plain indexed arrays + grep -E only.
+set -euo pipefail
+
+violations=0
+
+# Resolve base branch (mirrors check-mock-cleanup.sh / check-test-clock.sh).
+base_branch=""
+for branch in origin/main origin/master main master; do
+    if git rev-parse "$branch" >/dev/null 2>&1; then
+        base_branch="$branch"
+        break
+    fi
+done
+
+if [ -z "$base_branch" ]; then
+    echo "check-test-tmpdir: no base branch found (no PR context) — skipping (non-blocking)."
+    exit 0
+fi
+
+# Unified=0 diff restricted to test files (tests/**/*.test.ts AND src/**/*.test.ts
+# both carry raw os.tmpdir()/mkdtempSync() usage per grep survey), so hunk
+# headers give exact added-line numbers with no surrounding context lines to
+# filter out.
+diff_output="$(git diff --unified=0 "$base_branch" HEAD -- '*.test.ts' 2>/dev/null || true)"
+
+if [ -z "$diff_output" ]; then
+    echo "check-test-tmpdir: no test file changes in diff — nothing to check."
+    exit 0
+fi
+
+current_file=""
+current_lineno=0
+
+while IFS= read -r line; do
+    case "$line" in
+        "+++ "*)
+            # "+++ b/path/to/file.ts" (or "+++ /dev/null" for deletions).
+            current_file="${line#+++ }"
+            current_file="${current_file#b/}"
+            continue
+            ;;
+        "@@ "*)
+            # "@@ -a,b +c,d @@ ..." — extract the new-file starting line c.
+            hunk_new="$(echo "$line" | grep -oE '\+[0-9]+' | head -1 | tr -d '+' || true)"
+            current_lineno="${hunk_new:-0}"
+            continue
+            ;;
+        "--- "*)
+            continue
+            ;;
+    esac
+
+    case "$line" in
+        "+"*)
+            content="${line#+}"
+            if echo "$content" | grep -qE 'tmpdir\(\)'; then
+                if ! echo "$content" | grep -q 'realpathSync'; then
+                    echo "ERROR: ${current_file}:${current_lineno} adds a raw tmpdir() call not wrapped in realpathSync."
+                    echo "       Use canonicalTmpDir() / canonicalMkdtemp(prefix) from tests/helpers/tmpdir.ts"
+                    echo "       (or wrap with fs.realpathSync(...) on the same line) to close the macOS"
+                    echo "       /var -> /private/var symlink gap. See FR-011 (issue #1737)."
+                    violations=$((violations + 1))
+                fi
+            fi
+            current_lineno=$((current_lineno + 1))
+            ;;
+    esac
+done <<< "$diff_output"
+
+echo ""
+echo "=== Summary ==="
+echo "New violations (blocking): $violations"
+
+if [ "$violations" -gt 0 ]; then
+    exit 1
+fi
+
+echo "All new/changed test-file tmpdir usage is canonicalized."

--- a/scripts/ci/quarantined-tests.txt
+++ b/scripts/ci/quarantined-tests.txt
@@ -5,12 +5,21 @@
 #
 # Merge-group flaky tests — surface only in the broader Windows/macOS/coverage
 # matrix (PR-branch ubuntu-only CI doesn't hit them). Pre-existing, unrelated
-# to any specific PR. Tracked for a dedicated test-stability sprint.
+# to any specific PR. Tracked under #1737 (test quarantine debt) pending a
+# dedicated test-stability sprint.
+# swarm-artifact-cache.test.ts: all assertions pass, but bun can exit
+# non-zero on Windows CI runners (e.g. AV holding a handle on the tmpdir
+# during afterEach's recursive rm) — a platform quirk, not a test-logic bug.
 tests/unit/utils/swarm-artifact-cache.test.ts
+# skill-scoring-workflow.test.ts: root-cause clock-freeze fix already applied
+# (see file header). Un-quarantine is intentionally gated on a confirmed-green
+# merge-group run across all 3 OSes per #1782, not just local passing —
+# tracked under #1737.
 tests/unit/hooks/skill-scoring-workflow.test.ts
 # Merge-group flaky test: test-runner.test.ts runs the real test-runner
 # tool against a fake Pester project (line 559-565 asserts parsed.success===true).
 # In the coverage context the subprocess behavior can return success=false
 # (environment-sensitive). Pre-existing, unrelated to any specific PR.
-# Tracked for a dedicated test-stability sprint.
+# Tracked under #1737 (test quarantine debt) pending a dedicated
+# test-stability sprint.
 tests/unit/tools/test-runner.test.ts

--- a/scripts/ci/quarantined-tests.txt
+++ b/scripts/ci/quarantined-tests.txt
@@ -3,15 +3,6 @@
 # Format: one repo-relative test file path per line. Blank lines and lines
 # starting with # are ignored.
 #
-tests/unit/commands/cleanup-drift.test.ts
-tests/unit/commands/knowledge.adversarial.test.ts
-tests/unit/hooks/knowledge-injector-drift-adversarial.test.ts
-tests/unit/hooks/knowledge-floor-action.test.ts
-tests/unit/tools/knowledge-recall.test.ts
-# Pre-existing failure: AC-6 conflict handling test fails on both Windows and
-# Ubuntu CI. The mergeLaneBranch conflict detection returns "partial" instead
-# of "conflict". Unrelated to PR #1704 changes. Tracked for separate fix.
-tests/unit/turbo/lean/integration-worktree.test.ts
 # Merge-group flaky tests — surface only in the broader Windows/macOS/coverage
 # matrix (PR-branch ubuntu-only CI doesn't hit them). Pre-existing, unrelated
 # to any specific PR. Tracked for a dedicated test-stability sprint.

--- a/src/evidence/task-file.ts
+++ b/src/evidence/task-file.ts
@@ -21,6 +21,7 @@
 import { renameSync, unlinkSync } from 'node:fs';
 import * as path from 'node:path';
 import { bunWrite } from '../utils/bun-compat';
+import { invalidateCachedArtifact } from '../utils/swarm-artifact-cache.js';
 import { withEvidenceLock } from './lock.js';
 
 /**
@@ -51,6 +52,13 @@ export const _internals = {
  * Atomic write: write to a unique temp file, then rename over the target.
  * The rename is atomic on POSIX and Windows, so readers never observe a torn
  * file. The temp file is cleaned up in `finally` (no-op once renamed away).
+ *
+ * Invalidates any swarm-artifact-cache entry for `targetPath` after a
+ * successful rename: the cache's stat-based staleness check can collide on a
+ * same-size rewrite that lands within one filesystem timestamp tick (issue
+ * #1729), which would otherwise let a read immediately following this write
+ * (e.g. a second locked transaction in the same logical operation) observe
+ * the pre-write content instead of what was just committed.
  */
 export async function atomicWriteFile(
 	targetPath: string,
@@ -67,6 +75,7 @@ export async function atomicWriteFile(
 			/* already renamed or never created */
 		}
 	}
+	invalidateCachedArtifact(targetPath);
 }
 
 /**

--- a/src/hooks/knowledge-validator.ts
+++ b/src/hooks/knowledge-validator.ts
@@ -1113,6 +1113,7 @@ export async function unarchiveEntry(
 	const knowledgePath = resolveSwarmKnowledgePath(directory);
 	const swarmDir = storeDir;
 
+	// Ensure .swarm store dir exists
 	await mkdir(swarmDir, { recursive: true });
 
 	let release: (() => Promise<void>) | undefined;

--- a/src/hooks/system-enhancer.ts
+++ b/src/hooks/system-enhancer.ts
@@ -644,6 +644,17 @@ export function createSystemEnhancerHook(
 				_input: { sessionID?: string; model?: unknown },
 				output: { system: string[] },
 			): Promise<void> => {
+				// FR-004: hoisted above the try/catch so the finally block below
+				// can always write the actual injected demand to the unified
+				// budget ledger, even if an exception is thrown after injection
+				// has already mutated output.system but before the normal
+				// finalize call sites (Path A / Path B) are reached. Without
+				// this, a mid-turn throw silently skips the ledger write and
+				// getSystemEnhancerDemand() fails open to 0 on the next read,
+				// letting combined injected tokens exceed a configured
+				// unified_injection_tokens ceiling.
+				let actualDemand = 0;
+				let unifiedBudget: number | undefined;
 				try {
 					// Skip swarm context injection for native opencode agents (build,
 					// plan, general, explore, compaction, title, summary). These agents
@@ -675,13 +686,13 @@ export function createSystemEnhancerHook(
 					const maxInjectionTokens =
 						config.context_budget?.max_injection_tokens ?? 4000;
 					let injectedTokens = 0;
-					let actualDemand = 0;
 
 					// FR-002: unified injection budget — use pure allocation so
 					// system-enhancer (system.transform) and knowledge-injector
 					// (messagesTransform) share a single ceiling.
+					// (actualDemand / unifiedBudget are declared outside the
+					// try/catch above — see FR-004 comment there.)
 					let seAllocation: number;
-					let unifiedBudget: number | undefined;
 					if (
 						config.context_budget?.unified_injection_tokens !== undefined &&
 						_input.sessionID
@@ -2487,6 +2498,17 @@ ${scopedHandoff.body}`;
 					}
 				} catch (error) {
 					warn('System enhancer failed:', error);
+				} finally {
+					// FR-004: guarantee the unified budget ledger reflects the actual
+					// injected demand for this turn even if the try block above threw
+					// after tryInject() already mutated output.system but before either
+					// the Path A or Path B finalize call sites were reached. Runs on
+					// every exit (normal return, Path A's early return, or exception)
+					// so knowledge-injector never reads a stale/absent demand entry.
+					if (unifiedBudget !== undefined && _input.sessionID) {
+						resetUnifiedBudget(_input.sessionID, unifiedBudget);
+						setSystemEnhancerDemand(_input.sessionID, actualDemand);
+					}
 				}
 			},
 		),

--- a/src/turbo/lean/runner.ts
+++ b/src/turbo/lean/runner.ts
@@ -1310,8 +1310,6 @@ export class LeanTurboRunner {
 						('partial' in mergeResult && mergeResult.partial)
 					) {
 						// Merge conflict or partial failure: log warning, do NOT remove worktree, record failure
-						const isConflict =
-							'conflict' in mergeResult && mergeResult.conflict === true;
 						const conflictFiles =
 							'conflictFiles' in mergeResult &&
 							Array.isArray(
@@ -1319,6 +1317,14 @@ export class LeanTurboRunner {
 							)
 								? (mergeResult as { conflictFiles: string[] }).conflictFiles
 								: [];
+						// attemptMergeBackFromDirty's DirtyMergePartial result never sets a
+						// `conflict` field (only mergeLaneBranch's MergeConflict does) — it
+						// signals a real conflict via non-empty `conflictFiles` instead. Without
+						// this, every dirty-worktree merge conflict was misclassified as
+						// 'partial' rather than 'conflict'.
+						const isConflict =
+							('conflict' in mergeResult && mergeResult.conflict === true) ||
+							conflictFiles.length > 0;
 						const reason =
 							('message' in mergeResult &&
 								typeof (mergeResult as { message?: unknown }).message ===

--- a/src/utils/swarm-artifact-cache.ts
+++ b/src/utils/swarm-artifact-cache.ts
@@ -253,6 +253,27 @@ export async function readCachedParsedFile<T>(
 	return cloneCachedValue(value);
 }
 
+/**
+ * Drop any cached text/parsed entries for `filePath` immediately after a write.
+ *
+ * The stat-based staleness check (mtimeMs + ctimeMs + size) is a best-effort
+ * optimization: a same-size rewrite that lands within one filesystem timestamp
+ * tick of a prior cached read can produce an identical stamp, so the very next
+ * read-your-own-write can silently return the pre-write value (issue #1729).
+ * Writers that read-modify-write the same path twice in quick succession (e.g.
+ * a second locked transaction immediately after an atomic write) MUST call
+ * this after the write so the next read cannot observe stale content —
+ * relying on stat-stamp comparison alone is not sufficient in that window.
+ */
+export function invalidateCachedArtifact(filePath: string): void {
+	const resolvedPath = path.resolve(filePath);
+	textCache.delete(resolvedPath);
+	const prefix = `${resolvedPath}\0`;
+	for (const key of parsedCache.keys()) {
+		if (key.startsWith(prefix)) parsedCache.delete(key);
+	}
+}
+
 export function resetSwarmArtifactCache(): void {
 	textCache.clear();
 	parsedCache.clear();

--- a/tests/helpers/tmpdir.ts
+++ b/tests/helpers/tmpdir.ts
@@ -1,0 +1,43 @@
+/**
+ * Canonical-tmpdir test helper for opencode-swarm (issue #1737, FR-011).
+ *
+ * Why this exists: `os.tmpdir()` on macOS returns a path under `/var/...`,
+ * but `/var` is itself a symlink to `/private/var`. Production code that
+ * canonicalizes paths (via `path.resolve`/`fs.realpathSync`, e.g. containment
+ * guards and boundary checks) compares against the resolved `/private/var/...`
+ * form. A test that creates a fixture via the raw `os.tmpdir()` path and later
+ * checks it via a canonicalized path silently diverges on macOS CI (the two
+ * strings differ even though they name the same directory) — the class of bug
+ * that was individually patched with ad hoc `fs.realpathSync(os.tmpdir())`
+ * calls across 20+ test files before this helper existed.
+ *
+ * Use these helpers instead of calling `os.tmpdir()` / `fs.mkdtempSync()`
+ * directly in new tests so the symlink gap can't be reintroduced.
+ * `scripts/check-test-tmpdir.sh` lints new/changed test lines for raw usage.
+ *
+ * Usage:
+ *   const base = canonicalTmpDir();
+ *   const dir = canonicalMkdtemp('my-test-');
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Returns the realpath-resolved system temp directory, closing the macOS
+ * `/var` -> `/private/var` symlink gap (and the Windows 8.3 short-name
+ * mismatch, e.g. `C:\Users\RUNNER~1` vs `C:\Users\runneradmin`).
+ */
+export function canonicalTmpDir(): string {
+	return fs.realpathSync(os.tmpdir());
+}
+
+/**
+ * Creates a unique subdirectory under `os.tmpdir()` via `fs.mkdtempSync` and
+ * returns its realpath-resolved form, so the caller gets a directory that is
+ * already symlink-safe with no separate `realpathSync` call needed downstream.
+ */
+export function canonicalMkdtemp(prefix: string): string {
+	const rawDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	return fs.realpathSync(rawDir);
+}

--- a/tests/integration/phase-complete-events.adversarial.test.ts
+++ b/tests/integration/phase-complete-events.adversarial.test.ts
@@ -327,7 +327,7 @@ describe('phase_complete integration — adversarial scenarios', () => {
 	});
 
 	describe('4. Read-only .swarm directory', () => {
-		it('should add warning, not crash when .swarm directory is read-only', async () => {
+		it('should not crash, but split behavior per lock: events.jsonl soft-fails with a warning, plan.json lock fail-closes to success:false', async () => {
 			// Skip on Windows as file permissions are different
 			if (process.platform === 'win32') {
 				return; // Test skipped on Windows
@@ -378,6 +378,9 @@ describe('phase_complete integration — adversarial scenarios', () => {
 			}
 
 			try {
+				// Does not throw — a read-only .swarm directory must not crash
+				// phase_complete, regardless of which write path ultimately
+				// reports success:false.
 				const result = await executePhaseComplete(
 					{
 						phase: 1,
@@ -388,17 +391,45 @@ describe('phase_complete integration — adversarial scenarios', () => {
 				);
 
 				const parsed = JSON.parse(result);
+				const diagnostic = () => JSON.stringify(parsed, null, 2);
 
-				// Should still succeed (write failure is non-blocking)
-				expect(parsed.success).toBe(true);
+				// phase_complete acquires two SEPARATE locks against .swarm, and
+				// neither writeRetro() nor writeGateEvidence() pre-creates
+				// .swarm/locks/, so both lock acquisitions attempt to mkdir it
+				// under the now-read-only .swarm and hit EACCES:
+				//
+				//   1. events.jsonl lock (append-only) — soft-fail by design.
+				//      The lock failure and the subsequent write failure are
+				//      both recorded as non-blocking warnings.
+				//   2. plan.json lock (read-modify-write) — fail-closed by
+				//      design (src/tools/phase-complete.ts, F-002 comment):
+				//      writing plan state without a lock risks a lost update /
+				//      corruption, so the EACCES here is NOT swallowed — it
+				//      aborts the call with success:false.
+				//
+				// The sibling test above (same fixture, writable .swarm)
+				// proves this fixture clears every earlier success:false gate
+				// (autonomous-oversight, missing agents, etc.) with
+				// success:true, so the only new differentiator when .swarm is
+				// read-only is the lock failure — attributing success:false
+				// here to the plan.json lock, not to an earlier gate.
 
-				// Should have a warning about write failure
-				expect(parsed.warnings.length).toBeGreaterThan(0);
+				// events.jsonl path: soft-fail, recorded as a warning.
+				expect(parsed.warnings.length, diagnostic()).toBeGreaterThan(0);
 				expect(
 					parsed.warnings.some((w: string) =>
 						w.includes('failed to write phase complete event'),
 					),
+					diagnostic(),
 				).toBe(true);
+
+				// plan.json path: fail-closed, success:false with a specific
+				// lock-acquisition-failure message (not a generic crash).
+				expect(parsed.success, diagnostic()).toBe(false);
+				expect(parsed.status, diagnostic()).toBe('incomplete');
+				expect(parsed.message, diagnostic()).toContain(
+					'Failed to acquire lock for plan.json',
+				);
 			} finally {
 				// Restore permissions for cleanup
 				fs.chmodSync(swarmDir, 0o755);

--- a/tests/security/ci-workflow-security.test.ts
+++ b/tests/security/ci-workflow-security.test.ts
@@ -66,7 +66,7 @@ class WorkflowSecurityTester {
 			'github.event.review',
 		];
 
-		function checkExpressions(obj, path = '') {
+		function checkExpressions(obj, path = '', inEnvBlock = false) {
 			if (typeof obj === 'string') {
 				// Check for expression syntax
 				const expressionRegex = /\$\{\{[^}]+\}\}/g;
@@ -76,6 +76,18 @@ class WorkflowSecurityTester {
 					for (const match of matches) {
 						for (const dangerousCtx of dangerousContexts) {
 							if (match.includes(dangerousCtx)) {
+								if (inEnvBlock) {
+									// Assigning a dangerous context to an `env:` var is
+									// GitHub's own recommended mitigation for expression
+									// injection (see "Using an intermediate environment
+									// variable" in GitHub's security-hardening docs): the
+									// value becomes a shell environment variable, not text
+									// spliced into the run: script, so it cannot alter the
+									// script's syntax. Still flag the same context when it
+									// appears directly inline (e.g. in a `run:` string),
+									// since that is the actually-dangerous placement.
+									continue;
+								}
 								result.passed = false;
 								result.issues.push({
 									location: path,
@@ -88,11 +100,15 @@ class WorkflowSecurityTester {
 				}
 			} else if (Array.isArray(obj)) {
 				obj.forEach((item, index) =>
-					checkExpressions(item, `${path}[${index}]`),
+					checkExpressions(item, `${path}[${index}]`, inEnvBlock),
 				);
 			} else if (obj && typeof obj === 'object') {
 				Object.keys(obj).forEach((key) =>
-					checkExpressions(obj[key], `${path}.${key}`),
+					checkExpressions(
+						obj[key],
+						`${path}.${key}`,
+						inEnvBlock || key === 'env',
+					),
 				);
 			}
 		}

--- a/tests/unit/commands/knowledge.adversarial.test.ts
+++ b/tests/unit/commands/knowledge.adversarial.test.ts
@@ -15,6 +15,14 @@ const mockQuarantineEntry = mock(
 	async (_dir: string, _id: string, _reason: string, _by: string) => undefined,
 );
 const mockRestoreEntry = mock(async (_dir: string, _id: string) => undefined);
+const mockUnarchiveEntry = mock(
+	async (_dir: string, _id: string) =>
+		({ restored: false, reason: 'not_found' }) as {
+			restored: boolean;
+			restored_to?: string;
+			reason?: 'not_found' | 'not_archived' | 'invalid_lesson';
+		},
+);
 const mockMigrateContextToKnowledge = mock(
 	async (_dir: string, _config: unknown) => ({
 		entriesMigrated: 5,
@@ -44,6 +52,7 @@ mock.module('../../../src/hooks/knowledge-store.js', () => ({
 mock.module('../../../src/hooks/knowledge-validator.js', () => ({
 	quarantineEntry: mockQuarantineEntry,
 	restoreEntry: mockRestoreEntry,
+	unarchiveEntry: mockUnarchiveEntry,
 	resolveUnactionablePath: (dir: string) =>
 		`${dir}/.swarm/knowledge-unactionable.jsonl`,
 }));
@@ -80,6 +89,7 @@ describe('Adversarial Security Tests for knowledge.ts', () => {
 	beforeEach(() => {
 		mockQuarantineEntry.mockClear();
 		mockRestoreEntry.mockClear();
+		mockUnarchiveEntry.mockClear();
 		mockMigrateContextToKnowledge.mockClear();
 		mockReadKnowledge.mockClear();
 	});
@@ -255,6 +265,10 @@ describe('Adversarial Security Tests for knowledge.ts', () => {
 			const error = new Error(
 				'EACCES: permission denied, open /etc/sensitive-config',
 			);
+			// handleKnowledgeRestoreCommand (G6 #1716) reads the swarm store first to
+			// check for an archived entry, then falls through to the quarantine store.
+			// No match in the swarm store routes this through the restoreEntry path.
+			mockReadKnowledge.mockResolvedValueOnce([]);
 			mockReadKnowledge.mockResolvedValueOnce([{ id: 'valid-id' }]);
 			mockRestoreEntry.mockImplementationOnce(async () => {
 				throw error;

--- a/tests/unit/helpers/tmpdir.test.ts
+++ b/tests/unit/helpers/tmpdir.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { canonicalMkdtemp, canonicalTmpDir } from '../../helpers/tmpdir';
+
+describe('canonicalTmpDir', () => {
+	it('returns the realpath-resolved system temp directory', () => {
+		expect(canonicalTmpDir()).toBe(fs.realpathSync(os.tmpdir()));
+	});
+
+	it('is already canonical (realpath is a no-op on the result)', () => {
+		const dir = canonicalTmpDir();
+		expect(fs.realpathSync(dir)).toBe(dir);
+	});
+});
+
+describe('canonicalMkdtemp', () => {
+	it('creates a directory that exists', () => {
+		const dir = canonicalMkdtemp('swarm-tmpdir-helper-test-');
+		try {
+			expect(fs.existsSync(dir)).toBe(true);
+			expect(fs.statSync(dir).isDirectory()).toBe(true);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('returns a directory whose name starts with the given prefix', () => {
+		const prefix = 'swarm-tmpdir-helper-prefix-';
+		const dir = canonicalMkdtemp(prefix);
+		try {
+			expect(path.basename(dir).startsWith(prefix)).toBe(true);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('returns an already realpath-resolved directory (no separate resolve needed)', () => {
+		const dir = canonicalMkdtemp('swarm-tmpdir-helper-realpath-');
+		try {
+			expect(fs.realpathSync(dir)).toBe(dir);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('creates the directory under the canonical tmp base', () => {
+		const dir = canonicalMkdtemp('swarm-tmpdir-helper-base-');
+		try {
+			const base = canonicalTmpDir();
+			expect(dir === base || dir.startsWith(base + path.sep)).toBe(true);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/unit/hooks/knowledge-injector-drift-adversarial.test.ts
+++ b/tests/unit/hooks/knowledge-injector-drift-adversarial.test.ts
@@ -45,9 +45,11 @@ mock.module('../../../src/hooks/curator-drift.js', () => ({
 }));
 mock.module('../../../src/hooks/knowledge-reader.js', () => ({
 	readMergedKnowledge,
+	recordLessonsShown: async () => {},
 }));
 mock.module('../../../src/hooks/knowledge-store.js', () => ({
 	readRejectedLessons,
+	confirmEntriesPhase: async () => {},
 	readKnowledge: async () => [],
 	readRetractionRecords: async () => [],
 	appendRetractionRecord: async () => {},

--- a/tests/unit/hooks/system-enhancer-budget-ledger-finally.test.ts
+++ b/tests/unit/hooks/system-enhancer-budget-ledger-finally.test.ts
@@ -1,0 +1,171 @@
+/**
+ * FR-004 regression test (issue #1737, task 2.2).
+ *
+ * The unified budget ledger write in system-enhancer.ts's hook body
+ * (`resetUnifiedBudget` + `setSystemEnhancerDemand`) must be unconditional:
+ * it must execute even when an exception is thrown AFTER `tryInject()` has
+ * already mutated `output.system` — i.e. real token budget has already been
+ * consumed — but BEFORE either finalize call site (Path A / Path B) is
+ * reached.
+ *
+ * Before the fix, such a mid-turn throw was caught by the hook's own inner
+ * `catch` (which just `warn()`s) and the ledger write was skipped entirely
+ * for that turn. `getSystemEnhancerDemand()` fails open to 0 on a
+ * missing/stale entry (src/services/injection-budget.ts), so
+ * knowledge-injector could then allocate against undercounted demand and
+ * push combined injected tokens past a configured `unified_injection_tokens`
+ * ceiling.
+ *
+ * This test forces that exact mid-turn throw (via a marker-gated mock of
+ * `extractPlanCursor`, which system-enhancer.ts calls uncaught right after
+ * its first successful `tryInject()` call) and asserts the ledger still
+ * reflects the real accumulated demand — not 0/absent — after the fix.
+ *
+ * Isolated in its own file (rather than folded into
+ * system-enhancer-budget.test.ts) because it uses `mock.module` on
+ * `hooks/extractors.js`, which — per the DI-seam comment in
+ * src/hooks/utils.ts — leaks across files in Bun's shared test-runner
+ * process. The throw is gated behind a unique marker string embedded only
+ * in this file's own fixture plan.md, so the mock is a no-op for every
+ * other test that happens to share the process.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { PluginConfig } from '../../../src/config';
+import * as realExtractors from '../../../src/hooks/extractors.js';
+import {
+	clearUnifiedBudget,
+	getSystemEnhancerDemand,
+	getUnifiedBudgetTotal,
+} from '../../../src/services/injection-budget.js';
+import { resetSwarmState } from '../../../src/state.js';
+
+const FORCE_THROW_MARKER = '__FR004_FORCE_LEDGER_THROW__';
+
+// Mocked BEFORE system-enhancer.ts is (lazily) required below, so the hook
+// body's `extractPlanCursor` import resolves to this wrapper. Every real
+// export is passed through untouched; only `extractPlanCursor` is wrapped,
+// and it only diverges from the real implementation when the fixture's
+// plan.md contains the marker string.
+mock.module('../../../src/hooks/extractors.js', () => ({
+	...realExtractors,
+	extractPlanCursor: (
+		planContent: string,
+		options?: { maxTokens?: number; lookaheadTasks?: number },
+	) => {
+		if (
+			typeof planContent === 'string' &&
+			planContent.includes(FORCE_THROW_MARKER)
+		) {
+			throw new Error(
+				'Simulated mid-turn exception after injection (FR-004 repro)',
+			);
+		}
+		return realExtractors.extractPlanCursor(planContent, options);
+	},
+}));
+
+function createRelativeTempDir(): string {
+	const baseDir = 'tmp';
+	if (!fs.existsSync(baseDir)) {
+		fs.mkdirSync(baseDir, { recursive: true });
+	}
+	return fs.mkdtempSync(path.join(baseDir, 'system-enhancer-ledger-finally-'));
+}
+
+// Loaded lazily via `require` (after the `mock.module` registration above
+// has already run at module-evaluation time) so the mocked extractors
+// module is guaranteed to be in place. Mirrors the pattern used in
+// system-enhancer-load-evidence.test.ts for the same reason.
+function getCreateSystemEnhancerHook(): typeof import('../../../src/hooks/system-enhancer.js').createSystemEnhancerHook {
+	return require('../../../src/hooks/system-enhancer.js')
+		.createSystemEnhancerHook;
+}
+
+const PLAN_JSON = JSON.stringify({
+	schema_version: '1.0.0',
+	swarm: 'ledger-finally-test',
+	title: 'Ledger Finally Test',
+	current_phase: 1,
+	phases: [{ id: 1, name: 'Phase 1', status: 'in_progress', tasks: [] }],
+});
+
+describe('system-enhancer budget ledger — unconditional write on mid-turn throw (FR-004)', () => {
+	let tempDir: string;
+	const sessionID = 'fr004-ledger-finally-session';
+
+	beforeEach(() => {
+		tempDir = createRelativeTempDir();
+		const swarmDir = path.join(tempDir, '.swarm');
+		fs.mkdirSync(swarmDir, { recursive: true });
+		fs.writeFileSync(path.join(swarmDir, 'plan.json'), PLAN_JSON);
+		// The marker forces the mocked extractPlanCursor to throw — but only
+		// AFTER the phase-header tryInject() above it in Path A has already
+		// pushed real content and consumed real budget.
+		fs.writeFileSync(
+			path.join(swarmDir, 'plan.md'),
+			`# Plan\n\n${FORCE_THROW_MARKER}\n`,
+		);
+		fs.writeFileSync(path.join(swarmDir, 'context.md'), '# Context\n');
+		resetSwarmState();
+		clearUnifiedBudget(sessionID);
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+		clearUnifiedBudget(sessionID);
+	});
+
+	it('writes the actual injected demand to the ledger even when the hook throws after injection', async () => {
+		const unifiedBudget = 4600; // below the combined SE (≤4000) + KI (≤~660) cap
+		const config: PluginConfig = {
+			max_iterations: 5,
+			qa_retry_limit: 3,
+			inject_phase_reminders: true,
+			context_budget: {
+				max_injection_tokens: 4000,
+				unified_injection_tokens: unifiedBudget,
+			},
+		};
+
+		const createSystemEnhancerHook = getCreateSystemEnhancerHook();
+		const hook = createSystemEnhancerHook(config, tempDir);
+		const transform = hook['experimental.chat.system.transform'] as (
+			input: { sessionID?: string },
+			output: { system: string[] },
+		) => Promise<void>;
+
+		const output = { system: [] as string[] };
+
+		// The simulated throw must not propagate out of the hook — the hook's
+		// own inner catch (and the outer safeHook wrapper) swallow it.
+		await expect(transform({ sessionID }, output)).resolves.toBeUndefined();
+
+		// Sanity check on the fixture itself: the phase-header injection ran
+		// BEFORE the simulated throw, so it must be present...
+		expect(
+			output.system.some((s) => s.includes('[SWARM CONTEXT] Phase:')),
+		).toBe(true);
+		// ...but the plan-cursor injection, which runs immediately after the
+		// throw point, must be absent — proving the throw genuinely
+		// interrupted the hook mid-injection (not that the fixture failed to
+		// trigger Path A's injections at all).
+		expect(output.system.some((s) => s.includes('[SWARM PLAN CURSOR]'))).toBe(
+			false,
+		);
+
+		// FR-004 assertion: despite the mid-turn throw, the ledger reflects
+		// the REAL demand accumulated up to the throw point — not the
+		// fail-open-to-0 default getSystemEnhancerDemand() returns for a
+		// missing/stale entry.
+		const recordedDemand = getSystemEnhancerDemand(sessionID);
+		expect(recordedDemand).toBeGreaterThan(0);
+
+		// And resetUnifiedBudget() actually ran with the configured ceiling —
+		// proving a ledger entry exists at all, not merely that
+		// getSystemEnhancerDemand's default happens to be non-zero.
+		expect(getUnifiedBudgetTotal(sessionID)).toBe(unifiedBudget);
+	});
+});

--- a/tests/unit/tools/knowledge-recall.test.ts
+++ b/tests/unit/tools/knowledge-recall.test.ts
@@ -84,29 +84,18 @@ describe('knowledge_recall tool verification tests (FR-A1)', () => {
 		}
 	}
 
+	// Must resolve to exactly the same path the mocked `resolveHiveKnowledgePath`
+	// below returns (tmpDir/.swarm/shared-learnings.jsonl). The retrieval code
+	// under test reads via that mocked resolver, not the real platform-specific
+	// resolution (LOCALAPPDATA/Library/XDG) — a previous version of this helper
+	// computed the real per-platform path here, which silently diverged from the
+	// mock and caused every hive-tier entry written by `writeHiveKnowledge` to be
+	// invisible to `knowledge_recall` (wrong file, so `readKnowledge` saw ENOENT
+	// and returned []). The HOME/LOCALAPPDATA/XDG_* env overrides set in
+	// beforeEach remain as defense-in-depth in case some code path resolves the
+	// real hive location instead of going through the mock.
 	function hiveKnowledgePath(): string {
-		if (process.platform === 'win32') {
-			return path.join(
-				process.env.LOCALAPPDATA ?? tmpDir,
-				'opencode-swarm',
-				'Data',
-				'shared-learnings.jsonl',
-			);
-		}
-		if (process.platform === 'darwin') {
-			return path.join(
-				process.env.HOME ?? tmpDir,
-				'Library',
-				'Application Support',
-				'opencode-swarm',
-				'shared-learnings.jsonl',
-			);
-		}
-		return path.join(
-			process.env.XDG_DATA_HOME ?? path.join(tmpDir, '.local', 'share'),
-			'opencode-swarm',
-			'shared-learnings.jsonl',
-		);
+		return path.join(tmpDir, '.swarm', 'shared-learnings.jsonl');
 	}
 
 	// Mock resolveHiveKnowledgePath to return a path inside tmpDir so hive knowledge
@@ -970,8 +959,13 @@ describe('knowledge_recall tool verification tests (FR-A1)', () => {
 			const parsed = JSON.parse(result);
 
 			const ids = parsed.results.map((r: { id: string }) => r.id);
-			// established should be first (highest boost + base score)
-			expect(ids[0]).toBe('e1');
+			// `promoted` is the lifecycle apex and outranks `established`, which in
+			// turn outranks a lower-confidence `established` entry (G7 / #1716's
+			// boost-table correction: promoted +0.15 > established +0.10 > none).
+			// This assertion previously expected `e1` (established) first, which
+			// matched the pre-#1716 boost table (established +0.10 > promoted
+			// +0.05) — an inversion #1716 fixed but never updated this test for.
+			expect(ids).toEqual(['p1', 'e1', 'c1']);
 		});
 
 		it('Both tiers together, all active entries returned', async () => {


### PR DESCRIPTION
Partially addresses #1737

## Summary

- Fixed five genuinely broken knowledge-subsystem tests that had been quarantined instead of fixed (`cleanup-drift.test.ts`, `knowledge.adversarial.test.ts`, `knowledge-injector-drift-adversarial.test.ts`, `knowledge-recall.test.ts` x2 issues), and un-quarantined them from `scripts/ci/quarantined-tests.txt`.
- Fixed `tests/integration/phase-complete-events.adversarial.test.ts`'s "read-only `.swarm` directory" coverage to match the actual documented split-fail behavior (`events.jsonl` soft-fails with a warning, `plan.json` fails closed).
- Fixed a real bug in `src/hooks/system-enhancer.ts`: the unified-injection-budget ledger write could be skipped on a mid-flight exception; it's now guaranteed via a `finally` block, with a new regression test.
- Added `tests/helpers/tmpdir.ts` (macOS `/var` → `/private/var` symlink-safe helpers) and `scripts/check-test-tmpdir.sh`, a diff-scoped lint catching raw `tmpdir()` usage in new/changed test-file lines.
- Added `scripts/check-bash-portability.sh`, a full-scan lint for bash-4+-only constructs (`declare/typeset/local/readonly -A`, `grep -P`/`--perl-regexp`, `coproc`, `mapfile`/`readarray`) that silently break on macOS's system bash (3.2) — prevents recurrence of the class of bug fixed in issue #1729. Fixed one genuine pre-existing PCRE violation this lint caught in `scripts/check-cross-contamination.sh`.
- `.github/workflows/ci.yml`: added a `detect-paths` job that path-scopes the cross-OS (macOS/Windows) unit-test matrix to PRs touching platform-sensitive paths (`src/worktree/`, `src/turbo/`, `src/sandbox/`, `src/plan/`, `src/parallel/`, `scripts/`, `.github/workflows/`) or `merge_group` runs. Added a `unit-passed` aggregate check job. Corrected a stale comment about the `coverage` check's required-status state.
- Fixed a genuine SIGPIPE correctness bug caught during pre-push validation: the `detect-paths` step originally used `grep -qE` piped from `git diff`, which under `set -o pipefail` can make the `if` silently false on a large diff even when a match occurred (dropping platform-sensitive PRs to the ubuntu-only matrix — the unsafe direction). Fixed by using `grep -E ... >/dev/null` (no `-q`/`-m`, reads to EOF, cannot race). Verified empirically against a 100M-line producer.
- Refined `tests/security/ci-workflow-security.test.ts`'s expression-injection check to recognize GitHub's own recommended "intermediate environment variable" mitigation (a dangerous `github.event.*` context assigned to an `env:` block value, rather than interpolated inline in a `run:` script, is not itself a vulnerability) — needed because the new `detect-paths` job passes `github.event.pull_request.base.sha`/`head.sha` (immutable git SHAs) via `env:`.
- Un-quarantined `tests/unit/hooks/knowledge-floor-action.test.ts` and `tests/unit/turbo/lean/integration-worktree.test.ts` and fixed the two genuine production bugs their failures were exposing (not test bugs — see below).

## Two additional production bugs found and fixed during CI validation

Both of these were surfaced by un-quarantining tests that had been failing CI on `ubuntu-latest`/`windows-latest` shards. Both root-caused to real defects, not test issues:

1. **`swarm-artifact-cache.ts` lost-update bug**: the shared read cache (keyed on mtime+ctime+size) never invalidated on write. A locked read-modify-write immediately following an `atomicWriteFile` write to the same path can hit a same-tick, same-size stat collision and read back stale pre-write content, then persist it — silently clobbering the just-written value. Reachable any time two locked writes to the same file happen in quick succession (e.g. `bumpKnowledgeConfidenceBatch`'s delta-write followed by its confidence-floor-flag transaction). Fixed by invalidating the cache entry from the shared `atomicWriteFile` primitive (`src/evidence/task-file.ts`) after every successful write — closes the gap for all callers, not just this one path.
2. **Lean Turbo merge-conflict misclassification**: `attemptMergeBackFromDirty`'s real conflict result (`src/worktree/merge.ts`) never sets a `conflict: true` field — only `partial: true` + non-empty `conflictFiles`. `runner.ts`'s dirty-worktree cleanup path checked for `conflict === true` to classify a failure as `'conflict'` vs `'partial'`, which is unreachable for this call path — every real merge conflict reaching `_sequentialWorktreeCleanup` was being reported as `'partial'` in production. Fixed the classifier to key off non-empty `conflictFiles`.

Both reproduced deterministically (10/10 runs) on a clean `origin/main` checkout before the fix, and pass deterministically after it.

## Invariant audit
- 1 (plugin init): not touched - no changes to `src/index.ts` or plugin entry/init path.
- 2 (runtime portability): not touched - no `Bun.*`/`bun:` imports added; `bun run build` succeeds and `node --input-type=module -e "await import('./dist/index.js')"` confirms the bundle loads under Node.
- 3 (subprocesses): not touched - `git diff --name-only origin/main..HEAD | xargs -r grep -nE "bunSpawn\(|spawn\(|spawnSync\("` returns no matches in changed source files; new shell (`.sh`) lint scripts run via bash CI steps, not Node subprocess spawns.
- 4 (.swarm containment): touched - `tests/integration/phase-complete-events.adversarial.test.ts`'s read-only-`.swarm` coverage was corrected to match actual split-fail behavior (soft-fail `events.jsonl`, fail-closed `plan.json`); no `.swarm/` write-path code itself was changed, only test assertions.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched - all validation used shell commands (`bun run test:unit:ci`, `bun test`) per AGENTS.md #6, not the `test_runner` tool with broad scope.
- 7 (test writing): touched - all new/changed tests use `bun:test` only; `tests/unit/hooks/system-enhancer-budget-ledger-finally.test.ts` uses a marker-gated mock to avoid cross-test pollution rather than a leaking `mock.module()`; `scripts/check-mock-cleanup.sh` passes clean.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched - `bun run scripts/check-tool-registration.ts` passes ("106 tools, coherent").
- 12 (release/cache): not touched - no hand-edits to `package.json#version`, `CHANGELOG.md`, or `.release-please-manifest.json`; `docs/releases/pending/1737-quarantine-debt-and-ci-portability-lints.md` fragment added per contract.

## Test plan

- [x] `bun run build` succeeds; `node --input-type=module -e "await import('./dist/index.js')"` confirms bundle loads.
- [x] `bun run typecheck` clean.
- [x] `bun run lint:ci` equivalent (biome scoped to tracked `src/`, `tests/`, `test/`, config files) clean, 0 issues.
- [x] `bun run scripts/check-tool-registration.ts`, `check-mock-cleanup.sh`, `check-invariants.sh`, `check-cross-contamination.sh`, `check-test-clock.sh` all pass.
- [x] New lints (`check-test-tmpdir.sh`, `check-bash-portability.sh`) pass against current repo state.
- [x] `bun test tests/unit/hooks/knowledge-floor-action.test.ts` and `tests/unit/turbo/lean/integration-worktree.test.ts` — both pass deterministically across repeated runs (previously failed deterministically on clean `origin/main`).
- [x] `bun test tests/adversarial --timeout 120000` — 829 pass, 0 fail.
- [x] `bun test tests/security --timeout 120000` — 163 pass, 4 skip, 0 fail.
- [x] `bun test tests/smoke --timeout 120000` — 10 pass, 0 fail.
- [x] `bun test tests/integration ./test --timeout 120000` — 746 pass, 199 fail; all 199 failures independently confirmed pre-existing on clean `origin/main` (see Pre-existing failures).
- [x] All CI checks green at head (`unit` all shards, `unit-passed`, `security`, `quality`, `detect-paths`, `package-check`, `rust-sandbox-runner`, `php-validation`).
- [x] YAML syntax of `.github/workflows/ci.yml` validated via `Bun.YAML.parse`.
- [x] All third-party `uses:` in the diff are SHA-pinned.
- [x] Push-protection secret-pattern scan of the full commit range: clean.

## Pre-existing failures

- `bun test tests/integration ./test --timeout 120000`: 199 failures across ~15 unrelated subsystems (Phase Preflight Auto-Trigger, full-auto mode, curator v3, Gate Workflow, phase_complete adversarial/E2E, skill-feedback, macro/micro reflector, plan-persistence Layer 1↔2 bridge, etc.). None of these files are touched by this PR. Reproduced identically (746 pass / 199 fail) on a clean `git worktree add origin/main` + `bun install --frozen-lockfile`, confirming this is pre-existing repo state, not a regression from this branch.

## Known caveats / remaining #1737 scope

This PR does **not** close #1737 — 9 quarantine entries remain across 3 lists after this PR:
- `scripts/ci/quarantined-tests.txt`: 3 entries (swarm-artifact-cache, skill-scoring-workflow, test-runner)
- `scripts/ci/quarantined-tests-macos.txt`: 4 entries (3 lean-turbo tests + macOS `provisionWorktree`)
- `scripts/ci/quarantined-integration-tests.txt`: 2 entries (unified-injection-budget, one other)
- `scripts/ci/quarantined-tests-windows.txt`: 0 entries

Documented in the release-note fragment (`docs/releases/pending/1737-quarantine-debt-and-ci-portability-lints.md`):
- The new `unit-passed` aggregate CI job is intentionally not yet wired into branch protection (would break the merge queue for other open PRs since the check doesn't exist on `main` yet) — deferred to a follow-up once this lands.
- The remaining 9 quarantine entries (macOS lean-turbo, injection-budget, macOS `provisionWorktree` root-cause diagnosis) require further investigation and are intentionally deferred to follow-up work under #1737, which stays open.



<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1843?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>
