### PR TITLE
fix(sandbox): emit valid decimal byte count for bwrap --size

### DIFF
--- a/docs/releases/pending/1997-bwrap-tmpfs-size-bytes.md
+++ b/docs/releases/pending/1997-bwrap-tmpfs-size-bytes.md
@@ -44,9 +44,11 @@ argv changes from an invalid suffixed form to the required plain-byte form.
 
 ## Caveats
 
-- Validated via unit tests (`tests/unit/sandbox/linux.test.ts`,
-  `tests/unit/sandbox/linux-envoverride-verification.test.ts`) and a clean
-  `bun run build`. A live `bwrap --size 524288000 --tmpfs /tmp …` end-to-end
-  smoke test on a Linux host with bwrap installed is the gold-standard
-  confirmation; the parse contract was confirmed against the bwrap manpage and
-  upstream `bubblewrap.c` source.
+- The `--size` byte-count fix is validated by unit tests in
+  `tests/unit/sandbox/linux.test.ts`, which assert the `--size <bytes> --tmpfs`
+  adjacency bwrap requires. (`tests/unit/sandbox/linux-envoverride-verification.test.ts`
+  exercises `wrapCommand()` env-override paths but asserts no size value.)
+  Also confirmed by a clean `bun run build`. A live
+  `bwrap --size 524288000 --tmpfs /tmp …` end-to-end smoke test on a Linux host
+  with bwrap installed is the gold-standard confirmation; the parse contract was
+  confirmed against the bwrap manpage and upstream `bubblewrap.c` source.

--- a/docs/releases/pending/1997-bwrap-tmpfs-size-bytes.md
+++ b/docs/releases/pending/1997-bwrap-tmpfs-size-bytes.md
@@ -1,0 +1,52 @@
+# Fix: Linux Bubblewrap sandbox emits a valid `--size` byte count
+
+## What
+
+The Linux Bubblewrap (`bwrap`) sandbox executor generated an invalid `--size`
+argument for the `/tmp` tmpfs:
+
+```
+bwrap ... --size 500M --tmpfs /tmp ...
+```
+
+Bubblewrap's `--size` option accepts **only a plain non-zero decimal number of
+bytes** and does not parse suffixes such as `M` or `MB`. As a result bwrap
+rejected the value and aborted before the sandboxed process could start:
+
+```
+bwrap: --size takes a non-zero number of bytes
+```
+
+This broke every Linux sandboxed shell/bash command issued by swarm agents
+(coders, reviewers, …) whenever the Bubblewrap sandbox was available.
+
+The executor now emits the size as a decimal byte count — `524288000`
+(500 MiB = 500 × 1024 × 1024) — via a named, documented module constant
+`TMPFS_SIZE_BYTES` in `src/sandbox/linux/bubblewrap-executor.ts`. The two
+unit-test assertions that previously locked in the buggy `500M` value now
+assert the correct contract (`524288000`) and carry a `.not.toContain('500M')`
+regression guard.
+
+## Why
+
+`bwrap` performs its own argv validation and exits non-zero on an unparseable
+`--size` before exec'ing the wrapped command. The unit tests asserted on the
+generated command string rather than against a real `bwrap` parse, so the
+defective value was green by construction. This is a correctness fix to the
+representation of an existing value (500 MiB tmpfs) — the intended tmpfs size
+is unchanged.
+
+## Migration
+
+No breaking changes. No configuration, public API, or constructor-signature
+change. The tmpfs size remains 500 MiB; only its serialization into the bwrap
+argv changes from an invalid suffixed form to the required plain-byte form.
+
+## Caveats
+
+- Validated via unit tests (`tests/unit/sandbox/linux.test.ts`,
+  `tests/unit/sandbox/linux-envoverride-verification.test.ts`) and a clean
+  `bun run build`. A live `bwrap --size 524288000 --tmpfs /tmp …` end-to-end
+  smoke test on a Linux host with bwrap installed is the gold-standard
+  confirmation; the parse contract was confirmed against the bwrap manpage and
+  upstream `bubblewrap.c` source.

