### PR TITLE
fix(guardrails): make allowedPrefix block reason disclose allowed patterns

### DIFF
--- a/docs/releases/pending/1984-actionable-allowed-prefix-block-message.md
+++ b/docs/releases/pending/1984-actionable-allowed-prefix-block-message.md
@@ -1,0 +1,68 @@
+# Actionable WRITE BLOCKED message for non-coder agents
+
+## What
+
+Resolves #1984. When a non-coder write-capable agent (e.g. `test_engineer`,
+`docs`, `designer`, `critic`) attempts to write a file that does not match its
+authority rules, the Step 8 `allowedPrefix` block reason now discloses the
+agent's own effective allow patterns so the agent can self-correct in one step
+instead of looping on filename guessing.
+
+Before:
+```
+WRITE BLOCKED: Agent "test_engineer" is not authorised to write "phpr-mcp/test-build.mjs". Reason: Path phpr-mcp/test-build.mjs not in allowed list for test_engineer
+```
+
+After:
+```
+WRITE BLOCKED: Agent "test_engineer" is not authorised to write "phpr-mcp/test-build.mjs". Reason: Path phpr-mcp/test-build.mjs not in allowed list for test_engineer. Allowed prefixes: tests/, test/, .swarm/evidence/. Allowed globs: **/tests/**, **/test/**, **/__tests__/**, **/*.test.*, **/*.spec.*, … . Allowed case-sensitive globs: *Test.java, …. Block rules (blocked zones/prefixes/globs/exact) and universal deny paths still apply.
+```
+
+The change is a string-only enrichment of the two Step 8 return reasons in
+`src/hooks/guardrails/file-authority.ts` (a new module-local `formatAllowedHints`
+helper). The hint lists four separate categories — `Allowed exact paths`,
+`Allowed prefixes`, `Allowed globs`, and `Allowed case-sensitive globs` (the
+case-sensitive category is kept separate so an agent is not misled into a
+wrong-case filename, e.g. `contest.java` matching `*Test.java`). Each category
+caps at 20 entries (every built-in rule fits) with an accurate `… (+N more)`
+tail, and a trailing caveat notes that block rules and universal deny paths
+still apply.
+
+Security: the hint discloses ONLY the current agent's own positive permissions —
+never `blocked*` rules, universal deny prefixes, or any other agent's policy.
+
+## Why
+
+The previous opaque message named *what* was blocked and *which agent* was
+blocked, but never *what would be allowed*. The reason is surfaced verbatim to
+the LLM agent (via the fail-closed `tool.execute.before` chain), so an agent had
+no way to derive the correct filename without reading plugin source. In the
+reporter's run this caused a 3-attempt guess-and-retry loop, each attempt
+re-analyzing the codebase and re-running the full test suite — hundreds of
+wasted tool calls per occurrence. The aggravator (`declare_scope` being
+coder-only by design, so the architect's scope declaration has no effect on
+non-coder roles) is unchanged and is a separate, larger enhancement (see
+follow-ups).
+
+## Migration
+
+No breaking changes. The literal phrase `Path <path> not in allowed list for
+<agent>` is preserved as the reason prefix, so any tooling or assertions that
+match on that substring keep working. The appended hint is purely additive.
+User-configured per-project authority rules (`guardrails.authority.rules.<agent>`
+in `.opencode/opencode-swarm.json`) are surfaced the same way — the hint
+reflects the merged effective rules, including overrides.
+
+## Caveats
+
+- This implements Suggested Fix #1 (actionable message) from the issue. The
+  issue's larger asks are intentionally out of scope for this change and tracked
+  as follow-ups:
+  - Fix #2: a write-grant / `declare_scope` extension for non-coder roles (a
+    security-sensitive design change; the coder-only bypass is intentional).
+  - Fix #3: pre-dispatch validation of declared output files against the target
+    agent's authority rules.
+  - Fix #4 (broader): per-role write-authority guidance in agent prompts.
+- The hint is a necessary-but-not-sufficient guide: a path matching a listed
+  allow pattern can still be blocked by a `blocked` rule or universal deny
+    prefix. The trailing caveat states this explicitly.

