### PR TITLE
feat(knowledge): share opt-in repository memory across linked swarms (#1850)

### DIFF
--- a/.claude/skills/swarm/SKILL.md
+++ b/.claude/skills/swarm/SKILL.md
@@ -89,6 +89,9 @@ These are invoked as `/swarm <subcommand>`, NOT as bare `/subcommand`. The list 
 - `/swarm memory import` — import legacy JSONL memory into SQLite
 - `/swarm memory migrate` — run the one-time legacy JSONL to SQLite migration
 - `/swarm memory consolidation-log` — summarize recent memory consolidation passes
+- `/swarm memory link` — share memory across linked worktrees (requires `memory.link.enabled`)
+- `/swarm memory link status` — show whether memory is cohort-linked (distinct from knowledge link)
+- `/swarm memory unlink` — stop sharing memory; copies cohort family back to local
 - `/swarm curate` — run knowledge curation and hive promotion review
 - `/swarm consolidate` — run quota-bounded skill-improver consolidation
 - `/swarm promote` — manually promote a lesson to hive knowledge

--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,9 @@ Control how tool outputs are summarized for LLM context.
 | `/swarm memory evaluate` | Run memory recall evaluation fixtures |
 | `/swarm memory import` | Import legacy JSONL memory into SQLite |
 | `/swarm memory migrate` | Run the one-time JSONL to SQLite migration |
+| `/swarm memory link [name]` | Share memory across linked worktrees (requires `memory.link.enabled`) |
+| `/swarm memory link status` | Show whether memory is cohort-linked (distinct from knowledge link) |
+| `/swarm memory unlink` | Stop sharing memory; copies cohort family back to local |
 | `/swarm concurrency <set|status|reset>` | Manage session-scoped runtime concurrency override |
 | `/swarm turbo` | Enable turbo mode for the current session (bypasses QA gates) |
 | `/swarm full-auto` | Toggle Full-Auto Mode for the current session [on|off] |

--- a/docs/releases/pending/1850-cohort-memory-sharing.md
+++ b/docs/releases/pending/1850-cohort-memory-sharing.md
@@ -1,0 +1,46 @@
+## Linked Knowledge 5/5: cohort memory sharing across linked swarms (#1850)
+
+Makes the opt-in memory subsystem capable of sharing repository-scoped memory
+across linked sibling worktrees through the canonical cohort identity from
+#1846, completing the Linked Knowledge series. Knowledge link and memory link
+remain independently opt-in — linking knowledge does NOT link memory.
+
+### What's new
+- **`memory.link.enabled` config** (default off): gates cohort memory sharing.
+  When enabled and a memory-link pointer exists, repository-scoped memory
+  redirects to a shared cohort root under the platform data dir.
+- **`/swarm memory link [name]` / `/swarm memory unlink`**: establishes and
+  tears down the cohort memory link. The pointer lives at
+  `.swarm/memory-link.json` (separate from the knowledge `link.json`).
+- **`VettedMemoryRoot` capability type**: a discriminated union that can only
+  represent a validated project `.swarm/memory` root OR a cohort root derived
+  from the #1846 cohort identity. `validateSwarmPath` is NOT weakened — cohort
+  roots bypass it by construction (they live in the platform data dir, not
+  under `.swarm`).
+- **Cohort scope**: a new `'cohort'` `MemoryScopeType` + `cohortId` field on
+  `MemoryScopeRef`. `stableScopeKey` keys cohort scopes on `cohortId` so
+  different cohorts remain isolated. Records default to the cohort scope when
+  linked (shared across siblings); run/agent scopes stay worktree-local.
+- **Cohort-aware provider pool**: pooled by `cohort:<canonicalPath>` for cohort
+  roots, with generation-based invalidation on link/unlink.
+- **Memory family migration engine**: migrates the complete memory family
+  (`memory.db`, JSONL members, consolidation log) atomically under
+  `proper-lockfile`. SQLite non-empty destinations merge via ATTACH +
+  INSERT OR IGNORE (id-keyed, idempotent on retry).
+- **Cohort config fingerprint**: `memory-cohort-config.json` written at link
+  time with provider/embedding/redaction config. SQLite providers fail closed
+  on mismatch (acceptance #10).
+- **Privacy provenance**: records carry `cohortId`, `producerSessionId`,
+  `producerAgentRole`, `redactionPolicyVersion`, `providerVersion`. All
+  optional (backward compatible with pre-#1850 records).
+- **Status/diagnostics**: `**Memory Cohort**` block in `/swarm status`,
+  distinct from `**Knowledge Cohort**`. Reports provider, config fingerprint
+  match, degraded state.
+
+### Acceptance criteria
+All 13 from the issue are satisfied. See the PR description's Invariant audit
+and the trace artifacts at `.zcode/issue-traces/1850/`.
+
+### Dependencies
+Completes the Linked Knowledge series: #1846 (cohort identity), #1847 (hive
+promotion), #1848 (cohort curation), #1849 (real-host injection), #1850 (this).

--- a/docs/releases/pending/1850-cohort-memory-sharing.md
+++ b/docs/releases/pending/1850-cohort-memory-sharing.md
@@ -24,9 +24,12 @@ remain independently opt-in — linking knowledge does NOT link memory.
 - **Cohort-aware provider pool**: pooled by `cohort:<canonicalPath>` for cohort
   roots, with generation-based invalidation on link/unlink.
 - **Memory family migration engine**: migrates the complete memory family
-  (`memory.db`, JSONL members, consolidation log) atomically under
-  `proper-lockfile`. SQLite non-empty destinations merge via ATTACH +
-  INSERT OR IGNORE (id-keyed, idempotent on retry).
+  (`memory.db`, JSONL members, consolidation log) under `proper-lockfile` with
+  stage→validate→commit per member. The pointer is flipped last so a failed
+  migration leaves the worktree in its prior state and retry is idempotent
+  (id-keyed dedup). SQLite non-empty destinations merge via ATTACH +
+  INSERT OR IGNORE (id-keyed, idempotent on retry). NOTE: migration is NOT
+  atomic across the multi-member family — see Known limitations.
 - **Cohort config fingerprint**: `memory-cohort-config.json` written at link
   time with provider/embedding/redaction config. SQLite providers fail closed
   on mismatch (acceptance #10).
@@ -38,8 +41,23 @@ remain independently opt-in — linking knowledge does NOT link memory.
   match, degraded state.
 
 ### Acceptance criteria
-All 13 from the issue are satisfied. See the PR description's Invariant audit
+All 13 from the issue are addressed. See the PR description's Invariant audit
 and the trace artifacts at `.zcode/issue-traces/1850/`.
+
+### Known limitations
+- **Mixed-provider cohort**: a cohort mixing SQLite and JSONL providers is not
+  fully fail-closed at link time. The cohort-config fingerprint covers provider
+  mismatch, but JSONL-only paths (append, compact) are not cross-process
+  transactional the way SQLite WAL is. Recommendation: use a single provider
+  across all cohort members.
+- **Migration atomicity**: the memory family migration is idempotent and
+  recoverable (pointer flipped last, INSERT OR IGNORE dedup on retry), but it
+  is NOT atomic across the multi-member family — a mid-migration failure after
+  member N commits leaves members 1..N in the destination. Retry is safe.
+- **Cross-process write visibility**: relies on SQLite WAL mode + 2s TTL +
+  pointer-stat revalidation. A `memory.gen` marker is written on cohort writes
+  but is not yet consumed by a tighter revalidation loop (reserved for future
+  enhancement).
 
 ### Dependencies
 Completes the Linked Knowledge series: #1846 (cohort identity), #1847 (hive

--- a/src/commands/memory-link.ts
+++ b/src/commands/memory-link.ts
@@ -1,0 +1,300 @@
+/**
+ * #1850 Linked Knowledge 5/5: handles `/swarm memory link` / `/swarm memory unlink`.
+ *
+ * Ties this worktree's memory store to a shared cohort root through the #1846
+ * cohort identity — independently of the knowledge link (`/swarm link`).
+ * Knowledge link and memory link are separate opt-in toggles (issue #1850
+ * acceptance #1): linking knowledge does NOT link memory, and vice versa.
+ *
+ * On link:
+ *  1. Resolve the canonical cohort id (same id used by knowledge link).
+ *  2. Drain + close pooled providers for the local root (acceptance #5).
+ *  3. Migrate the local memory family into the cohort root via
+ *     `migrateMemoryFamily` (acceptance #7).
+ *  4. Write `memory-cohort-config.json` under the migration lock (acceptance
+ *     #10 — provider/schema/embedding/redaction fingerprint; CONCERN-2).
+ *  5. Write the `memory-link.json` pointer LAST so a failure above leaves the
+ *     worktree local (idempotent retry on re-link).
+ *
+ * On unlink:
+ *  1. Migrate the cohort memory family back into local `.swarm/memory/`.
+ *  2. Remove the pointer. The cohort store is NEVER deleted/truncated (other
+ *     worktrees may still be linked).
+ *
+ * Status: `/swarm memory link status` prints the memory link state distinctly
+ * from the knowledge link state (acceptance #2).
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import * as path from 'node:path';
+import { loadPluginConfigWithMeta } from '../config';
+import { MemoryConfigSchema } from '../config/schema.js';
+import {
+	type CohortIdentity,
+	resolveCohortId,
+} from '../knowledge/cohort-identity.js';
+import {
+	type MemoryLinkPointer,
+	readMemoryLinkPointer,
+	removeMemoryLinkPointer,
+	resolveLinkDir,
+	sanitizeLinkId,
+	writeMemoryLinkPointer,
+} from '../memory/memory-link.js';
+import { migrateMemoryFamily } from '../memory/memory-family-migration.js';
+import { evictAndCloseForRoot } from '../memory/provider-pool.js';
+import {
+	computeMemoryCohortFingerprint,
+	buildMemoryCohortFingerprintInput,
+} from '../memory/redaction.js';
+import {
+	type VettedMemoryRoot,
+	wrapLocalRoot,
+} from '../memory/storage-root.js';
+import { criticalWarn } from '../utils/logger.js';
+
+function formatStatus(directory: string): string {
+	const pointer = readMemoryLinkPointer(directory);
+	if (!pointer) {
+		return [
+			'ℹ️ Memory is NOT linked. Memory stays local to `.swarm/memory/`.',
+			'Run `/swarm memory link` to share memory across worktrees of this repo.',
+			'(Knowledge link and memory link are independent — `/swarm link` does not link memory.)',
+		].join('\n');
+	}
+	const cohortDir = resolveLinkDir(pointer.linkId);
+	const lines = [
+		'🔗 Memory is shared across linked worktrees.',
+		`  link id:   ${pointer.linkId}`,
+	];
+	if (pointer.cohortId) lines.push(`  cohort:    ${pointer.cohortId}`);
+	if (pointer.identitySource) {
+		lines.push(`  identity:  ${pointer.identitySource}`);
+	}
+	if (pointer.degraded) {
+		lines.push(
+			'  ⚠ degraded: cohort id is machine-local (not portable across machines).',
+		);
+	}
+	lines.push(`  shared at: ${path.join(cohortDir, 'memory')}`);
+	lines.push(`  since:     ${pointer.createdAt}`);
+	if (pointer.generation !== undefined) {
+		lines.push(`  generation: ${pointer.generation}`);
+	}
+	lines.push(
+		'Run `/swarm memory unlink` to stop sharing (keeps a local copy).',
+	);
+	return lines.join('\n');
+}
+
+// #1850 (final-critic dedup): the cohort fingerprint helpers are centralized in
+// src/memory/redaction.ts. The linker uses them to write the single source of
+// truth; the SQLite provider and status service read it back.
+
+export async function handleMemoryLinkCommand(
+	directory: string,
+	args: string[],
+): Promise<string> {
+	const first = args[0];
+	if (first === 'status') {
+		return formatStatus(directory);
+	}
+
+	const nameArg = args.find((a) => !a.startsWith('--'));
+
+	let linkId: string;
+	let displayName: string | undefined;
+	let cohort: CohortIdentity | undefined;
+	if (nameArg) {
+		const sanitized = sanitizeLinkId(nameArg);
+		if (!sanitized) {
+			return `❌ Invalid link name "${nameArg}". Use letters, digits, '.', '-', or '_'.`;
+		}
+		linkId = sanitized;
+		displayName = nameArg;
+		try {
+			cohort = await resolveCohortId(directory);
+		} catch {
+			/* optional for explicit name */
+		}
+	} else {
+		try {
+			cohort = await resolveCohortId(directory);
+			linkId = cohort.cohortId;
+		} catch (error) {
+			return `❌ Failed to resolve cohort identity: ${
+				error instanceof Error ? error.message : String(error)
+			}`;
+		}
+	}
+
+	if (cohort?.degraded) {
+		criticalWarn(
+			`[opencode-swarm] Cohort identity for memory link is degraded (source: ${cohort.source}). ` +
+				'The shared memory store will be cohesive for sibling worktrees on THIS machine, ' +
+				'but it is not a portable cohort identity (no usable git remote).',
+		);
+	}
+
+	const existing = readMemoryLinkPointer(directory);
+	if (existing && existing.linkId === linkId) {
+		return `ℹ️ Memory is already linked to "${linkId}".\n${formatStatus(directory)}`;
+	}
+
+	// Load the memory config to (a) check link.enabled and (b) compute the
+	// cohort config fingerprint.
+	const { config: loadedConfig } = loadPluginConfigWithMeta(directory);
+	const memoryConfig = MemoryConfigSchema.parse(loadedConfig.memory ?? {});
+	if (!memoryConfig.link?.enabled) {
+		return [
+			'❌ Memory sharing is not enabled. Set `memory.link.enabled: true` in your',
+			'opencode.json config before running `/swarm memory link`.',
+		].join('\n');
+	}
+
+	const cohortDir = resolveLinkDir(linkId);
+	// Build the source (local) and destination (cohort) vetted roots.
+	const localRoot: VettedMemoryRoot = {
+		kind: 'local',
+		root: path.join(directory, '.swarm'),
+		directory,
+	};
+	const cohortRoot: VettedMemoryRoot = {
+		kind: 'cohort',
+		cohortRoot: path.join(cohortDir, 'memory'),
+		cohortId: cohort?.cohortId ?? linkId,
+		generation: (existing?.generation ?? 0) + 1,
+		linkId,
+		directory,
+	};
+
+	// Drain pooled providers for the local root before migration (acceptance #5).
+	evictAndCloseForRoot(localRoot);
+
+	let totalMerged = 0;
+	let totalSkipped = 0;
+	let familySummary = '';
+	try {
+		const result = await migrateMemoryFamily(cohortRoot, localRoot);
+		for (const m of result.perMember) {
+			totalMerged += m.merged;
+			totalSkipped += m.skipped;
+		}
+		familySummary = result.perMember
+			.filter((m) => m.merged > 0 || m.skipped > 0)
+			.map((m) => `    ${m.filename}: ${m.merged} merged, ${m.skipped} kept`)
+			.join('\n');
+	} catch (error) {
+		return `❌ Failed to migrate the memory family into the cohort store: ${
+			error instanceof Error ? error.message : String(error)
+		}`;
+	}
+
+	// #1850 CONCERN-2: write the cohort config fingerprint UNDER the cohort dir
+	// (the migration engine held the lock; this write happens immediately after,
+	// before the pointer flips, so a concurrent linker sees the fingerprint).
+	try {
+		await mkdir(cohortRoot.cohortRoot, { recursive: true });
+		const fingerprintInput = buildMemoryCohortFingerprintInput(memoryConfig);
+		const fingerprint = computeMemoryCohortFingerprint(fingerprintInput);
+		await writeFile(
+			path.join(cohortRoot.cohortRoot, 'memory-cohort-config.json'),
+			JSON.stringify(
+				{
+					fingerprint,
+					config: fingerprintInput,
+					updated_at: new Date().toISOString(),
+				},
+				null,
+				2,
+			),
+			'utf-8',
+		);
+	} catch {
+		/* best-effort — open-time check fails closed when absent */
+	}
+
+	// Write the pointer LAST. If this fails, the worktree stays local while the
+	// local family is already in the cohort store — re-running link re-merges
+	// (idempotent) and writes the pointer.
+	const pointer: MemoryLinkPointer = {
+		version: 2,
+		linkId,
+		name: displayName,
+		createdAt: new Date().toISOString(),
+		cohortId: cohort?.cohortId,
+		identitySource: cohort?.source,
+		degraded: cohort?.degraded,
+		generation: (existing?.generation ?? 0) + 1,
+	};
+	try {
+		await writeMemoryLinkPointer(directory, pointer);
+	} catch (error) {
+		return `❌ Failed to write memory link pointer: ${
+			error instanceof Error ? error.message : String(error)
+		}`;
+	}
+
+	const relinkNote = existing
+		? `\n(Re-linked from previous memory link "${existing.linkId}".)`
+		: '';
+	const familyNote = familySummary ? `\n${familySummary}` : '';
+	return [
+		`🔗 Linked this worktree's memory to shared cohort store "${linkId}".`,
+		`  migrated the memory family (${totalMerged} new, ${totalSkipped} already present).`,
+		`  shared at: ${cohortRoot.cohortRoot}`,
+		'All worktrees linked to this id now read and write the same memory.' +
+			relinkNote +
+			familyNote,
+	].join('\n');
+}
+
+export async function handleMemoryUnlinkCommand(
+	directory: string,
+	args: string[],
+): Promise<string> {
+	const noCopy = args.includes('--no-copy');
+	const pointer = readMemoryLinkPointer(directory);
+	if (!pointer) {
+		return 'ℹ️ Memory is not linked. Nothing to unlink.';
+	}
+
+	const cohortDir = resolveLinkDir(pointer.linkId);
+	const localRoot: VettedMemoryRoot = wrapLocalRoot(directory);
+	const cohortRoot: VettedMemoryRoot = {
+		kind: 'cohort',
+		cohortRoot: path.join(cohortDir, 'memory'),
+		cohortId: pointer.cohortId ?? pointer.linkId,
+		generation: pointer.generation ?? 0,
+		linkId: pointer.linkId,
+		directory,
+	};
+
+	// Drain pooled providers for both roots before migration.
+	evictAndCloseForRoot(localRoot);
+	evictAndCloseForRoot(cohortRoot);
+
+	if (!noCopy) {
+		try {
+			await migrateMemoryFamily(localRoot, cohortRoot);
+		} catch (error) {
+			return `❌ Failed to copy the cohort memory family back to local storage: ${
+				error instanceof Error ? error.message : String(error)
+			}`;
+		}
+	}
+
+	try {
+		await removeMemoryLinkPointer(directory);
+	} catch (error) {
+		return `❌ Failed to remove memory link pointer: ${
+			error instanceof Error ? error.message : String(error)
+		}`;
+	}
+
+	return [
+		'🔓 Unlinked memory. A local copy of the cohort memory family has been restored.',
+		`  The shared cohort store at ${cohortRoot.cohortRoot} is NOT deleted`,
+		'  (other worktrees may still be linked to it).',
+	].join('\n');
+}

--- a/src/commands/memory-link.ts
+++ b/src/commands/memory-link.ts
@@ -33,6 +33,7 @@ import {
 	type CohortIdentity,
 	resolveCohortId,
 } from '../knowledge/cohort-identity.js';
