### PR TITLE
fix(tui): complete issue 1756 safety closeout

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -112,36 +112,6 @@
 			}
 		},
 		{
-			"includes": ["src/hooks/delegation-gate/worktree-isolation.ts"],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noConsole": "off"
-					}
-				}
-			}
-		},
-		{
-			"includes": ["src/hooks/knowledge-store.ts"],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noConsole": "off"
-					}
-				}
-			}
-		},
-		{
-			"includes": ["src/hooks/skill-usage-log.ts"],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noConsole": "off"
-					}
-				}
-			}
-		},
-		{
 			"includes": [
 				"src/commands/archive.error-handling.test.ts",
 				"src/commands/benchmark.error-handling.test.ts",

--- a/docs/releases/pending/issue-1756-tui-safety-closeout.md
+++ b/docs/releases/pending/issue-1756-tui-safety-closeout.md
@@ -14,6 +14,10 @@
 - Removed the leaking state-module mock from the reset command suite and
   restored that suite to the isolated CI matrix.
 - Repaired UTF-8 BOM and mojibake damage in runtime source and curator prompts.
+- Preserved the two `src/index.ts` `chat.message` diagnostic sites as explicit
+  `DEBUG_SWARM`-gated, inline-rationalized exceptions. They were audited rather
+  than migrated to `log()`, correcting the earlier fragment's inaccurate
+  migration claim while retaining their actual PR5 history.
 
 ## Why
 

--- a/docs/releases/pending/issue-1756-tui-safety-closeout.md
+++ b/docs/releases/pending/issue-1756-tui-safety-closeout.md
@@ -1,0 +1,28 @@
+# TUI safety closeout hardening
+
+## What changed
+
+- Replaced the curated console regression list with a recursive scan of
+  production TypeScript under `src/`. The CLI, logger, and warning-buffer
+  implementations keep narrow file-wide exemptions; every other intentional
+  raw console call requires a reasoned inline exception.
+- Removed three unused file-wide Biome exemptions so future hook changes cannot
+  silently bypass `noConsole` enforcement.
+- Routed malformed design-doc configuration, invalid primary-agent fallback,
+  unusable council overrides, and cherry-pick tip-only degradation through the
+  deferred operator advisory channel.
+- Removed the leaking state-module mock from the reset command suite and
+  restored that suite to the isolated CI matrix.
+- Repaired UTF-8 BOM and mojibake damage in runtime source and curator prompts.
+
+## Why
+
+The original issue migration was present, but its prevention test covered only
+a hand-maintained subset of source and the reset regression suite remained
+quarantined. This closeout makes the prevention boundary mechanical and keeps
+actionable failures discoverable without writing into the live terminal UI.
+
+## Migration
+
+No user action is required. Existing debug logging and `/swarm diagnose`
+behavior remain compatible.

--- a/docs/releases/pending/tui-pollution-pr5-consoles.md
+++ b/docs/releases/pending/tui-pollution-pr5-consoles.md
@@ -1,55 +1,33 @@
-# TUI pollution sweep — console wrapper final migration (PR5 of epic #1752)
+# TUI pollution sweep — console enforcement (PR5 of epic #1752)
 
-## What
+## What changed
 
-Migrates the last two raw `console.error` calls in `src/index.ts` (the
-`chat.message` plugin hook diagnostics on entry and exit) to `log()`, completing
-the epic #1752 migration. After this PR the codebase has zero raw
-`console.warn`/`console.error`/`console.log` in `src/` (biome `noConsole`
-enforcement).
+The final sweep migrated the issue-listed command, plan, worktree, parallel,
+Lean Turbo, SDD, and SBOM warning sites to the debug logger or deferred
+`advisoryWarn` channel. Biome now rejects new raw console calls in production
+source unless the call has a narrowly documented exception.
 
-The two sites are guarded by `if (process.env.DEBUG_SWARM)` and were
-intentionally excluded from the PR1–PR4 sweeps — they fire only on explicit
-debug activation and were considered low-risk for TUI pollution. The same
-`log()` helper used by PR1–PR4 is applied here for consistency.
-
-Also enables Biome `suspicious/noConsole` rule globally in `biome.json` as the
-enforcement mechanism for the epic's "zero raw console in src/" invariant.
-
-## Migration
-
-- `console.error(\`[DIAG] chat.message agent=... session=...\`)`
-  → `log(\`[DIAG] chat.message agent=... session=...\`)`
-- `console.error(\`[DIAG] chat.message DONE agent=...\`)`
-  → `log(\`[DIAG] chat.message DONE agent=...\`)`
-
-Both are `OPENCODE_SWARM_DEBUG=1`-gated (same as PR1–PR4).
-
-## Files
-
-- `src/index.ts` — 2 `chat.message` hook diagnostic calls
+The CLI, logger, and warning-buffer implementations retain narrow file-wide
+Biome exemptions because writing or retaining terminal diagnostics is their
+explicit responsibility. Elsewhere, intentional raw console calls remain only
+for bounded fatal/security messages, quiet-mode parity warnings, one-time
+download progress, and explicit debug diagnostics; each carries an inline
+`biome-ignore` rationale. Normal plugin operation remains free of terminal
+noise when debug mode is disabled.
 
 ## Why
 
-Epic #1752 systematically eliminated raw console writes from every agent-facing
-code path. The `chat.message` hook diagnostics in `src/index.ts` were the last
-two holdouts. Closing them completes the invariant: no console noise during
-normal operation (`OPENCODE_SWARM_DEBUG` unset). Operators with
-`OPENCODE_SWARM_DEBUG=1` see the same diagnostic messages; `/swarm diagnose`
-surfaces actionable advisories through the buffered `advisoryWarn` channel.
+Raw stdout/stderr writes can corrupt the Bubble Tea display while the OpenCode
+plugin host owns the terminal. Diagnostic-only messages now use debug logging,
+and recoverable conditions that require operator action are buffered for
+`/swarm diagnose` without writing into the live TUI stream.
 
-## Behavior changes
+## Behavior and migration
 
-- Zero console noise during normal operation (no `OPENCODE_SWARM_DEBUG`).
-- Same debug diagnostics available via `OPENCODE_SWARM_DEBUG=1`.
-- `/swarm diagnose` shows buffered `advisoryWarn` messages as before.
+No configuration or API migration is required. Operators can enable
+`OPENCODE_SWARM_DEBUG=1` for diagnostic logs and use `/swarm diagnose` for
+buffered advisories.
 
 ## Epic context
 
-- Closes #1752 (final PR of epic #1752)
-- PR1 #1758, PR2 #1789, PR3 #1829, PR4 #1834 already merged
-
-## Test impact
-
-Small set of test files updated to spy on the `log()` helper instead of
-`console.error` for the two `chat.message` diagnostic sites.
+This was PR5 of epic #1752, following PRs #1758, #1789, #1829, and #1834.

--- a/scripts/ci/quarantined-tests.txt
+++ b/scripts/ci/quarantined-tests.txt
@@ -8,12 +8,6 @@
 # to any specific PR. Tracked under #1737 (test quarantine debt) pending a
 # dedicated test-stability sprint.
 #
-# reset.test.ts: mock.module('../../../src/state.js') leaks across test files
-# in Bun's shared test-runner process, causing state.test.ts and other tests
-# in the same partition to receive the mock's resetSwarmState (which throws).
-# The mock must be replaced with a _internals DI seam in state.ts to fix properly.
-# Quarantined per issue #1854 (partition reassignment from epic file-count growth).
-tests/unit/commands/reset.test.ts
 # swarm-artifact-cache.test.ts: all assertions pass, but bun can exit
 # non-zero on Windows CI runners (e.g. AV holding a handle on the tmpdir
 # during afterEach's recursive rm) — a platform quirk, not a test-logic bug.

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1018,11 +1018,7 @@ export function getAgentConfigs(
 		config?.default_agent,
 	);
 	if (resolution.warning) {
-		if (!quiet) {
-			log(resolution.warning);
-		} else {
-			addDeferredWarning(resolution.warning);
-		}
+		advisoryWarn(resolution.warning);
 	}
 	// Diagnostic invariant: a non-empty generated agent set must produce at least
 	// one primary. resolvePrimaryAgentNames already guarantees this; this is a
@@ -1035,6 +1031,33 @@ export function getAgentConfigs(
 			log(diagnostic);
 		} else {
 			addDeferredWarning(diagnostic);
+		}
+	}
+
+	// Council enablement is config-global, so validate the architect override once
+	// per invocation rather than once per generated architect in multi-swarm mode.
+	// Repeating the same advisory can exhaust the bounded warning buffer and hide
+	// later, distinct operator guidance.
+	const architectOverride = toolFilterOverrides.architect;
+	if (
+		toolFilterEnabled &&
+		config?.council?.enabled !== true &&
+		architectOverride !== undefined
+	) {
+		const councilTools = [
+			'declare_council_criteria',
+			'submit_council_verdicts',
+			'submit_phase_council_verdicts',
+			'write_final_council_evidence',
+		];
+		const present = councilTools.filter((tool) =>
+			architectOverride.includes(tool),
+		);
+		if (present.length > 0) {
+			advisoryWarn(
+				`[opencode-swarm] tool_filter.overrides.architect includes ${present.join(', ')} but council.enabled is not true. ` +
+					`The runtime gate will reject these calls. Either set council.enabled=true, or remove ${present.join(', ')} from the architect override.`,
+			);
 		}
 	}
 
@@ -1175,31 +1198,6 @@ export function getAgentConfigs(
 						const skillToolsSet = new Set<string>(skillTools);
 						allowedTools = allowedTools.filter((t) => !skillToolsSet.has(t));
 					}
-				}
-			}
-
-			// Symmetric validation: when council is OFF but the user override
-			// INCLUDES the council tools, the runtime gate in
-			// src/tools/convene-council.ts will reject any model attempt to call
-			// them. Warn so the user knows the tools are present in the override
-			// but unusable at runtime.
-			if (
-				baseAgentName === 'architect' &&
-				config?.council?.enabled !== true &&
-				override !== undefined
-			) {
-				const councilTools = [
-					'declare_council_criteria',
-					'submit_council_verdicts',
-					'submit_phase_council_verdicts',
-					'write_final_council_evidence',
-				];
-				const present = councilTools.filter((t) => override.includes(t));
-				if (present.length > 0 && !quiet) {
-					advisoryWarn(
-						`[opencode-swarm] tool_filter.overrides.architect includes ${present.join(', ')} but council.enabled is not true. ` +
-							`The runtime gate will reject these calls. Either set council.enabled=true, or remove ${present.join(', ')} from the architect override.`,
-					);
 				}
 			}
 

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -1,4 +1,4 @@
-﻿import * as child_process from 'node:child_process';
+import * as child_process from 'node:child_process';
 import * as fsSync from 'node:fs';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';