--- a/src/hooks/guardrails/file-authority.ts
+++ b/src/hooks/guardrails/file-authority.ts
@@ -516,6 +516,60 @@ function isInDeclaredScope(
 }
 
 /**
+ * Maximum number of entries rendered per allow-pattern category in a Step 8
+ * block reason. Generous so every built-in rule shows in full (the largest is
+ * test_engineer's 15 ordinary globs at the time of writing); only pathological
+ * custom configs truncate, with an accurate omitted-count tail. Keeps the
+ * surfaced WRITE BLOCKED message bounded.
+ */
+const MAX_ALLOWED_HINT_ENTRIES = 20;
+
+/**
+ * Formats an agent's effective positive allow patterns into a hint appended to a
+ * Step 8 allowedPrefix block reason, so a blocked agent can self-correct (rename
+ * / redirect the file) instead of guessing.
+ *
+ * SECURITY: discloses ONLY the current agent's OWN positive permissions — never
+ * blocked* rules, universal deny prefixes, or any other agent's policy. Allow
+ * patterns are necessary-but-not-sufficient: blocked zones/prefixes/globs and
+ * universal deny paths still take precedence, which the trailing caveat states
+ * so a looping agent does not assume every listed pattern will succeed.
+ *
+ * Categories are rendered separately (exact paths, prefixes, globs, and
+ * case-sensitive globs) because they have distinct matching semantics — in
+ * particular `allowedCaseSensitiveGlobs` must not be merged into the
+ * case-insensitive globs list (e.g. `*Test.java` is case-sensitive; merging it
+ * could mislead an agent into a wrong-case filename).
+ */
+function formatAllowedHints(rules: AgentRule): string {
+	const fmt = (items: string[] | undefined): string => {
+		if (!items || items.length === 0) return '(none)';
+		if (items.length <= MAX_ALLOWED_HINT_ENTRIES) return items.join(', ');
+		const omitted = items.length - MAX_ALLOWED_HINT_ENTRIES;
+		return `${items.slice(0, MAX_ALLOWED_HINT_ENTRIES).join(', ')}, … (+${omitted} more)`;
+	};
+	const parts: string[] = [];
+	// Order mirrors the DENY-first evaluation so the hint reads like the rule model.
+	if (rules.allowedExact && rules.allowedExact.length > 0) {
+		parts.push(`Allowed exact paths: ${fmt(rules.allowedExact)}`);
+	}
+	parts.push(`Allowed prefixes: ${fmt(rules.allowedPrefix)}`);
+	parts.push(`Allowed globs: ${fmt(rules.allowedGlobs)}`);
+	if (
+		rules.allowedCaseSensitiveGlobs &&
+		rules.allowedCaseSensitiveGlobs.length > 0
+	) {
+		parts.push(
+			`Allowed case-sensitive globs: ${fmt(rules.allowedCaseSensitiveGlobs)}`,
+		);
+	}
+	parts.push(
+		'Block rules (blocked zones/prefixes/globs/exact) and universal deny paths still apply.',
+	);
+	return parts.join(' ');
+}
+
+/**
  * Checks file path authority against a pre-computed rules map.
  * Implements DENY-first evaluation order:
  * 1. readOnly - blocks all writes
@@ -733,7 +787,7 @@ export function checkFileAuthorityWithRules(
 			if (!isAllowed) {
 				return {
 					allowed: false,
-					reason: `Path ${normalizedPath} not in allowed list for ${normalizedAgent}`,
+					reason: `Path ${normalizedPath} not in allowed list for ${normalizedAgent}. ${formatAllowedHints(rules)}`,
 				};
 			}
 		} else if (
@@ -743,7 +797,7 @@ export function checkFileAuthorityWithRules(
 			// Empty allowedPrefix means nothing is allowed by prefix
 			return {
 				allowed: false,
-				reason: `Path ${normalizedPath} not in allowed list for ${normalizedAgent}`,
+				reason: `Path ${normalizedPath} not in allowed list for ${normalizedAgent}. ${formatAllowedHints(rules)}`,
 			};
 		}
 	}

--- a/tests/unit/hooks/guardrails-allowed-hints.test.ts
+++ b/tests/unit/hooks/guardrails-allowed-hints.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Issue #1984 — the Step 8 allowedPrefix block reason must be ACTIONABLE.
+ *
+ * Before the fix, a write blocked by the allowedPrefix check returned:
+ *   `Path <path> not in allowed list for <agent>`
+ * with zero hint about what WOULD be allowed. Non-coder write-capable agents
+ * (test_engineer / docs / designer / critic) therefore could not self-correct
+ * and looped on filename guessing, burning tokens.
+ *
+ * After the fix, the reason appends the agent's own effective positive allow
+ * patterns (exact paths, prefixes, globs, and case-sensitive globs as separate
+ * categories) plus a deny-precedence caveat. The original phrase is preserved so
+ * legacy substring/regex assertions stay green.
+ *
+ * SECURITY surface verified here: the hint discloses ONLY the current agent's
+ * positive permissions — never another agent's rules, blocked rules, or universal
+ * deny prefixes.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	type AuthorityConfig,
+	type GuardrailsConfig,
+	GuardrailsConfigSchema,
+} from '../../../src/config/schema';
+import { checkFileAuthority } from '../../../src/hooks/guardrails';
+
+const TEST_CWD = path.join(os.tmpdir(), 'issue-1984-project');
+
+function isDenied(
+	result: ReturnType<typeof checkFileAuthority>,
+): result is { allowed: false; reason: string; zone?: string } {
+	return !result.allowed;
+}
+
+describe('Issue #1984: actionable allowedPrefix block reason', () => {
+	describe('built-in agents surface their own allow patterns', () => {
+		test('test_engineer: shows prefixes, ordinary globs, AND case-sensitive globs separately', () => {
+			// The exact path from the issue report. The reporter had to read plugin
+			// source to learn that **/*.test.* is the matching glob.
+			const result = checkFileAuthority(
+				'test_engineer',
+				'phpr-mcp/test-build.mjs',
+				TEST_CWD,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				// Legacy phrase preserved (regression guard).
+				expect(result.reason).toContain(
+					'not in allowed list for test_engineer',
+				);
+				// Allowed prefixes from DEFAULT_AGENT_AUTHORITY_RULES.test_engineer.
+				expect(result.reason).toContain(
+					'Allowed prefixes: tests/, test/, .swarm/evidence/',
+				);
+				// The exact glob the reporter needed — proves the message is now
+				// actionable without reading source.
+				expect(result.reason).toContain('**/*.test.*');
+				expect(result.reason).toContain('**/*.spec.*');
+				// Ordinary and case-sensitive globs are SEPARATE categories (critic
+				// item 2): merging would mislead an agent into wrong-case filenames
+				// (e.g. contest.java matching *Test.java).
+				expect(result.reason).toContain('Allowed globs:');
+				expect(result.reason).toContain('Allowed case-sensitive globs:');
+				expect(result.reason).toContain('*Test.java');
+				// Deny-precedence caveat (critic item 4).
+				expect(result.reason).toContain('still apply');
+			}
+		});
+
+		test('test_engineer: the renamed (allowed) path is NOT blocked', () => {
+			// Sanity: the workaround from the issue still resolves to allowed.
+			const result = checkFileAuthority(
+				'test_engineer',
+				'phpr-mcp/test-build.test.mjs',
+				TEST_CWD,
+			);
+			expect(result.allowed).toBe(true);
+		});
+
+		test('docs: shows its own prefixes + ordinary globs; no case-sensitive label', () => {
+			const result = checkFileAuthority('docs', 'src/foo.ts', TEST_CWD);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain(
+					'Allowed prefixes: docs/, .swarm/outputs/',
+				);
+				expect(result.reason).toContain('**/docs/**');
+				// Use a word-boundary regex so `**/*.md` is not silently satisfied by
+				// `**/*.mdx`/`**/*.mdoc` sharing the same prefix (reviewer nit 1).
+				expect(result.reason).toMatch(/(?:^|, )\*\*\/\*\.md(?!x|oc)/);
+				// docs has no case-sensitive globs, so that category is omitted.
+				expect(result.reason).not.toContain('Allowed case-sensitive globs:');
+			}
+		});
+
+		test('designer: shows the same shape as docs', () => {
+			const result = checkFileAuthority('designer', 'src/x.ts', TEST_CWD);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain(
+					'Allowed prefixes: docs/, .swarm/outputs/',
+				);
+				expect(result.reason).toMatch(/(?:^|, )\*\*\/\*\.md(?!x|oc)/);
+			}
+		});
+
+		test('critic: globs render (none) when the rule has none', () => {
+			// critic allowedPrefix=['.swarm/evidence/'] only, no globs.
+			const result = checkFileAuthority('critic', 'src/foo.ts', TEST_CWD);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('Allowed prefixes: .swarm/evidence/');
+				expect(result.reason).toContain('Allowed globs: (none)');
+			}
+		});
+
+		test('negative: a readOnly block (Step 1) does NOT append the allowed hint', () => {
+			// Reviewer nit 4: the helper is only called from the Step 8 return
+			// sites. A readOnly agent is blocked at Step 1 with its own distinct
+			// reason and must never receive the allowed-pattern hint.
+			const result = checkFileAuthority('explorer', 'src/foo.ts', TEST_CWD);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('read-only');
+				expect(result.reason).not.toContain('Allowed prefixes:');
+				expect(result.reason).not.toContain('Allowed globs:');
+			}
+		});
+
+		test('negative: an unknown agent does NOT receive the allowed hint', () => {
+			// The unknown-agent guard returns before Step 8; the hint must not
+			// appear (there are no resolved rules to disclose).
+			const result = checkFileAuthority(
+				'totally_unknown_role',
+				'src/foo.ts',
+				TEST_CWD,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('Unknown agent');
+				expect(result.reason).not.toContain('Allowed prefixes:');
+			}
+		});
+	});
+
+	describe('both Step 8 branches (non-empty and empty allowedPrefix)', () => {
+		test('explicit allowedPrefix: [] with a glob renders "(none)" prefixes and the glob', () => {
+			// Covers the `else if` branch at file-authority.ts where allowedPrefix
+			// is an explicit empty array (deny-all-by-prefix). The glob is still the
+			// actionable signal.
+			const cfg: AuthorityConfig = {
+				enabled: true,
+				rules: {
+					custom_globonly: {
+						allowedPrefix: [],
+						allowedGlobs: ['**/*.test.*'],
+					},
+				},
+			};
+			const result = checkFileAuthority(
+				'custom_globonly',
+				'src/x.txt',
+				TEST_CWD,
+				cfg,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('Allowed prefixes: (none)');
+				expect(result.reason).toContain('**/*.test.*');
+			}
+		});
+
+		test('explicit allowedPrefix: [] with NO globs renders (none) for both', () => {
+			const cfg: AuthorityConfig = {
+				enabled: true,
+				rules: { custom_denyall: { allowedPrefix: [] } },
+			};
+			const result = checkFileAuthority(
+				'custom_denyall',
+				'out/x.txt',
+				TEST_CWD,
+				cfg,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('Allowed prefixes: (none)');
+				expect(result.reason).toContain('Allowed globs: (none)');
+			}
+		});
+
+		test('allowedExact renders its own category before prefixes', () => {
+			// A custom rule with both allowedExact and allowedPrefix: the hint
+			// must surface the exact-path compliance channel (critic item 1).
+			const cfg: AuthorityConfig = {
+				enabled: true,
+				rules: {
+					custom_exact: {
+						allowedPrefix: ['src/'],
+						allowedExact: ['config/secret.txt'],
+					},
+				},
+			};
+			const result = checkFileAuthority(
+				'custom_exact',
+				'other.txt',
+				TEST_CWD,
+				cfg,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('Allowed exact paths:');
+				expect(result.reason).toContain('config/secret.txt');
+				expect(result.reason).toContain('Allowed prefixes: src/');
+				// The exact-paths category must precede prefixes (matches the
+				// DENY-first evaluation order / push order in the helper).
+				// Reviewer nit 2: assert the ordering, not just presence.
+				const exactIdx = result.reason.indexOf('Allowed exact paths:');
+				const prefixIdx = result.reason.indexOf('Allowed prefixes:');
+				expect(exactIdx).toBeGreaterThan(-1);
+				expect(prefixIdx).toBeGreaterThan(-1);
+				expect(exactIdx).toBeLessThan(prefixIdx);
+			}
+		});
+
+		test('an agent with ONLY allowedCaseSensitiveGlobs renders just that category', () => {
+			// Reviewer nit 3: lock the invariant that the case-sensitive category
+			// is still emitted when it is the ONLY allow field present (helper
+			// must not gate it on other categories being non-empty).
+			const cfg: AuthorityConfig = {
+				enabled: true,
+				rules: {
+					custom_cs: {
+						allowedPrefix: [],
+						allowedCaseSensitiveGlobs: ['*Test.java'],
+					},
+				},
+			};
+			const result = checkFileAuthority(
+				'custom_cs',
+				'src/x.txt',
+				TEST_CWD,
+				cfg,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('Allowed prefixes: (none)');
+				expect(result.reason).toContain('Allowed globs: (none)');
+				expect(result.reason).toContain('Allowed case-sensitive globs:');
+				expect(result.reason).toContain('*Test.java');
+			}
+		});
+	});
+
+	describe('truncation guard (bounded message)', () => {
+		test('more than 20 entries in a category get an accurate omitted-count tail', () => {
+			// Per-category cap of 20 keeps the surfaced WRITE BLOCKED message
+			// bounded. Every built-in rule fits (max 15); only pathological custom
+			// configs truncate.
+			const manyGlobs = Array.from({ length: 25 }, (_, i) => `**/g${i}.ext`);
+			const cfg: AuthorityConfig = {
+				enabled: true,
+				rules: {
+					custom_many: {
+						allowedPrefix: [],
+						allowedGlobs: manyGlobs,
+					},
+				},
+			};
+			const result = checkFileAuthority(
+				'custom_many',
+				'out/x.txt',
+				TEST_CWD,
+				cfg,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				// First 20 shown.
+				expect(result.reason).toContain('**/g19.ext');
+				// 21st omitted with accurate count.
+				expect(result.reason).toContain('… (+5 more)');
+				expect(result.reason).not.toContain('**/g20.ext');
+				expect(result.reason).not.toContain('**/g24.ext');
+			}
+		});
+
+		test('exactly 20 entries render in full with no truncation tail', () => {
+			const globs = Array.from({ length: 20 }, (_, i) => `**/h${i}.ext`);
+			const cfg: AuthorityConfig = {
+				enabled: true,
+				rules: { custom_twenty: { allowedPrefix: [], allowedGlobs: globs } },
+			};
+			const result = checkFileAuthority(
+				'custom_twenty',
+				'out/x.txt',
+				TEST_CWD,
+				cfg,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('**/h19.ext');
+				expect(result.reason).not.toContain('… (+');
+			}
+		});
+	});
+
+	describe('security: no cross-agent or deny-rule leakage', () => {
+		test("a blocked agent does NOT see another agent's allow patterns", () => {
+			// Two custom agents with distinct globs. A block for agentA must only
+			// reveal agentA's own patterns, never agentB's.
+			const cfg: AuthorityConfig = {
+				enabled: true,
+				rules: {
+					agent_a: {
+						allowedPrefix: ['a-src/'],
+						allowedGlobs: ['**/*.a.test.*'],
+					},
+					agent_b: {
+						allowedPrefix: ['b-src/'],
+						allowedGlobs: ['**/*.b.test.*'],
+					},
+				},
+			};
+			const result = checkFileAuthority(
+				'agent_a',
+				'elsewhere/x.txt',
+				TEST_CWD,
+				cfg,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('a-src/');
+				expect(result.reason).toContain('**/*.a.test.*');
+				// agentB's patterns must NOT leak into agentA's reason.
+				expect(result.reason).not.toContain('b-src/');
+				expect(result.reason).not.toContain('**/*.b.test.*');
+			}
+		});
+
+		test('the hint never discloses blocked* rules or universal deny prefixes', () => {
+			// Even when the rule has blocked fields configured, only the positive
+			// allow surface is disclosed (the caveat names them generically).
+			const cfg: AuthorityConfig = {
+				enabled: true,
+				rules: {
+					custom_with_blocks: {
+						allowedPrefix: ['ok/'],
+						blockedExact: ['.swarm/secret.txt'],
+						blockedPrefix: ['forbidden/'],
+						blockedGlobs: ['**/*.bin'],
+						blockedZones: ['generated'],
+					},
+				},
+			};
+			const result = checkFileAuthority(
+				'custom_with_blocks',
+				'elsewhere/x.txt',
+				TEST_CWD,
+				cfg,
+			);
+			expect(result.allowed).toBe(false);
+			if (isDenied(result)) {
+				expect(result.reason).toContain('Allowed prefixes: ok/');
+				// Concrete blocked values never appear (only the generic caveat).
+				expect(result.reason).not.toContain('.swarm/secret.txt');
+				expect(result.reason).not.toContain('forbidden/');
+				expect(result.reason).not.toContain('**/*.bin');
+			}
+		});
+	});
+});
+
+// ─── toolBefore integration: the surfaced WRITE BLOCKED carries the hint ─────
+//
+// This block verifies the fix end-to-end through the hook layer (not just the
+// pure function), proving the LLM-facing thrown error contains the appended
+// hint. Models the write-lstat-authority.test.ts toolBefore pattern.
+
+describe('Issue #1984: toolBefore surfaces the actionable hint', () => {
+	test('docs write blocked via toolBefore throws an error carrying the allowed hint', async () => {
+		const { createGuardrailsHooks } = await import(
+			'../../../src/hooks/guardrails'
+		);
+		const { ensureAgentSession, swarmState, beginInvocation, resetSwarmState } =
+			await import('../../../src/state');
+		const { AuthorityConfigSchema } = await import(
+			'../../../src/config/schema'
+		);
+		const fs = await import('node:fs/promises');
+		const osMod = await import('node:os');
+		const pathMod = await import('node:path');
+
+		// realpath so macOS /tmp → /private/tmp doesn't cause path mismatches.
+		const dir = await fs.realpath(
+			await fs.mkdtemp(pathMod.join(osMod.tmpdir(), 'issue1984-hook-')),
+		);
+		const originalCwd = process.cwd();
+		process.chdir(dir);
+		resetSwarmState();
+		try {
+			const cfg = GuardrailsConfigSchema.parse({
+				enabled: true,
+			}) as GuardrailsConfig;
+			const authority = AuthorityConfigSchema.parse({}) as AuthorityConfig;
+			const hooks = createGuardrailsHooks(dir, undefined, cfg, authority);
+
+			const id = 'docs-hint';
+			ensureAgentSession(id, 'docs');
+			swarmState.activeAgent.set(id, 'docs');
+			beginInvocation(id, 'docs');
+
+			// docs writing to src/ is blocked; the thrown error must carry the
+			// actionable hint so the agent sees it in the tool rejection.
+			await expect(
+				hooks.toolBefore(
+					{ tool: 'write', sessionID: id, callID: 'hint1' },
+					{ args: { filePath: 'src/foo.ts' } },
+				),
+			).rejects.toThrow(
+				/not in allowed list for docs.*Allowed prefixes: docs\/, \.swarm\/outputs\//,
+			);
+		} finally {
+			process.chdir(originalCwd);
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
# PR body — fix(guardrails): actionable WRITE BLOCKED message for non-coder agents

## Summary

Resolves #1984.

When a non-coder write-capable agent (e.g. `test_engineer`, `docs`, `designer`,
`critic`) writes a file that doesn't match its authority rules, the guardrail's
Step 8 `allowedPrefix` block reason was **opaque** — it named the blocked path and
the agent, but never what *would* be allowed. Because this reason is surfaced
verbatim to the LLM agent (through the fail-closed `tool.execute.before` chain),
the agent could not self-correct and looped on filename guessing — in the
reporter's case, 3 full attempts re-analyzing the codebase and re-running the
test suite before resorting to reading plugin source to learn that `**/*.test.*`
is the matching glob.

This PR makes the reason **actionable** by appending the agent's own effective
allow patterns (exact paths, prefixes, globs, and case-sensitive globs as
separate categories) plus a deny-precedence caveat. The agent can now rename or
redirect the file in one step.

**Before:**
```
WRITE BLOCKED: Agent "test_engineer" is not authorised to write "phpr-mcp/test-build.mjs". Reason: Path phpr-mcp/test-build.mjs not in allowed list for test_engineer
```

**After:**
```
WRITE BLOCKED: Agent "test_engineer" is not authorised to write "phpr-mcp/test-build.mjs". Reason: Path phpr-mcp/test-build.mjs not in allowed list for test_engineer. Allowed prefixes: tests/, test/, .swarm/evidence/. Allowed globs: **/tests/**, **/test/**, **/__tests__/**, **/*.test.*, **/*.spec.*, …. Allowed case-sensitive globs: *Test.java, …. Block rules (blocked zones/prefixes/globs/exact) and universal deny paths still apply.
```

## Scope

This implements **Suggested Fix #1** (actionable message) from the issue — the
isolated, low-risk fix the maintainer endorsed as `good-first-issue`.

The issue's larger asks are **out of scope** for this PR and recorded as
follow-ups (to be noted in the closing issue comment):
- **#2** A write-grant / `declare_scope` extension for non-coder roles (security-
  sensitive design change; the coder-only bypass is an intentional decision).
- **#3** Pre-dispatch validation of declared output files against the target
  agent's authority rules.
- **#4 (broader)** Per-role write-authority guidance in agent prompts.

## Changes

- `src/hooks/guardrails/file-authority.ts` — new module-local
  `formatAllowedHints(rules)` helper + `MAX_ALLOWED_HINT_ENTRIES = 20` const;
  both Step 8 return reasons (the non-empty and empty `allowedPrefix` branches)
  now append `. ${formatAllowedHints(rules)}`. **String-only change** at the
  return sites; no control-flow, ordering, caller, or security-posture change.
  The literal phrase `Path <path> not in allowed list for <agent>` is preserved
  so existing substring/regex assertions stay green.
- `tests/unit/hooks/guardrails-allowed-hints.test.ts` (new, 16 tests, <500 lines)
  — covers built-in agents (test_engineer/docs/designer/critic), both Step 8
  branches, `allowedExact` category + ordering, an agent with only
  `allowedCaseSensitiveGlobs`, the truncation guard (25→20 + accurate tail;
  exactly-20 no tail), security (no cross-agent leakage, no blocked-rule
  disclosure), negative tests (readOnly / unknown-agent do not receive the hint),
  and a `toolBefore` integration test proving the surfaced WRITE BLOCKED error
  carries the hint end-to-end.
- `docs/releases/pending/1984-actionable-allowed-prefix-block-message.md` —
  release fragment.

### Security

The hint discloses ONLY the current agent's OWN positive permissions — never
`blocked*` rules, universal deny prefixes, or any other agent's policy. Proven
by the no-leakage tests. The threat model is a *confused* agent (looping), not
an adversarial one; the disclosed data is the agent's own role permissions,
already knowable via the explain CLI and source.

## Invariant audit

- 1 (plugin init):       **not touched** — change is in a guardrail check called at tool-execution time, not the init path.
- 2 (runtime portability): **not touched** — no `bun:`/`Bun.*`/bundle/entry-shape changes; `bun run build` clean; no top-level imports added.
- 3 (subprocesses):       **not touched** — no subprocess code changed.
- 4 (.swarm containment): **not touched** — no `.swarm/` writes or `process.cwd()` callers introduced.
- 5 (plan durability):    **not touched** — no plan-schema/ledger changes.
- 6 (test_runner safety): **not touched** — validation used per-file shell loops (AGENTS.md #6), not broad `test_runner` scopes.
- 7 (test writing):       **touched** — new test file uses `bun:test`, direct-import of public API (no `mock.module`, no `_internals` needed), `os.tmpdir()`+`path.join` for temp paths, <500 lines (FR-006). No mock-allowlist change required.
- 8 (session state):      **not touched** — no session/global state introduced.
- 9 (guardrails/retry):   **touched (message text only)** — enriched a block reason string; DENY-first ordering, coder-only `declaredScope` bypass, fail-closed propagation, and retry semantics are unchanged. Verified: `bun test tests/unit/hooks/guardrails-nontransient*.test.ts` and the full guardrails surface pass per-file.
- 10 (chat/system msg):   **not touched** — no system-message hook logic changed.
- 11 (tool registration): **not touched** — no tools/agents/commands added or changed. `bun run drift:check` → ✅ No drift detected.
- 12 (release/cache):     **touched** — added `docs/releases/pending/1984-actionable-allowed-prefix-block-message.md` (mandatory fragment, AGENTS.md #12). No `package.json#version`/CHANGELOG/manifest hand-edits.

## Test plan

- [x] `bun test tests/unit/hooks/guardrails-allowed-hints.test.ts` → **16 pass / 0 fail** (new regression coverage)
- [x] `bun test tests/unit/hooks/guardrails-authority.test.ts tests/unit/hooks/guardrails-codex-p1-fixes.test.ts tests/unit/hooks/write-lstat-authority.test.ts` → **242 pass / 0 fail** (legacy assertions preserved)
- [x] Per-file isolation loop over all 53 `tests/unit/hooks/guardrails*.test.ts` + `write-lstat-authority.test.ts` → **0 files with failures**
- [x] `bunx tsc --noEmit` → exit 0
- [x] `bun run build` → clean
- [x] `bun run check` (biome) → exit 0
- [x] `bun run drift:check` → ✅ No drift

Note: a broad `bun test tests/unit/hooks/guardrails*` glob shows 1 failure
(`guardrails-shell-write > ... Windows sandbox`), which is a **pre-existing**
cross-file subprocess-isolation flake — on clean `main` (changes stashed) the
same glob produces 13 failures; this branch produces only 1, and that test
passes in isolation. AGENTS.md #6 prescribes per-file validation for this reason.

## Review trail

- Independent **plan critic** (Kimi K3): NEEDS_REVISION → all 10 items adopted.
- Independent **implementation reviewer** (Kimi K2.7): APPROVE → 4 test-hardening nits adopted and re-verified.
- **Final critic** (Kimi K3): cleared all code/scope/evidence challenges; only item was the release fragment, now landed.

Closes #1984.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

