### PR TITLE
fix(phase-complete): warn on plan-free phases missing reviewer/test_engineer (#1744)

### DIFF
--- a/docs/releases/pending/1744-plan-free-agent-dispatch.md
+++ b/docs/releases/pending/1744-plan-free-agent-dispatch.md
@@ -1,0 +1,16 @@
+---
+title: Plan-free phase agent dispatch warning
+issue: 1744
+---
+
+## What changed
+
+Phase-complete gate now emits a prominent warning when a plan-free session (no `plan.json`) completes a phase without dispatching reviewer or test_engineer. Previously, plan-free phases could pass silently without independent review.
+
+## Fix
+
+Added a plan-free-aware check in `phase_complete` that verifies reviewer/test_engineer were dispatched via cross-session aggregation. When both are missing and no plan.json exists, a prominent `⚠️` warning is added to the phase-complete output and visible in curator compliance reports.
+
+## Acceptance
+
+A plan-free session that modifies code files without dispatching reviewer/test_engineer now produces a visible warning in the phase-complete result. Future curators and post-mortems can detect this gap.

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -1377,7 +1377,12 @@ export async function executePhaseComplete(
 	// the agent-dispatch fallback can't infer from task gates. If reviewer/
 	// test_engineer weren't dispatched independently, emit a prominent warning
 	// so the gap is visible in phase-complete output and curator reports.
-	const hasPlan = fs.existsSync(path.join(dir, '.swarm', 'plan.json'));
+	let hasPlan = false;
+	try {
+		hasPlan = fs.existsSync(validateSwarmPath(dir, 'plan.json'));
+	} catch {
+		// Non-blocking — treat as plan-free if path validation fails
+	}
 	if (
 		!hasPlan &&
 		!crossSessionResult.agents.has('reviewer') &&

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -1373,6 +1373,23 @@ export async function executePhaseComplete(
 		warnings,
 	};
 
+	// Plan-free code-change enforcement (issue #1744): when there's no plan.json,
+	// the agent-dispatch fallback can't infer from task gates. If reviewer/
+	// test_engineer weren't dispatched independently, emit a prominent warning
+	// so the gap is visible in phase-complete output and curator reports.
+	const hasPlan = fs.existsSync(path.join(dir, '.swarm', 'plan.json'));
+	if (
+		!hasPlan &&
+		!crossSessionResult.agents.has('reviewer') &&
+		!crossSessionResult.agents.has('test_engineer')
+	) {
+		warnings.push(
+			`⚠️ Plan-free phase ${phase}: no independent reviewer or test_engineer dispatch detected. ` +
+				`Code changes in plan-free sessions should have independent review. ` +
+				`Consider dispatching reviewer + test_engineer before completing future plan-free phases.`,
+		);
+	}
+
 	// Record retrieval outcome for shown lessons from this phase, using the
 	// REAL outcome. Previously this was hardcoded `true` and ran before `success`
 	// was determined — so a failed phase (policy=enforce + missing required

--- a/tests/unit/tools/phase-complete.test.ts
+++ b/tests/unit/tools/phase-complete.test.ts
@@ -2113,6 +2113,169 @@ describe('phase_complete tool', () => {
 		});
 	});
 
+	describe('plan-free warning', () => {
+		test('warns when plan-free and neither reviewer nor test_engineer dispatched', async () => {
+			// Set up permissive config with coder only
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({
+					phase_complete: {
+						enabled: true,
+						required_agents: ['coder'],
+						require_docs: false,
+						policy: 'warn',
+					},
+				}),
+			);
+
+			// Do NOT write plan.json — simulate plan-free session
+			// Only dispatch coder (not reviewer or test_engineer)
+			ensureAgentSession('sess1');
+			recordPhaseAgentDispatch('sess1', 'coder');
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'sess1',
+			});
+			const parsed = JSON.parse(result);
+
+			// Should still succeed (advisory warning only)
+			expect(parsed.success).toBe(true);
+			// Should include the plan-free warning
+			expect(
+				parsed.warnings.some((w: string) =>
+					w.includes(
+						'Plan-free phase 1: no independent reviewer or test_engineer',
+					),
+				),
+			).toBe(true);
+		});
+
+		test('does NOT warn when plan-free and reviewer was dispatched', async () => {
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({
+					phase_complete: {
+						enabled: true,
+						required_agents: ['coder'],
+						require_docs: false,
+						policy: 'warn',
+					},
+				}),
+			);
+
+			// Do NOT write plan.json
+			// Dispatch coder AND reviewer
+			ensureAgentSession('sess1');
+			recordPhaseAgentDispatch('sess1', 'coder');
+			recordPhaseAgentDispatch('sess1', 'reviewer');
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'sess1',
+			});
+			const parsed = JSON.parse(result);
+
+			expect(parsed.success).toBe(true);
+			// Should NOT include the plan-free warning
+			expect(
+				parsed.warnings.some((w: string) =>
+					w.includes(
+						'Plan-free phase 1: no independent reviewer or test_engineer',
+					),
+				),
+			).toBe(false);
+		});
+
+		test('does NOT warn when plan-free and test_engineer was dispatched', async () => {
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({
+					phase_complete: {
+						enabled: true,
+						required_agents: ['coder'],
+						require_docs: false,
+						policy: 'warn',
+					},
+				}),
+			);
+
+			// Do NOT write plan.json
+			// Dispatch coder AND test_engineer
+			ensureAgentSession('sess1');
+			recordPhaseAgentDispatch('sess1', 'coder');
+			recordPhaseAgentDispatch('sess1', 'test_engineer');
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'sess1',
+			});
+			const parsed = JSON.parse(result);
+
+			expect(parsed.success).toBe(true);
+			// Should NOT include the plan-free warning
+			expect(
+				parsed.warnings.some((w: string) =>
+					w.includes(
+						'Plan-free phase 1: no independent reviewer or test_engineer',
+					),
+				),
+			).toBe(false);
+		});
+
+		test('does NOT warn when plan.json exists even if reviewer/test_engineer are missing', async () => {
+			fs.mkdirSync(path.join(tempDir, '.opencode'), { recursive: true });
+			fs.writeFileSync(
+				path.join(tempDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({
+					phase_complete: {
+						enabled: true,
+						required_agents: ['coder'],
+						require_docs: false,
+						policy: 'warn',
+					},
+				}),
+			);
+
+			// Write plan.json — simulate plan-based session
+			const swarmDir = path.join(tempDir, '.swarm');
+			fs.mkdirSync(swarmDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(swarmDir, 'plan.json'),
+				JSON.stringify({
+					phases: [{ id: 1, status: 'pending', tasks: [] }],
+				}),
+			);
+			// Verify test fixture is correct — plan.json should exist
+			expect(fs.existsSync(path.join(tempDir, '.swarm', 'plan.json'))).toBe(
+				true,
+			);
+
+			// Only dispatch coder — no reviewer/test_engineer
+			ensureAgentSession('sess1');
+			recordPhaseAgentDispatch('sess1', 'coder');
+
+			const result = await phase_complete.execute({
+				phase: 1,
+				sessionID: 'sess1',
+			});
+			const parsed = JSON.parse(result);
+
+			expect(parsed.success).toBe(true);
+			// Should NOT include the plan-free warning because plan.json exists
+			expect(
+				parsed.warnings.some((w: string) =>
+					w.includes(
+						'Plan-free phase 1: no independent reviewer or test_engineer',
+					),
+				),
+			).toBe(false);
+		});
+	});
+
 	describe('bypass behavior validation', () => {
 		/**
 		 * Test 1: Normal mode with spec + drift evidence missing → blocks with DRIFT_VERIFICATION_MISSING


### PR DESCRIPTION
## Summary

Phase-complete gate now warns when plan-free sessions complete phases without dispatching reviewer/test_engineer. Previously these phases passed silently with no independent review.

## What changed

Added a plan-free-aware check in phase_complete that verifies reviewer/test_engineer were dispatched via cross-session aggregation. When both are missing and no plan.json exists, emits a prominent warning.

## Invariant audit
- 1 (plugin init): not touched — warning-only change, no new init-path work
- 2 (runtime portability): not touched — no new imports, no bun: references
- 3 (subprocesses): not touched — no new subprocess calls
- 4 (.swarm containment): touched — reads .swarm/plan.json via validateSwarmPath with try/catch
- 5 (plan durability): not touched — warning-only, no plan schema/ledger changes
- 6 (test_runner safety): not touched — no test_runner changes
- 7 (test writing): touched — 4 new tests added following bun:test + DI patterns
- 8 (session state): not touched — uses existing crossSessionResult.agents
- 9 (guardrails/retry): not touched — no guardrail/retry changes
- 10 (chat/system msg): not touched — no message-shape changes
- 11 (tool registration): not touched — no new tools, no agent-map changes
- 12 (release/cache): not touched — only adds pending release fragment

## Test plan
- [x] bun test tests/unit/tools/phase-complete.test.ts — 59/59 pass
- [x] bun run build — clean
- [x] bun run drift:check — clean
- [x] bunx biome ci src/tools/phase-complete.ts tests/unit/tools/phase-complete.test.ts — clean

Addresses #1744.