### PR TITLE
fix(checkpoint): separate auto_checkpoint_threshold from retention (#1691)

### DIFF
--- a/docs/releases/pending/1691-checkpoint-threshold-misuse.md
+++ b/docs/releases/pending/1691-checkpoint-threshold-misuse.md
@@ -1,0 +1,18 @@
+---
+title: Fix auto_checkpoint_threshold misuse as retention cap
+issue: 1691
+---
+
+## What changed
+
+`checkpoint.ts` used `auto_checkpoint_threshold` (intended: number of completed tasks before auto-save) as the checkpoint retention limit. This meant setting `auto_checkpoint_threshold: 3` (to auto-checkpoint every 3 tasks) would also cap retention to only 3 checkpoints.
+
+## Fix
+
+- Added `max_retention: z.number().int().min(1).max(100).default(20)` to checkpoint schema
+- Changed `checkpoint.ts` to use `max_retention` for the retention limit
+- `auto_checkpoint_threshold` now only controls the completed-task auto-save trigger (consumed by update_task_status)
+
+## Acceptance
+
+Setting `auto_checkpoint_threshold: 3` no longer limits retention to 3 checkpoints. Retention defaults to 20 and is independently configurable via `max_retention`.

--- a/docs/releases/pending/1691-checkpoint-threshold-misuse.md
+++ b/docs/releases/pending/1691-checkpoint-threshold-misuse.md
@@ -11,7 +11,7 @@ issue: 1691
 
 - Added `max_retention: z.number().int().min(1).max(100).default(20)` to checkpoint schema
 - Changed `checkpoint.ts` to use `max_retention` for the retention limit
-- `auto_checkpoint_threshold` now only controls the completed-task auto-save trigger (consumed by update_task_status)
+- `auto_checkpoint_threshold` now only controls the completed-task auto-save trigger.
 
 ## Acceptance
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1069,6 +1069,11 @@ export const CheckpointConfigSchema = z.preprocess(
 		.object({
 			enabled: z.boolean().default(true),
 			auto_checkpoint_threshold: z.number().int().min(1).max(20).default(3),
+			// Maximum number of checkpoints to retain in the log. Older entries
+			// are evicted (FIFO) when this limit is exceeded. Distinct from
+			// auto_checkpoint_threshold (which controls how many completed tasks
+			// trigger an auto-checkpoint, consumed by update_task_status).
+			max_retention: z.number().int().min(1).max(100).default(20),
 			// When false (default), checkpoint save skips the git commit if the working
 			// tree is clean, recording only the current HEAD SHA. Set to true to restore
 			// the previous behaviour of creating a git commit even with no file changes.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1072,7 +1072,7 @@ export const CheckpointConfigSchema = z.preprocess(
 			// Maximum number of checkpoints to retain in the log. Older entries
 			// are evicted (FIFO) when this limit is exceeded. Distinct from
 			// auto_checkpoint_threshold (which controls how many completed tasks
-			// trigger an auto-checkpoint, consumed by update_task_status).
+			// trigger an auto-checkpoint).
 			max_retention: z.number().int().min(1).max(100).default(20),
 			// When false (default), checkpoint save skips the git commit if the working
 			// tree is clean, recording only the current HEAD SHA. Set to true to restore

--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -265,8 +265,10 @@ function handleSave(label: string, directory: string): string {
 		let allowEmptyCommits = false;
 		try {
 			const { config } = loadPluginConfigWithMeta(directory);
-			maxCheckpoints =
-				config.checkpoint?.auto_checkpoint_threshold ?? maxCheckpoints;
+			// max_retention controls how many checkpoints are kept (issue #1691).
+			// Previously misused auto_checkpoint_threshold (which controls
+			// completed-task-count auto-save trigger, not retention).
+			maxCheckpoints = config.checkpoint?.max_retention ?? maxCheckpoints;
 			allowEmptyCommits = config.checkpoint?.allow_empty_commits === true;
 		} catch {
 			// Config load failure — use defaults

--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -261,7 +261,7 @@ function isGitRepo(directory: string): GitRepoProbe {
 function handleSave(label: string, directory: string): string {
 	try {
 		// Read checkpoint config
-		let maxCheckpoints = 20; // sensible default
+		let maxCheckpoints = 20; // sensible default (must match max_retention default(20) in CheckpointConfigSchema)
 		let allowEmptyCommits = false;
 		try {
 			const { config } = loadPluginConfigWithMeta(directory);

--- a/tests/adversarial/checkpoint-schema-adversarial.test.ts
+++ b/tests/adversarial/checkpoint-schema-adversarial.test.ts
@@ -146,6 +146,117 @@ describe('ADVERSARIAL: CheckpointConfigSchema security tests', () => {
 	});
 
 	// ============================================
+	// ATTACK VECTOR: Invalid number type for 'max_retention'
+	// ============================================
+	describe('ATTACK VECTOR: Invalid max_retention type', () => {
+		it('rejects string instead of number', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: '5',
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects boolean instead of number', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: true,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects null instead of number', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: null,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('accepts undefined (falls back to default)', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: undefined,
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.max_retention).toBe(20);
+			}
+		});
+
+		it('rejects object instead of number', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: { value: 5 },
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects array instead of number', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: [5],
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects BigInt instead of number', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: BigInt(5),
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects empty string', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: '',
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	// ============================================
+	// ATTACK VECTOR: Out of range values for 'max_retention'
+	// ============================================
+	describe('ATTACK VECTOR: Out of range max_retention', () => {
+		it('rejects value below minimum (0)', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: 0,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects value above maximum (101)', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: 101,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects negative value (-1)', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: -1,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects non-integer (3.5)', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: 3.5,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('accepts default value (20)', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: 20,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it('accepts middle value (50)', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: 50,
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	// ============================================
 	// ATTACK VECTOR: Out of range values for 'auto_checkpoint_threshold'
 	// ============================================
 	describe('ATTACK VECTOR: Out of range auto_checkpoint_threshold', () => {
@@ -502,14 +613,16 @@ describe('ADVERSARIAL: CheckpointConfigSchema security tests', () => {
 			const result = CheckpointConfigSchema.safeParse({
 				enabled: 'true',
 				auto_checkpoint_threshold: '5',
+				max_retention: '20',
 			});
 			expect(result.success).toBe(false);
 		});
 
-		it('rejects enabled as number and threshold as string', () => {
+		it('rejects enabled as number, threshold as string, max_retention as string', () => {
 			const result = CheckpointConfigSchema.safeParse({
 				enabled: 1,
 				auto_checkpoint_threshold: 'abc',
+				max_retention: 'def',
 			});
 			expect(result.success).toBe(false);
 		});
@@ -518,6 +631,7 @@ describe('ADVERSARIAL: CheckpointConfigSchema security tests', () => {
 			const result = CheckpointConfigSchema.safeParse({
 				enabled: true,
 				auto_checkpoint_threshold: 999999,
+				max_retention: 999999,
 				exec: 'malicious',
 			});
 			expect(result.success).toBe(false);
@@ -527,6 +641,7 @@ describe('ADVERSARIAL: CheckpointConfigSchema security tests', () => {
 			const result = CheckpointConfigSchema.safeParse({
 				enabled: { valueOf: () => true },
 				auto_checkpoint_threshold: { valueOf: () => 5 },
+				max_retention: { valueOf: () => 20 },
 			});
 			expect(result.success).toBe(false);
 		});
@@ -542,6 +657,7 @@ describe('ADVERSARIAL: CheckpointConfigSchema security tests', () => {
 			if (result.success) {
 				expect(result.data.enabled).toBe(true);
 				expect(result.data.auto_checkpoint_threshold).toBe(3);
+				expect(result.data.max_retention).toBe(20);
 			}
 		});
 
@@ -569,15 +685,31 @@ describe('ADVERSARIAL: CheckpointConfigSchema security tests', () => {
 			expect(result.success).toBe(true);
 		});
 
+		it('accepts explicit max_retention at min', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: 1,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it('accepts explicit max_retention at max', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: 100,
+			});
+			expect(result.success).toBe(true);
+		});
+
 		it('accepts full explicit config', () => {
 			const result = CheckpointConfigSchema.safeParse({
 				enabled: true,
 				auto_checkpoint_threshold: 5,
+				max_retention: 50,
 			});
 			expect(result.success).toBe(true);
 			if (result.success) {
 				expect(result.data.enabled).toBe(true);
 				expect(result.data.auto_checkpoint_threshold).toBe(5);
+				expect(result.data.max_retention).toBe(50);
 			}
 		});
 

--- a/tests/unit/config/checkpoint-schema-prototype.test.ts
+++ b/tests/unit/config/checkpoint-schema-prototype.test.ts
@@ -44,6 +44,7 @@ describe('CheckpointConfigSchema prototype safety', () => {
 		expect(result).toEqual({
 			enabled: true,
 			auto_checkpoint_threshold: 3,
+			max_retention: 20,
 			allow_empty_commits: false,
 		});
 	});

--- a/tests/unit/config/checkpoint-schema.test.ts
+++ b/tests/unit/config/checkpoint-schema.test.ts
@@ -10,11 +10,12 @@ describe('CheckpointConfigSchema', () => {
 			const result = CheckpointConfigSchema.safeParse({});
 			expect(result.success).toBe(true);
 			if (result.success) {
-				expect(result.data).toEqual({
-					enabled: true,
-					auto_checkpoint_threshold: 3,
-					allow_empty_commits: false,
-				});
+			expect(result.data).toEqual({
+				enabled: true,
+				auto_checkpoint_threshold: 3,
+				max_retention: 20,
+				allow_empty_commits: false,
+			});
 			}
 		});
 
@@ -23,6 +24,7 @@ describe('CheckpointConfigSchema', () => {
 				enabled: false,
 				auto_checkpoint_threshold: 5,
 				allow_empty_commits: false,
+			max_retention: 20,
 			};
 			const result = CheckpointConfigSchema.safeParse(config);
 			expect(result.success).toBe(true);
@@ -212,11 +214,12 @@ describe('CheckpointConfigSchema in PluginConfigSchema', () => {
 		const result = PluginConfigSchema.safeParse(config);
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data.checkpoint).toEqual({
-				enabled: false,
-				auto_checkpoint_threshold: 7,
-				allow_empty_commits: false,
-			});
+		expect(result.data.checkpoint).toEqual({
+			enabled: false,
+			auto_checkpoint_threshold: 7,
+			max_retention: 20,
+			allow_empty_commits: false,
+		});
 		}
 	});
 
@@ -235,11 +238,12 @@ describe('CheckpointConfigSchema in PluginConfigSchema', () => {
 		const result = PluginConfigSchema.safeParse(config);
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data.checkpoint).toEqual({
-				enabled: true,
-				auto_checkpoint_threshold: 3,
-				allow_empty_commits: false,
-			});
+		expect(result.data.checkpoint).toEqual({
+			enabled: true,
+			auto_checkpoint_threshold: 3,
+			max_retention: 20,
+			allow_empty_commits: false,
+		});
 		}
 	});
 

--- a/tests/unit/config/checkpoint-schema.test.ts
+++ b/tests/unit/config/checkpoint-schema.test.ts
@@ -10,12 +10,12 @@ describe('CheckpointConfigSchema', () => {
 			const result = CheckpointConfigSchema.safeParse({});
 			expect(result.success).toBe(true);
 			if (result.success) {
-			expect(result.data).toEqual({
-				enabled: true,
-				auto_checkpoint_threshold: 3,
-				max_retention: 20,
-				allow_empty_commits: false,
-			});
+				expect(result.data).toEqual({
+					enabled: true,
+					auto_checkpoint_threshold: 3,
+					max_retention: 20,
+					allow_empty_commits: false,
+				});
 			}
 		});
 
@@ -24,7 +24,7 @@ describe('CheckpointConfigSchema', () => {
 				enabled: false,
 				auto_checkpoint_threshold: 5,
 				allow_empty_commits: false,
-			max_retention: 20,
+				max_retention: 20,
 			};
 			const result = CheckpointConfigSchema.safeParse(config);
 			expect(result.success).toBe(true);
@@ -214,12 +214,12 @@ describe('CheckpointConfigSchema in PluginConfigSchema', () => {
 		const result = PluginConfigSchema.safeParse(config);
 		expect(result.success).toBe(true);
 		if (result.success) {
-		expect(result.data.checkpoint).toEqual({
-			enabled: false,
-			auto_checkpoint_threshold: 7,
-			max_retention: 20,
-			allow_empty_commits: false,
-		});
+			expect(result.data.checkpoint).toEqual({
+				enabled: false,
+				auto_checkpoint_threshold: 7,
+				max_retention: 20,
+				allow_empty_commits: false,
+			});
 		}
 	});
 
@@ -238,12 +238,12 @@ describe('CheckpointConfigSchema in PluginConfigSchema', () => {
 		const result = PluginConfigSchema.safeParse(config);
 		expect(result.success).toBe(true);
 		if (result.success) {
-		expect(result.data.checkpoint).toEqual({
-			enabled: true,
-			auto_checkpoint_threshold: 3,
-			max_retention: 20,
-			allow_empty_commits: false,
-		});
+			expect(result.data.checkpoint).toEqual({
+				enabled: true,
+				auto_checkpoint_threshold: 3,
+				max_retention: 20,
+				allow_empty_commits: false,
+			});
 		}
 	});
 

--- a/tests/unit/config/checkpoint-schema.test.ts
+++ b/tests/unit/config/checkpoint-schema.test.ts
@@ -160,6 +160,73 @@ describe('CheckpointConfigSchema', () => {
 		});
 	});
 
+	describe('bounds - max_retention', () => {
+		it('accepts minimum boundary: 1', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: 1,
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.max_retention).toBe(1);
+			}
+		});
+
+		it('accepts maximum boundary: 100', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: 100,
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.max_retention).toBe(100);
+			}
+		});
+
+		it('accepts mid-range value: 50', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: 50,
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.max_retention).toBe(50);
+			}
+		});
+
+		it('rejects below minimum: 0', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: 0,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects above maximum: 101', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: 101,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects negative value: -1', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: -1,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects non-integer: 3.5', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: 3.5,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects non-number: "10"', () => {
+			const result = CheckpointConfigSchema.safeParse({
+				max_retention: '10',
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
 	describe('edge cases', () => {
 		it('rejects non-boolean enabled: "true"', () => {
 			const result = CheckpointConfigSchema.safeParse({ enabled: 'true' });

--- a/tests/unit/tools/checkpoint-retention.test.ts
+++ b/tests/unit/tools/checkpoint-retention.test.ts
@@ -32,17 +32,13 @@ describe('checkpoint retention policy', () => {
 		execSync('git add .', { encoding: 'utf-8' });
 		execSync('git commit -m "initial"', { encoding: 'utf-8' });
 
-		// Set auto_checkpoint_threshold in config to match our expected threshold
+		// Set max_retention in config to match our expected retention limit.
 		// Note: loadPluginConfigWithMeta reads from .opencode/opencode-swarm.json, not .swarm/
 		const configDir = path.join(tempDir, '.opencode');
 		fs.mkdirSync(configDir, { recursive: true });
 		fs.writeFileSync(
 			path.join(configDir, 'opencode-swarm.json'),
-			JSON.stringify(
-				{ checkpoint: { auto_checkpoint_threshold: 20 } },
-				null,
-				2,
-			),
+			JSON.stringify({ checkpoint: { max_retention: 20 } }, null, 2),
 		);
 	});
 


### PR DESCRIPTION
## Summary

checkpoint.ts used auto_checkpoint_threshold (intended: completed-task auto-save trigger count) as the checkpoint retention limit. Setting auto_checkpoint_threshold=3 to auto-checkpoint every 3 tasks also capped retention to 3 checkpoints.

## What changed

- Added max_retention (default 20, range 1-100) to checkpoint schema
- checkpoint.ts now uses max_retention for retention limit
- auto_checkpoint_threshold left in schema for backward compatibility
- Added schema bounds tests and adversarial tests for max_retention
- Fixed checkpoint-retention test to use max_retention instead of auto_checkpoint_threshold

## Invariant audit
- 1-12: not touched — schema addition is backward-compatible (new field with default); no init/portability/subprocess changes.

## Test plan
- [x] bun test tests/unit/config/checkpoint-schema.test.ts — passes
- [x] bun test tests/adversarial/checkpoint-schema-adversarial.test.ts — passes
- [x] bun test tests/unit/tools/checkpoint.test.ts — passes

Completes #1691 (final sub-problem).