### PR TITLE
fix(tests): retire stability quarantine backlog

### DIFF
--- a/.opencode/skills/issue-tracer/scripts/trace-init.sh
+++ b/.opencode/skills/issue-tracer/scripts/trace-init.sh
@@ -15,6 +15,22 @@ set -eu
 # strict ASCII-only ranges regardless of the invoking environment.
 export LC_ALL=C
 
+# Native Git for Windows prints drive-qualified paths (C:/...) even when it is
+# invoked from MSYS/Git Bash. Coreutils do not consistently interpret that form
+# as absolute in restricted/non-login shells, so normalize Git-reported paths
+# before passing them to cd, mkdir, or redirection. POSIX hosts are unchanged.
+to_shell_path() {
+  case "$(uname -s 2>/dev/null || true)" in
+    MINGW* | MSYS* | CYGWIN*)
+      if command -v cygpath >/dev/null 2>&1; then
+        cygpath -u "$1"
+        return
+      fi
+      ;;
+  esac
+  printf '%s\n' "$1"
+}
+
 slug="${1:-}"
 if [ -z "$slug" ]; then
   echo "usage: trace-init.sh <issue-slug>" >&2
@@ -37,6 +53,7 @@ root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
   echo "trace-init: not inside a git work tree — run this from within the target repository" >&2
   exit 2
 }
+root="$(to_shell_path "$root")"
 root_real="$(cd "$root" && pwd -P)"
 trace_dir="$root/.agents/issue-traces/$slug"
 
@@ -88,10 +105,13 @@ if [ -z "$git_dir" ]; then
     echo "trace-init: could not resolve the git directory" >&2
     exit 2
   }
+  git_dir="$(to_shell_path "$git_dir")"
   case "$git_dir" in
     /*) ;; # already absolute
     *) git_dir="$(pwd)/$git_dir" ;;
   esac
+else
+  git_dir="$(to_shell_path "$git_dir")"
 fi
 exclude_file="$git_dir/info/exclude"
 entry='.agents/issue-traces/'

--- a/docs/audits/test-stability-audit.md
+++ b/docs/audits/test-stability-audit.md
@@ -1,66 +1,95 @@
-# Test-Stability Audit — opencode-swarm
+# Test-stability audit — issue #1908 resolution
 
-> Deliverable artifact (issue #1782, Phase 0). Lives under `docs/audits/` as a
-> version-controlled record of the known flaky-test inventory. The contributor
-> runbook is at `docs/testing/test-stability.md`.
+> Version-controlled inventory for the merge-group flake backlog consolidated by
+> issue #1908. The systemic detection and soak program remains tracked by #1782;
+> the contributor runbook is `docs/testing/test-stability.md`.
 
-## Summary statistics
+## Current status
 
-- **Total known flaky tests (from issue #1782 audit baseline):** 7
-- **By root-cause class:**
-  - Class 1 (time-sensitive): 2 (#1 skill-scoring-e2e, #3 cross-process-scope) + suspected #5 (skill-scoring-workflow)
-  - Class 2 (coverage sensitivity): 3 (#1, #4 swarm-artifact-cache, #6 test-runner Pester)
-  - Class 3 (cross-platform runtime): 2 (#2 infra runner starvation, #4 Windows bun exit-code)
-  - Class 4 (subprocess/env): 1 (#6 test-runner Pester)
-- **By quarantine status:** 4 quarantined (#4, #5, + 4 macOS lean-turbo in macos list), 3 fixed-at-root (#1, #2/#3, #6 Pester case-gated).
+- Tracked files investigated: **19** (9 ordinary candidates and 10 quarantined files).
+- Active global quarantines: **0**.
+- Active macOS-only quarantines: **0**.
+- Active integration quarantines: **0**.
+- Validation rule: an empty quarantine list is not proof by itself. Changes to
+  `scripts/` force the pull request's full Ubuntu/macOS/Windows unit matrix, and
+  merge-group validation owns the integration/coverage/smoke proof.
 
-## Flake inventory
+## Resolution inventory
 
-| # | Test file | Test / area | Root-cause class | First/last seen | Proposed fix | Quarantined? | Status |
-|---|-----------|-------------|------------------|-----------------|--------------|--------------|--------|
-| 1 | `tests/unit/hooks/skill-scoring-e2e.test.ts` | "scoring results are deterministic" / "idempotency" | 1, 2 | 2026-07-08/09 | Freeze `Date.now()` | No | **FIXED** — migrated to `withFrozenClock` (PR #1784) |
-| 2 | merge-group `quality`+`rust-sandbox-runner` jobs | n/a (infra) | 3 | 2026-07-08/10 | n/a (transient infra) | No | Infra — not a test flake; retry handles it |
-| 3 | `tests/integration/cross-process-scope.test.ts` | "TTL of zero is treated as already expired" | 1 | 2026-07-08 | `now >= expiresAt` (was `>`) | No | **FIXED** — `src/scope/scope-persistence.ts:295` (PR #1767) |
-| 4 | `tests/unit/utils/swarm-artifact-cache.test.ts` | whole file (Windows bun exit-code quirk) | 2, 3 | 2026-07-09 | bun/Windows quirk | **Yes** (`quarantined-tests.txt`) + per-case `skipIf` | Quarantined (double-protected) |
-| 5 | `tests/unit/hooks/skill-scoring-workflow.test.ts` | `computeSkillRelevanceScore` workflow boost | 1 (suspected) | 2026-07-09 | Freeze clock | **Yes** (`quarantined-tests.txt`) | **FIXED (PR #1784)** — wrapped in `withFrozenClock`; STAYS quarantined until merge-group confirms green (plan critic H1) |
-| 6 | `tests/unit/tools/test-runner.test.ts` | Pester convention-scope case (~L543) | 2, 4 | 2026-07-09 | gate on `hasPwsh` | No (case-gated) | **FIXED** — `test.skipIf(!hasPwsh)` guards the subprocess case |
-| 7 | (unknown — the "next to surface") | unknown | unknown | future | TBD | — | Addressed structurally by the flake-detection workflow (PR #1784) |
+| Test or cluster | Resolution | Evidence source |
+| --- | --- | --- |
+| `pr-monitor-status.test.ts` | Cross-session CLI state fixed | `53b7fb90` |
+| `stale-delegation-guard.test.ts` | Exact-boundary clock frozen | `7ab0a109` |
+| `update-command.test.ts` | Cross-platform path depth fixed; security fixtures now use unprivileged Windows junctions | `39c97866`, #1908 |
+| `knowledge-query.test.ts` | Scope-filter regression fixed | `5480cd62` |
+| `path-security.test.ts` | Drive-letter fallback fixed; asymmetric existence is simulated through a restored DI seam instead of writing to a drive root | `36bea060`, #1908 |
+| `knowledge-injector-shown-set.test.ts` | Real-host identity and receipt accounting fixed | `554d4972` |
+| `check-gate-status.gates.test.ts` | Platform-specific safe-miss categories accepted | `4fbcb7f4`, #1908 |
+| `suggest-patch.adversarial.test.ts` | Nonexistent-target containment fixed | `4fbcb7f4` |
+| `test-impact.adversarial.test.ts` | Windows separators normalized in every sibling assertion | `4fbcb7f4`, `d47d4e4e` |
+| `swarm-artifact-cache.test.ts` | Platform assertion semantics fixed; cleanup now retries transient Windows handle contention | `980e4a72`, #1908 |
+| `skill-scoring-workflow.test.ts` | Time-dependent workflow score frozen | `3c3bbadb` |
+| `test-runner.test.ts` | Pester test gates on the complete capability, not merely `pwsh` presence | #1908 |
+| `test-runner-impact.adversarial.test.ts` | Leaking module mocks replaced with restored dependency seams | #1908 |
+| `finalize-reward-sweep-multi-runid.test.ts` | Reward propagation uses the deterministic reward timestamp for recency | `e453e4c5` |
+| four Lean Turbo macOS tests | Removed from quarantine and required to execute in exact-head macOS CI | #1908 three-OS matrix |
+| `phase-complete-events*.test.ts` | Event-focused fixtures disable unrelated knowledge and curator pipelines | #1908 |
+| `unified-injection-budget.test.ts` | Fixture uses valid host messages/identity and a canonical external temp root | #1908 |
 
-### macOS-only quarantined (not in the issue's baseline, but related — issue #1729 follow-up)
+## Adjacent current-main recurrence
 
-| Test file | Root cause | Status |
-|-----------|-----------|--------|
-| `tests/unit/turbo/lean/integration-worktree.test.ts` | macOS lane-provisioning (provisionWorktree mock not called) | Quarantined (`quarantined-tests-macos.txt`) — needs macOS env to diagnose |
-| `tests/unit/turbo/lean/retroactive-adversarial.test.ts` | same cluster | Quarantined |
-| `tests/unit/turbo/lean/runner.adversarial.test.ts` | same cluster | Quarantined |
-| `tests/unit/turbo/lean/runner.test.ts` | same cluster | Quarantined |
+After the #1908 branch was rebased, the current `main` gates exposed four
+shell-script test files that resolved bare `bash` to the Windows WSL relay, two
+fixtures that still required privileged symbolic links, and three integration
+assertions that assumed POSIX paths, a stale TypeScript label, or an executable
+Unix package shim. The shell tests now share a Git-installation-derived Bash
+resolver, use bounded non-interactive spawns, and normalize native Git paths
+for MSYS coreutils. Link fixtures use unprivileged junctions or hard links on
+Windows, and integration fixtures resolve host-specific paths and binaries:
 
-## Priority ranking
+- `trace-init.test.ts`
+- `scan-deferred.test.ts`
+- `check-test-file-cap.test.ts`
+- `check-test-tmpdir-project-relative.test.ts`
+- `reset-backup.test.ts`
+- `delegation-gate-worktree-isolation.lane-teardown-fr205.supplemental.test.ts`
+- `issue-629-skill-improver.test.ts`
+- `lang/prompt-injection.test.ts`
+- `pre-check-batch.test.ts`
+- `subprocess-injection*.test.ts`
+- `checkpoint-schema-adversarial.test.ts`
 
-- **P0 (blocking the queue right now):** none remaining after this PR — the
-  systemic fixes (freezeClock + detection + lint) address the recurring class.
-- **P1 (next most likely to surface):** #5 (skill-scoring-workflow) if the
-  freeze proves incomplete cross-platform; the 4 macOS lean-turbo tests.
-- **P2 (latent/rare):** #2 (infra runner starvation — transient, retried).
+This adjacent recurrence repair does not change the original 19-file backlog
+count above; it prevents newly landed tests from reintroducing the same
+capability-detection and host-privilege failure classes while #1908 is open.
 
-## Acceptance-criteria status (issue #1782 §10)
+## Recurrence prevention
 
-This PR (partial delivery of the 6-phase sprint) meets the criteria achievable
-without elapsed wall-clock; the rest are explicitly tracked as open:
+- `scripts/check-test-tmpdir.sh` now rejects newly added project-relative test
+  temp roots as well as uncanonicalized system-temp paths.
+- Privilege-sensitive path regressions use DI seams or Windows junctions; they
+  do not require Developer Mode or drive-root write access.
+- Optional-runtime tests probe the complete capability they execute.
+- Shell-script tests resolve Git Bash from the active Git installation on
+  Windows instead of invoking the optional WSL relay by name.
+- Message-transform fixtures identify agents through the SDK-supported user
+  message/session paths enforced by `resolveMessageTransformContext`.
+- Impact-scope tests override restored `_internals` dependencies instead of
+  leaking `mock.module` replacements into later files.
+- Every test-runner detector and wiring suite now restores those `_internals`
+  dependencies after each case; no detector suite retains a module-scoped
+  discovery or filesystem mock.
+- Focused integration fixtures explicitly disable unrelated background work
+  when it is outside the behavior under test.
+- Checkpoint configuration rejects forbidden own keys and non-plain prototypes
+  before Zod can rebuild and erase the attack shape.
+- Shared test-environment isolation redirects `XDG_DATA_HOME` alongside the
+  existing config/home variables, so hive locks and data never reach a user's
+  real global store even under constrained-memory test runs.
 
-| AC | Status | Evidence |
-|----|--------|----------|
-| 1 (audit complete) | **MET** | this document (committed under `docs/audits/`) |
-| 2 (bulk quarantine + 5 green re-queues) | **NOT MET** | 5 consecutive green merge-group re-queues require elapsed wall-clock + multiple real PRs through the queue |
-| 3 (freezeClock adopted) | **PARTIAL** | helper + lint exist and work (PR #1784); 4 confirmed flaky sites migrated; the lint forces all NEW time-touching tests to use the helper. "Every Class 1 test" (~465 pre-existing files) is not migrated — diff-scoped lint is non-blocking for those by design |
-| 4 (coverage isolation) | **PARTIAL** | per-file coverage isolation already exists (`run-coverage-gate.sh`); `withIsolatedState` helper added. Coverage gate remains merge-group-only (extending to PR-branch is a separate change) |
-| 5 (cross-platform/subprocess) | **LARGELY PRE-EXISTING** | OS-specific quarantine lists + per-case `skipIf` guards already exist (#1729). Runbook documents the convention |
-| 6 (detection gate) | **PARTIAL** | detection workflow runs on failed merge-group runs; produces suggestion artifact + best-effort tracking issue. Auto-quarantine PR (needs PAT + branch-protection bypass) is out of scope |
-| 7 (runbook) | **MET** | `docs/testing/test-stability.md` |
-| 8 (2-week soak) | **NOT MET** | requires elapsed wall-clock with no new flakes |
+## Relationship to #1782
 
-**This PR does NOT close #1782.** It delivers the systemic tooling layer
-(Phases 0, 2, 5, 6 of the sprint) and the prevention/detection infrastructure.
-AC2 and AC8 require ongoing CI observation over weeks; AC3/AC4/AC6 are
-partially met and have clear follow-up work. The issue should remain open
-until those criteria are satisfied.
+Issue #1908 retires the concrete tracked backlog. It does **not** close #1782:
+that issue owns systemic flake detection, five consecutive green requeues, and
+the two-week soak. Those elapsed-time acceptance criteria remain separate from
+the code and quarantine debt resolved here.

--- a/docs/releases/pending/1908-test-stability-pass.md
+++ b/docs/releases/pending/1908-test-stability-pass.md
@@ -1,0 +1,40 @@
+---
+category: Fixed
+---
+
+# Retire the tracked merge-group stability backlog
+
+## What changed
+
+- Removed every tracked global, macOS-only, and integration quarantine after
+  repairing the underlying privilege-dependent path fixtures, incomplete Pester
+  capability detection, transient Windows cleanup, host-invalid message
+  fixtures, and phase-completion test isolation.
+- Replaced leaking test-runner module mocks with restored dependency seams and
+  added a diff-scoped guard that blocks repository-local test temp roots from
+  reintroducing shared `.swarm/` state.
+- Made shell-script fixtures resolve Git Bash explicitly on Windows and model
+  directory-link escapes with junctions, avoiding WSL and Developer Mode
+  assumptions. The trace initializer also normalizes native Git paths before
+  handing them to MSYS coreutils.
+- Removed remaining Windows-only integration failures by using host-native path
+  assertions, the current TypeScript profile label, and the packaged native
+  Biome executable instead of a Unix-style package shim.
+- Redirected XDG data storage in the shared test isolation helper so
+  skill-generation fixtures cannot acquire locks in a user's real hive store.
+- Closed a checkpoint-config prototype-pollution parsing gap discovered by the
+  restored adversarial tier, and replaced its remaining privileged Windows
+  symlink fixtures with junctions.
+
+## Why
+
+The quarantined tests repeatedly destabilized merge-group validation across
+Ubuntu, macOS, and Windows. These repairs make the tests exercise the intended
+runtime contracts without relying on host privileges, optional binaries, or
+state shared through the repository checkout.
+
+## Migration and compatibility
+
+No user migration or configuration change is required. Checkpoint config now
+fails closed for forbidden prototype keys and non-plain input objects; ordinary
+JSON configuration is unchanged.

--- a/scripts/check-test-tmpdir.sh
+++ b/scripts/check-test-tmpdir.sh
@@ -25,12 +25,11 @@
 # `canonicalMkdtemp(prefix)` from tests/helpers/tmpdir.ts instead of
 # hand-rolling the wrap.
 #
-# Deliberately NOT matched: a bare `mkdtempSync(...)` call whose argument does
-# not reference `tmpdir()` at all (e.g. a project-relative `mkdtempSync(path.
-# join('tmp', prefix))`) — that has nothing to do with the macOS symlink gap
-# this lint exists to catch, and flagging it would be a false positive. Any
-# `mkdtempSync(...)` call built from `tmpdir()` is still caught, because the
-# line then also matches the `tmpdir()` pattern above.
+# Project-relative temp roots are also rejected. Tests that create `tmp/` below
+# the checkout can leave runtime `.swarm/` state in the repository and couple
+# otherwise-isolated files through a shared directory. The line-scoped check
+# catches both direct calls and the historical `const baseDir = 'tmp'` helper
+# shape while leaving pre-existing occurrences outside the diff untouched.
 #
 # KNOWN LIMITATION: Plain-text substring match, not syntax-aware, so `tmpdir()`
 # in string literals/comments also trips it. Accepted tradeoff for a portable bash
@@ -102,6 +101,12 @@ while IFS= read -r line; do
                     violations=$((violations + 1))
                 fi
             fi
+            if echo "$content" | grep -qE "(baseDir|tempDir|tmpDir)[[:space:]]*=[[:space:]]*['\"]tmp['\"]|(mkdtemp|mkdtempSync|mkdir|mkdirSync)\([^)]*['\"]tmp['\"]"; then
+                echo "ERROR: ${current_file}:${current_lineno} adds a project-relative test temp root."
+                echo "       Use canonicalMkdtemp(prefix) from tests/helpers/tmpdir.ts so fixtures"
+                echo "       remain outside the repository and are realpath-canonicalized."
+                violations=$((violations + 1))
+            fi
             current_lineno=$((current_lineno + 1))
             ;;
     esac
@@ -115,4 +120,4 @@ if [ "$violations" -gt 0 ]; then
     exit 1
 fi
 
-echo "All new/changed test-file tmpdir usage is canonicalized."
+echo "All new/changed test temp roots are external and canonicalized."

--- a/scripts/ci/quarantined-integration-tests.txt
+++ b/scripts/ci/quarantined-integration-tests.txt
@@ -3,14 +3,4 @@
 # Format: one repo-relative test file path per line. Blank lines and lines
 # starting with # are ignored.
 #
-# STATUS: 2 active entries — integration tests that pass on a Windows host and
-# in isolated ubuntu worktree runs but fail on the ubuntu CI merge_group runner.
-# Root cause suspected to be test-ordering/shared-state contamination across
-# files in the same bun process (the integration job runs files sequentially
-# in a single `bun --smol test` process per file, but the failure signatures
-# suggest cross-test session-state leakage). Tracked as a follow-up to #1729.
-#
-# Do NOT un-quarantine without a merge_group `integration` validation run
-# confirming the fix.
-tests/integration/phase-complete-events.adversarial.test.ts
-tests/integration/unified-injection-budget.test.ts
+# No active integration quarantines. Issue #1908 requires merge-group proof.

--- a/scripts/ci/quarantined-tests-macos.txt
+++ b/scripts/ci/quarantined-tests-macos.txt
@@ -4,21 +4,4 @@
 # Format: one repo-relative test file path per line. Blank lines and lines
 # starting with # are ignored.
 #
-# STATUS: 4 active entries — lean-turbo worktree provisioning tests that fail
-# on the GitHub macos-latest runner. They pass on ubuntu-latest and on a
-# Windows host. The failures are `expect(...).toBeGreaterThan(0)` where the
-# received value is 0 (provisionWorktree mock not called) — a macOS-specific
-# lane-provisioning issue that requires a macOS environment to diagnose.
-#
-# These 4 files were un-quarantined in the initial #1729 push based on their
-# pre-existing realpathSync wraps + Windows-local validation, but the macOS
-# merge_group run revealed a SEPARATE failure mode (lane provisioning, not
-# path resolution). They are re-quarantined here until the root cause is
-# diagnosed on macOS. Tracked as a follow-up to #1729.
-#
-# Do NOT un-quarantine without a merge_group `unit (macos-latest, N)` validation
-# run confirming the fix.
-tests/unit/turbo/lean/integration-worktree.test.ts
-tests/unit/turbo/lean/retroactive-adversarial.test.ts
-tests/unit/turbo/lean/runner.adversarial.test.ts
-tests/unit/turbo/lean/runner.test.ts
+# No active macOS-only quarantines. Issue #1908 requires exact-head macOS proof.

--- a/scripts/ci/quarantined-tests.txt
+++ b/scripts/ci/quarantined-tests.txt
@@ -3,33 +3,4 @@
 # Format: one repo-relative test file path per line. Blank lines and lines
 # starting with # are ignored.
 #
-# Merge-group flaky tests — surface only in the broader Windows/macOS/coverage
-# matrix (PR-branch ubuntu-only CI doesn't hit them). Pre-existing, unrelated
-# to any specific PR. Tracked under #1737 (test quarantine debt) pending a
-# dedicated test-stability sprint.
-#
-# swarm-artifact-cache.test.ts: all assertions pass, but bun can exit
-# non-zero on Windows CI runners (e.g. AV holding a handle on the tmpdir
-# during afterEach's recursive rm) — a platform quirk, not a test-logic bug.
-tests/unit/utils/swarm-artifact-cache.test.ts
-# skill-scoring-workflow.test.ts: root-cause clock-freeze fix already applied
-# (see file header). Un-quarantine is intentionally gated on a confirmed-green
-# merge-group run across all 3 OSes per #1782, not just local passing —
-# tracked under #1737.
-tests/unit/hooks/skill-scoring-workflow.test.ts
-# Merge-group flaky test: test-runner.test.ts runs the real test-runner
-# tool against a fake Pester project (line 559-565 asserts parsed.success===true).
-# In the coverage context the subprocess behavior can return success=false
-# (environment-sensitive). Pre-existing, unrelated to any specific PR.
-# Tracked under #1737 (test quarantine debt) pending a dedicated
-# test-stability sprint.
-tests/unit/tools/test-runner.test.ts
-# Merge-group flaky test: finalize-reward-sweep-multi-runid.test.ts asserts a
-# Jaccard-related sibling's qValue propagates to exactly 0.485
-# (applyEmaUpdate(0.5, 0, 0.03) = 0.97 * 0.5) but the actual is 0.5 — the
-# propagation step is not applied, pointing to an ordering/initialization
-# nondeterminism in the sqlite-backed memory store. Reproduces consistently on
-# clean main (verified at 2616988a and 6f5e1376 — the latter is where PR #1906's
-# merge-queue CI happened to pass it). Pre-existing, unrelated to any specific
-# PR. Tracked under #1907 (root-cause fix) and #1737 (test quarantine debt).
-tests/unit/memory/finalize-reward-sweep-multi-runid.test.ts
+# No active global test quarantines. Issue #1908 retired the tracked backlog.

--- a/scripts/mock-allowlist.txt
+++ b/scripts/mock-allowlist.txt
@@ -111,7 +111,6 @@ src/session/snapshot-writer
 src/state
 src/summaries/manager
 src/telemetry
-src/test-impact/analyzer
 src/tools/checkpoint
 src/tools/co-change-analyzer
 src/tools/knowledge-recall

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1032,17 +1032,50 @@ export const RepoGraphConfigSchema = z.object({
 
 export type RepoGraphConfig = z.infer<typeof RepoGraphConfigSchema>;
 
+const INVALID_CHECKPOINT_PROTO_FIELD = '__swarm_invalid_checkpoint_proto__';
+const FORBIDDEN_CHECKPOINT_CONFIG_KEYS = new Set([
+	'__proto__',
+	'prototype',
+	'constructor',
+]);
+
+/** Reject prototype-polluted checkpoint config before Zod rebuilds the object. */
+function rejectCheckpointPrototypePollution(raw: unknown): unknown {
+	if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return raw;
+
+	try {
+		if (Object.getPrototypeOf(raw) !== Object.prototype) {
+			return { [INVALID_CHECKPOINT_PROTO_FIELD]: true };
+		}
+		for (const key of Reflect.ownKeys(raw)) {
+			if (
+				typeof key === 'string' &&
+				FORBIDDEN_CHECKPOINT_CONFIG_KEYS.has(key)
+			) {
+				return { [INVALID_CHECKPOINT_PROTO_FIELD]: true };
+			}
+		}
+	} catch {
+		return { [INVALID_CHECKPOINT_PROTO_FIELD]: true };
+	}
+
+	return raw;
+}
+
 // Checkpoint configuration
