### PR TITLE
fix(repo-graph): incremental update lifecycle correctness

### DIFF
--- a/docs/releases/pending/1985-repo-graph-incremental-correctness.md
+++ b/docs/releases/pending/1985-repo-graph-incremental-correctness.md
@@ -1,0 +1,137 @@
+# repo-graph incremental update lifecycle correctness
+
+## What
+
+Resolves #1985 — six verified lifecycle defects in the repo-graph subsystem
+(`src/tools/repo-graph/*`). The headline defect (A1) silently disabled
+incremental updates for any workspace importing JSON/CSS/asset files by relative
+path, forcing a full workspace rebuild on every agent write.
+
+### A1 — asset edges no longer disable incremental updates (CRITICAL)
+
+`resolveModuleSpecifier` resolves imports like `import data from './data.json'`
+to real files, but only scannable source languages become graph nodes. The
+incremental updater validated that *every* edge had nodes at both endpoints, so
+one asset edge anywhere ⇒ `validationFailed` ⇒ silent fallback to a full rebuild
+on every write, forever. The warning was gated behind `OPENCODE_SWARM_DEBUG=1`,
+so it was invisible in production.
+
+- `GraphEdge` gains an optional `targetKind: 'node' | 'asset'` field
+  (schema `1.2.0` → `1.3.0`; older graphs still load — the loader only checks
+  version presence, feature gating is per-query).
+- Edges whose target is not a scannable source file are tagged `'asset'` at all
+  four emission sites (`scanFile`, `scanFileAsync`, both builders).
+- The incremental validation loop now requires only the *source* node for asset
+  edges; node→node edges still require both endpoints. On a genuine orphan edge
+  the specific offending edge (source, target, reason) is logged before the
+  fallback, and an `incrementalFallbacks` diagnostics counter is bumped.
+- Asset targets are excluded from `key_files` in-degree ranking and from
+  importer / dependent lists (`getImporters`, `getKeyFiles`, `getBlastRadius`,
+  `getCallers`, `getDeadExports`, `getSymbolConsumers`, package boundaries).
+  Pre-1.3.0 graphs are handled via an extension-check fallback on untagged edges.
+
+**Scope note:** this fixes the common JSON/CSS/asset case. A scannable file
+that fails to become a node (binary, oversized, parse error) still triggers a
+fallback rebuild by design — the rare case is correctly reconciled by the
+rebuild.
+
+### A2 — write-hook extension parity
+
+The write hook's local `SUPPORTED_EXTENSIONS` (7 extensions) drifted from the
+builder's `LANGUAGE_REGISTRY`-derived set, so `.rs`/`.go`/`.pyw` edits never
+triggered an incremental update. Both now route through a single shared
+`isScannableSourcePath` helper derived from the walker's set.
+
+### A4 — cheaper concurrent-save recovery
+
+The optimistic-concurrency check used to fall back to a full rebuild whenever
+the on-disk graph mtime moved. It now reloads the freshest graph and replays the
+update **once** (with a pre-save re-check); only a second concurrent shift falls
+back to the full rebuild. Bounded — never loops. Once a mismatch is detected,
+the stale pre-reload graph is never saved over the newer on-disk graph — any
+reload/replay/stat failure after a detected mismatch routes to the terminal
+full rebuild (the only broad `catch` is the initial mtime stat, which tolerates
+transient I/O errors).
+
+### Incremental re-scan hardening (review-driven)
+
+Two latent incremental-path defects surfaced during independent review and are
+fixed in the same pass:
+
+- A previously-tracked source file whose re-scan returns `node: null` (it
+  became oversized, binary, or unreadable) now has its stale node removed, so
+  any dangling incoming node→node edge is caught by validation and triggers the
+  documented fallback — instead of leaving an inconsistent graph (stale node,
+  removed outgoing edges).
+- `updateGraphForFiles` is a public entry point, so it now guards with
+  `isScannableSourcePath` before mutating the graph, refusing to create an
+  `'unknown'`-language node from an unsupported extension.
+- Manifest-aware package boundaries stay consistent across incremental edits:
+  the incremental re-scan re-derives a bounded `hasManifest` closure from the
+  existing graph's node directories and forwards it to the scanner (including
+  the tree-sitter fail-open fallback).
+
+### A5 — realpath consistency
+
+`toolAfter` computed the realpath for its security boundary check but passed
+the non-realpath'd absolute path into the updater. Node keys originate from the
+realpath'd walk, so on case-insensitive filesystems or symlink aliases this
+could insert a duplicate node and strand the original. The realpath is now
+forwarded.
+
+### A7 — walk-truncation + fallback diagnostics
+
+Walk truncation (file cap / wall-clock budget) was a debug log only;
+`getGraphHealth` could not report it. `RepoGraphDiagnostics` gains
+`walkTruncated`, `walkTruncationReason` (`'budget' | 'cap'`), and
+`incrementalFallbacks`. `getGraphHealth` surfaces them with an explicit
+`"Graph is INCOMPLETE: …"` note, and the `repo_map` `build` action reports
+`truncated: boolean`.
+
+### A8 — generic package-boundary inference
+
+`boundaryForModule` hardcoded this repo's own layout (`src/tools/repo-graph`,
+`packages/`, `crates/`). The rule is now generic and shared by ontology
+extraction and the query-side no-ontology fallback via a pure
+`inferPackageBoundary` helper: `packages|crates|apps|libs|services` as the first
+segment, plus a manifest-driven rule (`package.json` / `Cargo.toml` /
+`pyproject.toml` / `go.mod`) plumbed from the walker through an optional
+`hasManifest` callback on `ExtractFileOntologyInput`. The ontology module stays
+pure (no fs I/O).
+
+### A6 — docs note
+
+`exclude_dirs` case-sensitivity on case-insensitive filesystems remains
+documented behavior in the schema JSDoc; no code change.
+
+## Why
+
+The repo-graph subsystem is the structural-awareness layer swarm agents use
+before refactoring. A1 made incremental updates non-functional for a large
+class of real user repos (any repo with a relative JSON/CSS import — measured
+~158 s full rebuild on a 2,787-file repo, on every agent write), so the graph
+was either permanently stale or permanently expensive. The other defects caused
+silent staleness (A2), duplicate nodes (A5), invisible truncation (A7), and
+repo-specific boundary guesses (A8).
+
+## Impact
+
+- Incremental updates now work for workspaces with asset imports — the common
+  case. Agents editing an unrelated file no longer pay for a full rebuild.
+- Rust / Go / `.pyw` edits now keep the graph current.
+- `graph_health` honestly reports when a graph is incomplete, instead of
+  confidently returning wrong blast radii and dead-export candidates.
+- Package-boundary inference works on user repos, not just this one.
+- Graph schema is additive (1.3.0); existing 1.0.0–1.2.0 graphs load and query
+  unchanged.
+
+## Verification
+
+`bun test` (repo-graph suite, 251 tests across 17 files, each run in isolation
+per AGENTS.md invariant 7), `bunx tsc --noEmit`, `bun run drift:check`, and
+`bunx biome check` all green. New regression tests cover the A1 repro
+(asset import no longer forces a fallback; asset targets excluded from queries;
+genuine node→node orphans still fall back), A2 (`.rs`/`.go`/`.pyw` writes
+trigger updates), A5 (realpath forwarded), A7 (truncation reason + fallback
+counters surface in `graph_health`), A8 (generic boundaries + removed special
+case), and 1.2.0 graph compatibility.

