### PR TITLE
fix(pr-workflow): prepend workflow banner instead of replacing architect text

### DIFF
--- a/.opencode/skills/swarm-pr-feedback/SKILL.md
+++ b/.opencode/skills/swarm-pr-feedback/SKILL.md
@@ -810,8 +810,8 @@ tool clears the durable session gate only when the content digest still equals
 the independently approved digest, the exact approved commit remains current,
 its bound upstream remote-tracking ref points to that exact commit, every
 feedback ID has exact-provenance evidence, and no PR-workflow lanes remain
-open. While the gate remains active, the runtime replaces architect
-final-response text with a mechanical blocked notice and normally re-wakes an
+open. While the gate remains active, the runtime prepends a workflow-active
+banner to architect text (the model's text is preserved below it) and normally re-wakes an
 idle parent session. A user interruption pauses automatic wakes until a later
 explicit user turn settles; the durable gate remains available to continue or
 abort.

--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -1631,8 +1631,9 @@ before emitting the user-facing final report, call `complete_pr_workflow` with
 mode `PR_REVIEW` and the same exact
 `pr_head_sha`. The tool refuses to clear the session gate while required base,
 trigger, declared reviewer/critic, or open-lane obligations remain incomplete.
-While the gate remains active, the runtime replaces architect final-response
-text with a mechanical blocked notice and re-wakes an idle parent session. A
+While the gate remains active, the runtime prepends a workflow-active banner
+to architect text parts (the model's text is preserved below the banner) and
+re-wakes an idle parent session. A
 user interruption pauses every automatic wake path until a later explicit user
 turn settles; the durable gate remains available to continue or abort. Only
 emit the final report after the completion tool confirms that the gate cleared.

--- a/docs/releases/pending/pr-review-gate-banner-prefix.md
+++ b/docs/releases/pending/pr-review-gate-banner-prefix.md
@@ -1,0 +1,47 @@
+# PR-workflow response gate: banner prefix instead of text replacement
+
+## What
+
+The `experimental.text.complete` hook (`src/hooks/pr-workflow-response-gate.ts`)
+previously **replaced** every architect text part with a "FINAL RESPONSE
+BLOCKED" notice while a durable PR-workflow gate was active. This erased all
+intermediate reasoning, making `/swarm pr-review` and `/swarm pr-feedback`
+nearly unusable: every thought, status update, and planning note was
+overwritten with the block message, and the auto-wake loop amplified the
+effect by re-prompting on every idle boundary.
+
+The hook now **prepends** a compact workflow-active banner and preserves the
+model's original text below it:
+
+```
+--- [PR_REVIEW WORKFLOW ACTIVE — output below is not a terminal verdict;
+     only `complete_pr_workflow` clears the gate; if the bind/checkout path
+     is unreachable call `abort_pr_workflow` or run `/swarm abort-pr-workflow`] ---
+
+Let me fetch the PR head and verify the merge base...
+```
+
+The model's reasoning is visible to the user, but the banner makes clear the
+output is not a terminal verdict. Recovery notices for suspended/interrupted
+states remain always-visible in the banner. Security is unchanged:
+`complete_pr_workflow` remains the sole clearing path; the banner is a
+visible signal, not a security boundary.
+
+## Why
+
+The text gate was a redundant secondary defense — the real gate is
+tool-gated (`completePrWorkflow`/`abortPrWorkflow`), not text-gated.
+Unconditional replacement destroyed the model's ability to communicate
+progress, causing the "constant firing" symptom reported by users.
+
+## Migration
+
+No breaking changes:
+- The gate state lifecycle, tool interception, and auto-wake loop logic are
+  unchanged.
+- The auto-wake continuation prompt (`blockedText`, used only in the
+  `session.idle` → `promptAsync` path) was updated to say "The workflow
+  gate is still active. Continue with…" instead of the false claim "The
+  replaced text is not a valid review."
+- Existing tests were updated to assert the banner + preserved-text
+  coexistence rather than text replacement.

--- a/docs/releases/pending/pr-review-gate-banner-prefix.md
+++ b/docs/releases/pending/pr-review-gate-banner-prefix.md
@@ -24,8 +24,9 @@ Let me fetch the PR head and verify the merge base...
 The model's reasoning is visible to the user, but the banner makes clear the
 output is not a terminal verdict. Recovery notices for suspended/interrupted
 states remain always-visible in the banner. Security is unchanged:
-`complete_pr_workflow` remains the sole clearing path; the banner is a
-visible signal, not a security boundary.
+`complete_pr_workflow` is the publication clearing path, while
+`abort_pr_workflow` can clear an unarmed workflow after its safety checks
+pass; the banner is a visible signal, not a security boundary.
 
 ## Why
 

--- a/docs/releases/pending/pr-review-gate-deadlock-abort.md
+++ b/docs/releases/pending/pr-review-gate-deadlock-abort.md
@@ -8,8 +8,8 @@ Closes an unrecoverable deadlock in the PR-workflow mechanical gates
 trapped in an unbounded auto-resume loop with no tool path to clear the gate
 — for example when a compound `git fetch … && git checkout …` was repeatedly
 rejected as read-only shell syntax and the working tree never reached the PR
-head. Every turn ended with `[PR_REVIEW MECHANICAL GATE: FINAL RESPONSE
-BLOCKED]` and `session.idle` mechanically re-awoke the session indefinitely.
+head. Every turn ended with the gate replacing the architect's text and
+`session.idle` mechanically re-awoke the session indefinitely.
 
 Two compounding faults are fixed:
 
@@ -30,13 +30,14 @@ Two compounding faults are fixed:
    replaces it with a progress-aware wake budget: the consecutive-unproductive
    counter resets whenever the durable gate's `revision` advances (so healthy
    long reviews never exhaust it) and suspends further auto-resumes after a
-   small number of consecutive unproductive wakes. `textComplete` keeps
-   rewriting text after suspension so the user-visible surface always names
-   the recovery path.
+   small number of consecutive unproductive wakes. `textComplete` prepends a
+   workflow-active banner to the architect's text (preserving the model's
+   reasoning below it) so the user-visible surface always names the recovery
+   path.
 
