### PR TITLE
fix(skills): remove git stash instructions from subagent pre-flight checks

### DIFF
--- a/.opencode/skills/codebase-review-swarm/SKILL.md
+++ b/.opencode/skills/codebase-review-swarm/SKILL.md
@@ -72,10 +72,13 @@ explorer or candidate-generation dispatch:
 
 1. Verify the working tree is clean with `git status --porcelain`. If
    uncommitted changes exist, **you (the orchestrator)** must handle them
-   before any explorer/candidate dispatch — use a temporary save branch
-   (`git branch tmp/save-<topic>`), a git worktree (see `running-tests`
-   skill precedent), or `prepare_pr_workflow_checkout` if the controller tool
-   is available. **Never delegate `git stash`, `git reset`, `git checkout -- .`,
+   before any explorer/candidate dispatch — use `prepare_pr_workflow_checkout`
+   (the controller-owned path; it preserves every dirty path — including
+   untracked files when called with no `paths` argument — and returns a recovery
+   command), or a git worktree (see `running-tests` skill precedent). Note:
+   `git branch tmp/save-<topic>` only moves the HEAD ref — it does not record or
+   preserve uncommitted working-tree changes, so do not rely on it to save dirty
+   work. **Never delegate `git stash`, `git reset`, `git checkout -- .`,
    or `git restore` to subagents** — these are worktree-global operations that
    destroy sibling agents' in-flight work under parallel execution.
 2. Fetch and check out the PR head branch locally. Explorer agents read the

--- a/.opencode/skills/codebase-review-swarm/SKILL.md
+++ b/.opencode/skills/codebase-review-swarm/SKILL.md
@@ -71,14 +71,27 @@ When the review target is a PR branch or commit range, complete this before any
 explorer or candidate-generation dispatch:
 
 1. Verify the working tree is clean with `git status --porcelain`. If
-   uncommitted changes exist, stash them or abort the checkout to prevent data
-   loss.
+   uncommitted changes exist, **you (the orchestrator)** must handle them
+   before any explorer/candidate dispatch — use a temporary save branch
+   (`git branch tmp/save-<topic>`), a git worktree (see `running-tests`
+   skill precedent), or `prepare_pr_workflow_checkout` if the controller tool
+   is available. **Never delegate `git stash`, `git reset`, `git checkout -- .`,
+   or `git restore` to subagents** — these are worktree-global operations that
+   destroy sibling agents' in-flight work under parallel execution.
 2. Fetch and check out the PR head branch locally. Explorer agents read the
    working-tree filesystem (`Read`/`Glob`/`Grep`), not git history, so reviewing
    a PR while the base branch is checked out produces invalid candidates.
 3. Record the exact commit range (`base_ref..head_ref`) in the source-of-truth
    packet and pass that range in every explorer/candidate-generation delegation
    so agents have revision context for targeted `git show` inspection.
+
+**Subagent prohibition — must reach every subagent prompt:**
+Include this line verbatim in every explorer/candidate-generation lane
+or subagent dispatch prompt:
+"You are a subagent sharing a worktree with sibling agents. You MUST
+NOT run `git stash`, `git reset`, `git checkout -- .`, `git restore`,
+or any other worktree-global destructive git command. These destroy
+sibling agents' in-flight work without error."
 
 ## Async advisory lanes
 

--- a/.opencode/skills/codebase-review-swarm/references/review-protocol-v8.2.md
+++ b/.opencode/skills/codebase-review-swarm/references/review-protocol-v8.2.md
@@ -197,10 +197,13 @@ candidate-generation dispatch:
 
 1. Verify the working tree is clean with `git status --porcelain`. If
    uncommitted changes exist, **you (the orchestrator)** must handle them
-   before any explorer/candidate dispatch — use a temporary save branch
-   (`git branch tmp/save-<topic>`), a git worktree (see `running-tests`
-   skill precedent), or `prepare_pr_workflow_checkout` if the controller tool
-   is available. **Never delegate `git stash`, `git reset`, `git checkout -- .`,
+   before any explorer/candidate dispatch — use `prepare_pr_workflow_checkout`
+   (the controller-owned path; it preserves every dirty path — including
+   untracked files when called with no `paths` argument — and returns a recovery
+   command), or a git worktree (see `running-tests` skill precedent). Note:
+   `git branch tmp/save-<topic>` only moves the HEAD ref — it does not record or
+   preserve uncommitted working-tree changes, so do not rely on it to save dirty
+   work. **Never delegate `git stash`, `git reset`, `git checkout -- .`,
    or `git restore` to subagents** — these are worktree-global operations that
    destroy sibling agents' in-flight work under parallel execution.
 2. Fetch and check out the PR head branch locally. Explorer agents read the

