### PR TITLE
fix(pr-workflow): restore review gate capability contracts

### DIFF
--- a/.opencode/skills/swarm-pr-feedback/SKILL.md
+++ b/.opencode/skills/swarm-pr-feedback/SKILL.md
@@ -203,20 +203,25 @@ for the Fix Planning step.
 
 ## Pre-flight: Scope Discipline
 
-The following `save_plan` / `declare_scope` mechanics apply only when those
-plugin tools are available. In other repositories or runtimes, use the native
-scope controller; if none exists, put exact allowed files and non-goals in the
-delegation and verify the resulting diff mechanically. Never bypass an
-available scope controller merely to reduce ceremony.
+When the plugin's mechanical controller is available, every coder Task must be
+preceded by `prepare_pr_feedback_scope({ task_id, files })`. The controller is
+available only after the immutable feedback-verification lanes have settled and
+binds the exact file set to the current feedback revision, parent session, and
+next matching Task call. The coder prompt must use the same numeric `task_id`,
+contain matching `FILE:` directives, and include a literal `ACCEPTANCE:` line.
+Once a Task consumes that scope, its `task_id` is immutable for the current
+feedback revision. Any retry must prepare and dispatch a fresh nested numeric
+task identity (for example `1.1.1`), never re-declare the consumed ID.
 
-`declare_scope({ taskId, files })` enforces that the delegated coder agent may only modify the declared files. The enforcement requires an active `.swarm/plan.json` — calling `declare_scope` in a feedback-closure run (which does not go through `save_plan`) rejects with "No plan found."
+Do not create a synthetic `save_plan` merely to authorize feedback work, and do
+not use `declare_scope`; those tools belong to the normal implementation-plan
+lifecycle. There is no one-file or single-function carve-out from the dedicated
+PR-feedback scope controller.
 
-**When to use `declare_scope` (preferred):** any feedback round that touches 2+ files, OR any feedback round where the file scope is not 100% obvious from the prompt. Before delegating, save a minimal plan via `save_plan` with a single phase containing the feedback-closure tasks, then call `declare_scope` per task with the exact file list.
-
-**Carve-out for direct Task delegation:** 1-file, single-function changes where the file path appears verbatim in the coder's prompt may use direct `Task(subagent_type="<coder>", ...)` delegation without `declare_scope`, where `<coder>` is the active swarm's coder agent (e.g. `coder`, or `paid_coder` when the swarm id is `paid`). This is a narrow exception; the orchestrator is responsible for verifying the scope is unambiguous.
-→ REQUIRED: even under this carve-out, the direct Task dispatch MUST contain a literal `ACCEPTANCE:` line — resolve per ACCEPTANCE FIELD RESOLUTION in your system prompt (one-line task-derived DONE restatement for the feedback fix, since feedback-closure runs typically have no fr_refs). A missing line is BLOCKED by ACCEPTANCE_FIELD_REQUIRED.
-
-**Anti-pattern:** do not use `Task` delegation for multi-file feedback fixes just to skip `save_plan` — the loss of scope discipline is not worth the saved ceremony.
+In runtimes without this controller, use the native scope mechanism. If none
+exists, put exact allowed files and non-goals in the delegation and verify the
+resulting diff mechanically. Never bypass an available scope controller merely
+to reduce ceremony.
 
 ## Intake Surfaces
 

--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -24,11 +24,11 @@ without running a fresh broad review.
 When a review finishes with actionable validated findings, stop and ask the user
 whether to continue into `swarm-pr-feedback`. Do not auto-dispatch fix work from
 `PR_REVIEW`. Instead, write a handoff artifact under
-`.swarm/pr-review/<run_id>/feedback-handoff.md` (or `.json`) and include the
-exact continuation prompt:
+`.swarm/pr-review/<run_id>/feedback-handoff.json` with `write_pr_review_artifact`
+and include the exact continuation prompt:
 
 ```text
-/swarm pr-feedback <PR_URL> continue from .swarm/pr-review/<run_id>/feedback-handoff.md
+/swarm pr-feedback <PR_URL> continue from .swarm/pr-review/<run_id>/feedback-handoff.json
 ```
 
 `<run_id>` is a stable identifier for this review run, such as
@@ -459,10 +459,10 @@ The context pack must include, when available:
 
 ## Review Finding Persistence
 
-Do not rely on conversation context to preserve review findings. Create a run
-artifact under `.swarm/pr-review/<run_id>/findings.jsonl` when file writes are
-allowed, or under `.swarm/evidence/pr-review-<run_id>-findings.jsonl` when the
-review already uses the evidence tree.
+Do not rely on conversation context to preserve review findings. Use
+`write_pr_review_artifact` with `kind: "findings"`; the controller creates and
+appends `.swarm/pr-review/<run_id>/findings.jsonl` without granting generic
+write authority over `.swarm/`.
 
 Each persisted finding record must include at least:
 
@@ -484,11 +484,14 @@ Minimum field contract:
 Persist after every major validation boundary:
 
 1. **Post-explorer:** after Phase 3/4 candidate parsing and before reviewer
-   dispatch, write all candidates as `PENDING` with their lane provenance.
-2. **Post-reviewer:** after Phase 6 reviewer validation, update each reviewed
+   dispatch, call `write_pr_review_artifact` with `boundary: "post_explorer"`
+   and all candidates as `PENDING` with their lane provenance.
+2. **Post-reviewer:** after Phase 6 reviewer validation, call the controller
+   with `boundary: "post_reviewer"` and update each reviewed
    record to `CONFIRMED`, `DISPROVED`, `PRE_EXISTING`, or keep `PENDING` with a
    concrete `next_action` if more evidence is required.
-3. **Post-critic:** after Phase 8 critic challenge, update final status,
+3. **Post-critic:** after Phase 8 critic challenge, call the controller with
+   `boundary: "post_critic"` and update final status,
    severity/action notes in `evidence`, and final reporting or handoff action.
 
 Resume/reload procedure:
@@ -1376,7 +1379,9 @@ Explain the recommendation in one short paragraph and list required actions befo
 ## Feedback handoff
 
 When the review produced actionable validated findings or operational blockers,
-include:
+call `write_pr_review_artifact` with `kind: "handoff"`. The controller writes
+`.swarm/pr-review/<run_id>/feedback-handoff.json` only when its finding IDs
+exactly match the latest confirmed `handoff_to_feedback` records. Include:
 
 - the handoff artifact path,
 - the preserved finding IDs and provenance that `swarm-pr-feedback` must carry
@@ -1387,7 +1392,7 @@ include:
 Use this exact continuation prompt format:
 
 ```text
-/swarm pr-feedback <PR_URL> continue from .swarm/pr-review/<run_id>/feedback-handoff.md
+/swarm pr-feedback <PR_URL> continue from .swarm/pr-review/<run_id>/feedback-handoff.json
 ```
 
 ---
@@ -1435,4 +1440,3 @@ unproductive wakes, and the only exits are:
 Abort is a recovery tool, not a coverage shortcut. Use it only when the
 bind/checkout path is genuinely unreachable; never use it to skip a
 coverage obligation that is merely expensive or inconvenient.
-

