### PR TITLE
fix(pr-workflow): add per-tier micro-lane consolidation floor

### DIFF
--- a/docs/releases/pending/1936-pr-review-micro-lane-floor.md
+++ b/docs/releases/pending/1936-pr-review-micro-lane-floor.md
@@ -1,0 +1,48 @@
+# PR review: per-tier lane-count floor for micro (risk-family) consolidation
+
+## What changed
+
+- Micro (risk-family) discovery lanes now have a per-tier minimum lane-count
+  floor, closing the asymmetry left when depth-tiered dispatch consolidation was
+  introduced: base dimensions were floored (`PR_REVIEW_BASE_LANE_FLOORS`) but
+  micro sweeps could consolidate all eleven risk families into a single lane at
+  tiers S and M with no minimum enforcement.
+- New `PR_REVIEW_MICRO_LANE_FLOORS` (`src/hooks/pr-workflow-gate.ts`):
+  **S = 1, M = 6, L = 11** (the risk-family count). The numbers mirror the base
+  floors' tier *semantics* rather than their values — S does not bind (a small
+  PR may consolidate a full sweep), M requires at least half the eleven families
+  to get independent lanes (`ceil(11/2) = 6`, the deliberate scale-up from base
+  M's `3 = ceil(6/2)`), and L requires one lane per family.
+- The floor is enforced at two sites, both keyed on the controller-computed
+  depth tier:
+  - **Dispatch** (`validatePrReviewMicroDispatch`): a micro batch whose lanes
+    collectively own all eleven families ("a full sweep") must meet the tier
+    floor. Partial retry batches that cover a subset of families are exempt, so
+    re-dispatching a single failed family never deadlocks.
+  - **Attestation** (`write_pr_review_trigger_eval`): the previously write-only
+    `dispatched_micro_lane_count` is now a gate — the durable ledger's distinct
+    dispatch-lane count for the eleven families must meet the tier floor. This
+    catches split-batch consolidations that slip past the per-batch dispatch
+    check, since the final attestation's distinct-lane count must meet the floor
+    regardless of dispatch history.
+- All eleven risk families remain mandatory to evaluate on every PR; every
+  family still needs its own attested `[CANDIDATE]`/`[CLEAN]` row, and the
+  distinct-evidence anti-templating check is unchanged. The floor bounds *how
+  far one lane may consolidate*, not *which families are reviewed*.
+
+## Why
+
+Without a micro-lane floor, a single subagent could nominally "cover" all eleven
+risk families at tiers S/M with far less independent scrutiny than the
+base-dimension floors were designed to require, and the persisted
+`dispatched_micro_lane_count` recorded that consolidation degree without ever
+enforcing on it. The base floors already bound base-dimension consolidation; this
+restores the same guarantee for the risk-family sweep.
+
+## Migration and compatibility
+
+Additive and backward compatible. Singleton micro dispatch (one lane per family,
+eleven lanes) validates unchanged at every tier — eleven meets every floor. Only
+degenerate full-sweep consolidations below a tier's floor at S/M are newly
+rejected. No tool schema, tool-registration, or persisted gate-state field
+changes.

--- a/docs/releases/pending/pr-skills-harness-portability.md
+++ b/docs/releases/pending/pr-skills-harness-portability.md
@@ -24,10 +24,12 @@
   (`resolvePrReviewDiffStats`; any failure fails strict to tier L) and
   persists the tier plus audit totals in the gate state. Base and micro
   discovery lanes accept a new optional `owned_workflow_lanes` field: at
-  tiers S and M one lane may own several review dimensions or risk families
-  (S: base wave ≥ 1 lane; M: ≥ 3; micro sweeps consolidated), while tier L
-  preserves the historical exact-six singleton wave and one micro-lane per
-  family byte-for-byte. All six dimensions and all eleven risk families
+  tiers S and M one lane may own several review dimensions or risk families,
+  with a per-tier lane-count floor bounding how far a full sweep may
+  consolidate (base lanes: S ≥ 1, M ≥ 3; micro lanes: S ≥ 1, M ≥ 6 for a
+  full sweep — see the micro-lane floor note), while tier L preserves the
+  historical exact-six singleton wave and one micro-lane per family
+  byte-for-byte. All six dimensions and all eleven risk families
   remain mandatory to EVALUATE on every PR: ownership sets must partition
   the required sets exactly, every owned family needs its own
   `[CANDIDATE]`/`[CLEAN]` attestation, and a consolidated lane that fails

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -79,6 +79,24 @@ export const PR_REVIEW_BASE_LANE_FLOORS: Record<PrReviewDepthTier, number> = {
 };
 
 /**
+ * Minimum lane counts for a FULL micro (risk-family) sweep per depth tier. These
+ * mirror the base floors' tier *semantics* — not their numbers — scaled to the
+ * eleven risk families: S does not bind (a tier-S PR of ≤50 lines/≤3 files may
+ * consolidate a full sweep into one lane, exactly as base tier S permits); M
+ * requires at least half the families to get independent lanes (ceil(11/2) = 6,
+ * the deliberate scale-up from base M's 3 = ceil(6/2)); L requires one lane per
+ * family (the family count, matching base L = dimension count). The floor binds
+ * only on a batch (or the final attestation) that covers all eleven families;
+ * partial retry batches covering a subset are exempt, and callers may always
+ * dispatch more lanes than a tier's floor, never fewer.
+ */
+export const PR_REVIEW_MICRO_LANE_FLOORS: Record<PrReviewDepthTier, number> = {
+	S: 1,
+	M: 6,
+	L: PR_REVIEW_REQUIRED_MICRO_LANE_IDS.length,
+};
+
+/**
  * Unknown or uncomputable diff size fails strict to the deepest tier, as does
  * any range containing a submodule pointer change: git's numstat reports a
  * gitlink bump as a fixed 1-added/1-deleted row regardless of the referenced

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -31,6 +31,7 @@ import {
 	enforcePrWorkflowDispatchLanesAsync,
 	PR_REVIEW_BASE_DIMENSION_IDS,
 	PR_REVIEW_BASE_LANE_FLOORS,
+	PR_REVIEW_MICRO_LANE_FLOORS,
 	PR_REVIEW_REQUIRED_MICRO_LANE_IDS,
 	type PrReviewDepthTier,
 	recordPrFeedbackGateBatch,
@@ -412,6 +413,21 @@ function validatePrReviewMicroDispatch(
 			].join(', ')}`,
 		);
 	}
+	// Per-tier consolidation floor for a FULL micro sweep. Only a batch whose
+	// lanes collectively own all eleven risk families is floored — this mirrors
+	// the base floor, which binds only the wave that covers every dimension.
+	// Partial retry batches (a subset of families) are exempt so re-dispatching a
+	// failed family never deadlocks; the aggregate floor on the final attestation
+	// (write_pr_review_trigger_eval) catches any split-consolidation that dodges
+	// this per-batch check.
+	const coversAllFamilies =
+		required.size > 0 && [...required].every((id) => flattened.includes(id));
+	const microFloor = PR_REVIEW_MICRO_LANE_FLOORS[depthTier];
+	if (coversAllFamilies && laneOwnership.length < microFloor) {
+		throw new Error(
+			`BLOCKED: PR_REVIEW micro dispatch at depth tier ${depthTier} covering all ${PR_REVIEW_REQUIRED_MICRO_LANE_IDS.length} risk families requires at least ${microFloor} lanes; received ${laneOwnership.length}. Partial retry batches covering a subset of families are exempt.`,
+		);
+	}
 }
 export type DispatchLanesArgs = z.infer<typeof DispatchLanesArgsSchema>;
 export type DispatchLanesAsyncArgs = z.infer<
@@ -567,6 +583,7 @@ export const _internals: {
 };
 
 export const _test_exports = {
+	validatePrReviewMicroDispatch,
 	applyCommonPrompt,
 	applyExplorerFormatSuffix,
 	applyPrWorkflowPromptContract,

--- a/src/tools/write-pr-review-trigger-eval.ts
+++ b/src/tools/write-pr-review-trigger-eval.ts
@@ -11,6 +11,7 @@ import {
 import {
 	assertPrReviewBaseCoverageSettled,
 	markPrReviewTriggerEvaluationComplete,
+	PR_REVIEW_MICRO_LANE_FLOORS,
 	PR_REVIEW_REQUIRED_MICRO_LANE_IDS,
 	prReviewDiscoveryArtifactCoversLane,
 	readPrWorkflowGateState,
@@ -384,6 +385,23 @@ export async function executeWritePrReviewTriggerEval(
 			(row) => `${row.source_batch_id}\0${row.source_lane_id}`,
 		),
 	).size;
+	// Aggregate per-tier micro-lane floor on the durable attestation. The final
+	// ledger attributes all eleven families to some number of distinct dispatch
+	// lanes; that count must meet the tier floor regardless of dispatch history.
+	// Normal one-for-one lane retries preserve the count, so legitimate flows are
+	// never rejected; only a final attestation that under-consolidates the eleven
+	// families into fewer than the floor's worth of independent lanes is blocked —
+	// which is exactly the gap this gate closes (including split-batch dodges that
+	// slip past the per-batch dispatch floor).
+	const microFloor =
+		PR_REVIEW_MICRO_LANE_FLOORS[gateState.prReviewDepthTier ?? 'L'];
+	if (dispatchedMicroLaneCount < microFloor) {
+		return failure(
+			`PR_REVIEW micro lane floor unmet: depth tier ${
+				gateState.prReviewDepthTier ?? 'L'
+			} requires at least ${microFloor} dispatched micro lane(s) across the attestation; the ledger attributes all ${PR_REVIEW_REQUIRED_MICRO_LANE_IDS.length} families to only ${dispatchedMicroLaneCount}`,
+		);
+	}
 	const artifact = {
 		schema_version: 1,
 		run_id: parsed.data.run_id,

--- a/tests/unit/tools/dispatch-lanes-micro-lane-floor.test.ts
+++ b/tests/unit/tools/dispatch-lanes-micro-lane-floor.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'bun:test';
+import { PR_REVIEW_REQUIRED_MICRO_LANE_IDS } from '../../../src/hooks/pr-workflow-gate.js';
+import { _test_exports as dispatchTestExports } from '../../../src/tools/dispatch-lanes.js';
+
+// Issue #1936: per-tier lane-count floor for a FULL micro (risk-family) sweep.
+// The floor mirrors the base-dimension floor's tier *semantics* scaled to the
+// eleven risk families — S does not bind (floor 1), M requires >= ceil(11/2) = 6
+// lanes, L requires one lane per family (11). It binds ONLY on a batch whose
+// lanes collectively own all eleven families; partial retry batches (a subset)
+// are exempt so re-dispatching a failed family never deadlocks.
+
+const { validatePrReviewMicroDispatch } = dispatchTestExports as unknown as {
+	validatePrReviewMicroDispatch: (
+		args: {
+			trigger_evaluation?: Array<{
+				trigger_id: string;
+				result: 'MATCHED';
+				evidence: string;
+			}>;
+			lanes: Array<{ workflow_lane: string; owned_workflow_lanes?: string[] }>;
+		},
+		depthTier: 'S' | 'M' | 'L',
+	) => void;
+};
+
+const FAMILIES = PR_REVIEW_REQUIRED_MICRO_LANE_IDS;
+
+function fullEvaluation() {
+	return FAMILIES.map((id) => ({
+		trigger_id: id,
+		result: 'MATCHED' as const,
+		evidence: `mandatory review focus for ${id}`,
+	}));
+}
+
+/** A single lane owning every family (the degenerate full-consolidation shape). */
+function oneLaneOwningAll() {
+	return [{ workflow_lane: FAMILIES[0], owned_workflow_lanes: [...FAMILIES] }];
+}
+
+/** Partition the eleven families into `laneCount` full-coverage lanes. */
+function fullSweepLanes(laneCount: number) {
+	const buckets: string[][] = Array.from({ length: laneCount }, () => []);
+	FAMILIES.forEach((id, index) => {
+		buckets[index % laneCount].push(id);
+	});
+	return buckets.map((owned) => ({
+		workflow_lane: owned[0],
+		owned_workflow_lanes: owned,
+	}));
+}
+
+/** One singleton lane per family (the canonical tier-L full sweep). */
+function elevenSingletonLanes() {
+	return FAMILIES.map((id) => ({
+		workflow_lane: id,
+		owned_workflow_lanes: [id],
+	}));
+}
+
+describe('validatePrReviewMicroDispatch — per-tier full-sweep floor (issue #1936)', () => {
+	test('tier M: a full sweep consolidated into one lane is BLOCKED below the floor', () => {
+		expect(() =>
+			validatePrReviewMicroDispatch(
+				{ trigger_evaluation: fullEvaluation(), lanes: oneLaneOwningAll() },
+				'M',
+			),
+		).toThrow(/at least 6 lanes/);
+	});
+
+	test('tier M: a full sweep consolidated into two lanes is BLOCKED below the floor', () => {
+		const sweepA = FAMILIES.slice(0, 6);
+		const sweepB = FAMILIES.slice(6);
+		expect(() =>
+			validatePrReviewMicroDispatch(
+				{
+					trigger_evaluation: fullEvaluation(),
+					lanes: [
+						{ workflow_lane: sweepA[0], owned_workflow_lanes: [...sweepA] },
+						{ workflow_lane: sweepB[0], owned_workflow_lanes: [...sweepB] },
+					],
+				},
+				'M',
+			),
+		).toThrow(/depth tier M .* at least 6 lanes/);
+	});
+
+	test('tier M: a full sweep spread across six lanes is accepted', () => {
+		expect(() =>
+			validatePrReviewMicroDispatch(
+				{ trigger_evaluation: fullEvaluation(), lanes: fullSweepLanes(6) },
+				'M',
+			),
+		).not.toThrow();
+	});
+
+	test('tier S: floor does not bind — a one-lane full sweep is accepted', () => {
+		expect(() =>
+			validatePrReviewMicroDispatch(
+				{ trigger_evaluation: fullEvaluation(), lanes: oneLaneOwningAll() },
+				'S',
+			),
+		).not.toThrow();
+	});
+
+	test('tier L: the canonical eleven-singleton full sweep is accepted (floor 11)', () => {
+		expect(() =>
+			validatePrReviewMicroDispatch(
+				{ trigger_evaluation: fullEvaluation(), lanes: elevenSingletonLanes() },
+				'L',
+			),
+		).not.toThrow();
+	});
+
+	// Regression for the plan-critic round-1 blocker: partial retry batches
+	// (covering a subset of the eleven families) must remain exempt from the
+	// floor, otherwise re-dispatching a single failed family deadlocks the run.
+	test('tier L: a one-family partial retry is exempt from the floor', () => {
+		expect(() =>
+			validatePrReviewMicroDispatch(
+				{
+					trigger_evaluation: fullEvaluation(),
+					lanes: [
+						{ workflow_lane: FAMILIES[0], owned_workflow_lanes: [FAMILIES[0]] },
+					],
+				},
+				'L',
+			),
+		).not.toThrow();
+	});
+
+	test('tier M: a two-family partial retry is exempt from the floor', () => {
+		expect(() =>
+			validatePrReviewMicroDispatch(
+				{
+					trigger_evaluation: fullEvaluation(),
+					lanes: [
+						{
+							workflow_lane: FAMILIES[0],
+							owned_workflow_lanes: [FAMILIES[0], FAMILIES[1]],
+						},
+					],
+				},
+				'M',
+			),
+		).not.toThrow();
+	});
+
+	test('tier L: consolidation still fails the per-family check before the floor', () => {
+		// A consolidated lane at tier L is rejected by the pre-existing per-family
+		// guard, independent of the new floor.
+		expect(() =>
+			validatePrReviewMicroDispatch(
+				{ trigger_evaluation: fullEvaluation(), lanes: oneLaneOwningAll() },
+				'L',
+			),
+		).toThrow(/one dedicated lane per risk family/);
+	});
+});

--- a/tests/unit/tools/write-pr-review-trigger-eval-provenance.test.ts
+++ b/tests/unit/tools/write-pr-review-trigger-eval-provenance.test.ts
@@ -39,6 +39,17 @@ const originalGateRevisionDigest =
 const originalResolveRevisionDigest =
 	writerInternals.resolvePrWorkflowRevisionDigest;
 const originalResolveMergeBase = writerInternals.resolveMergeBase;
+const originalResolveDiffStats = gateInternals.resolvePrReviewDiffStats;
+
+// Deterministic diff-stat fixtures for the controller depth tier. Without an
+// override the real numstat resolver runs against a git-less temp dir and fails
+// strict to tier L; the micro-lane floor (issue #1936) is tier-sensitive, so the
+// consolidated-ownership cases pin an explicit tier.
+const DIFF_STATS_BY_TIER = {
+	S: { changedLines: 10, changedFiles: 1, hasSubmoduleChange: false },
+	M: { changedLines: 300, changedFiles: 12, hasSubmoduleChange: false },
+	L: null,
+} as const;
 
 function tempRoot(): string {
 	const root = realpathSync(mkdtempSync(join(tmpdir(), 'trigger-eval-')));
@@ -126,11 +137,15 @@ async function recordCompletedLane(
 
 async function establishBoundReviewGate(
 	root: string,
-	options: { consolidatedMicro?: boolean } = {},
+	options: { consolidatedMicro?: boolean; depthTier?: 'S' | 'M' | 'L' } = {},
 ): Promise<void> {
 	gateInternals.resolveCurrentGitHead = () => HEAD_SHA;
 	gateInternals.resolveIsWorkingTreeClean = () => true;
 	gateInternals.resolvePrWorkflowRevisionDigest = () => REVISION_DIGEST;
+	if (options.depthTier) {
+		const stats = DIFF_STATS_BY_TIER[options.depthTier];
+		gateInternals.resolvePrReviewDiffStats = () => stats;
+	}
 	writerInternals.resolvePrWorkflowRevisionDigest = () => REVISION_DIGEST;
 	writerInternals.resolveMergeBase = () => 'def456';
 	await activatePrWorkflow(root, SESSION_ID, 'PR_REVIEW');
@@ -195,6 +210,7 @@ afterEach(() => {
 	writerInternals.resolvePrWorkflowRevisionDigest =
 		originalResolveRevisionDigest;
 	writerInternals.resolveMergeBase = originalResolveMergeBase;
+	gateInternals.resolvePrReviewDiffStats = originalResolveDiffStats;
 	for (const dir of tempDirs.splice(0)) {
 		rmSync(dir, { recursive: true, force: true });
 	}
@@ -277,9 +293,14 @@ describe('write_pr_review_trigger_eval provenance and ownership', () => {
 		);
 	});
 
-	test('accepts consolidated micro lanes that declared and attested every owned family', async () => {
+	test('accepts consolidated micro lanes that declared and attested every owned family (tier S — floor does not bind)', async () => {
 		const root = tempRoot();
-		await establishBoundReviewGate(root, { consolidatedMicro: true });
+		// Tier S: the micro-lane floor (issue #1936) is 1, so a two-lane
+		// consolidation of all eleven families is legal on the smallest PRs.
+		await establishBoundReviewGate(root, {
+			consolidatedMicro: true,
+			depthTier: 'S',
+		});
 		const sweepAFamilies = PR_REVIEW_REQUIRED_MICRO_LANE_IDS.slice(0, 6);
 		const consolidated = rows().map((row) => ({
 			...row,
@@ -309,6 +330,43 @@ describe('write_pr_review_trigger_eval provenance and ownership', () => {
 			no_match_count: 0,
 			dispatched_micro_lane_count: 2,
 		});
+	});
+
+	test('rejects a below-floor consolidated micro attestation at tier M (issue #1936 aggregate floor)', async () => {
+		const root = tempRoot();
+		// Tier M: the floor is 6. A durable attestation attributing all eleven
+		// families to only two dispatch lanes under-consolidates the record and
+		// must be rejected — including split-batch dodges of the dispatch floor.
+		await establishBoundReviewGate(root, {
+			consolidatedMicro: true,
+			depthTier: 'M',
+		});
+		const sweepAFamilies = PR_REVIEW_REQUIRED_MICRO_LANE_IDS.slice(0, 6);
+		const consolidated = rows().map((row) => ({
+			...row,
+			source_batch_id: 'micro-consolidated',
+			source_lane_id: (sweepAFamilies as readonly string[]).includes(
+				row.trigger_id,
+			)
+				? 'sweep-a'
+				: 'sweep-b',
+		}));
+		const response = JSON.parse(
+			await executeWritePrReviewTriggerEval(
+				{
+					run_id: 'review-consolidated-m',
+					pr_head_sha: HEAD_SHA,
+					base_sha: 'def456',
+					base_ref: 'origin/main',
+					rows: consolidated,
+				},
+				root,
+				{ sessionID: SESSION_ID },
+			),
+		);
+		expect(response.success).toBe(false);
+		expect(response.message).toContain('micro lane floor unmet');
+		expect(response.message).toContain('depth tier M');
 	});
 
 	test('rejects a consolidated tuple citing a family outside its declared ownership', async () => {


### PR DESCRIPTION
Closes #1936

## Summary
- Adds `PR_REVIEW_MICRO_LANE_FLOORS = { S: 1, M: 6, L: 11 }` (`src/hooks/pr-workflow-gate.ts`), the per-tier lane-count floor for micro (risk-family) PR-review consolidation that was missing while base dimensions already had `PR_REVIEW_BASE_LANE_FLOORS`. Numbers mirror the base floor's tier *semantics* scaled to 11 families (S does not bind; M = ceil(11/2) = 6; L = one lane per family), a deliberate choice rather than a copy of the base thresholds.
- Enforces the floor at two sites, both keyed on the controller-computed depth tier:
  - **Dispatch** (`validatePrReviewMicroDispatch`, `src/tools/dispatch-lanes.ts`): a micro batch whose lanes collectively own all 11 families ("a full sweep") must meet the tier floor. Partial retry batches (a subset of families) are exempt, so re-dispatching a failed family never deadlocks.
  - **Attestation** (`write_pr_review_trigger_eval`, `src/tools/write-pr-review-trigger-eval.ts`): the previously write-only `dispatched_micro_lane_count` is now a gate — the durable ledger's distinct-lane count for the 11 families must meet the tier floor regardless of dispatch history, catching split-batch consolidations that slip past the per-batch dispatch check.
- All 11 risk families remain mandatory to evaluate; every family still needs its own attested row. The floor bounds how far one lane may consolidate, not which families are reviewed.
- Reported tier-M reproduction (1 lane owning all 11 families) is now rejected at dispatch (`1 < 6`) and at attestation.

## Root cause
PR #1934 introduced depth-tiered consolidation for base and micro lanes but floored only base dimensions. `validatePrReviewMicroDispatch` enforced tier-L (one lane per family) but no S/M minimum-lane count, and `dispatched_micro_lane_count` was computed and persisted but never gated. (The issue's skeptical comment claiming these constructs did not exist was posted 2026-07-22T11:27Z, before #1934 merged at 13:56Z — it checked pre-merge code.)

## Invariant audit
- 1 (plugin init): not touched — no `src/index.ts` change (`git diff --cached --name-only | grep -c '^src/index.ts$'` → 0).
- 2 (runtime portability): not touched — no `bun:`/`Bun.` added in src (grep → none).
- 3 (subprocesses): not touched — no new `spawn`/`bunSpawn`/`spawnSync` call site (grep → none).
- 4 (.swarm containment): not touched — the attestation gate returns before the existing `.swarm` write; no new `.swarm` paths (grep → none).
- 5 (plan durability): not touched — no plan-ledger/plan.json/plan.md changes.
- 6 (test_runner safety): not touched — validation ran via `bun test`/repo scripts, not the `test_runner` tool.
- 7 (test writing): touched — new/changed tests use `bun:test` only; zero `mock.module` (grep → none); the new seam is a plain `_test_exports` function reference (established DI pattern), and the `resolvePrReviewDiffStats` override is restored in `afterEach`.
- 8 (session state): not touched — no new module-level global/session-keyed state.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no new tool, no `TOOL_NAMES`/`AGENT_TOOL_MAP` change (grep → none); `check-tool-registration.ts` → "112 tools, coherent".
- 12 (release/cache): touched — added `docs/releases/pending/1936-pr-review-micro-lane-floor.md` and corrected the asymmetry line in `pr-skills-harness-portability.md`; `package.json`/`CHANGELOG.md`/`.release-please-manifest.json` untouched (grep → none).

## Test plan
- [x] `bun test tests/unit/tools/dispatch-lanes-micro-lane-floor.test.ts` → 8 pass (new: S/M/L floor incl. retry exemption).
- [x] `bun test tests/unit/tools/write-pr-review-trigger-eval-provenance.test.ts` → 6 pass (incl. new tier-M aggregate rejection; consolidated test re-scoped to tier S).
- [x] Mutation kill-check (guards neutralized) → 3 fail; restored → 14 pass; no residue.
- [x] `bun test <39 files touching changed modules>` → 337 pass, 0 fail.
- [x] `bun run build` → succeeds; `node --input-type=module -e "await import('./dist/index.js')"` → `dist import OK`.
- [x] `bun run typecheck` → clean.
- [x] `bun run lint:ci` → clean, 2694 files, no fixes.
- [x] `bun run scripts/check-tool-registration.ts` → 112 tools coherent.
- [x] `bash scripts/check-mock-cleanup.sh` → 15 pre-existing violations (non-blocking), 0 new.
- [x] `bash scripts/check-invariants.sh` → all checks passed, 0 added/unapproved markers.
- [x] `bash scripts/check-cross-contamination.sh` → only known pre-existing warnings.
- [x] `bash scripts/check-test-clock.sh` → 0 new violations (443 pre-existing).
- [x] `bun run drift:check` → no drift.
- [x] `bash scripts/check-test-file-cap.sh` (FR-006) → 0 violations.
- [x] `scan-deferred.sh` + Contract clause-2 grep → no deferred-work markers.
- [x] `bun run test:unit:ci <9 touched + coupled test files>` (CI-equivalent scoped gate) → all 9 files `exitCode: 0`.
- [x] `bun test tests/security --timeout 120000` → 167 pass, 0 fail.
- [x] `bun test tests/adversarial --timeout 120000` → 829 pass, 0 fail.
- [x] `bun test tests/smoke --timeout 120000` → 10 pass, 0 fail.
- [x] `bun test tests/integration ./test --timeout 120000` → 749 pass, 206 fail. **Pre-existing, not a regression**: reproduced the identical 749/206/955 split on a clean `origin/main` worktree (`git worktree add /tmp/repro-check-1936 origin/main && bun install --frozen-lockfile && bun test tests/integration ./test --timeout 120000`); the specific failing file (`test/repro-plan-md-not-updated.test.ts`) passes 8/8 in isolation. Known combined-multi-file-run, shared-mutable-module-state artifact in plan persistence (`advanceTaskStateAndPersist`) — same failure PR #1934 already documented, unrelated to this diff (which touches no plan-persistence code).

## Pre-existing failures
- `tests/integration` + `./test`: 206/955 fail on both this branch and clean `origin/main` (identical split), isolated to shared-mutable-module-state in plan persistence. Not caused by this change; not carried as new signal.

## Acceptance Criteria → Evidence
- AC1 micro floor constant mirroring base shape → `PR_REVIEW_MICRO_LANE_FLOORS: Record<PrReviewDepthTier, number>` (pr-workflow-gate.ts).
- AC2 enforced at the micro `owned_workflow_lanes` validation site for S/M → `validatePrReviewMicroDispatch` full-sweep floor (dispatch-lanes.ts) + aggregate gate (write-eval).
- AC3 covers S/M, tier L preserved → dispatch floor keyed on depthTier; tier-L per-family check unchanged.
- AC4 deliberate numbers → S:1/M:6/L:11 with documented ceil(11/2) rationale, not base's 3.
- AC5 all 11 families mandatory → coverage/exact-ledger checks unchanged; floor bounds consolidation only.
- AC6 existing consolidated test updated → provenance "accepts consolidated micro lanes" re-scoped to tier S + new tier-M rejection test.
- AC7 no unwired code → `dispatched_micro_lane_count` now consumed as a gate (write-eval); constant consumed at both sites.
- AC8 release notes fixed → new #1936 fragment + corrected asymmetry line.

## Waivers (or none)
None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHA2Q1AfrxUFwqmmAaDfCy)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

