### PR TITLE
fix(evidence): add retention policy for web_search cache

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1390,6 +1390,8 @@ Configurable via `evidence` config:
 - `max_age_days`: Archive evidence older than N days (default: 90)
 - `max_bundles`: Maximum evidence bundles before auto-archive (default: 1000)
 - `auto_archive`: Enable automatic archiving (default: false)
+- `cache_max_bytes`: Optional byte cap for the documents cache (issue #1184; 512 B–50 MiB; default unset = append-only)
+- `cache_max_records`: Optional record-count cap for the same cache (10–100 000; default unset)
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -579,7 +579,7 @@ Generate an evidence summary showing completion ratio across all tasks, blockers
 
 ### `/swarm archive [--dry-run]`
 
-Archive old evidence bundles. Two-tier retention: age-based (`max_age_days`, default 90) then count-based (`max_bundles`, default 1000). Use `--dry-run` to preview.
+Archive old evidence bundles. Two-tier retention: age-based (`max_age_days`, default 90) then count-based (`max_bundles`, default 1000). When `evidence.cache_max_bytes` or `evidence.cache_max_records` is configured, the command also prunes the `web_search` / `web_fetch` documents cache (`.swarm/evidence-cache/documents.jsonl`); the report then includes a "Documents cache" section. Use `--dry-run` to preview.
 
 ### `/swarm benchmark [--cumulative] [--ci-gate] [--max-cost-usd <n>] [--gate-audit-run <id>]`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -664,8 +664,22 @@ Controls evidence bundle archival for `/swarm finalize` and `/swarm archive`. Th
 | `max_age_days` | number | **30** | 90 | 1–365 | Age threshold for archiving |
 | `max_bundles` | number | **10** | 1000 | 10–10000 | Count cap |
 | `auto_archive` | boolean | `false` | `false` | — | Future gate (config-only) |
+| `cache_max_bytes` | number | _unset_ | _unset_ | 512 B–50 MiB | Optional byte cap for the web_search/web_fetch documents cache (issue #1184). When unset, the cache is append-only. |
+| `cache_max_records` | number | _unset_ | _unset_ | 10–100 000 | Optional record-count cap for the same documents cache. |
 
 > **Note:** `/swarm finalize` applies tighter retention (30 days / 10 bundles) by default to keep only recent evidence for the current project. `/swarm archive` targets long-term retention (90 days / 1000 bundles). Both are configurable via `evidence.max_age_days` and `evidence.max_bundles` in your project config.
+
+### Documents cache retention (issue #1184)
+
+The web_search / web_fetch evidence cache (`.swarm/evidence-cache/documents.jsonl`)
+is **append-only by default**. Set `evidence.cache_max_bytes` and/or
+`evidence.cache_max_records` to opt in to bounded retention — both `/swarm archive`
+and `/swarm finalize` will then prune oldest cache rows (by `capturedAt`) until
+the surviving file is within the configured cap(s). When neither cap is set, the
+cache grows without bound exactly as before. See
+[docs/evidence-and-telemetry.md](evidence-and-telemetry.md#documents-cache-retention-issue-1184)
+for the full bounded-prune contract (atomic rewrite, corrupt-row handling,
+read cap, append-vs-rewrite race tradeoff).
 
 **Example** — Tighten finalize retention:
 

--- a/docs/evidence-and-telemetry.md
+++ b/docs/evidence-and-telemetry.md
@@ -57,7 +57,7 @@ Full field definitions live in `src/config/evidence-schema.ts`.
 
 ### Retention
 
-Config keys (`src/config/schema.ts:179`):
+Config keys (`src/config/schema.ts` → `EvidenceConfigSchema`):
 
 | Key | Archive default | Finalize default | Range | Purpose |
 |-----|:---:|:---:|:---:|---------|

--- a/docs/evidence-and-telemetry.md
+++ b/docs/evidence-and-telemetry.md
@@ -65,8 +65,63 @@ Config keys (`src/config/schema.ts:179`):
 | `max_age_days` | `90` | **30** | 1–365 | Age threshold for archiving |
 | `max_bundles` | `1000` | **10** | 10–10000 | Count cap |
 | `auto_archive` | `false` | `false` | — | Future gate (config-only) |
+| `cache_max_bytes` | _unset_ | _unset_ | 512 B–50 MiB | Optional documents-cache byte cap (issue #1184) |
+| `cache_max_records` | _unset_ | _unset_ | 10–100 000 | Optional documents-cache record cap (issue #1184) |
 
 `/swarm archive` applies two-tier retention: age first, then count. The same execution report includes ordinary evidence, generic evaluation runs, and gate-audit detail, and lists only successful deletions. `/swarm finalize` applies tighter retention (30 days / 10 bundles) to keep only recent evidence. Configure via `evidence.max_age_days` and `evidence.max_bundles` in your project config. Use `--dry-run` to preview.
+
+#### Documents cache retention (issue #1184)
+
+The web_search / web_fetch evidence cache at `.swarm/evidence-cache/documents.jsonl`
+is **append-only by default**. Records are written by `writeEvidenceDocuments`
+(`src/evidence/documents.ts`) on every search/fetch capture and are never removed
+unless you opt in to one or both of the cache retention caps:
+
+| Key | Default | Range | Effect |
+|-----|:---:|:---:|---|
+| `evidence.cache_max_bytes` | _unset_ (append-only) | 512 B–50 MiB | Prune oldest rows until the surviving file is at or below this size |
+| `evidence.cache_max_records` | _unset_ (append-only) | 10–100 000 | Prune oldest rows (by `capturedAt`) until the surviving record count is at or below this number |
+
+When either cap is set, `/swarm archive` and `/swarm finalize` also sweep the
+documents cache (in addition to evidence bundles) and the command report includes
+a **Documents cache** section showing inventory, pruned count, and byte size
+before/after. The prune is:
+
+- **Bounded:** the cache is streamed line-by-line with a hard 100 MiB read cap;
+  on breach the prune aborts and leaves the file byte-identical.
+- **Atomic:** surviving rows are written to a temp file, fsynced, then renamed
+  over the target with Windows-safe retry (`EPERM`/`EBUSY`/`ENOTEMPTY`/`EACCES`,
+  5× / 10 ms backoff). On any rewrite failure the temp file is removed and the
+  original is left untouched (fail-safe: no-change over partial-change).
+- **Corrupt-row tolerant:** lines that fail `JSON.parse` are dropped from the
+  rewrite and reported in the `corrupt` count. They are not relocated to a
+  sidecar — the bounded-growth contract requires that corrupt rows stop counting
+  toward caps.
+- **Project-root contained:** all paths route through `validateSwarmPath`; no
+  scan outside `.swarm/`.
+
+> **Append-vs-rewrite race (known, accepted):** the cache is NOT locked during
+> a prune. A concurrent `web_search`/`web_fetch` whose `appendFile` write is in
+> flight when the prune renames the temp file over the target will, on POSIX,
+> complete against the now-unlinked old inode — the appended row is silently
+> lost from the cache. On Windows the rename may contend (handled by retry) or
+> the appender may write into the replacement file. This data-loss window is
+> accepted because (a) evidence refs are content-addressed
+> (`evd_<sha256[:16]>`), so a lost row's ref re-materializes on the next capture
+> of the same content, and (b) the prune runs only via explicit `/swarm archive`
+> / `/swarm finalize`, not on every write. Locking the write path would tax
+> every `web_search` call and is deliberately avoided.
+
+**Example** — cap the cache at 5 MiB and 5000 records:
+
+```json
+{
+  "evidence": {
+    "cache_max_bytes": 5242880,
+    "cache_max_records": 5000
+  }
+}
+```
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -599,6 +599,8 @@ Configure evidence bundle retention:
 | `max_age_days` | number | `90` | Archive evidence older than N days |
 | `max_bundles` | number | `1000` | Maximum evidence bundles before auto-archive |
 | `auto_archive` | boolean | `false` | Enable automatic archiving of old evidence |
+| `cache_max_bytes` | number | _unset_ | Optional byte cap (512 B–50 MiB) for the `web_search`/`web_fetch` documents cache (issue #1184). Unset = append-only. |
+| `cache_max_records` | number | _unset_ | Optional record-count cap (10–100 000) for the same cache. Unset = append-only. |
 
 ---
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -244,7 +244,11 @@ Raw `api_finding` and `evidence` proposals are accepted as proposal records so
 they can be reviewed, rejected, or rephrased, but they are not directly
 promotable into durable memory. Keep raw API docs, search results, crawled
 pages, and bulky evidence in `.swarm/evidence-cache/documents.jsonl`; promote
-only the concise durable fact they support.
+only the concise durable fact they support. The cache is append-only by
+default; set `evidence.cache_max_bytes` and/or `evidence.cache_max_records`
+to opt in to bounded retention (see
+[docs/evidence-and-telemetry.md](evidence-and-telemetry.md#documents-cache-retention-issue-1184),
+issue #1184).
 
 Durable project, repository, and security memories require source evidence such as a file path, commit SHA, URL, test output reference, evidence ref, or manual reference.
 

--- a/docs/releases/pending/evidence-cache-retention.md
+++ b/docs/releases/pending/evidence-cache-retention.md
@@ -1,0 +1,61 @@
+# Documents cache retention policy (issue #1184)
+
+The `web_search` / `web_fetch` evidence cache at
+`.swarm/evidence-cache/documents.jsonl` now has an explicit, configurable
+retention policy. Previously the cache was purely append-only with no TTL,
+size cap, prune, or cleanup command — long-running projects accumulated
+unbounded disk usage with no automatic or documented cleanup path.
+
+## What changed
+
+- **New optional config keys** under `evidence.*`:
+  - `cache_max_bytes` (range 512 B–50 MiB) — prune oldest cache rows until
+    the surviving file is at or below this size.
+  - `cache_max_records` (range 10–100 000) — prune oldest rows (by
+    `capturedAt`) until the surviving record count is at or below this number.
+  - When **both are unset** (the default), the cache remains append-only —
+    zero behavior change for existing users.
+- **`/swarm archive` and `/swarm finalize`** now also sweep the documents
+  cache when at least one cap is configured, and the command report includes
+  a **Documents cache** section showing inventory, pruned count, and byte
+  size before/after. Both commands support `--dry-run` to preview the prune.
+- **Bounded and safe by construction:**
+  - Streamed line-by-line read with a hard 100 MiB cap; on breach the prune
+    aborts and leaves the file byte-identical.
+  - Atomic rewrite via temp file + fsync + Windows-safe rename retry
+    (`EPERM`/`EBUSY`/`ENOTEMPTY`/`EACCES`, 5× / 10 ms backoff). On any
+    failure (open, write, fsync, or rename) the temp file is removed and the
+    original is left untouched (fail-safe: no-change over partial-change).
+  - Corrupt rows (failed `JSON.parse`) are dropped from the rewrite and
+    reported in the `corrupt` count — they stop counting toward caps.
+  - Project-root contained: all paths route through `validateSwarmPath`.
+- **No plugin-init work:** the prune runs only via `/swarm archive` and
+  `/swarm finalize`, never at plugin load.
+
+## Known append-vs-rewrite race (accepted)
+
+The cache is NOT locked during a prune. A concurrent `web_search`/`web_fetch`
+whose `appendFile` write is in flight when the prune renames the temp file
+over the target will, on POSIX, complete against the now-unlinked old inode —
+the appended row is silently lost from the cache. This data-loss window is
+accepted because evidence refs are content-addressed
+(`evd_<sha256[:16]>`), so a lost row's ref re-materializes on the next
+capture of the same content, and because the prune runs only via explicit
+`/swarm archive` / `/swarm finalize`. Locking the write path would tax every
+`web_search` call and is deliberately avoided.
+
+## Why no age-based pruning
+
+Evidence refs are content-addressed (`evd_<sha256[:16]>`). Age-based pruning
+would silently invalidate cited refs that agents may still hold in
+conversation. Byte/count caps bound disk usage without time-based ref
+invalidation.
+
+## Migration
+
+No migration required. Existing caches are untouched until a user opts in by
+setting one of the new config keys. See
+[docs/evidence-and-telemetry.md](../evidence-and-telemetry.md#documents-cache-retention-issue-1184)
+for the full contract.
+
+Closes #1184.

--- a/src/commands/archive.ts
+++ b/src/commands/archive.ts
@@ -43,7 +43,10 @@ function formatDocumentsCacheSection(
 		(typeof maxRecords === 'number' && maxRecords > 0);
 	if (!capsConfigured) return '';
 
-	const lines: string[] = ['', '### Documents cache (`.swarm/evidence-cache/documents.jsonl`)'];
+	const lines: string[] = [
+		'',
+		'### Documents cache (`.swarm/evidence-cache/documents.jsonl`)',
+	];
 	if (cache.aborted) {
 		lines.push(
 			`**Aborted**: file exceeds the 100 MiB read cap; left untouched. Set a tighter cap or prune manually.`,
@@ -58,11 +61,17 @@ function formatDocumentsCacheSection(
 		capParts.push(`max ${maxRecords} records`);
 	}
 	lines.push(`**Retention caps**: ${capParts.join(', ')}`);
-	lines.push(`**Inventory**: ${cache.inventory} record(s), ${formatBytes(cache.bytesBefore)}`);
+	lines.push(
+		`**Inventory**: ${cache.inventory} record(s), ${formatBytes(cache.bytesBefore)}`,
+	);
 	if (cache.dryRun) {
-		lines.push(`**Would prune**: ${cache.selected} record(s) → ${formatBytes(cache.bytesAfter)}`);
+		lines.push(
+			`**Would prune**: ${cache.selected} record(s) → ${formatBytes(cache.bytesAfter)}`,
+		);
 	} else {
-		lines.push(`**Pruned**: ${cache.archived} record(s) → ${formatBytes(cache.bytesAfter)}`);
+		lines.push(
+			`**Pruned**: ${cache.archived} record(s) → ${formatBytes(cache.bytesAfter)}`,
+		);
 	}
 	if (cache.corrupt > 0) {
 		lines.push(

--- a/src/commands/archive.ts
+++ b/src/commands/archive.ts
@@ -12,6 +12,66 @@ function artifactLabel(artifact: {
 	return `${artifact.namespace}/${artifact.id}`;
 }
 
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+/**
+ * Builds the "Documents cache" report section. Returns '' when no caps are
+ * configured (the cache is append-only and was not swept). The section is
+ * appended to both the dry-run preview and the execution report so the
+ * cache retention is always visible when configured (issue #1184).
+ */
+function formatDocumentsCacheSection(
+	cache: {
+		inventory: number;
+		selected: number;
+		archived: number;
+		corrupt: number;
+		bytesBefore: number;
+		bytesAfter: number;
+		dryRun: boolean;
+		aborted: boolean;
+	},
+	maxBytes?: number,
+	maxRecords?: number,
+): string {
+	const capsConfigured =
+		(typeof maxBytes === 'number' && maxBytes > 0) ||
+		(typeof maxRecords === 'number' && maxRecords > 0);
+	if (!capsConfigured) return '';
+
+	const lines: string[] = ['', '### Documents cache (`.swarm/evidence-cache/documents.jsonl`)'];
+	if (cache.aborted) {
+		lines.push(
+			`**Aborted**: file exceeds the 100 MiB read cap; left untouched. Set a tighter cap or prune manually.`,
+		);
+		return lines.join('\n');
+	}
+	const capParts: string[] = [];
+	if (typeof maxBytes === 'number' && maxBytes > 0) {
+		capParts.push(`max ${formatBytes(maxBytes)}`);
+	}
+	if (typeof maxRecords === 'number' && maxRecords > 0) {
+		capParts.push(`max ${maxRecords} records`);
+	}
+	lines.push(`**Retention caps**: ${capParts.join(', ')}`);
+	lines.push(`**Inventory**: ${cache.inventory} record(s), ${formatBytes(cache.bytesBefore)}`);
+	if (cache.dryRun) {
+		lines.push(`**Would prune**: ${cache.selected} record(s) → ${formatBytes(cache.bytesAfter)}`);
+	} else {
+		lines.push(`**Pruned**: ${cache.archived} record(s) → ${formatBytes(cache.bytesAfter)}`);
+	}
+	if (cache.corrupt > 0) {
+		lines.push(
+			`**Corrupt rows dropped**: ${cache.corrupt} (unparseable lines removed from the cache; reported, not relocated)`,
+		);
+	}
+	return lines.join('\n');
+}
+
 /** Handles `/swarm archive` with a truthful preview/execution report. */
 export async function handleArchiveCommand(
 	directory: string,
@@ -20,11 +80,15 @@ export async function handleArchiveCommand(
 	const config = loadPluginConfig(directory);
 	const maxAgeDays = config?.evidence?.max_age_days ?? 90;
 	const maxBundles = config?.evidence?.max_bundles ?? 1000;
+	const cacheMaxBytes = config?.evidence?.cache_max_bytes;
+	const cacheMaxRecords = config?.evidence?.cache_max_records;
 	const dryRun = args.includes('--dry-run');
 	const report = await archiveEvidence(directory, maxAgeDays, maxBundles, {
 		report: true,
 		dryRun,
 		now: _internals.now(),
+		cacheMaxBytes,
+		cacheMaxRecords,
 	});
 
 	const evaluationSelected = report.evaluation.selected.map(artifactLabel);
@@ -38,12 +102,26 @@ export async function handleArchiveCommand(
 		report.inventoryEvidence.length + report.evaluation.inventory.length;
 
 	if (dryRun) {
+		// Compute the cache section once so it can be appended to any dry-run
+		// return path when caps are configured (issue #1184 — cache retention
+		// is independent of bundle retention and must be visible even when no
+		// bundles are eligible).
+		const cacheSection = formatDocumentsCacheSection(
+			report.documentsCache,
+			cacheMaxBytes,
+			cacheMaxRecords,
+		);
 		if (selectedCount === 0) {
-			if (corruptCount > 0) {
-				return `No valid evidence bundles to archive. Preserved ${corruptCount} corrupt evaluation artifact(s) for data-quality review.`;
+			const baseMsg =
+				corruptCount > 0
+					? `No valid evidence bundles to archive. Preserved ${corruptCount} corrupt evaluation artifact(s) for data-quality review.`
+					: inventoryCount === 0
+						? 'No evidence bundles to archive.'
+						: `No evidence bundles older than ${maxAgeDays} days found, and bundle count (${inventoryCount}) is within max_bundles limit (${maxBundles}).`;
+			if (cacheSection) {
+				return `${baseMsg}\n\n## Archive Preview (dry run)\n${cacheSection}`;
 			}
-			if (inventoryCount === 0) return 'No evidence bundles to archive.';
-			return `No evidence bundles older than ${maxAgeDays} days found, and bundle count (${inventoryCount}) is within max_bundles limit (${maxBundles}).`;
+			return baseMsg;
 		}
 		const lines = [
 			'## Archive Preview (dry run)',
@@ -92,12 +170,30 @@ export async function handleArchiveCommand(
 				`**Evaluation artifacts preserved**: ${report.evaluation.protected.length} lineage-protected, ${corruptCount} corrupt/data-quality`,
 			);
 		}
+		if (cacheSection) lines.push(cacheSection);
 		return lines.join('\n');
 	}
 
 	if (archivedCount === 0) {
 		const failedCount =
 			report.failedEvidence.length + report.evaluation.failed.length;
+		const cacheSection = formatDocumentsCacheSection(
+			report.documentsCache,
+			cacheMaxBytes,
+			cacheMaxRecords,
+		);
+		// When the cache was swept, surface a full report even if no bundles
+		// were archived (issue #1184 — cache retention is independent of bundle
+		// retention). Otherwise preserve the terse "nothing to archive" message.
+		if (cacheSection && report.documentsCache.archived > 0) {
+			const lines = [
+				'## Documents Cache Pruned',
+				'',
+				'No evidence bundles were archived.',
+				cacheSection,
+			];
+			return lines.join('\n');
+		}
 		if (failedCount > 0) {
 			return `No evidence bundles were archived; ${failedCount} selected deletion(s) failed and remain on disk.`;
 		}
@@ -122,5 +218,11 @@ export async function handleArchiveCommand(
 	if (failedCount > 0) {
 		lines.push('', `**Failed deletions preserved**: ${failedCount}`);
 	}
+	const cacheSection = formatDocumentsCacheSection(
+		report.documentsCache,
+		cacheMaxBytes,
+		cacheMaxRecords,
+	);
+	if (cacheSection) lines.push(cacheSection);
 	return lines.join('\n');
 }

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -1221,14 +1221,18 @@ export async function runArchiveStage(ctx: CloseStageContext): Promise<void> {
 
 /**
  * Runs the evidence-retention sub-logic of STAGE 2 (ARCHIVE).
- * Reads max_age_days / max_bundles from config.evidence (FR-016) and
- * calls archiveEvidence. Fail-open: pushes a warning on error but never throws.
+ * Reads max_age_days / max_bundles / cache_max_bytes / cache_max_records from
+ * config.evidence (FR-016, issue #1184) and calls archiveEvidence. The report
+ * overload is used so the documents-cache prune runs when cache caps are set.
+ * Fail-open: pushes a warning on error but never throws.
  */
 export async function runArchiveEvidenceRetention(
 	ctx: ArchiveStageContext,
 ): Promise<void> {
 	let maxAgeDays = 30;
 	let maxBundles = 10;
+	let cacheMaxBytes: number | undefined;
+	let cacheMaxRecords: number | undefined;
 	try {
 		const { config: evidenceLoadedConfig } =
 			_internals.loadPluginConfigWithMeta(ctx.directory);
@@ -1242,12 +1246,27 @@ export async function runArchiveEvidenceRetention(
 		if (typeof evidenceCfg.max_bundles === 'number') {
 			maxBundles = evidenceCfg.max_bundles;
 		}
+		// Issue #1184: documents-cache retention caps. Only forwarded when set
+		// so the cache remains append-only by default.
+		if (typeof evidenceCfg.cache_max_bytes === 'number') {
+			cacheMaxBytes = evidenceCfg.cache_max_bytes;
+		}
+		if (typeof evidenceCfg.cache_max_records === 'number') {
+			cacheMaxRecords = evidenceCfg.cache_max_records;
+		}
 	} catch {
 		// Fallback to defaults on config read failure
 	}
 
 	try {
-		await _internals.archiveEvidence(ctx.directory, maxAgeDays, maxBundles);
+		// Use the report overload so the documents-cache sweep (issue #1184)
+		// runs when cache caps are configured. The report itself is not surfaced
+		// to the finalize summary; only warnings on failure.
+		await _internals.archiveEvidence(ctx.directory, maxAgeDays, maxBundles, {
+			report: true,
+			cacheMaxBytes,
+			cacheMaxRecords,
+		});
 	} catch (error) {
 		const msg = error instanceof Error ? error.message : String(error);
 		ctx.warnings.push(`Evidence retention archive failed: ${msg}`);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -329,7 +329,11 @@ export const EvidenceConfigSchema = z.object({
 	 * `/swarm archive` and `/swarm finalize` prune oldest rows until the
 	 * surviving file is at or below this size. Range: 512 B – 50 MiB.
 	 */
-	cache_max_bytes: z.number().min(512).max(50 * 1024 * 1024).optional(),
+	cache_max_bytes: z
+		.number()
+		.min(512)
+		.max(50 * 1024 * 1024)
+		.optional(),
 	/**
 	 * Optional record-count cap for the same documents cache. When omitted, no
 	 * count-based pruning. When set, oldest rows (by `capturedAt`) are pruned

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -322,6 +322,21 @@ export const EvidenceConfigSchema = z.object({
 	max_age_days: z.number().min(1).max(365).default(90),
 	max_bundles: z.number().min(10).max(10000).default(1000),
 	auto_archive: z.boolean().default(false),
+	/**
+	 * Optional byte cap for the documents cache at
+	 * `.swarm/evidence-cache/documents.jsonl` (web_search / web_fetch captures).
+	 * When omitted, the cache is append-only by design (issue #1184). When set,
+	 * `/swarm archive` and `/swarm finalize` prune oldest rows until the
+	 * surviving file is at or below this size. Range: 512 B – 50 MiB.
+	 */
+	cache_max_bytes: z.number().min(512).max(50 * 1024 * 1024).optional(),
+	/**
+	 * Optional record-count cap for the same documents cache. When omitted, no
+	 * count-based pruning. When set, oldest rows (by `capturedAt`) are pruned
+	 * until the surviving record count is at or below this number.
+	 * Range: 10 – 100 000.
+	 */
+	cache_max_records: z.number().min(10).max(100_000).optional(),
 });
 
 export type EvidenceConfig = z.infer<typeof EvidenceConfigSchema>;

--- a/src/evidence/documents-retention.ts
+++ b/src/evidence/documents-retention.ts
@@ -36,10 +36,19 @@
  *   - Windows-safe rename: `EPERM`/`EBUSY`/`ENOTEMPTY`/`EACCES` are retried
  *     with bounded backoff (5× / 10ms). On final failure the temp file is
  *     removed and the original is left untouched (fail-safe).
+ *
+ * Memory tradeoff (L6-002): valid rows are parsed into a `ParsedRow[]` and
+ * retained in memory (raw string + parsed object per row) before selection.
+ * The 100 MiB read cap bounds input bytes, but the in-process heap footprint
+ * is higher (V8 string + object overhead). This is an accepted tradeoff: the
+ * prune runs once per explicit `/swarm archive` / `/swarm finalize` (never on
+ * a hot path), the input is bounded, and a streaming rewrite would be a
+ * materially larger refactor. If the cache ever needs to scale beyond the
+ * current cap, switch `readCacheRows` + `selectSurvivors` to a streaming
+ * selection (single pass, write survivors directly to the temp file).
  */
 import * as fs from 'node:fs';
 import * as fsp from 'node:fs/promises';
-import * as path from 'node:path';
 import * as readline from 'node:readline';
 import { validateSwarmPath } from '../hooks/utils';
 import { warn } from '../utils';
@@ -182,9 +191,7 @@ function emptyResult(dryRun: boolean): DocumentsRetentionResult {
  * Returns `{ rows, corrupt, aborted, bytesBefore }`. On `aborted: true` the
  * caller must not perform any rewrite.
  */
-async function readCacheRows(
-	filePath: string,
-): Promise<{
+async function readCacheRows(filePath: string): Promise<{
 	rows: ParsedRow[];
 	corrupt: number;
 	aborted: boolean;
@@ -207,36 +214,45 @@ async function readCacheRows(
 	let bytesRead = 0;
 	let aborted = false;
 
-	outer: for await (const line of rl) {
-		// readline strips the trailing newline; account for it (LF or CRLF).
-		// We cannot know which without inspecting the raw stream, so use LF
-		// (1 byte) as the conservative lower bound — the cap is a safety
-		// guard, not an exact budget.
-		const lineBytes = Buffer.byteLength(line, 'utf8') + 1;
-		bytesRead += lineBytes;
-		if (bytesRead > MAX_READ_BYTES) {
-			aborted = true;
-			break outer;
-		}
-		if (line.length === 0) continue;
-		let record: Record<string, unknown> | null = null;
-		try {
-			const parsed = JSON.parse(line);
-			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-				record = parsed as Record<string, unknown>;
-			} else {
+	// Cleanup runs in finally so a stream 'error' event (e.g. EIO mid-read)
+	// cannot skip rl.close()/stream.destroy() and leak the file handle (PRR-003).
+	try {
+		for await (const line of rl) {
+			// readline strips the trailing newline; account for it (LF or CRLF).
+			// We cannot know which without inspecting the raw stream, so use LF
+			// (1 byte) as the conservative lower bound — the cap is a safety
+			// guard, not an exact budget. Note: the rewrite (see rewriteAtomic)
+			// always joins survivors with '\n', so a CRLF source is normalized
+			// to LF on rewrite; bytesAfter reflects the post-normalization size
+			// (PRR-013).
+			const lineBytes = Buffer.byteLength(line, 'utf8') + 1;
+			bytesRead += lineBytes;
+			if (bytesRead > MAX_READ_BYTES) {
+				aborted = true;
+				break;
+			}
+			if (line.length === 0) continue;
+			let record: Record<string, unknown> | null = null;
+			try {
+				const parsed = JSON.parse(line);
+				if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+					record = parsed as Record<string, unknown>;
+				} else {
+					corrupt++;
+					continue;
+				}
+			} catch {
 				corrupt++;
 				continue;
 			}
-		} catch {
-			corrupt++;
-			continue;
+			rows.push({ raw: line, bytes: lineBytes, record });
 		}
-		rows.push({ raw: line, bytes: lineBytes, record });
+	} finally {
+		// Ensure the stream is fully released on every path (normal exit,
+		// break, or thrown stream error).
+		rl.close();
+		stream.destroy();
 	}
-	// Ensure the stream is fully released before returning.
-	rl.close();
-	stream.destroy();
 
 	return { rows, corrupt, aborted, bytesBefore };
 }
@@ -247,8 +263,14 @@ async function readCacheRows(
  * index (which would be non-deterministic across reads on some platforms).
  */
 function oldestFirst(a: ParsedRow, b: ParsedRow): number {
-	const at = typeof a.record?.capturedAt === 'string' ? (a.record.capturedAt as string) : '';
-	const bt = typeof b.record?.capturedAt === 'string' ? (b.record.capturedAt as string) : '';
+	const at =
+		typeof a.record?.capturedAt === 'string'
+			? (a.record.capturedAt as string)
+			: '';
+	const bt =
+		typeof b.record?.capturedAt === 'string'
+			? (b.record.capturedAt as string)
+			: '';
 	if (at === bt) return a.raw.localeCompare(b.raw);
 	return at.localeCompare(bt);
 }
@@ -261,21 +283,32 @@ function selectSurvivors(
 ): { survivors: ParsedRow[]; selected: number } {
 	// Work on a oldest-first copy so "drop oldest" is index-based and stable.
 	const ordered = [...rows].sort(oldestFirst);
-	let survivors = ordered;
 
-	if (typeof maxRecords === 'number' && survivors.length > maxRecords) {
-		survivors = survivors.slice(survivors.length - maxRecords);
+	// Count cap: keep the newest `maxRecords` rows (drop oldest via slice).
+	let keepFrom = 0;
+	if (typeof maxRecords === 'number' && ordered.length > maxRecords) {
+		keepFrom = ordered.length - maxRecords;
 	}
 
+	// Byte cap: advance `keepFrom` forward (dropping oldest) until the
+	// surviving tail is at or under the byte cap. Using an index instead of
+	// repeated Array.shift() keeps this O(n) rather than O(n²) (L6-001).
+	// `total` must start from the post-count-cap survivors (ordered[keepFrom:])
+	// — NOT all rows — so rows already dropped by the count cap are not
+	// double-subtracted (final-critic regression: without this, tight combined
+	// caps over-prune to an empty file).
 	if (typeof maxBytes === 'number' && maxBytes > 0) {
-		let total = survivors.reduce((sum, row) => sum + row.bytes, 0);
-		while (total > maxBytes && survivors.length > 0) {
-			const dropped = survivors.shift();
-			if (!dropped) break;
-			total -= dropped.bytes;
+		let total = 0;
+		for (let i = keepFrom; i < ordered.length; i++) {
+			total += ordered[i].bytes;
+		}
+		while (keepFrom < ordered.length && total > maxBytes) {
+			total -= ordered[keepFrom].bytes;
+			keepFrom++;
 		}
 	}
 
+	const survivors = ordered.slice(keepFrom);
 	const selected = rows.length - survivors.length;
 	return { survivors, selected };
 }
@@ -295,9 +328,10 @@ async function rewriteAtomic(
 	survivors: ParsedRow[],
 ): Promise<number> {
 	const tmpPath = `${filePath}.tmp.${Date.now()}.${process.pid}`;
-	const payload = survivors.length > 0
-		? `${survivors.map((row) => row.raw).join('\n')}\n`
-		: '';
+	const payload =
+		survivors.length > 0
+			? `${survivors.map((row) => row.raw).join('\n')}\n`
+			: '';
 	// `succeeded` flips to true only after the rename lands. The outer
 	// finally uses it to decide whether to clean up the temp file: on every
 	// error path (open/write/fsync/rename) the temp is removed; on success
@@ -349,12 +383,17 @@ export async function pruneEvidenceDocuments(
 
 	const filePath = validateSwarmPath(args.directory, EVIDENCE_CACHE_FILE);
 
-	// Missing file: idempotent no-op.
+	// Missing file: idempotent no-op. Only ENOENT is treated as "missing";
+	// other stat errors (EACCES, EIO, ELOOP, ...) are rethrown so the caller
+	// (archive command, fail-open) can log the real cause instead of masking
+	// it as a benign missing-file no-op (PRR-002).
 	let stat: fs.Stats;
 	try {
 		stat = await _internals.stat(filePath);
-	} catch {
-		return emptyResult(dryRun);
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException)?.code;
+		if (code === 'ENOENT') return emptyResult(dryRun);
+		throw err;
 	}
 
 	// No caps configured: preserve append-only behavior, report size only.
@@ -371,7 +410,12 @@ export async function pruneEvidenceDocuments(
 		};
 	}
 
-	let readResult: { rows: ParsedRow[]; corrupt: number; aborted: boolean; bytesBefore: number };
+	let readResult: {
+		rows: ParsedRow[];
+		corrupt: number;
+		aborted: boolean;
+		bytesBefore: number;
+	};
 	try {
 		readResult = await readCacheRows(filePath);
 	} catch (err) {

--- a/src/evidence/documents-retention.ts
+++ b/src/evidence/documents-retention.ts
@@ -1,0 +1,446 @@
+/**
+ * Retention for the web_search / web_fetch documents cache at
+ * `.swarm/evidence-cache/documents.jsonl`.
+ *
+ * Background (issue #1184): `writeEvidenceDocuments` in `./documents.ts` is
+ * purely append-only. Without this module the cache grows without bound.
+ * This module provides a bounded, project-root-contained, atomic-rewrite
+ * prune that is invoked only via `/swarm archive` and `/swarm finalize`
+ * (never on the plugin init path — AGENTS.md invariant #1).
+ *
+ * Design contract (mirrors `archiveEvaluationArtifacts` in
+ * `../evaluation/retention.ts` where applicable):
+ *   - Optional byte cap and optional record-count cap. When both are unset the
+ *     prune is a no-op (current append-only behavior preserved exactly).
+ *   - Corrupt rows (failed `JSON.parse`) are dropped from the rewrite and
+ *     reported via `corrupt` count. They are NOT relocated to a sidecar —
+ *     matches the "report, don't relocate" precedent in
+ *     `archiveEvaluationArtifacts` (retention.ts:246-254), while still
+ *     preserving the bounded-growth contract (a corrupt row otherwise counts
+ *     toward caps forever).
+ *   - Atomic rewrite via temp file + fsync + rename. NOT under
+ *     `withEvidenceLock`: web_search/web_fetch are hot paths and forcing a
+ *     lockfile round-trip on every capture is an unjustified latency tax
+ *     (issue-tracer critic item #2). The append-vs-rewrite race is a known,
+ *     accepted data-loss window: a concurrent `appendFile` whose write is in
+ *     flight when the prune renames the temp over the target will, on POSIX,
+ *     complete against the now-unlinked old inode (the appended row is
+ *     silently lost from the cache). This is accepted because refs are
+ *     content-addressed (`evd_<sha256[:16]>`) so a lost row's ref
+ *     re-materializes on the next capture of the same content, and because
+ *     the prune runs only via explicit `/swarm archive` / `/swarm finalize`,
+ *     not on every write.
+ *   - Read is streamed line-by-line via `node:readline` with a hard 100 MiB
+ *     cap. On cap breach the prune aborts, writes nothing, and leaves the
+ *     file byte-identical.
+ *   - Windows-safe rename: `EPERM`/`EBUSY`/`ENOTEMPTY`/`EACCES` are retried
+ *     with bounded backoff (5× / 10ms). On final failure the temp file is
+ *     removed and the original is left untouched (fail-safe).
+ */
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import * as readline from 'node:readline';
+import { validateSwarmPath } from '../hooks/utils';
+import { warn } from '../utils';
+
+const EVIDENCE_CACHE_FILE = 'evidence-cache/documents.jsonl';
+
+/**
+ * Hard upper bound on how many bytes `pruneEvidenceDocuments` will read
+ * before aborting. Prevents OOM on an attacker-controlled or pathologically
+ * large file. 100 MiB is far above any realistic evidence cache (per-record
+ * text is capped at 4000 chars in `documents.ts:8`) yet small enough that the
+ * read completes well within any reasonable command timeout.
+ */
+const MAX_READ_BYTES = 100 * 1024 * 1024;
+
+/** Windows-safe rename retry shape (mirrors `readSwarmFileAsync` in hooks/utils.ts). */
+const RENAME_MAX_ATTEMPTS = 5;
+const RENAME_BACKOFF_MS = 10;
+const RENAME_RETRY_CODES = new Set(['EPERM', 'EBUSY', 'ENOTEMPTY', 'EACCES']);
+
+export interface DocumentsRetentionResult {
+	/** Total valid (parseable) rows read before pruning. Excludes corrupt rows. */
+	inventory: number;
+	/** Rows marked for deletion by the policy (same as `inventory - surviving`). */
+	selected: number;
+	/** Rows actually removed from the file. Always 0 when `dryRun` or `aborted`. */
+	archived: number;
+	/** Unparseable rows dropped from the rewrite (count only; not preserved). */
+	corrupt: number;
+	/** File size in bytes before the prune (0 if the file did not exist). */
+	bytesBefore: number;
+	/** File size in bytes after the prune. Equal to `bytesBefore` on no-op. */
+	bytesAfter: number;
+	/** True when the prune produced no file mutation. */
+	dryRun: boolean;
+	/**
+	 * True when the read cap (`MAX_READ_BYTES`) was exceeded. On abort the file
+	 * is left byte-identical — no temp file, no rewrite, no sidecar.
+	 */
+	aborted: boolean;
+}
+
+export interface PruneEvidenceDocumentsArgs {
+	directory: string;
+	/** Optional byte cap. When omitted, no byte-based pruning. */
+	maxBytes?: number;
+	/** Optional record-count cap. When omitted, no count-based pruning. */
+	maxRecords?: number;
+	/** When true, compute the plan but write nothing. */
+	dryRun?: boolean;
+}
+
+interface ParsedRow {
+	/** Original raw line (without trailing newline). */
+	raw: string;
+	/** Byte length of `raw` plus the newline that separated it. */
+	bytes: number;
+	/** Parsed record, or null when JSON.parse failed. */
+	record: Record<string, unknown> | null;
+}
+
+/** Internal DI seam (AGENTS.md invariant #7 — preferred over mock.module). */
+export const _internals: {
+	stat: (path: string) => Promise<fs.Stats>;
+	createReadStream: (
+		path: string,
+		options: { encoding: BufferEncoding; highWaterMark: number },
+	) => fs.ReadStream;
+	openSync: (path: string, flags: fs.OpenMode) => number;
+	writeSync: (fd: number, data: string, position?: number | null) => number;
+	fsyncSync: (fd: number) => void;
+	closeSync: (fd: number) => void;
+	renameWithRetry: (src: string, dst: string) => Promise<void>;
+	unlink: (path: string) => Promise<void>;
+} = {
+	stat: (p) => fsp.stat(p),
+	createReadStream: (p, options) => fs.createReadStream(p, options),
+	openSync: (p, flags) => fs.openSync(p, flags),
+	writeSync: (fd, data, position) => fs.writeSync(fd, data, position),
+	fsyncSync: (fd) => fs.fsyncSync(fd),
+	closeSync: (fd) => fs.closeSync(fd),
+	renameWithRetry: atomicRenameWithRetry,
+	unlink: (p) => fsp.unlink(p),
+};
+
+/**
+ * Atomic rename with bounded retry for Windows.
+ *
+ * On Windows, `fs.rename` over an existing file can fail with `EPERM` when
+ * another handle (e.g. a concurrent `appendFile` from web_search) holds the
+ * target. We retry the rename a bounded number of times with a short backoff
+ * (the `readSwarmFileAsync` precedent in `hooks/utils.ts:263` uses the same
+ * 5× / 10ms shape for the macOS rename-visibility race). On final failure we
+ * rethrow — the caller is responsible for cleaning up the temp file.
+ *
+ * The optional `renameFn` is a test seam (defaults to `fsp.rename`) so the
+ * retry loop can be exercised deterministically on non-Windows hosts.
+ */
+export async function atomicRenameWithRetry(
+	src: string,
+	dst: string,
+	renameFn: (s: string, d: string) => Promise<void> = fsp.rename,
+): Promise<void> {
+	let lastErr: unknown;
+	for (let attempt = 0; attempt < RENAME_MAX_ATTEMPTS; attempt++) {
+		try {
+			await renameFn(src, dst);
+			return;
+		} catch (err) {
+			lastErr = err;
+			const code = (err as NodeJS.ErrnoException)?.code;
+			if (!code || !RENAME_RETRY_CODES.has(code)) {
+				throw err;
+			}
+			if (attempt < RENAME_MAX_ATTEMPTS - 1) {
+				await new Promise((resolve) => setTimeout(resolve, RENAME_BACKOFF_MS));
+			}
+		}
+	}
+	throw lastErr;
+}
+
+function emptyResult(dryRun: boolean): DocumentsRetentionResult {
+	return {
+		inventory: 0,
+		selected: 0,
+		archived: 0,
+		corrupt: 0,
+		bytesBefore: 0,
+		bytesAfter: 0,
+		dryRun,
+		aborted: false,
+	};
+}
+
+/**
+ * Stream the cache file line by line, parsing each row. Aborts if the total
+ * bytes read would exceed `MAX_READ_BYTES`.
+ *
+ * Returns `{ rows, corrupt, aborted, bytesBefore }`. On `aborted: true` the
+ * caller must not perform any rewrite.
+ */
+async function readCacheRows(
+	filePath: string,
+): Promise<{
+	rows: ParsedRow[];
+	corrupt: number;
+	aborted: boolean;
+	bytesBefore: number;
+}> {
+	const stat = await _internals.stat(filePath);
+	const bytesBefore = stat.size;
+	const stream = _internals.createReadStream(filePath, {
+		encoding: 'utf8',
+		// 64 KiB chunks balance syscall overhead against memory pressure.
+		highWaterMark: 64 * 1024,
+	});
+	const rl = readline.createInterface({
+		input: stream,
+		crlfDelay: Infinity,
+	});
+
+	const rows: ParsedRow[] = [];
+	let corrupt = 0;
+	let bytesRead = 0;
+	let aborted = false;
+
+	outer: for await (const line of rl) {
+		// readline strips the trailing newline; account for it (LF or CRLF).
+		// We cannot know which without inspecting the raw stream, so use LF
+		// (1 byte) as the conservative lower bound — the cap is a safety
+		// guard, not an exact budget.
+		const lineBytes = Buffer.byteLength(line, 'utf8') + 1;
+		bytesRead += lineBytes;
+		if (bytesRead > MAX_READ_BYTES) {
+			aborted = true;
+			break outer;
+		}
+		if (line.length === 0) continue;
+		let record: Record<string, unknown> | null = null;
+		try {
+			const parsed = JSON.parse(line);
+			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+				record = parsed as Record<string, unknown>;
+			} else {
+				corrupt++;
+				continue;
+			}
+		} catch {
+			corrupt++;
+			continue;
+		}
+		rows.push({ raw: line, bytes: lineBytes, record });
+	}
+	// Ensure the stream is fully released before returning.
+	rl.close();
+	stream.destroy();
+
+	return { rows, corrupt, aborted, bytesBefore };
+}
+
+/**
+ * Sort comparator: oldest first by `capturedAt` (ISO string). Falls back to
+ * original raw content for a stable, deterministic tiebreak — never to array
+ * index (which would be non-deterministic across reads on some platforms).
+ */
+function oldestFirst(a: ParsedRow, b: ParsedRow): number {
+	const at = typeof a.record?.capturedAt === 'string' ? (a.record.capturedAt as string) : '';
+	const bt = typeof b.record?.capturedAt === 'string' ? (b.record.capturedAt as string) : '';
+	if (at === bt) return a.raw.localeCompare(b.raw);
+	return at.localeCompare(bt);
+}
+
+/** Select which rows survive after applying count and byte caps. */
+function selectSurvivors(
+	rows: ParsedRow[],
+	maxRecords?: number,
+	maxBytes?: number,
+): { survivors: ParsedRow[]; selected: number } {
+	// Work on a oldest-first copy so "drop oldest" is index-based and stable.
+	const ordered = [...rows].sort(oldestFirst);
+	let survivors = ordered;
+
+	if (typeof maxRecords === 'number' && survivors.length > maxRecords) {
+		survivors = survivors.slice(survivors.length - maxRecords);
+	}
+
+	if (typeof maxBytes === 'number' && maxBytes > 0) {
+		let total = survivors.reduce((sum, row) => sum + row.bytes, 0);
+		while (total > maxBytes && survivors.length > 0) {
+			const dropped = survivors.shift();
+			if (!dropped) break;
+			total -= dropped.bytes;
+		}
+	}
+
+	const selected = rows.length - survivors.length;
+	return { survivors, selected };
+}
+
+/**
+ * Atomically rewrite the cache file with the surviving rows.
+ *
+ * Writes to `${filePath}.tmp.${ts}.${pid}`, fsyncs, then renames over the
+ * target with Windows-safe retry. On ANY failure (open, write, fsync, or
+ * rename) the temp file is removed and the original is left untouched
+ * (fail-safe: prefer no-change over partial-change). The temp file is
+ * tracked from open through successful rename so every error path cleans
+ * it up.
+ */
+async function rewriteAtomic(
+	filePath: string,
+	survivors: ParsedRow[],
+): Promise<number> {
+	const tmpPath = `${filePath}.tmp.${Date.now()}.${process.pid}`;
+	const payload = survivors.length > 0
+		? `${survivors.map((row) => row.raw).join('\n')}\n`
+		: '';
+	// `succeeded` flips to true only after the rename lands. The outer
+	// finally uses it to decide whether to clean up the temp file: on every
+	// error path (open/write/fsync/rename) the temp is removed; on success
+	// the temp no longer exists (it became the target via rename).
+	let succeeded = false;
+	const fd = _internals.openSync(tmpPath, 'w');
+	try {
+		_internals.writeSync(fd, payload, 0);
+		_internals.fsyncSync(fd);
+		_internals.closeSync(fd);
+		await _internals.renameWithRetry(tmpPath, filePath);
+		succeeded = true;
+	} catch (err) {
+		// Ensure the fd is closed on write/fsync/rename failure (closeSync is
+		// idempotent-ish: a double-close throws EBADF which we swallow).
+		try {
+			_internals.closeSync(fd);
+		} catch {
+			// Already closed or close failed — best effort.
+		}
+		const msg = err instanceof Error ? err.message : String(err);
+		throw new Error(`documents-cache rewrite failed: ${msg}`);
+	} finally {
+		if (!succeeded) {
+			try {
+				await _internals.unlink(tmpPath);
+			} catch {
+				// Best-effort cleanup; the OS will reap an orphaned tmp file.
+			}
+		}
+	}
+	return Buffer.byteLength(payload, 'utf8');
+}
+
+/**
+ * Apply the configured byte/count retention policy to the documents cache.
+ *
+ * Safe to call on a missing file (returns an idempotent zeroed result) and
+ * safe to call with both caps unset (no-op). Never throws for routine cases;
+ * surfaces unexpected I/O errors to the caller (archive command fails open).
+ */
+export async function pruneEvidenceDocuments(
+	args: PruneEvidenceDocumentsArgs,
+): Promise<DocumentsRetentionResult> {
+	const dryRun = args.dryRun === true;
+	const capsUnset =
+		(typeof args.maxBytes !== 'number' || args.maxBytes <= 0) &&
+		(typeof args.maxRecords !== 'number' || args.maxRecords <= 0);
+
+	const filePath = validateSwarmPath(args.directory, EVIDENCE_CACHE_FILE);
+
+	// Missing file: idempotent no-op.
+	let stat: fs.Stats;
+	try {
+		stat = await _internals.stat(filePath);
+	} catch {
+		return emptyResult(dryRun);
+	}
+
+	// No caps configured: preserve append-only behavior, report size only.
+	if (capsUnset) {
+		return {
+			inventory: 0,
+			selected: 0,
+			archived: 0,
+			corrupt: 0,
+			bytesBefore: stat.size,
+			bytesAfter: stat.size,
+			dryRun,
+			aborted: false,
+		};
+	}
+
+	let readResult: { rows: ParsedRow[]; corrupt: number; aborted: boolean; bytesBefore: number };
+	try {
+		readResult = await readCacheRows(filePath);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		warn(`documents-cache prune: read failed: ${msg}`);
+		throw err;
+	}
+
+	if (readResult.aborted) {
+		warn(
+			`documents-cache prune: aborted, file exceeds ${MAX_READ_BYTES} bytes; left untouched`,
+		);
+		return {
+			inventory: readResult.rows.length,
+			selected: 0,
+			archived: 0,
+			corrupt: readResult.corrupt,
+			bytesBefore: readResult.bytesBefore,
+			bytesAfter: readResult.bytesBefore,
+			dryRun,
+			aborted: true,
+		};
+	}
+
+	const { survivors, selected } = selectSurvivors(
+		readResult.rows,
+		args.maxRecords,
+		args.maxBytes,
+	);
+
+	if (dryRun) {
+		// Compute the post-prune byte size without writing.
+		const bytesAfter = survivors.reduce((sum, row) => sum + row.bytes, 0);
+		return {
+			inventory: readResult.rows.length,
+			selected,
+			archived: 0,
+			corrupt: readResult.corrupt,
+			bytesBefore: readResult.bytesBefore,
+			bytesAfter,
+			dryRun: true,
+			aborted: false,
+		};
+	}
+
+	if (selected === 0 && readResult.corrupt === 0) {
+		// Nothing to do — avoid an unnecessary rewrite entirely.
+		return {
+			inventory: readResult.rows.length,
+			selected: 0,
+			archived: 0,
+			corrupt: 0,
+			bytesBefore: readResult.bytesBefore,
+			bytesAfter: readResult.bytesBefore,
+			dryRun: false,
+			aborted: false,
+		};
+	}
+
+	const bytesAfter = await rewriteAtomic(filePath, survivors);
+
+	return {
+		inventory: readResult.rows.length,
+		selected,
+		archived: selected,
+		corrupt: readResult.corrupt,
+		bytesBefore: readResult.bytesBefore,
+		bytesAfter,
+		dryRun: false,
+		aborted: false,
+	};
+}

--- a/src/evidence/manager.ts
+++ b/src/evidence/manager.ts
@@ -27,6 +27,10 @@ import {
 	archiveEvaluationArtifacts,
 	type EvaluationRetentionResult,
 } from '../evaluation/retention.js';
+import {
+	type DocumentsRetentionResult,
+	pruneEvidenceDocuments,
+} from './documents-retention.js';
 import { readSwarmFileAsync, validateSwarmPath } from '../hooks/utils';
 import { warn } from '../utils';
 import { bunWrite } from '../utils/bun-compat';
@@ -653,12 +657,27 @@ export type EvidenceArchiveReport = {
 	archivedEvidence: string[];
 	failedEvidence: string[];
 	evaluation: EvaluationRetentionResult;
+	/**
+	 * Documents-cache retention result (issue #1184). Always present in the
+	 * report shape — a zeroed result ({ inventory: 0, selected: 0, ... })
+	 * indicates the cache was not pruned (no caps configured, file missing,
+	 * or prune disabled).
+	 */
+	documentsCache: DocumentsRetentionResult;
 };
 
 export type EvidenceArchiveReportOptions = {
 	report: true;
 	dryRun?: boolean;
 	now?: Date;
+	/**
+	 * Optional documents-cache retention caps (issue #1184). When either is a
+	 * positive number, `archiveEvidence` also prunes
+	 * `.swarm/evidence-cache/documents.jsonl` after the bundle/evaluation
+	 * sweep. When both are unset, the cache is left untouched (append-only).
+	 */
+	cacheMaxBytes?: number;
+	cacheMaxRecords?: number;
 };
 
 export function archiveEvidence(
@@ -744,6 +763,36 @@ export async function archiveEvidence(
 		now: options?.now,
 	});
 
+	// Documents-cache retention (issue #1184). Only runs when at least one cap
+	// is configured. Fail-open: a cache I/O error must never break the bundle
+	// archive. The zeroed result preserves the report shape for consumers.
+	let documentsCache: DocumentsRetentionResult = {
+		inventory: 0,
+		selected: 0,
+		archived: 0,
+		corrupt: 0,
+		bytesBefore: 0,
+		bytesAfter: 0,
+		dryRun: options?.dryRun === true,
+		aborted: false,
+	};
+	if (
+		(typeof options?.cacheMaxBytes === 'number' && options.cacheMaxBytes > 0) ||
+		(typeof options?.cacheMaxRecords === 'number' && options.cacheMaxRecords > 0)
+	) {
+		try {
+			documentsCache = await _internals.pruneEvidenceDocuments({
+				directory,
+				maxBytes: options?.cacheMaxBytes,
+				maxRecords: options?.cacheMaxRecords,
+				dryRun: options?.dryRun,
+			});
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			warn(`archiveEvidence: documents-cache prune failed (fail-open): ${msg}`);
+		}
+	}
+
 	if (options?.report) {
 		return {
 			inventoryEvidence: [...taskIds].sort(),
@@ -753,6 +802,7 @@ export async function archiveEvidence(
 			archivedEvidence: archived.sort(),
 			failedEvidence: failed.sort(),
 			evaluation,
+			documentsCache,
 		};
 	}
 	return archived.sort();
@@ -777,6 +827,7 @@ export const _internals: {
 	validateEvidence: typeof validateEvidence;
 	saveEvidence: typeof saveEvidence;
 	deleteEvidence: typeof deleteEvidence;
+	pruneEvidenceDocuments: typeof pruneEvidenceDocuments;
 	now: () => Date;
 } = {
 	wrapFlatRetrospective,
@@ -786,5 +837,6 @@ export const _internals: {
 	validateEvidence,
 	saveEvidence,
 	deleteEvidence,
+	pruneEvidenceDocuments,
 	now: () => new Date(),
 } as const;

--- a/src/evidence/manager.ts
+++ b/src/evidence/manager.ts
@@ -27,13 +27,13 @@ import {
 	archiveEvaluationArtifacts,
 	type EvaluationRetentionResult,
 } from '../evaluation/retention.js';
+import { readSwarmFileAsync, validateSwarmPath } from '../hooks/utils';
+import { warn } from '../utils';
+import { bunWrite } from '../utils/bun-compat';
 import {
 	type DocumentsRetentionResult,
 	pruneEvidenceDocuments,
 } from './documents-retention.js';
-import { readSwarmFileAsync, validateSwarmPath } from '../hooks/utils';
-import { warn } from '../utils';
-import { bunWrite } from '../utils/bun-compat';
 import { withEvidenceLock } from './lock.js';
 
 /**
@@ -778,7 +778,8 @@ export async function archiveEvidence(
 	};
 	if (
 		(typeof options?.cacheMaxBytes === 'number' && options.cacheMaxBytes > 0) ||
-		(typeof options?.cacheMaxRecords === 'number' && options.cacheMaxRecords > 0)
+		(typeof options?.cacheMaxRecords === 'number' &&
+			options.cacheMaxRecords > 0)
 	) {
 		try {
 			documentsCache = await _internals.pruneEvidenceDocuments({

--- a/tests/unit/commands/archive-documents-cache.test.ts
+++ b/tests/unit/commands/archive-documents-cache.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Integration tests for the documents-cache retention section of the
+ * `/swarm archive` command report (issue #1184).
+ *
+ * Proves:
+ *   - With no caps configured, the report has no "Documents cache" section
+ *     (append-only behavior preserved).
+ *   - With caps configured via `.opencode/opencode-swarm.json`, the dry-run
+ *     preview includes the cache inventory and projected prune.
+ *   - The execution report includes the cache section after a real prune.
+ *
+ * Uses real filesystem operations (no mock.module) per AGENTS.md invariant #7.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { handleArchiveCommand } from '../../../src/commands/archive';
+
+let tempDir: string;
+let originalXdg: string | undefined;
+
+beforeEach(() => {
+	// Isolate from the real user config (~/.config/opencode/opencode-swarm.json)
+	// so the test's project config is the only evidence config source.
+	originalXdg = process.env.XDG_CONFIG_HOME;
+	process.env.XDG_CONFIG_HOME = path.join(os.tmpdir(), 'archive-docs-cache-xdg-');
+	mkdirSync(process.env.XDG_CONFIG_HOME, { recursive: true });
+
+	tempDir = require('node:fs').realpathSync(
+		require('node:fs').mkdtempSync(
+			path.join(os.tmpdir(), 'archive-docs-cache-test-'),
+		),
+	);
+	mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+	mkdirSync(path.join(tempDir, '.swarm', 'evidence-cache'), { recursive: true });
+	mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+});
+
+afterEach(() => {
+	rmSync(tempDir, { recursive: true, force: true });
+	if (process.env.XDG_CONFIG_HOME) {
+		rmSync(process.env.XDG_CONFIG_HOME, { recursive: true, force: true });
+	}
+	if (originalXdg === undefined) {
+		delete process.env.XDG_CONFIG_HOME;
+	} else {
+		process.env.XDG_CONFIG_HOME = originalXdg;
+	}
+});
+
+function writeConfig(config: Record<string, unknown>): void {
+	writeFileSync(
+		path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+		JSON.stringify(config),
+		'utf8',
+	);
+}
+
+function writeCacheRow(id: string, daysAgo: number): void {
+	const now = Date.UTC(2026, 5, 1);
+	const ts = new Date(now - daysAgo * 86_400_000).toISOString();
+	const row = JSON.stringify({
+		id,
+		ref: `evidence-cache:${id}`,
+		sourceType: 'web_search',
+		text: 'x'.repeat(200),
+		capturedAt: ts,
+	});
+	const cacheFile = path.join(tempDir, '.swarm', 'evidence-cache', 'documents.jsonl');
+	// Append (the production write path is append-only).
+	writeFileSync(cacheFile, row + '\n', { flag: 'a' });
+}
+
+describe('handleArchiveCommand — documents cache section (issue #1184)', () => {
+	test('no caps configured → no "Documents cache" section in report', async () => {
+		writeConfig({ evidence: { max_age_days: 90, max_bundles: 1000 } });
+		writeCacheRow('evd_1', 1);
+		const result = await handleArchiveCommand(tempDir, []);
+		// Terse "no bundles" message; cache section is absent because no caps.
+		expect(result).toBe('No evidence bundles to archive.');
+	});
+
+	test('caps configured, dry-run → preview includes cache inventory + projection', async () => {
+		writeConfig({
+			evidence: {
+				max_age_days: 90,
+				max_bundles: 1000,
+				cache_max_records: 10,
+			},
+		});
+		// Write 12 rows so the 10-record cap prunes 2 oldest.
+		for (let i = 0; i < 12; i++) {
+			writeCacheRow(`evd_${i.toString().padStart(2, '0')}`, 30 - i);
+		}
+
+		const result = await handleArchiveCommand(tempDir, ['--dry-run']);
+
+		expect(result).toContain('Documents cache');
+		expect(result).toContain('max 10 records');
+		expect(result).toContain('**Inventory**: 12 record(s)');
+		expect(result).toContain('**Would prune**: 2 record(s)');
+		// Nothing was actually written (dry run).
+		const cacheFile = path.join(tempDir, '.swarm', 'evidence-cache', 'documents.jsonl');
+		const content = require('node:fs').readFileSync(cacheFile, 'utf8');
+		expect(content.split('\n').filter((l: string) => l.length > 0)).toHaveLength(12);
+	});
+
+	test('caps configured, execution → cache pruned, report shows Pruned count', async () => {
+		writeConfig({
+			evidence: {
+				max_age_days: 90,
+				max_bundles: 1000,
+				cache_max_records: 10,
+			},
+		});
+		// 12 rows; cap 10 → 2 oldest pruned.
+		for (let i = 0; i < 12; i++) {
+			writeCacheRow(`evd_${i.toString().padStart(2, '0')}`, 30 - i);
+		}
+
+		const result = await handleArchiveCommand(tempDir, []);
+
+		// No bundles archived but cache was pruned → dedicated report path.
+		expect(result).toContain('Documents Cache Pruned');
+		expect(result).toContain('**Pruned**: 2 record(s)');
+		expect(result).toContain('No evidence bundles were archived.');
+
+		// The newest 10 rows survive; the oldest 2 are gone.
+		const cacheFile = path.join(tempDir, '.swarm', 'evidence-cache', 'documents.jsonl');
+		const content = require('node:fs').readFileSync(cacheFile, 'utf8');
+		expect(content).toContain('evd_11'); // newest
+		expect(content).not.toContain('evd_00'); // oldest, pruned
+		expect(content).not.toContain('evd_01'); // second oldest, pruned
+	});
+
+	test('byte cap only (no record cap) → section reports byte cap', async () => {
+		// 512-byte cap (schema minimum). Each row is ~300 bytes.
+		writeConfig({
+			evidence: {
+				max_age_days: 90,
+				max_bundles: 1000,
+				cache_max_bytes: 512,
+			},
+		});
+		writeCacheRow('evd_a', 30);
+		writeCacheRow('evd_b', 20);
+		writeCacheRow('evd_c', 1);
+
+		const result = await handleArchiveCommand(tempDir, ['--dry-run']);
+
+		expect(result).toContain('max 512 B');
+		expect(result).toContain('**Inventory**: 3 record(s)');
+		expect(result).toMatch(/\*\*Would prune\*\*: \d+ record\(s\)/);
+	});
+});

--- a/tests/unit/commands/archive-documents-cache.test.ts
+++ b/tests/unit/commands/archive-documents-cache.test.ts
@@ -25,7 +25,10 @@ beforeEach(() => {
 	// Isolate from the real user config (~/.config/opencode/opencode-swarm.json)
 	// so the test's project config is the only evidence config source.
 	originalXdg = process.env.XDG_CONFIG_HOME;
-	process.env.XDG_CONFIG_HOME = path.join(os.tmpdir(), 'archive-docs-cache-xdg-');
+	process.env.XDG_CONFIG_HOME = path.join(
+		os.tmpdir(),
+		'archive-docs-cache-xdg-',
+	);
 	mkdirSync(process.env.XDG_CONFIG_HOME, { recursive: true });
 
 	tempDir = require('node:fs').realpathSync(
@@ -34,7 +37,9 @@ beforeEach(() => {
 		),
 	);
 	mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
-	mkdirSync(path.join(tempDir, '.swarm', 'evidence-cache'), { recursive: true });
+	mkdirSync(path.join(tempDir, '.swarm', 'evidence-cache'), {
+		recursive: true,
+	});
 	mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
 });
 
@@ -68,7 +73,12 @@ function writeCacheRow(id: string, daysAgo: number): void {
 		text: 'x'.repeat(200),
 		capturedAt: ts,
 	});
-	const cacheFile = path.join(tempDir, '.swarm', 'evidence-cache', 'documents.jsonl');
+	const cacheFile = path.join(
+		tempDir,
+		'.swarm',
+		'evidence-cache',
+		'documents.jsonl',
+	);
 	// Append (the production write path is append-only).
 	writeFileSync(cacheFile, row + '\n', { flag: 'a' });
 }
@@ -102,9 +112,16 @@ describe('handleArchiveCommand — documents cache section (issue #1184)', () =>
 		expect(result).toContain('**Inventory**: 12 record(s)');
 		expect(result).toContain('**Would prune**: 2 record(s)');
 		// Nothing was actually written (dry run).
-		const cacheFile = path.join(tempDir, '.swarm', 'evidence-cache', 'documents.jsonl');
+		const cacheFile = path.join(
+			tempDir,
+			'.swarm',
+			'evidence-cache',
+			'documents.jsonl',
+		);
 		const content = require('node:fs').readFileSync(cacheFile, 'utf8');
-		expect(content.split('\n').filter((l: string) => l.length > 0)).toHaveLength(12);
+		expect(
+			content.split('\n').filter((l: string) => l.length > 0),
+		).toHaveLength(12);
 	});
 
 	test('caps configured, execution → cache pruned, report shows Pruned count', async () => {
@@ -128,7 +145,12 @@ describe('handleArchiveCommand — documents cache section (issue #1184)', () =>
 		expect(result).toContain('No evidence bundles were archived.');
 
 		// The newest 10 rows survive; the oldest 2 are gone.
-		const cacheFile = path.join(tempDir, '.swarm', 'evidence-cache', 'documents.jsonl');
+		const cacheFile = path.join(
+			tempDir,
+			'.swarm',
+			'evidence-cache',
+			'documents.jsonl',
+		);
 		const content = require('node:fs').readFileSync(cacheFile, 'utf8');
 		expect(content).toContain('evd_11'); // newest
 		expect(content).not.toContain('evd_00'); // oldest, pruned

--- a/tests/unit/commands/close-archive-config.test.ts
+++ b/tests/unit/commands/close-archive-config.test.ts
@@ -249,4 +249,55 @@ describe('handleCloseCommand — archive retention config (FR-016)', () => {
 
 		expect(capturedDir).toBe(testDir);
 	});
+
+	it('forwards evidence.cache_max_bytes / cache_max_records to archiveEvidence (issue #1184)', async () => {
+		writePlan();
+		let capturedArgs: unknown[] = [];
+		closeInternals.loadPluginConfigWithMeta = () =>
+			makeConfig({
+				evidence: {
+					max_age_days: 30,
+					max_bundles: 10,
+					cache_max_bytes: 5_000_000,
+					cache_max_records: 5000,
+				},
+			});
+		closeInternals.archiveEvidence = mock(async (...args: unknown[]) => {
+			capturedArgs = args;
+			return [];
+		});
+
+		await handleCloseCommand(testDir, []);
+
+		// archiveEvidence(directory, maxAgeDays, maxBundles, options) — the
+		// 4th arg must be the report-options object carrying the cache caps.
+		expect(capturedArgs).toHaveLength(4);
+		expect(capturedArgs[0]).toBe(testDir);
+		expect(capturedArgs[1]).toBe(30);
+		expect(capturedArgs[2]).toBe(10);
+		const opts = capturedArgs[3] as Record<string, unknown>;
+		expect(opts.report).toBe(true);
+		expect(opts.cacheMaxBytes).toBe(5_000_000);
+		expect(opts.cacheMaxRecords).toBe(5000);
+	});
+
+	it('omits cache caps from archiveEvidence options when config does not set them', async () => {
+		writePlan();
+		let capturedArgs: unknown[] = [];
+		closeInternals.loadPluginConfigWithMeta = () =>
+			makeConfig({
+				evidence: { max_age_days: 30, max_bundles: 10 },
+			});
+		closeInternals.archiveEvidence = mock(async (...args: unknown[]) => {
+			capturedArgs = args;
+			return [];
+		});
+
+		await handleCloseCommand(testDir, []);
+
+		expect(capturedArgs).toHaveLength(4);
+		const opts = capturedArgs[3] as Record<string, unknown>;
+		expect(opts.cacheMaxBytes).toBeUndefined();
+		expect(opts.cacheMaxRecords).toBeUndefined();
+	});
 });

--- a/tests/unit/commands/close.test.ts
+++ b/tests/unit/commands/close.test.ts
@@ -599,7 +599,15 @@ describe('handleCloseCommand', () => {
 			await handleCloseCommand(testDir, []);
 
 			expect(mockArchiveEvidence).toHaveBeenCalledTimes(1);
-			expect(mockArchiveEvidence).toHaveBeenCalledWith(testDir, 30, 10);
+			// Issue #1184: finalize now uses the report overload (4th arg) so
+			// the documents-cache prune runs when cache caps are configured.
+			// When no cache caps are set, cacheMaxBytes/cacheMaxRecords are
+			// undefined (append-only default preserved).
+			expect(mockArchiveEvidence).toHaveBeenCalledWith(testDir, 30, 10, {
+				report: true,
+				cacheMaxBytes: undefined,
+				cacheMaxRecords: undefined,
+			});
 		});
 	});
 

--- a/tests/unit/evidence/documents-retention-rename.test.ts
+++ b/tests/unit/evidence/documents-retention-rename.test.ts
@@ -42,9 +42,7 @@ describe('atomicRenameWithRetry', () => {
 		// placeholders to honor AGENTS.md invariant #7 (no hardcoded /tmp).
 		const src = path.join(os.tmpdir(), 'swarm-rename-src');
 		const dst = path.join(os.tmpdir(), 'swarm-rename-dst');
-		await expect(
-			atomicRenameWithRetry(src, dst, failRename),
-		).rejects.toThrow();
+		await expect(atomicRenameWithRetry(src, dst, failRename)).rejects.toThrow();
 		expect(calls).toBe(1); // no retry on non-Windows-contention codes
 	});
 
@@ -84,9 +82,9 @@ describe('atomicRenameWithRetry', () => {
 		};
 		const src = path.join(os.tmpdir(), 'swarm-rename-src');
 		const dst = path.join(os.tmpdir(), 'swarm-rename-dst');
-		await expect(
-			atomicRenameWithRetry(src, dst, alwaysFail),
-		).rejects.toThrow('EBUSY');
+		await expect(atomicRenameWithRetry(src, dst, alwaysFail)).rejects.toThrow(
+			'EBUSY',
+		);
 		expect(calls).toBe(5); // exactly RENAME_MAX_ATTEMPTS
 	});
 });

--- a/tests/unit/evidence/documents-retention-rename.test.ts
+++ b/tests/unit/evidence/documents-retention-rename.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for `atomicRenameWithRetry` (issue #1184).
+ *
+ * Split from `documents-retention.test.ts` to keep both files under the
+ * 500-line ceiling (AGENTS.md invariant #7 / FR-006). These tests exercise
+ * the retry loop directly with an injectable rename function so they are
+ * deterministic on non-Windows hosts.
+ */
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { atomicRenameWithRetry } from '../../../src/evidence/documents-retention';
+
+describe('atomicRenameWithRetry', () => {
+	test('succeeds on first try when no contention', async () => {
+		const dir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-rename-')),
+		);
+		try {
+			const src = path.join(dir, 'src.txt');
+			const dst = path.join(dir, 'dst.txt');
+			await fsp.writeFile(src, 'hello', 'utf8');
+			await atomicRenameWithRetry(src, dst);
+			expect(await fsp.readFile(dst, 'utf8')).toBe('hello');
+			await expect(fsp.stat(src)).rejects.toThrow();
+		} finally {
+			await fsp.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test('non-retryable error throws immediately (no retry)', async () => {
+		let calls = 0;
+		const failRename = async () => {
+			calls++;
+			const err = new Error('ENOSPC') as NodeJS.ErrnoException;
+			err.code = 'ENOSPC';
+			throw err;
+		};
+		// The mocked rename ignores the path; use os.tmpdir()-anchored
+		// placeholders to honor AGENTS.md invariant #7 (no hardcoded /tmp).
+		const src = path.join(os.tmpdir(), 'swarm-rename-src');
+		const dst = path.join(os.tmpdir(), 'swarm-rename-dst');
+		await expect(
+			atomicRenameWithRetry(src, dst, failRename),
+		).rejects.toThrow();
+		expect(calls).toBe(1); // no retry on non-Windows-contention codes
+	});
+
+	test('EPERM retried up to 5 times then succeeds', async () => {
+		let calls = 0;
+		const retryThenSucceed = async (src: string, dst: string) => {
+			calls++;
+			if (calls < 5) {
+				const err = new Error('EPERM') as NodeJS.ErrnoException;
+				err.code = 'EPERM';
+				throw err;
+			}
+			await fsp.rename(src, dst);
+		};
+		const dir = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-rename-retry-')),
+		);
+		try {
+			const src = path.join(dir, 'src.txt');
+			const dst = path.join(dir, 'dst.txt');
+			await fsp.writeFile(src, 'data', 'utf8');
+			await atomicRenameWithRetry(src, dst, retryThenSucceed);
+			expect(calls).toBe(5);
+			expect(await fsp.readFile(dst, 'utf8')).toBe('data');
+		} finally {
+			await fsp.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test('EPERM exhausted after 5 attempts rethrows', async () => {
+		let calls = 0;
+		const alwaysFail = async () => {
+			calls++;
+			const err = new Error('EBUSY') as NodeJS.ErrnoException;
+			err.code = 'EBUSY';
+			throw err;
+		};
+		const src = path.join(os.tmpdir(), 'swarm-rename-src');
+		const dst = path.join(os.tmpdir(), 'swarm-rename-dst');
+		await expect(
+			atomicRenameWithRetry(src, dst, alwaysFail),
+		).rejects.toThrow('EBUSY');
+		expect(calls).toBe(5); // exactly RENAME_MAX_ATTEMPTS
+	});
+});

--- a/tests/unit/evidence/documents-retention.test.ts
+++ b/tests/unit/evidence/documents-retention.test.ts
@@ -6,8 +6,8 @@ import * as path from 'node:path';
 import {
 	_internals,
 	atomicRenameWithRetry,
-	pruneEvidenceDocuments,
 	type DocumentsRetentionResult,
+	pruneEvidenceDocuments,
 } from '../../../src/evidence/documents-retention';
 
 /**
@@ -21,7 +21,9 @@ import {
  */
 
 function makeTmpDir(): string {
-	const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-docs-ret-')));
+	const dir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-docs-ret-')),
+	);
 	fs.mkdirSync(path.join(dir, '.swarm', 'evidence-cache'), { recursive: true });
 	return dir;
 }
@@ -107,6 +109,26 @@ describe('pruneEvidenceDocuments', () => {
 			bytesAfter: 0,
 			aborted: false,
 		});
+	});
+
+	test('stat error other than ENOENT → rethrows (PRR-002)', async () => {
+		// EACCES (or any non-ENOENT errno) must surface to the caller rather
+		// than being masked as a benign "missing file" no-op.
+		const realStat = _internals.stat;
+		_internals.stat = async () => {
+			const err = new Error(
+				'EACCES: permission denied',
+			) as NodeJS.ErrnoException;
+			err.code = 'EACCES';
+			throw err;
+		};
+		try {
+			await expect(
+				pruneEvidenceDocuments({ directory: tempDir, maxRecords: 10 }),
+			).rejects.toThrow('EACCES');
+		} finally {
+			_internals.stat = realStat;
+		}
 	});
 
 	test('no caps configured → no-op, preserves append-only behavior', async () => {
@@ -214,6 +236,37 @@ describe('pruneEvidenceDocuments', () => {
 		expect(survivors.map((r) => r.id).sort()).toEqual(['evd_c', 'evd_d']);
 	});
 
+	test('both caps tight: byte cap applies AFTER count cap, no over-prune (critic regression)', async () => {
+		// 5 rows, each ~320 bytes (JSON + LF). maxRecords=3 keeps the
+		// newest 3 (drops 2 oldest). maxBytes=550 then drops oldest survivors
+		// until ≤ 550 B: 3×320=960 → drop 1 (640) → drop 2 (320 ≤ 550),
+		// leaving 1 survivor. This proves the byte-cap total starts from the
+		// post-count-cap survivors, not all rows (final-critic regression:
+		// the pre-fix bug computed total over all 5 rows and over-pruned to 0).
+		await writeRows(tempDir, [
+			makeRow('evd_0', 40, 'x'.repeat(200)),
+			makeRow('evd_1', 30, 'x'.repeat(200)),
+			makeRow('evd_2', 20, 'x'.repeat(200)),
+			makeRow('evd_3', 10, 'x'.repeat(200)),
+			makeRow('evd_4', 1, 'x'.repeat(200)),
+		]);
+
+		const result = await pruneEvidenceDocuments({
+			directory: tempDir,
+			maxRecords: 3,
+			maxBytes: 550,
+		});
+
+		// Count cap drops 2 (evd_0, evd_1); byte cap drops 2 more (evd_2,
+		// evd_3) from the 3 survivors → 1 survivor (evd_4). Total archived = 4.
+		expect(result.archived).toBe(4);
+		expect(result.bytesAfter).toBeLessThanOrEqual(550);
+		const survivors = await readRows(tempDir);
+		expect(survivors.map((r) => r.id)).toEqual(['evd_4']);
+		// Critical: the file must NOT be empty (the pre-fix bug rewrote it to 0).
+		expect(survivors.length).toBeGreaterThan(0);
+	});
+
 	test('corrupt row dropped + counted, not preserved in rewrite', async () => {
 		// Mix valid and corrupt lines.
 		const valid1 = rowToJson(makeRow('evd_1', 30));
@@ -296,10 +349,7 @@ describe('pruneEvidenceDocuments', () => {
 	});
 
 	test('Windows rename retry: EPERM twice then success (integration via _internals)', async () => {
-		await writeRows(tempDir, [
-			makeRow('evd_old', 30),
-			makeRow('evd_new', 1),
-		]);
+		await writeRows(tempDir, [makeRow('evd_old', 30), makeRow('evd_new', 1)]);
 
 		// Override the DI seam so the production code's retry path runs
 		// against a rename that throws EPERM twice then succeeds. This
@@ -310,7 +360,9 @@ describe('pruneEvidenceDocuments', () => {
 		const flakyRename = async (src: string, dst: string) => {
 			attempts++;
 			if (attempts < 3) {
-				const err = new Error('EPERM: operation not permitted') as NodeJS.ErrnoException;
+				const err = new Error(
+					'EPERM: operation not permitted',
+				) as NodeJS.ErrnoException;
 				err.code = 'EPERM';
 				throw err;
 			}
@@ -332,10 +384,7 @@ describe('pruneEvidenceDocuments', () => {
 	});
 
 	test('atomic-rewrite failure: tmp cleaned up, original untouched', async () => {
-		await writeRows(tempDir, [
-			makeRow('evd_old', 30),
-			makeRow('evd_new', 1),
-		]);
+		await writeRows(tempDir, [makeRow('evd_old', 30), makeRow('evd_new', 1)]);
 		const beforeContent = await fsp.readFile(cachePath(tempDir), 'utf8');
 
 		// rename always fails (non-retryable error).
@@ -359,10 +408,7 @@ describe('pruneEvidenceDocuments', () => {
 	});
 
 	test('writeSync failure: tmp cleaned up, original untouched (reviewer finding)', async () => {
-		await writeRows(tempDir, [
-			makeRow('evd_old', 30),
-			makeRow('evd_new', 1),
-		]);
+		await writeRows(tempDir, [makeRow('evd_old', 30), makeRow('evd_new', 1)]);
 		const beforeContent = await fsp.readFile(cachePath(tempDir), 'utf8');
 
 		// writeSync fails after openSync succeeds — temp file must still be
@@ -407,11 +453,7 @@ describe('pruneEvidenceDocuments', () => {
 
 	test('JSON array / non-object rows counted as corrupt', async () => {
 		// JSON.parse succeeds but the result is not an object.
-		await fsp.writeFile(
-			cachePath(tempDir),
-			'[1,2,3]\n"string"\n42\n',
-			'utf8',
-		);
+		await fsp.writeFile(cachePath(tempDir), '[1,2,3]\n"string"\n42\n', 'utf8');
 		const result = await pruneEvidenceDocuments({
 			directory: tempDir,
 			maxRecords: 10,
@@ -423,4 +465,3 @@ describe('pruneEvidenceDocuments', () => {
 		expect(content).toBe('');
 	});
 });
-

--- a/tests/unit/evidence/documents-retention.test.ts
+++ b/tests/unit/evidence/documents-retention.test.ts
@@ -1,0 +1,426 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	_internals,
+	atomicRenameWithRetry,
+	pruneEvidenceDocuments,
+	type DocumentsRetentionResult,
+} from '../../../src/evidence/documents-retention';
+
+/**
+ * Retention tests for the documents cache (issue #1184).
+ *
+ * Conventions (AGENTS.md invariant #7):
+ *   - bun:test only
+ *   - real fs under os.tmpdir() + realpath (no hardcoded /tmp or C:\)
+ *   - _internals DI seam restored in afterEach (no mock.module leaks)
+ *   - under 500 lines, focused on this one module
+ */
+
+function makeTmpDir(): string {
+	const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-docs-ret-')));
+	fs.mkdirSync(path.join(dir, '.swarm', 'evidence-cache'), { recursive: true });
+	return dir;
+}
+
+function cachePath(dir: string): string {
+	return path.join(dir, '.swarm', 'evidence-cache', 'documents.jsonl');
+}
+
+interface Row {
+	id: string;
+	ref: string;
+	text: string;
+	capturedAt: string;
+	sourceType?: string;
+}
+
+function rowToJson(row: Row): string {
+	return JSON.stringify({
+		id: row.id,
+		ref: row.ref,
+		sourceType: row.sourceType ?? 'web_search',
+		text: row.text,
+		capturedAt: row.capturedAt,
+	});
+}
+
+async function writeRows(dir: string, rows: Row[]): Promise<void> {
+	const content = rows.map(rowToJson).join('\n') + '\n';
+	await fsp.writeFile(cachePath(dir), content, 'utf8');
+}
+
+async function readRows(dir: string): Promise<Record<string, unknown>[]> {
+	const content = await fsp.readFile(cachePath(dir), 'utf8');
+	return content
+		.trim()
+		.split('\n')
+		.filter((line) => line.length > 0)
+		.map((line) => JSON.parse(line));
+}
+
+function makeRow(id: string, daysAgo: number, text = 'x'.repeat(100)): Row {
+	// Fixed "now" reference = 2026-06-01. `daysAgo` days BEFORE that date.
+	// Larger daysAgo → older row → pruned first.
+	const now = Date.UTC(2026, 5, 1);
+	const ts = new Date(now - daysAgo * 86_400_000).toISOString();
+	return { id, ref: `evidence-cache:${id}`, text, capturedAt: ts };
+}
+
+describe('pruneEvidenceDocuments', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = makeTmpDir();
+	});
+
+	afterEach(async () => {
+		// Restore the DI seam so a later file's overrides don't leak.
+		_internals.stat = (p) => fsp.stat(p);
+		_internals.createReadStream = (p, options) =>
+			fs.createReadStream(p, options);
+		_internals.openSync = (p, flags) => fs.openSync(p, flags);
+		_internals.writeSync = (fd, data, position) =>
+			fs.writeSync(fd, data, position);
+		_internals.fsyncSync = (fd) => fs.fsyncSync(fd);
+		_internals.closeSync = (fd) => fs.closeSync(fd);
+		_internals.renameWithRetry = atomicRenameWithRetry;
+		_internals.unlink = (p) => fsp.unlink(p);
+		await fsp.rm(tempDir, { recursive: true, force: true });
+	});
+
+	test('missing file → idempotent zeroed result, no throw', async () => {
+		const result = await pruneEvidenceDocuments({
+			directory: tempDir,
+			maxBytes: 1024,
+			maxRecords: 100,
+		});
+		expect(result).toMatchObject({
+			inventory: 0,
+			selected: 0,
+			archived: 0,
+			corrupt: 0,
+			bytesBefore: 0,
+			bytesAfter: 0,
+			aborted: false,
+		});
+	});
+
+	test('no caps configured → no-op, preserves append-only behavior', async () => {
+		await writeRows(tempDir, [makeRow('evd_1', 1), makeRow('evd_2', 2)]);
+		const before = await fsp.readFile(cachePath(tempDir), 'utf8');
+
+		const result = await pruneEvidenceDocuments({ directory: tempDir });
+
+		expect(result.selected).toBe(0);
+		expect(result.archived).toBe(0);
+		const after = await fsp.readFile(cachePath(tempDir), 'utf8');
+		expect(after).toBe(before);
+	});
+
+	test('dry_run: true writes nothing (content + mtime unchanged)', async () => {
+		await writeRows(tempDir, [
+			makeRow('evd_1', 10),
+			makeRow('evd_2', 1),
+			makeRow('evd_3', 2),
+		]);
+		const beforeStat = await fsp.stat(cachePath(tempDir));
+		const beforeContent = await fsp.readFile(cachePath(tempDir), 'utf8');
+
+		const result = await pruneEvidenceDocuments({
+			directory: tempDir,
+			maxRecords: 1,
+			dryRun: true,
+		});
+
+		expect(result.dryRun).toBe(true);
+		expect(result.archived).toBe(0);
+		expect(result.selected).toBe(2); // would drop the 2 oldest
+		expect(result.inventory).toBe(3);
+
+		const afterStat = await fsp.stat(cachePath(tempDir));
+		const afterContent = await fsp.readFile(cachePath(tempDir), 'utf8');
+		expect(afterContent).toBe(beforeContent);
+		// mtime must be unchanged when nothing was written.
+		expect(afterStat.mtimeMs).toBe(beforeStat.mtimeMs);
+	});
+
+	test('maxRecords drops oldest by capturedAt, keeps newest', async () => {
+		await writeRows(tempDir, [
+			makeRow('evd_old', 30),
+			makeRow('evd_mid', 10),
+			makeRow('evd_new', 1),
+		]);
+
+		const result = await pruneEvidenceDocuments({
+			directory: tempDir,
+			maxRecords: 1,
+		});
+
+		expect(result.archived).toBe(2);
+		expect(result.inventory).toBe(3);
+
+		const survivors = await readRows(tempDir);
+		expect(survivors).toHaveLength(1);
+		expect(survivors[0].id).toBe('evd_new');
+	});
+
+	test('maxBytes drops oldest until under cap', async () => {
+		// Each row: 100 bytes of text + ~80 bytes overhead ≈ 180 bytes.
+		const rows = [
+			makeRow('evd_a', 30, 'a'.repeat(100)),
+			makeRow('evd_b', 20, 'b'.repeat(100)),
+			makeRow('evd_c', 10, 'c'.repeat(100)),
+			makeRow('evd_d', 1, 'd'.repeat(100)),
+		];
+		await writeRows(tempDir, rows);
+
+		// Cap at ~250 bytes: should keep only the newest 1-2 rows.
+		const result = await pruneEvidenceDocuments({
+			directory: tempDir,
+			maxBytes: 250,
+		});
+
+		expect(result.archived).toBeGreaterThan(0);
+		expect(result.bytesAfter).toBeLessThanOrEqual(250);
+
+		const survivors = await readRows(tempDir);
+		// The newest row (evd_d) must always survive.
+		expect(survivors.some((r) => r.id === 'evd_d')).toBe(true);
+		// The oldest row (evd_a) must be dropped when trimming under a tight cap.
+		expect(survivors.some((r) => r.id === 'evd_a')).toBe(false);
+	});
+
+	test('both caps: whichever is tighter wins', async () => {
+		await writeRows(tempDir, [
+			makeRow('evd_a', 30),
+			makeRow('evd_b', 20),
+			makeRow('evd_c', 10),
+			makeRow('evd_d', 1),
+		]);
+
+		// maxRecords=2 is the binding constraint (4 rows → drop 2 oldest).
+		const result = await pruneEvidenceDocuments({
+			directory: tempDir,
+			maxRecords: 2,
+			maxBytes: 100_000, // loose, does not bind
+		});
+
+		expect(result.archived).toBe(2);
+		const survivors = await readRows(tempDir);
+		expect(survivors.map((r) => r.id).sort()).toEqual(['evd_c', 'evd_d']);
+	});
+
+	test('corrupt row dropped + counted, not preserved in rewrite', async () => {
+		// Mix valid and corrupt lines.
+		const valid1 = rowToJson(makeRow('evd_1', 30));
+		const corrupt = 'this is not valid json {{{';
+		const valid2 = rowToJson(makeRow('evd_2', 1));
+		await fsp.writeFile(
+			cachePath(tempDir),
+			`${valid1}\n${corrupt}\n${valid2}\n`,
+			'utf8',
+		);
+
+		const result = await pruneEvidenceDocuments({
+			directory: tempDir,
+			maxRecords: 10, // loose cap; corrupt row still triggers a rewrite
+		});
+
+		expect(result.corrupt).toBe(1);
+		expect(result.inventory).toBe(2); // corrupt row excluded from inventory
+		// Corrupt row is gone from the file.
+		const content = await fsp.readFile(cachePath(tempDir), 'utf8');
+		expect(content).not.toContain('this is not valid json');
+		expect(content).toContain('evd_1');
+		expect(content).toContain('evd_2');
+	});
+
+	test('no selection and no corrupt rows → skips rewrite entirely', async () => {
+		await writeRows(tempDir, [makeRow('evd_1', 1), makeRow('evd_2', 2)]);
+		const beforeStat = await fsp.stat(cachePath(tempDir));
+
+		// Cap is loose; nothing to drop.
+		const result = await pruneEvidenceDocuments({
+			directory: tempDir,
+			maxRecords: 100,
+		});
+
+		expect(result.selected).toBe(0);
+		expect(result.archived).toBe(0);
+		const afterStat = await fsp.stat(cachePath(tempDir));
+		expect(afterStat.mtimeMs).toBe(beforeStat.mtimeMs);
+	});
+
+	test('100 MiB read cap → aborted, file byte-identical, nothing written', async () => {
+		await writeRows(tempDir, [makeRow('evd_1', 1)]);
+
+		// Force the read loop to think it crossed the cap by making the first
+		// line's byte length report as over the limit.
+		const realCreateReadStream = _internals.createReadStream;
+		let readCount = 0;
+		// Replace stat so bytesBefore looks non-trivial.
+		const realStat = _internals.stat;
+		_internals.stat = async (p) => {
+			const s = await realStat(p);
+			// Report a size above the cap so the abort path is reachable.
+			return { ...s, size: 200 * 1024 * 1024 } as fs.Stats;
+		};
+		// Hijack the stream: emit a single oversized line.
+		_internals.createReadStream = (_p, _options) => {
+			const { Readable } = require('node:stream');
+			const stub = new Readable({ encoding: 'utf8' });
+			stub.push('x'.repeat(200 * 1024 * 1024));
+			stub.push(null);
+			// Attach destroy so the production code's stream.destroy() works.
+			(stub as unknown as fs.ReadStream).destroy = () => undefined;
+			readCount++;
+			return stub as unknown as fs.ReadStream;
+		};
+
+		const result = await pruneEvidenceDocuments({
+			directory: tempDir,
+			maxRecords: 1,
+		});
+
+		expect(result.aborted).toBe(true);
+		expect(result.selected).toBe(0);
+		expect(result.archived).toBe(0);
+		expect(readCount).toBe(1);
+		// Original file content unchanged.
+		const content = await fsp.readFile(cachePath(tempDir), 'utf8');
+		expect(content).toContain('evd_1');
+	});
+
+	test('Windows rename retry: EPERM twice then success (integration via _internals)', async () => {
+		await writeRows(tempDir, [
+			makeRow('evd_old', 30),
+			makeRow('evd_new', 1),
+		]);
+
+		// Override the DI seam so the production code's retry path runs
+		// against a rename that throws EPERM twice then succeeds. This
+		// proves the integration: rewriteAtomic → _internals.renameWithRetry
+		// → retry loop honors EPERM and eventually lands the file.
+		const realRename = fsp.rename;
+		let attempts = 0;
+		const flakyRename = async (src: string, dst: string) => {
+			attempts++;
+			if (attempts < 3) {
+				const err = new Error('EPERM: operation not permitted') as NodeJS.ErrnoException;
+				err.code = 'EPERM';
+				throw err;
+			}
+			await realRename(src, dst);
+		};
+		_internals.renameWithRetry = (src, dst) =>
+			atomicRenameWithRetry(src, dst, flakyRename);
+
+		const result = await pruneEvidenceDocuments({
+			directory: tempDir,
+			maxRecords: 1,
+		});
+
+		expect(result.archived).toBe(1);
+		expect(attempts).toBe(3); // 2 EPERM retries + 1 success
+		const survivors = await readRows(tempDir);
+		expect(survivors).toHaveLength(1);
+		expect(survivors[0].id).toBe('evd_new');
+	});
+
+	test('atomic-rewrite failure: tmp cleaned up, original untouched', async () => {
+		await writeRows(tempDir, [
+			makeRow('evd_old', 30),
+			makeRow('evd_new', 1),
+		]);
+		const beforeContent = await fsp.readFile(cachePath(tempDir), 'utf8');
+
+		// rename always fails (non-retryable error).
+		_internals.renameWithRetry = async () => {
+			const err = new Error('ENOSPC: no space') as NodeJS.ErrnoException;
+			err.code = 'ENOSPC';
+			throw err;
+		};
+
+		await expect(
+			pruneEvidenceDocuments({ directory: tempDir, maxRecords: 1 }),
+		).rejects.toThrow(/rewrite failed/);
+
+		// Original file untouched.
+		const afterContent = await fsp.readFile(cachePath(tempDir), 'utf8');
+		expect(afterContent).toBe(beforeContent);
+		// No temp file leaked.
+		const dirEntries = await fsp.readdir(path.dirname(cachePath(tempDir)));
+		const tmpLeaks = dirEntries.filter((name) => name.includes('.tmp.'));
+		expect(tmpLeaks).toEqual([]);
+	});
+
+	test('writeSync failure: tmp cleaned up, original untouched (reviewer finding)', async () => {
+		await writeRows(tempDir, [
+			makeRow('evd_old', 30),
+			makeRow('evd_new', 1),
+		]);
+		const beforeContent = await fsp.readFile(cachePath(tempDir), 'utf8');
+
+		// writeSync fails after openSync succeeds — temp file must still be
+		// cleaned up (the outer finally runs on every non-success path).
+		const realOpenSync = _internals.openSync;
+		const realCloseSync = _internals.closeSync;
+		let openedTmpPath: string | null = null;
+		_internals.openSync = (p, flags) => {
+			const fd = realOpenSync(p, flags);
+			if (typeof p === 'string' && p.includes('.tmp.')) {
+				openedTmpPath = p;
+			}
+			return fd;
+		};
+		_internals.writeSync = () => {
+			throw new Error('EIO: write error');
+		};
+		// closeSync must still work so the fd is released.
+		_internals.closeSync = (fd) => realCloseSync(fd);
+
+		await expect(
+			pruneEvidenceDocuments({ directory: tempDir, maxRecords: 1 }),
+		).rejects.toThrow(/rewrite failed/);
+
+		// Original file untouched.
+		const afterContent = await fsp.readFile(cachePath(tempDir), 'utf8');
+		expect(afterContent).toBe(beforeContent);
+		// The temp file opened during the failed write must be cleaned up.
+		expect(openedTmpPath).not.toBeNull();
+		await expect(fsp.stat(openedTmpPath as string)).rejects.toThrow();
+	});
+
+	test('empty file → zeroed result, no crash', async () => {
+		await fsp.writeFile(cachePath(tempDir), '', 'utf8');
+		const result = await pruneEvidenceDocuments({
+			directory: tempDir,
+			maxRecords: 10,
+		});
+		expect(result.inventory).toBe(0);
+		expect(result.corrupt).toBe(0);
+	});
+
+	test('JSON array / non-object rows counted as corrupt', async () => {
+		// JSON.parse succeeds but the result is not an object.
+		await fsp.writeFile(
+			cachePath(tempDir),
+			'[1,2,3]\n"string"\n42\n',
+			'utf8',
+		);
+		const result = await pruneEvidenceDocuments({
+			directory: tempDir,
+			maxRecords: 10,
+		});
+		expect(result.corrupt).toBe(3);
+		expect(result.inventory).toBe(0);
+		// File is rewritten empty (all rows dropped).
+		const content = await fsp.readFile(cachePath(tempDir), 'utf8');
+		expect(content).toBe('');
+	});
+});
+


### PR DESCRIPTION
Closes #1184

## Summary

The `web_search` / `web_fetch` evidence cache at `.swarm/evidence-cache/documents.jsonl` was purely append-only with no TTL, size cap, prune, or cleanup command. Long-running projects accumulated unbounded disk usage with no automatic or documented cleanup path. This PR adds an explicit, configurable, bounded retention policy exposed through the existing `/swarm archive` and `/swarm finalize` retention surfaces.

**Approach (smallest patch, no new tool/command):** extend the existing `archiveEvidence` retention flow to also sweep the documents cache when the user opts in via two new optional config keys. No new agent tool, no new top-level config section, no write-path lock, no init-path work.

### What changed

- **`src/config/schema.ts`** — `EvidenceConfigSchema` extended with two optional fields:
  - `cache_max_bytes` (512 B – 50 MiB) — prune oldest rows until the surviving file is at or below this size.
  - `cache_max_records` (10 – 100 000) — prune oldest rows (by `capturedAt`) until the surviving record count is at or below this number.
  - When **both are unset** (the default), the cache remains append-only — zero behavior change for existing users.
- **`src/evidence/documents-retention.ts`** (new) — `pruneEvidenceDocuments`: streamed line-by-line read (hard 100 MiB cap; aborts byte-identical on breach), age-stable oldest-first selection, atomic rewrite via temp + fsync + Windows-safe rename retry (`EPERM`/`EBUSY`/`ENOTEMPTY`/`EACCES`, 5× / 10 ms), corrupt-row drop-and-report, fail-safe temp cleanup on every error path. `_internals` DI seam for testing.
- **`src/evidence/manager.ts`** — `archiveEvidence` calls `pruneEvidenceDocuments` when at least one cap is configured (fail-open); `EvidenceArchiveReport` gains a `documentsCache` field; `_internals` seam extended.
- **`src/commands/archive.ts`** — `handleArchiveCommand` reads the caps from `config.evidence` and adds a "Documents cache" section to both the dry-run preview and the execution report.
- **`src/commands/close.ts`** — `runArchiveEvidenceRetention` (`/swarm finalize`) now uses the report overload and forwards the cache caps (initially missed — caught by independent reviewer).

### Why byte/count caps, not age-based

Evidence refs are content-addressed (`evd_<sha256[:16]>`). Age-based pruning would silently invalidate cited refs that agents may still hold in conversation. Byte/count caps bound disk usage without time-based ref invalidation. The issue lists age/count/size/manual as alternatives ("or"), not conjunctions.

### Known append-vs-rewrite race (accepted)

The cache is NOT locked during a prune (locking would tax every `web_search` call). A concurrent `appendFile` whose write is in flight when the prune renames the temp over the target will, on POSIX, complete against the now-unlinked old inode — the appended row is silently lost. This is accepted because refs are content-addressed (a lost row's ref re-materializes on the next capture of the same content) and the prune runs only via explicit `/swarm archive` / `/swarm finalize`. Documented in code, `docs/evidence-and-telemetry.md`, and the release fragment.

## Invariant audit

- **1 (plugin init):** not touched — `grep "pruneEvidenceDocuments" src/index.ts` → empty. Prune runs only via `/swarm archive` and `/swarm finalize`, never at plugin load. The issue explicitly forbids init-path cleanup.
- **2 (runtime portability):** not touched — no `bun:` imports in the new module (only `node:*`); no entry-shape change; `dist/` not staged (generated by CI).
- **3 (subprocesses):** not touched — no new spawn.
- **4 (.swarm containment):** touched — new file under `.swarm/evidence-cache/`; all paths via `validateSwarmPath` (`documents-retention.ts:332`); no sidecar (corrupt rows dropped + reported, not relocated).
- **5 (plan durability):** not touched.
- **6 (test_runner safety):** not touched.
- **7 (test writing):** touched — new test files use `bun:test`, `_internals` DI seam (restored in `afterEach`), `os.tmpdir()` + `realpathSync`, no `mock.module`, no hardcoded `/tmp`. Both new test files under 500 lines (426 + 92).
- **8 (session state):** not touched — prune is stateless.
- **9 (guardrails/retry):** touched — rename retry is bounded (5× / 10 ms) and fail-safe (original untouched on any failure).
- **10 (chat/system msg):** not touched.
- **11 (tool registration):** not touched — no new tool, no `TOOL_METADATA`/`manifest.ts`/`index.ts` barrel change (deliberately extended existing retention surfaces instead of adding a 6th registration surface).
- **12 (release/cache):** touched — `docs/releases/pending/evidence-cache-retention.md` added; no `package.json#version` / `CHANGELOG.md` / `.release-please-manifest.json` edit (release-please owns those).

## Test plan

All commands run on Windows (win32 10.0.26200), bun 1.3.14.

```
$ bunx tsc --noEmit
(exit 0, clean)

$ bun run build
Copied grammars to dist/lang/grammars/
Total grammar files: 20
(exit 0)

$ bun run drift:check
✅ No drift detected across skills, tools, commands, agents, and docs claims.

$ bun test tests/unit/evidence/ tests/unit/commands/archive.test.ts tests/unit/commands/archive-dry-run.test.ts tests/unit/commands/archive-documents-cache.test.ts tests/unit/commands/close-archive-config.test.ts tests/unit/commands/close-dry-run.test.ts --timeout 90000
266 pass, 1 skip (pre-existing), 0 fail

$ bun test tests/unit/config/ tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts --timeout 120000
1637 pass, 0 fail
```

New tests (26 total):
- `tests/unit/evidence/documents-retention.test.ts` (16 tests): missing file, stat-error rethrow, no-caps no-op, dry-run mtime preservation, maxRecords/maxBytes oldest-first, both-caps (loose), both-caps tight (regression), corrupt-row drop-and-report, no-selection skip, 100 MiB read-cap abort, Windows rename retry integration, atomic-rewrite failure cleanup, writeSync failure cleanup, empty file, non-object JSON.
- `tests/unit/evidence/documents-retention-rename.test.ts` (4 tests): atomicRenameWithRetry first-try success, non-retryable immediate throw, EPERM retry-then-success, EPERM exhausted rethrow.
- `tests/unit/commands/archive-documents-cache.test.ts` (4 tests): no-caps no section, dry-run preview, execution prune, byte-cap-only.
- `tests/unit/commands/close-archive-config.test.ts` (+2 new tests in existing file): finalize forwards cache caps; omits when unset.

### Note on issue #1184 AC2 ("age/count/size behavior")

The acceptance criterion literally reads "tests prove age/count/size behavior". This PR implements **count and size** caps but deliberately omits **age-based** pruning. Rationale: evidence refs are content-addressed (`evd_<sha256[:16]>`); age-based pruning would silently invalidate cited refs that agents may still hold in conversation. Byte/count caps bound disk usage without time-based ref invalidation. The issue's proposed scope lists age/count/size/manual/append-only as alternatives ("or"), and the release fragment documents this design decision explicitly.

## Review history

- **Plan critic (GLM-5.2):** NEEDS_REVISION → adopted all 6 must-fix items (use existing schema, drop write-path lock, honest Windows-retry, drop sidecar, drop agent tool, extend `/swarm archive`).
- **Implementation reviewer (Kimi K2.7, swarm-reviewer):** NEEDS_REVISION → fixed all 4 important findings (`/swarm finalize` was not pruning; temp leak on writeSync failure; overstated race doc; release-note overstate) + 2 nits (dead `now` param, hardcoded `/tmp`).
- **Final critic (GLM-5.2):** APPROVE → resolved the one observation (test file 4 lines over 500 → split into sibling file).
- **PR-review feedback (`b89f40b7`):** addressed all findings from two independent PR reviews (swarm-pr-review run-001 + zaxbysauce). Notable: the final critic caught a regression in the O(n) `selectSurvivors` rewrite (byte-cap `total` was computed over all rows instead of post-count-cap survivors → over-prune to empty under tight combined caps); fixed + regression test added. See the [closure-ledger comment](https://github.com/ZaxbyHub/opencode-swarm/pull/1892) for the full item-by-item disposition.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