+import { migrateMemoryFamily } from '../memory/memory-family-migration.js';
 import {
 	type MemoryLinkPointer,
 	readMemoryLinkPointer,
@@ -41,11 +42,10 @@ import {
 	sanitizeLinkId,
 	writeMemoryLinkPointer,
 } from '../memory/memory-link.js';
-import { migrateMemoryFamily } from '../memory/memory-family-migration.js';
 import { evictAndCloseForRoot } from '../memory/provider-pool.js';
 import {
-	computeMemoryCohortFingerprint,
 	buildMemoryCohortFingerprintInput,
+	computeMemoryCohortFingerprint,
 } from '../memory/redaction.js';
 import {
 	type VettedMemoryRoot,
@@ -292,8 +292,11 @@ export async function handleMemoryUnlinkCommand(
 		}`;
 	}
 
+	const copyNote = noCopy
+		? 'No local copy was made (--no-copy).'
+		: 'A local copy of the cohort memory family has been restored.';
 	return [
-		'🔓 Unlinked memory. A local copy of the cohort memory family has been restored.',
+		`🔓 Unlinked memory. ${copyNote}`,
 		`  The shared cohort store at ${cohortRoot.cohortRoot} is NOT deleted`,
 		'  (other worktrees may still be linked to it).',
 	].join('\n');

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -16,6 +16,7 @@ import {
 	resolveMemoryConfig,
 	resolveMemoryStorageDir,
 	resolveSqliteDatabasePath,
+	resolveVettedMemoryRoot,
 	SQLiteMemoryProvider,
 	writeJsonlExport,
 } from '../memory';
@@ -71,7 +72,15 @@ export async function handleMemoryConsolidationLogCommand(
 	});
 	if ('error' in parsed) return parsed.error;
 	const limit = Math.min(parsed.limit, 50);
-	const records = await readConsolidationLog(directory);
+	// #1850 (M-011 fix): read the consolidation log via the vetted root so it
+	// surfaces cohort-shared passes when linked, not the stale local path.
+	const loadedMemory = loadPluginConfig(directory).memory;
+	const records = await readConsolidationLog(
+		resolveVettedMemoryRoot(
+			directory,
+			resolveMemoryConfig(loadedMemory ?? DEFAULT_MEMORY_CONFIG),
+		),
+	);
 	const recent = records.slice(-limit).reverse();
 	const lines = [
 		'## Swarm Memory Consolidation Log',

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -53,6 +53,10 @@ export async function handleMemoryCommand(
 		'- `/swarm memory migrate` - run the one-time legacy JSONL to SQLite migration',
 		'- `/swarm memory evaluate --json` - run the golden recall evaluation fixtures and emit a JSON report',
 		'- `/swarm memory consolidation-log [--limit <n>]` - summarize recent episodic→semantic consolidation passes (max 50 per query)',
+		// #1850: cohort memory sharing commands.
+		'- `/swarm memory link [name]` - share memory across linked worktrees (requires `memory.link.enabled: true`)',
+		'- `/swarm memory link status` - show the memory link state (distinct from knowledge link)',
+		'- `/swarm memory unlink` - stop sharing memory; copies the cohort family back to local',
 	].join('\n');
 }
 

--- a/src/commands/registration-parity.test.ts
+++ b/src/commands/registration-parity.test.ts
@@ -539,6 +539,10 @@ describe('Command registration parity', () => {
 			'sync-plan',
 			'export',
 			'auto-proceed',
+			// #1850: cohort memory sharing commands (agent/utility + diagnostics)
+			'memory link',
+			'memory link status',
+			'memory unlink',
 		]);
 
 		// Authoritative pre-existing baseline (10 human-only entries)
@@ -580,6 +584,8 @@ describe('Command registration parity', () => {
 			'memory',
 			'memory status',
 			'memory export',
+			// #1850: memory link status has toolNoArgs: true
+			'memory link status',
 		]);
 
 		// After the fix, only these additions are permitted to differ.

--- a/src/commands/registry.tool-policy.test.ts
+++ b/src/commands/registry.tool-policy.test.ts
@@ -72,6 +72,10 @@ describe('toolPolicy classification snapshot — no regression', () => {
 		'guardrail-log',
 		'lanes',
 		'ci-simulate',
+		// #1850: cohort memory sharing commands
+		'memory link',
+		'memory link status',
+		'memory unlink',
 	]);
 
 	const EXPECTED_HUMAN_ONLY = new Set<string>([
@@ -344,6 +348,8 @@ describe('derived-set reproduction from registry toolPolicy fields', () => {
 			'memory status',
 			'memory export',
 			'lanes',
+			// #1850: memory link status has toolNoArgs: true
+			'memory link status',
 		]);
 		const derived = new Set<string>();
 		for (const [name, entry] of Object.entries(COMMAND_REGISTRY)) {

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -69,6 +69,10 @@ import {
 	handleMemoryStatusCommand,
 	handleMemoryValueLogCommand,
 } from './memory.js';
+import {
+	handleMemoryLinkCommand,
+	handleMemoryUnlinkCommand,
+} from './memory-link.js';
 import { handlePlanCommand } from './plan.js';
 import { handlePostMortemCommand } from './post-mortem.js';
 import { handlePrFeedbackCommand } from './pr-feedback.js';
@@ -1437,6 +1441,34 @@ export const COMMAND_REGISTRY = {
 		subcommandOf: 'memory',
 		args: '--limit <n>',
 		category: 'diagnostics',
+		toolPolicy: 'agent',
+	},
+	// #1850: cohort memory sharing commands (distinct from knowledge link).
+	'memory link': {
+		handler: (ctx) => handleMemoryLinkCommand(ctx.directory, ctx.args),
+		description:
+			'Share this worktree memory across linked sibling worktrees via the cohort identity (requires memory.link.enabled). Independently opt-in from /swarm link.',
+		subcommandOf: 'memory',
+		args: '[name]',
+		category: 'utility',
+		toolPolicy: 'agent',
+	},
+	'memory link status': {
+		handler: (ctx) => handleMemoryLinkCommand(ctx.directory, ['status']),
+		description: 'Show whether this worktree shares memory via a cohort link',
+		subcommandOf: 'memory',
+		args: '',
+		category: 'diagnostics',
+		toolPolicy: 'agent',
+		toolNoArgs: true,
+	},
+	'memory unlink': {
+		handler: (ctx) => handleMemoryUnlinkCommand(ctx.directory, ctx.args),
+		description:
+			'Stop sharing memory; copies the cohort memory family back to local .swarm/memory/. The cohort store is never deleted.',
+		subcommandOf: 'memory',
+		args: '[--no-copy]',
+		category: 'utility',
 		toolPolicy: 'agent',
 	},
 	// Aliases for the TUI shortcuts 'swarm-memory-status' / 'swarm-memory-export'

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1262,6 +1262,17 @@ export const MemoryConfigSchema = z.object({
 			busyTimeoutMs: z.number().int().min(0).max(60000).default(5000),
 		})
 		.default({ path: '.swarm/memory/memory.db', busyTimeoutMs: 5000 }),
+	/**
+	 * #1850 Linked Knowledge 5/5: opt-in cohort memory sharing. Default off —
+	 * memory remains worktree-local unless explicitly enabled. When enabled
+	 * and a memory-link pointer exists, repository-scoped memory redirects to
+	 * a shared cohort root derived from the #1846 cohort identity.
+	 */
+	link: z
+		.object({
+			enabled: z.boolean().default(false),
+		})
+		.default({ enabled: false }),
 	recall: z
 		.object({
 			defaultMaxItems: z.number().int().min(1).max(20).default(8),

--- a/src/knowledge/family-migration-shared.ts
+++ b/src/knowledge/family-migration-shared.ts
@@ -1,0 +1,22 @@
+/**
+ * #1850: shared lock config for family-migration engines.
+ *
+ * Both the knowledge family (`src/knowledge/family-migration.ts`) and the
+ * memory family (`src/memory/memory-family-migration.ts`) use the SAME lock
+ * discipline. Centralizing it here ensures one source of truth — a change to
+ * the stale window or retry policy applies to both subsystems.
+ */
+
+/**
+ * Lock stale window for the migration critical section. The default
+ * knowledge-store `stale: 5000` (5 s) is too short for an 8+ file merge under
+ * load; a long merge would have its lock stolen by a concurrent writer
+ * mid-flight (issue #1846 critic C9). 30 s comfortably covers worst-case
+ * merges of large corpora.
+ */
+export const MIGRATION_LOCK_STALE_MS = 30_000;
+
+/** Retry config for acquiring the migration lock. */
+export const MIGRATION_LOCK_RETRIES = {
+	retries: { retries: 10, minTimeout: 100, maxTimeout: 500 },
+} as const;

--- a/src/knowledge/family-migration.ts
+++ b/src/knowledge/family-migration.ts
@@ -39,19 +39,18 @@ import {
 	KNOWLEDGE_FAMILY,
 	type KnowledgeFamilyMember,
 } from './family-manifest.js';
+import {
+	MIGRATION_LOCK_RETRIES,
+	MIGRATION_LOCK_STALE_MS,
+} from './family-migration-shared.js';
 
 const DEDUP_THRESHOLD = 0.6;
 
 /**
- * Lock config for the migration critical section. The default knowledge-store
- * `stale: 5000` (5 s) is too short for an 8-file merge under load; a long
- * merge would have its lock stolen by a concurrent writer mid-flight (critic
- * C9). 30 s comfortably covers worst-case merges of large knowledge corpora.
+ * Lock config for the migration critical section. Re-exported from
+ * `family-migration-shared.ts` (issue #1850) so the memory family migration
+ * engine reuses the SAME values. See the shared module for rationale.
  */
-const MIGRATION_LOCK_STALE_MS = 30_000;
-const MIGRATION_LOCK_RETRIES = {
-	retries: { retries: 10, minTimeout: 100, maxTimeout: 500 },
-};
 
 export interface FamilyMigrationCounts {
 	/** Per-member counts (filename → {merged, skipped}). */

--- a/src/memory/config.ts
+++ b/src/memory/config.ts
@@ -39,6 +39,17 @@ export interface MemoryConfig {
 	/** Reflection / consolidation pass (issue #1464, Phase 3). */
 	consolidation: ConsolidationConfig;
 	hardDelete: boolean;
+	/**
+	 * #1850 Linked Knowledge 5/5: opt-in cohort memory sharing. Default off —
+	 * memory stays worktree-local (today's behavior) unless explicitly enabled.
+	 * When enabled AND a memory-link pointer is present, repository-scoped
+	 * memory is shared across sibling worktrees through the #1846 cohort
+	 * identity. Knowledge link and memory link are independent toggles: linking
+	 * knowledge does not imply linking memory.
+	 */
+	link: {
+		enabled: boolean;
+	};
 	embeddings: {
 		enabled: boolean;
 		model: string;
@@ -278,6 +289,8 @@ export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
 		...DEFAULT_CONSOLIDATION_CONFIG,
 		decayHalfLifeDays: { ...DEFAULT_DECAY_HALF_LIFE_DAYS },
 	},
+	// #1850: cohort memory sharing default-off.
+	link: { enabled: false },
 	embeddings: { ...DEFAULT_EMBEDDINGS_CONFIG },
 	retrieval: { ...DEFAULT_RETRIEVAL_CONFIG },
 	qLearning: { ...DEFAULT_QLEARNING_CONFIG },
@@ -340,12 +353,16 @@ export function resolveMemoryConfig(
 			},
 		},
 		consolidation: {
-			...DEFAULT_MEMORY_CONFIG.consolidation,
+			...DEFAULT_CONSOLIDATION_CONFIG,
 			...(input?.consolidation ?? {}),
 			decayHalfLifeDays: {
-				...DEFAULT_MEMORY_CONFIG.consolidation.decayHalfLifeDays,
+				...DEFAULT_CONSOLIDATION_CONFIG.decayHalfLifeDays,
 				...(input?.consolidation?.decayHalfLifeDays ?? {}),
 			},
+		},
+		// #1850: cohort link config — default-off but allow caller override.
+		link: {
+			enabled: input?.link?.enabled ?? DEFAULT_MEMORY_CONFIG.link.enabled,
 		},
 		embeddings: {
 			...DEFAULT_MEMORY_CONFIG.embeddings,

--- a/src/memory/consolidation-log.ts
+++ b/src/memory/consolidation-log.ts
@@ -1,6 +1,7 @@
 import { appendFile, mkdir, readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { validateSwarmPath } from '../hooks/utils';
+import type { VettedMemoryRoot } from './storage-root';
 
 /**
  * Durable, append-only record of a completed consolidation pass. Persisted to
@@ -8,6 +9,11 @@ import { validateSwarmPath } from '../hooks/utils';
  * under `.swarm/`). Serves two purposes:
  *  - idempotency: a pass for a `phaseNumber` already present here is a no-op;
  *  - observability: the `/swarm memory consolidation-log` CLI reads it.
+ *
+ * #1850 (critic GAP-3): when cohort sharing is active, the log follows the
+ * cohort root (acceptance #4 — consolidation state is part of the vetted-root
+ * surface). Callers may pass a `VettedMemoryRoot` to redirect; a raw directory
+ * string preserves today's local behavior.
  */
 export interface ConsolidationLogRecord {
 	phaseNumber: number;
@@ -31,11 +37,23 @@ export interface ConsolidationLogRecord {
 }
 
 const LOG_RELATIVE_PATH = path.join('memory', 'consolidation-log.jsonl');
+const LOG_BASENAME = 'consolidation-log.jsonl';
+
+/** #1850: resolve the log path under either a local directory or a vetted root. */
+function resolveLogPath(target: string | VettedMemoryRoot): string {
+	if (typeof target === 'string') {
+		return validateSwarmPath(target, LOG_RELATIVE_PATH);
+	}
+	if (target.kind === 'cohort') {
+		return path.join(target.cohortRoot, LOG_BASENAME);
+	}
+	return validateSwarmPath(target.directory, LOG_RELATIVE_PATH);
+}
 
 export async function readConsolidationLog(
-	directory: string,
+	target: string | VettedMemoryRoot,
 ): Promise<ConsolidationLogRecord[]> {
-	const filePath = validateSwarmPath(directory, LOG_RELATIVE_PATH);
+	const filePath = resolveLogPath(target);
 	let raw: string;
 	try {
 		raw = await readFile(filePath, 'utf-8');
@@ -56,10 +74,10 @@ export async function readConsolidationLog(
 }
 
 export async function appendConsolidationLog(
-	directory: string,
+	target: string | VettedMemoryRoot,
 	record: ConsolidationLogRecord,
 ): Promise<void> {
-	const filePath = validateSwarmPath(directory, LOG_RELATIVE_PATH);
+	const filePath = resolveLogPath(target);
 	await mkdir(path.dirname(filePath), { recursive: true });
 	await appendFile(filePath, `${JSON.stringify(record)}\n`, 'utf-8');
 }

--- a/src/memory/finalize-reward-sweep.ts
+++ b/src/memory/finalize-reward-sweep.ts
@@ -83,8 +83,12 @@
 
 import type { MemoryConfig } from '../config/schema';
 import { log as debugLog } from '../utils/logger';
-import { createConfiguredMemoryProvider } from './gateway';
+import {
+	createConfiguredMemoryProvider,
+	createConfiguredMemoryProviderForRoot,
+} from './gateway';
 import { applyCouncilReward } from './reward-capture';
+import { resolveVettedMemoryRoot } from './storage-root';
 
 /**
  * Negative terminal reward for memories recalled into non-completed
@@ -161,8 +165,12 @@ export async function runFinalizeRewardSweep(
 		}
 
 		const timestamp = args.timestamp ?? new Date().toISOString();
-		const provider = _internals.createConfiguredMemoryProvider(
-			directory,
+		// #1850 (critic GAP-4): resolve the vetted root so rewards captured by
+		// the finalize sweep land in the cohort store when linked. Without this,
+		// the sweep silently stays local (rewards invisible to siblings).
+		const vettedRoot = resolveVettedMemoryRoot(directory, memoryConfig);
+		const provider = _internals.createConfiguredMemoryProviderForRoot(
+			vettedRoot,
 			memoryConfig,
 		);
 		try {
@@ -245,5 +253,6 @@ export async function runFinalizeRewardSweep(
  */
 export const _internals = {
 	createConfiguredMemoryProvider,
+	createConfiguredMemoryProviderForRoot,
 	applyCouncilReward,
 };

--- a/src/memory/gateway.ts
+++ b/src/memory/gateway.ts
@@ -15,8 +15,16 @@ import type {
 	MemoryRecallUsageEvent,
 	MemoryRecallUsageFilter,
 } from './provider';
-import { getOrCreateProvider } from './provider-pool';
-import { redactSecrets } from './redaction';
+import {
+	getOrCreateProvider,
+	getOrCreateProviderForRoot,
+} from './provider-pool';
+import { computeRedactionPolicyVersion, redactSecrets } from './redaction';
+import {
+	type VettedMemoryRoot,
+	isCohortRoot,
+	resolveVettedMemoryRoot,
+} from './storage-root';
 import {
 	computeMemoryContentHash,
 	createBundleId,
@@ -77,6 +85,12 @@ export interface RecallMemoryInput {
 export class MemoryGateway {
 	private readonly config: MemoryConfig;
 	private readonly provider: MemoryProvider & Partial<MemoryProposalStore>;
+	/**
+	 * #1850: the resolved vetted memory root. Used by `deriveAllowedScopes` to
+	 * emit a cohort scope when cohort sharing is active, and by `propose` to
+	 * stamp provenance. Resolved once at construction (sync pointer read).
+	 */
+	private readonly vettedRoot: VettedMemoryRoot;
 	private readonly now: () => Date;
 	private disposed = false;
 
@@ -85,9 +99,10 @@ export class MemoryGateway {
 		options: MemoryGatewayOptions = {},
 	) {
 		this.config = resolveMemoryConfig(options.config ?? DEFAULT_MEMORY_CONFIG);
+		this.vettedRoot = resolveVettedMemoryRoot(context.directory, this.config);
 		this.provider =
 			options.provider ??
-			createConfiguredMemoryProvider(context.directory, this.config);
+			createConfiguredMemoryProviderForRoot(this.vettedRoot, this.config);
 		this.now = options.now ?? (() => new Date());
 	}
 
@@ -115,6 +130,17 @@ export class MemoryGateway {
 				repoRoot: resolvedRoot,
 			},
 		];
+		// #1850: when cohort sharing is active, emit a cohort scope. The
+		// cohortId is the canonical #1846 id shared by all sibling worktrees,
+		// so a record written by worktree A is visible to worktree B's recall
+		// (the scope key matches). Per-session/per-run scopes below remain
+		// worktree-local (acceptance #9).
+		if (isCohortRoot(this.vettedRoot)) {
+			scopes.push({
+				type: 'cohort',
+				cohortId: this.vettedRoot.cohortId,
+			});
+		}
 		if (this.context.runId || this.context.sessionID) {
 			scopes.push({
 				type: 'run',
@@ -431,6 +457,17 @@ export class MemoryGateway {
 			expiresAt,
 			contentHash: computeMemoryContentHash(recordBase),
 			metadata: input.metadata ?? {},
+			// #1850: provenance (acceptance #13). Stamped on every record so
+			// cohort members can attribute and verify redaction policy.
+			cohortId: isCohortRoot(this.vettedRoot)
+				? this.vettedRoot.cohortId
+				: undefined,
+			producerSessionId: this.context.sessionID,
+			producerAgentRole: this.context.agentRole,
+			redactionPolicyVersion: computeRedactionPolicyVersion(
+				this.config.redaction.rejectDurableSecrets,
+			),
+			providerVersion: this.provider.name,
 		};
 		return record;
 	}
@@ -496,9 +533,13 @@ export class MemoryGateway {
 	private resolveRecordScope(scope?: MemoryScopeRef): MemoryScopeRef {
 		const allowedScopes = this.deriveAllowedScopes();
 		if (!scope) {
-			// Curator-supplied NewMemoryRecord omits scope by default; bind it to
-			// the repository scope derived from this gateway context.
-			const defaultScope = allowedScopes[1] ?? allowedScopes[0];
+			// #1850: when cohort sharing is active, default durable records to
+			// the cohort scope so they are shared across sibling worktrees
+			// (acceptance #8). Curator-supplied NewMemoryRecord omits scope by
+			// default. Fall back to the repository scope (today's behavior)
+			// when not cohort-linked.
+			const cohortScope = allowedScopes.find((s) => s.type === 'cohort');
+			const defaultScope = cohortScope ?? allowedScopes[1] ?? allowedScopes[0];
 			if (!defaultScope) {
 				throw new MemoryValidationError(
 					'memory scope is not available for this context',
@@ -530,10 +571,27 @@ export function createConfiguredMemoryProvider(
 	directory: string,
 	config: MemoryConfig,
 ): MemoryProvider & MemoryProposalStore {
+	// #1850: resolve the vetted root so cohort sharing is honored. Callers
+	// that pass a raw directory get today's behavior unless a memory-link
+	// pointer is active AND config.link.enabled is true.
+	const root = resolveVettedMemoryRoot(directory, config);
+	return createConfiguredMemoryProviderForRoot(root, config);
+}
+
+/**
+ * #1850: cohort-aware provider factory. Takes a resolved `VettedMemoryRoot` so
+ * callers that have already resolved (e.g. the finalize-reward sweep) skip the
+ * redundant pointer read. Both overloads converge here.
+ */
+export function createConfiguredMemoryProviderForRoot(
+	root: VettedMemoryRoot,
+	config: MemoryConfig,
+): MemoryProvider & MemoryProposalStore {
 	if (config.provider === 'sqlite') {
-		return getOrCreateProvider(directory, config);
+		return getOrCreateProviderForRoot(root, config);
 	}
-	return new LocalJsonlMemoryProvider(directory, config);
+	const cohortRoot = root.kind === 'cohort' ? root.cohortRoot : null;
+	return new LocalJsonlMemoryProvider(root.directory, config, cohortRoot);
 }
 
 function sourceFromEvidence(

--- a/src/memory/gateway.ts
+++ b/src/memory/gateway.ts
@@ -15,16 +15,8 @@ import type {
 	MemoryRecallUsageEvent,
 	MemoryRecallUsageFilter,
 } from './provider';
-import {
-	getOrCreateProvider,
-	getOrCreateProviderForRoot,
-} from './provider-pool';
+import { getOrCreateProviderForRoot } from './provider-pool';
 import { computeRedactionPolicyVersion, redactSecrets } from './redaction';
-import {
-	type VettedMemoryRoot,
-	isCohortRoot,
-	resolveVettedMemoryRoot,
-} from './storage-root';
 import {
 	computeMemoryContentHash,
 	createBundleId,
@@ -35,6 +27,11 @@ import {
 	validateMemoryRecordRules,
 } from './schema';
 import type { RecallScoringDiagnostics } from './scoring';
+import {
+	isCohortRoot,
+	resolveVettedMemoryRoot,
+	type VettedMemoryRoot,
+} from './storage-root';
 import type {
 	AppliedMemoryChange,
 	CuratorMemoryDecision,
@@ -432,10 +429,14 @@ export class MemoryGateway {
 	}): MemoryRecord {
 		const now = this.now().toISOString();
 		const text = normalizeMemoryText(input.text);
-		const scope = this.resolveRecordScope(input.scope);
 		const kind = input.kind;
 		const stability =
 			input.stability ?? (kind === 'scratch' ? 'ephemeral' : 'durable');
+		// #1850 (H-002 fix): pass stability to resolveRecordScope so
+		// ephemeral/session records default to a worktree-local scope (run/agent)
+		// instead of the cohort scope. Only durable records default to cohort
+		// when linked; scratch and session-scoped records stay worktree-local.
+		const scope = this.resolveRecordScope(input.scope, stability);
 		const expiresAt =
 			kind === 'scratch'
 				? new Date(this.now().getTime() + 7 * 24 * 60 * 60 * 1000).toISOString()
@@ -530,16 +531,23 @@ export class MemoryGateway {
 		});
 	}
 
-	private resolveRecordScope(scope?: MemoryScopeRef): MemoryScopeRef {
+	private resolveRecordScope(
+		scope?: MemoryScopeRef,
+		stability?: MemoryRecord['stability'],
+	): MemoryScopeRef {
 		const allowedScopes = this.deriveAllowedScopes();
 		if (!scope) {
-			// #1850: when cohort sharing is active, default durable records to
-			// the cohort scope so they are shared across sibling worktrees
-			// (acceptance #8). Curator-supplied NewMemoryRecord omits scope by
-			// default. Fall back to the repository scope (today's behavior)
-			// when not cohort-linked.
+			// #1850 (H-002 fix): when cohort sharing is active, default DURABLE
+			// records to the cohort scope so they are shared across sibling
+			// worktrees (acceptance #8). Ephemeral and session-stability
+			// records stay worktree-local — they must NOT leak across the
+			// cohort boundary. When not cohort-linked, fall back to the
+			// repository scope (today's behavior).
+			const wantsCohort = stability !== 'ephemeral' && stability !== 'session';
 			const cohortScope = allowedScopes.find((s) => s.type === 'cohort');
-			const defaultScope = cohortScope ?? allowedScopes[1] ?? allowedScopes[0];
+			const defaultScope = wantsCohort
+				? (cohortScope ?? allowedScopes[1] ?? allowedScopes[0])
+				: (allowedScopes[1] ?? allowedScopes[0]);
 			if (!defaultScope) {
 				throw new MemoryValidationError(
 					'memory scope is not available for this context',
@@ -702,6 +710,11 @@ function scopeKey(scope: MemoryScopeRef): string {
 		repoRoot: scope.repoRoot ? path.resolve(scope.repoRoot) : undefined,
 		runId: scope.runId,
 		agentId: scope.agentId,
+		// #1850 (H-001 fix): cohortId MUST be part of the scope-validation key,
+		// otherwise validateRequestedScopes would accept a cross-cohort scope
+		// (both stringify to {"type":"cohort"} and pass the gate). This must
+		// stay in sync with the cohortId branch in stableScopeKey (schema.ts).
+		cohortId: scope.cohortId,
 	});
 }
 

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -1,5 +1,24 @@
 export type { MemoryConfig } from './config';
 export { DEFAULT_MEMORY_CONFIG, resolveMemoryConfig } from './config';
+// #1850 Linked Knowledge 5/5: cohort memory sharing.
+export {
+	type MemoryLinkPointer,
+	MEMORY_LINK_POINTER_FILENAME,
+	readMemoryLinkPointer,
+	removeMemoryLinkPointer,
+	writeMemoryLinkPointer,
+	resolveMemoryStoreDir,
+	invalidateMemoryStoreDirCache,
+	isMemoryLinked,
+} from './memory-link';
+export {
+	type VettedMemoryRoot,
+	resolveVettedMemoryRoot,
+	wrapLocalRoot,
+	isCohortRoot,
+	isLocalRoot,
+	rootStoragePath,
+} from './storage-root';
 export { MemoryDisabledError, MemoryValidationError } from './errors';
 export {
 	evaluateMemoryRecallFixtures,
@@ -18,6 +37,7 @@ export type {
 } from './gateway';
 export {
 	createConfiguredMemoryProvider,
+	createConfiguredMemoryProviderForRoot,
 	createMemoryGateway,
 	MemoryGateway,
 } from './gateway';
@@ -66,7 +86,13 @@ export {
 	type MemoryRecallPlan,
 	type MemoryRecallPlannerInput,
 } from './recall-planner';
-export { findSecrets, redactSecrets } from './redaction';
+export {
+	findSecrets,
+	redactSecrets,
+	computeRedactionPolicyVersion,
+	computeMemoryCohortFingerprint,
+	buildMemoryCohortFingerprintInput,
+} from './redaction';
 export {
 	MEMORY_RECALL_PROFILES,
 	type MemoryRecallProfile,

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -1,24 +1,5 @@
 export type { MemoryConfig } from './config';
 export { DEFAULT_MEMORY_CONFIG, resolveMemoryConfig } from './config';
-// #1850 Linked Knowledge 5/5: cohort memory sharing.
-export {
-	type MemoryLinkPointer,
-	MEMORY_LINK_POINTER_FILENAME,
-	readMemoryLinkPointer,
-	removeMemoryLinkPointer,
-	writeMemoryLinkPointer,
-	resolveMemoryStoreDir,
-	invalidateMemoryStoreDirCache,
-	isMemoryLinked,
-} from './memory-link';
-export {
-	type VettedMemoryRoot,
-	resolveVettedMemoryRoot,
-	wrapLocalRoot,
-	isCohortRoot,
-	isLocalRoot,
-	rootStoragePath,
-} from './storage-root';
 export { MemoryDisabledError, MemoryValidationError } from './errors';
 export {
 	evaluateMemoryRecallFixtures,
@@ -72,6 +53,17 @@ export {
 	type MemorySupersededChain,
 	shouldCompactMemory,
 } from './maintenance';
+// #1850 Linked Knowledge 5/5: cohort memory sharing.
+export {
+	invalidateMemoryStoreDirCache,
+	isMemoryLinked,
+	MEMORY_LINK_POINTER_FILENAME,
+	type MemoryLinkPointer,
+	readMemoryLinkPointer,
+	removeMemoryLinkPointer,
+	resolveMemoryStoreDir,
+	writeMemoryLinkPointer,
+} from './memory-link';
 export { buildRecallPromptBlock } from './prompt-block';
 export type {
 	MemoryCompactOptions,
@@ -87,11 +79,11 @@ export {
 	type MemoryRecallPlannerInput,
 } from './recall-planner';
 export {
+	buildMemoryCohortFingerprintInput,
+	computeMemoryCohortFingerprint,
+	computeRedactionPolicyVersion,
 	findSecrets,
 	redactSecrets,
-	computeRedactionPolicyVersion,
-	computeMemoryCohortFingerprint,
-	buildMemoryCohortFingerprintInput,
 } from './redaction';
 export {
 	MEMORY_RECALL_PROFILES,
@@ -112,6 +104,14 @@ export {
 	validateMemoryRecordRules,
 } from './schema';
 export { SQLiteMemoryProvider } from './sqlite-provider';
+export {
+	isCohortRoot,
+	isLocalRoot,
+	resolveVettedMemoryRoot,
+	rootStoragePath,
+	type VettedMemoryRoot,
+	wrapLocalRoot,
+} from './storage-root';
 export type {
 	AppliedMemoryChange,
 	CuratorMemoryDecision,

--- a/src/memory/local-jsonl-provider.ts
+++ b/src/memory/local-jsonl-provider.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { existsSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 import {
 	appendFile,
 	mkdir,
@@ -70,20 +70,35 @@ export class LocalJsonlMemoryProvider
 {
 	readonly name = 'local-jsonl';
 	private readonly rootDirectory: string;
+	/**
+	 * #1850: when set, the provider serves a cohort-shared store. Cohort roots
+	 * bypass `validateSwarmPath` (constructed by the resolver from a sanitized
+	 * linkId). `null` for local-root providers (today's behavior).
+	 */
+	private readonly cohortRoot: string | null;
 	private readonly config: MemoryConfig;
 	private initialized = false;
 	private memories = new Map<string, MemoryRecord>();
 	private proposals = new Map<string, MemoryProposal>();
 
-	constructor(rootDirectory: string, config: Partial<MemoryConfig> = {}) {
+	constructor(
+		rootDirectory: string,
+		config: Partial<MemoryConfig> = {},
+		vettedCohortRoot?: string | null,
+	) {
 		this.rootDirectory = rootDirectory;
+		this.cohortRoot = vettedCohortRoot ?? null;
 		this.config = { ...DEFAULT_MEMORY_CONFIG, ...config };
 	}
 
+	/**
+	 * #1850 (critic GAP-5): explicit cohort-root path branch.
+	 * - cohort root → `<cohortRoot>/<filename>` (NO validateSwarmPath).
+	 * - local root → existing behavior: strip `.swarm/`, validateSwarmPath.
+	 */
 	private pathFor(
 		file: 'memories' | 'proposals' | 'audit' | 'reward-events',
 	): string {
-		const storageDir = this.config.storageDir.replace(/^\.swarm[/\\]?/, '');
 		const filename =
 			file === 'memories'
 				? 'memories.jsonl'
@@ -92,6 +107,10 @@ export class LocalJsonlMemoryProvider
 					: file === 'audit'
 						? 'audit.jsonl'
 						: 'reward-events.jsonl';
+		if (this.cohortRoot) {
+			return path.join(this.cohortRoot, filename);
+		}
+		const storageDir = this.config.storageDir.replace(/^\.swarm[/\\]?/, '');
 		return validateSwarmPath(
 			this.rootDirectory,
 			path.join(storageDir, filename),
@@ -151,6 +170,7 @@ export class LocalJsonlMemoryProvider
 		this.memories.set(next.id, next);
 		await appendJsonl(this.pathFor('memories'), next);
 		await this.audit('upsert', next.id);
+		this.bumpCohortGeneration();
 		return next;
 	}
 
@@ -176,6 +196,7 @@ export class LocalJsonlMemoryProvider
 			await appendJsonl(this.pathFor('memories'), tombstone);
 		}
 		await this.audit('delete', id, reason);
+		this.bumpCohortGeneration();
 	}
 
 	async recall(request: RecallRequest): Promise<RecallResultItem[]> {
@@ -247,6 +268,7 @@ export class LocalJsonlMemoryProvider
 		await this.initialize();
 		const record: MemoryRewardEvent = { ...event, id: randomUUID() };
 		await appendJsonl(this.pathFor('reward-events'), record);
+		this.bumpCohortGeneration();
 	}
 
 	async listRewardEvents(
@@ -300,6 +322,7 @@ export class LocalJsonlMemoryProvider
 		this.proposals.set(next.id, next);
 		await appendJsonl(this.pathFor('proposals'), next);
 		await this.audit('proposal', next.id);
+		this.bumpCohortGeneration();
 		return next;
 	}
 
@@ -427,6 +450,7 @@ export class LocalJsonlMemoryProvider
 			change.reason,
 			buildCuratorDecisionEvent(change, proposal),
 		);
+		this.bumpCohortGeneration();
 		return change;
 	}
 
@@ -437,6 +461,7 @@ export class LocalJsonlMemoryProvider
 			Array.from(this.memories.values()),
 		);
 		await this.audit('compact', 'memories');
+		this.bumpCohortGeneration();
 	}
 
 	async compactMaintenance(
@@ -478,6 +503,7 @@ export class LocalJsonlMemoryProvider
 			'removed deleted, superseded, and expired scratch memories',
 			result,
 		);
+		this.bumpCohortGeneration();
 		return result;
 	}
 
@@ -496,6 +522,22 @@ export class LocalJsonlMemoryProvider
 			timestamp: new Date().toISOString(),
 		};
 		await appendJsonl(this.pathFor('audit'), event);
+	}
+
+	/**
+	 * #1850 (critic CONCERN-1): bump the cohort generation marker so sibling
+	 * worktrees observe this write on their next revalidation. Called at the
+	 * provider layer so ALL write paths invalidate peers. Local writes are
+	 * no-ops. Best-effort: a bump failure must never block the write.
+	 */
+	private bumpCohortGeneration(): void {
+		if (!this.cohortRoot) return;
+		try {
+			const markerPath = path.join(this.cohortRoot, 'memory.gen');
+			writeFileSync(markerPath, String(Date.now()), 'utf-8');
+		} catch {
+			/* best-effort — peer revalidation has TTL + pointer-stat backstops */
+		}
 	}
 
 	private activeMemory(memoryId: string): MemoryRecord {

--- a/src/memory/local-jsonl-provider.ts
+++ b/src/memory/local-jsonl-provider.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { existsSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import {
 	appendFile,
 	mkdir,
@@ -30,6 +30,10 @@ import type {
 	MemoryRewardEvent,
 	MemoryRewardEventFilter,
 } from './provider';
+import {
+	buildMemoryCohortFingerprintInput,
+	computeMemoryCohortFingerprint,
+} from './redaction';
 import { validateMemoryProposal, validateMemoryRecordRules } from './schema';
 import type { RecallScoringDiagnostics } from './scoring';
 import {
@@ -119,6 +123,12 @@ export class LocalJsonlMemoryProvider
 
 	async initialize(): Promise<void> {
 		if (this.initialized) return;
+		// #1850 (KC-001 fix): enforce the cohort config fingerprint for JSONL
+		// providers too, so a cohort member with a mismatched config fails
+		// closed (acceptance #10). Mirrors the SQLite provider's check.
+		if (this.cohortRoot) {
+			this.assertCohortConfigFingerprint();
+		}
 		const memoryPath = this.pathFor('memories');
 		const proposalPath = this.pathFor('proposals');
 		const memoryLoad = validateLoadedMemories(
@@ -537,6 +547,43 @@ export class LocalJsonlMemoryProvider
 			writeFileSync(markerPath, String(Date.now()), 'utf-8');
 		} catch {
 			/* best-effort — peer revalidation has TTL + pointer-stat backstops */
+		}
+	}
+
+	/**
+	 * #1850 (KC-001 fix): mirror the SQLite provider's fingerprint check. Reads
+	 * `memory-cohort-config.json` and throws on mismatch. Absent/malformed file
+	 * is permissive (fail-open never strands memory).
+	 */
+	private assertCohortConfigFingerprint(): void {
+		if (!this.cohortRoot) return;
+		const configPath = path.join(this.cohortRoot, 'memory-cohort-config.json');
+		if (!existsSync(configPath)) return;
+		try {
+			const stored = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<
+				string,
+				unknown
+			>;
+			const storedFingerprint = stored.fingerprint;
+			if (typeof storedFingerprint !== 'string') return;
+			const expectedFingerprint = computeMemoryCohortFingerprint(
+				buildMemoryCohortFingerprintInput(this.config),
+			);
+			if (storedFingerprint !== expectedFingerprint) {
+				throw new Error(
+					`memory cohort config fingerprint mismatch: cohort expects ${storedFingerprint}, this worktree computes ${expectedFingerprint}. ` +
+						'Provider/embedding/redaction config differs across cohort members. ' +
+						'Run `/swarm memory unlink` to recover local state, or align configs across linked worktrees.',
+				);
+			}
+		} catch (err) {
+			if (
+				err instanceof Error &&
+				err.message.includes('fingerprint mismatch')
+			) {
+				throw err;
+			}
+			/* malformed config file — fail-open */
 		}
 	}
 

--- a/src/memory/memory-family-manifest.ts
+++ b/src/memory/memory-family-manifest.ts
@@ -1,0 +1,117 @@
+/**
+ * #1850 Linked Knowledge 5/5: memory family manifest.
+ *
+ * One authoritative inventory of every memory artifact, classified by scope
+ * and merge strategy. Drives `migrateMemoryFamily` so a new artifact cannot be
+ * silently omitted from link/unlink migration (issue #1850 acceptance #7).
+ *
+ * Mirrors the structure of `KNOWLEDGE_FAMILY` in
+ * `src/knowledge/family-manifest.ts` but is memory-specific. The two
+ * manifests are deliberately separate: knowledge uses text/JSONL merge
+ * strategies; memory has a binary SQLite blob whose merge strategy is
+ * fundamentally different (ATTACH + INSERT OR IGNORE).
+ *
+ * Scope classifications:
+ *  - `canonical`  — data that must be migrated to preserve cohort state.
+ *  - `derived`    — rebuildable state (FTS shadow tables, vec0 index,
+ *                   embedding cache). Travels inside `memory.db` for SQLite;
+ *                   rebuilt on first open if missing. Not migrated separately.
+ *
+ * Merge strategies:
+ *  - `sqlite-file-copy` — whole-DB file copy under exclusive lock; for
+ *                         non-empty destinations, ATTACH + INSERT OR IGNORE
+ *                         keyed by record id (critic CONCERN-6).
+ *  - `append-union`     — id-keyed union of append-only JSONL (reuses the
+ *                         knowledge-family pattern).
+ *  - `skip`             — not migrated (derived state rebuilt on open).
+ */
+
+export type MemoryFamilyMergeStrategy =
+	| 'sqlite-file-copy'
+	| 'append-union'
+	| 'skip';
+
+export type MemoryFamilyScope = 'canonical' | 'derived';
+
+export interface MemoryFamilyMember {
+	filename: string;
+	scope: MemoryFamilyScope;
+	mergeStrategy: MemoryFamilyMergeStrategy;
+	/** Human-readable note for diagnostics. */
+	note?: string;
+}
+
+/**
+ * The canonical memory family manifest. Adding a member here automatically
+ * includes it in link + unlink migration (mirrors `KNOWLEDGE_FAMILY`).
+ *
+ * NOTE: for SQLite-provider cohort members, only `memory.db` is migrated as a
+ * binary blob; the JSONL members are migrated ONLY when a cohort member uses
+ * the `local-jsonl` provider (rare — JSONL is legacy/debug mode per schema).
+ * The migration engine skips JSONL members when the source uses SQLite, and
+ * vice versa, so a mixed-provider cohort fails closed with a diagnostic
+ * (acceptance #10) rather than silently losing data.
+ */
+export const MEMORY_FAMILY: readonly MemoryFamilyMember[] = [
+	{
+		filename: 'memory.db',
+		scope: 'canonical',
+		mergeStrategy: 'sqlite-file-copy',
+		note: 'SQLite memory database (records, proposals, events, recall usage, rewards, embedding config). FTS/vec indexes travel inside as derived state.',
+	},
+	{
+		filename: 'memories.jsonl',
+		scope: 'canonical',
+		mergeStrategy: 'append-union',
+		note: 'JSONL provider memory records (legacy/debug mode only).',
+	},
+	{
+		filename: 'proposals.jsonl',
+		scope: 'canonical',
+		mergeStrategy: 'append-union',
+		note: 'JSONL provider pending proposals.',
+	},
+	{
+		filename: 'audit.jsonl',
+		scope: 'canonical',
+		mergeStrategy: 'append-union',
+		note: 'JSONL provider audit events.',
+	},
+	{
+		filename: 'reward-events.jsonl',
+		scope: 'canonical',
+		mergeStrategy: 'append-union',
+		note: 'JSONL provider reward events.',
+	},
+	{
+		filename: 'consolidation-log.jsonl',
+		scope: 'canonical',
+		mergeStrategy: 'append-union',
+		note: 'Consolidation pass idempotency log (phaseNumber-keyed).',
+	},
+	{
+		filename: 'backups/',
+		scope: 'derived',
+		mergeStrategy: 'skip',
+		note: 'Pre-migration source backups (rebuildable; not migrated).',
+	},
+	{
+		filename: 'export/',
+		scope: 'derived',
+		mergeStrategy: 'skip',
+		note: 'JSONL export artifacts (rebuildable; not migrated).',
+	},
+];
+
+/** Filenames that are actually migrated (not skipped). */
+export const MIGRATED_MEMORY_FILENAMES: readonly string[] =
+	MEMORY_FAMILY.filter((m) => m.mergeStrategy !== 'skip').map(
+		(m) => m.filename,
+	);
+
+/** Look up a member by filename. */
+export function findMemoryFamilyMember(
+	filename: string,
+): MemoryFamilyMember | undefined {
+	return MEMORY_FAMILY.find((m) => m.filename === filename);
+}

--- a/src/memory/memory-family-migration.ts
+++ b/src/memory/memory-family-migration.ts
@@ -27,7 +27,7 @@
  */
 
 import { copyFileSync, existsSync, readFileSync, unlinkSync } from 'node:fs';
-import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { mkdir, rename } from 'node:fs/promises';
 import * as path from 'node:path';
 import lockfile from 'proper-lockfile';
 import { atomicWriteFile } from '../evidence/task-file.js';
@@ -35,12 +35,16 @@ import {
 	MIGRATION_LOCK_RETRIES,
 	MIGRATION_LOCK_STALE_MS,
 } from '../knowledge/family-migration-shared.js';
-import {
-	MEMORY_FAMILY,
-	type MemoryFamilyMember,
-} from './memory-family-manifest.js';
+import { warn } from '../utils/logger.js';
+import { MEMORY_FAMILY } from './memory-family-manifest.js';
 import type { VettedMemoryRoot } from './storage-root.js';
 import { isCohortRoot, rootStoragePath } from './storage-root.js';
+
+/**
+ * #1850 (H-008): max number of source-DB backups retained in
+ * `<cohortRoot>/backups/`. Oldest are pruned after each migration.
+ */
+const MAX_BACKUPS = 5;
 
 export interface MemoryFamilyMigrationCounts {
 	readonly perMember: ReadonlyArray<{
@@ -190,14 +194,17 @@ async function mergeStagedSqlite(
 	// unlink cycle (or two worktrees linking concurrently) merges rather than
 	// overwrites or fails. We open the destination DB directly (NOT via the
 	// pool — the pool was drained by the command handler before migration).
-	const beforeCount = await countRowsSafe(destDbPath);
 	try {
 		const { loadDatabaseCtor } = await import('../db/sqlite-loader.js');
 		const Db = loadDatabaseCtor();
 		const db = new Db(destDbPath);
 		try {
-			// ATTACH the staged DB read-only.
-			db.run(`ATTACH DATABASE '${stagedPath}' AS staged;`);
+			// ATTACH the staged DB read-only. #1850 (M-001 fix): escape single
+			// quotes in the path by doubling them (SQL-standard string escape)
+			// so paths containing `'` don't break the ATTACH. We avoid
+			// pathToFileURL because node:sqlite on Windows rejects file:// URLs.
+			const safePath = stagedPath.replace(/'/g, "''");
+			db.run(`ATTACH DATABASE '${safePath}' AS staged;`);
 			// Merge each id-keyed table. INSERT OR IGNORE skips rows whose id
 			// already exists in the destination (idempotent on retry).
 			const tables = [
@@ -208,6 +215,8 @@ async function mergeStagedSqlite(
 				'memory_reward_events',
 			];
 			let merged = 0;
+			let skippedDueToError = 0;
+			const failedTables: string[] = [];
 			for (const table of tables) {
 				try {
 					// Check the staged table exists (a freshly-created staged DB
@@ -222,12 +231,23 @@ async function mergeStagedSqlite(
 						`INSERT OR IGNORE INTO ${table} SELECT * FROM staged.${table};`,
 					);
 					merged += result.changes ?? 0;
-				} catch {
-					/* per-table best-effort — schema may differ */
+				} catch (err) {
+					// #1850 (M-002 fix): track tables that failed schema-mismatch or
+					// other errors, so the migration report surfaces them instead of
+					// silently claiming skipped:0.
+					skippedDueToError++;
+					failedTables.push(
+						`${table} (${err instanceof Error ? err.message : String(err)})`,
+					);
 				}
 			}
 			db.run('DETACH DATABASE staged;');
-			return { merged, skipped: 0 };
+			if (failedTables.length > 0) {
+				warn(
+					`[memory-family-migration] ${failedTables.length} table(s) skipped during SQLite ATTACH merge: ${failedTables.join(', ')}`,
+				);
+			}
+			return { merged, skipped: skippedDueToError };
 		} finally {
 			db.close();
 			// #1850 (final-critic cleanup): remove the staged DB file (+ sidecars)
@@ -358,12 +378,13 @@ export async function migrateMemoryFamily(
 				}
 				await atomicWriteFile(destPath, serialized);
 				perMember.push({ filename: member.filename, merged: added, skipped });
-				continue;
 			}
 		}
 
 		// 8. Source backup (step 9 of the issue sequence) — retained for recovery.
 		// Written under the cohort dir's backups/ subdir with a timestamp.
+		// #1850 (H-008 fix): cap at MAX_BACKUPS to prevent unbounded accumulation;
+		// oldest backups are pruned after each write.
 		if (isCohortRoot(sourceRoot)) {
 			const backupDir = path.join(destStoragePath, 'backups');
 			await mkdir(backupDir, { recursive: true });
@@ -377,6 +398,21 @@ export async function migrateMemoryFamily(
 					);
 				} catch {
 					/* best-effort backup */
+				}
+				// Prune oldest backups beyond the cap.
+				try {
+					const { readdirSync, unlinkSync: rmFileSync } = await import(
+						'node:fs'
+					);
+					const backups = readdirSync(backupDir)
+						.filter((f) => f.startsWith('memory.db.pre-merge-'))
+						.sort();
+					while (backups.length > MAX_BACKUPS) {
+						const oldest = backups.shift();
+						if (oldest) rmFileSync(path.join(backupDir, oldest));
+					}
+				} catch {
+					/* best-effort prune */
 				}
 			}
 		}

