### PR TITLE
feat(failover): wire quota/rate-limit failover into remaining dispatch sites (#1905)

### DIFF
--- a/docs/releases/pending/1905-model-failover-remaining-dispatch-sites.md
+++ b/docs/releases/pending/1905-model-failover-remaining-dispatch-sites.md
@@ -1,0 +1,75 @@
+## Model quota/rate-limit failover extended to remaining dispatch sites (#1896 follow-up)
+
+PR #1901 (closing #1896) shipped model quota/rate-limit failover for the four
+primary model-dispatch stages: full-auto oversight, lean-turbo reviewer,
+lean-turbo lane runner, and the evaluation dispatcher. This release completes
+the coverage by wiring the same failover into the three remaining production
+dispatch sites that still called `client.session.prompt` directly with no
+fallback:
+
+- **Legacy reactive-intercept critic** (`dispatchCriticAndWriteEvent` in
+  `src/hooks/full-auto-intercept.ts`) — the bespoke retry loop now advances to
+  a configured `critic_oversight` (or inherited `critic`) fallback model on a
+  transient/quota dispatch error, instead of pausing/terminating the Full-Auto
+  run. The v2 mirror event's `critic_model` attribution is rewritten to the
+  landed fallback, matching the `oversight.ts` precedent.
+- **Auto-review reviewer** (`runAutoReview` in `src/hooks/auto-review.ts`) —
+  the advisory-only execution-diff reviewer now fails over to a configured
+  `reviewer` fallback on a quota blip, instead of silently dropping the review
+  pass with a `verdict: 'error'` event. Uses the module's existing
+  `injectAdvisory` channel for the MODEL FALLBACK notice.
+- **Lean-turbo phase critic** (`dispatchPhaseCritic` in
+  `src/turbo/lean/integration.ts`) — the boundary-review critic now fails over
+  to a configured `critic` fallback on a quota blip, instead of cascading into
+  a false phase-rejection verdict.
+
+### Bug fix: SDK error-envelope preservation (the load-bearing change)
+
+The OpenCode SDK returns HTTP failures (including 429/402 quota) as
+`{ data: null, error }` envelopes, not thrown exceptions. Four dispatch sites
+discarded `response.error` into a token-free `'… returned no data'` Error,
+which meant the transient/quota classifier saw no quota token and classified
+the failure as permanent — **failover never fired on the dominant SDK error
+shape**, even after the #1901/#1896 wiring. This release preserves
+`JSON.stringify(response.error)` in the thrown message at:
+
+- `src/hooks/auto-review.ts` (`auto-review session returned no data: …`)
+- `src/turbo/lean/integration.ts` (`Critic session returned no data: …`)
+- `src/turbo/lean/reviewer.ts` (`Reviewer session returned no data: …`)
+- `src/evaluation/model-dispatcher.ts` (`Evaluation session returned no data: …`)
+
+### Bug fix: lean-turbo reviewer no-timeout-branch model override
+
+A pre-existing bug in `src/turbo/lean/reviewer.ts` left the `defaultDispatchReviewerAgent`
+**no-timeout branch** (`timeoutMs <= 0`, the default) missing the
+`...(model ? { model } : {})` override that the timeout branch had. This meant
+the #1896 failover wiring in `reviewer.ts` was silently broken for every
+caller passing `timeoutMs: 0` — the fallback model was resolved, passed to the
+dispatch fn, and then dropped on the floor. Discovered by the new
+envelope-path test, which drives the real dispatch fn and would have failed
+without the fix.
+
+### Refactor: shared inline-fallback-advancer helper
+
+The ~30-line fallback-advance block (resolve next → increment-before-parse →
+skip malformed → tag quota/transient reason → notify) shared by the bespoke
+oversight.ts loop and the new site-1 loop is extracted into a pure helper
+`src/utils/inline-fallback-advancer.ts` so the two bespoke loops cannot drift.
+`oversight.ts` is refactored to use it (behavior-preserving — pinned by the
+existing `oversight-fallback.test.ts`).
+
+### Out of scope (tracked in follow-up issues)
+
+- Opt-in dispatch sites (`createCuratorLLMDelegate`,
+  `createSkillImproverLLMDelegate`) — factory-closure shapes requiring their
+  own wiring approach. Tracked in #1927.
+- Shell-write-detection gaps (`tee` not flagged as a write; glued `-c`
+  interpreter-eval bypass) — distinct hardening concern from the model-failover
+  scope. Tracked in #1928.
+- `generateMutants` — dispatches with `agent: undefined`, so no role/chain
+  concept exists. Existing `return []` graceful degradation is correct.
+
+### Migration
+
+No migration required. The failover activates only when a role has configured
+`fallback_models`; roles without fallback chains behave exactly as before.

--- a/src/evaluation/model-dispatcher.ts
+++ b/src/evaluation/model-dispatcher.ts
@@ -197,7 +197,18 @@ export function createEvaluationModelDispatcher(
 					signal: controller.signal,
 				});
 				if (!response.data)
-					throw new Error('Evaluation session returned no data');
+					// #1905: preserve the SDK error body so the same-model retry
+					// classifier (isTransientProviderError at the call site below)
+					// can read the real provider message — without this, envelope-
+					// shaped 429/402 quota errors classify as non-retryable and the
+					// bounded same-model retry that exists to absorb a momentary
+					// quota hiccup (#1901 comment at line ~225) never fires. Parity
+					// with auto-review.ts / integration.ts / reviewer.ts. NOTE: this
+					// site is same-model-retry-only by design (benchmark attribution);
+					// no model substitution is added here.
+					throw new Error(
+						`Evaluation session returned no data: ${JSON.stringify(response.error)}`,
+					);
 				const text = response.data.parts
 					.filter((part) => part.type === 'text')
 					.map((part) => part.text ?? '')

--- a/src/full-auto/oversight.ts
+++ b/src/full-auto/oversight.ts
@@ -31,15 +31,10 @@ import { tryAcquireLock } from '../parallel/file-locks.js';
 import { _internals as stateInternals } from '../state.js';
 import { telemetry } from '../telemetry';
 import { sleep } from '../utils/bun-compat';
+import { advanceInlineFallback } from '../utils/inline-fallback-advancer';
 import * as logger from '../utils/logger';
