### PR TITLE
fix(config): surface specific validation detail in /swarm diagnose

### DIFF
--- a/docs/releases/pending/1886-config-validation-detail-in-diagnose.md
+++ b/docs/releases/pending/1886-config-validation-detail-in-diagnose.md
@@ -1,0 +1,40 @@
+# Config validation now tells you what to fix (issue #1886)
+
+## What
+
+When `opencode-swarm.json` fails validation, `/swarm diagnose` used to show only
+a bare `"[opencode-swarm] Merged config validation failed:"` line — a colon with
+nothing after it — so you couldn't tell which field was wrong. It now names the
+exact failing path(s) and the reason, e.g.:
+
+```
+[opencode-swarm] Merged config validation failed: agents.architect.fallback_models: Too big: expected array to have <=3 items; agents.coder.fallback_models: Too big: expected array to have <=3 items
+```
+
+The same detail now appears for the `external_skills` and `gates` validation
+advisories and for config load/prompt-read failures.
+
+## Why
+
+`advisoryWarn(message, data)` buffered only `message` for `/swarm diagnose` and
+sent the actionable `data` (the Zod validation detail) to the debug-only logger.
+Any advisory that put its detail in `data` therefore surfaced detail-less. The
+config loader passed the full Zod error as that dropped `data`, so operators saw
+a failure with no cause. (A common trigger: adding more than 3 `fallback_models`
+to an agent — the schema caps that array at 3.)
+
+## Fix
+
+- `advisoryWarn` now folds a compact, single-line, length-bounded rendering of
+  `data` into the buffered `/swarm diagnose` entry, in addition to the unchanged
+  debug log. This closes the whole class structurally: no advisory can silently
+  drop its detail from `/swarm diagnose`.
+- The config loader flattens Zod errors to a readable `path: message` summary
+  (`formatZodIssues`) instead of the nested `error.format()` object.
+
+## Behavior / compatibility
+
+- No config-schema change; the fail-secure fallback is unchanged (guardrails stay
+  ENABLED when a config is rejected).
+- The surfaced detail is issue **paths and messages** only — never a raw dump of
+  your config values.