--- a/.opencode/skills/codebase-review-swarm/references/review-protocol-v8.2.md
+++ b/.opencode/skills/codebase-review-swarm/references/review-protocol-v8.2.md
@@ -196,14 +196,27 @@ If the review target is a PR branch or commit range, complete this before Phase 
 candidate-generation dispatch:
 
 1. Verify the working tree is clean with `git status --porcelain`. If
-   uncommitted changes exist, stash them or abort the checkout to prevent data
-   loss.
+   uncommitted changes exist, **you (the orchestrator)** must handle them
+   before any explorer/candidate dispatch — use a temporary save branch
+   (`git branch tmp/save-<topic>`), a git worktree (see `running-tests`
+   skill precedent), or `prepare_pr_workflow_checkout` if the controller tool
+   is available. **Never delegate `git stash`, `git reset`, `git checkout -- .`,
+   or `git restore` to subagents** — these are worktree-global operations that
+   destroy sibling agents' in-flight work under parallel execution.
 2. Fetch and check out the PR head branch locally. Explorer agents read the
    working-tree filesystem (`Read`/`Glob`/`Grep`), not git history; without the
    checkout, they inspect the base branch and produce invalid candidates.
 3. Record `base_ref..head_ref` in `source-of-truth-packet.md` and pass that
    commit range in every explorer/candidate-generation delegation so lanes can
    use `git show` for revision-specific inspection.
+
+**Subagent prohibition — must reach every subagent prompt:**
+Include this line verbatim in every explorer/candidate-generation
+subagent dispatch prompt:
+"You are a subagent sharing a worktree with sibling agents. You MUST
+NOT run `git stash`, `git reset`, `git checkout -- .`, `git restore`,
+or any other worktree-global destructive git command. These destroy
+sibling agents' in-flight work without error."
 
 ### 0K — User review mode gate
 

--- a/.opencode/skills/swarm-implement/SKILL.md
+++ b/.opencode/skills/swarm-implement/SKILL.md
@@ -75,8 +75,13 @@ When implementation or review-scoping work depends on explorer agents reading a
 PR branch or commit range, complete this before Phase 1 explorer dispatch:
 
 1. Verify the working tree is clean with `git status --porcelain`. If
-   uncommitted changes exist, stash them or abort the checkout to prevent data
-   loss.
+   uncommitted changes exist, **you (the orchestrator)** must handle them
+   before Phase 1 dispatch — use a temporary save branch
+   (`git branch tmp/save-<topic>`), a git worktree (see `running-tests`
+   skill precedent), or `prepare_pr_workflow_checkout` if the controller tool
+   is available. **Never delegate `git stash`, `git reset`, `git checkout -- .`,
+   or `git restore` to subagents** — these are worktree-global operations that
+   destroy sibling agents' in-flight work under parallel execution.
 2. Fetch and check out the PR head branch locally. Explorer agents read files
    from the working tree (`Read`/`Glob`/`Grep`), not from git history, so a stale
    checkout makes them inspect the base branch.
@@ -89,6 +94,13 @@ PR branch or commit range, complete this before Phase 1 explorer dispatch:
 Launch parallel subagents for disjoint investigation tasks such as repository
 mapping, locating existing patterns, finding tests/contracts, side-effect
 analysis, and dependency or migration checks. Keep the main context focused.
+
+**Subagent prohibition — must reach every subagent prompt:**
+Include this line verbatim in every subagent dispatch prompt:
+"You are a subagent sharing a worktree with sibling agents. You MUST
+NOT run `git stash`, `git reset`, `git checkout -- .`, `git restore`,
+or any other worktree-global destructive git command. These destroy
+sibling agents' in-flight work without error."
 
 ### Phase 2 - Plan
 