-The block text now names `abort_pr_workflow` and `/swarm abort-pr-workflow`
+The banner text now names `abort_pr_workflow` and `/swarm abort-pr-workflow`
 and the triggering conditions, so a trapped model (and the user) see the exit
-on every turn. When the budget suspends, the block text carries an operational
+on every turn. When the budget suspends, the banner carries an operational
 notice naming the recovery command.
 
 Authorization and defense-in-depth:

--- a/src/hooks/pr-workflow-response-gate.ts
+++ b/src/hooks/pr-workflow-response-gate.ts
@@ -72,10 +72,12 @@ interface WakeBudget {
 }
 
 /**
- * Compose the user-visible block text. Naming the abort path is the
- * load-bearing prompt-surface change: a trapped model reads this text every
- * turn, and without an explicit exit it will keep retrying the same blocked
- * tools forever (the deadlock). When `suspended` is true, the operational
+ * Compose the auto-wake continuation prompt text. This is sent to the model
+ * as a user-role message on session.idle — NOT as a replacement of the
+ * model's own text. It tells the model the gate is still active and names
+ * the recovery paths. Naming the abort path is load-bearing: a trapped model
+ * reads this every wake, and without an explicit exit it will keep retrying
+ * the same blocked tools forever. When `suspended` is true, the operational
  * notice (invariant 10 — always visible, not debug-gated) tells the user
  * the session will not auto-resume and how to recover.
  */