-import {
-	type ModelOverride,
-	parseModelString,
-} from '../utils/model-dispatch-fallback';
-import {
-	isQuotaError,
-	isTransientProviderError,
-} from '../utils/provider-error-classification';
+import type { ModelOverride } from '../utils/model-dispatch-fallback';
+import { isTransientProviderError } from '../utils/provider-error-classification';
 import {
 	type ParsedCriticResponse,
 	parseCriticResponseFields,
@@ -544,38 +539,33 @@ export async function dispatchFullAutoOversight(
 			// Transient — will retry. #1896: advance to the next configured fallback
 			// model (if any) before the retry, so a quota/rate-limit hit fails over
 			// instead of just re-hitting the same exhausted model.
+			//
+			// #1905: the advance block (resolve → increment-before-parse → skip
+			// malformed → tag quota/transient → notify) is shared with the legacy
+			// critic dispatch in `src/hooks/full-auto-intercept.ts`. It lives in
+			// `advanceInlineFallback` so the two bespoke loops cannot drift.
 			dispatchError = undefined;
-			const nextModel = resolveOversightFallback(modelFallbackIndex + 1);
-			if (nextModel) {
-				// Advance the index FIRST so a malformed entry is skipped rather
-				// than re-resolved every retry (which would strand any valid
-				// fallback listed after it); only adopt the model on a clean parse.
-				modelFallbackIndex++;
-				let parsed: ModelOverride | undefined;
-				try {
-					parsed = parseModelString(nextModel);
-				} catch {
-					parsed = undefined; // malformed provider/model entry — skip it
-				}
-				if (parsed) {
-					modelOverride = parsed;
-					modelUsedLabel = nextModel;
-					const reason = isQuotaError(
-						lastError instanceof Error ? lastError.message : String(lastError),
-					)
-						? 'quota'
-						: 'transient_model_error';
+			const advanced = advanceInlineFallback({
+				resolveFallback: resolveOversightFallback,
+				index: modelFallbackIndex,
+				lastError,
+				onAdopt: ({ toModel, fallbackIndex, reason }) => {
 					logger.warn(
-						`[full-auto/oversight] failing over critic to fallback model "${nextModel}" (fallback ${modelFallbackIndex}, reason=${reason})`,
+						`[full-auto/oversight] failing over critic to fallback model "${toModel}" (fallback ${fallbackIndex}, reason=${reason})`,
 					);
 					telemetry.modelFallback(
 						input.sessionID,
 						input.oversightAgentName,
 						input.criticModel,
-						nextModel,
+						toModel,
 						reason,
 					);
-				}
+				},
+			});
+			modelFallbackIndex = advanced.nextIndex;
+			if (advanced.adopted) {
+				modelOverride = advanced.adopted.override;
+				modelUsedLabel = advanced.adopted.modelString;
 			}
 		} else {
 			// Exhausted retries.

--- a/src/hooks/auto-review.ts
+++ b/src/hooks/auto-review.ts
@@ -21,18 +21,35 @@
  * Bounds (AGENTS.md invariants 3 and 8): the diff subprocess uses execFile
  * with cwd/timeout/maxBuffer and ignored stdin; dispatches are guarded by a
  * per-session in-flight set plus a 60s cooldown in a bounded FIFO map.
+ *
+ * #1896 / #1905: on a transient/quota dispatch error the reviewer fails over to
+ * a configured `fallback_models` entry via the shared `dispatchWithModelFallback`
+ * helper, instead of immediately writing a `verdict: 'error'` event (a quota
+ * blip previously dropped the review pass with no recovery). The SDK error
+ * envelope is preserved in the thrown message so the classifier sees the quota
+ * token on the dominant SDK error shape.
  */
 
 import * as child_process from 'node:child_process';
 import * as fs from 'node:fs';
+import { getSwarmAgents, resolveFallbackModel } from '../agents/index.js';
 import { ORCHESTRATOR_NAME } from '../config/constants.js';
 import {
 	type AutoReviewConfig,
 	stripKnownSwarmPrefix,
 } from '../config/schema.js';
 import { swarmState } from '../state.js';
+import { telemetry } from '../telemetry.js';
 import { resolveDefaultReviewerAgent } from '../turbo/lean/reviewer.js';
 import * as logger from '../utils/logger.js';
+import {
+	dispatchWithModelFallback,
+	type ModelOverride,
+} from '../utils/model-dispatch-fallback.js';
+import {
+	isQuotaError,
+	isTransientProviderError,
+} from '../utils/provider-error-classification.js';
 import { normalizeToolName } from './normalize-tool-name.js';
 import {
 	buildApprovedReceipt,
@@ -191,6 +208,9 @@ async function dispatchReviewer(
 	agentName: string,
 	timeoutMs: number,
 	parentSessionId: string,
+	// #1905: per-call model override on a fallback attempt; omitted (undefined)
+	// means the registered reviewer agent model.
+	model?: ModelOverride,
 ): Promise<string> {
 	const client = swarmState.opencodeClient;
 	if (!client) {
@@ -215,6 +235,8 @@ async function dispatchReviewer(
 			path: { id: sessionId },
 			body: {
 				agent: agentName,
+				// #1905: per-call model override on a fallback attempt.
+				...(model ? { model } : {}),
 				// Read-only reviewer: verification only, never modification.
 				tools: { write: false, edit: false, patch: false },
 				parts: [{ type: 'text', text: prompt }],
@@ -231,7 +253,13 @@ async function dispatchReviewer(
 			}),
 		]);
 		if (!response.data) {
-			throw new Error('auto-review session returned no data');
+			// #1905: preserve the SDK error body so the transient/quota
+			// classifier can read the real provider message — without this,
+			// envelope-shaped 429/402 errors classify as permanent and the
+			// failover never fires.
+			throw new Error(
+				`auto-review session returned no data: ${JSON.stringify(response.error)}`,
+			);
 		}
 		return response.data.parts
 			.filter((p): p is typeof p & { text: string } => p.type === 'text')
@@ -357,20 +385,68 @@ export async function runAutoReview(input: AutoReviewRunInput): Promise<void> {
 		);
 		const prompt = buildReviewPrompt(trigger, diff, taskId, phase);
 
+		// #1896 / #1905: on a transient/quota dispatch error, fail over to a
+		// configured reviewer fallback_model instead of immediately writing a
+		// `verdict: 'error'` event (a quota blip previously dropped the review
+		// pass with no recovery). Only after the primary + all fallbacks are
+		// exhausted does the fail-open error path run.
+		const reviewerBase = stripKnownSwarmPrefix(agentName);
+		const reviewerSwarmId =
+			reviewerBase !== agentName
+				? agentName.slice(0, agentName.length - reviewerBase.length - 1)
+				: undefined;
+		const reviewerSwarmAgents = getSwarmAgents(reviewerSwarmId);
 		let transcript: string;
 		try {
-			transcript = await _internals.dispatchReviewer(
-				directory,
-				prompt,
-				agentName,
-				config.timeout_ms,
-				sessionID,
-			);
+			const dispatched = await dispatchWithModelFallback<string>({
+				dispatch: (model) =>
+					_internals.dispatchReviewer(
+						directory,
+						prompt,
+						agentName,
+						config.timeout_ms,
+						sessionID,
+						model,
+					),
+				resolveFallback: (index) =>
+					resolveFallbackModel(reviewerBase, index, reviewerSwarmAgents),
+				// Advance to the next model immediately on a transient/quota error —
+				// an instant same-model retry cannot clear an exhausted quota.
+				maxTransientRetriesPerModel: 0,
+				classify: (err) => {
+					const msg = err instanceof Error ? err.message : String(err);
+					// An auto-review dispatch TIMEOUT is not a provider transient —
+					// keep the existing fail-open error behavior instead of failing
+					// over (a slow call on one model does not predict quota
+					// exhaustion on the next). Mirrors the reviewer/runner carve-out.
+					if (/auto-review timed out/i.test(msg)) return 'permanent';
+					return isTransientProviderError(msg) ? 'transient' : 'permanent';
+				},
+				onFallback: ({ toModel, fallbackIndex }) => {
+					telemetry.modelFallback(
+						sessionID,
+						agentName,
+						reviewerSwarmAgents?.[reviewerBase]?.model ?? 'default',
+						toModel,
+						'transient_model_error',
+					);
+					// #1905: use the module's existing injected advisory channel
+					// (not getAgentSession — auto-review.ts already has its own).
+					input.injectAdvisory(
+						sessionID,
+						`MODEL FALLBACK: auto-review reviewer failed over to "${toModel}" (fallback ${fallbackIndex}) after a transient/quota dispatch error.`,
+					);
+				},
+			});
+			transcript = dispatched.result;
 		} catch (err) {
+			const isQuota = isQuotaError(
+				err instanceof Error ? err.message : String(err),
+			);
 			writeAutoReviewEvent(directory, {
 				...base,
 				verdict: 'error',
-				detail: `dispatch failed: ${err instanceof Error ? err.message : String(err)}`,
+				detail: `dispatch failed${isQuota ? ' (model quota/usage limit exhausted across all configured fallbacks)' : ''}: ${err instanceof Error ? err.message : String(err)}`,
 			});
 			return;
 		}

--- a/src/hooks/full-auto-intercept.ts
+++ b/src/hooks/full-auto-intercept.ts
@@ -11,6 +11,7 @@
 import * as fs from 'node:fs';
 
 import { createCriticAutonomousOversightAgent } from '../agents/critic';
+import { getSwarmAgents, resolveFallbackModel } from '../agents/index.js';
 import type { PluginConfig } from '../config';
 import { stripKnownSwarmPrefix } from '../config/schema.js';
 import {
@@ -36,7 +37,10 @@ import { tryAcquireLock } from '../parallel/file-locks.js';
 import { _internals as stateInternals } from '../state.js';
 import { telemetry } from '../telemetry';
 import { sleep } from '../utils/bun-compat';
+import { advanceInlineFallback } from '../utils/inline-fallback-advancer.js';
 import * as logger from '../utils/logger';
+import type { ModelOverride } from '../utils/model-dispatch-fallback.js';
+import { isTransientProviderError } from '../utils/provider-error-classification.js';
 import { validateSwarmPath } from './utils';
 
 // Pattern for detecting end-of-sentence question marks (not mid-sentence like "v1?")
@@ -524,7 +528,13 @@ export async function dispatchCriticAndWriteEvent(
 
 	// FR-003 retry helper: attempts one dispatch, returns { ok, response, error }.
 	// On retry attempts, waits 1s, 2s, 4s, … between tries.
-	async function attemptDispatch(attempt: number): Promise<{
+	// #1905: `modelOverride` lets a transient/quota retry fail over to a configured
+	// fallback model via the per-call `model` override (undefined = the registered
+	// critic_oversight agent model).
+	async function attemptDispatch(
+		attempt: number,
+		modelOverride: ModelOverride | undefined,
+	): Promise<{
 		ok: boolean;
 		response: string;
 		error: unknown;
@@ -573,11 +583,14 @@ export async function dispatchCriticAndWriteEvent(
 					`[full-auto-intercept] Created ephemeral session: ${ephemeralSessionId}`,
 				);
 
-				// 2. Prompt using the registered oversight agent (read-only tools)
+				// 2. Prompt using the registered oversight agent (read-only tools).
+				// #1905: per-call model override on a fallback attempt; omitted
+				// (undefined) means the registered critic_oversight agent model.
 				const promptResult = await client.session.prompt({
 					path: { id: ephemeralSessionId },
 					body: {
 						agent: oversightAgentName,
+						...(modelOverride ? { model: modelOverride } : {}),
 						tools: { write: false, edit: false, patch: false },
 						parts: [{ type: 'text', text: criticContext }],
 					},
@@ -619,11 +632,38 @@ export async function dispatchCriticAndWriteEvent(
 		return { ok: false, response: '', error: lastError };
 	}
 
+	// #1905: model-failover setup. On a transient/quota dispatch failure the
+	// critic fails over to a configured fallback model (critic_oversight's
+	// fallback_models, else critic's) via a per-call `model` override. The
+	// fallback index is tracked locally: this dispatch is a child of the parent
+	// orchestrator session and there is no per-role fallback state to reuse.
+	// Mirrors the sibling inline loop in `src/full-auto/oversight.ts` — the
+	// shared advance block lives in `advanceInlineFallback` (see utils/
+	// inline-fallback-advancer.ts) so the two bespoke loops cannot drift.
+	const oversightBaseRole = stripKnownSwarmPrefix(oversightAgentName);
+	const oversightSwarmId =
+		oversightBaseRole !== oversightAgentName
+			? oversightAgentName.slice(
+					0,
+					oversightAgentName.length - oversightBaseRole.length - 1,
+				)
+			: undefined;
+	const oversightSwarmAgents = getSwarmAgents(oversightSwarmId);
+	const oversightFallbackRole = oversightSwarmAgents?.[oversightBaseRole]
+		?.fallback_models?.length
+		? oversightBaseRole
+		: 'critic';
+	const resolveOversightFallback = (index: number): string | null =>
+		resolveFallbackModel(oversightFallbackRole, index, oversightSwarmAgents);
+	let modelFallbackIndex = 0;
+	let modelOverride: ModelOverride | undefined;
+	let modelUsedLabel = criticModel;
+
 	let criticResponse = '';
 	let lastDispatchError: unknown;
 	for (let attempt = 0; attempt <= maxDispatchRetries; attempt++) {
 		// eslint-disable-next-line no-await-in-loop
-		const result = await attemptDispatch(attempt);
+		const result = await attemptDispatch(attempt, modelOverride);
 		if (result.ok) {
 			criticResponse = result.response;
 			lastDispatchError = undefined;
@@ -636,7 +676,42 @@ export async function dispatchCriticAndWriteEvent(
 			`[full-auto-intercept] dispatch attempt ${attempt + 1}/${maxDispatchRetries + 1} failed: ${lastDispatchError instanceof Error ? lastDispatchError.message : String(lastDispatchError)}`,
 		);
 		if (attempt < maxDispatchRetries) {
-			// Transient — will retry.
+			// Will retry. #1905: if the failure is transient/quota, advance to the
+			// next configured fallback model BEFORE the retry so a quota/rate-limit
+			// hit fails over instead of just re-hitting the same exhausted model.
+			// NOTE: this site intentionally retries on PERMANENT errors too (FR-003
+			// semantics differ from oversight.ts's break-on-permanent) — the
+			// transient gate here only controls whether a fallback is adopted, not
+			// whether a retry happens. The advance block itself is shared with
+			// `src/full-auto/oversight.ts:543–579` via `advanceInlineFallback`.
+			const failureText =
+				lastDispatchError instanceof Error
+					? lastDispatchError.message
+					: String(lastDispatchError);
+			if (isTransientProviderError(failureText)) {
+				const advanced = advanceInlineFallback({
+					resolveFallback: resolveOversightFallback,
+					index: modelFallbackIndex,
+					lastError: lastDispatchError,
+					onAdopt: ({ toModel, fallbackIndex, reason }) => {
+						logger.warn(
+							`[full-auto-intercept] failing over critic to fallback model "${toModel}" (fallback ${fallbackIndex}, reason=${reason})`,
+						);
+						telemetry.modelFallback(
+							sessionID ?? '',
+							oversightAgentName,
+							criticModel,
+							toModel,
+							reason,
+						);
+					},
+				});
+				modelFallbackIndex = advanced.nextIndex;
+				if (advanced.adopted) {
+					modelOverride = advanced.adopted.override;
+					modelUsedLabel = advanced.adopted.modelString;
+				}
+			}
 		} else {
 			// Exhausted retries: SC-011 auto-degrade.
 			const infraReason = `oversight infrastructure failure after ${maxDispatchRetries + 1} attempt(s): ${lastDispatchError instanceof Error ? lastDispatchError.message : String(lastDispatchError)}`;
@@ -673,6 +748,13 @@ export async function dispatchCriticAndWriteEvent(
 		logger.log(
 			`[full-auto-intercept] Critic verdict: ${parsed.verdict} | escalation: ${parsed.escalationNeeded}`,
 		);
+		// #1905: when a fallback was adopted, record the actual model so the
+		// operational trail reflects which model landed the verdict.
+		if (modelFallbackIndex > 0) {
+			logger.log(
+				`[full-auto-intercept] Critic verdict recovered on fallback model "${modelUsedLabel}" (fallback ${modelFallbackIndex})`,
+			);
+		}
 	} catch (parseError) {
 		logger.error(
 			`[full-auto-intercept] Failed to parse critic response: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
@@ -705,6 +787,9 @@ export async function dispatchCriticAndWriteEvent(
 	// v2: Mirror the verdict into the shared oversight pipeline so that phase
 	// approval evidence and durable run-state stay coherent with reactive
 	// intercept verdicts. Best-effort — never throw.
+	// #1905: pass the landed model (may differ from `criticModel` when a
+	// transient/quota failover adopted a fallback) so the v2 event's
+	// `critic_model` attribution stays accurate.
 	try {
 		await mirrorReactiveVerdictToV2({
 			directory,
@@ -713,6 +798,7 @@ export async function dispatchCriticAndWriteEvent(
 			escalationType,
 			oversightAgentName,
 			criticModel,
+			criticModelUsed: modelUsedLabel,
 			sessionID,
 		});
 	} catch (mirrorError) {
@@ -1145,6 +1231,16 @@ interface MirrorParams {
 	escalationType: 'phase_completion' | 'question';
 	oversightAgentName: string;
 	criticModel: string;
+	/**
+	 * #1905: the ACTUAL model used for the dispatch — equal to `criticModel`
+	 * (the configured critic) on the primary, or a `provider/model` fallback
+	 * string when a transient/quota error forced a failover. The v2 mirror
+	 * writes the SAME `full_auto_oversight` event type as `oversight.ts`, which
+	 * rewrites `baseEvent.critic_model` post-fallback — passing the landed model
+	 * here keeps the two event writers' attribution coherent rather than
+	 * diverging (configured vs actual) when a fallback lands.
+	 */
+	criticModelUsed?: string;
 	sessionID?: string;
 }
 
@@ -1252,7 +1348,9 @@ async function mirrorReactiveVerdictToV2(params: MirrorParams): Promise<void> {
 		trigger_source: triggerSource,
 		trigger_reason: `reactive intercept (${params.escalationType})`,
 		critic_agent: params.oversightAgentName,
-		critic_model: params.criticModel,
+		// #1905: prefer the landed model when a fallback was adopted during
+		// dispatch, so the v2 event's audit trail matches oversight.ts.
+		critic_model: params.criticModelUsed ?? params.criticModel,
 		verdict: params.parsed.verdict,
 		reasoning: params.parsed.reasoning,
 		evidence_checked: params.parsed.evidenceChecked,

--- a/src/turbo/lean/integration.ts
+++ b/src/turbo/lean/integration.ts
@@ -10,10 +10,28 @@
  *
  * The dispatched critic agent receives `tools: { write: false, edit: false, patch: false }`
  * to enforce that it performs only verification and never modifies the codebase.
+ *
+ * #1896 / #1905: on a transient/quota dispatch error the critic fails over to a
+ * configured `fallback_models` entry via the shared `dispatchWithModelFallback`
+ * helper, instead of immediately writing a REJECTED verdict (a quota blip
+ * previously cascaded into a false phase rejection). The SDK error envelope is
+ * preserved in the thrown message so the classifier sees the quota token on the
+ * dominant SDK error shape.
  */
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { swarmState } from '../../state';
+import { getSwarmAgents, resolveFallbackModel } from '../../agents/index';
+import { stripKnownSwarmPrefix } from '../../config/schema';
+import { getAgentSession, swarmState } from '../../state';
+import { telemetry } from '../../telemetry';
+import {
+	dispatchWithModelFallback,
+	type ModelOverride,
+} from '../../utils/model-dispatch-fallback';
+import {
+	isQuotaError,
+	isTransientProviderError,
+} from '../../utils/provider-error-classification';
 import {
 	type LaneEvidence,
 	listLaneEvidence,
@@ -391,6 +409,9 @@ async function defaultDispatchCriticAgent(
 	agentName: string,
 	timeoutMs: number,
 	parentSessionId?: string,
+	// #1905: per-call model override on a fallback attempt; omitted (undefined)
+	// means the registered critic agent model.
+	model?: ModelOverride,
 ): Promise<string> {
 	const client = swarmState.opencodeClient;
 	if (!client) {
@@ -463,6 +484,8 @@ Be specific and evidence-based. When safety concerns are present, err on the sid
 
 		// When timeoutMs > 0: race prompt against a rejecting timeout promise
 		// When timeoutMs <= 0 or undefined: await prompt directly (no race)
+		// #1905: per-call model override on a fallback attempt; omitted
+		// (undefined) means the registered critic agent model.
 		const response =
 			timeoutMs > 0
 				? await Promise.race([
@@ -470,6 +493,7 @@ Be specific and evidence-based. When safety concerns are present, err on the sid
 							path: { id: sessionId },
 							body: {
 								agent: agentName,
+								...(model ? { model } : {}),
 								tools: { write: false, edit: false, patch: false },
 								parts: [{ type: 'text', text: promptText }],
 							},
@@ -488,6 +512,7 @@ Be specific and evidence-based. When safety concerns are present, err on the sid
 						path: { id: sessionId },
 						body: {
 							agent: agentName,
+							...(model ? { model } : {}),
 							tools: { write: false, edit: false, patch: false },
 							parts: [{ type: 'text', text: promptText }],
 						},
@@ -495,7 +520,13 @@ Be specific and evidence-based. When safety concerns are present, err on the sid
 					});
 
 		if (!response.data) {
-			throw new Error('Critic session returned no data');
+			// #1905: preserve the SDK error body so the transient/quota
+			// classifier can read the real provider message — without this,
+			// envelope-shaped 429/402 errors classify as permanent and the
+			// failover never fires.
+			throw new Error(
+				`Critic session returned no data: ${JSON.stringify(response.error)}`,
+			);
 		}
 
 		// Extract text from response parts
@@ -528,6 +559,7 @@ export const _internals: {
 		agentName: string,
 		timeoutMs: number,
 		parentSessionId?: string,
+		model?: ModelOverride,
 	) => Promise<string>;
 	resolveDefaultCriticAgent: typeof resolveDefaultCriticAgent;
 	readReviewerEvidence: typeof readReviewerEvidence;
@@ -588,18 +620,70 @@ export async function dispatchPhaseCritic(
 		sessionID,
 	);
 
-	// Dispatch the critic agent and await its response
+	// Dispatch the critic agent and await its response.
+	// #1896 / #1905: on a transient/quota dispatch error, fail over to a
+	// configured critic fallback_model instead of immediately writing a REJECTED
+	// verdict (a quota blip previously cascaded into a false phase rejection).
+	// Only after the primary + all fallbacks are exhausted does the fail-closed
+	// REJECTED path run.
+	const criticBase = stripKnownSwarmPrefix(agentName);
+	const criticSwarmId =
+		criticBase !== agentName
+			? agentName.slice(0, agentName.length - criticBase.length - 1)
+			: undefined;
+	const criticSwarmAgents = getSwarmAgents(criticSwarmId);
 	let responseText: string;
 	try {
-		responseText = await _internals.dispatchCriticAgent(
-			directory,
-			pkg,
-			agentName,
-			mergedConfig.timeoutMs,
-			sessionID,
-		);
+		const dispatched = await dispatchWithModelFallback<string>({
+			dispatch: (model) =>
+				_internals.dispatchCriticAgent(
+					directory,
+					pkg,
+					agentName,
+					mergedConfig.timeoutMs,
+					sessionID,
+					model,
+				),
+			resolveFallback: (index) =>
+				resolveFallbackModel(criticBase, index, criticSwarmAgents),
+			// Advance to the next model immediately on a transient/quota error — an
+			// instant same-model retry cannot clear an exhausted quota.
+			maxTransientRetriesPerModel: 0,
+			classify: (err) => {
+				const msg = err instanceof Error ? err.message : String(err);
+				// A critic dispatch TIMEOUT is not a provider transient — keep
+				// the existing fail-closed-then-REJECTED behavior instead of
+				// failing over (a slow call on one model does not predict quota
+				// exhaustion on the next). Mirrors the reviewer/runner carve-out.
+				if (/Critic dispatch timed out/i.test(msg)) return 'permanent';
+				return isTransientProviderError(msg) ? 'transient' : 'permanent';
+			},
+			onFallback: ({ toModel, fallbackIndex }) => {
+				telemetry.modelFallback(
+					sessionID,
+					agentName,
+					criticSwarmAgents?.[criticBase]?.model ?? 'default',
+					toModel,
+					'transient_model_error',
+				);
+				// Site 3 (lean-turbo integration) has no injected advisory
+				// channel (unlike auto-review.ts), so the advisory lands via the
+				// shared session-state path — same as the sibling reviewer.ts.
+				const session = getAgentSession(sessionID);
+				if (session) {
+					session.pendingAdvisoryMessages ??= [];
+					session.pendingAdvisoryMessages.push(
+						`MODEL FALLBACK: lean-turbo critic failed over to "${toModel}" (fallback ${fallbackIndex}) after a transient/quota dispatch error.`,
+					);
+				}
+			},
+		});
+		responseText = dispatched.result;
 	} catch (error) {
-		// Fail-closed: dispatch failure → write REJECTED verdict
+		// Fail-closed: dispatch failure (after fallbacks exhausted) → REJECTED verdict
+		const isQuota = isQuotaError(
+			error instanceof Error ? error.message : String(error),
+		);
 		const evidencePath = await _internals.writeCriticEvidence(
 			directory,
 			phase,
@@ -608,7 +692,7 @@ export async function dispatchPhaseCritic(
 		);
 		return {
 			verdict: 'REJECTED',
-			reason: `Critic dispatch failed: ${error instanceof Error ? error.message : String(error)}`,
+			reason: `Critic dispatch failed${isQuota ? ' (model quota/usage limit exhausted across all configured fallbacks)' : ''}: ${error instanceof Error ? error.message : String(error)}`,
 			evidencePath,
 		};
 	}

--- a/src/turbo/lean/reviewer.ts
+++ b/src/turbo/lean/reviewer.ts
@@ -476,6 +476,9 @@ Be specific and evidence-based. Do not approve a phase with unresolved degraded 
 						path: { id: sessionId },
 						body: {
 							agent: agentName,
+							// #1896/#1905: per-call model override on a fallback attempt
+							// (parity with the timeoutMs > 0 branch above).
+							...(model ? { model } : {}),
 							tools: { write: false, edit: false, patch: false },
 							parts: [{ type: 'text', text: promptText }],
 						},
@@ -483,7 +486,13 @@ Be specific and evidence-based. Do not approve a phase with unresolved degraded 
 					});
 
 		if (!response.data) {
-			throw new Error('Reviewer session returned no data');
+			// #1905: preserve the SDK error body so the transient/quota
+			// classifier can read the real provider message — without this,
+			// envelope-shaped 429/402 errors classify as permanent and the
+			// failover never fires (parity with auto-review.ts / integration.ts).
+			throw new Error(
+				`Reviewer session returned no data: ${JSON.stringify(response.error)}`,
+			);
 		}
 
 		// Extract text from response parts

--- a/src/utils/inline-fallback-advancer.ts
+++ b/src/utils/inline-fallback-advancer.ts
@@ -1,0 +1,124 @@
+/**
+ * Issue #1905: shared "inline fallback advancer" for bespoke dispatch loops that
+ * cannot use {@link dispatchWithModelFallback} because their retry semantics
+ * differ (e.g. retry-on-permanent, per-attempt session lifecycle, consecutive-
+ * failure counters).
+ *
+ * Before this helper, the advance block (resolve next → advance index → parse
+ * → skip-on-malformed → tag quota/transient reason → notify) was inlined in
+ * `src/full-auto/oversight.ts:543–579`. Issue #1905 adds a second copy at
+ * `src/hooks/full-auto-intercept.ts` (`dispatchCriticAndWriteEvent`). Extracting
+ * the block prevents the two copies from drifting — a future fix to the
+ * increment-before-parse ordering or the malformed-skip semantics applies to both.
+ *
+ * The helper is PURE: it resolves, parses, and classifies, then returns the
+ * result + invokes an `onAdopt` side-effect callback. It does NOT touch caller
+ * state (the loop's `modelOverride` / `modelUsedLabel` / `modelFallbackIndex`
+ * stay in the caller).
+ */
+
+import {
+	type ModelOverride,
+	parseModelString,
+} from './model-dispatch-fallback';
+import { isQuotaError } from './provider-error-classification';
+
+export interface AdvanceInlineFallbackOptions {
+	/**
+	 * Resolve the 1-based fallback model as a `provider/model` string, or null
+	 * when the fallback chain is exhausted. Typically wraps
+	 * `resolveFallbackModel(baseRole, index, getSwarmAgents(swarmId))`.
+	 */
+	resolveFallback: (fallbackIndex: number) => string | null;
+	/** Current fallback index (0 = primary / registered model). */
+	index: number;
+	/** The error from the just-failed attempt — used to tag the reason. */
+	lastError: unknown;
+	/**
+	 * Notified when a fallback model is cleanly adopted (for advisory logging
+	 * and telemetry). NOT called when the chain is exhausted or the entry is
+	 * malformed. The adopted override is returned in the result's `adopted`
+	 * field — callers read it there, not from this callback, so the info
+	 * payload intentionally omits the parsed `ModelOverride` (it would be
+	 * redundant with `result.adopted.override`).
+	 */
+	onAdopt: (info: {
+		toModel: string;
+		fallbackIndex: number;
+		reason: 'quota' | 'transient_model_error';
+	}) => void;
+}
+
+export interface AdvanceInlineFallbackResult {
+	/** The new fallback index (always >= the input `index`). */
+	nextIndex: number;
+	/**
+	 * The adopted fallback's raw string + parsed override, or `null` when no
+	 * new model was adopted (chain exhausted OR malformed entry skipped).
+	 *
+	 * When `null`, the caller must NOT change its current `modelOverride` — the
+	 * next retry continues on the same model. The index may still have advanced
+	 * (malformed-entry skip case) so the entry is not re-resolved.
+	 */
+	adopted: { modelString: string; override: ModelOverride } | null;
+}
+
+/**
+ * Advance the inline fallback chain by one step. Encapsulates the
+ * increment-before-parse + malformed-skip + reason-tagging logic shared by
+ * the bespoke dispatch loops in `oversight.ts` and `full-auto-intercept.ts`.
+ *
+ * Behavior:
+ *  - Chain exhausted (`resolveFallback(index + 1)` returns null):
+ *    `{ nextIndex: index, adopted: null }` — keep retrying the current model.
+ *  - Malformed entry (`parseModelString` throws or returns undefined):
+ *    `{ nextIndex: index + 1, adopted: null }` — index advances (so the entry
+ *    is not re-resolved next retry) but the override is NOT changed.
+ *  - Clean entry: `{ nextIndex: index + 1, adopted: { modelString, override } }`
+ *    — `onAdopt` is called with the quota/transient reason for side effects.
+ */
+export function advanceInlineFallback(
+	opts: AdvanceInlineFallbackOptions,
+): AdvanceInlineFallbackResult {
+	const nextModel = opts.resolveFallback(opts.index + 1);
+	if (!nextModel) {
+		// Chain exhausted — keep retrying the current model.
+		return { nextIndex: opts.index, adopted: null };
+	}
+
+	// Advance the index FIRST so a malformed entry is skipped rather than
+	// re-resolved every retry (which would strand any valid fallback listed
+	// after it); only adopt the model on a clean parse.
+	const advancedIndex = opts.index + 1;
+
+	let parsed: ModelOverride | undefined;
+	try {
+		parsed = parseModelString(nextModel);
+	} catch {
+		parsed = undefined; // malformed provider/model entry — skip it
+	}
+
+	if (!parsed) {
+		// Malformed entry — index advanced, override unchanged.
+		return { nextIndex: advancedIndex, adopted: null };
+	}
+
+	const reason = isQuotaError(
+		opts.lastError instanceof Error
+			? opts.lastError.message
+			: String(opts.lastError),
+	)
+		? 'quota'
+		: 'transient_model_error';
+
+	opts.onAdopt({
+		toModel: nextModel,
+		fallbackIndex: advancedIndex,
+		reason,
+	});
+
+	return {
+		nextIndex: advancedIndex,
+		adopted: { modelString: nextModel, override: parsed },
+	};
+}

--- a/tests/unit/hooks/auto-review-fallback.test.ts
+++ b/tests/unit/hooks/auto-review-fallback.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Issue #1905: the opt-in auto-review reviewer dispatch (`runAutoReview` in
+ * `src/hooks/auto-review.ts`) now fails over to a configured `fallback_models`
+ * entry on a transient/quota dispatch error instead of immediately writing a
+ * `verdict: 'error'` event (a quota blip previously dropped the review pass
+ * with no recovery). Mirrors `tests/unit/turbo/lean/reviewer-fallback.test.ts`
+ * for the sibling lean-turbo reviewer site (PR #1901), plus the #1905-specific
+ * envelope-preservation pin.
+ *
+ * Uses the `_internals` DI seam (no `mock.module`) per AGENTS.md invariant #7.
+ * The APPROVED-recovery case needs a real tmp `.swarm` dir because
+ * `persistReviewReceipt` / `parseReviewerOutput` are NOT in the `_internals`
+ * seam — they hit the real filesystem.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { getAgentConfigs } from '../../../src/agents/index';
+import type { PluginConfig } from '../../../src/config';
+import { _internals, runAutoReview } from '../../../src/hooks/auto-review';
+import { resetSwarmState, swarmState } from '../../../src/state';
+import { _internals as telemetryInternals } from '../../../src/telemetry';
+
+const APPROVED = 'VERDICT: APPROVED\nRISK: LOW\nISSUES:\n- none';
+
+function seedReviewerFallback(): void {
+	const config = {
+		agents: {
+			reviewer: {
+				model: 'prov/primary-reviewer',
+				fallback_models: ['prov/fb1', 'prov/fb2'],
+			},
+		},
+	} as unknown as PluginConfig;
+	getAgentConfigs(config);
+}
+
+let tmpDir: string;
+let origClient: typeof swarmState.opencodeClient;
+const origComputeDiff = _internals.computeExecutionDiff;
+const origDispatch = _internals.dispatchReviewer;
+const origNow = _internals.now;
+
+beforeEach(() => {
+	tmpDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'auto-review-fb-')),
+	);
+	fs.mkdirSync(path.join(tmpDir, '.swarm'), { recursive: true });
+	origClient = swarmState.opencodeClient;
+	resetSwarmState();
+	seedReviewerFallback();
+	_internals.now = () => 1_000_000;
+});
+
+afterEach(() => {
+	swarmState.opencodeClient = origClient;
+	_internals.computeExecutionDiff = origComputeDiff;
+	_internals.dispatchReviewer = origDispatch;
+	_internals.now = origNow;
+	resetSwarmState();
+	try {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	} catch {
+		// best-effort
+	}
+});
+
+function runInput(advisories: string[]) {
+	return {
+		directory: tmpDir,
+		sessionID: 's1',
+		trigger: 'phase_boundary' as const,
+		phase: 1,
+		config: { timeout_ms: 30_000, max_diff_kb: 256 },
+		injectAdvisory: (_sid: string, msg: string) => {
+			advisories.push(msg);
+		},
+	};
+}
+
+function readEvents(): Array<Record<string, unknown>> {
+	const p = path.join(tmpDir, '.swarm', 'events.jsonl');
+	if (!fs.existsSync(p)) return [];
+	return fs
+		.readFileSync(p, 'utf-8')
+		.split('\n')
+		.filter(Boolean)
+		.map((l) => JSON.parse(l));
+}
+
+describe('runAutoReview — model failover (#1905)', () => {
+	test('fails over to a fallback model on a quota dispatch error and records APPROVED', async () => {
+		_internals.computeExecutionDiff = async () => ({
+			status: 'ok' as const,
+			diff: 'diff --git a/x b/x\n+1',
+		});
+		const calls: Array<string | undefined> = [];
+		_internals.dispatchReviewer = async (
+			_dir,
+			_prompt,
+			_agent,
+			_timeout,
+			_parent,
+			model,
+		) => {
+			calls.push(model ? `${model.providerID}/${model.modelID}` : undefined);
+			// Primary (no override) hits quota; fallback succeeds.
+			if (!model)
+				throw new Error('429 insufficient_quota: usage limit exceeded');
+			return APPROVED;
+		};
+		const advisories: string[] = [];
+
+		await runAutoReview(runInput(advisories));
+
+		// Recovered → APPROVED event, NOT verdict:'error'.
+		const events = readEvents();
+		expect(events).toHaveLength(1);
+		expect(events[0]?.verdict).toBe('approved');
+		// Primary attempted (undefined), then the first fallback.
+		expect(calls[0]).toBeUndefined();
+		expect(calls[1]).toBe('prov/fb1');
+		// Advisory was pushed on the fallback (input.injectAdvisory channel).
+		expect(advisories.some((m) => m.includes('MODEL FALLBACK'))).toBe(true);
+	});
+
+	test('a permanent dispatch error still fails open (verdict:error) with no failover', async () => {
+		_internals.computeExecutionDiff = async () => ({
+			status: 'ok' as const,
+			diff: 'diff --git a/x b/x\n+1',
+		});
+		const calls: Array<string | undefined> = [];
+		_internals.dispatchReviewer = async (
+			_dir,
+			_prompt,
+			_agent,
+			_timeout,
+			_parent,
+			model,
+		) => {
+			calls.push(model ? `${model.providerID}/${model.modelID}` : undefined);
+			throw new Error('401 unauthorized: invalid api key');
+		};
+		const advisories: string[] = [];
+
+		await runAutoReview(runInput(advisories));
+
+		const events = readEvents();
+		expect(events).toHaveLength(1);
+		expect(events[0]?.verdict).toBe('error');
+		// Only the primary was attempted — no fallover on a permanent error.
+		expect(calls).toEqual([undefined]);
+		// No MODEL FALLBACK advisory.
+		expect(advisories.some((m) => m.includes('MODEL FALLBACK'))).toBe(false);
+	});
+
+	test('an auto-review dispatch timeout is permanent (no failover) — pins the defense-in-depth carve-out', async () => {
+		// The classify step explicitly treats "auto-review timed out" as
+		// permanent. This pins the carve-out so a future classifier change
+		// cannot silently start burning the fallback chain on a slow call.
+		_internals.computeExecutionDiff = async () => ({
+			status: 'ok' as const,
+			diff: 'diff --git a/x b/x\n+1',
+		});
+		const calls: Array<string | undefined> = [];
+		_internals.dispatchReviewer = async (
+			_dir,
+			_prompt,
+			_agent,
+			_timeout,
+			_parent,
+			model,
+		) => {
+			calls.push(model ? `${model.providerID}/${model.modelID}` : undefined);
+			throw new Error('auto-review timed out after 30000ms');
+		};
+
+		await runAutoReview(runInput([]));
+
+		const events = readEvents();
+		expect(events[0]?.verdict).toBe('error');
+		// Only the primary attempted — timeout is permanent, no failover.
+		expect(calls).toEqual([undefined]);
+	});
+
+	test('emits telemetry.modelFallback on a quota failover', async () => {
+		_internals.computeExecutionDiff = async () => ({
+			status: 'ok' as const,
+			diff: 'diff --git a/x b/x\n+1',
+		});
+		_internals.dispatchReviewer = async (
+			_dir,
+			_prompt,
+			_agent,
+			_timeout,
+			_parent,
+			model,
+		) => {
+			if (!model)
+				throw new Error('429 insufficient_quota: usage limit exceeded');
+			return APPROVED;
+		};
+
+		const emitted: Array<Record<string, unknown>> = [];
+		const origEmit = telemetryInternals.emit;
+		telemetryInternals.emit = ((
+			event: string,
+			payload: Record<string, unknown>,
+		) => {
+			if (event === 'model_fallback') emitted.push(payload);
+		}) as typeof telemetryInternals.emit;
+
+		try {
+			await runAutoReview(runInput([]));
+		} finally {
+			telemetryInternals.emit = origEmit;
+		}
+
+		expect(emitted).toHaveLength(1);
+		expect(emitted[0]?.toModel).toBe('prov/fb1');
+		expect(emitted[0]?.reason).toBe('transient_model_error');
+	});
+
+	test('quota-annotated error event detail when all fallbacks exhausted on a quota error', async () => {
+		// Mirrors integration-fallback.test.ts case d. No fallback chain seeded
+		// for THIS test — resolveFallbackModel returns null, so the primary is
+		// the only attempt and the quota error exhausts the (empty) chain
+		// immediately. The verdict:'error' event detail should carry the quota
+		// annotation added by the isQuotaError branch.
+		const config = {
+			agents: { reviewer: { model: 'prov/primary-reviewer' } },
+		} as unknown as PluginConfig;
+		getAgentConfigs(config);
+		_internals.computeExecutionDiff = async () => ({
+			status: 'ok' as const,
+			diff: 'diff --git a/x b/x\n+1',
+		});
+		_internals.dispatchReviewer = async () => {
+			throw new Error('429 insufficient_quota: usage limit exceeded');
+		};
+
+		await runAutoReview(runInput([]));
+
+		const events = readEvents();
+		expect(events).toHaveLength(1);
+		expect(events[0]?.verdict).toBe('error');
+		expect(events[0]?.detail).toContain('quota/usage limit exhausted');
+	});
+
+	test('envelope-shaped quota error via the real dispatchReviewer (data:null + error envelope) triggers failover — pins the #1905 envelope-preservation fix', async () => {
+		// This is the Critical-finding test: drive the REAL dispatchReviewer
+		// (not a throwing _internals mock) with a mock client returning
+		// { data: null, error: { message: '429 ...' } }. Without the
+		// envelope-preservation fix at the dispatch site, the classifier would
+		// see only "auto-review session returned no data" with no quota token
+		// → permanent → no failover. The fix embeds JSON.stringify(error).
+		_internals.computeExecutionDiff = async () => ({
+			status: 'ok' as const,
+			diff: 'diff --git a/x b/x\n+1',
+		});
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = {
+			session: {
+				create: async () => ({ data: { id: 'review-session-1' } }),
+				prompt: async (params: { body?: { model?: unknown } }) => {
+					const override = params.body?.model;
+					promptCalls.push(
+						override
+							? `${(override as any).providerID}/${(override as any).modelID}`
+							: undefined,
+					);
+					if (!override) {
+						return {
+							data: null,
+							error: {
+								code: 'RATE_LIMITED',
+								message: '429 rate_limit_exceeded: too many requests',
+							},
+						};
+					}
+					return { data: { parts: [{ type: 'text', text: APPROVED }] } };
+				},
+				delete: async () => ({}),
+			},
+		} as typeof swarmState.opencodeClient;
+
+		await runAutoReview(runInput([]));
+
+		// Failover fired on the envelope-shaped error → APPROVED event.
+		const events = readEvents();
+		expect(events).toHaveLength(1);
+		expect(events[0]?.verdict).toBe('approved');
+		expect(promptCalls[0]).toBeUndefined();
+		expect(promptCalls[1]).toBe('prov/fb1');
+	});
+});

--- a/tests/unit/hooks/full-auto-intercept-fallback.test.ts
+++ b/tests/unit/hooks/full-auto-intercept-fallback.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Issue #1905: the legacy reactive-intercept critic dispatch
+ * (`dispatchCriticAndWriteEvent` in `src/hooks/full-auto-intercept.ts`) now
+ * fails over to a configured `fallback_models` entry on a transient/quota
+ * dispatch error instead of failing the stage outright. This mirrors
+ * `tests/unit/full-auto/oversight-fallback.test.ts` for the sibling v2
+ * `dispatchFullAutoOversight` site (PR #1901), and pins the #1905-specific
+ * additions: the v2-mirror `critic_model` attribution rewrite and the
+ * SDK-error-envelope preservation.
+ *
+ * Uses the `_internals.swarmState.opencodeClient` injection pattern (no
+ * `mock.module`) per AGENTS.md invariant #7.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { getAgentConfigs } from '../../../src/agents/index';
+import type { PluginConfig } from '../../../src/config';
+import { startFullAutoRun } from '../../../src/full-auto/state';
+import { dispatchCriticAndWriteEvent } from '../../../src/hooks/full-auto-intercept';
+import { _internals as stateInternals } from '../../../src/state';
+import { _internals as telemetryInternals } from '../../../src/telemetry';
+
+// Seed the default swarm map so critic_oversight has a fallback chain. The
+// dispatcher resolves `oversightFallbackRole = critic_oversight` when this
+// role has fallback_models, else falls back to `critic` — same logic as the
+// sibling oversight.ts.
+function seedOversightFallback(
+	fallbackModels: string[],
+	role: 'critic_oversight' | 'critic' = 'critic_oversight',
+): void {
+	const config = {
+		agents: {
+			[role]: {
+				model: 'prov/primary-critic',
+				fallback_models: fallbackModels,
+			},
+		},
+	} as unknown as PluginConfig;
+	getAgentConfigs(config);
+}
+
+type PromptBody = {
+	agent?: string;
+	model?: { providerID: string; modelID: string };
+	tools?: Record<string, boolean>;
+	parts?: Array<{ type: string; text?: unknown }>;
+};
+
+let tmpDir: string;
+let origClient: typeof stateInternals.swarmState.opencodeClient;
+
+beforeEach(() => {
+	tmpDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'fai-fallback-')),
+	);
+	fs.mkdirSync(path.join(tmpDir, '.swarm'), { recursive: true });
+	origClient = stateInternals.swarmState.opencodeClient;
+});
+
+afterEach(() => {
+	stateInternals.swarmState.opencodeClient = origClient;
+	try {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	} catch {
+		// best-effort
+	}
+});
+
+// Build a mock SDK client whose `session.prompt` fails on the primary model
+// (no `body.model` override) with the supplied error shape, and succeeds on
+// any fallback attempt (override present). Returns the ordered list of model
+// labels actually passed to prompt so the test can assert the failover chain.
+//
+// The #1905 envelope fix means the classifier sees `response.error.message`
+// embedded in the wrapped "Critic LLM prompt failed: …" string — so we drive
+// the real default dispatch fn via the SDK envelope, NOT a throwing mock.
+function buildQuotaFailingClient(errorEnvelope: {
+	code: string;
+	message: string;
+}): {
+	client: unknown;
+	promptModels: Array<string | undefined>;
+} {
+	const promptModels: Array<string | undefined> = [];
+	const client = {
+		session: {
+			create: mock(async () => ({
+				data: { id: 'critic-session' },
+				error: null,
+			})),
+			prompt: mock(async (params: { body: PromptBody }) => {
+				const override = params.body?.model;
+				const label = override
+					? `${override.providerID}/${override.modelID}`
+					: undefined;
+				promptModels.push(label);
+				if (!override) {
+					// Primary model hit its quota — envelope shape (the dominant
+					// SDK error class). The #1905 envelope fix preserves this.
+					return { data: null, error: errorEnvelope };
+				}
+				return {
+					data: {
+						parts: [
+							{
+								type: 'text',
+								text: 'VERDICT: APPROVED\nREASONING: recovered on fallback',
+							},
+						],
+					},
+				};
+			}),
+			delete: mock(async () => ({})),
+		},
+	};
+	return { client, promptModels };
+}
+
+describe('dispatchCriticAndWriteEvent — model failover (#1905)', () => {
+	test('fails over to a fallback model on a quota dispatch error and recovers', async () => {
+		seedOversightFallback(['prov/fb1', 'prov/fb2']);
+		const { client, promptModels } = buildQuotaFailingClient({
+			code: 'QUOTA',
+			message: '429 insufficient_quota: usage limit exceeded',
+		});
+		stateInternals.swarmState.opencodeClient = client as any;
+
+		const result = await dispatchCriticAndWriteEvent(
+			tmpDir,
+			'architect output',
+			'critic context',
+			'prov/primary-critic',
+			'question',
+			1,
+			0,
+			'critic_oversight',
+			'sess-failover',
+			2, // maxDispatchRetries
+			3, // maxConsecutiveDispatchFailures
+		);
+
+		// Recovered → APPROVED, not NEEDS_REVISION.
+		expect(result.verdict).toBe('APPROVED');
+		// Primary attempted first (undefined), then the first fallback adopted.
+		expect(promptModels[0]).toBeUndefined();
+		expect(promptModels[1]).toBe('prov/fb1');
+	});
+
+	test('emits telemetry.modelFallback on a quota failover (sessionID ?? "" for optional sessionID)', async () => {
+		seedOversightFallback(['prov/fb1']);
+		const { client } = buildQuotaFailingClient({
+			code: 'QUOTA',
+			message: 'insufficient_quota: usage limit exceeded',
+		});
+		stateInternals.swarmState.opencodeClient = client as any;
+
+		const emitted: Array<Record<string, unknown>> = [];
+		const origEmit = telemetryInternals.emit;
+		telemetryInternals.emit = ((
+			event: string,
+			payload: Record<string, unknown>,
+		) => {
+			if (event === 'model_fallback') emitted.push(payload);
+		}) as typeof telemetryInternals.emit;
+
+		// NOTE: sessionID is intentionally OMITTED here to prove the
+		// `sessionID ?? ''` coercion in the telemetry call site (critic item 3).
+		try {
+			await dispatchCriticAndWriteEvent(
+				tmpDir,
+				'architect output',
+				'critic context',
+				'prov/primary-critic',
+				'question',
+				1,
+				0,
+				'critic_oversight',
+				// sessionID undefined — the telemetry call must still receive ''.
+				undefined,
+				2,
+				3,
+			);
+		} finally {
+			telemetryInternals.emit = origEmit;
+		}
+
+		expect(emitted).toHaveLength(1);
+		expect(emitted[0]?.agentName).toBe('critic_oversight');
+		expect(emitted[0]?.fromModel).toBe('prov/primary-critic');
+		expect(emitted[0]?.toModel).toBe('prov/fb1');
+		// Auto-review/oversight tag quota vs transient based on the error text.
+		// Here the error carries "insufficient_quota" → 'quota'.
+		expect(emitted[0]?.reason).toBe('quota');
+	});
+
+	test('a permanent dispatch error still fails closed with no failover', async () => {
+		seedOversightFallback(['prov/fb1', 'prov/fb2']);
+		// 401 unauthorized is NOT in the transient/quota classifier → permanent.
+		// The error code/message avoid any transient/quota token so the classifier
+		// returns 'permanent' and no failover fires (site 1 still retries on
+		// permanent per FR-003, but it re-hits the same primary each time).
+		const { client, promptModels } = buildQuotaFailingClient({
+			code: 'AUTH_REJECTED',
+			message: '401 unauthorized: invalid api key',
+		});
+		stateInternals.swarmState.opencodeClient = client as any;
+
+		const result = await dispatchCriticAndWriteEvent(
+			tmpDir,
+			'architect output',
+			'critic context',
+			'prov/primary-critic',
+			'question',
+			1,
+			0,
+			'critic_oversight',
+			'sess-permanent',
+			2,
+			3,
+		);
+
+		// Permanent → no failover: every retry re-hit the same primary.
+		expect(promptModels).toEqual([undefined, undefined, undefined]);
+		// Fail-closed: verdict NEEDS_REVISION (reactive intercept's fail-closed
+		// shape, distinct from oversight.ts's BLOCKED — pinned by existing tests).
+		expect(result.verdict).toBe('NEEDS_REVISION');
+	});
+
+	test('a malformed fallback_models entry is skipped and the next valid one is reached', async () => {
+		// maxDispatchRetries=4 gives 5 attempts → up to 4 fallback advances,
+		// enough to skip the malformed index-1 entry and reach index-2. Mirrors
+		// the oversight-fallback.test.ts:259 pin and the [undefined, undefined,
+		// 'prov/fb2'] prompt-models assertion that documents the increment-
+		// before-parse re-dispatched-primary quirk.
+		seedOversightFallback(['no-separator-string', 'prov/fb2']);
+		const { client, promptModels } = buildQuotaFailingClient({
+			code: 'QUOTA',
+			message: '429 insufficient_quota: usage limit exceeded',
+		});
+		stateInternals.swarmState.opencodeClient = client as any;
+
+		const result = await dispatchCriticAndWriteEvent(
+			tmpDir,
+			'architect output',
+			'critic context',
+			'prov/primary-critic',
+			'question',
+			1,
+			0,
+			'critic_oversight',
+			'sess-malformed',
+			4, // maxDispatchRetries — sized to reach index-2 after the skip
+			3,
+		);
+
+		// Recovered on the second valid fallback.
+		expect(result.verdict).toBe('APPROVED');
+		// Documented increment-before-parse behavior: the malformed index-1
+		// entry advances the index but is NOT adopted, so the next retry
+		// re-dispatches the still-undefined primary before the index-2 entry
+		// parses cleanly and lands. The malformed entry never reaches the SDK.
+		expect(promptModels).toEqual([undefined, undefined, 'prov/fb2']);
+	});
+
+	test('falls back to the `critic` role chain when critic_oversight has no fallback_models', async () => {
+		// Seed BOTH: critic_oversight with no fallback (forces the inherit
+		// branch) and critic with a fallback (the inherited chain).
+		const config = {
+			agents: {
+				critic_oversight: { model: 'prov/primary-critic' },
+				critic: {
+					model: 'prov/primary-critic',
+					fallback_models: ['prov/inherited-fb'],
+				},
+			},
+		} as unknown as PluginConfig;
+		getAgentConfigs(config);
+		const { client, promptModels } = buildQuotaFailingClient({
+			code: 'QUOTA',
+			message: '429 insufficient_quota: usage limit exceeded',
+		});
+		stateInternals.swarmState.opencodeClient = client as any;
+
+		const result = await dispatchCriticAndWriteEvent(
+			tmpDir,
+			'architect output',
+			'critic context',
+			'prov/primary-critic',
+			'question',
+			1,
+			0,
+			'critic_oversight',
+			'sess-inherit',
+			2,
+			3,
+		);
+
+		// oversightFallbackRole resolves to 'critic' when critic_oversight has
+		// no fallback_models, so the inherited fallback is reachable.
+		expect(result.verdict).toBe('APPROVED');
+		expect(promptModels[1]).toBe('prov/inherited-fb');
+	});
+
+	test('envelope-shaped quota error (data:null + error envelope) triggers failover — pins the #1905 envelope-preservation fix', async () => {
+		// This is the Critical-finding test: without the envelope-preservation
+		// fix at the dispatch site, the classifier would see only "Critic LLM
+		// prompt failed: " with no quota token → permanent → no failover. The
+		// fix embeds JSON.stringify(response.error) in the wrapped message.
+		seedOversightFallback(['prov/fb1']);
+		const { client, promptModels } = buildQuotaFailingClient({
+			code: 'RATE_LIMITED',
+			message: '429 rate_limit_exceeded: too many requests',
+		});
+		stateInternals.swarmState.opencodeClient = client as any;
+
+		const result = await dispatchCriticAndWriteEvent(
+			tmpDir,
+			'architect output',
+			'critic context',
+			'prov/primary-critic',
+			'question',
+			1,
+			0,
+			'critic_oversight',
+			'sess-envelope',
+			2,
+			3,
+		);
+
+		// Failover fired on the envelope-shaped error → recovered.
+		expect(result.verdict).toBe('APPROVED');
+		expect(promptModels[0]).toBeUndefined();
+		expect(promptModels[1]).toBe('prov/fb1');
+	});
+
+	test('v2 mirror event records the landed fallback model in critic_model — pins plan-critic finding 2 (#1905)', async () => {
+		// Plan-critic finding 2 (Important, 85/100) required: "Thread the landed
+		// model into the mirror … AND assert it in the new site-1 test." The
+		// threading is at full-auto-intercept.ts:801 (passes criticModelUsed)
+		// and :1353 (writes critic_model: criticModelUsed ?? criticModel). This
+		// test seeds a durable RUNNING v2 record so mirrorReactiveVerdictToV2
+		// fires, runs a quota-failover dispatch, and asserts the mirrored
+		// full_auto_oversight event's critic_model is the fallback — NOT the
+		// configured primary. Without the threading, this regresses to the exact
+		// stale-attribution defect #1901 fixed in oversight.ts.
+		seedOversightFallback(['prov/fb1']);
+		const { client } = buildQuotaFailingClient({
+			code: 'QUOTA',
+			message: '429 insufficient_quota: usage limit exceeded',
+		});
+		stateInternals.swarmState.opencodeClient = client as any;
+
+		// Seed a durable RUNNING v2 record so the mirror does not no-op.
+		// mirrorReactiveVerdictToV2 reads .swarm/full-auto-state.json, matches
+		// the caller's sessionID with status === 'running', and writes a
+		// full_auto_oversight event to .swarm/events.jsonl.
+		startFullAutoRun(tmpDir, 'sess-mirror', { enabled: true });
+
+		await dispatchCriticAndWriteEvent(
+			tmpDir,
+			'architect output',
+			'critic context',
+			'prov/primary-critic',
+			'question',
+			1,
+			0,
+			'critic_oversight',
+			'sess-mirror', // must match the durable record's sessionID
+			2,
+			3,
+		);
+
+		// Read the mirrored full_auto_oversight event from events.jsonl. The
+		// legacy auto_oversight event is also written; filter for the v2 type.
+		const eventsPath = path.join(tmpDir, '.swarm', 'events.jsonl');
+		const lines = fs
+			.readFileSync(eventsPath, 'utf-8')
+			.split('\n')
+			.filter(Boolean);
+		const v2Events = lines
+			.map((l) => JSON.parse(l))
+			.filter((e: { type?: string }) => e.type === 'full_auto_oversight');
+
+		expect(v2Events.length).toBeGreaterThanOrEqual(1);
+		const mirrorEvent = v2Events[v2Events.length - 1];
+		// The landed fallback model — NOT the configured primary. This is the
+		// attribution-rewrite pin plan-critic finding 2 required.
+		expect(mirrorEvent.critic_model).toBe('prov/fb1');
+		expect(mirrorEvent.critic_model).not.toBe('prov/primary-critic');
+	});
+});

--- a/tests/unit/turbo/lean/integration-fallback.test.ts
+++ b/tests/unit/turbo/lean/integration-fallback.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Issue #1905: the lean-turbo phase critic boundary-review dispatch
+ * (`dispatchPhaseCritic` in `src/turbo/lean/integration.ts`) now fails over to
+ * a configured `fallback_models` entry on a transient/quota dispatch error
+ * instead of immediately writing a REJECTED verdict (a quota blip previously
+ * cascaded into a false phase rejection). Mirrors
+ * `tests/unit/turbo/lean/reviewer-fallback.test.ts` for the sibling lean-turbo
+ * reviewer site (PR #1901), plus the #1905-specific envelope-preservation pin.
+ *
+ * Uses the `_internals` DI seam (no `mock.module`) per AGENTS.md invariant #7.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { getAgentConfigs } from '../../../../src/agents/index';
+import type { PluginConfig } from '../../../../src/config';
+import { resetSwarmState } from '../../../../src/state';
+import {
+	_internals,
+	dispatchPhaseCritic,
+} from '../../../../src/turbo/lean/integration';
+
+function seedCriticFallback(): void {
+	const config = {
+		agents: {
+			critic: {
+				model: 'prov/primary-critic',
+				fallback_models: ['prov/fb1', 'prov/fb2'],
+			},
+		},
+	} as unknown as PluginConfig;
+	getAgentConfigs(config);
+}
+
+const originalInternals = { ..._internals };
+
+describe('dispatchPhaseCritic — model failover (#1905)', () => {
+	beforeEach(() => {
+		resetSwarmState();
+		seedCriticFallback();
+		// Stub the fs/parse dependencies so the test is pure.
+		_internals.compileCriticPackage = (async () => ({
+			phase: 1,
+		})) as unknown as typeof _internals.compileCriticPackage;
+		_internals.writeCriticEvidence = async () => '/evidence/critic.json';
+		_internals.parseCriticVerdict = () => ({
+			verdict: 'APPROVED',
+			reason: 'boundary acceptable',
+		});
+	});
+
+	afterEach(() => {
+		Object.assign(_internals, originalInternals);
+		resetSwarmState();
+	});
+
+	test('fails over to a fallback model on a quota dispatch error and recovers', async () => {
+		const calls: Array<string | undefined> = [];
+		_internals.dispatchCriticAgent = async (
+			_dir,
+			_pkg,
+			_agent,
+			_timeout,
+			_parent,
+			model,
+		) => {
+			calls.push(model ? `${model.providerID}/${model.modelID}` : undefined);
+			// Primary (registered model, no override) hits quota; fallback succeeds.
+			if (!model)
+				throw new Error('429 insufficient_quota: usage limit exceeded');
+			return 'VERDICT: APPROVED';
+		};
+
+		const result = await dispatchPhaseCritic(
+			'/tmp/does-not-matter',
+			1,
+			'sess-1',
+			{
+				criticAgent: 'critic',
+				timeoutMs: 0,
+			},
+		);
+
+		// Recovered → APPROVED, NOT the old fail-closed REJECTED.
+		expect(result.verdict).toBe('APPROVED');
+		// Primary attempted (undefined), then the first fallback.
+		expect(calls[0]).toBeUndefined();
+		expect(calls[1]).toBe('prov/fb1');
+	});
+
+	test('a permanent dispatch error still fails closed (REJECTED) with no failover', async () => {
+		const calls: Array<string | undefined> = [];
+		_internals.dispatchCriticAgent = async (
+			_dir,
+			_pkg,
+			_agent,
+			_timeout,
+			_parent,
+			model,
+		) => {
+			calls.push(model ? `${model.providerID}/${model.modelID}` : undefined);
+			throw new Error('401 unauthorized: invalid api key');
+		};
+
+		const result = await dispatchPhaseCritic(
+			'/tmp/does-not-matter',
+			1,
+			'sess-2',
+			{
+				criticAgent: 'critic',
+				timeoutMs: 0,
+			},
+		);
+
+		expect(result.verdict).toBe('REJECTED');
+		// Only the primary was attempted — no fallover on a permanent error.
+		expect(calls).toEqual([undefined]);
+	});
+
+	test('a critic dispatch timeout is permanent (no failover) — pins the defense-in-depth carve-out', async () => {
+		// The classify step explicitly treats "Critic dispatch timed out" as
+		// permanent (mirroring the reviewer). This pins the carve-out so a
+		// future classifier change cannot silently start burning the fallback
+		// chain on a slow call.
+		const calls: Array<string | undefined> = [];
+		_internals.dispatchCriticAgent = async (
+			_dir,
+			_pkg,
+			_agent,
+			_timeout,
+			_parent,
+			model,
+		) => {
+			calls.push(model ? `${model.providerID}/${model.modelID}` : undefined);
+			throw new Error('Critic dispatch timed out after 60000ms');
+		};
+
+		const result = await dispatchPhaseCritic(
+			'/tmp/does-not-matter',
+			1,
+			'sess-timeout',
+			{ criticAgent: 'critic', timeoutMs: 0 },
+		);
+
+		expect(result.verdict).toBe('REJECTED');
+		// Only the primary attempted — timeout is permanent, no failover.
+		expect(calls).toEqual([undefined]);
+	});
+
+	test('quota-annotated REJECTED reason when all fallbacks exhausted on a quota error', async () => {
+		// No fallback chain seeded for THIS test — resolveFallbackModel returns
+		// null, so the primary is the only attempt and the quota error exhausts
+		// the (empty) chain immediately. The REJECTED reason should carry the
+		// quota annotation.
+		const config = {
+			agents: { critic: { model: 'prov/primary-critic' } },
+		} as unknown as PluginConfig;
+		getAgentConfigs(config);
+		_internals.dispatchCriticAgent = async () => {
+			throw new Error('429 insufficient_quota: usage limit exceeded');
+		};
+
+		const result = await dispatchPhaseCritic(
+			'/tmp/does-not-matter',
+			1,
+			'sess-exhausted',
+			{ criticAgent: 'critic', timeoutMs: 0 },
+		);
+
+		expect(result.verdict).toBe('REJECTED');
+		expect(result.reason).toContain('quota/usage limit exhausted');
+	});
+
+	test('envelope-shaped quota error via the real defaultDispatchCriticAgent (data:null + error envelope) triggers failover — pins the #1905 envelope-preservation fix', async () => {
+		// This is the Critical-finding test: drive the REAL
+		// defaultDispatchCriticAgent (not a throwing _internals mock) with a
+		// mock client returning { data: null, error: { message: '429 ...' } }.
+		// Without the envelope-preservation fix, the classifier would see only
+		// "Critic session returned no data" with no quota token → permanent →
+		// no failover. The fix embeds JSON.stringify(response.error).
+		//
+		// We re-assign _internals.dispatchCriticAgent back to the real
+		// defaultDispatchCriticAgent (the originalInternals captured above
+		// before the beforeEach stubs overwrote it) and seed a mock client.
+		const { swarmState } = await import('../../../../src/state');
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = {
+			session: {
+				create: async () => ({ data: { id: 'critic-session-1' } }),
+				prompt: async (params: { body?: { model?: unknown } }) => {
+					const override = params.body?.model;
+					promptCalls.push(
+						override
+							? `${(override as any).providerID}/${(override as any).modelID}`
+							: undefined,
+					);
+					if (!override) {
+						return {
+							data: null,
+							error: {
+								code: 'RATE_LIMITED',
+								message: '429 rate_limit_exceeded: too many requests',
+							},
+						};
+					}
+					return {
+						data: { parts: [{ type: 'text', text: 'VERDICT: APPROVED' }] },
+					};
+				},
+				delete: async () => ({}),
+			},
+		} as typeof swarmState.opencodeClient;
+		// Restore the REAL default dispatch fn (the beforeEach stubbed it).
+		_internals.dispatchCriticAgent = originalInternals.dispatchCriticAgent;
+
+		try {
+			const result = await dispatchPhaseCritic(
+				'/tmp/does-not-matter',
+				1,
+				'sess-envelope',
+				{ criticAgent: 'critic', timeoutMs: 0 },
+			);
+
+			// Failover fired on the envelope-shaped error → APPROVED.
+			expect(result.verdict).toBe('APPROVED');
+			expect(promptCalls[0]).toBeUndefined();
+			expect(promptCalls[1]).toBe('prov/fb1');
+		} finally {
+			swarmState.opencodeClient = undefined;
+		}
+	});
+});

--- a/tests/unit/turbo/lean/reviewer-fallback.test.ts
+++ b/tests/unit/turbo/lean/reviewer-fallback.test.ts
@@ -11,7 +11,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { getAgentConfigs } from '../../../../src/agents/index';
 import type { PluginConfig } from '../../../../src/config';
-import { resetSwarmState } from '../../../../src/state';
+import { resetSwarmState, swarmState } from '../../../../src/state';
 import {
 	_internals,
 	dispatchPhaseReviewer,
@@ -138,5 +138,62 @@ describe('dispatchPhaseReviewer — model failover (#1896)', () => {
 		expect(result.verdict).toBe('REJECTED');
 		// Only the primary attempted — timeout is permanent, no failover.
 		expect(calls).toEqual([undefined]);
+	});
+
+	test('envelope-shaped quota error via the real defaultDispatchReviewerAgent (data:null + error envelope) triggers failover — pins the #1905 envelope-preservation parity fix', async () => {
+		// Issue #1905 critic item 1 (Critical): the sibling reviewer site
+		// (already wired in PR #1901) had the SAME envelope-discard gap as
+		// auto-review.ts and integration.ts. Without the parity fix at
+		// reviewer.ts:486, the classifier would see only "Reviewer session
+		// returned no data" with no quota token → permanent → no failover. The
+		// fix embeds JSON.stringify(response.error) in the thrown message.
+		//
+		// Drive the REAL defaultDispatchReviewerAgent with a mock client
+		// returning { data: null, error: { message: '429 ...' } }.
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = {
+			session: {
+				create: async () => ({ data: { id: 'reviewer-session-1' } }),
+				prompt: async (params: { body?: { model?: unknown } }) => {
+					const override = params.body?.model;
+					promptCalls.push(
+						override
+							? `${(override as { providerID: string; modelID: string }).providerID}/${(override as { providerID: string; modelID: string }).modelID}`
+							: undefined,
+					);
+					if (!override) {
+						return {
+							data: null,
+							error: {
+								code: 'RATE_LIMITED',
+								message: '429 rate_limit_exceeded: too many requests',
+							},
+						};
+					}
+					return {
+						data: { parts: [{ type: 'text', text: 'VERDICT: APPROVED' }] },
+					};
+				},
+				delete: async () => ({}),
+			},
+		} as typeof swarmState.opencodeClient;
+		// Restore the REAL default dispatch fn (beforeEach stubbed it).
+		_internals.dispatchReviewerAgent = originalInternals.dispatchReviewerAgent;
+
+		try {
+			const result = await dispatchPhaseReviewer(
+				'/tmp/does-not-matter',
+				1,
+				'sess-envelope',
+				{ reviewerAgent: 'reviewer', timeoutMs: 0 },
+			);
+
+			// Failover fired on the envelope-shaped error → APPROVED.
+			expect(result.verdict).toBe('APPROVED');
+			expect(promptCalls[0]).toBeUndefined();
+			expect(promptCalls[1]).toBe('prov/fb1');
+		} finally {
+			swarmState.opencodeClient = undefined;
+		}
 	});
 });

--- a/tests/unit/utils/inline-fallback-advancer.test.ts
+++ b/tests/unit/utils/inline-fallback-advancer.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Issue #1905: unit tests for the shared inline fallback advancer
+ * (`src/utils/inline-fallback-advancer.ts`). The helper is a pure extraction of
+ * the advance block shared by `src/full-auto/oversight.ts:543–579` and the new
+ * site at `src/hooks/full-auto-intercept.ts`. These tests pin the three branches
+ * (chain exhausted, malformed skip, clean adopt) and the reason tagging.
+ */
+import { describe, expect, mock, test } from 'bun:test';
+import { advanceInlineFallback } from '../../../src/utils/inline-fallback-advancer';
+
+describe('advanceInlineFallback (#1905)', () => {
+	test('chain exhausted — returns current index and no adoption', () => {
+		const onAdopt = mock(() => {});
+		const result = advanceInlineFallback({
+			resolveFallback: () => null,
+			index: 0,
+			lastError: new Error('429 insufficient_quota'),
+			onAdopt,
+		});
+
+		expect(result.nextIndex).toBe(0);
+		expect(result.adopted).toBeNull();
+		expect(onAdopt).not.toHaveBeenCalled();
+	});
+
+	test('clean adopt — index advances and override is parsed', () => {
+		const onAdopt = mock(() => {});
+		const result = advanceInlineFallback({
+			resolveFallback: (i) => (i === 1 ? 'prov/fb1' : null),
+			index: 0,
+			lastError: new Error('429 insufficient_quota'),
+			onAdopt,
+		});
+
+		expect(result.nextIndex).toBe(1);
+		expect(result.adopted).not.toBeNull();
+		expect(result.adopted?.modelString).toBe('prov/fb1');
+		expect(result.adopted?.override).toEqual({
+			providerID: 'prov',
+			modelID: 'fb1',
+		});
+		expect(onAdopt).toHaveBeenCalledTimes(1);
+		expect(onAdopt.mock.calls[0]?.[0]).toEqual({
+			toModel: 'prov/fb1',
+			fallbackIndex: 1,
+			reason: 'quota',
+		});
+	});
+
+	test('quota error → reason is "quota"', () => {
+		const onAdopt = mock(() => {});
+		advanceInlineFallback({
+			resolveFallback: () => 'prov/fb1',
+			index: 0,
+			lastError: new Error('insufficient_quota: usage limit exceeded'),
+			onAdopt,
+		});
+
+		expect(onAdopt.mock.calls[0]?.[0]?.reason).toBe('quota');
+	});
+
+	test('transient (non-quota) error → reason is "transient_model_error"', () => {
+		const onAdopt = mock(() => {});
+		advanceInlineFallback({
+			resolveFallback: () => 'prov/fb1',
+			index: 0,
+			lastError: new Error('503 temporarily unavailable'),
+			onAdopt,
+		});
+
+		expect(onAdopt.mock.calls[0]?.[0]?.reason).toBe('transient_model_error');
+	});
+
+	test('malformed entry (no provider/model separator) is skipped — index advances, override unchanged', () => {
+		// parseModelString throws on a value with no `/` separator.
+		const onAdopt = mock(() => {});
+		const result = advanceInlineFallback({
+			resolveFallback: () => 'no-separator-string',
+			index: 0,
+			lastError: new Error('429 insufficient_quota'),
+			onAdopt,
+		});
+
+		// Index advances (so the malformed entry is not re-resolved on the next
+		// retry) but no override is adopted — the caller keeps its current model.
+		expect(result.nextIndex).toBe(1);
+		expect(result.adopted).toBeNull();
+		expect(onAdopt).not.toHaveBeenCalled();
+	});
+
+	test('works from a non-zero starting index (mid-chain recovery)', () => {
+		const onAdopt = mock(() => {});
+		const result = advanceInlineFallback({
+			resolveFallback: (i) => (i === 3 ? 'prov/fb3' : null),
+			index: 2,
+			lastError: new Error('503 service unavailable'),
+			onAdopt,
+		});
+
+		expect(result.nextIndex).toBe(3);
+		expect(result.adopted?.modelString).toBe('prov/fb3');
+		expect(onAdopt.mock.calls[0]?.[0]?.fallbackIndex).toBe(3);
+	});
+
+	test('handles a non-Error lastError (String() coercion path)', () => {
+		const onAdopt = mock(() => {});
+		advanceInlineFallback({
+			resolveFallback: () => 'prov/fb1',
+			index: 0,
+			lastError: { weird: 'object' },
+			onAdopt,
+		});
+
+		// No quota/transient token in "[object Object]" → transient_model_error
+		// is NOT the right tag here (the caller would not have called this for a
+		// non-transient error), but the classifier must not crash on non-Error.
+		expect(onAdopt).toHaveBeenCalledTimes(1);
+		expect(onAdopt.mock.calls[0]?.[0]?.reason).toBe('transient_model_error');
+	});
+});


### PR DESCRIPTION
Closes #1905

## Summary

PR #1901 (closing #1896) shipped model quota/rate-limit failover for the four primary model-dispatch stages. This PR completes the coverage by wiring the same failover into the **three remaining production dispatch sites** that still called `client.session.prompt` directly with no fallback, plus a parity envelope-preservation fix at a fourth site and a pre-existing bug fix the new tests caught.

### Production sites wired

| Site | Function | Pattern |
| --- | --- | --- |
| `src/hooks/full-auto-intercept.ts` | `dispatchCriticAndWriteEvent` (legacy reactive-intercept critic) | Inline `modelOverride` (mirrors `oversight.ts`); preserves FR-003 retry-on-any-error + SC-011 consecutive-failure semantics. v2 mirror event's `critic_model` rewritten to the landed fallback. |
| `src/hooks/auto-review.ts` | `runAutoReview` (advisory execution-diff reviewer) | Shared `dispatchWithModelFallback` (mirrors `reviewer.ts`); advisory via the module's existing `input.injectAdvisory` channel. |
| `src/turbo/lean/integration.ts` | `dispatchPhaseCritic` (lean-turbo boundary critic) | Shared `dispatchWithModelFallback`; advisory via `getAgentSession`. |

### Load-bearing bug fix — SDK error-envelope preservation

The OpenCode SDK returns HTTP failures (429/402 quota) as `{ data: null, error }` envelopes, not thrown exceptions. Four dispatch sites discarded `response.error` into a token-free `'… returned no data'` Error, so the transient/quota classifier saw no quota token → permanent → **failover never fired on the dominant SDK error shape**, even after the #1901 wiring. The plan critic (Kimi K3) caught this pre-implementation; this PR preserves `JSON.stringify(response.error)` in the thrown message at `auto-review.ts`, `integration.ts`, `reviewer.ts`, and `model-dispatcher.ts`.

### Bonus bug fix — lean-turbo reviewer no-timeout-branch model override

A pre-existing bug in `src/turbo/lean/reviewer.ts` left the `defaultDispatchReviewerAgent` no-timeout branch (`timeoutMs <= 0`, the default) missing the `...(model ? { model } : {})` override. The #1896 failover wiring was silently broken for every caller passing `timeoutMs: 0` — the fallback was resolved, passed to the dispatch fn, and dropped on the floor. The new envelope-path test (which drives the real dispatch fn, not a throwing mock) caught this; fix applied.

### Refactor — shared `inline-fallback-advancer` helper

The ~30-line fallback-advance block (resolve → increment-before-parse → skip malformed → tag reason) shared by `oversight.ts` and the new site-1 loop is extracted into `src/utils/inline-fallback-advancer.ts` so the two bespoke loops cannot drift. `oversight.ts` is refactored to use it (behavior-preserving — pinned by existing `oversight-fallback.test.ts`).

### Out of scope (tracked in follow-up issues)

- Opt-in dispatch sites (`createCuratorLLMDelegate`, `createSkillImproverLLMDelegate`) → **#1927**
- Shell-write-detection gaps (`tee`, glued `-c`) — distinct hardening concern → **#1928**
- `generateMutants` — dispatches with `agent: undefined`; no role/chain concept. Existing `return []` graceful degradation is correct.

## Invariant audit

- **1 (plugin init):** not touched — no init-path changes. Evidence: diff touches only dispatch sites + a pure helper; no `src/index.ts` / package exports / `server()` changes.
- **2 (runtime portability):** not touched — no `bun:`/`Bun.*` imports added. Evidence: `grep -rn "bun:\|Bun\." src/utils/inline-fallback-advancer.ts src/evaluation/model-dispatcher.ts src/full-auto/oversight.ts src/hooks/auto-review.ts src/hooks/full-auto-intercept.ts src/turbo/lean/integration.ts src/turbo/lean/reviewer.ts` → no hits. Build + Node smoke: `bun run build` succeeded; `node --input-type=module -e "await import('./dist/index.js')"` → `plugin id: opencode-swarm` / `has server: true`.
- **3 (subprocesses):** not touched — no new subprocess calls.
- **4 (.swarm containment):** not touched — no new `.swarm/` writes; the v2-mirror test writes to a tmp `.swarm/` via existing `startFullAutoRun`.
- **5 (plan durability):** not touched.
- **6 (test_runner safety):** not touched — all validation used per-file `bun --smol test <file>` shell loops, not `test_runner`.
- **7 (test writing):** touched — 5 new/modified test files. Evidence: `grep -rn "mock.module" <5 new test files>` → only matches in comments (documentation of "no mock.module"). All tests use `_internals` DI or `swarmState.opencodeClient` injection. Check 4 ratchet: `Base entries: 112 | Head entries: 112 | Added in this PR: 0 | Unapproved: 0`.
- **8 (session state):** not touched.
- **9 (guardrails/retry):** touched — failover wiring is the core of this PR. Evidence: site 1 preserves FR-003 retry-on-any-error (including permanent) — the `isTransientProviderError` gate only controls fallback adoption, not whether a retry happens; pinned by `[undefined, undefined, undefined]` assertion in the permanent-error test. Sites 2/3 use `maxTransientRetriesPerModel: 0` (advance immediately on transient) with timeout carve-outs, matching the reviewer.ts precedent.
- **10 (chat/system msg):** not touched.
- **11 (tool registration):** not touched — no tool/agent/command/help changes. Drift check: `bun run drift:check` → "No drift detected".
- **12 (release/cache):** touched — release-notes fragment added at `docs/releases/pending/1905-model-failover-remaining-dispatch-sites.md`. No version files hand-edited (release-please owns them).

## Test plan

### New tests (5 files)

| File | Tests | Result |
| --- | --- | --- |
| `tests/unit/utils/inline-fallback-advancer.test.ts` | 7 | ✅ 0 fail |
| `tests/unit/hooks/full-auto-intercept-fallback.test.ts` | 7 | ✅ 0 fail (incl. v2-mirror attribution + envelope path) |
| `tests/unit/hooks/auto-review-fallback.test.ts` | 6 | ✅ 0 fail (incl. quota-annotation + envelope path) |
| `tests/unit/turbo/lean/integration-fallback.test.ts` | 5 | ✅ 0 fail (incl. envelope path) |
| `tests/unit/turbo/lean/reviewer-fallback.test.ts` (+1 case) | 4 | ✅ 0 fail (envelope parity path) |

### Existing tests (no regression)

| File | Tests | Result |
| --- | --- | --- |
| `tests/unit/hooks/full-auto-intercept.dispatch.test.ts` | 52 | ✅ 0 fail |
| `tests/unit/hooks/full-auto-intercept-parenting.test.ts` | 2 | ✅ 0 fail |
| `tests/unit/hooks/auto-review.test.ts` | 16 | ✅ 0 fail |
| `tests/unit/turbo/lean/integration.test.ts` | 31 | ✅ 0 fail |
| `tests/unit/turbo/lean/reviewer.test.ts` | 31 | ✅ 0 fail |
| `tests/unit/full-auto/oversight.test.ts` | 11 | ✅ 0 fail |
| `tests/unit/full-auto/oversight-fallback.test.ts` | 5 | ✅ 0 fail (pins the oversight.ts refactor) |
| `tests/unit/full-auto/oversight-retry.test.ts` | 13 | ✅ 0 fail |
| `tests/unit/evaluation/model-dispatcher.test.ts` | 13 | ✅ 0 fail |

**Total: 203 tests across 14 files, 0 failures.** Per-file isolation (one `bun --smol test <file>` per process) per AGENTS.md invariant #6.

### Validation suite

| Check | Command | Result |
| --- | --- | --- |
| Typecheck | `bunx tsc --noEmit -p tsconfig.json` | ✅ clean |
| Lint/format | `bunx @biomejs/biome@2.3.14 check <12 touched files>` | ✅ "Checked 12 files. No fixes applied." |
| Invariants | `bash scripts/check-invariants.sh` | ✅ exit 0 — Check 4: Base 112 / Head 112 / Unapproved 0 |
| Drift | `bun run drift:check` | ✅ "No drift detected" |
| Build | `bun run build` | ✅ bundle emitted |
| Node smoke (inv #2) | `node --input-type=module -e "await import('./dist/index.js')"` | ✅ `plugin id: opencode-swarm` / `has server: true` |

### Review gates

- **Plan critic (Kimi K3):** NEEDS_REVISION → 1 Critical + 6 Important findings → all incorporated.
- **Implementation reviewer (Kimi K2.7):** APPROVE → 3 nits → all addressed.
- **Final critic (Kimi K3):** NEEDS_REVISION → 3 Important findings → all resolved (v2-mirror attribution test added; follow-up issues #1927/#1928 filed; model-dispatcher envelope fix folded in) → re-review APPROVE.

Three models (GLM-5.2 implementer, Kimi K2.7 reviewer, Kimi K3 final critic across two rounds) concur.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