--- a/.opencode/skills/swarm-implement/SKILL.md
+++ b/.opencode/skills/swarm-implement/SKILL.md
@@ -76,10 +76,13 @@ PR branch or commit range, complete this before Phase 1 explorer dispatch:
 
 1. Verify the working tree is clean with `git status --porcelain`. If
    uncommitted changes exist, **you (the orchestrator)** must handle them
-   before Phase 1 dispatch — use a temporary save branch
-   (`git branch tmp/save-<topic>`), a git worktree (see `running-tests`
-   skill precedent), or `prepare_pr_workflow_checkout` if the controller tool
-   is available. **Never delegate `git stash`, `git reset`, `git checkout -- .`,
+   before Phase 1 dispatch — use `prepare_pr_workflow_checkout` (the
+   controller-owned path; it preserves every dirty path — including untracked
+   files when called with no `paths` argument — and returns a recovery command),
+   or a git worktree (see `running-tests` skill precedent). Note: `git branch
+   tmp/save-<topic>` only moves the HEAD ref — it does not record or preserve
+   uncommitted working-tree changes, so do not rely on it to save dirty work.
+   **Never delegate `git stash`, `git reset`, `git checkout -- .`,
    or `git restore` to subagents** — these are worktree-global operations that
    destroy sibling agents' in-flight work under parallel execution.
 2. Fetch and check out the PR head branch locally. Explorer agents read files

--- a/docs/releases/pending/fix-git-stash-subagent-data-loss.md
+++ b/docs/releases/pending/fix-git-stash-subagent-data-loss.md
@@ -1,0 +1,14 @@
+## Fix: `swarm-implement` and `codebase-review-swarm` no longer instruct subagents to `git stash`
+
+**Issue:** #1970 — Both skills told subagents to `git stash` dirty worktrees
+before checkout. Under parallel subagent execution, this is worktree-global and
+silently destroys sibling agents' in-flight work.
+
+**Fix:** The stash instruction is now orchestrator-owned with safe alternatives
+(save branch, git worktree, controller tool). An explicit subagent prohibition
+against destructive git operations (`stash`, `reset`, `checkout -- .`,
+`restore`) is added to the delegation contract so it reaches agents that never
+read the pre-flight section.
+
+**Consistency:** Follows the same pattern as `swarm-pr-review`,
+`swarm-pr-feedback`, and `running-tests`, which already prohibit blind stash.

--- a/docs/releases/pending/fix-git-stash-subagent-data-loss.md
+++ b/docs/releases/pending/fix-git-stash-subagent-data-loss.md
@@ -1,14 +1,28 @@
-## Fix: `swarm-implement` and `codebase-review-swarm` no longer instruct subagents to `git stash`
+# `swarm-implement` and `codebase-review-swarm` no longer instruct subagents to `git stash`
 
 **Issue:** #1970 — Both skills told subagents to `git stash` dirty worktrees
 before checkout. Under parallel subagent execution, this is worktree-global and
 silently destroys sibling agents' in-flight work.
 
-**Fix:** The stash instruction is now orchestrator-owned with safe alternatives
-(save branch, git worktree, controller tool). An explicit subagent prohibition
-against destructive git operations (`stash`, `reset`, `checkout -- .`,
-`restore`) is added to the delegation contract so it reaches agents that never
-read the pre-flight section.
+**Fix:** The stash instruction is now orchestrator-owned. The recommended safe
+alternatives are the controller-owned `prepare_pr_workflow_checkout` (preserves
+every dirty path, including untracked files, and returns a recovery command) and
+a git worktree. The skills now also warn that `git branch tmp/save-<topic>` only
+moves the HEAD ref and does not preserve uncommitted changes, so it must not be
+relied on to save dirty work. An explicit subagent prohibition against
+destructive git operations (`stash`, `reset`, `checkout -- .`, `restore`) is
+added to the delegation contract so it reaches agents that never read the
+pre-flight section.
 
 **Consistency:** Follows the same pattern as `swarm-pr-review`,
 `swarm-pr-feedback`, and `running-tests`, which already prohibit blind stash.
