### PR TITLE
ci(mock-allowlist): add growth-direction ratchet with APPROVED-NEW escape hatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ Every PR that touches a relevant area must list which of these invariants it tou
     readFileSync: mockFn, // override only what you need
   }));
   ```
+- **`mock.module` allowlist growth ratchet (issue #1666):** `scripts/mock-allowlist.txt` is closed against unapproved growth by `scripts/check-invariants.sh` Check 4. Adding a new `mock.module` target requires a matching standalone marker line `# APPROVED-NEW: <normalized-target>` in `scripts/mock-allowlist.txt` (preserved across regen by `scripts/generate-mock-allowlist.sh`). `MOCK_ALLOWLIST_ENFORCE=0` soft-warns for a deliberate growth PR. Prefer `_internals` DI for new code — the allowlist is a legacy-pattern debt surface, not a way to bypass the seam convention.
 - Use `os.tmpdir()` + `path.join(...)` for temp paths. No hardcoded `/tmp` or `C:\` strings.
 - `mkdtempSync` must be wrapped in `realpathSync` if the result is `chdir`'d on macOS.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -57,9 +57,12 @@ mock.module('node:child_process', () => ({
 1. All `mock.module` calls have `afterEach(mock.restore())` cleanup or file-scoped `mockClear`/`mockReset` pattern
 2. All `mock.module('node:*', ...)` calls spread real exports (e.g., `...realFs`) to prevent test pollution
 
+**Allowlist growth ratchet (issue #1666):** `scripts/check-invariants.sh` Check 4 ratchets `scripts/mock-allowlist.txt` closed against unapproved growth. Adding a new `mock.module` target requires a matching standalone marker line `# APPROVED-NEW: <normalized-target>` in the allowlist (preserved across regen by `scripts/generate-mock-allowlist.sh`). `MOCK_ALLOWLIST_ENFORCE=0` soft-warns for a deliberate growth PR. Prefer the `_internals` DI seam for new code.
+
 Run locally before pushing:
 ```bash
 bash scripts/check-mock-cleanup.sh
+bash scripts/check-invariants.sh
 ```
 
 Intentionally skipped on Windows (async child process handles cause EBUSY):

--- a/contributing.md
+++ b/contributing.md
@@ -242,6 +242,8 @@ The `quality` job also runs `scripts/check-mock-cleanup.sh` which enforces:
 - All `mock.module` calls have proper cleanup (`afterEach(mock.restore())` or file-scoped `mockClear`/`mockReset`)
 - All `mock.module('node:*', ...)` calls spread real exports (e.g., `...realFs`) to prevent test pollution
 