-export const CheckpointConfigSchema = z
-	.object({
-		enabled: z.boolean().default(true),
-		auto_checkpoint_threshold: z.number().int().min(1).max(20).default(3),
-		// When false (default), checkpoint save skips the git commit if the working
-		// tree is clean, recording only the current HEAD SHA. Set to true to restore
-		// the previous behaviour of creating a git commit even with no file changes.
-		allow_empty_commits: z.boolean().default(false),
-	})
-	.strict();
+export const CheckpointConfigSchema = z.preprocess(
+	rejectCheckpointPrototypePollution,
+	z
+		.object({
+			enabled: z.boolean().default(true),
+			auto_checkpoint_threshold: z.number().int().min(1).max(20).default(3),
+			// When false (default), checkpoint save skips the git commit if the working
+			// tree is clean, recording only the current HEAD SHA. Set to true to restore
+			// the previous behaviour of creating a git commit even with no file changes.
+			allow_empty_commits: z.boolean().default(false),
+		})
+		.strict(),
+);
 
 export type CheckpointConfig = z.infer<typeof CheckpointConfigSchema>;
 

--- a/src/tools/__tests__/test-runner-impact.adversarial.test.ts
+++ b/src/tools/__tests__/test-runner-impact.adversarial.test.ts
@@ -8,9 +8,7 @@ import {
 	test,
 } from 'bun:test';
 import type { ToolResult } from '../create-tool';
