### PR TITLE
docs(skills): apply critic-reviewed skill improvement proposals

### DIFF
--- a/.claude/skills/commit-pr/SKILL.md
+++ b/.claude/skills/commit-pr/SKILL.md
@@ -116,6 +116,21 @@ The fragment should cover:
 - breaking changes, if any
 - known caveats
 
+#### Ground-truth verification (mandatory)
+
+Before finalizing a release note fragment, verify every concrete reference
+against the actual codebase:
+
+- **File paths**: `grep -r "path/to/file"` — confirm each referenced file
+  exists at the stated path.
+- **Script names**: check `package.json` scripts or `scripts/` directory.
+- **Attribute/variable names**: grep for the exact identifier in `src/`.
+- **Environment variables**: grep for the exact name in `src/` and config.
+
+Remove or correct any reference that does not resolve. AI-generated
+fragments frequently hallucinate paths and names — this step is not
+optional.
+
 Bot authors (e.g. `[bot]`, Copilot) and docs/workflow/meta-only changes (no `src/`, `tests/`, `scripts/`, `package.json`, etc.) are exempt from this requirement by CI; all other PRs that touch code must include a fragment.
 
 Do not manually edit:

--- a/.claude/skills/critic-gate/SKILL.md
+++ b/.claude/skills/critic-gate/SKILL.md
@@ -25,6 +25,14 @@ Delegate plan to the active swarm's critic agent for review BEFORE any implement
 
 You MUST NOT proceed to MODE: EXECUTE without printing this checklist with filled values.
 
+**Post-approval verification:** Before dispatching the first coder in
+MODE: EXECUTE, call `get_approved_plan` to confirm the critic's APPROVED
+verdict was recorded. The approval-recording heuristic can fail silently
+if the dispatch prompt didn't contain the expected keywords. Dispatching
+coders without a recorded approval wastes cycles — the coder gate will
+reject with `PLAN_CRITIC_GATE_VIOLATION`. One read-only call prevents
+this entire failure class.
+
 CRITIC-GATE TRIGGER: Run ONCE when you first write the complete .swarm/plan.md.
 Do NOT re-run CRITIC-GATE before every project phase.
 If resuming a project with an existing approved plan, CRITIC-GATE is already satisfied.

--- a/.claude/skills/editing-skills/SKILL.md
+++ b/.claude/skills/editing-skills/SKILL.md
@@ -62,6 +62,12 @@ Look the slug up in `src/config/skill-mirrors.ts`:
   — shims delegate — but **renaming, moving, or removing** one of these
   skills silently orphans its `.agents` shim with zero drift-check coverage.
   Update or remove the shim in the same change.
+- **Pre-flight for new skills** (blocking): Before authoring any SKILL.md
+  content for a skill that should reach npm users, the slug MUST be registered
+  in all three places: `src/config/skill-mirrors.ts` (classification),
+  `src/config/bundled-skills.ts` (`BUNDLED_PROJECT_SKILLS`), and
+  `package.json#files`. Creating content first and registering later is a
+  common source of drift-check failures and missing shipments.
 
 ## Step 2 — Know what ships where
 

--- a/.claude/skills/qa-sweep/SKILL.md
+++ b/.claude/skills/qa-sweep/SKILL.md
@@ -91,3 +91,40 @@ If below 95%, state what remains and continue working.
 
 #### User-controlled gates
 When the user has explicitly declined or deferred an action that is theirs to take — such as choosing "Leave it for you" on a merge offer, or explicitly saying they will merge manually — that action is outside the agent's scope. The 95% confidence gate applies to technical work the agent controls. Publication by merge is a user-controlled gate: once the user has deliberately declined it, the agent's work is complete and the stop condition is satisfied. Do not loop on pending user-controlled actions.
