### PR TITLE
refactor(skills): progressive-disclosure restructure via references/ splits

### DIFF
--- a/.claude/skills/commit-pr/SKILL.md
+++ b/.claude/skills/commit-pr/SKILL.md
@@ -83,7 +83,7 @@ If this changeset edited any SKILL.md file's wording, also run `file:.swarm/bund
 
 ## Step 1 - Commit and PR titles
 
-Use `<type>(<scope>): <description>` exactly.
+Use conventional commit format `<type>(<scope>): <description>` exactly.
 
 - description is lowercase and does not end with a period
 - allowed types: `feat`, `fix`, `perf`, `revert`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`
@@ -139,18 +139,7 @@ Do not manually edit:
 - `CHANGELOG.md`
 - `.release-please-manifest.json` — exception: reconciliation when the manifest desyncs from actual releases (see below)
 
-### Release-please manifest desync
-
-`.release-please-manifest.json` is the version source of truth for release-please. If it desyncs from the actual published release (e.g., `7.26.0` in manifest but `v7.27.1` on GitHub), release-please will propose a version that goes backwards.
-
-**Common cause:** An older release PR (e.g., `chore(main): release 7.26.0`) merges after a newer one (`chore(main): release 7.27.1`). Both PRs modify the manifest, so the later one to merge wins — regardless of which version is higher.
-
-**Detection:** If a release-please PR proposes a version that seems too low, check:
-1. `gh release list --limit 5` — what's the latest published release?
-2. `git show origin/main:.release-please-manifest.json` — what does the manifest say?
-3. If different, the manifest is desynced.
-
-**Fix:** Open a PR that updates `.release-please-manifest.json` to match the actual latest release (e.g., `"7.27.1"`). Close the incorrect release PR with explanation. After the manifest fix merges, release-please will auto-create a correct release PR.
+For the full release-please manifest desync diagnosis and fix protocol, read `references/pr-incident-playbook.md`.
 
 ## Step 3 - Mandatory validation suite
 
@@ -158,8 +147,7 @@ Run the full validation stack before pushing. The exact commands may be narrowed
 
 ### Pre-flight
 
-`dist/` is generated output and is **not** committed (#1047). Confirm the build still
-succeeds and the bundle loads — do not stage `dist/`:
+`dist/` is not committed (#1047) — do not stage it. Confirm the build succeeds:
 
 ```bash
 bun run build