--- a/src/hooks/repo-graph-builder.ts
+++ b/src/hooks/repo-graph-builder.ts
@@ -20,6 +20,7 @@ import * as path from 'node:path';
 import { WRITE_TOOL_NAMES } from '../config/constants';
 import {
 	buildWorkspaceGraphAsync,
+	isScannableSourcePath,
 	type RepoGraph,
 	saveGraph,
 	updateGraphForFiles,
@@ -60,16 +61,6 @@ export interface RepoGraphDeps {
 	safeRealpathSync?: typeof safeRealpathSync;
 }
 
-const SUPPORTED_EXTENSIONS = [
-	'.ts',
-	'.tsx',
-	'.js',
-	'.jsx',
-	'.mjs',
-	'.cjs',
-	'.py',
-];
-
 function extractFilePath(args: unknown): string | null {
 	if (!args || typeof args !== 'object') return null;
 	const a = args as Record<string, unknown>;
@@ -96,9 +87,59 @@ function extractFilePath(args: unknown): string | null {
 	return filePath;
 }
 
+/**
+ * Whether `filePath` is a scannable source file the graph tracks. Delegates to
+ * the single shared {@link isScannableSourcePath} (issue #1985, defect A2) so
+ * the write hook's allowlist can never drift from the builder's
+ * LANGUAGE_REGISTRY-derived set — picking up `.rs`/`.go`/`.pyw` automatically.
+ */
 function isSupportedSourceFile(filePath: string): boolean {
-	const ext = filePath.substring(filePath.lastIndexOf('.')).toLowerCase();
-	return SUPPORTED_EXTENSIONS.includes(ext);
+	return isScannableSourcePath(filePath);
+}
+
+/**
+ * Rebase a realpath'd file onto the lexical workspace root so the incremental
+ * update keys the same node the walk produced (issue #1985, defect A5). Exported
+ * for direct unit testing of the symlink-root rebase logic.
+ *
+ * The walk keys nodes lexically relative to `workspaceRoot` (realpath is used
+ * only as a cycle-break key). When the workspace root itself is a symlink
+ * (`workspaceRoot` → `realWorkspace`), a realpath'd file (`realFilePath`) lives
+ * under `realWorkspace` and would key a DIFFERENT node than the lexical path the
+ * walker would have produced — causing a duplicate node.
+ *
+ * If `realFilePath` is under `realWorkspace`, rebase its workspace-relative tail
+ * onto the lexical `workspaceRoot` (reconstructing the lexical absolute path the
+ * walker used). Otherwise (case-insensitive aliasing without a symlinked root,
+ * or an unexpected layout) return `realFilePath` so the case-folding benefit of
+ * the realpath is preserved.
+ */
+export function rebaseOntoWorkspace(
+	realFilePath: string,
+	realWorkspace: string,
+	workspaceRoot: string,
+): string {
+	// Normalize separators for a reliable prefix comparison.
+	const normRealFile = realFilePath.replace(/\\/g, '/');
+	const normRealWs = realWorkspace.replace(/\\/g, '/');
+	if (
+		normRealFile !== normRealWs &&
+		!normRealFile.startsWith(`${normRealWs}/`)
+	) {
+		// Not under the real workspace — keep the realpath (best effort).
+		return realFilePath;
+	}
+	// Same lexical and real workspace root? Nothing to rebase; the realpath
+	// already matches the walker's keys (modulo case, which realpath fixes).
+	if (path.resolve(workspaceRoot) === path.resolve(realWorkspace)) {
+		return realFilePath;
+	}
+	// Rebase the workspace-relative tail of the realpath'd file onto the
+	// lexical workspace root, reconstructing the path the walker produced.
+	const rel = normRealFile.slice(
+		normRealWs.length + (normRealFile === normRealWs ? 0 : 1),
+	);
+	return path.join(workspaceRoot, rel);
 }
 
 export function createRepoGraphBuilderHook(
@@ -279,7 +320,22 @@ export function createRepoGraphBuilderHook(
 			}
 
 			try {
-				await _updateGraphForFiles(workspaceRoot, [absoluteFilePath]);
+				// Pass a path consistent with how the graph's node keys were
+				// originally produced (issue #1985, defect A5). The walk keys
+				// nodes lexically relative to `workspaceRoot` (it uses realpath
+				// only as a cycle-break key, not for stored paths). To stay
+				// consistent on case-insensitive filesystems AND through symlink
+				// aliases (including a symlinked workspace root), rebase the
+				// realpath'd file back onto the lexical workspace root: this
+				// yields the same key the walker would have produced for a file
+				// reached via the lexical root, while still resolving any
+				// case/symlink aliasing of the file itself.
+				const pathForUpdate = rebaseOntoWorkspace(
+					realFilePath,
+					realWorkspace,
+					workspaceRoot,
+				);
+				await _updateGraphForFiles(workspaceRoot, [pathForUpdate]);
 				recordSuccess(input.sessionID);
 				logger.log(
 					`[repo-graph] Incremental update for ${path.basename(filePath)}`,

--- a/src/tools/repo-graph.ts
+++ b/src/tools/repo-graph.ts
@@ -20,6 +20,7 @@ export {
 	addEdge,
 	buildWorkspaceGraph,
 	buildWorkspaceGraphAsync,
+	isScannableSourcePath,
 	resolveModuleSpecifier,
 	upsertNode,
 } from './repo-graph/builder';

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -128,6 +128,32 @@ const SUPPORTED_EXTENSIONS = new Set(
 );
 
 /**
+ * Whether `p` is a scannable source file — i.e. one of the extensions the
+ * walker turns into a graph node. This is the SINGLE source of truth for "is
+ * this a graph-node-able file" (issue #1985, defect A2): the write hook and
+ * the incremental updater both route through it so the allowlist can never
+ * drift from the builder's `LANGUAGE_REGISTRY`-derived set.
+ */
+export function isScannableSourcePath(p: string): boolean {
+	return SUPPORTED_EXTENSIONS.has(path.extname(p).toLowerCase());
+}
+
+/**
+ * Whether an edge's resolved target is an asset (a real file that never
+ * becomes a graph node, e.g. JSON/CSS) rather than a node. Uses the explicit
+ * `targetKind` tag on schema >= 1.3.0 graphs and falls back to an extension
+ * check on older graphs whose edges are untagged (issue #1985, defect A1).
+ * Asset edges only require their source node to exist during incremental
+ * validation and are excluded from in-degree ranking / importer / dependent
+ * queries.
+ */
+export function isAssetEdge(edge: GraphEdge): boolean {
+	if (edge.targetKind === 'asset') return true;
+	if (edge.targetKind === 'node') return false;
+	return !isScannableSourcePath(edge.target);
+}
+
+/**
  * Default safety budgets for workspace traversal.
  */
 const DEFAULT_WALK_FILE_CAP = 10000;
@@ -513,9 +539,31 @@ interface ScanStats {
 	skippedFiles: number;
 	/** True if maxFiles limit was hit */
 	truncated: boolean;
+	/**
+	 * Absolute scan root, stashed by the builder so the recursive walker can
+	 * compute workspace-relative manifest-dir paths without threading an extra
+	 * parameter through every recursion (defect A8). Underscore-prefixed
+	 * because it is build-internal plumbing, not a reported diagnostic.
+	 */
+	_absoluteRoot?: string;
 }
 
-function createEmptyDiagnostics(): Required<RepoGraphDiagnostics> {
+/**
+ * Fully-populated diagnostics shape used during a build. `Required<>` would
+ * make `walkTruncationReason` (a `'budget' | 'cap'` union with no `undefined`)
+ * non-optional and therefore unrepresentable as "unset" — `undefined` is not
+ * assignable to that union under `strict` (issue #1985, defect A7). Omit the
+ * reason from `Required<>` and re-declare it optional so the rest of the
+ * fields stay required while the reason can be absent until a walk truncates.
+ */
+type FilledDiagnostics = Omit<
+	Required<RepoGraphDiagnostics>,
+	'walkTruncationReason'
+> & {
+	walkTruncationReason?: 'budget' | 'cap';
+};
+
+function createEmptyDiagnostics(): FilledDiagnostics {
 	return {
 		extractionFailures: [],
 		unresolvedImports: [],
@@ -524,6 +572,8 @@ function createEmptyDiagnostics(): Required<RepoGraphDiagnostics> {
 		binaryFiles: [],
 		unreadableFiles: [],
 		lowConfidenceEdgeCount: 0,
+		walkTruncated: false,
+		incrementalFallbacks: 0,
 	};
 }
 
@@ -535,7 +585,10 @@ function diagnosticsHaveEntries(diagnostics: RepoGraphDiagnostics): boolean {
 		(diagnostics.unsupportedFiles?.length ?? 0) > 0 ||
 		(diagnostics.binaryFiles?.length ?? 0) > 0 ||
 		(diagnostics.unreadableFiles?.length ?? 0) > 0 ||
-		(diagnostics.lowConfidenceEdgeCount ?? 0) > 0
+		(diagnostics.lowConfidenceEdgeCount ?? 0) > 0 ||
+		diagnostics.walkTruncated === true ||
+		diagnostics.walkTruncationReason !== undefined ||
+		(diagnostics.incrementalFallbacks ?? 0) > 0
 	);
 }
 
@@ -546,7 +599,7 @@ function pushCapped<T>(target: T[], value: T): void {
 }
 
 function mergeDiagnostics(
-	target: Required<RepoGraphDiagnostics>,
+	target: FilledDiagnostics,
 	source: RepoGraphDiagnostics | undefined,
 ): void {
 	if (!source) return;
@@ -569,6 +622,10 @@ function mergeDiagnostics(
 		pushCapped(target.unreadableFiles, entry);
 	}
 	target.lowConfidenceEdgeCount += source.lowConfidenceEdgeCount ?? 0;
+	// incrementalFallbacks accumulates across per-file scans (rare, but a
+	// single build could surface multiple); walk-level fields are set once
+	// after the walk completes, so they are NOT merged here.
+	target.incrementalFallbacks += source.incrementalFallbacks ?? 0;
 }
 
 function isRelativeImportSpecifier(specifier: string): boolean {
@@ -1273,6 +1330,41 @@ interface WalkContext {
 	/** Directory basenames to skip (built-in defaults ∪ caller excludeDirs). */
 	skipDirs: ReadonlySet<string>;
 	abortReason?: 'budget' | 'cap';
+	/**
+	 * Workspace-relative directories (forward slashes, no leading `./`) that
+	 * contain a package manifest (`package.json`, `Cargo.toml`,
+	 * `pyproject.toml`, `go.mod`). Populated during enumeration so the pure
+	 * ontology extractor can apply the generic manifest-driven boundary rule
+	 * without doing any fs I/O itself (issue #1985, defect A8). The workspace
+	 * root's own manifest is recorded as `''`; the seg0/seg1 boundary rule
+	 * never consults it (no seg0/seg1 at depth 1).
+	 */
+	manifestDirs: Set<string>;
+}
+
+/** Manifest basenames that mark a directory as a package root (defect A8). */
+const MANIFEST_BASENAMES = new Set([
+	'package.json',
+	'Cargo.toml',
+	'pyproject.toml',
+	'go.mod',
+]);
+
+/**
+ * Record `dir`'s workspace-relative path into `manifestDirs` when one of its
+ * direct file entries is a package manifest. `absoluteRoot` is the scan root
+ * used to compute the relative directory; the root itself records as `''`.
+ */
+function recordManifestDir(
+	manifestDirs: Set<string>,
+	absoluteRoot: string,
+	dir: string,
+	entryName: string,
+): void {
+	if (!MANIFEST_BASENAMES.has(entryName)) return;
+	let rel = path.relative(absoluteRoot, dir).split(path.sep).join('/');
+	if (rel.startsWith('./')) rel = rel.slice(2);
+	manifestDirs.add(rel);
 }
 
 function isWalkBudgetExceeded(ctx: WalkContext): boolean {
@@ -1317,7 +1409,7 @@ function findSourceFiles(
 		followSymlinks?: boolean;
 		excludeDirs?: readonly string[];
 	},
-): string[] {
+): { files: string[]; ctx: WalkContext } {
 	const ctx: WalkContext = {
 		stats,
 		seenRealPaths: new Set<string>(),
@@ -1326,13 +1418,14 @@ function findSourceFiles(
 		maxFiles: options?.maxFiles ?? DEFAULT_WALK_FILE_CAP,
 		followSymlinks: options?.followSymlinks ?? false,
 		skipDirs: resolveSkipDirectories(options?.excludeDirs),
+		manifestDirs: new Set<string>(),
 	};
 	const files: string[] = [];
 	walkSyncInto(dir, ctx, files);
 	if (ctx.abortReason === 'cap' || ctx.abortReason === 'budget') {
 		stats.truncated = true;
 	}
-	return files;
+	return { files, ctx };
 }
 
 function walkSyncInto(dir: string, ctx: WalkContext, files: string[]): void {
@@ -1361,6 +1454,9 @@ function walkSyncInto(dir: string, ctx: WalkContext, files: string[]): void {
 		a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
 	);
 
+	// absoluteRoot is the scan root (first call's `dir`). Manifest dirs are
+	// recorded relative to it so the pure ontology extractor needs no fs I/O.
+	const absoluteRoot = ctx.stats._absoluteRoot;
 	for (const entry of entries) {
 		if (isWalkBudgetExceeded(ctx) || isFileCapReached(ctx, files.length)) {
 			return;
@@ -1383,6 +1479,9 @@ function walkSyncInto(dir: string, ctx: WalkContext, files: string[]): void {
 		if (entry.isDirectory()) {
 			walkSyncInto(fullPath, ctx, files);
 		} else if (entry.isFile()) {
+			if (absoluteRoot !== undefined) {
+				recordManifestDir(ctx.manifestDirs, absoluteRoot, dir, entry.name);
+			}
 			const ext = path.extname(fullPath).toLowerCase();
 			if (SUPPORTED_EXTENSIONS.has(ext)) {
 				files.push(fullPath);
@@ -1408,7 +1507,7 @@ async function findSourceFilesAsync(
 		followSymlinks?: boolean;
 		excludeDirs?: readonly string[];
 	},
-): Promise<string[]> {
+): Promise<{ files: string[]; ctx: WalkContext }> {
 	const ctx: WalkContext = {
 		stats,
 		seenRealPaths: new Set<string>(),
@@ -1417,6 +1516,7 @@ async function findSourceFilesAsync(
 		maxFiles: options?.maxFiles ?? DEFAULT_WALK_FILE_CAP,
 		followSymlinks: options?.followSymlinks ?? false,
 		skipDirs: resolveSkipDirectories(options?.excludeDirs),
+		manifestDirs: new Set<string>(),
 	};
 	const files: string[] = [];
 	const queue: string[] = [dir];
@@ -1445,6 +1545,7 @@ async function findSourceFilesAsync(
 			a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
 		);
 
+		const absoluteRoot = ctx.stats._absoluteRoot;
 		for (const entry of entries) {
 			if (isWalkBudgetExceeded(ctx) || isFileCapReached(ctx, files.length)) {
 				break;
@@ -1461,6 +1562,14 @@ async function findSourceFilesAsync(
 			if (entry.isDirectory()) {
 				queue.push(fullPath);
 			} else if (entry.isFile()) {
+				if (absoluteRoot !== undefined) {
+					recordManifestDir(
+						ctx.manifestDirs,
+						absoluteRoot,
+						current,
+						entry.name,
+					);
+				}
 				const ext = path.extname(fullPath).toLowerCase();
 				if (SUPPORTED_EXTENSIONS.has(ext)) {
 					files.push(fullPath);
@@ -1475,7 +1584,7 @@ async function findSourceFilesAsync(
 	if (ctx.abortReason === 'cap' || ctx.abortReason === 'budget') {
 		ctx.stats.truncated = true;
 	}
-	return files;
+	return { files, ctx };
 }
 
 /**
@@ -1557,6 +1666,7 @@ export function scanFile(
 	filePath: string,
 	absoluteRoot: string,
 	maxFileSize: number,
+	hasManifest?: (relDir: string) => boolean,
 ): ScanResult {
 	let content: string;
 	let fileStats: fsSync.Stats;
@@ -1633,6 +1743,7 @@ export function scanFile(
 				language: getLanguage(filePath),
 				exports,
 				imports: parsedImports.map((p) => p.specifier),
+				hasManifest,
 			}),
 		};
 
@@ -1658,6 +1769,7 @@ export function scanFile(
 					importType: parsed.importType,
 					importedSymbols: parsed.importedSymbols,
 					...(usedSymbols !== undefined ? { usedSymbols } : {}),
+					targetKind: isScannableSourcePath(resolvedTarget) ? 'node' : 'asset',
 				});
 			}
 		}
@@ -1689,6 +1801,7 @@ export async function scanFileAsync(
 	filePath: string,
 	absoluteRoot: string,
 	maxFileSize: number,
+	hasManifest?: (relDir: string) => boolean,
 ): Promise<AsyncScanResult> {
 	let content: string;
 	let fileStats: fsSync.Stats;
@@ -1728,7 +1841,7 @@ export async function scanFileAsync(
 
 	// Fail-open: tree-sitter unavailable or timed out → minimal node
 	if (facts === null) {
-		const fallback = scanFile(filePath, absoluteRoot, maxFileSize);
+		const fallback = scanFile(filePath, absoluteRoot, maxFileSize, hasManifest);
 		let parsedImports: ParsedImport[] = [];
 		try {
 			parsedImports = _internals.parseFileImports(
@@ -1859,6 +1972,7 @@ export async function scanFileAsync(
 			language,
 			exports,
 			imports,
+			hasManifest,
 		}),
 	};
 
@@ -1905,6 +2019,7 @@ export async function scanFileAsync(
 				importType: edgeImportType,
 				importedSymbols: imp.bindings.map((b) => b.imported),
 				...(usedSymbols !== undefined ? { usedSymbols } : {}),
+				targetKind: isScannableSourcePath(resolvedTarget) ? 'node' : 'asset',
 			});
 		}
 	}
@@ -2067,13 +2182,16 @@ export function buildWorkspaceGraph(
 		skippedDirs: 0,
 		skippedFiles: 0,
 		truncated: false,
+		_absoluteRoot: absoluteRoot,
 	};
-	const sourceFiles = findSourceFiles(absoluteRoot, stats, {
+	const walked = findSourceFiles(absoluteRoot, stats, {
 		walkBudgetMs,
 		maxFiles,
 		followSymlinks,
 		excludeDirs: options?.excludeDirs,
 	});
+	const sourceFiles = walked.files;
+	const walkCtx = walked.ctx;
 
 	// Sort files for deterministic processing order
 	sourceFiles.sort((a, b) => {
@@ -2088,6 +2206,10 @@ export function buildWorkspaceGraph(
 				`${walkBudgetMs}ms / ${maxFiles}-file budget.`,
 		);
 	}
+
+	// Manifest-directory closure for the generic package-boundary rule (A8).
+	// Built once from the walk context; passed to every ontology extraction.
+	const hasManifest = (relDir: string) => walkCtx.manifestDirs.has(relDir);
 
 	// Process each file to extract nodes and edges. Edge dedup is tracked in a
 	// loop-local Set (O(1)) instead of addEdge's O(edges) linear scan, and nodes
@@ -2178,6 +2300,7 @@ export function buildWorkspaceGraph(
 				language,
 				exports,
 				imports: parsedImports.map((p) => p.specifier),
+				hasManifest,
 			}),
 		};
 
@@ -2214,6 +2337,7 @@ export function buildWorkspaceGraph(
 					importType: parsed.importType,
 					importedSymbols: parsed.importedSymbols,
 					...(usedSymbols !== undefined ? { usedSymbols } : {}),
+					targetKind: isScannableSourcePath(resolvedTarget) ? 'node' : 'asset',
 				};
 				// The node is already valid; an individual invalid edge (e.g. a
 				// control character in an import specifier) drops just that edge
@@ -2234,6 +2358,15 @@ export function buildWorkspaceGraph(
 		nodeCount: Object.keys(graph.nodes).length,
 		edgeCount: graph.edges.length,
 	};
+
+	// Surface walk-truncation diagnostics (defect A7) so getGraphHealth can
+	// report an INCOMPLETE graph instead of confidently wrong results.
+	const syncDiagnostics: FilledDiagnostics = createEmptyDiagnostics();
+	syncDiagnostics.walkTruncated = stats.truncated;
+	syncDiagnostics.walkTruncationReason = walkCtx.abortReason;
+	if (diagnosticsHaveEntries(syncDiagnostics)) {
+		graph.diagnostics = syncDiagnostics;
+	}
 
 	if (stats.skippedFiles > 0 || stats.skippedDirs > 0 || stats.truncated) {
 		logger.log(
@@ -2284,15 +2417,18 @@ export async function buildWorkspaceGraphAsync(
 		skippedDirs: 0,
 		skippedFiles: 0,
 		truncated: false,
+		_absoluteRoot: absoluteRoot,
 	};
 	const diagnostics = createEmptyDiagnostics();
 
-	const sourceFiles = await findSourceFilesAsync(absoluteRoot, stats, {
+	const walked = await findSourceFilesAsync(absoluteRoot, stats, {
 		walkBudgetMs,
 		maxFiles,
 		followSymlinks,
 		excludeDirs: options?.excludeDirs,
 	});
+	const sourceFiles = walked.files;
+	const walkCtx = walked.ctx;
 
 	sourceFiles.sort((a, b) => {
 		const normA = normalizeGraphPath(a);
@@ -2307,6 +2443,9 @@ export async function buildWorkspaceGraphAsync(
 		);
 	}
 
+	// Manifest-directory closure for the generic package-boundary rule (A8).
+	const hasManifest = (relDir: string) => walkCtx.manifestDirs.has(relDir);
+
 	// Edge dedup tracked in a loop-local Set (O(1)); nodes inserted via
 	// appendNodeFast — metadata is computed once below. Keeps construction O(N)
 	// on large repos. Async file reads yield naturally, and the smaller explicit
@@ -2317,7 +2456,12 @@ export async function buildWorkspaceGraphAsync(
 	const allSymbolEdges: SymbolEdge[] = [];
 	let processedSinceYield = 0;
 	for (const filePath of sourceFiles) {
-		const result = await scanFileAsync(filePath, absoluteRoot, maxFileSize);
+		const result = await scanFileAsync(
+			filePath,
+			absoluteRoot,
+			maxFileSize,
+			hasManifest,
+		);
 		mergeDiagnostics(diagnostics, result.diagnostics);
 		if (result.node) {
 			// A node that fails validation (e.g. control characters in ontology
@@ -2377,6 +2521,10 @@ export async function buildWorkspaceGraphAsync(
 	if (allSymbolEdges.length > 0) {
 		graph.symbolEdges = allSymbolEdges;
 	}
+	// Surface walk-truncation diagnostics (defect A7) — walk-level fields are
+	// set once after the walk, NOT merged per-file (extraction diagnostics are).
+	diagnostics.walkTruncated = stats.truncated;
+	diagnostics.walkTruncationReason = walkCtx.abortReason;
 	graph.diagnostics = diagnosticsHaveEntries(diagnostics)
 		? diagnostics
 		: createEmptyDiagnostics();

--- a/src/tools/repo-graph/incremental.ts
+++ b/src/tools/repo-graph/incremental.ts
@@ -5,25 +5,188 @@
  * their nodes and edges in the existing graph, and saves the result. It
  * includes an optimistic concurrency check (mtime comparison) so that
  * concurrent sessions do not overwrite each other's updates — when a race
- * is detected the function falls back to a full rebuild.
+ * is detected the function reloads the freshest on-disk graph and replays
+ * the update once before falling back to a full rebuild.
+ *
+ * Asset edges (issue #1985, defect A1): an edge whose target is a real file
+ * that never becomes a graph node (e.g. `import data from './data.json'`) is
+ * tagged `targetKind: 'asset'`. Such edges only require their SOURCE node to
+ * exist during validation, so a single asset import no longer forces a full
+ * rebuild on every incremental update.
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync, type Stats } from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
 import * as path from 'node:path';
 import * as logger from '../../utils/logger';
 import { containsControlChars } from '../../utils/path-security';
+
+/**
+ * DI seam for the optimistic-concurrency stat check (defect A4). Tests override
+ * `stat` to inject deterministic mtime shifts between load and the pre-save
+ * re-check, exercising the reload-and-replay branch without races. Defaults to
+ * the real `fsPromises.stat`. Restore in afterEach.
+ */
+export const _internals: {
+	stat: (path: string) => Promise<Stats>;
+} = {
+	stat: (p: string) => fsPromises.stat(p),
+};
+
 import {
 	addEdge,
 	buildWorkspaceGraphAsync,
+	isAssetEdge,
+	isScannableSourcePath,
 	scanFileAsync,
 	upsertNode,
 } from './builder';
-import { getCachedMtime } from './cache';
+import { clearCache, getCachedMtime } from './cache';
 import { resetQueryCache } from './query';
 import { getGraphPath, loadGraph, saveGraph } from './storage';
-import type { RepoGraph, SymbolEdge } from './types';
+import type { GraphEdge, RepoGraph, SymbolEdge } from './types';
 import { normalizeGraphPath, updateGraphMetadata } from './types';
+
+/** Manifest basenames that mark a directory as a package root (mirrors builder). */
+const MANIFEST_BASENAMES = new Set([
+	'package.json',
+	'Cargo.toml',
+	'pyproject.toml',
+	'go.mod',
+]);
+
+/**
+ * Build a bounded `hasManifest(relDir)` closure for the incremental re-scan by
+ * checking the unique ancestor directories of existing graph nodes for a package
+ * manifest (defect A8 consistency, issue #1985 review). This keeps the manifest-
+ * driven package boundary stable across incremental edits without redoing a full
+ * workspace walk. A manifest anywhere on a node's directory chain counts (the
+ * boundary rule queries `parts[0]` and `parts[0]/parts[1]`), so each ancestor up
+ * to the workspace root is checked. Bounded: at most one `readdirSync` per
+ * unique ancestor directory across all nodes.
+ */
+function buildManifestClosure(
+	graph: RepoGraph,
+	absoluteRoot: string,
+): (relDir: string) => boolean {
+	// Collect every unique ancestor directory (including the node's own parent)
+	// of every node, so a manifest at any depth on the chain is detected.
+	const dirs = new Set<string>();
+	for (const node of Object.values(graph.nodes)) {
+		const absDir = path.dirname(node.filePath);
+		let rel = path.relative(absoluteRoot, absDir).split(path.sep).join('/');
+		rel = rel.replace(/^(?:\.\/)+/, '');
+		// Walk up the chain, recording each ancestor.
+		while (true) {
+			dirs.add(rel);
+			const idx = rel.lastIndexOf('/');
+			if (idx < 0) {
+				if (rel !== '') dirs.add('');
+				break;
+			}
+			rel = rel.slice(0, idx);
+		}
+	}
+	const manifestDirs = new Set<string>();
+	for (const relDir of dirs) {
+		const absDir =
+			relDir === '' ? absoluteRoot : path.join(absoluteRoot, relDir);
+		try {
+			const entries = readdirSync(absDir);
+			if (entries.some((name) => MANIFEST_BASENAMES.has(name))) {
+				manifestDirs.add(relDir);
+			}
+		} catch {
+			/* directory unreadable — treat as no manifest */
+		}
+	}
+	return (relDir: string) => manifestDirs.has(relDir);
+}
+
+/**
+ * Delete + validation half of the per-file update. For each changed file that
+ * no longer exists on disk, remove its node and all edges referencing it; then
+ * validate the resulting edge set. The async re-scan of still-existing files
+ * is handled separately by {@link applyAsyncFileUpdates}. Splitting the two
+ * halves lets both the normal incremental path and the concurrent-save replay
+ * path (defect A4) share one validation implementation.
+ *
+ * Asset edges only require their source node to exist; node→node edges require
+ * both endpoints (defect A1). Returns `validationFailed: true` when a genuine
+ * orphan edge remains, along with the offending edge for diagnostics.
+ */
+function applyFileUpdates(
+	graph: RepoGraph,
+	filePaths: string[],
+): {
+	validationFailed: boolean;
+	offendingEdge?: GraphEdge;
+	reason?: 'missing-source-node' | 'missing-target-node';
+} {
+	for (const rawFilePath of filePaths) {
+		const normalizedPath = normalizeGraphPath(rawFilePath);
+		if (existsSync(rawFilePath)) continue;
+
+		// File was deleted - remove its node and all edges referencing it.
+		// NOTE (defect A1): asset edges whose target no longer exists on disk
+		// are retained but query-inert (assets are excluded from the reverse /
+		// forward indexes and every direct edge loop); pruning them is out of
+		// scope for this fix.
+		delete graph.nodes[normalizedPath];
+		graph.edges = graph.edges.filter(
+			(e) =>
+				normalizeGraphPath(e.source) !== normalizedPath &&
+				normalizeGraphPath(e.target) !== normalizedPath,
+		);
+		if (graph.symbolEdges) {
+			graph.symbolEdges = graph.symbolEdges.filter(
+				(se) =>
+					normalizeGraphPath(se.fromFile) !== normalizedPath &&
+					normalizeGraphPath(se.toFile) !== normalizedPath,
+			);
+		}
+	}
+
+	// Validate that edge endpoints have corresponding nodes. Asset edges
+	// (targetKind 'asset', or untagged edges whose target is not a scannable
+	// source file on pre-1.3.0 graphs) only require their source node; node→node
+	// edges require both endpoints (defect A1).
+	for (const edge of graph.edges) {
+		const normalizedSource = normalizeGraphPath(edge.source);
+		if (!graph.nodes[normalizedSource]) {
+			return {
+				validationFailed: true,
+				offendingEdge: edge,
+				reason: 'missing-source-node',
+			};
+		}
+		if (!isAssetEdge(edge)) {
+			const normalizedTarget = normalizeGraphPath(edge.target);
+			if (!graph.nodes[normalizedTarget]) {
+				return {
+					validationFailed: true,
+					offendingEdge: edge,
+					reason: 'missing-target-node',
+				};
+			}
+		}
+	}
+
+	// Prune stale symbolEdges whose fromFile or toFile node no longer exists.
+	if (graph.symbolEdges && graph.symbolEdges.length > 0) {
+		const validSymbolEdges: SymbolEdge[] = [];
+		for (const symbolEdge of graph.symbolEdges) {
+			const normalizedFromFile = normalizeGraphPath(symbolEdge.fromFile);
+			const normalizedToFile = normalizeGraphPath(symbolEdge.toFile);
+			if (graph.nodes[normalizedFromFile] && graph.nodes[normalizedToFile]) {
+				validSymbolEdges.push(symbolEdge);
+			}
+		}
+		graph.symbolEdges = validSymbolEdges;
+	}
+
+	return { validationFailed: false };
+}
 
 /**
  * Incrementally update the graph for a set of changed files.
@@ -57,180 +220,262 @@ export async function updateGraphForFiles(
 		return graph;
 	}
 
-	// Work on a copy of the existing graph
 	const graph = existingGraph;
 	const absoluteRoot = path.resolve(workspaceRoot);
 	const maxFileSize = 1024 * 1024; // 1MB default
 
-	// Normalize file paths to track which files were updated
-	const updatedPaths = new Set<string>();
+	// Manifest-aware package boundaries must stay consistent with the initial
+	// build across incremental edits (defect A8). Re-derive a bounded
+	// hasManifest closure from the existing graph's node directories.
+	const hasManifest = buildManifestClosure(graph, absoluteRoot);
 
-	for (const rawFilePath of filePaths) {
-		const normalizedPath = normalizeGraphPath(rawFilePath);
+	await applyAsyncFileUpdates(
+		graph,
+		filePaths,
+		absoluteRoot,
+		maxFileSize,
+		hasManifest,
+	);
 
-		// Check if file exists
-		const fileExists = existsSync(rawFilePath);
-
-		if (fileExists) {
-			// Remove old edges from this file before adding new ones
-			graph.edges = graph.edges.filter(
-				(e) => normalizeGraphPath(e.source) !== normalizedPath,
-			);
-
-			// Remove stale OUTGOING symbolEdges from this file before re-scanning.
-			// Incoming edges (toFile === changedFile) come from consumers' refs and
-			// cannot be rebuilt by rescanning only the provider; leave them in place.
-			if (graph.symbolEdges) {
-				graph.symbolEdges = graph.symbolEdges.filter(
-					(se) => normalizeGraphPath(se.fromFile) !== normalizedPath,
-				);
-			}
-
-			// Scan the file asynchronously to get node, edges, and symbolEdges
-			const result = await scanFileAsync(
-				rawFilePath,
-				absoluteRoot,
-				maxFileSize,
-			);
-
-			if (result.node) {
-				// Sanitize imports: strip control-char specifiers that tree-sitter
-				// may return raw (mirrors parseFileImports filtering in the sync path).
-				const sanitizedImports = result.node.imports.filter(
-					(imp) => !containsControlChars(imp),
-				);
-				const sanitizedNode: typeof result.node = {
-					...result.node,
-					imports: sanitizedImports,
-				};
-
-				// Remove old node if present
-				delete graph.nodes[normalizedPath];
-				// Add updated node (carries exportRanges when present)
-				upsertNode(graph, sanitizedNode);
-
-				// Add new edges (avoiding duplicates)
-				for (const edge of result.edges) {
-					const edgeExists = graph.edges.some(
-						(e) =>
-							e.source === edge.source &&
-							e.target === edge.target &&
-							e.importSpecifier === edge.importSpecifier,
-					);
-					if (!edgeExists) {
-						addEdge(graph, edge);
-					}
-				}
-
-				// Add new symbolEdges (avoiding duplicates)
-				if (result.symbolEdges.length > 0) {
-					if (!graph.symbolEdges) {
-						graph.symbolEdges = [];
-					}
-					const existingKeys = new Set(
-						graph.symbolEdges.map(
-							(se) =>
-								`${se.fromFile}\u0000${se.fromSymbol}\u0000${se.toFile}\u0000${se.toSymbol}`,
-						),
-					);
-					for (const symbolEdge of result.symbolEdges) {
-						const key = `${symbolEdge.fromFile}\u0000${symbolEdge.fromSymbol}\u0000${symbolEdge.toFile}\u0000${symbolEdge.toSymbol}`;
-						if (!existingKeys.has(key)) {
-							graph.symbolEdges.push(symbolEdge);
-							existingKeys.add(key);
-						}
-					}
-				}
-			}
-		} else {
-			// File was deleted - remove its node and all edges referencing it
-			delete graph.nodes[normalizedPath];
-			graph.edges = graph.edges.filter(
-				(e) =>
-					normalizeGraphPath(e.source) !== normalizedPath &&
-					normalizeGraphPath(e.target) !== normalizedPath,
-			);
-			// Remove stale symbolEdges referencing the deleted file
-			if (graph.symbolEdges) {
-				graph.symbolEdges = graph.symbolEdges.filter(
-					(se) =>
-						normalizeGraphPath(se.fromFile) !== normalizedPath &&
-						normalizeGraphPath(se.toFile) !== normalizedPath,
-				);
-			}
-		}
-
-		updatedPaths.add(normalizedPath);
-	}
-
-	// Validate that all edge sources and targets have corresponding nodes.
-	// Also prune stale symbolEdges whose fromFile or toFile node no longer exists.
-	let validationFailed = false;
-	for (const edge of graph.edges) {
-		const normalizedSource = normalizeGraphPath(edge.source);
-		const normalizedTarget = normalizeGraphPath(edge.target);
-		if (!graph.nodes[normalizedSource] || !graph.nodes[normalizedTarget]) {
-			validationFailed = true;
-			break;
-		}
-	}
-
-	if (graph.symbolEdges && graph.symbolEdges.length > 0) {
-		const validSymbolEdges: SymbolEdge[] = [];
-		for (const symbolEdge of graph.symbolEdges) {
-			const normalizedFromFile = normalizeGraphPath(symbolEdge.fromFile);
-			const normalizedToFile = normalizeGraphPath(symbolEdge.toFile);
-			if (graph.nodes[normalizedFromFile] && graph.nodes[normalizedToFile]) {
-				validSymbolEdges.push(symbolEdge);
-			}
-		}
-		graph.symbolEdges = validSymbolEdges;
-	}
-
-	if (validationFailed) {
-		logger.warn(
-			`[repo-graph] Incremental update failed, falling back to full rebuild`,
+	const firstCheck = applyFileUpdates(graph, filePaths);
+	if (firstCheck.validationFailed) {
+		return await fallBackToFullRebuild(
+			workspaceRoot,
+			firstCheck.offendingEdge,
+			firstCheck.reason,
 		);
-		const rebuiltGraph = await buildWorkspaceGraphAsync(workspaceRoot);
-		await saveGraph(workspaceRoot, rebuiltGraph);
-		return rebuiltGraph;
 	}
 
 	// Optimistic concurrency: check that the on-disk graph has not been
 	// modified by another session since we loaded it. If the mtime differs,
 	// another process saved a newer graph while we were computing our
-	// incremental update. Fall back to a full rebuild in that case so we
-	// do not overwrite the concurrent session's changes with a stale view.
+	// incremental update. Reload the freshest graph, replay the update ONCE,
+	// and if the mtime moved again during replay, fall back to a full rebuild
+	// (defect A4 — bounded, never loops).
 	const normalizedWorkspace = path.normalize(workspaceRoot);
 	const loadedMtime = getCachedMtime(normalizedWorkspace);
 	if (loadedMtime !== undefined) {
+		const graphPath = getGraphPath(workspaceRoot);
+		// The stat check is wrapped narrowly: a stat failure is a transient
+		// I/O error we tolerate (proceed with the save). Every other branch
+		// (mismatch detected, reload, replay) is handled explicitly below so a
+		// failure there can NEVER fall through to saving the stale `graph` over
+		// a newer on-disk graph (issue #1985 review).
+		let currentStats: Stats | null = null;
 		try {
-			const graphPath = getGraphPath(workspaceRoot);
 			if (existsSync(graphPath)) {
-				const currentStats = await fsPromises.stat(graphPath);
-				if (currentStats.mtimeMs !== loadedMtime) {
-					logger.warn(
-						`[repo-graph] Concurrent modification detected — falling back to full rebuild`,
-					);
-					const rebuiltGraph = await buildWorkspaceGraphAsync(workspaceRoot);
-					await saveGraph(workspaceRoot, rebuiltGraph);
-					return rebuiltGraph;
-				}
+				currentStats = await _internals.stat(graphPath);
 			}
 		} catch {
 			// If we can't stat the file, proceed with the save anyway.
 		}
+		if (currentStats !== null && currentStats.mtimeMs !== loadedMtime) {
+			// Concurrent modification detected — `graph` is now stale. Never
+			// return to saving it: reload + replay, or terminal rebuild.
+			clearCacheAndResetQuery(normalizedWorkspace);
+			const freshGraph = await loadGraph(workspaceRoot);
+			if (!freshGraph) {
+				// File vanished between our load and the concurrent write —
+				// full rebuild reconciles from the live workspace.
+				return await fallBackToFullRebuild(workspaceRoot);
+			}
+			await applyAsyncFileUpdates(
+				freshGraph,
+				filePaths,
+				absoluteRoot,
+				maxFileSize,
+				buildManifestClosure(freshGraph, absoluteRoot),
+			);
+			const replayCheck = applyFileUpdates(freshGraph, filePaths);
+			if (replayCheck.validationFailed) {
+				return await fallBackToFullRebuild(
+					workspaceRoot,
+					replayCheck.offendingEdge,
+					replayCheck.reason,
+				);
+			}
+			// Re-stat before save: if the mtime moved AGAIN during replay,
+			// another writer beat us — terminal full rebuild. A re-stat failure
+			// here is also treated as a rebuild (fail closed under concurrency).
+			const postReplayMtime = getCachedMtime(normalizedWorkspace);
+			try {
+				const postReplayStats = await _internals.stat(graphPath);
+				if (
+					postReplayMtime !== undefined &&
+					postReplayStats.mtimeMs !== postReplayMtime
+				) {
+					logger.warn(
+						'[repo-graph] Concurrent modification persisted during replay — falling back to full rebuild',
+					);
+					return await fallBackToFullRebuild(workspaceRoot);
+				}
+			} catch {
+				logger.warn(
+					'[repo-graph] Re-stat failed after concurrent-modification replay — falling back to full rebuild',
+				);
+				return await fallBackToFullRebuild(workspaceRoot);
+			}
+
+			return finalizeAndSave(workspaceRoot, freshGraph);
+		}
 	}
 
+	return finalizeAndSave(workspaceRoot, graph);
+}
+
+/**
+ * Async re-scan half of the per-file update: for each existing file, remove
+ * its old outgoing edges/symbolEdges, re-scan, and fold the new node + edges
+ * + symbolEdges into `graph`. Deleted files are handled by the synchronous
+ * `applyFileUpdates` delete branch.
+ *
+ * `hasManifest` (when available) is forwarded to the scanner so manifest-aware
+ * package boundaries stay consistent with the initial build (defect A8). A
+ * previously-tracked source file whose rescan returns `node: null` (it became
+ * oversized, binary, or unreadable) has its stale node removed and any
+ * incoming node→node edges caught by the subsequent validation fallback.
+ */
+async function applyAsyncFileUpdates(
+	graph: RepoGraph,
+	filePaths: string[],
+	absoluteRoot: string,
+	maxFileSize: number,
+	hasManifest?: (relDir: string) => boolean,
+): Promise<void> {
+	for (const rawFilePath of filePaths) {
+		const normalizedPath = normalizeGraphPath(rawFilePath);
+		if (!existsSync(rawFilePath)) continue;
+
+		// Defense in depth: only scannable source files become nodes. The write
+		// hook already filters, but updateGraphForFiles is a public entry point
+		// (issue #1985 review) — refuse to mutate the graph for an unsupported
+		// extension rather than letting scanFileAsync create an 'unknown' node.
+		if (!isScannableSourcePath(rawFilePath)) continue;
+
+		// Remove old edges from this file before adding new ones.
+		graph.edges = graph.edges.filter(
+			(e) => normalizeGraphPath(e.source) !== normalizedPath,
+		);
+		if (graph.symbolEdges) {
+			graph.symbolEdges = graph.symbolEdges.filter(
+				(se) => normalizeGraphPath(se.fromFile) !== normalizedPath,
+			);
+		}
+
+		const result = await scanFileAsync(
+			rawFilePath,
+			absoluteRoot,
+			maxFileSize,
+			hasManifest,
+		);
+
+		if (result.node) {
+			// Sanitize imports: strip control-char specifiers that tree-sitter
+			// may return raw (mirrors parseFileImports filtering in the sync path).
+			const sanitizedImports = result.node.imports.filter(
+				(imp) => !containsControlChars(imp),
+			);
+			const sanitizedNode: typeof result.node = {
+				...result.node,
+				imports: sanitizedImports,
+			};
+
+			delete graph.nodes[normalizedPath];
+			upsertNode(graph, sanitizedNode);
+
+			for (const edge of result.edges) {
+				const edgeExists = graph.edges.some(
+					(e) =>
+						e.source === edge.source &&
+						e.target === edge.target &&
+						e.importSpecifier === edge.importSpecifier,
+				);
+				if (!edgeExists) {
+					addEdge(graph, edge);
+				}
+			}
+
+			if (result.symbolEdges.length > 0) {
+				if (!graph.symbolEdges) {
+					graph.symbolEdges = [];
+				}
+				const existingKeys = new Set(
+					graph.symbolEdges.map(
+						(se) =>
+							`${se.fromFile}\u0000${se.fromSymbol}\u0000${se.toFile}\u0000${se.toSymbol}`,
+					),
+				);
+				for (const symbolEdge of result.symbolEdges) {
+					const key = `${symbolEdge.fromFile}\u0000${symbolEdge.fromSymbol}\u0000${symbolEdge.toFile}\u0000${symbolEdge.toSymbol}`;
+					if (!existingKeys.has(key)) {
+						graph.symbolEdges.push(symbolEdge);
+						existingKeys.add(key);
+					}
+				}
+			}
+		} else {
+			// The file was previously a node but is now oversized/binary/
+			// unreadable. Remove its stale node so the subsequent validation
+			// pass catches any dangling incoming node→node edges and triggers
+			// the documented full-rebuild fallback (issue #1985 review).
+			delete graph.nodes[normalizedPath];
+		}
+	}
+}
+
+function clearCacheAndResetQuery(normalizedWorkspace: string): void {
+	clearCache(normalizedWorkspace);
+	resetQueryCache();
+}
+
+async function finalizeAndSave(
+	workspaceRoot: string,
+	graph: RepoGraph,
+): Promise<RepoGraph> {
 	// Only keep symbolEdges when non-empty (matches buildWorkspaceGraphAsync behavior)
 	if (graph.symbolEdges && graph.symbolEdges.length === 0) {
 		delete graph.symbolEdges;
 	}
-
-	// Update metadata and save
 	updateGraphMetadata(graph);
 	resetQueryCache();
 	await saveGraph(workspaceRoot, graph);
-
 	return graph;
+}
+
+/**
+ * Fall back to a full workspace rebuild, logging the specific offending edge
+ * (when available) and incrementing the `incrementalFallbacks` diagnostics
+ * counter so `graph_health` can surface recurring fallbacks (defect A1/A7).
+ */
+async function fallBackToFullRebuild(
+	workspaceRoot: string,
+	offendingEdge?: GraphEdge,
+	reason?: 'missing-source-node' | 'missing-target-node',
+): Promise<RepoGraph> {
+	if (offendingEdge) {
+		logger.warn(
+			`[repo-graph] Incremental update failed, falling back to full rebuild ` +
+				`(offending edge: source=${offendingEdge.source} target=${offendingEdge.target} ` +
+				`importSpecifier=${offendingEdge.importSpecifier}` +
+				(reason ? `, reason=${reason}` : '') +
+				`)`,
+		);
+	} else {
+		logger.warn(
+			'[repo-graph] Concurrent modification detected — falling back to full rebuild',
+		);
+	}
+	const rebuiltGraph = await buildWorkspaceGraphAsync(workspaceRoot);
+	// Bump the fallback counter without clobbering extraction diagnostics.
+	const prev = rebuiltGraph.diagnostics ?? {};
+	const prevFallbacks =
+		typeof prev.incrementalFallbacks === 'number'
+			? prev.incrementalFallbacks
+			: 0;
+	rebuiltGraph.diagnostics = {
+		...prev,
+		incrementalFallbacks: prevFallbacks + 1,
+	};
+	await saveGraph(workspaceRoot, rebuiltGraph);
+	return rebuiltGraph;
 }

--- a/src/tools/repo-graph/ontology.ts
+++ b/src/tools/repo-graph/ontology.ts
@@ -9,6 +9,7 @@ import type {
 	RouteMethod,
 	SecurityFact,
 } from './types';
+import { inferPackageBoundary } from './types';
 
 export interface ExtractFileOntologyInput {
 	moduleName: string;
@@ -17,6 +18,14 @@ export interface ExtractFileOntologyInput {
 	language: string;
 	exports: string[];
 	imports: string[];
+	/**
+	 * Optional callback returning true when a workspace-relative directory
+	 * contains a package manifest (`package.json`, `Cargo.toml`,
+	 * `pyproject.toml`, `go.mod`). When provided, the package-boundary rule
+	 * becomes manifest-driven; otherwise it falls back to the static segment
+	 * rules (issue #1985, defect A8). The extractor stays pure — no fs I/O.
+	 */
+	hasManifest?: (relDir: string) => boolean;
 }
 
 const HTTP_METHODS: RouteMethod[] = [
@@ -102,21 +111,18 @@ function addRole(roles: Set<FileRole>, role: FileRole): void {
 	roles.add(role);
 }
 
-function boundaryForModule(moduleName: string): string {
-	const normalized = normalizeModuleName(moduleName);
-	const parts = normalized.split('/').filter(Boolean);
-	if (parts.length === 0) return '.';
-	if ((parts[0] === 'packages' || parts[0] === 'crates') && parts.length >= 2) {
-		return `${parts[0]}/${parts[1]}`;
-	}
-	if (parts[0] === 'src' && parts.length >= 3) {
-		if (parts[1] === 'tools' && parts[2] === 'repo-graph') {
-			return 'src/tools/repo-graph';
-		}
-		return `src/${parts[1]}`;
-	}
-	if (parts[0] === 'tests' && parts.length >= 2) return `tests/${parts[1]}`;
-	return parts[0];
+/**
+ * Infer the package boundary for a module. Delegates to the shared, pure
+ * `inferPackageBoundary` helper so ontology extraction and the query-side
+ * no-ontology fallback stay in lockstep (issue #1985, defect A8). The
+ * previous `src/tools/repo-graph` special case is removed: user repos should
+ * not inherit this project's internal layout.
+ */
+function boundaryForModule(
+	moduleName: string,
+	hasManifest?: (relDir: string) => boolean,
+): string {
+	return inferPackageBoundary(moduleName, hasManifest);
 }
 
 function inferRoles(moduleName: string, content: string): FileRole[] {
@@ -487,7 +493,7 @@ export function extractFileOntology(
 
 	return {
 		roles,
-		packageBoundary: boundaryForModule(moduleName),
+		packageBoundary: boundaryForModule(moduleName, input.hasManifest),
 		routes,
 		dataOperations,
 		security,

--- a/src/tools/repo-graph/query.ts
+++ b/src/tools/repo-graph/query.ts
@@ -4,6 +4,7 @@ import {
 	containsControlChars,
 	containsPathTraversal,
 } from '../../utils/path-security';
+import { isAssetEdge } from './builder';
 import type {
 	BlastRadiusResult,
 	CallerReference,
@@ -25,7 +26,11 @@ import type {
 	SymbolEdge,
 	SymbolReference,
 } from './types';
-import { isSchemaVersionAtLeast, normalizeGraphPath } from './types';
+import {
+	inferPackageBoundary,
+	isSchemaVersionAtLeast,
+	normalizeGraphPath,
+} from './types';
 
 const GRAPH_HEALTH_OUTPUT_LIMIT = 50;
 const MAX_HEALTH_PATH_LENGTH = 500;
@@ -82,6 +87,10 @@ function buildReverseIndex(graph: RepoGraph): Map<string, FileReference[]> {
 		moduleNameIndex.set(normalizeLookupPath(node.moduleName), node);
 	}
 	for (const edge of graph.edges) {
+		// Asset edges (e.g. import './data.json') never have a target node and
+		// must not count toward in-degree / importer / dependent rankings
+		// (issue #1985, defect A1).
+		if (isAssetEdge(edge)) continue;
 		const source = normalizeGraphPath(edge.source);
 		const target = normalizeGraphPath(edge.target);
 		const sourceRef: FileReference = {
@@ -241,6 +250,9 @@ export function getGraphHealth(
 			binaryFiles: [],
 			unreadableFiles: [],
 			lowConfidenceEdgeCount: 0,
+			walkTruncated: false,
+			walkTruncationReason: null,
+			incrementalFallbacks: 0,
 			notes: [
 				'No repo graph found at .swarm/repo-graph.json. Run repo_map with action="build" first.',
 			],
@@ -272,6 +284,29 @@ export function getGraphHealth(
 		);
 	}
 
+	// Walk-truncation + incremental-fallback diagnostics (issue #1985, A7).
+	const walkTruncated = diagnostics?.walkTruncated === true;
+	const rawReason = diagnostics?.walkTruncationReason;
+	const walkTruncationReason: 'budget' | 'cap' | null =
+		rawReason === 'budget' || rawReason === 'cap' ? rawReason : null;
+	const incrementalFallbacks =
+		typeof diagnostics?.incrementalFallbacks === 'number' &&
+		Number.isFinite(diagnostics.incrementalFallbacks) &&
+		diagnostics.incrementalFallbacks > 0
+			? Math.floor(diagnostics.incrementalFallbacks)
+			: 0;
+	if (walkTruncated) {
+		notes.push(
+			'Graph is INCOMPLETE: walk hit the file-cap/wall-clock budget — results may be missing files.' +
+				(walkTruncationReason ? ` (reason: ${walkTruncationReason})` : ''),
+		);
+	}
+	if (incrementalFallbacks > 0) {
+		notes.push(
+			`${incrementalFallbacks} incremental update(s) fell back to a full rebuild (validation failure or concurrent modification).`,
+		);
+	}
+
 	return {
 		schemaVersion: graph.schema_version,
 		fresh,
@@ -292,6 +327,9 @@ export function getGraphHealth(
 			diagnostics.lowConfidenceEdgeCount > 0
 				? Math.floor(diagnostics.lowConfidenceEdgeCount)
 				: 0,
+		walkTruncated,
+		walkTruncationReason,
+		incrementalFallbacks,
 		notes,
 	};
 }
@@ -325,6 +363,7 @@ export function getSymbolConsumers(
 	const targetKey = normalizeGraphPath(node.filePath);
 	const refs: SymbolReference[] = [];
 	for (const edge of graph.edges) {
+		if (isAssetEdge(edge)) continue;
 		if (normalizeGraphPath(edge.target) !== targetKey) continue;
 		const importedSymbols = edge.importedSymbols ?? [];
 		if (edge.importType === 'namespace') {
@@ -362,6 +401,7 @@ export function getCallers(
 	const refs: CallerReference[] = [];
 	const seen = new Set<string>();
 	for (const edge of graph.edges) {
+		if (isAssetEdge(edge)) continue;
 		if (normalizeGraphPath(edge.target) !== targetKey) continue;
 		const file = moduleNameForEdgePath(graph, edge.source);
 		if (seen.has(file)) continue;
@@ -431,6 +471,9 @@ export function getDeadExports(
 	// One O(edges) pass: per target, union of used symbols + unresolvable flag.
 	const usage = new Map<string, { used: Set<string>; unresolvable: boolean }>();
 	for (const edge of graph.edges) {
+		// Asset edges carry no node-level usage signal (their target never
+		// became a node), so they cannot contribute to dead-export analysis.
+		if (isAssetEdge(edge)) continue;
 		const target = normalizeGraphPath(edge.target);
 		let entry = usage.get(target);
 		if (!entry) {
@@ -793,6 +836,7 @@ function collectExternallyUsedSymbols(
 	const used = new Set<string>();
 	const targetKey = normalizeGraphPath(node.filePath);
 	for (const edge of graph.edges) {
+		if (isAssetEdge(edge)) continue;
 		if (normalizeGraphPath(edge.target) !== targetKey) continue;
 		for (const symbol of edge.importedSymbols ?? []) {
 			if (exported.has(symbol)) used.add(symbol);
@@ -911,6 +955,9 @@ function summarizePackageBoundaries(
 	const dependsOn = new Map<string, Set<string>>();
 	const dependedOnBy = new Map<string, Set<string>>();
 	for (const edge of edges) {
+		// Asset edges do not represent a real package dependency (their target
+		// is not a source file), so they are excluded from boundary graphs.
+		if (isAssetEdge(edge)) continue;
 		const sourceBoundary = boundaryByPath.get(normalizeGraphPath(edge.source));
 		const targetBoundary = boundaryByPath.get(normalizeGraphPath(edge.target));
 		if (
@@ -997,13 +1044,15 @@ function summarizeSelectedPackageBoundaries(
 	return summaries;
 }
 
+/**
+ * No-ontology fallback for the package boundary. Delegates to the shared
+ * `inferPackageBoundary` helper (no `hasManifest` callback here — the query
+ * path does not retain the walk-time manifest set, so it falls back to the
+ * static segment rules). Keeps the query fallback in lockstep with ontology
+ * extraction (issue #1985, defect A8).
+ */
 function inferBoundary(moduleName: string): string {
-	const parts = normalizeLookupPath(moduleName).split('/').filter(Boolean);
-	if (parts[0] === 'src' && parts.length >= 2) return `src/${parts[1]}`;
-	if (parts.length >= 2 && (parts[0] === 'packages' || parts[0] === 'crates')) {
-		return `${parts[0]}/${parts[1]}`;
-	}
-	return parts[0] || '.';
+	return inferPackageBoundary(moduleName);
 }
 
 export function buildOntologyPreflightPacket(

--- a/src/tools/repo-graph/types.ts
+++ b/src/tools/repo-graph/types.ts
@@ -28,11 +28,20 @@ export const REPO_GRAPH_FILENAME = 'repo-graph.json';
  * still load without corruption. New queries may use these fields to provide
  * more precise context-packing and symbol-level navigation.
  *
+ * 1.3.0 adds the optional per-edge `targetKind` field (`'node' | 'asset'`)
+ * that distinguishes edges whose resolved target is a scannable source file
+ * (a graph node) from edges whose target is an asset (JSON/CSS/etc. — a real
+ * file that never becomes a node). The field is optional, so 1.0.0–1.2.0
+ * graphs still load; `storage.ts` only checks that a version string is
+ * present, and feature gating is per-query via {@link isSchemaVersionAtLeast}.
+ * For pre-1.3.0 graphs the loader/queries fall back to an extension check
+ * (`isScannableSourcePath`) to classify an untagged edge's target kind.
+ *
  * Diagnostics are additive and optional on all schema versions. Old graphs
  * without diagnostics remain readable; graph-health queries surface empty
  * diagnostics with an explicit rebuild note.
  */
-export const GRAPH_SCHEMA_VERSION = '1.2.0';
+export const GRAPH_SCHEMA_VERSION = '1.3.0';
 
 /**
  * Compare dotted numeric version strings (e.g. '1.1.0' >= '1.1.0').
@@ -251,6 +260,16 @@ export interface GraphEdge {
 	 * imports, where individual symbol usage is not statically resolvable.
 	 */
 	usedSymbols?: string[];
+	/**
+	 * Whether the resolved target is a graph node or an asset. `'node'` targets
+	 * are scannable source files that become graph nodes; `'asset'` targets are
+	 * real files (JSON/CSS/etc.) that never become nodes (schema >= 1.3.0).
+	 * Absent on older graphs — callers fall back to `isScannableSourcePath` on
+	 * the target path. Asset edges only require their source node to exist
+	 * during incremental validation, and are excluded from in-degree ranking /
+	 * importer / dependent queries.
+	 */
+	targetKind?: 'node' | 'asset';
 }
 
 export interface FileReference {
@@ -378,6 +397,20 @@ export interface RepoGraphDiagnostics {
 	binaryFiles?: string[];
 	unreadableFiles?: string[];
 	lowConfidenceEdgeCount?: number;
+	/**
+	 * True when the last workspace walk was truncated by the file cap or wall-
+	 * clock budget (issue #1985, defect A7). Additive/optional on all schema
+	 * versions — old graphs without it read as `false`.
+	 */
+	walkTruncated?: boolean;
+	/** Why the walk truncated: hit the wall-clock `'budget'` or the `'cap'`. */
+	walkTruncationReason?: 'budget' | 'cap';
+	/**
+	 * Count of incremental-update passes that fell back to a full rebuild
+	 * (issue #1985, defect A1). Accumulated across incremental runs; reset on
+	 * a fresh full build.
+	 */
+	incrementalFallbacks?: number;
 }
 
 export interface GraphHealthResult {
@@ -391,6 +424,9 @@ export interface GraphHealthResult {
 	binaryFiles: string[];
 	unreadableFiles: string[];
 	lowConfidenceEdgeCount: number;
+	walkTruncated: boolean;
+	walkTruncationReason: 'budget' | 'cap' | null;
+	incrementalFallbacks: number;
 	notes: string[];
 }
 
@@ -478,6 +514,70 @@ export interface BuildWorkspaceGraphOptions {
  */
 export function normalizeGraphPath(filePath: string): string {
 	return path.normalize(filePath).replace(/\\/g, '/');
+}
+
+/**
+ * Top-level directory segments that, when present as the first path segment,
+ * mark the next segment as a package boundary (monorepo workspaces). Used by
+ * {@link inferPackageBoundary} (issue #1985, defect A8).
+ */
+const PACKAGE_BOUNDARY_ROOTS = new Set([
+	'packages',
+	'crates',
+	'apps',
+	'libs',
+	'services',
+]);
+
+/**
+ * Infer the package boundary for a module name using the generic rule shared
+ * by ontology extraction and the query-side no-ontology fallback (issue #1985,
+ * defect A8). Pure / dependency-free / no fs I/O so it can live in this
+ * foundation module and stay callable from both `ontology.ts` and `query.ts`.
+ *
+ * Rules (in order):
+ *  - empty → `'.'`
+ *  - segment 0 ∈ {packages, crates, apps, libs, services} with ≥2 segments → `<seg0>/<seg1>`
+ *  - segment 0 === `src` with ≥2 segments → `src/<seg1>`
+ *  - segment 0 === `tests` with ≥2 segments → `tests/<seg1>`
+ *  - when `hasManifest` is provided and either `<seg0>` or `<seg0>/<seg1>` is a
+ *    manifest-bearing directory (with ≥2 segments) → `<seg0>/<seg1>`
+ *  - otherwise → segment 0 (or `'.'` when there are no segments)
+ *
+ * The previous `src/tools/repo-graph` special case is intentionally removed:
+ * user repos should not inherit this project's internal layout.
+ *
+ * @param moduleName - Workspace-relative module name (forward slashes).
+ * @param hasManifest - Optional callback returning true when a workspace-
+ *   relative directory contains a package manifest (`package.json`,
+ *   `Cargo.toml`, `pyproject.toml`, `go.mod`). When omitted, only the static
+ *   segment rules apply.
+ */
+export function inferPackageBoundary(
+	moduleName: string,
+	hasManifest?: (relDir: string) => boolean,
+): string {
+	const normalized = moduleName.replace(/\\/g, '/').replace(/^(?:\.\/)+/, '');
+	const parts = normalized.split('/').filter(Boolean);
+	if (parts.length === 0) return '.';
+	if (PACKAGE_BOUNDARY_ROOTS.has(parts[0]) && parts.length >= 2) {
+		return `${parts[0]}/${parts[1]}`;
+	}
+	if (parts[0] === 'src' && parts.length >= 2) {
+		return `src/${parts[1]}`;
+	}
+	if (parts[0] === 'tests' && parts.length >= 2) {
+		return `tests/${parts[1]}`;
+	}
+	if (hasManifest && parts.length >= 2) {
+		// A manifest directly under seg0 (e.g. `<seg0>/package.json`) marks the
+		// whole subtree as one package root; a manifest under seg0/seg1 marks
+		// that subdirectory as its own package.
+		if (hasManifest(parts[0]) || hasManifest(`${parts[0]}/${parts[1]}`)) {
+			return `${parts[0]}/${parts[1]}`;
+		}
+	}
+	return parts[0];
 }
 
 // ============ Basic Graph Construction ============

--- a/src/tools/repo-graph/validation.ts
+++ b/src/tools/repo-graph/validation.ts
@@ -393,4 +393,13 @@ export function validateGraphEdge(edge: GraphEdge): void {
 			}
 		}
 	}
+	// targetKind is optional (schema >= 1.3.0). Old graphs omit it and load
+	// unchanged; a present-but-invalid value fails closed (issue #1985, A1).
+	if (
+		edge.targetKind !== undefined &&
+		edge.targetKind !== 'node' &&
+		edge.targetKind !== 'asset'
+	) {
+		throw new Error('Invalid edge: targetKind must be "node" or "asset"');
+	}
 }

--- a/src/tools/repo-map.ts
+++ b/src/tools/repo-map.ts
@@ -255,6 +255,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 					ontologyFileCount,
 					buildTimestamp: graph.metadata.generatedAt,
 					elapsedMs,
+					truncated: graph.diagnostics?.walkTruncated === true,
 					path: '.swarm/repo-graph.json',
 				});
 			} catch (e) {

--- a/tests/unit/hooks/repo-graph-builder.test.ts
+++ b/tests/unit/hooks/repo-graph-builder.test.ts
@@ -18,7 +18,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { createRepoGraphBuilderHook } from '../../../src/hooks/repo-graph-builder';
+import {
+	createRepoGraphBuilderHook,
+	rebaseOntoWorkspace,
+} from '../../../src/hooks/repo-graph-builder';
 import * as logger from '../../../src/utils/logger';
 
 // Workaround for Bun #32056: on Windows, a pending promise that leaves the
@@ -322,6 +325,96 @@ describe('toolAfter hook', () => {
 
 		// Verify updateGraphForFiles was NOT called
 		expect(mockUpdateGraphForFiles).not.toHaveBeenCalled();
+	});
+
+	test('toolAfter triggers update for .rs/.go/.pyw writes (A2 extension parity)', async () => {
+		// Regression for issue #1985 defect A2: the hook's extension list used
+		// to drift from the builder's, so Rust/Go/.pyw edits never triggered an
+		// incremental update. They now route through the shared
+		// isScannableSourcePath and pick up .rs/.go/.pyw automatically.
+		const workspaceRoot = tempWorkspace;
+		const hook = createRepoGraphBuilderHook(workspaceRoot, {
+			buildWorkspaceGraph: mockBuildWorkspaceGraph,
+			saveGraph: mockSaveGraph,
+			updateGraphForFiles: mockUpdateGraphForFiles,
+		});
+
+		for (const ext of ['.rs', '.go', '.pyw']) {
+			mockUpdateGraphForFiles.mockClear();
+			await hook.toolAfter(
+				{
+					tool: 'edit',
+					sessionID: 'test-session',
+					args: { file_path: `module${ext}` },
+				},
+				{ output: undefined },
+			);
+			expect(mockUpdateGraphForFiles).toHaveBeenCalledTimes(1);
+			expect(mockUpdateGraphForFiles.mock.calls[0][1]).toEqual(
+				expect.arrayContaining([expect.stringContaining(`module${ext}`)]),
+			);
+		}
+	});
+
+	test('toolAfter passes the realpath of the edited file (A5)', async () => {
+		// Regression for issue #1985 defect A5: the hook must pass the realpath
+		// (not the raw absolute path) into updateGraphForFiles so node keys
+		// match the realpath'd walk on case-insensitive filesystems.
+		const workspaceRoot = tempWorkspace;
+		const hook = createRepoGraphBuilderHook(workspaceRoot, {
+			buildWorkspaceGraph: mockBuildWorkspaceGraph,
+			saveGraph: mockSaveGraph,
+			updateGraphForFiles: mockUpdateGraphForFiles,
+		});
+
+		const absFile = path.join(workspaceRoot, 'real.ts');
+		fs.writeFileSync(absFile, 'export const x = 1;\n');
+		await hook.toolAfter(
+			{
+				tool: 'edit',
+				sessionID: 'test-session',
+				args: { file_path: absFile },
+			},
+			{ output: undefined },
+		);
+
+		expect(mockUpdateGraphForFiles).toHaveBeenCalledTimes(1);
+		const passedPath = mockUpdateGraphForFiles.mock.calls[0][1][0] as string;
+		// The passed path must resolve to the same canonical path as the file
+		// on disk (realpath), not a stale non-realpath'd absolute form.
+		expect(fs.realpathSync(passedPath)).toBe(fs.realpathSync(absFile));
+		fs.rmSync(absFile, { force: true });
+	});
+
+	test('rebaseOntoWorkspace rebases a symlinked-root file onto the lexical root (A5)', () => {
+		// The walk keys nodes lexically relative to workspaceRoot. When the
+		// workspace root is a symlink (lexical → real), a realpath'd file lives
+		// under the real root and must be rebased onto the lexical root so the
+		// incremental update keys the same node the walk produced.
+		const lexical = '/home/user/work';
+		const real = '/real/projects/work';
+		const realFile = `${real}/src/main.ts`;
+		const rebased = rebaseOntoWorkspace(realFile, real, lexical);
+		// The rebased path rejoins the lexical root with the workspace-relative
+		// tail — matching the walker's lexical key (modulo path.sep on Windows).
+		expect(rebased.replace(/\\/g, '/')).toBe(`${lexical}/src/main.ts`);
+	});
+
+	test('rebaseOntoWorkspace preserves realpath when workspace is not a symlink (A5)', () => {
+		// Same lexical and real root → return the realpath (case-folding fix
+		// preserved, no rebase needed).
+		const root = '/home/user/work';
+		const realFile = `${root}/src/main.ts`;
+		const rebased = rebaseOntoWorkspace(realFile, root, root);
+		expect(rebased).toBe(realFile);
+	});
+
+	test('rebaseOntoWorkspace falls back to realpath when file is outside the real workspace (A5)', () => {
+		const real = '/real/projects/work';
+		const lexical = '/home/user/work';
+		const outside = '/elsewhere/main.ts';
+		const rebased = rebaseOntoWorkspace(outside, real, lexical);
+		expect(rebased).toBe(outside);
 	});
 
 	test('toolAfter handles missing file_path gracefully', async () => {

--- a/tests/unit/tools/repo-graph-health.test.ts
+++ b/tests/unit/tools/repo-graph-health.test.ts
@@ -187,4 +187,68 @@ describe('repo graph health diagnostics', () => {
 			'Graph has no recorded diagnostics. Rebuild with repo_map action="build" to collect health details.',
 		);
 	});
+
+	test('truncated walk surfaces walkTruncated and an INCOMPLETE note (A7)', async () => {
+		// Force a walk truncation by setting a tiny file cap and producing more
+		// scannable files than it allows.
+		fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+		for (let i = 0; i < 5; i++) {
+			fs.writeFileSync(
+				path.join(tmp, 'src', `f${i}.ts`),
+				`export const f${i} = ${i};\n`,
+			);
+		}
+		const graph = await buildWorkspaceGraphAsync(tmp, { maxFiles: 2 });
+
+		expect(graph.diagnostics?.walkTruncated).toBe(true);
+		expect(graph.diagnostics?.walkTruncationReason).toBe('cap');
+
+		const health = getGraphHealth(graph);
+		expect(health.walkTruncated).toBe(true);
+		expect(health.walkTruncationReason).toBe('cap');
+		expect(
+			health.notes.some((n) =>
+				n.startsWith(
+					'Graph is INCOMPLETE: walk hit the file-cap/wall-clock budget',
+				),
+			),
+		).toBe(true);
+	});
+
+	test('budget-truncated walk reports reason "budget" (A7)', async () => {
+		fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+		for (let i = 0; i < 3; i++) {
+			fs.writeFileSync(
+				path.join(tmp, 'src', `f${i}.ts`),
+				`export const f${i} = ${i};\n`,
+			);
+		}
+		// A 0ms budget aborts on the first budget check.
+		const graph = await buildWorkspaceGraphAsync(tmp, { walkBudgetMs: 0 });
+		expect(graph.diagnostics?.walkTruncated).toBe(true);
+		expect(graph.diagnostics?.walkTruncationReason).toBe('budget');
+	});
+
+	test('incrementalFallbacks surface in graph_health (A7)', () => {
+		const graph = createEmptyGraph(tmp);
+		graph.diagnostics = { incrementalFallbacks: 4 };
+		const health = getGraphHealth(graph);
+		expect(health.incrementalFallbacks).toBe(4);
+		expect(
+			health.notes.some((n) =>
+				n.includes('incremental update(s) fell back to a full rebuild'),
+			),
+		).toBe(true);
+	});
+
+	test('non-truncated build reports walkTruncated false (A7)', async () => {
+		fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+		fs.writeFileSync(path.join(tmp, 'src', 'a.ts'), 'export const a = 1;\n');
+		const graph = await buildWorkspaceGraphAsync(tmp);
+		expect(graph.diagnostics?.walkTruncated).toBe(false);
+		const health = getGraphHealth(graph);
+		expect(health.walkTruncated).toBe(false);
+		expect(health.walkTruncationReason).toBeNull();
+		expect(health.incrementalFallbacks).toBe(0);
+	});
 });

--- a/tests/unit/tools/repo-graph-incremental-assets.test.ts
+++ b/tests/unit/tools/repo-graph-incremental-assets.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Regression test for issue #1985 defect A1: asset edges (e.g.
+ * `import data from './data.json'`) must NOT permanently disable incremental
+ * updates.
+ *
+ * Before the fix, one asset edge anywhere in the graph forced
+ * `validationFailed = true` on every incremental update (the target is a real
+ * file but never a graph node), causing a silent full-rebuild fallback on
+ * every agent write. After the fix, asset edges are tagged `targetKind:
+ * 'asset'` and only require their source node during validation, so an
+ * unrelated file edit rescans only that file.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fsSync from 'node:fs';
+import * as path from 'node:path';
+import { clearCache } from '../../../src/tools/repo-graph';
+
+// Dynamic import bypasses any mock.module from sibling test files (Bun's
+// shared-runner mock isolation caveat — AGENTS.md invariant 7).
+const getRealRepoGraph = async () => {
+	const module = await import('../../../src/tools/repo-graph');
+	return {
+		buildWorkspaceGraph: module.buildWorkspaceGraph,
+		buildWorkspaceGraphAsync: module.buildWorkspaceGraphAsync,
+		loadGraph: module.loadGraph,
+		saveGraph: module.saveGraph,
+		updateGraphForFiles: module.updateGraphForFiles,
+	};
+};
+
+describe('incremental updates with asset edges (A1)', () => {
+	let tempDir: string;
+	let workspacePath: string;
+
+	/** Normalize a path to a graph key (forward slashes, matching normalizeGraphPath). */
+	function normalizeKey(p: string): string {
+		return path.normalize(p).replace(/\\/g, '/');
+	}
+
+	async function real() {
+		const m = await getRealRepoGraph();
+		return {
+			buildWorkspaceGraph: m.buildWorkspaceGraph,
+			buildWorkspaceGraphAsync: m.buildWorkspaceGraphAsync,
+			loadGraph: m.loadGraph,
+			saveGraph: m.saveGraph,
+			updateGraphForFiles: m.updateGraphForFiles,
+		};
+	}
+
+	beforeEach(async () => {
+		tempDir = await fsSync.promises.mkdtemp(
+			path.join(process.cwd(), 'rg-assets-test-'),
+		);
+		workspacePath = path.relative(process.cwd(), tempDir);
+		await fsSync.promises.mkdir(path.join(tempDir, '.swarm'), {
+			recursive: true,
+		});
+	});
+
+	afterEach(async () => {
+		clearCache(workspacePath);
+		try {
+			await fsSync.promises.rm(tempDir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	test('asset import no longer forces a full rebuild on an unrelated edit', async () => {
+		const m = await real();
+		// Workspace mirrors the issue's repro: main.ts imports a JSON asset and
+		// a real helper.
+		await fsSync.promises.mkdir(path.join(tempDir, 'src'));
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'src/data.json'),
+			'{ "a": 1 }',
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'src/main.ts'),
+			[
+				`import data from './data.json';`,
+				`import { helper } from './helper';`,
+				`export function main(): number { return helper() + (data as { a: number }).a; }`,
+			].join('\n'),
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'src/helper.ts'),
+			'export function helper(): number { return 41; }\n',
+		);
+
+		// Initial full build.
+		const initial = await m.buildWorkspaceGraphAsync(workspacePath);
+		await m.saveGraph(workspacePath, initial);
+
+		// The asset edge main.ts -> data.json must exist and be tagged 'asset'.
+		const mainAbs = path.join(tempDir, 'src/main.ts');
+		const dataAbs = path.join(tempDir, 'src/data.json');
+		const assetEdge = initial.edges.find(
+			(e) =>
+				path.resolve(e.source) === mainAbs &&
+				path.resolve(e.target) === dataAbs,
+		);
+		expect(assetEdge).toBeDefined();
+		expect(assetEdge?.targetKind).toBe('asset');
+
+		// The node edge main.ts -> helper.ts must be tagged 'node'.
+		const helperAbs = path.join(tempDir, 'src/helper.ts');
+		const nodeEdge = initial.edges.find(
+			(e) =>
+				path.resolve(e.source) === mainAbs &&
+				path.resolve(e.target) === helperAbs,
+		);
+		expect(nodeEdge).toBeDefined();
+		expect(nodeEdge?.targetKind).toBe('node');
+
+		// Capture the initial helper.ts node identity so we can confirm the
+		// incremental update re-scanned it (mtime changes) rather than
+		// discarding it via a full rebuild. We assert "no fallback" two ways:
+		//   1. the returned graph carries NO incrementalFallbacks counter bump
+		//      (a fallback sets diagnostics.incrementalFallbacks >= 1);
+		//   2. main.ts's asset edge survives intact (a full rebuild would also
+		//      recreate it, so this is necessary-but-not-sufficient — paired
+		//      with the counter it is decisive).
+		const initialFallbacks =
+			(initial.diagnostics?.incrementalFallbacks as number | undefined) ?? 0;
+
+		// Edit helper.ts (unrelated to the JSON import).
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'src/helper.ts'),
+			'export function helper(): number { return 42; }\nexport const NEW = 99;\n',
+		);
+
+		const updated = await m.updateGraphForFiles(workspacePath, [helperAbs]);
+
+		// Decisive no-fallback assertion: the incrementalFallbacks counter did
+		// not increase. A fallback path always bumps it by 1.
+		const updatedFallbacks =
+			(updated.diagnostics?.incrementalFallbacks as number | undefined) ?? 0;
+		expect(updatedFallbacks).toBe(initialFallbacks);
+
+		// The helper.ts node reflects the new edit (proves re-scan happened).
+		const helperNode =
+			updated.nodes[path.normalize(helperAbs).replace(/\\/g, '/')];
+		expect(helperNode).toBeDefined();
+		expect(helperNode?.exports).toContain('NEW');
+
+		// The asset edge survived intact and is still tagged 'asset'.
+		const updatedAssetEdge = updated.edges.find(
+			(e) =>
+				path.resolve(e.source) === mainAbs &&
+				path.resolve(e.target) === dataAbs,
+		);
+		expect(updatedAssetEdge?.targetKind).toBe('asset');
+	});
+
+	test('asset targets are excluded from key_files in-degree and importers', async () => {
+		const m = await real();
+		await fsSync.promises.mkdir(path.join(tempDir, 'src'));
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'src/config.json'),
+			'{ "v": 1 }',
+		);
+		// Three files import config.json (the asset) — without exclusion it
+		// would dominate key_files by in-degree 3.
+		for (const name of ['a.ts', 'b.ts', 'c.ts']) {
+			await fsSync.promises.writeFile(
+				path.join(tempDir, `src/${name}`),
+				`import c from './config.json';\nimport { shared } from './shared';\nexport const x = shared;\n`,
+			);
+		}
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'src/shared.ts'),
+			'export const shared = 1;\n',
+		);
+
+		const graph = await m.buildWorkspaceGraphAsync(workspacePath);
+		await m.saveGraph(workspacePath, graph);
+
+		const { getKeyFiles, getImporters } = await import(
+			'../../../src/tools/repo-graph/query'
+		);
+		const key = getKeyFiles(graph, 10);
+		const keyFiles = key.map((n) => n.moduleName);
+
+		// config.json must NOT appear in key_files despite 3 importers.
+		expect(keyFiles).not.toContain('src/config.json');
+
+		// shared.ts (a real node imported by 3 files) SHOULD rank highly.
+		expect(keyFiles).toContain('src/shared.ts');
+
+		// getImporters of config.json returns [] (asset edges excluded).
+		const importers = getImporters(graph, 'src/config.json');
+		expect(importers.length).toBe(0);
+
+		// getImporters of shared.ts returns the 3 consumers.
+		const sharedImporters = getImporters(graph, 'src/shared.ts');
+		expect(sharedImporters.length).toBe(3);
+	});
+
+	test('a genuine node-to-node orphan edge still triggers a full rebuild', async () => {
+		// Guards against over-relaxing validation: relaxing the asset rule must
+		// NOT also let a real node→node edge whose target genuinely disappeared
+		// slip through. The fallback reconciles it via a full rebuild.
+		const m = await real();
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'index.ts'),
+			`import { foo } from './foo';\nexport const indexExport = 'hello';\n`,
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'foo.ts'),
+			`export const foo = 'foo';\n`,
+		);
+
+		const initial = await m.buildWorkspaceGraphAsync(workspacePath);
+		await m.saveGraph(workspacePath, initial);
+
+		// Corrupt the graph: add a node→node edge from foo.ts (a file we will
+		// NOT touch) to a file that has no node. Re-scanning a different file
+		// leaves this orphan in place, so validation must catch it.
+		const loaded = await m.loadGraph(workspacePath);
+		expect(loaded).not.toBeNull();
+		loaded!.edges.push({
+			source: path.join(tempDir, 'foo.ts'),
+			target: path.join(tempDir, 'ghost.ts'),
+			importSpecifier: './ghost',
+			importType: 'named',
+			targetKind: 'node',
+		});
+		await m.saveGraph(workspacePath, loaded!);
+
+		// Trigger an incremental update on index.ts (NOT foo.ts). The orphan
+		// node→node edge from foo.ts survives the re-scan and must force a
+		// fallback (incrementalFallbacks bumps to 1).
+		const updated = await m.updateGraphForFiles(workspacePath, [
+			path.join(tempDir, 'index.ts'),
+		]);
+		const fallbacks =
+			(updated.diagnostics?.incrementalFallbacks as number | undefined) ?? 0;
+		expect(fallbacks).toBeGreaterThanOrEqual(1);
+	});
+
+	test('a rescan that returns node:null removes the stale node (review fix)', async () => {
+		// If a previously-tracked source file becomes oversized/binary/
+		// unreadable, scanFileAsync returns node:null. The stale node must be
+		// removed so any incoming node→node edges are caught by validation and
+		// trigger the fallback (rather than silently leaving an inconsistent
+		// graph: stale node, removed outgoing edges).
+		const m = await real();
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'a.ts'),
+			`import { b } from './b';\nexport const a = b;\n`,
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'b.ts'),
+			`export const b = 1;\n`,
+		);
+		const initial = await m.buildWorkspaceGraphAsync(workspacePath);
+		await m.saveGraph(workspacePath, initial);
+		expect(
+			initial.nodes[normalizeKey(path.join(tempDir, 'b.ts'))],
+		).toBeDefined();
+
+		// Make b.ts "binary" (null byte) so scanFileAsync returns node:null.
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'b.ts'),
+			'binary\x00\x00content',
+		);
+
+		const updated = await m.updateGraphForFiles(workspacePath, [
+			path.join(tempDir, 'b.ts'),
+		]);
+
+		// The stale b.ts node was removed (rescan returned null).
+		expect(
+			updated.nodes[normalizeKey(path.join(tempDir, 'b.ts'))],
+		).toBeUndefined();
+		// The incoming a.ts -> b.ts node edge now has a missing target, so a
+		// fallback should have fired.
+		const fallbacks =
+			(updated.diagnostics?.incrementalFallbacks as number | undefined) ?? 0;
+		expect(fallbacks).toBeGreaterThanOrEqual(1);
+	});
+
+	test('direct updateGraphForFiles on an unsupported extension does not create a node (review fix)', async () => {
+		// updateGraphForFiles is a public entry point; a direct caller (not via
+		// the write hook) passing a .css file must not inject an 'unknown'-
+		// language node. isScannableSourcePath guards the incremental path.
+		const m = await real();
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'a.ts'),
+			`export const a = 1;\n`,
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'style.css'),
+			'.x { color: red; }\n',
+		);
+		const initial = await m.buildWorkspaceGraphAsync(workspacePath);
+		await m.saveGraph(workspacePath, initial);
+
+		await m.updateGraphForFiles(workspacePath, [
+			path.join(tempDir, 'style.css'),
+		]);
+		const loaded = await m.loadGraph(workspacePath);
+		const cssNode = Object.values(loaded!.nodes).find((n) =>
+			n.filePath.endsWith('style.css'),
+		);
+		expect(cssNode).toBeUndefined();
+	});
+});

--- a/tests/unit/tools/repo-graph-incremental.test.ts
+++ b/tests/unit/tools/repo-graph-incremental.test.ts
@@ -8,6 +8,7 @@ import * as fsSync from 'node:fs';
 import * as path from 'node:path';
 import { clearCache } from '../../../src/tools/repo-graph';
 import { _internals as builderInternals } from '../../../src/tools/repo-graph/builder';
+import { _internals as incrementalInternals } from '../../../src/tools/repo-graph/incremental';
 
 // Use dynamic import to get the real module (bypasses any mock.module from other test files)
 // This is necessary because bun:test's mock.module persists globally across tests
@@ -409,5 +410,250 @@ export const indexExport = 'hello';`,
 			expect(updatedGraph.nodes[normalizeKey(edge.source)]).toBeDefined();
 			expect(updatedGraph.nodes[normalizeKey(edge.target)]).toBeDefined();
 		}
+	});
+
+	test('normal incremental update does not bump incrementalFallbacks (A4 happy path)', async () => {
+		// Sanity that the optimistic-concurrency / replay path (defect A4) does
+		// not spuriously fire on a clean single-session update: the
+		// incrementalFallbacks diagnostics counter must stay at 0/undefined.
+		const files = {
+			'a.ts': `import { b } from './b';\nexport const a = b;\n`,
+			'b.ts': `export const b = 1;\n`,
+		};
+		for (const [name, content] of Object.entries(files)) {
+			await fsSync.promises.writeFile(path.join(tempDir, name), content);
+		}
+		const initialGraph = buildWorkspaceGraph(workspacePath);
+		await saveGraph(workspacePath, initialGraph);
+
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'b.ts'),
+			'export const b = 2;\nexport const bNew = 3;\n',
+		);
+		const updated = await updateGraphForFiles(workspacePath, [
+			path.join(tempDir, 'b.ts'),
+		]);
+		const fallbacks =
+			(updated.diagnostics?.incrementalFallbacks as number | undefined) ?? 0;
+		expect(fallbacks).toBe(0);
+		// The edit took effect (proves the incremental save path ran).
+		const bNode = updated.nodes[normalizeKey(path.join(tempDir, 'b.ts'))];
+		expect(bNode?.exports).toContain('bNew');
+	});
+});
+
+describe('updateGraphForFiles concurrent-save replay (A4)', () => {
+	let tempDir: string;
+	let workspacePath: string;
+	const realStat = incrementalInternals.stat;
+	const realParseFileImports = builderInternals.parseFileImports;
+
+	/** Normalize a path for use as a graph key (forward slashes). */
+	function normalizeKey(p: string): string {
+		return path.normalize(p).replace(/\\/g, '/');
+	}
+
+	async function real() {
+		const module = await getRealRepoGraph();
+		return {
+			buildWorkspaceGraph: module.buildWorkspaceGraph,
+			saveGraph: module.saveGraph,
+			loadGraph: module.loadGraph,
+			updateGraphForFiles: module.updateGraphForFiles,
+		};
+	}
+
+	beforeEach(async () => {
+		tempDir = await fsSync.promises.mkdtemp(
+			path.join(process.cwd(), 'incremental-a4-test-'),
+		);
+		workspacePath = path.relative(process.cwd(), tempDir);
+		await fsSync.promises.mkdir(path.join(tempDir, '.swarm'), {
+			recursive: true,
+		});
+	});
+
+	afterEach(async () => {
+		incrementalInternals.stat = realStat;
+		builderInternals.parseFileImports = realParseFileImports;
+		clearCache(workspacePath);
+		try {
+			await fsSync.promises.rm(tempDir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	test('one mtime shift triggers reload+replay (no full rebuild)', async () => {
+		const m = await real();
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'a.ts'),
+			`export const a = 1;\n`,
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'b.ts'),
+			`export const b = 1;\n`,
+		);
+		const initial = m.buildWorkspaceGraph(workspacePath);
+		await m.saveGraph(workspacePath, initial);
+
+		// Override the concurrency stat so the FIRST call (the pre-save mtime
+		// check) returns a shifted mtime, simulating a concurrent writer having
+		// saved between our load and our pre-save check. Subsequent calls use
+		// the real mtime so the post-replay re-stat matches and the replay
+		// succeeds without a terminal fallback.
+		let statCall = 0;
+		const graphFile = path.join(tempDir, '.swarm', 'repo-graph.json');
+		const realFileStats = await fsSync.promises.stat(graphFile);
+		incrementalInternals.stat = async (p: string) => {
+			if (p === graphFile) {
+				statCall++;
+				// First stat (pre-save check) reports a shifted mtime.
+				if (statCall === 1) {
+					return {
+						...realFileStats,
+						mtimeMs: realFileStats.mtimeMs + 5000,
+					} as fsSync.Stats;
+				}
+			}
+			return realStat(p);
+		};
+
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'b.ts'),
+			'export const b = 2;\nexport const bNew = 3;\n',
+		);
+
+		const updated = await m.updateGraphForFiles(workspacePath, [
+			path.join(tempDir, 'b.ts'),
+		]);
+
+		// Reload+replay succeeded (no terminal full rebuild): the fallback
+		// counter must NOT have been bumped.
+		const fallbacks =
+			(updated.diagnostics?.incrementalFallbacks as number | undefined) ?? 0;
+		expect(fallbacks).toBe(0);
+		// The replayed edit took effect (proves the reload+replay path ran and
+		// saved the fresh graph).
+		const bNode = updated.nodes[normalizeKey(path.join(tempDir, 'b.ts'))];
+		expect(bNode?.exports).toContain('bNew');
+	});
+
+	test('second mtime shift during replay triggers exactly one full rebuild', async () => {
+		const m = await real();
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'a.ts'),
+			`export const a = 1;\n`,
+		);
+		const initial = m.buildWorkspaceGraph(workspacePath);
+		await m.saveGraph(workspacePath, initial);
+
+		// Make EVERY concurrency stat report a shifted mtime, so: pre-save
+		// check shifts (triggers reload+replay), then post-replay re-stat also
+		// shifts (triggers terminal full rebuild). This exercises the double-
+		// shift terminal-fallback path — bounded, never loops.
+		const graphFile = path.join(tempDir, '.swarm', 'repo-graph.json');
+		const realFileStats = await fsSync.promises.stat(graphFile);
+		incrementalInternals.stat = async (p: string) => {
+			if (p === graphFile) {
+				return {
+					...realFileStats,
+					mtimeMs: realFileStats.mtimeMs + 5000,
+				} as fsSync.Stats;
+			}
+			return realStat(p);
+		};
+
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'a.ts'),
+			'export const a = 2;\nexport const aNew = 3;\n',
+		);
+
+		const updated = await m.updateGraphForFiles(workspacePath, [
+			path.join(tempDir, 'a.ts'),
+		]);
+
+		// The terminal full rebuild fired exactly once (counter bumped by 1).
+		const fallbacks =
+			(updated.diagnostics?.incrementalFallbacks as number | undefined) ?? 0;
+		expect(fallbacks).toBe(1);
+	});
+});
+
+describe('incremental manifest-aware boundaries (A8 manifest closure)', () => {
+	let tempDir: string;
+	let workspacePath: string;
+
+	async function real() {
+		const module = await getRealRepoGraph();
+		return {
+			buildWorkspaceGraph: module.buildWorkspaceGraph,
+			saveGraph: module.saveGraph,
+			loadGraph: module.loadGraph,
+			updateGraphForFiles: module.updateGraphForFiles,
+		};
+	}
+
+	beforeEach(async () => {
+		tempDir = await fsSync.promises.mkdtemp(
+			path.join(process.cwd(), 'incremental-manifest-test-'),
+		);
+		workspacePath = path.relative(process.cwd(), tempDir);
+		await fsSync.promises.mkdir(path.join(tempDir, '.swarm'), {
+			recursive: true,
+		});
+	});
+
+	afterEach(async () => {
+		clearCache(workspacePath);
+		try {
+			await fsSync.promises.rm(tempDir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	test('incremental edit preserves manifest-driven package boundary (buildManifestClosure)', async () => {
+		const m = await real();
+		// customdomain/ is NOT in the static packages|crates|apps|libs|services
+		// set, so without a manifest it would fall back to segment 0. A
+		// package.json under customdomain/ makes the boundary customdomain/users.
+		await fsSync.promises.mkdir(path.join(tempDir, 'customdomain/users'), {
+			recursive: true,
+		});
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'customdomain/package.json'),
+			'{ "name": "customdomain" }\n',
+		);
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'customdomain/users/svc.ts'),
+			'export const svc = 1;\n',
+		);
+
+		const initial = m.buildWorkspaceGraph(workspacePath);
+		await m.saveGraph(workspacePath, initial);
+
+		const svcNode = Object.values(initial.nodes).find(
+			(n) => n.moduleName === 'customdomain/users/svc.ts',
+		);
+		// The initial (manifest-aware) build classifies the boundary as
+		// customdomain/users thanks to the package.json under customdomain/.
+		expect(svcNode?.ontology?.packageBoundary).toBe('customdomain/users');
+
+		// Edit svc.ts. The incremental re-scan must re-derive the manifest
+		// closure (buildManifestClosure) and preserve the manifest-driven
+		// boundary — NOT regress to the static-rule 'customdomain'.
+		await fsSync.promises.writeFile(
+			path.join(tempDir, 'customdomain/users/svc.ts'),
+			'export const svc = 2;\nexport const svcNew = 3;\n',
+		);
+		const updated = await m.updateGraphForFiles(workspacePath, [
+			path.join(tempDir, 'customdomain/users/svc.ts'),
+		]);
+		const updatedSvc = Object.values(updated.nodes).find(
+			(n) => n.moduleName === 'customdomain/users/svc.ts',
+		);
+		expect(updatedSvc?.ontology?.packageBoundary).toBe('customdomain/users');
+		expect(updatedSvc?.exports).toContain('svcNew');
 	});
 });

--- a/tests/unit/tools/repo-graph-ontology.test.ts
+++ b/tests/unit/tools/repo-graph-ontology.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { extractFileOntology } from '../../../src/tools/repo-graph';
+import {
+	type ExtractFileOntologyInput,
+	extractFileOntology,
+} from '../../../src/tools/repo-graph';
+import { inferPackageBoundary } from '../../../src/tools/repo-graph/types';
 
 describe('repo graph ontology extraction', () => {
 	test('extracts route, data, security, and convention facts for an API route', () => {
@@ -105,5 +109,71 @@ describe('repo graph ontology extraction', () => {
 		expect(ontology.routes).toContainEqual(
 			expect.objectContaining({ method: 'POST', path: '/api/projects' }),
 		);
+	});
+});
+
+describe('package boundary inference (A8)', () => {
+	function ontologyFor(
+		moduleName: string,
+		hasManifest?: (d: string) => boolean,
+	) {
+		const input: ExtractFileOntologyInput = {
+			moduleName,
+			filePath: `/repo/${moduleName}`,
+			language: 'typescript',
+			exports: [],
+			imports: [],
+			content: '',
+			hasManifest,
+		};
+		return extractFileOntology(input).packageBoundary;
+	}
+
+	test('src/tools/repo-graph special case is removed (regression)', () => {
+		// Before A8 this returned 'src/tools/repo-graph'; the generic rule now
+		// returns 'src/tools'. This is the one intentional behavior change.
+		expect(ontologyFor('src/tools/repo-graph/builder.ts')).toBe('src/tools');
+	});
+
+	test('generic packages/crates/apps/libs/services boundary', () => {
+		expect(ontologyFor('packages/foo/src/index.ts')).toBe('packages/foo');
+		expect(ontologyFor('crates/core/src/lib.rs')).toBe('crates/core');
+		expect(ontologyFor('apps/web/pages/index.tsx')).toBe('apps/web');
+		expect(ontologyFor('libs/shared/src/index.ts')).toBe('libs/shared');
+		expect(ontologyFor('services/api/src/main.ts')).toBe('services/api');
+	});
+
+	test('src and tests layouts', () => {
+		expect(ontologyFor('src/hooks/foo.ts')).toBe('src/hooks');
+		expect(ontologyFor('tests/unit/foo.test.ts')).toBe('tests/unit');
+	});
+
+	test('manifest-driven boundary for arbitrary top-level dirs', () => {
+		// Without a manifest, a custom top-level dir falls back to segment 0.
+		expect(ontologyFor('customdomain/index.ts')).toBe('customdomain');
+		// With a manifest in customdomain/, the first two segments become the
+		// boundary.
+		const hasManifest = (d: string) => d === 'customdomain';
+		expect(ontologyFor('customdomain/users/svc.ts', hasManifest)).toBe(
+			'customdomain/users',
+		);
+		// Manifest under seg0/seg1 also splits there.
+		const hasManifestNested = (d: string) => d === 'customdomain/users';
+		expect(ontologyFor('customdomain/users/svc.ts', hasManifestNested)).toBe(
+			'customdomain/users',
+		);
+	});
+
+	test('inferPackageBoundary shared helper matches ontology + query fallback', () => {
+		// The shared helper is the single source of truth for both ontology
+		// extraction and the query-side no-ontology fallback.
+		expect(inferPackageBoundary('packages/a/b.ts')).toBe('packages/a');
+		expect(inferPackageBoundary('src/tools/repo-graph/builder.ts')).toBe(
+			'src/tools',
+		);
+		expect(inferPackageBoundary('foo.ts')).toBe('foo.ts');
+		expect(inferPackageBoundary('')).toBe('.');
+		// Query fallback path (no hasManifest) only uses static rules.
+		expect(inferPackageBoundary('customdomain/x/y.ts')).toBe('customdomain');
 	});
 });

--- a/tests/unit/tools/repo-graph-schema-compat.test.ts
+++ b/tests/unit/tools/repo-graph-schema-compat.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Old-graph compatibility (issue #1985): a 1.2.0 graph whose edges carry no
+ * `targetKind` must load and query correctly under the new 1.3.0 code. The
+ * `isAssetEdge` helper falls back to an extension check on untagged edges, so
+ * a pre-1.3.0 asset edge (e.g. `main.ts -> data.json`) is still classified as
+ * an asset and excluded from query rankings.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	buildWorkspaceGraphAsync,
+	clearCache,
+	getCallers,
+	getImporters,
+	getKeyFiles,
+	loadGraph,
+	saveGraph,
+} from '../../../src/tools/repo-graph';
+
+describe('schema 1.2.0 graph compatibility (A1)', () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'rg-compat-')));
+		fs.mkdirSync(path.join(tmp, '.swarm'), { recursive: true });
+	});
+
+	afterEach(() => {
+		clearCache(tmp);
+		fs.rmSync(tmp, { recursive: true, force: true });
+	});
+
+	test('a 1.2.0 graph with an untagged asset edge loads and queries correctly', async () => {
+		// Build a real 1.3.0 graph, then downgrade it to 1.2.0 shape (strip
+		// targetKind, set schema_version) and write it to .swarm/repo-graph.json.
+		fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+		fs.writeFileSync(path.join(tmp, 'src/data.json'), '{ "a": 1 }');
+		fs.writeFileSync(
+			path.join(tmp, 'src/main.ts'),
+			"import data from './data.json';\nimport { helper } from './helper';\nexport const main = helper + data;\n",
+		);
+		fs.writeFileSync(
+			path.join(tmp, 'src/helper.ts'),
+			'export const helper = 1;\n',
+		);
+
+		const built = await buildWorkspaceGraphAsync(tmp);
+		// Sanity: the modern graph tags the asset edge.
+		const assetEdge = built.edges.find((e) => e.target.endsWith('data.json'));
+		expect(assetEdge?.targetKind).toBe('asset');
+
+		// Downgrade to 1.2.0 shape: strip targetKind, set version.
+		const downgraded = {
+			...built,
+			schema_version: '1.2.0',
+			edges: built.edges.map(({ targetKind: _t, ...rest }) => {
+				void _t;
+				return rest;
+			}) as typeof built.edges,
+		};
+		await saveGraph(tmp, downgraded);
+		clearCache(tmp);
+
+		// Re-load and query — the untagged asset edge must still be treated as
+		// an asset via the extension fallback.
+		const loaded = await loadGraph(tmp);
+		expect(loaded).not.toBeNull();
+		if (!loaded) throw new Error('expected graph to load');
+		expect(loaded.schema_version).toBe('1.2.0');
+
+		// No edge in the loaded graph carries targetKind (proves it stayed 1.2.0).
+		expect(
+			loaded.edges.every(
+				(e) => (e as { targetKind?: string }).targetKind === undefined,
+			),
+		).toBe(true);
+
+		// data.json (asset) excluded from key_files and importers despite 1
+		// untagged importer edge.
+		const key = getKeyFiles(loaded, 10).map((n) => n.moduleName);
+		expect(key).not.toContain('src/data.json');
+		expect(getImporters(loaded, 'src/data.json')).toHaveLength(0);
+
+		// helper.ts (a real node) is queryable.
+		expect(getImporters(loaded, 'src/helper.ts').length).toBe(1);
+		// getCallers on helper's 'helper' export resolves via the node edge.
+		expect(getCallers(loaded, 'src/helper.ts', 'helper').length).toBe(1);
+	});
+});

--- a/tests/unit/tools/repo-map.test.ts
+++ b/tests/unit/tools/repo-map.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { GRAPH_SCHEMA_VERSION } from '../../../src/tools/repo-graph';
 import { repo_map } from '../../../src/tools/repo-map';
 
 let tmp: string;
@@ -106,7 +107,7 @@ describe('repo_map: graph_health', () => {
 			unresolvedImports: unknown[];
 		};
 		expect(r.success).toBe(true);
-		expect(r.schemaVersion).toBe('1.2.0');
+		expect(r.schemaVersion).toBe(GRAPH_SCHEMA_VERSION);
 		expect(r.fresh).toBe(true);
 		expect(r.extractionFailures).toEqual([]);
 		expect(r.unresolvedImports).toEqual([]);


### PR DESCRIPTION
Closes #1985

## Summary

Resolve six verified repo-graph lifecycle defects in `src/tools/repo-graph/*`. The headline defect (A1) silently disabled incremental updates for any workspace importing JSON/CSS/asset files by relative path — `resolveModuleSpecifier` resolved `./data.json` to a real file, but only scannable source files become graph nodes, so `updateGraphForFiles` validation required both endpoints and fell back to a **full workspace rebuild on every agent write, forever** (measured ~158 s on a 2,787-file repo). The fallback warning was gated behind `OPENCODE_SWARM_DEBUG=1`, so it was invisible in production.

- **A1 (CRITICAL):** `GraphEdge` gains optional `targetKind: 'node' | 'asset'` (schema `1.2.0` → `1.3.0`; older graphs load). Asset edges only require their source node during validation. Asset targets are excluded from `key_files` in-degree and importer/dependent lists. On a genuine orphan edge the specific offending edge (source, target, reason) is logged and an `incrementalFallbacks` counter bumps.
- **A2:** write-hook extension list now routes through a single shared `isScannableSourcePath` (picks up `.rs`/`.go`/`.pyw` automatically — no more drift).
- **A4:** concurrent-save recovery now reloads + replays once (with a pre-save re-check) instead of always full-rebuilding; bounded, never loops, fail-closed.
- **A5:** `toolAfter` forwards a realpath-consistent path (`rebaseOntoWorkspace`) so node keys match the walk on case-insensitive FS and symlinked workspace roots.
- **A7:** `RepoGraphDiagnostics` gains `walkTruncated`/`walkTruncationReason`/`incrementalFallbacks`; `getGraphHealth` surfaces them with an explicit INCOMPLETE note; `repo_map build` reports `truncated`.
- **A8:** `boundaryForModule` delegates to a pure shared `inferPackageBoundary` (generic `packages|crates|apps|libs|services` + manifest-driven rule); the `src/tools/repo-graph` special case is removed; the walkers plumb manifest dirs through an optional `hasManifest` callback.
- **A6:** docs note about `exclude_dirs` case-sensitivity included in the release fragment.

### A1 before/after (the repro from the issue)
Workspace: `src/main.ts` imports `./data.json` (asset) and `./helper` (node).
- **Before:** editing `helper.ts` logged `[repo-graph] Incremental update failed, falling back to full rebuild` and rescanned the entire workspace (every file), even though the JSON import is unrelated. Invisible in production (warning gated behind `OPENCODE_SWARM_DEBUG=1`).
- **After:** editing `helper.ts` rescans only `helper.ts`; no fallback; `incrementalFallbacks` stays at 0. The asset edge `main.ts -> data.json` survives intact, tagged `targetKind: 'asset'`. (Verified by `repo-graph-incremental-assets.test.ts`.)

## Invariant audit
- 1 (plugin init): not touched — the walkers add a `manifestDirs` Set member and record inside the existing enumeration loop; no new control flow, no new I/O, async yields at the same intervals. `doInit` is unchanged. Evidence: `builder.ts` walkSyncInto/findSourceFilesAsync changes are additive; `git diff origin/main -- src/hooks/repo-graph-builder.ts` shows `doInit` untouched.
- 2 (runtime portability): not touched — no new runtime imports beyond internal (`query.ts` imports `isAssetEdge` from `./builder`, acyclic — `builder.ts` does not import `query.ts`); barrel re-export of `isScannableSourcePath` is additive; on-disk graph shape gains only optional fields (`targetKind`, `walkTruncated`, `walkTruncationReason`, `incrementalFallbacks`). Evidence: `bunx tsc --noEmit` exit 0; `builder.ts`/`query.ts` import graph verified acyclic.
- 3 (subprocesses): not touched — no subprocess code changed.
- 4 (.swarm containment): not touched — all graph state stays under `.swarm/repo-graph.json`; new test temp dirs use `process.cwd()`-relative mkdtemp per existing convention.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — no `test_runner` use.
- 7 (test writing): touched — all tests use `bun:test`; new test files use dynamic-import mock isolation (the `getRealRepoGraph` pattern) to avoid `mock.module` cross-file leakage; `_internals` DI seams added on `incremental.ts` (`.stat`) following the AGENTS.md convention, restored in `afterEach`. All new test files are under 500 lines (FR-006): `repo-graph-incremental-assets.test.ts` ~300 lines, `repo-graph-schema-compat.test.ts` ~95 lines. Evidence: file line counts; `grep -r "mock.module" tests/unit/tools/repo-graph-incremental-assets.test.ts tests/unit/tools/repo-graph-schema-compat.test.ts` → no matches.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no new tools/agents/commands. Evidence: `bun run drift:check` → "No drift detected across skills, tools, commands, agents, docs claims".
- 12 (release/cache): touched — release fragment `docs/releases/pending/1985-repo-graph-incremental-correctness.md` added; `package.json#version`/`CHANGELOG.md`/`.release-please-manifest.json` NOT hand-edited (release-please owns them). Evidence: `git diff origin/main -- package.json CHANGELOG.md` → clean.

## Test plan

Validation run on branch `claude/issue-1985-repo-graph-incremental` (commit `3611ea06`):

```
$ bunx tsc --noEmit -p tsconfig.json
(exit 0 — no errors)

$ bun run drift:check
✅ No drift detected across skills, tools, commands, agents, docs claims, and dependency freshness.

$ bunx biome check <all changed files>
Checked N files. No fixes applied. (clean, no warnings)
```

Repo-graph test suite (each file run in isolation per AGENTS.md invariant 7 — `mock.module` cross-file pollution makes bulk runs produce false failures):

```
$ for f in <16 repo-graph + hook test files>; do bun test "$f" --timeout 60000; done
files failed: 0 of 16
ALL GREEN
```

New/updated tests covering each defect:
- **A1** (`repo-graph-incremental-assets.test.ts`, 5 tests): asset import no longer forces a fallback (asserts `incrementalFallbacks` stays 0 + edit applied); asset targets excluded from `key_files`/`getImporters`; genuine node→node orphan edge still triggers fallback; failed rescan removes stale node; unsupported extension via direct `updateGraphForFiles` creates no node.
- **A2** (`repo-graph-builder.test.ts`): `.rs`/`.go`/`.pyw` writes trigger updates.
- **A4** (`repo-graph-incremental.test.ts`, 3 new tests): one mtime shift ⇒ reload+replay (no fallback); double shift ⇒ exactly one full rebuild; happy-path ⇒ `incrementalFallbacks` stays 0.
- **A5** (`repo-graph-builder.test.ts`, 4 tests): realpath forwarded; `rebaseOntoWorkspace` unit tests (symlink-root rebase, non-symlink passthrough, outside-workspace fallback).
- **A7** (`repo-graph-health.test.ts`, 4 tests): cap-truncation surfaces `walkTruncated`+INCOMPLETE note; budget-truncation reports `reason: 'budget'`; `incrementalFallbacks` surfaces; non-truncated build reports false.
- **A8** (`repo-graph-ontology.test.ts`, 5 tests + `repo-graph-incremental.test.ts` manifest-closure test): `src/tools/repo-graph` special case removed; generic `apps/libs/services` boundaries; manifest-driven boundaries; shared helper consistency; incremental edit preserves manifest-driven boundary (`buildManifestClosure`).
- **1.2.0 compatibility** (`repo-graph-schema-compat.test.ts`): a downgraded 1.2.0 graph with untagged asset edges loads and queries correctly via the `isAssetEdge` extension fallback.

Independent swarm validation (per the issue-tracer / swarm-implement contract):
- **Plan critic (Kimi K3):** NEEDS_REVISION → all items incorporated (incl. an empirically-validated `Required<>` compile blocker caught before implementation).
- **Implementation reviewer (Kimi K2.7, 2 rounds):** NEEDS_REVISION → all 6 findings resolved (2 Critical concurrency/stale-node bugs introduced by the rewrite, both fixed + regression-tested; 2 Important consistency fixes; 1 A5 symlink-root regression caught in round 2 and fixed via `rebaseOntoWorkspace`).
- **Final critic (Kimi K3):** NEEDS_REVISION → all 4 challenges resolved (the A4 replay test mandate + a real `buildManifestClosure` ancestor-walk bug it surfaced, now fixed and tested).

Known limitations (out of scope for this issue, documented for follow-up):
- A symlinked *workspace root* where the lexical and real roots diverge in directory-name length is handled by `rebaseOntoWorkspace`; a deeper symlink *inside* the workspace tree (a subdirectory symlink) is not separately canonicalized by the walker — pre-existing representation behavior, not a regression.
- `excludeDirs` is not threaded through `updateGraphForFiles` fallback rebuilds — pre-existing at `origin/main`; the issue does not ask for it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