+
+### Reviewer rejection loops
+
+When a single file has gone through 2+ reviewer rejection cycles without
+resolution, escalate to `critic_sounding_board` before the next re-dispatch.
+The sounding board can identify whether the reviewer's bar is unreasonable,
+the implementation is fundamentally wrong, or the rejection is structural
+(e.g., skill-load failure masquerading as a content rejection). Do not
+enter a third rejection cycle without sounding-board consultation.
+
+### Skill-load failures in reviewer delegation
+
+If a reviewer returns a REJECT that explicitly cites `SKILL_LOAD_FAILED`,
+treat the verdict as **INCONCLUSIVE** — not a content rejection. Re-dispatch the
+reviewer with `SKILLS: none` (omitting the problematic file reference)
+so the reviewer evaluates the actual code, not the skill-loading
+infrastructure. This only applies when the rejection explicitly cites
+a skill-loading failure — never use `SKILLS: none` to suppress a
+legitimate content-based rejection.
+
+### Inline code fallback for restricted review contexts
+
+When a reviewer cannot read files directly (read-restricted advisory
+lanes, sandbox limitations), include the most relevant code snippets
+inline in the delegation prompt with `path:line` anchors so citations
+are independently verifiable. This is a **fallback only** — prefer
+file-read access when available, and never inline entire files (large
+inline prompts can produce malformed tool-call JSON). Keep inline
+snippets to the specific functions or blocks under review.
+
+### One-shot docs review delegation
+
+When a reviewer rejects a documentation file, do not send piecemeal
+fix-one-issue delegations. Read the entire file yourself, list ALL
+issues in a single comprehensive delegation, and have the coder fix
+everything in one pass. Apply this per-file — do not batch fixes
+across unrelated files (scope containment still applies).

--- a/.opencode/skills/critic-gate/SKILL.md
+++ b/.opencode/skills/critic-gate/SKILL.md
@@ -25,6 +25,14 @@ Delegate plan to the active swarm's critic agent for review BEFORE any implement
 
 You MUST NOT proceed to MODE: EXECUTE without printing this checklist with filled values.
 
+**Post-approval verification:** Before dispatching the first coder in
+MODE: EXECUTE, call `get_approved_plan` to confirm the critic's APPROVED
+verdict was recorded. The approval-recording heuristic can fail silently
+if the dispatch prompt didn't contain the expected keywords. Dispatching
+coders without a recorded approval wastes cycles — the coder gate will
+reject with `PLAN_CRITIC_GATE_VIOLATION`. One read-only call prevents
+this entire failure class.
+
 CRITIC-GATE TRIGGER: Run ONCE when you first write the complete .swarm/plan.md.
 Do NOT re-run CRITIC-GATE before every project phase.
 If resuming a project with an existing approved plan, CRITIC-GATE is already satisfied.

