### PR TITLE
fix(background): validate revision tokens in commit-count/single-child resolvers

### DIFF
--- a/docs/releases/pending/pr-workflow-revision-token-validation.md
+++ b/docs/releases/pending/pr-workflow-revision-token-validation.md
@@ -1,0 +1,35 @@
+## What changed
+
+`resolveCommitCountSince`/`resolveCommitCountSinceAsync` and
+`resolveIsExactSingleChildCommit`/`resolveIsExactSingleChildCommitAsync` in
+`src/background/workspace-snapshot.ts` now validate the `baseHeadSha`/
+`currentHeadSha` revision tokens they receive with the same
+`isSafeGitRevisionToken` guard their sibling resolvers (`resolveExactMergeBase`,
+`resolvePrReviewDiffStats`) already use, and append a `--` terminator to the
+underlying `rev-list`/`rev-parse --verify` calls.
+
+## Why
+
+These two resolvers built Git command arguments directly from PR-workflow
+state (`baseHeadSha`/`currentHeadSha`) without validating the tokens first.
+`normalizePrHeadSha` only trims and checks non-emptiness, so a value shaped
+like a Git option (for example, starting with `-`) was not rejected before
+reaching the underlying `git rev-list`/`git rev-parse` calls. Because these
+are array-form `spawn`/`spawnSync` invocations (not shell string
+concatenation), classic shell injection was never possible, but an
+option-injection vector against `rev-list`/`rev-parse` remained. Found by an
+automated Copilot review on PR #1952.
+
+## Migration steps
+
+No migration required. Both resolvers now return `null` (their existing
+fail-closed shape) for a revision token that fails validation, instead of
+passing it to Git.
+
+## Breaking changes
+
+None.
+
+## Known caveats
+
+None.