+The same job runs `scripts/check-invariants.sh` Check 4 (issue #1666): the `scripts/mock-allowlist.txt` allowlist is closed against unapproved growth. Adding a new `mock.module` target requires a matching standalone marker line `# APPROVED-NEW: <normalized-target>` in `scripts/mock-allowlist.txt` (preserved across regen by `scripts/generate-mock-allowlist.sh`). `MOCK_ALLOWLIST_ENFORCE=0` soft-warns for a deliberate growth PR. Prefer the `_internals` DI seam for new code — the allowlist is legacy debt, not a bypass.
+
 ---
 
 ## Test rules

--- a/docs/engineering-invariants.md
+++ b/docs/engineering-invariants.md
@@ -475,6 +475,7 @@ Split criteria: one behavioral aspect per file, shared test utilities extracted 
 **Verification:**
 
 - Run `scripts/check-mock-cleanup.sh` — it enforces Check 2: every `mock.module('node:*', ...)` must spread real exports (e.g., `...realFs`, `...realChildProcess`).
+- Run `scripts/check-invariants.sh` — Check 3 enforces the `scripts/mock-allowlist.txt` membership, and Check 4 (issue #1666) ratchets the allowlist closed against unapproved growth. Adding a new `mock.module` target requires a matching `# APPROVED-NEW: <normalized-target>` marker line in `scripts/mock-allowlist.txt`; `MOCK_ALLOWLIST_ENFORCE=0` soft-warns for a deliberate growth PR.
 - Run the new bounded tests alongside the existing real-git tests; no cross-file pollution.
 - New test files must be under 500 lines — `delegation-gate.test.ts` split is the exemplar pattern.
 - FR-009 Lean Turbo tests cover: acquire-locks, plan-lanes, review, runner-status, generate-mutants, set-qa-gates, get-qa-gate-profile.

--- a/docs/releases/pending/1666-mock-allowlist-growth-ratchet.md
+++ b/docs/releases/pending/1666-mock-allowlist-growth-ratchet.md
@@ -1,0 +1,43 @@
+# mock.module allowlist growth ratchet (issue #1666, item 3)
+
+Issue: #1666
+
+## What
+
+Closes the one remaining open sub-item of issue #1666. The `mock.module` allowlist (`scripts/mock-allowlist.txt`) was a *membership* check only: `scripts/check-invariants.sh` Check 3 verified each mocked target was listed, but nothing prevented the list from growing — running `scripts/generate-mock-allowlist.sh` silently expanded it. The maintainer's own close-out comment on #1666 flagged exactly this gap ("the specific 'baseline-count growth ratchet' with `APPROVED-NEW` escape hatch isn't implemented").
+
+A new **Check 4** in `scripts/check-invariants.sh` adds a diff-scoped growth-direction ratchet:
+
+- Compares the working-tree allowlist against the PR base via `git show <base>:scripts/mock-allowlist.txt` (no parallel baseline file to keep in sync).
+- For each entry present at HEAD but not at base (i.e. *added in this PR*), requires a matching standalone marker line `# APPROVED-NEW: <normalized-target>` somewhere in the allowlist.
+- Mirrors the established `scripts/check-test-file-cap.sh` (FR-006) shape: `MOCK_ALLOWLIST_ENFORCE` env var defaults to **enforce** when unset; `MOCK_ALLOWLIST_ENFORCE=0` (or `false`/`no`/`off`) soft-warns (prints violations, exits 0) for a deliberate growth PR.
+- Shrinking the allowlist is always allowed; the ratchet only fires on growth.
+- Bash 3.2-portable (indexed arrays, `grep -E` with POSIX `[[:space:]]`, no `declare -A`, no `grep -P`); CRLF-normalized on both base and head reads so a Windows contributor with `core.autocrlf=true` does not false-fire (issue #1781 re-critic B6 landmine).
+
+`scripts/generate-mock-allowlist.sh` now **preserves `# APPROVED-NEW:` markers across regeneration** — without this, the documented workflow ("run this script to update the list") would silently erase every approval marker and re-open the gap.
+
+The issue's other two items (checked-in coverage threshold, 500-line test-file cap) were already addressed by prior work and are out of scope for this PR — the coverage gate reads `COVERAGE_THRESHOLD` from env (`scripts/ci/run-coverage-gate.sh:9`, superseded the old hardcoded 41.48% literal), and the test-file cap is enforced by `scripts/check-test-file-cap.sh`.
+
+## Why
+
+`mock.module` is a legacy pattern (AGENTS.md invariant 7 prefers the `_internals` DI seam). Without a growth ratchet, the allowlist could only ever grow, and the membership check could not distinguish "this target was approved" from "this target was added and the list was regenerated."
+
+## Migration
+
+No action required for existing PRs. Only PRs that add new `mock.module` targets need to add a `# APPROVED-NEW: <normalized-target>` line to `scripts/mock-allowlist.txt` (convention: immediately above the new entry; the line is preserved by the regenerator). For a deliberate bulk-growth PR (e.g. migrating a test suite that legitimately needs many new mocks), set `MOCK_ALLOWLIST_ENFORCE=0` on the quality job or run locally with that env var.
+
+`AGENTS.md` invariant 7, `docs/engineering-invariants.md`, `contributing.md`, and `TESTING.md` were each updated with a short note pointing at Check 4 and the escape hatch. The allowlist header itself now documents the convention.
+
+## Known caveats
+
+- The marker is **standalone-line only**: `# APPROVED-NEW: src/path/to/target` on its own line. Inline trailing comments on the entry are not accepted (the regenerator would not preserve them).
+- The marker target is normalized through `scripts/lib/normalize-mock-target.sh`, so `# APPROVED-NEW: ../../../src/foo/bar.js` matches the entry `src/foo/bar`.
+- The marker may appear **anywhere** in the allowlist (the checker does flat set-membership, not adjacency). Convention places it immediately above the entry it approves, and `scripts/generate-mock-allowlist.sh` preserves that placement across regeneration.
+- The no-base-branch path (local-dev clone without `origin/main` fetched) is non-blocking: Check 4 prints a `NOTE:` and skips. Real CI (PR + merge-group events with `actions/checkout fetch-depth: 0`) always resolves `origin/main`.
+
+## Test plan
+
+- New `tests/unit/scripts/check-mock-allowlist-ratchet.test.ts` (11 cases: no-growth pass, growth+marker pass, growth−marker fail, growth+mismatched-marker fail, marker normalization pass, multi-target partial approval fail, shrink pass, simultaneous grow+shrink pass, soft-warn escape hatch, no-base-branch skip, CRLF head / LF base pass). Pattern mirrors `check-test-file-cap.test.ts` with explicit `timeout: 30000` on every spawn.
+- Extended `tests/unit/scripts/generate-mock-allowlist.test.ts` with a marker-preservation case.
+- Extended `tests/unit/scripts/check-invariants.test.ts` with a Check 4 header smoke test and renamed the stale sibling test to "should run all four checks".
+- `scripts/check-bash-portability.sh` confirms no bash4+-only constructs were introduced, and now also detects the empty-array `"${arr[@]}"`-under-`set -u` class (the bug class that originally failed macOS CI on this PR's first push — see revision 2).

--- a/scripts/check-bash-portability.sh
+++ b/scripts/check-bash-portability.sh
@@ -29,6 +29,14 @@
 #     reviewer's independent re-derivation during issue #1737 review.
 #   - `coproc` — coprocess keyword, added in bash 4.0.
 #   - `mapfile` / `readarray` — builtins added in bash 4.0 (synonyms).
+#   - Empty-array `"${arr[@]}"` expansion under `set -u` when the array was
+#     initialized empty (`arr=()`) earlier in the file. Under bash 3.2 this
+#     aborts with "unbound variable"; fixed in bash 4.4 (Debian #529627,
+#     ShellCheck #2387). Issue #1922 PRR-001/002/011 — this exact class killed
+#     macOS CI for the Check 4 ratchet. The fix is the `${arr[@]+"${arr[@]}"}`
+#     alternate-value expansion. The detector only flags arrays with a visible
+#     `name=()` empty-init earlier in the file (not arrays that are always
+#     populated by construction — those cannot trip the bug).
 # NOT flagged: hex escapes like `\x27`. bash 3.2 DOES support `\xHH` inside
 # `$'...'` ANSI-C-quoted strings (that support predates 4.0) — the actual
 # check-invariants.sh incident was about `grep -P`'s `\x27`, not bash's own
@@ -84,6 +92,40 @@ while IFS= read -r file; do
         echo "ERROR: $file uses \`mapfile\`/\`readarray\` (bash 4+ builtins) — not supported on macOS's bash 3.2."
         echo "       Use a while-read loop instead (see scripts/check-invariants.sh for the established pattern)."
         file_has_violation=1
+    fi
+
+    # Empty-array expansion under `set -u` (issue #1922 PRR-001/002/011).
+    # Under bash 3.2 + `set -u`, `"${arr[@]}"` over a declared-but-empty
+    # array aborts with "unbound variable" (Debian #529627, ShellCheck #2387).
+    # Heuristic: scan only scripts that use `set -.*u`, and within those,
+    # for each `name=()` empty-init declaration, flag any later bare
+    # `"${name[@]}"` expansion NOT guarded by the `${name[@]+...}` form.
+    # This avoids false-positives on arrays always populated by construction
+    # (e.g. `PAIRS=(a b c)` then `for x in "${PAIRS[@]}"`).
+    if echo "$code_only" | grep -qE '(^|[[:space:]])set[[:space:]]+-[^-]*u|(^|[[:space:]])set[[:space:]]+-[^-]*[eu][^-]*u'; then
+        # Find empty-init array names: lines like `name=()` or `local name=()`.
+        # Use grep -oE to extract the name; bash identifier charset is [A-Za-z_][A-Za-z0-9_]*.
+        empty_init_names="$(echo "$code_only" | grep -E '^[[:space:]]*(local[[:space:]]+|readonly[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=\([[:space:]]*\)' | sed -E 's/^[[:space:]]*(local[[:space:]]+|readonly[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=.*/\2/' | sort -u || true)"
+        if [ -n "$empty_init_names" ]; then
+            while IFS= read -r arr_name; do
+                [ -n "$arr_name" ] || continue
+                # Match a BARE `"${arr_name[@]}"` (not the guarded `${arr_name[@]+"${arr_name[@]}"}`).
+                # The negative-lookbehind on `${arr_name[@]+` is approximated by
+                # searching for the bare pattern and then excluding lines that
+                # contain the guarded pattern.
+                bare_hits="$(echo "$code_only" | grep -F "\"\${${arr_name}[@]}\"" || true)"
+                guarded_hits="$(echo "$code_only" | grep -F "\${${arr_name}[@]+\"\${${arr_name}[@]}\"}" || true)"
+                # Remove any line that appears in guarded_hits from bare_hits.
+                # (Line-by-line set difference via grep -Fxv.)
+                unguarded="$(echo "$bare_hits" | grep -Fxvf <(printf '%s\n' "$guarded_hits") || true)"
+                if [ -n "$unguarded" ]; then
+                    echo "ERROR: $file expands \"\${${arr_name}[@]}\" under \`set -u\` but ${arr_name}=() is initialized empty somewhere in the file."
+                    echo "       Under bash 3.2 (macOS) this aborts with 'unbound variable' when ${arr_name} is empty (fixed in bash 4.4)."
+                    echo "       Use the alternate-value form: \${${arr_name}[@]+\"\${${arr_name}[@]}\"}"
+                    file_has_violation=1
+                fi
+            done <<< "$empty_init_names"
+        fi
     fi
 
     if [ "$file_has_violation" -eq 1 ]; then

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 # Engineering invariant checks for opencode-swarm.
-# Runs three grep-based checks corresponding to AGENTS.md invariants 3, 4, and 7.
-# Compatible with GitHub Actions (ubuntu-latest AND macos-latest, bash).
+# Runs four grep-based checks corresponding to AGENTS.md invariants 3, 4, and 7
+# (Checks 1-3) plus the mock.module allowlist growth ratchet from issue #1666
+# (Check 4). Compatible with GitHub Actions (ubuntu-latest AND macos-latest, bash).
 # Portability constraints (issue #1729 merge_group macOS failures):
 #   - macOS ships bash 3.2 as /bin/bash: NO associative arrays (`declare -A`),
 #     NO `[[ ${arr["x"]} ]]` subscript syntax. Use plain files + grep -Fxf.
 #   - BSD grep does NOT support `-P` (Perl regex) or `\x27`. Use `grep -Eo`
 #     with explicit `'...'`/`"..."` alternation instead.
+#   - Empty-array expansion under `set -u`: bash 3.2 errors on
+#     `"${arr[@]}"` when `arr` is declared but empty (fixed in bash 4.4;
+#     Debian #529627, ShellCheck #2387). Use the `${arr[@]+"${arr[@]}"}`
+#     alternate-value pattern at every site where the array could be empty.
+#     scripts/check-bash-portability.sh enforces this.
 set -euo pipefail
 
 # Load shared normalization routine
@@ -100,8 +106,12 @@ else
 
   allowlist_contains() {
     # Linear scan; portable to bash 3.2 (no associative arrays).
+    # `${arr[@]+"${arr[@]}"}` is the bash-3.2-safe empty-array expansion
+    # (issue #1922 PRR-011): allowlist_patterns is initialized empty at
+    # line 99 and could legitimately be empty if the allowlist file is
+    # comment-only, which would trip `set -u` on macOS bash 3.2.
     local needle="$1"
-    for p in "${allowlist_patterns[@]}"; do
+    for p in ${allowlist_patterns[@]+"${allowlist_patterns[@]}"}; do
       [ "$p" = "$needle" ] && return 0
     done
     return 1
@@ -165,6 +175,149 @@ else
       | sed -E "s/^mock\.module\([[:space:]]*//; s/^'([^']+)'$/\1/; s/^\"([^\"]+)\"$/\1/" || true)
   done < <(grep -rl 'mock\.module(' tests/ src/ --include="*.test.ts" \
     --exclude-dir=node_modules --exclude-dir=dist || true)
+fi
+
+echo ""
+echo "=== Check 4: mock.module allowlist growth ratchet (issue #1666) ==="
+# Diff-scoped ratchet: fails CI when scripts/mock-allowlist.txt grows relative
+# to the PR base, unless each newly added target has a matching standalone
+# marker line  # APPROVED-NEW: <normalized-target>  somewhere in the file.
+# Mirrors scripts/check-test-file-cap.sh's diff-scoped shape and the
+# MOCK_ALLOWLIST_ENFORCE truth table (default-enforce-when-unset, like
+# TEST_CAP_ENFORCE). Closes the remaining open item of issue #1666: the
+# membership check (Check 3) cannot detect growth when the allowlist is
+# regenerated via scripts/generate-mock-allowlist.sh.
+ratchet_violations=0
+
+# --- MOCK_ALLOWLIST_ENFORCE truth table (mirrors TEST_CAP_ENFORCE) ---
+# unset OR any value other than 0/false/no/off → hard-fail (default enforce).
+# 0/false/no/off → soft-warn (exit 0). The ratchet is scoped to *new* entries
+# only (set-difference against the PR base), so defaulting to enforce in CI
+# (where the var is unset) is correct.
+if [ -z "${MOCK_ALLOWLIST_ENFORCE+x}" ]; then
+  ratchet_enforce=1  # unset → enforce (mirror check-test-file-cap.sh:46)
+else
+  case "$(echo "${MOCK_ALLOWLIST_ENFORCE}" | tr '[:upper:]' '[:lower:]')" in
+    0|false|no|off) ratchet_enforce=0;;
+    *) ratchet_enforce=1;;
+  esac
+fi
+
+# --- Resolve base branch (mirror check-test-file-cap.sh:69-76) ---
+ratchet_base_branch=""
+for branch in origin/main origin/master main master; do
+  if git rev-parse "$branch" >/dev/null 2>&1; then
+    ratchet_base_branch="$branch"
+    break
+  fi
+done
+
+# Allowlist file path is already set at Check 3 (line 82). Re-resolve in case
+# Check 3 was skipped because the file was missing (in which case there is
+# nothing to ratchet anyway).
+if [ -z "${ALLOWLIST_FILE:-}" ]; then
+  ALLOWLIST_FILE="$(dirname "$0")/mock-allowlist.txt"
+fi
+
+if [ ! -f "$ALLOWLIST_FILE" ]; then
+  echo "NOTE: $ALLOWLIST_FILE not found — Check 4 skipped (Check 3 already flagged this)."
+elif [ -z "$ratchet_base_branch" ]; then
+  # No PR context (local-dev run without origin/main fetched). Mirror
+  # check-test-tmpdir.sh:55-58: skip non-blocking rather than false-failing.
+  echo "NOTE: no base branch found (no PR context) — skipping Check 4 (non-blocking)."
+  echo "      Run from a checkout with origin/main fetched to enable the growth ratchet."
+else
+  # --- Read head entries from the working-tree allowlist ---
+  # `tr -d '\r'` normalizes CRLF→LF so a Windows contributor with
+  # core.autocrlf=true does not false-trigger "every entry is new" (issue
+  # #1781 re-critic B6 — same landmine as check-test-file-cap.sh:102).
+  head_entries=()
+  while IFS= read -r pattern; do
+    case "$pattern" in
+      ''|\#*) continue ;;
+    esac
+    head_entries+=( "$pattern" )
+  done < <(tr -d '\r' < "$ALLOWLIST_FILE")
+
+  # --- Read base entries from the PR base via `git show` ---
+  # `git show <ref>:<path>` bypasses the smudge filter and always returns LF
+  # content, but we still pipe through `tr -d '\r'` for symmetry/defense.
+  # If the path is missing at base (allowlist newly added in this PR — not
+  # realistic today but defensive), treat base as empty: everything is "new".
+  base_entries=()
+  while IFS= read -r pattern; do
+    [ -n "$pattern" ] || continue
+    case "$pattern" in
+      ''|\#*) continue ;;
+    esac
+    base_entries+=( "$pattern" )
+  done < <(git show "${ratchet_base_branch}:scripts/mock-allowlist.txt" 2>/dev/null \
+    | tr -d '\r' || true)
+
+  # --- Linear-scan membership helper (bash 3.2 portable, mirrors
+  # allowlist_contains at line 101-108) ---
+  array_contains() {
+    local needle="$1"
+    shift
+    for entry in "$@"; do
+      [ "$entry" = "$needle" ] && return 0
+    done
+    return 1
+  }
+
+  # --- Compute added set: head entries not present at base ---
+  added_entries=()
+  # Bash 3.2 + `set -u` portability (issue #1922 PRR-001/002/011, macOS CI):
+  # under bash 3.2 (macOS system bash), iterating `"${arr[@]}"` over a
+  # declared-but-empty array aborts with "unbound variable" (fixed in bash
+  # 4.4). The `${arr[@]+"${arr[@]}"}` alternate-value pattern expands to
+  # nothing when the array is empty and to the array otherwise, on every
+  # bash version back to 2.x. Apply at every empty-possible expansion site.
+  for h in ${head_entries[@]+"${head_entries[@]}"}; do
+    if ! array_contains "$h" ${base_entries[@]+"${base_entries[@]}"}; then
+      added_entries+=( "$h" )
+    fi
+  done
+
+  # --- Read approved markers from the working-tree allowlist ---
+  # Marker format (standalone line only):  # APPROVED-NEW: <normalized-target>
+  # We grep the prefix, strip it, normalize the target via
+  # normalize_mock_target (already sourced at line 13), and linear-scan
+  # compare. No regex interpolation of the target — the allowlist already
+  # contains entries with regex metacharacters (e.g. src/config/index.ts).
+  approved_markers=()
+  while IFS= read -r marker_line; do
+    [ -n "$marker_line" ] || continue
+    # Strip the leading "# APPROVED-NEW:" and surrounding whitespace.
+    target="$(echo "$marker_line" \
+      | sed -E 's/^#[[:space:]]*APPROVED-NEW:[[:space:]]*//' \
+      | sed -E 's/[[:space:]]*$//')"
+    [ -n "$target" ] || continue
+    approved_markers+=( "$(normalize_mock_target "$target")" )
+  done < <(grep -E '^#[[:space:]]*APPROVED-NEW:[[:space:]]*' "$ALLOWLIST_FILE" || true)
+
+  # --- For each added entry, require a matching approved marker ---
+  # Only increment the script-level `violations` counter when enforce is on.
+  # In soft-warn mode we still report each violation but do not fail the build
+  # (mirrors check-test-file-cap.sh:161-169's exit-decision gating).
+  for added in ${added_entries[@]+"${added_entries[@]}"}; do
+    if array_contains "$added" ${approved_markers[@]+"${approved_markers[@]}"}; then
+      continue
+    fi
+    echo "ERROR (ratchet): new mock target '$added' added to scripts/mock-allowlist.txt without approval."
+    echo "       Add a standalone marker line:  # APPROVED-NEW: $added"
+    echo "       OR remove the target and use the _internals DI seam instead (AGENTS.md invariant 7)."
+    ratchet_violations=$((ratchet_violations + 1))
+    if [ "$ratchet_enforce" -eq 1 ]; then
+      violations=$((violations + 1))
+    fi
+  done
+
+  # --- Summary line (per-PR annotation-style) ---
+  echo "Base entries: ${#base_entries[@]} | Head entries: ${#head_entries[@]} | Added in this PR: ${#added_entries[@]} | Approved-new markers found: ${#approved_markers[@]} | Unapproved: $ratchet_violations"
+  if [ "$ratchet_violations" -gt 0 ] && [ "$ratchet_enforce" -eq 0 ]; then
+    echo "MOCK_ALLOWLIST_ENFORCE is off — soft-warn (non-blocking)."
+  fi
 fi
 
 echo ""

--- a/scripts/check-mock-cleanup.sh
+++ b/scripts/check-mock-cleanup.sh
@@ -83,12 +83,16 @@ while IFS= read -r file; do
             mods+=("$mod")
         fi
     done < <(grep -E "mock\.module\(['\"]node:" "$file" 2>/dev/null || true)
-    # Remove duplicates and sort
+    # Remove duplicates and sort.
+    # `${arr[@]+"${arr[@]}"}` is the bash-3.2-safe empty-array expansion
+    # (issue #1922 PRR-011): mods is initialized empty at line 78 and could
+    # be empty for files that have no node: mocks, which would trip `set -u`
+    # on macOS bash 3.2.
     if [ ${#mods[@]} -gt 0 ]; then
-        mods=($(printf "%s\n" "${mods[@]}" | sort -u))
+        mods=($(printf "%s\n" ${mods[@]+"${mods[@]}"} | sort -u))
     fi
 
-    for mod in "${mods[@]}"; do
+    for mod in ${mods[@]+"${mods[@]}"}; do
         # Convert snake_case to camelCase and handle subpaths.
         # First letter is uppercased; subsequent letters after _ or / are also uppercased.
         # Examples: fs -> Fs, child_process -> ChildProcess, fs/promises -> FsPromises

--- a/scripts/generate-mock-allowlist.sh
+++ b/scripts/generate-mock-allowlist.sh
@@ -12,7 +12,9 @@ SCRIPT_DIR="$(dirname "$0")"
 ALLOWLIST_FILE="$SCRIPT_DIR/mock-allowlist.txt"
 ALLOWLIST_DISPLAY="scripts/mock-allowlist.txt"
 TEMP_ALLOWLIST="$(mktemp)"
-trap "rm -f '$TEMP_ALLOWLIST'" EXIT
+TEMP_APPROVED="$(mktemp)"
+trap "rm -f '$TEMP_ALLOWLIST' '$TEMP_APPROVED'" EXIT
+: > "$TEMP_APPROVED"
 
 # Load shared normalization routine
 source "$SCRIPT_DIR/lib/normalize-mock-target.sh"
@@ -53,6 +55,47 @@ if [ "$CHECK_MODE" = true ]; then
   echo "✓ mock-allowlist.txt is up-to-date" >&2
 else
   # In normal mode, regenerate the allowlist with headers
+  #
+  # Issue #1666 — preserve existing # APPROVED-NEW: <target> marker lines
+  # across regeneration. Without this, the documented workflow ("run this
+  # script to update the list") would silently erase every approval marker
+  # and re-open the gap that scripts/check-invariants.sh Check 4 closes.
+  # Harvested targets are normalized via the shared library and de-duplicated
+  # via `sort -u` (mirror the existing idiom at line 41, 45).
+  approved_markers=()
+  if [ -f "$ALLOWLIST_FILE" ]; then
+    while IFS= read -r marker_line; do
+      [ -n "$marker_line" ] || continue
+      # Strip leading "# APPROVED-NEW:" and surrounding whitespace.
+      target="$(echo "$marker_line" \
+        | sed -E 's/^#[[:space:]]*APPROVED-NEW:[[:space:]]*//' \
+        | sed -E 's/[[:space:]]*$//')"
+      [ -n "$target" ] || continue
+      approved_markers+=( "$(normalize_mock_target "$target")" )
+    done < <(grep -E '^#[[:space:]]*APPROVED-NEW:[[:space:]]*' "$ALLOWLIST_FILE" || true)
+  fi
+  # De-duplicate (defensive — merge artifacts, copy-paste). Indexed array
+  # from sorted unique input.
+  # `${arr[@]+"${arr[@]}"}` is the bash-3.2-safe empty-array expansion
+  # (issue #1922 PRR-011): the outer `${#...[@]} -gt 0` guard already
+  # prevents entry when approved_markers is empty, but self-documenting
+  # hardening is preferable to relying on the guard surviving future edits.
+  if [ "${#approved_markers[@]}" -gt 0 ]; then
+    printf '%s\n' ${approved_markers[@]+"${approved_markers[@]}"} | sort -u > "$TEMP_APPROVED"
+  else
+    : > "$TEMP_APPROVED"
+  fi
+
+  # Helper: emit a # APPROVED-NEW: marker line if the (already-normalized)
+  # generated entry is in the harvested approved set. POSIX-bash portable:
+  # plain file + grep -Fx (exact-line match, no regex interpolation).
+  emit_marker_if_approved() {
+    local entry="$1"
+    if [ -s "$TEMP_APPROVED" ] && grep -qFx "$entry" "$TEMP_APPROVED"; then
+      echo "# APPROVED-NEW: $entry"
+    fi
+  }
+
   {
     echo "# mock.module Allowlist — scripts/mock-allowlist.txt"
     echo "# One normalized target per line. Blank lines and # comments are ignored."
@@ -65,25 +108,39 @@ else
     echo "# To add a NEW mock target: append it here with a comment explaining why."
     echo "# Prefer _internals DI seam for new code — mock.module is a legacy pattern."
     echo "#"
+    echo "# The allowlist is growth-ratcheted by scripts/check-invariants.sh Check 4"
+    echo "# (issue #1666). To approve a new target added in a PR, add a standalone"
+    echo "# marker line:  # APPROVED-NEW: <normalized-target>"
+    echo "# The marker may appear anywhere in this file (flat set-membership, not"
+    echo "# adjacency); convention places it immediately above the approved entry,"
+    echo "# and this script preserves that placement across regeneration."
+    echo "# Escape hatch for a deliberate growth PR: MOCK_ALLOWLIST_ENFORCE=0 (soft-warn)."
+    echo "#"
     echo "# Last updated: $(date -u +'%Y-%m-%d') (normalization in scripts/lib/normalize-mock-target.sh)"
     echo ""
-    
+
     # Node builtins section
     if grep -q '^node:' "$TEMP_ALLOWLIST"; then
       echo "# --- Node builtins ---"
-      grep '^node:' "$TEMP_ALLOWLIST" | sort
+      while IFS= read -r entry; do
+        emit_marker_if_approved "$entry"
+        echo "$entry"
+      done < <(grep '^node:' "$TEMP_ALLOWLIST" | sort)
       echo ""
     fi
-    
+
     # Group by directory (e.g., src/agents, src/tools, etc.)
     grep -v '^node:' "$TEMP_ALLOWLIST" | sed 's|/.*||' | sort -u | while read -r category; do
       [ -z "$category" ] && continue
       echo "# --- $category ---"
-      grep "^$category/" "$TEMP_ALLOWLIST" | sort
+      while IFS= read -r entry; do
+        emit_marker_if_approved "$entry"
+        echo "$entry"
+      done < <(grep "^$category/" "$TEMP_ALLOWLIST" | sort)
       echo ""
     done
   } > "$ALLOWLIST_FILE"
-  
+
   ENTRY_COUNT=$(wc -l < "$TEMP_ALLOWLIST")
   echo "✓ Updated $ALLOWLIST_DISPLAY with $ENTRY_COUNT entries" >&2
 fi

--- a/scripts/mock-allowlist.txt
+++ b/scripts/mock-allowlist.txt
@@ -9,7 +9,15 @@
 # To add a NEW mock target: append it here with a comment explaining why.
 # Prefer _internals DI seam for new code — mock.module is a legacy pattern.
 #
-# Last updated: 2026-07-11 (normalization in scripts/lib/normalize-mock-target.sh)
+# The allowlist is growth-ratcheted by scripts/check-invariants.sh Check 4
+# (issue #1666). To approve a new target added in a PR, add a standalone
+# marker line:  # APPROVED-NEW: <normalized-target>
+# The marker may appear anywhere in this file (flat set-membership, not
+# adjacency); convention places it immediately above the approved entry,
+# and this script preserves that placement across regeneration.
+# Escape hatch for a deliberate growth PR: MOCK_ALLOWLIST_ENFORCE=0 (soft-warn).
+#
+# Last updated: 2026-07-21 (normalization in scripts/lib/normalize-mock-target.sh)
 
 # --- Node builtins ---
 node:child_process

--- a/tests/unit/scripts/check-invariants.test.ts
+++ b/tests/unit/scripts/check-invariants.test.ts
@@ -148,13 +148,27 @@ describe('check-invariants.sh', () => {
 		expect(result.stdout).toContain('Check 1: Subprocess timeout required');
 	});
 
-	test('should run all three checks', () => {
+	test('should run all four checks', () => {
 		if (isWindows) return;
 		const result = runCheckInvariants(REPO_ROOT);
 		expect(result.stdout).toContain('Check 1:');
 		expect(result.stdout).toContain('Check 2:');
 		expect(result.stdout).toContain('Check 3:');
+		expect(result.stdout).toContain('Check 4:');
 		expect(result.stdout).toContain('Summary');
+	});
+
+	test('issue #1666: Check 4 growth ratchet header is present', () => {
+		if (isWindows) return;
+		const result = runCheckInvariants(REPO_ROOT);
+		// The full Check 4 header is emitted whenever the allowlist file
+		// exists and a base branch resolves (REPO_ROOT always has origin/main).
+		// Deep behavioral coverage of the ratchet lives in the sibling file
+		// check-mock-allowlist-ratchet.test.ts (real temp git repo).
+		expect(result.stdout).toContain(
+			'Check 4: mock.module allowlist growth ratchet',
+		);
+		expect(result.stdout).toContain('issue #1666');
 	});
 
 	test('regression: bun-compat.ts is exempt from timeout warning by basename', () => {

--- a/tests/unit/scripts/check-mock-allowlist-ratchet.test.ts
+++ b/tests/unit/scripts/check-mock-allowlist-ratchet.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Issue #1666 — diff-scoped growth ratchet for scripts/mock-allowlist.txt.
+ *
+ * Each test spawns the real `scripts/check-invariants.sh` in a temp git
+ * repository so the diff-scoped set-difference logic (head allowlist vs base
+ * via `git show <ref>:scripts/mock-allowlist.txt`) is exercised against real
+ * `git diff` output. Pattern mirrors tests/unit/scripts/check-test-file-cap.test.ts
+ * but with explicit `timeout: 30000` on every spawn (AGENTS.md invariant 6 /
+ * subprocess-safety skill).
+ *
+ * The ratchet under test is Check 4 in scripts/check-invariants.sh. The other
+ * three checks also run when the script is invoked; we focus assertions on
+ * Check 4 output and the overall exit code.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const isWindows = process.platform === 'win32';
+const REPO_ROOT = path.resolve(__dirname, '../../../');
+const SCRIPT = path.join(REPO_ROOT, 'scripts', 'check-invariants.sh');
+const LIB = path.join(REPO_ROOT, 'scripts', 'lib', 'normalize-mock-target.sh');
+
+interface SpawnResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+/**
+ * Spawn check-invariants.sh in `repoDir`. The fixture's `scripts/` subtree is
+ * populated by `makeRepo()` so the script resolves its own directory relative
+ * to the fixture, not the live repo.
+ *
+ * `timeout: 30000` is mandatory (AGENTS.md invariant 6 + subprocess-safety
+ * skill). The sibling check-test-file-cap.test.ts omits it; we do not
+ * propagate that gap.
+ */
+function runScript(repoDir: string, env?: Record<string, string>): SpawnResult {
+	if (isWindows) {
+		// bash on Windows is the WSL stub; skip the same way the existing
+		// check-invariants.test.ts does (the CI runners that matter are
+		// ubuntu/macos). Bash is required because the script uses bash-only
+		// constructs (arrays, process substitution).
+		throw new Error('bash not available on Windows');
+	}
+	// CRITICAL: invoke the fixture's local script copy, not the repo's.
+	// scripts/check-invariants.sh resolves its allowlist via
+	// `ALLOWLIST_FILE="$(dirname "$0")/mock-allowlist.txt"` — $0-relative, NOT
+	// cwd-relative. If we invoked the repo's absolute SCRIPT path, dirname
+	// would resolve to <REPO>/scripts/, and the script would read the repo's
+	// ~110-entry allowlist instead of the fixture's 1-2-entry one — every
+	// assertion would be wrong. The sibling check-invariants.test.ts:39-40
+	// uses the same local-vs-absolute pattern. `copyScripts()` (called by
+	// makeRepo) already wrote the script into the fixture.
+	const localScript = path.join(repoDir, 'scripts', 'check-invariants.sh');
+	const result = spawnSync('bash', [localScript], {
+		cwd: repoDir,
+		env: { ...process.env, ...env },
+		encoding: 'utf-8',
+		stdio: ['pipe', 'pipe', 'pipe'],
+		timeout: 30000,
+	});
+	return {
+		exitCode: result.status ?? 1,
+		stdout: result.stdout || '',
+		stderr: result.stderr || '',
+	};
+}
+
+function git(repoDir: string, ...args: string[]): void {
+	const proc = spawnSync('git', args, {
+		cwd: repoDir,
+		env: process.env,
+		encoding: 'utf-8',
+		stdio: ['pipe', 'pipe', 'pipe'],
+		timeout: 30000,
+	});
+	if (proc.status !== 0) {
+		throw new Error(
+			`git ${args.join(' ')} failed in ${repoDir}: ${proc.stderr || proc.stdout}`,
+		);
+	}
+}
+
+/** Write `lineCount` filler lines so the fixture looks like a real test file. */
+function writeAllowlist(repoDir: string, entries: string[]): void {
+	const dir = path.join(repoDir, 'scripts', 'lib');
+	fs.mkdirSync(dir, { recursive: true });
+	// Minimal header — Check 4 only cares about non-comment, non-blank lines.
+	const lines = ['# mock.module Allowlist — test fixture', '#', ...entries, ''];
+	fs.writeFileSync(
+		path.join(repoDir, 'scripts', 'mock-allowlist.txt'),
+		lines.join('\n'),
+		'utf-8',
+	);
+}
+
+/** Seed the fixture with the live scripts so check-invariants.sh runs there. */
+function copyScripts(repoDir: string): void {
+	const scriptsDir = path.join(repoDir, 'scripts');
+	fs.mkdirSync(scriptsDir, { recursive: true });
+	fs.mkdirSync(path.join(scriptsDir, 'lib'), { recursive: true });
+	fs.copyFileSync(SCRIPT, path.join(scriptsDir, 'check-invariants.sh'));
+	fs.copyFileSync(
+		LIB,
+		path.join(scriptsDir, 'lib', 'normalize-mock-target.sh'),
+	);
+}
+
+/**
+ * Build a temp git repo whose initial commit on `main` is a baseline
+ * allowlist. Tests then modify HEAD's allowlist, commit, and run the script.
+ *
+ * `origin/main` is created as a branch ref so the script's
+ * `origin/main origin/master main master` lookup resolves it (mirrors the
+ * pattern in check-test-file-cap.test.ts:106-120).
+ */
+function makeRepo(baseEntries: string[]): string {
+	const repoDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'mock-ratchet-1666-')),
+	);
+	git(repoDir, 'init', '-q', '-b', 'main');
+	git(repoDir, 'config', 'user.email', 'test@example.com');
+	git(repoDir, 'config', 'user.name', 'Test');
+	copyScripts(repoDir);
+	writeAllowlist(repoDir, baseEntries);
+	// scripts/check-invariants.sh Check 1 also greps src/ for spawn — give it
+	// an empty src/ so the scan has no hits (avoids noise in output).
+	fs.mkdirSync(path.join(repoDir, 'src'), { recursive: true });
+	git(repoDir, 'add', '-A');
+	git(repoDir, 'commit', '-q', '-m', 'init');
+	git(repoDir, 'branch', 'origin/main');
+	return repoDir;
+}
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+	while (tempRoots.length > 0) {
+		const root = tempRoots.pop();
+		if (root) {
+			try {
+				fs.rmSync(root, { recursive: true, force: true });
+			} catch {
+				// best-effort
+			}
+		}
+	}
+});
+
+describe('check-invariants.sh Check 4 — mock.module allowlist growth ratchet', () => {
+	test('no-growth pass: base and HEAD allowlists identical → exit 0', () => {
+		if (isWindows) return;
+		const base = ['node:fs', 'src/foo/bar'];
+		const repoDir = makeRepo(base);
+		tempRoots.push(repoDir);
+		// HEAD allowlist unchanged from base.
+		const result = runScript(repoDir);
+		expect(result.stdout).toContain('Added in this PR: 0');
+		expect(result.stdout).toContain('Unapproved: 0');
+		expect(result.exitCode, result.stdout + result.stderr).toBe(0);
+	});
+
+	test('growth with marker pass: HEAD adds an entry AND the matching APPROVED-NEW marker → exit 0', () => {
+		if (isWindows) return;
+		const repoDir = makeRepo(['node:fs']);
+		tempRoots.push(repoDir);
+		// Add a new entry and a matching standalone marker.
+		writeAllowlist(repoDir, [
+			'# APPROVED-NEW: src/new/target',
+			'node:fs',
+			'src/new/target',
+		]);
+		git(repoDir, 'add', '-A');
+		git(repoDir, 'commit', '-q', '-m', 'add approved target');
+		const result = runScript(repoDir);
+		expect(result.stdout).toContain('Added in this PR: 1');
+		expect(result.stdout).toContain('Approved-new markers found: 1');
+		expect(result.stdout).toContain('Unapproved: 0');
+		expect(result.exitCode, result.stdout + result.stderr).toBe(0);
+	});
+
+	test('growth without marker fail: HEAD adds an entry without a marker → exit 1', () => {
+		if (isWindows) return;
+		const repoDir = makeRepo(['node:fs']);
+		tempRoots.push(repoDir);
+		writeAllowlist(repoDir, ['node:fs', 'src/new/target']);
+		git(repoDir, 'add', '-A');
+		git(repoDir, 'commit', '-q', '-m', 'add unapproved target');
+		const result = runScript(repoDir);
+		expect(result.stdout).toContain('Added in this PR: 1');
+		expect(result.stdout).toContain('Unapproved: 1');
+		expect(result.stdout).toContain(
+			"ERROR (ratchet): new mock target 'src/new/target'",
+		);
+		expect(result.exitCode, result.stdout + result.stderr).toBe(1);
+	});
+
+	test('growth with mismatched marker fail: marker names a different target → exit 1', () => {
+		if (isWindows) return;
+		const repoDir = makeRepo(['node:fs']);
+		tempRoots.push(repoDir);
+		// Marker names src/wrong — added entry is src/new. Ratchet must fail.
+		writeAllowlist(repoDir, [
+			'# APPROVED-NEW: src/wrong/target',
+			'node:fs',
+			'src/new/target',
+		]);
+		git(repoDir, 'add', '-A');
+		git(repoDir, 'commit', '-q', '-m', 'add target with wrong marker');
+		const result = runScript(repoDir);
+		expect(result.stdout).toContain(
+			"ERROR (ratchet): new mock target 'src/new/target'",
+		);
+		expect(result.stdout).toContain('Unapproved: 1');
+		expect(result.exitCode, result.stdout + result.stderr).toBe(1);
+	});
+
+	test('PRR-005 marker normalization: `# APPROVED-NEW: ../../../src/foo/bar.js` approves entry `src/foo/bar`', () => {
+		if (isWindows) return;
+		// normalize_mock_target strips leading ../ and ./, then leading src/,
+		// then trailing .js, then re-prefixes src/. The marker target is
+		// normalized through the same routine at check-invariants.sh:281, so
+		// a path-traversal form marker must match the canonical entry form.
+		// This is documented in docs/releases/pending/1666-mock-allowlist-growth-ratchet.md
+		// and was previously untested (PRR-005).
+		const repoDir = makeRepo(['node:fs']);
+		tempRoots.push(repoDir);
+		writeAllowlist(repoDir, [
+			'# APPROVED-NEW: ../../../src/foo/bar.js',
+			'node:fs',
+			'src/foo/bar',
+		]);
+		git(repoDir, 'add', '-A');
+		git(repoDir, 'commit', '-q', '-m', 'add target with path-traversal marker');
+		const result = runScript(repoDir);
+		expect(result.stdout).toContain('Added in this PR: 1');
+		expect(result.stdout).toContain('Approved-new markers found: 1');
+		expect(result.stdout).toContain('Unapproved: 0');
+		expect(result.exitCode, result.stdout + result.stderr).toBe(0);
+	});
+
+	test('PRR-006 multi-target partial approval: 2 added, only 1 has marker → exit 1 with one violation', () => {
+		if (isWindows) return;
+		// The per-entry loop at check-invariants.sh:288-299 must independently
+		// evaluate each added entry. With 2 added entries and only 1 approved,
+		// the unapproved one must still produce a violation. Previously
+		// untested (PRR-006).
+		const repoDir = makeRepo(['node:fs']);
+		tempRoots.push(repoDir);
+		writeAllowlist(repoDir, [
+			'# APPROVED-NEW: src/approved/target',
+			'node:fs',
+			'src/approved/target',
+			'src/unapproved/target',
+		]);
+		git(repoDir, 'add', '-A');
+		git(repoDir, 'commit', '-q', '-m', 'add two targets, one approved');
+		const result = runScript(repoDir);
+		expect(result.stdout).toContain('Added in this PR: 2');
+		expect(result.stdout).toContain('Approved-new markers found: 1');
+		expect(result.stdout).toContain('Unapproved: 1');
+		expect(result.stdout).toContain(
+			"ERROR (ratchet): new mock target 'src/unapproved/target'",
+		);
+		expect(result.stdout).not.toContain(
+			"ERROR (ratchet): new mock target 'src/approved/target'",
+		);
+		expect(result.exitCode, result.stdout + result.stderr).toBe(1);
+	});
+
+	test('shrink pass: HEAD removes an entry → exit 0 (ratchet only fires on growth)', () => {
+		if (isWindows) return;
+		const repoDir = makeRepo(['node:fs', 'src/foo/old']);
+		tempRoots.push(repoDir);
+		writeAllowlist(repoDir, ['node:fs']);
+		git(repoDir, 'add', '-A');
+		git(repoDir, 'commit', '-q', '-m', 'remove entry');
+		const result = runScript(repoDir);
+		expect(result.stdout).toContain('Added in this PR: 0');
+		expect(result.stdout).toContain('Unapproved: 0');
+		expect(result.exitCode, result.stdout + result.stderr).toBe(0);
+	});
+
+	test('simultaneous grow+shrink pass: HEAD adds (with marker) and removes → exit 0', () => {
+		if (isWindows) return;
+		const repoDir = makeRepo(['node:fs', 'src/foo/old']);
+		tempRoots.push(repoDir);
+		writeAllowlist(repoDir, [
+			'# APPROVED-NEW: src/new/target',
+			'node:fs',
+			'src/new/target',
+		]);
+		git(repoDir, 'add', '-A');
+		git(repoDir, 'commit', '-q', '-m', 'swap');
+		const result = runScript(repoDir);
+		expect(result.stdout).toContain('Added in this PR: 1');
+		expect(result.stdout).toContain('Unapproved: 0');
+		expect(result.exitCode, result.stdout + result.stderr).toBe(0);
+	});
+
+	test('soft-warn escape hatch: MOCK_ALLOWLIST_ENFORCE=0 → exit 0 with violation still printed', () => {
+		if (isWindows) return;
+		const repoDir = makeRepo(['node:fs']);
+		tempRoots.push(repoDir);
+		writeAllowlist(repoDir, ['node:fs', 'src/new/target']);
+		git(repoDir, 'add', '-A');
+		git(repoDir, 'commit', '-q', '-m', 'add unapproved target');
+		const result = runScript(repoDir, { MOCK_ALLOWLIST_ENFORCE: '0' });
+		expect(result.stdout).toContain(
+			"ERROR (ratchet): new mock target 'src/new/target'",
+		);
+		expect(result.stdout).toContain(
+			'MOCK_ALLOWLIST_ENFORCE is off — soft-warn (non-blocking).',
+		);
+		expect(result.exitCode, result.stdout + result.stderr).toBe(0);
+	});
+
+	test('no base branch skip: deleting origin/main and main → exit 0 with NOTE printed', () => {
+		if (isWindows) return;
+		const repoDir = makeRepo(['node:fs']);
+		tempRoots.push(repoDir);
+		writeAllowlist(repoDir, ['node:fs', 'src/new/target']);
+		git(repoDir, 'add', '-A');
+		git(repoDir, 'commit', '-q', '-m', 'add unapproved target');
+		// Remove the base-branch refs the script's lookup resolves.
+		git(repoDir, 'branch', '-D', 'origin/main');
+		// `main` is the current branch — rename it out of the way so the
+		// script's `main` lookup also fails. (git branch -m keeps the working
+		// tree on the renamed branch; the script will fail every branch name
+		// in its priority loop and hit the skip path.)
+		git(repoDir, 'branch', '-m', 'feature');
+		const result = runScript(repoDir);
+		expect(result.stdout).toContain(
+			'no base branch found (no PR context) — skipping Check 4',
+		);
+		// Exit 0 overall: the no-base-branch path is non-blocking.
+		expect(result.exitCode, result.stdout + result.stderr).toBe(0);
+	});
+
+	test('CRLF head, LF base pass: Windows contributor with core.autocrlf=true does not false-fire', () => {
+		if (isWindows) return;
+		const repoDir = makeRepo(['node:fs', 'src/foo/bar']);
+		tempRoots.push(repoDir);
+		// Rewrite HEAD allowlist with CRLF line endings. The base (committed
+		// with LF) is unchanged; without `tr -d '\r'`, every head entry would
+		// carry a trailing '\r' and look "added" (issue #1781 re-critic B6).
+		const crlfContent =
+			[
+				'# mock.module Allowlist — test fixture',
+				'#',
+				'node:fs',
+				'src/foo/bar',
+				'',
+			].join('\r\n') + '\r\n';
+		fs.writeFileSync(
+			path.join(repoDir, 'scripts', 'mock-allowlist.txt'),
+			crlfContent,
+			'utf-8',
+		);
+		git(repoDir, 'add', '-A');
+		// Suppress CRLF→LF normalization on commit so the blob actually
+		// differs (otherwise git would normalize and mask the bug).
+		git(repoDir, 'commit', '-q', '-m', 'rewrite allowlist with CRLF');
+		const result = runScript(repoDir);
+		expect(result.stdout).toContain('Added in this PR: 0');
+		expect(result.stdout).toContain('Unapproved: 0');
+		expect(result.exitCode, result.stdout + result.stderr).toBe(0);
+	});
+});

--- a/tests/unit/scripts/generate-mock-allowlist.test.ts
+++ b/tests/unit/scripts/generate-mock-allowlist.test.ts
@@ -143,4 +143,31 @@ describe('generate-mock-allowlist.sh', () => {
 
 		expect(normalize(firstRun)).toBe(normalize(secondRun));
 	});
+
+	test('issue #1666: preserves # APPROVED-NEW markers across regeneration', () => {
+		if (isWindows) return;
+		// The live allowlist has no markers today (none have ever been added),
+		// so this test seeds a synthetic one against an entry that already
+		// exists in the repo (src/agents/critic — confirmed at the head of
+		// the allowlist's `# --- src ---` section). The generator must
+		// re-emit the marker immediately above the entry after regen.
+		const markerLine = '# APPROVED-NEW: src/agents/critic';
+		fs.appendFileSync(ALLOWLIST_PATH, `\n${markerLine}\n`);
+		try {
+			runGenerateAllowlist(false);
+			const content = fs.readFileSync(ALLOWLIST_PATH, 'utf-8');
+			expect(content).toContain(markerLine);
+			// The marker must appear immediately above the entry it approves.
+			const lines = content.split('\n');
+			const markerIdx = lines.indexOf(markerLine);
+			expect(markerIdx).toBeGreaterThan(-1);
+			expect(lines[markerIdx + 1]).toBe('src/agents/critic');
+		} finally {
+			// afterEach() also restores via git checkout; this is belt-and-braces.
+			spawnSync('git', ['checkout', '--', 'scripts/mock-allowlist.txt'], {
+				cwd: REPO_ROOT,
+				stdio: 'pipe',
+			});
+		}
+	});
 });


