### PR TITLE
fix(knowledge-gate): prevent permanent deadlock on KNOWLEDGE_ENFORCE_GATE_DENY

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -471,14 +471,33 @@ generatedSkillPath, sessionId}`.
   "min_confidence": 0.85,
   "critical_requires_ack": true,
   "require_skill_refs": true,
-  "high_risk_tools": ["save_plan", "update_task_status", "phase_complete", "task", "Task"]
+  "high_risk_tools": ["save_plan", "update_task_status", "phase_complete", "task", "Task"],
+  "max_gate_denials": 5,       // enforce-mode escape hatch: auto-clear after this many denials
+  "gate_staleness_ms": 600000  // enforce-mode escape hatch: auto-clear after this many ms unacked (10 min)
 }
 ```
 
-In `enforce` mode the gate (`gateKnowledgeApplication` in
-`src/hooks/knowledge-application.ts`) blocks high-risk actions when a critical
-directive was shown but received no terminal acknowledgment
-(`KNOWLEDGE_APPLIED`, `KNOWLEDGE_IGNORED`, or `KNOWLEDGE_VIOLATED`).
+In `enforce` mode the gate (`knowledgeApplicationGateBefore` in
+`src/hooks/knowledge-application-gate.ts`) blocks high-risk actions when a
+critical directive was shown but received no terminal acknowledgment
+(`KNOWLEDGE_APPLIED`, `KNOWLEDGE_IGNORED`, or `KNOWLEDGE_VIOLATED`) — bounded by
+two escape hatches so the gate cannot deadlock a session forever:
+
+- **`max_gate_denials`** (default `5`) — after this many consecutive denials
+  against the same unacknowledged critical-directive set, the gate
+  auto-acknowledges the pending directives, clears them for that session, and
+  lets the action through.
+- **`gate_staleness_ms`** (default `600000`, 10 minutes) — a critical
+  directive shown longer ago than this is treated as stale and auto-cleared
+  the same way, regardless of denial count.
+
+Both auto-clears write an audit event to `.swarm/events.jsonl`
+(`knowledge_application_gate_denial_limit_clear` or
+`knowledge_application_gate_staleness_clear`) before the action proceeds — the
+bypass is never silent. These are safety nets against a broken acknowledgment
+pipeline (e.g. an ack marker that failed to parse), not a routine escape path:
+enforcement still applies for the first `max_gate_denials` attempts or the
+full `gate_staleness_ms` window.
 
 **`high_risk_tools`** — optionally override the set of tools that trigger the
 acknowledgment gate. When absent, defaults to `["save_plan",

--- a/docs/releases/pending/knowledge-gate-deadlock-escape-hatch.md
+++ b/docs/releases/pending/knowledge-gate-deadlock-escape-hatch.md
@@ -3,14 +3,22 @@
 ## What
 
 `knowledgeApplicationGateBefore` (`src/hooks/knowledge-application-gate.ts`)
-could permanently block every high-risk architect tool call (`save_plan`,
-`update_task_status`, `phase_complete`, `task`/`Task`, `skill_regenerate`,
-`skill_retire`) once a critical knowledge directive landed in
+could permanently block high-risk architect tool calls (`save_plan`,
+`update_task_status`, `phase_complete`, `task`/`Task` under the production
+default config) once a critical knowledge directive landed in
 `swarmState.currentCriticalShownIds` for a session, if the acknowledgment
 never made it into `swarmState.knowledgeAckDedup`. There was no timeout,
 retry limit, or staleness check — a single ack that failed to parse meant
 the architect could never take another high-risk action for the rest of
 the session.
+
+(`skill_regenerate`/`skill_retire` are declared in the source-level
+`HIGH_RISK_TOOLS` constant, but under the production default config path —
+`KnowledgeApplicationConfigSchema.parse(...)` — the Zod-defaulted
+`config.high_risk_tools` (5 tools) is always truthy and therefore always
+shadows that 7-tool fallback constant; those two tools are not actually
+gated unless an operator explicitly adds them via config. This shadowing is
+pre-existing on `main` and out of scope for this fix.)
 
 Two independent causes fed the deadlock:
 
@@ -35,25 +43,49 @@ Two independent causes fed the deadlock:
   behind new optional `KnowledgeApplicationConfig` fields
   (`src/config/schema.ts`, `src/hooks/knowledge-application.ts`):
   - `max_gate_denials` (default `5`) — after this many consecutive denials
-    for a session, the gate auto-acknowledges the pending directives as
-    `applied`, clears `currentCriticalShownIds` for that session, and lets
-    the action through.
+    against the *same* unacknowledged critical-directive set for a session,
+    the gate auto-acknowledges the pending directives as `applied`, clears
+    them for that session, and lets the action through.
   - `gate_staleness_ms` (default `600_000`, 10 minutes) — a directive shown
     longer ago than this is treated as stale and auto-cleared the same way.
-  - Both escapes write an auditable `knowledge_application_gate_denial_limit_clear`
-    / `knowledge_application_gate_staleness_clear` event to `.swarm/events.jsonl`
-    before returning, so the auto-clear is never silent.
-  - The per-session denial counter (`_gateDenialCounts`, a module-scoped
-    `Map<string, number>` in `knowledge-application-gate.ts`) is FIFO-bounded
-    to 500 entries and self-cleans whenever a session has no pending critical
-    IDs or its directives become acknowledged — no explicit cross-module
-    import into `resetSwarmState` was needed.
+  - Both escapes `await` an auditable `knowledge_application_gate_denial_limit_clear`
+    / `knowledge_application_gate_staleness_clear` event write to
+    `.swarm/events.jsonl` before returning, so the bypass state and its audit
+    record commit together — a write failure cannot leave the bypass silently
+    unaudited.
+- The per-session denial counter (`swarmState.gateDenialCounts`, a new
+  `Map<string, { count, directiveKey }>` alongside the pre-existing
+  `currentCriticalShownIds`/`knowledgeAckDedup` maps in `src/state.ts`,
+  managed via `incrementGateDenialCount`/`clearGateDenialCount`) is
+  **identity-scoped**: each entry also records a fingerprint
+  (`buildGateDenialDirectiveKey`, a sorted join of the directive-id set) of
+  which critical-directive set the count was accrued against. This closes a
+  cross-directive leak found in review: without identity-scoping, denials
+  accrued against one unacknowledged directive would silently carry over and
+  count toward an unrelated directive's budget when the injector swaps in a
+  new critical-directive set on an ordinary phase/task transition (via the
+  pre-existing `setCriticalShownIds`) — letting the new directive get
+  auto-cleared after far fewer than `max_gate_denials` real denials against
+  it. Re-injecting the *same* directive set across turns (the injector
+  re-stamps `generatedAt` on every cache-hit re-injection) does not reset the
+  count, since the identity key is the directive-id set, not the timestamp.
+  `gateDenialCounts` is FIFO-bounded to 500 entries
+  (`MAX_TRACKED_GATE_DENIALS`) and is cleared by `resetSwarmState()`
+  alongside its sibling maps, closing a second review finding where the
+  counter survived a same-process `/swarm close` and leaked into a reused
+  session.
+- The escape-hatch branches now clear `currentCriticalShownIds` via the
+  existing centralized `clearCriticalShownIds()` helper (`src/state.ts`)
+  instead of a direct `Map.delete()`, matching every other call site.
 - Corrected a stale doc comment on `swarmState.knowledgeAckDedup`
   (`src/state.ts`) that claimed the dedup key included a `dayKey` component;
   the actual implementation (`buildAckDedupKey`,
   `src/hooks/knowledge-application.ts`) never included one — confirmed by the
   existing `GATE-002` regression test, which asserts a prior-day ack still
   satisfies the same-session gate.
+- Updated `docs/knowledge.md`'s "Enforcement modes" section and the
+  architect system prompt (`src/agents/architect.ts`) to describe the two
+  new escape hatches instead of stating enforce mode blocks unconditionally.
 
 ## Migration
 
@@ -65,8 +97,14 @@ only after exhausting the configured grace period.
 ## Known caveats
 
 - The denial-count and staleness escape hatches are safety nets, not a
-  bypass: enforcement still applies for the first `max_gate_denials`
-  attempts or `gate_staleness_ms` window, and every auto-clear is logged.
+  routine escape path: enforcement still applies for the first
+  `max_gate_denials` attempts against a given directive set, or the full
+  `gate_staleness_ms` window, and every auto-clear is logged.
+- The staleness clock measures time since the directive was *last shown*
+  (`cached.generatedAt`), not time since it was *first* shown — the injector
+  re-stamps this on every cache-hit re-injection of the same directive set.
+  The denial-count hatch remains a functioning backstop for turns that
+  actually retry the gated tool call.
 - `knowledge_receipt` still intentionally does not satisfy the gate — only
   chat-text `KNOWLEDGE_APPLIED`/`IGNORED`/`VIOLATED` markers do. This is an
   existing, unchanged design decision, not a regression.

--- a/docs/releases/pending/knowledge-gate-deadlock-escape-hatch.md
+++ b/docs/releases/pending/knowledge-gate-deadlock-escape-hatch.md
@@ -1,0 +1,72 @@
+# Knowledge enforcement gate — deadlock escape hatch + ack-marker regex fix
+
+## What
+
+`knowledgeApplicationGateBefore` (`src/hooks/knowledge-application-gate.ts`)
+could permanently block every high-risk architect tool call (`save_plan`,
+`update_task_status`, `phase_complete`, `task`/`Task`, `skill_regenerate`,
+`skill_retire`) once a critical knowledge directive landed in
+`swarmState.currentCriticalShownIds` for a session, if the acknowledgment
+never made it into `swarmState.knowledgeAckDedup`. There was no timeout,
+retry limit, or staleness check — a single ack that failed to parse meant
+the architect could never take another high-risk action for the rest of
+the session.
+
+Two independent causes fed the deadlock:
+
+1. **Regex bug.** The `ACK_PATTERN` in `src/hooks/knowledge-application.ts`
+   required a strict lookahead after the directive ID (`$`, a newline, or
+   `\s+KNOWLEDGE_`). A marker like `KNOWLEDGE_APPLIED: <id> - I applied this.`
+   failed to parse because the trailing explanation text didn't match any of
+   the three accepted terminators.
+2. **No escape hatch.** Even with a correctly-formatted marker, any other
+   failure in the ack pipeline (a retrieval bug, a hook error swallowed by
+   `composeHandlers`, a session/transform ordering edge case) left the gate
+   with no recovery path in `enforce` mode.
+
+## Fix
+
+- Relaxed `ACK_PATTERN`'s outer lookahead from `(?=$|[\n\r]|\s+KNOWLEDGE_)` to
+  `(?=[^0-9a-fA-F-]|$)`, so a marker followed by punctuation, a parenthetical,
+  or free-text explanation now parses correctly. The reason-capture group
+  keeps its own tighter lookahead so `reason=...` text is not truncated by
+  the relaxation.
+- Added two escape hatches to `knowledgeApplicationGateBefore`, both gated
+  behind new optional `KnowledgeApplicationConfig` fields
+  (`src/config/schema.ts`, `src/hooks/knowledge-application.ts`):
+  - `max_gate_denials` (default `5`) — after this many consecutive denials
+    for a session, the gate auto-acknowledges the pending directives as
+    `applied`, clears `currentCriticalShownIds` for that session, and lets
+    the action through.
+  - `gate_staleness_ms` (default `600_000`, 10 minutes) — a directive shown
+    longer ago than this is treated as stale and auto-cleared the same way.
+  - Both escapes write an auditable `knowledge_application_gate_denial_limit_clear`
+    / `knowledge_application_gate_staleness_clear` event to `.swarm/events.jsonl`
+    before returning, so the auto-clear is never silent.
+  - The per-session denial counter (`_gateDenialCounts`, a module-scoped
+    `Map<string, number>` in `knowledge-application-gate.ts`) is FIFO-bounded
+    to 500 entries and self-cleans whenever a session has no pending critical
+    IDs or its directives become acknowledged — no explicit cross-module
+    import into `resetSwarmState` was needed.
+- Corrected a stale doc comment on `swarmState.knowledgeAckDedup`
+  (`src/state.ts`) that claimed the dedup key included a `dayKey` component;
+  the actual implementation (`buildAckDedupKey`,
+  `src/hooks/knowledge-application.ts`) never included one — confirmed by the
+  existing `GATE-002` regression test, which asserts a prior-day ack still
+  satisfies the same-session gate.
+
+## Migration
+
+No migration required. Both new config fields are optional with defaults
+that preserve today's behavior for the first 5 denials / 10 minutes; only
+sessions that would previously have deadlocked see different behavior, and
+only after exhausting the configured grace period.
+
+## Known caveats
+
+- The denial-count and staleness escape hatches are safety nets, not a
+  bypass: enforcement still applies for the first `max_gate_denials`
+  attempts or `gate_staleness_ms` window, and every auto-clear is logged.
+- `knowledge_receipt` still intentionally does not satisfy the gate — only
+  chat-text `KNOWLEDGE_APPLIED`/`IGNORED`/`VIOLATED` markers do. This is an
+  existing, unchanged design decision, not a regression.

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -483,7 +483,7 @@ For every applicable directive in the block:
 - If a directive references a generated skill via \`skill: file:...\`, you MUST add that path to the SKILLS: field of any matching subagent delegation.
 - If a directive does NOT apply to the current action, record \`KNOWLEDGE_IGNORED: <id> reason=<short reason>\` once in your reply.
 - If runtime evidence shows a directive was violated (reviewer rejection, failing test, scope breach), record \`KNOWLEDGE_VIOLATED: <id> reason=<reason>\` and re-plan.
-- NEVER silently ignore a \`priority: critical\` directive. The knowledge_application gate may run in 'enforce' mode; in that mode an omitted ack on a critical directive blocks the action.
+- NEVER silently ignore a \`priority: critical\` directive. The knowledge_application gate may run in 'enforce' mode; in that mode an omitted ack on a critical directive blocks the action for a bounded number of retries and time window (\`max_gate_denials\`, \`gate_staleness_ms\`), after which it auto-clears and logs the bypass — do not attempt out-of-band workarounds (editing .swarm/ state files, restarting sessions) to escape it; retry the ack with a correctly-terminated marker instead.
 
 Chat-text markers (KNOWLEDGE_APPLIED/IGNORED/VIOLATED) are the sole mechanism that satisfies the knowledge-application enforcement gate. The \`knowledge_receipt\` tool records knowledge-usage receipts for audit but does NOT satisfy the gate.
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1660,6 +1660,10 @@ export const KnowledgeApplicationConfigSchema = z.object({
 			'task',
 			'Task',
 		]),
+	/** Max consecutive gate denials per session before auto-clearing unacked directives. Default: 5 */
+	max_gate_denials: z.number().int().min(1).max(100).default(5),
+	/** Staleness TTL (ms) for critical shown IDs — directives older than this auto-clear. Default: 600000 (10 min) */
+	gate_staleness_ms: z.number().int().min(10000).max(3600000).default(600_000),
 });
 
 export type KnowledgeApplicationConfig = z.infer<

--- a/src/hooks/knowledge-application-gate.ts
+++ b/src/hooks/knowledge-application-gate.ts
@@ -174,8 +174,7 @@ export async function knowledgeApplicationGateBefore(
 	// who is acked via the dedup set; do not re-parse text).
 	if (config.mode === 'enforce' && config.critical_requires_ack) {
 		const maxDenials = config.max_gate_denials ?? DEFAULT_MAX_GATE_DENIALS;
-		const stalenessMs =
-			config.gate_staleness_ms ?? DEFAULT_GATE_STALENESS_MS;
+		const stalenessMs = config.gate_staleness_ms ?? DEFAULT_GATE_STALENESS_MS;
 
 		// Escape hatch 1: staleness — if the directive has been pending longer
 		// than the configured TTL, auto-clear and allow the action.

--- a/src/hooks/knowledge-application-gate.ts
+++ b/src/hooks/knowledge-application-gate.ts
@@ -52,6 +52,37 @@ export const HIGH_RISK_TOOLS = new Set([
 	'skill_retire',
 ]);
 
+// ============================================================================
+// Gate denial counter — prevents permanent deadlock when ack pipeline fails
+// ============================================================================
+
+const MAX_DENIAL_TRACKER_ENTRIES = 500;
+const DEFAULT_MAX_GATE_DENIALS = 5;
+const DEFAULT_GATE_STALENESS_MS = 600_000; // 10 minutes
+
+const _gateDenialCounts = new Map<string, number>();
+
+function incrementDenialCount(sessionID: string): number {
+	const current = (_gateDenialCounts.get(sessionID) ?? 0) + 1;
+	if (_gateDenialCounts.has(sessionID)) _gateDenialCounts.delete(sessionID);
+	_gateDenialCounts.set(sessionID, current);
+	if (_gateDenialCounts.size > MAX_DENIAL_TRACKER_ENTRIES) {
+		const oldest = _gateDenialCounts.keys().next().value;
+		if (oldest !== undefined && oldest !== sessionID) {
+			_gateDenialCounts.delete(oldest);
+		}
+	}
+	return current;
+}
+
+function clearDenialCount(sessionID: string): void {
+	_gateDenialCounts.delete(sessionID);
+}
+
+export function resetGateDenialCounts(): void {
+	_gateDenialCounts.clear();
+}
+
 export interface GateInput {
 	tool: unknown;
 	agent?: unknown;
@@ -113,7 +144,10 @@ export async function knowledgeApplicationGateBefore(
 	}
 
 	const cached = swarmState.currentCriticalShownIds.get(sessionID);
-	if (!cached || cached.ids.length === 0) return;
+	if (!cached || cached.ids.length === 0) {
+		clearDenialCount(sessionID);
+		return;
+	}
 
 	// Has an architect terminal ack landed in this session for any critical id?
 	const ackedIds = new Set<string>();
@@ -130,12 +164,67 @@ export async function knowledgeApplicationGateBefore(
 	}
 
 	const unacked = cached.ids.filter((id) => !ackedIds.has(id));
-	if (unacked.length === 0) return;
+	if (unacked.length === 0) {
+		clearDenialCount(sessionID);
+		return;
+	}
 
 	// Synthesise the gate result format expected by gateKnowledgeApplication
 	// (the helper itself takes recentArchitectText, but here we pre-decided
 	// who is acked via the dedup set; do not re-parse text).
 	if (config.mode === 'enforce' && config.critical_requires_ack) {
+		const maxDenials = config.max_gate_denials ?? DEFAULT_MAX_GATE_DENIALS;
+		const stalenessMs =
+			config.gate_staleness_ms ?? DEFAULT_GATE_STALENESS_MS;
+
+		// Escape hatch 1: staleness — if the directive has been pending longer
+		// than the configured TTL, auto-clear and allow the action.
+		const age = Date.now() - cached.generatedAt;
+		if (age > stalenessMs) {
+			for (const id of unacked) {
+				addKnowledgeAckDedup(buildAckDedupKey(sessionID, id, 'applied'));
+			}
+			swarmState.currentCriticalShownIds.delete(sessionID);
+			clearDenialCount(sessionID);
+			void writeWarnEvent(directory, {
+				timestamp: new Date().toISOString(),
+				event: 'knowledge_application_gate_staleness_clear',
+				tool: toolName,
+				agent: agentRaw,
+				sessionID,
+				cleared_ids: unacked,
+				age_ms: age,
+				staleness_threshold_ms: stalenessMs,
+			}).catch(() => {
+				/* never block tool path */
+			});
+			return;
+		}
+
+		// Escape hatch 2: denial count — if this session has been denied more
+		// than the configured max, auto-clear and allow the action.
+		const denials = incrementDenialCount(sessionID);
+		if (denials > maxDenials) {
+			for (const id of unacked) {
+				addKnowledgeAckDedup(buildAckDedupKey(sessionID, id, 'applied'));
+			}
+			swarmState.currentCriticalShownIds.delete(sessionID);
+			clearDenialCount(sessionID);
+			void writeWarnEvent(directory, {
+				timestamp: new Date().toISOString(),
+				event: 'knowledge_application_gate_denial_limit_clear',
+				tool: toolName,
+				agent: agentRaw,
+				sessionID,
+				cleared_ids: unacked,
+				denial_count: denials,
+				max_gate_denials: maxDenials,
+			}).catch(() => {
+				/* never block tool path */
+			});
+			return;
+		}
+
 		const ids = unacked.join(', ');
 		throw new Error(
 			`KNOWLEDGE_ENFORCE_GATE_DENY: ${toolName} blocked — critical knowledge directive(s) ${ids} require KNOWLEDGE_APPLIED:<id>, KNOWLEDGE_IGNORED:<id> reason=..., or KNOWLEDGE_VIOLATED:<id> reason=... before this action.`,
@@ -222,4 +311,6 @@ export const _internals = {
 	knowledgeApplicationTransformScan,
 	HIGH_RISK_TOOLS,
 	writeWarnEvent,
+	resetGateDenialCounts,
+	_gateDenialCounts,
 };

--- a/src/hooks/knowledge-application-gate.ts
+++ b/src/hooks/knowledge-application-gate.ts
@@ -15,8 +15,14 @@
  *      assemble the set of critical directives that have been shown but
  *      not acknowledged. In `mode: 'enforce'` it THROWS to block the
  *      action (per the FAIL-CLOSED contract — `output.error` is NOT a
- *      write API at toolBefore time). In `mode: 'warn'` it appends to
- *      `events.jsonl` and lets the action proceed.
+ *      write API at toolBefore time) — UNLESS one of two bounded escape
+ *      hatches has fired first (a per-directive denial-count limit, or a
+ *      staleness TTL since the directive was shown; see
+ *      `incrementGateDenialCount`/`buildGateDenialDirectiveKey` in
+ *      `../state.js`), in which case the pending directives are
+ *      auto-acknowledged and an audit event is durably written before the
+ *      action is allowed to proceed. In `mode: 'warn'` it appends to
+ *      `events.jsonl` and always lets the action proceed.
  *
  * Tools considered high-risk:
  *   - save_plan
@@ -30,7 +36,14 @@
 import { appendFile, mkdir } from 'node:fs/promises';
 import * as path from 'node:path';
 import { stripKnownSwarmPrefix } from '../config/schema.js';
-import { addKnowledgeAckDedup, swarmState } from '../state.js';
+import {
+	addKnowledgeAckDedup,
+	buildGateDenialDirectiveKey,
+	clearCriticalShownIds,
+	clearGateDenialCount,
+	incrementGateDenialCount,
+	swarmState,
+} from '../state.js';
 import { warn } from '../utils/logger.js';
 import {
 	buildAckDedupKey,
@@ -52,36 +65,8 @@ export const HIGH_RISK_TOOLS = new Set([
 	'skill_retire',
 ]);
 
-// ============================================================================
-// Gate denial counter — prevents permanent deadlock when ack pipeline fails
-// ============================================================================
-
-const MAX_DENIAL_TRACKER_ENTRIES = 500;
 const DEFAULT_MAX_GATE_DENIALS = 5;
 const DEFAULT_GATE_STALENESS_MS = 600_000; // 10 minutes
-
-const _gateDenialCounts = new Map<string, number>();
-
-function incrementDenialCount(sessionID: string): number {
-	const current = (_gateDenialCounts.get(sessionID) ?? 0) + 1;
-	if (_gateDenialCounts.has(sessionID)) _gateDenialCounts.delete(sessionID);
-	_gateDenialCounts.set(sessionID, current);
-	if (_gateDenialCounts.size > MAX_DENIAL_TRACKER_ENTRIES) {
-		const oldest = _gateDenialCounts.keys().next().value;
-		if (oldest !== undefined && oldest !== sessionID) {
-			_gateDenialCounts.delete(oldest);
-		}
-	}
-	return current;
-}
-
-function clearDenialCount(sessionID: string): void {
-	_gateDenialCounts.delete(sessionID);
-}
-
-export function resetGateDenialCounts(): void {
-	_gateDenialCounts.clear();
-}
 
 export interface GateInput {
 	tool: unknown;
@@ -145,7 +130,7 @@ export async function knowledgeApplicationGateBefore(
 
 	const cached = swarmState.currentCriticalShownIds.get(sessionID);
 	if (!cached || cached.ids.length === 0) {
-		clearDenialCount(sessionID);
+		clearGateDenialCount(sessionID);
 		return;
 	}
 
@@ -165,7 +150,7 @@ export async function knowledgeApplicationGateBefore(
 
 	const unacked = cached.ids.filter((id) => !ackedIds.has(id));
 	if (unacked.length === 0) {
-		clearDenialCount(sessionID);
+		clearGateDenialCount(sessionID);
 		return;
 	}
 
@@ -183,9 +168,14 @@ export async function knowledgeApplicationGateBefore(
 			for (const id of unacked) {
 				addKnowledgeAckDedup(buildAckDedupKey(sessionID, id, 'applied'));
 			}
-			swarmState.currentCriticalShownIds.delete(sessionID);
-			clearDenialCount(sessionID);
-			void writeWarnEvent(directory, {
+			clearCriticalShownIds(sessionID);
+			clearGateDenialCount(sessionID);
+			// Awaited (not fire-and-forget): the bypass state above is already
+			// committed, so the audit write is the only remaining evidence of
+			// this security-relevant auto-clear. Awaiting it before returning
+			// keeps the "never silent" guarantee true even under a write
+			// failure window, not just in the common case.
+			await writeWarnEvent(directory, {
 				timestamp: new Date().toISOString(),
 				event: 'knowledge_application_gate_staleness_clear',
 				tool: toolName,
@@ -194,22 +184,32 @@ export async function knowledgeApplicationGateBefore(
 				cleared_ids: unacked,
 				age_ms: age,
 				staleness_threshold_ms: stalenessMs,
-			}).catch(() => {
-				/* never block tool path */
+			}).catch((err: unknown) => {
+				warn(
+					`[knowledge-application-gate] staleness-clear audit write failed: ${
+						err instanceof Error ? err.message : String(err)
+					}`,
+				);
 			});
 			return;
 		}
 
 		// Escape hatch 2: denial count — if this session has been denied more
-		// than the configured max, auto-clear and allow the action.
-		const denials = incrementDenialCount(sessionID);
+		// than the configured max, auto-clear and allow the action. The
+		// counter is keyed to the current directive-id-set identity, so a
+		// session whose critical directives were swapped out from under it
+		// (an ordinary phase/task-transition occurrence via
+		// setCriticalShownIds) starts a fresh count instead of inheriting a
+		// stale one accrued against an unrelated, earlier directive.
+		const directiveKey = buildGateDenialDirectiveKey(cached.ids);
+		const denials = incrementGateDenialCount(sessionID, directiveKey);
 		if (denials > maxDenials) {
 			for (const id of unacked) {
 				addKnowledgeAckDedup(buildAckDedupKey(sessionID, id, 'applied'));
 			}
-			swarmState.currentCriticalShownIds.delete(sessionID);
-			clearDenialCount(sessionID);
-			void writeWarnEvent(directory, {
+			clearCriticalShownIds(sessionID);
+			clearGateDenialCount(sessionID);
+			await writeWarnEvent(directory, {
 				timestamp: new Date().toISOString(),
 				event: 'knowledge_application_gate_denial_limit_clear',
 				tool: toolName,
@@ -218,8 +218,12 @@ export async function knowledgeApplicationGateBefore(
 				cleared_ids: unacked,
 				denial_count: denials,
 				max_gate_denials: maxDenials,
-			}).catch(() => {
-				/* never block tool path */
+			}).catch((err: unknown) => {
+				warn(
+					`[knowledge-application-gate] denial-limit-clear audit write failed: ${
+						err instanceof Error ? err.message : String(err)
+					}`,
+				);
 			});
 			return;
 		}
@@ -310,6 +314,4 @@ export const _internals = {
 	knowledgeApplicationTransformScan,
 	HIGH_RISK_TOOLS,
 	writeWarnEvent,
-	resetGateDenialCounts,
-	_gateDenialCounts,
 };

--- a/src/hooks/knowledge-application.ts
+++ b/src/hooks/knowledge-application.ts
@@ -58,7 +58,7 @@ export interface ParsedAcknowledgment {
 }
 
 const ACK_PATTERN =
-	/KNOWLEDGE_(APPLIED|IGNORED|VIOLATED|N_A)\s*:\s*([0-9a-fA-F-]{8,64})(?:\s+reason\s*=\s*([^\n\r]+?))?(?=$|[\n\r]|\s+KNOWLEDGE_)/g;
+	/KNOWLEDGE_(APPLIED|IGNORED|VIOLATED|N_A)\s*:\s*([0-9a-fA-F-]{8,64})(?:\s+reason\s*=\s*([^\n\r]+?)(?=$|[\n\r]|\s+KNOWLEDGE_))?(?=[^0-9a-fA-F-]|$)/g;
 
 export function parseAcknowledgments(text: string): ParsedAcknowledgment[] {
 	if (!text || typeof text !== 'string') return [];
@@ -411,6 +411,8 @@ export interface KnowledgeApplicationConfig {
 	critical_requires_ack: boolean;
 	require_skill_refs: boolean;
 	high_risk_tools?: string[];
+	max_gate_denials?: number;
+	gate_staleness_ms?: number;
 }
 
 export const DEFAULT_KNOWLEDGE_APPLICATION_CONFIG: KnowledgeApplicationConfig =
@@ -427,6 +429,8 @@ export const DEFAULT_KNOWLEDGE_APPLICATION_CONFIG: KnowledgeApplicationConfig =
 			'task',
 			'Task',
 		],
+		max_gate_denials: 5,
+		gate_staleness_ms: 600_000,
 	};
 
 export interface GateResult {

--- a/src/state.ts
+++ b/src/state.ts
@@ -545,6 +545,17 @@ export const swarmState = {
 	 *  see addKnowledgeAckDedup. */
 	knowledgeAckDedup: new Set<string>(),
 
+	/** v2: per-session denial counter for the knowledge-application enforcement
+	 *  gate's deadlock escape hatch (`knowledgeApplicationGateBefore`). Keyed by
+	 *  sessionID; each entry also records the `directiveKey` (a sorted, joined
+	 *  fingerprint of the critical-directive-id set the count was accumulated
+	 *  against) so a session that has its critical directives swapped out from
+	 *  under it — an ordinary occurrence on phase/task transitions via
+	 *  `setCriticalShownIds` — does not carry a stale denial count into an
+	 *  unrelated new directive's budget. FIFO-capped — see
+	 *  incrementGateDenialCount/clearGateDenialCount. */
+	gateDenialCounts: new Map<string, { count: number; directiveKey: string }>(),
+
 	/**
 	 * All generated agent names registered with OpenCode at plugin init.
 	 * Used by Full-Auto v2 delegation guard to apply strict registry-aware
@@ -598,6 +609,7 @@ export function resetSwarmState(): void {
 	swarmState.specWriterAgentNames = [];
 	swarmState.currentCriticalShownIds.clear();
 	swarmState.knowledgeAckDedup.clear();
+	swarmState.gateDenialCounts.clear();
 	swarmState.generatedAgentNames = [];
 	_rehydrationCache = null;
 	// Full Auto Mode (Phase 4)
@@ -2159,6 +2171,7 @@ export function ensureSessionEnvironment(
 // preserves insertion order so `Map.keys().next()` is the FIFO oldest.
 export const MAX_TRACKED_CRITICAL_SHOWN = 500;
 export const MAX_TRACKED_KNOWLEDGE_ACKS = 5000;
+export const MAX_TRACKED_GATE_DENIALS = 500;
 
 /** Set the critical shown ids for a session, FIFO-evicting the oldest entry
  * if the cap is exceeded. Re-setting an existing key keeps insertion order
@@ -2188,6 +2201,47 @@ export function setCriticalShownIds(
  *  whether an entry was removed. */
 export function clearCriticalShownIds(sessionID: string): boolean {
 	return swarmState.currentCriticalShownIds.delete(sessionID);
+}
+
+/** Build the directive-identity fingerprint used to key the gate denial
+ *  counter — a sorted, joined snapshot of a critical-directive-id set. Two
+ *  calls with the same id set (regardless of order) produce the same key,
+ *  so re-injecting the identical directive on a later turn does not reset
+ *  the counter, but swapping to a genuinely different directive set does. */
+export function buildGateDenialDirectiveKey(ids: string[]): string {
+	return [...ids].sort().join(',');
+}
+
+/** Increment (or start) the per-session gate denial counter for the given
+ *  directive identity, FIFO-evicting the oldest session entry if the cap is
+ *  exceeded. When the stored entry's `directiveKey` does not match
+ *  `directiveKey`, the counter restarts at 1 instead of continuing to
+ *  accumulate — this is what prevents a stale denial count from an earlier,
+ *  unrelated critical directive from carrying into a fresh one's
+ *  `max_gate_denials` budget. Returns the resulting count. */
+export function incrementGateDenialCount(
+	sessionID: string,
+	directiveKey: string,
+): number {
+	const map = swarmState.gateDenialCounts;
+	const existing = map.get(sessionID);
+	const count =
+		existing && existing.directiveKey === directiveKey ? existing.count + 1 : 1;
+	if (map.has(sessionID)) map.delete(sessionID);
+	map.set(sessionID, { count, directiveKey });
+	if (map.size > MAX_TRACKED_GATE_DENIALS) {
+		const oldest = map.keys().next().value;
+		if (oldest !== undefined && oldest !== sessionID) {
+			map.delete(oldest);
+		}
+	}
+	return count;
+}
+
+/** Clear the gate denial counter for a session. Centralised so call sites do
+ *  not bypass the FIFO-cap pathway with a direct `.delete()`. */
+export function clearGateDenialCount(sessionID: string): void {
+	swarmState.gateDenialCounts.delete(sessionID);
 }
 
 /** Add a knowledge ack dedup key, FIFO-evicting the oldest if the cap is

--- a/src/state.ts
+++ b/src/state.ts
@@ -539,9 +539,9 @@ export const swarmState = {
 		{ ids: string[]; taskId?: string; phase?: string; generatedAt: number }
 	>(),
 
-	/** v2: dedup set for ack records. Key = `${sessionId}|${id}|${result}|${dayKey}`.
+	/** v2: dedup set for ack records. Key = `${sessionId}|${id}|${result}`.
 	 *  Prevents the chat.messages.transform path AND a knowledge_ack tool call
-	 *  from double-counting the same ack within a session-day. FIFO-capped —
+	 *  from double-counting the same ack within a session. FIFO-capped —
 	 *  see addKnowledgeAckDedup. */
 	knowledgeAckDedup: new Set<string>(),
 

--- a/tests/unit/hooks/knowledge-application-ack-parsing.test.ts
+++ b/tests/unit/hooks/knowledge-application-ack-parsing.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for parseAcknowledgments (the ACK_PATTERN regex) and the
+ * KnowledgeApplicationConfigSchema fields it's gated behind. Split from
+ * knowledge-application.test.ts to stay under the repo's 500-line test file
+ * limit (AGENTS.md invariant 7).
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { KnowledgeApplicationConfigSchema } from '../../../src/config/schema';
+import { parseAcknowledgments } from '../../../src/hooks/knowledge-application';
+
+describe('parseAcknowledgments', () => {
+	it('extracts applied/ignored/violated markers with reasons', () => {
+		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+		const text = `KNOWLEDGE_APPLIED: ${id}
+KNOWLEDGE_IGNORED: ${id} reason=not relevant
+KNOWLEDGE_VIOLATED: ${id} reason=scope breach`;
+		const acks = parseAcknowledgments(text);
+		expect(acks).toHaveLength(3);
+		expect(acks[0].result).toBe('applied');
+		expect(acks[1].result).toBe('ignored');
+		expect(acks[1].reason).toBe('not relevant');
+		expect(acks[2].result).toBe('violated');
+		expect(acks[2].reason).toBe('scope breach');
+	});
+
+	it('returns empty for non-matching text', () => {
+		expect(parseAcknowledgments('plain prose, no markers')).toEqual([]);
+	});
+
+	it('matches when ID is followed by trailing explanation text', () => {
+		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+		const text = `KNOWLEDGE_APPLIED: ${id} - I have incorporated this directive.`;
+		const acks = parseAcknowledgments(text);
+		expect(acks).toHaveLength(1);
+		expect(acks[0].id).toBe(id);
+		expect(acks[0].result).toBe('applied');
+	});
+
+	it('matches when ID is followed by a period', () => {
+		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+		const text = `KNOWLEDGE_APPLIED: ${id}. Moving on to the next step.`;
+		const acks = parseAcknowledgments(text);
+		expect(acks).toHaveLength(1);
+		expect(acks[0].id).toBe(id);
+		expect(acks[0].result).toBe('applied');
+	});
+
+	it('matches when ID is followed by parenthetical', () => {
+		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+		const text = `KNOWLEDGE_APPLIED: ${id}(used in plan)`;
+		const acks = parseAcknowledgments(text);
+		expect(acks).toHaveLength(1);
+		expect(acks[0].id).toBe(id);
+		expect(acks[0].result).toBe('applied');
+	});
+
+	it('matches inline multi-marker on same line separated by spaces', () => {
+		const id1 = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+		const id2 = 'bbbbbbbb-bbbb-4bbb-9bbb-bbbbbbbbbbbb';
+		const text = `KNOWLEDGE_APPLIED: ${id1} KNOWLEDGE_IGNORED: ${id2} reason=not relevant`;
+		const acks = parseAcknowledgments(text);
+		expect(acks).toHaveLength(2);
+		expect(acks[0].id).toBe(id1);
+		expect(acks[0].result).toBe('applied');
+		expect(acks[1].id).toBe(id2);
+		expect(acks[1].result).toBe('ignored');
+		expect(acks[1].reason).toBe('not relevant');
+	});
+
+	it('handles N_A marker', () => {
+		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+		const text = `KNOWLEDGE_N_A: ${id} reason=directive not applicable to this context`;
+		const acks = parseAcknowledgments(text);
+		expect(acks).toHaveLength(1);
+		expect(acks[0].result).toBe('n_a');
+		expect(acks[0].reason).toBe('directive not applicable to this context');
+	});
+
+	it('matches ID at end of string without newline', () => {
+		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+		const text = `KNOWLEDGE_APPLIED: ${id}`;
+		const acks = parseAcknowledgments(text);
+		expect(acks).toHaveLength(1);
+		expect(acks[0].id).toBe(id);
+	});
+});
+
+describe('KnowledgeApplicationConfigSchema — max_gate_denials / gate_staleness_ms', () => {
+	it('parses an empty object to the documented defaults', () => {
+		const parsed = KnowledgeApplicationConfigSchema.parse({});
+		expect(parsed.max_gate_denials).toBe(5);
+		expect(parsed.gate_staleness_ms).toBe(600_000);
+	});
+
+	it('accepts explicit values within bounds', () => {
+		const parsed = KnowledgeApplicationConfigSchema.parse({
+			max_gate_denials: 10,
+			gate_staleness_ms: 60_000,
+		});
+		expect(parsed.max_gate_denials).toBe(10);
+		expect(parsed.gate_staleness_ms).toBe(60_000);
+	});
+
+	it('accepts the documented floor values (max_gate_denials=1, gate_staleness_ms=10000)', () => {
+		const parsed = KnowledgeApplicationConfigSchema.parse({
+			max_gate_denials: 1,
+			gate_staleness_ms: 10_000,
+		});
+		expect(parsed.max_gate_denials).toBe(1);
+		expect(parsed.gate_staleness_ms).toBe(10_000);
+	});
+
+	it('accepts the documented ceiling values (max_gate_denials=100, gate_staleness_ms=3600000)', () => {
+		const parsed = KnowledgeApplicationConfigSchema.parse({
+			max_gate_denials: 100,
+			gate_staleness_ms: 3_600_000,
+		});
+		expect(parsed.max_gate_denials).toBe(100);
+		expect(parsed.gate_staleness_ms).toBe(3_600_000);
+	});
+
+	it('rejects max_gate_denials below the floor or above the ceiling', () => {
+		expect(() =>
+			KnowledgeApplicationConfigSchema.parse({ max_gate_denials: 0 }),
+		).toThrow();
+		expect(() =>
+			KnowledgeApplicationConfigSchema.parse({ max_gate_denials: 101 }),
+		).toThrow();
+	});
+
+	it('rejects gate_staleness_ms below the floor or above the ceiling', () => {
+		expect(() =>
+			KnowledgeApplicationConfigSchema.parse({ gate_staleness_ms: 9_999 }),
+		).toThrow();
+		expect(() =>
+			KnowledgeApplicationConfigSchema.parse({
+				gate_staleness_ms: 3_600_001,
+			}),
+		).toThrow();
+	});
+
+	it('rejects non-integer values', () => {
+		expect(() =>
+			KnowledgeApplicationConfigSchema.parse({ max_gate_denials: 2.5 }),
+		).toThrow();
+	});
+});

--- a/tests/unit/hooks/knowledge-application-filter-confidence.test.ts
+++ b/tests/unit/hooks/knowledge-application-filter-confidence.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for filterHighConfidenceKnowledge. Split from
+ * knowledge-application.test.ts to stay under the repo's 500-line test file
+ * limit (AGENTS.md invariant 7).
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { filterHighConfidenceKnowledge } from '../../../src/hooks/knowledge-application.js';
+import type { RankedEntry } from '../../../src/hooks/knowledge-reader.js';
+
+function makeRankedEntry(
+	id: string,
+	lesson: string,
+	confidence: number,
+): RankedEntry {
+	return {
+		id,
+		tier: 'swarm',
+		lesson,
+		category: 'process',
+		tags: [],
+		scope: 'global',
+		confidence,
+		status: 'established',
+		confirmed_by: [],
+		retrieval_outcomes: {
+			applied_count: 0,
+			succeeded_after_count: 0,
+			failed_after_count: 0,
+		},
+		schema_version: 1,
+		created_at: new Date().toISOString(),
+		updated_at: new Date().toISOString(),
+		relevanceScore: confidence,
+		finalScore: confidence,
+	};
+}
+
+describe('filterHighConfidenceKnowledge', () => {
+	// Happy path: entries >= threshold are included, < threshold are excluded
+
+	it('includes entries with confidence >= threshold', () => {
+		const entries = [
+			makeRankedEntry('id-1', 'Lesson one', 0.85),
+			makeRankedEntry('id-2', 'Lesson two', 0.92),
+			makeRankedEntry('id-3', 'Lesson three', 1.0),
+		];
+		const result = filterHighConfidenceKnowledge(entries, 0.8);
+		expect(result).toHaveLength(3);
+		expect(result.map((e) => e.id)).toEqual(['id-1', 'id-2', 'id-3']);
+	});
+
+	it('excludes entries with confidence < threshold', () => {
+		const entries = [
+			makeRankedEntry('id-1', 'High confidence', 0.9),
+			makeRankedEntry('id-2', 'Low confidence', 0.5),
+			makeRankedEntry('id-3', 'Another high', 0.85),
+		];
+		const result = filterHighConfidenceKnowledge(entries, 0.8);
+		expect(result).toHaveLength(2);
+		expect(result.map((e) => e.id)).toEqual(['id-1', 'id-3']);
+	});
+
+	// Default threshold: 0.8 when not provided
+
+	it('uses default threshold of 0.8 when called with no threshold argument', () => {
+		const entries = [
+			makeRankedEntry('id-1', 'Exactly 0.8', 0.8), // >= 0.8 → included
+			makeRankedEntry('id-2', 'Above 0.8', 0.81), // >= 0.8 → included
+			makeRankedEntry('id-3', 'Below 0.8', 0.79), // < 0.8 → excluded
+		];
+		const result = filterHighConfidenceKnowledge(entries);
+		expect(result).toHaveLength(2);
+		expect(result.map((e) => e.id)).toEqual(['id-1', 'id-2']);
+	});
+
+	// Custom threshold
+
+	it('works with custom threshold of 0.9', () => {
+		const entries = [
+			makeRankedEntry('id-1', 'Confidence 0.9', 0.9), // >= 0.9 → included
+			makeRankedEntry('id-2', 'Confidence 0.85', 0.85), // < 0.9 → excluded
+			makeRankedEntry('id-3', 'Confidence 1.0', 1.0), // >= 0.9 → included
+		];
+		const result = filterHighConfidenceKnowledge(entries, 0.9);
+		expect(result).toHaveLength(2);
+		expect(result.map((e) => e.id)).toEqual(['id-1', 'id-3']);
+	});
+
+	it('works with custom threshold of 0.5', () => {
+		const entries = [
+			makeRankedEntry('id-1', 'High', 0.9),
+			makeRankedEntry('id-2', 'Mid', 0.6),
+			makeRankedEntry('id-3', 'Low', 0.3),
+		];
+		const result = filterHighConfidenceKnowledge(entries, 0.5);
+		expect(result).toHaveLength(2);
+		expect(result.map((e) => e.id)).toEqual(['id-1', 'id-2']);
+	});
+
+	it('works with custom threshold of 1.0 (only perfect confidence included)', () => {
+		const entries = [
+			makeRankedEntry('id-1', 'Perfect', 1.0),
+			makeRankedEntry('id-2', 'Almost perfect', 0.99),
+			makeRankedEntry('id-3', 'High', 0.95),
+		];
+		const result = filterHighConfidenceKnowledge(entries, 1.0);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('id-1');
+	});
+
+	it('works with custom threshold of 0.0 (all entries included)', () => {
+		const entries = [
+			makeRankedEntry('id-1', 'Zero confidence', 0.0),
+			makeRankedEntry('id-2', 'Low confidence', 0.3),
+			makeRankedEntry('id-3', 'Any confidence', 0.5),
+		];
+		const result = filterHighConfidenceKnowledge(entries, 0.0);
+		expect(result).toHaveLength(3);
+	});
+
+	// Empty input
+
+	it('returns empty array for empty input', () => {
+		const result = filterHighConfidenceKnowledge([]);
+		expect(result).toEqual([]);
+	});
+
+	// Edge cases: boundary values
+
+	it('exactly 0.8 threshold: entry with confidence 0.8 is included', () => {
+		const entries = [makeRankedEntry('id-1', 'Exactly at threshold', 0.8)];
+		const result = filterHighConfidenceKnowledge(entries, 0.8);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('id-1');
+	});
+
+	it('confidence 0.0 is excluded when threshold is 0.8', () => {
+		const entries = [makeRankedEntry('id-1', 'Zero confidence', 0.0)];
+		const result = filterHighConfidenceKnowledge(entries, 0.8);
+		expect(result).toHaveLength(0);
+	});
+
+	it('confidence 1.0 is always included with default threshold', () => {
+		const entries = [makeRankedEntry('id-1', 'Perfect confidence', 1.0)];
+		const result = filterHighConfidenceKnowledge(entries);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('id-1');
+	});
+
+	it('mixed boundary values with default threshold 0.8', () => {
+		const entries = [
+			makeRankedEntry('id-1', 'Just below', 0.79),
+			makeRankedEntry('id-2', 'Exactly 0.8', 0.8),
+			makeRankedEntry('id-3', 'Just above', 0.81),
+			makeRankedEntry('id-4', 'Zero', 0.0),
+			makeRankedEntry('id-5', 'Perfect', 1.0),
+		];
+		const result = filterHighConfidenceKnowledge(entries);
+		expect(result).toHaveLength(3);
+		expect(result.map((e) => e.id)).toEqual(['id-2', 'id-3', 'id-5']);
+	});
+
+	// Preserves input type / generic behavior
+
+	it('preserves the type of entries (generic behavior)', () => {
+		interface CustomEntry extends RankedEntry {
+			customField?: string;
+		}
+		const entries: CustomEntry[] = [
+			{ ...makeRankedEntry('id-1', 'Lesson', 0.9), customField: 'value1' },
+			{ ...makeRankedEntry('id-2', 'Lesson', 0.7), customField: 'value2' },
+		];
+		const result = filterHighConfidenceKnowledge<CustomEntry>(entries, 0.8);
+		expect(result).toHaveLength(1);
+		expect(result[0].customField).toBe('value1');
+	});
+
+	it('returns new array, does not mutate original', () => {
+		const entries = [
+			makeRankedEntry('id-1', 'High', 0.9),
+			makeRankedEntry('id-2', 'Low', 0.5),
+		];
+		const result = filterHighConfidenceKnowledge(entries, 0.8);
+		expect(result).not.toBe(entries);
+		expect(entries).toHaveLength(2); // original unchanged
+	});
+});

--- a/tests/unit/hooks/knowledge-application-gate-escape-hatch-regression.test.ts
+++ b/tests/unit/hooks/knowledge-application-gate-escape-hatch-regression.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Regression tests for specific bugs found during PR review of the
+ * knowledge-application enforcement gate's deadlock escape hatches (see
+ * knowledge-application-gate-escape-hatch.test.ts for the base escape-hatch
+ * behavior tests, split out to stay under the repo's 500-line test file
+ * limit — AGENTS.md invariant 7):
+ *
+ *  - Cross-directive leak: denials accrued against one unacknowledged
+ *    critical directive must not carry over to an unrelated directive that
+ *    replaces it via setCriticalShownIds (an ordinary phase/task-transition
+ *    occurrence).
+ *  - Re-injection stability: the injector re-stamps `generatedAt` on every
+ *    cache-hit re-injection of the SAME directive set, so the denial-count
+ *    identity key must be derived from the directive-id set, not the
+ *    timestamp.
+ *  - Session-teardown boundary: resetSwarmState (and by extension
+ *    resetSwarmStatePreservingSingletons, the production `/swarm close`
+ *    path) must clear the denial counter so a reused sessionID does not
+ *    inherit a stale count.
+ *  - Centralized clear pathway: the escape hatches must clear
+ *    currentCriticalShownIds via the existing clearCriticalShownIds()
+ *    helper, not a direct Map.delete().
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+	buildAckDedupKey,
+	DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+} from '../../../src/hooks/knowledge-application';
+import { knowledgeApplicationGateBefore } from '../../../src/hooks/knowledge-application-gate';
+import { swarmState } from '../../../src/state';
+
+let tmp: string;
+beforeEach(() => {
+	mock.restore();
+	tmp = mkdtempSync(path.join(tmpdir(), 'swarm-gate-escape-regression-'));
+	swarmState.currentCriticalShownIds.clear();
+	swarmState.knowledgeAckDedup.clear();
+	swarmState.gateDenialCounts.clear();
+});
+afterEach(() => {
+	rmSync(tmp, { recursive: true, force: true });
+	mock.restore();
+});
+
+const ID_A = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+const ID_B = 'bbbbbbbb-bbbb-4bbb-9bbb-bbbbbbbbbbbb';
+
+describe('gate escape hatch regressions (PR review findings)', () => {
+	it('regression: denials against an unacked directive do not carry over to a swapped-in unrelated directive', async () => {
+		// Reproduces the cross-directive leak found in PR review: a session
+		// accrues denials against directive A (never acked), then the
+		// critical-directive set is swapped to an unrelated directive B via
+		// setCriticalShownIds (the ordinary phase/task-transition path in
+		// knowledge-injector.ts) — B must get its own full max_gate_denials
+		// budget, not inherit A's stale count.
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+			max_gate_denials: 5,
+		};
+
+		// Accrue 3 denials against A — never acked, never resolved.
+		for (let i = 0; i < 3; i++) {
+			await expect(
+				knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				),
+			).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		}
+
+		// Swap to an unrelated directive B without ever acking A (this is what
+		// setCriticalShownIds does on an ordinary phase/task transition).
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_B],
+			generatedAt: Date.now(),
+		});
+
+		// B must require its OWN 5 denials before the escape hatch fires — it
+		// must NOT inherit A's 3 accrued denials. Assert it still throws for
+		// denials 4 through 8 overall (i.e. 1 through 5 against B).
+		for (let i = 0; i < 5; i++) {
+			await expect(
+				knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				),
+			).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		}
+
+		// Only now (6th denial against B specifically) should the hatch fire.
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+		expect(
+			swarmState.knowledgeAckDedup.has(buildAckDedupKey('s1', ID_B, 'applied')),
+		).toBe(true);
+	});
+
+	it('regression: re-injecting the same directive across turns does not reset the denial count', async () => {
+		// The knowledge-injector re-stamps generatedAt on every cache-hit
+		// re-injection of the SAME directive set, so the identity key must be
+		// derived from the ids themselves (not generatedAt) — otherwise the
+		// denial-count escape hatch would never accumulate past 1 in normal
+		// usage, defeating its purpose.
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+			max_gate_denials: 3,
+		};
+
+		for (let i = 0; i < 3; i++) {
+			// Simulate the injector re-injecting the identical directive set on
+			// each turn with a freshly stamped generatedAt.
+			swarmState.currentCriticalShownIds.set('s1', {
+				ids: [ID_A],
+				generatedAt: Date.now() + i,
+			});
+			await expect(
+				knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				),
+			).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		}
+
+		// 4th denial against the same (re-stamped) directive set fires the hatch.
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now() + 100,
+		});
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+	});
+
+	it('regression: resetSwarmState clears the gate denial counter (session-teardown boundary)', async () => {
+		// Reproduces the unwired-reset gap found in PR review: /swarm close
+		// (resetSwarmStatePreservingSingletons -> resetSwarmState) must not
+		// leave a stale denial count for a sessionID that gets reused by a
+		// fresh incident.
+		const { resetSwarmState } = await import('../../../src/state');
+
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+			max_gate_denials: 5,
+		};
+
+		// Accrue denials near the max, then simulate session teardown.
+		for (let i = 0; i < 3; i++) {
+			await expect(
+				knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				),
+			).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		}
+		expect(swarmState.gateDenialCounts.get('s1')?.count).toBe(3);
+
+		resetSwarmState();
+		expect(swarmState.gateDenialCounts.has('s1')).toBe(false);
+
+		// A fresh incident on the same (reused) sessionID must require the
+		// FULL configured max_gate_denials again, not just the remaining 2.
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_B],
+			generatedAt: Date.now(),
+		});
+		for (let i = 0; i < 5; i++) {
+			await expect(
+				knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				),
+			).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		}
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+	});
+
+	it('uses clearCriticalShownIds (not a direct Map.delete) so escape-hatch clears go through the centralized FIFO-cap pathway', async () => {
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+			max_gate_denials: 1,
+		};
+
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		// 2nd call triggers the denial-limit escape hatch.
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+
+		expect(swarmState.currentCriticalShownIds.has('s1')).toBe(false);
+	});
+});

--- a/tests/unit/hooks/knowledge-application-gate-escape-hatch.test.ts
+++ b/tests/unit/hooks/knowledge-application-gate-escape-hatch.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Tests for the knowledge-application enforcement gate's deadlock escape
+ * hatches (denial-count limit + staleness TTL). Split from
+ * knowledge-application-gate.test.ts to stay under the repo's 500-line test
+ * file limit (AGENTS.md invariant 7). Regression tests for the specific
+ * cross-directive-leak / session-teardown bugs found in PR review live in
+ * knowledge-application-gate-escape-hatch-regression.test.ts; FIFO eviction
+ * of the underlying counter lives in
+ * knowledge-application-gate-denial-fifo.test.ts.
+ *
+ * Notes:
+ *  - The gate consults swarmState.currentCriticalShownIds,
+ *    swarmState.knowledgeAckDedup, and swarmState.gateDenialCounts. Tests
+ *    prime/clear them between cases.
+ *  - In `enforce` mode the gate throws KNOWLEDGE_ENFORCE_GATE_DENY until an
+ *    escape hatch fires.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+	buildAckDedupKey,
+	DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+} from '../../../src/hooks/knowledge-application';
+import { knowledgeApplicationGateBefore } from '../../../src/hooks/knowledge-application-gate';
+import { swarmState } from '../../../src/state';
+import { withFrozenClockAsync } from '../../helpers/test-clock.js';
+
+let tmp: string;
+beforeEach(() => {
+	mock.restore();
+	tmp = mkdtempSync(path.join(tmpdir(), 'swarm-gate-escape-'));
+	swarmState.currentCriticalShownIds.clear();
+	swarmState.knowledgeAckDedup.clear();
+	swarmState.gateDenialCounts.clear();
+});
+afterEach(() => {
+	rmSync(tmp, { recursive: true, force: true });
+	mock.restore();
+});
+
+const ID_A = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+const ID_B = 'bbbbbbbb-bbbb-4bbb-9bbb-bbbbbbbbbbbb';
+/** Fixed reference instant for staleness escape-hatch tests (withFrozenClockAsync). */
+const FIXED_NOW = 1_700_000_000_000;
+
+describe('gate escape hatches (KNOWLEDGE_ENFORCE_GATE_DENY deadlock)', () => {
+	it('auto-clears after max_gate_denials exceeded (default 5)', async () => {
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+		};
+
+		// First 5 calls should throw
+		for (let i = 0; i < 5; i++) {
+			await expect(
+				knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				),
+			).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		}
+
+		// 6th call should pass (escape hatch fires)
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+		// no throw
+	});
+
+	it('respects custom max_gate_denials from config', async () => {
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+			max_gate_denials: 2,
+		};
+
+		// First 2 calls throw
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+
+		// 3rd call passes
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+	});
+
+	it('auto-clears stale directives older than gate_staleness_ms', async () => {
+		await withFrozenClockAsync(
+			async () => {
+				const staleTime = FIXED_NOW - 700_000; // 700s ago > 600s default
+				swarmState.currentCriticalShownIds.set('s1', {
+					ids: [ID_A],
+					generatedAt: staleTime,
+				});
+				const cfg = {
+					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+					mode: 'enforce' as const,
+				};
+
+				// Should NOT throw — directive is stale
+				await knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				);
+			},
+			{ fixedNow: FIXED_NOW },
+		);
+	});
+
+	it('respects custom gate_staleness_ms from config', async () => {
+		await withFrozenClockAsync(
+			async () => {
+				const staleTime = FIXED_NOW - 15_000; // 15s ago
+				swarmState.currentCriticalShownIds.set('s1', {
+					ids: [ID_A],
+					generatedAt: staleTime,
+				});
+				const cfg = {
+					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+					mode: 'enforce' as const,
+					gate_staleness_ms: 10_000, // 10s staleness
+				};
+
+				// Should NOT throw — 15s > 10s
+				await knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				);
+			},
+			{ fixedNow: FIXED_NOW },
+		);
+	});
+
+	it('still throws when within staleness threshold', async () => {
+		await withFrozenClockAsync(
+			async () => {
+				const recentTime = FIXED_NOW - 1_000; // 1s ago
+				swarmState.currentCriticalShownIds.set('s1', {
+					ids: [ID_A],
+					generatedAt: recentTime,
+				});
+				const cfg = {
+					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+					mode: 'enforce' as const,
+				};
+
+				await expect(
+					knowledgeApplicationGateBefore(
+						tmp,
+						{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+						cfg,
+					),
+				).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+			},
+			{ fixedNow: FIXED_NOW },
+		);
+	});
+
+	it('populates knowledgeAckDedup after escape hatch fires', async () => {
+		await withFrozenClockAsync(
+			async () => {
+				const staleTime = FIXED_NOW - 700_000;
+				swarmState.currentCriticalShownIds.set('s1', {
+					ids: [ID_A, ID_B],
+					generatedAt: staleTime,
+				});
+				const cfg = {
+					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+					mode: 'enforce' as const,
+				};
+
+				await knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				);
+
+				// Both IDs should now be in the dedup set as 'applied'
+				expect(
+					swarmState.knowledgeAckDedup.has(
+						buildAckDedupKey('s1', ID_A, 'applied'),
+					),
+				).toBe(true);
+				expect(
+					swarmState.knowledgeAckDedup.has(
+						buildAckDedupKey('s1', ID_B, 'applied'),
+					),
+				).toBe(true);
+			},
+			{ fixedNow: FIXED_NOW },
+		);
+	});
+
+	it('clears currentCriticalShownIds for session after escape hatch', async () => {
+		await withFrozenClockAsync(
+			async () => {
+				const staleTime = FIXED_NOW - 700_000;
+				swarmState.currentCriticalShownIds.set('s1', {
+					ids: [ID_A],
+					generatedAt: staleTime,
+				});
+				const cfg = {
+					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+					mode: 'enforce' as const,
+				};
+
+				await knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				);
+
+				expect(swarmState.currentCriticalShownIds.has('s1')).toBe(false);
+			},
+			{ fixedNow: FIXED_NOW },
+		);
+	});
+
+	it('writes warning event to events.jsonl on staleness clear', async () => {
+		await withFrozenClockAsync(
+			async () => {
+				const staleTime = FIXED_NOW - 700_000;
+				swarmState.currentCriticalShownIds.set('s1', {
+					ids: [ID_A],
+					generatedAt: staleTime,
+				});
+				await mkdir(path.join(tmp, '.swarm'), { recursive: true });
+				const cfg = {
+					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+					mode: 'enforce' as const,
+				};
+
+				await knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				);
+
+				// The audit write is awaited inside knowledgeApplicationGateBefore
+				// before it returns, so the event is already durable here — no
+				// sleep needed.
+				const eventsPath = path.join(tmp, '.swarm', 'events.jsonl');
+				expect(existsSync(eventsPath)).toBe(true);
+				const body = readFileSync(eventsPath, 'utf-8');
+				expect(body).toContain('knowledge_application_gate_staleness_clear');
+				expect(body).toContain(ID_A);
+			},
+			{ fixedNow: FIXED_NOW },
+		);
+	});
+
+	it('writes warning event to events.jsonl on denial limit clear', async () => {
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		await mkdir(path.join(tmp, '.swarm'), { recursive: true });
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+			max_gate_denials: 1,
+		};
+
+		// First call throws
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+
+		// Second call triggers escape
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+
+		// The audit write is awaited inside knowledgeApplicationGateBefore
+		// before it returns, so the event is already durable here — no sleep
+		// needed.
+		const eventsPath = path.join(tmp, '.swarm', 'events.jsonl');
+		expect(existsSync(eventsPath)).toBe(true);
+		const body = readFileSync(eventsPath, 'utf-8');
+		expect(body).toContain('knowledge_application_gate_denial_limit_clear');
+	});
+
+	it('denial counter resets after successful ack', async () => {
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+			max_gate_denials: 3,
+		};
+
+		// Accumulate 2 denials
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+
+		// Simulate successful ack
+		swarmState.knowledgeAckDedup.add(buildAckDedupKey('s1', ID_A, 'applied'));
+
+		// This should pass (acked) and clear the counter
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+
+		// Now remove ack and add new critical ID — counter should be fresh
+		swarmState.knowledgeAckDedup.clear();
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_B],
+			generatedAt: Date.now(),
+		});
+
+		// Should need full 3 denials again before escape
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+
+		// 4th call passes (escape fires)
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+	});
+});

--- a/tests/unit/hooks/knowledge-application-gate.test.ts
+++ b/tests/unit/hooks/knowledge-application-gate.test.ts
@@ -27,6 +27,7 @@ import {
 import type { MessageWithParts } from '../../../src/hooks/knowledge-types';
 import { swarmState } from '../../../src/state';
 import { knowledge_receipt } from '../../../src/tools/knowledge-receipt';
+import { withFrozenClockAsync } from '../../helpers/test-clock.js';
 
 let tmp: string;
 beforeEach(() => {
@@ -42,6 +43,8 @@ afterEach(() => {
 
 const ID_A = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
 const ID_B = 'bbbbbbbb-bbbb-4bbb-9bbb-bbbbbbbbbbbb';
+/** Fixed reference instant for staleness escape-hatch tests (withFrozenClockAsync). */
+const FIXED_NOW = 1_700_000_000_000;
 
 describe('knowledgeApplicationGateBefore', () => {
 	it('does nothing when disabled', async () => {
@@ -510,134 +513,168 @@ describe('gate escape hatches (KNOWLEDGE_ENFORCE_GATE_DENY deadlock)', () => {
 	});
 
 	it('auto-clears stale directives older than gate_staleness_ms', async () => {
-		const staleTime = Date.now() - 700_000; // 700s ago > 600s default
-		swarmState.currentCriticalShownIds.set('s1', {
-			ids: [ID_A],
-			generatedAt: staleTime,
-		});
-		const cfg = {
-			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-			mode: 'enforce' as const,
-		};
+		await withFrozenClockAsync(
+			async () => {
+				const staleTime = FIXED_NOW - 700_000; // 700s ago > 600s default
+				swarmState.currentCriticalShownIds.set('s1', {
+					ids: [ID_A],
+					generatedAt: staleTime,
+				});
+				const cfg = {
+					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+					mode: 'enforce' as const,
+				};
 
-		// Should NOT throw — directive is stale
-		await knowledgeApplicationGateBefore(
-			tmp,
-			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-			cfg,
+				// Should NOT throw — directive is stale
+				await knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				);
+			},
+			{ fixedNow: FIXED_NOW },
 		);
 	});
 
 	it('respects custom gate_staleness_ms from config', async () => {
-		const staleTime = Date.now() - 15_000; // 15s ago
-		swarmState.currentCriticalShownIds.set('s1', {
-			ids: [ID_A],
-			generatedAt: staleTime,
-		});
-		const cfg = {
-			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-			mode: 'enforce' as const,
-			gate_staleness_ms: 10_000, // 10s staleness
-		};
+		await withFrozenClockAsync(
+			async () => {
+				const staleTime = FIXED_NOW - 15_000; // 15s ago
+				swarmState.currentCriticalShownIds.set('s1', {
+					ids: [ID_A],
+					generatedAt: staleTime,
+				});
+				const cfg = {
+					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+					mode: 'enforce' as const,
+					gate_staleness_ms: 10_000, // 10s staleness
+				};
 
-		// Should NOT throw — 15s > 10s
-		await knowledgeApplicationGateBefore(
-			tmp,
-			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-			cfg,
+				// Should NOT throw — 15s > 10s
+				await knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				);
+			},
+			{ fixedNow: FIXED_NOW },
 		);
 	});
 
 	it('still throws when within staleness threshold', async () => {
-		const recentTime = Date.now() - 1_000; // 1s ago
-		swarmState.currentCriticalShownIds.set('s1', {
-			ids: [ID_A],
-			generatedAt: recentTime,
-		});
-		const cfg = {
-			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-			mode: 'enforce' as const,
-		};
+		await withFrozenClockAsync(
+			async () => {
+				const recentTime = FIXED_NOW - 1_000; // 1s ago
+				swarmState.currentCriticalShownIds.set('s1', {
+					ids: [ID_A],
+					generatedAt: recentTime,
+				});
+				const cfg = {
+					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+					mode: 'enforce' as const,
+				};
 
-		await expect(
-			knowledgeApplicationGateBefore(
-				tmp,
-				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-				cfg,
-			),
-		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+				await expect(
+					knowledgeApplicationGateBefore(
+						tmp,
+						{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+						cfg,
+					),
+				).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+			},
+			{ fixedNow: FIXED_NOW },
+		);
 	});
 
 	it('populates knowledgeAckDedup after escape hatch fires', async () => {
-		const staleTime = Date.now() - 700_000;
-		swarmState.currentCriticalShownIds.set('s1', {
-			ids: [ID_A, ID_B],
-			generatedAt: staleTime,
-		});
-		const cfg = {
-			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-			mode: 'enforce' as const,
-		};
+		await withFrozenClockAsync(
+			async () => {
+				const staleTime = FIXED_NOW - 700_000;
+				swarmState.currentCriticalShownIds.set('s1', {
+					ids: [ID_A, ID_B],
+					generatedAt: staleTime,
+				});
+				const cfg = {
+					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+					mode: 'enforce' as const,
+				};
 
-		await knowledgeApplicationGateBefore(
-			tmp,
-			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-			cfg,
+				await knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				);
+
+				// Both IDs should now be in the dedup set as 'applied'
+				expect(
+					swarmState.knowledgeAckDedup.has(
+						buildAckDedupKey('s1', ID_A, 'applied'),
+					),
+				).toBe(true);
+				expect(
+					swarmState.knowledgeAckDedup.has(
+						buildAckDedupKey('s1', ID_B, 'applied'),
+					),
+				).toBe(true);
+			},
+			{ fixedNow: FIXED_NOW },
 		);
-
-		// Both IDs should now be in the dedup set as 'applied'
-		expect(
-			swarmState.knowledgeAckDedup.has(buildAckDedupKey('s1', ID_A, 'applied')),
-		).toBe(true);
-		expect(
-			swarmState.knowledgeAckDedup.has(buildAckDedupKey('s1', ID_B, 'applied')),
-		).toBe(true);
 	});
 
 	it('clears currentCriticalShownIds for session after escape hatch', async () => {
-		const staleTime = Date.now() - 700_000;
-		swarmState.currentCriticalShownIds.set('s1', {
-			ids: [ID_A],
-			generatedAt: staleTime,
-		});
-		const cfg = {
-			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-			mode: 'enforce' as const,
-		};
+		await withFrozenClockAsync(
+			async () => {
+				const staleTime = FIXED_NOW - 700_000;
+				swarmState.currentCriticalShownIds.set('s1', {
+					ids: [ID_A],
+					generatedAt: staleTime,
+				});
+				const cfg = {
+					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+					mode: 'enforce' as const,
+				};
 
-		await knowledgeApplicationGateBefore(
-			tmp,
-			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-			cfg,
+				await knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				);
+
+				expect(swarmState.currentCriticalShownIds.has('s1')).toBe(false);
+			},
+			{ fixedNow: FIXED_NOW },
 		);
-
-		expect(swarmState.currentCriticalShownIds.has('s1')).toBe(false);
 	});
 
 	it('writes warning event to events.jsonl on staleness clear', async () => {
-		const staleTime = Date.now() - 700_000;
-		swarmState.currentCriticalShownIds.set('s1', {
-			ids: [ID_A],
-			generatedAt: staleTime,
-		});
-		await mkdir(path.join(tmp, '.swarm'), { recursive: true });
-		const cfg = {
-			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-			mode: 'enforce' as const,
-		};
+		await withFrozenClockAsync(
+			async () => {
+				const staleTime = FIXED_NOW - 700_000;
+				swarmState.currentCriticalShownIds.set('s1', {
+					ids: [ID_A],
+					generatedAt: staleTime,
+				});
+				await mkdir(path.join(tmp, '.swarm'), { recursive: true });
+				const cfg = {
+					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+					mode: 'enforce' as const,
+				};
 
-		await knowledgeApplicationGateBefore(
-			tmp,
-			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-			cfg,
+				await knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				);
+
+				await new Promise((r) => setTimeout(r, 30));
+				const eventsPath = path.join(tmp, '.swarm', 'events.jsonl');
+				expect(existsSync(eventsPath)).toBe(true);
+				const body = readFileSync(eventsPath, 'utf-8');
+				expect(body).toContain('knowledge_application_gate_staleness_clear');
+				expect(body).toContain(ID_A);
+			},
+			{ fixedNow: FIXED_NOW },
 		);
-
-		await new Promise((r) => setTimeout(r, 30));
-		const eventsPath = path.join(tmp, '.swarm', 'events.jsonl');
-		expect(existsSync(eventsPath)).toBe(true);
-		const body = readFileSync(eventsPath, 'utf-8');
-		expect(body).toContain('knowledge_application_gate_staleness_clear');
-		expect(body).toContain(ID_A);
 	});
 
 	it('writes warning event to events.jsonl on denial limit clear', async () => {

--- a/tests/unit/hooks/knowledge-application-gate.test.ts
+++ b/tests/unit/hooks/knowledge-application-gate.test.ts
@@ -433,3 +433,305 @@ describe('knowledgeApplicationTransformScan', () => {
 		});
 	});
 });
+
+describe('gate escape hatches (#1690)', () => {
+	const { _internals } = await import(
+		'../../../src/hooks/knowledge-application-gate'
+	);
+
+	beforeEach(() => {
+		_internals.resetGateDenialCounts();
+	});
+
+	afterEach(() => {
+		_internals.resetGateDenialCounts();
+	});
+
+	it('auto-clears after max_gate_denials exceeded (default 5)', async () => {
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		const cfg = { ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' as const };
+
+		// First 5 calls should throw
+		for (let i = 0; i < 5; i++) {
+			await expect(
+				knowledgeApplicationGateBefore(
+					tmp,
+					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+					cfg,
+				),
+			).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		}
+
+		// 6th call should pass (escape hatch fires)
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+		// no throw
+	});
+
+	it('respects custom max_gate_denials from config', async () => {
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+			max_gate_denials: 2,
+		};
+
+		// First 2 calls throw
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+
+		// 3rd call passes
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+	});
+
+	it('auto-clears stale directives older than gate_staleness_ms', async () => {
+		const staleTime = Date.now() - 700_000; // 700s ago > 600s default
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: staleTime,
+		});
+		const cfg = { ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' as const };
+
+		// Should NOT throw — directive is stale
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+	});
+
+	it('respects custom gate_staleness_ms from config', async () => {
+		const staleTime = Date.now() - 15_000; // 15s ago
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: staleTime,
+		});
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+			gate_staleness_ms: 10_000, // 10s staleness
+		};
+
+		// Should NOT throw — 15s > 10s
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+	});
+
+	it('still throws when within staleness threshold', async () => {
+		const recentTime = Date.now() - 1_000; // 1s ago
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: recentTime,
+		});
+		const cfg = { ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' as const };
+
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+	});
+
+	it('populates knowledgeAckDedup after escape hatch fires', async () => {
+		const staleTime = Date.now() - 700_000;
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A, ID_B],
+			generatedAt: staleTime,
+		});
+		const cfg = { ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' as const };
+
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+
+		// Both IDs should now be in the dedup set as 'applied'
+		expect(
+			swarmState.knowledgeAckDedup.has(buildAckDedupKey('s1', ID_A, 'applied')),
+		).toBe(true);
+		expect(
+			swarmState.knowledgeAckDedup.has(buildAckDedupKey('s1', ID_B, 'applied')),
+		).toBe(true);
+	});
+
+	it('clears currentCriticalShownIds for session after escape hatch', async () => {
+		const staleTime = Date.now() - 700_000;
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: staleTime,
+		});
+		const cfg = { ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' as const };
+
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+
+		expect(swarmState.currentCriticalShownIds.has('s1')).toBe(false);
+	});
+
+	it('writes warning event to events.jsonl on staleness clear', async () => {
+		const staleTime = Date.now() - 700_000;
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: staleTime,
+		});
+		await mkdir(path.join(tmp, '.swarm'), { recursive: true });
+		const cfg = { ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' as const };
+
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+
+		await new Promise((r) => setTimeout(r, 30));
+		const eventsPath = path.join(tmp, '.swarm', 'events.jsonl');
+		expect(existsSync(eventsPath)).toBe(true);
+		const body = readFileSync(eventsPath, 'utf-8');
+		expect(body).toContain('knowledge_application_gate_staleness_clear');
+		expect(body).toContain(ID_A);
+	});
+
+	it('writes warning event to events.jsonl on denial limit clear', async () => {
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		await mkdir(path.join(tmp, '.swarm'), { recursive: true });
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+			max_gate_denials: 1,
+		};
+
+		// First call throws
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+
+		// Second call triggers escape
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+
+		await new Promise((r) => setTimeout(r, 30));
+		const eventsPath = path.join(tmp, '.swarm', 'events.jsonl');
+		expect(existsSync(eventsPath)).toBe(true);
+		const body = readFileSync(eventsPath, 'utf-8');
+		expect(body).toContain('knowledge_application_gate_denial_limit_clear');
+	});
+
+	it('denial counter resets after successful ack', async () => {
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_A],
+			generatedAt: Date.now(),
+		});
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+			max_gate_denials: 3,
+		};
+
+		// Accumulate 2 denials
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+
+		// Simulate successful ack
+		swarmState.knowledgeAckDedup.add(buildAckDedupKey('s1', ID_A, 'applied'));
+
+		// This should pass (acked) and clear the counter
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+
+		// Now remove ack and add new critical ID — counter should be fresh
+		swarmState.knowledgeAckDedup.clear();
+		swarmState.currentCriticalShownIds.set('s1', {
+			ids: [ID_B],
+			generatedAt: Date.now(),
+		});
+
+		// Should need full 3 denials again before escape
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+		await expect(
+			knowledgeApplicationGateBefore(
+				tmp,
+				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+				cfg,
+			),
+		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
+
+		// 4th call passes (escape fires)
+		await knowledgeApplicationGateBefore(
+			tmp,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
+			cfg,
+		);
+	});
+});

--- a/tests/unit/hooks/knowledge-application-gate.test.ts
+++ b/tests/unit/hooks/knowledge-application-gate.test.ts
@@ -435,7 +435,7 @@ describe('knowledgeApplicationTransformScan', () => {
 	});
 });
 
-describe('gate escape hatches (#1690)', () => {
+describe('gate escape hatches (KNOWLEDGE_ENFORCE_GATE_DENY deadlock)', () => {
 	beforeEach(() => {
 		_internals.resetGateDenialCounts();
 	});
@@ -449,7 +449,10 @@ describe('gate escape hatches (#1690)', () => {
 			ids: [ID_A],
 			generatedAt: Date.now(),
 		});
-		const cfg = { ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' as const };
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+		};
 
 		// First 5 calls should throw
 		for (let i = 0; i < 5; i++) {
@@ -512,7 +515,10 @@ describe('gate escape hatches (#1690)', () => {
 			ids: [ID_A],
 			generatedAt: staleTime,
 		});
-		const cfg = { ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' as const };
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+		};
 
 		// Should NOT throw — directive is stale
 		await knowledgeApplicationGateBefore(
@@ -548,7 +554,10 @@ describe('gate escape hatches (#1690)', () => {
 			ids: [ID_A],
 			generatedAt: recentTime,
 		});
-		const cfg = { ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' as const };
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+		};
 
 		await expect(
 			knowledgeApplicationGateBefore(
@@ -565,7 +574,10 @@ describe('gate escape hatches (#1690)', () => {
 			ids: [ID_A, ID_B],
 			generatedAt: staleTime,
 		});
-		const cfg = { ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' as const };
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+		};
 
 		await knowledgeApplicationGateBefore(
 			tmp,
@@ -588,7 +600,10 @@ describe('gate escape hatches (#1690)', () => {
 			ids: [ID_A],
 			generatedAt: staleTime,
 		});
-		const cfg = { ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' as const };
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+		};
 
 		await knowledgeApplicationGateBefore(
 			tmp,
@@ -606,7 +621,10 @@ describe('gate escape hatches (#1690)', () => {
 			generatedAt: staleTime,
 		});
 		await mkdir(path.join(tmp, '.swarm'), { recursive: true });
-		const cfg = { ...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG, mode: 'enforce' as const };
+		const cfg = {
+			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+			mode: 'enforce' as const,
+		};
 
 		await knowledgeApplicationGateBefore(
 			tmp,

--- a/tests/unit/hooks/knowledge-application-gate.test.ts
+++ b/tests/unit/hooks/knowledge-application-gate.test.ts
@@ -20,6 +20,7 @@ import {
 	resolveApplicationLogPath,
 } from '../../../src/hooks/knowledge-application';
 import {
+	_internals,
 	knowledgeApplicationGateBefore,
 	knowledgeApplicationTransformScan,
 } from '../../../src/hooks/knowledge-application-gate';
@@ -435,10 +436,6 @@ describe('knowledgeApplicationTransformScan', () => {
 });
 
 describe('gate escape hatches (#1690)', () => {
-	const { _internals } = await import(
-		'../../../src/hooks/knowledge-application-gate'
-	);
-
 	beforeEach(() => {
 		_internals.resetGateDenialCounts();
 	});

--- a/tests/unit/hooks/knowledge-application-gate.test.ts
+++ b/tests/unit/hooks/knowledge-application-gate.test.ts
@@ -7,6 +7,11 @@
  *    swarmState.knowledgeAckDedup. Tests prime/clear them between cases.
  *  - In `enforce` mode the gate throws KNOWLEDGE_ENFORCE_GATE_DENY.
  *  - In `warn` mode the gate appends to .swarm/events.jsonl and returns.
+ *
+ * Deadlock escape-hatch behavior (denial-count limit + staleness TTL) is
+ * covered in knowledge-application-gate-escape-hatch.test.ts and
+ * knowledge-application-gate-escape-hatch-regression.test.ts (split out to
+ * stay under the repo's 500-line test file limit — AGENTS.md invariant 7).
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
@@ -27,7 +32,7 @@ import {
 import type { MessageWithParts } from '../../../src/hooks/knowledge-types';
 import { swarmState } from '../../../src/state';
 import { knowledge_receipt } from '../../../src/tools/knowledge-receipt';
-import { withFrozenClockAsync } from '../../helpers/test-clock.js';
+import { withFrozenClock } from '../../helpers/test-clock.js';
 
 let tmp: string;
 beforeEach(() => {
@@ -35,6 +40,7 @@ beforeEach(() => {
 	tmp = mkdtempSync(path.join(tmpdir(), 'swarm-gate-'));
 	swarmState.currentCriticalShownIds.clear();
 	swarmState.knowledgeAckDedup.clear();
+	swarmState.gateDenialCounts.clear();
 });
 afterEach(() => {
 	rmSync(tmp, { recursive: true, force: true });
@@ -43,14 +49,14 @@ afterEach(() => {
 
 const ID_A = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
 const ID_B = 'bbbbbbbb-bbbb-4bbb-9bbb-bbbbbbbbbbbb';
-/** Fixed reference instant for staleness escape-hatch tests (withFrozenClockAsync). */
-const FIXED_NOW = 1_700_000_000_000;
 
 describe('knowledgeApplicationGateBefore', () => {
 	it('does nothing when disabled', async () => {
 		swarmState.currentCriticalShownIds.set('s1', {
 			ids: [ID_A],
-			generatedAt: Date.now(),
+			// generatedAt is fixture data here, never asserted against — frozen
+			// deterministically per repo test-stability convention (issue #1782).
+			generatedAt: withFrozenClock(() => Date.now()),
 		});
 		await knowledgeApplicationGateBefore(
 			tmp,
@@ -435,355 +441,5 @@ describe('knowledgeApplicationTransformScan', () => {
 				),
 			).toBe(false);
 		});
-	});
-});
-
-describe('gate escape hatches (KNOWLEDGE_ENFORCE_GATE_DENY deadlock)', () => {
-	beforeEach(() => {
-		_internals.resetGateDenialCounts();
-	});
-
-	afterEach(() => {
-		_internals.resetGateDenialCounts();
-	});
-
-	it('auto-clears after max_gate_denials exceeded (default 5)', async () => {
-		swarmState.currentCriticalShownIds.set('s1', {
-			ids: [ID_A],
-			generatedAt: Date.now(),
-		});
-		const cfg = {
-			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-			mode: 'enforce' as const,
-		};
-
-		// First 5 calls should throw
-		for (let i = 0; i < 5; i++) {
-			await expect(
-				knowledgeApplicationGateBefore(
-					tmp,
-					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-					cfg,
-				),
-			).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
-		}
-
-		// 6th call should pass (escape hatch fires)
-		await knowledgeApplicationGateBefore(
-			tmp,
-			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-			cfg,
-		);
-		// no throw
-	});
-
-	it('respects custom max_gate_denials from config', async () => {
-		swarmState.currentCriticalShownIds.set('s1', {
-			ids: [ID_A],
-			generatedAt: Date.now(),
-		});
-		const cfg = {
-			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-			mode: 'enforce' as const,
-			max_gate_denials: 2,
-		};
-
-		// First 2 calls throw
-		await expect(
-			knowledgeApplicationGateBefore(
-				tmp,
-				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-				cfg,
-			),
-		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
-		await expect(
-			knowledgeApplicationGateBefore(
-				tmp,
-				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-				cfg,
-			),
-		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
-
-		// 3rd call passes
-		await knowledgeApplicationGateBefore(
-			tmp,
-			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-			cfg,
-		);
-	});
-
-	it('auto-clears stale directives older than gate_staleness_ms', async () => {
-		await withFrozenClockAsync(
-			async () => {
-				const staleTime = FIXED_NOW - 700_000; // 700s ago > 600s default
-				swarmState.currentCriticalShownIds.set('s1', {
-					ids: [ID_A],
-					generatedAt: staleTime,
-				});
-				const cfg = {
-					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-					mode: 'enforce' as const,
-				};
-
-				// Should NOT throw — directive is stale
-				await knowledgeApplicationGateBefore(
-					tmp,
-					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-					cfg,
-				);
-			},
-			{ fixedNow: FIXED_NOW },
-		);
-	});
-
-	it('respects custom gate_staleness_ms from config', async () => {
-		await withFrozenClockAsync(
-			async () => {
-				const staleTime = FIXED_NOW - 15_000; // 15s ago
-				swarmState.currentCriticalShownIds.set('s1', {
-					ids: [ID_A],
-					generatedAt: staleTime,
-				});
-				const cfg = {
-					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-					mode: 'enforce' as const,
-					gate_staleness_ms: 10_000, // 10s staleness
-				};
-
-				// Should NOT throw — 15s > 10s
-				await knowledgeApplicationGateBefore(
-					tmp,
-					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-					cfg,
-				);
-			},
-			{ fixedNow: FIXED_NOW },
-		);
-	});
-
-	it('still throws when within staleness threshold', async () => {
-		await withFrozenClockAsync(
-			async () => {
-				const recentTime = FIXED_NOW - 1_000; // 1s ago
-				swarmState.currentCriticalShownIds.set('s1', {
-					ids: [ID_A],
-					generatedAt: recentTime,
-				});
-				const cfg = {
-					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-					mode: 'enforce' as const,
-				};
-
-				await expect(
-					knowledgeApplicationGateBefore(
-						tmp,
-						{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-						cfg,
-					),
-				).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
-			},
-			{ fixedNow: FIXED_NOW },
-		);
-	});
-
-	it('populates knowledgeAckDedup after escape hatch fires', async () => {
-		await withFrozenClockAsync(
-			async () => {
-				const staleTime = FIXED_NOW - 700_000;
-				swarmState.currentCriticalShownIds.set('s1', {
-					ids: [ID_A, ID_B],
-					generatedAt: staleTime,
-				});
-				const cfg = {
-					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-					mode: 'enforce' as const,
-				};
-
-				await knowledgeApplicationGateBefore(
-					tmp,
-					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-					cfg,
-				);
-
-				// Both IDs should now be in the dedup set as 'applied'
-				expect(
-					swarmState.knowledgeAckDedup.has(
-						buildAckDedupKey('s1', ID_A, 'applied'),
-					),
-				).toBe(true);
-				expect(
-					swarmState.knowledgeAckDedup.has(
-						buildAckDedupKey('s1', ID_B, 'applied'),
-					),
-				).toBe(true);
-			},
-			{ fixedNow: FIXED_NOW },
-		);
-	});
-
-	it('clears currentCriticalShownIds for session after escape hatch', async () => {
-		await withFrozenClockAsync(
-			async () => {
-				const staleTime = FIXED_NOW - 700_000;
-				swarmState.currentCriticalShownIds.set('s1', {
-					ids: [ID_A],
-					generatedAt: staleTime,
-				});
-				const cfg = {
-					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-					mode: 'enforce' as const,
-				};
-
-				await knowledgeApplicationGateBefore(
-					tmp,
-					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-					cfg,
-				);
-
-				expect(swarmState.currentCriticalShownIds.has('s1')).toBe(false);
-			},
-			{ fixedNow: FIXED_NOW },
-		);
-	});
-
-	it('writes warning event to events.jsonl on staleness clear', async () => {
-		await withFrozenClockAsync(
-			async () => {
-				const staleTime = FIXED_NOW - 700_000;
-				swarmState.currentCriticalShownIds.set('s1', {
-					ids: [ID_A],
-					generatedAt: staleTime,
-				});
-				await mkdir(path.join(tmp, '.swarm'), { recursive: true });
-				const cfg = {
-					...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-					mode: 'enforce' as const,
-				};
-
-				await knowledgeApplicationGateBefore(
-					tmp,
-					{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-					cfg,
-				);
-
-				await new Promise((r) => setTimeout(r, 30));
-				const eventsPath = path.join(tmp, '.swarm', 'events.jsonl');
-				expect(existsSync(eventsPath)).toBe(true);
-				const body = readFileSync(eventsPath, 'utf-8');
-				expect(body).toContain('knowledge_application_gate_staleness_clear');
-				expect(body).toContain(ID_A);
-			},
-			{ fixedNow: FIXED_NOW },
-		);
-	});
-
-	it('writes warning event to events.jsonl on denial limit clear', async () => {
-		swarmState.currentCriticalShownIds.set('s1', {
-			ids: [ID_A],
-			generatedAt: Date.now(),
-		});
-		await mkdir(path.join(tmp, '.swarm'), { recursive: true });
-		const cfg = {
-			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-			mode: 'enforce' as const,
-			max_gate_denials: 1,
-		};
-
-		// First call throws
-		await expect(
-			knowledgeApplicationGateBefore(
-				tmp,
-				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-				cfg,
-			),
-		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
-
-		// Second call triggers escape
-		await knowledgeApplicationGateBefore(
-			tmp,
-			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-			cfg,
-		);
-
-		await new Promise((r) => setTimeout(r, 30));
-		const eventsPath = path.join(tmp, '.swarm', 'events.jsonl');
-		expect(existsSync(eventsPath)).toBe(true);
-		const body = readFileSync(eventsPath, 'utf-8');
-		expect(body).toContain('knowledge_application_gate_denial_limit_clear');
-	});
-
-	it('denial counter resets after successful ack', async () => {
-		swarmState.currentCriticalShownIds.set('s1', {
-			ids: [ID_A],
-			generatedAt: Date.now(),
-		});
-		const cfg = {
-			...DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
-			mode: 'enforce' as const,
-			max_gate_denials: 3,
-		};
-
-		// Accumulate 2 denials
-		await expect(
-			knowledgeApplicationGateBefore(
-				tmp,
-				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-				cfg,
-			),
-		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
-		await expect(
-			knowledgeApplicationGateBefore(
-				tmp,
-				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-				cfg,
-			),
-		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
-
-		// Simulate successful ack
-		swarmState.knowledgeAckDedup.add(buildAckDedupKey('s1', ID_A, 'applied'));
-
-		// This should pass (acked) and clear the counter
-		await knowledgeApplicationGateBefore(
-			tmp,
-			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-			cfg,
-		);
-
-		// Now remove ack and add new critical ID — counter should be fresh
-		swarmState.knowledgeAckDedup.clear();
-		swarmState.currentCriticalShownIds.set('s1', {
-			ids: [ID_B],
-			generatedAt: Date.now(),
-		});
-
-		// Should need full 3 denials again before escape
-		await expect(
-			knowledgeApplicationGateBefore(
-				tmp,
-				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-				cfg,
-			),
-		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
-		await expect(
-			knowledgeApplicationGateBefore(
-				tmp,
-				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-				cfg,
-			),
-		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
-		await expect(
-			knowledgeApplicationGateBefore(
-				tmp,
-				{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-				cfg,
-			),
-		).rejects.toThrow(/KNOWLEDGE_ENFORCE_GATE_DENY/);
-
-		// 4th call passes (escape fires)
-		await knowledgeApplicationGateBefore(
-			tmp,
-			{ tool: 'save_plan', agent: 'architect', sessionID: 's1' },
-			cfg,
-		);
 	});
 });

--- a/tests/unit/hooks/knowledge-application.test.ts
+++ b/tests/unit/hooks/knowledge-application.test.ts
@@ -25,6 +25,7 @@ import {
 	resolveSwarmKnowledgePath,
 } from '../../../src/hooks/knowledge-store';
 import type { SwarmKnowledgeEntry } from '../../../src/hooks/knowledge-types';
+import { withFrozenClock } from '../../helpers/test-clock.js';
 
 let tmp: string;
 beforeEach(() => {
@@ -55,8 +56,13 @@ async function seedEntry(id: string): Promise<void> {
 			failed_after_count: 0,
 		},
 		schema_version: 2,
-		created_at: new Date().toISOString(),
-		updated_at: new Date().toISOString(),
+		...withFrozenClock(
+			() => ({
+				created_at: new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+			}),
+			{ isoNow: '2026-01-01T00:00:00.000Z' },
+		),
 		project_name: 'test',
 		directive_priority: 'critical',
 	};

--- a/tests/unit/hooks/knowledge-application.test.ts
+++ b/tests/unit/hooks/knowledge-application.test.ts
@@ -1,7 +1,14 @@
 /**
- * Tests for the v2 knowledge-application module: parsing acknowledgments,
- * recording shown/applied/ignored/violated outcomes, distinguishing shown
- * from applied, and the warn/enforce gate.
+ * Tests for the v2 knowledge-application module: recording
+ * shown/applied/ignored/violated outcomes, distinguishing shown from
+ * applied, and the warn/enforce gate.
+ *
+ * parseAcknowledgments (the ACK_PATTERN regex) and the
+ * KnowledgeApplicationConfigSchema max_gate_denials/gate_staleness_ms fields
+ * are covered in knowledge-application-ack-parsing.test.ts;
+ * filterHighConfidenceKnowledge is covered in
+ * knowledge-application-filter-confidence.test.ts (split out to stay under
+ * the repo's 500-line test file limit — AGENTS.md invariant 7).
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
@@ -14,7 +21,6 @@ import {
 	gateKnowledgeApplication,
 	getShownButNotAcknowledged,
 	MAX_LEGACY_APPLICATION_LOG_ENTRIES,
-	parseAcknowledgments,
 	processArchitectText,
 	recordAcknowledgment,
 	recordKnowledgeShown,
@@ -72,83 +78,6 @@ async function seedEntry(id: string): Promise<void> {
 		'utf-8',
 	);
 }
-
-describe('parseAcknowledgments', () => {
-	it('extracts applied/ignored/violated markers with reasons', () => {
-		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
-		const text = `KNOWLEDGE_APPLIED: ${id}
-KNOWLEDGE_IGNORED: ${id} reason=not relevant
-KNOWLEDGE_VIOLATED: ${id} reason=scope breach`;
-		const acks = parseAcknowledgments(text);
-		expect(acks).toHaveLength(3);
-		expect(acks[0].result).toBe('applied');
-		expect(acks[1].result).toBe('ignored');
-		expect(acks[1].reason).toBe('not relevant');
-		expect(acks[2].result).toBe('violated');
-		expect(acks[2].reason).toBe('scope breach');
-	});
-
-	it('returns empty for non-matching text', () => {
-		expect(parseAcknowledgments('plain prose, no markers')).toEqual([]);
-	});
-
-	it('matches when ID is followed by trailing explanation text', () => {
-		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
-		const text = `KNOWLEDGE_APPLIED: ${id} - I have incorporated this directive.`;
-		const acks = parseAcknowledgments(text);
-		expect(acks).toHaveLength(1);
-		expect(acks[0].id).toBe(id);
-		expect(acks[0].result).toBe('applied');
-	});
-
-	it('matches when ID is followed by a period', () => {
-		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
-		const text = `KNOWLEDGE_APPLIED: ${id}. Moving on to the next step.`;
-		const acks = parseAcknowledgments(text);
-		expect(acks).toHaveLength(1);
-		expect(acks[0].id).toBe(id);
-		expect(acks[0].result).toBe('applied');
-	});
-
-	it('matches when ID is followed by parenthetical', () => {
-		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
-		const text = `KNOWLEDGE_APPLIED: ${id}(used in plan)`;
-		const acks = parseAcknowledgments(text);
-		expect(acks).toHaveLength(1);
-		expect(acks[0].id).toBe(id);
-		expect(acks[0].result).toBe('applied');
-	});
-
-	it('matches inline multi-marker on same line separated by spaces', () => {
-		const id1 = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
-		const id2 = 'bbbbbbbb-bbbb-4bbb-9bbb-bbbbbbbbbbbb';
-		const text = `KNOWLEDGE_APPLIED: ${id1} KNOWLEDGE_IGNORED: ${id2} reason=not relevant`;
-		const acks = parseAcknowledgments(text);
-		expect(acks).toHaveLength(2);
-		expect(acks[0].id).toBe(id1);
-		expect(acks[0].result).toBe('applied');
-		expect(acks[1].id).toBe(id2);
-		expect(acks[1].result).toBe('ignored');
-		expect(acks[1].reason).toBe('not relevant');
-	});
-
-	it('handles N_A marker', () => {
-		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
-		const text = `KNOWLEDGE_N_A: ${id} reason=directive not applicable to this context`;
-		const acks = parseAcknowledgments(text);
-		expect(acks).toHaveLength(1);
-		expect(acks[0].result).toBe('n_a');
-		expect(acks[0].reason).toBe('directive not applicable to this context');
-	});
-
-	it('matches ID at end of string without newline', () => {
-		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
-		const text = `KNOWLEDGE_APPLIED: ${id}`;
-		const acks = parseAcknowledgments(text);
-		expect(acks).toHaveLength(1);
-		expect(acks[0].id).toBe(id);
-	});
-});
 
 describe('recordKnowledgeShown vs recordAcknowledgment', () => {
 	it('shown does not increment applied_explicit_count', async () => {
@@ -423,192 +352,6 @@ describe('recordAcknowledgment / bumpCountersBatch — TOCTOU race fix (#1285)',
 		expect(e1?.retrieval_outcomes.acknowledged_count).toBe(1);
 		expect(e2?.retrieval_outcomes.applied_explicit_count).toBe(1);
 		expect(e2?.retrieval_outcomes.acknowledged_count).toBe(1);
-	});
-});
-
-// ============================================================================
-// filterHighConfidenceKnowledge — unit tests
-// ============================================================================
-
-import { filterHighConfidenceKnowledge } from '../../../src/hooks/knowledge-application.js';
-import type { RankedEntry } from '../../../src/hooks/knowledge-reader.js';
-
-function makeRankedEntry(
-	id: string,
-	lesson: string,
-	confidence: number,
-): RankedEntry {
-	return {
-		id,
-		tier: 'swarm',
-		lesson,
-		category: 'process',
-		tags: [],
-		scope: 'global',
-		confidence,
-		status: 'established',
-		confirmed_by: [],
-		retrieval_outcomes: {
-			applied_count: 0,
-			succeeded_after_count: 0,
-			failed_after_count: 0,
-		},
-		schema_version: 1,
-		created_at: new Date().toISOString(),
-		updated_at: new Date().toISOString(),
-		relevanceScore: confidence,
-		finalScore: confidence,
-	};
-}
-
-describe('filterHighConfidenceKnowledge', () => {
-	// Happy path: entries >= threshold are included, < threshold are excluded
-
-	it('includes entries with confidence >= threshold', () => {
-		const entries = [
-			makeRankedEntry('id-1', 'Lesson one', 0.85),
-			makeRankedEntry('id-2', 'Lesson two', 0.92),
-			makeRankedEntry('id-3', 'Lesson three', 1.0),
-		];
-		const result = filterHighConfidenceKnowledge(entries, 0.8);
-		expect(result).toHaveLength(3);
-		expect(result.map((e) => e.id)).toEqual(['id-1', 'id-2', 'id-3']);
-	});
-
-	it('excludes entries with confidence < threshold', () => {
-		const entries = [
-			makeRankedEntry('id-1', 'High confidence', 0.9),
-			makeRankedEntry('id-2', 'Low confidence', 0.5),
-			makeRankedEntry('id-3', 'Another high', 0.85),
-		];
-		const result = filterHighConfidenceKnowledge(entries, 0.8);
-		expect(result).toHaveLength(2);
-		expect(result.map((e) => e.id)).toEqual(['id-1', 'id-3']);
-	});
-
-	// Default threshold: 0.8 when not provided
-
-	it('uses default threshold of 0.8 when called with no threshold argument', () => {
-		const entries = [
-			makeRankedEntry('id-1', 'Exactly 0.8', 0.8), // >= 0.8 → included
-			makeRankedEntry('id-2', 'Above 0.8', 0.81), // >= 0.8 → included
-			makeRankedEntry('id-3', 'Below 0.8', 0.79), // < 0.8 → excluded
-		];
-		const result = filterHighConfidenceKnowledge(entries);
-		expect(result).toHaveLength(2);
-		expect(result.map((e) => e.id)).toEqual(['id-1', 'id-2']);
-	});
-
-	// Custom threshold
-
-	it('works with custom threshold of 0.9', () => {
-		const entries = [
-			makeRankedEntry('id-1', 'Confidence 0.9', 0.9), // >= 0.9 → included
-			makeRankedEntry('id-2', 'Confidence 0.85', 0.85), // < 0.9 → excluded
-			makeRankedEntry('id-3', 'Confidence 1.0', 1.0), // >= 0.9 → included
-		];
-		const result = filterHighConfidenceKnowledge(entries, 0.9);
-		expect(result).toHaveLength(2);
-		expect(result.map((e) => e.id)).toEqual(['id-1', 'id-3']);
-	});
-
-	it('works with custom threshold of 0.5', () => {
-		const entries = [
-			makeRankedEntry('id-1', 'High', 0.9),
-			makeRankedEntry('id-2', 'Mid', 0.6),
-			makeRankedEntry('id-3', 'Low', 0.3),
-		];
-		const result = filterHighConfidenceKnowledge(entries, 0.5);
-		expect(result).toHaveLength(2);
-		expect(result.map((e) => e.id)).toEqual(['id-1', 'id-2']);
-	});
-
-	it('works with custom threshold of 1.0 (only perfect confidence included)', () => {
-		const entries = [
-			makeRankedEntry('id-1', 'Perfect', 1.0),
-			makeRankedEntry('id-2', 'Almost perfect', 0.99),
-			makeRankedEntry('id-3', 'High', 0.95),
-		];
-		const result = filterHighConfidenceKnowledge(entries, 1.0);
-		expect(result).toHaveLength(1);
-		expect(result[0].id).toBe('id-1');
-	});
-
-	it('works with custom threshold of 0.0 (all entries included)', () => {
-		const entries = [
-			makeRankedEntry('id-1', 'Zero confidence', 0.0),
-			makeRankedEntry('id-2', 'Low confidence', 0.3),
-			makeRankedEntry('id-3', 'Any confidence', 0.5),
-		];
-		const result = filterHighConfidenceKnowledge(entries, 0.0);
-		expect(result).toHaveLength(3);
-	});
-
-	// Empty input
-
-	it('returns empty array for empty input', () => {
-		const result = filterHighConfidenceKnowledge([]);
-		expect(result).toEqual([]);
-	});
-
-	// Edge cases: boundary values
-
-	it('exactly 0.8 threshold: entry with confidence 0.8 is included', () => {
-		const entries = [makeRankedEntry('id-1', 'Exactly at threshold', 0.8)];
-		const result = filterHighConfidenceKnowledge(entries, 0.8);
-		expect(result).toHaveLength(1);
-		expect(result[0].id).toBe('id-1');
-	});
-
-	it('confidence 0.0 is excluded when threshold is 0.8', () => {
-		const entries = [makeRankedEntry('id-1', 'Zero confidence', 0.0)];
-		const result = filterHighConfidenceKnowledge(entries, 0.8);
-		expect(result).toHaveLength(0);
-	});
-
-	it('confidence 1.0 is always included with default threshold', () => {
-		const entries = [makeRankedEntry('id-1', 'Perfect confidence', 1.0)];
-		const result = filterHighConfidenceKnowledge(entries);
-		expect(result).toHaveLength(1);
-		expect(result[0].id).toBe('id-1');
-	});
-
-	it('mixed boundary values with default threshold 0.8', () => {
-		const entries = [
-			makeRankedEntry('id-1', 'Just below', 0.79),
-			makeRankedEntry('id-2', 'Exactly 0.8', 0.8),
-			makeRankedEntry('id-3', 'Just above', 0.81),
-			makeRankedEntry('id-4', 'Zero', 0.0),
-			makeRankedEntry('id-5', 'Perfect', 1.0),
-		];
-		const result = filterHighConfidenceKnowledge(entries);
-		expect(result).toHaveLength(3);
-		expect(result.map((e) => e.id)).toEqual(['id-2', 'id-3', 'id-5']);
-	});
-
-	// Preserves input type / generic behavior
-
-	it('preserves the type of entries (generic behavior)', () => {
-		interface CustomEntry extends RankedEntry {
-			customField?: string;
-		}
-		const entries: CustomEntry[] = [
-			{ ...makeRankedEntry('id-1', 'Lesson', 0.9), customField: 'value1' },
-			{ ...makeRankedEntry('id-2', 'Lesson', 0.7), customField: 'value2' },
-		];
-		const result = filterHighConfidenceKnowledge<CustomEntry>(entries, 0.8);
-		expect(result).toHaveLength(1);
-		expect(result[0].customField).toBe('value1');
-	});
-
-	it('returns new array, does not mutate original', () => {
-		const entries = [
-			makeRankedEntry('id-1', 'High', 0.9),
-			makeRankedEntry('id-2', 'Low', 0.5),
-		];
-		const result = filterHighConfidenceKnowledge(entries, 0.8);
-		expect(result).not.toBe(entries);
-		expect(entries).toHaveLength(2); // original unchanged
 	});
 });
 

--- a/tests/unit/hooks/knowledge-application.test.ts
+++ b/tests/unit/hooks/knowledge-application.test.ts
@@ -85,6 +85,63 @@ KNOWLEDGE_VIOLATED: ${id} reason=scope breach`;
 	it('returns empty for non-matching text', () => {
 		expect(parseAcknowledgments('plain prose, no markers')).toEqual([]);
 	});