--- a/src/commands/design-docs.ts
+++ b/src/commands/design-docs.ts
@@ -5,9 +5,13 @@
  */
 
 import { loadPluginConfigWithMeta } from '../config';
-import { log } from '../utils/logger';
+import { advisoryWarn } from '../services/warning-buffer';
 
 const MAX_DESC_LEN = 2000;
+
+export const _internals: {
+	loadPluginConfigWithMeta: typeof loadPluginConfigWithMeta;
+} = { loadPluginConfigWithMeta };
 
 const USAGE = `Usage: /swarm design-docs <description> [--out <dir>] [--lang <name>] [--update]
 
@@ -142,7 +146,7 @@ export async function handleDesignDocsCommand(
 	// design_docs.enabled === true. Emitting the MODE signal while disabled would
 	// route the architect to dispatch an unregistered agent. Fail fast instead.
 	try {
-		const { config } = loadPluginConfigWithMeta(directory);
+		const { config } = _internals.loadPluginConfigWithMeta(directory);
 		if (config.design_docs?.enabled !== true) {
 			return (
 				'Error: design docs are disabled. Set `design_docs.enabled: true` in ' +
@@ -154,7 +158,7 @@ export async function handleDesignDocsCommand(
 		// If config cannot be loaded, fall through — the architect MODE protocol
 		// also checks registration and stops if docs_design is unavailable.
 		// Emit a warning so the UX is not silent (F-15 / PR #1096 follow-up).
-		log(
+		advisoryWarn(
 			`[design-docs] Could not read opencode-swarm.json (${String(configErr)}). ` +
 				'Falling through — the architect will abort if docs_design is not registered.',
 		);

--- a/src/commands/pr-feedback.ts
+++ b/src/commands/pr-feedback.ts
@@ -1,22 +1,22 @@
 /**
  * Handle /swarm pr-feedback command.
  *
- * Triggers the architect to enter MODE: PR_FEEDBACK â€” the swarm workflow for
+ * Triggers the architect to enter MODE: PR_FEEDBACK — the swarm workflow for
  * ingesting and closing KNOWN pull-request feedback (review comments, requested
  * changes, CI failures, merge conflicts, stale branches, pasted notes). This is
  * distinct from /swarm pr-review, which discovers NEW findings.
  *
  * Input contract (PR reference is optional):
- *   /swarm pr-feedback 155                         â†’ feedback pass on PR 155
- *   /swarm pr-feedback 155 also fix the lint errors â†’ PR 155 + extra instructions
+ *   /swarm pr-feedback 155                         → feedback pass on PR 155
+ *   /swarm pr-feedback 155 also fix the lint errors → PR 155 + extra instructions
  *   /swarm pr-feedback 155 continue from .swarm/pr-review/<run_id>/feedback-handoff.md
  *                                                   -> PR 155 + handoff path instructions
- *   /swarm pr-feedback owner/repo#155               â†’ shorthand
+ *   /swarm pr-feedback owner/repo#155               → shorthand
  *   /swarm pr-feedback https://github.com/.../pull/155
- *   /swarm pr-feedback                              â†’ bare signal; architect builds
+ *   /swarm pr-feedback                              → bare signal; architect builds
  *                                                     the ledger from current PR/branch
  *   /swarm pr-feedback address the review notes about error handling
- *                                                   â†’ no parseable PR ref â‡’ the whole
+ *                                                   → no parseable PR ref ⇒ the whole
  *                                                     input is forwarded as instructions
  *
  * PR-reference parsing and injection-hardening are shared with /swarm pr-review
@@ -35,7 +35,7 @@ export function handlePrFeedbackCommand(
 ): string {
 	const rest = args.filter((t) => t.trim().length > 0);
 
-	// No args â†’ bare signal. The architect/skill assembles the feedback ledger
+	// No args → bare signal. The architect/skill assembles the feedback ledger
 	// from the current PR, branch state, and any pasted context.
 	if (rest.length === 0) {
 		return '[MODE: PR_FEEDBACK]';
@@ -53,7 +53,7 @@ export function handlePrFeedbackCommand(
 	}
 
 	// The leading token is shaped like a PR reference (bare number, shorthand, or
-	// URL) but could not be resolved â€” e.g. a bare number with no reachable
+	// URL) but could not be resolved — e.g. a bare number with no reachable
 	// `origin` remote, or a rejected URL. Surface the error instead of silently
 	// demoting an intended PR reference to free-text feedback.
 	if (resolved && 'error' in resolved && looksLikePrRef(rest[0])) {

--- a/src/config/bundled-skills.ts
+++ b/src/config/bundled-skills.ts
@@ -1,4 +1,4 @@
-﻿import { randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import { advisoryWarn } from '../services/warning-buffer.js';
@@ -74,7 +74,7 @@ function describeBundledSkillSyncFailure(err: unknown): string {
 // ---------------------------------------------------------------------------
 // Async materialization for the plugin-init path. The plugin-init path must be
 // bounded by `withTimeout` (AGENTS.md Invariant 1). `withTimeout` is
-// `Promise.race`, so it can only bound work that actually yields â€” a synchronous
+// `Promise.race`, so it can only bound work that actually yields — a synchronous
 // copy loop wrapped in an async IIFE still runs to completion on one tick and is
 // NOT bounded. This implementation uses `fs/promises` with real await points
 // between files so the timeout is enforceable at file boundaries.

--- a/src/hooks/knowledge-curator.ts
+++ b/src/hooks/knowledge-curator.ts
@@ -1,4 +1,4 @@
-﻿/** Knowledge curator hook for opencode-swarm v6.17 two-tier knowledge system. */
+/** Knowledge curator hook for opencode-swarm v6.17 two-tier knowledge system. */
 import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import {
@@ -69,7 +69,7 @@ const seenRetroSections = new Map<
 	string,
 	{ value: string; timestamp: number }
 >();
-// AGENTS.md Â§8: module-level state must have an explicit eviction strategy, not
+// AGENTS.md §8: module-level state must have an explicit eviction strategy, not
 // only time-based pruning. A burst of distinct sessions inside the 24h window
 // would otherwise grow this map without bound. Cap the entry count and evict the
 // oldest-timestamp entries (LRU-by-recency) once the cap is exceeded.
@@ -515,19 +515,19 @@ export function buildV3EnrichmentPrompt(
 ): string {
 	return [
 		'Convert this prose lesson into an actionable knowledge directive.',
-		'Output ONLY a single JSON object â€” no code fences, no commentary.',
+		'Output ONLY a single JSON object — no code fences, no commentary.',
 		'',
 		'MANDATORY fields (the directive is rejected without them):',
 		'- At least ONE scope field non-empty:',
-		'  "applies_to_agents": string[] â€” roles from: architect, coder, reviewer, test_engineer, sme, docs, designer, critic, curator',
-		'  "applies_to_tools": string[] â€” tool names from: edit, write, patch, bash, read, grep, glob',
+		'  "applies_to_agents": string[] — roles from: architect, coder, reviewer, test_engineer, sme, docs, designer, critic, curator',
+		'  "applies_to_tools": string[] — tool names from: edit, write, patch, bash, read, grep, glob',
 		'- At least ONE predicate field non-empty:',
-		'  "forbidden_actions": string[] â€” concrete actions to never take',
-		'  "required_actions": string[] â€” concrete actions to always take',
-		'  "verification_checks": string[] â€” checks a reviewer can run',
+		'  "forbidden_actions": string[] — concrete actions to never take',
+		'  "required_actions": string[] — concrete actions to always take',
+		'  "verification_checks": string[] — checks a reviewer can run',
 		'',
 		'OPTIONAL fields:',
-		'  "triggers": string[] â€” short phrases that should surface this lesson',
+		'  "triggers": string[] — short phrases that should surface this lesson',
 		'  "directive_priority": "low" | "medium" | "high" | "critical"',
 		'',
 		'Example output:',
@@ -556,8 +556,8 @@ function buildV3BatchEnrichmentPrompt(
 		'',
 		'For EACH element, mandatory requirements:',
 		'- At least ONE scope field non-empty:',
-		'  "applies_to_agents": string[] â€” roles from: architect, coder, reviewer, test_engineer, sme, docs, designer, critic, curator',
-		'  "applies_to_tools": string[] â€” tool names from: edit, write, patch, bash, read, grep, glob',
+		'  "applies_to_agents": string[] — roles from: architect, coder, reviewer, test_engineer, sme, docs, designer, critic, curator',
+		'  "applies_to_tools": string[] — tool names from: edit, write, patch, bash, read, grep, glob',
 		'- At least ONE predicate field non-empty:',
 		'  "forbidden_actions": string[] | "required_actions": string[] | "verification_checks": string[]',
 		'',
@@ -809,7 +809,7 @@ interface EnrichmentLessonInput {
  * One retry on schema failure (with a RETRY message naming the missing
  * fields). Quota-gated per call via the dedicated knowledge-enrichment quota.
  * Returns null when
- * enrichment is unavailable (quota exhausted) or fails twice â€” the caller
+ * enrichment is unavailable (quota exhausted) or fails twice — the caller
  * quarantines the entry. Never throws.
  */
 export async function enrichLessonToV3(params: {
@@ -852,7 +852,7 @@ export async function enrichLessonToV3(params: {
 					err instanceof Error ? err.message : String(err)
 				}`,
 			);