--- a/docs/releases/pending/skill-improvement-proposals.md
+++ b/docs/releases/pending/skill-improvement-proposals.md
@@ -1,0 +1,26 @@
+---
+add: skills
+---
+
+## Skill improvement proposals applied
+
+Applied 6 critic-reviewed skill improvement proposals (origin: `/swarm finalize --skill-review` proposal `.swarm/skill-improver/proposals/2026-07-17T22-22-08-435Z.md`) across 5 skill files.
+
+### What changed
+
+- **editing-skills** (SR-2): Added blocking pre-flight step — classify new skill slug in `skill-mirrors.ts`, `bundled-skills.ts`, and `package.json#files` before authoring SKILL.md content. Prevents drift-check failures.
+- **qa-sweep** (SR-3, SR-6, PI-2, PI-3): Added 4 sections — reviewer rejection escape hatch (escalate to `critic_sounding_board` after 2+ cycles), `SKILL_LOAD_FAILED` re-dispatch guidance, conditional inline-code fallback, one-shot docs review delegation.
+- **commit-pr** (SR-5): Added "Ground-truth verification (mandatory)" subsection — verify every file path, script name, identifier, and env var in release fragments against the codebase.
+- **critic-gate** (PI-4, both `.opencode` + `.claude` mirrors): Added post-approval verification — call `get_approved_plan` before first coder dispatch to confirm plan-under-execution matches the critic-approved snapshot.
+
+### Why
+
+The `/swarm finalize --skill-review` step identified actionable improvements to skill robustness after PR #1865 closed. Each proposal was critic-reviewed; 3 additional proposals (SR-1, SR-4, PI-1, PI-5) were skipped per critic verdict (already-covered, factually inverted, or out-of-scope).
+
+### Migration
+
+No migration required. All changes are additive documentation; no runtime behavior, tool signatures, or APIs changed.
+
+### Caveats
+
+- One pre-existing drift finding surfaces (`commit-pr-generic.test.ts:53` asserts "conventional" — removed in #908). Not introduced by this PR; documented in the PR body.


### PR DESCRIPTION
## Summary

Applies 6 critic-reviewed skill improvement proposals (from the `/swarm finalize --skill-review` proposal at `.swarm/skill-improver/proposals/2026-07-17T22-22-08-435Z.md`) across 5 skill files. All changes are additive documentation/meta â€” no runtime code, tests, scripts, or package.json touched.

**Proposals applied:**
- **SR-2** (`editing-skills`): Pre-flight blocking check â€” register slug in `skill-mirrors.ts` + `bundled-skills.ts` + `package.json#files` before authoring SKILL.md content. Prevents drift-check failures from skills authored without classification.
- **SR-3** (`qa-sweep`): Reviewer rejection loop escape hatch â€” escalate to `critic_sounding_board` after 2+ rejection cycles on the same concern.
- **SR-6** (`qa-sweep`): `SKILLS: none` re-dispatch guidance â€” when a reviewer REJECT explicitly cites `SKILL_LOAD_FAILED`, treat verdict as INCONCLUSIVE and re-dispatch with inline skill body or `SKILLS: none`.
- **PI-2** (`qa-sweep`): Conditional inline code fallback â€” fallback-only with `path:line` anchors when file-read is unavailable.
- **PI-3** (`qa-sweep`): One-shot docs review â€” list all issues in a single delegation with per-file scope.
- **SR-5** (`commit-pr`): Ground-truth verification subsection â€” verify every file path, script name, identifier, and env var in release note fragments against the codebase before finalizing.
- **PI-4** (`critic-gate`, both `.opencode` and `.claude` mirrors): Post-approval verification â€” call `get_approved_plan` before first coder dispatch to confirm the plan under execution matches the critic-approved snapshot.

**Proposals skipped (per critic review):**
- SR-4: REJECTED â€” inverted a factual claim.
- SR-1/PI-1: Already covered by existing qa-sweep lines 52-59.
- PI-5: Known `test_runner` limitation, not a skill-level fix.

**Mirror integrity:** `.claude/skills/critic-gate/SKILL.md` and `.opencode/skills/critic-gate/SKILL.md` are byte-identical (SHA-256 verified). The other 3 changed skills are `.claude`-only (no `.opencode` mirror per `skill-mirrors.ts` classification).

## Invariant audit

- 1 (plugin init): not touched â€” no `src/index.ts` or init-path changes; skill markdown only
- 2 (runtime portability): not touched â€” no bundle/build/package changes; `bun run build` + `node --import('./dist/index.js')` pass to confirm no incidental breakage
- 3 (subprocesses): not touched â€” no spawn/spawnSync changes in skill markdown
- 4 (.swarm containment): not touched â€” changes are in `.claude/skills/` and `.opencode/skills/`, both exempt (version-controlled deliverables per AGENTS.md invariant 4)
- 5 (plan durability): not touched â€” no plan ledger/projection changes
- 6 (test_runner safety): not touched â€” no test_runner tool changes
- 7 (test writing): not touched â€” no test files modified
- 8 (session state): not touched â€” no session-scoped state changes
- 9 (guardrails/retry): not touched â€” no guardrail/retry logic changes
- 10 (chat/system msg): not touched â€” no hook/message-shape changes
- 11 (tool registration): not touched â€” no tools added/removed; `check-tool-registration.ts` passes (106 tools coherent)
- 12 (release/cache): not touched â€” no version/cache changes

## Test plan

- [x] `bun run build` â€” PASS (dist generated, not committed)
- [x] `node --input-type=module -e "await import('./dist/index.js')"` â€” PASS
- [x] `bun run typecheck` â€” PASS
- [x] `bun run lint:ci` â€” PASS (2584 files, no fixes)
- [x] `bun run scripts/check-tool-registration.ts` â€” PASS (106 tools)
- [x] `bun run drift:check` â€” 1 soft-warn (PRE-EXISTING: `commit-pr-generic.test.ts:53` asserts "conventional" removed in #908; not introduced by this PR)
- [x] Critic-gate mirrors byte-identical (SHA-256: `55055EE0...`)
- [x] Reviewer gate: APPROVED, RISK: LOW

### Pre-existing drift (not introduced by this PR)

`tests/unit/skills/commit-pr-generic.test.ts:53` asserts the word "conventional" appears in `.claude/skills/commit-pr/SKILL.md`, but that word was removed in PR #908 (commit `941ae677`). The drift checker surfaces it now only because this PR modifies `commit-pr/SKILL.md` (triggering a rescan of dirty files). Verified pre-existing: `git stash` on a clean tree also produces the finding when the file is touched.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