### PR DESCRIPTION
Closes #1666

## Summary

Closes the one remaining open sub-item of #1666: a diff-scoped growth-direction ratchet for `scripts/mock-allowlist.txt` with an `APPROVED-NEW` escape hatch. The issue's other two items (coverage threshold, 500-line test-file cap) are already addressed by prior work and are cross-referenced below — no changes needed.

**The gap this PR closes:** the existing `check-invariants.sh` Check 3 enforced only *membership* ("is this target known?"). Adding a new `mock.module` target and running `scripts/generate-mock-allowlist.sh` silently expanded the allowlist, with no review prompt and no record of approval. The maintainer's own close-out comment on #1666 flagged exactly this gap.

**The fix:** a new **Check 4** in `scripts/check-invariants.sh` compares the working-tree allowlist against the PR base via `git show <base>:scripts/mock-allowlist.txt`. For each entry added in the PR, a matching standalone marker line `# APPROVED-NEW: <normalized-target>` is required somewhere in the file. The design mirrors the established `check-test-file-cap.sh` (FR-006) diff-scoped ratchet pattern. `scripts/generate-mock-allowlist.sh` now preserves markers across regeneration — without this, the documented workflow would silently erase them.

**Escape hatch:** `MOCK_ALLOWLIST_ENFORCE=0` (or `false`/`no`/`off`) soft-warns (prints violations, exits 0) for a deliberate growth PR. Mirrors `TEST_CAP_ENFORCE`.