-
-// We need to use mock.module which is set up in beforeEach
-// This allows us to properly intercept the module imports
+import { _internals, test_runner } from '../test-runner';
 
 // Helper to convert ToolResult to string
 function resultToString(result: ToolResult): string {
@@ -23,19 +21,11 @@ function createToolContext(directory: string) {
 
 // Store mock references
 let mockAnalyzeImpact: Mock<(...args: any[]) => any>;
+const originalAnalyzeImpact = _internals.analyzeImpact;
+const originalIsCommandAvailable = _internals.isCommandAvailable;
 
 describe('test-runner impact scope ADVERSARIAL security tests', () => {
-	beforeEach(async () => {
-		// Reset module cache to ensure clean state
-		delete require.cache[require.resolve('../../../src/tools/test-runner.js')];
-		delete require.cache[
-			require.resolve('../../../src/test-impact/analyzer.js')
-		];
-		delete require.cache[
-			require.resolve('../../../src/utils/path-security.js')
-		];
-		delete require.cache[require.resolve('../../../src/build/discovery.js')];
-
+	beforeEach(() => {
 		// Create fresh mock for analyzeImpact
 		mockAnalyzeImpact = mock(() =>
 			Promise.resolve({
@@ -46,36 +36,13 @@ describe('test-runner impact scope ADVERSARIAL security tests', () => {
 			}),
 		);
 
-		// Mock the test-impact/analyzer module.
-		// Spread the real module so other named exports the test runner imports
-		// (e.g. loadImpactMap, used by estimateFanOut) survive the mock — only
-		// analyzeImpact is overridden. loadImpactMap with skipRebuild returns an
-		// empty map for the temp dirs used here, so it is safe and hermetic.
-		// See AGENTS.md invariant 7 (spread-real-exports).
-		const realAnalyzer = await import('../../../src/test-impact/analyzer.js');
-		mock.module('../../../src/test-impact/analyzer.js', () => ({
-			...realAnalyzer,
-			analyzeImpact: mockAnalyzeImpact,
-		}));
-
-		// Mock the build/discovery module to avoid real binary checks
-		mock.module('../../../src/build/discovery.js', () => ({
-			isCommandAvailable: () => false,
-		}));
-
-		// Mock the path-security module to avoid Windows path issues in tests
-		// Import real module and override only validateDirectory to allow test paths
-		const realPathSecurity = await import(
-			'../../../src/utils/path-security.js'
-		);
-		mock.module('../../../src/utils/path-security.js', () => ({
-			...realPathSecurity,
-			validateDirectory: () => {},
-			validateSymlinkBoundary: () => {},
-		}));
+		_internals.analyzeImpact = mockAnalyzeImpact;
+		_internals.isCommandAvailable = () => false;
 	});
 
 	afterEach(() => {
+		_internals.analyzeImpact = originalAnalyzeImpact;
+		_internals.isCommandAvailable = originalIsCommandAvailable;
 		mock.restore();
 	});
 
@@ -83,7 +50,6 @@ describe('test-runner impact scope ADVERSARIAL security tests', () => {
 		args: Record<string, unknown>,
 		directory?: string,
 	): Promise<{ parsed: Record<string, unknown>; raw: string }> {
-		const { test_runner } = await import('../../../src/tools/test-runner.js');
 		const result = await test_runner.execute(
 			args,
 			createToolContext(directory ?? '/fake/dir'),

--- a/src/tools/__tests__/test-runner-impact.test.ts
+++ b/src/tools/__tests__/test-runner-impact.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { test_runner } from '../test-runner.js';
+import { _internals, test_runner } from '../test-runner.js';
 
 // ============ Test Helpers ============
 
@@ -82,10 +82,7 @@ const mockAnalyzeImpact =
 		>
 	>();
 
-// Mock the analyzer module
-vi.mock('../../test-impact/analyzer.js', () => ({
-	analyzeImpact: mockAnalyzeImpact,
-}));
+const originalAnalyzeImpact = _internals.analyzeImpact;
 
 // ============ Tests ============
 
@@ -125,6 +122,7 @@ describe('impact scope execution', () => {
 
 		// Reset and configure the mock
 		mockAnalyzeImpact.mockReset();
+		_internals.analyzeImpact = mockAnalyzeImpact;
 	});
 
 	afterEach(() => {
@@ -132,6 +130,7 @@ describe('impact scope execution', () => {
 		try {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		} catch {}
+		_internals.analyzeImpact = originalAnalyzeImpact;
 	});
 
 	test('1. Impact scope with valid files and impacted tests found → returns impacted test files', async () => {

--- a/src/tools/__tests__/test-runner-source-files.test.ts
+++ b/src/tools/__tests__/test-runner-source-files.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { test_runner } from '../test-runner.js';
+import { _internals, test_runner } from '../test-runner.js';
 
 // ============ Mocks ============
 
@@ -38,9 +38,7 @@ const mockAnalyzeImpact =
 		>
 	>();
 
-vi.mock('../../test-impact/analyzer.js', () => ({
-	analyzeImpact: mockAnalyzeImpact,
-}));
+const originalAnalyzeImpact = _internals.analyzeImpact;
 
 // Mock Bun.spawn to prevent actual test execution for scope 'all' tests
 // This simulates a successful test run without actually running tests
@@ -144,6 +142,7 @@ describe('recordAndAnalyzeResults sourceFiles parameter behavior', () => {
 
 		// Reset and configure the impact mock
 		mockAnalyzeImpact.mockReset();
+		_internals.analyzeImpact = mockAnalyzeImpact;
 	});
 
 	afterEach(() => {
@@ -151,6 +150,7 @@ describe('recordAndAnalyzeResults sourceFiles parameter behavior', () => {
 		try {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		} catch {}
+		_internals.analyzeImpact = originalAnalyzeImpact;
 	});
 
 	/**
@@ -341,12 +341,14 @@ describe('recordAndAnalyzeResults backward compatibility', () => {
 
 		execute = getExecute();
 		mockAnalyzeImpact.mockReset();
+		_internals.analyzeImpact = mockAnalyzeImpact;
 	});
 
 	afterEach(() => {
 		try {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		} catch {}
+		_internals.analyzeImpact = originalAnalyzeImpact;
 	});
 
 	/**

--- a/src/tools/check-gate-status.gates.test.ts
+++ b/src/tools/check-gate-status.gates.test.ts
@@ -130,14 +130,13 @@ describe('check_gate_status', () => {
 		const parsed = JSON.parse(result);
 
 		// Tool safely returns no_evidence - no sensitive data leaked.
-		// resolveWorkingDirectory rejects /etc/passwd earlier rather than
-		// reaching the evidence-lookup stage. On Linux/macOS /etc/passwd is a
-		// real file, so the rejection is "is not a directory"; on Windows a
-		// leading '/' resolves drive-relative (e.g. D:\etc\passwd), which
-		// doesn't exist at all there, so the rejection is "does not exist".
-		// Either way the status is no_evidence and no file contents leak.
+		// POSIX rejects the real /etc/passwd as a file; Windows resolves the
+		// leading slash drive-relative and may reach the safe missing response.
+		// Both paths return no_evidence without leaking file contents.
 		expect(parsed.status).toBe('no_evidence');
-		expect(parsed.message).toMatch(/is not a directory|does not exist/);
+		expect(parsed.message).toMatch(
+			/is not a directory|does not exist|No evidence file found/,
+		);
 	});
 
 	// SECURITY FINDING: The path validation uses user-provided working_directory as base,

--- a/src/tools/test-runner.ts
+++ b/src/tools/test-runner.ts
@@ -43,7 +43,9 @@ export async function estimateFanOut(
 	cwd: string,
 ): Promise<{ estimatedCount: number }> {
 	try {
-		const impactMap = await loadImpactMap(cwd, { skipRebuild: true });
+		const impactMap = await _internals.loadImpactMap(cwd, {
+			skipRebuild: true,
+		});
 		const uniqueTestFiles = new Set<string>();
 
 		for (const sourceFile of sourceFiles) {
@@ -262,34 +264,42 @@ function hasDevDependency(
 /** Detect Go test runner (go test ./...) */
 function detectGoTest(cwd: string): boolean {
 	// check: go.mod exists AND go binary on PATH
-	return fs.existsSync(path.join(cwd, 'go.mod')) && isCommandAvailable('go');
+	return (
+		_internals.existsSync(path.join(cwd, 'go.mod')) &&
+		_internals.isCommandAvailable('go')
+	);
 }
 
 /** Detect Java/Maven test runner (mvn test) */
 function detectJavaMaven(cwd: string): boolean {
 	// check: pom.xml exists AND mvn binary on PATH
-	return fs.existsSync(path.join(cwd, 'pom.xml')) && isCommandAvailable('mvn');
+	return (
+		_internals.existsSync(path.join(cwd, 'pom.xml')) &&
+		_internals.isCommandAvailable('mvn')
+	);
 }
 
 /** Detect Java/Gradle or Kotlin/Gradle test runner (gradlew test) */
 function detectGradle(cwd: string): boolean {
 	// check: build.gradle or build.gradle.kts exists AND (gradlew script OR gradle binary)
 	const hasBuildFile =
-		fs.existsSync(path.join(cwd, 'build.gradle')) ||
-		fs.existsSync(path.join(cwd, 'build.gradle.kts'));
+		_internals.existsSync(path.join(cwd, 'build.gradle')) ||
+		_internals.existsSync(path.join(cwd, 'build.gradle.kts'));
 	const hasGradlew =
-		fs.existsSync(path.join(cwd, 'gradlew')) ||
-		fs.existsSync(path.join(cwd, 'gradlew.bat'));
-	return hasBuildFile && (hasGradlew || isCommandAvailable('gradle'));
+		_internals.existsSync(path.join(cwd, 'gradlew')) ||
+		_internals.existsSync(path.join(cwd, 'gradlew.bat'));
+	return (
+		hasBuildFile && (hasGradlew || _internals.isCommandAvailable('gradle'))
+	);
 }
 
 /** Detect C#/.NET test runner (dotnet test) */
 function detectDotnetTest(cwd: string): boolean {
 	// check: any .csproj file exists AND dotnet binary on PATH
 	try {
-		const files = fs.readdirSync(cwd);
+		const files = _internals.readdirSync(cwd);
 		const hasCsproj = files.some((f) => f.endsWith('.csproj'));
-		return hasCsproj && isCommandAvailable('dotnet');
+		return hasCsproj && _internals.isCommandAvailable('dotnet');
 	} catch {
 		return false;
 	}
@@ -298,19 +308,19 @@ function detectDotnetTest(cwd: string): boolean {
 /** Detect C/C++ CTest runner */
 function detectCTest(cwd: string): boolean {
 	// ctest works from build directory; accept both source and build directories
-	const hasSource = fs.existsSync(path.join(cwd, 'CMakeLists.txt'));
+	const hasSource = _internals.existsSync(path.join(cwd, 'CMakeLists.txt'));
 	const hasBuildCache =
-		fs.existsSync(path.join(cwd, 'CMakeCache.txt')) ||
-		fs.existsSync(path.join(cwd, 'build', 'CMakeCache.txt'));
-	return (hasSource || hasBuildCache) && isCommandAvailable('ctest');
+		_internals.existsSync(path.join(cwd, 'CMakeCache.txt')) ||
+		_internals.existsSync(path.join(cwd, 'build', 'CMakeCache.txt'));
+	return (hasSource || hasBuildCache) && _internals.isCommandAvailable('ctest');
 }
 
 /** Detect Swift test runner (swift test) */
 function detectSwiftTest(cwd: string): boolean {
 	// check: Package.swift exists AND swift binary on PATH
 	return (
-		fs.existsSync(path.join(cwd, 'Package.swift')) &&
-		isCommandAvailable('swift')
+		_internals.existsSync(path.join(cwd, 'Package.swift')) &&
+		_internals.isCommandAvailable('swift')
 	);
 }
 
@@ -318,20 +328,23 @@ function detectSwiftTest(cwd: string): boolean {
 function detectDartTest(cwd: string): boolean {
 	// check: pubspec.yaml exists AND (dart or flutter binary on PATH)
 	return (
-		fs.existsSync(path.join(cwd, 'pubspec.yaml')) &&
-		(isCommandAvailable('dart') || isCommandAvailable('flutter'))
+		_internals.existsSync(path.join(cwd, 'pubspec.yaml')) &&
+		(_internals.isCommandAvailable('dart') ||
+			_internals.isCommandAvailable('flutter'))
 	);
 }
 
 /** Detect Ruby/RSpec test runner */
 function detectRSpec(cwd: string): boolean {
 	// Require .rspec file OR (Gemfile + spec/ dir) for Ruby specificity
-	const hasRSpecFile = fs.existsSync(path.join(cwd, '.rspec'));
-	const hasGemfile = fs.existsSync(path.join(cwd, 'Gemfile'));
-	const hasSpecDir = fs.existsSync(path.join(cwd, 'spec'));
+	const hasRSpecFile = _internals.existsSync(path.join(cwd, '.rspec'));
+	const hasGemfile = _internals.existsSync(path.join(cwd, 'Gemfile'));
+	const hasSpecDir = _internals.existsSync(path.join(cwd, 'spec'));
 	const hasRSpec = hasRSpecFile || (hasGemfile && hasSpecDir);
 	return (
-		hasRSpec && (isCommandAvailable('bundle') || isCommandAvailable('rspec'))
+		hasRSpec &&
+		(_internals.isCommandAvailable('bundle') ||
+			_internals.isCommandAvailable('rspec'))
 	);
 }
 
@@ -339,10 +352,10 @@ function detectRSpec(cwd: string): boolean {
 function detectMinitest(cwd: string): boolean {
 	// Require test/ dir + Ruby-specific markers (Gemfile or Rakefile)
 	return (
-		fs.existsSync(path.join(cwd, 'test')) &&
-		(fs.existsSync(path.join(cwd, 'Gemfile')) ||
-			fs.existsSync(path.join(cwd, 'Rakefile'))) &&
-		isCommandAvailable('ruby')
+		_internals.existsSync(path.join(cwd, 'test')) &&
+		(_internals.existsSync(path.join(cwd, 'Gemfile')) ||
+			_internals.existsSync(path.join(cwd, 'Rakefile'))) &&
+		_internals.isCommandAvailable('ruby')
 	);
 }
 
@@ -490,8 +503,8 @@ export async function detectTestFramework(cwd: string): Promise<TestFramework> {
 	// Check for package.json to detect JS/TS frameworks
 	try {
 		const packageJsonPath = path.join(baseDir, 'package.json');
-		if (fs.existsSync(packageJsonPath)) {
-			const content = fs.readFileSync(packageJsonPath, 'utf-8');
+		if (_internals.existsSync(packageJsonPath)) {
+			const content = _internals.readFileSync(packageJsonPath, 'utf-8');
 			const pkg = JSON.parse(content) as {
 				dependencies?: Record<string, string>;
 				devDependencies?: Record<string, string>;
@@ -515,8 +528,8 @@ export async function detectTestFramework(cwd: string): Promise<TestFramework> {
 
 			// Check for bun.lockb or bun.lock
 			if (
-				fs.existsSync(path.join(baseDir, 'bun.lockb')) ||
-				fs.existsSync(path.join(baseDir, 'bun.lock'))
+				_internals.existsSync(path.join(baseDir, 'bun.lockb')) ||
+				_internals.existsSync(path.join(baseDir, 'bun.lock'))
 			) {
 				// Check if bun test is in scripts
 				if (scripts.test?.includes('bun')) return 'bun';
@@ -532,19 +545,19 @@ export async function detectTestFramework(cwd: string): Promise<TestFramework> {
 		const setupCfgPath = path.join(baseDir, 'setup.cfg');
 		const requirementsTxtPath = path.join(baseDir, 'requirements.txt');
 
-		if (fs.existsSync(pyprojectTomlPath)) {
-			const content = fs.readFileSync(pyprojectTomlPath, 'utf-8');
+		if (_internals.existsSync(pyprojectTomlPath)) {
+			const content = _internals.readFileSync(pyprojectTomlPath, 'utf-8');
 			if (content.includes('[tool.pytest')) return 'pytest';
 			if (content.includes('pytest')) return 'pytest';
 		}
 
-		if (fs.existsSync(setupCfgPath)) {
-			const content = fs.readFileSync(setupCfgPath, 'utf-8');
+		if (_internals.existsSync(setupCfgPath)) {
+			const content = _internals.readFileSync(setupCfgPath, 'utf-8');
 			if (content.includes('[pytest]')) return 'pytest';
 		}
 
-		if (fs.existsSync(requirementsTxtPath)) {
-			const content = fs.readFileSync(requirementsTxtPath, 'utf-8');
+		if (_internals.existsSync(requirementsTxtPath)) {
+			const content = _internals.readFileSync(requirementsTxtPath, 'utf-8');
 			if (content.includes('pytest')) return 'pytest';
 		}
 	} catch {
@@ -554,8 +567,8 @@ export async function detectTestFramework(cwd: string): Promise<TestFramework> {
 	// Check for Cargo/Rust (Cargo.toml)
 	try {
 		const cargoTomlPath = path.join(baseDir, 'Cargo.toml');
-		if (fs.existsSync(cargoTomlPath)) {
-			const content = fs.readFileSync(cargoTomlPath, 'utf-8');
+		if (_internals.existsSync(cargoTomlPath)) {
+			const content = _internals.readFileSync(cargoTomlPath, 'utf-8');
 			if (content.includes('[dev-dependencies]')) {
 				// Check for common test dependencies
 				if (
@@ -578,9 +591,9 @@ export async function detectTestFramework(cwd: string): Promise<TestFramework> {
 		const pesterPs1Path = path.join(baseDir, 'tests.ps1');
 
 		if (
-			fs.existsSync(pesterConfigPath) ||
-			fs.existsSync(pesterConfigJsonPath) ||
-			fs.existsSync(pesterPs1Path)
+			_internals.existsSync(pesterConfigPath) ||
+			_internals.existsSync(pesterConfigJsonPath) ||
+			_internals.existsSync(pesterPs1Path)
 		) {
 			return 'pester';
 		}
@@ -606,15 +619,15 @@ export async function detectTestFramework(cwd: string): Promise<TestFramework> {
 
 function detectPhpTest(cwd: string): TestFramework | null {
 	if (
-		fs.existsSync(path.join(cwd, 'artisan')) &&
-		fs.existsSync(path.join(cwd, 'composer.json'))
+		_internals.existsSync(path.join(cwd, 'artisan')) &&
+		_internals.existsSync(path.join(cwd, 'composer.json'))
 	) {
 		return 'php-artisan';
 	}
-	if (fs.existsSync(path.join(cwd, 'Pest.php'))) return 'pest';
+	if (_internals.existsSync(path.join(cwd, 'Pest.php'))) return 'pest';
 	if (
-		fs.existsSync(path.join(cwd, 'phpunit.xml')) ||
-		fs.existsSync(path.join(cwd, 'phpunit.xml.dist'))
+		_internals.existsSync(path.join(cwd, 'phpunit.xml')) ||
+		_internals.existsSync(path.join(cwd, 'phpunit.xml.dist'))
 	) {
 		return 'phpunit';
 	}
@@ -1263,12 +1276,12 @@ function buildTestCommand(
 		case 'dart-test':
 			// dart-test has no bail support — silently ignore
 			// Prefer flutter test for Flutter projects; fall back to dart test
-			return isCommandAvailable('flutter')
+			return _internals.isCommandAvailable('flutter')
 				? ['flutter', 'test', ...files]
 				: ['dart', 'test', ...files];
 		case 'rspec': {
 			// Use bundle exec when bundler is available, otherwise fall back to rspec directly
-			const args = isCommandAvailable('bundle')
+			const args = _internals.isCommandAvailable('bundle')
 				? ['bundle', 'exec', 'rspec']
 				: ['rspec'];
 			if (bail) args.push('--fail-fast');
@@ -2735,7 +2748,7 @@ export const test_runner: ReturnType<typeof tool> = createSwarmTool({
 			}
 
 			try {
-				const impactResult = await analyzeImpact(
+				const impactResult = await _internals.analyzeImpact(
 					sourceFiles,
 					workingDir,
 					MAX_SAFE_TEST_FILES,
@@ -2882,7 +2895,22 @@ export const test_runner: ReturnType<typeof tool> = createSwarmTool({
 	},
 });
 
-export const _internals = {
+export const _internals: {
+	analyzeImpact: typeof analyzeImpact;
+	loadImpactMap: typeof loadImpactMap;
+	isCommandAvailable: typeof isCommandAvailable;
+	existsSync: typeof fs.existsSync;
+	readdirSync: typeof fs.readdirSync;
+	readFileSync: typeof fs.readFileSync;
+	selectHistoryForAnalysis: typeof selectHistoryForAnalysis;
+	AGGREGATE_TEST_NAME: typeof AGGREGATE_TEST_NAME;
+} = {
+	analyzeImpact,
+	loadImpactMap,
+	isCommandAvailable,
+	existsSync: fs.existsSync,
+	readdirSync: fs.readdirSync,
+	readFileSync: fs.readFileSync,
 	selectHistoryForAnalysis,
 	AGGREGATE_TEST_NAME,
-} as const;
+};

--- a/src/turbo/lean/partition-common.ts
+++ b/src/turbo/lean/partition-common.ts
@@ -16,6 +16,7 @@
  * identical classifications and sort orders for the same inputs.
  */
 
+import * as path from 'node:path';
 import type { LeanTurboConfig } from '../../config/schema';
 import { criticalWarn } from '../../utils/logger.js';
 import { isPathSafe, normalizePath, readTaskScopes } from './conflicts';
@@ -95,8 +96,24 @@ export function getValidatedFiles(
 			continue;
 		}
 
-		const normalized = normalizePath(pathToCheck);
-		validFiles.push(normalized);
+		// Risk classification operates on repository-relative scope paths. Passing
+		// the absolute workspace prefix through here makes macOS temp roots such
+		// as /private/var look like a protected project path, so every normal
+		// scope is incorrectly degraded before worktree provisioning can begin.
+		const relativePath = path.relative(
+			path.resolve(directory),
+			path.resolve(pathToCheck),
+		);
+		if (
+			!relativePath ||
+			!isPathSafe(relativePath) ||
+			path.isAbsolute(relativePath)
+		) {
+			invalidCount++;
+			continue;
+		}
+
+		validFiles.push(normalizePath(relativePath));
 	}
 
 	return [validFiles, invalidCount];

--- a/src/utils/path-security.ts
+++ b/src/utils/path-security.ts
@@ -112,14 +112,14 @@ export function validateSymlinkBoundary(
 ): void {
 	let realTarget: string;
 	try {
-		realTarget = fs.realpathSync(targetPath);
+		realTarget = _internals.realpathSync(targetPath);
 	} catch {
 		realTarget = path.resolve(targetPath);
 	}
 
 	let realRoot: string;
 	try {
-		realRoot = fs.realpathSync(rootPath);
+		realRoot = _internals.realpathSync(rootPath);
 	} catch {
 		realRoot = path.resolve(rootPath);
 	}
@@ -222,6 +222,7 @@ export function validateTargetWithinRoot(
  * Internal calls should use _internals.fn() instead of fn() directly.
  */
 export const _internals: {
+	realpathSync: typeof fs.realpathSync;
 	containsPathTraversal: typeof containsPathTraversal;
 	containsControlChars: typeof containsControlChars;
 	validateDirectory: typeof validateDirectory;
@@ -229,6 +230,7 @@ export const _internals: {
 	isCanonicalPathWithinRoot: typeof isCanonicalPathWithinRoot;
 	validateTargetWithinRoot: typeof validateTargetWithinRoot;
 } = {
+	realpathSync: fs.realpathSync,
 	containsPathTraversal,
 	containsControlChars,
 	validateDirectory,

--- a/tests/adversarial/subprocess-injection.cwd-traversal.test.ts
+++ b/tests/adversarial/subprocess-injection.cwd-traversal.test.ts
@@ -87,13 +87,11 @@ console.log('arg:' + (args[0] || ''));`,
 		fs.mkdirSync(outerDir, { recursive: true });
 
 		const symlinkPath = path.join(innerDir, 'link_to_outer');
-		try {
-			fs.symlinkSync(outerDir, symlinkPath);
-		} catch {
-			// Symlink creation may fail on some Windows configurations
-			test.skip('symlinks not supported on this configuration', () => {});
-			return;
-		}
+		fs.symlinkSync(
+			outerDir,
+			symlinkPath,
+			process.platform === 'win32' ? 'junction' : 'dir',
+		);
 
 		const script = writeNodeScript(
 			'check-cwd.js',

--- a/tests/adversarial/subprocess-injection.test.ts
+++ b/tests/adversarial/subprocess-injection.test.ts
@@ -602,13 +602,11 @@ console.log('arg:' + (args[0] || ''));`,
 		fs.mkdirSync(outerDir, { recursive: true });
 
 		const symlinkPath = path.join(innerDir, 'link_to_outer');
-		try {
-			fs.symlinkSync(outerDir, symlinkPath);
-		} catch {
-			// Symlink creation may fail on some Windows configurations
-			test.skip('symlinks not supported on this configuration', () => {});
-			return;
-		}
+		fs.symlinkSync(
+			outerDir,
+			symlinkPath,
+			process.platform === 'win32' ? 'junction' : 'dir',
+		);
 
 		const script = writeNodeScript(
 			'check-cwd.js',

--- a/tests/helpers/bash.ts
+++ b/tests/helpers/bash.ts
@@ -1,0 +1,55 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Resolve a real Bash runtime for shell-script tests.
+ *
+ * On Windows, a bare `bash` can resolve to the System32 WSL relay even when no
+ * distribution is installed. Git Bash is already a repository prerequisite,
+ * so derive its executable from the active Git installation instead.
+ */
+export function resolveBash(): string {
+	if (process.platform !== 'win32') return Bun.which('bash') ?? 'bash';
+
+	const gitExe = Bun.which('git');
+	if (!gitExe) {
+		throw new Error('Git Bash is required for shell-script tests on Windows');
+	}
+
+	let current = path.dirname(gitExe);
+	for (let depth = 0; depth < 4; depth += 1) {
+		for (const candidate of [
+			path.join(current, 'bash.exe'),
+			path.join(current, 'bin', 'bash.exe'),
+			path.join(current, 'usr', 'bin', 'bash.exe'),
+		]) {
+			if (fs.existsSync(candidate)) return candidate;
+		}
+
+		const parent = path.dirname(current);
+		if (parent === current) break;
+		current = parent;
+	}
+
+	throw new Error(
+		`Git Bash is required for shell-script tests on Windows (git: ${gitExe})`,
+	);
+}
+
+/** Build a script command with Git Bash's core utilities on PATH on Windows. */
+export function bashCommand(script: string, ...args: string[]): string[] {
+	const bash = resolveBash();
+	if (process.platform !== 'win32') return [bash, script, ...args];
+
+	// Avoid login startup: Git's profile may try to create HOME before the test
+	// starts. Positional forwarding keeps script paths and arguments out of the
+	// command string while restoring the coreutils paths omitted by native spawn.
+	return [
+		bash,
+		'-c',
+		'export PATH="/usr/bin:/bin:$PATH"; exec /usr/bin/bash "$@"',
+		'bash',
+		script,
+		...args,
+	];
+}

--- a/tests/helpers/isolated-test-env.test.ts
+++ b/tests/helpers/isolated-test-env.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import { resolveHiveDataDir } from '../../src/knowledge/hive-paths';
 import { assertSafeForWrite, createIsolatedTestEnv } from './isolated-test-env';
 
 describe('isolated-test-env', () => {
@@ -20,6 +21,24 @@ describe('isolated-test-env', () => {
 			const { configDir, cleanup } = createIsolatedTestEnv();
 
 			expect(process.env.XDG_CONFIG_HOME).toBe(configDir);
+
+			cleanup();
+		});
+
+		test('XDG_DATA_HOME is set to the temp dir while active', () => {
+			const { configDir, cleanup } = createIsolatedTestEnv();
+
+			expect(process.env.XDG_DATA_HOME).toBe(configDir);
+
+			cleanup();
+		});
+
+		test('hive data resolves below the isolated temp dir', () => {
+			const { configDir, cleanup } = createIsolatedTestEnv();
+
+			const relative = path.relative(configDir, resolveHiveDataDir());
+			expect(relative.startsWith('..')).toBe(false);
+			expect(path.isAbsolute(relative)).toBe(false);
 
 			cleanup();
 		});
@@ -51,18 +70,21 @@ describe('isolated-test-env', () => {
 		test('After cleanup(), original env vars are restored', () => {
 			// Save originals
 			const originalXDG = process.env.XDG_CONFIG_HOME;
+			const originalXDGData = process.env.XDG_DATA_HOME;
 			const originalAPPDATA = process.env.APPDATA;
 			const originalLOCALAPPDATA = process.env.LOCALAPPDATA;
 			const originalHOME = process.env.HOME;
 
 			const { cleanup } = createIsolatedTestEnv();
 			const newXDG = process.env.XDG_CONFIG_HOME;
+			const newXDGData = process.env.XDG_DATA_HOME;
 			const newAPPDATA = process.env.APPDATA;
 			const newLOCALAPPDATA = process.env.LOCALAPPDATA;
 			const newHOME = process.env.HOME;
 
 			// Verify they changed
 			expect(newXDG).not.toBe(originalXDG);
+			expect(newXDGData).not.toBe(originalXDGData);
 			expect(newAPPDATA).not.toBe(originalAPPDATA);
 			expect(newLOCALAPPDATA).not.toBe(originalLOCALAPPDATA);
 			expect(newHOME).not.toBe(originalHOME);
@@ -71,6 +93,7 @@ describe('isolated-test-env', () => {
 
 			// After cleanup, original values should be restored
 			expect(process.env.XDG_CONFIG_HOME).toBe(originalXDG);
+			expect(process.env.XDG_DATA_HOME).toBe(originalXDGData);
 			expect(process.env.APPDATA).toBe(originalAPPDATA);
 			expect(process.env.LOCALAPPDATA).toBe(originalLOCALAPPDATA);
 			expect(process.env.HOME).toBe(originalHOME);
@@ -79,12 +102,14 @@ describe('isolated-test-env', () => {
 		test('After cleanup(), env vars that were originally undefined are deleted', () => {
 			// Save originals
 			const originalXDG = process.env.XDG_CONFIG_HOME;
+			const originalXDGData = process.env.XDG_DATA_HOME;
 			const originalAPPDATA = process.env.APPDATA;
 			const originalLOCALAPPDATA = process.env.LOCALAPPDATA;
 			const originalHOME = process.env.HOME;
 
 			// Ensure env vars are undefined for this test
 			delete process.env.XDG_CONFIG_HOME;
+			delete process.env.XDG_DATA_HOME;
 			delete process.env.APPDATA;
 			delete process.env.LOCALAPPDATA;
 			delete process.env.HOME;
@@ -93,6 +118,7 @@ describe('isolated-test-env', () => {
 
 			// Verify they are set
 			expect(process.env.XDG_CONFIG_HOME).toBeDefined();
+			expect(process.env.XDG_DATA_HOME).toBeDefined();
 			expect(process.env.APPDATA).toBeDefined();
 			expect(process.env.LOCALAPPDATA).toBeDefined();
 			expect(process.env.HOME).toBeDefined();
@@ -103,6 +129,9 @@ describe('isolated-test-env', () => {
 			// Check that they are truly deleted (not present in env)
 			if (originalXDG === undefined) {
 				expect(process.env.XDG_CONFIG_HOME).toBeUndefined();
+			}
+			if (originalXDGData === undefined) {
+				expect(process.env.XDG_DATA_HOME).toBeUndefined();
 			}
 			if (originalAPPDATA === undefined) {
 				expect(process.env.APPDATA).toBeUndefined();
@@ -116,6 +145,8 @@ describe('isolated-test-env', () => {
 
 			// Restore original state
 			if (originalXDG !== undefined) process.env.XDG_CONFIG_HOME = originalXDG;
+			if (originalXDGData !== undefined)
+				process.env.XDG_DATA_HOME = originalXDGData;
 			if (originalAPPDATA !== undefined) process.env.APPDATA = originalAPPDATA;
 			if (originalLOCALAPPDATA !== undefined)
 				process.env.LOCALAPPDATA = originalLOCALAPPDATA;

--- a/tests/helpers/isolated-test-env.ts
+++ b/tests/helpers/isolated-test-env.ts
@@ -3,8 +3,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 /**
- * Creates a temp directory and sets XDG_CONFIG_HOME + APPDATA + LOCALAPPDATA
- * so all config path resolution lands in the temp dir.
+ * Creates a temp directory and redirects config, data, and home environment
+ * roots so all test-owned global path resolution lands in the temp dir.
  * Returns a cleanup function that restores original env vars and
  * removes the temp dir.
  */
@@ -19,6 +19,7 @@ export function createIsolatedTestEnv(): {
 	// Save original values
 	const originalEnv: Record<string, string | undefined> = {
 		XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+		XDG_DATA_HOME: process.env.XDG_DATA_HOME,
 		APPDATA: process.env.APPDATA,
 		LOCALAPPDATA: process.env.LOCALAPPDATA,
 		HOME: process.env.HOME,
@@ -26,6 +27,7 @@ export function createIsolatedTestEnv(): {
 
 	// Set isolated config paths
 	process.env.XDG_CONFIG_HOME = configDir;
+	process.env.XDG_DATA_HOME = configDir;
 	process.env.APPDATA = configDir;
 	process.env.LOCALAPPDATA = configDir;
 	process.env.HOME = configDir;
@@ -36,6 +38,12 @@ export function createIsolatedTestEnv(): {
 			delete process.env.XDG_CONFIG_HOME;
 		} else {
 			process.env.XDG_CONFIG_HOME = originalEnv.XDG_CONFIG_HOME;
+		}
+
+		if (originalEnv.XDG_DATA_HOME === undefined) {
+			delete process.env.XDG_DATA_HOME;
+		} else {
+			process.env.XDG_DATA_HOME = originalEnv.XDG_DATA_HOME;
 		}
 
 		if (originalEnv.APPDATA === undefined) {
@@ -57,7 +65,12 @@ export function createIsolatedTestEnv(): {
 		}
 
 		// Remove temp directory
-		fs.rmSync(configDir, { recursive: true, force: true });
+		fs.rmSync(configDir, {
+			recursive: true,
+			force: true,
+			maxRetries: 5,
+			retryDelay: 100,
+		});
 	};
 
 	return { configDir, cleanup };

--- a/tests/integration/issue-629-skill-improver.test.ts
+++ b/tests/integration/issue-629-skill-improver.test.ts
@@ -9,23 +9,26 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { resolveSwarmKnowledgePath } from '../../src/hooks/knowledge-store';
 import type { SwarmKnowledgeEntry } from '../../src/hooks/knowledge-types';
 import { runSkillImprover } from '../../src/services/skill-improver';
 import { resolveQuotaPath } from '../../src/services/skill-improver-quota';
+import { createIsolatedTestEnv } from '../helpers/isolated-test-env';
 
 let tmp: string;
+let cleanupEnv: () => void;
 beforeEach(() => {
 	mock.restore();
-	tmp = mkdtempSync(path.join(tmpdir(), 'swarm-issue629-'));
+	const isolatedEnv = createIsolatedTestEnv();
+	tmp = isolatedEnv.configDir;
+	cleanupEnv = isolatedEnv.cleanup;
 });
 afterEach(() => {
-	rmSync(tmp, { recursive: true, force: true });
 	mock.restore();
+	cleanupEnv();
 });
 
 async function seedMatureKnowledge(): Promise<void> {
@@ -95,7 +98,9 @@ describe('issue #629 — low-frequency expensive skill_improver', () => {
 			config,
 		});
 		expect(r.ran).toBe(true);
-		expect(r.proposalPath).toContain('.swarm/skill-improver/proposals/');
+		expect(r.proposalPath).toContain(
+			path.join('.swarm', 'skill-improver', 'proposals'),
+		);
 		expect(existsSync(r.proposalPath!)).toBe(true);
 		// proposal mentions the configured model
 		expect(readFileSync(r.proposalPath!, 'utf-8')).toContain(

--- a/tests/integration/lang/prompt-injection.test.ts
+++ b/tests/integration/lang/prompt-injection.test.ts
@@ -119,9 +119,7 @@ describe('Language-specific prompt injection - Integration tests', () => {
 				'Update src/tools/lint.ts',
 			);
 			expect(result).not.toBeNull();
-			expect(result).toContain(
-				'[LANGUAGE-SPECIFIC CONSTRAINTS — TypeScript / JavaScript]',
-			);
+			expect(result).toContain('[LANGUAGE-SPECIFIC CONSTRAINTS — TypeScript]');
 			expect(result).toContain(
 				'Use strict TypeScript; no implicit any or type assertions without justification',
 			);
@@ -190,7 +188,7 @@ describe('Language-specific prompt injection - Integration tests', () => {
 			);
 			expect(result).not.toBeNull();
 			expect(result).toContain(
-				'[LANGUAGE-SPECIFIC REVIEW CHECKLIST — TypeScript / JavaScript]',
+				'[LANGUAGE-SPECIFIC REVIEW CHECKLIST — TypeScript]',
 			);
 			expect(result).toContain(
 				'- [ ] Verify no implicit any or unsafe type casts',

--- a/tests/integration/phase-complete-events.adversarial.test.ts
+++ b/tests/integration/phase-complete-events.adversarial.test.ts
@@ -58,10 +58,9 @@ describe('phase_complete integration — adversarial scenarios', () => {
 		return events;
 	}
 
-	/**
-	 * Helper to write config file
-	 */
 	function writeConfig(config: Record<string, unknown>): void {
+		config.knowledge ??= { enabled: false, sweep_enabled: false };
+		config.curator ??= { enabled: false };
 		fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
 		fs.writeFileSync(
 			path.join(tempDir, '.opencode', 'opencode-swarm.json'),

--- a/tests/integration/phase-complete-events.test.ts
+++ b/tests/integration/phase-complete-events.test.ts
@@ -46,10 +46,9 @@ describe('phase_complete integration — events.jsonl', () => {
 		return events;
 	}
 
-	/**
-	 * Helper to write config file
-	 */
 	function writeConfig(config: Record<string, unknown>): void {
+		config.knowledge ??= { enabled: false, sweep_enabled: false };
+		config.curator ??= { enabled: false };
 		fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
 		fs.writeFileSync(
 			path.join(tempDir, '.opencode', 'opencode-swarm.json'),

--- a/tests/integration/pre-check-batch.test.ts
+++ b/tests/integration/pre-check-batch.test.ts
@@ -28,9 +28,19 @@ describe('pre_check_batch integration', () => {
 	beforeEach(() => {
 		originalCwd = process.cwd();
 		originalPath = process.env.PATH || '';
-		// Add local node_modules/.bin to PATH so npx uses local biome
-		const projectBin = path.join(originalCwd, 'node_modules', '.bin');
-		process.env.PATH = projectBin + path.delimiter + originalPath;
+		// The Unix package shim is executable directly. On Windows, expose the
+		// optional native package directory because child-process array spawns do
+		// not execute the node_modules/.bin/biome.cmd shell shim.
+		const biomeBinDir =
+			process.platform === 'win32'
+				? path.join(
+						originalCwd,
+						'node_modules',
+						'@biomejs',
+						`cli-win32-${process.arch}`,
+					)
+				: path.join(originalCwd, 'node_modules', '.bin');
+		process.env.PATH = biomeBinDir + path.delimiter + originalPath;
 		tempDir = fs.mkdtempSync(
 			path.join(os.tmpdir(), 'pre-check-batch-integration-'),
 		);

--- a/tests/integration/unified-injection-budget.test.ts
+++ b/tests/integration/unified-injection-budget.test.ts
@@ -25,8 +25,11 @@ import {
 	allocateInjectionBudget,
 	clearUnifiedBudget,
 	type InjectionBudgetConfig,
+	resetUnifiedBudget,
+	setSystemEnhancerDemand,
 } from '../../src/services/injection-budget.js';
 import { resetSwarmState, swarmState } from '../../src/state.js';
+import { canonicalMkdtemp } from '../helpers/tmpdir.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -118,24 +121,16 @@ const DEFAULT_PLUGIN_CONFIG: PluginConfig = {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function createRelativeTempDir(): string {
-	const baseDir = 'tmp';
-	if (!fs.existsSync(baseDir)) {
-		fs.mkdirSync(baseDir, { recursive: true });
-	}
-	return fs.mkdtempSync(path.join(baseDir, 'unified-budget-test-'));
-}
-
 function makeMessages(totalChars: number): MessageWithParts[] {
 	const sysText = 'System prompt for architect agent';
 	const userPad = Math.max(1, totalChars - sysText.length);
 	return [
 		{
-			info: { role: 'system', agent: 'architect', sessionID: 'test-session' },
+			info: { role: 'assistant', sessionID: 'test-session' },
 			parts: [{ type: 'text', text: sysText }],
 		},
 		{
-			info: { role: 'user' },
+			info: { role: 'user', agent: 'architect', sessionID: 'test-session' },
 			parts: [{ type: 'text', text: 'x'.repeat(userPad) }],
 		},
 	];
@@ -166,7 +161,7 @@ describe('Unified injection budget integration (FR-002)', () => {
 	let tempDir: string;
 
 	beforeEach(() => {
-		tempDir = createRelativeTempDir();
+		tempDir = canonicalMkdtemp('unified-budget-test-');
 		const swarmDir = path.join(tempDir, '.swarm');
 		fs.mkdirSync(swarmDir, { recursive: true });
 		fs.writeFileSync(path.join(swarmDir, 'plan.json'), PLAN_JSON);
@@ -267,33 +262,15 @@ describe('Unified injection budget integration (FR-002)', () => {
 
 	it('SC-005: knowledge-injector gets 0 when system-enhancer alone exceeds the unified ceiling', async () => {
 		const unifiedBudget = 1000;
-		const pluginConfig: PluginConfig = {
-			...DEFAULT_PLUGIN_CONFIG,
-			context_budget: {
-				max_injection_tokens: 4000,
-				unified_injection_tokens: unifiedBudget,
-			},
-		};
 		const knowledgeConfig = {
 			...DEFAULT_KNOWLEDGE_CONFIG,
 		};
 
-		// system-enhancer: large demand that exceeds unified budget
-		// We create a plan with many decisions to force large injection
-		const decisions = Array.from(
-			{ length: 500 },
-			(_, i) =>
-				`- Decision ${i}: Use TypeScript strict mode with exactOptionalPropertyTypes`,
-		).join('\n');
-		fs.writeFileSync(
-			path.join(tempDir, '.swarm', 'context.md'),
-			`## Decisions\n${decisions}\n## Agent Activity\n- coder: no tool activity`,
-		);
-
-		const seHook = createSystemEnhancerHook(pluginConfig, tempDir);
-		const seTransform = seHook['experimental.chat.system.transform'] as any;
-		const seOutput = { system: [] as string[] };
-		await seTransform({ sessionID: 'test-session' }, seOutput);
+		// Seed the shared ledger with a real system-enhancer demand that alone
+		// exceeds the ceiling. This isolates the cross-hook budget contract from
+		// unrelated system-enhancer content-selection heuristics.
+		resetUnifiedBudget('test-session', unifiedBudget);
+		setSystemEnhancerDemand('test-session', unifiedBudget + 1);
 
 		// knowledge-injector runs after system-enhancer
 		const kiHook = createKnowledgeInjectorHook(

--- a/tests/unit/cli/update-command.test.ts
+++ b/tests/unit/cli/update-command.test.ts
@@ -560,6 +560,7 @@ describe('isSafeCachePath cross-platform path acceptance', () => {
 
 describe('M6 realpath canonicalization at delete sites', () => {
 	let tempDir: string;
+	const symlinkType = process.platform === 'win32' ? 'junction' : 'dir';
 
 	beforeEach(async () => {
 		tempDir = await realpath(
@@ -583,7 +584,7 @@ describe('M6 realpath canonicalization at delete sites', () => {
 		const linkDir = join(tempDir, 'opencode', 'node_modules');
 		await mkdir(linkDir, { recursive: true });
 		const symlinkPath = join(linkDir, 'opencode-swarm');
-		await symlink(evilTarget, symlinkPath);
+		await symlink(evilTarget, symlinkPath, symlinkType);
 
 		// Lexical guard (pre-M6 behavior) is fooled by the canonical-looking name.
 		expect(isSafeCachePath(symlinkPath)).toBe(true);
@@ -598,20 +599,18 @@ describe('M6 realpath canonicalization at delete sites', () => {
 	test('canonicalized symlinked lock leaf is refused after realpath (final-component swap)', async () => {
 		// Lock-file analogue: a symlink named bun.lock in a lexically-valid
 		// .../opencode/ dir that points at an unsafe real file.
-		const evilFileDir = join(tempDir, 'evil');
-		await mkdir(evilFileDir, { recursive: true });
-		const evilFile = join(evilFileDir, 'not-a-lock');
-		await writeFile(evilFile, '{}');
+		const evilTarget = join(tempDir, 'evil', 'not-a-lock');
+		await mkdir(evilTarget, { recursive: true });
 		const linkDir = join(tempDir, 'cache', 'opencode');
 		await mkdir(linkDir, { recursive: true });
 		const symlinkPath = join(linkDir, 'bun.lock');
-		await symlink(evilFile, symlinkPath);
+		await symlink(evilTarget, symlinkPath, symlinkType);
 
 		// Lexical guard is fooled: leaf bun.lock, parent opencode, grandparent cache.
 		expect(isSafeLockFilePath(symlinkPath)).toBe(true);
 
 		const canonical = safeRealpathSync(symlinkPath, symlinkPath);
-		expect(canonical).toBe(evilFile);
+		expect(canonical).toBe(evilTarget);
 		// Canonicalized guard refuses: leaf is 'not-a-lock'.
 		expect(isSafeLockFilePath(canonical as string)).toBe(false);
 	});

--- a/tests/unit/commands/reset-backup.test.ts
+++ b/tests/unit/commands/reset-backup.test.ts
@@ -120,7 +120,11 @@ describe('backupSwarmStateBeforeReset', () => {
 		);
 		tempRoots.push(realTarget);
 		fs.writeFileSync(path.join(realTarget, 'plan.json'), '{"a":1}');
-		fs.symlinkSync(realTarget, path.join(root, '.swarm'), 'dir');
+		fs.symlinkSync(
+			realTarget,
+			path.join(root, '.swarm'),
+			process.platform === 'win32' ? 'junction' : 'dir',
+		);
 
 		const result = backupSwarmStateBeforeReset(root, 'reset', ['plan.json']);
 

--- a/tests/unit/config/checkpoint-schema-prototype.test.ts
+++ b/tests/unit/config/checkpoint-schema-prototype.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { CheckpointConfigSchema } from '../../../src/config/schema';
+
+describe('CheckpointConfigSchema prototype safety', () => {
+	test('rejects an own __proto__ property before Zod strips it', () => {
+		const result = CheckpointConfigSchema.safeParse({
+			enabled: true,
+			['__proto__']: { polluted: true },
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects an object whose prototype was replaced', () => {
+		const polluted = { enabled: true } as Record<string, unknown>;
+		Object.setPrototypeOf(polluted, { polluted: true });
+
+		expect(CheckpointConfigSchema.safeParse(polluted).success).toBe(false);
+	});
+
+	test('rejects a null-prototype object', () => {
+		const input = Object.assign(Object.create(null), { enabled: true });
+
+		expect(CheckpointConfigSchema.safeParse(input).success).toBe(false);
+	});
+
+	test('fails closed when prototype reflection throws', () => {
+		const input = new Proxy(
+			{ enabled: true },
+			{
+				getPrototypeOf() {
+					throw new Error('blocked reflection');
+				},
+			},
+		);
+
+		expect(() => CheckpointConfigSchema.safeParse(input)).not.toThrow();
+		expect(CheckpointConfigSchema.safeParse(input).success).toBe(false);
+	});
+
+	test('preserves valid defaults', () => {
+		const result = CheckpointConfigSchema.parse({});
+
+		expect(result).toEqual({
+			enabled: true,
+			auto_checkpoint_threshold: 3,
+			allow_empty_commits: false,
+		});
+	});
+});

--- a/tests/unit/hooks/delegation-gate-worktree-isolation.lane-teardown-fr205.supplemental.test.ts
+++ b/tests/unit/hooks/delegation-gate-worktree-isolation.lane-teardown-fr205.supplemental.test.ts
@@ -7,15 +7,7 @@
  *
  * @note Tier 1 DI — uses real temp dirs and real functions.
  */
-import {
-	afterEach,
-	beforeEach,
-	describe,
-	expect,
-	it,
-	mock,
-	test,
-} from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import * as fs from 'node:fs';
 import * as realFs from 'node:fs/promises';
 import * as os from 'node:os';
@@ -69,24 +61,25 @@ describe('FR-205 SC-135: symlink safety — unlink removes symlink, not target',
 		}
 	});
 
-	it('removing a symlink does not delete the target file', async () => {
+	it('removing a linked file does not delete the target file', async () => {
 		// Create a real file in the target directory
 		const targetFile = path.join(symlinkTargetDir, 'real-content.txt');
 		fs.writeFileSync(targetFile, 'this is the real target content');
 
 		// Create a symlink at the lane env path pointing to the target file
 		const envSymlinkPath = path.join(tempDir, '.swarm', 'lanes', '0.env');
-		try {
+		if (process.platform === 'win32') {
+			fs.linkSync(targetFile, envSymlinkPath);
+		} else {
 			fs.symlinkSync(targetFile, envSymlinkPath);
-		} catch {
-			// On Windows, creating symlinks may require elevated privileges
-			test.skip('symlink creation failed — skipping on this platform');
-			return;
 		}
 
-		// Verify the symlink exists and target file exists
-		const symlinkExists = fs.lstatSync(envSymlinkPath).isSymbolicLink();
-		expect(symlinkExists).toBe(true);
+		const linkedEntry = fs.lstatSync(envSymlinkPath);
+		expect(
+			process.platform === 'win32'
+				? linkedEntry.isFile()
+				: linkedEntry.isSymbolicLink(),
+		).toBe(true);
 		const targetExistsBefore = fs.existsSync(targetFile);
 		expect(targetExistsBefore).toBe(true);
 
@@ -114,12 +107,11 @@ describe('FR-205 SC-135: symlink safety — unlink removes symlink, not target',
 
 		// Create a symlink to the directory at the env path
 		const envSymlinkPath = path.join(tempDir, '.swarm', 'lanes', '0.env');
-		try {
-			fs.symlinkSync(targetDir, envSymlinkPath, 'junction');
-		} catch {
-			test.skip('symlink creation failed — skipping on this platform');
-			return;
-		}
+		fs.symlinkSync(
+			targetDir,
+			envSymlinkPath,
+			process.platform === 'win32' ? 'junction' : 'dir',
+		);
 
 		// Verify target dir has files before removal
 		const filesBefore = fs.readdirSync(targetDir);

--- a/tests/unit/scripts/check-test-file-cap.test.ts
+++ b/tests/unit/scripts/check-test-file-cap.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { bashCommand } from '../../helpers/bash';
 
 const SCRIPT = path.resolve(process.cwd(), 'scripts', 'check-test-file-cap.sh');
 
@@ -19,23 +20,21 @@ interface SpawnResult {
 	stderr: string;
 }
 
-async function runScript(
-	repoDir: string,
-	env?: Record<string, string>,
-): Promise<SpawnResult> {
-	const proc = Bun.spawn({
-		cmd: ['bash', SCRIPT],
+function runScript(repoDir: string, env?: Record<string, string>): SpawnResult {
+	const proc = Bun.spawnSync({
+		cmd: bashCommand(SCRIPT),
 		cwd: repoDir,
 		env: { ...process.env, ...env },
+		stdin: 'ignore',
 		stdout: 'pipe',
 		stderr: 'pipe',
+		timeout: 30_000,
 	});
-	const [stdout, stderr] = await Promise.all([
-		new Response(proc.stdout).text(),
-		new Response(proc.stderr).text(),
-	]);
-	const exitCode = await proc.exited;
-	return { exitCode, stdout, stderr };
+	return {
+		exitCode: proc.exitCode,
+		stdout: proc.stdout.toString(),
+		stderr: proc.stderr.toString(),
+	};
 }
 
 function git(repoDir: string, ...args: string[]): void {
@@ -43,8 +42,10 @@ function git(repoDir: string, ...args: string[]): void {
 		cmd: ['git', ...args],
 		cwd: repoDir,
 		env: process.env,
+		stdin: 'ignore',
 		stdout: 'pipe',
 		stderr: 'pipe',
+		timeout: 10_000,
 	});
 	if (proc.exitCode !== 0) {
 		throw new Error(

--- a/tests/unit/scripts/check-test-tmpdir-project-relative.test.ts
+++ b/tests/unit/scripts/check-test-tmpdir-project-relative.test.ts
@@ -1,0 +1,91 @@
+/** Synthetic bite test for the project-relative temp-root guardrail (#1908). */
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { bashCommand } from '../../helpers/bash';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const SCRIPT = path.resolve(
+	import.meta.dir,
+	'../../../scripts/check-test-tmpdir.sh',
+);
+const tempRoots: string[] = [];
+
+function spawnSync(cmd: string[], cwd: string): Bun.SyncSubprocess {
+	return Bun.spawnSync(cmd, {
+		cwd,
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+		timeout: 10_000,
+	});
+}
+
+function git(cwd: string, ...args: string[]): void {
+	const proc = spawnSync(['git', ...args], cwd);
+	if (proc.exitCode !== 0) {
+		throw new Error(proc.stderr.toString());
+	}
+}
+
+function commit(cwd: string, message: string): void {
+	git(cwd, 'add', '-A');
+	git(cwd, 'commit', '-q', '-m', message);
+}
+
+function makeRepo(): string {
+	const cwd = canonicalMkdtemp('tmpdir-guard-1908-');
+	tempRoots.push(cwd);
+	git(cwd, 'init', '-q', '-b', 'main');
+	git(cwd, 'config', 'user.email', 'test@example.com');
+	git(cwd, 'config', 'user.name', 'Test');
+	fs.writeFileSync(path.join(cwd, 'README.md'), 'base\n');
+	commit(cwd, 'base');
+	git(cwd, 'branch', 'origin/main');
+	return cwd;
+}
+
+function writeTest(cwd: string, body: string): void {
+	const file = path.join(cwd, 'tests', 'fixture.test.ts');
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, body);
+	commit(cwd, 'fixture');
+}
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		fs.rmSync(root, { recursive: true, force: true, maxRetries: 5 });
+	}
+});
+
+describe('check-test-tmpdir project-relative guardrail', () => {
+	test('rejects the original baseDir tmp pattern and accepts canonicalMkdtemp', () => {
+		const badRepo = makeRepo();
+		writeTest(
+			badRepo,
+			[
+				'const base',
+				"Dir = 't",
+				"mp';\n",
+				'Bun.write(base',
+				"Dir + '/fixture', 'x');\n",
+			].join(''),
+		);
+		const rejected = spawnSync(bashCommand(SCRIPT), badRepo);
+		expect(rejected.exitCode).toBe(1);
+		expect(rejected.stdout.toString()).toContain(
+			'adds a project-relative test temp root',
+		);
+
+		const goodRepo = makeRepo();
+		writeTest(
+			goodRepo,
+			"import { canonicalMkdtemp } from '../helpers/tmpdir';\ncanonicalMkdtemp('fixture-');\n",
+		);
+		const accepted = spawnSync(bashCommand(SCRIPT), goodRepo);
+		expect(accepted.exitCode).toBe(0);
+		expect(accepted.stdout.toString()).toContain(
+			'All new/changed test temp roots are external and canonicalized',
+		);
+	});
+});

--- a/tests/unit/scripts/scan-deferred.test.ts
+++ b/tests/unit/scripts/scan-deferred.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { bashCommand } from '../../helpers/bash';
 
 const SCRIPT = path.resolve(
 	process.cwd(),
@@ -23,20 +24,21 @@ interface SpawnResult {
 	stderr: string;
 }
 
-async function runScript(cwd: string, args: string[]): Promise<SpawnResult> {
-	const proc = Bun.spawn({
-		cmd: ['bash', SCRIPT, ...args],
+function runScript(cwd: string, args: string[]): SpawnResult {
+	const proc = Bun.spawnSync({
+		cmd: bashCommand(SCRIPT, ...args),
 		cwd,
 		env: process.env,
+		stdin: 'ignore',
 		stdout: 'pipe',
 		stderr: 'pipe',
+		timeout: 10_000,
 	});
-	const [stdout, stderr] = await Promise.all([
-		new Response(proc.stdout).text(),
-		new Response(proc.stderr).text(),
-	]);
-	const exitCode = await proc.exited;
-	return { exitCode, stdout, stderr };
+	return {
+		exitCode: proc.exitCode,
+		stdout: proc.stdout.toString(),
+		stderr: proc.stderr.toString(),
+	};
 }
 
 function git(repoDir: string, ...args: string[]): string {
@@ -44,8 +46,10 @@ function git(repoDir: string, ...args: string[]): string {
 		cmd: ['git', ...args],
 		cwd: repoDir,
 		env: process.env,
+		stdin: 'ignore',
 		stdout: 'pipe',
 		stderr: 'pipe',
+		timeout: 10_000,
 	});
 	if (proc.exitCode !== 0) {
 		throw new Error(

--- a/tests/unit/scripts/trace-init.test.ts
+++ b/tests/unit/scripts/trace-init.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { bashCommand } from '../../helpers/bash';
 
 const SCRIPT = path.resolve(
 	process.cwd(),
@@ -24,20 +25,25 @@ interface SpawnResult {
 	stderr: string;
 }
 
-async function runScript(cwd: string, args: string[]): Promise<SpawnResult> {
-	const proc = Bun.spawn({
-		cmd: ['bash', SCRIPT, ...args],
+function runScript(
+	cwd: string,
+	args: string[],
+	env: Record<string, string | undefined> = process.env,
+): SpawnResult {
+	const proc = Bun.spawnSync({
+		cmd: bashCommand(SCRIPT, ...args),
 		cwd,
-		env: process.env,
+		env,
+		stdin: 'ignore',
 		stdout: 'pipe',
 		stderr: 'pipe',
+		timeout: 10_000,
 	});
-	const [stdout, stderr] = await Promise.all([
-		new Response(proc.stdout).text(),
-		new Response(proc.stderr).text(),
-	]);
-	const exitCode = await proc.exited;
-	return { exitCode, stdout, stderr };
+	return {
+		exitCode: proc.exitCode,
+		stdout: proc.stdout.toString(),
+		stderr: proc.stderr.toString(),
+	};
 }
 
 function git(repoDir: string, ...args: string[]): string {
@@ -45,8 +51,10 @@ function git(repoDir: string, ...args: string[]): string {
 		cmd: ['git', ...args],
 		cwd: repoDir,
 		env: process.env,
+		stdin: 'ignore',
 		stdout: 'pipe',
 		stderr: 'pipe',
+		timeout: 10_000,
 	});
 	if (proc.exitCode !== 0) {
 		throw new Error(
@@ -101,13 +109,8 @@ function makeRepo(prefix: string): string {
  * path, so without this shim the fallback branch has zero coverage.
  */
 function makeOldGitShim(): string {
-	const realGit = Bun.spawnSync({
-		cmd: ['sh', '-c', 'command -v git'],
-		env: process.env,
-		stdout: 'pipe',
-	})
-		.stdout.toString()
-		.trim();
+	const realGit = Bun.which('git');
+	if (!realGit) throw new Error('git is required for trace-init tests');
 	const shimDir = fs.mkdtempSync(
 		path.join(os.tmpdir(), 'trace-init-old-git-shim-'),
 	);
@@ -208,7 +211,7 @@ describe('trace-init.sh — issue-tracer trace directory setup (PR #1880 review)
 		expect(result.exitCode).toBe(0);
 	});
 
-	test('F-D1: refuses to follow a committed symlink that escapes the repo root', async () => {
+	test('F-D1: refuses to follow an existing directory link that escapes the repo root', async () => {
 		const outer = track(
 			fs.realpathSync(
 				fs.mkdtempSync(path.join(os.tmpdir(), 'trace-init-symlink-outer-')),
@@ -227,9 +230,12 @@ describe('trace-init.sh — issue-tracer trace directory setup (PR #1880 review)
 		fs.symlinkSync(
 			path.join(outer, 'attacker-target'),
 			path.join(repo, '.agents'),
+			process.platform === 'win32' ? 'junction' : 'dir',
 		);
-		git(repo, 'add', '-A');
-		git(repo, 'commit', '-q', '-m', 'add symlink escape');
+		if (process.platform !== 'win32') {
+			git(repo, 'add', '-A');
+			git(repo, 'commit', '-q', '-m', 'add symlink escape');
+		}
 
 		const result = await runScript(repo, ['evil-slug']);
 		expect(result.exitCode).toBe(2);
@@ -271,13 +277,15 @@ describe('trace-init.sh — issue-tracer trace directory setup (PR #1880 review)
 			],
 			cwd: linkedWorktree,
 			env: process.env,
+			stdin: 'ignore',
 			stdout: 'pipe',
 			stderr: 'pipe',
+			timeout: 10_000,
 		});
 		expect(checkIgnore.exitCode).toBe(0);
 	});
 
-	test('F-D1: refuses a committed symlink escape at a deeper ancestor (.agents/issue-traces itself, not .agents)', async () => {
+	test('F-D1: refuses a directory-link escape at a deeper ancestor (.agents/issue-traces itself, not .agents)', async () => {
 		// Distinguishes the containment check's ancestor-walk from the
 		// already-covered case where `.agents` itself is the symlink: here
 		// `.agents` is a real, committed directory and only the nested
@@ -302,9 +310,15 @@ describe('trace-init.sh — issue-tracer trace directory setup (PR #1880 review)
 		git(repo, 'add', '-A');
 		git(repo, 'commit', '-q', '-m', 'init');
 		fs.mkdirSync(path.join(repo, '.agents'));
-		fs.symlinkSync(attackerTarget, path.join(repo, '.agents', 'issue-traces'));
-		git(repo, 'add', '-A');
-		git(repo, 'commit', '-q', '-m', 'add deeper symlink escape');
+		fs.symlinkSync(
+			attackerTarget,
+			path.join(repo, '.agents', 'issue-traces'),
+			process.platform === 'win32' ? 'junction' : 'dir',
+		);
+		if (process.platform !== 'win32') {
+			git(repo, 'add', '-A');
+			git(repo, 'commit', '-q', '-m', 'add deeper symlink escape');
+		}
 
 		const result = await runScript(repo, ['evil-slug-deep']);
 		expect(result.exitCode).toBe(2);
@@ -344,21 +358,10 @@ describe('trace-init.sh — issue-tracer trace directory setup (PR #1880 review)
 			);
 
 			const shimDir = track(makeOldGitShim());
-			const proc = Bun.spawn({
-				cmd: ['bash', SCRIPT, 'old-git-slug'],
-				cwd: linkedWorktree,
-				env: {
-					...process.env,
-					PATH: `${shimDir}${path.delimiter}${process.env.PATH ?? ''}`,
-				},
-				stdout: 'pipe',
-				stderr: 'pipe',
+			const { exitCode, stderr } = runScript(linkedWorktree, ['old-git-slug'], {
+				...process.env,
+				PATH: `${shimDir}${path.delimiter}${process.env.PATH ?? ''}`,
 			});
-			const [stdout, stderr] = await Promise.all([
-				new Response(proc.stdout).text(),
-				new Response(proc.stderr).text(),
-			]);
-			const exitCode = await proc.exited;
 
 			expect(exitCode).toBe(0);
 			expect(stderr).not.toContain('unrecognized option');

--- a/tests/unit/tools/test-runner-detectors-adversarial.test.ts
+++ b/tests/unit/tools/test-runner-detectors-adversarial.test.ts
@@ -3,18 +3,14 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-// Mock the discovery module before importing test-runner
 const mockIsCommandAvailable = mock();
-mock.module('../../../src/build/discovery', () => ({
-	isCommandAvailable: (...args: unknown[]) => mockIsCommandAvailable(...args),
-	clearToolchainCache: mock(),
-	discoverBuildCommands: mock(),
-	discoverBuildCommandsFromProfiles: mock(),
-	getEcosystems: mock(() => []),
-}));
 
-// Now import after mocking is set up
-import { detectTestFramework } from '../../../src/tools/test-runner';
+import {
+	_internals,
+	detectTestFramework,
+} from '../../../src/tools/test-runner';
+
+const originalIsCommandAvailable = _internals.isCommandAvailable;
 
 describe('test-runner detector functions - adversarial tests', () => {
 	let tempDir: string;
@@ -28,9 +24,11 @@ describe('test-runner detector functions - adversarial tests', () => {
 		mockIsCommandAvailable.mockReset();
 		// Default: no commands available
 		mockIsCommandAvailable.mockImplementation(false);
+		_internals.isCommandAvailable = mockIsCommandAvailable as never;
 	});
 
 	afterEach(() => {
+		_internals.isCommandAvailable = originalIsCommandAvailable;
 		// Clean up all directories
 		for (const dir of cleanupDirs) {
 			try {
@@ -40,6 +38,7 @@ describe('test-runner detector functions - adversarial tests', () => {
 			}
 		}
 		cleanupDirs = [];
+		mock.restore();
 	});
 
 	describe('1. detectGoTest - go.mod exists but go binary unavailable', () => {

--- a/tests/unit/tools/test-runner-detectors.test.ts
+++ b/tests/unit/tools/test-runner-detectors.test.ts
@@ -2,18 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { detectTestFramework } from '../../../src/tools/test-runner';
+import {
+	_internals,
+	detectTestFramework,
+} from '../../../src/tools/test-runner';
 
-// Mock isCommandAvailable from discovery module
 const mockIsCommandAvailable = mock();
-mock.module('../../../src/build/discovery', () => ({
-	isCommandAvailable: (...args: unknown[]) => mockIsCommandAvailable(...args),
-	// Preserve other exports as no-ops
-	clearToolchainCache: mock(),
-	discoverBuildCommands: mock(),
-	discoverBuildCommandsFromProfiles: mock(),
-	getEcosystems: mock(() => []),
-}));
+const originalIsCommandAvailable = _internals.isCommandAvailable;
 
 describe('Test Framework Detectors (Go, Java, Gradle, .NET, C/C++, Swift, Dart, Ruby)', () => {
 	let tempDirs: string[];
@@ -23,9 +18,11 @@ describe('Test Framework Detectors (Go, Java, Gradle, .NET, C/C++, Swift, Dart, 
 		tempDirs = [];
 		// Reset mock
 		mockIsCommandAvailable.mockReset();
+		_internals.isCommandAvailable = mockIsCommandAvailable as never;
 	});
 
 	afterEach(() => {
+		_internals.isCommandAvailable = originalIsCommandAvailable;
 		// Clean up all temp directories
 		for (const dir of tempDirs) {
 			try {
@@ -34,6 +31,7 @@ describe('Test Framework Detectors (Go, Java, Gradle, .NET, C/C++, Swift, Dart, 
 				// Ignore cleanup errors
 			}
 		}
+		mock.restore();
 	});
 
 	function createTempDir(suffix: string): string {

--- a/tests/unit/tools/test-runner-wiring-adversarial.test.ts
+++ b/tests/unit/tools/test-runner-wiring-adversarial.test.ts
@@ -3,44 +3,33 @@
  * Testing Task 3.3: 9 new test framework detectors and their wiring
  */
 
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import {
-	afterEach,
-	beforeEach,
-	describe,
-	expect,
-	it,
-	mock,
-	spyOn,
-} from 'bun:test';
-import { detectTestFramework } from '../../../src/tools/test-runner';
+	_internals,
+	detectTestFramework,
+} from '../../../src/tools/test-runner';
 
-// Mock isCommandAvailable using module mock
 const mockIsCommandAvailable = mock();
-mock.module('../../../src/build/discovery', () => ({
-	isCommandAvailable: (...args: unknown[]) =>
-		mockIsCommandAvailable(...(args as [string])),
-}));
+const mockExistsSync = mock();
 
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-// Use spyOn instead of vi.mock for fs.existsSync so the spy can be properly
-// restored in afterEach and does not contaminate other test files in the same process.
-let fsExistsSyncSpy: ReturnType<typeof spyOn<typeof fs, 'existsSync'>>;
+const originalIsCommandAvailable = _internals.isCommandAvailable;
+const originalExistsSync = _internals.existsSync;
 
 describe('detectTestFramework - Adversarial Security Tests', () => {
 	beforeEach(() => {
-		mock.restore();
 		mock.clearAllMocks();
 		mockIsCommandAvailable.mockImplementation(() => false);
-		// Spy on existsSync per-test so it's automatically restored in afterEach
-		fsExistsSyncSpy = spyOn(fs, 'existsSync').mockImplementation(() => false);
+		mockExistsSync.mockImplementation(() => false);
+		_internals.isCommandAvailable = mockIsCommandAvailable as never;
+		_internals.existsSync = mockExistsSync as never;
 	});
 
 	afterEach(() => {
+		_internals.isCommandAvailable = originalIsCommandAvailable;
+		_internals.existsSync = originalExistsSync;
 		mock.restore();
-		// Restore the real existsSync so other test files are not affected
-		fsExistsSyncSpy.mockRestore();
 	});
 
 	describe('1. Path traversal in cwd argument', () => {
@@ -178,7 +167,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 			mockIsCommandAvailable.mockImplementation(
 				(cmd: string) => cmd === 'go' || cmd === 'mvn',
 			);
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				// Return true for both go.mod and pom.xml
 				return pathStr.endsWith('go.mod') || pathStr.endsWith('pom.xml');
@@ -191,7 +180,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 
 		it('should return maven when only pom.xml exists (no go.mod)', async () => {
 			mockIsCommandAvailable.mockImplementation((cmd: string) => cmd === 'mvn');
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				return pathStr.endsWith('pom.xml');
 			});
@@ -202,7 +191,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 
 		it('should return gradle when build.gradle exists', async () => {
 			mockIsCommandAvailable.mockReturnValue(true);
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				return pathStr.endsWith('build.gradle');
 			});
@@ -213,7 +202,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 
 		it('should respect priority: go > maven > gradle', async () => {
 			mockIsCommandAvailable.mockReturnValue(true);
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				// All three exist
 				return (
@@ -229,7 +218,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 
 		it('should respect priority: maven > gradle > dotnet-test', async () => {
 			mockIsCommandAvailable.mockReturnValue(true);
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				return (
 					pathStr.endsWith('pom.xml') ||
@@ -246,7 +235,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 	describe('5. Binary check bypass', () => {
 		it('should return none when go.mod exists but go binary is not available', async () => {
 			mockIsCommandAvailable.mockReturnValue(false); // No binaries available
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				return pathStr.endsWith('go.mod');
 			});
@@ -257,7 +246,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 
 		it('should return none when pom.xml exists but mvn binary is not available', async () => {
 			mockIsCommandAvailable.mockReturnValue(false);
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				return pathStr.endsWith('pom.xml');
 			});
@@ -268,7 +257,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 
 		it('should return none when build.gradle exists but gradle/gradlew not available', async () => {
 			mockIsCommandAvailable.mockReturnValue(false);
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				return pathStr.endsWith('build.gradle');
 			});
@@ -279,7 +268,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 
 		it('should return none when .csproj exists but dotnet binary is not available', async () => {
 			mockIsCommandAvailable.mockReturnValue(false);
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				return pathStr.endsWith('.csproj') || pathStr === '/fake/cwd';
 			});
@@ -290,7 +279,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 
 		it('should return none when CMakeLists.txt exists but ctest binary is not available', async () => {
 			mockIsCommandAvailable.mockReturnValue(false);
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				return pathStr.endsWith('CMakeLists.txt');
 			});
@@ -301,7 +290,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 
 		it('should return none when Package.swift exists but swift binary is not available', async () => {
 			mockIsCommandAvailable.mockReturnValue(false);
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				return pathStr.endsWith('Package.swift');
 			});
@@ -312,7 +301,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 
 		it('should return none when pubspec.yaml exists but dart/flutter binaries are not available', async () => {
 			mockIsCommandAvailable.mockReturnValue(false);
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				return pathStr.endsWith('pubspec.yaml');
 			});
@@ -323,7 +312,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 
 		it('should return none when .rspec exists but rspec/bundle binaries are not available', async () => {
 			mockIsCommandAvailable.mockReturnValue(false);
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				return pathStr.endsWith('.rspec');
 			});
@@ -334,7 +323,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 
 		it('should return none when test dir exists but ruby binary is not available', async () => {
 			mockIsCommandAvailable.mockReturnValue(false);
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const pathStr = String(p);
 				return pathStr === 'test' || pathStr.endsWith('Gemfile');
 			});
@@ -382,7 +371,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 			mockIsCommandAvailable.mockImplementation(() => {
 				throw new Error('Simulated error');
 			});
-			fsExistsSyncSpy.mockImplementation(() => {
+			mockExistsSync.mockImplementation(() => {
 				throw new Error('Simulated error');
 			});
 
@@ -394,7 +383,7 @@ describe('detectTestFramework - Adversarial Security Tests', () => {
 		it('should not crash when mock behavior is inconsistent', async () => {
 			let callCount = 0;
 			mockIsCommandAvailable.mockImplementation(() => callCount++ % 2 === 0);
-			fsExistsSyncSpy.mockImplementation((p) => {
+			mockExistsSync.mockImplementation((p) => {
 				const idx = callCount++;
 				const pathStr = String(p);
 				// Only return true for paths that don't match any framework marker

--- a/tests/unit/tools/test-runner-wiring.test.ts
+++ b/tests/unit/tools/test-runner-wiring.test.ts
@@ -1,53 +1,41 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-
-afterEach(() => {
-	mock.restore();
-});
-
-import type * as fs from 'node:fs';
-import * as realFs from 'node:fs';
 import * as path from 'node:path';
 
-// IMPORTANT MOCK PATTERN
 const mockIsCommandAvailable = mock();
-mock.module('../../../src/build/discovery', () => ({
-	isCommandAvailable: (...args: unknown[]) =>
-		mockIsCommandAvailable(...(args as [string])),
-}));
-
 const mockExistsSync = mock();
 const mockReaddirSync = mock();
 const mockReadFileSync = mock();
-mock.module('node:fs', () => ({
-	...realFs,
-	existsSync: (...args: unknown[]) =>
-		mockExistsSync(...(args as [fs.PathLike])),
-	readdirSync: (...args: unknown[]) => mockReaddirSync(...(args as [string])),
-	readFileSync: (...args: unknown[]) =>
-		mockReadFileSync(...(args as [string, string])),
-	default: {
-		...realFs,
-		existsSync: (...args: unknown[]) =>
-			mockExistsSync(...(args as [fs.PathLike])),
-		readdirSync: (...args: unknown[]) => mockReaddirSync(...(args as [string])),
-		readFileSync: (...args: unknown[]) =>
-			mockReadFileSync(...(args as [string, string])),
-	},
-}));
 
 import {
+	_internals,
 	detectTestFramework,
 	SUPPORTED_FRAMEWORKS,
 } from '../../../src/tools/test-runner';
 
+const originalIsCommandAvailable = _internals.isCommandAvailable;
+const originalExistsSync = _internals.existsSync;
+const originalReaddirSync = _internals.readdirSync;
+const originalReadFileSync = _internals.readFileSync;
+
 beforeEach(() => {
-	mock.restore();
 	mock.clearAllMocks();
 	// Default mocks for safety
 	mockIsCommandAvailable.mockImplementation(() => false);
 	mockExistsSync.mockImplementation(() => false);
 	mockReaddirSync.mockImplementation(() => []);
 	mockReadFileSync.mockImplementation(() => '{}');
+	_internals.isCommandAvailable = mockIsCommandAvailable as never;
+	_internals.existsSync = mockExistsSync as never;
+	_internals.readdirSync = mockReaddirSync as never;
+	_internals.readFileSync = mockReadFileSync as never;
+});
+
+afterEach(() => {
+	_internals.isCommandAvailable = originalIsCommandAvailable;
+	_internals.existsSync = originalExistsSync;
+	_internals.readdirSync = originalReaddirSync;
+	_internals.readFileSync = originalReadFileSync;
+	mock.restore();
 });
 
 describe('Group 1: SUPPORTED_FRAMEWORKS constant', () => {

--- a/tests/unit/tools/test-runner.test.ts
+++ b/tests/unit/tools/test-runner.test.ts
@@ -3,24 +3,24 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-// Import the module under test
 const testRunnerModule = await import('../../../src/tools/test-runner');
 
-// Runtime capability check: detect whether pwsh (PowerShell) is installed.
-// Tests that invoke pwsh are skipped when it is not available.
-let hasPwsh = false;
+const PESTER_PROBE =
+	'if (Get-Module -ListAvailable -Name Pester) { exit 0 }; exit 1';
+let hasPester = false;
 try {
-	const proc = Bun.spawnSync([
-		'pwsh',
-		'-NoLogo',
-		'-NonInteractive',
-		'-Command',
-		'exit 0',
-	]);
-	hasPwsh = proc.exitCode === 0;
-} catch {
-	hasPwsh = false;
-}
+	const proc = Bun.spawnSync(
+		['pwsh', '-NoLogo', '-NonInteractive', '-Command', PESTER_PROBE],
+		{
+			cwd: import.meta.dir,
+			stdin: 'ignore',
+			stdout: 'ignore',
+			stderr: 'ignore',
+			timeout: 10_000,
+		},
+	);
+	hasPester = proc.exitCode === 0;
+} catch {}
 
 // Extract the exports we need
 const {
@@ -540,7 +540,7 @@ describe('test-runner.ts - Security Validation', () => {
 		})();
 	}, 10000);
 
-	test.skipIf(!hasPwsh)(
+	test.skipIf(!hasPester)(
 		'accepts direct test files for convention scope without source extensions',
 		async () => {
 			const tempDir = fs.realpathSync(

--- a/tests/unit/turbo/lean/partition-common.test.ts
+++ b/tests/unit/turbo/lean/partition-common.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { getValidatedFiles } from '../../../../src/turbo/lean/partition-common';
+
+describe('getValidatedFiles', () => {
+	test('keeps scopes relative when the macOS workspace lives below /private', () => {
+		const workspace = '/private/var/folders/test/opencode-swarm';
+
+		expect(getValidatedFiles(['src/a.ts'], workspace)).toEqual([
+			['src/a.ts'],
+			0,
+		]);
+	});
+
+	test('normalizes an absolute scope inside the workspace to its relative path', () => {
+		const workspace = '/private/var/folders/test/opencode-swarm';
+
+		expect(
+			getValidatedFiles(
+				['/private/var/folders/test/opencode-swarm/src/a.ts'],
+				workspace,
+			),
+		).toEqual([['src/a.ts'], 0]);
+	});
+
+	test('rejects an absolute scope outside the workspace', () => {
+		const workspace = '/private/var/folders/test/opencode-swarm';
+
+		expect(
+			getValidatedFiles(['/private/var/folders/test/other/a.ts'], workspace),
+		).toEqual([[], 1]);
+	});
+});

--- a/tests/unit/turbo/lean/planner.test.ts
+++ b/tests/unit/turbo/lean/planner.test.ts
@@ -368,7 +368,7 @@ describe('planLeanTurboLanes', () => {
 					f.toLowerCase().replace(/\\/g, '/'),
 				),
 			).toEqual([
-				path.join(tempDir, 'package.json').toLowerCase().replace(/\\/g, '/'),
+				'package.json',
 			]);
 		});
 
@@ -892,7 +892,7 @@ describe('planLeanTurboLanes', () => {
 			expect(
 				result.lanes[0].files.map((f) => f.toLowerCase().replace(/\\/g, '/')),
 			).toContain(
-				path.join(tempDir, 'src/correct.ts').toLowerCase().replace(/\\/g, '/'),
+				'src/correct.ts',
 			);
 			expect(result.lanes[0].files).not.toContain('src/wrong.ts');
 		});
@@ -984,7 +984,7 @@ describe('planLeanTurboLanes', () => {
 			expect(
 				result.lanes[0].files.map((f) => f.toLowerCase().replace(/\\/g, '/')),
 			).toEqual([
-				path.join(tempDir, 'src/a.ts').toLowerCase().replace(/\\/g, '/'),
+				'src/a.ts',
 			]);
 			expect(result.lanes[0].status).toBe('pending');
 		});

--- a/tests/unit/turbo/lean/planner.test.ts
+++ b/tests/unit/turbo/lean/planner.test.ts
@@ -367,9 +367,7 @@ describe('planLeanTurboLanes', () => {
 				result.degradedTasks[0].files.map((f) =>
 					f.toLowerCase().replace(/\\/g, '/'),
 				),
-			).toEqual([
-				'package.json',
-			]);
+			).toEqual(['package.json']);
 		});
 
 		test('task touching lockfile is degraded', () => {
@@ -891,9 +889,7 @@ describe('planLeanTurboLanes', () => {
 			// Should use provided scope, not the file
 			expect(
 				result.lanes[0].files.map((f) => f.toLowerCase().replace(/\\/g, '/')),
-			).toContain(
-				'src/correct.ts',
-			);
+			).toContain('src/correct.ts');
 			expect(result.lanes[0].files).not.toContain('src/wrong.ts');
 		});
 	});
@@ -983,9 +979,7 @@ describe('planLeanTurboLanes', () => {
 			expect(result.lanes[0].taskIds).toEqual(['1.1']);
 			expect(
 				result.lanes[0].files.map((f) => f.toLowerCase().replace(/\\/g, '/')),
-			).toEqual([
-				'src/a.ts',
-			]);
+			).toEqual(['src/a.ts']);
 			expect(result.lanes[0].status).toBe('pending');
 		});
 	});

--- a/tests/unit/utils/path-security.test.ts
+++ b/tests/unit/utils/path-security.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+	_internals,
 	containsControlChars,
 	containsPathTraversal,
 	validateDirectory,
@@ -148,53 +149,22 @@ describe('validateSymlinkBoundary', () => {
 		).not.toThrow();
 	});
 
-	test.skipIf(process.platform !== 'win32')(
-		'handles asymmetric existence of a rootless-absolute path (root exists, target does not) without a spurious throw',
-		() => {
-			// Regression test for the drive-letter asymmetry bug: a rootless
-			// POSIX-style absolute path (leading '/', no drive letter) is
-			// resolved by Windows APIs relative to the CURRENT PROCESS DRIVE.
-			// If such a path happens to exist on disk (e.g. leftover state from
-			// an unrelated process/test) while a nested path under it does not,
-			// realpathSync succeeds for the existing one (producing a
-			// drive-letter-qualified resolved path) but throws for the
-			// non-existent one, falling back to the normalize/resolve branch.
-			// Before the fix (path.normalize fallback), that fallback did NOT
-			// add a drive letter, so the comparison was drive-lettered root vs
-			// non-drive-lettered target — a spurious "escaped boundary" throw
-			// unrelated to any real boundary violation. path.resolve anchors
-			// both consistently to the current drive regardless of which side
-			// actually exists.
-			//
-			// This exercises a genuinely current-drive-relative Windows path,
-			// which os.tmpdir() cannot express portably (it may live on a
-			// different drive than process.cwd()) — so this test intentionally
-			// creates a real directory directly under the current drive root
-			// rather than under os.tmpdir(), with a unique name and
-			// unconditional cleanup, and is skipped entirely off win32 where
-			// the drive-letter concept (and therefore this bug class) does not
-			// exist.
-			const rootless = `/boundary-asymmetric-test-${process.pid}-${Date.now()}`;
-			// Rootless target — keep it a POSIX-style string (no drive letter) so
-			// its realpathSync failure falls back through the same code path as
-			// root, rather than inheriting a drive letter via path.join from an
-			// already-resolved parent.
-			const targetRootless = `${rootless}/definitely-does-not-exist-subpath`;
-			const realRootDir = path.resolve(rootless);
-
-			// Create only the root — the nested target subpath must NOT exist,
-			// so realpathSync succeeds for root (drive-lettered) but throws for
-			// target (falls back to the normalize/resolve branch under test).
-			fs.mkdirSync(realRootDir, { recursive: true });
-			try {
-				expect(() =>
-					validateSymlinkBoundary(targetRootless, rootless),
-				).not.toThrow();
-			} finally {
-				fs.rmSync(realRootDir, { recursive: true, force: true });
-			}
-		},
-	);
+	test('handles asymmetric root existence without drive-root writes', () => {
+		const rootless = '/boundary-asymmetric-test';
+		const targetRootless = `${rootless}/definitely-does-not-exist`;
+		const originalRealpathSync = _internals.realpathSync;
+		_internals.realpathSync = ((candidate: fs.PathLike) => {
+			if (String(candidate) === rootless) return path.resolve(rootless);
+			throw new Error('ENOENT: synthetic non-existent child');
+		}) as typeof fs.realpathSync;
+		try {
+			expect(() =>
+				validateSymlinkBoundary(targetRootless, rootless),
+			).not.toThrow();
+		} finally {
+			_internals.realpathSync = originalRealpathSync;
+		}
+	});
 
 	test('works with subdirectory of root', () => {
 		expect(() => validateSymlinkBoundary('/foo/bar/baz', '/foo')).not.toThrow();

--- a/tests/unit/utils/swarm-artifact-cache.test.ts
+++ b/tests/unit/utils/swarm-artifact-cache.test.ts
@@ -30,7 +30,12 @@ describe('swarm-artifact-cache', () => {
 
 	afterEach(async () => {
 		resetSwarmArtifactCache();
-		await rm(tempDir, { recursive: true, force: true });
+		await rm(tempDir, {
+			recursive: true,
+			force: true,
+			maxRetries: 5,
+			retryDelay: 50,
+		});
 	});
 
 	test('reuses unchanged text reads and invalidates when size changes', async () => {


### PR DESCRIPTION
Closes #1908

## Summary

- retire every tracked global, macOS-only, and integration quarantine after repairing the underlying Windows privilege, optional-runtime, cleanup, message-shape, and cross-file mock-contamination defects
- add cross-platform Git Bash and temporary-directory test helpers, restore test-runner dependency-injection seams, and enforce a diff-scoped ban on repository-local test temp roots
- migrate the two remaining `analyzeImpact` test consumers to the restored injection seam and regenerate the affected mock-allowlist entry after exact-head CI exposed the stale module mocks
- normalize Lean Turbo scope paths to the repository root before risk classification, preventing macOS `/private/...` temporary workspaces from being falsely degraded as protected paths
- repair adjacent current-main Windows integration and adversarial failures found by the complete isolated sweep, including fail-closed checkpoint prototype validation and user-global hive isolation
- document the complete stability inventory and ship the required pending release fragment; the separate systemic soak program remains tracked by #1782

## Invariant audit

- 1 (plugin init): not touched — no plugin initialization or `src/index.ts` changes; exact-head CI remains the authoritative Windows timing proof
- 2 (runtime portability): touched — the path normalization uses the portable `node:path` API; `bun run build` and the real Node ESM import of `dist/index.js` pass
- 3 (subprocesses): touched — every changed Bun/Git Bash/Pester test spawn uses array arguments, explicit cwd, ignored stdin, consumed output, and a 10s or 30s timeout; subprocess-focused adversarial files pass in isolation
- 4 (.swarm containment): touched — test fixtures use canonical external temp roots, Windows junctions/hard links, and an isolated XDG/APPDATA/HOME data environment; Lean Turbo now rejects scopes outside the repository root before lane planning; the new diff gate reports zero violations
- 5 (plan durability): not touched — no ledger, projection, checkpoint import/export, or plan status code changed
- 6 (test_runner safety): touched — impact/detector dependencies use restored `_internals` seams and broad repository validation ran as per-file shell isolation, not `test_runner` broad scope
- 7 (test writing): touched — all new tests use `bun:test`, new files are below 500 lines, over-cap files did not grow, module mocks were removed from the affected test-runner family, and focused suites were repeated three times
- 8 (session state): not touched — only host-valid fixture identity/session shapes changed; no module-level session state or eviction behavior changed
- 9 (guardrails/retry): not touched — no retry, circuit-breaker, or write-authorization code changed
- 10 (chat/system msg): touched — unified-budget fixtures now use SDK-valid user/assistant messages and preserve the single-system-message runtime contract
- 11 (tool registration): not touched — `bun run scripts/check-tool-registration.ts` passes with 112 coherent tools
- 12 (release/cache): touched — all quarantine lists are empty, the stability audit is version controlled, and `docs/releases/pending/1908-test-stability-pass.md` is included; no cache or release-owned version files changed

## Test plan

- [x] issue-tracked files: three isolated-process rounds
- [x] test-runner family: 307 passed, 3 intentional capability skips, repeated three times
- [x] shell-script cluster: 43 passed, 1 intentional Windows capability skip, repeated three times
- [x] full unit isolation sweep: 1,849 unchanged files passed; the two discovered Windows link fixtures passed three follow-up rounds (15 tests each)
- [x] integration and legacy isolation: 78 files, 955 passed, 0 failed
- [x] security/adversarial/smoke isolation: 36 files, 1,007 passed, 4 intentional skips, 0 failed
- [x] configuration isolation: 69 files, 1,748 passed, 0 failed
- [x] final reviewer changed set: 170 passed, 0 failed; isolated environment + issue-629 co-run: 20 passed, 0 failed under `bun --smol`
- [x] `bun run typecheck`
- [x] `bun run lint:ci` (2,678 files)
- [x] `bun run build`
- [x] real Node ESM import of `dist/index.js`
- [x] `bun run drift:check`
- [x] `bun run scripts/check-tool-registration.ts`
- [x] `scripts/check-test-file-cap.sh`
- [x] `scripts/check-test-tmpdir.sh`
- [x] `scripts/check-mock-cleanup.sh`
- [x] `scripts/check-bash-portability.sh`
- [x] issue-tracer deferred-work scan against `zaxbyhub/main`
- [x] exact CI failure reproductions: `test-runner-source-files` (7 passed, 1 intentional skip) and `test-runner-impact` (12 passed)
- [x] Lean Turbo macOS root regression: 243 passed across the `/private` scope test, planner/risk coverage, and all four previously failing worktree suites
- [x] exact-head Ubuntu/macOS/Windows CI: run `29847660873` succeeded at `8f50d914610c90fdb7d7d19d053b55493c90a577`
- [ ] merge-group validation (requires the PR to be ready and queued; no merge authority was requested)

Local baseline notes: the repository-wide `check-invariants.sh` is already red on clean `main` with 755 mock-allowlist entries; this branch reduces that count to 747 and the focused mock gate passes. The local `repro-704` probe is worktree-sensitive here (branch T1 miss; clean-main comparison hangs past its process bound), so this PR requires exact-head Windows CI before merge.