--- a/docs/releases/pending/1900-loader-sync-async-parity-locked-or-gates-metadata.md
+++ b/docs/releases/pending/1900-loader-sync-async-parity-locked-or-gates-metadata.md
@@ -1,0 +1,30 @@
+Fixes sync/async config-loader drift, `full_auto.locked` OR-merge gap in the
+async path, and silent gates-strip recovery metadata (#1900).
+
+- **Shared core**: `buildConfigWithMeta` is now the single source of truth for
+  the merge → `full_auto.locked` OR → migrate → sanitize → parse → fallback
+  pipeline. All three entry points (`loadPluginConfig`,
+  `loadPluginConfigWithMeta`, `loadPluginConfigWithMetaAsync`) call it, making
+  sync/async drift structurally impossible.
+- **`full_auto.locked` async fix**: the async path (`loadPluginConfigWithMetaAsync`,
+  used by the plugin init path per issue #704) now correctly applies the
+  `full_auto.locked` OR-merge, closing the administrative hard-off bypass that
+  existed when user config set `locked: true` and project config set
+  `locked: false`.
+- **Gates-strip visibility**: `loadPluginConfigWithMeta[Async]` now returns
+  `recovery: 'stripped_keys'` and lists the stripped dotted key paths in
+  `removedKeys` when `sanitizeGatesConfig` silently discards unknown `gates.*`
+  keys. Previously both functions returned `recovery: 'none'` even when gates
+  keys were stripped.
+- **Recovery metadata**: both functions return `recovery` (`'none'` |
+  `'stripped_keys'` | `'user_only'` | `'guardrails_defaults'`),
+  `removedKeys: string[]`, and `warnings: string[]` so consumers can surface
+  config-health information without re-parsing the advisory buffer.
+- **Parity test**: `tests/unit/config/loader.metadata.parity.test.ts` runs both
+  loaders against ten fixture types, including separate invalid-project and
+  invalid-both JSON cases plus invalid `external_skills`, and
+  asserts semantic equality on config + recovery metadata (with removed-key
+  order intentionally ignored); a future edit to one path that forgets the
+  other will fail this test immediately.
+
+No migration required.

--- a/docs/releases/pending/pr-workflow-gate-capability-contract.md
+++ b/docs/releases/pending/pr-workflow-gate-capability-contract.md
@@ -1,0 +1,33 @@
+# Restore Mechanical PR Workflow Capability Contracts
+
+## What
+
+- Routes real OpenCode SDK `output.args` into the mechanical PR workflow gate,
+  fixing both false denials of safe commands and false admission of mutating
+  connector arguments.
+- Defines explicit mode-scoped observation and validation capabilities for the
+  tools required by `swarm-pr-review`, while keeping unknown and mutation-capable
+  surfaces fail-closed.
+- Adds controller-owned review findings and feedback-handoff artifacts with
+  exact candidate coverage, phase ordering, PR-head binding, and completion
+  checks.
+- Adds a dedicated, revision-bound PR-feedback scope controller so verified
+  coder Tasks work without fabricating an implementation plan. Active bindings
+  remain exact-file scoped and recover safely from plugin-process restarts.
+- Permits only the narrow post-bind `git fetch <remote> <branch>` form required
+  by the review protocol; force, refspec rewrite, checkout, and compound forms
+  remain blocked.
+
+## Why
+
+The gate read arguments from the SDK input object even though the live host
+supplies them on the output object. That made the PR-review workflow unable to
+perform required read-only operations and weakened argument-sensitive mutation
+checks. The sibling PR-feedback workflow also documented a planless coder
+carve-out that the current scope preflight no longer supported.
+
+## Migration
+
+No user configuration changes are required. PR review and feedback runs now use
+the dedicated controller tools documented in their bundled skills; generic
+writes to protected `.swarm/` workflow evidence remain blocked.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -40,7 +40,11 @@ export {
 	ReviewEvidenceSchema,
 	TestEvidenceSchema,
 } from './evidence-schema';
-
+export type {
+	ConfigBuildResult,
+	ConfigLoadResult,
+	ConfigRecovery,
+} from './loader';
 // Re-export loaders for DI seam
 export {
 	loadAgentPrompt,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -19,37 +19,6 @@ const PROMPTS_DIR_NAME = 'opencode-swarm';
 export const MAX_CONFIG_FILE_BYTES = 102_400;
 
 /**
- * Recovery type indicating how the config was recovered from parse failure.
- * - 'none': config parsed cleanly on first attempt
- * - 'stripped_keys': Zod-confirmed unrecognized keys were surgically removed and parse succeeded
- * - 'user_only': project config was ignored (validation error); user config used alone
- * - 'guardrails_defaults': no recovery succeeded; fail-secure guardrails defaults applied
- */
-export type RecoveryType =
-	| 'none'
-	| 'stripped_keys'
-	| 'user_only'
-	| 'guardrails_defaults';
-
-/**
- * Structured recovery metadata returned by parseConfigWithFallback.
- * Exposed via loadPluginConfigWithMeta[Async] so programmatic callers can
- * introspect what recovery was performed.
- */
-export interface RecoveryInfo {
-	recovery: RecoveryType;
-	/** Dotted key paths that were removed during recovery (empty if none were stripped). */
-	removedKeys: string[];
-	/** Human-readable advisory messages describing what recovery was performed. */
-	warnings: string[];
-}
-
-/** Full parse result including recovery metadata. */
-interface ParseResult extends RecoveryInfo {
-	config: PluginConfig;
-}
-
-/**
  * Get the user's configuration directory (XDG Base Directory spec).
  */
 function getUserConfigDir(): string {
@@ -182,17 +151,21 @@ function migratePresetsConfig(
  * If the section is present but invalid, warn and strip it so the rest
  * of the config loads cleanly (AGENTS.md #1 fail-open).
  */
-function sanitizeExternalSkillsConfig(
-	raw: Record<string, unknown>,
-): Record<string, unknown> {
+function sanitizeExternalSkillsConfig(raw: Record<string, unknown>): {
+	result: Record<string, unknown>;
+	strippedKeys: string[];
+} {
 	if (!('external_skills' in raw) || raw.external_skills === undefined) {
-		return raw;
+		return { result: raw, strippedKeys: [] };
 	}
 	const esResult = ExternalSkillsConfigSchema.safeParse(raw.external_skills);
 	if (esResult.success) {
 		return {
-			...raw,
-			external_skills: resolveExternalSkillsConfig(esResult.data),
+			result: {
+				...raw,
+				external_skills: resolveExternalSkillsConfig(esResult.data),
+			},
+			strippedKeys: [],
 		};
 	}
 	advisoryWarn(
@@ -204,14 +177,16 @@ function sanitizeExternalSkillsConfig(
 	);
 	const cleaned = { ...raw };
 	delete cleaned.external_skills;
-	return cleaned;
+	return { result: cleaned, strippedKeys: ['external_skills'] };
 }
 
-function sanitizeGatesConfig(
-	raw: Record<string, unknown>,
-): Record<string, unknown> {
+function sanitizeGatesConfig(raw: Record<string, unknown>): {
+	result: Record<string, unknown>;
+	strippedKeys: string[];
+} {
+	const strippedKeys: string[] = [];
 	if (!('gates' in raw) || raw.gates === undefined) {
-		return raw;
+		return { result: raw, strippedKeys };
 	}
 	if (
 		typeof raw.gates !== 'object' ||
@@ -223,7 +198,8 @@ function sanitizeGatesConfig(
 		);
 		const cleaned = { ...raw };
 		delete cleaned.gates;
-		return cleaned;
+		strippedKeys.push('gates');
+		return { result: cleaned, strippedKeys };
 	}
 
 	const gateSchemas = GateConfigSchema.shape;
@@ -235,6 +211,7 @@ function sanitizeGatesConfig(
 				`[opencode-swarm] Unknown gates config section "gates.${key}" ignored. Other config sections remain active.`,
 			);
 			delete cleanedGates[key];
+			strippedKeys.push(`gates.${key}`);
 			continue;
 		}
 		const knownFields =
@@ -256,6 +233,7 @@ function sanitizeGatesConfig(
 						`[opencode-swarm] Unknown gates config key "gates.${key}.${fieldName}" ignored. Other config sections remain active.`,
 					);
 					delete cleanedSection[fieldName];
+					strippedKeys.push(`gates.${key}.${fieldName}`);
 				}
 			}
 			sectionValue = cleanedSection;
@@ -268,14 +246,17 @@ function sanitizeGatesConfig(
 				formatZodIssues(sectionResult.error),
 			);
 			delete cleanedGates[key];
+			if (!strippedKeys.includes(`gates.${key}`)) {
+				strippedKeys.push(`gates.${key}`);
+			}
 		}
 	}
 
 	const gatesResult = GateConfigSchema.safeParse(cleanedGates);
 	if (gatesResult.success) {
 		return {
-			...raw,
-			gates: gatesResult.data,
+			result: { ...raw, gates: gatesResult.data },
+			strippedKeys,
 		};
 	}
 
@@ -285,13 +266,21 @@ function sanitizeGatesConfig(
 	);
 	const cleaned = { ...raw };
 	delete cleaned.gates;
-	return cleaned;
+	if (!strippedKeys.includes('gates')) {
+		strippedKeys.push('gates');
+	}
+	return { result: cleaned, strippedKeys };
 }
 
-function sanitizeSectionConfigs(
-	raw: Record<string, unknown>,
-): Record<string, unknown> {
-	return sanitizeGatesConfig(sanitizeExternalSkillsConfig(raw));
+function sanitizeSectionConfigs(raw: Record<string, unknown>): {
+	result: Record<string, unknown>;
+	strippedKeys: string[];
+} {
+	const { result: afterExternal, strippedKeys: externalStripped } =
+		sanitizeExternalSkillsConfig(raw);
+	const { result, strippedKeys: gatesStripped } =
+		sanitizeGatesConfig(afterExternal);
+	return { result, strippedKeys: [...externalStripped, ...gatesStripped] };
 }
 
 /**
@@ -363,135 +352,52 @@ function stripUnrecognizedKeys(
 }
 
 /**
- * Centralized strict-parse fallback shared by the sync (`loadPluginConfig`) and
- * async (`reduceParsedConfig`) paths so they can never diverge (issue #1778 H6).
+ * Recovery classification returned by `buildConfigWithMeta`.
  *
- * Recovery order:
- *   1. Parse the merged raw config.
- *   2. On failure caused by unrecognized keys in strict sections, surgically
- *      drop ONLY those keys and re-parse — preserving every other user setting
- *      (the #1690 acceptance: one typo must not wipe the whole config).
- *   3. If still invalid, retry user-config-alone (ignoring a broken project
- *      config), then fall back to fail-secure guardrails-only defaults.
- *
- * All fallbacks name the offending key path(s) so the failure is actionable
- * instead of a generic error dump.
+ *   'none'               – config parsed cleanly, no keys removed.
+ *   'stripped_keys'      – pre-Zod section sanitization (gates, external_skills)
+ *                          and/or Zod-targeted key removal dropped some keys;
+ *                          the remaining configuration was preserved.
+ *   'user_only'          – project config was discarded (failed validation and
+ *                          targeted recovery); user config alone was used.
+ *   'guardrails_defaults'– neither merged nor user config was recoverable;
+ *                          fell back to fail-secure guardrails-only defaults.
  */
-function parseConfigWithFallback(
-	mergedRaw: Record<string, unknown>,
-	rawUserConfig: Record<string, unknown> | null,
-	failedResult: z.ZodSafeParseError<unknown>,
-	loadedFromFile: boolean,
-	configHadErrors: boolean,
-): ParseResult {
-	const result = failedResult;
+export type ConfigRecovery =
+	| 'none'
+	| 'stripped_keys'
+	| 'user_only'
+	| 'guardrails_defaults';
 
-	// A config file that existed but failed to LOAD (unreadable/oversized/
-	// malformed JSON) is a stronger fail-secure signal than a typo. When that
-	// happened, any config we recover must still force guardrails ENABLED —
-	// exactly as the success path does — so a user's `guardrails:false` on the
-	// surviving file cannot disable guardrails during a partial-load failure
-	// (issue #1778 H6 review F2). Never a downgrade.
-	const secure = (config: PluginConfig): PluginConfig =>
-		loadedFromFile && configHadErrors
-			? PluginConfigSchema.parse({
-					...(config as Record<string, unknown>),
-					guardrails: { enabled: true },
-				})
-			: config;
-
-	// Attempt targeted recovery: drop only the Zod-confirmed unrecognized keys
-	// and re-parse, so a single typo in one strict section does not discard the
-	// user's entire configuration.
-	const { cleaned, removed } = stripUnrecognizedKeys(mergedRaw, result.error);
-	if (removed.length > 0) {
-		const recovered = PluginConfigSchema.safeParse(cleaned);
-		if (recovered.success) {
-			const warning = `Ignored ${removed.length} unrecognized config key(s): ${removed.join(', ')}. The rest of your configuration was preserved. Fix or remove these keys.`;
-			advisoryWarn(`[opencode-swarm] ${warning}`);
-			return {
-				config: secure(recovered.data),
-				recovery: 'stripped_keys',
-				removedKeys: removed,
-				warnings: [warning],
-			};
-		}
-	}
-
-	// If merged config still fails, try user config alone (a broken project
-	// config should not defeat a valid user config).
-	if (rawUserConfig) {
-		const userSanitized = sanitizeSectionConfigs(rawUserConfig ?? {});
-		const userParseResult = PluginConfigSchema.safeParse(userSanitized);
-		if (userParseResult.success) {
-			const warning =
-				'Project config ignored due to validation errors. Using user config.';
-			advisoryWarn(`[opencode-swarm] ${warning}`);
-			return {
-				config: secure(userParseResult.data),
-				recovery: 'user_only',
-				removedKeys: [],
-				warnings: [warning],
-			};
-		}
-		// Last targeted attempt: strip unrecognized keys from user config too.
-		const userStripped = stripUnrecognizedKeys(
-			userSanitized,
-			userParseResult.error,
-		);
-		if (userStripped.removed.length > 0) {
-			const userRecovered = PluginConfigSchema.safeParse(userStripped.cleaned);
-			if (userRecovered.success) {
-				const warning = `Project config ignored; also ignored ${userStripped.removed.length} unrecognized user-config key(s): ${userStripped.removed.join(', ')}.`;
-				advisoryWarn(`[opencode-swarm] ${warning}`);
-				return {
-					config: secure(userRecovered.data),
-					recovery: 'user_only',
-					removedKeys: userStripped.removed,
-					warnings: [warning],
-				};
-			}
-		}
-	}
-
-	// Neither merged nor user config is recoverable: fail-secure defaults with
-	// guardrails ENABLED. Name the offending keys so the loss is not silent.
-	const offending = stripUnrecognizedKeys(mergedRaw, result.error).removed;
-	const warnings: string[] = [];
-	if (offending.length > 0) {
-		const warning = `Merged config validation failed. Unrecognized key(s): ${offending.join(', ')}.`;
-		advisoryWarn(`[opencode-swarm] ${warning}`);
-		warnings.push(warning);
-	} else {
-		advisoryWarn(
-			'[opencode-swarm] Merged config validation failed:',
-			formatZodIssues(result.error),
-		);
-		warnings.push('Merged config validation failed.');
-	}
-	const securityWarning =
-		'⚠️ SECURITY: Falling back to conservative defaults with guardrails ENABLED. Fix the config file to restore custom configuration.';
-	advisoryWarn(`[opencode-swarm] ${securityWarning}`);
-	warnings.push(securityWarning);
-	return {
-		config: PluginConfigSchema.parse({ guardrails: { enabled: true } }),
-		recovery: 'guardrails_defaults',
-		removedKeys: offending,
-		warnings,
-	};
-}
+/** Full result from the shared config-build core. */
+export type ConfigBuildResult = {
+	config: PluginConfig;
+	recovery: ConfigRecovery;
+	/** Dotted key paths that were removed during recovery (gates, Zod strict, etc.). */
+	removedKeys: string[];
+	/** Human-readable summary messages about the recovery action. */
+	warnings: string[];
+};
 
 /**
- * Load plugin configuration from user and project config files.
- *
- * Config locations:
- * 1. User config: ~/.config/opencode/opencode-swarm.json
- * 2. Project config: <directory>/.opencode/opencode-swarm.json
- *
- * Project config takes precedence. Nested objects are deep-merged.
- * IMPORTANT: Raw configs are merged BEFORE Zod parsing so that
- * Zod defaults don't override explicit user values.
+ * Full result from `loadPluginConfigWithMeta` and `loadPluginConfigWithMetaAsync`.
+ * Extends `ConfigBuildResult` with I/O-layer fields about whether a config
+ * file was found and whether it could be read.
  */
+export type ConfigLoadResult = ConfigBuildResult & {
+	/** True when at least one config file (user or project) existed on disk. */
+	loadedFromFile: boolean;
+	/** True when a config file existed but could not be loaded (corrupt JSON,
+	 *  oversized, permission error). Consumers with fail-closed semantics —
+	 *  e.g. the Full-Auto `locked` activation guard — must treat this as
+	 *  "config unknown", not "config defaults". */
+	configHadErrors: boolean;
+};
+
+function warningForRemovedKeys(removedKeys: readonly string[]): string {
+	return `Ignored ${removedKeys.length} invalid or unrecognized config key(s): ${removedKeys.join(', ')}. The rest of your configuration was preserved. Fix or remove these keys.`;
+}
+
 /** True when a raw (pre-Zod) config object sets `full_auto.locked: true`. */
 function rawFullAutoLocked(raw: Record<string, unknown> | null): boolean {
 	if (!raw || typeof raw !== 'object') return false;
@@ -502,106 +408,236 @@ function rawFullAutoLocked(raw: Record<string, unknown> | null): boolean {
 	return (fullAuto as Record<string, unknown>).locked === true;
 }
 
+/**
+ * Single shared core: merges, migrates, sanitizes, and parses raw user +
+ * project configs, applying `full_auto.locked` OR-semantics and fail-secure
+ * defaults.  All entry points (sync and async) call this function; only the
+ * I/O layer (reading the files) differs between them.
+ *
+ * Recovery order:
+ *   1. Deep-merge → locked-OR → migrate → sanitize → first Zod parse.
+ *   2. On Zod failure: surgically drop only the confirmed unrecognized keys
+ *      and re-parse (issue #1778 H6 — one typo must not wipe the whole config).
+ *   3. If still invalid: retry user-config alone.
+ *   4. Last resort: fail-secure guardrails-only defaults.
+ *
+ * Returns `ConfigBuildResult` so callers that need metadata (e.g.
+ * `loadPluginConfigWithMeta[Async]`) have it without a second file-read.
+ */
+function buildConfigWithMeta(
+	rawUserConfig: Record<string, unknown> | null,
+	rawProjectConfig: Record<string, unknown> | null,
+	loadedFromFile: boolean,
+	configHadErrors: boolean,
+): ConfigBuildResult {
+	// 1. Deep-merge raw objects before Zod parsing so Zod defaults never
+	//    override explicit user values.
+	let mergedRaw: Record<string, unknown> = rawUserConfig ?? {};
+	if (rawProjectConfig) {
+		mergedRaw = deepMergeFn(mergedRaw, rawProjectConfig) as Record<
+			string,
+			unknown
+		>;
+	}
+
+	// 2. `full_auto.locked` is an administrative hard-off: a project-level
+	//    `locked: false` must NOT override a user-level `locked: true`.
+	//    OR across both raw configs before merging so deep-merge cannot
+	//    silently flip it back to false.
+	//    rawFullAutoLocked(raw): returns true when raw?.full_auto?.locked === true.
+	if (rawFullAutoLocked(rawUserConfig) || rawFullAutoLocked(rawProjectConfig)) {
+		const fa =
+			mergedRaw.full_auto &&
+			typeof mergedRaw.full_auto === 'object' &&
+			!Array.isArray(mergedRaw.full_auto)
+				? (mergedRaw.full_auto as Record<string, unknown>)
+				: {};
+		mergedRaw = { ...mergedRaw, full_auto: { ...fa, locked: true } };
+	}
+
+	// 3. Migrate v6.12 presets format to v6.13+ agents format.
+	mergedRaw = migratePresetsConfig(mergedRaw);
+
+	// 4. Pre-validate section-local configs so one invalid section doesn't
+	//    block plugin load.  Track which gates keys were stripped so we can
+	//    report them in the recovery metadata (issue #1900 FR-3).
+	const { result: sanitized, strippedKeys: gatesStripped } =
+		sanitizeSectionConfigs(mergedRaw);
+	mergedRaw = sanitized;
+	const sanitizedWarning =
+		gatesStripped.length > 0 ? warningForRemovedKeys(gatesStripped) : undefined;
+
+	// Fail-secure closure: when a config file existed but could not be loaded,
+	// force guardrails ENABLED on any recovered config (issue #1778 H6 F2).
+	const secure = (cfg: PluginConfig): PluginConfig =>
+		loadedFromFile && configHadErrors
+			? PluginConfigSchema.parse({
+					...(cfg as Record<string, unknown>),
+					guardrails: { enabled: true },
+				})
+			: cfg;
+
+	// 5. First parse attempt.
+	const firstResult = PluginConfigSchema.safeParse(mergedRaw);
+	if (firstResult.success) {
+		const config = secure(firstResult.data);
+		if (loadedFromFile && configHadErrors) {
+			const securityWarning =
+				'⚠️ SECURITY: Falling back to conservative defaults with guardrails ENABLED. Fix the config file to restore custom configuration.';
+			advisoryWarn(`[opencode-swarm] ${securityWarning}`);
+			return {
+				config,
+				recovery: 'guardrails_defaults',
+				removedKeys: [...gatesStripped],
+				warnings: [
+					...(sanitizedWarning ? [sanitizedWarning] : []),
+					securityWarning,
+				],
+			};
+		}
+		if (sanitizedWarning) advisoryWarn(`[opencode-swarm] ${sanitizedWarning}`);
+		return {
+			config,
+			recovery: gatesStripped.length > 0 ? 'stripped_keys' : 'none',
+			removedKeys: [...gatesStripped],
+			warnings: sanitizedWarning ? [sanitizedWarning] : [],
+		};
+	}
+
+	// 6. Targeted recovery: drop only Zod-confirmed unrecognized keys and
+	//    re-parse so a single typo does not discard the user's entire config.
+	const { cleaned, removed } = stripUnrecognizedKeys(
+		mergedRaw,
+		firstResult.error,
+	);
+	if (removed.length > 0) {
+		const recovered = PluginConfigSchema.safeParse(cleaned);
+		if (recovered.success) {
+			const removedKeys = [...gatesStripped, ...removed];
+			const warning = warningForRemovedKeys(removedKeys);
+			advisoryWarn(`[opencode-swarm] ${warning}`);
+			return {
+				config: secure(recovered.data),
+				recovery: 'stripped_keys',
+				removedKeys,
+				warnings: [warning],
+			};
+		}
+	}
+
+	// 7. User-config-alone fallback: a broken project config should not defeat
+	//    a valid user config.
+	if (rawUserConfig) {
+		const { result: userSanitized, strippedKeys: userGatesStripped } =
+			sanitizeSectionConfigs(rawUserConfig);
+		const userParseResult = PluginConfigSchema.safeParse(userSanitized);
+		if (userParseResult.success) {
+			advisoryWarn(
+				'[opencode-swarm] Project config ignored due to validation errors. Using user config.',
+			);
+			return {
+				config: secure(userParseResult.data),
+				recovery: 'user_only',
+				removedKeys: [...gatesStripped, ...userGatesStripped],
+				warnings: [
+					'Project config ignored due to validation errors; using user config.',
+				],
+			};
+		}
+		// Last targeted attempt: strip unrecognized keys from user config too.
+		const userStripped = stripUnrecognizedKeys(
+			userSanitized,
+			userParseResult.error,
+		);
+		if (userStripped.removed.length > 0) {
+			const userRecovered = PluginConfigSchema.safeParse(userStripped.cleaned);
+			if (userRecovered.success) {
+				advisoryWarn(
+					`[opencode-swarm] Project config ignored; also ignored ${userStripped.removed.length} unrecognized user-config key(s): ${userStripped.removed.join(', ')}.`,
+				);
+				return {
+					config: secure(userRecovered.data),
+					recovery: 'user_only',
+					removedKeys: [
+						...gatesStripped,
+						...userGatesStripped,
+						...userStripped.removed,
+					],
+					warnings: [
+						'Project config ignored due to validation errors; using user config.',
+					],
+				};
+			}
+		}
+	}
+
+	// 8. Guardrails defaults: nothing was recoverable.
+	const offending = stripUnrecognizedKeys(mergedRaw, firstResult.error).removed;
+	if (offending.length > 0) {
+		advisoryWarn(
+			`[opencode-swarm] Merged config validation failed. Unrecognized key(s): ${offending.join(', ')}.`,
+		);
+	} else {
+		advisoryWarn(
+			'[opencode-swarm] Merged config validation failed:',
+			formatZodIssues(firstResult.error),
+		);
+	}
+	advisoryWarn(
+		'[opencode-swarm] ⚠️ SECURITY: Falling back to conservative defaults with guardrails ENABLED. Fix the config file to restore custom configuration.',
+	);
+	return {
+		config: PluginConfigSchema.parse({ guardrails: { enabled: true } }),
+		recovery: 'guardrails_defaults',
+		removedKeys: [...gatesStripped],
+		warnings: [
+			'Config failed validation; using safe defaults with guardrails enabled.',
+		],
+	};
+}
+
+/**
+ * Load plugin configuration from user and project config files.
+ *
+ * Config locations:
+ * 1. User config: ~/.config/opencode/opencode-swarm.json
+ * 2. Project config: <directory>/.opencode/opencode-swarm.json
+ *
+ * Project config takes precedence. Nested objects are deep-merged, except
+ * `full_auto.locked`: it is a hard-off and OR-merges across both levels, so
+ * `locked: true` at either level cannot be overridden by `locked: false`.
+ * IMPORTANT: Raw configs are merged BEFORE Zod parsing so that
+ * Zod defaults don't override explicit user values.
+ */
 export function loadPluginConfig(directory: string): PluginConfig {
 	const userConfigPath = path.join(
 		getUserConfigDir(),
 		'opencode',
 		CONFIG_FILENAME,
 	);
-
 	const projectConfigPath = path.join(directory, '.opencode', CONFIG_FILENAME);
-
-	// Load raw configs (no Zod defaults applied yet)
 	const userResult = loadRawConfigFromPath(userConfigPath);
 	const projectResult = loadRawConfigFromPath(projectConfigPath);
-
-	const rawUserConfig = userResult.config;
-	const rawProjectConfig = projectResult.config;
-
-	// Track whether any config files existed AND whether there were load errors
-	// Use fileExisted to track if files existed (regardless of whether they loaded successfully)
 	const loadedFromFile = userResult.fileExisted || projectResult.fileExisted;
 	const configHadErrors = userResult.hadError || projectResult.hadError;
-
-	// Deep-merge raw objects before Zod parsing so that
-	// Zod defaults don't override explicit user values
-	let mergedRaw: Record<string, unknown> = rawUserConfig ?? {};
-	if (rawProjectConfig) {
-		mergedRaw = deepMergeFn(mergedRaw, rawProjectConfig) as Record<
-			string,
-			unknown
-		>;
-	}
-
-	// `full_auto.locked` is an administrative hard-off and must OR across
-	// config levels: a project-level `locked: false` must NOT override a
-	// user-level `locked: true` (deep-merge alone would let a repo-controlled
-	// .opencode/opencode-swarm.json defeat the user's lock).
-	if (rawFullAutoLocked(rawUserConfig) || rawFullAutoLocked(rawProjectConfig)) {
-		const fullAutoRaw =
-			mergedRaw.full_auto &&
-			typeof mergedRaw.full_auto === 'object' &&
-			!Array.isArray(mergedRaw.full_auto)
-				? (mergedRaw.full_auto as Record<string, unknown>)
-				: {};
-		mergedRaw = {
-			...mergedRaw,
-			full_auto: { ...fullAutoRaw, locked: true },
-		};
-	}
-
-	// Migrate v6.12 presets format to v6.13+ agents format
-	mergedRaw = migratePresetsConfig(mergedRaw);
-
-	// Pre-validate section-local configs so one invalid section doesn't block plugin load.
-	mergedRaw = sanitizeSectionConfigs(mergedRaw);
-
-	// Validate merged config with Zod (applies defaults ONCE). Nested optional
-	// schemas (e.g. council.general) surface automatically here.
-	const result = PluginConfigSchema.safeParse(mergedRaw);
-	if (result.success) {
-		// If config files existed but had load errors, apply fail-secure defaults
-		if (loadedFromFile && configHadErrors) {
-			return PluginConfigSchema.parse({
-				...mergedRaw,
-				guardrails: { enabled: true },
-			});
-		}
-		return result.data;
-	}
-
-	// A typo in any strict section triggers targeted recovery instead of a
-	// whole-config wipe (issue #1778 H6) via the centralized helper shared with
-	// the async path. parseConfigWithFallback fully subsumes the user-config-
-	// alone retry and advisoryWarn-based fail-secure fallback that used to be
-	// inlined here (merged from origin/main).
-	const { config } = parseConfigWithFallback(
-		mergedRaw,
-		rawUserConfig,
-		result,
+	// Delegate all merge→locked-OR→migrate→sanitize→parse→fallback logic to
+	// the shared core so this path can never diverge from the async path.
+	return buildConfigWithMeta(
+		userResult.config,
+		projectResult.config,
 		loadedFromFile,
 		configHadErrors,
-	);
-	return config;
+	).config;
 }
 
 /**
- * Internal variant of loadPluginConfig that also returns loader metadata.
- * Used only by src/index.ts to determine guardrails fallback behavior.
- * NOT part of the public API — use loadPluginConfig() for all other callers.
+ * Variant of `loadPluginConfig` that also returns loader metadata, including
+ * recovery classification, removed keys, and warning messages.  All callers
+ * that need to surface config-health information (doctor, command-return) use
+ * this function.  `buildConfigWithMeta` is the shared core — files are read
+ * exactly once, no double-read.
  */
-export function loadPluginConfigWithMeta(directory: string): {
-	config: PluginConfig;
-	loadedFromFile: boolean;
-	/** True when a config file existed but could not be loaded (corrupt JSON,
-	 *  oversized, permission error). Consumers with fail-closed semantics —
-	 *  e.g. the Full-Auto `locked` activation guard — must treat this as
-	 *  "config unknown", not "config defaults". */
-	configHadErrors: boolean;
-	recovery: RecoveryType;
-	removedKeys: string[];
-	warnings: string[];
-} {
+export function loadPluginConfigWithMeta(directory: string): ConfigLoadResult {
 	const userConfigPath = path.join(
 		getUserConfigDir(),
 		'opencode',
@@ -610,73 +646,11 @@ export function loadPluginConfigWithMeta(directory: string): {
 	const projectConfigPath = path.join(directory, '.opencode', CONFIG_FILENAME);
 	const userResult = loadRawConfigFromPath(userConfigPath);
 	const projectResult = loadRawConfigFromPath(projectConfigPath);
-
-	const rawUserConfig = userResult.config;
-	const rawProjectConfig = projectResult.config;
-
-	// Use fileExisted to track if files existed (regardless of load success)
 	const loadedFromFile = userResult.fileExisted || projectResult.fileExisted;
 	const configHadErrors = userResult.hadError || projectResult.hadError;
-
-	// Deep-merge raw objects before Zod parsing (same as loadPluginConfig)
-	let mergedRaw: Record<string, unknown> = rawUserConfig ?? {};
-	if (rawProjectConfig) {
-		mergedRaw = deepMergeFn(mergedRaw, rawProjectConfig) as Record<
-			string,
-			unknown
-		>;
-	}
-
-	// Handle full_auto.locked ORing (same as loadPluginConfig)
-	if (rawFullAutoLocked(rawUserConfig) || rawFullAutoLocked(rawProjectConfig)) {
-		const fullAutoRaw =
-			mergedRaw.full_auto &&
-			typeof mergedRaw.full_auto === 'object' &&
-			!Array.isArray(mergedRaw.full_auto)
-				? (mergedRaw.full_auto as Record<string, unknown>)
-				: {};
-		mergedRaw = {
-			...mergedRaw,
-			full_auto: { ...fullAutoRaw, locked: true },
-		};
-	}
-
-	mergedRaw = migratePresetsConfig(mergedRaw);
-	mergedRaw = sanitizeSectionConfigs(mergedRaw);
-
-	const result = PluginConfigSchema.safeParse(mergedRaw);
-	if (result.success) {
-		// If config files existed but had load errors, apply fail-secure defaults
-		if (loadedFromFile && configHadErrors) {
-			const config = PluginConfigSchema.parse({
-				...mergedRaw,
-				guardrails: { enabled: true },
-			});
-			return {
-				config,
-				loadedFromFile,
-				configHadErrors,
-				recovery: 'guardrails_defaults',
-				removedKeys: [],
-				warnings: [
-					'⚠️ SECURITY: Falling back to conservative defaults with guardrails ENABLED. Fix the config file to restore custom configuration.',
-				],
-			};
-		}
-		return {
-			config: result.data,
-			loadedFromFile,
-			configHadErrors,
-			recovery: 'none',
-			removedKeys: [],
-			warnings: [],
-		};
-	}
-
-	const { config, recovery, removedKeys, warnings } = parseConfigWithFallback(
-		mergedRaw,
-		rawUserConfig,
-		result,
+	const { config, recovery, removedKeys, warnings } = buildConfigWithMeta(
+		userResult.config,
+		projectResult.config,
 		loadedFromFile,
 		configHadErrors,
 	);
@@ -758,70 +732,15 @@ async function loadRawConfigFromPathAsync(configPath: string): Promise<{
 	}
 }
 
-function reduceParsedConfig(
-	rawUserConfig: Record<string, unknown> | null,
-	rawProjectConfig: Record<string, unknown> | null,
-	loadedFromFile: boolean,
-	configHadErrors: boolean,
-): ParseResult {
-	let mergedRaw: Record<string, unknown> = rawUserConfig ?? {};
-	if (rawProjectConfig) {
-		mergedRaw = deepMergeFn(mergedRaw, rawProjectConfig) as Record<
-			string,
-			unknown
-		>;
-	}
-	mergedRaw = migratePresetsConfig(mergedRaw);
-	mergedRaw = sanitizeSectionConfigs(mergedRaw);
-	const result = PluginConfigSchema.safeParse(mergedRaw);
-	if (result.success) {
-		if (loadedFromFile && configHadErrors) {
-			return {
-				config: PluginConfigSchema.parse({
-					...mergedRaw,
-					guardrails: { enabled: true },
-				}),
-				recovery: 'guardrails_defaults',
-				removedKeys: [],
-				warnings: [
-					'⚠️ SECURITY: Falling back to conservative defaults with guardrails ENABLED. Fix the config file to restore custom configuration.',
-				],
-			};
-		}
-		return {
-			config: result.data,
-			recovery: 'none',
-			removedKeys: [],
-			warnings: [],
-		};
-	}
-	// Targeted section recovery instead of whole-config wipe (issue #1778 H6),
-	// shared with the sync path so the two can never diverge. parseConfigWithFallback
-	// fully subsumes the user-config-alone retry and advisoryWarn-based
-	// fail-secure fallback that used to be inlined here (merged from origin/main).
-	return parseConfigWithFallback(
-		mergedRaw,
-		rawUserConfig,
-		result,
-		loadedFromFile,
-		configHadErrors,
-	);
-}
-
 /**
  * Async variant of `loadPluginConfigWithMeta`. Used by the plugin entry
  * (issue #704) so initialization does not perform synchronous fs reads.
+ * Calls the same `buildConfigWithMeta` shared core as the sync path — the
+ * only difference is that file I/O uses `node:fs/promises` (issue #1900 FR-1).
  */
 export async function loadPluginConfigWithMetaAsync(
 	directory: string,
-): Promise<{
-	config: PluginConfig;
-	loadedFromFile: boolean;
-	configHadErrors: boolean;
-	recovery: RecoveryType;
-	removedKeys: string[];
-	warnings: string[];
-}> {
+): Promise<ConfigLoadResult> {
 	const userConfigPath = path.join(
 		getUserConfigDir(),
 		'opencode',
@@ -834,7 +753,7 @@ export async function loadPluginConfigWithMetaAsync(
 	]);
 	const loadedFromFile = userResult.fileExisted || projectResult.fileExisted;
 	const configHadErrors = userResult.hadError || projectResult.hadError;
-	const { config, recovery, removedKeys, warnings } = reduceParsedConfig(
+	const { config, recovery, removedKeys, warnings } = buildConfigWithMeta(
 		userResult.config,
 		projectResult.config,
 		loadedFromFile,

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -36,12 +36,14 @@ import {
 	canonicalWorkspaceIdentity,
 	claimScopeBindingForChild,
 	clearScopeBindings,
+	createPrFeedbackScopeBinding,
 	createScopeBinding,
 	deriveChildScopeBinding,
 	getScopeBinding,
 	MAX_PENDING_SCOPE_BINDINGS,
 	registerScopeBinding,
 	resolveCoderScopeSources,
+	type ScopeBinding,
 } from '../scope/scope-binding';
 import {
 	clearScopeBindingFromDisk,
@@ -80,6 +82,7 @@ import {
 	standardWorktreeByCallID,
 	standardWorktreeSerializationSessions,
 } from './delegation-gate/worktree-isolation';
+import { consumePrFeedbackScopeDeclaration } from './pr-workflow-gate.js';
 export { resetStandardWorktreeIsolationState };
 
 import { COUNCIL_VERDICT_REWARDS } from '../memory/config';
@@ -203,10 +206,10 @@ export function clearPendingCoderScope(): void {
 }
 
 interface PreparedCoderScope {
-	plan: Plan;
+	plan: Plan | null;
 	taskId: string;
 	declaredFiles: string[] | null;
-	binding: NonNullable<ReturnType<typeof createScopeBinding>>;
+	binding: ScopeBinding;
 }
 
 async function prepareCoderScope(
@@ -215,6 +218,62 @@ async function prepareCoderScope(
 	args: Record<string, unknown>,
 ): Promise<PreparedCoderScope> {
 	const plan = await loadPlanJsonOnly(directory);
+	if (!plan) {
+		const rawTaskId =
+			typeof args.task_id === 'string'
+				? args.task_id.trim()
+				: typeof args.taskId === 'string'
+					? args.taskId.trim()
+					: '';
+		if (isStrictTaskId(rawTaskId)) {
+			const feedbackScope = await consumePrFeedbackScopeDeclaration(
+				directory,
+				input.sessionID,
+				rawTaskId,
+				input.callID,
+			);
+			if (feedbackScope) {
+				const directives = extractTaskFileDirectives(args);
+				if (directives.present && !directives.files) {
+					throw new Error(
+						'SCOPE_NOT_DECLARED: FILE: directives are present but empty or ambiguous; provide one complete relative path per FILE: line.',
+					);
+				}
+				const resolved = resolveCoderScopeSources({
+					explicitFiles: feedbackScope.files,
+					planFiles: null,
+					fileDirectiveFiles: directives.files,
+				});
+				if (!resolved.ok) {
+					throw new Error(
+						`${resolved.code}: PR-feedback coder scope conflicts with the verified controller declaration.`,
+					);
+				}
+				const binding = createPrFeedbackScopeBinding({
+					directory,
+					taskId: rawTaskId,
+					files: resolved.files,
+					ownerSessionId: input.sessionID,
+					ownerMessageId: input.callID,
+					dispatchCallId: input.callID,
+					activation: 'pending_child',
+					workflowSessionId: input.sessionID,
+					workflowRevisionDigest: feedbackScope.revisionDigest,
+				});
+				if (!binding) {
+					throw new Error(
+						'SCOPE_NOT_DECLARED: PR-feedback scope could not be bound to this Task invocation.',
+					);
+				}
+				return {
+					plan: null,
+					taskId: rawTaskId,
+					declaredFiles: resolved.files,
+					binding,
+				};
+			}
+		}
+	}
 	const planTaskIds = plan
 		? new Set(
 				plan.phases.flatMap((phase) => phase.tasks.map((task) => task.id)),
@@ -2235,6 +2294,11 @@ export function createDelegationGateHook(
 		// gates. It creates a staged binding but does not publish authorization.
 		const preparedScope = await prepareCoderScope(directory, input, args);
 		const { plan, taskId: incomingCoderTaskId } = preparedScope;
+		if (!plan) {
+			rememberCoderTaskChangeContext(input.callID, preparedScope.declaredFiles);
+			await publishScopeBinding(input.callID, directory, preparedScope.binding);
+			return;
+		}
 		const profile = plan?.execution_profile;
 		const parallelEnabled = profile?.parallelization_enabled === true;
 		const maxConcurrent = profile?.max_concurrent_tasks ?? 10;
@@ -2347,10 +2411,6 @@ export function createDelegationGateHook(
 			}
 		}
 
-		if (!plan) {
-			clearCoderTaskChangeContext(input.callID);
-			return;
-		}
 		if (!parallelModeActive) {
 			rememberCoderTaskChangeContext(input.callID, incomingCoderDeclaredFiles);
 			await publishScopeBinding(input.callID, directory, correlatedBinding);

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -22,6 +22,7 @@ import {
 } from '../background/workspace-snapshot.js';
 import { WRITE_TOOL_NAMES } from '../config/constants.js';
 import { resolveGeneratedAgentRole } from '../config/schema.js';
+import { getPrWorkflowToolCapability } from '../tools/tool-metadata.js';
 import { validateSwarmPath } from './utils.js';
 
 export const PR_REVIEW_BASE_DIMENSION_IDS = [
@@ -141,6 +142,18 @@ interface PrFeedbackReadyToPublishRecord {
 export type PrWorkflowCompletionStatus = 'completed' | 'ready-to-publish';
 
 export type PrReviewValidationPhase = 'council' | 'reviewer' | 'critic';
+export type PrReviewArtifactBoundary =
+	| 'post_explorer'
+	| 'post_reviewer'
+	| 'post_critic';
+
+interface PrFeedbackScopeDeclarationRecord {
+	taskId: string;
+	files: string[];
+	revisionDigest: string;
+	declaredAt: string;
+	consumedByCallId?: string;
+}
 
 interface PrReviewValidationBatchRecord {
 	batchId: string;
@@ -169,6 +182,11 @@ export interface PrWorkflowGateState {
 	prReviewBaseDispatch?: PrReviewBaseDispatchRecord;
 	prReviewTriggerEvalPath?: string;
 	prReviewValidationBatches?: PrReviewValidationBatchRecord[];
+	prReviewArtifactRunId?: string;
+	prReviewFindingsPath?: string;
+	prReviewArtifactBoundaries?: PrReviewArtifactBoundary[];
+	prReviewHandoffPath?: string;
+	prReviewHandoffRequired?: boolean;
 	prFeedbackInventory?: string[];
 	prFeedbackVerifications?: PrFeedbackVerificationRecord[];
 	/** @deprecated Compatibility projection of the most recent verification dispatch. */
@@ -176,6 +194,7 @@ export interface PrWorkflowGateState {
 	prFeedbackStageA?: PrFeedbackStageARecord;
 	prFeedbackGateBatches?: PrFeedbackGateBatchRecord[];
 	prFeedbackReadyToPublish?: PrFeedbackReadyToPublishRecord;
+	prFeedbackScopes?: PrFeedbackScopeDeclarationRecord[];
 }
 
 interface SessionStateMutationLock {
@@ -346,6 +365,16 @@ const PrReviewValidationBatchRecordSchema = z
 	})
 	.strict();
 
+const PrFeedbackScopeDeclarationRecordSchema = z
+	.object({
+		taskId: z.string().regex(/^\d+\.\d+(?:\.\d+)*$/),
+		files: z.array(z.string().min(1)).min(1).max(10_000),
+		revisionDigest: z.string().min(1),
+		declaredAt: z.string().min(1),
+		consumedByCallId: z.string().min(1).optional(),
+	})
+	.strict();
+
 const PrWorkflowGateStateSchema = z
 	.object({
 		schemaVersion: z.literal(GATE_SCHEMA_VERSION),
@@ -367,6 +396,14 @@ const PrWorkflowGateStateSchema = z
 			.array(PrReviewValidationBatchRecordSchema)
 			.max(MAX_WORKFLOW_BATCHES)
 			.optional(),
+		prReviewArtifactRunId: z.string().min(1).optional(),
+		prReviewFindingsPath: z.string().min(1).optional(),
+		prReviewArtifactBoundaries: z
+			.array(z.enum(['post_explorer', 'post_reviewer', 'post_critic']))
+			.max(3)
+			.optional(),
+		prReviewHandoffPath: z.string().min(1).optional(),
+		prReviewHandoffRequired: z.boolean().optional(),
 		prFeedbackInventory: z.array(z.string().min(1)).min(1).optional(),
 		prFeedbackVerifications: z
 			.array(PrFeedbackVerificationRecordSchema)
@@ -379,6 +416,10 @@ const PrWorkflowGateStateSchema = z
 			.max(MAX_WORKFLOW_BATCHES)
 			.optional(),
 		prFeedbackReadyToPublish: PrFeedbackReadyToPublishRecordSchema.optional(),
+		prFeedbackScopes: z
+			.array(PrFeedbackScopeDeclarationRecordSchema)
+			.max(MAX_WORKFLOW_BATCHES)
+			.optional(),
 	})
 	.strict();
 
@@ -1588,6 +1629,215 @@ export async function markPrReviewTriggerEvaluationComplete(
 	return nextState;
 }
 
+export async function assertPrReviewArtifactBoundary(
+	directory: string,
+	sessionID: string,
+	runId: string,
+	boundary: PrReviewArtifactBoundary,
+	findingIds: string[],
+): Promise<PrWorkflowGateState> {
+	let state = await requireBoundState(directory, sessionID, 'PR_REVIEW');
+	if (!state.prReviewTriggerEvalPath) {
+		throw new Error(
+			'BLOCKED: PR_REVIEW findings persistence requires the trigger evaluation artifact',
+		);
+	}
+	if (boundary === 'post_reviewer') {
+		state = await assertPrReviewValidationSettled(
+			directory,
+			sessionID,
+			'reviewer',
+		);
+	} else if (boundary === 'post_critic') {
+		await assertPrReviewValidationSettled(directory, sessionID, 'reviewer');
+		if (derivePrReviewCriticInventory(directory, state).length > 0) {
+			state = await assertPrReviewValidationSettled(
+				directory,
+				sessionID,
+				'critic',
+			);
+		}
+	}
+	if (state.prReviewArtifactRunId && state.prReviewArtifactRunId !== runId) {
+		throw new Error(
+			`BLOCKED: PR_REVIEW artifacts are already bound to run "${state.prReviewArtifactRunId}"`,
+		);
+	}
+	const expectedFindingIds = derivePrReviewCandidateInventory(directory, state);
+	const normalizedFindingIds = [...new Set(findingIds)].sort();
+	if (
+		normalizedFindingIds.length !== findingIds.length ||
+		JSON.stringify(normalizedFindingIds) !==
+			JSON.stringify([...expectedFindingIds].sort())
+	) {
+		throw new Error(
+			`BLOCKED: PR_REVIEW ${boundary} findings must exactly cover the discovered candidate inventory`,
+		);
+	}
+	return state;
+}
+
+export async function markPrReviewArtifactBoundary(
+	directory: string,
+	sessionID: string,
+	runId: string,
+	boundary: PrReviewArtifactBoundary,
+	artifactPath: string,
+	findingIds: string[],
+	handoffRequired: boolean,
+): Promise<PrWorkflowGateState> {
+	const state = await assertPrReviewArtifactBoundary(
+		directory,
+		sessionID,
+		runId,
+		boundary,
+		findingIds,
+	);
+	const boundaries = new Set(state.prReviewArtifactBoundaries ?? []);
+	boundaries.add(boundary);
+	const nextState: PrWorkflowGateState = {
+		...state,
+		updatedAt: isoNow(),
+		prReviewArtifactRunId: runId,
+		prReviewFindingsPath: artifactPath,
+		prReviewArtifactBoundaries: [...boundaries],
+		prReviewHandoffRequired: handoffRequired,
+	};
+	await persistState(directory, nextState);
+	return nextState;
+}
+
+export async function markPrReviewHandoffComplete(
+	directory: string,
+	sessionID: string,
+	runId: string,
+	artifactPath: string,
+): Promise<PrWorkflowGateState> {
+	const state = await requireBoundState(directory, sessionID, 'PR_REVIEW');
+	if (
+		state.prReviewArtifactRunId !== runId ||
+		!(state.prReviewArtifactBoundaries ?? []).includes('post_critic')
+	) {
+		throw new Error(
+			'BLOCKED: PR_REVIEW handoff requires the final findings boundary for the same run',
+		);
+	}
+	const nextState: PrWorkflowGateState = {
+		...state,
+		updatedAt: isoNow(),
+		prReviewHandoffPath: artifactPath,
+	};
+	await persistState(directory, nextState);
+	return nextState;
+}
+
+export async function declarePrFeedbackScope(
+	directory: string,
+	sessionID: string,
+	taskId: string,
+	files: string[],
+): Promise<PrWorkflowGateState> {
+	const state = await assertPrFeedbackVerificationSettled(directory, sessionID);
+	const revisionDigest = await currentPrFeedbackRevisionDigest(
+		directory,
+		state,
+	);
+	const previous = state.prFeedbackScopes ?? [];
+	const existing = previous.find((entry) => entry.taskId === taskId);
+	if (existing?.consumedByCallId) {
+		throw new Error(
+			`SCOPE_NOT_DECLARED: PR-feedback scope ${taskId} was already consumed; use a fresh task_id for any retry`,
+		);
+	}
+	const record: PrFeedbackScopeDeclarationRecord = {
+		taskId,
+		files,
+		revisionDigest,
+		declaredAt: isoNow(),
+	};
+	const nextState: PrWorkflowGateState = {
+		...state,
+		updatedAt: isoNow(),
+		prFeedbackScopes: [
+			...previous.filter((entry) => entry.taskId !== taskId),
+			record,
+		],
+	};
+	await persistState(directory, nextState);
+	return nextState;
+}
+
+export async function resolvePrFeedbackScopeDeclaration(
+	directory: string,
+	sessionID: string,
+	taskId: string,
+): Promise<PrFeedbackScopeDeclarationRecord | null> {
+	const state = await readPrWorkflowGateState(directory, sessionID);
+	if (state?.mode !== 'PR_FEEDBACK') return null;
+	const declaration = (state.prFeedbackScopes ?? []).find(
+		(entry) => entry.taskId === taskId,
+	);
+	if (!declaration) return null;
+	await assertPrFeedbackVerificationSettled(directory, sessionID);
+	const currentDigest = await currentPrFeedbackRevisionDigest(directory, state);
+	return currentDigest === declaration.revisionDigest ? declaration : null;
+}
+
+export async function consumePrFeedbackScopeDeclaration(
+	directory: string,
+	sessionID: string,
+	taskId: string,
+	callID: string,
+): Promise<PrFeedbackScopeDeclarationRecord | null> {
+	const declaration = await resolvePrFeedbackScopeDeclaration(
+		directory,
+		sessionID,
+		taskId,
+	);
+	if (!declaration) return null;
+	if (declaration.consumedByCallId && declaration.consumedByCallId !== callID) {
+		throw new Error(
+			`SCOPE_NOT_DECLARED: PR-feedback scope ${taskId} was already consumed by another Task call`,
+		);
+	}
+	if (declaration.consumedByCallId === callID) return declaration;
+	const state = await requireBoundState(directory, sessionID, 'PR_FEEDBACK');
+	const nextState: PrWorkflowGateState = {
+		...state,
+		updatedAt: isoNow(),
+		prFeedbackScopes: (state.prFeedbackScopes ?? []).map((entry) =>
+			entry.taskId === taskId ? { ...entry, consumedByCallId: callID } : entry,
+		),
+	};
+	await persistState(directory, nextState);
+	return { ...declaration, consumedByCallId: callID };
+}
+
+export async function validatePrFeedbackScopeBinding(
+	directory: string,
+	binding: {
+		taskId: string;
+		files: string[];
+		dispatchCallId?: string;
+		workflowSessionId?: string;
+		workflowRevisionDigest?: string;
+	},
+): Promise<boolean> {
+	if (!binding.workflowSessionId || !binding.workflowRevisionDigest)
+		return false;
+	const declaration = await resolvePrFeedbackScopeDeclaration(
+		directory,
+		binding.workflowSessionId,
+		binding.taskId,
+	);
+	return Boolean(
+		declaration &&
+			declaration.consumedByCallId === binding.dispatchCallId &&
+			declaration.revisionDigest === binding.workflowRevisionDigest &&
+			JSON.stringify(declaration.files) === JSON.stringify(binding.files),
+	);
+}
+
 export async function enforcePrWorkflowToolBefore(
 	directory: string,
 	sessionID: string,
@@ -1616,8 +1866,10 @@ export async function enforcePrWorkflowToolBefore(
 	const referencesProtectedWorkflowEvidence = containsProtectedWorkflowPath(
 		command || serializedArgs,
 	);
-	const isInternalWorkflowTool =
-		PR_WORKFLOW_CONTROLLER_TOOLS.has(normalizedTool);
+	const isInternalWorkflowTool = isPrWorkflowControllerTool(
+		state.mode,
+		normalizedTool,
+	);
 	const isShellTool = normalizedTool === 'bash' || normalizedTool === 'shell';
 	const isReadOnlyShell =
 		isShellTool &&
@@ -1625,10 +1877,19 @@ export async function enforcePrWorkflowToolBefore(
 		isAllowedPrWorkflowReadOnlyShell(command, {
 			allowCheckout: !state.prHeadSha,
 			allowFetch: !state.prHeadSha,
+			allowTrackingFetch: Boolean(state.prHeadSha),
 		});
+	const trustedCapability = getPrWorkflowToolCapability(
+		normalizedTool,
+		state.mode,
+	);
+	const isTrustedWorkflowTool =
+		trustedCapability !== null &&
+		isTrustedPrWorkflowToolInvocationSafe(normalizedTool, args ?? {});
 	const isNamedReadOnlyTool =
-		isAllowedPrReviewReadOnlyToolName(normalizedTool) &&
-		readOnlyToolArgumentsAreSafe(args ?? {});
+		isTrustedWorkflowTool ||
+		(isAllowedPrReviewReadOnlyToolName(normalizedTool) &&
+			readOnlyToolArgumentsAreSafe(args ?? {}));
 	if (
 		referencesProtectedWorkflowEvidence &&
 		!isInternalWorkflowTool &&
@@ -1747,6 +2008,7 @@ export async function enforcePrWorkflowToolBefore(
 			isAllowedPrWorkflowReadOnlyShell(command, {
 				allowCheckout: false,
 				allowFetch: false,
+				allowTrackingFetch: false,
 			})
 		)
 			return;
@@ -1783,7 +2045,8 @@ export async function enforcePrWorkflowToolBefore(
 		!isDirectWrite &&
 		!isShellCommandRequiringVerification &&
 		!isRemoteMutationTool &&
-		!isCoderTask
+		!isCoderTask &&
+		normalizedTool !== 'prepare_pr_feedback_scope'
 	)
 		return;
 	// abort_pr_workflow is a pure escape hatch, not a publication-adjacent
@@ -1849,6 +2112,25 @@ export async function completePrWorkflow(
 				);
 			}
 			await assertPrReviewValidationSettled(directory, sessionID, 'critic');
+		}
+		const requiredArtifactBoundaries: PrReviewArtifactBoundary[] = [
+			'post_explorer',
+			'post_reviewer',
+			'post_critic',
+		];
+		const persistedBoundaries = new Set(state.prReviewArtifactBoundaries ?? []);
+		const missingArtifactBoundaries = requiredArtifactBoundaries.filter(
+			(boundary) => !persistedBoundaries.has(boundary),
+		);
+		if (!state.prReviewFindingsPath || missingArtifactBoundaries.length > 0) {
+			throw new Error(
+				`BLOCKED: PR_REVIEW completion requires durable findings checkpoints; missing: ${missingArtifactBoundaries.join(', ') || 'findings path'}`,
+			);
+		}
+		if (state.prReviewHandoffRequired && !state.prReviewHandoffPath) {
+			throw new Error(
+				'BLOCKED: PR_REVIEW actionable findings require a persisted feedback handoff artifact',
+			);
 		}
 	} else {
 		const readyState = await assertPrFeedbackReadyToPublish(
@@ -2116,16 +2398,35 @@ function containsProtectedWorkflowPath(value: string): boolean {
 	);
 }
 
-const PR_WORKFLOW_CONTROLLER_TOOLS = new Set([
+const PR_WORKFLOW_SHARED_CONTROLLER_TOOLS = new Set([
 	'abort_pr_workflow',
 	'collect_lane_results',
 	'complete_pr_workflow',
 	'dispatch_lanes_async',
 	'get_async_result',
 	'get_async_status',
-	'run_pr_feedback_stage_a',
+]);
+
+const PR_REVIEW_CONTROLLER_TOOLS = new Set([
+	'parse_lane_candidates',
+	'write_pr_review_artifact',
 	'write_pr_review_trigger_eval',
 ]);
+
+const PR_FEEDBACK_CONTROLLER_TOOLS = new Set([
+	'prepare_pr_feedback_scope',
+	'run_pr_feedback_stage_a',
+]);
+
+function isPrWorkflowControllerTool(
+	mode: PrWorkflowMode,
+	toolName: string,
+): boolean {
+	if (PR_WORKFLOW_SHARED_CONTROLLER_TOOLS.has(toolName)) return true;
+	return mode === 'PR_REVIEW'
+		? PR_REVIEW_CONTROLLER_TOOLS.has(toolName)
+		: PR_FEEDBACK_CONTROLLER_TOOLS.has(toolName);
+}
 
 const PR_REVIEW_READ_ONLY_TOOL_NAMES = new Set([
 	'ast_grep_search',
@@ -2136,11 +2437,21 @@ const PR_REVIEW_READ_ONLY_TOOL_NAMES = new Set([
 	'open',
 	'read',
 	'search',
+	'skill',
 	'tree',
 	'view',
 	'webfetch',
 	'websearch',
 ]);
+
+function isTrustedPrWorkflowToolInvocationSafe(
+	toolName: string,
+	args: Record<string, unknown>,
+): boolean {
+	if (toolName === 'lint') return args.mode === 'check';
+	if (toolName === 'sast_scan') return args.capture_baseline !== true;
+	return true;
+}
 
 /**
  * Positive classifier for non-shell tools usable during PR_REVIEW.
@@ -2243,7 +2554,11 @@ function readOnlyToolArgumentsAreSafe(
 
 function isAllowedPrWorkflowReadOnlyShell(
 	command: string,
-	options: { allowCheckout: boolean; allowFetch: boolean },
+	options: {
+		allowCheckout: boolean;
+		allowFetch: boolean;
+		allowTrackingFetch: boolean;
+	},
 ): boolean {
 	const normalized = command.trim().replace(/\s+/g, ' ');
 	if (!normalized) return false;
@@ -2322,7 +2637,11 @@ function isSafeExactBoundPush(
 
 function isAllowedPrWorkflowGitIntake(
 	gitArgs: string,
-	options: { allowCheckout: boolean; allowFetch: boolean },
+	options: {
+		allowCheckout: boolean;
+		allowFetch: boolean;
+		allowTrackingFetch: boolean;
+	},
 ): boolean {
 	if (
 		/(?:--ext-diff|--textconv|--open-files-in-pager|--output(?:=|\s)|--upload-pack(?:=|\s)|--exec(?:=|\s))/i.test(
@@ -2339,6 +2658,8 @@ function isAllowedPrWorkflowGitIntake(
 		return true;
 
 	if (options.allowFetch && /^fetch(?:\s|$)/i.test(gitArgs)) return true;
+	if (options.allowTrackingFetch && isAllowedBoundRemoteTrackingFetch(gitArgs))
+		return true;
 
 	if (/^remote(?:\s+-v)?$/i.test(gitArgs)) return true;
 
@@ -2357,6 +2678,19 @@ function isAllowedPrWorkflowGitIntake(
 	// authorize a key/value write.
 	return /^config\s+(?:(?:--show-origin|--show-scope|--global|--local|--system|--worktree)\s+)*(?:--list|--get(?:-all)?\s+\S+)$/i.test(
 		gitArgs,
+	);
+}
+
+function isAllowedBoundRemoteTrackingFetch(gitArgs: string): boolean {
+	const tokens = gitArgs.trim().split(/\s+/);
+	if (tokens.length !== 3 || tokens[0].toLowerCase() !== 'fetch') return false;
+	const [, remote, remoteBranch] = tokens;
+	return (
+		isSafeGitRefToken(remote) &&
+		!remote.includes('/') &&
+		isSafeGitRefToken(remoteBranch) &&
+		!remoteBranch.startsWith('-') &&
+		!remoteBranch.includes(':')
 	);
 }
 

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -147,6 +147,18 @@ export type PrReviewArtifactBoundary =
 	| 'post_reviewer'
 	| 'post_critic';
 
+type PrReviewArtifactRecord = {
+	finding_id: string;
+	status: 'PENDING' | 'CONFIRMED' | 'DISPROVED' | 'PRE_EXISTING';
+	next_action:
+		| 'route_to_reviewer'
+		| 'route_to_critic'
+		| 'report'
+		| 'suppress_with_reason'
+		| 'handoff_to_feedback';
+	severity?: 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW';
+};
+
 interface PrFeedbackScopeDeclarationRecord {
 	taskId: string;
 	files: string[];
@@ -1642,6 +1654,31 @@ export async function assertPrReviewArtifactBoundary(
 			'BLOCKED: PR_REVIEW findings persistence requires the trigger evaluation artifact',
 		);
 	}
+	const persistedBoundaries = state.prReviewArtifactBoundaries ?? [];
+	const boundaryOrder: readonly PrReviewArtifactBoundary[] = [
+		'post_explorer',
+		'post_reviewer',
+		'post_critic',
+	];
+	const boundaryIndex = boundaryOrder.indexOf(boundary);
+	const requiredPriorBoundary = boundaryOrder[boundaryIndex - 1];
+	if (
+		requiredPriorBoundary &&
+		!persistedBoundaries.includes(requiredPriorBoundary)
+	) {
+		throw new Error(
+			`BLOCKED: PR_REVIEW ${boundary} findings require the prior ${requiredPriorBoundary} checkpoint`,
+		);
+	}
+	if (
+		persistedBoundaries.some(
+			(persisted) => boundaryOrder.indexOf(persisted) > boundaryIndex,
+		)
+	) {
+		throw new Error(
+			`BLOCKED: PR_REVIEW ${boundary} findings cannot be persisted after a later checkpoint`,
+		);
+	}
 	if (boundary === 'post_reviewer') {
 		state = await assertPrReviewValidationSettled(
 			directory,
@@ -1675,6 +1712,135 @@ export async function assertPrReviewArtifactBoundary(
 		);
 	}
 	return state;
+}
+
+/**
+ * Artifact records are a projection of lane receipts, never a caller-controlled
+ * replacement for them. Keep their workflow status/action aligned with the
+ * reviewer and critic rows that the gate already authenticated.
+ */
+export async function assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(
+	directory: string,
+	sessionID: string,
+	boundary: PrReviewArtifactBoundary,
+	records: readonly PrReviewArtifactRecord[],
+): Promise<void> {
+	const state = await requireBoundState(directory, sessionID, 'PR_REVIEW');
+	if (boundary === 'post_explorer') {
+		for (const record of records) {
+			if (
+				record.status !== 'PENDING' ||
+				record.next_action !== 'route_to_reviewer'
+			) {
+				throw new Error(
+					`BLOCKED: PR_REVIEW post_explorer record ${record.finding_id} must remain PENDING and route_to_reviewer`,
+				);
+			}
+		}
+		return;
+	}
+
+	const reviewerVerdicts = deriveLatestPrReviewReviewerVerdicts(
+		directory,
+		state,
+	);
+	const criticVerdicts =
+		boundary === 'post_critic'
+			? deriveLatestPrReviewCriticVerdicts(directory, state)
+			: undefined;
+	for (const record of records) {
+		const reviewer = reviewerVerdicts.get(record.finding_id);
+		if (!reviewer) {
+			throw new Error(
+				`BLOCKED: PR_REVIEW ${boundary} record ${record.finding_id} has no authoritative reviewer verdict`,
+			);
+		}
+		if (record.severity && record.severity !== reviewer.severity) {
+			throw new Error(
+				`BLOCKED: PR_REVIEW ${boundary} record ${record.finding_id} severity differs from its reviewer verdict`,
+			);
+		}
+		const requiresCritic =
+			reviewer.classification === 'CONFIRMED' &&
+			['CRITICAL', 'HIGH', 'MEDIUM'].includes(reviewer.severity);
+		if (boundary === 'post_reviewer') {
+			const expectedStatus =
+				reviewer.classification === 'UNVERIFIED'
+					? 'PENDING'
+					: reviewer.classification;
+			if (record.status !== expectedStatus) {
+				throw new Error(
+					`BLOCKED: PR_REVIEW post_reviewer record ${record.finding_id} status differs from its reviewer verdict`,
+				);
+			}
+			const expectedAction = requiresCritic
+				? 'route_to_critic'
+				: reviewer.classification === 'CONFIRMED' ||
+						reviewer.classification === 'PRE_EXISTING'
+					? 'report'
+					: reviewer.classification === 'DISPROVED'
+						? 'suppress_with_reason'
+						: 'route_to_reviewer';
+			if (record.next_action !== expectedAction) {
+				throw new Error(
+					`BLOCKED: PR_REVIEW post_reviewer record ${record.finding_id} action does not match reviewer disposition`,
+				);
+			}
+			continue;
+		}
+
+		if (!requiresCritic) {
+			const expectedStatus =
+				reviewer.classification === 'UNVERIFIED'
+					? 'PENDING'
+					: reviewer.classification;
+			const expectedAction =
+				reviewer.classification === 'CONFIRMED' ||
+				reviewer.classification === 'PRE_EXISTING'
+					? 'report'
+					: reviewer.classification === 'DISPROVED'
+						? 'suppress_with_reason'
+						: 'route_to_reviewer';
+			if (
+				record.status !== expectedStatus ||
+				record.next_action !== expectedAction
+			) {
+				throw new Error(
+					`BLOCKED: PR_REVIEW post_critic record ${record.finding_id} cannot override its non-critic reviewer disposition`,
+				);
+			}
+			continue;
+		}
+
+		const critic = criticVerdicts?.get(record.finding_id);
+		if (!critic) {
+			throw new Error(
+				`BLOCKED: PR_REVIEW post_critic record ${record.finding_id} has no authoritative critic verdict`,
+			);
+		}
+		if (record.severity && record.severity !== critic.severity) {
+			throw new Error(
+				`BLOCKED: PR_REVIEW post_critic record ${record.finding_id} severity differs from its critic verdict`,
+			);
+		}
+		if (critic.status === 'DISPROVED') {
+			if (
+				record.status !== 'DISPROVED' ||
+				record.next_action !== 'suppress_with_reason'
+			) {
+				throw new Error(
+					`BLOCKED: PR_REVIEW post_critic record ${record.finding_id} must preserve the critic DISPROVED disposition`,
+				);
+			}
+		} else if (
+			record.status !== 'CONFIRMED' ||
+			!['report', 'handoff_to_feedback'].includes(record.next_action)
+		) {
+			throw new Error(
+				`BLOCKED: PR_REVIEW post_critic record ${record.finding_id} action does not match its critic verdict`,
+			);
+		}
+	}
 }
 
 export async function markPrReviewArtifactBoundary(
@@ -1878,6 +2044,9 @@ export async function enforcePrWorkflowToolBefore(
 			allowCheckout: !state.prHeadSha,
 			allowFetch: !state.prHeadSha,
 			allowTrackingFetch: Boolean(state.prHeadSha),
+			trackingFetchTarget: state.prHeadSha
+				? _test_exports.resolveCurrentUpstreamPushTarget(directory)
+				: null,
 		});
 	const trustedCapability = getPrWorkflowToolCapability(
 		normalizedTool,
@@ -1888,7 +2057,8 @@ export async function enforcePrWorkflowToolBefore(
 		isTrustedPrWorkflowToolInvocationSafe(normalizedTool, args ?? {});
 	const isNamedReadOnlyTool =
 		isTrustedWorkflowTool ||
-		(isAllowedPrReviewReadOnlyToolName(normalizedTool) &&
+		(normalizedTool !== 'build_check' &&
+			isAllowedPrReviewReadOnlyToolName(normalizedTool) &&
 			readOnlyToolArgumentsAreSafe(args ?? {}));
 	if (
 		referencesProtectedWorkflowEvidence &&
@@ -2558,6 +2728,10 @@ function isAllowedPrWorkflowReadOnlyShell(
 		allowCheckout: boolean;
 		allowFetch: boolean;
 		allowTrackingFetch: boolean;
+		trackingFetchTarget?: {
+			remoteName: string;
+			remoteBranchRef: string;
+		} | null;
 	},
 ): boolean {
 	const normalized = command.trim().replace(/\s+/g, ' ');
@@ -2641,6 +2815,10 @@ function isAllowedPrWorkflowGitIntake(
 		allowCheckout: boolean;
 		allowFetch: boolean;
 		allowTrackingFetch: boolean;
+		trackingFetchTarget?: {
+			remoteName: string;
+			remoteBranchRef: string;
+		} | null;
 	},
 ): boolean {
 	if (
@@ -2658,7 +2836,10 @@ function isAllowedPrWorkflowGitIntake(
 		return true;
 
 	if (options.allowFetch && /^fetch(?:\s|$)/i.test(gitArgs)) return true;
-	if (options.allowTrackingFetch && isAllowedBoundRemoteTrackingFetch(gitArgs))
+	if (
+		options.allowTrackingFetch &&
+		isAllowedBoundRemoteTrackingFetch(gitArgs, options.trackingFetchTarget)
+	)
 		return true;
 
 	if (/^remote(?:\s+-v)?$/i.test(gitArgs)) return true;
@@ -2681,16 +2862,24 @@ function isAllowedPrWorkflowGitIntake(
 	);
 }
 
-function isAllowedBoundRemoteTrackingFetch(gitArgs: string): boolean {
+function isAllowedBoundRemoteTrackingFetch(
+	gitArgs: string,
+	target: { remoteName: string; remoteBranchRef: string } | null | undefined,
+): boolean {
+	if (!target?.remoteName || !target.remoteBranchRef.startsWith('refs/heads/'))
+		return false;
 	const tokens = gitArgs.trim().split(/\s+/);
 	if (tokens.length !== 3 || tokens[0].toLowerCase() !== 'fetch') return false;
 	const [, remote, remoteBranch] = tokens;
+	const expectedBranch = target.remoteBranchRef.slice('refs/heads/'.length);
 	return (
 		isSafeGitRefToken(remote) &&
 		!remote.includes('/') &&
 		isSafeGitRefToken(remoteBranch) &&
 		!remoteBranch.startsWith('-') &&
-		!remoteBranch.includes(':')
+		!remoteBranch.includes(':') &&
+		remote === target.remoteName &&
+		remoteBranch === expectedBranch
 	);
 }
 
@@ -3078,6 +3267,57 @@ function derivePrReviewCriticInventory(
 		)
 		.map(([itemId]) => itemId)
 		.sort();
+}
+
+function deriveLatestPrReviewCriticVerdicts(
+	directory: string,
+	state: PrWorkflowGateState,
+): Map<string, { status: string; severity: string }> {
+	const reviewerVerdicts = deriveLatestPrReviewReviewerVerdicts(
+		directory,
+		state,
+	);
+	const criticBatches = (state.prReviewValidationBatches ?? []).filter(
+		(batch) => batch.phase === 'critic',
+	);
+	for (const batch of [...criticBatches].reverse()) {
+		const successful = successfulObligationsFromExactBatch(
+			directory,
+			state,
+			batch.batchId,
+			batch.lanes,
+			'swarm-pr-review:critic',
+			batch.validatedAt,
+		);
+		if (
+			batch.lanes.some((lane) => !successful.has(lane.workflowLane)) ||
+			successful.size !== batch.lanes.length
+		) {
+			continue;
+		}
+		const required = batch.lanes.flatMap((lane) => lane.reviewItemIds ?? []);
+		const verdicts = new Map<string, { status: string; severity: string }>();
+		for (const lane of batch.lanes) {
+			const record = findByBatchId(directory, batch.batchId, {
+				parentSessionId: state.sessionID,
+			}).find((candidate) => candidate.laneId === lane.laneId);
+			const ref = record?.result?.outputRef?.trim();
+			const artifact = ref
+				? readLaneOutput(directory, ref)?.artifact
+				: undefined;
+			if (!artifact) continue;
+			for (const itemId of lane.reviewItemIds ?? []) {
+				const verdict = parseCriticVerdict(
+					artifact.text,
+					itemId,
+					reviewerVerdicts.get(itemId)?.severity,
+				);
+				if (verdict) verdicts.set(itemId, verdict);
+			}
+		}
+		if (required.every((itemId) => verdicts.has(itemId))) return verdicts;
+	}
+	return new Map();
 }
 
 function deriveLatestPrReviewReviewerVerdicts(

--- a/src/hooks/scope-guard.ts
+++ b/src/hooks/scope-guard.ts
@@ -12,12 +12,15 @@
 import * as path from 'node:path';
 import { ORCHESTRATOR_NAME, WRITE_TOOL_NAMES } from '../config/constants';
 import { stripKnownSwarmPrefix } from '../config/schema';
+import { getAuthorizedPrFeedbackScopeBinding } from '../scope/scope-binding';
 import {
+	resolveAuthorizedPrFeedbackScopeBindingFromDisk,
 	resolveAuthorizedScopeBinding,
 	resolveAuthorizedScopeBindingForSession,
 } from '../scope/scope-persistence';
 import { type AgentSessionState, swarmState } from '../state';
 import { normalizeToolName } from './normalize-tool-name';
+import { validatePrFeedbackScopeBinding } from './pr-workflow-gate';
 import { resolveWriteTargets } from './write-target-resolver';
 
 // bash/shell tools are intentionally excluded from WRITE_TOOLS because the main
@@ -94,7 +97,7 @@ export function createScopeGuardHook(
 			// Resolve only an exact active child binding. If plugin memory restarted,
 			// recover one unique binding from disk against the current plan identity.
 			let taskId = _internals.resolveTaskId(session);
-			const binding = taskId
+			let binding = taskId
 				? _internals.resolveAuthorizedScopeBinding({
 						directory,
 						taskId,
@@ -104,6 +107,25 @@ export function createScopeGuardHook(
 						directory,
 						activeSessionId: sessionId,
 					});
+			if (!binding) {
+				binding =
+					_internals.getAuthorizedPrFeedbackScopeBinding({
+						directory,
+						activeSessionId: sessionId,
+						taskId: taskId ?? undefined,
+					}) ??
+					_internals.resolveAuthorizedPrFeedbackScopeBindingFromDisk({
+						directory,
+						activeSessionId: sessionId,
+						taskId: taskId ?? undefined,
+					});
+				if (
+					binding &&
+					!(await _internals.validatePrFeedbackScopeBinding(directory, binding))
+				) {
+					binding = null;
+				}
+			}
 			if (!taskId && binding && session) {
 				taskId = binding.taskId;
 				session.currentTaskId = binding.taskId;
@@ -203,6 +225,9 @@ export const _internals = {
 	resolveWriteTargets,
 	resolveAuthorizedScopeBinding,
 	resolveAuthorizedScopeBindingForSession,
+	getAuthorizedPrFeedbackScopeBinding,
+	resolveAuthorizedPrFeedbackScopeBindingFromDisk,
+	validatePrFeedbackScopeBinding,
 	resolveTaskId: (session: AgentSessionState | undefined): string | null =>
 		session?.currentTaskId ?? null,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2250,11 +2250,15 @@ async function initializeOpenCodeSwarm(ctx: Parameters<Plugin>[0]) {
 			//    their durable lane and trigger obligations are satisfied.
 			const prWorkflowControllerSessionID =
 				await prWorkflowSessionResolver.resolve(input.sessionID);
+			const prWorkflowToolContext = resolveToolBeforeContext(
+				input as { tool: string; sessionID: string; callID: string },
+				output as { args?: unknown },
+			);
 			await enforcePrWorkflowToolBefore(
 				ctx.directory,
 				prWorkflowControllerSessionID,
 				normalizeToolName(input.tool) ?? input.tool,
-				input.args as Record<string, unknown> | undefined,
+				prWorkflowToolContext.args ?? undefined,
 				swarmState.generatedAgentNames,
 			);
 

--- a/src/scope/scope-binding.ts
+++ b/src/scope/scope-binding.ts
@@ -11,6 +11,7 @@ export type ScopeBindingSource =
 	| 'declare_scope'
 	| 'plan'
 	| 'file_directive'
+	| 'pr_feedback'
 	| 'worktree_derived';
 
 export interface ScopeBinding {
@@ -26,6 +27,9 @@ export interface ScopeBinding {
 	activation: 'declaration' | 'pending_child' | 'active';
 	parentOwnerSessionId?: string;
 	parentCallId?: string;
+	/** PR_FEEDBACK bindings carry their parent workflow identity and revision. */
+	workflowSessionId?: string;
+	workflowRevisionDigest?: string;
 	source: ScopeBindingSource;
 	files: string[];
 	declaredAt: number;
@@ -98,7 +102,7 @@ export function createScopeBinding(input: {
 	files: readonly string[];
 	ownerSessionId: string;
 	ownerMessageId: string;
-	source: Exclude<ScopeBindingSource, 'worktree_derived'>;
+	source: Exclude<ScopeBindingSource, 'pr_feedback' | 'worktree_derived'>;
 	dispatchCallId?: string;
 	activation?: ScopeBinding['activation'];
 	ttlMs?: number;
@@ -193,6 +197,83 @@ export function getScopeBinding(input: {
 	const candidate = candidates[0];
 	if (!candidate || candidate.planId !== derivePlanId(input.plan)) return null;
 	return candidate;
+}
+
+export function createPrFeedbackScopeBinding(input: {
+	directory: string;
+	taskId: string;
+	files: readonly string[];
+	ownerSessionId: string;
+	ownerMessageId: string;
+	workflowSessionId: string;
+	workflowRevisionDigest: string;
+	dispatchCallId?: string;
+	activation?: ScopeBinding['activation'];
+}): ScopeBinding | null {
+	if (
+		!input.ownerSessionId.trim() ||
+		!input.ownerMessageId.trim() ||
+		!input.workflowSessionId.trim() ||
+		!input.workflowRevisionDigest.trim() ||
+		!isStrictTaskId(input.taskId)
+	)
+		return null;
+	const workspaceIdentity = canonicalWorkspaceIdentity(input.directory);
+	const files = normalizeScopeFiles(input.files);
+	if (!workspaceIdentity || !files) return null;
+	const now = Date.now();
+	const workflowIdentity = `pr-feedback:${input.workflowSessionId}`;
+	return {
+		version: 2,
+		workspaceIdentity,
+		planId: workflowIdentity,
+		planStructureHash: input.workflowRevisionDigest,
+		taskId: input.taskId,
+		ownerSessionId: input.ownerSessionId,
+		ownerMessageId: input.ownerMessageId,
+		dispatchCallId: input.dispatchCallId,
+		activation:
+			input.activation ??
+			(input.dispatchCallId ? 'pending_child' : 'declaration'),
+		source: 'pr_feedback',
+		files,
+		declaredAt: now,
+		expiresAt: now + DEFAULT_SCOPE_BINDING_TTL_MS,
+		workflowSessionId: input.workflowSessionId,
+		workflowRevisionDigest: input.workflowRevisionDigest,
+	};
+}
+
+export function getAuthorizedPrFeedbackScopeBinding(input: {
+	directory: string;
+	activeSessionId: string;
+	taskId?: string;
+}): ScopeBinding | null {
+	sweepExpired();
+	const workspaceIdentity = canonicalWorkspaceIdentity(input.directory);
+	if (!workspaceIdentity || !input.activeSessionId.trim()) return null;
+	const matches = [...pendingScopeBindings.values()].filter(
+		(binding) =>
+			binding.workspaceIdentity === workspaceIdentity &&
+			binding.source === 'pr_feedback' &&
+			binding.activation === 'active' &&
+			binding.ownerSessionId === input.activeSessionId &&
+			(!input.taskId || binding.taskId === input.taskId) &&
+			typeof binding.dispatchCallId === 'string' &&
+			binding.dispatchCallId.length > 0 &&
+			binding.ownerMessageId === binding.dispatchCallId &&
+			typeof binding.parentOwnerSessionId === 'string' &&
+			binding.parentOwnerSessionId.length > 0 &&
+			binding.ownerSessionId !== binding.parentOwnerSessionId &&
+			binding.parentCallId === binding.dispatchCallId &&
+			typeof binding.workflowSessionId === 'string' &&
+			binding.workflowSessionId === binding.parentOwnerSessionId &&
+			typeof binding.workflowRevisionDigest === 'string' &&
+			binding.workflowRevisionDigest.length > 0 &&
+			binding.planId === `pr-feedback:${binding.workflowSessionId}` &&
+			binding.planStructureHash === binding.workflowRevisionDigest,
+	);
+	return matches.length === 1 ? matches[0] : null;
 }
 
 /** Resolve the one Task-correlated authorization for an executing coder. */

--- a/src/scope/scope-persistence.ts
+++ b/src/scope/scope-persistence.ts
@@ -74,6 +74,7 @@ const SCOPES_DIR = '.swarm/scopes';
 const MAX_FILES_PER_SCOPE = 10_000;
 const MAX_PLAN_BYTES = 10 * 1024 * 1024; // 10 MiB — plan.json size cap
 const MAX_SCOPE_BYTES = 2 * 1024 * 1024; // 2 MiB — scope file size cap
+const MAX_BINDING_FILES_TO_SCAN = 10_000;
 
 // Windows reserved device names. Defence-in-depth — declare-scope already
 // constrains taskId to N.M[.P], but this module is also imported by readers
@@ -581,6 +582,142 @@ export function resolveAuthorizedScopeBindingForSession(input: {
 		if (matches.length > 1) return null;
 	}
 	return matches[0] ?? null;
+}
+
+function readPrFeedbackBindingFile(
+	directory: string,
+	filePath: string,
+	activeSessionId: string,
+	taskId?: string,
+): ScopeBinding | null {
+	try {
+		const leaf = fs.lstatSync(filePath);
+		if (!leaf.isFile() || leaf.isSymbolicLink()) return null;
+		if (
+			normalizePathForComparison(fs.realpathSync(filePath)) !==
+			normalizePathForComparison(filePath)
+		)
+			return null;
+	} catch {
+		return null;
+	}
+	const nofollow = (fs.constants as { O_NOFOLLOW?: number }).O_NOFOLLOW ?? 0;
+	let fd: number;
+	try {
+		fd = fs.openSync(filePath, fs.constants.O_RDONLY | nofollow);
+	} catch {
+		return null;
+	}
+	let raw = '';
+	try {
+		const stat = fs.fstatSync(fd);
+		if (!stat.isFile() || stat.size > MAX_SCOPE_BYTES) return null;
+		const buffer = Buffer.alloc(stat.size);
+		fs.readSync(fd, buffer, 0, stat.size, 0);
+		raw = buffer.toString('utf8');
+	} catch {
+		return null;
+	} finally {
+		try {
+			fs.closeSync(fd);
+		} catch {
+			/* already closed */
+		}
+	}
+
+	let parsed: Partial<ScopeBinding>;
+	try {
+		parsed = JSON.parse(raw) as Partial<ScopeBinding>;
+	} catch {
+		return null;
+	}
+	const workspaceIdentity = canonicalWorkspaceIdentity(directory);
+	const files = Array.isArray(parsed.files)
+		? normalizeScopeFiles(
+				parsed.files.filter((file): file is string => typeof file === 'string'),
+			)
+		: null;
+	const now = Date.now();
+	if (
+		parsed.version !== 2 ||
+		parsed.source !== 'pr_feedback' ||
+		!workspaceIdentity ||
+		parsed.workspaceIdentity !== workspaceIdentity ||
+		!isSafeTaskId(parsed.taskId ?? '') ||
+		(taskId !== undefined && parsed.taskId !== taskId) ||
+		parsed.ownerSessionId !== activeSessionId ||
+		parsed.activation !== 'active' ||
+		typeof parsed.dispatchCallId !== 'string' ||
+		!parsed.dispatchCallId ||
+		parsed.ownerMessageId !== parsed.dispatchCallId ||
+		typeof parsed.parentOwnerSessionId !== 'string' ||
+		!parsed.parentOwnerSessionId ||
+		parsed.ownerSessionId === parsed.parentOwnerSessionId ||
+		parsed.parentCallId !== parsed.dispatchCallId ||
+		parsed.workflowSessionId !== parsed.parentOwnerSessionId ||
+		typeof parsed.workflowRevisionDigest !== 'string' ||
+		!parsed.workflowRevisionDigest ||
+		parsed.planId !== `pr-feedback:${parsed.workflowSessionId}` ||
+		parsed.planStructureHash !== parsed.workflowRevisionDigest ||
+		typeof parsed.declaredAt !== 'number' ||
+		parsed.declaredAt > now ||
+		typeof parsed.expiresAt !== 'number' ||
+		parsed.expiresAt <= now ||
+		!files
+	)
+		return null;
+	const expectedPath = getBindingFilePath(
+		directory,
+		parsed.taskId!,
+		activeSessionId,
+	);
+	if (
+		normalizePathForComparison(expectedPath) !==
+		normalizePathForComparison(filePath)
+	)
+		return null;
+	return { ...(parsed as ScopeBinding), files };
+}
+
+/** Recover one exact planless PR_FEEDBACK child binding after plugin restart. */
+export function resolveAuthorizedPrFeedbackScopeBindingFromDisk(input: {
+	directory: string;
+	activeSessionId: string;
+	taskId?: string;
+}): ScopeBinding | null {
+	if (!input.activeSessionId.trim()) return null;
+	const scopesDir = getScopesDir(input.directory);
+	if (!isScopesDirSafe(input.directory, scopesDir)) return null;
+	let candidates: string[];
+	if (input.taskId) {
+		if (!isSafeTaskId(input.taskId)) return null;
+		candidates = [
+			getBindingFilePath(input.directory, input.taskId, input.activeSessionId),
+		];
+	} else {
+		try {
+			const names = fs.readdirSync(scopesDir);
+			if (names.length > MAX_BINDING_FILES_TO_SCAN) return null;
+			candidates = names
+				.filter((name) => name.startsWith('binding-') && name.endsWith('.json'))
+				.map((name) => path.join(scopesDir, name));
+		} catch {
+			return null;
+		}
+	}
+	const matches = candidates
+		.map((candidate) =>
+			readPrFeedbackBindingFile(
+				input.directory,
+				candidate,
+				input.activeSessionId,
+				input.taskId,
+			),
+		)
+		.filter((binding): binding is ScopeBinding => binding !== null);
+	if (matches.length !== 1) return null;
+	registerScopeBinding(matches[0]);
+	return matches[0];
 }
 
 /**

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -71,6 +71,10 @@ export {
 	type ToolResult,
 } from './pre-check-batch';
 export {
+	executePreparePrFeedbackScope,
+	prepare_pr_feedback_scope,
+} from './prepare-pr-feedback-scope';
+export {
 	type QualityBudgetInput,
 	type QualityBudgetResult,
 	quality_budget,
@@ -199,6 +203,10 @@ export { write_drift_evidence } from './write-drift-evidence';
 export { write_final_council_evidence } from './write-final-council-evidence';
 export { write_hallucination_evidence } from './write-hallucination-evidence';
 export { write_mutation_evidence } from './write-mutation-evidence';
+export {
+	executeWritePrReviewArtifact,
+	write_pr_review_artifact,
+} from './write-pr-review-artifact';
 export {
 	executeWritePrReviewTriggerEval,
 	PR_REVIEW_TRIGGER_DEFINITIONS,

--- a/src/tools/manifest.ts
+++ b/src/tools/manifest.ts
@@ -90,6 +90,7 @@ import { phase_complete } from './phase-complete';
 import { pkg_audit } from './pkg-audit';
 import { placeholder_scan } from './placeholder-scan';
 import { pre_check_batch } from './pre-check-batch';
+import { prepare_pr_feedback_scope } from './prepare-pr-feedback-scope';
 import { quality_budget } from './quality-budget';
 import { repo_map } from './repo-map';
 import { req_coverage } from './req-coverage';
@@ -132,6 +133,7 @@ import { write_drift_evidence } from './write-drift-evidence';
 import { write_final_council_evidence } from './write-final-council-evidence';
 import { write_hallucination_evidence } from './write-hallucination-evidence';
 import { write_mutation_evidence } from './write-mutation-evidence';
+import { write_pr_review_artifact } from './write-pr-review-artifact';
 import { write_pr_review_trigger_eval } from './write-pr-review-trigger-eval';
 import { write_retro } from './write-retro';
 
@@ -178,6 +180,8 @@ export const TOOL_MANIFEST = defineHandlers({
 	checkpoint: () => checkpoint,
 	pkg_audit: () => pkg_audit,
 	parse_lane_candidates: () => parse_lane_candidates,
+	prepare_pr_feedback_scope: () => prepare_pr_feedback_scope,
+	write_pr_review_artifact: () => write_pr_review_artifact,
 	write_pr_review_trigger_eval: () => write_pr_review_trigger_eval,
 	test_runner: () => test_runner,
 	test_impact: () => test_impact,

--- a/src/tools/prepare-pr-feedback-scope.ts
+++ b/src/tools/prepare-pr-feedback-scope.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+import { checkWriteTargetForSymlink } from '../hooks/guardrails.js';
+import { declarePrFeedbackScope } from '../hooks/pr-workflow-gate.js';
+import { normalizeScopeFiles } from '../scope/scope-binding.js';
+import { createSwarmTool } from './create-tool.js';
+
+const PreparePrFeedbackScopeArgsSchema = z
+	.object({
+		task_id: z
+			.string()
+			.regex(/^\d+\.\d+(?:\.\d+)*$/, 'task_id must use N.M notation'),
+		files: z.array(z.string().min(1).max(4096)).min(1).max(10_000),
+	})
+	.strict();
+
+function failure(message: string): string {
+	return JSON.stringify({ success: false, message }, null, 2);
+}
+
+export async function executePreparePrFeedbackScope(
+	args: unknown,
+	directory: string,
+	context: { sessionID?: string } = {},
+): Promise<string> {
+	const parsed = PreparePrFeedbackScopeArgsSchema.safeParse(args);
+	if (!parsed.success) {
+		return failure(
+			`Invalid PR-feedback scope: ${parsed.error.issues
+				.map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+				.join('; ')}`,
+		);
+	}
+	const sessionID = context.sessionID?.trim();
+	if (!sessionID)
+		return failure('PR-feedback scope requires an active session');
+	const files = normalizeScopeFiles(parsed.data.files);
+	if (!files) return failure('PR-feedback scope contains an unsafe file path');
+	for (const file of files) {
+		const symlinkBlock = checkWriteTargetForSymlink(file, directory);
+		if (symlinkBlock) return failure(symlinkBlock);
+	}
+	try {
+		await declarePrFeedbackScope(
+			directory,
+			sessionID,
+			parsed.data.task_id,
+			files,
+		);
+	} catch (error) {
+		return failure(error instanceof Error ? error.message : String(error));
+	}
+	return JSON.stringify(
+		{
+			success: true,
+			task_id: parsed.data.task_id,
+			files,
+			message:
+				'Scope is bound to the verified PR-feedback revision and will authorize only the next matching coder Task.',
+		},
+		null,
+		2,
+	);
+}
+
+export const prepare_pr_feedback_scope: ReturnType<typeof createSwarmTool> =
+	createSwarmTool({
+		description:
+			'Prepare an exact file scope for one PR-feedback coder Task after immutable feedback verification settles.',
+		args: {
+			task_id: PreparePrFeedbackScopeArgsSchema.shape.task_id,
+			files: PreparePrFeedbackScopeArgsSchema.shape.files,
+		},
+		execute: executePreparePrFeedbackScope,
+	});

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -126,10 +126,6 @@ export const TOOL_METADATA = {
 		description:
 			'discover and run build, typecheck, and test commands for various project ecosystems in the working directory',
 		agents: ['architect', 'coder', 'test_engineer'],
-		prWorkflow: {
-			modes: ['PR_REVIEW'],
-			capability: 'validate',
-		},
 	},
 	pre_check_batch: {
 		description:

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -22,6 +22,11 @@ export interface ToolMeta {
 	description: string;
 	/** Agents granted this tool by default (inverted into AGENT_TOOL_MAP). Empty = overlay-only. */
 	agents: AgentName[];
+	/** Explicit PR-workflow capability. Omitted tools remain fail-closed. */
+	prWorkflow?: {
+		modes: Array<'PR_REVIEW' | 'PR_FEEDBACK'>;
+		capability: 'observe' | 'validate';
+	};
 }
 
 /**
@@ -38,20 +43,36 @@ export const TOOL_METADATA = {
 			'coder',
 			'test_engineer',
 		],
+		prWorkflow: {
+			modes: ['PR_REVIEW', 'PR_FEEDBACK'],
+			capability: 'observe',
+		},
 	},
 	diff_summary: {
 		description:
 			'filter classified AST changes by category, risk level, or file for reviewer drill-down',
 		agents: ['architect', 'reviewer', 'critic_oversight'],
+		prWorkflow: {
+			modes: ['PR_REVIEW', 'PR_FEEDBACK'],
+			capability: 'observe',
+		},
 	},
 	syntax_check: {
 		description:
 			'check syntax of source files using tree-sitter parsers across multiple languages, returning per-file errors',
 		agents: ['architect', 'coder', 'test_engineer'],
+		prWorkflow: {
+			modes: ['PR_REVIEW'],
+			capability: 'validate',
+		},
 	},
 	placeholder_scan: {
 		description: 'todo and FIXME comment detection',
 		agents: ['architect', 'reviewer'],
+		prWorkflow: {
+			modes: ['PR_REVIEW', 'PR_FEEDBACK'],
+			capability: 'observe',
+		},
 	},
 	imports: {
 		description:
@@ -70,25 +91,45 @@ export const TOOL_METADATA = {
 			'coder',
 			'test_engineer',
 		],
+		prWorkflow: {
+			modes: ['PR_REVIEW', 'PR_FEEDBACK'],
+			capability: 'observe',
+		},
 	},
 	lint: {
 		description:
 			'run project linter in check or fix mode; supports biome, eslint, ruff, clippy, and more, returns structured results',
 		agents: ['architect', 'reviewer', 'coder'],
+		prWorkflow: {
+			modes: ['PR_REVIEW'],
+			capability: 'validate',
+		},
 	},
 	secretscan: {
 		description:
 			'scan for secrets (API keys, tokens, passwords) via regex and entropy; returns redacted previews, excludes common dirs',
 		agents: ['architect', 'reviewer', 'critic_oversight'],
+		prWorkflow: {
+			modes: ['PR_REVIEW'],
+			capability: 'validate',
+		},
 	},
 	sast_scan: {
 		description: 'static analysis security scan',
 		agents: ['architect', 'reviewer', 'critic_oversight'],
+		prWorkflow: {
+			modes: ['PR_REVIEW'],
+			capability: 'validate',
+		},
 	},
 	build_check: {
 		description:
 			'discover and run build, typecheck, and test commands for various project ecosystems in the working directory',
 		agents: ['architect', 'coder', 'test_engineer'],
+		prWorkflow: {
+			modes: ['PR_REVIEW'],
+			capability: 'validate',
+		},
 	},
 	pre_check_batch: {
 		description:
@@ -98,6 +139,10 @@ export const TOOL_METADATA = {
 	quality_budget: {
 		description: 'code quality budget check',
 		agents: ['architect'],
+		prWorkflow: {
+			modes: ['PR_REVIEW'],
+			capability: 'validate',
+		},
 	},
 	symbols: {
 		description:
@@ -138,10 +183,18 @@ export const TOOL_METADATA = {
 	schema_drift: {
 		description: 'OpenAPI spec vs route drift',
 		agents: ['architect', 'sme', 'researcher', 'docs', 'explorer'],
+		prWorkflow: {
+			modes: ['PR_REVIEW', 'PR_FEEDBACK'],
+			capability: 'observe',
+		},
 	},
 	todo_extract: {
 		description: 'structured TODO/FIXME extraction',
 		agents: ['architect', 'researcher', 'docs', 'explorer'],
+		prWorkflow: {
+			modes: ['PR_REVIEW', 'PR_FEEDBACK'],
+			capability: 'observe',
+		},
 	},
 	evidence_check: {
 		description: 'verify task evidence completeness',
@@ -203,6 +256,10 @@ export const TOOL_METADATA = {
 			'critic_oversight',
 			'test_engineer',
 		],
+		prWorkflow: {
+			modes: ['PR_REVIEW'],
+			capability: 'validate',
+		},
 	},
 	parse_lane_candidates: {
 		description:
@@ -214,14 +271,32 @@ export const TOOL_METADATA = {
 			'persist the complete PR-review trigger evaluation with exact-set validation, dispatch provenance, and live merge-base verification',
 		agents: ['architect'],
 	},
+	write_pr_review_artifact: {
+		description:
+			'persist schema-validated PR-review findings checkpoints and exact actionable feedback handoffs under the active run',
+		agents: ['architect'],
+	},
+	prepare_pr_feedback_scope: {
+		description:
+			'prepare an exact file scope for one PR-feedback coder Task after immutable feedback verification settles',
+		agents: ['architect'],
+	},
 	test_runner: {
 		description: 'auto-detect and run tests',
 		agents: ['architect', 'reviewer', 'test_engineer'],
+		prWorkflow: {
+			modes: ['PR_REVIEW'],
+			capability: 'validate',
+		},
 	},
 	test_impact: {
 		description:
 			'identify test files impacted by changed source files via import analysis',
 		agents: ['architect', 'reviewer', 'critic_oversight', 'test_engineer'],
+		prWorkflow: {
+			modes: ['PR_REVIEW', 'PR_FEEDBACK'],
+			capability: 'observe',
+		},
 	},
 	mutation_test: {
 		description:
@@ -252,10 +327,18 @@ export const TOOL_METADATA = {
 		description:
 			'per-line git blame metadata: sha, author, date, summary for each line in a file',
 		agents: ['reviewer', 'explorer', 'architect'],
+		prWorkflow: {
+			modes: ['PR_REVIEW', 'PR_FEEDBACK'],
+			capability: 'observe',
+		},
 	},
 	gitingest: {
 		description: 'fetch a GitHub repository full content via gitingest.com',
 		agents: ['architect', 'docs', 'explorer'],
+		prWorkflow: {
+			modes: ['PR_REVIEW', 'PR_FEEDBACK'],
+			capability: 'observe',
+		},
 	},
 	retrieve_summary: {
 		description: 'retrieve the full content of a stored tool output summary',
@@ -280,6 +363,10 @@ export const TOOL_METADATA = {
 		description:
 			'retrieve paged full dispatch lane output by output_ref; use before consuming truncated lane previews or routing candidates from lane results',
 		agents: ['architect'],
+		prWorkflow: {
+			modes: ['PR_REVIEW', 'PR_FEEDBACK'],
+			capability: 'observe',
+		},
 	},
 	extract_code_blocks: {
 		description: 'extract code blocks from text content and save them to files',
@@ -441,16 +528,28 @@ export const TOOL_METADATA = {
 		description:
 			'Run actionlint against GitHub Actions workflow YAML files with structured findings. Resolves actionlint lazily and does not modify files.',
 		agents: ['architect', 'test_engineer'],
+		prWorkflow: {
+			modes: ['PR_REVIEW'],
+			capability: 'validate',
+		},
 	},
 	osv_scan: {
 		description:
 			'Run OSV-Scanner against a workspace path and return structured dependency vulnerability findings. Resolves osv-scanner lazily and does not modify files.',
 		agents: ['architect', 'test_engineer'],
+		prWorkflow: {
+			modes: ['PR_REVIEW'],
+			capability: 'validate',
+		},
 	},
 	gh_evidence: {
 		description:
 			'Fetch bounded GitHub pull request or issue metadata through gh for review and CI evidence. Resolves gh lazily and is read-only.',
 		agents: ['architect', 'researcher'],
+		prWorkflow: {
+			modes: ['PR_REVIEW', 'PR_FEEDBACK'],
+			capability: 'observe',
+		},
 	},
 	batch_symbols: {
 		description:
@@ -500,6 +599,10 @@ export const TOOL_METADATA = {
 			'explorer',
 			'coder',
 		],
+		prWorkflow: {
+			modes: ['PR_REVIEW', 'PR_FEEDBACK'],
+			capability: 'observe',
+		},
 	},
 	get_qa_gate_profile: {
 		description:
@@ -774,6 +877,15 @@ export const TOOL_NAMES: readonly ToolName[] = Object.keys(
 
 /** Set for O(1) tool name validation. */
 export const TOOL_NAME_SET: ReadonlySet<ToolName> = new Set(TOOL_NAMES);
+
+export function getPrWorkflowToolCapability(
+	toolName: string,
+	mode: 'PR_REVIEW' | 'PR_FEEDBACK',
+): 'observe' | 'validate' | null {
+	const metadata = (TOOL_METADATA as Record<string, ToolMeta>)[toolName];
+	if (!metadata?.prWorkflow?.modes.includes(mode)) return null;
+	return metadata.prWorkflow.capability;
+}
 
 /** Human-readable descriptions, keyed by tool name. */
 export const TOOL_DESCRIPTIONS: Partial<Record<ToolName, string>> =

--- a/src/tools/write-pr-review-artifact.ts
+++ b/src/tools/write-pr-review-artifact.ts
@@ -1,0 +1,296 @@
+import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { z } from 'zod';
+import {
+	assertPrReviewArtifactBoundary,
+	markPrReviewArtifactBoundary,
+	markPrReviewHandoffComplete,
+	readPrWorkflowGateState,
+} from '../hooks/pr-workflow-gate.js';
+import { validateSwarmPath } from '../hooks/utils.js';
+import { createSwarmTool } from './create-tool.js';
+
+const RunIdSchema = z
+	.string()
+	.regex(
+		/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/,
+		'run_id must be a safe relative identifier',
+	);
+
+const FindingSchema = z
+	.object({
+		finding_id: z.string().trim().min(1).max(128),
+		status: z.enum(['PENDING', 'CONFIRMED', 'DISPROVED', 'PRE_EXISTING']),
+		file_line: z.string().trim().min(1).max(1000),
+		evidence: z.string().trim().min(1).max(20_000),
+		next_action: z.enum([
+			'route_to_reviewer',
+			'route_to_critic',
+			'report',
+			'suppress_with_reason',
+			'handoff_to_feedback',
+		]),
+		severity: z.enum(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']).optional(),
+		category: z.string().trim().min(1).max(128).optional(),
+	})
+	.strict();
+
+const HandoffSchema = z
+	.object({
+		pr_url: z.string().url(),
+		finding_ids: z.array(z.string().trim().min(1).max(128)).min(1),
+		summary: z.string().trim().min(1).max(20_000),
+		provenance: z.array(z.string().trim().min(1).max(4000)).min(1),
+	})
+	.strict();
+
+const WritePrReviewArtifactArgsSchema = z.discriminatedUnion('kind', [
+	z
+		.object({
+			kind: z.literal('findings'),
+			run_id: RunIdSchema,
+			pr_head_sha: z
+				.string()
+				.trim()
+				.regex(/^[0-9a-f]{6,64}$/i),
+			boundary: z.enum(['post_explorer', 'post_reviewer', 'post_critic']),
+			records: z.array(FindingSchema).min(1).max(1000),
+		})
+		.strict(),
+	z
+		.object({
+			kind: z.literal('handoff'),
+			run_id: RunIdSchema,
+			pr_head_sha: z
+				.string()
+				.trim()
+				.regex(/^[0-9a-f]{6,64}$/i),
+			handoff: HandoffSchema,
+		})
+		.strict(),
+]);
+
+type PersistedFinding = z.infer<typeof FindingSchema> & {
+	boundary: 'post_explorer' | 'post_reviewer' | 'post_critic';
+	pr_head_sha: string;
+	recorded_at: string;
+};
+
+function failure(message: string): string {
+	return JSON.stringify({ success: false, message }, null, 2);
+}
+
+async function readFindings(filePath: string): Promise<PersistedFinding[]> {
+	try {
+		const stat = await fs.promises.stat(filePath);
+		if (!stat.isFile() || stat.size > 10 * 1024 * 1024) {
+			throw new Error('findings artifact is not a bounded regular file');
+		}
+		const text = await fs.promises.readFile(filePath, 'utf8');
+		return text
+			.split(/\r?\n/)
+			.filter(Boolean)
+			.map((line) => JSON.parse(line) as PersistedFinding);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+		throw error;
+	}
+}
+
+async function atomicWrite(filePath: string, content: string): Promise<void> {
+	await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+	const tempPath = path.join(
+		path.dirname(filePath),
+		`.${path.basename(filePath)}.${randomUUID()}.tmp`,
+	);
+	try {
+		await fs.promises.writeFile(tempPath, content, {
+			encoding: 'utf8',
+			flag: 'wx',
+		});
+		await fs.promises.rename(tempPath, filePath);
+	} finally {
+		await fs.promises.rm(tempPath, { force: true }).catch(() => undefined);
+	}
+}
+
+function latestFindings(
+	records: readonly PersistedFinding[],
+): Map<string, PersistedFinding> {
+	const latest = new Map<string, PersistedFinding>();
+	for (const record of records) latest.set(record.finding_id, record);
+	return latest;
+}
+
+export async function executeWritePrReviewArtifact(
+	args: unknown,
+	directory: string,
+	context: { sessionID?: string } = {},
+): Promise<string> {
+	const parsed = WritePrReviewArtifactArgsSchema.safeParse(args);
+	if (!parsed.success) {
+		return failure(
+			`Invalid PR-review artifact: ${parsed.error.issues
+				.map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+				.join('; ')}`,
+		);
+	}
+	const sessionID = context.sessionID?.trim();
+	if (!sessionID)
+		return failure('PR-review artifact requires an active session');
+	const state = await readPrWorkflowGateState(directory, sessionID);
+	if (state?.mode !== 'PR_REVIEW' || !state.prHeadSha) {
+		return failure(
+			'PR-review artifact requires an active, bound PR_REVIEW gate',
+		);
+	}
+	if (state.prHeadSha !== parsed.data.pr_head_sha.toLowerCase()) {
+		return failure(
+			`PR-review artifact head mismatch: expected ${state.prHeadSha}, received ${parsed.data.pr_head_sha}`,
+		);
+	}
+	if (
+		state.prReviewArtifactRunId &&
+		state.prReviewArtifactRunId !== parsed.data.run_id
+	) {
+		return failure(
+			`PR-review artifacts are already bound to run ${state.prReviewArtifactRunId}`,
+		);
+	}
+
+	const relativeFindingsPath = path.join(
+		'pr-review',
+		parsed.data.run_id,
+		'findings.jsonl',
+	);
+	const findingsPath = validateSwarmPath(directory, relativeFindingsPath);
+	const existing = await readFindings(findingsPath);
+
+	if (parsed.data.kind === 'findings') {
+		const findingsInput = parsed.data;
+		const findingIds = findingsInput.records.map((record) => record.finding_id);
+		await assertPrReviewArtifactBoundary(
+			directory,
+			sessionID,
+			findingsInput.run_id,
+			findingsInput.boundary,
+			findingIds,
+		);
+		const recordedAt = new Date().toISOString();
+		const appended: PersistedFinding[] = findingsInput.records.map(
+			(record) => ({
+				...record,
+				boundary: findingsInput.boundary,
+				pr_head_sha: state.prHeadSha!,
+				recorded_at: recordedAt,
+			}),
+		);
+		const allRecords = [...existing, ...appended];
+		await atomicWrite(
+			findingsPath,
+			allRecords.map((record) => JSON.stringify(record)).join('\n') +
+				(allRecords.length > 0 ? '\n' : ''),
+		);
+		const latest = latestFindings(allRecords);
+		const handoffRequired = [...latest.values()].some(
+			(record) =>
+				record.status === 'CONFIRMED' &&
+				record.next_action === 'handoff_to_feedback',
+		);
+		await markPrReviewArtifactBoundary(
+			directory,
+			sessionID,
+			findingsInput.run_id,
+			findingsInput.boundary,
+			relativeFindingsPath.split(path.sep).join('/'),
+			findingIds,
+			handoffRequired,
+		);
+		return JSON.stringify(
+			{
+				success: true,
+				path: relativeFindingsPath.split(path.sep).join('/'),
+				boundary: findingsInput.boundary,
+				appended: appended.length,
+				handoff_required: handoffRequired,
+			},
+			null,
+			2,
+		);
+	}
+
+	const latest = latestFindings(existing);
+	const actionableIds = [...latest.values()]
+		.filter(
+			(record) =>
+				record.status === 'CONFIRMED' &&
+				record.next_action === 'handoff_to_feedback',
+		)
+		.map((record) => record.finding_id)
+		.sort();
+	const requestedIds = [...new Set(parsed.data.handoff.finding_ids)].sort();
+	if (
+		actionableIds.length === 0 ||
+		JSON.stringify(actionableIds) !== JSON.stringify(requestedIds)
+	) {
+		return failure(
+			`handoff finding_ids must exactly match actionable findings: ${actionableIds.join(', ') || '(none)'}`,
+		);
+	}
+	const relativeHandoffPath = path.join(
+		'pr-review',
+		parsed.data.run_id,
+		'feedback-handoff.json',
+	);
+	const handoffPath = validateSwarmPath(directory, relativeHandoffPath);
+	await atomicWrite(
+		handoffPath,
+		`${JSON.stringify(
+			{
+				schema_version: 1,
+				run_id: parsed.data.run_id,
+				pr_head_sha: state.prHeadSha,
+				created_at: new Date().toISOString(),
+				...parsed.data.handoff,
+			},
+			null,
+			2,
+		)}\n`,
+	);
+	await markPrReviewHandoffComplete(
+		directory,
+		sessionID,
+		parsed.data.run_id,
+		relativeHandoffPath.split(path.sep).join('/'),
+	);
+	return JSON.stringify(
+		{
+			success: true,
+			path: relativeHandoffPath.split(path.sep).join('/'),
+			finding_count: actionableIds.length,
+		},
+		null,
+		2,
+	);
+}
+
+export const write_pr_review_artifact: ReturnType<typeof createSwarmTool> =
+	createSwarmTool({
+		description:
+			'Persist schema-validated PR-review findings checkpoints and exact actionable feedback handoffs under the active run.',
+		args: {
+			kind: z.enum(['findings', 'handoff']),
+			run_id: RunIdSchema,
+			pr_head_sha: z
+				.string()
+				.trim()
+				.regex(/^[0-9a-f]{6,64}$/i),
+			boundary: z
+				.enum(['post_explorer', 'post_reviewer', 'post_critic'])
+				.optional(),
+			records: z.array(FindingSchema).min(1).max(1000).optional(),
+			handoff: HandoffSchema.optional(),
+		},
+		execute: executeWritePrReviewArtifact,
+	});

--- a/src/tools/write-pr-review-artifact.ts
+++ b/src/tools/write-pr-review-artifact.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { z } from 'zod';
 import {
 	assertPrReviewArtifactBoundary,
+	assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts,
 	markPrReviewArtifactBoundary,
 	markPrReviewHandoffComplete,
 	readPrWorkflowGateState,
@@ -176,6 +177,12 @@ export async function executeWritePrReviewArtifact(
 			findingsInput.run_id,
 			findingsInput.boundary,
 			findingIds,
+		);
+		await assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(
+			directory,
+			sessionID,
+			findingsInput.boundary,
+			findingsInput.records,
 		);
 		const recordedAt = new Date().toISOString();
 		const appended: PersistedFinding[] = findingsInput.records.map(

--- a/tests/integration/pr-workflow-real-host-boundary.test.ts
+++ b/tests/integration/pr-workflow-real-host-boundary.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { rmSync } from 'node:fs';
+import {
+	deleteStoredInputArgs,
+	getStoredInputArgs,
+} from '../../src/hooks/guardrails.js';
+import {
+	_test_exports,
+	activatePrWorkflow,
+} from '../../src/hooks/pr-workflow-gate.js';
+import { resetSwarmState } from '../../src/state.js';
+import {
+	bootKnowledgeHost,
+	createKnowledgeProject,
+} from '../helpers/knowledge-real-host.js';
+
+const SESSION_ID = 'pr-workflow-real-host';
+
+describe('PR workflow gate uses the real SDK output.args boundary', () => {
+	let directory: string;
+	let plugin: Awaited<ReturnType<typeof bootKnowledgeHost>>;
+
+	beforeEach(async () => {
+		resetSwarmState();
+		_test_exports.resetTrackedStateCache();
+		directory = createKnowledgeProject();
+		plugin = await bootKnowledgeHost(directory);
+		await activatePrWorkflow(directory, SESSION_ID, 'PR_REVIEW');
+	});
+
+	afterEach(() => {
+		deleteStoredInputArgs('read-call');
+		deleteStoredInputArgs('mutation-call');
+		_test_exports.resetTrackedStateCache();
+		resetSwarmState();
+		try {
+			rmSync(directory, { recursive: true, force: true });
+		} catch {
+			// Windows may briefly retain a plugin-init handle in the temp project.
+		}
+	});
+
+	test('allows safe shell args and rejects mutating connector args supplied only through output.args', async () => {
+		const before = plugin.hooks['tool.execute.before'];
+		const after = plugin.hooks['tool.execute.after'];
+
+		await expect(
+			before(
+				{ tool: 'shell', sessionID: SESSION_ID, callID: 'read-call' },
+				{ args: { command: 'git status --short' } },
+			),
+		).resolves.toBeUndefined();
+		try {
+			expect(getStoredInputArgs('read-call')).toEqual({
+				command: 'git status --short',
+			});
+		} finally {
+			await after(
+				{ tool: 'shell', sessionID: SESSION_ID, callID: 'read-call' },
+				{ output: '' },
+			);
+		}
+
+		await expect(
+			before(
+				{
+					tool: 'mcp__github__get_pull_request',
+					sessionID: SESSION_ID,
+					callID: 'mutation-call',
+				},
+				{
+					args: {
+						owner: 'example',
+						repo: 'project',
+						method: 'POST',
+						body: { title: 'mutated' },
+					},
+				},
+			),
+		).rejects.toThrow(/read-only and fail-closed/i);
+	});
+});

--- a/tests/unit/commands/doctor-command-recovery.test.ts
+++ b/tests/unit/commands/doctor-command-recovery.test.ts
@@ -18,7 +18,7 @@ import { _internals } from '../../../src/config';
 const VALID_CONFIG = {
 	max_iterations: 9,
 	memory: { enabled: true },
-	gates: { enabled: true },
+	gates: { syntax_check: { enabled: true } },
 };
 
 function writeProjectConfig(projectDir: string, content: object): void {
@@ -69,7 +69,9 @@ describe('/swarm config doctor — FR-004 (SC-004.1 + SC-004.2 + SC-004.3)', () 
 			// 1 bad key in 4 strict sections (gates is pre-Zod sanitized)
 			writeProjectConfig(projectDir, {
 				max_iterations: 9,
-				gates: { enabled: true, gatesBogusKey: 'val' },
+				gates: {
+					syntax_check: { enabled: true, gatesBogusKey: 'val' },
+				},
 				council: { enabled: true, councilBogusKey: 1 },
 				checkpoint: { enabled: true, checkpointBogusKey: 1 },
 				pr_monitor: { enabled: true, prMonitorBogusKey: 1 },
@@ -88,6 +90,7 @@ describe('/swarm config doctor — FR-004 (SC-004.1 + SC-004.2 + SC-004.3)', () 
 			expect(output).toContain('## Config Recovery');
 			expect(output).toContain('`stripped_keys`');
 			// removedKeys listing present
+			expect(output).toContain('gates.syntax_check.gatesBogusKey');
 			expect(output).toContain('council.councilBogusKey');
 			expect(output).toContain('checkpoint.checkpointBogusKey');
 			expect(output).toContain('pr_monitor.prMonitorBogusKey');
@@ -133,7 +136,10 @@ describe('/swarm config doctor — FR-004 (SC-004.1 + SC-004.2 + SC-004.3)', () 
 			mkdirSync(join(userDir, 'opencode'), { recursive: true });
 			writeFileSync(
 				join(userDir, 'opencode', 'opencode-swarm.json'),
-				JSON.stringify({ max_iterations: 7, gates: { enabled: true } }),
+				JSON.stringify({
+					max_iterations: 7,
+					gates: { syntax_check: { enabled: true } },
+				}),
 				'utf-8',
 			);
 			writeProjectConfig(projectDir, {

--- a/tests/unit/config/loader-strict-recovery.test.ts
+++ b/tests/unit/config/loader-strict-recovery.test.ts
@@ -91,6 +91,25 @@ describe('config/loader — strict-section typo recovery (#1778 H6)', () => {
 		fs.rmSync(projectDir, { recursive: true, force: true });
 	});
 
+	it('preserves the rest of the config when turbo.epic has a nested typo', () => {
+		const projectDir = writeProjectConfig({
+			max_iterations: 6,
+			turbo: {
+				strategy: 'standard',
+				epic: { mode: { enabled: true, misspelledEpicKey: true } },
+			},
+		});
+		const result = loadPluginConfig(projectDir);
+
+		expect(result.max_iterations).toBe(6);
+		expect(result.turbo?.epic?.mode?.enabled).toBe(true);
+		expect(
+			(result.turbo?.epic?.mode as Record<string, unknown>).misspelledEpicKey,
+		).toBeUndefined();
+
+		fs.rmSync(projectDir, { recursive: true, force: true });
+	});
+
 	it('does not delete valid z.record (open-ended) keys during recovery', () => {
 		// `agents` is a z.record — arbitrary user keys are legal and must survive
 		// even when another section carries a typo that triggers recovery.

--- a/tests/unit/config/loader.metadata.parity.test.ts
+++ b/tests/unit/config/loader.metadata.parity.test.ts
@@ -1,0 +1,198 @@
+/**
+ * loader.metadata.parity.test.ts
+ *
+ * Property test: both `loadPluginConfigWithMeta` (sync) and
+ * `loadPluginConfigWithMetaAsync` (async) must produce structurally equal
+ * `recovery`, `removedKeys`, `warnings`, and `config` for every fixture
+ * in the battery.
+ *
+ * Purpose: Guards against future re-divergence in the I/O layer (sync vs async
+ * file reads) and ensures the shared `buildConfigWithMeta` core produces identical
+ * outputs for both entry points. If separate sync/async logic is ever reintroduced
+ * or the I/O wiring drifts, this test fires immediately. It is the regression
+ * guard for issue #1900 FR-4 and the architectural invariant in FR-1.
+ *
+ * Fixtures:
+ *   1. clean config
+ *   2. single typo in council (strict section)
+ *   3. single typo in checkpoint (strict section)
+ *   4. single typo in pr_monitor (strict section)
+ *   5. invalid JSON in project config
+ *   6. invalid JSON in both user and project configs
+ *   7. single typo in gates section
+ *   8. full_auto.locked user=true / project=false
+ *   9. no config files at all (defaults only)
+ *  10. invalid external_skills section
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	loadPluginConfigWithMeta,
+	loadPluginConfigWithMetaAsync,
+} from '../../../src/config/loader';
+
+type ParityFixture = {
+	name: string;
+	/** Writes the config files and returns the project directory to pass to the loaders. */
+	setup: (xdgDir: string) => string;
+};
+
+describe('config/loader — sync/async parity (issue #1900 FR-4)', () => {
+	let tempXdg: string;
+	let originalXDG: string | undefined;
+
+	beforeEach(() => {
+		tempXdg = fs.mkdtempSync(path.join(os.tmpdir(), 'parity-xdg-'));
+		originalXDG = process.env.XDG_CONFIG_HOME;
+		process.env.XDG_CONFIG_HOME = tempXdg;
+	});
+
+	afterEach(() => {
+		if (originalXDG === undefined) delete process.env.XDG_CONFIG_HOME;
+		else process.env.XDG_CONFIG_HOME = originalXDG;
+		fs.rmSync(tempXdg, { recursive: true, force: true });
+	});
+
+	function makeProjectDir(xdgDir: string, cfg: unknown): string {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'parity-proj-'));
+		fs.mkdirSync(path.join(dir, '.opencode'), { recursive: true });
+		fs.writeFileSync(
+			path.join(dir, '.opencode', 'opencode-swarm.json'),
+			JSON.stringify(cfg),
+		);
+		return dir;
+	}
+
+	function writeUserConfigIn(xdgDir: string, cfg: unknown): void {
+		const dir = path.join(xdgDir, 'opencode');
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(dir, 'opencode-swarm.json'),
+			JSON.stringify(cfg),
+		);
+	}
+
+	function writeRawUserConfigIn(xdgDir: string, rawContent: string): void {
+		const dir = path.join(xdgDir, 'opencode');
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(path.join(dir, 'opencode-swarm.json'), rawContent);
+	}
+
+	function makeEmptyProjectDir(): string {
+		return fs.mkdtempSync(path.join(os.tmpdir(), 'parity-empty-'));
+	}
+
+	const fixtures: ParityFixture[] = [
+		{
+			name: 'clean config',
+			setup: (xdg) => makeProjectDir(xdg, { max_iterations: 3 }),
+		},
+		{
+			name: 'typo in council (strict section)',
+			setup: (xdg) =>
+				makeProjectDir(xdg, {
+					council: { enabled: true, bogusCouncilKey: 42 },
+				}),
+		},
+		{
+			name: 'typo in checkpoint (strict section)',
+			setup: (xdg) =>
+				makeProjectDir(xdg, {
+					checkpoint: { enabled: true, bogusCheckpointKey: true },
+				}),
+		},
+		{
+			name: 'typo in pr_monitor (strict section)',
+			setup: (xdg) =>
+				makeProjectDir(xdg, {
+					pr_monitor: { enabled: false, noSuchField: 'x' },
+				}),
+		},
+		{
+			name: 'invalid JSON in project config',
+			setup: (_xdg) => {
+				const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'parity-badjson-'));
+				fs.mkdirSync(path.join(dir, '.opencode'), { recursive: true });
+				fs.writeFileSync(
+					path.join(dir, '.opencode', 'opencode-swarm.json'),
+					'{ this is not json',
+				);
+				return dir;
+			},
+		},
+		{
+			name: 'invalid JSON in both user and project configs',
+			setup: (xdg) => {
+				writeRawUserConfigIn(xdg, '{ invalid user json');
+				const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'parity-badjson-'));
+				fs.mkdirSync(path.join(dir, '.opencode'), { recursive: true });
+				fs.writeFileSync(
+					path.join(dir, '.opencode', 'opencode-swarm.json'),
+					'{ invalid project json',
+				);
+				return dir;
+			},
+		},
+		{
+			name: 'typo in gates section',
+			setup: (xdg) =>
+				makeProjectDir(xdg, {
+					max_iterations: 6,
+					gates: { unknownGateKey: { enabled: true } },
+				}),
+		},
+		{
+			name: 'full_auto.locked user=true / project=false',
+			setup: (xdg) => {
+				writeUserConfigIn(xdg, { full_auto: { locked: true } });
+				return makeProjectDir(xdg, { full_auto: { locked: false } });
+			},
+		},
+		{
+			name: 'no config files (defaults only)',
+			setup: (_xdg) => makeEmptyProjectDir(),
+		},
+		{
+			name: 'invalid external_skills section',
+			setup: (xdg) =>
+				makeProjectDir(xdg, {
+					max_iterations: 5,
+					external_skills: { curation_enabled: 'not-a-boolean' },
+				}),
+		},
+	];
+
+	for (const fixture of fixtures) {
+		it(`sync and async produce identical results for: ${fixture.name}`, async () => {
+			// Each test gets a fresh XDG to avoid cross-fixture user-config pollution.
+			const freshXdg = fs.mkdtempSync(path.join(os.tmpdir(), 'parity-xdg2-'));
+			const savedXDG = process.env.XDG_CONFIG_HOME;
+			process.env.XDG_CONFIG_HOME = freshXdg;
+			let dir: string | undefined;
+			try {
+				dir = fixture.setup(freshXdg);
+				const syncResult = loadPluginConfigWithMeta(dir);
+				const asyncResult = await loadPluginConfigWithMetaAsync(dir);
+
+				// config must be deeply equal
+				expect(syncResult.config).toEqual(asyncResult.config);
+				// loader-level metadata must match
+				expect(syncResult.loadedFromFile).toBe(asyncResult.loadedFromFile);
+				expect(syncResult.configHadErrors).toBe(asyncResult.configHadErrors);
+				// recovery metadata must match
+				expect(syncResult.recovery).toBe(asyncResult.recovery);
+				expect(syncResult.removedKeys.sort()).toEqual(
+					asyncResult.removedKeys.sort(),
+				);
+				expect(syncResult.warnings).toEqual(asyncResult.warnings);
+			} finally {
+				if (dir) fs.rmSync(dir, { recursive: true, force: true });
+				process.env.XDG_CONFIG_HOME = savedXDG;
+				fs.rmSync(freshXdg, { recursive: true, force: true });
+			}
+		});
+	}
+});

--- a/tests/unit/config/loader.metadata.test.ts
+++ b/tests/unit/config/loader.metadata.test.ts
@@ -1,417 +1,347 @@
-﻿import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+/**
+ * loader.metadata.test.ts
+ *
+ * Tests for the recovery metadata returned by `loadPluginConfigWithMeta`
+ * and `loadPluginConfigWithMetaAsync` (issue #1900).
+ *
+ * Covers:
+ *   - 'none' recovery for a clean config
+ *   - 'stripped_keys' recovery for a gates-section typo (FR-3)
+ *   - 'stripped_keys' recovery for a Zod strict-section typo
+ *   - 'user_only' recovery when project config is irrecoverable
+ *   - 'guardrails_defaults' recovery when everything fails
+ *   - full_auto.locked OR-merge preserved in sync metadata path
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { _internals } from '../../../src/config/index';
-import { loadPluginConfigWithMetaAsync } from '../../../src/config/loader';
+import {
+	loadPluginConfigWithMeta,
+	loadPluginConfigWithMetaAsync,
+} from '../../../src/config/loader';
 
-/**
- * FR-001 regression tests: metadata exposure for loadPluginConfigWithMeta.
- * Issue #1690 - SC-001.1 through SC-001.7.
- *
- * The 5 strict sections are: gates, council, checkpoint, pr_monitor, turbo.epic.
- *
- * NOTE: gates uses pre-Zod sanitizeGatesConfig (loader.ts:210-289) which
- * strips unknown keys before Zod sees them. Recovery metadata (stripped_keys)
- * is NOT produced for gates - unknown keys are silently removed and the
- * config parses cleanly. The other 4 sections (council, checkpoint,
- * pr_monitor, turbo.epic) use .strict() Zod schemas and DO produce
- * recovery metadata when unknown keys are encountered.
- */
-
-function writeProjectConfig(cfg: unknown): string {
-	const projectDir = fs.mkdtempSync(
-		path.join(os.tmpdir(), 'meta-test-project-'),
-	);
-	fs.mkdirSync(path.join(projectDir, '.opencode'), { recursive: true });
-	fs.writeFileSync(
-		path.join(projectDir, '.opencode', 'opencode-swarm.json'),
-		JSON.stringify(cfg),
-	);
-	return projectDir;
-}
-
-describe('config/loader -- FR-001 metadata exposure (#1690)', () => {
-	let tempDir: string;
-	let originalXdg: string | undefined;
+describe('config/loader — metadata (issue #1900)', () => {
+	let tempXdg: string;
+	let originalXDG: string | undefined;
 
 	beforeEach(() => {
-		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'meta-test-xdg-'));
-		originalXdg = process.env.XDG_CONFIG_HOME;
-		process.env.XDG_CONFIG_HOME = tempDir;
+		tempXdg = fs.mkdtempSync(path.join(os.tmpdir(), 'meta-xdg-'));
+		originalXDG = process.env.XDG_CONFIG_HOME;
+		process.env.XDG_CONFIG_HOME = tempXdg;
 	});
 
 	afterEach(() => {
-		if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
-		else process.env.XDG_CONFIG_HOME = originalXdg;
-		fs.rmSync(tempDir, { recursive: true, force: true });
+		if (originalXDG === undefined) delete process.env.XDG_CONFIG_HOME;
+		else process.env.XDG_CONFIG_HOME = originalXDG;
+		fs.rmSync(tempXdg, { recursive: true, force: true });
 	});
 
-	// SC-001.4: clean parse
-	describe('SC-001.4 -- clean load produces empty recovery fields', () => {
-		it('recovery === none, removedKeys === [], warnings === [] on valid config', () => {
-			const projectDir = writeProjectConfig({
-				max_iterations: 9,
-				memory: { enabled: true },
-				gates: { enabled: true },
-			});
-			const result = _internals.loadPluginConfigWithMeta(projectDir);
-			expect(result.recovery).toBe('none');
-			expect(result.removedKeys).toEqual([]);
-			expect(result.warnings).toEqual([]);
-			expect(result.config.max_iterations).toBe(9);
-			expect(result.config.memory?.enabled).toBe(true);
-		});
+	function projectDir(cfg: unknown): string {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'meta-proj-'));
+		fs.mkdirSync(path.join(dir, '.opencode'), { recursive: true });
+		fs.writeFileSync(
+			path.join(dir, '.opencode', 'opencode-swarm.json'),
+			JSON.stringify(cfg),
+		);
+		return dir;
+	}
 
-		it('clean load with only optional sections present', () => {
-			const projectDir = writeProjectConfig({
-				gates: { syntax_check: { enabled: true } },
-				council: { enabled: false },
-			});
-			const result = _internals.loadPluginConfigWithMeta(projectDir);
-			expect(result.recovery).toBe('none');
-			expect(result.removedKeys).toEqual([]);
-			expect(result.warnings).toEqual([]);
-			expect(result.config.gates?.syntax_check?.enabled).toBe(true);
-		});
-	});
+	function projectDirWithRaw(rawContent: string): string {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'meta-proj-'));
+		fs.mkdirSync(path.join(dir, '.opencode'), { recursive: true });
+		fs.writeFileSync(
+			path.join(dir, '.opencode', 'opencode-swarm.json'),
+			rawContent,
+		);
+		return dir;
+	}
 
-	// SC-001.1: council is the clearest example of the strict-schema recovery
-	describe('SC-001.1 -- council section malformed key (strict-schema recovery)', () => {
-		it('strips the unknown council key and returns stripped_keys recovery', () => {
-			const projectDir = writeProjectConfig({
-				max_iterations: 9,
-				council: { enabled: true, maxRounds: 4, unknownCouncilKey: 1 },
-			});
-			const result = _internals.loadPluginConfigWithMeta(projectDir);
-			expect(result.recovery).toBe('stripped_keys');
-			expect(result.removedKeys).toContain('council.unknownCouncilKey');
-			expect(result.removedKeys.length).toBeGreaterThan(0);
-			expect(result.warnings.length).toBeGreaterThan(0);
-			expect(result.warnings[0]).toContain('council');
-			expect(result.config.max_iterations).toBe(9);
-			expect(result.config.council?.enabled).toBe(true);
-		});
-	});
+	function userConfigDir(): string {
+		const dir = path.join(tempXdg, 'opencode');
+		fs.mkdirSync(dir, { recursive: true });
+		return dir;
+	}
 
-	// SC-001.2: gates uses pre-Zod sanitization (no recovery metadata)
-	describe('SC-001.2 -- gates section uses pre-Zod sanitization (no recovery metadata)', () => {
-		it('strips unknown gates key silently without recovery metadata', () => {
-			const projectDir = writeProjectConfig({
-				max_iterations: 9,
-				gates: { enabled: true, totallyBogusGateKey: true },
-			});
-			const result = _internals.loadPluginConfigWithMeta(projectDir);
-			// gates uses sanitizeGatesConfig before Zod: no recovery metadata produced
-			expect(result.recovery).toBe('none');
-			expect(result.removedKeys).toEqual([]);
-			expect(result.warnings).toEqual([]);
-			// valid sections still preserved
-			expect(result.config.max_iterations).toBe(9);
-		});
+	function writeUserConfig(cfg: unknown): void {
+		fs.writeFileSync(
+			path.join(userConfigDir(), 'opencode-swarm.json'),
+			JSON.stringify(cfg),
+		);
+	}
 
-		it('nested unknown key in gate subsection is also sanitized silently', () => {
-			const projectDir = writeProjectConfig({
-				max_iterations: 5,
-				gates: { syntax_check: { enabled: true, bogusNestedKey: 1 } },
-			});
-			const result = _internals.loadPluginConfigWithMeta(projectDir);
-			expect(result.recovery).toBe('none');
-			expect(result.removedKeys).toEqual([]);
-			expect(result.config.max_iterations).toBe(5);
-		});
-	});
+	function writeRawUserConfig(rawContent: string): void {
+		fs.writeFileSync(
+			path.join(userConfigDir(), 'opencode-swarm.json'),
+			rawContent,
+		);
+	}
 
-	// SC-001.3: non-stripped recovery paths (user_only, guardrails_defaults)
-	describe('SC-001.3 -- non-stripped recovery: user_only and guardrails_defaults', () => {
-		it('user_only: project has type error; user config valid → falls back to user alone', () => {
-			// User config (via XDG_CONFIG_HOME) is minimal valid.
-			const userConfigPath = path.join(
-				tempDir,
-				'opencode',
-				'opencode-swarm.json',
-			);
-			fs.mkdirSync(path.dirname(userConfigPath), { recursive: true });
-			fs.writeFileSync(
-				userConfigPath,
-				JSON.stringify({ max_iterations: 7, gates: { enabled: true } }),
-				'utf-8',
-			);
-			// Project config has a Zod type error (council.enabled: "yes" instead of boolean)
-			// that survives the unrecognized_keys strip.
-			const projectDir = writeProjectConfig({
-				max_iterations: 9,
-				council: { enabled: 'yes' as unknown as boolean },
-			});
-			const result = _internals.loadPluginConfigWithMeta(projectDir);
-			expect(result.recovery).toBe('user_only');
-			expect(result.warnings.length).toBeGreaterThan(0);
-			const warningsText = result.warnings.join(' ');
-			expect(warningsText).toMatch(/user config|Project config ignored/i);
-			// user config is applied (not project overrides)
-			expect(result.config.max_iterations).toBe(7);
-		});
-
-		it('guardrails_defaults: project config file exists with invalid JSON → ultimate fallback', () => {
-			// XDG_CONFIG_HOME has no user config (clean).
-			// Project config file exists but contains INVALID JSON (not parseable),
-			// which sets configHadErrors=true and triggers guardrails_defaults fallback.
-			const projectDir = fs.mkdtempSync(
-				path.join(os.tmpdir(), 'meta-test-guardrails-'),
-			);
-			fs.mkdirSync(path.join(projectDir, '.opencode'), { recursive: true });
-			fs.writeFileSync(
-				path.join(projectDir, '.opencode', 'opencode-swarm.json'),
-				'this is not valid JSON at all { unclosed',
-				'utf-8',
-			);
+	// 1. Clean config → recovery: 'none', no removedKeys
+	describe('clean config', () => {
+		it('sync: returns recovery=none and empty removedKeys', () => {
+			const dir = projectDir({ max_iterations: 5 });
 			try {
-				const result = _internals.loadPluginConfigWithMeta(projectDir);
-				// guardrails_defaults recovery (file existed, content invalid, ultimate fallback)
-				expect(result.recovery).toBe('guardrails_defaults');
-				expect(result.warnings.length).toBeGreaterThan(0);
-				const warningsText = result.warnings.join(' ');
-				expect(warningsText).toMatch(/SECURITY|Falling back|guardrails/i);
-				// guardrails ENABLED forced
-				expect(result.config.guardrails?.enabled).toBe(true);
+				const meta = loadPluginConfigWithMeta(dir);
+				expect(meta.recovery).toBe('none');
+				expect(meta.removedKeys).toEqual([]);
+				expect(meta.warnings).toEqual([]);
+				expect(meta.config.max_iterations).toBe(5);
 			} finally {
-				fs.rmSync(projectDir, { recursive: true, force: true });
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+
+		it('async: returns recovery=none and empty removedKeys', async () => {
+			const dir = projectDir({ max_iterations: 5 });
+			try {
+				const meta = await loadPluginConfigWithMetaAsync(dir);
+				expect(meta.recovery).toBe('none');
+				expect(meta.removedKeys).toEqual([]);
+				expect(meta.warnings).toEqual([]);
+				expect(meta.config.max_iterations).toBe(5);
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
 			}
 		});
 	});
 
-	// SC-001.5: backward compat — configHadErrors + loadedFromFile still present
-	describe('SC-001.5 -- backward compat: existing metadata fields retained', () => {
-		it('configHadErrors and loadedFromFile are present alongside the new recovery fields', () => {
-			const projectDir = writeProjectConfig({
-				max_iterations: 9,
-				gates: { enabled: true },
-			});
-			const result = _internals.loadPluginConfigWithMeta(projectDir);
-			// existing fields present
-			expect(typeof result.configHadErrors).toBe('boolean');
-			expect(typeof result.loadedFromFile).toBe('boolean');
-			// new fields present (SC-001.1/SC-001.3/...)
-			expect([
-				'none',
-				'stripped_keys',
-				'user_only',
-				'guardrails_defaults',
-			]).toContain(result.recovery);
-			expect(Array.isArray(result.removedKeys)).toBe(true);
-			expect(Array.isArray(result.warnings)).toBe(true);
-		});
-	});
-
-	// SC-001.6: 4 strict sections (gates excluded - uses pre-Zod sanitization)
-	describe('SC-001.6 -- regression: malformed key in each of 4 Zod-strict sections', () => {
-		it('metadata lists all 4 stripped keys; gates sanitized silently', () => {
-			const projectDir = writeProjectConfig({
-				max_iterations: 9,
-				gates: { enabled: true, gatesBogusKey: 'val' },
-				council: { enabled: true, councilBogusKey: 1 },
-				checkpoint: { enabled: true, checkpointBogusKey: 1 },
-				pr_monitor: { enabled: true, prMonitorBogusKey: 1 },
-				turbo: {
-					strategy: 'standard',
-					epic: {
-						enabled: false,
-						mode: { enabled: false },
-						calibration: { enabled: true },
-						turboEpicBogusKey: 'val',
-					},
-				},
-			});
-			const result = _internals.loadPluginConfigWithMeta(projectDir);
-			expect(result.recovery).toBe('stripped_keys');
-			// 4 strict sections produce removedKeys
-			expect(result.removedKeys).toContain('council.councilBogusKey');
-			expect(result.removedKeys).toContain('checkpoint.checkpointBogusKey');
-			expect(result.removedKeys).toContain('pr_monitor.prMonitorBogusKey');
-			expect(result.removedKeys).toContain('turbo.epic.turboEpicBogusKey');
-			// gates is sanitized pre-Zod: no recovery metadata
-			expect(result.removedKeys.some((k) => k.includes('gates'))).toBe(false);
-			// warnings cite the 4 strict sections
-			const warningsText = result.warnings.join(' ');
-			expect(warningsText).toContain('council');
-			expect(warningsText).toContain('checkpoint');
-			expect(warningsText).toContain('pr_monitor');
-			expect(warningsText).toContain('turbo');
-			// valid sections survive
-			expect(result.config.max_iterations).toBe(9);
-			expect(result.config.council?.enabled).toBe(true);
-			expect(result.config.checkpoint?.enabled).toBe(true);
-		});
-	});
-
-	// SC-001.7: per-section tests for non-gates strict sections
-	describe('SC-001.7 -- per-section malformed key: checkpoint', () => {
-		it('checkpoint with unknown key triggers stripped_keys recovery', () => {
-			const projectDir = writeProjectConfig({
+	// 2. Zod strict-section typo → recovery: 'stripped_keys'
+	describe('strict-section typo (council)', () => {
+		it('sync: returns recovery=stripped_keys with the typo key in removedKeys', () => {
+			const dir = projectDir({
 				max_iterations: 7,
-				checkpoint: { enabled: true, checkpointBogusKey: 1 },
+				council: { enabled: true, typoField: 99 },
 			});
-			const result = _internals.loadPluginConfigWithMeta(projectDir);
-			expect(result.recovery).toBe('stripped_keys');
-			expect(result.removedKeys).toContain('checkpoint.checkpointBogusKey');
-			expect(result.warnings[0]).toContain('checkpoint');
-			expect(result.config.max_iterations).toBe(7);
-		});
-	});
-
-	describe('SC-001.7 -- per-section malformed key: pr_monitor', () => {
-		it('pr_monitor with unknown key triggers stripped_keys recovery', () => {
-			const projectDir = writeProjectConfig({
-				max_iterations: 6,
-				pr_monitor: { enabled: true, prMonitorBogusKey: true },
-			});
-			const result = _internals.loadPluginConfigWithMeta(projectDir);
-			expect(result.recovery).toBe('stripped_keys');
-			expect(result.removedKeys).toContain('pr_monitor.prMonitorBogusKey');
-			expect(result.warnings[0]).toContain('pr_monitor');
-			expect(result.config.max_iterations).toBe(6);
-		});
-	});
-
-	describe('SC-001.7 -- per-section malformed key: turbo.epic', () => {
-		it('turbo.epic with unknown key triggers stripped_keys recovery', () => {
-			const projectDir = writeProjectConfig({
-				max_iterations: 5,
-				turbo: {
-					strategy: 'standard',
-					epic: {
-						enabled: false,
-						mode: { enabled: false },
-						calibration: { enabled: true },
-						epicBogusKey: 'val',
-					},
-				},
-			});
-			const result = _internals.loadPluginConfigWithMeta(projectDir);
-			expect(result.recovery).toBe('stripped_keys');
-			expect(result.removedKeys.some((k) => k.includes('turbo'))).toBe(true);
-			expect(result.warnings[0]).toContain('turbo');
-			expect(result.config.max_iterations).toBe(5);
-		});
-	});
-
-	describe('SC-001.7 -- per-section malformed key: council', () => {
-		it('council with unknown key triggers stripped_keys recovery', () => {
-			const projectDir = writeProjectConfig({
-				max_iterations: 4,
-				council: { enabled: false, councilBogusKey: 1 },
-			});
-			const result = _internals.loadPluginConfigWithMeta(projectDir);
-			expect(result.recovery).toBe('stripped_keys');
-			expect(result.removedKeys).toContain('council.councilBogusKey');
-			expect(result.warnings[0]).toContain('council');
-			expect(result.config.max_iterations).toBe(4);
-		});
-	});
-
-	// Async variant
-	describe('SC-001 async -- loadPluginConfigWithMetaAsync parity', () => {
-		it('async: clean load returns same metadata shape as sync', async () => {
-			const projectDir = writeProjectConfig({
-				max_iterations: 9,
-				memory: { enabled: true },
-			});
-			const syncResult = _internals.loadPluginConfigWithMeta(projectDir);
-			const asyncResult = await loadPluginConfigWithMetaAsync(projectDir);
-			expect(asyncResult.recovery).toBe('none');
-			expect(asyncResult.removedKeys).toEqual([]);
-			expect(asyncResult.warnings).toEqual([]);
-			expect(asyncResult.recovery).toBe(syncResult.recovery);
-			expect(asyncResult.config.max_iterations).toBe(9);
-		});
-
-		it('async: council typo returns stripped_keys with correct removedKeys', async () => {
-			const projectDir = writeProjectConfig({
-				max_iterations: 9,
-				council: { enabled: true, asyncCouncilBogus: 1 },
-			});
-			const result = await loadPluginConfigWithMetaAsync(projectDir);
-			expect(result.recovery).toBe('stripped_keys');
-			expect(result.removedKeys).toContain('council.asyncCouncilBogus');
-			expect(result.warnings.length).toBeGreaterThan(0);
-			expect(result.warnings[0]).toContain('council');
-			expect(result.config.max_iterations).toBe(9);
-		});
-
-		it('async: 4 Zod-strict sections malformed -- all keys listed in removedKeys', async () => {
-			const projectDir = writeProjectConfig({
-				max_iterations: 9,
-				council: { enabled: true, asyncCouncilBogus: 1 },
-				checkpoint: { enabled: true, asyncCheckpointBogus: 1 },
-				pr_monitor: { enabled: true, asyncPrMonitorBogus: 1 },
-				turbo: {
-					strategy: 'standard',
-					epic: {
-						enabled: false,
-						mode: { enabled: false },
-						calibration: { enabled: true },
-						asyncTurboEpicBogus: 'val',
-					},
-				},
-			});
-			const result = await loadPluginConfigWithMetaAsync(projectDir);
-			expect(result.recovery).toBe('stripped_keys');
-			expect(result.removedKeys).toContain('council.asyncCouncilBogus');
-			expect(result.removedKeys).toContain('checkpoint.asyncCheckpointBogus');
-			expect(result.removedKeys).toContain('pr_monitor.asyncPrMonitorBogus');
-			expect(result.removedKeys.some((k) => k.includes('turbo.epic'))).toBe(
-				true,
-			);
-			expect(result.warnings.length).toBeGreaterThan(0);
-		});
-
-		it('async: user_only: project has type error; user config valid → falls back to user alone (parity with sync)', async () => {
-			// User config (via XDG_CONFIG_HOME) is minimal valid.
-			const userConfigPath = path.join(
-				tempDir,
-				'opencode',
-				'opencode-swarm.json',
-			);
-			fs.mkdirSync(path.dirname(userConfigPath), { recursive: true });
-			fs.writeFileSync(
-				userConfigPath,
-				JSON.stringify({ max_iterations: 7, gates: { enabled: true } }),
-				'utf-8',
-			);
-			// Project config has a Zod type error (council.enabled: "yes" instead of
-			// boolean) that survives the unrecognized_keys strip.
-			const projectDir = writeProjectConfig({
-				max_iterations: 9,
-				council: { enabled: 'yes' as unknown as boolean },
-			});
-			const result = await loadPluginConfigWithMetaAsync(projectDir);
-			expect(result.recovery).toBe('user_only');
-			expect(result.warnings.length).toBeGreaterThan(0);
-			const warningsText = result.warnings.join(' ');
-			expect(warningsText).toMatch(/user config|Project config ignored/i);
-			// user config is applied (not project overrides)
-			expect(result.config.max_iterations).toBe(7);
-		});
-
-		it('async: guardrails_defaults recovery surfaces SECURITY warning (parity with sync)', async () => {
-			// Project config file exists but contains invalid JSON — configHadErrors=true.
-			const projectDir = fs.mkdtempSync(
-				path.join(os.tmpdir(), 'meta-async-guard-'),
-			);
-			fs.mkdirSync(path.join(projectDir, '.opencode'), { recursive: true });
-			fs.writeFileSync(
-				path.join(projectDir, '.opencode', 'opencode-swarm.json'),
-				'this is not valid JSON { unclosed',
-				'utf-8',
-			);
 			try {
-				const result = await loadPluginConfigWithMetaAsync(projectDir);
-				expect(result.recovery).toBe('guardrails_defaults');
-				expect(result.warnings.length).toBeGreaterThan(0);
-				expect(result.warnings[0]).toMatch(/SECURITY|Falling back|guardrails/i);
-				expect(result.config.guardrails?.enabled).toBe(true);
+				const meta = loadPluginConfigWithMeta(dir);
+				expect(meta.recovery).toBe('stripped_keys');
+				expect(meta.removedKeys).toContain('council.typoField');
+				expect(meta.warnings.join(' ')).toContain('council.typoField');
+				expect(meta.config.max_iterations).toBe(7);
+				expect(meta.config.council?.enabled).toBe(true);
 			} finally {
-				fs.rmSync(projectDir, { recursive: true, force: true });
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+
+		it('async: returns recovery=stripped_keys with the typo key in removedKeys', async () => {
+			const dir = projectDir({
+				max_iterations: 7,
+				council: { enabled: true, typoField: 99 },
+			});
+			try {
+				const meta = await loadPluginConfigWithMetaAsync(dir);
+				expect(meta.recovery).toBe('stripped_keys');
+				expect(meta.removedKeys).toContain('council.typoField');
+				expect(meta.warnings.join(' ')).toContain('council.typoField');
+				expect(meta.config.max_iterations).toBe(7);
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	// 3. Gates-section typo → recovery: 'stripped_keys' (FR-3)
+	// Previously: sanitizeGatesConfig stripped silently, loadPluginConfigWithMeta
+	// returned recovery:'none'. Now it must return recovery:'stripped_keys' with
+	// the offending key path in removedKeys.
+	describe('gates-section typo (FR-3 regression gate)', () => {
+		it('sync: unknown gates section → recovery=stripped_keys with gates key in removedKeys', () => {
+			const dir = projectDir({
+				max_iterations: 8,
+				gates: { unknownGateSection: { enabled: true } },
+			});
+			try {
+				const meta = loadPluginConfigWithMeta(dir);
+				expect(meta.recovery).toBe('stripped_keys');
+				expect(meta.removedKeys).toContain('gates.unknownGateSection');
+				expect(meta.warnings.join(' ')).toContain('gates.unknownGateSection');
+				// Other config is preserved
+				expect(meta.config.max_iterations).toBe(8);
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+
+		it('async: unknown gates section → recovery=stripped_keys with gates key in removedKeys', async () => {
+			const dir = projectDir({
+				max_iterations: 8,
+				gates: { unknownGateSection: { enabled: true } },
+			});
+			try {
+				const meta = await loadPluginConfigWithMetaAsync(dir);
+				expect(meta.recovery).toBe('stripped_keys');
+				expect(meta.removedKeys).toContain('gates.unknownGateSection');
+				expect(meta.warnings.join(' ')).toContain('gates.unknownGateSection');
+				expect(meta.config.max_iterations).toBe(8);
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+
+		it('sync: entirely invalid gates value → recovery=stripped_keys with "gates" in removedKeys', () => {
+			const dir = projectDir({
+				gates: 'not-an-object',
+			});
+			try {
+				const meta = loadPluginConfigWithMeta(dir);
+				expect(meta.recovery).toBe('stripped_keys');
+				expect(meta.removedKeys).toContain('gates');
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+
+		it('async: entirely invalid gates value → recovery=stripped_keys with "gates" in removedKeys', async () => {
+			const dir = projectDir({
+				gates: 'not-an-object',
+			});
+			try {
+				const meta = await loadPluginConfigWithMetaAsync(dir);
+				expect(meta.recovery).toBe('stripped_keys');
+				expect(meta.removedKeys).toContain('gates');
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	// 4. Invalid JSON → configHadErrors=true and fail-secure guardrails defaults.
+	describe('invalid JSON in project config', () => {
+		it('sync: invalid project JSON with no user config → guardrails_defaults', () => {
+			const dir = projectDirWithRaw('{ not valid json');
+			try {
+				const meta = loadPluginConfigWithMeta(dir);
+				expect(meta.configHadErrors).toBe(true);
+				expect(meta.recovery).toBe('guardrails_defaults');
+				expect(meta.config.guardrails?.enabled).toBe(true);
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+
+		it('async: invalid project JSON with no user config → guardrails_defaults', async () => {
+			const dir = projectDirWithRaw('{ not valid json');
+			try {
+				const meta = await loadPluginConfigWithMetaAsync(dir);
+				expect(meta.configHadErrors).toBe(true);
+				expect(meta.recovery).toBe('guardrails_defaults');
+				expect(meta.config.guardrails?.enabled).toBe(true);
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	// 5. full_auto.locked: user-level locked=true cannot be overridden by project locked=false
+	describe('full_auto.locked OR-merge (FR-2)', () => {
+		it('sync: user locked=true + project locked=false → merged config has locked=true', () => {
+			writeUserConfig({ full_auto: { locked: true } });
+			const dir = projectDir({ full_auto: { locked: false } });
+			try {
+				const meta = loadPluginConfigWithMeta(dir);
+				expect(meta.config.full_auto?.locked).toBe(true);
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+
+		it('async: user locked=true + project locked=false → merged config has locked=true', async () => {
+			writeUserConfig({ full_auto: { locked: true } });
+			const dir = projectDir({ full_auto: { locked: false } });
+			try {
+				const meta = await loadPluginConfigWithMetaAsync(dir);
+				expect(meta.config.full_auto?.locked).toBe(true);
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+
+		it('async: project locked=true + user locked=false → merged config has locked=true', async () => {
+			writeUserConfig({ full_auto: { locked: false } });
+			const dir = projectDir({ full_auto: { locked: true } });
+			try {
+				const meta = await loadPluginConfigWithMetaAsync(dir);
+				expect(meta.config.full_auto?.locked).toBe(true);
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+
+		it('sync: project locked=true + user locked=false → merged config has locked=true', () => {
+			writeUserConfig({ full_auto: { locked: false } });
+			const dir = projectDir({ full_auto: { locked: true } });
+			try {
+				const meta = loadPluginConfigWithMeta(dir);
+				expect(meta.config.full_auto?.locked).toBe(true);
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	// 6. Unrecoverable merged config → 'guardrails_defaults'
+	describe('guardrails defaults fallback', () => {
+		it('sync and async: irrecoverable config returns guardrails_defaults', async () => {
+			// Both user and project configs are syntactically invalid JSON.
+			writeRawUserConfig('not json at all -- intentionally invalid');
+			const dir = projectDirWithRaw('also not json');
+			try {
+				const [syncMeta, asyncMeta] = await Promise.all([
+					Promise.resolve(loadPluginConfigWithMeta(dir)),
+					loadPluginConfigWithMetaAsync(dir),
+				]);
+				for (const meta of [syncMeta, asyncMeta]) {
+					expect(meta.configHadErrors).toBe(true);
+					expect(meta.recovery).toBe('guardrails_defaults');
+					expect(meta.config.guardrails?.enabled).toBe(true);
+				}
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	describe('user-only recovery', () => {
+		it('sync and async: valid user config survives an irrecoverable project config', async () => {
+			writeUserConfig({ max_iterations: 7 });
+			const dir = projectDir({ council: { enabled: 'not-a-boolean' } });
+			try {
+				const [syncMeta, asyncMeta] = await Promise.all([
+					Promise.resolve(loadPluginConfigWithMeta(dir)),
+					loadPluginConfigWithMetaAsync(dir),
+				]);
+				for (const meta of [syncMeta, asyncMeta]) {
+					expect(meta.recovery).toBe('user_only');
+					expect(meta.config.max_iterations).toBe(7);
+					expect(meta.warnings.join(' ')).toMatch(/project config ignored/i);
+				}
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	describe('external_skills stripping', () => {
+		it('sync and async: invalid external_skills is surfaced as stripped_keys', async () => {
+			const dir = projectDir({
+				max_iterations: 5,
+				external_skills: { curation_enabled: 'not-a-boolean' },
+			});
+			try {
+				const [syncMeta, asyncMeta] = await Promise.all([
+					Promise.resolve(loadPluginConfigWithMeta(dir)),
+					loadPluginConfigWithMetaAsync(dir),
+				]);
+				for (const meta of [syncMeta, asyncMeta]) {
+					expect(meta.recovery).toBe('stripped_keys');
+					expect(meta.removedKeys).toContain('external_skills');
+					expect(meta.warnings.join(' ')).toContain('external_skills');
+				}
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
 			}
 		});
 	});

--- a/tests/unit/hooks/pr-feedback-scope-controller.test.ts
+++ b/tests/unit/hooks/pr-feedback-scope-controller.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate.js';
+import {
+	_test_exports,
+	activatePrWorkflow,
+	declarePrFeedbackInventory,
+	enforcePrFeedbackVerificationOwnership,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import { createScopeGuardHook } from '../../../src/hooks/scope-guard.js';
+import {
+	clearScopeBindings,
+	getAuthorizedPrFeedbackScopeBinding,
+} from '../../../src/scope/scope-binding.js';
+import { ensureAgentSession, resetSwarmState } from '../../../src/state.js';
+import { executePreparePrFeedbackScope } from '../../../src/tools/prepare-pr-feedback-scope.js';
+import { makeConfig } from './_delegation-gate-helpers.js';
+import {
+	HEAD_SHA,
+	persistBatch,
+	REVISION_DIGEST,
+	SESSION_ID,
+	tempDir,
+} from './pr-workflow-gate.test-fixtures.js';
+
+async function settleFeedbackVerification(): Promise<void> {
+	await activatePrWorkflow(tempDir, SESSION_ID, 'PR_FEEDBACK');
+	await declarePrFeedbackInventory(tempDir, SESSION_ID, ['FB-001'], {
+		prHeadSha: HEAD_SHA,
+	});
+	await enforcePrFeedbackVerificationOwnership(
+		tempDir,
+		SESSION_ID,
+		[{ laneId: 'verify-scope', ownedItemIds: ['FB-001'] }],
+		{ batchId: 'verify-scope', prHeadSha: HEAD_SHA },
+	);
+	await persistBatch(
+		'verify-scope',
+		'swarm-pr-feedback:verification',
+		[{ laneId: 'verify-scope', workflowLane: 'verify-scope' }],
+		{
+			textOverride: '[FEEDBACK-VERIFIED] | FB-001 | CONFIRMED | evidence',
+		},
+	);
+}
+
+describe('PR_FEEDBACK dedicated coder scope controller', () => {
+	beforeEach(() => {
+		resetSwarmState();
+		ensureAgentSession(SESSION_ID, 'architect', tempDir);
+	});
+
+	test('fails closed before immutable verification settles', async () => {
+		await activatePrWorkflow(tempDir, SESSION_ID, 'PR_FEEDBACK', {
+			prHeadSha: HEAD_SHA,
+		});
+		const result = JSON.parse(
+			await executePreparePrFeedbackScope(
+				{ task_id: '1.1', files: ['src/index.ts'] },
+				tempDir,
+				{ sessionID: SESSION_ID },
+			),
+		) as { success: boolean; message: string };
+		expect(result.success).toBe(false);
+		expect(result.message).toMatch(/verification/i);
+	});
+
+	test('authorizes exactly one planless coder Task and enforces its bound files', async () => {
+		await settleFeedbackVerification();
+		const prepared = JSON.parse(
+			await executePreparePrFeedbackScope(
+				{ task_id: '1.1', files: ['src/index.ts'] },
+				tempDir,
+				{ sessionID: SESSION_ID },
+			),
+		) as { success: boolean; files: string[] };
+		expect(prepared).toMatchObject({
+			success: true,
+			files: ['src/index.ts'],
+		});
+
+		const delegation = createDelegationGateHook(makeConfig(), tempDir);
+		await delegation.toolBefore(
+			{ tool: 'Task', sessionID: SESSION_ID, callID: 'feedback-coder-call' },
+			{
+				args: {
+					subagent_type: 'coder',
+					task_id: '1.1',
+					prompt:
+						'TASK: 1.1\nFILE: src/index.ts\nACCEPTANCE: close FB-001 with focused validation',
+				},
+			},
+		);
+		await delegation.taskMetadata({
+			callID: 'feedback-coder-call',
+			parentSessionID: SESSION_ID,
+			childSessionID: 'feedback-coder-child',
+		});
+
+		const binding = getAuthorizedPrFeedbackScopeBinding({
+			directory: tempDir,
+			activeSessionId: 'feedback-coder-child',
+			taskId: '1.1',
+		});
+		expect(binding).toMatchObject({
+			source: 'pr_feedback',
+			files: ['src/index.ts'],
+			workflowSessionId: SESSION_ID,
+			workflowRevisionDigest: REVISION_DIGEST,
+		});
+		await expect(
+			delegation.toolBefore(
+				{
+					tool: 'Task',
+					sessionID: SESSION_ID,
+					callID: 'feedback-coder-call-2',
+				},
+				{
+					args: {
+						subagent_type: 'coder',
+						task_id: '1.1',
+						prompt:
+							'TASK: 1.1\nFILE: src/index.ts\nACCEPTANCE: duplicate dispatch',
+					},
+				},
+			),
+		).rejects.toThrow(/already consumed/i);
+		const redeclared = JSON.parse(
+			await executePreparePrFeedbackScope(
+				{ task_id: '1.1', files: ['src/other.ts'] },
+				tempDir,
+				{ sessionID: SESSION_ID },
+			),
+		) as { success: boolean; message: string };
+		expect(redeclared.success).toBe(false);
+		expect(redeclared.message).toMatch(/already consumed/i);
+
+		const scopeGuard = createScopeGuardHook(
+			{ enabled: true },
+			tempDir,
+			() => undefined,
+		);
+		await expect(
+			scopeGuard.toolBefore(
+				{
+					tool: 'edit',
+					sessionID: 'feedback-coder-child',
+					callID: 'allowed-edit',
+				},
+				{ args: { path: 'src/index.ts' } },
+			),
+		).resolves.toBeUndefined();
+		await expect(
+			scopeGuard.toolBefore(
+				{
+					tool: 'edit',
+					sessionID: 'feedback-coder-child',
+					callID: 'blocked-edit',
+				},
+				{ args: { path: 'src/other.ts' } },
+			),
+		).rejects.toThrow(/SCOPE VIOLATION/i);
+
+		clearScopeBindings();
+		resetSwarmState();
+		ensureAgentSession('feedback-coder-child', 'coder', tempDir);
+		const restartedGuard = createScopeGuardHook(
+			{ enabled: true },
+			tempDir,
+			() => undefined,
+		);
+		await expect(
+			restartedGuard.toolBefore(
+				{
+					tool: 'edit',
+					sessionID: 'feedback-coder-child',
+					callID: 'restarted-edit',
+				},
+				{ args: { path: 'src/index.ts' } },
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('invalidates a prepared scope when the feedback revision changes', async () => {
+		await settleFeedbackVerification();
+		const result = JSON.parse(
+			await executePreparePrFeedbackScope(
+				{ task_id: '1.1', files: ['src/index.ts'] },
+				tempDir,
+				{ sessionID: SESSION_ID },
+			),
+		) as { success: boolean };
+		expect(result.success).toBe(true);
+		_test_exports.resolvePrWorkflowRevisionDigest = () => 'changed-revision';
+
+		const delegation = createDelegationGateHook(makeConfig(), tempDir);
+		await expect(
+			delegation.toolBefore(
+				{ tool: 'Task', sessionID: SESSION_ID, callID: 'stale-call' },
+				{
+					args: {
+						subagent_type: 'coder',
+						task_id: '1.1',
+						prompt: 'TASK: 1.1\nFILE: src/index.ts\nACCEPTANCE: close FB-001',
+					},
+				},
+			),
+		).rejects.toThrow(/verification ownership is incomplete/i);
+	});
+});

--- a/tests/unit/hooks/pr-workflow-gate-capabilities.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-capabilities.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	_test_exports,
+	activatePrWorkflow,
+	enforcePrWorkflowToolBefore,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	HEAD_SHA,
+	REVISION_DIGEST,
+	SESSION_ID,
+	tempDir,
+} from './pr-workflow-gate.test-fixtures.js';
+
+describe('PR workflow explicit capability contract', () => {
+	const originalResolveCurrentGitHead = _test_exports.resolveCurrentGitHead;
+	const originalResolvePrWorkflowRevisionDigest =
+		_test_exports.resolvePrWorkflowRevisionDigest;
+	const originalResolveIsWorkingTreeClean =
+		_test_exports.resolveIsWorkingTreeClean;
+
+	beforeEach(() => {
+		_test_exports.resetTrackedStateCache();
+		_test_exports.resolveCurrentGitHead = () => HEAD_SHA;
+		_test_exports.resolvePrWorkflowRevisionDigest = () => REVISION_DIGEST;
+		_test_exports.resolveIsWorkingTreeClean = () => true;
+	});
+
+	afterEach(() => {
+		_test_exports.resetTrackedStateCache();
+		_test_exports.resolveCurrentGitHead = originalResolveCurrentGitHead;
+		_test_exports.resolvePrWorkflowRevisionDigest =
+			originalResolvePrWorkflowRevisionDigest;
+		_test_exports.resolveIsWorkingTreeClean = originalResolveIsWorkingTreeClean;
+	});
+
+	test('admits required PR_REVIEW observation and safe validation tools', async () => {
+		await activatePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW', {
+			prHeadSha: HEAD_SHA,
+		});
+		for (const [toolName, args] of [
+			['skill', { name: 'swarm-pr-review' }],
+			['gh_evidence', { kind: 'pr', number: 123 }],
+			['gitingest', { repo: 'owner/repo' }],
+			['retrieve_lane_output', { output_ref: 'lane-output-ref' }],
+			['parse_lane_candidates', { output_ref: 'lane-output-ref' }],
+			[
+				'write_pr_review_artifact',
+				{
+					kind: 'findings',
+					run_id: 'review-run',
+					pr_head_sha: HEAD_SHA,
+				},
+			],
+			['test_runner', { files: ['tests/focused.test.ts'] }],
+			['lint', { mode: 'check' }],
+		] as const) {
+			await expect(
+				enforcePrWorkflowToolBefore(tempDir, SESSION_ID, toolName, args),
+			).resolves.toBeUndefined();
+		}
+	});
+
+	test('keeps mutation-capable modes and mode-specific controllers fail-closed', async () => {
+		await activatePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW', {
+			prHeadSha: HEAD_SHA,
+		});
+		await expect(
+			enforcePrWorkflowToolBefore(tempDir, SESSION_ID, 'lint', {
+				mode: 'fix',
+			}),
+		).rejects.toThrow(/read-only and fail-closed/i);
+		await expect(
+			enforcePrWorkflowToolBefore(
+				tempDir,
+				SESSION_ID,
+				'prepare_pr_feedback_scope',
+				{ task_id: '1.1', files: ['src/index.ts'] },
+			),
+		).rejects.toThrow(/read-only and fail-closed/i);
+		await expect(
+			enforcePrWorkflowToolBefore(
+				tempDir,
+				SESSION_ID,
+				'mcp__github__get_pull_request',
+				{ method: 'POST', body: { title: 'changed' } },
+			),
+		).rejects.toThrow(/read-only and fail-closed/i);
+	});
+
+	test('permits only a narrow post-bind remote-tracking fetch', async () => {
+		await activatePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW', {
+			prHeadSha: HEAD_SHA,
+		});
+		await expect(
+			enforcePrWorkflowToolBefore(tempDir, SESSION_ID, 'shell', {
+				command: 'git fetch origin feature/pr-head',
+			}),
+		).resolves.toBeUndefined();
+		for (const command of [
+			'git fetch --force origin feature/pr-head',
+			'git fetch origin feature/pr-head:local-copy',
+			'git fetch origin feature/pr-head && git checkout feature/pr-head',
+			'git checkout feature/pr-head',
+		]) {
+			await expect(
+				enforcePrWorkflowToolBefore(tempDir, SESSION_ID, 'shell', {
+					command,
+				}),
+			).rejects.toThrow(/read-only and fail-closed/i);
+		}
+	});
+
+	test('admits the dedicated scope controller only in PR_FEEDBACK', async () => {
+		const feedbackSessionId = `${SESSION_ID}-feedback`;
+		await activatePrWorkflow(tempDir, feedbackSessionId, 'PR_FEEDBACK', {
+			prHeadSha: HEAD_SHA,
+		});
+		await expect(
+			enforcePrWorkflowToolBefore(
+				tempDir,
+				feedbackSessionId,
+				'prepare_pr_feedback_scope',
+				{ task_id: '1.1', files: ['src/index.ts'] },
+			),
+		).rejects.toThrow(/verification/i);
+		await expect(
+			enforcePrWorkflowToolBefore(
+				tempDir,
+				feedbackSessionId,
+				'write_pr_review_artifact',
+				{ kind: 'findings' },
+			),
+		).rejects.toThrow(/unclassified plugin\/MCP tools/i);
+	});
+});

--- a/tests/unit/hooks/pr-workflow-gate-capabilities.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-capabilities.test.ts
@@ -17,12 +17,19 @@ describe('PR workflow explicit capability contract', () => {
 		_test_exports.resolvePrWorkflowRevisionDigest;
 	const originalResolveIsWorkingTreeClean =
 		_test_exports.resolveIsWorkingTreeClean;
+	const originalResolveCurrentUpstreamPushTarget =
+		_test_exports.resolveCurrentUpstreamPushTarget;
 
 	beforeEach(() => {
 		_test_exports.resetTrackedStateCache();
 		_test_exports.resolveCurrentGitHead = () => HEAD_SHA;
 		_test_exports.resolvePrWorkflowRevisionDigest = () => REVISION_DIGEST;
 		_test_exports.resolveIsWorkingTreeClean = () => true;
+		_test_exports.resolveCurrentUpstreamPushTarget = () => ({
+			remoteName: 'origin',
+			remoteBranchRef: 'refs/heads/feature/pr-head',
+			remoteTrackingRef: 'refs/remotes/origin/feature/pr-head',
+		});
 	});
 
 	afterEach(() => {
@@ -31,6 +38,8 @@ describe('PR workflow explicit capability contract', () => {
 		_test_exports.resolvePrWorkflowRevisionDigest =
 			originalResolvePrWorkflowRevisionDigest;
 		_test_exports.resolveIsWorkingTreeClean = originalResolveIsWorkingTreeClean;
+		_test_exports.resolveCurrentUpstreamPushTarget =
+			originalResolveCurrentUpstreamPushTarget;
 	});
 
 	test('admits required PR_REVIEW observation and safe validation tools', async () => {
@@ -87,7 +96,7 @@ describe('PR workflow explicit capability contract', () => {
 		).rejects.toThrow(/read-only and fail-closed/i);
 	});
 
-	test('permits only a narrow post-bind remote-tracking fetch', async () => {
+	test('RT-001 regression: permits only the exact bound post-bind tracking fetch', async () => {
 		await activatePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW', {
 			prHeadSha: HEAD_SHA,
 		});
@@ -97,6 +106,8 @@ describe('PR workflow explicit capability contract', () => {
 			}),
 		).resolves.toBeUndefined();
 		for (const command of [
+			'git fetch untrusted-remote feature/pr-head',
+			'git fetch origin unrelated-branch',
 			'git fetch --force origin feature/pr-head',
 			'git fetch origin feature/pr-head:local-copy',
 			'git fetch origin feature/pr-head && git checkout feature/pr-head',
@@ -108,6 +119,17 @@ describe('PR workflow explicit capability contract', () => {
 				}),
 			).rejects.toThrow(/read-only and fail-closed/i);
 		}
+	});
+
+	test('PWR-001 regression: blocks build_check because it can execute PR-controlled scripts', async () => {
+		await activatePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW', {
+			prHeadSha: HEAD_SHA,
+		});
+		await expect(
+			enforcePrWorkflowToolBefore(tempDir, SESSION_ID, 'build_check', {
+				scope: 'all',
+			}),
+		).rejects.toThrow(/read-only and fail-closed/i);
 	});
 
 	test('admits the dedicated scope controller only in PR_FEEDBACK', async () => {

--- a/tests/unit/skills/plan-and-feedback-acceptance-coverage.test.ts
+++ b/tests/unit/skills/plan-and-feedback-acceptance-coverage.test.ts
@@ -45,20 +45,19 @@ describe('.opencode/skills/plan/SKILL.md ACCEPTANCE coverage (issue: architect-a
 });
 
 describe('.opencode/skills/swarm-pr-feedback/SKILL.md ACCEPTANCE coverage (issue: architect-acceptance-criteria)', () => {
-	it('direct-Task coder carve-out carries an ACCEPTANCE reminder', () => {
-		// The carve-out sanctions Task(subagent_type="<coder>", ...) without
-		// declare_scope. The dispatch is still gated by ACCEPTANCE_FIELD_REQUIRED.
-		const idx = feedbackContent.indexOf('Carve-out for direct Task delegation');
+	it('dedicated feedback scope controller requires matching Task directives and acceptance', () => {
+		const idx = feedbackContent.indexOf(
+			"When the plugin's mechanical controller is available",
+		);
 		expect(idx).toBeGreaterThan(-1);
-		// Slice to the next `##` markdown header rather than a cosmetic bold
-		// marker (e.g. `**Anti-pattern:**`) so the test is robust to harmless
-		// rebolding of unrelated section labels.
 		const next = feedbackContent.indexOf('\n## ', idx);
 		expect(next).toBeGreaterThan(idx);
 		const block = feedbackContent.slice(idx, next);
+		expect(block).toContain('prepare_pr_feedback_scope({ task_id, files })');
+		expect(block).toContain('matching `FILE:` directives');
+		expect(block).toContain('literal `ACCEPTANCE:` line');
 		expect(block).toContain(
-			'direct Task dispatch MUST contain a literal `ACCEPTANCE:` line',
+			'There is no one-file or single-function carve-out',
 		);
-		expect(block).toContain('ACCEPTANCE_FIELD_REQUIRED');
 	});
 });

--- a/tests/unit/skills/swarm-pr-review-dispatch-guidance.test.ts
+++ b/tests/unit/skills/swarm-pr-review-dispatch-guidance.test.ts
@@ -148,10 +148,10 @@ describe('swarm-pr-review deterministic async lane dispatch guidance', () => {
 			'Fall back to blocking `dispatch_lanes` when async launch is unavailable',
 		);
 		expect(handoffSection).toContain(
-			'.swarm/pr-review/<run_id>/feedback-handoff.md',
+			'.swarm/pr-review/<run_id>/feedback-handoff.json',
 		);
 		expect(handoffSection).toContain(
-			'/swarm pr-feedback <PR_URL> continue from .swarm/pr-review/<run_id>/feedback-handoff.md',
+			'/swarm pr-feedback <PR_URL> continue from .swarm/pr-review/<run_id>/feedback-handoff.json',
 		);
 		expect(handoffSection).toContain('stop and ask the user');
 		expect(mergeabilitySection).toContain('remains read-only');

--- a/tests/unit/tools/prepare-pr-feedback-scope.test.ts
+++ b/tests/unit/tools/prepare-pr-feedback-scope.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, realpathSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { storeLaneOutput } from '../../../src/background/lane-output-store.js';
+import {
+	appendDelegationTransition,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations.js';
+import {
+	_test_exports,
+	activatePrWorkflow,
+	declarePrFeedbackInventory,
+	enforcePrFeedbackVerificationOwnership,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	createScopeGuardHook,
+	_internals as scopeGuardInternals,
+} from '../../../src/hooks/scope-guard.js';
+import { clearScopeBindings } from '../../../src/scope/scope-binding.js';
+import { ensureAgentSession, resetSwarmState } from '../../../src/state.js';
+import { executePreparePrFeedbackScope } from '../../../src/tools/prepare-pr-feedback-scope.js';
+import { installLegacyScopeGuardTargetSeam } from '../../helpers/scope-guard-binding-seam';
+import {
+	createDelegationGateHook,
+	makeConfig,
+} from '../../unit/hooks/_delegation-gate-helpers';
+
+const SESSION_ID = 'prepare-pr-feedback-scope';
+const HEAD_SHA = 'abc123';
+const REVISION_DIGEST = 'revision-1';
+
+let directory = '';
+const originalResolveCurrentGitHead = _test_exports.resolveCurrentGitHead;
+const originalResolveRevisionDigest =
+	_test_exports.resolvePrWorkflowRevisionDigest;
+const originalResolveIsWorkingTreeClean =
+	_test_exports.resolveIsWorkingTreeClean;
+
+beforeEach(() => {
+	clearScopeBindings();
+	resetSwarmState();
+	directory = realpathSync(
+		mkdtempSync(path.join(os.tmpdir(), 'prepare-pr-feedback-scope-')),
+	);
+	_test_exports.resetTrackedStateCache();
+	_test_exports.resolveCurrentGitHead = () => HEAD_SHA;
+	_test_exports.resolvePrWorkflowRevisionDigest = () => REVISION_DIGEST;
+	_test_exports.resolveIsWorkingTreeClean = () => true;
+});
+
+afterEach(async () => {
+	_test_exports.resetTrackedStateCache();
+	clearScopeBindings();
+	resetSwarmState();
+	_test_exports.resolveCurrentGitHead = originalResolveCurrentGitHead;
+	_test_exports.resolvePrWorkflowRevisionDigest = originalResolveRevisionDigest;
+	_test_exports.resolveIsWorkingTreeClean = originalResolveIsWorkingTreeClean;
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+async function persistPrFeedbackBatch(
+	batchId: string,
+	mode: string,
+	lanes: ReadonlyArray<{ laneId: string; workflowLane: string }>,
+	text: string,
+): Promise<void> {
+	for (const [index, lane] of lanes.entries()) {
+		const correlationId = `${batchId}-${index}`;
+		await recordPendingDelegation(directory, {
+			correlationId,
+			jobId: null,
+			subagentSessionId: correlationId,
+			parentSessionId: SESSION_ID,
+			callID: `call-${correlationId}`,
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId,
+			laneId: lane.laneId,
+			mode,
+			workflowLane: lane.workflowLane,
+			workspace: {
+				directory,
+				gitHead: HEAD_SHA,
+				dirtyHash: null,
+				prHeadSha: HEAD_SHA,
+				scope: null,
+			},
+		});
+		const stored = storeLaneOutput(directory, {
+			batchId,
+			laneId: lane.laneId,
+			agent: 'reviewer',
+			role: 'reviewer',
+			sessionId: correlationId,
+			parentSessionId: SESSION_ID,
+			mode,
+			workflowLane: lane.workflowLane,
+			prHeadSha: HEAD_SHA,
+			gitHead: HEAD_SHA,
+			revisionDigest: REVISION_DIGEST,
+			source: 'collect_lane_results',
+			text,
+		});
+		await appendDelegationTransition(directory, correlationId, {
+			status: 'completed',
+			result: {
+				text,
+				chars: stored.chars,
+				truncated: false,
+				digest: stored.digest,
+				...(stored.ref ? { outputRef: stored.ref } : {}),
+			},
+		});
+	}
+}
+
+describe('prepare_pr_feedback_scope', () => {
+	test('enables a planless coder Task and scope-guard blocks out-of-scope writes', async () => {
+		await activatePrWorkflow(directory, SESSION_ID, 'PR_FEEDBACK', {
+			prHeadSha: HEAD_SHA,
+		});
+		await declarePrFeedbackInventory(directory, SESSION_ID, ['FB-001'], {
+			prHeadSha: HEAD_SHA,
+		});
+		await enforcePrFeedbackVerificationOwnership(
+			directory,
+			SESSION_ID,
+			[{ laneId: 'verify-scope', ownedItemIds: ['FB-001'] }],
+			{ batchId: 'feedback-scope', prHeadSha: HEAD_SHA },
+		);
+		await persistPrFeedbackBatch(
+			'feedback-scope',
+			'swarm-pr-feedback:verification',
+			[{ laneId: 'verify-scope', workflowLane: 'verify-scope' }],
+			'[FEEDBACK-VERIFIED] | FB-001 | CONFIRMED | evidence',
+		);
+
+		const prepared = JSON.parse(
+			await executePreparePrFeedbackScope(
+				{ task_id: '1.1', files: ['src/index.ts'] },
+				directory,
+				{ sessionID: SESSION_ID },
+			),
+		) as { success: boolean; task_id: string; files: string[] };
+		expect(prepared).toMatchObject({
+			success: true,
+			task_id: '1.1',
+			files: ['src/index.ts'],
+		});
+
+		ensureAgentSession(SESSION_ID, 'architect', directory);
+		const delegationGate = createDelegationGateHook(makeConfig(), directory);
+		await expect(
+			delegationGate.toolBefore(
+				{ tool: 'Task', sessionID: SESSION_ID, callID: 'feedback-task' },
+				{
+					args: {
+						subagent_type: 'coder',
+						task_id: '1.1',
+						prompt:
+							'TASK: 1.1\nFILE: src/index.ts\nACCEPTANCE: repair the feedback-scoped bug',
+					},
+				},
+			),
+		).resolves.toBeUndefined();
+		await delegationGate.taskMetadata({
+			callID: 'feedback-task',
+			parentSessionID: SESSION_ID,
+			childSessionID: 'feedback-child',
+		});
+
+		const restoreTargets =
+			installLegacyScopeGuardTargetSeam(scopeGuardInternals);
+		try {
+			const scopeGuard = createScopeGuardHook(
+				{ enabled: true, skip_in_turbo: false },
+				directory,
+			);
+			await expect(
+				scopeGuard.toolBefore(
+					{
+						tool: 'apply_patch',
+						sessionID: 'feedback-child',
+						callID: 'write-allowed',
+					},
+					{ args: { path: 'src/index.ts' } },
+				),
+			).resolves.toBeUndefined();
+			await expect(
+				scopeGuard.toolBefore(
+					{
+						tool: 'apply_patch',
+						sessionID: 'feedback-child',
+						callID: 'write-blocked',
+					},
+					{ args: { path: 'src/other.ts' } },
+				),
+			).rejects.toThrow('SCOPE VIOLATION');
+		} finally {
+			restoreTargets();
+		}
+	});
+});

--- a/tests/unit/tools/write-pr-review-artifact.test.ts
+++ b/tests/unit/tools/write-pr-review-artifact.test.ts
@@ -190,7 +190,7 @@ async function establishPrReviewPrerequisites(): Promise<void> {
 }
 
 describe('write_pr_review_artifact', () => {
-	test('validates exact discovery coverage and reviewer phase before writing', async () => {
+	test('ARTIFACT-ORDER regression: requires explorer, reviewer, then critic checkpoints', async () => {
 		await establishPrReviewPrerequisites();
 		const candidateIds = PR_REVIEW_BASE_DIMENSION_IDS.map(
 			(_dimension, index) => `C-${index}`,
@@ -215,6 +215,19 @@ describe('write_pr_review_artifact', () => {
 				{ sessionID: SESSION_ID },
 			),
 		).rejects.toThrow(/exactly cover/i);
+		await expect(
+			executeWritePrReviewArtifact(
+				{
+					kind: 'findings',
+					run_id: 'coverage-order',
+					pr_head_sha: HEAD_SHA,
+					boundary: 'post_reviewer',
+					records: explorerRecords,
+				},
+				directory,
+				{ sessionID: SESSION_ID },
+			),
+		).rejects.toThrow(/prior post_explorer checkpoint/i);
 		await expect(
 			fs.stat(path.join(directory, '.swarm', 'pr-review', 'coverage-order')),
 		).rejects.toThrow();
@@ -246,7 +259,7 @@ describe('write_pr_review_artifact', () => {
 		).rejects.toThrow(/reviewer/i);
 	});
 
-	test('persists all boundaries and exact actionable handoff before completion', async () => {
+	test('ARTIFACT-VERDICT regression: persists only reviewer and critic-authoritative dispositions', async () => {
 		await establishPrReviewPrerequisites();
 		const candidateIds = PR_REVIEW_BASE_DIMENSION_IDS.map(
 			(_dimension, index) => `C-${index}`,
@@ -258,25 +271,33 @@ describe('write_pr_review_artifact', () => {
 			evidence: 'discovery evidence',
 			next_action: 'route_to_reviewer' as const,
 		}));
-		const reviewerRecords = candidateIds.map((id) => ({
+		const reviewerRecords = candidateIds.map((id, index) => ({
 			finding_id: id,
-			status: 'CONFIRMED' as const,
+			status: index === 0 ? ('DISPROVED' as const) : ('CONFIRMED' as const),
 			file_line: 'src/index.ts:1',
 			evidence: 'reviewer evidence',
-			next_action: 'route_to_critic' as const,
+			next_action:
+				index === 0
+					? ('suppress_with_reason' as const)
+					: ('route_to_critic' as const),
 		}));
 		const criticRecords = candidateIds.map((id, index) => ({
 			finding_id: id,
-			status: 'CONFIRMED' as const,
+			status: index === 0 ? ('DISPROVED' as const) : ('CONFIRMED' as const),
 			file_line: 'src/index.ts:1',
 			evidence: 'critic evidence',
 			next_action:
-				index === 0 ? ('handoff_to_feedback' as const) : ('report' as const),
+				index === 0
+					? ('suppress_with_reason' as const)
+					: index === 1
+						? ('handoff_to_feedback' as const)
+						: ('report' as const),
 		}));
 		const reviewerRows = candidateIds
-			.map(
-				(id) =>
-					`[REVIEWED] | ${id} | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer`,
+			.map((id, index) =>
+				index === 0
+					? `[REVIEWED] | ${id} | DISPROVED | STRUCTURALLY_PROVEN | LOW | YES | file.ts:1 | rationale | probe | reviewer`
+					: `[REVIEWED] | ${id} | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer`,
 			)
 			.join('\n');
 		await recordPrReviewValidationBatch(
@@ -309,7 +330,7 @@ describe('write_pr_review_artifact', () => {
 				{
 					laneId: 'critic-boundaries',
 					workflowLane: 'critic-boundaries',
-					reviewItemIds: candidateIds,
+					reviewItemIds: candidateIds.slice(1),
 				},
 			],
 			{ batchId: 'critic-boundaries', prHeadSha: HEAD_SHA },
@@ -334,6 +355,40 @@ describe('write_pr_review_artifact', () => {
 				{ sessionID: SESSION_ID },
 			),
 		).resolves.toContain('"success": true');
+		await expect(
+			executeWritePrReviewArtifact(
+				{
+					kind: 'findings',
+					run_id: 'review-boundaries',
+					pr_head_sha: HEAD_SHA,
+					boundary: 'post_reviewer',
+					records: reviewerRecords.map((record) => ({
+						...record,
+						status: 'DISPROVED' as const,
+						next_action: 'suppress_with_reason' as const,
+					})),
+				},
+				directory,
+				{ sessionID: SESSION_ID },
+			),
+		).rejects.toThrow(/status differs from its reviewer verdict/i);
+		await expect(
+			executeWritePrReviewArtifact(
+				{
+					kind: 'findings',
+					run_id: 'review-boundaries',
+					pr_head_sha: HEAD_SHA,
+					boundary: 'post_reviewer',
+					records: reviewerRecords.map((record, index) =>
+						index === 0
+							? { ...record, next_action: 'report' as const }
+							: record,
+					),
+				},
+				directory,
+				{ sessionID: SESSION_ID },
+			),
+		).rejects.toThrow(/action does not match reviewer disposition/i);
 
 		await expect(
 			executeWritePrReviewArtifact(
@@ -348,6 +403,23 @@ describe('write_pr_review_artifact', () => {
 				{ sessionID: SESSION_ID },
 			),
 		).resolves.toContain('"success": true');
+		await expect(
+			executeWritePrReviewArtifact(
+				{
+					kind: 'findings',
+					run_id: 'review-boundaries',
+					pr_head_sha: HEAD_SHA,
+					boundary: 'post_critic',
+					records: criticRecords.map((record) => ({
+						...record,
+						status: 'DISPROVED' as const,
+						next_action: 'suppress_with_reason' as const,
+					})),
+				},
+				directory,
+				{ sessionID: SESSION_ID },
+			),
+		).rejects.toThrow(/action does not match its critic verdict/i);
 
 		await expect(
 			executeWritePrReviewArtifact(
@@ -381,7 +453,7 @@ describe('write_pr_review_artifact', () => {
 			pr_head_sha: HEAD_SHA,
 			handoff: {
 				pr_url: 'https://github.com/example/project/pull/123',
-				finding_ids: ['C-0'],
+				finding_ids: ['C-1'],
 				summary: 'validated actionable finding',
 				provenance: ['review-boundaries', 'critic-boundaries'],
 			},
@@ -389,7 +461,7 @@ describe('write_pr_review_artifact', () => {
 		const wrongHandoff = await executeWritePrReviewArtifact(
 			{
 				...handoffArgs,
-				handoff: { ...handoffArgs.handoff, finding_ids: ['C-1'] },
+				handoff: { ...handoffArgs.handoff, finding_ids: ['C-0'] },
 			},
 			directory,
 			{ sessionID: SESSION_ID },

--- a/tests/unit/tools/write-pr-review-artifact.test.ts
+++ b/tests/unit/tools/write-pr-review-artifact.test.ts
@@ -1,0 +1,407 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, realpathSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { storeLaneOutput } from '../../../src/background/lane-output-store.js';
+import {
+	appendDelegationTransition,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations.js';
+import {
+	_test_exports,
+	activatePrWorkflow,
+	completePrWorkflow,
+	enforcePrReviewBaseDimensions,
+	markPrReviewTriggerEvaluationComplete,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	PR_REVIEW_REQUIRED_MICRO_LANE_IDS,
+	readPrWorkflowGateState,
+	recordPrReviewValidationBatch,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import { executeWritePrReviewArtifact } from '../../../src/tools/write-pr-review-artifact.js';
+
+const SESSION_ID = 'write-pr-review-artifact';
+const HEAD_SHA = 'abc123';
+const REVISION_DIGEST = 'revision-1';
+
+let directory = '';
+const originalResolveCurrentGitHead = _test_exports.resolveCurrentGitHead;
+const originalResolveRevisionDigest =
+	_test_exports.resolvePrWorkflowRevisionDigest;
+const originalResolveIsWorkingTreeClean =
+	_test_exports.resolveIsWorkingTreeClean;
+
+beforeEach(() => {
+	directory = realpathSync(
+		mkdtempSync(path.join(os.tmpdir(), 'write-pr-review-artifact-')),
+	);
+	_test_exports.resetTrackedStateCache();
+	_test_exports.resolveCurrentGitHead = () => HEAD_SHA;
+	_test_exports.resolvePrWorkflowRevisionDigest = () => REVISION_DIGEST;
+	_test_exports.resolveIsWorkingTreeClean = () => true;
+});
+
+afterEach(async () => {
+	_test_exports.resetTrackedStateCache();
+	_test_exports.resolveCurrentGitHead = originalResolveCurrentGitHead;
+	_test_exports.resolvePrWorkflowRevisionDigest = originalResolveRevisionDigest;
+	_test_exports.resolveIsWorkingTreeClean = originalResolveIsWorkingTreeClean;
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+async function persistPrReviewBatch(
+	batchId: string,
+	mode: string,
+	lanes: ReadonlyArray<{ laneId: string; workflowLane: string }>,
+	options: {
+		status?: 'completed' | 'error';
+		head?: string;
+		empty?: boolean;
+		textOverride?: string;
+		transcriptIncomplete?: boolean;
+		artifactRole?: string;
+		subagentSessionId?: string;
+	} = {},
+): Promise<void> {
+	for (const [index, lane] of lanes.entries()) {
+		const correlationId = `${batchId}-${index}`;
+		const subagentSessionId = options.subagentSessionId ?? correlationId;
+		await recordPendingDelegation(directory, {
+			correlationId,
+			jobId: null,
+			subagentSessionId,
+			parentSessionId: SESSION_ID,
+			callID: `call-${correlationId}`,
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId,
+			laneId: lane.laneId,
+			mode,
+			workflowLane: lane.workflowLane,
+			workspace: {
+				directory,
+				gitHead: HEAD_SHA,
+				dirtyHash: null,
+				prHeadSha: options.head ?? HEAD_SHA,
+				scope: null,
+			},
+		});
+		const text =
+			options.textOverride ??
+			(options.empty
+				? ''
+				: mode === 'swarm-pr-review:reviewer'
+					? '[REVIEWED] | C-001 | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer'
+					: mode === 'swarm-pr-review:critic'
+						? '[CRITIC] | C-001 | UPHELD | HIGH | reason | no change'
+						: mode === 'swarm-pr-feedback:verification'
+							? `[FEEDBACK-VERIFIED] | ${lane.workflowLane} | CONFIRMED | evidence`
+							: `[CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence_summary | impact_context | confidence\nC-${index} | ${lane.workflowLane} | HIGH | correctness | file.ts:1 | claim | evidence | impact | HIGH`);
+		const stored = storeLaneOutput(directory, {
+			batchId,
+			laneId: lane.laneId,
+			agent: 'reviewer',
+			role: options.artifactRole ?? 'reviewer',
+			sessionId: subagentSessionId,
+			parentSessionId: SESSION_ID,
+			mode,
+			workflowLane: lane.workflowLane,
+			prHeadSha: options.head ?? HEAD_SHA,
+			gitHead: HEAD_SHA,
+			revisionDigest: REVISION_DIGEST,
+			source: 'collect_lane_results',
+			text,
+			transcriptIncomplete: options.transcriptIncomplete,
+		});
+		await appendDelegationTransition(directory, correlationId, {
+			status: options.status ?? 'completed',
+			result: {
+				text,
+				chars: stored.chars,
+				truncated: false,
+				digest: stored.digest,
+				...(stored.ref ? { outputRef: stored.ref } : {}),
+				...(options.transcriptIncomplete ? { transcriptIncomplete: true } : {}),
+			},
+		});
+	}
+}
+
+async function establishPrReviewPrerequisites(): Promise<void> {
+	await activatePrWorkflow(directory, SESSION_ID, 'PR_REVIEW', {
+		prHeadSha: HEAD_SHA,
+	});
+	const baseLanes = PR_REVIEW_BASE_DIMENSION_IDS.map((workflowLane) => ({
+		laneId: workflowLane,
+		workflowLane,
+	}));
+	await enforcePrReviewBaseDimensions(directory, SESSION_ID, baseLanes, {
+		batchId: 'base-all',
+		prHeadSha: HEAD_SHA,
+	});
+	await persistPrReviewBatch('base-all', 'swarm-pr-review:base', baseLanes);
+	for (const [
+		index,
+		workflowLane,
+	] of PR_REVIEW_REQUIRED_MICRO_LANE_IDS.entries()) {
+		const batchId = `micro-${index}`;
+		const laneId = `micro-lane-${index}`;
+		await persistPrReviewBatch(
+			batchId,
+			'swarm-pr-review:micro',
+			[{ laneId, workflowLane }],
+			{
+				textOverride: `[CLEAN] | ${workflowLane} | exact reviewed diff | no finding after focused invariant review`,
+			},
+		);
+	}
+	const triggerRows: Array<Record<string, string>> = [];
+	for (const [
+		index,
+		workflowLane,
+	] of PR_REVIEW_REQUIRED_MICRO_LANE_IDS.entries()) {
+		triggerRows.push({
+			trigger_id: workflowLane,
+			result: 'MATCHED',
+			source_batch_id: `micro-${index}`,
+			source_lane_id: `micro-lane-${index}`,
+		});
+	}
+	const triggerRelative = path.join(
+		'pr-review',
+		'test-run',
+		'trigger-eval.json',
+	);
+	const triggerAbsolute = path.join(directory, '.swarm', triggerRelative);
+	await fs.mkdir(path.dirname(triggerAbsolute), { recursive: true });
+	await fs.writeFile(
+		triggerAbsolute,
+		JSON.stringify({ rows: triggerRows }),
+		'utf-8',
+	);
+	await markPrReviewTriggerEvaluationComplete(
+		directory,
+		SESSION_ID,
+		triggerRelative,
+	);
+}
+
+describe('write_pr_review_artifact', () => {
+	test('validates exact discovery coverage and reviewer phase before writing', async () => {
+		await establishPrReviewPrerequisites();
+		const candidateIds = PR_REVIEW_BASE_DIMENSION_IDS.map(
+			(_dimension, index) => `C-${index}`,
+		);
+		const explorerRecords = candidateIds.map((id) => ({
+			finding_id: id,
+			status: 'PENDING' as const,
+			file_line: 'src/index.ts:1',
+			evidence: 'discovery evidence',
+			next_action: 'route_to_reviewer' as const,
+		}));
+		await expect(
+			executeWritePrReviewArtifact(
+				{
+					kind: 'findings',
+					run_id: 'coverage-order',
+					pr_head_sha: HEAD_SHA,
+					boundary: 'post_explorer',
+					records: explorerRecords.slice(0, -1),
+				},
+				directory,
+				{ sessionID: SESSION_ID },
+			),
+		).rejects.toThrow(/exactly cover/i);
+		await expect(
+			fs.stat(path.join(directory, '.swarm', 'pr-review', 'coverage-order')),
+		).rejects.toThrow();
+		await expect(
+			executeWritePrReviewArtifact(
+				{
+					kind: 'findings',
+					run_id: 'coverage-order',
+					pr_head_sha: HEAD_SHA,
+					boundary: 'post_explorer',
+					records: explorerRecords,
+				},
+				directory,
+				{ sessionID: SESSION_ID },
+			),
+		).resolves.toContain('"success": true');
+		await expect(
+			executeWritePrReviewArtifact(
+				{
+					kind: 'findings',
+					run_id: 'coverage-order',
+					pr_head_sha: HEAD_SHA,
+					boundary: 'post_reviewer',
+					records: explorerRecords,
+				},
+				directory,
+				{ sessionID: SESSION_ID },
+			),
+		).rejects.toThrow(/reviewer/i);
+	});
+
+	test('persists all boundaries and exact actionable handoff before completion', async () => {
+		await establishPrReviewPrerequisites();
+		const candidateIds = PR_REVIEW_BASE_DIMENSION_IDS.map(
+			(_dimension, index) => `C-${index}`,
+		);
+		const explorerRecords = candidateIds.map((id) => ({
+			finding_id: id,
+			status: 'PENDING' as const,
+			file_line: 'src/index.ts:1',
+			evidence: 'discovery evidence',
+			next_action: 'route_to_reviewer' as const,
+		}));
+		const reviewerRecords = candidateIds.map((id) => ({
+			finding_id: id,
+			status: 'CONFIRMED' as const,
+			file_line: 'src/index.ts:1',
+			evidence: 'reviewer evidence',
+			next_action: 'route_to_critic' as const,
+		}));
+		const criticRecords = candidateIds.map((id, index) => ({
+			finding_id: id,
+			status: 'CONFIRMED' as const,
+			file_line: 'src/index.ts:1',
+			evidence: 'critic evidence',
+			next_action:
+				index === 0 ? ('handoff_to_feedback' as const) : ('report' as const),
+		}));
+		const reviewerRows = candidateIds
+			.map(
+				(id) =>
+					`[REVIEWED] | ${id} | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer`,
+			)
+			.join('\n');
+		await recordPrReviewValidationBatch(
+			directory,
+			SESSION_ID,
+			'reviewer',
+			[
+				{
+					laneId: 'review-boundaries',
+					workflowLane: 'review-boundaries',
+					reviewItemIds: candidateIds,
+				},
+			],
+			{ batchId: 'review-boundaries', prHeadSha: HEAD_SHA },
+		);
+		await persistPrReviewBatch(
+			'review-boundaries',
+			'swarm-pr-review:reviewer',
+			[{ laneId: 'review-boundaries', workflowLane: 'review-boundaries' }],
+			{ textOverride: reviewerRows },
+		);
+		const criticRows = candidateIds
+			.map((id) => `[CRITIC] | ${id} | UPHELD | HIGH | reason | no change`)
+			.join('\n');
+		await recordPrReviewValidationBatch(
+			directory,
+			SESSION_ID,
+			'critic',
+			[
+				{
+					laneId: 'critic-boundaries',
+					workflowLane: 'critic-boundaries',
+					reviewItemIds: candidateIds,
+				},
+			],
+			{ batchId: 'critic-boundaries', prHeadSha: HEAD_SHA },
+		);
+		await persistPrReviewBatch(
+			'critic-boundaries',
+			'swarm-pr-review:critic',
+			[{ laneId: 'critic-boundaries', workflowLane: 'critic-boundaries' }],
+			{ textOverride: criticRows },
+		);
+
+		await expect(
+			executeWritePrReviewArtifact(
+				{
+					kind: 'findings',
+					run_id: 'review-boundaries',
+					pr_head_sha: HEAD_SHA,
+					boundary: 'post_explorer',
+					records: explorerRecords,
+				},
+				directory,
+				{ sessionID: SESSION_ID },
+			),
+		).resolves.toContain('"success": true');
+
+		await expect(
+			executeWritePrReviewArtifact(
+				{
+					kind: 'findings',
+					run_id: 'review-boundaries',
+					pr_head_sha: HEAD_SHA,
+					boundary: 'post_reviewer',
+					records: reviewerRecords,
+				},
+				directory,
+				{ sessionID: SESSION_ID },
+			),
+		).resolves.toContain('"success": true');
+
+		await expect(
+			executeWritePrReviewArtifact(
+				{
+					kind: 'findings',
+					run_id: 'review-boundaries',
+					pr_head_sha: HEAD_SHA,
+					boundary: 'post_critic',
+					records: criticRecords,
+				},
+				directory,
+				{ sessionID: SESSION_ID },
+			),
+		).resolves.toContain('"success": true');
+
+		await expect(
+			readPrWorkflowGateState(directory, SESSION_ID),
+		).resolves.toMatchObject({
+			prReviewArtifactRunId: 'review-boundaries',
+			prReviewFindingsPath: 'pr-review/review-boundaries/findings.jsonl',
+			prReviewArtifactBoundaries: [
+				'post_explorer',
+				'post_reviewer',
+				'post_critic',
+			],
+		});
+
+		const handoffArgs = {
+			kind: 'handoff' as const,
+			run_id: 'review-boundaries',
+			pr_head_sha: HEAD_SHA,
+			handoff: {
+				pr_url: 'https://github.com/example/project/pull/123',
+				finding_ids: ['C-0'],
+				summary: 'validated actionable finding',
+				provenance: ['review-boundaries', 'critic-boundaries'],
+			},
+		};
+		const wrongHandoff = await executeWritePrReviewArtifact(
+			{
+				...handoffArgs,
+				handoff: { ...handoffArgs.handoff, finding_ids: ['C-1'] },
+			},
+			directory,
+			{ sessionID: SESSION_ID },
+		);
+		expect(wrongHandoff).toContain('"success": false');
+		await expect(
+			executeWritePrReviewArtifact(handoffArgs, directory, {
+				sessionID: SESSION_ID,
+			}),
+		).resolves.toContain('feedback-handoff.json');
+		await expect(
+			completePrWorkflow(directory, SESSION_ID, 'PR_REVIEW', HEAD_SHA),
+		).resolves.toBe('completed');
+	});
+});


### PR DESCRIPTION
## Summary

- Harden PR-review gate capabilities: `build_check` is no longer admitted in review mode, post-bind fetches must match the bound upstream remote and branch, and persisted artifacts must follow explorer → reviewer → critic checkpoints and authenticated verdicts.
- Repair stale PR-workflow skill assertions to match the JSON feedback handoff and mechanical feedback-scope contract.
- Consolidate sync/async config loading through one recovery core; surface stripped gates metadata and warnings; preserve `full_auto.locked` as a hard-off OR merge; add recovery/parity coverage including `turbo.epic` typo recovery.
- Correct the doctor recovery fixtures to use valid `gates.syntax_check` configuration while retaining explicit nested-key recovery coverage.

## Invariant audit

- 1 (plugin init): touched — async config loading continues to use the shared recovery core; `bun run repro:704` passed T1 in 239.7 ms (under 400 ms).
- 2 (runtime portability): touched — build, Node ESM import, bundle portability, and plugin-shape checks passed.
- 3 (subprocesses): not touched — no subprocess implementation changed.
- 4 (.swarm containment): touched — PR-review artifact state remains under the project-root `.swarm/` contract; artifact tests passed.
- 5 (plan durability): not touched — no plan ledger or projection path changed.
- 6 (test_runner safety): not touched — validation used explicit shell test commands only.
- 7 (test writing): touched — focused `bun:test` regressions cover gate/artifact and loader recovery paths, including valid doctor gate fixtures; every touched test file is under 500 lines.
- 8 (session state): touched — review artifact validation remains session-bound; focused gate tests passed.
- 9 (guardrails/retry): touched — fail-secure loader recovery and review-gate fail-closed behavior are tested.
- 10 (chat/system msg): not touched — no chat hook changed.
- 11 (tool registration): touched — tool metadata changed; `bun run scripts/check-tool-registration.ts` passed (111 tools).
- 12 (release/cache): touched — added `docs/releases/pending/1900-loader-sync-async-parity-locked-or-gates-metadata.md`.

## Test plan

- [x] `bun run build`, `bun run typecheck`, `bun run lint:ci`, `bun run drift:check`, `bun run scripts/check-tool-registration.ts`, `git diff --check`
- [x] `bun run package:smoke`; `bun run repro:704`; Node ESM import; bundle portability/plugin-shape tests
- [x] Loader suites: 74 tests across loader, strict-recovery, metadata, and sync/async parity (including `turbo.epic`)
- [x] Doctor recovery suite: 5 focused tests, including a schema-valid clean config, nested-gates stripping, and user-only fallback
- [x] PR workflow suites: gate capabilities (5), review validation (9), artifact writer (2), and skill-contract tests (7), run in isolated Bun processes
- [x] Independent Stage B reviewer, Stage B test engineer, closeout reviewer, and closeout critic approved all 15 feedback items plus `turbo.epic` scenario preservation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