@@ -88,9 +90,9 @@ function blockedText(
 	} = {},
 ): string {
 	const lines: string[] = [
-		`[${mode} MECHANICAL GATE: FINAL RESPONSE BLOCKED]`,
-		'This workflow still has an active durable gate. The replaced text is not a valid review, closure ledger, or completion verdict.',
-		`Continue with the required structured lanes and evidence. If the bind/checkout path is unreachable — for example a compound \`git fetch && git checkout\` was rejected as read-only shell syntax, the PR head cannot be fetched, or the working tree is on the wrong branch — call \`abort_pr_workflow\` (mode: "${mode}", reason: "<one-line cause>") to clear the gate, or ask the user to run \`/swarm abort-pr-workflow\`. Only \`complete_pr_workflow\` clears the gate on terminal success.`,
+		`[${mode} WORKFLOW ACTIVE]`,
+		`The ${mode} workflow gate is still active. Continue with the required structured lanes, evidence, and controller tools until \`complete_pr_workflow\` succeeds.`,
+		`If the bind/checkout path is unreachable — for example a compound \`git fetch && git checkout\` was rejected as read-only shell syntax, the PR head cannot be fetched, or the working tree is on the wrong branch — call \`abort_pr_workflow\` (mode: "${mode}", reason: "<one-line cause>") to clear the gate, or ask the user to run \`/swarm abort-pr-workflow\`.`,
 	];
 	if (options.suspended) {
 		const max = options.maxConsecutive;
@@ -100,21 +102,59 @@ function blockedText(
 	}
 	if (options.userInterrupted) {
 		lines.push(
-			'Auto-resume is paused after a user interruption. The durable workflow gate is preserved, but the plugin will not re-awaken this session. Send a new user message to continue, or run `/swarm abort-pr-workflow` to clear the workflow.',
+			'Auto-resume is paused after a user interruption. The durable workflow gate is preserved, but the plugin will not re-awaken this session. Send a new message to continue, or run `/swarm abort-pr-workflow` to clear the workflow.',
 		);
 	}
 	return lines.join('\n');
 }
 
 /**
- * Prevent an architect from bypassing PR obligations by simply emitting text.
- * The text-complete hook replaces every architect-session text part while the
- * durable gate exists; session.idle then mechanically resumes that session.
+ * Compose a compact workflow-active banner prepended to architect text parts.
+ * Unlike {@link blockedText} (used for auto-wake continuation prompts), this
+ * banner does NOT replace the model's text — it is prepended so the user can
+ * see the architect's reasoning and progress while being clearly informed
+ * that the output is not a terminal verdict.
+ *
+ * Recovery instructions for suspended/interrupted states are always present
+ * in the banner so they remain visible on every text part regardless of
+ * content.
+ */
+function workflowBanner(
+	mode: string,
+	options: {
+		suspended?: boolean;
+		userInterrupted?: boolean;
+		maxConsecutive?: number;
+	} = {},
+): string {
+	const lines: string[] = [
+		`--- [${mode} WORKFLOW ACTIVE — output below is not a terminal verdict; only \`complete_pr_workflow\` clears the gate; if the bind/checkout path is unreachable call \`abort_pr_workflow\` or run \`/swarm abort-pr-workflow\`] ---`,
+	];
+	if (options.suspended) {
+		const max = options.maxConsecutive;
+		lines.push(
+			`[Auto-resume is suspended after ${max ?? 'the configured number of'} consecutive unproductive retries. Run \`/swarm abort-pr-workflow\` or call \`abort_pr_workflow\` to clear the gate, or complete the workflow with \`complete_pr_workflow\`.]`,
+		);
+	}
+	if (options.userInterrupted) {
+		lines.push(
+			'[Auto-resume paused after a user interruption. Send a new message to continue, or run `/swarm abort-pr-workflow` to clear the workflow.]',
+		);
+	}
+	return lines.join(' ');
+}
+
+/**
+ * Prevent an architect from masquerading a premature text output as a terminal
+ * verdict. The text-complete hook prepends a workflow-active banner to every
+ * architect-session text part while the durable gate exists; the model's
+ * original text is preserved below the banner. session.idle then mechanically
+ * resumes that session.
  *
  * The resume loop is bounded (see DEFAULT_MAX_CONSECUTIVE_UNPRODUCTIVE_WAKES)
  * so a session that cannot make progress suspends instead of spinning
- * forever. `textComplete` keeps rewriting text after suspension so the
- * user-visible surface always names the recovery path.
+ * forever. The banner always carries suspension/interruption recovery notices
+ * so the user-visible surface always names the recovery path.
  */
 export function createPrWorkflowResponseGate(options: {
 	directory: string;
@@ -167,7 +207,11 @@ export function createPrWorkflowResponseGate(options: {
 			return;
 		}
 		const budget = wakeBudgets.get(input.sessionID);
-		output.text = blockedText(state.mode, {
+		// Prepend a workflow-active banner to the model's text. The original
+		// text is preserved so the user can see the architect's reasoning and
+		// progress. The banner makes clear that this output is not a terminal
+		// verdict — only complete_pr_workflow clears the gate.
+		const banner = workflowBanner(state.mode, {
 			suspended: budget?.suspended ?? false,
 			userInterrupted: isPrWorkflowAutoWakeSuppressed(
 				options.directory,
@@ -175,6 +219,7 @@ export function createPrWorkflowResponseGate(options: {
 			),
 			maxConsecutive: maxConsecutive,
 		});
+		output.text = `${banner}\n\n${output.text}`;
 	};
 
 	const event = async (input: { event: unknown }): Promise<void> => {

--- a/src/hooks/pr-workflow-response-gate.ts
+++ b/src/hooks/pr-workflow-response-gate.ts
@@ -128,7 +128,7 @@ function workflowBanner(
 	} = {},
 ): string {
 	const lines: string[] = [
-		`--- [${mode} WORKFLOW ACTIVE — output below is not a terminal verdict; only \`complete_pr_workflow\` clears the gate; if the bind/checkout path is unreachable call \`abort_pr_workflow\` or run \`/swarm abort-pr-workflow\`] ---`,
+		`--- [${mode} WORKFLOW ACTIVE — output below is not a terminal verdict; \`complete_pr_workflow\` clears the gate on success; if the bind/checkout path is unreachable call \`abort_pr_workflow\` or run \`/swarm abort-pr-workflow\`] ---`,
 	];
 	if (options.suspended) {
 		const max = options.maxConsecutive;
@@ -210,7 +210,8 @@ export function createPrWorkflowResponseGate(options: {
 		// Prepend a workflow-active banner to the model's text. The original
 		// text is preserved so the user can see the architect's reasoning and
 		// progress. The banner makes clear that this output is not a terminal
-		// verdict — only complete_pr_workflow clears the gate.
+		// verdict — complete_pr_workflow clears the gate on success;
+		// abort_pr_workflow can clear an unarmed workflow.
 		const banner = workflowBanner(state.mode, {
 			suspended: budget?.suspended ?? false,
 			userInterrupted: isPrWorkflowAutoWakeSuppressed(

--- a/src/index.ts
+++ b/src/index.ts
@@ -2185,9 +2185,10 @@ async function initializeOpenCodeSwarm(
 			// biome-ignore lint/suspicious/noExplicitAny: Plugin API requires generic hook wrappers
 		) as any,
 
-		// Correctness boundary: while a durable PR workflow gate exists, no
-		// architect text can masquerade as a terminal verdict or closure response.
-		// Raw-await this hook so gate-state read failures block text completion.
+		// Correctness boundary: while a durable PR workflow gate exists, architect
+		// text is prepended with a workflow-active banner so it cannot masquerade
+		// as a terminal verdict or closure response. Raw-await this hook so
+		// gate-state read failures block text completion.
 		'experimental.text.complete': prWorkflowResponseGate.textComplete,
 
 		// Inject system prompt enhancements + phase monitor (when phase_preflight or knowledge enabled)

--- a/tests/unit/hooks/pr-workflow-response-gate.test.ts
+++ b/tests/unit/hooks/pr-workflow-response-gate.test.ts
@@ -4,6 +4,10 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+	_test_exports as autoWakeInternals,
+	isPrWorkflowAutoWakeSuppressed,
+} from '../../../src/hooks/pr-workflow-auto-wake.js';
+import {
 	activatePrWorkflow,
 	clearPrWorkflowGateState,
 	type PrWorkflowGateState,
@@ -18,10 +22,12 @@ beforeEach(() => {
 		mkdtempSync(path.join(os.tmpdir(), 'pr-response-gate-')),
 	);
 	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
 });
 
 afterEach(async () => {
 	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
 	await fs.rm(directory, { recursive: true, force: true });
 });
 
@@ -58,6 +64,10 @@ describe('PR workflow response-level gate', () => {
 		expect(blocked.text).toContain('WORKFLOW ACTIVE');
 		// The model's original text is preserved below the banner, not erased.
 		expect(blocked.text).toContain('Looks good');
+		// Banner appears BEFORE the model's text (F-004: ordering guard).
+		const bannerIdx = blocked.text.indexOf('WORKFLOW ACTIVE');
+		const textIdx = blocked.text.indexOf('Looks good');
+		expect(bannerIdx).toBeLessThan(textIdx);
 
 		await clearPrWorkflowGateState(directory, 'review-session');
 		const completed = { text: 'Verified completion.' };
@@ -95,6 +105,52 @@ describe('PR workflow response-level gate', () => {
 		const output = { text: '' };
 		await gate.textComplete({ sessionID: 'empty-text-session' }, output);
 		expect(output.text).toContain('WORKFLOW ACTIVE');
+	});
+
+	test('banner carries both suspension and interruption notices when both are active (F-003)', async () => {
+		// Drive the wake budget to suspension (max=1 for quick exhaustion),
+		// then trigger a MessageAbortedError to set the interruption pause.
+		// textComplete must produce a banner containing BOTH recovery notices.
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 1,
+			wakeCooldownMs: 0,
+		});
+		await writeStateWithRevision('combined-session', 0);
+		const idle = {
+			event: {
+				type: 'session.idle',
+				properties: { sessionID: 'combined-session' },
+			},
+		};
+		// Wake 1 (probe), wake 2 (unproductive → suspend at max=1).
+		await gate.event(idle);
+		await gate.event(idle);
+		expect(gate._inspectWakeBudget('combined-session')?.suspended).toBe(true);
+
+		// Now trigger a user interruption.
+		await gate.event({
+			event: {
+				type: 'session.error',
+				properties: {
+					sessionID: 'combined-session',
+					error: { name: 'MessageAbortedError', data: { message: 'aborted' } },
+				},
+			},
+		});
+		expect(isPrWorkflowAutoWakeSuppressed(directory, 'combined-session')).toBe(
+			true,
+		);
+
+		// textComplete must show BOTH the suspension notice and the interruption notice.
+		const output = { text: 'still working' };
+		await gate.textComplete({ sessionID: 'combined-session' }, output);
+		expect(output.text).toContain('Auto-resume is suspended');
+		expect(output.text).toContain('user interruption');
+		// Model text preserved below both notices.
+		expect(output.text).toContain('still working');
 	});
 
 	test('session idle mechanically resumes an active workflow', async () => {

--- a/tests/unit/hooks/pr-workflow-response-gate.test.ts
+++ b/tests/unit/hooks/pr-workflow-response-gate.test.ts
@@ -46,7 +46,7 @@ async function writeStateWithRevision(
 }
 
 describe('PR workflow response-level gate', () => {
-	test('replaces architect text until complete_pr_workflow clears durable state', async () => {
+	test('prepends workflow banner to architect text until complete_pr_workflow clears durable state', async () => {
 		const promptAsync = mock(async () => ({}));
 		const gate = createPrWorkflowResponseGate({
 			directory,
@@ -55,13 +55,46 @@ describe('PR workflow response-level gate', () => {
 		await activatePrWorkflow(directory, 'review-session', 'PR_REVIEW');
 		const blocked = { text: 'Looks good. APPROVE.' };
 		await gate.textComplete({ sessionID: 'review-session' }, blocked);
-		expect(blocked.text).toContain('FINAL RESPONSE BLOCKED');
-		expect(blocked.text).not.toContain('Looks good');
+		expect(blocked.text).toContain('WORKFLOW ACTIVE');
+		// The model's original text is preserved below the banner, not erased.
+		expect(blocked.text).toContain('Looks good');
 
 		await clearPrWorkflowGateState(directory, 'review-session');
 		const completed = { text: 'Verified completion.' };
 		await gate.textComplete({ sessionID: 'review-session' }, completed);
 		expect(completed.text).toBe('Verified completion.');
+	});
+
+	test('preserves intermediate reasoning text below the workflow banner', async () => {
+		const gate = createPrWorkflowResponseGate({ directory });
+		await activatePrWorkflow(directory, 'working-session', 'PR_REVIEW');
+		const output = {
+			text: 'Let me fetch the PR head and verify the merge base before dispatching lanes.',
+		};
+		await gate.textComplete({ sessionID: 'working-session' }, output);
+		// Banner present at the top.
+		expect(output.text).toContain('WORKFLOW ACTIVE');
+		expect(output.text).toContain('not a terminal verdict');
+		// The model's full reasoning text survives below the banner.
+		expect(output.text).toContain('Let me fetch the PR head');
+		expect(output.text).toContain('verify the merge base');
+	});
+
+	test('banner is mode-aware for PR_FEEDBACK as well as PR_REVIEW', async () => {
+		const gate = createPrWorkflowResponseGate({ directory });
+		await activatePrWorkflow(directory, 'feedback-mode-session', 'PR_FEEDBACK');
+		const output = { text: 'Stage A checks passing.' };
+		await gate.textComplete({ sessionID: 'feedback-mode-session' }, output);
+		expect(output.text).toContain('PR_FEEDBACK WORKFLOW ACTIVE');
+		expect(output.text).toContain('Stage A checks passing.');
+	});
+
+	test('banner appears even on empty text', async () => {
+		const gate = createPrWorkflowResponseGate({ directory });
+		await activatePrWorkflow(directory, 'empty-text-session', 'PR_REVIEW');
+		const output = { text: '' };
+		await gate.textComplete({ sessionID: 'empty-text-session' }, output);
+		expect(output.text).toContain('WORKFLOW ACTIVE');
 	});
 
 	test('session idle mechanically resumes an active workflow', async () => {
@@ -104,7 +137,7 @@ describe('PR workflow response-level gate', () => {
 		expect(promptAsync).not.toHaveBeenCalled();
 	});
 
-	test('keeps text enforcement but skips resume when the host has no session API', async () => {
+	test('prepends workflow banner but skips resume when the host has no session API', async () => {
 		const gate = createPrWorkflowResponseGate({ directory });
 		await activatePrWorkflow(directory, 'limited-host-session', 'PR_REVIEW');
 		const output = { text: 'ordinary response' };
@@ -115,7 +148,9 @@ describe('PR workflow response-level gate', () => {
 				properties: { sessionID: 'limited-host-session' },
 			},
 		});
-		expect(output.text).toContain('FINAL RESPONSE BLOCKED');
+		expect(output.text).toContain('WORKFLOW ACTIVE');
+		// Original text preserved below banner.
+		expect(output.text).toContain('ordinary response');
 	});
 });
 
@@ -159,12 +194,14 @@ describe('PR workflow response-gate wake budget', () => {
 		await gate.event(idleEvent);
 		expect(promptAsync).toHaveBeenCalledTimes(3);
 
-		// textComplete still rewrites text so the user-visible surface is
-		// preserved and now carries the suspend notice.
+		// textComplete still prepends the banner so the user-visible surface
+		// is preserved and now carries the suspend notice.
 		const output = { text: 'x' };
 		await gate.textComplete({ sessionID: 'stuck-session' }, output);
 		expect(output.text).toContain('Auto-resume is suspended');
 		expect(output.text).toContain('/swarm abort-pr-workflow');
+		// The model's text is preserved below the banner even when suspended.
+		expect(output.text).toContain('x');
 	});
 
 	test('resets the consecutive counter when state.revision advances (progress)', async () => {
@@ -236,7 +273,7 @@ describe('PR workflow response-gate wake budget', () => {
 		// starts fresh, not stuck in the old suspended state.
 		expect(gate._inspectWakeBudget('cleared-session')).toBeUndefined();
 
-		// And textComplete stops rewriting once the gate is gone.
+		// And textComplete stops prepending the banner once the gate is gone.
 		const output = { text: 'final real text' };
 		await gate.textComplete({ sessionID: 'cleared-session' }, output);
 		expect(output.text).toBe('final real text');


### PR DESCRIPTION
## Summary

The `experimental.text.complete` hook (`src/hooks/pr-workflow-response-gate.ts`) unconditionally **replaced** every architect text part with a `FINAL RESPONSE BLOCKED` notice while a durable PR-workflow gate was active. This erased all intermediate reasoning, making `/swarm pr-review` and `/swarm pr-feedback` nearly unusable: every thought, status update, and planning note was overwritten with the block message, and the auto-wake loop amplified the effect by re-prompting on every idle boundary.

The hook now **prepends** a compact workflow-active banner and preserves the model's original text below it:

```
--- [PR_REVIEW WORKFLOW ACTIVE — output below is not a terminal verdict;
     only `complete_pr_workflow` clears the gate; if the bind/checkout path
     is unreachable call `abort_pr_workflow` or run `/swarm abort-pr-workflow`] ---

Let me fetch the PR head and verify the merge base...
```

The model's reasoning is visible to the user, but the banner makes clear the output is not a terminal verdict. Security is unchanged: `complete_pr_workflow` remains the sole clearing path; the banner is a visible signal, not a security boundary.

### Why banner, not content filtering

An independent Kimi K3 plan critic reviewed a content-classifier approach and identified six issues (PR_FEEDBACK mode unwired, recovery notices lost, patterns too aggressive/bypassable, false "replaced text" claim in auto-wake prompts, content cannot determine terminality at the per-part hook boundary). The banner approach resolves all six: it's content-independent, mode-aware, preserves recovery notices, and is simpler.

## Invariant audit

- 1 (plugin init): not touched — no init-path code changed
- 2 (runtime portability): not touched — no `bun:` imports, no entry shape change; `bun run build` passes
- 3 (subprocesses): not touched — no spawn changes
- 4 (.swarm containment): not touched — no tool/hook writes to `.swarm/`
- 5 (plan durability): not touched — no ledger/projection changes
- 6 (test_runner safety): not touched — used shell `bun --smol test` per-file, not `test_runner`
- 7 (test writing): touched — updated `tests/unit/hooks/pr-workflow-response-gate.test.ts` with bun:test; 3 new tests + 2 updated; no `mock.module` added; `_internals` seams unchanged; `os.tmpdir()` + `path.join()` used
- 8 (session state): not touched — wake budget map unchanged
- 9 (guardrails/retry): not touched — no retry/circuit-breaker logic changed
- 10 (chat/system msg): touched — `experimental.text.complete` hook behavior changed from text replacement to banner prepend; verified: `bunx tsc --noEmit` clean, 52 tests pass across 4 affected test files, `bun run drift:check` clean
- 11 (tool registration): not touched — no tools added/removed
- 12 (release/cache): touched — release fragment `docs/releases/pending/pr-review-gate-banner-prefix.md` added; existing pending fragment `pr-review-gate-deadlock-abort.md` updated to remove stale `MECHANICAL GATE: FINAL RESPONSE BLOCKED` references; no version files hand-edited

## Test plan

```bash
# Typecheck
$ bunx tsc --noEmit
(clean — no output)

# Lint
$ bunx biome check src/hooks/pr-workflow-response-gate.ts src/index.ts tests/unit/hooks/pr-workflow-response-gate.test.ts
Checked 3 files in 50ms. No fixes applied.

# Affected tests
$ bun --smol test tests/unit/hooks/pr-workflow-response-gate.test.ts tests/unit/hooks/pr-workflow-response-gate-cancellation.test.ts tests/unit/hooks/hook-composition.test.ts tests/unit/hooks/pr-workflow-auto-wake-regressions.test.ts
52 pass, 0 fail, 126 expect() calls

# Full PR workflow hook suite (16 files)
$ for f in tests/unit/hooks/pr-workflow-*.test.ts; do bun --smol test "$f"; done
116 pass, 0 fail

# Build
$ bun run build
(success)

# Drift check
$ bun run drift:check
✅ No drift detected

# Stale reference scan
$ grep -rn "FINAL RESPONSE BLOCKED\|MECHANICAL GATE: FINAL" src/ tests/ docs/ .agents/ .claude/ .opencode/
(no results — all stale references eliminated)
```

### Review chain

- **Plan critic (Kimi K3):** original content-classifier approach rejected → revised to banner approach → all 6 concerns addressed
- **Implementation reviewer (Kimi K2.7):** APPROVE — no critical/important defects
- **Final critic (Kimi K3):** found 2 doc drift issues (stale release note + skill docs) → both fixed → APPROVED
