### PR TITLE
fix(hooks): wire quota/rate-limit failover into curator + skill-improver opt-in dispatch

### DIFF
--- a/docs/releases/pending/1927-wire-quota-failover-optin-dispatch.md
+++ b/docs/releases/pending/1927-wire-quota-failover-optin-dispatch.md
@@ -1,0 +1,47 @@
+# Model quota/rate-limit failover for the opt-in curator and skill-improver dispatch sites
+
+## What
+
+Extends model quota/rate-limit failover (the #1896/#1901/#1905 class) to the two
+remaining opt-in LLM dispatch sites that previously called `client.session.prompt`
+directly with no failover:
+
+- The curator LLM delegate (`createCuratorLLMDelegate`) — used by phase curation,
+  post-mortems, retrospective lesson enrichment, the knowledge/phase-monitor
+  hooks, and memory consolidation.
+- The skill-improver LLM delegate (`createSkillImproverLLMDelegate`) — used by
+  session reflection and the skill-improvement service.
+
+On a transient/quota dispatch error, each site now advances through its configured
+`fallback_models` chain (re-prompting with a per-call `model` override) instead of
+failing the opt-in feature outright. The curator inherits the explorer chain when
+it declares none — now including `curator_consolidation`, whose model already
+defaulted to explorer's but whose fallback chain did not, so consolidation-mode
+dispatch previously had no failover. A `telemetry.modelFallback` event is emitted
+on each failover for observability.
+
+## Why
+
+A role whose model exhausted its quota mid-run failed the opt-in feature — the
+same incident class #1905 closed for the production dispatch sites and explicitly
+deferred for these opt-in sites with a commitment to file the follow-up (#1927).
+The `curator_consolidation` inheritance gap meant one curator mode silently had no
+failover even after wiring.
+
+## Migration
+
+No breaking changes. The delegate signatures and their `undefined`-when-no-client
+contract are unchanged; the existing `CURATOR_LLM_TIMEOUT` /
+`SKILL_IMPROVER_LLM_TIMEOUT` timeout and cancellation semantics are preserved
+(abort is classified as a permanent error and still maps to the sentinel). With no
+`fallback_models` configured, behavior is identical to before (the primary error
+surfaces and the caller degrades as it did previously).
+
+## Caveats
+
+- A new coherence guardrail (`tests/unit/hooks/dispatch-fallback-coverage.test.ts`)
+  fails CI if a future production `client.session.prompt` dispatch site is added
+  without model failover and without an explicit, reasoned allowlist entry. The
+  two issue-declared out-of-scope sites (`evaluation/model-dispatcher.ts`,
+  same-model-retry-only for benchmark attribution; `mutation/generator.ts`,
+  `agent: undefined` with graceful `return []`) are allowlisted.

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -201,12 +201,17 @@ export function resolveFallbackModel(
 	let fallbackModels = agentConfig?.fallback_models;
 
 	// 2. If not explicitly set, check if this is a curator agent that should inherit from explorer
-	// Only inherit if the curator agent does NOT have fallback_models key at all
+	// Only inherit if the curator agent does NOT have fallback_models key at all.
+	// All four curator modes default their model to explorer's (see createSwarmAgents:
+	// curator_init/phase/postmortem/consolidation all use `?? getModel('explorer')`), so
+	// they inherit explorer's fallback chain too — otherwise consolidation-mode dispatch
+	// (memory-consolidation service) would fail over to nothing while the other modes do.
 	if (
 		fallbackModels === undefined &&
 		(agentBaseName === 'curator_init' ||
 			agentBaseName === 'curator_phase' ||
-			agentBaseName === 'curator_postmortem')
+			agentBaseName === 'curator_postmortem' ||
+			agentBaseName === 'curator_consolidation')
 	) {
 		fallbackModels = swarmAgents?.explorer?.fallback_models;
 	}

--- a/src/hooks/curator-llm-factory.ts
+++ b/src/hooks/curator-llm-factory.ts
@@ -1,4 +1,9 @@
+import { getSwarmAgents, resolveFallbackModel } from '../agents/index.js';
+import { stripKnownSwarmPrefix } from '../config/schema.js';
 import { swarmState } from '../state.js';
+import { telemetry } from '../telemetry.js';
+import { dispatchWithModelFallback } from '../utils/model-dispatch-fallback.js';
+import { isTransientProviderError } from '../utils/provider-error-classification.js';
 import { isAbortError } from './abort-utils.js';
 import type { CuratorLLMDelegate } from './curator.js';
 
@@ -183,25 +188,82 @@ export function createCuratorLLMDelegate(
 			// 2. Resolve the curator agent name for the calling swarm.
 			const agentName = resolveCuratorAgentName(mode, sessionId);
 
-			// 3. Prompt using the registered curator agent.
-			const promptResult = await client.session.prompt({
-				path: { id: ephemeralSessionId },
-				body: {
-					agent: agentName,
-					tools: { write: false, edit: false, patch: false },
-					parts: [{ type: 'text', text: userInput }],
+			// Derive the canonical role + swarm id from the resolved agent name so
+			// quota/rate-limit failover can route through the configured curator (or
+			// inherited explorer) fallback chain. Uses stripKnownSwarmPrefix — NOT a
+			// naive `_`-split — because curator role names themselves contain an
+			// underscore (`curator_phase`, `curator_consolidation`), which a split
+			// would misread as a swarm prefix. Mirrors src/turbo/lean/reviewer.ts.
+			const baseRole = stripKnownSwarmPrefix(agentName);
+			const swarmId =
+				baseRole !== agentName
+					? agentName.slice(0, agentName.length - baseRole.length - 1)
+					: undefined;
+			const swarmAgents = getSwarmAgents(swarmId);
+
+			// Capture the session id as a const so the type narrows to `string`
+			// inside the dispatch closure below (the `let` binding is `string |
+			// undefined` and cleanup can null it, so flow-narrowing is lost across
+			// the closure boundary).
+			const promptSessionId = ephemeralSessionId;
+
+			// 3. Prompt using the registered curator agent, failing over to a
+			// configured fallback model on a transient/quota dispatch error (#1927,
+			// the #1905 follow-up for the opt-in curator site). The fallback wraps
+			// only the prompt: the ephemeral session is reused across attempts and
+			// still torn down in `finally`.
+			const dispatched = await dispatchWithModelFallback({
+				dispatch: async (model) => {
+					const promptResult = await client.session.prompt({
+						path: { id: promptSessionId },
+						body: {
+							agent: agentName,
+							// #1927: per-call model override on a fallback attempt;
+							// omitted (undefined) means the registered curator model.
+							...(model ? { model } : {}),
+							tools: { write: false, edit: false, patch: false },
+							parts: [{ type: 'text', text: userInput }],
+						},
+						...sdkOpts,
+					});
+					if (!promptResult.data) {
+						// Preserve the SDK error envelope so the transient/quota
+						// classifier can read the real provider message (#1905
+						// envelope-preservation pattern).
+						throw new Error(
+							`Curator LLM prompt failed: ${JSON.stringify(promptResult.error)}`,
+						);
+					}
+					return promptResult.data;
 				},
-				...sdkOpts,
+				resolveFallback: (index) =>
+					resolveFallbackModel(baseRole, index, swarmAgents),
+				// Advance to the next model immediately on a transient/quota error —
+				// an instant same-model retry cannot clear an exhausted quota.
+				maxTransientRetriesPerModel: 0,
+				classify: (err) => {
+					// A genuine cancellation is not a provider transient: surface it so
+					// the outer catch maps it to CURATOR_LLM_TIMEOUT, and never fail
+					// over on abort.
+					if (isAbortError(err)) return 'permanent';
+					const msg = err instanceof Error ? err.message : String(err);
+					return isTransientProviderError(msg) ? 'transient' : 'permanent';
+				},
+				onFallback: ({ toModel }) => {
+					if (sessionId) {
+						telemetry.modelFallback(
+							sessionId,
+							agentName,
+							swarmAgents?.[baseRole]?.model ?? 'default',
+							toModel,
+							'transient_model_error',
+						);
+					}
+				},
 			});
 
-			if (!promptResult.data) {
-				throw new Error(
-					`Curator LLM prompt failed: ${JSON.stringify(promptResult.error)}`,
-				);
-			}
-
 			// 4. Extract text parts from response (filter out tool/reasoning parts)
-			const textParts = promptResult.data.parts.filter(
+			const textParts = dispatched.result.parts.filter(
 				(p): p is typeof p & { text: string } => p.type === 'text',
 			);
 			return textParts.map((p) => p.text).join('\n');

--- a/src/hooks/skill-improver-llm-factory.ts
+++ b/src/hooks/skill-improver-llm-factory.ts
@@ -13,7 +13,12 @@
  * `skill_improver` agent.
  */
 
+import { getSwarmAgents, resolveFallbackModel } from '../agents/index.js';
+import { stripKnownSwarmPrefix } from '../config/schema.js';
 import { swarmState } from '../state.js';
+import { telemetry } from '../telemetry.js';
+import { dispatchWithModelFallback } from '../utils/model-dispatch-fallback.js';
+import { isTransientProviderError } from '../utils/provider-error-classification.js';
 import { isAbortError } from './abort-utils.js';
 
 export type SkillImproverLLMDelegate = (
@@ -130,26 +135,82 @@ export function createSkillImproverLLMDelegate(
 
 			const agentName = resolveSkillImproverAgentName(sessionId);
 
+			// Derive the canonical role + swarm id so quota/rate-limit failover can
+			// route through the configured skill_improver fallback chain. Uses
+			// stripKnownSwarmPrefix — NOT a naive `_`-split — because `skill_improver`
+			// itself contains an underscore. Mirrors src/turbo/lean/reviewer.ts.
+			const baseRole = stripKnownSwarmPrefix(agentName);
+			const swarmId =
+				baseRole !== agentName
+					? agentName.slice(0, agentName.length - baseRole.length - 1)
+					: undefined;
+			const swarmAgents = getSwarmAgents(swarmId);
+
+			// Capture the session id as a const so the type narrows to `string`
+			// inside the dispatch closure below (the `let` binding is `string |
+			// undefined` and cleanup can null it, so flow-narrowing is lost across
+			// the closure boundary).
+			const promptSessionId = ephemeralSessionId;
+
 			const prelude = systemPrompt
 				? `${systemPrompt}\n\n---\n\n${userInput}`
 				: userInput;
-			const promptResult = await client.session.prompt({
-				path: { id: ephemeralSessionId },
-				body: {
-					agent: agentName,
-					tools: { write: false, edit: false, patch: false },
-					parts: [{ type: 'text', text: prelude }],
+			// Prompt the registered skill_improver agent, failing over to a
+			// configured fallback model on a transient/quota dispatch error (#1927,
+			// the #1905 follow-up for the opt-in skill-improvement site). The
+			// fallback wraps only the prompt: the ephemeral session is reused across
+			// attempts and still torn down in `finally`.
+			const dispatched = await dispatchWithModelFallback({
+				dispatch: async (model) => {
+					const promptResult = await client.session.prompt({
+						path: { id: promptSessionId },
+						body: {
+							agent: agentName,
+							// #1927: per-call model override on a fallback attempt;
+							// omitted (undefined) means the registered skill_improver model.
+							...(model ? { model } : {}),
+							tools: { write: false, edit: false, patch: false },
+							parts: [{ type: 'text', text: prelude }],
+						},
+						...sdkOpts,
+					});
+					if (!promptResult.data) {
+						// Preserve the SDK error envelope so the transient/quota
+						// classifier can read the real provider message (#1905
+						// envelope-preservation pattern).
+						throw new Error(
+							`skill_improver LLM prompt failed: ${JSON.stringify(promptResult.error)}`,
+						);
+					}
+					return promptResult.data;
 				},
-				...sdkOpts,
+				resolveFallback: (index) =>
+					resolveFallbackModel(baseRole, index, swarmAgents),
+				// Advance to the next model immediately on a transient/quota error —
+				// an instant same-model retry cannot clear an exhausted quota.
+				maxTransientRetriesPerModel: 0,
+				classify: (err) => {
+					// A genuine cancellation is not a provider transient: surface it so
+					// the outer catch maps it to SKILL_IMPROVER_LLM_TIMEOUT, and never
+					// fail over on abort.
+					if (isAbortError(err)) return 'permanent';
+					const msg = err instanceof Error ? err.message : String(err);
+					return isTransientProviderError(msg) ? 'transient' : 'permanent';
+				},
+				onFallback: ({ toModel }) => {
+					if (sessionId) {
+						telemetry.modelFallback(
+							sessionId,
+							agentName,
+							swarmAgents?.[baseRole]?.model ?? 'default',
+							toModel,
+							'transient_model_error',
+						);
+					}
+				},
 			});
 
-			if (!promptResult.data) {
-				throw new Error(
-					`skill_improver LLM prompt failed: ${JSON.stringify(promptResult.error)}`,
-				);
-			}
-
-			const textParts = promptResult.data.parts.filter(
+			const textParts = dispatched.result.parts.filter(
 				(p): p is typeof p & { text: string } => p.type === 'text',
 			);
 			return textParts.map((p) => p.text).join('\n');

--- a/tests/unit/agents/fallback-inheritance.test.ts
+++ b/tests/unit/agents/fallback-inheritance.test.ts
@@ -27,6 +27,49 @@ describe('resolveFallbackModel - curator fallback inheritance', () => {
 		expect(fallback3).toBeNull();
 	});
 
+	test('curator_consolidation inherits fallback_models from explorer when not explicitly set (#1927)', () => {
+		// curator_consolidation's model already defaults to explorer's in
+		// createSwarmAgents, so it must inherit explorer's fallback chain too —
+		// otherwise the opt-in memory-consolidation dispatch fails over to nothing.
+		const swarmAgents = {
+			explorer: {
+				model: 'opencode/big-pickle',
+				fallback_models: ['consol-fb-1', 'consol-fb-2'],
+			},
+			curator_consolidation: {
+				model: 'opencode/big-pickle',
+				// No fallback_models explicitly set
+			},
+		};
+
+		expect(resolveFallbackModel('curator_consolidation', 1, swarmAgents)).toBe(
+			'consol-fb-1',
+		);
+		expect(resolveFallbackModel('curator_consolidation', 2, swarmAgents)).toBe(
+			'consol-fb-2',
+		);
+		expect(
+			resolveFallbackModel('curator_consolidation', 3, swarmAgents),
+		).toBeNull();
+	});
+
+	test('curator_consolidation uses explicit fallback_models when set, ignoring explorer (#1927)', () => {
+		const swarmAgents = {
+			explorer: {
+				model: 'opencode/big-pickle',
+				fallback_models: ['explorer-fallback-1'],
+			},
+			curator_consolidation: {
+				model: 'custom-model',
+				fallback_models: ['consol-explicit'],
+			},
+		};
+
+		expect(resolveFallbackModel('curator_consolidation', 1, swarmAgents)).toBe(
+			'consol-explicit',
+		);
+	});
+
 	test('curator_phase inherits fallback_models from explorer when not explicitly set', () => {
 		const swarmAgents = {
 			explorer: {

--- a/tests/unit/commands/close-finalizer.test.ts
+++ b/tests/unit/commands/close-finalizer.test.ts
@@ -34,6 +34,7 @@ import { rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+import { isValidEvidenceType } from '../../../src/evidence/manager.js';
 import { initLedger } from '../../../src/plan/ledger.js';
 
 // ── Mocks (must precede the dynamic import) ──────────────────────────
@@ -161,10 +162,19 @@ mock.module('../../../src/hooks/knowledge-curator.js', () => ({
 
 mock.module('../../../src/evidence/manager.js', () => ({
 	archiveEvidence: mockArchiveEvidence,
+	isValidEvidenceType,
 }));
 
 mock.module('../../../src/session/snapshot-writer.js', () => ({
 	flushPendingSnapshot: mockFlushPendingSnapshot,
+	writeSnapshot: async () => {},
+}));
+
+mock.module('../../../src/hooks/hive-promoter.js', () => ({
+	isHiveEligible: () => false,
+	checkHivePromotions: async () => {},
+	promoteToHive: async () => '',
+	promoteFromSwarm: async () => '',
 }));
 
 // state.js mock — close.ts calls resetSwarmStatePreservingSingletons (NOT resetSwarmState)
@@ -201,6 +211,30 @@ mock.module('../../../src/state.js', () => {
 		},
 		resetSwarmStatePreservingSingletons:
 			mockResetSwarmStatePreservingSingletons,
+		// The remaining state.ts exports below are not exercised by this
+		// test's assertions, but must exist: some other module's import
+		// graph (reached transitively via createCuratorLLMDelegate ->
+		// agents/index.ts, #1927) now reaches them. Bound to
+		// `mockedSwarmState` (not a real import/spread) to avoid the
+		// real-vs-mock swarmState split-brain a full spread hits — real
+		// state.ts functions close over their own module-internal swarmState
+		// singleton, not this test's mocked one (see close.test.ts for the
+		// full incident notes).
+		getAgentSession: (sessionId: string) =>
+			mockedSwarmState.agentSessions?.get(sessionId),
+		ensureAgentSession: (sessionId: string, agentName?: string) => {
+			let session = mockedSwarmState.agentSessions.get(sessionId);
+			if (!session) {
+				session = { agentName };
+				mockedSwarmState.agentSessions.set(sessionId, session);
+			}
+			return session;
+		},
+		hasActiveTurboMode: () => false,
+		hasActiveFullAuto: () => false,
+		getActiveFullAutoSessionID: () => undefined,
+		hasActiveLeanTurbo: () => false,
+		hasActiveEpicMode: () => false,
 	};
 });
 

--- a/tests/unit/commands/close.test.ts
+++ b/tests/unit/commands/close.test.ts
@@ -14,6 +14,7 @@ import {
 } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { isValidEvidenceType } from '../../../src/evidence/manager.js';
 import { initLedger } from '../../../src/plan/ledger.js';
 import { derivePlanId } from '../../../src/plan/utils.js';
 
@@ -162,14 +163,28 @@ mock.module('../../../src/hooks/knowledge-curator.js', () => ({
 mock.module('../../../src/hooks/hive-promoter.js', () => ({
 	isHiveEligible: () => false,
 	checkHivePromotions: mockCheckHivePromotions,
+	// Not exercised by this test (isHiveEligible is stubbed false so
+	// promotion never triggers); must exist for transitive imports to
+	// resolve against.
+	promoteToHive: async () => '',
+	promoteFromSwarm: async () => '',
 }));
 
 mock.module('../../../src/evidence/manager.js', () => ({
 	archiveEvidence: mockArchiveEvidence,
+	// Pure, stateless type-guard — safe to keep real. Any code path
+	// transitively reached from close.ts's import graph that imports it
+	// needs a real binding, or Bun's mock.module throws "export not found"
+	// at import time for the whole file.
+	isValidEvidenceType,
 }));
 
 mock.module('../../../src/session/snapshot-writer.js', () => ({
 	flushPendingSnapshot: mockFlushPendingSnapshot,
+	// Real writeSnapshot does file I/O; flushPendingSnapshot (mocked above)
+	// is this test's actual entry point, so a no-op is safe here — it only
+	// needs to exist for any transitively-reached import to resolve against.
+	writeSnapshot: async () => {},
 }));
 
 mock.module('../../../src/config.js', () => ({
@@ -178,6 +193,9 @@ mock.module('../../../src/config.js', () => ({
 
 mock.module('../../../src/config/index.js', () => ({
 	loadPluginConfigWithMeta: mockLoadPluginConfigWithMeta,
+	// Pure filesystem lookup for a user prompt override; not exercised by
+	// this test and must not touch the real filesystem in a unit test.
+	loadAgentPrompt: () => ({}),
 }));
 
 mock.module('../../../src/services/skill-improver.js', () => ({
@@ -258,6 +276,37 @@ mock.module('../../../src/state.js', () => ({
 	endAgentSession: mockEndAgentSession,
 	resetSwarmState: mockResetSwarmState,
 	resetSwarmStatePreservingSingletons: mockResetSwarmStatePreservingSingletons,
+	// getAgentSession is not exercised by this test's expectations, but must
+	// stay present: any code path transitively reached from close.ts's
+	// import graph that imports it from state.js needs a real binding to
+	// resolve against, or Bun's mock.module throws "export not found" at
+	// import time for the whole file (not a spread — see close.test.ts's
+	// endAgentSession/resetSwarmStatePreservingSingletons regression when a
+	// full spread was tried: some real, non-overridden state.ts functions
+	// call these internally by direct reference, bypassing the mock).
+	getAgentSession: (sessionId: string) =>
+		mockSwarmState.agentSessions?.get(sessionId),
+	// Minimal stub matching the real function's essential shape (an upsert
+	// against agentSessions); this test's expectations don't depend on its
+	// precise fields, only that it exists and doesn't throw.
+	ensureAgentSession: (sessionId: string, agentName?: string) => {
+		let session = mockSwarmState.agentSessions.get(sessionId);
+		if (!session) {
+			session = { agentName };
+			mockSwarmState.agentSessions.set(sessionId, session);
+		}
+		return session;
+	},
+	// This test doesn't exercise turbo/full-auto/lean-turbo/epic mode; these
+	// read-only checks are bound to mockSwarmState (not a real import) to
+	// avoid the exact real-vs-mock swarmState split-brain the spread
+	// attempt above hit — real state.ts functions close over their own
+	// module-internal swarmState singleton, not this test's mockSwarmState.
+	hasActiveTurboMode: () => false,
+	hasActiveFullAuto: () => false,
+	getActiveFullAutoSessionID: () => undefined,
+	hasActiveLeanTurbo: () => false,
+	hasActiveEpicMode: () => false,
 }));
 
 // Import after mock setup

--- a/tests/unit/hooks/curator-llm-factory-fallback.test.ts
+++ b/tests/unit/hooks/curator-llm-factory-fallback.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Issue #1927 (the #1905 follow-up): the opt-in curator LLM delegate
+ * (`createCuratorLLMDelegate` in `src/hooks/curator-llm-factory.ts`) now fails
+ * over to a configured `fallback_models` entry on a transient/quota dispatch
+ * error instead of failing the opt-in curation feature outright. Mirrors
+ * `tests/unit/hooks/auto-review-fallback.test.ts` (the sibling reviewer site).
+ *
+ * DI is via `swarmState.opencodeClient` (the factory reads it directly) — no
+ * `mock.module`, per AGENTS.md invariant #7. Fallback config is seeded through
+ * `getAgentConfigs`, which populates the `_swarmAgentsMap` that
+ * `resolveFallbackModel` reads.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { getAgentConfigs } from '../../../src/agents/index';
+import type { PluginConfig } from '../../../src/config';
+import { createCuratorLLMDelegate } from '../../../src/hooks/curator-llm-factory';
+import { resetSwarmState, swarmState } from '../../../src/state';
+import { _internals as telemetryInternals } from '../../../src/telemetry';
+
+const RESULT_TEXT = 'curator analysis complete';
+
+type ModelOverride = { providerID: string; modelID: string };
+
+/** Build a fake OpenCode client whose `session.prompt` is driven per attempt. */
+function fakeClient(
+	prompt: (
+		model: ModelOverride | undefined,
+		callIndex: number,
+	) => Promise<unknown>,
+	promptCalls: Array<string | undefined>,
+): typeof swarmState.opencodeClient {
+	return {
+		session: {
+			create: async () => ({ data: { id: 'curator-session-1' } }),
+			prompt: async (params: { body?: { model?: ModelOverride } }) => {
+				const model = params.body?.model;
+				promptCalls.push(
+					model ? `${model.providerID}/${model.modelID}` : undefined,
+				);
+				return prompt(model, promptCalls.length - 1);
+			},
+			delete: async () => ({}),
+		},
+	} as unknown as typeof swarmState.opencodeClient;
+}
+
+const QUOTA_ENVELOPE = {
+	data: null,
+	error: {
+		code: 'RATE_LIMITED',
+		message: '429 rate_limit_exceeded: too many requests',
+	},
+};
+const OK_ENVELOPE = { data: { parts: [{ type: 'text', text: RESULT_TEXT }] } };
+
+/** Seed the default-swarm curator_phase's own fallback chain. */
+function seedCuratorFallback(): void {
+	getAgentConfigs({
+		agents: {
+			curator_phase: {
+				model: 'prov/primary-curator',
+				fallback_models: ['prov/fb1', 'prov/fb2'],
+			},
+		},
+	} as unknown as PluginConfig);
+}
+
+let origClient: typeof swarmState.opencodeClient;
+const origEmit = telemetryInternals.emit;
+
+beforeEach(() => {
+	origClient = swarmState.opencodeClient;
+	resetSwarmState();
+});
+
+afterEach(() => {
+	swarmState.opencodeClient = origClient;
+	telemetryInternals.emit = origEmit;
+	resetSwarmState();
+});
+
+describe('createCuratorLLMDelegate — model failover (#1927)', () => {
+	test('fails over to a fallback model on a quota dispatch error and returns the fallback result', async () => {
+		seedCuratorFallback();
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = fakeClient(async (model) => {
+			// Primary (no override) hits the quota envelope; first fallback succeeds.
+			if (!model) return QUOTA_ENVELOPE;
+			return OK_ENVELOPE;
+		}, promptCalls);
+
+		const delegate = createCuratorLLMDelegate('/tmp/proj', 'phase', 'sess-1');
+		expect(delegate).toBeDefined();
+		const out = await delegate!('sys', 'user input');
+
+		expect(out).toBe(RESULT_TEXT);
+		// Primary attempted with no override, then the first fallback model.
+		expect(promptCalls[0]).toBeUndefined();
+		expect(promptCalls[1]).toBe('prov/fb1');
+	});
+
+	test('emits telemetry.modelFallback on a quota failover', async () => {
+		seedCuratorFallback();
+		const emitted: Array<{ event: string; data: Record<string, unknown> }> = [];
+		telemetryInternals.emit = (event, data) => {
+			emitted.push({ event, data });
+		};
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = fakeClient(async (model) => {
+			if (!model) return QUOTA_ENVELOPE;
+			return OK_ENVELOPE;
+		}, promptCalls);
+
+		const delegate = createCuratorLLMDelegate('/tmp/proj', 'phase', 'sess-1');
+		await delegate!('sys', 'user input');
+
+		const fallbackEvents = emitted.filter((e) => e.event === 'model_fallback');
+		expect(fallbackEvents).toHaveLength(1);
+		expect(fallbackEvents[0]?.data.toModel).toBe('prov/fb1');
+		expect(fallbackEvents[0]?.data.agentName).toBe('curator_phase');
+		expect(fallbackEvents[0]?.data.reason).toBe('transient_model_error');
+	});
+
+	test('a permanent dispatch error does not fail over and surfaces the primary error', async () => {
+		seedCuratorFallback();
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = fakeClient(
+			async () => ({
+				data: null,
+				error: {
+					code: 'UNAUTHORIZED',
+					message: '401 unauthorized: invalid api key',
+				},
+			}),
+			promptCalls,
+		);
+
+		const delegate = createCuratorLLMDelegate('/tmp/proj', 'phase', 'sess-1');
+		await expect(delegate!('sys', 'user input')).rejects.toThrow(
+			/401 unauthorized/,
+		);
+		// Only the primary was attempted — no failover on a permanent error.
+		expect(promptCalls).toHaveLength(1);
+		expect(promptCalls[0]).toBeUndefined();
+	});
+
+	test('an abort during dispatch maps to CURATOR_LLM_TIMEOUT with no failover', async () => {
+		seedCuratorFallback();
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = fakeClient(async () => {
+			const err = new Error('The operation was aborted');
+			err.name = 'AbortError';
+			throw err;
+		}, promptCalls);
+
+		const delegate = createCuratorLLMDelegate('/tmp/proj', 'phase', 'sess-1');
+		await expect(delegate!('sys', 'user input')).rejects.toThrow(
+			'CURATOR_LLM_TIMEOUT',
+		);
+		// Abort is classified permanent → single attempt, no fallback.
+		expect(promptCalls).toHaveLength(1);
+	});
+
+	test('with no fallback chain configured, a quota error degrades exactly as before (primary error surfaces)', async () => {
+		// Explicitly seed an empty default-swarm config: `_swarmAgentsMap` is
+		// module-global and NOT cleared by resetSwarmState, so this overwrites any
+		// chain a prior test seeded, making the no-fallback case order-independent.
+		getAgentConfigs({ agents: {} } as unknown as PluginConfig);
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = fakeClient(
+			async () => QUOTA_ENVELOPE,
+			promptCalls,
+		);
+
+		const delegate = createCuratorLLMDelegate('/tmp/proj', 'phase', 'sess-1');
+		await expect(delegate!('sys', 'user input')).rejects.toThrow(
+			/Curator LLM prompt failed/,
+		);
+		expect(promptCalls).toHaveLength(1);
+	});
+
+	test('inherits the explorer fallback chain when the curator declares none', async () => {
+		// Only explorer has fallback_models; curator_phase inherits it.
+		getAgentConfigs({
+			agents: {
+				explorer: {
+					model: 'prov/explorer',
+					fallback_models: ['prov/explorer-fb1'],
+				},
+				curator_phase: { model: 'prov/explorer' },
+			},
+		} as unknown as PluginConfig);
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = fakeClient(async (model) => {
+			if (!model) return QUOTA_ENVELOPE;
+			return OK_ENVELOPE;
+		}, promptCalls);
+
+		const delegate = createCuratorLLMDelegate('/tmp/proj', 'phase', 'sess-1');
+		const out = await delegate!('sys', 'user input');
+
+		expect(out).toBe(RESULT_TEXT);
+		expect(promptCalls[1]).toBe('prov/explorer-fb1');
+	});
+
+	test('routes failover through the correct swarm chain for a prefixed agent name', async () => {
+		// Register a named swarm and its curator so resolveCuratorAgentName
+		// resolves the prefixed name and swarmId derivation picks swarm1's chain.
+		getAgentConfigs({
+			swarms: {
+				swarm1: {
+					name: 'Swarm1',
+					agents: {
+						curator_phase: {
+							model: 'prov/s1-primary',
+							fallback_models: ['prov/s1-fb1'],
+						},
+					},
+				},
+			},
+		} as unknown as PluginConfig);
+		swarmState.curatorPhaseAgentNames = ['swarm1_curator_phase'];
+		const promptCalls: Array<string | undefined> = [];
+		const agentNames: Array<string | undefined> = [];
+		swarmState.opencodeClient = {
+			session: {
+				create: async () => ({ data: { id: 'curator-session-1' } }),
+				prompt: async (params: {
+					body?: { agent?: string; model?: ModelOverride };
+				}) => {
+					agentNames.push(params.body?.agent);
+					const model = params.body?.model;
+					promptCalls.push(
+						model ? `${model.providerID}/${model.modelID}` : undefined,
+					);
+					if (!model) return QUOTA_ENVELOPE;
+					return OK_ENVELOPE;
+				},
+				delete: async () => ({}),
+			},
+		} as unknown as typeof swarmState.opencodeClient;
+
+		const delegate = createCuratorLLMDelegate('/tmp/proj', 'phase', 'sess-1');
+		const out = await delegate!('sys', 'user input');
+
+		expect(out).toBe(RESULT_TEXT);
+		expect(agentNames[0]).toBe('swarm1_curator_phase');
+		expect(promptCalls[1]).toBe('prov/s1-fb1');
+	});
+});

--- a/tests/unit/hooks/dispatch-fallback-coverage.test.ts
+++ b/tests/unit/hooks/dispatch-fallback-coverage.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Recurrence guardrail for issue #1927 (and the #1896/#1905 class).
+ *
+ * Defect class: an opt-in / production `client.session.prompt(...)` model-dispatch
+ * site that calls the provider directly without wrapping the call in
+ * `dispatchWithModelFallback`, so a quota/rate-limit error fails the stage
+ * instead of failing over to the role's configured `fallback_models` chain.
+ *
+ * This test enumerates every production `.session.prompt(` dispatch site under
+ * `src/` and asserts each one either (a) also references
+ * `dispatchWithModelFallback` (it is failover-wrapped), or (b) is on an explicit
+ * allowlist with a recorded reason. A NEW dispatch site added without failover
+ * and without an allowlist entry fails this test — catching the silent return of
+ * the class by machinery rather than vigilance.
+ *
+ * When a genuinely same-model-only or no-role dispatch site is added, add it to
+ * ALLOWLIST below WITH a reason. Do not add a site here to silence a real gap:
+ * the correct fix for an opt-in role dispatch is to wrap it in failover.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dir, '..', '..', '..');
+const SRC_DIR = join(REPO_ROOT, 'src');
+
+const SESSION_PROMPT_RE = /\.session\.prompt\(/;
+// A site "does model failover" if it resolves the fallback chain via
+// `resolveFallbackModel` — the shared resolver used by BOTH failover
+// primitives: `dispatchWithModelFallback` (reviewer/runner/auto-review/
+// integration/curator/skill-improver) and the inline fallback-advancer loop
+// (full-auto oversight sites). Either marker counts as wired.
+const FAILOVER_MARKERS = ['dispatchWithModelFallback', 'resolveFallbackModel'];
+
+/**
+ * Sites that intentionally dispatch without model failover. Each entry MUST
+ * carry a reason. Keyed by the src-relative path (posix separators).
+ */
+const ALLOWLIST: Record<string, string> = {
+	// The failover helper itself — only a doc comment mentions session.prompt.
+	'src/utils/model-dispatch-fallback.ts':
+		'the failover helper; no direct dispatch (doc comment only)',
+	// Issue #1927 "out of scope (already handled)": benchmark dispatch is
+	// intentionally same-model-retry-only to preserve benchmark attribution.
+	'src/evaluation/model-dispatcher.ts':
+		'#1927 out-of-scope: same-model-retry-only to preserve benchmark attribution',
+	// Issue #1927 "out of scope": generateMutants dispatches with agent:undefined
+	// (no role/chain), so resolveFallbackModel cannot resolve a target; the
+	// existing graceful `return []` is the correct opt-in-tool behavior.
+	'src/mutation/generator.ts':
+		'#1927 out-of-scope: agent:undefined, no role/chain; graceful return [] is correct',
+};
+
+function listSourceFiles(): string[] {
+	const entries = readdirSync(SRC_DIR, { recursive: true }) as string[];
+	return entries
+		.filter((rel) => rel.endsWith('.ts'))
+		.filter((rel) => !rel.endsWith('.test.ts') && !rel.endsWith('.spec.ts'))
+		.map((rel) => `src/${rel.split('\\').join('/')}`);
+}
+
+/** True when a file's contents represent an unwired dispatch site. */
+function isUnwiredDispatch(relPath: string, contents: string): boolean {
+	if (!SESSION_PROMPT_RE.test(contents)) return false; // not a dispatch site
+	if (FAILOVER_MARKERS.some((m) => contents.includes(m))) return false; // wired
+	if (relPath in ALLOWLIST) return false; // explicitly allowlisted
+	return true;
+}
+
+describe('model-dispatch failover coverage (#1927 recurrence guardrail)', () => {
+	test('every production client.session.prompt site is failover-wrapped or allowlisted', () => {
+		const unwired: string[] = [];
+		for (const rel of listSourceFiles()) {
+			const contents = readFileSync(join(REPO_ROOT, rel), 'utf-8');
+			if (isUnwiredDispatch(rel, contents)) unwired.push(rel);
+		}
+		expect(
+			unwired,
+			`Unwired model-dispatch site(s) found — wrap the client.session.prompt call in ` +
+				`dispatchWithModelFallback (see src/hooks/curator-llm-factory.ts) or, if the site ` +
+				`is genuinely same-model-only / has no role chain, add it to ALLOWLIST with a reason:\n` +
+				unwired.join('\n'),
+		).toEqual([]);
+	});
+
+	test('the two #1927 target sites are wired for failover (positive coverage)', () => {
+		for (const rel of [
+			'src/hooks/curator-llm-factory.ts',
+			'src/hooks/skill-improver-llm-factory.ts',
+		]) {
+			const contents = readFileSync(join(REPO_ROOT, rel), 'utf-8');
+			expect(SESSION_PROMPT_RE.test(contents)).toBe(true);
+			expect(contents.includes('dispatchWithModelFallback')).toBe(true);
+			expect(isUnwiredDispatch(rel, contents)).toBe(false);
+		}
+	});
+
+	test('the guardrail bites: a synthetic unwired dispatch site is flagged', () => {
+		// Prove the detector catches the class: a file that dispatches via
+		// client.session.prompt but neither wraps failover nor is allowlisted.
+		const synthetic =
+			'export async function dispatchThing(client) {\n' +
+			'  return client.session.prompt({ body: { agent, parts } });\n' +
+			'}\n';
+		expect(isUnwiredDispatch('src/fake/new-dispatch.ts', synthetic)).toBe(true);
+		// And it does NOT flag the same site once failover is added...
+		expect(
+			isUnwiredDispatch(
+				'src/fake/new-dispatch.ts',
+				`${synthetic}// uses ${FAILOVER_MARKERS[0]}`,
+			),
+		).toBe(false);
+		// ...nor when it is explicitly allowlisted.
+		expect(
+			isUnwiredDispatch('src/utils/model-dispatch-fallback.ts', synthetic),
+		).toBe(false);
+	});
+});

--- a/tests/unit/hooks/skill-improver-llm-factory-fallback.test.ts
+++ b/tests/unit/hooks/skill-improver-llm-factory-fallback.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Issue #1927 (the #1905 follow-up): the opt-in skill-improver LLM delegate
+ * (`createSkillImproverLLMDelegate` in `src/hooks/skill-improver-llm-factory.ts`)
+ * now fails over to a configured `fallback_models` entry on a transient/quota
+ * dispatch error instead of failing the opt-in skill-improvement feature
+ * outright. Mirrors `tests/unit/hooks/auto-review-fallback.test.ts`.
+ *
+ * DI is via `swarmState.opencodeClient` (the factory reads it directly) — no
+ * `mock.module`, per AGENTS.md invariant #7. Fallback config is seeded through
+ * `getAgentConfigs`, which populates the `_swarmAgentsMap` that
+ * `resolveFallbackModel` reads.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { getAgentConfigs } from '../../../src/agents/index';
+import type { PluginConfig } from '../../../src/config';
+import { createSkillImproverLLMDelegate } from '../../../src/hooks/skill-improver-llm-factory';
+import { resetSwarmState, swarmState } from '../../../src/state';
+import { _internals as telemetryInternals } from '../../../src/telemetry';
+
+const RESULT_TEXT = 'skill improvement report';
+
+type ModelOverride = { providerID: string; modelID: string };
+
+function fakeClient(
+	prompt: (model: ModelOverride | undefined) => Promise<unknown>,
+	promptCalls: Array<string | undefined>,
+): typeof swarmState.opencodeClient {
+	return {
+		session: {
+			create: async () => ({ data: { id: 'skill-improver-session-1' } }),
+			prompt: async (params: { body?: { model?: ModelOverride } }) => {
+				const model = params.body?.model;
+				promptCalls.push(
+					model ? `${model.providerID}/${model.modelID}` : undefined,
+				);
+				return prompt(model);
+			},
+			delete: async () => ({}),
+		},
+	} as unknown as typeof swarmState.opencodeClient;
+}
+
+const QUOTA_ENVELOPE = {
+	data: null,
+	error: {
+		code: 'RATE_LIMITED',
+		message: '429 rate_limit_exceeded: too many requests',
+	},
+};
+const OK_ENVELOPE = { data: { parts: [{ type: 'text', text: RESULT_TEXT }] } };
+
+/** Seed the skill_improver's own fallback chain (no inheritance for this role). */
+function seedSkillImproverFallback(): void {
+	getAgentConfigs({
+		agents: {
+			skill_improver: {
+				model: 'prov/primary-skill',
+				fallback_models: ['prov/fb1', 'prov/fb2'],
+			},
+		},
+	} as unknown as PluginConfig);
+}
+
+let origClient: typeof swarmState.opencodeClient;
+const origEmit = telemetryInternals.emit;
+
+beforeEach(() => {
+	origClient = swarmState.opencodeClient;
+	resetSwarmState();
+});
+
+afterEach(() => {
+	swarmState.opencodeClient = origClient;
+	telemetryInternals.emit = origEmit;
+	resetSwarmState();
+});
+
+describe('createSkillImproverLLMDelegate — model failover (#1927)', () => {
+	test('fails over to a fallback model on a quota dispatch error and returns the fallback result', async () => {
+		seedSkillImproverFallback();
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = fakeClient(async (model) => {
+			if (!model) return QUOTA_ENVELOPE;
+			return OK_ENVELOPE;
+		}, promptCalls);
+
+		const delegate = createSkillImproverLLMDelegate('/tmp/proj', 'sess-1');
+		expect(delegate).toBeDefined();
+		const out = await delegate!('sys prompt', 'user input');
+
+		expect(out).toBe(RESULT_TEXT);
+		expect(promptCalls[0]).toBeUndefined();
+		expect(promptCalls[1]).toBe('prov/fb1');
+	});
+
+	test('emits telemetry.modelFallback on a quota failover', async () => {
+		seedSkillImproverFallback();
+		const emitted: Array<{ event: string; data: Record<string, unknown> }> = [];
+		telemetryInternals.emit = (event, data) => {
+			emitted.push({ event, data });
+		};
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = fakeClient(async (model) => {
+			if (!model) return QUOTA_ENVELOPE;
+			return OK_ENVELOPE;
+		}, promptCalls);
+
+		const delegate = createSkillImproverLLMDelegate('/tmp/proj', 'sess-1');
+		await delegate!('sys prompt', 'user input');
+
+		const fallbackEvents = emitted.filter((e) => e.event === 'model_fallback');
+		expect(fallbackEvents).toHaveLength(1);
+		expect(fallbackEvents[0]?.data.toModel).toBe('prov/fb1');
+		expect(fallbackEvents[0]?.data.agentName).toBe('skill_improver');
+		expect(fallbackEvents[0]?.data.reason).toBe('transient_model_error');
+	});
+
+	test('a permanent dispatch error does not fail over and surfaces the primary error', async () => {
+		seedSkillImproverFallback();
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = fakeClient(
+			async () => ({
+				data: null,
+				error: {
+					code: 'UNAUTHORIZED',
+					message: '401 unauthorized: invalid api key',
+				},
+			}),
+			promptCalls,
+		);
+
+		const delegate = createSkillImproverLLMDelegate('/tmp/proj', 'sess-1');
+		await expect(delegate!('sys prompt', 'user input')).rejects.toThrow(
+			/401 unauthorized/,
+		);
+		expect(promptCalls).toHaveLength(1);
+		expect(promptCalls[0]).toBeUndefined();
+	});
+
+	test('an abort during dispatch maps to SKILL_IMPROVER_LLM_TIMEOUT with no failover', async () => {
+		seedSkillImproverFallback();
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = fakeClient(async () => {
+			const err = new Error('The operation was aborted');
+			err.name = 'AbortError';
+			throw err;
+		}, promptCalls);
+
+		const delegate = createSkillImproverLLMDelegate('/tmp/proj', 'sess-1');
+		await expect(delegate!('sys prompt', 'user input')).rejects.toThrow(
+			'SKILL_IMPROVER_LLM_TIMEOUT',
+		);
+		expect(promptCalls).toHaveLength(1);
+	});
+
+	test('with no fallback chain configured, a quota error degrades exactly as before (primary error surfaces)', async () => {
+		// Explicitly seed an empty default-swarm config: `_swarmAgentsMap` is
+		// module-global and NOT cleared by resetSwarmState, so this overwrites any
+		// chain a prior test seeded, making the no-fallback case order-independent.
+		getAgentConfigs({ agents: {} } as unknown as PluginConfig);
+		const promptCalls: Array<string | undefined> = [];
+		swarmState.opencodeClient = fakeClient(
+			async () => QUOTA_ENVELOPE,
+			promptCalls,
+		);
+
+		const delegate = createSkillImproverLLMDelegate('/tmp/proj', 'sess-1');
+		await expect(delegate!('sys prompt', 'user input')).rejects.toThrow(
+			/skill_improver LLM prompt failed/,
+		);
+		expect(promptCalls).toHaveLength(1);
+	});
+
+	test('routes failover through the correct swarm chain for a prefixed agent name', async () => {
+		getAgentConfigs({
+			swarms: {
+				swarm1: {
+					name: 'Swarm1',
+					agents: {
+						skill_improver: {
+							model: 'prov/s1-primary',
+							fallback_models: ['prov/s1-fb1'],
+						},
+					},
+				},
+			},
+		} as unknown as PluginConfig);
+		swarmState.skillImproverAgentNames = ['swarm1_skill_improver'];
+		const promptCalls: Array<string | undefined> = [];
+		const agentNames: Array<string | undefined> = [];
+		swarmState.opencodeClient = {
+			session: {
+				create: async () => ({ data: { id: 'skill-improver-session-1' } }),
+				prompt: async (params: {
+					body?: { agent?: string; model?: ModelOverride };
+				}) => {
+					agentNames.push(params.body?.agent);
+					const model = params.body?.model;
+					promptCalls.push(
+						model ? `${model.providerID}/${model.modelID}` : undefined,
+					);
+					if (!model) return QUOTA_ENVELOPE;
+					return OK_ENVELOPE;
+				},
+				delete: async () => ({}),
+			},
+		} as unknown as typeof swarmState.opencodeClient;
+
+		const delegate = createSkillImproverLLMDelegate('/tmp/proj', 'sess-1');
+		const out = await delegate!('sys prompt', 'user input');
+
+		expect(out).toBe(RESULT_TEXT);
+		expect(agentNames[0]).toBe('swarm1_skill_improver');
+		expect(promptCalls[1]).toBe('prov/s1-fb1');
+	});
+});


### PR DESCRIPTION
Closes #1927

## Summary
- The opt-in curator and skill-improver LLM delegate closures (`createCuratorLLMDelegate` in `src/hooks/curator-llm-factory.ts`, `createSkillImproverLLMDelegate` in `src/hooks/skill-improver-llm-factory.ts`) called `client.session.prompt` once with no per-call model override and no transient/quota classification, so a provider quota/rate-limit envelope (`data:null`) failed the opt-in feature outright — the #1896 incident class, deferred for these sites in #1905.
- Both delegates now wrap the prompt in `dispatchWithModelFallback`, resolving the fallback chain via `resolveFallbackModel(baseRole, index, getSwarmAgents(swarmId))`, with `baseRole`/`swarmId` derived from the internally-resolved agent name using `stripKnownSwarmPrefix` (curator/`skill_improver` role names contain underscores, so a naive `_`-split would misread the swarm id).
- `src/agents/index.ts`: `resolveFallbackModel` now also grants `curator_consolidation` explorer-chain inheritance — its model already defaulted to explorer's, so the memory-consolidation dispatch path previously had no failover even after wiring the other three curator modes.
- Timeout/cancellation sentinels are preserved: abort is classified `permanent`, so `dispatchWithModelFallback` rethrows the original `AbortError` into the unchanged outer catch, which still maps it to `CURATOR_LLM_TIMEOUT` / `SKILL_IMPROVER_LLM_TIMEOUT`. With no fallback chain configured, behavior is byte-identical to before.
- Added a recurrence guardrail (`tests/unit/hooks/dispatch-fallback-coverage.test.ts`) that enumerates every production `client.session.prompt` dispatch site and fails if a new one is added without failover wiring and without a reasoned allowlist entry.
- **Follow-up commit (`ce1b13a`):** CI caught a real regression the local scoped test run didn't: `close.test.ts`/`close-finalizer.test.ts` partially mock `state.js` (and a few sibling modules) with only the handful of exports they explicitly care about. Adding the `getSwarmAgents(...)` call inside the delegate closure makes `agents/index.ts` — a large barrel file — reachable from `close.ts` for the first time ever (verified via a load-marker that never fired on clean `origin/main`), which touches several more real exports those partial mocks didn't provide. Fixed by extending the mocks with targeted stubs (real pass-throughs for pure functions, stubs bound to the test's own mocked state for session accessors, safe no-ops for real-I/O functions whose actual entry points are already mocked). A full `...actualState` spread was tried first and rejected — it silently broke an `endAgentSession` call-tracking assertion.

## Invariant audit
- 1 (plugin init): not touched — no init-path work added; the factories' existing imports of `agents/index` (already loaded at init) are unchanged in shape, and all new logic runs only inside the returned delegate closure at call time, never during plugin registration.
- 2 (runtime portability): not touched — no `bun:` imports, no `Bun.*` calls, no plugin-shape change. `tsc --noEmit` clean; no bundle/build change required for this diff.
- 3 (subprocesses): not touched — no subprocess spawned. `git diff --name-only origin/main..HEAD | xargs grep -nE "spawn\(|spawnSync\("` → no matches.
- 4 (.swarm containment): not touched — no filesystem/`.swarm` writes added.
- 5 (plan durability): not touched — no plan/ledger schema or read/write path change.
- 6 (test_runner safety): not touched — validation used `bun test`/`bun run test:unit:ci` with explicit file lists, never `test_runner` with `scope: 'all'`.
- 7 (test writing): touched — 3 new `bun:test` files + 3 modified (`fallback-inheritance.test.ts`, `close.test.ts`, `close-finalizer.test.ts`), DI via the real `swarmState.opencodeClient`/`getAgentConfigs`/targeted mock-object stubs (no new `mock.module` targets beyond the pre-existing ones being extended), each well under the 500-line cap. `scripts/check-mock-cleanup.sh` and `scripts/check-invariants.sh` (mock.module allowlist ratchet: 0 new entries) both pass.
- 8 (session state): not touched — no new module-level session map; telemetry emission is gated on the existing `sessionId` parameter already threaded through both factories.
- 9 (guardrails/retry): touched — model failover is independent of transient retry (`maxTransientRetriesPerModel: 0`, so a quota error advances immediately rather than retrying the same model); `classify` separates transient/quota (`isTransientProviderError`) from permanent/abort. Evidenced by the failover, permanent-error-no-failover, and abort-classified-permanent tests in both new suites.
- 10 (chat/system msg): not touched — no chat/system message emission changed.
- 11 (tool registration): not touched — no new tool/agent/command/map entry added; `resolveFallbackModel`/the two factories are pre-existing exported symbols being extended internally. `scripts/check-tool-registration.ts` passes (112 tools, unchanged coherence).
- 12 (release/cache): touched — added `docs/releases/pending/1927-wire-quota-failover-optin-dispatch.md`; did not edit `package.json` version, `CHANGELOG.md`, or the release-please manifest.

## Test plan
- [x] `bun run typecheck` → exit 0.
- [x] `bun run lint:ci` (pinned Biome) → clean, no fixes applied.
- [x] `bun run scripts/check-tool-registration.ts` → passed (112 tools).
- [x] `bash scripts/check-mock-cleanup.sh` → passed (only pre-existing, unrelated warnings; 0 new violations).
- [x] `bash scripts/check-invariants.sh` → passed (mock.module allowlist ratchet: 0 added).
- [x] `bash scripts/check-cross-contamination.sh` → passed with only pre-existing advisory notices.
- [x] `bash scripts/check-test-clock.sh` → passed (0 new violations; 443 pre-existing, non-blocking).
- [x] `bun run test:unit:ci` scoped to every changed/adjacent file (18 files total, including all 7 repo-wide `mock.module('.../state.js', ...)` test files, run individually to match CI's exact per-file isolation model) → exit 0 for every file.
- [x] Regression proof (fails-before/passes-after) for the core failover fix: stashed the 3 source changes → the two factory fallback suites went from all-pass to 6 pass / 7 fail; restored the fix → all pass again.
- [x] Regression proof for the test-mock fix: bisected in isolated worktrees with fresh `bun install` (ruling out session-local cache artifacts) — confirmed the exact closure-body change that newly reaches `agents/index.ts`, and confirmed via a load-marker that this reachability never existed on clean `origin/main`.
- [x] `bun test tests/integration ./test --timeout 120000` (Tier 3) → 749 pass, 206 fail, 955 total across 78 files.
- [x] **Pre-existing-failure verification** — reproduced the identical Tier 3 run on a clean `origin/main` worktree → **749 pass, 206 fail, byte-identical failing-file set** (`diff` of sorted failing-file lists showed no differences). All 206 failures are pre-existing and unrelated.
- [x] `bun test tests/security --timeout 120000` (Tier 4) → 167 pass, 0 fail.
- [x] `bun test tests/adversarial --timeout 120000` (Tier 4) → 829 pass, 0 fail.
- [x] `bun test tests/smoke --timeout 120000` (Tier 5) → 10 pass, 0 fail.
- Independent plan critic, independent adversarial implementation reviewer, and a distinct final critic all reviewed the original diff (`79459f9`) and returned APPROVE before push; the follow-up test-mock fix (`ce1b13a`) was driven entirely by real CI failures and validated with the same rigor (isolated-worktree bisection, per-file CI-equivalent gate, full regression sweep) before this second push.

## Pre-existing failures
Tier 3 integration: 206 of 955 tests fail identically on this branch and on clean `origin/main` (same 78-file suite, same failing-file set verified by diff). Not carried as new failures; not introduced by this change.

## Waivers (or none)
None.