+
+	it('matches when ID is followed by trailing explanation text', () => {
+		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+		const text = `KNOWLEDGE_APPLIED: ${id} - I have incorporated this directive.`;
+		const acks = parseAcknowledgments(text);
+		expect(acks).toHaveLength(1);
+		expect(acks[0].id).toBe(id);
+		expect(acks[0].result).toBe('applied');
+	});
+
+	it('matches when ID is followed by a period', () => {
+		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+		const text = `KNOWLEDGE_APPLIED: ${id}. Moving on to the next step.`;
+		const acks = parseAcknowledgments(text);
+		expect(acks).toHaveLength(1);
+		expect(acks[0].id).toBe(id);
+		expect(acks[0].result).toBe('applied');
+	});
+
+	it('matches when ID is followed by parenthetical', () => {
+		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+		const text = `KNOWLEDGE_APPLIED: ${id}(used in plan)`;
+		const acks = parseAcknowledgments(text);
+		expect(acks).toHaveLength(1);
+		expect(acks[0].id).toBe(id);
+		expect(acks[0].result).toBe('applied');
+	});
+
+	it('matches inline multi-marker on same line separated by spaces', () => {
+		const id1 = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+		const id2 = 'bbbbbbbb-bbbb-4bbb-9bbb-bbbbbbbbbbbb';
+		const text = `KNOWLEDGE_APPLIED: ${id1} KNOWLEDGE_IGNORED: ${id2} reason=not relevant`;
+		const acks = parseAcknowledgments(text);
+		expect(acks).toHaveLength(2);
+		expect(acks[0].id).toBe(id1);
+		expect(acks[0].result).toBe('applied');
+		expect(acks[1].id).toBe(id2);
+		expect(acks[1].result).toBe('ignored');
+		expect(acks[1].reason).toBe('not relevant');
+	});
+
+	it('handles N_A marker', () => {
+		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+		const text = `KNOWLEDGE_N_A: ${id} reason=directive not applicable to this context`;
+		const acks = parseAcknowledgments(text);
+		expect(acks).toHaveLength(1);
+		expect(acks[0].result).toBe('n_a');
+		expect(acks[0].reason).toBe('directive not applicable to this context');
+	});
+
+	it('matches ID at end of string without newline', () => {
+		const id = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
+		const text = `KNOWLEDGE_APPLIED: ${id}`;
+		const acks = parseAcknowledgments(text);
+		expect(acks).toHaveLength(1);
+		expect(acks[0].id).toBe(id);
+	});
 });
 
 describe('recordKnowledgeShown vs recordAcknowledgment', () => {

--- a/tests/unit/state-knowledge-eviction.test.ts
+++ b/tests/unit/state-knowledge-eviction.test.ts
@@ -1,15 +1,20 @@
 /**
  * AGENTS.md invariant #8: module-level global state must have an explicit
- * eviction strategy. The v2 knowledge state (currentCriticalShownIds Map and
- * knowledgeAckDedup Set) is unbounded by default; setCriticalShownIds and
- * addKnowledgeAckDedup wrap insertion with FIFO caps.
+ * eviction strategy. The v2 knowledge state (currentCriticalShownIds Map,
+ * knowledgeAckDedup Set, and gateDenialCounts Map) is unbounded by default;
+ * setCriticalShownIds, addKnowledgeAckDedup, and incrementGateDenialCount
+ * wrap insertion with FIFO caps.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import {
 	addKnowledgeAckDedup,
+	buildGateDenialDirectiveKey,
 	clearCriticalShownIds,
+	clearGateDenialCount,
+	incrementGateDenialCount,
 	MAX_TRACKED_CRITICAL_SHOWN,
+	MAX_TRACKED_GATE_DENIALS,
 	MAX_TRACKED_KNOWLEDGE_ACKS,
 	resetSwarmState,
 	setCriticalShownIds,
@@ -115,5 +120,90 @@ describe('addKnowledgeAckDedup — FIFO cap', () => {
 		addKnowledgeAckDedup('ack-x');
 		addKnowledgeAckDedup('ack-x');
 		expect(swarmState.knowledgeAckDedup.size).toBe(1);
+	});
+});
+
+describe('incrementGateDenialCount/clearGateDenialCount — FIFO cap', () => {
+	const key = buildGateDenialDirectiveKey(['dir-a']);
+
+	it('caps the map at MAX_TRACKED_GATE_DENIALS entries', () => {
+		const total = MAX_TRACKED_GATE_DENIALS + 5;
+		for (let i = 0; i < total; i++) {
+			incrementGateDenialCount(`session-${i}`, key);
+		}
+		expect(swarmState.gateDenialCounts.size).toBe(MAX_TRACKED_GATE_DENIALS);
+		// Oldest 5 evicted
+		expect(swarmState.gateDenialCounts.has('session-0')).toBe(false);
+		expect(swarmState.gateDenialCounts.has('session-4')).toBe(false);
+		expect(swarmState.gateDenialCounts.has('session-5')).toBe(true);
+		expect(swarmState.gateDenialCounts.has(`session-${total - 1}`)).toBe(true);
+	});
+
+	it('refresh on existing key keeps cap and re-inserts as newest', () => {
+		for (let i = 0; i < MAX_TRACKED_GATE_DENIALS; i++) {
+			incrementGateDenialCount(`g-${i}`, key);
+		}
+		expect(swarmState.gateDenialCounts.size).toBe(MAX_TRACKED_GATE_DENIALS);
+		// Refresh oldest — does not push size over the cap, and oldest remains tracked
+		incrementGateDenialCount('g-0', key);
+		expect(swarmState.gateDenialCounts.size).toBe(MAX_TRACKED_GATE_DENIALS);
+		expect(swarmState.gateDenialCounts.get('g-0')?.count).toBe(2);
+		// Now the new oldest is g-1; one more insertion evicts it (not g-0)
+		incrementGateDenialCount('g-new', key);
+		expect(swarmState.gateDenialCounts.has('g-1')).toBe(false);
+		expect(swarmState.gateDenialCounts.has('g-0')).toBe(true);
+	});
+
+	it('a mismatched directiveKey restarts the count at 1 instead of accumulating', () => {
+		incrementGateDenialCount('s1', key);
+		incrementGateDenialCount('s1', key);
+		expect(incrementGateDenialCount('s1', key)).toBe(3);
+
+		const otherKey = buildGateDenialDirectiveKey(['dir-b']);
+		expect(incrementGateDenialCount('s1', otherKey)).toBe(1);
+	});
+
+	it('clearGateDenialCount removes an entry', () => {
+		incrementGateDenialCount('s-clear', key);
+		expect(swarmState.gateDenialCounts.has('s-clear')).toBe(true);
+		clearGateDenialCount('s-clear');
+		expect(swarmState.gateDenialCounts.has('s-clear')).toBe(false);
+	});
+
+	it('does not break the cap when interleaved with increment+clear', () => {
+		for (let i = 0; i < MAX_TRACKED_GATE_DENIALS; i++) {
+			incrementGateDenialCount(`d-${i}`, key);
+		}
+		for (let i = 0; i < 100; i++) clearGateDenialCount(`d-${i}`);
+		expect(swarmState.gateDenialCounts.size).toBe(
+			MAX_TRACKED_GATE_DENIALS - 100,
+		);
+		for (let i = 0; i < 200; i++) {
+			incrementGateDenialCount(`d-new-${i}`, key);
+		}
+		expect(swarmState.gateDenialCounts.size).toBeLessThanOrEqual(
+			MAX_TRACKED_GATE_DENIALS,
+		);
+	});
+
+	it('resetSwarmState clears the gate denial counter map', () => {
+		incrementGateDenialCount('s-reset', key);
+		expect(swarmState.gateDenialCounts.size).toBeGreaterThan(0);
+		resetSwarmState();
+		expect(swarmState.gateDenialCounts.size).toBe(0);
+	});
+});
+
+describe('buildGateDenialDirectiveKey', () => {
+	it('is order-independent (same id set, different order, same key)', () => {
+		expect(buildGateDenialDirectiveKey(['b', 'a'])).toBe(
+			buildGateDenialDirectiveKey(['a', 'b']),
+		);
+	});
+
+	it('distinguishes different id sets', () => {
+		expect(buildGateDenialDirectiveKey(['a'])).not.toBe(
+			buildGateDenialDirectiveKey(['b']),
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- Fixed a permanent deadlock in the knowledge-enforcement gate: once a critical knowledge directive landed in `swarmState.currentCriticalShownIds` for a session and its acknowledgment failed to parse, every subsequent high-risk architect tool call (`save_plan`, `update_task_status`, `phase_complete`, `task`/`Task`) threw `KNOWLEDGE_ENFORCE_GATE_DENY` for the rest of the session with no recovery path.
- Root cause #1: `ACK_PATTERN` in `src/hooks/knowledge-application.ts` required a strict lookahead after the directive ID (end-of-string, newline, or another `KNOWLEDGE_` marker). A common architect pattern — `KNOWLEDGE_APPLIED: <id> - I applied this.` — never matched, so the ack silently never landed.
- Root cause #2: the gate itself had no escape hatch — no denial limit, no staleness TTL — so any ack-pipeline failure (regex bug, hook error, ordering edge case) was unrecoverable in `enforce` mode.
- Added two independently configurable, auditable escape hatches to `knowledgeApplicationGateBefore` (`src/hooks/knowledge-application-gate.ts`): a denial-count limit (`max_gate_denials`, default 5) and a staleness TTL (`gate_staleness_ms`, default 10 min). Both auto-acknowledge the pending directives and durably write a `knowledge_application_gate_denial_limit_clear` / `knowledge_application_gate_staleness_clear` event to `.swarm/events.jsonl` **before returning** — never silent.
- Relaxed `ACK_PATTERN`'s outer lookahead so markers followed by punctuation or free text now parse; the `reason=` capture keeps its own tighter lookahead so reason text is unaffected.

### Follow-up round (self-requested `swarm-pr-review`)
After the initial push, an adapted `swarm-pr-review` run (17 explorer lanes → independent reviewer validation → adversarial critic challenge on HIGH/CRITICAL findings, since the canonical workflow's plugin-native dispatch tools aren't available in this Claude Code session) found two real bugs in the escape-hatch implementation, both confirmed via executed probe tests during critic review:
- **Cross-directive leak (HIGH → confirmed):** the per-session denial counter was keyed only by `sessionID`, not by *which* critical-directive set it was accrued against. When the injector swaps in an unrelated directive on an ordinary phase/task transition (`setCriticalShownIds`), the new directive silently inherited the old one's denial count and could get auto-cleared after far fewer than `max_gate_denials` real denials against it — contradicting the PR's own stated guarantee.
- **Unwired session-reset gap (MEDIUM → confirmed):** the denial-count map was a private module-scoped variable, never wired into `resetSwarmState`/`resetSwarmStatePreservingSingletons` (the production `/swarm close` teardown path), unlike its sibling maps. A stale count could survive a same-process close and leak into a reused session — a literal instance of this repo's "we never ship unwired code" directive.

**Fix:** moved the counter into `swarmState.gateDenialCounts` (`src/state.ts`), matching the existing `currentCriticalShownIds`/`knowledgeAckDedup` pattern exactly. `incrementGateDenialCount`/`clearGateDenialCount` now key each entry to a `directiveKey` fingerprint (`buildGateDenialDirectiveKey`, a sorted join of the directive-id set), so re-injecting the *same* directive across turns (the injector re-stamps `generatedAt` on every cache-hit re-injection) doesn't reset the count, but swapping to a genuinely different directive does. `resetSwarmState()` now clears `gateDenialCounts` alongside its siblings.

Also addressed in the same round: the escape-hatch audit-event writes are now `await`ed before the gate returns (were fire-and-forget, contradicting the release note's "never silent" claim); the escape hatches clear `currentCriticalShownIds` via the existing centralized `clearCriticalShownIds()` helper instead of a direct `Map.delete()`; corrected an overclaim in the release note about `skill_regenerate`/`skill_retire` being gated under the production default config (they aren't — a separate, pre-existing, out-of-scope shadowing bug); and updated `docs/knowledge.md` + the architect system prompt to describe the bounded escape hatches instead of claiming unconditional blocking.

Two test files that grew past the repo's 500-line limit (AGENTS.md invariant 7) were split into focused files; new regression tests cover both bugs plus FIFO-eviction for `gateDenialCounts`.

- Corrected a stale doc comment on `swarmState.knowledgeAckDedup` (`src/state.ts`) claiming the dedup key includes a `dayKey` component it never actually had (confirmed by the existing `GATE-002` regression test).
- Note: the real GitHub issue #1690 in this repo is an unrelated bug (a partial `gates` config block silently wiping the whole user config). The "issue #1690" framing in the original task description was fictional narrative content, not a real tracked issue — this PR does not close #1690 and no other tracked issue exists for this fix.

## Invariant audit
- 1 (plugin init): not touched — no changes to `src/index.ts` or the plugin init path.
- 2 (runtime portability): not touched — only `bun:test` imports (required test-framework imports); no `bun:sqlite` or `Bun.*` runtime calls added.
- 3 (subprocesses): not touched — `git diff --name-only origin/main..HEAD | xargs grep -nE "bunSpawn\(|spawn\(|spawnSync\("` returns no matches.
- 4 (.swarm containment): not touched — `git diff --name-only origin/main..HEAD | xargs grep -nE "process\.cwd\(\)"` returns no matches; `writeWarnEvent` (pre-existing) already takes `directory` as a parameter.
- 5 (plan durability): not touched — no `plan.json`/`plan-ledger.jsonl`/`plan.md` read or write paths were added or modified.
- 6 (test_runner safety): not touched — all validation used `bun test`/`bun --smol test` shell commands directly, never the `test_runner` tool.
- 7 (test writing): touched — all new tests use `bun:test` only. Two test files that grew past 500 lines were split into 4 focused files (`knowledge-application-gate-escape-hatch.test.ts`, `knowledge-application-gate-escape-hatch-regression.test.ts`, `knowledge-application-ack-parsing.test.ts`, `knowledge-application-filter-confidence.test.ts`), each under the limit. Time-sensitive tests use `withFrozenClockAsync`/`withFrozenClock` (`scripts/check-test-clock.sh` passes: "New violations (blocking): 0").
- 8 (session state): touched — `swarmState.gateDenialCounts` (`src/state.ts`) is a new `Map<string, {count, directiveKey}>` keyed by `sessionID`, FIFO-bounded to `MAX_TRACKED_GATE_DENIALS = 500` via `incrementGateDenialCount`/`clearGateDenialCount`, matching the exact pattern of `currentCriticalShownIds`/`knowledgeAckDedup`. Wired into `resetSwarmState()` (closes the follow-up round's unwired-reset finding). FIFO-eviction tests added to `tests/unit/state-knowledge-eviction.test.ts`.
- 9 (guardrails/retry): not touched — distinct enforcement-gate subsystem, not the guardrails/circuit-breaker retry system.
- 10 (chat/system msg): not touched — no changes to message-shape handling.
- 11 (tool registration): not touched — no new tools, agents, or commands.
- 12 (release/cache): not touched (cache-eviction/version logic) — `docs/releases/pending/knowledge-gate-deadlock-escape-hatch.md` fragment added/updated per policy; version files not hand-edited.

## Test plan
- [x] `bun run typecheck` — pass, no errors.
- [x] `bun run lint:ci` — pass ("Checked 2631 files ... No fixes applied.").
- [x] `bun run scripts/check-tool-registration.ts` — pass (108 tools, coherent).
- [x] `bash scripts/check-mock-cleanup.sh` — pass (pre-existing warnings only, none in changed files).
- [x] `bash scripts/check-invariants.sh` — pass (all sub-checks clean).
- [x] `bash scripts/check-cross-contamination.sh` — pass (no annotations reference the changed files).
- [x] `bash scripts/check-test-clock.sh` — pass ("New violations (blocking): 0").
- [x] Direct test run across the 7 knowledge-application(-gate) test files + `state-knowledge-eviction.test.ts` — **94 pass, 0 fail** (213 expect() calls).
- [x] Broad consumer/prompt-drift sweep (59 files: 46 architect-prompt tests + gate/ack tests + 2 integration tests) — **1208 pass, 0 fail** (4032 expect() calls); confirmed no stale references anywhere to the removed `_gateDenialCounts`/`resetGateDenialCounts` internals.
- [x] `bun --smol test tests/unit/config --timeout 120000` — 1584 pass / 41 fail; verified byte-identical against the pre-fix baseline (pre-existing, in `backward-compatibility-v67.test.ts` and `bundled-skills-async.test.ts`, unrelated).
- [x] `bun test tests/security --timeout 120000` — 167 pass, 0 fail.
- [x] `bun test tests/adversarial --timeout 120000` — 829 pass, 0 fail.
- [x] `bun test tests/smoke --timeout 120000` — 10 pass, 0 fail.
- [x] `bun test tests/integration --timeout 120000` — 609 pass / 207 fail; verified byte-identical against the pre-fix baseline (pre-existing, unrelated subsystems — none touch the knowledge-enforcement-gate code paths).
- [x] `bun run build` — succeeds; `node --input-type=module -e "await import('./dist/index.js')"` — succeeds.
- [x] Push-protection secret scan — clean.
- [x] Adapted `swarm-pr-review` (17 explorer lanes + independent reviewer + adversarial critic) run against this PR; both critic-upheld findings addressed and re-validated above.