--- a/src/background/workspace-snapshot.ts
+++ b/src/background/workspace-snapshot.ts
@@ -557,11 +557,17 @@ export function resolveCommitCountSince(
 	baseHeadSha: string,
 	currentHeadSha: string,
 ): number | null {
+	if (
+		!isSafeGitRevisionToken(baseHeadSha) ||
+		!isSafeGitRevisionToken(currentHeadSha)
+	)
+		return null;
 	const output = runGit(directory, [
 		'rev-list',
 		'--count',
 		'--ancestry-path',
 		`${baseHeadSha}..${currentHeadSha}`,
+		'--',
 	]);
 	if (!output || !/^\d+$/.test(output)) return null;
 	const count = Number(output);
@@ -574,11 +580,17 @@ export async function resolveCommitCountSinceAsync(
 	baseHeadSha: string,
 	currentHeadSha: string,
 ): Promise<number | null> {
+	if (
+		!isSafeGitRevisionToken(baseHeadSha) ||
+		!isSafeGitRevisionToken(currentHeadSha)
+	)
+		return null;
 	const output = await runGitAsync(directory, [
 		'rev-list',
 		'--count',
 		'--ancestry-path',
 		`${baseHeadSha}..${currentHeadSha}`,
+		'--',
 	]);
 	if (!output || !/^\d+$/.test(output)) return null;
 	const count = Number(output);
@@ -591,15 +603,22 @@ export function resolveIsExactSingleChildCommit(
 	baseHeadSha: string,
 	currentHeadSha: string,
 ): boolean | null {
+	if (
+		!isSafeGitRevisionToken(baseHeadSha) ||
+		!isSafeGitRevisionToken(currentHeadSha)
+	)
+		return null;
 	const base = runGit(directory, [
 		'rev-parse',
 		'--verify',
 		`${baseHeadSha}^{commit}`,
+		'--',
 	]);
 	const current = runGit(directory, [
 		'rev-parse',
 		'--verify',
 		`${currentHeadSha}^{commit}`,
+		'--',
 	]);
 	if (!base || !current) return null;
 	const commitAndParents = runGit(directory, [
@@ -624,15 +643,22 @@ export async function resolveIsExactSingleChildCommitAsync(
 	baseHeadSha: string,
 	currentHeadSha: string,
 ): Promise<boolean | null> {
+	if (
+		!isSafeGitRevisionToken(baseHeadSha) ||
+		!isSafeGitRevisionToken(currentHeadSha)
+	)
+		return null;
 	const base = await runGitAsync(directory, [
 		'rev-parse',
 		'--verify',
 		`${baseHeadSha}^{commit}`,
+		'--',
 	]);
 	const current = await runGitAsync(directory, [
 		'rev-parse',
 		'--verify',
 		`${currentHeadSha}^{commit}`,
+		'--',
 	]);
 	if (!base || !current) return null;
 	const commitAndParents = await runGitAsync(directory, [

--- a/tests/unit/background/workspace-snapshot-pr-review-triggers.test.ts
+++ b/tests/unit/background/workspace-snapshot-pr-review-triggers.test.ts
@@ -2,12 +2,14 @@ import { afterEach, describe, expect, mock, test } from 'bun:test';
 import {
 	_internals,
 	resolveCommitCountSince,
+	resolveCommitCountSinceAsync,
 	resolveCurrentUpstreamPushTarget,
 	resolveCurrentUpstreamRemoteRef,
 	resolveExactMergeBase,
 	resolveExactRemoteBranchHead,
 	resolveGitControlStateDigest,
 	resolveIsExactSingleChildCommit,
+	resolveIsExactSingleChildCommitAsync,
 	resolveIsWorkingTreeClean,
 	resolvePrReviewDiffStats,
 	resolveRemoteRefsContainingHead,
@@ -184,6 +186,33 @@ describe('PR workflow Git publication observations', () => {
 		expect(resolveCommitCountSince('.', 'base', 'current')).toBe(1);
 	});
 
+	test('commit count rejects unsafe revision tokens before reaching Git', async () => {
+		const spawn = mock(() => ({
+			status: 0,
+			signal: null,
+			pid: 1,
+			output: [],
+			stdout: '1\n',
+			stderr: '',
+		}));
+		_internals.spawnSync = spawn as typeof _internals.spawnSync;
+
+		expect(resolveCommitCountSince('.', '--upload-pack=evil', 'current')).toBe(
+			null,
+		);
+		expect(resolveCommitCountSince('.', 'base', '--upload-pack=evil')).toBe(
+			null,
+		);
+		expect(spawn).not.toHaveBeenCalled();
+
+		await expect(
+			resolveCommitCountSinceAsync('.', '--upload-pack=evil', 'current'),
+		).resolves.toBeNull();
+		await expect(
+			resolveCommitCountSinceAsync('.', 'base', '--upload-pack=evil'),
+		).resolves.toBeNull();
+	});
+
 	test('clean proof includes tracked, staged, and untracked worktree state', () => {
 		_internals.spawnSync = mock((_command, args) => ({
 			status: 0,
@@ -241,6 +270,37 @@ describe('PR workflow Git publication observations', () => {
 		}) as typeof _internals.spawnSync;
 
 		expect(resolveIsExactSingleChildCommit('.', 'base', 'current')).toBe(false);
+	});
+
+	test('single-child-commit proof rejects unsafe revision tokens before reaching Git', async () => {
+		const spawn = mock(() => ({
+			status: 0,
+			signal: null,
+			pid: 1,
+			output: [],
+			stdout: 'irrelevant\n',
+			stderr: '',
+		}));
+		_internals.spawnSync = spawn as typeof _internals.spawnSync;
+
+		expect(
+			resolveIsExactSingleChildCommit('.', '--upload-pack=evil', 'current'),
+		).toBe(null);
+		expect(
+			resolveIsExactSingleChildCommit('.', 'base', '--upload-pack=evil'),
+		).toBe(null);
+		expect(spawn).not.toHaveBeenCalled();
+
+		await expect(
+			resolveIsExactSingleChildCommitAsync(
+				'.',
+				'--upload-pack=evil',
+				'current',
+			),
+		).resolves.toBeNull();
+		await expect(
+			resolveIsExactSingleChildCommitAsync('.', 'base', '--upload-pack=evil'),
+		).resolves.toBeNull();
 	});
 });
 


### PR DESCRIPTION
## Summary

- Follow-up to #1952 (merged). A Copilot automated review on that PR flagged that `resolveIsExactSingleChildCommitAsync` forwards revision tokens to Git without validating them or terminating option parsing with `--`; I confirmed the same gap also exists in the sync twin and in both twins of `resolveCommitCountSince`.
- `resolveCommitCountSince`/`resolveCommitCountSinceAsync` and `resolveIsExactSingleChildCommit`/`resolveIsExactSingleChildCommitAsync` in `src/background/workspace-snapshot.ts` built Git command args directly from `baseHeadSha`/`currentHeadSha` without the `isSafeGitRevisionToken` guard their sibling resolvers (`resolveExactMergeBase`, `resolvePrReviewDiffStats`) already use. `normalizePrHeadSha` only trims and checks non-emptiness, so a value shaped like a Git option was not rejected before reaching `git rev-list`/`git rev-parse`.
- These are array-form `spawn`/`spawnSync` invocations (not shell string concatenation), so classic shell injection was never possible — this closes an option-injection vector, not a shell-injection one.
- Adds the same `isSafeGitRevisionToken` guard to both sync/async twins of both functions, plus a `--` terminator. I verified directly against real Git (throwaway repo) that a trailing `--` does not change `rev-list --ancestry-path`/`rev-parse --verify` semantics — `rev-parse --verify` rejects a *leading* `--` before the revision (`fatal: Needed a single revision`), so the terminator is placed after the token in both cases.
- Adds direct regression tests proving an unsafe token (`--upload-pack=evil`) is rejected before any Git process runs, for all four functions.

## Invariant audit
- 1 (plugin init): not touched
- 2 (runtime portability): not touched - no `bun:`/`Bun.*` calls added
- 3 (subprocesses): touched - no new `spawn`/`spawnSync` call sites: `git diff --name-only origin/main..HEAD | xargs -r grep -nE "bunSpawn\(|spawn\(|spawnSync\("` shows only the pre-existing `runGit`/`runGitAsync` wrapper primitives; this diff only adds a validation guard and a `--` array element to existing calls
- 4 (.swarm containment): not touched
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched
- 7 (test writing): touched - new tests use `bun:test` and the pre-existing `_internals.spawnSync` DI seam (no `mock.module`)
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched - no new tools
- 12 (release/cache): touched (fragment only) - `docs/releases/pending/pr-workflow-revision-token-validation.md` added

## Test plan
- [x] `bun run build`, `node scripts/repro-704.mjs`, dist import — all pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint:ci` (pinned Biome) — clean
- [x] `bash scripts/check-invariants.sh`, `check-mock-cleanup.sh`, `check-cross-contamination.sh`, `check-test-clock.sh` — all clean, 0 new violations
- [x] `bun run scripts/check-tool-registration.ts` — 112 tools coherent
- [x] `bun run test:unit:ci` scoped to the 4 directly-affected files — all exit 0
- [x] New tests: unsafe token (`--upload-pack=evil`) rejected before any Git process runs, for `resolveCommitCountSince`, `resolveCommitCountSinceAsync`, `resolveIsExactSingleChildCommit`, `resolveIsExactSingleChildCommitAsync`
- [x] `bun test tests/security --timeout 120000` — 167 pass, 0 fail
- [x] `bun test tests/adversarial --timeout 120000` — 829 pass, 0 fail
- [x] `bun test tests/smoke --timeout 120000` — 10 pass, 0 fail

## Known caveats
None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C72Mei7L3R5bztMbVpMnFA)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