--- a/src/sandbox/linux/bubblewrap-executor.ts
+++ b/src/sandbox/linux/bubblewrap-executor.ts
@@ -20,6 +20,13 @@ const BWRAP_VERSION_EXIT = 0;
 const BWRAP_UNAVAILABLE_CODES = new Set(['ENOENT', 'EACCES', 'ENOSPC']);
 
 /**
+ * Size in bytes for the /tmp tmpfs (500 MiB).
+ * bwrap --size requires a plain non-zero decimal byte count; suffixes (M, MB)
+ * are rejected with "--size takes a non-zero number of bytes" (issue #1997).
+ */
+const TMPFS_SIZE_BYTES = 524288000; // 500 * 1024 * 1024
+
+/**
  * Check whether the bwrap binary is present on PATH.
  * Uses spawnSync to probe synchronously without throwing.
  * Logs specific error codes when bwrap is found but unusable.
@@ -221,7 +228,7 @@ export class BubblewrapSandboxExecutor implements SandboxExecutor {
 			'--dev',
 			'/dev',
 			'--size',
-			'500M',
+			String(TMPFS_SIZE_BYTES),
 			'--tmpfs',
 			`'${shellEscape(temp)}'`,
 			'--ro-bind',

--- a/tests/unit/sandbox/linux.test.ts
+++ b/tests/unit/sandbox/linux.test.ts
@@ -141,10 +141,12 @@ describe('BubblewrapSandboxExecutor', () => {
 
 			expect(result).toContain('--tmpfs');
 			expect(result).toContain('/tmp');
-			expect(result).toContain('--size');
 			// bwrap --size requires a plain decimal byte count, not a suffixed
 			// value like "500M" (issue #1997). 500 MiB = 524288000 bytes.
-			expect(result).toContain('524288000');
+			// bwrap also binds --size to the NEXT --tmpfs, so assert the two
+			// appear as an adjacent argv pair (`--size <bytes> --tmpfs`), not
+			// just as independent substrings (PRR-001/PRR-002 hardening).
+			expect(result).toContain('--size 524288000 --tmpfs');
 			expect(result).not.toContain('500M');
 		});
 
@@ -153,8 +155,7 @@ describe('BubblewrapSandboxExecutor', () => {
 
 			expect(result).toContain('--tmpfs');
 			expect(result).toContain('/custom/tmp');
-			expect(result).toContain('--size');
-			expect(result).toContain('524288000');
+			expect(result).toContain('--size 524288000 --tmpfs');
 			expect(result).not.toContain('500M');
 		});
 

--- a/tests/unit/sandbox/linux.test.ts
+++ b/tests/unit/sandbox/linux.test.ts
@@ -142,7 +142,10 @@ describe('BubblewrapSandboxExecutor', () => {
 			expect(result).toContain('--tmpfs');
 			expect(result).toContain('/tmp');
 			expect(result).toContain('--size');
-			expect(result).toContain('500M');
+			// bwrap --size requires a plain decimal byte count, not a suffixed
+			// value like "500M" (issue #1997). 500 MiB = 524288000 bytes.
+			expect(result).toContain('524288000');
+			expect(result).not.toContain('500M');
 		});
 
 		test('uses custom tempDir when provided to wrapCommand', () => {
@@ -151,7 +154,8 @@ describe('BubblewrapSandboxExecutor', () => {
 			expect(result).toContain('--tmpfs');
 			expect(result).toContain('/custom/tmp');
 			expect(result).toContain('--size');
-			expect(result).toContain('500M');
+			expect(result).toContain('524288000');
+			expect(result).not.toContain('500M');
 		});
 
 		test('includes --ro-bind /usr', () => {


### PR DESCRIPTION
Closes #1997

## Summary

The Linux Bubblewrap (`bwrap`) sandbox executor emitted an invalid `--size`
argument for the `/tmp` tmpfs:

```
bwrap ... --size 500M --tmpfs /tmp ...
```

Bubblewrap's `--size` accepts **only a plain non-zero decimal number of bytes**
and does not parse suffixes (`M`/`MB`). It therefore rejected the value and
aborted before the sandboxed process could start:

```
bwrap: --size takes a non-zero number of bytes
```

This broke every Linux sandboxed shell/bash command issued by swarm agents
whenever the Bubblewrap sandbox was available.

The executor now emits the size as a decimal byte count — `524288000`
(500 MiB = 500 × 1024 × 1024) — via a named, documented module constant
`TMPFS_SIZE_BYTES`. The two unit-test assertions that previously locked in the
buggy `500M` value now assert the correct contract and carry a regression guard.

This is a correctness fix to the *representation* of an existing value; the
intended 500 MiB tmpfs size is unchanged. No config/public-API/constructor
change (configurability is explicitly out of scope — the reporter framed it as
a "more robust approach would…" nice-to-have, not a requirement, and no config
plumbing exists today).

## Root cause

`src/sandbox/linux/bubblewrap-executor.ts`, `wrapCommand()`, hard-coded
`'500M'` for the `--size` argument, joined into `bwrap ${args.join(' ')}`.
The unit tests asserted on the generated string (not a real bwrap parse), so
the defective value was green by construction.

## Invariant audit

- 1 (plugin init):       not touched — change is in a runtime sandbox executor, not the init path.
- 2 (runtime portability): not touched — no `bun:`/`Bun.*`/bundle/entry-shape change; `bun run build` clean.
- 3 (subprocesses):       not touched — no spawn change; the bwrap argv is built the same way (only the size literal changed).
- 4 (.swarm containment): not touched — no `.swarm/` or working-directory change.
- 5 (plan durability):    not touched.
- 6 (test_runner safety): not touched.
- 7 (test writing):       touched — two assertions in `tests/unit/sandbox/linux.test.ts` updated to the correct contract + `not.toContain('500M')` regression guard; no new `mock.module` targets; bun:test retained.
- 8 (session state):      not touched.
- 9 (guardrails/retry):   not touched.
- 10 (chat/system msg):   not touched.
- 11 (tool registration): not touched.
- 12 (release/cache):     touched — added mandatory `docs/releases/pending/1997-bwrap-tmpfs-size-bytes.md` fragment; version files untouched.

## Test plan

All commands run on Windows (win32); the `test.skipIf(isWindows)` cases skip by
design (bwrap is Linux-only).

```
$ bun run typecheck   → exit 0
$ bunx biome ci <3 changed files> → 2 files checked, no fixes applied, exit 0
$ bun run build       → exit 0
$ bun test tests/unit/sandbox/linux.test.ts tests/unit/sandbox/linux-envoverride-verification.test.ts
  → 43 pass, 17 skip, 0 fail (68 expect() calls, 60 tests across 2 files)
```

Grep re-confirmation: no remaining `500M` producer in `src/`; the only `tests/`
references are the two `not.toContain('500M')` guards + an explanatory comment.
The new `TMPFS_SIZE_BYTES = 524288000` constant is consumed at
`bubblewrap-executor.ts:231` (not dead).

Independent review gates (issue-tracer skill):
- Plan critic (Kimi K3): APPROVE, 95/100.
- Implementation review (opus, fallback after K2.7 rate-limit): APPROVE — all 8 review points verified, read upstream `bubblewrap.c` for the `--size` parse contract, ran full `bun test tests/unit/sandbox/` (355 pass, 112 skip, 0 fail).
- Final critic (Kimi K3): APPROVE after adding the release-note fragment it flagged as missing.

### Review hardening (commit 8b33b678 — swarm-pr-feedback)

A `swarm-pr-review` pass on this PR surfaced three LOW findings; all resolved:
- **Test strength:** the two size assertions now check the positional form
  `--size 524288000 --tmpfs` (bwrap binds `--size` to the next `--tmpfs`),
  instead of independent substrings. This is strictly stronger — it fails on a
  reordered argv, a suffixed value (e.g. `524288000MB`), and the original
  `500M` bug, while the standalone checks did not. Verified with a `node -e`
  counterexample proof.
- **Doc accuracy:** the release fragment's Caveats no longer claims
  `linux-envoverride-verification.test.ts` validates the size fix (it covers
  env-override paths and asserts no size value); only `linux.test.ts` does.

Independent gates on the feedback fixes: reviewer (Kimi K2.7) APPROVE; final
critic (Kimi K3) APPROVE — no deferred work, no unwired code.

Caveat: a live `bwrap --size 524288000 --tmpfs /tmp …` end-to-end smoke test on
a Linux host with bwrap installed is the gold-standard confirmation; not run in
this Windows dev environment. The parse contract was confirmed against the
bwrap manpage and upstream `bubblewrap.c` source.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/1998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