--- a/src/memory/memory-family-migration.ts
+++ b/src/memory/memory-family-migration.ts
@@ -1,0 +1,403 @@
+/**
+ * #1850 Linked Knowledge 5/5: cohort memory family migration engine.
+ *
+ * Drives both `/swarm memory link` and `/swarm memory unlink` off the single
+ * {@link MEMORY_FAMILY} manifest. Mirrors the architecture of
+ * `src/knowledge/family-migration.ts` (issue #1846) but is memory-specific:
+ *
+ *  - JSONL members use `append-union` (id-keyed, idempotent on retry) — the
+ *    same primitive the knowledge family uses.
+ *  - The SQLite `memory.db` uses `sqlite-file-copy`: under an exclusive lock,
+ *    checkpoint+close the source, copy the file into a staging path, validate
+ *    by opening read-only and counting rows, then either (a) atomically rename
+ *    into an empty destination, or (b) for a non-empty destination, ATTACH the
+ *    staged DB and `INSERT OR IGNORE` keyed by id (critic CONCERN-6).
+ *
+ * All-or-nothing commit (issue #1850 acceptance #7): stage → validate →
+ * commit. The memory-link pointer is flipped LAST by the caller
+ * (`handleMemoryLinkCommand`), so a mid-migration failure leaves the worktree
+ * in its prior link state and a retry is idempotent.
+ *
+ * Lock discipline: `proper-lockfile` on the destination cohort dir with a
+ * bumped `stale` (30s) for the migration critical section — reused from the
+ * knowledge family so there is one source of truth for the lock config.
+ *
+ * No writes happen here on the plugin-init path (invariant 1). Called only
+ * from the `/swarm memory link` / `/swarm memory unlink` command handlers.
+ */
+
+import { copyFileSync, existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import * as path from 'node:path';
+import lockfile from 'proper-lockfile';
+import { atomicWriteFile } from '../evidence/task-file.js';
+import {
+	MIGRATION_LOCK_RETRIES,
+	MIGRATION_LOCK_STALE_MS,
+} from '../knowledge/family-migration-shared.js';
+import {
+	MEMORY_FAMILY,
+	type MemoryFamilyMember,
+} from './memory-family-manifest.js';
+import type { VettedMemoryRoot } from './storage-root.js';
+import { isCohortRoot, rootStoragePath } from './storage-root.js';
+
+export interface MemoryFamilyMigrationCounts {
+	readonly perMember: ReadonlyArray<{
+		filename: string;
+		merged: number;
+		skipped: number;
+	}>;
+}
+
+/** Read a JSONL file into parsed objects (malformed lines skipped). */
+function readJsonl<T>(filePath: string): T[] {
+	if (!existsSync(filePath)) return [];
+	try {
+		const content = readFileSync(filePath, 'utf-8');
+		const out: T[] = [];
+		for (const line of content.split('\n')) {
+			const trimmed = line.trim();
+			if (!trimmed) continue;
+			try {
+				out.push(JSON.parse(trimmed) as T);
+			} catch {
+				/* skip malformed */
+			}
+		}
+		return out;
+	} catch {
+		return [];
+	}
+}
+
+/** Id-keyed union of two append-only JSONL arrays (idempotent on retry). */
+function appendUnionById<T>(
+	destination: T[],
+	source: T[],
+): { merged: T[]; added: number; skipped: number } {
+	const result = [...destination];
+	const seen = new Set(
+		result.map((r) => {
+			const o = r as unknown as Record<string, unknown>;
+			return typeof o.id === 'string' ? o.id : JSON.stringify(r);
+		}),
+	);
+	let added = 0;
+	let skipped = 0;
+	for (const src of source) {
+		const o = src as unknown as Record<string, unknown>;
+		const id = typeof o.id === 'string' ? o.id : JSON.stringify(src);
+		if (seen.has(id)) {
+			skipped++;
+			continue;
+		}
+		result.push(src);
+		seen.add(id);
+		added++;
+	}
+	return { merged: result, added, skipped };
+}
+
+/** Serialize a merged JSONL member. */
+function serializeJsonl(values: unknown[]): string {
+	if (values.length === 0) return '';
+	return `${values.map((e) => JSON.stringify(e)).join('\n')}\n`;
+}
+
+/** Validate a serialized JSONL member: every line must parse and carry an id. */
+function validateSerializedJsonl(serialized: string): boolean {
+	for (const line of serialized.split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			const parsed = JSON.parse(trimmed) as unknown;
+			if (!parsed || typeof parsed !== 'object') return false;
+		} catch {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Copy the SQLite DB file (+ non-empty WAL/SHM sidecars) from source to a
+ * staging path under the destination directory. The caller MUST have drained
+ * and closed the source provider first (the command handler does this via
+ * `evictAndCloseForRoot`).
+ *
+ * Returns the staging path, or null if the source DB does not exist.
+ */
+function stageSqliteDb(
+	sourceStoragePath: string,
+	destDir: string,
+): { stagedPath: string } | null {
+	const sourceDbPath = path.join(sourceStoragePath, 'memory.db');
+	if (!existsSync(sourceDbPath)) return null;
+	const stagedPath = path.join(destDir, '.memory.db.stage');
+	copyFileSync(sourceDbPath, stagedPath);
+	// Copy WAL/SHM sidecars if present and non-empty (post-checkpoint they
+	// should be empty/absent, but copy-as-is is still correct — SQLite
+	// recovers from WAL on next open).
+	for (const suffix of ['-wal', '-shm']) {
+		const sidecar = `${sourceDbPath}${suffix}`;
+		if (existsSync(sidecar)) {
+			try {
+				copyFileSync(sidecar, `${stagedPath}${suffix}`);
+			} catch {
+				/* best-effort — sidecar may be absent mid-copy */
+			}
+		}
+	}
+	return { stagedPath };
+}
+
+/**
+ * Merge a staged SQLite DB into the destination. If the destination has no
+ * existing DB, atomically rename the staged file into place. If the
+ * destination has an existing DB, ATTACH the staged DB and INSERT OR IGNORE
+ * rows keyed by id (critic CONCERN-6 — two worktrees linking concurrently
+ * must not overwrite each other's data).
+ *
+ * NOTE: this function does NOT open the DB via the provider (that would
+ * re-enter the pool). It uses a minimal direct-open to copy rows. The
+ * destination provider will re-open and rebuild FTS/vec on next access.
+ */
+async function mergeStagedSqlite(
+	destStoragePath: string,
+	stagedPath: string,
+): Promise<{ merged: number; skipped: number }> {
+	const destDbPath = path.join(destStoragePath, 'memory.db');
+	if (!existsSync(destDbPath)) {
+		// Empty destination — atomic rename.
+		await rename(stagedPath, destDbPath);
+		// Move sidecars too.
+		for (const suffix of ['-wal', '-shm']) {
+			const stagedSidecar = `${stagedPath}${suffix}`;
+			if (existsSync(stagedSidecar)) {
+				try {
+					await rename(stagedSidecar, `${destDbPath}${suffix}`);
+				} catch {
+					/* best-effort */
+				}
+			}
+		}
+		// Count rows in the renamed DB for the report (best-effort).
+		return { merged: await countRowsSafe(destDbPath), skipped: 0 };
+	}
+	// #1850 (reviewer fix + CONCERN-6): non-empty destination — ATTACH the
+	// staged DB and INSERT OR IGNORE rows keyed by id, so a re-link-after-
+	// unlink cycle (or two worktrees linking concurrently) merges rather than
+	// overwrites or fails. We open the destination DB directly (NOT via the
+	// pool — the pool was drained by the command handler before migration).
+	const beforeCount = await countRowsSafe(destDbPath);
+	try {
+		const { loadDatabaseCtor } = await import('../db/sqlite-loader.js');
+		const Db = loadDatabaseCtor();
+		const db = new Db(destDbPath);
+		try {
+			// ATTACH the staged DB read-only.
+			db.run(`ATTACH DATABASE '${stagedPath}' AS staged;`);
+			// Merge each id-keyed table. INSERT OR IGNORE skips rows whose id
+			// already exists in the destination (idempotent on retry).
+			const tables = [
+				'memory_items',
+				'memory_proposals',
+				'memory_events',
+				'memory_recall_usage',
+				'memory_reward_events',
+			];
+			let merged = 0;
+			for (const table of tables) {
+				try {
+					// Check the staged table exists (a freshly-created staged DB
+					// from a minimal source may not have all tables).
+					const stashed = db
+						.query<{ n: number }, []>(
+							`SELECT COUNT(*) AS n FROM staged.sqlite_master WHERE type='table' AND name='${table}'`,
+						)
+						.get();
+					if (!stashed || stashed.n === 0) continue;
+					const result = db.run(
+						`INSERT OR IGNORE INTO ${table} SELECT * FROM staged.${table};`,
+					);
+					merged += result.changes ?? 0;
+				} catch {
+					/* per-table best-effort — schema may differ */
+				}
+			}
+			db.run('DETACH DATABASE staged;');
+			return { merged, skipped: 0 };
+		} finally {
+			db.close();
+			// #1850 (final-critic cleanup): remove the staged DB file (+ sidecars)
+			// after the ATTACH merge so it does not litter the destination dir.
+			try {
+				unlinkSync(stagedPath);
+				for (const suffix of ['-wal', '-shm']) {
+					try {
+						unlinkSync(`${stagedPath}${suffix}`);
+					} catch {
+						/* sidecar may not exist */
+					}
+				}
+			} catch {
+				/* best-effort cleanup */
+			}
+		}
+	} catch (err) {
+		throw new Error(
+			`memory-family-migration: failed to merge SQLite into non-empty destination ${destDbPath}: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		);
+	}
+}
+
+/** Best-effort row count via a direct DB open (does not enter the pool). */
+async function countRowsSafe(dbPath: string): Promise<number> {
+	// We avoid importing the provider here to prevent a pool re-entry cycle.
+	// The count is informational only; a failure returns 0.
+	try {
+		const { loadDatabaseCtor } = await import('../db/sqlite-loader.js');
+		const Db = loadDatabaseCtor();
+		const db = new Db(dbPath);
+		try {
+			const row = db
+				.query<{ n: number }, []>('SELECT COUNT(*) AS n FROM memory_items')
+				.get();
+			return row?.n ?? 0;
+		} finally {
+			db.close();
+		}
+	} catch {
+		return 0;
+	}
+}
+
+/**
+ * Migrate the complete memory family from `sourceRoot` into `destRoot`,
+ * merging each member according to its manifest strategy. All-or-nothing:
+ * stage → validate → commit. The memory-link pointer is NOT touched here
+ * (caller flips it).
+ *
+ * @param destRoot the cohort root that absorbs the merge (link → cohort;
+ *   unlink → local).
+ * @param sourceRoot the root whose family is merged in (link → local;
+ *   unlink → cohort).
+ */
+export async function migrateMemoryFamily(
+	destRoot: VettedMemoryRoot,
+	sourceRoot: VettedMemoryRoot,
+): Promise<MemoryFamilyMigrationCounts> {
+	const destStoragePath = rootStoragePath(destRoot);
+	const sourceStoragePath = rootStoragePath(sourceRoot);
+
+	// #1850 (reviewer critical fix): the destination may be EITHER a cohort
+	// root (link direction: local → cohort) OR a local root (unlink direction:
+	// cohort → local). Both are valid. We lock the destination directory when
+	// possible; local roots are single-writer by construction (no cross-process
+	// contender), so locking is best-effort for them. The source is always read
+	// under its own brief snapshot.
+	await mkdir(destStoragePath, { recursive: true });
+	let destRelease: (() => Promise<void>) | null = null;
+	try {
+		destRelease = await lockfile.lock(destStoragePath, {
+			...MIGRATION_LOCK_RETRIES,
+			stale: MIGRATION_LOCK_STALE_MS,
+		});
+	} catch {
+		// Local roots or missing dirs may not be lockable; proceed unlocked.
+		// The destination write is still atomic (temp + rename per member).
+	}
+
+	const perMember: Array<{
+		filename: string;
+		merged: number;
+		skipped: number;
+	}> = [];
+
+	try {
+		// 2-7. For each member: read source, merge into destination, validate, commit.
+		for (const member of MEMORY_FAMILY) {
+			if (member.mergeStrategy === 'skip') continue;
+			const srcPath = path.join(sourceStoragePath, member.filename);
+			const destPath = path.join(destStoragePath, member.filename);
+
+			if (member.mergeStrategy === 'sqlite-file-copy') {
+				if (!existsSync(srcPath)) {
+					perMember.push({ filename: member.filename, merged: 0, skipped: 0 });
+					continue;
+				}
+				const staged = stageSqliteDb(sourceStoragePath, destStoragePath);
+				if (!staged) {
+					perMember.push({ filename: member.filename, merged: 0, skipped: 0 });
+					continue;
+				}
+				const { merged, skipped } = await mergeStagedSqlite(
+					destStoragePath,
+					staged.stagedPath,
+				);
+				perMember.push({ filename: member.filename, merged, skipped });
+				continue;
+			}
+
+			if (member.mergeStrategy === 'append-union') {
+				if (!existsSync(srcPath)) {
+					perMember.push({ filename: member.filename, merged: 0, skipped: 0 });
+					continue;
+				}
+				const srcData = readJsonl<unknown>(srcPath);
+				const destData = readJsonl<unknown>(destPath);
+				const { merged, added, skipped } = appendUnionById(destData, srcData);
+				const serialized = serializeJsonl(merged);
+				if (!validateSerializedJsonl(serialized)) {
+					throw new Error(
+						`memory-family-migration: validation failed for ${member.filename}; aborting before commit`,
+					);
+				}
+				await atomicWriteFile(destPath, serialized);
+				perMember.push({ filename: member.filename, merged: added, skipped });
+				continue;
+			}
+		}
+
+		// 8. Source backup (step 9 of the issue sequence) — retained for recovery.
+		// Written under the cohort dir's backups/ subdir with a timestamp.
+		if (isCohortRoot(sourceRoot)) {
+			const backupDir = path.join(destStoragePath, 'backups');
+			await mkdir(backupDir, { recursive: true });
+			const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+			const sourceDbPath = path.join(sourceStoragePath, 'memory.db');
+			if (existsSync(sourceDbPath)) {
+				try {
+					copyFileSync(
+						sourceDbPath,
+						path.join(backupDir, `memory.db.pre-merge-${stamp}`),
+					);
+				} catch {
+					/* best-effort backup */
+				}
+			}
+		}
+	} finally {
+		if (destRelease) {
+			try {
+				await destRelease();
+			} catch {
+				/* non-blocking */
+			}
+		}
+	}
+
+	return { perMember };
+}
+
+export const _internals = {
+	appendUnionById,
+	serializeJsonl,
+	validateSerializedJsonl,
+	stageSqliteDb,
+	mergeStagedSqlite,
+	countRowsSafe,
+};

--- a/src/memory/memory-link.ts
+++ b/src/memory/memory-link.ts
@@ -1,0 +1,289 @@
+/**
+ * #1850 Linked Knowledge 5/5: memory link pointer + resolution cache.
+ *
+ * Mirrors `src/hooks/knowledge-link.ts` for the memory subsystem. The pointer
+ * lives at `<directory>/.swarm/memory-link.json` — a SEPARATE pointer from the
+ * knowledge `link.json`. This deliberate split satisfies issue #1850 acceptance
+ * #1 (memory sharing is independently opt-in) and #2 (status distinguishes
+ * knowledge link from memory link). Both pointers carry the same canonical
+ * cohort id from #1846 — they identify the same cohort — but toggling one does
+ * not toggle the other.
+ *
+ * The shared cohort store lives at `<dataDir>/links/<linkId>/` (reusing
+ * `resolveLinkBaseDir` / `resolveLinkDir` from `knowledge-link.ts`). Memory
+ * occupies the `memory/` subdirectory of that cohort container, keeping
+ * knowledge and memory family files siblings without filename collisions.
+ *
+ * Reuses from `knowledge-link.ts`:
+ *  - `resolveLinkBaseDir`, `resolveLinkDir`, `sanitizeLinkId` — the cohort
+ *    directory layout and id sanitization are shared infrastructure (one
+ *    cohort container per cohort id).
+ *
+ * Does NOT duplicate the platform data-dir logic (Windows LOCALAPPDATA, macOS
+ * Application Support, linux XDG) — that lives once in `knowledge-link.ts`.
+ *
+ * Cross-process revalidation (issue #1850 §6 "bounded revalidation window"):
+ * like the knowledge resolver, a cache hit re-stats the pointer file and
+ * invalidates on `mtimeMs:ctimeMs:size` change, so a sibling worktree's
+ * `/swarm memory link` / `/swarm memory unlink` is observed without restart
+ * and without waiting for the TTL backstop.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync } from 'node:fs';
+import * as path from 'node:path';
+import { atomicWriteFile } from '../evidence/task-file.js';
+import {
+	resolveLinkBaseDir,
+	resolveLinkDir,
+	sanitizeLinkId,
+} from '../hooks/knowledge-link.js';
+import { warn } from '../utils/logger.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** On-disk pointer at `<directory>/.swarm/memory-link.json`. */
+export interface MemoryLinkPointer {
+	/** Pointer schema version. */
+	version: 1 | 2;
+	/** Sanitized link id (cohort directory segment). */
+	linkId: string;
+	/** Human-friendly name when the link was created from an explicit name. */
+	name?: string;
+	/** ISO 8601 creation timestamp. */
+	createdAt: string;
+	/** Canonical cohort id from `resolveCohortId` (issue #1846). */
+	cohortId?: string;
+	/** How the cohort id was derived. */
+	identitySource?: 'remote' | 'git-common-dir' | 'path';
+	/** True when the cohort id is machine-local (not portable). */
+	degraded?: boolean;
+	/** Memory cohort config fingerprint (provider/schema/embedding/redaction). */
+	configFingerprint?: string;
+	/** Monotonic generation counter, bumped on each link/unlink. */
+	generation?: number;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+export const MEMORY_LINK_POINTER_FILENAME = 'memory-link.json';
+
+/** Cache TTL — mirrors `knowledge-link.ts` `CACHE_TTL_MS`. */
+const CACHE_TTL_MS = 2_000;
+
+/** Bounded cache (Invariant 8: module-level state needs explicit eviction). */
+const MAX_CACHE_ENTRIES = 500;
+
+// ============================================================================
+// Pointer read / write / remove
+// ============================================================================
+
+function resolveMemoryLinkPointerPath(directory: string): string {
+	return path.join(directory, '.swarm', MEMORY_LINK_POINTER_FILENAME);
+}
+
+/**
+ * Read and validate the memory link pointer for a worktree. Null if absent or
+ * malformed (fail-open — a corrupt pointer never strands memory; it degrades
+ * to local).
+ */
+export function readMemoryLinkPointer(
+	directory: string,
+): MemoryLinkPointer | null {
+	const pointerPath = resolveMemoryLinkPointerPath(directory);
+	if (!existsSync(pointerPath)) return null;
+	try {
+		const raw = JSON.parse(readFileSync(pointerPath, 'utf-8')) as unknown;
+		if (!raw || typeof raw !== 'object') return null;
+		const obj = raw as Record<string, unknown>;
+		const linkId = obj.linkId;
+		if (typeof linkId !== 'string' || linkId.length === 0) return null;
+		// Re-sanitize on read: the linkId becomes a path segment.
+		const safeId = sanitizeLinkId(linkId);
+		if (!safeId) return null;
+		const rawVersion = obj.version;
+		const version: 1 | 2 = rawVersion === 2 ? 2 : 1;
+		return {
+			version,
+			linkId: safeId,
+			name: typeof obj.name === 'string' ? obj.name : undefined,
+			createdAt:
+				typeof obj.createdAt === 'string'
+					? obj.createdAt
+					: new Date(0).toISOString(),
+			cohortId: typeof obj.cohortId === 'string' ? obj.cohortId : undefined,
+			identitySource:
+				obj.identitySource === 'remote' ||
+				obj.identitySource === 'git-common-dir' ||
+				obj.identitySource === 'path'
+					? obj.identitySource
+					: undefined,
+			degraded: typeof obj.degraded === 'boolean' ? obj.degraded : undefined,
+			configFingerprint:
+				typeof obj.configFingerprint === 'string'
+					? obj.configFingerprint
+					: undefined,
+			generation:
+				typeof obj.generation === 'number' ? obj.generation : undefined,
+		};
+	} catch {
+		return null;
+	}
+}
+
+/** Write the memory link pointer atomically and invalidate the cache. */
+export async function writeMemoryLinkPointer(
+	directory: string,
+	pointer: MemoryLinkPointer,
+): Promise<void> {
+	const swarmDir = path.join(directory, '.swarm');
+	mkdirSync(swarmDir, { recursive: true });
+	const pointerPath = resolveMemoryLinkPointerPath(directory);
+	await atomicWriteFile(pointerPath, JSON.stringify(pointer, null, 2));
+	invalidateMemoryStoreDirCache(directory);
+}
+
+/** Remove the memory link pointer (idempotent) and invalidate the cache. */
+export async function removeMemoryLinkPointer(
+	directory: string,
+): Promise<void> {
+	const pointerPath = resolveMemoryLinkPointerPath(directory);
+	try {
+		rmSync(pointerPath, { force: true });
+	} finally {
+		invalidateMemoryStoreDirCache(directory);
+	}
+}
+
+// ============================================================================
+// Resolution (the seam used by resolveVettedMemoryRoot)
+// ============================================================================
+
+interface CacheEntry {
+	linkDir: string | null;
+	expires: number;
+	/** Pointer-file stat fingerprint for cross-process revalidation. */
+	pointerStat: string | null;
+}
+
+const _resolutionCache = new Map<string, CacheEntry>();
+
+/**
+ * Build the stat fingerprint for the pointer file. Returns null when absent
+ * (so an absent→present transition is detected as a change). Includes ctimeMs
+ * because Windows rename preserves mtimeMs (mirrors knowledge-link.ts:365).
+ */
+function pointerStatFingerprint(directory: string): string | null {
+	const pointerPath = resolveMemoryLinkPointerPath(directory);
+	try {
+		const st = statSync(pointerPath);
+		return `${st.mtimeMs}:${st.ctimeMs}:${st.size}`;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Resolve the directory that holds the cohort store for `directory`.
+ *
+ * Returns the shared link directory (`<dataDir>/links/<linkId>`) when an active
+ * memory-link pointer is present, otherwise the local `<directory>/.swarm`.
+ * Fail-open: any read/parse error degrades to local. Synchronous and cached;
+ * on a cache hit a cheap `stat` revalidates cross-process changes so the hot
+ * recall path stays fast while observing link/unlink without TTL wait.
+ *
+ * NOTE: when unlinked, the return value is byte-identical to
+ * `path.join(directory, '.swarm')`, so callers are unaffected.
+ *
+ * Memory occupies `<result>/memory/`. The caller (`resolveVettedMemoryRoot`)
+ * appends `memory` to namespace within the cohort container.
+ */
+export function resolveMemoryStoreDir(directory: string): string {
+	const localSwarm = path.join(directory, '.swarm');
+	const now = Date.now();
+
+	const cached = _resolutionCache.get(directory);
+	const currentStat = pointerStatFingerprint(directory);
+	if (cached && now < cached.expires && cached.pointerStat === currentStat) {
+		return cached.linkDir ?? localSwarm;
+	}
+
+	let linkDir: string | null = null;
+	try {
+		const pointer = readMemoryLinkPointer(directory);
+		if (pointer) {
+			// path.resolve() canonicalizes — callers never operate on non-canonical
+			// paths. Traversal safety is enforced by sanitizeLinkId on the linkId.
+			linkDir = path.resolve(resolveLinkDir(pointer.linkId));
+		}
+	} catch {
+		linkDir = null;
+	}
+
+	// FIFO eviction (Invariant 8) before inserting a fresh key.
+	if (
+		!_resolutionCache.has(directory) &&
+		_resolutionCache.size >= MAX_CACHE_ENTRIES
+	) {
+		const oldest = _resolutionCache.keys().next().value;
+		if (oldest !== undefined) _resolutionCache.delete(oldest);
+	}
+	_resolutionCache.set(directory, {
+		linkDir,
+		expires: now + CACHE_TTL_MS,
+		pointerStat: currentStat,
+	});
+
+	return linkDir ?? localSwarm;
+}
+
+/** Drop cached resolution(s). Pass a directory to invalidate one, omit for all. */
+export function invalidateMemoryStoreDirCache(directory?: string): void {
+	if (directory === undefined) {
+		_resolutionCache.clear();
+		return;
+	}
+	_resolutionCache.delete(directory);
+}
+
+/** True when the worktree currently redirects to a shared cohort store. */
+export function isMemoryLinked(directory: string): boolean {
+	return readMemoryLinkPointer(directory) !== null;
+}
+
+/** Surface an orphaned local memory store if the link pointer is active. */
+export function warnIfMemoryOrphaned(directory: string): void {
+	const pointer = readMemoryLinkPointer(directory);
+	if (!pointer) return;
+	const localMemoryDb = path.join(directory, '.swarm', 'memory', 'memory.db');
+	const localJsonl = path.join(directory, '.swarm', 'memory', 'memories.jsonl');
+	if (existsSync(localMemoryDb) || existsSync(localJsonl)) {
+		warn(
+			'[memory-link] local memory store is orphaned by cohort link — run `/swarm memory unlink` to recover it or delete the local files',
+			{ directory, linkId: pointer.linkId },
+		);
+	}
+}
+
+// ============================================================================
+// DI seam (mirrors the codebase convention for bounded test isolation)
+// ============================================================================
+
+export const _internals = {
+	resolveMemoryStoreDir,
+	readMemoryLinkPointer,
+	writeMemoryLinkPointer,
+	removeMemoryLinkPointer,
+	invalidateMemoryStoreDirCache,
+	resolveLinkDir,
+	resolveLinkBaseDir,
+	sanitizeLinkId,
+	pointerStatFingerprint,
+};
+
+// Re-exported so callers (e.g. the status service) can resolve the cohort
+// container directory without depending on knowledge-link.ts directly.
+export { resolveLinkDir, resolveLinkBaseDir, sanitizeLinkId };

--- a/src/memory/provider-pool.ts
+++ b/src/memory/provider-pool.ts
@@ -2,6 +2,7 @@ import { realpathSync } from 'node:fs';
 import * as path from 'node:path';
 
 import type { MemoryConfig } from './config';
+import type { VettedMemoryRoot } from './storage-root';
 import type { MemoryProposalStore, MemoryProvider } from './provider';
 import { SQLiteMemoryProvider } from './sqlite-provider';
 
@@ -123,6 +124,12 @@ export function isPooledProvider(
  * Note: this function returns synchronously. The provider's actual database
  * open happens lazily inside `provider.initialize()`, which callers await
  * separately (and which is protected by the provider's own init mutex).
+ *
+ * #1850: callers that have resolved a `VettedMemoryRoot` should prefer
+ * `getOrCreateProviderForRoot` so the cohort dimension (cohort id + generation)
+ * is part of the pool key. This legacy entry treats `directory` as a local
+ * root (cohort sharing inactive for that caller — emits a debug log per
+ * critic CONCERN-5 so incomplete wiring is visible).
  */
 export function getOrCreateProvider(
 	directory: string,
@@ -192,6 +199,147 @@ export function getOrCreateProvider(
 	entriesByKey.set(key, entry);
 
 	return provider;
+}
+
+/**
+ * #1850: cohort-aware provider acquisition. The pool key incorporates the
+ * root kind + canonical path + cohort generation, so:
+ *   - the same cohort root always converges on the same pool entry (acceptance #5);
+ *   - a generation bump (observed via the `memory-link.json` pointer-stat
+ *     revalidation in `resolveVettedMemoryRoot`) invalidates the stale entry
+ *     so the in-memory mirror is reloaded (acceptance #8).
+ *
+ * NOTE (final-critic correction): the `memory.gen` marker written by providers
+ * on cohort writes is NOT consumed by this pool today. Cross-process write
+ * visibility relies on SQLite WAL mode (readers see committed writes on the
+ * next query) plus the 2s TTL + pointer-stat revalidation in
+ * `resolveMemoryStoreDir`. The `memory.gen` marker is reserved for a future
+ * tighter revalidation loop and is safe to write (best-effort, never blocks).
+ *
+ * Revalidation: on each call for a cohort root, the caller is expected to have
+ * already resolved the current generation (the resolver does this via
+ * `memory-link.json` pointer-stat). If the generation in the supplied root
+ * differs from the cached entry's generation, the cached entry is evicted and
+ * a fresh provider is constructed (which reloads the in-memory mirror).
+ */
+export function getOrCreateProviderForRoot(
+	root: VettedMemoryRoot,
+	config: MemoryConfig,
+): MemoryProvider & MemoryProposalStore {
+	const key = resolvePoolKeyForRoot(root);
+	const rootGeneration = root.kind === 'cohort' ? root.generation : 0;
+
+	// Cache hit — but revalidate generation for cohort roots.
+	const existing = entriesByKey.get(key);
+	if (existing) {
+		const existingGen =
+			(existing as PoolEntry & { generation?: number }).generation ?? 0;
+		if (existingGen === rootGeneration) {
+			moveToHead(existing);
+			existing.refCount++;
+			return existing.provider;
+		}
+		// Generation changed — peer wrote. Evict and reconstruct so the
+		// in-memory mirror reloads. Wait for refCount to drain via the deferred
+		// mechanism if the entry is currently held.
+		evictEntryByKey(key);
+	}
+
+	// Cache miss — check deferred entries similarly.
+	for (const deferred of deferredEntries) {
+		if (deferred.key === key) {
+			const deferredGen =
+				(deferred as PoolEntry & { generation?: number }).generation ?? 0;
+			if (deferredGen === rootGeneration) {
+				deferredEntries.delete(deferred);
+				if (entriesByKey.size >= MAX_POOL_SIZE) evictLru();
+				deferred.prev = null;
+				deferred.next = head;
+				if (head) head.prev = deferred;
+				head = deferred;
+				if (!tail) tail = deferred;
+				entriesByKey.set(key, deferred);
+				deferred.refCount++;
+				return deferred.provider;
+			}
+			// Stale generation — drop the deferred entry too.
+			deferredEntries.delete(deferred);
+			callRealClose(deferred.provider);
+			break;
+		}
+	}
+
+	const directory = root.directory;
+	const cohortRoot = root.kind === 'cohort' ? root.cohortRoot : null;
+	const provider = new SQLiteMemoryProvider(directory, config, cohortRoot);
+	markAsPooled(provider);
+
+	if (entriesByKey.size >= MAX_POOL_SIZE) {
+		evictLru();
+	}
+
+	const entry: PoolEntry = {
+		key,
+		provider,
+		refCount: 1,
+		prev: null,
+		next: head,
+	} as PoolEntry & { generation?: number };
+	(entry as PoolEntry & { generation?: number }).generation = rootGeneration;
+
+	if (head) head.prev = entry;
+	head = entry;
+	if (!tail) tail = entry;
+	entriesByKey.set(key, entry);
+
+	return provider;
+}
+
+/**
+ * #1850: pool key for a vetted root. Includes the kind discriminator and
+ * (for cohort roots) the canonical cohort root path. Generation is tracked
+ * on the entry separately (see `getOrCreateProviderForRoot`) so a generation
+ * bump triggers revalidation without changing the key (same root, fresh
+ * mirror).
+ */
+function resolvePoolKeyForRoot(root: VettedMemoryRoot): string {
+	if (root.kind === 'cohort') {
+		// Cohort root is already canonical (resolver used path.resolve on a
+		// sanitized linkId-derived path). realpathSync it if possible to
+		// collapse symlinks, otherwise use it as-is.
+		try {
+			return `cohort:${realpathSync(root.cohortRoot)}`;
+		} catch {
+			return `cohort:${path.resolve(root.cohortRoot)}`;
+		}
+	}
+	return resolvePoolKey(root.directory);
+}
+
+/** Evict a specific entry by key, closing it if unreferenced. */
+function evictEntryByKey(key: string): void {
+	const entry = entriesByKey.get(key);
+	if (!entry) return;
+	if (entry.refCount > 0) {
+		// Still held — defer real close to refCount drain.
+		deferredEntries.add(entry);
+		unlinkEntry(entry);
+		entriesByKey.delete(key);
+		return;
+	}
+	unlinkEntry(entry);
+	entriesByKey.delete(key);
+	callRealClose(entry.provider);
+}
+
+/**
+ * #1850: scoped eviction — close and drop the pool entry for a specific root
+ * (used by the migration engine before file copy). Waits for refCount=0 via
+ * the deferred mechanism if held; callers should retry-acquire or fail closed.
+ */
+export function evictAndCloseForRoot(root: VettedMemoryRoot): void {
+	const key = resolvePoolKeyForRoot(root);
+	evictEntryByKey(key);
 }
 
 /**

--- a/src/memory/provider-pool.ts
+++ b/src/memory/provider-pool.ts
@@ -2,9 +2,9 @@ import { realpathSync } from 'node:fs';
 import * as path from 'node:path';
 
 import type { MemoryConfig } from './config';
-import type { VettedMemoryRoot } from './storage-root';
 import type { MemoryProposalStore, MemoryProvider } from './provider';
 import { SQLiteMemoryProvider } from './sqlite-provider';
+import type { VettedMemoryRoot } from './storage-root';
 
 /**
  * Maximum number of cached providers in the process-level pool.

--- a/src/memory/redaction.ts
+++ b/src/memory/redaction.ts
@@ -69,6 +69,71 @@ const SECRET_PATTERNS: SecretPattern[] = [
 	},
 ];
 
+/**
+ * #1850: Coarse redaction-policy fingerprint. Two cohort members with the same
+ * count of secret-pattern families and the same `rejectDurableSecrets` setting
+ * are considered policy-compatible; a mismatch fails closed at link time and on
+ * cohort-root open. This is honest about what it measures (the regex pattern
+ * count + the durable-rejection toggle) — it is NOT a content hash of stored
+ * records. Bump the salt constant when the redaction contract changes
+ * meaningfully (e.g. adding PII detection per #1466).
+ */
+export const REDACTION_POLICY_SALT = 1;
+export function computeRedactionPolicyVersion(
+	rejectDurableSecrets: boolean,
+): number {
+	return (
+		REDACTION_POLICY_SALT * 1_000_000 +
+		SECRET_PATTERNS.length * 2 +
+		(rejectDurableSecrets ? 1 : 0)
+	);
+}
+
+/**
+ * #1850 (final-critic dedup): the single cohort-config fingerprint algorithm.
+ * Consumed by the linker (writer), the SQLite provider (fail-closed check),
+ * and the status service (health surface). Centralizing it here prevents the
+ * triple-duplication the final critic flagged — any future edit to the input
+ * shape or hash params changes all three sites consistently.
+ *
+ * Input shape mirrors what `handleMemoryLinkCommand` writes to
+ * `memory-cohort-config.json`. Two cohort members with the same fingerprint
+ * are considered config-compatible.
+ */
+import { createHash } from 'node:crypto';
+
+export interface MemoryCohortFingerprintInput {
+	provider: string;
+	redaction_policy_version: number;
+	embedding_model: string;
+	embedding_dimension: number;
+	embedding_version: string;
+}
+
+export function computeMemoryCohortFingerprint(
+	input: MemoryCohortFingerprintInput,
+): string {
+	const canonical = JSON.stringify(input, Object.keys(input).sort());
+	return createHash('sha256').update(canonical).digest('hex').slice(0, 12);
+}
+
+/** Convenience: build the fingerprint input from a memory config subset. */
+export function buildMemoryCohortFingerprintInput(config: {
+	provider: string;
+	redaction: { rejectDurableSecrets: boolean };
+	embeddings: { model: string; dimension: number; version?: string };
+}): MemoryCohortFingerprintInput {
+	return {
+		provider: config.provider,
+		redaction_policy_version: computeRedactionPolicyVersion(
+			config.redaction.rejectDurableSecrets,
+		),
+		embedding_model: config.embeddings.model,
+		embedding_dimension: config.embeddings.dimension,
+		embedding_version: config.embeddings.version ?? 'default',
+	};
+}
+
 export function findSecrets(text: string): SecretFinding[] {
 	const findings: SecretFinding[] = [];
 	for (const { type, pattern } of SECRET_PATTERNS) {

--- a/src/memory/schema.ts
+++ b/src/memory/schema.ts
@@ -21,6 +21,8 @@ export const MemoryScopeTypeSchema = z.enum([
 	'repository',
 	'run',
 	'agent',
+	// #1850: cohort-scoped shared memory.
+	'cohort',
 ]);
 
 export const MemoryScopeRefSchema = z
@@ -33,6 +35,9 @@ export const MemoryScopeRefSchema = z
 		repoRoot: z.string().optional(),
 		runId: z.string().optional(),
 		agentId: z.string().optional(),
+		// #1850: required to key cohort scopes so different cohorts do not
+		// collapse to one stable scope key (critic GAP-1/GAP-2).
+		cohortId: z.string().optional(),
 	})
 	.strict();
 
@@ -91,6 +96,14 @@ export const MemoryRecordSchema = z
 		supersededBy: z.string().optional(),
 		contentHash: z.string().regex(/^[a-f0-9]{64}$/),
 		metadata: z.record(z.string(), z.unknown()),
+		// #1850 cohort-sharing provenance (all optional for back-compat).
+		cohortId: z.string().optional(),
+		producerSessionId: z.string().optional(),
+		producerAgentRole: z.string().optional(),
+		redactionPolicyVersion: z.number().int().min(0).optional(),
+		schemaVersion: z.number().int().min(0).optional(),
+		providerVersion: z.string().optional(),
+		sourceRevision: z.string().optional(),
 	})
 	.strict();
 
@@ -218,18 +231,23 @@ export function normalizeMemoryText(text: string): string {
 
 export function stableScopeKey(scope: MemoryScopeRef): string {
 	const ordered: Record<string, string> = { type: scope.type };
+	// #1850 (critic GAP-1): cohort scopes MUST key on cohortId, otherwise every
+	// cohort collapses to `{"type":"cohort"}` and recall returns records from
+	// unrelated cohorts. The branch is a single-key extraction like `repository`.
 	const keys =
 		scope.type === 'repository'
 			? (['repoId'] as const)
-			: ([
-					'userId',
-					'workspaceId',
-					'projectId',
-					'repoId',
-					'repoRoot',
-					'runId',
-					'agentId',
-				] as const);
+			: scope.type === 'cohort'
+				? (['cohortId'] as const)
+				: ([
+						'userId',
+						'workspaceId',
+						'projectId',
+						'repoId',
+						'repoRoot',
+						'runId',
+						'agentId',
+					] as const);
 	for (const key of keys) {
 		const value = scope[key];
 		if (value) ordered[key] = value;

--- a/src/memory/scoring.ts
+++ b/src/memory/scoring.ts
@@ -215,6 +215,12 @@ function scopeSpecificityBoost(scope: MemoryScopeRef): number {
 			return 0.9;
 		case 'repository':
 			return 0.8;
+		// #1850: a cohort scope is broader than repository (shared across
+		// sibling worktrees) but more specific than a single project. Score it
+		// just below repository so cohort-shared memories rank comparably to
+		// repository memories in the absence of a repository-tier match.
+		case 'cohort':
+			return 0.75;
 		case 'project':
 			return 0.65;
 		case 'workspace':

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -49,10 +49,6 @@ import {
 	writeMigrationReport,
 } from './jsonl-migration';
 import { shouldCompactMemory } from './maintenance';
-import {
-	computeMemoryCohortFingerprint,
-	buildMemoryCohortFingerprintInput,
-} from './redaction';
 import type {
 	MemoryCompactOptions,
 	MemoryCompactResult,
@@ -64,6 +60,10 @@ import type {
 	MemoryRewardEventFilter,
 	MemoryTransaction,
 } from './provider';
+import {
+	buildMemoryCohortFingerprintInput,
+	computeMemoryCohortFingerprint,
+} from './redaction';
 import {
 	normalizeMemoryText,
 	stableScopeKey,
@@ -1975,14 +1975,30 @@ export class SQLiteMemoryProvider
 	private assertCohortConfigFingerprint(): void {
 		if (!this.cohortRoot) return;
 		const configPath = path.join(this.cohortRoot, 'memory-cohort-config.json');
-		if (!existsSync(configPath)) return; // first open — permissive
+		if (!existsSync(configPath)) {
+			// #1850 (M-010): absent config AFTER a cohort root is opened is
+			// suspicious — the linker writes it before flipping the pointer.
+			// Fail-open (do not strand memory) but surface a visible warning so
+			// the operator knows config-coherence is not enforced for this open.
+			warn(
+				'[memory-cohort] cohort config fingerprint file is absent; config-coherence check skipped. Run `/swarm memory link` to re-establish the fingerprint.',
+				{ cohortRoot: this.cohortRoot },
+			);
+			return;
+		}
 		try {
 			const stored = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<
 				string,
 				unknown
 			>;
 			const storedFingerprint = stored.fingerprint;
-			if (typeof storedFingerprint !== 'string') return; // malformed — permissive
+			if (typeof storedFingerprint !== 'string') {
+				warn(
+					'[memory-cohort] cohort config fingerprint file is malformed; config-coherence check skipped.',
+					{ cohortRoot: this.cohortRoot },
+				);
+				return;
+			}
 			// #1850 (final-critic dedup): use the shared fingerprint helper so the
 			// SQLite provider, status service, and linker all agree on the algorithm.
 			const expectedFingerprint = computeMemoryCohortFingerprint(
@@ -2002,7 +2018,14 @@ export class SQLiteMemoryProvider
 			) {
 				throw err; // re-throw the mismatch — this is the fail-closed path
 			}
-			// malformed config file — fail-open (do not strand memory)
+			// malformed config file — fail-open with a warning (do not strand memory)
+			warn(
+				'[memory-cohort] failed to read cohort config fingerprint; config-coherence check skipped.',
+				{
+					cohortRoot: this.cohortRoot,
+					reason: err instanceof Error ? err.message : String(err),
+				},
+			);
 		}
 	}
 

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -1,6 +1,12 @@
 import type { Database, SQLQueryBindings } from 'bun:sqlite';
 import { randomUUID } from 'node:crypto';
-import { mkdirSync } from 'node:fs';
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	statSync,
+	writeFileSync,
+} from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { loadDatabaseCtor } from '../db/sqlite-loader.js';
@@ -43,6 +49,10 @@ import {
 	writeMigrationReport,
 } from './jsonl-migration';
 import { shouldCompactMemory } from './maintenance';
+import {
+	computeMemoryCohortFingerprint,
+	buildMemoryCohortFingerprintInput,
+} from './redaction';
 import type {
 	MemoryCompactOptions,
 	MemoryCompactResult,
@@ -364,6 +374,14 @@ export class SQLiteMemoryProvider
 {
 	readonly name = 'sqlite';
 	private readonly rootDirectory: string;
+	/**
+	 * #1850: when set, the provider serves a cohort-shared store rather than
+	 * the worktree-local `.swarm/memory`. Cohort roots live under the platform
+	 * data dir (`<dataDir>/links/<linkId>/memory`) and bypass
+	 * `validateSwarmPath` by construction (the resolver sanitizes the linkId).
+	 * `null` for local-root providers (today's behavior, still validated).
+	 */
+	private readonly cohortRoot: string | null;
 	private readonly config: MemoryConfig;
 	private initialized = false;
 	private initPromise: Promise<void> | null = null;
@@ -379,8 +397,21 @@ export class SQLiteMemoryProvider
 	private recallCountSinceLastCompaction = 0;
 	private isCompacting = false;
 
-	constructor(rootDirectory: string, config: Partial<MemoryConfig> = {}) {
+	constructor(
+		rootDirectory: string,
+		config: Partial<MemoryConfig> = {},
+		/**
+		 * #1850: optional cohort root. When provided, the provider opens the DB
+		 * at `<cohortRoot>/memory.db` and bypasses `validateSwarmPath` (the
+		 * cohort root is resolver-constructed from a sanitized linkId, not a
+		 * user-supplied path). When omitted, the provider uses the worktree
+		 * `.swarm` path with full `validateSwarmPath` enforcement (today's
+		 * behavior).
+		 */
+		vettedCohortRoot?: string | null,
+	) {
 		this.rootDirectory = rootDirectory;
+		this.cohortRoot = vettedCohortRoot ?? null;
 		this.config = {
 			...DEFAULT_MEMORY_CONFIG,
 			...config,
@@ -411,7 +442,18 @@ export class SQLiteMemoryProvider
 		};
 	}
 
+	/**
+	 * #1850 (critic GAP-5): explicit cohort-root path branch.
+	 * - cohort root → `<cohortRoot>/memory.db` (NO validateSwarmPath — the
+	 *   cohort root is a platform-data-dir path constructed by the resolver
+	 *   from a sanitized linkId, never from user input).
+	 * - local root → existing behavior: strip `.swarm/` prefix, pass through
+	 *   `validateSwarmPath` to enforce `.swarm` containment.
+	 */
 	private databasePath(): string {
+		if (this.cohortRoot) {
+			return path.join(this.cohortRoot, 'memory.db');
+		}
 		const relativePath = this.config.sqlite.path.replace(/^\.swarm[/\\]?/, '');
 		return validateSwarmPath(this.rootDirectory, relativePath);
 	}
@@ -429,6 +471,13 @@ export class SQLiteMemoryProvider
 
 	private async doInitialize(): Promise<void> {
 		const dbPath = this.databasePath();
+		// #1850 (reviewer important fix): enforce the cohort config fingerprint
+		// BEFORE opening the DB, so a cohort member with a mismatched provider,
+		// embedding model, or redaction policy fails closed (acceptance #10).
+		// The fingerprint was written at link time by `handleMemoryLinkCommand`.
+		if (this.cohortRoot) {
+			this.assertCohortConfigFingerprint();
+		}
 		mkdirSync(path.dirname(dbPath), { recursive: true });
 		const Db = loadDatabaseCtor();
 		this.db = new Db(dbPath);
@@ -1223,6 +1272,60 @@ export class SQLiteMemoryProvider
 	}
 
 	/**
+	 * #1850 (critic CONCERN-3): checkpoint the WAL into the main DB, then
+	 * close the handle. Used by the memory family migration engine before it
+	 * copies the DB file, so the copy reflects all committed writes and is not
+	 * mid-checkpoint. After this call, the provider is closed and must be
+	 * re-opened (the migration engine re-creates it via the pool).
+	 *
+	 * Returns the absolute paths to copy: `memory.db` plus any non-empty
+	 * `-wal`/`-shm` sidecars (after a TRUNCATE checkpoint the WAL is typically
+	 * empty; if it is not, copying it alongside the DB is still correct because
+	 * SQLite recovers from WAL on next open).
+	 */
+	checkpointCloseSnapshot(): {
+		dbPath: string;
+		walPath: string | null;
+		shmPath: string | null;
+	} {
+		const dbPath = this.databasePath();
+		let walPath: string | null = null;
+		let shmPath: string | null = null;
+		try {
+			if (this.db) {
+				try {
+					this.db.run('PRAGMA wal_checkpoint(TRUNCATE);');
+				} catch {
+					/* non-fatal — close will still produce a consistent DB */
+				}
+				this.db.close();
+				this.db = null;
+				this.ftsAvailable = false;
+				this.initialized = false;
+				this.initPromise = null;
+			}
+			// Stat the sidecars; include only non-empty ones.
+			try {
+				const wal = `${dbPath}-wal`;
+				const st = statSync(wal);
+				if (st.size > 0) walPath = wal;
+			} catch {
+				/* no WAL sidecar */
+			}
+			try {
+				const shm = `${dbPath}-shm`;
+				const st = statSync(shm);
+				if (st.size > 0) shmPath = shm;
+			} catch {
+				/* no SHM sidecar */
+			}
+		} catch {
+			/* best-effort */
+		}
+		return { dbPath, walPath, shmPath };
+	}
+
+	/**
 	 * Re-embed all durable memory records with the current embedding provider
 	 * model, update the stored global model_version, and clear the embedding
 	 * cache. This is the recovery path for EmbeddingVersionMismatchError.
@@ -1838,6 +1941,69 @@ export class SQLiteMemoryProvider
 			],
 		);
 		this.writeMemoryFts(record);
+		// #1850 (critic CONCERN-1): bump the cohort generation marker so sibling
+		// worktrees observe this write on their next revalidation. Bumped at the
+		// provider layer so ALL write paths (propose, curator, finalize-reward,
+		// direct upsert) invalidate peers. Local writes are no-ops. Best-effort:
+		// a bump failure must never block the write.
+		this.bumpCohortGeneration();
+	}
+
+	/**
+	 * #1850: write a monotonic generation marker so siblings re-open their
+	 * in-memory mirror. Fire-and-forget; failures are non-fatal (peers simply
+	 * revalidate on the next pointer-stat change or TTL expiry).
+	 */
+	private bumpCohortGeneration(): void {
+		if (!this.cohortRoot) return;
+		try {
+			const markerPath = path.join(this.cohortRoot, 'memory.gen');
+			writeFileSync(markerPath, String(Date.now()), 'utf-8');
+		} catch {
+			/* best-effort — peer revalidation has TTL + pointer-stat backstops */
+		}
+	}
+
+	/**
+	 * #1850 (reviewer important fix): read `memory-cohort-config.json` and fail
+	 * closed if the stored provider/embedding/redaction fingerprint disagrees
+	 * with this worktree's config (acceptance #10). Absent file = first link
+	 * (permissive — the linker writes it immediately after migration). A
+	 * malformed file is also permissive (fail-open never strands memory, but
+	 * a mismatch is a hard error).
+	 */
+	private assertCohortConfigFingerprint(): void {
+		if (!this.cohortRoot) return;
+		const configPath = path.join(this.cohortRoot, 'memory-cohort-config.json');
+		if (!existsSync(configPath)) return; // first open — permissive
+		try {
+			const stored = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<
+				string,
+				unknown
+			>;
+			const storedFingerprint = stored.fingerprint;
+			if (typeof storedFingerprint !== 'string') return; // malformed — permissive
+			// #1850 (final-critic dedup): use the shared fingerprint helper so the
+			// SQLite provider, status service, and linker all agree on the algorithm.
+			const expectedFingerprint = computeMemoryCohortFingerprint(
+				buildMemoryCohortFingerprintInput(this.config),
+			);
+			if (storedFingerprint !== expectedFingerprint) {
+				throw new Error(
+					`memory cohort config fingerprint mismatch: cohort expects ${storedFingerprint}, this worktree computes ${expectedFingerprint}. ` +
+						'Provider/embedding/redaction config differs across cohort members. ' +
+						'Run `/swarm memory unlink` to recover local state, or align configs across linked worktrees.',
+				);
+			}
+		} catch (err) {
+			if (
+				err instanceof Error &&
+				err.message.includes('fingerprint mismatch')
+			) {
+				throw err; // re-throw the mismatch — this is the fail-closed path
+			}
+			// malformed config file — fail-open (do not strand memory)
+		}
 	}
 
 	private writeMemoryFts(record: MemoryRecord): void {

--- a/src/memory/storage-root.ts
+++ b/src/memory/storage-root.ts
@@ -27,13 +27,13 @@
  */
 
 import * as path from 'node:path';
+import { log, warn } from '../utils/logger.js';
 import type { MemoryConfig } from './config.js';
 import {
 	type MemoryLinkPointer,
 	readMemoryLinkPointer,
 	resolveMemoryStoreDir,
 } from './memory-link.js';
-import { log } from '../utils/logger.js';
 
 /**
  * The vetted root. `directory` is always the worktree's project root (so
@@ -86,6 +86,16 @@ export function resolveVettedMemoryRoot(
 ): VettedMemoryRoot {
 	const linkEnabled = config?.link?.enabled === true;
 	if (!linkEnabled) {
+		// #1850 (C-001-config fix): if a cohort pointer exists but link is
+		// disabled in config, warn the operator — cohort memory is unreachable
+		// and new writes land in the local store, diverging from the cohort.
+		const existingPointer = readMemoryLinkPointer(directory);
+		if (existingPointer) {
+			warn(
+				`[memory-link] memory.link.enabled is false but a cohort pointer exists (linkId=${existingPointer.linkId}). Cohort memory is unreachable — run \`/swarm memory link\` or remove the pointer with \`/swarm memory unlink\`.`,
+				{ directory, linkId: existingPointer.linkId },
+			);
+		}
 		return wrapLocalRoot(directory);
 	}
 	const pointer = readMemoryLinkPointer(directory);
@@ -145,7 +155,13 @@ export function isLocalRoot(
 
 /** Return the resolved storage path for a given root (no validation). */
 export function rootStoragePath(root: VettedMemoryRoot): string {
-	return root.kind === 'cohort' ? root.cohortRoot : root.root;
+	// #1850 (reviewer fix): local roots must resolve to `.swarm/memory` (where
+	// the SQLite provider stores memory.db and the JSONL provider stores its
+	// files), NOT bare `.swarm`. Cohort roots already include the `memory`
+	// segment by construction (storage-root.ts resolveVettedMemoryRoot).
+	return root.kind === 'cohort'
+		? root.cohortRoot
+		: path.join(root.root, 'memory');
 }
 
 export const _internals = {

--- a/src/memory/storage-root.ts
+++ b/src/memory/storage-root.ts
@@ -1,0 +1,157 @@
+/**
+ * #1850 Linked Knowledge 5/5: vetted memory storage-root capability.
+ *
+ * Problem: when cohort memory sharing is opted in, the memory provider must
+ * open a database at a cohort-scoped root (under the platform data dir), not
+ * the worktree's `.swarm/memory`. But accepting an arbitrary external path
+ * would violate `validateSwarmPath` and `.swarm` containment (AGENTS.md
+ * invariant #4, issue #1850 acceptance #3).
+ *
+ * Resolution: a narrow discriminated union `VettedMemoryRoot` that can only
+ * represent one of two validated shapes:
+ *   - `{kind:'local'}`  — the worktree's `.swarm/memory` root (today's path,
+ *     still gated by `validateSwarmPath` in the provider constructors).
+ *   - `{kind:'cohort'}` — a cohort root derived from the #1846 cohort
+ *     identity via the sanitized linkId. Constructed only by
+ *     `resolveVettedMemoryRoot` from the memory-link pointer; there is no
+ *     public `openMemoryAt(arbitraryPath)` entry.
+ *
+ * Cohort roots live under `<dataDir>/links/<linkId>/memory/` — the SAME shared
+ * store directory used by knowledge linking, namespaced under `memory/`. The
+ * `validateSwarmPath` invariant is preserved by construction: cohort roots are
+ * never passed through it (they are platform-data-dir paths, not `.swarm`
+ * paths), and local roots continue to flow through the existing validation.
+ *
+ * This module is sync-only and side-effect-free (a pointer read) so it is safe
+ * to call from the lazy gateway constructor on the plugin hot path.
+ */
+
+import * as path from 'node:path';
+import type { MemoryConfig } from './config.js';
+import {
+	type MemoryLinkPointer,
+	readMemoryLinkPointer,
+	resolveMemoryStoreDir,
+} from './memory-link.js';
+import { log } from '../utils/logger.js';
+
+/**
+ * The vetted root. `directory` is always the worktree's project root (so
+ * providers can still derive auxiliary per-worktree paths when needed); `root`
+ * is the resolved storage root (worktree `.swarm` for local, cohort dir for
+ * cohort).
+ */
+export type VettedMemoryRoot =
+	| {
+			kind: 'local';
+			/** Resolved worktree `.swarm` directory (parent of `storageDir`). */
+			root: string;
+			/** Original worktree project root (ctx.directory). */
+			directory: string;
+	  }
+	| {
+			kind: 'cohort';
+			/** Cohort memory root: `<dataDir>/links/<linkId>/memory`. */
+			cohortRoot: string;
+			/** Canonical cohort id from #1846 (shared by all sibling worktrees). */
+			cohortId: string;
+			/** Monotonic link generation (bumped on link/unlink; aids revalidation). */
+			generation: number;
+			/** Sanitized linkId (the cohort directory segment). */
+			linkId: string;
+			/** Original worktree project root (ctx.directory). */
+			directory: string;
+	  };
+
+/**
+ * Resolve the vetted memory root for a worktree. Sync, side-effect-free.
+ *
+ * Decision tree:
+ *  1. If `config.link?.enabled !== true` → local (today's behavior).
+ *  2. Read the memory-link pointer. If absent or malformed → local.
+ *  3. If the pointer resolves to a cohort store → cohort root under
+ *     `<resolveMemoryStoreDir(directory)>/memory`. `resolveMemoryStoreDir`
+ *     already canonicalizes via `path.resolve` and revalidates the pointer
+ *     stat on cache hits (mirrors `resolveKnowledgeStoreDir` in
+ *     `src/hooks/knowledge-link.ts:396`).
+ *
+ * The cohort memory root is `<resolveMemoryStoreDir(directory)>/memory` — a
+ * `memory/` subdirectory of the shared link dir, sibling to the knowledge
+ * family files. This keeps knowledge and memory in the same cohort container
+ * without colliding filenames.
+ */
+export function resolveVettedMemoryRoot(
+	directory: string,
+	config: Pick<MemoryConfig, 'link'> | Partial<Pick<MemoryConfig, 'link'>>,
+): VettedMemoryRoot {
+	const linkEnabled = config?.link?.enabled === true;
+	if (!linkEnabled) {
+		return wrapLocalRoot(directory);
+	}
+	const pointer = readMemoryLinkPointer(directory);
+	if (!pointer) {
+		// Opt-in is enabled in config but no link has been established yet.
+		// Memory stays local until `/swarm memory link` writes the pointer.
+		return wrapLocalRoot(directory);
+	}
+	const sharedDir = resolveMemoryStoreDir(directory);
+	// When the pointer is present but `resolveMemoryStoreDir` returns the
+	// local `.swarm` (e.g. the link dir is unavailable), fall back to local —
+	// fail-open never strands memory.
+	const localSwarm = path.join(directory, '.swarm');
+	if (sharedDir === localSwarm) {
+		return wrapLocalRoot(directory);
+	}
+	return {
+		kind: 'cohort',
+		cohortRoot: path.join(sharedDir, 'memory'),
+		cohortId: pointer.cohortId ?? pointer.linkId,
+		generation: pointer.generation ?? 0,
+		linkId: pointer.linkId,
+		directory,
+	};
+}
+
+/**
+ * Backward-compat shim: wraps a raw directory into a local vetted root. Emits
+ * a debug log so incomplete wiring (a caller that should have resolved a vetted
+ * root itself) is visible during development (critic CONCERN-5).
+ */
+export function wrapLocalRoot(directory: string): VettedMemoryRoot {
+	log(
+		'[memory] wrapping raw directory as local vetted root — cohort sharing inactive for this caller',
+		{ directory },
+	);
+	return {
+		kind: 'local',
+		root: path.join(directory, '.swarm'),
+		directory,
+	};
+}
+
+/** Type guard for the cohort branch. */
+export function isCohortRoot(
+	root: VettedMemoryRoot,
+): root is Extract<VettedMemoryRoot, { kind: 'cohort' }> {
+	return root.kind === 'cohort';
+}
+
+/** Type guard for the local branch. */
+export function isLocalRoot(
+	root: VettedMemoryRoot,
+): root is Extract<VettedMemoryRoot, { kind: 'local' }> {
+	return root.kind === 'local';
+}
+
+/** Return the resolved storage path for a given root (no validation). */
+export function rootStoragePath(root: VettedMemoryRoot): string {
+	return root.kind === 'cohort' ? root.cohortRoot : root.root;
+}
+
+export const _internals = {
+	resolveVettedMemoryRoot,
+	wrapLocalRoot,
+};
+
+// Re-export the pointer type so consumers don't need a second import site.
+export type { MemoryLinkPointer };

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -4,7 +4,13 @@ export type MemoryScopeType =
 	| 'project'
 	| 'repository'
 	| 'run'
-	| 'agent';
+	| 'agent'
+	// Linked Knowledge 5/5 (#1850): cohort-scoped memory shared across linked
+	// sibling worktrees through the #1846 cohort identity. A cohort scope is
+	// visible to every worktree that resolves the same canonical cohort id, so
+	// it is the scope used for shared repository memory. Per-session/per-run
+	// state continues to use the `run`/`agent` scopes (which stay worktree-local).
+	| 'cohort';
 
 export interface MemoryScopeRef {
 	type: MemoryScopeType;
@@ -15,6 +21,10 @@ export interface MemoryScopeRef {
 	repoRoot?: string;
 	runId?: string;
 	agentId?: string;
+	/** Canonical cohort id from `resolveCohortId` (#1850). Set when
+	 * `type === 'cohort'`. Required for cohort-scoped records so the scope key
+	 * and recall filters distinguish different cohorts. */
+	cohortId?: string;
 }
 
 export type MemoryKind =
@@ -66,6 +76,26 @@ export interface MemoryRecord {
 	supersededBy?: string;
 	contentHash: string;
 	metadata: Record<string, unknown>;
+	// Linked Knowledge 5/5 (#1850): cohort-sharing provenance. All optional so
+	// pre-#1850 records continue to load without migration. Populated by the
+	// gateway on cohort-linked writes; validated by `validateMemoryRecordRules`
+	// for cohort-scoped records. Provenance preserves privacy/redaction policy
+	// across cohort members (acceptance #13).
+	/** Canonical cohort id the record belongs to. Matches `scope.cohortId`
+	 * when `scope.type === 'cohort'`. */
+	cohortId?: string;
+	/** Session id of the producer (when policy permits retention). */
+	producerSessionId?: string;
+	/** Agent role of the producer. */
+	producerAgentRole?: string;
+	/** Redaction policy version at write time (from REDACTION_POLICY_VERSION). */
+	redactionPolicyVersion?: number;
+	/** Memory schema version at write time. */
+	schemaVersion?: number;
+	/** Provider name at write time (`'sqlite'` | `'local-jsonl'`). */
+	providerVersion?: string;
+	/** Source git revision of the producer, when available. */
+	sourceRevision?: string;
 }
 
 export interface MemoryProposal {

--- a/src/services/knowledge-diagnostics.ts
+++ b/src/services/knowledge-diagnostics.ts
@@ -22,6 +22,7 @@ import {
 	resolveKnowledgeStoreDir,
 	resolveLinkDir,
 } from '../hooks/knowledge-link.js';
+import { readMemoryLinkPointer } from '../memory/memory-link.js';
 import {
 	readKnowledge,
 	readRejectedLessons,
@@ -171,6 +172,25 @@ export interface KnowledgeDebugMeta {
 		 * that blocked destructive intent is queued.
 		 */
 		pending_proposals: number;
+	};
+	/**
+	 * #1850: memory cohort link health. Distinct from the knowledge `cohort`
+	 * block so diagnostics can report knowledge-link and memory-link
+	 * independently. Carries provider/config fingerprint agreement so an
+	 * operator can detect cohort divergence. No record text is emitted here
+	 * (diagnostics-no-leakage discipline, acceptance #13).
+	 */
+	memory: {
+		linked: boolean;
+		pointer_version: 1 | 2 | null;
+		link_id: string | null;
+		cohort_id: string | null;
+		identity_source: 'remote' | 'git-common-dir' | 'path' | null;
+		degraded: boolean;
+		shared_root: string | null;
+		generation: number | null;
+		/** Provider name from config ('sqlite' | 'local-jsonl'). */
+		provider: string | null;
 	};
 }
 
@@ -418,7 +438,76 @@ export async function computeKnowledgeDebug(
 		// carry it (by design), so merging them in would miscount every hive
 		// entry as "unknown owner". Pass SWARM raw entries only.
 		curation: await computeCurationDiagnostics(directory, swarmRaw.entries),
+		// #1850: memory cohort link health (distinct from knowledge link).
+		memory: computeMemoryCohortDiagnostics(directory),
 	};
+}
+
+/**
+ * #1850: best-effort memory cohort diagnostics. Reads the memory-link pointer
+ * and config to surface link state + provider. Fail-open to the unlinked shape.
+ * Does NOT read memory record contents (no-leakage discipline, acceptance #13).
+ */
+function computeMemoryCohortDiagnostics(directory: string): {
+	linked: boolean;
+	pointer_version: 1 | 2 | null;
+	link_id: string | null;
+	cohort_id: string | null;
+	identity_source: 'remote' | 'git-common-dir' | 'path' | null;
+	degraded: boolean;
+	shared_root: string | null;
+	generation: number | null;
+	provider: string | null;
+} {
+	try {
+		const pointer = readMemoryLinkPointer(directory);
+		let provider: string | null = null;
+		try {
+			const { loadPluginConfig } = require('../config/loader.js') as {
+				loadPluginConfig: (dir: string) => { memory?: { provider?: string } };
+			};
+			const cfg = loadPluginConfig(directory);
+			provider = cfg.memory?.provider ?? null;
+		} catch {
+			/* best-effort */
+		}
+		if (pointer) {
+			return {
+				linked: true,
+				pointer_version: pointer.version,
+				link_id: pointer.linkId,
+				cohort_id: pointer.cohortId ?? null,
+				identity_source: pointer.identitySource ?? null,
+				degraded: pointer.degraded ?? false,
+				shared_root: pointer.linkId ? resolveLinkDir(pointer.linkId) : null,
+				generation: pointer.generation ?? null,
+				provider,
+			};
+		}
+		return {
+			linked: false,
+			pointer_version: null,
+			link_id: null,
+			cohort_id: null,
+			identity_source: null,
+			degraded: false,
+			shared_root: null,
+			generation: null,
+			provider,
+		};
+	} catch {
+		return {
+			linked: false,
+			pointer_version: null,
+			link_id: null,
+			cohort_id: null,
+			identity_source: null,
+			degraded: false,
+			shared_root: null,
+			generation: null,
+			provider: null,
+		};
+	}
 }
 
 /**

--- a/src/services/knowledge-diagnostics.ts
+++ b/src/services/knowledge-diagnostics.ts
@@ -8,7 +8,7 @@
  * status breakdown, event volume, and cache freshness so those issues surface.
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import packageJson from '../../package.json' with { type: 'json' };
@@ -22,7 +22,6 @@ import {
 	resolveKnowledgeStoreDir,
 	resolveLinkDir,
 } from '../hooks/knowledge-link.js';
-import { readMemoryLinkPointer } from '../memory/memory-link.js';
 import {
 	readKnowledge,
 	readRejectedLessons,
@@ -35,6 +34,11 @@ import type {
 } from '../hooks/knowledge-types.js';
 import { resolveUnactionablePath } from '../hooks/knowledge-validator.js';
 import { resolveInsightCandidatesPath } from '../hooks/micro-reflector.js';
+import { readMemoryLinkPointer } from '../memory/memory-link.js';
+import {
+	buildMemoryCohortFingerprintInput,
+	computeMemoryCohortFingerprint,
+} from '../memory/redaction.js';
 import { readSynonymMap } from './synonym-map.js';
 import { compareVersions, readVersionCache } from './version-check.js';
 
@@ -191,6 +195,12 @@ export interface KnowledgeDebugMeta {
 		generation: number | null;
 		/** Provider name from config ('sqlite' | 'local-jsonl'). */
 		provider: string | null;
+		/**
+		 * #1850 (KC-002): config fingerprint agreement — true when this
+		 * worktree's config matches the cohort's stored fingerprint, false on
+		 * mismatch, null when not checked (unlinked or file absent).
+		 */
+		config_fingerprint_match: boolean | null;
 	};
 }
 
@@ -458,16 +468,57 @@ function computeMemoryCohortDiagnostics(directory: string): {
 	shared_root: string | null;
 	generation: number | null;
 	provider: string | null;
+	config_fingerprint_match: boolean | null;
 } {
 	try {
 		const pointer = readMemoryLinkPointer(directory);
 		let provider: string | null = null;
+		let configFingerprintMatch: boolean | null = null;
 		try {
 			const { loadPluginConfig } = require('../config/loader.js') as {
-				loadPluginConfig: (dir: string) => { memory?: { provider?: string } };
+				loadPluginConfig: (dir: string) => {
+					memory?: {
+						provider?: string;
+						redaction?: { rejectDurableSecrets?: boolean };
+						embeddings?: {
+							model?: string;
+							dimension?: number;
+							version?: string;
+						};
+					};
+				};
 			};
 			const cfg = loadPluginConfig(directory);
 			provider = cfg.memory?.provider ?? null;
+			// #1850 (KC-002): compute config fingerprint match when linked.
+			if (pointer && cfg.memory) {
+				const cohortConfigPath = join(
+					resolveLinkDir(pointer.linkId),
+					'memory',
+					'memory-cohort-config.json',
+				);
+				if (existsSync(cohortConfigPath)) {
+					const stored = JSON.parse(
+						readFileSync(cohortConfigPath, 'utf-8'),
+					) as { fingerprint?: string };
+					const expected = computeMemoryCohortFingerprint(
+						buildMemoryCohortFingerprintInput({
+							provider: cfg.memory.provider ?? 'sqlite',
+							redaction: {
+								rejectDurableSecrets:
+									cfg.memory.redaction?.rejectDurableSecrets ?? true,
+							},
+							embeddings: {
+								model:
+									cfg.memory.embeddings?.model ?? 'Xenova/all-MiniLM-L6-v2',
+								dimension: cfg.memory.embeddings?.dimension ?? 384,
+								version: cfg.memory.embeddings?.version,
+							},
+						}),
+					);
+					configFingerprintMatch = stored.fingerprint === expected;
+				}
+			}
 		} catch {
 			/* best-effort */
 		}
@@ -482,6 +533,7 @@ function computeMemoryCohortDiagnostics(directory: string): {
 				shared_root: pointer.linkId ? resolveLinkDir(pointer.linkId) : null,
 				generation: pointer.generation ?? null,
 				provider,
+				config_fingerprint_match: configFingerprintMatch,
 			};
 		}
 		return {
@@ -494,6 +546,7 @@ function computeMemoryCohortDiagnostics(directory: string): {
 			shared_root: null,
 			generation: null,
 			provider,
+			config_fingerprint_match: null,
 		};
 	} catch {
 		return {
@@ -506,6 +559,7 @@ function computeMemoryCohortDiagnostics(directory: string): {
 			shared_root: null,
 			generation: null,
 			provider: null,
+			config_fingerprint_match: null,
 		};
 	}
 }

--- a/src/services/memory-consolidation.ts
+++ b/src/services/memory-consolidation.ts
@@ -25,6 +25,7 @@ import {
 } from '../memory/consolidation-log.js';
 import { createMemoryGateway } from '../memory/gateway.js';
 import { appendMemoryRunLog } from '../memory/run-log.js';
+import { resolveVettedMemoryRoot } from '../memory/storage-root.js';
 
 export interface MemoryConsolidationRequest {
 	directory: string;
@@ -98,8 +99,17 @@ export async function runMemoryConsolidation(
 					now: () => new Date(),
 					logEvent: (event) =>
 						appendMemoryRunLog(req.directory, req.sessionId, event),
-					readLog: () => readConsolidationLog(req.directory),
-					appendLog: (record) => appendConsolidationLog(req.directory, record),
+					// #1850 GAP-3: route the consolidation log through the vetted
+					// root so it lands in the cohort store when linked.
+					readLog: () =>
+						readConsolidationLog(
+							resolveVettedMemoryRoot(req.directory, req.config),
+						),
+					appendLog: (record) =>
+						appendConsolidationLog(
+							resolveVettedMemoryRoot(req.directory, req.config),
+							record,
+						),
 					signal: controller.signal,
 				},
 			);

--- a/src/services/status-service.ts
+++ b/src/services/status-service.ts
@@ -2,6 +2,8 @@ import * as fsSync from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import type { AgentDefinition } from '../agents';
+import { loadPluginConfig } from '../config/loader';
+import { MemoryConfigSchema } from '../config/schema';
 import {
 	type FullAutoRunState,
 	loadFullAutoRunState,
@@ -15,15 +17,13 @@ import {
 	readRecentEscalations,
 } from '../hooks/knowledge-escalator';
 import { readLinkPointer, resolveLinkDir } from '../hooks/knowledge-link';
-import { readMemoryLinkPointer } from '../memory/memory-link';
-import { MemoryConfigSchema } from '../config/schema';
-import { loadPluginConfig } from '../config/loader';
-import {
-	computeMemoryCohortFingerprint,
-	buildMemoryCohortFingerprintInput,
-} from '../memory/redaction';
 import { resolveUnactionablePath } from '../hooks/knowledge-validator';
 import { readSwarmFileAsync, validateSwarmPath } from '../hooks/utils';
+import { readMemoryLinkPointer } from '../memory/memory-link';
+import {
+	buildMemoryCohortFingerprintInput,
+	computeMemoryCohortFingerprint,
+} from '../memory/redaction';
 import { loadPlan } from '../plan/manager';
 import {
 	getActiveFullAutoSessionID,

--- a/src/services/status-service.ts
+++ b/src/services/status-service.ts
@@ -15,6 +15,13 @@ import {
 	readRecentEscalations,
 } from '../hooks/knowledge-escalator';
 import { readLinkPointer, resolveLinkDir } from '../hooks/knowledge-link';
+import { readMemoryLinkPointer } from '../memory/memory-link';
+import { MemoryConfigSchema } from '../config/schema';
+import { loadPluginConfig } from '../config/loader';
+import {
+	computeMemoryCohortFingerprint,
+	buildMemoryCohortFingerprintInput,
+} from '../memory/redaction';
 import { resolveUnactionablePath } from '../hooks/knowledge-validator';
 import { readSwarmFileAsync, validateSwarmPath } from '../hooks/utils';
 import { loadPlan } from '../plan/manager';
@@ -117,6 +124,22 @@ export interface StatusData {
 		degraded?: boolean;
 		sharedRoot?: string;
 		generation?: number;
+	};
+	/**
+	 * #1850: memory cohort link status. Distinct from `cohort` (knowledge link)
+	 * so status can distinguish knowledge-linked from memory-linked (acceptance
+	 * #2). Carries provider/config/privacy health fields.
+	 */
+	memoryCohort?: {
+		linked: boolean;
+		linkId?: string;
+		cohortId?: string;
+		identitySource?: 'remote' | 'git-common-dir' | 'path';
+		degraded?: boolean;
+		sharedRoot?: string;
+		generation?: number;
+		provider?: string;
+		configFingerprintMatch?: boolean;
 	};
 }
 
@@ -286,6 +309,60 @@ export async function getStatusData(
 		}
 	} catch {
 		status.cohort = { linked: false };
+	}
+
+	// #1850: surface the memory link status SEPARATELY from the knowledge link
+	// (acceptance #2). Best-effort: a missing or corrupt memory pointer reports
+	// the unlinked shape. Provider/config/privacy health is populated when
+	// available so operators can detect cohort divergence.
+	try {
+		const memoryPointer = readMemoryLinkPointer(directory);
+		// #1850 (reviewer nit): populate provider + configFingerprintMatch so
+		// status surfaces cohort divergence (acceptance #2). Best-effort.
+		let provider: string | undefined;
+		let configFingerprintMatch: boolean | undefined;
+		try {
+			const memoryConfig = MemoryConfigSchema.parse(
+				(loadPluginConfig(directory) as { memory?: unknown }).memory ?? {},
+			);
+			provider = memoryConfig.provider;
+			if (memoryPointer) {
+				const cohortConfigPath = path.join(
+					resolveLinkDir(memoryPointer.linkId),
+					'memory',
+					'memory-cohort-config.json',
+				);
+				if (fsSync.existsSync(cohortConfigPath)) {
+					const stored = JSON.parse(
+						fsSync.readFileSync(cohortConfigPath, 'utf-8'),
+					) as { fingerprint?: string };
+					// #1850 (final-critic dedup): shared fingerprint helper.
+					const expected = computeMemoryCohortFingerprint(
+						buildMemoryCohortFingerprintInput(memoryConfig),
+					);
+					configFingerprintMatch = stored.fingerprint === expected;
+				}
+			}
+		} catch {
+			/* best-effort config read */
+		}
+		if (memoryPointer) {
+			status.memoryCohort = {
+				linked: true,
+				linkId: memoryPointer.linkId,
+				cohortId: memoryPointer.cohortId,
+				identitySource: memoryPointer.identitySource,
+				degraded: memoryPointer.degraded,
+				sharedRoot: resolveLinkDir(memoryPointer.linkId),
+				generation: memoryPointer.generation,
+				provider,
+				configFingerprintMatch,
+			};
+		} else {
+			status.memoryCohort = { linked: false, provider };
+		}
+	} catch {
+		status.memoryCohort = { linked: false };
 	}
 
 	// Check Full-Auto status (issue #1781 E2: this was previously nested
@@ -530,6 +607,44 @@ export function formatStatusMarkdown(status: StatusData): string {
 		lines.push(
 			'',
 			'**Knowledge Cohort**: local (not linked — run `/swarm link` to share across worktrees)',
+		);
+	}
+
+	// #1850: memory cohort status — rendered separately so users can tell
+	// knowledge-link and memory-link apart (acceptance #2). No record text is
+	// emitted here (diagnostics-no-leakage discipline, acceptance #13).
+	if (status.memoryCohort?.linked) {
+		lines.push('', '**Memory Cohort**:');
+		lines.push(
+			`  - 🔗 Memory shared across linked worktrees "${status.memoryCohort.linkId}"`,
+		);
+		if (status.memoryCohort.cohortId)
+			lines.push(`    cohort: ${status.memoryCohort.cohortId}`);
+		if (status.memoryCohort.identitySource)
+			lines.push(`    identity: ${status.memoryCohort.identitySource}`);
+		if (status.memoryCohort.degraded)
+			lines.push(
+				'    ⚠ degraded (machine-local, not portable across machines)',
+			);
+		if (status.memoryCohort.sharedRoot)
+			lines.push(`    shared at: ${status.memoryCohort.sharedRoot}/memory`);
+		if (status.memoryCohort.generation !== undefined)
+			lines.push(`    generation: ${status.memoryCohort.generation}`);
+		// #1850 (final-critic #2 fix): render provider + config fingerprint
+		// health so operators can detect cohort divergence (acceptance #2).
+		if (status.memoryCohort.provider)
+			lines.push(`    provider: ${status.memoryCohort.provider}`);
+		if (status.memoryCohort.configFingerprintMatch === false) {
+			lines.push(
+				'    ⚠ config fingerprint mismatch — provider/embedding/redaction config differs across cohort members',
+			);
+		} else if (status.memoryCohort.configFingerprintMatch === true) {
+			lines.push('    config: ✅ fingerprint matches cohort');
+		}
+	} else {
+		lines.push(
+			'',
+			'**Memory Cohort**: local (not linked — run `/swarm memory link` to share memory across worktrees; requires `memory.link.enabled: true`)',
 		);
 	}
 

--- a/tests/smoke/packaging.test.ts
+++ b/tests/smoke/packaging.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 const ROOT = path.resolve(import.meta.dir, '../../');
-const MAIN_BUNDLE_MAX_BYTES = 4.9 * 1024 * 1024;
+const MAIN_BUNDLE_MAX_BYTES = 5.0 * 1024 * 1024;
 
 describe('packaging smoke tests', () => {
 	test('dist/index.js exists', () => {
@@ -38,15 +38,17 @@ describe('packaging smoke tests', () => {
 		expect(typeof plugin.config).toBe('function');
 	});
 
-	test('dist/index.js file size is reasonable (< 4.9MB)', () => {
+	test('dist/index.js file size is reasonable (< 5.0MB)', () => {
 		const stats = Bun.file(path.join(ROOT, 'dist/index.js'));
 		// The main bundle is built with identifier-preserving minification
 		// (`--minify-whitespace --minify-syntax`, no `--minify-identifiers`).
 		// Main had grown to 4,824,030 bytes before #1820. After integrating current
-		// main plus the evaluation substrate, the measured bundle is 4,960,550
-		// bytes. The 4.9 MiB cap preserves about 177 KB of cross-platform headroom,
-		// while a further 10% increase still exceeds the limit. The exact merged
-		// size is rechecked by this smoke test after every build.
+		// main plus the evaluation substrate, the measured bundle was 4,960,550
+		// bytes. The #1850 cohort memory sharing feature (vetted root, cohort-aware
+		// provider pool, migration engine, memory-link command, status/diagnostics)
+		// pushed it to 5,150,646 bytes — bumping the cap to 5.0 MiB preserves ~97 KB
+		// of cross-platform headroom. The exact merged size is rechecked by this
+		// smoke test after every build.
 		expect(stats.size).toBeLessThan(MAIN_BUNDLE_MAX_BYTES);
 		// But should be at least 10KB (non-empty)
 		expect(stats.size).toBeGreaterThan(10 * 1024);

--- a/tests/unit/commands/memory-link.test.ts
+++ b/tests/unit/commands/memory-link.test.ts
@@ -2,17 +2,29 @@
  * #1850: command-level tests for `/swarm memory link` / `/swarm memory unlink`.
  * Covers the unlink-migration guard regression caught by the implementation
  * reviewer, plus status output and opt-in gating.
+ *
+ * C-TI-001 fix: env vars (XDG_DATA_HOME, HOME) saved in beforeEach and restored
+ * in afterEach so tests don't leak platform-dir redirection to siblings.
+ * F-22 fix: seed a real memory.db with a record and verify it survives the
+ * link→unlink round-trip (previously the test was vacuous — never wrote data).
  */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
 	handleMemoryLinkCommand,
 	handleMemoryUnlinkCommand,
 } from '../../../src/commands/memory-link';
-import { loadPluginConfig } from '../../../src/config/loader';
+import { DEFAULT_MEMORY_CONFIG } from '../../../src/memory/config';
 import { readMemoryLinkPointer } from '../../../src/memory/memory-link';
+import { clearPool } from '../../../src/memory/provider-pool';
+import {
+	computeMemoryContentHash,
+	createMemoryId,
+} from '../../../src/memory/schema';
+import { SQLiteMemoryProvider } from '../../../src/memory/sqlite-provider';
 
 function makeTmp(prefix: string): string {
 	return realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
@@ -21,8 +33,12 @@ function makeTmp(prefix: string): string {
 describe('#1850 /swarm memory link + unlink commands', () => {
 	const dirs: string[] = [];
 	let dir: string;
+	let prevXdg: string | undefined;
+	let prevHome: string | undefined;
 
 	beforeEach(() => {
+		prevXdg = process.env.XDG_DATA_HOME;
+		prevHome = process.env.HOME;
 		const dataDir = makeTmp('memlink-cmd-data-');
 		dirs.push(dataDir);
 		process.env.XDG_DATA_HOME = dataDir;
@@ -32,6 +48,9 @@ describe('#1850 /swarm memory link + unlink commands', () => {
 	});
 
 	afterEach(() => {
+		process.env.XDG_DATA_HOME = prevXdg;
+		process.env.HOME = prevHome;
+		clearPool();
 		for (const d of dirs.splice(0)) {
 			try {
 				rmSync(d, { recursive: true, force: true });
@@ -51,11 +70,10 @@ describe('#1850 /swarm memory link + unlink commands', () => {
 		expect(result).toContain('NOT linked');
 	});
 
-	test('F-22: link + unlink round-trip does not throw (reviewer critical regression)', async () => {
-		// This is the exact scenario the reviewer flagged: unlink was broken
-		// by the cohort-only destination guard in migrateMemoryFamily.
-		// Enable link in config by writing to .opencode/opencode-swarm.json
-		// (the canonical project config path the loader reads from).
+	test('F-22: link + unlink round-trip preserves seeded data', async () => {
+		// Reviewer-flagged regression: unlink was broken by the cohort-only
+		// destination guard. This test seeds a real record, links, unlinks,
+		// and verifies the record survived the round-trip.
 		const fs = await import('node:fs/promises');
 		await fs.mkdir(path.join(dir, '.opencode'), { recursive: true });
 		await fs.writeFile(
@@ -63,21 +81,88 @@ describe('#1850 /swarm memory link + unlink commands', () => {
 			JSON.stringify({ memory: { enabled: true, link: { enabled: true } } }),
 			'utf-8',
 		);
-		// Seed a local memory.db so migration has something to copy.
-		const memDir = path.join(dir, '.swarm', 'memory');
-		await fs.mkdir(memDir, { recursive: true });
-		// Link — should succeed and write the pointer.
+		// Seed a local memory.db with a real record via the SQLite provider.
+		const config = { ...DEFAULT_MEMORY_CONFIG, enabled: true };
+		const seedProvider = new SQLiteMemoryProvider(dir, config);
+		await seedProvider.initialize();
+		const recordBase = {
+			scope: {
+				type: 'repository' as const,
+				repoId: 'f22-test-repo',
+				repoRoot: dir,
+			},
+			kind: 'project_fact' as const,
+			text: 'F-22 seed record for link/unlink round-trip',
+		};
+		const record = {
+			...recordBase,
+			id: createMemoryId(recordBase),
+			tags: ['test'],
+			confidence: 0.8,
+			stability: 'durable' as const,
+			source: { type: 'manual' as const, ref: 'f22-test' },
+			createdAt: '2026-07-18T00:00:00.000Z',
+			updatedAt: '2026-07-18T00:00:00.000Z',
+			contentHash: computeMemoryContentHash(recordBase),
+			metadata: {},
+		};
+		const seededId = record.id;
+		await seedProvider.upsert(record);
+		seedProvider.close();
+		clearPool();
+
+		// Link — should migrate the local memory.db into the cohort store.
 		const linkResult = await handleMemoryLinkCommand(dir, ['test-cohort']);
 		expect(linkResult).toContain('Linked');
 		expect(readMemoryLinkPointer(dir)?.linkId).toBe('test-cohort');
-		// Unlink — the critical regression test. Must NOT throw.
+		clearPool();
+
+		// Delete the LOCAL memory.db so the verify step can ONLY succeed if the
+		// unlink copy-back actually restored the data from the cohort store.
+		// Without this, the test is vacuous — the source DB is never deleted by
+		// migration, so the record would survive even if migration was a no-op.
+		const localDbPath = path.join(dir, '.swarm', 'memory', 'memory.db');
+		const fs2 = await import('node:fs/promises');
+		await fs2.unlink(localDbPath);
+		// Also remove WAL/SHM sidecars if present.
+		for (const suffix of ['-wal', '-shm']) {
+			await fs2.unlink(`${localDbPath}${suffix}`).catch(() => {});
+		}
+
+		// Unlink — must copy the cohort family back to local.
 		const unlinkResult = await handleMemoryUnlinkCommand(dir, []);
 		expect(unlinkResult).toContain('Unlinked');
 		expect(readMemoryLinkPointer(dir)).toBeNull();
+		clearPool();
+
+		// Verify the seeded record survived the round-trip. This can only pass
+		// if link migrated local→cohort AND unlink copied cohort→local.
+		const verifyProvider = new SQLiteMemoryProvider(dir, config);
+		await verifyProvider.initialize();
+		const recalled = await verifyProvider.get(seededId);
+		verifyProvider.close();
+		clearPool();
+		expect(recalled).not.toBeNull();
+		expect(recalled?.text).toBe('F-22 seed record for link/unlink round-trip');
 	});
 
 	test('F-23: unlink when not linked is a no-op with a message', async () => {
 		const result = await handleMemoryUnlinkCommand(dir, []);
 		expect(result).toContain('not linked');
+	});
+
+	test('F-26b: unlink with --no-copy does not claim restoration', async () => {
+		const fs = await import('node:fs/promises');
+		await fs.mkdir(path.join(dir, '.opencode'), { recursive: true });
+		await fs.writeFile(
+			path.join(dir, '.opencode', 'opencode-swarm.json'),
+			JSON.stringify({ memory: { enabled: true, link: { enabled: true } } }),
+			'utf-8',
+		);
+		await handleMemoryLinkCommand(dir, ['nocopy-cohort']);
+		clearPool();
+		const result = await handleMemoryUnlinkCommand(dir, ['--no-copy']);
+		expect(result).toContain('Unlinked');
+		expect(result).toContain('No local copy was made');
 	});
 });

--- a/tests/unit/commands/memory-link.test.ts
+++ b/tests/unit/commands/memory-link.test.ts
@@ -1,0 +1,83 @@
+/**
+ * #1850: command-level tests for `/swarm memory link` / `/swarm memory unlink`.
+ * Covers the unlink-migration guard regression caught by the implementation
+ * reviewer, plus status output and opt-in gating.
+ */
+import { existsSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	handleMemoryLinkCommand,
+	handleMemoryUnlinkCommand,
+} from '../../../src/commands/memory-link';
+import { loadPluginConfig } from '../../../src/config/loader';
+import { readMemoryLinkPointer } from '../../../src/memory/memory-link';
+
+function makeTmp(prefix: string): string {
+	return realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+}
+
+describe('#1850 /swarm memory link + unlink commands', () => {
+	const dirs: string[] = [];
+	let dir: string;
+
+	beforeEach(() => {
+		const dataDir = makeTmp('memlink-cmd-data-');
+		dirs.push(dataDir);
+		process.env.XDG_DATA_HOME = dataDir;
+		process.env.HOME = dataDir;
+		dir = makeTmp('memlink-cmd-');
+		dirs.push(dir);
+	});
+
+	afterEach(() => {
+		for (const d of dirs.splice(0)) {
+			try {
+				rmSync(d, { recursive: true, force: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+
+	test('link without memory.link.enabled returns an error message', async () => {
+		const result = await handleMemoryLinkCommand(dir, []);
+		expect(result).toContain('not enabled');
+	});
+
+	test('link status when not linked shows local state', async () => {
+		const result = await handleMemoryLinkCommand(dir, ['status']);
+		expect(result).toContain('NOT linked');
+	});
+
+	test('F-22: link + unlink round-trip does not throw (reviewer critical regression)', async () => {
+		// This is the exact scenario the reviewer flagged: unlink was broken
+		// by the cohort-only destination guard in migrateMemoryFamily.
+		// Enable link in config by writing to .opencode/opencode-swarm.json
+		// (the canonical project config path the loader reads from).
+		const fs = await import('node:fs/promises');
+		await fs.mkdir(path.join(dir, '.opencode'), { recursive: true });
+		await fs.writeFile(
+			path.join(dir, '.opencode', 'opencode-swarm.json'),
+			JSON.stringify({ memory: { enabled: true, link: { enabled: true } } }),
+			'utf-8',
+		);
+		// Seed a local memory.db so migration has something to copy.
+		const memDir = path.join(dir, '.swarm', 'memory');
+		await fs.mkdir(memDir, { recursive: true });
+		// Link — should succeed and write the pointer.
+		const linkResult = await handleMemoryLinkCommand(dir, ['test-cohort']);
+		expect(linkResult).toContain('Linked');
+		expect(readMemoryLinkPointer(dir)?.linkId).toBe('test-cohort');
+		// Unlink — the critical regression test. Must NOT throw.
+		const unlinkResult = await handleMemoryUnlinkCommand(dir, []);
+		expect(unlinkResult).toContain('Unlinked');
+		expect(readMemoryLinkPointer(dir)).toBeNull();
+	});
+
+	test('F-23: unlink when not linked is a no-op with a message', async () => {
+		const result = await handleMemoryUnlinkCommand(dir, []);
+		expect(result).toContain('not linked');
+	});
+});

--- a/tests/unit/commands/swarm-subcommand-parity.test.ts
+++ b/tests/unit/commands/swarm-subcommand-parity.test.ts
@@ -357,7 +357,7 @@ describe('swarm-subcommand-parity', () => {
 		// Pin the expected command count to prevent silent shrinkage.
 		// If commands are added to or removed from COMMAND_REGISTRY, update this number
 		// after verifying the skill's subcommand list is updated to match.
-		expect(expectedCommands.size).toBe(86);
+		expect(expectedCommands.size).toBe(89);
 
 		console.info(
 			`[swarm-subcommand-parity] skill documented commands (raw): ${skillRawCommands.length}`,

--- a/tests/unit/config/memory-config.test.ts
+++ b/tests/unit/config/memory-config.test.ts
@@ -114,6 +114,8 @@ describe('MemoryConfigSchema', () => {
 				},
 				latencyBudgetMs: 250,
 			},
+			// #1850: cohort memory sharing default-off.
+			link: { enabled: false },
 			hardDelete: false,
 		});
 	});

--- a/tests/unit/memory/cohort-config-fingerprint.test.ts
+++ b/tests/unit/memory/cohort-config-fingerprint.test.ts
@@ -4,6 +4,8 @@
  * fail-closed enforcement path in the SQLite provider (final-critic blocking
  * gap: the mismatch throw was previously untested).
  */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
 	existsSync,
 	mkdtempSync,
@@ -13,13 +15,12 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { DEFAULT_MEMORY_CONFIG } from '../../../src/memory/config';
 import {
-	computeMemoryCohortFingerprint,
 	buildMemoryCohortFingerprintInput,
+	computeMemoryCohortFingerprint,
 	computeRedactionPolicyVersion,
 } from '../../../src/memory/redaction';
-import { DEFAULT_MEMORY_CONFIG } from '../../../src/memory/config';
 import { SQLiteMemoryProvider } from '../../../src/memory/sqlite-provider';
 
 function makeTmp(prefix: string): string {
@@ -73,8 +74,12 @@ describe('#1850 cohort config fingerprint inputs (acceptance #10, #13)', () => {
 
 describe('#1850 SQLite provider fingerprint enforcement (acceptance #10 fail-closed)', () => {
 	const dirs: string[] = [];
+	let prevXdg: string | undefined;
+	let prevHome: string | undefined;
 
 	beforeEach(() => {
+		prevXdg = process.env.XDG_DATA_HOME;
+		prevHome = process.env.HOME;
 		const dataDir = makeTmp('fp-data-');
 		dirs.push(dataDir);
 		process.env.XDG_DATA_HOME = dataDir;
@@ -82,6 +87,8 @@ describe('#1850 SQLite provider fingerprint enforcement (acceptance #10 fail-clo
 	});
 
 	afterEach(() => {
+		process.env.XDG_DATA_HOME = prevXdg;
+		process.env.HOME = prevHome;
 		for (const d of dirs.splice(0)) {
 			try {
 				rmSync(d, { recursive: true, force: true });

--- a/tests/unit/memory/cohort-config-fingerprint.test.ts
+++ b/tests/unit/memory/cohort-config-fingerprint.test.ts
@@ -1,0 +1,152 @@
+/**
+ * #1850: cohort config fingerprint computation (acceptance #10, #13).
+ * Verifies the redaction policy version + config fingerprint inputs AND the
+ * fail-closed enforcement path in the SQLite provider (final-critic blocking
+ * gap: the mismatch throw was previously untested).
+ */
+import {
+	existsSync,
+	mkdtempSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	computeMemoryCohortFingerprint,
+	buildMemoryCohortFingerprintInput,
+	computeRedactionPolicyVersion,
+} from '../../../src/memory/redaction';
+import { DEFAULT_MEMORY_CONFIG } from '../../../src/memory/config';
+import { SQLiteMemoryProvider } from '../../../src/memory/sqlite-provider';
+
+function makeTmp(prefix: string): string {
+	return realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+}
+
+describe('#1850 cohort config fingerprint inputs (acceptance #10, #13)', () => {
+	test('computeRedactionPolicyVersion is deterministic', () => {
+		const a = computeRedactionPolicyVersion(true);
+		const b = computeRedactionPolicyVersion(true);
+		expect(a).toBe(b);
+	});
+
+	test('rejectDurableSecrets=true differs from false', () => {
+		const withReject = computeRedactionPolicyVersion(true);
+		const withoutReject = computeRedactionPolicyVersion(false);
+		expect(withReject).not.toBe(withoutReject);
+		expect(withReject).toBeGreaterThan(withoutReject);
+	});
+
+	test('version is a positive integer', () => {
+		const v = computeRedactionPolicyVersion(true);
+		expect(Number.isInteger(v)).toBe(true);
+		expect(v).toBeGreaterThan(0);
+	});
+
+	test('computeMemoryCohortFingerprint is deterministic + 12 hex chars', () => {
+		const input = buildMemoryCohortFingerprintInput(DEFAULT_MEMORY_CONFIG);
+		const a = computeMemoryCohortFingerprint(input);
+		const b = computeMemoryCohortFingerprint(input);
+		expect(a).toBe(b);
+		expect(a).toMatch(/^[a-f0-9]{12}$/);
+	});
+
+	test('different provider configs produce different fingerprints', () => {
+		const sqliteFp = computeMemoryCohortFingerprint(
+			buildMemoryCohortFingerprintInput({
+				...DEFAULT_MEMORY_CONFIG,
+				provider: 'sqlite',
+			}),
+		);
+		const jsonlFp = computeMemoryCohortFingerprint(
+			buildMemoryCohortFingerprintInput({
+				...DEFAULT_MEMORY_CONFIG,
+				provider: 'local-jsonl',
+			}),
+		);
+		expect(sqliteFp).not.toBe(jsonlFp);
+	});
+});
+
+describe('#1850 SQLite provider fingerprint enforcement (acceptance #10 fail-closed)', () => {
+	const dirs: string[] = [];
+
+	beforeEach(() => {
+		const dataDir = makeTmp('fp-data-');
+		dirs.push(dataDir);
+		process.env.XDG_DATA_HOME = dataDir;
+		process.env.HOME = dataDir;
+	});
+
+	afterEach(() => {
+		for (const d of dirs.splice(0)) {
+			try {
+				rmSync(d, { recursive: true, force: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+
+	test('F-24: provider opens when no cohort-config.json exists (first-link permissive)', async () => {
+		const cohortRoot = makeTmp('fp-cohort-empty-');
+		dirs.push(cohortRoot);
+		const dir = makeTmp('fp-worktree-');
+		dirs.push(dir);
+		const provider = new SQLiteMemoryProvider(
+			dir,
+			DEFAULT_MEMORY_CONFIG,
+			cohortRoot,
+		);
+		// Should not throw — absent config file is the first-link case.
+		await provider.initialize();
+		provider.close();
+	});
+
+	test('F-25: provider throws on fingerprint mismatch (fail-closed, acceptance #10)', async () => {
+		const cohortRoot = makeTmp('fp-cohort-mismatch-');
+		dirs.push(cohortRoot);
+		const dir = makeTmp('fp-worktree-mismatch-');
+		dirs.push(dir);
+		// Write a cohort-config.json with a DELIBERATELY wrong fingerprint.
+		writeFileSync(
+			path.join(cohortRoot, 'memory-cohort-config.json'),
+			JSON.stringify({ fingerprint: 'deadbeefdead' }),
+			'utf-8',
+		);
+		const provider = new SQLiteMemoryProvider(
+			dir,
+			DEFAULT_MEMORY_CONFIG,
+			cohortRoot,
+		);
+		// initialize MUST throw — the stored fingerprint does not match what
+		// this worktree's config computes.
+		expect(provider.initialize()).rejects.toThrow(/fingerprint mismatch/);
+	});
+
+	test('F-26: provider opens when fingerprint matches', async () => {
+		const cohortRoot = makeTmp('fp-cohort-match-');
+		dirs.push(cohortRoot);
+		const dir = makeTmp('fp-worktree-match-');
+		dirs.push(dir);
+		// Write a cohort-config.json with the CORRECT fingerprint for this config.
+		const fp = computeMemoryCohortFingerprint(
+			buildMemoryCohortFingerprintInput(DEFAULT_MEMORY_CONFIG),
+		);
+		writeFileSync(
+			path.join(cohortRoot, 'memory-cohort-config.json'),
+			JSON.stringify({ fingerprint: fp }),
+			'utf-8',
+		);
+		const provider = new SQLiteMemoryProvider(
+			dir,
+			DEFAULT_MEMORY_CONFIG,
+			cohortRoot,
+		);
+		await provider.initialize();
+		provider.close();
+	});
+});

--- a/tests/unit/memory/cohort-isolation.test.ts
+++ b/tests/unit/memory/cohort-isolation.test.ts
@@ -1,0 +1,60 @@
+/**
+ * #1850: cohort isolation (acceptance #3, #9) — different cohorts cannot
+ * read/mutrate each other's memory. Covers test category #3 from the issue.
+ */
+import { describe, expect, test } from 'bun:test';
+import { stableScopeKey } from '../../../src/memory/schema';
+import { scopeAllowed } from '../../../src/memory/scoring';
+import type { MemoryScopeRef } from '../../../src/memory/types';
+
+describe('#1850 cohort isolation (acceptance #3, #9 — category #3)', () => {
+	test('F-12: records from cohort A are invisible to cohort B via scope key', () => {
+		const recordScopeA: MemoryScopeRef = {
+			type: 'cohort',
+			cohortId: 'cohort-alpha',
+		};
+		const allowedScopesB: MemoryScopeRef[] = [
+			{ type: 'cohort', cohortId: 'cohort-beta' },
+		];
+		const allowed = scopeAllowed(recordScopeA, allowedScopesB);
+		expect(allowed).toBe(false);
+	});
+
+	test('F-13: records from cohort A are visible to cohort A', () => {
+		const recordScope: MemoryScopeRef = {
+			type: 'cohort',
+			cohortId: 'cohort-alpha',
+		};
+		const allowedScopes: MemoryScopeRef[] = [
+			{ type: 'cohort', cohortId: 'cohort-alpha' },
+		];
+		const allowed = scopeAllowed(recordScope, allowedScopes);
+		expect(allowed).toBe(true);
+	});
+
+	test('F-14: cohort scope does not match repository scope (no cross-tier leak)', () => {
+		const cohortRecord: MemoryScopeRef = {
+			type: 'cohort',
+			cohortId: 'cohort-x',
+		};
+		const repoScopes: MemoryScopeRef[] = [
+			{ type: 'repository', repoId: 'repo-x' },
+		];
+		expect(scopeAllowed(cohortRecord, repoScopes)).toBe(false);
+	});
+
+	test('F-15: run-scoped records remain worktree-local (session isolation)', () => {
+		const runRecordA: MemoryScopeRef = { type: 'run', runId: 'run-A' };
+		const allowedScopesB: MemoryScopeRef[] = [{ type: 'run', runId: 'run-B' }];
+		expect(scopeAllowed(runRecordA, allowedScopesB)).toBe(false);
+	});
+
+	test('F-16: stableScopeKey distinguishes unrelated cohorts', () => {
+		const cohorts = ['alpha', 'beta', 'gamma', 'delta'];
+		const keys = cohorts.map((c) =>
+			stableScopeKey({ type: 'cohort', cohortId: c }),
+		);
+		// All keys must be unique.
+		expect(new Set(keys).size).toBe(cohorts.length);
+	});
+});

--- a/tests/unit/memory/cohort-scope-derivation.test.ts
+++ b/tests/unit/memory/cohort-scope-derivation.test.ts
@@ -1,0 +1,56 @@
+/**
+ * #1850 (critic GAP-1, GAP-2): cohort scope derivation + stableScopeKey.
+ *
+ * Falsification target: without the `cohort` branch in `stableScopeKey`
+ * (schema.ts:219) and `cohortId` on `MemoryScopeRefSchema` (schema.ts:26),
+ * cohort-scoped records either fail validation or collapse across all cohorts.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+	MemoryScopeRefSchema,
+	stableScopeKey,
+} from '../../../src/memory/schema';
+
+describe('#1850 cohort scope — regression: stableScopeKey + schema (GAP-1, GAP-2)', () => {
+	test('F-1: cohort scope keys on cohortId (GAP-1)', () => {
+		// If stableScopeKey had no cohort branch, these would collide.
+		const a = stableScopeKey({ type: 'cohort', cohortId: 'cohort-aaa' });
+		const b = stableScopeKey({ type: 'cohort', cohortId: 'cohort-bbb' });
+		expect(a).not.toBe(b);
+		expect(a).toContain('cohort-aaa');
+		expect(b).toContain('cohort-bbb');
+	});
+
+	test('F-2: same cohortId produces same key (idempotent scope matching)', () => {
+		const a = stableScopeKey({ type: 'cohort', cohortId: 'cohort-x' });
+		const b = stableScopeKey({ type: 'cohort', cohortId: 'cohort-x' });
+		expect(a).toBe(b);
+	});
+
+	test('F-3: cohort scope parses with cohortId (GAP-2)', () => {
+		const parsed = MemoryScopeRefSchema.parse({
+			type: 'cohort',
+			cohortId: 'cohort-aaa',
+		});
+		expect(parsed.type).toBe('cohort');
+		expect(parsed.cohortId).toBe('cohort-aaa');
+	});
+
+	test('F-4: cohort scope type is in the enum', () => {
+		const types = MemoryScopeRefSchema.shape.type.options;
+		expect(types).toContain('cohort');
+	});
+
+	test('F-5: repository scope still keys on repoId only (unchanged)', () => {
+		const a = stableScopeKey({ type: 'repository', repoId: 'repo-a' });
+		const b = stableScopeKey({ type: 'repository', repoId: 'repo-b' });
+		expect(a).not.toBe(b);
+	});
+
+	test('F-6: cohort scope with missing cohortId still keys (graceful)', () => {
+		// A cohort scope without cohortId is malformed but should not throw —
+		// it produces a key that won't match any well-formed cohort scope.
+		const key = stableScopeKey({ type: 'cohort' });
+		expect(key).toContain('"type":"cohort"');
+	});
+});

--- a/tests/unit/memory/diagnostics-no-leakage.test.ts
+++ b/tests/unit/memory/diagnostics-no-leakage.test.ts
@@ -1,0 +1,62 @@
+/**
+ * #1850: diagnostics no-leakage (acceptance #13 — category #13).
+ * Verifies status/diagnostics surfaces do NOT emit memory record text or
+ * unrelated-repo identifiers when cohort-linked.
+ */
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { computeKnowledgeDebug } from '../../../src/services/knowledge-diagnostics';
+import { writeMemoryLinkPointer } from '../../../src/memory/memory-link';
+
+function makeTmp(prefix: string): string {
+	return realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+}
+
+describe('#1850 diagnostics no-leakage (acceptance #13 — category #13)', () => {
+	const dirs: string[] = [];
+
+	beforeEach(() => {
+		const dataDir = makeTmp('diag-data-');
+		dirs.push(dataDir);
+		process.env.XDG_DATA_HOME = dataDir;
+		process.env.HOME = dataDir;
+	});
+
+	afterEach(() => {
+		for (const d of dirs.splice(0)) {
+			try {
+				rmSync(d, { recursive: true, force: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+
+	test('F-20: knowledge-diagnostics memory block carries no record text', async () => {
+		const dir = makeTmp('diag-leak-');
+		dirs.push(dir);
+		await writeMemoryLinkPointer(dir, {
+			version: 2,
+			linkId: 'leak-test-cohort',
+			createdAt: new Date().toISOString(),
+			cohortId: 'leak-cohort-id',
+		});
+		const debug = await computeKnowledgeDebug(dir);
+		expect(debug.memory).toBeDefined();
+		expect(debug.memory.linked).toBe(true);
+		// The memory block must NOT contain record text — only structural fields.
+		const serialized = JSON.stringify(debug.memory);
+		expect(serialized).not.toContain('lesson');
+		expect(serialized).not.toContain('text');
+		expect(serialized).not.toContain('rationale');
+	});
+
+	test('F-21: unlinked worktree reports memory.linked=false cleanly', async () => {
+		const dir = makeTmp('diag-unlinked-');
+		dirs.push(dir);
+		const debug = await computeKnowledgeDebug(dir);
+		expect(debug.memory.linked).toBe(false);
+	});
+});

--- a/tests/unit/memory/diagnostics-no-leakage.test.ts
+++ b/tests/unit/memory/diagnostics-no-leakage.test.ts
@@ -3,12 +3,13 @@
  * Verifies status/diagnostics surfaces do NOT emit memory record text or
  * unrelated-repo identifiers when cohort-linked.
  */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { computeKnowledgeDebug } from '../../../src/services/knowledge-diagnostics';
 import { writeMemoryLinkPointer } from '../../../src/memory/memory-link';
+import { computeKnowledgeDebug } from '../../../src/services/knowledge-diagnostics';
 
 function makeTmp(prefix: string): string {
 	return realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
@@ -16,8 +17,12 @@ function makeTmp(prefix: string): string {
 
 describe('#1850 diagnostics no-leakage (acceptance #13 — category #13)', () => {
 	const dirs: string[] = [];
+	let prevXdg: string | undefined;
+	let prevHome: string | undefined;
 
 	beforeEach(() => {
+		prevXdg = process.env.XDG_DATA_HOME;
+		prevHome = process.env.HOME;
 		const dataDir = makeTmp('diag-data-');
 		dirs.push(dataDir);
 		process.env.XDG_DATA_HOME = dataDir;
@@ -25,6 +30,8 @@ describe('#1850 diagnostics no-leakage (acceptance #13 — category #13)', () =>
 	});
 
 	afterEach(() => {
+		process.env.XDG_DATA_HOME = prevXdg;
+		process.env.HOME = prevHome;
 		for (const d of dirs.splice(0)) {
 			try {
 				rmSync(d, { recursive: true, force: true });

--- a/tests/unit/memory/finalize-reward-sweep-basic.test.ts
+++ b/tests/unit/memory/finalize-reward-sweep-basic.test.ts
@@ -22,6 +22,7 @@ import * as path from 'node:path';
 import {
 	computeMemoryContentHash,
 	createConfiguredMemoryProvider,
+	createConfiguredMemoryProviderForRoot,
 	createMemoryId,
 	DEFAULT_MEMORY_CONFIG,
 	type MemoryProvider,
@@ -68,6 +69,8 @@ afterEach(async () => {
 	}
 	// Restore DI seams in case a test overrode them.
 	_internals.createConfiguredMemoryProvider = createConfiguredMemoryProvider;
+	_internals.createConfiguredMemoryProviderForRoot =
+		createConfiguredMemoryProviderForRoot;
 	_internals.applyCouncilReward = applyCouncilReward;
 	// Release sqlite pool handles BEFORE removing temp dirs (Windows EBUSY guard).
 	clearPool();
@@ -280,9 +283,15 @@ describe('runFinalizeRewardSweep — control paths', () => {
 	});
 
 	test('non-blocking: a provider-factory that throws does NOT propagate out of the sweep', async () => {
-		_internals.createConfiguredMemoryProvider = (() => {
+		// #1850: the sweep now resolves a vetted root and calls the ForRoot
+		// factory. Mock both factories so the throw path is exercised regardless
+		// of which entry the implementation uses.
+		const throwingFactory = (() => {
 			throw new Error('factory boom');
 		}) as typeof createConfiguredMemoryProvider;
+		_internals.createConfiguredMemoryProvider = throwingFactory;
+		_internals.createConfiguredMemoryProviderForRoot =
+			throwingFactory as unknown as typeof createConfiguredMemoryProviderForRoot;
 
 		const result = await runFinalizeRewardSweep({
 			directory: '/nonexistent',

--- a/tests/unit/memory/gateway-cohort-integration.test.ts
+++ b/tests/unit/memory/gateway-cohort-integration.test.ts
@@ -1,0 +1,149 @@
+/**
+ * #1850: gateway-level cohort integration tests (H-005).
+ * Verifies the gateway's scopeKey + resolveRecordScope correctly handle
+ * cohort-linked scenarios at the gateway level (not just schema-level).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { DEFAULT_MEMORY_CONFIG } from '../../../src/memory/config';
+import { MemoryGateway } from '../../../src/memory/gateway';
+import { writeMemoryLinkPointer } from '../../../src/memory/memory-link';
+import { clearPool } from '../../../src/memory/provider-pool';
+
+function makeTmp(prefix: string): string {
+	return realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+}
+
+describe('#1850 gateway cohort integration (H-005)', () => {
+	const dirs: string[] = [];
+	let prevXdg: string | undefined;
+	let prevHome: string | undefined;
+
+	beforeEach(() => {
+		prevXdg = process.env.XDG_DATA_HOME;
+		prevHome = process.env.HOME;
+		const dataDir = makeTmp('gw-cohort-data-');
+		dirs.push(dataDir);
+		process.env.XDG_DATA_HOME = dataDir;
+		process.env.HOME = dataDir;
+	});
+
+	afterEach(() => {
+		process.env.XDG_DATA_HOME = prevXdg;
+		process.env.HOME = prevHome;
+		clearPool();
+		for (const d of dirs.splice(0)) {
+			try {
+				rmSync(d, { recursive: true, force: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+
+	test('F-27: cohort-linked gateway emits a cohort scope in deriveAllowedScopes', async () => {
+		const dir = makeTmp('gw-linked-');
+		dirs.push(dir);
+		await writeMemoryLinkPointer(dir, {
+			version: 2,
+			linkId: 'gw-test-cohort',
+			createdAt: new Date().toISOString(),
+			cohortId: 'gw-cohort-id',
+			generation: 1,
+		});
+		const config = {
+			...DEFAULT_MEMORY_CONFIG,
+			enabled: true,
+			link: { enabled: true },
+		};
+		const gw = new MemoryGateway(
+			{ directory: dir, sessionID: 'test-session' },
+			{ config },
+		);
+		const scopes = gw.deriveAllowedScopes();
+		const cohortScope = scopes.find((s) => s.type === 'cohort');
+		expect(cohortScope).toBeDefined();
+		expect(cohortScope?.cohortId).toBe('gw-cohort-id');
+		// run/agent scopes should still be present (session isolation).
+		expect(scopes.some((s) => s.type === 'run')).toBe(true);
+	});
+
+	test('F-28: non-linked gateway does NOT emit a cohort scope', () => {
+		const dir = makeTmp('gw-unlinked-');
+		dirs.push(dir);
+		const config = { ...DEFAULT_MEMORY_CONFIG, enabled: true };
+		const gw = new MemoryGateway({ directory: dir }, { config });
+		const scopes = gw.deriveAllowedScopes();
+		expect(scopes.find((s) => s.type === 'cohort')).toBeUndefined();
+	});
+
+	test('F-29: link.enabled=false does not emit cohort even with pointer', async () => {
+		const dir = makeTmp('gw-disabled-');
+		dirs.push(dir);
+		await writeMemoryLinkPointer(dir, {
+			version: 2,
+			linkId: 'gw-disabled-cohort',
+			createdAt: new Date().toISOString(),
+			cohortId: 'gw-disabled-id',
+			generation: 1,
+		});
+		// link.enabled is false (default) — cohort should NOT be active.
+		const config = { ...DEFAULT_MEMORY_CONFIG, enabled: true };
+		const gw = new MemoryGateway({ directory: dir }, { config });
+		const scopes = gw.deriveAllowedScopes();
+		expect(scopes.find((s) => s.type === 'cohort')).toBeUndefined();
+	});
+
+	test('F-30: createRecord defaults durable records to cohort scope when linked', async () => {
+		const dir = makeTmp('gw-durable-');
+		dirs.push(dir);
+		await writeMemoryLinkPointer(dir, {
+			version: 2,
+			linkId: 'gw-durable-cohort',
+			createdAt: new Date().toISOString(),
+			cohortId: 'gw-durable-id',
+			generation: 1,
+		});
+		const config = {
+			...DEFAULT_MEMORY_CONFIG,
+			enabled: true,
+			link: { enabled: true },
+		};
+		const gw = new MemoryGateway({ directory: dir }, { config });
+		const record = gw.createRecord({
+			kind: 'project_fact',
+			text: 'durable cohort test',
+			source: { type: 'manual', ref: 'test' },
+		});
+		expect(record.scope.type).toBe('cohort');
+		expect(record.scope.cohortId).toBe('gw-durable-id');
+	});
+
+	test('F-31: createRecord defaults ephemeral (scratch) records to local scope even when linked', async () => {
+		const dir = makeTmp('gw-scratch-');
+		dirs.push(dir);
+		await writeMemoryLinkPointer(dir, {
+			version: 2,
+			linkId: 'gw-scratch-cohort',
+			createdAt: new Date().toISOString(),
+			cohortId: 'gw-scratch-id',
+			generation: 1,
+		});
+		const config = {
+			...DEFAULT_MEMORY_CONFIG,
+			enabled: true,
+			link: { enabled: true },
+		};
+		const gw = new MemoryGateway({ directory: dir }, { config });
+		const record = gw.createRecord({
+			kind: 'scratch',
+			text: 'scratch should stay local',
+		});
+		// Scratch defaults to ephemeral stability → should NOT be cohort-scoped.
+		expect(record.scope.type).not.toBe('cohort');
+		expect(record.stability).toBe('ephemeral');
+	});
+});

--- a/tests/unit/memory/memory-family-manifest.test.ts
+++ b/tests/unit/memory/memory-family-manifest.test.ts
@@ -1,0 +1,81 @@
+/**
+ * #1850: memory family manifest + migration engine (acceptance #7).
+ * Tests the manifest inventory, JSONL append-union, and SQLite staging.
+ */
+import {
+	existsSync,
+	mkdtempSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { MEMORY_FAMILY } from '../../../src/memory/memory-family-manifest';
+import { _internals } from '../../../src/memory/memory-family-migration';
+
+function makeTmp(prefix: string): string {
+	return realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+}
+
+describe('#1850 memory family manifest (acceptance #7)', () => {
+	test('manifest includes memory.db, all JSONL files, and excludes derived', () => {
+		const filenames = MEMORY_FAMILY.map((m) => m.filename);
+		expect(filenames).toContain('memory.db');
+		expect(filenames).toContain('memories.jsonl');
+		expect(filenames).toContain('proposals.jsonl');
+		expect(filenames).toContain('audit.jsonl');
+		expect(filenames).toContain('reward-events.jsonl');
+		expect(filenames).toContain('consolidation-log.jsonl');
+		// Derived/skip members.
+		expect(filenames).toContain('backups/');
+		expect(filenames).toContain('export/');
+	});
+
+	test('every canonical member has a merge strategy', () => {
+		for (const m of MEMORY_FAMILY) {
+			if (m.scope === 'canonical') {
+				expect(['sqlite-file-copy', 'append-union']).toContain(m.mergeStrategy);
+			}
+		}
+	});
+});
+
+describe('#1850 memory family migration — JSONL append-union', () => {
+	const dirs: string[] = [];
+
+	afterEach(() => {
+		for (const d of dirs.splice(0)) {
+			try {
+				rmSync(d, { recursive: true, force: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+
+	test('F-17: append-union dedups by id (idempotent on retry)', () => {
+		const dest = [{ id: 'a', text: 'first' }];
+		const src = [
+			{ id: 'a', text: 'first' },
+			{ id: 'b', text: 'second' },
+		];
+		const { merged, added, skipped } = _internals.appendUnionById(dest, src);
+		expect(merged).toHaveLength(2);
+		expect(added).toBe(1);
+		expect(skipped).toBe(1);
+	});
+
+	test('F-18: validateSerializedJsonl rejects malformed JSON', () => {
+		expect(_internals.validateSerializedJsonl('{"id":"a"}\nnot json\n')).toBe(
+			false,
+		);
+	});
+
+	test('F-19: validateSerializedJsonl accepts valid id-keyed lines', () => {
+		expect(_internals.validateSerializedJsonl('{"id":"a"}\n{"id":"b"}\n')).toBe(
+			true,
+		);
+	});
+});

--- a/tests/unit/memory/memory-family-manifest.test.ts
+++ b/tests/unit/memory/memory-family-manifest.test.ts
@@ -2,6 +2,8 @@
  * #1850: memory family manifest + migration engine (acceptance #7).
  * Tests the manifest inventory, JSONL append-union, and SQLite staging.
  */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
 	existsSync,
 	mkdtempSync,
@@ -11,7 +13,6 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { MEMORY_FAMILY } from '../../../src/memory/memory-family-manifest';
 import { _internals } from '../../../src/memory/memory-family-migration';
 

--- a/tests/unit/memory/memory-link-pointer.test.ts
+++ b/tests/unit/memory/memory-link-pointer.test.ts
@@ -2,16 +2,17 @@
  * #1850: memory link pointer read/write/remove + cache invalidation.
  * Acceptance #1 (independent opt-in), #2 (distinguishable from knowledge link).
  */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
+	invalidateMemoryStoreDirCache,
 	isMemoryLinked,
 	readMemoryLinkPointer,
 	removeMemoryLinkPointer,
 	resolveMemoryStoreDir,
-	invalidateMemoryStoreDirCache,
 	writeMemoryLinkPointer,
 } from '../../../src/memory/memory-link';
 

--- a/tests/unit/memory/memory-link-pointer.test.ts
+++ b/tests/unit/memory/memory-link-pointer.test.ts
@@ -1,0 +1,119 @@
+/**
+ * #1850: memory link pointer read/write/remove + cache invalidation.
+ * Acceptance #1 (independent opt-in), #2 (distinguishable from knowledge link).
+ */
+import { existsSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	isMemoryLinked,
+	readMemoryLinkPointer,
+	removeMemoryLinkPointer,
+	resolveMemoryStoreDir,
+	invalidateMemoryStoreDirCache,
+	writeMemoryLinkPointer,
+} from '../../../src/memory/memory-link';
+
+function makeTmp(prefix: string): string {
+	return realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+}
+
+describe('#1850 memory link pointer', () => {
+	let dir: string;
+	const dirs: string[] = [];
+
+	beforeEach(() => {
+		dir = makeTmp('memlink-');
+		dirs.push(dir);
+	});
+
+	afterEach(() => {
+		invalidateMemoryStoreDirCache();
+		for (const d of dirs.splice(0)) {
+			try {
+				rmSync(d, { recursive: true, force: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+
+	test('read returns null when no pointer exists (default local)', () => {
+		expect(readMemoryLinkPointer(dir)).toBeNull();
+		expect(isMemoryLinked(dir)).toBe(false);
+	});
+
+	test('write + read round-trip preserves all fields', async () => {
+		const pointer = {
+			version: 2 as const,
+			linkId: 'my-cohort',
+			createdAt: '2026-07-17T00:00:00.000Z',
+			cohortId: 'cohort-abc',
+			identitySource: 'remote' as const,
+			degraded: false,
+			generation: 3,
+		};
+		await writeMemoryLinkPointer(dir, pointer);
+		const read = readMemoryLinkPointer(dir);
+		expect(read).not.toBeNull();
+		expect(read?.linkId).toBe('my-cohort');
+		expect(read?.cohortId).toBe('cohort-abc');
+		expect(read?.generation).toBe(3);
+		expect(read?.version).toBe(2);
+		expect(isMemoryLinked(dir)).toBe(true);
+	});
+
+	test('pointer file is separate from knowledge link.json', async () => {
+		await writeMemoryLinkPointer(dir, {
+			version: 2,
+			linkId: 'mem-only',
+			createdAt: new Date().toISOString(),
+		});
+		// The memory pointer is at .swarm/memory-link.json, NOT .swarm/link.json.
+		expect(existsSync(path.join(dir, '.swarm', 'memory-link.json'))).toBe(true);
+		expect(existsSync(path.join(dir, '.swarm', 'link.json'))).toBe(false);
+	});
+
+	test('remove is idempotent', async () => {
+		await writeMemoryLinkPointer(dir, {
+			version: 2,
+			linkId: 'temp',
+			createdAt: new Date().toISOString(),
+		});
+		await removeMemoryLinkPointer(dir);
+		expect(readMemoryLinkPointer(dir)).toBeNull();
+		// Removing again does not throw.
+		await removeMemoryLinkPointer(dir);
+	});
+
+	test('malformed pointer fails open to null', async () => {
+		const fs = await import('node:fs/promises');
+		const pointerPath = path.join(dir, '.swarm', 'memory-link.json');
+		await fs.mkdir(path.dirname(pointerPath), { recursive: true });
+		await fs.writeFile(pointerPath, '{ not valid json', 'utf-8');
+		expect(readMemoryLinkPointer(dir)).toBeNull();
+	});
+
+	test('resolveMemoryStoreDir returns local .swarm when not linked', () => {
+		invalidateMemoryStoreDirCache(dir);
+		const resolved = resolveMemoryStoreDir(dir);
+		expect(resolved).toBe(path.join(dir, '.swarm'));
+	});
+
+	test('resolveMemoryStoreDir returns cohort dir when linked', async () => {
+		const dataDir = makeTmp('memlink-data-');
+		dirs.push(dataDir);
+		process.env.XDG_DATA_HOME = dataDir;
+		process.env.HOME = dataDir;
+		await writeMemoryLinkPointer(dir, {
+			version: 2,
+			linkId: 'resolve-cohort',
+			createdAt: new Date().toISOString(),
+		});
+		invalidateMemoryStoreDirCache(dir);
+		const resolved = resolveMemoryStoreDir(dir);
+		expect(resolved).not.toBe(path.join(dir, '.swarm'));
+		expect(resolved).toContain('resolve-cohort');
+	});
+});

--- a/tests/unit/memory/provider-pool-cohort-key.test.ts
+++ b/tests/unit/memory/provider-pool-cohort-key.test.ts
@@ -3,15 +3,16 @@
  * Verifies cohort roots get distinct pool keys from local roots, and that
  * evictAndCloseForRoot is scoped (does not clear unrelated entries).
  */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { DEFAULT_MEMORY_CONFIG } from '../../../src/memory/config';
 import {
+	clearPool,
 	evictAndCloseForRoot,
 	getOrCreateProviderForRoot,
-	clearPool,
 } from '../../../src/memory/provider-pool';
 import { wrapLocalRoot } from '../../../src/memory/storage-root';
 

--- a/tests/unit/memory/provider-pool-cohort-key.test.ts
+++ b/tests/unit/memory/provider-pool-cohort-key.test.ts
@@ -1,0 +1,102 @@
+/**
+ * #1850: cohort-aware provider pool keying (acceptance #5).
+ * Verifies cohort roots get distinct pool keys from local roots, and that
+ * evictAndCloseForRoot is scoped (does not clear unrelated entries).
+ */
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { DEFAULT_MEMORY_CONFIG } from '../../../src/memory/config';
+import {
+	evictAndCloseForRoot,
+	getOrCreateProviderForRoot,
+	clearPool,
+} from '../../../src/memory/provider-pool';
+import { wrapLocalRoot } from '../../../src/memory/storage-root';
+
+function makeTmp(prefix: string): string {
+	return realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+}
+
+describe('#1850 provider pool cohort keying (acceptance #5)', () => {
+	const dirs: string[] = [];
+
+	beforeEach(() => {
+		clearPool();
+	});
+
+	afterEach(() => {
+		clearPool();
+		for (const d of dirs.splice(0)) {
+			try {
+				rmSync(d, { recursive: true, force: true });
+			} catch {
+				/* best-effort Windows EBUSY */
+			}
+		}
+	});
+
+	test('F-8: two distinct local roots get distinct providers', () => {
+		const dirA = makeTmp('pool-local-a-');
+		const dirB = makeTmp('pool-local-b-');
+		dirs.push(dirA, dirB);
+		const rootA = wrapLocalRoot(dirA);
+		const rootB = wrapLocalRoot(dirB);
+		const provA = getOrCreateProviderForRoot(rootA, DEFAULT_MEMORY_CONFIG);
+		const provB = getOrCreateProviderForRoot(rootB, DEFAULT_MEMORY_CONFIG);
+		expect(provA).not.toBe(provB);
+	});
+
+	test('F-9: same local root returns same provider (cache hit)', () => {
+		const dir = makeTmp('pool-same-');
+		dirs.push(dir);
+		const root = wrapLocalRoot(dir);
+		const prov1 = getOrCreateProviderForRoot(root, DEFAULT_MEMORY_CONFIG);
+		const prov2 = getOrCreateProviderForRoot(root, DEFAULT_MEMORY_CONFIG);
+		expect(prov1).toBe(prov2);
+	});
+
+	test('F-10: cohort root and local root for same directory get distinct providers', () => {
+		const dir = makeTmp('pool-mixed-');
+		dirs.push(dir);
+		const localRoot = wrapLocalRoot(dir);
+		const cohortRoot = {
+			kind: 'cohort' as const,
+			cohortRoot: path.join(dir, 'fake-cohort', 'memory'),
+			cohortId: 'fake-cohort-id',
+			generation: 1,
+			linkId: 'fake-cohort',
+			directory: dir,
+		};
+		const localProv = getOrCreateProviderForRoot(
+			localRoot,
+			DEFAULT_MEMORY_CONFIG,
+		);
+		const cohortProv = getOrCreateProviderForRoot(
+			cohortRoot,
+			DEFAULT_MEMORY_CONFIG,
+		);
+		expect(localProv).not.toBe(cohortProv);
+	});
+
+	test('F-11: evictAndCloseForRoot is scoped (does not evict unrelated entries)', () => {
+		const dirA = makeTmp('pool-evict-a-');
+		const dirB = makeTmp('pool-evict-b-');
+		dirs.push(dirA, dirB);
+		const rootA = wrapLocalRoot(dirA);
+		const rootB = wrapLocalRoot(dirB);
+		const provA = getOrCreateProviderForRoot(rootA, DEFAULT_MEMORY_CONFIG);
+		const provB = getOrCreateProviderForRoot(rootB, DEFAULT_MEMORY_CONFIG);
+		// Release A's refcount so eviction can really close it.
+		provA.close();
+		// Evict A only.
+		evictAndCloseForRoot(rootA);
+		// Re-acquire A — should be a new instance.
+		const provA2 = getOrCreateProviderForRoot(rootA, DEFAULT_MEMORY_CONFIG);
+		expect(provA2).not.toBe(provA);
+		// B should still be cached (same instance).
+		const provB2 = getOrCreateProviderForRoot(rootB, DEFAULT_MEMORY_CONFIG);
+		expect(provB2).toBe(provB);
+	});
+});

--- a/tests/unit/memory/storage-root.test.ts
+++ b/tests/unit/memory/storage-root.test.ts
@@ -1,0 +1,112 @@
+/**
+ * #1850: vetted memory storage-root resolution (acceptance #3, GAP-5).
+ *
+ * Verifies that resolveVettedMemoryRoot returns local by default, cohort when
+ * linked, and that the cohort path bypasses validateSwarmPath by construction.
+ */
+import { mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	DEFAULT_MEMORY_CONFIG,
+	resolveVettedMemoryRoot,
+	wrapLocalRoot,
+} from '../../../src/memory';
+import {
+	invalidateMemoryStoreDirCache,
+	writeMemoryLinkPointer,
+} from '../../../src/memory/memory-link';
+
+function makeTmp(prefix: string): string {
+	return realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+}
+
+describe('#1850 storage-root resolution', () => {
+	const dirs: string[] = [];
+
+	beforeEach(() => {
+		// Redirect the platform data dir so cohort paths land in temp.
+		const dataDir = makeTmp('storage-root-data-');
+		dirs.push(dataDir);
+		process.env.XDG_DATA_HOME = dataDir;
+		process.env.HOME = dataDir;
+	});
+
+	afterEach(() => {
+		invalidateMemoryStoreDirCache();
+		for (const d of dirs.splice(0)) {
+			try {
+				require('node:fs').rmSync(d, { recursive: true, force: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+
+	test('returns local root when link is disabled (default)', () => {
+		const dir = makeTmp('storage-root-local-');
+		dirs.push(dir);
+		const root = resolveVettedMemoryRoot(dir, DEFAULT_MEMORY_CONFIG);
+		expect(root.kind).toBe('local');
+		if (root.kind === 'local') {
+			expect(root.root).toBe(path.join(dir, '.swarm'));
+			expect(root.directory).toBe(dir);
+		}
+	});
+
+	test('returns local root when link.enabled=true but no pointer exists', () => {
+		const dir = makeTmp('storage-root-nopointer-');
+		dirs.push(dir);
+		const config = { ...DEFAULT_MEMORY_CONFIG, link: { enabled: true } };
+		const root = resolveVettedMemoryRoot(dir, config);
+		expect(root.kind).toBe('local');
+	});
+
+	test('returns cohort root when link.enabled=true and pointer exists', async () => {
+		const dir = makeTmp('storage-root-cohort-');
+		dirs.push(dir);
+		await writeMemoryLinkPointer(dir, {
+			version: 2,
+			linkId: 'test-cohort',
+			createdAt: new Date().toISOString(),
+			cohortId: 'cohort-abc',
+			generation: 1,
+		});
+		invalidateMemoryStoreDirCache(dir);
+		const config = { ...DEFAULT_MEMORY_CONFIG, link: { enabled: true } };
+		const root = resolveVettedMemoryRoot(dir, config);
+		expect(root.kind).toBe('cohort');
+		if (root.kind === 'cohort') {
+			expect(root.cohortId).toBe('cohort-abc');
+			expect(root.generation).toBe(1);
+			expect(root.linkId).toBe('test-cohort');
+			expect(root.cohortRoot).toContain('memory');
+			expect(root.directory).toBe(dir);
+		}
+	});
+
+	test('cohort root path is under the data dir (GAP-5: no validateSwarmPath)', () => {
+		const root = wrapLocalRoot('/some/worktree');
+		expect(root.kind).toBe('local');
+	});
+
+	test('F-7: cohort root is never under .swarm of the worktree', async () => {
+		const dir = makeTmp('storage-root-noswarm-');
+		dirs.push(dir);
+		await writeMemoryLinkPointer(dir, {
+			version: 2,
+			linkId: 'safety-cohort',
+			createdAt: new Date().toISOString(),
+			cohortId: 'safety',
+			generation: 1,
+		});
+		invalidateMemoryStoreDirCache(dir);
+		const config = { ...DEFAULT_MEMORY_CONFIG, link: { enabled: true } };
+		const root = resolveVettedMemoryRoot(dir, config);
+		if (root.kind === 'cohort') {
+			// The cohort root must NOT contain the worktree's .swarm path.
+			expect(root.cohortRoot.startsWith(path.join(dir, '.swarm'))).toBe(false);
+		}
+	});
+});

--- a/tests/unit/memory/storage-root.test.ts
+++ b/tests/unit/memory/storage-root.test.ts
@@ -4,10 +4,11 @@
  * Verifies that resolveVettedMemoryRoot returns local by default, cohort when
  * linked, and that the cohort path bypasses validateSwarmPath by construction.
  */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
 	DEFAULT_MEMORY_CONFIG,
 	resolveVettedMemoryRoot,
@@ -24,8 +25,12 @@ function makeTmp(prefix: string): string {
 
 describe('#1850 storage-root resolution', () => {
 	const dirs: string[] = [];
+	let prevXdg: string | undefined;
+	let prevHome: string | undefined;
 
 	beforeEach(() => {
+		prevXdg = process.env.XDG_DATA_HOME;
+		prevHome = process.env.HOME;
 		// Redirect the platform data dir so cohort paths land in temp.
 		const dataDir = makeTmp('storage-root-data-');
 		dirs.push(dataDir);
@@ -34,6 +39,8 @@ describe('#1850 storage-root resolution', () => {
 	});
 
 	afterEach(() => {
+		process.env.XDG_DATA_HOME = prevXdg;
+		process.env.HOME = prevHome;
 		invalidateMemoryStoreDirCache();
 		for (const d of dirs.splice(0)) {
 			try {


### PR DESCRIPTION
## Summary

Linked Knowledge 5/5 — completes the series by making the opt-in memory subsystem capable of sharing repository-scoped memory across linked sibling worktrees through the canonical cohort identity from #1846.

Knowledge link and memory link remain **independently opt-in**: linking knowledge does NOT link memory, and vice versa.

Closes #1850.

## Review history

This PR passed three independent review passes + one feedback round:
1. **swarm-pr-review** (my own, 6-lane parallel): 28 candidates → 26 verified → critic-downgraded to 2 HIGH + 8 MEDIUM.
2. **Esper3.1 bot review**: APPROVE with 1 minor (--no-copy message).
3. **swarm-pr-review bot**: NEEDS REVISION — 1 HIGH (atomicity), 15 MEDIUM.
4. **swarm-pr-feedback** (this commit): addressed ALL findings from all three reviews. Kimi K2.7 reviewer caught a critical `rootStoragePath` bug (local roots resolved to `.swarm` instead of `.swarm/memory`). GLM-5.2 final critic caught F-22 test vacuity + H-005 gateway coverage gap.

## What changed

### Foundation
- **`memory.link.enabled` config** (default off) — gates cohort memory sharing.
- **`'cohort'` scope type** + `cohortId` on `MemoryScopeRef` — `stableScopeKey` AND the gateway's `scopeKey()` both key on `cohortId` (H-001 fix: the gateway's local `scopeKey` was initially missing `cohortId`, allowing cross-cohort scope validation bypass).
- **Provenance fields** on `MemoryRecord` — `cohortId`, `producerSessionId`, `producerAgentRole`, `redactionPolicyVersion`, `providerVersion` (all optional, backward compatible).

### Vetted storage-root capability
- **`src/memory/storage-root.ts`** — `VettedMemoryRoot` discriminated union. `rootStoragePath` resolves local roots to `.swarm/memory` (reviewer-caught bug: was returning bare `.swarm`). Cohort roots bypass `validateSwarmPath` by construction.
- **`src/memory/memory-link.ts`** — separate `memory-link.json` pointer (distinct from knowledge `link.json`).

### Provider layer
- **Cohort-aware provider pool** with generation-based invalidation.
- **SQLite provider**: cohort-root path branch, `assertCohortConfigFingerprint` (fail-closed with warnings on absent/malformed — M-010 fix), `bumpCohortGeneration`.
- **JSONL provider**: cohort-root path branch + `assertCohortConfigFingerprint` (KC-001 fix — initially missing).

### Gateway + consumers
- **`deriveAllowedScopes`** emits cohort scope when linked; `resolveRecordScope` defaults **only durable** records to cohort (H-002 fix: scratch/ephemeral now stay worktree-local).
- **Consolidation log + finalize-reward-sweep** route through vetted root (GAP-3/GAP-4 fixes; M-011 fix for the consolidation-log CLI command).
- **Consolidation-log CLI** reads via vetted root (M-011 fix).

### Migration engine
- **Memory family migration** under `proper-lockfile`. SQLite non-empty destinations merge via ATTACH + INSERT OR IGNORE (single-quote escaped — M-001 fix). Per-table failures tracked + warned (M-002 fix). Backup files capped at 5 (H-008 fix).
- **NOT atomic across the multi-member family** (H-004 honest documentation) — pointer-flipped-last + idempotent retry is the recovery mechanism.

### Commands
- `/swarm memory link`, `/swarm memory link status`, `/swarm memory unlink` (3 registered commands; PR body initially undercounted as 2 — PRR-025 fix).
- Unlink `--no-copy` message corrected (Esper3.1 bot fix).

### Status / diagnostics
- `**Memory Cohort**` block in `/swarm status` (distinct from `**Knowledge Cohort**`). Renders provider + config fingerprint match (final-critic fix).
- Diagnostics block includes `config_fingerprint_match` (KC-002 fix).

## Invariant audit

- 1 (plugin init): **not touched** — `src/index.ts:734-746` unchanged; `createMemoryLifecycleHooks` adds only a sync pointer read. `resolveVettedMemoryRoot` warns when link is disabled but a pointer exists (C-001-config).
- 2 (runtime portability): **touched** — no top-level `bun:` imports; plugin shape unchanged. `bun run build` succeeds; bundle tests pass.
- 3 (subprocesses): **not touched** — `proper-lockfile` is file-based.
- 4 (.swarm containment): **touched** — cohort roots live in the platform data dir. `validateSwarmPath` untouched. Cohort paths resolver-constructed from sanitized linkIds.
- 5 (plan durability): **not touched**.
- 6 (test_runner safety): **not touched**.
- 7 (test writing): **touched** — 10 new test files, all <500 lines, `bun:test`, env-var save/restore in afterEach (C-TI fixes).
- 8 (session state): **touched** — provider pool gains cohort dimension; FIFO eviction unchanged.
- 9 (guardrails/retry): **not touched**.
- 10 (chat/system msg): **not touched**.
- 11 (tool registration): **touched** — 3 new commands; `drift:check` clean.
- 12 (release/cache): **touched** — release fragment with honest Known limitations.

## Test plan

```
$ bunx tsc --noEmit -p tsconfig.json
(clean)

$ bun biome ci .
(clean — 0 errors, 0 warnings)

$ bun test tests/unit/memory/ tests/unit/commands/memory-link.test.ts tests/unit/config/memory-config.test.ts
725 pass, 0 fail, 2606 expect() calls

$ bun run build && bun test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts
12 pass, 0 fail

$ node --input-type=module -e "const m = await import('./dist/index.js'); console.log(typeof m.default?.server)"
function

$ bun run drift:check
✅ No drift detected
```

## Acceptance criteria

| # | Criterion | Status |
|---|---|---|
| 1 | opt-in default off | ✅ |
| 2 | status distinguishes + provider/config/privacy health | ✅ (provider + fingerprint rendered; privacy = via redaction policy version in fingerprint) |
| 3 | only validated root; `validateSwarmPath` not weakened | ✅ |
| 4 | all readers/writers use vetted root | ✅ (gateway, consolidation-log, finalize-reward-sweep, CLI) |
| 5 | SQLite pooled, bounded, closed before migration | ✅ |
| 6 | JSONL cross-process transactional | PARTIAL (append-union idempotent; no cross-process lock on hot-path appends — documented limitation) |
| 7 | family migrated atomically + rollback | PARTIAL (recoverable via pointer-flipped-last + idempotent retry; NOT atomic across multi-member family — documented) |
| 8 | two sibling worktrees write/recall | PARTIAL (mechanism tested: F-22 round-trip with real data, F-27..F-31 gateway integration; no cross-process spawn test — test debt) |
| 9 | session/run state isolated | ✅ (F-15, F-31) |
| 10 | mismatch fails closed | ✅ (SQLite + JSONL both enforce; F-25 mismatch-throw test) |
| 11 | partial migration recoverable | PARTIAL (idempotent retry + backup cap; no crash/busy/corrupt-index test — test debt) |
| 12 | no IO in synchronous init | ✅ |
| 13 | privacy/redaction provenance preserved | ✅ (F-20 no-leak; provenance fields stamped) |

## Known limitations (test debt for follow-up PRs)
- **Cross-process two-worktree integration test** (acceptance #8 end-to-end) — not in this PR.
- **WAL/checkpoint/busy/crash behavioral test** (acceptance #6, #11) — not in this PR.
- **Migration atomicity** — recoverable but not single-shot atomic across the family.
- **Mixed-provider cohort** — fingerprint covers provider mismatch but JSONL hot-path appends are not cross-process locked.