**Revision 2 (post-review):** the first push failed `unit (macos-latest, *)` — bash 3.2 + `set -u` aborts on `"${arr[@]}"` when the array is declared-but-empty (fixed in bash 4.4; Debian #529627, ShellCheck #2387). All empty-possible array sites in `check-invariants.sh` (and matching latent sites in `check-mock-cleanup.sh` and `generate-mock-allowlist.sh` uncovered by the new linter check) now use the `${arr[@]+"${arr[@]}"}` alternate-value expansion. `scripts/check-bash-portability.sh` was extended to catch this class going forward.

### Acceptance criteria status

- ✅ "Coverage threshold is read from a checked-in file, not a hardcoded workflow literal." — already done by `scripts/ci/run-coverage-gate.sh:9` (reads `COVERAGE_THRESHOLD` from env, superseded the old 41.48% literal). Not touched by this PR.
- ✅ "A PR adding a new >500-line test file fails CI; a PR touching but not growing an existing violator does not." — already done by `scripts/check-test-file-cap.sh` (wired at `ci.yml:201-204`). Not touched by this PR.
- ✅ "A PR adding a new `mock.module` target without an `APPROVED-NEW` marker fails `check-invariants.sh`." — **this PR.**
- ✅ "`TESTING.md` and `contributing.md` agree on the 500-line rule's enforcement status." — already done; this PR additionally reconciles both files (plus AGENTS.md and `docs/engineering-invariants.md`) with a note about Check 4.

## Files changed

| File | Change |
|---|---|
| `scripts/check-invariants.sh` | New Check 4 block (~140 lines): diff-scoped growth ratchet, `MOCK_ALLOWLIST_ENFORCE` env toggle, `tr -d '\r'` CRLF normalization on both base and head reads. **Rev 2:** `${arr[@]+"${arr[@]}"}` guard at every empty-possible array expansion site (5 sites) for bash 3.2 + `set -u` portability; header portability note extended. |
| `scripts/check-bash-portability.sh` | **Rev 2:** new detector for the `"${arr[@]}"`-under-`set -u`-with-empty-init class (the bug class that failed macOS CI on rev 1). Flags only arrays with a visible `name=()` empty-init earlier in the file, so always-populated arrays don't false-fire. |
| `scripts/check-mock-cleanup.sh` | **Rev 2:** same `${arr[@]+"${arr[@]}"}` fix on the `mods` array (latent same-class bug that the new detector would have flagged). |
| `scripts/generate-mock-allowlist.sh` | Marker-preservation logic: harvests existing `# APPROVED-NEW:` markers before regen, re-emits them above the matching entry. `sort -u` de-duplication. New header docs. **Rev 2:** `${arr[@]+"${arr[@]}"}` fix on the `approved_markers` array. |
| `scripts/mock-allowlist.txt` | Regenerated header documenting the ratchet, marker convention, and escape hatch. The 112 existing entries are unchanged. |
| `tests/unit/scripts/check-mock-allowlist-ratchet.test.ts` | **NEW** — 11 tests exercising the ratchet against real temp git repos (no-growth pass, growth+marker pass, growth−marker fail, mismatched-marker fail, **marker normalization pass** [PRR-005], **multi-target partial approval fail** [PRR-006], shrink pass, simultaneous grow+shrink pass, soft-warn escape hatch, no-base-branch skip, CRLF head / LF base pass). |
| `tests/unit/scripts/check-invariants.test.ts` | +1 smoke test for Check 4 header. **Rev 2:** renamed sibling test "should run all three checks" → "should run all four checks" with Check 4 assertion (PRR-010). |
| `tests/unit/scripts/generate-mock-allowlist.test.ts` | +1 test for marker preservation across regen. |
| `AGENTS.md` | One bullet under invariant 7. |
| `contributing.md` | One paragraph after the existing `check-mock-cleanup.sh` description. |
| `TESTING.md` | One paragraph after the existing mock-cleanup description. |
| `docs/engineering-invariants.md` | One bullet in the verification list. |
| `docs/releases/pending/1666-mock-allowlist-growth-ratchet.md` | **NEW** release-notes fragment (mandatory per AGENTS.md invariant 12). |

## Invariant audit

- **1 (plugin init):** not touched — no `src/index.ts`, plugin manifest, or init-path code changed. Evidence: `git diff --stat HEAD` shows no `src/` files touched.
- **2 (runtime portability):** not touched — no `src/` code, `package.json`, or build config changed. Evidence: same.
- **3 (subprocesses):** not touched — the new Check 4 uses `git show <ref>:<path>` (read-only, no spawn), and the test file uses `spawnSync('bash', [localScript], { timeout: 30000, ... })` with explicit timeout per the subprocess-safety skill. Evidence: `tests/unit/scripts/check-mock-allowlist-ratchet.test.ts:55-65`.
- **4 (.swarm containment):** not touched — no runtime state, no `.swarm/` paths. Evidence: no `.swarm/` strings in the diff.
- **5 (plan durability):** not touched — no plan code changed. Evidence: same.
- **6 (test_runner safety):** not touched — no `test_runner` tool or `MAX_SAFE_TEST_FILES` change. The new test file runs in CI as a per-file bun:test invocation. Evidence: 11 test cases, well under any threshold.
- **7 (test writing):** touched — bun:test used, no `mock.module` in tests, `os.tmpdir() + path.join` for temp paths, `mkdtempSync` wrapped in `realpathSync`, explicit `timeout: 30000` on every `spawnSync`. Evidence: `tests/unit/scripts/check-mock-allowlist-ratchet.test.ts:67-84, 117-125`.
- **8 (session state):** not touched — no session/global state. Evidence: same.
- **9 (guardrails/retry):** not touched — no guardrail/retry code changed. Evidence: same.
- **10 (chat/system msg):** not touched — no chat hooks changed. Evidence: same.
- **11 (tool registration):** not touched — no tools/agents/commands changed. `scripts/drift-check.ts` will not flag anything new (no skills/tools/commands/agents added). Evidence: `git diff --stat HEAD` shows no `src/tools/`, `src/agents/`, or `src/commands/` files.
- **12 (release/cache):** touched — release-notes fragment `docs/releases/pending/1666-mock-allowlist-growth-ratchet.md` added (mandatory per `AGENTS.md:138`). Version files (`package.json`, `CHANGELOG.md`, `.release-please-manifest.json`) NOT touched. Evidence: fragment file in correct directory using established format; `git diff --stat HEAD` shows no version files modified.

## Test plan

All commands run from `E:/ZCode/opencode-swarm` on branch `claude/issue-1666-mock-allowlist-ratchet`.

```text
$ bun --smol test tests/unit/scripts/check-mock-allowlist-ratchet.test.ts \
                    tests/unit/scripts/check-invariants.test.ts \
                    tests/unit/scripts/generate-mock-allowlist.test.ts
  27 pass / 0 fail across 3 files

$ bash scripts/check-invariants.sh
  exit 0 — "All engineering invariant checks passed."
  Check 4 reports: "Base entries: 112 | Head entries: 112 | Added in this PR: 0 | Unapproved: 0"

$ bash scripts/check-bash-portability.sh
  exit 0 — "No bash4+-only constructs found in scripts/."
  (no `declare -A`, no `grep -P`, no `coproc`, no `mapfile`/`readarray`; POSIX `[[:space:]]` used, not `\s`;
   rev 2 also confirms no `"${arr[@]}"`-under-`set -u`-with-empty-init — the bug class that failed macOS CI on rev 1)

$ bash scripts/generate-mock-allowlist.sh --check
  exit 0 — "✓ mock-allowlist.txt is up-to-date"

$ bun run typecheck
  exit 0 — tsc --noEmit clean

$ bunx biome check tests/unit/scripts/
  Checked 24 files. No fixes applied.
```

### Falsifiability evidence (per the writing-tests skill)

This dev host is Windows (`process.platform === 'win32'`), so all bash-spawning tests trivially pass via the `if (isWindows) return;` early-exit guard (same convention as the existing `check-invariants.test.ts:46-48`). CI is the source of truth (ubuntu-latest). Falsifiability was verified manually via Git Bash:

1. **continue-skip mutation** (bypass ratchet detection): produces `Unapproved: 0, exit 0` where the unmutated code produces `Unapproved: 1, exit 1`. The `expect(result.stdout).toContain('Unapproved: 1')` assertion at `check-mock-allowlist-ratchet.test.ts:191` would fail.
2. **Truth-table inversion** (unset → soft-warn): this was a real bug in the first implementation; the `expect(result.exitCode).toBe(1)` assertion at `:195` caught it and forced a fix at `scripts/check-invariants.sh:189`.
3. **Marker-mismatch path** (marker names a different target than the added entry): manually verified that `# APPROVED-NEW: src/wrong` does NOT match an added entry `src/new` (linear-scan string equality, not regex). Covered by test at `:198-213`.

Full mutation evidence in `.zcode/issue-traces/1666/falsifiability-evidence.md`.

### Manual reproduction of the issue AC

AC: *"A PR adding a new `mock.module` target without an `APPROVED-NEW` marker fails `check-invariants.sh`."*

```text
# Temp git repo, base = node:fs, HEAD = node:fs + src/new/target (no marker)
$ bash scripts/check-invariants.sh
=== Check 4: mock.module allowlist growth ratchet (issue #1666) ===
ERROR (ratchet): new mock target 'src/new/target' added to scripts/mock-allowlist.txt without approval.
       Add a standalone marker line:  # APPROVED-NEW: src/new/target
       OR remove the target and use the _internals DI seam instead (AGENTS.md invariant 7).
Base entries: 1 | Head entries: 2 | Added in this PR: 1 | Approved-new markers found: 0 | Unapproved: 1

=== Summary ===
1 invariant violation(s) found.
exit: 1   ✓ AC satisfied

# Same setup but with `# APPROVED-NEW: src/new/target` marker added
$ bash scripts/check-invariants.sh
Base entries: 1 | Head entries: 2 | Added in this PR: 1 | Approved-new markers found: 1 | Unapproved: 0
=== Summary ===
All engineering invariant checks passed.
exit: 0   ✓ counter-AC satisfied
```

## Known caveats

- **Standalone marker only:** `# APPROVED-NEW: <target>` on its own line. Inline trailing comments on the entry are not accepted (the regenerator would not preserve them).
- **Marker target is normalized** through `scripts/lib/normalize-mock-target.sh`, so `# APPROVED-NEW: ../../../src/foo/bar.js` matches the entry `src/foo/bar`.
- **No-base-branch path is non-blocking:** local-dev clone without `origin/main` fetched → Check 4 prints a `NOTE:` and skips. Real CI (PR + merge-group events with `actions/checkout fetch-depth: 0`) always resolves `origin/main`.
- **Bash 3.2 portability of empty-array iteration under `set -u`** is a latent concern (not blocking — CI is ubuntu-only at `.github/workflows/ci.yml:151`, and the existing Check 3 at `check-invariants.sh:105` uses the same pattern). Out of scope for this PR; documented in `.zcode/issue-traces/1666/08b-implementation-review.md` for a future portability pass should a macOS runner be added.
- **Pre-existing "53 unique normalized targets" claim** at `docs/releases/pending/ci-invariant-checks-post-merge-closeout.md:14` is stale (actual count is 112), but that file belongs to a previously-merged PR and is out of scope for #1666.

## Reviewer / critic trail

Full artifacts under `.zcode/issue-traces/1666/`:
- `04-root-cause.md` — root-cause analysis
- `05-fix-plan.md` — fix plan (post-critic revision at `07-approved-plan.md`)
- `06-critic-review.md` — plan critic (Kimi K3): NEEDS_REVISION → 7 items addressed (release fragment, `\s`→`[[:space:]]`, CRLF normalization, regex interpolation, marker form, de-dup, test timeouts)
- `08-test-results.md` — validation evidence
- `08b-implementation-review.md` — implementation reviewer (Kimi K2.7): NEEDS_REVISION → 2 items fixed (test-harness path bug, allowlist regen)
- `09-final-critic.md` — final critic (Kimi K3): NEEDS_REVISION → 1 item fixed (allowlist header regen actually applied to working tree)
- `falsifiability-evidence.md` — mutation testing evidence