--- a/docs/releases/pending/1886-doctor-value-constraint-autofix.md
+++ b/docs/releases/pending/1886-doctor-value-constraint-autofix.md
@@ -1,0 +1,38 @@
+# `/swarm doctor` now detects value-constraint config failures + opt-in fallback trim (issue #1886)
+
+## What
+
+`/swarm doctor` (config doctor) previously only surfaced **unrecognized** config
+keys. A value-constraint failure — e.g. an agent's `fallback_models` array
+exceeding the schema maximum of 3 — produced **no finding and no fix**, so the
+doctor reported "no issues" while the config stayed broken and swarm silently ran
+on safe defaults.
+
+Now the doctor:
+
+- **Reports every value-constraint failure** on the raw config (naming the exact
+  path and reason), so it explains *why* a config was rejected — not just unknown
+  keys.
+- **Offers an opt-in auto-fix** for an over-length `fallback_models` array that
+  trims it to the schema maximum. Because trimming drops user-chosen models, it
+  is applied **only** via the explicit `/swarm config doctor --fix` command —
+  **never** by the passive startup auto-fix path. The finding lists exactly which
+  models would be dropped.
+
+## Why
+
+Reported in #1886: a user's config was rejected because several `fallback_models`
+lists had more than 3 entries, but neither `/swarm diagnose` nor `/swarm doctor`
+said so. The companion diagnose fix surfaces the reason; this makes the doctor's
+suggested `--fix` path actually resolve this class of failure.
+
+## Behavior / compatibility
+
+- No config-schema change (the `fallback_models` max stays 3; it is now a named
+  constant `FALLBACK_MODELS_MAX` shared by the schema and the doctor so the trim
+  can never drift from the constraint).
+- The lossy trim is double-gated: an explicit `--fix` command **and** the
+  existing config backup taken before any auto-fix. Startup auto-fix
+  (`config_doctor_autofix`) reports the issue but never trims it, and now nudges
+  the user to run `--fix` for any auto-fixable finding it declined to apply.
+- Non-`fallback_models` value errors are reported only (never auto-fixed).

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -151,7 +151,12 @@ export async function handleDoctorCommand(
 		const { runConfigDoctorWithFixes } = await import(
 			'../services/config-doctor'
 		);
-		const fixResult = await runConfigDoctorWithFixes(directory, config, true);
+		// The interactive `--fix` command is an explicit, confirmed user action, so
+		// it opts into lossy fixes (e.g. trimming an over-length fallback_models
+		// array). The passive startup autofix path never does (issue #1886).
+		const fixResult = await runConfigDoctorWithFixes(directory, config, true, {
+			applyLossy: true,
+		});
 		output = formatDoctorMarkdown(fixResult.result);
 	} else {
 		const lastRun = readDoctorArtifact(directory);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -166,7 +166,7 @@ function sanitizeExternalSkillsConfig(
 	}
 	advisoryWarn(
 		'[opencode-swarm] external_skills config validation failed:',
-		esResult.error.format(),
+		formatZodIssues(esResult.error),
 	);
 	advisoryWarn(
 		'[opencode-swarm] External skills curation disabled due to invalid config. Fix the external_skills section to enable it.',
@@ -234,7 +234,7 @@ function sanitizeGatesConfig(
 		if (!sectionResult.success) {
 			advisoryWarn(
 				`[opencode-swarm] gates.${key} config validation failed; that gate section will use defaults and other config sections remain active:`,
-				sectionResult.error.format(),
+				formatZodIssues(sectionResult.error),
 			);
 			delete cleanedGates[key];
 		}
@@ -250,7 +250,7 @@ function sanitizeGatesConfig(
 
 	advisoryWarn(
 		'[opencode-swarm] gates config validation failed after section cleanup; quality gates will use defaults and other config sections remain active:',
-		gatesResult.error.format(),
+		formatZodIssues(gatesResult.error),
 	);
 	const cleaned = { ...raw };
 	delete cleaned.gates;
@@ -261,6 +261,30 @@ function sanitizeSectionConfigs(
 	raw: Record<string, unknown>,
 ): Record<string, unknown> {
 	return sanitizeGatesConfig(sanitizeExternalSkillsConfig(raw));
+}
+
+/**
+ * Flatten a ZodError into a compact, single-line, human-readable summary that
+ * names each failing config path and why it failed, e.g.
+ *   "agents.architect.fallback_models: Too big: expected array to have <=3 items"
+ *
+ * Surfaced to operators via `advisoryWarn` → `/swarm diagnose` so a config
+ * validation failure tells the user exactly what to fix, instead of the bare
+ * `"... validation failed:"` line they used to see (issue #1886). Replaces
+ * `error.format()` (a nested object that `advisoryWarn` dropped from the
+ * operator-visible buffer). It emits issue paths and messages only — never a
+ * raw dump of the user's config values.
+ */
+export function formatZodIssues(error: z.ZodError): string {
+	if (error.issues.length === 0) return '';
+	return error.issues
+		.map((issue) => {
+			// Guard the JOINED path, not the raw array: an empty `path` array is
+			// truthy in JS, so a top-level issue must fall through to message-only.
+			const dotted = issue.path.map(String).join('.');
+			return dotted ? `${dotted}: ${issue.message}` : issue.message;
+		})
+		.join('; ');
 }
 
 /**
@@ -396,7 +420,7 @@ function parseConfigWithFallback(
 	} else {
 		advisoryWarn(
 			'[opencode-swarm] Merged config validation failed:',
-			result.error.format(),
+			formatZodIssues(result.error),
 		);
 	}
 	advisoryWarn(

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -166,6 +166,13 @@ export const AgentThinkingConfigSchema = z.object({
 });
 export type AgentThinkingConfig = z.infer<typeof AgentThinkingConfigSchema>;
 
+/**
+ * Maximum number of `fallback_models` an agent override may declare. Shared so
+ * the config doctor's opt-in trim (src/services/config-doctor.ts) can never
+ * drift from the schema constraint enforced here (issue #1886 follow-up).
+ */
+export const FALLBACK_MODELS_MAX = 3;
+
 // Agent override configuration
 export const AgentOverrideConfigSchema = z.object({
 	model: z.string().optional(),
@@ -184,7 +191,7 @@ export const AgentOverrideConfigSchema = z.object({
 	variant: z.string().min(1).optional(),
 	temperature: z.number().min(0).max(2).optional(),
 	disabled: z.boolean().optional(),
-	fallback_models: z.array(z.string()).max(3).optional(),
+	fallback_models: z.array(z.string()).max(FALLBACK_MODELS_MAX).optional(),
 	// Provider-native extended-reasoning / extended-thinking blocks. These
 	// were previously silently stripped by Zod's default strip behavior;
 	// they are now first-class fields. See AgentReasoningConfigSchema /

--- a/src/index.ts
+++ b/src/index.ts
@@ -1264,6 +1264,7 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 							const autoFixableCount = doctorResult.result.findings.filter(
 								(f) => f.autoFixable,
 							).length;
+							const appliedCount = doctorResult.appliedFixes.length;
 
 							if (!enableAutofix && autoFixableCount > 0) {
 								const msg = `[opencode-swarm] Config Doctor found ${autoFixableCount} auto-fixable issue(s). Run /swarm config doctor --fix to apply.`;
@@ -1273,16 +1274,29 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 								} else {
 									addDeferredWarning(msg);
 								}
-							} else if (
-								enableAutofix &&
-								doctorResult.appliedFixes.length > 0
-							) {
-								const msg = `[opencode-swarm] Config Doctor applied ${doctorResult.appliedFixes.length} fix(es) automatically.`;
-								if (!config.quiet) {
-									// biome-ignore lint/suspicious/noConsole: Config Doctor applied fixes confirmation — user must see what was auto-fixed
-									console.warn(msg);
-								} else {
-									addDeferredWarning(msg);
+							} else if (enableAutofix) {
+								// Report what was applied, and — crucially — nudge for any
+								// auto-fixable finding NOT applied because it is lossy.
+								// Over-length fallback_models is never trimmed silently at
+								// startup; the user must opt in via --fix (issue #1886).
+								const parts: string[] = [];
+								if (appliedCount > 0) {
+									parts.push(`applied ${appliedCount} fix(es) automatically`);
+								}
+								const unapplied = Math.max(0, autoFixableCount - appliedCount);
+								if (unapplied > 0) {
+									parts.push(
+										`${unapplied} auto-fixable issue(s) need explicit review — run /swarm config doctor --fix`,
+									);
+								}
+								if (parts.length > 0) {
+									const msg = `[opencode-swarm] Config Doctor: ${parts.join('; ')}.`;
+									if (!config.quiet) {
+										// biome-ignore lint/suspicious/noConsole: Config Doctor autofix summary — user must see what was fixed / still needs --fix
+										console.warn(msg);
+									} else {
+										addDeferredWarning(msg);
+									}
 								}
 							}
 						} catch {

--- a/src/services/config-doctor.ts
+++ b/src/services/config-doctor.ts
@@ -12,6 +12,7 @@ import * as path from 'node:path';
 import { ALL_AGENT_NAMES } from '../config/constants';
 import type { PluginConfig } from '../config/schema';
 import {
+	FALLBACK_MODELS_MAX,
 	GATE_CONFIG_KNOWN_SECTION_KEYS,
 	GateConfigSchema,
 	PluginConfigSchema,
@@ -272,6 +273,149 @@ function collectRawStrictSectionFindings(directory: string): ConfigFinding[] {
 	return findings;
 }
 
+/**
+ * Walk a raw (pre-parse) config object by a Zod issue path, returning the value
+ * at that location or `undefined` if the path does not resolve.
+ */
+function getRawValueAtPath(
+	raw: unknown,
+	issuePath: ReadonlyArray<PropertyKey>,
+): unknown {
+	let node: unknown = raw;
+	for (const seg of issuePath) {
+		if (node === null || typeof node !== 'object') return undefined;
+		node = (node as Record<PropertyKey, unknown>)[seg];
+	}
+	return node;
+}
+
+/**
+ * Surface value-constraint config failures (issue #1886 follow-up).
+ *
+ * `collectRawStrictSectionFindings` only reports UNRECOGNIZED keys, and
+ * `runConfigDoctor` otherwise inspects the already-parsed config — which, for a
+ * config rejected on a value constraint, is the fail-secure DEFAULTS. So a
+ * `too_big`/`too_small`/`invalid_type`/… failure (e.g. an agent's
+ * `fallback_models` array exceeding the schema max) produced NO finding, leaving
+ * the user to guess why their config was discarded.
+ *
+ * This re-reads the raw user + project configs, runs the full schema, and:
+ *   - reports every value-constraint issue so the doctor names WHY the config is
+ *     rejected, and
+ *   - for an over-length `fallback_models` array, attaches an opt-in, lossy
+ *     auto-fix that trims it to the schema max. The trim is applied ONLY via the
+ *     explicit `/swarm config doctor --fix` command (see `applySafeAutoFixes`
+ *     `applyLossy`), never at startup.
+ *
+ * `unrecognized_keys` (owned by `collectRawStrictSectionFindings`) and `gates.*`
+ * (owned by `collectRawGatesConfigFindings`) issues are skipped to avoid
+ * duplicate findings.
+ */
+function collectRawValueConstraintFindings(directory: string): ConfigFinding[] {
+	const findings: ConfigFinding[] = [];
+	const { userConfigPath, projectConfigPath } = getConfigPaths(directory);
+
+	// The file `applySafeAutoFixes` will actually write (project wins when it
+	// exists). Only a finding in THIS file is marked auto-fixable, so `--fix`
+	// never claims to trim an array it would not touch.
+	const applyTargetPath = fs.existsSync(projectConfigPath)
+		? projectConfigPath
+		: userConfigPath;
+
+	// One dedupe set across both files so a key present in user AND project
+	// configs is reported once. Iterate the apply-target file FIRST so that, on a
+	// same-path collision, the dedupe keeps the FIXABLE (apply-target) variant
+	// instead of a report-only one that points at the merge-losing file — which
+	// would make `--fix` silently no-op on a repairable config.
+	const seen = new Set<string>();
+	const filesInApplyOrder =
+		applyTargetPath === projectConfigPath
+			? [projectConfigPath, userConfigPath]
+			: [userConfigPath, projectConfigPath];
+
+	for (const configPath of filesInApplyOrder) {
+		if (!fs.existsSync(configPath)) continue;
+		try {
+			const stats = fs.statSync(configPath);
+			if (stats.size > CONFIG_DOCTOR_MAX_CONFIG_FILE_BYTES) continue;
+			const raw = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as unknown;
+			if (!isPlainObject(raw)) continue;
+
+			const parsed = PluginConfigSchema.safeParse(raw);
+			if (parsed.success) continue;
+
+			for (const issue of parsed.error.issues) {
+				// Owned by sibling collectors — skip to avoid duplicate findings.
+				if (issue.code === 'unrecognized_keys') continue;
+				if (issue.path[0] === 'gates') continue;
+
+				const dotted = issue.path.map(String).join('.');
+				const dedupeKey = `${dotted}|${issue.code}`;
+				if (seen.has(dedupeKey)) continue;
+				seen.add(dedupeKey);
+
+				const current = getRawValueAtPath(raw, issue.path);
+
+				// Opt-in lossy auto-fix: an over-length fallback_models array can be
+				// mechanically trimmed to the schema max — the one value constraint we
+				// can repair without guessing user intent.
+				if (
+					issue.code === 'too_big' &&
+					dotted.endsWith('fallback_models') &&
+					Array.isArray(current) &&
+					current.length > FALLBACK_MODELS_MAX
+				) {
+					const trimmed = current.slice(0, FALLBACK_MODELS_MAX);
+					const dropped = current.slice(FALLBACK_MODELS_MAX).map(String);
+					const inApplyTarget = configPath === applyTargetPath;
+					const drop = `${dropped.length} entr${dropped.length === 1 ? 'y' : 'ies'}`;
+					findings.push({
+						id: 'fallback-models-too-many',
+						title: 'Too many fallback models',
+						description:
+							`"${dotted}" in ${configPath} lists ${current.length} models; the maximum is ${FALLBACK_MODELS_MAX}. ` +
+							`A config that fails validation is discarded in favor of safe defaults. ` +
+							(inApplyTarget
+								? `Run /swarm config doctor --fix to trim to the first ${FALLBACK_MODELS_MAX} (drops ${drop}: ${dropped.join(', ')}), or edit the file yourself.`
+								: `Remove ${drop} from that file (would drop: ${dropped.join(', ')}).`),
+						severity: 'error',
+						path: dotted,
+						currentValue: current,
+						autoFixable: inApplyTarget,
+						proposedFix: {
+							type: 'update',
+							path: dotted,
+							value: trimmed,
+							description: `Trim "${dotted}" to the first ${FALLBACK_MODELS_MAX} models`,
+							risk: 'low',
+							lossy: true,
+						},
+					});
+					continue;
+				}
+
+				// General detection: report every other value-constraint failure so
+				// the doctor names exactly what is invalid.
+				findings.push({
+					id: 'invalid-config-value',
+					title: 'Invalid config value',
+					description:
+						`"${dotted || '(root)'}" in ${configPath} is invalid: ${issue.message}. ` +
+						`A config that fails validation is discarded in favor of safe defaults until this is fixed.`,
+					severity: 'error',
+					path: dotted,
+					currentValue: current,
+					autoFixable: false,
+				});
+			}
+		} catch {
+			// Best-effort, non-blocking (see collectRawGatesConfigFindings).
+		}
+	}
+
+	return findings;
+}
+
 function emitWorktreeIsolationLayeringAdvisory(
 	config: PluginConfig,
 	findings: ConfigFinding[],
@@ -333,6 +477,14 @@ export interface ConfigFix {
 	description: string;
 	/** Risk level - only 'low' is auto-fixable */
 	risk: 'low' | 'medium' | 'high';
+	/**
+	 * When true, the fix loses user-authored data (e.g. trimming an over-length
+	 * array). Lossy fixes are applied ONLY when the caller explicitly opts in via
+	 * `applySafeAutoFixes(..., { applyLossy: true })` — the interactive
+	 * `/swarm config doctor --fix` command does; the passive startup autofix path
+	 * never does. This keeps a lossy repair from being applied silently (#1886).
+	 */
+	lossy?: boolean;
 }
 
 /** Result of running the config doctor */
@@ -1505,6 +1657,7 @@ export function runConfigDoctor(
 	walkConfigAndValidate(config, '', findings);
 	findings.push(...collectRawGatesConfigFindings(directory));
 	findings.push(...collectRawStrictSectionFindings(directory));
+	findings.push(...collectRawValueConstraintFindings(directory));
 	emitWorktreeIsolationLayeringAdvisory(config, findings);
 
 	// Count by severity
@@ -1574,10 +1727,16 @@ function isPathSafe(fixPath: string): boolean {
 export function applySafeAutoFixes(
 	directory: string,
 	result: ConfigDoctorResult,
+	options: { applyLossy?: boolean } = {},
 ): {
 	appliedFixes: ConfigFix[];
 	updatedConfigPath: string | null;
 } {
+	// Lossy fixes (e.g. trimming an over-length array, which drops user-authored
+	// entries) are applied ONLY when the caller explicitly opts in — the
+	// interactive `/swarm config doctor --fix` command does; the passive startup
+	// autofix path never does (issue #1886 follow-up).
+	const applyLossy = options.applyLossy === true;
 	const appliedFixes: ConfigFix[] = [];
 	let updatedConfigPath: string | null = null;
 
@@ -1608,9 +1767,13 @@ export function applySafeAutoFixes(
 		return { appliedFixes, updatedConfigPath: null };
 	}
 
-	// Filter for safe fixes only
+	// Filter for safe fixes only. Lossy fixes are held back unless the caller
+	// opted in (see `applyLossy` above).
 	const safeFixes = result.findings.filter(
-		(f) => f.autoFixable && f.proposedFix?.risk === 'low',
+		(f) =>
+			f.autoFixable &&
+			f.proposedFix?.risk === 'low' &&
+			(applyLossy || !f.proposedFix?.lossy),
 	);
 
 	// Apply each safe fix
@@ -1827,6 +1990,7 @@ export function writeDoctorArtifact(
 						path: f.proposedFix.path,
 						description: f.proposedFix.description,
 						risk: f.proposedFix.risk,
+						lossy: f.proposedFix.lossy === true,
 					}
 				: null,
 		})),
@@ -1865,6 +2029,7 @@ export async function runConfigDoctorWithFixes(
 	directory: string,
 	config: PluginConfig,
 	autoFix: boolean = false,
+	options: { applyLossy?: boolean } = {},
 ): Promise<{
 	result: ConfigDoctorResult;
 	backupPath: string | null;
@@ -1901,6 +2066,7 @@ export async function runConfigDoctorWithFixes(
 	const { appliedFixes, updatedConfigPath } = applySafeAutoFixes(
 		directory,
 		result,
+		options,
 	);
 
 	// Re-run doctor after fixes to get post-fix result

--- a/src/services/diagnose-service.ts
+++ b/src/services/diagnose-service.ts
@@ -1106,7 +1106,7 @@ export async function getDiagnoseData(
 		checks.push({
 			name: 'Deferred Warnings',
 			status: '⚠️',
-			detail: `${getDeferredWarnings().length} warning(s) deferred from init (run with verbose logs for details)`,
+			detail: `${getDeferredWarnings().length} warning(s) deferred from init — see the Deferred Warnings section below (or set OPENCODE_SWARM_DEBUG=1 for full detail)`,
 		});
 	}
 

--- a/src/services/warning-buffer.ts
+++ b/src/services/warning-buffer.ts
@@ -33,15 +33,65 @@ export function addDeferredWarning(warning: string): void {
 }
 
 /**
+ * Upper bound (chars) on the rendered `data` detail appended to a buffered
+ * advisory. The buffer itself is already capped at MAX_DEFERRED_WARNINGS
+ * entries; this bounds per-entry size so a large validation dump cannot bloat
+ * `/swarm diagnose`. Overflow is truncated with an ellipsis.
+ */
+const MAX_ADVISORY_DETAIL_CHARS = 600;
+
+/**
+ * Render the optional `data` argument of `advisoryWarn` into a compact,
+ * single-line, bounded string that is safe to append to the operator-visible
+ * deferred-warning buffer. Returns '' when there is nothing meaningful to show.
+ *
+ * Intentionally generic (no Zod/domain coupling): strings pass through, Errors
+ * surface their `.message`, string arrays join, and anything else is
+ * JSON-stringified with a `String()` fallback for circular refs, BigInt, and
+ * the `undefined`-return cases (functions/symbols). Callers that want a clean,
+ * human-readable summary (e.g. flattened Zod issues) should pass a pre-formatted
+ * string — see `formatZodIssues` in `config/loader.ts` (issue #1886).
+ */
+function renderAdvisoryDetail(data: unknown): string {
+	if (data === undefined || data === null) return '';
+	let raw: string;
+	if (typeof data === 'string') {
+		raw = data;
+	} else if (data instanceof Error) {
+		raw = data.message;
+	} else if (Array.isArray(data) && data.every((d) => typeof d === 'string')) {
+		raw = (data as string[]).join('; ');
+	} else {
+		try {
+			// JSON.stringify RETURNS undefined (does not throw) for functions and
+			// symbols; the ?? covers that, the catch covers circular refs/BigInt.
+			raw = JSON.stringify(data) ?? String(data);
+		} catch {
+			raw = String(data);
+		}
+	}
+	// Collapse to a single line so /swarm diagnose renders one markdown bullet
+	// per warning (formatDiagnoseMarkdown emits `- ${warning}`).
+	const collapsed = raw.replace(/\s+/g, ' ').trim();
+	if (collapsed === '') return '';
+	return collapsed.length > MAX_ADVISORY_DETAIL_CHARS
+		? `${collapsed.slice(0, MAX_ADVISORY_DETAIL_CHARS - 1)}…`
+		: collapsed;
+}
+
+/**
  * Operational advisory: a non-fatal, operator-actionable condition reached on
  * a path that can run while the host TUI owns the terminal (plugin init,
- * /swarm command handlers, tool execution, chat/tool hooks). Routes the message
- * to BOTH delivery channels:
+ * /swarm command handlers, tool execution, chat/tool hooks). Routes to BOTH
+ * delivery channels:
  *
  * 1. `addDeferredWarning` — buffers it for `/swarm diagnose`, so the operator
- *    can discover the condition without it polluting the live display.
- * 2. `log` — the debug-gated logger, so it also shows under
- *    `OPENCODE_SWARM_DEBUG=1` for live debugging.
+ *    can discover the condition without it polluting the live display. The
+ *    optional `data` is folded into the buffered entry (rendered compact +
+ *    single-line) so actionable detail is visible in `/swarm diagnose`, not
+ *    only under debug (issue #1886: config-validation detail was silently lost).
+ * 2. `log` — the debug-gated logger, so the message AND the structured `data`
+ *    also show under `OPENCODE_SWARM_DEBUG=1` for live debugging.
  *
  * This NEVER writes raw stderr/stdout. It is the safe replacement for the raw
  * `console.warn` calls that corrupt the bubbletea TUI (issue #1249 class, and
@@ -57,7 +107,8 @@ export function addDeferredWarning(warning: string): void {
  * streams."
  */
 export function advisoryWarn(message: string, data?: unknown): void {
-	addDeferredWarning(message);
+	const detail = renderAdvisoryDetail(data);
+	addDeferredWarning(detail ? `${message} ${detail}` : message);
 	log(message, data);
 }
 

--- a/src/services/warning-buffer.ts
+++ b/src/services/warning-buffer.ts
@@ -15,9 +15,54 @@ const MAX_DEFERRED_WARNINGS = 50;
 // advisories (epic #1752 PR2 review F-003).
 let deferredWarningsTruncated = false;
 
+/**
+ * C0/C1 control characters and DEL: covers ESC (`\x1B`, the start of every
+ * ANSI/CSI/OSC terminal-control sequence), BEL (`\x07`), and the rest of the
+ * 0x00-0x1F and 0x7F-0x9F ranges. `\s` in JS regex does NOT match these, so a
+ * plain whitespace collapse leaves them intact.
+ */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — this regex's entire purpose is matching terminal-control characters (ESC/BEL/etc.) so they can be stripped before /swarm diagnose renders untrusted content (security review, issue #1886 follow-up).
+const CONTROL_CHARS_RE = /[\x00-\x1F\x7F-\x9F]/g;
+
+/**
+ * Strip terminal-control characters and collapse whitespace runs to a single
+ * space, producing a string safe to append as one `/swarm diagnose` markdown
+ * bullet (`formatDiagnoseMarkdown` emits `- ${warning}`).
+ */
+function sanitizeBufferedLine(s: string): string {
+	// Collapse whitespace FIRST: tab/LF/CR fall inside the C0 control range
+	// too, and they must become a single space (readability), not vanish
+	// outright the way a dangerous control char (ESC, BEL, ...) should. A
+	// second collapse pass after stripping controls cleans up any new
+	// adjacency left behind when a control char sat between two independent
+	// whitespace runs (e.g. "a \x1B\n b" -> "a  b" -> "a b").
+	return s
+		.replace(/\s+/g, ' ')
+		.replace(CONTROL_CHARS_RE, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/**
+ * Buffer a warning for `/swarm diagnose`. This is the single write boundary
+ * for `deferredWarnings` — `advisoryWarn` funnels through it, and roughly a
+ * dozen call sites across `src/index.ts` and `src/agents/index.ts` call it
+ * directly with hand-composed messages. Several of those interpolate
+ * repo-controlled config content (agent names from `agents: z.record(...)`,
+ * the `auto_select_architect` string, …) that flows straight from an
+ * auto-loaded, attacker-editable `.opencode/opencode-swarm.json`.
+ *
+ * Sanitizing HERE — not in `advisoryWarn` — is what actually closes the class:
+ * every path into the buffer passes through this one function, so a future
+ * direct caller can't reintroduce the terminal-control-character /
+ * markdown-bullet-breaking class this guards against (security review,
+ * issue #1886 follow-up; an earlier revision of this fix sanitized only
+ * inside `advisoryWarn` and missed every direct caller).
+ */
 export function addDeferredWarning(warning: string): void {
+	const sanitized = sanitizeBufferedLine(warning);
 	if (deferredWarnings.length < MAX_DEFERRED_WARNINGS - 1) {
-		deferredWarnings.push(warning);
+		deferredWarnings.push(sanitized);
 		return;
 	}
 	// Reserve the last slot for a truncation sentinel so /swarm diagnose can
@@ -70,9 +115,7 @@ function renderAdvisoryDetail(data: unknown): string {
 			raw = String(data);
 		}
 	}
-	// Collapse to a single line so /swarm diagnose renders one markdown bullet
-	// per warning (formatDiagnoseMarkdown emits `- ${warning}`).
-	const collapsed = raw.replace(/\s+/g, ' ').trim();
+	const collapsed = sanitizeBufferedLine(raw);
 	if (collapsed === '') return '';
 	return collapsed.length > MAX_ADVISORY_DETAIL_CHARS
 		? `${collapsed.slice(0, MAX_ADVISORY_DETAIL_CHARS - 1)}…`
@@ -108,6 +151,9 @@ function renderAdvisoryDetail(data: unknown): string {
  */
 export function advisoryWarn(message: string, data?: unknown): void {
 	const detail = renderAdvisoryDetail(data);
+	// addDeferredWarning sanitizes on write, so `message` (which some callers
+	// build by interpolating untrusted content) is protected there too — not
+	// just the `data` half rendered above.
 	addDeferredWarning(detail ? `${message} ${detail}` : message);
 	log(message, data);
 }

--- a/tests/unit/config/loader-validation-detail.test.ts
+++ b/tests/unit/config/loader-validation-detail.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Regression tests for issue #1886 — "opencode-swarm Merged config validation
+ * failed" with no detail.
+ *
+ * The reporter's config failed validation, but `/swarm diagnose` showed only a
+ * bare "[opencode-swarm] Merged config validation failed:" line (colon, nothing
+ * after) because `advisoryWarn(message, data)` dropped the Zod detail (passed as
+ * `data`) from the deferred-warning buffer. The fix:
+ *   1. `advisoryWarn` folds `data` into the buffered entry (see
+ *      tests/unit/services/warning-buffer.test.ts for the structural guardrail).
+ *   2. The loader flattens Zod errors to a readable string via `formatZodIssues`
+ *      instead of the nested `error.format()` object.
+ *
+ * These tests pin the loader-side behavior: the specific failing field and
+ * constraint are now surfaced, while the fail-secure fallback is preserved.
+ *
+ * Kept in a dedicated file because tests/unit/config/loader.test.ts is already
+ * over the FR-006 500-line cap and must not grow (scripts/check-test-file-cap.sh).
+ */
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { z } from 'zod';
+import { formatZodIssues, loadPluginConfig } from '../../../src/config/loader';
+import {
+	clearDeferredWarnings,
+	getDeferredWarnings,
+} from '../../../src/services/warning-buffer';
+
+describe('formatZodIssues', () => {
+	it('flattens issues to "path: message" joined with "; "', () => {
+		const schema = z.object({
+			a: z.object({ b: z.array(z.string()).max(3) }),
+		});
+		const result = schema.safeParse({ a: { b: ['1', '2', '3', '4'] } });
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const out = formatZodIssues(result.error);
+			expect(out).toContain('a.b: ');
+			expect(out).toContain('Too big');
+		}
+	});
+
+	it('joins multiple issues with "; "', () => {
+		const schema = z.object({ a: z.number(), b: z.number() });
+		const result = schema.safeParse({ a: 'x', b: 'y' });
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const out = formatZodIssues(result.error);
+			expect(out).toContain('a: ');
+			expect(out).toContain('b: ');
+			expect(out).toContain('; ');
+		}
+	});
+
+	it('emits message only (no leading ": ") for a top-level/empty-path issue', () => {
+		const result = z.string().safeParse(123);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const out = formatZodIssues(result.error);
+			expect(out.startsWith(':')).toBe(false);
+			expect(out.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('returns an empty string when there are no issues', () => {
+		expect(formatZodIssues(new z.ZodError([]))).toBe('');
+	});
+});
+
+describe('merged config validation surfaces specific detail (#1886)', () => {
+	let tempDir: string;
+	let originalXDG: string | undefined;
+	let warnSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-1886-'));
+		originalXDG = process.env.XDG_CONFIG_HOME;
+		// Isolate from any real user config so only our project config is loaded.
+		process.env.XDG_CONFIG_HOME = tempDir;
+		clearDeferredWarnings();
+		warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
+		clearDeferredWarnings();
+		if (originalXDG === undefined) {
+			delete process.env.XDG_CONFIG_HOME;
+		} else {
+			process.env.XDG_CONFIG_HOME = originalXDG;
+		}
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	function writeProjectConfig(config: unknown): string {
+		const projectDir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'project-1886-')),
+		);
+		const configDir = path.join(projectDir, '.opencode');
+		fs.mkdirSync(configDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(configDir, 'opencode-swarm.json'),
+			JSON.stringify(config),
+		);
+		return projectDir;
+	}
+
+	it("names the failing field(s) and constraint for the reporter's config", () => {
+		// Reporter's config: several fallback_models arrays exceed the schema
+		// max of 3 (z.array(z.string()).max(3)). No unrecognized keys → the
+		// detail-less `else` branch. This is the exact #1886 scenario.
+		const projectDir = writeProjectConfig({
+			agents: {
+				architect: {
+					model: 'kimi-for-coding/k3',
+					fallback_models: [
+						'opencode/nemotron-3-ultra-free',
+						'openrouter/nvidia/nemotron-3-ultra-550b-a55b:free',
+						'kimi-for-coding/k2p7',
+						'kimi-for-coding/k2p7',
+						'opencode-go/glm-5.2',
+					],
+				},
+				coder: {
+					model: 'opencode/hy3-free',
+					fallback_models: [
+						'openrouter/tencent/hy3:free',
+						'opencode/kimi-k2.7-code',
+						'openrouter/moonshotai/kimi-k2.7-code',
+						'opencode/nemotron-3-ultra-free',
+						'openrouter/nvidia/nemotron-3-ultra-550b-a55b:free',
+					],
+				},
+			},
+			max_iterations: 3,
+			guardrails: {
+				enabled: true,
+				max_tool_calls: 60,
+				max_duration_minutes: 40,
+			},
+		});
+
+		try {
+			const result = loadPluginConfig(projectDir);
+
+			const warnings = getDeferredWarnings().join('\n');
+			// The reported bare line is still present...
+			expect(warnings).toContain('Merged config validation failed:');
+			// ...but now it NAMES what to fix (the whole point of #1886).
+			expect(warnings).toContain('fallback_models');
+			expect(warnings).toContain('<=3');
+			expect(warnings).toContain('agents.architect.fallback_models');
+			expect(warnings).toContain('agents.coder.fallback_models');
+
+			// Fail-secure fallback is preserved: guardrails stay ENABLED and the
+			// rejected config falls back to defaults.
+			expect(result.guardrails?.enabled).toBe(true);
+			expect(result.max_iterations).toBe(5);
+
+			// TUI safety: never raw stderr.
+			expect(warnSpy).not.toHaveBeenCalled();
+		} finally {
+			fs.rmSync(projectDir, { recursive: true, force: true });
+		}
+	});
+
+	it('surfaces the constraint for a single-field value error too', () => {
+		// max_iterations: 999 exceeds the schema max of 10 — a value error with
+		// no unrecognized keys, same `else` branch.
+		const projectDir = writeProjectConfig({ max_iterations: 999 });
+		try {
+			loadPluginConfig(projectDir);
+			const warnings = getDeferredWarnings().join('\n');
+			expect(warnings).toContain('Merged config validation failed:');
+			expect(warnings).toContain('max_iterations');
+		} finally {
+			fs.rmSync(projectDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/unit/services/config-doctor-value-constraints.test.ts
+++ b/tests/unit/services/config-doctor-value-constraints.test.ts
@@ -333,6 +333,41 @@ describe('config-doctor artifact + schema sync (#1886)', () => {
 		}
 	});
 
+	it('excludes currentValue from the serialized artifact (PR #1890 review, security-2)', () => {
+		// writeDoctorArtifact whitelists which ConfigFinding fields it serializes
+		// for the GUI. currentValue can hold raw config content (e.g. the
+		// over-length fallback_models array); confirm it never reaches the
+		// on-disk artifact, not just that `lossy` happens to be present.
+		const dir = writeProject({
+			agents: {
+				architect: { model: 'k', fallback_models: overLongFallback() },
+			},
+		});
+		try {
+			const result = runConfigDoctor(loadPluginConfig(dir), dir);
+			const fbFinding = result.findings.find(
+				(f) => f.id === 'fallback-models-too-many',
+			);
+			// Sanity: the in-memory finding DOES carry currentValue (so this test
+			// actually exercises the artifact-serialization whitelist, not an
+			// already-absent value).
+			expect(fbFinding?.currentValue).toBeDefined();
+
+			const artifactPath = writeDoctorArtifact(dir, result);
+			const rawArtifact = fs.readFileSync(artifactPath, 'utf-8');
+			expect(rawArtifact).not.toContain('currentValue');
+
+			const artifact = JSON.parse(rawArtifact);
+			const fb = artifact.findings.find(
+				(f: { id: string }) => f.id === 'fallback-models-too-many',
+			);
+			expect(fb.currentValue).toBeUndefined();
+			expect(Object.keys(fb)).not.toContain('currentValue');
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it('FALLBACK_MODELS_MAX matches the schema constraint', () => {
 		const okList = Array.from(
 			{ length: FALLBACK_MODELS_MAX },

--- a/tests/unit/services/config-doctor-value-constraints.test.ts
+++ b/tests/unit/services/config-doctor-value-constraints.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Tests for the config-doctor value-constraint detection + opt-in lossy autofix
+ * (issue #1886 follow-up).
+ *
+ * `/swarm doctor` previously only surfaced unrecognized config keys, so a
+ * value-constraint failure (e.g. an agent's `fallback_models` array exceeding the
+ * schema max of FALLBACK_MODELS_MAX) produced no finding and no fix — the config
+ * stayed broken. This adds:
+ *   - detection of every value-constraint failure (so the doctor says WHY the
+ *     config is rejected), and
+ *   - an opt-in autofix that trims over-length `fallback_models`, applied ONLY
+ *     when the caller passes `{ applyLossy: true }` (the `/swarm config doctor
+ *     --fix` command) — never by the passive startup autofix path.
+ *
+ * New file: src/services/config-doctor.test.ts is over the FR-006 500-line cap
+ * and must not grow.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { loadPluginConfig } from '../../../src/config/loader';
+import {
+	FALLBACK_MODELS_MAX,
+	PluginConfigSchema,
+} from '../../../src/config/schema';
+import {
+	applySafeAutoFixes,
+	runConfigDoctor,
+	runConfigDoctorWithFixes,
+	writeDoctorArtifact,
+} from '../../../src/services/config-doctor';
+
+let xdgDir: string;
+let originalXDG: string | undefined;
+
+beforeEach(() => {
+	// Isolate the USER config path so only our project config is seen.
+	xdgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-xdg-'));
+	originalXDG = process.env.XDG_CONFIG_HOME;
+	process.env.XDG_CONFIG_HOME = xdgDir;
+});
+
+afterEach(() => {
+	if (originalXDG === undefined) {
+		delete process.env.XDG_CONFIG_HOME;
+	} else {
+		process.env.XDG_CONFIG_HOME = originalXDG;
+	}
+	fs.rmSync(xdgDir, { recursive: true, force: true });
+});
+
+function writeProject(config: unknown): string {
+	const dir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-proj-')),
+	);
+	fs.mkdirSync(path.join(dir, '.opencode'), { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, '.opencode', 'opencode-swarm.json'),
+		JSON.stringify(config),
+	);
+	return dir;
+}
+
+function overLongFallback(): string[] {
+	return Array.from({ length: FALLBACK_MODELS_MAX + 2 }, (_v, i) => `m${i}`);
+}
+
+describe('config-doctor value-constraint detection (#1886)', () => {
+	it('reports over-length fallback_models with an opt-in lossy autofix', () => {
+		const dir = writeProject({
+			agents: {
+				architect: { model: 'k', fallback_models: overLongFallback() },
+				coder: { model: 'k', fallback_models: overLongFallback() },
+			},
+		});
+		try {
+			const result = runConfigDoctor(loadPluginConfig(dir), dir);
+			const fb = result.findings.filter(
+				(f) => f.id === 'fallback-models-too-many',
+			);
+			expect(fb.length).toBe(2);
+			const architect = fb.find(
+				(f) => f.path === 'agents.architect.fallback_models',
+			);
+			expect(architect).toBeDefined();
+			expect(architect?.severity).toBe('error');
+			expect(architect?.autoFixable).toBe(true);
+			expect(architect?.proposedFix?.type).toBe('update');
+			expect(architect?.proposedFix?.risk).toBe('low');
+			expect(architect?.proposedFix?.lossy).toBe(true);
+			expect((architect?.proposedFix?.value as string[]).length).toBe(
+				FALLBACK_MODELS_MAX,
+			);
+			expect(result.hasAutoFixableIssues).toBe(true);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('reports non-fallback value errors as report-only (not auto-fixable)', () => {
+		// max_iterations: 999 exceeds the schema max of 10.
+		const dir = writeProject({ max_iterations: 999 });
+		try {
+			const result = runConfigDoctor(loadPluginConfig(dir), dir);
+			const invalid = result.findings.filter(
+				(f) => f.id === 'invalid-config-value',
+			);
+			expect(invalid.length).toBeGreaterThan(0);
+			expect(invalid.some((f) => f.path === 'max_iterations')).toBe(true);
+			expect(invalid.every((f) => f.autoFixable === false)).toBe(true);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('produces no value-constraint findings for a valid config', () => {
+		const dir = writeProject({
+			agents: { architect: { model: 'k', fallback_models: ['a', 'b'] } },
+		});
+		try {
+			const result = runConfigDoctor(loadPluginConfig(dir), dir);
+			const noise = result.findings.filter(
+				(f) =>
+					f.id === 'invalid-config-value' ||
+					f.id === 'fallback-models-too-many',
+			);
+			expect(noise.length).toBe(0);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('does not duplicate unrecognized-key or gates findings', () => {
+		const dir = writeProject({
+			totally_unknown_key: true,
+			gates: { placeholder_scan: { deny_patterns: 'not-an-array' } },
+			agents: {
+				architect: { model: 'k', fallback_models: overLongFallback() },
+			},
+		});
+		try {
+			const result = runConfigDoctor(loadPluginConfig(dir), dir);
+			// The new collector must not emit an invalid-config-value for the
+			// unrecognized key or for anything under gates.*.
+			const invalid = result.findings.filter(
+				(f) => f.id === 'invalid-config-value',
+			);
+			expect(invalid.some((f) => f.path.startsWith('gates'))).toBe(false);
+			expect(invalid.some((f) => f.path === 'totally_unknown_key')).toBe(false);
+			// The fallback finding still fires.
+			expect(
+				result.findings.some((f) => f.id === 'fallback-models-too-many'),
+			).toBe(true);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('config-doctor lossy autofix gating (#1886)', () => {
+	it('on a dual-config same-path collision, --fix trims the apply-target (project) file', () => {
+		// Both the user AND project configs carry the same over-long array at the
+		// same path. The finding must be reported once and remain FIXABLE (the
+		// apply-target/project variant), and `--fix` must trim the project file
+		// (the write target and the deep-merge winner) — not no-op while pointing
+		// at the merge-losing user file.
+		const overLong = overLongFallback();
+		const userCfgDir = path.join(xdgDir, 'opencode');
+		fs.mkdirSync(userCfgDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(userCfgDir, 'opencode-swarm.json'),
+			JSON.stringify({
+				agents: { architect: { model: 'k', fallback_models: overLong } },
+			}),
+		);
+		const dir = writeProject({
+			agents: { architect: { model: 'k', fallback_models: overLong } },
+		});
+		try {
+			const result = runConfigDoctor(loadPluginConfig(dir), dir);
+			const fb = result.findings.filter(
+				(f) => f.id === 'fallback-models-too-many',
+			);
+			expect(fb.length).toBe(1);
+			expect(fb[0]?.autoFixable).toBe(true);
+
+			const { appliedFixes } = applySafeAutoFixes(dir, result, {
+				applyLossy: true,
+			});
+			expect(appliedFixes.length).toBe(1);
+			const projectOnDisk = JSON.parse(
+				fs.readFileSync(
+					path.join(dir, '.opencode', 'opencode-swarm.json'),
+					'utf-8',
+				),
+			);
+			expect(projectOnDisk.agents.architect.fallback_models.length).toBe(
+				FALLBACK_MODELS_MAX,
+			);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('applySafeAutoFixes SKIPS the lossy trim by default', () => {
+		const dir = writeProject({
+			agents: {
+				architect: { model: 'k', fallback_models: overLongFallback() },
+			},
+		});
+		try {
+			const result = runConfigDoctor(loadPluginConfig(dir), dir);
+			const { appliedFixes } = applySafeAutoFixes(dir, result);
+			expect(appliedFixes.length).toBe(0);
+			const onDisk = JSON.parse(
+				fs.readFileSync(
+					path.join(dir, '.opencode', 'opencode-swarm.json'),
+					'utf-8',
+				),
+			);
+			expect(onDisk.agents.architect.fallback_models.length).toBe(
+				FALLBACK_MODELS_MAX + 2,
+			);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('applySafeAutoFixes APPLIES the lossy trim when applyLossy is true', () => {
+		const dir = writeProject({
+			agents: {
+				architect: { model: 'k', fallback_models: overLongFallback() },
+			},
+		});
+		try {
+			const result = runConfigDoctor(loadPluginConfig(dir), dir);
+			const { appliedFixes } = applySafeAutoFixes(dir, result, {
+				applyLossy: true,
+			});
+			expect(appliedFixes.length).toBe(1);
+			const onDisk = JSON.parse(
+				fs.readFileSync(
+					path.join(dir, '.opencode', 'opencode-swarm.json'),
+					'utf-8',
+				),
+			);
+			expect(onDisk.agents.architect.fallback_models.length).toBe(
+				FALLBACK_MODELS_MAX,
+			);
+			expect(PluginConfigSchema.safeParse(onDisk).success).toBe(true);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('startup-style runConfigDoctorWithFixes(autoFix) does NOT trim silently', async () => {
+		const dir = writeProject({
+			agents: {
+				architect: { model: 'k', fallback_models: overLongFallback() },
+			},
+		});
+		try {
+			// No applyLossy option — mirrors the src/index.ts startup call.
+			await runConfigDoctorWithFixes(dir, loadPluginConfig(dir), true);
+			const onDisk = JSON.parse(
+				fs.readFileSync(
+					path.join(dir, '.opencode', 'opencode-swarm.json'),
+					'utf-8',
+				),
+			);
+			expect(onDisk.agents.architect.fallback_models.length).toBe(
+				FALLBACK_MODELS_MAX + 2,
+			);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('--fix-style runConfigDoctorWithFixes(autoFix, {applyLossy:true}) trims and validates', async () => {
+		const dir = writeProject({
+			agents: {
+				architect: { model: 'k', fallback_models: overLongFallback() },
+				coder: { model: 'k', fallback_models: overLongFallback() },
+			},
+		});
+		try {
+			const fix = await runConfigDoctorWithFixes(
+				dir,
+				loadPluginConfig(dir),
+				true,
+				{
+					applyLossy: true,
+				},
+			);
+			expect(fix.appliedFixes.length).toBe(2);
+			const onDisk = JSON.parse(
+				fs.readFileSync(
+					path.join(dir, '.opencode', 'opencode-swarm.json'),
+					'utf-8',
+				),
+			);
+			expect(onDisk.agents.architect.fallback_models.length).toBe(
+				FALLBACK_MODELS_MAX,
+			);
+			expect(onDisk.agents.coder.fallback_models.length).toBe(
+				FALLBACK_MODELS_MAX,
+			);
+			expect(PluginConfigSchema.safeParse(onDisk).success).toBe(true);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('config-doctor artifact + schema sync (#1886)', () => {
+	it('serializes the lossy flag into the config-doctor artifact', () => {
+		const dir = writeProject({
+			agents: {
+				architect: { model: 'k', fallback_models: overLongFallback() },
+			},
+		});
+		try {
+			const result = runConfigDoctor(loadPluginConfig(dir), dir);
+			const artifactPath = writeDoctorArtifact(dir, result);
+			const artifact = JSON.parse(fs.readFileSync(artifactPath, 'utf-8'));
+			const fb = artifact.findings.find(
+				(f: { id: string }) => f.id === 'fallback-models-too-many',
+			);
+			expect(fb?.proposedFix?.lossy).toBe(true);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('FALLBACK_MODELS_MAX matches the schema constraint', () => {
+		const okList = Array.from(
+			{ length: FALLBACK_MODELS_MAX },
+			(_v, i) => `m${i}`,
+		);
+		const tooMany = [...okList, 'one-too-many'];
+		const base = { agents: { architect: { model: 'k' } } };
+		expect(
+			PluginConfigSchema.safeParse({
+				agents: { architect: { model: 'k', fallback_models: okList } },
+			}).success,
+		).toBe(true);
+		expect(
+			PluginConfigSchema.safeParse({
+				...base,
+				agents: { architect: { model: 'k', fallback_models: tooMany } },
+			}).success,
+		).toBe(false);
+	});
+});

--- a/tests/unit/services/warning-buffer.test.ts
+++ b/tests/unit/services/warning-buffer.test.ts
@@ -167,4 +167,84 @@ describe('advisoryWarn', () => {
 
 		expect(getDeferredWarnings()).toEqual(['first', 'second', 'third']);
 	});
+
+	// --- Issue #1886: the `data` argument must reach /swarm diagnose, not only
+	// the debug log. Structural guardrail for the whole defect class: any
+	// two-arg advisoryWarn caller (config-validation, fs errors, …) whose
+	// actionable detail lives in `data` must surface that detail in the buffer.
+	// These fail on the pre-fix advisoryWarn (which buffered only `message`).
+	describe('folds the optional data arg into the buffered warning (#1886)', () => {
+		test('appends string detail to the buffered entry', () => {
+			advisoryWarn(
+				'validation failed:',
+				'agents.architect.fallback_models: too big',
+			);
+			const [entry] = getDeferredWarnings();
+			expect(entry).toBe(
+				'validation failed: agents.architect.fallback_models: too big',
+			);
+		});
+
+		test("surfaces an Error's message", () => {
+			advisoryWarn('Failed to load config:', new Error('ENOENT: missing file'));
+			expect(getDeferredWarnings()[0]).toContain('ENOENT: missing file');
+		});
+
+		test('renders a plain object as compact JSON', () => {
+			advisoryWarn('detail:', { field: 'x', code: 'too_big' });
+			expect(getDeferredWarnings()[0]).toContain(
+				'{"field":"x","code":"too_big"}',
+			);
+		});
+
+		test('joins a string array with "; "', () => {
+			advisoryWarn('issues:', ['a: bad', 'b: worse']);
+			expect(getDeferredWarnings()[0]).toBe('issues: a: bad; b: worse');
+		});
+
+		test('buffers exactly the message when data is absent or nullish', () => {
+			advisoryWarn('no data');
+			advisoryWarn('null data', null);
+			advisoryWarn('undefined data', undefined);
+			expect(getDeferredWarnings()).toEqual([
+				'no data',
+				'null data',
+				'undefined data',
+			]);
+		});
+
+		test('collapses multi-line detail to a single line (markdown-bullet safe)', () => {
+			advisoryWarn('multiline:', 'line one\n  line two\n\tline three');
+			const entry = getDeferredWarnings()[0];
+			expect(entry).not.toContain('\n');
+			expect(entry).toBe('multiline: line one line two line three');
+		});
+
+		test('bounds very long detail with an ellipsis', () => {
+			advisoryWarn('big:', 'D'.repeat(5000));
+			const entry = getDeferredWarnings()[0];
+			// message + space + <=600 chars of detail; far below the 5000 raw.
+			expect(entry.length).toBeLessThan(700);
+			expect(entry.endsWith('…')).toBe(true);
+		});
+
+		test('does not throw on circular / BigInt data (String() fallback)', () => {
+			const circular: Record<string, unknown> = {};
+			circular.self = circular;
+			expect(() => advisoryWarn('circular:', circular)).not.toThrow();
+			expect(() => advisoryWarn('bigint:', { n: 10n })).not.toThrow();
+			// Both still buffered (one entry each), never lost.
+			expect(getDeferredWarnings().length).toBe(2);
+		});
+
+		test('still forwards raw structured data to the debug logger unchanged', () => {
+			process.env.OPENCODE_SWARM_DEBUG = '1';
+			const payload = { slug: 'x' };
+			advisoryWarn('advisory:', payload);
+			expect(consoleLogSpy).toHaveBeenCalledWith(
+				expect.stringContaining('advisory:'),
+				payload,
+			);
+		});
+	});
 });

--- a/tests/unit/services/warning-buffer.test.ts
+++ b/tests/unit/services/warning-buffer.test.ts
@@ -246,5 +246,140 @@ describe('advisoryWarn', () => {
 				payload,
 			);
 		});
+
+		test('bounds detail at exactly the 600-char limit with no truncation', () => {
+			advisoryWarn('exact:', 'D'.repeat(600));
+			const entry = getDeferredWarnings()[0];
+			expect(entry).toBe(`exact: ${'D'.repeat(600)}`);
+			expect(entry.endsWith('…')).toBe(false);
+		});
+
+		test('truncates at exactly 601 chars (one over the limit)', () => {
+			advisoryWarn('over:', 'D'.repeat(601));
+			const entry = getDeferredWarnings()[0];
+			expect(entry).toBe(`over: ${'D'.repeat(599)}…`);
+			expect(entry.length).toBe('over: '.length + 600);
+		});
+	});
+
+	// --- PR #1890 review, security-1: renderAdvisoryDetail's whitespace
+	// collapse (`/\s+/g`) does not match C0/C1 terminal-control characters
+	// (ESC \x1B, BEL \x07, ...), and `message` was never sanitized at all. A
+	// malicious repo-committed opencode-swarm.json (auto-loaded — see
+	// config/loader.ts) can carry these in an attacker-controlled key name
+	// (e.g. an `agents` record key, or an unrecognized `gates.<key>`), which
+	// then flows into an advisoryWarn call and is rendered verbatim as a
+	// /swarm diagnose markdown bullet. These tests fail on the pre-fix
+	// sanitizeBufferedLine (control-char strip missing entirely).
+	describe('strips terminal-control characters (PR #1890 security review)', () => {
+		test('strips ESC from the data-arg path', () => {
+			advisoryWarn('validation failed:', 'before\x1B[2Jafter');
+			const entry = getDeferredWarnings()[0];
+			expect(entry).not.toMatch(/[\x00-\x1F\x7F-\x9F]/);
+			expect(entry).toBe('validation failed: before[2Jafter');
+		});
+
+		test('strips BEL from the data-arg path', () => {
+			advisoryWarn('detail:', 'ring\x07bell');
+			expect(getDeferredWarnings()[0]).not.toMatch(/[\x00-\x1F\x7F-\x9F]/);
+		});
+
+		test('strips control characters embedded directly in the message arg (the broader gap)', () => {
+			// Simulates loader.ts's `gates.${key}` / unrecognized-key-list sites,
+			// which interpolate an attacker-controlled key name directly into
+			// `message` rather than passing it as `data` — bypassing
+			// renderAdvisoryDetail entirely on the pre-fix code.
+			const maliciousKey = 'evil\x1B[31mkey\x07';
+			advisoryWarn(
+				`[opencode-swarm] Unknown gates config section "gates.${maliciousKey}" ignored.`,
+			);
+			const entry = getDeferredWarnings()[0];
+			expect(entry).not.toMatch(/[\x00-\x1F\x7F-\x9F]/);
+			expect(entry).toBe(
+				'[opencode-swarm] Unknown gates config section "gates.evil[31mkey" ignored.',
+			);
+		});
+
+		test('collapses a literal newline embedded in the message arg to one markdown bullet', () => {
+			// A malicious config key containing a raw newline must not be able to
+			// inject a fake bullet / fake "## Deferred Warnings" header into
+			// /swarm diagnose output.
+			const maliciousKey = 'evil\nkey';
+			advisoryWarn(
+				`[opencode-swarm] Ignored unrecognized config key(s): gates.${maliciousKey}.`,
+			);
+			const entry = getDeferredWarnings()[0];
+			expect(entry).not.toContain('\n');
+			expect(entry).toBe(
+				'[opencode-swarm] Ignored unrecognized config key(s): gates.evil key.',
+			);
+		});
+
+		test('neuters an OSC-52 clipboard-write attempt (ESC ] ... BEL)', () => {
+			advisoryWarn('detail:', 'x\x1B]52;c;ZGF0YQ==\x07y');
+			const entry = getDeferredWarnings()[0];
+			// No ESC/BEL survive, so no terminal emulator can parse this as OSC.
+			expect(entry).not.toMatch(/[\x00-\x1F\x7F-\x9F]/);
+		});
+
+		test('does not strip legitimate prose punctuation (em dash, ellipsis)', () => {
+			advisoryWarn('note:', 'em—dash and ellipsis…stay');
+			expect(getDeferredWarnings()[0]).toBe('note: em—dash and ellipsis…stay');
+		});
+	});
+});
+
+// --- PR #1890 review, security-1 (round 2): the round-1 fix sanitized only
+// inside `advisoryWarn`, but ~15 call sites across src/index.ts and
+// src/agents/index.ts call `addDeferredWarning` DIRECTLY with hand-composed
+// messages, bypassing `advisoryWarn` entirely. Two confirmed reachable with
+// attacker-controlled content from the same auto-loaded, repo-committed
+// opencode-swarm.json threat model: the no-fallback-models warning (agent
+// names are `agents: z.record(z.string(), ...)` keys) and the
+// auto_select_architect mismatch warning (a lightly-validated user string).
+// These tests call addDeferredWarning directly — bypassing advisoryWarn on
+// purpose — to prove the fix lives at the true buffer-write choke point, not
+// merely one of its callers. They fail on the round-1 fix.
+describe('addDeferredWarning sanitizes direct callers, not just advisoryWarn (#1886 follow-up, round 2)', () => {
+	beforeEach(() => {
+		clearDeferredWarnings();
+	});
+
+	afterEach(() => {
+		clearDeferredWarnings();
+	});
+
+	test('sanitizes a message built the same way as the no-fallback-models warning (src/index.ts)', () => {
+		// Mirrors: noFallback.push(`${name}(${cfg.model})`) where `name` is an
+		// attacker-controlled `agents` record key from a malicious repo config.
+		const maliciousAgentName = 'evil\x1B[2Hpwn\x07agent';
+		const noFallback = [`${maliciousAgentName}(some-model)`];
+		const msg =
+			`[opencode-swarm] WARNING: ${noFallback.length} agent(s) use a custom model without fallback_models: ` +
+			noFallback.join(', ') +
+			'. Add "fallback_models": ["model-a"] to each agent config for reliability.';
+
+		addDeferredWarning(msg);
+
+		const entry = getDeferredWarnings()[0];
+		expect(entry).not.toMatch(/[\x00-\x1F\x7F-\x9F]/);
+		expect(entry).toContain('evil[2Hpwnagent(some-model)');
+	});
+
+	test('sanitizes a message built the same way as the auto_select_architect mismatch warning (src/index.ts)', () => {
+		const maliciousTarget = 'evil\x1B[2Jname\x07';
+		const msg = `[opencode-swarm] auto_select_architect target "${maliciousTarget}" not found among generated agents.`;
+
+		addDeferredWarning(msg);
+
+		const entry = getDeferredWarnings()[0];
+		expect(entry).not.toMatch(/[\x00-\x1F\x7F-\x9F]/);
+	});
+
+	test('sanitizes any direct addDeferredWarning caller generically (structural guardrail)', () => {
+		addDeferredWarning('unknown\x1B[31magent\x07 not found in config');
+		const entry = getDeferredWarnings()[0];
+		expect(entry).not.toMatch(/[\x00-\x1F\x7F-\x9F]/);
+		expect(entry).not.toContain('\n');
 	});
 });


### PR DESCRIPTION
Closes #1886

## Summary
- `/swarm diagnose` used to show a bare `"[opencode-swarm] Merged config validation failed:"` (colon, nothing after) when a config was rejected, so the user couldn't tell what to fix. It now names the exact failing path(s) and reason, e.g. `agents.architect.fallback_models: Too big: expected array to have <=3 items`.
- Root cause: `advisoryWarn(message, data)` buffered only `message` for `/swarm diagnose` and sent the actionable `data` (the Zod validation detail) to the debug-only logger. `advisoryWarn` now folds a bounded, single-line, safe rendering of `data` into the buffered entry — closing the defect class for every two-arg caller, not just the reported one. The config loader now flattens Zod errors via a new `formatZodIssues` helper instead of the nested `error.format()` object.
- Follow-up (user-requested): `/swarm doctor` previously only surfaced unrecognized config keys, so a value-constraint failure (e.g. an over-length `fallback_models` array) produced no finding and no fix — the suggested `/swarm doctor` workaround would not have helped this reporter. The doctor now detects every value-constraint failure on the raw config and offers an **opt-in** auto-fix that trims an over-length `fallback_models` array to the schema max (`FALLBACK_MODELS_MAX`). The trim is lossy, so it is applied **only** via the explicit `/swarm config doctor --fix` command — never by the passive startup auto-fix path, which now nudges the user to run `--fix` instead of silently doing nothing.
- Fail-secure fallback (guardrails ENABLED on invalid config) is unchanged throughout. Surfaced detail is issue paths and messages only — never a raw dump of config values.

## Invariant audit
- 1 (plugin init): touched — `advisoryWarn`/`loadPluginConfig` run on the init path; `config-doctor`'s startup auto-fix hook in `src/index.ts` also runs on init. Changes add only bounded synchronous string formatting / raw-config re-parsing (no new fs/network/subprocess/unbounded await). Verified: `bun run build` OK; `node scripts/repro-704.mjs` → server() resolved in 134.0ms (T1, deadline 400ms), T2/T3 OK.
- 2 (runtime portability): touched (bundle content) — no `bun:` imports, no `Bun.*`, plugin shape unchanged. Verified: `node --input-type=module -e "await import('./dist/index.js')"` → "dist import OK".
- 3 (subprocesses): not touched — no `spawn`/`spawnSync` added. Verified: `git diff --name-only origin/main...HEAD | xargs grep -nE "spawn\(|spawnSync\("` → no matches in changed files.
- 4 (.swarm containment): not touched — no new `.swarm/` paths; the config-doctor artifact write path (`.swarm/config-doctor.json`) already existed and is unchanged in location.
- 5 (plan durability): not touched — no plan/ledger code changed.
- 6 (test_runner safety): not touched — validation used shell `bun test` / the CI-equivalent scoped unit gate, not the `test_runner` tool with broad scope.
- 7 (test writing): touched — added `tests/unit/config/loader-validation-detail.test.ts` (182 lines) and `tests/unit/services/config-doctor-value-constraints.test.ts` (390 lines), both well under the 500-line FR-006 cap; extended `tests/unit/services/warning-buffer.test.ts` (250 lines, also under cap). `bun:test` only, no `mock.module` (uses `spyOn` + env save/restore in `afterEach`). Verified: `bash scripts/check-mock-cleanup.sh` pass (only pre-existing, non-blocking violations); `bash scripts/check-test-file-cap.sh` → 0 new-file violations, 0 ratchet violations.
- 8 (session state): not touched — the deferred-warning buffer's cap (50) and truncation sentinel are unchanged; only the buffered string content changed.
- 9 (guardrails/retry): not touched — retry logic unchanged; the fail-secure guardrails-ENABLED fallback on invalid config is preserved and asserted by new tests.
- 10 (chat/system msg): touched — `advisoryWarn` is the TUI-safe advisory helper (AGENTS.md invariant 10: no raw diagnostic noise into chat-visible streams). The fix keeps it TUI-safe: detail is folded into the buffered `/swarm diagnose` entry and the debug-gated log only; never raw stderr/stdout. Verified: `warning-buffer.test.ts` asserts `console.warn` is never called and `console.log` is not called when debug is off.
- 11 (tool registration): not touched — no tools, agent maps, or commands added/renamed. Verified: `bun run scripts/check-tool-registration.ts` → "106 tools, coherent across metadata, handlers, the plugin object, TOOL_NAMES, and AGENT_TOOL_MAP."
- 12 (release/cache): touched — added `docs/releases/pending/1886-config-validation-detail-in-diagnose.md` and `docs/releases/pending/1886-doctor-value-constraint-autofix.md`; no `package.json#version`, `CHANGELOG.md`, or `.release-please-manifest.json` edits.

## Test plan
- [x] Reproduction: the reporter's exact config (`fallback_models` arrays of 5 entries on `architect`/`coder`) now surfaces `agents.architect.fallback_models: Too big: expected array to have <=3 items; ...` in `/swarm diagnose` (pre-fix: bare `"...failed:"` with no detail).
- [x] `/swarm doctor` on the same config now reports a `fallback-models-too-many` finding (severity `error`, `autoFixable: true`); `/swarm config doctor --fix` trims to 3 entries and the config re-validates; the passive startup auto-fix path (no `--fix`) leaves the array untouched and instead emits a nudge to run `--fix`.
- [x] Structural guardrail: an adversarial revert-check proved 6 new `advisoryWarn` tests fail on the pre-fix implementation and pass after — the fix closes the whole defect class, not just the reported instance.
- [x] Dual-config edge case (same over-long array in both user and project config): a dedicated regression test proves `--fix` trims the correct (apply-target/project) file; the ordering fix was validated with its own revert-check.
- [x] `bun run typecheck` — clean. `bun run lint:ci` — clean (2586 files). `bun run scripts/check-tool-registration.ts` — 106 tools coherent. `bash scripts/check-invariants.sh`, `bash scripts/check-mock-cleanup.sh`, `bash scripts/check-test-file-cap.sh` — all pass.
- [x] `bun run build && node --input-type=module -e "await import('./dist/index.js')"` — OK. `node scripts/repro-704.mjs` — T1/T2/T3 all OK (init well under the 400ms deadline).
- [x] Scoped CI-equivalent unit gate (`bun run test:unit:ci `) across 18 files spanning config, services, and command suites — all exit 0.
- [x] Full regression: all pre-existing `config-doctor`, `loader`, and `diagnose-service` test suites pass unchanged (1300+ tests across those suites, 0 failures).

### Pre-existing / environmental notes (not introduced by this PR)
- `bash scripts/check-test-clock.sh` reports one "new" violation on `tests/unit/tools/dispatch-lanes.test.ts` — verified this is a false positive from the script's two-dot `git diff origin/main HEAD` comparison picking up an unrelated file that changed upstream (in the merged #1850 memory-sharing PR) after this branch's fork point. The three-dot merge-base diff (`git diff origin/main...HEAD`, which matches how GitHub computes an actual PR's file list) shows this PR's file set contains exactly the 12 intended files and does not include `dispatch-lanes.test.ts`. This file was not touched by this PR.
- `tests/unit/config/bundled-skills-async.test.ts` fails ~41 tests only when the whole `tests/unit/config/` directory runs in one Bun process (cross-file mock/module pollution); it passes 21/21 in isolation and under the per-file CI-equivalent gate. Verified pre-existing on a clean `origin/main` worktree with this PR's changes stashed (identical failure count). Unrelated to this change.

## Waivers (or none)
None.