### PR TITLE
feat(scripts): add swarm-model config CLI (supersedes #1857)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,14 @@ jobs:
         shell: bash
         run: chmod +x scripts/check-bash-portability.sh && bash scripts/check-bash-portability.sh
 
+      # Standalone helper under scripts/swarm-model/ has its own node:test suite
+      # (not part of the src/**/*.test.ts glob the unit job discovers). Run it
+      # here so the utility's regression tests are actually gated in CI.
+      - name: swarm-model CLI tests
+        if: needs.detect-release.outputs.is-release != 'true'
+        shell: bash
+        run: cd scripts/swarm-model && node --test
+
   # Two-tier CI: on pull_request, run ubuntu-only with 4 shards for fast feedback
   # UNLESS the diff touches a platform-sensitive path (issue #1737 FR-013,
   # detect-paths job above), in which case the full 3-OS matrix runs on

--- a/docs/releases/pending/1857-swarm-model-cli.md
+++ b/docs/releases/pending/1857-swarm-model-cli.md
@@ -1,0 +1,28 @@
+# swarm-model config CLI (contributor utility)
+
+## What
+
+Adds `scripts/swarm-model/` (Node.js, cross-platform) and `scripts/swarm-model.ps1`
+(PowerShell, Windows) — an interactive helper that reads available providers and
+models from `opencode.json` and rewrites an agent's `model`/`temperature` in
+`opencode-swarm.json`, backing up the file before every write. Imported from
+community PR #1857 and hardened during review:
+
+- Fixed the interactive Node path, which crashed on every run because `ask` was
+  never imported (the temperature step threw `ReferenceError`).
+- `list`/`help` no longer hang on a TTY — the readline interface is created
+  lazily instead of at import.
+- Guarded agent entries that have no `model` field so agent selection no longer
+  throws.
+- Node `selectFromList` now offers a quit option at every selection step.
+- Backup filenames use a full `YYYYMMDDHHMMSS` (second-resolution) timestamp, so
+  backups within the same 10-minute window no longer overwrite each other.
+- PowerShell `ConvertTo-Json` now uses `-Depth 10`, so nested agent fields
+  (`fallback_models`, `reasoning`, `thinking`) are no longer truncated on write.
+- Robust home-dir resolution (`os.homedir()`), graceful malformed-JSON handling,
+  and a clear error on a missing `--swarm-config`/`--opencode-config` value.
+- Added a `node:test` suite covering the config/backup/provider-merge logic and
+  an end-to-end drive of the interactive flow.
+
+This is a standalone contributor utility under `scripts/`; it is not part of the
+published `opencode-swarm` package.

--- a/scripts/swarm-model.ps1
+++ b/scripts/swarm-model.ps1
@@ -38,14 +38,17 @@ function Write-SwarmConfig {
     $path = $args[1]
     if (Test-Path -LiteralPath $path) {
         $backupPath = $path + '.bak'
-        $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+        $timestamp = Get-Date -Format 'yyyyMMddHHmmss'
         if (Test-Path -LiteralPath $backupPath) {
             $backupPath = $path + '.' + $timestamp + '.bak'
         }
         Copy-Item -LiteralPath $path -Destination $backupPath -Force
         Write-Host "已备份原配置: $backupPath" -ForegroundColor DarkGray
     }
-    $json = $cfg | ConvertTo-Json
+    # -Depth 10: PowerShell's ConvertTo-Json defaults to depth 2, which would
+    # serialize nested agent fields (fallback_models, reasoning, thinking) as
+    # type-name strings and silently corrupt them on write.
+    $json = $cfg | ConvertTo-Json -Depth 10
     Set-Content -LiteralPath $path -Value $json -NoNewline
 }
 

--- a/scripts/swarm-model.ps1
+++ b/scripts/swarm-model.ps1
@@ -1,0 +1,375 @@
+﻿param(
+    [Parameter(Position = 0)]
+    [string]$Command = '',
+    [string]$ConfigPath = '',
+    [string]$OpenCodeConfigPath = ''
+)
+
+$DefaultSwarmConfigPath = Join-Path $env:USERPROFILE '.config\opencode\opencode-swarm.json'
+$DefaultOpenCodeConfigPath = Join-Path $env:USERPROFILE '.config\opencode\opencode.json'
+if (-not $ConfigPath) { $ConfigPath = $DefaultSwarmConfigPath }
+if (-not $OpenCodeConfigPath) { $OpenCodeConfigPath = $DefaultOpenCodeConfigPath }
+
+function Read-SwarmConfig {
+    $path = $args[0]
+    if (-not (Test-Path -LiteralPath $path)) {
+        Write-Host "配置文件不存在: $path" -ForegroundColor Yellow
+        Write-Host "正在创建新配置文件..." -ForegroundColor DarkGray
+        $dir = Split-Path -Parent $path
+        if (-not (Test-Path -LiteralPath $dir)) {
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        }
+        $initial = @{ agents = @{} }
+        $initial | ConvertTo-Json | Set-Content -LiteralPath $path -NoNewline
+        Write-Host "已创建: $path" -ForegroundColor Green
+        $raw = [System.IO.File]::ReadAllText($path, [System.Text.Encoding]::UTF8)
+        return ($raw | ConvertFrom-Json)
+    }
+    try {
+        $raw = [System.IO.File]::ReadAllText($path, [System.Text.Encoding]::UTF8)
+    } catch {
+        $raw = Get-Content -LiteralPath $path -Raw
+    }
+    return ($raw | ConvertFrom-Json)
+}
+
+function Write-SwarmConfig {
+    $cfg = $args[0]
+    $path = $args[1]
+    if (Test-Path -LiteralPath $path) {
+        $backupPath = $path + '.bak'
+        $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+        if (Test-Path -LiteralPath $backupPath) {
+            $backupPath = $path + '.' + $timestamp + '.bak'
+        }
+        Copy-Item -LiteralPath $path -Destination $backupPath -Force
+        Write-Host "已备份原配置: $backupPath" -ForegroundColor DarkGray
+    }
+    $json = $cfg | ConvertTo-Json
+    Set-Content -LiteralPath $path -Value $json -NoNewline
+}
+
+function Get-OpenCodeProviders {
+    $path = $args[0]
+    if (-not (Test-Path -LiteralPath $path)) {
+        return @{}
+    }
+    try {
+        $raw = [System.IO.File]::ReadAllText($path, [System.Text.Encoding]::UTF8)
+        $config = $raw | ConvertFrom-Json
+    } catch {
+        return @{}
+    }
+    if (-not $config -or -not $config.provider) {
+        return @{}
+    }
+    $providers = @{}
+    foreach ($prop in $config.provider.PSObject.Properties) {
+        $provName = $prop.Name
+        $provData = $prop.Value
+        if ($provData.models) {
+            $models = @($provData.models.PSObject.Properties.Name | Sort-Object)
+            $providers[$provName] = $models
+        }
+    }
+    return $providers
+}
+
+function Split-ModelName {
+    $name = $args[0]
+    if ($name -match '/') {
+        $idx = $name.LastIndexOf('/')
+        return @{ Provider = $name.Substring(0, $idx); Model = $name.Substring($idx + 1) }
+    }
+    return @{ Provider = ''; Model = $name }
+}
+
+function Get-AllModels {
+    $config = $args[0]
+    $models = @{}
+    foreach ($prop in $config.agents.PSObject.Properties) {
+        $agent = $prop.Value
+        if ($agent.model) {
+            $parts = Split-ModelName $agent.model
+            $key = $parts.Provider + '/' + $parts.Model
+            if (-not $models.Contains($key)) { $models[$key] = $parts }
+        }
+        if ($agent.fallback_models) {
+            foreach ($fb in $agent.fallback_models) {
+                $parts = Split-ModelName $fb
+                $key = $parts.Provider + '/' + $parts.Model
+                if (-not $models.Contains($key)) { $models[$key] = $parts }
+            }
+        }
+    }
+    return $models
+}
+
+function Get-Providers {
+    $allModels = $args[0]
+    $providers = @{}
+    foreach ($entry in $allModels.Values) {
+        if ($entry.Provider -and -not $providers.ContainsKey($entry.Provider)) {
+            $providers[$entry.Provider] = @()
+        }
+    }
+    foreach ($entry in $allModels.Values) {
+        if ($entry.Provider) {
+            $providers[$entry.Provider] = $providers[$entry.Provider] + $entry.Model
+        }
+    }
+    foreach ($key in @($providers.Keys)) {
+        $providers[$key] = @($providers[$key] | Sort-Object -Unique)
+    }
+    return $providers
+}
+
+function Merge-ProviderModels {
+    param(
+        [object]$SwarmProviders,
+        [object]$OpenCodeProviders
+    )
+    $merged = @{}
+    foreach ($key in $SwarmProviders.Keys) {
+        $merged[$key] = $SwarmProviders[$key]
+    }
+    foreach ($key in $OpenCodeProviders.Keys) {
+        if ($merged.ContainsKey($key)) {
+            $combined = @($merged[$key] + $OpenCodeProviders[$key])
+            $merged[$key] = @($combined | Sort-Object -Unique)
+        } else {
+            $merged[$key] = $OpenCodeProviders[$key]
+        }
+    }
+    return $merged
+}
+
+function Select-FromList {
+    param([string]$Title, [array]$Labels, [array]$Values, [bool]$AllowQuit = $true)
+    if ($AllowQuit) {
+        $Labels = $Labels + '[quit/退出]'
+        $Values = $Values + '__quit__'
+    }
+    Write-Host ""
+    Write-Host $Title -ForegroundColor Cyan
+    Write-Host ("-" * 60) -ForegroundColor DarkGray
+    for ($i = 0; $i -lt $Labels.Count; $i++) {
+        Write-Host ("  [{0}] {1}" -f ($i + 1), $Labels[$i])
+    }
+    Write-Host ""
+    $idx = 0
+    while ($true) {
+        $inputVal = Read-Host "请选择 (1-$($Labels.Count))"
+        $idx = 0
+        if ([int]::TryParse($inputVal, [ref]$idx)) { $idx = $idx - 1 }
+        if ($idx -ge 0 -and $idx -lt $Labels.Count) { break }
+        Write-Host "请输入有效编号" -ForegroundColor Yellow
+    }
+    return $Values[$idx]
+}
+
+function Show-List {
+    $config = $args[0]
+    $agents = $config.agents.PSObject.Properties | Sort-Object Name
+    Write-Host ""
+    Write-Host "Swarm Agent 模型配置" -ForegroundColor Cyan
+    Write-Host ("=" * 70) -ForegroundColor DarkGray
+    Write-Host ("{0,-28} {1,-35} {2}" -f 'Agent', 'Model', 'Temp') -ForegroundColor White
+    Write-Host ("-" * 70) -ForegroundColor DarkGray
+    foreach ($prop in $agents) {
+        $name = $prop.Name
+        $agent = $prop.Value
+        $temp = ''
+        if ($null -ne $agent.temperature) { $temp = $agent.temperature.ToString() }
+        Write-Host ("{0,-28} {1,-35} {2}" -f $name, $agent.model, $temp)
+    }
+    Write-Host ""
+}
+
+function Show-Help {
+    Write-Host ""
+    Write-Host "swarm-model.ps1 - Swarm Agent 模型配置工具" -ForegroundColor Cyan
+    Write-Host ("=" * 50) -ForegroundColor DarkGray
+    Write-Host ""
+    Write-Host "用法:"
+    Write-Host "  .\scripts\swarm-model.ps1              交互式修改 agent 模型"
+    Write-Host "  .\scripts\swarm-model.ps1 list         列出所有 agent 及模型"
+    Write-Host "  .\scripts\swarm-model.ps1 help         显示帮助"
+    Write-Host ""
+    Write-Host "参数:"
+    Write-Host "  -ConfigPath <路径>            指定 swarm 配置文件路径"
+    Write-Host "  -OpenCodeConfigPath <路径>    指定 opencode 配置文件路径"
+    Write-Host ""
+    Write-Host "说明:"
+    Write-Host "  脚本会从 opencode.json 读取所有可用 provider 和模型"
+    Write-Host "  从 opencode-swarm.json 读取当前 agent 配置"
+    Write-Host ""
+}
+
+function Run-Interactive {
+    $running = $true
+    while ($running) {
+        $config = Read-SwarmConfig $ConfigPath
+        $swarmModels = Get-AllModels $config
+        $swarmProviders = Get-Providers $swarmModels
+        $openCodeProviders = Get-OpenCodeProviders $OpenCodeConfigPath
+        $allProviders = Merge-ProviderModels $swarmProviders $openCodeProviders
+        $agentNames = @($config.agents.PSObject.Properties.Name | Sort-Object)
+        if ($agentNames.Count -eq 0) {
+            Write-Host "没有可配置的 agent" -ForegroundColor Red
+            exit 1
+        }
+
+        # Show available providers info
+        Write-Host ""
+        Write-Host "=== Swarm Model 配置工具 ===" -ForegroundColor Cyan
+        $provCount = $allProviders.Count
+        Write-Host "检测到 $provCount 个 provider ($( ($allProviders.Keys -join ', ') ))" -ForegroundColor DarkGray
+
+        # Step 1: Select agent
+        $agentLabels = @()
+        foreach ($name in $agentNames) {
+            $agent = $config.agents.$name
+            $agentLabels += "$name | $($agent.model) | temp=$($agent.temperature)"
+        }
+        $selectedAgent = Select-FromList -Title "Step 1: 选择要修改的 Agent" -Labels $agentLabels -Values $agentNames
+        if ($selectedAgent -eq '__quit__') { break }
+        $currentAgent = $config.agents.$selectedAgent
+        $currentParts = Split-ModelName $currentAgent.model
+        $currentProvider = $currentParts.Provider
+        $currentModelName = $currentParts.Model
+        Write-Host ""
+        Write-Host "当前: $selectedAgent = $($currentAgent.model) (temp=$($currentAgent.temperature))" -ForegroundColor Green
+
+        # Step 2: Select provider
+        $providerNames = @($allProviders.Keys | Sort-Object)
+        $providerLabels = @()
+        foreach ($p in $providerNames) {
+            $count = $allProviders[$p].Count
+            $marker = ''
+            if ($p -eq $currentProvider) { $marker = ' [当前]' }
+            $providerLabels += "$p ($count 个模型)$marker"
+        }
+        $providerLabels += '[自定义 provider...]'
+        $providerValues = $providerNames + '__custom__'
+        $selectedProvider = Select-FromList -Title "Step 2: 选择 Provider (模型服务商)" -Labels $providerLabels -Values $providerValues
+        if ($selectedProvider -eq '__quit__') { break }
+        if ($selectedProvider -eq '__custom__') {
+            $selectedProvider = ''
+            while ($true) {
+                $selectedProvider = Read-Host "输入 Provider 名称"
+                if ([string]::IsNullOrWhiteSpace($selectedProvider)) {
+                    Write-Host "Provider 名称不能为空" -ForegroundColor Red
+                } else {
+                    break
+                }
+            }
+        }
+
+        # Step 3: Select model
+        $providerModels = @()
+        if ($allProviders.ContainsKey($selectedProvider)) {
+            $providerModels = $allProviders[$selectedProvider]
+        }
+        if ($providerModels.Count -eq 0) {
+            $selectedModel = ''
+            while ($true) {
+                $selectedModel = Read-Host "该 Provider 下没有已有模型，输入模型名"
+                if ([string]::IsNullOrWhiteSpace($selectedModel)) {
+                    Write-Host "模型名称不能为空" -ForegroundColor Red
+                } else {
+                    break
+                }
+            }
+        } else {
+            $modelLabels = @()
+            foreach ($m in $providerModels) {
+                $marker = ''
+                if ($m -eq $currentModelName -and $selectedProvider -eq $currentProvider) { $marker = ' [当前]' }
+                $modelLabels += "$selectedProvider/$m$marker"
+            }
+            $modelLabels += '[自定义 model...]'
+            $modelValues = $providerModels + '__custom__'
+            $selectedModel = Select-FromList -Title "Step 3: 选择模型 ($selectedProvider)" -Labels $modelLabels -Values $modelValues
+            if ($selectedModel -eq '__quit__') { break }
+            if ($selectedModel -eq '__custom__') {
+                $selectedModel = ''
+                while ($true) {
+                    $selectedModel = Read-Host "输入模型名称"
+                    if ([string]::IsNullOrWhiteSpace($selectedModel)) {
+                        Write-Host "模型名称不能为空" -ForegroundColor Red
+                    } else {
+                        break
+                    }
+                }
+            }
+        }
+        if ($selectedProvider) {
+            $fullModel = "$selectedProvider/$selectedModel"
+        } else {
+            $fullModel = $selectedModel
+        }
+
+        # Step 4: Temperature
+        Write-Host ""
+        Write-Host "Step 4: Temperature 设置" -ForegroundColor Cyan
+        Write-Host "当前温度: $($currentAgent.temperature)" -ForegroundColor DarkGray
+        $tempPrompt = '新温度值 (0.0-2.0, 回车保持当前值 [' + $currentAgent.temperature + '])'
+        $tempInput = Read-Host $tempPrompt
+        $newTemp = $currentAgent.temperature
+        if ($tempInput -and $tempInput.Trim() -ne '') {
+            $tempNum = 0
+            if ([double]::TryParse($tempInput.Trim(), [ref]$tempNum)) {
+                if ($tempNum -lt 0 -or $tempNum -gt 2) {
+                    Write-Host "温度必须在 0.0 到 2.0 之间，保持当前值" -ForegroundColor Yellow
+                } else {
+                    $newTemp = $tempNum
+                }
+            } else {
+                Write-Host "无效数值，保持当前值" -ForegroundColor Yellow
+            }
+        }
+
+        # Step 5: Confirm
+        Write-Host ""
+        Write-Host "=== 确认变更 ===" -ForegroundColor Cyan
+        Write-Host ("-" * 50) -ForegroundColor DarkGray
+        Write-Host "  Agent:       $selectedAgent" -ForegroundColor White
+        Write-Host "  Model:       $($currentAgent.model) -> $fullModel" -ForegroundColor White
+        Write-Host "  Temperature: $($currentAgent.temperature) -> $newTemp" -ForegroundColor White
+        Write-Host ""
+        $confirm = Read-Host "确认修改? ([Y]/n)"
+        if ($confirm -match '^[nN]') {
+            Write-Host "已取消" -ForegroundColor Yellow
+            continue
+        }
+        $config.agents.$selectedAgent.model = $fullModel
+        $config.agents.$selectedAgent.temperature = $newTemp
+        Write-SwarmConfig $config $ConfigPath
+        Write-Host ""
+        Write-Host "配置已更新!" -ForegroundColor Green
+        Write-Host "  $selectedAgent = $fullModel (temp=$newTemp)" -ForegroundColor Green
+        Write-Host "提示: 修改后需要重启 opencode/swarm 会话才能生效" -ForegroundColor Yellow
+        Write-Host ""
+
+        # Continue or quit
+        $contLabel = @('继续修改其他 agent', 'quit/退出')
+        $contValue = @('continue', '__quit__')
+        $choice = Select-FromList -Title "下一步" -Labels $contLabel -Values $contValue -AllowQuit $false
+        if ($choice -eq '__quit__') {
+            Write-Host "再见!" -ForegroundColor Cyan
+            $running = $false
+        }
+    }
+}
+
+# ---------- Main dispatch ----------
+
+if ($Command -eq 'list') {
+    $config = Read-SwarmConfig $ConfigPath
+    Show-List $config
+} elseif ($Command -in 'help', '--help', '-h', '/?') {
+    Show-Help
+} else {
+    Run-Interactive
+}

--- a/scripts/swarm-model.ps1
+++ b/scripts/swarm-model.ps1
@@ -41,8 +41,14 @@ function Write-SwarmConfig {
         $timestamp = Get-Date -Format 'yyyyMMddHHmmss'
         if (Test-Path -LiteralPath $backupPath) {
             $backupPath = $path + '.' + $timestamp + '.bak'
+            # Guarantee uniqueness for multiple writes within the same second.
+            $n = 1
+            while (Test-Path -LiteralPath $backupPath) {
+                $backupPath = $path + '.' + $timestamp + '-' + $n + '.bak'
+                $n++
+            }
         }
-        Copy-Item -LiteralPath $path -Destination $backupPath -Force
+        Copy-Item -LiteralPath $path -Destination $backupPath
         Write-Host "已备份原配置: $backupPath" -ForegroundColor DarkGray
     }
     # -Depth 10: PowerShell's ConvertTo-Json defaults to depth 2, which would

--- a/scripts/swarm-model/README.md
+++ b/scripts/swarm-model/README.md
@@ -1,0 +1,116 @@
+# Swarm Model Config Tool
+
+Interactive CLI tool for configuring swarm agent LLM models. Reads available providers and models from the OpenCode configuration and lets you swap models and temperatures for any agent.
+
+## Features
+
+- **Reads all available providers** from `~/.config/opencode/opencode.json` (not just the ones currently in use)
+- **Two implementations**: Node.js (cross-platform) and PowerShell (Windows)
+- **Backup before every change** — creates a `.bak` file, with timestamps if `.bak` already exists
+- **Auto-creates config** if `opencode-swarm.json` doesn't exist yet
+- **Preserves `fallback_models`** exactly as-is, only modifies `model` and `temperature`
+- **Loop mode** — after modifying one agent, choose to modify another or exit
+- **Quit option** at every selection step (press the last number in any list)
+
+## Quick Start
+
+### Node.js version (recommended, cross-platform)
+
+```bash
+# List all agents
+node scripts/swarm-model/src/cli.js list
+
+# Interactive mode
+node scripts/swarm-model/src/cli.js
+
+# Specify custom config paths
+node scripts/swarm-model/src/cli.js \
+  --swarm-config ~/.config/opencode/opencode-swarm.json \
+  --opencode-config ~/.config/opencode/opencode.json
+
+# Help
+node scripts/swarm-model/src/cli.js help
+```
+
+### PowerShell version (Windows only)
+
+```powershell
+# List all agents
+.\scripts\swarm-model.ps1 list
+
+# Interactive mode
+.\scripts\swarm-model.ps1
+
+# Help
+.\scripts\swarm-model.ps1 help
+```
+
+## Interactive Flow
+
+```
+=== Swarm Model Config Tool ===
+Detected 6 providers (agnes, geminiproxy, opencode-go, opencode-zen, sensenova, wolfai)
+
+Step 1: Select Agent to Configure
+------------------------------------------------------------
+  [1] architect | opencode-go/deepseek-v4-pro | temp=0.1
+  [2] coder | opencode-go/deepseek-v4-flash | temp=0.2
+  ...
+  [18] test_engineer | opencode-go/minimax-m2.5 | temp=0.2
+  [19] [quit/退出]
+
+Please select (1-19):
+```
+
+1. **Select Agent** — pick the agent to configure
+2. **Select Provider** — choose from all providers in `opencode.json` (e.g., `wolfai`, `agnes`, `geminiproxy`, etc.)
+3. **Select Model** — choose a model under that provider
+4. **Set Temperature** — optional, defaults to current value
+5. **Confirm** — press Enter (default Y) or type `n` to cancel
+6. **Continue or Quit** — modify another agent or exit
+
+## Provider Sources
+
+The tool reads providers from two places:
+
+| Source | Path | Purpose |
+|--------|------|---------|
+| **OpenCode config** | `~/.config/opencode/opencode.json` | All available providers and models |
+| **Swarm config** | `~/.config/opencode/opencode-swarm.json` | Current agent assignments (used for backup) |
+
+Available providers in the current config:
+
+| Provider | Models |
+|----------|--------|
+| `agnes` | agnes-1.5-flash, agnes-2.0-flash, agnes-image-2.0-flash, agnes-image-2.1-flash, agnes-video-v2.0 |
+| `geminiproxy` | gemini-2.0-flash-001, gemini-2.5-flash, gemini-2.5-pro, gemini-3.1-pro-preview, gemini-3.5-flash, gemma-4-31b-it |
+| `opencode-go` | hy3-preview, kimi-k2.5, kimi-k2.6, minimax-m2.5, qwen3.7-max |
+| `opencode-zen` | deepseek-v4-flash-free, mimo-v2.5-free, nemotron-3-ultra-free, north-mini-code-free |
+| `sensenova` | deepseek-v4-flash, glm-5.2, sensenova-6.7-flash-lite, sensenova-u1-fast |
+| `wolfai` | claude-opus-4-5-20251101-thinking, claude-sonnet-4-5-20250929, gemini-3-flash-preview, gemini-3-pro-preview, glm-4.7, glm-5, gpt-5.2, gpt-5.2-codex, gpt-5.2-codex-high, gpt-5.3-codex, gpt-5.3-codex-high, grok-code-fast-1, kimi-k2-0905, kimi-k2.5, minimax-m2.1, minimax-m2.5 |
+
+## Backup Behavior
+
+Before every write, the current config is backed up:
+
+```
+opencode-swarm.json.bak              # First backup
+opencode-swarm.json.20260714170500.bak  # Subsequent backups (timestamped)
+```
+
+Timestamps are in `YYYYMMDD-HHMMSS` format. Old backups are never overwritten.
+
+## Temperature Guide
+
+| Range | Behavior | Recommended Agents |
+|-------|----------|-------------------|
+| 0.0 – 0.3 | Deterministic, consistent | `coder`, `reviewer`, `critic*` |
+| 0.3 – 0.7 | Balanced | `sme`, `docs` |
+| 0.7 – 2.0 | Creative, varied | `explorer`, `designer` |
+
+## Notes
+
+- **Restart required** after modifying — changes only take effect on the next opencode/swarm session
+- **Cross-platform** — the Node.js version works on Windows, macOS, and Linux
+- **Windows-only** — the PowerShell version requires Windows PowerShell 5.1+
+- **Custom provider/model** — if a provider or model is not in the list, you can type it manually

--- a/scripts/swarm-model/README.md
+++ b/scripts/swarm-model/README.md
@@ -43,9 +43,18 @@ node scripts/swarm-model/src/cli.js help
 
 # Help
 .\scripts\swarm-model.ps1 help
+
+# Custom config paths (note: PowerShell uses different flag names than Node)
+.\scripts\swarm-model.ps1 -ConfigPath C:\path\opencode-swarm.json -OpenCodeConfigPath C:\path\opencode.json
 ```
 
+> **Note:** the PowerShell version's on-screen prompts and help text are in
+> Chinese; the Node version is in English. Both drive the same config format.
+
 ## Interactive Flow
+
+The provider count and agent list below are **illustrative** — the tool prints
+whatever it discovers in your own `opencode.json` and `opencode-swarm.json`:
 
 ```
 === Swarm Model Config Tool ===
@@ -53,11 +62,11 @@ Detected 6 providers (agnes, geminiproxy, opencode-go, opencode-zen, sensenova, 
 
 Step 1: Select Agent to Configure
 ------------------------------------------------------------
-  [1] architect | opencode-go/deepseek-v4-pro | temp=0.1
-  [2] coder | opencode-go/deepseek-v4-flash | temp=0.2
+  [1] architect | opencode-go/hy3-preview | temp=0.1
+  [2] coder | opencode-go/kimi-k2.5 | temp=0.2
   ...
   [18] test_engineer | opencode-go/minimax-m2.5 | temp=0.2
-  [19] [quit/退出]
+  [19] [quit/exit]
 
 Please select (1-19):
 ```
@@ -98,7 +107,8 @@ opencode-swarm.json.bak              # First backup
 opencode-swarm.json.20260714170500.bak  # Subsequent backups (timestamped)
 ```
 
-Timestamps are in `YYYYMMDD-HHMMSS` format. Old backups are never overwritten.
+Timestamps are in `YYYYMMDDHHMMSS` format (14 digits, second resolution). The
+first `.bak` and any timestamped backups are never overwritten.
 
 ## Temperature Guide
 
@@ -108,8 +118,24 @@ Timestamps are in `YYYYMMDD-HHMMSS` format. Old backups are never overwritten.
 | 0.3 – 0.7 | Balanced | `sme`, `docs` |
 | 0.7 – 2.0 | Creative, varied | `explorer`, `designer` |
 
+## Testing
+
+The Node.js version has a self-contained test suite (Node's built-in
+`node:test`, no dependencies):
+
+```bash
+cd scripts/swarm-model
+npm test   # or: node --test
+```
+
+It covers the config read/write/backup and provider-merge logic plus an
+end-to-end drive of the interactive flow.
+
 ## Notes
 
+- **Standalone utility** — this is a contributor helper script under `scripts/`;
+  it is not part of the published `opencode-swarm` package and is run directly
+  from a repo checkout.
 - **Restart required** after modifying — changes only take effect on the next opencode/swarm session
 - **Cross-platform** — the Node.js version works on Windows, macOS, and Linux
 - **Windows-only** — the PowerShell version requires Windows PowerShell 5.1+

--- a/scripts/swarm-model/package.json
+++ b/scripts/swarm-model/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "swarm-model",
+  "version": "1.0.0",
+  "description": "Interactive CLI to configure swarm agent LLM models",
+  "type": "module",
+  "main": "src/index.js",
+  "bin": {
+    "swarm-model": "./src/cli.js"
+  },
+  "scripts": {
+    "start": "node src/cli.js",
+    "list": "node src/cli.js list",
+    "help": "node src/cli.js help"
+  },
+  "keywords": ["swarm", "opencode", "model", "config"],
+  "author": "",
+  "license": "MIT"
+}

--- a/scripts/swarm-model/package.json
+++ b/scripts/swarm-model/package.json
@@ -3,14 +3,14 @@
   "version": "1.0.0",
   "description": "Interactive CLI to configure swarm agent LLM models",
   "type": "module",
-  "main": "src/index.js",
   "bin": {
     "swarm-model": "./src/cli.js"
   },
   "scripts": {
     "start": "node src/cli.js",
     "list": "node src/cli.js list",
-    "help": "node src/cli.js help"
+    "help": "node src/cli.js help",
+    "test": "node --test"
   },
   "keywords": ["swarm", "opencode", "model", "config"],
   "author": "",

--- a/scripts/swarm-model/src/cli.js
+++ b/scripts/swarm-model/src/cli.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { showList, showHelp } from './commands.js';
+import { runInteractive } from './interactive.js';
+import { resolve } from 'path';
+
+const defaultSwarmConfig = resolve(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode-swarm.json');
+const defaultOpenCodeConfig = resolve(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode.json');
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let command = '';
+  let swarmConfig = defaultSwarmConfig;
+  let openCodeConfig = defaultOpenCodeConfig;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--swarm-config' && args[i + 1]) {
+      swarmConfig = resolve(args[++i]);
+    } else if (args[i] === '--opencode-config' && args[i + 1]) {
+      openCodeConfig = resolve(args[++i]);
+    } else {
+      command = args[i];
+    }
+  }
+
+  return { command, swarmConfig, openCodeConfig };
+}
+
+async function main() {
+  const { command, swarmConfig, openCodeConfig } = parseArgs();
+
+  if (command === 'list') {
+    showList(swarmConfig);
+  } else if (command === 'help' || command === '--help' || command === '-h' || command === '/?') {
+    showHelp();
+  } else {
+    await runInteractive(swarmConfig, openCodeConfig);
+  }
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/scripts/swarm-model/src/cli.js
+++ b/scripts/swarm-model/src/cli.js
@@ -3,21 +3,27 @@
 import { showList, showHelp } from './commands.js';
 import { runInteractive } from './interactive.js';
 import { resolve } from 'path';
-
-const defaultSwarmConfig = resolve(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode-swarm.json');
-const defaultOpenCodeConfig = resolve(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode.json');
+import { DEFAULT_SWARM_CONFIG, DEFAULT_OPENCODE_CONFIG } from './paths.js';
 
 function parseArgs() {
   const args = process.argv.slice(2);
   let command = '';
-  let swarmConfig = defaultSwarmConfig;
-  let openCodeConfig = defaultOpenCodeConfig;
+  let swarmConfig = DEFAULT_SWARM_CONFIG;
+  let openCodeConfig = DEFAULT_OPENCODE_CONFIG;
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--swarm-config' && args[i + 1]) {
-      swarmConfig = resolve(args[++i]);
-    } else if (args[i] === '--opencode-config' && args[i + 1]) {
-      openCodeConfig = resolve(args[++i]);
+    if (args[i] === '--swarm-config' || args[i] === '--opencode-config') {
+      const flag = args[i];
+      const value = args[i + 1];
+      if (!value) {
+        throw new Error(`Missing value for ${flag}`);
+      }
+      i++;
+      if (flag === '--swarm-config') {
+        swarmConfig = resolve(value);
+      } else {
+        openCodeConfig = resolve(value);
+      }
     } else {
       command = args[i];
     }

--- a/scripts/swarm-model/src/cli.js
+++ b/scripts/swarm-model/src/cli.js
@@ -15,7 +15,9 @@ function parseArgs() {
     if (args[i] === '--swarm-config' || args[i] === '--opencode-config') {
       const flag = args[i];
       const value = args[i + 1];
-      if (!value) {
+      // Treat a following flag (or no token) as a missing value rather than
+      // silently consuming `--other-flag` as this flag's path.
+      if (!value || value.startsWith('--')) {
         throw new Error(`Missing value for ${flag}`);
       }
       i++;

--- a/scripts/swarm-model/src/commands.js
+++ b/scripts/swarm-model/src/commands.js
@@ -1,9 +1,6 @@
 #!/usr/bin/env node
 
 import { readSwarmConfig } from './config.js';
-import { resolve } from 'path';
-
-const defaultSwarmConfig = resolve(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode-swarm.json');
 
 export function showList(configPath) {
   const config = readSwarmConfig(configPath);

--- a/scripts/swarm-model/src/commands.js
+++ b/scripts/swarm-model/src/commands.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import { readSwarmConfig } from './config.js';
+import { resolve } from 'path';
+
+const defaultSwarmConfig = resolve(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode-swarm.json');
+
+export function showList(configPath) {
+  const config = readSwarmConfig(configPath);
+  const agents = Object.entries(config.agents || {}).sort((a, b) => a[0].localeCompare(b[0]));
+
+  console.log('');
+  console.log('\x1b[36mSwarm Agent Model Config\x1b[0m');
+  console.log('='.repeat(70));
+  console.log(`\x1b[37m${'Agent'.padEnd(28)} ${'Model'.padEnd(35)} Temp\x1b[0m`);
+  console.log('-'.repeat(70));
+
+  for (const [name, agent] of agents) {
+    const temp = agent.temperature ?? '';
+    console.log(`${name.padEnd(28)} ${(agent.model || '').padEnd(35)} ${temp}`);
+  }
+  console.log('');
+}
+
+export function showHelp() {
+  console.log('');
+  console.log('\x1b[36mswarm-model - Swarm Agent Model Config Tool\x1b[0m');
+  console.log('='.repeat(50));
+  console.log('');
+  console.log('Usage:');
+  console.log('  node src/cli.js                  Interactive mode');
+  console.log('  node src/cli.js list             List all agents');
+  console.log('  node src/cli.js help             Show this help');
+  console.log('');
+  console.log('Params:');
+  console.log('  --swarm-config <path>    Swarm config path');
+  console.log('                           Default: ~/.config/opencode/opencode-swarm.json');
+  console.log('  --opencode-config <path> OpenCode config path');
+  console.log('                           Default: ~/.config/opencode/opencode.json');
+  console.log('');
+}

--- a/scripts/swarm-model/src/config.js
+++ b/scripts/swarm-model/src/config.js
@@ -1,9 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 
-const DEFAULT_SWARM_CONFIG = path.join(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode-swarm.json');
-const DEFAULT_OPENCODE_CONFIG = path.join(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode.json');
-
 export function readSwarmConfig(filePath) {
   if (!fs.existsSync(filePath)) {
     const dir = path.dirname(filePath);
@@ -14,7 +11,11 @@ export function readSwarmConfig(filePath) {
     console.log(`Created: ${filePath}`);
   }
   const raw = fs.readFileSync(filePath, 'utf8');
-  return JSON.parse(raw);
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Failed to parse swarm config ${filePath}: ${err.message}`);
+  }
 }
 
 export function writeSwarmConfig(config, filePath) {
@@ -22,7 +23,12 @@ export function writeSwarmConfig(config, filePath) {
   if (fs.existsSync(filePath)) {
     let dest = backupPath;
     if (fs.existsSync(backupPath)) {
-      const ts = new Date().toISOString().replace(/[:.]/g, '').slice(0, 14);
+      // Full YYYYMMDDHHMMSS second-resolution stamp (matches README + the
+      // PowerShell impl). The earlier slice(0,14) of the raw ISO string kept
+      // the `-`/`T` separators and truncated to ~10-minute resolution, so
+      // backups within the same 10-minute window collided and overwrote each
+      // other; stripping all non-digits first avoids that.
+      const ts = new Date().toISOString().replace(/\D/g, '').slice(0, 14);
       dest = filePath + '.' + ts + '.bak';
     }
     fs.copyFileSync(filePath, dest);
@@ -34,7 +40,15 @@ export function writeSwarmConfig(config, filePath) {
 export function getOpenCodeProviders(filePath) {
   if (!fs.existsSync(filePath)) return {};
   const raw = fs.readFileSync(filePath, 'utf8');
-  const config = JSON.parse(raw);
+  let config;
+  try {
+    config = JSON.parse(raw);
+  } catch {
+    // Malformed opencode.json is non-fatal: fall back to no discovered
+    // providers (parity with the PowerShell impl) rather than aborting the tool.
+    console.warn(`\x1b[33mWarning: could not parse ${filePath}; ignoring discovered providers\x1b[0m`);
+    return {};
+  }
   if (!config.provider) return {};
   const providers = {};
   for (const [name, data] of Object.entries(config.provider)) {

--- a/scripts/swarm-model/src/config.js
+++ b/scripts/swarm-model/src/config.js
@@ -1,0 +1,93 @@
+import fs from 'fs';
+import path from 'path';
+
+const DEFAULT_SWARM_CONFIG = path.join(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode-swarm.json');
+const DEFAULT_OPENCODE_CONFIG = path.join(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode.json');
+
+export function readSwarmConfig(filePath) {
+  if (!fs.existsSync(filePath)) {
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(filePath, JSON.stringify({ agents: {} }, null, 2), 'utf8');
+    console.log(`Created: ${filePath}`);
+  }
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+export function writeSwarmConfig(config, filePath) {
+  const backupPath = filePath + '.bak';
+  if (fs.existsSync(filePath)) {
+    let dest = backupPath;
+    if (fs.existsSync(backupPath)) {
+      const ts = new Date().toISOString().replace(/[:.]/g, '').slice(0, 14);
+      dest = filePath + '.' + ts + '.bak';
+    }
+    fs.copyFileSync(filePath, dest);
+    console.log(`Backed up to: ${dest}`);
+  }
+  fs.writeFileSync(filePath, JSON.stringify(config, null, 2), 'utf8');
+}
+
+export function getOpenCodeProviders(filePath) {
+  if (!fs.existsSync(filePath)) return {};
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const config = JSON.parse(raw);
+  if (!config.provider) return {};
+  const providers = {};
+  for (const [name, data] of Object.entries(config.provider)) {
+    if (data.models) {
+      providers[name] = Object.keys(data.models).sort();
+    }
+  }
+  return providers;
+}
+
+export function splitModelName(fullName) {
+  const idx = fullName.lastIndexOf('/');
+  if (idx === -1) return { provider: '', model: fullName };
+  return { provider: fullName.substring(0, idx), model: fullName.substring(idx + 1) };
+}
+
+export function getAllModels(config) {
+  const models = {};
+  for (const [name, agent] of Object.entries(config.agents || {})) {
+    const add = (modelName) => {
+      if (!modelName) return;
+      const parts = splitModelName(modelName);
+      const key = parts.provider + '/' + parts.model;
+      if (!models[key]) models[key] = parts;
+    };
+    add(agent.model);
+    if (agent.fallback_models) {
+      agent.fallback_models.forEach(add);
+    }
+  }
+  return models;
+}
+
+export function getProviders(allModels) {
+  const providers = {};
+  for (const entry of Object.values(allModels)) {
+    if (!entry.provider) continue;
+    if (!providers[entry.provider]) providers[entry.provider] = [];
+    if (!providers[entry.provider].includes(entry.model)) {
+      providers[entry.provider].push(entry.model);
+    }
+  }
+  return providers;
+}
+
+export function mergeProviderModels(swarmProviders, openCodeProviders) {
+  const merged = { ...swarmProviders };
+  for (const [key, models] of Object.entries(openCodeProviders)) {
+    if (merged[key]) {
+      merged[key] = [...new Set([...merged[key], ...models])].sort();
+    } else {
+      merged[key] = [...models];
+    }
+  }
+  return merged;
+}

--- a/scripts/swarm-model/src/config.js
+++ b/scripts/swarm-model/src/config.js
@@ -30,6 +30,13 @@ export function writeSwarmConfig(config, filePath) {
       // other; stripping all non-digits first avoids that.
       const ts = new Date().toISOString().replace(/\D/g, '').slice(0, 14);
       dest = filePath + '.' + ts + '.bak';
+      // Guarantee uniqueness even for multiple writes within the same second
+      // (second-resolution stamps would otherwise collide and overwrite).
+      let n = 1;
+      while (fs.existsSync(dest)) {
+        dest = filePath + '.' + ts + '-' + n + '.bak';
+        n++;
+      }
     }
     fs.copyFileSync(filePath, dest);
     console.log(`Backed up to: ${dest}`);

--- a/scripts/swarm-model/src/interactive.js
+++ b/scripts/swarm-model/src/interactive.js
@@ -1,9 +1,5 @@
-import { readSwarmConfig, writeSwarmConfig, getOpenCodeProviders, getAllModels, getProviders, mergeProviderModels } from './config.js';
-import { selectFromList, close } from './ui.js';
-import { resolve } from 'path';
-
-const defaultSwarmConfig = resolve(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode-swarm.json');
-const defaultOpenCodeConfig = resolve(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode.json');
+import { readSwarmConfig, writeSwarmConfig, getOpenCodeProviders, getAllModels, getProviders, mergeProviderModels, splitModelName } from './config.js';
+import { selectFromList, ask, close } from './ui.js';
 
 export async function runInteractive(swarmPath, openCodePath) {
   const config = readSwarmConfig(swarmPath);
@@ -25,10 +21,9 @@ export async function runInteractive(swarmPath, openCodePath) {
   const provList = Object.keys(allProviders).join(', ');
   console.log(`\x1b[90mDetected ${provCount} providers (${provList})\x1b[0m`);
 
-  const running = true;
   let exitLoop = false;
 
-  while (running && !exitLoop) {
+  while (!exitLoop) {
     // Refresh config each iteration
     const cfg = readSwarmConfig(swarmPath);
     const sm = getAllModels(cfg);
@@ -43,10 +38,12 @@ export async function runInteractive(swarmPath, openCodePath) {
     if (selectedAgent === '__quit__') { exitLoop = true; break; }
 
     const currentAgent = cfg.agents[selectedAgent];
-    const cp = currentAgent.model.split('/');
-    const currentProvider = cp.length > 1 ? cp[0] : '';
-    const currentModelName = cp.length > 1 ? cp[1] : currentAgent.model;
-    console.log(`\x1b[32mCurrent: ${selectedAgent} = ${currentAgent.model} (temp=${currentAgent.temperature})\x1b[0m`);
+    const currentModel = currentAgent.model || '';
+    // Use the same splitter as the provider/model lists (lastIndexOf-based) so
+    // the `[current]` marker matches, and guard against agents with no `model`
+    // field (valid: an agent may set only temperature/disabled).
+    const { provider: currentProvider, model: currentModelName } = splitModelName(currentModel);
+    console.log(`\x1b[32mCurrent: ${selectedAgent} = ${currentModel || '(unset)'} (temp=${currentAgent.temperature ?? '(unset)'})\x1b[0m`);
 
     // Step 2: Select provider
     const providerNames = Object.keys(ap).sort();
@@ -106,8 +103,9 @@ export async function runInteractive(swarmPath, openCodePath) {
     // Step 4: Temperature
     console.log('');
     console.log('\x1b[36mStep 4: Temperature\x1b[0m');
-    console.log(`Current: ${currentAgent.temperature}`);
-    const tempPrompt = `New temp (0.0-2.0, Enter to keep current [${currentAgent.temperature}]): `;
+    const currentTempDisplay = currentAgent.temperature ?? '(unset)';
+    console.log(`Current: ${currentTempDisplay}`);
+    const tempPrompt = `New temp (0.0-2.0, Enter to keep current [${currentTempDisplay}]): `;
     const tempInput = await ask(tempPrompt);
     let newTemp = currentAgent.temperature;
     if (tempInput.trim()) {
@@ -123,8 +121,8 @@ export async function runInteractive(swarmPath, openCodePath) {
     console.log('');
     console.log('\x1b[36m=== Confirm ===\x1b[0m');
     console.log('  Agent:       ' + selectedAgent);
-    console.log('  Model:       ' + currentAgent.model + ' -> ' + fullModel);
-    console.log('  Temperature: ' + currentAgent.temperature + ' -> ' + newTemp);
+    console.log('  Model:       ' + (currentModel || '(unset)') + ' -> ' + fullModel);
+    console.log('  Temperature: ' + (currentAgent.temperature ?? '(unset)') + ' -> ' + (newTemp ?? '(unset)'));
     console.log('');
 
     const confirm = await ask('Confirm? ([Y]/n): ');
@@ -134,20 +132,20 @@ export async function runInteractive(swarmPath, openCodePath) {
     }
 
     cfg.agents[selectedAgent].model = fullModel;
-    cfg.agents[selectedAgent].temperature = newTemp;
+    if (newTemp !== undefined) {
+      cfg.agents[selectedAgent].temperature = newTemp;
+    }
     writeSwarmConfig(cfg, swarmPath);
 
     console.log('');
     console.log('\x1b[32mConfig updated!\x1b[0m');
-    console.log(`  ${selectedAgent} = ${fullModel} (temp=${newTemp})`);
+    console.log(`  ${selectedAgent} = ${fullModel} (temp=${newTemp ?? '(unset)'})`);
     console.log('');
     console.log('\x1b[33mNote: Restart opencode/swarm session to apply changes\x1b[0m');
     console.log('');
 
-    // Continue or quit
-    const contLabels = ['Continue modifying another agent', 'Quit/Exit'];
-    const contValues = ['continue', '__quit__'];
-    const choice = await selectFromList('Next', contLabels, contValues);
+    // Continue or quit (selectFromList appends the quit option itself)
+    const choice = await selectFromList('Next', ['Continue modifying another agent'], ['continue']);
     if (choice === '__quit__') {
       console.log('\x1b[36mGoodbye!\x1b[0m');
       exitLoop = true;

--- a/scripts/swarm-model/src/interactive.js
+++ b/scripts/swarm-model/src/interactive.js
@@ -1,0 +1,158 @@
+import { readSwarmConfig, writeSwarmConfig, getOpenCodeProviders, getAllModels, getProviders, mergeProviderModels } from './config.js';
+import { selectFromList, close } from './ui.js';
+import { resolve } from 'path';
+
+const defaultSwarmConfig = resolve(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode-swarm.json');
+const defaultOpenCodeConfig = resolve(process.env.HOME || process.env.USERPROFILE, '.config', 'opencode', 'opencode.json');
+
+export async function runInteractive(swarmPath, openCodePath) {
+  const config = readSwarmConfig(swarmPath);
+  const swarmModels = getAllModels(config);
+  const swarmProviders = getProviders(swarmModels);
+  const openCodeProviders = getOpenCodeProviders(openCodePath);
+  const allProviders = mergeProviderModels(swarmProviders, openCodeProviders);
+  const agentNames = Object.keys(config.agents || {}).sort();
+
+  if (agentNames.length === 0) {
+    console.log('\x1b[31mNo agents configured\x1b[0m');
+    close();
+    process.exit(1);
+  }
+
+  console.log('');
+  console.log('\x1b[36m=== Swarm Model Config Tool ===\x1b[0m');
+  const provCount = Object.keys(allProviders).length;
+  const provList = Object.keys(allProviders).join(', ');
+  console.log(`\x1b[90mDetected ${provCount} providers (${provList})\x1b[0m`);
+
+  const running = true;
+  let exitLoop = false;
+
+  while (running && !exitLoop) {
+    // Refresh config each iteration
+    const cfg = readSwarmConfig(swarmPath);
+    const sm = getAllModels(cfg);
+    const sp = getProviders(sm);
+    const oc = getOpenCodeProviders(openCodePath);
+    const ap = mergeProviderModels(sp, oc);
+    const an = Object.keys(cfg.agents || {}).sort();
+
+    // Step 1: Select agent
+    const agentLabels = an.map(n => `${n} | ${(cfg.agents[n]?.model || 'N/A')} | temp=${cfg.agents[n]?.temperature ?? 'N/A'}`);
+    const selectedAgent = await selectFromList('Step 1: Select Agent to Configure', agentLabels, an);
+    if (selectedAgent === '__quit__') { exitLoop = true; break; }
+
+    const currentAgent = cfg.agents[selectedAgent];
+    const cp = currentAgent.model.split('/');
+    const currentProvider = cp.length > 1 ? cp[0] : '';
+    const currentModelName = cp.length > 1 ? cp[1] : currentAgent.model;
+    console.log(`\x1b[32mCurrent: ${selectedAgent} = ${currentAgent.model} (temp=${currentAgent.temperature})\x1b[0m`);
+
+    // Step 2: Select provider
+    const providerNames = Object.keys(ap).sort();
+    const providerLabels = providerNames.map(p => {
+      const marker = p === currentProvider ? ' [current]' : '';
+      return `${p} (${ap[p].length} models)${marker}`;
+    });
+    providerLabels.push('[Custom provider...]');
+    const providerValues = [...providerNames, '__custom__'];
+
+    let selectedProvider = await selectFromList('Step 2: Select Provider', providerLabels, providerValues);
+    if (selectedProvider === '__quit__') { exitLoop = true; break; }
+
+    if (selectedProvider === '__custom__') {
+      let val = '';
+      while (val === '') {
+        val = await ask('Enter provider name: ');
+        if (val.trim() === '') console.log('\x1b[31mProvider name cannot be empty\x1b[0m');
+      }
+      selectedProvider = val.trim();
+    }
+
+    // Step 3: Select model
+    const providerModels = ap[selectedProvider] || [];
+    let selectedModel;
+
+    if (providerModels.length === 0) {
+      let val = '';
+      while (val === '') {
+        val = await ask(`No models for ${selectedProvider}, enter model name: `);
+        if (val.trim() === '') console.log('\x1b[31mModel name cannot be empty\x1b[0m');
+      }
+      selectedModel = val.trim();
+    } else {
+      const modelLabels = providerModels.map(m => {
+        const marker = m === currentModelName && selectedProvider === currentProvider ? ' [current]' : '';
+        return `${selectedProvider}/${m}${marker}`;
+      });
+      modelLabels.push('[Custom model...]');
+      const modelValues = [...providerModels, '__custom__'];
+
+      selectedModel = await selectFromList(`Step 3: Select Model (${selectedProvider})`, modelLabels, modelValues);
+      if (selectedModel === '__quit__') { exitLoop = true; break; }
+
+      if (selectedModel === '__custom__') {
+        let val = '';
+        while (val === '') {
+          val = await ask('Enter model name: ');
+          if (val.trim() === '') console.log('\x1b[31mModel name cannot be empty\x1b[0m');
+        }
+        selectedModel = val.trim();
+      }
+    }
+
+    const fullModel = selectedProvider ? `${selectedProvider}/${selectedModel}` : selectedModel;
+
+    // Step 4: Temperature
+    console.log('');
+    console.log('\x1b[36mStep 4: Temperature\x1b[0m');
+    console.log(`Current: ${currentAgent.temperature}`);
+    const tempPrompt = `New temp (0.0-2.0, Enter to keep current [${currentAgent.temperature}]): `;
+    const tempInput = await ask(tempPrompt);
+    let newTemp = currentAgent.temperature;
+    if (tempInput.trim()) {
+      const num = parseFloat(tempInput.trim());
+      if (!isNaN(num) && num >= 0 && num <= 2) {
+        newTemp = num;
+      } else {
+        console.log('\x1b[33mInvalid or out of range, keeping current\x1b[0m');
+      }
+    }
+
+    // Step 5: Confirm
+    console.log('');
+    console.log('\x1b[36m=== Confirm ===\x1b[0m');
+    console.log('  Agent:       ' + selectedAgent);
+    console.log('  Model:       ' + currentAgent.model + ' -> ' + fullModel);
+    console.log('  Temperature: ' + currentAgent.temperature + ' -> ' + newTemp);
+    console.log('');
+
+    const confirm = await ask('Confirm? ([Y]/n): ');
+    if (confirm.match(/^[nN]/)) {
+      console.log('\x1b[33mCancelled\x1b[0m');
+      continue;
+    }
+
+    cfg.agents[selectedAgent].model = fullModel;
+    cfg.agents[selectedAgent].temperature = newTemp;
+    writeSwarmConfig(cfg, swarmPath);
+
+    console.log('');
+    console.log('\x1b[32mConfig updated!\x1b[0m');
+    console.log(`  ${selectedAgent} = ${fullModel} (temp=${newTemp})`);
+    console.log('');
+    console.log('\x1b[33mNote: Restart opencode/swarm session to apply changes\x1b[0m');
+    console.log('');
+
+    // Continue or quit
+    const contLabels = ['Continue modifying another agent', 'Quit/Exit'];
+    const contValues = ['continue', '__quit__'];
+    const choice = await selectFromList('Next', contLabels, contValues);
+    if (choice === '__quit__') {
+      console.log('\x1b[36mGoodbye!\x1b[0m');
+      exitLoop = true;
+    }
+  }
+
+  close();
+}

--- a/scripts/swarm-model/src/paths.js
+++ b/scripts/swarm-model/src/paths.js
@@ -1,0 +1,11 @@
+import os from 'os';
+import path from 'path';
+
+// os.homedir() is the robust cross-platform home lookup and never throws.
+// Fall back to env vars, then the current directory, so module load can never
+// crash with `path.join(undefined, ...)` when HOME/USERPROFILE are both unset
+// (e.g. minimal containers / CI runners).
+const home = os.homedir() || process.env.HOME || process.env.USERPROFILE || '.';
+
+export const DEFAULT_SWARM_CONFIG = path.join(home, '.config', 'opencode', 'opencode-swarm.json');
+export const DEFAULT_OPENCODE_CONFIG = path.join(home, '.config', 'opencode', 'opencode.json');

--- a/scripts/swarm-model/src/ui.js
+++ b/scripts/swarm-model/src/ui.js
@@ -1,30 +1,57 @@
 import readline from 'readline';
 
-const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+// The readline interface is created lazily on first prompt rather than at
+// import time. Commands that never prompt (`list`, `help`) therefore never
+// open stdin and exit cleanly instead of hanging on an open TTY.
+let rl = null;
+let ioInput = process.stdin;
+let ioOutput = process.stdout;
 
-function ask(prompt) {
-  return new Promise((resolve) => rl.question(prompt, resolve));
+// Allow tests to drive the interactive flow with scripted streams.
+export function setIo(input, output) {
+  ioInput = input;
+  ioOutput = output;
 }
 
-export async function selectFromList(title, labels, values) {
+function getRl() {
+  if (!rl) {
+    rl = readline.createInterface({ input: ioInput, output: ioOutput });
+  }
+  return rl;
+}
+
+export function ask(prompt) {
+  return new Promise((resolve) => getRl().question(prompt, resolve));
+}
+
+const QUIT_LABEL = '[quit/exit]';
+export const QUIT_VALUE = '__quit__';
+
+export async function selectFromList(title, labels, values, allowQuit = true) {
+  const shownLabels = allowQuit ? [...labels, QUIT_LABEL] : labels;
+  const shownValues = allowQuit ? [...values, QUIT_VALUE] : values;
+
   console.log('');
   console.log(`\x1b[36m${title}\x1b[0m`);
   console.log('-'.repeat(60));
-  labels.forEach((label, i) => {
+  shownLabels.forEach((label, i) => {
     console.log(`  [\x1b[33m${i + 1}\x1b[0m] ${label}`);
   });
   console.log('');
 
   while (true) {
-    const input = await ask(`Please select (1-${labels.length}): `);
-    const idx = parseInt(input) - 1;
-    if (idx >= 0 && idx < labels.length) {
-      return values[idx];
+    const input = await ask(`Please select (1-${shownLabels.length}): `);
+    const idx = parseInt(input, 10) - 1;
+    if (idx >= 0 && idx < shownLabels.length) {
+      return shownValues[idx];
     }
     console.log('\x1b[33mPlease enter a valid number\x1b[0m');
   }
 }
 
 export function close() {
-  rl.close();
+  if (rl) {
+    rl.close();
+    rl = null;
+  }
 }

--- a/scripts/swarm-model/src/ui.js
+++ b/scripts/swarm-model/src/ui.js
@@ -1,0 +1,30 @@
+import readline from 'readline';
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+function ask(prompt) {
+  return new Promise((resolve) => rl.question(prompt, resolve));
+}
+
+export async function selectFromList(title, labels, values) {
+  console.log('');
+  console.log(`\x1b[36m${title}\x1b[0m`);
+  console.log('-'.repeat(60));
+  labels.forEach((label, i) => {
+    console.log(`  [\x1b[33m${i + 1}\x1b[0m] ${label}`);
+  });
+  console.log('');
+
+  while (true) {
+    const input = await ask(`Please select (1-${labels.length}): `);
+    const idx = parseInt(input) - 1;
+    if (idx >= 0 && idx < labels.length) {
+      return values[idx];
+    }
+    console.log('\x1b[33mPlease enter a valid number\x1b[0m');
+  }
+}
+
+export function close() {
+  rl.close();
+}

--- a/scripts/swarm-model/test/cli.test.js
+++ b/scripts/swarm-model/test/cli.test.js
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const CLI = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'src', 'cli.js');
+
+// Run cli.js as a child process. `keepStdinOpen` leaves the child's stdin pipe
+// open (never .end()) so that a regressed eager-readline build — which holds
+// stdin open and hangs — would time out instead of exiting. Closing stdin here
+// would let even a hung build receive 'end' and exit, making the probe
+// tautological, so the no-hang tests must keep it open.
+function run(args, { env, keepStdinOpen = false, timeoutMs = 5000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      env: env ?? process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.stderr.on('data', (d) => { stderr += d; });
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`cli ${args.join(' ')} did not exit within ${timeoutMs}ms (hang)`));
+    }, timeoutMs);
+    child.on('error', (err) => { clearTimeout(timer); reject(err); });
+    child.on('exit', (code) => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
+    if (!keepStdinOpen) child.stdin.end();
+    // when keepStdinOpen: intentionally leave stdin open; child must still exit.
+  });
+}
+
+// F-07: `help`/`list` must never open readline, so they exit cleanly even while
+// stdin stays open. A regression to eager readline creation would hang here.
+test('help exits 0 without hanging while stdin stays open (F-07)', async () => {
+  const { code, stdout } = await run(['help'], { keepStdinOpen: true });
+  assert.equal(code, 0);
+  assert.match(stdout, /swarm-model/);
+});
+
+test('list exits 0 without hanging while stdin stays open (F-07)', async () => {
+  const { code } = await run(['list'], { keepStdinOpen: true });
+  assert.equal(code, 0);
+});
+
+// F-09: a value-less --swarm-config flag must fail fast with a clear message,
+// not silently swallow the next arg or crash obscurely.
+test('valueless --swarm-config exits 1 with a clear message (F-09)', async () => {
+  const { code, stderr } = await run(['list', '--swarm-config']);
+  assert.equal(code, 1);
+  assert.match(stderr, /Missing value for --swarm-config/);
+});
+
+test('valueless --opencode-config exits 1 with a clear message (F-09)', async () => {
+  const { code, stderr } = await run(['list', '--opencode-config']);
+  assert.equal(code, 1);
+  assert.match(stderr, /Missing value for --opencode-config/);
+});
+
+// F-13: with HOME and USERPROFILE both unset the module-level default paths
+// must still resolve (os.homedir fallback), so the CLI starts instead of
+// crashing at import with `path.join(undefined, ...)`.
+test('starts with HOME and USERPROFILE unset (F-13)', async () => {
+  const env = { ...process.env };
+  delete env.HOME;
+  delete env.USERPROFILE;
+  const { code, stdout } = await run(['help'], { env });
+  assert.equal(code, 0);
+  assert.match(stdout, /swarm-model/);
+});

--- a/scripts/swarm-model/test/cli.test.js
+++ b/scripts/swarm-model/test/cli.test.js
@@ -59,6 +59,13 @@ test('valueless --opencode-config exits 1 with a clear message (F-09)', async ()
   assert.match(stderr, /Missing value for --opencode-config/);
 });
 
+// A following flag must not be swallowed as this flag's path value.
+test('--swarm-config followed by another flag errors rather than consuming it', async () => {
+  const { code, stderr } = await run(['--swarm-config', '--opencode-config', 'x']);
+  assert.equal(code, 1);
+  assert.match(stderr, /Missing value for --swarm-config/);
+});
+
 // F-13: with HOME and USERPROFILE both unset the module-level default paths
 // must still resolve (os.homedir fallback), so the CLI starts instead of
 // crashing at import with `path.join(undefined, ...)`.

--- a/scripts/swarm-model/test/config.test.js
+++ b/scripts/swarm-model/test/config.test.js
@@ -1,0 +1,117 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  splitModelName,
+  getAllModels,
+  getProviders,
+  mergeProviderModels,
+  getOpenCodeProviders,
+  readSwarmConfig,
+  writeSwarmConfig,
+} from '../src/config.js';
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-model-test-'));
+}
+
+test('splitModelName splits on the last slash', () => {
+  assert.deepEqual(splitModelName('wolfai/glm-5'), { provider: 'wolfai', model: 'glm-5' });
+  // 3-segment provider/model/variant: keep the variant with the model tail.
+  assert.deepEqual(splitModelName('anthropic/claude/high'), { provider: 'anthropic/claude', model: 'high' });
+  assert.deepEqual(splitModelName('bareword'), { provider: '', model: 'bareword' });
+});
+
+test('getAllModels collects model + fallback_models, tolerating missing model', () => {
+  const models = getAllModels({
+    agents: {
+      a: { model: 'wolfai/glm-5', fallback_models: ['wolfai/gpt-5.2'] },
+      b: { temperature: 0.5 }, // no model — must not throw
+    },
+  });
+  assert.ok(models['wolfai/glm-5']);
+  assert.ok(models['wolfai/gpt-5.2']);
+});
+
+test('getProviders skips empty-provider entries and dedups', () => {
+  const providers = getProviders({
+    'wolfai/glm-5': { provider: 'wolfai', model: 'glm-5' },
+    'wolfai/glm-5-dup': { provider: 'wolfai', model: 'glm-5' },
+    '/bare': { provider: '', model: 'bare' },
+  });
+  assert.deepEqual(providers, { wolfai: ['glm-5'] });
+});
+
+test('mergeProviderModels unions, sorts, dedups, and keeps swarm-only keys', () => {
+  const merged = mergeProviderModels(
+    { wolfai: ['glm-5'], only: ['x'] },
+    { wolfai: ['gpt-5.2', 'glm-5'], extra: ['y'] },
+  );
+  assert.deepEqual(merged.wolfai, ['glm-5', 'gpt-5.2']);
+  assert.deepEqual(merged.only, ['x']);
+  assert.deepEqual(merged.extra, ['y']);
+});
+
+test('getOpenCodeProviders returns {} on missing file and on malformed JSON', () => {
+  const dir = tmpDir();
+  assert.deepEqual(getOpenCodeProviders(path.join(dir, 'nope.json')), {});
+  const bad = path.join(dir, 'bad.json');
+  fs.writeFileSync(bad, '{ this is not json ');
+  assert.deepEqual(getOpenCodeProviders(bad), {}); // F-08: no throw
+});
+
+test('getOpenCodeProviders reads provider models sorted', () => {
+  const dir = tmpDir();
+  const p = path.join(dir, 'opencode.json');
+  fs.writeFileSync(p, JSON.stringify({ provider: { wolfai: { models: { 'gpt-5.2': {}, 'glm-5': {} } } } }));
+  assert.deepEqual(getOpenCodeProviders(p), { wolfai: ['glm-5', 'gpt-5.2'] });
+});
+
+test('readSwarmConfig throws a clear error on malformed JSON (F-08)', () => {
+  const dir = tmpDir();
+  const p = path.join(dir, 'swarm.json');
+  fs.writeFileSync(p, '{ broken ');
+  assert.throws(() => readSwarmConfig(p), /Failed to parse swarm config/);
+});
+
+test('writeSwarmConfig backup filename is full-resolution and never overwrites the first .bak (F-02)', () => {
+  const dir = tmpDir();
+  const p = path.join(dir, 'swarm.json');
+  fs.writeFileSync(p, JSON.stringify({ agents: { a: { model: 'x/y' } } }));
+
+  // First write -> .bak
+  writeSwarmConfig({ agents: { a: { model: 'x/z' } } }, p);
+  assert.ok(fs.existsSync(p + '.bak'), 'first backup is .bak');
+
+  // Second write -> timestamped .bak, 14-digit YYYYMMDDHHMMSS, no separators
+  writeSwarmConfig({ agents: { a: { model: 'x/w' } } }, p);
+  const stamped = fs.readdirSync(dir).filter((f) => /^swarm\.json\.\d{14}\.bak$/.test(f));
+  assert.equal(stamped.length, 1, 'exactly one 14-digit timestamped backup');
+  assert.ok(fs.existsSync(p + '.bak'), 'original .bak still present (not overwritten)');
+});
+
+test('writeSwarmConfig preserves non-edited nested fields (schema integrity)', () => {
+  const dir = tmpDir();
+  const p = path.join(dir, 'swarm.json');
+  const cfg = {
+    agents: {
+      a: {
+        model: 'wolfai/glm-5',
+        temperature: 0.2,
+        disabled: false,
+        variant: 'high',
+        fallback_models: ['wolfai/gpt-5.2'],
+        reasoning: { effort: 'high' },
+        thinking: { type: 'enabled', budget_tokens: 1000 },
+      },
+    },
+  };
+  writeSwarmConfig(cfg, p);
+  const back = JSON.parse(fs.readFileSync(p, 'utf8'));
+  assert.deepEqual(back.agents.a.fallback_models, ['wolfai/gpt-5.2']);
+  assert.deepEqual(back.agents.a.reasoning, { effort: 'high' });
+  assert.deepEqual(back.agents.a.thinking, { type: 'enabled', budget_tokens: 1000 });
+  assert.equal(back.agents.a.variant, 'high');
+});

--- a/scripts/swarm-model/test/config.test.js
+++ b/scripts/swarm-model/test/config.test.js
@@ -92,6 +92,25 @@ test('writeSwarmConfig backup filename is full-resolution and never overwrites t
   assert.ok(fs.existsSync(p + '.bak'), 'original .bak still present (not overwritten)');
 });
 
+test('writeSwarmConfig never overwrites an existing timestamped backup (same-second collision)', () => {
+  const dir = tmpDir();
+  const p = path.join(dir, 'swarm.json');
+  fs.writeFileSync(p, JSON.stringify({ agents: { a: { model: 'x/y' } } }));
+
+  // Occupy the .bak slot and the timestamped slot for "now" with sentinels.
+  fs.writeFileSync(p + '.bak', 'SENTINEL_BAK');
+  const ts = new Date().toISOString().replace(/\D/g, '').slice(0, 14);
+  const stampedSlot = `${p}.${ts}.bak`;
+  fs.writeFileSync(stampedSlot, 'SENTINEL_TS');
+
+  writeSwarmConfig({ agents: { a: { model: 'x/z' } } }, p);
+
+  // Neither pre-existing backup may be overwritten, whichever second the write
+  // lands in (same second -> uses a `-N` suffix; next second -> a fresh stamp).
+  assert.equal(fs.readFileSync(p + '.bak', 'utf8'), 'SENTINEL_BAK');
+  assert.equal(fs.readFileSync(stampedSlot, 'utf8'), 'SENTINEL_TS');
+});
+
 test('writeSwarmConfig preserves non-edited nested fields (schema integrity)', () => {
   const dir = tmpDir();
   const p = path.join(dir, 'swarm.json');

--- a/scripts/swarm-model/test/interactive.test.js
+++ b/scripts/swarm-model/test/interactive.test.js
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Readable, Writable } from 'stream';
+import { runInteractive } from '../src/interactive.js';
+import { setIo, close } from '../src/ui.js';
+
+// Deterministic prompt/response pairing: console.log output goes to stdout,
+// but readline writes each prompt to the *injected* output stream. So every
+// write here is a prompt — feed the next scripted answer line in response,
+// which synchronizes input delivery with each question exactly.
+function makeIo(lines) {
+  const input = new Readable({ read() {} });
+  let i = 0;
+  const output = new Writable({
+    write(_chunk, _enc, cb) {
+      queueMicrotask(() => {
+        if (i < lines.length) input.push(lines[i++] + '\n');
+      });
+      cb();
+    },
+  });
+  return { input, output };
+}
+
+function setup(swarm, opencode) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-model-int-'));
+  const swarmPath = path.join(dir, 'opencode-swarm.json');
+  const openCodePath = path.join(dir, 'opencode.json');
+  fs.writeFileSync(swarmPath, JSON.stringify(swarm, null, 2));
+  fs.writeFileSync(openCodePath, JSON.stringify(opencode, null, 2));
+  return { swarmPath, openCodePath };
+}
+
+async function drive(lines, swarmPath, openCodePath) {
+  const { input, output } = makeIo(lines);
+  setIo(input, output);
+  try {
+    await runInteractive(swarmPath, openCodePath);
+  } finally {
+    close();
+    setIo(process.stdin, process.stdout);
+  }
+}
+
+const OPENCODE = { provider: { wolfai: { models: { 'glm-5': {}, 'gpt-5.2': {} } } } };
+
+// F-01: the whole flow reaches Step 4 (temperature) + confirm + write without
+// `ReferenceError: ask is not defined`. Also proves schema preservation.
+test('interactive edit writes model+temperature and preserves nested fields (F-01, schema)', async () => {
+  const { swarmPath, openCodePath } = setup(
+    { agents: { architect: { model: 'wolfai/glm-5', temperature: 0.1, fallback_models: ['wolfai/gpt-5.2'], reasoning: { effort: 'high' } } } },
+    OPENCODE,
+  );
+  // agent=1, provider=1(wolfai), model=2(gpt-5.2), temp=0.5, confirm=y, next=2(quit)
+  await drive(['1', '1', '2', '0.5', 'y', '2'], swarmPath, openCodePath);
+
+  const cfg = JSON.parse(fs.readFileSync(swarmPath, 'utf8'));
+  assert.equal(cfg.agents.architect.model, 'wolfai/gpt-5.2');
+  assert.equal(cfg.agents.architect.temperature, 0.5);
+  assert.deepEqual(cfg.agents.architect.fallback_models, ['wolfai/gpt-5.2']);
+  assert.deepEqual(cfg.agents.architect.reasoning, { effort: 'high' });
+});
+
+// F-04: quit is offered at Step 1 and aborts without writing.
+test('quit at Step 1 makes no change (F-04)', async () => {
+  const { swarmPath, openCodePath } = setup(
+    { agents: { architect: { model: 'wolfai/glm-5', temperature: 0.1 } } },
+    OPENCODE,
+  );
+  const before = fs.readFileSync(swarmPath, 'utf8');
+  // one agent -> list is [architect, quit]; pick 2 = quit
+  await drive(['2'], swarmPath, openCodePath);
+  assert.equal(fs.readFileSync(swarmPath, 'utf8'), before);
+});
+
+// F-06 / F-15: selecting an agent with no `model` field must not crash, and
+// keeping the temperature (empty input) must leave it intact.
+test('selecting a model-less agent does not crash and keeps temperature (F-06, F-15)', async () => {
+  const { swarmPath, openCodePath } = setup(
+    { agents: { nomodel: { temperature: 0.5 } } },
+    OPENCODE,
+  );
+  // agent=1(nomodel), provider=1(wolfai), model=1(glm-5), temp=<enter>, confirm=y, next=2(quit)
+  await drive(['1', '1', '1', '', 'y', '2'], swarmPath, openCodePath);
+
+  const cfg = JSON.parse(fs.readFileSync(swarmPath, 'utf8'));
+  assert.equal(cfg.agents.nomodel.model, 'wolfai/glm-5');
+  assert.equal(cfg.agents.nomodel.temperature, 0.5);
+});


### PR DESCRIPTION
The design and both implementations (Node + PowerShell) are @goodie1972's work from #1857. This PR carries their original commit as its base and adds review fixes on top. It's a separate PR only because their branch lives on a fork this session can't push to; #1857 is closed in favor of this one.

## Summary

Adds an interactive helper CLI — `scripts/swarm-model/` (Node.js, cross-platform) and `scripts/swarm-model.ps1` (PowerShell, Windows) — that reads available providers/models from `opencode.json` and rewrites an agent's `model`/`temperature` in `opencode-swarm.json`, backing up the file before every write.

Imported from #1857 and hardened against 17 validated review findings:

- **F-01 (was CRITICAL):** interactive mode crashed on every run — `ask` was called but never imported. Now exported from `ui.js` and imported in `interactive.js`.
- **F-07:** `list`/`help` hung on a TTY because readline was created at import; now created lazily.
- **F-06:** agent entries with no `model` field no longer crash agent selection.
- **F-04:** the Node picker now offers a quit option at every selection step.
- **F-02:** backup filenames use a full `YYYYMMDDHHMMSS` (second-resolution) timestamp, so writes in the same 10-minute window no longer overwrite each other.
- **F-03:** PowerShell `ConvertTo-Json -Depth 10` — nested agent fields (`fallback_models`, `reasoning`, `thinking`) are no longer truncated on write.
- **F-08/F-09/F-13:** graceful malformed-JSON handling, a clear error on a missing `--swarm-config`/`--opencode-config` value, and robust `os.homedir()` resolution (no import-time crash when `HOME`/`USERPROFILE` are unset).
- **F-05/F-11/F-15/F-16/F-17:** consistent model splitting, removed dead `main`/duplicated constants, cleaner unset-temperature display, and README fixes (example/table consistency, PS flags, i18n note, backup format).
- **F-12:** added a `node:test` suite and wired it into CI so the utility's regression tests are actually gated.

This is a standalone contributor utility under `scripts/`; it is not part of the published `opencode-swarm` package.

## Invariant audit
- 1 (plugin init):       not touched — no changes under `src/`; only `scripts/` utility + one CI step.
- 2 (runtime portability): not touched — plugin shape (`src/`) unchanged; the utility is a standalone Node CLI that uses `os.homedir()` for cross-platform home resolution.
- 3 (subprocesses):       not touched (plugin) — the new `test/cli.test.js` spawns short-lived `node` children for CLI integration; each exits within the test and is not a plugin-runtime subprocess.
- 4 (.swarm containment): not touched — the tool writes only to user-supplied config paths; tests use `fs.mkdtempSync(os.tmpdir())`; no `.swarm/` writes.
- 5 (plan durability):    not touched.
- 6 (test_runner safety): not touched — utility tests run via `node --test` in a dedicated `quality`-job step, not the plugin's `test_runner`.
- 7 (test writing):       touched (adjacent) — added Node built-in `node:test` (not `bun:test`) for this standalone utility, outside `src/tests`; tests are deterministic and isolated (per-test `mkdtemp`, injected IO reset in `finally`). Evidence: `cd scripts/swarm-model && node --test` → 17/17 pass; each fix proven load-bearing by reverting it and observing the matching test fail.
- 8 (session state):      not touched.
- 9 (guardrails/retry):   not touched.
- 10 (chat/system msg):   not touched.
- 11 (tool registration): not touched — no plugin tools/agents added. A CI workflow step was added; evidence: `ci.yml` parses as valid YAML and its `if: needs.detect-release.outputs.is-release != 'true'` mirrors 15 existing sibling steps in the same `quality` job.
- 12 (release/cache):     touched — added `docs/releases/pending/1857-swarm-model-cli.md`. Evidence: satisfies the `pr-standards` scripts/-change release-fragment gate (an ADDED `docs/releases/pending/*.md`).

## Test plan
- `cd scripts/swarm-model && node --test` → **17/17 pass** (config/backup/provider-merge units + end-to-end interactive drive + CLI integration).
- Reversion proof: reverting F-01/F-07/F-13 makes the corresponding tests fail (`ReferenceError` / hang-timeout / import-time `TypeError`); the config/backup tests fail under the old `slice(0,14)` timestamp logic.
- Runtime probes: `help`/`list` exit 0 with stdin held open (were hanging); `list --swarm-config` with no value exits 1 with a clear message; `env -u HOME -u USERPROFILE ... help` exits 0.
- Repo gates: `bun run typecheck` clean, `bun run lint` (biome) clean, `bun run build` green, `git diff --check` clean. (`scripts/**/*.js` is outside biome/tsc scope by repo convention; covered by `node --check` + the new CI test step.)