@@ -286,62 +274,17 @@ This requires `actions: write` permission on the base repository. See the `fork-
 
 Before `git push`, run both checks:
 
-#### Push protection scan
+1. **Push protection scan** — scan for literal secret patterns that trigger GitHub push protection:
+   ```bash
+   git log origin/main..HEAD -p | grep -E 'sk_live|ghp_|xox[abprs]-|AKIA|eyJ|AIza' || true
+   ```
+2. **Canonical remote resolution** — push to the canonical-org remote, not a personal fork:
+   ```bash
+   git remote -v   # identify the org-owned remote
+   git push -u <canonical-remote> <branch>
+   ```
 
-GitHub push protection blocks commits containing literal secret patterns. This bit the
-first commit of PR #1472 — a test file with a literal `sk_live_*` Stripe fixture
-pattern was pushed before the string-concatenation workaround was applied.
-
-**The primary check (pre-push, after commit exists):**
-
-```bash
-git log origin/main..HEAD -p | grep -E 'sk_live|ghp_|xox[abprs]-|AKIA|eyJ|AIza' || true
-```
-
-**The optional pre-commit add-on (staged changes only):**
-
-```bash
-git diff --cached | grep -E 'sk_live|ghp_|xox[abprs]-|AKIA|eyJ|AIza' || true
-```
-
-Forbidden patterns: Stripe (`sk_live_*`), GitHub (`ghp_*`), Slack (`xox[abprs]-*`),
-AWS (`AKIA*`), JWT (`eyJ*`), Google API (`AIza*`).
-
-**The fix:** Construct test fixtures via string concatenation rather than literal
-patterns. For example:
-
-```typescript
-// Wrong — triggers push protection:
-const stripeKey = 'sk_live_' + '1234567890abcdefghijklmn'
-
-// Right — split the literal so it never appears verbatim in source:
-const stripeKey = 'sk_' + 'live_' + '1234567890abcdefghijklmn'
-```
-
-> **Note:** This scan is a best-effort heuristic. It will not catch deliberately obfuscated patterns (e.g., base64 or hex encoding, runtime string assembly). For genuinely sensitive keys, use environment variables or a secret store — never commit credentials to source.
-
-#### Canonical remote resolution
-
-When a repo has multiple remotes (e.g. `zaxbysauce/opencode-swarm` and
-`ZaxbyHub/opencode-swarm`), pushing to the wrong remote causes `gh pr create` to
-fail with "No commits between <canonical>:main and <mirror>:<branch>". This happened
-on PR #1472.
-
-**The check:** `git remote -v` before push. Identify the canonical-org remote.
-
-**The rule:** Push to the canonical-org remote explicitly:
-
-```bash
-git push -u <canonical-remote> <branch>
-```
-
-Create the PR against the canonical repo:
-
-```bash
-gh pr create --repo <canonical-org>/<repo>
-```
-
-**Heuristic for identifying the canonical remote:** the canonical remote is the one whose URL points to the owning organization (e.g. `github.com/<org>/<repo>.git`), not a personal fork or mirror. When the owning org differs from the local fork's owner, the org-owned remote is canonical. Example: `github.com/ZaxbyHub/opencode-swarm.git` is canonical; `github.com/zaxbysauce/opencode-swarm.git` is a personal fork.
+For full details, patterns, workarounds, and anecdotes, read `references/pr-incident-playbook.md`.
 
 ## Step 6 - PR creation
 
@@ -430,7 +373,7 @@ The issue comment must include:
 3. how to use it
 4. migration steps or "No migration required"
 
-PowerShell-safe pattern:
+Uses the same UTF-8-no-BOM file-write pattern as Step 6 above.
 
 ````powershell
 $comment = @"
@@ -458,23 +401,7 @@ If the PR merged before this was done, post the missing issue comment immediatel
 
 ## Commit messages
 
-`git commit -m "..."` with parens, brackets, backticks, or dollar-signs in the message fails on PowerShell because the shell parses them as expressions. Write the commit message to a UTF-8 (no BOM) file first and use `git commit -F <file>`.
-
-PowerShell-safe pattern:
-
-```powershell
-$msg = @"
-<type>(<scope>): <description>
-
-<optional body — note this is for the git commit message, NOT the PR body>
-"@
-$utf8NoBom = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
-$commitMsgPath = Join-Path ([System.IO.Path]::GetTempPath()) "commit-msg.txt"
-[System.IO.File]::WriteAllText($commitMsgPath, $msg, $utf8NoBom)
-git commit -F $commitMsgPath
-```
-
-Apply this pattern for any commit message containing special characters, multi-paragraph bodies, or code blocks. The plain `git commit -m "..."` form remains fine for short single-line messages with no special characters.
+PowerShell parens/brackets/backticks/dollar-signs in `git commit -m "..."` fail. Use the same UTF-8-no-BOM file-write pattern (see Step 6), then `git commit -F <file>`.
 
 ## Step 7 - Existing PR follow-up and closeout
 
@@ -517,33 +444,7 @@ conflict is resolved.
 
 ### GitHub auto-merge race condition
 
-With a merge queue enabled, prefer queuing over manual freshness rebases, which
-avoids this race entirely. It can still occur if you rebase manually: when `main`
-advances while your PR is open, GitHub's PR sync machinery may **automatically push a
-merge commit to your branch** in the window between when you fetch and when you push.
-This is distinct from a conflict — it is GitHub creating a merge commit on your behalf
-without rebuilding generated outputs (lockfiles, etc.).
-
-Symptoms:
-- `git push` is rejected with "fetch first" even though you just fetched
-- `git log HEAD..origin/<branch>` shows a commit authored by GitHub/the repo owner with message `Merge branch 'main' into <branch>`
-- generated outputs (e.g. lockfiles) on that auto-merge commit are stale because it was not rebuilt
-
-Recovery:
-```bash
-git fetch origin <branch>
-git log HEAD..origin/<branch>   # confirm it's only the GitHub auto-merge
-# Your local commit is correct. Force-push it:
-git push origin <branch> --force-with-lease
-```
-
-After force-pushing, verify the PR head SHA updated and cancel any CI run
-targeting the superseded auto-merge SHA to unblock concurrency:
-
-```powershell
-gh run list --branch <branch> --limit 5 --json databaseId,headSha,status,workflowName
-gh run cancel <stale-run-id>
-```
+With a merge queue enabled, prefer queuing over manual freshness rebases. If you encounter "fetch first" errors after a fresh fetch, GitHub may have auto-pushed a merge commit. Recovery: force-push your local commit with `--force-with-lease`. See `references/pr-incident-playbook.md` for full diagnosis and recovery steps.
 
 ### Check closeout
 

--- a/.claude/skills/commit-pr/references/pr-incident-playbook.md
+++ b/.claude/skills/commit-pr/references/pr-incident-playbook.md
@@ -1,0 +1,101 @@
+# PR Incident Playbook
+
+## Release-please manifest desync
+
+`.release-please-manifest.json` is the version source of truth for release-please. If it desyncs from the actual published release (e.g., `7.26.0` in manifest but `v7.27.1` on GitHub), release-please will propose a version that goes backwards.
+
+**Common cause:** An older release PR (e.g., `chore(main): release 7.26.0`) merges after a newer one (`chore(main): release 7.27.1`). Both PRs modify the manifest, so the later one to merge wins — regardless of which version is higher.
+
+**Detection:** If a release-please PR proposes a version that seems too low, check:
+1. `gh release list --limit 5` — what's the latest published release?
+2. `git show origin/main:.release-please-manifest.json` — what does the manifest say?
+3. If different, the manifest is desynced.
+
+**Fix:** Open a PR that updates `.release-please-manifest.json` to match the actual latest release (e.g., `"7.27.1"`). Close the incorrect release PR with explanation. After the manifest fix merges, release-please will auto-create a correct release PR.
+
+## Push protection scan
+
+GitHub push protection blocks commits containing literal secret patterns. This bit the
+first commit of PR #1472 — a test file with a literal `sk_live_*` Stripe fixture
+pattern was pushed before the string-concatenation workaround was applied.
+
+**The primary check (pre-push, after commit exists):**
+
+```bash
+git log origin/main..HEAD -p | grep -E 'sk_live|ghp_|xox[abprs]-|AKIA|eyJ|AIza' || true
+```
+
+**The optional pre-commit add-on (staged changes only):**
+
+```bash
+git diff --cached | grep -E 'sk_live|ghp_|xox[abprs]-|AKIA|eyJ|AIza' || true
+```
+
+Forbidden patterns: Stripe (`sk_live_*`), GitHub (`ghp_*`), Slack (`xox[abprs]-*`),
+AWS (`AKIA*`), JWT (`eyJ*`), Google API (`AIza*`).
+
+**The fix:** Construct test fixtures via string concatenation rather than literal
+patterns. For example:
+
+```typescript
+// Wrong — triggers push protection:
+const stripeKey = 'sk_live_' + '1234567890abcdefghijklmn'
+
+// Right — split the literal so it never appears verbatim in source:
+const stripeKey = 'sk_' + 'live_' + '1234567890abcdefghijklmn'
+```
+
+> **Note:** This scan is a best-effort heuristic. It will not catch deliberately obfuscated patterns (e.g., base64 or hex encoding, runtime string assembly). For genuinely sensitive keys, use environment variables or a secret store — never commit credentials to source.
+
+## Canonical remote resolution
+
+When a repo has multiple remotes (e.g. `zaxbysauce/opencode-swarm` and
+`ZaxbyHub/opencode-swarm`), pushing to the wrong remote causes `gh pr create` to
+fail with "No commits between <canonical>:main and <mirror>:<branch>". This happened
+on PR #1472.
+
+**The check:** `git remote -v` before push. Identify the canonical-org remote.
+
+**The rule:** Push to the canonical-org remote explicitly:
+
+```bash
+git push -u <canonical-remote> <branch>
+```
+
+Create the PR against the canonical repo:
+
+```bash
+gh pr create --repo <canonical-org>/<repo>
+```
+
+**Heuristic for identifying the canonical remote:** the canonical remote is the one whose URL points to the owning organization (e.g. `github.com/<org>/<repo>.git`), not a personal fork or mirror. When the owning org differs from the local fork's owner, the org-owned remote is canonical. Example: `github.com/ZaxbyHub/opencode-swarm.git` is canonical; `github.com/zaxbysauce/opencode-swarm.git` is a personal fork.
+
+## GitHub auto-merge race condition
+
+With a merge queue enabled, prefer queuing over manual freshness rebases, which
+avoids this race entirely. It can still occur if you rebase manually: when `main`
+advances while your PR is open, GitHub's PR sync machinery may **automatically push a
+merge commit to your branch** in the window between when you fetch and when you push.
+This is distinct from a conflict — it is GitHub creating a merge commit on your behalf
+without rebuilding generated outputs (lockfiles, etc.).
+
+Symptoms:
+- `git push` is rejected with "fetch first" even though you just fetched
+- `git log HEAD..origin/<branch>` shows a commit authored by GitHub/the repo owner with message `Merge branch 'main' into <branch>`
+- generated outputs (e.g. lockfiles) on that auto-merge commit are stale because it was not rebuilt
+
+Recovery:
+```bash
+git fetch origin <branch>
+git log HEAD..origin/<branch>   # confirm it's only the GitHub auto-merge
+# Your local commit is correct. Force-push it:
+git push origin <branch> --force-with-lease
+```
+
+After force-pushing, verify the PR head SHA updated and cancel any CI run
+targeting the superseded auto-merge SHA to unblock concurrency:
+
+```powershell
+gh run list --branch <branch> --limit 5 --json databaseId,headSha,status,workflowName
+gh run cancel <stale-run-id>
+```

--- a/.opencode/skills/swarm-pr-feedback/SKILL.md
+++ b/.opencode/skills/swarm-pr-feedback/SKILL.md
@@ -101,75 +101,9 @@ rounds of review for N pushes, and budget for it.
 each round's work is bounded by new findings + carried-forward items only.
 This matches how the bot actually behaves and avoids wasted cycles.
 
-### Bot Review Verification Traps
+### Bot and Security Claim Verification
 
-When a bot or pasted review cites a code fact, verify the fact against the
-current branch before editing:
-
-- **Import/export claims:** Check the exact import path used by the changed file.
-  A symbol may be missing from an internal submodule but correctly exported by the
-  public barrel the tests or runtime actually import.
-- **Line numbers:** Treat bot line references as approximate after any follow-up
-  push or local edit. Re-locate the symbol or block with `rg` before patching.
-- **Ordering claims:** If the concern is about rule precedence, add or run a
-  direct precedence test that would fail under the wrong ordering; comments alone
-  are not enough.
-- **Disproved findings:** Do not change unrelated code to satisfy a false claim.
-  Keep the finding in the closure ledger with the source or test evidence that
-  disproves it.
-- **Cache/state claims:** Test both relevant state orders when the behavior
-  depends on cache priming, singleton state, or prior calls.
-
-### Automated Security Finding Verification
-
-This is a repository-agnostic verification checklist. Technology names and
-paths in the examples below are illustrative only: apply an example only when
-the reviewed repository actually uses that API, validator, runtime, or file
-layout, and otherwise translate the same origin-to-sink question to the
-repository's language and framework. No example creates a dependency on the
-opencode-swarm tree.
-
-Automated security bots can produce CRITICAL or HIGH false positives. Before
-acting on any bot security finding, perform these source-level checks:
-
-1. **`child_process.exec` vs `RegExp.exec`**: SAST rules pattern-match on
-   `.exec(` and cannot distinguish `child_process.exec(userInput)` (real
-   injection risk) from `/^pattern$/.exec(str)` (safe regex test). Read the
-   actual line to determine which `.exec` is called.
-
-2. **Schema validation already present**: Bots may flag "missing type
-   validation" without checking the Zod schema. Search for the field name in
-   `src/config/schema.ts` — `z.number().int()`, `z.string().min()`, etc. are
-   runtime validators that run before the code path the bot reviewed.
-
-3. **`Object.assign` mutation claims**: Bots may claim `Object.assign` mutates
-   the source object. Check whether the call is `Object.assign(target, source)`
-   (mutates target) vs `Object.assign({}, source)` or a manual copy loop into a
-   new `{}` (creates a new object, source is safe). Read the actual assignment.
-
-4. **Path containment for system-generated paths**: Bots may flag "path
-   traversal" on file paths. Check whether the path is user-controlled (real
-   risk) or system-generated from `provisionWorktree`, `mkdtempSync`, or
-   similar (no user input reaches the path). Trace the variable's origin.
-
-5. **Value validation vs key validation**: Bots may suggest validating env var
-   *values* for shell injection characters. Check whether the value is passed
-   through a sandbox executor that escapes arguments (e.g., `wrapCommand`
-   which returns a shell-quoted / `psStringEscape`-escaped string for the
-   `bunSpawn` array-form argv to consume). Value validation would break
-   legitimate env vars (PATH with `;`, URLs with `$`); escaping is the
-   sandbox's job — see `engineering-conventions` § "Sandbox env overrides"
-   for the full escape contract.
-
-6. **Deduplication for independent resources**: Bots may suggest deduplicating
-   cache redirects or env var entries. Check whether the entries map to
-   independent keys (different env var names) — independent keys cannot
-   "collide" and deduplication is nonsensical.
-
-**Rule:** For any bot finding rated CRITICAL or HIGH, read the actual source
-line AND its surrounding context (parent function, schema definition, type
-annotations) before accepting the finding. If the finding is disproved, record
-it in the closure ledger with the specific source evidence that disproves it.
+Before trusting automated review findings (SAST bots, security scanners, AI reviewers), apply the verification protocol in `references/bot-claim-verification.md`. Key principle: every bot claim is unverified until you reproduce the exact finding against the current HEAD with the exact tool and rule it names.
 
 ## Operating Stance
 
@@ -256,22 +190,12 @@ proceeding. The bundled `ci-failure-batching` skill is one conditional
 implementation; otherwise apply the host-neutral complete-ledger protocol
 below.
 
-The anti-pattern: iterating check-by-check, proposing a fix for one failure,
-pushing, waiting for CI, then discovering the next failure. Each cycle costs
-one push + one CI run.
+For the detailed 6-step batch collection protocol, read `file:.swarm/bundled-skills/ci-failure-batching/SKILL.md`. The steps below are a summary:
 
-**The fix:** Collect all failures and their logs in one batch operation before
-proposing any fix.
-
-1. `gh pr checks <n> --json name,bucket,state,link` — get every check,
-   its bucket/state, and the URL to its run details.
-2. Filter to failing checks (`bucket == "fail"` | `bucket == "cancel"`).
-3. For each failing check, extract the run ID from `link` and run
-   `gh run view <run-id> --log-failed` to fetch the full log output.
-4. Build a complete failure ledger: all checks + all failure logs collected.
-5. Triage the full ledger to identify root causes.
-6. Propose fixes for all failures in **one batch** — do not iterate
-   check-by-check through push cycles.
+1. `gh pr checks <number> --json name,bucket,state,link` to collect all check results
+2. Filter to `bucket == "fail"` or `bucket == "cancel"`
+3. `gh run view <id> --log-failed` for each failing run
+4. Group failures by root cause before fixing
 
 **Rule:** The complete failure ledger must be collected before any
 modification is proposed. Verifying the ledger is complete is a prerequisite
@@ -506,29 +430,9 @@ Verification checklist:
 - Check related tests and whether a failing/proposed test would prove the item.
 - Check whether multiple feedback items share one root cause.
 
-### DI seam migration validation (when the repository uses this pattern)
+### DI seam migration validation
 
-`_internals` and `mock.module()` below are JavaScript/TypeScript examples only.
-For another stack, apply the same live-binding question using that language and
-test runner's dependency-injection/mocking semantics.
-
-When a test file mutates a DI seam object (e.g., `_internals.foo = mock`),
-verify that the production source reads from the seam at call time. A common
-anti-pattern: the test mutates the seam object, but the production code
-imports the named function (`import { foo } from './module'`) which is bound
-at module load. The seam mutation has no effect on the named reference,
-so the test fails even though the seam object's `foo === mock`.
-
-Verification: open the source file and grep for call sites. If you see
-`import { foo } from '...'` followed by `foo(...)` in the production code,
-and the test does `_internals.foo = mock`, the test will fail. The fix is
-to change the production code to call `_internals.foo(...)` (or equivalent
-active-seam pattern) so the seam mutation is read at call time.
-
-If only a few call sites exist, fix them in the source. If many call sites
-exist, consider whether the migration should use `mock.module()` instead,
-which replaces the entire module object (including the named export
-reference).
+When the repository uses `_internals` seam / `mock.module()` patterns, apply the validation protocol in `references/operational-gotchas.md`.
 
 ## Fix Planning
 
@@ -571,27 +475,7 @@ or compatibility policy, mark the item `NEEDS_USER_DECISION` and ask.
 
 ### Conditional runtime/host gotchas
 
-Apply each item below only when the named plugin tool, plan model, shell, or
-code-host client is actually present. They are portability examples, not
-requirements imposed on unrelated repositories.
-
- - **Plan identity change:** When switching from a review plan to a feedback-closure
-   plan, `save_plan` rejects with `PLAN_IDENTITY_MISMATCH`. Pass
-   `confirm_identity_change: true` to acknowledge the intentional overwrite.
- - **Stale gate evidence:** After a plan identity change, `check_gate_status` returns
-   timestamps from the *prior* plan. Reset task statuses and re-run Stage A gates
-   before trusting gate results. Do not accept cached gate verdicts from before the
-   identity change.
- - **PowerShell PR comment posting:** Complex markdown bodies containing backticks,
-   dollar signs, or nested quotes fail in PowerShell here-strings. Write the body
-   to a temp file and use `gh pr comment <number> --body-file <tempfile>` instead
-   of inline `--body "..."`.
- - **Same-file batching:** Multiple findings targeting the same file for the same
-   review cycle CAN be fixed in one coder task when the fixes are trivially
-   independent (e.g., a one-line guard and a typo fix). When findings require
-   different fixes on different code paths, use separate coder tasks even if
-   targeting the same file. The "ONE task per coder" rule is about distinct
-   objectives, not about N edits to one file.
+For portability gotchas (plan identity, stale gate evidence, PowerShell comment posting, same-file batching), read `references/operational-gotchas.md`.
 
 ## Mandatory Gates
 

--- a/.opencode/skills/swarm-pr-feedback/references/bot-claim-verification.md
+++ b/.opencode/skills/swarm-pr-feedback/references/bot-claim-verification.md
@@ -1,0 +1,71 @@
+# Bot Claim Verification
+
+## Bot Review Verification Traps
+
+When a bot or pasted review cites a code fact, verify the fact against the
+current branch before editing:
+
+- **Import/export claims:** Check the exact import path used by the changed file.
+  A symbol may be missing from an internal submodule but correctly exported by the
+  public barrel the tests or runtime actually import.
+- **Line numbers:** Treat bot line references as approximate after any follow-up
+  push or local edit. Re-locate the symbol or block with `rg` before patching.
+- **Ordering claims:** If the concern is about rule precedence, add or run a
+  direct precedence test that would fail under the wrong ordering; comments alone
+  are not enough.
+- **Disproved findings:** Do not change unrelated code to satisfy a false claim.
+  Keep the finding in the closure ledger with the source or test evidence that
+  disproves it.
+- **Cache/state claims:** Test both relevant state orders when the behavior
+  depends on cache priming, singleton state, or prior calls.
+
+## Automated Security Finding Verification
+
+This is a repository-agnostic verification checklist. Technology names and
+paths in the examples below are illustrative only: apply an example only when
+the reviewed repository actually uses that API, validator, runtime, or file
+layout, and otherwise translate the same origin-to-sink question to the
+repository's language and framework. No example creates a dependency on the
+opencode-swarm tree.
+
+Automated security bots can produce CRITICAL or HIGH false positives. Before
+acting on any bot security finding, perform these source-level checks:
+
+1. **`child_process.exec` vs `RegExp.exec`**: SAST rules pattern-match on
+   `.exec(` and cannot distinguish `child_process.exec(userInput)` (real
+   injection risk) from `/^pattern$/.exec(str)` (safe regex test). Read the
+   actual line to determine which `.exec` is called.
+
+2. **Schema validation already present**: Bots may flag "missing type
+   validation" without checking the Zod schema. Search for the field name in
+   `src/config/schema.ts` — `z.number().int()`, `z.string().min()`, etc. are
+   runtime validators that run before the code path the bot reviewed.
+
+3. **`Object.assign` mutation claims**: Bots may claim `Object.assign` mutates
+   the source object. Check whether the call is `Object.assign(target, source)`
+   (mutates target) vs `Object.assign({}, source)` or a manual copy loop into a
+   new `{}` (creates a new object, source is safe). Read the actual assignment.
+
+4. **Path containment for system-generated paths**: Bots may flag "path
+   traversal" on file paths. Check whether the path is user-controlled (real
+   risk) or system-generated from `provisionWorktree`, `mkdtempSync`, or
+   similar (no user input reaches the path). Trace the variable's origin.
+
+5. **Value validation vs key validation**: Bots may suggest validating env var
+   *values* for shell injection characters. Check whether the value is passed
+   through a sandbox executor that escapes arguments (e.g., `wrapCommand`
+   which returns a shell-quoted / `psStringEscape`-escaped string for the
+   `bunSpawn` array-form argv to consume). Value validation would break
+   legitimate env vars (PATH with `;`, URLs with `$`); escaping is the
+   sandbox's job — see `engineering-conventions` § "Sandbox env overrides"
+   for the full escape contract.
+
+6. **Deduplication for independent resources**: Bots may suggest deduplicating
+   cache redirects or env var entries. Check whether the entries map to
+   independent keys (different env var names) — independent keys cannot
+   "collide" and deduplication is nonsensical.
+
+**Rule:** For any bot finding rated CRITICAL or HIGH, read the actual source
+line AND its surrounding context (parent function, schema definition, type
+annotations) before accepting the finding. If the finding is disproved, record
+it in the closure ledger with the specific source evidence that disproves it.

--- a/.opencode/skills/swarm-pr-feedback/references/operational-gotchas.md
+++ b/.opencode/skills/swarm-pr-feedback/references/operational-gotchas.md
@@ -1,0 +1,49 @@
+# Operational Reference
+
+## DI seam migration validation (when the repository uses this pattern)
+
+`_internals` and `mock.module()` below are JavaScript/TypeScript examples only.
+For another stack, apply the same live-binding question using that language and
+test runner's dependency-injection/mocking semantics.
+
+When a test file mutates a DI seam object (e.g., `_internals.foo = mock`),
+verify that the production source reads from the seam at call time. A common
+anti-pattern: the test mutates the seam object, but the production code
+imports the named function (`import { foo } from './module'`) which is bound
+at module load. The seam mutation has no effect on the named reference,
+so the test fails even though the seam object's `foo === mock`.
+
+Verification: open the source file and grep for call sites. If you see
+`import { foo } from '...'` followed by `foo(...)` in the production code,
+and the test does `_internals.foo = mock`, the test will fail. The fix is
+to change the production code to call `_internals.foo(...)` (or equivalent
+active-seam pattern) so the seam mutation is read at call time.
+
+If only a few call sites exist, fix them in the source. If many call sites
+exist, consider whether the migration should use `mock.module()` instead,
+which replaces the entire module object (including the named export
+reference).
+
+## Conditional runtime/host gotchas
+
+Apply each item below only when the named plugin tool, plan model, shell, or
+code-host client is actually present. They are portability examples, not
+requirements imposed on unrelated repositories.
+
+ - **Plan identity change:** When switching from a review plan to a feedback-closure
+   plan, `save_plan` rejects with `PLAN_IDENTITY_MISMATCH`. Pass
+   `confirm_identity_change: true` to acknowledge the intentional overwrite.
+ - **Stale gate evidence:** After a plan identity change, `check_gate_status` returns
+   timestamps from the *prior* plan. Reset task statuses and re-run Stage A gates
+   before trusting gate results. Do not accept cached gate verdicts from before the
+   identity change.
+ - **PowerShell PR comment posting:** Complex markdown bodies containing backticks,
+   dollar signs, or nested quotes fail in PowerShell here-strings. Write the body
+   to a temp file and use `gh pr comment <number> --body-file <tempfile>` instead
+   of inline `--body "..."`.
+ - **Same-file batching:** Multiple findings targeting the same file for the same
+   review cycle CAN be fixed in one coder task when the fixes are trivially
+   independent (e.g., a one-line guard and a typo fix). When findings require
+   different fixes on different code paths, use separate coder tasks even if
+   targeting the same file. The "ONE task per coder" rule is about distinct
+   objectives, not about N edits to one file.

--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -649,7 +649,7 @@ rather than preview-text extraction:
 4. Stage reviewer-sized chunks, but do not dispatch reviewers yet. Phase 4 must
    complete trigger accounting and settle every launched micro-lane first.
 
-If a lane has `output_degraded: true`, `transcript_incomplete: true`, or no usable `output_ref`, apply the COVERAGE GATE from Phase 3 with a structured async retry using the applicable workflow mode and the same exact `pr_head_sha`. If the gap cannot be closed, stop and surface the lane failure to the user as BLOCKED. Do not use blocking or direct-Task fallbacks, mark affected candidates UNVERIFIED to proceed, or infer candidate absence from a preview.
+If a lane has `output_degraded: true`, `transcript_incomplete: true`, or no usable `output_ref`, apply the COVERAGE GATE (Phase 3). Do not use blocking or direct-Task fallbacks, mark affected candidates UNVERIFIED to proceed, or infer candidate absence from a preview.
 
 After candidate parsing and before reviewer dispatch, persist the post-explorer
 candidate ledger using the Review Finding Persistence contract. This is the
@@ -782,12 +782,7 @@ errors, zero malformed rows, and a complete, non-degraded source:
 [CLEAN] | micro_lane | coverage_scope | evidence
 ```
 
-Header-only or malformed zero output is `UNATTESTED` and must follow the
-canonical COVERAGE GATE retry path. Only the structured async PR-workflow path
-preserves the required `L1`, exact-head, batch, and workflow-lane provenance;
-the active controller rejects blocking and direct-Task substitutes. Task-derived
-findings or CLEAN prose cannot satisfy Phase 4; if bounded structured retries
-cannot produce an artifact, the phase is BLOCKED.
+Header-only or malformed zero output is `UNATTESTED`; apply the COVERAGE GATE (Phase 3). The structured async PR-workflow path is required to preserve `L1`, exact-head, batch, and workflow-lane provenance; the active controller rejects blocking and direct-Task substitutes. Task-derived findings or CLEAN prose cannot satisfy Phase 4.
 
 Each micro-lane receives:
 
@@ -1041,7 +1036,7 @@ BLOCKED. Terminal critic rows are cross-field checked: `DISPROVED` requires
 `NONE`, `UPHELD` requires CRITICAL/HIGH/MEDIUM, and `DOWNGRADED` cannot remain
 CRITICAL.
 
-**COVERAGE GATE alignment:** Critic lane failures follow the same COVERAGE GATE as explorer lanes: retry (max 2 attempts) with materially different parameters using `dispatch_lanes_async`, `mode: "swarm-pr-review:critic"`, and the same exact `pr_head_sha`. Blocking and direct-Task fallbacks are not provenance-equivalent and are rejected. If no structured retry closes coverage, stop and surface the critic-lane failure to the user as BLOCKED — do NOT mark findings UNVERIFIED or continue past the gap. The orchestrator NEVER fabricates a critic verdict by parsing prose, by tolerating a planning preamble, by presenting partial findings, or by silently accepting reduced coverage.
+**COVERAGE GATE alignment:** Critic lane failures apply the COVERAGE GATE (Phase 3) using `dispatch_lanes_async` with `mode: "swarm-pr-review:critic"` and the same exact `pr_head_sha`. Do NOT mark findings UNVERIFIED or continue past the gap. The orchestrator NEVER fabricates a critic verdict by parsing prose, by tolerating a planning preamble, by presenting partial findings, or by silently accepting reduced coverage.
 
 Refuted findings become `DISPROVED` or `ADVISORY`, depending on critic rationale. Downgrades must be listed in the final validation provenance.
 
@@ -1170,240 +1165,7 @@ Update the verdict only after re-verifying all previously blocking findings.
 
 ---
 
-## Dry-Run: Parser-Based Candidate Extraction
-
-This section demonstrates the new parser-based extraction path end-to-end
-using synthetic data. It is concrete enough to implement the same pattern in
-another skill.
-
-### Scenario
-
-A PR review has dispatched six base explorer lanes via `dispatch_lanes_async`.
-The batch completed and `collect_lane_results` returned:
-
-```json
-{
-  "batch_id": "batch-a1b2c3",
-  "lane_results": [
-    {
-      "lane_id": "pr_review_lane1_correctness",
-      "status": "completed",
-      "output_ref": "L1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-      "output_degraded": false
-    },
-    {
-      "lane_id": "pr_review_lane2_security",
-      "status": "completed",
-      "output_ref": "L1:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "output_degraded": false
-    }
-  ]
-}
-```
-
-### Step 1 — Call the parser
-
-The orchestrator calls `parse_lane_candidates` for each `output_ref`:
-
-```json
-{
-  "tool": "parse_lane_candidates",
-  "arguments": {
-    "output_ref": "L1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-    "producer": "swarm-pr-review",
-    "expected_family": "base_explorer"
-  }
-}
-```
-
-### Step 2 — Structured response
-
-The parser returns a `ParseResultWithSidecar`. On success, `error` and `error_code` are absent:
-
-```json
-{
-  "candidates": [
-    {
-      "record_type": "candidate",
-      "row_format_family": "base_explorer",
-      "row_format_version": 1,
-      "record_version": { "major": 1, "minor": 1 },
-      "source_output_ref": "L1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-      "source_batch_id": "B-2025-06-22-001",
-      "source_lane_id": "explorer-1",
-      "source_agent": "paid_explorer",
-      "source_digest": "sha256:abc123def456...",
-      "extracted_from_partial_source": false,
-      "sessionId": "ses_01HXYZ...",
-      "parentSessionId": "ses_01HABC...",
-      "producer": "swarm-pr-review",
-      "candidate_id": "C-001",
-      "lane": "Lane 1: Correctness and edge cases",
-      "micro_lane": null,
-      "severity": "HIGH",
-      "category": "null-safety",
-      "file_line": "src/utils/cache.ts:142",
-      "claim": "Uncached getter may return undefined on cold start",
-      "evidence_summary": "The `getCached` function returns `cache[key]` without a fallback when the cache is empty.",
-      "impact_context": "Downstream callers in `src/handlers/*.ts` expect a defined value and call `.toString()` directly.",
-      "invariant_violated": null,
-      "confidence": "HIGH"
-    },
-    {
-      "record_type": "candidate",
-      "row_format_family": "base_explorer",
-      "row_format_version": 1,
-      "record_version": { "major": 1, "minor": 1 },
-      "source_output_ref": "L1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-      "source_batch_id": "B-2025-06-22-001",
-      "source_lane_id": "explorer-1",
-      "source_agent": "paid_explorer",
-      "source_digest": "sha256:abc123def456...",
-      "extracted_from_partial_source": false,
-      "sessionId": "ses_01HXYZ...",
-      "parentSessionId": "ses_01HABC...",
-      "producer": "swarm-pr-review",
-      "candidate_id": "C-002",
-      "lane": "Lane 1: Correctness and edge cases",
-      "micro_lane": null,
-      "severity": "MEDIUM",
-      "category": "async-ordering",
-      "file_line": "src/services/queue.ts:88",
-      "claim": "Race between `drain` and `processNext` may drop items",
-      "evidence_summary": "`drain` sets `active = false` before awaiting `processNext`, which also checks `active`.",
-      "impact_context": "Items submitted during the drain window are silently dropped.",
-      "invariant_violated": null,
-      "confidence": "MEDIUM"
-    }
-  ],
-  "invocation_envelope": {
-    "record_type": "invocation",
-    "source_output_ref": "L1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-    "source_batch_id": "B-2025-06-22-001",
-    "source_lane_id": "explorer-1",
-    "source_agent": "paid_explorer",
-    "source_digest": "sha256:abc123def456...",
-    "row_format_version": 1,
-    "record_version": { "major": 1, "minor": 1 },
-    "sessionId": "ses_01HXYZ...",
-    "parentSessionId": "ses_01HABC...",
-    "producer": "swarm-pr-review",
-    "produced_at": "2025-06-22T14:30:00.000Z",
-     "format_families_detected": ["base_explorer"],
-     "candidate_count": 2,
-     "parse_errors": 0,
-     "malformed_rows": 0,
-     "clean_attestation_count": 0
-  },
-  "diagnostics": {
-    "candidate_count": 2,
-    "parse_errors": 0,
-    "parse_error_details": [],
-    "malformed_rows": 0,
-    "duplicate_id_count": 0,
-    "duplicate_id_warnings": [],
-    "degraded_source_count": 0,
-    "incomplete_source_count": 0,
-     "format_families_detected": ["base_explorer"],
-     "clean_attestation_count": 0
-   }
-}
-```
-> **Note**: callers pass `expected_family` for each dispatch batch. A recognizable
-> conflicting header fails closed with `expected-family-mismatch`; when the flag
-> is absent, the recognized header controls the mapping and positional detection
-> is only a legacy unknown-header fallback. Marker-prefixed data rows remain
-> accepted for compatibility. Valid canonical rows produce `parse_errors: 0`.
-
-On refusal (e.g. `output_ref` does not exist), `error` and `error_code` are present; `candidates` is `[]`; `invocation_envelope` and `diagnostics` are populated with empty fields for traceability:
-
-```json
-{
-  "error": "Artifact reference not found in store",
-  "error_code": "ref-not-found",
-  "candidates": [],
-  "invocation_envelope": {
-    "record_type": "invocation",
-    "source_output_ref": "L1:1111111111111111111111111111111111111111111111111111111111111111:2222222222222222222222222222222222222222222222222222222222222222:3333333333333333333333333333333333333333333333333333333333333333",
-    "source_batch_id": "",
-    "source_lane_id": "",
-    "source_agent": "",
-    "source_digest": "",
-    "row_format_version": 1,
-    "record_version": { "major": 1, "minor": 1 },
-    "produced_at": "2025-06-22T14:30:00.000Z",
-    "format_families_detected": [],
-    "candidate_count": 0,
-    "parse_errors": 0,
-    "malformed_rows": 0,
-    "clean_attestation_count": 0
-  },
-  "diagnostics": {
-    "candidate_count": 0,
-    "parse_errors": 0,
-    "parse_error_details": [],
-    "malformed_rows": 0,
-    "duplicate_id_count": 0,
-    "duplicate_id_warnings": [],
-    "degraded_source_count": 0,
-    "incomplete_source_count": 0,
-    "format_families_detected": [],
-    "clean_attestation_count": 0
-   }
-}
-```
-
-### Step 3 — Filter and group
-
-The orchestrator filters the returned `candidates[]` array by `producer: "swarm-pr-review"` and the exact allowed `source_batch_id` / `source_lane_id` tuples, then groups
-the candidates. In this synthetic example, the two candidates above are grouped
-by file area:
-
-- **Chunk A — `src/utils/`** (1 candidate): C-001
-- **Chunk B — `src/services/`** (1 candidate): C-002
-
-If there were more candidates, the orchestrator would also group by category
-(e.g., `null-safety`, `async-ordering`) and cap each chunk at 50 candidates.
-
-### Step 4 — Dispatch reviewer lanes
-
-The orchestrator dispatches one reviewer lane per chunk:
-
-```text
-You are the independent reviewer. Validate only the candidates assigned below.
-Do not search for new issues except where needed to validate reachability or
-mitigation. Do not trust explorer severity.
-
-Context pack summary:
-- scope: ...
-- obligations: ...
-- impact cone: ...
-- deterministic signals: ...
-- relevant Swarm artifacts / knowledge: ...
-- base_ref: <commit SHA of base branch>
-- head_ref: <commit SHA of PR head branch>
-
-Candidates (Chunk A — src/utils/):
-- C-001 | HIGH | null-safety | src/utils/cache.ts:142 | Uncached getter may return undefined on cold start
-
-For each candidate, return:
-[REVIEWED] | candidate_id | CONFIRMED/DISPROVED/UNVERIFIED/PRE_EXISTING | evidence_type | final_severity | introduced_by_pr | file:line | rationale | falsification_probe | reviewer_id
-
-You must check caller context, reachability, schema/middleware/framework mitigations, state-machine constraints, test coverage, PR-introducedness, and severity.
-
-IMPORTANT: If a finding claims behavior is "new" or "introduced by the PR", you MUST read the equivalent code on the base branch (git show <base_ref>:<file>) to verify it was not present before. A reviewer claim of "this is new" is invalid without base-branch evidence. Do not compare the new code to an idealized baseline — compare it to what actually existed on the base branch at the time of the PR.
-```
-
-### Key invariants
-
-- The parser reads the **full artifact**, not a preview. Truncation in the
-  `dispatch_lanes` preview does not affect candidate extraction.
-- The orchestrator never classifies candidates — it only filters, groups, and
-  routes them.
-- Each reviewer receives a bounded chunk. A chunk with more than 50 candidates
-  is split before dispatch.
-- The `invocation_envelope` in the parser response provides audit provenance
-  for every extracted candidate.
+For the full parser-based candidate extraction dry-run example, read `references/parser-dry-run.md`.
 
 ---
 
@@ -1522,7 +1284,7 @@ If any reviewer lane lacks a parseable `[REVIEWED]` row after bounded
 re-dispatch, the reviewer dimension is BLOCKED. Do not infer or silently
 downgrade a verdict.
 
-**COVERAGE GATE CONDITION:** If ANY validation dimension shows incomplete coverage (lanes that failed and were not closed by retry or verified equivalent alternative, CI that did not run, tools that were unavailable after retry), the Pre-Synthesis Gate FAILS. Do not proceed to final output. Surface the unclosed gaps to the user as BLOCKED with exact failing dimensions and retry/equivalence evidence. Do not include partial findings from successful dimensions, do not issue a review verdict, and do not silently accept reduced coverage.
+**COVERAGE GATE CONDITION:** If ANY validation dimension shows incomplete coverage (lanes that failed and were not closed by retry or verified equivalent alternative, CI that did not run, tools that were unavailable after retry), the Pre-Synthesis Gate FAILS — apply the COVERAGE GATE (Phase 3). Do not proceed to final output. Surface unclosed gaps with exact failing dimensions and retry/equivalence evidence.
 
 ---
 
@@ -1630,109 +1392,7 @@ Use this exact continuation prompt format:
 
 ---
 
-# Reviewer Prompt Template
-
-Use this template when dispatching reviewer subagents:
-
-```text
-You are the independent reviewer. Validate only the candidates assigned below.
-Do not search for new issues except where needed to validate reachability or mitigation.
-Do not trust explorer severity.
-
-Context pack summary:
-- scope: ...
-- obligations: ...
-- impact cone: ...
-- deterministic signals: ...
-- relevant Swarm artifacts / knowledge: ...
-- base_ref: <commit SHA of base branch>
-- head_ref: <commit SHA of PR head branch>
-
-Candidates:
-- ...
-
-For each candidate, return:
-[REVIEWED] | candidate_id | CONFIRMED/DISPROVED/UNVERIFIED/PRE_EXISTING | evidence_type | final_severity | introduced_by_pr | file:line | rationale | falsification_probe | reviewer_id
-
-You must check caller context, reachability, schema/middleware/framework mitigations, state-machine constraints, test coverage, PR-introducedness, and severity.
-
-IMPORTANT: If a finding claims behavior is "new" or "introduced by the PR", you MUST read the equivalent code on the base branch (git show <base_ref>:<file>) to verify it was not present before. A reviewer claim of "this is new" is invalid without base-branch evidence. Do not compare the new code to an idealized baseline — compare it to what actually existed on the base branch at the time of the PR.
-```
-
----
-
-# Critic Prompt Template
-
-Use this template when dispatching critic subagents:
-
-```text
-You are the adversarial critic. Challenge only reviewer-confirmed findings assigned below.
-Your goal is to reduce false positives, severity inflation, and non-actionable reports.
-
-For each finding, challenge:
-- whether evidence proves the claim,
-- whether the path is reachable,
-- whether mitigations apply,
-- whether severity is inflated,
-- whether it is PR-introduced,
-- whether suggested fixes are safe/actionable,
-- whether related files were missed,
-- whether multiple findings should be grouped.
-
-Return:
-[CRITIC] | finding_id | UPHELD/DOWNGRADED/DISPROVED/NEEDS_MORE_EVIDENCE | final_severity | reason | required_report_change
-
-REQUIRED FINAL LINE — your final line MUST be exactly the row above (no variations, no labeled fields, no placeholders):
-[CRITIC] | finding_id | UPHELD/DOWNGRADED/DISPROVED/NEEDS_MORE_EVIDENCE | final_severity | reason | required_report_change
-
-A response without this exact row is treated as a planning preamble and re-dispatched. Do not output only a planning or investigation message.
-```
-
----
-
-# Explorer Prompt Template
-
-Use this template when dispatching base explorer or micro-lane agents:
-
-```text
-You are an explorer. Optimize for recall, not final judgment.
-Return candidates only. Do not use CONFIRMED, DISPROVED, or PRE_EXISTING.
-
-Lane:
-Scope:
-base_ref:
-head_ref:
-Obligations:
-Changed files/hunks:
-Impact cone:
-Relevant deterministic signals:
-Relevant Swarm artifacts / knowledge:
-Checklist:
-
-You must inspect or mark unavailable:
-1. changed hunk,
-2. caller/consumer,
-3. callee/dependency,
-4. sibling implementation or prior pattern,
-5. nearest test or missing-test location,
-6. deterministic signals,
-7. Swarm artifacts/knowledge,
-8. the exact `base_sha...pr_head_sha` merge-base range and both endpoint revisions.
-
-Return:
-[CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence_summary | impact_context | confidence
-Emit the marker-bearing header once, then unprefixed data rows.
-For a clean micro-lane, emit `[CLEAN] | micro_lane | coverage_scope | evidence`.
-For a clean base lane, emit `[CLEAN] | workflow_lane | coverage_scope | evidence`.
-```
-
-The orchestrator extracts candidates from the full lane artifact via
-`parse_lane_candidates` as the primary mechanism. The `[CANDIDATE]` row
-format above is a fallback convention for environments where the parser is
-unavailable. Explorers should still emit structured records regardless of
-whether the parser is present.
-
-Do not let speed degrade validation quality.
+For reviewer, critic, and explorer prompt templates, read `references/prompt-templates.md`.
 
 After metrics and durable review artifacts are complete, but before emitting the
 user-facing final report, call `complete_pr_workflow` with mode `PR_REVIEW` and

--- a/.opencode/skills/swarm-pr-review/references/parser-dry-run.md
+++ b/.opencode/skills/swarm-pr-review/references/parser-dry-run.md
@@ -1,0 +1,235 @@
+# Dry-Run: Parser-Based Candidate Extraction
+
+This section demonstrates the new parser-based extraction path end-to-end
+using synthetic data. It is concrete enough to implement the same pattern in
+another skill.
+
+### Scenario
+
+A PR review has dispatched six base explorer lanes via `dispatch_lanes_async`.
+The batch completed and `collect_lane_results` returned:
+
+```json
+{
+  "batch_id": "batch-a1b2c3",
+  "lane_results": [
+    {
+      "lane_id": "pr_review_lane1_correctness",
+      "status": "completed",
+      "output_ref": "L1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "output_degraded": false
+    },
+    {
+      "lane_id": "pr_review_lane2_security",
+      "status": "completed",
+      "output_ref": "L1:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "output_degraded": false
+    }
+  ]
+}
+```
+
+### Step 1 — Call the parser
+
+The orchestrator calls `parse_lane_candidates` for each `output_ref`:
+
+```json
+{
+  "tool": "parse_lane_candidates",
+  "arguments": {
+    "output_ref": "L1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "producer": "swarm-pr-review",
+    "expected_family": "base_explorer"
+  }
+}
+```
+
+### Step 2 — Structured response
+
+The parser returns a `ParseResultWithSidecar`. On success, `error` and `error_code` are absent:
+
+```json
+{
+  "candidates": [
+    {
+      "record_type": "candidate",
+      "row_format_family": "base_explorer",
+      "row_format_version": 1,
+      "record_version": { "major": 1, "minor": 1 },
+      "source_output_ref": "L1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "source_batch_id": "B-2025-06-22-001",
+      "source_lane_id": "explorer-1",
+      "source_agent": "paid_explorer",
+      "source_digest": "sha256:abc123def456...",
+      "extracted_from_partial_source": false,
+      "sessionId": "ses_01HXYZ...",
+      "parentSessionId": "ses_01HABC...",
+      "producer": "swarm-pr-review",
+      "candidate_id": "C-001",
+      "lane": "Lane 1: Correctness and edge cases",
+      "micro_lane": null,
+      "severity": "HIGH",
+      "category": "null-safety",
+      "file_line": "src/utils/cache.ts:142",
+      "claim": "Uncached getter may return undefined on cold start",
+      "evidence_summary": "The `getCached` function returns `cache[key]` without a fallback when the cache is empty.",
+      "impact_context": "Downstream callers in `src/handlers/*.ts` expect a defined value and call `.toString()` directly.",
+      "invariant_violated": null,
+      "confidence": "HIGH"
+    },
+    {
+      "record_type": "candidate",
+      "row_format_family": "base_explorer",
+      "row_format_version": 1,
+      "record_version": { "major": 1, "minor": 1 },
+      "source_output_ref": "L1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "source_batch_id": "B-2025-06-22-001",
+      "source_lane_id": "explorer-1",
+      "source_agent": "paid_explorer",
+      "source_digest": "sha256:abc123def456...",
+      "extracted_from_partial_source": false,
+      "sessionId": "ses_01HXYZ...",
+      "parentSessionId": "ses_01HABC...",
+      "producer": "swarm-pr-review",
+      "candidate_id": "C-002",
+      "lane": "Lane 1: Correctness and edge cases",
+      "micro_lane": null,
+      "severity": "MEDIUM",
+      "category": "async-ordering",
+      "file_line": "src/services/queue.ts:88",
+      "claim": "Race between `drain` and `processNext` may drop items",
+      "evidence_summary": "`drain` sets `active = false` before awaiting `processNext`, which also checks `active`.",
+      "impact_context": "Items submitted during the drain window are silently dropped.",
+      "invariant_violated": null,
+      "confidence": "MEDIUM"
+    }
+  ],
+  "invocation_envelope": {
+    "record_type": "invocation",
+    "source_output_ref": "L1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "source_batch_id": "B-2025-06-22-001",
+    "source_lane_id": "explorer-1",
+    "source_agent": "paid_explorer",
+    "source_digest": "sha256:abc123def456...",
+    "row_format_version": 1,
+    "record_version": { "major": 1, "minor": 1 },
+    "sessionId": "ses_01HXYZ...",
+    "parentSessionId": "ses_01HABC...",
+    "producer": "swarm-pr-review",
+    "produced_at": "2025-06-22T14:30:00.000Z",
+     "format_families_detected": ["base_explorer"],
+     "candidate_count": 2,
+     "parse_errors": 0,
+     "malformed_rows": 0,
+     "clean_attestation_count": 0
+  },
+  "diagnostics": {
+    "candidate_count": 2,
+    "parse_errors": 0,
+    "parse_error_details": [],
+    "malformed_rows": 0,
+    "duplicate_id_count": 0,
+    "duplicate_id_warnings": [],
+    "degraded_source_count": 0,
+    "incomplete_source_count": 0,
+     "format_families_detected": ["base_explorer"],
+     "clean_attestation_count": 0
+   }
+}
+```
+> **Note**: callers pass `expected_family` for each dispatch batch. A recognizable
+> conflicting header fails closed with `expected-family-mismatch`; when the flag
+> is absent, the recognized header controls the mapping and positional detection
+> is only a legacy unknown-header fallback. Marker-prefixed data rows remain
+> accepted for compatibility. Valid canonical rows produce `parse_errors: 0`.
+
+On refusal (e.g. `output_ref` does not exist), `error` and `error_code` are present; `candidates` is `[]`; `invocation_envelope` and `diagnostics` are populated with empty fields for traceability:
+
+```json
+{
+  "error": "Artifact reference not found in store",
+  "error_code": "ref-not-found",
+  "candidates": [],
+  "invocation_envelope": {
+    "record_type": "invocation",
+    "source_output_ref": "L1:1111111111111111111111111111111111111111111111111111111111111111:2222222222222222222222222222222222222222222222222222222222222222:3333333333333333333333333333333333333333333333333333333333333333",
+    "source_batch_id": "",
+    "source_lane_id": "",
+    "source_agent": "",
+    "source_digest": "",
+    "row_format_version": 1,
+    "record_version": { "major": 1, "minor": 1 },
+    "produced_at": "2025-06-22T14:30:00.000Z",
+    "format_families_detected": [],
+    "candidate_count": 0,
+    "parse_errors": 0,
+    "malformed_rows": 0,
+    "clean_attestation_count": 0
+  },
+  "diagnostics": {
+    "candidate_count": 0,
+    "parse_errors": 0,
+    "parse_error_details": [],
+    "malformed_rows": 0,
+    "duplicate_id_count": 0,
+    "duplicate_id_warnings": [],
+    "degraded_source_count": 0,
+    "incomplete_source_count": 0,
+    "format_families_detected": [],
+    "clean_attestation_count": 0
+   }
+}
+```
+
+### Step 3 — Filter and group
+
+The orchestrator filters the returned `candidates[]` array by `producer: "swarm-pr-review"` and the exact allowed `source_batch_id` / `source_lane_id` tuples, then groups
+the candidates. In this synthetic example, the two candidates above are grouped
+by file area:
+
+- **Chunk A — `src/utils/`** (1 candidate): C-001
+- **Chunk B — `src/services/`** (1 candidate): C-002
+
+If there were more candidates, the orchestrator would also group by category
+(e.g., `null-safety`, `async-ordering`) and cap each chunk at 50 candidates.
+
+### Step 4 — Dispatch reviewer lanes
+
+The orchestrator dispatches one reviewer lane per chunk:
+
+```text
+You are the independent reviewer. Validate only the candidates assigned below.
+Do not search for new issues except where needed to validate reachability or
+mitigation. Do not trust explorer severity.
+
+Context pack summary:
+- scope: ...
+- obligations: ...
+- impact cone: ...
+- deterministic signals: ...
+- relevant Swarm artifacts / knowledge: ...
+- base_ref: <commit SHA of base branch>
+- head_ref: <commit SHA of PR head branch>
+
+Candidates (Chunk A — src/utils/):
+- C-001 | HIGH | null-safety | src/utils/cache.ts:142 | Uncached getter may return undefined on cold start
+
+For each candidate, return:
+[REVIEWED] | candidate_id | CONFIRMED/DISPROVED/UNVERIFIED/PRE_EXISTING | evidence_type | final_severity | introduced_by_pr | file:line | rationale | falsification_probe | reviewer_id
+
+You must check caller context, reachability, schema/middleware/framework mitigations, state-machine constraints, test coverage, PR-introducedness, and severity.
+
+IMPORTANT: If a finding claims behavior is "new" or "introduced by the PR", you MUST read the equivalent code on the base branch (git show <base_ref>:<file>) to verify it was not present before. A reviewer claim of "this is new" is invalid without base-branch evidence. Do not compare the new code to an idealized baseline — compare it to what actually existed on the base branch at the time of the PR.
+```
+
+### Key invariants
+
+- The parser reads the **full artifact**, not a preview. Truncation in the
+  `dispatch_lanes` preview does not affect candidate extraction.
+- The orchestrator never classifies candidates — it only filters, groups, and
+  routes them.
+- Each reviewer receives a bounded chunk. A chunk with more than 50 candidates
+  is split before dispatch.
+- The `invocation_envelope` in the parser response provides audit provenance
+  for every extracted candidate.
+

--- a/.opencode/skills/swarm-pr-review/references/prompt-templates.md
+++ b/.opencode/skills/swarm-pr-review/references/prompt-templates.md
@@ -1,0 +1,103 @@
+# Reviewer Prompt Template
+
+Use this template when dispatching reviewer subagents:
+
+```text
+You are the independent reviewer. Validate only the candidates assigned below.
+Do not search for new issues except where needed to validate reachability or mitigation.
+Do not trust explorer severity.
+
+Context pack summary:
+- scope: ...
+- obligations: ...
+- impact cone: ...
+- deterministic signals: ...
+- relevant Swarm artifacts / knowledge: ...
+- base_ref: <commit SHA of base branch>
+- head_ref: <commit SHA of PR head branch>
+
+Candidates:
+- ...
+
+For each candidate, return:
+[REVIEWED] | candidate_id | CONFIRMED/DISPROVED/UNVERIFIED/PRE_EXISTING | evidence_type | final_severity | introduced_by_pr | file:line | rationale | falsification_probe | reviewer_id
+
+You must check caller context, reachability, schema/middleware/framework mitigations, state-machine constraints, test coverage, PR-introducedness, and severity.
+
+IMPORTANT: If a finding claims behavior is "new" or "introduced by the PR", you MUST read the equivalent code on the base branch (git show <base_ref>:<file>) to verify it was not present before. A reviewer claim of "this is new" is invalid without base-branch evidence. Do not compare the new code to an idealized baseline — compare it to what actually existed on the base branch at the time of the PR.
+```
+
+---
+
+# Critic Prompt Template
+
+Use this template when dispatching critic subagents:
+
+```text
+You are the adversarial critic. Challenge only reviewer-confirmed findings assigned below.
+Your goal is to reduce false positives, severity inflation, and non-actionable reports.
+
+For each finding, challenge:
+- whether evidence proves the claim,
+- whether the path is reachable,
+- whether mitigations apply,
+- whether severity is inflated,
+- whether it is PR-introduced,
+- whether suggested fixes are safe/actionable,
+- whether related files were missed,
+- whether multiple findings should be grouped.
+
+Return:
+[CRITIC] | finding_id | UPHELD/DOWNGRADED/DISPROVED/NEEDS_MORE_EVIDENCE | final_severity | reason | required_report_change
+
+REQUIRED FINAL LINE — your final line MUST be exactly the row above (no variations, no labeled fields, no placeholders):
+[CRITIC] | finding_id | UPHELD/DOWNGRADED/DISPROVED/NEEDS_MORE_EVIDENCE | final_severity | reason | required_report_change
+
+A response without this exact row is treated as a planning preamble and re-dispatched. Do not output only a planning or investigation message.
+```
+
+---
+
+# Explorer Prompt Template
+
+Use this template when dispatching base explorer or micro-lane agents:
+
+```text
+You are an explorer. Optimize for recall, not final judgment.
+Return candidates only. Do not use CONFIRMED, DISPROVED, or PRE_EXISTING.
+
+Lane:
+Scope:
+base_ref:
+head_ref:
+Obligations:
+Changed files/hunks:
+Impact cone:
+Relevant deterministic signals:
+Relevant Swarm artifacts / knowledge:
+Checklist:
+
+You must inspect or mark unavailable:
+1. changed hunk,
+2. caller/consumer,
+3. callee/dependency,
+4. sibling implementation or prior pattern,
+5. nearest test or missing-test location,
+6. deterministic signals,
+7. Swarm artifacts/knowledge,
+8. the exact `base_sha...pr_head_sha` merge-base range and both endpoint revisions.
+
+Return:
+[CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence_summary | impact_context | confidence
+Emit the marker-bearing header once, then unprefixed data rows.
+For a clean micro-lane, emit `[CLEAN] | micro_lane | coverage_scope | evidence`.
+For a clean base lane, emit `[CLEAN] | workflow_lane | coverage_scope | evidence`.
+```
+
+The orchestrator extracts candidates from the full lane artifact via
+`parse_lane_candidates` as the primary mechanism. The `[CANDIDATE]` row
+format above is a fallback convention for environments where the parser is
+unavailable. Explorers should still emit structured records regardless of
+whether the parser is present.
+
+Do not let speed degrade validation quality.

--- a/.opencode/skills/writing-tests/SKILL.md
+++ b/.opencode/skills/writing-tests/SKILL.md
@@ -619,44 +619,6 @@ authority checks:
 
 For the full splitting protocol (describe-block extraction, shared helper management, pure-function extraction, mock isolation verification, cascading-split detection), read `file:.swarm/bundled-skills/test-file-split/SKILL.md`.
 
-### Checking file length
-
-```bash
-# Check a single file
-wc -l tests/unit/scripts/my-test.test.ts
-
-# Find all test files exceeding 400 lines (early warning threshold)
-find tests/ -name "*.test.ts" -exec wc -l {} \; | sort -rn | awk '$1 > 400'
-```
-
-### Splitting pattern
-
-When a test file approaches or exceeds 500 lines, split it by extracting cohesive `describe()` blocks into a new file with a descriptive suffix:
-
-1. **Identify natural boundaries.** Group `describe()` blocks by functional area (e.g., SHA resolution, validation, merge logic).
-2. **Create the new file** with a descriptive suffix: `<module>-<area>.test.ts` (e.g., `release-notes-fragments-sha.test.ts`, `release-notes-fragments-validation.test.ts`).
-3. **Move shared imports and helpers.** Either:
-   - Duplicate shared imports in both files (simple, for small overlap), OR
-   - Extract shared test helpers to a utility module (e.g., `tests/helpers/<module>-shared.ts`) and import from both files (preferred for complex shared setup).
-4. **Extract testable pure functions.** If the source module has inline validation logic (e.g., `isValidPrNumber`), extract it as an exported pure function so both test files can target it independently.
-5. **Verify both files are under 500 lines.**
-6. **Run both files independently AND co-run** to verify no mock isolation breakage:
-   ```bash
-   bun --smol test tests/unit/scripts/release-notes-fragments.test.ts --timeout 60000
-   bun --smol test tests/unit/scripts/release-notes-fragments-sha.test.ts --timeout 60000
-   bun --smol test tests/unit/scripts/release-notes-fragments*.test.ts --timeout 60000
-   ```
-
-### When to split vs refactor
-
-- **Split** when there are natural `describe()` boundaries (e.g., one file per functional area).
-- **Refactor** when the file is a single monolithic test with no clear boundaries — consolidate test logic instead.
-- **Warning:** If a previously split file exceeds 500 lines again, the test suite is structurally too large. Reorganize by module rather than continuing to split.
-
-### Reference
-
-See PR #1762 for a real-world example: `release-notes-fragments.test.ts` was split into `release-notes-fragments.test.ts` (379 lines) + `release-notes-fragments-sha.test.ts` (261 lines).
-
 ## Cross-Entry Invariants (config maps)
 
 When you modify any entry of a "map of agents/tools/roles" in `src/config/constants.ts` (`AGENT_TOOL_MAP`, `DEFAULT_MODELS`, `QA_AGENTS`, `PIPELINE_AGENTS`, etc.) or tool-name registration in `src/tools/tool-names.ts`, there are tests that assert **parity across sibling entries**, not just shape of one entry.
@@ -847,50 +809,7 @@ try {
 
 ## Running Tests
 
-### bash (Linux / macOS)
-
-```bash
-# Single file
-bun test src/hooks/scope-guard.test.ts
-
-# Batch directory (safe for dirs without mock conflicts)
-bun --smol test tests/unit/hooks --timeout 30000
-
-# Per-file loop (required for tools/services/agents — prevents mock poisoning)
-for f in tests/unit/tools/*.test.ts; do bun --smol test "$f" --timeout 30000; done
-
-# CI-equivalent run for batch steps (step 2: cli; step 3: commands + config)
-bun --smol test tests/unit/cli --timeout 120000
-bun --smol test tests/unit/commands tests/unit/config --timeout 120000
-```
-
-### PowerShell (Windows)
-
-```powershell
-# Single file
-bun test src/hooks/scope-guard.test.ts
-
-# Batch directory (safe for dirs without mock conflicts)
-bun --smol test tests/unit/hooks --timeout 30000
-
-# Per-file loop (required for tools/services/agents — prevents mock poisoning)
-Get-ChildItem tests/unit/tools/*.test.ts | ForEach-Object { bun --smol test $_.FullName --timeout 30000 }
-
-# CI-equivalent run for batch steps (step 2: cli; step 3: commands + config)
-bun --smol test tests/unit/cli --timeout 120000
-bun --smol test tests/unit/commands tests/unit/config --timeout 120000
-
-# Capture output to file (avoids truncation when output is large)
-bun --smol test tests/unit/agents --timeout 60000 | Out-File "$env:TEMP\test_out.txt"; Get-Content "$env:TEMP\test_out.txt" | Select-Object -Last 50
-```
-
-**Note:** `for f in ...; do` bash syntax is invalid in PowerShell. Use `Get-ChildItem | ForEach-Object` instead. `Select-String -Last N` is also invalid — use `Select-Object -Last N`.
-
-**Warning:** Running `bun --smol test tests/unit/tools` as a single batch will cause mock poisoning failures. Always use the per-file loop for the per-file-isolation steps (1a, 1b, 4-6: tools, services, agents, etc.).
-
-The `--smol` flag reduces Bun's memory footprint. Use it when running large directories (50+ files).
-
-The `--timeout 120000` flag sets per-test timeout to 120 seconds. Individual tests should complete in under 5 seconds. If a test needs more than 10 seconds, it's doing too much — split it or mock the slow dependency.
+For the full test execution commands (bash and PowerShell per-file isolation loops, CI integration), read `file:.swarm/bundled-skills/running-tests/SKILL.md`. The key principle: always run one test file per process (`bun --smol test <file> --timeout 30000`) to prevent `mock.module` cross-contamination.
 
 ## Before Submitting
 
@@ -905,44 +824,6 @@ The `--timeout 120000` flag sets per-test timeout to 120 seconds. Individual tes
 
 Pre-existing and flaky failures are tracked in the per-platform quarantine ledgers (`scripts/ci/quarantined-tests.txt`, `quarantined-tests-macos.txt`, `quarantined-tests-windows.txt`), not in this skill. To confirm a failure is pre-existing, reproduce it in a clean worktree on `origin/main` (see the worktree verify protocol in `running-tests`).
 
-## Known Cross-module mock.module Locations
+## Mock and Seam Inventories
 
-The following directories contain test files that use cross-module `mock.module` (permitted under two-tier convention):
-
-- `tests/unit/commands/` — mocks tools, hooks, services, state
-- `tests/unit/hooks/` — mocks knowledge-store, knowledge-validator, knowledge-reader, telemetry, utils
-- `tests/unit/tools/` — mocks Node built-ins (fs, child_process), sast-baseline, build/discovery
-- `tests/unit/services/` — mocks path-security
-- `tests/unit/config/` — mocks node:fs/promises
-- `tests/unit/background/` — mocks utils, event-bus, evidence-summary-service
-- `tests/unit/council/` — mocks node:fs
-- `tests/unit/plan/` — mocks spec-hash
-- `tests/unit/mutation/` — mocks node:child_process
-- `tests/unit/git/` — mocks node:child_process
-- `tests/integration/` — mocks co-change-analyzer, knowledge-store
-- `src/__tests__/` — mocks plan/manager, preflight-service, telemetry
-- `src/hooks/` — mocks logger, event-bus
-- `src/tools/__tests__/` — mocks test-impact/analyzer, build/discovery, path-security
-- `src/mutation/__tests__/` — mocks state
-- `src/agents/` — mocks node:fs/promises
-- `src/background/` — mocks vulnerability trigger
-
-## Dead-code _internals Seams
-
-The following source modules export `_internals` but have no test consumers (as of this writing). They are harmless but may be removed in future cleanup:
-
-- `src/tools/secretscan.ts`
-- `src/tools/knowledge-recall.ts`
-- `src/tools/lint.ts`
-- `src/tools/sast-scan.ts`
-- `src/tools/sast-baseline.ts`
-- `src/mutation/gate.ts`
-- `src/mutation/equivalence.ts`
-- `src/mutation/engine.ts`
-- `src/db/qa-gate-profile.ts`
-- `src/config/schema.ts`
-- `src/config/index.ts`
-- `src/commands/registry.ts`
-- `src/background/manager.ts`
-- `src/background/event-bus.ts`
-- `src/agents/critic.ts`
+For the current cross-module `mock.module` location inventory and dead-code `_internals` seam inventory, read `references/mock-and-seam-inventory.md`.

--- a/.opencode/skills/writing-tests/references/mock-and-seam-inventory.md
+++ b/.opencode/skills/writing-tests/references/mock-and-seam-inventory.md
@@ -1,0 +1,43 @@
+# Mock and Seam Inventory
+
+## Known Cross-module mock.module Locations
+
+The following directories contain test files that use cross-module `mock.module` (permitted under two-tier convention):
+
+- `tests/unit/commands/` — mocks tools, hooks, services, state
+- `tests/unit/hooks/` — mocks knowledge-store, knowledge-validator, knowledge-reader, telemetry, utils
+- `tests/unit/tools/` — mocks Node built-ins (fs, child_process), sast-baseline, build/discovery
+- `tests/unit/services/` — mocks path-security
+- `tests/unit/config/` — mocks node:fs/promises
+- `tests/unit/background/` — mocks utils, event-bus, evidence-summary-service
+- `tests/unit/council/` — mocks node:fs
+- `tests/unit/plan/` — mocks spec-hash
+- `tests/unit/mutation/` — mocks node:child_process
+- `tests/unit/git/` — mocks node:child_process
+- `tests/integration/` — mocks co-change-analyzer, knowledge-store
+- `src/__tests__/` — mocks plan/manager, preflight-service, telemetry
+- `src/hooks/` — mocks logger, event-bus
+- `src/tools/__tests__/` — mocks test-impact/analyzer, build/discovery, path-security
+- `src/mutation/__tests__/` — mocks state
+- `src/agents/` — mocks node:fs/promises
+- `src/background/` — mocks vulnerability trigger
+
+## Dead-code _internals Seams
+
+The following source modules export `_internals` but have no test consumers (as of this writing). They are harmless but may be removed in future cleanup:
+
+- `src/tools/secretscan.ts`
+- `src/tools/knowledge-recall.ts`
+- `src/tools/lint.ts`
+- `src/tools/sast-scan.ts`
+- `src/tools/sast-baseline.ts`
+- `src/mutation/gate.ts`
+- `src/mutation/equivalence.ts`
+- `src/mutation/engine.ts`
+- `src/db/qa-gate-profile.ts`
+- `src/config/schema.ts`
+- `src/config/index.ts`
+- `src/commands/registry.ts`
+- `src/background/manager.ts`
+- `src/background/event-bus.ts`
+- `src/agents/critic.ts`

--- a/docs/releases/pending/skills-progressive-disclosure.md
+++ b/docs/releases/pending/skills-progressive-disclosure.md
@@ -1,0 +1,28 @@
+# `refactor(skills)`: progressive-disclosure restructure via references/ splits
+
+## Summary
+
+- Extracted deep/duplicated material from four oversized SKILL.md files into `references/` subdirectories, following the exemplar pattern established by `codebase-review-swarm/`:
+  - **swarm-pr-review** (~1744 → ~1400 lines): parser dry-run example → `references/parser-dry-run.md`; reviewer/critic/explorer prompt templates → `references/prompt-templates.md`; COVERAGE GATE restatements collapsed to Phase 3 references
+  - **writing-tests** (~948 → ~825 lines): mock.module location + dead-code _internals seam inventories → `references/mock-and-seam-inventory.md`; FR-006 splitting protocol collapsed to limit + skill pointer; Running Tests trimmed to pointer
+  - **commit-pr** (~632 → ~465 lines): push-protection scan, canonical remote resolution, auto-merge race, release-please desync → `references/pr-incident-playbook.md`; PowerShell heredoc blocks collapsed; dist/ rule deduplicated
+  - **swarm-pr-feedback** (~856 → ~525 lines): bot review traps + security finding verification → `references/bot-claim-verification.md`; DI seam validation + runtime/host gotchas → `references/operational-gotchas.md`; batch collection deduped against ci-failure-batching skill
+- Each trimmed SKILL.md retains explicit "read `references/`" pointers so agents following the bundled copy can locate the deep material
+- Updated `swarm-pr-review-dry-run.test.ts` to read from the new `references/parser-dry-run.md` path
+
+## User-facing changes
+
+None — pure restructuring of skill documentation. No runtime behavior, no protocol changes, no tool registration changes. The bundler copies `references/` subdirectories recursively, so bundled-skill consumers receive the extracted material as before.
+
+## Migration notes
+
+None required. Agents loading these skills will see `references/` pointers in the SKILL.md entrypoints and can follow them for deep material.
+
+## Breaking changes
+
+None.
+
+## Caveats
+
+- The `commit-pr` skill is classified `divergent` (PR-1 / #1692): `.claude/skills/commit-pr/` is the repo-internal canonical, `.opencode/skills/commit-pr/` is the portable project-agnostic version. The new `references/pr-incident-playbook.md` lives only under `.claude/` since its content is repo-specific.
+- All test pins verified intact; `check-skill-assertions.ts` CI job validates automatically.

--- a/docs/releases/pending/skills-progressive-disclosure.md
+++ b/docs/releases/pending/skills-progressive-disclosure.md
@@ -5,8 +5,8 @@
 - Extracted deep/duplicated material from four oversized SKILL.md files into `references/` subdirectories, following the exemplar pattern established by `codebase-review-swarm/`:
   - **swarm-pr-review** (~1744 → ~1400 lines): parser dry-run example → `references/parser-dry-run.md`; reviewer/critic/explorer prompt templates → `references/prompt-templates.md`; COVERAGE GATE restatements collapsed to Phase 3 references
   - **writing-tests** (~948 → ~825 lines): mock.module location + dead-code _internals seam inventories → `references/mock-and-seam-inventory.md`; FR-006 splitting protocol collapsed to limit + skill pointer; Running Tests trimmed to pointer
-  - **commit-pr** (~632 → ~465 lines): push-protection scan, canonical remote resolution, auto-merge race, release-please desync → `references/pr-incident-playbook.md`; PowerShell heredoc blocks collapsed; dist/ rule deduplicated
-  - **swarm-pr-feedback** (~856 → ~525 lines): bot review traps + security finding verification → `references/bot-claim-verification.md`; DI seam validation + runtime/host gotchas → `references/operational-gotchas.md`; batch collection deduped against ci-failure-batching skill
+  - **commit-pr** (~632 → ~533 lines): push-protection scan, canonical remote resolution, auto-merge race, release-please desync → `references/pr-incident-playbook.md`; PowerShell heredoc blocks collapsed; dist/ rule deduplicated
+  - **swarm-pr-feedback** (~856 → ~740 lines): bot review traps + security finding verification → `references/bot-claim-verification.md`; DI seam validation + runtime/host gotchas → `references/operational-gotchas.md`; batch collection deduped against ci-failure-batching skill
 - Each trimmed SKILL.md retains explicit "read `references/`" pointers so agents following the bundled copy can locate the deep material
 - Updated `swarm-pr-review-dry-run.test.ts` to read from the new `references/parser-dry-run.md` path
 

--- a/tests/unit/skills/swarm-pr-review-dry-run.test.ts
+++ b/tests/unit/skills/swarm-pr-review-dry-run.test.ts
@@ -486,7 +486,7 @@ describe('Failure case — artifact_status: ref-not-found', () => {
 
 	test('documented refusal JSON includes both CLEAN counters', () => {
 		const skill = fs.readFileSync(
-			path.join(process.cwd(), '.opencode/skills/swarm-pr-review/SKILL.md'),
+			path.join(process.cwd(), '.opencode/skills/swarm-pr-review/references/parser-dry-run.md'),
 			'utf-8',
 		);
 		const refusalStart = skill.indexOf(

--- a/tests/unit/skills/swarm-pr-review-dry-run.test.ts
+++ b/tests/unit/skills/swarm-pr-review-dry-run.test.ts
@@ -486,7 +486,10 @@ describe('Failure case — artifact_status: ref-not-found', () => {
 
 	test('documented refusal JSON includes both CLEAN counters', () => {
 		const skill = fs.readFileSync(
-			path.join(process.cwd(), '.opencode/skills/swarm-pr-review/references/parser-dry-run.md'),
+			path.join(
+				process.cwd(),
+				'.opencode/skills/swarm-pr-review/references/parser-dry-run.md',
+			),
 			'utf-8',
 		);
 		const refusalStart = skill.indexOf(


### PR DESCRIPTION
Closes #1809

## Summary

- Extracted deep/duplicated material from four oversized SKILL.md files into `references/` subdirectories, following the exemplar pattern established by `codebase-review-swarm/`
- Each trimmed SKILL.md retains explicit "read `references/`" pointers so agents can locate the deep material
- No runtime behavior, protocol, or tool registration changes — pure documentation restructuring

| Skill | Before | After | Extracted to |
|-------|--------|-------|--------------|
| swarm-pr-review | 1744 lines | 1404 lines | `references/parser-dry-run.md`, `references/prompt-templates.md` |
| writing-tests | 948 lines | 829 lines | `references/mock-and-seam-inventory.md` |
| commit-pr | 632 lines | 533 lines | `references/pr-incident-playbook.md` |
| swarm-pr-feedback | 856 lines | 740 lines | `references/bot-claim-verification.md`, `references/operational-gotchas.md` |

Caveats:
- `commit-pr` is `divergent` (#1692): `references/pr-incident-playbook.md` lives only under `.claude/` since its content is repo-specific
- `swarm-pr-feedback` landed at 740 lines (target ~525) — the remaining material is load-bearing protocol that couldn't be safely extracted without breaking mechanical-gate test pins

## Invariant audit

- 1 (plugin init): not touched - no plugin init code changed
- 2 (runtime portability): not touched - no runtime code changed
- 3 (subprocesses): not touched - no subprocess code changed
- 4 (.swarm containment): not touched - no `.swarm/` code changed
- 5 (plan durability): not touched - no plan/ledger code changed
- 6 (test_runner safety): not touched - validation run via direct `bun test`, not `test_runner`
- 7 (test writing): touched - updated `tests/unit/skills/swarm-pr-review-dry-run.test.ts` to read the relocated `references/parser-dry-run.md` path instead of the old inline SKILL.md section; `bun test tests/unit/skills` → 498 pass, 0 fail
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched - no tools, agents, or commands added/changed
- 12 (release/cache): touched - added `docs/releases/pending/skills-progressive-disclosure.md` per Step 2; change is documentation-only (no user-facing behavior) so the fragment documents that explicitly

## Test plan

- [x] `bun test tests/unit/skills` — 498 pass, 0 fail
- [x] `bun run drift:check` — no drift detected
- [x] Verified all 4 skill directories stay within bundler limits (max 3 files / 96KB vs 64 files / 512KB limits)
- [x] `bunx biome ci .` — clean after formatting fix
- [ ] Full CI matrix (unit/quality/pr-standards) — pending on this push