+
+**Scope note:** This fix is scoped to the parallel-subagent dispatch skills named
+in #1970 (`swarm-implement`, `codebase-review-swarm`), where `git stash` is
+worktree-global and destroys sibling agents' work. `.claude/skills/commit-pr/SKILL.md`
+recommends "temporary save branches over `git stash`" as a session-hygiene hint; it
+is a serial orchestrator-only skill (no parallel subagents), pre-existing on `main`,
+and intentionally cited by #1970 as the precedent for this fix — so it is out of
+scope here. If tightened later, "save branch" should specify the commit step, since a
+bare `git branch <name>` moves only the HEAD ref and does not preserve uncommitted
+changes.


### PR DESCRIPTION
# PR Body — Fix for Issue #1970

## Summary

`swarm-implement` and `codebase-review-swarm` told subagents to `git stash` dirty worktrees before checkout. Under parallel subagent execution (which both skills mandate), `git stash` is worktree-global and silently destroys sibling agents' in-flight work. No error signal — all agents report success, but the work is gone.

## Changes

**Three files edited (all canonical `.opencode` sources):**

1. **`.opencode/skills/swarm-implement/SKILL.md`** — Phase 0b stash instruction replaced with orchestrator-owned alternatives (`prepare_pr_workflow_checkout`, git worktree) and an explicit warning that a bare `git branch tmp/save-<topic>` does not preserve uncommitted changes. Phase 1 prohibition block added for subagent dispatch prompts.

2. **`.opencode/skills/codebase-review-swarm/SKILL.md`** — Pre-flight stash instruction replaced with the same orchestrator-owned alternatives + `git branch` warning. Prohibition block added adjacent to dispatch instructions.

3. **`.opencode/skills/codebase-review-swarm/references/review-protocol-v8.2.md`** — Section 0J-bis stash instruction replaced. Prohibition block added.

**One file created:**
- `docs/releases/pending/fix-git-stash-subagent-data-loss.md`

## Follow-up (swarm-pr-feedback)

A `swarm-pr-review` run identified that the first revision's recommended alternative "use a temporary save branch (`git branch tmp/save-<topic>`)" was itself misleading/unsafe: `git branch <name>` only moves the HEAD ref and does not record or preserve uncommitted working-tree changes. An orchestrator following it literally would not actually save dirty work before checkout. The fix was verified (PRR-001) and addressed by leading with the genuinely-safe alternatives (`prepare_pr_workflow_checkout`, which preserves every dirty path including untracked files when called with no `paths` and returns a recovery command; and a git worktree) and adding an explicit warning against relying on a bare `git branch` to save dirty work. The release fragment includes a scope note recording that `.claude/skills/commit-pr:80` (the precedent cited by #1970) is intentionally out of scope as a serial orchestrator-only skill.

## Consistency

Follows the same pattern already established in `swarm-pr-review`, `swarm-pr-feedback`, and `running-tests`, which prohibit blind stash and use the controller tool or git worktrees instead.

## Invariant audit

- 1 (plugin init): not touched — documentation-only change
- 2 (runtime portability): not touched
- 3 (subprocesses): not touched
- 4 (.swarm containment): not touched
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched
- 7 (test writing): not touched
- 8 (session state): not touched
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched — `bun run drift:check` clean; `prepare_pr_workflow_checkout` is referenced (not changed) and is a real, registered tool (`src/tools/index.ts:185`)
- 12 (release/cache): touched — release fragment created under `docs/releases/pending/`. Verified by `bun run drift:check` (clean).

## Test plan

- `bun run drift:check` — clean (no drift across skills, tools, commands, agents, docs claims)
- `bun run scripts/check-skill-assertions.ts` — 3 skill files changed, 0 broken assertions
- Grep for "stash them or abort" — zero results in all skill trees
- Grep for `git branch tmp/save` — appears only in the explicit "do not rely on it" warning, never as a recommended option
- Grep for stash in `.agents/skills/` and `.claude/skills/` — zero results in relevant adapter shims (confirmed thin pointers)
- Three-model verification of the follow-up: independent reviewer (GLM-5.2, APPROVE @ 0.93) and final critic (Kimi K3, APPROVE @ 92/100). Original review: implementer (GLM-5.2), independent reviewer (Kimi K2.7, APPROVE), final critic (Kimi K3, APPROVE).

Closes #1970