-			// LLM/transport error: do not retry on a second transport failure path â€”
+			// LLM/transport error: do not retry on a second transport failure path —
 			// the loop's second iteration is the single retry budget either way.
 		}
 	}
@@ -882,7 +882,7 @@ async function appendCuratorSkippedEvent(
 	}
 }
 // ============================================================================
-// Meso reflector â€” micro-reflection insight consumption (Change 6, Task 5.2)
+// Meso reflector — micro-reflection insight consumption (Change 6, Task 5.2)
 // ============================================================================
 /** Max insight candidates folded into the store per phase boundary. */
 export const MESO_INSIGHT_BATCH_LIMIT = 20;
@@ -1139,7 +1139,7 @@ export async function curateAndStoreSwarm(
 			project_name: projectName,
 			auto_generated: true,
 		};
-		// Layer 5 â€” Mandatory v3 actionability (Change 4). No new entry reaches the
+		// Layer 5 — Mandatory v3 actionability (Change 4). No new entry reaches the
 		// active store without >=1 machine-checkable predicate AND >=1 scope tag.
 		// Plain-prose lessons are enriched via the curator LLM (one retry); entries
 		// that still fail are quarantined to the unactionable queue (recoverable by
@@ -1229,7 +1229,7 @@ export async function curateAndStoreSwarm(
 			// Defense-in-depth (Phase 5 review): the insight-candidates queue is an
 			// on-disk file that could be tampered between the micro-reflector's write
 			// and this read, so re-apply BOTH gates the micro-reflector applied at
-			// write time â€” shape (validateActionableFields: length caps, name
+			// write time — shape (validateActionableFields: length caps, name
 			// patterns, injection/control-char checks) AND presence
 			// (validateActionability). insightCandidateToEntry already copies only an
 			// explicit field allowlist (verification_predicate is never carried), so
@@ -1323,7 +1323,7 @@ export async function curateAndStoreSwarm(
 	await enforceKnowledgeCap(knowledgePath, config.swarm_max_entries);
 	// Change 5 / Task 6.2: refresh the tag co-occurrence synonym map from the
 	// post-write corpus so retrieval can expand queries along learned synonyms.
-	// Only when the corpus actually changed (something stored) â€” a no-op curation
+	// Only when the corpus actually changed (something stored) — a no-op curation
 	// run leaves the tag distribution untouched. Best-effort: a failure here must
 	// never break curation, and the retrieval read path degrades to no-expansion
 	// when the map is absent. The map is bounded by synonym_map_max_pairs.
@@ -1434,15 +1434,15 @@ export async function runAutoPromotion(
 /**
  * G7 (#1716): Auto-demote swarm entries that have sustained a net-negative
  * outcome signal over consecutive phase EVALUATIONS (i.e. consecutive
- * `runAutoDemotion` invocations with distinct phase numbers â€” a skipped phase
- * in between still counts, matching the issue's "â‰¥3 consecutive" intent as
+ * `runAutoDemotion` invocations with distinct phase numbers — a skipped phase
+ * in between still counts, matching the issue's "≥3 consecutive" intent as
  * implemented against evaluation cadence, not wall-clock phase contiguity).
  *
  * Companion to {@link runAutoPromotion}. For each `promoted` entry:
  *  1. Dedupe by phase: if `entry.last_demotion_phase === phaseNumber`, this
  *     entry has already been processed for this phase (handles the case where
  *     `curateAndStoreSwarm` is invoked multiple times in the same logical
- *     phase â€” e.g. phase-complete + close). Skip the counter update.
+ *     phase — e.g. phase-complete + close). Skip the counter update.
  *  2. Otherwise compute the outcome signal. If at/below
  *     `config.promoted_demotion_signal_threshold`, increment
  *     `recent_negative_phase_count`; else reset it to 0.
@@ -1486,7 +1486,7 @@ export async function runAutoDemotion(
 		// changed. Three real state transitions: counter increments, counter
 		// resets from a non-zero value (the entry "recovered" this phase), or
 		// demotion fires. A consistently-positive entry that stays at 0 between
-		// phases is a no-op â€” its `last_demotion_phase` update is the only
+		// phases is a no-op — its `last_demotion_phase` update is the only
 		// change and isn't worth a rewrite (the dedupe gate keys off it but a
 		// missing update is harmless: the next phase just re-evaluates).
 		const counterChanged = next !== prevCount;
@@ -1501,9 +1501,9 @@ export async function runAutoDemotion(
 		entry.recent_negative_phase_count = next;
 		entry.last_demotion_phase = phaseNumber;
 		if (willDemote) {
-			// Demote: promoted â†’ established. The boost-table raise (G7.2) means
+			// Demote: promoted → established. The boost-table raise (G7.2) means
 			// an `established` entry (+0.10) outranks a `candidate` (+0.0) but
-			// is outranked by a still-`promoted` entry (+0.15) â€” satisfying the
+			// is outranked by a still-`promoted` entry (+0.15) — satisfying the
 			// issue's intent that demoted entries no longer get the promoted boost.
 			entry.status = 'established';
 			entry.hive_eligible = false;
@@ -1648,7 +1648,7 @@ export function createKnowledgeCuratorHook(
 	return safeHook(handler);
 }
 // ============================================================================
-// DI Seam â€” _internals
+// DI Seam — _internals
 // ============================================================================
 export const _internals: {
 	isWriteToEvidenceFile: typeof isWriteToEvidenceFile;

--- a/src/worktree/merge.ts
+++ b/src/worktree/merge.ts
@@ -10,6 +10,7 @@
  * @module merge-back
  */
 
+import { advisoryWarn } from '../services/warning-buffer';
 import { log } from '../utils';
 import { bunSpawn } from '../utils/bun-compat';
 import { autoCommitDirty, cleanUntrackedFiles } from './core';
@@ -262,7 +263,7 @@ export async function mergeLaneBranch(
 			} else {
 				// No common ancestor (e.g. unrelated histories) — fall back
 				// to cherry-picking just the branch tip with a warning.
-				log(
+				advisoryWarn(
 					'[worktree] mergeLaneBranch: git merge-base failed for cherry-pick; falling back to tip-only cherry-pick',
 				);
 				result = await runGit(['cherry-pick', branchName], primaryDir);

--- a/tests/unit/agents/primary-warning-routing.test.ts
+++ b/tests/unit/agents/primary-warning-routing.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { getAgentConfigs } from '../../../src/agents';
+import type { PluginConfig } from '../../../src/config';
+import {
+	clearDeferredWarnings,
+	getDeferredWarnings,
+} from '../../../src/services/warning-buffer';
+
+const originalDebug = process.env.OPENCODE_SWARM_DEBUG;
+
+afterEach(() => {
+	clearDeferredWarnings();
+	if (originalDebug === undefined) delete process.env.OPENCODE_SWARM_DEBUG;
+	else process.env.OPENCODE_SWARM_DEBUG = originalDebug;
+});
+
+function configWithActionableWarnings(quiet: boolean): PluginConfig {
+	return {
+		quiet,
+		default_agent: 'not_a_registered_agent',
+		tool_filter: {
+			enabled: true,
+			overrides: { architect: ['declare_council_criteria'] },
+		},
+	} as PluginConfig;
+}
+
+function councilWarnings(): string[] {
+	return getDeferredWarnings().filter((message) =>
+		message.includes('council.enabled is not true'),
+	);
+}
+
+describe('getAgentConfigs actionable warning routing', () => {
+	for (const quiet of [true, false]) {
+		test(`buffers primary fallback and unusable council override when quiet=${quiet}`, () => {
+			delete process.env.OPENCODE_SWARM_DEBUG;
+			clearDeferredWarnings();
+
+			getAgentConfigs(configWithActionableWarnings(quiet));
+
+			const warnings = getDeferredWarnings();
+			expect(
+				warnings.some((message) => message.includes('default_agent')),
+			).toBe(true);
+			expect(
+				warnings.some((message) =>
+					message.includes('council.enabled is not true'),
+				),
+			).toBe(true);
+		});
+
+		test(`buffers one council advisory across multiple swarms when quiet=${quiet}`, () => {
+			getAgentConfigs({
+				quiet,
+				swarms: {
+					local: { name: 'Local', agents: {} },
+					mega: { name: 'Mega', agents: {} },
+				},
+				tool_filter: {
+					enabled: true,
+					overrides: { architect: ['declare_council_criteria'] },
+				},
+			} as PluginConfig);
+
+			expect(councilWarnings()).toHaveLength(1);
+		});
+	}
+
+	test('does not warn when council is enabled', () => {
+		getAgentConfigs({
+			council: { enabled: true },
+			tool_filter: {
+				enabled: true,
+				overrides: { architect: ['declare_council_criteria'] },
+			},
+		} as PluginConfig);
+
+		expect(councilWarnings()).toHaveLength(0);
+	});
+
+	test('does not warn when the architect override is absent', () => {
+		getAgentConfigs({
+			council: { enabled: false },
+			tool_filter: { enabled: true, overrides: {} },
+		} as PluginConfig);
+
+		expect(councilWarnings()).toHaveLength(0);
+	});
+});

--- a/tests/unit/commands/design-docs.test.ts
+++ b/tests/unit/commands/design-docs.test.ts
@@ -5,11 +5,18 @@
  * when no actionable input is given.
  */
 
-import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { handleDesignDocsCommand } from '../../../src/commands/design-docs';
+import {
+	_internals,
+	handleDesignDocsCommand,
+} from '../../../src/commands/design-docs';
+import {
+	clearDeferredWarnings,
+	getDeferredWarnings,
+} from '../../../src/services/warning-buffer';
 import { createIsolatedTestEnv } from '../../helpers/isolated-test-env';
 
 // A project dir with design_docs enabled, so the gate lets the signal through.
@@ -21,6 +28,7 @@ let disabledDir: string;
 // cannot leak into loadPluginConfigWithMeta()'s user-config lookup and make
 // the "disabled" gate test non-deterministic across machines.
 let isolatedEnv: ReturnType<typeof createIsolatedTestEnv>;
+const realLoadPluginConfigWithMeta = _internals.loadPluginConfigWithMeta;
 
 beforeAll(() => {
 	isolatedEnv = createIsolatedTestEnv();
@@ -38,6 +46,11 @@ afterAll(() => {
 	fs.rmSync(enabledDir, { recursive: true, force: true });
 	fs.rmSync(disabledDir, { recursive: true, force: true });
 	isolatedEnv.cleanup();
+});
+
+afterEach(() => {
+	_internals.loadPluginConfigWithMeta = realLoadPluginConfigWithMeta;
+	clearDeferredWarnings();
 });
 
 describe('handleDesignDocsCommand — opt-in gate', () => {
@@ -71,6 +84,20 @@ describe('handleDesignDocsCommand — opt-in gate', () => {
 		} finally {
 			fs.rmSync(malformedDir, { recursive: true, force: true });
 		}
+	});
+
+	it('buffers an advisory when config loading throws and still falls through', async () => {
+		clearDeferredWarnings();
+		_internals.loadPluginConfigWithMeta = () => {
+			throw new Error('forced config loader failure');
+		};
+
+		const out = await handleDesignDocsCommand(disabledDir, ['--update']);
+		expect(out).toContain('[MODE: DESIGN_DOCS');
+		expect(getDeferredWarnings()).toHaveLength(1);
+		expect(getDeferredWarnings()[0]).toContain(
+			'Could not read opencode-swarm.json',
+		);
 	});
 });
 

--- a/tests/unit/commands/reset.test.ts
+++ b/tests/unit/commands/reset.test.ts
@@ -5,70 +5,11 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-// ── Mocks (must precede the SUT import; state mock for singleton preservation test) ──
-// reset command itself does not import state (unlike close.ts), but we mock surrounding
-// state to verify that the reset command path leaves the 7 init singletons intact.
-type MockSwarmState = {
-	activeToolCalls: Map<string, unknown>;
-	toolAggregates: Map<string, unknown>;
-	activeAgent: Map<string, unknown>;
-	delegationChains: Map<string, unknown>;
-	pendingEvents: number;
-	lastBudgetPct: number;
-	agentSessions: Map<string, unknown>;
-	pendingRehydrations: Set<unknown>;
-	opencodeClient: unknown;
-	fullAutoEnabledInConfig: boolean;
-	curatorInitAgentNames: string[];
-	curatorPhaseAgentNames: string[];
-	skillImproverAgentNames: string[];
-	specWriterAgentNames: string[];
-	generatedAgentNames: string[];
-	currentCriticalShownIds: Map<string, unknown>;
-	knowledgeAckDedup: Set<unknown>;
-	environmentProfiles: Map<string, unknown>;
-};
-
-let mockedSwarmState: MockSwarmState = {} as MockSwarmState;
-
-mock.module('../../../src/state.js', () => {
-	mockedSwarmState = {
-		activeToolCalls: new Map<string, unknown>(),
-		toolAggregates: new Map<string, unknown>(),
-		activeAgent: new Map<string, unknown>(),
-		delegationChains: new Map<string, unknown>(),
-		pendingEvents: 0,
-		lastBudgetPct: 0,
-		agentSessions: new Map<string, unknown>(),
-		pendingRehydrations: new Set<unknown>(),
-		opencodeClient: null,
-		fullAutoEnabledInConfig: false,
-		curatorInitAgentNames: [] as string[],
-		curatorPhaseAgentNames: [] as string[],
-		skillImproverAgentNames: [] as string[],
-		specWriterAgentNames: [] as string[],
-		generatedAgentNames: [] as string[],
-		currentCriticalShownIds: new Map<string, unknown>(),
-		knowledgeAckDedup: new Set<unknown>(),
-		environmentProfiles: new Map<string, unknown>(),
-	};
-	return {
-		swarmState: mockedSwarmState,
-		endAgentSession: () => {},
-		// Guard: reset command path must never invoke swarmState reset (bare or preserving).
-		// Only close.ts uses resetSwarmStatePreservingSingletons to keep the 7 init singletons.
-		resetSwarmState: () => {
-			throw new Error('reset command path must not call resetSwarmState');
-		},
-		resetSwarmStatePreservingSingletons: () => {
-			throw new Error(
-				'reset command path must not call resetSwarmStatePreservingSingletons',
-			);
-		},
-	};
-});
-
+// The only cross-module mock in this file is the scoped node:fs error simulation.
+// The reset command does not import state; this suite verifies the real singleton
+// remains intact without a process-global state mock.
 import { handleResetCommand } from '../../../src/commands/reset';
+import { swarmState } from '../../../src/state';
 
 describe('handleResetCommand', () => {
 	let tempDir: string;
@@ -79,8 +20,7 @@ describe('handleResetCommand', () => {
 	});
 
 	afterEach(async () => {
-		// Restore cross-module mocks (state.js) to prevent leakage to other tests in file.
-		// Per writing-tests skill and AGENTS.md test isolation rules.
+		// Restore the node:fs mock used by the EBUSY/EACCES cases below.
 		mock.restore();
 		if (existsSync(tempDir)) {
 			await rm(tempDir, { recursive: true, force: true });
@@ -364,28 +304,7 @@ describe('handleResetCommand', () => {
 	// Verifies that the reset command path does not disturb the 7 module-scoped
 	// singletons that are preserved by resetSwarmStatePreservingSingletons (used by close).
 	// reset command only clears .swarm/ files + automation; swarmState singletons must survive.
-	test('singleton preservation through reset command path - 7 init singletons survive (mock surrounding state)', async () => {
-		// Re-initialize mockedSwarmState (mock.module runs once at load; afterEach
-		// mock.restore() may have cleared it, so re-assign the fields we need).
-		mockedSwarmState = {
-			activeToolCalls: new Map<string, unknown>(),
-			toolAggregates: new Map<string, unknown>(),
-			activeAgent: new Map<string, unknown>(),
-			delegationChains: new Map<string, unknown>(),
-			pendingEvents: 0,
-			opencodeClient: null,
-			curatorInitAgentNames: [] as string[],
-			curatorPhaseAgentNames: [] as string[],
-			skillImproverAgentNames: [] as string[],
-			specWriterAgentNames: [] as string[],
-			generatedAgentNames: [] as string[],
-			lastBudgetPct: 0,
-			agentSessions: new Map<string, unknown>(),
-			pendingRehydrations: new Set<Promise<void>>(),
-			fullAutoEnabledInConfig: false,
-			environmentProfiles: new Map<string, unknown>(),
-		} as MockSwarmState;
-
+	test('singleton preservation through reset command path - 7 init singletons survive', async () => {
 		// Create .swarm/plan.md so the reset command actually deletes it.
 		await mkdir(join(tempDir, '.swarm'), { recursive: true });
 		await writeFile(join(tempDir, '.swarm', 'plan.md'), '# test');
@@ -393,38 +312,54 @@ describe('handleResetCommand', () => {
 		// Set sentinel values for the 7 preserved singletons (populated at plugin init).
 		// Also seed transient state that a bare resetSwarmState would clear.
 		const sentinelClient = { __reset_test: 'preserved-opencode-client' };
-		mockedSwarmState.opencodeClient = sentinelClient;
-		mockedSwarmState.fullAutoEnabledInConfig = true;
-		mockedSwarmState.curatorInitAgentNames = ['reset_init_a', 'reset_init_b'];
-		mockedSwarmState.curatorPhaseAgentNames = ['reset_phase_x'];
-		mockedSwarmState.skillImproverAgentNames = ['reset_skill_y'];
-		mockedSwarmState.specWriterAgentNames = ['reset_spec_z'];
-		mockedSwarmState.generatedAgentNames = ['reset_gen_1', 'reset_gen_2'];
-		mockedSwarmState.pendingEvents = 999;
-		mockedSwarmState.lastBudgetPct = 42;
-		mockedSwarmState.activeToolCalls.set('reset-test-call', { tool: 'y' });
+		const original = {
+			opencodeClient: swarmState.opencodeClient,
+			fullAutoEnabledInConfig: swarmState.fullAutoEnabledInConfig,
+			curatorInitAgentNames: swarmState.curatorInitAgentNames,
+			curatorPhaseAgentNames: swarmState.curatorPhaseAgentNames,
+			skillImproverAgentNames: swarmState.skillImproverAgentNames,
+			specWriterAgentNames: swarmState.specWriterAgentNames,
+			generatedAgentNames: swarmState.generatedAgentNames,
+			pendingEvents: swarmState.pendingEvents,
+			lastBudgetPct: swarmState.lastBudgetPct,
+		};
+		try {
+			swarmState.opencodeClient = sentinelClient as never;
+			swarmState.fullAutoEnabledInConfig = true;
+			swarmState.curatorInitAgentNames = ['reset_init_a', 'reset_init_b'];
+			swarmState.curatorPhaseAgentNames = ['reset_phase_x'];
+			swarmState.skillImproverAgentNames = ['reset_skill_y'];
+			swarmState.specWriterAgentNames = ['reset_spec_z'];
+			swarmState.generatedAgentNames = ['reset_gen_1', 'reset_gen_2'];
+			swarmState.pendingEvents = 999;
+			swarmState.lastBudgetPct = 42;
+			swarmState.activeToolCalls.set('reset-test-call', { tool: 'y' });
 
-		const result = await handleResetCommand(tempDir, ['--confirm']);
+			const result = await handleResetCommand(tempDir, ['--confirm']);
 
-		// Reset command still performs its file/automation work.
-		expect(result).toContain('## Swarm Reset Complete');
-		expect(result).toContain('✅ Deleted plan.md');
+			// Reset command still performs its file/automation work.
+			expect(result).toContain('## Swarm Reset Complete');
+			expect(result).toContain('✅ Deleted plan.md');
 
-		// All 7 singletons must survive the reset command path (proves no bare or
-		// preserving reset of swarmState was triggered by handleResetCommand).
-		expect(mockedSwarmState.opencodeClient).toBe(sentinelClient);
-		expect(mockedSwarmState.fullAutoEnabledInConfig).toBe(true);
-		expect(mockedSwarmState.curatorInitAgentNames).toEqual([
-			'reset_init_a',
-			'reset_init_b',
-		]);
-		expect(mockedSwarmState.curatorPhaseAgentNames).toEqual(['reset_phase_x']);
-		expect(mockedSwarmState.skillImproverAgentNames).toEqual(['reset_skill_y']);
-		expect(mockedSwarmState.specWriterAgentNames).toEqual(['reset_spec_z']);
-		expect(mockedSwarmState.generatedAgentNames).toEqual([
-			'reset_gen_1',
-			'reset_gen_2',
-		]);
+			// All 7 singletons must survive the reset command path (proves no bare or
+			// preserving reset of swarmState was triggered by handleResetCommand).
+			expect(swarmState.opencodeClient).toBe(sentinelClient);
+			expect(swarmState.fullAutoEnabledInConfig).toBe(true);
+			expect(swarmState.curatorInitAgentNames).toEqual([
+				'reset_init_a',
+				'reset_init_b',
+			]);
+			expect(swarmState.curatorPhaseAgentNames).toEqual(['reset_phase_x']);
+			expect(swarmState.skillImproverAgentNames).toEqual(['reset_skill_y']);
+			expect(swarmState.specWriterAgentNames).toEqual(['reset_spec_z']);
+			expect(swarmState.generatedAgentNames).toEqual([
+				'reset_gen_1',
+				'reset_gen_2',
+			]);
+		} finally {
+			Object.assign(swarmState, original);
+			swarmState.activeToolCalls.delete('reset-test-call');
+		}
 	});
 
 	// ── EBUSY / LOCKED FILE ERROR HANDLING (FR-007) ──────────────────────────────

--- a/tests/unit/hooks/knowledge-curator-encoding.test.ts
+++ b/tests/unit/hooks/knowledge-curator-encoding.test.ts
@@ -6,6 +6,7 @@ import { buildV3EnrichmentPrompt } from '../../../src/hooks/knowledge-curator';
 const REPO_ROOT = path.resolve(import.meta.dir, '../../..');
 const PR5_RUNTIME_FILES = [
 	'src/commands/close.ts',
+	'src/commands/pr-feedback.ts',
 	'src/config/bundled-skills.ts',
 	'src/hooks/knowledge-curator.ts',
 ];
@@ -29,5 +30,16 @@ describe('PR5 runtime text encoding', () => {
 		);
 		expect(prompt).toContain('—');
 		expect(prompt).not.toContain('â€”');
+	});
+
+	test('PR feedback command documentation contains real punctuation, not mojibake', () => {
+		const source = readFileSync(
+			path.join(REPO_ROOT, 'src/commands/pr-feedback.ts'),
+			'utf8',
+		);
+		expect(source).toContain('MODE: PR_FEEDBACK — the swarm workflow');
+		expect(source).toContain('→ feedback pass on PR 155');
+		expect(source).toContain('no parseable PR ref ⇒ the whole');
+		expect(source).not.toMatch(/[âÃ]/u);
 	});
 });

--- a/tests/unit/hooks/knowledge-curator-encoding.test.ts
+++ b/tests/unit/hooks/knowledge-curator-encoding.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { buildV3EnrichmentPrompt } from '../../../src/hooks/knowledge-curator';
+
+const REPO_ROOT = path.resolve(import.meta.dir, '../../..');
+const PR5_RUNTIME_FILES = [
+	'src/commands/close.ts',
+	'src/config/bundled-skills.ts',
+	'src/hooks/knowledge-curator.ts',
+];
+
+describe('PR5 runtime text encoding', () => {
+	test('changed runtime files are UTF-8 without a byte-order mark', () => {
+		for (const file of PR5_RUNTIME_FILES) {
+			const bytes = readFileSync(path.join(REPO_ROOT, file));
+			expect(
+				[...bytes.subarray(0, 3)],
+				`${file} must not begin with UTF-8 BOM bytes`,
+			).not.toEqual([0xef, 0xbb, 0xbf]);
+		}
+	});
+
+	test('knowledge-curator enrichment prompt contains real punctuation, not mojibake', () => {
+		const prompt = buildV3EnrichmentPrompt(
+			'Always verify the current PR head.',
+			'workflow',
+			['github'],
+		);
+		expect(prompt).toContain('—');
+		expect(prompt).not.toContain('â€”');
+	});
+});

--- a/tests/unit/plugin-tui-safety.test.ts
+++ b/tests/unit/plugin-tui-safety.test.ts
@@ -1,443 +1,134 @@
 import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
-import path from 'path';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
 
 const REPO_ROOT = path.resolve(import.meta.dir, '../..');
+const SRC_ROOT = path.join(REPO_ROOT, 'src');
+const RAW_CONSOLE = /console\.(warn|error|log)\(/;
+const INLINE_RATIONALE = /biome-ignore lint\/suspicious\/noConsole:\s*\S/;
+const IMPLEMENTATION_EXEMPTIONS = new Set([
+	'src/utils/logger.ts',
+	'src/services/warning-buffer.ts',
+]);
 
-/**
- * Source files on the plugin-host path that can write to the terminal while the
- * host bubbletea TUI owns it. Each is scanned for raw `console.warn` calls that
- * bypass the TUI-safety contract (issue #1249 class; broader sweep in epic
- * #1752). As PR2–5 of #1752 migrate the remaining modules, add them to this
- * scope list so the same class of regression cannot recur there.
- *
- * The contract: every `console.warn` must be guarded by a `quiet`/`config.quiet`
- * check (either `!config.quiet` / `!quiet`, or a `quiet ... else` two-way
- * branch). The bundled-skill sync failure path legitimately retains a guarded
- * `console.warn` for the `quiet=false` host parity branch; that is allowed
- * because it is guarded. The success path is now debug-gated only.
- *
- * Unconditional `console.error` / `logger.error()` on exceptional paths (init
- * failure, pr-monitor errors) are intentionally out of scope — the two
- * intentional FATAL `console.error` calls in src/index.ts are biome-ignored
- * with an explicit issue #675 rationale.
- */
-const TUI_SAFETY_SCOPES: Array<{
-	file: string;
-	label: string;
-	quietTokens: string[];
-}> = [
-	// src/index.ts uses `config.quiet` as the guard variable name.
-	{
-		file: 'src/index.ts',
-		label: 'index.ts',
-		quietTokens: ['!config.quiet'],
-	},
-	// src/config/bundled-skills.ts uses a local `quiet` parameter.
-	{
-		file: 'src/config/bundled-skills.ts',
-		label: 'bundled-skills.ts',
-		quietTokens: ['!quiet', 'quiet)'],
-	},
-	// src/commands/registry.ts: the command path must never write stderr
-	// mid-turn; assert it has zero unguarded console.warn (it should have
-	// zero console.warn at all).
-	{
-		file: 'src/commands/registry.ts',
-		label: 'registry.ts',
-		quietTokens: ['!config.quiet', '!quiet'],
-	},
-	// PR2 of epic #1752 migrated these init-path modules to advisoryWarn/log.
-	// They must contain ZERO raw console.warn/error/log (the `noConsole` lint
-	// rule is deferred to PR5, so this static guard is the interim regression
-	// net). quietTokens: [] means findUnguardedWarns flags ANY console.warn.
-	{
-		file: 'src/config/loader.ts',
-		label: 'loader.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/agents/architect.ts',
-		label: 'architect.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/session/snapshot-reader.ts',
-		label: 'snapshot-reader.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/config/project-init.ts',
-		label: 'project-init.ts',
-		quietTokens: [],
-	},
-	// PR3 of epic #1752 migrated these hook-path modules (chat/tool/system
-	// message hooks + their service deps + the prm subsystem) to
-	// advisoryWarn/log. Same contract as the PR2 block above: zero raw
-	// console.warn. This is the interim regression guard until PR5 enables
-	// Biome `noConsole` globally.
-	{
-		file: 'src/hooks/delegation-gate.ts',
-		label: 'delegation-gate.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/hooks/delegation-gate/worktree-isolation.ts',
-		label: 'worktree-isolation.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/hooks/knowledge-store.ts',
-		label: 'knowledge-store.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/hooks/skill-usage-log.ts',
-		label: 'skill-usage-log.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/council/council-evidence-writer.ts',
-		label: 'council-evidence-writer.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/diff/ast-diff.ts',
-		label: 'ast-diff.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/services/context-budget-service.ts',
-		label: 'context-budget-service.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/session/worktree-link-suggestion.ts',
-		label: 'worktree-link-suggestion.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/prm/index.ts',
-		label: 'prm-index.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/prm/replay.ts',
-		label: 'prm-replay.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/prm/trajectory-store.ts',
-		label: 'prm-trajectory-store.ts',
-		quietTokens: [],
-	},
-	// PR4 of epic #1752 migrated these tool-execute-path modules (the tool
-	// handler bodies in src/tools/*, plus the mutation generator and semgrep
-	// SAST runner) to logger.log. Same contract as the PR2/PR3 blocks above:
-	// zero raw console.warn/error/log. This is the interim regression guard
-	// until PR5 enables Biome `noConsole` globally.
-	{
-		file: 'src/tools/build-check.ts',
-		label: 'build-check.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/tools/convene-general-council.ts',
-		label: 'convene-general-council.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/tools/dispatch-lanes.ts',
-		label: 'dispatch-lanes.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/tools/lean-turbo-run-phase.ts',
-		label: 'lean-turbo-run-phase.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/tools/req-coverage.ts',
-		label: 'req-coverage.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/tools/sbom-generate.ts',
-		label: 'sbom-generate.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/tools/update-task-status.ts',
-		label: 'update-task-status.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/tools/write-drift-evidence.ts',
-		label: 'write-drift-evidence.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/mutation/generator.ts',
-		label: 'mutation-generator.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/sast/semgrep.ts',
-		label: 'semgrep.ts',
-		quietTokens: [],
-	},
-	// PR5 of epic #1752 migrated these modules to advisoryWarn/log.
-	// quietTokens: [] means findUnguardedWarns flags ANY console.warn.
-	{
-		file: 'src/sdd/effective-spec.ts',
-		label: 'effective-spec.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/plan/checkpoint.ts',
-		label: 'checkpoint.ts',
-		quietTokens: [],
-	},
-	// src/plan/manager.ts: the console.warn at ~line 786 is guarded by the
-	// DEBUG_SWARM env-var check at line 785 (preserved per issue #1754 note).
-	{
-		file: 'src/plan/manager.ts',
-		label: 'manager.ts',
-		quietTokens: ['process.env.DEBUG_SWARM'],
-	},
-	{
-		file: 'src/plan/ledger.ts',
-		label: 'ledger.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/worktree/core.ts',
-		label: 'core.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/worktree/merge.ts',
-		label: 'merge.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/parallel/dependency-graph.ts',
-		label: 'dependency-graph.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/parallel/meta-indexer.ts',
-		label: 'meta-indexer.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/sbom/detectors/index.ts',
-		label: 'sbom-detectors-index.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/turbo/lean/state-lock.ts',
-		label: 'state-lock.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/turbo/lean/runner.ts',
-		label: 'runner.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/agents/index.ts',
-		label: 'agents-index.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/commands/dark-matter.ts',
-		label: 'dark-matter.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/commands/close.ts',
-		label: 'close.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/commands/knowledge.ts',
-		label: 'knowledge.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/commands/design-docs.ts',
-		label: 'design-docs.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/commands/ci-simulate.ts',
-		label: 'ci-simulate.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/commands/acknowledge-spec-drift.ts',
-		label: 'acknowledge-spec-drift.ts',
-		quietTokens: [],
-	},
-	{
-		file: 'src/commands/rollback.ts',
-		label: 'rollback.ts',
-		quietTokens: [],
-	},
-];
-
-function readScope(file: string): string {
-	return readFileSync(path.resolve(REPO_ROOT, file), 'utf-8');
+function toRepoPath(file: string): string {
+	return path.relative(REPO_ROOT, file).replaceAll('\\', '/');
 }
 
-/**
- * Asserts that every `console.warn(` line in `src` is preceded (within 8 lines)
- * by a quiet-guard. A guard is recognized in EITHER of two forms (both are used
- * in this codebase):
- *   - negated guard: a `!config.quiet` / `!quiet` token in the preceding context
- *   - two-way else branch: a `quiet`/`config.quiet` token AND a `} else` in the
- *     preceding context (the `if (config.quiet) ... else console.warn(...)` form
- *     used by scheduleVersionCheck and the bundled-skill failure path).
- * Any `console.warn` lacking either form is collected as unguarded.
- *
- * Limitation: the `hasElseBranch` check matches a `} else` and a quiet token
- * anywhere in the 8-line window without verifying they belong to the same
- * if-statement; this is adequate for the owned files (which have clean guard
- * patterns) but is not AST-accurate for arbitrary dense control flow.
- */
-function findUnguardedWarns(
-	src: string,
-	quietTokens: string[],
-): Array<{ line: number; context: string }> {
-	const lines = src.split('\n');
-	const unguarded: Array<{
-		line: number;
-		context: string;
-	}> = [];
-	for (let i = 0; i < lines.length; i += 1) {
-		if (!/console\.warn\(/.test(lines[i])) continue;
-		const context = lines.slice(Math.max(0, i - 8), i + 1).join('\n');
-		const hasNegatedGuard = quietTokens.some((token) =>
-			context.includes(token),
-		);
-		const hasElseBranch =
-			context.includes('} else') &&
-			quietTokens.some((token) => context.includes(token.replace('!', '')));
-		if (!hasNegatedGuard && !hasElseBranch) {
-			unguarded.push({ line: i + 1, context });
+function productionSourceFiles(directory = SRC_ROOT): string[] {
+	const files: string[] = [];
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		const absolute = path.join(directory, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name !== '__tests__')
+				files.push(...productionSourceFiles(absolute));
+			continue;
+		}
+		if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+			files.push(absolute);
 		}
 	}
-	return unguarded;
+	return files.sort();
+}
+
+function rawConsoleViolations(source: string): number[] {
+	const lines = source.split(/\r?\n/);
+	const violations: number[] = [];
+	for (let index = 0; index < lines.length; index += 1) {
+		if (!RAW_CONSOLE.test(lines[index])) continue;
+		if (!INLINE_RATIONALE.test(lines[index - 1] ?? '')) {
+			violations.push(index + 1);
+		}
+	}
+	return violations;
+}
+
+function readRepoFile(file: string): string {
+	return readFileSync(path.join(REPO_ROOT, file), 'utf8');
+}
+
+function isAllowedNoConsoleOverride(pattern: string): boolean {
+	return (
+		pattern === 'src/cli/**' ||
+		IMPLEMENTATION_EXEMPTIONS.has(pattern) ||
+		pattern.startsWith('tests/') ||
+		pattern.startsWith('test/') ||
+		pattern.endsWith('.test.ts') ||
+		pattern.includes('/__tests__/')
+	);
 }
 
 describe('Plugin TUI safety', () => {
-	test('no process.exit in SIGINT/SIGTERM handlers', () => {
-		const INDEX_SRC = readScope('src/index.ts');
-		const sigintBlock = /process\.once\(\s*['"]SIGINT['"][\s\S]*?process\.exit/;
-		const sigtermBlock =
-			/process\.once\(\s*['"]SIGTERM['"][\s\S]*?process\.exit/;
-		expect(sigintBlock.test(INDEX_SRC)).toBe(false);
-		expect(sigtermBlock.test(INDEX_SRC)).toBe(false);
+	test('full production src scan requires an inline rationale for every raw console call', () => {
+		const scanned = productionSourceFiles();
+		expect(scanned.length).toBeGreaterThan(200);
+		expect(scanned.map(toRepoPath)).toContain('src/index.ts');
+
+		const violations: string[] = [];
+		for (const file of scanned) {
+			const repoPath = toRepoPath(file);
+			if (
+				repoPath.startsWith('src/cli/') ||
+				IMPLEMENTATION_EXEMPTIONS.has(repoPath)
+			) {
+				continue;
+			}
+			for (const line of rawConsoleViolations(readFileSync(file, 'utf8'))) {
+				violations.push(`${repoPath}:${line}`);
+			}
+		}
+
+		expect(violations).toEqual([]);
 	});
 
-	test('no SIGINT/SIGTERM handler registrations via any method', () => {
-		const INDEX_SRC = readScope('src/index.ts');
-		const methods = ['process.once', 'process.on', 'process.addListener'];
-		const signals = ['SIGINT', 'SIGTERM'];
-		for (const method of methods) {
-			for (const signal of signals) {
-				expect(INDEX_SRC).not.toContain(`${method}('${signal}'`);
-				expect(INDEX_SRC).not.toContain(`${method}("${signal}"`);
+	test('raw-console detector rejects an unannotated call and accepts a reasoned exception', () => {
+		expect(rawConsoleViolations("console.warn('unsafe');")).toEqual([1]);
+		expect(
+			rawConsoleViolations(
+				"// biome-ignore lint/suspicious/noConsole: test-only reason\nconsole.warn('guarded');",
+			),
+		).toEqual([]);
+	});
+
+	test('Biome noConsole exemptions are limited to tests, CLI, and logger implementations', () => {
+		const biome = JSON.parse(readRepoFile('biome.json')) as {
+			overrides?: Array<{
+				includes?: string[];
+				linter?: { rules?: { suspicious?: { noConsole?: string } } };
+			}>;
+		};
+		const forbidden = (biome.overrides ?? [])
+			.filter(
+				(override) => override.linter?.rules?.suspicious?.noConsole === 'off',
+			)
+			.flatMap((override) => override.includes ?? [])
+			.filter((pattern) => !isAllowedNoConsoleOverride(pattern));
+		expect(forbidden).toEqual([]);
+	});
+
+	test('no SIGINT or SIGTERM handler registrations are introduced', () => {
+		const indexSource = readRepoFile('src/index.ts');
+		for (const method of [
+			'process.once',
+			'process.on',
+			'process.addListener',
+		]) {
+			for (const signal of ['SIGINT', 'SIGTERM']) {
+				expect(indexSource).not.toContain(`${method}('${signal}'`);
+				expect(indexSource).not.toContain(`${method}("${signal}"`);
 			}
 		}
 	});
 
-	test('Config Doctor console.warn calls are guarded by config.quiet', () => {
-		const INDEX_SRC = readScope('src/index.ts');
-		const doctorSection = INDEX_SRC.slice(
-			INDEX_SRC.indexOf('Config Doctor'),
-			INDEX_SRC.indexOf('Advisory emission must never block startup') + 50,
-		);
-		const warnCalls = doctorSection.match(/console\.warn\(/g) || [];
-		const quietGuards = doctorSection.match(/!config\.quiet/g) || [];
-		expect(warnCalls.length).toBeGreaterThan(0);
-		expect(quietGuards.length).toBeGreaterThanOrEqual(warnCalls.length);
+	test('command registry never writes raw console output mid-turn', () => {
+		const registry = readRepoFile('src/commands/registry.ts');
+		expect(registry.match(/console\.(warn|error|log)\(/g) ?? []).toEqual([]);
 	});
 
-	test('every console.warn in index.ts is guarded by config.quiet check', () => {
-		const INDEX_SRC = readScope('src/index.ts');
-		const unguarded = findUnguardedWarns(INDEX_SRC, ['!config.quiet']).map(
-			(u) => u.line,
-		);
-		expect(unguarded).toEqual([]);
-	});
-
-	test('bundled-skill sync has no unguarded console.warn (issue #1249 class)', () => {
-		const src = readScope('src/config/bundled-skills.ts');
-		const unguarded = findUnguardedWarns(src, ['!quiet', 'quiet)']);
-		expect(unguarded).toEqual([]);
-	});
-
-	test('command registry has no unguarded console.warn (command path TUI safety)', () => {
-		const src = readScope('src/commands/registry.ts');
-		const unguarded = findUnguardedWarns(src, ['!config.quiet', '!quiet']);
-		expect(unguarded).toEqual([]);
-		expect(
-			(src.match(/console\.warn\(/g) || []).length,
-			'registry.ts command path must contain zero console.warn calls (mid-turn stderr corrupts the TUI)',
-		).toBe(0);
-	});
-
-	test('TUI_SAFETY_SCOPES files all exist and are non-empty', () => {
-		for (const scope of TUI_SAFETY_SCOPES) {
-			const src = readScope(scope.file);
-			expect(src.length, `${scope.file} should be non-empty`).toBeGreaterThan(
-				0,
-			);
-		}
-	});
-
-	test('PR2/PR3/PR4/PR5-migrated modules have zero raw console.* (epic #1752)', () => {
-		// PR2 (loader.ts, architect.ts, snapshot-reader.ts, project-init.ts),
-		// PR3 (delegation-gate, worktree-isolation, knowledge-store,
-		// skill-usage-log, council-evidence-writer, ast-diff,
-		// context-budget-service, worktree-link-suggestion, prm/*), PR4
-		// (build-check, convene-general-council, dispatch-lanes,
-		// lean-turbo-run-phase, req-coverage, sbom-generate, update-task-status,
-		// write-drift-evidence, mutation/generator, sast/semgrep), and PR5
-		// (effective-spec, checkpoint, manager, ledger, worktree/*, parallel/*,
-		// turbo/lean/*, agents/index, council-evidence-writer, commands/*) were
-		// migrated to advisoryWarn/log. They must contain ZERO raw
-		// console.warn/error/log (the `noConsole` lint is deferred to PR5, so
-		// this static guard is the interim regression guard until PR5 enables
-		// Biome `noConsole` globally. The regex covers all three console
-		// channels because PR4 migrated `console.error` sites (semgrep
-		// kill-failed, build-check evidence, lean-turbo cleanup) in addition
-		// to `console.warn`.
-		for (const scope of TUI_SAFETY_SCOPES) {
-			if (scope.quietTokens.length > 0) continue; // skip guarded-scope files
-			const src = readScope(scope.file);
-			const warnCount = (src.match(/console\.warn\(/g) || []).length;
-			const errorCount = (src.match(/console\.error\(/g) || []).length;
-			const logCount = (src.match(/console\.log\(/g) || []).length;
-			const consoleCount = warnCount + errorCount + logCount;
-			expect(
-				consoleCount,
-				`${scope.file} must contain zero raw console.warn/error/log after epic #1752 PR2/PR3/PR4/PR5 migration`,
-			).toBe(0);
-		}
-	});
-
-	test('gitignore-warning.ts has exactly one intentional raw console.warn (tracked-file security)', () => {
-		// src/utils/gitignore-warning.ts retains ONE intentionally-unguarded
-		// console.warn — the ".swarm/ files are tracked by Git" remediation
-		// warning (must-see-always security/hygiene). All other advisories in
-		// this file route through advisoryWarn. Assert the count is exactly 1
-		// and the comment rationale is present.
-		const src = readScope('src/utils/gitignore-warning.ts');
-		const warnMatches = src.match(/console\.warn\(/g) || [];
-		expect(warnMatches.length).toBe(1);
-		expect(src).toContain('intentionally always emitted as raw');
+	test('gitignore warning keeps exactly one documented always-visible security warning', () => {
+		const source = readRepoFile('src/utils/gitignore-warning.ts');
+		expect(source.match(/console\.warn\(/g) ?? []).toHaveLength(1);
+		expect(source).toContain('intentionally always emitted as raw');
+		expect(rawConsoleViolations(source)).toEqual([]);
 	});
 });

--- a/tests/unit/turbo/lean/merge-back.test.ts
+++ b/tests/unit/turbo/lean/merge-back.test.ts
@@ -375,8 +375,6 @@ describe('mergeLaneBranch', () => {
 			return mockProc(0, '', '');
 		};
 
-		const warnSpy = (console.warn = vi.fn() as unknown as typeof console.warn);
-
 		const result = await mergeLaneBranch(fakeDir, fakeBranch, 'cherry-pick');
 
 		expect(result).toEqual({ merged: true, strategy: 'cherry-pick' });
@@ -386,8 +384,6 @@ describe('mergeLaneBranch', () => {
 		);
 		expect(cherryPickCall).toBeDefined();
 		expect(cherryPickCall![2]).toBe(fakeBranch);
-
-		warnSpy.mockRestore?.();
 	});
 });
 

--- a/tests/unit/turbo/lean/merge-back.test.ts
+++ b/tests/unit/turbo/lean/merge-back.test.ts
@@ -9,6 +9,10 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
 import type { LeanTurboConfig } from '../../../../src/config/schema';
 import {
+	clearDeferredWarnings,
+	getDeferredWarnings,
+} from '../../../../src/services/warning-buffer';
+import {
 	_internals,
 	attemptMergeBackFromDirty,
 	cleanupOrphanedBranches,
@@ -62,6 +66,7 @@ function stubSpawn(exitCode: number, stdout = '', stderr = '') {
 /** Restores the real bunSpawn after every test. */
 afterEach(() => {
 	_internals.bunSpawn = realBunSpawn;
+	clearDeferredWarnings();
 });
 
 // ---------------------------------------------------------------------------
@@ -331,42 +336,29 @@ describe('mergeLaneBranch', () => {
 			return mockProc(0, '', '');
 		};
 
-		// Enable debug mode so log() actually calls console.log
-		const originalDebug = process.env.OPENCODE_SWARM_DEBUG;
-		process.env.OPENCODE_SWARM_DEBUG = '1';
-		const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		clearDeferredWarnings();
+		const result = await mergeLaneBranch(fakeDir, fakeBranch, 'cherry-pick');
 
-		try {
-			const result = await mergeLaneBranch(fakeDir, fakeBranch, 'cherry-pick');
+		expect(result).toEqual({ merged: true, strategy: 'cherry-pick' });
+		expect(callCount).toBe(2);
 
-			expect(result).toEqual({ merged: true, strategy: 'cherry-pick' });
-			expect(callCount).toBe(2);
+		// Verify merge-base was attempted
+		const mergeBaseCall = spawnCalls.find(
+			(args) => args[0] === 'git' && args[1] === 'merge-base',
+		);
+		expect(mergeBaseCall).toBeDefined();
 
-			// Verify merge-base was attempted
-			const mergeBaseCall = spawnCalls.find(
-				(args) => args[0] === 'git' && args[1] === 'merge-base',
-			);
-			expect(mergeBaseCall).toBeDefined();
+		// Verify fallback used tip-only cherry-pick (not a range)
+		const cherryPickCall = spawnCalls.find(
+			(args) => args[0] === 'git' && args[1] === 'cherry-pick',
+		);
+		expect(cherryPickCall).toBeDefined();
+		expect(cherryPickCall![2]).toBe(fakeBranch);
+		expect(cherryPickCall![2]).not.toContain('..');
 
-			// Verify fallback used tip-only cherry-pick (not a range)
-			const cherryPickCall = spawnCalls.find(
-				(args) => args[0] === 'git' && args[1] === 'cherry-pick',
-			);
-			expect(cherryPickCall).toBeDefined();
-			expect(cherryPickCall![2]).toBe(fakeBranch);
-			expect(cherryPickCall![2]).not.toContain('..');
-
-			expect(consoleLogSpy).toHaveBeenCalledWith(
-				expect.stringContaining('merge-base failed'),
-			);
-		} finally {
-			consoleLogSpy.mockRestore();
-			if (originalDebug === undefined) {
-				delete process.env.OPENCODE_SWARM_DEBUG;
-			} else {
-				process.env.OPENCODE_SWARM_DEBUG = originalDebug;
-			}
-		}
+		expect(getDeferredWarnings()).toEqual([
+			expect.stringContaining('merge-base failed'),
+		]);
 	});
 
 	test('cherry-pick merge-base returns empty stdout falls back to tip-only', async () => {


### PR DESCRIPTION
Closes #1756
Closes #1752

## Summary
- replace the curated TUI console regression list with a recursive production-source scan and remove three unused Biome enforcement holes
- route actionable design-doc, primary-agent, council-override, and cherry-pick degradation warnings through the deferred advisory channel without duplicate multi-swarm warnings
- restore reset-command coverage to CI isolation, repair runtime-source BOM/mojibake damage, and correct the pending release narrative

## Invariant audit
- 1 (plugin init): touched - agent-config warning validation remains synchronous and bounded; `node scripts/repro-704.mjs` passed T1 at 288.4 ms under the 400 ms deadline
- 2 (runtime portability): touched - repaired runtime-source encoding; `bun run build`, Node ESM import, smoke tests, and package smoke passed
- 3 (subprocesses): not touched - no subprocess implementation changed
- 4 (.swarm containment): not touched - no runtime storage path changed
- 5 (plan durability): not touched - ledger and projection behavior are unchanged
- 6 (test_runner safety): not touched - validation used shell-driven per-file isolation; no test_runner behavior changed
- 7 (test writing): touched - loaded the writing-tests protocol; new tests use public APIs or a restored DI seam, reset restores real singleton state in finally, and diff-scoped file-cap/mock-cleanup conditions pass
- 8 (session state): touched - config-global council validation now emits once per getAgentConfigs invocation so multi-swarm agents cannot exhaust the bounded warning buffer; quiet-mode, multi-swarm, and negative regressions pass
- 9 (guardrails/retry): not touched - no guardrail or retry semantics changed
- 10 (chat/system msg): touched - full-source console enforcement and deferred advisory routing keep actionable warnings discoverable without raw TUI writes; focused regressions pass
- 11 (tool registration): not touched - no tool, command registration, or agent tool-map entry changed
- 12 (release/cache): touched - corrected the PR5 fragment and added a unique pending closeout fragment; version, changelog, manifest, cache, and generated dist files are untouched

## Test plan
- [x] `bun run test:unit:ci` for all six changed/pivotal test files (6/6 files passed)
- [x] original issue regression set through `bun run test:unit:ci` (6/6 files passed)
- [x] reset plus state direct co-run (102 passed, 0 failed)
- [x] adjacent agent/default/quiet/tool-gating regressions, including reviewer follow-up (all isolated files passed)
- [x] `bun run typecheck`, pinned Biome CI, `bun run lint`, `bun run drift:check`, and `git diff --check`
- [x] `bun run build`, Node ESM dist import, `node scripts/repro-704.mjs`, smoke tests (10 passed), and `bun run package:smoke`
- [x] security tier (163 passed, 4 skipped, 0 failed)
- [x] two broad-batch integration failures rerun in isolation (21 passed, 0 failed), confirming shared-process contamination rather than this diff
- [x] independent implementation review and fresh final critic approval
- [ ] current-head GitHub Actions matrix and PR standards (pending after push)

## Pre-existing host limitation
- The isolated Windows symlink adversarial exemplar passes 9/10; its remaining test calls `test.skip()` from inside a running test after Windows denies symlink creation. This pre-existing test-harness defect is unrelated to the changed paths; the remote platform matrix is authoritative.
